### PR TITLE
cpu/saml1x: add support for SAML10 and SAML11 MCUs (Cortex-M23)

### DIFF
--- a/boards/common/saml1x/Makefile
+++ b/boards/common/saml1x/Makefile
@@ -1,0 +1,3 @@
+MODULE = boards_common_saml1x
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/common/saml1x/Makefile.dep
+++ b/boards/common/saml1x/Makefile.dep
@@ -1,0 +1,3 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif

--- a/boards/common/saml1x/Makefile.features
+++ b/boards/common/saml1x/Makefile.features
@@ -1,0 +1,13 @@
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_rtt
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# The board MPU family (used for grouping by the CI system)
+FEATURES_MCU_GROUP = cortex_m23
+
+include $(RIOTCPU)/saml1x/Makefile.features

--- a/boards/common/saml1x/Makefile.include
+++ b/boards/common/saml1x/Makefile.include
@@ -1,0 +1,12 @@
+# define the cpu used by the saml11 board
+export CPU = saml1x
+
+# set edbg device type
+EDBG_DEVICE_TYPE = mchp_cm23
+
+USEMODULE += boards_common_saml1x
+
+include $(RIOTMAKE)/boards/sam0.inc.mk
+
+# add the common header files to the include path
+INCLUDES += -I$(RIOTBOARD)/common/saml1x/include

--- a/boards/common/saml1x/board.c
+++ b/boards/common/saml1x/board.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2019 Mesotic SAS
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_common_saml1x
+ * @{
+ *
+ * @file        board.c
+ * @brief       Board specific implementations for the Microchip
+ *              SAML10 and SAML11 Xplained Pro board
+ *
+ * @author      Dylan Laduranty <dylan.laduranty@mesotic.com>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "board.h"
+#include "periph/gpio.h"
+
+void led_init(void);
+
+void board_init(void)
+{
+    /* initialize the boards LEDs */
+    led_init();
+    /* initialize the CPU */
+    cpu_init();
+
+}
+
+
+/**
+ * @brief Initialize the boards on-board LED
+ */
+void led_init(void)
+{
+    gpio_init(GPIO_PIN(PA, 7), GPIO_OUT);
+}

--- a/boards/common/saml1x/include/board.h
+++ b/boards/common/saml1x/include/board.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2019 Mesotic SAS
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    boards_common_saml1x Microchip SAML1X
+ * @ingroup     boards
+ * @brief       Support for SAML10 and SAML11 boards
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the Microchip
+ *              SAML10 & SAML11 Xplained Pro board.
+ *
+ * @author      Dylan Laduranty <dylan.laduranty@mesotic.com>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    PORT selection macros
+ * @{
+ */
+#ifdef CPU_FAM_SAML11
+#define _PORT PORT_SEC
+#else
+#define _PORT PORT
+#endif
+/** @} */
+
+/**
+ * @name    LED pin definitions and handlers
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(PA, 7)
+
+#define LED_PORT            _PORT->Group[PA]
+#define LED0_MASK           (1 << 7)
+
+#define LED0_ON             (LED_PORT.OUTCLR.reg = LED0_MASK)
+#define LED0_OFF            (LED_PORT.OUTSET.reg = LED0_MASK)
+#define LED0_TOGGLE         (LED_PORT.OUTTGL.reg = LED0_MASK)
+/** @} */
+
+/**
+ * @name SW0 (Button) pin definitions
+ * @{
+ */
+#define BTN0_PORT           _PORT->Group[PA]
+#define BTN0_PIN            GPIO_PIN(PA, 27)
+#define BTN0_MODE           GPIO_IN_PU
+/** @} */
+
+
+/**
+ * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/common/saml1x/include/gpio_params.h
+++ b/boards/common/saml1x/include/gpio_params.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2019 Mesotic SAS
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   boards_common_saml1x
+ * @{
+ *
+ * @file
+ * @brief     Board specific configuration of direct mapped GPIOs
+ *
+ * @author    Dylan Laduranty <dylan.laduranty@mesotic.com>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    GPIO pin configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "LED(orange)",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR)
+    },
+    {
+        .name = "Button(SW0)",
+        .pin  = BTN0_PIN,
+        .mode = BTN0_MODE,
+        .flags = SAUL_GPIO_INVERTED
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/common/saml1x/include/periph_conf.h
+++ b/boards/common/saml1x/include/periph_conf.h
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2019 Mesotic SAS
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_common_saml1x
+ * @{
+ *
+ * @file
+ * @brief       Peripheral MCU configuration for the Microchip
+ *              SAML10 & SAML11 Xplained Pro board
+ *
+ * @author      Dylan Laduranty <dylan.laduranty@mesotic.com>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   GCLK reference speed
+ */
+#define CLOCK_CORECLOCK     (16000000U)
+
+/**
+ * @name    Timer peripheral configuration
+ * @{
+ */
+#define TIMER_NUMOF        (1U)
+#define TIMER_0_EN         1
+
+/* Timer 0 configuration */
+#define TIMER_0_DEV        TC0->COUNT32
+#define TIMER_0_CHANNELS   1
+#define TIMER_0_MAX_VALUE  (0xffffffff)
+#define TIMER_0_ISR        isr_tc0
+/** @} */
+
+/**
+ * @name    UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {    /* Virtual COM Port */
+        .dev      = &SERCOM2->USART,
+        .rx_pin   = GPIO_PIN(PA,25),
+        .tx_pin   = GPIO_PIN(PA,24),
+        .mux      = GPIO_MUX_D,
+        .rx_pad   = UART_PAD_RX_3,
+        .tx_pad   = UART_PAD_TX_2,
+        .flags    = UART_FLAG_NONE,
+        .gclk_src = GCLK_PCHCTRL_GEN_GCLK0
+    }
+};
+
+/* interrupt function name mapping */
+#define UART_0_ISR          isr_sercom2_2
+
+#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+/** @} */
+
+/**
+ * @name    SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .dev      = &(SERCOM0->SPI),
+        .miso_pin = GPIO_PIN(PA,  4),
+        .mosi_pin = GPIO_PIN(PA, 14),
+        .clk_pin  = GPIO_PIN(PA, 15),
+        .miso_mux = GPIO_MUX_D,
+        .mosi_mux = GPIO_MUX_D,
+        .clk_mux  = GPIO_MUX_D,
+        .miso_pad = SPI_PAD_MISO_0,
+        .mosi_pad = SPI_PAD_MOSI_2_SCK_3
+
+    }
+};
+
+#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+/** @} */
+
+/**
+ * @name    I2C configuration
+ * @{
+ */
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev      = &(SERCOM1->I2CM),
+        .speed    = I2C_SPEED_NORMAL,
+        .scl_pin  = GPIO_PIN(PA, 17),
+        .sda_pin  = GPIO_PIN(PA, 16),
+        .mux      = GPIO_MUX_C,
+        .gclk_src = GCLK_PCHCTRL_GEN_GCLK0,
+        .flags    = I2C_FLAG_NONE
+    }
+};
+
+#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+/** @} */
+
+/**
+ * @name    RTC configuration
+ * @{
+ */
+#define RTC_NUMOF           (1)
+#define EXTERNAL_OSC32_SOURCE                    1
+#define INTERNAL_OSC32_SOURCE                    0
+#define ULTRA_LOW_POWER_INTERNAL_OSC_SOURCE      0
+/** @} */
+
+/**
+ * @name    RTT configuration
+ * @{
+ */
+#define RTT_FREQUENCY       (32768U)
+#define RTT_MAX_VALUE       (0xffffffffU)
+#define RTT_NUMOF           (1)
+/** @} */
+
+/**
+ * @name ADC Configuration
+ * @{
+ */
+#define ADC_NUMOF                          (1U)
+
+/* ADC 0 Default values */
+#define ADC_0_CLK_SOURCE                   0 /* GCLK_GENERATOR_0 */
+#define ADC_0_PRESCALER                    ADC_CTRLB_PRESCALER_DIV256
+
+static const adc_conf_chan_t adc_channels[] = {
+    /* port, pin, muxpos */
+    {GPIO_PIN(PA, 10), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN8)},
+};
+
+#define ADC_0_NEG_INPUT                    ADC_INPUTCTRL_MUXNEG(0x18u)
+#define ADC_0_REF_DEFAULT                  ADC_REFCTRL_REFSEL_INTVCC2
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/boards/saml10-xpro/Makefile
+++ b/boards/saml10-xpro/Makefile
@@ -1,0 +1,4 @@
+MODULE = board
+DIRS = $(RIOTBOARD)/common/saml1x
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/saml10-xpro/Makefile.dep
+++ b/boards/saml10-xpro/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/common/saml1x/Makefile.dep

--- a/boards/saml10-xpro/Makefile.features
+++ b/boards/saml10-xpro/Makefile.features
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/common/saml1x/Makefile.features

--- a/boards/saml10-xpro/Makefile.include
+++ b/boards/saml10-xpro/Makefile.include
@@ -1,0 +1,5 @@
+export CPU_FAM  = saml10
+export CPU_MODEL = saml10e16a
+export CFLAGS += -D__SAML10E16A__
+
+include $(RIOTBOARD)/common/saml1x/Makefile.include

--- a/boards/saml10-xpro/doc.txt
+++ b/boards/saml10-xpro/doc.txt
@@ -1,0 +1,75 @@
+/**
+@defgroup    boards_saml10-xpro Microchip SAML10 Xplained Pro
+@ingroup     boards
+@brief       Support for the Microchip SAML10 Xplained Pro board.
+
+## Overview
+
+The `SAML10 Xplained Pro` is an ultra-low power evaluation board by Microchip
+featuring a ATSAML10E16A SoC. The SoC includes a SAML10 ARM Cortex-M23 micro-
+controller. For programming the MCU comes with 16KB of RAM and 64KB of flash
+memory.
+
+## Hardware
+
+![saml10-xpro image](https://www.microchip.com/_ImagedCopy/SAML10%20Xpro%20Front%20Title.jpg)
+
+
+### MCU
+| MCU        | ATSAML10E16A      |
+|:------------- |:--------------------- |
+| Family | ARM Cortex-M23    |
+| Vendor | Microchip |
+| RAM        | 16KB |
+| Flash      | 64KB             |
+| Frequency  | up to 32MHz |
+| FPU        | no                |
+| Timers | 3 (16-bit)    |
+| ADCs       | 1x 12-bit (10 channels)           |
+| UARTs      | max 3 (shared with SPI and I2C)               |
+| SPIs       | max 3 (see UART)                  |
+| I2Cs       | max 3 (see UART)              |
+| Vcc        | 1.6V - 3.6V           |
+| Datasheet  | [Datasheet](http://ww1.microchip.com/downloads/en/DeviceDoc/SAM-L10L11%20Family-DataSheet%20-%20DS60001513B.pdf) |
+| Board Manual   | [Board Manual](http://ww1.microchip.com/downloads/en/DeviceDoc/70005359B.pdf)|
+
+### User Interface
+
+1 User button and 1 LED:
+
+| Device | PIN |
+|:------ |:--- |
+| LED0   | PA07 |
+| SW0 (button) | PA27 |
+
+
+## Implementation Status
+
+| Device | ID        | Supported | Comments  |
+|:------------- |:------------- |:------------- |:------------- |
+| MCU        | saml10    | partly    | PLL clock not implemented |
+| Low-level driver | GPIO    | yes       | |
+|        | PWM       | no            | |
+|        | UART      | yes           | |
+|        | I2C       | no        | |
+|        | SPI       | no        | |
+|        | USB       | no        | |
+|        | RTT       | no        | |
+|        | RTC       | no       |  |
+|        | RNG       | no        |  |
+|        | Timer     | yes           | |
+|        | ADC       | no          | |
+
+## Flashing the device
+
+Connect the device to your Micro-USB cable.
+
+The standard method for flashing RIOT to the saml10-xpro is using EDBG.
+
+## Supported Toolchains
+
+For using the saml10-xpro board we strongly recommend the usage of the
+[GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-embedded)
+toolchain.
+
+ */

--- a/boards/saml11-xpro/Makefile
+++ b/boards/saml11-xpro/Makefile
@@ -1,0 +1,4 @@
+MODULE = board
+DIRS = $(RIOTBOARD)/common/saml1x
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/saml11-xpro/Makefile.dep
+++ b/boards/saml11-xpro/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/common/saml1x/Makefile.dep

--- a/boards/saml11-xpro/Makefile.features
+++ b/boards/saml11-xpro/Makefile.features
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/common/saml1x/Makefile.features

--- a/boards/saml11-xpro/Makefile.include
+++ b/boards/saml11-xpro/Makefile.include
@@ -1,0 +1,5 @@
+export CPU_FAM  = saml11
+export CPU_MODEL = saml11e16a
+export CFLAGS += -D__SAML11E16A__
+
+include $(RIOTBOARD)/common/saml1x/Makefile.include

--- a/boards/saml11-xpro/doc.txt
+++ b/boards/saml11-xpro/doc.txt
@@ -1,0 +1,77 @@
+/**
+@defgroup    boards_saml11-xpro Microchip SAML11 Xplained Pro
+@ingroup     boards
+@brief       Support for the Microchip SAML11 Xplained Pro board.
+
+## Overview
+
+The `SAML11 Xplained Pro` is an ultra-low power evaluation board by Microchip
+featuring a ATSAML11E16A SoC. The SoC includes a SAML11 ARM Cortex-M23 micro-
+controller. For programming the MCU comes with 16KB of RAM and 64KB of flash
+memory. In addition, this SoC features the ARM TrustZone technology.
+
+## Hardware
+
+![saml11-xpro image](https://www.microchip.com/_ImagedCopy/SAML11%20Xpro%20Front%20Title.jpg)
+
+
+### MCU
+| MCU        | ATSAML11E14A      |
+|:------------- |:--------------------- |
+| Family | ARM Cortex-M23    |
+| Vendor | Microchip |
+| RAM        | 16KB |
+| Flash      | 64KB             |
+| Frequency  | up to 32MHz |
+| FPU        | no                |
+| Timers | 3 (16-bit)    |
+| ADCs       | 1x 12-bit (10 channels)           |
+| UARTs      | max 3 (shared with SPI and I2C)               |
+| SPIs       | max 3 (see UART)                  |
+| I2Cs       | max 3 (see UART)              |
+| Vcc        | 1.6V - 3.6V           |
+| Datasheet  | [Datasheet](http://ww1.microchip.com/downloads/en/DeviceDoc/SAM-L10L11%20Family-DataSheet%20-%20DS60001513B.pdf) |
+| Board Manual   | [Board Manual](http://ww1.microchip.com/downloads/en/DeviceDoc/70005359B.pdf)|
+
+### User Interface
+
+1 User button and 1 LED:
+
+| Device | PIN |
+|:------ |:--- |
+| LED0   | PA07 |
+| SW0 (button) | PA27 |
+
+
+## Implementation Status
+
+| Device | ID        | Supported | Comments  |
+|:------------- |:------------- |:------------- |:------------- |
+| MCU        | saml11    | partly    | PLL clock not implemented |
+| Low-level driver | GPIO    | yes       | |
+|        | PWM       | no            | |
+|        | UART      | yes           | |
+|        | I2C       | no        | |
+|        | SPI       | no        | |
+|        | USB       | no        | |
+|        | RTT       | no        | |
+|        | RTC       | no       |  |
+|        | RNG       | no        |  |
+|        | Timer     | yes           | |
+|        | ADC       | no          | |
+
+
+
+## Flashing the device
+
+Connect the device to your Micro-USB cable.
+
+The standard method for flashing RIOT to the saml11-xpro is using EDBG.
+
+## Supported Toolchains
+
+For using the saml11-xpro board we strongly recommend the usage of the
+[GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-embedded)
+toolchain.
+
+*/

--- a/cpu/cortexm_common/cortexm_init.c
+++ b/cpu/cortexm_common/cortexm_init.c
@@ -65,7 +65,8 @@ void cortexm_init(void)
     /* configure the vector table location to internal flash */
 #if defined(CPU_ARCH_CORTEX_M3) || defined(CPU_ARCH_CORTEX_M4) || \
     defined(CPU_ARCH_CORTEX_M4F) || defined(CPU_ARCH_CORTEX_M7) || \
-    (defined(CPU_ARCH_CORTEX_M0PLUS) && (__VTOR_PRESENT == 1))
+    (defined(CPU_ARCH_CORTEX_M0PLUS) || defined(CPU_ARCH_CORTEX_M23) \
+    && (__VTOR_PRESENT == 1))
     SCB->VTOR = (uint32_t)&_isr_vectors;
 #endif
 

--- a/cpu/cortexm_common/mpu.c
+++ b/cpu/cortexm_common/mpu.c
@@ -59,7 +59,8 @@ bool mpu_enabled(void) {
 }
 
 int mpu_configure(uint_fast8_t region, uintptr_t base, uint_fast32_t attr) {
-#if __MPU_PRESENT
+/* Todo enable MPU support for Cortex-M23/M33 */
+#if __MPU_PRESENT && !defined(CPU_ARCH_CORTEX_M23)
     assert(region < MPU_NUM_REGIONS);
 
     MPU->RNR  = region;

--- a/cpu/cortexm_common/thread_arch.c
+++ b/cpu/cortexm_common/thread_arch.c
@@ -187,7 +187,8 @@ char *thread_stack_init(thread_task_func_t task_func,
      * For the Cortex-M3 and Cortex-M4 we write them continuously onto the stack
      * as they can be read/written continuously by stack instructions. */
 
-#if defined(CPU_ARCH_CORTEX_M0) || defined(CPU_ARCH_CORTEX_M0PLUS)
+#if defined(CPU_ARCH_CORTEX_M0) || defined(CPU_ARCH_CORTEX_M0PLUS) \
+    || defined(CPU_ARCH_CORTEX_M23)
     /* start with r7 - r4 */
     for (int i = 7; i >= 4; i--) {
         stk--;
@@ -286,7 +287,8 @@ void __attribute__((naked)) __attribute__((used)) isr_pendsv(void) {
     /* {r0-r3,r12,LR,PC,xPSR,s0-s15,FPSCR} are saved automatically on exception entry */
     ".thumb_func                      \n"
     "mrs    r0, psp                   \n" /* get stack pointer from user mode */
-#if defined(CPU_ARCH_CORTEX_M0) || defined(CPU_ARCH_CORTEX_M0PLUS)
+#if defined(CPU_ARCH_CORTEX_M0) || defined(CPU_ARCH_CORTEX_M0PLUS) \
+    || defined(CPU_ARCH_CORTEX_M23)
     "mov    r12, sp                   \n" /* remember the exception SP */
     "mov    sp, r0                    \n" /* set user mode SP as active SP */
     /* we can not push high registers directly, so we move R11-R8 into
@@ -326,7 +328,8 @@ void __attribute__((naked)) __attribute__((used)) isr_svc(void) {
     /* restore context and return from exception */
     ".thumb_func                      \n"
     "context_restore:                 \n"
-#if defined(CPU_ARCH_CORTEX_M0) || defined(CPU_ARCH_CORTEX_M0PLUS)
+#if defined(CPU_ARCH_CORTEX_M0) || defined(CPU_ARCH_CORTEX_M0PLUS) \
+    || defined(CPU_ARCH_CORTEX_M23)
     "mov    lr, sp                    \n" /* save MSR stack pointer for later */
     "ldr    r0, =sched_active_thread  \n" /* load address of current TCB */
     "ldr    r0, [r0]                  \n" /* dereference TCB */

--- a/cpu/sam0_common/Makefile.include
+++ b/cpu/sam0_common/Makefile.include
@@ -6,12 +6,18 @@ ifneq (,$(filter samd21g18a samd21j18a saml21j18b saml21j18a samr21g18a samr30g1
   ROM_LEN ?= 0x40000
   RAM_LEN ?= 0x8000
 endif
+ifneq (,$(filter saml10e16a saml11e16a,$(CPU_MODEL)))
+  ROM_LEN ?= 64K
+  RAM_LEN ?= 16K
+endif
 
 ROM_START_ADDR ?= 0x00000000
 RAM_START_ADDR ?= 0x20000000
 
 # this CPU implementation doesn't use CMSIS initialization
 export CFLAGS += -DDONT_USE_CMSIS_INIT
+export CFLAGS += -DDONT_USE_PREDEFINED_CORE_HANDLERS
+export CFLAGS += -DDONT_USE_PREDEFINED_PERIPHERALS_HANDLERS
 
 # For Cortex-M cpu we use the common cortexm.ld linker script
 LINKER_SCRIPT ?= cortexm.ld

--- a/cpu/sam0_common/include/cpu_conf.h
+++ b/cpu/sam0_common/include/cpu_conf.h
@@ -22,7 +22,11 @@
 #define CPU_CONF_H
 
 #include "cpu_conf_common.h"
+#if defined(CPU_SAML1X)
+#include "vendor/sam23.h"
+#else
 #include "vendor/sam0.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -69,7 +69,11 @@ typedef uint32_t gpio_t;
  * @brief   Macro for accessing GPIO pins
  * @{
  */
+#ifdef CPU_FAM_SAML11
+#define GPIO_PIN(x, y)      (((gpio_t)(&PORT_SEC->Group[x])) | y)
+#else
 #define GPIO_PIN(x, y)      (((gpio_t)(&PORT->Group[x])) | y)
+#endif
 
 /**
  * @brief   Available ports on the SAMD21 & SAML21
@@ -94,7 +98,11 @@ enum {
  * @name    Power mode configuration
  * @{
  */
+#ifdef CPU_FAM_SAML11
+#define PM_NUM_MODES        (2)
+#else
 #define PM_NUM_MODES        (3)
+#endif
 /** @} */
 
 #ifndef DOXYGEN
@@ -127,6 +135,7 @@ typedef enum {
 /**
  * @brief   Available MUX values for configuring a pin's alternate function
  */
+#ifndef SAM_MUX_T
 typedef enum {
     GPIO_MUX_A = 0x0,       /**< select peripheral function A */
     GPIO_MUX_B = 0x1,       /**< select peripheral function B */
@@ -137,6 +146,7 @@ typedef enum {
     GPIO_MUX_G = 0x6,       /**< select peripheral function G */
     GPIO_MUX_H = 0x7,       /**< select peripheral function H */
 } gpio_mux_t;
+#endif
 
 /**
  * @brief   Available values for SERCOM UART RX pad selection
@@ -298,6 +308,8 @@ static inline int sercom_id(void *sercom)
 {
 #if defined(CPU_FAM_SAMD21)
     return ((((uint32_t)sercom) >> 10) & 0x7) - 2;
+#elif defined (CPU_FAM_SAML10) || defined (CPU_FAM_SAML11)
+    return ((((uint32_t)sercom) >> 10) & 0x7) - 1;
 #elif defined(CPU_FAM_SAML21) || defined(CPU_FAM_SAMR30)
     /* Left side handles SERCOM0-4 while right side handles unaligned address of SERCOM5 */
     return ((((uint32_t)sercom) >> 10) & 0x7) + ((((uint32_t)sercom) >> 22) & 0x04);
@@ -313,12 +325,15 @@ static inline void sercom_clk_en(void *sercom)
 {
 #if defined(CPU_FAM_SAMD21)
     PM->APBCMASK.reg |= (PM_APBCMASK_SERCOM0 << sercom_id(sercom));
-#elif defined(CPU_FAM_SAML21) || defined(CPU_FAM_SAMR30)
+#else
     if (sercom_id(sercom) < 5) {
         MCLK->APBCMASK.reg |= (MCLK_APBCMASK_SERCOM0 << sercom_id(sercom));
-    } else {
+    }
+#if defined(CPU_FAM_SAML21)
+    else {
         MCLK->APBDMASK.reg |= (MCLK_APBDMASK_SERCOM5);
     }
+#endif /* CPU_FAM_SAML21 */
 #endif
 }
 
@@ -331,12 +346,15 @@ static inline void sercom_clk_dis(void *sercom)
 {
 #if defined(CPU_FAM_SAMD21)
     PM->APBCMASK.reg &= ~(PM_APBCMASK_SERCOM0 << sercom_id(sercom));
-#elif defined(CPU_FAM_SAML21) || defined(CPU_FAM_SAMR30)
+#else
     if (sercom_id(sercom) < 5) {
         MCLK->APBCMASK.reg &= ~(MCLK_APBCMASK_SERCOM0 << sercom_id(sercom));
-    } else {
+    }
+#if defined (CPU_FAM_SAML21)
+    else {
         MCLK->APBDMASK.reg &= ~(MCLK_APBDMASK_SERCOM5);
     }
+#endif /* CPU_FAM_SAML21 */
 #endif
 }
 
@@ -352,14 +370,17 @@ static inline void sercom_set_gen(void *sercom, uint32_t gclk)
     GCLK->CLKCTRL.reg = (GCLK_CLKCTRL_CLKEN | gclk |
                          (SERCOM0_GCLK_ID_CORE + sercom_id(sercom)));
     while (GCLK->STATUS.reg & GCLK_STATUS_SYNCBUSY) {}
-#elif defined(CPU_FAM_SAML21) || defined(CPU_FAM_SAMR30)
+#else
     if (sercom_id(sercom) < 5) {
         GCLK->PCHCTRL[SERCOM0_GCLK_ID_CORE + sercom_id(sercom)].reg =
                                                     (GCLK_PCHCTRL_CHEN | gclk);
-    } else {
+    }
+#if defined(CPU_FAM_SAML21)
+    else {
         GCLK->PCHCTRL[SERCOM5_GCLK_ID_CORE].reg =
                                                     (GCLK_PCHCTRL_CHEN | gclk);
     }
+#endif /* CPU_FAM_SAML21 */
 #endif
 }
 

--- a/cpu/sam0_common/include/vendor/sam23.h
+++ b/cpu/sam0_common/include/vendor/sam23.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2018 Mesotic SAS
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup         cpu_saml1x
+ * @{
+ *
+ * @file
+ * @brief           Wrapper include file for including the specific
+ *                  SAML10/SAML11 vendor header
+ *
+ * @author          Dylan Laduranty <dylan.laduranty@mesotic.com>
+ */
+
+#ifndef SAM23_H
+#define SAM23_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Workaround redefinition of LITTLE_ENDIAN macro (part1) */
+#ifdef LITTLE_ENDIAN
+#define __TMP_LITTLE_ENDIAN     LITTLE_ENDIAN
+#undef LITTLE_ENDIAN
+#endif
+
+#if   defined(CPU_MODEL_SAML10D14A)
+  #include "vendor/saml10/include/saml10d14a.h"
+#elif defined(CPU_MODEL_SAML10D15A)
+  #include "vendor/saml10/include/saml10d15a.h"
+#elif defined(CPU_MODEL_SAML10D16A)
+  #include "vendor/saml10/include/saml10d16a.h"
+#elif defined(CPU_MODEL_SAML10E14A)
+  #include "vendor/saml10/include/saml10e14a.h"
+#elif defined(CPU_MODEL_SAML10E15A)
+  #include "vendor/saml10/include/saml10e15a.h"
+#elif defined(CPU_MODEL_SAML10E16A)
+  #include "vendor/saml10/include/saml10e16a.h"
+
+#elif   defined(CPU_MODEL_SAML11D14A)
+  #include "vendor/saml11/include/saml11d14a.h"
+#elif defined(CPU_MODEL_SAML11D15A)
+  #include "vendor/saml11/include/saml11d15a.h"
+#elif defined(CPU_MODEL_SAML11D16A)
+  #include "vendor/saml11/include/saml11d16a.h"
+#elif defined(CPU_MODEL_SAML11E14A)
+  #include "vendor/saml11/include/saml11e14a.h"
+#elif defined(CPU_MODEL_SAML11E15A)
+  #include "vendor/saml11/include/saml11e15a.h"
+#elif defined(CPU_MODEL_SAML11E16A)
+  #include "vendor/saml11/include/saml11e16a.h"
+
+
+#else
+  #error "Unsupported SAM23 variant."
+#endif
+
+/* Workaround redefinition of LITTLE_ENDIAN macro (part2) */
+#ifdef LITTLE_ENDIAN
+#undef LITTLE_ENDIAN
+#endif
+
+#ifdef __TMP_LITTLE_ENDIAN
+#define LITTLE_ENDIAN       __TMP_LITTLE_ENDIAN
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SAM23_H */
+/** @} */

--- a/cpu/sam0_common/include/vendor/saml10/include/component-version.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component-version.h
@@ -1,0 +1,64 @@
+/**
+ * \file
+ *
+ * \brief Component version header file
+ *
+ * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+#ifndef _COMPONENT_VERSION_H_INCLUDED
+#define _COMPONENT_VERSION_H_INCLUDED
+
+#define COMPONENT_VERSION_MAJOR 1
+#define COMPONENT_VERSION_MINOR 0
+
+//
+// The COMPONENT_VERSION define is composed of the major and the minor version number.
+//
+// The last four digits of the COMPONENT_VERSION is the minor version with leading zeros.
+// The rest of the COMPONENT_VERSION is the major version.
+//
+#define COMPONENT_VERSION 10000
+
+//
+// The build number does not refer to the component, but to the build number
+// of the device pack that provides the component.
+//
+#define BUILD_NUMBER 142
+
+//
+// The COMPONENT_VERSION_STRING is a string (enclosed in ") that can be used for logging or embedding.
+//
+#define COMPONENT_VERSION_STRING "1.0"
+
+//
+// The COMPONENT_DATE_STRING contains a timestamp of when the pack was generated.
+//
+// The COMPONENT_DATE_STRING is written out using the following strftime pattern.
+//
+//     "%Y-%m-%d %H:%M:%S"
+//
+//
+#define COMPONENT_DATE_STRING "2018-09-06 14:18:38"
+
+#endif/* #ifndef _COMPONENT_VERSION_H_INCLUDED */
+

--- a/cpu/sam0_common/include/vendor/saml10/include/component/ac.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/ac.h
@@ -1,0 +1,661 @@
+/**
+ * \file
+ *
+ * \brief Component description for AC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_AC_COMPONENT_H_
+#define _SAML10_AC_COMPONENT_H_
+#define _SAML10_AC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML10 Analog Comparators
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR AC */
+/* ========================================================================== */
+
+#define AC_U2245                      /**< (AC) Module ID */
+#define REV_AC 0x102                  /**< (AC) Module revision */
+
+/* -------- AC_CTRLA : (AC Offset: 0x00) (R/W 8) Control A -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint8_t  ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint8_t  :6;                        /**< bit:   2..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} AC_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_CTRLA_OFFSET                     (0x00)                                        /**<  (AC_CTRLA) Control A  Offset */
+#define AC_CTRLA_RESETVALUE                 _U_(0x00)                                     /**<  (AC_CTRLA) Control A  Reset Value */
+
+#define AC_CTRLA_SWRST_Pos                  0                                              /**< (AC_CTRLA) Software Reset Position */
+#define AC_CTRLA_SWRST_Msk                  (_U_(0x1) << AC_CTRLA_SWRST_Pos)               /**< (AC_CTRLA) Software Reset Mask */
+#define AC_CTRLA_SWRST                      AC_CTRLA_SWRST_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_CTRLA_SWRST_Msk instead */
+#define AC_CTRLA_ENABLE_Pos                 1                                              /**< (AC_CTRLA) Enable Position */
+#define AC_CTRLA_ENABLE_Msk                 (_U_(0x1) << AC_CTRLA_ENABLE_Pos)              /**< (AC_CTRLA) Enable Mask */
+#define AC_CTRLA_ENABLE                     AC_CTRLA_ENABLE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_CTRLA_ENABLE_Msk instead */
+#define AC_CTRLA_MASK                       _U_(0x03)                                      /**< \deprecated (AC_CTRLA) Register MASK  (Use AC_CTRLA_Msk instead)  */
+#define AC_CTRLA_Msk                        _U_(0x03)                                      /**< (AC_CTRLA) Register Mask  */
+
+
+/* -------- AC_CTRLB : (AC Offset: 0x01) (/W 8) Control B -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  START0:1;                  /**< bit:      0  Comparator 0 Start Comparison            */
+    uint8_t  START1:1;                  /**< bit:      1  Comparator 1 Start Comparison            */
+    uint8_t  :6;                        /**< bit:   2..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint8_t  START:2;                   /**< bit:   0..1  Comparator x Start Comparison            */
+    uint8_t  :6;                        /**< bit:   2..7 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint8_t  reg;                         /**< Type used for register access */
+} AC_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_CTRLB_OFFSET                     (0x01)                                        /**<  (AC_CTRLB) Control B  Offset */
+#define AC_CTRLB_RESETVALUE                 _U_(0x00)                                     /**<  (AC_CTRLB) Control B  Reset Value */
+
+#define AC_CTRLB_START0_Pos                 0                                              /**< (AC_CTRLB) Comparator 0 Start Comparison Position */
+#define AC_CTRLB_START0_Msk                 (_U_(0x1) << AC_CTRLB_START0_Pos)              /**< (AC_CTRLB) Comparator 0 Start Comparison Mask */
+#define AC_CTRLB_START0                     AC_CTRLB_START0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_CTRLB_START0_Msk instead */
+#define AC_CTRLB_START1_Pos                 1                                              /**< (AC_CTRLB) Comparator 1 Start Comparison Position */
+#define AC_CTRLB_START1_Msk                 (_U_(0x1) << AC_CTRLB_START1_Pos)              /**< (AC_CTRLB) Comparator 1 Start Comparison Mask */
+#define AC_CTRLB_START1                     AC_CTRLB_START1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_CTRLB_START1_Msk instead */
+#define AC_CTRLB_MASK                       _U_(0x03)                                      /**< \deprecated (AC_CTRLB) Register MASK  (Use AC_CTRLB_Msk instead)  */
+#define AC_CTRLB_Msk                        _U_(0x03)                                      /**< (AC_CTRLB) Register Mask  */
+
+#define AC_CTRLB_START_Pos                  0                                              /**< (AC_CTRLB Position) Comparator x Start Comparison */
+#define AC_CTRLB_START_Msk                  (_U_(0x3) << AC_CTRLB_START_Pos)               /**< (AC_CTRLB Mask) START */
+#define AC_CTRLB_START(value)               (AC_CTRLB_START_Msk & ((value) << AC_CTRLB_START_Pos))  
+
+/* -------- AC_EVCTRL : (AC Offset: 0x02) (R/W 16) Event Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t COMPEO0:1;                 /**< bit:      0  Comparator 0 Event Output Enable         */
+    uint16_t COMPEO1:1;                 /**< bit:      1  Comparator 1 Event Output Enable         */
+    uint16_t :2;                        /**< bit:   2..3  Reserved */
+    uint16_t WINEO0:1;                  /**< bit:      4  Window 0 Event Output Enable             */
+    uint16_t :3;                        /**< bit:   5..7  Reserved */
+    uint16_t COMPEI0:1;                 /**< bit:      8  Comparator 0 Event Input Enable          */
+    uint16_t COMPEI1:1;                 /**< bit:      9  Comparator 1 Event Input Enable          */
+    uint16_t :2;                        /**< bit: 10..11  Reserved */
+    uint16_t INVEI0:1;                  /**< bit:     12  Comparator 0 Input Event Invert Enable   */
+    uint16_t INVEI1:1;                  /**< bit:     13  Comparator 1 Input Event Invert Enable   */
+    uint16_t :2;                        /**< bit: 14..15  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint16_t COMPEO:2;                  /**< bit:   0..1  Comparator x Event Output Enable         */
+    uint16_t :2;                        /**< bit:   2..3  Reserved */
+    uint16_t WINEO:1;                   /**< bit:      4  Window x Event Output Enable             */
+    uint16_t :3;                        /**< bit:   5..7  Reserved */
+    uint16_t COMPEI:2;                  /**< bit:   8..9  Comparator x Event Input Enable          */
+    uint16_t :2;                        /**< bit: 10..11  Reserved */
+    uint16_t INVEI:2;                   /**< bit: 12..13  Comparator x Input Event Invert Enable   */
+    uint16_t :2;                        /**< bit: 14..15 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint16_t reg;                         /**< Type used for register access */
+} AC_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_EVCTRL_OFFSET                    (0x02)                                        /**<  (AC_EVCTRL) Event Control  Offset */
+#define AC_EVCTRL_RESETVALUE                _U_(0x00)                                     /**<  (AC_EVCTRL) Event Control  Reset Value */
+
+#define AC_EVCTRL_COMPEO0_Pos               0                                              /**< (AC_EVCTRL) Comparator 0 Event Output Enable Position */
+#define AC_EVCTRL_COMPEO0_Msk               (_U_(0x1) << AC_EVCTRL_COMPEO0_Pos)            /**< (AC_EVCTRL) Comparator 0 Event Output Enable Mask */
+#define AC_EVCTRL_COMPEO0                   AC_EVCTRL_COMPEO0_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_EVCTRL_COMPEO0_Msk instead */
+#define AC_EVCTRL_COMPEO1_Pos               1                                              /**< (AC_EVCTRL) Comparator 1 Event Output Enable Position */
+#define AC_EVCTRL_COMPEO1_Msk               (_U_(0x1) << AC_EVCTRL_COMPEO1_Pos)            /**< (AC_EVCTRL) Comparator 1 Event Output Enable Mask */
+#define AC_EVCTRL_COMPEO1                   AC_EVCTRL_COMPEO1_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_EVCTRL_COMPEO1_Msk instead */
+#define AC_EVCTRL_WINEO0_Pos                4                                              /**< (AC_EVCTRL) Window 0 Event Output Enable Position */
+#define AC_EVCTRL_WINEO0_Msk                (_U_(0x1) << AC_EVCTRL_WINEO0_Pos)             /**< (AC_EVCTRL) Window 0 Event Output Enable Mask */
+#define AC_EVCTRL_WINEO0                    AC_EVCTRL_WINEO0_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_EVCTRL_WINEO0_Msk instead */
+#define AC_EVCTRL_COMPEI0_Pos               8                                              /**< (AC_EVCTRL) Comparator 0 Event Input Enable Position */
+#define AC_EVCTRL_COMPEI0_Msk               (_U_(0x1) << AC_EVCTRL_COMPEI0_Pos)            /**< (AC_EVCTRL) Comparator 0 Event Input Enable Mask */
+#define AC_EVCTRL_COMPEI0                   AC_EVCTRL_COMPEI0_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_EVCTRL_COMPEI0_Msk instead */
+#define AC_EVCTRL_COMPEI1_Pos               9                                              /**< (AC_EVCTRL) Comparator 1 Event Input Enable Position */
+#define AC_EVCTRL_COMPEI1_Msk               (_U_(0x1) << AC_EVCTRL_COMPEI1_Pos)            /**< (AC_EVCTRL) Comparator 1 Event Input Enable Mask */
+#define AC_EVCTRL_COMPEI1                   AC_EVCTRL_COMPEI1_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_EVCTRL_COMPEI1_Msk instead */
+#define AC_EVCTRL_INVEI0_Pos                12                                             /**< (AC_EVCTRL) Comparator 0 Input Event Invert Enable Position */
+#define AC_EVCTRL_INVEI0_Msk                (_U_(0x1) << AC_EVCTRL_INVEI0_Pos)             /**< (AC_EVCTRL) Comparator 0 Input Event Invert Enable Mask */
+#define AC_EVCTRL_INVEI0                    AC_EVCTRL_INVEI0_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_EVCTRL_INVEI0_Msk instead */
+#define AC_EVCTRL_INVEI1_Pos                13                                             /**< (AC_EVCTRL) Comparator 1 Input Event Invert Enable Position */
+#define AC_EVCTRL_INVEI1_Msk                (_U_(0x1) << AC_EVCTRL_INVEI1_Pos)             /**< (AC_EVCTRL) Comparator 1 Input Event Invert Enable Mask */
+#define AC_EVCTRL_INVEI1                    AC_EVCTRL_INVEI1_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_EVCTRL_INVEI1_Msk instead */
+#define AC_EVCTRL_MASK                      _U_(0x3313)                                    /**< \deprecated (AC_EVCTRL) Register MASK  (Use AC_EVCTRL_Msk instead)  */
+#define AC_EVCTRL_Msk                       _U_(0x3313)                                    /**< (AC_EVCTRL) Register Mask  */
+
+#define AC_EVCTRL_COMPEO_Pos                0                                              /**< (AC_EVCTRL Position) Comparator x Event Output Enable */
+#define AC_EVCTRL_COMPEO_Msk                (_U_(0x3) << AC_EVCTRL_COMPEO_Pos)             /**< (AC_EVCTRL Mask) COMPEO */
+#define AC_EVCTRL_COMPEO(value)             (AC_EVCTRL_COMPEO_Msk & ((value) << AC_EVCTRL_COMPEO_Pos))  
+#define AC_EVCTRL_WINEO_Pos                 4                                              /**< (AC_EVCTRL Position) Window x Event Output Enable */
+#define AC_EVCTRL_WINEO_Msk                 (_U_(0x1) << AC_EVCTRL_WINEO_Pos)              /**< (AC_EVCTRL Mask) WINEO */
+#define AC_EVCTRL_WINEO(value)              (AC_EVCTRL_WINEO_Msk & ((value) << AC_EVCTRL_WINEO_Pos))  
+#define AC_EVCTRL_COMPEI_Pos                8                                              /**< (AC_EVCTRL Position) Comparator x Event Input Enable */
+#define AC_EVCTRL_COMPEI_Msk                (_U_(0x3) << AC_EVCTRL_COMPEI_Pos)             /**< (AC_EVCTRL Mask) COMPEI */
+#define AC_EVCTRL_COMPEI(value)             (AC_EVCTRL_COMPEI_Msk & ((value) << AC_EVCTRL_COMPEI_Pos))  
+#define AC_EVCTRL_INVEI_Pos                 12                                             /**< (AC_EVCTRL Position) Comparator x Input Event Invert Enable */
+#define AC_EVCTRL_INVEI_Msk                 (_U_(0x3) << AC_EVCTRL_INVEI_Pos)              /**< (AC_EVCTRL Mask) INVEI */
+#define AC_EVCTRL_INVEI(value)              (AC_EVCTRL_INVEI_Msk & ((value) << AC_EVCTRL_INVEI_Pos))  
+
+/* -------- AC_INTENCLR : (AC Offset: 0x04) (R/W 8) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  COMP0:1;                   /**< bit:      0  Comparator 0 Interrupt Enable            */
+    uint8_t  COMP1:1;                   /**< bit:      1  Comparator 1 Interrupt Enable            */
+    uint8_t  :2;                        /**< bit:   2..3  Reserved */
+    uint8_t  WIN0:1;                    /**< bit:      4  Window 0 Interrupt Enable                */
+    uint8_t  :3;                        /**< bit:   5..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint8_t  COMP:2;                    /**< bit:   0..1  Comparator x Interrupt Enable            */
+    uint8_t  :2;                        /**< bit:   2..3  Reserved */
+    uint8_t  WIN:1;                     /**< bit:      4  Window x Interrupt Enable                */
+    uint8_t  :3;                        /**< bit:   5..7 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint8_t  reg;                         /**< Type used for register access */
+} AC_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_INTENCLR_OFFSET                  (0x04)                                        /**<  (AC_INTENCLR) Interrupt Enable Clear  Offset */
+#define AC_INTENCLR_RESETVALUE              _U_(0x00)                                     /**<  (AC_INTENCLR) Interrupt Enable Clear  Reset Value */
+
+#define AC_INTENCLR_COMP0_Pos               0                                              /**< (AC_INTENCLR) Comparator 0 Interrupt Enable Position */
+#define AC_INTENCLR_COMP0_Msk               (_U_(0x1) << AC_INTENCLR_COMP0_Pos)            /**< (AC_INTENCLR) Comparator 0 Interrupt Enable Mask */
+#define AC_INTENCLR_COMP0                   AC_INTENCLR_COMP0_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_INTENCLR_COMP0_Msk instead */
+#define AC_INTENCLR_COMP1_Pos               1                                              /**< (AC_INTENCLR) Comparator 1 Interrupt Enable Position */
+#define AC_INTENCLR_COMP1_Msk               (_U_(0x1) << AC_INTENCLR_COMP1_Pos)            /**< (AC_INTENCLR) Comparator 1 Interrupt Enable Mask */
+#define AC_INTENCLR_COMP1                   AC_INTENCLR_COMP1_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_INTENCLR_COMP1_Msk instead */
+#define AC_INTENCLR_WIN0_Pos                4                                              /**< (AC_INTENCLR) Window 0 Interrupt Enable Position */
+#define AC_INTENCLR_WIN0_Msk                (_U_(0x1) << AC_INTENCLR_WIN0_Pos)             /**< (AC_INTENCLR) Window 0 Interrupt Enable Mask */
+#define AC_INTENCLR_WIN0                    AC_INTENCLR_WIN0_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_INTENCLR_WIN0_Msk instead */
+#define AC_INTENCLR_MASK                    _U_(0x13)                                      /**< \deprecated (AC_INTENCLR) Register MASK  (Use AC_INTENCLR_Msk instead)  */
+#define AC_INTENCLR_Msk                     _U_(0x13)                                      /**< (AC_INTENCLR) Register Mask  */
+
+#define AC_INTENCLR_COMP_Pos                0                                              /**< (AC_INTENCLR Position) Comparator x Interrupt Enable */
+#define AC_INTENCLR_COMP_Msk                (_U_(0x3) << AC_INTENCLR_COMP_Pos)             /**< (AC_INTENCLR Mask) COMP */
+#define AC_INTENCLR_COMP(value)             (AC_INTENCLR_COMP_Msk & ((value) << AC_INTENCLR_COMP_Pos))  
+#define AC_INTENCLR_WIN_Pos                 4                                              /**< (AC_INTENCLR Position) Window x Interrupt Enable */
+#define AC_INTENCLR_WIN_Msk                 (_U_(0x1) << AC_INTENCLR_WIN_Pos)              /**< (AC_INTENCLR Mask) WIN */
+#define AC_INTENCLR_WIN(value)              (AC_INTENCLR_WIN_Msk & ((value) << AC_INTENCLR_WIN_Pos))  
+
+/* -------- AC_INTENSET : (AC Offset: 0x05) (R/W 8) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  COMP0:1;                   /**< bit:      0  Comparator 0 Interrupt Enable            */
+    uint8_t  COMP1:1;                   /**< bit:      1  Comparator 1 Interrupt Enable            */
+    uint8_t  :2;                        /**< bit:   2..3  Reserved */
+    uint8_t  WIN0:1;                    /**< bit:      4  Window 0 Interrupt Enable                */
+    uint8_t  :3;                        /**< bit:   5..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint8_t  COMP:2;                    /**< bit:   0..1  Comparator x Interrupt Enable            */
+    uint8_t  :2;                        /**< bit:   2..3  Reserved */
+    uint8_t  WIN:1;                     /**< bit:      4  Window x Interrupt Enable                */
+    uint8_t  :3;                        /**< bit:   5..7 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint8_t  reg;                         /**< Type used for register access */
+} AC_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_INTENSET_OFFSET                  (0x05)                                        /**<  (AC_INTENSET) Interrupt Enable Set  Offset */
+#define AC_INTENSET_RESETVALUE              _U_(0x00)                                     /**<  (AC_INTENSET) Interrupt Enable Set  Reset Value */
+
+#define AC_INTENSET_COMP0_Pos               0                                              /**< (AC_INTENSET) Comparator 0 Interrupt Enable Position */
+#define AC_INTENSET_COMP0_Msk               (_U_(0x1) << AC_INTENSET_COMP0_Pos)            /**< (AC_INTENSET) Comparator 0 Interrupt Enable Mask */
+#define AC_INTENSET_COMP0                   AC_INTENSET_COMP0_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_INTENSET_COMP0_Msk instead */
+#define AC_INTENSET_COMP1_Pos               1                                              /**< (AC_INTENSET) Comparator 1 Interrupt Enable Position */
+#define AC_INTENSET_COMP1_Msk               (_U_(0x1) << AC_INTENSET_COMP1_Pos)            /**< (AC_INTENSET) Comparator 1 Interrupt Enable Mask */
+#define AC_INTENSET_COMP1                   AC_INTENSET_COMP1_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_INTENSET_COMP1_Msk instead */
+#define AC_INTENSET_WIN0_Pos                4                                              /**< (AC_INTENSET) Window 0 Interrupt Enable Position */
+#define AC_INTENSET_WIN0_Msk                (_U_(0x1) << AC_INTENSET_WIN0_Pos)             /**< (AC_INTENSET) Window 0 Interrupt Enable Mask */
+#define AC_INTENSET_WIN0                    AC_INTENSET_WIN0_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_INTENSET_WIN0_Msk instead */
+#define AC_INTENSET_MASK                    _U_(0x13)                                      /**< \deprecated (AC_INTENSET) Register MASK  (Use AC_INTENSET_Msk instead)  */
+#define AC_INTENSET_Msk                     _U_(0x13)                                      /**< (AC_INTENSET) Register Mask  */
+
+#define AC_INTENSET_COMP_Pos                0                                              /**< (AC_INTENSET Position) Comparator x Interrupt Enable */
+#define AC_INTENSET_COMP_Msk                (_U_(0x3) << AC_INTENSET_COMP_Pos)             /**< (AC_INTENSET Mask) COMP */
+#define AC_INTENSET_COMP(value)             (AC_INTENSET_COMP_Msk & ((value) << AC_INTENSET_COMP_Pos))  
+#define AC_INTENSET_WIN_Pos                 4                                              /**< (AC_INTENSET Position) Window x Interrupt Enable */
+#define AC_INTENSET_WIN_Msk                 (_U_(0x1) << AC_INTENSET_WIN_Pos)              /**< (AC_INTENSET Mask) WIN */
+#define AC_INTENSET_WIN(value)              (AC_INTENSET_WIN_Msk & ((value) << AC_INTENSET_WIN_Pos))  
+
+/* -------- AC_INTFLAG : (AC Offset: 0x06) (R/W 8) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t COMP0:1;                   /**< bit:      0  Comparator 0                             */
+    __I uint8_t COMP1:1;                   /**< bit:      1  Comparator 1                             */
+    __I uint8_t :2;                        /**< bit:   2..3  Reserved */
+    __I uint8_t WIN0:1;                    /**< bit:      4  Window 0                                 */
+    __I uint8_t :3;                        /**< bit:   5..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    __I uint8_t COMP:2;                    /**< bit:   0..1  Comparator x                             */
+    __I uint8_t :2;                        /**< bit:   2..3  Reserved */
+    __I uint8_t WIN:1;                     /**< bit:      4  Window x                                 */
+    __I uint8_t :3;                        /**< bit:   5..7 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint8_t  reg;                         /**< Type used for register access */
+} AC_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_INTFLAG_OFFSET                   (0x06)                                        /**<  (AC_INTFLAG) Interrupt Flag Status and Clear  Offset */
+#define AC_INTFLAG_RESETVALUE               _U_(0x00)                                     /**<  (AC_INTFLAG) Interrupt Flag Status and Clear  Reset Value */
+
+#define AC_INTFLAG_COMP0_Pos                0                                              /**< (AC_INTFLAG) Comparator 0 Position */
+#define AC_INTFLAG_COMP0_Msk                (_U_(0x1) << AC_INTFLAG_COMP0_Pos)             /**< (AC_INTFLAG) Comparator 0 Mask */
+#define AC_INTFLAG_COMP0                    AC_INTFLAG_COMP0_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_INTFLAG_COMP0_Msk instead */
+#define AC_INTFLAG_COMP1_Pos                1                                              /**< (AC_INTFLAG) Comparator 1 Position */
+#define AC_INTFLAG_COMP1_Msk                (_U_(0x1) << AC_INTFLAG_COMP1_Pos)             /**< (AC_INTFLAG) Comparator 1 Mask */
+#define AC_INTFLAG_COMP1                    AC_INTFLAG_COMP1_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_INTFLAG_COMP1_Msk instead */
+#define AC_INTFLAG_WIN0_Pos                 4                                              /**< (AC_INTFLAG) Window 0 Position */
+#define AC_INTFLAG_WIN0_Msk                 (_U_(0x1) << AC_INTFLAG_WIN0_Pos)              /**< (AC_INTFLAG) Window 0 Mask */
+#define AC_INTFLAG_WIN0                     AC_INTFLAG_WIN0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_INTFLAG_WIN0_Msk instead */
+#define AC_INTFLAG_MASK                     _U_(0x13)                                      /**< \deprecated (AC_INTFLAG) Register MASK  (Use AC_INTFLAG_Msk instead)  */
+#define AC_INTFLAG_Msk                      _U_(0x13)                                      /**< (AC_INTFLAG) Register Mask  */
+
+#define AC_INTFLAG_COMP_Pos                 0                                              /**< (AC_INTFLAG Position) Comparator x */
+#define AC_INTFLAG_COMP_Msk                 (_U_(0x3) << AC_INTFLAG_COMP_Pos)              /**< (AC_INTFLAG Mask) COMP */
+#define AC_INTFLAG_COMP(value)              (AC_INTFLAG_COMP_Msk & ((value) << AC_INTFLAG_COMP_Pos))  
+#define AC_INTFLAG_WIN_Pos                  4                                              /**< (AC_INTFLAG Position) Window x */
+#define AC_INTFLAG_WIN_Msk                  (_U_(0x1) << AC_INTFLAG_WIN_Pos)               /**< (AC_INTFLAG Mask) WIN */
+#define AC_INTFLAG_WIN(value)               (AC_INTFLAG_WIN_Msk & ((value) << AC_INTFLAG_WIN_Pos))  
+
+/* -------- AC_STATUSA : (AC Offset: 0x07) (R/ 8) Status A -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  STATE0:1;                  /**< bit:      0  Comparator 0 Current State               */
+    uint8_t  STATE1:1;                  /**< bit:      1  Comparator 1 Current State               */
+    uint8_t  :2;                        /**< bit:   2..3  Reserved */
+    uint8_t  WSTATE0:2;                 /**< bit:   4..5  Window 0 Current State                   */
+    uint8_t  :2;                        /**< bit:   6..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint8_t  STATE:2;                   /**< bit:   0..1  Comparator x Current State               */
+    uint8_t  :6;                        /**< bit:   2..7 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint8_t  reg;                         /**< Type used for register access */
+} AC_STATUSA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_STATUSA_OFFSET                   (0x07)                                        /**<  (AC_STATUSA) Status A  Offset */
+#define AC_STATUSA_RESETVALUE               _U_(0x00)                                     /**<  (AC_STATUSA) Status A  Reset Value */
+
+#define AC_STATUSA_STATE0_Pos               0                                              /**< (AC_STATUSA) Comparator 0 Current State Position */
+#define AC_STATUSA_STATE0_Msk               (_U_(0x1) << AC_STATUSA_STATE0_Pos)            /**< (AC_STATUSA) Comparator 0 Current State Mask */
+#define AC_STATUSA_STATE0                   AC_STATUSA_STATE0_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_STATUSA_STATE0_Msk instead */
+#define AC_STATUSA_STATE1_Pos               1                                              /**< (AC_STATUSA) Comparator 1 Current State Position */
+#define AC_STATUSA_STATE1_Msk               (_U_(0x1) << AC_STATUSA_STATE1_Pos)            /**< (AC_STATUSA) Comparator 1 Current State Mask */
+#define AC_STATUSA_STATE1                   AC_STATUSA_STATE1_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_STATUSA_STATE1_Msk instead */
+#define AC_STATUSA_WSTATE0_Pos              4                                              /**< (AC_STATUSA) Window 0 Current State Position */
+#define AC_STATUSA_WSTATE0_Msk              (_U_(0x3) << AC_STATUSA_WSTATE0_Pos)           /**< (AC_STATUSA) Window 0 Current State Mask */
+#define AC_STATUSA_WSTATE0(value)           (AC_STATUSA_WSTATE0_Msk & ((value) << AC_STATUSA_WSTATE0_Pos))
+#define   AC_STATUSA_WSTATE0_ABOVE_Val      _U_(0x0)                                       /**< (AC_STATUSA) Signal is above window  */
+#define   AC_STATUSA_WSTATE0_INSIDE_Val     _U_(0x1)                                       /**< (AC_STATUSA) Signal is inside window  */
+#define   AC_STATUSA_WSTATE0_BELOW_Val      _U_(0x2)                                       /**< (AC_STATUSA) Signal is below window  */
+#define AC_STATUSA_WSTATE0_ABOVE            (AC_STATUSA_WSTATE0_ABOVE_Val << AC_STATUSA_WSTATE0_Pos)  /**< (AC_STATUSA) Signal is above window Position  */
+#define AC_STATUSA_WSTATE0_INSIDE           (AC_STATUSA_WSTATE0_INSIDE_Val << AC_STATUSA_WSTATE0_Pos)  /**< (AC_STATUSA) Signal is inside window Position  */
+#define AC_STATUSA_WSTATE0_BELOW            (AC_STATUSA_WSTATE0_BELOW_Val << AC_STATUSA_WSTATE0_Pos)  /**< (AC_STATUSA) Signal is below window Position  */
+#define AC_STATUSA_MASK                     _U_(0x33)                                      /**< \deprecated (AC_STATUSA) Register MASK  (Use AC_STATUSA_Msk instead)  */
+#define AC_STATUSA_Msk                      _U_(0x33)                                      /**< (AC_STATUSA) Register Mask  */
+
+#define AC_STATUSA_STATE_Pos                0                                              /**< (AC_STATUSA Position) Comparator x Current State */
+#define AC_STATUSA_STATE_Msk                (_U_(0x3) << AC_STATUSA_STATE_Pos)             /**< (AC_STATUSA Mask) STATE */
+#define AC_STATUSA_STATE(value)             (AC_STATUSA_STATE_Msk & ((value) << AC_STATUSA_STATE_Pos))  
+
+/* -------- AC_STATUSB : (AC Offset: 0x08) (R/ 8) Status B -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  READY0:1;                  /**< bit:      0  Comparator 0 Ready                       */
+    uint8_t  READY1:1;                  /**< bit:      1  Comparator 1 Ready                       */
+    uint8_t  :6;                        /**< bit:   2..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint8_t  READY:2;                   /**< bit:   0..1  Comparator x Ready                       */
+    uint8_t  :6;                        /**< bit:   2..7 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint8_t  reg;                         /**< Type used for register access */
+} AC_STATUSB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_STATUSB_OFFSET                   (0x08)                                        /**<  (AC_STATUSB) Status B  Offset */
+#define AC_STATUSB_RESETVALUE               _U_(0x00)                                     /**<  (AC_STATUSB) Status B  Reset Value */
+
+#define AC_STATUSB_READY0_Pos               0                                              /**< (AC_STATUSB) Comparator 0 Ready Position */
+#define AC_STATUSB_READY0_Msk               (_U_(0x1) << AC_STATUSB_READY0_Pos)            /**< (AC_STATUSB) Comparator 0 Ready Mask */
+#define AC_STATUSB_READY0                   AC_STATUSB_READY0_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_STATUSB_READY0_Msk instead */
+#define AC_STATUSB_READY1_Pos               1                                              /**< (AC_STATUSB) Comparator 1 Ready Position */
+#define AC_STATUSB_READY1_Msk               (_U_(0x1) << AC_STATUSB_READY1_Pos)            /**< (AC_STATUSB) Comparator 1 Ready Mask */
+#define AC_STATUSB_READY1                   AC_STATUSB_READY1_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_STATUSB_READY1_Msk instead */
+#define AC_STATUSB_MASK                     _U_(0x03)                                      /**< \deprecated (AC_STATUSB) Register MASK  (Use AC_STATUSB_Msk instead)  */
+#define AC_STATUSB_Msk                      _U_(0x03)                                      /**< (AC_STATUSB) Register Mask  */
+
+#define AC_STATUSB_READY_Pos                0                                              /**< (AC_STATUSB Position) Comparator x Ready */
+#define AC_STATUSB_READY_Msk                (_U_(0x3) << AC_STATUSB_READY_Pos)             /**< (AC_STATUSB Mask) READY */
+#define AC_STATUSB_READY(value)             (AC_STATUSB_READY_Msk & ((value) << AC_STATUSB_READY_Pos))  
+
+/* -------- AC_DBGCTRL : (AC Offset: 0x09) (R/W 8) Debug Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DBGRUN:1;                  /**< bit:      0  Debug Run                                */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} AC_DBGCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_DBGCTRL_OFFSET                   (0x09)                                        /**<  (AC_DBGCTRL) Debug Control  Offset */
+#define AC_DBGCTRL_RESETVALUE               _U_(0x00)                                     /**<  (AC_DBGCTRL) Debug Control  Reset Value */
+
+#define AC_DBGCTRL_DBGRUN_Pos               0                                              /**< (AC_DBGCTRL) Debug Run Position */
+#define AC_DBGCTRL_DBGRUN_Msk               (_U_(0x1) << AC_DBGCTRL_DBGRUN_Pos)            /**< (AC_DBGCTRL) Debug Run Mask */
+#define AC_DBGCTRL_DBGRUN                   AC_DBGCTRL_DBGRUN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_DBGCTRL_DBGRUN_Msk instead */
+#define AC_DBGCTRL_MASK                     _U_(0x01)                                      /**< \deprecated (AC_DBGCTRL) Register MASK  (Use AC_DBGCTRL_Msk instead)  */
+#define AC_DBGCTRL_Msk                      _U_(0x01)                                      /**< (AC_DBGCTRL) Register Mask  */
+
+
+/* -------- AC_WINCTRL : (AC Offset: 0x0a) (R/W 8) Window Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  WEN0:1;                    /**< bit:      0  Window 0 Mode Enable                     */
+    uint8_t  WINTSEL0:2;                /**< bit:   1..2  Window 0 Interrupt Selection             */
+    uint8_t  :5;                        /**< bit:   3..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint8_t  WEN:1;                     /**< bit:      0  Window x Mode Enable                     */
+    uint8_t  :7;                        /**< bit:   1..7 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint8_t  reg;                         /**< Type used for register access */
+} AC_WINCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_WINCTRL_OFFSET                   (0x0A)                                        /**<  (AC_WINCTRL) Window Control  Offset */
+#define AC_WINCTRL_RESETVALUE               _U_(0x00)                                     /**<  (AC_WINCTRL) Window Control  Reset Value */
+
+#define AC_WINCTRL_WEN0_Pos                 0                                              /**< (AC_WINCTRL) Window 0 Mode Enable Position */
+#define AC_WINCTRL_WEN0_Msk                 (_U_(0x1) << AC_WINCTRL_WEN0_Pos)              /**< (AC_WINCTRL) Window 0 Mode Enable Mask */
+#define AC_WINCTRL_WEN0                     AC_WINCTRL_WEN0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_WINCTRL_WEN0_Msk instead */
+#define AC_WINCTRL_WINTSEL0_Pos             1                                              /**< (AC_WINCTRL) Window 0 Interrupt Selection Position */
+#define AC_WINCTRL_WINTSEL0_Msk             (_U_(0x3) << AC_WINCTRL_WINTSEL0_Pos)          /**< (AC_WINCTRL) Window 0 Interrupt Selection Mask */
+#define AC_WINCTRL_WINTSEL0(value)          (AC_WINCTRL_WINTSEL0_Msk & ((value) << AC_WINCTRL_WINTSEL0_Pos))
+#define   AC_WINCTRL_WINTSEL0_ABOVE_Val     _U_(0x0)                                       /**< (AC_WINCTRL) Interrupt on signal above window  */
+#define   AC_WINCTRL_WINTSEL0_INSIDE_Val    _U_(0x1)                                       /**< (AC_WINCTRL) Interrupt on signal inside window  */
+#define   AC_WINCTRL_WINTSEL0_BELOW_Val     _U_(0x2)                                       /**< (AC_WINCTRL) Interrupt on signal below window  */
+#define   AC_WINCTRL_WINTSEL0_OUTSIDE_Val   _U_(0x3)                                       /**< (AC_WINCTRL) Interrupt on signal outside window  */
+#define AC_WINCTRL_WINTSEL0_ABOVE           (AC_WINCTRL_WINTSEL0_ABOVE_Val << AC_WINCTRL_WINTSEL0_Pos)  /**< (AC_WINCTRL) Interrupt on signal above window Position  */
+#define AC_WINCTRL_WINTSEL0_INSIDE          (AC_WINCTRL_WINTSEL0_INSIDE_Val << AC_WINCTRL_WINTSEL0_Pos)  /**< (AC_WINCTRL) Interrupt on signal inside window Position  */
+#define AC_WINCTRL_WINTSEL0_BELOW           (AC_WINCTRL_WINTSEL0_BELOW_Val << AC_WINCTRL_WINTSEL0_Pos)  /**< (AC_WINCTRL) Interrupt on signal below window Position  */
+#define AC_WINCTRL_WINTSEL0_OUTSIDE         (AC_WINCTRL_WINTSEL0_OUTSIDE_Val << AC_WINCTRL_WINTSEL0_Pos)  /**< (AC_WINCTRL) Interrupt on signal outside window Position  */
+#define AC_WINCTRL_MASK                     _U_(0x07)                                      /**< \deprecated (AC_WINCTRL) Register MASK  (Use AC_WINCTRL_Msk instead)  */
+#define AC_WINCTRL_Msk                      _U_(0x07)                                      /**< (AC_WINCTRL) Register Mask  */
+
+#define AC_WINCTRL_WEN_Pos                  0                                              /**< (AC_WINCTRL Position) Window x Mode Enable */
+#define AC_WINCTRL_WEN_Msk                  (_U_(0x1) << AC_WINCTRL_WEN_Pos)               /**< (AC_WINCTRL Mask) WEN */
+#define AC_WINCTRL_WEN(value)               (AC_WINCTRL_WEN_Msk & ((value) << AC_WINCTRL_WEN_Pos))  
+
+/* -------- AC_SCALER : (AC Offset: 0x0c) (R/W 8) Scaler n -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  VALUE:6;                   /**< bit:   0..5  Scaler Value                             */
+    uint8_t  :2;                        /**< bit:   6..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} AC_SCALER_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_SCALER_OFFSET                    (0x0C)                                        /**<  (AC_SCALER) Scaler n  Offset */
+#define AC_SCALER_RESETVALUE                _U_(0x00)                                     /**<  (AC_SCALER) Scaler n  Reset Value */
+
+#define AC_SCALER_VALUE_Pos                 0                                              /**< (AC_SCALER) Scaler Value Position */
+#define AC_SCALER_VALUE_Msk                 (_U_(0x3F) << AC_SCALER_VALUE_Pos)             /**< (AC_SCALER) Scaler Value Mask */
+#define AC_SCALER_VALUE(value)              (AC_SCALER_VALUE_Msk & ((value) << AC_SCALER_VALUE_Pos))
+#define AC_SCALER_MASK                      _U_(0x3F)                                      /**< \deprecated (AC_SCALER) Register MASK  (Use AC_SCALER_Msk instead)  */
+#define AC_SCALER_Msk                       _U_(0x3F)                                      /**< (AC_SCALER) Register Mask  */
+
+
+/* -------- AC_COMPCTRL : (AC Offset: 0x10) (R/W 32) Comparator Control n -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint32_t SINGLE:1;                  /**< bit:      2  Single-Shot Mode                         */
+    uint32_t INTSEL:2;                  /**< bit:   3..4  Interrupt Selection                      */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t RUNSTDBY:1;                /**< bit:      6  Run in Standby                           */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t MUXNEG:3;                  /**< bit:  8..10  Negative Input Mux Selection             */
+    uint32_t :1;                        /**< bit:     11  Reserved */
+    uint32_t MUXPOS:3;                  /**< bit: 12..14  Positive Input Mux Selection             */
+    uint32_t SWAP:1;                    /**< bit:     15  Swap Inputs and Invert                   */
+    uint32_t SPEED:2;                   /**< bit: 16..17  Speed Selection                          */
+    uint32_t :1;                        /**< bit:     18  Reserved */
+    uint32_t HYSTEN:1;                  /**< bit:     19  Hysteresis Enable                        */
+    uint32_t HYST:2;                    /**< bit: 20..21  Hysteresis Level                         */
+    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t FLEN:3;                    /**< bit: 24..26  Filter Length                            */
+    uint32_t :1;                        /**< bit:     27  Reserved */
+    uint32_t OUT:2;                     /**< bit: 28..29  Output                                   */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AC_COMPCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_COMPCTRL_OFFSET                  (0x10)                                        /**<  (AC_COMPCTRL) Comparator Control n  Offset */
+#define AC_COMPCTRL_RESETVALUE              _U_(0x00)                                     /**<  (AC_COMPCTRL) Comparator Control n  Reset Value */
+
+#define AC_COMPCTRL_ENABLE_Pos              1                                              /**< (AC_COMPCTRL) Enable Position */
+#define AC_COMPCTRL_ENABLE_Msk              (_U_(0x1) << AC_COMPCTRL_ENABLE_Pos)           /**< (AC_COMPCTRL) Enable Mask */
+#define AC_COMPCTRL_ENABLE                  AC_COMPCTRL_ENABLE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_COMPCTRL_ENABLE_Msk instead */
+#define AC_COMPCTRL_SINGLE_Pos              2                                              /**< (AC_COMPCTRL) Single-Shot Mode Position */
+#define AC_COMPCTRL_SINGLE_Msk              (_U_(0x1) << AC_COMPCTRL_SINGLE_Pos)           /**< (AC_COMPCTRL) Single-Shot Mode Mask */
+#define AC_COMPCTRL_SINGLE                  AC_COMPCTRL_SINGLE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_COMPCTRL_SINGLE_Msk instead */
+#define AC_COMPCTRL_INTSEL_Pos              3                                              /**< (AC_COMPCTRL) Interrupt Selection Position */
+#define AC_COMPCTRL_INTSEL_Msk              (_U_(0x3) << AC_COMPCTRL_INTSEL_Pos)           /**< (AC_COMPCTRL) Interrupt Selection Mask */
+#define AC_COMPCTRL_INTSEL(value)           (AC_COMPCTRL_INTSEL_Msk & ((value) << AC_COMPCTRL_INTSEL_Pos))
+#define   AC_COMPCTRL_INTSEL_TOGGLE_Val     _U_(0x0)                                       /**< (AC_COMPCTRL) Interrupt on comparator output toggle  */
+#define   AC_COMPCTRL_INTSEL_RISING_Val     _U_(0x1)                                       /**< (AC_COMPCTRL) Interrupt on comparator output rising  */
+#define   AC_COMPCTRL_INTSEL_FALLING_Val    _U_(0x2)                                       /**< (AC_COMPCTRL) Interrupt on comparator output falling  */
+#define   AC_COMPCTRL_INTSEL_EOC_Val        _U_(0x3)                                       /**< (AC_COMPCTRL) Interrupt on end of comparison (single-shot mode only)  */
+#define AC_COMPCTRL_INTSEL_TOGGLE           (AC_COMPCTRL_INTSEL_TOGGLE_Val << AC_COMPCTRL_INTSEL_Pos)  /**< (AC_COMPCTRL) Interrupt on comparator output toggle Position  */
+#define AC_COMPCTRL_INTSEL_RISING           (AC_COMPCTRL_INTSEL_RISING_Val << AC_COMPCTRL_INTSEL_Pos)  /**< (AC_COMPCTRL) Interrupt on comparator output rising Position  */
+#define AC_COMPCTRL_INTSEL_FALLING          (AC_COMPCTRL_INTSEL_FALLING_Val << AC_COMPCTRL_INTSEL_Pos)  /**< (AC_COMPCTRL) Interrupt on comparator output falling Position  */
+#define AC_COMPCTRL_INTSEL_EOC              (AC_COMPCTRL_INTSEL_EOC_Val << AC_COMPCTRL_INTSEL_Pos)  /**< (AC_COMPCTRL) Interrupt on end of comparison (single-shot mode only) Position  */
+#define AC_COMPCTRL_RUNSTDBY_Pos            6                                              /**< (AC_COMPCTRL) Run in Standby Position */
+#define AC_COMPCTRL_RUNSTDBY_Msk            (_U_(0x1) << AC_COMPCTRL_RUNSTDBY_Pos)         /**< (AC_COMPCTRL) Run in Standby Mask */
+#define AC_COMPCTRL_RUNSTDBY                AC_COMPCTRL_RUNSTDBY_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_COMPCTRL_RUNSTDBY_Msk instead */
+#define AC_COMPCTRL_MUXNEG_Pos              8                                              /**< (AC_COMPCTRL) Negative Input Mux Selection Position */
+#define AC_COMPCTRL_MUXNEG_Msk              (_U_(0x7) << AC_COMPCTRL_MUXNEG_Pos)           /**< (AC_COMPCTRL) Negative Input Mux Selection Mask */
+#define AC_COMPCTRL_MUXNEG(value)           (AC_COMPCTRL_MUXNEG_Msk & ((value) << AC_COMPCTRL_MUXNEG_Pos))
+#define   AC_COMPCTRL_MUXNEG_PIN0_Val       _U_(0x0)                                       /**< (AC_COMPCTRL) I/O pin 0  */
+#define   AC_COMPCTRL_MUXNEG_PIN1_Val       _U_(0x1)                                       /**< (AC_COMPCTRL) I/O pin 1  */
+#define   AC_COMPCTRL_MUXNEG_PIN2_Val       _U_(0x2)                                       /**< (AC_COMPCTRL) I/O pin 2  */
+#define   AC_COMPCTRL_MUXNEG_PIN3_Val       _U_(0x3)                                       /**< (AC_COMPCTRL) I/O pin 3  */
+#define   AC_COMPCTRL_MUXNEG_GND_Val        _U_(0x4)                                       /**< (AC_COMPCTRL) Ground  */
+#define   AC_COMPCTRL_MUXNEG_VSCALE_Val     _U_(0x5)                                       /**< (AC_COMPCTRL) VDD scaler  */
+#define   AC_COMPCTRL_MUXNEG_BANDGAP_Val    _U_(0x6)                                       /**< (AC_COMPCTRL) Internal bandgap voltage  */
+#define   AC_COMPCTRL_MUXNEG_OPAMP_Val      _U_(0x7)                                       /**< (AC_COMPCTRL) OPAMP output (on AC1)  */
+#define   AC_COMPCTRL_MUXNEG_DAC_Val        _U_(0x7)                                       /**< (AC_COMPCTRL) DAC output (on AC0)  */
+#define AC_COMPCTRL_MUXNEG_PIN0             (AC_COMPCTRL_MUXNEG_PIN0_Val << AC_COMPCTRL_MUXNEG_Pos)  /**< (AC_COMPCTRL) I/O pin 0 Position  */
+#define AC_COMPCTRL_MUXNEG_PIN1             (AC_COMPCTRL_MUXNEG_PIN1_Val << AC_COMPCTRL_MUXNEG_Pos)  /**< (AC_COMPCTRL) I/O pin 1 Position  */
+#define AC_COMPCTRL_MUXNEG_PIN2             (AC_COMPCTRL_MUXNEG_PIN2_Val << AC_COMPCTRL_MUXNEG_Pos)  /**< (AC_COMPCTRL) I/O pin 2 Position  */
+#define AC_COMPCTRL_MUXNEG_PIN3             (AC_COMPCTRL_MUXNEG_PIN3_Val << AC_COMPCTRL_MUXNEG_Pos)  /**< (AC_COMPCTRL) I/O pin 3 Position  */
+#define AC_COMPCTRL_MUXNEG_GND              (AC_COMPCTRL_MUXNEG_GND_Val << AC_COMPCTRL_MUXNEG_Pos)  /**< (AC_COMPCTRL) Ground Position  */
+#define AC_COMPCTRL_MUXNEG_VSCALE           (AC_COMPCTRL_MUXNEG_VSCALE_Val << AC_COMPCTRL_MUXNEG_Pos)  /**< (AC_COMPCTRL) VDD scaler Position  */
+#define AC_COMPCTRL_MUXNEG_BANDGAP          (AC_COMPCTRL_MUXNEG_BANDGAP_Val << AC_COMPCTRL_MUXNEG_Pos)  /**< (AC_COMPCTRL) Internal bandgap voltage Position  */
+#define AC_COMPCTRL_MUXNEG_OPAMP            (AC_COMPCTRL_MUXNEG_OPAMP_Val << AC_COMPCTRL_MUXNEG_Pos)  /**< (AC_COMPCTRL) OPAMP output (on AC1) Position  */
+#define AC_COMPCTRL_MUXNEG_DAC              (AC_COMPCTRL_MUXNEG_DAC_Val << AC_COMPCTRL_MUXNEG_Pos)  /**< (AC_COMPCTRL) DAC output (on AC0) Position  */
+#define AC_COMPCTRL_MUXPOS_Pos              12                                             /**< (AC_COMPCTRL) Positive Input Mux Selection Position */
+#define AC_COMPCTRL_MUXPOS_Msk              (_U_(0x7) << AC_COMPCTRL_MUXPOS_Pos)           /**< (AC_COMPCTRL) Positive Input Mux Selection Mask */
+#define AC_COMPCTRL_MUXPOS(value)           (AC_COMPCTRL_MUXPOS_Msk & ((value) << AC_COMPCTRL_MUXPOS_Pos))
+#define   AC_COMPCTRL_MUXPOS_PIN0_Val       _U_(0x0)                                       /**< (AC_COMPCTRL) I/O pin 0  */
+#define   AC_COMPCTRL_MUXPOS_PIN1_Val       _U_(0x1)                                       /**< (AC_COMPCTRL) I/O pin 1  */
+#define   AC_COMPCTRL_MUXPOS_PIN2_Val       _U_(0x2)                                       /**< (AC_COMPCTRL) I/O pin 2  */
+#define   AC_COMPCTRL_MUXPOS_PIN3_Val       _U_(0x3)                                       /**< (AC_COMPCTRL) I/O pin 3  */
+#define   AC_COMPCTRL_MUXPOS_VSCALE_Val     _U_(0x4)                                       /**< (AC_COMPCTRL) VDD Scaler  */
+#define AC_COMPCTRL_MUXPOS_PIN0             (AC_COMPCTRL_MUXPOS_PIN0_Val << AC_COMPCTRL_MUXPOS_Pos)  /**< (AC_COMPCTRL) I/O pin 0 Position  */
+#define AC_COMPCTRL_MUXPOS_PIN1             (AC_COMPCTRL_MUXPOS_PIN1_Val << AC_COMPCTRL_MUXPOS_Pos)  /**< (AC_COMPCTRL) I/O pin 1 Position  */
+#define AC_COMPCTRL_MUXPOS_PIN2             (AC_COMPCTRL_MUXPOS_PIN2_Val << AC_COMPCTRL_MUXPOS_Pos)  /**< (AC_COMPCTRL) I/O pin 2 Position  */
+#define AC_COMPCTRL_MUXPOS_PIN3             (AC_COMPCTRL_MUXPOS_PIN3_Val << AC_COMPCTRL_MUXPOS_Pos)  /**< (AC_COMPCTRL) I/O pin 3 Position  */
+#define AC_COMPCTRL_MUXPOS_VSCALE           (AC_COMPCTRL_MUXPOS_VSCALE_Val << AC_COMPCTRL_MUXPOS_Pos)  /**< (AC_COMPCTRL) VDD Scaler Position  */
+#define AC_COMPCTRL_SWAP_Pos                15                                             /**< (AC_COMPCTRL) Swap Inputs and Invert Position */
+#define AC_COMPCTRL_SWAP_Msk                (_U_(0x1) << AC_COMPCTRL_SWAP_Pos)             /**< (AC_COMPCTRL) Swap Inputs and Invert Mask */
+#define AC_COMPCTRL_SWAP                    AC_COMPCTRL_SWAP_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_COMPCTRL_SWAP_Msk instead */
+#define AC_COMPCTRL_SPEED_Pos               16                                             /**< (AC_COMPCTRL) Speed Selection Position */
+#define AC_COMPCTRL_SPEED_Msk               (_U_(0x3) << AC_COMPCTRL_SPEED_Pos)            /**< (AC_COMPCTRL) Speed Selection Mask */
+#define AC_COMPCTRL_SPEED(value)            (AC_COMPCTRL_SPEED_Msk & ((value) << AC_COMPCTRL_SPEED_Pos))
+#define   AC_COMPCTRL_SPEED_LOW_Val         _U_(0x0)                                       /**< (AC_COMPCTRL) Low speed  */
+#define   AC_COMPCTRL_SPEED_MEDLOW_Val      _U_(0x1)                                       /**< (AC_COMPCTRL) Medium low speed  */
+#define   AC_COMPCTRL_SPEED_MEDHIGH_Val     _U_(0x2)                                       /**< (AC_COMPCTRL) Medium high speed  */
+#define   AC_COMPCTRL_SPEED_HIGH_Val        _U_(0x3)                                       /**< (AC_COMPCTRL) High speed  */
+#define AC_COMPCTRL_SPEED_LOW               (AC_COMPCTRL_SPEED_LOW_Val << AC_COMPCTRL_SPEED_Pos)  /**< (AC_COMPCTRL) Low speed Position  */
+#define AC_COMPCTRL_SPEED_MEDLOW            (AC_COMPCTRL_SPEED_MEDLOW_Val << AC_COMPCTRL_SPEED_Pos)  /**< (AC_COMPCTRL) Medium low speed Position  */
+#define AC_COMPCTRL_SPEED_MEDHIGH           (AC_COMPCTRL_SPEED_MEDHIGH_Val << AC_COMPCTRL_SPEED_Pos)  /**< (AC_COMPCTRL) Medium high speed Position  */
+#define AC_COMPCTRL_SPEED_HIGH              (AC_COMPCTRL_SPEED_HIGH_Val << AC_COMPCTRL_SPEED_Pos)  /**< (AC_COMPCTRL) High speed Position  */
+#define AC_COMPCTRL_HYSTEN_Pos              19                                             /**< (AC_COMPCTRL) Hysteresis Enable Position */
+#define AC_COMPCTRL_HYSTEN_Msk              (_U_(0x1) << AC_COMPCTRL_HYSTEN_Pos)           /**< (AC_COMPCTRL) Hysteresis Enable Mask */
+#define AC_COMPCTRL_HYSTEN                  AC_COMPCTRL_HYSTEN_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_COMPCTRL_HYSTEN_Msk instead */
+#define AC_COMPCTRL_HYST_Pos                20                                             /**< (AC_COMPCTRL) Hysteresis Level Position */
+#define AC_COMPCTRL_HYST_Msk                (_U_(0x3) << AC_COMPCTRL_HYST_Pos)             /**< (AC_COMPCTRL) Hysteresis Level Mask */
+#define AC_COMPCTRL_HYST(value)             (AC_COMPCTRL_HYST_Msk & ((value) << AC_COMPCTRL_HYST_Pos))
+#define   AC_COMPCTRL_HYST_HYST50_Val       _U_(0x0)                                       /**< (AC_COMPCTRL) 50mV  */
+#define   AC_COMPCTRL_HYST_HYST70_Val       _U_(0x1)                                       /**< (AC_COMPCTRL) 70mV  */
+#define   AC_COMPCTRL_HYST_HYST90_Val       _U_(0x2)                                       /**< (AC_COMPCTRL) 90mV  */
+#define   AC_COMPCTRL_HYST_HYST110_Val      _U_(0x3)                                       /**< (AC_COMPCTRL) 110mV  */
+#define AC_COMPCTRL_HYST_HYST50             (AC_COMPCTRL_HYST_HYST50_Val << AC_COMPCTRL_HYST_Pos)  /**< (AC_COMPCTRL) 50mV Position  */
+#define AC_COMPCTRL_HYST_HYST70             (AC_COMPCTRL_HYST_HYST70_Val << AC_COMPCTRL_HYST_Pos)  /**< (AC_COMPCTRL) 70mV Position  */
+#define AC_COMPCTRL_HYST_HYST90             (AC_COMPCTRL_HYST_HYST90_Val << AC_COMPCTRL_HYST_Pos)  /**< (AC_COMPCTRL) 90mV Position  */
+#define AC_COMPCTRL_HYST_HYST110            (AC_COMPCTRL_HYST_HYST110_Val << AC_COMPCTRL_HYST_Pos)  /**< (AC_COMPCTRL) 110mV Position  */
+#define AC_COMPCTRL_FLEN_Pos                24                                             /**< (AC_COMPCTRL) Filter Length Position */
+#define AC_COMPCTRL_FLEN_Msk                (_U_(0x7) << AC_COMPCTRL_FLEN_Pos)             /**< (AC_COMPCTRL) Filter Length Mask */
+#define AC_COMPCTRL_FLEN(value)             (AC_COMPCTRL_FLEN_Msk & ((value) << AC_COMPCTRL_FLEN_Pos))
+#define   AC_COMPCTRL_FLEN_OFF_Val          _U_(0x0)                                       /**< (AC_COMPCTRL) No filtering  */
+#define   AC_COMPCTRL_FLEN_MAJ3_Val         _U_(0x1)                                       /**< (AC_COMPCTRL) 3-bit majority function (2 of 3)  */
+#define   AC_COMPCTRL_FLEN_MAJ5_Val         _U_(0x2)                                       /**< (AC_COMPCTRL) 5-bit majority function (3 of 5)  */
+#define AC_COMPCTRL_FLEN_OFF                (AC_COMPCTRL_FLEN_OFF_Val << AC_COMPCTRL_FLEN_Pos)  /**< (AC_COMPCTRL) No filtering Position  */
+#define AC_COMPCTRL_FLEN_MAJ3               (AC_COMPCTRL_FLEN_MAJ3_Val << AC_COMPCTRL_FLEN_Pos)  /**< (AC_COMPCTRL) 3-bit majority function (2 of 3) Position  */
+#define AC_COMPCTRL_FLEN_MAJ5               (AC_COMPCTRL_FLEN_MAJ5_Val << AC_COMPCTRL_FLEN_Pos)  /**< (AC_COMPCTRL) 5-bit majority function (3 of 5) Position  */
+#define AC_COMPCTRL_OUT_Pos                 28                                             /**< (AC_COMPCTRL) Output Position */
+#define AC_COMPCTRL_OUT_Msk                 (_U_(0x3) << AC_COMPCTRL_OUT_Pos)              /**< (AC_COMPCTRL) Output Mask */
+#define AC_COMPCTRL_OUT(value)              (AC_COMPCTRL_OUT_Msk & ((value) << AC_COMPCTRL_OUT_Pos))
+#define   AC_COMPCTRL_OUT_OFF_Val           _U_(0x0)                                       /**< (AC_COMPCTRL) The output of COMPn is not routed to the COMPn I/O port  */
+#define   AC_COMPCTRL_OUT_ASYNC_Val         _U_(0x1)                                       /**< (AC_COMPCTRL) The asynchronous output of COMPn is routed to the COMPn I/O port  */
+#define   AC_COMPCTRL_OUT_SYNC_Val          _U_(0x2)                                       /**< (AC_COMPCTRL) The synchronous output (including filtering) of COMPn is routed to the COMPn I/O port  */
+#define AC_COMPCTRL_OUT_OFF                 (AC_COMPCTRL_OUT_OFF_Val << AC_COMPCTRL_OUT_Pos)  /**< (AC_COMPCTRL) The output of COMPn is not routed to the COMPn I/O port Position  */
+#define AC_COMPCTRL_OUT_ASYNC               (AC_COMPCTRL_OUT_ASYNC_Val << AC_COMPCTRL_OUT_Pos)  /**< (AC_COMPCTRL) The asynchronous output of COMPn is routed to the COMPn I/O port Position  */
+#define AC_COMPCTRL_OUT_SYNC                (AC_COMPCTRL_OUT_SYNC_Val << AC_COMPCTRL_OUT_Pos)  /**< (AC_COMPCTRL) The synchronous output (including filtering) of COMPn is routed to the COMPn I/O port Position  */
+#define AC_COMPCTRL_MASK                    _U_(0x373BF75E)                                /**< \deprecated (AC_COMPCTRL) Register MASK  (Use AC_COMPCTRL_Msk instead)  */
+#define AC_COMPCTRL_Msk                     _U_(0x373BF75E)                                /**< (AC_COMPCTRL) Register Mask  */
+
+
+/* -------- AC_SYNCBUSY : (AC Offset: 0x20) (R/ 32) Synchronization Busy -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SWRST:1;                   /**< bit:      0  Software Reset Synchronization Busy      */
+    uint32_t ENABLE:1;                  /**< bit:      1  Enable Synchronization Busy              */
+    uint32_t WINCTRL:1;                 /**< bit:      2  WINCTRL Synchronization Busy             */
+    uint32_t COMPCTRL0:1;               /**< bit:      3  COMPCTRL 0 Synchronization Busy          */
+    uint32_t COMPCTRL1:1;               /**< bit:      4  COMPCTRL 1 Synchronization Busy          */
+    uint32_t :27;                       /**< bit:  5..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :3;                        /**< bit:   0..2  Reserved */
+    uint32_t COMPCTRL:2;                /**< bit:   3..4  COMPCTRL x Synchronization Busy          */
+    uint32_t :27;                       /**< bit:  5..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} AC_SYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_SYNCBUSY_OFFSET                  (0x20)                                        /**<  (AC_SYNCBUSY) Synchronization Busy  Offset */
+#define AC_SYNCBUSY_RESETVALUE              _U_(0x00)                                     /**<  (AC_SYNCBUSY) Synchronization Busy  Reset Value */
+
+#define AC_SYNCBUSY_SWRST_Pos               0                                              /**< (AC_SYNCBUSY) Software Reset Synchronization Busy Position */
+#define AC_SYNCBUSY_SWRST_Msk               (_U_(0x1) << AC_SYNCBUSY_SWRST_Pos)            /**< (AC_SYNCBUSY) Software Reset Synchronization Busy Mask */
+#define AC_SYNCBUSY_SWRST                   AC_SYNCBUSY_SWRST_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_SYNCBUSY_SWRST_Msk instead */
+#define AC_SYNCBUSY_ENABLE_Pos              1                                              /**< (AC_SYNCBUSY) Enable Synchronization Busy Position */
+#define AC_SYNCBUSY_ENABLE_Msk              (_U_(0x1) << AC_SYNCBUSY_ENABLE_Pos)           /**< (AC_SYNCBUSY) Enable Synchronization Busy Mask */
+#define AC_SYNCBUSY_ENABLE                  AC_SYNCBUSY_ENABLE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_SYNCBUSY_ENABLE_Msk instead */
+#define AC_SYNCBUSY_WINCTRL_Pos             2                                              /**< (AC_SYNCBUSY) WINCTRL Synchronization Busy Position */
+#define AC_SYNCBUSY_WINCTRL_Msk             (_U_(0x1) << AC_SYNCBUSY_WINCTRL_Pos)          /**< (AC_SYNCBUSY) WINCTRL Synchronization Busy Mask */
+#define AC_SYNCBUSY_WINCTRL                 AC_SYNCBUSY_WINCTRL_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_SYNCBUSY_WINCTRL_Msk instead */
+#define AC_SYNCBUSY_COMPCTRL0_Pos           3                                              /**< (AC_SYNCBUSY) COMPCTRL 0 Synchronization Busy Position */
+#define AC_SYNCBUSY_COMPCTRL0_Msk           (_U_(0x1) << AC_SYNCBUSY_COMPCTRL0_Pos)        /**< (AC_SYNCBUSY) COMPCTRL 0 Synchronization Busy Mask */
+#define AC_SYNCBUSY_COMPCTRL0               AC_SYNCBUSY_COMPCTRL0_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_SYNCBUSY_COMPCTRL0_Msk instead */
+#define AC_SYNCBUSY_COMPCTRL1_Pos           4                                              /**< (AC_SYNCBUSY) COMPCTRL 1 Synchronization Busy Position */
+#define AC_SYNCBUSY_COMPCTRL1_Msk           (_U_(0x1) << AC_SYNCBUSY_COMPCTRL1_Pos)        /**< (AC_SYNCBUSY) COMPCTRL 1 Synchronization Busy Mask */
+#define AC_SYNCBUSY_COMPCTRL1               AC_SYNCBUSY_COMPCTRL1_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_SYNCBUSY_COMPCTRL1_Msk instead */
+#define AC_SYNCBUSY_MASK                    _U_(0x1F)                                      /**< \deprecated (AC_SYNCBUSY) Register MASK  (Use AC_SYNCBUSY_Msk instead)  */
+#define AC_SYNCBUSY_Msk                     _U_(0x1F)                                      /**< (AC_SYNCBUSY) Register Mask  */
+
+#define AC_SYNCBUSY_COMPCTRL_Pos            3                                              /**< (AC_SYNCBUSY Position) COMPCTRL x Synchronization Busy */
+#define AC_SYNCBUSY_COMPCTRL_Msk            (_U_(0x3) << AC_SYNCBUSY_COMPCTRL_Pos)         /**< (AC_SYNCBUSY Mask) COMPCTRL */
+#define AC_SYNCBUSY_COMPCTRL(value)         (AC_SYNCBUSY_COMPCTRL_Msk & ((value) << AC_SYNCBUSY_COMPCTRL_Pos))  
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief AC hardware registers */
+typedef struct {  /* Analog Comparators */
+  __IO AC_CTRLA_Type                  CTRLA;          /**< Offset: 0x00 (R/W   8) Control A */
+  __O  AC_CTRLB_Type                  CTRLB;          /**< Offset: 0x01 ( /W   8) Control B */
+  __IO AC_EVCTRL_Type                 EVCTRL;         /**< Offset: 0x02 (R/W  16) Event Control */
+  __IO AC_INTENCLR_Type               INTENCLR;       /**< Offset: 0x04 (R/W   8) Interrupt Enable Clear */
+  __IO AC_INTENSET_Type               INTENSET;       /**< Offset: 0x05 (R/W   8) Interrupt Enable Set */
+  __IO AC_INTFLAG_Type                INTFLAG;        /**< Offset: 0x06 (R/W   8) Interrupt Flag Status and Clear */
+  __I  AC_STATUSA_Type                STATUSA;        /**< Offset: 0x07 (R/    8) Status A */
+  __I  AC_STATUSB_Type                STATUSB;        /**< Offset: 0x08 (R/    8) Status B */
+  __IO AC_DBGCTRL_Type                DBGCTRL;        /**< Offset: 0x09 (R/W   8) Debug Control */
+  __IO AC_WINCTRL_Type                WINCTRL;        /**< Offset: 0x0A (R/W   8) Window Control */
+  __I  uint8_t                        Reserved1[1];
+  __IO AC_SCALER_Type                 SCALER[2];      /**< Offset: 0x0C (R/W   8) Scaler n */
+  __I  uint8_t                        Reserved2[2];
+  __IO AC_COMPCTRL_Type               COMPCTRL[2];    /**< Offset: 0x10 (R/W  32) Comparator Control n */
+  __I  uint8_t                        Reserved3[8];
+  __I  AC_SYNCBUSY_Type               SYNCBUSY;       /**< Offset: 0x20 (R/   32) Synchronization Busy */
+} Ac;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Analog Comparators */
+
+#endif /* _SAML10_AC_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/component/adc.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/adc.h
@@ -1,0 +1,851 @@
+/**
+ * \file
+ *
+ * \brief Component description for ADC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_ADC_COMPONENT_H_
+#define _SAML10_ADC_COMPONENT_H_
+#define _SAML10_ADC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML10 Analog Digital Converter
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR ADC */
+/* ========================================================================== */
+
+#define ADC_U2247                      /**< (ADC) Module ID */
+#define REV_ADC 0x240                  /**< (ADC) Module revision */
+
+/* -------- ADC_CTRLA : (ADC Offset: 0x00) (R/W 8) Control A -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint8_t  ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint8_t  :3;                        /**< bit:   2..4  Reserved */
+    uint8_t  SLAVEEN:1;                 /**< bit:      5  Slave Enable                             */
+    uint8_t  RUNSTDBY:1;                /**< bit:      6  Run During Standby                       */
+    uint8_t  ONDEMAND:1;                /**< bit:      7  On Demand Control                        */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} ADC_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_CTRLA_OFFSET                    (0x00)                                        /**<  (ADC_CTRLA) Control A  Offset */
+#define ADC_CTRLA_RESETVALUE                _U_(0x00)                                     /**<  (ADC_CTRLA) Control A  Reset Value */
+
+#define ADC_CTRLA_SWRST_Pos                 0                                              /**< (ADC_CTRLA) Software Reset Position */
+#define ADC_CTRLA_SWRST_Msk                 (_U_(0x1) << ADC_CTRLA_SWRST_Pos)              /**< (ADC_CTRLA) Software Reset Mask */
+#define ADC_CTRLA_SWRST                     ADC_CTRLA_SWRST_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_CTRLA_SWRST_Msk instead */
+#define ADC_CTRLA_ENABLE_Pos                1                                              /**< (ADC_CTRLA) Enable Position */
+#define ADC_CTRLA_ENABLE_Msk                (_U_(0x1) << ADC_CTRLA_ENABLE_Pos)             /**< (ADC_CTRLA) Enable Mask */
+#define ADC_CTRLA_ENABLE                    ADC_CTRLA_ENABLE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_CTRLA_ENABLE_Msk instead */
+#define ADC_CTRLA_SLAVEEN_Pos               5                                              /**< (ADC_CTRLA) Slave Enable Position */
+#define ADC_CTRLA_SLAVEEN_Msk               (_U_(0x1) << ADC_CTRLA_SLAVEEN_Pos)            /**< (ADC_CTRLA) Slave Enable Mask */
+#define ADC_CTRLA_SLAVEEN                   ADC_CTRLA_SLAVEEN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_CTRLA_SLAVEEN_Msk instead */
+#define ADC_CTRLA_RUNSTDBY_Pos              6                                              /**< (ADC_CTRLA) Run During Standby Position */
+#define ADC_CTRLA_RUNSTDBY_Msk              (_U_(0x1) << ADC_CTRLA_RUNSTDBY_Pos)           /**< (ADC_CTRLA) Run During Standby Mask */
+#define ADC_CTRLA_RUNSTDBY                  ADC_CTRLA_RUNSTDBY_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_CTRLA_RUNSTDBY_Msk instead */
+#define ADC_CTRLA_ONDEMAND_Pos              7                                              /**< (ADC_CTRLA) On Demand Control Position */
+#define ADC_CTRLA_ONDEMAND_Msk              (_U_(0x1) << ADC_CTRLA_ONDEMAND_Pos)           /**< (ADC_CTRLA) On Demand Control Mask */
+#define ADC_CTRLA_ONDEMAND                  ADC_CTRLA_ONDEMAND_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_CTRLA_ONDEMAND_Msk instead */
+#define ADC_CTRLA_MASK                      _U_(0xE3)                                      /**< \deprecated (ADC_CTRLA) Register MASK  (Use ADC_CTRLA_Msk instead)  */
+#define ADC_CTRLA_Msk                       _U_(0xE3)                                      /**< (ADC_CTRLA) Register Mask  */
+
+
+/* -------- ADC_CTRLB : (ADC Offset: 0x01) (R/W 8) Control B -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  PRESCALER:3;               /**< bit:   0..2  Prescaler Configuration                  */
+    uint8_t  :5;                        /**< bit:   3..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} ADC_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_CTRLB_OFFSET                    (0x01)                                        /**<  (ADC_CTRLB) Control B  Offset */
+#define ADC_CTRLB_RESETVALUE                _U_(0x00)                                     /**<  (ADC_CTRLB) Control B  Reset Value */
+
+#define ADC_CTRLB_PRESCALER_Pos             0                                              /**< (ADC_CTRLB) Prescaler Configuration Position */
+#define ADC_CTRLB_PRESCALER_Msk             (_U_(0x7) << ADC_CTRLB_PRESCALER_Pos)          /**< (ADC_CTRLB) Prescaler Configuration Mask */
+#define ADC_CTRLB_PRESCALER(value)          (ADC_CTRLB_PRESCALER_Msk & ((value) << ADC_CTRLB_PRESCALER_Pos))
+#define   ADC_CTRLB_PRESCALER_DIV2_Val      _U_(0x0)                                       /**< (ADC_CTRLB) Peripheral clock divided by 2  */
+#define   ADC_CTRLB_PRESCALER_DIV4_Val      _U_(0x1)                                       /**< (ADC_CTRLB) Peripheral clock divided by 4  */
+#define   ADC_CTRLB_PRESCALER_DIV8_Val      _U_(0x2)                                       /**< (ADC_CTRLB) Peripheral clock divided by 8  */
+#define   ADC_CTRLB_PRESCALER_DIV16_Val     _U_(0x3)                                       /**< (ADC_CTRLB) Peripheral clock divided by 16  */
+#define   ADC_CTRLB_PRESCALER_DIV32_Val     _U_(0x4)                                       /**< (ADC_CTRLB) Peripheral clock divided by 32  */
+#define   ADC_CTRLB_PRESCALER_DIV64_Val     _U_(0x5)                                       /**< (ADC_CTRLB) Peripheral clock divided by 64  */
+#define   ADC_CTRLB_PRESCALER_DIV128_Val    _U_(0x6)                                       /**< (ADC_CTRLB) Peripheral clock divided by 128  */
+#define   ADC_CTRLB_PRESCALER_DIV256_Val    _U_(0x7)                                       /**< (ADC_CTRLB) Peripheral clock divided by 256  */
+#define ADC_CTRLB_PRESCALER_DIV2            (ADC_CTRLB_PRESCALER_DIV2_Val << ADC_CTRLB_PRESCALER_Pos)  /**< (ADC_CTRLB) Peripheral clock divided by 2 Position  */
+#define ADC_CTRLB_PRESCALER_DIV4            (ADC_CTRLB_PRESCALER_DIV4_Val << ADC_CTRLB_PRESCALER_Pos)  /**< (ADC_CTRLB) Peripheral clock divided by 4 Position  */
+#define ADC_CTRLB_PRESCALER_DIV8            (ADC_CTRLB_PRESCALER_DIV8_Val << ADC_CTRLB_PRESCALER_Pos)  /**< (ADC_CTRLB) Peripheral clock divided by 8 Position  */
+#define ADC_CTRLB_PRESCALER_DIV16           (ADC_CTRLB_PRESCALER_DIV16_Val << ADC_CTRLB_PRESCALER_Pos)  /**< (ADC_CTRLB) Peripheral clock divided by 16 Position  */
+#define ADC_CTRLB_PRESCALER_DIV32           (ADC_CTRLB_PRESCALER_DIV32_Val << ADC_CTRLB_PRESCALER_Pos)  /**< (ADC_CTRLB) Peripheral clock divided by 32 Position  */
+#define ADC_CTRLB_PRESCALER_DIV64           (ADC_CTRLB_PRESCALER_DIV64_Val << ADC_CTRLB_PRESCALER_Pos)  /**< (ADC_CTRLB) Peripheral clock divided by 64 Position  */
+#define ADC_CTRLB_PRESCALER_DIV128          (ADC_CTRLB_PRESCALER_DIV128_Val << ADC_CTRLB_PRESCALER_Pos)  /**< (ADC_CTRLB) Peripheral clock divided by 128 Position  */
+#define ADC_CTRLB_PRESCALER_DIV256          (ADC_CTRLB_PRESCALER_DIV256_Val << ADC_CTRLB_PRESCALER_Pos)  /**< (ADC_CTRLB) Peripheral clock divided by 256 Position  */
+#define ADC_CTRLB_MASK                      _U_(0x07)                                      /**< \deprecated (ADC_CTRLB) Register MASK  (Use ADC_CTRLB_Msk instead)  */
+#define ADC_CTRLB_Msk                       _U_(0x07)                                      /**< (ADC_CTRLB) Register Mask  */
+
+
+/* -------- ADC_REFCTRL : (ADC Offset: 0x02) (R/W 8) Reference Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  REFSEL:4;                  /**< bit:   0..3  Reference Selection                      */
+    uint8_t  :3;                        /**< bit:   4..6  Reserved */
+    uint8_t  REFCOMP:1;                 /**< bit:      7  Reference Buffer Offset Compensation Enable */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} ADC_REFCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_REFCTRL_OFFSET                  (0x02)                                        /**<  (ADC_REFCTRL) Reference Control  Offset */
+#define ADC_REFCTRL_RESETVALUE              _U_(0x00)                                     /**<  (ADC_REFCTRL) Reference Control  Reset Value */
+
+#define ADC_REFCTRL_REFSEL_Pos              0                                              /**< (ADC_REFCTRL) Reference Selection Position */
+#define ADC_REFCTRL_REFSEL_Msk              (_U_(0xF) << ADC_REFCTRL_REFSEL_Pos)           /**< (ADC_REFCTRL) Reference Selection Mask */
+#define ADC_REFCTRL_REFSEL(value)           (ADC_REFCTRL_REFSEL_Msk & ((value) << ADC_REFCTRL_REFSEL_Pos))
+#define   ADC_REFCTRL_REFSEL_INTREF_Val     _U_(0x0)                                       /**< (ADC_REFCTRL) Internal Bandgap Reference  */
+#define   ADC_REFCTRL_REFSEL_INTVCC0_Val    _U_(0x1)                                       /**< (ADC_REFCTRL) 1/1.6 VDDANA  */
+#define   ADC_REFCTRL_REFSEL_INTVCC1_Val    _U_(0x2)                                       /**< (ADC_REFCTRL) 1/2 VDDANA  */
+#define   ADC_REFCTRL_REFSEL_AREFA_Val      _U_(0x3)                                       /**< (ADC_REFCTRL) External Reference  */
+#define   ADC_REFCTRL_REFSEL_AREFB_Val      _U_(0x4)                                       /**< (ADC_REFCTRL) External Reference  */
+#define   ADC_REFCTRL_REFSEL_INTVCC2_Val    _U_(0x5)                                       /**< (ADC_REFCTRL) VCCANA  */
+#define ADC_REFCTRL_REFSEL_INTREF           (ADC_REFCTRL_REFSEL_INTREF_Val << ADC_REFCTRL_REFSEL_Pos)  /**< (ADC_REFCTRL) Internal Bandgap Reference Position  */
+#define ADC_REFCTRL_REFSEL_INTVCC0          (ADC_REFCTRL_REFSEL_INTVCC0_Val << ADC_REFCTRL_REFSEL_Pos)  /**< (ADC_REFCTRL) 1/1.6 VDDANA Position  */
+#define ADC_REFCTRL_REFSEL_INTVCC1          (ADC_REFCTRL_REFSEL_INTVCC1_Val << ADC_REFCTRL_REFSEL_Pos)  /**< (ADC_REFCTRL) 1/2 VDDANA Position  */
+#define ADC_REFCTRL_REFSEL_AREFA            (ADC_REFCTRL_REFSEL_AREFA_Val << ADC_REFCTRL_REFSEL_Pos)  /**< (ADC_REFCTRL) External Reference Position  */
+#define ADC_REFCTRL_REFSEL_AREFB            (ADC_REFCTRL_REFSEL_AREFB_Val << ADC_REFCTRL_REFSEL_Pos)  /**< (ADC_REFCTRL) External Reference Position  */
+#define ADC_REFCTRL_REFSEL_INTVCC2          (ADC_REFCTRL_REFSEL_INTVCC2_Val << ADC_REFCTRL_REFSEL_Pos)  /**< (ADC_REFCTRL) VCCANA Position  */
+#define ADC_REFCTRL_REFCOMP_Pos             7                                              /**< (ADC_REFCTRL) Reference Buffer Offset Compensation Enable Position */
+#define ADC_REFCTRL_REFCOMP_Msk             (_U_(0x1) << ADC_REFCTRL_REFCOMP_Pos)          /**< (ADC_REFCTRL) Reference Buffer Offset Compensation Enable Mask */
+#define ADC_REFCTRL_REFCOMP                 ADC_REFCTRL_REFCOMP_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_REFCTRL_REFCOMP_Msk instead */
+#define ADC_REFCTRL_MASK                    _U_(0x8F)                                      /**< \deprecated (ADC_REFCTRL) Register MASK  (Use ADC_REFCTRL_Msk instead)  */
+#define ADC_REFCTRL_Msk                     _U_(0x8F)                                      /**< (ADC_REFCTRL) Register Mask  */
+
+
+/* -------- ADC_EVCTRL : (ADC Offset: 0x03) (R/W 8) Event Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  FLUSHEI:1;                 /**< bit:      0  Flush Event Input Enable                 */
+    uint8_t  STARTEI:1;                 /**< bit:      1  Start Conversion Event Input Enable      */
+    uint8_t  FLUSHINV:1;                /**< bit:      2  Flush Event Invert Enable                */
+    uint8_t  STARTINV:1;                /**< bit:      3  Satrt Event Invert Enable                */
+    uint8_t  RESRDYEO:1;                /**< bit:      4  Result Ready Event Out                   */
+    uint8_t  WINMONEO:1;                /**< bit:      5  Window Monitor Event Out                 */
+    uint8_t  :2;                        /**< bit:   6..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} ADC_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_EVCTRL_OFFSET                   (0x03)                                        /**<  (ADC_EVCTRL) Event Control  Offset */
+#define ADC_EVCTRL_RESETVALUE               _U_(0x00)                                     /**<  (ADC_EVCTRL) Event Control  Reset Value */
+
+#define ADC_EVCTRL_FLUSHEI_Pos              0                                              /**< (ADC_EVCTRL) Flush Event Input Enable Position */
+#define ADC_EVCTRL_FLUSHEI_Msk              (_U_(0x1) << ADC_EVCTRL_FLUSHEI_Pos)           /**< (ADC_EVCTRL) Flush Event Input Enable Mask */
+#define ADC_EVCTRL_FLUSHEI                  ADC_EVCTRL_FLUSHEI_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_EVCTRL_FLUSHEI_Msk instead */
+#define ADC_EVCTRL_STARTEI_Pos              1                                              /**< (ADC_EVCTRL) Start Conversion Event Input Enable Position */
+#define ADC_EVCTRL_STARTEI_Msk              (_U_(0x1) << ADC_EVCTRL_STARTEI_Pos)           /**< (ADC_EVCTRL) Start Conversion Event Input Enable Mask */
+#define ADC_EVCTRL_STARTEI                  ADC_EVCTRL_STARTEI_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_EVCTRL_STARTEI_Msk instead */
+#define ADC_EVCTRL_FLUSHINV_Pos             2                                              /**< (ADC_EVCTRL) Flush Event Invert Enable Position */
+#define ADC_EVCTRL_FLUSHINV_Msk             (_U_(0x1) << ADC_EVCTRL_FLUSHINV_Pos)          /**< (ADC_EVCTRL) Flush Event Invert Enable Mask */
+#define ADC_EVCTRL_FLUSHINV                 ADC_EVCTRL_FLUSHINV_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_EVCTRL_FLUSHINV_Msk instead */
+#define ADC_EVCTRL_STARTINV_Pos             3                                              /**< (ADC_EVCTRL) Satrt Event Invert Enable Position */
+#define ADC_EVCTRL_STARTINV_Msk             (_U_(0x1) << ADC_EVCTRL_STARTINV_Pos)          /**< (ADC_EVCTRL) Satrt Event Invert Enable Mask */
+#define ADC_EVCTRL_STARTINV                 ADC_EVCTRL_STARTINV_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_EVCTRL_STARTINV_Msk instead */
+#define ADC_EVCTRL_RESRDYEO_Pos             4                                              /**< (ADC_EVCTRL) Result Ready Event Out Position */
+#define ADC_EVCTRL_RESRDYEO_Msk             (_U_(0x1) << ADC_EVCTRL_RESRDYEO_Pos)          /**< (ADC_EVCTRL) Result Ready Event Out Mask */
+#define ADC_EVCTRL_RESRDYEO                 ADC_EVCTRL_RESRDYEO_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_EVCTRL_RESRDYEO_Msk instead */
+#define ADC_EVCTRL_WINMONEO_Pos             5                                              /**< (ADC_EVCTRL) Window Monitor Event Out Position */
+#define ADC_EVCTRL_WINMONEO_Msk             (_U_(0x1) << ADC_EVCTRL_WINMONEO_Pos)          /**< (ADC_EVCTRL) Window Monitor Event Out Mask */
+#define ADC_EVCTRL_WINMONEO                 ADC_EVCTRL_WINMONEO_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_EVCTRL_WINMONEO_Msk instead */
+#define ADC_EVCTRL_MASK                     _U_(0x3F)                                      /**< \deprecated (ADC_EVCTRL) Register MASK  (Use ADC_EVCTRL_Msk instead)  */
+#define ADC_EVCTRL_Msk                      _U_(0x3F)                                      /**< (ADC_EVCTRL) Register Mask  */
+
+
+/* -------- ADC_INTENCLR : (ADC Offset: 0x04) (R/W 8) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  RESRDY:1;                  /**< bit:      0  Result Ready Interrupt Disable           */
+    uint8_t  OVERRUN:1;                 /**< bit:      1  Overrun Interrupt Disable                */
+    uint8_t  WINMON:1;                  /**< bit:      2  Window Monitor Interrupt Disable         */
+    uint8_t  :5;                        /**< bit:   3..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} ADC_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_INTENCLR_OFFSET                 (0x04)                                        /**<  (ADC_INTENCLR) Interrupt Enable Clear  Offset */
+#define ADC_INTENCLR_RESETVALUE             _U_(0x00)                                     /**<  (ADC_INTENCLR) Interrupt Enable Clear  Reset Value */
+
+#define ADC_INTENCLR_RESRDY_Pos             0                                              /**< (ADC_INTENCLR) Result Ready Interrupt Disable Position */
+#define ADC_INTENCLR_RESRDY_Msk             (_U_(0x1) << ADC_INTENCLR_RESRDY_Pos)          /**< (ADC_INTENCLR) Result Ready Interrupt Disable Mask */
+#define ADC_INTENCLR_RESRDY                 ADC_INTENCLR_RESRDY_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_INTENCLR_RESRDY_Msk instead */
+#define ADC_INTENCLR_OVERRUN_Pos            1                                              /**< (ADC_INTENCLR) Overrun Interrupt Disable Position */
+#define ADC_INTENCLR_OVERRUN_Msk            (_U_(0x1) << ADC_INTENCLR_OVERRUN_Pos)         /**< (ADC_INTENCLR) Overrun Interrupt Disable Mask */
+#define ADC_INTENCLR_OVERRUN                ADC_INTENCLR_OVERRUN_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_INTENCLR_OVERRUN_Msk instead */
+#define ADC_INTENCLR_WINMON_Pos             2                                              /**< (ADC_INTENCLR) Window Monitor Interrupt Disable Position */
+#define ADC_INTENCLR_WINMON_Msk             (_U_(0x1) << ADC_INTENCLR_WINMON_Pos)          /**< (ADC_INTENCLR) Window Monitor Interrupt Disable Mask */
+#define ADC_INTENCLR_WINMON                 ADC_INTENCLR_WINMON_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_INTENCLR_WINMON_Msk instead */
+#define ADC_INTENCLR_MASK                   _U_(0x07)                                      /**< \deprecated (ADC_INTENCLR) Register MASK  (Use ADC_INTENCLR_Msk instead)  */
+#define ADC_INTENCLR_Msk                    _U_(0x07)                                      /**< (ADC_INTENCLR) Register Mask  */
+
+
+/* -------- ADC_INTENSET : (ADC Offset: 0x05) (R/W 8) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  RESRDY:1;                  /**< bit:      0  Result Ready Interrupt Enable            */
+    uint8_t  OVERRUN:1;                 /**< bit:      1  Overrun Interrupt Enable                 */
+    uint8_t  WINMON:1;                  /**< bit:      2  Window Monitor Interrupt Enable          */
+    uint8_t  :5;                        /**< bit:   3..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} ADC_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_INTENSET_OFFSET                 (0x05)                                        /**<  (ADC_INTENSET) Interrupt Enable Set  Offset */
+#define ADC_INTENSET_RESETVALUE             _U_(0x00)                                     /**<  (ADC_INTENSET) Interrupt Enable Set  Reset Value */
+
+#define ADC_INTENSET_RESRDY_Pos             0                                              /**< (ADC_INTENSET) Result Ready Interrupt Enable Position */
+#define ADC_INTENSET_RESRDY_Msk             (_U_(0x1) << ADC_INTENSET_RESRDY_Pos)          /**< (ADC_INTENSET) Result Ready Interrupt Enable Mask */
+#define ADC_INTENSET_RESRDY                 ADC_INTENSET_RESRDY_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_INTENSET_RESRDY_Msk instead */
+#define ADC_INTENSET_OVERRUN_Pos            1                                              /**< (ADC_INTENSET) Overrun Interrupt Enable Position */
+#define ADC_INTENSET_OVERRUN_Msk            (_U_(0x1) << ADC_INTENSET_OVERRUN_Pos)         /**< (ADC_INTENSET) Overrun Interrupt Enable Mask */
+#define ADC_INTENSET_OVERRUN                ADC_INTENSET_OVERRUN_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_INTENSET_OVERRUN_Msk instead */
+#define ADC_INTENSET_WINMON_Pos             2                                              /**< (ADC_INTENSET) Window Monitor Interrupt Enable Position */
+#define ADC_INTENSET_WINMON_Msk             (_U_(0x1) << ADC_INTENSET_WINMON_Pos)          /**< (ADC_INTENSET) Window Monitor Interrupt Enable Mask */
+#define ADC_INTENSET_WINMON                 ADC_INTENSET_WINMON_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_INTENSET_WINMON_Msk instead */
+#define ADC_INTENSET_MASK                   _U_(0x07)                                      /**< \deprecated (ADC_INTENSET) Register MASK  (Use ADC_INTENSET_Msk instead)  */
+#define ADC_INTENSET_Msk                    _U_(0x07)                                      /**< (ADC_INTENSET) Register Mask  */
+
+
+/* -------- ADC_INTFLAG : (ADC Offset: 0x06) (R/W 8) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t RESRDY:1;                  /**< bit:      0  Result Ready Interrupt Flag              */
+    __I uint8_t OVERRUN:1;                 /**< bit:      1  Overrun Interrupt Flag                   */
+    __I uint8_t WINMON:1;                  /**< bit:      2  Window Monitor Interrupt Flag            */
+    __I uint8_t :5;                        /**< bit:   3..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} ADC_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_INTFLAG_OFFSET                  (0x06)                                        /**<  (ADC_INTFLAG) Interrupt Flag Status and Clear  Offset */
+#define ADC_INTFLAG_RESETVALUE              _U_(0x00)                                     /**<  (ADC_INTFLAG) Interrupt Flag Status and Clear  Reset Value */
+
+#define ADC_INTFLAG_RESRDY_Pos              0                                              /**< (ADC_INTFLAG) Result Ready Interrupt Flag Position */
+#define ADC_INTFLAG_RESRDY_Msk              (_U_(0x1) << ADC_INTFLAG_RESRDY_Pos)           /**< (ADC_INTFLAG) Result Ready Interrupt Flag Mask */
+#define ADC_INTFLAG_RESRDY                  ADC_INTFLAG_RESRDY_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_INTFLAG_RESRDY_Msk instead */
+#define ADC_INTFLAG_OVERRUN_Pos             1                                              /**< (ADC_INTFLAG) Overrun Interrupt Flag Position */
+#define ADC_INTFLAG_OVERRUN_Msk             (_U_(0x1) << ADC_INTFLAG_OVERRUN_Pos)          /**< (ADC_INTFLAG) Overrun Interrupt Flag Mask */
+#define ADC_INTFLAG_OVERRUN                 ADC_INTFLAG_OVERRUN_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_INTFLAG_OVERRUN_Msk instead */
+#define ADC_INTFLAG_WINMON_Pos              2                                              /**< (ADC_INTFLAG) Window Monitor Interrupt Flag Position */
+#define ADC_INTFLAG_WINMON_Msk              (_U_(0x1) << ADC_INTFLAG_WINMON_Pos)           /**< (ADC_INTFLAG) Window Monitor Interrupt Flag Mask */
+#define ADC_INTFLAG_WINMON                  ADC_INTFLAG_WINMON_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_INTFLAG_WINMON_Msk instead */
+#define ADC_INTFLAG_MASK                    _U_(0x07)                                      /**< \deprecated (ADC_INTFLAG) Register MASK  (Use ADC_INTFLAG_Msk instead)  */
+#define ADC_INTFLAG_Msk                     _U_(0x07)                                      /**< (ADC_INTFLAG) Register Mask  */
+
+
+/* -------- ADC_SEQSTATUS : (ADC Offset: 0x07) (R/ 8) Sequence Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  SEQSTATE:5;                /**< bit:   0..4  Sequence State                           */
+    uint8_t  :2;                        /**< bit:   5..6  Reserved */
+    uint8_t  SEQBUSY:1;                 /**< bit:      7  Sequence Busy                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} ADC_SEQSTATUS_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_SEQSTATUS_OFFSET                (0x07)                                        /**<  (ADC_SEQSTATUS) Sequence Status  Offset */
+#define ADC_SEQSTATUS_RESETVALUE            _U_(0x00)                                     /**<  (ADC_SEQSTATUS) Sequence Status  Reset Value */
+
+#define ADC_SEQSTATUS_SEQSTATE_Pos          0                                              /**< (ADC_SEQSTATUS) Sequence State Position */
+#define ADC_SEQSTATUS_SEQSTATE_Msk          (_U_(0x1F) << ADC_SEQSTATUS_SEQSTATE_Pos)      /**< (ADC_SEQSTATUS) Sequence State Mask */
+#define ADC_SEQSTATUS_SEQSTATE(value)       (ADC_SEQSTATUS_SEQSTATE_Msk & ((value) << ADC_SEQSTATUS_SEQSTATE_Pos))
+#define ADC_SEQSTATUS_SEQBUSY_Pos           7                                              /**< (ADC_SEQSTATUS) Sequence Busy Position */
+#define ADC_SEQSTATUS_SEQBUSY_Msk           (_U_(0x1) << ADC_SEQSTATUS_SEQBUSY_Pos)        /**< (ADC_SEQSTATUS) Sequence Busy Mask */
+#define ADC_SEQSTATUS_SEQBUSY               ADC_SEQSTATUS_SEQBUSY_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_SEQSTATUS_SEQBUSY_Msk instead */
+#define ADC_SEQSTATUS_MASK                  _U_(0x9F)                                      /**< \deprecated (ADC_SEQSTATUS) Register MASK  (Use ADC_SEQSTATUS_Msk instead)  */
+#define ADC_SEQSTATUS_Msk                   _U_(0x9F)                                      /**< (ADC_SEQSTATUS) Register Mask  */
+
+
+/* -------- ADC_INPUTCTRL : (ADC Offset: 0x08) (R/W 16) Input Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t MUXPOS:5;                  /**< bit:   0..4  Positive Mux Input Selection             */
+    uint16_t :3;                        /**< bit:   5..7  Reserved */
+    uint16_t MUXNEG:5;                  /**< bit:  8..12  Negative Mux Input Selection             */
+    uint16_t :3;                        /**< bit: 13..15  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} ADC_INPUTCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_INPUTCTRL_OFFSET                (0x08)                                        /**<  (ADC_INPUTCTRL) Input Control  Offset */
+#define ADC_INPUTCTRL_RESETVALUE            _U_(0x00)                                     /**<  (ADC_INPUTCTRL) Input Control  Reset Value */
+
+#define ADC_INPUTCTRL_MUXPOS_Pos            0                                              /**< (ADC_INPUTCTRL) Positive Mux Input Selection Position */
+#define ADC_INPUTCTRL_MUXPOS_Msk            (_U_(0x1F) << ADC_INPUTCTRL_MUXPOS_Pos)        /**< (ADC_INPUTCTRL) Positive Mux Input Selection Mask */
+#define ADC_INPUTCTRL_MUXPOS(value)         (ADC_INPUTCTRL_MUXPOS_Msk & ((value) << ADC_INPUTCTRL_MUXPOS_Pos))
+#define   ADC_INPUTCTRL_MUXPOS_AIN0_Val     _U_(0x0)                                       /**< (ADC_INPUTCTRL) ADC AIN0 Pin  */
+#define   ADC_INPUTCTRL_MUXPOS_AIN1_Val     _U_(0x1)                                       /**< (ADC_INPUTCTRL) ADC AIN1 Pin  */
+#define   ADC_INPUTCTRL_MUXPOS_AIN2_Val     _U_(0x2)                                       /**< (ADC_INPUTCTRL) ADC AIN2 Pin  */
+#define   ADC_INPUTCTRL_MUXPOS_AIN3_Val     _U_(0x3)                                       /**< (ADC_INPUTCTRL) ADC AIN3 Pin  */
+#define   ADC_INPUTCTRL_MUXPOS_AIN4_Val     _U_(0x4)                                       /**< (ADC_INPUTCTRL) ADC AIN4 Pin  */
+#define   ADC_INPUTCTRL_MUXPOS_AIN5_Val     _U_(0x5)                                       /**< (ADC_INPUTCTRL) ADC AIN5 Pin  */
+#define   ADC_INPUTCTRL_MUXPOS_AIN6_Val     _U_(0x6)                                       /**< (ADC_INPUTCTRL) ADC AIN6 Pin  */
+#define   ADC_INPUTCTRL_MUXPOS_AIN7_Val     _U_(0x7)                                       /**< (ADC_INPUTCTRL) ADC AIN7 Pin  */
+#define   ADC_INPUTCTRL_MUXPOS_AIN8_Val     _U_(0x8)                                       /**< (ADC_INPUTCTRL) ADC AIN8 Pin  */
+#define   ADC_INPUTCTRL_MUXPOS_AIN9_Val     _U_(0x9)                                       /**< (ADC_INPUTCTRL) ADC AIN9 Pin  */
+#define   ADC_INPUTCTRL_MUXPOS_AIN10_Val    _U_(0xA)                                       /**< (ADC_INPUTCTRL) ADC AIN10 Pin  */
+#define   ADC_INPUTCTRL_MUXPOS_AIN11_Val    _U_(0xB)                                       /**< (ADC_INPUTCTRL) ADC AIN11 Pin  */
+#define   ADC_INPUTCTRL_MUXPOS_AIN12_Val    _U_(0xC)                                       /**< (ADC_INPUTCTRL) ADC AIN12 Pin  */
+#define   ADC_INPUTCTRL_MUXPOS_AIN13_Val    _U_(0xD)                                       /**< (ADC_INPUTCTRL) ADC AIN13 Pin  */
+#define   ADC_INPUTCTRL_MUXPOS_AIN14_Val    _U_(0xE)                                       /**< (ADC_INPUTCTRL) ADC AIN14 Pin  */
+#define   ADC_INPUTCTRL_MUXPOS_AIN15_Val    _U_(0xF)                                       /**< (ADC_INPUTCTRL) ADC AIN15 Pin  */
+#define   ADC_INPUTCTRL_MUXPOS_AIN16_Val    _U_(0x10)                                      /**< (ADC_INPUTCTRL) ADC AIN16 Pin  */
+#define   ADC_INPUTCTRL_MUXPOS_AIN17_Val    _U_(0x11)                                      /**< (ADC_INPUTCTRL) ADC AIN17 Pin  */
+#define   ADC_INPUTCTRL_MUXPOS_AIN18_Val    _U_(0x12)                                      /**< (ADC_INPUTCTRL) ADC AIN18 Pin  */
+#define   ADC_INPUTCTRL_MUXPOS_AIN19_Val    _U_(0x13)                                      /**< (ADC_INPUTCTRL) ADC AIN19 Pin  */
+#define   ADC_INPUTCTRL_MUXPOS_AIN20_Val    _U_(0x14)                                      /**< (ADC_INPUTCTRL) ADC AIN20 Pin  */
+#define   ADC_INPUTCTRL_MUXPOS_AIN21_Val    _U_(0x15)                                      /**< (ADC_INPUTCTRL) ADC AIN21 Pin  */
+#define   ADC_INPUTCTRL_MUXPOS_AIN22_Val    _U_(0x16)                                      /**< (ADC_INPUTCTRL) ADC AIN22 Pin  */
+#define   ADC_INPUTCTRL_MUXPOS_AIN23_Val    _U_(0x17)                                      /**< (ADC_INPUTCTRL) ADC AIN23 Pin  */
+#define   ADC_INPUTCTRL_MUXPOS_TEMP_Val     _U_(0x18)                                      /**< (ADC_INPUTCTRL) Temperature Sensor  */
+#define   ADC_INPUTCTRL_MUXPOS_BANDGAP_Val  _U_(0x19)                                      /**< (ADC_INPUTCTRL) Bandgap Voltage  */
+#define   ADC_INPUTCTRL_MUXPOS_SCALEDCOREVCC_Val _U_(0x1A)                                      /**< (ADC_INPUTCTRL) 1/4 Scaled Core Supply  */
+#define   ADC_INPUTCTRL_MUXPOS_SCALEDIOVCC_Val _U_(0x1B)                                      /**< (ADC_INPUTCTRL) 1/4 Scaled I/O Supply  */
+#define   ADC_INPUTCTRL_MUXPOS_DAC_Val      _U_(0x1C)                                      /**< (ADC_INPUTCTRL) DAC Output  */
+#define   ADC_INPUTCTRL_MUXPOS_SCALEDVBAT_Val _U_(0x1D)                                      /**< (ADC_INPUTCTRL) 1/4 Scaled VBAT Supply  */
+#define   ADC_INPUTCTRL_MUXPOS_OPAMP01_Val  _U_(0x1E)                                      /**< (ADC_INPUTCTRL) OPAMP0 or OPAMP1 output  */
+#define   ADC_INPUTCTRL_MUXPOS_OPAMP2_Val   _U_(0x1F)                                      /**< (ADC_INPUTCTRL) OPAMP2 output  */
+#define ADC_INPUTCTRL_MUXPOS_AIN0           (ADC_INPUTCTRL_MUXPOS_AIN0_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) ADC AIN0 Pin Position  */
+#define ADC_INPUTCTRL_MUXPOS_AIN1           (ADC_INPUTCTRL_MUXPOS_AIN1_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) ADC AIN1 Pin Position  */
+#define ADC_INPUTCTRL_MUXPOS_AIN2           (ADC_INPUTCTRL_MUXPOS_AIN2_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) ADC AIN2 Pin Position  */
+#define ADC_INPUTCTRL_MUXPOS_AIN3           (ADC_INPUTCTRL_MUXPOS_AIN3_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) ADC AIN3 Pin Position  */
+#define ADC_INPUTCTRL_MUXPOS_AIN4           (ADC_INPUTCTRL_MUXPOS_AIN4_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) ADC AIN4 Pin Position  */
+#define ADC_INPUTCTRL_MUXPOS_AIN5           (ADC_INPUTCTRL_MUXPOS_AIN5_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) ADC AIN5 Pin Position  */
+#define ADC_INPUTCTRL_MUXPOS_AIN6           (ADC_INPUTCTRL_MUXPOS_AIN6_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) ADC AIN6 Pin Position  */
+#define ADC_INPUTCTRL_MUXPOS_AIN7           (ADC_INPUTCTRL_MUXPOS_AIN7_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) ADC AIN7 Pin Position  */
+#define ADC_INPUTCTRL_MUXPOS_AIN8           (ADC_INPUTCTRL_MUXPOS_AIN8_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) ADC AIN8 Pin Position  */
+#define ADC_INPUTCTRL_MUXPOS_AIN9           (ADC_INPUTCTRL_MUXPOS_AIN9_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) ADC AIN9 Pin Position  */
+#define ADC_INPUTCTRL_MUXPOS_AIN10          (ADC_INPUTCTRL_MUXPOS_AIN10_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) ADC AIN10 Pin Position  */
+#define ADC_INPUTCTRL_MUXPOS_AIN11          (ADC_INPUTCTRL_MUXPOS_AIN11_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) ADC AIN11 Pin Position  */
+#define ADC_INPUTCTRL_MUXPOS_AIN12          (ADC_INPUTCTRL_MUXPOS_AIN12_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) ADC AIN12 Pin Position  */
+#define ADC_INPUTCTRL_MUXPOS_AIN13          (ADC_INPUTCTRL_MUXPOS_AIN13_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) ADC AIN13 Pin Position  */
+#define ADC_INPUTCTRL_MUXPOS_AIN14          (ADC_INPUTCTRL_MUXPOS_AIN14_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) ADC AIN14 Pin Position  */
+#define ADC_INPUTCTRL_MUXPOS_AIN15          (ADC_INPUTCTRL_MUXPOS_AIN15_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) ADC AIN15 Pin Position  */
+#define ADC_INPUTCTRL_MUXPOS_AIN16          (ADC_INPUTCTRL_MUXPOS_AIN16_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) ADC AIN16 Pin Position  */
+#define ADC_INPUTCTRL_MUXPOS_AIN17          (ADC_INPUTCTRL_MUXPOS_AIN17_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) ADC AIN17 Pin Position  */
+#define ADC_INPUTCTRL_MUXPOS_AIN18          (ADC_INPUTCTRL_MUXPOS_AIN18_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) ADC AIN18 Pin Position  */
+#define ADC_INPUTCTRL_MUXPOS_AIN19          (ADC_INPUTCTRL_MUXPOS_AIN19_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) ADC AIN19 Pin Position  */
+#define ADC_INPUTCTRL_MUXPOS_AIN20          (ADC_INPUTCTRL_MUXPOS_AIN20_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) ADC AIN20 Pin Position  */
+#define ADC_INPUTCTRL_MUXPOS_AIN21          (ADC_INPUTCTRL_MUXPOS_AIN21_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) ADC AIN21 Pin Position  */
+#define ADC_INPUTCTRL_MUXPOS_AIN22          (ADC_INPUTCTRL_MUXPOS_AIN22_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) ADC AIN22 Pin Position  */
+#define ADC_INPUTCTRL_MUXPOS_AIN23          (ADC_INPUTCTRL_MUXPOS_AIN23_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) ADC AIN23 Pin Position  */
+#define ADC_INPUTCTRL_MUXPOS_TEMP           (ADC_INPUTCTRL_MUXPOS_TEMP_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) Temperature Sensor Position  */
+#define ADC_INPUTCTRL_MUXPOS_BANDGAP        (ADC_INPUTCTRL_MUXPOS_BANDGAP_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) Bandgap Voltage Position  */
+#define ADC_INPUTCTRL_MUXPOS_SCALEDCOREVCC  (ADC_INPUTCTRL_MUXPOS_SCALEDCOREVCC_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) 1/4 Scaled Core Supply Position  */
+#define ADC_INPUTCTRL_MUXPOS_SCALEDIOVCC    (ADC_INPUTCTRL_MUXPOS_SCALEDIOVCC_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) 1/4 Scaled I/O Supply Position  */
+#define ADC_INPUTCTRL_MUXPOS_DAC            (ADC_INPUTCTRL_MUXPOS_DAC_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) DAC Output Position  */
+#define ADC_INPUTCTRL_MUXPOS_SCALEDVBAT     (ADC_INPUTCTRL_MUXPOS_SCALEDVBAT_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) 1/4 Scaled VBAT Supply Position  */
+#define ADC_INPUTCTRL_MUXPOS_OPAMP01        (ADC_INPUTCTRL_MUXPOS_OPAMP01_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) OPAMP0 or OPAMP1 output Position  */
+#define ADC_INPUTCTRL_MUXPOS_OPAMP2         (ADC_INPUTCTRL_MUXPOS_OPAMP2_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) OPAMP2 output Position  */
+#define ADC_INPUTCTRL_MUXNEG_Pos            8                                              /**< (ADC_INPUTCTRL) Negative Mux Input Selection Position */
+#define ADC_INPUTCTRL_MUXNEG_Msk            (_U_(0x1F) << ADC_INPUTCTRL_MUXNEG_Pos)        /**< (ADC_INPUTCTRL) Negative Mux Input Selection Mask */
+#define ADC_INPUTCTRL_MUXNEG(value)         (ADC_INPUTCTRL_MUXNEG_Msk & ((value) << ADC_INPUTCTRL_MUXNEG_Pos))
+#define   ADC_INPUTCTRL_MUXNEG_AIN0_Val     _U_(0x0)                                       /**< (ADC_INPUTCTRL) ADC AIN0 Pin  */
+#define   ADC_INPUTCTRL_MUXNEG_AIN1_Val     _U_(0x1)                                       /**< (ADC_INPUTCTRL) ADC AIN1 Pin  */
+#define   ADC_INPUTCTRL_MUXNEG_AIN2_Val     _U_(0x2)                                       /**< (ADC_INPUTCTRL) ADC AIN2 Pin  */
+#define   ADC_INPUTCTRL_MUXNEG_AIN3_Val     _U_(0x3)                                       /**< (ADC_INPUTCTRL) ADC AIN3 Pin  */
+#define   ADC_INPUTCTRL_MUXNEG_AIN4_Val     _U_(0x4)                                       /**< (ADC_INPUTCTRL) ADC AIN4 Pin  */
+#define   ADC_INPUTCTRL_MUXNEG_AIN5_Val     _U_(0x5)                                       /**< (ADC_INPUTCTRL) ADC AIN5 Pin  */
+#define   ADC_INPUTCTRL_MUXNEG_AIN6_Val     _U_(0x6)                                       /**< (ADC_INPUTCTRL) ADC AIN6 Pin  */
+#define   ADC_INPUTCTRL_MUXNEG_AIN7_Val     _U_(0x7)                                       /**< (ADC_INPUTCTRL) ADC AIN7 Pin  */
+#define ADC_INPUTCTRL_MUXNEG_AIN0           (ADC_INPUTCTRL_MUXNEG_AIN0_Val << ADC_INPUTCTRL_MUXNEG_Pos)  /**< (ADC_INPUTCTRL) ADC AIN0 Pin Position  */
+#define ADC_INPUTCTRL_MUXNEG_AIN1           (ADC_INPUTCTRL_MUXNEG_AIN1_Val << ADC_INPUTCTRL_MUXNEG_Pos)  /**< (ADC_INPUTCTRL) ADC AIN1 Pin Position  */
+#define ADC_INPUTCTRL_MUXNEG_AIN2           (ADC_INPUTCTRL_MUXNEG_AIN2_Val << ADC_INPUTCTRL_MUXNEG_Pos)  /**< (ADC_INPUTCTRL) ADC AIN2 Pin Position  */
+#define ADC_INPUTCTRL_MUXNEG_AIN3           (ADC_INPUTCTRL_MUXNEG_AIN3_Val << ADC_INPUTCTRL_MUXNEG_Pos)  /**< (ADC_INPUTCTRL) ADC AIN3 Pin Position  */
+#define ADC_INPUTCTRL_MUXNEG_AIN4           (ADC_INPUTCTRL_MUXNEG_AIN4_Val << ADC_INPUTCTRL_MUXNEG_Pos)  /**< (ADC_INPUTCTRL) ADC AIN4 Pin Position  */
+#define ADC_INPUTCTRL_MUXNEG_AIN5           (ADC_INPUTCTRL_MUXNEG_AIN5_Val << ADC_INPUTCTRL_MUXNEG_Pos)  /**< (ADC_INPUTCTRL) ADC AIN5 Pin Position  */
+#define ADC_INPUTCTRL_MUXNEG_AIN6           (ADC_INPUTCTRL_MUXNEG_AIN6_Val << ADC_INPUTCTRL_MUXNEG_Pos)  /**< (ADC_INPUTCTRL) ADC AIN6 Pin Position  */
+#define ADC_INPUTCTRL_MUXNEG_AIN7           (ADC_INPUTCTRL_MUXNEG_AIN7_Val << ADC_INPUTCTRL_MUXNEG_Pos)  /**< (ADC_INPUTCTRL) ADC AIN7 Pin Position  */
+#define ADC_INPUTCTRL_MASK                  _U_(0x1F1F)                                    /**< \deprecated (ADC_INPUTCTRL) Register MASK  (Use ADC_INPUTCTRL_Msk instead)  */
+#define ADC_INPUTCTRL_Msk                   _U_(0x1F1F)                                    /**< (ADC_INPUTCTRL) Register Mask  */
+
+
+/* -------- ADC_CTRLC : (ADC Offset: 0x0a) (R/W 16) Control C -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t DIFFMODE:1;                /**< bit:      0  Differential Mode                        */
+    uint16_t LEFTADJ:1;                 /**< bit:      1  Left-Adjusted Result                     */
+    uint16_t FREERUN:1;                 /**< bit:      2  Free Running Mode                        */
+    uint16_t CORREN:1;                  /**< bit:      3  Digital Correction Logic Enable          */
+    uint16_t RESSEL:2;                  /**< bit:   4..5  Conversion Result Resolution             */
+    uint16_t :1;                        /**< bit:      6  Reserved */
+    uint16_t R2R:1;                     /**< bit:      7  Rail-to-Rail mode enable                 */
+    uint16_t WINMODE:3;                 /**< bit:  8..10  Window Monitor Mode                      */
+    uint16_t :1;                        /**< bit:     11  Reserved */
+    uint16_t DUALSEL:2;                 /**< bit: 12..13  Dual Mode Trigger Selection              */
+    uint16_t :2;                        /**< bit: 14..15  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} ADC_CTRLC_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_CTRLC_OFFSET                    (0x0A)                                        /**<  (ADC_CTRLC) Control C  Offset */
+#define ADC_CTRLC_RESETVALUE                _U_(0x00)                                     /**<  (ADC_CTRLC) Control C  Reset Value */
+
+#define ADC_CTRLC_DIFFMODE_Pos              0                                              /**< (ADC_CTRLC) Differential Mode Position */
+#define ADC_CTRLC_DIFFMODE_Msk              (_U_(0x1) << ADC_CTRLC_DIFFMODE_Pos)           /**< (ADC_CTRLC) Differential Mode Mask */
+#define ADC_CTRLC_DIFFMODE                  ADC_CTRLC_DIFFMODE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_CTRLC_DIFFMODE_Msk instead */
+#define ADC_CTRLC_LEFTADJ_Pos               1                                              /**< (ADC_CTRLC) Left-Adjusted Result Position */
+#define ADC_CTRLC_LEFTADJ_Msk               (_U_(0x1) << ADC_CTRLC_LEFTADJ_Pos)            /**< (ADC_CTRLC) Left-Adjusted Result Mask */
+#define ADC_CTRLC_LEFTADJ                   ADC_CTRLC_LEFTADJ_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_CTRLC_LEFTADJ_Msk instead */
+#define ADC_CTRLC_FREERUN_Pos               2                                              /**< (ADC_CTRLC) Free Running Mode Position */
+#define ADC_CTRLC_FREERUN_Msk               (_U_(0x1) << ADC_CTRLC_FREERUN_Pos)            /**< (ADC_CTRLC) Free Running Mode Mask */
+#define ADC_CTRLC_FREERUN                   ADC_CTRLC_FREERUN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_CTRLC_FREERUN_Msk instead */
+#define ADC_CTRLC_CORREN_Pos                3                                              /**< (ADC_CTRLC) Digital Correction Logic Enable Position */
+#define ADC_CTRLC_CORREN_Msk                (_U_(0x1) << ADC_CTRLC_CORREN_Pos)             /**< (ADC_CTRLC) Digital Correction Logic Enable Mask */
+#define ADC_CTRLC_CORREN                    ADC_CTRLC_CORREN_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_CTRLC_CORREN_Msk instead */
+#define ADC_CTRLC_RESSEL_Pos                4                                              /**< (ADC_CTRLC) Conversion Result Resolution Position */
+#define ADC_CTRLC_RESSEL_Msk                (_U_(0x3) << ADC_CTRLC_RESSEL_Pos)             /**< (ADC_CTRLC) Conversion Result Resolution Mask */
+#define ADC_CTRLC_RESSEL(value)             (ADC_CTRLC_RESSEL_Msk & ((value) << ADC_CTRLC_RESSEL_Pos))
+#define   ADC_CTRLC_RESSEL_12BIT_Val        _U_(0x0)                                       /**< (ADC_CTRLC) 12-bit result  */
+#define   ADC_CTRLC_RESSEL_16BIT_Val        _U_(0x1)                                       /**< (ADC_CTRLC) For averaging mode output  */
+#define   ADC_CTRLC_RESSEL_10BIT_Val        _U_(0x2)                                       /**< (ADC_CTRLC) 10-bit result  */
+#define   ADC_CTRLC_RESSEL_8BIT_Val         _U_(0x3)                                       /**< (ADC_CTRLC) 8-bit result  */
+#define ADC_CTRLC_RESSEL_12BIT              (ADC_CTRLC_RESSEL_12BIT_Val << ADC_CTRLC_RESSEL_Pos)  /**< (ADC_CTRLC) 12-bit result Position  */
+#define ADC_CTRLC_RESSEL_16BIT              (ADC_CTRLC_RESSEL_16BIT_Val << ADC_CTRLC_RESSEL_Pos)  /**< (ADC_CTRLC) For averaging mode output Position  */
+#define ADC_CTRLC_RESSEL_10BIT              (ADC_CTRLC_RESSEL_10BIT_Val << ADC_CTRLC_RESSEL_Pos)  /**< (ADC_CTRLC) 10-bit result Position  */
+#define ADC_CTRLC_RESSEL_8BIT               (ADC_CTRLC_RESSEL_8BIT_Val << ADC_CTRLC_RESSEL_Pos)  /**< (ADC_CTRLC) 8-bit result Position  */
+#define ADC_CTRLC_R2R_Pos                   7                                              /**< (ADC_CTRLC) Rail-to-Rail mode enable Position */
+#define ADC_CTRLC_R2R_Msk                   (_U_(0x1) << ADC_CTRLC_R2R_Pos)                /**< (ADC_CTRLC) Rail-to-Rail mode enable Mask */
+#define ADC_CTRLC_R2R                       ADC_CTRLC_R2R_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_CTRLC_R2R_Msk instead */
+#define ADC_CTRLC_WINMODE_Pos               8                                              /**< (ADC_CTRLC) Window Monitor Mode Position */
+#define ADC_CTRLC_WINMODE_Msk               (_U_(0x7) << ADC_CTRLC_WINMODE_Pos)            /**< (ADC_CTRLC) Window Monitor Mode Mask */
+#define ADC_CTRLC_WINMODE(value)            (ADC_CTRLC_WINMODE_Msk & ((value) << ADC_CTRLC_WINMODE_Pos))
+#define   ADC_CTRLC_WINMODE_DISABLE_Val     _U_(0x0)                                       /**< (ADC_CTRLC) No window mode (default)  */
+#define   ADC_CTRLC_WINMODE_MODE1_Val       _U_(0x1)                                       /**< (ADC_CTRLC) RESULT > WINLT  */
+#define   ADC_CTRLC_WINMODE_MODE2_Val       _U_(0x2)                                       /**< (ADC_CTRLC) RESULT < WINUT  */
+#define   ADC_CTRLC_WINMODE_MODE3_Val       _U_(0x3)                                       /**< (ADC_CTRLC) WINLT < RESULT < WINUT  */
+#define   ADC_CTRLC_WINMODE_MODE4_Val       _U_(0x4)                                       /**< (ADC_CTRLC) !(WINLT < RESULT < WINUT)  */
+#define ADC_CTRLC_WINMODE_DISABLE           (ADC_CTRLC_WINMODE_DISABLE_Val << ADC_CTRLC_WINMODE_Pos)  /**< (ADC_CTRLC) No window mode (default) Position  */
+#define ADC_CTRLC_WINMODE_MODE1             (ADC_CTRLC_WINMODE_MODE1_Val << ADC_CTRLC_WINMODE_Pos)  /**< (ADC_CTRLC) RESULT > WINLT Position  */
+#define ADC_CTRLC_WINMODE_MODE2             (ADC_CTRLC_WINMODE_MODE2_Val << ADC_CTRLC_WINMODE_Pos)  /**< (ADC_CTRLC) RESULT < WINUT Position  */
+#define ADC_CTRLC_WINMODE_MODE3             (ADC_CTRLC_WINMODE_MODE3_Val << ADC_CTRLC_WINMODE_Pos)  /**< (ADC_CTRLC) WINLT < RESULT < WINUT Position  */
+#define ADC_CTRLC_WINMODE_MODE4             (ADC_CTRLC_WINMODE_MODE4_Val << ADC_CTRLC_WINMODE_Pos)  /**< (ADC_CTRLC) !(WINLT < RESULT < WINUT) Position  */
+#define ADC_CTRLC_DUALSEL_Pos               12                                             /**< (ADC_CTRLC) Dual Mode Trigger Selection Position */
+#define ADC_CTRLC_DUALSEL_Msk               (_U_(0x3) << ADC_CTRLC_DUALSEL_Pos)            /**< (ADC_CTRLC) Dual Mode Trigger Selection Mask */
+#define ADC_CTRLC_DUALSEL(value)            (ADC_CTRLC_DUALSEL_Msk & ((value) << ADC_CTRLC_DUALSEL_Pos))
+#define   ADC_CTRLC_DUALSEL_BOTH_Val        _U_(0x0)                                       /**< (ADC_CTRLC) Start event or software trigger will start a conversion on both ADCs  */
+#define   ADC_CTRLC_DUALSEL_INTERLEAVE_Val  _U_(0x1)                                       /**< (ADC_CTRLC) START event or software trigger will alternatingly start a conversion on ADC0 and ADC1  */
+#define ADC_CTRLC_DUALSEL_BOTH              (ADC_CTRLC_DUALSEL_BOTH_Val << ADC_CTRLC_DUALSEL_Pos)  /**< (ADC_CTRLC) Start event or software trigger will start a conversion on both ADCs Position  */
+#define ADC_CTRLC_DUALSEL_INTERLEAVE        (ADC_CTRLC_DUALSEL_INTERLEAVE_Val << ADC_CTRLC_DUALSEL_Pos)  /**< (ADC_CTRLC) START event or software trigger will alternatingly start a conversion on ADC0 and ADC1 Position  */
+#define ADC_CTRLC_MASK                      _U_(0x37BF)                                    /**< \deprecated (ADC_CTRLC) Register MASK  (Use ADC_CTRLC_Msk instead)  */
+#define ADC_CTRLC_Msk                       _U_(0x37BF)                                    /**< (ADC_CTRLC) Register Mask  */
+
+
+/* -------- ADC_AVGCTRL : (ADC Offset: 0x0c) (R/W 8) Average Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  SAMPLENUM:4;               /**< bit:   0..3  Number of Samples to be Collected        */
+    uint8_t  ADJRES:3;                  /**< bit:   4..6  Adjusting Result / Division Coefficient  */
+    uint8_t  :1;                        /**< bit:      7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} ADC_AVGCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_AVGCTRL_OFFSET                  (0x0C)                                        /**<  (ADC_AVGCTRL) Average Control  Offset */
+#define ADC_AVGCTRL_RESETVALUE              _U_(0x00)                                     /**<  (ADC_AVGCTRL) Average Control  Reset Value */
+
+#define ADC_AVGCTRL_SAMPLENUM_Pos           0                                              /**< (ADC_AVGCTRL) Number of Samples to be Collected Position */
+#define ADC_AVGCTRL_SAMPLENUM_Msk           (_U_(0xF) << ADC_AVGCTRL_SAMPLENUM_Pos)        /**< (ADC_AVGCTRL) Number of Samples to be Collected Mask */
+#define ADC_AVGCTRL_SAMPLENUM(value)        (ADC_AVGCTRL_SAMPLENUM_Msk & ((value) << ADC_AVGCTRL_SAMPLENUM_Pos))
+#define   ADC_AVGCTRL_SAMPLENUM_1_Val       _U_(0x0)                                       /**< (ADC_AVGCTRL) 1 sample  */
+#define   ADC_AVGCTRL_SAMPLENUM_2_Val       _U_(0x1)                                       /**< (ADC_AVGCTRL) 2 samples  */
+#define   ADC_AVGCTRL_SAMPLENUM_4_Val       _U_(0x2)                                       /**< (ADC_AVGCTRL) 4 samples  */
+#define   ADC_AVGCTRL_SAMPLENUM_8_Val       _U_(0x3)                                       /**< (ADC_AVGCTRL) 8 samples  */
+#define   ADC_AVGCTRL_SAMPLENUM_16_Val      _U_(0x4)                                       /**< (ADC_AVGCTRL) 16 samples  */
+#define   ADC_AVGCTRL_SAMPLENUM_32_Val      _U_(0x5)                                       /**< (ADC_AVGCTRL) 32 samples  */
+#define   ADC_AVGCTRL_SAMPLENUM_64_Val      _U_(0x6)                                       /**< (ADC_AVGCTRL) 64 samples  */
+#define   ADC_AVGCTRL_SAMPLENUM_128_Val     _U_(0x7)                                       /**< (ADC_AVGCTRL) 128 samples  */
+#define   ADC_AVGCTRL_SAMPLENUM_256_Val     _U_(0x8)                                       /**< (ADC_AVGCTRL) 256 samples  */
+#define   ADC_AVGCTRL_SAMPLENUM_512_Val     _U_(0x9)                                       /**< (ADC_AVGCTRL) 512 samples  */
+#define   ADC_AVGCTRL_SAMPLENUM_1024_Val    _U_(0xA)                                       /**< (ADC_AVGCTRL) 1024 samples  */
+#define ADC_AVGCTRL_SAMPLENUM_1             (ADC_AVGCTRL_SAMPLENUM_1_Val << ADC_AVGCTRL_SAMPLENUM_Pos)  /**< (ADC_AVGCTRL) 1 sample Position  */
+#define ADC_AVGCTRL_SAMPLENUM_2             (ADC_AVGCTRL_SAMPLENUM_2_Val << ADC_AVGCTRL_SAMPLENUM_Pos)  /**< (ADC_AVGCTRL) 2 samples Position  */
+#define ADC_AVGCTRL_SAMPLENUM_4             (ADC_AVGCTRL_SAMPLENUM_4_Val << ADC_AVGCTRL_SAMPLENUM_Pos)  /**< (ADC_AVGCTRL) 4 samples Position  */
+#define ADC_AVGCTRL_SAMPLENUM_8             (ADC_AVGCTRL_SAMPLENUM_8_Val << ADC_AVGCTRL_SAMPLENUM_Pos)  /**< (ADC_AVGCTRL) 8 samples Position  */
+#define ADC_AVGCTRL_SAMPLENUM_16            (ADC_AVGCTRL_SAMPLENUM_16_Val << ADC_AVGCTRL_SAMPLENUM_Pos)  /**< (ADC_AVGCTRL) 16 samples Position  */
+#define ADC_AVGCTRL_SAMPLENUM_32            (ADC_AVGCTRL_SAMPLENUM_32_Val << ADC_AVGCTRL_SAMPLENUM_Pos)  /**< (ADC_AVGCTRL) 32 samples Position  */
+#define ADC_AVGCTRL_SAMPLENUM_64            (ADC_AVGCTRL_SAMPLENUM_64_Val << ADC_AVGCTRL_SAMPLENUM_Pos)  /**< (ADC_AVGCTRL) 64 samples Position  */
+#define ADC_AVGCTRL_SAMPLENUM_128           (ADC_AVGCTRL_SAMPLENUM_128_Val << ADC_AVGCTRL_SAMPLENUM_Pos)  /**< (ADC_AVGCTRL) 128 samples Position  */
+#define ADC_AVGCTRL_SAMPLENUM_256           (ADC_AVGCTRL_SAMPLENUM_256_Val << ADC_AVGCTRL_SAMPLENUM_Pos)  /**< (ADC_AVGCTRL) 256 samples Position  */
+#define ADC_AVGCTRL_SAMPLENUM_512           (ADC_AVGCTRL_SAMPLENUM_512_Val << ADC_AVGCTRL_SAMPLENUM_Pos)  /**< (ADC_AVGCTRL) 512 samples Position  */
+#define ADC_AVGCTRL_SAMPLENUM_1024          (ADC_AVGCTRL_SAMPLENUM_1024_Val << ADC_AVGCTRL_SAMPLENUM_Pos)  /**< (ADC_AVGCTRL) 1024 samples Position  */
+#define ADC_AVGCTRL_ADJRES_Pos              4                                              /**< (ADC_AVGCTRL) Adjusting Result / Division Coefficient Position */
+#define ADC_AVGCTRL_ADJRES_Msk              (_U_(0x7) << ADC_AVGCTRL_ADJRES_Pos)           /**< (ADC_AVGCTRL) Adjusting Result / Division Coefficient Mask */
+#define ADC_AVGCTRL_ADJRES(value)           (ADC_AVGCTRL_ADJRES_Msk & ((value) << ADC_AVGCTRL_ADJRES_Pos))
+#define ADC_AVGCTRL_MASK                    _U_(0x7F)                                      /**< \deprecated (ADC_AVGCTRL) Register MASK  (Use ADC_AVGCTRL_Msk instead)  */
+#define ADC_AVGCTRL_Msk                     _U_(0x7F)                                      /**< (ADC_AVGCTRL) Register Mask  */
+
+
+/* -------- ADC_SAMPCTRL : (ADC Offset: 0x0d) (R/W 8) Sample Time Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  SAMPLEN:6;                 /**< bit:   0..5  Sampling Time Length                     */
+    uint8_t  :1;                        /**< bit:      6  Reserved */
+    uint8_t  OFFCOMP:1;                 /**< bit:      7  Comparator Offset Compensation Enable    */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} ADC_SAMPCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_SAMPCTRL_OFFSET                 (0x0D)                                        /**<  (ADC_SAMPCTRL) Sample Time Control  Offset */
+#define ADC_SAMPCTRL_RESETVALUE             _U_(0x00)                                     /**<  (ADC_SAMPCTRL) Sample Time Control  Reset Value */
+
+#define ADC_SAMPCTRL_SAMPLEN_Pos            0                                              /**< (ADC_SAMPCTRL) Sampling Time Length Position */
+#define ADC_SAMPCTRL_SAMPLEN_Msk            (_U_(0x3F) << ADC_SAMPCTRL_SAMPLEN_Pos)        /**< (ADC_SAMPCTRL) Sampling Time Length Mask */
+#define ADC_SAMPCTRL_SAMPLEN(value)         (ADC_SAMPCTRL_SAMPLEN_Msk & ((value) << ADC_SAMPCTRL_SAMPLEN_Pos))
+#define ADC_SAMPCTRL_OFFCOMP_Pos            7                                              /**< (ADC_SAMPCTRL) Comparator Offset Compensation Enable Position */
+#define ADC_SAMPCTRL_OFFCOMP_Msk            (_U_(0x1) << ADC_SAMPCTRL_OFFCOMP_Pos)         /**< (ADC_SAMPCTRL) Comparator Offset Compensation Enable Mask */
+#define ADC_SAMPCTRL_OFFCOMP                ADC_SAMPCTRL_OFFCOMP_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_SAMPCTRL_OFFCOMP_Msk instead */
+#define ADC_SAMPCTRL_MASK                   _U_(0xBF)                                      /**< \deprecated (ADC_SAMPCTRL) Register MASK  (Use ADC_SAMPCTRL_Msk instead)  */
+#define ADC_SAMPCTRL_Msk                    _U_(0xBF)                                      /**< (ADC_SAMPCTRL) Register Mask  */
+
+
+/* -------- ADC_WINLT : (ADC Offset: 0x0e) (R/W 16) Window Monitor Lower Threshold -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t WINLT:16;                  /**< bit:  0..15  Window Lower Threshold                   */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} ADC_WINLT_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_WINLT_OFFSET                    (0x0E)                                        /**<  (ADC_WINLT) Window Monitor Lower Threshold  Offset */
+#define ADC_WINLT_RESETVALUE                _U_(0x00)                                     /**<  (ADC_WINLT) Window Monitor Lower Threshold  Reset Value */
+
+#define ADC_WINLT_WINLT_Pos                 0                                              /**< (ADC_WINLT) Window Lower Threshold Position */
+#define ADC_WINLT_WINLT_Msk                 (_U_(0xFFFF) << ADC_WINLT_WINLT_Pos)           /**< (ADC_WINLT) Window Lower Threshold Mask */
+#define ADC_WINLT_WINLT(value)              (ADC_WINLT_WINLT_Msk & ((value) << ADC_WINLT_WINLT_Pos))
+#define ADC_WINLT_MASK                      _U_(0xFFFF)                                    /**< \deprecated (ADC_WINLT) Register MASK  (Use ADC_WINLT_Msk instead)  */
+#define ADC_WINLT_Msk                       _U_(0xFFFF)                                    /**< (ADC_WINLT) Register Mask  */
+
+
+/* -------- ADC_WINUT : (ADC Offset: 0x10) (R/W 16) Window Monitor Upper Threshold -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t WINUT:16;                  /**< bit:  0..15  Window Upper Threshold                   */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} ADC_WINUT_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_WINUT_OFFSET                    (0x10)                                        /**<  (ADC_WINUT) Window Monitor Upper Threshold  Offset */
+#define ADC_WINUT_RESETVALUE                _U_(0x00)                                     /**<  (ADC_WINUT) Window Monitor Upper Threshold  Reset Value */
+
+#define ADC_WINUT_WINUT_Pos                 0                                              /**< (ADC_WINUT) Window Upper Threshold Position */
+#define ADC_WINUT_WINUT_Msk                 (_U_(0xFFFF) << ADC_WINUT_WINUT_Pos)           /**< (ADC_WINUT) Window Upper Threshold Mask */
+#define ADC_WINUT_WINUT(value)              (ADC_WINUT_WINUT_Msk & ((value) << ADC_WINUT_WINUT_Pos))
+#define ADC_WINUT_MASK                      _U_(0xFFFF)                                    /**< \deprecated (ADC_WINUT) Register MASK  (Use ADC_WINUT_Msk instead)  */
+#define ADC_WINUT_Msk                       _U_(0xFFFF)                                    /**< (ADC_WINUT) Register Mask  */
+
+
+/* -------- ADC_GAINCORR : (ADC Offset: 0x12) (R/W 16) Gain Correction -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t GAINCORR:12;               /**< bit:  0..11  Gain Correction Value                    */
+    uint16_t :4;                        /**< bit: 12..15  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} ADC_GAINCORR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_GAINCORR_OFFSET                 (0x12)                                        /**<  (ADC_GAINCORR) Gain Correction  Offset */
+#define ADC_GAINCORR_RESETVALUE             _U_(0x00)                                     /**<  (ADC_GAINCORR) Gain Correction  Reset Value */
+
+#define ADC_GAINCORR_GAINCORR_Pos           0                                              /**< (ADC_GAINCORR) Gain Correction Value Position */
+#define ADC_GAINCORR_GAINCORR_Msk           (_U_(0xFFF) << ADC_GAINCORR_GAINCORR_Pos)      /**< (ADC_GAINCORR) Gain Correction Value Mask */
+#define ADC_GAINCORR_GAINCORR(value)        (ADC_GAINCORR_GAINCORR_Msk & ((value) << ADC_GAINCORR_GAINCORR_Pos))
+#define ADC_GAINCORR_MASK                   _U_(0xFFF)                                     /**< \deprecated (ADC_GAINCORR) Register MASK  (Use ADC_GAINCORR_Msk instead)  */
+#define ADC_GAINCORR_Msk                    _U_(0xFFF)                                     /**< (ADC_GAINCORR) Register Mask  */
+
+
+/* -------- ADC_OFFSETCORR : (ADC Offset: 0x14) (R/W 16) Offset Correction -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t OFFSETCORR:12;             /**< bit:  0..11  Offset Correction Value                  */
+    uint16_t :4;                        /**< bit: 12..15  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} ADC_OFFSETCORR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_OFFSETCORR_OFFSET               (0x14)                                        /**<  (ADC_OFFSETCORR) Offset Correction  Offset */
+#define ADC_OFFSETCORR_RESETVALUE           _U_(0x00)                                     /**<  (ADC_OFFSETCORR) Offset Correction  Reset Value */
+
+#define ADC_OFFSETCORR_OFFSETCORR_Pos       0                                              /**< (ADC_OFFSETCORR) Offset Correction Value Position */
+#define ADC_OFFSETCORR_OFFSETCORR_Msk       (_U_(0xFFF) << ADC_OFFSETCORR_OFFSETCORR_Pos)  /**< (ADC_OFFSETCORR) Offset Correction Value Mask */
+#define ADC_OFFSETCORR_OFFSETCORR(value)    (ADC_OFFSETCORR_OFFSETCORR_Msk & ((value) << ADC_OFFSETCORR_OFFSETCORR_Pos))
+#define ADC_OFFSETCORR_MASK                 _U_(0xFFF)                                     /**< \deprecated (ADC_OFFSETCORR) Register MASK  (Use ADC_OFFSETCORR_Msk instead)  */
+#define ADC_OFFSETCORR_Msk                  _U_(0xFFF)                                     /**< (ADC_OFFSETCORR) Register Mask  */
+
+
+/* -------- ADC_SWTRIG : (ADC Offset: 0x18) (R/W 8) Software Trigger -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  FLUSH:1;                   /**< bit:      0  ADC Flush                                */
+    uint8_t  START:1;                   /**< bit:      1  Start ADC Conversion                     */
+    uint8_t  :6;                        /**< bit:   2..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} ADC_SWTRIG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_SWTRIG_OFFSET                   (0x18)                                        /**<  (ADC_SWTRIG) Software Trigger  Offset */
+#define ADC_SWTRIG_RESETVALUE               _U_(0x00)                                     /**<  (ADC_SWTRIG) Software Trigger  Reset Value */
+
+#define ADC_SWTRIG_FLUSH_Pos                0                                              /**< (ADC_SWTRIG) ADC Flush Position */
+#define ADC_SWTRIG_FLUSH_Msk                (_U_(0x1) << ADC_SWTRIG_FLUSH_Pos)             /**< (ADC_SWTRIG) ADC Flush Mask */
+#define ADC_SWTRIG_FLUSH                    ADC_SWTRIG_FLUSH_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_SWTRIG_FLUSH_Msk instead */
+#define ADC_SWTRIG_START_Pos                1                                              /**< (ADC_SWTRIG) Start ADC Conversion Position */
+#define ADC_SWTRIG_START_Msk                (_U_(0x1) << ADC_SWTRIG_START_Pos)             /**< (ADC_SWTRIG) Start ADC Conversion Mask */
+#define ADC_SWTRIG_START                    ADC_SWTRIG_START_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_SWTRIG_START_Msk instead */
+#define ADC_SWTRIG_MASK                     _U_(0x03)                                      /**< \deprecated (ADC_SWTRIG) Register MASK  (Use ADC_SWTRIG_Msk instead)  */
+#define ADC_SWTRIG_Msk                      _U_(0x03)                                      /**< (ADC_SWTRIG) Register Mask  */
+
+
+/* -------- ADC_DBGCTRL : (ADC Offset: 0x1c) (R/W 8) Debug Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DBGRUN:1;                  /**< bit:      0  Debug Run                                */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} ADC_DBGCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_DBGCTRL_OFFSET                  (0x1C)                                        /**<  (ADC_DBGCTRL) Debug Control  Offset */
+#define ADC_DBGCTRL_RESETVALUE              _U_(0x00)                                     /**<  (ADC_DBGCTRL) Debug Control  Reset Value */
+
+#define ADC_DBGCTRL_DBGRUN_Pos              0                                              /**< (ADC_DBGCTRL) Debug Run Position */
+#define ADC_DBGCTRL_DBGRUN_Msk              (_U_(0x1) << ADC_DBGCTRL_DBGRUN_Pos)           /**< (ADC_DBGCTRL) Debug Run Mask */
+#define ADC_DBGCTRL_DBGRUN                  ADC_DBGCTRL_DBGRUN_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_DBGCTRL_DBGRUN_Msk instead */
+#define ADC_DBGCTRL_MASK                    _U_(0x01)                                      /**< \deprecated (ADC_DBGCTRL) Register MASK  (Use ADC_DBGCTRL_Msk instead)  */
+#define ADC_DBGCTRL_Msk                     _U_(0x01)                                      /**< (ADC_DBGCTRL) Register Mask  */
+
+
+/* -------- ADC_SYNCBUSY : (ADC Offset: 0x20) (R/ 16) Synchronization Busy -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t SWRST:1;                   /**< bit:      0  SWRST Synchronization Busy               */
+    uint16_t ENABLE:1;                  /**< bit:      1  ENABLE Synchronization Busy              */
+    uint16_t INPUTCTRL:1;               /**< bit:      2  INPUTCTRL Synchronization Busy           */
+    uint16_t CTRLC:1;                   /**< bit:      3  CTRLC Synchronization Busy               */
+    uint16_t AVGCTRL:1;                 /**< bit:      4  AVGCTRL Synchronization Busy             */
+    uint16_t SAMPCTRL:1;                /**< bit:      5  SAMPCTRL Synchronization Busy            */
+    uint16_t WINLT:1;                   /**< bit:      6  WINLT Synchronization Busy               */
+    uint16_t WINUT:1;                   /**< bit:      7  WINUT Synchronization Busy               */
+    uint16_t GAINCORR:1;                /**< bit:      8  GAINCORR Synchronization Busy            */
+    uint16_t OFFSETCORR:1;              /**< bit:      9  OFFSETCTRL Synchronization Busy          */
+    uint16_t SWTRIG:1;                  /**< bit:     10  SWTRG Synchronization Busy               */
+    uint16_t :5;                        /**< bit: 11..15  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} ADC_SYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_SYNCBUSY_OFFSET                 (0x20)                                        /**<  (ADC_SYNCBUSY) Synchronization Busy  Offset */
+#define ADC_SYNCBUSY_RESETVALUE             _U_(0x00)                                     /**<  (ADC_SYNCBUSY) Synchronization Busy  Reset Value */
+
+#define ADC_SYNCBUSY_SWRST_Pos              0                                              /**< (ADC_SYNCBUSY) SWRST Synchronization Busy Position */
+#define ADC_SYNCBUSY_SWRST_Msk              (_U_(0x1) << ADC_SYNCBUSY_SWRST_Pos)           /**< (ADC_SYNCBUSY) SWRST Synchronization Busy Mask */
+#define ADC_SYNCBUSY_SWRST                  ADC_SYNCBUSY_SWRST_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_SYNCBUSY_SWRST_Msk instead */
+#define ADC_SYNCBUSY_ENABLE_Pos             1                                              /**< (ADC_SYNCBUSY) ENABLE Synchronization Busy Position */
+#define ADC_SYNCBUSY_ENABLE_Msk             (_U_(0x1) << ADC_SYNCBUSY_ENABLE_Pos)          /**< (ADC_SYNCBUSY) ENABLE Synchronization Busy Mask */
+#define ADC_SYNCBUSY_ENABLE                 ADC_SYNCBUSY_ENABLE_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_SYNCBUSY_ENABLE_Msk instead */
+#define ADC_SYNCBUSY_INPUTCTRL_Pos          2                                              /**< (ADC_SYNCBUSY) INPUTCTRL Synchronization Busy Position */
+#define ADC_SYNCBUSY_INPUTCTRL_Msk          (_U_(0x1) << ADC_SYNCBUSY_INPUTCTRL_Pos)       /**< (ADC_SYNCBUSY) INPUTCTRL Synchronization Busy Mask */
+#define ADC_SYNCBUSY_INPUTCTRL              ADC_SYNCBUSY_INPUTCTRL_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_SYNCBUSY_INPUTCTRL_Msk instead */
+#define ADC_SYNCBUSY_CTRLC_Pos              3                                              /**< (ADC_SYNCBUSY) CTRLC Synchronization Busy Position */
+#define ADC_SYNCBUSY_CTRLC_Msk              (_U_(0x1) << ADC_SYNCBUSY_CTRLC_Pos)           /**< (ADC_SYNCBUSY) CTRLC Synchronization Busy Mask */
+#define ADC_SYNCBUSY_CTRLC                  ADC_SYNCBUSY_CTRLC_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_SYNCBUSY_CTRLC_Msk instead */
+#define ADC_SYNCBUSY_AVGCTRL_Pos            4                                              /**< (ADC_SYNCBUSY) AVGCTRL Synchronization Busy Position */
+#define ADC_SYNCBUSY_AVGCTRL_Msk            (_U_(0x1) << ADC_SYNCBUSY_AVGCTRL_Pos)         /**< (ADC_SYNCBUSY) AVGCTRL Synchronization Busy Mask */
+#define ADC_SYNCBUSY_AVGCTRL                ADC_SYNCBUSY_AVGCTRL_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_SYNCBUSY_AVGCTRL_Msk instead */
+#define ADC_SYNCBUSY_SAMPCTRL_Pos           5                                              /**< (ADC_SYNCBUSY) SAMPCTRL Synchronization Busy Position */
+#define ADC_SYNCBUSY_SAMPCTRL_Msk           (_U_(0x1) << ADC_SYNCBUSY_SAMPCTRL_Pos)        /**< (ADC_SYNCBUSY) SAMPCTRL Synchronization Busy Mask */
+#define ADC_SYNCBUSY_SAMPCTRL               ADC_SYNCBUSY_SAMPCTRL_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_SYNCBUSY_SAMPCTRL_Msk instead */
+#define ADC_SYNCBUSY_WINLT_Pos              6                                              /**< (ADC_SYNCBUSY) WINLT Synchronization Busy Position */
+#define ADC_SYNCBUSY_WINLT_Msk              (_U_(0x1) << ADC_SYNCBUSY_WINLT_Pos)           /**< (ADC_SYNCBUSY) WINLT Synchronization Busy Mask */
+#define ADC_SYNCBUSY_WINLT                  ADC_SYNCBUSY_WINLT_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_SYNCBUSY_WINLT_Msk instead */
+#define ADC_SYNCBUSY_WINUT_Pos              7                                              /**< (ADC_SYNCBUSY) WINUT Synchronization Busy Position */
+#define ADC_SYNCBUSY_WINUT_Msk              (_U_(0x1) << ADC_SYNCBUSY_WINUT_Pos)           /**< (ADC_SYNCBUSY) WINUT Synchronization Busy Mask */
+#define ADC_SYNCBUSY_WINUT                  ADC_SYNCBUSY_WINUT_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_SYNCBUSY_WINUT_Msk instead */
+#define ADC_SYNCBUSY_GAINCORR_Pos           8                                              /**< (ADC_SYNCBUSY) GAINCORR Synchronization Busy Position */
+#define ADC_SYNCBUSY_GAINCORR_Msk           (_U_(0x1) << ADC_SYNCBUSY_GAINCORR_Pos)        /**< (ADC_SYNCBUSY) GAINCORR Synchronization Busy Mask */
+#define ADC_SYNCBUSY_GAINCORR               ADC_SYNCBUSY_GAINCORR_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_SYNCBUSY_GAINCORR_Msk instead */
+#define ADC_SYNCBUSY_OFFSETCORR_Pos         9                                              /**< (ADC_SYNCBUSY) OFFSETCTRL Synchronization Busy Position */
+#define ADC_SYNCBUSY_OFFSETCORR_Msk         (_U_(0x1) << ADC_SYNCBUSY_OFFSETCORR_Pos)      /**< (ADC_SYNCBUSY) OFFSETCTRL Synchronization Busy Mask */
+#define ADC_SYNCBUSY_OFFSETCORR             ADC_SYNCBUSY_OFFSETCORR_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_SYNCBUSY_OFFSETCORR_Msk instead */
+#define ADC_SYNCBUSY_SWTRIG_Pos             10                                             /**< (ADC_SYNCBUSY) SWTRG Synchronization Busy Position */
+#define ADC_SYNCBUSY_SWTRIG_Msk             (_U_(0x1) << ADC_SYNCBUSY_SWTRIG_Pos)          /**< (ADC_SYNCBUSY) SWTRG Synchronization Busy Mask */
+#define ADC_SYNCBUSY_SWTRIG                 ADC_SYNCBUSY_SWTRIG_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_SYNCBUSY_SWTRIG_Msk instead */
+#define ADC_SYNCBUSY_MASK                   _U_(0x7FF)                                     /**< \deprecated (ADC_SYNCBUSY) Register MASK  (Use ADC_SYNCBUSY_Msk instead)  */
+#define ADC_SYNCBUSY_Msk                    _U_(0x7FF)                                     /**< (ADC_SYNCBUSY) Register Mask  */
+
+
+/* -------- ADC_RESULT : (ADC Offset: 0x24) (R/ 16) Result -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t RESULT:16;                 /**< bit:  0..15  Result Value                             */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} ADC_RESULT_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_RESULT_OFFSET                   (0x24)                                        /**<  (ADC_RESULT) Result  Offset */
+#define ADC_RESULT_RESETVALUE               _U_(0x00)                                     /**<  (ADC_RESULT) Result  Reset Value */
+
+#define ADC_RESULT_RESULT_Pos               0                                              /**< (ADC_RESULT) Result Value Position */
+#define ADC_RESULT_RESULT_Msk               (_U_(0xFFFF) << ADC_RESULT_RESULT_Pos)         /**< (ADC_RESULT) Result Value Mask */
+#define ADC_RESULT_RESULT(value)            (ADC_RESULT_RESULT_Msk & ((value) << ADC_RESULT_RESULT_Pos))
+#define ADC_RESULT_MASK                     _U_(0xFFFF)                                    /**< \deprecated (ADC_RESULT) Register MASK  (Use ADC_RESULT_Msk instead)  */
+#define ADC_RESULT_Msk                      _U_(0xFFFF)                                    /**< (ADC_RESULT) Register Mask  */
+
+
+/* -------- ADC_SEQCTRL : (ADC Offset: 0x28) (R/W 32) Sequence Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SEQEN:32;                  /**< bit:  0..31  Enable Positive Input in the Sequence    */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ADC_SEQCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_SEQCTRL_OFFSET                  (0x28)                                        /**<  (ADC_SEQCTRL) Sequence Control  Offset */
+#define ADC_SEQCTRL_RESETVALUE              _U_(0x00)                                     /**<  (ADC_SEQCTRL) Sequence Control  Reset Value */
+
+#define ADC_SEQCTRL_SEQEN_Pos               0                                              /**< (ADC_SEQCTRL) Enable Positive Input in the Sequence Position */
+#define ADC_SEQCTRL_SEQEN_Msk               (_U_(0xFFFFFFFF) << ADC_SEQCTRL_SEQEN_Pos)     /**< (ADC_SEQCTRL) Enable Positive Input in the Sequence Mask */
+#define ADC_SEQCTRL_SEQEN(value)            (ADC_SEQCTRL_SEQEN_Msk & ((value) << ADC_SEQCTRL_SEQEN_Pos))
+#define ADC_SEQCTRL_MASK                    _U_(0xFFFFFFFF)                                /**< \deprecated (ADC_SEQCTRL) Register MASK  (Use ADC_SEQCTRL_Msk instead)  */
+#define ADC_SEQCTRL_Msk                     _U_(0xFFFFFFFF)                                /**< (ADC_SEQCTRL) Register Mask  */
+
+
+/* -------- ADC_CALIB : (ADC Offset: 0x2c) (R/W 16) Calibration -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t BIASCOMP:3;                /**< bit:   0..2  Bias Comparator Scaling                  */
+    uint16_t :5;                        /**< bit:   3..7  Reserved */
+    uint16_t BIASREFBUF:3;              /**< bit:  8..10  Bias  Reference Buffer Scaling           */
+    uint16_t :5;                        /**< bit: 11..15  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} ADC_CALIB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_CALIB_OFFSET                    (0x2C)                                        /**<  (ADC_CALIB) Calibration  Offset */
+#define ADC_CALIB_RESETVALUE                _U_(0x00)                                     /**<  (ADC_CALIB) Calibration  Reset Value */
+
+#define ADC_CALIB_BIASCOMP_Pos              0                                              /**< (ADC_CALIB) Bias Comparator Scaling Position */
+#define ADC_CALIB_BIASCOMP_Msk              (_U_(0x7) << ADC_CALIB_BIASCOMP_Pos)           /**< (ADC_CALIB) Bias Comparator Scaling Mask */
+#define ADC_CALIB_BIASCOMP(value)           (ADC_CALIB_BIASCOMP_Msk & ((value) << ADC_CALIB_BIASCOMP_Pos))
+#define ADC_CALIB_BIASREFBUF_Pos            8                                              /**< (ADC_CALIB) Bias  Reference Buffer Scaling Position */
+#define ADC_CALIB_BIASREFBUF_Msk            (_U_(0x7) << ADC_CALIB_BIASREFBUF_Pos)         /**< (ADC_CALIB) Bias  Reference Buffer Scaling Mask */
+#define ADC_CALIB_BIASREFBUF(value)         (ADC_CALIB_BIASREFBUF_Msk & ((value) << ADC_CALIB_BIASREFBUF_Pos))
+#define ADC_CALIB_MASK                      _U_(0x707)                                     /**< \deprecated (ADC_CALIB) Register MASK  (Use ADC_CALIB_Msk instead)  */
+#define ADC_CALIB_Msk                       _U_(0x707)                                     /**< (ADC_CALIB) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief ADC hardware registers */
+typedef struct {  /* Analog Digital Converter */
+  __IO ADC_CTRLA_Type                 CTRLA;          /**< Offset: 0x00 (R/W   8) Control A */
+  __IO ADC_CTRLB_Type                 CTRLB;          /**< Offset: 0x01 (R/W   8) Control B */
+  __IO ADC_REFCTRL_Type               REFCTRL;        /**< Offset: 0x02 (R/W   8) Reference Control */
+  __IO ADC_EVCTRL_Type                EVCTRL;         /**< Offset: 0x03 (R/W   8) Event Control */
+  __IO ADC_INTENCLR_Type              INTENCLR;       /**< Offset: 0x04 (R/W   8) Interrupt Enable Clear */
+  __IO ADC_INTENSET_Type              INTENSET;       /**< Offset: 0x05 (R/W   8) Interrupt Enable Set */
+  __IO ADC_INTFLAG_Type               INTFLAG;        /**< Offset: 0x06 (R/W   8) Interrupt Flag Status and Clear */
+  __I  ADC_SEQSTATUS_Type             SEQSTATUS;      /**< Offset: 0x07 (R/    8) Sequence Status */
+  __IO ADC_INPUTCTRL_Type             INPUTCTRL;      /**< Offset: 0x08 (R/W  16) Input Control */
+  __IO ADC_CTRLC_Type                 CTRLC;          /**< Offset: 0x0A (R/W  16) Control C */
+  __IO ADC_AVGCTRL_Type               AVGCTRL;        /**< Offset: 0x0C (R/W   8) Average Control */
+  __IO ADC_SAMPCTRL_Type              SAMPCTRL;       /**< Offset: 0x0D (R/W   8) Sample Time Control */
+  __IO ADC_WINLT_Type                 WINLT;          /**< Offset: 0x0E (R/W  16) Window Monitor Lower Threshold */
+  __IO ADC_WINUT_Type                 WINUT;          /**< Offset: 0x10 (R/W  16) Window Monitor Upper Threshold */
+  __IO ADC_GAINCORR_Type              GAINCORR;       /**< Offset: 0x12 (R/W  16) Gain Correction */
+  __IO ADC_OFFSETCORR_Type            OFFSETCORR;     /**< Offset: 0x14 (R/W  16) Offset Correction */
+  __I  uint8_t                        Reserved1[2];
+  __IO ADC_SWTRIG_Type                SWTRIG;         /**< Offset: 0x18 (R/W   8) Software Trigger */
+  __I  uint8_t                        Reserved2[3];
+  __IO ADC_DBGCTRL_Type               DBGCTRL;        /**< Offset: 0x1C (R/W   8) Debug Control */
+  __I  uint8_t                        Reserved3[3];
+  __I  ADC_SYNCBUSY_Type              SYNCBUSY;       /**< Offset: 0x20 (R/   16) Synchronization Busy */
+  __I  uint8_t                        Reserved4[2];
+  __I  ADC_RESULT_Type                RESULT;         /**< Offset: 0x24 (R/   16) Result */
+  __I  uint8_t                        Reserved5[2];
+  __IO ADC_SEQCTRL_Type               SEQCTRL;        /**< Offset: 0x28 (R/W  32) Sequence Control */
+  __IO ADC_CALIB_Type                 CALIB;          /**< Offset: 0x2C (R/W  16) Calibration */
+} Adc;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Analog Digital Converter */
+
+#endif /* _SAML10_ADC_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/component/ccl.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/ccl.h
@@ -1,0 +1,258 @@
+/**
+ * \file
+ *
+ * \brief Component description for CCL
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_CCL_COMPONENT_H_
+#define _SAML10_CCL_COMPONENT_H_
+#define _SAML10_CCL_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML10 Configurable Custom Logic
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR CCL */
+/* ========================================================================== */
+
+#define CCL_U2225                      /**< (CCL) Module ID */
+#define REV_CCL 0x200                  /**< (CCL) Module revision */
+
+/* -------- CCL_CTRL : (CCL Offset: 0x00) (R/W 8) Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint8_t  ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint8_t  :4;                        /**< bit:   2..5  Reserved */
+    uint8_t  RUNSTDBY:1;                /**< bit:      6  Run in Standby                           */
+    uint8_t  :1;                        /**< bit:      7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} CCL_CTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CCL_CTRL_OFFSET                     (0x00)                                        /**<  (CCL_CTRL) Control  Offset */
+#define CCL_CTRL_RESETVALUE                 _U_(0x00)                                     /**<  (CCL_CTRL) Control  Reset Value */
+
+#define CCL_CTRL_SWRST_Pos                  0                                              /**< (CCL_CTRL) Software Reset Position */
+#define CCL_CTRL_SWRST_Msk                  (_U_(0x1) << CCL_CTRL_SWRST_Pos)               /**< (CCL_CTRL) Software Reset Mask */
+#define CCL_CTRL_SWRST                      CCL_CTRL_SWRST_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use CCL_CTRL_SWRST_Msk instead */
+#define CCL_CTRL_ENABLE_Pos                 1                                              /**< (CCL_CTRL) Enable Position */
+#define CCL_CTRL_ENABLE_Msk                 (_U_(0x1) << CCL_CTRL_ENABLE_Pos)              /**< (CCL_CTRL) Enable Mask */
+#define CCL_CTRL_ENABLE                     CCL_CTRL_ENABLE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use CCL_CTRL_ENABLE_Msk instead */
+#define CCL_CTRL_RUNSTDBY_Pos               6                                              /**< (CCL_CTRL) Run in Standby Position */
+#define CCL_CTRL_RUNSTDBY_Msk               (_U_(0x1) << CCL_CTRL_RUNSTDBY_Pos)            /**< (CCL_CTRL) Run in Standby Mask */
+#define CCL_CTRL_RUNSTDBY                   CCL_CTRL_RUNSTDBY_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use CCL_CTRL_RUNSTDBY_Msk instead */
+#define CCL_CTRL_MASK                       _U_(0x43)                                      /**< \deprecated (CCL_CTRL) Register MASK  (Use CCL_CTRL_Msk instead)  */
+#define CCL_CTRL_Msk                        _U_(0x43)                                      /**< (CCL_CTRL) Register Mask  */
+
+
+/* -------- CCL_SEQCTRL : (CCL Offset: 0x04) (R/W 8) SEQ Control x -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  SEQSEL:4;                  /**< bit:   0..3  Sequential Selection                     */
+    uint8_t  :4;                        /**< bit:   4..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} CCL_SEQCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CCL_SEQCTRL_OFFSET                  (0x04)                                        /**<  (CCL_SEQCTRL) SEQ Control x  Offset */
+#define CCL_SEQCTRL_RESETVALUE              _U_(0x00)                                     /**<  (CCL_SEQCTRL) SEQ Control x  Reset Value */
+
+#define CCL_SEQCTRL_SEQSEL_Pos              0                                              /**< (CCL_SEQCTRL) Sequential Selection Position */
+#define CCL_SEQCTRL_SEQSEL_Msk              (_U_(0xF) << CCL_SEQCTRL_SEQSEL_Pos)           /**< (CCL_SEQCTRL) Sequential Selection Mask */
+#define CCL_SEQCTRL_SEQSEL(value)           (CCL_SEQCTRL_SEQSEL_Msk & ((value) << CCL_SEQCTRL_SEQSEL_Pos))
+#define   CCL_SEQCTRL_SEQSEL_DISABLE_Val    _U_(0x0)                                       /**< (CCL_SEQCTRL) Sequential logic is disabled  */
+#define   CCL_SEQCTRL_SEQSEL_DFF_Val        _U_(0x1)                                       /**< (CCL_SEQCTRL) D flip flop  */
+#define   CCL_SEQCTRL_SEQSEL_JK_Val         _U_(0x2)                                       /**< (CCL_SEQCTRL) JK flip flop  */
+#define   CCL_SEQCTRL_SEQSEL_LATCH_Val      _U_(0x3)                                       /**< (CCL_SEQCTRL) D latch  */
+#define   CCL_SEQCTRL_SEQSEL_RS_Val         _U_(0x4)                                       /**< (CCL_SEQCTRL) RS latch  */
+#define CCL_SEQCTRL_SEQSEL_DISABLE          (CCL_SEQCTRL_SEQSEL_DISABLE_Val << CCL_SEQCTRL_SEQSEL_Pos)  /**< (CCL_SEQCTRL) Sequential logic is disabled Position  */
+#define CCL_SEQCTRL_SEQSEL_DFF              (CCL_SEQCTRL_SEQSEL_DFF_Val << CCL_SEQCTRL_SEQSEL_Pos)  /**< (CCL_SEQCTRL) D flip flop Position  */
+#define CCL_SEQCTRL_SEQSEL_JK               (CCL_SEQCTRL_SEQSEL_JK_Val << CCL_SEQCTRL_SEQSEL_Pos)  /**< (CCL_SEQCTRL) JK flip flop Position  */
+#define CCL_SEQCTRL_SEQSEL_LATCH            (CCL_SEQCTRL_SEQSEL_LATCH_Val << CCL_SEQCTRL_SEQSEL_Pos)  /**< (CCL_SEQCTRL) D latch Position  */
+#define CCL_SEQCTRL_SEQSEL_RS               (CCL_SEQCTRL_SEQSEL_RS_Val << CCL_SEQCTRL_SEQSEL_Pos)  /**< (CCL_SEQCTRL) RS latch Position  */
+#define CCL_SEQCTRL_MASK                    _U_(0x0F)                                      /**< \deprecated (CCL_SEQCTRL) Register MASK  (Use CCL_SEQCTRL_Msk instead)  */
+#define CCL_SEQCTRL_Msk                     _U_(0x0F)                                      /**< (CCL_SEQCTRL) Register Mask  */
+
+
+/* -------- CCL_LUTCTRL : (CCL Offset: 0x08) (R/W 32) LUT Control x -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t ENABLE:1;                  /**< bit:      1  LUT Enable                               */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t FILTSEL:2;                 /**< bit:   4..5  Filter Selection                         */
+    uint32_t :1;                        /**< bit:      6  Reserved */
+    uint32_t EDGESEL:1;                 /**< bit:      7  Edge Selection                           */
+    uint32_t INSEL0:4;                  /**< bit:  8..11  Input Selection 0                        */
+    uint32_t INSEL1:4;                  /**< bit: 12..15  Input Selection 1                        */
+    uint32_t INSEL2:4;                  /**< bit: 16..19  Input Selection 2                        */
+    uint32_t INVEI:1;                   /**< bit:     20  Inverted Event Input Enable              */
+    uint32_t LUTEI:1;                   /**< bit:     21  LUT Event Input Enable                   */
+    uint32_t LUTEO:1;                   /**< bit:     22  LUT Event Output Enable                  */
+    uint32_t :1;                        /**< bit:     23  Reserved */
+    uint32_t TRUTH:8;                   /**< bit: 24..31  Truth Value                              */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} CCL_LUTCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CCL_LUTCTRL_OFFSET                  (0x08)                                        /**<  (CCL_LUTCTRL) LUT Control x  Offset */
+#define CCL_LUTCTRL_RESETVALUE              _U_(0x00)                                     /**<  (CCL_LUTCTRL) LUT Control x  Reset Value */
+
+#define CCL_LUTCTRL_ENABLE_Pos              1                                              /**< (CCL_LUTCTRL) LUT Enable Position */
+#define CCL_LUTCTRL_ENABLE_Msk              (_U_(0x1) << CCL_LUTCTRL_ENABLE_Pos)           /**< (CCL_LUTCTRL) LUT Enable Mask */
+#define CCL_LUTCTRL_ENABLE                  CCL_LUTCTRL_ENABLE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use CCL_LUTCTRL_ENABLE_Msk instead */
+#define CCL_LUTCTRL_FILTSEL_Pos             4                                              /**< (CCL_LUTCTRL) Filter Selection Position */
+#define CCL_LUTCTRL_FILTSEL_Msk             (_U_(0x3) << CCL_LUTCTRL_FILTSEL_Pos)          /**< (CCL_LUTCTRL) Filter Selection Mask */
+#define CCL_LUTCTRL_FILTSEL(value)          (CCL_LUTCTRL_FILTSEL_Msk & ((value) << CCL_LUTCTRL_FILTSEL_Pos))
+#define   CCL_LUTCTRL_FILTSEL_DISABLE_Val   _U_(0x0)                                       /**< (CCL_LUTCTRL) Filter disabled  */
+#define   CCL_LUTCTRL_FILTSEL_SYNCH_Val     _U_(0x1)                                       /**< (CCL_LUTCTRL) Synchronizer enabled  */
+#define   CCL_LUTCTRL_FILTSEL_FILTER_Val    _U_(0x2)                                       /**< (CCL_LUTCTRL) Filter enabled  */
+#define CCL_LUTCTRL_FILTSEL_DISABLE         (CCL_LUTCTRL_FILTSEL_DISABLE_Val << CCL_LUTCTRL_FILTSEL_Pos)  /**< (CCL_LUTCTRL) Filter disabled Position  */
+#define CCL_LUTCTRL_FILTSEL_SYNCH           (CCL_LUTCTRL_FILTSEL_SYNCH_Val << CCL_LUTCTRL_FILTSEL_Pos)  /**< (CCL_LUTCTRL) Synchronizer enabled Position  */
+#define CCL_LUTCTRL_FILTSEL_FILTER          (CCL_LUTCTRL_FILTSEL_FILTER_Val << CCL_LUTCTRL_FILTSEL_Pos)  /**< (CCL_LUTCTRL) Filter enabled Position  */
+#define CCL_LUTCTRL_EDGESEL_Pos             7                                              /**< (CCL_LUTCTRL) Edge Selection Position */
+#define CCL_LUTCTRL_EDGESEL_Msk             (_U_(0x1) << CCL_LUTCTRL_EDGESEL_Pos)          /**< (CCL_LUTCTRL) Edge Selection Mask */
+#define CCL_LUTCTRL_EDGESEL                 CCL_LUTCTRL_EDGESEL_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use CCL_LUTCTRL_EDGESEL_Msk instead */
+#define CCL_LUTCTRL_INSEL0_Pos              8                                              /**< (CCL_LUTCTRL) Input Selection 0 Position */
+#define CCL_LUTCTRL_INSEL0_Msk              (_U_(0xF) << CCL_LUTCTRL_INSEL0_Pos)           /**< (CCL_LUTCTRL) Input Selection 0 Mask */
+#define CCL_LUTCTRL_INSEL0(value)           (CCL_LUTCTRL_INSEL0_Msk & ((value) << CCL_LUTCTRL_INSEL0_Pos))
+#define   CCL_LUTCTRL_INSEL0_MASK_Val       _U_(0x0)                                       /**< (CCL_LUTCTRL) Masked input  */
+#define   CCL_LUTCTRL_INSEL0_FEEDBACK_Val   _U_(0x1)                                       /**< (CCL_LUTCTRL) Feedback input source  */
+#define   CCL_LUTCTRL_INSEL0_LINK_Val       _U_(0x2)                                       /**< (CCL_LUTCTRL) Linked LUT input source  */
+#define   CCL_LUTCTRL_INSEL0_EVENT_Val      _U_(0x3)                                       /**< (CCL_LUTCTRL) Event input source  */
+#define   CCL_LUTCTRL_INSEL0_IO_Val         _U_(0x4)                                       /**< (CCL_LUTCTRL) I/O pin input source  */
+#define   CCL_LUTCTRL_INSEL0_AC_Val         _U_(0x5)                                       /**< (CCL_LUTCTRL) AC input source  */
+#define   CCL_LUTCTRL_INSEL0_TC_Val         _U_(0x6)                                       /**< (CCL_LUTCTRL) TC input source  */
+#define   CCL_LUTCTRL_INSEL0_ALTTC_Val      _U_(0x7)                                       /**< (CCL_LUTCTRL) Alternate TC input source  */
+#define   CCL_LUTCTRL_INSEL0_TCC_Val        _U_(0x8)                                       /**< (CCL_LUTCTRL) TCC input source  */
+#define   CCL_LUTCTRL_INSEL0_SERCOM_Val     _U_(0x9)                                       /**< (CCL_LUTCTRL) SERCOM input source  */
+#define   CCL_LUTCTRL_INSEL0_ALT2TC_Val     _U_(0xA)                                       /**< (CCL_LUTCTRL) Alternate 2 TC input source  */
+#define   CCL_LUTCTRL_INSEL0_ASYNCEVENT_Val _U_(0xB)                                       /**< (CCL_LUTCTRL) Asynchronous event input source. The EVENT input will bypass edge detection logic.  */
+#define CCL_LUTCTRL_INSEL0_MASK             (CCL_LUTCTRL_INSEL0_MASK_Val << CCL_LUTCTRL_INSEL0_Pos)  /**< (CCL_LUTCTRL) Masked input Position  */
+#define CCL_LUTCTRL_INSEL0_FEEDBACK         (CCL_LUTCTRL_INSEL0_FEEDBACK_Val << CCL_LUTCTRL_INSEL0_Pos)  /**< (CCL_LUTCTRL) Feedback input source Position  */
+#define CCL_LUTCTRL_INSEL0_LINK             (CCL_LUTCTRL_INSEL0_LINK_Val << CCL_LUTCTRL_INSEL0_Pos)  /**< (CCL_LUTCTRL) Linked LUT input source Position  */
+#define CCL_LUTCTRL_INSEL0_EVENT            (CCL_LUTCTRL_INSEL0_EVENT_Val << CCL_LUTCTRL_INSEL0_Pos)  /**< (CCL_LUTCTRL) Event input source Position  */
+#define CCL_LUTCTRL_INSEL0_IO               (CCL_LUTCTRL_INSEL0_IO_Val << CCL_LUTCTRL_INSEL0_Pos)  /**< (CCL_LUTCTRL) I/O pin input source Position  */
+#define CCL_LUTCTRL_INSEL0_AC               (CCL_LUTCTRL_INSEL0_AC_Val << CCL_LUTCTRL_INSEL0_Pos)  /**< (CCL_LUTCTRL) AC input source Position  */
+#define CCL_LUTCTRL_INSEL0_TC               (CCL_LUTCTRL_INSEL0_TC_Val << CCL_LUTCTRL_INSEL0_Pos)  /**< (CCL_LUTCTRL) TC input source Position  */
+#define CCL_LUTCTRL_INSEL0_ALTTC            (CCL_LUTCTRL_INSEL0_ALTTC_Val << CCL_LUTCTRL_INSEL0_Pos)  /**< (CCL_LUTCTRL) Alternate TC input source Position  */
+#define CCL_LUTCTRL_INSEL0_TCC              (CCL_LUTCTRL_INSEL0_TCC_Val << CCL_LUTCTRL_INSEL0_Pos)  /**< (CCL_LUTCTRL) TCC input source Position  */
+#define CCL_LUTCTRL_INSEL0_SERCOM           (CCL_LUTCTRL_INSEL0_SERCOM_Val << CCL_LUTCTRL_INSEL0_Pos)  /**< (CCL_LUTCTRL) SERCOM input source Position  */
+#define CCL_LUTCTRL_INSEL0_ALT2TC           (CCL_LUTCTRL_INSEL0_ALT2TC_Val << CCL_LUTCTRL_INSEL0_Pos)  /**< (CCL_LUTCTRL) Alternate 2 TC input source Position  */
+#define CCL_LUTCTRL_INSEL0_ASYNCEVENT       (CCL_LUTCTRL_INSEL0_ASYNCEVENT_Val << CCL_LUTCTRL_INSEL0_Pos)  /**< (CCL_LUTCTRL) Asynchronous event input source. The EVENT input will bypass edge detection logic. Position  */
+#define CCL_LUTCTRL_INSEL1_Pos              12                                             /**< (CCL_LUTCTRL) Input Selection 1 Position */
+#define CCL_LUTCTRL_INSEL1_Msk              (_U_(0xF) << CCL_LUTCTRL_INSEL1_Pos)           /**< (CCL_LUTCTRL) Input Selection 1 Mask */
+#define CCL_LUTCTRL_INSEL1(value)           (CCL_LUTCTRL_INSEL1_Msk & ((value) << CCL_LUTCTRL_INSEL1_Pos))
+#define   CCL_LUTCTRL_INSEL1_MASK_Val       _U_(0x0)                                       /**< (CCL_LUTCTRL) Masked input  */
+#define   CCL_LUTCTRL_INSEL1_FEEDBACK_Val   _U_(0x1)                                       /**< (CCL_LUTCTRL) Feedback input source  */
+#define   CCL_LUTCTRL_INSEL1_LINK_Val       _U_(0x2)                                       /**< (CCL_LUTCTRL) Linked LUT input source  */
+#define   CCL_LUTCTRL_INSEL1_EVENT_Val      _U_(0x3)                                       /**< (CCL_LUTCTRL) Event input source  */
+#define   CCL_LUTCTRL_INSEL1_IO_Val         _U_(0x4)                                       /**< (CCL_LUTCTRL) I/O pin input source  */
+#define   CCL_LUTCTRL_INSEL1_AC_Val         _U_(0x5)                                       /**< (CCL_LUTCTRL) AC input source  */
+#define   CCL_LUTCTRL_INSEL1_TC_Val         _U_(0x6)                                       /**< (CCL_LUTCTRL) TC input source  */
+#define   CCL_LUTCTRL_INSEL1_ALTTC_Val      _U_(0x7)                                       /**< (CCL_LUTCTRL) Alternate TC input source  */
+#define   CCL_LUTCTRL_INSEL1_TCC_Val        _U_(0x8)                                       /**< (CCL_LUTCTRL) TCC input source  */
+#define   CCL_LUTCTRL_INSEL1_SERCOM_Val     _U_(0x9)                                       /**< (CCL_LUTCTRL) SERCOM input source  */
+#define   CCL_LUTCTRL_INSEL1_ALT2TC_Val     _U_(0xA)                                       /**< (CCL_LUTCTRL) Alternate 2 TC input source  */
+#define   CCL_LUTCTRL_INSEL1_ASYNCEVENT_Val _U_(0xB)                                       /**< (CCL_LUTCTRL) Asynchronous event input source. The EVENT input will bypass edge detection logic.  */
+#define CCL_LUTCTRL_INSEL1_MASK             (CCL_LUTCTRL_INSEL1_MASK_Val << CCL_LUTCTRL_INSEL1_Pos)  /**< (CCL_LUTCTRL) Masked input Position  */
+#define CCL_LUTCTRL_INSEL1_FEEDBACK         (CCL_LUTCTRL_INSEL1_FEEDBACK_Val << CCL_LUTCTRL_INSEL1_Pos)  /**< (CCL_LUTCTRL) Feedback input source Position  */
+#define CCL_LUTCTRL_INSEL1_LINK             (CCL_LUTCTRL_INSEL1_LINK_Val << CCL_LUTCTRL_INSEL1_Pos)  /**< (CCL_LUTCTRL) Linked LUT input source Position  */
+#define CCL_LUTCTRL_INSEL1_EVENT            (CCL_LUTCTRL_INSEL1_EVENT_Val << CCL_LUTCTRL_INSEL1_Pos)  /**< (CCL_LUTCTRL) Event input source Position  */
+#define CCL_LUTCTRL_INSEL1_IO               (CCL_LUTCTRL_INSEL1_IO_Val << CCL_LUTCTRL_INSEL1_Pos)  /**< (CCL_LUTCTRL) I/O pin input source Position  */
+#define CCL_LUTCTRL_INSEL1_AC               (CCL_LUTCTRL_INSEL1_AC_Val << CCL_LUTCTRL_INSEL1_Pos)  /**< (CCL_LUTCTRL) AC input source Position  */
+#define CCL_LUTCTRL_INSEL1_TC               (CCL_LUTCTRL_INSEL1_TC_Val << CCL_LUTCTRL_INSEL1_Pos)  /**< (CCL_LUTCTRL) TC input source Position  */
+#define CCL_LUTCTRL_INSEL1_ALTTC            (CCL_LUTCTRL_INSEL1_ALTTC_Val << CCL_LUTCTRL_INSEL1_Pos)  /**< (CCL_LUTCTRL) Alternate TC input source Position  */
+#define CCL_LUTCTRL_INSEL1_TCC              (CCL_LUTCTRL_INSEL1_TCC_Val << CCL_LUTCTRL_INSEL1_Pos)  /**< (CCL_LUTCTRL) TCC input source Position  */
+#define CCL_LUTCTRL_INSEL1_SERCOM           (CCL_LUTCTRL_INSEL1_SERCOM_Val << CCL_LUTCTRL_INSEL1_Pos)  /**< (CCL_LUTCTRL) SERCOM input source Position  */
+#define CCL_LUTCTRL_INSEL1_ALT2TC           (CCL_LUTCTRL_INSEL1_ALT2TC_Val << CCL_LUTCTRL_INSEL1_Pos)  /**< (CCL_LUTCTRL) Alternate 2 TC input source Position  */
+#define CCL_LUTCTRL_INSEL1_ASYNCEVENT       (CCL_LUTCTRL_INSEL1_ASYNCEVENT_Val << CCL_LUTCTRL_INSEL1_Pos)  /**< (CCL_LUTCTRL) Asynchronous event input source. The EVENT input will bypass edge detection logic. Position  */
+#define CCL_LUTCTRL_INSEL2_Pos              16                                             /**< (CCL_LUTCTRL) Input Selection 2 Position */
+#define CCL_LUTCTRL_INSEL2_Msk              (_U_(0xF) << CCL_LUTCTRL_INSEL2_Pos)           /**< (CCL_LUTCTRL) Input Selection 2 Mask */
+#define CCL_LUTCTRL_INSEL2(value)           (CCL_LUTCTRL_INSEL2_Msk & ((value) << CCL_LUTCTRL_INSEL2_Pos))
+#define   CCL_LUTCTRL_INSEL2_MASK_Val       _U_(0x0)                                       /**< (CCL_LUTCTRL) Masked input  */
+#define   CCL_LUTCTRL_INSEL2_FEEDBACK_Val   _U_(0x1)                                       /**< (CCL_LUTCTRL) Feedback input source  */
+#define   CCL_LUTCTRL_INSEL2_LINK_Val       _U_(0x2)                                       /**< (CCL_LUTCTRL) Linked LUT input source  */
+#define   CCL_LUTCTRL_INSEL2_EVENT_Val      _U_(0x3)                                       /**< (CCL_LUTCTRL) Event input source  */
+#define   CCL_LUTCTRL_INSEL2_IO_Val         _U_(0x4)                                       /**< (CCL_LUTCTRL) I/O pin input source  */
+#define   CCL_LUTCTRL_INSEL2_AC_Val         _U_(0x5)                                       /**< (CCL_LUTCTRL) AC input source  */
+#define   CCL_LUTCTRL_INSEL2_TC_Val         _U_(0x6)                                       /**< (CCL_LUTCTRL) TC input source  */
+#define   CCL_LUTCTRL_INSEL2_ALTTC_Val      _U_(0x7)                                       /**< (CCL_LUTCTRL) Alternate TC input source  */
+#define   CCL_LUTCTRL_INSEL2_TCC_Val        _U_(0x8)                                       /**< (CCL_LUTCTRL) TCC input source  */
+#define   CCL_LUTCTRL_INSEL2_SERCOM_Val     _U_(0x9)                                       /**< (CCL_LUTCTRL) SERCOM input source  */
+#define   CCL_LUTCTRL_INSEL2_ALT2TC_Val     _U_(0xA)                                       /**< (CCL_LUTCTRL) Alternate 2 TC input source  */
+#define   CCL_LUTCTRL_INSEL2_ASYNCEVENT_Val _U_(0xB)                                       /**< (CCL_LUTCTRL) Asynchronous event input source. The EVENT input will bypass edge detection logic.  */
+#define CCL_LUTCTRL_INSEL2_MASK             (CCL_LUTCTRL_INSEL2_MASK_Val << CCL_LUTCTRL_INSEL2_Pos)  /**< (CCL_LUTCTRL) Masked input Position  */
+#define CCL_LUTCTRL_INSEL2_FEEDBACK         (CCL_LUTCTRL_INSEL2_FEEDBACK_Val << CCL_LUTCTRL_INSEL2_Pos)  /**< (CCL_LUTCTRL) Feedback input source Position  */
+#define CCL_LUTCTRL_INSEL2_LINK             (CCL_LUTCTRL_INSEL2_LINK_Val << CCL_LUTCTRL_INSEL2_Pos)  /**< (CCL_LUTCTRL) Linked LUT input source Position  */
+#define CCL_LUTCTRL_INSEL2_EVENT            (CCL_LUTCTRL_INSEL2_EVENT_Val << CCL_LUTCTRL_INSEL2_Pos)  /**< (CCL_LUTCTRL) Event input source Position  */
+#define CCL_LUTCTRL_INSEL2_IO               (CCL_LUTCTRL_INSEL2_IO_Val << CCL_LUTCTRL_INSEL2_Pos)  /**< (CCL_LUTCTRL) I/O pin input source Position  */
+#define CCL_LUTCTRL_INSEL2_AC               (CCL_LUTCTRL_INSEL2_AC_Val << CCL_LUTCTRL_INSEL2_Pos)  /**< (CCL_LUTCTRL) AC input source Position  */
+#define CCL_LUTCTRL_INSEL2_TC               (CCL_LUTCTRL_INSEL2_TC_Val << CCL_LUTCTRL_INSEL2_Pos)  /**< (CCL_LUTCTRL) TC input source Position  */
+#define CCL_LUTCTRL_INSEL2_ALTTC            (CCL_LUTCTRL_INSEL2_ALTTC_Val << CCL_LUTCTRL_INSEL2_Pos)  /**< (CCL_LUTCTRL) Alternate TC input source Position  */
+#define CCL_LUTCTRL_INSEL2_TCC              (CCL_LUTCTRL_INSEL2_TCC_Val << CCL_LUTCTRL_INSEL2_Pos)  /**< (CCL_LUTCTRL) TCC input source Position  */
+#define CCL_LUTCTRL_INSEL2_SERCOM           (CCL_LUTCTRL_INSEL2_SERCOM_Val << CCL_LUTCTRL_INSEL2_Pos)  /**< (CCL_LUTCTRL) SERCOM input source Position  */
+#define CCL_LUTCTRL_INSEL2_ALT2TC           (CCL_LUTCTRL_INSEL2_ALT2TC_Val << CCL_LUTCTRL_INSEL2_Pos)  /**< (CCL_LUTCTRL) Alternate 2 TC input source Position  */
+#define CCL_LUTCTRL_INSEL2_ASYNCEVENT       (CCL_LUTCTRL_INSEL2_ASYNCEVENT_Val << CCL_LUTCTRL_INSEL2_Pos)  /**< (CCL_LUTCTRL) Asynchronous event input source. The EVENT input will bypass edge detection logic. Position  */
+#define CCL_LUTCTRL_INVEI_Pos               20                                             /**< (CCL_LUTCTRL) Inverted Event Input Enable Position */
+#define CCL_LUTCTRL_INVEI_Msk               (_U_(0x1) << CCL_LUTCTRL_INVEI_Pos)            /**< (CCL_LUTCTRL) Inverted Event Input Enable Mask */
+#define CCL_LUTCTRL_INVEI                   CCL_LUTCTRL_INVEI_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use CCL_LUTCTRL_INVEI_Msk instead */
+#define CCL_LUTCTRL_LUTEI_Pos               21                                             /**< (CCL_LUTCTRL) LUT Event Input Enable Position */
+#define CCL_LUTCTRL_LUTEI_Msk               (_U_(0x1) << CCL_LUTCTRL_LUTEI_Pos)            /**< (CCL_LUTCTRL) LUT Event Input Enable Mask */
+#define CCL_LUTCTRL_LUTEI                   CCL_LUTCTRL_LUTEI_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use CCL_LUTCTRL_LUTEI_Msk instead */
+#define CCL_LUTCTRL_LUTEO_Pos               22                                             /**< (CCL_LUTCTRL) LUT Event Output Enable Position */
+#define CCL_LUTCTRL_LUTEO_Msk               (_U_(0x1) << CCL_LUTCTRL_LUTEO_Pos)            /**< (CCL_LUTCTRL) LUT Event Output Enable Mask */
+#define CCL_LUTCTRL_LUTEO                   CCL_LUTCTRL_LUTEO_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use CCL_LUTCTRL_LUTEO_Msk instead */
+#define CCL_LUTCTRL_TRUTH_Pos               24                                             /**< (CCL_LUTCTRL) Truth Value Position */
+#define CCL_LUTCTRL_TRUTH_Msk               (_U_(0xFF) << CCL_LUTCTRL_TRUTH_Pos)           /**< (CCL_LUTCTRL) Truth Value Mask */
+#define CCL_LUTCTRL_TRUTH(value)            (CCL_LUTCTRL_TRUTH_Msk & ((value) << CCL_LUTCTRL_TRUTH_Pos))
+#define CCL_LUTCTRL_MASK                    _U_(0xFF7FFFB2)                                /**< \deprecated (CCL_LUTCTRL) Register MASK  (Use CCL_LUTCTRL_Msk instead)  */
+#define CCL_LUTCTRL_Msk                     _U_(0xFF7FFFB2)                                /**< (CCL_LUTCTRL) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief CCL hardware registers */
+typedef struct {  /* Configurable Custom Logic */
+  __IO CCL_CTRL_Type                  CTRL;           /**< Offset: 0x00 (R/W   8) Control */
+  __I  uint8_t                        Reserved1[3];
+  __IO CCL_SEQCTRL_Type               SEQCTRL[1];     /**< Offset: 0x04 (R/W   8) SEQ Control x */
+  __I  uint8_t                        Reserved2[3];
+  __IO CCL_LUTCTRL_Type               LUTCTRL[2];     /**< Offset: 0x08 (R/W  32) LUT Control x */
+} Ccl;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Configurable Custom Logic */
+
+#endif /* _SAML10_CCL_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/component/dac.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/dac.h
@@ -1,0 +1,364 @@
+/**
+ * \file
+ *
+ * \brief Component description for DAC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_DAC_COMPONENT_H_
+#define _SAML10_DAC_COMPONENT_H_
+#define _SAML10_DAC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML10 Digital Analog Converter
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR DAC */
+/* ========================================================================== */
+
+#define DAC_U2214                      /**< (DAC) Module ID */
+#define REV_DAC 0x210                  /**< (DAC) Module revision */
+
+/* -------- DAC_CTRLA : (DAC Offset: 0x00) (R/W 8) Control A -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint8_t  ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint8_t  :4;                        /**< bit:   2..5  Reserved */
+    uint8_t  RUNSTDBY:1;                /**< bit:      6  Run in Standby                           */
+    uint8_t  :1;                        /**< bit:      7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} DAC_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_CTRLA_OFFSET                    (0x00)                                        /**<  (DAC_CTRLA) Control A  Offset */
+#define DAC_CTRLA_RESETVALUE                _U_(0x00)                                     /**<  (DAC_CTRLA) Control A  Reset Value */
+
+#define DAC_CTRLA_SWRST_Pos                 0                                              /**< (DAC_CTRLA) Software Reset Position */
+#define DAC_CTRLA_SWRST_Msk                 (_U_(0x1) << DAC_CTRLA_SWRST_Pos)              /**< (DAC_CTRLA) Software Reset Mask */
+#define DAC_CTRLA_SWRST                     DAC_CTRLA_SWRST_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use DAC_CTRLA_SWRST_Msk instead */
+#define DAC_CTRLA_ENABLE_Pos                1                                              /**< (DAC_CTRLA) Enable Position */
+#define DAC_CTRLA_ENABLE_Msk                (_U_(0x1) << DAC_CTRLA_ENABLE_Pos)             /**< (DAC_CTRLA) Enable Mask */
+#define DAC_CTRLA_ENABLE                    DAC_CTRLA_ENABLE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use DAC_CTRLA_ENABLE_Msk instead */
+#define DAC_CTRLA_RUNSTDBY_Pos              6                                              /**< (DAC_CTRLA) Run in Standby Position */
+#define DAC_CTRLA_RUNSTDBY_Msk              (_U_(0x1) << DAC_CTRLA_RUNSTDBY_Pos)           /**< (DAC_CTRLA) Run in Standby Mask */
+#define DAC_CTRLA_RUNSTDBY                  DAC_CTRLA_RUNSTDBY_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use DAC_CTRLA_RUNSTDBY_Msk instead */
+#define DAC_CTRLA_MASK                      _U_(0x43)                                      /**< \deprecated (DAC_CTRLA) Register MASK  (Use DAC_CTRLA_Msk instead)  */
+#define DAC_CTRLA_Msk                       _U_(0x43)                                      /**< (DAC_CTRLA) Register Mask  */
+
+
+/* -------- DAC_CTRLB : (DAC Offset: 0x01) (R/W 8) Control B -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  EOEN:1;                    /**< bit:      0  External Output Enable                   */
+    uint8_t  IOEN:1;                    /**< bit:      1  Internal Output Enable                   */
+    uint8_t  LEFTADJ:1;                 /**< bit:      2  Left Adjusted Data                       */
+    uint8_t  VPD:1;                     /**< bit:      3  Voltage Pump Disable                     */
+    uint8_t  :1;                        /**< bit:      4  Reserved */
+    uint8_t  DITHER:1;                  /**< bit:      5  Dither Enable                            */
+    uint8_t  REFSEL:2;                  /**< bit:   6..7  Reference Selection                      */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} DAC_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_CTRLB_OFFSET                    (0x01)                                        /**<  (DAC_CTRLB) Control B  Offset */
+#define DAC_CTRLB_RESETVALUE                _U_(0x00)                                     /**<  (DAC_CTRLB) Control B  Reset Value */
+
+#define DAC_CTRLB_EOEN_Pos                  0                                              /**< (DAC_CTRLB) External Output Enable Position */
+#define DAC_CTRLB_EOEN_Msk                  (_U_(0x1) << DAC_CTRLB_EOEN_Pos)               /**< (DAC_CTRLB) External Output Enable Mask */
+#define DAC_CTRLB_EOEN                      DAC_CTRLB_EOEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use DAC_CTRLB_EOEN_Msk instead */
+#define DAC_CTRLB_IOEN_Pos                  1                                              /**< (DAC_CTRLB) Internal Output Enable Position */
+#define DAC_CTRLB_IOEN_Msk                  (_U_(0x1) << DAC_CTRLB_IOEN_Pos)               /**< (DAC_CTRLB) Internal Output Enable Mask */
+#define DAC_CTRLB_IOEN                      DAC_CTRLB_IOEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use DAC_CTRLB_IOEN_Msk instead */
+#define DAC_CTRLB_LEFTADJ_Pos               2                                              /**< (DAC_CTRLB) Left Adjusted Data Position */
+#define DAC_CTRLB_LEFTADJ_Msk               (_U_(0x1) << DAC_CTRLB_LEFTADJ_Pos)            /**< (DAC_CTRLB) Left Adjusted Data Mask */
+#define DAC_CTRLB_LEFTADJ                   DAC_CTRLB_LEFTADJ_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use DAC_CTRLB_LEFTADJ_Msk instead */
+#define DAC_CTRLB_VPD_Pos                   3                                              /**< (DAC_CTRLB) Voltage Pump Disable Position */
+#define DAC_CTRLB_VPD_Msk                   (_U_(0x1) << DAC_CTRLB_VPD_Pos)                /**< (DAC_CTRLB) Voltage Pump Disable Mask */
+#define DAC_CTRLB_VPD                       DAC_CTRLB_VPD_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use DAC_CTRLB_VPD_Msk instead */
+#define DAC_CTRLB_DITHER_Pos                5                                              /**< (DAC_CTRLB) Dither Enable Position */
+#define DAC_CTRLB_DITHER_Msk                (_U_(0x1) << DAC_CTRLB_DITHER_Pos)             /**< (DAC_CTRLB) Dither Enable Mask */
+#define DAC_CTRLB_DITHER                    DAC_CTRLB_DITHER_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use DAC_CTRLB_DITHER_Msk instead */
+#define DAC_CTRLB_REFSEL_Pos                6                                              /**< (DAC_CTRLB) Reference Selection Position */
+#define DAC_CTRLB_REFSEL_Msk                (_U_(0x3) << DAC_CTRLB_REFSEL_Pos)             /**< (DAC_CTRLB) Reference Selection Mask */
+#define DAC_CTRLB_REFSEL(value)             (DAC_CTRLB_REFSEL_Msk & ((value) << DAC_CTRLB_REFSEL_Pos))
+#define   DAC_CTRLB_REFSEL_INT1V_Val        _U_(0x0)                                       /**< (DAC_CTRLB) Internal 1.0V reference  */
+#define   DAC_CTRLB_REFSEL_AVCC_Val         _U_(0x1)                                       /**< (DAC_CTRLB) AVCC  */
+#define   DAC_CTRLB_REFSEL_VREFP_Val        _U_(0x2)                                       /**< (DAC_CTRLB) External reference  */
+#define DAC_CTRLB_REFSEL_INT1V              (DAC_CTRLB_REFSEL_INT1V_Val << DAC_CTRLB_REFSEL_Pos)  /**< (DAC_CTRLB) Internal 1.0V reference Position  */
+#define DAC_CTRLB_REFSEL_AVCC               (DAC_CTRLB_REFSEL_AVCC_Val << DAC_CTRLB_REFSEL_Pos)  /**< (DAC_CTRLB) AVCC Position  */
+#define DAC_CTRLB_REFSEL_VREFP              (DAC_CTRLB_REFSEL_VREFP_Val << DAC_CTRLB_REFSEL_Pos)  /**< (DAC_CTRLB) External reference Position  */
+#define DAC_CTRLB_MASK                      _U_(0xEF)                                      /**< \deprecated (DAC_CTRLB) Register MASK  (Use DAC_CTRLB_Msk instead)  */
+#define DAC_CTRLB_Msk                       _U_(0xEF)                                      /**< (DAC_CTRLB) Register Mask  */
+
+
+/* -------- DAC_EVCTRL : (DAC Offset: 0x02) (R/W 8) Event Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  STARTEI:1;                 /**< bit:      0  Start Conversion Event Input             */
+    uint8_t  EMPTYEO:1;                 /**< bit:      1  Data Buffer Empty Event Output           */
+    uint8_t  INVEI:1;                   /**< bit:      2  Invert Event Input                       */
+    uint8_t  :5;                        /**< bit:   3..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} DAC_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_EVCTRL_OFFSET                   (0x02)                                        /**<  (DAC_EVCTRL) Event Control  Offset */
+#define DAC_EVCTRL_RESETVALUE               _U_(0x00)                                     /**<  (DAC_EVCTRL) Event Control  Reset Value */
+
+#define DAC_EVCTRL_STARTEI_Pos              0                                              /**< (DAC_EVCTRL) Start Conversion Event Input Position */
+#define DAC_EVCTRL_STARTEI_Msk              (_U_(0x1) << DAC_EVCTRL_STARTEI_Pos)           /**< (DAC_EVCTRL) Start Conversion Event Input Mask */
+#define DAC_EVCTRL_STARTEI                  DAC_EVCTRL_STARTEI_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use DAC_EVCTRL_STARTEI_Msk instead */
+#define DAC_EVCTRL_EMPTYEO_Pos              1                                              /**< (DAC_EVCTRL) Data Buffer Empty Event Output Position */
+#define DAC_EVCTRL_EMPTYEO_Msk              (_U_(0x1) << DAC_EVCTRL_EMPTYEO_Pos)           /**< (DAC_EVCTRL) Data Buffer Empty Event Output Mask */
+#define DAC_EVCTRL_EMPTYEO                  DAC_EVCTRL_EMPTYEO_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use DAC_EVCTRL_EMPTYEO_Msk instead */
+#define DAC_EVCTRL_INVEI_Pos                2                                              /**< (DAC_EVCTRL) Invert Event Input Position */
+#define DAC_EVCTRL_INVEI_Msk                (_U_(0x1) << DAC_EVCTRL_INVEI_Pos)             /**< (DAC_EVCTRL) Invert Event Input Mask */
+#define DAC_EVCTRL_INVEI                    DAC_EVCTRL_INVEI_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use DAC_EVCTRL_INVEI_Msk instead */
+#define DAC_EVCTRL_MASK                     _U_(0x07)                                      /**< \deprecated (DAC_EVCTRL) Register MASK  (Use DAC_EVCTRL_Msk instead)  */
+#define DAC_EVCTRL_Msk                      _U_(0x07)                                      /**< (DAC_EVCTRL) Register Mask  */
+
+
+/* -------- DAC_INTENCLR : (DAC Offset: 0x04) (R/W 8) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  UNDERRUN:1;                /**< bit:      0  Underrun Interrupt Enable                */
+    uint8_t  EMPTY:1;                   /**< bit:      1  Data Buffer Empty Interrupt Enable       */
+    uint8_t  :6;                        /**< bit:   2..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} DAC_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_INTENCLR_OFFSET                 (0x04)                                        /**<  (DAC_INTENCLR) Interrupt Enable Clear  Offset */
+#define DAC_INTENCLR_RESETVALUE             _U_(0x00)                                     /**<  (DAC_INTENCLR) Interrupt Enable Clear  Reset Value */
+
+#define DAC_INTENCLR_UNDERRUN_Pos           0                                              /**< (DAC_INTENCLR) Underrun Interrupt Enable Position */
+#define DAC_INTENCLR_UNDERRUN_Msk           (_U_(0x1) << DAC_INTENCLR_UNDERRUN_Pos)        /**< (DAC_INTENCLR) Underrun Interrupt Enable Mask */
+#define DAC_INTENCLR_UNDERRUN               DAC_INTENCLR_UNDERRUN_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use DAC_INTENCLR_UNDERRUN_Msk instead */
+#define DAC_INTENCLR_EMPTY_Pos              1                                              /**< (DAC_INTENCLR) Data Buffer Empty Interrupt Enable Position */
+#define DAC_INTENCLR_EMPTY_Msk              (_U_(0x1) << DAC_INTENCLR_EMPTY_Pos)           /**< (DAC_INTENCLR) Data Buffer Empty Interrupt Enable Mask */
+#define DAC_INTENCLR_EMPTY                  DAC_INTENCLR_EMPTY_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use DAC_INTENCLR_EMPTY_Msk instead */
+#define DAC_INTENCLR_MASK                   _U_(0x03)                                      /**< \deprecated (DAC_INTENCLR) Register MASK  (Use DAC_INTENCLR_Msk instead)  */
+#define DAC_INTENCLR_Msk                    _U_(0x03)                                      /**< (DAC_INTENCLR) Register Mask  */
+
+
+/* -------- DAC_INTENSET : (DAC Offset: 0x05) (R/W 8) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  UNDERRUN:1;                /**< bit:      0  Underrun Interrupt Enable                */
+    uint8_t  EMPTY:1;                   /**< bit:      1  Data Buffer Empty Interrupt Enable       */
+    uint8_t  :6;                        /**< bit:   2..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} DAC_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_INTENSET_OFFSET                 (0x05)                                        /**<  (DAC_INTENSET) Interrupt Enable Set  Offset */
+#define DAC_INTENSET_RESETVALUE             _U_(0x00)                                     /**<  (DAC_INTENSET) Interrupt Enable Set  Reset Value */
+
+#define DAC_INTENSET_UNDERRUN_Pos           0                                              /**< (DAC_INTENSET) Underrun Interrupt Enable Position */
+#define DAC_INTENSET_UNDERRUN_Msk           (_U_(0x1) << DAC_INTENSET_UNDERRUN_Pos)        /**< (DAC_INTENSET) Underrun Interrupt Enable Mask */
+#define DAC_INTENSET_UNDERRUN               DAC_INTENSET_UNDERRUN_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use DAC_INTENSET_UNDERRUN_Msk instead */
+#define DAC_INTENSET_EMPTY_Pos              1                                              /**< (DAC_INTENSET) Data Buffer Empty Interrupt Enable Position */
+#define DAC_INTENSET_EMPTY_Msk              (_U_(0x1) << DAC_INTENSET_EMPTY_Pos)           /**< (DAC_INTENSET) Data Buffer Empty Interrupt Enable Mask */
+#define DAC_INTENSET_EMPTY                  DAC_INTENSET_EMPTY_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use DAC_INTENSET_EMPTY_Msk instead */
+#define DAC_INTENSET_MASK                   _U_(0x03)                                      /**< \deprecated (DAC_INTENSET) Register MASK  (Use DAC_INTENSET_Msk instead)  */
+#define DAC_INTENSET_Msk                    _U_(0x03)                                      /**< (DAC_INTENSET) Register Mask  */
+
+
+/* -------- DAC_INTFLAG : (DAC Offset: 0x06) (R/W 8) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t UNDERRUN:1;                /**< bit:      0  Underrun                                 */
+    __I uint8_t EMPTY:1;                   /**< bit:      1  Data Buffer Empty                        */
+    __I uint8_t :6;                        /**< bit:   2..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} DAC_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_INTFLAG_OFFSET                  (0x06)                                        /**<  (DAC_INTFLAG) Interrupt Flag Status and Clear  Offset */
+#define DAC_INTFLAG_RESETVALUE              _U_(0x00)                                     /**<  (DAC_INTFLAG) Interrupt Flag Status and Clear  Reset Value */
+
+#define DAC_INTFLAG_UNDERRUN_Pos            0                                              /**< (DAC_INTFLAG) Underrun Position */
+#define DAC_INTFLAG_UNDERRUN_Msk            (_U_(0x1) << DAC_INTFLAG_UNDERRUN_Pos)         /**< (DAC_INTFLAG) Underrun Mask */
+#define DAC_INTFLAG_UNDERRUN                DAC_INTFLAG_UNDERRUN_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use DAC_INTFLAG_UNDERRUN_Msk instead */
+#define DAC_INTFLAG_EMPTY_Pos               1                                              /**< (DAC_INTFLAG) Data Buffer Empty Position */
+#define DAC_INTFLAG_EMPTY_Msk               (_U_(0x1) << DAC_INTFLAG_EMPTY_Pos)            /**< (DAC_INTFLAG) Data Buffer Empty Mask */
+#define DAC_INTFLAG_EMPTY                   DAC_INTFLAG_EMPTY_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use DAC_INTFLAG_EMPTY_Msk instead */
+#define DAC_INTFLAG_MASK                    _U_(0x03)                                      /**< \deprecated (DAC_INTFLAG) Register MASK  (Use DAC_INTFLAG_Msk instead)  */
+#define DAC_INTFLAG_Msk                     _U_(0x03)                                      /**< (DAC_INTFLAG) Register Mask  */
+
+
+/* -------- DAC_STATUS : (DAC Offset: 0x07) (R/ 8) Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  READY:1;                   /**< bit:      0  Ready                                    */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} DAC_STATUS_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_STATUS_OFFSET                   (0x07)                                        /**<  (DAC_STATUS) Status  Offset */
+#define DAC_STATUS_RESETVALUE               _U_(0x00)                                     /**<  (DAC_STATUS) Status  Reset Value */
+
+#define DAC_STATUS_READY_Pos                0                                              /**< (DAC_STATUS) Ready Position */
+#define DAC_STATUS_READY_Msk                (_U_(0x1) << DAC_STATUS_READY_Pos)             /**< (DAC_STATUS) Ready Mask */
+#define DAC_STATUS_READY                    DAC_STATUS_READY_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use DAC_STATUS_READY_Msk instead */
+#define DAC_STATUS_MASK                     _U_(0x01)                                      /**< \deprecated (DAC_STATUS) Register MASK  (Use DAC_STATUS_Msk instead)  */
+#define DAC_STATUS_Msk                      _U_(0x01)                                      /**< (DAC_STATUS) Register Mask  */
+
+
+/* -------- DAC_DATA : (DAC Offset: 0x08) (/W 16) Data -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t DATA:16;                   /**< bit:  0..15  Data value to be converted               */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} DAC_DATA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_DATA_OFFSET                     (0x08)                                        /**<  (DAC_DATA) Data  Offset */
+#define DAC_DATA_RESETVALUE                 _U_(0x00)                                     /**<  (DAC_DATA) Data  Reset Value */
+
+#define DAC_DATA_DATA_Pos                   0                                              /**< (DAC_DATA) Data value to be converted Position */
+#define DAC_DATA_DATA_Msk                   (_U_(0xFFFF) << DAC_DATA_DATA_Pos)             /**< (DAC_DATA) Data value to be converted Mask */
+#define DAC_DATA_DATA(value)                (DAC_DATA_DATA_Msk & ((value) << DAC_DATA_DATA_Pos))
+#define DAC_DATA_MASK                       _U_(0xFFFF)                                    /**< \deprecated (DAC_DATA) Register MASK  (Use DAC_DATA_Msk instead)  */
+#define DAC_DATA_Msk                        _U_(0xFFFF)                                    /**< (DAC_DATA) Register Mask  */
+
+
+/* -------- DAC_DATABUF : (DAC Offset: 0x0c) (/W 16) Data Buffer -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t DATABUF:16;                /**< bit:  0..15  Data Buffer                              */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} DAC_DATABUF_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_DATABUF_OFFSET                  (0x0C)                                        /**<  (DAC_DATABUF) Data Buffer  Offset */
+#define DAC_DATABUF_RESETVALUE              _U_(0x00)                                     /**<  (DAC_DATABUF) Data Buffer  Reset Value */
+
+#define DAC_DATABUF_DATABUF_Pos             0                                              /**< (DAC_DATABUF) Data Buffer Position */
+#define DAC_DATABUF_DATABUF_Msk             (_U_(0xFFFF) << DAC_DATABUF_DATABUF_Pos)       /**< (DAC_DATABUF) Data Buffer Mask */
+#define DAC_DATABUF_DATABUF(value)          (DAC_DATABUF_DATABUF_Msk & ((value) << DAC_DATABUF_DATABUF_Pos))
+#define DAC_DATABUF_MASK                    _U_(0xFFFF)                                    /**< \deprecated (DAC_DATABUF) Register MASK  (Use DAC_DATABUF_Msk instead)  */
+#define DAC_DATABUF_Msk                     _U_(0xFFFF)                                    /**< (DAC_DATABUF) Register Mask  */
+
+
+/* -------- DAC_SYNCBUSY : (DAC Offset: 0x10) (R/ 32) Synchronization Busy -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint32_t ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint32_t DATA:1;                    /**< bit:      2  Data                                     */
+    uint32_t DATABUF:1;                 /**< bit:      3  Data Buffer                              */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DAC_SYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_SYNCBUSY_OFFSET                 (0x10)                                        /**<  (DAC_SYNCBUSY) Synchronization Busy  Offset */
+#define DAC_SYNCBUSY_RESETVALUE             _U_(0x00)                                     /**<  (DAC_SYNCBUSY) Synchronization Busy  Reset Value */
+
+#define DAC_SYNCBUSY_SWRST_Pos              0                                              /**< (DAC_SYNCBUSY) Software Reset Position */
+#define DAC_SYNCBUSY_SWRST_Msk              (_U_(0x1) << DAC_SYNCBUSY_SWRST_Pos)           /**< (DAC_SYNCBUSY) Software Reset Mask */
+#define DAC_SYNCBUSY_SWRST                  DAC_SYNCBUSY_SWRST_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use DAC_SYNCBUSY_SWRST_Msk instead */
+#define DAC_SYNCBUSY_ENABLE_Pos             1                                              /**< (DAC_SYNCBUSY) Enable Position */
+#define DAC_SYNCBUSY_ENABLE_Msk             (_U_(0x1) << DAC_SYNCBUSY_ENABLE_Pos)          /**< (DAC_SYNCBUSY) Enable Mask */
+#define DAC_SYNCBUSY_ENABLE                 DAC_SYNCBUSY_ENABLE_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DAC_SYNCBUSY_ENABLE_Msk instead */
+#define DAC_SYNCBUSY_DATA_Pos               2                                              /**< (DAC_SYNCBUSY) Data Position */
+#define DAC_SYNCBUSY_DATA_Msk               (_U_(0x1) << DAC_SYNCBUSY_DATA_Pos)            /**< (DAC_SYNCBUSY) Data Mask */
+#define DAC_SYNCBUSY_DATA                   DAC_SYNCBUSY_DATA_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use DAC_SYNCBUSY_DATA_Msk instead */
+#define DAC_SYNCBUSY_DATABUF_Pos            3                                              /**< (DAC_SYNCBUSY) Data Buffer Position */
+#define DAC_SYNCBUSY_DATABUF_Msk            (_U_(0x1) << DAC_SYNCBUSY_DATABUF_Pos)         /**< (DAC_SYNCBUSY) Data Buffer Mask */
+#define DAC_SYNCBUSY_DATABUF                DAC_SYNCBUSY_DATABUF_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use DAC_SYNCBUSY_DATABUF_Msk instead */
+#define DAC_SYNCBUSY_MASK                   _U_(0x0F)                                      /**< \deprecated (DAC_SYNCBUSY) Register MASK  (Use DAC_SYNCBUSY_Msk instead)  */
+#define DAC_SYNCBUSY_Msk                    _U_(0x0F)                                      /**< (DAC_SYNCBUSY) Register Mask  */
+
+
+/* -------- DAC_DBGCTRL : (DAC Offset: 0x14) (R/W 8) Debug Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DBGRUN:1;                  /**< bit:      0  Debug Run                                */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} DAC_DBGCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_DBGCTRL_OFFSET                  (0x14)                                        /**<  (DAC_DBGCTRL) Debug Control  Offset */
+#define DAC_DBGCTRL_RESETVALUE              _U_(0x00)                                     /**<  (DAC_DBGCTRL) Debug Control  Reset Value */
+
+#define DAC_DBGCTRL_DBGRUN_Pos              0                                              /**< (DAC_DBGCTRL) Debug Run Position */
+#define DAC_DBGCTRL_DBGRUN_Msk              (_U_(0x1) << DAC_DBGCTRL_DBGRUN_Pos)           /**< (DAC_DBGCTRL) Debug Run Mask */
+#define DAC_DBGCTRL_DBGRUN                  DAC_DBGCTRL_DBGRUN_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use DAC_DBGCTRL_DBGRUN_Msk instead */
+#define DAC_DBGCTRL_MASK                    _U_(0x01)                                      /**< \deprecated (DAC_DBGCTRL) Register MASK  (Use DAC_DBGCTRL_Msk instead)  */
+#define DAC_DBGCTRL_Msk                     _U_(0x01)                                      /**< (DAC_DBGCTRL) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief DAC hardware registers */
+typedef struct {  /* Digital Analog Converter */
+  __IO DAC_CTRLA_Type                 CTRLA;          /**< Offset: 0x00 (R/W   8) Control A */
+  __IO DAC_CTRLB_Type                 CTRLB;          /**< Offset: 0x01 (R/W   8) Control B */
+  __IO DAC_EVCTRL_Type                EVCTRL;         /**< Offset: 0x02 (R/W   8) Event Control */
+  __I  uint8_t                        Reserved1[1];
+  __IO DAC_INTENCLR_Type              INTENCLR;       /**< Offset: 0x04 (R/W   8) Interrupt Enable Clear */
+  __IO DAC_INTENSET_Type              INTENSET;       /**< Offset: 0x05 (R/W   8) Interrupt Enable Set */
+  __IO DAC_INTFLAG_Type               INTFLAG;        /**< Offset: 0x06 (R/W   8) Interrupt Flag Status and Clear */
+  __I  DAC_STATUS_Type                STATUS;         /**< Offset: 0x07 (R/    8) Status */
+  __O  DAC_DATA_Type                  DATA;           /**< Offset: 0x08 ( /W  16) Data */
+  __I  uint8_t                        Reserved2[2];
+  __O  DAC_DATABUF_Type               DATABUF;        /**< Offset: 0x0C ( /W  16) Data Buffer */
+  __I  uint8_t                        Reserved3[2];
+  __I  DAC_SYNCBUSY_Type              SYNCBUSY;       /**< Offset: 0x10 (R/   32) Synchronization Busy */
+  __IO DAC_DBGCTRL_Type               DBGCTRL;        /**< Offset: 0x14 (R/W   8) Debug Control */
+} Dac;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Digital Analog Converter */
+
+#endif /* _SAML10_DAC_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/component/dmac.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/dmac.h
@@ -1,0 +1,1158 @@
+/**
+ * \file
+ *
+ * \brief Component description for DMAC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_DMAC_COMPONENT_H_
+#define _SAML10_DMAC_COMPONENT_H_
+#define _SAML10_DMAC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML10 Direct Memory Access Controller
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR DMAC */
+/* ========================================================================== */
+
+#define DMAC_U2223                      /**< (DMAC) Module ID */
+#define REV_DMAC 0x240                  /**< (DMAC) Module revision */
+
+/* -------- DMAC_BTCTRL : (DMAC Offset: 0x00) (R/W 16) Block Transfer Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t VALID:1;                   /**< bit:      0  Descriptor Valid                         */
+    uint16_t EVOSEL:2;                  /**< bit:   1..2  Event Output Selection                   */
+    uint16_t BLOCKACT:2;                /**< bit:   3..4  Block Action                             */
+    uint16_t :3;                        /**< bit:   5..7  Reserved */
+    uint16_t BEATSIZE:2;                /**< bit:   8..9  Beat Size                                */
+    uint16_t SRCINC:1;                  /**< bit:     10  Source Address Increment Enable          */
+    uint16_t DSTINC:1;                  /**< bit:     11  Destination Address Increment Enable     */
+    uint16_t STEPSEL:1;                 /**< bit:     12  Step Selection                           */
+    uint16_t STEPSIZE:3;                /**< bit: 13..15  Address Increment Step Size              */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} DMAC_BTCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_BTCTRL_OFFSET                  (0x00)                                        /**<  (DMAC_BTCTRL) Block Transfer Control  Offset */
+#define DMAC_BTCTRL_RESETVALUE              _U_(0x00)                                     /**<  (DMAC_BTCTRL) Block Transfer Control  Reset Value */
+
+#define DMAC_BTCTRL_VALID_Pos               0                                              /**< (DMAC_BTCTRL) Descriptor Valid Position */
+#define DMAC_BTCTRL_VALID_Msk               (_U_(0x1) << DMAC_BTCTRL_VALID_Pos)            /**< (DMAC_BTCTRL) Descriptor Valid Mask */
+#define DMAC_BTCTRL_VALID                   DMAC_BTCTRL_VALID_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_BTCTRL_VALID_Msk instead */
+#define DMAC_BTCTRL_EVOSEL_Pos              1                                              /**< (DMAC_BTCTRL) Event Output Selection Position */
+#define DMAC_BTCTRL_EVOSEL_Msk              (_U_(0x3) << DMAC_BTCTRL_EVOSEL_Pos)           /**< (DMAC_BTCTRL) Event Output Selection Mask */
+#define DMAC_BTCTRL_EVOSEL(value)           (DMAC_BTCTRL_EVOSEL_Msk & ((value) << DMAC_BTCTRL_EVOSEL_Pos))
+#define   DMAC_BTCTRL_EVOSEL_DISABLE_Val    _U_(0x0)                                       /**< (DMAC_BTCTRL) Event generation disabled  */
+#define   DMAC_BTCTRL_EVOSEL_BLOCK_Val      _U_(0x1)                                       /**< (DMAC_BTCTRL) Event strobe when block transfer complete  */
+#define   DMAC_BTCTRL_EVOSEL_BEAT_Val       _U_(0x3)                                       /**< (DMAC_BTCTRL) Event strobe when beat transfer complete  */
+#define DMAC_BTCTRL_EVOSEL_DISABLE          (DMAC_BTCTRL_EVOSEL_DISABLE_Val << DMAC_BTCTRL_EVOSEL_Pos)  /**< (DMAC_BTCTRL) Event generation disabled Position  */
+#define DMAC_BTCTRL_EVOSEL_BLOCK            (DMAC_BTCTRL_EVOSEL_BLOCK_Val << DMAC_BTCTRL_EVOSEL_Pos)  /**< (DMAC_BTCTRL) Event strobe when block transfer complete Position  */
+#define DMAC_BTCTRL_EVOSEL_BEAT             (DMAC_BTCTRL_EVOSEL_BEAT_Val << DMAC_BTCTRL_EVOSEL_Pos)  /**< (DMAC_BTCTRL) Event strobe when beat transfer complete Position  */
+#define DMAC_BTCTRL_BLOCKACT_Pos            3                                              /**< (DMAC_BTCTRL) Block Action Position */
+#define DMAC_BTCTRL_BLOCKACT_Msk            (_U_(0x3) << DMAC_BTCTRL_BLOCKACT_Pos)         /**< (DMAC_BTCTRL) Block Action Mask */
+#define DMAC_BTCTRL_BLOCKACT(value)         (DMAC_BTCTRL_BLOCKACT_Msk & ((value) << DMAC_BTCTRL_BLOCKACT_Pos))
+#define   DMAC_BTCTRL_BLOCKACT_NOACT_Val    _U_(0x0)                                       /**< (DMAC_BTCTRL) Channel will be disabled if it is the last block transfer in the transaction  */
+#define   DMAC_BTCTRL_BLOCKACT_INT_Val      _U_(0x1)                                       /**< (DMAC_BTCTRL) Channel will be disabled if it is the last block transfer in the transaction and block interrupt  */
+#define   DMAC_BTCTRL_BLOCKACT_SUSPEND_Val  _U_(0x2)                                       /**< (DMAC_BTCTRL) Channel suspend operation is completed  */
+#define   DMAC_BTCTRL_BLOCKACT_BOTH_Val     _U_(0x3)                                       /**< (DMAC_BTCTRL) Both channel suspend operation and block interrupt  */
+#define DMAC_BTCTRL_BLOCKACT_NOACT          (DMAC_BTCTRL_BLOCKACT_NOACT_Val << DMAC_BTCTRL_BLOCKACT_Pos)  /**< (DMAC_BTCTRL) Channel will be disabled if it is the last block transfer in the transaction Position  */
+#define DMAC_BTCTRL_BLOCKACT_INT            (DMAC_BTCTRL_BLOCKACT_INT_Val << DMAC_BTCTRL_BLOCKACT_Pos)  /**< (DMAC_BTCTRL) Channel will be disabled if it is the last block transfer in the transaction and block interrupt Position  */
+#define DMAC_BTCTRL_BLOCKACT_SUSPEND        (DMAC_BTCTRL_BLOCKACT_SUSPEND_Val << DMAC_BTCTRL_BLOCKACT_Pos)  /**< (DMAC_BTCTRL) Channel suspend operation is completed Position  */
+#define DMAC_BTCTRL_BLOCKACT_BOTH           (DMAC_BTCTRL_BLOCKACT_BOTH_Val << DMAC_BTCTRL_BLOCKACT_Pos)  /**< (DMAC_BTCTRL) Both channel suspend operation and block interrupt Position  */
+#define DMAC_BTCTRL_BEATSIZE_Pos            8                                              /**< (DMAC_BTCTRL) Beat Size Position */
+#define DMAC_BTCTRL_BEATSIZE_Msk            (_U_(0x3) << DMAC_BTCTRL_BEATSIZE_Pos)         /**< (DMAC_BTCTRL) Beat Size Mask */
+#define DMAC_BTCTRL_BEATSIZE(value)         (DMAC_BTCTRL_BEATSIZE_Msk & ((value) << DMAC_BTCTRL_BEATSIZE_Pos))
+#define   DMAC_BTCTRL_BEATSIZE_BYTE_Val     _U_(0x0)                                       /**< (DMAC_BTCTRL) 8-bit bus transfer  */
+#define   DMAC_BTCTRL_BEATSIZE_HWORD_Val    _U_(0x1)                                       /**< (DMAC_BTCTRL) 16-bit bus transfer  */
+#define   DMAC_BTCTRL_BEATSIZE_WORD_Val     _U_(0x2)                                       /**< (DMAC_BTCTRL) 32-bit bus transfer  */
+#define DMAC_BTCTRL_BEATSIZE_BYTE           (DMAC_BTCTRL_BEATSIZE_BYTE_Val << DMAC_BTCTRL_BEATSIZE_Pos)  /**< (DMAC_BTCTRL) 8-bit bus transfer Position  */
+#define DMAC_BTCTRL_BEATSIZE_HWORD          (DMAC_BTCTRL_BEATSIZE_HWORD_Val << DMAC_BTCTRL_BEATSIZE_Pos)  /**< (DMAC_BTCTRL) 16-bit bus transfer Position  */
+#define DMAC_BTCTRL_BEATSIZE_WORD           (DMAC_BTCTRL_BEATSIZE_WORD_Val << DMAC_BTCTRL_BEATSIZE_Pos)  /**< (DMAC_BTCTRL) 32-bit bus transfer Position  */
+#define DMAC_BTCTRL_SRCINC_Pos              10                                             /**< (DMAC_BTCTRL) Source Address Increment Enable Position */
+#define DMAC_BTCTRL_SRCINC_Msk              (_U_(0x1) << DMAC_BTCTRL_SRCINC_Pos)           /**< (DMAC_BTCTRL) Source Address Increment Enable Mask */
+#define DMAC_BTCTRL_SRCINC                  DMAC_BTCTRL_SRCINC_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_BTCTRL_SRCINC_Msk instead */
+#define DMAC_BTCTRL_DSTINC_Pos              11                                             /**< (DMAC_BTCTRL) Destination Address Increment Enable Position */
+#define DMAC_BTCTRL_DSTINC_Msk              (_U_(0x1) << DMAC_BTCTRL_DSTINC_Pos)           /**< (DMAC_BTCTRL) Destination Address Increment Enable Mask */
+#define DMAC_BTCTRL_DSTINC                  DMAC_BTCTRL_DSTINC_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_BTCTRL_DSTINC_Msk instead */
+#define DMAC_BTCTRL_STEPSEL_Pos             12                                             /**< (DMAC_BTCTRL) Step Selection Position */
+#define DMAC_BTCTRL_STEPSEL_Msk             (_U_(0x1) << DMAC_BTCTRL_STEPSEL_Pos)          /**< (DMAC_BTCTRL) Step Selection Mask */
+#define DMAC_BTCTRL_STEPSEL                 DMAC_BTCTRL_STEPSEL_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_BTCTRL_STEPSEL_Msk instead */
+#define   DMAC_BTCTRL_STEPSEL_DST_Val       _U_(0x0)                                       /**< (DMAC_BTCTRL) Step size settings apply to the destination address  */
+#define   DMAC_BTCTRL_STEPSEL_SRC_Val       _U_(0x1)                                       /**< (DMAC_BTCTRL) Step size settings apply to the source address  */
+#define DMAC_BTCTRL_STEPSEL_DST             (DMAC_BTCTRL_STEPSEL_DST_Val << DMAC_BTCTRL_STEPSEL_Pos)  /**< (DMAC_BTCTRL) Step size settings apply to the destination address Position  */
+#define DMAC_BTCTRL_STEPSEL_SRC             (DMAC_BTCTRL_STEPSEL_SRC_Val << DMAC_BTCTRL_STEPSEL_Pos)  /**< (DMAC_BTCTRL) Step size settings apply to the source address Position  */
+#define DMAC_BTCTRL_STEPSIZE_Pos            13                                             /**< (DMAC_BTCTRL) Address Increment Step Size Position */
+#define DMAC_BTCTRL_STEPSIZE_Msk            (_U_(0x7) << DMAC_BTCTRL_STEPSIZE_Pos)         /**< (DMAC_BTCTRL) Address Increment Step Size Mask */
+#define DMAC_BTCTRL_STEPSIZE(value)         (DMAC_BTCTRL_STEPSIZE_Msk & ((value) << DMAC_BTCTRL_STEPSIZE_Pos))
+#define   DMAC_BTCTRL_STEPSIZE_X1_Val       _U_(0x0)                                       /**< (DMAC_BTCTRL) Next ADDR = ADDR + (BEATSIZE+1) * 1  */
+#define   DMAC_BTCTRL_STEPSIZE_X2_Val       _U_(0x1)                                       /**< (DMAC_BTCTRL) Next ADDR = ADDR + (BEATSIZE+1) * 2  */
+#define   DMAC_BTCTRL_STEPSIZE_X4_Val       _U_(0x2)                                       /**< (DMAC_BTCTRL) Next ADDR = ADDR + (BEATSIZE+1) * 4  */
+#define   DMAC_BTCTRL_STEPSIZE_X8_Val       _U_(0x3)                                       /**< (DMAC_BTCTRL) Next ADDR = ADDR + (BEATSIZE+1) * 8  */
+#define   DMAC_BTCTRL_STEPSIZE_X16_Val      _U_(0x4)                                       /**< (DMAC_BTCTRL) Next ADDR = ADDR + (BEATSIZE+1) * 16  */
+#define   DMAC_BTCTRL_STEPSIZE_X32_Val      _U_(0x5)                                       /**< (DMAC_BTCTRL) Next ADDR = ADDR + (BEATSIZE+1) * 32  */
+#define   DMAC_BTCTRL_STEPSIZE_X64_Val      _U_(0x6)                                       /**< (DMAC_BTCTRL) Next ADDR = ADDR + (BEATSIZE+1) * 64  */
+#define   DMAC_BTCTRL_STEPSIZE_X128_Val     _U_(0x7)                                       /**< (DMAC_BTCTRL) Next ADDR = ADDR + (BEATSIZE+1) * 128  */
+#define DMAC_BTCTRL_STEPSIZE_X1             (DMAC_BTCTRL_STEPSIZE_X1_Val << DMAC_BTCTRL_STEPSIZE_Pos)  /**< (DMAC_BTCTRL) Next ADDR = ADDR + (BEATSIZE+1) * 1 Position  */
+#define DMAC_BTCTRL_STEPSIZE_X2             (DMAC_BTCTRL_STEPSIZE_X2_Val << DMAC_BTCTRL_STEPSIZE_Pos)  /**< (DMAC_BTCTRL) Next ADDR = ADDR + (BEATSIZE+1) * 2 Position  */
+#define DMAC_BTCTRL_STEPSIZE_X4             (DMAC_BTCTRL_STEPSIZE_X4_Val << DMAC_BTCTRL_STEPSIZE_Pos)  /**< (DMAC_BTCTRL) Next ADDR = ADDR + (BEATSIZE+1) * 4 Position  */
+#define DMAC_BTCTRL_STEPSIZE_X8             (DMAC_BTCTRL_STEPSIZE_X8_Val << DMAC_BTCTRL_STEPSIZE_Pos)  /**< (DMAC_BTCTRL) Next ADDR = ADDR + (BEATSIZE+1) * 8 Position  */
+#define DMAC_BTCTRL_STEPSIZE_X16            (DMAC_BTCTRL_STEPSIZE_X16_Val << DMAC_BTCTRL_STEPSIZE_Pos)  /**< (DMAC_BTCTRL) Next ADDR = ADDR + (BEATSIZE+1) * 16 Position  */
+#define DMAC_BTCTRL_STEPSIZE_X32            (DMAC_BTCTRL_STEPSIZE_X32_Val << DMAC_BTCTRL_STEPSIZE_Pos)  /**< (DMAC_BTCTRL) Next ADDR = ADDR + (BEATSIZE+1) * 32 Position  */
+#define DMAC_BTCTRL_STEPSIZE_X64            (DMAC_BTCTRL_STEPSIZE_X64_Val << DMAC_BTCTRL_STEPSIZE_Pos)  /**< (DMAC_BTCTRL) Next ADDR = ADDR + (BEATSIZE+1) * 64 Position  */
+#define DMAC_BTCTRL_STEPSIZE_X128           (DMAC_BTCTRL_STEPSIZE_X128_Val << DMAC_BTCTRL_STEPSIZE_Pos)  /**< (DMAC_BTCTRL) Next ADDR = ADDR + (BEATSIZE+1) * 128 Position  */
+#define DMAC_BTCTRL_MASK                    _U_(0xFF1F)                                    /**< \deprecated (DMAC_BTCTRL) Register MASK  (Use DMAC_BTCTRL_Msk instead)  */
+#define DMAC_BTCTRL_Msk                     _U_(0xFF1F)                                    /**< (DMAC_BTCTRL) Register Mask  */
+
+
+/* -------- DMAC_BTCNT : (DMAC Offset: 0x02) (R/W 16) Block Transfer Count -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t BTCNT:16;                  /**< bit:  0..15  Block Transfer Count                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} DMAC_BTCNT_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_BTCNT_OFFSET                   (0x02)                                        /**<  (DMAC_BTCNT) Block Transfer Count  Offset */
+
+#define DMAC_BTCNT_BTCNT_Pos                0                                              /**< (DMAC_BTCNT) Block Transfer Count Position */
+#define DMAC_BTCNT_BTCNT_Msk                (_U_(0xFFFF) << DMAC_BTCNT_BTCNT_Pos)          /**< (DMAC_BTCNT) Block Transfer Count Mask */
+#define DMAC_BTCNT_BTCNT(value)             (DMAC_BTCNT_BTCNT_Msk & ((value) << DMAC_BTCNT_BTCNT_Pos))
+#define DMAC_BTCNT_MASK                     _U_(0xFFFF)                                    /**< \deprecated (DMAC_BTCNT) Register MASK  (Use DMAC_BTCNT_Msk instead)  */
+#define DMAC_BTCNT_Msk                      _U_(0xFFFF)                                    /**< (DMAC_BTCNT) Register Mask  */
+
+
+/* -------- DMAC_SRCADDR : (DMAC Offset: 0x04) (R/W 32) Block Transfer Source Address -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SRCADDR:32;                /**< bit:  0..31  Transfer Source Address                  */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DMAC_SRCADDR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_SRCADDR_OFFSET                 (0x04)                                        /**<  (DMAC_SRCADDR) Block Transfer Source Address  Offset */
+
+#define DMAC_SRCADDR_SRCADDR_Pos            0                                              /**< (DMAC_SRCADDR) Transfer Source Address Position */
+#define DMAC_SRCADDR_SRCADDR_Msk            (_U_(0xFFFFFFFF) << DMAC_SRCADDR_SRCADDR_Pos)  /**< (DMAC_SRCADDR) Transfer Source Address Mask */
+#define DMAC_SRCADDR_SRCADDR(value)         (DMAC_SRCADDR_SRCADDR_Msk & ((value) << DMAC_SRCADDR_SRCADDR_Pos))
+#define DMAC_SRCADDR_MASK                   _U_(0xFFFFFFFF)                                /**< \deprecated (DMAC_SRCADDR) Register MASK  (Use DMAC_SRCADDR_Msk instead)  */
+#define DMAC_SRCADDR_Msk                    _U_(0xFFFFFFFF)                                /**< (DMAC_SRCADDR) Register Mask  */
+
+
+/* -------- DMAC_DSTADDR : (DMAC Offset: 0x08) (R/W 32) Block Transfer Destination Address -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t DSTADDR:32;                /**< bit:  0..31  Transfer Destination Address             */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DMAC_DSTADDR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_DSTADDR_OFFSET                 (0x08)                                        /**<  (DMAC_DSTADDR) Block Transfer Destination Address  Offset */
+
+#define DMAC_DSTADDR_DSTADDR_Pos            0                                              /**< (DMAC_DSTADDR) Transfer Destination Address Position */
+#define DMAC_DSTADDR_DSTADDR_Msk            (_U_(0xFFFFFFFF) << DMAC_DSTADDR_DSTADDR_Pos)  /**< (DMAC_DSTADDR) Transfer Destination Address Mask */
+#define DMAC_DSTADDR_DSTADDR(value)         (DMAC_DSTADDR_DSTADDR_Msk & ((value) << DMAC_DSTADDR_DSTADDR_Pos))
+#define DMAC_DSTADDR_MASK                   _U_(0xFFFFFFFF)                                /**< \deprecated (DMAC_DSTADDR) Register MASK  (Use DMAC_DSTADDR_Msk instead)  */
+#define DMAC_DSTADDR_Msk                    _U_(0xFFFFFFFF)                                /**< (DMAC_DSTADDR) Register Mask  */
+
+
+/* -------- DMAC_DESCADDR : (DMAC Offset: 0x0c) (R/W 32) Next Descriptor Address -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t DESCADDR:32;               /**< bit:  0..31  Next Descriptor Address                  */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DMAC_DESCADDR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_DESCADDR_OFFSET                (0x0C)                                        /**<  (DMAC_DESCADDR) Next Descriptor Address  Offset */
+
+#define DMAC_DESCADDR_DESCADDR_Pos          0                                              /**< (DMAC_DESCADDR) Next Descriptor Address Position */
+#define DMAC_DESCADDR_DESCADDR_Msk          (_U_(0xFFFFFFFF) << DMAC_DESCADDR_DESCADDR_Pos)  /**< (DMAC_DESCADDR) Next Descriptor Address Mask */
+#define DMAC_DESCADDR_DESCADDR(value)       (DMAC_DESCADDR_DESCADDR_Msk & ((value) << DMAC_DESCADDR_DESCADDR_Pos))
+#define DMAC_DESCADDR_MASK                  _U_(0xFFFFFFFF)                                /**< \deprecated (DMAC_DESCADDR) Register MASK  (Use DMAC_DESCADDR_Msk instead)  */
+#define DMAC_DESCADDR_Msk                   _U_(0xFFFFFFFF)                                /**< (DMAC_DESCADDR) Register Mask  */
+
+
+/* -------- DMAC_CTRL : (DMAC Offset: 0x00) (R/W 16) Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint16_t DMAENABLE:1;               /**< bit:      1  DMA Enable                               */
+    uint16_t CRCENABLE:1;               /**< bit:      2  CRC Enable                               */
+    uint16_t :5;                        /**< bit:   3..7  Reserved */
+    uint16_t LVLEN0:1;                  /**< bit:      8  Priority Level 0 Enable                  */
+    uint16_t LVLEN1:1;                  /**< bit:      9  Priority Level 1 Enable                  */
+    uint16_t LVLEN2:1;                  /**< bit:     10  Priority Level 2 Enable                  */
+    uint16_t LVLEN3:1;                  /**< bit:     11  Priority Level 3 Enable                  */
+    uint16_t :4;                        /**< bit: 12..15  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint16_t :8;                        /**< bit:   0..7  Reserved */
+    uint16_t LVLEN:4;                   /**< bit:  8..11  Priority Level 3 Enable                  */
+    uint16_t :4;                        /**< bit: 12..15 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint16_t reg;                         /**< Type used for register access */
+} DMAC_CTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_CTRL_OFFSET                    (0x00)                                        /**<  (DMAC_CTRL) Control  Offset */
+#define DMAC_CTRL_RESETVALUE                _U_(0x00)                                     /**<  (DMAC_CTRL) Control  Reset Value */
+
+#define DMAC_CTRL_SWRST_Pos                 0                                              /**< (DMAC_CTRL) Software Reset Position */
+#define DMAC_CTRL_SWRST_Msk                 (_U_(0x1) << DMAC_CTRL_SWRST_Pos)              /**< (DMAC_CTRL) Software Reset Mask */
+#define DMAC_CTRL_SWRST                     DMAC_CTRL_SWRST_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CTRL_SWRST_Msk instead */
+#define DMAC_CTRL_DMAENABLE_Pos             1                                              /**< (DMAC_CTRL) DMA Enable Position */
+#define DMAC_CTRL_DMAENABLE_Msk             (_U_(0x1) << DMAC_CTRL_DMAENABLE_Pos)          /**< (DMAC_CTRL) DMA Enable Mask */
+#define DMAC_CTRL_DMAENABLE                 DMAC_CTRL_DMAENABLE_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CTRL_DMAENABLE_Msk instead */
+#define DMAC_CTRL_CRCENABLE_Pos             2                                              /**< (DMAC_CTRL) CRC Enable Position */
+#define DMAC_CTRL_CRCENABLE_Msk             (_U_(0x1) << DMAC_CTRL_CRCENABLE_Pos)          /**< (DMAC_CTRL) CRC Enable Mask */
+#define DMAC_CTRL_CRCENABLE                 DMAC_CTRL_CRCENABLE_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CTRL_CRCENABLE_Msk instead */
+#define DMAC_CTRL_LVLEN0_Pos                8                                              /**< (DMAC_CTRL) Priority Level 0 Enable Position */
+#define DMAC_CTRL_LVLEN0_Msk                (_U_(0x1) << DMAC_CTRL_LVLEN0_Pos)             /**< (DMAC_CTRL) Priority Level 0 Enable Mask */
+#define DMAC_CTRL_LVLEN0                    DMAC_CTRL_LVLEN0_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CTRL_LVLEN0_Msk instead */
+#define DMAC_CTRL_LVLEN1_Pos                9                                              /**< (DMAC_CTRL) Priority Level 1 Enable Position */
+#define DMAC_CTRL_LVLEN1_Msk                (_U_(0x1) << DMAC_CTRL_LVLEN1_Pos)             /**< (DMAC_CTRL) Priority Level 1 Enable Mask */
+#define DMAC_CTRL_LVLEN1                    DMAC_CTRL_LVLEN1_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CTRL_LVLEN1_Msk instead */
+#define DMAC_CTRL_LVLEN2_Pos                10                                             /**< (DMAC_CTRL) Priority Level 2 Enable Position */
+#define DMAC_CTRL_LVLEN2_Msk                (_U_(0x1) << DMAC_CTRL_LVLEN2_Pos)             /**< (DMAC_CTRL) Priority Level 2 Enable Mask */
+#define DMAC_CTRL_LVLEN2                    DMAC_CTRL_LVLEN2_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CTRL_LVLEN2_Msk instead */
+#define DMAC_CTRL_LVLEN3_Pos                11                                             /**< (DMAC_CTRL) Priority Level 3 Enable Position */
+#define DMAC_CTRL_LVLEN3_Msk                (_U_(0x1) << DMAC_CTRL_LVLEN3_Pos)             /**< (DMAC_CTRL) Priority Level 3 Enable Mask */
+#define DMAC_CTRL_LVLEN3                    DMAC_CTRL_LVLEN3_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CTRL_LVLEN3_Msk instead */
+#define DMAC_CTRL_MASK                      _U_(0xF07)                                     /**< \deprecated (DMAC_CTRL) Register MASK  (Use DMAC_CTRL_Msk instead)  */
+#define DMAC_CTRL_Msk                       _U_(0xF07)                                     /**< (DMAC_CTRL) Register Mask  */
+
+#define DMAC_CTRL_LVLEN_Pos                 8                                              /**< (DMAC_CTRL Position) Priority Level 3 Enable */
+#define DMAC_CTRL_LVLEN_Msk                 (_U_(0xF) << DMAC_CTRL_LVLEN_Pos)              /**< (DMAC_CTRL Mask) LVLEN */
+#define DMAC_CTRL_LVLEN(value)              (DMAC_CTRL_LVLEN_Msk & ((value) << DMAC_CTRL_LVLEN_Pos))  
+
+/* -------- DMAC_CRCCTRL : (DMAC Offset: 0x02) (R/W 16) CRC Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t CRCBEATSIZE:2;             /**< bit:   0..1  CRC Beat Size                            */
+    uint16_t CRCPOLY:2;                 /**< bit:   2..3  CRC Polynomial Type                      */
+    uint16_t :4;                        /**< bit:   4..7  Reserved */
+    uint16_t CRCSRC:6;                  /**< bit:  8..13  CRC Input Source                         */
+    uint16_t :2;                        /**< bit: 14..15  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} DMAC_CRCCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_CRCCTRL_OFFSET                 (0x02)                                        /**<  (DMAC_CRCCTRL) CRC Control  Offset */
+#define DMAC_CRCCTRL_RESETVALUE             _U_(0x00)                                     /**<  (DMAC_CRCCTRL) CRC Control  Reset Value */
+
+#define DMAC_CRCCTRL_CRCBEATSIZE_Pos        0                                              /**< (DMAC_CRCCTRL) CRC Beat Size Position */
+#define DMAC_CRCCTRL_CRCBEATSIZE_Msk        (_U_(0x3) << DMAC_CRCCTRL_CRCBEATSIZE_Pos)     /**< (DMAC_CRCCTRL) CRC Beat Size Mask */
+#define DMAC_CRCCTRL_CRCBEATSIZE(value)     (DMAC_CRCCTRL_CRCBEATSIZE_Msk & ((value) << DMAC_CRCCTRL_CRCBEATSIZE_Pos))
+#define   DMAC_CRCCTRL_CRCBEATSIZE_BYTE_Val _U_(0x0)                                       /**< (DMAC_CRCCTRL) 8-bit bus transfer  */
+#define   DMAC_CRCCTRL_CRCBEATSIZE_HWORD_Val _U_(0x1)                                       /**< (DMAC_CRCCTRL) 16-bit bus transfer  */
+#define   DMAC_CRCCTRL_CRCBEATSIZE_WORD_Val _U_(0x2)                                       /**< (DMAC_CRCCTRL) 32-bit bus transfer  */
+#define DMAC_CRCCTRL_CRCBEATSIZE_BYTE       (DMAC_CRCCTRL_CRCBEATSIZE_BYTE_Val << DMAC_CRCCTRL_CRCBEATSIZE_Pos)  /**< (DMAC_CRCCTRL) 8-bit bus transfer Position  */
+#define DMAC_CRCCTRL_CRCBEATSIZE_HWORD      (DMAC_CRCCTRL_CRCBEATSIZE_HWORD_Val << DMAC_CRCCTRL_CRCBEATSIZE_Pos)  /**< (DMAC_CRCCTRL) 16-bit bus transfer Position  */
+#define DMAC_CRCCTRL_CRCBEATSIZE_WORD       (DMAC_CRCCTRL_CRCBEATSIZE_WORD_Val << DMAC_CRCCTRL_CRCBEATSIZE_Pos)  /**< (DMAC_CRCCTRL) 32-bit bus transfer Position  */
+#define DMAC_CRCCTRL_CRCPOLY_Pos            2                                              /**< (DMAC_CRCCTRL) CRC Polynomial Type Position */
+#define DMAC_CRCCTRL_CRCPOLY_Msk            (_U_(0x3) << DMAC_CRCCTRL_CRCPOLY_Pos)         /**< (DMAC_CRCCTRL) CRC Polynomial Type Mask */
+#define DMAC_CRCCTRL_CRCPOLY(value)         (DMAC_CRCCTRL_CRCPOLY_Msk & ((value) << DMAC_CRCCTRL_CRCPOLY_Pos))
+#define   DMAC_CRCCTRL_CRCPOLY_CRC16_Val    _U_(0x0)                                       /**< (DMAC_CRCCTRL) CRC-16 (CRC-CCITT)  */
+#define   DMAC_CRCCTRL_CRCPOLY_CRC32_Val    _U_(0x1)                                       /**< (DMAC_CRCCTRL) CRC32 (IEEE 802.3)  */
+#define DMAC_CRCCTRL_CRCPOLY_CRC16          (DMAC_CRCCTRL_CRCPOLY_CRC16_Val << DMAC_CRCCTRL_CRCPOLY_Pos)  /**< (DMAC_CRCCTRL) CRC-16 (CRC-CCITT) Position  */
+#define DMAC_CRCCTRL_CRCPOLY_CRC32          (DMAC_CRCCTRL_CRCPOLY_CRC32_Val << DMAC_CRCCTRL_CRCPOLY_Pos)  /**< (DMAC_CRCCTRL) CRC32 (IEEE 802.3) Position  */
+#define DMAC_CRCCTRL_CRCSRC_Pos             8                                              /**< (DMAC_CRCCTRL) CRC Input Source Position */
+#define DMAC_CRCCTRL_CRCSRC_Msk             (_U_(0x3F) << DMAC_CRCCTRL_CRCSRC_Pos)         /**< (DMAC_CRCCTRL) CRC Input Source Mask */
+#define DMAC_CRCCTRL_CRCSRC(value)          (DMAC_CRCCTRL_CRCSRC_Msk & ((value) << DMAC_CRCCTRL_CRCSRC_Pos))
+#define   DMAC_CRCCTRL_CRCSRC_NOACT_Val     _U_(0x0)                                       /**< (DMAC_CRCCTRL) No action  */
+#define   DMAC_CRCCTRL_CRCSRC_IO_Val        _U_(0x1)                                       /**< (DMAC_CRCCTRL) I/O interface  */
+#define DMAC_CRCCTRL_CRCSRC_NOACT           (DMAC_CRCCTRL_CRCSRC_NOACT_Val << DMAC_CRCCTRL_CRCSRC_Pos)  /**< (DMAC_CRCCTRL) No action Position  */
+#define DMAC_CRCCTRL_CRCSRC_IO              (DMAC_CRCCTRL_CRCSRC_IO_Val << DMAC_CRCCTRL_CRCSRC_Pos)  /**< (DMAC_CRCCTRL) I/O interface Position  */
+#define DMAC_CRCCTRL_MASK                   _U_(0x3F0F)                                    /**< \deprecated (DMAC_CRCCTRL) Register MASK  (Use DMAC_CRCCTRL_Msk instead)  */
+#define DMAC_CRCCTRL_Msk                    _U_(0x3F0F)                                    /**< (DMAC_CRCCTRL) Register Mask  */
+
+
+/* -------- DMAC_CRCDATAIN : (DMAC Offset: 0x04) (R/W 32) CRC Data Input -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t CRCDATAIN:32;              /**< bit:  0..31  CRC Data Input                           */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DMAC_CRCDATAIN_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_CRCDATAIN_OFFSET               (0x04)                                        /**<  (DMAC_CRCDATAIN) CRC Data Input  Offset */
+#define DMAC_CRCDATAIN_RESETVALUE           _U_(0x00)                                     /**<  (DMAC_CRCDATAIN) CRC Data Input  Reset Value */
+
+#define DMAC_CRCDATAIN_CRCDATAIN_Pos        0                                              /**< (DMAC_CRCDATAIN) CRC Data Input Position */
+#define DMAC_CRCDATAIN_CRCDATAIN_Msk        (_U_(0xFFFFFFFF) << DMAC_CRCDATAIN_CRCDATAIN_Pos)  /**< (DMAC_CRCDATAIN) CRC Data Input Mask */
+#define DMAC_CRCDATAIN_CRCDATAIN(value)     (DMAC_CRCDATAIN_CRCDATAIN_Msk & ((value) << DMAC_CRCDATAIN_CRCDATAIN_Pos))
+#define DMAC_CRCDATAIN_MASK                 _U_(0xFFFFFFFF)                                /**< \deprecated (DMAC_CRCDATAIN) Register MASK  (Use DMAC_CRCDATAIN_Msk instead)  */
+#define DMAC_CRCDATAIN_Msk                  _U_(0xFFFFFFFF)                                /**< (DMAC_CRCDATAIN) Register Mask  */
+
+
+/* -------- DMAC_CRCCHKSUM : (DMAC Offset: 0x08) (R/W 32) CRC Checksum -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t CRCCHKSUM:32;              /**< bit:  0..31  CRC Checksum                             */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DMAC_CRCCHKSUM_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_CRCCHKSUM_OFFSET               (0x08)                                        /**<  (DMAC_CRCCHKSUM) CRC Checksum  Offset */
+#define DMAC_CRCCHKSUM_RESETVALUE           _U_(0x00)                                     /**<  (DMAC_CRCCHKSUM) CRC Checksum  Reset Value */
+
+#define DMAC_CRCCHKSUM_CRCCHKSUM_Pos        0                                              /**< (DMAC_CRCCHKSUM) CRC Checksum Position */
+#define DMAC_CRCCHKSUM_CRCCHKSUM_Msk        (_U_(0xFFFFFFFF) << DMAC_CRCCHKSUM_CRCCHKSUM_Pos)  /**< (DMAC_CRCCHKSUM) CRC Checksum Mask */
+#define DMAC_CRCCHKSUM_CRCCHKSUM(value)     (DMAC_CRCCHKSUM_CRCCHKSUM_Msk & ((value) << DMAC_CRCCHKSUM_CRCCHKSUM_Pos))
+#define DMAC_CRCCHKSUM_MASK                 _U_(0xFFFFFFFF)                                /**< \deprecated (DMAC_CRCCHKSUM) Register MASK  (Use DMAC_CRCCHKSUM_Msk instead)  */
+#define DMAC_CRCCHKSUM_Msk                  _U_(0xFFFFFFFF)                                /**< (DMAC_CRCCHKSUM) Register Mask  */
+
+
+/* -------- DMAC_CRCSTATUS : (DMAC Offset: 0x0c) (R/W 8) CRC Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  CRCBUSY:1;                 /**< bit:      0  CRC Module Busy                          */
+    uint8_t  CRCZERO:1;                 /**< bit:      1  CRC Zero                                 */
+    uint8_t  :6;                        /**< bit:   2..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} DMAC_CRCSTATUS_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_CRCSTATUS_OFFSET               (0x0C)                                        /**<  (DMAC_CRCSTATUS) CRC Status  Offset */
+#define DMAC_CRCSTATUS_RESETVALUE           _U_(0x00)                                     /**<  (DMAC_CRCSTATUS) CRC Status  Reset Value */
+
+#define DMAC_CRCSTATUS_CRCBUSY_Pos          0                                              /**< (DMAC_CRCSTATUS) CRC Module Busy Position */
+#define DMAC_CRCSTATUS_CRCBUSY_Msk          (_U_(0x1) << DMAC_CRCSTATUS_CRCBUSY_Pos)       /**< (DMAC_CRCSTATUS) CRC Module Busy Mask */
+#define DMAC_CRCSTATUS_CRCBUSY              DMAC_CRCSTATUS_CRCBUSY_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CRCSTATUS_CRCBUSY_Msk instead */
+#define DMAC_CRCSTATUS_CRCZERO_Pos          1                                              /**< (DMAC_CRCSTATUS) CRC Zero Position */
+#define DMAC_CRCSTATUS_CRCZERO_Msk          (_U_(0x1) << DMAC_CRCSTATUS_CRCZERO_Pos)       /**< (DMAC_CRCSTATUS) CRC Zero Mask */
+#define DMAC_CRCSTATUS_CRCZERO              DMAC_CRCSTATUS_CRCZERO_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CRCSTATUS_CRCZERO_Msk instead */
+#define DMAC_CRCSTATUS_MASK                 _U_(0x03)                                      /**< \deprecated (DMAC_CRCSTATUS) Register MASK  (Use DMAC_CRCSTATUS_Msk instead)  */
+#define DMAC_CRCSTATUS_Msk                  _U_(0x03)                                      /**< (DMAC_CRCSTATUS) Register Mask  */
+
+
+/* -------- DMAC_DBGCTRL : (DMAC Offset: 0x0d) (R/W 8) Debug Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DBGRUN:1;                  /**< bit:      0  Debug Run                                */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} DMAC_DBGCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_DBGCTRL_OFFSET                 (0x0D)                                        /**<  (DMAC_DBGCTRL) Debug Control  Offset */
+#define DMAC_DBGCTRL_RESETVALUE             _U_(0x00)                                     /**<  (DMAC_DBGCTRL) Debug Control  Reset Value */
+
+#define DMAC_DBGCTRL_DBGRUN_Pos             0                                              /**< (DMAC_DBGCTRL) Debug Run Position */
+#define DMAC_DBGCTRL_DBGRUN_Msk             (_U_(0x1) << DMAC_DBGCTRL_DBGRUN_Pos)          /**< (DMAC_DBGCTRL) Debug Run Mask */
+#define DMAC_DBGCTRL_DBGRUN                 DMAC_DBGCTRL_DBGRUN_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_DBGCTRL_DBGRUN_Msk instead */
+#define DMAC_DBGCTRL_MASK                   _U_(0x01)                                      /**< \deprecated (DMAC_DBGCTRL) Register MASK  (Use DMAC_DBGCTRL_Msk instead)  */
+#define DMAC_DBGCTRL_Msk                    _U_(0x01)                                      /**< (DMAC_DBGCTRL) Register Mask  */
+
+
+/* -------- DMAC_QOSCTRL : (DMAC Offset: 0x0e) (R/W 8) QOS Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  WRBQOS:2;                  /**< bit:   0..1  Write-Back Quality of Service            */
+    uint8_t  FQOS:2;                    /**< bit:   2..3  Fetch Quality of Service                 */
+    uint8_t  DQOS:2;                    /**< bit:   4..5  Data Transfer Quality of Service         */
+    uint8_t  :2;                        /**< bit:   6..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} DMAC_QOSCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_QOSCTRL_OFFSET                 (0x0E)                                        /**<  (DMAC_QOSCTRL) QOS Control  Offset */
+#define DMAC_QOSCTRL_RESETVALUE             _U_(0x2A)                                     /**<  (DMAC_QOSCTRL) QOS Control  Reset Value */
+
+#define DMAC_QOSCTRL_WRBQOS_Pos             0                                              /**< (DMAC_QOSCTRL) Write-Back Quality of Service Position */
+#define DMAC_QOSCTRL_WRBQOS_Msk             (_U_(0x3) << DMAC_QOSCTRL_WRBQOS_Pos)          /**< (DMAC_QOSCTRL) Write-Back Quality of Service Mask */
+#define DMAC_QOSCTRL_WRBQOS(value)          (DMAC_QOSCTRL_WRBQOS_Msk & ((value) << DMAC_QOSCTRL_WRBQOS_Pos))
+#define   DMAC_QOSCTRL_WRBQOS_DISABLE_Val   _U_(0x0)                                       /**< (DMAC_QOSCTRL) Background (no sensitive operation)  */
+#define   DMAC_QOSCTRL_WRBQOS_LOW_Val       _U_(0x1)                                       /**< (DMAC_QOSCTRL) Sensitive Bandwidth  */
+#define   DMAC_QOSCTRL_WRBQOS_MEDIUM_Val    _U_(0x2)                                       /**< (DMAC_QOSCTRL) Sensitive Latency  */
+#define   DMAC_QOSCTRL_WRBQOS_HIGH_Val      _U_(0x3)                                       /**< (DMAC_QOSCTRL) Critical Latency  */
+#define DMAC_QOSCTRL_WRBQOS_DISABLE         (DMAC_QOSCTRL_WRBQOS_DISABLE_Val << DMAC_QOSCTRL_WRBQOS_Pos)  /**< (DMAC_QOSCTRL) Background (no sensitive operation) Position  */
+#define DMAC_QOSCTRL_WRBQOS_LOW             (DMAC_QOSCTRL_WRBQOS_LOW_Val << DMAC_QOSCTRL_WRBQOS_Pos)  /**< (DMAC_QOSCTRL) Sensitive Bandwidth Position  */
+#define DMAC_QOSCTRL_WRBQOS_MEDIUM          (DMAC_QOSCTRL_WRBQOS_MEDIUM_Val << DMAC_QOSCTRL_WRBQOS_Pos)  /**< (DMAC_QOSCTRL) Sensitive Latency Position  */
+#define DMAC_QOSCTRL_WRBQOS_HIGH            (DMAC_QOSCTRL_WRBQOS_HIGH_Val << DMAC_QOSCTRL_WRBQOS_Pos)  /**< (DMAC_QOSCTRL) Critical Latency Position  */
+#define DMAC_QOSCTRL_FQOS_Pos               2                                              /**< (DMAC_QOSCTRL) Fetch Quality of Service Position */
+#define DMAC_QOSCTRL_FQOS_Msk               (_U_(0x3) << DMAC_QOSCTRL_FQOS_Pos)            /**< (DMAC_QOSCTRL) Fetch Quality of Service Mask */
+#define DMAC_QOSCTRL_FQOS(value)            (DMAC_QOSCTRL_FQOS_Msk & ((value) << DMAC_QOSCTRL_FQOS_Pos))
+#define   DMAC_QOSCTRL_FQOS_DISABLE_Val     _U_(0x0)                                       /**< (DMAC_QOSCTRL) Background (no sensitive operation)  */
+#define   DMAC_QOSCTRL_FQOS_LOW_Val         _U_(0x1)                                       /**< (DMAC_QOSCTRL) Sensitive Bandwidth  */
+#define   DMAC_QOSCTRL_FQOS_MEDIUM_Val      _U_(0x2)                                       /**< (DMAC_QOSCTRL) Sensitive Latency  */
+#define   DMAC_QOSCTRL_FQOS_HIGH_Val        _U_(0x3)                                       /**< (DMAC_QOSCTRL) Critical Latency  */
+#define DMAC_QOSCTRL_FQOS_DISABLE           (DMAC_QOSCTRL_FQOS_DISABLE_Val << DMAC_QOSCTRL_FQOS_Pos)  /**< (DMAC_QOSCTRL) Background (no sensitive operation) Position  */
+#define DMAC_QOSCTRL_FQOS_LOW               (DMAC_QOSCTRL_FQOS_LOW_Val << DMAC_QOSCTRL_FQOS_Pos)  /**< (DMAC_QOSCTRL) Sensitive Bandwidth Position  */
+#define DMAC_QOSCTRL_FQOS_MEDIUM            (DMAC_QOSCTRL_FQOS_MEDIUM_Val << DMAC_QOSCTRL_FQOS_Pos)  /**< (DMAC_QOSCTRL) Sensitive Latency Position  */
+#define DMAC_QOSCTRL_FQOS_HIGH              (DMAC_QOSCTRL_FQOS_HIGH_Val << DMAC_QOSCTRL_FQOS_Pos)  /**< (DMAC_QOSCTRL) Critical Latency Position  */
+#define DMAC_QOSCTRL_DQOS_Pos               4                                              /**< (DMAC_QOSCTRL) Data Transfer Quality of Service Position */
+#define DMAC_QOSCTRL_DQOS_Msk               (_U_(0x3) << DMAC_QOSCTRL_DQOS_Pos)            /**< (DMAC_QOSCTRL) Data Transfer Quality of Service Mask */
+#define DMAC_QOSCTRL_DQOS(value)            (DMAC_QOSCTRL_DQOS_Msk & ((value) << DMAC_QOSCTRL_DQOS_Pos))
+#define   DMAC_QOSCTRL_DQOS_DISABLE_Val     _U_(0x0)                                       /**< (DMAC_QOSCTRL) Background (no sensitive operation)  */
+#define   DMAC_QOSCTRL_DQOS_LOW_Val         _U_(0x1)                                       /**< (DMAC_QOSCTRL) Sensitive Bandwidth  */
+#define   DMAC_QOSCTRL_DQOS_MEDIUM_Val      _U_(0x2)                                       /**< (DMAC_QOSCTRL) Sensitive Latency  */
+#define   DMAC_QOSCTRL_DQOS_HIGH_Val        _U_(0x3)                                       /**< (DMAC_QOSCTRL) Critical Latency  */
+#define DMAC_QOSCTRL_DQOS_DISABLE           (DMAC_QOSCTRL_DQOS_DISABLE_Val << DMAC_QOSCTRL_DQOS_Pos)  /**< (DMAC_QOSCTRL) Background (no sensitive operation) Position  */
+#define DMAC_QOSCTRL_DQOS_LOW               (DMAC_QOSCTRL_DQOS_LOW_Val << DMAC_QOSCTRL_DQOS_Pos)  /**< (DMAC_QOSCTRL) Sensitive Bandwidth Position  */
+#define DMAC_QOSCTRL_DQOS_MEDIUM            (DMAC_QOSCTRL_DQOS_MEDIUM_Val << DMAC_QOSCTRL_DQOS_Pos)  /**< (DMAC_QOSCTRL) Sensitive Latency Position  */
+#define DMAC_QOSCTRL_DQOS_HIGH              (DMAC_QOSCTRL_DQOS_HIGH_Val << DMAC_QOSCTRL_DQOS_Pos)  /**< (DMAC_QOSCTRL) Critical Latency Position  */
+#define DMAC_QOSCTRL_MASK                   _U_(0x3F)                                      /**< \deprecated (DMAC_QOSCTRL) Register MASK  (Use DMAC_QOSCTRL_Msk instead)  */
+#define DMAC_QOSCTRL_Msk                    _U_(0x3F)                                      /**< (DMAC_QOSCTRL) Register Mask  */
+
+
+/* -------- DMAC_SWTRIGCTRL : (DMAC Offset: 0x10) (R/W 32) Software Trigger Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SWTRIG0:1;                 /**< bit:      0  Channel 0 Software Trigger               */
+    uint32_t SWTRIG1:1;                 /**< bit:      1  Channel 1 Software Trigger               */
+    uint32_t SWTRIG2:1;                 /**< bit:      2  Channel 2 Software Trigger               */
+    uint32_t SWTRIG3:1;                 /**< bit:      3  Channel 3 Software Trigger               */
+    uint32_t SWTRIG4:1;                 /**< bit:      4  Channel 4 Software Trigger               */
+    uint32_t SWTRIG5:1;                 /**< bit:      5  Channel 5 Software Trigger               */
+    uint32_t SWTRIG6:1;                 /**< bit:      6  Channel 6 Software Trigger               */
+    uint32_t SWTRIG7:1;                 /**< bit:      7  Channel 7 Software Trigger               */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t SWTRIG:8;                  /**< bit:   0..7  Channel 7 Software Trigger               */
+    uint32_t :24;                       /**< bit:  8..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} DMAC_SWTRIGCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_SWTRIGCTRL_OFFSET              (0x10)                                        /**<  (DMAC_SWTRIGCTRL) Software Trigger Control  Offset */
+#define DMAC_SWTRIGCTRL_RESETVALUE          _U_(0x00)                                     /**<  (DMAC_SWTRIGCTRL) Software Trigger Control  Reset Value */
+
+#define DMAC_SWTRIGCTRL_SWTRIG0_Pos         0                                              /**< (DMAC_SWTRIGCTRL) Channel 0 Software Trigger Position */
+#define DMAC_SWTRIGCTRL_SWTRIG0_Msk         (_U_(0x1) << DMAC_SWTRIGCTRL_SWTRIG0_Pos)      /**< (DMAC_SWTRIGCTRL) Channel 0 Software Trigger Mask */
+#define DMAC_SWTRIGCTRL_SWTRIG0             DMAC_SWTRIGCTRL_SWTRIG0_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_SWTRIGCTRL_SWTRIG0_Msk instead */
+#define DMAC_SWTRIGCTRL_SWTRIG1_Pos         1                                              /**< (DMAC_SWTRIGCTRL) Channel 1 Software Trigger Position */
+#define DMAC_SWTRIGCTRL_SWTRIG1_Msk         (_U_(0x1) << DMAC_SWTRIGCTRL_SWTRIG1_Pos)      /**< (DMAC_SWTRIGCTRL) Channel 1 Software Trigger Mask */
+#define DMAC_SWTRIGCTRL_SWTRIG1             DMAC_SWTRIGCTRL_SWTRIG1_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_SWTRIGCTRL_SWTRIG1_Msk instead */
+#define DMAC_SWTRIGCTRL_SWTRIG2_Pos         2                                              /**< (DMAC_SWTRIGCTRL) Channel 2 Software Trigger Position */
+#define DMAC_SWTRIGCTRL_SWTRIG2_Msk         (_U_(0x1) << DMAC_SWTRIGCTRL_SWTRIG2_Pos)      /**< (DMAC_SWTRIGCTRL) Channel 2 Software Trigger Mask */
+#define DMAC_SWTRIGCTRL_SWTRIG2             DMAC_SWTRIGCTRL_SWTRIG2_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_SWTRIGCTRL_SWTRIG2_Msk instead */
+#define DMAC_SWTRIGCTRL_SWTRIG3_Pos         3                                              /**< (DMAC_SWTRIGCTRL) Channel 3 Software Trigger Position */
+#define DMAC_SWTRIGCTRL_SWTRIG3_Msk         (_U_(0x1) << DMAC_SWTRIGCTRL_SWTRIG3_Pos)      /**< (DMAC_SWTRIGCTRL) Channel 3 Software Trigger Mask */
+#define DMAC_SWTRIGCTRL_SWTRIG3             DMAC_SWTRIGCTRL_SWTRIG3_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_SWTRIGCTRL_SWTRIG3_Msk instead */
+#define DMAC_SWTRIGCTRL_SWTRIG4_Pos         4                                              /**< (DMAC_SWTRIGCTRL) Channel 4 Software Trigger Position */
+#define DMAC_SWTRIGCTRL_SWTRIG4_Msk         (_U_(0x1) << DMAC_SWTRIGCTRL_SWTRIG4_Pos)      /**< (DMAC_SWTRIGCTRL) Channel 4 Software Trigger Mask */
+#define DMAC_SWTRIGCTRL_SWTRIG4             DMAC_SWTRIGCTRL_SWTRIG4_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_SWTRIGCTRL_SWTRIG4_Msk instead */
+#define DMAC_SWTRIGCTRL_SWTRIG5_Pos         5                                              /**< (DMAC_SWTRIGCTRL) Channel 5 Software Trigger Position */
+#define DMAC_SWTRIGCTRL_SWTRIG5_Msk         (_U_(0x1) << DMAC_SWTRIGCTRL_SWTRIG5_Pos)      /**< (DMAC_SWTRIGCTRL) Channel 5 Software Trigger Mask */
+#define DMAC_SWTRIGCTRL_SWTRIG5             DMAC_SWTRIGCTRL_SWTRIG5_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_SWTRIGCTRL_SWTRIG5_Msk instead */
+#define DMAC_SWTRIGCTRL_SWTRIG6_Pos         6                                              /**< (DMAC_SWTRIGCTRL) Channel 6 Software Trigger Position */
+#define DMAC_SWTRIGCTRL_SWTRIG6_Msk         (_U_(0x1) << DMAC_SWTRIGCTRL_SWTRIG6_Pos)      /**< (DMAC_SWTRIGCTRL) Channel 6 Software Trigger Mask */
+#define DMAC_SWTRIGCTRL_SWTRIG6             DMAC_SWTRIGCTRL_SWTRIG6_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_SWTRIGCTRL_SWTRIG6_Msk instead */
+#define DMAC_SWTRIGCTRL_SWTRIG7_Pos         7                                              /**< (DMAC_SWTRIGCTRL) Channel 7 Software Trigger Position */
+#define DMAC_SWTRIGCTRL_SWTRIG7_Msk         (_U_(0x1) << DMAC_SWTRIGCTRL_SWTRIG7_Pos)      /**< (DMAC_SWTRIGCTRL) Channel 7 Software Trigger Mask */
+#define DMAC_SWTRIGCTRL_SWTRIG7             DMAC_SWTRIGCTRL_SWTRIG7_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_SWTRIGCTRL_SWTRIG7_Msk instead */
+#define DMAC_SWTRIGCTRL_MASK                _U_(0xFF)                                      /**< \deprecated (DMAC_SWTRIGCTRL) Register MASK  (Use DMAC_SWTRIGCTRL_Msk instead)  */
+#define DMAC_SWTRIGCTRL_Msk                 _U_(0xFF)                                      /**< (DMAC_SWTRIGCTRL) Register Mask  */
+
+#define DMAC_SWTRIGCTRL_SWTRIG_Pos          0                                              /**< (DMAC_SWTRIGCTRL Position) Channel 7 Software Trigger */
+#define DMAC_SWTRIGCTRL_SWTRIG_Msk          (_U_(0xFF) << DMAC_SWTRIGCTRL_SWTRIG_Pos)      /**< (DMAC_SWTRIGCTRL Mask) SWTRIG */
+#define DMAC_SWTRIGCTRL_SWTRIG(value)       (DMAC_SWTRIGCTRL_SWTRIG_Msk & ((value) << DMAC_SWTRIGCTRL_SWTRIG_Pos))  
+
+/* -------- DMAC_PRICTRL0 : (DMAC Offset: 0x14) (R/W 32) Priority Control 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t LVLPRI0:3;                 /**< bit:   0..2  Level 0 Channel Priority Number          */
+    uint32_t :4;                        /**< bit:   3..6  Reserved */
+    uint32_t RRLVLEN0:1;                /**< bit:      7  Level 0 Round-Robin Scheduling Enable    */
+    uint32_t LVLPRI1:3;                 /**< bit:  8..10  Level 1 Channel Priority Number          */
+    uint32_t :4;                        /**< bit: 11..14  Reserved */
+    uint32_t RRLVLEN1:1;                /**< bit:     15  Level 1 Round-Robin Scheduling Enable    */
+    uint32_t LVLPRI2:3;                 /**< bit: 16..18  Level 2 Channel Priority Number          */
+    uint32_t :4;                        /**< bit: 19..22  Reserved */
+    uint32_t RRLVLEN2:1;                /**< bit:     23  Level 2 Round-Robin Scheduling Enable    */
+    uint32_t LVLPRI3:3;                 /**< bit: 24..26  Level 3 Channel Priority Number          */
+    uint32_t :4;                        /**< bit: 27..30  Reserved */
+    uint32_t RRLVLEN3:1;                /**< bit:     31  Level 3 Round-Robin Scheduling Enable    */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DMAC_PRICTRL0_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_PRICTRL0_OFFSET                (0x14)                                        /**<  (DMAC_PRICTRL0) Priority Control 0  Offset */
+#define DMAC_PRICTRL0_RESETVALUE            _U_(0x00)                                     /**<  (DMAC_PRICTRL0) Priority Control 0  Reset Value */
+
+#define DMAC_PRICTRL0_LVLPRI0_Pos           0                                              /**< (DMAC_PRICTRL0) Level 0 Channel Priority Number Position */
+#define DMAC_PRICTRL0_LVLPRI0_Msk           (_U_(0x7) << DMAC_PRICTRL0_LVLPRI0_Pos)        /**< (DMAC_PRICTRL0) Level 0 Channel Priority Number Mask */
+#define DMAC_PRICTRL0_LVLPRI0(value)        (DMAC_PRICTRL0_LVLPRI0_Msk & ((value) << DMAC_PRICTRL0_LVLPRI0_Pos))
+#define DMAC_PRICTRL0_RRLVLEN0_Pos          7                                              /**< (DMAC_PRICTRL0) Level 0 Round-Robin Scheduling Enable Position */
+#define DMAC_PRICTRL0_RRLVLEN0_Msk          (_U_(0x1) << DMAC_PRICTRL0_RRLVLEN0_Pos)       /**< (DMAC_PRICTRL0) Level 0 Round-Robin Scheduling Enable Mask */
+#define DMAC_PRICTRL0_RRLVLEN0              DMAC_PRICTRL0_RRLVLEN0_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_PRICTRL0_RRLVLEN0_Msk instead */
+#define DMAC_PRICTRL0_LVLPRI1_Pos           8                                              /**< (DMAC_PRICTRL0) Level 1 Channel Priority Number Position */
+#define DMAC_PRICTRL0_LVLPRI1_Msk           (_U_(0x7) << DMAC_PRICTRL0_LVLPRI1_Pos)        /**< (DMAC_PRICTRL0) Level 1 Channel Priority Number Mask */
+#define DMAC_PRICTRL0_LVLPRI1(value)        (DMAC_PRICTRL0_LVLPRI1_Msk & ((value) << DMAC_PRICTRL0_LVLPRI1_Pos))
+#define DMAC_PRICTRL0_RRLVLEN1_Pos          15                                             /**< (DMAC_PRICTRL0) Level 1 Round-Robin Scheduling Enable Position */
+#define DMAC_PRICTRL0_RRLVLEN1_Msk          (_U_(0x1) << DMAC_PRICTRL0_RRLVLEN1_Pos)       /**< (DMAC_PRICTRL0) Level 1 Round-Robin Scheduling Enable Mask */
+#define DMAC_PRICTRL0_RRLVLEN1              DMAC_PRICTRL0_RRLVLEN1_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_PRICTRL0_RRLVLEN1_Msk instead */
+#define DMAC_PRICTRL0_LVLPRI2_Pos           16                                             /**< (DMAC_PRICTRL0) Level 2 Channel Priority Number Position */
+#define DMAC_PRICTRL0_LVLPRI2_Msk           (_U_(0x7) << DMAC_PRICTRL0_LVLPRI2_Pos)        /**< (DMAC_PRICTRL0) Level 2 Channel Priority Number Mask */
+#define DMAC_PRICTRL0_LVLPRI2(value)        (DMAC_PRICTRL0_LVLPRI2_Msk & ((value) << DMAC_PRICTRL0_LVLPRI2_Pos))
+#define DMAC_PRICTRL0_RRLVLEN2_Pos          23                                             /**< (DMAC_PRICTRL0) Level 2 Round-Robin Scheduling Enable Position */
+#define DMAC_PRICTRL0_RRLVLEN2_Msk          (_U_(0x1) << DMAC_PRICTRL0_RRLVLEN2_Pos)       /**< (DMAC_PRICTRL0) Level 2 Round-Robin Scheduling Enable Mask */
+#define DMAC_PRICTRL0_RRLVLEN2              DMAC_PRICTRL0_RRLVLEN2_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_PRICTRL0_RRLVLEN2_Msk instead */
+#define DMAC_PRICTRL0_LVLPRI3_Pos           24                                             /**< (DMAC_PRICTRL0) Level 3 Channel Priority Number Position */
+#define DMAC_PRICTRL0_LVLPRI3_Msk           (_U_(0x7) << DMAC_PRICTRL0_LVLPRI3_Pos)        /**< (DMAC_PRICTRL0) Level 3 Channel Priority Number Mask */
+#define DMAC_PRICTRL0_LVLPRI3(value)        (DMAC_PRICTRL0_LVLPRI3_Msk & ((value) << DMAC_PRICTRL0_LVLPRI3_Pos))
+#define DMAC_PRICTRL0_RRLVLEN3_Pos          31                                             /**< (DMAC_PRICTRL0) Level 3 Round-Robin Scheduling Enable Position */
+#define DMAC_PRICTRL0_RRLVLEN3_Msk          (_U_(0x1) << DMAC_PRICTRL0_RRLVLEN3_Pos)       /**< (DMAC_PRICTRL0) Level 3 Round-Robin Scheduling Enable Mask */
+#define DMAC_PRICTRL0_RRLVLEN3              DMAC_PRICTRL0_RRLVLEN3_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_PRICTRL0_RRLVLEN3_Msk instead */
+#define DMAC_PRICTRL0_MASK                  _U_(0x87878787)                                /**< \deprecated (DMAC_PRICTRL0) Register MASK  (Use DMAC_PRICTRL0_Msk instead)  */
+#define DMAC_PRICTRL0_Msk                   _U_(0x87878787)                                /**< (DMAC_PRICTRL0) Register Mask  */
+
+
+/* -------- DMAC_INTPEND : (DMAC Offset: 0x20) (R/W 16) Interrupt Pending -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t ID:3;                      /**< bit:   0..2  Channel ID                               */
+    uint16_t :5;                        /**< bit:   3..7  Reserved */
+    uint16_t TERR:1;                    /**< bit:      8  Transfer Error                           */
+    uint16_t TCMPL:1;                   /**< bit:      9  Transfer Complete                        */
+    uint16_t SUSP:1;                    /**< bit:     10  Channel Suspend                          */
+    uint16_t :2;                        /**< bit: 11..12  Reserved */
+    uint16_t FERR:1;                    /**< bit:     13  Fetch Error                              */
+    uint16_t BUSY:1;                    /**< bit:     14  Busy                                     */
+    uint16_t PEND:1;                    /**< bit:     15  Pending                                  */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} DMAC_INTPEND_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_INTPEND_OFFSET                 (0x20)                                        /**<  (DMAC_INTPEND) Interrupt Pending  Offset */
+#define DMAC_INTPEND_RESETVALUE             _U_(0x00)                                     /**<  (DMAC_INTPEND) Interrupt Pending  Reset Value */
+
+#define DMAC_INTPEND_ID_Pos                 0                                              /**< (DMAC_INTPEND) Channel ID Position */
+#define DMAC_INTPEND_ID_Msk                 (_U_(0x7) << DMAC_INTPEND_ID_Pos)              /**< (DMAC_INTPEND) Channel ID Mask */
+#define DMAC_INTPEND_ID(value)              (DMAC_INTPEND_ID_Msk & ((value) << DMAC_INTPEND_ID_Pos))
+#define DMAC_INTPEND_TERR_Pos               8                                              /**< (DMAC_INTPEND) Transfer Error Position */
+#define DMAC_INTPEND_TERR_Msk               (_U_(0x1) << DMAC_INTPEND_TERR_Pos)            /**< (DMAC_INTPEND) Transfer Error Mask */
+#define DMAC_INTPEND_TERR                   DMAC_INTPEND_TERR_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_INTPEND_TERR_Msk instead */
+#define DMAC_INTPEND_TCMPL_Pos              9                                              /**< (DMAC_INTPEND) Transfer Complete Position */
+#define DMAC_INTPEND_TCMPL_Msk              (_U_(0x1) << DMAC_INTPEND_TCMPL_Pos)           /**< (DMAC_INTPEND) Transfer Complete Mask */
+#define DMAC_INTPEND_TCMPL                  DMAC_INTPEND_TCMPL_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_INTPEND_TCMPL_Msk instead */
+#define DMAC_INTPEND_SUSP_Pos               10                                             /**< (DMAC_INTPEND) Channel Suspend Position */
+#define DMAC_INTPEND_SUSP_Msk               (_U_(0x1) << DMAC_INTPEND_SUSP_Pos)            /**< (DMAC_INTPEND) Channel Suspend Mask */
+#define DMAC_INTPEND_SUSP                   DMAC_INTPEND_SUSP_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_INTPEND_SUSP_Msk instead */
+#define DMAC_INTPEND_FERR_Pos               13                                             /**< (DMAC_INTPEND) Fetch Error Position */
+#define DMAC_INTPEND_FERR_Msk               (_U_(0x1) << DMAC_INTPEND_FERR_Pos)            /**< (DMAC_INTPEND) Fetch Error Mask */
+#define DMAC_INTPEND_FERR                   DMAC_INTPEND_FERR_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_INTPEND_FERR_Msk instead */
+#define DMAC_INTPEND_BUSY_Pos               14                                             /**< (DMAC_INTPEND) Busy Position */
+#define DMAC_INTPEND_BUSY_Msk               (_U_(0x1) << DMAC_INTPEND_BUSY_Pos)            /**< (DMAC_INTPEND) Busy Mask */
+#define DMAC_INTPEND_BUSY                   DMAC_INTPEND_BUSY_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_INTPEND_BUSY_Msk instead */
+#define DMAC_INTPEND_PEND_Pos               15                                             /**< (DMAC_INTPEND) Pending Position */
+#define DMAC_INTPEND_PEND_Msk               (_U_(0x1) << DMAC_INTPEND_PEND_Pos)            /**< (DMAC_INTPEND) Pending Mask */
+#define DMAC_INTPEND_PEND                   DMAC_INTPEND_PEND_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_INTPEND_PEND_Msk instead */
+#define DMAC_INTPEND_MASK                   _U_(0xE707)                                    /**< \deprecated (DMAC_INTPEND) Register MASK  (Use DMAC_INTPEND_Msk instead)  */
+#define DMAC_INTPEND_Msk                    _U_(0xE707)                                    /**< (DMAC_INTPEND) Register Mask  */
+
+
+/* -------- DMAC_INTSTATUS : (DMAC Offset: 0x24) (R/ 32) Interrupt Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t CHINT0:1;                  /**< bit:      0  Channel 0 Pending Interrupt              */
+    uint32_t CHINT1:1;                  /**< bit:      1  Channel 1 Pending Interrupt              */
+    uint32_t CHINT2:1;                  /**< bit:      2  Channel 2 Pending Interrupt              */
+    uint32_t CHINT3:1;                  /**< bit:      3  Channel 3 Pending Interrupt              */
+    uint32_t CHINT4:1;                  /**< bit:      4  Channel 4 Pending Interrupt              */
+    uint32_t CHINT5:1;                  /**< bit:      5  Channel 5 Pending Interrupt              */
+    uint32_t CHINT6:1;                  /**< bit:      6  Channel 6 Pending Interrupt              */
+    uint32_t CHINT7:1;                  /**< bit:      7  Channel 7 Pending Interrupt              */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t CHINT:8;                   /**< bit:   0..7  Channel 7 Pending Interrupt              */
+    uint32_t :24;                       /**< bit:  8..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} DMAC_INTSTATUS_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_INTSTATUS_OFFSET               (0x24)                                        /**<  (DMAC_INTSTATUS) Interrupt Status  Offset */
+#define DMAC_INTSTATUS_RESETVALUE           _U_(0x00)                                     /**<  (DMAC_INTSTATUS) Interrupt Status  Reset Value */
+
+#define DMAC_INTSTATUS_CHINT0_Pos           0                                              /**< (DMAC_INTSTATUS) Channel 0 Pending Interrupt Position */
+#define DMAC_INTSTATUS_CHINT0_Msk           (_U_(0x1) << DMAC_INTSTATUS_CHINT0_Pos)        /**< (DMAC_INTSTATUS) Channel 0 Pending Interrupt Mask */
+#define DMAC_INTSTATUS_CHINT0               DMAC_INTSTATUS_CHINT0_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_INTSTATUS_CHINT0_Msk instead */
+#define DMAC_INTSTATUS_CHINT1_Pos           1                                              /**< (DMAC_INTSTATUS) Channel 1 Pending Interrupt Position */
+#define DMAC_INTSTATUS_CHINT1_Msk           (_U_(0x1) << DMAC_INTSTATUS_CHINT1_Pos)        /**< (DMAC_INTSTATUS) Channel 1 Pending Interrupt Mask */
+#define DMAC_INTSTATUS_CHINT1               DMAC_INTSTATUS_CHINT1_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_INTSTATUS_CHINT1_Msk instead */
+#define DMAC_INTSTATUS_CHINT2_Pos           2                                              /**< (DMAC_INTSTATUS) Channel 2 Pending Interrupt Position */
+#define DMAC_INTSTATUS_CHINT2_Msk           (_U_(0x1) << DMAC_INTSTATUS_CHINT2_Pos)        /**< (DMAC_INTSTATUS) Channel 2 Pending Interrupt Mask */
+#define DMAC_INTSTATUS_CHINT2               DMAC_INTSTATUS_CHINT2_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_INTSTATUS_CHINT2_Msk instead */
+#define DMAC_INTSTATUS_CHINT3_Pos           3                                              /**< (DMAC_INTSTATUS) Channel 3 Pending Interrupt Position */
+#define DMAC_INTSTATUS_CHINT3_Msk           (_U_(0x1) << DMAC_INTSTATUS_CHINT3_Pos)        /**< (DMAC_INTSTATUS) Channel 3 Pending Interrupt Mask */
+#define DMAC_INTSTATUS_CHINT3               DMAC_INTSTATUS_CHINT3_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_INTSTATUS_CHINT3_Msk instead */
+#define DMAC_INTSTATUS_CHINT4_Pos           4                                              /**< (DMAC_INTSTATUS) Channel 4 Pending Interrupt Position */
+#define DMAC_INTSTATUS_CHINT4_Msk           (_U_(0x1) << DMAC_INTSTATUS_CHINT4_Pos)        /**< (DMAC_INTSTATUS) Channel 4 Pending Interrupt Mask */
+#define DMAC_INTSTATUS_CHINT4               DMAC_INTSTATUS_CHINT4_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_INTSTATUS_CHINT4_Msk instead */
+#define DMAC_INTSTATUS_CHINT5_Pos           5                                              /**< (DMAC_INTSTATUS) Channel 5 Pending Interrupt Position */
+#define DMAC_INTSTATUS_CHINT5_Msk           (_U_(0x1) << DMAC_INTSTATUS_CHINT5_Pos)        /**< (DMAC_INTSTATUS) Channel 5 Pending Interrupt Mask */
+#define DMAC_INTSTATUS_CHINT5               DMAC_INTSTATUS_CHINT5_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_INTSTATUS_CHINT5_Msk instead */
+#define DMAC_INTSTATUS_CHINT6_Pos           6                                              /**< (DMAC_INTSTATUS) Channel 6 Pending Interrupt Position */
+#define DMAC_INTSTATUS_CHINT6_Msk           (_U_(0x1) << DMAC_INTSTATUS_CHINT6_Pos)        /**< (DMAC_INTSTATUS) Channel 6 Pending Interrupt Mask */
+#define DMAC_INTSTATUS_CHINT6               DMAC_INTSTATUS_CHINT6_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_INTSTATUS_CHINT6_Msk instead */
+#define DMAC_INTSTATUS_CHINT7_Pos           7                                              /**< (DMAC_INTSTATUS) Channel 7 Pending Interrupt Position */
+#define DMAC_INTSTATUS_CHINT7_Msk           (_U_(0x1) << DMAC_INTSTATUS_CHINT7_Pos)        /**< (DMAC_INTSTATUS) Channel 7 Pending Interrupt Mask */
+#define DMAC_INTSTATUS_CHINT7               DMAC_INTSTATUS_CHINT7_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_INTSTATUS_CHINT7_Msk instead */
+#define DMAC_INTSTATUS_MASK                 _U_(0xFF)                                      /**< \deprecated (DMAC_INTSTATUS) Register MASK  (Use DMAC_INTSTATUS_Msk instead)  */
+#define DMAC_INTSTATUS_Msk                  _U_(0xFF)                                      /**< (DMAC_INTSTATUS) Register Mask  */
+
+#define DMAC_INTSTATUS_CHINT_Pos            0                                              /**< (DMAC_INTSTATUS Position) Channel 7 Pending Interrupt */
+#define DMAC_INTSTATUS_CHINT_Msk            (_U_(0xFF) << DMAC_INTSTATUS_CHINT_Pos)        /**< (DMAC_INTSTATUS Mask) CHINT */
+#define DMAC_INTSTATUS_CHINT(value)         (DMAC_INTSTATUS_CHINT_Msk & ((value) << DMAC_INTSTATUS_CHINT_Pos))  
+
+/* -------- DMAC_BUSYCH : (DMAC Offset: 0x28) (R/ 32) Busy Channels -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t BUSYCH0:1;                 /**< bit:      0  Busy Channel 0                           */
+    uint32_t BUSYCH1:1;                 /**< bit:      1  Busy Channel 1                           */
+    uint32_t BUSYCH2:1;                 /**< bit:      2  Busy Channel 2                           */
+    uint32_t BUSYCH3:1;                 /**< bit:      3  Busy Channel 3                           */
+    uint32_t BUSYCH4:1;                 /**< bit:      4  Busy Channel 4                           */
+    uint32_t BUSYCH5:1;                 /**< bit:      5  Busy Channel 5                           */
+    uint32_t BUSYCH6:1;                 /**< bit:      6  Busy Channel 6                           */
+    uint32_t BUSYCH7:1;                 /**< bit:      7  Busy Channel 7                           */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t BUSYCH:8;                  /**< bit:   0..7  Busy Channel 7                           */
+    uint32_t :24;                       /**< bit:  8..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} DMAC_BUSYCH_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_BUSYCH_OFFSET                  (0x28)                                        /**<  (DMAC_BUSYCH) Busy Channels  Offset */
+#define DMAC_BUSYCH_RESETVALUE              _U_(0x00)                                     /**<  (DMAC_BUSYCH) Busy Channels  Reset Value */
+
+#define DMAC_BUSYCH_BUSYCH0_Pos             0                                              /**< (DMAC_BUSYCH) Busy Channel 0 Position */
+#define DMAC_BUSYCH_BUSYCH0_Msk             (_U_(0x1) << DMAC_BUSYCH_BUSYCH0_Pos)          /**< (DMAC_BUSYCH) Busy Channel 0 Mask */
+#define DMAC_BUSYCH_BUSYCH0                 DMAC_BUSYCH_BUSYCH0_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_BUSYCH_BUSYCH0_Msk instead */
+#define DMAC_BUSYCH_BUSYCH1_Pos             1                                              /**< (DMAC_BUSYCH) Busy Channel 1 Position */
+#define DMAC_BUSYCH_BUSYCH1_Msk             (_U_(0x1) << DMAC_BUSYCH_BUSYCH1_Pos)          /**< (DMAC_BUSYCH) Busy Channel 1 Mask */
+#define DMAC_BUSYCH_BUSYCH1                 DMAC_BUSYCH_BUSYCH1_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_BUSYCH_BUSYCH1_Msk instead */
+#define DMAC_BUSYCH_BUSYCH2_Pos             2                                              /**< (DMAC_BUSYCH) Busy Channel 2 Position */
+#define DMAC_BUSYCH_BUSYCH2_Msk             (_U_(0x1) << DMAC_BUSYCH_BUSYCH2_Pos)          /**< (DMAC_BUSYCH) Busy Channel 2 Mask */
+#define DMAC_BUSYCH_BUSYCH2                 DMAC_BUSYCH_BUSYCH2_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_BUSYCH_BUSYCH2_Msk instead */
+#define DMAC_BUSYCH_BUSYCH3_Pos             3                                              /**< (DMAC_BUSYCH) Busy Channel 3 Position */
+#define DMAC_BUSYCH_BUSYCH3_Msk             (_U_(0x1) << DMAC_BUSYCH_BUSYCH3_Pos)          /**< (DMAC_BUSYCH) Busy Channel 3 Mask */
+#define DMAC_BUSYCH_BUSYCH3                 DMAC_BUSYCH_BUSYCH3_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_BUSYCH_BUSYCH3_Msk instead */
+#define DMAC_BUSYCH_BUSYCH4_Pos             4                                              /**< (DMAC_BUSYCH) Busy Channel 4 Position */
+#define DMAC_BUSYCH_BUSYCH4_Msk             (_U_(0x1) << DMAC_BUSYCH_BUSYCH4_Pos)          /**< (DMAC_BUSYCH) Busy Channel 4 Mask */
+#define DMAC_BUSYCH_BUSYCH4                 DMAC_BUSYCH_BUSYCH4_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_BUSYCH_BUSYCH4_Msk instead */
+#define DMAC_BUSYCH_BUSYCH5_Pos             5                                              /**< (DMAC_BUSYCH) Busy Channel 5 Position */
+#define DMAC_BUSYCH_BUSYCH5_Msk             (_U_(0x1) << DMAC_BUSYCH_BUSYCH5_Pos)          /**< (DMAC_BUSYCH) Busy Channel 5 Mask */
+#define DMAC_BUSYCH_BUSYCH5                 DMAC_BUSYCH_BUSYCH5_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_BUSYCH_BUSYCH5_Msk instead */
+#define DMAC_BUSYCH_BUSYCH6_Pos             6                                              /**< (DMAC_BUSYCH) Busy Channel 6 Position */
+#define DMAC_BUSYCH_BUSYCH6_Msk             (_U_(0x1) << DMAC_BUSYCH_BUSYCH6_Pos)          /**< (DMAC_BUSYCH) Busy Channel 6 Mask */
+#define DMAC_BUSYCH_BUSYCH6                 DMAC_BUSYCH_BUSYCH6_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_BUSYCH_BUSYCH6_Msk instead */
+#define DMAC_BUSYCH_BUSYCH7_Pos             7                                              /**< (DMAC_BUSYCH) Busy Channel 7 Position */
+#define DMAC_BUSYCH_BUSYCH7_Msk             (_U_(0x1) << DMAC_BUSYCH_BUSYCH7_Pos)          /**< (DMAC_BUSYCH) Busy Channel 7 Mask */
+#define DMAC_BUSYCH_BUSYCH7                 DMAC_BUSYCH_BUSYCH7_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_BUSYCH_BUSYCH7_Msk instead */
+#define DMAC_BUSYCH_MASK                    _U_(0xFF)                                      /**< \deprecated (DMAC_BUSYCH) Register MASK  (Use DMAC_BUSYCH_Msk instead)  */
+#define DMAC_BUSYCH_Msk                     _U_(0xFF)                                      /**< (DMAC_BUSYCH) Register Mask  */
+
+#define DMAC_BUSYCH_BUSYCH_Pos              0                                              /**< (DMAC_BUSYCH Position) Busy Channel 7 */
+#define DMAC_BUSYCH_BUSYCH_Msk              (_U_(0xFF) << DMAC_BUSYCH_BUSYCH_Pos)          /**< (DMAC_BUSYCH Mask) BUSYCH */
+#define DMAC_BUSYCH_BUSYCH(value)           (DMAC_BUSYCH_BUSYCH_Msk & ((value) << DMAC_BUSYCH_BUSYCH_Pos))  
+
+/* -------- DMAC_PENDCH : (DMAC Offset: 0x2c) (R/ 32) Pending Channels -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t PENDCH0:1;                 /**< bit:      0  Pending Channel 0                        */
+    uint32_t PENDCH1:1;                 /**< bit:      1  Pending Channel 1                        */
+    uint32_t PENDCH2:1;                 /**< bit:      2  Pending Channel 2                        */
+    uint32_t PENDCH3:1;                 /**< bit:      3  Pending Channel 3                        */
+    uint32_t PENDCH4:1;                 /**< bit:      4  Pending Channel 4                        */
+    uint32_t PENDCH5:1;                 /**< bit:      5  Pending Channel 5                        */
+    uint32_t PENDCH6:1;                 /**< bit:      6  Pending Channel 6                        */
+    uint32_t PENDCH7:1;                 /**< bit:      7  Pending Channel 7                        */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t PENDCH:8;                  /**< bit:   0..7  Pending Channel 7                        */
+    uint32_t :24;                       /**< bit:  8..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} DMAC_PENDCH_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_PENDCH_OFFSET                  (0x2C)                                        /**<  (DMAC_PENDCH) Pending Channels  Offset */
+#define DMAC_PENDCH_RESETVALUE              _U_(0x00)                                     /**<  (DMAC_PENDCH) Pending Channels  Reset Value */
+
+#define DMAC_PENDCH_PENDCH0_Pos             0                                              /**< (DMAC_PENDCH) Pending Channel 0 Position */
+#define DMAC_PENDCH_PENDCH0_Msk             (_U_(0x1) << DMAC_PENDCH_PENDCH0_Pos)          /**< (DMAC_PENDCH) Pending Channel 0 Mask */
+#define DMAC_PENDCH_PENDCH0                 DMAC_PENDCH_PENDCH0_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_PENDCH_PENDCH0_Msk instead */
+#define DMAC_PENDCH_PENDCH1_Pos             1                                              /**< (DMAC_PENDCH) Pending Channel 1 Position */
+#define DMAC_PENDCH_PENDCH1_Msk             (_U_(0x1) << DMAC_PENDCH_PENDCH1_Pos)          /**< (DMAC_PENDCH) Pending Channel 1 Mask */
+#define DMAC_PENDCH_PENDCH1                 DMAC_PENDCH_PENDCH1_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_PENDCH_PENDCH1_Msk instead */
+#define DMAC_PENDCH_PENDCH2_Pos             2                                              /**< (DMAC_PENDCH) Pending Channel 2 Position */
+#define DMAC_PENDCH_PENDCH2_Msk             (_U_(0x1) << DMAC_PENDCH_PENDCH2_Pos)          /**< (DMAC_PENDCH) Pending Channel 2 Mask */
+#define DMAC_PENDCH_PENDCH2                 DMAC_PENDCH_PENDCH2_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_PENDCH_PENDCH2_Msk instead */
+#define DMAC_PENDCH_PENDCH3_Pos             3                                              /**< (DMAC_PENDCH) Pending Channel 3 Position */
+#define DMAC_PENDCH_PENDCH3_Msk             (_U_(0x1) << DMAC_PENDCH_PENDCH3_Pos)          /**< (DMAC_PENDCH) Pending Channel 3 Mask */
+#define DMAC_PENDCH_PENDCH3                 DMAC_PENDCH_PENDCH3_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_PENDCH_PENDCH3_Msk instead */
+#define DMAC_PENDCH_PENDCH4_Pos             4                                              /**< (DMAC_PENDCH) Pending Channel 4 Position */
+#define DMAC_PENDCH_PENDCH4_Msk             (_U_(0x1) << DMAC_PENDCH_PENDCH4_Pos)          /**< (DMAC_PENDCH) Pending Channel 4 Mask */
+#define DMAC_PENDCH_PENDCH4                 DMAC_PENDCH_PENDCH4_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_PENDCH_PENDCH4_Msk instead */
+#define DMAC_PENDCH_PENDCH5_Pos             5                                              /**< (DMAC_PENDCH) Pending Channel 5 Position */
+#define DMAC_PENDCH_PENDCH5_Msk             (_U_(0x1) << DMAC_PENDCH_PENDCH5_Pos)          /**< (DMAC_PENDCH) Pending Channel 5 Mask */
+#define DMAC_PENDCH_PENDCH5                 DMAC_PENDCH_PENDCH5_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_PENDCH_PENDCH5_Msk instead */
+#define DMAC_PENDCH_PENDCH6_Pos             6                                              /**< (DMAC_PENDCH) Pending Channel 6 Position */
+#define DMAC_PENDCH_PENDCH6_Msk             (_U_(0x1) << DMAC_PENDCH_PENDCH6_Pos)          /**< (DMAC_PENDCH) Pending Channel 6 Mask */
+#define DMAC_PENDCH_PENDCH6                 DMAC_PENDCH_PENDCH6_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_PENDCH_PENDCH6_Msk instead */
+#define DMAC_PENDCH_PENDCH7_Pos             7                                              /**< (DMAC_PENDCH) Pending Channel 7 Position */
+#define DMAC_PENDCH_PENDCH7_Msk             (_U_(0x1) << DMAC_PENDCH_PENDCH7_Pos)          /**< (DMAC_PENDCH) Pending Channel 7 Mask */
+#define DMAC_PENDCH_PENDCH7                 DMAC_PENDCH_PENDCH7_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_PENDCH_PENDCH7_Msk instead */
+#define DMAC_PENDCH_MASK                    _U_(0xFF)                                      /**< \deprecated (DMAC_PENDCH) Register MASK  (Use DMAC_PENDCH_Msk instead)  */
+#define DMAC_PENDCH_Msk                     _U_(0xFF)                                      /**< (DMAC_PENDCH) Register Mask  */
+
+#define DMAC_PENDCH_PENDCH_Pos              0                                              /**< (DMAC_PENDCH Position) Pending Channel 7 */
+#define DMAC_PENDCH_PENDCH_Msk              (_U_(0xFF) << DMAC_PENDCH_PENDCH_Pos)          /**< (DMAC_PENDCH Mask) PENDCH */
+#define DMAC_PENDCH_PENDCH(value)           (DMAC_PENDCH_PENDCH_Msk & ((value) << DMAC_PENDCH_PENDCH_Pos))  
+
+/* -------- DMAC_ACTIVE : (DMAC Offset: 0x30) (R/ 32) Active Channel and Levels -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t LVLEX0:1;                  /**< bit:      0  Level 0 Channel Trigger Request Executing */
+    uint32_t LVLEX1:1;                  /**< bit:      1  Level 1 Channel Trigger Request Executing */
+    uint32_t LVLEX2:1;                  /**< bit:      2  Level 2 Channel Trigger Request Executing */
+    uint32_t LVLEX3:1;                  /**< bit:      3  Level 3 Channel Trigger Request Executing */
+    uint32_t :4;                        /**< bit:   4..7  Reserved */
+    uint32_t ID:5;                      /**< bit:  8..12  Active Channel ID                        */
+    uint32_t :2;                        /**< bit: 13..14  Reserved */
+    uint32_t ABUSY:1;                   /**< bit:     15  Active Channel Busy                      */
+    uint32_t BTCNT:16;                  /**< bit: 16..31  Active Channel Block Transfer Count      */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t LVLEX:4;                   /**< bit:   0..3  Level x Channel Trigger Request Executing */
+    uint32_t :28;                       /**< bit:  4..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} DMAC_ACTIVE_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_ACTIVE_OFFSET                  (0x30)                                        /**<  (DMAC_ACTIVE) Active Channel and Levels  Offset */
+#define DMAC_ACTIVE_RESETVALUE              _U_(0x00)                                     /**<  (DMAC_ACTIVE) Active Channel and Levels  Reset Value */
+
+#define DMAC_ACTIVE_LVLEX0_Pos              0                                              /**< (DMAC_ACTIVE) Level 0 Channel Trigger Request Executing Position */
+#define DMAC_ACTIVE_LVLEX0_Msk              (_U_(0x1) << DMAC_ACTIVE_LVLEX0_Pos)           /**< (DMAC_ACTIVE) Level 0 Channel Trigger Request Executing Mask */
+#define DMAC_ACTIVE_LVLEX0                  DMAC_ACTIVE_LVLEX0_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_ACTIVE_LVLEX0_Msk instead */
+#define DMAC_ACTIVE_LVLEX1_Pos              1                                              /**< (DMAC_ACTIVE) Level 1 Channel Trigger Request Executing Position */
+#define DMAC_ACTIVE_LVLEX1_Msk              (_U_(0x1) << DMAC_ACTIVE_LVLEX1_Pos)           /**< (DMAC_ACTIVE) Level 1 Channel Trigger Request Executing Mask */
+#define DMAC_ACTIVE_LVLEX1                  DMAC_ACTIVE_LVLEX1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_ACTIVE_LVLEX1_Msk instead */
+#define DMAC_ACTIVE_LVLEX2_Pos              2                                              /**< (DMAC_ACTIVE) Level 2 Channel Trigger Request Executing Position */
+#define DMAC_ACTIVE_LVLEX2_Msk              (_U_(0x1) << DMAC_ACTIVE_LVLEX2_Pos)           /**< (DMAC_ACTIVE) Level 2 Channel Trigger Request Executing Mask */
+#define DMAC_ACTIVE_LVLEX2                  DMAC_ACTIVE_LVLEX2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_ACTIVE_LVLEX2_Msk instead */
+#define DMAC_ACTIVE_LVLEX3_Pos              3                                              /**< (DMAC_ACTIVE) Level 3 Channel Trigger Request Executing Position */
+#define DMAC_ACTIVE_LVLEX3_Msk              (_U_(0x1) << DMAC_ACTIVE_LVLEX3_Pos)           /**< (DMAC_ACTIVE) Level 3 Channel Trigger Request Executing Mask */
+#define DMAC_ACTIVE_LVLEX3                  DMAC_ACTIVE_LVLEX3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_ACTIVE_LVLEX3_Msk instead */
+#define DMAC_ACTIVE_ID_Pos                  8                                              /**< (DMAC_ACTIVE) Active Channel ID Position */
+#define DMAC_ACTIVE_ID_Msk                  (_U_(0x1F) << DMAC_ACTIVE_ID_Pos)              /**< (DMAC_ACTIVE) Active Channel ID Mask */
+#define DMAC_ACTIVE_ID(value)               (DMAC_ACTIVE_ID_Msk & ((value) << DMAC_ACTIVE_ID_Pos))
+#define DMAC_ACTIVE_ABUSY_Pos               15                                             /**< (DMAC_ACTIVE) Active Channel Busy Position */
+#define DMAC_ACTIVE_ABUSY_Msk               (_U_(0x1) << DMAC_ACTIVE_ABUSY_Pos)            /**< (DMAC_ACTIVE) Active Channel Busy Mask */
+#define DMAC_ACTIVE_ABUSY                   DMAC_ACTIVE_ABUSY_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_ACTIVE_ABUSY_Msk instead */
+#define DMAC_ACTIVE_BTCNT_Pos               16                                             /**< (DMAC_ACTIVE) Active Channel Block Transfer Count Position */
+#define DMAC_ACTIVE_BTCNT_Msk               (_U_(0xFFFF) << DMAC_ACTIVE_BTCNT_Pos)         /**< (DMAC_ACTIVE) Active Channel Block Transfer Count Mask */
+#define DMAC_ACTIVE_BTCNT(value)            (DMAC_ACTIVE_BTCNT_Msk & ((value) << DMAC_ACTIVE_BTCNT_Pos))
+#define DMAC_ACTIVE_MASK                    _U_(0xFFFF9F0F)                                /**< \deprecated (DMAC_ACTIVE) Register MASK  (Use DMAC_ACTIVE_Msk instead)  */
+#define DMAC_ACTIVE_Msk                     _U_(0xFFFF9F0F)                                /**< (DMAC_ACTIVE) Register Mask  */
+
+#define DMAC_ACTIVE_LVLEX_Pos               0                                              /**< (DMAC_ACTIVE Position) Level x Channel Trigger Request Executing */
+#define DMAC_ACTIVE_LVLEX_Msk               (_U_(0xF) << DMAC_ACTIVE_LVLEX_Pos)            /**< (DMAC_ACTIVE Mask) LVLEX */
+#define DMAC_ACTIVE_LVLEX(value)            (DMAC_ACTIVE_LVLEX_Msk & ((value) << DMAC_ACTIVE_LVLEX_Pos))  
+
+/* -------- DMAC_BASEADDR : (DMAC Offset: 0x34) (R/W 32) Descriptor Memory Section Base Address -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t BASEADDR:32;               /**< bit:  0..31  Descriptor Memory Base Address           */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DMAC_BASEADDR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_BASEADDR_OFFSET                (0x34)                                        /**<  (DMAC_BASEADDR) Descriptor Memory Section Base Address  Offset */
+#define DMAC_BASEADDR_RESETVALUE            _U_(0x00)                                     /**<  (DMAC_BASEADDR) Descriptor Memory Section Base Address  Reset Value */
+
+#define DMAC_BASEADDR_BASEADDR_Pos          0                                              /**< (DMAC_BASEADDR) Descriptor Memory Base Address Position */
+#define DMAC_BASEADDR_BASEADDR_Msk          (_U_(0xFFFFFFFF) << DMAC_BASEADDR_BASEADDR_Pos)  /**< (DMAC_BASEADDR) Descriptor Memory Base Address Mask */
+#define DMAC_BASEADDR_BASEADDR(value)       (DMAC_BASEADDR_BASEADDR_Msk & ((value) << DMAC_BASEADDR_BASEADDR_Pos))
+#define DMAC_BASEADDR_MASK                  _U_(0xFFFFFFFF)                                /**< \deprecated (DMAC_BASEADDR) Register MASK  (Use DMAC_BASEADDR_Msk instead)  */
+#define DMAC_BASEADDR_Msk                   _U_(0xFFFFFFFF)                                /**< (DMAC_BASEADDR) Register Mask  */
+
+
+/* -------- DMAC_WRBADDR : (DMAC Offset: 0x38) (R/W 32) Write-Back Memory Section Base Address -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t WRBADDR:32;                /**< bit:  0..31  Write-Back Memory Base Address           */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DMAC_WRBADDR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_WRBADDR_OFFSET                 (0x38)                                        /**<  (DMAC_WRBADDR) Write-Back Memory Section Base Address  Offset */
+#define DMAC_WRBADDR_RESETVALUE             _U_(0x00)                                     /**<  (DMAC_WRBADDR) Write-Back Memory Section Base Address  Reset Value */
+
+#define DMAC_WRBADDR_WRBADDR_Pos            0                                              /**< (DMAC_WRBADDR) Write-Back Memory Base Address Position */
+#define DMAC_WRBADDR_WRBADDR_Msk            (_U_(0xFFFFFFFF) << DMAC_WRBADDR_WRBADDR_Pos)  /**< (DMAC_WRBADDR) Write-Back Memory Base Address Mask */
+#define DMAC_WRBADDR_WRBADDR(value)         (DMAC_WRBADDR_WRBADDR_Msk & ((value) << DMAC_WRBADDR_WRBADDR_Pos))
+#define DMAC_WRBADDR_MASK                   _U_(0xFFFFFFFF)                                /**< \deprecated (DMAC_WRBADDR) Register MASK  (Use DMAC_WRBADDR_Msk instead)  */
+#define DMAC_WRBADDR_Msk                    _U_(0xFFFFFFFF)                                /**< (DMAC_WRBADDR) Register Mask  */
+
+
+/* -------- DMAC_CHID : (DMAC Offset: 0x3f) (R/W 8) Channel ID -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  ID:3;                      /**< bit:   0..2  Channel ID                               */
+    uint8_t  :5;                        /**< bit:   3..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} DMAC_CHID_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_CHID_OFFSET                    (0x3F)                                        /**<  (DMAC_CHID) Channel ID  Offset */
+#define DMAC_CHID_RESETVALUE                _U_(0x00)                                     /**<  (DMAC_CHID) Channel ID  Reset Value */
+
+#define DMAC_CHID_ID_Pos                    0                                              /**< (DMAC_CHID) Channel ID Position */
+#define DMAC_CHID_ID_Msk                    (_U_(0x7) << DMAC_CHID_ID_Pos)                 /**< (DMAC_CHID) Channel ID Mask */
+#define DMAC_CHID_ID(value)                 (DMAC_CHID_ID_Msk & ((value) << DMAC_CHID_ID_Pos))
+#define DMAC_CHID_MASK                      _U_(0x07)                                      /**< \deprecated (DMAC_CHID) Register MASK  (Use DMAC_CHID_Msk instead)  */
+#define DMAC_CHID_Msk                       _U_(0x07)                                      /**< (DMAC_CHID) Register Mask  */
+
+
+/* -------- DMAC_CHCTRLA : (DMAC Offset: 0x40) (R/W 8) Channel Control A -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  SWRST:1;                   /**< bit:      0  Channel Software Reset                   */
+    uint8_t  ENABLE:1;                  /**< bit:      1  Channel Enable                           */
+    uint8_t  :4;                        /**< bit:   2..5  Reserved */
+    uint8_t  RUNSTDBY:1;                /**< bit:      6  Channel run in standby                   */
+    uint8_t  :1;                        /**< bit:      7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} DMAC_CHCTRLA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_CHCTRLA_OFFSET                 (0x40)                                        /**<  (DMAC_CHCTRLA) Channel Control A  Offset */
+#define DMAC_CHCTRLA_RESETVALUE             _U_(0x00)                                     /**<  (DMAC_CHCTRLA) Channel Control A  Reset Value */
+
+#define DMAC_CHCTRLA_SWRST_Pos              0                                              /**< (DMAC_CHCTRLA) Channel Software Reset Position */
+#define DMAC_CHCTRLA_SWRST_Msk              (_U_(0x1) << DMAC_CHCTRLA_SWRST_Pos)           /**< (DMAC_CHCTRLA) Channel Software Reset Mask */
+#define DMAC_CHCTRLA_SWRST                  DMAC_CHCTRLA_SWRST_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CHCTRLA_SWRST_Msk instead */
+#define DMAC_CHCTRLA_ENABLE_Pos             1                                              /**< (DMAC_CHCTRLA) Channel Enable Position */
+#define DMAC_CHCTRLA_ENABLE_Msk             (_U_(0x1) << DMAC_CHCTRLA_ENABLE_Pos)          /**< (DMAC_CHCTRLA) Channel Enable Mask */
+#define DMAC_CHCTRLA_ENABLE                 DMAC_CHCTRLA_ENABLE_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CHCTRLA_ENABLE_Msk instead */
+#define DMAC_CHCTRLA_RUNSTDBY_Pos           6                                              /**< (DMAC_CHCTRLA) Channel run in standby Position */
+#define DMAC_CHCTRLA_RUNSTDBY_Msk           (_U_(0x1) << DMAC_CHCTRLA_RUNSTDBY_Pos)        /**< (DMAC_CHCTRLA) Channel run in standby Mask */
+#define DMAC_CHCTRLA_RUNSTDBY               DMAC_CHCTRLA_RUNSTDBY_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CHCTRLA_RUNSTDBY_Msk instead */
+#define DMAC_CHCTRLA_MASK                   _U_(0x43)                                      /**< \deprecated (DMAC_CHCTRLA) Register MASK  (Use DMAC_CHCTRLA_Msk instead)  */
+#define DMAC_CHCTRLA_Msk                    _U_(0x43)                                      /**< (DMAC_CHCTRLA) Register Mask  */
+
+
+/* -------- DMAC_CHCTRLB : (DMAC Offset: 0x44) (R/W 32) Channel Control B -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t EVACT:3;                   /**< bit:   0..2  Event Input Action                       */
+    uint32_t EVIE:1;                    /**< bit:      3  Channel Event Input Enable               */
+    uint32_t EVOE:1;                    /**< bit:      4  Channel Event Output Enable              */
+    uint32_t LVL:2;                     /**< bit:   5..6  Channel Arbitration Level                */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t TRIGSRC:5;                 /**< bit:  8..12  Trigger Source                           */
+    uint32_t :9;                        /**< bit: 13..21  Reserved */
+    uint32_t TRIGACT:2;                 /**< bit: 22..23  Trigger Action                           */
+    uint32_t CMD:2;                     /**< bit: 24..25  Software Command                         */
+    uint32_t :6;                        /**< bit: 26..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DMAC_CHCTRLB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_CHCTRLB_OFFSET                 (0x44)                                        /**<  (DMAC_CHCTRLB) Channel Control B  Offset */
+#define DMAC_CHCTRLB_RESETVALUE             _U_(0x00)                                     /**<  (DMAC_CHCTRLB) Channel Control B  Reset Value */
+
+#define DMAC_CHCTRLB_EVACT_Pos              0                                              /**< (DMAC_CHCTRLB) Event Input Action Position */
+#define DMAC_CHCTRLB_EVACT_Msk              (_U_(0x7) << DMAC_CHCTRLB_EVACT_Pos)           /**< (DMAC_CHCTRLB) Event Input Action Mask */
+#define DMAC_CHCTRLB_EVACT(value)           (DMAC_CHCTRLB_EVACT_Msk & ((value) << DMAC_CHCTRLB_EVACT_Pos))
+#define   DMAC_CHCTRLB_EVACT_NOACT_Val      _U_(0x0)                                       /**< (DMAC_CHCTRLB) No action  */
+#define   DMAC_CHCTRLB_EVACT_TRIG_Val       _U_(0x1)                                       /**< (DMAC_CHCTRLB) Transfer and periodic transfer trigger  */
+#define   DMAC_CHCTRLB_EVACT_CTRIG_Val      _U_(0x2)                                       /**< (DMAC_CHCTRLB) Conditional transfer trigger  */
+#define   DMAC_CHCTRLB_EVACT_CBLOCK_Val     _U_(0x3)                                       /**< (DMAC_CHCTRLB) Conditional block transfer  */
+#define   DMAC_CHCTRLB_EVACT_SUSPEND_Val    _U_(0x4)                                       /**< (DMAC_CHCTRLB) Channel suspend operation  */
+#define   DMAC_CHCTRLB_EVACT_RESUME_Val     _U_(0x5)                                       /**< (DMAC_CHCTRLB) Channel resume operation  */
+#define   DMAC_CHCTRLB_EVACT_SSKIP_Val      _U_(0x6)                                       /**< (DMAC_CHCTRLB) Skip next block suspend action  */
+#define DMAC_CHCTRLB_EVACT_NOACT            (DMAC_CHCTRLB_EVACT_NOACT_Val << DMAC_CHCTRLB_EVACT_Pos)  /**< (DMAC_CHCTRLB) No action Position  */
+#define DMAC_CHCTRLB_EVACT_TRIG             (DMAC_CHCTRLB_EVACT_TRIG_Val << DMAC_CHCTRLB_EVACT_Pos)  /**< (DMAC_CHCTRLB) Transfer and periodic transfer trigger Position  */
+#define DMAC_CHCTRLB_EVACT_CTRIG            (DMAC_CHCTRLB_EVACT_CTRIG_Val << DMAC_CHCTRLB_EVACT_Pos)  /**< (DMAC_CHCTRLB) Conditional transfer trigger Position  */
+#define DMAC_CHCTRLB_EVACT_CBLOCK           (DMAC_CHCTRLB_EVACT_CBLOCK_Val << DMAC_CHCTRLB_EVACT_Pos)  /**< (DMAC_CHCTRLB) Conditional block transfer Position  */
+#define DMAC_CHCTRLB_EVACT_SUSPEND          (DMAC_CHCTRLB_EVACT_SUSPEND_Val << DMAC_CHCTRLB_EVACT_Pos)  /**< (DMAC_CHCTRLB) Channel suspend operation Position  */
+#define DMAC_CHCTRLB_EVACT_RESUME           (DMAC_CHCTRLB_EVACT_RESUME_Val << DMAC_CHCTRLB_EVACT_Pos)  /**< (DMAC_CHCTRLB) Channel resume operation Position  */
+#define DMAC_CHCTRLB_EVACT_SSKIP            (DMAC_CHCTRLB_EVACT_SSKIP_Val << DMAC_CHCTRLB_EVACT_Pos)  /**< (DMAC_CHCTRLB) Skip next block suspend action Position  */
+#define DMAC_CHCTRLB_EVIE_Pos               3                                              /**< (DMAC_CHCTRLB) Channel Event Input Enable Position */
+#define DMAC_CHCTRLB_EVIE_Msk               (_U_(0x1) << DMAC_CHCTRLB_EVIE_Pos)            /**< (DMAC_CHCTRLB) Channel Event Input Enable Mask */
+#define DMAC_CHCTRLB_EVIE                   DMAC_CHCTRLB_EVIE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CHCTRLB_EVIE_Msk instead */
+#define DMAC_CHCTRLB_EVOE_Pos               4                                              /**< (DMAC_CHCTRLB) Channel Event Output Enable Position */
+#define DMAC_CHCTRLB_EVOE_Msk               (_U_(0x1) << DMAC_CHCTRLB_EVOE_Pos)            /**< (DMAC_CHCTRLB) Channel Event Output Enable Mask */
+#define DMAC_CHCTRLB_EVOE                   DMAC_CHCTRLB_EVOE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CHCTRLB_EVOE_Msk instead */
+#define DMAC_CHCTRLB_LVL_Pos                5                                              /**< (DMAC_CHCTRLB) Channel Arbitration Level Position */
+#define DMAC_CHCTRLB_LVL_Msk                (_U_(0x3) << DMAC_CHCTRLB_LVL_Pos)             /**< (DMAC_CHCTRLB) Channel Arbitration Level Mask */
+#define DMAC_CHCTRLB_LVL(value)             (DMAC_CHCTRLB_LVL_Msk & ((value) << DMAC_CHCTRLB_LVL_Pos))
+#define DMAC_CHCTRLB_TRIGSRC_Pos            8                                              /**< (DMAC_CHCTRLB) Trigger Source Position */
+#define DMAC_CHCTRLB_TRIGSRC_Msk            (_U_(0x1F) << DMAC_CHCTRLB_TRIGSRC_Pos)        /**< (DMAC_CHCTRLB) Trigger Source Mask */
+#define DMAC_CHCTRLB_TRIGSRC(value)         (DMAC_CHCTRLB_TRIGSRC_Msk & ((value) << DMAC_CHCTRLB_TRIGSRC_Pos))
+#define   DMAC_CHCTRLB_TRIGSRC_DISABLE_Val  _U_(0x0)                                       /**< (DMAC_CHCTRLB) Only software/event triggers  */
+#define DMAC_CHCTRLB_TRIGSRC_DISABLE        (DMAC_CHCTRLB_TRIGSRC_DISABLE_Val << DMAC_CHCTRLB_TRIGSRC_Pos)  /**< (DMAC_CHCTRLB) Only software/event triggers Position  */
+#define DMAC_CHCTRLB_TRIGACT_Pos            22                                             /**< (DMAC_CHCTRLB) Trigger Action Position */
+#define DMAC_CHCTRLB_TRIGACT_Msk            (_U_(0x3) << DMAC_CHCTRLB_TRIGACT_Pos)         /**< (DMAC_CHCTRLB) Trigger Action Mask */
+#define DMAC_CHCTRLB_TRIGACT(value)         (DMAC_CHCTRLB_TRIGACT_Msk & ((value) << DMAC_CHCTRLB_TRIGACT_Pos))
+#define   DMAC_CHCTRLB_TRIGACT_BLOCK_Val    _U_(0x0)                                       /**< (DMAC_CHCTRLB) One trigger required for each block transfer  */
+#define   DMAC_CHCTRLB_TRIGACT_BEAT_Val     _U_(0x2)                                       /**< (DMAC_CHCTRLB) One trigger required for each beat transfer  */
+#define   DMAC_CHCTRLB_TRIGACT_TRANSACTION_Val _U_(0x3)                                       /**< (DMAC_CHCTRLB) One trigger required for each transaction  */
+#define DMAC_CHCTRLB_TRIGACT_BLOCK          (DMAC_CHCTRLB_TRIGACT_BLOCK_Val << DMAC_CHCTRLB_TRIGACT_Pos)  /**< (DMAC_CHCTRLB) One trigger required for each block transfer Position  */
+#define DMAC_CHCTRLB_TRIGACT_BEAT           (DMAC_CHCTRLB_TRIGACT_BEAT_Val << DMAC_CHCTRLB_TRIGACT_Pos)  /**< (DMAC_CHCTRLB) One trigger required for each beat transfer Position  */
+#define DMAC_CHCTRLB_TRIGACT_TRANSACTION    (DMAC_CHCTRLB_TRIGACT_TRANSACTION_Val << DMAC_CHCTRLB_TRIGACT_Pos)  /**< (DMAC_CHCTRLB) One trigger required for each transaction Position  */
+#define DMAC_CHCTRLB_CMD_Pos                24                                             /**< (DMAC_CHCTRLB) Software Command Position */
+#define DMAC_CHCTRLB_CMD_Msk                (_U_(0x3) << DMAC_CHCTRLB_CMD_Pos)             /**< (DMAC_CHCTRLB) Software Command Mask */
+#define DMAC_CHCTRLB_CMD(value)             (DMAC_CHCTRLB_CMD_Msk & ((value) << DMAC_CHCTRLB_CMD_Pos))
+#define   DMAC_CHCTRLB_CMD_NOACT_Val        _U_(0x0)                                       /**< (DMAC_CHCTRLB) No action  */
+#define   DMAC_CHCTRLB_CMD_SUSPEND_Val      _U_(0x1)                                       /**< (DMAC_CHCTRLB) Channel suspend operation  */
+#define   DMAC_CHCTRLB_CMD_RESUME_Val       _U_(0x2)                                       /**< (DMAC_CHCTRLB) Channel resume operation  */
+#define DMAC_CHCTRLB_CMD_NOACT              (DMAC_CHCTRLB_CMD_NOACT_Val << DMAC_CHCTRLB_CMD_Pos)  /**< (DMAC_CHCTRLB) No action Position  */
+#define DMAC_CHCTRLB_CMD_SUSPEND            (DMAC_CHCTRLB_CMD_SUSPEND_Val << DMAC_CHCTRLB_CMD_Pos)  /**< (DMAC_CHCTRLB) Channel suspend operation Position  */
+#define DMAC_CHCTRLB_CMD_RESUME             (DMAC_CHCTRLB_CMD_RESUME_Val << DMAC_CHCTRLB_CMD_Pos)  /**< (DMAC_CHCTRLB) Channel resume operation Position  */
+#define DMAC_CHCTRLB_MASK                   _U_(0x3C01F7F)                                 /**< \deprecated (DMAC_CHCTRLB) Register MASK  (Use DMAC_CHCTRLB_Msk instead)  */
+#define DMAC_CHCTRLB_Msk                    _U_(0x3C01F7F)                                 /**< (DMAC_CHCTRLB) Register Mask  */
+
+
+/* -------- DMAC_CHINTENCLR : (DMAC Offset: 0x4c) (R/W 8) Channel Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  TERR:1;                    /**< bit:      0  Channel Transfer Error Interrupt Enable  */
+    uint8_t  TCMPL:1;                   /**< bit:      1  Channel Transfer Complete Interrupt Enable */
+    uint8_t  SUSP:1;                    /**< bit:      2  Channel Suspend Interrupt Enable         */
+    uint8_t  :5;                        /**< bit:   3..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} DMAC_CHINTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_CHINTENCLR_OFFSET              (0x4C)                                        /**<  (DMAC_CHINTENCLR) Channel Interrupt Enable Clear  Offset */
+#define DMAC_CHINTENCLR_RESETVALUE          _U_(0x00)                                     /**<  (DMAC_CHINTENCLR) Channel Interrupt Enable Clear  Reset Value */
+
+#define DMAC_CHINTENCLR_TERR_Pos            0                                              /**< (DMAC_CHINTENCLR) Channel Transfer Error Interrupt Enable Position */
+#define DMAC_CHINTENCLR_TERR_Msk            (_U_(0x1) << DMAC_CHINTENCLR_TERR_Pos)         /**< (DMAC_CHINTENCLR) Channel Transfer Error Interrupt Enable Mask */
+#define DMAC_CHINTENCLR_TERR                DMAC_CHINTENCLR_TERR_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CHINTENCLR_TERR_Msk instead */
+#define DMAC_CHINTENCLR_TCMPL_Pos           1                                              /**< (DMAC_CHINTENCLR) Channel Transfer Complete Interrupt Enable Position */
+#define DMAC_CHINTENCLR_TCMPL_Msk           (_U_(0x1) << DMAC_CHINTENCLR_TCMPL_Pos)        /**< (DMAC_CHINTENCLR) Channel Transfer Complete Interrupt Enable Mask */
+#define DMAC_CHINTENCLR_TCMPL               DMAC_CHINTENCLR_TCMPL_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CHINTENCLR_TCMPL_Msk instead */
+#define DMAC_CHINTENCLR_SUSP_Pos            2                                              /**< (DMAC_CHINTENCLR) Channel Suspend Interrupt Enable Position */
+#define DMAC_CHINTENCLR_SUSP_Msk            (_U_(0x1) << DMAC_CHINTENCLR_SUSP_Pos)         /**< (DMAC_CHINTENCLR) Channel Suspend Interrupt Enable Mask */
+#define DMAC_CHINTENCLR_SUSP                DMAC_CHINTENCLR_SUSP_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CHINTENCLR_SUSP_Msk instead */
+#define DMAC_CHINTENCLR_MASK                _U_(0x07)                                      /**< \deprecated (DMAC_CHINTENCLR) Register MASK  (Use DMAC_CHINTENCLR_Msk instead)  */
+#define DMAC_CHINTENCLR_Msk                 _U_(0x07)                                      /**< (DMAC_CHINTENCLR) Register Mask  */
+
+
+/* -------- DMAC_CHINTENSET : (DMAC Offset: 0x4d) (R/W 8) Channel Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  TERR:1;                    /**< bit:      0  Channel Transfer Error Interrupt Enable  */
+    uint8_t  TCMPL:1;                   /**< bit:      1  Channel Transfer Complete Interrupt Enable */
+    uint8_t  SUSP:1;                    /**< bit:      2  Channel Suspend Interrupt Enable         */
+    uint8_t  :5;                        /**< bit:   3..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} DMAC_CHINTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_CHINTENSET_OFFSET              (0x4D)                                        /**<  (DMAC_CHINTENSET) Channel Interrupt Enable Set  Offset */
+#define DMAC_CHINTENSET_RESETVALUE          _U_(0x00)                                     /**<  (DMAC_CHINTENSET) Channel Interrupt Enable Set  Reset Value */
+
+#define DMAC_CHINTENSET_TERR_Pos            0                                              /**< (DMAC_CHINTENSET) Channel Transfer Error Interrupt Enable Position */
+#define DMAC_CHINTENSET_TERR_Msk            (_U_(0x1) << DMAC_CHINTENSET_TERR_Pos)         /**< (DMAC_CHINTENSET) Channel Transfer Error Interrupt Enable Mask */
+#define DMAC_CHINTENSET_TERR                DMAC_CHINTENSET_TERR_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CHINTENSET_TERR_Msk instead */
+#define DMAC_CHINTENSET_TCMPL_Pos           1                                              /**< (DMAC_CHINTENSET) Channel Transfer Complete Interrupt Enable Position */
+#define DMAC_CHINTENSET_TCMPL_Msk           (_U_(0x1) << DMAC_CHINTENSET_TCMPL_Pos)        /**< (DMAC_CHINTENSET) Channel Transfer Complete Interrupt Enable Mask */
+#define DMAC_CHINTENSET_TCMPL               DMAC_CHINTENSET_TCMPL_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CHINTENSET_TCMPL_Msk instead */
+#define DMAC_CHINTENSET_SUSP_Pos            2                                              /**< (DMAC_CHINTENSET) Channel Suspend Interrupt Enable Position */
+#define DMAC_CHINTENSET_SUSP_Msk            (_U_(0x1) << DMAC_CHINTENSET_SUSP_Pos)         /**< (DMAC_CHINTENSET) Channel Suspend Interrupt Enable Mask */
+#define DMAC_CHINTENSET_SUSP                DMAC_CHINTENSET_SUSP_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CHINTENSET_SUSP_Msk instead */
+#define DMAC_CHINTENSET_MASK                _U_(0x07)                                      /**< \deprecated (DMAC_CHINTENSET) Register MASK  (Use DMAC_CHINTENSET_Msk instead)  */
+#define DMAC_CHINTENSET_Msk                 _U_(0x07)                                      /**< (DMAC_CHINTENSET) Register Mask  */
+
+
+/* -------- DMAC_CHINTFLAG : (DMAC Offset: 0x4e) (R/W 8) Channel Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t TERR:1;                    /**< bit:      0  Channel Transfer Error                   */
+    __I uint8_t TCMPL:1;                   /**< bit:      1  Channel Transfer Complete                */
+    __I uint8_t SUSP:1;                    /**< bit:      2  Channel Suspend                          */
+    __I uint8_t :5;                        /**< bit:   3..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} DMAC_CHINTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_CHINTFLAG_OFFSET               (0x4E)                                        /**<  (DMAC_CHINTFLAG) Channel Interrupt Flag Status and Clear  Offset */
+#define DMAC_CHINTFLAG_RESETVALUE           _U_(0x00)                                     /**<  (DMAC_CHINTFLAG) Channel Interrupt Flag Status and Clear  Reset Value */
+
+#define DMAC_CHINTFLAG_TERR_Pos             0                                              /**< (DMAC_CHINTFLAG) Channel Transfer Error Position */
+#define DMAC_CHINTFLAG_TERR_Msk             (_U_(0x1) << DMAC_CHINTFLAG_TERR_Pos)          /**< (DMAC_CHINTFLAG) Channel Transfer Error Mask */
+#define DMAC_CHINTFLAG_TERR                 DMAC_CHINTFLAG_TERR_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CHINTFLAG_TERR_Msk instead */
+#define DMAC_CHINTFLAG_TCMPL_Pos            1                                              /**< (DMAC_CHINTFLAG) Channel Transfer Complete Position */
+#define DMAC_CHINTFLAG_TCMPL_Msk            (_U_(0x1) << DMAC_CHINTFLAG_TCMPL_Pos)         /**< (DMAC_CHINTFLAG) Channel Transfer Complete Mask */
+#define DMAC_CHINTFLAG_TCMPL                DMAC_CHINTFLAG_TCMPL_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CHINTFLAG_TCMPL_Msk instead */
+#define DMAC_CHINTFLAG_SUSP_Pos             2                                              /**< (DMAC_CHINTFLAG) Channel Suspend Position */
+#define DMAC_CHINTFLAG_SUSP_Msk             (_U_(0x1) << DMAC_CHINTFLAG_SUSP_Pos)          /**< (DMAC_CHINTFLAG) Channel Suspend Mask */
+#define DMAC_CHINTFLAG_SUSP                 DMAC_CHINTFLAG_SUSP_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CHINTFLAG_SUSP_Msk instead */
+#define DMAC_CHINTFLAG_MASK                 _U_(0x07)                                      /**< \deprecated (DMAC_CHINTFLAG) Register MASK  (Use DMAC_CHINTFLAG_Msk instead)  */
+#define DMAC_CHINTFLAG_Msk                  _U_(0x07)                                      /**< (DMAC_CHINTFLAG) Register Mask  */
+
+
+/* -------- DMAC_CHSTATUS : (DMAC Offset: 0x4f) (R/ 8) Channel Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  PEND:1;                    /**< bit:      0  Channel Pending                          */
+    uint8_t  BUSY:1;                    /**< bit:      1  Channel Busy                             */
+    uint8_t  FERR:1;                    /**< bit:      2  Channel Fetch Error                      */
+    uint8_t  :5;                        /**< bit:   3..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} DMAC_CHSTATUS_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_CHSTATUS_OFFSET                (0x4F)                                        /**<  (DMAC_CHSTATUS) Channel Status  Offset */
+#define DMAC_CHSTATUS_RESETVALUE            _U_(0x00)                                     /**<  (DMAC_CHSTATUS) Channel Status  Reset Value */
+
+#define DMAC_CHSTATUS_PEND_Pos              0                                              /**< (DMAC_CHSTATUS) Channel Pending Position */
+#define DMAC_CHSTATUS_PEND_Msk              (_U_(0x1) << DMAC_CHSTATUS_PEND_Pos)           /**< (DMAC_CHSTATUS) Channel Pending Mask */
+#define DMAC_CHSTATUS_PEND                  DMAC_CHSTATUS_PEND_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CHSTATUS_PEND_Msk instead */
+#define DMAC_CHSTATUS_BUSY_Pos              1                                              /**< (DMAC_CHSTATUS) Channel Busy Position */
+#define DMAC_CHSTATUS_BUSY_Msk              (_U_(0x1) << DMAC_CHSTATUS_BUSY_Pos)           /**< (DMAC_CHSTATUS) Channel Busy Mask */
+#define DMAC_CHSTATUS_BUSY                  DMAC_CHSTATUS_BUSY_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CHSTATUS_BUSY_Msk instead */
+#define DMAC_CHSTATUS_FERR_Pos              2                                              /**< (DMAC_CHSTATUS) Channel Fetch Error Position */
+#define DMAC_CHSTATUS_FERR_Msk              (_U_(0x1) << DMAC_CHSTATUS_FERR_Pos)           /**< (DMAC_CHSTATUS) Channel Fetch Error Mask */
+#define DMAC_CHSTATUS_FERR                  DMAC_CHSTATUS_FERR_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CHSTATUS_FERR_Msk instead */
+#define DMAC_CHSTATUS_MASK                  _U_(0x07)                                      /**< \deprecated (DMAC_CHSTATUS) Register MASK  (Use DMAC_CHSTATUS_Msk instead)  */
+#define DMAC_CHSTATUS_Msk                   _U_(0x07)                                      /**< (DMAC_CHSTATUS) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief DMAC_DESCRIPTOR hardware registers */
+typedef struct {  /* Direct Memory Access Controller */
+  __IO DMAC_BTCTRL_Type               BTCTRL;         /**< Offset: 0x00 (R/W  16) Block Transfer Control */
+  __IO DMAC_BTCNT_Type                BTCNT;          /**< Offset: 0x02 (R/W  16) Block Transfer Count */
+  __IO DMAC_SRCADDR_Type              SRCADDR;        /**< Offset: 0x04 (R/W  32) Block Transfer Source Address */
+  __IO DMAC_DSTADDR_Type              DSTADDR;        /**< Offset: 0x08 (R/W  32) Block Transfer Destination Address */
+  __IO DMAC_DESCADDR_Type             DESCADDR;       /**< Offset: 0x0C (R/W  32) Next Descriptor Address */
+} DmacDescriptor
+#ifdef __GNUC__
+  __attribute__ ((aligned (8)))
+#endif
+;
+
+/** \brief DMAC hardware registers */
+typedef struct {  /* Direct Memory Access Controller */
+  __IO DMAC_CTRL_Type                 CTRL;           /**< Offset: 0x00 (R/W  16) Control */
+  __IO DMAC_CRCCTRL_Type              CRCCTRL;        /**< Offset: 0x02 (R/W  16) CRC Control */
+  __IO DMAC_CRCDATAIN_Type            CRCDATAIN;      /**< Offset: 0x04 (R/W  32) CRC Data Input */
+  __IO DMAC_CRCCHKSUM_Type            CRCCHKSUM;      /**< Offset: 0x08 (R/W  32) CRC Checksum */
+  __IO DMAC_CRCSTATUS_Type            CRCSTATUS;      /**< Offset: 0x0C (R/W   8) CRC Status */
+  __IO DMAC_DBGCTRL_Type              DBGCTRL;        /**< Offset: 0x0D (R/W   8) Debug Control */
+  __IO DMAC_QOSCTRL_Type              QOSCTRL;        /**< Offset: 0x0E (R/W   8) QOS Control */
+  __I  uint8_t                        Reserved1[1];
+  __IO DMAC_SWTRIGCTRL_Type           SWTRIGCTRL;     /**< Offset: 0x10 (R/W  32) Software Trigger Control */
+  __IO DMAC_PRICTRL0_Type             PRICTRL0;       /**< Offset: 0x14 (R/W  32) Priority Control 0 */
+  __I  uint8_t                        Reserved2[8];
+  __IO DMAC_INTPEND_Type              INTPEND;        /**< Offset: 0x20 (R/W  16) Interrupt Pending */
+  __I  uint8_t                        Reserved3[2];
+  __I  DMAC_INTSTATUS_Type            INTSTATUS;      /**< Offset: 0x24 (R/   32) Interrupt Status */
+  __I  DMAC_BUSYCH_Type               BUSYCH;         /**< Offset: 0x28 (R/   32) Busy Channels */
+  __I  DMAC_PENDCH_Type               PENDCH;         /**< Offset: 0x2C (R/   32) Pending Channels */
+  __I  DMAC_ACTIVE_Type               ACTIVE;         /**< Offset: 0x30 (R/   32) Active Channel and Levels */
+  __IO DMAC_BASEADDR_Type             BASEADDR;       /**< Offset: 0x34 (R/W  32) Descriptor Memory Section Base Address */
+  __IO DMAC_WRBADDR_Type              WRBADDR;        /**< Offset: 0x38 (R/W  32) Write-Back Memory Section Base Address */
+  __I  uint8_t                        Reserved4[3];
+  __IO DMAC_CHID_Type                 CHID;           /**< Offset: 0x3F (R/W   8) Channel ID */
+  __IO DMAC_CHCTRLA_Type              CHCTRLA;        /**< Offset: 0x40 (R/W   8) Channel Control A */
+  __I  uint8_t                        Reserved5[3];
+  __IO DMAC_CHCTRLB_Type              CHCTRLB;        /**< Offset: 0x44 (R/W  32) Channel Control B */
+  __I  uint8_t                        Reserved6[4];
+  __IO DMAC_CHINTENCLR_Type           CHINTENCLR;     /**< Offset: 0x4C (R/W   8) Channel Interrupt Enable Clear */
+  __IO DMAC_CHINTENSET_Type           CHINTENSET;     /**< Offset: 0x4D (R/W   8) Channel Interrupt Enable Set */
+  __IO DMAC_CHINTFLAG_Type            CHINTFLAG;      /**< Offset: 0x4E (R/W   8) Channel Interrupt Flag Status and Clear */
+  __I  DMAC_CHSTATUS_Type             CHSTATUS;       /**< Offset: 0x4F (R/    8) Channel Status */
+} Dmac;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** \brief DMAC_DESCRIPTOR memory section attribute */
+#define SECTION_DMAC_DESCRIPTOR
+
+/** @}  end of Direct Memory Access Controller */
+
+#endif /* _SAML10_DMAC_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/component/dsu.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/dsu.h
@@ -1,0 +1,785 @@
+/**
+ * \file
+ *
+ * \brief Component description for DSU
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_DSU_COMPONENT_H_
+#define _SAML10_DSU_COMPONENT_H_
+#define _SAML10_DSU_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML10 Device Service Unit
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR DSU */
+/* ========================================================================== */
+
+#define DSU_U2810                      /**< (DSU) Module ID */
+#define REV_DSU 0x100                  /**< (DSU) Module revision */
+
+/* -------- DSU_CTRL : (DSU Offset: 0x00) (/W 8) Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint8_t  :1;                        /**< bit:      1  Reserved */
+    uint8_t  CRC:1;                     /**< bit:      2  32-bit Cyclic Redundancy Code            */
+    uint8_t  MBIST:1;                   /**< bit:      3  Memory built-in self-test                */
+    uint8_t  :4;                        /**< bit:   4..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} DSU_CTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_CTRL_OFFSET                     (0x00)                                        /**<  (DSU_CTRL) Control  Offset */
+#define DSU_CTRL_RESETVALUE                 _U_(0x00)                                     /**<  (DSU_CTRL) Control  Reset Value */
+
+#define DSU_CTRL_SWRST_Pos                  0                                              /**< (DSU_CTRL) Software Reset Position */
+#define DSU_CTRL_SWRST_Msk                  (_U_(0x1) << DSU_CTRL_SWRST_Pos)               /**< (DSU_CTRL) Software Reset Mask */
+#define DSU_CTRL_SWRST                      DSU_CTRL_SWRST_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use DSU_CTRL_SWRST_Msk instead */
+#define DSU_CTRL_CRC_Pos                    2                                              /**< (DSU_CTRL) 32-bit Cyclic Redundancy Code Position */
+#define DSU_CTRL_CRC_Msk                    (_U_(0x1) << DSU_CTRL_CRC_Pos)                 /**< (DSU_CTRL) 32-bit Cyclic Redundancy Code Mask */
+#define DSU_CTRL_CRC                        DSU_CTRL_CRC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use DSU_CTRL_CRC_Msk instead */
+#define DSU_CTRL_MBIST_Pos                  3                                              /**< (DSU_CTRL) Memory built-in self-test Position */
+#define DSU_CTRL_MBIST_Msk                  (_U_(0x1) << DSU_CTRL_MBIST_Pos)               /**< (DSU_CTRL) Memory built-in self-test Mask */
+#define DSU_CTRL_MBIST                      DSU_CTRL_MBIST_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use DSU_CTRL_MBIST_Msk instead */
+#define DSU_CTRL_MASK                       _U_(0x0D)                                      /**< \deprecated (DSU_CTRL) Register MASK  (Use DSU_CTRL_Msk instead)  */
+#define DSU_CTRL_Msk                        _U_(0x0D)                                      /**< (DSU_CTRL) Register Mask  */
+
+
+/* -------- DSU_STATUSA : (DSU Offset: 0x01) (R/W 8) Status A -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DONE:1;                    /**< bit:      0  Done                                     */
+    uint8_t  CRSTEXT:1;                 /**< bit:      1  CPU Reset Phase Extension                */
+    uint8_t  BERR:1;                    /**< bit:      2  Bus Error                                */
+    uint8_t  FAIL:1;                    /**< bit:      3  Failure                                  */
+    uint8_t  PERR:1;                    /**< bit:      4  Protection Error Detected by the State Machine */
+    uint8_t  BREXT:1;                   /**< bit:      5  BootRom Phase Extension                  */
+    uint8_t  :2;                        /**< bit:   6..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} DSU_STATUSA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_STATUSA_OFFSET                  (0x01)                                        /**<  (DSU_STATUSA) Status A  Offset */
+#define DSU_STATUSA_RESETVALUE              _U_(0x00)                                     /**<  (DSU_STATUSA) Status A  Reset Value */
+
+#define DSU_STATUSA_DONE_Pos                0                                              /**< (DSU_STATUSA) Done Position */
+#define DSU_STATUSA_DONE_Msk                (_U_(0x1) << DSU_STATUSA_DONE_Pos)             /**< (DSU_STATUSA) Done Mask */
+#define DSU_STATUSA_DONE                    DSU_STATUSA_DONE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use DSU_STATUSA_DONE_Msk instead */
+#define DSU_STATUSA_CRSTEXT_Pos             1                                              /**< (DSU_STATUSA) CPU Reset Phase Extension Position */
+#define DSU_STATUSA_CRSTEXT_Msk             (_U_(0x1) << DSU_STATUSA_CRSTEXT_Pos)          /**< (DSU_STATUSA) CPU Reset Phase Extension Mask */
+#define DSU_STATUSA_CRSTEXT                 DSU_STATUSA_CRSTEXT_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DSU_STATUSA_CRSTEXT_Msk instead */
+#define DSU_STATUSA_BERR_Pos                2                                              /**< (DSU_STATUSA) Bus Error Position */
+#define DSU_STATUSA_BERR_Msk                (_U_(0x1) << DSU_STATUSA_BERR_Pos)             /**< (DSU_STATUSA) Bus Error Mask */
+#define DSU_STATUSA_BERR                    DSU_STATUSA_BERR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use DSU_STATUSA_BERR_Msk instead */
+#define DSU_STATUSA_FAIL_Pos                3                                              /**< (DSU_STATUSA) Failure Position */
+#define DSU_STATUSA_FAIL_Msk                (_U_(0x1) << DSU_STATUSA_FAIL_Pos)             /**< (DSU_STATUSA) Failure Mask */
+#define DSU_STATUSA_FAIL                    DSU_STATUSA_FAIL_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use DSU_STATUSA_FAIL_Msk instead */
+#define DSU_STATUSA_PERR_Pos                4                                              /**< (DSU_STATUSA) Protection Error Detected by the State Machine Position */
+#define DSU_STATUSA_PERR_Msk                (_U_(0x1) << DSU_STATUSA_PERR_Pos)             /**< (DSU_STATUSA) Protection Error Detected by the State Machine Mask */
+#define DSU_STATUSA_PERR                    DSU_STATUSA_PERR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use DSU_STATUSA_PERR_Msk instead */
+#define DSU_STATUSA_BREXT_Pos               5                                              /**< (DSU_STATUSA) BootRom Phase Extension Position */
+#define DSU_STATUSA_BREXT_Msk               (_U_(0x1) << DSU_STATUSA_BREXT_Pos)            /**< (DSU_STATUSA) BootRom Phase Extension Mask */
+#define DSU_STATUSA_BREXT                   DSU_STATUSA_BREXT_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use DSU_STATUSA_BREXT_Msk instead */
+#define DSU_STATUSA_MASK                    _U_(0x3F)                                      /**< \deprecated (DSU_STATUSA) Register MASK  (Use DSU_STATUSA_Msk instead)  */
+#define DSU_STATUSA_Msk                     _U_(0x3F)                                      /**< (DSU_STATUSA) Register Mask  */
+
+
+/* -------- DSU_STATUSB : (DSU Offset: 0x02) (R/ 8) Status B -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DAL:2;                     /**< bit:   0..1  Debugger Access Level                    */
+    uint8_t  DBGPRES:1;                 /**< bit:      2  Debugger Present                         */
+    uint8_t  HPE:1;                     /**< bit:      3  Hot-Plugging Enable                      */
+    uint8_t  DCCD0:1;                   /**< bit:      4  Debug Communication Channel 0 Dirty      */
+    uint8_t  DCCD1:1;                   /**< bit:      5  Debug Communication Channel 1 Dirty      */
+    uint8_t  BCCD0:1;                   /**< bit:      6  Boot ROM Communication Channel 0 Dirty   */
+    uint8_t  BCCD1:1;                   /**< bit:      7  Boot ROM Communication Channel 1 Dirty   */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint8_t  :4;                        /**< bit:   0..3  Reserved */
+    uint8_t  DCCD:2;                    /**< bit:   4..5  Debug Communication Channel x Dirty      */
+    uint8_t  BCCD:2;                    /**< bit:   6..7  Boot ROM Communication Channel x Dirty   */
+  } vec;                                /**< Structure used for vec  access  */
+  uint8_t  reg;                         /**< Type used for register access */
+} DSU_STATUSB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_STATUSB_OFFSET                  (0x02)                                        /**<  (DSU_STATUSB) Status B  Offset */
+#define DSU_STATUSB_RESETVALUE              _U_(0x00)                                     /**<  (DSU_STATUSB) Status B  Reset Value */
+
+#define DSU_STATUSB_DAL_Pos                 0                                              /**< (DSU_STATUSB) Debugger Access Level Position */
+#define DSU_STATUSB_DAL_Msk                 (_U_(0x3) << DSU_STATUSB_DAL_Pos)              /**< (DSU_STATUSB) Debugger Access Level Mask */
+#define DSU_STATUSB_DAL(value)              (DSU_STATUSB_DAL_Msk & ((value) << DSU_STATUSB_DAL_Pos))
+#define   DSU_STATUSB_DAL_SECURED_Val       _U_(0x0)                                       /**< (DSU_STATUSB)   */
+#define   DSU_STATUSB_DAL_NS_DEBUG_Val      _U_(0x1)                                       /**< (DSU_STATUSB)   */
+#define   DSU_STATUSB_DAL_FULL_DEBUG_Val    _U_(0x2)                                       /**< (DSU_STATUSB)   */
+#define DSU_STATUSB_DAL_SECURED             (DSU_STATUSB_DAL_SECURED_Val << DSU_STATUSB_DAL_Pos)  /**< (DSU_STATUSB)  Position  */
+#define DSU_STATUSB_DAL_NS_DEBUG            (DSU_STATUSB_DAL_NS_DEBUG_Val << DSU_STATUSB_DAL_Pos)  /**< (DSU_STATUSB)  Position  */
+#define DSU_STATUSB_DAL_FULL_DEBUG          (DSU_STATUSB_DAL_FULL_DEBUG_Val << DSU_STATUSB_DAL_Pos)  /**< (DSU_STATUSB)  Position  */
+#define DSU_STATUSB_DBGPRES_Pos             2                                              /**< (DSU_STATUSB) Debugger Present Position */
+#define DSU_STATUSB_DBGPRES_Msk             (_U_(0x1) << DSU_STATUSB_DBGPRES_Pos)          /**< (DSU_STATUSB) Debugger Present Mask */
+#define DSU_STATUSB_DBGPRES                 DSU_STATUSB_DBGPRES_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DSU_STATUSB_DBGPRES_Msk instead */
+#define DSU_STATUSB_HPE_Pos                 3                                              /**< (DSU_STATUSB) Hot-Plugging Enable Position */
+#define DSU_STATUSB_HPE_Msk                 (_U_(0x1) << DSU_STATUSB_HPE_Pos)              /**< (DSU_STATUSB) Hot-Plugging Enable Mask */
+#define DSU_STATUSB_HPE                     DSU_STATUSB_HPE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use DSU_STATUSB_HPE_Msk instead */
+#define DSU_STATUSB_DCCD0_Pos               4                                              /**< (DSU_STATUSB) Debug Communication Channel 0 Dirty Position */
+#define DSU_STATUSB_DCCD0_Msk               (_U_(0x1) << DSU_STATUSB_DCCD0_Pos)            /**< (DSU_STATUSB) Debug Communication Channel 0 Dirty Mask */
+#define DSU_STATUSB_DCCD0                   DSU_STATUSB_DCCD0_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use DSU_STATUSB_DCCD0_Msk instead */
+#define DSU_STATUSB_DCCD1_Pos               5                                              /**< (DSU_STATUSB) Debug Communication Channel 1 Dirty Position */
+#define DSU_STATUSB_DCCD1_Msk               (_U_(0x1) << DSU_STATUSB_DCCD1_Pos)            /**< (DSU_STATUSB) Debug Communication Channel 1 Dirty Mask */
+#define DSU_STATUSB_DCCD1                   DSU_STATUSB_DCCD1_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use DSU_STATUSB_DCCD1_Msk instead */
+#define DSU_STATUSB_BCCD0_Pos               6                                              /**< (DSU_STATUSB) Boot ROM Communication Channel 0 Dirty Position */
+#define DSU_STATUSB_BCCD0_Msk               (_U_(0x1) << DSU_STATUSB_BCCD0_Pos)            /**< (DSU_STATUSB) Boot ROM Communication Channel 0 Dirty Mask */
+#define DSU_STATUSB_BCCD0                   DSU_STATUSB_BCCD0_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use DSU_STATUSB_BCCD0_Msk instead */
+#define DSU_STATUSB_BCCD1_Pos               7                                              /**< (DSU_STATUSB) Boot ROM Communication Channel 1 Dirty Position */
+#define DSU_STATUSB_BCCD1_Msk               (_U_(0x1) << DSU_STATUSB_BCCD1_Pos)            /**< (DSU_STATUSB) Boot ROM Communication Channel 1 Dirty Mask */
+#define DSU_STATUSB_BCCD1                   DSU_STATUSB_BCCD1_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use DSU_STATUSB_BCCD1_Msk instead */
+#define DSU_STATUSB_MASK                    _U_(0xFF)                                      /**< \deprecated (DSU_STATUSB) Register MASK  (Use DSU_STATUSB_Msk instead)  */
+#define DSU_STATUSB_Msk                     _U_(0xFF)                                      /**< (DSU_STATUSB) Register Mask  */
+
+#define DSU_STATUSB_DCCD_Pos                4                                              /**< (DSU_STATUSB Position) Debug Communication Channel x Dirty */
+#define DSU_STATUSB_DCCD_Msk                (_U_(0x3) << DSU_STATUSB_DCCD_Pos)             /**< (DSU_STATUSB Mask) DCCD */
+#define DSU_STATUSB_DCCD(value)             (DSU_STATUSB_DCCD_Msk & ((value) << DSU_STATUSB_DCCD_Pos))  
+#define DSU_STATUSB_BCCD_Pos                6                                              /**< (DSU_STATUSB Position) Boot ROM Communication Channel x Dirty */
+#define DSU_STATUSB_BCCD_Msk                (_U_(0x3) << DSU_STATUSB_BCCD_Pos)             /**< (DSU_STATUSB Mask) BCCD */
+#define DSU_STATUSB_BCCD(value)             (DSU_STATUSB_BCCD_Msk & ((value) << DSU_STATUSB_BCCD_Pos))  
+
+/* -------- DSU_STATUSC : (DSU Offset: 0x03) (R/ 8) Status C -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  uint8_t  reg;                         /**< Type used for register access */
+} DSU_STATUSC_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_STATUSC_OFFSET                  (0x03)                                        /**<  (DSU_STATUSC) Status C  Offset */
+#define DSU_STATUSC_RESETVALUE              _U_(0x00)                                     /**<  (DSU_STATUSC) Status C  Reset Value */
+
+#define DSU_STATUSC_MASK                    _U_(0x00)                                      /**< \deprecated (DSU_STATUSC) Register MASK  (Use DSU_STATUSC_Msk instead)  */
+#define DSU_STATUSC_Msk                     _U_(0x00)                                      /**< (DSU_STATUSC) Register Mask  */
+
+
+/* -------- DSU_ADDR : (DSU Offset: 0x04) (R/W 32) Address -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t AMOD:2;                    /**< bit:   0..1  Access Mode                              */
+    uint32_t ADDR:30;                   /**< bit:  2..31  Address                                  */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DSU_ADDR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_ADDR_OFFSET                     (0x04)                                        /**<  (DSU_ADDR) Address  Offset */
+#define DSU_ADDR_RESETVALUE                 _U_(0x00)                                     /**<  (DSU_ADDR) Address  Reset Value */
+
+#define DSU_ADDR_AMOD_Pos                   0                                              /**< (DSU_ADDR) Access Mode Position */
+#define DSU_ADDR_AMOD_Msk                   (_U_(0x3) << DSU_ADDR_AMOD_Pos)                /**< (DSU_ADDR) Access Mode Mask */
+#define DSU_ADDR_AMOD(value)                (DSU_ADDR_AMOD_Msk & ((value) << DSU_ADDR_AMOD_Pos))
+#define DSU_ADDR_ADDR_Pos                   2                                              /**< (DSU_ADDR) Address Position */
+#define DSU_ADDR_ADDR_Msk                   (_U_(0x3FFFFFFF) << DSU_ADDR_ADDR_Pos)         /**< (DSU_ADDR) Address Mask */
+#define DSU_ADDR_ADDR(value)                (DSU_ADDR_ADDR_Msk & ((value) << DSU_ADDR_ADDR_Pos))
+#define DSU_ADDR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (DSU_ADDR) Register MASK  (Use DSU_ADDR_Msk instead)  */
+#define DSU_ADDR_Msk                        _U_(0xFFFFFFFF)                                /**< (DSU_ADDR) Register Mask  */
+
+
+/* -------- DSU_LENGTH : (DSU Offset: 0x08) (R/W 32) Length -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t LENGTH:30;                 /**< bit:  2..31  Length                                   */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DSU_LENGTH_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_LENGTH_OFFSET                   (0x08)                                        /**<  (DSU_LENGTH) Length  Offset */
+#define DSU_LENGTH_RESETVALUE               _U_(0x00)                                     /**<  (DSU_LENGTH) Length  Reset Value */
+
+#define DSU_LENGTH_LENGTH_Pos               2                                              /**< (DSU_LENGTH) Length Position */
+#define DSU_LENGTH_LENGTH_Msk               (_U_(0x3FFFFFFF) << DSU_LENGTH_LENGTH_Pos)     /**< (DSU_LENGTH) Length Mask */
+#define DSU_LENGTH_LENGTH(value)            (DSU_LENGTH_LENGTH_Msk & ((value) << DSU_LENGTH_LENGTH_Pos))
+#define DSU_LENGTH_MASK                     _U_(0xFFFFFFFC)                                /**< \deprecated (DSU_LENGTH) Register MASK  (Use DSU_LENGTH_Msk instead)  */
+#define DSU_LENGTH_Msk                      _U_(0xFFFFFFFC)                                /**< (DSU_LENGTH) Register Mask  */
+
+
+/* -------- DSU_DATA : (DSU Offset: 0x0c) (R/W 32) Data -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t DATA:32;                   /**< bit:  0..31  Data                                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DSU_DATA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_DATA_OFFSET                     (0x0C)                                        /**<  (DSU_DATA) Data  Offset */
+#define DSU_DATA_RESETVALUE                 _U_(0x00)                                     /**<  (DSU_DATA) Data  Reset Value */
+
+#define DSU_DATA_DATA_Pos                   0                                              /**< (DSU_DATA) Data Position */
+#define DSU_DATA_DATA_Msk                   (_U_(0xFFFFFFFF) << DSU_DATA_DATA_Pos)         /**< (DSU_DATA) Data Mask */
+#define DSU_DATA_DATA(value)                (DSU_DATA_DATA_Msk & ((value) << DSU_DATA_DATA_Pos))
+#define DSU_DATA_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (DSU_DATA) Register MASK  (Use DSU_DATA_Msk instead)  */
+#define DSU_DATA_Msk                        _U_(0xFFFFFFFF)                                /**< (DSU_DATA) Register Mask  */
+
+
+/* -------- DSU_DCC : (DSU Offset: 0x10) (R/W 32) Debug Communication Channel n -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t DATA:32;                   /**< bit:  0..31  Data                                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DSU_DCC_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_DCC_OFFSET                      (0x10)                                        /**<  (DSU_DCC) Debug Communication Channel n  Offset */
+#define DSU_DCC_RESETVALUE                  _U_(0x00)                                     /**<  (DSU_DCC) Debug Communication Channel n  Reset Value */
+
+#define DSU_DCC_DATA_Pos                    0                                              /**< (DSU_DCC) Data Position */
+#define DSU_DCC_DATA_Msk                    (_U_(0xFFFFFFFF) << DSU_DCC_DATA_Pos)          /**< (DSU_DCC) Data Mask */
+#define DSU_DCC_DATA(value)                 (DSU_DCC_DATA_Msk & ((value) << DSU_DCC_DATA_Pos))
+#define DSU_DCC_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (DSU_DCC) Register MASK  (Use DSU_DCC_Msk instead)  */
+#define DSU_DCC_Msk                         _U_(0xFFFFFFFF)                                /**< (DSU_DCC) Register Mask  */
+
+
+/* -------- DSU_DID : (DSU Offset: 0x18) (R/ 32) Device Identification -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t DEVSEL:8;                  /**< bit:   0..7  Device Select                            */
+    uint32_t REVISION:4;                /**< bit:  8..11  Revision Number                          */
+    uint32_t DIE:4;                     /**< bit: 12..15  Die Number                               */
+    uint32_t SERIES:6;                  /**< bit: 16..21  Series                                   */
+    uint32_t :1;                        /**< bit:     22  Reserved */
+    uint32_t FAMILY:5;                  /**< bit: 23..27  Family                                   */
+    uint32_t PROCESSOR:4;               /**< bit: 28..31  Processor                                */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DSU_DID_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_DID_OFFSET                      (0x18)                                        /**<  (DSU_DID) Device Identification  Offset */
+#define DSU_DID_RESETVALUE                  _U_(0x20840000)                               /**<  (DSU_DID) Device Identification  Reset Value */
+
+#define DSU_DID_DEVSEL_Pos                  0                                              /**< (DSU_DID) Device Select Position */
+#define DSU_DID_DEVSEL_Msk                  (_U_(0xFF) << DSU_DID_DEVSEL_Pos)              /**< (DSU_DID) Device Select Mask */
+#define DSU_DID_DEVSEL(value)               (DSU_DID_DEVSEL_Msk & ((value) << DSU_DID_DEVSEL_Pos))
+#define DSU_DID_REVISION_Pos                8                                              /**< (DSU_DID) Revision Number Position */
+#define DSU_DID_REVISION_Msk                (_U_(0xF) << DSU_DID_REVISION_Pos)             /**< (DSU_DID) Revision Number Mask */
+#define DSU_DID_REVISION(value)             (DSU_DID_REVISION_Msk & ((value) << DSU_DID_REVISION_Pos))
+#define DSU_DID_DIE_Pos                     12                                             /**< (DSU_DID) Die Number Position */
+#define DSU_DID_DIE_Msk                     (_U_(0xF) << DSU_DID_DIE_Pos)                  /**< (DSU_DID) Die Number Mask */
+#define DSU_DID_DIE(value)                  (DSU_DID_DIE_Msk & ((value) << DSU_DID_DIE_Pos))
+#define DSU_DID_SERIES_Pos                  16                                             /**< (DSU_DID) Series Position */
+#define DSU_DID_SERIES_Msk                  (_U_(0x3F) << DSU_DID_SERIES_Pos)              /**< (DSU_DID) Series Mask */
+#define DSU_DID_SERIES(value)               (DSU_DID_SERIES_Msk & ((value) << DSU_DID_SERIES_Pos))
+#define   DSU_DID_SERIES_0_Val              _U_(0x0)                                       /**< (DSU_DID) Cortex-M0+ processor, basic feature set  */
+#define   DSU_DID_SERIES_1_Val              _U_(0x1)                                       /**< (DSU_DID) Cortex-M0+ processor, USB  */
+#define DSU_DID_SERIES_0                    (DSU_DID_SERIES_0_Val << DSU_DID_SERIES_Pos)   /**< (DSU_DID) Cortex-M0+ processor, basic feature set Position  */
+#define DSU_DID_SERIES_1                    (DSU_DID_SERIES_1_Val << DSU_DID_SERIES_Pos)   /**< (DSU_DID) Cortex-M0+ processor, USB Position  */
+#define DSU_DID_FAMILY_Pos                  23                                             /**< (DSU_DID) Family Position */
+#define DSU_DID_FAMILY_Msk                  (_U_(0x1F) << DSU_DID_FAMILY_Pos)              /**< (DSU_DID) Family Mask */
+#define DSU_DID_FAMILY(value)               (DSU_DID_FAMILY_Msk & ((value) << DSU_DID_FAMILY_Pos))
+#define   DSU_DID_FAMILY_0_Val              _U_(0x0)                                       /**< (DSU_DID) General purpose microcontroller  */
+#define   DSU_DID_FAMILY_1_Val              _U_(0x1)                                       /**< (DSU_DID) PicoPower  */
+#define DSU_DID_FAMILY_0                    (DSU_DID_FAMILY_0_Val << DSU_DID_FAMILY_Pos)   /**< (DSU_DID) General purpose microcontroller Position  */
+#define DSU_DID_FAMILY_1                    (DSU_DID_FAMILY_1_Val << DSU_DID_FAMILY_Pos)   /**< (DSU_DID) PicoPower Position  */
+#define DSU_DID_PROCESSOR_Pos               28                                             /**< (DSU_DID) Processor Position */
+#define DSU_DID_PROCESSOR_Msk               (_U_(0xF) << DSU_DID_PROCESSOR_Pos)            /**< (DSU_DID) Processor Mask */
+#define DSU_DID_PROCESSOR(value)            (DSU_DID_PROCESSOR_Msk & ((value) << DSU_DID_PROCESSOR_Pos))
+#define   DSU_DID_PROCESSOR_CM0P_Val        _U_(0x1)                                       /**< (DSU_DID) Cortex-M0+  */
+#define   DSU_DID_PROCESSOR_CM23_Val        _U_(0x2)                                       /**< (DSU_DID) Cortex-M23  */
+#define   DSU_DID_PROCESSOR_CM3_Val         _U_(0x3)                                       /**< (DSU_DID) Cortex-M3  */
+#define   DSU_DID_PROCESSOR_CM4_Val         _U_(0x5)                                       /**< (DSU_DID) Cortex-M4  */
+#define   DSU_DID_PROCESSOR_CM4F_Val        _U_(0x6)                                       /**< (DSU_DID) Cortex-M4 with FPU  */
+#define   DSU_DID_PROCESSOR_CM33_Val        _U_(0x7)                                       /**< (DSU_DID) Cortex-M33  */
+#define DSU_DID_PROCESSOR_CM0P              (DSU_DID_PROCESSOR_CM0P_Val << DSU_DID_PROCESSOR_Pos)  /**< (DSU_DID) Cortex-M0+ Position  */
+#define DSU_DID_PROCESSOR_CM23              (DSU_DID_PROCESSOR_CM23_Val << DSU_DID_PROCESSOR_Pos)  /**< (DSU_DID) Cortex-M23 Position  */
+#define DSU_DID_PROCESSOR_CM3               (DSU_DID_PROCESSOR_CM3_Val << DSU_DID_PROCESSOR_Pos)  /**< (DSU_DID) Cortex-M3 Position  */
+#define DSU_DID_PROCESSOR_CM4               (DSU_DID_PROCESSOR_CM4_Val << DSU_DID_PROCESSOR_Pos)  /**< (DSU_DID) Cortex-M4 Position  */
+#define DSU_DID_PROCESSOR_CM4F              (DSU_DID_PROCESSOR_CM4F_Val << DSU_DID_PROCESSOR_Pos)  /**< (DSU_DID) Cortex-M4 with FPU Position  */
+#define DSU_DID_PROCESSOR_CM33              (DSU_DID_PROCESSOR_CM33_Val << DSU_DID_PROCESSOR_Pos)  /**< (DSU_DID) Cortex-M33 Position  */
+#define DSU_DID_MASK                        _U_(0xFFBFFFFF)                                /**< \deprecated (DSU_DID) Register MASK  (Use DSU_DID_Msk instead)  */
+#define DSU_DID_Msk                         _U_(0xFFBFFFFF)                                /**< (DSU_DID) Register Mask  */
+
+
+/* -------- DSU_CFG : (DSU Offset: 0x1c) (R/W 32) Configuration -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t LQOS:2;                    /**< bit:   0..1  Latency Quality Of Service               */
+    uint32_t DCCDMALEVEL:2;             /**< bit:   2..3  DMA Trigger Level                        */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DSU_CFG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_CFG_OFFSET                      (0x1C)                                        /**<  (DSU_CFG) Configuration  Offset */
+#define DSU_CFG_RESETVALUE                  _U_(0x02)                                     /**<  (DSU_CFG) Configuration  Reset Value */
+
+#define DSU_CFG_LQOS_Pos                    0                                              /**< (DSU_CFG) Latency Quality Of Service Position */
+#define DSU_CFG_LQOS_Msk                    (_U_(0x3) << DSU_CFG_LQOS_Pos)                 /**< (DSU_CFG) Latency Quality Of Service Mask */
+#define DSU_CFG_LQOS(value)                 (DSU_CFG_LQOS_Msk & ((value) << DSU_CFG_LQOS_Pos))
+#define DSU_CFG_DCCDMALEVEL_Pos             2                                              /**< (DSU_CFG) DMA Trigger Level Position */
+#define DSU_CFG_DCCDMALEVEL_Msk             (_U_(0x3) << DSU_CFG_DCCDMALEVEL_Pos)          /**< (DSU_CFG) DMA Trigger Level Mask */
+#define DSU_CFG_DCCDMALEVEL(value)          (DSU_CFG_DCCDMALEVEL_Msk & ((value) << DSU_CFG_DCCDMALEVEL_Pos))
+#define   DSU_CFG_DCCDMALEVEL_EMPTY_Val     _U_(0x0)                                       /**< (DSU_CFG) Trigger rises when DCC is empty  */
+#define   DSU_CFG_DCCDMALEVEL_FULL_Val      _U_(0x1)                                       /**< (DSU_CFG) Trigger rises when DCC is full  */
+#define DSU_CFG_DCCDMALEVEL_EMPTY           (DSU_CFG_DCCDMALEVEL_EMPTY_Val << DSU_CFG_DCCDMALEVEL_Pos)  /**< (DSU_CFG) Trigger rises when DCC is empty Position  */
+#define DSU_CFG_DCCDMALEVEL_FULL            (DSU_CFG_DCCDMALEVEL_FULL_Val << DSU_CFG_DCCDMALEVEL_Pos)  /**< (DSU_CFG) Trigger rises when DCC is full Position  */
+#define DSU_CFG_MASK                        _U_(0x0F)                                      /**< \deprecated (DSU_CFG) Register MASK  (Use DSU_CFG_Msk instead)  */
+#define DSU_CFG_Msk                         _U_(0x0F)                                      /**< (DSU_CFG) Register Mask  */
+
+
+/* -------- DSU_BCC : (DSU Offset: 0x20) (R/W 32) Boot ROM Communication Channel n -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t DATA:32;                   /**< bit:  0..31  Data                                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DSU_BCC_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_BCC_OFFSET                      (0x20)                                        /**<  (DSU_BCC) Boot ROM Communication Channel n  Offset */
+#define DSU_BCC_RESETVALUE                  _U_(0x00)                                     /**<  (DSU_BCC) Boot ROM Communication Channel n  Reset Value */
+
+#define DSU_BCC_DATA_Pos                    0                                              /**< (DSU_BCC) Data Position */
+#define DSU_BCC_DATA_Msk                    (_U_(0xFFFFFFFF) << DSU_BCC_DATA_Pos)          /**< (DSU_BCC) Data Mask */
+#define DSU_BCC_DATA(value)                 (DSU_BCC_DATA_Msk & ((value) << DSU_BCC_DATA_Pos))
+#define DSU_BCC_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (DSU_BCC) Register MASK  (Use DSU_BCC_Msk instead)  */
+#define DSU_BCC_Msk                         _U_(0xFFFFFFFF)                                /**< (DSU_BCC) Register Mask  */
+
+
+/* -------- DSU_DCFG : (DSU Offset: 0xf0) (R/W 32) Device Configuration -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t DCFG:32;                   /**< bit:  0..31  Device Configuration                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DSU_DCFG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_DCFG_OFFSET                     (0xF0)                                        /**<  (DSU_DCFG) Device Configuration  Offset */
+#define DSU_DCFG_RESETVALUE                 _U_(0x00)                                     /**<  (DSU_DCFG) Device Configuration  Reset Value */
+
+#define DSU_DCFG_DCFG_Pos                   0                                              /**< (DSU_DCFG) Device Configuration Position */
+#define DSU_DCFG_DCFG_Msk                   (_U_(0xFFFFFFFF) << DSU_DCFG_DCFG_Pos)         /**< (DSU_DCFG) Device Configuration Mask */
+#define DSU_DCFG_DCFG(value)                (DSU_DCFG_DCFG_Msk & ((value) << DSU_DCFG_DCFG_Pos))
+#define DSU_DCFG_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (DSU_DCFG) Register MASK  (Use DSU_DCFG_Msk instead)  */
+#define DSU_DCFG_Msk                        _U_(0xFFFFFFFF)                                /**< (DSU_DCFG) Register Mask  */
+
+
+/* -------- DSU_ENTRY0 : (DSU Offset: 0x1000) (R/ 32) CoreSight ROM Table Entry 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t EPRES:1;                   /**< bit:      0  Entry Present                            */
+    uint32_t FMT:1;                     /**< bit:      1  Format                                   */
+    uint32_t :10;                       /**< bit:  2..11  Reserved */
+    uint32_t ADDOFF:20;                 /**< bit: 12..31  Address Offset                           */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DSU_ENTRY0_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_ENTRY0_OFFSET                   (0x1000)                                      /**<  (DSU_ENTRY0) CoreSight ROM Table Entry 0  Offset */
+#define DSU_ENTRY0_RESETVALUE               _U_(0x9F0FC002)                               /**<  (DSU_ENTRY0) CoreSight ROM Table Entry 0  Reset Value */
+
+#define DSU_ENTRY0_EPRES_Pos                0                                              /**< (DSU_ENTRY0) Entry Present Position */
+#define DSU_ENTRY0_EPRES_Msk                (_U_(0x1) << DSU_ENTRY0_EPRES_Pos)             /**< (DSU_ENTRY0) Entry Present Mask */
+#define DSU_ENTRY0_EPRES                    DSU_ENTRY0_EPRES_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use DSU_ENTRY0_EPRES_Msk instead */
+#define DSU_ENTRY0_FMT_Pos                  1                                              /**< (DSU_ENTRY0) Format Position */
+#define DSU_ENTRY0_FMT_Msk                  (_U_(0x1) << DSU_ENTRY0_FMT_Pos)               /**< (DSU_ENTRY0) Format Mask */
+#define DSU_ENTRY0_FMT                      DSU_ENTRY0_FMT_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use DSU_ENTRY0_FMT_Msk instead */
+#define DSU_ENTRY0_ADDOFF_Pos               12                                             /**< (DSU_ENTRY0) Address Offset Position */
+#define DSU_ENTRY0_ADDOFF_Msk               (_U_(0xFFFFF) << DSU_ENTRY0_ADDOFF_Pos)        /**< (DSU_ENTRY0) Address Offset Mask */
+#define DSU_ENTRY0_ADDOFF(value)            (DSU_ENTRY0_ADDOFF_Msk & ((value) << DSU_ENTRY0_ADDOFF_Pos))
+#define DSU_ENTRY0_MASK                     _U_(0xFFFFF003)                                /**< \deprecated (DSU_ENTRY0) Register MASK  (Use DSU_ENTRY0_Msk instead)  */
+#define DSU_ENTRY0_Msk                      _U_(0xFFFFF003)                                /**< (DSU_ENTRY0) Register Mask  */
+
+
+/* -------- DSU_ENTRY1 : (DSU Offset: 0x1004) (R/ 32) CoreSight ROM Table Entry 1 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  uint32_t reg;                         /**< Type used for register access */
+} DSU_ENTRY1_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_ENTRY1_OFFSET                   (0x1004)                                      /**<  (DSU_ENTRY1) CoreSight ROM Table Entry 1  Offset */
+#define DSU_ENTRY1_RESETVALUE               _U_(0x00)                                     /**<  (DSU_ENTRY1) CoreSight ROM Table Entry 1  Reset Value */
+
+#define DSU_ENTRY1_MASK                     _U_(0x00)                                      /**< \deprecated (DSU_ENTRY1) Register MASK  (Use DSU_ENTRY1_Msk instead)  */
+#define DSU_ENTRY1_Msk                      _U_(0x00)                                      /**< (DSU_ENTRY1) Register Mask  */
+
+
+/* -------- DSU_END : (DSU Offset: 0x1008) (R/ 32) CoreSight ROM Table End -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t END:32;                    /**< bit:  0..31  End Marker                               */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DSU_END_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_END_OFFSET                      (0x1008)                                      /**<  (DSU_END) CoreSight ROM Table End  Offset */
+#define DSU_END_RESETVALUE                  _U_(0x00)                                     /**<  (DSU_END) CoreSight ROM Table End  Reset Value */
+
+#define DSU_END_END_Pos                     0                                              /**< (DSU_END) End Marker Position */
+#define DSU_END_END_Msk                     (_U_(0xFFFFFFFF) << DSU_END_END_Pos)           /**< (DSU_END) End Marker Mask */
+#define DSU_END_END(value)                  (DSU_END_END_Msk & ((value) << DSU_END_END_Pos))
+#define DSU_END_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (DSU_END) Register MASK  (Use DSU_END_Msk instead)  */
+#define DSU_END_Msk                         _U_(0xFFFFFFFF)                                /**< (DSU_END) Register Mask  */
+
+
+/* -------- DSU_MEMTYPE : (DSU Offset: 0x1fcc) (R/ 32) CoreSight ROM Table Memory Type -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SMEMP:1;                   /**< bit:      0  System Memory Present                    */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DSU_MEMTYPE_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_MEMTYPE_OFFSET                  (0x1FCC)                                      /**<  (DSU_MEMTYPE) CoreSight ROM Table Memory Type  Offset */
+#define DSU_MEMTYPE_RESETVALUE              _U_(0x00)                                     /**<  (DSU_MEMTYPE) CoreSight ROM Table Memory Type  Reset Value */
+
+#define DSU_MEMTYPE_SMEMP_Pos               0                                              /**< (DSU_MEMTYPE) System Memory Present Position */
+#define DSU_MEMTYPE_SMEMP_Msk               (_U_(0x1) << DSU_MEMTYPE_SMEMP_Pos)            /**< (DSU_MEMTYPE) System Memory Present Mask */
+#define DSU_MEMTYPE_SMEMP                   DSU_MEMTYPE_SMEMP_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use DSU_MEMTYPE_SMEMP_Msk instead */
+#define DSU_MEMTYPE_MASK                    _U_(0x01)                                      /**< \deprecated (DSU_MEMTYPE) Register MASK  (Use DSU_MEMTYPE_Msk instead)  */
+#define DSU_MEMTYPE_Msk                     _U_(0x01)                                      /**< (DSU_MEMTYPE) Register Mask  */
+
+
+/* -------- DSU_PID4 : (DSU Offset: 0x1fd0) (R/ 32) Peripheral Identification 4 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t JEPCC:4;                   /**< bit:   0..3  JEP-106 Continuation Code                */
+    uint32_t FKBC:4;                    /**< bit:   4..7  4KB count                                */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DSU_PID4_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_PID4_OFFSET                     (0x1FD0)                                      /**<  (DSU_PID4) Peripheral Identification 4  Offset */
+#define DSU_PID4_RESETVALUE                 _U_(0x00)                                     /**<  (DSU_PID4) Peripheral Identification 4  Reset Value */
+
+#define DSU_PID4_JEPCC_Pos                  0                                              /**< (DSU_PID4) JEP-106 Continuation Code Position */
+#define DSU_PID4_JEPCC_Msk                  (_U_(0xF) << DSU_PID4_JEPCC_Pos)               /**< (DSU_PID4) JEP-106 Continuation Code Mask */
+#define DSU_PID4_JEPCC(value)               (DSU_PID4_JEPCC_Msk & ((value) << DSU_PID4_JEPCC_Pos))
+#define DSU_PID4_FKBC_Pos                   4                                              /**< (DSU_PID4) 4KB count Position */
+#define DSU_PID4_FKBC_Msk                   (_U_(0xF) << DSU_PID4_FKBC_Pos)                /**< (DSU_PID4) 4KB count Mask */
+#define DSU_PID4_FKBC(value)                (DSU_PID4_FKBC_Msk & ((value) << DSU_PID4_FKBC_Pos))
+#define DSU_PID4_MASK                       _U_(0xFF)                                      /**< \deprecated (DSU_PID4) Register MASK  (Use DSU_PID4_Msk instead)  */
+#define DSU_PID4_Msk                        _U_(0xFF)                                      /**< (DSU_PID4) Register Mask  */
+
+
+/* -------- DSU_PID5 : (DSU Offset: 0x1fd4) (R/ 32) Peripheral Identification 5 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  uint32_t reg;                         /**< Type used for register access */
+} DSU_PID5_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_PID5_OFFSET                     (0x1FD4)                                      /**<  (DSU_PID5) Peripheral Identification 5  Offset */
+#define DSU_PID5_RESETVALUE                 _U_(0x00)                                     /**<  (DSU_PID5) Peripheral Identification 5  Reset Value */
+
+#define DSU_PID5_MASK                       _U_(0x00)                                      /**< \deprecated (DSU_PID5) Register MASK  (Use DSU_PID5_Msk instead)  */
+#define DSU_PID5_Msk                        _U_(0x00)                                      /**< (DSU_PID5) Register Mask  */
+
+
+/* -------- DSU_PID6 : (DSU Offset: 0x1fd8) (R/ 32) Peripheral Identification 6 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  uint32_t reg;                         /**< Type used for register access */
+} DSU_PID6_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_PID6_OFFSET                     (0x1FD8)                                      /**<  (DSU_PID6) Peripheral Identification 6  Offset */
+#define DSU_PID6_RESETVALUE                 _U_(0x00)                                     /**<  (DSU_PID6) Peripheral Identification 6  Reset Value */
+
+#define DSU_PID6_MASK                       _U_(0x00)                                      /**< \deprecated (DSU_PID6) Register MASK  (Use DSU_PID6_Msk instead)  */
+#define DSU_PID6_Msk                        _U_(0x00)                                      /**< (DSU_PID6) Register Mask  */
+
+
+/* -------- DSU_PID7 : (DSU Offset: 0x1fdc) (R/ 32) Peripheral Identification 7 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  uint32_t reg;                         /**< Type used for register access */
+} DSU_PID7_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_PID7_OFFSET                     (0x1FDC)                                      /**<  (DSU_PID7) Peripheral Identification 7  Offset */
+#define DSU_PID7_RESETVALUE                 _U_(0x00)                                     /**<  (DSU_PID7) Peripheral Identification 7  Reset Value */
+
+#define DSU_PID7_MASK                       _U_(0x00)                                      /**< \deprecated (DSU_PID7) Register MASK  (Use DSU_PID7_Msk instead)  */
+#define DSU_PID7_Msk                        _U_(0x00)                                      /**< (DSU_PID7) Register Mask  */
+
+
+/* -------- DSU_PID0 : (DSU Offset: 0x1fe0) (R/ 32) Peripheral Identification 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t PARTNBL:8;                 /**< bit:   0..7  Part Number Low                          */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DSU_PID0_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_PID0_OFFSET                     (0x1FE0)                                      /**<  (DSU_PID0) Peripheral Identification 0  Offset */
+#define DSU_PID0_RESETVALUE                 _U_(0xD0)                                     /**<  (DSU_PID0) Peripheral Identification 0  Reset Value */
+
+#define DSU_PID0_PARTNBL_Pos                0                                              /**< (DSU_PID0) Part Number Low Position */
+#define DSU_PID0_PARTNBL_Msk                (_U_(0xFF) << DSU_PID0_PARTNBL_Pos)            /**< (DSU_PID0) Part Number Low Mask */
+#define DSU_PID0_PARTNBL(value)             (DSU_PID0_PARTNBL_Msk & ((value) << DSU_PID0_PARTNBL_Pos))
+#define DSU_PID0_MASK                       _U_(0xFF)                                      /**< \deprecated (DSU_PID0) Register MASK  (Use DSU_PID0_Msk instead)  */
+#define DSU_PID0_Msk                        _U_(0xFF)                                      /**< (DSU_PID0) Register Mask  */
+
+
+/* -------- DSU_PID1 : (DSU Offset: 0x1fe4) (R/ 32) Peripheral Identification 1 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t PARTNBH:4;                 /**< bit:   0..3  Part Number High                         */
+    uint32_t JEPIDCL:4;                 /**< bit:   4..7  Low part of the JEP-106 Identity Code    */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DSU_PID1_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_PID1_OFFSET                     (0x1FE4)                                      /**<  (DSU_PID1) Peripheral Identification 1  Offset */
+#define DSU_PID1_RESETVALUE                 _U_(0xFC)                                     /**<  (DSU_PID1) Peripheral Identification 1  Reset Value */
+
+#define DSU_PID1_PARTNBH_Pos                0                                              /**< (DSU_PID1) Part Number High Position */
+#define DSU_PID1_PARTNBH_Msk                (_U_(0xF) << DSU_PID1_PARTNBH_Pos)             /**< (DSU_PID1) Part Number High Mask */
+#define DSU_PID1_PARTNBH(value)             (DSU_PID1_PARTNBH_Msk & ((value) << DSU_PID1_PARTNBH_Pos))
+#define DSU_PID1_JEPIDCL_Pos                4                                              /**< (DSU_PID1) Low part of the JEP-106 Identity Code Position */
+#define DSU_PID1_JEPIDCL_Msk                (_U_(0xF) << DSU_PID1_JEPIDCL_Pos)             /**< (DSU_PID1) Low part of the JEP-106 Identity Code Mask */
+#define DSU_PID1_JEPIDCL(value)             (DSU_PID1_JEPIDCL_Msk & ((value) << DSU_PID1_JEPIDCL_Pos))
+#define DSU_PID1_MASK                       _U_(0xFF)                                      /**< \deprecated (DSU_PID1) Register MASK  (Use DSU_PID1_Msk instead)  */
+#define DSU_PID1_Msk                        _U_(0xFF)                                      /**< (DSU_PID1) Register Mask  */
+
+
+/* -------- DSU_PID2 : (DSU Offset: 0x1fe8) (R/ 32) Peripheral Identification 2 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t JEPIDCH:3;                 /**< bit:   0..2  JEP-106 Identity Code High               */
+    uint32_t JEPU:1;                    /**< bit:      3  JEP-106 Identity Code is used            */
+    uint32_t REVISION:4;                /**< bit:   4..7  Revision Number                          */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DSU_PID2_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_PID2_OFFSET                     (0x1FE8)                                      /**<  (DSU_PID2) Peripheral Identification 2  Offset */
+#define DSU_PID2_RESETVALUE                 _U_(0x09)                                     /**<  (DSU_PID2) Peripheral Identification 2  Reset Value */
+
+#define DSU_PID2_JEPIDCH_Pos                0                                              /**< (DSU_PID2) JEP-106 Identity Code High Position */
+#define DSU_PID2_JEPIDCH_Msk                (_U_(0x7) << DSU_PID2_JEPIDCH_Pos)             /**< (DSU_PID2) JEP-106 Identity Code High Mask */
+#define DSU_PID2_JEPIDCH(value)             (DSU_PID2_JEPIDCH_Msk & ((value) << DSU_PID2_JEPIDCH_Pos))
+#define DSU_PID2_JEPU_Pos                   3                                              /**< (DSU_PID2) JEP-106 Identity Code is used Position */
+#define DSU_PID2_JEPU_Msk                   (_U_(0x1) << DSU_PID2_JEPU_Pos)                /**< (DSU_PID2) JEP-106 Identity Code is used Mask */
+#define DSU_PID2_JEPU                       DSU_PID2_JEPU_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use DSU_PID2_JEPU_Msk instead */
+#define DSU_PID2_REVISION_Pos               4                                              /**< (DSU_PID2) Revision Number Position */
+#define DSU_PID2_REVISION_Msk               (_U_(0xF) << DSU_PID2_REVISION_Pos)            /**< (DSU_PID2) Revision Number Mask */
+#define DSU_PID2_REVISION(value)            (DSU_PID2_REVISION_Msk & ((value) << DSU_PID2_REVISION_Pos))
+#define DSU_PID2_MASK                       _U_(0xFF)                                      /**< \deprecated (DSU_PID2) Register MASK  (Use DSU_PID2_Msk instead)  */
+#define DSU_PID2_Msk                        _U_(0xFF)                                      /**< (DSU_PID2) Register Mask  */
+
+
+/* -------- DSU_PID3 : (DSU Offset: 0x1fec) (R/ 32) Peripheral Identification 3 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t CUSMOD:4;                  /**< bit:   0..3  ARM CUSMOD                               */
+    uint32_t REVAND:4;                  /**< bit:   4..7  Revision Number                          */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DSU_PID3_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_PID3_OFFSET                     (0x1FEC)                                      /**<  (DSU_PID3) Peripheral Identification 3  Offset */
+#define DSU_PID3_RESETVALUE                 _U_(0x00)                                     /**<  (DSU_PID3) Peripheral Identification 3  Reset Value */
+
+#define DSU_PID3_CUSMOD_Pos                 0                                              /**< (DSU_PID3) ARM CUSMOD Position */
+#define DSU_PID3_CUSMOD_Msk                 (_U_(0xF) << DSU_PID3_CUSMOD_Pos)              /**< (DSU_PID3) ARM CUSMOD Mask */
+#define DSU_PID3_CUSMOD(value)              (DSU_PID3_CUSMOD_Msk & ((value) << DSU_PID3_CUSMOD_Pos))
+#define DSU_PID3_REVAND_Pos                 4                                              /**< (DSU_PID3) Revision Number Position */
+#define DSU_PID3_REVAND_Msk                 (_U_(0xF) << DSU_PID3_REVAND_Pos)              /**< (DSU_PID3) Revision Number Mask */
+#define DSU_PID3_REVAND(value)              (DSU_PID3_REVAND_Msk & ((value) << DSU_PID3_REVAND_Pos))
+#define DSU_PID3_MASK                       _U_(0xFF)                                      /**< \deprecated (DSU_PID3) Register MASK  (Use DSU_PID3_Msk instead)  */
+#define DSU_PID3_Msk                        _U_(0xFF)                                      /**< (DSU_PID3) Register Mask  */
+
+
+/* -------- DSU_CID0 : (DSU Offset: 0x1ff0) (R/ 32) Component Identification 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t PREAMBLEB0:8;              /**< bit:   0..7  Preamble Byte 0                          */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DSU_CID0_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_CID0_OFFSET                     (0x1FF0)                                      /**<  (DSU_CID0) Component Identification 0  Offset */
+#define DSU_CID0_RESETVALUE                 _U_(0x0D)                                     /**<  (DSU_CID0) Component Identification 0  Reset Value */
+
+#define DSU_CID0_PREAMBLEB0_Pos             0                                              /**< (DSU_CID0) Preamble Byte 0 Position */
+#define DSU_CID0_PREAMBLEB0_Msk             (_U_(0xFF) << DSU_CID0_PREAMBLEB0_Pos)         /**< (DSU_CID0) Preamble Byte 0 Mask */
+#define DSU_CID0_PREAMBLEB0(value)          (DSU_CID0_PREAMBLEB0_Msk & ((value) << DSU_CID0_PREAMBLEB0_Pos))
+#define DSU_CID0_MASK                       _U_(0xFF)                                      /**< \deprecated (DSU_CID0) Register MASK  (Use DSU_CID0_Msk instead)  */
+#define DSU_CID0_Msk                        _U_(0xFF)                                      /**< (DSU_CID0) Register Mask  */
+
+
+/* -------- DSU_CID1 : (DSU Offset: 0x1ff4) (R/ 32) Component Identification 1 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t PREAMBLE:4;                /**< bit:   0..3  Preamble                                 */
+    uint32_t CCLASS:4;                  /**< bit:   4..7  Component Class                          */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DSU_CID1_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_CID1_OFFSET                     (0x1FF4)                                      /**<  (DSU_CID1) Component Identification 1  Offset */
+#define DSU_CID1_RESETVALUE                 _U_(0x10)                                     /**<  (DSU_CID1) Component Identification 1  Reset Value */
+
+#define DSU_CID1_PREAMBLE_Pos               0                                              /**< (DSU_CID1) Preamble Position */
+#define DSU_CID1_PREAMBLE_Msk               (_U_(0xF) << DSU_CID1_PREAMBLE_Pos)            /**< (DSU_CID1) Preamble Mask */
+#define DSU_CID1_PREAMBLE(value)            (DSU_CID1_PREAMBLE_Msk & ((value) << DSU_CID1_PREAMBLE_Pos))
+#define DSU_CID1_CCLASS_Pos                 4                                              /**< (DSU_CID1) Component Class Position */
+#define DSU_CID1_CCLASS_Msk                 (_U_(0xF) << DSU_CID1_CCLASS_Pos)              /**< (DSU_CID1) Component Class Mask */
+#define DSU_CID1_CCLASS(value)              (DSU_CID1_CCLASS_Msk & ((value) << DSU_CID1_CCLASS_Pos))
+#define DSU_CID1_MASK                       _U_(0xFF)                                      /**< \deprecated (DSU_CID1) Register MASK  (Use DSU_CID1_Msk instead)  */
+#define DSU_CID1_Msk                        _U_(0xFF)                                      /**< (DSU_CID1) Register Mask  */
+
+
+/* -------- DSU_CID2 : (DSU Offset: 0x1ff8) (R/ 32) Component Identification 2 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t PREAMBLEB2:8;              /**< bit:   0..7  Preamble Byte 2                          */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DSU_CID2_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_CID2_OFFSET                     (0x1FF8)                                      /**<  (DSU_CID2) Component Identification 2  Offset */
+#define DSU_CID2_RESETVALUE                 _U_(0x05)                                     /**<  (DSU_CID2) Component Identification 2  Reset Value */
+
+#define DSU_CID2_PREAMBLEB2_Pos             0                                              /**< (DSU_CID2) Preamble Byte 2 Position */
+#define DSU_CID2_PREAMBLEB2_Msk             (_U_(0xFF) << DSU_CID2_PREAMBLEB2_Pos)         /**< (DSU_CID2) Preamble Byte 2 Mask */
+#define DSU_CID2_PREAMBLEB2(value)          (DSU_CID2_PREAMBLEB2_Msk & ((value) << DSU_CID2_PREAMBLEB2_Pos))
+#define DSU_CID2_MASK                       _U_(0xFF)                                      /**< \deprecated (DSU_CID2) Register MASK  (Use DSU_CID2_Msk instead)  */
+#define DSU_CID2_Msk                        _U_(0xFF)                                      /**< (DSU_CID2) Register Mask  */
+
+
+/* -------- DSU_CID3 : (DSU Offset: 0x1ffc) (R/ 32) Component Identification 3 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t PREAMBLEB3:8;              /**< bit:   0..7  Preamble Byte 3                          */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DSU_CID3_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_CID3_OFFSET                     (0x1FFC)                                      /**<  (DSU_CID3) Component Identification 3  Offset */
+#define DSU_CID3_RESETVALUE                 _U_(0xB1)                                     /**<  (DSU_CID3) Component Identification 3  Reset Value */
+
+#define DSU_CID3_PREAMBLEB3_Pos             0                                              /**< (DSU_CID3) Preamble Byte 3 Position */
+#define DSU_CID3_PREAMBLEB3_Msk             (_U_(0xFF) << DSU_CID3_PREAMBLEB3_Pos)         /**< (DSU_CID3) Preamble Byte 3 Mask */
+#define DSU_CID3_PREAMBLEB3(value)          (DSU_CID3_PREAMBLEB3_Msk & ((value) << DSU_CID3_PREAMBLEB3_Pos))
+#define DSU_CID3_MASK                       _U_(0xFF)                                      /**< \deprecated (DSU_CID3) Register MASK  (Use DSU_CID3_Msk instead)  */
+#define DSU_CID3_Msk                        _U_(0xFF)                                      /**< (DSU_CID3) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief DSU hardware registers */
+typedef struct {  /* Device Service Unit */
+  __O  DSU_CTRL_Type                  CTRL;           /**< Offset: 0x00 ( /W   8) Control */
+  __IO DSU_STATUSA_Type               STATUSA;        /**< Offset: 0x01 (R/W   8) Status A */
+  __I  DSU_STATUSB_Type               STATUSB;        /**< Offset: 0x02 (R/    8) Status B */
+  __I  DSU_STATUSC_Type               STATUSC;        /**< Offset: 0x03 (R/    8) Status C */
+  __IO DSU_ADDR_Type                  ADDR;           /**< Offset: 0x04 (R/W  32) Address */
+  __IO DSU_LENGTH_Type                LENGTH;         /**< Offset: 0x08 (R/W  32) Length */
+  __IO DSU_DATA_Type                  DATA;           /**< Offset: 0x0C (R/W  32) Data */
+  __IO DSU_DCC_Type                   DCC[2];         /**< Offset: 0x10 (R/W  32) Debug Communication Channel n */
+  __I  DSU_DID_Type                   DID;            /**< Offset: 0x18 (R/   32) Device Identification */
+  __IO DSU_CFG_Type                   CFG;            /**< Offset: 0x1C (R/W  32) Configuration */
+  __IO DSU_BCC_Type                   BCC[2];         /**< Offset: 0x20 (R/W  32) Boot ROM Communication Channel n */
+  __I  uint8_t                        Reserved1[200];
+  __IO DSU_DCFG_Type                  DCFG[2];        /**< Offset: 0xF0 (R/W  32) Device Configuration */
+  __I  uint8_t                        Reserved2[3848];
+  __I  DSU_ENTRY0_Type                ENTRY0;         /**< Offset: 0x1000 (R/   32) CoreSight ROM Table Entry 0 */
+  __I  DSU_ENTRY1_Type                ENTRY1;         /**< Offset: 0x1004 (R/   32) CoreSight ROM Table Entry 1 */
+  __I  DSU_END_Type                   END;            /**< Offset: 0x1008 (R/   32) CoreSight ROM Table End */
+  __I  uint8_t                        Reserved3[4032];
+  __I  DSU_MEMTYPE_Type               MEMTYPE;        /**< Offset: 0x1FCC (R/   32) CoreSight ROM Table Memory Type */
+  __I  DSU_PID4_Type                  PID4;           /**< Offset: 0x1FD0 (R/   32) Peripheral Identification 4 */
+  __I  DSU_PID5_Type                  PID5;           /**< Offset: 0x1FD4 (R/   32) Peripheral Identification 5 */
+  __I  DSU_PID6_Type                  PID6;           /**< Offset: 0x1FD8 (R/   32) Peripheral Identification 6 */
+  __I  DSU_PID7_Type                  PID7;           /**< Offset: 0x1FDC (R/   32) Peripheral Identification 7 */
+  __I  DSU_PID0_Type                  PID0;           /**< Offset: 0x1FE0 (R/   32) Peripheral Identification 0 */
+  __I  DSU_PID1_Type                  PID1;           /**< Offset: 0x1FE4 (R/   32) Peripheral Identification 1 */
+  __I  DSU_PID2_Type                  PID2;           /**< Offset: 0x1FE8 (R/   32) Peripheral Identification 2 */
+  __I  DSU_PID3_Type                  PID3;           /**< Offset: 0x1FEC (R/   32) Peripheral Identification 3 */
+  __I  DSU_CID0_Type                  CID0;           /**< Offset: 0x1FF0 (R/   32) Component Identification 0 */
+  __I  DSU_CID1_Type                  CID1;           /**< Offset: 0x1FF4 (R/   32) Component Identification 1 */
+  __I  DSU_CID2_Type                  CID2;           /**< Offset: 0x1FF8 (R/   32) Component Identification 2 */
+  __I  DSU_CID3_Type                  CID3;           /**< Offset: 0x1FFC (R/   32) Component Identification 3 */
+} Dsu;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Device Service Unit */
+
+#endif /* _SAML10_DSU_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/component/eic.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/eic.h
@@ -1,0 +1,610 @@
+/**
+ * \file
+ *
+ * \brief Component description for EIC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_EIC_COMPONENT_H_
+#define _SAML10_EIC_COMPONENT_H_
+#define _SAML10_EIC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML10 External Interrupt Controller
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR EIC */
+/* ========================================================================== */
+
+#define EIC_U2804                      /**< (EIC) Module ID */
+#define REV_EIC 0x100                  /**< (EIC) Module revision */
+
+/* -------- EIC_CTRLA : (EIC Offset: 0x00) (R/W 8) Control A -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint8_t  ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint8_t  :2;                        /**< bit:   2..3  Reserved */
+    uint8_t  CKSEL:1;                   /**< bit:      4  Clock Selection                          */
+    uint8_t  :3;                        /**< bit:   5..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} EIC_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_CTRLA_OFFSET                    (0x00)                                        /**<  (EIC_CTRLA) Control A  Offset */
+#define EIC_CTRLA_RESETVALUE                _U_(0x00)                                     /**<  (EIC_CTRLA) Control A  Reset Value */
+
+#define EIC_CTRLA_SWRST_Pos                 0                                              /**< (EIC_CTRLA) Software Reset Position */
+#define EIC_CTRLA_SWRST_Msk                 (_U_(0x1) << EIC_CTRLA_SWRST_Pos)              /**< (EIC_CTRLA) Software Reset Mask */
+#define EIC_CTRLA_SWRST                     EIC_CTRLA_SWRST_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use EIC_CTRLA_SWRST_Msk instead */
+#define EIC_CTRLA_ENABLE_Pos                1                                              /**< (EIC_CTRLA) Enable Position */
+#define EIC_CTRLA_ENABLE_Msk                (_U_(0x1) << EIC_CTRLA_ENABLE_Pos)             /**< (EIC_CTRLA) Enable Mask */
+#define EIC_CTRLA_ENABLE                    EIC_CTRLA_ENABLE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use EIC_CTRLA_ENABLE_Msk instead */
+#define EIC_CTRLA_CKSEL_Pos                 4                                              /**< (EIC_CTRLA) Clock Selection Position */
+#define EIC_CTRLA_CKSEL_Msk                 (_U_(0x1) << EIC_CTRLA_CKSEL_Pos)              /**< (EIC_CTRLA) Clock Selection Mask */
+#define EIC_CTRLA_CKSEL                     EIC_CTRLA_CKSEL_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use EIC_CTRLA_CKSEL_Msk instead */
+#define EIC_CTRLA_MASK                      _U_(0x13)                                      /**< \deprecated (EIC_CTRLA) Register MASK  (Use EIC_CTRLA_Msk instead)  */
+#define EIC_CTRLA_Msk                       _U_(0x13)                                      /**< (EIC_CTRLA) Register Mask  */
+
+
+/* -------- EIC_NMICTRL : (EIC Offset: 0x01) (R/W 8) Non-Maskable Interrupt Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  NMISENSE:3;                /**< bit:   0..2  Non-Maskable Interrupt Sense Configuration */
+    uint8_t  NMIFILTEN:1;               /**< bit:      3  Non-Maskable Interrupt Filter Enable     */
+    uint8_t  NMIASYNCH:1;               /**< bit:      4  Asynchronous Edge Detection Mode         */
+    uint8_t  :3;                        /**< bit:   5..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} EIC_NMICTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_NMICTRL_OFFSET                  (0x01)                                        /**<  (EIC_NMICTRL) Non-Maskable Interrupt Control  Offset */
+#define EIC_NMICTRL_RESETVALUE              _U_(0x00)                                     /**<  (EIC_NMICTRL) Non-Maskable Interrupt Control  Reset Value */
+
+#define EIC_NMICTRL_NMISENSE_Pos            0                                              /**< (EIC_NMICTRL) Non-Maskable Interrupt Sense Configuration Position */
+#define EIC_NMICTRL_NMISENSE_Msk            (_U_(0x7) << EIC_NMICTRL_NMISENSE_Pos)         /**< (EIC_NMICTRL) Non-Maskable Interrupt Sense Configuration Mask */
+#define EIC_NMICTRL_NMISENSE(value)         (EIC_NMICTRL_NMISENSE_Msk & ((value) << EIC_NMICTRL_NMISENSE_Pos))
+#define   EIC_NMICTRL_NMISENSE_NONE_Val     _U_(0x0)                                       /**< (EIC_NMICTRL) No detection  */
+#define   EIC_NMICTRL_NMISENSE_RISE_Val     _U_(0x1)                                       /**< (EIC_NMICTRL) Rising-edge detection  */
+#define   EIC_NMICTRL_NMISENSE_FALL_Val     _U_(0x2)                                       /**< (EIC_NMICTRL) Falling-edge detection  */
+#define   EIC_NMICTRL_NMISENSE_BOTH_Val     _U_(0x3)                                       /**< (EIC_NMICTRL) Both-edges detection  */
+#define   EIC_NMICTRL_NMISENSE_HIGH_Val     _U_(0x4)                                       /**< (EIC_NMICTRL) High-level detection  */
+#define   EIC_NMICTRL_NMISENSE_LOW_Val      _U_(0x5)                                       /**< (EIC_NMICTRL) Low-level detection  */
+#define EIC_NMICTRL_NMISENSE_NONE           (EIC_NMICTRL_NMISENSE_NONE_Val << EIC_NMICTRL_NMISENSE_Pos)  /**< (EIC_NMICTRL) No detection Position  */
+#define EIC_NMICTRL_NMISENSE_RISE           (EIC_NMICTRL_NMISENSE_RISE_Val << EIC_NMICTRL_NMISENSE_Pos)  /**< (EIC_NMICTRL) Rising-edge detection Position  */
+#define EIC_NMICTRL_NMISENSE_FALL           (EIC_NMICTRL_NMISENSE_FALL_Val << EIC_NMICTRL_NMISENSE_Pos)  /**< (EIC_NMICTRL) Falling-edge detection Position  */
+#define EIC_NMICTRL_NMISENSE_BOTH           (EIC_NMICTRL_NMISENSE_BOTH_Val << EIC_NMICTRL_NMISENSE_Pos)  /**< (EIC_NMICTRL) Both-edges detection Position  */
+#define EIC_NMICTRL_NMISENSE_HIGH           (EIC_NMICTRL_NMISENSE_HIGH_Val << EIC_NMICTRL_NMISENSE_Pos)  /**< (EIC_NMICTRL) High-level detection Position  */
+#define EIC_NMICTRL_NMISENSE_LOW            (EIC_NMICTRL_NMISENSE_LOW_Val << EIC_NMICTRL_NMISENSE_Pos)  /**< (EIC_NMICTRL) Low-level detection Position  */
+#define EIC_NMICTRL_NMIFILTEN_Pos           3                                              /**< (EIC_NMICTRL) Non-Maskable Interrupt Filter Enable Position */
+#define EIC_NMICTRL_NMIFILTEN_Msk           (_U_(0x1) << EIC_NMICTRL_NMIFILTEN_Pos)        /**< (EIC_NMICTRL) Non-Maskable Interrupt Filter Enable Mask */
+#define EIC_NMICTRL_NMIFILTEN               EIC_NMICTRL_NMIFILTEN_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use EIC_NMICTRL_NMIFILTEN_Msk instead */
+#define EIC_NMICTRL_NMIASYNCH_Pos           4                                              /**< (EIC_NMICTRL) Asynchronous Edge Detection Mode Position */
+#define EIC_NMICTRL_NMIASYNCH_Msk           (_U_(0x1) << EIC_NMICTRL_NMIASYNCH_Pos)        /**< (EIC_NMICTRL) Asynchronous Edge Detection Mode Mask */
+#define EIC_NMICTRL_NMIASYNCH               EIC_NMICTRL_NMIASYNCH_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use EIC_NMICTRL_NMIASYNCH_Msk instead */
+#define EIC_NMICTRL_MASK                    _U_(0x1F)                                      /**< \deprecated (EIC_NMICTRL) Register MASK  (Use EIC_NMICTRL_Msk instead)  */
+#define EIC_NMICTRL_Msk                     _U_(0x1F)                                      /**< (EIC_NMICTRL) Register Mask  */
+
+
+/* -------- EIC_NMIFLAG : (EIC Offset: 0x02) (R/W 16) Non-Maskable Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t NMI:1;                     /**< bit:      0  Non-Maskable Interrupt                   */
+    uint16_t :15;                       /**< bit:  1..15  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} EIC_NMIFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_NMIFLAG_OFFSET                  (0x02)                                        /**<  (EIC_NMIFLAG) Non-Maskable Interrupt Flag Status and Clear  Offset */
+#define EIC_NMIFLAG_RESETVALUE              _U_(0x00)                                     /**<  (EIC_NMIFLAG) Non-Maskable Interrupt Flag Status and Clear  Reset Value */
+
+#define EIC_NMIFLAG_NMI_Pos                 0                                              /**< (EIC_NMIFLAG) Non-Maskable Interrupt Position */
+#define EIC_NMIFLAG_NMI_Msk                 (_U_(0x1) << EIC_NMIFLAG_NMI_Pos)              /**< (EIC_NMIFLAG) Non-Maskable Interrupt Mask */
+#define EIC_NMIFLAG_NMI                     EIC_NMIFLAG_NMI_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use EIC_NMIFLAG_NMI_Msk instead */
+#define EIC_NMIFLAG_MASK                    _U_(0x01)                                      /**< \deprecated (EIC_NMIFLAG) Register MASK  (Use EIC_NMIFLAG_Msk instead)  */
+#define EIC_NMIFLAG_Msk                     _U_(0x01)                                      /**< (EIC_NMIFLAG) Register Mask  */
+
+
+/* -------- EIC_SYNCBUSY : (EIC Offset: 0x04) (R/ 32) Synchronization Busy -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SWRST:1;                   /**< bit:      0  Software Reset Synchronization Busy Status */
+    uint32_t ENABLE:1;                  /**< bit:      1  Enable Synchronization Busy Status       */
+    uint32_t :30;                       /**< bit:  2..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} EIC_SYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_SYNCBUSY_OFFSET                 (0x04)                                        /**<  (EIC_SYNCBUSY) Synchronization Busy  Offset */
+#define EIC_SYNCBUSY_RESETVALUE             _U_(0x00)                                     /**<  (EIC_SYNCBUSY) Synchronization Busy  Reset Value */
+
+#define EIC_SYNCBUSY_SWRST_Pos              0                                              /**< (EIC_SYNCBUSY) Software Reset Synchronization Busy Status Position */
+#define EIC_SYNCBUSY_SWRST_Msk              (_U_(0x1) << EIC_SYNCBUSY_SWRST_Pos)           /**< (EIC_SYNCBUSY) Software Reset Synchronization Busy Status Mask */
+#define EIC_SYNCBUSY_SWRST                  EIC_SYNCBUSY_SWRST_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use EIC_SYNCBUSY_SWRST_Msk instead */
+#define EIC_SYNCBUSY_ENABLE_Pos             1                                              /**< (EIC_SYNCBUSY) Enable Synchronization Busy Status Position */
+#define EIC_SYNCBUSY_ENABLE_Msk             (_U_(0x1) << EIC_SYNCBUSY_ENABLE_Pos)          /**< (EIC_SYNCBUSY) Enable Synchronization Busy Status Mask */
+#define EIC_SYNCBUSY_ENABLE                 EIC_SYNCBUSY_ENABLE_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use EIC_SYNCBUSY_ENABLE_Msk instead */
+#define EIC_SYNCBUSY_MASK                   _U_(0x03)                                      /**< \deprecated (EIC_SYNCBUSY) Register MASK  (Use EIC_SYNCBUSY_Msk instead)  */
+#define EIC_SYNCBUSY_Msk                    _U_(0x03)                                      /**< (EIC_SYNCBUSY) Register Mask  */
+
+
+/* -------- EIC_EVCTRL : (EIC Offset: 0x08) (R/W 32) Event Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t EXTINTEO:8;                /**< bit:   0..7  External Interrupt Event Output Enable   */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} EIC_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_EVCTRL_OFFSET                   (0x08)                                        /**<  (EIC_EVCTRL) Event Control  Offset */
+#define EIC_EVCTRL_RESETVALUE               _U_(0x00)                                     /**<  (EIC_EVCTRL) Event Control  Reset Value */
+
+#define EIC_EVCTRL_EXTINTEO_Pos             0                                              /**< (EIC_EVCTRL) External Interrupt Event Output Enable Position */
+#define EIC_EVCTRL_EXTINTEO_Msk             (_U_(0xFF) << EIC_EVCTRL_EXTINTEO_Pos)         /**< (EIC_EVCTRL) External Interrupt Event Output Enable Mask */
+#define EIC_EVCTRL_EXTINTEO(value)          (EIC_EVCTRL_EXTINTEO_Msk & ((value) << EIC_EVCTRL_EXTINTEO_Pos))
+#define EIC_EVCTRL_MASK                     _U_(0xFF)                                      /**< \deprecated (EIC_EVCTRL) Register MASK  (Use EIC_EVCTRL_Msk instead)  */
+#define EIC_EVCTRL_Msk                      _U_(0xFF)                                      /**< (EIC_EVCTRL) Register Mask  */
+
+
+/* -------- EIC_INTENCLR : (EIC Offset: 0x0c) (R/W 32) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t EXTINT:8;                  /**< bit:   0..7  External Interrupt Enable                */
+    uint32_t :23;                       /**< bit:  8..30  Reserved */
+    uint32_t NSCHK:1;                   /**< bit:     31  Non-secure Check Interrupt Enable        */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} EIC_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_INTENCLR_OFFSET                 (0x0C)                                        /**<  (EIC_INTENCLR) Interrupt Enable Clear  Offset */
+#define EIC_INTENCLR_RESETVALUE             _U_(0x00)                                     /**<  (EIC_INTENCLR) Interrupt Enable Clear  Reset Value */
+
+#define EIC_INTENCLR_EXTINT_Pos             0                                              /**< (EIC_INTENCLR) External Interrupt Enable Position */
+#define EIC_INTENCLR_EXTINT_Msk             (_U_(0xFF) << EIC_INTENCLR_EXTINT_Pos)         /**< (EIC_INTENCLR) External Interrupt Enable Mask */
+#define EIC_INTENCLR_EXTINT(value)          (EIC_INTENCLR_EXTINT_Msk & ((value) << EIC_INTENCLR_EXTINT_Pos))
+#define EIC_INTENCLR_NSCHK_Pos              31                                             /**< (EIC_INTENCLR) Non-secure Check Interrupt Enable Position */
+#define EIC_INTENCLR_NSCHK_Msk              (_U_(0x1) << EIC_INTENCLR_NSCHK_Pos)           /**< (EIC_INTENCLR) Non-secure Check Interrupt Enable Mask */
+#define EIC_INTENCLR_NSCHK                  EIC_INTENCLR_NSCHK_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use EIC_INTENCLR_NSCHK_Msk instead */
+#define EIC_INTENCLR_MASK                   _U_(0x800000FF)                                /**< \deprecated (EIC_INTENCLR) Register MASK  (Use EIC_INTENCLR_Msk instead)  */
+#define EIC_INTENCLR_Msk                    _U_(0x800000FF)                                /**< (EIC_INTENCLR) Register Mask  */
+
+
+/* -------- EIC_INTENSET : (EIC Offset: 0x10) (R/W 32) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t EXTINT:8;                  /**< bit:   0..7  External Interrupt Enable                */
+    uint32_t :23;                       /**< bit:  8..30  Reserved */
+    uint32_t NSCHK:1;                   /**< bit:     31  Non-secure Check Interrupt Enable        */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} EIC_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_INTENSET_OFFSET                 (0x10)                                        /**<  (EIC_INTENSET) Interrupt Enable Set  Offset */
+#define EIC_INTENSET_RESETVALUE             _U_(0x00)                                     /**<  (EIC_INTENSET) Interrupt Enable Set  Reset Value */
+
+#define EIC_INTENSET_EXTINT_Pos             0                                              /**< (EIC_INTENSET) External Interrupt Enable Position */
+#define EIC_INTENSET_EXTINT_Msk             (_U_(0xFF) << EIC_INTENSET_EXTINT_Pos)         /**< (EIC_INTENSET) External Interrupt Enable Mask */
+#define EIC_INTENSET_EXTINT(value)          (EIC_INTENSET_EXTINT_Msk & ((value) << EIC_INTENSET_EXTINT_Pos))
+#define EIC_INTENSET_NSCHK_Pos              31                                             /**< (EIC_INTENSET) Non-secure Check Interrupt Enable Position */
+#define EIC_INTENSET_NSCHK_Msk              (_U_(0x1) << EIC_INTENSET_NSCHK_Pos)           /**< (EIC_INTENSET) Non-secure Check Interrupt Enable Mask */
+#define EIC_INTENSET_NSCHK                  EIC_INTENSET_NSCHK_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use EIC_INTENSET_NSCHK_Msk instead */
+#define EIC_INTENSET_MASK                   _U_(0x800000FF)                                /**< \deprecated (EIC_INTENSET) Register MASK  (Use EIC_INTENSET_Msk instead)  */
+#define EIC_INTENSET_Msk                    _U_(0x800000FF)                                /**< (EIC_INTENSET) Register Mask  */
+
+
+/* -------- EIC_INTFLAG : (EIC Offset: 0x14) (R/W 32) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint32_t EXTINT:8;                  /**< bit:   0..7  External Interrupt                       */
+    __I uint32_t :23;                       /**< bit:  8..30  Reserved */
+    __I uint32_t NSCHK:1;                   /**< bit:     31  Non-secure Check Interrupt               */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} EIC_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_INTFLAG_OFFSET                  (0x14)                                        /**<  (EIC_INTFLAG) Interrupt Flag Status and Clear  Offset */
+#define EIC_INTFLAG_RESETVALUE              _U_(0x00)                                     /**<  (EIC_INTFLAG) Interrupt Flag Status and Clear  Reset Value */
+
+#define EIC_INTFLAG_EXTINT_Pos              0                                              /**< (EIC_INTFLAG) External Interrupt Position */
+#define EIC_INTFLAG_EXTINT_Msk              (_U_(0xFF) << EIC_INTFLAG_EXTINT_Pos)          /**< (EIC_INTFLAG) External Interrupt Mask */
+#define EIC_INTFLAG_EXTINT(value)           (EIC_INTFLAG_EXTINT_Msk & ((value) << EIC_INTFLAG_EXTINT_Pos))
+#define EIC_INTFLAG_NSCHK_Pos               31                                             /**< (EIC_INTFLAG) Non-secure Check Interrupt Position */
+#define EIC_INTFLAG_NSCHK_Msk               (_U_(0x1) << EIC_INTFLAG_NSCHK_Pos)            /**< (EIC_INTFLAG) Non-secure Check Interrupt Mask */
+#define EIC_INTFLAG_NSCHK                   EIC_INTFLAG_NSCHK_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use EIC_INTFLAG_NSCHK_Msk instead */
+#define EIC_INTFLAG_MASK                    _U_(0x800000FF)                                /**< \deprecated (EIC_INTFLAG) Register MASK  (Use EIC_INTFLAG_Msk instead)  */
+#define EIC_INTFLAG_Msk                     _U_(0x800000FF)                                /**< (EIC_INTFLAG) Register Mask  */
+
+
+/* -------- EIC_ASYNCH : (EIC Offset: 0x18) (R/W 32) External Interrupt Asynchronous Mode -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t ASYNCH:8;                  /**< bit:   0..7  Asynchronous Edge Detection Mode         */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} EIC_ASYNCH_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_ASYNCH_OFFSET                   (0x18)                                        /**<  (EIC_ASYNCH) External Interrupt Asynchronous Mode  Offset */
+#define EIC_ASYNCH_RESETVALUE               _U_(0x00)                                     /**<  (EIC_ASYNCH) External Interrupt Asynchronous Mode  Reset Value */
+
+#define EIC_ASYNCH_ASYNCH_Pos               0                                              /**< (EIC_ASYNCH) Asynchronous Edge Detection Mode Position */
+#define EIC_ASYNCH_ASYNCH_Msk               (_U_(0xFF) << EIC_ASYNCH_ASYNCH_Pos)           /**< (EIC_ASYNCH) Asynchronous Edge Detection Mode Mask */
+#define EIC_ASYNCH_ASYNCH(value)            (EIC_ASYNCH_ASYNCH_Msk & ((value) << EIC_ASYNCH_ASYNCH_Pos))
+#define EIC_ASYNCH_MASK                     _U_(0xFF)                                      /**< \deprecated (EIC_ASYNCH) Register MASK  (Use EIC_ASYNCH_Msk instead)  */
+#define EIC_ASYNCH_Msk                      _U_(0xFF)                                      /**< (EIC_ASYNCH) Register Mask  */
+
+
+/* -------- EIC_CONFIG : (EIC Offset: 0x1c) (R/W 32) External Interrupt Sense Configuration -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SENSE0:3;                  /**< bit:   0..2  Input Sense Configuration 0              */
+    uint32_t FILTEN0:1;                 /**< bit:      3  Filter Enable 0                          */
+    uint32_t SENSE1:3;                  /**< bit:   4..6  Input Sense Configuration 1              */
+    uint32_t FILTEN1:1;                 /**< bit:      7  Filter Enable 1                          */
+    uint32_t SENSE2:3;                  /**< bit:  8..10  Input Sense Configuration 2              */
+    uint32_t FILTEN2:1;                 /**< bit:     11  Filter Enable 2                          */
+    uint32_t SENSE3:3;                  /**< bit: 12..14  Input Sense Configuration 3              */
+    uint32_t FILTEN3:1;                 /**< bit:     15  Filter Enable 3                          */
+    uint32_t SENSE4:3;                  /**< bit: 16..18  Input Sense Configuration 4              */
+    uint32_t FILTEN4:1;                 /**< bit:     19  Filter Enable 4                          */
+    uint32_t SENSE5:3;                  /**< bit: 20..22  Input Sense Configuration 5              */
+    uint32_t FILTEN5:1;                 /**< bit:     23  Filter Enable 5                          */
+    uint32_t SENSE6:3;                  /**< bit: 24..26  Input Sense Configuration 6              */
+    uint32_t FILTEN6:1;                 /**< bit:     27  Filter Enable 6                          */
+    uint32_t SENSE7:3;                  /**< bit: 28..30  Input Sense Configuration 7              */
+    uint32_t FILTEN7:1;                 /**< bit:     31  Filter Enable 7                          */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} EIC_CONFIG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_CONFIG_OFFSET                   (0x1C)                                        /**<  (EIC_CONFIG) External Interrupt Sense Configuration  Offset */
+#define EIC_CONFIG_RESETVALUE               _U_(0x00)                                     /**<  (EIC_CONFIG) External Interrupt Sense Configuration  Reset Value */
+
+#define EIC_CONFIG_SENSE0_Pos               0                                              /**< (EIC_CONFIG) Input Sense Configuration 0 Position */
+#define EIC_CONFIG_SENSE0_Msk               (_U_(0x7) << EIC_CONFIG_SENSE0_Pos)            /**< (EIC_CONFIG) Input Sense Configuration 0 Mask */
+#define EIC_CONFIG_SENSE0(value)            (EIC_CONFIG_SENSE0_Msk & ((value) << EIC_CONFIG_SENSE0_Pos))
+#define   EIC_CONFIG_SENSE0_NONE_Val        _U_(0x0)                                       /**< (EIC_CONFIG) No detection  */
+#define   EIC_CONFIG_SENSE0_RISE_Val        _U_(0x1)                                       /**< (EIC_CONFIG) Rising edge detection  */
+#define   EIC_CONFIG_SENSE0_FALL_Val        _U_(0x2)                                       /**< (EIC_CONFIG) Falling edge detection  */
+#define   EIC_CONFIG_SENSE0_BOTH_Val        _U_(0x3)                                       /**< (EIC_CONFIG) Both edges detection  */
+#define   EIC_CONFIG_SENSE0_HIGH_Val        _U_(0x4)                                       /**< (EIC_CONFIG) High level detection  */
+#define   EIC_CONFIG_SENSE0_LOW_Val         _U_(0x5)                                       /**< (EIC_CONFIG) Low level detection  */
+#define EIC_CONFIG_SENSE0_NONE              (EIC_CONFIG_SENSE0_NONE_Val << EIC_CONFIG_SENSE0_Pos)  /**< (EIC_CONFIG) No detection Position  */
+#define EIC_CONFIG_SENSE0_RISE              (EIC_CONFIG_SENSE0_RISE_Val << EIC_CONFIG_SENSE0_Pos)  /**< (EIC_CONFIG) Rising edge detection Position  */
+#define EIC_CONFIG_SENSE0_FALL              (EIC_CONFIG_SENSE0_FALL_Val << EIC_CONFIG_SENSE0_Pos)  /**< (EIC_CONFIG) Falling edge detection Position  */
+#define EIC_CONFIG_SENSE0_BOTH              (EIC_CONFIG_SENSE0_BOTH_Val << EIC_CONFIG_SENSE0_Pos)  /**< (EIC_CONFIG) Both edges detection Position  */
+#define EIC_CONFIG_SENSE0_HIGH              (EIC_CONFIG_SENSE0_HIGH_Val << EIC_CONFIG_SENSE0_Pos)  /**< (EIC_CONFIG) High level detection Position  */
+#define EIC_CONFIG_SENSE0_LOW               (EIC_CONFIG_SENSE0_LOW_Val << EIC_CONFIG_SENSE0_Pos)  /**< (EIC_CONFIG) Low level detection Position  */
+#define EIC_CONFIG_FILTEN0_Pos              3                                              /**< (EIC_CONFIG) Filter Enable 0 Position */
+#define EIC_CONFIG_FILTEN0_Msk              (_U_(0x1) << EIC_CONFIG_FILTEN0_Pos)           /**< (EIC_CONFIG) Filter Enable 0 Mask */
+#define EIC_CONFIG_FILTEN0                  EIC_CONFIG_FILTEN0_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use EIC_CONFIG_FILTEN0_Msk instead */
+#define EIC_CONFIG_SENSE1_Pos               4                                              /**< (EIC_CONFIG) Input Sense Configuration 1 Position */
+#define EIC_CONFIG_SENSE1_Msk               (_U_(0x7) << EIC_CONFIG_SENSE1_Pos)            /**< (EIC_CONFIG) Input Sense Configuration 1 Mask */
+#define EIC_CONFIG_SENSE1(value)            (EIC_CONFIG_SENSE1_Msk & ((value) << EIC_CONFIG_SENSE1_Pos))
+#define   EIC_CONFIG_SENSE1_NONE_Val        _U_(0x0)                                       /**< (EIC_CONFIG) No detection  */
+#define   EIC_CONFIG_SENSE1_RISE_Val        _U_(0x1)                                       /**< (EIC_CONFIG) Rising edge detection  */
+#define   EIC_CONFIG_SENSE1_FALL_Val        _U_(0x2)                                       /**< (EIC_CONFIG) Falling edge detection  */
+#define   EIC_CONFIG_SENSE1_BOTH_Val        _U_(0x3)                                       /**< (EIC_CONFIG) Both edges detection  */
+#define   EIC_CONFIG_SENSE1_HIGH_Val        _U_(0x4)                                       /**< (EIC_CONFIG) High level detection  */
+#define   EIC_CONFIG_SENSE1_LOW_Val         _U_(0x5)                                       /**< (EIC_CONFIG) Low level detection  */
+#define EIC_CONFIG_SENSE1_NONE              (EIC_CONFIG_SENSE1_NONE_Val << EIC_CONFIG_SENSE1_Pos)  /**< (EIC_CONFIG) No detection Position  */
+#define EIC_CONFIG_SENSE1_RISE              (EIC_CONFIG_SENSE1_RISE_Val << EIC_CONFIG_SENSE1_Pos)  /**< (EIC_CONFIG) Rising edge detection Position  */
+#define EIC_CONFIG_SENSE1_FALL              (EIC_CONFIG_SENSE1_FALL_Val << EIC_CONFIG_SENSE1_Pos)  /**< (EIC_CONFIG) Falling edge detection Position  */
+#define EIC_CONFIG_SENSE1_BOTH              (EIC_CONFIG_SENSE1_BOTH_Val << EIC_CONFIG_SENSE1_Pos)  /**< (EIC_CONFIG) Both edges detection Position  */
+#define EIC_CONFIG_SENSE1_HIGH              (EIC_CONFIG_SENSE1_HIGH_Val << EIC_CONFIG_SENSE1_Pos)  /**< (EIC_CONFIG) High level detection Position  */
+#define EIC_CONFIG_SENSE1_LOW               (EIC_CONFIG_SENSE1_LOW_Val << EIC_CONFIG_SENSE1_Pos)  /**< (EIC_CONFIG) Low level detection Position  */
+#define EIC_CONFIG_FILTEN1_Pos              7                                              /**< (EIC_CONFIG) Filter Enable 1 Position */
+#define EIC_CONFIG_FILTEN1_Msk              (_U_(0x1) << EIC_CONFIG_FILTEN1_Pos)           /**< (EIC_CONFIG) Filter Enable 1 Mask */
+#define EIC_CONFIG_FILTEN1                  EIC_CONFIG_FILTEN1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use EIC_CONFIG_FILTEN1_Msk instead */
+#define EIC_CONFIG_SENSE2_Pos               8                                              /**< (EIC_CONFIG) Input Sense Configuration 2 Position */
+#define EIC_CONFIG_SENSE2_Msk               (_U_(0x7) << EIC_CONFIG_SENSE2_Pos)            /**< (EIC_CONFIG) Input Sense Configuration 2 Mask */
+#define EIC_CONFIG_SENSE2(value)            (EIC_CONFIG_SENSE2_Msk & ((value) << EIC_CONFIG_SENSE2_Pos))
+#define   EIC_CONFIG_SENSE2_NONE_Val        _U_(0x0)                                       /**< (EIC_CONFIG) No detection  */
+#define   EIC_CONFIG_SENSE2_RISE_Val        _U_(0x1)                                       /**< (EIC_CONFIG) Rising edge detection  */
+#define   EIC_CONFIG_SENSE2_FALL_Val        _U_(0x2)                                       /**< (EIC_CONFIG) Falling edge detection  */
+#define   EIC_CONFIG_SENSE2_BOTH_Val        _U_(0x3)                                       /**< (EIC_CONFIG) Both edges detection  */
+#define   EIC_CONFIG_SENSE2_HIGH_Val        _U_(0x4)                                       /**< (EIC_CONFIG) High level detection  */
+#define   EIC_CONFIG_SENSE2_LOW_Val         _U_(0x5)                                       /**< (EIC_CONFIG) Low level detection  */
+#define EIC_CONFIG_SENSE2_NONE              (EIC_CONFIG_SENSE2_NONE_Val << EIC_CONFIG_SENSE2_Pos)  /**< (EIC_CONFIG) No detection Position  */
+#define EIC_CONFIG_SENSE2_RISE              (EIC_CONFIG_SENSE2_RISE_Val << EIC_CONFIG_SENSE2_Pos)  /**< (EIC_CONFIG) Rising edge detection Position  */
+#define EIC_CONFIG_SENSE2_FALL              (EIC_CONFIG_SENSE2_FALL_Val << EIC_CONFIG_SENSE2_Pos)  /**< (EIC_CONFIG) Falling edge detection Position  */
+#define EIC_CONFIG_SENSE2_BOTH              (EIC_CONFIG_SENSE2_BOTH_Val << EIC_CONFIG_SENSE2_Pos)  /**< (EIC_CONFIG) Both edges detection Position  */
+#define EIC_CONFIG_SENSE2_HIGH              (EIC_CONFIG_SENSE2_HIGH_Val << EIC_CONFIG_SENSE2_Pos)  /**< (EIC_CONFIG) High level detection Position  */
+#define EIC_CONFIG_SENSE2_LOW               (EIC_CONFIG_SENSE2_LOW_Val << EIC_CONFIG_SENSE2_Pos)  /**< (EIC_CONFIG) Low level detection Position  */
+#define EIC_CONFIG_FILTEN2_Pos              11                                             /**< (EIC_CONFIG) Filter Enable 2 Position */
+#define EIC_CONFIG_FILTEN2_Msk              (_U_(0x1) << EIC_CONFIG_FILTEN2_Pos)           /**< (EIC_CONFIG) Filter Enable 2 Mask */
+#define EIC_CONFIG_FILTEN2                  EIC_CONFIG_FILTEN2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use EIC_CONFIG_FILTEN2_Msk instead */
+#define EIC_CONFIG_SENSE3_Pos               12                                             /**< (EIC_CONFIG) Input Sense Configuration 3 Position */
+#define EIC_CONFIG_SENSE3_Msk               (_U_(0x7) << EIC_CONFIG_SENSE3_Pos)            /**< (EIC_CONFIG) Input Sense Configuration 3 Mask */
+#define EIC_CONFIG_SENSE3(value)            (EIC_CONFIG_SENSE3_Msk & ((value) << EIC_CONFIG_SENSE3_Pos))
+#define   EIC_CONFIG_SENSE3_NONE_Val        _U_(0x0)                                       /**< (EIC_CONFIG) No detection  */
+#define   EIC_CONFIG_SENSE3_RISE_Val        _U_(0x1)                                       /**< (EIC_CONFIG) Rising edge detection  */
+#define   EIC_CONFIG_SENSE3_FALL_Val        _U_(0x2)                                       /**< (EIC_CONFIG) Falling edge detection  */
+#define   EIC_CONFIG_SENSE3_BOTH_Val        _U_(0x3)                                       /**< (EIC_CONFIG) Both edges detection  */
+#define   EIC_CONFIG_SENSE3_HIGH_Val        _U_(0x4)                                       /**< (EIC_CONFIG) High level detection  */
+#define   EIC_CONFIG_SENSE3_LOW_Val         _U_(0x5)                                       /**< (EIC_CONFIG) Low level detection  */
+#define EIC_CONFIG_SENSE3_NONE              (EIC_CONFIG_SENSE3_NONE_Val << EIC_CONFIG_SENSE3_Pos)  /**< (EIC_CONFIG) No detection Position  */
+#define EIC_CONFIG_SENSE3_RISE              (EIC_CONFIG_SENSE3_RISE_Val << EIC_CONFIG_SENSE3_Pos)  /**< (EIC_CONFIG) Rising edge detection Position  */
+#define EIC_CONFIG_SENSE3_FALL              (EIC_CONFIG_SENSE3_FALL_Val << EIC_CONFIG_SENSE3_Pos)  /**< (EIC_CONFIG) Falling edge detection Position  */
+#define EIC_CONFIG_SENSE3_BOTH              (EIC_CONFIG_SENSE3_BOTH_Val << EIC_CONFIG_SENSE3_Pos)  /**< (EIC_CONFIG) Both edges detection Position  */
+#define EIC_CONFIG_SENSE3_HIGH              (EIC_CONFIG_SENSE3_HIGH_Val << EIC_CONFIG_SENSE3_Pos)  /**< (EIC_CONFIG) High level detection Position  */
+#define EIC_CONFIG_SENSE3_LOW               (EIC_CONFIG_SENSE3_LOW_Val << EIC_CONFIG_SENSE3_Pos)  /**< (EIC_CONFIG) Low level detection Position  */
+#define EIC_CONFIG_FILTEN3_Pos              15                                             /**< (EIC_CONFIG) Filter Enable 3 Position */
+#define EIC_CONFIG_FILTEN3_Msk              (_U_(0x1) << EIC_CONFIG_FILTEN3_Pos)           /**< (EIC_CONFIG) Filter Enable 3 Mask */
+#define EIC_CONFIG_FILTEN3                  EIC_CONFIG_FILTEN3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use EIC_CONFIG_FILTEN3_Msk instead */
+#define EIC_CONFIG_SENSE4_Pos               16                                             /**< (EIC_CONFIG) Input Sense Configuration 4 Position */
+#define EIC_CONFIG_SENSE4_Msk               (_U_(0x7) << EIC_CONFIG_SENSE4_Pos)            /**< (EIC_CONFIG) Input Sense Configuration 4 Mask */
+#define EIC_CONFIG_SENSE4(value)            (EIC_CONFIG_SENSE4_Msk & ((value) << EIC_CONFIG_SENSE4_Pos))
+#define   EIC_CONFIG_SENSE4_NONE_Val        _U_(0x0)                                       /**< (EIC_CONFIG) No detection  */
+#define   EIC_CONFIG_SENSE4_RISE_Val        _U_(0x1)                                       /**< (EIC_CONFIG) Rising edge detection  */
+#define   EIC_CONFIG_SENSE4_FALL_Val        _U_(0x2)                                       /**< (EIC_CONFIG) Falling edge detection  */
+#define   EIC_CONFIG_SENSE4_BOTH_Val        _U_(0x3)                                       /**< (EIC_CONFIG) Both edges detection  */
+#define   EIC_CONFIG_SENSE4_HIGH_Val        _U_(0x4)                                       /**< (EIC_CONFIG) High level detection  */
+#define   EIC_CONFIG_SENSE4_LOW_Val         _U_(0x5)                                       /**< (EIC_CONFIG) Low level detection  */
+#define EIC_CONFIG_SENSE4_NONE              (EIC_CONFIG_SENSE4_NONE_Val << EIC_CONFIG_SENSE4_Pos)  /**< (EIC_CONFIG) No detection Position  */
+#define EIC_CONFIG_SENSE4_RISE              (EIC_CONFIG_SENSE4_RISE_Val << EIC_CONFIG_SENSE4_Pos)  /**< (EIC_CONFIG) Rising edge detection Position  */
+#define EIC_CONFIG_SENSE4_FALL              (EIC_CONFIG_SENSE4_FALL_Val << EIC_CONFIG_SENSE4_Pos)  /**< (EIC_CONFIG) Falling edge detection Position  */
+#define EIC_CONFIG_SENSE4_BOTH              (EIC_CONFIG_SENSE4_BOTH_Val << EIC_CONFIG_SENSE4_Pos)  /**< (EIC_CONFIG) Both edges detection Position  */
+#define EIC_CONFIG_SENSE4_HIGH              (EIC_CONFIG_SENSE4_HIGH_Val << EIC_CONFIG_SENSE4_Pos)  /**< (EIC_CONFIG) High level detection Position  */
+#define EIC_CONFIG_SENSE4_LOW               (EIC_CONFIG_SENSE4_LOW_Val << EIC_CONFIG_SENSE4_Pos)  /**< (EIC_CONFIG) Low level detection Position  */
+#define EIC_CONFIG_FILTEN4_Pos              19                                             /**< (EIC_CONFIG) Filter Enable 4 Position */
+#define EIC_CONFIG_FILTEN4_Msk              (_U_(0x1) << EIC_CONFIG_FILTEN4_Pos)           /**< (EIC_CONFIG) Filter Enable 4 Mask */
+#define EIC_CONFIG_FILTEN4                  EIC_CONFIG_FILTEN4_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use EIC_CONFIG_FILTEN4_Msk instead */
+#define EIC_CONFIG_SENSE5_Pos               20                                             /**< (EIC_CONFIG) Input Sense Configuration 5 Position */
+#define EIC_CONFIG_SENSE5_Msk               (_U_(0x7) << EIC_CONFIG_SENSE5_Pos)            /**< (EIC_CONFIG) Input Sense Configuration 5 Mask */
+#define EIC_CONFIG_SENSE5(value)            (EIC_CONFIG_SENSE5_Msk & ((value) << EIC_CONFIG_SENSE5_Pos))
+#define   EIC_CONFIG_SENSE5_NONE_Val        _U_(0x0)                                       /**< (EIC_CONFIG) No detection  */
+#define   EIC_CONFIG_SENSE5_RISE_Val        _U_(0x1)                                       /**< (EIC_CONFIG) Rising edge detection  */
+#define   EIC_CONFIG_SENSE5_FALL_Val        _U_(0x2)                                       /**< (EIC_CONFIG) Falling edge detection  */
+#define   EIC_CONFIG_SENSE5_BOTH_Val        _U_(0x3)                                       /**< (EIC_CONFIG) Both edges detection  */
+#define   EIC_CONFIG_SENSE5_HIGH_Val        _U_(0x4)                                       /**< (EIC_CONFIG) High level detection  */
+#define   EIC_CONFIG_SENSE5_LOW_Val         _U_(0x5)                                       /**< (EIC_CONFIG) Low level detection  */
+#define EIC_CONFIG_SENSE5_NONE              (EIC_CONFIG_SENSE5_NONE_Val << EIC_CONFIG_SENSE5_Pos)  /**< (EIC_CONFIG) No detection Position  */
+#define EIC_CONFIG_SENSE5_RISE              (EIC_CONFIG_SENSE5_RISE_Val << EIC_CONFIG_SENSE5_Pos)  /**< (EIC_CONFIG) Rising edge detection Position  */
+#define EIC_CONFIG_SENSE5_FALL              (EIC_CONFIG_SENSE5_FALL_Val << EIC_CONFIG_SENSE5_Pos)  /**< (EIC_CONFIG) Falling edge detection Position  */
+#define EIC_CONFIG_SENSE5_BOTH              (EIC_CONFIG_SENSE5_BOTH_Val << EIC_CONFIG_SENSE5_Pos)  /**< (EIC_CONFIG) Both edges detection Position  */
+#define EIC_CONFIG_SENSE5_HIGH              (EIC_CONFIG_SENSE5_HIGH_Val << EIC_CONFIG_SENSE5_Pos)  /**< (EIC_CONFIG) High level detection Position  */
+#define EIC_CONFIG_SENSE5_LOW               (EIC_CONFIG_SENSE5_LOW_Val << EIC_CONFIG_SENSE5_Pos)  /**< (EIC_CONFIG) Low level detection Position  */
+#define EIC_CONFIG_FILTEN5_Pos              23                                             /**< (EIC_CONFIG) Filter Enable 5 Position */
+#define EIC_CONFIG_FILTEN5_Msk              (_U_(0x1) << EIC_CONFIG_FILTEN5_Pos)           /**< (EIC_CONFIG) Filter Enable 5 Mask */
+#define EIC_CONFIG_FILTEN5                  EIC_CONFIG_FILTEN5_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use EIC_CONFIG_FILTEN5_Msk instead */
+#define EIC_CONFIG_SENSE6_Pos               24                                             /**< (EIC_CONFIG) Input Sense Configuration 6 Position */
+#define EIC_CONFIG_SENSE6_Msk               (_U_(0x7) << EIC_CONFIG_SENSE6_Pos)            /**< (EIC_CONFIG) Input Sense Configuration 6 Mask */
+#define EIC_CONFIG_SENSE6(value)            (EIC_CONFIG_SENSE6_Msk & ((value) << EIC_CONFIG_SENSE6_Pos))
+#define   EIC_CONFIG_SENSE6_NONE_Val        _U_(0x0)                                       /**< (EIC_CONFIG) No detection  */
+#define   EIC_CONFIG_SENSE6_RISE_Val        _U_(0x1)                                       /**< (EIC_CONFIG) Rising edge detection  */
+#define   EIC_CONFIG_SENSE6_FALL_Val        _U_(0x2)                                       /**< (EIC_CONFIG) Falling edge detection  */
+#define   EIC_CONFIG_SENSE6_BOTH_Val        _U_(0x3)                                       /**< (EIC_CONFIG) Both edges detection  */
+#define   EIC_CONFIG_SENSE6_HIGH_Val        _U_(0x4)                                       /**< (EIC_CONFIG) High level detection  */
+#define   EIC_CONFIG_SENSE6_LOW_Val         _U_(0x5)                                       /**< (EIC_CONFIG) Low level detection  */
+#define EIC_CONFIG_SENSE6_NONE              (EIC_CONFIG_SENSE6_NONE_Val << EIC_CONFIG_SENSE6_Pos)  /**< (EIC_CONFIG) No detection Position  */
+#define EIC_CONFIG_SENSE6_RISE              (EIC_CONFIG_SENSE6_RISE_Val << EIC_CONFIG_SENSE6_Pos)  /**< (EIC_CONFIG) Rising edge detection Position  */
+#define EIC_CONFIG_SENSE6_FALL              (EIC_CONFIG_SENSE6_FALL_Val << EIC_CONFIG_SENSE6_Pos)  /**< (EIC_CONFIG) Falling edge detection Position  */
+#define EIC_CONFIG_SENSE6_BOTH              (EIC_CONFIG_SENSE6_BOTH_Val << EIC_CONFIG_SENSE6_Pos)  /**< (EIC_CONFIG) Both edges detection Position  */
+#define EIC_CONFIG_SENSE6_HIGH              (EIC_CONFIG_SENSE6_HIGH_Val << EIC_CONFIG_SENSE6_Pos)  /**< (EIC_CONFIG) High level detection Position  */
+#define EIC_CONFIG_SENSE6_LOW               (EIC_CONFIG_SENSE6_LOW_Val << EIC_CONFIG_SENSE6_Pos)  /**< (EIC_CONFIG) Low level detection Position  */
+#define EIC_CONFIG_FILTEN6_Pos              27                                             /**< (EIC_CONFIG) Filter Enable 6 Position */
+#define EIC_CONFIG_FILTEN6_Msk              (_U_(0x1) << EIC_CONFIG_FILTEN6_Pos)           /**< (EIC_CONFIG) Filter Enable 6 Mask */
+#define EIC_CONFIG_FILTEN6                  EIC_CONFIG_FILTEN6_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use EIC_CONFIG_FILTEN6_Msk instead */
+#define EIC_CONFIG_SENSE7_Pos               28                                             /**< (EIC_CONFIG) Input Sense Configuration 7 Position */
+#define EIC_CONFIG_SENSE7_Msk               (_U_(0x7) << EIC_CONFIG_SENSE7_Pos)            /**< (EIC_CONFIG) Input Sense Configuration 7 Mask */
+#define EIC_CONFIG_SENSE7(value)            (EIC_CONFIG_SENSE7_Msk & ((value) << EIC_CONFIG_SENSE7_Pos))
+#define   EIC_CONFIG_SENSE7_NONE_Val        _U_(0x0)                                       /**< (EIC_CONFIG) No detection  */
+#define   EIC_CONFIG_SENSE7_RISE_Val        _U_(0x1)                                       /**< (EIC_CONFIG) Rising edge detection  */
+#define   EIC_CONFIG_SENSE7_FALL_Val        _U_(0x2)                                       /**< (EIC_CONFIG) Falling edge detection  */
+#define   EIC_CONFIG_SENSE7_BOTH_Val        _U_(0x3)                                       /**< (EIC_CONFIG) Both edges detection  */
+#define   EIC_CONFIG_SENSE7_HIGH_Val        _U_(0x4)                                       /**< (EIC_CONFIG) High level detection  */
+#define   EIC_CONFIG_SENSE7_LOW_Val         _U_(0x5)                                       /**< (EIC_CONFIG) Low level detection  */
+#define EIC_CONFIG_SENSE7_NONE              (EIC_CONFIG_SENSE7_NONE_Val << EIC_CONFIG_SENSE7_Pos)  /**< (EIC_CONFIG) No detection Position  */
+#define EIC_CONFIG_SENSE7_RISE              (EIC_CONFIG_SENSE7_RISE_Val << EIC_CONFIG_SENSE7_Pos)  /**< (EIC_CONFIG) Rising edge detection Position  */
+#define EIC_CONFIG_SENSE7_FALL              (EIC_CONFIG_SENSE7_FALL_Val << EIC_CONFIG_SENSE7_Pos)  /**< (EIC_CONFIG) Falling edge detection Position  */
+#define EIC_CONFIG_SENSE7_BOTH              (EIC_CONFIG_SENSE7_BOTH_Val << EIC_CONFIG_SENSE7_Pos)  /**< (EIC_CONFIG) Both edges detection Position  */
+#define EIC_CONFIG_SENSE7_HIGH              (EIC_CONFIG_SENSE7_HIGH_Val << EIC_CONFIG_SENSE7_Pos)  /**< (EIC_CONFIG) High level detection Position  */
+#define EIC_CONFIG_SENSE7_LOW               (EIC_CONFIG_SENSE7_LOW_Val << EIC_CONFIG_SENSE7_Pos)  /**< (EIC_CONFIG) Low level detection Position  */
+#define EIC_CONFIG_FILTEN7_Pos              31                                             /**< (EIC_CONFIG) Filter Enable 7 Position */
+#define EIC_CONFIG_FILTEN7_Msk              (_U_(0x1) << EIC_CONFIG_FILTEN7_Pos)           /**< (EIC_CONFIG) Filter Enable 7 Mask */
+#define EIC_CONFIG_FILTEN7                  EIC_CONFIG_FILTEN7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use EIC_CONFIG_FILTEN7_Msk instead */
+#define EIC_CONFIG_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (EIC_CONFIG) Register MASK  (Use EIC_CONFIG_Msk instead)  */
+#define EIC_CONFIG_Msk                      _U_(0xFFFFFFFF)                                /**< (EIC_CONFIG) Register Mask  */
+
+
+/* -------- EIC_DEBOUNCEN : (EIC Offset: 0x30) (R/W 32) Debouncer Enable -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t DEBOUNCEN:8;               /**< bit:   0..7  Debouncer Enable                         */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} EIC_DEBOUNCEN_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_DEBOUNCEN_OFFSET                (0x30)                                        /**<  (EIC_DEBOUNCEN) Debouncer Enable  Offset */
+#define EIC_DEBOUNCEN_RESETVALUE            _U_(0x00)                                     /**<  (EIC_DEBOUNCEN) Debouncer Enable  Reset Value */
+
+#define EIC_DEBOUNCEN_DEBOUNCEN_Pos         0                                              /**< (EIC_DEBOUNCEN) Debouncer Enable Position */
+#define EIC_DEBOUNCEN_DEBOUNCEN_Msk         (_U_(0xFF) << EIC_DEBOUNCEN_DEBOUNCEN_Pos)     /**< (EIC_DEBOUNCEN) Debouncer Enable Mask */
+#define EIC_DEBOUNCEN_DEBOUNCEN(value)      (EIC_DEBOUNCEN_DEBOUNCEN_Msk & ((value) << EIC_DEBOUNCEN_DEBOUNCEN_Pos))
+#define EIC_DEBOUNCEN_MASK                  _U_(0xFF)                                      /**< \deprecated (EIC_DEBOUNCEN) Register MASK  (Use EIC_DEBOUNCEN_Msk instead)  */
+#define EIC_DEBOUNCEN_Msk                   _U_(0xFF)                                      /**< (EIC_DEBOUNCEN) Register Mask  */
+
+
+/* -------- EIC_DPRESCALER : (EIC Offset: 0x34) (R/W 32) Debouncer Prescaler -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t PRESCALER0:3;              /**< bit:   0..2  Debouncer Prescaler                      */
+    uint32_t STATES0:1;                 /**< bit:      3  Debouncer number of states               */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t TICKON:1;                  /**< bit:     16  Pin Sampler frequency selection          */
+    uint32_t :15;                       /**< bit: 17..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :3;                        /**< bit:   0..2  Reserved */
+    uint32_t STATES:1;                  /**< bit:      3  Debouncer number of states               */
+    uint32_t :28;                       /**< bit:  4..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} EIC_DPRESCALER_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_DPRESCALER_OFFSET               (0x34)                                        /**<  (EIC_DPRESCALER) Debouncer Prescaler  Offset */
+#define EIC_DPRESCALER_RESETVALUE           _U_(0x00)                                     /**<  (EIC_DPRESCALER) Debouncer Prescaler  Reset Value */
+
+#define EIC_DPRESCALER_PRESCALER0_Pos       0                                              /**< (EIC_DPRESCALER) Debouncer Prescaler Position */
+#define EIC_DPRESCALER_PRESCALER0_Msk       (_U_(0x7) << EIC_DPRESCALER_PRESCALER0_Pos)    /**< (EIC_DPRESCALER) Debouncer Prescaler Mask */
+#define EIC_DPRESCALER_PRESCALER0(value)    (EIC_DPRESCALER_PRESCALER0_Msk & ((value) << EIC_DPRESCALER_PRESCALER0_Pos))
+#define EIC_DPRESCALER_STATES0_Pos          3                                              /**< (EIC_DPRESCALER) Debouncer number of states Position */
+#define EIC_DPRESCALER_STATES0_Msk          (_U_(0x1) << EIC_DPRESCALER_STATES0_Pos)       /**< (EIC_DPRESCALER) Debouncer number of states Mask */
+#define EIC_DPRESCALER_STATES0              EIC_DPRESCALER_STATES0_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EIC_DPRESCALER_STATES0_Msk instead */
+#define EIC_DPRESCALER_TICKON_Pos           16                                             /**< (EIC_DPRESCALER) Pin Sampler frequency selection Position */
+#define EIC_DPRESCALER_TICKON_Msk           (_U_(0x1) << EIC_DPRESCALER_TICKON_Pos)        /**< (EIC_DPRESCALER) Pin Sampler frequency selection Mask */
+#define EIC_DPRESCALER_TICKON               EIC_DPRESCALER_TICKON_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use EIC_DPRESCALER_TICKON_Msk instead */
+#define EIC_DPRESCALER_MASK                 _U_(0x1000F)                                   /**< \deprecated (EIC_DPRESCALER) Register MASK  (Use EIC_DPRESCALER_Msk instead)  */
+#define EIC_DPRESCALER_Msk                  _U_(0x1000F)                                   /**< (EIC_DPRESCALER) Register Mask  */
+
+#define EIC_DPRESCALER_STATES_Pos           3                                              /**< (EIC_DPRESCALER Position) Debouncer number of states */
+#define EIC_DPRESCALER_STATES_Msk           (_U_(0x1) << EIC_DPRESCALER_STATES_Pos)        /**< (EIC_DPRESCALER Mask) STATES */
+#define EIC_DPRESCALER_STATES(value)        (EIC_DPRESCALER_STATES_Msk & ((value) << EIC_DPRESCALER_STATES_Pos))  
+
+/* -------- EIC_PINSTATE : (EIC Offset: 0x38) (R/ 32) Pin State -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t PINSTATE:8;                /**< bit:   0..7  Pin State                                */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} EIC_PINSTATE_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_PINSTATE_OFFSET                 (0x38)                                        /**<  (EIC_PINSTATE) Pin State  Offset */
+#define EIC_PINSTATE_RESETVALUE             _U_(0x00)                                     /**<  (EIC_PINSTATE) Pin State  Reset Value */
+
+#define EIC_PINSTATE_PINSTATE_Pos           0                                              /**< (EIC_PINSTATE) Pin State Position */
+#define EIC_PINSTATE_PINSTATE_Msk           (_U_(0xFF) << EIC_PINSTATE_PINSTATE_Pos)       /**< (EIC_PINSTATE) Pin State Mask */
+#define EIC_PINSTATE_PINSTATE(value)        (EIC_PINSTATE_PINSTATE_Msk & ((value) << EIC_PINSTATE_PINSTATE_Pos))
+#define EIC_PINSTATE_MASK                   _U_(0xFF)                                      /**< \deprecated (EIC_PINSTATE) Register MASK  (Use EIC_PINSTATE_Msk instead)  */
+#define EIC_PINSTATE_Msk                    _U_(0xFF)                                      /**< (EIC_PINSTATE) Register Mask  */
+
+
+/* -------- EIC_NSCHK : (EIC Offset: 0x3c) (R/W 32) Non-secure Interrupt Check Enable -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t EXTINT:8;                  /**< bit:   0..7  External Interrupt Nonsecure Check Enable */
+    uint32_t :23;                       /**< bit:  8..30  Reserved */
+    uint32_t NMI:1;                     /**< bit:     31  Non-Maskable External Interrupt Nonsecure Check Enable */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} EIC_NSCHK_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_NSCHK_OFFSET                    (0x3C)                                        /**<  (EIC_NSCHK) Non-secure Interrupt Check Enable  Offset */
+#define EIC_NSCHK_RESETVALUE                _U_(0x00)                                     /**<  (EIC_NSCHK) Non-secure Interrupt Check Enable  Reset Value */
+
+#define EIC_NSCHK_EXTINT_Pos                0                                              /**< (EIC_NSCHK) External Interrupt Nonsecure Check Enable Position */
+#define EIC_NSCHK_EXTINT_Msk                (_U_(0xFF) << EIC_NSCHK_EXTINT_Pos)            /**< (EIC_NSCHK) External Interrupt Nonsecure Check Enable Mask */
+#define EIC_NSCHK_EXTINT(value)             (EIC_NSCHK_EXTINT_Msk & ((value) << EIC_NSCHK_EXTINT_Pos))
+#define EIC_NSCHK_NMI_Pos                   31                                             /**< (EIC_NSCHK) Non-Maskable External Interrupt Nonsecure Check Enable Position */
+#define EIC_NSCHK_NMI_Msk                   (_U_(0x1) << EIC_NSCHK_NMI_Pos)                /**< (EIC_NSCHK) Non-Maskable External Interrupt Nonsecure Check Enable Mask */
+#define EIC_NSCHK_NMI                       EIC_NSCHK_NMI_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use EIC_NSCHK_NMI_Msk instead */
+#define EIC_NSCHK_MASK                      _U_(0x800000FF)                                /**< \deprecated (EIC_NSCHK) Register MASK  (Use EIC_NSCHK_Msk instead)  */
+#define EIC_NSCHK_Msk                       _U_(0x800000FF)                                /**< (EIC_NSCHK) Register Mask  */
+
+
+/* -------- EIC_NONSEC : (EIC Offset: 0x40) (R/W 32) Non-secure Interrupt -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t EXTINT:8;                  /**< bit:   0..7  External Interrupt Nonsecure Enable      */
+    uint32_t :23;                       /**< bit:  8..30  Reserved */
+    uint32_t NMI:1;                     /**< bit:     31  Non-Maskable Interrupt Nonsecure Enable  */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} EIC_NONSEC_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_NONSEC_OFFSET                   (0x40)                                        /**<  (EIC_NONSEC) Non-secure Interrupt  Offset */
+#define EIC_NONSEC_RESETVALUE               _U_(0x00)                                     /**<  (EIC_NONSEC) Non-secure Interrupt  Reset Value */
+
+#define EIC_NONSEC_EXTINT_Pos               0                                              /**< (EIC_NONSEC) External Interrupt Nonsecure Enable Position */
+#define EIC_NONSEC_EXTINT_Msk               (_U_(0xFF) << EIC_NONSEC_EXTINT_Pos)           /**< (EIC_NONSEC) External Interrupt Nonsecure Enable Mask */
+#define EIC_NONSEC_EXTINT(value)            (EIC_NONSEC_EXTINT_Msk & ((value) << EIC_NONSEC_EXTINT_Pos))
+#define EIC_NONSEC_NMI_Pos                  31                                             /**< (EIC_NONSEC) Non-Maskable Interrupt Nonsecure Enable Position */
+#define EIC_NONSEC_NMI_Msk                  (_U_(0x1) << EIC_NONSEC_NMI_Pos)               /**< (EIC_NONSEC) Non-Maskable Interrupt Nonsecure Enable Mask */
+#define EIC_NONSEC_NMI                      EIC_NONSEC_NMI_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use EIC_NONSEC_NMI_Msk instead */
+#define EIC_NONSEC_MASK                     _U_(0x800000FF)                                /**< \deprecated (EIC_NONSEC) Register MASK  (Use EIC_NONSEC_Msk instead)  */
+#define EIC_NONSEC_Msk                      _U_(0x800000FF)                                /**< (EIC_NONSEC) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief EIC hardware registers */
+typedef struct {  /* External Interrupt Controller */
+  __IO EIC_CTRLA_Type                 CTRLA;          /**< Offset: 0x00 (R/W   8) Control A */
+  __IO EIC_NMICTRL_Type               NMICTRL;        /**< Offset: 0x01 (R/W   8) Non-Maskable Interrupt Control */
+  __IO EIC_NMIFLAG_Type               NMIFLAG;        /**< Offset: 0x02 (R/W  16) Non-Maskable Interrupt Flag Status and Clear */
+  __I  EIC_SYNCBUSY_Type              SYNCBUSY;       /**< Offset: 0x04 (R/   32) Synchronization Busy */
+  __IO EIC_EVCTRL_Type                EVCTRL;         /**< Offset: 0x08 (R/W  32) Event Control */
+  __IO EIC_INTENCLR_Type              INTENCLR;       /**< Offset: 0x0C (R/W  32) Interrupt Enable Clear */
+  __IO EIC_INTENSET_Type              INTENSET;       /**< Offset: 0x10 (R/W  32) Interrupt Enable Set */
+  __IO EIC_INTFLAG_Type               INTFLAG;        /**< Offset: 0x14 (R/W  32) Interrupt Flag Status and Clear */
+  __IO EIC_ASYNCH_Type                ASYNCH;         /**< Offset: 0x18 (R/W  32) External Interrupt Asynchronous Mode */
+  __IO EIC_CONFIG_Type                CONFIG[1];      /**< Offset: 0x1C (R/W  32) External Interrupt Sense Configuration */
+  __I  uint8_t                        Reserved1[16];
+  __IO EIC_DEBOUNCEN_Type             DEBOUNCEN;      /**< Offset: 0x30 (R/W  32) Debouncer Enable */
+  __IO EIC_DPRESCALER_Type            DPRESCALER;     /**< Offset: 0x34 (R/W  32) Debouncer Prescaler */
+  __I  EIC_PINSTATE_Type              PINSTATE;       /**< Offset: 0x38 (R/   32) Pin State */
+  __IO EIC_NSCHK_Type                 NSCHK;          /**< Offset: 0x3C (R/W  32) Non-secure Interrupt Check Enable */
+  __IO EIC_NONSEC_Type                NONSEC;         /**< Offset: 0x40 (R/W  32) Non-secure Interrupt */
+} Eic;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of External Interrupt Controller */
+
+#endif /* _SAML10_EIC_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/component/evsys.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/evsys.h
@@ -1,0 +1,927 @@
+/**
+ * \file
+ *
+ * \brief Component description for EVSYS
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_EVSYS_COMPONENT_H_
+#define _SAML10_EVSYS_COMPONENT_H_
+#define _SAML10_EVSYS_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML10 Event System Interface
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR EVSYS */
+/* ========================================================================== */
+
+#define EVSYS_U2504                      /**< (EVSYS) Module ID */
+#define REV_EVSYS 0x200                  /**< (EVSYS) Module revision */
+
+/* -------- EVSYS_CHANNEL : (EVSYS Offset: 0x00) (R/W 32) Channel n Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t EVGEN:6;                   /**< bit:   0..5  Event Generator Selection                */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t PATH:2;                    /**< bit:   8..9  Path Selection                           */
+    uint32_t EDGSEL:2;                  /**< bit: 10..11  Edge Detection Selection                 */
+    uint32_t :2;                        /**< bit: 12..13  Reserved */
+    uint32_t RUNSTDBY:1;                /**< bit:     14  Run in standby                           */
+    uint32_t ONDEMAND:1;                /**< bit:     15  Generic Clock On Demand                  */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} EVSYS_CHANNEL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_CHANNEL_OFFSET                (0x00)                                        /**<  (EVSYS_CHANNEL) Channel n Control  Offset */
+#define EVSYS_CHANNEL_RESETVALUE            _U_(0x8000)                                   /**<  (EVSYS_CHANNEL) Channel n Control  Reset Value */
+
+#define EVSYS_CHANNEL_EVGEN_Pos             0                                              /**< (EVSYS_CHANNEL) Event Generator Selection Position */
+#define EVSYS_CHANNEL_EVGEN_Msk             (_U_(0x3F) << EVSYS_CHANNEL_EVGEN_Pos)         /**< (EVSYS_CHANNEL) Event Generator Selection Mask */
+#define EVSYS_CHANNEL_EVGEN(value)          (EVSYS_CHANNEL_EVGEN_Msk & ((value) << EVSYS_CHANNEL_EVGEN_Pos))
+#define EVSYS_CHANNEL_PATH_Pos              8                                              /**< (EVSYS_CHANNEL) Path Selection Position */
+#define EVSYS_CHANNEL_PATH_Msk              (_U_(0x3) << EVSYS_CHANNEL_PATH_Pos)           /**< (EVSYS_CHANNEL) Path Selection Mask */
+#define EVSYS_CHANNEL_PATH(value)           (EVSYS_CHANNEL_PATH_Msk & ((value) << EVSYS_CHANNEL_PATH_Pos))
+#define   EVSYS_CHANNEL_PATH_SYNCHRONOUS_Val _U_(0x0)                                       /**< (EVSYS_CHANNEL) Synchronous path  */
+#define   EVSYS_CHANNEL_PATH_RESYNCHRONIZED_Val _U_(0x1)                                       /**< (EVSYS_CHANNEL) Resynchronized path  */
+#define   EVSYS_CHANNEL_PATH_ASYNCHRONOUS_Val _U_(0x2)                                       /**< (EVSYS_CHANNEL) Asynchronous path  */
+#define EVSYS_CHANNEL_PATH_SYNCHRONOUS      (EVSYS_CHANNEL_PATH_SYNCHRONOUS_Val << EVSYS_CHANNEL_PATH_Pos)  /**< (EVSYS_CHANNEL) Synchronous path Position  */
+#define EVSYS_CHANNEL_PATH_RESYNCHRONIZED   (EVSYS_CHANNEL_PATH_RESYNCHRONIZED_Val << EVSYS_CHANNEL_PATH_Pos)  /**< (EVSYS_CHANNEL) Resynchronized path Position  */
+#define EVSYS_CHANNEL_PATH_ASYNCHRONOUS     (EVSYS_CHANNEL_PATH_ASYNCHRONOUS_Val << EVSYS_CHANNEL_PATH_Pos)  /**< (EVSYS_CHANNEL) Asynchronous path Position  */
+#define EVSYS_CHANNEL_EDGSEL_Pos            10                                             /**< (EVSYS_CHANNEL) Edge Detection Selection Position */
+#define EVSYS_CHANNEL_EDGSEL_Msk            (_U_(0x3) << EVSYS_CHANNEL_EDGSEL_Pos)         /**< (EVSYS_CHANNEL) Edge Detection Selection Mask */
+#define EVSYS_CHANNEL_EDGSEL(value)         (EVSYS_CHANNEL_EDGSEL_Msk & ((value) << EVSYS_CHANNEL_EDGSEL_Pos))
+#define   EVSYS_CHANNEL_EDGSEL_NO_EVT_OUTPUT_Val _U_(0x0)                                       /**< (EVSYS_CHANNEL) No event output when using the resynchronized or synchronous path  */
+#define   EVSYS_CHANNEL_EDGSEL_RISING_EDGE_Val _U_(0x1)                                       /**< (EVSYS_CHANNEL) Event detection only on the rising edge of the signal from the event generator when using the resynchronized or synchronous path  */
+#define   EVSYS_CHANNEL_EDGSEL_FALLING_EDGE_Val _U_(0x2)                                       /**< (EVSYS_CHANNEL) Event detection only on the falling edge of the signal from the event generator when using the resynchronized or synchronous path  */
+#define   EVSYS_CHANNEL_EDGSEL_BOTH_EDGES_Val _U_(0x3)                                       /**< (EVSYS_CHANNEL) Event detection on rising and falling edges of the signal from the event generator when using the resynchronized or synchronous path  */
+#define EVSYS_CHANNEL_EDGSEL_NO_EVT_OUTPUT  (EVSYS_CHANNEL_EDGSEL_NO_EVT_OUTPUT_Val << EVSYS_CHANNEL_EDGSEL_Pos)  /**< (EVSYS_CHANNEL) No event output when using the resynchronized or synchronous path Position  */
+#define EVSYS_CHANNEL_EDGSEL_RISING_EDGE    (EVSYS_CHANNEL_EDGSEL_RISING_EDGE_Val << EVSYS_CHANNEL_EDGSEL_Pos)  /**< (EVSYS_CHANNEL) Event detection only on the rising edge of the signal from the event generator when using the resynchronized or synchronous path Position  */
+#define EVSYS_CHANNEL_EDGSEL_FALLING_EDGE   (EVSYS_CHANNEL_EDGSEL_FALLING_EDGE_Val << EVSYS_CHANNEL_EDGSEL_Pos)  /**< (EVSYS_CHANNEL) Event detection only on the falling edge of the signal from the event generator when using the resynchronized or synchronous path Position  */
+#define EVSYS_CHANNEL_EDGSEL_BOTH_EDGES     (EVSYS_CHANNEL_EDGSEL_BOTH_EDGES_Val << EVSYS_CHANNEL_EDGSEL_Pos)  /**< (EVSYS_CHANNEL) Event detection on rising and falling edges of the signal from the event generator when using the resynchronized or synchronous path Position  */
+#define EVSYS_CHANNEL_RUNSTDBY_Pos          14                                             /**< (EVSYS_CHANNEL) Run in standby Position */
+#define EVSYS_CHANNEL_RUNSTDBY_Msk          (_U_(0x1) << EVSYS_CHANNEL_RUNSTDBY_Pos)       /**< (EVSYS_CHANNEL) Run in standby Mask */
+#define EVSYS_CHANNEL_RUNSTDBY              EVSYS_CHANNEL_RUNSTDBY_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_CHANNEL_RUNSTDBY_Msk instead */
+#define EVSYS_CHANNEL_ONDEMAND_Pos          15                                             /**< (EVSYS_CHANNEL) Generic Clock On Demand Position */
+#define EVSYS_CHANNEL_ONDEMAND_Msk          (_U_(0x1) << EVSYS_CHANNEL_ONDEMAND_Pos)       /**< (EVSYS_CHANNEL) Generic Clock On Demand Mask */
+#define EVSYS_CHANNEL_ONDEMAND              EVSYS_CHANNEL_ONDEMAND_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_CHANNEL_ONDEMAND_Msk instead */
+#define EVSYS_CHANNEL_MASK                  _U_(0xCF3F)                                    /**< \deprecated (EVSYS_CHANNEL) Register MASK  (Use EVSYS_CHANNEL_Msk instead)  */
+#define EVSYS_CHANNEL_Msk                   _U_(0xCF3F)                                    /**< (EVSYS_CHANNEL) Register Mask  */
+
+
+/* -------- EVSYS_CHINTENCLR : (EVSYS Offset: 0x04) (R/W 8) Channel n Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  OVR:1;                     /**< bit:      0  Channel Overrun Interrupt Disable        */
+    uint8_t  EVD:1;                     /**< bit:      1  Channel Event Detected Interrupt Disable */
+    uint8_t  :6;                        /**< bit:   2..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} EVSYS_CHINTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_CHINTENCLR_OFFSET             (0x04)                                        /**<  (EVSYS_CHINTENCLR) Channel n Interrupt Enable Clear  Offset */
+#define EVSYS_CHINTENCLR_RESETVALUE         _U_(0x00)                                     /**<  (EVSYS_CHINTENCLR) Channel n Interrupt Enable Clear  Reset Value */
+
+#define EVSYS_CHINTENCLR_OVR_Pos            0                                              /**< (EVSYS_CHINTENCLR) Channel Overrun Interrupt Disable Position */
+#define EVSYS_CHINTENCLR_OVR_Msk            (_U_(0x1) << EVSYS_CHINTENCLR_OVR_Pos)         /**< (EVSYS_CHINTENCLR) Channel Overrun Interrupt Disable Mask */
+#define EVSYS_CHINTENCLR_OVR                EVSYS_CHINTENCLR_OVR_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_CHINTENCLR_OVR_Msk instead */
+#define EVSYS_CHINTENCLR_EVD_Pos            1                                              /**< (EVSYS_CHINTENCLR) Channel Event Detected Interrupt Disable Position */
+#define EVSYS_CHINTENCLR_EVD_Msk            (_U_(0x1) << EVSYS_CHINTENCLR_EVD_Pos)         /**< (EVSYS_CHINTENCLR) Channel Event Detected Interrupt Disable Mask */
+#define EVSYS_CHINTENCLR_EVD                EVSYS_CHINTENCLR_EVD_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_CHINTENCLR_EVD_Msk instead */
+#define EVSYS_CHINTENCLR_MASK               _U_(0x03)                                      /**< \deprecated (EVSYS_CHINTENCLR) Register MASK  (Use EVSYS_CHINTENCLR_Msk instead)  */
+#define EVSYS_CHINTENCLR_Msk                _U_(0x03)                                      /**< (EVSYS_CHINTENCLR) Register Mask  */
+
+
+/* -------- EVSYS_CHINTENSET : (EVSYS Offset: 0x05) (R/W 8) Channel n Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  OVR:1;                     /**< bit:      0  Channel Overrun Interrupt Enable         */
+    uint8_t  EVD:1;                     /**< bit:      1  Channel Event Detected Interrupt Enable  */
+    uint8_t  :6;                        /**< bit:   2..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} EVSYS_CHINTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_CHINTENSET_OFFSET             (0x05)                                        /**<  (EVSYS_CHINTENSET) Channel n Interrupt Enable Set  Offset */
+#define EVSYS_CHINTENSET_RESETVALUE         _U_(0x00)                                     /**<  (EVSYS_CHINTENSET) Channel n Interrupt Enable Set  Reset Value */
+
+#define EVSYS_CHINTENSET_OVR_Pos            0                                              /**< (EVSYS_CHINTENSET) Channel Overrun Interrupt Enable Position */
+#define EVSYS_CHINTENSET_OVR_Msk            (_U_(0x1) << EVSYS_CHINTENSET_OVR_Pos)         /**< (EVSYS_CHINTENSET) Channel Overrun Interrupt Enable Mask */
+#define EVSYS_CHINTENSET_OVR                EVSYS_CHINTENSET_OVR_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_CHINTENSET_OVR_Msk instead */
+#define EVSYS_CHINTENSET_EVD_Pos            1                                              /**< (EVSYS_CHINTENSET) Channel Event Detected Interrupt Enable Position */
+#define EVSYS_CHINTENSET_EVD_Msk            (_U_(0x1) << EVSYS_CHINTENSET_EVD_Pos)         /**< (EVSYS_CHINTENSET) Channel Event Detected Interrupt Enable Mask */
+#define EVSYS_CHINTENSET_EVD                EVSYS_CHINTENSET_EVD_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_CHINTENSET_EVD_Msk instead */
+#define EVSYS_CHINTENSET_MASK               _U_(0x03)                                      /**< \deprecated (EVSYS_CHINTENSET) Register MASK  (Use EVSYS_CHINTENSET_Msk instead)  */
+#define EVSYS_CHINTENSET_Msk                _U_(0x03)                                      /**< (EVSYS_CHINTENSET) Register Mask  */
+
+
+/* -------- EVSYS_CHINTFLAG : (EVSYS Offset: 0x06) (R/W 8) Channel n Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t OVR:1;                     /**< bit:      0  Channel Overrun                          */
+    __I uint8_t EVD:1;                     /**< bit:      1  Channel Event Detected                   */
+    __I uint8_t :6;                        /**< bit:   2..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} EVSYS_CHINTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_CHINTFLAG_OFFSET              (0x06)                                        /**<  (EVSYS_CHINTFLAG) Channel n Interrupt Flag Status and Clear  Offset */
+#define EVSYS_CHINTFLAG_RESETVALUE          _U_(0x00)                                     /**<  (EVSYS_CHINTFLAG) Channel n Interrupt Flag Status and Clear  Reset Value */
+
+#define EVSYS_CHINTFLAG_OVR_Pos             0                                              /**< (EVSYS_CHINTFLAG) Channel Overrun Position */
+#define EVSYS_CHINTFLAG_OVR_Msk             (_U_(0x1) << EVSYS_CHINTFLAG_OVR_Pos)          /**< (EVSYS_CHINTFLAG) Channel Overrun Mask */
+#define EVSYS_CHINTFLAG_OVR                 EVSYS_CHINTFLAG_OVR_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_CHINTFLAG_OVR_Msk instead */
+#define EVSYS_CHINTFLAG_EVD_Pos             1                                              /**< (EVSYS_CHINTFLAG) Channel Event Detected Position */
+#define EVSYS_CHINTFLAG_EVD_Msk             (_U_(0x1) << EVSYS_CHINTFLAG_EVD_Pos)          /**< (EVSYS_CHINTFLAG) Channel Event Detected Mask */
+#define EVSYS_CHINTFLAG_EVD                 EVSYS_CHINTFLAG_EVD_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_CHINTFLAG_EVD_Msk instead */
+#define EVSYS_CHINTFLAG_MASK                _U_(0x03)                                      /**< \deprecated (EVSYS_CHINTFLAG) Register MASK  (Use EVSYS_CHINTFLAG_Msk instead)  */
+#define EVSYS_CHINTFLAG_Msk                 _U_(0x03)                                      /**< (EVSYS_CHINTFLAG) Register Mask  */
+
+
+/* -------- EVSYS_CHSTATUS : (EVSYS Offset: 0x07) (R/ 8) Channel n Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  RDYUSR:1;                  /**< bit:      0  Ready User                               */
+    uint8_t  BUSYCH:1;                  /**< bit:      1  Busy Channel                             */
+    uint8_t  :6;                        /**< bit:   2..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} EVSYS_CHSTATUS_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_CHSTATUS_OFFSET               (0x07)                                        /**<  (EVSYS_CHSTATUS) Channel n Status  Offset */
+#define EVSYS_CHSTATUS_RESETVALUE           _U_(0x01)                                     /**<  (EVSYS_CHSTATUS) Channel n Status  Reset Value */
+
+#define EVSYS_CHSTATUS_RDYUSR_Pos           0                                              /**< (EVSYS_CHSTATUS) Ready User Position */
+#define EVSYS_CHSTATUS_RDYUSR_Msk           (_U_(0x1) << EVSYS_CHSTATUS_RDYUSR_Pos)        /**< (EVSYS_CHSTATUS) Ready User Mask */
+#define EVSYS_CHSTATUS_RDYUSR               EVSYS_CHSTATUS_RDYUSR_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_CHSTATUS_RDYUSR_Msk instead */
+#define EVSYS_CHSTATUS_BUSYCH_Pos           1                                              /**< (EVSYS_CHSTATUS) Busy Channel Position */
+#define EVSYS_CHSTATUS_BUSYCH_Msk           (_U_(0x1) << EVSYS_CHSTATUS_BUSYCH_Pos)        /**< (EVSYS_CHSTATUS) Busy Channel Mask */
+#define EVSYS_CHSTATUS_BUSYCH               EVSYS_CHSTATUS_BUSYCH_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_CHSTATUS_BUSYCH_Msk instead */
+#define EVSYS_CHSTATUS_MASK                 _U_(0x03)                                      /**< \deprecated (EVSYS_CHSTATUS) Register MASK  (Use EVSYS_CHSTATUS_Msk instead)  */
+#define EVSYS_CHSTATUS_Msk                  _U_(0x03)                                      /**< (EVSYS_CHSTATUS) Register Mask  */
+
+
+/* -------- EVSYS_CTRLA : (EVSYS Offset: 0x00) (/W 8) Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} EVSYS_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_CTRLA_OFFSET                  (0x00)                                        /**<  (EVSYS_CTRLA) Control  Offset */
+#define EVSYS_CTRLA_RESETVALUE              _U_(0x00)                                     /**<  (EVSYS_CTRLA) Control  Reset Value */
+
+#define EVSYS_CTRLA_SWRST_Pos               0                                              /**< (EVSYS_CTRLA) Software Reset Position */
+#define EVSYS_CTRLA_SWRST_Msk               (_U_(0x1) << EVSYS_CTRLA_SWRST_Pos)            /**< (EVSYS_CTRLA) Software Reset Mask */
+#define EVSYS_CTRLA_SWRST                   EVSYS_CTRLA_SWRST_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_CTRLA_SWRST_Msk instead */
+#define EVSYS_CTRLA_MASK                    _U_(0x01)                                      /**< \deprecated (EVSYS_CTRLA) Register MASK  (Use EVSYS_CTRLA_Msk instead)  */
+#define EVSYS_CTRLA_Msk                     _U_(0x01)                                      /**< (EVSYS_CTRLA) Register Mask  */
+
+
+/* -------- EVSYS_SWEVT : (EVSYS Offset: 0x04) (/W 32) Software Event -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t CHANNEL0:1;                /**< bit:      0  Channel 0 Software Selection             */
+    uint32_t CHANNEL1:1;                /**< bit:      1  Channel 1 Software Selection             */
+    uint32_t CHANNEL2:1;                /**< bit:      2  Channel 2 Software Selection             */
+    uint32_t CHANNEL3:1;                /**< bit:      3  Channel 3 Software Selection             */
+    uint32_t CHANNEL4:1;                /**< bit:      4  Channel 4 Software Selection             */
+    uint32_t CHANNEL5:1;                /**< bit:      5  Channel 5 Software Selection             */
+    uint32_t CHANNEL6:1;                /**< bit:      6  Channel 6 Software Selection             */
+    uint32_t CHANNEL7:1;                /**< bit:      7  Channel 7 Software Selection             */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t CHANNEL:8;                 /**< bit:   0..7  Channel 7 Software Selection             */
+    uint32_t :24;                       /**< bit:  8..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} EVSYS_SWEVT_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_SWEVT_OFFSET                  (0x04)                                        /**<  (EVSYS_SWEVT) Software Event  Offset */
+#define EVSYS_SWEVT_RESETVALUE              _U_(0x00)                                     /**<  (EVSYS_SWEVT) Software Event  Reset Value */
+
+#define EVSYS_SWEVT_CHANNEL0_Pos            0                                              /**< (EVSYS_SWEVT) Channel 0 Software Selection Position */
+#define EVSYS_SWEVT_CHANNEL0_Msk            (_U_(0x1) << EVSYS_SWEVT_CHANNEL0_Pos)         /**< (EVSYS_SWEVT) Channel 0 Software Selection Mask */
+#define EVSYS_SWEVT_CHANNEL0                EVSYS_SWEVT_CHANNEL0_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_SWEVT_CHANNEL0_Msk instead */
+#define EVSYS_SWEVT_CHANNEL1_Pos            1                                              /**< (EVSYS_SWEVT) Channel 1 Software Selection Position */
+#define EVSYS_SWEVT_CHANNEL1_Msk            (_U_(0x1) << EVSYS_SWEVT_CHANNEL1_Pos)         /**< (EVSYS_SWEVT) Channel 1 Software Selection Mask */
+#define EVSYS_SWEVT_CHANNEL1                EVSYS_SWEVT_CHANNEL1_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_SWEVT_CHANNEL1_Msk instead */
+#define EVSYS_SWEVT_CHANNEL2_Pos            2                                              /**< (EVSYS_SWEVT) Channel 2 Software Selection Position */
+#define EVSYS_SWEVT_CHANNEL2_Msk            (_U_(0x1) << EVSYS_SWEVT_CHANNEL2_Pos)         /**< (EVSYS_SWEVT) Channel 2 Software Selection Mask */
+#define EVSYS_SWEVT_CHANNEL2                EVSYS_SWEVT_CHANNEL2_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_SWEVT_CHANNEL2_Msk instead */
+#define EVSYS_SWEVT_CHANNEL3_Pos            3                                              /**< (EVSYS_SWEVT) Channel 3 Software Selection Position */
+#define EVSYS_SWEVT_CHANNEL3_Msk            (_U_(0x1) << EVSYS_SWEVT_CHANNEL3_Pos)         /**< (EVSYS_SWEVT) Channel 3 Software Selection Mask */
+#define EVSYS_SWEVT_CHANNEL3                EVSYS_SWEVT_CHANNEL3_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_SWEVT_CHANNEL3_Msk instead */
+#define EVSYS_SWEVT_CHANNEL4_Pos            4                                              /**< (EVSYS_SWEVT) Channel 4 Software Selection Position */
+#define EVSYS_SWEVT_CHANNEL4_Msk            (_U_(0x1) << EVSYS_SWEVT_CHANNEL4_Pos)         /**< (EVSYS_SWEVT) Channel 4 Software Selection Mask */
+#define EVSYS_SWEVT_CHANNEL4                EVSYS_SWEVT_CHANNEL4_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_SWEVT_CHANNEL4_Msk instead */
+#define EVSYS_SWEVT_CHANNEL5_Pos            5                                              /**< (EVSYS_SWEVT) Channel 5 Software Selection Position */
+#define EVSYS_SWEVT_CHANNEL5_Msk            (_U_(0x1) << EVSYS_SWEVT_CHANNEL5_Pos)         /**< (EVSYS_SWEVT) Channel 5 Software Selection Mask */
+#define EVSYS_SWEVT_CHANNEL5                EVSYS_SWEVT_CHANNEL5_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_SWEVT_CHANNEL5_Msk instead */
+#define EVSYS_SWEVT_CHANNEL6_Pos            6                                              /**< (EVSYS_SWEVT) Channel 6 Software Selection Position */
+#define EVSYS_SWEVT_CHANNEL6_Msk            (_U_(0x1) << EVSYS_SWEVT_CHANNEL6_Pos)         /**< (EVSYS_SWEVT) Channel 6 Software Selection Mask */
+#define EVSYS_SWEVT_CHANNEL6                EVSYS_SWEVT_CHANNEL6_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_SWEVT_CHANNEL6_Msk instead */
+#define EVSYS_SWEVT_CHANNEL7_Pos            7                                              /**< (EVSYS_SWEVT) Channel 7 Software Selection Position */
+#define EVSYS_SWEVT_CHANNEL7_Msk            (_U_(0x1) << EVSYS_SWEVT_CHANNEL7_Pos)         /**< (EVSYS_SWEVT) Channel 7 Software Selection Mask */
+#define EVSYS_SWEVT_CHANNEL7                EVSYS_SWEVT_CHANNEL7_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_SWEVT_CHANNEL7_Msk instead */
+#define EVSYS_SWEVT_MASK                    _U_(0xFF)                                      /**< \deprecated (EVSYS_SWEVT) Register MASK  (Use EVSYS_SWEVT_Msk instead)  */
+#define EVSYS_SWEVT_Msk                     _U_(0xFF)                                      /**< (EVSYS_SWEVT) Register Mask  */
+
+#define EVSYS_SWEVT_CHANNEL_Pos             0                                              /**< (EVSYS_SWEVT Position) Channel 7 Software Selection */
+#define EVSYS_SWEVT_CHANNEL_Msk             (_U_(0xFF) << EVSYS_SWEVT_CHANNEL_Pos)         /**< (EVSYS_SWEVT Mask) CHANNEL */
+#define EVSYS_SWEVT_CHANNEL(value)          (EVSYS_SWEVT_CHANNEL_Msk & ((value) << EVSYS_SWEVT_CHANNEL_Pos))  
+
+/* -------- EVSYS_PRICTRL : (EVSYS Offset: 0x08) (R/W 8) Priority Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  PRI:2;                     /**< bit:   0..1  Channel Priority Number                  */
+    uint8_t  :5;                        /**< bit:   2..6  Reserved */
+    uint8_t  RREN:1;                    /**< bit:      7  Round-Robin Scheduling Enable            */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} EVSYS_PRICTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_PRICTRL_OFFSET                (0x08)                                        /**<  (EVSYS_PRICTRL) Priority Control  Offset */
+#define EVSYS_PRICTRL_RESETVALUE            _U_(0x00)                                     /**<  (EVSYS_PRICTRL) Priority Control  Reset Value */
+
+#define EVSYS_PRICTRL_PRI_Pos               0                                              /**< (EVSYS_PRICTRL) Channel Priority Number Position */
+#define EVSYS_PRICTRL_PRI_Msk               (_U_(0x3) << EVSYS_PRICTRL_PRI_Pos)            /**< (EVSYS_PRICTRL) Channel Priority Number Mask */
+#define EVSYS_PRICTRL_PRI(value)            (EVSYS_PRICTRL_PRI_Msk & ((value) << EVSYS_PRICTRL_PRI_Pos))
+#define EVSYS_PRICTRL_RREN_Pos              7                                              /**< (EVSYS_PRICTRL) Round-Robin Scheduling Enable Position */
+#define EVSYS_PRICTRL_RREN_Msk              (_U_(0x1) << EVSYS_PRICTRL_RREN_Pos)           /**< (EVSYS_PRICTRL) Round-Robin Scheduling Enable Mask */
+#define EVSYS_PRICTRL_RREN                  EVSYS_PRICTRL_RREN_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_PRICTRL_RREN_Msk instead */
+#define EVSYS_PRICTRL_MASK                  _U_(0x83)                                      /**< \deprecated (EVSYS_PRICTRL) Register MASK  (Use EVSYS_PRICTRL_Msk instead)  */
+#define EVSYS_PRICTRL_Msk                   _U_(0x83)                                      /**< (EVSYS_PRICTRL) Register Mask  */
+
+
+/* -------- EVSYS_INTPEND : (EVSYS Offset: 0x10) (R/W 16) Channel Pending Interrupt -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t ID:2;                      /**< bit:   0..1  Channel ID                               */
+    uint16_t :6;                        /**< bit:   2..7  Reserved */
+    uint16_t OVR:1;                     /**< bit:      8  Channel Overrun                          */
+    uint16_t EVD:1;                     /**< bit:      9  Channel Event Detected                   */
+    uint16_t :4;                        /**< bit: 10..13  Reserved */
+    uint16_t READY:1;                   /**< bit:     14  Ready                                    */
+    uint16_t BUSY:1;                    /**< bit:     15  Busy                                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} EVSYS_INTPEND_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_INTPEND_OFFSET                (0x10)                                        /**<  (EVSYS_INTPEND) Channel Pending Interrupt  Offset */
+#define EVSYS_INTPEND_RESETVALUE            _U_(0x4000)                                   /**<  (EVSYS_INTPEND) Channel Pending Interrupt  Reset Value */
+
+#define EVSYS_INTPEND_ID_Pos                0                                              /**< (EVSYS_INTPEND) Channel ID Position */
+#define EVSYS_INTPEND_ID_Msk                (_U_(0x3) << EVSYS_INTPEND_ID_Pos)             /**< (EVSYS_INTPEND) Channel ID Mask */
+#define EVSYS_INTPEND_ID(value)             (EVSYS_INTPEND_ID_Msk & ((value) << EVSYS_INTPEND_ID_Pos))
+#define EVSYS_INTPEND_OVR_Pos               8                                              /**< (EVSYS_INTPEND) Channel Overrun Position */
+#define EVSYS_INTPEND_OVR_Msk               (_U_(0x1) << EVSYS_INTPEND_OVR_Pos)            /**< (EVSYS_INTPEND) Channel Overrun Mask */
+#define EVSYS_INTPEND_OVR                   EVSYS_INTPEND_OVR_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_INTPEND_OVR_Msk instead */
+#define EVSYS_INTPEND_EVD_Pos               9                                              /**< (EVSYS_INTPEND) Channel Event Detected Position */
+#define EVSYS_INTPEND_EVD_Msk               (_U_(0x1) << EVSYS_INTPEND_EVD_Pos)            /**< (EVSYS_INTPEND) Channel Event Detected Mask */
+#define EVSYS_INTPEND_EVD                   EVSYS_INTPEND_EVD_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_INTPEND_EVD_Msk instead */
+#define EVSYS_INTPEND_READY_Pos             14                                             /**< (EVSYS_INTPEND) Ready Position */
+#define EVSYS_INTPEND_READY_Msk             (_U_(0x1) << EVSYS_INTPEND_READY_Pos)          /**< (EVSYS_INTPEND) Ready Mask */
+#define EVSYS_INTPEND_READY                 EVSYS_INTPEND_READY_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_INTPEND_READY_Msk instead */
+#define EVSYS_INTPEND_BUSY_Pos              15                                             /**< (EVSYS_INTPEND) Busy Position */
+#define EVSYS_INTPEND_BUSY_Msk              (_U_(0x1) << EVSYS_INTPEND_BUSY_Pos)           /**< (EVSYS_INTPEND) Busy Mask */
+#define EVSYS_INTPEND_BUSY                  EVSYS_INTPEND_BUSY_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_INTPEND_BUSY_Msk instead */
+#define EVSYS_INTPEND_MASK                  _U_(0xC303)                                    /**< \deprecated (EVSYS_INTPEND) Register MASK  (Use EVSYS_INTPEND_Msk instead)  */
+#define EVSYS_INTPEND_Msk                   _U_(0xC303)                                    /**< (EVSYS_INTPEND) Register Mask  */
+
+
+/* -------- EVSYS_INTSTATUS : (EVSYS Offset: 0x14) (R/ 32) Interrupt Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t CHINT0:1;                  /**< bit:      0  Channel 0 Pending Interrupt              */
+    uint32_t CHINT1:1;                  /**< bit:      1  Channel 1 Pending Interrupt              */
+    uint32_t CHINT2:1;                  /**< bit:      2  Channel 2 Pending Interrupt              */
+    uint32_t CHINT3:1;                  /**< bit:      3  Channel 3 Pending Interrupt              */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t CHINT:4;                   /**< bit:   0..3  Channel 3 Pending Interrupt              */
+    uint32_t :28;                       /**< bit:  4..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} EVSYS_INTSTATUS_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_INTSTATUS_OFFSET              (0x14)                                        /**<  (EVSYS_INTSTATUS) Interrupt Status  Offset */
+#define EVSYS_INTSTATUS_RESETVALUE          _U_(0x00)                                     /**<  (EVSYS_INTSTATUS) Interrupt Status  Reset Value */
+
+#define EVSYS_INTSTATUS_CHINT0_Pos          0                                              /**< (EVSYS_INTSTATUS) Channel 0 Pending Interrupt Position */
+#define EVSYS_INTSTATUS_CHINT0_Msk          (_U_(0x1) << EVSYS_INTSTATUS_CHINT0_Pos)       /**< (EVSYS_INTSTATUS) Channel 0 Pending Interrupt Mask */
+#define EVSYS_INTSTATUS_CHINT0              EVSYS_INTSTATUS_CHINT0_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_INTSTATUS_CHINT0_Msk instead */
+#define EVSYS_INTSTATUS_CHINT1_Pos          1                                              /**< (EVSYS_INTSTATUS) Channel 1 Pending Interrupt Position */
+#define EVSYS_INTSTATUS_CHINT1_Msk          (_U_(0x1) << EVSYS_INTSTATUS_CHINT1_Pos)       /**< (EVSYS_INTSTATUS) Channel 1 Pending Interrupt Mask */
+#define EVSYS_INTSTATUS_CHINT1              EVSYS_INTSTATUS_CHINT1_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_INTSTATUS_CHINT1_Msk instead */
+#define EVSYS_INTSTATUS_CHINT2_Pos          2                                              /**< (EVSYS_INTSTATUS) Channel 2 Pending Interrupt Position */
+#define EVSYS_INTSTATUS_CHINT2_Msk          (_U_(0x1) << EVSYS_INTSTATUS_CHINT2_Pos)       /**< (EVSYS_INTSTATUS) Channel 2 Pending Interrupt Mask */
+#define EVSYS_INTSTATUS_CHINT2              EVSYS_INTSTATUS_CHINT2_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_INTSTATUS_CHINT2_Msk instead */
+#define EVSYS_INTSTATUS_CHINT3_Pos          3                                              /**< (EVSYS_INTSTATUS) Channel 3 Pending Interrupt Position */
+#define EVSYS_INTSTATUS_CHINT3_Msk          (_U_(0x1) << EVSYS_INTSTATUS_CHINT3_Pos)       /**< (EVSYS_INTSTATUS) Channel 3 Pending Interrupt Mask */
+#define EVSYS_INTSTATUS_CHINT3              EVSYS_INTSTATUS_CHINT3_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_INTSTATUS_CHINT3_Msk instead */
+#define EVSYS_INTSTATUS_MASK                _U_(0x0F)                                      /**< \deprecated (EVSYS_INTSTATUS) Register MASK  (Use EVSYS_INTSTATUS_Msk instead)  */
+#define EVSYS_INTSTATUS_Msk                 _U_(0x0F)                                      /**< (EVSYS_INTSTATUS) Register Mask  */
+
+#define EVSYS_INTSTATUS_CHINT_Pos           0                                              /**< (EVSYS_INTSTATUS Position) Channel 3 Pending Interrupt */
+#define EVSYS_INTSTATUS_CHINT_Msk           (_U_(0xF) << EVSYS_INTSTATUS_CHINT_Pos)        /**< (EVSYS_INTSTATUS Mask) CHINT */
+#define EVSYS_INTSTATUS_CHINT(value)        (EVSYS_INTSTATUS_CHINT_Msk & ((value) << EVSYS_INTSTATUS_CHINT_Pos))  
+
+/* -------- EVSYS_BUSYCH : (EVSYS Offset: 0x18) (R/ 32) Busy Channels -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t BUSYCH0:1;                 /**< bit:      0  Busy Channel 0                           */
+    uint32_t BUSYCH1:1;                 /**< bit:      1  Busy Channel 1                           */
+    uint32_t BUSYCH2:1;                 /**< bit:      2  Busy Channel 2                           */
+    uint32_t BUSYCH3:1;                 /**< bit:      3  Busy Channel 3                           */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t BUSYCH:4;                  /**< bit:   0..3  Busy Channel 3                           */
+    uint32_t :28;                       /**< bit:  4..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} EVSYS_BUSYCH_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_BUSYCH_OFFSET                 (0x18)                                        /**<  (EVSYS_BUSYCH) Busy Channels  Offset */
+#define EVSYS_BUSYCH_RESETVALUE             _U_(0x00)                                     /**<  (EVSYS_BUSYCH) Busy Channels  Reset Value */
+
+#define EVSYS_BUSYCH_BUSYCH0_Pos            0                                              /**< (EVSYS_BUSYCH) Busy Channel 0 Position */
+#define EVSYS_BUSYCH_BUSYCH0_Msk            (_U_(0x1) << EVSYS_BUSYCH_BUSYCH0_Pos)         /**< (EVSYS_BUSYCH) Busy Channel 0 Mask */
+#define EVSYS_BUSYCH_BUSYCH0                EVSYS_BUSYCH_BUSYCH0_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_BUSYCH_BUSYCH0_Msk instead */
+#define EVSYS_BUSYCH_BUSYCH1_Pos            1                                              /**< (EVSYS_BUSYCH) Busy Channel 1 Position */
+#define EVSYS_BUSYCH_BUSYCH1_Msk            (_U_(0x1) << EVSYS_BUSYCH_BUSYCH1_Pos)         /**< (EVSYS_BUSYCH) Busy Channel 1 Mask */
+#define EVSYS_BUSYCH_BUSYCH1                EVSYS_BUSYCH_BUSYCH1_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_BUSYCH_BUSYCH1_Msk instead */
+#define EVSYS_BUSYCH_BUSYCH2_Pos            2                                              /**< (EVSYS_BUSYCH) Busy Channel 2 Position */
+#define EVSYS_BUSYCH_BUSYCH2_Msk            (_U_(0x1) << EVSYS_BUSYCH_BUSYCH2_Pos)         /**< (EVSYS_BUSYCH) Busy Channel 2 Mask */
+#define EVSYS_BUSYCH_BUSYCH2                EVSYS_BUSYCH_BUSYCH2_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_BUSYCH_BUSYCH2_Msk instead */
+#define EVSYS_BUSYCH_BUSYCH3_Pos            3                                              /**< (EVSYS_BUSYCH) Busy Channel 3 Position */
+#define EVSYS_BUSYCH_BUSYCH3_Msk            (_U_(0x1) << EVSYS_BUSYCH_BUSYCH3_Pos)         /**< (EVSYS_BUSYCH) Busy Channel 3 Mask */
+#define EVSYS_BUSYCH_BUSYCH3                EVSYS_BUSYCH_BUSYCH3_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_BUSYCH_BUSYCH3_Msk instead */
+#define EVSYS_BUSYCH_MASK                   _U_(0x0F)                                      /**< \deprecated (EVSYS_BUSYCH) Register MASK  (Use EVSYS_BUSYCH_Msk instead)  */
+#define EVSYS_BUSYCH_Msk                    _U_(0x0F)                                      /**< (EVSYS_BUSYCH) Register Mask  */
+
+#define EVSYS_BUSYCH_BUSYCH_Pos             0                                              /**< (EVSYS_BUSYCH Position) Busy Channel 3 */
+#define EVSYS_BUSYCH_BUSYCH_Msk             (_U_(0xF) << EVSYS_BUSYCH_BUSYCH_Pos)          /**< (EVSYS_BUSYCH Mask) BUSYCH */
+#define EVSYS_BUSYCH_BUSYCH(value)          (EVSYS_BUSYCH_BUSYCH_Msk & ((value) << EVSYS_BUSYCH_BUSYCH_Pos))  
+
+/* -------- EVSYS_READYUSR : (EVSYS Offset: 0x1c) (R/ 32) Ready Users -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t READYUSR0:1;               /**< bit:      0  Ready User for Channel 0                 */
+    uint32_t READYUSR1:1;               /**< bit:      1  Ready User for Channel 1                 */
+    uint32_t READYUSR2:1;               /**< bit:      2  Ready User for Channel 2                 */
+    uint32_t READYUSR3:1;               /**< bit:      3  Ready User for Channel 3                 */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t READYUSR:4;                /**< bit:   0..3  Ready User for Channel 3                 */
+    uint32_t :28;                       /**< bit:  4..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} EVSYS_READYUSR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_READYUSR_OFFSET               (0x1C)                                        /**<  (EVSYS_READYUSR) Ready Users  Offset */
+#define EVSYS_READYUSR_RESETVALUE           _U_(0xFFFFFFFF)                               /**<  (EVSYS_READYUSR) Ready Users  Reset Value */
+
+#define EVSYS_READYUSR_READYUSR0_Pos        0                                              /**< (EVSYS_READYUSR) Ready User for Channel 0 Position */
+#define EVSYS_READYUSR_READYUSR0_Msk        (_U_(0x1) << EVSYS_READYUSR_READYUSR0_Pos)     /**< (EVSYS_READYUSR) Ready User for Channel 0 Mask */
+#define EVSYS_READYUSR_READYUSR0            EVSYS_READYUSR_READYUSR0_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_READYUSR_READYUSR0_Msk instead */
+#define EVSYS_READYUSR_READYUSR1_Pos        1                                              /**< (EVSYS_READYUSR) Ready User for Channel 1 Position */
+#define EVSYS_READYUSR_READYUSR1_Msk        (_U_(0x1) << EVSYS_READYUSR_READYUSR1_Pos)     /**< (EVSYS_READYUSR) Ready User for Channel 1 Mask */
+#define EVSYS_READYUSR_READYUSR1            EVSYS_READYUSR_READYUSR1_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_READYUSR_READYUSR1_Msk instead */
+#define EVSYS_READYUSR_READYUSR2_Pos        2                                              /**< (EVSYS_READYUSR) Ready User for Channel 2 Position */
+#define EVSYS_READYUSR_READYUSR2_Msk        (_U_(0x1) << EVSYS_READYUSR_READYUSR2_Pos)     /**< (EVSYS_READYUSR) Ready User for Channel 2 Mask */
+#define EVSYS_READYUSR_READYUSR2            EVSYS_READYUSR_READYUSR2_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_READYUSR_READYUSR2_Msk instead */
+#define EVSYS_READYUSR_READYUSR3_Pos        3                                              /**< (EVSYS_READYUSR) Ready User for Channel 3 Position */
+#define EVSYS_READYUSR_READYUSR3_Msk        (_U_(0x1) << EVSYS_READYUSR_READYUSR3_Pos)     /**< (EVSYS_READYUSR) Ready User for Channel 3 Mask */
+#define EVSYS_READYUSR_READYUSR3            EVSYS_READYUSR_READYUSR3_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_READYUSR_READYUSR3_Msk instead */
+#define EVSYS_READYUSR_MASK                 _U_(0x0F)                                      /**< \deprecated (EVSYS_READYUSR) Register MASK  (Use EVSYS_READYUSR_Msk instead)  */
+#define EVSYS_READYUSR_Msk                  _U_(0x0F)                                      /**< (EVSYS_READYUSR) Register Mask  */
+
+#define EVSYS_READYUSR_READYUSR_Pos         0                                              /**< (EVSYS_READYUSR Position) Ready User for Channel 3 */
+#define EVSYS_READYUSR_READYUSR_Msk         (_U_(0xF) << EVSYS_READYUSR_READYUSR_Pos)      /**< (EVSYS_READYUSR Mask) READYUSR */
+#define EVSYS_READYUSR_READYUSR(value)      (EVSYS_READYUSR_READYUSR_Msk & ((value) << EVSYS_READYUSR_READYUSR_Pos))  
+
+/* -------- EVSYS_USER : (EVSYS Offset: 0x120) (R/W 8) User Multiplexer n -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  CHANNEL:4;                 /**< bit:   0..3  Channel Event Selection                  */
+    uint8_t  :4;                        /**< bit:   4..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} EVSYS_USER_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_USER_OFFSET                   (0x120)                                       /**<  (EVSYS_USER) User Multiplexer n  Offset */
+#define EVSYS_USER_RESETVALUE               _U_(0x00)                                     /**<  (EVSYS_USER) User Multiplexer n  Reset Value */
+
+#define EVSYS_USER_CHANNEL_Pos              0                                              /**< (EVSYS_USER) Channel Event Selection Position */
+#define EVSYS_USER_CHANNEL_Msk              (_U_(0xF) << EVSYS_USER_CHANNEL_Pos)           /**< (EVSYS_USER) Channel Event Selection Mask */
+#define EVSYS_USER_CHANNEL(value)           (EVSYS_USER_CHANNEL_Msk & ((value) << EVSYS_USER_CHANNEL_Pos))
+#define EVSYS_USER_MASK                     _U_(0x0F)                                      /**< \deprecated (EVSYS_USER) Register MASK  (Use EVSYS_USER_Msk instead)  */
+#define EVSYS_USER_Msk                      _U_(0x0F)                                      /**< (EVSYS_USER) Register Mask  */
+
+
+/* -------- EVSYS_INTENCLR : (EVSYS Offset: 0x1d4) (R/W 8) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  NSCHK:1;                   /**< bit:      0  Non-Secure Check Interrupt Enable        */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} EVSYS_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_INTENCLR_OFFSET               (0x1D4)                                       /**<  (EVSYS_INTENCLR) Interrupt Enable Clear  Offset */
+#define EVSYS_INTENCLR_RESETVALUE           _U_(0x00)                                     /**<  (EVSYS_INTENCLR) Interrupt Enable Clear  Reset Value */
+
+#define EVSYS_INTENCLR_NSCHK_Pos            0                                              /**< (EVSYS_INTENCLR) Non-Secure Check Interrupt Enable Position */
+#define EVSYS_INTENCLR_NSCHK_Msk            (_U_(0x1) << EVSYS_INTENCLR_NSCHK_Pos)         /**< (EVSYS_INTENCLR) Non-Secure Check Interrupt Enable Mask */
+#define EVSYS_INTENCLR_NSCHK                EVSYS_INTENCLR_NSCHK_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_INTENCLR_NSCHK_Msk instead */
+#define EVSYS_INTENCLR_MASK                 _U_(0x01)                                      /**< \deprecated (EVSYS_INTENCLR) Register MASK  (Use EVSYS_INTENCLR_Msk instead)  */
+#define EVSYS_INTENCLR_Msk                  _U_(0x01)                                      /**< (EVSYS_INTENCLR) Register Mask  */
+
+
+/* -------- EVSYS_INTENSET : (EVSYS Offset: 0x1d5) (R/W 8) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  NSCHK:1;                   /**< bit:      0  Non-Secure Check Interrupt Enable        */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} EVSYS_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_INTENSET_OFFSET               (0x1D5)                                       /**<  (EVSYS_INTENSET) Interrupt Enable Set  Offset */
+#define EVSYS_INTENSET_RESETVALUE           _U_(0x00)                                     /**<  (EVSYS_INTENSET) Interrupt Enable Set  Reset Value */
+
+#define EVSYS_INTENSET_NSCHK_Pos            0                                              /**< (EVSYS_INTENSET) Non-Secure Check Interrupt Enable Position */
+#define EVSYS_INTENSET_NSCHK_Msk            (_U_(0x1) << EVSYS_INTENSET_NSCHK_Pos)         /**< (EVSYS_INTENSET) Non-Secure Check Interrupt Enable Mask */
+#define EVSYS_INTENSET_NSCHK                EVSYS_INTENSET_NSCHK_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_INTENSET_NSCHK_Msk instead */
+#define EVSYS_INTENSET_MASK                 _U_(0x01)                                      /**< \deprecated (EVSYS_INTENSET) Register MASK  (Use EVSYS_INTENSET_Msk instead)  */
+#define EVSYS_INTENSET_Msk                  _U_(0x01)                                      /**< (EVSYS_INTENSET) Register Mask  */
+
+
+/* -------- EVSYS_INTFLAG : (EVSYS Offset: 0x1d6) (R/W 8) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t NSCHK:1;                   /**< bit:      0  Non-Secure Check                         */
+    __I uint8_t :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} EVSYS_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_INTFLAG_OFFSET                (0x1D6)                                       /**<  (EVSYS_INTFLAG) Interrupt Flag Status and Clear  Offset */
+#define EVSYS_INTFLAG_RESETVALUE            _U_(0x00)                                     /**<  (EVSYS_INTFLAG) Interrupt Flag Status and Clear  Reset Value */
+
+#define EVSYS_INTFLAG_NSCHK_Pos             0                                              /**< (EVSYS_INTFLAG) Non-Secure Check Position */
+#define EVSYS_INTFLAG_NSCHK_Msk             (_U_(0x1) << EVSYS_INTFLAG_NSCHK_Pos)          /**< (EVSYS_INTFLAG) Non-Secure Check Mask */
+#define EVSYS_INTFLAG_NSCHK                 EVSYS_INTFLAG_NSCHK_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_INTFLAG_NSCHK_Msk instead */
+#define EVSYS_INTFLAG_MASK                  _U_(0x01)                                      /**< \deprecated (EVSYS_INTFLAG) Register MASK  (Use EVSYS_INTFLAG_Msk instead)  */
+#define EVSYS_INTFLAG_Msk                   _U_(0x01)                                      /**< (EVSYS_INTFLAG) Register Mask  */
+
+
+/* -------- EVSYS_NONSECCHAN : (EVSYS Offset: 0x1d8) (R/W 32) Channels Security Attribution -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t CHANNEL0:1;                /**< bit:      0  Non-Secure for Channel 0                 */
+    uint32_t CHANNEL1:1;                /**< bit:      1  Non-Secure for Channel 1                 */
+    uint32_t CHANNEL2:1;                /**< bit:      2  Non-Secure for Channel 2                 */
+    uint32_t CHANNEL3:1;                /**< bit:      3  Non-Secure for Channel 3                 */
+    uint32_t CHANNEL4:1;                /**< bit:      4  Non-Secure for Channel 4                 */
+    uint32_t CHANNEL5:1;                /**< bit:      5  Non-Secure for Channel 5                 */
+    uint32_t CHANNEL6:1;                /**< bit:      6  Non-Secure for Channel 6                 */
+    uint32_t CHANNEL7:1;                /**< bit:      7  Non-Secure for Channel 7                 */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t CHANNEL:8;                 /**< bit:   0..7  Non-Secure for Channel 7                 */
+    uint32_t :24;                       /**< bit:  8..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} EVSYS_NONSECCHAN_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_NONSECCHAN_OFFSET             (0x1D8)                                       /**<  (EVSYS_NONSECCHAN) Channels Security Attribution  Offset */
+#define EVSYS_NONSECCHAN_RESETVALUE         _U_(0x00)                                     /**<  (EVSYS_NONSECCHAN) Channels Security Attribution  Reset Value */
+
+#define EVSYS_NONSECCHAN_CHANNEL0_Pos       0                                              /**< (EVSYS_NONSECCHAN) Non-Secure for Channel 0 Position */
+#define EVSYS_NONSECCHAN_CHANNEL0_Msk       (_U_(0x1) << EVSYS_NONSECCHAN_CHANNEL0_Pos)    /**< (EVSYS_NONSECCHAN) Non-Secure for Channel 0 Mask */
+#define EVSYS_NONSECCHAN_CHANNEL0           EVSYS_NONSECCHAN_CHANNEL0_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECCHAN_CHANNEL0_Msk instead */
+#define EVSYS_NONSECCHAN_CHANNEL1_Pos       1                                              /**< (EVSYS_NONSECCHAN) Non-Secure for Channel 1 Position */
+#define EVSYS_NONSECCHAN_CHANNEL1_Msk       (_U_(0x1) << EVSYS_NONSECCHAN_CHANNEL1_Pos)    /**< (EVSYS_NONSECCHAN) Non-Secure for Channel 1 Mask */
+#define EVSYS_NONSECCHAN_CHANNEL1           EVSYS_NONSECCHAN_CHANNEL1_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECCHAN_CHANNEL1_Msk instead */
+#define EVSYS_NONSECCHAN_CHANNEL2_Pos       2                                              /**< (EVSYS_NONSECCHAN) Non-Secure for Channel 2 Position */
+#define EVSYS_NONSECCHAN_CHANNEL2_Msk       (_U_(0x1) << EVSYS_NONSECCHAN_CHANNEL2_Pos)    /**< (EVSYS_NONSECCHAN) Non-Secure for Channel 2 Mask */
+#define EVSYS_NONSECCHAN_CHANNEL2           EVSYS_NONSECCHAN_CHANNEL2_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECCHAN_CHANNEL2_Msk instead */
+#define EVSYS_NONSECCHAN_CHANNEL3_Pos       3                                              /**< (EVSYS_NONSECCHAN) Non-Secure for Channel 3 Position */
+#define EVSYS_NONSECCHAN_CHANNEL3_Msk       (_U_(0x1) << EVSYS_NONSECCHAN_CHANNEL3_Pos)    /**< (EVSYS_NONSECCHAN) Non-Secure for Channel 3 Mask */
+#define EVSYS_NONSECCHAN_CHANNEL3           EVSYS_NONSECCHAN_CHANNEL3_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECCHAN_CHANNEL3_Msk instead */
+#define EVSYS_NONSECCHAN_CHANNEL4_Pos       4                                              /**< (EVSYS_NONSECCHAN) Non-Secure for Channel 4 Position */
+#define EVSYS_NONSECCHAN_CHANNEL4_Msk       (_U_(0x1) << EVSYS_NONSECCHAN_CHANNEL4_Pos)    /**< (EVSYS_NONSECCHAN) Non-Secure for Channel 4 Mask */
+#define EVSYS_NONSECCHAN_CHANNEL4           EVSYS_NONSECCHAN_CHANNEL4_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECCHAN_CHANNEL4_Msk instead */
+#define EVSYS_NONSECCHAN_CHANNEL5_Pos       5                                              /**< (EVSYS_NONSECCHAN) Non-Secure for Channel 5 Position */
+#define EVSYS_NONSECCHAN_CHANNEL5_Msk       (_U_(0x1) << EVSYS_NONSECCHAN_CHANNEL5_Pos)    /**< (EVSYS_NONSECCHAN) Non-Secure for Channel 5 Mask */
+#define EVSYS_NONSECCHAN_CHANNEL5           EVSYS_NONSECCHAN_CHANNEL5_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECCHAN_CHANNEL5_Msk instead */
+#define EVSYS_NONSECCHAN_CHANNEL6_Pos       6                                              /**< (EVSYS_NONSECCHAN) Non-Secure for Channel 6 Position */
+#define EVSYS_NONSECCHAN_CHANNEL6_Msk       (_U_(0x1) << EVSYS_NONSECCHAN_CHANNEL6_Pos)    /**< (EVSYS_NONSECCHAN) Non-Secure for Channel 6 Mask */
+#define EVSYS_NONSECCHAN_CHANNEL6           EVSYS_NONSECCHAN_CHANNEL6_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECCHAN_CHANNEL6_Msk instead */
+#define EVSYS_NONSECCHAN_CHANNEL7_Pos       7                                              /**< (EVSYS_NONSECCHAN) Non-Secure for Channel 7 Position */
+#define EVSYS_NONSECCHAN_CHANNEL7_Msk       (_U_(0x1) << EVSYS_NONSECCHAN_CHANNEL7_Pos)    /**< (EVSYS_NONSECCHAN) Non-Secure for Channel 7 Mask */
+#define EVSYS_NONSECCHAN_CHANNEL7           EVSYS_NONSECCHAN_CHANNEL7_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECCHAN_CHANNEL7_Msk instead */
+#define EVSYS_NONSECCHAN_MASK               _U_(0xFF)                                      /**< \deprecated (EVSYS_NONSECCHAN) Register MASK  (Use EVSYS_NONSECCHAN_Msk instead)  */
+#define EVSYS_NONSECCHAN_Msk                _U_(0xFF)                                      /**< (EVSYS_NONSECCHAN) Register Mask  */
+
+#define EVSYS_NONSECCHAN_CHANNEL_Pos        0                                              /**< (EVSYS_NONSECCHAN Position) Non-Secure for Channel 7 */
+#define EVSYS_NONSECCHAN_CHANNEL_Msk        (_U_(0xFF) << EVSYS_NONSECCHAN_CHANNEL_Pos)    /**< (EVSYS_NONSECCHAN Mask) CHANNEL */
+#define EVSYS_NONSECCHAN_CHANNEL(value)     (EVSYS_NONSECCHAN_CHANNEL_Msk & ((value) << EVSYS_NONSECCHAN_CHANNEL_Pos))  
+
+/* -------- EVSYS_NSCHKCHAN : (EVSYS Offset: 0x1dc) (R/W 32) Non-Secure Channels Check -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t CHANNEL0:1;                /**< bit:      0  Channel 0 to be checked as non-secured   */
+    uint32_t CHANNEL1:1;                /**< bit:      1  Channel 1 to be checked as non-secured   */
+    uint32_t CHANNEL2:1;                /**< bit:      2  Channel 2 to be checked as non-secured   */
+    uint32_t CHANNEL3:1;                /**< bit:      3  Channel 3 to be checked as non-secured   */
+    uint32_t CHANNEL4:1;                /**< bit:      4  Channel 4 to be checked as non-secured   */
+    uint32_t CHANNEL5:1;                /**< bit:      5  Channel 5 to be checked as non-secured   */
+    uint32_t CHANNEL6:1;                /**< bit:      6  Channel 6 to be checked as non-secured   */
+    uint32_t CHANNEL7:1;                /**< bit:      7  Channel 7 to be checked as non-secured   */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t CHANNEL:8;                 /**< bit:   0..7  Channel 7 to be checked as non-secured   */
+    uint32_t :24;                       /**< bit:  8..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} EVSYS_NSCHKCHAN_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_NSCHKCHAN_OFFSET              (0x1DC)                                       /**<  (EVSYS_NSCHKCHAN) Non-Secure Channels Check  Offset */
+#define EVSYS_NSCHKCHAN_RESETVALUE          _U_(0x00)                                     /**<  (EVSYS_NSCHKCHAN) Non-Secure Channels Check  Reset Value */
+
+#define EVSYS_NSCHKCHAN_CHANNEL0_Pos        0                                              /**< (EVSYS_NSCHKCHAN) Channel 0 to be checked as non-secured Position */
+#define EVSYS_NSCHKCHAN_CHANNEL0_Msk        (_U_(0x1) << EVSYS_NSCHKCHAN_CHANNEL0_Pos)     /**< (EVSYS_NSCHKCHAN) Channel 0 to be checked as non-secured Mask */
+#define EVSYS_NSCHKCHAN_CHANNEL0            EVSYS_NSCHKCHAN_CHANNEL0_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKCHAN_CHANNEL0_Msk instead */
+#define EVSYS_NSCHKCHAN_CHANNEL1_Pos        1                                              /**< (EVSYS_NSCHKCHAN) Channel 1 to be checked as non-secured Position */
+#define EVSYS_NSCHKCHAN_CHANNEL1_Msk        (_U_(0x1) << EVSYS_NSCHKCHAN_CHANNEL1_Pos)     /**< (EVSYS_NSCHKCHAN) Channel 1 to be checked as non-secured Mask */
+#define EVSYS_NSCHKCHAN_CHANNEL1            EVSYS_NSCHKCHAN_CHANNEL1_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKCHAN_CHANNEL1_Msk instead */
+#define EVSYS_NSCHKCHAN_CHANNEL2_Pos        2                                              /**< (EVSYS_NSCHKCHAN) Channel 2 to be checked as non-secured Position */
+#define EVSYS_NSCHKCHAN_CHANNEL2_Msk        (_U_(0x1) << EVSYS_NSCHKCHAN_CHANNEL2_Pos)     /**< (EVSYS_NSCHKCHAN) Channel 2 to be checked as non-secured Mask */
+#define EVSYS_NSCHKCHAN_CHANNEL2            EVSYS_NSCHKCHAN_CHANNEL2_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKCHAN_CHANNEL2_Msk instead */
+#define EVSYS_NSCHKCHAN_CHANNEL3_Pos        3                                              /**< (EVSYS_NSCHKCHAN) Channel 3 to be checked as non-secured Position */
+#define EVSYS_NSCHKCHAN_CHANNEL3_Msk        (_U_(0x1) << EVSYS_NSCHKCHAN_CHANNEL3_Pos)     /**< (EVSYS_NSCHKCHAN) Channel 3 to be checked as non-secured Mask */
+#define EVSYS_NSCHKCHAN_CHANNEL3            EVSYS_NSCHKCHAN_CHANNEL3_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKCHAN_CHANNEL3_Msk instead */
+#define EVSYS_NSCHKCHAN_CHANNEL4_Pos        4                                              /**< (EVSYS_NSCHKCHAN) Channel 4 to be checked as non-secured Position */
+#define EVSYS_NSCHKCHAN_CHANNEL4_Msk        (_U_(0x1) << EVSYS_NSCHKCHAN_CHANNEL4_Pos)     /**< (EVSYS_NSCHKCHAN) Channel 4 to be checked as non-secured Mask */
+#define EVSYS_NSCHKCHAN_CHANNEL4            EVSYS_NSCHKCHAN_CHANNEL4_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKCHAN_CHANNEL4_Msk instead */
+#define EVSYS_NSCHKCHAN_CHANNEL5_Pos        5                                              /**< (EVSYS_NSCHKCHAN) Channel 5 to be checked as non-secured Position */
+#define EVSYS_NSCHKCHAN_CHANNEL5_Msk        (_U_(0x1) << EVSYS_NSCHKCHAN_CHANNEL5_Pos)     /**< (EVSYS_NSCHKCHAN) Channel 5 to be checked as non-secured Mask */
+#define EVSYS_NSCHKCHAN_CHANNEL5            EVSYS_NSCHKCHAN_CHANNEL5_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKCHAN_CHANNEL5_Msk instead */
+#define EVSYS_NSCHKCHAN_CHANNEL6_Pos        6                                              /**< (EVSYS_NSCHKCHAN) Channel 6 to be checked as non-secured Position */
+#define EVSYS_NSCHKCHAN_CHANNEL6_Msk        (_U_(0x1) << EVSYS_NSCHKCHAN_CHANNEL6_Pos)     /**< (EVSYS_NSCHKCHAN) Channel 6 to be checked as non-secured Mask */
+#define EVSYS_NSCHKCHAN_CHANNEL6            EVSYS_NSCHKCHAN_CHANNEL6_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKCHAN_CHANNEL6_Msk instead */
+#define EVSYS_NSCHKCHAN_CHANNEL7_Pos        7                                              /**< (EVSYS_NSCHKCHAN) Channel 7 to be checked as non-secured Position */
+#define EVSYS_NSCHKCHAN_CHANNEL7_Msk        (_U_(0x1) << EVSYS_NSCHKCHAN_CHANNEL7_Pos)     /**< (EVSYS_NSCHKCHAN) Channel 7 to be checked as non-secured Mask */
+#define EVSYS_NSCHKCHAN_CHANNEL7            EVSYS_NSCHKCHAN_CHANNEL7_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKCHAN_CHANNEL7_Msk instead */
+#define EVSYS_NSCHKCHAN_MASK                _U_(0xFF)                                      /**< \deprecated (EVSYS_NSCHKCHAN) Register MASK  (Use EVSYS_NSCHKCHAN_Msk instead)  */
+#define EVSYS_NSCHKCHAN_Msk                 _U_(0xFF)                                      /**< (EVSYS_NSCHKCHAN) Register Mask  */
+
+#define EVSYS_NSCHKCHAN_CHANNEL_Pos         0                                              /**< (EVSYS_NSCHKCHAN Position) Channel 7 to be checked as non-secured */
+#define EVSYS_NSCHKCHAN_CHANNEL_Msk         (_U_(0xFF) << EVSYS_NSCHKCHAN_CHANNEL_Pos)     /**< (EVSYS_NSCHKCHAN Mask) CHANNEL */
+#define EVSYS_NSCHKCHAN_CHANNEL(value)      (EVSYS_NSCHKCHAN_CHANNEL_Msk & ((value) << EVSYS_NSCHKCHAN_CHANNEL_Pos))  
+
+/* -------- EVSYS_NONSECUSER : (EVSYS Offset: 0x1e0) (R/W 32) Users Security Attribution -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t USER0:1;                   /**< bit:      0  Non-Secure for User 0                    */
+    uint32_t USER1:1;                   /**< bit:      1  Non-Secure for User 1                    */
+    uint32_t USER2:1;                   /**< bit:      2  Non-Secure for User 2                    */
+    uint32_t USER3:1;                   /**< bit:      3  Non-Secure for User 3                    */
+    uint32_t USER4:1;                   /**< bit:      4  Non-Secure for User 4                    */
+    uint32_t USER5:1;                   /**< bit:      5  Non-Secure for User 5                    */
+    uint32_t USER6:1;                   /**< bit:      6  Non-Secure for User 6                    */
+    uint32_t USER7:1;                   /**< bit:      7  Non-Secure for User 7                    */
+    uint32_t USER8:1;                   /**< bit:      8  Non-Secure for User 8                    */
+    uint32_t USER9:1;                   /**< bit:      9  Non-Secure for User 9                    */
+    uint32_t USER10:1;                  /**< bit:     10  Non-Secure for User 10                   */
+    uint32_t USER11:1;                  /**< bit:     11  Non-Secure for User 11                   */
+    uint32_t USER12:1;                  /**< bit:     12  Non-Secure for User 12                   */
+    uint32_t USER13:1;                  /**< bit:     13  Non-Secure for User 13                   */
+    uint32_t USER14:1;                  /**< bit:     14  Non-Secure for User 14                   */
+    uint32_t USER15:1;                  /**< bit:     15  Non-Secure for User 15                   */
+    uint32_t USER16:1;                  /**< bit:     16  Non-Secure for User 16                   */
+    uint32_t USER17:1;                  /**< bit:     17  Non-Secure for User 17                   */
+    uint32_t USER18:1;                  /**< bit:     18  Non-Secure for User 18                   */
+    uint32_t USER19:1;                  /**< bit:     19  Non-Secure for User 19                   */
+    uint32_t USER20:1;                  /**< bit:     20  Non-Secure for User 20                   */
+    uint32_t USER21:1;                  /**< bit:     21  Non-Secure for User 21                   */
+    uint32_t USER22:1;                  /**< bit:     22  Non-Secure for User 22                   */
+    uint32_t :9;                        /**< bit: 23..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t USER:23;                   /**< bit:  0..22  Non-Secure for User 22                   */
+    uint32_t :9;                        /**< bit: 23..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} EVSYS_NONSECUSER_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_NONSECUSER_OFFSET             (0x1E0)                                       /**<  (EVSYS_NONSECUSER) Users Security Attribution  Offset */
+#define EVSYS_NONSECUSER_RESETVALUE         _U_(0x00)                                     /**<  (EVSYS_NONSECUSER) Users Security Attribution  Reset Value */
+
+#define EVSYS_NONSECUSER_USER0_Pos          0                                              /**< (EVSYS_NONSECUSER) Non-Secure for User 0 Position */
+#define EVSYS_NONSECUSER_USER0_Msk          (_U_(0x1) << EVSYS_NONSECUSER_USER0_Pos)       /**< (EVSYS_NONSECUSER) Non-Secure for User 0 Mask */
+#define EVSYS_NONSECUSER_USER0              EVSYS_NONSECUSER_USER0_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECUSER_USER0_Msk instead */
+#define EVSYS_NONSECUSER_USER1_Pos          1                                              /**< (EVSYS_NONSECUSER) Non-Secure for User 1 Position */
+#define EVSYS_NONSECUSER_USER1_Msk          (_U_(0x1) << EVSYS_NONSECUSER_USER1_Pos)       /**< (EVSYS_NONSECUSER) Non-Secure for User 1 Mask */
+#define EVSYS_NONSECUSER_USER1              EVSYS_NONSECUSER_USER1_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECUSER_USER1_Msk instead */
+#define EVSYS_NONSECUSER_USER2_Pos          2                                              /**< (EVSYS_NONSECUSER) Non-Secure for User 2 Position */
+#define EVSYS_NONSECUSER_USER2_Msk          (_U_(0x1) << EVSYS_NONSECUSER_USER2_Pos)       /**< (EVSYS_NONSECUSER) Non-Secure for User 2 Mask */
+#define EVSYS_NONSECUSER_USER2              EVSYS_NONSECUSER_USER2_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECUSER_USER2_Msk instead */
+#define EVSYS_NONSECUSER_USER3_Pos          3                                              /**< (EVSYS_NONSECUSER) Non-Secure for User 3 Position */
+#define EVSYS_NONSECUSER_USER3_Msk          (_U_(0x1) << EVSYS_NONSECUSER_USER3_Pos)       /**< (EVSYS_NONSECUSER) Non-Secure for User 3 Mask */
+#define EVSYS_NONSECUSER_USER3              EVSYS_NONSECUSER_USER3_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECUSER_USER3_Msk instead */
+#define EVSYS_NONSECUSER_USER4_Pos          4                                              /**< (EVSYS_NONSECUSER) Non-Secure for User 4 Position */
+#define EVSYS_NONSECUSER_USER4_Msk          (_U_(0x1) << EVSYS_NONSECUSER_USER4_Pos)       /**< (EVSYS_NONSECUSER) Non-Secure for User 4 Mask */
+#define EVSYS_NONSECUSER_USER4              EVSYS_NONSECUSER_USER4_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECUSER_USER4_Msk instead */
+#define EVSYS_NONSECUSER_USER5_Pos          5                                              /**< (EVSYS_NONSECUSER) Non-Secure for User 5 Position */
+#define EVSYS_NONSECUSER_USER5_Msk          (_U_(0x1) << EVSYS_NONSECUSER_USER5_Pos)       /**< (EVSYS_NONSECUSER) Non-Secure for User 5 Mask */
+#define EVSYS_NONSECUSER_USER5              EVSYS_NONSECUSER_USER5_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECUSER_USER5_Msk instead */
+#define EVSYS_NONSECUSER_USER6_Pos          6                                              /**< (EVSYS_NONSECUSER) Non-Secure for User 6 Position */
+#define EVSYS_NONSECUSER_USER6_Msk          (_U_(0x1) << EVSYS_NONSECUSER_USER6_Pos)       /**< (EVSYS_NONSECUSER) Non-Secure for User 6 Mask */
+#define EVSYS_NONSECUSER_USER6              EVSYS_NONSECUSER_USER6_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECUSER_USER6_Msk instead */
+#define EVSYS_NONSECUSER_USER7_Pos          7                                              /**< (EVSYS_NONSECUSER) Non-Secure for User 7 Position */
+#define EVSYS_NONSECUSER_USER7_Msk          (_U_(0x1) << EVSYS_NONSECUSER_USER7_Pos)       /**< (EVSYS_NONSECUSER) Non-Secure for User 7 Mask */
+#define EVSYS_NONSECUSER_USER7              EVSYS_NONSECUSER_USER7_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECUSER_USER7_Msk instead */
+#define EVSYS_NONSECUSER_USER8_Pos          8                                              /**< (EVSYS_NONSECUSER) Non-Secure for User 8 Position */
+#define EVSYS_NONSECUSER_USER8_Msk          (_U_(0x1) << EVSYS_NONSECUSER_USER8_Pos)       /**< (EVSYS_NONSECUSER) Non-Secure for User 8 Mask */
+#define EVSYS_NONSECUSER_USER8              EVSYS_NONSECUSER_USER8_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECUSER_USER8_Msk instead */
+#define EVSYS_NONSECUSER_USER9_Pos          9                                              /**< (EVSYS_NONSECUSER) Non-Secure for User 9 Position */
+#define EVSYS_NONSECUSER_USER9_Msk          (_U_(0x1) << EVSYS_NONSECUSER_USER9_Pos)       /**< (EVSYS_NONSECUSER) Non-Secure for User 9 Mask */
+#define EVSYS_NONSECUSER_USER9              EVSYS_NONSECUSER_USER9_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECUSER_USER9_Msk instead */
+#define EVSYS_NONSECUSER_USER10_Pos         10                                             /**< (EVSYS_NONSECUSER) Non-Secure for User 10 Position */
+#define EVSYS_NONSECUSER_USER10_Msk         (_U_(0x1) << EVSYS_NONSECUSER_USER10_Pos)      /**< (EVSYS_NONSECUSER) Non-Secure for User 10 Mask */
+#define EVSYS_NONSECUSER_USER10             EVSYS_NONSECUSER_USER10_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECUSER_USER10_Msk instead */
+#define EVSYS_NONSECUSER_USER11_Pos         11                                             /**< (EVSYS_NONSECUSER) Non-Secure for User 11 Position */
+#define EVSYS_NONSECUSER_USER11_Msk         (_U_(0x1) << EVSYS_NONSECUSER_USER11_Pos)      /**< (EVSYS_NONSECUSER) Non-Secure for User 11 Mask */
+#define EVSYS_NONSECUSER_USER11             EVSYS_NONSECUSER_USER11_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECUSER_USER11_Msk instead */
+#define EVSYS_NONSECUSER_USER12_Pos         12                                             /**< (EVSYS_NONSECUSER) Non-Secure for User 12 Position */
+#define EVSYS_NONSECUSER_USER12_Msk         (_U_(0x1) << EVSYS_NONSECUSER_USER12_Pos)      /**< (EVSYS_NONSECUSER) Non-Secure for User 12 Mask */
+#define EVSYS_NONSECUSER_USER12             EVSYS_NONSECUSER_USER12_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECUSER_USER12_Msk instead */
+#define EVSYS_NONSECUSER_USER13_Pos         13                                             /**< (EVSYS_NONSECUSER) Non-Secure for User 13 Position */
+#define EVSYS_NONSECUSER_USER13_Msk         (_U_(0x1) << EVSYS_NONSECUSER_USER13_Pos)      /**< (EVSYS_NONSECUSER) Non-Secure for User 13 Mask */
+#define EVSYS_NONSECUSER_USER13             EVSYS_NONSECUSER_USER13_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECUSER_USER13_Msk instead */
+#define EVSYS_NONSECUSER_USER14_Pos         14                                             /**< (EVSYS_NONSECUSER) Non-Secure for User 14 Position */
+#define EVSYS_NONSECUSER_USER14_Msk         (_U_(0x1) << EVSYS_NONSECUSER_USER14_Pos)      /**< (EVSYS_NONSECUSER) Non-Secure for User 14 Mask */
+#define EVSYS_NONSECUSER_USER14             EVSYS_NONSECUSER_USER14_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECUSER_USER14_Msk instead */
+#define EVSYS_NONSECUSER_USER15_Pos         15                                             /**< (EVSYS_NONSECUSER) Non-Secure for User 15 Position */
+#define EVSYS_NONSECUSER_USER15_Msk         (_U_(0x1) << EVSYS_NONSECUSER_USER15_Pos)      /**< (EVSYS_NONSECUSER) Non-Secure for User 15 Mask */
+#define EVSYS_NONSECUSER_USER15             EVSYS_NONSECUSER_USER15_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECUSER_USER15_Msk instead */
+#define EVSYS_NONSECUSER_USER16_Pos         16                                             /**< (EVSYS_NONSECUSER) Non-Secure for User 16 Position */
+#define EVSYS_NONSECUSER_USER16_Msk         (_U_(0x1) << EVSYS_NONSECUSER_USER16_Pos)      /**< (EVSYS_NONSECUSER) Non-Secure for User 16 Mask */
+#define EVSYS_NONSECUSER_USER16             EVSYS_NONSECUSER_USER16_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECUSER_USER16_Msk instead */
+#define EVSYS_NONSECUSER_USER17_Pos         17                                             /**< (EVSYS_NONSECUSER) Non-Secure for User 17 Position */
+#define EVSYS_NONSECUSER_USER17_Msk         (_U_(0x1) << EVSYS_NONSECUSER_USER17_Pos)      /**< (EVSYS_NONSECUSER) Non-Secure for User 17 Mask */
+#define EVSYS_NONSECUSER_USER17             EVSYS_NONSECUSER_USER17_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECUSER_USER17_Msk instead */
+#define EVSYS_NONSECUSER_USER18_Pos         18                                             /**< (EVSYS_NONSECUSER) Non-Secure for User 18 Position */
+#define EVSYS_NONSECUSER_USER18_Msk         (_U_(0x1) << EVSYS_NONSECUSER_USER18_Pos)      /**< (EVSYS_NONSECUSER) Non-Secure for User 18 Mask */
+#define EVSYS_NONSECUSER_USER18             EVSYS_NONSECUSER_USER18_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECUSER_USER18_Msk instead */
+#define EVSYS_NONSECUSER_USER19_Pos         19                                             /**< (EVSYS_NONSECUSER) Non-Secure for User 19 Position */
+#define EVSYS_NONSECUSER_USER19_Msk         (_U_(0x1) << EVSYS_NONSECUSER_USER19_Pos)      /**< (EVSYS_NONSECUSER) Non-Secure for User 19 Mask */
+#define EVSYS_NONSECUSER_USER19             EVSYS_NONSECUSER_USER19_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECUSER_USER19_Msk instead */
+#define EVSYS_NONSECUSER_USER20_Pos         20                                             /**< (EVSYS_NONSECUSER) Non-Secure for User 20 Position */
+#define EVSYS_NONSECUSER_USER20_Msk         (_U_(0x1) << EVSYS_NONSECUSER_USER20_Pos)      /**< (EVSYS_NONSECUSER) Non-Secure for User 20 Mask */
+#define EVSYS_NONSECUSER_USER20             EVSYS_NONSECUSER_USER20_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECUSER_USER20_Msk instead */
+#define EVSYS_NONSECUSER_USER21_Pos         21                                             /**< (EVSYS_NONSECUSER) Non-Secure for User 21 Position */
+#define EVSYS_NONSECUSER_USER21_Msk         (_U_(0x1) << EVSYS_NONSECUSER_USER21_Pos)      /**< (EVSYS_NONSECUSER) Non-Secure for User 21 Mask */
+#define EVSYS_NONSECUSER_USER21             EVSYS_NONSECUSER_USER21_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECUSER_USER21_Msk instead */
+#define EVSYS_NONSECUSER_USER22_Pos         22                                             /**< (EVSYS_NONSECUSER) Non-Secure for User 22 Position */
+#define EVSYS_NONSECUSER_USER22_Msk         (_U_(0x1) << EVSYS_NONSECUSER_USER22_Pos)      /**< (EVSYS_NONSECUSER) Non-Secure for User 22 Mask */
+#define EVSYS_NONSECUSER_USER22             EVSYS_NONSECUSER_USER22_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECUSER_USER22_Msk instead */
+#define EVSYS_NONSECUSER_MASK               _U_(0x7FFFFF)                                  /**< \deprecated (EVSYS_NONSECUSER) Register MASK  (Use EVSYS_NONSECUSER_Msk instead)  */
+#define EVSYS_NONSECUSER_Msk                _U_(0x7FFFFF)                                  /**< (EVSYS_NONSECUSER) Register Mask  */
+
+#define EVSYS_NONSECUSER_USER_Pos           0                                              /**< (EVSYS_NONSECUSER Position) Non-Secure for User 22 */
+#define EVSYS_NONSECUSER_USER_Msk           (_U_(0x7FFFFF) << EVSYS_NONSECUSER_USER_Pos)   /**< (EVSYS_NONSECUSER Mask) USER */
+#define EVSYS_NONSECUSER_USER(value)        (EVSYS_NONSECUSER_USER_Msk & ((value) << EVSYS_NONSECUSER_USER_Pos))  
+
+/* -------- EVSYS_NSCHKUSER : (EVSYS Offset: 0x1f0) (R/W 32) Non-Secure Users Check -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t USER0:1;                   /**< bit:      0  User 0 to be checked as non-secured      */
+    uint32_t USER1:1;                   /**< bit:      1  User 1 to be checked as non-secured      */
+    uint32_t USER2:1;                   /**< bit:      2  User 2 to be checked as non-secured      */
+    uint32_t USER3:1;                   /**< bit:      3  User 3 to be checked as non-secured      */
+    uint32_t USER4:1;                   /**< bit:      4  User 4 to be checked as non-secured      */
+    uint32_t USER5:1;                   /**< bit:      5  User 5 to be checked as non-secured      */
+    uint32_t USER6:1;                   /**< bit:      6  User 6 to be checked as non-secured      */
+    uint32_t USER7:1;                   /**< bit:      7  User 7 to be checked as non-secured      */
+    uint32_t USER8:1;                   /**< bit:      8  User 8 to be checked as non-secured      */
+    uint32_t USER9:1;                   /**< bit:      9  User 9 to be checked as non-secured      */
+    uint32_t USER10:1;                  /**< bit:     10  User 10 to be checked as non-secured     */
+    uint32_t USER11:1;                  /**< bit:     11  User 11 to be checked as non-secured     */
+    uint32_t USER12:1;                  /**< bit:     12  User 12 to be checked as non-secured     */
+    uint32_t USER13:1;                  /**< bit:     13  User 13 to be checked as non-secured     */
+    uint32_t USER14:1;                  /**< bit:     14  User 14 to be checked as non-secured     */
+    uint32_t USER15:1;                  /**< bit:     15  User 15 to be checked as non-secured     */
+    uint32_t USER16:1;                  /**< bit:     16  User 16 to be checked as non-secured     */
+    uint32_t USER17:1;                  /**< bit:     17  User 17 to be checked as non-secured     */
+    uint32_t USER18:1;                  /**< bit:     18  User 18 to be checked as non-secured     */
+    uint32_t USER19:1;                  /**< bit:     19  User 19 to be checked as non-secured     */
+    uint32_t USER20:1;                  /**< bit:     20  User 20 to be checked as non-secured     */
+    uint32_t USER21:1;                  /**< bit:     21  User 21 to be checked as non-secured     */
+    uint32_t USER22:1;                  /**< bit:     22  User 22 to be checked as non-secured     */
+    uint32_t :9;                        /**< bit: 23..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t USER:23;                   /**< bit:  0..22  User 22 to be checked as non-secured     */
+    uint32_t :9;                        /**< bit: 23..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} EVSYS_NSCHKUSER_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_NSCHKUSER_OFFSET              (0x1F0)                                       /**<  (EVSYS_NSCHKUSER) Non-Secure Users Check  Offset */
+#define EVSYS_NSCHKUSER_RESETVALUE          _U_(0x00)                                     /**<  (EVSYS_NSCHKUSER) Non-Secure Users Check  Reset Value */
+
+#define EVSYS_NSCHKUSER_USER0_Pos           0                                              /**< (EVSYS_NSCHKUSER) User 0 to be checked as non-secured Position */
+#define EVSYS_NSCHKUSER_USER0_Msk           (_U_(0x1) << EVSYS_NSCHKUSER_USER0_Pos)        /**< (EVSYS_NSCHKUSER) User 0 to be checked as non-secured Mask */
+#define EVSYS_NSCHKUSER_USER0               EVSYS_NSCHKUSER_USER0_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKUSER_USER0_Msk instead */
+#define EVSYS_NSCHKUSER_USER1_Pos           1                                              /**< (EVSYS_NSCHKUSER) User 1 to be checked as non-secured Position */
+#define EVSYS_NSCHKUSER_USER1_Msk           (_U_(0x1) << EVSYS_NSCHKUSER_USER1_Pos)        /**< (EVSYS_NSCHKUSER) User 1 to be checked as non-secured Mask */
+#define EVSYS_NSCHKUSER_USER1               EVSYS_NSCHKUSER_USER1_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKUSER_USER1_Msk instead */
+#define EVSYS_NSCHKUSER_USER2_Pos           2                                              /**< (EVSYS_NSCHKUSER) User 2 to be checked as non-secured Position */
+#define EVSYS_NSCHKUSER_USER2_Msk           (_U_(0x1) << EVSYS_NSCHKUSER_USER2_Pos)        /**< (EVSYS_NSCHKUSER) User 2 to be checked as non-secured Mask */
+#define EVSYS_NSCHKUSER_USER2               EVSYS_NSCHKUSER_USER2_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKUSER_USER2_Msk instead */
+#define EVSYS_NSCHKUSER_USER3_Pos           3                                              /**< (EVSYS_NSCHKUSER) User 3 to be checked as non-secured Position */
+#define EVSYS_NSCHKUSER_USER3_Msk           (_U_(0x1) << EVSYS_NSCHKUSER_USER3_Pos)        /**< (EVSYS_NSCHKUSER) User 3 to be checked as non-secured Mask */
+#define EVSYS_NSCHKUSER_USER3               EVSYS_NSCHKUSER_USER3_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKUSER_USER3_Msk instead */
+#define EVSYS_NSCHKUSER_USER4_Pos           4                                              /**< (EVSYS_NSCHKUSER) User 4 to be checked as non-secured Position */
+#define EVSYS_NSCHKUSER_USER4_Msk           (_U_(0x1) << EVSYS_NSCHKUSER_USER4_Pos)        /**< (EVSYS_NSCHKUSER) User 4 to be checked as non-secured Mask */
+#define EVSYS_NSCHKUSER_USER4               EVSYS_NSCHKUSER_USER4_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKUSER_USER4_Msk instead */
+#define EVSYS_NSCHKUSER_USER5_Pos           5                                              /**< (EVSYS_NSCHKUSER) User 5 to be checked as non-secured Position */
+#define EVSYS_NSCHKUSER_USER5_Msk           (_U_(0x1) << EVSYS_NSCHKUSER_USER5_Pos)        /**< (EVSYS_NSCHKUSER) User 5 to be checked as non-secured Mask */
+#define EVSYS_NSCHKUSER_USER5               EVSYS_NSCHKUSER_USER5_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKUSER_USER5_Msk instead */
+#define EVSYS_NSCHKUSER_USER6_Pos           6                                              /**< (EVSYS_NSCHKUSER) User 6 to be checked as non-secured Position */
+#define EVSYS_NSCHKUSER_USER6_Msk           (_U_(0x1) << EVSYS_NSCHKUSER_USER6_Pos)        /**< (EVSYS_NSCHKUSER) User 6 to be checked as non-secured Mask */
+#define EVSYS_NSCHKUSER_USER6               EVSYS_NSCHKUSER_USER6_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKUSER_USER6_Msk instead */
+#define EVSYS_NSCHKUSER_USER7_Pos           7                                              /**< (EVSYS_NSCHKUSER) User 7 to be checked as non-secured Position */
+#define EVSYS_NSCHKUSER_USER7_Msk           (_U_(0x1) << EVSYS_NSCHKUSER_USER7_Pos)        /**< (EVSYS_NSCHKUSER) User 7 to be checked as non-secured Mask */
+#define EVSYS_NSCHKUSER_USER7               EVSYS_NSCHKUSER_USER7_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKUSER_USER7_Msk instead */
+#define EVSYS_NSCHKUSER_USER8_Pos           8                                              /**< (EVSYS_NSCHKUSER) User 8 to be checked as non-secured Position */
+#define EVSYS_NSCHKUSER_USER8_Msk           (_U_(0x1) << EVSYS_NSCHKUSER_USER8_Pos)        /**< (EVSYS_NSCHKUSER) User 8 to be checked as non-secured Mask */
+#define EVSYS_NSCHKUSER_USER8               EVSYS_NSCHKUSER_USER8_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKUSER_USER8_Msk instead */
+#define EVSYS_NSCHKUSER_USER9_Pos           9                                              /**< (EVSYS_NSCHKUSER) User 9 to be checked as non-secured Position */
+#define EVSYS_NSCHKUSER_USER9_Msk           (_U_(0x1) << EVSYS_NSCHKUSER_USER9_Pos)        /**< (EVSYS_NSCHKUSER) User 9 to be checked as non-secured Mask */
+#define EVSYS_NSCHKUSER_USER9               EVSYS_NSCHKUSER_USER9_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKUSER_USER9_Msk instead */
+#define EVSYS_NSCHKUSER_USER10_Pos          10                                             /**< (EVSYS_NSCHKUSER) User 10 to be checked as non-secured Position */
+#define EVSYS_NSCHKUSER_USER10_Msk          (_U_(0x1) << EVSYS_NSCHKUSER_USER10_Pos)       /**< (EVSYS_NSCHKUSER) User 10 to be checked as non-secured Mask */
+#define EVSYS_NSCHKUSER_USER10              EVSYS_NSCHKUSER_USER10_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKUSER_USER10_Msk instead */
+#define EVSYS_NSCHKUSER_USER11_Pos          11                                             /**< (EVSYS_NSCHKUSER) User 11 to be checked as non-secured Position */
+#define EVSYS_NSCHKUSER_USER11_Msk          (_U_(0x1) << EVSYS_NSCHKUSER_USER11_Pos)       /**< (EVSYS_NSCHKUSER) User 11 to be checked as non-secured Mask */
+#define EVSYS_NSCHKUSER_USER11              EVSYS_NSCHKUSER_USER11_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKUSER_USER11_Msk instead */
+#define EVSYS_NSCHKUSER_USER12_Pos          12                                             /**< (EVSYS_NSCHKUSER) User 12 to be checked as non-secured Position */
+#define EVSYS_NSCHKUSER_USER12_Msk          (_U_(0x1) << EVSYS_NSCHKUSER_USER12_Pos)       /**< (EVSYS_NSCHKUSER) User 12 to be checked as non-secured Mask */
+#define EVSYS_NSCHKUSER_USER12              EVSYS_NSCHKUSER_USER12_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKUSER_USER12_Msk instead */
+#define EVSYS_NSCHKUSER_USER13_Pos          13                                             /**< (EVSYS_NSCHKUSER) User 13 to be checked as non-secured Position */
+#define EVSYS_NSCHKUSER_USER13_Msk          (_U_(0x1) << EVSYS_NSCHKUSER_USER13_Pos)       /**< (EVSYS_NSCHKUSER) User 13 to be checked as non-secured Mask */
+#define EVSYS_NSCHKUSER_USER13              EVSYS_NSCHKUSER_USER13_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKUSER_USER13_Msk instead */
+#define EVSYS_NSCHKUSER_USER14_Pos          14                                             /**< (EVSYS_NSCHKUSER) User 14 to be checked as non-secured Position */
+#define EVSYS_NSCHKUSER_USER14_Msk          (_U_(0x1) << EVSYS_NSCHKUSER_USER14_Pos)       /**< (EVSYS_NSCHKUSER) User 14 to be checked as non-secured Mask */
+#define EVSYS_NSCHKUSER_USER14              EVSYS_NSCHKUSER_USER14_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKUSER_USER14_Msk instead */
+#define EVSYS_NSCHKUSER_USER15_Pos          15                                             /**< (EVSYS_NSCHKUSER) User 15 to be checked as non-secured Position */
+#define EVSYS_NSCHKUSER_USER15_Msk          (_U_(0x1) << EVSYS_NSCHKUSER_USER15_Pos)       /**< (EVSYS_NSCHKUSER) User 15 to be checked as non-secured Mask */
+#define EVSYS_NSCHKUSER_USER15              EVSYS_NSCHKUSER_USER15_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKUSER_USER15_Msk instead */
+#define EVSYS_NSCHKUSER_USER16_Pos          16                                             /**< (EVSYS_NSCHKUSER) User 16 to be checked as non-secured Position */
+#define EVSYS_NSCHKUSER_USER16_Msk          (_U_(0x1) << EVSYS_NSCHKUSER_USER16_Pos)       /**< (EVSYS_NSCHKUSER) User 16 to be checked as non-secured Mask */
+#define EVSYS_NSCHKUSER_USER16              EVSYS_NSCHKUSER_USER16_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKUSER_USER16_Msk instead */
+#define EVSYS_NSCHKUSER_USER17_Pos          17                                             /**< (EVSYS_NSCHKUSER) User 17 to be checked as non-secured Position */
+#define EVSYS_NSCHKUSER_USER17_Msk          (_U_(0x1) << EVSYS_NSCHKUSER_USER17_Pos)       /**< (EVSYS_NSCHKUSER) User 17 to be checked as non-secured Mask */
+#define EVSYS_NSCHKUSER_USER17              EVSYS_NSCHKUSER_USER17_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKUSER_USER17_Msk instead */
+#define EVSYS_NSCHKUSER_USER18_Pos          18                                             /**< (EVSYS_NSCHKUSER) User 18 to be checked as non-secured Position */
+#define EVSYS_NSCHKUSER_USER18_Msk          (_U_(0x1) << EVSYS_NSCHKUSER_USER18_Pos)       /**< (EVSYS_NSCHKUSER) User 18 to be checked as non-secured Mask */
+#define EVSYS_NSCHKUSER_USER18              EVSYS_NSCHKUSER_USER18_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKUSER_USER18_Msk instead */
+#define EVSYS_NSCHKUSER_USER19_Pos          19                                             /**< (EVSYS_NSCHKUSER) User 19 to be checked as non-secured Position */
+#define EVSYS_NSCHKUSER_USER19_Msk          (_U_(0x1) << EVSYS_NSCHKUSER_USER19_Pos)       /**< (EVSYS_NSCHKUSER) User 19 to be checked as non-secured Mask */
+#define EVSYS_NSCHKUSER_USER19              EVSYS_NSCHKUSER_USER19_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKUSER_USER19_Msk instead */
+#define EVSYS_NSCHKUSER_USER20_Pos          20                                             /**< (EVSYS_NSCHKUSER) User 20 to be checked as non-secured Position */
+#define EVSYS_NSCHKUSER_USER20_Msk          (_U_(0x1) << EVSYS_NSCHKUSER_USER20_Pos)       /**< (EVSYS_NSCHKUSER) User 20 to be checked as non-secured Mask */
+#define EVSYS_NSCHKUSER_USER20              EVSYS_NSCHKUSER_USER20_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKUSER_USER20_Msk instead */
+#define EVSYS_NSCHKUSER_USER21_Pos          21                                             /**< (EVSYS_NSCHKUSER) User 21 to be checked as non-secured Position */
+#define EVSYS_NSCHKUSER_USER21_Msk          (_U_(0x1) << EVSYS_NSCHKUSER_USER21_Pos)       /**< (EVSYS_NSCHKUSER) User 21 to be checked as non-secured Mask */
+#define EVSYS_NSCHKUSER_USER21              EVSYS_NSCHKUSER_USER21_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKUSER_USER21_Msk instead */
+#define EVSYS_NSCHKUSER_USER22_Pos          22                                             /**< (EVSYS_NSCHKUSER) User 22 to be checked as non-secured Position */
+#define EVSYS_NSCHKUSER_USER22_Msk          (_U_(0x1) << EVSYS_NSCHKUSER_USER22_Pos)       /**< (EVSYS_NSCHKUSER) User 22 to be checked as non-secured Mask */
+#define EVSYS_NSCHKUSER_USER22              EVSYS_NSCHKUSER_USER22_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKUSER_USER22_Msk instead */
+#define EVSYS_NSCHKUSER_MASK                _U_(0x7FFFFF)                                  /**< \deprecated (EVSYS_NSCHKUSER) Register MASK  (Use EVSYS_NSCHKUSER_Msk instead)  */
+#define EVSYS_NSCHKUSER_Msk                 _U_(0x7FFFFF)                                  /**< (EVSYS_NSCHKUSER) Register Mask  */
+
+#define EVSYS_NSCHKUSER_USER_Pos            0                                              /**< (EVSYS_NSCHKUSER Position) User 22 to be checked as non-secured */
+#define EVSYS_NSCHKUSER_USER_Msk            (_U_(0x7FFFFF) << EVSYS_NSCHKUSER_USER_Pos)    /**< (EVSYS_NSCHKUSER Mask) USER */
+#define EVSYS_NSCHKUSER_USER(value)         (EVSYS_NSCHKUSER_USER_Msk & ((value) << EVSYS_NSCHKUSER_USER_Pos))  
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief CHANNEL hardware registers */
+typedef struct {  
+  __IO EVSYS_CHANNEL_Type             CHANNEL;        /**< Offset: 0x00 (R/W  32) Channel n Control */
+  __IO EVSYS_CHINTENCLR_Type          CHINTENCLR;     /**< Offset: 0x04 (R/W   8) Channel n Interrupt Enable Clear */
+  __IO EVSYS_CHINTENSET_Type          CHINTENSET;     /**< Offset: 0x05 (R/W   8) Channel n Interrupt Enable Set */
+  __IO EVSYS_CHINTFLAG_Type           CHINTFLAG;      /**< Offset: 0x06 (R/W   8) Channel n Interrupt Flag Status and Clear */
+  __I  EVSYS_CHSTATUS_Type            CHSTATUS;       /**< Offset: 0x07 (R/    8) Channel n Status */
+} EvsysChannel;
+
+/** \brief EVSYS hardware registers */
+typedef struct {  /* Event System Interface */
+  __O  EVSYS_CTRLA_Type               CTRLA;          /**< Offset: 0x00 ( /W   8) Control */
+  __I  uint8_t                        Reserved1[3];
+  __O  EVSYS_SWEVT_Type               SWEVT;          /**< Offset: 0x04 ( /W  32) Software Event */
+  __IO EVSYS_PRICTRL_Type             PRICTRL;        /**< Offset: 0x08 (R/W   8) Priority Control */
+  __I  uint8_t                        Reserved2[7];
+  __IO EVSYS_INTPEND_Type             INTPEND;        /**< Offset: 0x10 (R/W  16) Channel Pending Interrupt */
+  __I  uint8_t                        Reserved3[2];
+  __I  EVSYS_INTSTATUS_Type           INTSTATUS;      /**< Offset: 0x14 (R/   32) Interrupt Status */
+  __I  EVSYS_BUSYCH_Type              BUSYCH;         /**< Offset: 0x18 (R/   32) Busy Channels */
+  __I  EVSYS_READYUSR_Type            READYUSR;       /**< Offset: 0x1C (R/   32) Ready Users */
+       EvsysChannel                   Channel[8];     /**< Offset: 0x20  */
+  __I  uint8_t                        Reserved4[192];
+  __IO EVSYS_USER_Type                USER[23];       /**< Offset: 0x120 (R/W   8) User Multiplexer n */
+  __I  uint8_t                        Reserved5[157];
+  __IO EVSYS_INTENCLR_Type            INTENCLR;       /**< Offset: 0x1D4 (R/W   8) Interrupt Enable Clear */
+  __IO EVSYS_INTENSET_Type            INTENSET;       /**< Offset: 0x1D5 (R/W   8) Interrupt Enable Set */
+  __IO EVSYS_INTFLAG_Type             INTFLAG;        /**< Offset: 0x1D6 (R/W   8) Interrupt Flag Status and Clear */
+  __I  uint8_t                        Reserved6[1];
+  __IO EVSYS_NONSECCHAN_Type          NONSECCHAN;     /**< Offset: 0x1D8 (R/W  32) Channels Security Attribution */
+  __IO EVSYS_NSCHKCHAN_Type           NSCHKCHAN;      /**< Offset: 0x1DC (R/W  32) Non-Secure Channels Check */
+  __IO EVSYS_NONSECUSER_Type          NONSECUSER[1];  /**< Offset: 0x1E0 (R/W  32) Users Security Attribution */
+  __I  uint8_t                        Reserved7[12];
+  __IO EVSYS_NSCHKUSER_Type           NSCHKUSER[1];   /**< Offset: 0x1F0 (R/W  32) Non-Secure Users Check */
+} Evsys;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Event System Interface */
+
+#endif /* _SAML10_EVSYS_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/component/freqm.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/freqm.h
@@ -1,0 +1,269 @@
+/**
+ * \file
+ *
+ * \brief Component description for FREQM
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_FREQM_COMPONENT_H_
+#define _SAML10_FREQM_COMPONENT_H_
+#define _SAML10_FREQM_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML10 Frequency Meter
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR FREQM */
+/* ========================================================================== */
+
+#define FREQM_U2257                      /**< (FREQM) Module ID */
+#define REV_FREQM 0x210                  /**< (FREQM) Module revision */
+
+/* -------- FREQM_CTRLA : (FREQM Offset: 0x00) (R/W 8) Control A Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint8_t  ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint8_t  :6;                        /**< bit:   2..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} FREQM_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define FREQM_CTRLA_OFFSET                  (0x00)                                        /**<  (FREQM_CTRLA) Control A Register  Offset */
+#define FREQM_CTRLA_RESETVALUE              _U_(0x00)                                     /**<  (FREQM_CTRLA) Control A Register  Reset Value */
+
+#define FREQM_CTRLA_SWRST_Pos               0                                              /**< (FREQM_CTRLA) Software Reset Position */
+#define FREQM_CTRLA_SWRST_Msk               (_U_(0x1) << FREQM_CTRLA_SWRST_Pos)            /**< (FREQM_CTRLA) Software Reset Mask */
+#define FREQM_CTRLA_SWRST                   FREQM_CTRLA_SWRST_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use FREQM_CTRLA_SWRST_Msk instead */
+#define FREQM_CTRLA_ENABLE_Pos              1                                              /**< (FREQM_CTRLA) Enable Position */
+#define FREQM_CTRLA_ENABLE_Msk              (_U_(0x1) << FREQM_CTRLA_ENABLE_Pos)           /**< (FREQM_CTRLA) Enable Mask */
+#define FREQM_CTRLA_ENABLE                  FREQM_CTRLA_ENABLE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use FREQM_CTRLA_ENABLE_Msk instead */
+#define FREQM_CTRLA_MASK                    _U_(0x03)                                      /**< \deprecated (FREQM_CTRLA) Register MASK  (Use FREQM_CTRLA_Msk instead)  */
+#define FREQM_CTRLA_Msk                     _U_(0x03)                                      /**< (FREQM_CTRLA) Register Mask  */
+
+
+/* -------- FREQM_CTRLB : (FREQM Offset: 0x01) (/W 8) Control B Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  START:1;                   /**< bit:      0  Start Measurement                        */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} FREQM_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define FREQM_CTRLB_OFFSET                  (0x01)                                        /**<  (FREQM_CTRLB) Control B Register  Offset */
+#define FREQM_CTRLB_RESETVALUE              _U_(0x00)                                     /**<  (FREQM_CTRLB) Control B Register  Reset Value */
+
+#define FREQM_CTRLB_START_Pos               0                                              /**< (FREQM_CTRLB) Start Measurement Position */
+#define FREQM_CTRLB_START_Msk               (_U_(0x1) << FREQM_CTRLB_START_Pos)            /**< (FREQM_CTRLB) Start Measurement Mask */
+#define FREQM_CTRLB_START                   FREQM_CTRLB_START_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use FREQM_CTRLB_START_Msk instead */
+#define FREQM_CTRLB_MASK                    _U_(0x01)                                      /**< \deprecated (FREQM_CTRLB) Register MASK  (Use FREQM_CTRLB_Msk instead)  */
+#define FREQM_CTRLB_Msk                     _U_(0x01)                                      /**< (FREQM_CTRLB) Register Mask  */
+
+
+/* -------- FREQM_CFGA : (FREQM Offset: 0x02) (R/W 16) Config A register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t REFNUM:8;                  /**< bit:   0..7  Number of Reference Clock Cycles         */
+    uint16_t :7;                        /**< bit:  8..14  Reserved */
+    uint16_t DIVREF:1;                  /**< bit:     15  Divide Reference Clock                   */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} FREQM_CFGA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define FREQM_CFGA_OFFSET                   (0x02)                                        /**<  (FREQM_CFGA) Config A register  Offset */
+#define FREQM_CFGA_RESETVALUE               _U_(0x00)                                     /**<  (FREQM_CFGA) Config A register  Reset Value */
+
+#define FREQM_CFGA_REFNUM_Pos               0                                              /**< (FREQM_CFGA) Number of Reference Clock Cycles Position */
+#define FREQM_CFGA_REFNUM_Msk               (_U_(0xFF) << FREQM_CFGA_REFNUM_Pos)           /**< (FREQM_CFGA) Number of Reference Clock Cycles Mask */
+#define FREQM_CFGA_REFNUM(value)            (FREQM_CFGA_REFNUM_Msk & ((value) << FREQM_CFGA_REFNUM_Pos))
+#define FREQM_CFGA_DIVREF_Pos               15                                             /**< (FREQM_CFGA) Divide Reference Clock Position */
+#define FREQM_CFGA_DIVREF_Msk               (_U_(0x1) << FREQM_CFGA_DIVREF_Pos)            /**< (FREQM_CFGA) Divide Reference Clock Mask */
+#define FREQM_CFGA_DIVREF                   FREQM_CFGA_DIVREF_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use FREQM_CFGA_DIVREF_Msk instead */
+#define FREQM_CFGA_MASK                     _U_(0x80FF)                                    /**< \deprecated (FREQM_CFGA) Register MASK  (Use FREQM_CFGA_Msk instead)  */
+#define FREQM_CFGA_Msk                      _U_(0x80FF)                                    /**< (FREQM_CFGA) Register Mask  */
+
+
+/* -------- FREQM_INTENCLR : (FREQM Offset: 0x08) (R/W 8) Interrupt Enable Clear Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DONE:1;                    /**< bit:      0  Measurement Done Interrupt Enable        */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} FREQM_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define FREQM_INTENCLR_OFFSET               (0x08)                                        /**<  (FREQM_INTENCLR) Interrupt Enable Clear Register  Offset */
+#define FREQM_INTENCLR_RESETVALUE           _U_(0x00)                                     /**<  (FREQM_INTENCLR) Interrupt Enable Clear Register  Reset Value */
+
+#define FREQM_INTENCLR_DONE_Pos             0                                              /**< (FREQM_INTENCLR) Measurement Done Interrupt Enable Position */
+#define FREQM_INTENCLR_DONE_Msk             (_U_(0x1) << FREQM_INTENCLR_DONE_Pos)          /**< (FREQM_INTENCLR) Measurement Done Interrupt Enable Mask */
+#define FREQM_INTENCLR_DONE                 FREQM_INTENCLR_DONE_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use FREQM_INTENCLR_DONE_Msk instead */
+#define FREQM_INTENCLR_MASK                 _U_(0x01)                                      /**< \deprecated (FREQM_INTENCLR) Register MASK  (Use FREQM_INTENCLR_Msk instead)  */
+#define FREQM_INTENCLR_Msk                  _U_(0x01)                                      /**< (FREQM_INTENCLR) Register Mask  */
+
+
+/* -------- FREQM_INTENSET : (FREQM Offset: 0x09) (R/W 8) Interrupt Enable Set Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DONE:1;                    /**< bit:      0  Measurement Done Interrupt Enable        */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} FREQM_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define FREQM_INTENSET_OFFSET               (0x09)                                        /**<  (FREQM_INTENSET) Interrupt Enable Set Register  Offset */
+#define FREQM_INTENSET_RESETVALUE           _U_(0x00)                                     /**<  (FREQM_INTENSET) Interrupt Enable Set Register  Reset Value */
+
+#define FREQM_INTENSET_DONE_Pos             0                                              /**< (FREQM_INTENSET) Measurement Done Interrupt Enable Position */
+#define FREQM_INTENSET_DONE_Msk             (_U_(0x1) << FREQM_INTENSET_DONE_Pos)          /**< (FREQM_INTENSET) Measurement Done Interrupt Enable Mask */
+#define FREQM_INTENSET_DONE                 FREQM_INTENSET_DONE_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use FREQM_INTENSET_DONE_Msk instead */
+#define FREQM_INTENSET_MASK                 _U_(0x01)                                      /**< \deprecated (FREQM_INTENSET) Register MASK  (Use FREQM_INTENSET_Msk instead)  */
+#define FREQM_INTENSET_Msk                  _U_(0x01)                                      /**< (FREQM_INTENSET) Register Mask  */
+
+
+/* -------- FREQM_INTFLAG : (FREQM Offset: 0x0a) (R/W 8) Interrupt Flag Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t DONE:1;                    /**< bit:      0  Measurement Done                         */
+    __I uint8_t :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} FREQM_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define FREQM_INTFLAG_OFFSET                (0x0A)                                        /**<  (FREQM_INTFLAG) Interrupt Flag Register  Offset */
+#define FREQM_INTFLAG_RESETVALUE            _U_(0x00)                                     /**<  (FREQM_INTFLAG) Interrupt Flag Register  Reset Value */
+
+#define FREQM_INTFLAG_DONE_Pos              0                                              /**< (FREQM_INTFLAG) Measurement Done Position */
+#define FREQM_INTFLAG_DONE_Msk              (_U_(0x1) << FREQM_INTFLAG_DONE_Pos)           /**< (FREQM_INTFLAG) Measurement Done Mask */
+#define FREQM_INTFLAG_DONE                  FREQM_INTFLAG_DONE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use FREQM_INTFLAG_DONE_Msk instead */
+#define FREQM_INTFLAG_MASK                  _U_(0x01)                                      /**< \deprecated (FREQM_INTFLAG) Register MASK  (Use FREQM_INTFLAG_Msk instead)  */
+#define FREQM_INTFLAG_Msk                   _U_(0x01)                                      /**< (FREQM_INTFLAG) Register Mask  */
+
+
+/* -------- FREQM_STATUS : (FREQM Offset: 0x0b) (R/W 8) Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  BUSY:1;                    /**< bit:      0  FREQM Status                             */
+    uint8_t  OVF:1;                     /**< bit:      1  Sticky Count Value Overflow              */
+    uint8_t  :6;                        /**< bit:   2..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} FREQM_STATUS_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define FREQM_STATUS_OFFSET                 (0x0B)                                        /**<  (FREQM_STATUS) Status Register  Offset */
+#define FREQM_STATUS_RESETVALUE             _U_(0x00)                                     /**<  (FREQM_STATUS) Status Register  Reset Value */
+
+#define FREQM_STATUS_BUSY_Pos               0                                              /**< (FREQM_STATUS) FREQM Status Position */
+#define FREQM_STATUS_BUSY_Msk               (_U_(0x1) << FREQM_STATUS_BUSY_Pos)            /**< (FREQM_STATUS) FREQM Status Mask */
+#define FREQM_STATUS_BUSY                   FREQM_STATUS_BUSY_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use FREQM_STATUS_BUSY_Msk instead */
+#define FREQM_STATUS_OVF_Pos                1                                              /**< (FREQM_STATUS) Sticky Count Value Overflow Position */
+#define FREQM_STATUS_OVF_Msk                (_U_(0x1) << FREQM_STATUS_OVF_Pos)             /**< (FREQM_STATUS) Sticky Count Value Overflow Mask */
+#define FREQM_STATUS_OVF                    FREQM_STATUS_OVF_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use FREQM_STATUS_OVF_Msk instead */
+#define FREQM_STATUS_MASK                   _U_(0x03)                                      /**< \deprecated (FREQM_STATUS) Register MASK  (Use FREQM_STATUS_Msk instead)  */
+#define FREQM_STATUS_Msk                    _U_(0x03)                                      /**< (FREQM_STATUS) Register Mask  */
+
+
+/* -------- FREQM_SYNCBUSY : (FREQM Offset: 0x0c) (R/ 32) Synchronization Busy Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint32_t ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint32_t :30;                       /**< bit:  2..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} FREQM_SYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define FREQM_SYNCBUSY_OFFSET               (0x0C)                                        /**<  (FREQM_SYNCBUSY) Synchronization Busy Register  Offset */
+#define FREQM_SYNCBUSY_RESETVALUE           _U_(0x00)                                     /**<  (FREQM_SYNCBUSY) Synchronization Busy Register  Reset Value */
+
+#define FREQM_SYNCBUSY_SWRST_Pos            0                                              /**< (FREQM_SYNCBUSY) Software Reset Position */
+#define FREQM_SYNCBUSY_SWRST_Msk            (_U_(0x1) << FREQM_SYNCBUSY_SWRST_Pos)         /**< (FREQM_SYNCBUSY) Software Reset Mask */
+#define FREQM_SYNCBUSY_SWRST                FREQM_SYNCBUSY_SWRST_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use FREQM_SYNCBUSY_SWRST_Msk instead */
+#define FREQM_SYNCBUSY_ENABLE_Pos           1                                              /**< (FREQM_SYNCBUSY) Enable Position */
+#define FREQM_SYNCBUSY_ENABLE_Msk           (_U_(0x1) << FREQM_SYNCBUSY_ENABLE_Pos)        /**< (FREQM_SYNCBUSY) Enable Mask */
+#define FREQM_SYNCBUSY_ENABLE               FREQM_SYNCBUSY_ENABLE_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use FREQM_SYNCBUSY_ENABLE_Msk instead */
+#define FREQM_SYNCBUSY_MASK                 _U_(0x03)                                      /**< \deprecated (FREQM_SYNCBUSY) Register MASK  (Use FREQM_SYNCBUSY_Msk instead)  */
+#define FREQM_SYNCBUSY_Msk                  _U_(0x03)                                      /**< (FREQM_SYNCBUSY) Register Mask  */
+
+
+/* -------- FREQM_VALUE : (FREQM Offset: 0x10) (R/ 32) Count Value Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t VALUE:24;                  /**< bit:  0..23  Measurement Value                        */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} FREQM_VALUE_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define FREQM_VALUE_OFFSET                  (0x10)                                        /**<  (FREQM_VALUE) Count Value Register  Offset */
+#define FREQM_VALUE_RESETVALUE              _U_(0x00)                                     /**<  (FREQM_VALUE) Count Value Register  Reset Value */
+
+#define FREQM_VALUE_VALUE_Pos               0                                              /**< (FREQM_VALUE) Measurement Value Position */
+#define FREQM_VALUE_VALUE_Msk               (_U_(0xFFFFFF) << FREQM_VALUE_VALUE_Pos)       /**< (FREQM_VALUE) Measurement Value Mask */
+#define FREQM_VALUE_VALUE(value)            (FREQM_VALUE_VALUE_Msk & ((value) << FREQM_VALUE_VALUE_Pos))
+#define FREQM_VALUE_MASK                    _U_(0xFFFFFF)                                  /**< \deprecated (FREQM_VALUE) Register MASK  (Use FREQM_VALUE_Msk instead)  */
+#define FREQM_VALUE_Msk                     _U_(0xFFFFFF)                                  /**< (FREQM_VALUE) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief FREQM hardware registers */
+typedef struct {  /* Frequency Meter */
+  __IO FREQM_CTRLA_Type               CTRLA;          /**< Offset: 0x00 (R/W   8) Control A Register */
+  __O  FREQM_CTRLB_Type               CTRLB;          /**< Offset: 0x01 ( /W   8) Control B Register */
+  __IO FREQM_CFGA_Type                CFGA;           /**< Offset: 0x02 (R/W  16) Config A register */
+  __I  uint8_t                        Reserved1[4];
+  __IO FREQM_INTENCLR_Type            INTENCLR;       /**< Offset: 0x08 (R/W   8) Interrupt Enable Clear Register */
+  __IO FREQM_INTENSET_Type            INTENSET;       /**< Offset: 0x09 (R/W   8) Interrupt Enable Set Register */
+  __IO FREQM_INTFLAG_Type             INTFLAG;        /**< Offset: 0x0A (R/W   8) Interrupt Flag Register */
+  __IO FREQM_STATUS_Type              STATUS;         /**< Offset: 0x0B (R/W   8) Status Register */
+  __I  FREQM_SYNCBUSY_Type            SYNCBUSY;       /**< Offset: 0x0C (R/   32) Synchronization Busy Register */
+  __I  FREQM_VALUE_Type               VALUE;          /**< Offset: 0x10 (R/   32) Count Value Register */
+} Freqm;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Frequency Meter */
+
+#endif /* _SAML10_FREQM_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/component/gclk.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/gclk.h
@@ -1,0 +1,238 @@
+/**
+ * \file
+ *
+ * \brief Component description for GCLK
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_GCLK_COMPONENT_H_
+#define _SAML10_GCLK_COMPONENT_H_
+#define _SAML10_GCLK_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML10 Generic Clock Generator
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR GCLK */
+/* ========================================================================== */
+
+#define GCLK_U2122                      /**< (GCLK) Module ID */
+#define REV_GCLK 0x112                  /**< (GCLK) Module revision */
+
+/* -------- GCLK_CTRLA : (GCLK Offset: 0x00) (R/W 8) Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} GCLK_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GCLK_CTRLA_OFFSET                   (0x00)                                        /**<  (GCLK_CTRLA) Control  Offset */
+#define GCLK_CTRLA_RESETVALUE               _U_(0x00)                                     /**<  (GCLK_CTRLA) Control  Reset Value */
+
+#define GCLK_CTRLA_SWRST_Pos                0                                              /**< (GCLK_CTRLA) Software Reset Position */
+#define GCLK_CTRLA_SWRST_Msk                (_U_(0x1) << GCLK_CTRLA_SWRST_Pos)             /**< (GCLK_CTRLA) Software Reset Mask */
+#define GCLK_CTRLA_SWRST                    GCLK_CTRLA_SWRST_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GCLK_CTRLA_SWRST_Msk instead */
+#define GCLK_CTRLA_MASK                     _U_(0x01)                                      /**< \deprecated (GCLK_CTRLA) Register MASK  (Use GCLK_CTRLA_Msk instead)  */
+#define GCLK_CTRLA_Msk                      _U_(0x01)                                      /**< (GCLK_CTRLA) Register Mask  */
+
+
+/* -------- GCLK_SYNCBUSY : (GCLK Offset: 0x04) (R/ 32) Synchronization Busy -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SWRST:1;                   /**< bit:      0  Software Reset Synchroniation Busy bit   */
+    uint32_t :1;                        /**< bit:      1  Reserved */
+    uint32_t GENCTRL0:1;                /**< bit:      2  Generic Clock Generator Control 0 Synchronization Busy bit */
+    uint32_t GENCTRL1:1;                /**< bit:      3  Generic Clock Generator Control 1 Synchronization Busy bit */
+    uint32_t GENCTRL2:1;                /**< bit:      4  Generic Clock Generator Control 2 Synchronization Busy bit */
+    uint32_t GENCTRL3:1;                /**< bit:      5  Generic Clock Generator Control 3 Synchronization Busy bit */
+    uint32_t GENCTRL4:1;                /**< bit:      6  Generic Clock Generator Control 4 Synchronization Busy bit */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t GENCTRL:5;                 /**< bit:   2..6  Generic Clock Generator Control 4 Synchronization Busy bit */
+    uint32_t :25;                       /**< bit:  7..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} GCLK_SYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GCLK_SYNCBUSY_OFFSET                (0x04)                                        /**<  (GCLK_SYNCBUSY) Synchronization Busy  Offset */
+#define GCLK_SYNCBUSY_RESETVALUE            _U_(0x00)                                     /**<  (GCLK_SYNCBUSY) Synchronization Busy  Reset Value */
+
+#define GCLK_SYNCBUSY_SWRST_Pos             0                                              /**< (GCLK_SYNCBUSY) Software Reset Synchroniation Busy bit Position */
+#define GCLK_SYNCBUSY_SWRST_Msk             (_U_(0x1) << GCLK_SYNCBUSY_SWRST_Pos)          /**< (GCLK_SYNCBUSY) Software Reset Synchroniation Busy bit Mask */
+#define GCLK_SYNCBUSY_SWRST                 GCLK_SYNCBUSY_SWRST_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use GCLK_SYNCBUSY_SWRST_Msk instead */
+#define GCLK_SYNCBUSY_GENCTRL0_Pos          2                                              /**< (GCLK_SYNCBUSY) Generic Clock Generator Control 0 Synchronization Busy bit Position */
+#define GCLK_SYNCBUSY_GENCTRL0_Msk          (_U_(0x1) << GCLK_SYNCBUSY_GENCTRL0_Pos)       /**< (GCLK_SYNCBUSY) Generic Clock Generator Control 0 Synchronization Busy bit Mask */
+#define GCLK_SYNCBUSY_GENCTRL0              GCLK_SYNCBUSY_GENCTRL0_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use GCLK_SYNCBUSY_GENCTRL0_Msk instead */
+#define GCLK_SYNCBUSY_GENCTRL1_Pos          3                                              /**< (GCLK_SYNCBUSY) Generic Clock Generator Control 1 Synchronization Busy bit Position */
+#define GCLK_SYNCBUSY_GENCTRL1_Msk          (_U_(0x1) << GCLK_SYNCBUSY_GENCTRL1_Pos)       /**< (GCLK_SYNCBUSY) Generic Clock Generator Control 1 Synchronization Busy bit Mask */
+#define GCLK_SYNCBUSY_GENCTRL1              GCLK_SYNCBUSY_GENCTRL1_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use GCLK_SYNCBUSY_GENCTRL1_Msk instead */
+#define GCLK_SYNCBUSY_GENCTRL2_Pos          4                                              /**< (GCLK_SYNCBUSY) Generic Clock Generator Control 2 Synchronization Busy bit Position */
+#define GCLK_SYNCBUSY_GENCTRL2_Msk          (_U_(0x1) << GCLK_SYNCBUSY_GENCTRL2_Pos)       /**< (GCLK_SYNCBUSY) Generic Clock Generator Control 2 Synchronization Busy bit Mask */
+#define GCLK_SYNCBUSY_GENCTRL2              GCLK_SYNCBUSY_GENCTRL2_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use GCLK_SYNCBUSY_GENCTRL2_Msk instead */
+#define GCLK_SYNCBUSY_GENCTRL3_Pos          5                                              /**< (GCLK_SYNCBUSY) Generic Clock Generator Control 3 Synchronization Busy bit Position */
+#define GCLK_SYNCBUSY_GENCTRL3_Msk          (_U_(0x1) << GCLK_SYNCBUSY_GENCTRL3_Pos)       /**< (GCLK_SYNCBUSY) Generic Clock Generator Control 3 Synchronization Busy bit Mask */
+#define GCLK_SYNCBUSY_GENCTRL3              GCLK_SYNCBUSY_GENCTRL3_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use GCLK_SYNCBUSY_GENCTRL3_Msk instead */
+#define GCLK_SYNCBUSY_GENCTRL4_Pos          6                                              /**< (GCLK_SYNCBUSY) Generic Clock Generator Control 4 Synchronization Busy bit Position */
+#define GCLK_SYNCBUSY_GENCTRL4_Msk          (_U_(0x1) << GCLK_SYNCBUSY_GENCTRL4_Pos)       /**< (GCLK_SYNCBUSY) Generic Clock Generator Control 4 Synchronization Busy bit Mask */
+#define GCLK_SYNCBUSY_GENCTRL4              GCLK_SYNCBUSY_GENCTRL4_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use GCLK_SYNCBUSY_GENCTRL4_Msk instead */
+#define GCLK_SYNCBUSY_MASK                  _U_(0x7D)                                      /**< \deprecated (GCLK_SYNCBUSY) Register MASK  (Use GCLK_SYNCBUSY_Msk instead)  */
+#define GCLK_SYNCBUSY_Msk                   _U_(0x7D)                                      /**< (GCLK_SYNCBUSY) Register Mask  */
+
+#define GCLK_SYNCBUSY_GENCTRL_Pos           2                                              /**< (GCLK_SYNCBUSY Position) Generic Clock Generator Control 4 Synchronization Busy bit */
+#define GCLK_SYNCBUSY_GENCTRL_Msk           (_U_(0x1F) << GCLK_SYNCBUSY_GENCTRL_Pos)       /**< (GCLK_SYNCBUSY Mask) GENCTRL */
+#define GCLK_SYNCBUSY_GENCTRL(value)        (GCLK_SYNCBUSY_GENCTRL_Msk & ((value) << GCLK_SYNCBUSY_GENCTRL_Pos))  
+
+/* -------- GCLK_GENCTRL : (GCLK Offset: 0x20) (R/W 32) Generic Clock Generator Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SRC:3;                     /**< bit:   0..2  Source Select                            */
+    uint32_t :5;                        /**< bit:   3..7  Reserved */
+    uint32_t GENEN:1;                   /**< bit:      8  Generic Clock Generator Enable           */
+    uint32_t IDC:1;                     /**< bit:      9  Improve Duty Cycle                       */
+    uint32_t OOV:1;                     /**< bit:     10  Output Off Value                         */
+    uint32_t OE:1;                      /**< bit:     11  Output Enable                            */
+    uint32_t DIVSEL:1;                  /**< bit:     12  Divide Selection                         */
+    uint32_t RUNSTDBY:1;                /**< bit:     13  Run in Standby                           */
+    uint32_t :2;                        /**< bit: 14..15  Reserved */
+    uint32_t DIV:16;                    /**< bit: 16..31  Division Factor                          */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GCLK_GENCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GCLK_GENCTRL_OFFSET                 (0x20)                                        /**<  (GCLK_GENCTRL) Generic Clock Generator Control  Offset */
+#define GCLK_GENCTRL_RESETVALUE             _U_(0x00)                                     /**<  (GCLK_GENCTRL) Generic Clock Generator Control  Reset Value */
+
+#define GCLK_GENCTRL_SRC_Pos                0                                              /**< (GCLK_GENCTRL) Source Select Position */
+#define GCLK_GENCTRL_SRC_Msk                (_U_(0x7) << GCLK_GENCTRL_SRC_Pos)             /**< (GCLK_GENCTRL) Source Select Mask */
+#define GCLK_GENCTRL_SRC(value)             (GCLK_GENCTRL_SRC_Msk & ((value) << GCLK_GENCTRL_SRC_Pos))
+#define   GCLK_GENCTRL_SRC_XOSC_Val         _U_(0x0)                                       /**< (GCLK_GENCTRL) XOSC oscillator output  */
+#define   GCLK_GENCTRL_SRC_GCLKIN_Val       _U_(0x1)                                       /**< (GCLK_GENCTRL) Generator input pad  */
+#define   GCLK_GENCTRL_SRC_GCLKGEN1_Val     _U_(0x2)                                       /**< (GCLK_GENCTRL) Generic clock generator 1 output  */
+#define   GCLK_GENCTRL_SRC_OSCULP32K_Val    _U_(0x3)                                       /**< (GCLK_GENCTRL) OSCULP32K oscillator output  */
+#define   GCLK_GENCTRL_SRC_XOSC32K_Val      _U_(0x4)                                       /**< (GCLK_GENCTRL) XOSC32K oscillator output  */
+#define   GCLK_GENCTRL_SRC_OSC16M_Val       _U_(0x5)                                       /**< (GCLK_GENCTRL) OSC16M oscillator output  */
+#define   GCLK_GENCTRL_SRC_DFLLULP_Val      _U_(0x6)                                       /**< (GCLK_GENCTRL) DFLLULP output  */
+#define   GCLK_GENCTRL_SRC_FDPLL96M_Val     _U_(0x7)                                       /**< (GCLK_GENCTRL) FDPLL output  */
+#define GCLK_GENCTRL_SRC_XOSC               (GCLK_GENCTRL_SRC_XOSC_Val << GCLK_GENCTRL_SRC_Pos)  /**< (GCLK_GENCTRL) XOSC oscillator output Position  */
+#define GCLK_GENCTRL_SRC_GCLKIN             (GCLK_GENCTRL_SRC_GCLKIN_Val << GCLK_GENCTRL_SRC_Pos)  /**< (GCLK_GENCTRL) Generator input pad Position  */
+#define GCLK_GENCTRL_SRC_GCLKGEN1           (GCLK_GENCTRL_SRC_GCLKGEN1_Val << GCLK_GENCTRL_SRC_Pos)  /**< (GCLK_GENCTRL) Generic clock generator 1 output Position  */
+#define GCLK_GENCTRL_SRC_OSCULP32K          (GCLK_GENCTRL_SRC_OSCULP32K_Val << GCLK_GENCTRL_SRC_Pos)  /**< (GCLK_GENCTRL) OSCULP32K oscillator output Position  */
+#define GCLK_GENCTRL_SRC_XOSC32K            (GCLK_GENCTRL_SRC_XOSC32K_Val << GCLK_GENCTRL_SRC_Pos)  /**< (GCLK_GENCTRL) XOSC32K oscillator output Position  */
+#define GCLK_GENCTRL_SRC_OSC16M             (GCLK_GENCTRL_SRC_OSC16M_Val << GCLK_GENCTRL_SRC_Pos)  /**< (GCLK_GENCTRL) OSC16M oscillator output Position  */
+#define GCLK_GENCTRL_SRC_DFLLULP            (GCLK_GENCTRL_SRC_DFLLULP_Val << GCLK_GENCTRL_SRC_Pos)  /**< (GCLK_GENCTRL) DFLLULP output Position  */
+#define GCLK_GENCTRL_SRC_FDPLL96M           (GCLK_GENCTRL_SRC_FDPLL96M_Val << GCLK_GENCTRL_SRC_Pos)  /**< (GCLK_GENCTRL) FDPLL output Position  */
+#define GCLK_GENCTRL_GENEN_Pos              8                                              /**< (GCLK_GENCTRL) Generic Clock Generator Enable Position */
+#define GCLK_GENCTRL_GENEN_Msk              (_U_(0x1) << GCLK_GENCTRL_GENEN_Pos)           /**< (GCLK_GENCTRL) Generic Clock Generator Enable Mask */
+#define GCLK_GENCTRL_GENEN                  GCLK_GENCTRL_GENEN_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use GCLK_GENCTRL_GENEN_Msk instead */
+#define GCLK_GENCTRL_IDC_Pos                9                                              /**< (GCLK_GENCTRL) Improve Duty Cycle Position */
+#define GCLK_GENCTRL_IDC_Msk                (_U_(0x1) << GCLK_GENCTRL_IDC_Pos)             /**< (GCLK_GENCTRL) Improve Duty Cycle Mask */
+#define GCLK_GENCTRL_IDC                    GCLK_GENCTRL_IDC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GCLK_GENCTRL_IDC_Msk instead */
+#define GCLK_GENCTRL_OOV_Pos                10                                             /**< (GCLK_GENCTRL) Output Off Value Position */
+#define GCLK_GENCTRL_OOV_Msk                (_U_(0x1) << GCLK_GENCTRL_OOV_Pos)             /**< (GCLK_GENCTRL) Output Off Value Mask */
+#define GCLK_GENCTRL_OOV                    GCLK_GENCTRL_OOV_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GCLK_GENCTRL_OOV_Msk instead */
+#define GCLK_GENCTRL_OE_Pos                 11                                             /**< (GCLK_GENCTRL) Output Enable Position */
+#define GCLK_GENCTRL_OE_Msk                 (_U_(0x1) << GCLK_GENCTRL_OE_Pos)              /**< (GCLK_GENCTRL) Output Enable Mask */
+#define GCLK_GENCTRL_OE                     GCLK_GENCTRL_OE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GCLK_GENCTRL_OE_Msk instead */
+#define GCLK_GENCTRL_DIVSEL_Pos             12                                             /**< (GCLK_GENCTRL) Divide Selection Position */
+#define GCLK_GENCTRL_DIVSEL_Msk             (_U_(0x1) << GCLK_GENCTRL_DIVSEL_Pos)          /**< (GCLK_GENCTRL) Divide Selection Mask */
+#define GCLK_GENCTRL_DIVSEL                 GCLK_GENCTRL_DIVSEL_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use GCLK_GENCTRL_DIVSEL_Msk instead */
+#define GCLK_GENCTRL_RUNSTDBY_Pos           13                                             /**< (GCLK_GENCTRL) Run in Standby Position */
+#define GCLK_GENCTRL_RUNSTDBY_Msk           (_U_(0x1) << GCLK_GENCTRL_RUNSTDBY_Pos)        /**< (GCLK_GENCTRL) Run in Standby Mask */
+#define GCLK_GENCTRL_RUNSTDBY               GCLK_GENCTRL_RUNSTDBY_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use GCLK_GENCTRL_RUNSTDBY_Msk instead */
+#define GCLK_GENCTRL_DIV_Pos                16                                             /**< (GCLK_GENCTRL) Division Factor Position */
+#define GCLK_GENCTRL_DIV_Msk                (_U_(0xFFFF) << GCLK_GENCTRL_DIV_Pos)          /**< (GCLK_GENCTRL) Division Factor Mask */
+#define GCLK_GENCTRL_DIV(value)             (GCLK_GENCTRL_DIV_Msk & ((value) << GCLK_GENCTRL_DIV_Pos))
+#define GCLK_GENCTRL_MASK                   _U_(0xFFFF3F07)                                /**< \deprecated (GCLK_GENCTRL) Register MASK  (Use GCLK_GENCTRL_Msk instead)  */
+#define GCLK_GENCTRL_Msk                    _U_(0xFFFF3F07)                                /**< (GCLK_GENCTRL) Register Mask  */
+
+
+/* -------- GCLK_PCHCTRL : (GCLK Offset: 0x80) (R/W 32) Peripheral Clock Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t GEN:3;                     /**< bit:   0..2  Generic Clock Generator                  */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t CHEN:1;                    /**< bit:      6  Channel Enable                           */
+    uint32_t WRTLOCK:1;                 /**< bit:      7  Write Lock                               */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GCLK_PCHCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GCLK_PCHCTRL_OFFSET                 (0x80)                                        /**<  (GCLK_PCHCTRL) Peripheral Clock Control  Offset */
+#define GCLK_PCHCTRL_RESETVALUE             _U_(0x00)                                     /**<  (GCLK_PCHCTRL) Peripheral Clock Control  Reset Value */
+
+#define GCLK_PCHCTRL_GEN_Pos                0                                              /**< (GCLK_PCHCTRL) Generic Clock Generator Position */
+#define GCLK_PCHCTRL_GEN_Msk                (_U_(0x7) << GCLK_PCHCTRL_GEN_Pos)             /**< (GCLK_PCHCTRL) Generic Clock Generator Mask */
+#define GCLK_PCHCTRL_GEN(value)             (GCLK_PCHCTRL_GEN_Msk & ((value) << GCLK_PCHCTRL_GEN_Pos))
+#define   GCLK_PCHCTRL_GEN_GCLK0_Val        _U_(0x0)                                       /**< (GCLK_PCHCTRL) Generic clock generator 0  */
+#define   GCLK_PCHCTRL_GEN_GCLK1_Val        _U_(0x1)                                       /**< (GCLK_PCHCTRL) Generic clock generator 1  */
+#define   GCLK_PCHCTRL_GEN_GCLK2_Val        _U_(0x2)                                       /**< (GCLK_PCHCTRL) Generic clock generator 2  */
+#define   GCLK_PCHCTRL_GEN_GCLK3_Val        _U_(0x3)                                       /**< (GCLK_PCHCTRL) Generic clock generator 3  */
+#define   GCLK_PCHCTRL_GEN_GCLK4_Val        _U_(0x4)                                       /**< (GCLK_PCHCTRL) Generic clock generator 4  */
+#define GCLK_PCHCTRL_GEN_GCLK0              (GCLK_PCHCTRL_GEN_GCLK0_Val << GCLK_PCHCTRL_GEN_Pos)  /**< (GCLK_PCHCTRL) Generic clock generator 0 Position  */
+#define GCLK_PCHCTRL_GEN_GCLK1              (GCLK_PCHCTRL_GEN_GCLK1_Val << GCLK_PCHCTRL_GEN_Pos)  /**< (GCLK_PCHCTRL) Generic clock generator 1 Position  */
+#define GCLK_PCHCTRL_GEN_GCLK2              (GCLK_PCHCTRL_GEN_GCLK2_Val << GCLK_PCHCTRL_GEN_Pos)  /**< (GCLK_PCHCTRL) Generic clock generator 2 Position  */
+#define GCLK_PCHCTRL_GEN_GCLK3              (GCLK_PCHCTRL_GEN_GCLK3_Val << GCLK_PCHCTRL_GEN_Pos)  /**< (GCLK_PCHCTRL) Generic clock generator 3 Position  */
+#define GCLK_PCHCTRL_GEN_GCLK4              (GCLK_PCHCTRL_GEN_GCLK4_Val << GCLK_PCHCTRL_GEN_Pos)  /**< (GCLK_PCHCTRL) Generic clock generator 4 Position  */
+#define GCLK_PCHCTRL_CHEN_Pos               6                                              /**< (GCLK_PCHCTRL) Channel Enable Position */
+#define GCLK_PCHCTRL_CHEN_Msk               (_U_(0x1) << GCLK_PCHCTRL_CHEN_Pos)            /**< (GCLK_PCHCTRL) Channel Enable Mask */
+#define GCLK_PCHCTRL_CHEN                   GCLK_PCHCTRL_CHEN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use GCLK_PCHCTRL_CHEN_Msk instead */
+#define GCLK_PCHCTRL_WRTLOCK_Pos            7                                              /**< (GCLK_PCHCTRL) Write Lock Position */
+#define GCLK_PCHCTRL_WRTLOCK_Msk            (_U_(0x1) << GCLK_PCHCTRL_WRTLOCK_Pos)         /**< (GCLK_PCHCTRL) Write Lock Mask */
+#define GCLK_PCHCTRL_WRTLOCK                GCLK_PCHCTRL_WRTLOCK_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use GCLK_PCHCTRL_WRTLOCK_Msk instead */
+#define GCLK_PCHCTRL_MASK                   _U_(0xC7)                                      /**< \deprecated (GCLK_PCHCTRL) Register MASK  (Use GCLK_PCHCTRL_Msk instead)  */
+#define GCLK_PCHCTRL_Msk                    _U_(0xC7)                                      /**< (GCLK_PCHCTRL) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief GCLK hardware registers */
+typedef struct {  /* Generic Clock Generator */
+  __IO GCLK_CTRLA_Type                CTRLA;          /**< Offset: 0x00 (R/W   8) Control */
+  __I  uint8_t                        Reserved1[3];
+  __I  GCLK_SYNCBUSY_Type             SYNCBUSY;       /**< Offset: 0x04 (R/   32) Synchronization Busy */
+  __I  uint8_t                        Reserved2[24];
+  __IO GCLK_GENCTRL_Type              GENCTRL[5];     /**< Offset: 0x20 (R/W  32) Generic Clock Generator Control */
+  __I  uint8_t                        Reserved3[76];
+  __IO GCLK_PCHCTRL_Type              PCHCTRL[21];    /**< Offset: 0x80 (R/W  32) Peripheral Clock Control */
+} Gclk;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Generic Clock Generator */
+
+#endif /* _SAML10_GCLK_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/component/idau.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/idau.h
@@ -1,0 +1,53 @@
+/**
+ * \file
+ *
+ * \brief Component description for IDAU
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_IDAU_COMPONENT_H_
+#define _SAML10_IDAU_COMPONENT_H_
+#define _SAML10_IDAU_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML10 Implementation Defined Attribution Unit
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR IDAU */
+/* ========================================================================== */
+
+#define IDAU_U2803                      /**< (IDAU) Module ID */
+#define REV_IDAU 0x100                  /**< (IDAU) Module revision */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief No hardware registers defined for IDAU */
+typedef void Idau;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Implementation Defined Attribution Unit */
+
+#endif /* _SAML10_IDAU_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/component/mclk.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/mclk.h
@@ -1,0 +1,416 @@
+/**
+ * \file
+ *
+ * \brief Component description for MCLK
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_MCLK_COMPONENT_H_
+#define _SAML10_MCLK_COMPONENT_H_
+#define _SAML10_MCLK_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML10 Main Clock
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR MCLK */
+/* ========================================================================== */
+
+#define MCLK_U2234                      /**< (MCLK) Module ID */
+#define REV_MCLK 0x300                  /**< (MCLK) Module revision */
+
+/* -------- MCLK_CTRLA : (MCLK Offset: 0x00) (R/W 8) Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  :2;                        /**< bit:   0..1  Reserved */
+    uint8_t  CKSEL:1;                   /**< bit:      2  Clock Select                             */
+    uint8_t  :5;                        /**< bit:   3..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} MCLK_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCLK_CTRLA_OFFSET                   (0x00)                                        /**<  (MCLK_CTRLA) Control  Offset */
+#define MCLK_CTRLA_RESETVALUE               _U_(0x00)                                     /**<  (MCLK_CTRLA) Control  Reset Value */
+
+#define MCLK_CTRLA_CKSEL_Pos                2                                              /**< (MCLK_CTRLA) Clock Select Position */
+#define MCLK_CTRLA_CKSEL_Msk                (_U_(0x1) << MCLK_CTRLA_CKSEL_Pos)             /**< (MCLK_CTRLA) Clock Select Mask */
+#define MCLK_CTRLA_CKSEL                    MCLK_CTRLA_CKSEL_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_CTRLA_CKSEL_Msk instead */
+#define MCLK_CTRLA_MASK                     _U_(0x04)                                      /**< \deprecated (MCLK_CTRLA) Register MASK  (Use MCLK_CTRLA_Msk instead)  */
+#define MCLK_CTRLA_Msk                      _U_(0x04)                                      /**< (MCLK_CTRLA) Register Mask  */
+
+
+/* -------- MCLK_INTENCLR : (MCLK Offset: 0x01) (R/W 8) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  CKRDY:1;                   /**< bit:      0  Clock Ready Interrupt Enable             */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} MCLK_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCLK_INTENCLR_OFFSET                (0x01)                                        /**<  (MCLK_INTENCLR) Interrupt Enable Clear  Offset */
+#define MCLK_INTENCLR_RESETVALUE            _U_(0x00)                                     /**<  (MCLK_INTENCLR) Interrupt Enable Clear  Reset Value */
+
+#define MCLK_INTENCLR_CKRDY_Pos             0                                              /**< (MCLK_INTENCLR) Clock Ready Interrupt Enable Position */
+#define MCLK_INTENCLR_CKRDY_Msk             (_U_(0x1) << MCLK_INTENCLR_CKRDY_Pos)          /**< (MCLK_INTENCLR) Clock Ready Interrupt Enable Mask */
+#define MCLK_INTENCLR_CKRDY                 MCLK_INTENCLR_CKRDY_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_INTENCLR_CKRDY_Msk instead */
+#define MCLK_INTENCLR_MASK                  _U_(0x01)                                      /**< \deprecated (MCLK_INTENCLR) Register MASK  (Use MCLK_INTENCLR_Msk instead)  */
+#define MCLK_INTENCLR_Msk                   _U_(0x01)                                      /**< (MCLK_INTENCLR) Register Mask  */
+
+
+/* -------- MCLK_INTENSET : (MCLK Offset: 0x02) (R/W 8) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  CKRDY:1;                   /**< bit:      0  Clock Ready Interrupt Enable             */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} MCLK_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCLK_INTENSET_OFFSET                (0x02)                                        /**<  (MCLK_INTENSET) Interrupt Enable Set  Offset */
+#define MCLK_INTENSET_RESETVALUE            _U_(0x00)                                     /**<  (MCLK_INTENSET) Interrupt Enable Set  Reset Value */
+
+#define MCLK_INTENSET_CKRDY_Pos             0                                              /**< (MCLK_INTENSET) Clock Ready Interrupt Enable Position */
+#define MCLK_INTENSET_CKRDY_Msk             (_U_(0x1) << MCLK_INTENSET_CKRDY_Pos)          /**< (MCLK_INTENSET) Clock Ready Interrupt Enable Mask */
+#define MCLK_INTENSET_CKRDY                 MCLK_INTENSET_CKRDY_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_INTENSET_CKRDY_Msk instead */
+#define MCLK_INTENSET_MASK                  _U_(0x01)                                      /**< \deprecated (MCLK_INTENSET) Register MASK  (Use MCLK_INTENSET_Msk instead)  */
+#define MCLK_INTENSET_Msk                   _U_(0x01)                                      /**< (MCLK_INTENSET) Register Mask  */
+
+
+/* -------- MCLK_INTFLAG : (MCLK Offset: 0x03) (R/W 8) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t CKRDY:1;                   /**< bit:      0  Clock Ready                              */
+    __I uint8_t :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} MCLK_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCLK_INTFLAG_OFFSET                 (0x03)                                        /**<  (MCLK_INTFLAG) Interrupt Flag Status and Clear  Offset */
+#define MCLK_INTFLAG_RESETVALUE             _U_(0x01)                                     /**<  (MCLK_INTFLAG) Interrupt Flag Status and Clear  Reset Value */
+
+#define MCLK_INTFLAG_CKRDY_Pos              0                                              /**< (MCLK_INTFLAG) Clock Ready Position */
+#define MCLK_INTFLAG_CKRDY_Msk              (_U_(0x1) << MCLK_INTFLAG_CKRDY_Pos)           /**< (MCLK_INTFLAG) Clock Ready Mask */
+#define MCLK_INTFLAG_CKRDY                  MCLK_INTFLAG_CKRDY_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_INTFLAG_CKRDY_Msk instead */
+#define MCLK_INTFLAG_MASK                   _U_(0x01)                                      /**< \deprecated (MCLK_INTFLAG) Register MASK  (Use MCLK_INTFLAG_Msk instead)  */
+#define MCLK_INTFLAG_Msk                    _U_(0x01)                                      /**< (MCLK_INTFLAG) Register Mask  */
+
+
+/* -------- MCLK_CPUDIV : (MCLK Offset: 0x04) (R/W 8) CPU Clock Division -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  CPUDIV:8;                  /**< bit:   0..7  CPU Clock Division Factor                */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} MCLK_CPUDIV_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCLK_CPUDIV_OFFSET                  (0x04)                                        /**<  (MCLK_CPUDIV) CPU Clock Division  Offset */
+#define MCLK_CPUDIV_RESETVALUE              _U_(0x01)                                     /**<  (MCLK_CPUDIV) CPU Clock Division  Reset Value */
+
+#define MCLK_CPUDIV_CPUDIV_Pos              0                                              /**< (MCLK_CPUDIV) CPU Clock Division Factor Position */
+#define MCLK_CPUDIV_CPUDIV_Msk              (_U_(0xFF) << MCLK_CPUDIV_CPUDIV_Pos)          /**< (MCLK_CPUDIV) CPU Clock Division Factor Mask */
+#define MCLK_CPUDIV_CPUDIV(value)           (MCLK_CPUDIV_CPUDIV_Msk & ((value) << MCLK_CPUDIV_CPUDIV_Pos))
+#define   MCLK_CPUDIV_CPUDIV_DIV1_Val       _U_(0x1)                                       /**< (MCLK_CPUDIV) Divide by 1  */
+#define   MCLK_CPUDIV_CPUDIV_DIV2_Val       _U_(0x2)                                       /**< (MCLK_CPUDIV) Divide by 2  */
+#define   MCLK_CPUDIV_CPUDIV_DIV4_Val       _U_(0x4)                                       /**< (MCLK_CPUDIV) Divide by 4  */
+#define   MCLK_CPUDIV_CPUDIV_DIV8_Val       _U_(0x8)                                       /**< (MCLK_CPUDIV) Divide by 8  */
+#define   MCLK_CPUDIV_CPUDIV_DIV16_Val      _U_(0x10)                                      /**< (MCLK_CPUDIV) Divide by 16  */
+#define   MCLK_CPUDIV_CPUDIV_DIV32_Val      _U_(0x20)                                      /**< (MCLK_CPUDIV) Divide by 32  */
+#define   MCLK_CPUDIV_CPUDIV_DIV64_Val      _U_(0x40)                                      /**< (MCLK_CPUDIV) Divide by 64  */
+#define   MCLK_CPUDIV_CPUDIV_DIV128_Val     _U_(0x80)                                      /**< (MCLK_CPUDIV) Divide by 128  */
+#define MCLK_CPUDIV_CPUDIV_DIV1             (MCLK_CPUDIV_CPUDIV_DIV1_Val << MCLK_CPUDIV_CPUDIV_Pos)  /**< (MCLK_CPUDIV) Divide by 1 Position  */
+#define MCLK_CPUDIV_CPUDIV_DIV2             (MCLK_CPUDIV_CPUDIV_DIV2_Val << MCLK_CPUDIV_CPUDIV_Pos)  /**< (MCLK_CPUDIV) Divide by 2 Position  */
+#define MCLK_CPUDIV_CPUDIV_DIV4             (MCLK_CPUDIV_CPUDIV_DIV4_Val << MCLK_CPUDIV_CPUDIV_Pos)  /**< (MCLK_CPUDIV) Divide by 4 Position  */
+#define MCLK_CPUDIV_CPUDIV_DIV8             (MCLK_CPUDIV_CPUDIV_DIV8_Val << MCLK_CPUDIV_CPUDIV_Pos)  /**< (MCLK_CPUDIV) Divide by 8 Position  */
+#define MCLK_CPUDIV_CPUDIV_DIV16            (MCLK_CPUDIV_CPUDIV_DIV16_Val << MCLK_CPUDIV_CPUDIV_Pos)  /**< (MCLK_CPUDIV) Divide by 16 Position  */
+#define MCLK_CPUDIV_CPUDIV_DIV32            (MCLK_CPUDIV_CPUDIV_DIV32_Val << MCLK_CPUDIV_CPUDIV_Pos)  /**< (MCLK_CPUDIV) Divide by 32 Position  */
+#define MCLK_CPUDIV_CPUDIV_DIV64            (MCLK_CPUDIV_CPUDIV_DIV64_Val << MCLK_CPUDIV_CPUDIV_Pos)  /**< (MCLK_CPUDIV) Divide by 64 Position  */
+#define MCLK_CPUDIV_CPUDIV_DIV128           (MCLK_CPUDIV_CPUDIV_DIV128_Val << MCLK_CPUDIV_CPUDIV_Pos)  /**< (MCLK_CPUDIV) Divide by 128 Position  */
+#define MCLK_CPUDIV_MASK                    _U_(0xFF)                                      /**< \deprecated (MCLK_CPUDIV) Register MASK  (Use MCLK_CPUDIV_Msk instead)  */
+#define MCLK_CPUDIV_Msk                     _U_(0xFF)                                      /**< (MCLK_CPUDIV) Register Mask  */
+
+
+/* -------- MCLK_AHBMASK : (MCLK Offset: 0x10) (R/W 32) AHB Mask -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t HPB0_:1;                   /**< bit:      0  HPB0 AHB Clock Mask                      */
+    uint32_t HPB1_:1;                   /**< bit:      1  HPB1 AHB Clock Mask                      */
+    uint32_t HPB2_:1;                   /**< bit:      2  HPB2 AHB Clock Mask                      */
+    uint32_t DMAC_:1;                   /**< bit:      3  DMAC AHB Clock Mask                      */
+    uint32_t DSU_:1;                    /**< bit:      4  DSU AHB Clock Mask                       */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t PAC_:1;                    /**< bit:      6  PAC AHB Clock Mask                       */
+    uint32_t NVMCTRL_:1;                /**< bit:      7  NVMCTRL AHB Clock Mask                   */
+    uint32_t :4;                        /**< bit:  8..11  Reserved */
+    uint32_t TRAM_:1;                   /**< bit:     12  TRAM AHB Clock Mask                      */
+    uint32_t :19;                       /**< bit: 13..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCLK_AHBMASK_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCLK_AHBMASK_OFFSET                 (0x10)                                        /**<  (MCLK_AHBMASK) AHB Mask  Offset */
+#define MCLK_AHBMASK_RESETVALUE             _U_(0x1FFF)                                   /**<  (MCLK_AHBMASK) AHB Mask  Reset Value */
+
+#define MCLK_AHBMASK_HPB0_Pos               0                                              /**< (MCLK_AHBMASK) HPB0 AHB Clock Mask Position */
+#define MCLK_AHBMASK_HPB0_Msk               (_U_(0x1) << MCLK_AHBMASK_HPB0_Pos)            /**< (MCLK_AHBMASK) HPB0 AHB Clock Mask Mask */
+#define MCLK_AHBMASK_HPB0                   MCLK_AHBMASK_HPB0_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_AHBMASK_HPB0_Msk instead */
+#define MCLK_AHBMASK_HPB1_Pos               1                                              /**< (MCLK_AHBMASK) HPB1 AHB Clock Mask Position */
+#define MCLK_AHBMASK_HPB1_Msk               (_U_(0x1) << MCLK_AHBMASK_HPB1_Pos)            /**< (MCLK_AHBMASK) HPB1 AHB Clock Mask Mask */
+#define MCLK_AHBMASK_HPB1                   MCLK_AHBMASK_HPB1_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_AHBMASK_HPB1_Msk instead */
+#define MCLK_AHBMASK_HPB2_Pos               2                                              /**< (MCLK_AHBMASK) HPB2 AHB Clock Mask Position */
+#define MCLK_AHBMASK_HPB2_Msk               (_U_(0x1) << MCLK_AHBMASK_HPB2_Pos)            /**< (MCLK_AHBMASK) HPB2 AHB Clock Mask Mask */
+#define MCLK_AHBMASK_HPB2                   MCLK_AHBMASK_HPB2_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_AHBMASK_HPB2_Msk instead */
+#define MCLK_AHBMASK_DMAC_Pos               3                                              /**< (MCLK_AHBMASK) DMAC AHB Clock Mask Position */
+#define MCLK_AHBMASK_DMAC_Msk               (_U_(0x1) << MCLK_AHBMASK_DMAC_Pos)            /**< (MCLK_AHBMASK) DMAC AHB Clock Mask Mask */
+#define MCLK_AHBMASK_DMAC                   MCLK_AHBMASK_DMAC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_AHBMASK_DMAC_Msk instead */
+#define MCLK_AHBMASK_DSU_Pos                4                                              /**< (MCLK_AHBMASK) DSU AHB Clock Mask Position */
+#define MCLK_AHBMASK_DSU_Msk                (_U_(0x1) << MCLK_AHBMASK_DSU_Pos)             /**< (MCLK_AHBMASK) DSU AHB Clock Mask Mask */
+#define MCLK_AHBMASK_DSU                    MCLK_AHBMASK_DSU_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_AHBMASK_DSU_Msk instead */
+#define MCLK_AHBMASK_PAC_Pos                6                                              /**< (MCLK_AHBMASK) PAC AHB Clock Mask Position */
+#define MCLK_AHBMASK_PAC_Msk                (_U_(0x1) << MCLK_AHBMASK_PAC_Pos)             /**< (MCLK_AHBMASK) PAC AHB Clock Mask Mask */
+#define MCLK_AHBMASK_PAC                    MCLK_AHBMASK_PAC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_AHBMASK_PAC_Msk instead */
+#define MCLK_AHBMASK_NVMCTRL_Pos            7                                              /**< (MCLK_AHBMASK) NVMCTRL AHB Clock Mask Position */
+#define MCLK_AHBMASK_NVMCTRL_Msk            (_U_(0x1) << MCLK_AHBMASK_NVMCTRL_Pos)         /**< (MCLK_AHBMASK) NVMCTRL AHB Clock Mask Mask */
+#define MCLK_AHBMASK_NVMCTRL                MCLK_AHBMASK_NVMCTRL_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_AHBMASK_NVMCTRL_Msk instead */
+#define MCLK_AHBMASK_TRAM_Pos               12                                             /**< (MCLK_AHBMASK) TRAM AHB Clock Mask Position */
+#define MCLK_AHBMASK_TRAM_Msk               (_U_(0x1) << MCLK_AHBMASK_TRAM_Pos)            /**< (MCLK_AHBMASK) TRAM AHB Clock Mask Mask */
+#define MCLK_AHBMASK_TRAM                   MCLK_AHBMASK_TRAM_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_AHBMASK_TRAM_Msk instead */
+#define MCLK_AHBMASK_MASK                   _U_(0x10DF)                                    /**< \deprecated (MCLK_AHBMASK) Register MASK  (Use MCLK_AHBMASK_Msk instead)  */
+#define MCLK_AHBMASK_Msk                    _U_(0x10DF)                                    /**< (MCLK_AHBMASK) Register Mask  */
+
+#define MCLK_AHBMASK_HPB_Pos                0                                              /**< (MCLK_AHBMASK Position) HPBx AHB Clock Mask */
+#define MCLK_AHBMASK_HPB_Msk                (_U_(0x7) << MCLK_AHBMASK_HPB_Pos)             /**< (MCLK_AHBMASK Mask) HPB */
+#define MCLK_AHBMASK_HPB(value)             (MCLK_AHBMASK_HPB_Msk & ((value) << MCLK_AHBMASK_HPB_Pos))  
+
+/* -------- MCLK_APBAMASK : (MCLK Offset: 0x14) (R/W 32) APBA Mask -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t PAC_:1;                    /**< bit:      0  PAC APB Clock Enable                     */
+    uint32_t PM_:1;                     /**< bit:      1  PM APB Clock Enable                      */
+    uint32_t MCLK_:1;                   /**< bit:      2  MCLK APB Clock Enable                    */
+    uint32_t RSTC_:1;                   /**< bit:      3  RSTC APB Clock Enable                    */
+    uint32_t OSCCTRL_:1;                /**< bit:      4  OSCCTRL APB Clock Enable                 */
+    uint32_t OSC32KCTRL_:1;             /**< bit:      5  OSC32KCTRL APB Clock Enable              */
+    uint32_t SUPC_:1;                   /**< bit:      6  SUPC APB Clock Enable                    */
+    uint32_t GCLK_:1;                   /**< bit:      7  GCLK APB Clock Enable                    */
+    uint32_t WDT_:1;                    /**< bit:      8  WDT APB Clock Enable                     */
+    uint32_t RTC_:1;                    /**< bit:      9  RTC APB Clock Enable                     */
+    uint32_t EIC_:1;                    /**< bit:     10  EIC APB Clock Enable                     */
+    uint32_t FREQM_:1;                  /**< bit:     11  FREQM APB Clock Enable                   */
+    uint32_t PORT_:1;                   /**< bit:     12  PORT APB Clock Enable                    */
+    uint32_t AC_:1;                     /**< bit:     13  AC APB Clock Enable                      */
+    uint32_t :18;                       /**< bit: 14..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCLK_APBAMASK_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCLK_APBAMASK_OFFSET                (0x14)                                        /**<  (MCLK_APBAMASK) APBA Mask  Offset */
+#define MCLK_APBAMASK_RESETVALUE            _U_(0x7FFF)                                   /**<  (MCLK_APBAMASK) APBA Mask  Reset Value */
+
+#define MCLK_APBAMASK_PAC_Pos               0                                              /**< (MCLK_APBAMASK) PAC APB Clock Enable Position */
+#define MCLK_APBAMASK_PAC_Msk               (_U_(0x1) << MCLK_APBAMASK_PAC_Pos)            /**< (MCLK_APBAMASK) PAC APB Clock Enable Mask */
+#define MCLK_APBAMASK_PAC                   MCLK_APBAMASK_PAC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBAMASK_PAC_Msk instead */
+#define MCLK_APBAMASK_PM_Pos                1                                              /**< (MCLK_APBAMASK) PM APB Clock Enable Position */
+#define MCLK_APBAMASK_PM_Msk                (_U_(0x1) << MCLK_APBAMASK_PM_Pos)             /**< (MCLK_APBAMASK) PM APB Clock Enable Mask */
+#define MCLK_APBAMASK_PM                    MCLK_APBAMASK_PM_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBAMASK_PM_Msk instead */
+#define MCLK_APBAMASK_MCLK_Pos              2                                              /**< (MCLK_APBAMASK) MCLK APB Clock Enable Position */
+#define MCLK_APBAMASK_MCLK_Msk              (_U_(0x1) << MCLK_APBAMASK_MCLK_Pos)           /**< (MCLK_APBAMASK) MCLK APB Clock Enable Mask */
+#define MCLK_APBAMASK_MCLK                  MCLK_APBAMASK_MCLK_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBAMASK_MCLK_Msk instead */
+#define MCLK_APBAMASK_RSTC_Pos              3                                              /**< (MCLK_APBAMASK) RSTC APB Clock Enable Position */
+#define MCLK_APBAMASK_RSTC_Msk              (_U_(0x1) << MCLK_APBAMASK_RSTC_Pos)           /**< (MCLK_APBAMASK) RSTC APB Clock Enable Mask */
+#define MCLK_APBAMASK_RSTC                  MCLK_APBAMASK_RSTC_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBAMASK_RSTC_Msk instead */
+#define MCLK_APBAMASK_OSCCTRL_Pos           4                                              /**< (MCLK_APBAMASK) OSCCTRL APB Clock Enable Position */
+#define MCLK_APBAMASK_OSCCTRL_Msk           (_U_(0x1) << MCLK_APBAMASK_OSCCTRL_Pos)        /**< (MCLK_APBAMASK) OSCCTRL APB Clock Enable Mask */
+#define MCLK_APBAMASK_OSCCTRL               MCLK_APBAMASK_OSCCTRL_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBAMASK_OSCCTRL_Msk instead */
+#define MCLK_APBAMASK_OSC32KCTRL_Pos        5                                              /**< (MCLK_APBAMASK) OSC32KCTRL APB Clock Enable Position */
+#define MCLK_APBAMASK_OSC32KCTRL_Msk        (_U_(0x1) << MCLK_APBAMASK_OSC32KCTRL_Pos)     /**< (MCLK_APBAMASK) OSC32KCTRL APB Clock Enable Mask */
+#define MCLK_APBAMASK_OSC32KCTRL            MCLK_APBAMASK_OSC32KCTRL_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBAMASK_OSC32KCTRL_Msk instead */
+#define MCLK_APBAMASK_SUPC_Pos              6                                              /**< (MCLK_APBAMASK) SUPC APB Clock Enable Position */
+#define MCLK_APBAMASK_SUPC_Msk              (_U_(0x1) << MCLK_APBAMASK_SUPC_Pos)           /**< (MCLK_APBAMASK) SUPC APB Clock Enable Mask */
+#define MCLK_APBAMASK_SUPC                  MCLK_APBAMASK_SUPC_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBAMASK_SUPC_Msk instead */
+#define MCLK_APBAMASK_GCLK_Pos              7                                              /**< (MCLK_APBAMASK) GCLK APB Clock Enable Position */
+#define MCLK_APBAMASK_GCLK_Msk              (_U_(0x1) << MCLK_APBAMASK_GCLK_Pos)           /**< (MCLK_APBAMASK) GCLK APB Clock Enable Mask */
+#define MCLK_APBAMASK_GCLK                  MCLK_APBAMASK_GCLK_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBAMASK_GCLK_Msk instead */
+#define MCLK_APBAMASK_WDT_Pos               8                                              /**< (MCLK_APBAMASK) WDT APB Clock Enable Position */
+#define MCLK_APBAMASK_WDT_Msk               (_U_(0x1) << MCLK_APBAMASK_WDT_Pos)            /**< (MCLK_APBAMASK) WDT APB Clock Enable Mask */
+#define MCLK_APBAMASK_WDT                   MCLK_APBAMASK_WDT_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBAMASK_WDT_Msk instead */
+#define MCLK_APBAMASK_RTC_Pos               9                                              /**< (MCLK_APBAMASK) RTC APB Clock Enable Position */
+#define MCLK_APBAMASK_RTC_Msk               (_U_(0x1) << MCLK_APBAMASK_RTC_Pos)            /**< (MCLK_APBAMASK) RTC APB Clock Enable Mask */
+#define MCLK_APBAMASK_RTC                   MCLK_APBAMASK_RTC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBAMASK_RTC_Msk instead */
+#define MCLK_APBAMASK_EIC_Pos               10                                             /**< (MCLK_APBAMASK) EIC APB Clock Enable Position */
+#define MCLK_APBAMASK_EIC_Msk               (_U_(0x1) << MCLK_APBAMASK_EIC_Pos)            /**< (MCLK_APBAMASK) EIC APB Clock Enable Mask */
+#define MCLK_APBAMASK_EIC                   MCLK_APBAMASK_EIC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBAMASK_EIC_Msk instead */
+#define MCLK_APBAMASK_FREQM_Pos             11                                             /**< (MCLK_APBAMASK) FREQM APB Clock Enable Position */
+#define MCLK_APBAMASK_FREQM_Msk             (_U_(0x1) << MCLK_APBAMASK_FREQM_Pos)          /**< (MCLK_APBAMASK) FREQM APB Clock Enable Mask */
+#define MCLK_APBAMASK_FREQM                 MCLK_APBAMASK_FREQM_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBAMASK_FREQM_Msk instead */
+#define MCLK_APBAMASK_PORT_Pos              12                                             /**< (MCLK_APBAMASK) PORT APB Clock Enable Position */
+#define MCLK_APBAMASK_PORT_Msk              (_U_(0x1) << MCLK_APBAMASK_PORT_Pos)           /**< (MCLK_APBAMASK) PORT APB Clock Enable Mask */
+#define MCLK_APBAMASK_PORT                  MCLK_APBAMASK_PORT_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBAMASK_PORT_Msk instead */
+#define MCLK_APBAMASK_AC_Pos                13                                             /**< (MCLK_APBAMASK) AC APB Clock Enable Position */
+#define MCLK_APBAMASK_AC_Msk                (_U_(0x1) << MCLK_APBAMASK_AC_Pos)             /**< (MCLK_APBAMASK) AC APB Clock Enable Mask */
+#define MCLK_APBAMASK_AC                    MCLK_APBAMASK_AC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBAMASK_AC_Msk instead */
+#define MCLK_APBAMASK_MASK                  _U_(0x3FFF)                                    /**< \deprecated (MCLK_APBAMASK) Register MASK  (Use MCLK_APBAMASK_Msk instead)  */
+#define MCLK_APBAMASK_Msk                   _U_(0x3FFF)                                    /**< (MCLK_APBAMASK) Register Mask  */
+
+
+/* -------- MCLK_APBBMASK : (MCLK Offset: 0x18) (R/W 32) APBB Mask -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t IDAU_:1;                   /**< bit:      0  IDAU APB Clock Enable                    */
+    uint32_t DSU_:1;                    /**< bit:      1  DSU APB Clock Enable                     */
+    uint32_t NVMCTRL_:1;                /**< bit:      2  NVMCTRL APB Clock Enable                 */
+    uint32_t :29;                       /**< bit:  3..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCLK_APBBMASK_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCLK_APBBMASK_OFFSET                (0x18)                                        /**<  (MCLK_APBBMASK) APBB Mask  Offset */
+#define MCLK_APBBMASK_RESETVALUE            _U_(0x17)                                     /**<  (MCLK_APBBMASK) APBB Mask  Reset Value */
+
+#define MCLK_APBBMASK_IDAU_Pos              0                                              /**< (MCLK_APBBMASK) IDAU APB Clock Enable Position */
+#define MCLK_APBBMASK_IDAU_Msk              (_U_(0x1) << MCLK_APBBMASK_IDAU_Pos)           /**< (MCLK_APBBMASK) IDAU APB Clock Enable Mask */
+#define MCLK_APBBMASK_IDAU                  MCLK_APBBMASK_IDAU_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBBMASK_IDAU_Msk instead */
+#define MCLK_APBBMASK_DSU_Pos               1                                              /**< (MCLK_APBBMASK) DSU APB Clock Enable Position */
+#define MCLK_APBBMASK_DSU_Msk               (_U_(0x1) << MCLK_APBBMASK_DSU_Pos)            /**< (MCLK_APBBMASK) DSU APB Clock Enable Mask */
+#define MCLK_APBBMASK_DSU                   MCLK_APBBMASK_DSU_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBBMASK_DSU_Msk instead */
+#define MCLK_APBBMASK_NVMCTRL_Pos           2                                              /**< (MCLK_APBBMASK) NVMCTRL APB Clock Enable Position */
+#define MCLK_APBBMASK_NVMCTRL_Msk           (_U_(0x1) << MCLK_APBBMASK_NVMCTRL_Pos)        /**< (MCLK_APBBMASK) NVMCTRL APB Clock Enable Mask */
+#define MCLK_APBBMASK_NVMCTRL               MCLK_APBBMASK_NVMCTRL_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBBMASK_NVMCTRL_Msk instead */
+#define MCLK_APBBMASK_MASK                  _U_(0x07)                                      /**< \deprecated (MCLK_APBBMASK) Register MASK  (Use MCLK_APBBMASK_Msk instead)  */
+#define MCLK_APBBMASK_Msk                   _U_(0x07)                                      /**< (MCLK_APBBMASK) Register Mask  */
+
+
+/* -------- MCLK_APBCMASK : (MCLK Offset: 0x1c) (R/W 32) APBC Mask -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t EVSYS_:1;                  /**< bit:      0  EVSYS APB Clock Enable                   */
+    uint32_t SERCOM0_:1;                /**< bit:      1  SERCOM0 APB Clock Enable                 */
+    uint32_t SERCOM1_:1;                /**< bit:      2  SERCOM1 APB Clock Enable                 */
+    uint32_t SERCOM2_:1;                /**< bit:      3  SERCOM2 APB Clock Enable                 */
+    uint32_t TC0_:1;                    /**< bit:      4  TC0 APB Clock Enable                     */
+    uint32_t TC1_:1;                    /**< bit:      5  TC1 APB Clock Enable                     */
+    uint32_t TC2_:1;                    /**< bit:      6  TC2 APB Clock Enable                     */
+    uint32_t ADC_:1;                    /**< bit:      7  ADC APB Clock Enable                     */
+    uint32_t DAC_:1;                    /**< bit:      8  DAC APB Clock Enable                     */
+    uint32_t PTC_:1;                    /**< bit:      9  PTC APB Clock Enable                     */
+    uint32_t TRNG_:1;                   /**< bit:     10  TRNG APB Clock Enable                    */
+    uint32_t CCL_:1;                    /**< bit:     11  CCL APB Clock Enable                     */
+    uint32_t OPAMP_:1;                  /**< bit:     12  OPAMP APB Clock Enable                   */
+    uint32_t :19;                       /**< bit: 13..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCLK_APBCMASK_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCLK_APBCMASK_OFFSET                (0x1C)                                        /**<  (MCLK_APBCMASK) APBC Mask  Offset */
+#define MCLK_APBCMASK_RESETVALUE            _U_(0x1FFF)                                   /**<  (MCLK_APBCMASK) APBC Mask  Reset Value */
+
+#define MCLK_APBCMASK_EVSYS_Pos             0                                              /**< (MCLK_APBCMASK) EVSYS APB Clock Enable Position */
+#define MCLK_APBCMASK_EVSYS_Msk             (_U_(0x1) << MCLK_APBCMASK_EVSYS_Pos)          /**< (MCLK_APBCMASK) EVSYS APB Clock Enable Mask */
+#define MCLK_APBCMASK_EVSYS                 MCLK_APBCMASK_EVSYS_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBCMASK_EVSYS_Msk instead */
+#define MCLK_APBCMASK_SERCOM0_Pos           1                                              /**< (MCLK_APBCMASK) SERCOM0 APB Clock Enable Position */
+#define MCLK_APBCMASK_SERCOM0_Msk           (_U_(0x1) << MCLK_APBCMASK_SERCOM0_Pos)        /**< (MCLK_APBCMASK) SERCOM0 APB Clock Enable Mask */
+#define MCLK_APBCMASK_SERCOM0               MCLK_APBCMASK_SERCOM0_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBCMASK_SERCOM0_Msk instead */
+#define MCLK_APBCMASK_SERCOM1_Pos           2                                              /**< (MCLK_APBCMASK) SERCOM1 APB Clock Enable Position */
+#define MCLK_APBCMASK_SERCOM1_Msk           (_U_(0x1) << MCLK_APBCMASK_SERCOM1_Pos)        /**< (MCLK_APBCMASK) SERCOM1 APB Clock Enable Mask */
+#define MCLK_APBCMASK_SERCOM1               MCLK_APBCMASK_SERCOM1_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBCMASK_SERCOM1_Msk instead */
+#define MCLK_APBCMASK_SERCOM2_Pos           3                                              /**< (MCLK_APBCMASK) SERCOM2 APB Clock Enable Position */
+#define MCLK_APBCMASK_SERCOM2_Msk           (_U_(0x1) << MCLK_APBCMASK_SERCOM2_Pos)        /**< (MCLK_APBCMASK) SERCOM2 APB Clock Enable Mask */
+#define MCLK_APBCMASK_SERCOM2               MCLK_APBCMASK_SERCOM2_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBCMASK_SERCOM2_Msk instead */
+#define MCLK_APBCMASK_TC0_Pos               4                                              /**< (MCLK_APBCMASK) TC0 APB Clock Enable Position */
+#define MCLK_APBCMASK_TC0_Msk               (_U_(0x1) << MCLK_APBCMASK_TC0_Pos)            /**< (MCLK_APBCMASK) TC0 APB Clock Enable Mask */
+#define MCLK_APBCMASK_TC0                   MCLK_APBCMASK_TC0_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBCMASK_TC0_Msk instead */
+#define MCLK_APBCMASK_TC1_Pos               5                                              /**< (MCLK_APBCMASK) TC1 APB Clock Enable Position */
+#define MCLK_APBCMASK_TC1_Msk               (_U_(0x1) << MCLK_APBCMASK_TC1_Pos)            /**< (MCLK_APBCMASK) TC1 APB Clock Enable Mask */
+#define MCLK_APBCMASK_TC1                   MCLK_APBCMASK_TC1_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBCMASK_TC1_Msk instead */
+#define MCLK_APBCMASK_TC2_Pos               6                                              /**< (MCLK_APBCMASK) TC2 APB Clock Enable Position */
+#define MCLK_APBCMASK_TC2_Msk               (_U_(0x1) << MCLK_APBCMASK_TC2_Pos)            /**< (MCLK_APBCMASK) TC2 APB Clock Enable Mask */
+#define MCLK_APBCMASK_TC2                   MCLK_APBCMASK_TC2_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBCMASK_TC2_Msk instead */
+#define MCLK_APBCMASK_ADC_Pos               7                                              /**< (MCLK_APBCMASK) ADC APB Clock Enable Position */
+#define MCLK_APBCMASK_ADC_Msk               (_U_(0x1) << MCLK_APBCMASK_ADC_Pos)            /**< (MCLK_APBCMASK) ADC APB Clock Enable Mask */
+#define MCLK_APBCMASK_ADC                   MCLK_APBCMASK_ADC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBCMASK_ADC_Msk instead */
+#define MCLK_APBCMASK_DAC_Pos               8                                              /**< (MCLK_APBCMASK) DAC APB Clock Enable Position */
+#define MCLK_APBCMASK_DAC_Msk               (_U_(0x1) << MCLK_APBCMASK_DAC_Pos)            /**< (MCLK_APBCMASK) DAC APB Clock Enable Mask */
+#define MCLK_APBCMASK_DAC                   MCLK_APBCMASK_DAC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBCMASK_DAC_Msk instead */
+#define MCLK_APBCMASK_PTC_Pos               9                                              /**< (MCLK_APBCMASK) PTC APB Clock Enable Position */
+#define MCLK_APBCMASK_PTC_Msk               (_U_(0x1) << MCLK_APBCMASK_PTC_Pos)            /**< (MCLK_APBCMASK) PTC APB Clock Enable Mask */
+#define MCLK_APBCMASK_PTC                   MCLK_APBCMASK_PTC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBCMASK_PTC_Msk instead */
+#define MCLK_APBCMASK_TRNG_Pos              10                                             /**< (MCLK_APBCMASK) TRNG APB Clock Enable Position */
+#define MCLK_APBCMASK_TRNG_Msk              (_U_(0x1) << MCLK_APBCMASK_TRNG_Pos)           /**< (MCLK_APBCMASK) TRNG APB Clock Enable Mask */
+#define MCLK_APBCMASK_TRNG                  MCLK_APBCMASK_TRNG_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBCMASK_TRNG_Msk instead */
+#define MCLK_APBCMASK_CCL_Pos               11                                             /**< (MCLK_APBCMASK) CCL APB Clock Enable Position */
+#define MCLK_APBCMASK_CCL_Msk               (_U_(0x1) << MCLK_APBCMASK_CCL_Pos)            /**< (MCLK_APBCMASK) CCL APB Clock Enable Mask */
+#define MCLK_APBCMASK_CCL                   MCLK_APBCMASK_CCL_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBCMASK_CCL_Msk instead */
+#define MCLK_APBCMASK_OPAMP_Pos             12                                             /**< (MCLK_APBCMASK) OPAMP APB Clock Enable Position */
+#define MCLK_APBCMASK_OPAMP_Msk             (_U_(0x1) << MCLK_APBCMASK_OPAMP_Pos)          /**< (MCLK_APBCMASK) OPAMP APB Clock Enable Mask */
+#define MCLK_APBCMASK_OPAMP                 MCLK_APBCMASK_OPAMP_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBCMASK_OPAMP_Msk instead */
+#define MCLK_APBCMASK_MASK                  _U_(0x1FFF)                                    /**< \deprecated (MCLK_APBCMASK) Register MASK  (Use MCLK_APBCMASK_Msk instead)  */
+#define MCLK_APBCMASK_Msk                   _U_(0x1FFF)                                    /**< (MCLK_APBCMASK) Register Mask  */
+
+#define MCLK_APBCMASK_SERCOM_Pos            1                                              /**< (MCLK_APBCMASK Position) SERCOMx APB Clock Enable */
+#define MCLK_APBCMASK_SERCOM_Msk            (_U_(0x7) << MCLK_APBCMASK_SERCOM_Pos)         /**< (MCLK_APBCMASK Mask) SERCOM */
+#define MCLK_APBCMASK_SERCOM(value)         (MCLK_APBCMASK_SERCOM_Msk & ((value) << MCLK_APBCMASK_SERCOM_Pos))  
+#define MCLK_APBCMASK_TC_Pos                4                                              /**< (MCLK_APBCMASK Position) TCx APB Clock Enable */
+#define MCLK_APBCMASK_TC_Msk                (_U_(0x7) << MCLK_APBCMASK_TC_Pos)             /**< (MCLK_APBCMASK Mask) TC */
+#define MCLK_APBCMASK_TC(value)             (MCLK_APBCMASK_TC_Msk & ((value) << MCLK_APBCMASK_TC_Pos))  
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief MCLK hardware registers */
+typedef struct {  /* Main Clock */
+  __IO MCLK_CTRLA_Type                CTRLA;          /**< Offset: 0x00 (R/W   8) Control */
+  __IO MCLK_INTENCLR_Type             INTENCLR;       /**< Offset: 0x01 (R/W   8) Interrupt Enable Clear */
+  __IO MCLK_INTENSET_Type             INTENSET;       /**< Offset: 0x02 (R/W   8) Interrupt Enable Set */
+  __IO MCLK_INTFLAG_Type              INTFLAG;        /**< Offset: 0x03 (R/W   8) Interrupt Flag Status and Clear */
+  __IO MCLK_CPUDIV_Type               CPUDIV;         /**< Offset: 0x04 (R/W   8) CPU Clock Division */
+  __I  uint8_t                        Reserved1[11];
+  __IO MCLK_AHBMASK_Type              AHBMASK;        /**< Offset: 0x10 (R/W  32) AHB Mask */
+  __IO MCLK_APBAMASK_Type             APBAMASK;       /**< Offset: 0x14 (R/W  32) APBA Mask */
+  __IO MCLK_APBBMASK_Type             APBBMASK;       /**< Offset: 0x18 (R/W  32) APBB Mask */
+  __IO MCLK_APBCMASK_Type             APBCMASK;       /**< Offset: 0x1C (R/W  32) APBC Mask */
+} Mclk;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Main Clock */
+
+#endif /* _SAML10_MCLK_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/component/nvmctrl.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/nvmctrl.h
@@ -1,0 +1,1051 @@
+/**
+ * \file
+ *
+ * \brief Component description for NVMCTRL
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_NVMCTRL_COMPONENT_H_
+#define _SAML10_NVMCTRL_COMPONENT_H_
+#define _SAML10_NVMCTRL_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML10 Non-Volatile Memory Controller
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR NVMCTRL */
+/* ========================================================================== */
+
+#define NVMCTRL_U2802                      /**< (NVMCTRL) Module ID */
+#define REV_NVMCTRL 0x100                  /**< (NVMCTRL) Module revision */
+
+/* -------- NVMCTRL_CTRLA : (NVMCTRL Offset: 0x00) (/W 16) Control A -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t CMD:7;                     /**< bit:   0..6  Command                                  */
+    uint16_t :1;                        /**< bit:      7  Reserved */
+    uint16_t CMDEX:8;                   /**< bit:  8..15  Command Execution                        */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} NVMCTRL_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_CTRLA_OFFSET                (0x00)                                        /**<  (NVMCTRL_CTRLA) Control A  Offset */
+#define NVMCTRL_CTRLA_RESETVALUE            _U_(0x00)                                     /**<  (NVMCTRL_CTRLA) Control A  Reset Value */
+
+#define NVMCTRL_CTRLA_CMD_Pos               0                                              /**< (NVMCTRL_CTRLA) Command Position */
+#define NVMCTRL_CTRLA_CMD_Msk               (_U_(0x7F) << NVMCTRL_CTRLA_CMD_Pos)           /**< (NVMCTRL_CTRLA) Command Mask */
+#define NVMCTRL_CTRLA_CMD(value)            (NVMCTRL_CTRLA_CMD_Msk & ((value) << NVMCTRL_CTRLA_CMD_Pos))
+#define   NVMCTRL_CTRLA_CMD_ER_Val          _U_(0x2)                                       /**< (NVMCTRL_CTRLA) Erase Row - Erases the row addressed by the ADDR register.  */
+#define   NVMCTRL_CTRLA_CMD_WP_Val          _U_(0x4)                                       /**< (NVMCTRL_CTRLA) Write Page - Writes the contents of the page buffer to the page addressed by the ADDR register.  */
+#define   NVMCTRL_CTRLA_CMD_SPRM_Val        _U_(0x42)                                      /**< (NVMCTRL_CTRLA) Sets the power reduction mode.  */
+#define   NVMCTRL_CTRLA_CMD_CPRM_Val        _U_(0x43)                                      /**< (NVMCTRL_CTRLA) Clears the power reduction mode.  */
+#define   NVMCTRL_CTRLA_CMD_PBC_Val         _U_(0x44)                                      /**< (NVMCTRL_CTRLA) Page Buffer Clear - Clears the page buffer.  */
+#define   NVMCTRL_CTRLA_CMD_INVALL_Val      _U_(0x46)                                      /**< (NVMCTRL_CTRLA) Invalidate all cache lines.  */
+#define   NVMCTRL_CTRLA_CMD_SDAL0_Val       _U_(0x4B)                                      /**< (NVMCTRL_CTRLA) Set DAL=0  */
+#define   NVMCTRL_CTRLA_CMD_SDAL1_Val       _U_(0x4C)                                      /**< (NVMCTRL_CTRLA) Set DAL=1  */
+#define NVMCTRL_CTRLA_CMD_ER                (NVMCTRL_CTRLA_CMD_ER_Val << NVMCTRL_CTRLA_CMD_Pos)  /**< (NVMCTRL_CTRLA) Erase Row - Erases the row addressed by the ADDR register. Position  */
+#define NVMCTRL_CTRLA_CMD_WP                (NVMCTRL_CTRLA_CMD_WP_Val << NVMCTRL_CTRLA_CMD_Pos)  /**< (NVMCTRL_CTRLA) Write Page - Writes the contents of the page buffer to the page addressed by the ADDR register. Position  */
+#define NVMCTRL_CTRLA_CMD_SPRM              (NVMCTRL_CTRLA_CMD_SPRM_Val << NVMCTRL_CTRLA_CMD_Pos)  /**< (NVMCTRL_CTRLA) Sets the power reduction mode. Position  */
+#define NVMCTRL_CTRLA_CMD_CPRM              (NVMCTRL_CTRLA_CMD_CPRM_Val << NVMCTRL_CTRLA_CMD_Pos)  /**< (NVMCTRL_CTRLA) Clears the power reduction mode. Position  */
+#define NVMCTRL_CTRLA_CMD_PBC               (NVMCTRL_CTRLA_CMD_PBC_Val << NVMCTRL_CTRLA_CMD_Pos)  /**< (NVMCTRL_CTRLA) Page Buffer Clear - Clears the page buffer. Position  */
+#define NVMCTRL_CTRLA_CMD_INVALL            (NVMCTRL_CTRLA_CMD_INVALL_Val << NVMCTRL_CTRLA_CMD_Pos)  /**< (NVMCTRL_CTRLA) Invalidate all cache lines. Position  */
+#define NVMCTRL_CTRLA_CMD_SDAL0             (NVMCTRL_CTRLA_CMD_SDAL0_Val << NVMCTRL_CTRLA_CMD_Pos)  /**< (NVMCTRL_CTRLA) Set DAL=0 Position  */
+#define NVMCTRL_CTRLA_CMD_SDAL1             (NVMCTRL_CTRLA_CMD_SDAL1_Val << NVMCTRL_CTRLA_CMD_Pos)  /**< (NVMCTRL_CTRLA) Set DAL=1 Position  */
+#define NVMCTRL_CTRLA_CMDEX_Pos             8                                              /**< (NVMCTRL_CTRLA) Command Execution Position */
+#define NVMCTRL_CTRLA_CMDEX_Msk             (_U_(0xFF) << NVMCTRL_CTRLA_CMDEX_Pos)         /**< (NVMCTRL_CTRLA) Command Execution Mask */
+#define NVMCTRL_CTRLA_CMDEX(value)          (NVMCTRL_CTRLA_CMDEX_Msk & ((value) << NVMCTRL_CTRLA_CMDEX_Pos))
+#define   NVMCTRL_CTRLA_CMDEX_KEY_Val       _U_(0xA5)                                      /**< (NVMCTRL_CTRLA) Execution Key  */
+#define NVMCTRL_CTRLA_CMDEX_KEY             (NVMCTRL_CTRLA_CMDEX_KEY_Val << NVMCTRL_CTRLA_CMDEX_Pos)  /**< (NVMCTRL_CTRLA) Execution Key Position  */
+#define NVMCTRL_CTRLA_MASK                  _U_(0xFF7F)                                    /**< \deprecated (NVMCTRL_CTRLA) Register MASK  (Use NVMCTRL_CTRLA_Msk instead)  */
+#define NVMCTRL_CTRLA_Msk                   _U_(0xFF7F)                                    /**< (NVMCTRL_CTRLA) Register Mask  */
+
+
+/* -------- NVMCTRL_CTRLB : (NVMCTRL Offset: 0x04) (R/W 32) Control B -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t RWS:4;                     /**< bit:   1..4  NVM Read Wait States                     */
+    uint32_t :3;                        /**< bit:   5..7  Reserved */
+    uint32_t SLEEPPRM:2;                /**< bit:   8..9  Power Reduction Mode during Sleep        */
+    uint32_t :1;                        /**< bit:     10  Reserved */
+    uint32_t FWUP:1;                    /**< bit:     11  fast wake-up                             */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t READMODE:2;                /**< bit: 16..17  NVMCTRL Read Mode                        */
+    uint32_t CACHEDIS:1;                /**< bit:     18  Cache Disable                            */
+    uint32_t QWEN:1;                    /**< bit:     19  Quick Write Enable                       */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} NVMCTRL_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_CTRLB_OFFSET                (0x04)                                        /**<  (NVMCTRL_CTRLB) Control B  Offset */
+#define NVMCTRL_CTRLB_RESETVALUE            _U_(0x00)                                     /**<  (NVMCTRL_CTRLB) Control B  Reset Value */
+
+#define NVMCTRL_CTRLB_RWS_Pos               1                                              /**< (NVMCTRL_CTRLB) NVM Read Wait States Position */
+#define NVMCTRL_CTRLB_RWS_Msk               (_U_(0xF) << NVMCTRL_CTRLB_RWS_Pos)            /**< (NVMCTRL_CTRLB) NVM Read Wait States Mask */
+#define NVMCTRL_CTRLB_RWS(value)            (NVMCTRL_CTRLB_RWS_Msk & ((value) << NVMCTRL_CTRLB_RWS_Pos))
+#define NVMCTRL_CTRLB_SLEEPPRM_Pos          8                                              /**< (NVMCTRL_CTRLB) Power Reduction Mode during Sleep Position */
+#define NVMCTRL_CTRLB_SLEEPPRM_Msk          (_U_(0x3) << NVMCTRL_CTRLB_SLEEPPRM_Pos)       /**< (NVMCTRL_CTRLB) Power Reduction Mode during Sleep Mask */
+#define NVMCTRL_CTRLB_SLEEPPRM(value)       (NVMCTRL_CTRLB_SLEEPPRM_Msk & ((value) << NVMCTRL_CTRLB_SLEEPPRM_Pos))
+#define   NVMCTRL_CTRLB_SLEEPPRM_WAKEONACCESS_Val _U_(0x0)                                       /**< (NVMCTRL_CTRLB) NVM block enters low-power mode when entering sleep.NVM block exits low-power mode upon first access.  */
+#define   NVMCTRL_CTRLB_SLEEPPRM_WAKEUPINSTANT_Val _U_(0x1)                                       /**< (NVMCTRL_CTRLB) NVM block enters low-power mode when entering sleep.NVM block exits low-power mode when exiting sleep.  */
+#define   NVMCTRL_CTRLB_SLEEPPRM_DISABLED_Val _U_(0x3)                                       /**< (NVMCTRL_CTRLB) Auto power reduction disabled.  */
+#define NVMCTRL_CTRLB_SLEEPPRM_WAKEONACCESS (NVMCTRL_CTRLB_SLEEPPRM_WAKEONACCESS_Val << NVMCTRL_CTRLB_SLEEPPRM_Pos)  /**< (NVMCTRL_CTRLB) NVM block enters low-power mode when entering sleep.NVM block exits low-power mode upon first access. Position  */
+#define NVMCTRL_CTRLB_SLEEPPRM_WAKEUPINSTANT (NVMCTRL_CTRLB_SLEEPPRM_WAKEUPINSTANT_Val << NVMCTRL_CTRLB_SLEEPPRM_Pos)  /**< (NVMCTRL_CTRLB) NVM block enters low-power mode when entering sleep.NVM block exits low-power mode when exiting sleep. Position  */
+#define NVMCTRL_CTRLB_SLEEPPRM_DISABLED     (NVMCTRL_CTRLB_SLEEPPRM_DISABLED_Val << NVMCTRL_CTRLB_SLEEPPRM_Pos)  /**< (NVMCTRL_CTRLB) Auto power reduction disabled. Position  */
+#define NVMCTRL_CTRLB_FWUP_Pos              11                                             /**< (NVMCTRL_CTRLB) fast wake-up Position */
+#define NVMCTRL_CTRLB_FWUP_Msk              (_U_(0x1) << NVMCTRL_CTRLB_FWUP_Pos)           /**< (NVMCTRL_CTRLB) fast wake-up Mask */
+#define NVMCTRL_CTRLB_FWUP                  NVMCTRL_CTRLB_FWUP_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_CTRLB_FWUP_Msk instead */
+#define NVMCTRL_CTRLB_READMODE_Pos          16                                             /**< (NVMCTRL_CTRLB) NVMCTRL Read Mode Position */
+#define NVMCTRL_CTRLB_READMODE_Msk          (_U_(0x3) << NVMCTRL_CTRLB_READMODE_Pos)       /**< (NVMCTRL_CTRLB) NVMCTRL Read Mode Mask */
+#define NVMCTRL_CTRLB_READMODE(value)       (NVMCTRL_CTRLB_READMODE_Msk & ((value) << NVMCTRL_CTRLB_READMODE_Pos))
+#define   NVMCTRL_CTRLB_READMODE_NO_MISS_PENALTY_Val _U_(0x0)                                       /**< (NVMCTRL_CTRLB) The NVM Controller (cache system) does not insert wait states on a cache miss. Gives the best system performance.  */
+#define   NVMCTRL_CTRLB_READMODE_LOW_POWER_Val _U_(0x1)                                       /**< (NVMCTRL_CTRLB) Reduces power consumption of the cache system, but inserts a wait state each time there is a cache miss. This mode may not be relevant if CPU performance is required, as the application will be stalled and may lead to increase run time.  */
+#define   NVMCTRL_CTRLB_READMODE_DETERMINISTIC_Val _U_(0x2)                                       /**< (NVMCTRL_CTRLB) The cache system ensures that a cache hit or miss takes the same amount of time, determined by the number of programmed flash wait states. This mode can be used for real-time applications that require deterministic execution timings.  */
+#define NVMCTRL_CTRLB_READMODE_NO_MISS_PENALTY (NVMCTRL_CTRLB_READMODE_NO_MISS_PENALTY_Val << NVMCTRL_CTRLB_READMODE_Pos)  /**< (NVMCTRL_CTRLB) The NVM Controller (cache system) does not insert wait states on a cache miss. Gives the best system performance. Position  */
+#define NVMCTRL_CTRLB_READMODE_LOW_POWER    (NVMCTRL_CTRLB_READMODE_LOW_POWER_Val << NVMCTRL_CTRLB_READMODE_Pos)  /**< (NVMCTRL_CTRLB) Reduces power consumption of the cache system, but inserts a wait state each time there is a cache miss. This mode may not be relevant if CPU performance is required, as the application will be stalled and may lead to increase run time. Position  */
+#define NVMCTRL_CTRLB_READMODE_DETERMINISTIC (NVMCTRL_CTRLB_READMODE_DETERMINISTIC_Val << NVMCTRL_CTRLB_READMODE_Pos)  /**< (NVMCTRL_CTRLB) The cache system ensures that a cache hit or miss takes the same amount of time, determined by the number of programmed flash wait states. This mode can be used for real-time applications that require deterministic execution timings. Position  */
+#define NVMCTRL_CTRLB_CACHEDIS_Pos          18                                             /**< (NVMCTRL_CTRLB) Cache Disable Position */
+#define NVMCTRL_CTRLB_CACHEDIS_Msk          (_U_(0x1) << NVMCTRL_CTRLB_CACHEDIS_Pos)       /**< (NVMCTRL_CTRLB) Cache Disable Mask */
+#define NVMCTRL_CTRLB_CACHEDIS              NVMCTRL_CTRLB_CACHEDIS_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_CTRLB_CACHEDIS_Msk instead */
+#define NVMCTRL_CTRLB_QWEN_Pos              19                                             /**< (NVMCTRL_CTRLB) Quick Write Enable Position */
+#define NVMCTRL_CTRLB_QWEN_Msk              (_U_(0x1) << NVMCTRL_CTRLB_QWEN_Pos)           /**< (NVMCTRL_CTRLB) Quick Write Enable Mask */
+#define NVMCTRL_CTRLB_QWEN                  NVMCTRL_CTRLB_QWEN_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_CTRLB_QWEN_Msk instead */
+#define NVMCTRL_CTRLB_MASK                  _U_(0xF0B1E)                                   /**< \deprecated (NVMCTRL_CTRLB) Register MASK  (Use NVMCTRL_CTRLB_Msk instead)  */
+#define NVMCTRL_CTRLB_Msk                   _U_(0xF0B1E)                                   /**< (NVMCTRL_CTRLB) Register Mask  */
+
+
+/* -------- NVMCTRL_CTRLC : (NVMCTRL Offset: 0x08) (R/W 8) Control C -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  MANW:1;                    /**< bit:      0  Manual Write                             */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} NVMCTRL_CTRLC_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_CTRLC_OFFSET                (0x08)                                        /**<  (NVMCTRL_CTRLC) Control C  Offset */
+#define NVMCTRL_CTRLC_RESETVALUE            _U_(0x01)                                     /**<  (NVMCTRL_CTRLC) Control C  Reset Value */
+
+#define NVMCTRL_CTRLC_MANW_Pos              0                                              /**< (NVMCTRL_CTRLC) Manual Write Position */
+#define NVMCTRL_CTRLC_MANW_Msk              (_U_(0x1) << NVMCTRL_CTRLC_MANW_Pos)           /**< (NVMCTRL_CTRLC) Manual Write Mask */
+#define NVMCTRL_CTRLC_MANW                  NVMCTRL_CTRLC_MANW_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_CTRLC_MANW_Msk instead */
+#define NVMCTRL_CTRLC_MASK                  _U_(0x01)                                      /**< \deprecated (NVMCTRL_CTRLC) Register MASK  (Use NVMCTRL_CTRLC_Msk instead)  */
+#define NVMCTRL_CTRLC_Msk                   _U_(0x01)                                      /**< (NVMCTRL_CTRLC) Register Mask  */
+
+
+/* -------- NVMCTRL_EVCTRL : (NVMCTRL Offset: 0x0a) (R/W 8) Event Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  AUTOWEI:1;                 /**< bit:      0  Auto Write Event Enable                  */
+    uint8_t  AUTOWINV:1;                /**< bit:      1  Auto Write Event Polarity Inverted       */
+    uint8_t  :6;                        /**< bit:   2..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} NVMCTRL_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_EVCTRL_OFFSET               (0x0A)                                        /**<  (NVMCTRL_EVCTRL) Event Control  Offset */
+#define NVMCTRL_EVCTRL_RESETVALUE           _U_(0x00)                                     /**<  (NVMCTRL_EVCTRL) Event Control  Reset Value */
+
+#define NVMCTRL_EVCTRL_AUTOWEI_Pos          0                                              /**< (NVMCTRL_EVCTRL) Auto Write Event Enable Position */
+#define NVMCTRL_EVCTRL_AUTOWEI_Msk          (_U_(0x1) << NVMCTRL_EVCTRL_AUTOWEI_Pos)       /**< (NVMCTRL_EVCTRL) Auto Write Event Enable Mask */
+#define NVMCTRL_EVCTRL_AUTOWEI              NVMCTRL_EVCTRL_AUTOWEI_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_EVCTRL_AUTOWEI_Msk instead */
+#define NVMCTRL_EVCTRL_AUTOWINV_Pos         1                                              /**< (NVMCTRL_EVCTRL) Auto Write Event Polarity Inverted Position */
+#define NVMCTRL_EVCTRL_AUTOWINV_Msk         (_U_(0x1) << NVMCTRL_EVCTRL_AUTOWINV_Pos)      /**< (NVMCTRL_EVCTRL) Auto Write Event Polarity Inverted Mask */
+#define NVMCTRL_EVCTRL_AUTOWINV             NVMCTRL_EVCTRL_AUTOWINV_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_EVCTRL_AUTOWINV_Msk instead */
+#define NVMCTRL_EVCTRL_MASK                 _U_(0x03)                                      /**< \deprecated (NVMCTRL_EVCTRL) Register MASK  (Use NVMCTRL_EVCTRL_Msk instead)  */
+#define NVMCTRL_EVCTRL_Msk                  _U_(0x03)                                      /**< (NVMCTRL_EVCTRL) Register Mask  */
+
+
+/* -------- NVMCTRL_INTENCLR : (NVMCTRL Offset: 0x0c) (R/W 8) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DONE:1;                    /**< bit:      0  NVM Done Interrupt Clear                 */
+    uint8_t  PROGE:1;                   /**< bit:      1  Programming Error Status Interrupt Clear */
+    uint8_t  LOCKE:1;                   /**< bit:      2  Lock Error Status Interrupt Clear        */
+    uint8_t  NVME:1;                    /**< bit:      3  NVM Error Interrupt Clear                */
+    uint8_t  KEYE:1;                    /**< bit:      4  Key Write Error Interrupt Clear          */
+    uint8_t  NSCHK:1;                   /**< bit:      5  NS configuration change detected Interrupt Clear */
+    uint8_t  :2;                        /**< bit:   6..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} NVMCTRL_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_INTENCLR_OFFSET             (0x0C)                                        /**<  (NVMCTRL_INTENCLR) Interrupt Enable Clear  Offset */
+#define NVMCTRL_INTENCLR_RESETVALUE         _U_(0x00)                                     /**<  (NVMCTRL_INTENCLR) Interrupt Enable Clear  Reset Value */
+
+#define NVMCTRL_INTENCLR_DONE_Pos           0                                              /**< (NVMCTRL_INTENCLR) NVM Done Interrupt Clear Position */
+#define NVMCTRL_INTENCLR_DONE_Msk           (_U_(0x1) << NVMCTRL_INTENCLR_DONE_Pos)        /**< (NVMCTRL_INTENCLR) NVM Done Interrupt Clear Mask */
+#define NVMCTRL_INTENCLR_DONE               NVMCTRL_INTENCLR_DONE_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_INTENCLR_DONE_Msk instead */
+#define NVMCTRL_INTENCLR_PROGE_Pos          1                                              /**< (NVMCTRL_INTENCLR) Programming Error Status Interrupt Clear Position */
+#define NVMCTRL_INTENCLR_PROGE_Msk          (_U_(0x1) << NVMCTRL_INTENCLR_PROGE_Pos)       /**< (NVMCTRL_INTENCLR) Programming Error Status Interrupt Clear Mask */
+#define NVMCTRL_INTENCLR_PROGE              NVMCTRL_INTENCLR_PROGE_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_INTENCLR_PROGE_Msk instead */
+#define NVMCTRL_INTENCLR_LOCKE_Pos          2                                              /**< (NVMCTRL_INTENCLR) Lock Error Status Interrupt Clear Position */
+#define NVMCTRL_INTENCLR_LOCKE_Msk          (_U_(0x1) << NVMCTRL_INTENCLR_LOCKE_Pos)       /**< (NVMCTRL_INTENCLR) Lock Error Status Interrupt Clear Mask */
+#define NVMCTRL_INTENCLR_LOCKE              NVMCTRL_INTENCLR_LOCKE_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_INTENCLR_LOCKE_Msk instead */
+#define NVMCTRL_INTENCLR_NVME_Pos           3                                              /**< (NVMCTRL_INTENCLR) NVM Error Interrupt Clear Position */
+#define NVMCTRL_INTENCLR_NVME_Msk           (_U_(0x1) << NVMCTRL_INTENCLR_NVME_Pos)        /**< (NVMCTRL_INTENCLR) NVM Error Interrupt Clear Mask */
+#define NVMCTRL_INTENCLR_NVME               NVMCTRL_INTENCLR_NVME_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_INTENCLR_NVME_Msk instead */
+#define NVMCTRL_INTENCLR_KEYE_Pos           4                                              /**< (NVMCTRL_INTENCLR) Key Write Error Interrupt Clear Position */
+#define NVMCTRL_INTENCLR_KEYE_Msk           (_U_(0x1) << NVMCTRL_INTENCLR_KEYE_Pos)        /**< (NVMCTRL_INTENCLR) Key Write Error Interrupt Clear Mask */
+#define NVMCTRL_INTENCLR_KEYE               NVMCTRL_INTENCLR_KEYE_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_INTENCLR_KEYE_Msk instead */
+#define NVMCTRL_INTENCLR_NSCHK_Pos          5                                              /**< (NVMCTRL_INTENCLR) NS configuration change detected Interrupt Clear Position */
+#define NVMCTRL_INTENCLR_NSCHK_Msk          (_U_(0x1) << NVMCTRL_INTENCLR_NSCHK_Pos)       /**< (NVMCTRL_INTENCLR) NS configuration change detected Interrupt Clear Mask */
+#define NVMCTRL_INTENCLR_NSCHK              NVMCTRL_INTENCLR_NSCHK_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_INTENCLR_NSCHK_Msk instead */
+#define NVMCTRL_INTENCLR_MASK               _U_(0x3F)                                      /**< \deprecated (NVMCTRL_INTENCLR) Register MASK  (Use NVMCTRL_INTENCLR_Msk instead)  */
+#define NVMCTRL_INTENCLR_Msk                _U_(0x3F)                                      /**< (NVMCTRL_INTENCLR) Register Mask  */
+
+
+/* -------- NVMCTRL_INTENSET : (NVMCTRL Offset: 0x10) (R/W 8) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DONE:1;                    /**< bit:      0  NVM Done Interrupt Enable                */
+    uint8_t  PROGE:1;                   /**< bit:      1  Programming Error Status Interrupt Enable */
+    uint8_t  LOCKE:1;                   /**< bit:      2  Lock Error Status Interrupt Enable       */
+    uint8_t  NVME:1;                    /**< bit:      3  NVM Error Interrupt Enable               */
+    uint8_t  KEYE:1;                    /**< bit:      4  Key Write Error Interrupt Enable         */
+    uint8_t  NSCHK:1;                   /**< bit:      5  NS configuration change detected Interrupt Enable */
+    uint8_t  :2;                        /**< bit:   6..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} NVMCTRL_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_INTENSET_OFFSET             (0x10)                                        /**<  (NVMCTRL_INTENSET) Interrupt Enable Set  Offset */
+#define NVMCTRL_INTENSET_RESETVALUE         _U_(0x00)                                     /**<  (NVMCTRL_INTENSET) Interrupt Enable Set  Reset Value */
+
+#define NVMCTRL_INTENSET_DONE_Pos           0                                              /**< (NVMCTRL_INTENSET) NVM Done Interrupt Enable Position */
+#define NVMCTRL_INTENSET_DONE_Msk           (_U_(0x1) << NVMCTRL_INTENSET_DONE_Pos)        /**< (NVMCTRL_INTENSET) NVM Done Interrupt Enable Mask */
+#define NVMCTRL_INTENSET_DONE               NVMCTRL_INTENSET_DONE_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_INTENSET_DONE_Msk instead */
+#define NVMCTRL_INTENSET_PROGE_Pos          1                                              /**< (NVMCTRL_INTENSET) Programming Error Status Interrupt Enable Position */
+#define NVMCTRL_INTENSET_PROGE_Msk          (_U_(0x1) << NVMCTRL_INTENSET_PROGE_Pos)       /**< (NVMCTRL_INTENSET) Programming Error Status Interrupt Enable Mask */
+#define NVMCTRL_INTENSET_PROGE              NVMCTRL_INTENSET_PROGE_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_INTENSET_PROGE_Msk instead */
+#define NVMCTRL_INTENSET_LOCKE_Pos          2                                              /**< (NVMCTRL_INTENSET) Lock Error Status Interrupt Enable Position */
+#define NVMCTRL_INTENSET_LOCKE_Msk          (_U_(0x1) << NVMCTRL_INTENSET_LOCKE_Pos)       /**< (NVMCTRL_INTENSET) Lock Error Status Interrupt Enable Mask */
+#define NVMCTRL_INTENSET_LOCKE              NVMCTRL_INTENSET_LOCKE_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_INTENSET_LOCKE_Msk instead */
+#define NVMCTRL_INTENSET_NVME_Pos           3                                              /**< (NVMCTRL_INTENSET) NVM Error Interrupt Enable Position */
+#define NVMCTRL_INTENSET_NVME_Msk           (_U_(0x1) << NVMCTRL_INTENSET_NVME_Pos)        /**< (NVMCTRL_INTENSET) NVM Error Interrupt Enable Mask */
+#define NVMCTRL_INTENSET_NVME               NVMCTRL_INTENSET_NVME_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_INTENSET_NVME_Msk instead */
+#define NVMCTRL_INTENSET_KEYE_Pos           4                                              /**< (NVMCTRL_INTENSET) Key Write Error Interrupt Enable Position */
+#define NVMCTRL_INTENSET_KEYE_Msk           (_U_(0x1) << NVMCTRL_INTENSET_KEYE_Pos)        /**< (NVMCTRL_INTENSET) Key Write Error Interrupt Enable Mask */
+#define NVMCTRL_INTENSET_KEYE               NVMCTRL_INTENSET_KEYE_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_INTENSET_KEYE_Msk instead */
+#define NVMCTRL_INTENSET_NSCHK_Pos          5                                              /**< (NVMCTRL_INTENSET) NS configuration change detected Interrupt Enable Position */
+#define NVMCTRL_INTENSET_NSCHK_Msk          (_U_(0x1) << NVMCTRL_INTENSET_NSCHK_Pos)       /**< (NVMCTRL_INTENSET) NS configuration change detected Interrupt Enable Mask */
+#define NVMCTRL_INTENSET_NSCHK              NVMCTRL_INTENSET_NSCHK_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_INTENSET_NSCHK_Msk instead */
+#define NVMCTRL_INTENSET_MASK               _U_(0x3F)                                      /**< \deprecated (NVMCTRL_INTENSET) Register MASK  (Use NVMCTRL_INTENSET_Msk instead)  */
+#define NVMCTRL_INTENSET_Msk                _U_(0x3F)                                      /**< (NVMCTRL_INTENSET) Register Mask  */
+
+
+/* -------- NVMCTRL_INTFLAG : (NVMCTRL Offset: 0x14) (R/W 8) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t DONE:1;                    /**< bit:      0  NVM Done                                 */
+    __I uint8_t PROGE:1;                   /**< bit:      1  Programming Error Status                 */
+    __I uint8_t LOCKE:1;                   /**< bit:      2  Lock Error Status                        */
+    __I uint8_t NVME:1;                    /**< bit:      3  NVM Error                                */
+    __I uint8_t KEYE:1;                    /**< bit:      4  KEY Write Error                          */
+    __I uint8_t NSCHK:1;                   /**< bit:      5  NS configuration change detected         */
+    __I uint8_t :2;                        /**< bit:   6..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} NVMCTRL_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_INTFLAG_OFFSET              (0x14)                                        /**<  (NVMCTRL_INTFLAG) Interrupt Flag Status and Clear  Offset */
+#define NVMCTRL_INTFLAG_RESETVALUE          _U_(0x00)                                     /**<  (NVMCTRL_INTFLAG) Interrupt Flag Status and Clear  Reset Value */
+
+#define NVMCTRL_INTFLAG_DONE_Pos            0                                              /**< (NVMCTRL_INTFLAG) NVM Done Position */
+#define NVMCTRL_INTFLAG_DONE_Msk            (_U_(0x1) << NVMCTRL_INTFLAG_DONE_Pos)         /**< (NVMCTRL_INTFLAG) NVM Done Mask */
+#define NVMCTRL_INTFLAG_DONE                NVMCTRL_INTFLAG_DONE_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_INTFLAG_DONE_Msk instead */
+#define NVMCTRL_INTFLAG_PROGE_Pos           1                                              /**< (NVMCTRL_INTFLAG) Programming Error Status Position */
+#define NVMCTRL_INTFLAG_PROGE_Msk           (_U_(0x1) << NVMCTRL_INTFLAG_PROGE_Pos)        /**< (NVMCTRL_INTFLAG) Programming Error Status Mask */
+#define NVMCTRL_INTFLAG_PROGE               NVMCTRL_INTFLAG_PROGE_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_INTFLAG_PROGE_Msk instead */
+#define NVMCTRL_INTFLAG_LOCKE_Pos           2                                              /**< (NVMCTRL_INTFLAG) Lock Error Status Position */
+#define NVMCTRL_INTFLAG_LOCKE_Msk           (_U_(0x1) << NVMCTRL_INTFLAG_LOCKE_Pos)        /**< (NVMCTRL_INTFLAG) Lock Error Status Mask */
+#define NVMCTRL_INTFLAG_LOCKE               NVMCTRL_INTFLAG_LOCKE_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_INTFLAG_LOCKE_Msk instead */
+#define NVMCTRL_INTFLAG_NVME_Pos            3                                              /**< (NVMCTRL_INTFLAG) NVM Error Position */
+#define NVMCTRL_INTFLAG_NVME_Msk            (_U_(0x1) << NVMCTRL_INTFLAG_NVME_Pos)         /**< (NVMCTRL_INTFLAG) NVM Error Mask */
+#define NVMCTRL_INTFLAG_NVME                NVMCTRL_INTFLAG_NVME_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_INTFLAG_NVME_Msk instead */
+#define NVMCTRL_INTFLAG_KEYE_Pos            4                                              /**< (NVMCTRL_INTFLAG) KEY Write Error Position */
+#define NVMCTRL_INTFLAG_KEYE_Msk            (_U_(0x1) << NVMCTRL_INTFLAG_KEYE_Pos)         /**< (NVMCTRL_INTFLAG) KEY Write Error Mask */
+#define NVMCTRL_INTFLAG_KEYE                NVMCTRL_INTFLAG_KEYE_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_INTFLAG_KEYE_Msk instead */
+#define NVMCTRL_INTFLAG_NSCHK_Pos           5                                              /**< (NVMCTRL_INTFLAG) NS configuration change detected Position */
+#define NVMCTRL_INTFLAG_NSCHK_Msk           (_U_(0x1) << NVMCTRL_INTFLAG_NSCHK_Pos)        /**< (NVMCTRL_INTFLAG) NS configuration change detected Mask */
+#define NVMCTRL_INTFLAG_NSCHK               NVMCTRL_INTFLAG_NSCHK_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_INTFLAG_NSCHK_Msk instead */
+#define NVMCTRL_INTFLAG_MASK                _U_(0x3F)                                      /**< \deprecated (NVMCTRL_INTFLAG) Register MASK  (Use NVMCTRL_INTFLAG_Msk instead)  */
+#define NVMCTRL_INTFLAG_Msk                 _U_(0x3F)                                      /**< (NVMCTRL_INTFLAG) Register Mask  */
+
+
+/* -------- NVMCTRL_STATUS : (NVMCTRL Offset: 0x18) (R/ 16) Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t PRM:1;                     /**< bit:      0  Power Reduction Mode                     */
+    uint16_t LOAD:1;                    /**< bit:      1  NVM Page Buffer Active Loading           */
+    uint16_t READY:1;                   /**< bit:      2  NVM Ready                                */
+    uint16_t DALFUSE:2;                 /**< bit:   3..4  Debug Access Level Fuse                  */
+    uint16_t :11;                       /**< bit:  5..15  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} NVMCTRL_STATUS_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_STATUS_OFFSET               (0x18)                                        /**<  (NVMCTRL_STATUS) Status  Offset */
+#define NVMCTRL_STATUS_RESETVALUE           _U_(0x00)                                     /**<  (NVMCTRL_STATUS) Status  Reset Value */
+
+#define NVMCTRL_STATUS_PRM_Pos              0                                              /**< (NVMCTRL_STATUS) Power Reduction Mode Position */
+#define NVMCTRL_STATUS_PRM_Msk              (_U_(0x1) << NVMCTRL_STATUS_PRM_Pos)           /**< (NVMCTRL_STATUS) Power Reduction Mode Mask */
+#define NVMCTRL_STATUS_PRM                  NVMCTRL_STATUS_PRM_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_STATUS_PRM_Msk instead */
+#define NVMCTRL_STATUS_LOAD_Pos             1                                              /**< (NVMCTRL_STATUS) NVM Page Buffer Active Loading Position */
+#define NVMCTRL_STATUS_LOAD_Msk             (_U_(0x1) << NVMCTRL_STATUS_LOAD_Pos)          /**< (NVMCTRL_STATUS) NVM Page Buffer Active Loading Mask */
+#define NVMCTRL_STATUS_LOAD                 NVMCTRL_STATUS_LOAD_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_STATUS_LOAD_Msk instead */
+#define NVMCTRL_STATUS_READY_Pos            2                                              /**< (NVMCTRL_STATUS) NVM Ready Position */
+#define NVMCTRL_STATUS_READY_Msk            (_U_(0x1) << NVMCTRL_STATUS_READY_Pos)         /**< (NVMCTRL_STATUS) NVM Ready Mask */
+#define NVMCTRL_STATUS_READY                NVMCTRL_STATUS_READY_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_STATUS_READY_Msk instead */
+#define NVMCTRL_STATUS_DALFUSE_Pos          3                                              /**< (NVMCTRL_STATUS) Debug Access Level Fuse Position */
+#define NVMCTRL_STATUS_DALFUSE_Msk          (_U_(0x3) << NVMCTRL_STATUS_DALFUSE_Pos)       /**< (NVMCTRL_STATUS) Debug Access Level Fuse Mask */
+#define NVMCTRL_STATUS_DALFUSE(value)       (NVMCTRL_STATUS_DALFUSE_Msk & ((value) << NVMCTRL_STATUS_DALFUSE_Pos))
+#define NVMCTRL_STATUS_MASK                 _U_(0x1F)                                      /**< \deprecated (NVMCTRL_STATUS) Register MASK  (Use NVMCTRL_STATUS_Msk instead)  */
+#define NVMCTRL_STATUS_Msk                  _U_(0x1F)                                      /**< (NVMCTRL_STATUS) Register Mask  */
+
+
+/* -------- NVMCTRL_ADDR : (NVMCTRL Offset: 0x1c) (R/W 32) Address -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t AOFFSET:16;                /**< bit:  0..15  NVM Address Offset In The Selected Array */
+    uint32_t :6;                        /**< bit: 16..21  Reserved */
+    uint32_t ARRAY:2;                   /**< bit: 22..23  Array Select                             */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} NVMCTRL_ADDR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_ADDR_OFFSET                 (0x1C)                                        /**<  (NVMCTRL_ADDR) Address  Offset */
+#define NVMCTRL_ADDR_RESETVALUE             _U_(0x00)                                     /**<  (NVMCTRL_ADDR) Address  Reset Value */
+
+#define NVMCTRL_ADDR_AOFFSET_Pos            0                                              /**< (NVMCTRL_ADDR) NVM Address Offset In The Selected Array Position */
+#define NVMCTRL_ADDR_AOFFSET_Msk            (_U_(0xFFFF) << NVMCTRL_ADDR_AOFFSET_Pos)      /**< (NVMCTRL_ADDR) NVM Address Offset In The Selected Array Mask */
+#define NVMCTRL_ADDR_AOFFSET(value)         (NVMCTRL_ADDR_AOFFSET_Msk & ((value) << NVMCTRL_ADDR_AOFFSET_Pos))
+#define NVMCTRL_ADDR_ARRAY_Pos              22                                             /**< (NVMCTRL_ADDR) Array Select Position */
+#define NVMCTRL_ADDR_ARRAY_Msk              (_U_(0x3) << NVMCTRL_ADDR_ARRAY_Pos)           /**< (NVMCTRL_ADDR) Array Select Mask */
+#define NVMCTRL_ADDR_ARRAY(value)           (NVMCTRL_ADDR_ARRAY_Msk & ((value) << NVMCTRL_ADDR_ARRAY_Pos))
+#define   NVMCTRL_ADDR_ARRAY_FLASH_Val      _U_(0x0)                                       /**< (NVMCTRL_ADDR) FLASH Array  */
+#define   NVMCTRL_ADDR_ARRAY_DATAFLASH_Val  _U_(0x1)                                       /**< (NVMCTRL_ADDR) DATA FLASH Array  */
+#define   NVMCTRL_ADDR_ARRAY_AUX_Val        _U_(0x2)                                       /**< (NVMCTRL_ADDR) Auxilliary Space  */
+#define   NVMCTRL_ADDR_ARRAY_RESERVED_Val   _U_(0x3)                                       /**< (NVMCTRL_ADDR) Reserved Array  */
+#define NVMCTRL_ADDR_ARRAY_FLASH            (NVMCTRL_ADDR_ARRAY_FLASH_Val << NVMCTRL_ADDR_ARRAY_Pos)  /**< (NVMCTRL_ADDR) FLASH Array Position  */
+#define NVMCTRL_ADDR_ARRAY_DATAFLASH        (NVMCTRL_ADDR_ARRAY_DATAFLASH_Val << NVMCTRL_ADDR_ARRAY_Pos)  /**< (NVMCTRL_ADDR) DATA FLASH Array Position  */
+#define NVMCTRL_ADDR_ARRAY_AUX              (NVMCTRL_ADDR_ARRAY_AUX_Val << NVMCTRL_ADDR_ARRAY_Pos)  /**< (NVMCTRL_ADDR) Auxilliary Space Position  */
+#define NVMCTRL_ADDR_ARRAY_RESERVED         (NVMCTRL_ADDR_ARRAY_RESERVED_Val << NVMCTRL_ADDR_ARRAY_Pos)  /**< (NVMCTRL_ADDR) Reserved Array Position  */
+#define NVMCTRL_ADDR_MASK                   _U_(0xC0FFFF)                                  /**< \deprecated (NVMCTRL_ADDR) Register MASK  (Use NVMCTRL_ADDR_Msk instead)  */
+#define NVMCTRL_ADDR_Msk                    _U_(0xC0FFFF)                                  /**< (NVMCTRL_ADDR) Register Mask  */
+
+
+/* -------- NVMCTRL_SULCK : (NVMCTRL Offset: 0x20) (R/W 16) Secure Unlock Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t BS:1;                      /**< bit:      0  Secure Boot Region                       */
+    uint16_t AS:1;                      /**< bit:      1  Secure Application Region                */
+    uint16_t DS:1;                      /**< bit:      2  Data Secure Region                       */
+    uint16_t :5;                        /**< bit:   3..7  Reserved */
+    uint16_t SLKEY:8;                   /**< bit:  8..15  Write Key                                */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} NVMCTRL_SULCK_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_SULCK_OFFSET                (0x20)                                        /**<  (NVMCTRL_SULCK) Secure Unlock Register  Offset */
+
+#define NVMCTRL_SULCK_BS_Pos                0                                              /**< (NVMCTRL_SULCK) Secure Boot Region Position */
+#define NVMCTRL_SULCK_BS_Msk                (_U_(0x1) << NVMCTRL_SULCK_BS_Pos)             /**< (NVMCTRL_SULCK) Secure Boot Region Mask */
+#define NVMCTRL_SULCK_BS                    NVMCTRL_SULCK_BS_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_SULCK_BS_Msk instead */
+#define NVMCTRL_SULCK_AS_Pos                1                                              /**< (NVMCTRL_SULCK) Secure Application Region Position */
+#define NVMCTRL_SULCK_AS_Msk                (_U_(0x1) << NVMCTRL_SULCK_AS_Pos)             /**< (NVMCTRL_SULCK) Secure Application Region Mask */
+#define NVMCTRL_SULCK_AS                    NVMCTRL_SULCK_AS_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_SULCK_AS_Msk instead */
+#define NVMCTRL_SULCK_DS_Pos                2                                              /**< (NVMCTRL_SULCK) Data Secure Region Position */
+#define NVMCTRL_SULCK_DS_Msk                (_U_(0x1) << NVMCTRL_SULCK_DS_Pos)             /**< (NVMCTRL_SULCK) Data Secure Region Mask */
+#define NVMCTRL_SULCK_DS                    NVMCTRL_SULCK_DS_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_SULCK_DS_Msk instead */
+#define NVMCTRL_SULCK_SLKEY_Pos             8                                              /**< (NVMCTRL_SULCK) Write Key Position */
+#define NVMCTRL_SULCK_SLKEY_Msk             (_U_(0xFF) << NVMCTRL_SULCK_SLKEY_Pos)         /**< (NVMCTRL_SULCK) Write Key Mask */
+#define NVMCTRL_SULCK_SLKEY(value)          (NVMCTRL_SULCK_SLKEY_Msk & ((value) << NVMCTRL_SULCK_SLKEY_Pos))
+#define   NVMCTRL_SULCK_SLKEY_KEY_Val       _U_(0xA5)                                      /**< (NVMCTRL_SULCK) Write Key  */
+#define NVMCTRL_SULCK_SLKEY_KEY             (NVMCTRL_SULCK_SLKEY_KEY_Val << NVMCTRL_SULCK_SLKEY_Pos)  /**< (NVMCTRL_SULCK) Write Key Position  */
+#define NVMCTRL_SULCK_MASK                  _U_(0xFF07)                                    /**< \deprecated (NVMCTRL_SULCK) Register MASK  (Use NVMCTRL_SULCK_Msk instead)  */
+#define NVMCTRL_SULCK_Msk                   _U_(0xFF07)                                    /**< (NVMCTRL_SULCK) Register Mask  */
+
+
+/* -------- NVMCTRL_NSULCK : (NVMCTRL Offset: 0x22) (R/W 16) Non-Secure Unlock Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t BNS:1;                     /**< bit:      0  Non-Secure Boot Region                   */
+    uint16_t ANS:1;                     /**< bit:      1  Non-Secure Application Region            */
+    uint16_t DNS:1;                     /**< bit:      2  Non-Secure Data Region                   */
+    uint16_t :5;                        /**< bit:   3..7  Reserved */
+    uint16_t NSLKEY:8;                  /**< bit:  8..15  Write Key                                */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} NVMCTRL_NSULCK_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_NSULCK_OFFSET               (0x22)                                        /**<  (NVMCTRL_NSULCK) Non-Secure Unlock Register  Offset */
+
+#define NVMCTRL_NSULCK_BNS_Pos              0                                              /**< (NVMCTRL_NSULCK) Non-Secure Boot Region Position */
+#define NVMCTRL_NSULCK_BNS_Msk              (_U_(0x1) << NVMCTRL_NSULCK_BNS_Pos)           /**< (NVMCTRL_NSULCK) Non-Secure Boot Region Mask */
+#define NVMCTRL_NSULCK_BNS                  NVMCTRL_NSULCK_BNS_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_NSULCK_BNS_Msk instead */
+#define NVMCTRL_NSULCK_ANS_Pos              1                                              /**< (NVMCTRL_NSULCK) Non-Secure Application Region Position */
+#define NVMCTRL_NSULCK_ANS_Msk              (_U_(0x1) << NVMCTRL_NSULCK_ANS_Pos)           /**< (NVMCTRL_NSULCK) Non-Secure Application Region Mask */
+#define NVMCTRL_NSULCK_ANS                  NVMCTRL_NSULCK_ANS_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_NSULCK_ANS_Msk instead */
+#define NVMCTRL_NSULCK_DNS_Pos              2                                              /**< (NVMCTRL_NSULCK) Non-Secure Data Region Position */
+#define NVMCTRL_NSULCK_DNS_Msk              (_U_(0x1) << NVMCTRL_NSULCK_DNS_Pos)           /**< (NVMCTRL_NSULCK) Non-Secure Data Region Mask */
+#define NVMCTRL_NSULCK_DNS                  NVMCTRL_NSULCK_DNS_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_NSULCK_DNS_Msk instead */
+#define NVMCTRL_NSULCK_NSLKEY_Pos           8                                              /**< (NVMCTRL_NSULCK) Write Key Position */
+#define NVMCTRL_NSULCK_NSLKEY_Msk           (_U_(0xFF) << NVMCTRL_NSULCK_NSLKEY_Pos)       /**< (NVMCTRL_NSULCK) Write Key Mask */
+#define NVMCTRL_NSULCK_NSLKEY(value)        (NVMCTRL_NSULCK_NSLKEY_Msk & ((value) << NVMCTRL_NSULCK_NSLKEY_Pos))
+#define   NVMCTRL_NSULCK_NSLKEY_KEY_Val     _U_(0xA5)                                      /**< (NVMCTRL_NSULCK) Write Key  */
+#define NVMCTRL_NSULCK_NSLKEY_KEY           (NVMCTRL_NSULCK_NSLKEY_KEY_Val << NVMCTRL_NSULCK_NSLKEY_Pos)  /**< (NVMCTRL_NSULCK) Write Key Position  */
+#define NVMCTRL_NSULCK_MASK                 _U_(0xFF07)                                    /**< \deprecated (NVMCTRL_NSULCK) Register MASK  (Use NVMCTRL_NSULCK_Msk instead)  */
+#define NVMCTRL_NSULCK_Msk                  _U_(0xFF07)                                    /**< (NVMCTRL_NSULCK) Register Mask  */
+
+
+/* -------- NVMCTRL_PARAM : (NVMCTRL Offset: 0x24) (R/W 32) NVM Parameter -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t FLASHP:16;                 /**< bit:  0..15  FLASH Pages                              */
+    uint32_t PSZ:3;                     /**< bit: 16..18  Page Size                                */
+    uint32_t :1;                        /**< bit:     19  Reserved */
+    uint32_t DFLASHP:12;                /**< bit: 20..31  DATAFLASH Pages                          */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} NVMCTRL_PARAM_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_PARAM_OFFSET                (0x24)                                        /**<  (NVMCTRL_PARAM) NVM Parameter  Offset */
+#define NVMCTRL_PARAM_RESETVALUE            _U_(0x00)                                     /**<  (NVMCTRL_PARAM) NVM Parameter  Reset Value */
+
+#define NVMCTRL_PARAM_FLASHP_Pos            0                                              /**< (NVMCTRL_PARAM) FLASH Pages Position */
+#define NVMCTRL_PARAM_FLASHP_Msk            (_U_(0xFFFF) << NVMCTRL_PARAM_FLASHP_Pos)      /**< (NVMCTRL_PARAM) FLASH Pages Mask */
+#define NVMCTRL_PARAM_FLASHP(value)         (NVMCTRL_PARAM_FLASHP_Msk & ((value) << NVMCTRL_PARAM_FLASHP_Pos))
+#define NVMCTRL_PARAM_PSZ_Pos               16                                             /**< (NVMCTRL_PARAM) Page Size Position */
+#define NVMCTRL_PARAM_PSZ_Msk               (_U_(0x7) << NVMCTRL_PARAM_PSZ_Pos)            /**< (NVMCTRL_PARAM) Page Size Mask */
+#define NVMCTRL_PARAM_PSZ(value)            (NVMCTRL_PARAM_PSZ_Msk & ((value) << NVMCTRL_PARAM_PSZ_Pos))
+#define   NVMCTRL_PARAM_PSZ_8_Val           _U_(0x0)                                       /**< (NVMCTRL_PARAM) 8 bytes  */
+#define   NVMCTRL_PARAM_PSZ_16_Val          _U_(0x1)                                       /**< (NVMCTRL_PARAM) 16 bytes  */
+#define   NVMCTRL_PARAM_PSZ_32_Val          _U_(0x2)                                       /**< (NVMCTRL_PARAM) 32 bytes  */
+#define   NVMCTRL_PARAM_PSZ_64_Val          _U_(0x3)                                       /**< (NVMCTRL_PARAM) 64 bytes  */
+#define   NVMCTRL_PARAM_PSZ_128_Val         _U_(0x4)                                       /**< (NVMCTRL_PARAM) 128 bytes  */
+#define   NVMCTRL_PARAM_PSZ_256_Val         _U_(0x5)                                       /**< (NVMCTRL_PARAM) 256 bytes  */
+#define   NVMCTRL_PARAM_PSZ_512_Val         _U_(0x6)                                       /**< (NVMCTRL_PARAM) 512 bytes  */
+#define   NVMCTRL_PARAM_PSZ_1024_Val        _U_(0x7)                                       /**< (NVMCTRL_PARAM) 1024 bytes  */
+#define NVMCTRL_PARAM_PSZ_8                 (NVMCTRL_PARAM_PSZ_8_Val << NVMCTRL_PARAM_PSZ_Pos)  /**< (NVMCTRL_PARAM) 8 bytes Position  */
+#define NVMCTRL_PARAM_PSZ_16                (NVMCTRL_PARAM_PSZ_16_Val << NVMCTRL_PARAM_PSZ_Pos)  /**< (NVMCTRL_PARAM) 16 bytes Position  */
+#define NVMCTRL_PARAM_PSZ_32                (NVMCTRL_PARAM_PSZ_32_Val << NVMCTRL_PARAM_PSZ_Pos)  /**< (NVMCTRL_PARAM) 32 bytes Position  */
+#define NVMCTRL_PARAM_PSZ_64                (NVMCTRL_PARAM_PSZ_64_Val << NVMCTRL_PARAM_PSZ_Pos)  /**< (NVMCTRL_PARAM) 64 bytes Position  */
+#define NVMCTRL_PARAM_PSZ_128               (NVMCTRL_PARAM_PSZ_128_Val << NVMCTRL_PARAM_PSZ_Pos)  /**< (NVMCTRL_PARAM) 128 bytes Position  */
+#define NVMCTRL_PARAM_PSZ_256               (NVMCTRL_PARAM_PSZ_256_Val << NVMCTRL_PARAM_PSZ_Pos)  /**< (NVMCTRL_PARAM) 256 bytes Position  */
+#define NVMCTRL_PARAM_PSZ_512               (NVMCTRL_PARAM_PSZ_512_Val << NVMCTRL_PARAM_PSZ_Pos)  /**< (NVMCTRL_PARAM) 512 bytes Position  */
+#define NVMCTRL_PARAM_PSZ_1024              (NVMCTRL_PARAM_PSZ_1024_Val << NVMCTRL_PARAM_PSZ_Pos)  /**< (NVMCTRL_PARAM) 1024 bytes Position  */
+#define NVMCTRL_PARAM_DFLASHP_Pos           20                                             /**< (NVMCTRL_PARAM) DATAFLASH Pages Position */
+#define NVMCTRL_PARAM_DFLASHP_Msk           (_U_(0xFFF) << NVMCTRL_PARAM_DFLASHP_Pos)      /**< (NVMCTRL_PARAM) DATAFLASH Pages Mask */
+#define NVMCTRL_PARAM_DFLASHP(value)        (NVMCTRL_PARAM_DFLASHP_Msk & ((value) << NVMCTRL_PARAM_DFLASHP_Pos))
+#define NVMCTRL_PARAM_MASK                  _U_(0xFFF7FFFF)                                /**< \deprecated (NVMCTRL_PARAM) Register MASK  (Use NVMCTRL_PARAM_Msk instead)  */
+#define NVMCTRL_PARAM_Msk                   _U_(0xFFF7FFFF)                                /**< (NVMCTRL_PARAM) Register Mask  */
+
+
+/* -------- NVMCTRL_DSCC : (NVMCTRL Offset: 0x30) (/W 32) Data Scramble Configuration -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t DSCKEY:30;                 /**< bit:  0..29  Data Scramble Key                        */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} NVMCTRL_DSCC_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_DSCC_OFFSET                 (0x30)                                        /**<  (NVMCTRL_DSCC) Data Scramble Configuration  Offset */
+#define NVMCTRL_DSCC_RESETVALUE             _U_(0x00)                                     /**<  (NVMCTRL_DSCC) Data Scramble Configuration  Reset Value */
+
+#define NVMCTRL_DSCC_DSCKEY_Pos             0                                              /**< (NVMCTRL_DSCC) Data Scramble Key Position */
+#define NVMCTRL_DSCC_DSCKEY_Msk             (_U_(0x3FFFFFFF) << NVMCTRL_DSCC_DSCKEY_Pos)   /**< (NVMCTRL_DSCC) Data Scramble Key Mask */
+#define NVMCTRL_DSCC_DSCKEY(value)          (NVMCTRL_DSCC_DSCKEY_Msk & ((value) << NVMCTRL_DSCC_DSCKEY_Pos))
+#define NVMCTRL_DSCC_MASK                   _U_(0x3FFFFFFF)                                /**< \deprecated (NVMCTRL_DSCC) Register MASK  (Use NVMCTRL_DSCC_Msk instead)  */
+#define NVMCTRL_DSCC_Msk                    _U_(0x3FFFFFFF)                                /**< (NVMCTRL_DSCC) Register Mask  */
+
+
+/* -------- NVMCTRL_SECCTRL : (NVMCTRL Offset: 0x34) (R/W 32) Security Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t TAMPEEN:1;                 /**< bit:      0  Tamper Erase Enable                      */
+    uint32_t :1;                        /**< bit:      1  Reserved */
+    uint32_t SILACC:1;                  /**< bit:      2  Silent Access                            */
+    uint32_t DSCEN:1;                   /**< bit:      3  Data Scramble Enable                     */
+    uint32_t :2;                        /**< bit:   4..5  Reserved */
+    uint32_t DXN:1;                     /**< bit:      6  Data Flash is eXecute Never              */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t TEROW:3;                   /**< bit:  8..10  Tamper Rease Row                         */
+    uint32_t :13;                       /**< bit: 11..23  Reserved */
+    uint32_t KEY:8;                     /**< bit: 24..31  Write Key                                */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} NVMCTRL_SECCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_SECCTRL_OFFSET              (0x34)                                        /**<  (NVMCTRL_SECCTRL) Security Control  Offset */
+#define NVMCTRL_SECCTRL_RESETVALUE          _U_(0x30)                                     /**<  (NVMCTRL_SECCTRL) Security Control  Reset Value */
+
+#define NVMCTRL_SECCTRL_TAMPEEN_Pos         0                                              /**< (NVMCTRL_SECCTRL) Tamper Erase Enable Position */
+#define NVMCTRL_SECCTRL_TAMPEEN_Msk         (_U_(0x1) << NVMCTRL_SECCTRL_TAMPEEN_Pos)      /**< (NVMCTRL_SECCTRL) Tamper Erase Enable Mask */
+#define NVMCTRL_SECCTRL_TAMPEEN             NVMCTRL_SECCTRL_TAMPEEN_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_SECCTRL_TAMPEEN_Msk instead */
+#define NVMCTRL_SECCTRL_SILACC_Pos          2                                              /**< (NVMCTRL_SECCTRL) Silent Access Position */
+#define NVMCTRL_SECCTRL_SILACC_Msk          (_U_(0x1) << NVMCTRL_SECCTRL_SILACC_Pos)       /**< (NVMCTRL_SECCTRL) Silent Access Mask */
+#define NVMCTRL_SECCTRL_SILACC              NVMCTRL_SECCTRL_SILACC_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_SECCTRL_SILACC_Msk instead */
+#define NVMCTRL_SECCTRL_DSCEN_Pos           3                                              /**< (NVMCTRL_SECCTRL) Data Scramble Enable Position */
+#define NVMCTRL_SECCTRL_DSCEN_Msk           (_U_(0x1) << NVMCTRL_SECCTRL_DSCEN_Pos)        /**< (NVMCTRL_SECCTRL) Data Scramble Enable Mask */
+#define NVMCTRL_SECCTRL_DSCEN               NVMCTRL_SECCTRL_DSCEN_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_SECCTRL_DSCEN_Msk instead */
+#define NVMCTRL_SECCTRL_DXN_Pos             6                                              /**< (NVMCTRL_SECCTRL) Data Flash is eXecute Never Position */
+#define NVMCTRL_SECCTRL_DXN_Msk             (_U_(0x1) << NVMCTRL_SECCTRL_DXN_Pos)          /**< (NVMCTRL_SECCTRL) Data Flash is eXecute Never Mask */
+#define NVMCTRL_SECCTRL_DXN                 NVMCTRL_SECCTRL_DXN_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_SECCTRL_DXN_Msk instead */
+#define NVMCTRL_SECCTRL_TEROW_Pos           8                                              /**< (NVMCTRL_SECCTRL) Tamper Rease Row Position */
+#define NVMCTRL_SECCTRL_TEROW_Msk           (_U_(0x7) << NVMCTRL_SECCTRL_TEROW_Pos)        /**< (NVMCTRL_SECCTRL) Tamper Rease Row Mask */
+#define NVMCTRL_SECCTRL_TEROW(value)        (NVMCTRL_SECCTRL_TEROW_Msk & ((value) << NVMCTRL_SECCTRL_TEROW_Pos))
+#define NVMCTRL_SECCTRL_KEY_Pos             24                                             /**< (NVMCTRL_SECCTRL) Write Key Position */
+#define NVMCTRL_SECCTRL_KEY_Msk             (_U_(0xFF) << NVMCTRL_SECCTRL_KEY_Pos)         /**< (NVMCTRL_SECCTRL) Write Key Mask */
+#define NVMCTRL_SECCTRL_KEY(value)          (NVMCTRL_SECCTRL_KEY_Msk & ((value) << NVMCTRL_SECCTRL_KEY_Pos))
+#define   NVMCTRL_SECCTRL_KEY_KEY_Val       _U_(0xA5)                                      /**< (NVMCTRL_SECCTRL) Write Key  */
+#define NVMCTRL_SECCTRL_KEY_KEY             (NVMCTRL_SECCTRL_KEY_KEY_Val << NVMCTRL_SECCTRL_KEY_Pos)  /**< (NVMCTRL_SECCTRL) Write Key Position  */
+#define NVMCTRL_SECCTRL_MASK                _U_(0xFF00074D)                                /**< \deprecated (NVMCTRL_SECCTRL) Register MASK  (Use NVMCTRL_SECCTRL_Msk instead)  */
+#define NVMCTRL_SECCTRL_Msk                 _U_(0xFF00074D)                                /**< (NVMCTRL_SECCTRL) Register Mask  */
+
+
+/* -------- NVMCTRL_SCFGB : (NVMCTRL Offset: 0x38) (R/W 32) Secure Boot Configuration -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t BCREN:1;                   /**< bit:      0  Boot Configuration Row Read Enable       */
+    uint32_t BCWEN:1;                   /**< bit:      1  Boot Configuration Row Write Enable      */
+    uint32_t :30;                       /**< bit:  2..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} NVMCTRL_SCFGB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_SCFGB_OFFSET                (0x38)                                        /**<  (NVMCTRL_SCFGB) Secure Boot Configuration  Offset */
+#define NVMCTRL_SCFGB_RESETVALUE            _U_(0x03)                                     /**<  (NVMCTRL_SCFGB) Secure Boot Configuration  Reset Value */
+
+#define NVMCTRL_SCFGB_BCREN_Pos             0                                              /**< (NVMCTRL_SCFGB) Boot Configuration Row Read Enable Position */
+#define NVMCTRL_SCFGB_BCREN_Msk             (_U_(0x1) << NVMCTRL_SCFGB_BCREN_Pos)          /**< (NVMCTRL_SCFGB) Boot Configuration Row Read Enable Mask */
+#define NVMCTRL_SCFGB_BCREN                 NVMCTRL_SCFGB_BCREN_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_SCFGB_BCREN_Msk instead */
+#define NVMCTRL_SCFGB_BCWEN_Pos             1                                              /**< (NVMCTRL_SCFGB) Boot Configuration Row Write Enable Position */
+#define NVMCTRL_SCFGB_BCWEN_Msk             (_U_(0x1) << NVMCTRL_SCFGB_BCWEN_Pos)          /**< (NVMCTRL_SCFGB) Boot Configuration Row Write Enable Mask */
+#define NVMCTRL_SCFGB_BCWEN                 NVMCTRL_SCFGB_BCWEN_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_SCFGB_BCWEN_Msk instead */
+#define NVMCTRL_SCFGB_MASK                  _U_(0x03)                                      /**< \deprecated (NVMCTRL_SCFGB) Register MASK  (Use NVMCTRL_SCFGB_Msk instead)  */
+#define NVMCTRL_SCFGB_Msk                   _U_(0x03)                                      /**< (NVMCTRL_SCFGB) Register Mask  */
+
+
+/* -------- NVMCTRL_SCFGAD : (NVMCTRL Offset: 0x3c) (R/W 32) Secure Application and Data Configuration -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t URWEN:1;                   /**< bit:      0  User Row Write Enable                    */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} NVMCTRL_SCFGAD_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_SCFGAD_OFFSET               (0x3C)                                        /**<  (NVMCTRL_SCFGAD) Secure Application and Data Configuration  Offset */
+#define NVMCTRL_SCFGAD_RESETVALUE           _U_(0x01)                                     /**<  (NVMCTRL_SCFGAD) Secure Application and Data Configuration  Reset Value */
+
+#define NVMCTRL_SCFGAD_URWEN_Pos            0                                              /**< (NVMCTRL_SCFGAD) User Row Write Enable Position */
+#define NVMCTRL_SCFGAD_URWEN_Msk            (_U_(0x1) << NVMCTRL_SCFGAD_URWEN_Pos)         /**< (NVMCTRL_SCFGAD) User Row Write Enable Mask */
+#define NVMCTRL_SCFGAD_URWEN                NVMCTRL_SCFGAD_URWEN_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_SCFGAD_URWEN_Msk instead */
+#define NVMCTRL_SCFGAD_MASK                 _U_(0x01)                                      /**< \deprecated (NVMCTRL_SCFGAD) Register MASK  (Use NVMCTRL_SCFGAD_Msk instead)  */
+#define NVMCTRL_SCFGAD_Msk                  _U_(0x01)                                      /**< (NVMCTRL_SCFGAD) Register Mask  */
+
+
+/* -------- NVMCTRL_NONSEC : (NVMCTRL Offset: 0x40) (R/W 32) Non-secure Write Enable -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t WRITE:1;                   /**< bit:      0  Non-secure APB alias write enable, non-secure AHB writes to non-secure regions enable */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} NVMCTRL_NONSEC_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_NONSEC_OFFSET               (0x40)                                        /**<  (NVMCTRL_NONSEC) Non-secure Write Enable  Offset */
+#define NVMCTRL_NONSEC_RESETVALUE           _U_(0x01)                                     /**<  (NVMCTRL_NONSEC) Non-secure Write Enable  Reset Value */
+
+#define NVMCTRL_NONSEC_WRITE_Pos            0                                              /**< (NVMCTRL_NONSEC) Non-secure APB alias write enable, non-secure AHB writes to non-secure regions enable Position */
+#define NVMCTRL_NONSEC_WRITE_Msk            (_U_(0x1) << NVMCTRL_NONSEC_WRITE_Pos)         /**< (NVMCTRL_NONSEC) Non-secure APB alias write enable, non-secure AHB writes to non-secure regions enable Mask */
+#define NVMCTRL_NONSEC_WRITE                NVMCTRL_NONSEC_WRITE_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_NONSEC_WRITE_Msk instead */
+#define NVMCTRL_NONSEC_MASK                 _U_(0x01)                                      /**< \deprecated (NVMCTRL_NONSEC) Register MASK  (Use NVMCTRL_NONSEC_Msk instead)  */
+#define NVMCTRL_NONSEC_Msk                  _U_(0x01)                                      /**< (NVMCTRL_NONSEC) Register Mask  */
+
+
+/* -------- NVMCTRL_NSCHK : (NVMCTRL Offset: 0x44) (R/W 32) Non-secure Write Reference Value -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t WRITE:1;                   /**< bit:      0  Reference value to be checked against NONSEC.WRITE */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} NVMCTRL_NSCHK_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_NSCHK_OFFSET                (0x44)                                        /**<  (NVMCTRL_NSCHK) Non-secure Write Reference Value  Offset */
+#define NVMCTRL_NSCHK_RESETVALUE            _U_(0x01)                                     /**<  (NVMCTRL_NSCHK) Non-secure Write Reference Value  Reset Value */
+
+#define NVMCTRL_NSCHK_WRITE_Pos             0                                              /**< (NVMCTRL_NSCHK) Reference value to be checked against NONSEC.WRITE Position */
+#define NVMCTRL_NSCHK_WRITE_Msk             (_U_(0x1) << NVMCTRL_NSCHK_WRITE_Pos)          /**< (NVMCTRL_NSCHK) Reference value to be checked against NONSEC.WRITE Mask */
+#define NVMCTRL_NSCHK_WRITE                 NVMCTRL_NSCHK_WRITE_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_NSCHK_WRITE_Msk instead */
+#define NVMCTRL_NSCHK_MASK                  _U_(0x01)                                      /**< \deprecated (NVMCTRL_NSCHK) Register MASK  (Use NVMCTRL_NSCHK_Msk instead)  */
+#define NVMCTRL_NSCHK_Msk                   _U_(0x01)                                      /**< (NVMCTRL_NSCHK) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief NVMCTRL hardware registers */
+typedef struct {  /* Non-Volatile Memory Controller */
+  __O  NVMCTRL_CTRLA_Type             CTRLA;          /**< Offset: 0x00 ( /W  16) Control A */
+  __I  uint8_t                        Reserved1[2];
+  __IO NVMCTRL_CTRLB_Type             CTRLB;          /**< Offset: 0x04 (R/W  32) Control B */
+  __IO NVMCTRL_CTRLC_Type             CTRLC;          /**< Offset: 0x08 (R/W   8) Control C */
+  __I  uint8_t                        Reserved2[1];
+  __IO NVMCTRL_EVCTRL_Type            EVCTRL;         /**< Offset: 0x0A (R/W   8) Event Control */
+  __I  uint8_t                        Reserved3[1];
+  __IO NVMCTRL_INTENCLR_Type          INTENCLR;       /**< Offset: 0x0C (R/W   8) Interrupt Enable Clear */
+  __I  uint8_t                        Reserved4[3];
+  __IO NVMCTRL_INTENSET_Type          INTENSET;       /**< Offset: 0x10 (R/W   8) Interrupt Enable Set */
+  __I  uint8_t                        Reserved5[3];
+  __IO NVMCTRL_INTFLAG_Type           INTFLAG;        /**< Offset: 0x14 (R/W   8) Interrupt Flag Status and Clear */
+  __I  uint8_t                        Reserved6[3];
+  __I  NVMCTRL_STATUS_Type            STATUS;         /**< Offset: 0x18 (R/   16) Status */
+  __I  uint8_t                        Reserved7[2];
+  __IO NVMCTRL_ADDR_Type              ADDR;           /**< Offset: 0x1C (R/W  32) Address */
+  __IO NVMCTRL_SULCK_Type             SULCK;          /**< Offset: 0x20 (R/W  16) Secure Unlock Register */
+  __IO NVMCTRL_NSULCK_Type            NSULCK;         /**< Offset: 0x22 (R/W  16) Non-Secure Unlock Register */
+  __IO NVMCTRL_PARAM_Type             PARAM;          /**< Offset: 0x24 (R/W  32) NVM Parameter */
+  __I  uint8_t                        Reserved8[8];
+  __O  NVMCTRL_DSCC_Type              DSCC;           /**< Offset: 0x30 ( /W  32) Data Scramble Configuration */
+  __IO NVMCTRL_SECCTRL_Type           SECCTRL;        /**< Offset: 0x34 (R/W  32) Security Control */
+  __IO NVMCTRL_SCFGB_Type             SCFGB;          /**< Offset: 0x38 (R/W  32) Secure Boot Configuration */
+  __IO NVMCTRL_SCFGAD_Type            SCFGAD;         /**< Offset: 0x3C (R/W  32) Secure Application and Data Configuration */
+  __IO NVMCTRL_NONSEC_Type            NONSEC;         /**< Offset: 0x40 (R/W  32) Non-secure Write Enable */
+  __IO NVMCTRL_NSCHK_Type             NSCHK;          /**< Offset: 0x44 (R/W  32) Non-secure Write Reference Value */
+} Nvmctrl;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+#if defined (__GNUC__) || defined (__CC_ARM)
+  #define SECTION_AUX                  __attribute__ ((section(".flash")))
+  #define SECTION_BOCOR                __attribute__ ((section(".flash")))
+  #define SECTION_DATAFLASH            __attribute__ ((section(".flash")))
+  #define SECTION_SW_CALIB             __attribute__ ((section(".flash")))
+  #define SECTION_TEMP_LOG             __attribute__ ((section(".flash")))
+  #define SECTION_USER_PAGE            __attribute__ ((section(".flash")))
+
+#elif defined(__ICCARM__)
+  #define SECTION_AUX                  @".flash"
+  #define SECTION_BOCOR                @".flash"
+  #define SECTION_DATAFLASH            @".flash"
+  #define SECTION_SW_CALIB             @".flash"
+  #define SECTION_TEMP_LOG             @".flash"
+  #define SECTION_USER_PAGE            @".flash"
+
+#endif
+  #define SECTION_NVMCTRL_AUX          SECTION_AUX          /**< \brief \deprecated Old style definition. Use SECTION_AUX instead */
+  #define SECTION_NVMCTRL_BOCOR        SECTION_BOCOR        /**< \brief \deprecated Old style definition. Use SECTION_BOCOR instead */
+  #define SECTION_NVMCTRL_DATAFLASH    SECTION_DATAFLASH    /**< \brief \deprecated Old style definition. Use SECTION_DATAFLASH instead */
+  #define SECTION_NVMCTRL_SW_CALIB     SECTION_SW_CALIB     /**< \brief \deprecated Old style definition. Use SECTION_SW_CALIB instead */
+  #define SECTION_NVMCTRL_TEMP_LOG     SECTION_TEMP_LOG     /**< \brief \deprecated Old style definition. Use SECTION_TEMP_LOG instead */
+  #define SECTION_NVMCTRL_USER         SECTION_USER_PAGE    /**< \brief \deprecated Old style definition. Use SECTION_USER_PAGE instead */
+
+/** @}  end of Non-Volatile Memory Controller */
+
+/** \addtogroup fuses_api Peripheral Software API
+ *  @{
+ */
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR NON-VOLATILE FUSES */
+/* ************************************************************************** */
+#define ADC_FUSES_BIASCOMP_ADDR     SW_CALIB_ADDR
+#define ADC_FUSES_BIASCOMP_Pos      3            /**< \brief (SW_CALIB_ADDR) ADC Comparator Scaling */
+#define ADC_FUSES_BIASCOMP_Msk      (_U_(0x7) << ADC_FUSES_BIASCOMP_Pos)
+#define ADC_FUSES_BIASCOMP(value)   (ADC_FUSES_BIASCOMP_Msk & ((value) << ADC_FUSES_BIASCOMP_Pos))
+
+#define ADC_FUSES_BIASREFBUF_ADDR   SW_CALIB_ADDR
+#define ADC_FUSES_BIASREFBUF_Pos    0            /**< \brief (SW_CALIB_ADDR) ADC Bias Reference Buffer Scaling */
+#define ADC_FUSES_BIASREFBUF_Msk    (_U_(0x7) << ADC_FUSES_BIASREFBUF_Pos)
+#define ADC_FUSES_BIASREFBUF(value) (ADC_FUSES_BIASREFBUF_Msk & ((value) << ADC_FUSES_BIASREFBUF_Pos))
+
+#define FUSES_BOD33USERLEVEL_ADDR   USER_PAGE_ADDR
+#define FUSES_BOD33USERLEVEL_Pos    7            /**< \brief (USER_PAGE_ADDR) BOD33 User Level */
+#define FUSES_BOD33USERLEVEL_Msk    (_U_(0x3F) << FUSES_BOD33USERLEVEL_Pos)
+#define FUSES_BOD33USERLEVEL(value) (FUSES_BOD33USERLEVEL_Msk & ((value) << FUSES_BOD33USERLEVEL_Pos))
+
+#define FUSES_BOD33_ACTION_ADDR     USER_PAGE_ADDR
+#define FUSES_BOD33_ACTION_Pos      14           /**< \brief (USER_PAGE_ADDR) BOD33 Action */
+#define FUSES_BOD33_ACTION_Msk      (_U_(0x3) << FUSES_BOD33_ACTION_Pos)
+#define FUSES_BOD33_ACTION(value)   (FUSES_BOD33_ACTION_Msk & ((value) << FUSES_BOD33_ACTION_Pos))
+
+#define FUSES_BOD33_DIS_ADDR        USER_PAGE_ADDR
+#define FUSES_BOD33_DIS_Pos         13           /**< \brief (USER_PAGE_ADDR) BOD33 Disable */
+#define FUSES_BOD33_DIS_Msk         (_U_(0x1) << FUSES_BOD33_DIS_Pos)
+
+#define FUSES_BOD33_HYST_ADDR       (USER_PAGE_ADDR + 4)
+#define FUSES_BOD33_HYST_Pos        9            /**< \brief (USER_PAGE_ADDR) BOD33 Hysteresis */
+#define FUSES_BOD33_HYST_Msk        (_U_(0x1) << FUSES_BOD33_HYST_Pos)
+
+#define FUSES_BOOTROM_BOCORCRC_ADDR (BOCOR_ADDR + 8)
+#define FUSES_BOOTROM_BOCORCRC_Pos  0            /**< \brief (BOCOR_ADDR) CRC for BOCOR0 DWORD */
+#define FUSES_BOOTROM_BOCORCRC_Msk  (_U_(0xFFFFFFFF) << FUSES_BOOTROM_BOCORCRC_Pos)
+#define FUSES_BOOTROM_BOCORCRC(value) (FUSES_BOOTROM_BOCORCRC_Msk & ((value) << FUSES_BOOTROM_BOCORCRC_Pos))
+
+#define FUSES_BOOTROM_BOCORHASH_0_ADDR (BOCOR_ADDR + 224)
+#define FUSES_BOOTROM_BOCORHASH_0_Pos 0            /**< \brief (BOCOR_ADDR) Boot Configuration Row Hash bits 31:0 */
+#define FUSES_BOOTROM_BOCORHASH_0_Msk (_U_(0xFFFFFFFF) << FUSES_BOOTROM_BOCORHASH_0_Pos)
+#define FUSES_BOOTROM_BOCORHASH_0(value) (FUSES_BOOTROM_BOCORHASH_0_Msk & ((value) << FUSES_BOOTROM_BOCORHASH_0_Pos))
+
+#define FUSES_BOOTROM_BOCORHASH_1_ADDR (BOCOR_ADDR + 228)
+#define FUSES_BOOTROM_BOCORHASH_1_Pos 0            /**< \brief (BOCOR_ADDR) Boot Configuration Row Hash bits 63:32 */
+#define FUSES_BOOTROM_BOCORHASH_1_Msk (_U_(0xFFFFFFFF) << FUSES_BOOTROM_BOCORHASH_1_Pos)
+#define FUSES_BOOTROM_BOCORHASH_1(value) (FUSES_BOOTROM_BOCORHASH_1_Msk & ((value) << FUSES_BOOTROM_BOCORHASH_1_Pos))
+
+#define FUSES_BOOTROM_BOCORHASH_2_ADDR (BOCOR_ADDR + 232)
+#define FUSES_BOOTROM_BOCORHASH_2_Pos 0            /**< \brief (BOCOR_ADDR) Boot Configuration Row Hash bits 95:64 */
+#define FUSES_BOOTROM_BOCORHASH_2_Msk (_U_(0xFFFFFFFF) << FUSES_BOOTROM_BOCORHASH_2_Pos)
+#define FUSES_BOOTROM_BOCORHASH_2(value) (FUSES_BOOTROM_BOCORHASH_2_Msk & ((value) << FUSES_BOOTROM_BOCORHASH_2_Pos))
+
+#define FUSES_BOOTROM_BOCORHASH_3_ADDR (BOCOR_ADDR + 236)
+#define FUSES_BOOTROM_BOCORHASH_3_Pos 0            /**< \brief (BOCOR_ADDR) Boot Configuration Row Hash bits 127:96 */
+#define FUSES_BOOTROM_BOCORHASH_3_Msk (_U_(0xFFFFFFFF) << FUSES_BOOTROM_BOCORHASH_3_Pos)
+#define FUSES_BOOTROM_BOCORHASH_3(value) (FUSES_BOOTROM_BOCORHASH_3_Msk & ((value) << FUSES_BOOTROM_BOCORHASH_3_Pos))
+
+#define FUSES_BOOTROM_BOCORHASH_4_ADDR (BOCOR_ADDR + 240)
+#define FUSES_BOOTROM_BOCORHASH_4_Pos 0            /**< \brief (BOCOR_ADDR) Boot Configuration Row Hash bits 159:128 */
+#define FUSES_BOOTROM_BOCORHASH_4_Msk (_U_(0xFFFFFFFF) << FUSES_BOOTROM_BOCORHASH_4_Pos)
+#define FUSES_BOOTROM_BOCORHASH_4(value) (FUSES_BOOTROM_BOCORHASH_4_Msk & ((value) << FUSES_BOOTROM_BOCORHASH_4_Pos))
+
+#define FUSES_BOOTROM_BOCORHASH_5_ADDR (BOCOR_ADDR + 244)
+#define FUSES_BOOTROM_BOCORHASH_5_Pos 0            /**< \brief (BOCOR_ADDR) Boot Configuration Row Hash bits 191:160 */
+#define FUSES_BOOTROM_BOCORHASH_5_Msk (_U_(0xFFFFFFFF) << FUSES_BOOTROM_BOCORHASH_5_Pos)
+#define FUSES_BOOTROM_BOCORHASH_5(value) (FUSES_BOOTROM_BOCORHASH_5_Msk & ((value) << FUSES_BOOTROM_BOCORHASH_5_Pos))
+
+#define FUSES_BOOTROM_BOCORHASH_6_ADDR (BOCOR_ADDR + 248)
+#define FUSES_BOOTROM_BOCORHASH_6_Pos 0            /**< \brief (BOCOR_ADDR) Boot Configuration Row Hash bits 223:192 */
+#define FUSES_BOOTROM_BOCORHASH_6_Msk (_U_(0xFFFFFFFF) << FUSES_BOOTROM_BOCORHASH_6_Pos)
+#define FUSES_BOOTROM_BOCORHASH_6(value) (FUSES_BOOTROM_BOCORHASH_6_Msk & ((value) << FUSES_BOOTROM_BOCORHASH_6_Pos))
+
+#define FUSES_BOOTROM_BOCORHASH_7_ADDR (BOCOR_ADDR + 252)
+#define FUSES_BOOTROM_BOCORHASH_7_Pos 0            /**< \brief (BOCOR_ADDR) Boot Configuration Row Hash bits 255:224 */
+#define FUSES_BOOTROM_BOCORHASH_7_Msk (_U_(0xFFFFFFFF) << FUSES_BOOTROM_BOCORHASH_7_Pos)
+#define FUSES_BOOTROM_BOCORHASH_7(value) (FUSES_BOOTROM_BOCORHASH_7_Msk & ((value) << FUSES_BOOTROM_BOCORHASH_7_Pos))
+
+#define FUSES_BOOTROM_BOOTKEY_0_ADDR (BOCOR_ADDR + 80)
+#define FUSES_BOOTROM_BOOTKEY_0_Pos 0            /**< \brief (BOCOR_ADDR) Secure Boot Key bits 31:0 */
+#define FUSES_BOOTROM_BOOTKEY_0_Msk (_U_(0xFFFFFFFF) << FUSES_BOOTROM_BOOTKEY_0_Pos)
+#define FUSES_BOOTROM_BOOTKEY_0(value) (FUSES_BOOTROM_BOOTKEY_0_Msk & ((value) << FUSES_BOOTROM_BOOTKEY_0_Pos))
+
+#define FUSES_BOOTROM_BOOTKEY_1_ADDR (BOCOR_ADDR + 84)
+#define FUSES_BOOTROM_BOOTKEY_1_Pos 0            /**< \brief (BOCOR_ADDR) Secure Boot Key bits 63:32 */
+#define FUSES_BOOTROM_BOOTKEY_1_Msk (_U_(0xFFFFFFFF) << FUSES_BOOTROM_BOOTKEY_1_Pos)
+#define FUSES_BOOTROM_BOOTKEY_1(value) (FUSES_BOOTROM_BOOTKEY_1_Msk & ((value) << FUSES_BOOTROM_BOOTKEY_1_Pos))
+
+#define FUSES_BOOTROM_BOOTKEY_2_ADDR (BOCOR_ADDR + 88)
+#define FUSES_BOOTROM_BOOTKEY_2_Pos 0            /**< \brief (BOCOR_ADDR) Secure Boot Key bits 95:64 */
+#define FUSES_BOOTROM_BOOTKEY_2_Msk (_U_(0xFFFFFFFF) << FUSES_BOOTROM_BOOTKEY_2_Pos)
+#define FUSES_BOOTROM_BOOTKEY_2(value) (FUSES_BOOTROM_BOOTKEY_2_Msk & ((value) << FUSES_BOOTROM_BOOTKEY_2_Pos))
+
+#define FUSES_BOOTROM_BOOTKEY_3_ADDR (BOCOR_ADDR + 92)
+#define FUSES_BOOTROM_BOOTKEY_3_Pos 0            /**< \brief (BOCOR_ADDR) Secure Boot Key bits 127:96 */
+#define FUSES_BOOTROM_BOOTKEY_3_Msk (_U_(0xFFFFFFFF) << FUSES_BOOTROM_BOOTKEY_3_Pos)
+#define FUSES_BOOTROM_BOOTKEY_3(value) (FUSES_BOOTROM_BOOTKEY_3_Msk & ((value) << FUSES_BOOTROM_BOOTKEY_3_Pos))
+
+#define FUSES_BOOTROM_BOOTKEY_4_ADDR (BOCOR_ADDR + 96)
+#define FUSES_BOOTROM_BOOTKEY_4_Pos 0            /**< \brief (BOCOR_ADDR) Secure Boot Key bits 159:128 */
+#define FUSES_BOOTROM_BOOTKEY_4_Msk (_U_(0xFFFFFFFF) << FUSES_BOOTROM_BOOTKEY_4_Pos)
+#define FUSES_BOOTROM_BOOTKEY_4(value) (FUSES_BOOTROM_BOOTKEY_4_Msk & ((value) << FUSES_BOOTROM_BOOTKEY_4_Pos))
+
+#define FUSES_BOOTROM_BOOTKEY_5_ADDR (BOCOR_ADDR + 100)
+#define FUSES_BOOTROM_BOOTKEY_5_Pos 0            /**< \brief (BOCOR_ADDR) Secure Boot Key bits 191:160 */
+#define FUSES_BOOTROM_BOOTKEY_5_Msk (_U_(0xFFFFFFFF) << FUSES_BOOTROM_BOOTKEY_5_Pos)
+#define FUSES_BOOTROM_BOOTKEY_5(value) (FUSES_BOOTROM_BOOTKEY_5_Msk & ((value) << FUSES_BOOTROM_BOOTKEY_5_Pos))
+
+#define FUSES_BOOTROM_BOOTKEY_6_ADDR (BOCOR_ADDR + 104)
+#define FUSES_BOOTROM_BOOTKEY_6_Pos 0            /**< \brief (BOCOR_ADDR) Secure Boot Key bits 223:192 */
+#define FUSES_BOOTROM_BOOTKEY_6_Msk (_U_(0xFFFFFFFF) << FUSES_BOOTROM_BOOTKEY_6_Pos)
+#define FUSES_BOOTROM_BOOTKEY_6(value) (FUSES_BOOTROM_BOOTKEY_6_Msk & ((value) << FUSES_BOOTROM_BOOTKEY_6_Pos))
+
+#define FUSES_BOOTROM_BOOTKEY_7_ADDR (BOCOR_ADDR + 108)
+#define FUSES_BOOTROM_BOOTKEY_7_Pos 0            /**< \brief (BOCOR_ADDR) Secure Boot Key bits 255:224 */
+#define FUSES_BOOTROM_BOOTKEY_7_Msk (_U_(0xFFFFFFFF) << FUSES_BOOTROM_BOOTKEY_7_Pos)
+#define FUSES_BOOTROM_BOOTKEY_7(value) (FUSES_BOOTROM_BOOTKEY_7_Msk & ((value) << FUSES_BOOTROM_BOOTKEY_7_Pos))
+
+#define FUSES_BOOTROM_BOOTOPT_ADDR  BOCOR_ADDR
+#define FUSES_BOOTROM_BOOTOPT_Pos   24           /**< \brief (BOCOR_ADDR) Boot Option */
+#define FUSES_BOOTROM_BOOTOPT_Msk   (_U_(0xFF) << FUSES_BOOTROM_BOOTOPT_Pos)
+#define FUSES_BOOTROM_BOOTOPT(value) (FUSES_BOOTROM_BOOTOPT_Msk & ((value) << FUSES_BOOTROM_BOOTOPT_Pos))
+
+#define FUSES_BOOTROM_CEKEY0_0_ADDR (BOCOR_ADDR + 16)
+#define FUSES_BOOTROM_CEKEY0_0_Pos  0            /**< \brief (BOCOR_ADDR) Chip Erase Key 0 bits 31:0 */
+#define FUSES_BOOTROM_CEKEY0_0_Msk  (_U_(0xFFFFFFFF) << FUSES_BOOTROM_CEKEY0_0_Pos)
+#define FUSES_BOOTROM_CEKEY0_0(value) (FUSES_BOOTROM_CEKEY0_0_Msk & ((value) << FUSES_BOOTROM_CEKEY0_0_Pos))
+
+#define FUSES_BOOTROM_CEKEY0_1_ADDR (BOCOR_ADDR + 20)
+#define FUSES_BOOTROM_CEKEY0_1_Pos  0            /**< \brief (BOCOR_ADDR) Chip Erase Key 0 bits 63:32 */
+#define FUSES_BOOTROM_CEKEY0_1_Msk  (_U_(0xFFFFFFFF) << FUSES_BOOTROM_CEKEY0_1_Pos)
+#define FUSES_BOOTROM_CEKEY0_1(value) (FUSES_BOOTROM_CEKEY0_1_Msk & ((value) << FUSES_BOOTROM_CEKEY0_1_Pos))
+
+#define FUSES_BOOTROM_CEKEY0_2_ADDR (BOCOR_ADDR + 24)
+#define FUSES_BOOTROM_CEKEY0_2_Pos  0            /**< \brief (BOCOR_ADDR) Chip Erase Key 0 bits 95:64 */
+#define FUSES_BOOTROM_CEKEY0_2_Msk  (_U_(0xFFFFFFFF) << FUSES_BOOTROM_CEKEY0_2_Pos)
+#define FUSES_BOOTROM_CEKEY0_2(value) (FUSES_BOOTROM_CEKEY0_2_Msk & ((value) << FUSES_BOOTROM_CEKEY0_2_Pos))
+
+#define FUSES_BOOTROM_CEKEY0_3_ADDR (BOCOR_ADDR + 28)
+#define FUSES_BOOTROM_CEKEY0_3_Pos  0            /**< \brief (BOCOR_ADDR) Chip Erase Key 0 bits 127:96 */
+#define FUSES_BOOTROM_CEKEY0_3_Msk  (_U_(0xFFFFFFFF) << FUSES_BOOTROM_CEKEY0_3_Pos)
+#define FUSES_BOOTROM_CEKEY0_3(value) (FUSES_BOOTROM_CEKEY0_3_Msk & ((value) << FUSES_BOOTROM_CEKEY0_3_Pos))
+
+#define FUSES_BOOTROM_CEKEY1_0_ADDR (BOCOR_ADDR + 32)
+#define FUSES_BOOTROM_CEKEY1_0_Pos  0            /**< \brief (BOCOR_ADDR) Chip Erase Key 1 bits 31:0 */
+#define FUSES_BOOTROM_CEKEY1_0_Msk  (_U_(0xFFFFFFFF) << FUSES_BOOTROM_CEKEY1_0_Pos)
+#define FUSES_BOOTROM_CEKEY1_0(value) (FUSES_BOOTROM_CEKEY1_0_Msk & ((value) << FUSES_BOOTROM_CEKEY1_0_Pos))
+
+#define FUSES_BOOTROM_CEKEY1_1_ADDR (BOCOR_ADDR + 36)
+#define FUSES_BOOTROM_CEKEY1_1_Pos  0            /**< \brief (BOCOR_ADDR) Chip Erase Key 1 bits 63:32 */
+#define FUSES_BOOTROM_CEKEY1_1_Msk  (_U_(0xFFFFFFFF) << FUSES_BOOTROM_CEKEY1_1_Pos)
+#define FUSES_BOOTROM_CEKEY1_1(value) (FUSES_BOOTROM_CEKEY1_1_Msk & ((value) << FUSES_BOOTROM_CEKEY1_1_Pos))
+
+#define FUSES_BOOTROM_CEKEY1_2_ADDR (BOCOR_ADDR + 40)
+#define FUSES_BOOTROM_CEKEY1_2_Pos  0            /**< \brief (BOCOR_ADDR) Chip Erase Key 1 bits 95:64 */
+#define FUSES_BOOTROM_CEKEY1_2_Msk  (_U_(0xFFFFFFFF) << FUSES_BOOTROM_CEKEY1_2_Pos)
+#define FUSES_BOOTROM_CEKEY1_2(value) (FUSES_BOOTROM_CEKEY1_2_Msk & ((value) << FUSES_BOOTROM_CEKEY1_2_Pos))
+
+#define FUSES_BOOTROM_CEKEY1_3_ADDR (BOCOR_ADDR + 44)
+#define FUSES_BOOTROM_CEKEY1_3_Pos  0            /**< \brief (BOCOR_ADDR) Chip Erase Key 1 bits 127:96 */
+#define FUSES_BOOTROM_CEKEY1_3_Msk  (_U_(0xFFFFFFFF) << FUSES_BOOTROM_CEKEY1_3_Pos)
+#define FUSES_BOOTROM_CEKEY1_3(value) (FUSES_BOOTROM_CEKEY1_3_Msk & ((value) << FUSES_BOOTROM_CEKEY1_3_Pos))
+
+#define FUSES_BOOTROM_CEKEY2_0_ADDR (BOCOR_ADDR + 48)
+#define FUSES_BOOTROM_CEKEY2_0_Pos  0            /**< \brief (BOCOR_ADDR) Chip Erase Key 2 bits 31:0 */
+#define FUSES_BOOTROM_CEKEY2_0_Msk  (_U_(0xFFFFFFFF) << FUSES_BOOTROM_CEKEY2_0_Pos)
+#define FUSES_BOOTROM_CEKEY2_0(value) (FUSES_BOOTROM_CEKEY2_0_Msk & ((value) << FUSES_BOOTROM_CEKEY2_0_Pos))
+
+#define FUSES_BOOTROM_CEKEY2_1_ADDR (BOCOR_ADDR + 52)
+#define FUSES_BOOTROM_CEKEY2_1_Pos  0            /**< \brief (BOCOR_ADDR) Chip Erase Key 2 bits 63:32 */
+#define FUSES_BOOTROM_CEKEY2_1_Msk  (_U_(0xFFFFFFFF) << FUSES_BOOTROM_CEKEY2_1_Pos)
+#define FUSES_BOOTROM_CEKEY2_1(value) (FUSES_BOOTROM_CEKEY2_1_Msk & ((value) << FUSES_BOOTROM_CEKEY2_1_Pos))
+
+#define FUSES_BOOTROM_CEKEY2_2_ADDR (BOCOR_ADDR + 56)
+#define FUSES_BOOTROM_CEKEY2_2_Pos  0            /**< \brief (BOCOR_ADDR) Chip Erase Key 2 bits 95:64 */
+#define FUSES_BOOTROM_CEKEY2_2_Msk  (_U_(0xFFFFFFFF) << FUSES_BOOTROM_CEKEY2_2_Pos)
+#define FUSES_BOOTROM_CEKEY2_2(value) (FUSES_BOOTROM_CEKEY2_2_Msk & ((value) << FUSES_BOOTROM_CEKEY2_2_Pos))
+
+#define FUSES_BOOTROM_CEKEY2_3_ADDR (BOCOR_ADDR + 60)
+#define FUSES_BOOTROM_CEKEY2_3_Pos  0            /**< \brief (BOCOR_ADDR) Chip Erase Key 2 bits 127:96 */
+#define FUSES_BOOTROM_CEKEY2_3_Msk  (_U_(0xFFFFFFFF) << FUSES_BOOTROM_CEKEY2_3_Pos)
+#define FUSES_BOOTROM_CEKEY2_3(value) (FUSES_BOOTROM_CEKEY2_3_Msk & ((value) << FUSES_BOOTROM_CEKEY2_3_Pos))
+
+#define FUSES_BOOTROM_CRCKEY_0_ADDR (BOCOR_ADDR + 64)
+#define FUSES_BOOTROM_CRCKEY_0_Pos  0            /**< \brief (BOCOR_ADDR) CRC Key bits 31:0 */
+#define FUSES_BOOTROM_CRCKEY_0_Msk  (_U_(0xFFFFFFFF) << FUSES_BOOTROM_CRCKEY_0_Pos)
+#define FUSES_BOOTROM_CRCKEY_0(value) (FUSES_BOOTROM_CRCKEY_0_Msk & ((value) << FUSES_BOOTROM_CRCKEY_0_Pos))
+
+#define FUSES_BOOTROM_CRCKEY_1_ADDR (BOCOR_ADDR + 68)
+#define FUSES_BOOTROM_CRCKEY_1_Pos  0            /**< \brief (BOCOR_ADDR) CRC Key bits 63:32 */
+#define FUSES_BOOTROM_CRCKEY_1_Msk  (_U_(0xFFFFFFFF) << FUSES_BOOTROM_CRCKEY_1_Pos)
+#define FUSES_BOOTROM_CRCKEY_1(value) (FUSES_BOOTROM_CRCKEY_1_Msk & ((value) << FUSES_BOOTROM_CRCKEY_1_Pos))
+
+#define FUSES_BOOTROM_CRCKEY_2_ADDR (BOCOR_ADDR + 72)
+#define FUSES_BOOTROM_CRCKEY_2_Pos  0            /**< \brief (BOCOR_ADDR) CRC Key bits 95:64 */
+#define FUSES_BOOTROM_CRCKEY_2_Msk  (_U_(0xFFFFFFFF) << FUSES_BOOTROM_CRCKEY_2_Pos)
+#define FUSES_BOOTROM_CRCKEY_2(value) (FUSES_BOOTROM_CRCKEY_2_Msk & ((value) << FUSES_BOOTROM_CRCKEY_2_Pos))
+
+#define FUSES_BOOTROM_CRCKEY_3_ADDR (BOCOR_ADDR + 76)
+#define FUSES_BOOTROM_CRCKEY_3_Pos  0            /**< \brief (BOCOR_ADDR) CRC Key bits 127:96 */
+#define FUSES_BOOTROM_CRCKEY_3_Msk  (_U_(0xFFFFFFFF) << FUSES_BOOTROM_CRCKEY_3_Pos)
+#define FUSES_BOOTROM_CRCKEY_3(value) (FUSES_BOOTROM_CRCKEY_3_Msk & ((value) << FUSES_BOOTROM_CRCKEY_3_Pos))
+
+#define FUSES_BOOTROM_DXN_ADDR      (USER_PAGE_ADDR + 4)
+#define FUSES_BOOTROM_DXN_Pos       12           /**< \brief (USER_PAGE_ADDR) DATA FLASH is eXecute Never */
+#define FUSES_BOOTROM_DXN_Msk       (_U_(0x1) << FUSES_BOOTROM_DXN_Pos)
+
+#define FUSES_BOOTROM_NONSECA_ADDR  (USER_PAGE_ADDR + 16)
+#define FUSES_BOOTROM_NONSECA_Pos   0            /**< \brief (USER_PAGE_ADDR) NONSEC fuses for the bridgeA peripherals */
+#define FUSES_BOOTROM_NONSECA_Msk   (_U_(0xFFFFFFFF) << FUSES_BOOTROM_NONSECA_Pos)
+#define FUSES_BOOTROM_NONSECA(value) (FUSES_BOOTROM_NONSECA_Msk & ((value) << FUSES_BOOTROM_NONSECA_Pos))
+
+#define FUSES_BOOTROM_NONSECB_ADDR  (USER_PAGE_ADDR + 20)
+#define FUSES_BOOTROM_NONSECB_Pos   0            /**< \brief (USER_PAGE_ADDR) NONSEC fuses for the bridgeB peripherals */
+#define FUSES_BOOTROM_NONSECB_Msk   (_U_(0xFFFFFFFF) << FUSES_BOOTROM_NONSECB_Pos)
+#define FUSES_BOOTROM_NONSECB(value) (FUSES_BOOTROM_NONSECB_Msk & ((value) << FUSES_BOOTROM_NONSECB_Pos))
+
+#define FUSES_BOOTROM_NONSECC_ADDR  (USER_PAGE_ADDR + 24)
+#define FUSES_BOOTROM_NONSECC_Pos   0            /**< \brief (USER_PAGE_ADDR) NONSEC fuses for the bridgeC peripherals */
+#define FUSES_BOOTROM_NONSECC_Msk   (_U_(0xFFFFFFFF) << FUSES_BOOTROM_NONSECC_Pos)
+#define FUSES_BOOTROM_NONSECC(value) (FUSES_BOOTROM_NONSECC_Msk & ((value) << FUSES_BOOTROM_NONSECC_Pos))
+
+#define FUSES_BOOTROM_ROMVERSION_ADDR (BOCOR_ADDR + 12)
+#define FUSES_BOOTROM_ROMVERSION_Pos 0            /**< \brief (BOCOR_ADDR) BOOTROM Version */
+#define FUSES_BOOTROM_ROMVERSION_Msk (_U_(0xFFFFFFFF) << FUSES_BOOTROM_ROMVERSION_Pos)
+#define FUSES_BOOTROM_ROMVERSION(value) (FUSES_BOOTROM_ROMVERSION_Msk & ((value) << FUSES_BOOTROM_ROMVERSION_Pos))
+
+#define FUSES_BOOTROM_RXN_ADDR      (USER_PAGE_ADDR + 4)
+#define FUSES_BOOTROM_RXN_Pos       11           /**< \brief (USER_PAGE_ADDR) RAM is eXecute Never */
+#define FUSES_BOOTROM_RXN_Msk       (_U_(0x1) << FUSES_BOOTROM_RXN_Pos)
+
+#define FUSES_BOOTROM_USERCRC_ADDR  (USER_PAGE_ADDR + 28)
+#define FUSES_BOOTROM_USERCRC_Pos   0            /**< \brief (USER_PAGE_ADDR) CRC for USER[1,2,3] DWORDS */
+#define FUSES_BOOTROM_USERCRC_Msk   (_U_(0xFFFFFFFF) << FUSES_BOOTROM_USERCRC_Pos)
+#define FUSES_BOOTROM_USERCRC(value) (FUSES_BOOTROM_USERCRC_Msk & ((value) << FUSES_BOOTROM_USERCRC_Pos))
+
+#define FUSES_DFLLULP_DIV_PL0_ADDR  SW_CALIB_ADDR
+#define FUSES_DFLLULP_DIV_PL0_Pos   6            /**< \brief (SW_CALIB_ADDR) DFLLULP DIV at PL0 */
+#define FUSES_DFLLULP_DIV_PL0_Msk   (_U_(0x7) << FUSES_DFLLULP_DIV_PL0_Pos)
+#define FUSES_DFLLULP_DIV_PL0(value) (FUSES_DFLLULP_DIV_PL0_Msk & ((value) << FUSES_DFLLULP_DIV_PL0_Pos))
+
+#define FUSES_DFLLULP_DIV_PL2_ADDR  SW_CALIB_ADDR
+#define FUSES_DFLLULP_DIV_PL2_Pos   9            /**< \brief (SW_CALIB_ADDR) DFLLULP DIV at PL2 */
+#define FUSES_DFLLULP_DIV_PL2_Msk   (_U_(0x7) << FUSES_DFLLULP_DIV_PL2_Pos)
+#define FUSES_DFLLULP_DIV_PL2(value) (FUSES_DFLLULP_DIV_PL2_Msk & ((value) << FUSES_DFLLULP_DIV_PL2_Pos))
+
+#define FUSES_HOT_ADC_VAL_PTAT_ADDR (TEMP_LOG_ADDR + 4)
+#define FUSES_HOT_ADC_VAL_PTAT_Pos  20           /**< \brief (TEMP_LOG_ADDR) 12-bit ADC conversion at hot temperature PTAT */
+#define FUSES_HOT_ADC_VAL_PTAT_Msk  (_U_(0xFFF) << FUSES_HOT_ADC_VAL_PTAT_Pos)
+#define FUSES_HOT_ADC_VAL_PTAT(value) (FUSES_HOT_ADC_VAL_PTAT_Msk & ((value) << FUSES_HOT_ADC_VAL_PTAT_Pos))
+
+#define FUSES_HOT_INT1V_VAL_ADDR    (TEMP_LOG_ADDR + 4)
+#define FUSES_HOT_INT1V_VAL_Pos     0            /**< \brief (TEMP_LOG_ADDR) 2's complement of the internal 1V reference drift at hot temperature (versus a 1.0 centered value) */
+#define FUSES_HOT_INT1V_VAL_Msk     (_U_(0xFF) << FUSES_HOT_INT1V_VAL_Pos)
+#define FUSES_HOT_INT1V_VAL(value)  (FUSES_HOT_INT1V_VAL_Msk & ((value) << FUSES_HOT_INT1V_VAL_Pos))
+
+#define FUSES_HOT_TEMP_VAL_DEC_ADDR TEMP_LOG_ADDR
+#define FUSES_HOT_TEMP_VAL_DEC_Pos  20           /**< \brief (TEMP_LOG_ADDR) Decimal part of hot temperature */
+#define FUSES_HOT_TEMP_VAL_DEC_Msk  (_U_(0xF) << FUSES_HOT_TEMP_VAL_DEC_Pos)
+#define FUSES_HOT_TEMP_VAL_DEC(value) (FUSES_HOT_TEMP_VAL_DEC_Msk & ((value) << FUSES_HOT_TEMP_VAL_DEC_Pos))
+
+#define FUSES_HOT_TEMP_VAL_INT_ADDR TEMP_LOG_ADDR
+#define FUSES_HOT_TEMP_VAL_INT_Pos  12           /**< \brief (TEMP_LOG_ADDR) Integer part of hot temperature in oC */
+#define FUSES_HOT_TEMP_VAL_INT_Msk  (_U_(0xFF) << FUSES_HOT_TEMP_VAL_INT_Pos)
+#define FUSES_HOT_TEMP_VAL_INT(value) (FUSES_HOT_TEMP_VAL_INT_Msk & ((value) << FUSES_HOT_TEMP_VAL_INT_Pos))
+
+#define FUSES_ROOM_ADC_VAL_PTAT_ADDR (TEMP_LOG_ADDR + 4)
+#define FUSES_ROOM_ADC_VAL_PTAT_Pos 8            /**< \brief (TEMP_LOG_ADDR) 12-bit ADC conversion at room temperature PTAT */
+#define FUSES_ROOM_ADC_VAL_PTAT_Msk (_U_(0xFFF) << FUSES_ROOM_ADC_VAL_PTAT_Pos)
+#define FUSES_ROOM_ADC_VAL_PTAT(value) (FUSES_ROOM_ADC_VAL_PTAT_Msk & ((value) << FUSES_ROOM_ADC_VAL_PTAT_Pos))
+
+#define FUSES_ROOM_INT1V_VAL_ADDR   TEMP_LOG_ADDR
+#define FUSES_ROOM_INT1V_VAL_Pos    24           /**< \brief (TEMP_LOG_ADDR) 2's complement of the internal 1V reference drift at room temperature (versus a 1.0 centered value) */
+#define FUSES_ROOM_INT1V_VAL_Msk    (_U_(0xFF) << FUSES_ROOM_INT1V_VAL_Pos)
+#define FUSES_ROOM_INT1V_VAL(value) (FUSES_ROOM_INT1V_VAL_Msk & ((value) << FUSES_ROOM_INT1V_VAL_Pos))
+
+#define FUSES_ROOM_TEMP_VAL_DEC_ADDR TEMP_LOG_ADDR
+#define FUSES_ROOM_TEMP_VAL_DEC_Pos 8            /**< \brief (TEMP_LOG_ADDR) Decimal part of room temperature */
+#define FUSES_ROOM_TEMP_VAL_DEC_Msk (_U_(0xF) << FUSES_ROOM_TEMP_VAL_DEC_Pos)
+#define FUSES_ROOM_TEMP_VAL_DEC(value) (FUSES_ROOM_TEMP_VAL_DEC_Msk & ((value) << FUSES_ROOM_TEMP_VAL_DEC_Pos))
+
+#define FUSES_ROOM_TEMP_VAL_INT_ADDR TEMP_LOG_ADDR
+#define FUSES_ROOM_TEMP_VAL_INT_Pos 0            /**< \brief (TEMP_LOG_ADDR) Integer part of room temperature in oC */
+#define FUSES_ROOM_TEMP_VAL_INT_Msk (_U_(0xFF) << FUSES_ROOM_TEMP_VAL_INT_Pos)
+#define FUSES_ROOM_TEMP_VAL_INT(value) (FUSES_ROOM_TEMP_VAL_INT_Msk & ((value) << FUSES_ROOM_TEMP_VAL_INT_Pos))
+
+#define NVMCTRL_FUSES_BCREN_ADDR    (BOCOR_ADDR + 4)
+#define NVMCTRL_FUSES_BCREN_Pos     17           /**< \brief (BOCOR_ADDR) Boot Configuration Read Enable */
+#define NVMCTRL_FUSES_BCREN_Msk     (_U_(0x1) << NVMCTRL_FUSES_BCREN_Pos)
+
+#define NVMCTRL_FUSES_BCWEN_ADDR    (BOCOR_ADDR + 4)
+#define NVMCTRL_FUSES_BCWEN_Pos     16           /**< \brief (BOCOR_ADDR) Boot Configuration Write Enable */
+#define NVMCTRL_FUSES_BCWEN_Msk     (_U_(0x1) << NVMCTRL_FUSES_BCWEN_Pos)
+
+#define NVMCTRL_FUSES_NSULCK_ADDR   USER_PAGE_ADDR
+#define NVMCTRL_FUSES_NSULCK_Pos    3            /**< \brief (USER_PAGE_ADDR) NVM Non-Secure Region Locks */
+#define NVMCTRL_FUSES_NSULCK_Msk    (_U_(0x7) << NVMCTRL_FUSES_NSULCK_Pos)
+#define NVMCTRL_FUSES_NSULCK(value) (NVMCTRL_FUSES_NSULCK_Msk & ((value) << NVMCTRL_FUSES_NSULCK_Pos))
+
+#define NVMCTRL_FUSES_SULCK_ADDR    USER_PAGE_ADDR
+#define NVMCTRL_FUSES_SULCK_Pos     0            /**< \brief (USER_PAGE_ADDR) NVM Secure Region Locks */
+#define NVMCTRL_FUSES_SULCK_Msk     (_U_(0x7) << NVMCTRL_FUSES_SULCK_Pos)
+#define NVMCTRL_FUSES_SULCK(value)  (NVMCTRL_FUSES_SULCK_Msk & ((value) << NVMCTRL_FUSES_SULCK_Pos))
+
+#define NVMCTRL_FUSES_URWEN_ADDR    (USER_PAGE_ADDR + 12)
+#define NVMCTRL_FUSES_URWEN_Pos     0            /**< \brief (USER_PAGE_ADDR) User Row Write Enable */
+#define NVMCTRL_FUSES_URWEN_Msk     (_U_(0x1) << NVMCTRL_FUSES_URWEN_Pos)
+
+#define WDT_FUSES_ALWAYSON_ADDR     USER_PAGE_ADDR
+#define WDT_FUSES_ALWAYSON_Pos      27           /**< \brief (USER_PAGE_ADDR) WDT Always On */
+#define WDT_FUSES_ALWAYSON_Msk      (_U_(0x1) << WDT_FUSES_ALWAYSON_Pos)
+
+#define WDT_FUSES_ENABLE_ADDR       USER_PAGE_ADDR
+#define WDT_FUSES_ENABLE_Pos        26           /**< \brief (USER_PAGE_ADDR) WDT Enable */
+#define WDT_FUSES_ENABLE_Msk        (_U_(0x1) << WDT_FUSES_ENABLE_Pos)
+
+#define WDT_FUSES_EWOFFSET_ADDR     (USER_PAGE_ADDR + 4)
+#define WDT_FUSES_EWOFFSET_Pos      4            /**< \brief (USER_PAGE_ADDR) WDT Early Warning Offset */
+#define WDT_FUSES_EWOFFSET_Msk      (_U_(0xF) << WDT_FUSES_EWOFFSET_Pos)
+#define WDT_FUSES_EWOFFSET(value)   (WDT_FUSES_EWOFFSET_Msk & ((value) << WDT_FUSES_EWOFFSET_Pos))
+
+#define WDT_FUSES_PER_ADDR          USER_PAGE_ADDR
+#define WDT_FUSES_PER_Pos           28           /**< \brief (USER_PAGE_ADDR) WDT Period */
+#define WDT_FUSES_PER_Msk           (_U_(0xF) << WDT_FUSES_PER_Pos)
+#define WDT_FUSES_PER(value)        (WDT_FUSES_PER_Msk & ((value) << WDT_FUSES_PER_Pos))
+
+#define WDT_FUSES_RUNSTDBY_ADDR     USER_PAGE_ADDR
+#define WDT_FUSES_RUNSTDBY_Pos      25           /**< \brief (USER_PAGE_ADDR) WDT Run During Standby */
+#define WDT_FUSES_RUNSTDBY_Msk      (_U_(0x1) << WDT_FUSES_RUNSTDBY_Pos)
+
+#define WDT_FUSES_WEN_ADDR          (USER_PAGE_ADDR + 4)
+#define WDT_FUSES_WEN_Pos           8            /**< \brief (USER_PAGE_ADDR) WDT Window Mode Enable */
+#define WDT_FUSES_WEN_Msk           (_U_(0x1) << WDT_FUSES_WEN_Pos)
+
+#define WDT_FUSES_WINDOW_ADDR       (USER_PAGE_ADDR + 4)
+#define WDT_FUSES_WINDOW_Pos        0            /**< \brief (USER_PAGE_ADDR) WDT Window */
+#define WDT_FUSES_WINDOW_Msk        (_U_(0xF) << WDT_FUSES_WINDOW_Pos)
+#define WDT_FUSES_WINDOW(value)     (WDT_FUSES_WINDOW_Msk & ((value) << WDT_FUSES_WINDOW_Pos))
+
+/** @}  end of Peripheral Software API */
+
+#endif /* _SAML10_NVMCTRL_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/component/opamp.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/opamp.h
@@ -1,0 +1,227 @@
+/**
+ * \file
+ *
+ * \brief Component description for OPAMP
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_OPAMP_COMPONENT_H_
+#define _SAML10_OPAMP_COMPONENT_H_
+#define _SAML10_OPAMP_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML10 Operational Amplifier
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR OPAMP */
+/* ========================================================================== */
+
+#define OPAMP_U2237                      /**< (OPAMP) Module ID */
+#define REV_OPAMP 0x200                  /**< (OPAMP) Module revision */
+
+/* -------- OPAMP_CTRLA : (OPAMP Offset: 0x00) (R/W 8) Control A -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint8_t  ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint8_t  :5;                        /**< bit:   2..6  Reserved */
+    uint8_t  LPMUX:1;                   /**< bit:      7  Low-Power Mux                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} OPAMP_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OPAMP_CTRLA_OFFSET                  (0x00)                                        /**<  (OPAMP_CTRLA) Control A  Offset */
+#define OPAMP_CTRLA_RESETVALUE              _U_(0x00)                                     /**<  (OPAMP_CTRLA) Control A  Reset Value */
+
+#define OPAMP_CTRLA_SWRST_Pos               0                                              /**< (OPAMP_CTRLA) Software Reset Position */
+#define OPAMP_CTRLA_SWRST_Msk               (_U_(0x1) << OPAMP_CTRLA_SWRST_Pos)            /**< (OPAMP_CTRLA) Software Reset Mask */
+#define OPAMP_CTRLA_SWRST                   OPAMP_CTRLA_SWRST_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use OPAMP_CTRLA_SWRST_Msk instead */
+#define OPAMP_CTRLA_ENABLE_Pos              1                                              /**< (OPAMP_CTRLA) Enable Position */
+#define OPAMP_CTRLA_ENABLE_Msk              (_U_(0x1) << OPAMP_CTRLA_ENABLE_Pos)           /**< (OPAMP_CTRLA) Enable Mask */
+#define OPAMP_CTRLA_ENABLE                  OPAMP_CTRLA_ENABLE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use OPAMP_CTRLA_ENABLE_Msk instead */
+#define OPAMP_CTRLA_LPMUX_Pos               7                                              /**< (OPAMP_CTRLA) Low-Power Mux Position */
+#define OPAMP_CTRLA_LPMUX_Msk               (_U_(0x1) << OPAMP_CTRLA_LPMUX_Pos)            /**< (OPAMP_CTRLA) Low-Power Mux Mask */
+#define OPAMP_CTRLA_LPMUX                   OPAMP_CTRLA_LPMUX_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use OPAMP_CTRLA_LPMUX_Msk instead */
+#define OPAMP_CTRLA_MASK                    _U_(0x83)                                      /**< \deprecated (OPAMP_CTRLA) Register MASK  (Use OPAMP_CTRLA_Msk instead)  */
+#define OPAMP_CTRLA_Msk                     _U_(0x83)                                      /**< (OPAMP_CTRLA) Register Mask  */
+
+
+/* -------- OPAMP_STATUS : (OPAMP Offset: 0x02) (R/ 8) Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  READY0:1;                  /**< bit:      0  OPAMP 0 Ready                            */
+    uint8_t  READY1:1;                  /**< bit:      1  OPAMP 1 Ready                            */
+    uint8_t  READY2:1;                  /**< bit:      2  OPAMP 2 Ready                            */
+    uint8_t  :5;                        /**< bit:   3..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint8_t  READY:3;                   /**< bit:   0..2  OPAMP 2 Ready                            */
+    uint8_t  :5;                        /**< bit:   3..7 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint8_t  reg;                         /**< Type used for register access */
+} OPAMP_STATUS_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OPAMP_STATUS_OFFSET                 (0x02)                                        /**<  (OPAMP_STATUS) Status  Offset */
+#define OPAMP_STATUS_RESETVALUE             _U_(0x00)                                     /**<  (OPAMP_STATUS) Status  Reset Value */
+
+#define OPAMP_STATUS_READY0_Pos             0                                              /**< (OPAMP_STATUS) OPAMP 0 Ready Position */
+#define OPAMP_STATUS_READY0_Msk             (_U_(0x1) << OPAMP_STATUS_READY0_Pos)          /**< (OPAMP_STATUS) OPAMP 0 Ready Mask */
+#define OPAMP_STATUS_READY0                 OPAMP_STATUS_READY0_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use OPAMP_STATUS_READY0_Msk instead */
+#define OPAMP_STATUS_READY1_Pos             1                                              /**< (OPAMP_STATUS) OPAMP 1 Ready Position */
+#define OPAMP_STATUS_READY1_Msk             (_U_(0x1) << OPAMP_STATUS_READY1_Pos)          /**< (OPAMP_STATUS) OPAMP 1 Ready Mask */
+#define OPAMP_STATUS_READY1                 OPAMP_STATUS_READY1_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use OPAMP_STATUS_READY1_Msk instead */
+#define OPAMP_STATUS_READY2_Pos             2                                              /**< (OPAMP_STATUS) OPAMP 2 Ready Position */
+#define OPAMP_STATUS_READY2_Msk             (_U_(0x1) << OPAMP_STATUS_READY2_Pos)          /**< (OPAMP_STATUS) OPAMP 2 Ready Mask */
+#define OPAMP_STATUS_READY2                 OPAMP_STATUS_READY2_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use OPAMP_STATUS_READY2_Msk instead */
+#define OPAMP_STATUS_MASK                   _U_(0x07)                                      /**< \deprecated (OPAMP_STATUS) Register MASK  (Use OPAMP_STATUS_Msk instead)  */
+#define OPAMP_STATUS_Msk                    _U_(0x07)                                      /**< (OPAMP_STATUS) Register Mask  */
+
+#define OPAMP_STATUS_READY_Pos              0                                              /**< (OPAMP_STATUS Position) OPAMP 2 Ready */
+#define OPAMP_STATUS_READY_Msk              (_U_(0x7) << OPAMP_STATUS_READY_Pos)           /**< (OPAMP_STATUS Mask) READY */
+#define OPAMP_STATUS_READY(value)           (OPAMP_STATUS_READY_Msk & ((value) << OPAMP_STATUS_READY_Pos))  
+
+/* -------- OPAMP_OPAMPCTRL : (OPAMP Offset: 0x04) (R/W 32) OPAMP n Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t ENABLE:1;                  /**< bit:      1  Operational Amplifier Enable             */
+    uint32_t ANAOUT:1;                  /**< bit:      2  Analog Output                            */
+    uint32_t BIAS:2;                    /**< bit:   3..4  Bias Selection                           */
+    uint32_t RES2VCC:1;                 /**< bit:      5  Resistor ladder To VCC                   */
+    uint32_t RUNSTDBY:1;                /**< bit:      6  Run in Standby                           */
+    uint32_t ONDEMAND:1;                /**< bit:      7  On Demand Control                        */
+    uint32_t RES2OUT:1;                 /**< bit:      8  Resistor ladder To Output                */
+    uint32_t RES1EN:1;                  /**< bit:      9  Resistor 1 Enable                        */
+    uint32_t RES1MUX:3;                 /**< bit: 10..12  Resistor 1 Mux                           */
+    uint32_t POTMUX:3;                  /**< bit: 13..15  Potentiometer Selection                  */
+    uint32_t MUXPOS:4;                  /**< bit: 16..19  Positive Input Mux Selection             */
+    uint32_t MUXNEG:4;                  /**< bit: 20..23  Negative Input Mux Selection             */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} OPAMP_OPAMPCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OPAMP_OPAMPCTRL_OFFSET              (0x04)                                        /**<  (OPAMP_OPAMPCTRL) OPAMP n Control  Offset */
+#define OPAMP_OPAMPCTRL_RESETVALUE          _U_(0x00)                                     /**<  (OPAMP_OPAMPCTRL) OPAMP n Control  Reset Value */
+
+#define OPAMP_OPAMPCTRL_ENABLE_Pos          1                                              /**< (OPAMP_OPAMPCTRL) Operational Amplifier Enable Position */
+#define OPAMP_OPAMPCTRL_ENABLE_Msk          (_U_(0x1) << OPAMP_OPAMPCTRL_ENABLE_Pos)       /**< (OPAMP_OPAMPCTRL) Operational Amplifier Enable Mask */
+#define OPAMP_OPAMPCTRL_ENABLE              OPAMP_OPAMPCTRL_ENABLE_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use OPAMP_OPAMPCTRL_ENABLE_Msk instead */
+#define OPAMP_OPAMPCTRL_ANAOUT_Pos          2                                              /**< (OPAMP_OPAMPCTRL) Analog Output Position */
+#define OPAMP_OPAMPCTRL_ANAOUT_Msk          (_U_(0x1) << OPAMP_OPAMPCTRL_ANAOUT_Pos)       /**< (OPAMP_OPAMPCTRL) Analog Output Mask */
+#define OPAMP_OPAMPCTRL_ANAOUT              OPAMP_OPAMPCTRL_ANAOUT_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use OPAMP_OPAMPCTRL_ANAOUT_Msk instead */
+#define OPAMP_OPAMPCTRL_BIAS_Pos            3                                              /**< (OPAMP_OPAMPCTRL) Bias Selection Position */
+#define OPAMP_OPAMPCTRL_BIAS_Msk            (_U_(0x3) << OPAMP_OPAMPCTRL_BIAS_Pos)         /**< (OPAMP_OPAMPCTRL) Bias Selection Mask */
+#define OPAMP_OPAMPCTRL_BIAS(value)         (OPAMP_OPAMPCTRL_BIAS_Msk & ((value) << OPAMP_OPAMPCTRL_BIAS_Pos))
+#define OPAMP_OPAMPCTRL_RES2VCC_Pos         5                                              /**< (OPAMP_OPAMPCTRL) Resistor ladder To VCC Position */
+#define OPAMP_OPAMPCTRL_RES2VCC_Msk         (_U_(0x1) << OPAMP_OPAMPCTRL_RES2VCC_Pos)      /**< (OPAMP_OPAMPCTRL) Resistor ladder To VCC Mask */
+#define OPAMP_OPAMPCTRL_RES2VCC             OPAMP_OPAMPCTRL_RES2VCC_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use OPAMP_OPAMPCTRL_RES2VCC_Msk instead */
+#define OPAMP_OPAMPCTRL_RUNSTDBY_Pos        6                                              /**< (OPAMP_OPAMPCTRL) Run in Standby Position */
+#define OPAMP_OPAMPCTRL_RUNSTDBY_Msk        (_U_(0x1) << OPAMP_OPAMPCTRL_RUNSTDBY_Pos)     /**< (OPAMP_OPAMPCTRL) Run in Standby Mask */
+#define OPAMP_OPAMPCTRL_RUNSTDBY            OPAMP_OPAMPCTRL_RUNSTDBY_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use OPAMP_OPAMPCTRL_RUNSTDBY_Msk instead */
+#define OPAMP_OPAMPCTRL_ONDEMAND_Pos        7                                              /**< (OPAMP_OPAMPCTRL) On Demand Control Position */
+#define OPAMP_OPAMPCTRL_ONDEMAND_Msk        (_U_(0x1) << OPAMP_OPAMPCTRL_ONDEMAND_Pos)     /**< (OPAMP_OPAMPCTRL) On Demand Control Mask */
+#define OPAMP_OPAMPCTRL_ONDEMAND            OPAMP_OPAMPCTRL_ONDEMAND_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use OPAMP_OPAMPCTRL_ONDEMAND_Msk instead */
+#define OPAMP_OPAMPCTRL_RES2OUT_Pos         8                                              /**< (OPAMP_OPAMPCTRL) Resistor ladder To Output Position */
+#define OPAMP_OPAMPCTRL_RES2OUT_Msk         (_U_(0x1) << OPAMP_OPAMPCTRL_RES2OUT_Pos)      /**< (OPAMP_OPAMPCTRL) Resistor ladder To Output Mask */
+#define OPAMP_OPAMPCTRL_RES2OUT             OPAMP_OPAMPCTRL_RES2OUT_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use OPAMP_OPAMPCTRL_RES2OUT_Msk instead */
+#define OPAMP_OPAMPCTRL_RES1EN_Pos          9                                              /**< (OPAMP_OPAMPCTRL) Resistor 1 Enable Position */
+#define OPAMP_OPAMPCTRL_RES1EN_Msk          (_U_(0x1) << OPAMP_OPAMPCTRL_RES1EN_Pos)       /**< (OPAMP_OPAMPCTRL) Resistor 1 Enable Mask */
+#define OPAMP_OPAMPCTRL_RES1EN              OPAMP_OPAMPCTRL_RES1EN_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use OPAMP_OPAMPCTRL_RES1EN_Msk instead */
+#define OPAMP_OPAMPCTRL_RES1MUX_Pos         10                                             /**< (OPAMP_OPAMPCTRL) Resistor 1 Mux Position */
+#define OPAMP_OPAMPCTRL_RES1MUX_Msk         (_U_(0x7) << OPAMP_OPAMPCTRL_RES1MUX_Pos)      /**< (OPAMP_OPAMPCTRL) Resistor 1 Mux Mask */
+#define OPAMP_OPAMPCTRL_RES1MUX(value)      (OPAMP_OPAMPCTRL_RES1MUX_Msk & ((value) << OPAMP_OPAMPCTRL_RES1MUX_Pos))
+#define OPAMP_OPAMPCTRL_POTMUX_Pos          13                                             /**< (OPAMP_OPAMPCTRL) Potentiometer Selection Position */
+#define OPAMP_OPAMPCTRL_POTMUX_Msk          (_U_(0x7) << OPAMP_OPAMPCTRL_POTMUX_Pos)       /**< (OPAMP_OPAMPCTRL) Potentiometer Selection Mask */
+#define OPAMP_OPAMPCTRL_POTMUX(value)       (OPAMP_OPAMPCTRL_POTMUX_Msk & ((value) << OPAMP_OPAMPCTRL_POTMUX_Pos))
+#define OPAMP_OPAMPCTRL_MUXPOS_Pos          16                                             /**< (OPAMP_OPAMPCTRL) Positive Input Mux Selection Position */
+#define OPAMP_OPAMPCTRL_MUXPOS_Msk          (_U_(0xF) << OPAMP_OPAMPCTRL_MUXPOS_Pos)       /**< (OPAMP_OPAMPCTRL) Positive Input Mux Selection Mask */
+#define OPAMP_OPAMPCTRL_MUXPOS(value)       (OPAMP_OPAMPCTRL_MUXPOS_Msk & ((value) << OPAMP_OPAMPCTRL_MUXPOS_Pos))
+#define OPAMP_OPAMPCTRL_MUXNEG_Pos          20                                             /**< (OPAMP_OPAMPCTRL) Negative Input Mux Selection Position */
+#define OPAMP_OPAMPCTRL_MUXNEG_Msk          (_U_(0xF) << OPAMP_OPAMPCTRL_MUXNEG_Pos)       /**< (OPAMP_OPAMPCTRL) Negative Input Mux Selection Mask */
+#define OPAMP_OPAMPCTRL_MUXNEG(value)       (OPAMP_OPAMPCTRL_MUXNEG_Msk & ((value) << OPAMP_OPAMPCTRL_MUXNEG_Pos))
+#define OPAMP_OPAMPCTRL_MASK                _U_(0xFFFFFE)                                  /**< \deprecated (OPAMP_OPAMPCTRL) Register MASK  (Use OPAMP_OPAMPCTRL_Msk instead)  */
+#define OPAMP_OPAMPCTRL_Msk                 _U_(0xFFFFFE)                                  /**< (OPAMP_OPAMPCTRL) Register Mask  */
+
+
+/* -------- OPAMP_RESCTRL : (OPAMP Offset: 0x10) (R/W 8) Resister Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  RES2OUT:1;                 /**< bit:      0  Resistor ladder To Output                */
+    uint8_t  RES1EN:1;                  /**< bit:      1  Resistor 1 Enable                        */
+    uint8_t  RES1MUX:1;                 /**< bit:      2  Resistor 1 Mux                           */
+    uint8_t  POTMUX:3;                  /**< bit:   3..5  Potentiometer Selection                  */
+    uint8_t  REFBUFLEVEL:2;             /**< bit:   6..7  Reference output voltage level select    */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} OPAMP_RESCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OPAMP_RESCTRL_OFFSET                (0x10)                                        /**<  (OPAMP_RESCTRL) Resister Control  Offset */
+#define OPAMP_RESCTRL_RESETVALUE            _U_(0x00)                                     /**<  (OPAMP_RESCTRL) Resister Control  Reset Value */
+
+#define OPAMP_RESCTRL_RES2OUT_Pos           0                                              /**< (OPAMP_RESCTRL) Resistor ladder To Output Position */
+#define OPAMP_RESCTRL_RES2OUT_Msk           (_U_(0x1) << OPAMP_RESCTRL_RES2OUT_Pos)        /**< (OPAMP_RESCTRL) Resistor ladder To Output Mask */
+#define OPAMP_RESCTRL_RES2OUT               OPAMP_RESCTRL_RES2OUT_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use OPAMP_RESCTRL_RES2OUT_Msk instead */
+#define OPAMP_RESCTRL_RES1EN_Pos            1                                              /**< (OPAMP_RESCTRL) Resistor 1 Enable Position */
+#define OPAMP_RESCTRL_RES1EN_Msk            (_U_(0x1) << OPAMP_RESCTRL_RES1EN_Pos)         /**< (OPAMP_RESCTRL) Resistor 1 Enable Mask */
+#define OPAMP_RESCTRL_RES1EN                OPAMP_RESCTRL_RES1EN_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use OPAMP_RESCTRL_RES1EN_Msk instead */
+#define OPAMP_RESCTRL_RES1MUX_Pos           2                                              /**< (OPAMP_RESCTRL) Resistor 1 Mux Position */
+#define OPAMP_RESCTRL_RES1MUX_Msk           (_U_(0x1) << OPAMP_RESCTRL_RES1MUX_Pos)        /**< (OPAMP_RESCTRL) Resistor 1 Mux Mask */
+#define OPAMP_RESCTRL_RES1MUX               OPAMP_RESCTRL_RES1MUX_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use OPAMP_RESCTRL_RES1MUX_Msk instead */
+#define OPAMP_RESCTRL_POTMUX_Pos            3                                              /**< (OPAMP_RESCTRL) Potentiometer Selection Position */
+#define OPAMP_RESCTRL_POTMUX_Msk            (_U_(0x7) << OPAMP_RESCTRL_POTMUX_Pos)         /**< (OPAMP_RESCTRL) Potentiometer Selection Mask */
+#define OPAMP_RESCTRL_POTMUX(value)         (OPAMP_RESCTRL_POTMUX_Msk & ((value) << OPAMP_RESCTRL_POTMUX_Pos))
+#define OPAMP_RESCTRL_REFBUFLEVEL_Pos       6                                              /**< (OPAMP_RESCTRL) Reference output voltage level select Position */
+#define OPAMP_RESCTRL_REFBUFLEVEL_Msk       (_U_(0x3) << OPAMP_RESCTRL_REFBUFLEVEL_Pos)    /**< (OPAMP_RESCTRL) Reference output voltage level select Mask */
+#define OPAMP_RESCTRL_REFBUFLEVEL(value)    (OPAMP_RESCTRL_REFBUFLEVEL_Msk & ((value) << OPAMP_RESCTRL_REFBUFLEVEL_Pos))
+#define OPAMP_RESCTRL_MASK                  _U_(0xFF)                                      /**< \deprecated (OPAMP_RESCTRL) Register MASK  (Use OPAMP_RESCTRL_Msk instead)  */
+#define OPAMP_RESCTRL_Msk                   _U_(0xFF)                                      /**< (OPAMP_RESCTRL) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief OPAMP hardware registers */
+typedef struct {  /* Operational Amplifier */
+  __IO OPAMP_CTRLA_Type               CTRLA;          /**< Offset: 0x00 (R/W   8) Control A */
+  __I  uint8_t                        Reserved1[1];
+  __I  OPAMP_STATUS_Type              STATUS;         /**< Offset: 0x02 (R/    8) Status */
+  __I  uint8_t                        Reserved2[1];
+  __IO OPAMP_OPAMPCTRL_Type           OPAMPCTRL[3];   /**< Offset: 0x04 (R/W  32) OPAMP n Control */
+  __IO OPAMP_RESCTRL_Type             RESCTRL;        /**< Offset: 0x10 (R/W   8) Resister Control */
+} Opamp;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Operational Amplifier */
+
+#endif /* _SAML10_OPAMP_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/component/osc32kctrl.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/osc32kctrl.h
@@ -1,0 +1,344 @@
+/**
+ * \file
+ *
+ * \brief Component description for OSC32KCTRL
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_OSC32KCTRL_COMPONENT_H_
+#define _SAML10_OSC32KCTRL_COMPONENT_H_
+#define _SAML10_OSC32KCTRL_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML10 32k Oscillators Control
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR OSC32KCTRL */
+/* ========================================================================== */
+
+#define OSC32KCTRL_U2246                      /**< (OSC32KCTRL) Module ID */
+#define REV_OSC32KCTRL 0x400                  /**< (OSC32KCTRL) Module revision */
+
+/* -------- OSC32KCTRL_INTENCLR : (OSC32KCTRL Offset: 0x00) (R/W 32) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t XOSC32KRDY:1;              /**< bit:      0  XOSC32K Ready Interrupt Enable           */
+    uint32_t :1;                        /**< bit:      1  Reserved */
+    uint32_t CLKFAIL:1;                 /**< bit:      2  XOSC32K Clock Failure Detector Interrupt Enable */
+    uint32_t :29;                       /**< bit:  3..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} OSC32KCTRL_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSC32KCTRL_INTENCLR_OFFSET          (0x00)                                        /**<  (OSC32KCTRL_INTENCLR) Interrupt Enable Clear  Offset */
+#define OSC32KCTRL_INTENCLR_RESETVALUE      _U_(0x00)                                     /**<  (OSC32KCTRL_INTENCLR) Interrupt Enable Clear  Reset Value */
+
+#define OSC32KCTRL_INTENCLR_XOSC32KRDY_Pos  0                                              /**< (OSC32KCTRL_INTENCLR) XOSC32K Ready Interrupt Enable Position */
+#define OSC32KCTRL_INTENCLR_XOSC32KRDY_Msk  (_U_(0x1) << OSC32KCTRL_INTENCLR_XOSC32KRDY_Pos)  /**< (OSC32KCTRL_INTENCLR) XOSC32K Ready Interrupt Enable Mask */
+#define OSC32KCTRL_INTENCLR_XOSC32KRDY      OSC32KCTRL_INTENCLR_XOSC32KRDY_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSC32KCTRL_INTENCLR_XOSC32KRDY_Msk instead */
+#define OSC32KCTRL_INTENCLR_CLKFAIL_Pos     2                                              /**< (OSC32KCTRL_INTENCLR) XOSC32K Clock Failure Detector Interrupt Enable Position */
+#define OSC32KCTRL_INTENCLR_CLKFAIL_Msk     (_U_(0x1) << OSC32KCTRL_INTENCLR_CLKFAIL_Pos)  /**< (OSC32KCTRL_INTENCLR) XOSC32K Clock Failure Detector Interrupt Enable Mask */
+#define OSC32KCTRL_INTENCLR_CLKFAIL         OSC32KCTRL_INTENCLR_CLKFAIL_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSC32KCTRL_INTENCLR_CLKFAIL_Msk instead */
+#define OSC32KCTRL_INTENCLR_MASK            _U_(0x05)                                      /**< \deprecated (OSC32KCTRL_INTENCLR) Register MASK  (Use OSC32KCTRL_INTENCLR_Msk instead)  */
+#define OSC32KCTRL_INTENCLR_Msk             _U_(0x05)                                      /**< (OSC32KCTRL_INTENCLR) Register Mask  */
+
+
+/* -------- OSC32KCTRL_INTENSET : (OSC32KCTRL Offset: 0x04) (R/W 32) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t XOSC32KRDY:1;              /**< bit:      0  XOSC32K Ready Interrupt Enable           */
+    uint32_t :1;                        /**< bit:      1  Reserved */
+    uint32_t CLKFAIL:1;                 /**< bit:      2  XOSC32K Clock Failure Detector Interrupt Enable */
+    uint32_t :29;                       /**< bit:  3..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} OSC32KCTRL_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSC32KCTRL_INTENSET_OFFSET          (0x04)                                        /**<  (OSC32KCTRL_INTENSET) Interrupt Enable Set  Offset */
+#define OSC32KCTRL_INTENSET_RESETVALUE      _U_(0x00)                                     /**<  (OSC32KCTRL_INTENSET) Interrupt Enable Set  Reset Value */
+
+#define OSC32KCTRL_INTENSET_XOSC32KRDY_Pos  0                                              /**< (OSC32KCTRL_INTENSET) XOSC32K Ready Interrupt Enable Position */
+#define OSC32KCTRL_INTENSET_XOSC32KRDY_Msk  (_U_(0x1) << OSC32KCTRL_INTENSET_XOSC32KRDY_Pos)  /**< (OSC32KCTRL_INTENSET) XOSC32K Ready Interrupt Enable Mask */
+#define OSC32KCTRL_INTENSET_XOSC32KRDY      OSC32KCTRL_INTENSET_XOSC32KRDY_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSC32KCTRL_INTENSET_XOSC32KRDY_Msk instead */
+#define OSC32KCTRL_INTENSET_CLKFAIL_Pos     2                                              /**< (OSC32KCTRL_INTENSET) XOSC32K Clock Failure Detector Interrupt Enable Position */
+#define OSC32KCTRL_INTENSET_CLKFAIL_Msk     (_U_(0x1) << OSC32KCTRL_INTENSET_CLKFAIL_Pos)  /**< (OSC32KCTRL_INTENSET) XOSC32K Clock Failure Detector Interrupt Enable Mask */
+#define OSC32KCTRL_INTENSET_CLKFAIL         OSC32KCTRL_INTENSET_CLKFAIL_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSC32KCTRL_INTENSET_CLKFAIL_Msk instead */
+#define OSC32KCTRL_INTENSET_MASK            _U_(0x05)                                      /**< \deprecated (OSC32KCTRL_INTENSET) Register MASK  (Use OSC32KCTRL_INTENSET_Msk instead)  */
+#define OSC32KCTRL_INTENSET_Msk             _U_(0x05)                                      /**< (OSC32KCTRL_INTENSET) Register Mask  */
+
+
+/* -------- OSC32KCTRL_INTFLAG : (OSC32KCTRL Offset: 0x08) (R/W 32) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint32_t XOSC32KRDY:1;              /**< bit:      0  XOSC32K Ready                            */
+    __I uint32_t :1;                        /**< bit:      1  Reserved */
+    __I uint32_t CLKFAIL:1;                 /**< bit:      2  XOSC32K Clock Failure Detector           */
+    __I uint32_t :29;                       /**< bit:  3..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} OSC32KCTRL_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSC32KCTRL_INTFLAG_OFFSET           (0x08)                                        /**<  (OSC32KCTRL_INTFLAG) Interrupt Flag Status and Clear  Offset */
+#define OSC32KCTRL_INTFLAG_RESETVALUE       _U_(0x00)                                     /**<  (OSC32KCTRL_INTFLAG) Interrupt Flag Status and Clear  Reset Value */
+
+#define OSC32KCTRL_INTFLAG_XOSC32KRDY_Pos   0                                              /**< (OSC32KCTRL_INTFLAG) XOSC32K Ready Position */
+#define OSC32KCTRL_INTFLAG_XOSC32KRDY_Msk   (_U_(0x1) << OSC32KCTRL_INTFLAG_XOSC32KRDY_Pos)  /**< (OSC32KCTRL_INTFLAG) XOSC32K Ready Mask */
+#define OSC32KCTRL_INTFLAG_XOSC32KRDY       OSC32KCTRL_INTFLAG_XOSC32KRDY_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSC32KCTRL_INTFLAG_XOSC32KRDY_Msk instead */
+#define OSC32KCTRL_INTFLAG_CLKFAIL_Pos      2                                              /**< (OSC32KCTRL_INTFLAG) XOSC32K Clock Failure Detector Position */
+#define OSC32KCTRL_INTFLAG_CLKFAIL_Msk      (_U_(0x1) << OSC32KCTRL_INTFLAG_CLKFAIL_Pos)   /**< (OSC32KCTRL_INTFLAG) XOSC32K Clock Failure Detector Mask */
+#define OSC32KCTRL_INTFLAG_CLKFAIL          OSC32KCTRL_INTFLAG_CLKFAIL_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSC32KCTRL_INTFLAG_CLKFAIL_Msk instead */
+#define OSC32KCTRL_INTFLAG_MASK             _U_(0x05)                                      /**< \deprecated (OSC32KCTRL_INTFLAG) Register MASK  (Use OSC32KCTRL_INTFLAG_Msk instead)  */
+#define OSC32KCTRL_INTFLAG_Msk              _U_(0x05)                                      /**< (OSC32KCTRL_INTFLAG) Register Mask  */
+
+
+/* -------- OSC32KCTRL_STATUS : (OSC32KCTRL Offset: 0x0c) (R/ 32) Power and Clocks Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t XOSC32KRDY:1;              /**< bit:      0  XOSC32K Ready                            */
+    uint32_t :1;                        /**< bit:      1  Reserved */
+    uint32_t CLKFAIL:1;                 /**< bit:      2  XOSC32K Clock Failure Detector           */
+    uint32_t CLKSW:1;                   /**< bit:      3  XOSC32K Clock switch                     */
+    uint32_t ULP32KSW:1;                /**< bit:      4  OSCULP32K Clock Switch                   */
+    uint32_t :27;                       /**< bit:  5..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} OSC32KCTRL_STATUS_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSC32KCTRL_STATUS_OFFSET            (0x0C)                                        /**<  (OSC32KCTRL_STATUS) Power and Clocks Status  Offset */
+#define OSC32KCTRL_STATUS_RESETVALUE        _U_(0x00)                                     /**<  (OSC32KCTRL_STATUS) Power and Clocks Status  Reset Value */
+
+#define OSC32KCTRL_STATUS_XOSC32KRDY_Pos    0                                              /**< (OSC32KCTRL_STATUS) XOSC32K Ready Position */
+#define OSC32KCTRL_STATUS_XOSC32KRDY_Msk    (_U_(0x1) << OSC32KCTRL_STATUS_XOSC32KRDY_Pos)  /**< (OSC32KCTRL_STATUS) XOSC32K Ready Mask */
+#define OSC32KCTRL_STATUS_XOSC32KRDY        OSC32KCTRL_STATUS_XOSC32KRDY_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSC32KCTRL_STATUS_XOSC32KRDY_Msk instead */
+#define OSC32KCTRL_STATUS_CLKFAIL_Pos       2                                              /**< (OSC32KCTRL_STATUS) XOSC32K Clock Failure Detector Position */
+#define OSC32KCTRL_STATUS_CLKFAIL_Msk       (_U_(0x1) << OSC32KCTRL_STATUS_CLKFAIL_Pos)    /**< (OSC32KCTRL_STATUS) XOSC32K Clock Failure Detector Mask */
+#define OSC32KCTRL_STATUS_CLKFAIL           OSC32KCTRL_STATUS_CLKFAIL_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSC32KCTRL_STATUS_CLKFAIL_Msk instead */
+#define OSC32KCTRL_STATUS_CLKSW_Pos         3                                              /**< (OSC32KCTRL_STATUS) XOSC32K Clock switch Position */
+#define OSC32KCTRL_STATUS_CLKSW_Msk         (_U_(0x1) << OSC32KCTRL_STATUS_CLKSW_Pos)      /**< (OSC32KCTRL_STATUS) XOSC32K Clock switch Mask */
+#define OSC32KCTRL_STATUS_CLKSW             OSC32KCTRL_STATUS_CLKSW_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSC32KCTRL_STATUS_CLKSW_Msk instead */
+#define OSC32KCTRL_STATUS_ULP32KSW_Pos      4                                              /**< (OSC32KCTRL_STATUS) OSCULP32K Clock Switch Position */
+#define OSC32KCTRL_STATUS_ULP32KSW_Msk      (_U_(0x1) << OSC32KCTRL_STATUS_ULP32KSW_Pos)   /**< (OSC32KCTRL_STATUS) OSCULP32K Clock Switch Mask */
+#define OSC32KCTRL_STATUS_ULP32KSW          OSC32KCTRL_STATUS_ULP32KSW_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSC32KCTRL_STATUS_ULP32KSW_Msk instead */
+#define OSC32KCTRL_STATUS_MASK              _U_(0x1D)                                      /**< \deprecated (OSC32KCTRL_STATUS) Register MASK  (Use OSC32KCTRL_STATUS_Msk instead)  */
+#define OSC32KCTRL_STATUS_Msk               _U_(0x1D)                                      /**< (OSC32KCTRL_STATUS) Register Mask  */
+
+
+/* -------- OSC32KCTRL_RTCCTRL : (OSC32KCTRL Offset: 0x10) (R/W 8) RTC Clock Selection -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  RTCSEL:3;                  /**< bit:   0..2  RTC Clock Selection                      */
+    uint8_t  :5;                        /**< bit:   3..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} OSC32KCTRL_RTCCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSC32KCTRL_RTCCTRL_OFFSET           (0x10)                                        /**<  (OSC32KCTRL_RTCCTRL) RTC Clock Selection  Offset */
+#define OSC32KCTRL_RTCCTRL_RESETVALUE       _U_(0x00)                                     /**<  (OSC32KCTRL_RTCCTRL) RTC Clock Selection  Reset Value */
+
+#define OSC32KCTRL_RTCCTRL_RTCSEL_Pos       0                                              /**< (OSC32KCTRL_RTCCTRL) RTC Clock Selection Position */
+#define OSC32KCTRL_RTCCTRL_RTCSEL_Msk       (_U_(0x7) << OSC32KCTRL_RTCCTRL_RTCSEL_Pos)    /**< (OSC32KCTRL_RTCCTRL) RTC Clock Selection Mask */
+#define OSC32KCTRL_RTCCTRL_RTCSEL(value)    (OSC32KCTRL_RTCCTRL_RTCSEL_Msk & ((value) << OSC32KCTRL_RTCCTRL_RTCSEL_Pos))
+#define   OSC32KCTRL_RTCCTRL_RTCSEL_ULP1K_Val _U_(0x0)                                       /**< (OSC32KCTRL_RTCCTRL) 1.024kHz from 32kHz internal ULP oscillator  */
+#define   OSC32KCTRL_RTCCTRL_RTCSEL_ULP32K_Val _U_(0x1)                                       /**< (OSC32KCTRL_RTCCTRL) 32.768kHz from 32kHz internal ULP oscillator  */
+#define   OSC32KCTRL_RTCCTRL_RTCSEL_OSC1K_Val _U_(0x2)                                       /**< (OSC32KCTRL_RTCCTRL) 1.024kHz from 32.768kHz internal oscillator  */
+#define   OSC32KCTRL_RTCCTRL_RTCSEL_OSC32K_Val _U_(0x3)                                       /**< (OSC32KCTRL_RTCCTRL) 32.768kHz from 32.768kHz internal oscillator  */
+#define   OSC32KCTRL_RTCCTRL_RTCSEL_XOSC1K_Val _U_(0x4)                                       /**< (OSC32KCTRL_RTCCTRL) 1.024kHz from 32.768kHz internal oscillator  */
+#define   OSC32KCTRL_RTCCTRL_RTCSEL_XOSC32K_Val _U_(0x5)                                       /**< (OSC32KCTRL_RTCCTRL) 32.768kHz from 32.768kHz external crystal oscillator  */
+#define OSC32KCTRL_RTCCTRL_RTCSEL_ULP1K     (OSC32KCTRL_RTCCTRL_RTCSEL_ULP1K_Val << OSC32KCTRL_RTCCTRL_RTCSEL_Pos)  /**< (OSC32KCTRL_RTCCTRL) 1.024kHz from 32kHz internal ULP oscillator Position  */
+#define OSC32KCTRL_RTCCTRL_RTCSEL_ULP32K    (OSC32KCTRL_RTCCTRL_RTCSEL_ULP32K_Val << OSC32KCTRL_RTCCTRL_RTCSEL_Pos)  /**< (OSC32KCTRL_RTCCTRL) 32.768kHz from 32kHz internal ULP oscillator Position  */
+#define OSC32KCTRL_RTCCTRL_RTCSEL_OSC1K     (OSC32KCTRL_RTCCTRL_RTCSEL_OSC1K_Val << OSC32KCTRL_RTCCTRL_RTCSEL_Pos)  /**< (OSC32KCTRL_RTCCTRL) 1.024kHz from 32.768kHz internal oscillator Position  */
+#define OSC32KCTRL_RTCCTRL_RTCSEL_OSC32K    (OSC32KCTRL_RTCCTRL_RTCSEL_OSC32K_Val << OSC32KCTRL_RTCCTRL_RTCSEL_Pos)  /**< (OSC32KCTRL_RTCCTRL) 32.768kHz from 32.768kHz internal oscillator Position  */
+#define OSC32KCTRL_RTCCTRL_RTCSEL_XOSC1K    (OSC32KCTRL_RTCCTRL_RTCSEL_XOSC1K_Val << OSC32KCTRL_RTCCTRL_RTCSEL_Pos)  /**< (OSC32KCTRL_RTCCTRL) 1.024kHz from 32.768kHz internal oscillator Position  */
+#define OSC32KCTRL_RTCCTRL_RTCSEL_XOSC32K   (OSC32KCTRL_RTCCTRL_RTCSEL_XOSC32K_Val << OSC32KCTRL_RTCCTRL_RTCSEL_Pos)  /**< (OSC32KCTRL_RTCCTRL) 32.768kHz from 32.768kHz external crystal oscillator Position  */
+#define OSC32KCTRL_RTCCTRL_MASK             _U_(0x07)                                      /**< \deprecated (OSC32KCTRL_RTCCTRL) Register MASK  (Use OSC32KCTRL_RTCCTRL_Msk instead)  */
+#define OSC32KCTRL_RTCCTRL_Msk              _U_(0x07)                                      /**< (OSC32KCTRL_RTCCTRL) Register Mask  */
+
+
+/* -------- OSC32KCTRL_XOSC32K : (OSC32KCTRL Offset: 0x14) (R/W 16) 32kHz External Crystal Oscillator (XOSC32K) Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t :1;                        /**< bit:      0  Reserved */
+    uint16_t ENABLE:1;                  /**< bit:      1  Oscillator Enable                        */
+    uint16_t XTALEN:1;                  /**< bit:      2  Crystal Oscillator Enable                */
+    uint16_t EN32K:1;                   /**< bit:      3  32kHz Output Enable                      */
+    uint16_t EN1K:1;                    /**< bit:      4  1kHz Output Enable                       */
+    uint16_t :1;                        /**< bit:      5  Reserved */
+    uint16_t RUNSTDBY:1;                /**< bit:      6  Run in Standby                           */
+    uint16_t ONDEMAND:1;                /**< bit:      7  On Demand Control                        */
+    uint16_t STARTUP:3;                 /**< bit:  8..10  Oscillator Start-Up Time                 */
+    uint16_t :1;                        /**< bit:     11  Reserved */
+    uint16_t WRTLOCK:1;                 /**< bit:     12  Write Lock                               */
+    uint16_t :3;                        /**< bit: 13..15  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} OSC32KCTRL_XOSC32K_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSC32KCTRL_XOSC32K_OFFSET           (0x14)                                        /**<  (OSC32KCTRL_XOSC32K) 32kHz External Crystal Oscillator (XOSC32K) Control  Offset */
+#define OSC32KCTRL_XOSC32K_RESETVALUE       _U_(0x80)                                     /**<  (OSC32KCTRL_XOSC32K) 32kHz External Crystal Oscillator (XOSC32K) Control  Reset Value */
+
+#define OSC32KCTRL_XOSC32K_ENABLE_Pos       1                                              /**< (OSC32KCTRL_XOSC32K) Oscillator Enable Position */
+#define OSC32KCTRL_XOSC32K_ENABLE_Msk       (_U_(0x1) << OSC32KCTRL_XOSC32K_ENABLE_Pos)    /**< (OSC32KCTRL_XOSC32K) Oscillator Enable Mask */
+#define OSC32KCTRL_XOSC32K_ENABLE           OSC32KCTRL_XOSC32K_ENABLE_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSC32KCTRL_XOSC32K_ENABLE_Msk instead */
+#define OSC32KCTRL_XOSC32K_XTALEN_Pos       2                                              /**< (OSC32KCTRL_XOSC32K) Crystal Oscillator Enable Position */
+#define OSC32KCTRL_XOSC32K_XTALEN_Msk       (_U_(0x1) << OSC32KCTRL_XOSC32K_XTALEN_Pos)    /**< (OSC32KCTRL_XOSC32K) Crystal Oscillator Enable Mask */
+#define OSC32KCTRL_XOSC32K_XTALEN           OSC32KCTRL_XOSC32K_XTALEN_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSC32KCTRL_XOSC32K_XTALEN_Msk instead */
+#define OSC32KCTRL_XOSC32K_EN32K_Pos        3                                              /**< (OSC32KCTRL_XOSC32K) 32kHz Output Enable Position */
+#define OSC32KCTRL_XOSC32K_EN32K_Msk        (_U_(0x1) << OSC32KCTRL_XOSC32K_EN32K_Pos)     /**< (OSC32KCTRL_XOSC32K) 32kHz Output Enable Mask */
+#define OSC32KCTRL_XOSC32K_EN32K            OSC32KCTRL_XOSC32K_EN32K_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSC32KCTRL_XOSC32K_EN32K_Msk instead */
+#define OSC32KCTRL_XOSC32K_EN1K_Pos         4                                              /**< (OSC32KCTRL_XOSC32K) 1kHz Output Enable Position */
+#define OSC32KCTRL_XOSC32K_EN1K_Msk         (_U_(0x1) << OSC32KCTRL_XOSC32K_EN1K_Pos)      /**< (OSC32KCTRL_XOSC32K) 1kHz Output Enable Mask */
+#define OSC32KCTRL_XOSC32K_EN1K             OSC32KCTRL_XOSC32K_EN1K_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSC32KCTRL_XOSC32K_EN1K_Msk instead */
+#define OSC32KCTRL_XOSC32K_RUNSTDBY_Pos     6                                              /**< (OSC32KCTRL_XOSC32K) Run in Standby Position */
+#define OSC32KCTRL_XOSC32K_RUNSTDBY_Msk     (_U_(0x1) << OSC32KCTRL_XOSC32K_RUNSTDBY_Pos)  /**< (OSC32KCTRL_XOSC32K) Run in Standby Mask */
+#define OSC32KCTRL_XOSC32K_RUNSTDBY         OSC32KCTRL_XOSC32K_RUNSTDBY_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSC32KCTRL_XOSC32K_RUNSTDBY_Msk instead */
+#define OSC32KCTRL_XOSC32K_ONDEMAND_Pos     7                                              /**< (OSC32KCTRL_XOSC32K) On Demand Control Position */
+#define OSC32KCTRL_XOSC32K_ONDEMAND_Msk     (_U_(0x1) << OSC32KCTRL_XOSC32K_ONDEMAND_Pos)  /**< (OSC32KCTRL_XOSC32K) On Demand Control Mask */
+#define OSC32KCTRL_XOSC32K_ONDEMAND         OSC32KCTRL_XOSC32K_ONDEMAND_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSC32KCTRL_XOSC32K_ONDEMAND_Msk instead */
+#define OSC32KCTRL_XOSC32K_STARTUP_Pos      8                                              /**< (OSC32KCTRL_XOSC32K) Oscillator Start-Up Time Position */
+#define OSC32KCTRL_XOSC32K_STARTUP_Msk      (_U_(0x7) << OSC32KCTRL_XOSC32K_STARTUP_Pos)   /**< (OSC32KCTRL_XOSC32K) Oscillator Start-Up Time Mask */
+#define OSC32KCTRL_XOSC32K_STARTUP(value)   (OSC32KCTRL_XOSC32K_STARTUP_Msk & ((value) << OSC32KCTRL_XOSC32K_STARTUP_Pos))
+#define OSC32KCTRL_XOSC32K_WRTLOCK_Pos      12                                             /**< (OSC32KCTRL_XOSC32K) Write Lock Position */
+#define OSC32KCTRL_XOSC32K_WRTLOCK_Msk      (_U_(0x1) << OSC32KCTRL_XOSC32K_WRTLOCK_Pos)   /**< (OSC32KCTRL_XOSC32K) Write Lock Mask */
+#define OSC32KCTRL_XOSC32K_WRTLOCK          OSC32KCTRL_XOSC32K_WRTLOCK_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSC32KCTRL_XOSC32K_WRTLOCK_Msk instead */
+#define OSC32KCTRL_XOSC32K_MASK             _U_(0x17DE)                                    /**< \deprecated (OSC32KCTRL_XOSC32K) Register MASK  (Use OSC32KCTRL_XOSC32K_Msk instead)  */
+#define OSC32KCTRL_XOSC32K_Msk              _U_(0x17DE)                                    /**< (OSC32KCTRL_XOSC32K) Register Mask  */
+
+
+/* -------- OSC32KCTRL_CFDCTRL : (OSC32KCTRL Offset: 0x16) (R/W 8) Clock Failure Detector Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  CFDEN:1;                   /**< bit:      0  Clock Failure Detector Enable            */
+    uint8_t  SWBACK:1;                  /**< bit:      1  Clock Switch Back                        */
+    uint8_t  CFDPRESC:1;                /**< bit:      2  Clock Failure Detector Prescaler         */
+    uint8_t  :5;                        /**< bit:   3..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} OSC32KCTRL_CFDCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSC32KCTRL_CFDCTRL_OFFSET           (0x16)                                        /**<  (OSC32KCTRL_CFDCTRL) Clock Failure Detector Control  Offset */
+#define OSC32KCTRL_CFDCTRL_RESETVALUE       _U_(0x00)                                     /**<  (OSC32KCTRL_CFDCTRL) Clock Failure Detector Control  Reset Value */
+
+#define OSC32KCTRL_CFDCTRL_CFDEN_Pos        0                                              /**< (OSC32KCTRL_CFDCTRL) Clock Failure Detector Enable Position */
+#define OSC32KCTRL_CFDCTRL_CFDEN_Msk        (_U_(0x1) << OSC32KCTRL_CFDCTRL_CFDEN_Pos)     /**< (OSC32KCTRL_CFDCTRL) Clock Failure Detector Enable Mask */
+#define OSC32KCTRL_CFDCTRL_CFDEN            OSC32KCTRL_CFDCTRL_CFDEN_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSC32KCTRL_CFDCTRL_CFDEN_Msk instead */
+#define OSC32KCTRL_CFDCTRL_SWBACK_Pos       1                                              /**< (OSC32KCTRL_CFDCTRL) Clock Switch Back Position */
+#define OSC32KCTRL_CFDCTRL_SWBACK_Msk       (_U_(0x1) << OSC32KCTRL_CFDCTRL_SWBACK_Pos)    /**< (OSC32KCTRL_CFDCTRL) Clock Switch Back Mask */
+#define OSC32KCTRL_CFDCTRL_SWBACK           OSC32KCTRL_CFDCTRL_SWBACK_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSC32KCTRL_CFDCTRL_SWBACK_Msk instead */
+#define OSC32KCTRL_CFDCTRL_CFDPRESC_Pos     2                                              /**< (OSC32KCTRL_CFDCTRL) Clock Failure Detector Prescaler Position */
+#define OSC32KCTRL_CFDCTRL_CFDPRESC_Msk     (_U_(0x1) << OSC32KCTRL_CFDCTRL_CFDPRESC_Pos)  /**< (OSC32KCTRL_CFDCTRL) Clock Failure Detector Prescaler Mask */
+#define OSC32KCTRL_CFDCTRL_CFDPRESC         OSC32KCTRL_CFDCTRL_CFDPRESC_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSC32KCTRL_CFDCTRL_CFDPRESC_Msk instead */
+#define OSC32KCTRL_CFDCTRL_MASK             _U_(0x07)                                      /**< \deprecated (OSC32KCTRL_CFDCTRL) Register MASK  (Use OSC32KCTRL_CFDCTRL_Msk instead)  */
+#define OSC32KCTRL_CFDCTRL_Msk              _U_(0x07)                                      /**< (OSC32KCTRL_CFDCTRL) Register Mask  */
+
+
+/* -------- OSC32KCTRL_EVCTRL : (OSC32KCTRL Offset: 0x17) (R/W 8) Event Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  CFDEO:1;                   /**< bit:      0  Clock Failure Detector Event Output Enable */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} OSC32KCTRL_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSC32KCTRL_EVCTRL_OFFSET            (0x17)                                        /**<  (OSC32KCTRL_EVCTRL) Event Control  Offset */
+#define OSC32KCTRL_EVCTRL_RESETVALUE        _U_(0x00)                                     /**<  (OSC32KCTRL_EVCTRL) Event Control  Reset Value */
+
+#define OSC32KCTRL_EVCTRL_CFDEO_Pos         0                                              /**< (OSC32KCTRL_EVCTRL) Clock Failure Detector Event Output Enable Position */
+#define OSC32KCTRL_EVCTRL_CFDEO_Msk         (_U_(0x1) << OSC32KCTRL_EVCTRL_CFDEO_Pos)      /**< (OSC32KCTRL_EVCTRL) Clock Failure Detector Event Output Enable Mask */
+#define OSC32KCTRL_EVCTRL_CFDEO             OSC32KCTRL_EVCTRL_CFDEO_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSC32KCTRL_EVCTRL_CFDEO_Msk instead */
+#define OSC32KCTRL_EVCTRL_MASK              _U_(0x01)                                      /**< \deprecated (OSC32KCTRL_EVCTRL) Register MASK  (Use OSC32KCTRL_EVCTRL_Msk instead)  */
+#define OSC32KCTRL_EVCTRL_Msk               _U_(0x01)                                      /**< (OSC32KCTRL_EVCTRL) Register Mask  */
+
+
+/* -------- OSC32KCTRL_OSCULP32K : (OSC32KCTRL Offset: 0x1c) (R/W 32) 32kHz Ultra Low Power Internal Oscillator (OSCULP32K) Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t :5;                        /**< bit:   0..4  Reserved */
+    uint32_t ULP32KSW:1;                /**< bit:      5  OSCULP32K Clock Switch Enable            */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t CALIB:5;                   /**< bit:  8..12  Oscillator Calibration                   */
+    uint32_t :2;                        /**< bit: 13..14  Reserved */
+    uint32_t WRTLOCK:1;                 /**< bit:     15  Write Lock                               */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} OSC32KCTRL_OSCULP32K_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSC32KCTRL_OSCULP32K_OFFSET         (0x1C)                                        /**<  (OSC32KCTRL_OSCULP32K) 32kHz Ultra Low Power Internal Oscillator (OSCULP32K) Control  Offset */
+#define OSC32KCTRL_OSCULP32K_RESETVALUE     _U_(0x00)                                     /**<  (OSC32KCTRL_OSCULP32K) 32kHz Ultra Low Power Internal Oscillator (OSCULP32K) Control  Reset Value */
+
+#define OSC32KCTRL_OSCULP32K_ULP32KSW_Pos   5                                              /**< (OSC32KCTRL_OSCULP32K) OSCULP32K Clock Switch Enable Position */
+#define OSC32KCTRL_OSCULP32K_ULP32KSW_Msk   (_U_(0x1) << OSC32KCTRL_OSCULP32K_ULP32KSW_Pos)  /**< (OSC32KCTRL_OSCULP32K) OSCULP32K Clock Switch Enable Mask */
+#define OSC32KCTRL_OSCULP32K_ULP32KSW       OSC32KCTRL_OSCULP32K_ULP32KSW_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSC32KCTRL_OSCULP32K_ULP32KSW_Msk instead */
+#define OSC32KCTRL_OSCULP32K_CALIB_Pos      8                                              /**< (OSC32KCTRL_OSCULP32K) Oscillator Calibration Position */
+#define OSC32KCTRL_OSCULP32K_CALIB_Msk      (_U_(0x1F) << OSC32KCTRL_OSCULP32K_CALIB_Pos)  /**< (OSC32KCTRL_OSCULP32K) Oscillator Calibration Mask */
+#define OSC32KCTRL_OSCULP32K_CALIB(value)   (OSC32KCTRL_OSCULP32K_CALIB_Msk & ((value) << OSC32KCTRL_OSCULP32K_CALIB_Pos))
+#define OSC32KCTRL_OSCULP32K_WRTLOCK_Pos    15                                             /**< (OSC32KCTRL_OSCULP32K) Write Lock Position */
+#define OSC32KCTRL_OSCULP32K_WRTLOCK_Msk    (_U_(0x1) << OSC32KCTRL_OSCULP32K_WRTLOCK_Pos)  /**< (OSC32KCTRL_OSCULP32K) Write Lock Mask */
+#define OSC32KCTRL_OSCULP32K_WRTLOCK        OSC32KCTRL_OSCULP32K_WRTLOCK_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSC32KCTRL_OSCULP32K_WRTLOCK_Msk instead */
+#define OSC32KCTRL_OSCULP32K_MASK           _U_(0x9F20)                                    /**< \deprecated (OSC32KCTRL_OSCULP32K) Register MASK  (Use OSC32KCTRL_OSCULP32K_Msk instead)  */
+#define OSC32KCTRL_OSCULP32K_Msk            _U_(0x9F20)                                    /**< (OSC32KCTRL_OSCULP32K) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief OSC32KCTRL hardware registers */
+typedef struct {  /* 32k Oscillators Control */
+  __IO OSC32KCTRL_INTENCLR_Type       INTENCLR;       /**< Offset: 0x00 (R/W  32) Interrupt Enable Clear */
+  __IO OSC32KCTRL_INTENSET_Type       INTENSET;       /**< Offset: 0x04 (R/W  32) Interrupt Enable Set */
+  __IO OSC32KCTRL_INTFLAG_Type        INTFLAG;        /**< Offset: 0x08 (R/W  32) Interrupt Flag Status and Clear */
+  __I  OSC32KCTRL_STATUS_Type         STATUS;         /**< Offset: 0x0C (R/   32) Power and Clocks Status */
+  __IO OSC32KCTRL_RTCCTRL_Type        RTCCTRL;        /**< Offset: 0x10 (R/W   8) RTC Clock Selection */
+  __I  uint8_t                        Reserved1[3];
+  __IO OSC32KCTRL_XOSC32K_Type        XOSC32K;        /**< Offset: 0x14 (R/W  16) 32kHz External Crystal Oscillator (XOSC32K) Control */
+  __IO OSC32KCTRL_CFDCTRL_Type        CFDCTRL;        /**< Offset: 0x16 (R/W   8) Clock Failure Detector Control */
+  __IO OSC32KCTRL_EVCTRL_Type         EVCTRL;         /**< Offset: 0x17 (R/W   8) Event Control */
+  __I  uint8_t                        Reserved2[4];
+  __IO OSC32KCTRL_OSCULP32K_Type      OSCULP32K;      /**< Offset: 0x1C (R/W  32) 32kHz Ultra Low Power Internal Oscillator (OSCULP32K) Control */
+} Osc32kctrl;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of 32k Oscillators Control */
+
+#endif /* _SAML10_OSC32KCTRL_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/component/oscctrl.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/oscctrl.h
@@ -1,0 +1,878 @@
+/**
+ * \file
+ *
+ * \brief Component description for OSCCTRL
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_OSCCTRL_COMPONENT_H_
+#define _SAML10_OSCCTRL_COMPONENT_H_
+#define _SAML10_OSCCTRL_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML10 Oscillators Control
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR OSCCTRL */
+/* ========================================================================== */
+
+#define OSCCTRL_U2119                      /**< (OSCCTRL) Module ID */
+#define REV_OSCCTRL 0x400                  /**< (OSCCTRL) Module revision */
+
+/* -------- OSCCTRL_EVCTRL : (OSCCTRL Offset: 0x00) (R/W 8) Event Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  CFDEO:1;                   /**< bit:      0  Clock Failure Detector Event Output Enable */
+    uint8_t  TUNEEI:1;                  /**< bit:      1  Tune Event Input Enable                  */
+    uint8_t  TUNEINV:1;                 /**< bit:      2  Tune Event Input Invert                  */
+    uint8_t  :5;                        /**< bit:   3..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} OSCCTRL_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_EVCTRL_OFFSET               (0x00)                                        /**<  (OSCCTRL_EVCTRL) Event Control  Offset */
+#define OSCCTRL_EVCTRL_RESETVALUE           _U_(0x00)                                     /**<  (OSCCTRL_EVCTRL) Event Control  Reset Value */
+
+#define OSCCTRL_EVCTRL_CFDEO_Pos            0                                              /**< (OSCCTRL_EVCTRL) Clock Failure Detector Event Output Enable Position */
+#define OSCCTRL_EVCTRL_CFDEO_Msk            (_U_(0x1) << OSCCTRL_EVCTRL_CFDEO_Pos)         /**< (OSCCTRL_EVCTRL) Clock Failure Detector Event Output Enable Mask */
+#define OSCCTRL_EVCTRL_CFDEO                OSCCTRL_EVCTRL_CFDEO_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_EVCTRL_CFDEO_Msk instead */
+#define OSCCTRL_EVCTRL_TUNEEI_Pos           1                                              /**< (OSCCTRL_EVCTRL) Tune Event Input Enable Position */
+#define OSCCTRL_EVCTRL_TUNEEI_Msk           (_U_(0x1) << OSCCTRL_EVCTRL_TUNEEI_Pos)        /**< (OSCCTRL_EVCTRL) Tune Event Input Enable Mask */
+#define OSCCTRL_EVCTRL_TUNEEI               OSCCTRL_EVCTRL_TUNEEI_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_EVCTRL_TUNEEI_Msk instead */
+#define OSCCTRL_EVCTRL_TUNEINV_Pos          2                                              /**< (OSCCTRL_EVCTRL) Tune Event Input Invert Position */
+#define OSCCTRL_EVCTRL_TUNEINV_Msk          (_U_(0x1) << OSCCTRL_EVCTRL_TUNEINV_Pos)       /**< (OSCCTRL_EVCTRL) Tune Event Input Invert Mask */
+#define OSCCTRL_EVCTRL_TUNEINV              OSCCTRL_EVCTRL_TUNEINV_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_EVCTRL_TUNEINV_Msk instead */
+#define OSCCTRL_EVCTRL_MASK                 _U_(0x07)                                      /**< \deprecated (OSCCTRL_EVCTRL) Register MASK  (Use OSCCTRL_EVCTRL_Msk instead)  */
+#define OSCCTRL_EVCTRL_Msk                  _U_(0x07)                                      /**< (OSCCTRL_EVCTRL) Register Mask  */
+
+
+/* -------- OSCCTRL_INTENCLR : (OSCCTRL Offset: 0x04) (R/W 32) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t XOSCRDY:1;                 /**< bit:      0  XOSC Ready Interrupt Enable              */
+    uint32_t XOSCFAIL:1;                /**< bit:      1  XOSC Clock Failure Detector Interrupt Enable */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t OSC16MRDY:1;               /**< bit:      4  OSC16M Ready Interrupt Enable            */
+    uint32_t :3;                        /**< bit:   5..7  Reserved */
+    uint32_t DFLLULPRDY:1;              /**< bit:      8  DFLLULP Ready interrupt Enable           */
+    uint32_t DFLLULPLOCK:1;             /**< bit:      9  DFLLULP Lock Interrupt Enable            */
+    uint32_t DFLLULPNOLOCK:1;           /**< bit:     10  DFLLULP No Lock Interrupt Enable         */
+    uint32_t :5;                        /**< bit: 11..15  Reserved */
+    uint32_t DPLLLCKR:1;                /**< bit:     16  DPLL Lock Rise Interrupt Enable          */
+    uint32_t DPLLLCKF:1;                /**< bit:     17  DPLL Lock Fall Interrupt Enable          */
+    uint32_t DPLLLTO:1;                 /**< bit:     18  DPLL Lock Timeout Interrupt Enable       */
+    uint32_t DPLLLDRTO:1;               /**< bit:     19  DPLL Loop Divider Ratio Update Complete Interrupt Enable */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} OSCCTRL_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_INTENCLR_OFFSET             (0x04)                                        /**<  (OSCCTRL_INTENCLR) Interrupt Enable Clear  Offset */
+#define OSCCTRL_INTENCLR_RESETVALUE         _U_(0x00)                                     /**<  (OSCCTRL_INTENCLR) Interrupt Enable Clear  Reset Value */
+
+#define OSCCTRL_INTENCLR_XOSCRDY_Pos        0                                              /**< (OSCCTRL_INTENCLR) XOSC Ready Interrupt Enable Position */
+#define OSCCTRL_INTENCLR_XOSCRDY_Msk        (_U_(0x1) << OSCCTRL_INTENCLR_XOSCRDY_Pos)     /**< (OSCCTRL_INTENCLR) XOSC Ready Interrupt Enable Mask */
+#define OSCCTRL_INTENCLR_XOSCRDY            OSCCTRL_INTENCLR_XOSCRDY_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTENCLR_XOSCRDY_Msk instead */
+#define OSCCTRL_INTENCLR_XOSCFAIL_Pos       1                                              /**< (OSCCTRL_INTENCLR) XOSC Clock Failure Detector Interrupt Enable Position */
+#define OSCCTRL_INTENCLR_XOSCFAIL_Msk       (_U_(0x1) << OSCCTRL_INTENCLR_XOSCFAIL_Pos)    /**< (OSCCTRL_INTENCLR) XOSC Clock Failure Detector Interrupt Enable Mask */
+#define OSCCTRL_INTENCLR_XOSCFAIL           OSCCTRL_INTENCLR_XOSCFAIL_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTENCLR_XOSCFAIL_Msk instead */
+#define OSCCTRL_INTENCLR_OSC16MRDY_Pos      4                                              /**< (OSCCTRL_INTENCLR) OSC16M Ready Interrupt Enable Position */
+#define OSCCTRL_INTENCLR_OSC16MRDY_Msk      (_U_(0x1) << OSCCTRL_INTENCLR_OSC16MRDY_Pos)   /**< (OSCCTRL_INTENCLR) OSC16M Ready Interrupt Enable Mask */
+#define OSCCTRL_INTENCLR_OSC16MRDY          OSCCTRL_INTENCLR_OSC16MRDY_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTENCLR_OSC16MRDY_Msk instead */
+#define OSCCTRL_INTENCLR_DFLLULPRDY_Pos     8                                              /**< (OSCCTRL_INTENCLR) DFLLULP Ready interrupt Enable Position */
+#define OSCCTRL_INTENCLR_DFLLULPRDY_Msk     (_U_(0x1) << OSCCTRL_INTENCLR_DFLLULPRDY_Pos)  /**< (OSCCTRL_INTENCLR) DFLLULP Ready interrupt Enable Mask */
+#define OSCCTRL_INTENCLR_DFLLULPRDY         OSCCTRL_INTENCLR_DFLLULPRDY_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTENCLR_DFLLULPRDY_Msk instead */
+#define OSCCTRL_INTENCLR_DFLLULPLOCK_Pos    9                                              /**< (OSCCTRL_INTENCLR) DFLLULP Lock Interrupt Enable Position */
+#define OSCCTRL_INTENCLR_DFLLULPLOCK_Msk    (_U_(0x1) << OSCCTRL_INTENCLR_DFLLULPLOCK_Pos)  /**< (OSCCTRL_INTENCLR) DFLLULP Lock Interrupt Enable Mask */
+#define OSCCTRL_INTENCLR_DFLLULPLOCK        OSCCTRL_INTENCLR_DFLLULPLOCK_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTENCLR_DFLLULPLOCK_Msk instead */
+#define OSCCTRL_INTENCLR_DFLLULPNOLOCK_Pos  10                                             /**< (OSCCTRL_INTENCLR) DFLLULP No Lock Interrupt Enable Position */
+#define OSCCTRL_INTENCLR_DFLLULPNOLOCK_Msk  (_U_(0x1) << OSCCTRL_INTENCLR_DFLLULPNOLOCK_Pos)  /**< (OSCCTRL_INTENCLR) DFLLULP No Lock Interrupt Enable Mask */
+#define OSCCTRL_INTENCLR_DFLLULPNOLOCK      OSCCTRL_INTENCLR_DFLLULPNOLOCK_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTENCLR_DFLLULPNOLOCK_Msk instead */
+#define OSCCTRL_INTENCLR_DPLLLCKR_Pos       16                                             /**< (OSCCTRL_INTENCLR) DPLL Lock Rise Interrupt Enable Position */
+#define OSCCTRL_INTENCLR_DPLLLCKR_Msk       (_U_(0x1) << OSCCTRL_INTENCLR_DPLLLCKR_Pos)    /**< (OSCCTRL_INTENCLR) DPLL Lock Rise Interrupt Enable Mask */
+#define OSCCTRL_INTENCLR_DPLLLCKR           OSCCTRL_INTENCLR_DPLLLCKR_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTENCLR_DPLLLCKR_Msk instead */
+#define OSCCTRL_INTENCLR_DPLLLCKF_Pos       17                                             /**< (OSCCTRL_INTENCLR) DPLL Lock Fall Interrupt Enable Position */
+#define OSCCTRL_INTENCLR_DPLLLCKF_Msk       (_U_(0x1) << OSCCTRL_INTENCLR_DPLLLCKF_Pos)    /**< (OSCCTRL_INTENCLR) DPLL Lock Fall Interrupt Enable Mask */
+#define OSCCTRL_INTENCLR_DPLLLCKF           OSCCTRL_INTENCLR_DPLLLCKF_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTENCLR_DPLLLCKF_Msk instead */
+#define OSCCTRL_INTENCLR_DPLLLTO_Pos        18                                             /**< (OSCCTRL_INTENCLR) DPLL Lock Timeout Interrupt Enable Position */
+#define OSCCTRL_INTENCLR_DPLLLTO_Msk        (_U_(0x1) << OSCCTRL_INTENCLR_DPLLLTO_Pos)     /**< (OSCCTRL_INTENCLR) DPLL Lock Timeout Interrupt Enable Mask */
+#define OSCCTRL_INTENCLR_DPLLLTO            OSCCTRL_INTENCLR_DPLLLTO_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTENCLR_DPLLLTO_Msk instead */
+#define OSCCTRL_INTENCLR_DPLLLDRTO_Pos      19                                             /**< (OSCCTRL_INTENCLR) DPLL Loop Divider Ratio Update Complete Interrupt Enable Position */
+#define OSCCTRL_INTENCLR_DPLLLDRTO_Msk      (_U_(0x1) << OSCCTRL_INTENCLR_DPLLLDRTO_Pos)   /**< (OSCCTRL_INTENCLR) DPLL Loop Divider Ratio Update Complete Interrupt Enable Mask */
+#define OSCCTRL_INTENCLR_DPLLLDRTO          OSCCTRL_INTENCLR_DPLLLDRTO_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTENCLR_DPLLLDRTO_Msk instead */
+#define OSCCTRL_INTENCLR_MASK               _U_(0xF0713)                                   /**< \deprecated (OSCCTRL_INTENCLR) Register MASK  (Use OSCCTRL_INTENCLR_Msk instead)  */
+#define OSCCTRL_INTENCLR_Msk                _U_(0xF0713)                                   /**< (OSCCTRL_INTENCLR) Register Mask  */
+
+
+/* -------- OSCCTRL_INTENSET : (OSCCTRL Offset: 0x08) (R/W 32) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t XOSCRDY:1;                 /**< bit:      0  XOSC Ready Interrupt Enable              */
+    uint32_t XOSCFAIL:1;                /**< bit:      1  XOSC Clock Failure Detector Interrupt Enable */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t OSC16MRDY:1;               /**< bit:      4  OSC16M Ready Interrupt Enable            */
+    uint32_t :3;                        /**< bit:   5..7  Reserved */
+    uint32_t DFLLULPRDY:1;              /**< bit:      8  DFLLULP Ready interrupt Enable           */
+    uint32_t DFLLULPLOCK:1;             /**< bit:      9  DFLLULP Lock Interrupt Enable            */
+    uint32_t DFLLULPNOLOCK:1;           /**< bit:     10  DFLLULP No Lock Interrupt Enable         */
+    uint32_t :5;                        /**< bit: 11..15  Reserved */
+    uint32_t DPLLLCKR:1;                /**< bit:     16  DPLL Lock Rise Interrupt Enable          */
+    uint32_t DPLLLCKF:1;                /**< bit:     17  DPLL Lock Fall Interrupt Enable          */
+    uint32_t DPLLLTO:1;                 /**< bit:     18  DPLL Lock Timeout Interrupt Enable       */
+    uint32_t DPLLLDRTO:1;               /**< bit:     19  DPLL Loop Divider Ratio Update Complete Interrupt Enable */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} OSCCTRL_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_INTENSET_OFFSET             (0x08)                                        /**<  (OSCCTRL_INTENSET) Interrupt Enable Set  Offset */
+#define OSCCTRL_INTENSET_RESETVALUE         _U_(0x00)                                     /**<  (OSCCTRL_INTENSET) Interrupt Enable Set  Reset Value */
+
+#define OSCCTRL_INTENSET_XOSCRDY_Pos        0                                              /**< (OSCCTRL_INTENSET) XOSC Ready Interrupt Enable Position */
+#define OSCCTRL_INTENSET_XOSCRDY_Msk        (_U_(0x1) << OSCCTRL_INTENSET_XOSCRDY_Pos)     /**< (OSCCTRL_INTENSET) XOSC Ready Interrupt Enable Mask */
+#define OSCCTRL_INTENSET_XOSCRDY            OSCCTRL_INTENSET_XOSCRDY_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTENSET_XOSCRDY_Msk instead */
+#define OSCCTRL_INTENSET_XOSCFAIL_Pos       1                                              /**< (OSCCTRL_INTENSET) XOSC Clock Failure Detector Interrupt Enable Position */
+#define OSCCTRL_INTENSET_XOSCFAIL_Msk       (_U_(0x1) << OSCCTRL_INTENSET_XOSCFAIL_Pos)    /**< (OSCCTRL_INTENSET) XOSC Clock Failure Detector Interrupt Enable Mask */
+#define OSCCTRL_INTENSET_XOSCFAIL           OSCCTRL_INTENSET_XOSCFAIL_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTENSET_XOSCFAIL_Msk instead */
+#define OSCCTRL_INTENSET_OSC16MRDY_Pos      4                                              /**< (OSCCTRL_INTENSET) OSC16M Ready Interrupt Enable Position */
+#define OSCCTRL_INTENSET_OSC16MRDY_Msk      (_U_(0x1) << OSCCTRL_INTENSET_OSC16MRDY_Pos)   /**< (OSCCTRL_INTENSET) OSC16M Ready Interrupt Enable Mask */
+#define OSCCTRL_INTENSET_OSC16MRDY          OSCCTRL_INTENSET_OSC16MRDY_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTENSET_OSC16MRDY_Msk instead */
+#define OSCCTRL_INTENSET_DFLLULPRDY_Pos     8                                              /**< (OSCCTRL_INTENSET) DFLLULP Ready interrupt Enable Position */
+#define OSCCTRL_INTENSET_DFLLULPRDY_Msk     (_U_(0x1) << OSCCTRL_INTENSET_DFLLULPRDY_Pos)  /**< (OSCCTRL_INTENSET) DFLLULP Ready interrupt Enable Mask */
+#define OSCCTRL_INTENSET_DFLLULPRDY         OSCCTRL_INTENSET_DFLLULPRDY_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTENSET_DFLLULPRDY_Msk instead */
+#define OSCCTRL_INTENSET_DFLLULPLOCK_Pos    9                                              /**< (OSCCTRL_INTENSET) DFLLULP Lock Interrupt Enable Position */
+#define OSCCTRL_INTENSET_DFLLULPLOCK_Msk    (_U_(0x1) << OSCCTRL_INTENSET_DFLLULPLOCK_Pos)  /**< (OSCCTRL_INTENSET) DFLLULP Lock Interrupt Enable Mask */
+#define OSCCTRL_INTENSET_DFLLULPLOCK        OSCCTRL_INTENSET_DFLLULPLOCK_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTENSET_DFLLULPLOCK_Msk instead */
+#define OSCCTRL_INTENSET_DFLLULPNOLOCK_Pos  10                                             /**< (OSCCTRL_INTENSET) DFLLULP No Lock Interrupt Enable Position */
+#define OSCCTRL_INTENSET_DFLLULPNOLOCK_Msk  (_U_(0x1) << OSCCTRL_INTENSET_DFLLULPNOLOCK_Pos)  /**< (OSCCTRL_INTENSET) DFLLULP No Lock Interrupt Enable Mask */
+#define OSCCTRL_INTENSET_DFLLULPNOLOCK      OSCCTRL_INTENSET_DFLLULPNOLOCK_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTENSET_DFLLULPNOLOCK_Msk instead */
+#define OSCCTRL_INTENSET_DPLLLCKR_Pos       16                                             /**< (OSCCTRL_INTENSET) DPLL Lock Rise Interrupt Enable Position */
+#define OSCCTRL_INTENSET_DPLLLCKR_Msk       (_U_(0x1) << OSCCTRL_INTENSET_DPLLLCKR_Pos)    /**< (OSCCTRL_INTENSET) DPLL Lock Rise Interrupt Enable Mask */
+#define OSCCTRL_INTENSET_DPLLLCKR           OSCCTRL_INTENSET_DPLLLCKR_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTENSET_DPLLLCKR_Msk instead */
+#define OSCCTRL_INTENSET_DPLLLCKF_Pos       17                                             /**< (OSCCTRL_INTENSET) DPLL Lock Fall Interrupt Enable Position */
+#define OSCCTRL_INTENSET_DPLLLCKF_Msk       (_U_(0x1) << OSCCTRL_INTENSET_DPLLLCKF_Pos)    /**< (OSCCTRL_INTENSET) DPLL Lock Fall Interrupt Enable Mask */
+#define OSCCTRL_INTENSET_DPLLLCKF           OSCCTRL_INTENSET_DPLLLCKF_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTENSET_DPLLLCKF_Msk instead */
+#define OSCCTRL_INTENSET_DPLLLTO_Pos        18                                             /**< (OSCCTRL_INTENSET) DPLL Lock Timeout Interrupt Enable Position */
+#define OSCCTRL_INTENSET_DPLLLTO_Msk        (_U_(0x1) << OSCCTRL_INTENSET_DPLLLTO_Pos)     /**< (OSCCTRL_INTENSET) DPLL Lock Timeout Interrupt Enable Mask */
+#define OSCCTRL_INTENSET_DPLLLTO            OSCCTRL_INTENSET_DPLLLTO_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTENSET_DPLLLTO_Msk instead */
+#define OSCCTRL_INTENSET_DPLLLDRTO_Pos      19                                             /**< (OSCCTRL_INTENSET) DPLL Loop Divider Ratio Update Complete Interrupt Enable Position */
+#define OSCCTRL_INTENSET_DPLLLDRTO_Msk      (_U_(0x1) << OSCCTRL_INTENSET_DPLLLDRTO_Pos)   /**< (OSCCTRL_INTENSET) DPLL Loop Divider Ratio Update Complete Interrupt Enable Mask */
+#define OSCCTRL_INTENSET_DPLLLDRTO          OSCCTRL_INTENSET_DPLLLDRTO_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTENSET_DPLLLDRTO_Msk instead */
+#define OSCCTRL_INTENSET_MASK               _U_(0xF0713)                                   /**< \deprecated (OSCCTRL_INTENSET) Register MASK  (Use OSCCTRL_INTENSET_Msk instead)  */
+#define OSCCTRL_INTENSET_Msk                _U_(0xF0713)                                   /**< (OSCCTRL_INTENSET) Register Mask  */
+
+
+/* -------- OSCCTRL_INTFLAG : (OSCCTRL Offset: 0x0c) (R/W 32) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint32_t XOSCRDY:1;                 /**< bit:      0  XOSC Ready                               */
+    __I uint32_t XOSCFAIL:1;                /**< bit:      1  XOSC Clock Failure Detector              */
+    __I uint32_t :2;                        /**< bit:   2..3  Reserved */
+    __I uint32_t OSC16MRDY:1;               /**< bit:      4  OSC16M Ready                             */
+    __I uint32_t :3;                        /**< bit:   5..7  Reserved */
+    __I uint32_t DFLLULPRDY:1;              /**< bit:      8  DFLLULP Ready                            */
+    __I uint32_t DFLLULPLOCK:1;             /**< bit:      9  DFLLULP Lock                             */
+    __I uint32_t DFLLULPNOLOCK:1;           /**< bit:     10  DFLLULP No Lock                          */
+    __I uint32_t :5;                        /**< bit: 11..15  Reserved */
+    __I uint32_t DPLLLCKR:1;                /**< bit:     16  DPLL Lock Rise                           */
+    __I uint32_t DPLLLCKF:1;                /**< bit:     17  DPLL Lock Fall                           */
+    __I uint32_t DPLLLTO:1;                 /**< bit:     18  DPLL Lock Timeout                        */
+    __I uint32_t DPLLLDRTO:1;               /**< bit:     19  DPLL Loop Divider Ratio Update Complete  */
+    __I uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} OSCCTRL_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_INTFLAG_OFFSET              (0x0C)                                        /**<  (OSCCTRL_INTFLAG) Interrupt Flag Status and Clear  Offset */
+#define OSCCTRL_INTFLAG_RESETVALUE          _U_(0x00)                                     /**<  (OSCCTRL_INTFLAG) Interrupt Flag Status and Clear  Reset Value */
+
+#define OSCCTRL_INTFLAG_XOSCRDY_Pos         0                                              /**< (OSCCTRL_INTFLAG) XOSC Ready Position */
+#define OSCCTRL_INTFLAG_XOSCRDY_Msk         (_U_(0x1) << OSCCTRL_INTFLAG_XOSCRDY_Pos)      /**< (OSCCTRL_INTFLAG) XOSC Ready Mask */
+#define OSCCTRL_INTFLAG_XOSCRDY             OSCCTRL_INTFLAG_XOSCRDY_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTFLAG_XOSCRDY_Msk instead */
+#define OSCCTRL_INTFLAG_XOSCFAIL_Pos        1                                              /**< (OSCCTRL_INTFLAG) XOSC Clock Failure Detector Position */
+#define OSCCTRL_INTFLAG_XOSCFAIL_Msk        (_U_(0x1) << OSCCTRL_INTFLAG_XOSCFAIL_Pos)     /**< (OSCCTRL_INTFLAG) XOSC Clock Failure Detector Mask */
+#define OSCCTRL_INTFLAG_XOSCFAIL            OSCCTRL_INTFLAG_XOSCFAIL_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTFLAG_XOSCFAIL_Msk instead */
+#define OSCCTRL_INTFLAG_OSC16MRDY_Pos       4                                              /**< (OSCCTRL_INTFLAG) OSC16M Ready Position */
+#define OSCCTRL_INTFLAG_OSC16MRDY_Msk       (_U_(0x1) << OSCCTRL_INTFLAG_OSC16MRDY_Pos)    /**< (OSCCTRL_INTFLAG) OSC16M Ready Mask */
+#define OSCCTRL_INTFLAG_OSC16MRDY           OSCCTRL_INTFLAG_OSC16MRDY_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTFLAG_OSC16MRDY_Msk instead */
+#define OSCCTRL_INTFLAG_DFLLULPRDY_Pos      8                                              /**< (OSCCTRL_INTFLAG) DFLLULP Ready Position */
+#define OSCCTRL_INTFLAG_DFLLULPRDY_Msk      (_U_(0x1) << OSCCTRL_INTFLAG_DFLLULPRDY_Pos)   /**< (OSCCTRL_INTFLAG) DFLLULP Ready Mask */
+#define OSCCTRL_INTFLAG_DFLLULPRDY          OSCCTRL_INTFLAG_DFLLULPRDY_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTFLAG_DFLLULPRDY_Msk instead */
+#define OSCCTRL_INTFLAG_DFLLULPLOCK_Pos     9                                              /**< (OSCCTRL_INTFLAG) DFLLULP Lock Position */
+#define OSCCTRL_INTFLAG_DFLLULPLOCK_Msk     (_U_(0x1) << OSCCTRL_INTFLAG_DFLLULPLOCK_Pos)  /**< (OSCCTRL_INTFLAG) DFLLULP Lock Mask */
+#define OSCCTRL_INTFLAG_DFLLULPLOCK         OSCCTRL_INTFLAG_DFLLULPLOCK_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTFLAG_DFLLULPLOCK_Msk instead */
+#define OSCCTRL_INTFLAG_DFLLULPNOLOCK_Pos   10                                             /**< (OSCCTRL_INTFLAG) DFLLULP No Lock Position */
+#define OSCCTRL_INTFLAG_DFLLULPNOLOCK_Msk   (_U_(0x1) << OSCCTRL_INTFLAG_DFLLULPNOLOCK_Pos)  /**< (OSCCTRL_INTFLAG) DFLLULP No Lock Mask */
+#define OSCCTRL_INTFLAG_DFLLULPNOLOCK       OSCCTRL_INTFLAG_DFLLULPNOLOCK_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTFLAG_DFLLULPNOLOCK_Msk instead */
+#define OSCCTRL_INTFLAG_DPLLLCKR_Pos        16                                             /**< (OSCCTRL_INTFLAG) DPLL Lock Rise Position */
+#define OSCCTRL_INTFLAG_DPLLLCKR_Msk        (_U_(0x1) << OSCCTRL_INTFLAG_DPLLLCKR_Pos)     /**< (OSCCTRL_INTFLAG) DPLL Lock Rise Mask */
+#define OSCCTRL_INTFLAG_DPLLLCKR            OSCCTRL_INTFLAG_DPLLLCKR_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTFLAG_DPLLLCKR_Msk instead */
+#define OSCCTRL_INTFLAG_DPLLLCKF_Pos        17                                             /**< (OSCCTRL_INTFLAG) DPLL Lock Fall Position */
+#define OSCCTRL_INTFLAG_DPLLLCKF_Msk        (_U_(0x1) << OSCCTRL_INTFLAG_DPLLLCKF_Pos)     /**< (OSCCTRL_INTFLAG) DPLL Lock Fall Mask */
+#define OSCCTRL_INTFLAG_DPLLLCKF            OSCCTRL_INTFLAG_DPLLLCKF_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTFLAG_DPLLLCKF_Msk instead */
+#define OSCCTRL_INTFLAG_DPLLLTO_Pos         18                                             /**< (OSCCTRL_INTFLAG) DPLL Lock Timeout Position */
+#define OSCCTRL_INTFLAG_DPLLLTO_Msk         (_U_(0x1) << OSCCTRL_INTFLAG_DPLLLTO_Pos)      /**< (OSCCTRL_INTFLAG) DPLL Lock Timeout Mask */
+#define OSCCTRL_INTFLAG_DPLLLTO             OSCCTRL_INTFLAG_DPLLLTO_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTFLAG_DPLLLTO_Msk instead */
+#define OSCCTRL_INTFLAG_DPLLLDRTO_Pos       19                                             /**< (OSCCTRL_INTFLAG) DPLL Loop Divider Ratio Update Complete Position */
+#define OSCCTRL_INTFLAG_DPLLLDRTO_Msk       (_U_(0x1) << OSCCTRL_INTFLAG_DPLLLDRTO_Pos)    /**< (OSCCTRL_INTFLAG) DPLL Loop Divider Ratio Update Complete Mask */
+#define OSCCTRL_INTFLAG_DPLLLDRTO           OSCCTRL_INTFLAG_DPLLLDRTO_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTFLAG_DPLLLDRTO_Msk instead */
+#define OSCCTRL_INTFLAG_MASK                _U_(0xF0713)                                   /**< \deprecated (OSCCTRL_INTFLAG) Register MASK  (Use OSCCTRL_INTFLAG_Msk instead)  */
+#define OSCCTRL_INTFLAG_Msk                 _U_(0xF0713)                                   /**< (OSCCTRL_INTFLAG) Register Mask  */
+
+
+/* -------- OSCCTRL_STATUS : (OSCCTRL Offset: 0x10) (R/ 32) Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t XOSCRDY:1;                 /**< bit:      0  XOSC Ready                               */
+    uint32_t XOSCFAIL:1;                /**< bit:      1  XOSC Clock Failure Detector              */
+    uint32_t XOSCCKSW:1;                /**< bit:      2  XOSC Clock Switch                        */
+    uint32_t :1;                        /**< bit:      3  Reserved */
+    uint32_t OSC16MRDY:1;               /**< bit:      4  OSC16M Ready                             */
+    uint32_t :3;                        /**< bit:   5..7  Reserved */
+    uint32_t DFLLULPRDY:1;              /**< bit:      8  DFLLULP Ready                            */
+    uint32_t DFLLULPLOCK:1;             /**< bit:      9  DFLLULP Lock                             */
+    uint32_t DFLLULPNOLOCK:1;           /**< bit:     10  DFLLULP No Lock                          */
+    uint32_t :5;                        /**< bit: 11..15  Reserved */
+    uint32_t DPLLLCKR:1;                /**< bit:     16  DPLL Lock Rise                           */
+    uint32_t DPLLLCKF:1;                /**< bit:     17  DPLL Lock Fall                           */
+    uint32_t DPLLTO:1;                  /**< bit:     18  DPLL Lock Timeout                        */
+    uint32_t DPLLLDRTO:1;               /**< bit:     19  DPLL Loop Divider Ratio Update Complete  */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} OSCCTRL_STATUS_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_STATUS_OFFSET               (0x10)                                        /**<  (OSCCTRL_STATUS) Status  Offset */
+#define OSCCTRL_STATUS_RESETVALUE           _U_(0x00)                                     /**<  (OSCCTRL_STATUS) Status  Reset Value */
+
+#define OSCCTRL_STATUS_XOSCRDY_Pos          0                                              /**< (OSCCTRL_STATUS) XOSC Ready Position */
+#define OSCCTRL_STATUS_XOSCRDY_Msk          (_U_(0x1) << OSCCTRL_STATUS_XOSCRDY_Pos)       /**< (OSCCTRL_STATUS) XOSC Ready Mask */
+#define OSCCTRL_STATUS_XOSCRDY              OSCCTRL_STATUS_XOSCRDY_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_STATUS_XOSCRDY_Msk instead */
+#define OSCCTRL_STATUS_XOSCFAIL_Pos         1                                              /**< (OSCCTRL_STATUS) XOSC Clock Failure Detector Position */
+#define OSCCTRL_STATUS_XOSCFAIL_Msk         (_U_(0x1) << OSCCTRL_STATUS_XOSCFAIL_Pos)      /**< (OSCCTRL_STATUS) XOSC Clock Failure Detector Mask */
+#define OSCCTRL_STATUS_XOSCFAIL             OSCCTRL_STATUS_XOSCFAIL_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_STATUS_XOSCFAIL_Msk instead */
+#define OSCCTRL_STATUS_XOSCCKSW_Pos         2                                              /**< (OSCCTRL_STATUS) XOSC Clock Switch Position */
+#define OSCCTRL_STATUS_XOSCCKSW_Msk         (_U_(0x1) << OSCCTRL_STATUS_XOSCCKSW_Pos)      /**< (OSCCTRL_STATUS) XOSC Clock Switch Mask */
+#define OSCCTRL_STATUS_XOSCCKSW             OSCCTRL_STATUS_XOSCCKSW_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_STATUS_XOSCCKSW_Msk instead */
+#define OSCCTRL_STATUS_OSC16MRDY_Pos        4                                              /**< (OSCCTRL_STATUS) OSC16M Ready Position */
+#define OSCCTRL_STATUS_OSC16MRDY_Msk        (_U_(0x1) << OSCCTRL_STATUS_OSC16MRDY_Pos)     /**< (OSCCTRL_STATUS) OSC16M Ready Mask */
+#define OSCCTRL_STATUS_OSC16MRDY            OSCCTRL_STATUS_OSC16MRDY_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_STATUS_OSC16MRDY_Msk instead */
+#define OSCCTRL_STATUS_DFLLULPRDY_Pos       8                                              /**< (OSCCTRL_STATUS) DFLLULP Ready Position */
+#define OSCCTRL_STATUS_DFLLULPRDY_Msk       (_U_(0x1) << OSCCTRL_STATUS_DFLLULPRDY_Pos)    /**< (OSCCTRL_STATUS) DFLLULP Ready Mask */
+#define OSCCTRL_STATUS_DFLLULPRDY           OSCCTRL_STATUS_DFLLULPRDY_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_STATUS_DFLLULPRDY_Msk instead */
+#define OSCCTRL_STATUS_DFLLULPLOCK_Pos      9                                              /**< (OSCCTRL_STATUS) DFLLULP Lock Position */
+#define OSCCTRL_STATUS_DFLLULPLOCK_Msk      (_U_(0x1) << OSCCTRL_STATUS_DFLLULPLOCK_Pos)   /**< (OSCCTRL_STATUS) DFLLULP Lock Mask */
+#define OSCCTRL_STATUS_DFLLULPLOCK          OSCCTRL_STATUS_DFLLULPLOCK_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_STATUS_DFLLULPLOCK_Msk instead */
+#define OSCCTRL_STATUS_DFLLULPNOLOCK_Pos    10                                             /**< (OSCCTRL_STATUS) DFLLULP No Lock Position */
+#define OSCCTRL_STATUS_DFLLULPNOLOCK_Msk    (_U_(0x1) << OSCCTRL_STATUS_DFLLULPNOLOCK_Pos)  /**< (OSCCTRL_STATUS) DFLLULP No Lock Mask */
+#define OSCCTRL_STATUS_DFLLULPNOLOCK        OSCCTRL_STATUS_DFLLULPNOLOCK_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_STATUS_DFLLULPNOLOCK_Msk instead */
+#define OSCCTRL_STATUS_DPLLLCKR_Pos         16                                             /**< (OSCCTRL_STATUS) DPLL Lock Rise Position */
+#define OSCCTRL_STATUS_DPLLLCKR_Msk         (_U_(0x1) << OSCCTRL_STATUS_DPLLLCKR_Pos)      /**< (OSCCTRL_STATUS) DPLL Lock Rise Mask */
+#define OSCCTRL_STATUS_DPLLLCKR             OSCCTRL_STATUS_DPLLLCKR_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_STATUS_DPLLLCKR_Msk instead */
+#define OSCCTRL_STATUS_DPLLLCKF_Pos         17                                             /**< (OSCCTRL_STATUS) DPLL Lock Fall Position */
+#define OSCCTRL_STATUS_DPLLLCKF_Msk         (_U_(0x1) << OSCCTRL_STATUS_DPLLLCKF_Pos)      /**< (OSCCTRL_STATUS) DPLL Lock Fall Mask */
+#define OSCCTRL_STATUS_DPLLLCKF             OSCCTRL_STATUS_DPLLLCKF_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_STATUS_DPLLLCKF_Msk instead */
+#define OSCCTRL_STATUS_DPLLTO_Pos           18                                             /**< (OSCCTRL_STATUS) DPLL Lock Timeout Position */
+#define OSCCTRL_STATUS_DPLLTO_Msk           (_U_(0x1) << OSCCTRL_STATUS_DPLLTO_Pos)        /**< (OSCCTRL_STATUS) DPLL Lock Timeout Mask */
+#define OSCCTRL_STATUS_DPLLTO               OSCCTRL_STATUS_DPLLTO_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_STATUS_DPLLTO_Msk instead */
+#define OSCCTRL_STATUS_DPLLLDRTO_Pos        19                                             /**< (OSCCTRL_STATUS) DPLL Loop Divider Ratio Update Complete Position */
+#define OSCCTRL_STATUS_DPLLLDRTO_Msk        (_U_(0x1) << OSCCTRL_STATUS_DPLLLDRTO_Pos)     /**< (OSCCTRL_STATUS) DPLL Loop Divider Ratio Update Complete Mask */
+#define OSCCTRL_STATUS_DPLLLDRTO            OSCCTRL_STATUS_DPLLLDRTO_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_STATUS_DPLLLDRTO_Msk instead */
+#define OSCCTRL_STATUS_MASK                 _U_(0xF0717)                                   /**< \deprecated (OSCCTRL_STATUS) Register MASK  (Use OSCCTRL_STATUS_Msk instead)  */
+#define OSCCTRL_STATUS_Msk                  _U_(0xF0717)                                   /**< (OSCCTRL_STATUS) Register Mask  */
+
+
+/* -------- OSCCTRL_XOSCCTRL : (OSCCTRL Offset: 0x14) (R/W 16) External Multipurpose Crystal Oscillator (XOSC) Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t :1;                        /**< bit:      0  Reserved */
+    uint16_t ENABLE:1;                  /**< bit:      1  Oscillator Enable                        */
+    uint16_t XTALEN:1;                  /**< bit:      2  Crystal Oscillator Enable                */
+    uint16_t CFDEN:1;                   /**< bit:      3  Clock Failure Detector Enable            */
+    uint16_t SWBEN:1;                   /**< bit:      4  Xosc Clock Switch Enable                 */
+    uint16_t :1;                        /**< bit:      5  Reserved */
+    uint16_t RUNSTDBY:1;                /**< bit:      6  Run in Standby                           */
+    uint16_t ONDEMAND:1;                /**< bit:      7  On Demand Control                        */
+    uint16_t GAIN:3;                    /**< bit:  8..10  Oscillator Gain                          */
+    uint16_t AMPGC:1;                   /**< bit:     11  Automatic Amplitude Gain Control         */
+    uint16_t STARTUP:4;                 /**< bit: 12..15  Start-Up Time                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} OSCCTRL_XOSCCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_XOSCCTRL_OFFSET             (0x14)                                        /**<  (OSCCTRL_XOSCCTRL) External Multipurpose Crystal Oscillator (XOSC) Control  Offset */
+#define OSCCTRL_XOSCCTRL_RESETVALUE         _U_(0x80)                                     /**<  (OSCCTRL_XOSCCTRL) External Multipurpose Crystal Oscillator (XOSC) Control  Reset Value */
+
+#define OSCCTRL_XOSCCTRL_ENABLE_Pos         1                                              /**< (OSCCTRL_XOSCCTRL) Oscillator Enable Position */
+#define OSCCTRL_XOSCCTRL_ENABLE_Msk         (_U_(0x1) << OSCCTRL_XOSCCTRL_ENABLE_Pos)      /**< (OSCCTRL_XOSCCTRL) Oscillator Enable Mask */
+#define OSCCTRL_XOSCCTRL_ENABLE             OSCCTRL_XOSCCTRL_ENABLE_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_XOSCCTRL_ENABLE_Msk instead */
+#define OSCCTRL_XOSCCTRL_XTALEN_Pos         2                                              /**< (OSCCTRL_XOSCCTRL) Crystal Oscillator Enable Position */
+#define OSCCTRL_XOSCCTRL_XTALEN_Msk         (_U_(0x1) << OSCCTRL_XOSCCTRL_XTALEN_Pos)      /**< (OSCCTRL_XOSCCTRL) Crystal Oscillator Enable Mask */
+#define OSCCTRL_XOSCCTRL_XTALEN             OSCCTRL_XOSCCTRL_XTALEN_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_XOSCCTRL_XTALEN_Msk instead */
+#define OSCCTRL_XOSCCTRL_CFDEN_Pos          3                                              /**< (OSCCTRL_XOSCCTRL) Clock Failure Detector Enable Position */
+#define OSCCTRL_XOSCCTRL_CFDEN_Msk          (_U_(0x1) << OSCCTRL_XOSCCTRL_CFDEN_Pos)       /**< (OSCCTRL_XOSCCTRL) Clock Failure Detector Enable Mask */
+#define OSCCTRL_XOSCCTRL_CFDEN              OSCCTRL_XOSCCTRL_CFDEN_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_XOSCCTRL_CFDEN_Msk instead */
+#define OSCCTRL_XOSCCTRL_SWBEN_Pos          4                                              /**< (OSCCTRL_XOSCCTRL) Xosc Clock Switch Enable Position */
+#define OSCCTRL_XOSCCTRL_SWBEN_Msk          (_U_(0x1) << OSCCTRL_XOSCCTRL_SWBEN_Pos)       /**< (OSCCTRL_XOSCCTRL) Xosc Clock Switch Enable Mask */
+#define OSCCTRL_XOSCCTRL_SWBEN              OSCCTRL_XOSCCTRL_SWBEN_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_XOSCCTRL_SWBEN_Msk instead */
+#define OSCCTRL_XOSCCTRL_RUNSTDBY_Pos       6                                              /**< (OSCCTRL_XOSCCTRL) Run in Standby Position */
+#define OSCCTRL_XOSCCTRL_RUNSTDBY_Msk       (_U_(0x1) << OSCCTRL_XOSCCTRL_RUNSTDBY_Pos)    /**< (OSCCTRL_XOSCCTRL) Run in Standby Mask */
+#define OSCCTRL_XOSCCTRL_RUNSTDBY           OSCCTRL_XOSCCTRL_RUNSTDBY_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_XOSCCTRL_RUNSTDBY_Msk instead */
+#define OSCCTRL_XOSCCTRL_ONDEMAND_Pos       7                                              /**< (OSCCTRL_XOSCCTRL) On Demand Control Position */
+#define OSCCTRL_XOSCCTRL_ONDEMAND_Msk       (_U_(0x1) << OSCCTRL_XOSCCTRL_ONDEMAND_Pos)    /**< (OSCCTRL_XOSCCTRL) On Demand Control Mask */
+#define OSCCTRL_XOSCCTRL_ONDEMAND           OSCCTRL_XOSCCTRL_ONDEMAND_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_XOSCCTRL_ONDEMAND_Msk instead */
+#define OSCCTRL_XOSCCTRL_GAIN_Pos           8                                              /**< (OSCCTRL_XOSCCTRL) Oscillator Gain Position */
+#define OSCCTRL_XOSCCTRL_GAIN_Msk           (_U_(0x7) << OSCCTRL_XOSCCTRL_GAIN_Pos)        /**< (OSCCTRL_XOSCCTRL) Oscillator Gain Mask */
+#define OSCCTRL_XOSCCTRL_GAIN(value)        (OSCCTRL_XOSCCTRL_GAIN_Msk & ((value) << OSCCTRL_XOSCCTRL_GAIN_Pos))
+#define OSCCTRL_XOSCCTRL_AMPGC_Pos          11                                             /**< (OSCCTRL_XOSCCTRL) Automatic Amplitude Gain Control Position */
+#define OSCCTRL_XOSCCTRL_AMPGC_Msk          (_U_(0x1) << OSCCTRL_XOSCCTRL_AMPGC_Pos)       /**< (OSCCTRL_XOSCCTRL) Automatic Amplitude Gain Control Mask */
+#define OSCCTRL_XOSCCTRL_AMPGC              OSCCTRL_XOSCCTRL_AMPGC_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_XOSCCTRL_AMPGC_Msk instead */
+#define OSCCTRL_XOSCCTRL_STARTUP_Pos        12                                             /**< (OSCCTRL_XOSCCTRL) Start-Up Time Position */
+#define OSCCTRL_XOSCCTRL_STARTUP_Msk        (_U_(0xF) << OSCCTRL_XOSCCTRL_STARTUP_Pos)     /**< (OSCCTRL_XOSCCTRL) Start-Up Time Mask */
+#define OSCCTRL_XOSCCTRL_STARTUP(value)     (OSCCTRL_XOSCCTRL_STARTUP_Msk & ((value) << OSCCTRL_XOSCCTRL_STARTUP_Pos))
+#define OSCCTRL_XOSCCTRL_MASK               _U_(0xFFDE)                                    /**< \deprecated (OSCCTRL_XOSCCTRL) Register MASK  (Use OSCCTRL_XOSCCTRL_Msk instead)  */
+#define OSCCTRL_XOSCCTRL_Msk                _U_(0xFFDE)                                    /**< (OSCCTRL_XOSCCTRL) Register Mask  */
+
+
+/* -------- OSCCTRL_CFDPRESC : (OSCCTRL Offset: 0x16) (R/W 8) Clock Failure Detector Prescaler -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  CFDPRESC:3;                /**< bit:   0..2  Clock Failure Detector Prescaler         */
+    uint8_t  :5;                        /**< bit:   3..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} OSCCTRL_CFDPRESC_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_CFDPRESC_OFFSET             (0x16)                                        /**<  (OSCCTRL_CFDPRESC) Clock Failure Detector Prescaler  Offset */
+#define OSCCTRL_CFDPRESC_RESETVALUE         _U_(0x00)                                     /**<  (OSCCTRL_CFDPRESC) Clock Failure Detector Prescaler  Reset Value */
+
+#define OSCCTRL_CFDPRESC_CFDPRESC_Pos       0                                              /**< (OSCCTRL_CFDPRESC) Clock Failure Detector Prescaler Position */
+#define OSCCTRL_CFDPRESC_CFDPRESC_Msk       (_U_(0x7) << OSCCTRL_CFDPRESC_CFDPRESC_Pos)    /**< (OSCCTRL_CFDPRESC) Clock Failure Detector Prescaler Mask */
+#define OSCCTRL_CFDPRESC_CFDPRESC(value)    (OSCCTRL_CFDPRESC_CFDPRESC_Msk & ((value) << OSCCTRL_CFDPRESC_CFDPRESC_Pos))
+#define OSCCTRL_CFDPRESC_MASK               _U_(0x07)                                      /**< \deprecated (OSCCTRL_CFDPRESC) Register MASK  (Use OSCCTRL_CFDPRESC_Msk instead)  */
+#define OSCCTRL_CFDPRESC_Msk                _U_(0x07)                                      /**< (OSCCTRL_CFDPRESC) Register Mask  */
+
+
+/* -------- OSCCTRL_OSC16MCTRL : (OSCCTRL Offset: 0x18) (R/W 8) 16MHz Internal Oscillator (OSC16M) Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  :1;                        /**< bit:      0  Reserved */
+    uint8_t  ENABLE:1;                  /**< bit:      1  Oscillator Enable                        */
+    uint8_t  FSEL:2;                    /**< bit:   2..3  Oscillator Frequency Selection           */
+    uint8_t  :2;                        /**< bit:   4..5  Reserved */
+    uint8_t  RUNSTDBY:1;                /**< bit:      6  Run in Standby                           */
+    uint8_t  ONDEMAND:1;                /**< bit:      7  On Demand Control                        */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} OSCCTRL_OSC16MCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_OSC16MCTRL_OFFSET           (0x18)                                        /**<  (OSCCTRL_OSC16MCTRL) 16MHz Internal Oscillator (OSC16M) Control  Offset */
+#define OSCCTRL_OSC16MCTRL_RESETVALUE       _U_(0x82)                                     /**<  (OSCCTRL_OSC16MCTRL) 16MHz Internal Oscillator (OSC16M) Control  Reset Value */
+
+#define OSCCTRL_OSC16MCTRL_ENABLE_Pos       1                                              /**< (OSCCTRL_OSC16MCTRL) Oscillator Enable Position */
+#define OSCCTRL_OSC16MCTRL_ENABLE_Msk       (_U_(0x1) << OSCCTRL_OSC16MCTRL_ENABLE_Pos)    /**< (OSCCTRL_OSC16MCTRL) Oscillator Enable Mask */
+#define OSCCTRL_OSC16MCTRL_ENABLE           OSCCTRL_OSC16MCTRL_ENABLE_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_OSC16MCTRL_ENABLE_Msk instead */
+#define OSCCTRL_OSC16MCTRL_FSEL_Pos         2                                              /**< (OSCCTRL_OSC16MCTRL) Oscillator Frequency Selection Position */
+#define OSCCTRL_OSC16MCTRL_FSEL_Msk         (_U_(0x3) << OSCCTRL_OSC16MCTRL_FSEL_Pos)      /**< (OSCCTRL_OSC16MCTRL) Oscillator Frequency Selection Mask */
+#define OSCCTRL_OSC16MCTRL_FSEL(value)      (OSCCTRL_OSC16MCTRL_FSEL_Msk & ((value) << OSCCTRL_OSC16MCTRL_FSEL_Pos))
+#define   OSCCTRL_OSC16MCTRL_FSEL_4_Val     _U_(0x0)                                       /**< (OSCCTRL_OSC16MCTRL) 4MHz  */
+#define   OSCCTRL_OSC16MCTRL_FSEL_8_Val     _U_(0x1)                                       /**< (OSCCTRL_OSC16MCTRL) 8MHz  */
+#define   OSCCTRL_OSC16MCTRL_FSEL_12_Val    _U_(0x2)                                       /**< (OSCCTRL_OSC16MCTRL) 12MHz  */
+#define   OSCCTRL_OSC16MCTRL_FSEL_16_Val    _U_(0x3)                                       /**< (OSCCTRL_OSC16MCTRL) 16MHz  */
+#define OSCCTRL_OSC16MCTRL_FSEL_4           (OSCCTRL_OSC16MCTRL_FSEL_4_Val << OSCCTRL_OSC16MCTRL_FSEL_Pos)  /**< (OSCCTRL_OSC16MCTRL) 4MHz Position  */
+#define OSCCTRL_OSC16MCTRL_FSEL_8           (OSCCTRL_OSC16MCTRL_FSEL_8_Val << OSCCTRL_OSC16MCTRL_FSEL_Pos)  /**< (OSCCTRL_OSC16MCTRL) 8MHz Position  */
+#define OSCCTRL_OSC16MCTRL_FSEL_12          (OSCCTRL_OSC16MCTRL_FSEL_12_Val << OSCCTRL_OSC16MCTRL_FSEL_Pos)  /**< (OSCCTRL_OSC16MCTRL) 12MHz Position  */
+#define OSCCTRL_OSC16MCTRL_FSEL_16          (OSCCTRL_OSC16MCTRL_FSEL_16_Val << OSCCTRL_OSC16MCTRL_FSEL_Pos)  /**< (OSCCTRL_OSC16MCTRL) 16MHz Position  */
+#define OSCCTRL_OSC16MCTRL_RUNSTDBY_Pos     6                                              /**< (OSCCTRL_OSC16MCTRL) Run in Standby Position */
+#define OSCCTRL_OSC16MCTRL_RUNSTDBY_Msk     (_U_(0x1) << OSCCTRL_OSC16MCTRL_RUNSTDBY_Pos)  /**< (OSCCTRL_OSC16MCTRL) Run in Standby Mask */
+#define OSCCTRL_OSC16MCTRL_RUNSTDBY         OSCCTRL_OSC16MCTRL_RUNSTDBY_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_OSC16MCTRL_RUNSTDBY_Msk instead */
+#define OSCCTRL_OSC16MCTRL_ONDEMAND_Pos     7                                              /**< (OSCCTRL_OSC16MCTRL) On Demand Control Position */
+#define OSCCTRL_OSC16MCTRL_ONDEMAND_Msk     (_U_(0x1) << OSCCTRL_OSC16MCTRL_ONDEMAND_Pos)  /**< (OSCCTRL_OSC16MCTRL) On Demand Control Mask */
+#define OSCCTRL_OSC16MCTRL_ONDEMAND         OSCCTRL_OSC16MCTRL_ONDEMAND_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_OSC16MCTRL_ONDEMAND_Msk instead */
+#define OSCCTRL_OSC16MCTRL_MASK             _U_(0xCE)                                      /**< \deprecated (OSCCTRL_OSC16MCTRL) Register MASK  (Use OSCCTRL_OSC16MCTRL_Msk instead)  */
+#define OSCCTRL_OSC16MCTRL_Msk              _U_(0xCE)                                      /**< (OSCCTRL_OSC16MCTRL) Register Mask  */
+
+
+/* -------- OSCCTRL_DFLLULPCTRL : (OSCCTRL Offset: 0x1c) (R/W 16) DFLLULP Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t :1;                        /**< bit:      0  Reserved */
+    uint16_t ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint16_t :1;                        /**< bit:      2  Reserved */
+    uint16_t BINSE:1;                   /**< bit:      3  Binary Search Enable                     */
+    uint16_t SAFE:1;                    /**< bit:      4  Tuner Safe Mode                          */
+    uint16_t DITHER:1;                  /**< bit:      5  Tuner Dither Mode                        */
+    uint16_t RUNSTDBY:1;                /**< bit:      6  Run in Standby                           */
+    uint16_t ONDEMAND:1;                /**< bit:      7  On Demand                                */
+    uint16_t DIV:3;                     /**< bit:  8..10  Division Factor                          */
+    uint16_t :5;                        /**< bit: 11..15  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} OSCCTRL_DFLLULPCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_DFLLULPCTRL_OFFSET          (0x1C)                                        /**<  (OSCCTRL_DFLLULPCTRL) DFLLULP Control  Offset */
+#define OSCCTRL_DFLLULPCTRL_RESETVALUE      _U_(0x504)                                    /**<  (OSCCTRL_DFLLULPCTRL) DFLLULP Control  Reset Value */
+
+#define OSCCTRL_DFLLULPCTRL_ENABLE_Pos      1                                              /**< (OSCCTRL_DFLLULPCTRL) Enable Position */
+#define OSCCTRL_DFLLULPCTRL_ENABLE_Msk      (_U_(0x1) << OSCCTRL_DFLLULPCTRL_ENABLE_Pos)   /**< (OSCCTRL_DFLLULPCTRL) Enable Mask */
+#define OSCCTRL_DFLLULPCTRL_ENABLE          OSCCTRL_DFLLULPCTRL_ENABLE_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_DFLLULPCTRL_ENABLE_Msk instead */
+#define OSCCTRL_DFLLULPCTRL_BINSE_Pos       3                                              /**< (OSCCTRL_DFLLULPCTRL) Binary Search Enable Position */
+#define OSCCTRL_DFLLULPCTRL_BINSE_Msk       (_U_(0x1) << OSCCTRL_DFLLULPCTRL_BINSE_Pos)    /**< (OSCCTRL_DFLLULPCTRL) Binary Search Enable Mask */
+#define OSCCTRL_DFLLULPCTRL_BINSE           OSCCTRL_DFLLULPCTRL_BINSE_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_DFLLULPCTRL_BINSE_Msk instead */
+#define OSCCTRL_DFLLULPCTRL_SAFE_Pos        4                                              /**< (OSCCTRL_DFLLULPCTRL) Tuner Safe Mode Position */
+#define OSCCTRL_DFLLULPCTRL_SAFE_Msk        (_U_(0x1) << OSCCTRL_DFLLULPCTRL_SAFE_Pos)     /**< (OSCCTRL_DFLLULPCTRL) Tuner Safe Mode Mask */
+#define OSCCTRL_DFLLULPCTRL_SAFE            OSCCTRL_DFLLULPCTRL_SAFE_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_DFLLULPCTRL_SAFE_Msk instead */
+#define OSCCTRL_DFLLULPCTRL_DITHER_Pos      5                                              /**< (OSCCTRL_DFLLULPCTRL) Tuner Dither Mode Position */
+#define OSCCTRL_DFLLULPCTRL_DITHER_Msk      (_U_(0x1) << OSCCTRL_DFLLULPCTRL_DITHER_Pos)   /**< (OSCCTRL_DFLLULPCTRL) Tuner Dither Mode Mask */
+#define OSCCTRL_DFLLULPCTRL_DITHER          OSCCTRL_DFLLULPCTRL_DITHER_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_DFLLULPCTRL_DITHER_Msk instead */
+#define OSCCTRL_DFLLULPCTRL_RUNSTDBY_Pos    6                                              /**< (OSCCTRL_DFLLULPCTRL) Run in Standby Position */
+#define OSCCTRL_DFLLULPCTRL_RUNSTDBY_Msk    (_U_(0x1) << OSCCTRL_DFLLULPCTRL_RUNSTDBY_Pos)  /**< (OSCCTRL_DFLLULPCTRL) Run in Standby Mask */
+#define OSCCTRL_DFLLULPCTRL_RUNSTDBY        OSCCTRL_DFLLULPCTRL_RUNSTDBY_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_DFLLULPCTRL_RUNSTDBY_Msk instead */
+#define OSCCTRL_DFLLULPCTRL_ONDEMAND_Pos    7                                              /**< (OSCCTRL_DFLLULPCTRL) On Demand Position */
+#define OSCCTRL_DFLLULPCTRL_ONDEMAND_Msk    (_U_(0x1) << OSCCTRL_DFLLULPCTRL_ONDEMAND_Pos)  /**< (OSCCTRL_DFLLULPCTRL) On Demand Mask */
+#define OSCCTRL_DFLLULPCTRL_ONDEMAND        OSCCTRL_DFLLULPCTRL_ONDEMAND_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_DFLLULPCTRL_ONDEMAND_Msk instead */
+#define OSCCTRL_DFLLULPCTRL_DIV_Pos         8                                              /**< (OSCCTRL_DFLLULPCTRL) Division Factor Position */
+#define OSCCTRL_DFLLULPCTRL_DIV_Msk         (_U_(0x7) << OSCCTRL_DFLLULPCTRL_DIV_Pos)      /**< (OSCCTRL_DFLLULPCTRL) Division Factor Mask */
+#define OSCCTRL_DFLLULPCTRL_DIV(value)      (OSCCTRL_DFLLULPCTRL_DIV_Msk & ((value) << OSCCTRL_DFLLULPCTRL_DIV_Pos))
+#define   OSCCTRL_DFLLULPCTRL_DIV_DIV1_Val  _U_(0x0)                                       /**< (OSCCTRL_DFLLULPCTRL) Frequency Divided by 1  */
+#define   OSCCTRL_DFLLULPCTRL_DIV_DIV2_Val  _U_(0x1)                                       /**< (OSCCTRL_DFLLULPCTRL) Frequency Divided by 2  */
+#define   OSCCTRL_DFLLULPCTRL_DIV_DIV4_Val  _U_(0x2)                                       /**< (OSCCTRL_DFLLULPCTRL) Frequency Divided by 4  */
+#define   OSCCTRL_DFLLULPCTRL_DIV_DIV8_Val  _U_(0x3)                                       /**< (OSCCTRL_DFLLULPCTRL) Frequency Divided by 8  */
+#define   OSCCTRL_DFLLULPCTRL_DIV_DIV16_Val _U_(0x4)                                       /**< (OSCCTRL_DFLLULPCTRL) Frequency Divided by 16  */
+#define   OSCCTRL_DFLLULPCTRL_DIV_DIV32_Val _U_(0x5)                                       /**< (OSCCTRL_DFLLULPCTRL) Frequency Divided by 32  */
+#define OSCCTRL_DFLLULPCTRL_DIV_DIV1        (OSCCTRL_DFLLULPCTRL_DIV_DIV1_Val << OSCCTRL_DFLLULPCTRL_DIV_Pos)  /**< (OSCCTRL_DFLLULPCTRL) Frequency Divided by 1 Position  */
+#define OSCCTRL_DFLLULPCTRL_DIV_DIV2        (OSCCTRL_DFLLULPCTRL_DIV_DIV2_Val << OSCCTRL_DFLLULPCTRL_DIV_Pos)  /**< (OSCCTRL_DFLLULPCTRL) Frequency Divided by 2 Position  */
+#define OSCCTRL_DFLLULPCTRL_DIV_DIV4        (OSCCTRL_DFLLULPCTRL_DIV_DIV4_Val << OSCCTRL_DFLLULPCTRL_DIV_Pos)  /**< (OSCCTRL_DFLLULPCTRL) Frequency Divided by 4 Position  */
+#define OSCCTRL_DFLLULPCTRL_DIV_DIV8        (OSCCTRL_DFLLULPCTRL_DIV_DIV8_Val << OSCCTRL_DFLLULPCTRL_DIV_Pos)  /**< (OSCCTRL_DFLLULPCTRL) Frequency Divided by 8 Position  */
+#define OSCCTRL_DFLLULPCTRL_DIV_DIV16       (OSCCTRL_DFLLULPCTRL_DIV_DIV16_Val << OSCCTRL_DFLLULPCTRL_DIV_Pos)  /**< (OSCCTRL_DFLLULPCTRL) Frequency Divided by 16 Position  */
+#define OSCCTRL_DFLLULPCTRL_DIV_DIV32       (OSCCTRL_DFLLULPCTRL_DIV_DIV32_Val << OSCCTRL_DFLLULPCTRL_DIV_Pos)  /**< (OSCCTRL_DFLLULPCTRL) Frequency Divided by 32 Position  */
+#define OSCCTRL_DFLLULPCTRL_MASK            _U_(0x7FA)                                     /**< \deprecated (OSCCTRL_DFLLULPCTRL) Register MASK  (Use OSCCTRL_DFLLULPCTRL_Msk instead)  */
+#define OSCCTRL_DFLLULPCTRL_Msk             _U_(0x7FA)                                     /**< (OSCCTRL_DFLLULPCTRL) Register Mask  */
+
+
+/* -------- OSCCTRL_DFLLULPDITHER : (OSCCTRL Offset: 0x1e) (R/W 8) DFLLULP Dither Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  STEP:3;                    /**< bit:   0..2  Dither Step                              */
+    uint8_t  :1;                        /**< bit:      3  Reserved */
+    uint8_t  PER:3;                     /**< bit:   4..6  Dither Period                            */
+    uint8_t  :1;                        /**< bit:      7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} OSCCTRL_DFLLULPDITHER_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_DFLLULPDITHER_OFFSET        (0x1E)                                        /**<  (OSCCTRL_DFLLULPDITHER) DFLLULP Dither Control  Offset */
+#define OSCCTRL_DFLLULPDITHER_RESETVALUE    _U_(0x00)                                     /**<  (OSCCTRL_DFLLULPDITHER) DFLLULP Dither Control  Reset Value */
+
+#define OSCCTRL_DFLLULPDITHER_STEP_Pos      0                                              /**< (OSCCTRL_DFLLULPDITHER) Dither Step Position */
+#define OSCCTRL_DFLLULPDITHER_STEP_Msk      (_U_(0x7) << OSCCTRL_DFLLULPDITHER_STEP_Pos)   /**< (OSCCTRL_DFLLULPDITHER) Dither Step Mask */
+#define OSCCTRL_DFLLULPDITHER_STEP(value)   (OSCCTRL_DFLLULPDITHER_STEP_Msk & ((value) << OSCCTRL_DFLLULPDITHER_STEP_Pos))
+#define   OSCCTRL_DFLLULPDITHER_STEP_STEP1_Val _U_(0x0)                                       /**< (OSCCTRL_DFLLULPDITHER) Dither Step = 1  */
+#define   OSCCTRL_DFLLULPDITHER_STEP_STEP2_Val _U_(0x1)                                       /**< (OSCCTRL_DFLLULPDITHER) Dither Step = 2  */
+#define   OSCCTRL_DFLLULPDITHER_STEP_STEP4_Val _U_(0x2)                                       /**< (OSCCTRL_DFLLULPDITHER) Dither Step = 4  */
+#define   OSCCTRL_DFLLULPDITHER_STEP_STEP8_Val _U_(0x3)                                       /**< (OSCCTRL_DFLLULPDITHER) Dither Step = 8  */
+#define OSCCTRL_DFLLULPDITHER_STEP_STEP1    (OSCCTRL_DFLLULPDITHER_STEP_STEP1_Val << OSCCTRL_DFLLULPDITHER_STEP_Pos)  /**< (OSCCTRL_DFLLULPDITHER) Dither Step = 1 Position  */
+#define OSCCTRL_DFLLULPDITHER_STEP_STEP2    (OSCCTRL_DFLLULPDITHER_STEP_STEP2_Val << OSCCTRL_DFLLULPDITHER_STEP_Pos)  /**< (OSCCTRL_DFLLULPDITHER) Dither Step = 2 Position  */
+#define OSCCTRL_DFLLULPDITHER_STEP_STEP4    (OSCCTRL_DFLLULPDITHER_STEP_STEP4_Val << OSCCTRL_DFLLULPDITHER_STEP_Pos)  /**< (OSCCTRL_DFLLULPDITHER) Dither Step = 4 Position  */
+#define OSCCTRL_DFLLULPDITHER_STEP_STEP8    (OSCCTRL_DFLLULPDITHER_STEP_STEP8_Val << OSCCTRL_DFLLULPDITHER_STEP_Pos)  /**< (OSCCTRL_DFLLULPDITHER) Dither Step = 8 Position  */
+#define OSCCTRL_DFLLULPDITHER_PER_Pos       4                                              /**< (OSCCTRL_DFLLULPDITHER) Dither Period Position */
+#define OSCCTRL_DFLLULPDITHER_PER_Msk       (_U_(0x7) << OSCCTRL_DFLLULPDITHER_PER_Pos)    /**< (OSCCTRL_DFLLULPDITHER) Dither Period Mask */
+#define OSCCTRL_DFLLULPDITHER_PER(value)    (OSCCTRL_DFLLULPDITHER_PER_Msk & ((value) << OSCCTRL_DFLLULPDITHER_PER_Pos))
+#define   OSCCTRL_DFLLULPDITHER_PER_PER1_Val _U_(0x0)                                       /**< (OSCCTRL_DFLLULPDITHER) Dither Over 1 Reference Clock Period  */
+#define   OSCCTRL_DFLLULPDITHER_PER_PER2_Val _U_(0x1)                                       /**< (OSCCTRL_DFLLULPDITHER) Dither Over 2 Reference Clock Period  */
+#define   OSCCTRL_DFLLULPDITHER_PER_PER4_Val _U_(0x2)                                       /**< (OSCCTRL_DFLLULPDITHER) Dither Over 4 Reference Clock Period  */
+#define   OSCCTRL_DFLLULPDITHER_PER_PER8_Val _U_(0x3)                                       /**< (OSCCTRL_DFLLULPDITHER) Dither Over 8 Reference Clock Period  */
+#define   OSCCTRL_DFLLULPDITHER_PER_PER16_Val _U_(0x4)                                       /**< (OSCCTRL_DFLLULPDITHER) Dither Over 16 Reference Clock Period  */
+#define   OSCCTRL_DFLLULPDITHER_PER_PER32_Val _U_(0x5)                                       /**< (OSCCTRL_DFLLULPDITHER) Dither Over 32 Reference Clock Period  */
+#define OSCCTRL_DFLLULPDITHER_PER_PER1      (OSCCTRL_DFLLULPDITHER_PER_PER1_Val << OSCCTRL_DFLLULPDITHER_PER_Pos)  /**< (OSCCTRL_DFLLULPDITHER) Dither Over 1 Reference Clock Period Position  */
+#define OSCCTRL_DFLLULPDITHER_PER_PER2      (OSCCTRL_DFLLULPDITHER_PER_PER2_Val << OSCCTRL_DFLLULPDITHER_PER_Pos)  /**< (OSCCTRL_DFLLULPDITHER) Dither Over 2 Reference Clock Period Position  */
+#define OSCCTRL_DFLLULPDITHER_PER_PER4      (OSCCTRL_DFLLULPDITHER_PER_PER4_Val << OSCCTRL_DFLLULPDITHER_PER_Pos)  /**< (OSCCTRL_DFLLULPDITHER) Dither Over 4 Reference Clock Period Position  */
+#define OSCCTRL_DFLLULPDITHER_PER_PER8      (OSCCTRL_DFLLULPDITHER_PER_PER8_Val << OSCCTRL_DFLLULPDITHER_PER_Pos)  /**< (OSCCTRL_DFLLULPDITHER) Dither Over 8 Reference Clock Period Position  */
+#define OSCCTRL_DFLLULPDITHER_PER_PER16     (OSCCTRL_DFLLULPDITHER_PER_PER16_Val << OSCCTRL_DFLLULPDITHER_PER_Pos)  /**< (OSCCTRL_DFLLULPDITHER) Dither Over 16 Reference Clock Period Position  */
+#define OSCCTRL_DFLLULPDITHER_PER_PER32     (OSCCTRL_DFLLULPDITHER_PER_PER32_Val << OSCCTRL_DFLLULPDITHER_PER_Pos)  /**< (OSCCTRL_DFLLULPDITHER) Dither Over 32 Reference Clock Period Position  */
+#define OSCCTRL_DFLLULPDITHER_MASK          _U_(0x77)                                      /**< \deprecated (OSCCTRL_DFLLULPDITHER) Register MASK  (Use OSCCTRL_DFLLULPDITHER_Msk instead)  */
+#define OSCCTRL_DFLLULPDITHER_Msk           _U_(0x77)                                      /**< (OSCCTRL_DFLLULPDITHER) Register Mask  */
+
+
+/* -------- OSCCTRL_DFLLULPRREQ : (OSCCTRL Offset: 0x1f) (R/W 8) DFLLULP Read Request -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  :7;                        /**< bit:   0..6  Reserved */
+    uint8_t  RREQ:1;                    /**< bit:      7  Read Request                             */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} OSCCTRL_DFLLULPRREQ_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_DFLLULPRREQ_OFFSET          (0x1F)                                        /**<  (OSCCTRL_DFLLULPRREQ) DFLLULP Read Request  Offset */
+#define OSCCTRL_DFLLULPRREQ_RESETVALUE      _U_(0x00)                                     /**<  (OSCCTRL_DFLLULPRREQ) DFLLULP Read Request  Reset Value */
+
+#define OSCCTRL_DFLLULPRREQ_RREQ_Pos        7                                              /**< (OSCCTRL_DFLLULPRREQ) Read Request Position */
+#define OSCCTRL_DFLLULPRREQ_RREQ_Msk        (_U_(0x1) << OSCCTRL_DFLLULPRREQ_RREQ_Pos)     /**< (OSCCTRL_DFLLULPRREQ) Read Request Mask */
+#define OSCCTRL_DFLLULPRREQ_RREQ            OSCCTRL_DFLLULPRREQ_RREQ_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_DFLLULPRREQ_RREQ_Msk instead */
+#define OSCCTRL_DFLLULPRREQ_MASK            _U_(0x80)                                      /**< \deprecated (OSCCTRL_DFLLULPRREQ) Register MASK  (Use OSCCTRL_DFLLULPRREQ_Msk instead)  */
+#define OSCCTRL_DFLLULPRREQ_Msk             _U_(0x80)                                      /**< (OSCCTRL_DFLLULPRREQ) Register Mask  */
+
+
+/* -------- OSCCTRL_DFLLULPDLY : (OSCCTRL Offset: 0x20) (R/W 32) DFLLULP Delay Value -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t DELAY:8;                   /**< bit:   0..7  Delay Value                              */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} OSCCTRL_DFLLULPDLY_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_DFLLULPDLY_OFFSET           (0x20)                                        /**<  (OSCCTRL_DFLLULPDLY) DFLLULP Delay Value  Offset */
+#define OSCCTRL_DFLLULPDLY_RESETVALUE       _U_(0x80)                                     /**<  (OSCCTRL_DFLLULPDLY) DFLLULP Delay Value  Reset Value */
+
+#define OSCCTRL_DFLLULPDLY_DELAY_Pos        0                                              /**< (OSCCTRL_DFLLULPDLY) Delay Value Position */
+#define OSCCTRL_DFLLULPDLY_DELAY_Msk        (_U_(0xFF) << OSCCTRL_DFLLULPDLY_DELAY_Pos)    /**< (OSCCTRL_DFLLULPDLY) Delay Value Mask */
+#define OSCCTRL_DFLLULPDLY_DELAY(value)     (OSCCTRL_DFLLULPDLY_DELAY_Msk & ((value) << OSCCTRL_DFLLULPDLY_DELAY_Pos))
+#define OSCCTRL_DFLLULPDLY_MASK             _U_(0xFF)                                      /**< \deprecated (OSCCTRL_DFLLULPDLY) Register MASK  (Use OSCCTRL_DFLLULPDLY_Msk instead)  */
+#define OSCCTRL_DFLLULPDLY_Msk              _U_(0xFF)                                      /**< (OSCCTRL_DFLLULPDLY) Register Mask  */
+
+
+/* -------- OSCCTRL_DFLLULPRATIO : (OSCCTRL Offset: 0x24) (R/W 32) DFLLULP Target Ratio -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t RATIO:11;                  /**< bit:  0..10  Target Tuner Ratio                       */
+    uint32_t :21;                       /**< bit: 11..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} OSCCTRL_DFLLULPRATIO_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_DFLLULPRATIO_OFFSET         (0x24)                                        /**<  (OSCCTRL_DFLLULPRATIO) DFLLULP Target Ratio  Offset */
+#define OSCCTRL_DFLLULPRATIO_RESETVALUE     _U_(0x00)                                     /**<  (OSCCTRL_DFLLULPRATIO) DFLLULP Target Ratio  Reset Value */
+
+#define OSCCTRL_DFLLULPRATIO_RATIO_Pos      0                                              /**< (OSCCTRL_DFLLULPRATIO) Target Tuner Ratio Position */
+#define OSCCTRL_DFLLULPRATIO_RATIO_Msk      (_U_(0x7FF) << OSCCTRL_DFLLULPRATIO_RATIO_Pos)  /**< (OSCCTRL_DFLLULPRATIO) Target Tuner Ratio Mask */
+#define OSCCTRL_DFLLULPRATIO_RATIO(value)   (OSCCTRL_DFLLULPRATIO_RATIO_Msk & ((value) << OSCCTRL_DFLLULPRATIO_RATIO_Pos))
+#define OSCCTRL_DFLLULPRATIO_MASK           _U_(0x7FF)                                     /**< \deprecated (OSCCTRL_DFLLULPRATIO) Register MASK  (Use OSCCTRL_DFLLULPRATIO_Msk instead)  */
+#define OSCCTRL_DFLLULPRATIO_Msk            _U_(0x7FF)                                     /**< (OSCCTRL_DFLLULPRATIO) Register Mask  */
+
+
+/* -------- OSCCTRL_DFLLULPSYNCBUSY : (OSCCTRL Offset: 0x28) (R/ 32) DFLLULP Synchronization Busy -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t ENABLE:1;                  /**< bit:      1  Enable Bit Synchronization Busy          */
+    uint32_t TUNE:1;                    /**< bit:      2  Tune Bit Synchronization Busy            */
+    uint32_t DELAY:1;                   /**< bit:      3  Delay Register Synchronization Busy      */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} OSCCTRL_DFLLULPSYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_DFLLULPSYNCBUSY_OFFSET      (0x28)                                        /**<  (OSCCTRL_DFLLULPSYNCBUSY) DFLLULP Synchronization Busy  Offset */
+#define OSCCTRL_DFLLULPSYNCBUSY_RESETVALUE  _U_(0x00)                                     /**<  (OSCCTRL_DFLLULPSYNCBUSY) DFLLULP Synchronization Busy  Reset Value */
+
+#define OSCCTRL_DFLLULPSYNCBUSY_ENABLE_Pos  1                                              /**< (OSCCTRL_DFLLULPSYNCBUSY) Enable Bit Synchronization Busy Position */
+#define OSCCTRL_DFLLULPSYNCBUSY_ENABLE_Msk  (_U_(0x1) << OSCCTRL_DFLLULPSYNCBUSY_ENABLE_Pos)  /**< (OSCCTRL_DFLLULPSYNCBUSY) Enable Bit Synchronization Busy Mask */
+#define OSCCTRL_DFLLULPSYNCBUSY_ENABLE      OSCCTRL_DFLLULPSYNCBUSY_ENABLE_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_DFLLULPSYNCBUSY_ENABLE_Msk instead */
+#define OSCCTRL_DFLLULPSYNCBUSY_TUNE_Pos    2                                              /**< (OSCCTRL_DFLLULPSYNCBUSY) Tune Bit Synchronization Busy Position */
+#define OSCCTRL_DFLLULPSYNCBUSY_TUNE_Msk    (_U_(0x1) << OSCCTRL_DFLLULPSYNCBUSY_TUNE_Pos)  /**< (OSCCTRL_DFLLULPSYNCBUSY) Tune Bit Synchronization Busy Mask */
+#define OSCCTRL_DFLLULPSYNCBUSY_TUNE        OSCCTRL_DFLLULPSYNCBUSY_TUNE_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_DFLLULPSYNCBUSY_TUNE_Msk instead */
+#define OSCCTRL_DFLLULPSYNCBUSY_DELAY_Pos   3                                              /**< (OSCCTRL_DFLLULPSYNCBUSY) Delay Register Synchronization Busy Position */
+#define OSCCTRL_DFLLULPSYNCBUSY_DELAY_Msk   (_U_(0x1) << OSCCTRL_DFLLULPSYNCBUSY_DELAY_Pos)  /**< (OSCCTRL_DFLLULPSYNCBUSY) Delay Register Synchronization Busy Mask */
+#define OSCCTRL_DFLLULPSYNCBUSY_DELAY       OSCCTRL_DFLLULPSYNCBUSY_DELAY_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_DFLLULPSYNCBUSY_DELAY_Msk instead */
+#define OSCCTRL_DFLLULPSYNCBUSY_MASK        _U_(0x0E)                                      /**< \deprecated (OSCCTRL_DFLLULPSYNCBUSY) Register MASK  (Use OSCCTRL_DFLLULPSYNCBUSY_Msk instead)  */
+#define OSCCTRL_DFLLULPSYNCBUSY_Msk         _U_(0x0E)                                      /**< (OSCCTRL_DFLLULPSYNCBUSY) Register Mask  */
+
+
+/* -------- OSCCTRL_DPLLCTRLA : (OSCCTRL Offset: 0x2c) (R/W 8) DPLL Control A -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  :1;                        /**< bit:      0  Reserved */
+    uint8_t  ENABLE:1;                  /**< bit:      1  DPLL Enable                              */
+    uint8_t  :4;                        /**< bit:   2..5  Reserved */
+    uint8_t  RUNSTDBY:1;                /**< bit:      6  Run in Standby                           */
+    uint8_t  ONDEMAND:1;                /**< bit:      7  On Demand Clock Activation               */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} OSCCTRL_DPLLCTRLA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_DPLLCTRLA_OFFSET            (0x2C)                                        /**<  (OSCCTRL_DPLLCTRLA) DPLL Control A  Offset */
+#define OSCCTRL_DPLLCTRLA_RESETVALUE        _U_(0x80)                                     /**<  (OSCCTRL_DPLLCTRLA) DPLL Control A  Reset Value */
+
+#define OSCCTRL_DPLLCTRLA_ENABLE_Pos        1                                              /**< (OSCCTRL_DPLLCTRLA) DPLL Enable Position */
+#define OSCCTRL_DPLLCTRLA_ENABLE_Msk        (_U_(0x1) << OSCCTRL_DPLLCTRLA_ENABLE_Pos)     /**< (OSCCTRL_DPLLCTRLA) DPLL Enable Mask */
+#define OSCCTRL_DPLLCTRLA_ENABLE            OSCCTRL_DPLLCTRLA_ENABLE_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_DPLLCTRLA_ENABLE_Msk instead */
+#define OSCCTRL_DPLLCTRLA_RUNSTDBY_Pos      6                                              /**< (OSCCTRL_DPLLCTRLA) Run in Standby Position */
+#define OSCCTRL_DPLLCTRLA_RUNSTDBY_Msk      (_U_(0x1) << OSCCTRL_DPLLCTRLA_RUNSTDBY_Pos)   /**< (OSCCTRL_DPLLCTRLA) Run in Standby Mask */
+#define OSCCTRL_DPLLCTRLA_RUNSTDBY          OSCCTRL_DPLLCTRLA_RUNSTDBY_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_DPLLCTRLA_RUNSTDBY_Msk instead */
+#define OSCCTRL_DPLLCTRLA_ONDEMAND_Pos      7                                              /**< (OSCCTRL_DPLLCTRLA) On Demand Clock Activation Position */
+#define OSCCTRL_DPLLCTRLA_ONDEMAND_Msk      (_U_(0x1) << OSCCTRL_DPLLCTRLA_ONDEMAND_Pos)   /**< (OSCCTRL_DPLLCTRLA) On Demand Clock Activation Mask */
+#define OSCCTRL_DPLLCTRLA_ONDEMAND          OSCCTRL_DPLLCTRLA_ONDEMAND_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_DPLLCTRLA_ONDEMAND_Msk instead */
+#define OSCCTRL_DPLLCTRLA_MASK              _U_(0xC2)                                      /**< \deprecated (OSCCTRL_DPLLCTRLA) Register MASK  (Use OSCCTRL_DPLLCTRLA_Msk instead)  */
+#define OSCCTRL_DPLLCTRLA_Msk               _U_(0xC2)                                      /**< (OSCCTRL_DPLLCTRLA) Register Mask  */
+
+
+/* -------- OSCCTRL_DPLLRATIO : (OSCCTRL Offset: 0x30) (R/W 32) DPLL Ratio Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t LDR:12;                    /**< bit:  0..11  Loop Divider Ratio                       */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t LDRFRAC:4;                 /**< bit: 16..19  Loop Divider Ratio Fractional Part       */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} OSCCTRL_DPLLRATIO_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_DPLLRATIO_OFFSET            (0x30)                                        /**<  (OSCCTRL_DPLLRATIO) DPLL Ratio Control  Offset */
+#define OSCCTRL_DPLLRATIO_RESETVALUE        _U_(0x00)                                     /**<  (OSCCTRL_DPLLRATIO) DPLL Ratio Control  Reset Value */
+
+#define OSCCTRL_DPLLRATIO_LDR_Pos           0                                              /**< (OSCCTRL_DPLLRATIO) Loop Divider Ratio Position */
+#define OSCCTRL_DPLLRATIO_LDR_Msk           (_U_(0xFFF) << OSCCTRL_DPLLRATIO_LDR_Pos)      /**< (OSCCTRL_DPLLRATIO) Loop Divider Ratio Mask */
+#define OSCCTRL_DPLLRATIO_LDR(value)        (OSCCTRL_DPLLRATIO_LDR_Msk & ((value) << OSCCTRL_DPLLRATIO_LDR_Pos))
+#define OSCCTRL_DPLLRATIO_LDRFRAC_Pos       16                                             /**< (OSCCTRL_DPLLRATIO) Loop Divider Ratio Fractional Part Position */
+#define OSCCTRL_DPLLRATIO_LDRFRAC_Msk       (_U_(0xF) << OSCCTRL_DPLLRATIO_LDRFRAC_Pos)    /**< (OSCCTRL_DPLLRATIO) Loop Divider Ratio Fractional Part Mask */
+#define OSCCTRL_DPLLRATIO_LDRFRAC(value)    (OSCCTRL_DPLLRATIO_LDRFRAC_Msk & ((value) << OSCCTRL_DPLLRATIO_LDRFRAC_Pos))
+#define OSCCTRL_DPLLRATIO_MASK              _U_(0xF0FFF)                                   /**< \deprecated (OSCCTRL_DPLLRATIO) Register MASK  (Use OSCCTRL_DPLLRATIO_Msk instead)  */
+#define OSCCTRL_DPLLRATIO_Msk               _U_(0xF0FFF)                                   /**< (OSCCTRL_DPLLRATIO) Register Mask  */
+
+
+/* -------- OSCCTRL_DPLLCTRLB : (OSCCTRL Offset: 0x34) (R/W 32) DPLL Control B -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t FILTER:2;                  /**< bit:   0..1  Proportional Integral Filter Selection   */
+    uint32_t LPEN:1;                    /**< bit:      2  Low-Power Enable                         */
+    uint32_t WUF:1;                     /**< bit:      3  Wake Up Fast                             */
+    uint32_t REFCLK:2;                  /**< bit:   4..5  Reference Clock Selection                */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t LTIME:3;                   /**< bit:  8..10  Lock Time                                */
+    uint32_t :1;                        /**< bit:     11  Reserved */
+    uint32_t LBYPASS:1;                 /**< bit:     12  Lock Bypass                              */
+    uint32_t :3;                        /**< bit: 13..15  Reserved */
+    uint32_t DIV:11;                    /**< bit: 16..26  Clock Divider                            */
+    uint32_t :5;                        /**< bit: 27..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} OSCCTRL_DPLLCTRLB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_DPLLCTRLB_OFFSET            (0x34)                                        /**<  (OSCCTRL_DPLLCTRLB) DPLL Control B  Offset */
+#define OSCCTRL_DPLLCTRLB_RESETVALUE        _U_(0x00)                                     /**<  (OSCCTRL_DPLLCTRLB) DPLL Control B  Reset Value */
+
+#define OSCCTRL_DPLLCTRLB_FILTER_Pos        0                                              /**< (OSCCTRL_DPLLCTRLB) Proportional Integral Filter Selection Position */
+#define OSCCTRL_DPLLCTRLB_FILTER_Msk        (_U_(0x3) << OSCCTRL_DPLLCTRLB_FILTER_Pos)     /**< (OSCCTRL_DPLLCTRLB) Proportional Integral Filter Selection Mask */
+#define OSCCTRL_DPLLCTRLB_FILTER(value)     (OSCCTRL_DPLLCTRLB_FILTER_Msk & ((value) << OSCCTRL_DPLLCTRLB_FILTER_Pos))
+#define   OSCCTRL_DPLLCTRLB_FILTER_Default_Val _U_(0x0)                                       /**< (OSCCTRL_DPLLCTRLB) Default Filter Mode  */
+#define   OSCCTRL_DPLLCTRLB_FILTER_LBFILT_Val _U_(0x1)                                       /**< (OSCCTRL_DPLLCTRLB) Low Bandwidth Filter  */
+#define   OSCCTRL_DPLLCTRLB_FILTER_HBFILT_Val _U_(0x2)                                       /**< (OSCCTRL_DPLLCTRLB) High Bandwidth Filter  */
+#define   OSCCTRL_DPLLCTRLB_FILTER_HDFILT_Val _U_(0x3)                                       /**< (OSCCTRL_DPLLCTRLB) High Damping Filter  */
+#define OSCCTRL_DPLLCTRLB_FILTER_Default    (OSCCTRL_DPLLCTRLB_FILTER_Default_Val << OSCCTRL_DPLLCTRLB_FILTER_Pos)  /**< (OSCCTRL_DPLLCTRLB) Default Filter Mode Position  */
+#define OSCCTRL_DPLLCTRLB_FILTER_LBFILT     (OSCCTRL_DPLLCTRLB_FILTER_LBFILT_Val << OSCCTRL_DPLLCTRLB_FILTER_Pos)  /**< (OSCCTRL_DPLLCTRLB) Low Bandwidth Filter Position  */
+#define OSCCTRL_DPLLCTRLB_FILTER_HBFILT     (OSCCTRL_DPLLCTRLB_FILTER_HBFILT_Val << OSCCTRL_DPLLCTRLB_FILTER_Pos)  /**< (OSCCTRL_DPLLCTRLB) High Bandwidth Filter Position  */
+#define OSCCTRL_DPLLCTRLB_FILTER_HDFILT     (OSCCTRL_DPLLCTRLB_FILTER_HDFILT_Val << OSCCTRL_DPLLCTRLB_FILTER_Pos)  /**< (OSCCTRL_DPLLCTRLB) High Damping Filter Position  */
+#define OSCCTRL_DPLLCTRLB_LPEN_Pos          2                                              /**< (OSCCTRL_DPLLCTRLB) Low-Power Enable Position */
+#define OSCCTRL_DPLLCTRLB_LPEN_Msk          (_U_(0x1) << OSCCTRL_DPLLCTRLB_LPEN_Pos)       /**< (OSCCTRL_DPLLCTRLB) Low-Power Enable Mask */
+#define OSCCTRL_DPLLCTRLB_LPEN              OSCCTRL_DPLLCTRLB_LPEN_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_DPLLCTRLB_LPEN_Msk instead */
+#define OSCCTRL_DPLLCTRLB_WUF_Pos           3                                              /**< (OSCCTRL_DPLLCTRLB) Wake Up Fast Position */
+#define OSCCTRL_DPLLCTRLB_WUF_Msk           (_U_(0x1) << OSCCTRL_DPLLCTRLB_WUF_Pos)        /**< (OSCCTRL_DPLLCTRLB) Wake Up Fast Mask */
+#define OSCCTRL_DPLLCTRLB_WUF               OSCCTRL_DPLLCTRLB_WUF_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_DPLLCTRLB_WUF_Msk instead */
+#define OSCCTRL_DPLLCTRLB_REFCLK_Pos        4                                              /**< (OSCCTRL_DPLLCTRLB) Reference Clock Selection Position */
+#define OSCCTRL_DPLLCTRLB_REFCLK_Msk        (_U_(0x3) << OSCCTRL_DPLLCTRLB_REFCLK_Pos)     /**< (OSCCTRL_DPLLCTRLB) Reference Clock Selection Mask */
+#define OSCCTRL_DPLLCTRLB_REFCLK(value)     (OSCCTRL_DPLLCTRLB_REFCLK_Msk & ((value) << OSCCTRL_DPLLCTRLB_REFCLK_Pos))
+#define   OSCCTRL_DPLLCTRLB_REFCLK_XOSC32K_Val _U_(0x0)                                       /**< (OSCCTRL_DPLLCTRLB) XOSC32K Clock Reference  */
+#define   OSCCTRL_DPLLCTRLB_REFCLK_XOSC_Val _U_(0x1)                                       /**< (OSCCTRL_DPLLCTRLB) XOSC Clock Reference  */
+#define   OSCCTRL_DPLLCTRLB_REFCLK_GCLK_Val _U_(0x2)                                       /**< (OSCCTRL_DPLLCTRLB) GCLK Clock Reference  */
+#define OSCCTRL_DPLLCTRLB_REFCLK_XOSC32K    (OSCCTRL_DPLLCTRLB_REFCLK_XOSC32K_Val << OSCCTRL_DPLLCTRLB_REFCLK_Pos)  /**< (OSCCTRL_DPLLCTRLB) XOSC32K Clock Reference Position  */
+#define OSCCTRL_DPLLCTRLB_REFCLK_XOSC       (OSCCTRL_DPLLCTRLB_REFCLK_XOSC_Val << OSCCTRL_DPLLCTRLB_REFCLK_Pos)  /**< (OSCCTRL_DPLLCTRLB) XOSC Clock Reference Position  */
+#define OSCCTRL_DPLLCTRLB_REFCLK_GCLK       (OSCCTRL_DPLLCTRLB_REFCLK_GCLK_Val << OSCCTRL_DPLLCTRLB_REFCLK_Pos)  /**< (OSCCTRL_DPLLCTRLB) GCLK Clock Reference Position  */
+#define OSCCTRL_DPLLCTRLB_LTIME_Pos         8                                              /**< (OSCCTRL_DPLLCTRLB) Lock Time Position */
+#define OSCCTRL_DPLLCTRLB_LTIME_Msk         (_U_(0x7) << OSCCTRL_DPLLCTRLB_LTIME_Pos)      /**< (OSCCTRL_DPLLCTRLB) Lock Time Mask */
+#define OSCCTRL_DPLLCTRLB_LTIME(value)      (OSCCTRL_DPLLCTRLB_LTIME_Msk & ((value) << OSCCTRL_DPLLCTRLB_LTIME_Pos))
+#define   OSCCTRL_DPLLCTRLB_LTIME_Default_Val _U_(0x0)                                       /**< (OSCCTRL_DPLLCTRLB) No time-out. Automatic lock  */
+#define   OSCCTRL_DPLLCTRLB_LTIME_8MS_Val   _U_(0x4)                                       /**< (OSCCTRL_DPLLCTRLB) Time-out if no lock within 8 ms  */
+#define   OSCCTRL_DPLLCTRLB_LTIME_9MS_Val   _U_(0x5)                                       /**< (OSCCTRL_DPLLCTRLB) Time-out if no lock within 9 ms  */
+#define   OSCCTRL_DPLLCTRLB_LTIME_10MS_Val  _U_(0x6)                                       /**< (OSCCTRL_DPLLCTRLB) Time-out if no lock within 10 ms  */
+#define   OSCCTRL_DPLLCTRLB_LTIME_11MS_Val  _U_(0x7)                                       /**< (OSCCTRL_DPLLCTRLB) Time-out if no lock within 11 ms  */
+#define OSCCTRL_DPLLCTRLB_LTIME_Default     (OSCCTRL_DPLLCTRLB_LTIME_Default_Val << OSCCTRL_DPLLCTRLB_LTIME_Pos)  /**< (OSCCTRL_DPLLCTRLB) No time-out. Automatic lock Position  */
+#define OSCCTRL_DPLLCTRLB_LTIME_8MS         (OSCCTRL_DPLLCTRLB_LTIME_8MS_Val << OSCCTRL_DPLLCTRLB_LTIME_Pos)  /**< (OSCCTRL_DPLLCTRLB) Time-out if no lock within 8 ms Position  */
+#define OSCCTRL_DPLLCTRLB_LTIME_9MS         (OSCCTRL_DPLLCTRLB_LTIME_9MS_Val << OSCCTRL_DPLLCTRLB_LTIME_Pos)  /**< (OSCCTRL_DPLLCTRLB) Time-out if no lock within 9 ms Position  */
+#define OSCCTRL_DPLLCTRLB_LTIME_10MS        (OSCCTRL_DPLLCTRLB_LTIME_10MS_Val << OSCCTRL_DPLLCTRLB_LTIME_Pos)  /**< (OSCCTRL_DPLLCTRLB) Time-out if no lock within 10 ms Position  */
+#define OSCCTRL_DPLLCTRLB_LTIME_11MS        (OSCCTRL_DPLLCTRLB_LTIME_11MS_Val << OSCCTRL_DPLLCTRLB_LTIME_Pos)  /**< (OSCCTRL_DPLLCTRLB) Time-out if no lock within 11 ms Position  */
+#define OSCCTRL_DPLLCTRLB_LBYPASS_Pos       12                                             /**< (OSCCTRL_DPLLCTRLB) Lock Bypass Position */
+#define OSCCTRL_DPLLCTRLB_LBYPASS_Msk       (_U_(0x1) << OSCCTRL_DPLLCTRLB_LBYPASS_Pos)    /**< (OSCCTRL_DPLLCTRLB) Lock Bypass Mask */
+#define OSCCTRL_DPLLCTRLB_LBYPASS           OSCCTRL_DPLLCTRLB_LBYPASS_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_DPLLCTRLB_LBYPASS_Msk instead */
+#define OSCCTRL_DPLLCTRLB_DIV_Pos           16                                             /**< (OSCCTRL_DPLLCTRLB) Clock Divider Position */
+#define OSCCTRL_DPLLCTRLB_DIV_Msk           (_U_(0x7FF) << OSCCTRL_DPLLCTRLB_DIV_Pos)      /**< (OSCCTRL_DPLLCTRLB) Clock Divider Mask */
+#define OSCCTRL_DPLLCTRLB_DIV(value)        (OSCCTRL_DPLLCTRLB_DIV_Msk & ((value) << OSCCTRL_DPLLCTRLB_DIV_Pos))
+#define OSCCTRL_DPLLCTRLB_MASK              _U_(0x7FF173F)                                 /**< \deprecated (OSCCTRL_DPLLCTRLB) Register MASK  (Use OSCCTRL_DPLLCTRLB_Msk instead)  */
+#define OSCCTRL_DPLLCTRLB_Msk               _U_(0x7FF173F)                                 /**< (OSCCTRL_DPLLCTRLB) Register Mask  */
+
+
+/* -------- OSCCTRL_DPLLPRESC : (OSCCTRL Offset: 0x38) (R/W 8) DPLL Prescaler -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  PRESC:2;                   /**< bit:   0..1  Output Clock Prescaler                   */
+    uint8_t  :6;                        /**< bit:   2..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} OSCCTRL_DPLLPRESC_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_DPLLPRESC_OFFSET            (0x38)                                        /**<  (OSCCTRL_DPLLPRESC) DPLL Prescaler  Offset */
+#define OSCCTRL_DPLLPRESC_RESETVALUE        _U_(0x00)                                     /**<  (OSCCTRL_DPLLPRESC) DPLL Prescaler  Reset Value */
+
+#define OSCCTRL_DPLLPRESC_PRESC_Pos         0                                              /**< (OSCCTRL_DPLLPRESC) Output Clock Prescaler Position */
+#define OSCCTRL_DPLLPRESC_PRESC_Msk         (_U_(0x3) << OSCCTRL_DPLLPRESC_PRESC_Pos)      /**< (OSCCTRL_DPLLPRESC) Output Clock Prescaler Mask */
+#define OSCCTRL_DPLLPRESC_PRESC(value)      (OSCCTRL_DPLLPRESC_PRESC_Msk & ((value) << OSCCTRL_DPLLPRESC_PRESC_Pos))
+#define   OSCCTRL_DPLLPRESC_PRESC_DIV1_Val  _U_(0x0)                                       /**< (OSCCTRL_DPLLPRESC) DPLL output is divided by 1  */
+#define   OSCCTRL_DPLLPRESC_PRESC_DIV2_Val  _U_(0x1)                                       /**< (OSCCTRL_DPLLPRESC) DPLL output is divided by 2  */
+#define   OSCCTRL_DPLLPRESC_PRESC_DIV4_Val  _U_(0x2)                                       /**< (OSCCTRL_DPLLPRESC) DPLL output is divided by 4  */
+#define OSCCTRL_DPLLPRESC_PRESC_DIV1        (OSCCTRL_DPLLPRESC_PRESC_DIV1_Val << OSCCTRL_DPLLPRESC_PRESC_Pos)  /**< (OSCCTRL_DPLLPRESC) DPLL output is divided by 1 Position  */
+#define OSCCTRL_DPLLPRESC_PRESC_DIV2        (OSCCTRL_DPLLPRESC_PRESC_DIV2_Val << OSCCTRL_DPLLPRESC_PRESC_Pos)  /**< (OSCCTRL_DPLLPRESC) DPLL output is divided by 2 Position  */
+#define OSCCTRL_DPLLPRESC_PRESC_DIV4        (OSCCTRL_DPLLPRESC_PRESC_DIV4_Val << OSCCTRL_DPLLPRESC_PRESC_Pos)  /**< (OSCCTRL_DPLLPRESC) DPLL output is divided by 4 Position  */
+#define OSCCTRL_DPLLPRESC_MASK              _U_(0x03)                                      /**< \deprecated (OSCCTRL_DPLLPRESC) Register MASK  (Use OSCCTRL_DPLLPRESC_Msk instead)  */
+#define OSCCTRL_DPLLPRESC_Msk               _U_(0x03)                                      /**< (OSCCTRL_DPLLPRESC) Register Mask  */
+
+
+/* -------- OSCCTRL_DPLLSYNCBUSY : (OSCCTRL Offset: 0x3c) (R/ 8) DPLL Synchronization Busy -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  :1;                        /**< bit:      0  Reserved */
+    uint8_t  ENABLE:1;                  /**< bit:      1  DPLL Enable Synchronization Status       */
+    uint8_t  DPLLRATIO:1;               /**< bit:      2  DPLL Loop Divider Ratio Synchronization Status */
+    uint8_t  DPLLPRESC:1;               /**< bit:      3  DPLL Prescaler Synchronization Status    */
+    uint8_t  :4;                        /**< bit:   4..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} OSCCTRL_DPLLSYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_DPLLSYNCBUSY_OFFSET         (0x3C)                                        /**<  (OSCCTRL_DPLLSYNCBUSY) DPLL Synchronization Busy  Offset */
+#define OSCCTRL_DPLLSYNCBUSY_RESETVALUE     _U_(0x00)                                     /**<  (OSCCTRL_DPLLSYNCBUSY) DPLL Synchronization Busy  Reset Value */
+
+#define OSCCTRL_DPLLSYNCBUSY_ENABLE_Pos     1                                              /**< (OSCCTRL_DPLLSYNCBUSY) DPLL Enable Synchronization Status Position */
+#define OSCCTRL_DPLLSYNCBUSY_ENABLE_Msk     (_U_(0x1) << OSCCTRL_DPLLSYNCBUSY_ENABLE_Pos)  /**< (OSCCTRL_DPLLSYNCBUSY) DPLL Enable Synchronization Status Mask */
+#define OSCCTRL_DPLLSYNCBUSY_ENABLE         OSCCTRL_DPLLSYNCBUSY_ENABLE_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_DPLLSYNCBUSY_ENABLE_Msk instead */
+#define OSCCTRL_DPLLSYNCBUSY_DPLLRATIO_Pos  2                                              /**< (OSCCTRL_DPLLSYNCBUSY) DPLL Loop Divider Ratio Synchronization Status Position */
+#define OSCCTRL_DPLLSYNCBUSY_DPLLRATIO_Msk  (_U_(0x1) << OSCCTRL_DPLLSYNCBUSY_DPLLRATIO_Pos)  /**< (OSCCTRL_DPLLSYNCBUSY) DPLL Loop Divider Ratio Synchronization Status Mask */
+#define OSCCTRL_DPLLSYNCBUSY_DPLLRATIO      OSCCTRL_DPLLSYNCBUSY_DPLLRATIO_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_DPLLSYNCBUSY_DPLLRATIO_Msk instead */
+#define OSCCTRL_DPLLSYNCBUSY_DPLLPRESC_Pos  3                                              /**< (OSCCTRL_DPLLSYNCBUSY) DPLL Prescaler Synchronization Status Position */
+#define OSCCTRL_DPLLSYNCBUSY_DPLLPRESC_Msk  (_U_(0x1) << OSCCTRL_DPLLSYNCBUSY_DPLLPRESC_Pos)  /**< (OSCCTRL_DPLLSYNCBUSY) DPLL Prescaler Synchronization Status Mask */
+#define OSCCTRL_DPLLSYNCBUSY_DPLLPRESC      OSCCTRL_DPLLSYNCBUSY_DPLLPRESC_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_DPLLSYNCBUSY_DPLLPRESC_Msk instead */
+#define OSCCTRL_DPLLSYNCBUSY_MASK           _U_(0x0E)                                      /**< \deprecated (OSCCTRL_DPLLSYNCBUSY) Register MASK  (Use OSCCTRL_DPLLSYNCBUSY_Msk instead)  */
+#define OSCCTRL_DPLLSYNCBUSY_Msk            _U_(0x0E)                                      /**< (OSCCTRL_DPLLSYNCBUSY) Register Mask  */
+
+
+/* -------- OSCCTRL_DPLLSTATUS : (OSCCTRL Offset: 0x40) (R/ 8) DPLL Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  LOCK:1;                    /**< bit:      0  DPLL Lock                                */
+    uint8_t  CLKRDY:1;                  /**< bit:      1  DPLL Clock Ready                         */
+    uint8_t  :6;                        /**< bit:   2..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} OSCCTRL_DPLLSTATUS_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_DPLLSTATUS_OFFSET           (0x40)                                        /**<  (OSCCTRL_DPLLSTATUS) DPLL Status  Offset */
+#define OSCCTRL_DPLLSTATUS_RESETVALUE       _U_(0x00)                                     /**<  (OSCCTRL_DPLLSTATUS) DPLL Status  Reset Value */
+
+#define OSCCTRL_DPLLSTATUS_LOCK_Pos         0                                              /**< (OSCCTRL_DPLLSTATUS) DPLL Lock Position */
+#define OSCCTRL_DPLLSTATUS_LOCK_Msk         (_U_(0x1) << OSCCTRL_DPLLSTATUS_LOCK_Pos)      /**< (OSCCTRL_DPLLSTATUS) DPLL Lock Mask */
+#define OSCCTRL_DPLLSTATUS_LOCK             OSCCTRL_DPLLSTATUS_LOCK_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_DPLLSTATUS_LOCK_Msk instead */
+#define OSCCTRL_DPLLSTATUS_CLKRDY_Pos       1                                              /**< (OSCCTRL_DPLLSTATUS) DPLL Clock Ready Position */
+#define OSCCTRL_DPLLSTATUS_CLKRDY_Msk       (_U_(0x1) << OSCCTRL_DPLLSTATUS_CLKRDY_Pos)    /**< (OSCCTRL_DPLLSTATUS) DPLL Clock Ready Mask */
+#define OSCCTRL_DPLLSTATUS_CLKRDY           OSCCTRL_DPLLSTATUS_CLKRDY_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_DPLLSTATUS_CLKRDY_Msk instead */
+#define OSCCTRL_DPLLSTATUS_MASK             _U_(0x03)                                      /**< \deprecated (OSCCTRL_DPLLSTATUS) Register MASK  (Use OSCCTRL_DPLLSTATUS_Msk instead)  */
+#define OSCCTRL_DPLLSTATUS_Msk              _U_(0x03)                                      /**< (OSCCTRL_DPLLSTATUS) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief OSCCTRL hardware registers */
+typedef struct {  /* Oscillators Control */
+  __IO OSCCTRL_EVCTRL_Type            EVCTRL;         /**< Offset: 0x00 (R/W   8) Event Control */
+  __I  uint8_t                        Reserved1[3];
+  __IO OSCCTRL_INTENCLR_Type          INTENCLR;       /**< Offset: 0x04 (R/W  32) Interrupt Enable Clear */
+  __IO OSCCTRL_INTENSET_Type          INTENSET;       /**< Offset: 0x08 (R/W  32) Interrupt Enable Set */
+  __IO OSCCTRL_INTFLAG_Type           INTFLAG;        /**< Offset: 0x0C (R/W  32) Interrupt Flag Status and Clear */
+  __I  OSCCTRL_STATUS_Type            STATUS;         /**< Offset: 0x10 (R/   32) Status */
+  __IO OSCCTRL_XOSCCTRL_Type          XOSCCTRL;       /**< Offset: 0x14 (R/W  16) External Multipurpose Crystal Oscillator (XOSC) Control */
+  __IO OSCCTRL_CFDPRESC_Type          CFDPRESC;       /**< Offset: 0x16 (R/W   8) Clock Failure Detector Prescaler */
+  __I  uint8_t                        Reserved2[1];
+  __IO OSCCTRL_OSC16MCTRL_Type        OSC16MCTRL;     /**< Offset: 0x18 (R/W   8) 16MHz Internal Oscillator (OSC16M) Control */
+  __I  uint8_t                        Reserved3[3];
+  __IO OSCCTRL_DFLLULPCTRL_Type       DFLLULPCTRL;    /**< Offset: 0x1C (R/W  16) DFLLULP Control */
+  __IO OSCCTRL_DFLLULPDITHER_Type     DFLLULPDITHER;  /**< Offset: 0x1E (R/W   8) DFLLULP Dither Control */
+  __IO OSCCTRL_DFLLULPRREQ_Type       DFLLULPRREQ;    /**< Offset: 0x1F (R/W   8) DFLLULP Read Request */
+  __IO OSCCTRL_DFLLULPDLY_Type        DFLLULPDLY;     /**< Offset: 0x20 (R/W  32) DFLLULP Delay Value */
+  __IO OSCCTRL_DFLLULPRATIO_Type      DFLLULPRATIO;   /**< Offset: 0x24 (R/W  32) DFLLULP Target Ratio */
+  __I  OSCCTRL_DFLLULPSYNCBUSY_Type   DFLLULPSYNCBUSY; /**< Offset: 0x28 (R/   32) DFLLULP Synchronization Busy */
+  __IO OSCCTRL_DPLLCTRLA_Type         DPLLCTRLA;      /**< Offset: 0x2C (R/W   8) DPLL Control A */
+  __I  uint8_t                        Reserved4[3];
+  __IO OSCCTRL_DPLLRATIO_Type         DPLLRATIO;      /**< Offset: 0x30 (R/W  32) DPLL Ratio Control */
+  __IO OSCCTRL_DPLLCTRLB_Type         DPLLCTRLB;      /**< Offset: 0x34 (R/W  32) DPLL Control B */
+  __IO OSCCTRL_DPLLPRESC_Type         DPLLPRESC;      /**< Offset: 0x38 (R/W   8) DPLL Prescaler */
+  __I  uint8_t                        Reserved5[3];
+  __I  OSCCTRL_DPLLSYNCBUSY_Type      DPLLSYNCBUSY;   /**< Offset: 0x3C (R/    8) DPLL Synchronization Busy */
+  __I  uint8_t                        Reserved6[3];
+  __I  OSCCTRL_DPLLSTATUS_Type        DPLLSTATUS;     /**< Offset: 0x40 (R/    8) DPLL Status */
+} Oscctrl;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Oscillators Control */
+
+#endif /* _SAML10_OSCCTRL_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/component/pac.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/pac.h
@@ -1,0 +1,966 @@
+/**
+ * \file
+ *
+ * \brief Component description for PAC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_PAC_COMPONENT_H_
+#define _SAML10_PAC_COMPONENT_H_
+#define _SAML10_PAC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML10 Peripheral Access Controller
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR PAC */
+/* ========================================================================== */
+
+#define PAC_U2120                      /**< (PAC) Module ID */
+#define REV_PAC 0x200                  /**< (PAC) Module revision */
+
+/* -------- PAC_WRCTRL : (PAC Offset: 0x00) (R/W 32) Write control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t PERID:16;                  /**< bit:  0..15  Peripheral identifier                    */
+    uint32_t KEY:8;                     /**< bit: 16..23  Peripheral access control key            */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PAC_WRCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_WRCTRL_OFFSET                   (0x00)                                        /**<  (PAC_WRCTRL) Write control  Offset */
+#define PAC_WRCTRL_RESETVALUE               _U_(0x00)                                     /**<  (PAC_WRCTRL) Write control  Reset Value */
+
+#define PAC_WRCTRL_PERID_Pos                0                                              /**< (PAC_WRCTRL) Peripheral identifier Position */
+#define PAC_WRCTRL_PERID_Msk                (_U_(0xFFFF) << PAC_WRCTRL_PERID_Pos)          /**< (PAC_WRCTRL) Peripheral identifier Mask */
+#define PAC_WRCTRL_PERID(value)             (PAC_WRCTRL_PERID_Msk & ((value) << PAC_WRCTRL_PERID_Pos))
+#define PAC_WRCTRL_KEY_Pos                  16                                             /**< (PAC_WRCTRL) Peripheral access control key Position */
+#define PAC_WRCTRL_KEY_Msk                  (_U_(0xFF) << PAC_WRCTRL_KEY_Pos)              /**< (PAC_WRCTRL) Peripheral access control key Mask */
+#define PAC_WRCTRL_KEY(value)               (PAC_WRCTRL_KEY_Msk & ((value) << PAC_WRCTRL_KEY_Pos))
+#define   PAC_WRCTRL_KEY_OFF_Val            _U_(0x0)                                       /**< (PAC_WRCTRL) No action  */
+#define   PAC_WRCTRL_KEY_CLR_Val            _U_(0x1)                                       /**< (PAC_WRCTRL) Clear protection  */
+#define   PAC_WRCTRL_KEY_SET_Val            _U_(0x2)                                       /**< (PAC_WRCTRL) Set protection  */
+#define   PAC_WRCTRL_KEY_SETLCK_Val         _U_(0x3)                                       /**< (PAC_WRCTRL) Set and lock protection  */
+#define   PAC_WRCTRL_KEY_SETSEC_Val         _U_(0x4)                                       /**< (PAC_WRCTRL) Set IP secure  */
+#define   PAC_WRCTRL_KEY_SETNONSEC_Val      _U_(0x5)                                       /**< (PAC_WRCTRL) Set IP non-secure  */
+#define   PAC_WRCTRL_KEY_SECLOCK_Val        _U_(0x6)                                       /**< (PAC_WRCTRL) Lock IP security value  */
+#define PAC_WRCTRL_KEY_OFF                  (PAC_WRCTRL_KEY_OFF_Val << PAC_WRCTRL_KEY_Pos)  /**< (PAC_WRCTRL) No action Position  */
+#define PAC_WRCTRL_KEY_CLR                  (PAC_WRCTRL_KEY_CLR_Val << PAC_WRCTRL_KEY_Pos)  /**< (PAC_WRCTRL) Clear protection Position  */
+#define PAC_WRCTRL_KEY_SET                  (PAC_WRCTRL_KEY_SET_Val << PAC_WRCTRL_KEY_Pos)  /**< (PAC_WRCTRL) Set protection Position  */
+#define PAC_WRCTRL_KEY_SETLCK               (PAC_WRCTRL_KEY_SETLCK_Val << PAC_WRCTRL_KEY_Pos)  /**< (PAC_WRCTRL) Set and lock protection Position  */
+#define PAC_WRCTRL_KEY_SETSEC               (PAC_WRCTRL_KEY_SETSEC_Val << PAC_WRCTRL_KEY_Pos)  /**< (PAC_WRCTRL) Set IP secure Position  */
+#define PAC_WRCTRL_KEY_SETNONSEC            (PAC_WRCTRL_KEY_SETNONSEC_Val << PAC_WRCTRL_KEY_Pos)  /**< (PAC_WRCTRL) Set IP non-secure Position  */
+#define PAC_WRCTRL_KEY_SECLOCK              (PAC_WRCTRL_KEY_SECLOCK_Val << PAC_WRCTRL_KEY_Pos)  /**< (PAC_WRCTRL) Lock IP security value Position  */
+#define PAC_WRCTRL_MASK                     _U_(0xFFFFFF)                                  /**< \deprecated (PAC_WRCTRL) Register MASK  (Use PAC_WRCTRL_Msk instead)  */
+#define PAC_WRCTRL_Msk                      _U_(0xFFFFFF)                                  /**< (PAC_WRCTRL) Register Mask  */
+
+
+/* -------- PAC_EVCTRL : (PAC Offset: 0x04) (R/W 8) Event control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  ERREO:1;                   /**< bit:      0  Peripheral acess error event output      */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} PAC_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_EVCTRL_OFFSET                   (0x04)                                        /**<  (PAC_EVCTRL) Event control  Offset */
+#define PAC_EVCTRL_RESETVALUE               _U_(0x00)                                     /**<  (PAC_EVCTRL) Event control  Reset Value */
+
+#define PAC_EVCTRL_ERREO_Pos                0                                              /**< (PAC_EVCTRL) Peripheral acess error event output Position */
+#define PAC_EVCTRL_ERREO_Msk                (_U_(0x1) << PAC_EVCTRL_ERREO_Pos)             /**< (PAC_EVCTRL) Peripheral acess error event output Mask */
+#define PAC_EVCTRL_ERREO                    PAC_EVCTRL_ERREO_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_EVCTRL_ERREO_Msk instead */
+#define PAC_EVCTRL_MASK                     _U_(0x01)                                      /**< \deprecated (PAC_EVCTRL) Register MASK  (Use PAC_EVCTRL_Msk instead)  */
+#define PAC_EVCTRL_Msk                      _U_(0x01)                                      /**< (PAC_EVCTRL) Register Mask  */
+
+
+/* -------- PAC_INTENCLR : (PAC Offset: 0x08) (R/W 8) Interrupt enable clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  ERR:1;                     /**< bit:      0  Peripheral access error interrupt disable */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} PAC_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_INTENCLR_OFFSET                 (0x08)                                        /**<  (PAC_INTENCLR) Interrupt enable clear  Offset */
+#define PAC_INTENCLR_RESETVALUE             _U_(0x00)                                     /**<  (PAC_INTENCLR) Interrupt enable clear  Reset Value */
+
+#define PAC_INTENCLR_ERR_Pos                0                                              /**< (PAC_INTENCLR) Peripheral access error interrupt disable Position */
+#define PAC_INTENCLR_ERR_Msk                (_U_(0x1) << PAC_INTENCLR_ERR_Pos)             /**< (PAC_INTENCLR) Peripheral access error interrupt disable Mask */
+#define PAC_INTENCLR_ERR                    PAC_INTENCLR_ERR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTENCLR_ERR_Msk instead */
+#define PAC_INTENCLR_MASK                   _U_(0x01)                                      /**< \deprecated (PAC_INTENCLR) Register MASK  (Use PAC_INTENCLR_Msk instead)  */
+#define PAC_INTENCLR_Msk                    _U_(0x01)                                      /**< (PAC_INTENCLR) Register Mask  */
+
+
+/* -------- PAC_INTENSET : (PAC Offset: 0x09) (R/W 8) Interrupt enable set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  ERR:1;                     /**< bit:      0  Peripheral access error interrupt enable */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} PAC_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_INTENSET_OFFSET                 (0x09)                                        /**<  (PAC_INTENSET) Interrupt enable set  Offset */
+#define PAC_INTENSET_RESETVALUE             _U_(0x00)                                     /**<  (PAC_INTENSET) Interrupt enable set  Reset Value */
+
+#define PAC_INTENSET_ERR_Pos                0                                              /**< (PAC_INTENSET) Peripheral access error interrupt enable Position */
+#define PAC_INTENSET_ERR_Msk                (_U_(0x1) << PAC_INTENSET_ERR_Pos)             /**< (PAC_INTENSET) Peripheral access error interrupt enable Mask */
+#define PAC_INTENSET_ERR                    PAC_INTENSET_ERR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTENSET_ERR_Msk instead */
+#define PAC_INTENSET_MASK                   _U_(0x01)                                      /**< \deprecated (PAC_INTENSET) Register MASK  (Use PAC_INTENSET_Msk instead)  */
+#define PAC_INTENSET_Msk                    _U_(0x01)                                      /**< (PAC_INTENSET) Register Mask  */
+
+
+/* -------- PAC_INTFLAGAHB : (PAC Offset: 0x10) (R/W 32) Bridge interrupt flag status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint32_t FLASH_:1;                  /**< bit:      0  FLASH                                    */
+    __I uint32_t HPB0_:1;                   /**< bit:      1  HPB0                                     */
+    __I uint32_t HPB1_:1;                   /**< bit:      2  HPB1                                     */
+    __I uint32_t HPB2_:1;                   /**< bit:      3  HPB2                                     */
+    __I uint32_t HSRAMCPU_:1;               /**< bit:      4  HSRAMCPU                                 */
+    __I uint32_t HSRAMDMAC_:1;              /**< bit:      5  HSRAMDMAC                                */
+    __I uint32_t HSRAMDSU_:1;               /**< bit:      6  HSRAMDSU                                 */
+    __I uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PAC_INTFLAGAHB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_INTFLAGAHB_OFFSET               (0x10)                                        /**<  (PAC_INTFLAGAHB) Bridge interrupt flag status  Offset */
+#define PAC_INTFLAGAHB_RESETVALUE           _U_(0x00)                                     /**<  (PAC_INTFLAGAHB) Bridge interrupt flag status  Reset Value */
+
+#define PAC_INTFLAGAHB_FLASH_Pos            0                                              /**< (PAC_INTFLAGAHB) FLASH Position */
+#define PAC_INTFLAGAHB_FLASH_Msk            (_U_(0x1) << PAC_INTFLAGAHB_FLASH_Pos)         /**< (PAC_INTFLAGAHB) FLASH Mask */
+#define PAC_INTFLAGAHB_FLASH                PAC_INTFLAGAHB_FLASH_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGAHB_FLASH_Msk instead */
+#define PAC_INTFLAGAHB_HPB0_Pos             1                                              /**< (PAC_INTFLAGAHB) HPB0 Position */
+#define PAC_INTFLAGAHB_HPB0_Msk             (_U_(0x1) << PAC_INTFLAGAHB_HPB0_Pos)          /**< (PAC_INTFLAGAHB) HPB0 Mask */
+#define PAC_INTFLAGAHB_HPB0                 PAC_INTFLAGAHB_HPB0_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGAHB_HPB0_Msk instead */
+#define PAC_INTFLAGAHB_HPB1_Pos             2                                              /**< (PAC_INTFLAGAHB) HPB1 Position */
+#define PAC_INTFLAGAHB_HPB1_Msk             (_U_(0x1) << PAC_INTFLAGAHB_HPB1_Pos)          /**< (PAC_INTFLAGAHB) HPB1 Mask */
+#define PAC_INTFLAGAHB_HPB1                 PAC_INTFLAGAHB_HPB1_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGAHB_HPB1_Msk instead */
+#define PAC_INTFLAGAHB_HPB2_Pos             3                                              /**< (PAC_INTFLAGAHB) HPB2 Position */
+#define PAC_INTFLAGAHB_HPB2_Msk             (_U_(0x1) << PAC_INTFLAGAHB_HPB2_Pos)          /**< (PAC_INTFLAGAHB) HPB2 Mask */
+#define PAC_INTFLAGAHB_HPB2                 PAC_INTFLAGAHB_HPB2_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGAHB_HPB2_Msk instead */
+#define PAC_INTFLAGAHB_HSRAMCPU_Pos         4                                              /**< (PAC_INTFLAGAHB) HSRAMCPU Position */
+#define PAC_INTFLAGAHB_HSRAMCPU_Msk         (_U_(0x1) << PAC_INTFLAGAHB_HSRAMCPU_Pos)      /**< (PAC_INTFLAGAHB) HSRAMCPU Mask */
+#define PAC_INTFLAGAHB_HSRAMCPU             PAC_INTFLAGAHB_HSRAMCPU_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGAHB_HSRAMCPU_Msk instead */
+#define PAC_INTFLAGAHB_HSRAMDMAC_Pos        5                                              /**< (PAC_INTFLAGAHB) HSRAMDMAC Position */
+#define PAC_INTFLAGAHB_HSRAMDMAC_Msk        (_U_(0x1) << PAC_INTFLAGAHB_HSRAMDMAC_Pos)     /**< (PAC_INTFLAGAHB) HSRAMDMAC Mask */
+#define PAC_INTFLAGAHB_HSRAMDMAC            PAC_INTFLAGAHB_HSRAMDMAC_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGAHB_HSRAMDMAC_Msk instead */
+#define PAC_INTFLAGAHB_HSRAMDSU_Pos         6                                              /**< (PAC_INTFLAGAHB) HSRAMDSU Position */
+#define PAC_INTFLAGAHB_HSRAMDSU_Msk         (_U_(0x1) << PAC_INTFLAGAHB_HSRAMDSU_Pos)      /**< (PAC_INTFLAGAHB) HSRAMDSU Mask */
+#define PAC_INTFLAGAHB_HSRAMDSU             PAC_INTFLAGAHB_HSRAMDSU_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGAHB_HSRAMDSU_Msk instead */
+#define PAC_INTFLAGAHB_MASK                 _U_(0x7F)                                      /**< \deprecated (PAC_INTFLAGAHB) Register MASK  (Use PAC_INTFLAGAHB_Msk instead)  */
+#define PAC_INTFLAGAHB_Msk                  _U_(0x7F)                                      /**< (PAC_INTFLAGAHB) Register Mask  */
+
+#define PAC_INTFLAGAHB_HPB_Pos              1                                              /**< (PAC_INTFLAGAHB Position) HPBx */
+#define PAC_INTFLAGAHB_HPB_Msk              (_U_(0x7) << PAC_INTFLAGAHB_HPB_Pos)           /**< (PAC_INTFLAGAHB Mask) HPB */
+#define PAC_INTFLAGAHB_HPB(value)           (PAC_INTFLAGAHB_HPB_Msk & ((value) << PAC_INTFLAGAHB_HPB_Pos))  
+
+/* -------- PAC_INTFLAGA : (PAC Offset: 0x14) (R/W 32) Peripheral interrupt flag status - Bridge A -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint32_t PAC_:1;                    /**< bit:      0  PAC                                      */
+    __I uint32_t PM_:1;                     /**< bit:      1  PM                                       */
+    __I uint32_t MCLK_:1;                   /**< bit:      2  MCLK                                     */
+    __I uint32_t RSTC_:1;                   /**< bit:      3  RSTC                                     */
+    __I uint32_t OSCCTRL_:1;                /**< bit:      4  OSCCTRL                                  */
+    __I uint32_t OSC32KCTRL_:1;             /**< bit:      5  OSC32KCTRL                               */
+    __I uint32_t SUPC_:1;                   /**< bit:      6  SUPC                                     */
+    __I uint32_t GCLK_:1;                   /**< bit:      7  GCLK                                     */
+    __I uint32_t WDT_:1;                    /**< bit:      8  WDT                                      */
+    __I uint32_t RTC_:1;                    /**< bit:      9  RTC                                      */
+    __I uint32_t EIC_:1;                    /**< bit:     10  EIC                                      */
+    __I uint32_t FREQM_:1;                  /**< bit:     11  FREQM                                    */
+    __I uint32_t PORT_:1;                   /**< bit:     12  PORT                                     */
+    __I uint32_t AC_:1;                     /**< bit:     13  AC                                       */
+    __I uint32_t :18;                       /**< bit: 14..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PAC_INTFLAGA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_INTFLAGA_OFFSET                 (0x14)                                        /**<  (PAC_INTFLAGA) Peripheral interrupt flag status - Bridge A  Offset */
+#define PAC_INTFLAGA_RESETVALUE             _U_(0x00)                                     /**<  (PAC_INTFLAGA) Peripheral interrupt flag status - Bridge A  Reset Value */
+
+#define PAC_INTFLAGA_PAC_Pos                0                                              /**< (PAC_INTFLAGA) PAC Position */
+#define PAC_INTFLAGA_PAC_Msk                (_U_(0x1) << PAC_INTFLAGA_PAC_Pos)             /**< (PAC_INTFLAGA) PAC Mask */
+#define PAC_INTFLAGA_PAC                    PAC_INTFLAGA_PAC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGA_PAC_Msk instead */
+#define PAC_INTFLAGA_PM_Pos                 1                                              /**< (PAC_INTFLAGA) PM Position */
+#define PAC_INTFLAGA_PM_Msk                 (_U_(0x1) << PAC_INTFLAGA_PM_Pos)              /**< (PAC_INTFLAGA) PM Mask */
+#define PAC_INTFLAGA_PM                     PAC_INTFLAGA_PM_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGA_PM_Msk instead */
+#define PAC_INTFLAGA_MCLK_Pos               2                                              /**< (PAC_INTFLAGA) MCLK Position */
+#define PAC_INTFLAGA_MCLK_Msk               (_U_(0x1) << PAC_INTFLAGA_MCLK_Pos)            /**< (PAC_INTFLAGA) MCLK Mask */
+#define PAC_INTFLAGA_MCLK                   PAC_INTFLAGA_MCLK_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGA_MCLK_Msk instead */
+#define PAC_INTFLAGA_RSTC_Pos               3                                              /**< (PAC_INTFLAGA) RSTC Position */
+#define PAC_INTFLAGA_RSTC_Msk               (_U_(0x1) << PAC_INTFLAGA_RSTC_Pos)            /**< (PAC_INTFLAGA) RSTC Mask */
+#define PAC_INTFLAGA_RSTC                   PAC_INTFLAGA_RSTC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGA_RSTC_Msk instead */
+#define PAC_INTFLAGA_OSCCTRL_Pos            4                                              /**< (PAC_INTFLAGA) OSCCTRL Position */
+#define PAC_INTFLAGA_OSCCTRL_Msk            (_U_(0x1) << PAC_INTFLAGA_OSCCTRL_Pos)         /**< (PAC_INTFLAGA) OSCCTRL Mask */
+#define PAC_INTFLAGA_OSCCTRL                PAC_INTFLAGA_OSCCTRL_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGA_OSCCTRL_Msk instead */
+#define PAC_INTFLAGA_OSC32KCTRL_Pos         5                                              /**< (PAC_INTFLAGA) OSC32KCTRL Position */
+#define PAC_INTFLAGA_OSC32KCTRL_Msk         (_U_(0x1) << PAC_INTFLAGA_OSC32KCTRL_Pos)      /**< (PAC_INTFLAGA) OSC32KCTRL Mask */
+#define PAC_INTFLAGA_OSC32KCTRL             PAC_INTFLAGA_OSC32KCTRL_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGA_OSC32KCTRL_Msk instead */
+#define PAC_INTFLAGA_SUPC_Pos               6                                              /**< (PAC_INTFLAGA) SUPC Position */
+#define PAC_INTFLAGA_SUPC_Msk               (_U_(0x1) << PAC_INTFLAGA_SUPC_Pos)            /**< (PAC_INTFLAGA) SUPC Mask */
+#define PAC_INTFLAGA_SUPC                   PAC_INTFLAGA_SUPC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGA_SUPC_Msk instead */
+#define PAC_INTFLAGA_GCLK_Pos               7                                              /**< (PAC_INTFLAGA) GCLK Position */
+#define PAC_INTFLAGA_GCLK_Msk               (_U_(0x1) << PAC_INTFLAGA_GCLK_Pos)            /**< (PAC_INTFLAGA) GCLK Mask */
+#define PAC_INTFLAGA_GCLK                   PAC_INTFLAGA_GCLK_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGA_GCLK_Msk instead */
+#define PAC_INTFLAGA_WDT_Pos                8                                              /**< (PAC_INTFLAGA) WDT Position */
+#define PAC_INTFLAGA_WDT_Msk                (_U_(0x1) << PAC_INTFLAGA_WDT_Pos)             /**< (PAC_INTFLAGA) WDT Mask */
+#define PAC_INTFLAGA_WDT                    PAC_INTFLAGA_WDT_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGA_WDT_Msk instead */
+#define PAC_INTFLAGA_RTC_Pos                9                                              /**< (PAC_INTFLAGA) RTC Position */
+#define PAC_INTFLAGA_RTC_Msk                (_U_(0x1) << PAC_INTFLAGA_RTC_Pos)             /**< (PAC_INTFLAGA) RTC Mask */
+#define PAC_INTFLAGA_RTC                    PAC_INTFLAGA_RTC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGA_RTC_Msk instead */
+#define PAC_INTFLAGA_EIC_Pos                10                                             /**< (PAC_INTFLAGA) EIC Position */
+#define PAC_INTFLAGA_EIC_Msk                (_U_(0x1) << PAC_INTFLAGA_EIC_Pos)             /**< (PAC_INTFLAGA) EIC Mask */
+#define PAC_INTFLAGA_EIC                    PAC_INTFLAGA_EIC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGA_EIC_Msk instead */
+#define PAC_INTFLAGA_FREQM_Pos              11                                             /**< (PAC_INTFLAGA) FREQM Position */
+#define PAC_INTFLAGA_FREQM_Msk              (_U_(0x1) << PAC_INTFLAGA_FREQM_Pos)           /**< (PAC_INTFLAGA) FREQM Mask */
+#define PAC_INTFLAGA_FREQM                  PAC_INTFLAGA_FREQM_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGA_FREQM_Msk instead */
+#define PAC_INTFLAGA_PORT_Pos               12                                             /**< (PAC_INTFLAGA) PORT Position */
+#define PAC_INTFLAGA_PORT_Msk               (_U_(0x1) << PAC_INTFLAGA_PORT_Pos)            /**< (PAC_INTFLAGA) PORT Mask */
+#define PAC_INTFLAGA_PORT                   PAC_INTFLAGA_PORT_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGA_PORT_Msk instead */
+#define PAC_INTFLAGA_AC_Pos                 13                                             /**< (PAC_INTFLAGA) AC Position */
+#define PAC_INTFLAGA_AC_Msk                 (_U_(0x1) << PAC_INTFLAGA_AC_Pos)              /**< (PAC_INTFLAGA) AC Mask */
+#define PAC_INTFLAGA_AC                     PAC_INTFLAGA_AC_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGA_AC_Msk instead */
+#define PAC_INTFLAGA_MASK                   _U_(0x3FFF)                                    /**< \deprecated (PAC_INTFLAGA) Register MASK  (Use PAC_INTFLAGA_Msk instead)  */
+#define PAC_INTFLAGA_Msk                    _U_(0x3FFF)                                    /**< (PAC_INTFLAGA) Register Mask  */
+
+
+/* -------- PAC_INTFLAGB : (PAC Offset: 0x18) (R/W 32) Peripheral interrupt flag status - Bridge B -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint32_t IDAU_:1;                   /**< bit:      0  IDAU                                     */
+    __I uint32_t DSU_:1;                    /**< bit:      1  DSU                                      */
+    __I uint32_t NVMCTRL_:1;                /**< bit:      2  NVMCTRL                                  */
+    __I uint32_t DMAC_:1;                   /**< bit:      3  DMAC                                     */
+    __I uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PAC_INTFLAGB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_INTFLAGB_OFFSET                 (0x18)                                        /**<  (PAC_INTFLAGB) Peripheral interrupt flag status - Bridge B  Offset */
+#define PAC_INTFLAGB_RESETVALUE             _U_(0x00)                                     /**<  (PAC_INTFLAGB) Peripheral interrupt flag status - Bridge B  Reset Value */
+
+#define PAC_INTFLAGB_IDAU_Pos               0                                              /**< (PAC_INTFLAGB) IDAU Position */
+#define PAC_INTFLAGB_IDAU_Msk               (_U_(0x1) << PAC_INTFLAGB_IDAU_Pos)            /**< (PAC_INTFLAGB) IDAU Mask */
+#define PAC_INTFLAGB_IDAU                   PAC_INTFLAGB_IDAU_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGB_IDAU_Msk instead */
+#define PAC_INTFLAGB_DSU_Pos                1                                              /**< (PAC_INTFLAGB) DSU Position */
+#define PAC_INTFLAGB_DSU_Msk                (_U_(0x1) << PAC_INTFLAGB_DSU_Pos)             /**< (PAC_INTFLAGB) DSU Mask */
+#define PAC_INTFLAGB_DSU                    PAC_INTFLAGB_DSU_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGB_DSU_Msk instead */
+#define PAC_INTFLAGB_NVMCTRL_Pos            2                                              /**< (PAC_INTFLAGB) NVMCTRL Position */
+#define PAC_INTFLAGB_NVMCTRL_Msk            (_U_(0x1) << PAC_INTFLAGB_NVMCTRL_Pos)         /**< (PAC_INTFLAGB) NVMCTRL Mask */
+#define PAC_INTFLAGB_NVMCTRL                PAC_INTFLAGB_NVMCTRL_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGB_NVMCTRL_Msk instead */
+#define PAC_INTFLAGB_DMAC_Pos               3                                              /**< (PAC_INTFLAGB) DMAC Position */
+#define PAC_INTFLAGB_DMAC_Msk               (_U_(0x1) << PAC_INTFLAGB_DMAC_Pos)            /**< (PAC_INTFLAGB) DMAC Mask */
+#define PAC_INTFLAGB_DMAC                   PAC_INTFLAGB_DMAC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGB_DMAC_Msk instead */
+#define PAC_INTFLAGB_MASK                   _U_(0x0F)                                      /**< \deprecated (PAC_INTFLAGB) Register MASK  (Use PAC_INTFLAGB_Msk instead)  */
+#define PAC_INTFLAGB_Msk                    _U_(0x0F)                                      /**< (PAC_INTFLAGB) Register Mask  */
+
+
+/* -------- PAC_INTFLAGC : (PAC Offset: 0x1c) (R/W 32) Peripheral interrupt flag status - Bridge C -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint32_t EVSYS_:1;                  /**< bit:      0  EVSYS                                    */
+    __I uint32_t SERCOM0_:1;                /**< bit:      1  SERCOM0                                  */
+    __I uint32_t SERCOM1_:1;                /**< bit:      2  SERCOM1                                  */
+    __I uint32_t SERCOM2_:1;                /**< bit:      3  SERCOM2                                  */
+    __I uint32_t TC0_:1;                    /**< bit:      4  TC0                                      */
+    __I uint32_t TC1_:1;                    /**< bit:      5  TC1                                      */
+    __I uint32_t TC2_:1;                    /**< bit:      6  TC2                                      */
+    __I uint32_t ADC_:1;                    /**< bit:      7  ADC                                      */
+    __I uint32_t DAC_:1;                    /**< bit:      8  DAC                                      */
+    __I uint32_t PTC_:1;                    /**< bit:      9  PTC                                      */
+    __I uint32_t TRNG_:1;                   /**< bit:     10  TRNG                                     */
+    __I uint32_t CCL_:1;                    /**< bit:     11  CCL                                      */
+    __I uint32_t OPAMP_:1;                  /**< bit:     12  OPAMP                                    */
+    __I uint32_t TRAM_:1;                   /**< bit:     13  TRAM                                     */
+    __I uint32_t :18;                       /**< bit: 14..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PAC_INTFLAGC_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_INTFLAGC_OFFSET                 (0x1C)                                        /**<  (PAC_INTFLAGC) Peripheral interrupt flag status - Bridge C  Offset */
+#define PAC_INTFLAGC_RESETVALUE             _U_(0x00)                                     /**<  (PAC_INTFLAGC) Peripheral interrupt flag status - Bridge C  Reset Value */
+
+#define PAC_INTFLAGC_EVSYS_Pos              0                                              /**< (PAC_INTFLAGC) EVSYS Position */
+#define PAC_INTFLAGC_EVSYS_Msk              (_U_(0x1) << PAC_INTFLAGC_EVSYS_Pos)           /**< (PAC_INTFLAGC) EVSYS Mask */
+#define PAC_INTFLAGC_EVSYS                  PAC_INTFLAGC_EVSYS_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGC_EVSYS_Msk instead */
+#define PAC_INTFLAGC_SERCOM0_Pos            1                                              /**< (PAC_INTFLAGC) SERCOM0 Position */
+#define PAC_INTFLAGC_SERCOM0_Msk            (_U_(0x1) << PAC_INTFLAGC_SERCOM0_Pos)         /**< (PAC_INTFLAGC) SERCOM0 Mask */
+#define PAC_INTFLAGC_SERCOM0                PAC_INTFLAGC_SERCOM0_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGC_SERCOM0_Msk instead */
+#define PAC_INTFLAGC_SERCOM1_Pos            2                                              /**< (PAC_INTFLAGC) SERCOM1 Position */
+#define PAC_INTFLAGC_SERCOM1_Msk            (_U_(0x1) << PAC_INTFLAGC_SERCOM1_Pos)         /**< (PAC_INTFLAGC) SERCOM1 Mask */
+#define PAC_INTFLAGC_SERCOM1                PAC_INTFLAGC_SERCOM1_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGC_SERCOM1_Msk instead */
+#define PAC_INTFLAGC_SERCOM2_Pos            3                                              /**< (PAC_INTFLAGC) SERCOM2 Position */
+#define PAC_INTFLAGC_SERCOM2_Msk            (_U_(0x1) << PAC_INTFLAGC_SERCOM2_Pos)         /**< (PAC_INTFLAGC) SERCOM2 Mask */
+#define PAC_INTFLAGC_SERCOM2                PAC_INTFLAGC_SERCOM2_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGC_SERCOM2_Msk instead */
+#define PAC_INTFLAGC_TC0_Pos                4                                              /**< (PAC_INTFLAGC) TC0 Position */
+#define PAC_INTFLAGC_TC0_Msk                (_U_(0x1) << PAC_INTFLAGC_TC0_Pos)             /**< (PAC_INTFLAGC) TC0 Mask */
+#define PAC_INTFLAGC_TC0                    PAC_INTFLAGC_TC0_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGC_TC0_Msk instead */
+#define PAC_INTFLAGC_TC1_Pos                5                                              /**< (PAC_INTFLAGC) TC1 Position */
+#define PAC_INTFLAGC_TC1_Msk                (_U_(0x1) << PAC_INTFLAGC_TC1_Pos)             /**< (PAC_INTFLAGC) TC1 Mask */
+#define PAC_INTFLAGC_TC1                    PAC_INTFLAGC_TC1_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGC_TC1_Msk instead */
+#define PAC_INTFLAGC_TC2_Pos                6                                              /**< (PAC_INTFLAGC) TC2 Position */
+#define PAC_INTFLAGC_TC2_Msk                (_U_(0x1) << PAC_INTFLAGC_TC2_Pos)             /**< (PAC_INTFLAGC) TC2 Mask */
+#define PAC_INTFLAGC_TC2                    PAC_INTFLAGC_TC2_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGC_TC2_Msk instead */
+#define PAC_INTFLAGC_ADC_Pos                7                                              /**< (PAC_INTFLAGC) ADC Position */
+#define PAC_INTFLAGC_ADC_Msk                (_U_(0x1) << PAC_INTFLAGC_ADC_Pos)             /**< (PAC_INTFLAGC) ADC Mask */
+#define PAC_INTFLAGC_ADC                    PAC_INTFLAGC_ADC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGC_ADC_Msk instead */
+#define PAC_INTFLAGC_DAC_Pos                8                                              /**< (PAC_INTFLAGC) DAC Position */
+#define PAC_INTFLAGC_DAC_Msk                (_U_(0x1) << PAC_INTFLAGC_DAC_Pos)             /**< (PAC_INTFLAGC) DAC Mask */
+#define PAC_INTFLAGC_DAC                    PAC_INTFLAGC_DAC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGC_DAC_Msk instead */
+#define PAC_INTFLAGC_PTC_Pos                9                                              /**< (PAC_INTFLAGC) PTC Position */
+#define PAC_INTFLAGC_PTC_Msk                (_U_(0x1) << PAC_INTFLAGC_PTC_Pos)             /**< (PAC_INTFLAGC) PTC Mask */
+#define PAC_INTFLAGC_PTC                    PAC_INTFLAGC_PTC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGC_PTC_Msk instead */
+#define PAC_INTFLAGC_TRNG_Pos               10                                             /**< (PAC_INTFLAGC) TRNG Position */
+#define PAC_INTFLAGC_TRNG_Msk               (_U_(0x1) << PAC_INTFLAGC_TRNG_Pos)            /**< (PAC_INTFLAGC) TRNG Mask */
+#define PAC_INTFLAGC_TRNG                   PAC_INTFLAGC_TRNG_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGC_TRNG_Msk instead */
+#define PAC_INTFLAGC_CCL_Pos                11                                             /**< (PAC_INTFLAGC) CCL Position */
+#define PAC_INTFLAGC_CCL_Msk                (_U_(0x1) << PAC_INTFLAGC_CCL_Pos)             /**< (PAC_INTFLAGC) CCL Mask */
+#define PAC_INTFLAGC_CCL                    PAC_INTFLAGC_CCL_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGC_CCL_Msk instead */
+#define PAC_INTFLAGC_OPAMP_Pos              12                                             /**< (PAC_INTFLAGC) OPAMP Position */
+#define PAC_INTFLAGC_OPAMP_Msk              (_U_(0x1) << PAC_INTFLAGC_OPAMP_Pos)           /**< (PAC_INTFLAGC) OPAMP Mask */
+#define PAC_INTFLAGC_OPAMP                  PAC_INTFLAGC_OPAMP_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGC_OPAMP_Msk instead */
+#define PAC_INTFLAGC_TRAM_Pos               13                                             /**< (PAC_INTFLAGC) TRAM Position */
+#define PAC_INTFLAGC_TRAM_Msk               (_U_(0x1) << PAC_INTFLAGC_TRAM_Pos)            /**< (PAC_INTFLAGC) TRAM Mask */
+#define PAC_INTFLAGC_TRAM                   PAC_INTFLAGC_TRAM_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGC_TRAM_Msk instead */
+#define PAC_INTFLAGC_MASK                   _U_(0x3FFF)                                    /**< \deprecated (PAC_INTFLAGC) Register MASK  (Use PAC_INTFLAGC_Msk instead)  */
+#define PAC_INTFLAGC_Msk                    _U_(0x3FFF)                                    /**< (PAC_INTFLAGC) Register Mask  */
+
+#define PAC_INTFLAGC_SERCOM_Pos             1                                              /**< (PAC_INTFLAGC Position) SERCOMx */
+#define PAC_INTFLAGC_SERCOM_Msk             (_U_(0x7) << PAC_INTFLAGC_SERCOM_Pos)          /**< (PAC_INTFLAGC Mask) SERCOM */
+#define PAC_INTFLAGC_SERCOM(value)          (PAC_INTFLAGC_SERCOM_Msk & ((value) << PAC_INTFLAGC_SERCOM_Pos))  
+#define PAC_INTFLAGC_TC_Pos                 4                                              /**< (PAC_INTFLAGC Position) TCx */
+#define PAC_INTFLAGC_TC_Msk                 (_U_(0x7) << PAC_INTFLAGC_TC_Pos)              /**< (PAC_INTFLAGC Mask) TC */
+#define PAC_INTFLAGC_TC(value)              (PAC_INTFLAGC_TC_Msk & ((value) << PAC_INTFLAGC_TC_Pos))  
+
+/* -------- PAC_STATUSA : (PAC Offset: 0x34) (R/ 32) Peripheral write protection status - Bridge A -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t PAC_:1;                    /**< bit:      0  PAC APB Protect Enable                   */
+    uint32_t PM_:1;                     /**< bit:      1  PM APB Protect Enable                    */
+    uint32_t MCLK_:1;                   /**< bit:      2  MCLK APB Protect Enable                  */
+    uint32_t RSTC_:1;                   /**< bit:      3  RSTC APB Protect Enable                  */
+    uint32_t OSCCTRL_:1;                /**< bit:      4  OSCCTRL APB Protect Enable               */
+    uint32_t OSC32KCTRL_:1;             /**< bit:      5  OSC32KCTRL APB Protect Enable            */
+    uint32_t SUPC_:1;                   /**< bit:      6  SUPC APB Protect Enable                  */
+    uint32_t GCLK_:1;                   /**< bit:      7  GCLK APB Protect Enable                  */
+    uint32_t WDT_:1;                    /**< bit:      8  WDT APB Protect Enable                   */
+    uint32_t RTC_:1;                    /**< bit:      9  RTC APB Protect Enable                   */
+    uint32_t EIC_:1;                    /**< bit:     10  EIC APB Protect Enable                   */
+    uint32_t FREQM_:1;                  /**< bit:     11  FREQM APB Protect Enable                 */
+    uint32_t PORT_:1;                   /**< bit:     12  PORT APB Protect Enable                  */
+    uint32_t AC_:1;                     /**< bit:     13  AC APB Protect Enable                    */
+    uint32_t :18;                       /**< bit: 14..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PAC_STATUSA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_STATUSA_OFFSET                  (0x34)                                        /**<  (PAC_STATUSA) Peripheral write protection status - Bridge A  Offset */
+#define PAC_STATUSA_RESETVALUE              _U_(0xC000)                                   /**<  (PAC_STATUSA) Peripheral write protection status - Bridge A  Reset Value */
+
+#define PAC_STATUSA_PAC_Pos                 0                                              /**< (PAC_STATUSA) PAC APB Protect Enable Position */
+#define PAC_STATUSA_PAC_Msk                 (_U_(0x1) << PAC_STATUSA_PAC_Pos)              /**< (PAC_STATUSA) PAC APB Protect Enable Mask */
+#define PAC_STATUSA_PAC                     PAC_STATUSA_PAC_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSA_PAC_Msk instead */
+#define PAC_STATUSA_PM_Pos                  1                                              /**< (PAC_STATUSA) PM APB Protect Enable Position */
+#define PAC_STATUSA_PM_Msk                  (_U_(0x1) << PAC_STATUSA_PM_Pos)               /**< (PAC_STATUSA) PM APB Protect Enable Mask */
+#define PAC_STATUSA_PM                      PAC_STATUSA_PM_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSA_PM_Msk instead */
+#define PAC_STATUSA_MCLK_Pos                2                                              /**< (PAC_STATUSA) MCLK APB Protect Enable Position */
+#define PAC_STATUSA_MCLK_Msk                (_U_(0x1) << PAC_STATUSA_MCLK_Pos)             /**< (PAC_STATUSA) MCLK APB Protect Enable Mask */
+#define PAC_STATUSA_MCLK                    PAC_STATUSA_MCLK_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSA_MCLK_Msk instead */
+#define PAC_STATUSA_RSTC_Pos                3                                              /**< (PAC_STATUSA) RSTC APB Protect Enable Position */
+#define PAC_STATUSA_RSTC_Msk                (_U_(0x1) << PAC_STATUSA_RSTC_Pos)             /**< (PAC_STATUSA) RSTC APB Protect Enable Mask */
+#define PAC_STATUSA_RSTC                    PAC_STATUSA_RSTC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSA_RSTC_Msk instead */
+#define PAC_STATUSA_OSCCTRL_Pos             4                                              /**< (PAC_STATUSA) OSCCTRL APB Protect Enable Position */
+#define PAC_STATUSA_OSCCTRL_Msk             (_U_(0x1) << PAC_STATUSA_OSCCTRL_Pos)          /**< (PAC_STATUSA) OSCCTRL APB Protect Enable Mask */
+#define PAC_STATUSA_OSCCTRL                 PAC_STATUSA_OSCCTRL_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSA_OSCCTRL_Msk instead */
+#define PAC_STATUSA_OSC32KCTRL_Pos          5                                              /**< (PAC_STATUSA) OSC32KCTRL APB Protect Enable Position */
+#define PAC_STATUSA_OSC32KCTRL_Msk          (_U_(0x1) << PAC_STATUSA_OSC32KCTRL_Pos)       /**< (PAC_STATUSA) OSC32KCTRL APB Protect Enable Mask */
+#define PAC_STATUSA_OSC32KCTRL              PAC_STATUSA_OSC32KCTRL_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSA_OSC32KCTRL_Msk instead */
+#define PAC_STATUSA_SUPC_Pos                6                                              /**< (PAC_STATUSA) SUPC APB Protect Enable Position */
+#define PAC_STATUSA_SUPC_Msk                (_U_(0x1) << PAC_STATUSA_SUPC_Pos)             /**< (PAC_STATUSA) SUPC APB Protect Enable Mask */
+#define PAC_STATUSA_SUPC                    PAC_STATUSA_SUPC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSA_SUPC_Msk instead */
+#define PAC_STATUSA_GCLK_Pos                7                                              /**< (PAC_STATUSA) GCLK APB Protect Enable Position */
+#define PAC_STATUSA_GCLK_Msk                (_U_(0x1) << PAC_STATUSA_GCLK_Pos)             /**< (PAC_STATUSA) GCLK APB Protect Enable Mask */
+#define PAC_STATUSA_GCLK                    PAC_STATUSA_GCLK_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSA_GCLK_Msk instead */
+#define PAC_STATUSA_WDT_Pos                 8                                              /**< (PAC_STATUSA) WDT APB Protect Enable Position */
+#define PAC_STATUSA_WDT_Msk                 (_U_(0x1) << PAC_STATUSA_WDT_Pos)              /**< (PAC_STATUSA) WDT APB Protect Enable Mask */
+#define PAC_STATUSA_WDT                     PAC_STATUSA_WDT_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSA_WDT_Msk instead */
+#define PAC_STATUSA_RTC_Pos                 9                                              /**< (PAC_STATUSA) RTC APB Protect Enable Position */
+#define PAC_STATUSA_RTC_Msk                 (_U_(0x1) << PAC_STATUSA_RTC_Pos)              /**< (PAC_STATUSA) RTC APB Protect Enable Mask */
+#define PAC_STATUSA_RTC                     PAC_STATUSA_RTC_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSA_RTC_Msk instead */
+#define PAC_STATUSA_EIC_Pos                 10                                             /**< (PAC_STATUSA) EIC APB Protect Enable Position */
+#define PAC_STATUSA_EIC_Msk                 (_U_(0x1) << PAC_STATUSA_EIC_Pos)              /**< (PAC_STATUSA) EIC APB Protect Enable Mask */
+#define PAC_STATUSA_EIC                     PAC_STATUSA_EIC_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSA_EIC_Msk instead */
+#define PAC_STATUSA_FREQM_Pos               11                                             /**< (PAC_STATUSA) FREQM APB Protect Enable Position */
+#define PAC_STATUSA_FREQM_Msk               (_U_(0x1) << PAC_STATUSA_FREQM_Pos)            /**< (PAC_STATUSA) FREQM APB Protect Enable Mask */
+#define PAC_STATUSA_FREQM                   PAC_STATUSA_FREQM_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSA_FREQM_Msk instead */
+#define PAC_STATUSA_PORT_Pos                12                                             /**< (PAC_STATUSA) PORT APB Protect Enable Position */
+#define PAC_STATUSA_PORT_Msk                (_U_(0x1) << PAC_STATUSA_PORT_Pos)             /**< (PAC_STATUSA) PORT APB Protect Enable Mask */
+#define PAC_STATUSA_PORT                    PAC_STATUSA_PORT_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSA_PORT_Msk instead */
+#define PAC_STATUSA_AC_Pos                  13                                             /**< (PAC_STATUSA) AC APB Protect Enable Position */
+#define PAC_STATUSA_AC_Msk                  (_U_(0x1) << PAC_STATUSA_AC_Pos)               /**< (PAC_STATUSA) AC APB Protect Enable Mask */
+#define PAC_STATUSA_AC                      PAC_STATUSA_AC_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSA_AC_Msk instead */
+#define PAC_STATUSA_MASK                    _U_(0x3FFF)                                    /**< \deprecated (PAC_STATUSA) Register MASK  (Use PAC_STATUSA_Msk instead)  */
+#define PAC_STATUSA_Msk                     _U_(0x3FFF)                                    /**< (PAC_STATUSA) Register Mask  */
+
+
+/* -------- PAC_STATUSB : (PAC Offset: 0x38) (R/ 32) Peripheral write protection status - Bridge B -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t IDAU_:1;                   /**< bit:      0  IDAU APB Protect Enable                  */
+    uint32_t DSU_:1;                    /**< bit:      1  DSU APB Protect Enable                   */
+    uint32_t NVMCTRL_:1;                /**< bit:      2  NVMCTRL APB Protect Enable               */
+    uint32_t DMAC_:1;                   /**< bit:      3  DMAC APB Protect Enable                  */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PAC_STATUSB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_STATUSB_OFFSET                  (0x38)                                        /**<  (PAC_STATUSB) Peripheral write protection status - Bridge B  Offset */
+#define PAC_STATUSB_RESETVALUE              _U_(0x02)                                     /**<  (PAC_STATUSB) Peripheral write protection status - Bridge B  Reset Value */
+
+#define PAC_STATUSB_IDAU_Pos                0                                              /**< (PAC_STATUSB) IDAU APB Protect Enable Position */
+#define PAC_STATUSB_IDAU_Msk                (_U_(0x1) << PAC_STATUSB_IDAU_Pos)             /**< (PAC_STATUSB) IDAU APB Protect Enable Mask */
+#define PAC_STATUSB_IDAU                    PAC_STATUSB_IDAU_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSB_IDAU_Msk instead */
+#define PAC_STATUSB_DSU_Pos                 1                                              /**< (PAC_STATUSB) DSU APB Protect Enable Position */
+#define PAC_STATUSB_DSU_Msk                 (_U_(0x1) << PAC_STATUSB_DSU_Pos)              /**< (PAC_STATUSB) DSU APB Protect Enable Mask */
+#define PAC_STATUSB_DSU                     PAC_STATUSB_DSU_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSB_DSU_Msk instead */
+#define PAC_STATUSB_NVMCTRL_Pos             2                                              /**< (PAC_STATUSB) NVMCTRL APB Protect Enable Position */
+#define PAC_STATUSB_NVMCTRL_Msk             (_U_(0x1) << PAC_STATUSB_NVMCTRL_Pos)          /**< (PAC_STATUSB) NVMCTRL APB Protect Enable Mask */
+#define PAC_STATUSB_NVMCTRL                 PAC_STATUSB_NVMCTRL_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSB_NVMCTRL_Msk instead */
+#define PAC_STATUSB_DMAC_Pos                3                                              /**< (PAC_STATUSB) DMAC APB Protect Enable Position */
+#define PAC_STATUSB_DMAC_Msk                (_U_(0x1) << PAC_STATUSB_DMAC_Pos)             /**< (PAC_STATUSB) DMAC APB Protect Enable Mask */
+#define PAC_STATUSB_DMAC                    PAC_STATUSB_DMAC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSB_DMAC_Msk instead */
+#define PAC_STATUSB_MASK                    _U_(0x0F)                                      /**< \deprecated (PAC_STATUSB) Register MASK  (Use PAC_STATUSB_Msk instead)  */
+#define PAC_STATUSB_Msk                     _U_(0x0F)                                      /**< (PAC_STATUSB) Register Mask  */
+
+
+/* -------- PAC_STATUSC : (PAC Offset: 0x3c) (R/ 32) Peripheral write protection status - Bridge C -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t EVSYS_:1;                  /**< bit:      0  EVSYS APB Protect Enable                 */
+    uint32_t SERCOM0_:1;                /**< bit:      1  SERCOM0 APB Protect Enable               */
+    uint32_t SERCOM1_:1;                /**< bit:      2  SERCOM1 APB Protect Enable               */
+    uint32_t SERCOM2_:1;                /**< bit:      3  SERCOM2 APB Protect Enable               */
+    uint32_t TC0_:1;                    /**< bit:      4  TC0 APB Protect Enable                   */
+    uint32_t TC1_:1;                    /**< bit:      5  TC1 APB Protect Enable                   */
+    uint32_t TC2_:1;                    /**< bit:      6  TC2 APB Protect Enable                   */
+    uint32_t ADC_:1;                    /**< bit:      7  ADC APB Protect Enable                   */
+    uint32_t DAC_:1;                    /**< bit:      8  DAC APB Protect Enable                   */
+    uint32_t PTC_:1;                    /**< bit:      9  PTC APB Protect Enable                   */
+    uint32_t TRNG_:1;                   /**< bit:     10  TRNG APB Protect Enable                  */
+    uint32_t CCL_:1;                    /**< bit:     11  CCL APB Protect Enable                   */
+    uint32_t OPAMP_:1;                  /**< bit:     12  OPAMP APB Protect Enable                 */
+    uint32_t TRAM_:1;                   /**< bit:     13  TRAM APB Protect Enable                  */
+    uint32_t :18;                       /**< bit: 14..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PAC_STATUSC_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_STATUSC_OFFSET                  (0x3C)                                        /**<  (PAC_STATUSC) Peripheral write protection status - Bridge C  Offset */
+#define PAC_STATUSC_RESETVALUE              _U_(0x00)                                     /**<  (PAC_STATUSC) Peripheral write protection status - Bridge C  Reset Value */
+
+#define PAC_STATUSC_EVSYS_Pos               0                                              /**< (PAC_STATUSC) EVSYS APB Protect Enable Position */
+#define PAC_STATUSC_EVSYS_Msk               (_U_(0x1) << PAC_STATUSC_EVSYS_Pos)            /**< (PAC_STATUSC) EVSYS APB Protect Enable Mask */
+#define PAC_STATUSC_EVSYS                   PAC_STATUSC_EVSYS_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSC_EVSYS_Msk instead */
+#define PAC_STATUSC_SERCOM0_Pos             1                                              /**< (PAC_STATUSC) SERCOM0 APB Protect Enable Position */
+#define PAC_STATUSC_SERCOM0_Msk             (_U_(0x1) << PAC_STATUSC_SERCOM0_Pos)          /**< (PAC_STATUSC) SERCOM0 APB Protect Enable Mask */
+#define PAC_STATUSC_SERCOM0                 PAC_STATUSC_SERCOM0_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSC_SERCOM0_Msk instead */
+#define PAC_STATUSC_SERCOM1_Pos             2                                              /**< (PAC_STATUSC) SERCOM1 APB Protect Enable Position */
+#define PAC_STATUSC_SERCOM1_Msk             (_U_(0x1) << PAC_STATUSC_SERCOM1_Pos)          /**< (PAC_STATUSC) SERCOM1 APB Protect Enable Mask */
+#define PAC_STATUSC_SERCOM1                 PAC_STATUSC_SERCOM1_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSC_SERCOM1_Msk instead */
+#define PAC_STATUSC_SERCOM2_Pos             3                                              /**< (PAC_STATUSC) SERCOM2 APB Protect Enable Position */
+#define PAC_STATUSC_SERCOM2_Msk             (_U_(0x1) << PAC_STATUSC_SERCOM2_Pos)          /**< (PAC_STATUSC) SERCOM2 APB Protect Enable Mask */
+#define PAC_STATUSC_SERCOM2                 PAC_STATUSC_SERCOM2_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSC_SERCOM2_Msk instead */
+#define PAC_STATUSC_TC0_Pos                 4                                              /**< (PAC_STATUSC) TC0 APB Protect Enable Position */
+#define PAC_STATUSC_TC0_Msk                 (_U_(0x1) << PAC_STATUSC_TC0_Pos)              /**< (PAC_STATUSC) TC0 APB Protect Enable Mask */
+#define PAC_STATUSC_TC0                     PAC_STATUSC_TC0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSC_TC0_Msk instead */
+#define PAC_STATUSC_TC1_Pos                 5                                              /**< (PAC_STATUSC) TC1 APB Protect Enable Position */
+#define PAC_STATUSC_TC1_Msk                 (_U_(0x1) << PAC_STATUSC_TC1_Pos)              /**< (PAC_STATUSC) TC1 APB Protect Enable Mask */
+#define PAC_STATUSC_TC1                     PAC_STATUSC_TC1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSC_TC1_Msk instead */
+#define PAC_STATUSC_TC2_Pos                 6                                              /**< (PAC_STATUSC) TC2 APB Protect Enable Position */
+#define PAC_STATUSC_TC2_Msk                 (_U_(0x1) << PAC_STATUSC_TC2_Pos)              /**< (PAC_STATUSC) TC2 APB Protect Enable Mask */
+#define PAC_STATUSC_TC2                     PAC_STATUSC_TC2_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSC_TC2_Msk instead */
+#define PAC_STATUSC_ADC_Pos                 7                                              /**< (PAC_STATUSC) ADC APB Protect Enable Position */
+#define PAC_STATUSC_ADC_Msk                 (_U_(0x1) << PAC_STATUSC_ADC_Pos)              /**< (PAC_STATUSC) ADC APB Protect Enable Mask */
+#define PAC_STATUSC_ADC                     PAC_STATUSC_ADC_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSC_ADC_Msk instead */
+#define PAC_STATUSC_DAC_Pos                 8                                              /**< (PAC_STATUSC) DAC APB Protect Enable Position */
+#define PAC_STATUSC_DAC_Msk                 (_U_(0x1) << PAC_STATUSC_DAC_Pos)              /**< (PAC_STATUSC) DAC APB Protect Enable Mask */
+#define PAC_STATUSC_DAC                     PAC_STATUSC_DAC_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSC_DAC_Msk instead */
+#define PAC_STATUSC_PTC_Pos                 9                                              /**< (PAC_STATUSC) PTC APB Protect Enable Position */
+#define PAC_STATUSC_PTC_Msk                 (_U_(0x1) << PAC_STATUSC_PTC_Pos)              /**< (PAC_STATUSC) PTC APB Protect Enable Mask */
+#define PAC_STATUSC_PTC                     PAC_STATUSC_PTC_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSC_PTC_Msk instead */
+#define PAC_STATUSC_TRNG_Pos                10                                             /**< (PAC_STATUSC) TRNG APB Protect Enable Position */
+#define PAC_STATUSC_TRNG_Msk                (_U_(0x1) << PAC_STATUSC_TRNG_Pos)             /**< (PAC_STATUSC) TRNG APB Protect Enable Mask */
+#define PAC_STATUSC_TRNG                    PAC_STATUSC_TRNG_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSC_TRNG_Msk instead */
+#define PAC_STATUSC_CCL_Pos                 11                                             /**< (PAC_STATUSC) CCL APB Protect Enable Position */
+#define PAC_STATUSC_CCL_Msk                 (_U_(0x1) << PAC_STATUSC_CCL_Pos)              /**< (PAC_STATUSC) CCL APB Protect Enable Mask */
+#define PAC_STATUSC_CCL                     PAC_STATUSC_CCL_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSC_CCL_Msk instead */
+#define PAC_STATUSC_OPAMP_Pos               12                                             /**< (PAC_STATUSC) OPAMP APB Protect Enable Position */
+#define PAC_STATUSC_OPAMP_Msk               (_U_(0x1) << PAC_STATUSC_OPAMP_Pos)            /**< (PAC_STATUSC) OPAMP APB Protect Enable Mask */
+#define PAC_STATUSC_OPAMP                   PAC_STATUSC_OPAMP_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSC_OPAMP_Msk instead */
+#define PAC_STATUSC_TRAM_Pos                13                                             /**< (PAC_STATUSC) TRAM APB Protect Enable Position */
+#define PAC_STATUSC_TRAM_Msk                (_U_(0x1) << PAC_STATUSC_TRAM_Pos)             /**< (PAC_STATUSC) TRAM APB Protect Enable Mask */
+#define PAC_STATUSC_TRAM                    PAC_STATUSC_TRAM_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSC_TRAM_Msk instead */
+#define PAC_STATUSC_MASK                    _U_(0x3FFF)                                    /**< \deprecated (PAC_STATUSC) Register MASK  (Use PAC_STATUSC_Msk instead)  */
+#define PAC_STATUSC_Msk                     _U_(0x3FFF)                                    /**< (PAC_STATUSC) Register Mask  */
+
+#define PAC_STATUSC_SERCOM_Pos              1                                              /**< (PAC_STATUSC Position) SERCOMx APB Protect Enable */
+#define PAC_STATUSC_SERCOM_Msk              (_U_(0x7) << PAC_STATUSC_SERCOM_Pos)           /**< (PAC_STATUSC Mask) SERCOM */
+#define PAC_STATUSC_SERCOM(value)           (PAC_STATUSC_SERCOM_Msk & ((value) << PAC_STATUSC_SERCOM_Pos))  
+#define PAC_STATUSC_TC_Pos                  4                                              /**< (PAC_STATUSC Position) TCx APB Protect Enable */
+#define PAC_STATUSC_TC_Msk                  (_U_(0x7) << PAC_STATUSC_TC_Pos)               /**< (PAC_STATUSC Mask) TC */
+#define PAC_STATUSC_TC(value)               (PAC_STATUSC_TC_Msk & ((value) << PAC_STATUSC_TC_Pos))  
+
+/* -------- PAC_NONSECA : (PAC Offset: 0x54) (R/ 32) Peripheral non-secure status - Bridge A -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t PAC_:1;                    /**< bit:      0  PAC Non-Secure                           */
+    uint32_t PM_:1;                     /**< bit:      1  PM Non-Secure                            */
+    uint32_t MCLK_:1;                   /**< bit:      2  MCLK Non-Secure                          */
+    uint32_t RSTC_:1;                   /**< bit:      3  RSTC Non-Secure                          */
+    uint32_t OSCCTRL_:1;                /**< bit:      4  OSCCTRL Non-Secure                       */
+    uint32_t OSC32KCTRL_:1;             /**< bit:      5  OSC32KCTRL Non-Secure                    */
+    uint32_t SUPC_:1;                   /**< bit:      6  SUPC Non-Secure                          */
+    uint32_t GCLK_:1;                   /**< bit:      7  GCLK Non-Secure                          */
+    uint32_t WDT_:1;                    /**< bit:      8  WDT Non-Secure                           */
+    uint32_t RTC_:1;                    /**< bit:      9  RTC Non-Secure                           */
+    uint32_t EIC_:1;                    /**< bit:     10  EIC Non-Secure                           */
+    uint32_t FREQM_:1;                  /**< bit:     11  FREQM Non-Secure                         */
+    uint32_t PORT_:1;                   /**< bit:     12  PORT Non-Secure                          */
+    uint32_t AC_:1;                     /**< bit:     13  AC Non-Secure                            */
+    uint32_t :18;                       /**< bit: 14..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PAC_NONSECA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_NONSECA_OFFSET                  (0x54)                                        /**<  (PAC_NONSECA) Peripheral non-secure status - Bridge A  Offset */
+#define PAC_NONSECA_RESETVALUE              _U_(0x00)                                     /**<  (PAC_NONSECA) Peripheral non-secure status - Bridge A  Reset Value */
+
+#define PAC_NONSECA_PAC_Pos                 0                                              /**< (PAC_NONSECA) PAC Non-Secure Position */
+#define PAC_NONSECA_PAC_Msk                 (_U_(0x1) << PAC_NONSECA_PAC_Pos)              /**< (PAC_NONSECA) PAC Non-Secure Mask */
+#define PAC_NONSECA_PAC                     PAC_NONSECA_PAC_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECA_PAC_Msk instead */
+#define PAC_NONSECA_PM_Pos                  1                                              /**< (PAC_NONSECA) PM Non-Secure Position */
+#define PAC_NONSECA_PM_Msk                  (_U_(0x1) << PAC_NONSECA_PM_Pos)               /**< (PAC_NONSECA) PM Non-Secure Mask */
+#define PAC_NONSECA_PM                      PAC_NONSECA_PM_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECA_PM_Msk instead */
+#define PAC_NONSECA_MCLK_Pos                2                                              /**< (PAC_NONSECA) MCLK Non-Secure Position */
+#define PAC_NONSECA_MCLK_Msk                (_U_(0x1) << PAC_NONSECA_MCLK_Pos)             /**< (PAC_NONSECA) MCLK Non-Secure Mask */
+#define PAC_NONSECA_MCLK                    PAC_NONSECA_MCLK_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECA_MCLK_Msk instead */
+#define PAC_NONSECA_RSTC_Pos                3                                              /**< (PAC_NONSECA) RSTC Non-Secure Position */
+#define PAC_NONSECA_RSTC_Msk                (_U_(0x1) << PAC_NONSECA_RSTC_Pos)             /**< (PAC_NONSECA) RSTC Non-Secure Mask */
+#define PAC_NONSECA_RSTC                    PAC_NONSECA_RSTC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECA_RSTC_Msk instead */
+#define PAC_NONSECA_OSCCTRL_Pos             4                                              /**< (PAC_NONSECA) OSCCTRL Non-Secure Position */
+#define PAC_NONSECA_OSCCTRL_Msk             (_U_(0x1) << PAC_NONSECA_OSCCTRL_Pos)          /**< (PAC_NONSECA) OSCCTRL Non-Secure Mask */
+#define PAC_NONSECA_OSCCTRL                 PAC_NONSECA_OSCCTRL_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECA_OSCCTRL_Msk instead */
+#define PAC_NONSECA_OSC32KCTRL_Pos          5                                              /**< (PAC_NONSECA) OSC32KCTRL Non-Secure Position */
+#define PAC_NONSECA_OSC32KCTRL_Msk          (_U_(0x1) << PAC_NONSECA_OSC32KCTRL_Pos)       /**< (PAC_NONSECA) OSC32KCTRL Non-Secure Mask */
+#define PAC_NONSECA_OSC32KCTRL              PAC_NONSECA_OSC32KCTRL_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECA_OSC32KCTRL_Msk instead */
+#define PAC_NONSECA_SUPC_Pos                6                                              /**< (PAC_NONSECA) SUPC Non-Secure Position */
+#define PAC_NONSECA_SUPC_Msk                (_U_(0x1) << PAC_NONSECA_SUPC_Pos)             /**< (PAC_NONSECA) SUPC Non-Secure Mask */
+#define PAC_NONSECA_SUPC                    PAC_NONSECA_SUPC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECA_SUPC_Msk instead */
+#define PAC_NONSECA_GCLK_Pos                7                                              /**< (PAC_NONSECA) GCLK Non-Secure Position */
+#define PAC_NONSECA_GCLK_Msk                (_U_(0x1) << PAC_NONSECA_GCLK_Pos)             /**< (PAC_NONSECA) GCLK Non-Secure Mask */
+#define PAC_NONSECA_GCLK                    PAC_NONSECA_GCLK_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECA_GCLK_Msk instead */
+#define PAC_NONSECA_WDT_Pos                 8                                              /**< (PAC_NONSECA) WDT Non-Secure Position */
+#define PAC_NONSECA_WDT_Msk                 (_U_(0x1) << PAC_NONSECA_WDT_Pos)              /**< (PAC_NONSECA) WDT Non-Secure Mask */
+#define PAC_NONSECA_WDT                     PAC_NONSECA_WDT_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECA_WDT_Msk instead */
+#define PAC_NONSECA_RTC_Pos                 9                                              /**< (PAC_NONSECA) RTC Non-Secure Position */
+#define PAC_NONSECA_RTC_Msk                 (_U_(0x1) << PAC_NONSECA_RTC_Pos)              /**< (PAC_NONSECA) RTC Non-Secure Mask */
+#define PAC_NONSECA_RTC                     PAC_NONSECA_RTC_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECA_RTC_Msk instead */
+#define PAC_NONSECA_EIC_Pos                 10                                             /**< (PAC_NONSECA) EIC Non-Secure Position */
+#define PAC_NONSECA_EIC_Msk                 (_U_(0x1) << PAC_NONSECA_EIC_Pos)              /**< (PAC_NONSECA) EIC Non-Secure Mask */
+#define PAC_NONSECA_EIC                     PAC_NONSECA_EIC_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECA_EIC_Msk instead */
+#define PAC_NONSECA_FREQM_Pos               11                                             /**< (PAC_NONSECA) FREQM Non-Secure Position */
+#define PAC_NONSECA_FREQM_Msk               (_U_(0x1) << PAC_NONSECA_FREQM_Pos)            /**< (PAC_NONSECA) FREQM Non-Secure Mask */
+#define PAC_NONSECA_FREQM                   PAC_NONSECA_FREQM_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECA_FREQM_Msk instead */
+#define PAC_NONSECA_PORT_Pos                12                                             /**< (PAC_NONSECA) PORT Non-Secure Position */
+#define PAC_NONSECA_PORT_Msk                (_U_(0x1) << PAC_NONSECA_PORT_Pos)             /**< (PAC_NONSECA) PORT Non-Secure Mask */
+#define PAC_NONSECA_PORT                    PAC_NONSECA_PORT_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECA_PORT_Msk instead */
+#define PAC_NONSECA_AC_Pos                  13                                             /**< (PAC_NONSECA) AC Non-Secure Position */
+#define PAC_NONSECA_AC_Msk                  (_U_(0x1) << PAC_NONSECA_AC_Pos)               /**< (PAC_NONSECA) AC Non-Secure Mask */
+#define PAC_NONSECA_AC                      PAC_NONSECA_AC_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECA_AC_Msk instead */
+#define PAC_NONSECA_MASK                    _U_(0x3FFF)                                    /**< \deprecated (PAC_NONSECA) Register MASK  (Use PAC_NONSECA_Msk instead)  */
+#define PAC_NONSECA_Msk                     _U_(0x3FFF)                                    /**< (PAC_NONSECA) Register Mask  */
+
+
+/* -------- PAC_NONSECB : (PAC Offset: 0x58) (R/ 32) Peripheral non-secure status - Bridge B -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t IDAU_:1;                   /**< bit:      0  IDAU Non-Secure                          */
+    uint32_t DSU_:1;                    /**< bit:      1  DSU Non-Secure                           */
+    uint32_t NVMCTRL_:1;                /**< bit:      2  NVMCTRL Non-Secure                       */
+    uint32_t DMAC_:1;                   /**< bit:      3  DMAC Non-Secure                          */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PAC_NONSECB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_NONSECB_OFFSET                  (0x58)                                        /**<  (PAC_NONSECB) Peripheral non-secure status - Bridge B  Offset */
+#define PAC_NONSECB_RESETVALUE              _U_(0x02)                                     /**<  (PAC_NONSECB) Peripheral non-secure status - Bridge B  Reset Value */
+
+#define PAC_NONSECB_IDAU_Pos                0                                              /**< (PAC_NONSECB) IDAU Non-Secure Position */
+#define PAC_NONSECB_IDAU_Msk                (_U_(0x1) << PAC_NONSECB_IDAU_Pos)             /**< (PAC_NONSECB) IDAU Non-Secure Mask */
+#define PAC_NONSECB_IDAU                    PAC_NONSECB_IDAU_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECB_IDAU_Msk instead */
+#define PAC_NONSECB_DSU_Pos                 1                                              /**< (PAC_NONSECB) DSU Non-Secure Position */
+#define PAC_NONSECB_DSU_Msk                 (_U_(0x1) << PAC_NONSECB_DSU_Pos)              /**< (PAC_NONSECB) DSU Non-Secure Mask */
+#define PAC_NONSECB_DSU                     PAC_NONSECB_DSU_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECB_DSU_Msk instead */
+#define PAC_NONSECB_NVMCTRL_Pos             2                                              /**< (PAC_NONSECB) NVMCTRL Non-Secure Position */
+#define PAC_NONSECB_NVMCTRL_Msk             (_U_(0x1) << PAC_NONSECB_NVMCTRL_Pos)          /**< (PAC_NONSECB) NVMCTRL Non-Secure Mask */
+#define PAC_NONSECB_NVMCTRL                 PAC_NONSECB_NVMCTRL_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECB_NVMCTRL_Msk instead */
+#define PAC_NONSECB_DMAC_Pos                3                                              /**< (PAC_NONSECB) DMAC Non-Secure Position */
+#define PAC_NONSECB_DMAC_Msk                (_U_(0x1) << PAC_NONSECB_DMAC_Pos)             /**< (PAC_NONSECB) DMAC Non-Secure Mask */
+#define PAC_NONSECB_DMAC                    PAC_NONSECB_DMAC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECB_DMAC_Msk instead */
+#define PAC_NONSECB_MASK                    _U_(0x0F)                                      /**< \deprecated (PAC_NONSECB) Register MASK  (Use PAC_NONSECB_Msk instead)  */
+#define PAC_NONSECB_Msk                     _U_(0x0F)                                      /**< (PAC_NONSECB) Register Mask  */
+
+
+/* -------- PAC_NONSECC : (PAC Offset: 0x5c) (R/ 32) Peripheral non-secure status - Bridge C -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t EVSYS_:1;                  /**< bit:      0  EVSYS Non-Secure                         */
+    uint32_t SERCOM0_:1;                /**< bit:      1  SERCOM0 Non-Secure                       */
+    uint32_t SERCOM1_:1;                /**< bit:      2  SERCOM1 Non-Secure                       */
+    uint32_t SERCOM2_:1;                /**< bit:      3  SERCOM2 Non-Secure                       */
+    uint32_t TC0_:1;                    /**< bit:      4  TC0 Non-Secure                           */
+    uint32_t TC1_:1;                    /**< bit:      5  TC1 Non-Secure                           */
+    uint32_t TC2_:1;                    /**< bit:      6  TC2 Non-Secure                           */
+    uint32_t ADC_:1;                    /**< bit:      7  ADC Non-Secure                           */
+    uint32_t DAC_:1;                    /**< bit:      8  DAC Non-Secure                           */
+    uint32_t PTC_:1;                    /**< bit:      9  PTC Non-Secure                           */
+    uint32_t TRNG_:1;                   /**< bit:     10  TRNG Non-Secure                          */
+    uint32_t CCL_:1;                    /**< bit:     11  CCL Non-Secure                           */
+    uint32_t OPAMP_:1;                  /**< bit:     12  OPAMP Non-Secure                         */
+    uint32_t TRAM_:1;                   /**< bit:     13  TRAM Non-Secure                          */
+    uint32_t :18;                       /**< bit: 14..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PAC_NONSECC_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_NONSECC_OFFSET                  (0x5C)                                        /**<  (PAC_NONSECC) Peripheral non-secure status - Bridge C  Offset */
+#define PAC_NONSECC_RESETVALUE              _U_(0x00)                                     /**<  (PAC_NONSECC) Peripheral non-secure status - Bridge C  Reset Value */
+
+#define PAC_NONSECC_EVSYS_Pos               0                                              /**< (PAC_NONSECC) EVSYS Non-Secure Position */
+#define PAC_NONSECC_EVSYS_Msk               (_U_(0x1) << PAC_NONSECC_EVSYS_Pos)            /**< (PAC_NONSECC) EVSYS Non-Secure Mask */
+#define PAC_NONSECC_EVSYS                   PAC_NONSECC_EVSYS_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECC_EVSYS_Msk instead */
+#define PAC_NONSECC_SERCOM0_Pos             1                                              /**< (PAC_NONSECC) SERCOM0 Non-Secure Position */
+#define PAC_NONSECC_SERCOM0_Msk             (_U_(0x1) << PAC_NONSECC_SERCOM0_Pos)          /**< (PAC_NONSECC) SERCOM0 Non-Secure Mask */
+#define PAC_NONSECC_SERCOM0                 PAC_NONSECC_SERCOM0_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECC_SERCOM0_Msk instead */
+#define PAC_NONSECC_SERCOM1_Pos             2                                              /**< (PAC_NONSECC) SERCOM1 Non-Secure Position */
+#define PAC_NONSECC_SERCOM1_Msk             (_U_(0x1) << PAC_NONSECC_SERCOM1_Pos)          /**< (PAC_NONSECC) SERCOM1 Non-Secure Mask */
+#define PAC_NONSECC_SERCOM1                 PAC_NONSECC_SERCOM1_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECC_SERCOM1_Msk instead */
+#define PAC_NONSECC_SERCOM2_Pos             3                                              /**< (PAC_NONSECC) SERCOM2 Non-Secure Position */
+#define PAC_NONSECC_SERCOM2_Msk             (_U_(0x1) << PAC_NONSECC_SERCOM2_Pos)          /**< (PAC_NONSECC) SERCOM2 Non-Secure Mask */
+#define PAC_NONSECC_SERCOM2                 PAC_NONSECC_SERCOM2_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECC_SERCOM2_Msk instead */
+#define PAC_NONSECC_TC0_Pos                 4                                              /**< (PAC_NONSECC) TC0 Non-Secure Position */
+#define PAC_NONSECC_TC0_Msk                 (_U_(0x1) << PAC_NONSECC_TC0_Pos)              /**< (PAC_NONSECC) TC0 Non-Secure Mask */
+#define PAC_NONSECC_TC0                     PAC_NONSECC_TC0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECC_TC0_Msk instead */
+#define PAC_NONSECC_TC1_Pos                 5                                              /**< (PAC_NONSECC) TC1 Non-Secure Position */
+#define PAC_NONSECC_TC1_Msk                 (_U_(0x1) << PAC_NONSECC_TC1_Pos)              /**< (PAC_NONSECC) TC1 Non-Secure Mask */
+#define PAC_NONSECC_TC1                     PAC_NONSECC_TC1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECC_TC1_Msk instead */
+#define PAC_NONSECC_TC2_Pos                 6                                              /**< (PAC_NONSECC) TC2 Non-Secure Position */
+#define PAC_NONSECC_TC2_Msk                 (_U_(0x1) << PAC_NONSECC_TC2_Pos)              /**< (PAC_NONSECC) TC2 Non-Secure Mask */
+#define PAC_NONSECC_TC2                     PAC_NONSECC_TC2_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECC_TC2_Msk instead */
+#define PAC_NONSECC_ADC_Pos                 7                                              /**< (PAC_NONSECC) ADC Non-Secure Position */
+#define PAC_NONSECC_ADC_Msk                 (_U_(0x1) << PAC_NONSECC_ADC_Pos)              /**< (PAC_NONSECC) ADC Non-Secure Mask */
+#define PAC_NONSECC_ADC                     PAC_NONSECC_ADC_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECC_ADC_Msk instead */
+#define PAC_NONSECC_DAC_Pos                 8                                              /**< (PAC_NONSECC) DAC Non-Secure Position */
+#define PAC_NONSECC_DAC_Msk                 (_U_(0x1) << PAC_NONSECC_DAC_Pos)              /**< (PAC_NONSECC) DAC Non-Secure Mask */
+#define PAC_NONSECC_DAC                     PAC_NONSECC_DAC_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECC_DAC_Msk instead */
+#define PAC_NONSECC_PTC_Pos                 9                                              /**< (PAC_NONSECC) PTC Non-Secure Position */
+#define PAC_NONSECC_PTC_Msk                 (_U_(0x1) << PAC_NONSECC_PTC_Pos)              /**< (PAC_NONSECC) PTC Non-Secure Mask */
+#define PAC_NONSECC_PTC                     PAC_NONSECC_PTC_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECC_PTC_Msk instead */
+#define PAC_NONSECC_TRNG_Pos                10                                             /**< (PAC_NONSECC) TRNG Non-Secure Position */
+#define PAC_NONSECC_TRNG_Msk                (_U_(0x1) << PAC_NONSECC_TRNG_Pos)             /**< (PAC_NONSECC) TRNG Non-Secure Mask */
+#define PAC_NONSECC_TRNG                    PAC_NONSECC_TRNG_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECC_TRNG_Msk instead */
+#define PAC_NONSECC_CCL_Pos                 11                                             /**< (PAC_NONSECC) CCL Non-Secure Position */
+#define PAC_NONSECC_CCL_Msk                 (_U_(0x1) << PAC_NONSECC_CCL_Pos)              /**< (PAC_NONSECC) CCL Non-Secure Mask */
+#define PAC_NONSECC_CCL                     PAC_NONSECC_CCL_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECC_CCL_Msk instead */
+#define PAC_NONSECC_OPAMP_Pos               12                                             /**< (PAC_NONSECC) OPAMP Non-Secure Position */
+#define PAC_NONSECC_OPAMP_Msk               (_U_(0x1) << PAC_NONSECC_OPAMP_Pos)            /**< (PAC_NONSECC) OPAMP Non-Secure Mask */
+#define PAC_NONSECC_OPAMP                   PAC_NONSECC_OPAMP_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECC_OPAMP_Msk instead */
+#define PAC_NONSECC_TRAM_Pos                13                                             /**< (PAC_NONSECC) TRAM Non-Secure Position */
+#define PAC_NONSECC_TRAM_Msk                (_U_(0x1) << PAC_NONSECC_TRAM_Pos)             /**< (PAC_NONSECC) TRAM Non-Secure Mask */
+#define PAC_NONSECC_TRAM                    PAC_NONSECC_TRAM_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECC_TRAM_Msk instead */
+#define PAC_NONSECC_MASK                    _U_(0x3FFF)                                    /**< \deprecated (PAC_NONSECC) Register MASK  (Use PAC_NONSECC_Msk instead)  */
+#define PAC_NONSECC_Msk                     _U_(0x3FFF)                                    /**< (PAC_NONSECC) Register Mask  */
+
+#define PAC_NONSECC_SERCOM_Pos              1                                              /**< (PAC_NONSECC Position) SERCOMx Non-Secure */
+#define PAC_NONSECC_SERCOM_Msk              (_U_(0x7) << PAC_NONSECC_SERCOM_Pos)           /**< (PAC_NONSECC Mask) SERCOM */
+#define PAC_NONSECC_SERCOM(value)           (PAC_NONSECC_SERCOM_Msk & ((value) << PAC_NONSECC_SERCOM_Pos))  
+#define PAC_NONSECC_TC_Pos                  4                                              /**< (PAC_NONSECC Position) TCx Non-Secure */
+#define PAC_NONSECC_TC_Msk                  (_U_(0x7) << PAC_NONSECC_TC_Pos)               /**< (PAC_NONSECC Mask) TC */
+#define PAC_NONSECC_TC(value)               (PAC_NONSECC_TC_Msk & ((value) << PAC_NONSECC_TC_Pos))  
+
+/* -------- PAC_SECLOCKA : (PAC Offset: 0x74) (R/ 32) Peripheral secure status locked - Bridge A -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t PAC_:1;                    /**< bit:      0  PAC Secure Status Locked                 */
+    uint32_t PM_:1;                     /**< bit:      1  PM Secure Status Locked                  */
+    uint32_t MCLK_:1;                   /**< bit:      2  MCLK Secure Status Locked                */
+    uint32_t RSTC_:1;                   /**< bit:      3  RSTC Secure Status Locked                */
+    uint32_t OSCCTRL_:1;                /**< bit:      4  OSCCTRL Secure Status Locked             */
+    uint32_t OSC32KCTRL_:1;             /**< bit:      5  OSC32KCTRL Secure Status Locked          */
+    uint32_t SUPC_:1;                   /**< bit:      6  SUPC Secure Status Locked                */
+    uint32_t GCLK_:1;                   /**< bit:      7  GCLK Secure Status Locked                */
+    uint32_t WDT_:1;                    /**< bit:      8  WDT Secure Status Locked                 */
+    uint32_t RTC_:1;                    /**< bit:      9  RTC Secure Status Locked                 */
+    uint32_t EIC_:1;                    /**< bit:     10  EIC Secure Status Locked                 */
+    uint32_t FREQM_:1;                  /**< bit:     11  FREQM Secure Status Locked               */
+    uint32_t PORT_:1;                   /**< bit:     12  PORT Secure Status Locked                */
+    uint32_t AC_:1;                     /**< bit:     13  AC Secure Status Locked                  */
+    uint32_t :18;                       /**< bit: 14..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PAC_SECLOCKA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_SECLOCKA_OFFSET                 (0x74)                                        /**<  (PAC_SECLOCKA) Peripheral secure status locked - Bridge A  Offset */
+#define PAC_SECLOCKA_RESETVALUE             _U_(0x00)                                     /**<  (PAC_SECLOCKA) Peripheral secure status locked - Bridge A  Reset Value */
+
+#define PAC_SECLOCKA_PAC_Pos                0                                              /**< (PAC_SECLOCKA) PAC Secure Status Locked Position */
+#define PAC_SECLOCKA_PAC_Msk                (_U_(0x1) << PAC_SECLOCKA_PAC_Pos)             /**< (PAC_SECLOCKA) PAC Secure Status Locked Mask */
+#define PAC_SECLOCKA_PAC                    PAC_SECLOCKA_PAC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKA_PAC_Msk instead */
+#define PAC_SECLOCKA_PM_Pos                 1                                              /**< (PAC_SECLOCKA) PM Secure Status Locked Position */
+#define PAC_SECLOCKA_PM_Msk                 (_U_(0x1) << PAC_SECLOCKA_PM_Pos)              /**< (PAC_SECLOCKA) PM Secure Status Locked Mask */
+#define PAC_SECLOCKA_PM                     PAC_SECLOCKA_PM_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKA_PM_Msk instead */
+#define PAC_SECLOCKA_MCLK_Pos               2                                              /**< (PAC_SECLOCKA) MCLK Secure Status Locked Position */
+#define PAC_SECLOCKA_MCLK_Msk               (_U_(0x1) << PAC_SECLOCKA_MCLK_Pos)            /**< (PAC_SECLOCKA) MCLK Secure Status Locked Mask */
+#define PAC_SECLOCKA_MCLK                   PAC_SECLOCKA_MCLK_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKA_MCLK_Msk instead */
+#define PAC_SECLOCKA_RSTC_Pos               3                                              /**< (PAC_SECLOCKA) RSTC Secure Status Locked Position */
+#define PAC_SECLOCKA_RSTC_Msk               (_U_(0x1) << PAC_SECLOCKA_RSTC_Pos)            /**< (PAC_SECLOCKA) RSTC Secure Status Locked Mask */
+#define PAC_SECLOCKA_RSTC                   PAC_SECLOCKA_RSTC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKA_RSTC_Msk instead */
+#define PAC_SECLOCKA_OSCCTRL_Pos            4                                              /**< (PAC_SECLOCKA) OSCCTRL Secure Status Locked Position */
+#define PAC_SECLOCKA_OSCCTRL_Msk            (_U_(0x1) << PAC_SECLOCKA_OSCCTRL_Pos)         /**< (PAC_SECLOCKA) OSCCTRL Secure Status Locked Mask */
+#define PAC_SECLOCKA_OSCCTRL                PAC_SECLOCKA_OSCCTRL_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKA_OSCCTRL_Msk instead */
+#define PAC_SECLOCKA_OSC32KCTRL_Pos         5                                              /**< (PAC_SECLOCKA) OSC32KCTRL Secure Status Locked Position */
+#define PAC_SECLOCKA_OSC32KCTRL_Msk         (_U_(0x1) << PAC_SECLOCKA_OSC32KCTRL_Pos)      /**< (PAC_SECLOCKA) OSC32KCTRL Secure Status Locked Mask */
+#define PAC_SECLOCKA_OSC32KCTRL             PAC_SECLOCKA_OSC32KCTRL_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKA_OSC32KCTRL_Msk instead */
+#define PAC_SECLOCKA_SUPC_Pos               6                                              /**< (PAC_SECLOCKA) SUPC Secure Status Locked Position */
+#define PAC_SECLOCKA_SUPC_Msk               (_U_(0x1) << PAC_SECLOCKA_SUPC_Pos)            /**< (PAC_SECLOCKA) SUPC Secure Status Locked Mask */
+#define PAC_SECLOCKA_SUPC                   PAC_SECLOCKA_SUPC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKA_SUPC_Msk instead */
+#define PAC_SECLOCKA_GCLK_Pos               7                                              /**< (PAC_SECLOCKA) GCLK Secure Status Locked Position */
+#define PAC_SECLOCKA_GCLK_Msk               (_U_(0x1) << PAC_SECLOCKA_GCLK_Pos)            /**< (PAC_SECLOCKA) GCLK Secure Status Locked Mask */
+#define PAC_SECLOCKA_GCLK                   PAC_SECLOCKA_GCLK_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKA_GCLK_Msk instead */
+#define PAC_SECLOCKA_WDT_Pos                8                                              /**< (PAC_SECLOCKA) WDT Secure Status Locked Position */
+#define PAC_SECLOCKA_WDT_Msk                (_U_(0x1) << PAC_SECLOCKA_WDT_Pos)             /**< (PAC_SECLOCKA) WDT Secure Status Locked Mask */
+#define PAC_SECLOCKA_WDT                    PAC_SECLOCKA_WDT_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKA_WDT_Msk instead */
+#define PAC_SECLOCKA_RTC_Pos                9                                              /**< (PAC_SECLOCKA) RTC Secure Status Locked Position */
+#define PAC_SECLOCKA_RTC_Msk                (_U_(0x1) << PAC_SECLOCKA_RTC_Pos)             /**< (PAC_SECLOCKA) RTC Secure Status Locked Mask */
+#define PAC_SECLOCKA_RTC                    PAC_SECLOCKA_RTC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKA_RTC_Msk instead */
+#define PAC_SECLOCKA_EIC_Pos                10                                             /**< (PAC_SECLOCKA) EIC Secure Status Locked Position */
+#define PAC_SECLOCKA_EIC_Msk                (_U_(0x1) << PAC_SECLOCKA_EIC_Pos)             /**< (PAC_SECLOCKA) EIC Secure Status Locked Mask */
+#define PAC_SECLOCKA_EIC                    PAC_SECLOCKA_EIC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKA_EIC_Msk instead */
+#define PAC_SECLOCKA_FREQM_Pos              11                                             /**< (PAC_SECLOCKA) FREQM Secure Status Locked Position */
+#define PAC_SECLOCKA_FREQM_Msk              (_U_(0x1) << PAC_SECLOCKA_FREQM_Pos)           /**< (PAC_SECLOCKA) FREQM Secure Status Locked Mask */
+#define PAC_SECLOCKA_FREQM                  PAC_SECLOCKA_FREQM_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKA_FREQM_Msk instead */
+#define PAC_SECLOCKA_PORT_Pos               12                                             /**< (PAC_SECLOCKA) PORT Secure Status Locked Position */
+#define PAC_SECLOCKA_PORT_Msk               (_U_(0x1) << PAC_SECLOCKA_PORT_Pos)            /**< (PAC_SECLOCKA) PORT Secure Status Locked Mask */
+#define PAC_SECLOCKA_PORT                   PAC_SECLOCKA_PORT_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKA_PORT_Msk instead */
+#define PAC_SECLOCKA_AC_Pos                 13                                             /**< (PAC_SECLOCKA) AC Secure Status Locked Position */
+#define PAC_SECLOCKA_AC_Msk                 (_U_(0x1) << PAC_SECLOCKA_AC_Pos)              /**< (PAC_SECLOCKA) AC Secure Status Locked Mask */
+#define PAC_SECLOCKA_AC                     PAC_SECLOCKA_AC_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKA_AC_Msk instead */
+#define PAC_SECLOCKA_MASK                   _U_(0x3FFF)                                    /**< \deprecated (PAC_SECLOCKA) Register MASK  (Use PAC_SECLOCKA_Msk instead)  */
+#define PAC_SECLOCKA_Msk                    _U_(0x3FFF)                                    /**< (PAC_SECLOCKA) Register Mask  */
+
+
+/* -------- PAC_SECLOCKB : (PAC Offset: 0x78) (R/ 32) Peripheral secure status locked - Bridge B -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t IDAU_:1;                   /**< bit:      0  IDAU Secure Status Locked                */
+    uint32_t DSU_:1;                    /**< bit:      1  DSU Secure Status Locked                 */
+    uint32_t NVMCTRL_:1;                /**< bit:      2  NVMCTRL Secure Status Locked             */
+    uint32_t DMAC_:1;                   /**< bit:      3  DMAC Secure Status Locked                */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PAC_SECLOCKB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_SECLOCKB_OFFSET                 (0x78)                                        /**<  (PAC_SECLOCKB) Peripheral secure status locked - Bridge B  Offset */
+#define PAC_SECLOCKB_RESETVALUE             _U_(0x03)                                     /**<  (PAC_SECLOCKB) Peripheral secure status locked - Bridge B  Reset Value */
+
+#define PAC_SECLOCKB_IDAU_Pos               0                                              /**< (PAC_SECLOCKB) IDAU Secure Status Locked Position */
+#define PAC_SECLOCKB_IDAU_Msk               (_U_(0x1) << PAC_SECLOCKB_IDAU_Pos)            /**< (PAC_SECLOCKB) IDAU Secure Status Locked Mask */
+#define PAC_SECLOCKB_IDAU                   PAC_SECLOCKB_IDAU_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKB_IDAU_Msk instead */
+#define PAC_SECLOCKB_DSU_Pos                1                                              /**< (PAC_SECLOCKB) DSU Secure Status Locked Position */
+#define PAC_SECLOCKB_DSU_Msk                (_U_(0x1) << PAC_SECLOCKB_DSU_Pos)             /**< (PAC_SECLOCKB) DSU Secure Status Locked Mask */
+#define PAC_SECLOCKB_DSU                    PAC_SECLOCKB_DSU_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKB_DSU_Msk instead */
+#define PAC_SECLOCKB_NVMCTRL_Pos            2                                              /**< (PAC_SECLOCKB) NVMCTRL Secure Status Locked Position */
+#define PAC_SECLOCKB_NVMCTRL_Msk            (_U_(0x1) << PAC_SECLOCKB_NVMCTRL_Pos)         /**< (PAC_SECLOCKB) NVMCTRL Secure Status Locked Mask */
+#define PAC_SECLOCKB_NVMCTRL                PAC_SECLOCKB_NVMCTRL_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKB_NVMCTRL_Msk instead */
+#define PAC_SECLOCKB_DMAC_Pos               3                                              /**< (PAC_SECLOCKB) DMAC Secure Status Locked Position */
+#define PAC_SECLOCKB_DMAC_Msk               (_U_(0x1) << PAC_SECLOCKB_DMAC_Pos)            /**< (PAC_SECLOCKB) DMAC Secure Status Locked Mask */
+#define PAC_SECLOCKB_DMAC                   PAC_SECLOCKB_DMAC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKB_DMAC_Msk instead */
+#define PAC_SECLOCKB_MASK                   _U_(0x0F)                                      /**< \deprecated (PAC_SECLOCKB) Register MASK  (Use PAC_SECLOCKB_Msk instead)  */
+#define PAC_SECLOCKB_Msk                    _U_(0x0F)                                      /**< (PAC_SECLOCKB) Register Mask  */
+
+
+/* -------- PAC_SECLOCKC : (PAC Offset: 0x7c) (R/ 32) Peripheral secure status locked - Bridge C -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t EVSYS_:1;                  /**< bit:      0  EVSYS Secure Status Locked               */
+    uint32_t SERCOM0_:1;                /**< bit:      1  SERCOM0 Secure Status Locked             */
+    uint32_t SERCOM1_:1;                /**< bit:      2  SERCOM1 Secure Status Locked             */
+    uint32_t SERCOM2_:1;                /**< bit:      3  SERCOM2 Secure Status Locked             */
+    uint32_t TC0_:1;                    /**< bit:      4  TC0 Secure Status Locked                 */
+    uint32_t TC1_:1;                    /**< bit:      5  TC1 Secure Status Locked                 */
+    uint32_t TC2_:1;                    /**< bit:      6  TC2 Secure Status Locked                 */
+    uint32_t ADC_:1;                    /**< bit:      7  ADC Secure Status Locked                 */
+    uint32_t DAC_:1;                    /**< bit:      8  DAC Secure Status Locked                 */
+    uint32_t PTC_:1;                    /**< bit:      9  PTC Secure Status Locked                 */
+    uint32_t TRNG_:1;                   /**< bit:     10  TRNG Secure Status Locked                */
+    uint32_t CCL_:1;                    /**< bit:     11  CCL Secure Status Locked                 */
+    uint32_t OPAMP_:1;                  /**< bit:     12  OPAMP Secure Status Locked               */
+    uint32_t TRAM_:1;                   /**< bit:     13  TRAM Secure Status Locked                */
+    uint32_t :18;                       /**< bit: 14..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PAC_SECLOCKC_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_SECLOCKC_OFFSET                 (0x7C)                                        /**<  (PAC_SECLOCKC) Peripheral secure status locked - Bridge C  Offset */
+#define PAC_SECLOCKC_RESETVALUE             _U_(0x00)                                     /**<  (PAC_SECLOCKC) Peripheral secure status locked - Bridge C  Reset Value */
+
+#define PAC_SECLOCKC_EVSYS_Pos              0                                              /**< (PAC_SECLOCKC) EVSYS Secure Status Locked Position */
+#define PAC_SECLOCKC_EVSYS_Msk              (_U_(0x1) << PAC_SECLOCKC_EVSYS_Pos)           /**< (PAC_SECLOCKC) EVSYS Secure Status Locked Mask */
+#define PAC_SECLOCKC_EVSYS                  PAC_SECLOCKC_EVSYS_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKC_EVSYS_Msk instead */
+#define PAC_SECLOCKC_SERCOM0_Pos            1                                              /**< (PAC_SECLOCKC) SERCOM0 Secure Status Locked Position */
+#define PAC_SECLOCKC_SERCOM0_Msk            (_U_(0x1) << PAC_SECLOCKC_SERCOM0_Pos)         /**< (PAC_SECLOCKC) SERCOM0 Secure Status Locked Mask */
+#define PAC_SECLOCKC_SERCOM0                PAC_SECLOCKC_SERCOM0_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKC_SERCOM0_Msk instead */
+#define PAC_SECLOCKC_SERCOM1_Pos            2                                              /**< (PAC_SECLOCKC) SERCOM1 Secure Status Locked Position */
+#define PAC_SECLOCKC_SERCOM1_Msk            (_U_(0x1) << PAC_SECLOCKC_SERCOM1_Pos)         /**< (PAC_SECLOCKC) SERCOM1 Secure Status Locked Mask */
+#define PAC_SECLOCKC_SERCOM1                PAC_SECLOCKC_SERCOM1_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKC_SERCOM1_Msk instead */
+#define PAC_SECLOCKC_SERCOM2_Pos            3                                              /**< (PAC_SECLOCKC) SERCOM2 Secure Status Locked Position */
+#define PAC_SECLOCKC_SERCOM2_Msk            (_U_(0x1) << PAC_SECLOCKC_SERCOM2_Pos)         /**< (PAC_SECLOCKC) SERCOM2 Secure Status Locked Mask */
+#define PAC_SECLOCKC_SERCOM2                PAC_SECLOCKC_SERCOM2_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKC_SERCOM2_Msk instead */
+#define PAC_SECLOCKC_TC0_Pos                4                                              /**< (PAC_SECLOCKC) TC0 Secure Status Locked Position */
+#define PAC_SECLOCKC_TC0_Msk                (_U_(0x1) << PAC_SECLOCKC_TC0_Pos)             /**< (PAC_SECLOCKC) TC0 Secure Status Locked Mask */
+#define PAC_SECLOCKC_TC0                    PAC_SECLOCKC_TC0_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKC_TC0_Msk instead */
+#define PAC_SECLOCKC_TC1_Pos                5                                              /**< (PAC_SECLOCKC) TC1 Secure Status Locked Position */
+#define PAC_SECLOCKC_TC1_Msk                (_U_(0x1) << PAC_SECLOCKC_TC1_Pos)             /**< (PAC_SECLOCKC) TC1 Secure Status Locked Mask */
+#define PAC_SECLOCKC_TC1                    PAC_SECLOCKC_TC1_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKC_TC1_Msk instead */
+#define PAC_SECLOCKC_TC2_Pos                6                                              /**< (PAC_SECLOCKC) TC2 Secure Status Locked Position */
+#define PAC_SECLOCKC_TC2_Msk                (_U_(0x1) << PAC_SECLOCKC_TC2_Pos)             /**< (PAC_SECLOCKC) TC2 Secure Status Locked Mask */
+#define PAC_SECLOCKC_TC2                    PAC_SECLOCKC_TC2_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKC_TC2_Msk instead */
+#define PAC_SECLOCKC_ADC_Pos                7                                              /**< (PAC_SECLOCKC) ADC Secure Status Locked Position */
+#define PAC_SECLOCKC_ADC_Msk                (_U_(0x1) << PAC_SECLOCKC_ADC_Pos)             /**< (PAC_SECLOCKC) ADC Secure Status Locked Mask */
+#define PAC_SECLOCKC_ADC                    PAC_SECLOCKC_ADC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKC_ADC_Msk instead */
+#define PAC_SECLOCKC_DAC_Pos                8                                              /**< (PAC_SECLOCKC) DAC Secure Status Locked Position */
+#define PAC_SECLOCKC_DAC_Msk                (_U_(0x1) << PAC_SECLOCKC_DAC_Pos)             /**< (PAC_SECLOCKC) DAC Secure Status Locked Mask */
+#define PAC_SECLOCKC_DAC                    PAC_SECLOCKC_DAC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKC_DAC_Msk instead */
+#define PAC_SECLOCKC_PTC_Pos                9                                              /**< (PAC_SECLOCKC) PTC Secure Status Locked Position */
+#define PAC_SECLOCKC_PTC_Msk                (_U_(0x1) << PAC_SECLOCKC_PTC_Pos)             /**< (PAC_SECLOCKC) PTC Secure Status Locked Mask */
+#define PAC_SECLOCKC_PTC                    PAC_SECLOCKC_PTC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKC_PTC_Msk instead */
+#define PAC_SECLOCKC_TRNG_Pos               10                                             /**< (PAC_SECLOCKC) TRNG Secure Status Locked Position */
+#define PAC_SECLOCKC_TRNG_Msk               (_U_(0x1) << PAC_SECLOCKC_TRNG_Pos)            /**< (PAC_SECLOCKC) TRNG Secure Status Locked Mask */
+#define PAC_SECLOCKC_TRNG                   PAC_SECLOCKC_TRNG_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKC_TRNG_Msk instead */
+#define PAC_SECLOCKC_CCL_Pos                11                                             /**< (PAC_SECLOCKC) CCL Secure Status Locked Position */
+#define PAC_SECLOCKC_CCL_Msk                (_U_(0x1) << PAC_SECLOCKC_CCL_Pos)             /**< (PAC_SECLOCKC) CCL Secure Status Locked Mask */
+#define PAC_SECLOCKC_CCL                    PAC_SECLOCKC_CCL_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKC_CCL_Msk instead */
+#define PAC_SECLOCKC_OPAMP_Pos              12                                             /**< (PAC_SECLOCKC) OPAMP Secure Status Locked Position */
+#define PAC_SECLOCKC_OPAMP_Msk              (_U_(0x1) << PAC_SECLOCKC_OPAMP_Pos)           /**< (PAC_SECLOCKC) OPAMP Secure Status Locked Mask */
+#define PAC_SECLOCKC_OPAMP                  PAC_SECLOCKC_OPAMP_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKC_OPAMP_Msk instead */
+#define PAC_SECLOCKC_TRAM_Pos               13                                             /**< (PAC_SECLOCKC) TRAM Secure Status Locked Position */
+#define PAC_SECLOCKC_TRAM_Msk               (_U_(0x1) << PAC_SECLOCKC_TRAM_Pos)            /**< (PAC_SECLOCKC) TRAM Secure Status Locked Mask */
+#define PAC_SECLOCKC_TRAM                   PAC_SECLOCKC_TRAM_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKC_TRAM_Msk instead */
+#define PAC_SECLOCKC_MASK                   _U_(0x3FFF)                                    /**< \deprecated (PAC_SECLOCKC) Register MASK  (Use PAC_SECLOCKC_Msk instead)  */
+#define PAC_SECLOCKC_Msk                    _U_(0x3FFF)                                    /**< (PAC_SECLOCKC) Register Mask  */
+
+#define PAC_SECLOCKC_SERCOM_Pos             1                                              /**< (PAC_SECLOCKC Position) SERCOMx Secure Status Locked */
+#define PAC_SECLOCKC_SERCOM_Msk             (_U_(0x7) << PAC_SECLOCKC_SERCOM_Pos)          /**< (PAC_SECLOCKC Mask) SERCOM */
+#define PAC_SECLOCKC_SERCOM(value)          (PAC_SECLOCKC_SERCOM_Msk & ((value) << PAC_SECLOCKC_SERCOM_Pos))  
+#define PAC_SECLOCKC_TC_Pos                 4                                              /**< (PAC_SECLOCKC Position) TCx Secure Status Locked */
+#define PAC_SECLOCKC_TC_Msk                 (_U_(0x7) << PAC_SECLOCKC_TC_Pos)              /**< (PAC_SECLOCKC Mask) TC */
+#define PAC_SECLOCKC_TC(value)              (PAC_SECLOCKC_TC_Msk & ((value) << PAC_SECLOCKC_TC_Pos))  
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief PAC hardware registers */
+typedef struct {  /* Peripheral Access Controller */
+  __IO PAC_WRCTRL_Type                WRCTRL;         /**< Offset: 0x00 (R/W  32) Write control */
+  __IO PAC_EVCTRL_Type                EVCTRL;         /**< Offset: 0x04 (R/W   8) Event control */
+  __I  uint8_t                        Reserved1[3];
+  __IO PAC_INTENCLR_Type              INTENCLR;       /**< Offset: 0x08 (R/W   8) Interrupt enable clear */
+  __IO PAC_INTENSET_Type              INTENSET;       /**< Offset: 0x09 (R/W   8) Interrupt enable set */
+  __I  uint8_t                        Reserved2[6];
+  __IO PAC_INTFLAGAHB_Type            INTFLAGAHB;     /**< Offset: 0x10 (R/W  32) Bridge interrupt flag status */
+  __IO PAC_INTFLAGA_Type              INTFLAGA;       /**< Offset: 0x14 (R/W  32) Peripheral interrupt flag status - Bridge A */
+  __IO PAC_INTFLAGB_Type              INTFLAGB;       /**< Offset: 0x18 (R/W  32) Peripheral interrupt flag status - Bridge B */
+  __IO PAC_INTFLAGC_Type              INTFLAGC;       /**< Offset: 0x1C (R/W  32) Peripheral interrupt flag status - Bridge C */
+  __I  uint8_t                        Reserved3[20];
+  __I  PAC_STATUSA_Type               STATUSA;        /**< Offset: 0x34 (R/   32) Peripheral write protection status - Bridge A */
+  __I  PAC_STATUSB_Type               STATUSB;        /**< Offset: 0x38 (R/   32) Peripheral write protection status - Bridge B */
+  __I  PAC_STATUSC_Type               STATUSC;        /**< Offset: 0x3C (R/   32) Peripheral write protection status - Bridge C */
+  __I  uint8_t                        Reserved4[20];
+  __I  PAC_NONSECA_Type               NONSECA;        /**< Offset: 0x54 (R/   32) Peripheral non-secure status - Bridge A */
+  __I  PAC_NONSECB_Type               NONSECB;        /**< Offset: 0x58 (R/   32) Peripheral non-secure status - Bridge B */
+  __I  PAC_NONSECC_Type               NONSECC;        /**< Offset: 0x5C (R/   32) Peripheral non-secure status - Bridge C */
+  __I  uint8_t                        Reserved5[20];
+  __I  PAC_SECLOCKA_Type              SECLOCKA;       /**< Offset: 0x74 (R/   32) Peripheral secure status locked - Bridge A */
+  __I  PAC_SECLOCKB_Type              SECLOCKB;       /**< Offset: 0x78 (R/   32) Peripheral secure status locked - Bridge B */
+  __I  PAC_SECLOCKC_Type              SECLOCKC;       /**< Offset: 0x7C (R/   32) Peripheral secure status locked - Bridge C */
+} Pac;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Peripheral Access Controller */
+
+#endif /* _SAML10_PAC_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/component/pm.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/pm.h
@@ -1,0 +1,266 @@
+/**
+ * \file
+ *
+ * \brief Component description for PM
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_PM_COMPONENT_H_
+#define _SAML10_PM_COMPONENT_H_
+#define _SAML10_PM_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML10 Power Manager
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR PM */
+/* ========================================================================== */
+
+#define PM_U2240                      /**< (PM) Module ID */
+#define REV_PM 0x310                  /**< (PM) Module revision */
+
+/* -------- PM_SLEEPCFG : (PM Offset: 0x01) (R/W 8) Sleep Configuration -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  SLEEPMODE:3;               /**< bit:   0..2  Sleep Mode                               */
+    uint8_t  :5;                        /**< bit:   3..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} PM_SLEEPCFG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_SLEEPCFG_OFFSET                  (0x01)                                        /**<  (PM_SLEEPCFG) Sleep Configuration  Offset */
+#define PM_SLEEPCFG_RESETVALUE              _U_(0x02)                                     /**<  (PM_SLEEPCFG) Sleep Configuration  Reset Value */
+
+#define PM_SLEEPCFG_SLEEPMODE_Pos           0                                              /**< (PM_SLEEPCFG) Sleep Mode Position */
+#define PM_SLEEPCFG_SLEEPMODE_Msk           (_U_(0x7) << PM_SLEEPCFG_SLEEPMODE_Pos)        /**< (PM_SLEEPCFG) Sleep Mode Mask */
+#define PM_SLEEPCFG_SLEEPMODE(value)        (PM_SLEEPCFG_SLEEPMODE_Msk & ((value) << PM_SLEEPCFG_SLEEPMODE_Pos))
+#define   PM_SLEEPCFG_SLEEPMODE_IDLE_Val    _U_(0x2)                                       /**< (PM_SLEEPCFG) CPU, AHB, APB clocks are OFF  */
+#define   PM_SLEEPCFG_SLEEPMODE_STANDBY_Val _U_(0x4)                                       /**< (PM_SLEEPCFG) All Clocks are OFF  */
+#define   PM_SLEEPCFG_SLEEPMODE_OFF_Val     _U_(0x6)                                       /**< (PM_SLEEPCFG) All power domains are powered OFF  */
+#define PM_SLEEPCFG_SLEEPMODE_IDLE          (PM_SLEEPCFG_SLEEPMODE_IDLE_Val << PM_SLEEPCFG_SLEEPMODE_Pos)  /**< (PM_SLEEPCFG) CPU, AHB, APB clocks are OFF Position  */
+#define PM_SLEEPCFG_SLEEPMODE_STANDBY       (PM_SLEEPCFG_SLEEPMODE_STANDBY_Val << PM_SLEEPCFG_SLEEPMODE_Pos)  /**< (PM_SLEEPCFG) All Clocks are OFF Position  */
+#define PM_SLEEPCFG_SLEEPMODE_OFF           (PM_SLEEPCFG_SLEEPMODE_OFF_Val << PM_SLEEPCFG_SLEEPMODE_Pos)  /**< (PM_SLEEPCFG) All power domains are powered OFF Position  */
+#define PM_SLEEPCFG_MASK                    _U_(0x07)                                      /**< \deprecated (PM_SLEEPCFG) Register MASK  (Use PM_SLEEPCFG_Msk instead)  */
+#define PM_SLEEPCFG_Msk                     _U_(0x07)                                      /**< (PM_SLEEPCFG) Register Mask  */
+
+
+/* -------- PM_PLCFG : (PM Offset: 0x02) (R/W 8) Performance Level Configuration -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  PLSEL:2;                   /**< bit:   0..1  Performance Level Select                 */
+    uint8_t  :5;                        /**< bit:   2..6  Reserved */
+    uint8_t  PLDIS:1;                   /**< bit:      7  Performance Level Disable                */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} PM_PLCFG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_PLCFG_OFFSET                     (0x02)                                        /**<  (PM_PLCFG) Performance Level Configuration  Offset */
+#define PM_PLCFG_RESETVALUE                 _U_(0x00)                                     /**<  (PM_PLCFG) Performance Level Configuration  Reset Value */
+
+#define PM_PLCFG_PLSEL_Pos                  0                                              /**< (PM_PLCFG) Performance Level Select Position */
+#define PM_PLCFG_PLSEL_Msk                  (_U_(0x3) << PM_PLCFG_PLSEL_Pos)               /**< (PM_PLCFG) Performance Level Select Mask */
+#define PM_PLCFG_PLSEL(value)               (PM_PLCFG_PLSEL_Msk & ((value) << PM_PLCFG_PLSEL_Pos))
+#define   PM_PLCFG_PLSEL_PL0_Val            _U_(0x0)                                       /**< (PM_PLCFG) Performance Level 0  */
+#define   PM_PLCFG_PLSEL_PL2_Val            _U_(0x2)                                       /**< (PM_PLCFG) Performance Level 2  */
+#define PM_PLCFG_PLSEL_PL0                  (PM_PLCFG_PLSEL_PL0_Val << PM_PLCFG_PLSEL_Pos)  /**< (PM_PLCFG) Performance Level 0 Position  */
+#define PM_PLCFG_PLSEL_PL2                  (PM_PLCFG_PLSEL_PL2_Val << PM_PLCFG_PLSEL_Pos)  /**< (PM_PLCFG) Performance Level 2 Position  */
+#define PM_PLCFG_PLDIS_Pos                  7                                              /**< (PM_PLCFG) Performance Level Disable Position */
+#define PM_PLCFG_PLDIS_Msk                  (_U_(0x1) << PM_PLCFG_PLDIS_Pos)               /**< (PM_PLCFG) Performance Level Disable Mask */
+#define PM_PLCFG_PLDIS                      PM_PLCFG_PLDIS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PM_PLCFG_PLDIS_Msk instead */
+#define PM_PLCFG_MASK                       _U_(0x83)                                      /**< \deprecated (PM_PLCFG) Register MASK  (Use PM_PLCFG_Msk instead)  */
+#define PM_PLCFG_Msk                        _U_(0x83)                                      /**< (PM_PLCFG) Register Mask  */
+
+
+/* -------- PM_PWCFG : (PM Offset: 0x03) (R/W 8) Power Configuration -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  RAMPSWC:2;                 /**< bit:   0..1  RAM Power Switch Configuration           */
+    uint8_t  :6;                        /**< bit:   2..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} PM_PWCFG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_PWCFG_OFFSET                     (0x03)                                        /**<  (PM_PWCFG) Power Configuration  Offset */
+#define PM_PWCFG_RESETVALUE                 _U_(0x00)                                     /**<  (PM_PWCFG) Power Configuration  Reset Value */
+
+#define PM_PWCFG_RAMPSWC_Pos                0                                              /**< (PM_PWCFG) RAM Power Switch Configuration Position */
+#define PM_PWCFG_RAMPSWC_Msk                (_U_(0x3) << PM_PWCFG_RAMPSWC_Pos)             /**< (PM_PWCFG) RAM Power Switch Configuration Mask */
+#define PM_PWCFG_RAMPSWC(value)             (PM_PWCFG_RAMPSWC_Msk & ((value) << PM_PWCFG_RAMPSWC_Pos))
+#define   PM_PWCFG_RAMPSWC_16KB_Val         _U_(0x0)                                       /**< (PM_PWCFG) 16KB Available  */
+#define   PM_PWCFG_RAMPSWC_12KB_Val         _U_(0x1)                                       /**< (PM_PWCFG) 12KB Available  */
+#define   PM_PWCFG_RAMPSWC_8KB_Val          _U_(0x2)                                       /**< (PM_PWCFG) 8KB Available  */
+#define   PM_PWCFG_RAMPSWC_4KB_Val          _U_(0x3)                                       /**< (PM_PWCFG) 4KB Available  */
+#define PM_PWCFG_RAMPSWC_16KB               (PM_PWCFG_RAMPSWC_16KB_Val << PM_PWCFG_RAMPSWC_Pos)  /**< (PM_PWCFG) 16KB Available Position  */
+#define PM_PWCFG_RAMPSWC_12KB               (PM_PWCFG_RAMPSWC_12KB_Val << PM_PWCFG_RAMPSWC_Pos)  /**< (PM_PWCFG) 12KB Available Position  */
+#define PM_PWCFG_RAMPSWC_8KB                (PM_PWCFG_RAMPSWC_8KB_Val << PM_PWCFG_RAMPSWC_Pos)  /**< (PM_PWCFG) 8KB Available Position  */
+#define PM_PWCFG_RAMPSWC_4KB                (PM_PWCFG_RAMPSWC_4KB_Val << PM_PWCFG_RAMPSWC_Pos)  /**< (PM_PWCFG) 4KB Available Position  */
+#define PM_PWCFG_MASK                       _U_(0x03)                                      /**< \deprecated (PM_PWCFG) Register MASK  (Use PM_PWCFG_Msk instead)  */
+#define PM_PWCFG_Msk                        _U_(0x03)                                      /**< (PM_PWCFG) Register Mask  */
+
+
+/* -------- PM_INTENCLR : (PM Offset: 0x04) (R/W 8) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  PLRDY:1;                   /**< bit:      0  Performance Level Interrupt Enable       */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} PM_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_INTENCLR_OFFSET                  (0x04)                                        /**<  (PM_INTENCLR) Interrupt Enable Clear  Offset */
+#define PM_INTENCLR_RESETVALUE              _U_(0x00)                                     /**<  (PM_INTENCLR) Interrupt Enable Clear  Reset Value */
+
+#define PM_INTENCLR_PLRDY_Pos               0                                              /**< (PM_INTENCLR) Performance Level Interrupt Enable Position */
+#define PM_INTENCLR_PLRDY_Msk               (_U_(0x1) << PM_INTENCLR_PLRDY_Pos)            /**< (PM_INTENCLR) Performance Level Interrupt Enable Mask */
+#define PM_INTENCLR_PLRDY                   PM_INTENCLR_PLRDY_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PM_INTENCLR_PLRDY_Msk instead */
+#define PM_INTENCLR_MASK                    _U_(0x01)                                      /**< \deprecated (PM_INTENCLR) Register MASK  (Use PM_INTENCLR_Msk instead)  */
+#define PM_INTENCLR_Msk                     _U_(0x01)                                      /**< (PM_INTENCLR) Register Mask  */
+
+
+/* -------- PM_INTENSET : (PM Offset: 0x05) (R/W 8) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  PLRDY:1;                   /**< bit:      0  Performance Level Ready interrupt Enable */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} PM_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_INTENSET_OFFSET                  (0x05)                                        /**<  (PM_INTENSET) Interrupt Enable Set  Offset */
+#define PM_INTENSET_RESETVALUE              _U_(0x00)                                     /**<  (PM_INTENSET) Interrupt Enable Set  Reset Value */
+
+#define PM_INTENSET_PLRDY_Pos               0                                              /**< (PM_INTENSET) Performance Level Ready interrupt Enable Position */
+#define PM_INTENSET_PLRDY_Msk               (_U_(0x1) << PM_INTENSET_PLRDY_Pos)            /**< (PM_INTENSET) Performance Level Ready interrupt Enable Mask */
+#define PM_INTENSET_PLRDY                   PM_INTENSET_PLRDY_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PM_INTENSET_PLRDY_Msk instead */
+#define PM_INTENSET_MASK                    _U_(0x01)                                      /**< \deprecated (PM_INTENSET) Register MASK  (Use PM_INTENSET_Msk instead)  */
+#define PM_INTENSET_Msk                     _U_(0x01)                                      /**< (PM_INTENSET) Register Mask  */
+
+
+/* -------- PM_INTFLAG : (PM Offset: 0x06) (R/W 8) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t PLRDY:1;                   /**< bit:      0  Performance Level Ready                  */
+    __I uint8_t :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} PM_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_INTFLAG_OFFSET                   (0x06)                                        /**<  (PM_INTFLAG) Interrupt Flag Status and Clear  Offset */
+#define PM_INTFLAG_RESETVALUE               _U_(0x00)                                     /**<  (PM_INTFLAG) Interrupt Flag Status and Clear  Reset Value */
+
+#define PM_INTFLAG_PLRDY_Pos                0                                              /**< (PM_INTFLAG) Performance Level Ready Position */
+#define PM_INTFLAG_PLRDY_Msk                (_U_(0x1) << PM_INTFLAG_PLRDY_Pos)             /**< (PM_INTFLAG) Performance Level Ready Mask */
+#define PM_INTFLAG_PLRDY                    PM_INTFLAG_PLRDY_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PM_INTFLAG_PLRDY_Msk instead */
+#define PM_INTFLAG_MASK                     _U_(0x01)                                      /**< \deprecated (PM_INTFLAG) Register MASK  (Use PM_INTFLAG_Msk instead)  */
+#define PM_INTFLAG_Msk                      _U_(0x01)                                      /**< (PM_INTFLAG) Register Mask  */
+
+
+/* -------- PM_STDBYCFG : (PM Offset: 0x08) (R/W 16) Standby Configuration -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t PDCFG:1;                   /**< bit:      0  Power Domain Configuration               */
+    uint16_t :3;                        /**< bit:   1..3  Reserved */
+    uint16_t DPGPDSW:1;                 /**< bit:      4  Dynamic Power Gating for PDSW            */
+    uint16_t :1;                        /**< bit:      5  Reserved */
+    uint16_t VREGSMOD:2;                /**< bit:   6..7  Voltage Regulator Standby mode           */
+    uint16_t :2;                        /**< bit:   8..9  Reserved */
+    uint16_t BBIASHS:1;                 /**< bit:     10  Back Bias for HSRAM                      */
+    uint16_t :1;                        /**< bit:     11  Reserved */
+    uint16_t BBIASTR:1;                 /**< bit:     12  Back Bias for Trust RAM                  */
+    uint16_t :3;                        /**< bit: 13..15  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} PM_STDBYCFG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_STDBYCFG_OFFSET                  (0x08)                                        /**<  (PM_STDBYCFG) Standby Configuration  Offset */
+#define PM_STDBYCFG_RESETVALUE              _U_(0x00)                                     /**<  (PM_STDBYCFG) Standby Configuration  Reset Value */
+
+#define PM_STDBYCFG_PDCFG_Pos               0                                              /**< (PM_STDBYCFG) Power Domain Configuration Position */
+#define PM_STDBYCFG_PDCFG_Msk               (_U_(0x1) << PM_STDBYCFG_PDCFG_Pos)            /**< (PM_STDBYCFG) Power Domain Configuration Mask */
+#define PM_STDBYCFG_PDCFG                   PM_STDBYCFG_PDCFG_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PM_STDBYCFG_PDCFG_Msk instead */
+#define   PM_STDBYCFG_PDCFG_DEFAULT_Val     _U_(0x0)                                       /**< (PM_STDBYCFG) PDSW power domain switching is handled by hardware.  */
+#define   PM_STDBYCFG_PDCFG_PDSW_Val        _U_(0x1)                                       /**< (PM_STDBYCFG) PDSW is forced ACTIVE.  */
+#define PM_STDBYCFG_PDCFG_DEFAULT           (PM_STDBYCFG_PDCFG_DEFAULT_Val << PM_STDBYCFG_PDCFG_Pos)  /**< (PM_STDBYCFG) PDSW power domain switching is handled by hardware. Position  */
+#define PM_STDBYCFG_PDCFG_PDSW              (PM_STDBYCFG_PDCFG_PDSW_Val << PM_STDBYCFG_PDCFG_Pos)  /**< (PM_STDBYCFG) PDSW is forced ACTIVE. Position  */
+#define PM_STDBYCFG_DPGPDSW_Pos             4                                              /**< (PM_STDBYCFG) Dynamic Power Gating for PDSW Position */
+#define PM_STDBYCFG_DPGPDSW_Msk             (_U_(0x1) << PM_STDBYCFG_DPGPDSW_Pos)          /**< (PM_STDBYCFG) Dynamic Power Gating for PDSW Mask */
+#define PM_STDBYCFG_DPGPDSW                 PM_STDBYCFG_DPGPDSW_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PM_STDBYCFG_DPGPDSW_Msk instead */
+#define   PM_STDBYCFG_DPGPDSW_0_Val         _U_(0x0)                                       /**< (PM_STDBYCFG) Dynamic Power Gating disabled  */
+#define   PM_STDBYCFG_DPGPDSW_1_Val         _U_(0x1)                                       /**< (PM_STDBYCFG) Dynamic Power Gating enabled  */
+#define PM_STDBYCFG_DPGPDSW_0               (PM_STDBYCFG_DPGPDSW_0_Val << PM_STDBYCFG_DPGPDSW_Pos)  /**< (PM_STDBYCFG) Dynamic Power Gating disabled Position  */
+#define PM_STDBYCFG_DPGPDSW_1               (PM_STDBYCFG_DPGPDSW_1_Val << PM_STDBYCFG_DPGPDSW_Pos)  /**< (PM_STDBYCFG) Dynamic Power Gating enabled Position  */
+#define PM_STDBYCFG_VREGSMOD_Pos            6                                              /**< (PM_STDBYCFG) Voltage Regulator Standby mode Position */
+#define PM_STDBYCFG_VREGSMOD_Msk            (_U_(0x3) << PM_STDBYCFG_VREGSMOD_Pos)         /**< (PM_STDBYCFG) Voltage Regulator Standby mode Mask */
+#define PM_STDBYCFG_VREGSMOD(value)         (PM_STDBYCFG_VREGSMOD_Msk & ((value) << PM_STDBYCFG_VREGSMOD_Pos))
+#define   PM_STDBYCFG_VREGSMOD_AUTO_Val     _U_(0x0)                                       /**< (PM_STDBYCFG) Automatic mode  */
+#define   PM_STDBYCFG_VREGSMOD_PERFORMANCE_Val _U_(0x1)                                       /**< (PM_STDBYCFG) Performance oriented  */
+#define   PM_STDBYCFG_VREGSMOD_LP_Val       _U_(0x2)                                       /**< (PM_STDBYCFG) Low Power oriented  */
+#define PM_STDBYCFG_VREGSMOD_AUTO           (PM_STDBYCFG_VREGSMOD_AUTO_Val << PM_STDBYCFG_VREGSMOD_Pos)  /**< (PM_STDBYCFG) Automatic mode Position  */
+#define PM_STDBYCFG_VREGSMOD_PERFORMANCE    (PM_STDBYCFG_VREGSMOD_PERFORMANCE_Val << PM_STDBYCFG_VREGSMOD_Pos)  /**< (PM_STDBYCFG) Performance oriented Position  */
+#define PM_STDBYCFG_VREGSMOD_LP             (PM_STDBYCFG_VREGSMOD_LP_Val << PM_STDBYCFG_VREGSMOD_Pos)  /**< (PM_STDBYCFG) Low Power oriented Position  */
+#define PM_STDBYCFG_BBIASHS_Pos             10                                             /**< (PM_STDBYCFG) Back Bias for HSRAM Position */
+#define PM_STDBYCFG_BBIASHS_Msk             (_U_(0x1) << PM_STDBYCFG_BBIASHS_Pos)          /**< (PM_STDBYCFG) Back Bias for HSRAM Mask */
+#define PM_STDBYCFG_BBIASHS                 PM_STDBYCFG_BBIASHS_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PM_STDBYCFG_BBIASHS_Msk instead */
+#define PM_STDBYCFG_BBIASTR_Pos             12                                             /**< (PM_STDBYCFG) Back Bias for Trust RAM Position */
+#define PM_STDBYCFG_BBIASTR_Msk             (_U_(0x1) << PM_STDBYCFG_BBIASTR_Pos)          /**< (PM_STDBYCFG) Back Bias for Trust RAM Mask */
+#define PM_STDBYCFG_BBIASTR                 PM_STDBYCFG_BBIASTR_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PM_STDBYCFG_BBIASTR_Msk instead */
+#define PM_STDBYCFG_MASK                    _U_(0x14D1)                                    /**< \deprecated (PM_STDBYCFG) Register MASK  (Use PM_STDBYCFG_Msk instead)  */
+#define PM_STDBYCFG_Msk                     _U_(0x14D1)                                    /**< (PM_STDBYCFG) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief PM hardware registers */
+typedef struct {  /* Power Manager */
+  __I  uint8_t                        Reserved1[1];
+  __IO PM_SLEEPCFG_Type               SLEEPCFG;       /**< Offset: 0x01 (R/W   8) Sleep Configuration */
+  __IO PM_PLCFG_Type                  PLCFG;          /**< Offset: 0x02 (R/W   8) Performance Level Configuration */
+  __IO PM_PWCFG_Type                  PWCFG;          /**< Offset: 0x03 (R/W   8) Power Configuration */
+  __IO PM_INTENCLR_Type               INTENCLR;       /**< Offset: 0x04 (R/W   8) Interrupt Enable Clear */
+  __IO PM_INTENSET_Type               INTENSET;       /**< Offset: 0x05 (R/W   8) Interrupt Enable Set */
+  __IO PM_INTFLAG_Type                INTFLAG;        /**< Offset: 0x06 (R/W   8) Interrupt Flag Status and Clear */
+  __I  uint8_t                        Reserved2[1];
+  __IO PM_STDBYCFG_Type               STDBYCFG;       /**< Offset: 0x08 (R/W  16) Standby Configuration */
+} Pm;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Power Manager */
+
+#endif /* _SAML10_PM_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/component/port.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/port.h
@@ -1,0 +1,566 @@
+/**
+ * \file
+ *
+ * \brief Component description for PORT
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_PORT_COMPONENT_H_
+#define _SAML10_PORT_COMPONENT_H_
+#define _SAML10_PORT_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML10 Port Module
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR PORT */
+/* ========================================================================== */
+
+#define PORT_U2210                      /**< (PORT) Module ID */
+#define REV_PORT 0x300                  /**< (PORT) Module revision */
+
+/* -------- PORT_DIR : (PORT Offset: 0x00) (R/W 32) Data Direction -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t DIR:32;                    /**< bit:  0..31  Port Data Direction                      */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PORT_DIR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_DIR_OFFSET                     (0x00)                                        /**<  (PORT_DIR) Data Direction  Offset */
+#define PORT_DIR_RESETVALUE                 _U_(0x00)                                     /**<  (PORT_DIR) Data Direction  Reset Value */
+
+#define PORT_DIR_DIR_Pos                    0                                              /**< (PORT_DIR) Port Data Direction Position */
+#define PORT_DIR_DIR_Msk                    (_U_(0xFFFFFFFF) << PORT_DIR_DIR_Pos)          /**< (PORT_DIR) Port Data Direction Mask */
+#define PORT_DIR_DIR(value)                 (PORT_DIR_DIR_Msk & ((value) << PORT_DIR_DIR_Pos))
+#define PORT_DIR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (PORT_DIR) Register MASK  (Use PORT_DIR_Msk instead)  */
+#define PORT_DIR_Msk                        _U_(0xFFFFFFFF)                                /**< (PORT_DIR) Register Mask  */
+
+
+/* -------- PORT_DIRCLR : (PORT Offset: 0x04) (R/W 32) Data Direction Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t DIRCLR:32;                 /**< bit:  0..31  Port Data Direction Clear                */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PORT_DIRCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_DIRCLR_OFFSET                  (0x04)                                        /**<  (PORT_DIRCLR) Data Direction Clear  Offset */
+#define PORT_DIRCLR_RESETVALUE              _U_(0x00)                                     /**<  (PORT_DIRCLR) Data Direction Clear  Reset Value */
+
+#define PORT_DIRCLR_DIRCLR_Pos              0                                              /**< (PORT_DIRCLR) Port Data Direction Clear Position */
+#define PORT_DIRCLR_DIRCLR_Msk              (_U_(0xFFFFFFFF) << PORT_DIRCLR_DIRCLR_Pos)    /**< (PORT_DIRCLR) Port Data Direction Clear Mask */
+#define PORT_DIRCLR_DIRCLR(value)           (PORT_DIRCLR_DIRCLR_Msk & ((value) << PORT_DIRCLR_DIRCLR_Pos))
+#define PORT_DIRCLR_MASK                    _U_(0xFFFFFFFF)                                /**< \deprecated (PORT_DIRCLR) Register MASK  (Use PORT_DIRCLR_Msk instead)  */
+#define PORT_DIRCLR_Msk                     _U_(0xFFFFFFFF)                                /**< (PORT_DIRCLR) Register Mask  */
+
+
+/* -------- PORT_DIRSET : (PORT Offset: 0x08) (R/W 32) Data Direction Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t DIRSET:32;                 /**< bit:  0..31  Port Data Direction Set                  */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PORT_DIRSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_DIRSET_OFFSET                  (0x08)                                        /**<  (PORT_DIRSET) Data Direction Set  Offset */
+#define PORT_DIRSET_RESETVALUE              _U_(0x00)                                     /**<  (PORT_DIRSET) Data Direction Set  Reset Value */
+
+#define PORT_DIRSET_DIRSET_Pos              0                                              /**< (PORT_DIRSET) Port Data Direction Set Position */
+#define PORT_DIRSET_DIRSET_Msk              (_U_(0xFFFFFFFF) << PORT_DIRSET_DIRSET_Pos)    /**< (PORT_DIRSET) Port Data Direction Set Mask */
+#define PORT_DIRSET_DIRSET(value)           (PORT_DIRSET_DIRSET_Msk & ((value) << PORT_DIRSET_DIRSET_Pos))
+#define PORT_DIRSET_MASK                    _U_(0xFFFFFFFF)                                /**< \deprecated (PORT_DIRSET) Register MASK  (Use PORT_DIRSET_Msk instead)  */
+#define PORT_DIRSET_Msk                     _U_(0xFFFFFFFF)                                /**< (PORT_DIRSET) Register Mask  */
+
+
+/* -------- PORT_DIRTGL : (PORT Offset: 0x0c) (R/W 32) Data Direction Toggle -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t DIRTGL:32;                 /**< bit:  0..31  Port Data Direction Toggle               */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PORT_DIRTGL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_DIRTGL_OFFSET                  (0x0C)                                        /**<  (PORT_DIRTGL) Data Direction Toggle  Offset */
+#define PORT_DIRTGL_RESETVALUE              _U_(0x00)                                     /**<  (PORT_DIRTGL) Data Direction Toggle  Reset Value */
+
+#define PORT_DIRTGL_DIRTGL_Pos              0                                              /**< (PORT_DIRTGL) Port Data Direction Toggle Position */
+#define PORT_DIRTGL_DIRTGL_Msk              (_U_(0xFFFFFFFF) << PORT_DIRTGL_DIRTGL_Pos)    /**< (PORT_DIRTGL) Port Data Direction Toggle Mask */
+#define PORT_DIRTGL_DIRTGL(value)           (PORT_DIRTGL_DIRTGL_Msk & ((value) << PORT_DIRTGL_DIRTGL_Pos))
+#define PORT_DIRTGL_MASK                    _U_(0xFFFFFFFF)                                /**< \deprecated (PORT_DIRTGL) Register MASK  (Use PORT_DIRTGL_Msk instead)  */
+#define PORT_DIRTGL_Msk                     _U_(0xFFFFFFFF)                                /**< (PORT_DIRTGL) Register Mask  */
+
+
+/* -------- PORT_OUT : (PORT Offset: 0x10) (R/W 32) Data Output Value -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t OUT:32;                    /**< bit:  0..31  PORT Data Output Value                   */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PORT_OUT_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_OUT_OFFSET                     (0x10)                                        /**<  (PORT_OUT) Data Output Value  Offset */
+#define PORT_OUT_RESETVALUE                 _U_(0x00)                                     /**<  (PORT_OUT) Data Output Value  Reset Value */
+
+#define PORT_OUT_OUT_Pos                    0                                              /**< (PORT_OUT) PORT Data Output Value Position */
+#define PORT_OUT_OUT_Msk                    (_U_(0xFFFFFFFF) << PORT_OUT_OUT_Pos)          /**< (PORT_OUT) PORT Data Output Value Mask */
+#define PORT_OUT_OUT(value)                 (PORT_OUT_OUT_Msk & ((value) << PORT_OUT_OUT_Pos))
+#define PORT_OUT_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (PORT_OUT) Register MASK  (Use PORT_OUT_Msk instead)  */
+#define PORT_OUT_Msk                        _U_(0xFFFFFFFF)                                /**< (PORT_OUT) Register Mask  */
+
+
+/* -------- PORT_OUTCLR : (PORT Offset: 0x14) (R/W 32) Data Output Value Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t OUTCLR:32;                 /**< bit:  0..31  PORT Data Output Value Clear             */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PORT_OUTCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_OUTCLR_OFFSET                  (0x14)                                        /**<  (PORT_OUTCLR) Data Output Value Clear  Offset */
+#define PORT_OUTCLR_RESETVALUE              _U_(0x00)                                     /**<  (PORT_OUTCLR) Data Output Value Clear  Reset Value */
+
+#define PORT_OUTCLR_OUTCLR_Pos              0                                              /**< (PORT_OUTCLR) PORT Data Output Value Clear Position */
+#define PORT_OUTCLR_OUTCLR_Msk              (_U_(0xFFFFFFFF) << PORT_OUTCLR_OUTCLR_Pos)    /**< (PORT_OUTCLR) PORT Data Output Value Clear Mask */
+#define PORT_OUTCLR_OUTCLR(value)           (PORT_OUTCLR_OUTCLR_Msk & ((value) << PORT_OUTCLR_OUTCLR_Pos))
+#define PORT_OUTCLR_MASK                    _U_(0xFFFFFFFF)                                /**< \deprecated (PORT_OUTCLR) Register MASK  (Use PORT_OUTCLR_Msk instead)  */
+#define PORT_OUTCLR_Msk                     _U_(0xFFFFFFFF)                                /**< (PORT_OUTCLR) Register Mask  */
+
+
+/* -------- PORT_OUTSET : (PORT Offset: 0x18) (R/W 32) Data Output Value Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t OUTSET:32;                 /**< bit:  0..31  PORT Data Output Value Set               */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PORT_OUTSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_OUTSET_OFFSET                  (0x18)                                        /**<  (PORT_OUTSET) Data Output Value Set  Offset */
+#define PORT_OUTSET_RESETVALUE              _U_(0x00)                                     /**<  (PORT_OUTSET) Data Output Value Set  Reset Value */
+
+#define PORT_OUTSET_OUTSET_Pos              0                                              /**< (PORT_OUTSET) PORT Data Output Value Set Position */
+#define PORT_OUTSET_OUTSET_Msk              (_U_(0xFFFFFFFF) << PORT_OUTSET_OUTSET_Pos)    /**< (PORT_OUTSET) PORT Data Output Value Set Mask */
+#define PORT_OUTSET_OUTSET(value)           (PORT_OUTSET_OUTSET_Msk & ((value) << PORT_OUTSET_OUTSET_Pos))
+#define PORT_OUTSET_MASK                    _U_(0xFFFFFFFF)                                /**< \deprecated (PORT_OUTSET) Register MASK  (Use PORT_OUTSET_Msk instead)  */
+#define PORT_OUTSET_Msk                     _U_(0xFFFFFFFF)                                /**< (PORT_OUTSET) Register Mask  */
+
+
+/* -------- PORT_OUTTGL : (PORT Offset: 0x1c) (R/W 32) Data Output Value Toggle -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t OUTTGL:32;                 /**< bit:  0..31  PORT Data Output Value Toggle            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PORT_OUTTGL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_OUTTGL_OFFSET                  (0x1C)                                        /**<  (PORT_OUTTGL) Data Output Value Toggle  Offset */
+#define PORT_OUTTGL_RESETVALUE              _U_(0x00)                                     /**<  (PORT_OUTTGL) Data Output Value Toggle  Reset Value */
+
+#define PORT_OUTTGL_OUTTGL_Pos              0                                              /**< (PORT_OUTTGL) PORT Data Output Value Toggle Position */
+#define PORT_OUTTGL_OUTTGL_Msk              (_U_(0xFFFFFFFF) << PORT_OUTTGL_OUTTGL_Pos)    /**< (PORT_OUTTGL) PORT Data Output Value Toggle Mask */
+#define PORT_OUTTGL_OUTTGL(value)           (PORT_OUTTGL_OUTTGL_Msk & ((value) << PORT_OUTTGL_OUTTGL_Pos))
+#define PORT_OUTTGL_MASK                    _U_(0xFFFFFFFF)                                /**< \deprecated (PORT_OUTTGL) Register MASK  (Use PORT_OUTTGL_Msk instead)  */
+#define PORT_OUTTGL_Msk                     _U_(0xFFFFFFFF)                                /**< (PORT_OUTTGL) Register Mask  */
+
+
+/* -------- PORT_IN : (PORT Offset: 0x20) (R/ 32) Data Input Value -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t IN:32;                     /**< bit:  0..31  PORT Data Input Value                    */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PORT_IN_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_IN_OFFSET                      (0x20)                                        /**<  (PORT_IN) Data Input Value  Offset */
+#define PORT_IN_RESETVALUE                  _U_(0x00)                                     /**<  (PORT_IN) Data Input Value  Reset Value */
+
+#define PORT_IN_IN_Pos                      0                                              /**< (PORT_IN) PORT Data Input Value Position */
+#define PORT_IN_IN_Msk                      (_U_(0xFFFFFFFF) << PORT_IN_IN_Pos)            /**< (PORT_IN) PORT Data Input Value Mask */
+#define PORT_IN_IN(value)                   (PORT_IN_IN_Msk & ((value) << PORT_IN_IN_Pos))
+#define PORT_IN_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (PORT_IN) Register MASK  (Use PORT_IN_Msk instead)  */
+#define PORT_IN_Msk                         _U_(0xFFFFFFFF)                                /**< (PORT_IN) Register Mask  */
+
+
+/* -------- PORT_CTRL : (PORT Offset: 0x24) (R/W 32) Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SAMPLING:32;               /**< bit:  0..31  Input Sampling Mode                      */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PORT_CTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_CTRL_OFFSET                    (0x24)                                        /**<  (PORT_CTRL) Control  Offset */
+#define PORT_CTRL_RESETVALUE                _U_(0x00)                                     /**<  (PORT_CTRL) Control  Reset Value */
+
+#define PORT_CTRL_SAMPLING_Pos              0                                              /**< (PORT_CTRL) Input Sampling Mode Position */
+#define PORT_CTRL_SAMPLING_Msk              (_U_(0xFFFFFFFF) << PORT_CTRL_SAMPLING_Pos)    /**< (PORT_CTRL) Input Sampling Mode Mask */
+#define PORT_CTRL_SAMPLING(value)           (PORT_CTRL_SAMPLING_Msk & ((value) << PORT_CTRL_SAMPLING_Pos))
+#define PORT_CTRL_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (PORT_CTRL) Register MASK  (Use PORT_CTRL_Msk instead)  */
+#define PORT_CTRL_Msk                       _U_(0xFFFFFFFF)                                /**< (PORT_CTRL) Register Mask  */
+
+
+/* -------- PORT_WRCONFIG : (PORT Offset: 0x28) (/W 32) Write Configuration -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t PINMASK:16;                /**< bit:  0..15  Pin Mask for Multiple Pin Configuration  */
+    uint32_t PMUXEN:1;                  /**< bit:     16  Peripheral Multiplexer Enable            */
+    uint32_t INEN:1;                    /**< bit:     17  Input Enable                             */
+    uint32_t PULLEN:1;                  /**< bit:     18  Pull Enable                              */
+    uint32_t :3;                        /**< bit: 19..21  Reserved */
+    uint32_t DRVSTR:1;                  /**< bit:     22  Output Driver Strength Selection         */
+    uint32_t :1;                        /**< bit:     23  Reserved */
+    uint32_t PMUX:4;                    /**< bit: 24..27  Peripheral Multiplexing                  */
+    uint32_t WRPMUX:1;                  /**< bit:     28  Write PMUX                               */
+    uint32_t :1;                        /**< bit:     29  Reserved */
+    uint32_t WRPINCFG:1;                /**< bit:     30  Write PINCFG                             */
+    uint32_t HWSEL:1;                   /**< bit:     31  Half-Word Select                         */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PORT_WRCONFIG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_WRCONFIG_OFFSET                (0x28)                                        /**<  (PORT_WRCONFIG) Write Configuration  Offset */
+#define PORT_WRCONFIG_RESETVALUE            _U_(0x00)                                     /**<  (PORT_WRCONFIG) Write Configuration  Reset Value */
+
+#define PORT_WRCONFIG_PINMASK_Pos           0                                              /**< (PORT_WRCONFIG) Pin Mask for Multiple Pin Configuration Position */
+#define PORT_WRCONFIG_PINMASK_Msk           (_U_(0xFFFF) << PORT_WRCONFIG_PINMASK_Pos)     /**< (PORT_WRCONFIG) Pin Mask for Multiple Pin Configuration Mask */
+#define PORT_WRCONFIG_PINMASK(value)        (PORT_WRCONFIG_PINMASK_Msk & ((value) << PORT_WRCONFIG_PINMASK_Pos))
+#define PORT_WRCONFIG_PMUXEN_Pos            16                                             /**< (PORT_WRCONFIG) Peripheral Multiplexer Enable Position */
+#define PORT_WRCONFIG_PMUXEN_Msk            (_U_(0x1) << PORT_WRCONFIG_PMUXEN_Pos)         /**< (PORT_WRCONFIG) Peripheral Multiplexer Enable Mask */
+#define PORT_WRCONFIG_PMUXEN                PORT_WRCONFIG_PMUXEN_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PORT_WRCONFIG_PMUXEN_Msk instead */
+#define PORT_WRCONFIG_INEN_Pos              17                                             /**< (PORT_WRCONFIG) Input Enable Position */
+#define PORT_WRCONFIG_INEN_Msk              (_U_(0x1) << PORT_WRCONFIG_INEN_Pos)           /**< (PORT_WRCONFIG) Input Enable Mask */
+#define PORT_WRCONFIG_INEN                  PORT_WRCONFIG_INEN_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PORT_WRCONFIG_INEN_Msk instead */
+#define PORT_WRCONFIG_PULLEN_Pos            18                                             /**< (PORT_WRCONFIG) Pull Enable Position */
+#define PORT_WRCONFIG_PULLEN_Msk            (_U_(0x1) << PORT_WRCONFIG_PULLEN_Pos)         /**< (PORT_WRCONFIG) Pull Enable Mask */
+#define PORT_WRCONFIG_PULLEN                PORT_WRCONFIG_PULLEN_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PORT_WRCONFIG_PULLEN_Msk instead */
+#define PORT_WRCONFIG_DRVSTR_Pos            22                                             /**< (PORT_WRCONFIG) Output Driver Strength Selection Position */
+#define PORT_WRCONFIG_DRVSTR_Msk            (_U_(0x1) << PORT_WRCONFIG_DRVSTR_Pos)         /**< (PORT_WRCONFIG) Output Driver Strength Selection Mask */
+#define PORT_WRCONFIG_DRVSTR                PORT_WRCONFIG_DRVSTR_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PORT_WRCONFIG_DRVSTR_Msk instead */
+#define PORT_WRCONFIG_PMUX_Pos              24                                             /**< (PORT_WRCONFIG) Peripheral Multiplexing Position */
+#define PORT_WRCONFIG_PMUX_Msk              (_U_(0xF) << PORT_WRCONFIG_PMUX_Pos)           /**< (PORT_WRCONFIG) Peripheral Multiplexing Mask */
+#define PORT_WRCONFIG_PMUX(value)           (PORT_WRCONFIG_PMUX_Msk & ((value) << PORT_WRCONFIG_PMUX_Pos))
+#define PORT_WRCONFIG_WRPMUX_Pos            28                                             /**< (PORT_WRCONFIG) Write PMUX Position */
+#define PORT_WRCONFIG_WRPMUX_Msk            (_U_(0x1) << PORT_WRCONFIG_WRPMUX_Pos)         /**< (PORT_WRCONFIG) Write PMUX Mask */
+#define PORT_WRCONFIG_WRPMUX                PORT_WRCONFIG_WRPMUX_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PORT_WRCONFIG_WRPMUX_Msk instead */
+#define PORT_WRCONFIG_WRPINCFG_Pos          30                                             /**< (PORT_WRCONFIG) Write PINCFG Position */
+#define PORT_WRCONFIG_WRPINCFG_Msk          (_U_(0x1) << PORT_WRCONFIG_WRPINCFG_Pos)       /**< (PORT_WRCONFIG) Write PINCFG Mask */
+#define PORT_WRCONFIG_WRPINCFG              PORT_WRCONFIG_WRPINCFG_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use PORT_WRCONFIG_WRPINCFG_Msk instead */
+#define PORT_WRCONFIG_HWSEL_Pos             31                                             /**< (PORT_WRCONFIG) Half-Word Select Position */
+#define PORT_WRCONFIG_HWSEL_Msk             (_U_(0x1) << PORT_WRCONFIG_HWSEL_Pos)          /**< (PORT_WRCONFIG) Half-Word Select Mask */
+#define PORT_WRCONFIG_HWSEL                 PORT_WRCONFIG_HWSEL_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PORT_WRCONFIG_HWSEL_Msk instead */
+#define PORT_WRCONFIG_Msk                   _U_(0xDF47FFFF)                                /**< (PORT_WRCONFIG) Register Mask  */
+
+
+/* -------- PORT_EVCTRL : (PORT Offset: 0x2c) (R/W 32) Event Input Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t PID0:5;                    /**< bit:   0..4  PORT Event Pin Identifier 0              */
+    uint32_t EVACT0:2;                  /**< bit:   5..6  PORT Event Action 0                      */
+    uint32_t PORTEI0:1;                 /**< bit:      7  PORT Event Input Enable 0                */
+    uint32_t PID1:5;                    /**< bit:  8..12  PORT Event Pin Identifier 1              */
+    uint32_t EVACT1:2;                  /**< bit: 13..14  PORT Event Action 1                      */
+    uint32_t PORTEI1:1;                 /**< bit:     15  PORT Event Input Enable 1                */
+    uint32_t PID2:5;                    /**< bit: 16..20  PORT Event Pin Identifier 2              */
+    uint32_t EVACT2:2;                  /**< bit: 21..22  PORT Event Action 2                      */
+    uint32_t PORTEI2:1;                 /**< bit:     23  PORT Event Input Enable 2                */
+    uint32_t PID3:5;                    /**< bit: 24..28  PORT Event Pin Identifier 3              */
+    uint32_t EVACT3:2;                  /**< bit: 29..30  PORT Event Action 3                      */
+    uint32_t PORTEI3:1;                 /**< bit:     31  PORT Event Input Enable 3                */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PORT_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_EVCTRL_OFFSET                  (0x2C)                                        /**<  (PORT_EVCTRL) Event Input Control  Offset */
+#define PORT_EVCTRL_RESETVALUE              _U_(0x00)                                     /**<  (PORT_EVCTRL) Event Input Control  Reset Value */
+
+#define PORT_EVCTRL_PID0_Pos                0                                              /**< (PORT_EVCTRL) PORT Event Pin Identifier 0 Position */
+#define PORT_EVCTRL_PID0_Msk                (_U_(0x1F) << PORT_EVCTRL_PID0_Pos)            /**< (PORT_EVCTRL) PORT Event Pin Identifier 0 Mask */
+#define PORT_EVCTRL_PID0(value)             (PORT_EVCTRL_PID0_Msk & ((value) << PORT_EVCTRL_PID0_Pos))
+#define PORT_EVCTRL_EVACT0_Pos              5                                              /**< (PORT_EVCTRL) PORT Event Action 0 Position */
+#define PORT_EVCTRL_EVACT0_Msk              (_U_(0x3) << PORT_EVCTRL_EVACT0_Pos)           /**< (PORT_EVCTRL) PORT Event Action 0 Mask */
+#define PORT_EVCTRL_EVACT0(value)           (PORT_EVCTRL_EVACT0_Msk & ((value) << PORT_EVCTRL_EVACT0_Pos))
+#define   PORT_EVCTRL_EVACT0_OUT_Val        _U_(0x0)                                       /**< (PORT_EVCTRL) Event output to pin  */
+#define   PORT_EVCTRL_EVACT0_SET_Val        _U_(0x1)                                       /**< (PORT_EVCTRL) Set output register of pin on event  */
+#define   PORT_EVCTRL_EVACT0_CLR_Val        _U_(0x2)                                       /**< (PORT_EVCTRL) Clear output register of pin on event  */
+#define   PORT_EVCTRL_EVACT0_TGL_Val        _U_(0x3)                                       /**< (PORT_EVCTRL) Toggle output register of pin on event  */
+#define PORT_EVCTRL_EVACT0_OUT              (PORT_EVCTRL_EVACT0_OUT_Val << PORT_EVCTRL_EVACT0_Pos)  /**< (PORT_EVCTRL) Event output to pin Position  */
+#define PORT_EVCTRL_EVACT0_SET              (PORT_EVCTRL_EVACT0_SET_Val << PORT_EVCTRL_EVACT0_Pos)  /**< (PORT_EVCTRL) Set output register of pin on event Position  */
+#define PORT_EVCTRL_EVACT0_CLR              (PORT_EVCTRL_EVACT0_CLR_Val << PORT_EVCTRL_EVACT0_Pos)  /**< (PORT_EVCTRL) Clear output register of pin on event Position  */
+#define PORT_EVCTRL_EVACT0_TGL              (PORT_EVCTRL_EVACT0_TGL_Val << PORT_EVCTRL_EVACT0_Pos)  /**< (PORT_EVCTRL) Toggle output register of pin on event Position  */
+#define PORT_EVCTRL_PORTEI0_Pos             7                                              /**< (PORT_EVCTRL) PORT Event Input Enable 0 Position */
+#define PORT_EVCTRL_PORTEI0_Msk             (_U_(0x1) << PORT_EVCTRL_PORTEI0_Pos)          /**< (PORT_EVCTRL) PORT Event Input Enable 0 Mask */
+#define PORT_EVCTRL_PORTEI0                 PORT_EVCTRL_PORTEI0_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PORT_EVCTRL_PORTEI0_Msk instead */
+#define PORT_EVCTRL_PID1_Pos                8                                              /**< (PORT_EVCTRL) PORT Event Pin Identifier 1 Position */
+#define PORT_EVCTRL_PID1_Msk                (_U_(0x1F) << PORT_EVCTRL_PID1_Pos)            /**< (PORT_EVCTRL) PORT Event Pin Identifier 1 Mask */
+#define PORT_EVCTRL_PID1(value)             (PORT_EVCTRL_PID1_Msk & ((value) << PORT_EVCTRL_PID1_Pos))
+#define PORT_EVCTRL_EVACT1_Pos              13                                             /**< (PORT_EVCTRL) PORT Event Action 1 Position */
+#define PORT_EVCTRL_EVACT1_Msk              (_U_(0x3) << PORT_EVCTRL_EVACT1_Pos)           /**< (PORT_EVCTRL) PORT Event Action 1 Mask */
+#define PORT_EVCTRL_EVACT1(value)           (PORT_EVCTRL_EVACT1_Msk & ((value) << PORT_EVCTRL_EVACT1_Pos))
+#define PORT_EVCTRL_PORTEI1_Pos             15                                             /**< (PORT_EVCTRL) PORT Event Input Enable 1 Position */
+#define PORT_EVCTRL_PORTEI1_Msk             (_U_(0x1) << PORT_EVCTRL_PORTEI1_Pos)          /**< (PORT_EVCTRL) PORT Event Input Enable 1 Mask */
+#define PORT_EVCTRL_PORTEI1                 PORT_EVCTRL_PORTEI1_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PORT_EVCTRL_PORTEI1_Msk instead */
+#define PORT_EVCTRL_PID2_Pos                16                                             /**< (PORT_EVCTRL) PORT Event Pin Identifier 2 Position */
+#define PORT_EVCTRL_PID2_Msk                (_U_(0x1F) << PORT_EVCTRL_PID2_Pos)            /**< (PORT_EVCTRL) PORT Event Pin Identifier 2 Mask */
+#define PORT_EVCTRL_PID2(value)             (PORT_EVCTRL_PID2_Msk & ((value) << PORT_EVCTRL_PID2_Pos))
+#define PORT_EVCTRL_EVACT2_Pos              21                                             /**< (PORT_EVCTRL) PORT Event Action 2 Position */
+#define PORT_EVCTRL_EVACT2_Msk              (_U_(0x3) << PORT_EVCTRL_EVACT2_Pos)           /**< (PORT_EVCTRL) PORT Event Action 2 Mask */
+#define PORT_EVCTRL_EVACT2(value)           (PORT_EVCTRL_EVACT2_Msk & ((value) << PORT_EVCTRL_EVACT2_Pos))
+#define PORT_EVCTRL_PORTEI2_Pos             23                                             /**< (PORT_EVCTRL) PORT Event Input Enable 2 Position */
+#define PORT_EVCTRL_PORTEI2_Msk             (_U_(0x1) << PORT_EVCTRL_PORTEI2_Pos)          /**< (PORT_EVCTRL) PORT Event Input Enable 2 Mask */
+#define PORT_EVCTRL_PORTEI2                 PORT_EVCTRL_PORTEI2_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PORT_EVCTRL_PORTEI2_Msk instead */
+#define PORT_EVCTRL_PID3_Pos                24                                             /**< (PORT_EVCTRL) PORT Event Pin Identifier 3 Position */
+#define PORT_EVCTRL_PID3_Msk                (_U_(0x1F) << PORT_EVCTRL_PID3_Pos)            /**< (PORT_EVCTRL) PORT Event Pin Identifier 3 Mask */
+#define PORT_EVCTRL_PID3(value)             (PORT_EVCTRL_PID3_Msk & ((value) << PORT_EVCTRL_PID3_Pos))
+#define PORT_EVCTRL_EVACT3_Pos              29                                             /**< (PORT_EVCTRL) PORT Event Action 3 Position */
+#define PORT_EVCTRL_EVACT3_Msk              (_U_(0x3) << PORT_EVCTRL_EVACT3_Pos)           /**< (PORT_EVCTRL) PORT Event Action 3 Mask */
+#define PORT_EVCTRL_EVACT3(value)           (PORT_EVCTRL_EVACT3_Msk & ((value) << PORT_EVCTRL_EVACT3_Pos))
+#define PORT_EVCTRL_PORTEI3_Pos             31                                             /**< (PORT_EVCTRL) PORT Event Input Enable 3 Position */
+#define PORT_EVCTRL_PORTEI3_Msk             (_U_(0x1) << PORT_EVCTRL_PORTEI3_Pos)          /**< (PORT_EVCTRL) PORT Event Input Enable 3 Mask */
+#define PORT_EVCTRL_PORTEI3                 PORT_EVCTRL_PORTEI3_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PORT_EVCTRL_PORTEI3_Msk instead */
+#define PORT_EVCTRL_MASK                    _U_(0xFFFFFFFF)                                /**< \deprecated (PORT_EVCTRL) Register MASK  (Use PORT_EVCTRL_Msk instead)  */
+#define PORT_EVCTRL_Msk                     _U_(0xFFFFFFFF)                                /**< (PORT_EVCTRL) Register Mask  */
+
+
+/* -------- PORT_PMUX : (PORT Offset: 0x30) (R/W 8) Peripheral Multiplexing -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  PMUXE:4;                   /**< bit:   0..3  Peripheral Multiplexing for Even-Numbered Pin */
+    uint8_t  PMUXO:4;                   /**< bit:   4..7  Peripheral Multiplexing for Odd-Numbered Pin */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} PORT_PMUX_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_PMUX_OFFSET                    (0x30)                                        /**<  (PORT_PMUX) Peripheral Multiplexing  Offset */
+#define PORT_PMUX_RESETVALUE                _U_(0x00)                                     /**<  (PORT_PMUX) Peripheral Multiplexing  Reset Value */
+
+#define PORT_PMUX_PMUXE_Pos                 0                                              /**< (PORT_PMUX) Peripheral Multiplexing for Even-Numbered Pin Position */
+#define PORT_PMUX_PMUXE_Msk                 (_U_(0xF) << PORT_PMUX_PMUXE_Pos)              /**< (PORT_PMUX) Peripheral Multiplexing for Even-Numbered Pin Mask */
+#define PORT_PMUX_PMUXE(value)              (PORT_PMUX_PMUXE_Msk & ((value) << PORT_PMUX_PMUXE_Pos))
+#define PORT_PMUX_PMUXO_Pos                 4                                              /**< (PORT_PMUX) Peripheral Multiplexing for Odd-Numbered Pin Position */
+#define PORT_PMUX_PMUXO_Msk                 (_U_(0xF) << PORT_PMUX_PMUXO_Pos)              /**< (PORT_PMUX) Peripheral Multiplexing for Odd-Numbered Pin Mask */
+#define PORT_PMUX_PMUXO(value)              (PORT_PMUX_PMUXO_Msk & ((value) << PORT_PMUX_PMUXO_Pos))
+#define PORT_PMUX_MASK                      _U_(0xFF)                                      /**< \deprecated (PORT_PMUX) Register MASK  (Use PORT_PMUX_Msk instead)  */
+#define PORT_PMUX_Msk                       _U_(0xFF)                                      /**< (PORT_PMUX) Register Mask  */
+
+
+/* -------- PORT_PINCFG : (PORT Offset: 0x40) (R/W 8) Pin Configuration -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  PMUXEN:1;                  /**< bit:      0  Peripheral Multiplexer Enable            */
+    uint8_t  INEN:1;                    /**< bit:      1  Input Enable                             */
+    uint8_t  PULLEN:1;                  /**< bit:      2  Pull Enable                              */
+    uint8_t  :3;                        /**< bit:   3..5  Reserved */
+    uint8_t  DRVSTR:1;                  /**< bit:      6  Output Driver Strength Selection         */
+    uint8_t  :1;                        /**< bit:      7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} PORT_PINCFG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_PINCFG_OFFSET                  (0x40)                                        /**<  (PORT_PINCFG) Pin Configuration  Offset */
+#define PORT_PINCFG_RESETVALUE              _U_(0x00)                                     /**<  (PORT_PINCFG) Pin Configuration  Reset Value */
+
+#define PORT_PINCFG_PMUXEN_Pos              0                                              /**< (PORT_PINCFG) Peripheral Multiplexer Enable Position */
+#define PORT_PINCFG_PMUXEN_Msk              (_U_(0x1) << PORT_PINCFG_PMUXEN_Pos)           /**< (PORT_PINCFG) Peripheral Multiplexer Enable Mask */
+#define PORT_PINCFG_PMUXEN                  PORT_PINCFG_PMUXEN_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PORT_PINCFG_PMUXEN_Msk instead */
+#define PORT_PINCFG_INEN_Pos                1                                              /**< (PORT_PINCFG) Input Enable Position */
+#define PORT_PINCFG_INEN_Msk                (_U_(0x1) << PORT_PINCFG_INEN_Pos)             /**< (PORT_PINCFG) Input Enable Mask */
+#define PORT_PINCFG_INEN                    PORT_PINCFG_INEN_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PORT_PINCFG_INEN_Msk instead */
+#define PORT_PINCFG_PULLEN_Pos              2                                              /**< (PORT_PINCFG) Pull Enable Position */
+#define PORT_PINCFG_PULLEN_Msk              (_U_(0x1) << PORT_PINCFG_PULLEN_Pos)           /**< (PORT_PINCFG) Pull Enable Mask */
+#define PORT_PINCFG_PULLEN                  PORT_PINCFG_PULLEN_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PORT_PINCFG_PULLEN_Msk instead */
+#define PORT_PINCFG_DRVSTR_Pos              6                                              /**< (PORT_PINCFG) Output Driver Strength Selection Position */
+#define PORT_PINCFG_DRVSTR_Msk              (_U_(0x1) << PORT_PINCFG_DRVSTR_Pos)           /**< (PORT_PINCFG) Output Driver Strength Selection Mask */
+#define PORT_PINCFG_DRVSTR                  PORT_PINCFG_DRVSTR_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PORT_PINCFG_DRVSTR_Msk instead */
+#define PORT_PINCFG_MASK                    _U_(0x47)                                      /**< \deprecated (PORT_PINCFG) Register MASK  (Use PORT_PINCFG_Msk instead)  */
+#define PORT_PINCFG_Msk                     _U_(0x47)                                      /**< (PORT_PINCFG) Register Mask  */
+
+
+/* -------- PORT_INTENCLR : (PORT Offset: 0x60) (R/W 32) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t NSCHK:1;                   /**< bit:      0  Non-Secure Check Interrupt Enable        */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PORT_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_INTENCLR_OFFSET                (0x60)                                        /**<  (PORT_INTENCLR) Interrupt Enable Clear  Offset */
+#define PORT_INTENCLR_RESETVALUE            _U_(0x00)                                     /**<  (PORT_INTENCLR) Interrupt Enable Clear  Reset Value */
+
+#define PORT_INTENCLR_NSCHK_Pos             0                                              /**< (PORT_INTENCLR) Non-Secure Check Interrupt Enable Position */
+#define PORT_INTENCLR_NSCHK_Msk             (_U_(0x1) << PORT_INTENCLR_NSCHK_Pos)          /**< (PORT_INTENCLR) Non-Secure Check Interrupt Enable Mask */
+#define PORT_INTENCLR_NSCHK                 PORT_INTENCLR_NSCHK_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PORT_INTENCLR_NSCHK_Msk instead */
+#define PORT_INTENCLR_MASK                  _U_(0x01)                                      /**< \deprecated (PORT_INTENCLR) Register MASK  (Use PORT_INTENCLR_Msk instead)  */
+#define PORT_INTENCLR_Msk                   _U_(0x01)                                      /**< (PORT_INTENCLR) Register Mask  */
+
+
+/* -------- PORT_INTENSET : (PORT Offset: 0x64) (R/W 32) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t NSCHK:1;                   /**< bit:      0  Non-Secure Check Interrupt Enable        */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PORT_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_INTENSET_OFFSET                (0x64)                                        /**<  (PORT_INTENSET) Interrupt Enable Set  Offset */
+#define PORT_INTENSET_RESETVALUE            _U_(0x00)                                     /**<  (PORT_INTENSET) Interrupt Enable Set  Reset Value */
+
+#define PORT_INTENSET_NSCHK_Pos             0                                              /**< (PORT_INTENSET) Non-Secure Check Interrupt Enable Position */
+#define PORT_INTENSET_NSCHK_Msk             (_U_(0x1) << PORT_INTENSET_NSCHK_Pos)          /**< (PORT_INTENSET) Non-Secure Check Interrupt Enable Mask */
+#define PORT_INTENSET_NSCHK                 PORT_INTENSET_NSCHK_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PORT_INTENSET_NSCHK_Msk instead */
+#define PORT_INTENSET_MASK                  _U_(0x01)                                      /**< \deprecated (PORT_INTENSET) Register MASK  (Use PORT_INTENSET_Msk instead)  */
+#define PORT_INTENSET_Msk                   _U_(0x01)                                      /**< (PORT_INTENSET) Register Mask  */
+
+
+/* -------- PORT_INTFLAG : (PORT Offset: 0x68) (R/W 32) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint32_t NSCHK:1;                   /**< bit:      0  Non-Secure Check                         */
+    __I uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PORT_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_INTFLAG_OFFSET                 (0x68)                                        /**<  (PORT_INTFLAG) Interrupt Flag Status and Clear  Offset */
+#define PORT_INTFLAG_RESETVALUE             _U_(0x00)                                     /**<  (PORT_INTFLAG) Interrupt Flag Status and Clear  Reset Value */
+
+#define PORT_INTFLAG_NSCHK_Pos              0                                              /**< (PORT_INTFLAG) Non-Secure Check Position */
+#define PORT_INTFLAG_NSCHK_Msk              (_U_(0x1) << PORT_INTFLAG_NSCHK_Pos)           /**< (PORT_INTFLAG) Non-Secure Check Mask */
+#define PORT_INTFLAG_NSCHK                  PORT_INTFLAG_NSCHK_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PORT_INTFLAG_NSCHK_Msk instead */
+#define PORT_INTFLAG_MASK                   _U_(0x01)                                      /**< \deprecated (PORT_INTFLAG) Register MASK  (Use PORT_INTFLAG_Msk instead)  */
+#define PORT_INTFLAG_Msk                    _U_(0x01)                                      /**< (PORT_INTFLAG) Register Mask  */
+
+
+/* -------- PORT_NONSEC : (PORT Offset: 0x6c) (R/W 32) Security Attribution -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t NONSEC:32;                 /**< bit:  0..31  Port Security Attribution                */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PORT_NONSEC_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_NONSEC_OFFSET                  (0x6C)                                        /**<  (PORT_NONSEC) Security Attribution  Offset */
+#define PORT_NONSEC_RESETVALUE              _U_(0x00)                                     /**<  (PORT_NONSEC) Security Attribution  Reset Value */
+
+#define PORT_NONSEC_NONSEC_Pos              0                                              /**< (PORT_NONSEC) Port Security Attribution Position */
+#define PORT_NONSEC_NONSEC_Msk              (_U_(0xFFFFFFFF) << PORT_NONSEC_NONSEC_Pos)    /**< (PORT_NONSEC) Port Security Attribution Mask */
+#define PORT_NONSEC_NONSEC(value)           (PORT_NONSEC_NONSEC_Msk & ((value) << PORT_NONSEC_NONSEC_Pos))
+#define PORT_NONSEC_MASK                    _U_(0xFFFFFFFF)                                /**< \deprecated (PORT_NONSEC) Register MASK  (Use PORT_NONSEC_Msk instead)  */
+#define PORT_NONSEC_Msk                     _U_(0xFFFFFFFF)                                /**< (PORT_NONSEC) Register Mask  */
+
+
+/* -------- PORT_NSCHK : (PORT Offset: 0x70) (R/W 32) Security Attribution Check -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t NSCHK:32;                  /**< bit:  0..31  Port Security Attribution Check          */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PORT_NSCHK_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_NSCHK_OFFSET                   (0x70)                                        /**<  (PORT_NSCHK) Security Attribution Check  Offset */
+#define PORT_NSCHK_RESETVALUE               _U_(0x00)                                     /**<  (PORT_NSCHK) Security Attribution Check  Reset Value */
+
+#define PORT_NSCHK_NSCHK_Pos                0                                              /**< (PORT_NSCHK) Port Security Attribution Check Position */
+#define PORT_NSCHK_NSCHK_Msk                (_U_(0xFFFFFFFF) << PORT_NSCHK_NSCHK_Pos)      /**< (PORT_NSCHK) Port Security Attribution Check Mask */
+#define PORT_NSCHK_NSCHK(value)             (PORT_NSCHK_NSCHK_Msk & ((value) << PORT_NSCHK_NSCHK_Pos))
+#define PORT_NSCHK_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (PORT_NSCHK) Register MASK  (Use PORT_NSCHK_Msk instead)  */
+#define PORT_NSCHK_Msk                      _U_(0xFFFFFFFF)                                /**< (PORT_NSCHK) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief GROUP hardware registers */
+typedef struct {  
+  __IO PORT_DIR_Type                  DIR;            /**< Offset: 0x00 (R/W  32) Data Direction */
+  __IO PORT_DIRCLR_Type               DIRCLR;         /**< Offset: 0x04 (R/W  32) Data Direction Clear */
+  __IO PORT_DIRSET_Type               DIRSET;         /**< Offset: 0x08 (R/W  32) Data Direction Set */
+  __IO PORT_DIRTGL_Type               DIRTGL;         /**< Offset: 0x0C (R/W  32) Data Direction Toggle */
+  __IO PORT_OUT_Type                  OUT;            /**< Offset: 0x10 (R/W  32) Data Output Value */
+  __IO PORT_OUTCLR_Type               OUTCLR;         /**< Offset: 0x14 (R/W  32) Data Output Value Clear */
+  __IO PORT_OUTSET_Type               OUTSET;         /**< Offset: 0x18 (R/W  32) Data Output Value Set */
+  __IO PORT_OUTTGL_Type               OUTTGL;         /**< Offset: 0x1C (R/W  32) Data Output Value Toggle */
+  __I  PORT_IN_Type                   IN;             /**< Offset: 0x20 (R/   32) Data Input Value */
+  __IO PORT_CTRL_Type                 CTRL;           /**< Offset: 0x24 (R/W  32) Control */
+  __O  PORT_WRCONFIG_Type             WRCONFIG;       /**< Offset: 0x28 ( /W  32) Write Configuration */
+  __IO PORT_EVCTRL_Type               EVCTRL;         /**< Offset: 0x2C (R/W  32) Event Input Control */
+  __IO PORT_PMUX_Type                 PMUX[16];       /**< Offset: 0x30 (R/W   8) Peripheral Multiplexing */
+  __IO PORT_PINCFG_Type               PINCFG[32];     /**< Offset: 0x40 (R/W   8) Pin Configuration */
+  __IO PORT_INTENCLR_Type             INTENCLR;       /**< Offset: 0x60 (R/W  32) Interrupt Enable Clear */
+  __IO PORT_INTENSET_Type             INTENSET;       /**< Offset: 0x64 (R/W  32) Interrupt Enable Set */
+  __IO PORT_INTFLAG_Type              INTFLAG;        /**< Offset: 0x68 (R/W  32) Interrupt Flag Status and Clear */
+  __IO PORT_NONSEC_Type               NONSEC;         /**< Offset: 0x6C (R/W  32) Security Attribution */
+  __IO PORT_NSCHK_Type                NSCHK;          /**< Offset: 0x70 (R/W  32) Security Attribution Check */
+  __I  uint8_t                        Reserved1[12];
+} PortGroup;
+
+/** \brief PORT hardware registers */
+typedef struct {  /* Port Module */
+       PortGroup                      Group[1];       /**< Offset: 0x00  */
+} Port;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Port Module */
+
+#endif /* _SAML10_PORT_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/component/ptc.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/ptc.h
@@ -1,0 +1,53 @@
+/**
+ * \file
+ *
+ * \brief Component description for PTC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_PTC_COMPONENT_H_
+#define _SAML10_PTC_COMPONENT_H_
+#define _SAML10_PTC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML10 Peripheral Touch Controller
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR PTC */
+/* ========================================================================== */
+
+#define PTC_U2215                      /**< (PTC) Module ID */
+#define REV_PTC 0x500                  /**< (PTC) Module revision */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief No hardware registers defined for PTC */
+typedef void Ptc;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Peripheral Touch Controller */
+
+#endif /* _SAML10_PTC_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/component/rstc.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/rstc.h
@@ -1,0 +1,96 @@
+/**
+ * \file
+ *
+ * \brief Component description for RSTC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_RSTC_COMPONENT_H_
+#define _SAML10_RSTC_COMPONENT_H_
+#define _SAML10_RSTC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML10 Reset Controller
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR RSTC */
+/* ========================================================================== */
+
+#define RSTC_U2239                      /**< (RSTC) Module ID */
+#define REV_RSTC 0x300                  /**< (RSTC) Module revision */
+
+/* -------- RSTC_RCAUSE : (RSTC Offset: 0x00) (R/ 8) Reset Cause -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  POR:1;                     /**< bit:      0  Power On Reset                           */
+    uint8_t  BODCORE:1;                 /**< bit:      1  Brown Out CORE Detector Reset            */
+    uint8_t  BODVDD:1;                  /**< bit:      2  Brown Out VDD Detector Reset             */
+    uint8_t  :1;                        /**< bit:      3  Reserved */
+    uint8_t  EXT:1;                     /**< bit:      4  External Reset                           */
+    uint8_t  WDT:1;                     /**< bit:      5  Watchdog Reset                           */
+    uint8_t  SYST:1;                    /**< bit:      6  System Reset Request                     */
+    uint8_t  :1;                        /**< bit:      7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} RSTC_RCAUSE_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RSTC_RCAUSE_OFFSET                  (0x00)                                        /**<  (RSTC_RCAUSE) Reset Cause  Offset */
+
+#define RSTC_RCAUSE_POR_Pos                 0                                              /**< (RSTC_RCAUSE) Power On Reset Position */
+#define RSTC_RCAUSE_POR_Msk                 (_U_(0x1) << RSTC_RCAUSE_POR_Pos)              /**< (RSTC_RCAUSE) Power On Reset Mask */
+#define RSTC_RCAUSE_POR                     RSTC_RCAUSE_POR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use RSTC_RCAUSE_POR_Msk instead */
+#define RSTC_RCAUSE_BODCORE_Pos             1                                              /**< (RSTC_RCAUSE) Brown Out CORE Detector Reset Position */
+#define RSTC_RCAUSE_BODCORE_Msk             (_U_(0x1) << RSTC_RCAUSE_BODCORE_Pos)          /**< (RSTC_RCAUSE) Brown Out CORE Detector Reset Mask */
+#define RSTC_RCAUSE_BODCORE                 RSTC_RCAUSE_BODCORE_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use RSTC_RCAUSE_BODCORE_Msk instead */
+#define RSTC_RCAUSE_BODVDD_Pos              2                                              /**< (RSTC_RCAUSE) Brown Out VDD Detector Reset Position */
+#define RSTC_RCAUSE_BODVDD_Msk              (_U_(0x1) << RSTC_RCAUSE_BODVDD_Pos)           /**< (RSTC_RCAUSE) Brown Out VDD Detector Reset Mask */
+#define RSTC_RCAUSE_BODVDD                  RSTC_RCAUSE_BODVDD_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use RSTC_RCAUSE_BODVDD_Msk instead */
+#define RSTC_RCAUSE_EXT_Pos                 4                                              /**< (RSTC_RCAUSE) External Reset Position */
+#define RSTC_RCAUSE_EXT_Msk                 (_U_(0x1) << RSTC_RCAUSE_EXT_Pos)              /**< (RSTC_RCAUSE) External Reset Mask */
+#define RSTC_RCAUSE_EXT                     RSTC_RCAUSE_EXT_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use RSTC_RCAUSE_EXT_Msk instead */
+#define RSTC_RCAUSE_WDT_Pos                 5                                              /**< (RSTC_RCAUSE) Watchdog Reset Position */
+#define RSTC_RCAUSE_WDT_Msk                 (_U_(0x1) << RSTC_RCAUSE_WDT_Pos)              /**< (RSTC_RCAUSE) Watchdog Reset Mask */
+#define RSTC_RCAUSE_WDT                     RSTC_RCAUSE_WDT_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use RSTC_RCAUSE_WDT_Msk instead */
+#define RSTC_RCAUSE_SYST_Pos                6                                              /**< (RSTC_RCAUSE) System Reset Request Position */
+#define RSTC_RCAUSE_SYST_Msk                (_U_(0x1) << RSTC_RCAUSE_SYST_Pos)             /**< (RSTC_RCAUSE) System Reset Request Mask */
+#define RSTC_RCAUSE_SYST                    RSTC_RCAUSE_SYST_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use RSTC_RCAUSE_SYST_Msk instead */
+#define RSTC_RCAUSE_MASK                    _U_(0x77)                                      /**< \deprecated (RSTC_RCAUSE) Register MASK  (Use RSTC_RCAUSE_Msk instead)  */
+#define RSTC_RCAUSE_Msk                     _U_(0x77)                                      /**< (RSTC_RCAUSE) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief RSTC hardware registers */
+typedef struct {  /* Reset Controller */
+  __I  RSTC_RCAUSE_Type               RCAUSE;         /**< Offset: 0x00 (R/    8) Reset Cause */
+} Rstc;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Reset Controller */
+
+#endif /* _SAML10_RSTC_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/component/rtc.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/rtc.h
@@ -1,0 +1,2294 @@
+/**
+ * \file
+ *
+ * \brief Component description for RTC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_RTC_COMPONENT_H_
+#define _SAML10_RTC_COMPONENT_H_
+#define _SAML10_RTC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML10 Real-Time Counter
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR RTC */
+/* ========================================================================== */
+
+#define RTC_U2250                      /**< (RTC) Module ID */
+#define REV_RTC 0x300                  /**< (RTC) Module revision */
+
+/* -------- RTC_MODE2_ALARM : (RTC Offset: 0x00) (R/W 32) MODE2_ALARM Alarm n Value -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SECOND:6;                  /**< bit:   0..5  Second                                   */
+    uint32_t MINUTE:6;                  /**< bit:  6..11  Minute                                   */
+    uint32_t HOUR:5;                    /**< bit: 12..16  Hour                                     */
+    uint32_t DAY:5;                     /**< bit: 17..21  Day                                      */
+    uint32_t MONTH:4;                   /**< bit: 22..25  Month                                    */
+    uint32_t YEAR:6;                    /**< bit: 26..31  Year                                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_MODE2_ALARM_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE2_ALARM_OFFSET              (0x00)                                        /**<  (RTC_MODE2_ALARM) MODE2_ALARM Alarm n Value  Offset */
+#define RTC_MODE2_ALARM_RESETVALUE          _U_(0x00)                                     /**<  (RTC_MODE2_ALARM) MODE2_ALARM Alarm n Value  Reset Value */
+
+#define RTC_MODE2_ALARM_SECOND_Pos          0                                              /**< (RTC_MODE2_ALARM) Second Position */
+#define RTC_MODE2_ALARM_SECOND_Msk          (_U_(0x3F) << RTC_MODE2_ALARM_SECOND_Pos)      /**< (RTC_MODE2_ALARM) Second Mask */
+#define RTC_MODE2_ALARM_SECOND(value)       (RTC_MODE2_ALARM_SECOND_Msk & ((value) << RTC_MODE2_ALARM_SECOND_Pos))
+#define RTC_MODE2_ALARM_MINUTE_Pos          6                                              /**< (RTC_MODE2_ALARM) Minute Position */
+#define RTC_MODE2_ALARM_MINUTE_Msk          (_U_(0x3F) << RTC_MODE2_ALARM_MINUTE_Pos)      /**< (RTC_MODE2_ALARM) Minute Mask */
+#define RTC_MODE2_ALARM_MINUTE(value)       (RTC_MODE2_ALARM_MINUTE_Msk & ((value) << RTC_MODE2_ALARM_MINUTE_Pos))
+#define RTC_MODE2_ALARM_HOUR_Pos            12                                             /**< (RTC_MODE2_ALARM) Hour Position */
+#define RTC_MODE2_ALARM_HOUR_Msk            (_U_(0x1F) << RTC_MODE2_ALARM_HOUR_Pos)        /**< (RTC_MODE2_ALARM) Hour Mask */
+#define RTC_MODE2_ALARM_HOUR(value)         (RTC_MODE2_ALARM_HOUR_Msk & ((value) << RTC_MODE2_ALARM_HOUR_Pos))
+#define   RTC_MODE2_ALARM_HOUR_AM_Val       _U_(0x0)                                       /**< (RTC_MODE2_ALARM) Morning hour  */
+#define   RTC_MODE2_ALARM_HOUR_PM_Val       _U_(0x10)                                      /**< (RTC_MODE2_ALARM) Afternoon hour  */
+#define RTC_MODE2_ALARM_HOUR_AM             (RTC_MODE2_ALARM_HOUR_AM_Val << RTC_MODE2_ALARM_HOUR_Pos)  /**< (RTC_MODE2_ALARM) Morning hour Position  */
+#define RTC_MODE2_ALARM_HOUR_PM             (RTC_MODE2_ALARM_HOUR_PM_Val << RTC_MODE2_ALARM_HOUR_Pos)  /**< (RTC_MODE2_ALARM) Afternoon hour Position  */
+#define RTC_MODE2_ALARM_DAY_Pos             17                                             /**< (RTC_MODE2_ALARM) Day Position */
+#define RTC_MODE2_ALARM_DAY_Msk             (_U_(0x1F) << RTC_MODE2_ALARM_DAY_Pos)         /**< (RTC_MODE2_ALARM) Day Mask */
+#define RTC_MODE2_ALARM_DAY(value)          (RTC_MODE2_ALARM_DAY_Msk & ((value) << RTC_MODE2_ALARM_DAY_Pos))
+#define RTC_MODE2_ALARM_MONTH_Pos           22                                             /**< (RTC_MODE2_ALARM) Month Position */
+#define RTC_MODE2_ALARM_MONTH_Msk           (_U_(0xF) << RTC_MODE2_ALARM_MONTH_Pos)        /**< (RTC_MODE2_ALARM) Month Mask */
+#define RTC_MODE2_ALARM_MONTH(value)        (RTC_MODE2_ALARM_MONTH_Msk & ((value) << RTC_MODE2_ALARM_MONTH_Pos))
+#define RTC_MODE2_ALARM_YEAR_Pos            26                                             /**< (RTC_MODE2_ALARM) Year Position */
+#define RTC_MODE2_ALARM_YEAR_Msk            (_U_(0x3F) << RTC_MODE2_ALARM_YEAR_Pos)        /**< (RTC_MODE2_ALARM) Year Mask */
+#define RTC_MODE2_ALARM_YEAR(value)         (RTC_MODE2_ALARM_YEAR_Msk & ((value) << RTC_MODE2_ALARM_YEAR_Pos))
+#define RTC_MODE2_ALARM_MASK                _U_(0xFFFFFFFF)                                /**< \deprecated (RTC_MODE2_ALARM) Register MASK  (Use RTC_MODE2_ALARM_Msk instead)  */
+#define RTC_MODE2_ALARM_Msk                 _U_(0xFFFFFFFF)                                /**< (RTC_MODE2_ALARM) Register Mask  */
+
+
+/* -------- RTC_MODE2_MASK : (RTC Offset: 0x04) (R/W 8) MODE2_ALARM Alarm n Mask -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  SEL:3;                     /**< bit:   0..2  Alarm Mask Selection                     */
+    uint8_t  :5;                        /**< bit:   3..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} RTC_MODE2_MASK_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE2_MASK_OFFSET               (0x04)                                        /**<  (RTC_MODE2_MASK) MODE2_ALARM Alarm n Mask  Offset */
+#define RTC_MODE2_MASK_RESETVALUE           _U_(0x00)                                     /**<  (RTC_MODE2_MASK) MODE2_ALARM Alarm n Mask  Reset Value */
+
+#define RTC_MODE2_MASK_SEL_Pos              0                                              /**< (RTC_MODE2_MASK) Alarm Mask Selection Position */
+#define RTC_MODE2_MASK_SEL_Msk              (_U_(0x7) << RTC_MODE2_MASK_SEL_Pos)           /**< (RTC_MODE2_MASK) Alarm Mask Selection Mask */
+#define RTC_MODE2_MASK_SEL(value)           (RTC_MODE2_MASK_SEL_Msk & ((value) << RTC_MODE2_MASK_SEL_Pos))
+#define   RTC_MODE2_MASK_SEL_OFF_Val        _U_(0x0)                                       /**< (RTC_MODE2_MASK) Alarm Disabled  */
+#define   RTC_MODE2_MASK_SEL_SS_Val         _U_(0x1)                                       /**< (RTC_MODE2_MASK) Match seconds only  */
+#define   RTC_MODE2_MASK_SEL_MMSS_Val       _U_(0x2)                                       /**< (RTC_MODE2_MASK) Match seconds and minutes only  */
+#define   RTC_MODE2_MASK_SEL_HHMMSS_Val     _U_(0x3)                                       /**< (RTC_MODE2_MASK) Match seconds, minutes, and hours only  */
+#define   RTC_MODE2_MASK_SEL_DDHHMMSS_Val   _U_(0x4)                                       /**< (RTC_MODE2_MASK) Match seconds, minutes, hours, and days only  */
+#define   RTC_MODE2_MASK_SEL_MMDDHHMMSS_Val _U_(0x5)                                       /**< (RTC_MODE2_MASK) Match seconds, minutes, hours, days, and months only  */
+#define   RTC_MODE2_MASK_SEL_YYMMDDHHMMSS_Val _U_(0x6)                                       /**< (RTC_MODE2_MASK) Match seconds, minutes, hours, days, months, and years  */
+#define RTC_MODE2_MASK_SEL_OFF              (RTC_MODE2_MASK_SEL_OFF_Val << RTC_MODE2_MASK_SEL_Pos)  /**< (RTC_MODE2_MASK) Alarm Disabled Position  */
+#define RTC_MODE2_MASK_SEL_SS               (RTC_MODE2_MASK_SEL_SS_Val << RTC_MODE2_MASK_SEL_Pos)  /**< (RTC_MODE2_MASK) Match seconds only Position  */
+#define RTC_MODE2_MASK_SEL_MMSS             (RTC_MODE2_MASK_SEL_MMSS_Val << RTC_MODE2_MASK_SEL_Pos)  /**< (RTC_MODE2_MASK) Match seconds and minutes only Position  */
+#define RTC_MODE2_MASK_SEL_HHMMSS           (RTC_MODE2_MASK_SEL_HHMMSS_Val << RTC_MODE2_MASK_SEL_Pos)  /**< (RTC_MODE2_MASK) Match seconds, minutes, and hours only Position  */
+#define RTC_MODE2_MASK_SEL_DDHHMMSS         (RTC_MODE2_MASK_SEL_DDHHMMSS_Val << RTC_MODE2_MASK_SEL_Pos)  /**< (RTC_MODE2_MASK) Match seconds, minutes, hours, and days only Position  */
+#define RTC_MODE2_MASK_SEL_MMDDHHMMSS       (RTC_MODE2_MASK_SEL_MMDDHHMMSS_Val << RTC_MODE2_MASK_SEL_Pos)  /**< (RTC_MODE2_MASK) Match seconds, minutes, hours, days, and months only Position  */
+#define RTC_MODE2_MASK_SEL_YYMMDDHHMMSS     (RTC_MODE2_MASK_SEL_YYMMDDHHMMSS_Val << RTC_MODE2_MASK_SEL_Pos)  /**< (RTC_MODE2_MASK) Match seconds, minutes, hours, days, months, and years Position  */
+#define RTC_MODE2_MASK_MASK                 _U_(0x07)                                      /**< \deprecated (RTC_MODE2_MASK) Register MASK  (Use RTC_MODE2_MASK_Msk instead)  */
+#define RTC_MODE2_MASK_Msk                  _U_(0x07)                                      /**< (RTC_MODE2_MASK) Register Mask  */
+
+
+/* -------- RTC_MODE0_CTRLA : (RTC Offset: 0x00) (R/W 16) MODE0 Control A -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint16_t ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint16_t MODE:2;                    /**< bit:   2..3  Operating Mode                           */
+    uint16_t :3;                        /**< bit:   4..6  Reserved */
+    uint16_t MATCHCLR:1;                /**< bit:      7  Clear on Match                           */
+    uint16_t PRESCALER:4;               /**< bit:  8..11  Prescaler                                */
+    uint16_t :2;                        /**< bit: 12..13  Reserved */
+    uint16_t GPTRST:1;                  /**< bit:     14  GP Registers Reset On Tamper Enable      */
+    uint16_t COUNTSYNC:1;               /**< bit:     15  Count Read Synchronization Enable        */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} RTC_MODE0_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE0_CTRLA_OFFSET              (0x00)                                        /**<  (RTC_MODE0_CTRLA) MODE0 Control A  Offset */
+#define RTC_MODE0_CTRLA_RESETVALUE          _U_(0x00)                                     /**<  (RTC_MODE0_CTRLA) MODE0 Control A  Reset Value */
+
+#define RTC_MODE0_CTRLA_SWRST_Pos           0                                              /**< (RTC_MODE0_CTRLA) Software Reset Position */
+#define RTC_MODE0_CTRLA_SWRST_Msk           (_U_(0x1) << RTC_MODE0_CTRLA_SWRST_Pos)        /**< (RTC_MODE0_CTRLA) Software Reset Mask */
+#define RTC_MODE0_CTRLA_SWRST               RTC_MODE0_CTRLA_SWRST_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_CTRLA_SWRST_Msk instead */
+#define RTC_MODE0_CTRLA_ENABLE_Pos          1                                              /**< (RTC_MODE0_CTRLA) Enable Position */
+#define RTC_MODE0_CTRLA_ENABLE_Msk          (_U_(0x1) << RTC_MODE0_CTRLA_ENABLE_Pos)       /**< (RTC_MODE0_CTRLA) Enable Mask */
+#define RTC_MODE0_CTRLA_ENABLE              RTC_MODE0_CTRLA_ENABLE_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_CTRLA_ENABLE_Msk instead */
+#define RTC_MODE0_CTRLA_MODE_Pos            2                                              /**< (RTC_MODE0_CTRLA) Operating Mode Position */
+#define RTC_MODE0_CTRLA_MODE_Msk            (_U_(0x3) << RTC_MODE0_CTRLA_MODE_Pos)         /**< (RTC_MODE0_CTRLA) Operating Mode Mask */
+#define RTC_MODE0_CTRLA_MODE(value)         (RTC_MODE0_CTRLA_MODE_Msk & ((value) << RTC_MODE0_CTRLA_MODE_Pos))
+#define   RTC_MODE0_CTRLA_MODE_COUNT32_Val  _U_(0x0)                                       /**< (RTC_MODE0_CTRLA) Mode 0: 32-bit Counter  */
+#define   RTC_MODE0_CTRLA_MODE_COUNT16_Val  _U_(0x1)                                       /**< (RTC_MODE0_CTRLA) Mode 1: 16-bit Counter  */
+#define   RTC_MODE0_CTRLA_MODE_CLOCK_Val    _U_(0x2)                                       /**< (RTC_MODE0_CTRLA) Mode 2: Clock/Calendar  */
+#define RTC_MODE0_CTRLA_MODE_COUNT32        (RTC_MODE0_CTRLA_MODE_COUNT32_Val << RTC_MODE0_CTRLA_MODE_Pos)  /**< (RTC_MODE0_CTRLA) Mode 0: 32-bit Counter Position  */
+#define RTC_MODE0_CTRLA_MODE_COUNT16        (RTC_MODE0_CTRLA_MODE_COUNT16_Val << RTC_MODE0_CTRLA_MODE_Pos)  /**< (RTC_MODE0_CTRLA) Mode 1: 16-bit Counter Position  */
+#define RTC_MODE0_CTRLA_MODE_CLOCK          (RTC_MODE0_CTRLA_MODE_CLOCK_Val << RTC_MODE0_CTRLA_MODE_Pos)  /**< (RTC_MODE0_CTRLA) Mode 2: Clock/Calendar Position  */
+#define RTC_MODE0_CTRLA_MATCHCLR_Pos        7                                              /**< (RTC_MODE0_CTRLA) Clear on Match Position */
+#define RTC_MODE0_CTRLA_MATCHCLR_Msk        (_U_(0x1) << RTC_MODE0_CTRLA_MATCHCLR_Pos)     /**< (RTC_MODE0_CTRLA) Clear on Match Mask */
+#define RTC_MODE0_CTRLA_MATCHCLR            RTC_MODE0_CTRLA_MATCHCLR_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_CTRLA_MATCHCLR_Msk instead */
+#define RTC_MODE0_CTRLA_PRESCALER_Pos       8                                              /**< (RTC_MODE0_CTRLA) Prescaler Position */
+#define RTC_MODE0_CTRLA_PRESCALER_Msk       (_U_(0xF) << RTC_MODE0_CTRLA_PRESCALER_Pos)    /**< (RTC_MODE0_CTRLA) Prescaler Mask */
+#define RTC_MODE0_CTRLA_PRESCALER(value)    (RTC_MODE0_CTRLA_PRESCALER_Msk & ((value) << RTC_MODE0_CTRLA_PRESCALER_Pos))
+#define   RTC_MODE0_CTRLA_PRESCALER_OFF_Val _U_(0x0)                                       /**< (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/1  */
+#define   RTC_MODE0_CTRLA_PRESCALER_DIV1_Val _U_(0x1)                                       /**< (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/1  */
+#define   RTC_MODE0_CTRLA_PRESCALER_DIV2_Val _U_(0x2)                                       /**< (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/2  */
+#define   RTC_MODE0_CTRLA_PRESCALER_DIV4_Val _U_(0x3)                                       /**< (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/4  */
+#define   RTC_MODE0_CTRLA_PRESCALER_DIV8_Val _U_(0x4)                                       /**< (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/8  */
+#define   RTC_MODE0_CTRLA_PRESCALER_DIV16_Val _U_(0x5)                                       /**< (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/16  */
+#define   RTC_MODE0_CTRLA_PRESCALER_DIV32_Val _U_(0x6)                                       /**< (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/32  */
+#define   RTC_MODE0_CTRLA_PRESCALER_DIV64_Val _U_(0x7)                                       /**< (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/64  */
+#define   RTC_MODE0_CTRLA_PRESCALER_DIV128_Val _U_(0x8)                                       /**< (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/128  */
+#define   RTC_MODE0_CTRLA_PRESCALER_DIV256_Val _U_(0x9)                                       /**< (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/256  */
+#define   RTC_MODE0_CTRLA_PRESCALER_DIV512_Val _U_(0xA)                                       /**< (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/512  */
+#define   RTC_MODE0_CTRLA_PRESCALER_DIV1024_Val _U_(0xB)                                       /**< (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/1024  */
+#define RTC_MODE0_CTRLA_PRESCALER_OFF       (RTC_MODE0_CTRLA_PRESCALER_OFF_Val << RTC_MODE0_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/1 Position  */
+#define RTC_MODE0_CTRLA_PRESCALER_DIV1      (RTC_MODE0_CTRLA_PRESCALER_DIV1_Val << RTC_MODE0_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/1 Position  */
+#define RTC_MODE0_CTRLA_PRESCALER_DIV2      (RTC_MODE0_CTRLA_PRESCALER_DIV2_Val << RTC_MODE0_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/2 Position  */
+#define RTC_MODE0_CTRLA_PRESCALER_DIV4      (RTC_MODE0_CTRLA_PRESCALER_DIV4_Val << RTC_MODE0_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/4 Position  */
+#define RTC_MODE0_CTRLA_PRESCALER_DIV8      (RTC_MODE0_CTRLA_PRESCALER_DIV8_Val << RTC_MODE0_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/8 Position  */
+#define RTC_MODE0_CTRLA_PRESCALER_DIV16     (RTC_MODE0_CTRLA_PRESCALER_DIV16_Val << RTC_MODE0_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/16 Position  */
+#define RTC_MODE0_CTRLA_PRESCALER_DIV32     (RTC_MODE0_CTRLA_PRESCALER_DIV32_Val << RTC_MODE0_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/32 Position  */
+#define RTC_MODE0_CTRLA_PRESCALER_DIV64     (RTC_MODE0_CTRLA_PRESCALER_DIV64_Val << RTC_MODE0_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/64 Position  */
+#define RTC_MODE0_CTRLA_PRESCALER_DIV128    (RTC_MODE0_CTRLA_PRESCALER_DIV128_Val << RTC_MODE0_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/128 Position  */
+#define RTC_MODE0_CTRLA_PRESCALER_DIV256    (RTC_MODE0_CTRLA_PRESCALER_DIV256_Val << RTC_MODE0_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/256 Position  */
+#define RTC_MODE0_CTRLA_PRESCALER_DIV512    (RTC_MODE0_CTRLA_PRESCALER_DIV512_Val << RTC_MODE0_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/512 Position  */
+#define RTC_MODE0_CTRLA_PRESCALER_DIV1024   (RTC_MODE0_CTRLA_PRESCALER_DIV1024_Val << RTC_MODE0_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/1024 Position  */
+#define RTC_MODE0_CTRLA_GPTRST_Pos          14                                             /**< (RTC_MODE0_CTRLA) GP Registers Reset On Tamper Enable Position */
+#define RTC_MODE0_CTRLA_GPTRST_Msk          (_U_(0x1) << RTC_MODE0_CTRLA_GPTRST_Pos)       /**< (RTC_MODE0_CTRLA) GP Registers Reset On Tamper Enable Mask */
+#define RTC_MODE0_CTRLA_GPTRST              RTC_MODE0_CTRLA_GPTRST_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_CTRLA_GPTRST_Msk instead */
+#define RTC_MODE0_CTRLA_COUNTSYNC_Pos       15                                             /**< (RTC_MODE0_CTRLA) Count Read Synchronization Enable Position */
+#define RTC_MODE0_CTRLA_COUNTSYNC_Msk       (_U_(0x1) << RTC_MODE0_CTRLA_COUNTSYNC_Pos)    /**< (RTC_MODE0_CTRLA) Count Read Synchronization Enable Mask */
+#define RTC_MODE0_CTRLA_COUNTSYNC           RTC_MODE0_CTRLA_COUNTSYNC_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_CTRLA_COUNTSYNC_Msk instead */
+#define RTC_MODE0_CTRLA_MASK                _U_(0xCF8F)                                    /**< \deprecated (RTC_MODE0_CTRLA) Register MASK  (Use RTC_MODE0_CTRLA_Msk instead)  */
+#define RTC_MODE0_CTRLA_Msk                 _U_(0xCF8F)                                    /**< (RTC_MODE0_CTRLA) Register Mask  */
+
+
+/* -------- RTC_MODE1_CTRLA : (RTC Offset: 0x00) (R/W 16) MODE1 Control A -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint16_t ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint16_t MODE:2;                    /**< bit:   2..3  Operating Mode                           */
+    uint16_t :4;                        /**< bit:   4..7  Reserved */
+    uint16_t PRESCALER:4;               /**< bit:  8..11  Prescaler                                */
+    uint16_t :2;                        /**< bit: 12..13  Reserved */
+    uint16_t GPTRST:1;                  /**< bit:     14  GP Registers Reset On Tamper Enable      */
+    uint16_t COUNTSYNC:1;               /**< bit:     15  Count Read Synchronization Enable        */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} RTC_MODE1_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE1_CTRLA_OFFSET              (0x00)                                        /**<  (RTC_MODE1_CTRLA) MODE1 Control A  Offset */
+#define RTC_MODE1_CTRLA_RESETVALUE          _U_(0x00)                                     /**<  (RTC_MODE1_CTRLA) MODE1 Control A  Reset Value */
+
+#define RTC_MODE1_CTRLA_SWRST_Pos           0                                              /**< (RTC_MODE1_CTRLA) Software Reset Position */
+#define RTC_MODE1_CTRLA_SWRST_Msk           (_U_(0x1) << RTC_MODE1_CTRLA_SWRST_Pos)        /**< (RTC_MODE1_CTRLA) Software Reset Mask */
+#define RTC_MODE1_CTRLA_SWRST               RTC_MODE1_CTRLA_SWRST_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_CTRLA_SWRST_Msk instead */
+#define RTC_MODE1_CTRLA_ENABLE_Pos          1                                              /**< (RTC_MODE1_CTRLA) Enable Position */
+#define RTC_MODE1_CTRLA_ENABLE_Msk          (_U_(0x1) << RTC_MODE1_CTRLA_ENABLE_Pos)       /**< (RTC_MODE1_CTRLA) Enable Mask */
+#define RTC_MODE1_CTRLA_ENABLE              RTC_MODE1_CTRLA_ENABLE_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_CTRLA_ENABLE_Msk instead */
+#define RTC_MODE1_CTRLA_MODE_Pos            2                                              /**< (RTC_MODE1_CTRLA) Operating Mode Position */
+#define RTC_MODE1_CTRLA_MODE_Msk            (_U_(0x3) << RTC_MODE1_CTRLA_MODE_Pos)         /**< (RTC_MODE1_CTRLA) Operating Mode Mask */
+#define RTC_MODE1_CTRLA_MODE(value)         (RTC_MODE1_CTRLA_MODE_Msk & ((value) << RTC_MODE1_CTRLA_MODE_Pos))
+#define   RTC_MODE1_CTRLA_MODE_COUNT32_Val  _U_(0x0)                                       /**< (RTC_MODE1_CTRLA) Mode 0: 32-bit Counter  */
+#define   RTC_MODE1_CTRLA_MODE_COUNT16_Val  _U_(0x1)                                       /**< (RTC_MODE1_CTRLA) Mode 1: 16-bit Counter  */
+#define   RTC_MODE1_CTRLA_MODE_CLOCK_Val    _U_(0x2)                                       /**< (RTC_MODE1_CTRLA) Mode 2: Clock/Calendar  */
+#define RTC_MODE1_CTRLA_MODE_COUNT32        (RTC_MODE1_CTRLA_MODE_COUNT32_Val << RTC_MODE1_CTRLA_MODE_Pos)  /**< (RTC_MODE1_CTRLA) Mode 0: 32-bit Counter Position  */
+#define RTC_MODE1_CTRLA_MODE_COUNT16        (RTC_MODE1_CTRLA_MODE_COUNT16_Val << RTC_MODE1_CTRLA_MODE_Pos)  /**< (RTC_MODE1_CTRLA) Mode 1: 16-bit Counter Position  */
+#define RTC_MODE1_CTRLA_MODE_CLOCK          (RTC_MODE1_CTRLA_MODE_CLOCK_Val << RTC_MODE1_CTRLA_MODE_Pos)  /**< (RTC_MODE1_CTRLA) Mode 2: Clock/Calendar Position  */
+#define RTC_MODE1_CTRLA_PRESCALER_Pos       8                                              /**< (RTC_MODE1_CTRLA) Prescaler Position */
+#define RTC_MODE1_CTRLA_PRESCALER_Msk       (_U_(0xF) << RTC_MODE1_CTRLA_PRESCALER_Pos)    /**< (RTC_MODE1_CTRLA) Prescaler Mask */
+#define RTC_MODE1_CTRLA_PRESCALER(value)    (RTC_MODE1_CTRLA_PRESCALER_Msk & ((value) << RTC_MODE1_CTRLA_PRESCALER_Pos))
+#define   RTC_MODE1_CTRLA_PRESCALER_OFF_Val _U_(0x0)                                       /**< (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/1  */
+#define   RTC_MODE1_CTRLA_PRESCALER_DIV1_Val _U_(0x1)                                       /**< (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/1  */
+#define   RTC_MODE1_CTRLA_PRESCALER_DIV2_Val _U_(0x2)                                       /**< (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/2  */
+#define   RTC_MODE1_CTRLA_PRESCALER_DIV4_Val _U_(0x3)                                       /**< (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/4  */
+#define   RTC_MODE1_CTRLA_PRESCALER_DIV8_Val _U_(0x4)                                       /**< (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/8  */
+#define   RTC_MODE1_CTRLA_PRESCALER_DIV16_Val _U_(0x5)                                       /**< (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/16  */
+#define   RTC_MODE1_CTRLA_PRESCALER_DIV32_Val _U_(0x6)                                       /**< (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/32  */
+#define   RTC_MODE1_CTRLA_PRESCALER_DIV64_Val _U_(0x7)                                       /**< (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/64  */
+#define   RTC_MODE1_CTRLA_PRESCALER_DIV128_Val _U_(0x8)                                       /**< (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/128  */
+#define   RTC_MODE1_CTRLA_PRESCALER_DIV256_Val _U_(0x9)                                       /**< (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/256  */
+#define   RTC_MODE1_CTRLA_PRESCALER_DIV512_Val _U_(0xA)                                       /**< (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/512  */
+#define   RTC_MODE1_CTRLA_PRESCALER_DIV1024_Val _U_(0xB)                                       /**< (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/1024  */
+#define RTC_MODE1_CTRLA_PRESCALER_OFF       (RTC_MODE1_CTRLA_PRESCALER_OFF_Val << RTC_MODE1_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/1 Position  */
+#define RTC_MODE1_CTRLA_PRESCALER_DIV1      (RTC_MODE1_CTRLA_PRESCALER_DIV1_Val << RTC_MODE1_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/1 Position  */
+#define RTC_MODE1_CTRLA_PRESCALER_DIV2      (RTC_MODE1_CTRLA_PRESCALER_DIV2_Val << RTC_MODE1_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/2 Position  */
+#define RTC_MODE1_CTRLA_PRESCALER_DIV4      (RTC_MODE1_CTRLA_PRESCALER_DIV4_Val << RTC_MODE1_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/4 Position  */
+#define RTC_MODE1_CTRLA_PRESCALER_DIV8      (RTC_MODE1_CTRLA_PRESCALER_DIV8_Val << RTC_MODE1_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/8 Position  */
+#define RTC_MODE1_CTRLA_PRESCALER_DIV16     (RTC_MODE1_CTRLA_PRESCALER_DIV16_Val << RTC_MODE1_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/16 Position  */
+#define RTC_MODE1_CTRLA_PRESCALER_DIV32     (RTC_MODE1_CTRLA_PRESCALER_DIV32_Val << RTC_MODE1_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/32 Position  */
+#define RTC_MODE1_CTRLA_PRESCALER_DIV64     (RTC_MODE1_CTRLA_PRESCALER_DIV64_Val << RTC_MODE1_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/64 Position  */
+#define RTC_MODE1_CTRLA_PRESCALER_DIV128    (RTC_MODE1_CTRLA_PRESCALER_DIV128_Val << RTC_MODE1_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/128 Position  */
+#define RTC_MODE1_CTRLA_PRESCALER_DIV256    (RTC_MODE1_CTRLA_PRESCALER_DIV256_Val << RTC_MODE1_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/256 Position  */
+#define RTC_MODE1_CTRLA_PRESCALER_DIV512    (RTC_MODE1_CTRLA_PRESCALER_DIV512_Val << RTC_MODE1_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/512 Position  */
+#define RTC_MODE1_CTRLA_PRESCALER_DIV1024   (RTC_MODE1_CTRLA_PRESCALER_DIV1024_Val << RTC_MODE1_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/1024 Position  */
+#define RTC_MODE1_CTRLA_GPTRST_Pos          14                                             /**< (RTC_MODE1_CTRLA) GP Registers Reset On Tamper Enable Position */
+#define RTC_MODE1_CTRLA_GPTRST_Msk          (_U_(0x1) << RTC_MODE1_CTRLA_GPTRST_Pos)       /**< (RTC_MODE1_CTRLA) GP Registers Reset On Tamper Enable Mask */
+#define RTC_MODE1_CTRLA_GPTRST              RTC_MODE1_CTRLA_GPTRST_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_CTRLA_GPTRST_Msk instead */
+#define RTC_MODE1_CTRLA_COUNTSYNC_Pos       15                                             /**< (RTC_MODE1_CTRLA) Count Read Synchronization Enable Position */
+#define RTC_MODE1_CTRLA_COUNTSYNC_Msk       (_U_(0x1) << RTC_MODE1_CTRLA_COUNTSYNC_Pos)    /**< (RTC_MODE1_CTRLA) Count Read Synchronization Enable Mask */
+#define RTC_MODE1_CTRLA_COUNTSYNC           RTC_MODE1_CTRLA_COUNTSYNC_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_CTRLA_COUNTSYNC_Msk instead */
+#define RTC_MODE1_CTRLA_MASK                _U_(0xCF0F)                                    /**< \deprecated (RTC_MODE1_CTRLA) Register MASK  (Use RTC_MODE1_CTRLA_Msk instead)  */
+#define RTC_MODE1_CTRLA_Msk                 _U_(0xCF0F)                                    /**< (RTC_MODE1_CTRLA) Register Mask  */
+
+
+/* -------- RTC_MODE2_CTRLA : (RTC Offset: 0x00) (R/W 16) MODE2 Control A -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint16_t ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint16_t MODE:2;                    /**< bit:   2..3  Operating Mode                           */
+    uint16_t :2;                        /**< bit:   4..5  Reserved */
+    uint16_t CLKREP:1;                  /**< bit:      6  Clock Representation                     */
+    uint16_t MATCHCLR:1;                /**< bit:      7  Clear on Match                           */
+    uint16_t PRESCALER:4;               /**< bit:  8..11  Prescaler                                */
+    uint16_t :2;                        /**< bit: 12..13  Reserved */
+    uint16_t GPTRST:1;                  /**< bit:     14  GP Registers Reset On Tamper Enable      */
+    uint16_t CLOCKSYNC:1;               /**< bit:     15  Clock Read Synchronization Enable        */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} RTC_MODE2_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE2_CTRLA_OFFSET              (0x00)                                        /**<  (RTC_MODE2_CTRLA) MODE2 Control A  Offset */
+#define RTC_MODE2_CTRLA_RESETVALUE          _U_(0x00)                                     /**<  (RTC_MODE2_CTRLA) MODE2 Control A  Reset Value */
+
+#define RTC_MODE2_CTRLA_SWRST_Pos           0                                              /**< (RTC_MODE2_CTRLA) Software Reset Position */
+#define RTC_MODE2_CTRLA_SWRST_Msk           (_U_(0x1) << RTC_MODE2_CTRLA_SWRST_Pos)        /**< (RTC_MODE2_CTRLA) Software Reset Mask */
+#define RTC_MODE2_CTRLA_SWRST               RTC_MODE2_CTRLA_SWRST_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_CTRLA_SWRST_Msk instead */
+#define RTC_MODE2_CTRLA_ENABLE_Pos          1                                              /**< (RTC_MODE2_CTRLA) Enable Position */
+#define RTC_MODE2_CTRLA_ENABLE_Msk          (_U_(0x1) << RTC_MODE2_CTRLA_ENABLE_Pos)       /**< (RTC_MODE2_CTRLA) Enable Mask */
+#define RTC_MODE2_CTRLA_ENABLE              RTC_MODE2_CTRLA_ENABLE_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_CTRLA_ENABLE_Msk instead */
+#define RTC_MODE2_CTRLA_MODE_Pos            2                                              /**< (RTC_MODE2_CTRLA) Operating Mode Position */
+#define RTC_MODE2_CTRLA_MODE_Msk            (_U_(0x3) << RTC_MODE2_CTRLA_MODE_Pos)         /**< (RTC_MODE2_CTRLA) Operating Mode Mask */
+#define RTC_MODE2_CTRLA_MODE(value)         (RTC_MODE2_CTRLA_MODE_Msk & ((value) << RTC_MODE2_CTRLA_MODE_Pos))
+#define   RTC_MODE2_CTRLA_MODE_COUNT32_Val  _U_(0x0)                                       /**< (RTC_MODE2_CTRLA) Mode 0: 32-bit Counter  */
+#define   RTC_MODE2_CTRLA_MODE_COUNT16_Val  _U_(0x1)                                       /**< (RTC_MODE2_CTRLA) Mode 1: 16-bit Counter  */
+#define   RTC_MODE2_CTRLA_MODE_CLOCK_Val    _U_(0x2)                                       /**< (RTC_MODE2_CTRLA) Mode 2: Clock/Calendar  */
+#define RTC_MODE2_CTRLA_MODE_COUNT32        (RTC_MODE2_CTRLA_MODE_COUNT32_Val << RTC_MODE2_CTRLA_MODE_Pos)  /**< (RTC_MODE2_CTRLA) Mode 0: 32-bit Counter Position  */
+#define RTC_MODE2_CTRLA_MODE_COUNT16        (RTC_MODE2_CTRLA_MODE_COUNT16_Val << RTC_MODE2_CTRLA_MODE_Pos)  /**< (RTC_MODE2_CTRLA) Mode 1: 16-bit Counter Position  */
+#define RTC_MODE2_CTRLA_MODE_CLOCK          (RTC_MODE2_CTRLA_MODE_CLOCK_Val << RTC_MODE2_CTRLA_MODE_Pos)  /**< (RTC_MODE2_CTRLA) Mode 2: Clock/Calendar Position  */
+#define RTC_MODE2_CTRLA_CLKREP_Pos          6                                              /**< (RTC_MODE2_CTRLA) Clock Representation Position */
+#define RTC_MODE2_CTRLA_CLKREP_Msk          (_U_(0x1) << RTC_MODE2_CTRLA_CLKREP_Pos)       /**< (RTC_MODE2_CTRLA) Clock Representation Mask */
+#define RTC_MODE2_CTRLA_CLKREP              RTC_MODE2_CTRLA_CLKREP_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_CTRLA_CLKREP_Msk instead */
+#define RTC_MODE2_CTRLA_MATCHCLR_Pos        7                                              /**< (RTC_MODE2_CTRLA) Clear on Match Position */
+#define RTC_MODE2_CTRLA_MATCHCLR_Msk        (_U_(0x1) << RTC_MODE2_CTRLA_MATCHCLR_Pos)     /**< (RTC_MODE2_CTRLA) Clear on Match Mask */
+#define RTC_MODE2_CTRLA_MATCHCLR            RTC_MODE2_CTRLA_MATCHCLR_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_CTRLA_MATCHCLR_Msk instead */
+#define RTC_MODE2_CTRLA_PRESCALER_Pos       8                                              /**< (RTC_MODE2_CTRLA) Prescaler Position */
+#define RTC_MODE2_CTRLA_PRESCALER_Msk       (_U_(0xF) << RTC_MODE2_CTRLA_PRESCALER_Pos)    /**< (RTC_MODE2_CTRLA) Prescaler Mask */
+#define RTC_MODE2_CTRLA_PRESCALER(value)    (RTC_MODE2_CTRLA_PRESCALER_Msk & ((value) << RTC_MODE2_CTRLA_PRESCALER_Pos))
+#define   RTC_MODE2_CTRLA_PRESCALER_OFF_Val _U_(0x0)                                       /**< (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/1  */
+#define   RTC_MODE2_CTRLA_PRESCALER_DIV1_Val _U_(0x1)                                       /**< (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/1  */
+#define   RTC_MODE2_CTRLA_PRESCALER_DIV2_Val _U_(0x2)                                       /**< (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/2  */
+#define   RTC_MODE2_CTRLA_PRESCALER_DIV4_Val _U_(0x3)                                       /**< (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/4  */
+#define   RTC_MODE2_CTRLA_PRESCALER_DIV8_Val _U_(0x4)                                       /**< (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/8  */
+#define   RTC_MODE2_CTRLA_PRESCALER_DIV16_Val _U_(0x5)                                       /**< (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/16  */
+#define   RTC_MODE2_CTRLA_PRESCALER_DIV32_Val _U_(0x6)                                       /**< (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/32  */
+#define   RTC_MODE2_CTRLA_PRESCALER_DIV64_Val _U_(0x7)                                       /**< (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/64  */
+#define   RTC_MODE2_CTRLA_PRESCALER_DIV128_Val _U_(0x8)                                       /**< (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/128  */
+#define   RTC_MODE2_CTRLA_PRESCALER_DIV256_Val _U_(0x9)                                       /**< (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/256  */
+#define   RTC_MODE2_CTRLA_PRESCALER_DIV512_Val _U_(0xA)                                       /**< (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/512  */
+#define   RTC_MODE2_CTRLA_PRESCALER_DIV1024_Val _U_(0xB)                                       /**< (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/1024  */
+#define RTC_MODE2_CTRLA_PRESCALER_OFF       (RTC_MODE2_CTRLA_PRESCALER_OFF_Val << RTC_MODE2_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/1 Position  */
+#define RTC_MODE2_CTRLA_PRESCALER_DIV1      (RTC_MODE2_CTRLA_PRESCALER_DIV1_Val << RTC_MODE2_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/1 Position  */
+#define RTC_MODE2_CTRLA_PRESCALER_DIV2      (RTC_MODE2_CTRLA_PRESCALER_DIV2_Val << RTC_MODE2_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/2 Position  */
+#define RTC_MODE2_CTRLA_PRESCALER_DIV4      (RTC_MODE2_CTRLA_PRESCALER_DIV4_Val << RTC_MODE2_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/4 Position  */
+#define RTC_MODE2_CTRLA_PRESCALER_DIV8      (RTC_MODE2_CTRLA_PRESCALER_DIV8_Val << RTC_MODE2_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/8 Position  */
+#define RTC_MODE2_CTRLA_PRESCALER_DIV16     (RTC_MODE2_CTRLA_PRESCALER_DIV16_Val << RTC_MODE2_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/16 Position  */
+#define RTC_MODE2_CTRLA_PRESCALER_DIV32     (RTC_MODE2_CTRLA_PRESCALER_DIV32_Val << RTC_MODE2_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/32 Position  */
+#define RTC_MODE2_CTRLA_PRESCALER_DIV64     (RTC_MODE2_CTRLA_PRESCALER_DIV64_Val << RTC_MODE2_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/64 Position  */
+#define RTC_MODE2_CTRLA_PRESCALER_DIV128    (RTC_MODE2_CTRLA_PRESCALER_DIV128_Val << RTC_MODE2_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/128 Position  */
+#define RTC_MODE2_CTRLA_PRESCALER_DIV256    (RTC_MODE2_CTRLA_PRESCALER_DIV256_Val << RTC_MODE2_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/256 Position  */
+#define RTC_MODE2_CTRLA_PRESCALER_DIV512    (RTC_MODE2_CTRLA_PRESCALER_DIV512_Val << RTC_MODE2_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/512 Position  */
+#define RTC_MODE2_CTRLA_PRESCALER_DIV1024   (RTC_MODE2_CTRLA_PRESCALER_DIV1024_Val << RTC_MODE2_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/1024 Position  */
+#define RTC_MODE2_CTRLA_GPTRST_Pos          14                                             /**< (RTC_MODE2_CTRLA) GP Registers Reset On Tamper Enable Position */
+#define RTC_MODE2_CTRLA_GPTRST_Msk          (_U_(0x1) << RTC_MODE2_CTRLA_GPTRST_Pos)       /**< (RTC_MODE2_CTRLA) GP Registers Reset On Tamper Enable Mask */
+#define RTC_MODE2_CTRLA_GPTRST              RTC_MODE2_CTRLA_GPTRST_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_CTRLA_GPTRST_Msk instead */
+#define RTC_MODE2_CTRLA_CLOCKSYNC_Pos       15                                             /**< (RTC_MODE2_CTRLA) Clock Read Synchronization Enable Position */
+#define RTC_MODE2_CTRLA_CLOCKSYNC_Msk       (_U_(0x1) << RTC_MODE2_CTRLA_CLOCKSYNC_Pos)    /**< (RTC_MODE2_CTRLA) Clock Read Synchronization Enable Mask */
+#define RTC_MODE2_CTRLA_CLOCKSYNC           RTC_MODE2_CTRLA_CLOCKSYNC_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_CTRLA_CLOCKSYNC_Msk instead */
+#define RTC_MODE2_CTRLA_MASK                _U_(0xCFCF)                                    /**< \deprecated (RTC_MODE2_CTRLA) Register MASK  (Use RTC_MODE2_CTRLA_Msk instead)  */
+#define RTC_MODE2_CTRLA_Msk                 _U_(0xCFCF)                                    /**< (RTC_MODE2_CTRLA) Register Mask  */
+
+
+/* -------- RTC_MODE0_CTRLB : (RTC Offset: 0x02) (R/W 16) MODE0 Control B -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t GP0EN:1;                   /**< bit:      0  General Purpose 0 Enable                 */
+    uint16_t :3;                        /**< bit:   1..3  Reserved */
+    uint16_t DEBMAJ:1;                  /**< bit:      4  Debouncer Majority Enable                */
+    uint16_t DEBASYNC:1;                /**< bit:      5  Debouncer Asynchronous Enable            */
+    uint16_t RTCOUT:1;                  /**< bit:      6  RTC Output Enable                        */
+    uint16_t DMAEN:1;                   /**< bit:      7  DMA Enable                               */
+    uint16_t DEBF:3;                    /**< bit:  8..10  Debounce Frequency                       */
+    uint16_t :1;                        /**< bit:     11  Reserved */
+    uint16_t ACTF:3;                    /**< bit: 12..14  Active Layer Frequency                   */
+    uint16_t SEPTO:1;                   /**< bit:     15  Separate Tamper Outputs                  */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} RTC_MODE0_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE0_CTRLB_OFFSET              (0x02)                                        /**<  (RTC_MODE0_CTRLB) MODE0 Control B  Offset */
+#define RTC_MODE0_CTRLB_RESETVALUE          _U_(0x00)                                     /**<  (RTC_MODE0_CTRLB) MODE0 Control B  Reset Value */
+
+#define RTC_MODE0_CTRLB_GP0EN_Pos           0                                              /**< (RTC_MODE0_CTRLB) General Purpose 0 Enable Position */
+#define RTC_MODE0_CTRLB_GP0EN_Msk           (_U_(0x1) << RTC_MODE0_CTRLB_GP0EN_Pos)        /**< (RTC_MODE0_CTRLB) General Purpose 0 Enable Mask */
+#define RTC_MODE0_CTRLB_GP0EN               RTC_MODE0_CTRLB_GP0EN_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_CTRLB_GP0EN_Msk instead */
+#define RTC_MODE0_CTRLB_DEBMAJ_Pos          4                                              /**< (RTC_MODE0_CTRLB) Debouncer Majority Enable Position */
+#define RTC_MODE0_CTRLB_DEBMAJ_Msk          (_U_(0x1) << RTC_MODE0_CTRLB_DEBMAJ_Pos)       /**< (RTC_MODE0_CTRLB) Debouncer Majority Enable Mask */
+#define RTC_MODE0_CTRLB_DEBMAJ              RTC_MODE0_CTRLB_DEBMAJ_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_CTRLB_DEBMAJ_Msk instead */
+#define RTC_MODE0_CTRLB_DEBASYNC_Pos        5                                              /**< (RTC_MODE0_CTRLB) Debouncer Asynchronous Enable Position */
+#define RTC_MODE0_CTRLB_DEBASYNC_Msk        (_U_(0x1) << RTC_MODE0_CTRLB_DEBASYNC_Pos)     /**< (RTC_MODE0_CTRLB) Debouncer Asynchronous Enable Mask */
+#define RTC_MODE0_CTRLB_DEBASYNC            RTC_MODE0_CTRLB_DEBASYNC_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_CTRLB_DEBASYNC_Msk instead */
+#define RTC_MODE0_CTRLB_RTCOUT_Pos          6                                              /**< (RTC_MODE0_CTRLB) RTC Output Enable Position */
+#define RTC_MODE0_CTRLB_RTCOUT_Msk          (_U_(0x1) << RTC_MODE0_CTRLB_RTCOUT_Pos)       /**< (RTC_MODE0_CTRLB) RTC Output Enable Mask */
+#define RTC_MODE0_CTRLB_RTCOUT              RTC_MODE0_CTRLB_RTCOUT_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_CTRLB_RTCOUT_Msk instead */
+#define RTC_MODE0_CTRLB_DMAEN_Pos           7                                              /**< (RTC_MODE0_CTRLB) DMA Enable Position */
+#define RTC_MODE0_CTRLB_DMAEN_Msk           (_U_(0x1) << RTC_MODE0_CTRLB_DMAEN_Pos)        /**< (RTC_MODE0_CTRLB) DMA Enable Mask */
+#define RTC_MODE0_CTRLB_DMAEN               RTC_MODE0_CTRLB_DMAEN_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_CTRLB_DMAEN_Msk instead */
+#define RTC_MODE0_CTRLB_DEBF_Pos            8                                              /**< (RTC_MODE0_CTRLB) Debounce Frequency Position */
+#define RTC_MODE0_CTRLB_DEBF_Msk            (_U_(0x7) << RTC_MODE0_CTRLB_DEBF_Pos)         /**< (RTC_MODE0_CTRLB) Debounce Frequency Mask */
+#define RTC_MODE0_CTRLB_DEBF(value)         (RTC_MODE0_CTRLB_DEBF_Msk & ((value) << RTC_MODE0_CTRLB_DEBF_Pos))
+#define   RTC_MODE0_CTRLB_DEBF_DIV2_Val     _U_(0x0)                                       /**< (RTC_MODE0_CTRLB) CLK_RTC_DEB = CLK_RTC/2  */
+#define   RTC_MODE0_CTRLB_DEBF_DIV4_Val     _U_(0x1)                                       /**< (RTC_MODE0_CTRLB) CLK_RTC_DEB = CLK_RTC/4  */
+#define   RTC_MODE0_CTRLB_DEBF_DIV8_Val     _U_(0x2)                                       /**< (RTC_MODE0_CTRLB) CLK_RTC_DEB = CLK_RTC/8  */
+#define   RTC_MODE0_CTRLB_DEBF_DIV16_Val    _U_(0x3)                                       /**< (RTC_MODE0_CTRLB) CLK_RTC_DEB = CLK_RTC/16  */
+#define   RTC_MODE0_CTRLB_DEBF_DIV32_Val    _U_(0x4)                                       /**< (RTC_MODE0_CTRLB) CLK_RTC_DEB = CLK_RTC/32  */
+#define   RTC_MODE0_CTRLB_DEBF_DIV64_Val    _U_(0x5)                                       /**< (RTC_MODE0_CTRLB) CLK_RTC_DEB = CLK_RTC/64  */
+#define   RTC_MODE0_CTRLB_DEBF_DIV128_Val   _U_(0x6)                                       /**< (RTC_MODE0_CTRLB) CLK_RTC_DEB = CLK_RTC/128  */
+#define   RTC_MODE0_CTRLB_DEBF_DIV256_Val   _U_(0x7)                                       /**< (RTC_MODE0_CTRLB) CLK_RTC_DEB = CLK_RTC/256  */
+#define RTC_MODE0_CTRLB_DEBF_DIV2           (RTC_MODE0_CTRLB_DEBF_DIV2_Val << RTC_MODE0_CTRLB_DEBF_Pos)  /**< (RTC_MODE0_CTRLB) CLK_RTC_DEB = CLK_RTC/2 Position  */
+#define RTC_MODE0_CTRLB_DEBF_DIV4           (RTC_MODE0_CTRLB_DEBF_DIV4_Val << RTC_MODE0_CTRLB_DEBF_Pos)  /**< (RTC_MODE0_CTRLB) CLK_RTC_DEB = CLK_RTC/4 Position  */
+#define RTC_MODE0_CTRLB_DEBF_DIV8           (RTC_MODE0_CTRLB_DEBF_DIV8_Val << RTC_MODE0_CTRLB_DEBF_Pos)  /**< (RTC_MODE0_CTRLB) CLK_RTC_DEB = CLK_RTC/8 Position  */
+#define RTC_MODE0_CTRLB_DEBF_DIV16          (RTC_MODE0_CTRLB_DEBF_DIV16_Val << RTC_MODE0_CTRLB_DEBF_Pos)  /**< (RTC_MODE0_CTRLB) CLK_RTC_DEB = CLK_RTC/16 Position  */
+#define RTC_MODE0_CTRLB_DEBF_DIV32          (RTC_MODE0_CTRLB_DEBF_DIV32_Val << RTC_MODE0_CTRLB_DEBF_Pos)  /**< (RTC_MODE0_CTRLB) CLK_RTC_DEB = CLK_RTC/32 Position  */
+#define RTC_MODE0_CTRLB_DEBF_DIV64          (RTC_MODE0_CTRLB_DEBF_DIV64_Val << RTC_MODE0_CTRLB_DEBF_Pos)  /**< (RTC_MODE0_CTRLB) CLK_RTC_DEB = CLK_RTC/64 Position  */
+#define RTC_MODE0_CTRLB_DEBF_DIV128         (RTC_MODE0_CTRLB_DEBF_DIV128_Val << RTC_MODE0_CTRLB_DEBF_Pos)  /**< (RTC_MODE0_CTRLB) CLK_RTC_DEB = CLK_RTC/128 Position  */
+#define RTC_MODE0_CTRLB_DEBF_DIV256         (RTC_MODE0_CTRLB_DEBF_DIV256_Val << RTC_MODE0_CTRLB_DEBF_Pos)  /**< (RTC_MODE0_CTRLB) CLK_RTC_DEB = CLK_RTC/256 Position  */
+#define RTC_MODE0_CTRLB_ACTF_Pos            12                                             /**< (RTC_MODE0_CTRLB) Active Layer Frequency Position */
+#define RTC_MODE0_CTRLB_ACTF_Msk            (_U_(0x7) << RTC_MODE0_CTRLB_ACTF_Pos)         /**< (RTC_MODE0_CTRLB) Active Layer Frequency Mask */
+#define RTC_MODE0_CTRLB_ACTF(value)         (RTC_MODE0_CTRLB_ACTF_Msk & ((value) << RTC_MODE0_CTRLB_ACTF_Pos))
+#define   RTC_MODE0_CTRLB_ACTF_DIV2_Val     _U_(0x0)                                       /**< (RTC_MODE0_CTRLB) CLK_RTC_OUT = CLK_RTC/2  */
+#define   RTC_MODE0_CTRLB_ACTF_DIV4_Val     _U_(0x1)                                       /**< (RTC_MODE0_CTRLB) CLK_RTC_OUT = CLK_RTC/4  */
+#define   RTC_MODE0_CTRLB_ACTF_DIV8_Val     _U_(0x2)                                       /**< (RTC_MODE0_CTRLB) CLK_RTC_OUT = CLK_RTC/8  */
+#define   RTC_MODE0_CTRLB_ACTF_DIV16_Val    _U_(0x3)                                       /**< (RTC_MODE0_CTRLB) CLK_RTC_OUT = CLK_RTC/16  */
+#define   RTC_MODE0_CTRLB_ACTF_DIV32_Val    _U_(0x4)                                       /**< (RTC_MODE0_CTRLB) CLK_RTC_OUT = CLK_RTC/32  */
+#define   RTC_MODE0_CTRLB_ACTF_DIV64_Val    _U_(0x5)                                       /**< (RTC_MODE0_CTRLB) CLK_RTC_OUT = CLK_RTC/64  */
+#define   RTC_MODE0_CTRLB_ACTF_DIV128_Val   _U_(0x6)                                       /**< (RTC_MODE0_CTRLB) CLK_RTC_OUT = CLK_RTC/128  */
+#define   RTC_MODE0_CTRLB_ACTF_DIV256_Val   _U_(0x7)                                       /**< (RTC_MODE0_CTRLB) CLK_RTC_OUT = CLK_RTC/256  */
+#define RTC_MODE0_CTRLB_ACTF_DIV2           (RTC_MODE0_CTRLB_ACTF_DIV2_Val << RTC_MODE0_CTRLB_ACTF_Pos)  /**< (RTC_MODE0_CTRLB) CLK_RTC_OUT = CLK_RTC/2 Position  */
+#define RTC_MODE0_CTRLB_ACTF_DIV4           (RTC_MODE0_CTRLB_ACTF_DIV4_Val << RTC_MODE0_CTRLB_ACTF_Pos)  /**< (RTC_MODE0_CTRLB) CLK_RTC_OUT = CLK_RTC/4 Position  */
+#define RTC_MODE0_CTRLB_ACTF_DIV8           (RTC_MODE0_CTRLB_ACTF_DIV8_Val << RTC_MODE0_CTRLB_ACTF_Pos)  /**< (RTC_MODE0_CTRLB) CLK_RTC_OUT = CLK_RTC/8 Position  */
+#define RTC_MODE0_CTRLB_ACTF_DIV16          (RTC_MODE0_CTRLB_ACTF_DIV16_Val << RTC_MODE0_CTRLB_ACTF_Pos)  /**< (RTC_MODE0_CTRLB) CLK_RTC_OUT = CLK_RTC/16 Position  */
+#define RTC_MODE0_CTRLB_ACTF_DIV32          (RTC_MODE0_CTRLB_ACTF_DIV32_Val << RTC_MODE0_CTRLB_ACTF_Pos)  /**< (RTC_MODE0_CTRLB) CLK_RTC_OUT = CLK_RTC/32 Position  */
+#define RTC_MODE0_CTRLB_ACTF_DIV64          (RTC_MODE0_CTRLB_ACTF_DIV64_Val << RTC_MODE0_CTRLB_ACTF_Pos)  /**< (RTC_MODE0_CTRLB) CLK_RTC_OUT = CLK_RTC/64 Position  */
+#define RTC_MODE0_CTRLB_ACTF_DIV128         (RTC_MODE0_CTRLB_ACTF_DIV128_Val << RTC_MODE0_CTRLB_ACTF_Pos)  /**< (RTC_MODE0_CTRLB) CLK_RTC_OUT = CLK_RTC/128 Position  */
+#define RTC_MODE0_CTRLB_ACTF_DIV256         (RTC_MODE0_CTRLB_ACTF_DIV256_Val << RTC_MODE0_CTRLB_ACTF_Pos)  /**< (RTC_MODE0_CTRLB) CLK_RTC_OUT = CLK_RTC/256 Position  */
+#define RTC_MODE0_CTRLB_SEPTO_Pos           15                                             /**< (RTC_MODE0_CTRLB) Separate Tamper Outputs Position */
+#define RTC_MODE0_CTRLB_SEPTO_Msk           (_U_(0x1) << RTC_MODE0_CTRLB_SEPTO_Pos)        /**< (RTC_MODE0_CTRLB) Separate Tamper Outputs Mask */
+#define RTC_MODE0_CTRLB_SEPTO               RTC_MODE0_CTRLB_SEPTO_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_CTRLB_SEPTO_Msk instead */
+#define RTC_MODE0_CTRLB_MASK                _U_(0xF7F1)                                    /**< \deprecated (RTC_MODE0_CTRLB) Register MASK  (Use RTC_MODE0_CTRLB_Msk instead)  */
+#define RTC_MODE0_CTRLB_Msk                 _U_(0xF7F1)                                    /**< (RTC_MODE0_CTRLB) Register Mask  */
+
+
+/* -------- RTC_MODE1_CTRLB : (RTC Offset: 0x02) (R/W 16) MODE1 Control B -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t GP0EN:1;                   /**< bit:      0  General Purpose 0 Enable                 */
+    uint16_t :3;                        /**< bit:   1..3  Reserved */
+    uint16_t DEBMAJ:1;                  /**< bit:      4  Debouncer Majority Enable                */
+    uint16_t DEBASYNC:1;                /**< bit:      5  Debouncer Asynchronous Enable            */
+    uint16_t RTCOUT:1;                  /**< bit:      6  RTC Output Enable                        */
+    uint16_t DMAEN:1;                   /**< bit:      7  DMA Enable                               */
+    uint16_t DEBF:3;                    /**< bit:  8..10  Debounce Frequency                       */
+    uint16_t :1;                        /**< bit:     11  Reserved */
+    uint16_t ACTF:3;                    /**< bit: 12..14  Active Layer Frequency                   */
+    uint16_t SEPTO:1;                   /**< bit:     15  Separate Tamper Outputs                  */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} RTC_MODE1_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE1_CTRLB_OFFSET              (0x02)                                        /**<  (RTC_MODE1_CTRLB) MODE1 Control B  Offset */
+#define RTC_MODE1_CTRLB_RESETVALUE          _U_(0x00)                                     /**<  (RTC_MODE1_CTRLB) MODE1 Control B  Reset Value */
+
+#define RTC_MODE1_CTRLB_GP0EN_Pos           0                                              /**< (RTC_MODE1_CTRLB) General Purpose 0 Enable Position */
+#define RTC_MODE1_CTRLB_GP0EN_Msk           (_U_(0x1) << RTC_MODE1_CTRLB_GP0EN_Pos)        /**< (RTC_MODE1_CTRLB) General Purpose 0 Enable Mask */
+#define RTC_MODE1_CTRLB_GP0EN               RTC_MODE1_CTRLB_GP0EN_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_CTRLB_GP0EN_Msk instead */
+#define RTC_MODE1_CTRLB_DEBMAJ_Pos          4                                              /**< (RTC_MODE1_CTRLB) Debouncer Majority Enable Position */
+#define RTC_MODE1_CTRLB_DEBMAJ_Msk          (_U_(0x1) << RTC_MODE1_CTRLB_DEBMAJ_Pos)       /**< (RTC_MODE1_CTRLB) Debouncer Majority Enable Mask */
+#define RTC_MODE1_CTRLB_DEBMAJ              RTC_MODE1_CTRLB_DEBMAJ_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_CTRLB_DEBMAJ_Msk instead */
+#define RTC_MODE1_CTRLB_DEBASYNC_Pos        5                                              /**< (RTC_MODE1_CTRLB) Debouncer Asynchronous Enable Position */
+#define RTC_MODE1_CTRLB_DEBASYNC_Msk        (_U_(0x1) << RTC_MODE1_CTRLB_DEBASYNC_Pos)     /**< (RTC_MODE1_CTRLB) Debouncer Asynchronous Enable Mask */
+#define RTC_MODE1_CTRLB_DEBASYNC            RTC_MODE1_CTRLB_DEBASYNC_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_CTRLB_DEBASYNC_Msk instead */
+#define RTC_MODE1_CTRLB_RTCOUT_Pos          6                                              /**< (RTC_MODE1_CTRLB) RTC Output Enable Position */
+#define RTC_MODE1_CTRLB_RTCOUT_Msk          (_U_(0x1) << RTC_MODE1_CTRLB_RTCOUT_Pos)       /**< (RTC_MODE1_CTRLB) RTC Output Enable Mask */
+#define RTC_MODE1_CTRLB_RTCOUT              RTC_MODE1_CTRLB_RTCOUT_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_CTRLB_RTCOUT_Msk instead */
+#define RTC_MODE1_CTRLB_DMAEN_Pos           7                                              /**< (RTC_MODE1_CTRLB) DMA Enable Position */
+#define RTC_MODE1_CTRLB_DMAEN_Msk           (_U_(0x1) << RTC_MODE1_CTRLB_DMAEN_Pos)        /**< (RTC_MODE1_CTRLB) DMA Enable Mask */
+#define RTC_MODE1_CTRLB_DMAEN               RTC_MODE1_CTRLB_DMAEN_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_CTRLB_DMAEN_Msk instead */
+#define RTC_MODE1_CTRLB_DEBF_Pos            8                                              /**< (RTC_MODE1_CTRLB) Debounce Frequency Position */
+#define RTC_MODE1_CTRLB_DEBF_Msk            (_U_(0x7) << RTC_MODE1_CTRLB_DEBF_Pos)         /**< (RTC_MODE1_CTRLB) Debounce Frequency Mask */
+#define RTC_MODE1_CTRLB_DEBF(value)         (RTC_MODE1_CTRLB_DEBF_Msk & ((value) << RTC_MODE1_CTRLB_DEBF_Pos))
+#define   RTC_MODE1_CTRLB_DEBF_DIV2_Val     _U_(0x0)                                       /**< (RTC_MODE1_CTRLB) CLK_RTC_DEB = CLK_RTC/2  */
+#define   RTC_MODE1_CTRLB_DEBF_DIV4_Val     _U_(0x1)                                       /**< (RTC_MODE1_CTRLB) CLK_RTC_DEB = CLK_RTC/4  */
+#define   RTC_MODE1_CTRLB_DEBF_DIV8_Val     _U_(0x2)                                       /**< (RTC_MODE1_CTRLB) CLK_RTC_DEB = CLK_RTC/8  */
+#define   RTC_MODE1_CTRLB_DEBF_DIV16_Val    _U_(0x3)                                       /**< (RTC_MODE1_CTRLB) CLK_RTC_DEB = CLK_RTC/16  */
+#define   RTC_MODE1_CTRLB_DEBF_DIV32_Val    _U_(0x4)                                       /**< (RTC_MODE1_CTRLB) CLK_RTC_DEB = CLK_RTC/32  */
+#define   RTC_MODE1_CTRLB_DEBF_DIV64_Val    _U_(0x5)                                       /**< (RTC_MODE1_CTRLB) CLK_RTC_DEB = CLK_RTC/64  */
+#define   RTC_MODE1_CTRLB_DEBF_DIV128_Val   _U_(0x6)                                       /**< (RTC_MODE1_CTRLB) CLK_RTC_DEB = CLK_RTC/128  */
+#define   RTC_MODE1_CTRLB_DEBF_DIV256_Val   _U_(0x7)                                       /**< (RTC_MODE1_CTRLB) CLK_RTC_DEB = CLK_RTC/256  */
+#define RTC_MODE1_CTRLB_DEBF_DIV2           (RTC_MODE1_CTRLB_DEBF_DIV2_Val << RTC_MODE1_CTRLB_DEBF_Pos)  /**< (RTC_MODE1_CTRLB) CLK_RTC_DEB = CLK_RTC/2 Position  */
+#define RTC_MODE1_CTRLB_DEBF_DIV4           (RTC_MODE1_CTRLB_DEBF_DIV4_Val << RTC_MODE1_CTRLB_DEBF_Pos)  /**< (RTC_MODE1_CTRLB) CLK_RTC_DEB = CLK_RTC/4 Position  */
+#define RTC_MODE1_CTRLB_DEBF_DIV8           (RTC_MODE1_CTRLB_DEBF_DIV8_Val << RTC_MODE1_CTRLB_DEBF_Pos)  /**< (RTC_MODE1_CTRLB) CLK_RTC_DEB = CLK_RTC/8 Position  */
+#define RTC_MODE1_CTRLB_DEBF_DIV16          (RTC_MODE1_CTRLB_DEBF_DIV16_Val << RTC_MODE1_CTRLB_DEBF_Pos)  /**< (RTC_MODE1_CTRLB) CLK_RTC_DEB = CLK_RTC/16 Position  */
+#define RTC_MODE1_CTRLB_DEBF_DIV32          (RTC_MODE1_CTRLB_DEBF_DIV32_Val << RTC_MODE1_CTRLB_DEBF_Pos)  /**< (RTC_MODE1_CTRLB) CLK_RTC_DEB = CLK_RTC/32 Position  */
+#define RTC_MODE1_CTRLB_DEBF_DIV64          (RTC_MODE1_CTRLB_DEBF_DIV64_Val << RTC_MODE1_CTRLB_DEBF_Pos)  /**< (RTC_MODE1_CTRLB) CLK_RTC_DEB = CLK_RTC/64 Position  */
+#define RTC_MODE1_CTRLB_DEBF_DIV128         (RTC_MODE1_CTRLB_DEBF_DIV128_Val << RTC_MODE1_CTRLB_DEBF_Pos)  /**< (RTC_MODE1_CTRLB) CLK_RTC_DEB = CLK_RTC/128 Position  */
+#define RTC_MODE1_CTRLB_DEBF_DIV256         (RTC_MODE1_CTRLB_DEBF_DIV256_Val << RTC_MODE1_CTRLB_DEBF_Pos)  /**< (RTC_MODE1_CTRLB) CLK_RTC_DEB = CLK_RTC/256 Position  */
+#define RTC_MODE1_CTRLB_ACTF_Pos            12                                             /**< (RTC_MODE1_CTRLB) Active Layer Frequency Position */
+#define RTC_MODE1_CTRLB_ACTF_Msk            (_U_(0x7) << RTC_MODE1_CTRLB_ACTF_Pos)         /**< (RTC_MODE1_CTRLB) Active Layer Frequency Mask */
+#define RTC_MODE1_CTRLB_ACTF(value)         (RTC_MODE1_CTRLB_ACTF_Msk & ((value) << RTC_MODE1_CTRLB_ACTF_Pos))
+#define   RTC_MODE1_CTRLB_ACTF_DIV2_Val     _U_(0x0)                                       /**< (RTC_MODE1_CTRLB) CLK_RTC_OUT = CLK_RTC/2  */
+#define   RTC_MODE1_CTRLB_ACTF_DIV4_Val     _U_(0x1)                                       /**< (RTC_MODE1_CTRLB) CLK_RTC_OUT = CLK_RTC/4  */
+#define   RTC_MODE1_CTRLB_ACTF_DIV8_Val     _U_(0x2)                                       /**< (RTC_MODE1_CTRLB) CLK_RTC_OUT = CLK_RTC/8  */
+#define   RTC_MODE1_CTRLB_ACTF_DIV16_Val    _U_(0x3)                                       /**< (RTC_MODE1_CTRLB) CLK_RTC_OUT = CLK_RTC/16  */
+#define   RTC_MODE1_CTRLB_ACTF_DIV32_Val    _U_(0x4)                                       /**< (RTC_MODE1_CTRLB) CLK_RTC_OUT = CLK_RTC/32  */
+#define   RTC_MODE1_CTRLB_ACTF_DIV64_Val    _U_(0x5)                                       /**< (RTC_MODE1_CTRLB) CLK_RTC_OUT = CLK_RTC/64  */
+#define   RTC_MODE1_CTRLB_ACTF_DIV128_Val   _U_(0x6)                                       /**< (RTC_MODE1_CTRLB) CLK_RTC_OUT = CLK_RTC/128  */
+#define   RTC_MODE1_CTRLB_ACTF_DIV256_Val   _U_(0x7)                                       /**< (RTC_MODE1_CTRLB) CLK_RTC_OUT = CLK_RTC/256  */
+#define RTC_MODE1_CTRLB_ACTF_DIV2           (RTC_MODE1_CTRLB_ACTF_DIV2_Val << RTC_MODE1_CTRLB_ACTF_Pos)  /**< (RTC_MODE1_CTRLB) CLK_RTC_OUT = CLK_RTC/2 Position  */
+#define RTC_MODE1_CTRLB_ACTF_DIV4           (RTC_MODE1_CTRLB_ACTF_DIV4_Val << RTC_MODE1_CTRLB_ACTF_Pos)  /**< (RTC_MODE1_CTRLB) CLK_RTC_OUT = CLK_RTC/4 Position  */
+#define RTC_MODE1_CTRLB_ACTF_DIV8           (RTC_MODE1_CTRLB_ACTF_DIV8_Val << RTC_MODE1_CTRLB_ACTF_Pos)  /**< (RTC_MODE1_CTRLB) CLK_RTC_OUT = CLK_RTC/8 Position  */
+#define RTC_MODE1_CTRLB_ACTF_DIV16          (RTC_MODE1_CTRLB_ACTF_DIV16_Val << RTC_MODE1_CTRLB_ACTF_Pos)  /**< (RTC_MODE1_CTRLB) CLK_RTC_OUT = CLK_RTC/16 Position  */
+#define RTC_MODE1_CTRLB_ACTF_DIV32          (RTC_MODE1_CTRLB_ACTF_DIV32_Val << RTC_MODE1_CTRLB_ACTF_Pos)  /**< (RTC_MODE1_CTRLB) CLK_RTC_OUT = CLK_RTC/32 Position  */
+#define RTC_MODE1_CTRLB_ACTF_DIV64          (RTC_MODE1_CTRLB_ACTF_DIV64_Val << RTC_MODE1_CTRLB_ACTF_Pos)  /**< (RTC_MODE1_CTRLB) CLK_RTC_OUT = CLK_RTC/64 Position  */
+#define RTC_MODE1_CTRLB_ACTF_DIV128         (RTC_MODE1_CTRLB_ACTF_DIV128_Val << RTC_MODE1_CTRLB_ACTF_Pos)  /**< (RTC_MODE1_CTRLB) CLK_RTC_OUT = CLK_RTC/128 Position  */
+#define RTC_MODE1_CTRLB_ACTF_DIV256         (RTC_MODE1_CTRLB_ACTF_DIV256_Val << RTC_MODE1_CTRLB_ACTF_Pos)  /**< (RTC_MODE1_CTRLB) CLK_RTC_OUT = CLK_RTC/256 Position  */
+#define RTC_MODE1_CTRLB_SEPTO_Pos           15                                             /**< (RTC_MODE1_CTRLB) Separate Tamper Outputs Position */
+#define RTC_MODE1_CTRLB_SEPTO_Msk           (_U_(0x1) << RTC_MODE1_CTRLB_SEPTO_Pos)        /**< (RTC_MODE1_CTRLB) Separate Tamper Outputs Mask */
+#define RTC_MODE1_CTRLB_SEPTO               RTC_MODE1_CTRLB_SEPTO_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_CTRLB_SEPTO_Msk instead */
+#define RTC_MODE1_CTRLB_MASK                _U_(0xF7F1)                                    /**< \deprecated (RTC_MODE1_CTRLB) Register MASK  (Use RTC_MODE1_CTRLB_Msk instead)  */
+#define RTC_MODE1_CTRLB_Msk                 _U_(0xF7F1)                                    /**< (RTC_MODE1_CTRLB) Register Mask  */
+
+
+/* -------- RTC_MODE2_CTRLB : (RTC Offset: 0x02) (R/W 16) MODE2 Control B -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t GP0EN:1;                   /**< bit:      0  General Purpose 0 Enable                 */
+    uint16_t :3;                        /**< bit:   1..3  Reserved */
+    uint16_t DEBMAJ:1;                  /**< bit:      4  Debouncer Majority Enable                */
+    uint16_t DEBASYNC:1;                /**< bit:      5  Debouncer Asynchronous Enable            */
+    uint16_t RTCOUT:1;                  /**< bit:      6  RTC Output Enable                        */
+    uint16_t DMAEN:1;                   /**< bit:      7  DMA Enable                               */
+    uint16_t DEBF:3;                    /**< bit:  8..10  Debounce Frequency                       */
+    uint16_t :1;                        /**< bit:     11  Reserved */
+    uint16_t ACTF:3;                    /**< bit: 12..14  Active Layer Frequency                   */
+    uint16_t SEPTO:1;                   /**< bit:     15  Separate Tamper Outputs                  */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} RTC_MODE2_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE2_CTRLB_OFFSET              (0x02)                                        /**<  (RTC_MODE2_CTRLB) MODE2 Control B  Offset */
+#define RTC_MODE2_CTRLB_RESETVALUE          _U_(0x00)                                     /**<  (RTC_MODE2_CTRLB) MODE2 Control B  Reset Value */
+
+#define RTC_MODE2_CTRLB_GP0EN_Pos           0                                              /**< (RTC_MODE2_CTRLB) General Purpose 0 Enable Position */
+#define RTC_MODE2_CTRLB_GP0EN_Msk           (_U_(0x1) << RTC_MODE2_CTRLB_GP0EN_Pos)        /**< (RTC_MODE2_CTRLB) General Purpose 0 Enable Mask */
+#define RTC_MODE2_CTRLB_GP0EN               RTC_MODE2_CTRLB_GP0EN_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_CTRLB_GP0EN_Msk instead */
+#define RTC_MODE2_CTRLB_DEBMAJ_Pos          4                                              /**< (RTC_MODE2_CTRLB) Debouncer Majority Enable Position */
+#define RTC_MODE2_CTRLB_DEBMAJ_Msk          (_U_(0x1) << RTC_MODE2_CTRLB_DEBMAJ_Pos)       /**< (RTC_MODE2_CTRLB) Debouncer Majority Enable Mask */
+#define RTC_MODE2_CTRLB_DEBMAJ              RTC_MODE2_CTRLB_DEBMAJ_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_CTRLB_DEBMAJ_Msk instead */
+#define RTC_MODE2_CTRLB_DEBASYNC_Pos        5                                              /**< (RTC_MODE2_CTRLB) Debouncer Asynchronous Enable Position */
+#define RTC_MODE2_CTRLB_DEBASYNC_Msk        (_U_(0x1) << RTC_MODE2_CTRLB_DEBASYNC_Pos)     /**< (RTC_MODE2_CTRLB) Debouncer Asynchronous Enable Mask */
+#define RTC_MODE2_CTRLB_DEBASYNC            RTC_MODE2_CTRLB_DEBASYNC_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_CTRLB_DEBASYNC_Msk instead */
+#define RTC_MODE2_CTRLB_RTCOUT_Pos          6                                              /**< (RTC_MODE2_CTRLB) RTC Output Enable Position */
+#define RTC_MODE2_CTRLB_RTCOUT_Msk          (_U_(0x1) << RTC_MODE2_CTRLB_RTCOUT_Pos)       /**< (RTC_MODE2_CTRLB) RTC Output Enable Mask */
+#define RTC_MODE2_CTRLB_RTCOUT              RTC_MODE2_CTRLB_RTCOUT_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_CTRLB_RTCOUT_Msk instead */
+#define RTC_MODE2_CTRLB_DMAEN_Pos           7                                              /**< (RTC_MODE2_CTRLB) DMA Enable Position */
+#define RTC_MODE2_CTRLB_DMAEN_Msk           (_U_(0x1) << RTC_MODE2_CTRLB_DMAEN_Pos)        /**< (RTC_MODE2_CTRLB) DMA Enable Mask */
+#define RTC_MODE2_CTRLB_DMAEN               RTC_MODE2_CTRLB_DMAEN_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_CTRLB_DMAEN_Msk instead */
+#define RTC_MODE2_CTRLB_DEBF_Pos            8                                              /**< (RTC_MODE2_CTRLB) Debounce Frequency Position */
+#define RTC_MODE2_CTRLB_DEBF_Msk            (_U_(0x7) << RTC_MODE2_CTRLB_DEBF_Pos)         /**< (RTC_MODE2_CTRLB) Debounce Frequency Mask */
+#define RTC_MODE2_CTRLB_DEBF(value)         (RTC_MODE2_CTRLB_DEBF_Msk & ((value) << RTC_MODE2_CTRLB_DEBF_Pos))
+#define   RTC_MODE2_CTRLB_DEBF_DIV2_Val     _U_(0x0)                                       /**< (RTC_MODE2_CTRLB) CLK_RTC_DEB = CLK_RTC/2  */
+#define   RTC_MODE2_CTRLB_DEBF_DIV4_Val     _U_(0x1)                                       /**< (RTC_MODE2_CTRLB) CLK_RTC_DEB = CLK_RTC/4  */
+#define   RTC_MODE2_CTRLB_DEBF_DIV8_Val     _U_(0x2)                                       /**< (RTC_MODE2_CTRLB) CLK_RTC_DEB = CLK_RTC/8  */
+#define   RTC_MODE2_CTRLB_DEBF_DIV16_Val    _U_(0x3)                                       /**< (RTC_MODE2_CTRLB) CLK_RTC_DEB = CLK_RTC/16  */
+#define   RTC_MODE2_CTRLB_DEBF_DIV32_Val    _U_(0x4)                                       /**< (RTC_MODE2_CTRLB) CLK_RTC_DEB = CLK_RTC/32  */
+#define   RTC_MODE2_CTRLB_DEBF_DIV64_Val    _U_(0x5)                                       /**< (RTC_MODE2_CTRLB) CLK_RTC_DEB = CLK_RTC/64  */
+#define   RTC_MODE2_CTRLB_DEBF_DIV128_Val   _U_(0x6)                                       /**< (RTC_MODE2_CTRLB) CLK_RTC_DEB = CLK_RTC/128  */
+#define   RTC_MODE2_CTRLB_DEBF_DIV256_Val   _U_(0x7)                                       /**< (RTC_MODE2_CTRLB) CLK_RTC_DEB = CLK_RTC/256  */
+#define RTC_MODE2_CTRLB_DEBF_DIV2           (RTC_MODE2_CTRLB_DEBF_DIV2_Val << RTC_MODE2_CTRLB_DEBF_Pos)  /**< (RTC_MODE2_CTRLB) CLK_RTC_DEB = CLK_RTC/2 Position  */
+#define RTC_MODE2_CTRLB_DEBF_DIV4           (RTC_MODE2_CTRLB_DEBF_DIV4_Val << RTC_MODE2_CTRLB_DEBF_Pos)  /**< (RTC_MODE2_CTRLB) CLK_RTC_DEB = CLK_RTC/4 Position  */
+#define RTC_MODE2_CTRLB_DEBF_DIV8           (RTC_MODE2_CTRLB_DEBF_DIV8_Val << RTC_MODE2_CTRLB_DEBF_Pos)  /**< (RTC_MODE2_CTRLB) CLK_RTC_DEB = CLK_RTC/8 Position  */
+#define RTC_MODE2_CTRLB_DEBF_DIV16          (RTC_MODE2_CTRLB_DEBF_DIV16_Val << RTC_MODE2_CTRLB_DEBF_Pos)  /**< (RTC_MODE2_CTRLB) CLK_RTC_DEB = CLK_RTC/16 Position  */
+#define RTC_MODE2_CTRLB_DEBF_DIV32          (RTC_MODE2_CTRLB_DEBF_DIV32_Val << RTC_MODE2_CTRLB_DEBF_Pos)  /**< (RTC_MODE2_CTRLB) CLK_RTC_DEB = CLK_RTC/32 Position  */
+#define RTC_MODE2_CTRLB_DEBF_DIV64          (RTC_MODE2_CTRLB_DEBF_DIV64_Val << RTC_MODE2_CTRLB_DEBF_Pos)  /**< (RTC_MODE2_CTRLB) CLK_RTC_DEB = CLK_RTC/64 Position  */
+#define RTC_MODE2_CTRLB_DEBF_DIV128         (RTC_MODE2_CTRLB_DEBF_DIV128_Val << RTC_MODE2_CTRLB_DEBF_Pos)  /**< (RTC_MODE2_CTRLB) CLK_RTC_DEB = CLK_RTC/128 Position  */
+#define RTC_MODE2_CTRLB_DEBF_DIV256         (RTC_MODE2_CTRLB_DEBF_DIV256_Val << RTC_MODE2_CTRLB_DEBF_Pos)  /**< (RTC_MODE2_CTRLB) CLK_RTC_DEB = CLK_RTC/256 Position  */
+#define RTC_MODE2_CTRLB_ACTF_Pos            12                                             /**< (RTC_MODE2_CTRLB) Active Layer Frequency Position */
+#define RTC_MODE2_CTRLB_ACTF_Msk            (_U_(0x7) << RTC_MODE2_CTRLB_ACTF_Pos)         /**< (RTC_MODE2_CTRLB) Active Layer Frequency Mask */
+#define RTC_MODE2_CTRLB_ACTF(value)         (RTC_MODE2_CTRLB_ACTF_Msk & ((value) << RTC_MODE2_CTRLB_ACTF_Pos))
+#define   RTC_MODE2_CTRLB_ACTF_DIV2_Val     _U_(0x0)                                       /**< (RTC_MODE2_CTRLB) CLK_RTC_OUT = CLK_RTC/2  */
+#define   RTC_MODE2_CTRLB_ACTF_DIV4_Val     _U_(0x1)                                       /**< (RTC_MODE2_CTRLB) CLK_RTC_OUT = CLK_RTC/4  */
+#define   RTC_MODE2_CTRLB_ACTF_DIV8_Val     _U_(0x2)                                       /**< (RTC_MODE2_CTRLB) CLK_RTC_OUT = CLK_RTC/8  */
+#define   RTC_MODE2_CTRLB_ACTF_DIV16_Val    _U_(0x3)                                       /**< (RTC_MODE2_CTRLB) CLK_RTC_OUT = CLK_RTC/16  */
+#define   RTC_MODE2_CTRLB_ACTF_DIV32_Val    _U_(0x4)                                       /**< (RTC_MODE2_CTRLB) CLK_RTC_OUT = CLK_RTC/32  */
+#define   RTC_MODE2_CTRLB_ACTF_DIV64_Val    _U_(0x5)                                       /**< (RTC_MODE2_CTRLB) CLK_RTC_OUT = CLK_RTC/64  */
+#define   RTC_MODE2_CTRLB_ACTF_DIV128_Val   _U_(0x6)                                       /**< (RTC_MODE2_CTRLB) CLK_RTC_OUT = CLK_RTC/128  */
+#define   RTC_MODE2_CTRLB_ACTF_DIV256_Val   _U_(0x7)                                       /**< (RTC_MODE2_CTRLB) CLK_RTC_OUT = CLK_RTC/256  */
+#define RTC_MODE2_CTRLB_ACTF_DIV2           (RTC_MODE2_CTRLB_ACTF_DIV2_Val << RTC_MODE2_CTRLB_ACTF_Pos)  /**< (RTC_MODE2_CTRLB) CLK_RTC_OUT = CLK_RTC/2 Position  */
+#define RTC_MODE2_CTRLB_ACTF_DIV4           (RTC_MODE2_CTRLB_ACTF_DIV4_Val << RTC_MODE2_CTRLB_ACTF_Pos)  /**< (RTC_MODE2_CTRLB) CLK_RTC_OUT = CLK_RTC/4 Position  */
+#define RTC_MODE2_CTRLB_ACTF_DIV8           (RTC_MODE2_CTRLB_ACTF_DIV8_Val << RTC_MODE2_CTRLB_ACTF_Pos)  /**< (RTC_MODE2_CTRLB) CLK_RTC_OUT = CLK_RTC/8 Position  */
+#define RTC_MODE2_CTRLB_ACTF_DIV16          (RTC_MODE2_CTRLB_ACTF_DIV16_Val << RTC_MODE2_CTRLB_ACTF_Pos)  /**< (RTC_MODE2_CTRLB) CLK_RTC_OUT = CLK_RTC/16 Position  */
+#define RTC_MODE2_CTRLB_ACTF_DIV32          (RTC_MODE2_CTRLB_ACTF_DIV32_Val << RTC_MODE2_CTRLB_ACTF_Pos)  /**< (RTC_MODE2_CTRLB) CLK_RTC_OUT = CLK_RTC/32 Position  */
+#define RTC_MODE2_CTRLB_ACTF_DIV64          (RTC_MODE2_CTRLB_ACTF_DIV64_Val << RTC_MODE2_CTRLB_ACTF_Pos)  /**< (RTC_MODE2_CTRLB) CLK_RTC_OUT = CLK_RTC/64 Position  */
+#define RTC_MODE2_CTRLB_ACTF_DIV128         (RTC_MODE2_CTRLB_ACTF_DIV128_Val << RTC_MODE2_CTRLB_ACTF_Pos)  /**< (RTC_MODE2_CTRLB) CLK_RTC_OUT = CLK_RTC/128 Position  */
+#define RTC_MODE2_CTRLB_ACTF_DIV256         (RTC_MODE2_CTRLB_ACTF_DIV256_Val << RTC_MODE2_CTRLB_ACTF_Pos)  /**< (RTC_MODE2_CTRLB) CLK_RTC_OUT = CLK_RTC/256 Position  */
+#define RTC_MODE2_CTRLB_SEPTO_Pos           15                                             /**< (RTC_MODE2_CTRLB) Separate Tamper Outputs Position */
+#define RTC_MODE2_CTRLB_SEPTO_Msk           (_U_(0x1) << RTC_MODE2_CTRLB_SEPTO_Pos)        /**< (RTC_MODE2_CTRLB) Separate Tamper Outputs Mask */
+#define RTC_MODE2_CTRLB_SEPTO               RTC_MODE2_CTRLB_SEPTO_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_CTRLB_SEPTO_Msk instead */
+#define RTC_MODE2_CTRLB_MASK                _U_(0xF7F1)                                    /**< \deprecated (RTC_MODE2_CTRLB) Register MASK  (Use RTC_MODE2_CTRLB_Msk instead)  */
+#define RTC_MODE2_CTRLB_Msk                 _U_(0xF7F1)                                    /**< (RTC_MODE2_CTRLB) Register Mask  */
+
+
+/* -------- RTC_MODE0_EVCTRL : (RTC Offset: 0x04) (R/W 32) MODE0 Event Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t PEREO0:1;                  /**< bit:      0  Periodic Interval 0 Event Output Enable  */
+    uint32_t PEREO1:1;                  /**< bit:      1  Periodic Interval 1 Event Output Enable  */
+    uint32_t PEREO2:1;                  /**< bit:      2  Periodic Interval 2 Event Output Enable  */
+    uint32_t PEREO3:1;                  /**< bit:      3  Periodic Interval 3 Event Output Enable  */
+    uint32_t PEREO4:1;                  /**< bit:      4  Periodic Interval 4 Event Output Enable  */
+    uint32_t PEREO5:1;                  /**< bit:      5  Periodic Interval 5 Event Output Enable  */
+    uint32_t PEREO6:1;                  /**< bit:      6  Periodic Interval 6 Event Output Enable  */
+    uint32_t PEREO7:1;                  /**< bit:      7  Periodic Interval 7 Event Output Enable  */
+    uint32_t CMPEO0:1;                  /**< bit:      8  Compare 0 Event Output Enable            */
+    uint32_t :5;                        /**< bit:  9..13  Reserved */
+    uint32_t TAMPEREO:1;                /**< bit:     14  Tamper Event Output Enable               */
+    uint32_t OVFEO:1;                   /**< bit:     15  Overflow Event Output Enable             */
+    uint32_t TAMPEVEI:1;                /**< bit:     16  Tamper Event Input Enable                */
+    uint32_t :7;                        /**< bit: 17..23  Reserved */
+    uint32_t PERDEO:1;                  /**< bit:     24  Periodic Interval Daily Event Output Enable */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t PEREO:8;                   /**< bit:   0..7  Periodic Interval x Event Output Enable  */
+    uint32_t CMPEO:1;                   /**< bit:      8  Compare x Event Output Enable            */
+    uint32_t :23;                       /**< bit:  9..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_MODE0_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE0_EVCTRL_OFFSET             (0x04)                                        /**<  (RTC_MODE0_EVCTRL) MODE0 Event Control  Offset */
+#define RTC_MODE0_EVCTRL_RESETVALUE         _U_(0x00)                                     /**<  (RTC_MODE0_EVCTRL) MODE0 Event Control  Reset Value */
+
+#define RTC_MODE0_EVCTRL_PEREO0_Pos         0                                              /**< (RTC_MODE0_EVCTRL) Periodic Interval 0 Event Output Enable Position */
+#define RTC_MODE0_EVCTRL_PEREO0_Msk         (_U_(0x1) << RTC_MODE0_EVCTRL_PEREO0_Pos)      /**< (RTC_MODE0_EVCTRL) Periodic Interval 0 Event Output Enable Mask */
+#define RTC_MODE0_EVCTRL_PEREO0             RTC_MODE0_EVCTRL_PEREO0_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_EVCTRL_PEREO0_Msk instead */
+#define RTC_MODE0_EVCTRL_PEREO1_Pos         1                                              /**< (RTC_MODE0_EVCTRL) Periodic Interval 1 Event Output Enable Position */
+#define RTC_MODE0_EVCTRL_PEREO1_Msk         (_U_(0x1) << RTC_MODE0_EVCTRL_PEREO1_Pos)      /**< (RTC_MODE0_EVCTRL) Periodic Interval 1 Event Output Enable Mask */
+#define RTC_MODE0_EVCTRL_PEREO1             RTC_MODE0_EVCTRL_PEREO1_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_EVCTRL_PEREO1_Msk instead */
+#define RTC_MODE0_EVCTRL_PEREO2_Pos         2                                              /**< (RTC_MODE0_EVCTRL) Periodic Interval 2 Event Output Enable Position */
+#define RTC_MODE0_EVCTRL_PEREO2_Msk         (_U_(0x1) << RTC_MODE0_EVCTRL_PEREO2_Pos)      /**< (RTC_MODE0_EVCTRL) Periodic Interval 2 Event Output Enable Mask */
+#define RTC_MODE0_EVCTRL_PEREO2             RTC_MODE0_EVCTRL_PEREO2_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_EVCTRL_PEREO2_Msk instead */
+#define RTC_MODE0_EVCTRL_PEREO3_Pos         3                                              /**< (RTC_MODE0_EVCTRL) Periodic Interval 3 Event Output Enable Position */
+#define RTC_MODE0_EVCTRL_PEREO3_Msk         (_U_(0x1) << RTC_MODE0_EVCTRL_PEREO3_Pos)      /**< (RTC_MODE0_EVCTRL) Periodic Interval 3 Event Output Enable Mask */
+#define RTC_MODE0_EVCTRL_PEREO3             RTC_MODE0_EVCTRL_PEREO3_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_EVCTRL_PEREO3_Msk instead */
+#define RTC_MODE0_EVCTRL_PEREO4_Pos         4                                              /**< (RTC_MODE0_EVCTRL) Periodic Interval 4 Event Output Enable Position */
+#define RTC_MODE0_EVCTRL_PEREO4_Msk         (_U_(0x1) << RTC_MODE0_EVCTRL_PEREO4_Pos)      /**< (RTC_MODE0_EVCTRL) Periodic Interval 4 Event Output Enable Mask */
+#define RTC_MODE0_EVCTRL_PEREO4             RTC_MODE0_EVCTRL_PEREO4_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_EVCTRL_PEREO4_Msk instead */
+#define RTC_MODE0_EVCTRL_PEREO5_Pos         5                                              /**< (RTC_MODE0_EVCTRL) Periodic Interval 5 Event Output Enable Position */
+#define RTC_MODE0_EVCTRL_PEREO5_Msk         (_U_(0x1) << RTC_MODE0_EVCTRL_PEREO5_Pos)      /**< (RTC_MODE0_EVCTRL) Periodic Interval 5 Event Output Enable Mask */
+#define RTC_MODE0_EVCTRL_PEREO5             RTC_MODE0_EVCTRL_PEREO5_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_EVCTRL_PEREO5_Msk instead */
+#define RTC_MODE0_EVCTRL_PEREO6_Pos         6                                              /**< (RTC_MODE0_EVCTRL) Periodic Interval 6 Event Output Enable Position */
+#define RTC_MODE0_EVCTRL_PEREO6_Msk         (_U_(0x1) << RTC_MODE0_EVCTRL_PEREO6_Pos)      /**< (RTC_MODE0_EVCTRL) Periodic Interval 6 Event Output Enable Mask */
+#define RTC_MODE0_EVCTRL_PEREO6             RTC_MODE0_EVCTRL_PEREO6_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_EVCTRL_PEREO6_Msk instead */
+#define RTC_MODE0_EVCTRL_PEREO7_Pos         7                                              /**< (RTC_MODE0_EVCTRL) Periodic Interval 7 Event Output Enable Position */
+#define RTC_MODE0_EVCTRL_PEREO7_Msk         (_U_(0x1) << RTC_MODE0_EVCTRL_PEREO7_Pos)      /**< (RTC_MODE0_EVCTRL) Periodic Interval 7 Event Output Enable Mask */
+#define RTC_MODE0_EVCTRL_PEREO7             RTC_MODE0_EVCTRL_PEREO7_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_EVCTRL_PEREO7_Msk instead */
+#define RTC_MODE0_EVCTRL_CMPEO0_Pos         8                                              /**< (RTC_MODE0_EVCTRL) Compare 0 Event Output Enable Position */
+#define RTC_MODE0_EVCTRL_CMPEO0_Msk         (_U_(0x1) << RTC_MODE0_EVCTRL_CMPEO0_Pos)      /**< (RTC_MODE0_EVCTRL) Compare 0 Event Output Enable Mask */
+#define RTC_MODE0_EVCTRL_CMPEO0             RTC_MODE0_EVCTRL_CMPEO0_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_EVCTRL_CMPEO0_Msk instead */
+#define RTC_MODE0_EVCTRL_TAMPEREO_Pos       14                                             /**< (RTC_MODE0_EVCTRL) Tamper Event Output Enable Position */
+#define RTC_MODE0_EVCTRL_TAMPEREO_Msk       (_U_(0x1) << RTC_MODE0_EVCTRL_TAMPEREO_Pos)    /**< (RTC_MODE0_EVCTRL) Tamper Event Output Enable Mask */
+#define RTC_MODE0_EVCTRL_TAMPEREO           RTC_MODE0_EVCTRL_TAMPEREO_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_EVCTRL_TAMPEREO_Msk instead */
+#define RTC_MODE0_EVCTRL_OVFEO_Pos          15                                             /**< (RTC_MODE0_EVCTRL) Overflow Event Output Enable Position */
+#define RTC_MODE0_EVCTRL_OVFEO_Msk          (_U_(0x1) << RTC_MODE0_EVCTRL_OVFEO_Pos)       /**< (RTC_MODE0_EVCTRL) Overflow Event Output Enable Mask */
+#define RTC_MODE0_EVCTRL_OVFEO              RTC_MODE0_EVCTRL_OVFEO_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_EVCTRL_OVFEO_Msk instead */
+#define RTC_MODE0_EVCTRL_TAMPEVEI_Pos       16                                             /**< (RTC_MODE0_EVCTRL) Tamper Event Input Enable Position */
+#define RTC_MODE0_EVCTRL_TAMPEVEI_Msk       (_U_(0x1) << RTC_MODE0_EVCTRL_TAMPEVEI_Pos)    /**< (RTC_MODE0_EVCTRL) Tamper Event Input Enable Mask */
+#define RTC_MODE0_EVCTRL_TAMPEVEI           RTC_MODE0_EVCTRL_TAMPEVEI_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_EVCTRL_TAMPEVEI_Msk instead */
+#define RTC_MODE0_EVCTRL_PERDEO_Pos         24                                             /**< (RTC_MODE0_EVCTRL) Periodic Interval Daily Event Output Enable Position */
+#define RTC_MODE0_EVCTRL_PERDEO_Msk         (_U_(0x1) << RTC_MODE0_EVCTRL_PERDEO_Pos)      /**< (RTC_MODE0_EVCTRL) Periodic Interval Daily Event Output Enable Mask */
+#define RTC_MODE0_EVCTRL_PERDEO             RTC_MODE0_EVCTRL_PERDEO_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_EVCTRL_PERDEO_Msk instead */
+#define RTC_MODE0_EVCTRL_MASK               _U_(0x101C1FF)                                 /**< \deprecated (RTC_MODE0_EVCTRL) Register MASK  (Use RTC_MODE0_EVCTRL_Msk instead)  */
+#define RTC_MODE0_EVCTRL_Msk                _U_(0x101C1FF)                                 /**< (RTC_MODE0_EVCTRL) Register Mask  */
+
+#define RTC_MODE0_EVCTRL_PEREO_Pos          0                                              /**< (RTC_MODE0_EVCTRL Position) Periodic Interval x Event Output Enable */
+#define RTC_MODE0_EVCTRL_PEREO_Msk          (_U_(0xFF) << RTC_MODE0_EVCTRL_PEREO_Pos)      /**< (RTC_MODE0_EVCTRL Mask) PEREO */
+#define RTC_MODE0_EVCTRL_PEREO(value)       (RTC_MODE0_EVCTRL_PEREO_Msk & ((value) << RTC_MODE0_EVCTRL_PEREO_Pos))  
+#define RTC_MODE0_EVCTRL_CMPEO_Pos          8                                              /**< (RTC_MODE0_EVCTRL Position) Compare x Event Output Enable */
+#define RTC_MODE0_EVCTRL_CMPEO_Msk          (_U_(0x1) << RTC_MODE0_EVCTRL_CMPEO_Pos)       /**< (RTC_MODE0_EVCTRL Mask) CMPEO */
+#define RTC_MODE0_EVCTRL_CMPEO(value)       (RTC_MODE0_EVCTRL_CMPEO_Msk & ((value) << RTC_MODE0_EVCTRL_CMPEO_Pos))  
+
+/* -------- RTC_MODE1_EVCTRL : (RTC Offset: 0x04) (R/W 32) MODE1 Event Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t PEREO0:1;                  /**< bit:      0  Periodic Interval 0 Event Output Enable  */
+    uint32_t PEREO1:1;                  /**< bit:      1  Periodic Interval 1 Event Output Enable  */
+    uint32_t PEREO2:1;                  /**< bit:      2  Periodic Interval 2 Event Output Enable  */
+    uint32_t PEREO3:1;                  /**< bit:      3  Periodic Interval 3 Event Output Enable  */
+    uint32_t PEREO4:1;                  /**< bit:      4  Periodic Interval 4 Event Output Enable  */
+    uint32_t PEREO5:1;                  /**< bit:      5  Periodic Interval 5 Event Output Enable  */
+    uint32_t PEREO6:1;                  /**< bit:      6  Periodic Interval 6 Event Output Enable  */
+    uint32_t PEREO7:1;                  /**< bit:      7  Periodic Interval 7 Event Output Enable  */
+    uint32_t CMPEO0:1;                  /**< bit:      8  Compare 0 Event Output Enable            */
+    uint32_t CMPEO1:1;                  /**< bit:      9  Compare 1 Event Output Enable            */
+    uint32_t :4;                        /**< bit: 10..13  Reserved */
+    uint32_t TAMPEREO:1;                /**< bit:     14  Tamper Event Output Enable               */
+    uint32_t OVFEO:1;                   /**< bit:     15  Overflow Event Output Enable             */
+    uint32_t TAMPEVEI:1;                /**< bit:     16  Tamper Event Input Enable                */
+    uint32_t :7;                        /**< bit: 17..23  Reserved */
+    uint32_t PERDEO:1;                  /**< bit:     24  Periodic Interval Daily Event Output Enable */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t PEREO:8;                   /**< bit:   0..7  Periodic Interval x Event Output Enable  */
+    uint32_t CMPEO:2;                   /**< bit:   8..9  Compare x Event Output Enable            */
+    uint32_t :22;                       /**< bit: 10..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_MODE1_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE1_EVCTRL_OFFSET             (0x04)                                        /**<  (RTC_MODE1_EVCTRL) MODE1 Event Control  Offset */
+#define RTC_MODE1_EVCTRL_RESETVALUE         _U_(0x00)                                     /**<  (RTC_MODE1_EVCTRL) MODE1 Event Control  Reset Value */
+
+#define RTC_MODE1_EVCTRL_PEREO0_Pos         0                                              /**< (RTC_MODE1_EVCTRL) Periodic Interval 0 Event Output Enable Position */
+#define RTC_MODE1_EVCTRL_PEREO0_Msk         (_U_(0x1) << RTC_MODE1_EVCTRL_PEREO0_Pos)      /**< (RTC_MODE1_EVCTRL) Periodic Interval 0 Event Output Enable Mask */
+#define RTC_MODE1_EVCTRL_PEREO0             RTC_MODE1_EVCTRL_PEREO0_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_EVCTRL_PEREO0_Msk instead */
+#define RTC_MODE1_EVCTRL_PEREO1_Pos         1                                              /**< (RTC_MODE1_EVCTRL) Periodic Interval 1 Event Output Enable Position */
+#define RTC_MODE1_EVCTRL_PEREO1_Msk         (_U_(0x1) << RTC_MODE1_EVCTRL_PEREO1_Pos)      /**< (RTC_MODE1_EVCTRL) Periodic Interval 1 Event Output Enable Mask */
+#define RTC_MODE1_EVCTRL_PEREO1             RTC_MODE1_EVCTRL_PEREO1_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_EVCTRL_PEREO1_Msk instead */
+#define RTC_MODE1_EVCTRL_PEREO2_Pos         2                                              /**< (RTC_MODE1_EVCTRL) Periodic Interval 2 Event Output Enable Position */
+#define RTC_MODE1_EVCTRL_PEREO2_Msk         (_U_(0x1) << RTC_MODE1_EVCTRL_PEREO2_Pos)      /**< (RTC_MODE1_EVCTRL) Periodic Interval 2 Event Output Enable Mask */
+#define RTC_MODE1_EVCTRL_PEREO2             RTC_MODE1_EVCTRL_PEREO2_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_EVCTRL_PEREO2_Msk instead */
+#define RTC_MODE1_EVCTRL_PEREO3_Pos         3                                              /**< (RTC_MODE1_EVCTRL) Periodic Interval 3 Event Output Enable Position */
+#define RTC_MODE1_EVCTRL_PEREO3_Msk         (_U_(0x1) << RTC_MODE1_EVCTRL_PEREO3_Pos)      /**< (RTC_MODE1_EVCTRL) Periodic Interval 3 Event Output Enable Mask */
+#define RTC_MODE1_EVCTRL_PEREO3             RTC_MODE1_EVCTRL_PEREO3_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_EVCTRL_PEREO3_Msk instead */
+#define RTC_MODE1_EVCTRL_PEREO4_Pos         4                                              /**< (RTC_MODE1_EVCTRL) Periodic Interval 4 Event Output Enable Position */
+#define RTC_MODE1_EVCTRL_PEREO4_Msk         (_U_(0x1) << RTC_MODE1_EVCTRL_PEREO4_Pos)      /**< (RTC_MODE1_EVCTRL) Periodic Interval 4 Event Output Enable Mask */
+#define RTC_MODE1_EVCTRL_PEREO4             RTC_MODE1_EVCTRL_PEREO4_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_EVCTRL_PEREO4_Msk instead */
+#define RTC_MODE1_EVCTRL_PEREO5_Pos         5                                              /**< (RTC_MODE1_EVCTRL) Periodic Interval 5 Event Output Enable Position */
+#define RTC_MODE1_EVCTRL_PEREO5_Msk         (_U_(0x1) << RTC_MODE1_EVCTRL_PEREO5_Pos)      /**< (RTC_MODE1_EVCTRL) Periodic Interval 5 Event Output Enable Mask */
+#define RTC_MODE1_EVCTRL_PEREO5             RTC_MODE1_EVCTRL_PEREO5_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_EVCTRL_PEREO5_Msk instead */
+#define RTC_MODE1_EVCTRL_PEREO6_Pos         6                                              /**< (RTC_MODE1_EVCTRL) Periodic Interval 6 Event Output Enable Position */
+#define RTC_MODE1_EVCTRL_PEREO6_Msk         (_U_(0x1) << RTC_MODE1_EVCTRL_PEREO6_Pos)      /**< (RTC_MODE1_EVCTRL) Periodic Interval 6 Event Output Enable Mask */
+#define RTC_MODE1_EVCTRL_PEREO6             RTC_MODE1_EVCTRL_PEREO6_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_EVCTRL_PEREO6_Msk instead */
+#define RTC_MODE1_EVCTRL_PEREO7_Pos         7                                              /**< (RTC_MODE1_EVCTRL) Periodic Interval 7 Event Output Enable Position */
+#define RTC_MODE1_EVCTRL_PEREO7_Msk         (_U_(0x1) << RTC_MODE1_EVCTRL_PEREO7_Pos)      /**< (RTC_MODE1_EVCTRL) Periodic Interval 7 Event Output Enable Mask */
+#define RTC_MODE1_EVCTRL_PEREO7             RTC_MODE1_EVCTRL_PEREO7_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_EVCTRL_PEREO7_Msk instead */
+#define RTC_MODE1_EVCTRL_CMPEO0_Pos         8                                              /**< (RTC_MODE1_EVCTRL) Compare 0 Event Output Enable Position */
+#define RTC_MODE1_EVCTRL_CMPEO0_Msk         (_U_(0x1) << RTC_MODE1_EVCTRL_CMPEO0_Pos)      /**< (RTC_MODE1_EVCTRL) Compare 0 Event Output Enable Mask */
+#define RTC_MODE1_EVCTRL_CMPEO0             RTC_MODE1_EVCTRL_CMPEO0_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_EVCTRL_CMPEO0_Msk instead */
+#define RTC_MODE1_EVCTRL_CMPEO1_Pos         9                                              /**< (RTC_MODE1_EVCTRL) Compare 1 Event Output Enable Position */
+#define RTC_MODE1_EVCTRL_CMPEO1_Msk         (_U_(0x1) << RTC_MODE1_EVCTRL_CMPEO1_Pos)      /**< (RTC_MODE1_EVCTRL) Compare 1 Event Output Enable Mask */
+#define RTC_MODE1_EVCTRL_CMPEO1             RTC_MODE1_EVCTRL_CMPEO1_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_EVCTRL_CMPEO1_Msk instead */
+#define RTC_MODE1_EVCTRL_TAMPEREO_Pos       14                                             /**< (RTC_MODE1_EVCTRL) Tamper Event Output Enable Position */
+#define RTC_MODE1_EVCTRL_TAMPEREO_Msk       (_U_(0x1) << RTC_MODE1_EVCTRL_TAMPEREO_Pos)    /**< (RTC_MODE1_EVCTRL) Tamper Event Output Enable Mask */
+#define RTC_MODE1_EVCTRL_TAMPEREO           RTC_MODE1_EVCTRL_TAMPEREO_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_EVCTRL_TAMPEREO_Msk instead */
+#define RTC_MODE1_EVCTRL_OVFEO_Pos          15                                             /**< (RTC_MODE1_EVCTRL) Overflow Event Output Enable Position */
+#define RTC_MODE1_EVCTRL_OVFEO_Msk          (_U_(0x1) << RTC_MODE1_EVCTRL_OVFEO_Pos)       /**< (RTC_MODE1_EVCTRL) Overflow Event Output Enable Mask */
+#define RTC_MODE1_EVCTRL_OVFEO              RTC_MODE1_EVCTRL_OVFEO_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_EVCTRL_OVFEO_Msk instead */
+#define RTC_MODE1_EVCTRL_TAMPEVEI_Pos       16                                             /**< (RTC_MODE1_EVCTRL) Tamper Event Input Enable Position */
+#define RTC_MODE1_EVCTRL_TAMPEVEI_Msk       (_U_(0x1) << RTC_MODE1_EVCTRL_TAMPEVEI_Pos)    /**< (RTC_MODE1_EVCTRL) Tamper Event Input Enable Mask */
+#define RTC_MODE1_EVCTRL_TAMPEVEI           RTC_MODE1_EVCTRL_TAMPEVEI_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_EVCTRL_TAMPEVEI_Msk instead */
+#define RTC_MODE1_EVCTRL_PERDEO_Pos         24                                             /**< (RTC_MODE1_EVCTRL) Periodic Interval Daily Event Output Enable Position */
+#define RTC_MODE1_EVCTRL_PERDEO_Msk         (_U_(0x1) << RTC_MODE1_EVCTRL_PERDEO_Pos)      /**< (RTC_MODE1_EVCTRL) Periodic Interval Daily Event Output Enable Mask */
+#define RTC_MODE1_EVCTRL_PERDEO             RTC_MODE1_EVCTRL_PERDEO_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_EVCTRL_PERDEO_Msk instead */
+#define RTC_MODE1_EVCTRL_MASK               _U_(0x101C3FF)                                 /**< \deprecated (RTC_MODE1_EVCTRL) Register MASK  (Use RTC_MODE1_EVCTRL_Msk instead)  */
+#define RTC_MODE1_EVCTRL_Msk                _U_(0x101C3FF)                                 /**< (RTC_MODE1_EVCTRL) Register Mask  */
+
+#define RTC_MODE1_EVCTRL_PEREO_Pos          0                                              /**< (RTC_MODE1_EVCTRL Position) Periodic Interval x Event Output Enable */
+#define RTC_MODE1_EVCTRL_PEREO_Msk          (_U_(0xFF) << RTC_MODE1_EVCTRL_PEREO_Pos)      /**< (RTC_MODE1_EVCTRL Mask) PEREO */
+#define RTC_MODE1_EVCTRL_PEREO(value)       (RTC_MODE1_EVCTRL_PEREO_Msk & ((value) << RTC_MODE1_EVCTRL_PEREO_Pos))  
+#define RTC_MODE1_EVCTRL_CMPEO_Pos          8                                              /**< (RTC_MODE1_EVCTRL Position) Compare x Event Output Enable */
+#define RTC_MODE1_EVCTRL_CMPEO_Msk          (_U_(0x3) << RTC_MODE1_EVCTRL_CMPEO_Pos)       /**< (RTC_MODE1_EVCTRL Mask) CMPEO */
+#define RTC_MODE1_EVCTRL_CMPEO(value)       (RTC_MODE1_EVCTRL_CMPEO_Msk & ((value) << RTC_MODE1_EVCTRL_CMPEO_Pos))  
+
+/* -------- RTC_MODE2_EVCTRL : (RTC Offset: 0x04) (R/W 32) MODE2 Event Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t PEREO0:1;                  /**< bit:      0  Periodic Interval 0 Event Output Enable  */
+    uint32_t PEREO1:1;                  /**< bit:      1  Periodic Interval 1 Event Output Enable  */
+    uint32_t PEREO2:1;                  /**< bit:      2  Periodic Interval 2 Event Output Enable  */
+    uint32_t PEREO3:1;                  /**< bit:      3  Periodic Interval 3 Event Output Enable  */
+    uint32_t PEREO4:1;                  /**< bit:      4  Periodic Interval 4 Event Output Enable  */
+    uint32_t PEREO5:1;                  /**< bit:      5  Periodic Interval 5 Event Output Enable  */
+    uint32_t PEREO6:1;                  /**< bit:      6  Periodic Interval 6 Event Output Enable  */
+    uint32_t PEREO7:1;                  /**< bit:      7  Periodic Interval 7 Event Output Enable  */
+    uint32_t ALARMEO0:1;                /**< bit:      8  Alarm 0 Event Output Enable              */
+    uint32_t :5;                        /**< bit:  9..13  Reserved */
+    uint32_t TAMPEREO:1;                /**< bit:     14  Tamper Event Output Enable               */
+    uint32_t OVFEO:1;                   /**< bit:     15  Overflow Event Output Enable             */
+    uint32_t TAMPEVEI:1;                /**< bit:     16  Tamper Event Input Enable                */
+    uint32_t :7;                        /**< bit: 17..23  Reserved */
+    uint32_t PERDEO:1;                  /**< bit:     24  Periodic Interval Daily Event Output Enable */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t PEREO:8;                   /**< bit:   0..7  Periodic Interval x Event Output Enable  */
+    uint32_t ALARMEO:1;                 /**< bit:      8  Alarm x Event Output Enable              */
+    uint32_t :23;                       /**< bit:  9..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_MODE2_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE2_EVCTRL_OFFSET             (0x04)                                        /**<  (RTC_MODE2_EVCTRL) MODE2 Event Control  Offset */
+#define RTC_MODE2_EVCTRL_RESETVALUE         _U_(0x00)                                     /**<  (RTC_MODE2_EVCTRL) MODE2 Event Control  Reset Value */
+
+#define RTC_MODE2_EVCTRL_PEREO0_Pos         0                                              /**< (RTC_MODE2_EVCTRL) Periodic Interval 0 Event Output Enable Position */
+#define RTC_MODE2_EVCTRL_PEREO0_Msk         (_U_(0x1) << RTC_MODE2_EVCTRL_PEREO0_Pos)      /**< (RTC_MODE2_EVCTRL) Periodic Interval 0 Event Output Enable Mask */
+#define RTC_MODE2_EVCTRL_PEREO0             RTC_MODE2_EVCTRL_PEREO0_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_EVCTRL_PEREO0_Msk instead */
+#define RTC_MODE2_EVCTRL_PEREO1_Pos         1                                              /**< (RTC_MODE2_EVCTRL) Periodic Interval 1 Event Output Enable Position */
+#define RTC_MODE2_EVCTRL_PEREO1_Msk         (_U_(0x1) << RTC_MODE2_EVCTRL_PEREO1_Pos)      /**< (RTC_MODE2_EVCTRL) Periodic Interval 1 Event Output Enable Mask */
+#define RTC_MODE2_EVCTRL_PEREO1             RTC_MODE2_EVCTRL_PEREO1_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_EVCTRL_PEREO1_Msk instead */
+#define RTC_MODE2_EVCTRL_PEREO2_Pos         2                                              /**< (RTC_MODE2_EVCTRL) Periodic Interval 2 Event Output Enable Position */
+#define RTC_MODE2_EVCTRL_PEREO2_Msk         (_U_(0x1) << RTC_MODE2_EVCTRL_PEREO2_Pos)      /**< (RTC_MODE2_EVCTRL) Periodic Interval 2 Event Output Enable Mask */
+#define RTC_MODE2_EVCTRL_PEREO2             RTC_MODE2_EVCTRL_PEREO2_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_EVCTRL_PEREO2_Msk instead */
+#define RTC_MODE2_EVCTRL_PEREO3_Pos         3                                              /**< (RTC_MODE2_EVCTRL) Periodic Interval 3 Event Output Enable Position */
+#define RTC_MODE2_EVCTRL_PEREO3_Msk         (_U_(0x1) << RTC_MODE2_EVCTRL_PEREO3_Pos)      /**< (RTC_MODE2_EVCTRL) Periodic Interval 3 Event Output Enable Mask */
+#define RTC_MODE2_EVCTRL_PEREO3             RTC_MODE2_EVCTRL_PEREO3_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_EVCTRL_PEREO3_Msk instead */
+#define RTC_MODE2_EVCTRL_PEREO4_Pos         4                                              /**< (RTC_MODE2_EVCTRL) Periodic Interval 4 Event Output Enable Position */
+#define RTC_MODE2_EVCTRL_PEREO4_Msk         (_U_(0x1) << RTC_MODE2_EVCTRL_PEREO4_Pos)      /**< (RTC_MODE2_EVCTRL) Periodic Interval 4 Event Output Enable Mask */
+#define RTC_MODE2_EVCTRL_PEREO4             RTC_MODE2_EVCTRL_PEREO4_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_EVCTRL_PEREO4_Msk instead */
+#define RTC_MODE2_EVCTRL_PEREO5_Pos         5                                              /**< (RTC_MODE2_EVCTRL) Periodic Interval 5 Event Output Enable Position */
+#define RTC_MODE2_EVCTRL_PEREO5_Msk         (_U_(0x1) << RTC_MODE2_EVCTRL_PEREO5_Pos)      /**< (RTC_MODE2_EVCTRL) Periodic Interval 5 Event Output Enable Mask */
+#define RTC_MODE2_EVCTRL_PEREO5             RTC_MODE2_EVCTRL_PEREO5_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_EVCTRL_PEREO5_Msk instead */
+#define RTC_MODE2_EVCTRL_PEREO6_Pos         6                                              /**< (RTC_MODE2_EVCTRL) Periodic Interval 6 Event Output Enable Position */
+#define RTC_MODE2_EVCTRL_PEREO6_Msk         (_U_(0x1) << RTC_MODE2_EVCTRL_PEREO6_Pos)      /**< (RTC_MODE2_EVCTRL) Periodic Interval 6 Event Output Enable Mask */
+#define RTC_MODE2_EVCTRL_PEREO6             RTC_MODE2_EVCTRL_PEREO6_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_EVCTRL_PEREO6_Msk instead */
+#define RTC_MODE2_EVCTRL_PEREO7_Pos         7                                              /**< (RTC_MODE2_EVCTRL) Periodic Interval 7 Event Output Enable Position */
+#define RTC_MODE2_EVCTRL_PEREO7_Msk         (_U_(0x1) << RTC_MODE2_EVCTRL_PEREO7_Pos)      /**< (RTC_MODE2_EVCTRL) Periodic Interval 7 Event Output Enable Mask */
+#define RTC_MODE2_EVCTRL_PEREO7             RTC_MODE2_EVCTRL_PEREO7_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_EVCTRL_PEREO7_Msk instead */
+#define RTC_MODE2_EVCTRL_ALARMEO0_Pos       8                                              /**< (RTC_MODE2_EVCTRL) Alarm 0 Event Output Enable Position */
+#define RTC_MODE2_EVCTRL_ALARMEO0_Msk       (_U_(0x1) << RTC_MODE2_EVCTRL_ALARMEO0_Pos)    /**< (RTC_MODE2_EVCTRL) Alarm 0 Event Output Enable Mask */
+#define RTC_MODE2_EVCTRL_ALARMEO0           RTC_MODE2_EVCTRL_ALARMEO0_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_EVCTRL_ALARMEO0_Msk instead */
+#define RTC_MODE2_EVCTRL_TAMPEREO_Pos       14                                             /**< (RTC_MODE2_EVCTRL) Tamper Event Output Enable Position */
+#define RTC_MODE2_EVCTRL_TAMPEREO_Msk       (_U_(0x1) << RTC_MODE2_EVCTRL_TAMPEREO_Pos)    /**< (RTC_MODE2_EVCTRL) Tamper Event Output Enable Mask */
+#define RTC_MODE2_EVCTRL_TAMPEREO           RTC_MODE2_EVCTRL_TAMPEREO_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_EVCTRL_TAMPEREO_Msk instead */
+#define RTC_MODE2_EVCTRL_OVFEO_Pos          15                                             /**< (RTC_MODE2_EVCTRL) Overflow Event Output Enable Position */
+#define RTC_MODE2_EVCTRL_OVFEO_Msk          (_U_(0x1) << RTC_MODE2_EVCTRL_OVFEO_Pos)       /**< (RTC_MODE2_EVCTRL) Overflow Event Output Enable Mask */
+#define RTC_MODE2_EVCTRL_OVFEO              RTC_MODE2_EVCTRL_OVFEO_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_EVCTRL_OVFEO_Msk instead */
+#define RTC_MODE2_EVCTRL_TAMPEVEI_Pos       16                                             /**< (RTC_MODE2_EVCTRL) Tamper Event Input Enable Position */
+#define RTC_MODE2_EVCTRL_TAMPEVEI_Msk       (_U_(0x1) << RTC_MODE2_EVCTRL_TAMPEVEI_Pos)    /**< (RTC_MODE2_EVCTRL) Tamper Event Input Enable Mask */
+#define RTC_MODE2_EVCTRL_TAMPEVEI           RTC_MODE2_EVCTRL_TAMPEVEI_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_EVCTRL_TAMPEVEI_Msk instead */
+#define RTC_MODE2_EVCTRL_PERDEO_Pos         24                                             /**< (RTC_MODE2_EVCTRL) Periodic Interval Daily Event Output Enable Position */
+#define RTC_MODE2_EVCTRL_PERDEO_Msk         (_U_(0x1) << RTC_MODE2_EVCTRL_PERDEO_Pos)      /**< (RTC_MODE2_EVCTRL) Periodic Interval Daily Event Output Enable Mask */
+#define RTC_MODE2_EVCTRL_PERDEO             RTC_MODE2_EVCTRL_PERDEO_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_EVCTRL_PERDEO_Msk instead */
+#define RTC_MODE2_EVCTRL_MASK               _U_(0x101C1FF)                                 /**< \deprecated (RTC_MODE2_EVCTRL) Register MASK  (Use RTC_MODE2_EVCTRL_Msk instead)  */
+#define RTC_MODE2_EVCTRL_Msk                _U_(0x101C1FF)                                 /**< (RTC_MODE2_EVCTRL) Register Mask  */
+
+#define RTC_MODE2_EVCTRL_PEREO_Pos          0                                              /**< (RTC_MODE2_EVCTRL Position) Periodic Interval x Event Output Enable */
+#define RTC_MODE2_EVCTRL_PEREO_Msk          (_U_(0xFF) << RTC_MODE2_EVCTRL_PEREO_Pos)      /**< (RTC_MODE2_EVCTRL Mask) PEREO */
+#define RTC_MODE2_EVCTRL_PEREO(value)       (RTC_MODE2_EVCTRL_PEREO_Msk & ((value) << RTC_MODE2_EVCTRL_PEREO_Pos))  
+#define RTC_MODE2_EVCTRL_ALARMEO_Pos        8                                              /**< (RTC_MODE2_EVCTRL Position) Alarm x Event Output Enable */
+#define RTC_MODE2_EVCTRL_ALARMEO_Msk        (_U_(0x1) << RTC_MODE2_EVCTRL_ALARMEO_Pos)     /**< (RTC_MODE2_EVCTRL Mask) ALARMEO */
+#define RTC_MODE2_EVCTRL_ALARMEO(value)     (RTC_MODE2_EVCTRL_ALARMEO_Msk & ((value) << RTC_MODE2_EVCTRL_ALARMEO_Pos))  
+
+/* -------- RTC_MODE0_INTENCLR : (RTC Offset: 0x08) (R/W 16) MODE0 Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t PER0:1;                    /**< bit:      0  Periodic Interval 0 Interrupt Enable     */
+    uint16_t PER1:1;                    /**< bit:      1  Periodic Interval 1 Interrupt Enable     */
+    uint16_t PER2:1;                    /**< bit:      2  Periodic Interval 2 Interrupt Enable     */
+    uint16_t PER3:1;                    /**< bit:      3  Periodic Interval 3 Interrupt Enable     */
+    uint16_t PER4:1;                    /**< bit:      4  Periodic Interval 4 Interrupt Enable     */
+    uint16_t PER5:1;                    /**< bit:      5  Periodic Interval 5 Interrupt Enable     */
+    uint16_t PER6:1;                    /**< bit:      6  Periodic Interval 6 Interrupt Enable     */
+    uint16_t PER7:1;                    /**< bit:      7  Periodic Interval 7 Interrupt Enable     */
+    uint16_t CMP0:1;                    /**< bit:      8  Compare 0 Interrupt Enable               */
+    uint16_t :5;                        /**< bit:  9..13  Reserved */
+    uint16_t TAMPER:1;                  /**< bit:     14  Tamper Enable                            */
+    uint16_t OVF:1;                     /**< bit:     15  Overflow Interrupt Enable                */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint16_t PER:8;                     /**< bit:   0..7  Periodic Interval x Interrupt Enable     */
+    uint16_t CMP:1;                     /**< bit:      8  Compare x Interrupt Enable               */
+    uint16_t :7;                        /**< bit:  9..15 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint16_t reg;                         /**< Type used for register access */
+} RTC_MODE0_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE0_INTENCLR_OFFSET           (0x08)                                        /**<  (RTC_MODE0_INTENCLR) MODE0 Interrupt Enable Clear  Offset */
+#define RTC_MODE0_INTENCLR_RESETVALUE       _U_(0x00)                                     /**<  (RTC_MODE0_INTENCLR) MODE0 Interrupt Enable Clear  Reset Value */
+
+#define RTC_MODE0_INTENCLR_PER0_Pos         0                                              /**< (RTC_MODE0_INTENCLR) Periodic Interval 0 Interrupt Enable Position */
+#define RTC_MODE0_INTENCLR_PER0_Msk         (_U_(0x1) << RTC_MODE0_INTENCLR_PER0_Pos)      /**< (RTC_MODE0_INTENCLR) Periodic Interval 0 Interrupt Enable Mask */
+#define RTC_MODE0_INTENCLR_PER0             RTC_MODE0_INTENCLR_PER0_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTENCLR_PER0_Msk instead */
+#define RTC_MODE0_INTENCLR_PER1_Pos         1                                              /**< (RTC_MODE0_INTENCLR) Periodic Interval 1 Interrupt Enable Position */
+#define RTC_MODE0_INTENCLR_PER1_Msk         (_U_(0x1) << RTC_MODE0_INTENCLR_PER1_Pos)      /**< (RTC_MODE0_INTENCLR) Periodic Interval 1 Interrupt Enable Mask */
+#define RTC_MODE0_INTENCLR_PER1             RTC_MODE0_INTENCLR_PER1_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTENCLR_PER1_Msk instead */
+#define RTC_MODE0_INTENCLR_PER2_Pos         2                                              /**< (RTC_MODE0_INTENCLR) Periodic Interval 2 Interrupt Enable Position */
+#define RTC_MODE0_INTENCLR_PER2_Msk         (_U_(0x1) << RTC_MODE0_INTENCLR_PER2_Pos)      /**< (RTC_MODE0_INTENCLR) Periodic Interval 2 Interrupt Enable Mask */
+#define RTC_MODE0_INTENCLR_PER2             RTC_MODE0_INTENCLR_PER2_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTENCLR_PER2_Msk instead */
+#define RTC_MODE0_INTENCLR_PER3_Pos         3                                              /**< (RTC_MODE0_INTENCLR) Periodic Interval 3 Interrupt Enable Position */
+#define RTC_MODE0_INTENCLR_PER3_Msk         (_U_(0x1) << RTC_MODE0_INTENCLR_PER3_Pos)      /**< (RTC_MODE0_INTENCLR) Periodic Interval 3 Interrupt Enable Mask */
+#define RTC_MODE0_INTENCLR_PER3             RTC_MODE0_INTENCLR_PER3_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTENCLR_PER3_Msk instead */
+#define RTC_MODE0_INTENCLR_PER4_Pos         4                                              /**< (RTC_MODE0_INTENCLR) Periodic Interval 4 Interrupt Enable Position */
+#define RTC_MODE0_INTENCLR_PER4_Msk         (_U_(0x1) << RTC_MODE0_INTENCLR_PER4_Pos)      /**< (RTC_MODE0_INTENCLR) Periodic Interval 4 Interrupt Enable Mask */
+#define RTC_MODE0_INTENCLR_PER4             RTC_MODE0_INTENCLR_PER4_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTENCLR_PER4_Msk instead */
+#define RTC_MODE0_INTENCLR_PER5_Pos         5                                              /**< (RTC_MODE0_INTENCLR) Periodic Interval 5 Interrupt Enable Position */
+#define RTC_MODE0_INTENCLR_PER5_Msk         (_U_(0x1) << RTC_MODE0_INTENCLR_PER5_Pos)      /**< (RTC_MODE0_INTENCLR) Periodic Interval 5 Interrupt Enable Mask */
+#define RTC_MODE0_INTENCLR_PER5             RTC_MODE0_INTENCLR_PER5_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTENCLR_PER5_Msk instead */
+#define RTC_MODE0_INTENCLR_PER6_Pos         6                                              /**< (RTC_MODE0_INTENCLR) Periodic Interval 6 Interrupt Enable Position */
+#define RTC_MODE0_INTENCLR_PER6_Msk         (_U_(0x1) << RTC_MODE0_INTENCLR_PER6_Pos)      /**< (RTC_MODE0_INTENCLR) Periodic Interval 6 Interrupt Enable Mask */
+#define RTC_MODE0_INTENCLR_PER6             RTC_MODE0_INTENCLR_PER6_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTENCLR_PER6_Msk instead */
+#define RTC_MODE0_INTENCLR_PER7_Pos         7                                              /**< (RTC_MODE0_INTENCLR) Periodic Interval 7 Interrupt Enable Position */
+#define RTC_MODE0_INTENCLR_PER7_Msk         (_U_(0x1) << RTC_MODE0_INTENCLR_PER7_Pos)      /**< (RTC_MODE0_INTENCLR) Periodic Interval 7 Interrupt Enable Mask */
+#define RTC_MODE0_INTENCLR_PER7             RTC_MODE0_INTENCLR_PER7_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTENCLR_PER7_Msk instead */
+#define RTC_MODE0_INTENCLR_CMP0_Pos         8                                              /**< (RTC_MODE0_INTENCLR) Compare 0 Interrupt Enable Position */
+#define RTC_MODE0_INTENCLR_CMP0_Msk         (_U_(0x1) << RTC_MODE0_INTENCLR_CMP0_Pos)      /**< (RTC_MODE0_INTENCLR) Compare 0 Interrupt Enable Mask */
+#define RTC_MODE0_INTENCLR_CMP0             RTC_MODE0_INTENCLR_CMP0_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTENCLR_CMP0_Msk instead */
+#define RTC_MODE0_INTENCLR_TAMPER_Pos       14                                             /**< (RTC_MODE0_INTENCLR) Tamper Enable Position */
+#define RTC_MODE0_INTENCLR_TAMPER_Msk       (_U_(0x1) << RTC_MODE0_INTENCLR_TAMPER_Pos)    /**< (RTC_MODE0_INTENCLR) Tamper Enable Mask */
+#define RTC_MODE0_INTENCLR_TAMPER           RTC_MODE0_INTENCLR_TAMPER_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTENCLR_TAMPER_Msk instead */
+#define RTC_MODE0_INTENCLR_OVF_Pos          15                                             /**< (RTC_MODE0_INTENCLR) Overflow Interrupt Enable Position */
+#define RTC_MODE0_INTENCLR_OVF_Msk          (_U_(0x1) << RTC_MODE0_INTENCLR_OVF_Pos)       /**< (RTC_MODE0_INTENCLR) Overflow Interrupt Enable Mask */
+#define RTC_MODE0_INTENCLR_OVF              RTC_MODE0_INTENCLR_OVF_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTENCLR_OVF_Msk instead */
+#define RTC_MODE0_INTENCLR_MASK             _U_(0xC1FF)                                    /**< \deprecated (RTC_MODE0_INTENCLR) Register MASK  (Use RTC_MODE0_INTENCLR_Msk instead)  */
+#define RTC_MODE0_INTENCLR_Msk              _U_(0xC1FF)                                    /**< (RTC_MODE0_INTENCLR) Register Mask  */
+
+#define RTC_MODE0_INTENCLR_PER_Pos          0                                              /**< (RTC_MODE0_INTENCLR Position) Periodic Interval x Interrupt Enable */
+#define RTC_MODE0_INTENCLR_PER_Msk          (_U_(0xFF) << RTC_MODE0_INTENCLR_PER_Pos)      /**< (RTC_MODE0_INTENCLR Mask) PER */
+#define RTC_MODE0_INTENCLR_PER(value)       (RTC_MODE0_INTENCLR_PER_Msk & ((value) << RTC_MODE0_INTENCLR_PER_Pos))  
+#define RTC_MODE0_INTENCLR_CMP_Pos          8                                              /**< (RTC_MODE0_INTENCLR Position) Compare x Interrupt Enable */
+#define RTC_MODE0_INTENCLR_CMP_Msk          (_U_(0x1) << RTC_MODE0_INTENCLR_CMP_Pos)       /**< (RTC_MODE0_INTENCLR Mask) CMP */
+#define RTC_MODE0_INTENCLR_CMP(value)       (RTC_MODE0_INTENCLR_CMP_Msk & ((value) << RTC_MODE0_INTENCLR_CMP_Pos))  
+
+/* -------- RTC_MODE1_INTENCLR : (RTC Offset: 0x08) (R/W 16) MODE1 Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t PER0:1;                    /**< bit:      0  Periodic Interval 0 Interrupt Enable     */
+    uint16_t PER1:1;                    /**< bit:      1  Periodic Interval 1 Interrupt Enable     */
+    uint16_t PER2:1;                    /**< bit:      2  Periodic Interval 2 Interrupt Enable     */
+    uint16_t PER3:1;                    /**< bit:      3  Periodic Interval 3 Interrupt Enable     */
+    uint16_t PER4:1;                    /**< bit:      4  Periodic Interval 4 Interrupt Enable     */
+    uint16_t PER5:1;                    /**< bit:      5  Periodic Interval 5 Interrupt Enable     */
+    uint16_t PER6:1;                    /**< bit:      6  Periodic Interval 6 Interrupt Enable     */
+    uint16_t PER7:1;                    /**< bit:      7  Periodic Interval 7 Interrupt Enable     */
+    uint16_t CMP0:1;                    /**< bit:      8  Compare 0 Interrupt Enable               */
+    uint16_t CMP1:1;                    /**< bit:      9  Compare 1 Interrupt Enable               */
+    uint16_t :4;                        /**< bit: 10..13  Reserved */
+    uint16_t TAMPER:1;                  /**< bit:     14  Tamper Enable                            */
+    uint16_t OVF:1;                     /**< bit:     15  Overflow Interrupt Enable                */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint16_t PER:8;                     /**< bit:   0..7  Periodic Interval x Interrupt Enable     */
+    uint16_t CMP:2;                     /**< bit:   8..9  Compare x Interrupt Enable               */
+    uint16_t :6;                        /**< bit: 10..15 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint16_t reg;                         /**< Type used for register access */
+} RTC_MODE1_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE1_INTENCLR_OFFSET           (0x08)                                        /**<  (RTC_MODE1_INTENCLR) MODE1 Interrupt Enable Clear  Offset */
+#define RTC_MODE1_INTENCLR_RESETVALUE       _U_(0x00)                                     /**<  (RTC_MODE1_INTENCLR) MODE1 Interrupt Enable Clear  Reset Value */
+
+#define RTC_MODE1_INTENCLR_PER0_Pos         0                                              /**< (RTC_MODE1_INTENCLR) Periodic Interval 0 Interrupt Enable Position */
+#define RTC_MODE1_INTENCLR_PER0_Msk         (_U_(0x1) << RTC_MODE1_INTENCLR_PER0_Pos)      /**< (RTC_MODE1_INTENCLR) Periodic Interval 0 Interrupt Enable Mask */
+#define RTC_MODE1_INTENCLR_PER0             RTC_MODE1_INTENCLR_PER0_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTENCLR_PER0_Msk instead */
+#define RTC_MODE1_INTENCLR_PER1_Pos         1                                              /**< (RTC_MODE1_INTENCLR) Periodic Interval 1 Interrupt Enable Position */
+#define RTC_MODE1_INTENCLR_PER1_Msk         (_U_(0x1) << RTC_MODE1_INTENCLR_PER1_Pos)      /**< (RTC_MODE1_INTENCLR) Periodic Interval 1 Interrupt Enable Mask */
+#define RTC_MODE1_INTENCLR_PER1             RTC_MODE1_INTENCLR_PER1_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTENCLR_PER1_Msk instead */
+#define RTC_MODE1_INTENCLR_PER2_Pos         2                                              /**< (RTC_MODE1_INTENCLR) Periodic Interval 2 Interrupt Enable Position */
+#define RTC_MODE1_INTENCLR_PER2_Msk         (_U_(0x1) << RTC_MODE1_INTENCLR_PER2_Pos)      /**< (RTC_MODE1_INTENCLR) Periodic Interval 2 Interrupt Enable Mask */
+#define RTC_MODE1_INTENCLR_PER2             RTC_MODE1_INTENCLR_PER2_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTENCLR_PER2_Msk instead */
+#define RTC_MODE1_INTENCLR_PER3_Pos         3                                              /**< (RTC_MODE1_INTENCLR) Periodic Interval 3 Interrupt Enable Position */
+#define RTC_MODE1_INTENCLR_PER3_Msk         (_U_(0x1) << RTC_MODE1_INTENCLR_PER3_Pos)      /**< (RTC_MODE1_INTENCLR) Periodic Interval 3 Interrupt Enable Mask */
+#define RTC_MODE1_INTENCLR_PER3             RTC_MODE1_INTENCLR_PER3_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTENCLR_PER3_Msk instead */
+#define RTC_MODE1_INTENCLR_PER4_Pos         4                                              /**< (RTC_MODE1_INTENCLR) Periodic Interval 4 Interrupt Enable Position */
+#define RTC_MODE1_INTENCLR_PER4_Msk         (_U_(0x1) << RTC_MODE1_INTENCLR_PER4_Pos)      /**< (RTC_MODE1_INTENCLR) Periodic Interval 4 Interrupt Enable Mask */
+#define RTC_MODE1_INTENCLR_PER4             RTC_MODE1_INTENCLR_PER4_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTENCLR_PER4_Msk instead */
+#define RTC_MODE1_INTENCLR_PER5_Pos         5                                              /**< (RTC_MODE1_INTENCLR) Periodic Interval 5 Interrupt Enable Position */
+#define RTC_MODE1_INTENCLR_PER5_Msk         (_U_(0x1) << RTC_MODE1_INTENCLR_PER5_Pos)      /**< (RTC_MODE1_INTENCLR) Periodic Interval 5 Interrupt Enable Mask */
+#define RTC_MODE1_INTENCLR_PER5             RTC_MODE1_INTENCLR_PER5_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTENCLR_PER5_Msk instead */
+#define RTC_MODE1_INTENCLR_PER6_Pos         6                                              /**< (RTC_MODE1_INTENCLR) Periodic Interval 6 Interrupt Enable Position */
+#define RTC_MODE1_INTENCLR_PER6_Msk         (_U_(0x1) << RTC_MODE1_INTENCLR_PER6_Pos)      /**< (RTC_MODE1_INTENCLR) Periodic Interval 6 Interrupt Enable Mask */
+#define RTC_MODE1_INTENCLR_PER6             RTC_MODE1_INTENCLR_PER6_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTENCLR_PER6_Msk instead */
+#define RTC_MODE1_INTENCLR_PER7_Pos         7                                              /**< (RTC_MODE1_INTENCLR) Periodic Interval 7 Interrupt Enable Position */
+#define RTC_MODE1_INTENCLR_PER7_Msk         (_U_(0x1) << RTC_MODE1_INTENCLR_PER7_Pos)      /**< (RTC_MODE1_INTENCLR) Periodic Interval 7 Interrupt Enable Mask */
+#define RTC_MODE1_INTENCLR_PER7             RTC_MODE1_INTENCLR_PER7_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTENCLR_PER7_Msk instead */
+#define RTC_MODE1_INTENCLR_CMP0_Pos         8                                              /**< (RTC_MODE1_INTENCLR) Compare 0 Interrupt Enable Position */
+#define RTC_MODE1_INTENCLR_CMP0_Msk         (_U_(0x1) << RTC_MODE1_INTENCLR_CMP0_Pos)      /**< (RTC_MODE1_INTENCLR) Compare 0 Interrupt Enable Mask */
+#define RTC_MODE1_INTENCLR_CMP0             RTC_MODE1_INTENCLR_CMP0_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTENCLR_CMP0_Msk instead */
+#define RTC_MODE1_INTENCLR_CMP1_Pos         9                                              /**< (RTC_MODE1_INTENCLR) Compare 1 Interrupt Enable Position */
+#define RTC_MODE1_INTENCLR_CMP1_Msk         (_U_(0x1) << RTC_MODE1_INTENCLR_CMP1_Pos)      /**< (RTC_MODE1_INTENCLR) Compare 1 Interrupt Enable Mask */
+#define RTC_MODE1_INTENCLR_CMP1             RTC_MODE1_INTENCLR_CMP1_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTENCLR_CMP1_Msk instead */
+#define RTC_MODE1_INTENCLR_TAMPER_Pos       14                                             /**< (RTC_MODE1_INTENCLR) Tamper Enable Position */
+#define RTC_MODE1_INTENCLR_TAMPER_Msk       (_U_(0x1) << RTC_MODE1_INTENCLR_TAMPER_Pos)    /**< (RTC_MODE1_INTENCLR) Tamper Enable Mask */
+#define RTC_MODE1_INTENCLR_TAMPER           RTC_MODE1_INTENCLR_TAMPER_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTENCLR_TAMPER_Msk instead */
+#define RTC_MODE1_INTENCLR_OVF_Pos          15                                             /**< (RTC_MODE1_INTENCLR) Overflow Interrupt Enable Position */
+#define RTC_MODE1_INTENCLR_OVF_Msk          (_U_(0x1) << RTC_MODE1_INTENCLR_OVF_Pos)       /**< (RTC_MODE1_INTENCLR) Overflow Interrupt Enable Mask */
+#define RTC_MODE1_INTENCLR_OVF              RTC_MODE1_INTENCLR_OVF_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTENCLR_OVF_Msk instead */
+#define RTC_MODE1_INTENCLR_MASK             _U_(0xC3FF)                                    /**< \deprecated (RTC_MODE1_INTENCLR) Register MASK  (Use RTC_MODE1_INTENCLR_Msk instead)  */
+#define RTC_MODE1_INTENCLR_Msk              _U_(0xC3FF)                                    /**< (RTC_MODE1_INTENCLR) Register Mask  */
+
+#define RTC_MODE1_INTENCLR_PER_Pos          0                                              /**< (RTC_MODE1_INTENCLR Position) Periodic Interval x Interrupt Enable */
+#define RTC_MODE1_INTENCLR_PER_Msk          (_U_(0xFF) << RTC_MODE1_INTENCLR_PER_Pos)      /**< (RTC_MODE1_INTENCLR Mask) PER */
+#define RTC_MODE1_INTENCLR_PER(value)       (RTC_MODE1_INTENCLR_PER_Msk & ((value) << RTC_MODE1_INTENCLR_PER_Pos))  
+#define RTC_MODE1_INTENCLR_CMP_Pos          8                                              /**< (RTC_MODE1_INTENCLR Position) Compare x Interrupt Enable */
+#define RTC_MODE1_INTENCLR_CMP_Msk          (_U_(0x3) << RTC_MODE1_INTENCLR_CMP_Pos)       /**< (RTC_MODE1_INTENCLR Mask) CMP */
+#define RTC_MODE1_INTENCLR_CMP(value)       (RTC_MODE1_INTENCLR_CMP_Msk & ((value) << RTC_MODE1_INTENCLR_CMP_Pos))  
+
+/* -------- RTC_MODE2_INTENCLR : (RTC Offset: 0x08) (R/W 16) MODE2 Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t PER0:1;                    /**< bit:      0  Periodic Interval 0 Interrupt Enable     */
+    uint16_t PER1:1;                    /**< bit:      1  Periodic Interval 1 Interrupt Enable     */
+    uint16_t PER2:1;                    /**< bit:      2  Periodic Interval 2 Interrupt Enable     */
+    uint16_t PER3:1;                    /**< bit:      3  Periodic Interval 3 Interrupt Enable     */
+    uint16_t PER4:1;                    /**< bit:      4  Periodic Interval 4 Interrupt Enable     */
+    uint16_t PER5:1;                    /**< bit:      5  Periodic Interval 5 Interrupt Enable     */
+    uint16_t PER6:1;                    /**< bit:      6  Periodic Interval 6 Interrupt Enable     */
+    uint16_t PER7:1;                    /**< bit:      7  Periodic Interval 7 Interrupt Enable     */
+    uint16_t ALARM0:1;                  /**< bit:      8  Alarm 0 Interrupt Enable                 */
+    uint16_t :5;                        /**< bit:  9..13  Reserved */
+    uint16_t TAMPER:1;                  /**< bit:     14  Tamper Enable                            */
+    uint16_t OVF:1;                     /**< bit:     15  Overflow Interrupt Enable                */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint16_t PER:8;                     /**< bit:   0..7  Periodic Interval x Interrupt Enable     */
+    uint16_t ALARM:1;                   /**< bit:      8  Alarm x Interrupt Enable                 */
+    uint16_t :7;                        /**< bit:  9..15 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint16_t reg;                         /**< Type used for register access */
+} RTC_MODE2_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE2_INTENCLR_OFFSET           (0x08)                                        /**<  (RTC_MODE2_INTENCLR) MODE2 Interrupt Enable Clear  Offset */
+#define RTC_MODE2_INTENCLR_RESETVALUE       _U_(0x00)                                     /**<  (RTC_MODE2_INTENCLR) MODE2 Interrupt Enable Clear  Reset Value */
+
+#define RTC_MODE2_INTENCLR_PER0_Pos         0                                              /**< (RTC_MODE2_INTENCLR) Periodic Interval 0 Interrupt Enable Position */
+#define RTC_MODE2_INTENCLR_PER0_Msk         (_U_(0x1) << RTC_MODE2_INTENCLR_PER0_Pos)      /**< (RTC_MODE2_INTENCLR) Periodic Interval 0 Interrupt Enable Mask */
+#define RTC_MODE2_INTENCLR_PER0             RTC_MODE2_INTENCLR_PER0_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTENCLR_PER0_Msk instead */
+#define RTC_MODE2_INTENCLR_PER1_Pos         1                                              /**< (RTC_MODE2_INTENCLR) Periodic Interval 1 Interrupt Enable Position */
+#define RTC_MODE2_INTENCLR_PER1_Msk         (_U_(0x1) << RTC_MODE2_INTENCLR_PER1_Pos)      /**< (RTC_MODE2_INTENCLR) Periodic Interval 1 Interrupt Enable Mask */
+#define RTC_MODE2_INTENCLR_PER1             RTC_MODE2_INTENCLR_PER1_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTENCLR_PER1_Msk instead */
+#define RTC_MODE2_INTENCLR_PER2_Pos         2                                              /**< (RTC_MODE2_INTENCLR) Periodic Interval 2 Interrupt Enable Position */
+#define RTC_MODE2_INTENCLR_PER2_Msk         (_U_(0x1) << RTC_MODE2_INTENCLR_PER2_Pos)      /**< (RTC_MODE2_INTENCLR) Periodic Interval 2 Interrupt Enable Mask */
+#define RTC_MODE2_INTENCLR_PER2             RTC_MODE2_INTENCLR_PER2_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTENCLR_PER2_Msk instead */
+#define RTC_MODE2_INTENCLR_PER3_Pos         3                                              /**< (RTC_MODE2_INTENCLR) Periodic Interval 3 Interrupt Enable Position */
+#define RTC_MODE2_INTENCLR_PER3_Msk         (_U_(0x1) << RTC_MODE2_INTENCLR_PER3_Pos)      /**< (RTC_MODE2_INTENCLR) Periodic Interval 3 Interrupt Enable Mask */
+#define RTC_MODE2_INTENCLR_PER3             RTC_MODE2_INTENCLR_PER3_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTENCLR_PER3_Msk instead */
+#define RTC_MODE2_INTENCLR_PER4_Pos         4                                              /**< (RTC_MODE2_INTENCLR) Periodic Interval 4 Interrupt Enable Position */
+#define RTC_MODE2_INTENCLR_PER4_Msk         (_U_(0x1) << RTC_MODE2_INTENCLR_PER4_Pos)      /**< (RTC_MODE2_INTENCLR) Periodic Interval 4 Interrupt Enable Mask */
+#define RTC_MODE2_INTENCLR_PER4             RTC_MODE2_INTENCLR_PER4_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTENCLR_PER4_Msk instead */
+#define RTC_MODE2_INTENCLR_PER5_Pos         5                                              /**< (RTC_MODE2_INTENCLR) Periodic Interval 5 Interrupt Enable Position */
+#define RTC_MODE2_INTENCLR_PER5_Msk         (_U_(0x1) << RTC_MODE2_INTENCLR_PER5_Pos)      /**< (RTC_MODE2_INTENCLR) Periodic Interval 5 Interrupt Enable Mask */
+#define RTC_MODE2_INTENCLR_PER5             RTC_MODE2_INTENCLR_PER5_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTENCLR_PER5_Msk instead */
+#define RTC_MODE2_INTENCLR_PER6_Pos         6                                              /**< (RTC_MODE2_INTENCLR) Periodic Interval 6 Interrupt Enable Position */
+#define RTC_MODE2_INTENCLR_PER6_Msk         (_U_(0x1) << RTC_MODE2_INTENCLR_PER6_Pos)      /**< (RTC_MODE2_INTENCLR) Periodic Interval 6 Interrupt Enable Mask */
+#define RTC_MODE2_INTENCLR_PER6             RTC_MODE2_INTENCLR_PER6_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTENCLR_PER6_Msk instead */
+#define RTC_MODE2_INTENCLR_PER7_Pos         7                                              /**< (RTC_MODE2_INTENCLR) Periodic Interval 7 Interrupt Enable Position */
+#define RTC_MODE2_INTENCLR_PER7_Msk         (_U_(0x1) << RTC_MODE2_INTENCLR_PER7_Pos)      /**< (RTC_MODE2_INTENCLR) Periodic Interval 7 Interrupt Enable Mask */
+#define RTC_MODE2_INTENCLR_PER7             RTC_MODE2_INTENCLR_PER7_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTENCLR_PER7_Msk instead */
+#define RTC_MODE2_INTENCLR_ALARM0_Pos       8                                              /**< (RTC_MODE2_INTENCLR) Alarm 0 Interrupt Enable Position */
+#define RTC_MODE2_INTENCLR_ALARM0_Msk       (_U_(0x1) << RTC_MODE2_INTENCLR_ALARM0_Pos)    /**< (RTC_MODE2_INTENCLR) Alarm 0 Interrupt Enable Mask */
+#define RTC_MODE2_INTENCLR_ALARM0           RTC_MODE2_INTENCLR_ALARM0_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTENCLR_ALARM0_Msk instead */
+#define RTC_MODE2_INTENCLR_TAMPER_Pos       14                                             /**< (RTC_MODE2_INTENCLR) Tamper Enable Position */
+#define RTC_MODE2_INTENCLR_TAMPER_Msk       (_U_(0x1) << RTC_MODE2_INTENCLR_TAMPER_Pos)    /**< (RTC_MODE2_INTENCLR) Tamper Enable Mask */
+#define RTC_MODE2_INTENCLR_TAMPER           RTC_MODE2_INTENCLR_TAMPER_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTENCLR_TAMPER_Msk instead */
+#define RTC_MODE2_INTENCLR_OVF_Pos          15                                             /**< (RTC_MODE2_INTENCLR) Overflow Interrupt Enable Position */
+#define RTC_MODE2_INTENCLR_OVF_Msk          (_U_(0x1) << RTC_MODE2_INTENCLR_OVF_Pos)       /**< (RTC_MODE2_INTENCLR) Overflow Interrupt Enable Mask */
+#define RTC_MODE2_INTENCLR_OVF              RTC_MODE2_INTENCLR_OVF_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTENCLR_OVF_Msk instead */
+#define RTC_MODE2_INTENCLR_MASK             _U_(0xC1FF)                                    /**< \deprecated (RTC_MODE2_INTENCLR) Register MASK  (Use RTC_MODE2_INTENCLR_Msk instead)  */
+#define RTC_MODE2_INTENCLR_Msk              _U_(0xC1FF)                                    /**< (RTC_MODE2_INTENCLR) Register Mask  */
+
+#define RTC_MODE2_INTENCLR_PER_Pos          0                                              /**< (RTC_MODE2_INTENCLR Position) Periodic Interval x Interrupt Enable */
+#define RTC_MODE2_INTENCLR_PER_Msk          (_U_(0xFF) << RTC_MODE2_INTENCLR_PER_Pos)      /**< (RTC_MODE2_INTENCLR Mask) PER */
+#define RTC_MODE2_INTENCLR_PER(value)       (RTC_MODE2_INTENCLR_PER_Msk & ((value) << RTC_MODE2_INTENCLR_PER_Pos))  
+#define RTC_MODE2_INTENCLR_ALARM_Pos        8                                              /**< (RTC_MODE2_INTENCLR Position) Alarm x Interrupt Enable */
+#define RTC_MODE2_INTENCLR_ALARM_Msk        (_U_(0x1) << RTC_MODE2_INTENCLR_ALARM_Pos)     /**< (RTC_MODE2_INTENCLR Mask) ALARM */
+#define RTC_MODE2_INTENCLR_ALARM(value)     (RTC_MODE2_INTENCLR_ALARM_Msk & ((value) << RTC_MODE2_INTENCLR_ALARM_Pos))  
+
+/* -------- RTC_MODE0_INTENSET : (RTC Offset: 0x0a) (R/W 16) MODE0 Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t PER0:1;                    /**< bit:      0  Periodic Interval 0 Interrupt Enable     */
+    uint16_t PER1:1;                    /**< bit:      1  Periodic Interval 1 Interrupt Enable     */
+    uint16_t PER2:1;                    /**< bit:      2  Periodic Interval 2 Interrupt Enable     */
+    uint16_t PER3:1;                    /**< bit:      3  Periodic Interval 3 Interrupt Enable     */
+    uint16_t PER4:1;                    /**< bit:      4  Periodic Interval 4 Interrupt Enable     */
+    uint16_t PER5:1;                    /**< bit:      5  Periodic Interval 5 Interrupt Enable     */
+    uint16_t PER6:1;                    /**< bit:      6  Periodic Interval 6 Interrupt Enable     */
+    uint16_t PER7:1;                    /**< bit:      7  Periodic Interval 7 Interrupt Enable     */
+    uint16_t CMP0:1;                    /**< bit:      8  Compare 0 Interrupt Enable               */
+    uint16_t :5;                        /**< bit:  9..13  Reserved */
+    uint16_t TAMPER:1;                  /**< bit:     14  Tamper Enable                            */
+    uint16_t OVF:1;                     /**< bit:     15  Overflow Interrupt Enable                */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint16_t PER:8;                     /**< bit:   0..7  Periodic Interval x Interrupt Enable     */
+    uint16_t CMP:1;                     /**< bit:      8  Compare x Interrupt Enable               */
+    uint16_t :7;                        /**< bit:  9..15 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint16_t reg;                         /**< Type used for register access */
+} RTC_MODE0_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE0_INTENSET_OFFSET           (0x0A)                                        /**<  (RTC_MODE0_INTENSET) MODE0 Interrupt Enable Set  Offset */
+#define RTC_MODE0_INTENSET_RESETVALUE       _U_(0x00)                                     /**<  (RTC_MODE0_INTENSET) MODE0 Interrupt Enable Set  Reset Value */
+
+#define RTC_MODE0_INTENSET_PER0_Pos         0                                              /**< (RTC_MODE0_INTENSET) Periodic Interval 0 Interrupt Enable Position */
+#define RTC_MODE0_INTENSET_PER0_Msk         (_U_(0x1) << RTC_MODE0_INTENSET_PER0_Pos)      /**< (RTC_MODE0_INTENSET) Periodic Interval 0 Interrupt Enable Mask */
+#define RTC_MODE0_INTENSET_PER0             RTC_MODE0_INTENSET_PER0_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTENSET_PER0_Msk instead */
+#define RTC_MODE0_INTENSET_PER1_Pos         1                                              /**< (RTC_MODE0_INTENSET) Periodic Interval 1 Interrupt Enable Position */
+#define RTC_MODE0_INTENSET_PER1_Msk         (_U_(0x1) << RTC_MODE0_INTENSET_PER1_Pos)      /**< (RTC_MODE0_INTENSET) Periodic Interval 1 Interrupt Enable Mask */
+#define RTC_MODE0_INTENSET_PER1             RTC_MODE0_INTENSET_PER1_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTENSET_PER1_Msk instead */
+#define RTC_MODE0_INTENSET_PER2_Pos         2                                              /**< (RTC_MODE0_INTENSET) Periodic Interval 2 Interrupt Enable Position */
+#define RTC_MODE0_INTENSET_PER2_Msk         (_U_(0x1) << RTC_MODE0_INTENSET_PER2_Pos)      /**< (RTC_MODE0_INTENSET) Periodic Interval 2 Interrupt Enable Mask */
+#define RTC_MODE0_INTENSET_PER2             RTC_MODE0_INTENSET_PER2_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTENSET_PER2_Msk instead */
+#define RTC_MODE0_INTENSET_PER3_Pos         3                                              /**< (RTC_MODE0_INTENSET) Periodic Interval 3 Interrupt Enable Position */
+#define RTC_MODE0_INTENSET_PER3_Msk         (_U_(0x1) << RTC_MODE0_INTENSET_PER3_Pos)      /**< (RTC_MODE0_INTENSET) Periodic Interval 3 Interrupt Enable Mask */
+#define RTC_MODE0_INTENSET_PER3             RTC_MODE0_INTENSET_PER3_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTENSET_PER3_Msk instead */
+#define RTC_MODE0_INTENSET_PER4_Pos         4                                              /**< (RTC_MODE0_INTENSET) Periodic Interval 4 Interrupt Enable Position */
+#define RTC_MODE0_INTENSET_PER4_Msk         (_U_(0x1) << RTC_MODE0_INTENSET_PER4_Pos)      /**< (RTC_MODE0_INTENSET) Periodic Interval 4 Interrupt Enable Mask */
+#define RTC_MODE0_INTENSET_PER4             RTC_MODE0_INTENSET_PER4_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTENSET_PER4_Msk instead */
+#define RTC_MODE0_INTENSET_PER5_Pos         5                                              /**< (RTC_MODE0_INTENSET) Periodic Interval 5 Interrupt Enable Position */
+#define RTC_MODE0_INTENSET_PER5_Msk         (_U_(0x1) << RTC_MODE0_INTENSET_PER5_Pos)      /**< (RTC_MODE0_INTENSET) Periodic Interval 5 Interrupt Enable Mask */
+#define RTC_MODE0_INTENSET_PER5             RTC_MODE0_INTENSET_PER5_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTENSET_PER5_Msk instead */
+#define RTC_MODE0_INTENSET_PER6_Pos         6                                              /**< (RTC_MODE0_INTENSET) Periodic Interval 6 Interrupt Enable Position */
+#define RTC_MODE0_INTENSET_PER6_Msk         (_U_(0x1) << RTC_MODE0_INTENSET_PER6_Pos)      /**< (RTC_MODE0_INTENSET) Periodic Interval 6 Interrupt Enable Mask */
+#define RTC_MODE0_INTENSET_PER6             RTC_MODE0_INTENSET_PER6_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTENSET_PER6_Msk instead */
+#define RTC_MODE0_INTENSET_PER7_Pos         7                                              /**< (RTC_MODE0_INTENSET) Periodic Interval 7 Interrupt Enable Position */
+#define RTC_MODE0_INTENSET_PER7_Msk         (_U_(0x1) << RTC_MODE0_INTENSET_PER7_Pos)      /**< (RTC_MODE0_INTENSET) Periodic Interval 7 Interrupt Enable Mask */
+#define RTC_MODE0_INTENSET_PER7             RTC_MODE0_INTENSET_PER7_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTENSET_PER7_Msk instead */
+#define RTC_MODE0_INTENSET_CMP0_Pos         8                                              /**< (RTC_MODE0_INTENSET) Compare 0 Interrupt Enable Position */
+#define RTC_MODE0_INTENSET_CMP0_Msk         (_U_(0x1) << RTC_MODE0_INTENSET_CMP0_Pos)      /**< (RTC_MODE0_INTENSET) Compare 0 Interrupt Enable Mask */
+#define RTC_MODE0_INTENSET_CMP0             RTC_MODE0_INTENSET_CMP0_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTENSET_CMP0_Msk instead */
+#define RTC_MODE0_INTENSET_TAMPER_Pos       14                                             /**< (RTC_MODE0_INTENSET) Tamper Enable Position */
+#define RTC_MODE0_INTENSET_TAMPER_Msk       (_U_(0x1) << RTC_MODE0_INTENSET_TAMPER_Pos)    /**< (RTC_MODE0_INTENSET) Tamper Enable Mask */
+#define RTC_MODE0_INTENSET_TAMPER           RTC_MODE0_INTENSET_TAMPER_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTENSET_TAMPER_Msk instead */
+#define RTC_MODE0_INTENSET_OVF_Pos          15                                             /**< (RTC_MODE0_INTENSET) Overflow Interrupt Enable Position */
+#define RTC_MODE0_INTENSET_OVF_Msk          (_U_(0x1) << RTC_MODE0_INTENSET_OVF_Pos)       /**< (RTC_MODE0_INTENSET) Overflow Interrupt Enable Mask */
+#define RTC_MODE0_INTENSET_OVF              RTC_MODE0_INTENSET_OVF_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTENSET_OVF_Msk instead */
+#define RTC_MODE0_INTENSET_MASK             _U_(0xC1FF)                                    /**< \deprecated (RTC_MODE0_INTENSET) Register MASK  (Use RTC_MODE0_INTENSET_Msk instead)  */
+#define RTC_MODE0_INTENSET_Msk              _U_(0xC1FF)                                    /**< (RTC_MODE0_INTENSET) Register Mask  */
+
+#define RTC_MODE0_INTENSET_PER_Pos          0                                              /**< (RTC_MODE0_INTENSET Position) Periodic Interval x Interrupt Enable */
+#define RTC_MODE0_INTENSET_PER_Msk          (_U_(0xFF) << RTC_MODE0_INTENSET_PER_Pos)      /**< (RTC_MODE0_INTENSET Mask) PER */
+#define RTC_MODE0_INTENSET_PER(value)       (RTC_MODE0_INTENSET_PER_Msk & ((value) << RTC_MODE0_INTENSET_PER_Pos))  
+#define RTC_MODE0_INTENSET_CMP_Pos          8                                              /**< (RTC_MODE0_INTENSET Position) Compare x Interrupt Enable */
+#define RTC_MODE0_INTENSET_CMP_Msk          (_U_(0x1) << RTC_MODE0_INTENSET_CMP_Pos)       /**< (RTC_MODE0_INTENSET Mask) CMP */
+#define RTC_MODE0_INTENSET_CMP(value)       (RTC_MODE0_INTENSET_CMP_Msk & ((value) << RTC_MODE0_INTENSET_CMP_Pos))  
+
+/* -------- RTC_MODE1_INTENSET : (RTC Offset: 0x0a) (R/W 16) MODE1 Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t PER0:1;                    /**< bit:      0  Periodic Interval 0 Interrupt Enable     */
+    uint16_t PER1:1;                    /**< bit:      1  Periodic Interval 1 Interrupt Enable     */
+    uint16_t PER2:1;                    /**< bit:      2  Periodic Interval 2 Interrupt Enable     */
+    uint16_t PER3:1;                    /**< bit:      3  Periodic Interval 3 Interrupt Enable     */
+    uint16_t PER4:1;                    /**< bit:      4  Periodic Interval 4 Interrupt Enable     */
+    uint16_t PER5:1;                    /**< bit:      5  Periodic Interval 5 Interrupt Enable     */
+    uint16_t PER6:1;                    /**< bit:      6  Periodic Interval 6 Interrupt Enable     */
+    uint16_t PER7:1;                    /**< bit:      7  Periodic Interval 7 Interrupt Enable     */
+    uint16_t CMP0:1;                    /**< bit:      8  Compare 0 Interrupt Enable               */
+    uint16_t CMP1:1;                    /**< bit:      9  Compare 1 Interrupt Enable               */
+    uint16_t :4;                        /**< bit: 10..13  Reserved */
+    uint16_t TAMPER:1;                  /**< bit:     14  Tamper Enable                            */
+    uint16_t OVF:1;                     /**< bit:     15  Overflow Interrupt Enable                */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint16_t PER:8;                     /**< bit:   0..7  Periodic Interval x Interrupt Enable     */
+    uint16_t CMP:2;                     /**< bit:   8..9  Compare x Interrupt Enable               */
+    uint16_t :6;                        /**< bit: 10..15 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint16_t reg;                         /**< Type used for register access */
+} RTC_MODE1_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE1_INTENSET_OFFSET           (0x0A)                                        /**<  (RTC_MODE1_INTENSET) MODE1 Interrupt Enable Set  Offset */
+#define RTC_MODE1_INTENSET_RESETVALUE       _U_(0x00)                                     /**<  (RTC_MODE1_INTENSET) MODE1 Interrupt Enable Set  Reset Value */
+
+#define RTC_MODE1_INTENSET_PER0_Pos         0                                              /**< (RTC_MODE1_INTENSET) Periodic Interval 0 Interrupt Enable Position */
+#define RTC_MODE1_INTENSET_PER0_Msk         (_U_(0x1) << RTC_MODE1_INTENSET_PER0_Pos)      /**< (RTC_MODE1_INTENSET) Periodic Interval 0 Interrupt Enable Mask */
+#define RTC_MODE1_INTENSET_PER0             RTC_MODE1_INTENSET_PER0_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTENSET_PER0_Msk instead */
+#define RTC_MODE1_INTENSET_PER1_Pos         1                                              /**< (RTC_MODE1_INTENSET) Periodic Interval 1 Interrupt Enable Position */
+#define RTC_MODE1_INTENSET_PER1_Msk         (_U_(0x1) << RTC_MODE1_INTENSET_PER1_Pos)      /**< (RTC_MODE1_INTENSET) Periodic Interval 1 Interrupt Enable Mask */
+#define RTC_MODE1_INTENSET_PER1             RTC_MODE1_INTENSET_PER1_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTENSET_PER1_Msk instead */
+#define RTC_MODE1_INTENSET_PER2_Pos         2                                              /**< (RTC_MODE1_INTENSET) Periodic Interval 2 Interrupt Enable Position */
+#define RTC_MODE1_INTENSET_PER2_Msk         (_U_(0x1) << RTC_MODE1_INTENSET_PER2_Pos)      /**< (RTC_MODE1_INTENSET) Periodic Interval 2 Interrupt Enable Mask */
+#define RTC_MODE1_INTENSET_PER2             RTC_MODE1_INTENSET_PER2_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTENSET_PER2_Msk instead */
+#define RTC_MODE1_INTENSET_PER3_Pos         3                                              /**< (RTC_MODE1_INTENSET) Periodic Interval 3 Interrupt Enable Position */
+#define RTC_MODE1_INTENSET_PER3_Msk         (_U_(0x1) << RTC_MODE1_INTENSET_PER3_Pos)      /**< (RTC_MODE1_INTENSET) Periodic Interval 3 Interrupt Enable Mask */
+#define RTC_MODE1_INTENSET_PER3             RTC_MODE1_INTENSET_PER3_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTENSET_PER3_Msk instead */
+#define RTC_MODE1_INTENSET_PER4_Pos         4                                              /**< (RTC_MODE1_INTENSET) Periodic Interval 4 Interrupt Enable Position */
+#define RTC_MODE1_INTENSET_PER4_Msk         (_U_(0x1) << RTC_MODE1_INTENSET_PER4_Pos)      /**< (RTC_MODE1_INTENSET) Periodic Interval 4 Interrupt Enable Mask */
+#define RTC_MODE1_INTENSET_PER4             RTC_MODE1_INTENSET_PER4_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTENSET_PER4_Msk instead */
+#define RTC_MODE1_INTENSET_PER5_Pos         5                                              /**< (RTC_MODE1_INTENSET) Periodic Interval 5 Interrupt Enable Position */
+#define RTC_MODE1_INTENSET_PER5_Msk         (_U_(0x1) << RTC_MODE1_INTENSET_PER5_Pos)      /**< (RTC_MODE1_INTENSET) Periodic Interval 5 Interrupt Enable Mask */
+#define RTC_MODE1_INTENSET_PER5             RTC_MODE1_INTENSET_PER5_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTENSET_PER5_Msk instead */
+#define RTC_MODE1_INTENSET_PER6_Pos         6                                              /**< (RTC_MODE1_INTENSET) Periodic Interval 6 Interrupt Enable Position */
+#define RTC_MODE1_INTENSET_PER6_Msk         (_U_(0x1) << RTC_MODE1_INTENSET_PER6_Pos)      /**< (RTC_MODE1_INTENSET) Periodic Interval 6 Interrupt Enable Mask */
+#define RTC_MODE1_INTENSET_PER6             RTC_MODE1_INTENSET_PER6_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTENSET_PER6_Msk instead */
+#define RTC_MODE1_INTENSET_PER7_Pos         7                                              /**< (RTC_MODE1_INTENSET) Periodic Interval 7 Interrupt Enable Position */
+#define RTC_MODE1_INTENSET_PER7_Msk         (_U_(0x1) << RTC_MODE1_INTENSET_PER7_Pos)      /**< (RTC_MODE1_INTENSET) Periodic Interval 7 Interrupt Enable Mask */
+#define RTC_MODE1_INTENSET_PER7             RTC_MODE1_INTENSET_PER7_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTENSET_PER7_Msk instead */
+#define RTC_MODE1_INTENSET_CMP0_Pos         8                                              /**< (RTC_MODE1_INTENSET) Compare 0 Interrupt Enable Position */
+#define RTC_MODE1_INTENSET_CMP0_Msk         (_U_(0x1) << RTC_MODE1_INTENSET_CMP0_Pos)      /**< (RTC_MODE1_INTENSET) Compare 0 Interrupt Enable Mask */
+#define RTC_MODE1_INTENSET_CMP0             RTC_MODE1_INTENSET_CMP0_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTENSET_CMP0_Msk instead */
+#define RTC_MODE1_INTENSET_CMP1_Pos         9                                              /**< (RTC_MODE1_INTENSET) Compare 1 Interrupt Enable Position */
+#define RTC_MODE1_INTENSET_CMP1_Msk         (_U_(0x1) << RTC_MODE1_INTENSET_CMP1_Pos)      /**< (RTC_MODE1_INTENSET) Compare 1 Interrupt Enable Mask */
+#define RTC_MODE1_INTENSET_CMP1             RTC_MODE1_INTENSET_CMP1_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTENSET_CMP1_Msk instead */
+#define RTC_MODE1_INTENSET_TAMPER_Pos       14                                             /**< (RTC_MODE1_INTENSET) Tamper Enable Position */
+#define RTC_MODE1_INTENSET_TAMPER_Msk       (_U_(0x1) << RTC_MODE1_INTENSET_TAMPER_Pos)    /**< (RTC_MODE1_INTENSET) Tamper Enable Mask */
+#define RTC_MODE1_INTENSET_TAMPER           RTC_MODE1_INTENSET_TAMPER_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTENSET_TAMPER_Msk instead */
+#define RTC_MODE1_INTENSET_OVF_Pos          15                                             /**< (RTC_MODE1_INTENSET) Overflow Interrupt Enable Position */
+#define RTC_MODE1_INTENSET_OVF_Msk          (_U_(0x1) << RTC_MODE1_INTENSET_OVF_Pos)       /**< (RTC_MODE1_INTENSET) Overflow Interrupt Enable Mask */
+#define RTC_MODE1_INTENSET_OVF              RTC_MODE1_INTENSET_OVF_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTENSET_OVF_Msk instead */
+#define RTC_MODE1_INTENSET_MASK             _U_(0xC3FF)                                    /**< \deprecated (RTC_MODE1_INTENSET) Register MASK  (Use RTC_MODE1_INTENSET_Msk instead)  */
+#define RTC_MODE1_INTENSET_Msk              _U_(0xC3FF)                                    /**< (RTC_MODE1_INTENSET) Register Mask  */
+
+#define RTC_MODE1_INTENSET_PER_Pos          0                                              /**< (RTC_MODE1_INTENSET Position) Periodic Interval x Interrupt Enable */
+#define RTC_MODE1_INTENSET_PER_Msk          (_U_(0xFF) << RTC_MODE1_INTENSET_PER_Pos)      /**< (RTC_MODE1_INTENSET Mask) PER */
+#define RTC_MODE1_INTENSET_PER(value)       (RTC_MODE1_INTENSET_PER_Msk & ((value) << RTC_MODE1_INTENSET_PER_Pos))  
+#define RTC_MODE1_INTENSET_CMP_Pos          8                                              /**< (RTC_MODE1_INTENSET Position) Compare x Interrupt Enable */
+#define RTC_MODE1_INTENSET_CMP_Msk          (_U_(0x3) << RTC_MODE1_INTENSET_CMP_Pos)       /**< (RTC_MODE1_INTENSET Mask) CMP */
+#define RTC_MODE1_INTENSET_CMP(value)       (RTC_MODE1_INTENSET_CMP_Msk & ((value) << RTC_MODE1_INTENSET_CMP_Pos))  
+
+/* -------- RTC_MODE2_INTENSET : (RTC Offset: 0x0a) (R/W 16) MODE2 Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t PER0:1;                    /**< bit:      0  Periodic Interval 0 Enable               */
+    uint16_t PER1:1;                    /**< bit:      1  Periodic Interval 1 Enable               */
+    uint16_t PER2:1;                    /**< bit:      2  Periodic Interval 2 Enable               */
+    uint16_t PER3:1;                    /**< bit:      3  Periodic Interval 3 Enable               */
+    uint16_t PER4:1;                    /**< bit:      4  Periodic Interval 4 Enable               */
+    uint16_t PER5:1;                    /**< bit:      5  Periodic Interval 5 Enable               */
+    uint16_t PER6:1;                    /**< bit:      6  Periodic Interval 6 Enable               */
+    uint16_t PER7:1;                    /**< bit:      7  Periodic Interval 7 Enable               */
+    uint16_t ALARM0:1;                  /**< bit:      8  Alarm 0 Interrupt Enable                 */
+    uint16_t :5;                        /**< bit:  9..13  Reserved */
+    uint16_t TAMPER:1;                  /**< bit:     14  Tamper Enable                            */
+    uint16_t OVF:1;                     /**< bit:     15  Overflow Interrupt Enable                */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint16_t PER:8;                     /**< bit:   0..7  Periodic Interval x Enable               */
+    uint16_t ALARM:1;                   /**< bit:      8  Alarm x Interrupt Enable                 */
+    uint16_t :7;                        /**< bit:  9..15 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint16_t reg;                         /**< Type used for register access */
+} RTC_MODE2_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE2_INTENSET_OFFSET           (0x0A)                                        /**<  (RTC_MODE2_INTENSET) MODE2 Interrupt Enable Set  Offset */
+#define RTC_MODE2_INTENSET_RESETVALUE       _U_(0x00)                                     /**<  (RTC_MODE2_INTENSET) MODE2 Interrupt Enable Set  Reset Value */
+
+#define RTC_MODE2_INTENSET_PER0_Pos         0                                              /**< (RTC_MODE2_INTENSET) Periodic Interval 0 Enable Position */
+#define RTC_MODE2_INTENSET_PER0_Msk         (_U_(0x1) << RTC_MODE2_INTENSET_PER0_Pos)      /**< (RTC_MODE2_INTENSET) Periodic Interval 0 Enable Mask */
+#define RTC_MODE2_INTENSET_PER0             RTC_MODE2_INTENSET_PER0_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTENSET_PER0_Msk instead */
+#define RTC_MODE2_INTENSET_PER1_Pos         1                                              /**< (RTC_MODE2_INTENSET) Periodic Interval 1 Enable Position */
+#define RTC_MODE2_INTENSET_PER1_Msk         (_U_(0x1) << RTC_MODE2_INTENSET_PER1_Pos)      /**< (RTC_MODE2_INTENSET) Periodic Interval 1 Enable Mask */
+#define RTC_MODE2_INTENSET_PER1             RTC_MODE2_INTENSET_PER1_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTENSET_PER1_Msk instead */
+#define RTC_MODE2_INTENSET_PER2_Pos         2                                              /**< (RTC_MODE2_INTENSET) Periodic Interval 2 Enable Position */
+#define RTC_MODE2_INTENSET_PER2_Msk         (_U_(0x1) << RTC_MODE2_INTENSET_PER2_Pos)      /**< (RTC_MODE2_INTENSET) Periodic Interval 2 Enable Mask */
+#define RTC_MODE2_INTENSET_PER2             RTC_MODE2_INTENSET_PER2_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTENSET_PER2_Msk instead */
+#define RTC_MODE2_INTENSET_PER3_Pos         3                                              /**< (RTC_MODE2_INTENSET) Periodic Interval 3 Enable Position */
+#define RTC_MODE2_INTENSET_PER3_Msk         (_U_(0x1) << RTC_MODE2_INTENSET_PER3_Pos)      /**< (RTC_MODE2_INTENSET) Periodic Interval 3 Enable Mask */
+#define RTC_MODE2_INTENSET_PER3             RTC_MODE2_INTENSET_PER3_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTENSET_PER3_Msk instead */
+#define RTC_MODE2_INTENSET_PER4_Pos         4                                              /**< (RTC_MODE2_INTENSET) Periodic Interval 4 Enable Position */
+#define RTC_MODE2_INTENSET_PER4_Msk         (_U_(0x1) << RTC_MODE2_INTENSET_PER4_Pos)      /**< (RTC_MODE2_INTENSET) Periodic Interval 4 Enable Mask */
+#define RTC_MODE2_INTENSET_PER4             RTC_MODE2_INTENSET_PER4_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTENSET_PER4_Msk instead */
+#define RTC_MODE2_INTENSET_PER5_Pos         5                                              /**< (RTC_MODE2_INTENSET) Periodic Interval 5 Enable Position */
+#define RTC_MODE2_INTENSET_PER5_Msk         (_U_(0x1) << RTC_MODE2_INTENSET_PER5_Pos)      /**< (RTC_MODE2_INTENSET) Periodic Interval 5 Enable Mask */
+#define RTC_MODE2_INTENSET_PER5             RTC_MODE2_INTENSET_PER5_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTENSET_PER5_Msk instead */
+#define RTC_MODE2_INTENSET_PER6_Pos         6                                              /**< (RTC_MODE2_INTENSET) Periodic Interval 6 Enable Position */
+#define RTC_MODE2_INTENSET_PER6_Msk         (_U_(0x1) << RTC_MODE2_INTENSET_PER6_Pos)      /**< (RTC_MODE2_INTENSET) Periodic Interval 6 Enable Mask */
+#define RTC_MODE2_INTENSET_PER6             RTC_MODE2_INTENSET_PER6_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTENSET_PER6_Msk instead */
+#define RTC_MODE2_INTENSET_PER7_Pos         7                                              /**< (RTC_MODE2_INTENSET) Periodic Interval 7 Enable Position */
+#define RTC_MODE2_INTENSET_PER7_Msk         (_U_(0x1) << RTC_MODE2_INTENSET_PER7_Pos)      /**< (RTC_MODE2_INTENSET) Periodic Interval 7 Enable Mask */
+#define RTC_MODE2_INTENSET_PER7             RTC_MODE2_INTENSET_PER7_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTENSET_PER7_Msk instead */
+#define RTC_MODE2_INTENSET_ALARM0_Pos       8                                              /**< (RTC_MODE2_INTENSET) Alarm 0 Interrupt Enable Position */
+#define RTC_MODE2_INTENSET_ALARM0_Msk       (_U_(0x1) << RTC_MODE2_INTENSET_ALARM0_Pos)    /**< (RTC_MODE2_INTENSET) Alarm 0 Interrupt Enable Mask */
+#define RTC_MODE2_INTENSET_ALARM0           RTC_MODE2_INTENSET_ALARM0_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTENSET_ALARM0_Msk instead */
+#define RTC_MODE2_INTENSET_TAMPER_Pos       14                                             /**< (RTC_MODE2_INTENSET) Tamper Enable Position */
+#define RTC_MODE2_INTENSET_TAMPER_Msk       (_U_(0x1) << RTC_MODE2_INTENSET_TAMPER_Pos)    /**< (RTC_MODE2_INTENSET) Tamper Enable Mask */
+#define RTC_MODE2_INTENSET_TAMPER           RTC_MODE2_INTENSET_TAMPER_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTENSET_TAMPER_Msk instead */
+#define RTC_MODE2_INTENSET_OVF_Pos          15                                             /**< (RTC_MODE2_INTENSET) Overflow Interrupt Enable Position */
+#define RTC_MODE2_INTENSET_OVF_Msk          (_U_(0x1) << RTC_MODE2_INTENSET_OVF_Pos)       /**< (RTC_MODE2_INTENSET) Overflow Interrupt Enable Mask */
+#define RTC_MODE2_INTENSET_OVF              RTC_MODE2_INTENSET_OVF_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTENSET_OVF_Msk instead */
+#define RTC_MODE2_INTENSET_MASK             _U_(0xC1FF)                                    /**< \deprecated (RTC_MODE2_INTENSET) Register MASK  (Use RTC_MODE2_INTENSET_Msk instead)  */
+#define RTC_MODE2_INTENSET_Msk              _U_(0xC1FF)                                    /**< (RTC_MODE2_INTENSET) Register Mask  */
+
+#define RTC_MODE2_INTENSET_PER_Pos          0                                              /**< (RTC_MODE2_INTENSET Position) Periodic Interval x Enable */
+#define RTC_MODE2_INTENSET_PER_Msk          (_U_(0xFF) << RTC_MODE2_INTENSET_PER_Pos)      /**< (RTC_MODE2_INTENSET Mask) PER */
+#define RTC_MODE2_INTENSET_PER(value)       (RTC_MODE2_INTENSET_PER_Msk & ((value) << RTC_MODE2_INTENSET_PER_Pos))  
+#define RTC_MODE2_INTENSET_ALARM_Pos        8                                              /**< (RTC_MODE2_INTENSET Position) Alarm x Interrupt Enable */
+#define RTC_MODE2_INTENSET_ALARM_Msk        (_U_(0x1) << RTC_MODE2_INTENSET_ALARM_Pos)     /**< (RTC_MODE2_INTENSET Mask) ALARM */
+#define RTC_MODE2_INTENSET_ALARM(value)     (RTC_MODE2_INTENSET_ALARM_Msk & ((value) << RTC_MODE2_INTENSET_ALARM_Pos))  
+
+/* -------- RTC_MODE0_INTFLAG : (RTC Offset: 0x0c) (R/W 16) MODE0 Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint16_t PER0:1;                    /**< bit:      0  Periodic Interval 0                      */
+    __I uint16_t PER1:1;                    /**< bit:      1  Periodic Interval 1                      */
+    __I uint16_t PER2:1;                    /**< bit:      2  Periodic Interval 2                      */
+    __I uint16_t PER3:1;                    /**< bit:      3  Periodic Interval 3                      */
+    __I uint16_t PER4:1;                    /**< bit:      4  Periodic Interval 4                      */
+    __I uint16_t PER5:1;                    /**< bit:      5  Periodic Interval 5                      */
+    __I uint16_t PER6:1;                    /**< bit:      6  Periodic Interval 6                      */
+    __I uint16_t PER7:1;                    /**< bit:      7  Periodic Interval 7                      */
+    __I uint16_t CMP0:1;                    /**< bit:      8  Compare 0                                */
+    __I uint16_t :5;                        /**< bit:  9..13  Reserved */
+    __I uint16_t TAMPER:1;                  /**< bit:     14  Tamper                                   */
+    __I uint16_t OVF:1;                     /**< bit:     15  Overflow                                 */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    __I uint16_t PER:8;                     /**< bit:   0..7  Periodic Interval x                      */
+    __I uint16_t CMP:1;                     /**< bit:      8  Compare x                                */
+    __I uint16_t :7;                        /**< bit:  9..15 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint16_t reg;                         /**< Type used for register access */
+} RTC_MODE0_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE0_INTFLAG_OFFSET            (0x0C)                                        /**<  (RTC_MODE0_INTFLAG) MODE0 Interrupt Flag Status and Clear  Offset */
+#define RTC_MODE0_INTFLAG_RESETVALUE        _U_(0x00)                                     /**<  (RTC_MODE0_INTFLAG) MODE0 Interrupt Flag Status and Clear  Reset Value */
+
+#define RTC_MODE0_INTFLAG_PER0_Pos          0                                              /**< (RTC_MODE0_INTFLAG) Periodic Interval 0 Position */
+#define RTC_MODE0_INTFLAG_PER0_Msk          (_U_(0x1) << RTC_MODE0_INTFLAG_PER0_Pos)       /**< (RTC_MODE0_INTFLAG) Periodic Interval 0 Mask */
+#define RTC_MODE0_INTFLAG_PER0              RTC_MODE0_INTFLAG_PER0_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTFLAG_PER0_Msk instead */
+#define RTC_MODE0_INTFLAG_PER1_Pos          1                                              /**< (RTC_MODE0_INTFLAG) Periodic Interval 1 Position */
+#define RTC_MODE0_INTFLAG_PER1_Msk          (_U_(0x1) << RTC_MODE0_INTFLAG_PER1_Pos)       /**< (RTC_MODE0_INTFLAG) Periodic Interval 1 Mask */
+#define RTC_MODE0_INTFLAG_PER1              RTC_MODE0_INTFLAG_PER1_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTFLAG_PER1_Msk instead */
+#define RTC_MODE0_INTFLAG_PER2_Pos          2                                              /**< (RTC_MODE0_INTFLAG) Periodic Interval 2 Position */
+#define RTC_MODE0_INTFLAG_PER2_Msk          (_U_(0x1) << RTC_MODE0_INTFLAG_PER2_Pos)       /**< (RTC_MODE0_INTFLAG) Periodic Interval 2 Mask */
+#define RTC_MODE0_INTFLAG_PER2              RTC_MODE0_INTFLAG_PER2_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTFLAG_PER2_Msk instead */
+#define RTC_MODE0_INTFLAG_PER3_Pos          3                                              /**< (RTC_MODE0_INTFLAG) Periodic Interval 3 Position */
+#define RTC_MODE0_INTFLAG_PER3_Msk          (_U_(0x1) << RTC_MODE0_INTFLAG_PER3_Pos)       /**< (RTC_MODE0_INTFLAG) Periodic Interval 3 Mask */
+#define RTC_MODE0_INTFLAG_PER3              RTC_MODE0_INTFLAG_PER3_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTFLAG_PER3_Msk instead */
+#define RTC_MODE0_INTFLAG_PER4_Pos          4                                              /**< (RTC_MODE0_INTFLAG) Periodic Interval 4 Position */
+#define RTC_MODE0_INTFLAG_PER4_Msk          (_U_(0x1) << RTC_MODE0_INTFLAG_PER4_Pos)       /**< (RTC_MODE0_INTFLAG) Periodic Interval 4 Mask */
+#define RTC_MODE0_INTFLAG_PER4              RTC_MODE0_INTFLAG_PER4_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTFLAG_PER4_Msk instead */
+#define RTC_MODE0_INTFLAG_PER5_Pos          5                                              /**< (RTC_MODE0_INTFLAG) Periodic Interval 5 Position */
+#define RTC_MODE0_INTFLAG_PER5_Msk          (_U_(0x1) << RTC_MODE0_INTFLAG_PER5_Pos)       /**< (RTC_MODE0_INTFLAG) Periodic Interval 5 Mask */
+#define RTC_MODE0_INTFLAG_PER5              RTC_MODE0_INTFLAG_PER5_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTFLAG_PER5_Msk instead */
+#define RTC_MODE0_INTFLAG_PER6_Pos          6                                              /**< (RTC_MODE0_INTFLAG) Periodic Interval 6 Position */
+#define RTC_MODE0_INTFLAG_PER6_Msk          (_U_(0x1) << RTC_MODE0_INTFLAG_PER6_Pos)       /**< (RTC_MODE0_INTFLAG) Periodic Interval 6 Mask */
+#define RTC_MODE0_INTFLAG_PER6              RTC_MODE0_INTFLAG_PER6_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTFLAG_PER6_Msk instead */
+#define RTC_MODE0_INTFLAG_PER7_Pos          7                                              /**< (RTC_MODE0_INTFLAG) Periodic Interval 7 Position */
+#define RTC_MODE0_INTFLAG_PER7_Msk          (_U_(0x1) << RTC_MODE0_INTFLAG_PER7_Pos)       /**< (RTC_MODE0_INTFLAG) Periodic Interval 7 Mask */
+#define RTC_MODE0_INTFLAG_PER7              RTC_MODE0_INTFLAG_PER7_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTFLAG_PER7_Msk instead */
+#define RTC_MODE0_INTFLAG_CMP0_Pos          8                                              /**< (RTC_MODE0_INTFLAG) Compare 0 Position */
+#define RTC_MODE0_INTFLAG_CMP0_Msk          (_U_(0x1) << RTC_MODE0_INTFLAG_CMP0_Pos)       /**< (RTC_MODE0_INTFLAG) Compare 0 Mask */
+#define RTC_MODE0_INTFLAG_CMP0              RTC_MODE0_INTFLAG_CMP0_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTFLAG_CMP0_Msk instead */
+#define RTC_MODE0_INTFLAG_TAMPER_Pos        14                                             /**< (RTC_MODE0_INTFLAG) Tamper Position */
+#define RTC_MODE0_INTFLAG_TAMPER_Msk        (_U_(0x1) << RTC_MODE0_INTFLAG_TAMPER_Pos)     /**< (RTC_MODE0_INTFLAG) Tamper Mask */
+#define RTC_MODE0_INTFLAG_TAMPER            RTC_MODE0_INTFLAG_TAMPER_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTFLAG_TAMPER_Msk instead */
+#define RTC_MODE0_INTFLAG_OVF_Pos           15                                             /**< (RTC_MODE0_INTFLAG) Overflow Position */
+#define RTC_MODE0_INTFLAG_OVF_Msk           (_U_(0x1) << RTC_MODE0_INTFLAG_OVF_Pos)        /**< (RTC_MODE0_INTFLAG) Overflow Mask */
+#define RTC_MODE0_INTFLAG_OVF               RTC_MODE0_INTFLAG_OVF_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTFLAG_OVF_Msk instead */
+#define RTC_MODE0_INTFLAG_MASK              _U_(0xC1FF)                                    /**< \deprecated (RTC_MODE0_INTFLAG) Register MASK  (Use RTC_MODE0_INTFLAG_Msk instead)  */
+#define RTC_MODE0_INTFLAG_Msk               _U_(0xC1FF)                                    /**< (RTC_MODE0_INTFLAG) Register Mask  */
+
+#define RTC_MODE0_INTFLAG_PER_Pos           0                                              /**< (RTC_MODE0_INTFLAG Position) Periodic Interval x */
+#define RTC_MODE0_INTFLAG_PER_Msk           (_U_(0xFF) << RTC_MODE0_INTFLAG_PER_Pos)       /**< (RTC_MODE0_INTFLAG Mask) PER */
+#define RTC_MODE0_INTFLAG_PER(value)        (RTC_MODE0_INTFLAG_PER_Msk & ((value) << RTC_MODE0_INTFLAG_PER_Pos))  
+#define RTC_MODE0_INTFLAG_CMP_Pos           8                                              /**< (RTC_MODE0_INTFLAG Position) Compare x */
+#define RTC_MODE0_INTFLAG_CMP_Msk           (_U_(0x1) << RTC_MODE0_INTFLAG_CMP_Pos)        /**< (RTC_MODE0_INTFLAG Mask) CMP */
+#define RTC_MODE0_INTFLAG_CMP(value)        (RTC_MODE0_INTFLAG_CMP_Msk & ((value) << RTC_MODE0_INTFLAG_CMP_Pos))  
+
+/* -------- RTC_MODE1_INTFLAG : (RTC Offset: 0x0c) (R/W 16) MODE1 Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint16_t PER0:1;                    /**< bit:      0  Periodic Interval 0                      */
+    __I uint16_t PER1:1;                    /**< bit:      1  Periodic Interval 1                      */
+    __I uint16_t PER2:1;                    /**< bit:      2  Periodic Interval 2                      */
+    __I uint16_t PER3:1;                    /**< bit:      3  Periodic Interval 3                      */
+    __I uint16_t PER4:1;                    /**< bit:      4  Periodic Interval 4                      */
+    __I uint16_t PER5:1;                    /**< bit:      5  Periodic Interval 5                      */
+    __I uint16_t PER6:1;                    /**< bit:      6  Periodic Interval 6                      */
+    __I uint16_t PER7:1;                    /**< bit:      7  Periodic Interval 7                      */
+    __I uint16_t CMP0:1;                    /**< bit:      8  Compare 0                                */
+    __I uint16_t CMP1:1;                    /**< bit:      9  Compare 1                                */
+    __I uint16_t :4;                        /**< bit: 10..13  Reserved */
+    __I uint16_t TAMPER:1;                  /**< bit:     14  Tamper                                   */
+    __I uint16_t OVF:1;                     /**< bit:     15  Overflow                                 */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    __I uint16_t PER:8;                     /**< bit:   0..7  Periodic Interval x                      */
+    __I uint16_t CMP:2;                     /**< bit:   8..9  Compare x                                */
+    __I uint16_t :6;                        /**< bit: 10..15 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint16_t reg;                         /**< Type used for register access */
+} RTC_MODE1_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE1_INTFLAG_OFFSET            (0x0C)                                        /**<  (RTC_MODE1_INTFLAG) MODE1 Interrupt Flag Status and Clear  Offset */
+#define RTC_MODE1_INTFLAG_RESETVALUE        _U_(0x00)                                     /**<  (RTC_MODE1_INTFLAG) MODE1 Interrupt Flag Status and Clear  Reset Value */
+
+#define RTC_MODE1_INTFLAG_PER0_Pos          0                                              /**< (RTC_MODE1_INTFLAG) Periodic Interval 0 Position */
+#define RTC_MODE1_INTFLAG_PER0_Msk          (_U_(0x1) << RTC_MODE1_INTFLAG_PER0_Pos)       /**< (RTC_MODE1_INTFLAG) Periodic Interval 0 Mask */
+#define RTC_MODE1_INTFLAG_PER0              RTC_MODE1_INTFLAG_PER0_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTFLAG_PER0_Msk instead */
+#define RTC_MODE1_INTFLAG_PER1_Pos          1                                              /**< (RTC_MODE1_INTFLAG) Periodic Interval 1 Position */
+#define RTC_MODE1_INTFLAG_PER1_Msk          (_U_(0x1) << RTC_MODE1_INTFLAG_PER1_Pos)       /**< (RTC_MODE1_INTFLAG) Periodic Interval 1 Mask */
+#define RTC_MODE1_INTFLAG_PER1              RTC_MODE1_INTFLAG_PER1_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTFLAG_PER1_Msk instead */
+#define RTC_MODE1_INTFLAG_PER2_Pos          2                                              /**< (RTC_MODE1_INTFLAG) Periodic Interval 2 Position */
+#define RTC_MODE1_INTFLAG_PER2_Msk          (_U_(0x1) << RTC_MODE1_INTFLAG_PER2_Pos)       /**< (RTC_MODE1_INTFLAG) Periodic Interval 2 Mask */
+#define RTC_MODE1_INTFLAG_PER2              RTC_MODE1_INTFLAG_PER2_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTFLAG_PER2_Msk instead */
+#define RTC_MODE1_INTFLAG_PER3_Pos          3                                              /**< (RTC_MODE1_INTFLAG) Periodic Interval 3 Position */
+#define RTC_MODE1_INTFLAG_PER3_Msk          (_U_(0x1) << RTC_MODE1_INTFLAG_PER3_Pos)       /**< (RTC_MODE1_INTFLAG) Periodic Interval 3 Mask */
+#define RTC_MODE1_INTFLAG_PER3              RTC_MODE1_INTFLAG_PER3_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTFLAG_PER3_Msk instead */
+#define RTC_MODE1_INTFLAG_PER4_Pos          4                                              /**< (RTC_MODE1_INTFLAG) Periodic Interval 4 Position */
+#define RTC_MODE1_INTFLAG_PER4_Msk          (_U_(0x1) << RTC_MODE1_INTFLAG_PER4_Pos)       /**< (RTC_MODE1_INTFLAG) Periodic Interval 4 Mask */
+#define RTC_MODE1_INTFLAG_PER4              RTC_MODE1_INTFLAG_PER4_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTFLAG_PER4_Msk instead */
+#define RTC_MODE1_INTFLAG_PER5_Pos          5                                              /**< (RTC_MODE1_INTFLAG) Periodic Interval 5 Position */
+#define RTC_MODE1_INTFLAG_PER5_Msk          (_U_(0x1) << RTC_MODE1_INTFLAG_PER5_Pos)       /**< (RTC_MODE1_INTFLAG) Periodic Interval 5 Mask */
+#define RTC_MODE1_INTFLAG_PER5              RTC_MODE1_INTFLAG_PER5_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTFLAG_PER5_Msk instead */
+#define RTC_MODE1_INTFLAG_PER6_Pos          6                                              /**< (RTC_MODE1_INTFLAG) Periodic Interval 6 Position */
+#define RTC_MODE1_INTFLAG_PER6_Msk          (_U_(0x1) << RTC_MODE1_INTFLAG_PER6_Pos)       /**< (RTC_MODE1_INTFLAG) Periodic Interval 6 Mask */
+#define RTC_MODE1_INTFLAG_PER6              RTC_MODE1_INTFLAG_PER6_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTFLAG_PER6_Msk instead */
+#define RTC_MODE1_INTFLAG_PER7_Pos          7                                              /**< (RTC_MODE1_INTFLAG) Periodic Interval 7 Position */
+#define RTC_MODE1_INTFLAG_PER7_Msk          (_U_(0x1) << RTC_MODE1_INTFLAG_PER7_Pos)       /**< (RTC_MODE1_INTFLAG) Periodic Interval 7 Mask */
+#define RTC_MODE1_INTFLAG_PER7              RTC_MODE1_INTFLAG_PER7_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTFLAG_PER7_Msk instead */
+#define RTC_MODE1_INTFLAG_CMP0_Pos          8                                              /**< (RTC_MODE1_INTFLAG) Compare 0 Position */
+#define RTC_MODE1_INTFLAG_CMP0_Msk          (_U_(0x1) << RTC_MODE1_INTFLAG_CMP0_Pos)       /**< (RTC_MODE1_INTFLAG) Compare 0 Mask */
+#define RTC_MODE1_INTFLAG_CMP0              RTC_MODE1_INTFLAG_CMP0_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTFLAG_CMP0_Msk instead */
+#define RTC_MODE1_INTFLAG_CMP1_Pos          9                                              /**< (RTC_MODE1_INTFLAG) Compare 1 Position */
+#define RTC_MODE1_INTFLAG_CMP1_Msk          (_U_(0x1) << RTC_MODE1_INTFLAG_CMP1_Pos)       /**< (RTC_MODE1_INTFLAG) Compare 1 Mask */
+#define RTC_MODE1_INTFLAG_CMP1              RTC_MODE1_INTFLAG_CMP1_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTFLAG_CMP1_Msk instead */
+#define RTC_MODE1_INTFLAG_TAMPER_Pos        14                                             /**< (RTC_MODE1_INTFLAG) Tamper Position */
+#define RTC_MODE1_INTFLAG_TAMPER_Msk        (_U_(0x1) << RTC_MODE1_INTFLAG_TAMPER_Pos)     /**< (RTC_MODE1_INTFLAG) Tamper Mask */
+#define RTC_MODE1_INTFLAG_TAMPER            RTC_MODE1_INTFLAG_TAMPER_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTFLAG_TAMPER_Msk instead */
+#define RTC_MODE1_INTFLAG_OVF_Pos           15                                             /**< (RTC_MODE1_INTFLAG) Overflow Position */
+#define RTC_MODE1_INTFLAG_OVF_Msk           (_U_(0x1) << RTC_MODE1_INTFLAG_OVF_Pos)        /**< (RTC_MODE1_INTFLAG) Overflow Mask */
+#define RTC_MODE1_INTFLAG_OVF               RTC_MODE1_INTFLAG_OVF_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTFLAG_OVF_Msk instead */
+#define RTC_MODE1_INTFLAG_MASK              _U_(0xC3FF)                                    /**< \deprecated (RTC_MODE1_INTFLAG) Register MASK  (Use RTC_MODE1_INTFLAG_Msk instead)  */
+#define RTC_MODE1_INTFLAG_Msk               _U_(0xC3FF)                                    /**< (RTC_MODE1_INTFLAG) Register Mask  */
+
+#define RTC_MODE1_INTFLAG_PER_Pos           0                                              /**< (RTC_MODE1_INTFLAG Position) Periodic Interval x */
+#define RTC_MODE1_INTFLAG_PER_Msk           (_U_(0xFF) << RTC_MODE1_INTFLAG_PER_Pos)       /**< (RTC_MODE1_INTFLAG Mask) PER */
+#define RTC_MODE1_INTFLAG_PER(value)        (RTC_MODE1_INTFLAG_PER_Msk & ((value) << RTC_MODE1_INTFLAG_PER_Pos))  
+#define RTC_MODE1_INTFLAG_CMP_Pos           8                                              /**< (RTC_MODE1_INTFLAG Position) Compare x */
+#define RTC_MODE1_INTFLAG_CMP_Msk           (_U_(0x3) << RTC_MODE1_INTFLAG_CMP_Pos)        /**< (RTC_MODE1_INTFLAG Mask) CMP */
+#define RTC_MODE1_INTFLAG_CMP(value)        (RTC_MODE1_INTFLAG_CMP_Msk & ((value) << RTC_MODE1_INTFLAG_CMP_Pos))  
+
+/* -------- RTC_MODE2_INTFLAG : (RTC Offset: 0x0c) (R/W 16) MODE2 Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint16_t PER0:1;                    /**< bit:      0  Periodic Interval 0                      */
+    __I uint16_t PER1:1;                    /**< bit:      1  Periodic Interval 1                      */
+    __I uint16_t PER2:1;                    /**< bit:      2  Periodic Interval 2                      */
+    __I uint16_t PER3:1;                    /**< bit:      3  Periodic Interval 3                      */
+    __I uint16_t PER4:1;                    /**< bit:      4  Periodic Interval 4                      */
+    __I uint16_t PER5:1;                    /**< bit:      5  Periodic Interval 5                      */
+    __I uint16_t PER6:1;                    /**< bit:      6  Periodic Interval 6                      */
+    __I uint16_t PER7:1;                    /**< bit:      7  Periodic Interval 7                      */
+    __I uint16_t ALARM0:1;                  /**< bit:      8  Alarm 0                                  */
+    __I uint16_t :5;                        /**< bit:  9..13  Reserved */
+    __I uint16_t TAMPER:1;                  /**< bit:     14  Tamper                                   */
+    __I uint16_t OVF:1;                     /**< bit:     15  Overflow                                 */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    __I uint16_t PER:8;                     /**< bit:   0..7  Periodic Interval x                      */
+    __I uint16_t ALARM:1;                   /**< bit:      8  Alarm x                                  */
+    __I uint16_t :7;                        /**< bit:  9..15 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint16_t reg;                         /**< Type used for register access */
+} RTC_MODE2_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE2_INTFLAG_OFFSET            (0x0C)                                        /**<  (RTC_MODE2_INTFLAG) MODE2 Interrupt Flag Status and Clear  Offset */
+#define RTC_MODE2_INTFLAG_RESETVALUE        _U_(0x00)                                     /**<  (RTC_MODE2_INTFLAG) MODE2 Interrupt Flag Status and Clear  Reset Value */
+
+#define RTC_MODE2_INTFLAG_PER0_Pos          0                                              /**< (RTC_MODE2_INTFLAG) Periodic Interval 0 Position */
+#define RTC_MODE2_INTFLAG_PER0_Msk          (_U_(0x1) << RTC_MODE2_INTFLAG_PER0_Pos)       /**< (RTC_MODE2_INTFLAG) Periodic Interval 0 Mask */
+#define RTC_MODE2_INTFLAG_PER0              RTC_MODE2_INTFLAG_PER0_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTFLAG_PER0_Msk instead */
+#define RTC_MODE2_INTFLAG_PER1_Pos          1                                              /**< (RTC_MODE2_INTFLAG) Periodic Interval 1 Position */
+#define RTC_MODE2_INTFLAG_PER1_Msk          (_U_(0x1) << RTC_MODE2_INTFLAG_PER1_Pos)       /**< (RTC_MODE2_INTFLAG) Periodic Interval 1 Mask */
+#define RTC_MODE2_INTFLAG_PER1              RTC_MODE2_INTFLAG_PER1_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTFLAG_PER1_Msk instead */
+#define RTC_MODE2_INTFLAG_PER2_Pos          2                                              /**< (RTC_MODE2_INTFLAG) Periodic Interval 2 Position */
+#define RTC_MODE2_INTFLAG_PER2_Msk          (_U_(0x1) << RTC_MODE2_INTFLAG_PER2_Pos)       /**< (RTC_MODE2_INTFLAG) Periodic Interval 2 Mask */
+#define RTC_MODE2_INTFLAG_PER2              RTC_MODE2_INTFLAG_PER2_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTFLAG_PER2_Msk instead */
+#define RTC_MODE2_INTFLAG_PER3_Pos          3                                              /**< (RTC_MODE2_INTFLAG) Periodic Interval 3 Position */
+#define RTC_MODE2_INTFLAG_PER3_Msk          (_U_(0x1) << RTC_MODE2_INTFLAG_PER3_Pos)       /**< (RTC_MODE2_INTFLAG) Periodic Interval 3 Mask */
+#define RTC_MODE2_INTFLAG_PER3              RTC_MODE2_INTFLAG_PER3_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTFLAG_PER3_Msk instead */
+#define RTC_MODE2_INTFLAG_PER4_Pos          4                                              /**< (RTC_MODE2_INTFLAG) Periodic Interval 4 Position */
+#define RTC_MODE2_INTFLAG_PER4_Msk          (_U_(0x1) << RTC_MODE2_INTFLAG_PER4_Pos)       /**< (RTC_MODE2_INTFLAG) Periodic Interval 4 Mask */
+#define RTC_MODE2_INTFLAG_PER4              RTC_MODE2_INTFLAG_PER4_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTFLAG_PER4_Msk instead */
+#define RTC_MODE2_INTFLAG_PER5_Pos          5                                              /**< (RTC_MODE2_INTFLAG) Periodic Interval 5 Position */
+#define RTC_MODE2_INTFLAG_PER5_Msk          (_U_(0x1) << RTC_MODE2_INTFLAG_PER5_Pos)       /**< (RTC_MODE2_INTFLAG) Periodic Interval 5 Mask */
+#define RTC_MODE2_INTFLAG_PER5              RTC_MODE2_INTFLAG_PER5_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTFLAG_PER5_Msk instead */
+#define RTC_MODE2_INTFLAG_PER6_Pos          6                                              /**< (RTC_MODE2_INTFLAG) Periodic Interval 6 Position */
+#define RTC_MODE2_INTFLAG_PER6_Msk          (_U_(0x1) << RTC_MODE2_INTFLAG_PER6_Pos)       /**< (RTC_MODE2_INTFLAG) Periodic Interval 6 Mask */
+#define RTC_MODE2_INTFLAG_PER6              RTC_MODE2_INTFLAG_PER6_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTFLAG_PER6_Msk instead */
+#define RTC_MODE2_INTFLAG_PER7_Pos          7                                              /**< (RTC_MODE2_INTFLAG) Periodic Interval 7 Position */
+#define RTC_MODE2_INTFLAG_PER7_Msk          (_U_(0x1) << RTC_MODE2_INTFLAG_PER7_Pos)       /**< (RTC_MODE2_INTFLAG) Periodic Interval 7 Mask */
+#define RTC_MODE2_INTFLAG_PER7              RTC_MODE2_INTFLAG_PER7_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTFLAG_PER7_Msk instead */
+#define RTC_MODE2_INTFLAG_ALARM0_Pos        8                                              /**< (RTC_MODE2_INTFLAG) Alarm 0 Position */
+#define RTC_MODE2_INTFLAG_ALARM0_Msk        (_U_(0x1) << RTC_MODE2_INTFLAG_ALARM0_Pos)     /**< (RTC_MODE2_INTFLAG) Alarm 0 Mask */
+#define RTC_MODE2_INTFLAG_ALARM0            RTC_MODE2_INTFLAG_ALARM0_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTFLAG_ALARM0_Msk instead */
+#define RTC_MODE2_INTFLAG_TAMPER_Pos        14                                             /**< (RTC_MODE2_INTFLAG) Tamper Position */
+#define RTC_MODE2_INTFLAG_TAMPER_Msk        (_U_(0x1) << RTC_MODE2_INTFLAG_TAMPER_Pos)     /**< (RTC_MODE2_INTFLAG) Tamper Mask */
+#define RTC_MODE2_INTFLAG_TAMPER            RTC_MODE2_INTFLAG_TAMPER_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTFLAG_TAMPER_Msk instead */
+#define RTC_MODE2_INTFLAG_OVF_Pos           15                                             /**< (RTC_MODE2_INTFLAG) Overflow Position */
+#define RTC_MODE2_INTFLAG_OVF_Msk           (_U_(0x1) << RTC_MODE2_INTFLAG_OVF_Pos)        /**< (RTC_MODE2_INTFLAG) Overflow Mask */
+#define RTC_MODE2_INTFLAG_OVF               RTC_MODE2_INTFLAG_OVF_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTFLAG_OVF_Msk instead */
+#define RTC_MODE2_INTFLAG_MASK              _U_(0xC1FF)                                    /**< \deprecated (RTC_MODE2_INTFLAG) Register MASK  (Use RTC_MODE2_INTFLAG_Msk instead)  */
+#define RTC_MODE2_INTFLAG_Msk               _U_(0xC1FF)                                    /**< (RTC_MODE2_INTFLAG) Register Mask  */
+
+#define RTC_MODE2_INTFLAG_PER_Pos           0                                              /**< (RTC_MODE2_INTFLAG Position) Periodic Interval x */
+#define RTC_MODE2_INTFLAG_PER_Msk           (_U_(0xFF) << RTC_MODE2_INTFLAG_PER_Pos)       /**< (RTC_MODE2_INTFLAG Mask) PER */
+#define RTC_MODE2_INTFLAG_PER(value)        (RTC_MODE2_INTFLAG_PER_Msk & ((value) << RTC_MODE2_INTFLAG_PER_Pos))  
+#define RTC_MODE2_INTFLAG_ALARM_Pos         8                                              /**< (RTC_MODE2_INTFLAG Position) Alarm x */
+#define RTC_MODE2_INTFLAG_ALARM_Msk         (_U_(0x1) << RTC_MODE2_INTFLAG_ALARM_Pos)      /**< (RTC_MODE2_INTFLAG Mask) ALARM */
+#define RTC_MODE2_INTFLAG_ALARM(value)      (RTC_MODE2_INTFLAG_ALARM_Msk & ((value) << RTC_MODE2_INTFLAG_ALARM_Pos))  
+
+/* -------- RTC_DBGCTRL : (RTC Offset: 0x0e) (R/W 8) Debug Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DBGRUN:1;                  /**< bit:      0  Run During Debug                         */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} RTC_DBGCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_DBGCTRL_OFFSET                  (0x0E)                                        /**<  (RTC_DBGCTRL) Debug Control  Offset */
+#define RTC_DBGCTRL_RESETVALUE              _U_(0x00)                                     /**<  (RTC_DBGCTRL) Debug Control  Reset Value */
+
+#define RTC_DBGCTRL_DBGRUN_Pos              0                                              /**< (RTC_DBGCTRL) Run During Debug Position */
+#define RTC_DBGCTRL_DBGRUN_Msk              (_U_(0x1) << RTC_DBGCTRL_DBGRUN_Pos)           /**< (RTC_DBGCTRL) Run During Debug Mask */
+#define RTC_DBGCTRL_DBGRUN                  RTC_DBGCTRL_DBGRUN_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_DBGCTRL_DBGRUN_Msk instead */
+#define RTC_DBGCTRL_MASK                    _U_(0x01)                                      /**< \deprecated (RTC_DBGCTRL) Register MASK  (Use RTC_DBGCTRL_Msk instead)  */
+#define RTC_DBGCTRL_Msk                     _U_(0x01)                                      /**< (RTC_DBGCTRL) Register Mask  */
+
+
+/* -------- RTC_MODE0_SYNCBUSY : (RTC Offset: 0x10) (R/ 32) MODE0 Synchronization Busy Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SWRST:1;                   /**< bit:      0  Software Reset Busy                      */
+    uint32_t ENABLE:1;                  /**< bit:      1  Enable Bit Busy                          */
+    uint32_t FREQCORR:1;                /**< bit:      2  FREQCORR Register Busy                   */
+    uint32_t COUNT:1;                   /**< bit:      3  COUNT Register Busy                      */
+    uint32_t :1;                        /**< bit:      4  Reserved */
+    uint32_t COMP0:1;                   /**< bit:      5  COMP 0 Register Busy                     */
+    uint32_t :9;                        /**< bit:  6..14  Reserved */
+    uint32_t COUNTSYNC:1;               /**< bit:     15  Count Synchronization Enable Bit Busy    */
+    uint32_t GP0:1;                     /**< bit:     16  General Purpose 0 Register Busy          */
+    uint32_t GP1:1;                     /**< bit:     17  General Purpose 1 Register Busy          */
+    uint32_t :14;                       /**< bit: 18..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :5;                        /**< bit:   0..4  Reserved */
+    uint32_t COMP:1;                    /**< bit:      5  COMP x Register Busy                     */
+    uint32_t :10;                       /**< bit:  6..15  Reserved */
+    uint32_t GP:2;                      /**< bit: 16..17  General Purpose x Register Busy          */
+    uint32_t :14;                       /**< bit: 18..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_MODE0_SYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE0_SYNCBUSY_OFFSET           (0x10)                                        /**<  (RTC_MODE0_SYNCBUSY) MODE0 Synchronization Busy Status  Offset */
+#define RTC_MODE0_SYNCBUSY_RESETVALUE       _U_(0x00)                                     /**<  (RTC_MODE0_SYNCBUSY) MODE0 Synchronization Busy Status  Reset Value */
+
+#define RTC_MODE0_SYNCBUSY_SWRST_Pos        0                                              /**< (RTC_MODE0_SYNCBUSY) Software Reset Busy Position */
+#define RTC_MODE0_SYNCBUSY_SWRST_Msk        (_U_(0x1) << RTC_MODE0_SYNCBUSY_SWRST_Pos)     /**< (RTC_MODE0_SYNCBUSY) Software Reset Busy Mask */
+#define RTC_MODE0_SYNCBUSY_SWRST            RTC_MODE0_SYNCBUSY_SWRST_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_SYNCBUSY_SWRST_Msk instead */
+#define RTC_MODE0_SYNCBUSY_ENABLE_Pos       1                                              /**< (RTC_MODE0_SYNCBUSY) Enable Bit Busy Position */
+#define RTC_MODE0_SYNCBUSY_ENABLE_Msk       (_U_(0x1) << RTC_MODE0_SYNCBUSY_ENABLE_Pos)    /**< (RTC_MODE0_SYNCBUSY) Enable Bit Busy Mask */
+#define RTC_MODE0_SYNCBUSY_ENABLE           RTC_MODE0_SYNCBUSY_ENABLE_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_SYNCBUSY_ENABLE_Msk instead */
+#define RTC_MODE0_SYNCBUSY_FREQCORR_Pos     2                                              /**< (RTC_MODE0_SYNCBUSY) FREQCORR Register Busy Position */
+#define RTC_MODE0_SYNCBUSY_FREQCORR_Msk     (_U_(0x1) << RTC_MODE0_SYNCBUSY_FREQCORR_Pos)  /**< (RTC_MODE0_SYNCBUSY) FREQCORR Register Busy Mask */
+#define RTC_MODE0_SYNCBUSY_FREQCORR         RTC_MODE0_SYNCBUSY_FREQCORR_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_SYNCBUSY_FREQCORR_Msk instead */
+#define RTC_MODE0_SYNCBUSY_COUNT_Pos        3                                              /**< (RTC_MODE0_SYNCBUSY) COUNT Register Busy Position */
+#define RTC_MODE0_SYNCBUSY_COUNT_Msk        (_U_(0x1) << RTC_MODE0_SYNCBUSY_COUNT_Pos)     /**< (RTC_MODE0_SYNCBUSY) COUNT Register Busy Mask */
+#define RTC_MODE0_SYNCBUSY_COUNT            RTC_MODE0_SYNCBUSY_COUNT_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_SYNCBUSY_COUNT_Msk instead */
+#define RTC_MODE0_SYNCBUSY_COMP0_Pos        5                                              /**< (RTC_MODE0_SYNCBUSY) COMP 0 Register Busy Position */
+#define RTC_MODE0_SYNCBUSY_COMP0_Msk        (_U_(0x1) << RTC_MODE0_SYNCBUSY_COMP0_Pos)     /**< (RTC_MODE0_SYNCBUSY) COMP 0 Register Busy Mask */
+#define RTC_MODE0_SYNCBUSY_COMP0            RTC_MODE0_SYNCBUSY_COMP0_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_SYNCBUSY_COMP0_Msk instead */
+#define RTC_MODE0_SYNCBUSY_COUNTSYNC_Pos    15                                             /**< (RTC_MODE0_SYNCBUSY) Count Synchronization Enable Bit Busy Position */
+#define RTC_MODE0_SYNCBUSY_COUNTSYNC_Msk    (_U_(0x1) << RTC_MODE0_SYNCBUSY_COUNTSYNC_Pos)  /**< (RTC_MODE0_SYNCBUSY) Count Synchronization Enable Bit Busy Mask */
+#define RTC_MODE0_SYNCBUSY_COUNTSYNC        RTC_MODE0_SYNCBUSY_COUNTSYNC_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_SYNCBUSY_COUNTSYNC_Msk instead */
+#define RTC_MODE0_SYNCBUSY_GP0_Pos          16                                             /**< (RTC_MODE0_SYNCBUSY) General Purpose 0 Register Busy Position */
+#define RTC_MODE0_SYNCBUSY_GP0_Msk          (_U_(0x1) << RTC_MODE0_SYNCBUSY_GP0_Pos)       /**< (RTC_MODE0_SYNCBUSY) General Purpose 0 Register Busy Mask */
+#define RTC_MODE0_SYNCBUSY_GP0              RTC_MODE0_SYNCBUSY_GP0_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_SYNCBUSY_GP0_Msk instead */
+#define RTC_MODE0_SYNCBUSY_GP1_Pos          17                                             /**< (RTC_MODE0_SYNCBUSY) General Purpose 1 Register Busy Position */
+#define RTC_MODE0_SYNCBUSY_GP1_Msk          (_U_(0x1) << RTC_MODE0_SYNCBUSY_GP1_Pos)       /**< (RTC_MODE0_SYNCBUSY) General Purpose 1 Register Busy Mask */
+#define RTC_MODE0_SYNCBUSY_GP1              RTC_MODE0_SYNCBUSY_GP1_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_SYNCBUSY_GP1_Msk instead */
+#define RTC_MODE0_SYNCBUSY_MASK             _U_(0x3802F)                                   /**< \deprecated (RTC_MODE0_SYNCBUSY) Register MASK  (Use RTC_MODE0_SYNCBUSY_Msk instead)  */
+#define RTC_MODE0_SYNCBUSY_Msk              _U_(0x3802F)                                   /**< (RTC_MODE0_SYNCBUSY) Register Mask  */
+
+#define RTC_MODE0_SYNCBUSY_COMP_Pos         5                                              /**< (RTC_MODE0_SYNCBUSY Position) COMP x Register Busy */
+#define RTC_MODE0_SYNCBUSY_COMP_Msk         (_U_(0x1) << RTC_MODE0_SYNCBUSY_COMP_Pos)      /**< (RTC_MODE0_SYNCBUSY Mask) COMP */
+#define RTC_MODE0_SYNCBUSY_COMP(value)      (RTC_MODE0_SYNCBUSY_COMP_Msk & ((value) << RTC_MODE0_SYNCBUSY_COMP_Pos))  
+#define RTC_MODE0_SYNCBUSY_GP_Pos           16                                             /**< (RTC_MODE0_SYNCBUSY Position) General Purpose x Register Busy */
+#define RTC_MODE0_SYNCBUSY_GP_Msk           (_U_(0x3) << RTC_MODE0_SYNCBUSY_GP_Pos)        /**< (RTC_MODE0_SYNCBUSY Mask) GP */
+#define RTC_MODE0_SYNCBUSY_GP(value)        (RTC_MODE0_SYNCBUSY_GP_Msk & ((value) << RTC_MODE0_SYNCBUSY_GP_Pos))  
+
+/* -------- RTC_MODE1_SYNCBUSY : (RTC Offset: 0x10) (R/ 32) MODE1 Synchronization Busy Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SWRST:1;                   /**< bit:      0  Software Reset Bit Busy                  */
+    uint32_t ENABLE:1;                  /**< bit:      1  Enable Bit Busy                          */
+    uint32_t FREQCORR:1;                /**< bit:      2  FREQCORR Register Busy                   */
+    uint32_t COUNT:1;                   /**< bit:      3  COUNT Register Busy                      */
+    uint32_t PER:1;                     /**< bit:      4  PER Register Busy                        */
+    uint32_t COMP0:1;                   /**< bit:      5  COMP 0 Register Busy                     */
+    uint32_t COMP1:1;                   /**< bit:      6  COMP 1 Register Busy                     */
+    uint32_t :8;                        /**< bit:  7..14  Reserved */
+    uint32_t COUNTSYNC:1;               /**< bit:     15  Count Synchronization Enable Bit Busy    */
+    uint32_t GP0:1;                     /**< bit:     16  General Purpose 0 Register Busy          */
+    uint32_t GP1:1;                     /**< bit:     17  General Purpose 1 Register Busy          */
+    uint32_t :14;                       /**< bit: 18..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :5;                        /**< bit:   0..4  Reserved */
+    uint32_t COMP:2;                    /**< bit:   5..6  COMP x Register Busy                     */
+    uint32_t :9;                        /**< bit:  7..15  Reserved */
+    uint32_t GP:2;                      /**< bit: 16..17  General Purpose x Register Busy          */
+    uint32_t :14;                       /**< bit: 18..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_MODE1_SYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE1_SYNCBUSY_OFFSET           (0x10)                                        /**<  (RTC_MODE1_SYNCBUSY) MODE1 Synchronization Busy Status  Offset */
+#define RTC_MODE1_SYNCBUSY_RESETVALUE       _U_(0x00)                                     /**<  (RTC_MODE1_SYNCBUSY) MODE1 Synchronization Busy Status  Reset Value */
+
+#define RTC_MODE1_SYNCBUSY_SWRST_Pos        0                                              /**< (RTC_MODE1_SYNCBUSY) Software Reset Bit Busy Position */
+#define RTC_MODE1_SYNCBUSY_SWRST_Msk        (_U_(0x1) << RTC_MODE1_SYNCBUSY_SWRST_Pos)     /**< (RTC_MODE1_SYNCBUSY) Software Reset Bit Busy Mask */
+#define RTC_MODE1_SYNCBUSY_SWRST            RTC_MODE1_SYNCBUSY_SWRST_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_SYNCBUSY_SWRST_Msk instead */
+#define RTC_MODE1_SYNCBUSY_ENABLE_Pos       1                                              /**< (RTC_MODE1_SYNCBUSY) Enable Bit Busy Position */
+#define RTC_MODE1_SYNCBUSY_ENABLE_Msk       (_U_(0x1) << RTC_MODE1_SYNCBUSY_ENABLE_Pos)    /**< (RTC_MODE1_SYNCBUSY) Enable Bit Busy Mask */
+#define RTC_MODE1_SYNCBUSY_ENABLE           RTC_MODE1_SYNCBUSY_ENABLE_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_SYNCBUSY_ENABLE_Msk instead */
+#define RTC_MODE1_SYNCBUSY_FREQCORR_Pos     2                                              /**< (RTC_MODE1_SYNCBUSY) FREQCORR Register Busy Position */
+#define RTC_MODE1_SYNCBUSY_FREQCORR_Msk     (_U_(0x1) << RTC_MODE1_SYNCBUSY_FREQCORR_Pos)  /**< (RTC_MODE1_SYNCBUSY) FREQCORR Register Busy Mask */
+#define RTC_MODE1_SYNCBUSY_FREQCORR         RTC_MODE1_SYNCBUSY_FREQCORR_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_SYNCBUSY_FREQCORR_Msk instead */
+#define RTC_MODE1_SYNCBUSY_COUNT_Pos        3                                              /**< (RTC_MODE1_SYNCBUSY) COUNT Register Busy Position */
+#define RTC_MODE1_SYNCBUSY_COUNT_Msk        (_U_(0x1) << RTC_MODE1_SYNCBUSY_COUNT_Pos)     /**< (RTC_MODE1_SYNCBUSY) COUNT Register Busy Mask */
+#define RTC_MODE1_SYNCBUSY_COUNT            RTC_MODE1_SYNCBUSY_COUNT_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_SYNCBUSY_COUNT_Msk instead */
+#define RTC_MODE1_SYNCBUSY_PER_Pos          4                                              /**< (RTC_MODE1_SYNCBUSY) PER Register Busy Position */
+#define RTC_MODE1_SYNCBUSY_PER_Msk          (_U_(0x1) << RTC_MODE1_SYNCBUSY_PER_Pos)       /**< (RTC_MODE1_SYNCBUSY) PER Register Busy Mask */
+#define RTC_MODE1_SYNCBUSY_PER              RTC_MODE1_SYNCBUSY_PER_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_SYNCBUSY_PER_Msk instead */
+#define RTC_MODE1_SYNCBUSY_COMP0_Pos        5                                              /**< (RTC_MODE1_SYNCBUSY) COMP 0 Register Busy Position */
+#define RTC_MODE1_SYNCBUSY_COMP0_Msk        (_U_(0x1) << RTC_MODE1_SYNCBUSY_COMP0_Pos)     /**< (RTC_MODE1_SYNCBUSY) COMP 0 Register Busy Mask */
+#define RTC_MODE1_SYNCBUSY_COMP0            RTC_MODE1_SYNCBUSY_COMP0_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_SYNCBUSY_COMP0_Msk instead */
+#define RTC_MODE1_SYNCBUSY_COMP1_Pos        6                                              /**< (RTC_MODE1_SYNCBUSY) COMP 1 Register Busy Position */
+#define RTC_MODE1_SYNCBUSY_COMP1_Msk        (_U_(0x1) << RTC_MODE1_SYNCBUSY_COMP1_Pos)     /**< (RTC_MODE1_SYNCBUSY) COMP 1 Register Busy Mask */
+#define RTC_MODE1_SYNCBUSY_COMP1            RTC_MODE1_SYNCBUSY_COMP1_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_SYNCBUSY_COMP1_Msk instead */
+#define RTC_MODE1_SYNCBUSY_COUNTSYNC_Pos    15                                             /**< (RTC_MODE1_SYNCBUSY) Count Synchronization Enable Bit Busy Position */
+#define RTC_MODE1_SYNCBUSY_COUNTSYNC_Msk    (_U_(0x1) << RTC_MODE1_SYNCBUSY_COUNTSYNC_Pos)  /**< (RTC_MODE1_SYNCBUSY) Count Synchronization Enable Bit Busy Mask */
+#define RTC_MODE1_SYNCBUSY_COUNTSYNC        RTC_MODE1_SYNCBUSY_COUNTSYNC_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_SYNCBUSY_COUNTSYNC_Msk instead */
+#define RTC_MODE1_SYNCBUSY_GP0_Pos          16                                             /**< (RTC_MODE1_SYNCBUSY) General Purpose 0 Register Busy Position */
+#define RTC_MODE1_SYNCBUSY_GP0_Msk          (_U_(0x1) << RTC_MODE1_SYNCBUSY_GP0_Pos)       /**< (RTC_MODE1_SYNCBUSY) General Purpose 0 Register Busy Mask */
+#define RTC_MODE1_SYNCBUSY_GP0              RTC_MODE1_SYNCBUSY_GP0_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_SYNCBUSY_GP0_Msk instead */
+#define RTC_MODE1_SYNCBUSY_GP1_Pos          17                                             /**< (RTC_MODE1_SYNCBUSY) General Purpose 1 Register Busy Position */
+#define RTC_MODE1_SYNCBUSY_GP1_Msk          (_U_(0x1) << RTC_MODE1_SYNCBUSY_GP1_Pos)       /**< (RTC_MODE1_SYNCBUSY) General Purpose 1 Register Busy Mask */
+#define RTC_MODE1_SYNCBUSY_GP1              RTC_MODE1_SYNCBUSY_GP1_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_SYNCBUSY_GP1_Msk instead */
+#define RTC_MODE1_SYNCBUSY_MASK             _U_(0x3807F)                                   /**< \deprecated (RTC_MODE1_SYNCBUSY) Register MASK  (Use RTC_MODE1_SYNCBUSY_Msk instead)  */
+#define RTC_MODE1_SYNCBUSY_Msk              _U_(0x3807F)                                   /**< (RTC_MODE1_SYNCBUSY) Register Mask  */
+
+#define RTC_MODE1_SYNCBUSY_COMP_Pos         5                                              /**< (RTC_MODE1_SYNCBUSY Position) COMP x Register Busy */
+#define RTC_MODE1_SYNCBUSY_COMP_Msk         (_U_(0x3) << RTC_MODE1_SYNCBUSY_COMP_Pos)      /**< (RTC_MODE1_SYNCBUSY Mask) COMP */
+#define RTC_MODE1_SYNCBUSY_COMP(value)      (RTC_MODE1_SYNCBUSY_COMP_Msk & ((value) << RTC_MODE1_SYNCBUSY_COMP_Pos))  
+#define RTC_MODE1_SYNCBUSY_GP_Pos           16                                             /**< (RTC_MODE1_SYNCBUSY Position) General Purpose x Register Busy */
+#define RTC_MODE1_SYNCBUSY_GP_Msk           (_U_(0x3) << RTC_MODE1_SYNCBUSY_GP_Pos)        /**< (RTC_MODE1_SYNCBUSY Mask) GP */
+#define RTC_MODE1_SYNCBUSY_GP(value)        (RTC_MODE1_SYNCBUSY_GP_Msk & ((value) << RTC_MODE1_SYNCBUSY_GP_Pos))  
+
+/* -------- RTC_MODE2_SYNCBUSY : (RTC Offset: 0x10) (R/ 32) MODE2 Synchronization Busy Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SWRST:1;                   /**< bit:      0  Software Reset Bit Busy                  */
+    uint32_t ENABLE:1;                  /**< bit:      1  Enable Bit Busy                          */
+    uint32_t FREQCORR:1;                /**< bit:      2  FREQCORR Register Busy                   */
+    uint32_t CLOCK:1;                   /**< bit:      3  CLOCK Register Busy                      */
+    uint32_t :1;                        /**< bit:      4  Reserved */
+    uint32_t ALARM0:1;                  /**< bit:      5  ALARM 0 Register Busy                    */
+    uint32_t :5;                        /**< bit:  6..10  Reserved */
+    uint32_t MASK0:1;                   /**< bit:     11  MASK 0 Register Busy                     */
+    uint32_t :3;                        /**< bit: 12..14  Reserved */
+    uint32_t CLOCKSYNC:1;               /**< bit:     15  Clock Synchronization Enable Bit Busy    */
+    uint32_t GP0:1;                     /**< bit:     16  General Purpose 0 Register Busy          */
+    uint32_t GP1:1;                     /**< bit:     17  General Purpose 1 Register Busy          */
+    uint32_t :14;                       /**< bit: 18..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :5;                        /**< bit:   0..4  Reserved */
+    uint32_t ALARM:1;                   /**< bit:      5  ALARM x Register Busy                    */
+    uint32_t :5;                        /**< bit:  6..10  Reserved */
+    uint32_t MASK:1;                    /**< bit:     11  MASK x Register Busy                     */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t GP:2;                      /**< bit: 16..17  General Purpose x Register Busy          */
+    uint32_t :14;                       /**< bit: 18..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_MODE2_SYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE2_SYNCBUSY_OFFSET           (0x10)                                        /**<  (RTC_MODE2_SYNCBUSY) MODE2 Synchronization Busy Status  Offset */
+#define RTC_MODE2_SYNCBUSY_RESETVALUE       _U_(0x00)                                     /**<  (RTC_MODE2_SYNCBUSY) MODE2 Synchronization Busy Status  Reset Value */
+
+#define RTC_MODE2_SYNCBUSY_SWRST_Pos        0                                              /**< (RTC_MODE2_SYNCBUSY) Software Reset Bit Busy Position */
+#define RTC_MODE2_SYNCBUSY_SWRST_Msk        (_U_(0x1) << RTC_MODE2_SYNCBUSY_SWRST_Pos)     /**< (RTC_MODE2_SYNCBUSY) Software Reset Bit Busy Mask */
+#define RTC_MODE2_SYNCBUSY_SWRST            RTC_MODE2_SYNCBUSY_SWRST_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_SYNCBUSY_SWRST_Msk instead */
+#define RTC_MODE2_SYNCBUSY_ENABLE_Pos       1                                              /**< (RTC_MODE2_SYNCBUSY) Enable Bit Busy Position */
+#define RTC_MODE2_SYNCBUSY_ENABLE_Msk       (_U_(0x1) << RTC_MODE2_SYNCBUSY_ENABLE_Pos)    /**< (RTC_MODE2_SYNCBUSY) Enable Bit Busy Mask */
+#define RTC_MODE2_SYNCBUSY_ENABLE           RTC_MODE2_SYNCBUSY_ENABLE_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_SYNCBUSY_ENABLE_Msk instead */
+#define RTC_MODE2_SYNCBUSY_FREQCORR_Pos     2                                              /**< (RTC_MODE2_SYNCBUSY) FREQCORR Register Busy Position */
+#define RTC_MODE2_SYNCBUSY_FREQCORR_Msk     (_U_(0x1) << RTC_MODE2_SYNCBUSY_FREQCORR_Pos)  /**< (RTC_MODE2_SYNCBUSY) FREQCORR Register Busy Mask */
+#define RTC_MODE2_SYNCBUSY_FREQCORR         RTC_MODE2_SYNCBUSY_FREQCORR_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_SYNCBUSY_FREQCORR_Msk instead */
+#define RTC_MODE2_SYNCBUSY_CLOCK_Pos        3                                              /**< (RTC_MODE2_SYNCBUSY) CLOCK Register Busy Position */
+#define RTC_MODE2_SYNCBUSY_CLOCK_Msk        (_U_(0x1) << RTC_MODE2_SYNCBUSY_CLOCK_Pos)     /**< (RTC_MODE2_SYNCBUSY) CLOCK Register Busy Mask */
+#define RTC_MODE2_SYNCBUSY_CLOCK            RTC_MODE2_SYNCBUSY_CLOCK_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_SYNCBUSY_CLOCK_Msk instead */
+#define RTC_MODE2_SYNCBUSY_ALARM0_Pos       5                                              /**< (RTC_MODE2_SYNCBUSY) ALARM 0 Register Busy Position */
+#define RTC_MODE2_SYNCBUSY_ALARM0_Msk       (_U_(0x1) << RTC_MODE2_SYNCBUSY_ALARM0_Pos)    /**< (RTC_MODE2_SYNCBUSY) ALARM 0 Register Busy Mask */
+#define RTC_MODE2_SYNCBUSY_ALARM0           RTC_MODE2_SYNCBUSY_ALARM0_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_SYNCBUSY_ALARM0_Msk instead */
+#define RTC_MODE2_SYNCBUSY_MASK0_Pos        11                                             /**< (RTC_MODE2_SYNCBUSY) MASK 0 Register Busy Position */
+#define RTC_MODE2_SYNCBUSY_MASK0_Msk        (_U_(0x1) << RTC_MODE2_SYNCBUSY_MASK0_Pos)     /**< (RTC_MODE2_SYNCBUSY) MASK 0 Register Busy Mask */
+#define RTC_MODE2_SYNCBUSY_MASK0            RTC_MODE2_SYNCBUSY_MASK0_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_SYNCBUSY_MASK0_Msk instead */
+#define RTC_MODE2_SYNCBUSY_CLOCKSYNC_Pos    15                                             /**< (RTC_MODE2_SYNCBUSY) Clock Synchronization Enable Bit Busy Position */
+#define RTC_MODE2_SYNCBUSY_CLOCKSYNC_Msk    (_U_(0x1) << RTC_MODE2_SYNCBUSY_CLOCKSYNC_Pos)  /**< (RTC_MODE2_SYNCBUSY) Clock Synchronization Enable Bit Busy Mask */
+#define RTC_MODE2_SYNCBUSY_CLOCKSYNC        RTC_MODE2_SYNCBUSY_CLOCKSYNC_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_SYNCBUSY_CLOCKSYNC_Msk instead */
+#define RTC_MODE2_SYNCBUSY_GP0_Pos          16                                             /**< (RTC_MODE2_SYNCBUSY) General Purpose 0 Register Busy Position */
+#define RTC_MODE2_SYNCBUSY_GP0_Msk          (_U_(0x1) << RTC_MODE2_SYNCBUSY_GP0_Pos)       /**< (RTC_MODE2_SYNCBUSY) General Purpose 0 Register Busy Mask */
+#define RTC_MODE2_SYNCBUSY_GP0              RTC_MODE2_SYNCBUSY_GP0_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_SYNCBUSY_GP0_Msk instead */
+#define RTC_MODE2_SYNCBUSY_GP1_Pos          17                                             /**< (RTC_MODE2_SYNCBUSY) General Purpose 1 Register Busy Position */
+#define RTC_MODE2_SYNCBUSY_GP1_Msk          (_U_(0x1) << RTC_MODE2_SYNCBUSY_GP1_Pos)       /**< (RTC_MODE2_SYNCBUSY) General Purpose 1 Register Busy Mask */
+#define RTC_MODE2_SYNCBUSY_GP1              RTC_MODE2_SYNCBUSY_GP1_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_SYNCBUSY_GP1_Msk instead */
+#define RTC_MODE2_SYNCBUSY_Msk              _U_(0x3882F)                                   /**< (RTC_MODE2_SYNCBUSY) Register Mask  */
+
+#define RTC_MODE2_SYNCBUSY_ALARM_Pos        5                                              /**< (RTC_MODE2_SYNCBUSY Position) ALARM x Register Busy */
+#define RTC_MODE2_SYNCBUSY_ALARM_Msk        (_U_(0x1) << RTC_MODE2_SYNCBUSY_ALARM_Pos)     /**< (RTC_MODE2_SYNCBUSY Mask) ALARM */
+#define RTC_MODE2_SYNCBUSY_ALARM(value)     (RTC_MODE2_SYNCBUSY_ALARM_Msk & ((value) << RTC_MODE2_SYNCBUSY_ALARM_Pos))  
+#define RTC_MODE2_SYNCBUSY_MASK_Pos         11                                             /**< (RTC_MODE2_SYNCBUSY Position) MASK x Register Busy */
+#define RTC_MODE2_SYNCBUSY_MASK_Msk         (_U_(0x1) << RTC_MODE2_SYNCBUSY_MASK_Pos)      /**< (RTC_MODE2_SYNCBUSY Mask) MASK */
+#define RTC_MODE2_SYNCBUSY_MASK(value)      (RTC_MODE2_SYNCBUSY_MASK_Msk & ((value) << RTC_MODE2_SYNCBUSY_MASK_Pos))  
+#define RTC_MODE2_SYNCBUSY_GP_Pos           16                                             /**< (RTC_MODE2_SYNCBUSY Position) General Purpose x Register Busy */
+#define RTC_MODE2_SYNCBUSY_GP_Msk           (_U_(0x3) << RTC_MODE2_SYNCBUSY_GP_Pos)        /**< (RTC_MODE2_SYNCBUSY Mask) GP */
+#define RTC_MODE2_SYNCBUSY_GP(value)        (RTC_MODE2_SYNCBUSY_GP_Msk & ((value) << RTC_MODE2_SYNCBUSY_GP_Pos))  
+
+/* -------- RTC_FREQCORR : (RTC Offset: 0x14) (R/W 8) Frequency Correction -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  VALUE:7;                   /**< bit:   0..6  Correction Value                         */
+    uint8_t  SIGN:1;                    /**< bit:      7  Correction Sign                          */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} RTC_FREQCORR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_FREQCORR_OFFSET                 (0x14)                                        /**<  (RTC_FREQCORR) Frequency Correction  Offset */
+#define RTC_FREQCORR_RESETVALUE             _U_(0x00)                                     /**<  (RTC_FREQCORR) Frequency Correction  Reset Value */
+
+#define RTC_FREQCORR_VALUE_Pos              0                                              /**< (RTC_FREQCORR) Correction Value Position */
+#define RTC_FREQCORR_VALUE_Msk              (_U_(0x7F) << RTC_FREQCORR_VALUE_Pos)          /**< (RTC_FREQCORR) Correction Value Mask */
+#define RTC_FREQCORR_VALUE(value)           (RTC_FREQCORR_VALUE_Msk & ((value) << RTC_FREQCORR_VALUE_Pos))
+#define RTC_FREQCORR_SIGN_Pos               7                                              /**< (RTC_FREQCORR) Correction Sign Position */
+#define RTC_FREQCORR_SIGN_Msk               (_U_(0x1) << RTC_FREQCORR_SIGN_Pos)            /**< (RTC_FREQCORR) Correction Sign Mask */
+#define RTC_FREQCORR_SIGN                   RTC_FREQCORR_SIGN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_FREQCORR_SIGN_Msk instead */
+#define RTC_FREQCORR_MASK                   _U_(0xFF)                                      /**< \deprecated (RTC_FREQCORR) Register MASK  (Use RTC_FREQCORR_Msk instead)  */
+#define RTC_FREQCORR_Msk                    _U_(0xFF)                                      /**< (RTC_FREQCORR) Register Mask  */
+
+
+/* -------- RTC_MODE0_COUNT : (RTC Offset: 0x18) (R/W 32) MODE0 Counter Value -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t COUNT:32;                  /**< bit:  0..31  Counter Value                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_MODE0_COUNT_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE0_COUNT_OFFSET              (0x18)                                        /**<  (RTC_MODE0_COUNT) MODE0 Counter Value  Offset */
+#define RTC_MODE0_COUNT_RESETVALUE          _U_(0x00)                                     /**<  (RTC_MODE0_COUNT) MODE0 Counter Value  Reset Value */
+
+#define RTC_MODE0_COUNT_COUNT_Pos           0                                              /**< (RTC_MODE0_COUNT) Counter Value Position */
+#define RTC_MODE0_COUNT_COUNT_Msk           (_U_(0xFFFFFFFF) << RTC_MODE0_COUNT_COUNT_Pos)  /**< (RTC_MODE0_COUNT) Counter Value Mask */
+#define RTC_MODE0_COUNT_COUNT(value)        (RTC_MODE0_COUNT_COUNT_Msk & ((value) << RTC_MODE0_COUNT_COUNT_Pos))
+#define RTC_MODE0_COUNT_MASK                _U_(0xFFFFFFFF)                                /**< \deprecated (RTC_MODE0_COUNT) Register MASK  (Use RTC_MODE0_COUNT_Msk instead)  */
+#define RTC_MODE0_COUNT_Msk                 _U_(0xFFFFFFFF)                                /**< (RTC_MODE0_COUNT) Register Mask  */
+
+
+/* -------- RTC_MODE1_COUNT : (RTC Offset: 0x18) (R/W 16) MODE1 Counter Value -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t COUNT:16;                  /**< bit:  0..15  Counter Value                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} RTC_MODE1_COUNT_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE1_COUNT_OFFSET              (0x18)                                        /**<  (RTC_MODE1_COUNT) MODE1 Counter Value  Offset */
+#define RTC_MODE1_COUNT_RESETVALUE          _U_(0x00)                                     /**<  (RTC_MODE1_COUNT) MODE1 Counter Value  Reset Value */
+
+#define RTC_MODE1_COUNT_COUNT_Pos           0                                              /**< (RTC_MODE1_COUNT) Counter Value Position */
+#define RTC_MODE1_COUNT_COUNT_Msk           (_U_(0xFFFF) << RTC_MODE1_COUNT_COUNT_Pos)     /**< (RTC_MODE1_COUNT) Counter Value Mask */
+#define RTC_MODE1_COUNT_COUNT(value)        (RTC_MODE1_COUNT_COUNT_Msk & ((value) << RTC_MODE1_COUNT_COUNT_Pos))
+#define RTC_MODE1_COUNT_MASK                _U_(0xFFFF)                                    /**< \deprecated (RTC_MODE1_COUNT) Register MASK  (Use RTC_MODE1_COUNT_Msk instead)  */
+#define RTC_MODE1_COUNT_Msk                 _U_(0xFFFF)                                    /**< (RTC_MODE1_COUNT) Register Mask  */
+
+
+/* -------- RTC_MODE2_CLOCK : (RTC Offset: 0x18) (R/W 32) MODE2 Clock Value -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SECOND:6;                  /**< bit:   0..5  Second                                   */
+    uint32_t MINUTE:6;                  /**< bit:  6..11  Minute                                   */
+    uint32_t HOUR:5;                    /**< bit: 12..16  Hour                                     */
+    uint32_t DAY:5;                     /**< bit: 17..21  Day                                      */
+    uint32_t MONTH:4;                   /**< bit: 22..25  Month                                    */
+    uint32_t YEAR:6;                    /**< bit: 26..31  Year                                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_MODE2_CLOCK_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE2_CLOCK_OFFSET              (0x18)                                        /**<  (RTC_MODE2_CLOCK) MODE2 Clock Value  Offset */
+#define RTC_MODE2_CLOCK_RESETVALUE          _U_(0x00)                                     /**<  (RTC_MODE2_CLOCK) MODE2 Clock Value  Reset Value */
+
+#define RTC_MODE2_CLOCK_SECOND_Pos          0                                              /**< (RTC_MODE2_CLOCK) Second Position */
+#define RTC_MODE2_CLOCK_SECOND_Msk          (_U_(0x3F) << RTC_MODE2_CLOCK_SECOND_Pos)      /**< (RTC_MODE2_CLOCK) Second Mask */
+#define RTC_MODE2_CLOCK_SECOND(value)       (RTC_MODE2_CLOCK_SECOND_Msk & ((value) << RTC_MODE2_CLOCK_SECOND_Pos))
+#define RTC_MODE2_CLOCK_MINUTE_Pos          6                                              /**< (RTC_MODE2_CLOCK) Minute Position */
+#define RTC_MODE2_CLOCK_MINUTE_Msk          (_U_(0x3F) << RTC_MODE2_CLOCK_MINUTE_Pos)      /**< (RTC_MODE2_CLOCK) Minute Mask */
+#define RTC_MODE2_CLOCK_MINUTE(value)       (RTC_MODE2_CLOCK_MINUTE_Msk & ((value) << RTC_MODE2_CLOCK_MINUTE_Pos))
+#define RTC_MODE2_CLOCK_HOUR_Pos            12                                             /**< (RTC_MODE2_CLOCK) Hour Position */
+#define RTC_MODE2_CLOCK_HOUR_Msk            (_U_(0x1F) << RTC_MODE2_CLOCK_HOUR_Pos)        /**< (RTC_MODE2_CLOCK) Hour Mask */
+#define RTC_MODE2_CLOCK_HOUR(value)         (RTC_MODE2_CLOCK_HOUR_Msk & ((value) << RTC_MODE2_CLOCK_HOUR_Pos))
+#define RTC_MODE2_CLOCK_DAY_Pos             17                                             /**< (RTC_MODE2_CLOCK) Day Position */
+#define RTC_MODE2_CLOCK_DAY_Msk             (_U_(0x1F) << RTC_MODE2_CLOCK_DAY_Pos)         /**< (RTC_MODE2_CLOCK) Day Mask */
+#define RTC_MODE2_CLOCK_DAY(value)          (RTC_MODE2_CLOCK_DAY_Msk & ((value) << RTC_MODE2_CLOCK_DAY_Pos))
+#define RTC_MODE2_CLOCK_MONTH_Pos           22                                             /**< (RTC_MODE2_CLOCK) Month Position */
+#define RTC_MODE2_CLOCK_MONTH_Msk           (_U_(0xF) << RTC_MODE2_CLOCK_MONTH_Pos)        /**< (RTC_MODE2_CLOCK) Month Mask */
+#define RTC_MODE2_CLOCK_MONTH(value)        (RTC_MODE2_CLOCK_MONTH_Msk & ((value) << RTC_MODE2_CLOCK_MONTH_Pos))
+#define RTC_MODE2_CLOCK_YEAR_Pos            26                                             /**< (RTC_MODE2_CLOCK) Year Position */
+#define RTC_MODE2_CLOCK_YEAR_Msk            (_U_(0x3F) << RTC_MODE2_CLOCK_YEAR_Pos)        /**< (RTC_MODE2_CLOCK) Year Mask */
+#define RTC_MODE2_CLOCK_YEAR(value)         (RTC_MODE2_CLOCK_YEAR_Msk & ((value) << RTC_MODE2_CLOCK_YEAR_Pos))
+#define RTC_MODE2_CLOCK_MASK                _U_(0xFFFFFFFF)                                /**< \deprecated (RTC_MODE2_CLOCK) Register MASK  (Use RTC_MODE2_CLOCK_Msk instead)  */
+#define RTC_MODE2_CLOCK_Msk                 _U_(0xFFFFFFFF)                                /**< (RTC_MODE2_CLOCK) Register Mask  */
+
+
+/* -------- RTC_MODE1_PER : (RTC Offset: 0x1c) (R/W 16) MODE1 Counter Period -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t PER:16;                    /**< bit:  0..15  Counter Period                           */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} RTC_MODE1_PER_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE1_PER_OFFSET                (0x1C)                                        /**<  (RTC_MODE1_PER) MODE1 Counter Period  Offset */
+#define RTC_MODE1_PER_RESETVALUE            _U_(0x00)                                     /**<  (RTC_MODE1_PER) MODE1 Counter Period  Reset Value */
+
+#define RTC_MODE1_PER_PER_Pos               0                                              /**< (RTC_MODE1_PER) Counter Period Position */
+#define RTC_MODE1_PER_PER_Msk               (_U_(0xFFFF) << RTC_MODE1_PER_PER_Pos)         /**< (RTC_MODE1_PER) Counter Period Mask */
+#define RTC_MODE1_PER_PER(value)            (RTC_MODE1_PER_PER_Msk & ((value) << RTC_MODE1_PER_PER_Pos))
+#define RTC_MODE1_PER_MASK                  _U_(0xFFFF)                                    /**< \deprecated (RTC_MODE1_PER) Register MASK  (Use RTC_MODE1_PER_Msk instead)  */
+#define RTC_MODE1_PER_Msk                   _U_(0xFFFF)                                    /**< (RTC_MODE1_PER) Register Mask  */
+
+
+/* -------- RTC_MODE0_COMP : (RTC Offset: 0x20) (R/W 32) MODE0 Compare n Value -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t COMP:32;                   /**< bit:  0..31  Compare Value                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_MODE0_COMP_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE0_COMP_OFFSET               (0x20)                                        /**<  (RTC_MODE0_COMP) MODE0 Compare n Value  Offset */
+#define RTC_MODE0_COMP_RESETVALUE           _U_(0x00)                                     /**<  (RTC_MODE0_COMP) MODE0 Compare n Value  Reset Value */
+
+#define RTC_MODE0_COMP_COMP_Pos             0                                              /**< (RTC_MODE0_COMP) Compare Value Position */
+#define RTC_MODE0_COMP_COMP_Msk             (_U_(0xFFFFFFFF) << RTC_MODE0_COMP_COMP_Pos)   /**< (RTC_MODE0_COMP) Compare Value Mask */
+#define RTC_MODE0_COMP_COMP(value)          (RTC_MODE0_COMP_COMP_Msk & ((value) << RTC_MODE0_COMP_COMP_Pos))
+#define RTC_MODE0_COMP_MASK                 _U_(0xFFFFFFFF)                                /**< \deprecated (RTC_MODE0_COMP) Register MASK  (Use RTC_MODE0_COMP_Msk instead)  */
+#define RTC_MODE0_COMP_Msk                  _U_(0xFFFFFFFF)                                /**< (RTC_MODE0_COMP) Register Mask  */
+
+
+/* -------- RTC_MODE1_COMP : (RTC Offset: 0x20) (R/W 16) MODE1 Compare n Value -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t COMP:16;                   /**< bit:  0..15  Compare Value                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} RTC_MODE1_COMP_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE1_COMP_OFFSET               (0x20)                                        /**<  (RTC_MODE1_COMP) MODE1 Compare n Value  Offset */
+#define RTC_MODE1_COMP_RESETVALUE           _U_(0x00)                                     /**<  (RTC_MODE1_COMP) MODE1 Compare n Value  Reset Value */
+
+#define RTC_MODE1_COMP_COMP_Pos             0                                              /**< (RTC_MODE1_COMP) Compare Value Position */
+#define RTC_MODE1_COMP_COMP_Msk             (_U_(0xFFFF) << RTC_MODE1_COMP_COMP_Pos)       /**< (RTC_MODE1_COMP) Compare Value Mask */
+#define RTC_MODE1_COMP_COMP(value)          (RTC_MODE1_COMP_COMP_Msk & ((value) << RTC_MODE1_COMP_COMP_Pos))
+#define RTC_MODE1_COMP_MASK                 _U_(0xFFFF)                                    /**< \deprecated (RTC_MODE1_COMP) Register MASK  (Use RTC_MODE1_COMP_Msk instead)  */
+#define RTC_MODE1_COMP_Msk                  _U_(0xFFFF)                                    /**< (RTC_MODE1_COMP) Register Mask  */
+
+
+/* -------- RTC_GP : (RTC Offset: 0x40) (R/W 32) General Purpose -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t GP:32;                     /**< bit:  0..31  General Purpose                          */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_GP_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_GP_OFFSET                       (0x40)                                        /**<  (RTC_GP) General Purpose  Offset */
+#define RTC_GP_RESETVALUE                   _U_(0x00)                                     /**<  (RTC_GP) General Purpose  Reset Value */
+
+#define RTC_GP_GP_Pos                       0                                              /**< (RTC_GP) General Purpose Position */
+#define RTC_GP_GP_Msk                       (_U_(0xFFFFFFFF) << RTC_GP_GP_Pos)             /**< (RTC_GP) General Purpose Mask */
+#define RTC_GP_GP(value)                    (RTC_GP_GP_Msk & ((value) << RTC_GP_GP_Pos)) 
+#define RTC_GP_MASK                         _U_(0xFFFFFFFF)                                /**< \deprecated (RTC_GP) Register MASK  (Use RTC_GP_Msk instead)  */
+#define RTC_GP_Msk                          _U_(0xFFFFFFFF)                                /**< (RTC_GP) Register Mask  */
+
+
+/* -------- RTC_TAMPCTRL : (RTC Offset: 0x60) (R/W 32) Tamper Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t IN0ACT:2;                  /**< bit:   0..1  Tamper Input 0 Action                    */
+    uint32_t IN1ACT:2;                  /**< bit:   2..3  Tamper Input 1 Action                    */
+    uint32_t IN2ACT:2;                  /**< bit:   4..5  Tamper Input 2 Action                    */
+    uint32_t IN3ACT:2;                  /**< bit:   6..7  Tamper Input 3 Action                    */
+    uint32_t :8;                        /**< bit:  8..15  Reserved */
+    uint32_t TAMLVL0:1;                 /**< bit:     16  Tamper Level Select 0                    */
+    uint32_t TAMLVL1:1;                 /**< bit:     17  Tamper Level Select 1                    */
+    uint32_t TAMLVL2:1;                 /**< bit:     18  Tamper Level Select 2                    */
+    uint32_t TAMLVL3:1;                 /**< bit:     19  Tamper Level Select 3                    */
+    uint32_t :4;                        /**< bit: 20..23  Reserved */
+    uint32_t DEBNC0:1;                  /**< bit:     24  Debouncer Enable 0                       */
+    uint32_t DEBNC1:1;                  /**< bit:     25  Debouncer Enable 1                       */
+    uint32_t DEBNC2:1;                  /**< bit:     26  Debouncer Enable 2                       */
+    uint32_t DEBNC3:1;                  /**< bit:     27  Debouncer Enable 3                       */
+    uint32_t :4;                        /**< bit: 28..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :16;                       /**< bit:  0..15  Reserved */
+    uint32_t TAMLVL:4;                  /**< bit: 16..19  Tamper Level Select x                    */
+    uint32_t :4;                        /**< bit: 20..23  Reserved */
+    uint32_t DEBNC:4;                   /**< bit: 24..27  Debouncer Enable 3                       */
+    uint32_t :4;                        /**< bit: 28..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_TAMPCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_TAMPCTRL_OFFSET                 (0x60)                                        /**<  (RTC_TAMPCTRL) Tamper Control  Offset */
+#define RTC_TAMPCTRL_RESETVALUE             _U_(0x00)                                     /**<  (RTC_TAMPCTRL) Tamper Control  Reset Value */
+
+#define RTC_TAMPCTRL_IN0ACT_Pos             0                                              /**< (RTC_TAMPCTRL) Tamper Input 0 Action Position */
+#define RTC_TAMPCTRL_IN0ACT_Msk             (_U_(0x3) << RTC_TAMPCTRL_IN0ACT_Pos)          /**< (RTC_TAMPCTRL) Tamper Input 0 Action Mask */
+#define RTC_TAMPCTRL_IN0ACT(value)          (RTC_TAMPCTRL_IN0ACT_Msk & ((value) << RTC_TAMPCTRL_IN0ACT_Pos))
+#define   RTC_TAMPCTRL_IN0ACT_OFF_Val       _U_(0x0)                                       /**< (RTC_TAMPCTRL) Off (Disabled)  */
+#define   RTC_TAMPCTRL_IN0ACT_WAKE_Val      _U_(0x1)                                       /**< (RTC_TAMPCTRL) Wake and set Tamper flag  */
+#define   RTC_TAMPCTRL_IN0ACT_CAPTURE_Val   _U_(0x2)                                       /**< (RTC_TAMPCTRL) Capture timestamp and set Tamper flag  */
+#define   RTC_TAMPCTRL_IN0ACT_ACTL_Val      _U_(0x3)                                       /**< (RTC_TAMPCTRL) Compare IN0 to OUT. When a mismatch occurs, capture timestamp and set Tamper flag  */
+#define RTC_TAMPCTRL_IN0ACT_OFF             (RTC_TAMPCTRL_IN0ACT_OFF_Val << RTC_TAMPCTRL_IN0ACT_Pos)  /**< (RTC_TAMPCTRL) Off (Disabled) Position  */
+#define RTC_TAMPCTRL_IN0ACT_WAKE            (RTC_TAMPCTRL_IN0ACT_WAKE_Val << RTC_TAMPCTRL_IN0ACT_Pos)  /**< (RTC_TAMPCTRL) Wake and set Tamper flag Position  */
+#define RTC_TAMPCTRL_IN0ACT_CAPTURE         (RTC_TAMPCTRL_IN0ACT_CAPTURE_Val << RTC_TAMPCTRL_IN0ACT_Pos)  /**< (RTC_TAMPCTRL) Capture timestamp and set Tamper flag Position  */
+#define RTC_TAMPCTRL_IN0ACT_ACTL            (RTC_TAMPCTRL_IN0ACT_ACTL_Val << RTC_TAMPCTRL_IN0ACT_Pos)  /**< (RTC_TAMPCTRL) Compare IN0 to OUT. When a mismatch occurs, capture timestamp and set Tamper flag Position  */
+#define RTC_TAMPCTRL_IN1ACT_Pos             2                                              /**< (RTC_TAMPCTRL) Tamper Input 1 Action Position */
+#define RTC_TAMPCTRL_IN1ACT_Msk             (_U_(0x3) << RTC_TAMPCTRL_IN1ACT_Pos)          /**< (RTC_TAMPCTRL) Tamper Input 1 Action Mask */
+#define RTC_TAMPCTRL_IN1ACT(value)          (RTC_TAMPCTRL_IN1ACT_Msk & ((value) << RTC_TAMPCTRL_IN1ACT_Pos))
+#define   RTC_TAMPCTRL_IN1ACT_OFF_Val       _U_(0x0)                                       /**< (RTC_TAMPCTRL) Off (Disabled)  */
+#define   RTC_TAMPCTRL_IN1ACT_WAKE_Val      _U_(0x1)                                       /**< (RTC_TAMPCTRL) Wake and set Tamper flag  */
+#define   RTC_TAMPCTRL_IN1ACT_CAPTURE_Val   _U_(0x2)                                       /**< (RTC_TAMPCTRL) Capture timestamp and set Tamper flag  */
+#define   RTC_TAMPCTRL_IN1ACT_ACTL_Val      _U_(0x3)                                       /**< (RTC_TAMPCTRL) Compare IN1 to OUT. When a mismatch occurs, capture timestamp and set Tamper flag  */
+#define RTC_TAMPCTRL_IN1ACT_OFF             (RTC_TAMPCTRL_IN1ACT_OFF_Val << RTC_TAMPCTRL_IN1ACT_Pos)  /**< (RTC_TAMPCTRL) Off (Disabled) Position  */
+#define RTC_TAMPCTRL_IN1ACT_WAKE            (RTC_TAMPCTRL_IN1ACT_WAKE_Val << RTC_TAMPCTRL_IN1ACT_Pos)  /**< (RTC_TAMPCTRL) Wake and set Tamper flag Position  */
+#define RTC_TAMPCTRL_IN1ACT_CAPTURE         (RTC_TAMPCTRL_IN1ACT_CAPTURE_Val << RTC_TAMPCTRL_IN1ACT_Pos)  /**< (RTC_TAMPCTRL) Capture timestamp and set Tamper flag Position  */
+#define RTC_TAMPCTRL_IN1ACT_ACTL            (RTC_TAMPCTRL_IN1ACT_ACTL_Val << RTC_TAMPCTRL_IN1ACT_Pos)  /**< (RTC_TAMPCTRL) Compare IN1 to OUT. When a mismatch occurs, capture timestamp and set Tamper flag Position  */
+#define RTC_TAMPCTRL_IN2ACT_Pos             4                                              /**< (RTC_TAMPCTRL) Tamper Input 2 Action Position */
+#define RTC_TAMPCTRL_IN2ACT_Msk             (_U_(0x3) << RTC_TAMPCTRL_IN2ACT_Pos)          /**< (RTC_TAMPCTRL) Tamper Input 2 Action Mask */
+#define RTC_TAMPCTRL_IN2ACT(value)          (RTC_TAMPCTRL_IN2ACT_Msk & ((value) << RTC_TAMPCTRL_IN2ACT_Pos))
+#define   RTC_TAMPCTRL_IN2ACT_OFF_Val       _U_(0x0)                                       /**< (RTC_TAMPCTRL) Off (Disabled)  */
+#define   RTC_TAMPCTRL_IN2ACT_WAKE_Val      _U_(0x1)                                       /**< (RTC_TAMPCTRL) Wake and set Tamper flag  */
+#define   RTC_TAMPCTRL_IN2ACT_CAPTURE_Val   _U_(0x2)                                       /**< (RTC_TAMPCTRL) Capture timestamp and set Tamper flag  */
+#define   RTC_TAMPCTRL_IN2ACT_ACTL_Val      _U_(0x3)                                       /**< (RTC_TAMPCTRL) Compare IN2 to OUT. When a mismatch occurs, capture timestamp and set Tamper flag  */
+#define RTC_TAMPCTRL_IN2ACT_OFF             (RTC_TAMPCTRL_IN2ACT_OFF_Val << RTC_TAMPCTRL_IN2ACT_Pos)  /**< (RTC_TAMPCTRL) Off (Disabled) Position  */
+#define RTC_TAMPCTRL_IN2ACT_WAKE            (RTC_TAMPCTRL_IN2ACT_WAKE_Val << RTC_TAMPCTRL_IN2ACT_Pos)  /**< (RTC_TAMPCTRL) Wake and set Tamper flag Position  */
+#define RTC_TAMPCTRL_IN2ACT_CAPTURE         (RTC_TAMPCTRL_IN2ACT_CAPTURE_Val << RTC_TAMPCTRL_IN2ACT_Pos)  /**< (RTC_TAMPCTRL) Capture timestamp and set Tamper flag Position  */
+#define RTC_TAMPCTRL_IN2ACT_ACTL            (RTC_TAMPCTRL_IN2ACT_ACTL_Val << RTC_TAMPCTRL_IN2ACT_Pos)  /**< (RTC_TAMPCTRL) Compare IN2 to OUT. When a mismatch occurs, capture timestamp and set Tamper flag Position  */
+#define RTC_TAMPCTRL_IN3ACT_Pos             6                                              /**< (RTC_TAMPCTRL) Tamper Input 3 Action Position */
+#define RTC_TAMPCTRL_IN3ACT_Msk             (_U_(0x3) << RTC_TAMPCTRL_IN3ACT_Pos)          /**< (RTC_TAMPCTRL) Tamper Input 3 Action Mask */
+#define RTC_TAMPCTRL_IN3ACT(value)          (RTC_TAMPCTRL_IN3ACT_Msk & ((value) << RTC_TAMPCTRL_IN3ACT_Pos))
+#define   RTC_TAMPCTRL_IN3ACT_OFF_Val       _U_(0x0)                                       /**< (RTC_TAMPCTRL) Off (Disabled)  */
+#define   RTC_TAMPCTRL_IN3ACT_WAKE_Val      _U_(0x1)                                       /**< (RTC_TAMPCTRL) Wake and set Tamper flag  */
+#define   RTC_TAMPCTRL_IN3ACT_CAPTURE_Val   _U_(0x2)                                       /**< (RTC_TAMPCTRL) Capture timestamp and set Tamper flag  */
+#define   RTC_TAMPCTRL_IN3ACT_ACTL_Val      _U_(0x3)                                       /**< (RTC_TAMPCTRL) Compare IN3 to OUT. When a mismatch occurs, capture timestamp and set Tamper flag  */
+#define RTC_TAMPCTRL_IN3ACT_OFF             (RTC_TAMPCTRL_IN3ACT_OFF_Val << RTC_TAMPCTRL_IN3ACT_Pos)  /**< (RTC_TAMPCTRL) Off (Disabled) Position  */
+#define RTC_TAMPCTRL_IN3ACT_WAKE            (RTC_TAMPCTRL_IN3ACT_WAKE_Val << RTC_TAMPCTRL_IN3ACT_Pos)  /**< (RTC_TAMPCTRL) Wake and set Tamper flag Position  */
+#define RTC_TAMPCTRL_IN3ACT_CAPTURE         (RTC_TAMPCTRL_IN3ACT_CAPTURE_Val << RTC_TAMPCTRL_IN3ACT_Pos)  /**< (RTC_TAMPCTRL) Capture timestamp and set Tamper flag Position  */
+#define RTC_TAMPCTRL_IN3ACT_ACTL            (RTC_TAMPCTRL_IN3ACT_ACTL_Val << RTC_TAMPCTRL_IN3ACT_Pos)  /**< (RTC_TAMPCTRL) Compare IN3 to OUT. When a mismatch occurs, capture timestamp and set Tamper flag Position  */
+#define RTC_TAMPCTRL_TAMLVL0_Pos            16                                             /**< (RTC_TAMPCTRL) Tamper Level Select 0 Position */
+#define RTC_TAMPCTRL_TAMLVL0_Msk            (_U_(0x1) << RTC_TAMPCTRL_TAMLVL0_Pos)         /**< (RTC_TAMPCTRL) Tamper Level Select 0 Mask */
+#define RTC_TAMPCTRL_TAMLVL0                RTC_TAMPCTRL_TAMLVL0_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_TAMPCTRL_TAMLVL0_Msk instead */
+#define RTC_TAMPCTRL_TAMLVL1_Pos            17                                             /**< (RTC_TAMPCTRL) Tamper Level Select 1 Position */
+#define RTC_TAMPCTRL_TAMLVL1_Msk            (_U_(0x1) << RTC_TAMPCTRL_TAMLVL1_Pos)         /**< (RTC_TAMPCTRL) Tamper Level Select 1 Mask */
+#define RTC_TAMPCTRL_TAMLVL1                RTC_TAMPCTRL_TAMLVL1_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_TAMPCTRL_TAMLVL1_Msk instead */
+#define RTC_TAMPCTRL_TAMLVL2_Pos            18                                             /**< (RTC_TAMPCTRL) Tamper Level Select 2 Position */
+#define RTC_TAMPCTRL_TAMLVL2_Msk            (_U_(0x1) << RTC_TAMPCTRL_TAMLVL2_Pos)         /**< (RTC_TAMPCTRL) Tamper Level Select 2 Mask */
+#define RTC_TAMPCTRL_TAMLVL2                RTC_TAMPCTRL_TAMLVL2_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_TAMPCTRL_TAMLVL2_Msk instead */
+#define RTC_TAMPCTRL_TAMLVL3_Pos            19                                             /**< (RTC_TAMPCTRL) Tamper Level Select 3 Position */
+#define RTC_TAMPCTRL_TAMLVL3_Msk            (_U_(0x1) << RTC_TAMPCTRL_TAMLVL3_Pos)         /**< (RTC_TAMPCTRL) Tamper Level Select 3 Mask */
+#define RTC_TAMPCTRL_TAMLVL3                RTC_TAMPCTRL_TAMLVL3_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_TAMPCTRL_TAMLVL3_Msk instead */
+#define RTC_TAMPCTRL_DEBNC0_Pos             24                                             /**< (RTC_TAMPCTRL) Debouncer Enable 0 Position */
+#define RTC_TAMPCTRL_DEBNC0_Msk             (_U_(0x1) << RTC_TAMPCTRL_DEBNC0_Pos)          /**< (RTC_TAMPCTRL) Debouncer Enable 0 Mask */
+#define RTC_TAMPCTRL_DEBNC0                 RTC_TAMPCTRL_DEBNC0_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_TAMPCTRL_DEBNC0_Msk instead */
+#define RTC_TAMPCTRL_DEBNC1_Pos             25                                             /**< (RTC_TAMPCTRL) Debouncer Enable 1 Position */
+#define RTC_TAMPCTRL_DEBNC1_Msk             (_U_(0x1) << RTC_TAMPCTRL_DEBNC1_Pos)          /**< (RTC_TAMPCTRL) Debouncer Enable 1 Mask */
+#define RTC_TAMPCTRL_DEBNC1                 RTC_TAMPCTRL_DEBNC1_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_TAMPCTRL_DEBNC1_Msk instead */
+#define RTC_TAMPCTRL_DEBNC2_Pos             26                                             /**< (RTC_TAMPCTRL) Debouncer Enable 2 Position */
+#define RTC_TAMPCTRL_DEBNC2_Msk             (_U_(0x1) << RTC_TAMPCTRL_DEBNC2_Pos)          /**< (RTC_TAMPCTRL) Debouncer Enable 2 Mask */
+#define RTC_TAMPCTRL_DEBNC2                 RTC_TAMPCTRL_DEBNC2_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_TAMPCTRL_DEBNC2_Msk instead */
+#define RTC_TAMPCTRL_DEBNC3_Pos             27                                             /**< (RTC_TAMPCTRL) Debouncer Enable 3 Position */
+#define RTC_TAMPCTRL_DEBNC3_Msk             (_U_(0x1) << RTC_TAMPCTRL_DEBNC3_Pos)          /**< (RTC_TAMPCTRL) Debouncer Enable 3 Mask */
+#define RTC_TAMPCTRL_DEBNC3                 RTC_TAMPCTRL_DEBNC3_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_TAMPCTRL_DEBNC3_Msk instead */
+#define RTC_TAMPCTRL_MASK                   _U_(0xF0F00FF)                                 /**< \deprecated (RTC_TAMPCTRL) Register MASK  (Use RTC_TAMPCTRL_Msk instead)  */
+#define RTC_TAMPCTRL_Msk                    _U_(0xF0F00FF)                                 /**< (RTC_TAMPCTRL) Register Mask  */
+
+#define RTC_TAMPCTRL_TAMLVL_Pos             16                                             /**< (RTC_TAMPCTRL Position) Tamper Level Select x */
+#define RTC_TAMPCTRL_TAMLVL_Msk             (_U_(0xF) << RTC_TAMPCTRL_TAMLVL_Pos)          /**< (RTC_TAMPCTRL Mask) TAMLVL */
+#define RTC_TAMPCTRL_TAMLVL(value)          (RTC_TAMPCTRL_TAMLVL_Msk & ((value) << RTC_TAMPCTRL_TAMLVL_Pos))  
+#define RTC_TAMPCTRL_DEBNC_Pos              24                                             /**< (RTC_TAMPCTRL Position) Debouncer Enable 3 */
+#define RTC_TAMPCTRL_DEBNC_Msk              (_U_(0xF) << RTC_TAMPCTRL_DEBNC_Pos)           /**< (RTC_TAMPCTRL Mask) DEBNC */
+#define RTC_TAMPCTRL_DEBNC(value)           (RTC_TAMPCTRL_DEBNC_Msk & ((value) << RTC_TAMPCTRL_DEBNC_Pos))  
+
+/* -------- RTC_MODE0_TIMESTAMP : (RTC Offset: 0x64) (R/ 32) MODE0 Timestamp -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t COUNT:32;                  /**< bit:  0..31  Count Timestamp Value                    */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_MODE0_TIMESTAMP_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE0_TIMESTAMP_OFFSET          (0x64)                                        /**<  (RTC_MODE0_TIMESTAMP) MODE0 Timestamp  Offset */
+#define RTC_MODE0_TIMESTAMP_RESETVALUE      _U_(0x00)                                     /**<  (RTC_MODE0_TIMESTAMP) MODE0 Timestamp  Reset Value */
+
+#define RTC_MODE0_TIMESTAMP_COUNT_Pos       0                                              /**< (RTC_MODE0_TIMESTAMP) Count Timestamp Value Position */
+#define RTC_MODE0_TIMESTAMP_COUNT_Msk       (_U_(0xFFFFFFFF) << RTC_MODE0_TIMESTAMP_COUNT_Pos)  /**< (RTC_MODE0_TIMESTAMP) Count Timestamp Value Mask */
+#define RTC_MODE0_TIMESTAMP_COUNT(value)    (RTC_MODE0_TIMESTAMP_COUNT_Msk & ((value) << RTC_MODE0_TIMESTAMP_COUNT_Pos))
+#define RTC_MODE0_TIMESTAMP_MASK            _U_(0xFFFFFFFF)                                /**< \deprecated (RTC_MODE0_TIMESTAMP) Register MASK  (Use RTC_MODE0_TIMESTAMP_Msk instead)  */
+#define RTC_MODE0_TIMESTAMP_Msk             _U_(0xFFFFFFFF)                                /**< (RTC_MODE0_TIMESTAMP) Register Mask  */
+
+
+/* -------- RTC_MODE1_TIMESTAMP : (RTC Offset: 0x64) (R/ 32) MODE1 Timestamp -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t COUNT:16;                  /**< bit:  0..15  Count Timestamp Value                    */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_MODE1_TIMESTAMP_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE1_TIMESTAMP_OFFSET          (0x64)                                        /**<  (RTC_MODE1_TIMESTAMP) MODE1 Timestamp  Offset */
+#define RTC_MODE1_TIMESTAMP_RESETVALUE      _U_(0x00)                                     /**<  (RTC_MODE1_TIMESTAMP) MODE1 Timestamp  Reset Value */
+
+#define RTC_MODE1_TIMESTAMP_COUNT_Pos       0                                              /**< (RTC_MODE1_TIMESTAMP) Count Timestamp Value Position */
+#define RTC_MODE1_TIMESTAMP_COUNT_Msk       (_U_(0xFFFF) << RTC_MODE1_TIMESTAMP_COUNT_Pos)  /**< (RTC_MODE1_TIMESTAMP) Count Timestamp Value Mask */
+#define RTC_MODE1_TIMESTAMP_COUNT(value)    (RTC_MODE1_TIMESTAMP_COUNT_Msk & ((value) << RTC_MODE1_TIMESTAMP_COUNT_Pos))
+#define RTC_MODE1_TIMESTAMP_MASK            _U_(0xFFFF)                                    /**< \deprecated (RTC_MODE1_TIMESTAMP) Register MASK  (Use RTC_MODE1_TIMESTAMP_Msk instead)  */
+#define RTC_MODE1_TIMESTAMP_Msk             _U_(0xFFFF)                                    /**< (RTC_MODE1_TIMESTAMP) Register Mask  */
+
+
+/* -------- RTC_MODE2_TIMESTAMP : (RTC Offset: 0x64) (R/ 32) MODE2 Timestamp -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SECOND:6;                  /**< bit:   0..5  Second Timestamp Value                   */
+    uint32_t MINUTE:6;                  /**< bit:  6..11  Minute Timestamp Value                   */
+    uint32_t HOUR:5;                    /**< bit: 12..16  Hour Timestamp Value                     */
+    uint32_t DAY:5;                     /**< bit: 17..21  Day Timestamp Value                      */
+    uint32_t MONTH:4;                   /**< bit: 22..25  Month Timestamp Value                    */
+    uint32_t YEAR:6;                    /**< bit: 26..31  Year Timestamp Value                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_MODE2_TIMESTAMP_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE2_TIMESTAMP_OFFSET          (0x64)                                        /**<  (RTC_MODE2_TIMESTAMP) MODE2 Timestamp  Offset */
+#define RTC_MODE2_TIMESTAMP_RESETVALUE      _U_(0x00)                                     /**<  (RTC_MODE2_TIMESTAMP) MODE2 Timestamp  Reset Value */
+
+#define RTC_MODE2_TIMESTAMP_SECOND_Pos      0                                              /**< (RTC_MODE2_TIMESTAMP) Second Timestamp Value Position */
+#define RTC_MODE2_TIMESTAMP_SECOND_Msk      (_U_(0x3F) << RTC_MODE2_TIMESTAMP_SECOND_Pos)  /**< (RTC_MODE2_TIMESTAMP) Second Timestamp Value Mask */
+#define RTC_MODE2_TIMESTAMP_SECOND(value)   (RTC_MODE2_TIMESTAMP_SECOND_Msk & ((value) << RTC_MODE2_TIMESTAMP_SECOND_Pos))
+#define RTC_MODE2_TIMESTAMP_MINUTE_Pos      6                                              /**< (RTC_MODE2_TIMESTAMP) Minute Timestamp Value Position */
+#define RTC_MODE2_TIMESTAMP_MINUTE_Msk      (_U_(0x3F) << RTC_MODE2_TIMESTAMP_MINUTE_Pos)  /**< (RTC_MODE2_TIMESTAMP) Minute Timestamp Value Mask */
+#define RTC_MODE2_TIMESTAMP_MINUTE(value)   (RTC_MODE2_TIMESTAMP_MINUTE_Msk & ((value) << RTC_MODE2_TIMESTAMP_MINUTE_Pos))
+#define RTC_MODE2_TIMESTAMP_HOUR_Pos        12                                             /**< (RTC_MODE2_TIMESTAMP) Hour Timestamp Value Position */
+#define RTC_MODE2_TIMESTAMP_HOUR_Msk        (_U_(0x1F) << RTC_MODE2_TIMESTAMP_HOUR_Pos)    /**< (RTC_MODE2_TIMESTAMP) Hour Timestamp Value Mask */
+#define RTC_MODE2_TIMESTAMP_HOUR(value)     (RTC_MODE2_TIMESTAMP_HOUR_Msk & ((value) << RTC_MODE2_TIMESTAMP_HOUR_Pos))
+#define RTC_MODE2_TIMESTAMP_DAY_Pos         17                                             /**< (RTC_MODE2_TIMESTAMP) Day Timestamp Value Position */
+#define RTC_MODE2_TIMESTAMP_DAY_Msk         (_U_(0x1F) << RTC_MODE2_TIMESTAMP_DAY_Pos)     /**< (RTC_MODE2_TIMESTAMP) Day Timestamp Value Mask */
+#define RTC_MODE2_TIMESTAMP_DAY(value)      (RTC_MODE2_TIMESTAMP_DAY_Msk & ((value) << RTC_MODE2_TIMESTAMP_DAY_Pos))
+#define RTC_MODE2_TIMESTAMP_MONTH_Pos       22                                             /**< (RTC_MODE2_TIMESTAMP) Month Timestamp Value Position */
+#define RTC_MODE2_TIMESTAMP_MONTH_Msk       (_U_(0xF) << RTC_MODE2_TIMESTAMP_MONTH_Pos)    /**< (RTC_MODE2_TIMESTAMP) Month Timestamp Value Mask */
+#define RTC_MODE2_TIMESTAMP_MONTH(value)    (RTC_MODE2_TIMESTAMP_MONTH_Msk & ((value) << RTC_MODE2_TIMESTAMP_MONTH_Pos))
+#define RTC_MODE2_TIMESTAMP_YEAR_Pos        26                                             /**< (RTC_MODE2_TIMESTAMP) Year Timestamp Value Position */
+#define RTC_MODE2_TIMESTAMP_YEAR_Msk        (_U_(0x3F) << RTC_MODE2_TIMESTAMP_YEAR_Pos)    /**< (RTC_MODE2_TIMESTAMP) Year Timestamp Value Mask */
+#define RTC_MODE2_TIMESTAMP_YEAR(value)     (RTC_MODE2_TIMESTAMP_YEAR_Msk & ((value) << RTC_MODE2_TIMESTAMP_YEAR_Pos))
+#define RTC_MODE2_TIMESTAMP_MASK            _U_(0xFFFFFFFF)                                /**< \deprecated (RTC_MODE2_TIMESTAMP) Register MASK  (Use RTC_MODE2_TIMESTAMP_Msk instead)  */
+#define RTC_MODE2_TIMESTAMP_Msk             _U_(0xFFFFFFFF)                                /**< (RTC_MODE2_TIMESTAMP) Register Mask  */
+
+
+/* -------- RTC_TAMPID : (RTC Offset: 0x68) (R/W 32) Tamper ID -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t TAMPID0:1;                 /**< bit:      0  Tamper Input 0 Detected                  */
+    uint32_t TAMPID1:1;                 /**< bit:      1  Tamper Input 1 Detected                  */
+    uint32_t TAMPID2:1;                 /**< bit:      2  Tamper Input 2 Detected                  */
+    uint32_t TAMPID3:1;                 /**< bit:      3  Tamper Input 3 Detected                  */
+    uint32_t :27;                       /**< bit:  4..30  Reserved */
+    uint32_t TAMPEVT:1;                 /**< bit:     31  Tamper Event Detected                    */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t TAMPID:4;                  /**< bit:   0..3  Tamper Input x Detected                  */
+    uint32_t :28;                       /**< bit:  4..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_TAMPID_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_TAMPID_OFFSET                   (0x68)                                        /**<  (RTC_TAMPID) Tamper ID  Offset */
+#define RTC_TAMPID_RESETVALUE               _U_(0x00)                                     /**<  (RTC_TAMPID) Tamper ID  Reset Value */
+
+#define RTC_TAMPID_TAMPID0_Pos              0                                              /**< (RTC_TAMPID) Tamper Input 0 Detected Position */
+#define RTC_TAMPID_TAMPID0_Msk              (_U_(0x1) << RTC_TAMPID_TAMPID0_Pos)           /**< (RTC_TAMPID) Tamper Input 0 Detected Mask */
+#define RTC_TAMPID_TAMPID0                  RTC_TAMPID_TAMPID0_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_TAMPID_TAMPID0_Msk instead */
+#define RTC_TAMPID_TAMPID1_Pos              1                                              /**< (RTC_TAMPID) Tamper Input 1 Detected Position */
+#define RTC_TAMPID_TAMPID1_Msk              (_U_(0x1) << RTC_TAMPID_TAMPID1_Pos)           /**< (RTC_TAMPID) Tamper Input 1 Detected Mask */
+#define RTC_TAMPID_TAMPID1                  RTC_TAMPID_TAMPID1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_TAMPID_TAMPID1_Msk instead */
+#define RTC_TAMPID_TAMPID2_Pos              2                                              /**< (RTC_TAMPID) Tamper Input 2 Detected Position */
+#define RTC_TAMPID_TAMPID2_Msk              (_U_(0x1) << RTC_TAMPID_TAMPID2_Pos)           /**< (RTC_TAMPID) Tamper Input 2 Detected Mask */
+#define RTC_TAMPID_TAMPID2                  RTC_TAMPID_TAMPID2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_TAMPID_TAMPID2_Msk instead */
+#define RTC_TAMPID_TAMPID3_Pos              3                                              /**< (RTC_TAMPID) Tamper Input 3 Detected Position */
+#define RTC_TAMPID_TAMPID3_Msk              (_U_(0x1) << RTC_TAMPID_TAMPID3_Pos)           /**< (RTC_TAMPID) Tamper Input 3 Detected Mask */
+#define RTC_TAMPID_TAMPID3                  RTC_TAMPID_TAMPID3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_TAMPID_TAMPID3_Msk instead */
+#define RTC_TAMPID_TAMPEVT_Pos              31                                             /**< (RTC_TAMPID) Tamper Event Detected Position */
+#define RTC_TAMPID_TAMPEVT_Msk              (_U_(0x1) << RTC_TAMPID_TAMPEVT_Pos)           /**< (RTC_TAMPID) Tamper Event Detected Mask */
+#define RTC_TAMPID_TAMPEVT                  RTC_TAMPID_TAMPEVT_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_TAMPID_TAMPEVT_Msk instead */
+#define RTC_TAMPID_MASK                     _U_(0x8000000F)                                /**< \deprecated (RTC_TAMPID) Register MASK  (Use RTC_TAMPID_Msk instead)  */
+#define RTC_TAMPID_Msk                      _U_(0x8000000F)                                /**< (RTC_TAMPID) Register Mask  */
+
+#define RTC_TAMPID_TAMPID_Pos               0                                              /**< (RTC_TAMPID Position) Tamper Input x Detected */
+#define RTC_TAMPID_TAMPID_Msk               (_U_(0xF) << RTC_TAMPID_TAMPID_Pos)            /**< (RTC_TAMPID Mask) TAMPID */
+#define RTC_TAMPID_TAMPID(value)            (RTC_TAMPID_TAMPID_Msk & ((value) << RTC_TAMPID_TAMPID_Pos))  
+
+/* -------- RTC_TAMPCTRLB : (RTC Offset: 0x6c) (R/W 32) Tamper Control B -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t ALSI0:1;                   /**< bit:      0  Active Layer Select Internal 0           */
+    uint32_t ALSI1:1;                   /**< bit:      1  Active Layer Select Internal 1           */
+    uint32_t ALSI2:1;                   /**< bit:      2  Active Layer Select Internal 2           */
+    uint32_t ALSI3:1;                   /**< bit:      3  Active Layer Select Internal 3           */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t ALSI:4;                    /**< bit:   0..3  Active Layer Select Internal 3           */
+    uint32_t :28;                       /**< bit:  4..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_TAMPCTRLB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_TAMPCTRLB_OFFSET                (0x6C)                                        /**<  (RTC_TAMPCTRLB) Tamper Control B  Offset */
+#define RTC_TAMPCTRLB_RESETVALUE            _U_(0x00)                                     /**<  (RTC_TAMPCTRLB) Tamper Control B  Reset Value */
+
+#define RTC_TAMPCTRLB_ALSI0_Pos             0                                              /**< (RTC_TAMPCTRLB) Active Layer Select Internal 0 Position */
+#define RTC_TAMPCTRLB_ALSI0_Msk             (_U_(0x1) << RTC_TAMPCTRLB_ALSI0_Pos)          /**< (RTC_TAMPCTRLB) Active Layer Select Internal 0 Mask */
+#define RTC_TAMPCTRLB_ALSI0                 RTC_TAMPCTRLB_ALSI0_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_TAMPCTRLB_ALSI0_Msk instead */
+#define RTC_TAMPCTRLB_ALSI1_Pos             1                                              /**< (RTC_TAMPCTRLB) Active Layer Select Internal 1 Position */
+#define RTC_TAMPCTRLB_ALSI1_Msk             (_U_(0x1) << RTC_TAMPCTRLB_ALSI1_Pos)          /**< (RTC_TAMPCTRLB) Active Layer Select Internal 1 Mask */
+#define RTC_TAMPCTRLB_ALSI1                 RTC_TAMPCTRLB_ALSI1_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_TAMPCTRLB_ALSI1_Msk instead */
+#define RTC_TAMPCTRLB_ALSI2_Pos             2                                              /**< (RTC_TAMPCTRLB) Active Layer Select Internal 2 Position */
+#define RTC_TAMPCTRLB_ALSI2_Msk             (_U_(0x1) << RTC_TAMPCTRLB_ALSI2_Pos)          /**< (RTC_TAMPCTRLB) Active Layer Select Internal 2 Mask */
+#define RTC_TAMPCTRLB_ALSI2                 RTC_TAMPCTRLB_ALSI2_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_TAMPCTRLB_ALSI2_Msk instead */
+#define RTC_TAMPCTRLB_ALSI3_Pos             3                                              /**< (RTC_TAMPCTRLB) Active Layer Select Internal 3 Position */
+#define RTC_TAMPCTRLB_ALSI3_Msk             (_U_(0x1) << RTC_TAMPCTRLB_ALSI3_Pos)          /**< (RTC_TAMPCTRLB) Active Layer Select Internal 3 Mask */
+#define RTC_TAMPCTRLB_ALSI3                 RTC_TAMPCTRLB_ALSI3_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_TAMPCTRLB_ALSI3_Msk instead */
+#define RTC_TAMPCTRLB_MASK                  _U_(0x0F)                                      /**< \deprecated (RTC_TAMPCTRLB) Register MASK  (Use RTC_TAMPCTRLB_Msk instead)  */
+#define RTC_TAMPCTRLB_Msk                   _U_(0x0F)                                      /**< (RTC_TAMPCTRLB) Register Mask  */
+
+#define RTC_TAMPCTRLB_ALSI_Pos              0                                              /**< (RTC_TAMPCTRLB Position) Active Layer Select Internal 3 */
+#define RTC_TAMPCTRLB_ALSI_Msk              (_U_(0xF) << RTC_TAMPCTRLB_ALSI_Pos)           /**< (RTC_TAMPCTRLB Mask) ALSI */
+#define RTC_TAMPCTRLB_ALSI(value)           (RTC_TAMPCTRLB_ALSI_Msk & ((value) << RTC_TAMPCTRLB_ALSI_Pos))  
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief MODE2_ALARM hardware registers */
+typedef struct {  
+  __IO RTC_MODE2_ALARM_Type           ALARM;          /**< Offset: 0x00 (R/W  32) MODE2_ALARM Alarm n Value */
+  __IO RTC_MODE2_MASK_Type            MASK;           /**< Offset: 0x04 (R/W   8) MODE2_ALARM Alarm n Mask */
+  __I  uint8_t                        Reserved1[3];
+} RtcMode2Alarm;
+
+/** \brief RTC hardware registers */
+typedef struct {  /* Real-Time Counter */
+  __IO RTC_MODE0_CTRLA_Type           CTRLA;          /**< Offset: 0x00 (R/W  16) MODE0 Control A */
+  __IO RTC_MODE0_CTRLB_Type           CTRLB;          /**< Offset: 0x02 (R/W  16) MODE0 Control B */
+  __IO RTC_MODE0_EVCTRL_Type          EVCTRL;         /**< Offset: 0x04 (R/W  32) MODE0 Event Control */
+  __IO RTC_MODE0_INTENCLR_Type        INTENCLR;       /**< Offset: 0x08 (R/W  16) MODE0 Interrupt Enable Clear */
+  __IO RTC_MODE0_INTENSET_Type        INTENSET;       /**< Offset: 0x0A (R/W  16) MODE0 Interrupt Enable Set */
+  __IO RTC_MODE0_INTFLAG_Type         INTFLAG;        /**< Offset: 0x0C (R/W  16) MODE0 Interrupt Flag Status and Clear */
+  __IO RTC_DBGCTRL_Type               DBGCTRL;        /**< Offset: 0x0E (R/W   8) Debug Control */
+  __I  uint8_t                        Reserved1[1];
+  __I  RTC_MODE0_SYNCBUSY_Type        SYNCBUSY;       /**< Offset: 0x10 (R/   32) MODE0 Synchronization Busy Status */
+  __IO RTC_FREQCORR_Type              FREQCORR;       /**< Offset: 0x14 (R/W   8) Frequency Correction */
+  __I  uint8_t                        Reserved2[3];
+  __IO RTC_MODE0_COUNT_Type           COUNT;          /**< Offset: 0x18 (R/W  32) MODE0 Counter Value */
+  __I  uint8_t                        Reserved3[4];
+  __IO RTC_MODE0_COMP_Type            COMP[1];        /**< Offset: 0x20 (R/W  32) MODE0 Compare n Value */
+  __I  uint8_t                        Reserved4[28];
+  __IO RTC_GP_Type                    GP[2];          /**< Offset: 0x40 (R/W  32) General Purpose */
+  __I  uint8_t                        Reserved5[24];
+  __IO RTC_TAMPCTRL_Type              TAMPCTRL;       /**< Offset: 0x60 (R/W  32) Tamper Control */
+  __I  RTC_MODE0_TIMESTAMP_Type       TIMESTAMP;      /**< Offset: 0x64 (R/   32) MODE0 Timestamp */
+  __IO RTC_TAMPID_Type                TAMPID;         /**< Offset: 0x68 (R/W  32) Tamper ID */
+  __IO RTC_TAMPCTRLB_Type             TAMPCTRLB;      /**< Offset: 0x6C (R/W  32) Tamper Control B */
+} RtcMode0;
+
+/** \brief RTC hardware registers */
+typedef struct {  /* Real-Time Counter */
+  __IO RTC_MODE1_CTRLA_Type           CTRLA;          /**< Offset: 0x00 (R/W  16) MODE1 Control A */
+  __IO RTC_MODE1_CTRLB_Type           CTRLB;          /**< Offset: 0x02 (R/W  16) MODE1 Control B */
+  __IO RTC_MODE1_EVCTRL_Type          EVCTRL;         /**< Offset: 0x04 (R/W  32) MODE1 Event Control */
+  __IO RTC_MODE1_INTENCLR_Type        INTENCLR;       /**< Offset: 0x08 (R/W  16) MODE1 Interrupt Enable Clear */
+  __IO RTC_MODE1_INTENSET_Type        INTENSET;       /**< Offset: 0x0A (R/W  16) MODE1 Interrupt Enable Set */
+  __IO RTC_MODE1_INTFLAG_Type         INTFLAG;        /**< Offset: 0x0C (R/W  16) MODE1 Interrupt Flag Status and Clear */
+  __IO RTC_DBGCTRL_Type               DBGCTRL;        /**< Offset: 0x0E (R/W   8) Debug Control */
+  __I  uint8_t                        Reserved1[1];
+  __I  RTC_MODE1_SYNCBUSY_Type        SYNCBUSY;       /**< Offset: 0x10 (R/   32) MODE1 Synchronization Busy Status */
+  __IO RTC_FREQCORR_Type              FREQCORR;       /**< Offset: 0x14 (R/W   8) Frequency Correction */
+  __I  uint8_t                        Reserved2[3];
+  __IO RTC_MODE1_COUNT_Type           COUNT;          /**< Offset: 0x18 (R/W  16) MODE1 Counter Value */
+  __I  uint8_t                        Reserved3[2];
+  __IO RTC_MODE1_PER_Type             PER;            /**< Offset: 0x1C (R/W  16) MODE1 Counter Period */
+  __I  uint8_t                        Reserved4[2];
+  __IO RTC_MODE1_COMP_Type            COMP[2];        /**< Offset: 0x20 (R/W  16) MODE1 Compare n Value */
+  __I  uint8_t                        Reserved5[28];
+  __IO RTC_GP_Type                    GP[2];          /**< Offset: 0x40 (R/W  32) General Purpose */
+  __I  uint8_t                        Reserved6[24];
+  __IO RTC_TAMPCTRL_Type              TAMPCTRL;       /**< Offset: 0x60 (R/W  32) Tamper Control */
+  __I  RTC_MODE1_TIMESTAMP_Type       TIMESTAMP;      /**< Offset: 0x64 (R/   32) MODE1 Timestamp */
+  __IO RTC_TAMPID_Type                TAMPID;         /**< Offset: 0x68 (R/W  32) Tamper ID */
+  __IO RTC_TAMPCTRLB_Type             TAMPCTRLB;      /**< Offset: 0x6C (R/W  32) Tamper Control B */
+} RtcMode1;
+
+/** \brief RTC hardware registers */
+typedef struct {  /* Real-Time Counter */
+  __IO RTC_MODE2_CTRLA_Type           CTRLA;          /**< Offset: 0x00 (R/W  16) MODE2 Control A */
+  __IO RTC_MODE2_CTRLB_Type           CTRLB;          /**< Offset: 0x02 (R/W  16) MODE2 Control B */
+  __IO RTC_MODE2_EVCTRL_Type          EVCTRL;         /**< Offset: 0x04 (R/W  32) MODE2 Event Control */
+  __IO RTC_MODE2_INTENCLR_Type        INTENCLR;       /**< Offset: 0x08 (R/W  16) MODE2 Interrupt Enable Clear */
+  __IO RTC_MODE2_INTENSET_Type        INTENSET;       /**< Offset: 0x0A (R/W  16) MODE2 Interrupt Enable Set */
+  __IO RTC_MODE2_INTFLAG_Type         INTFLAG;        /**< Offset: 0x0C (R/W  16) MODE2 Interrupt Flag Status and Clear */
+  __IO RTC_DBGCTRL_Type               DBGCTRL;        /**< Offset: 0x0E (R/W   8) Debug Control */
+  __I  uint8_t                        Reserved1[1];
+  __I  RTC_MODE2_SYNCBUSY_Type        SYNCBUSY;       /**< Offset: 0x10 (R/   32) MODE2 Synchronization Busy Status */
+  __IO RTC_FREQCORR_Type              FREQCORR;       /**< Offset: 0x14 (R/W   8) Frequency Correction */
+  __I  uint8_t                        Reserved2[3];
+  __IO RTC_MODE2_CLOCK_Type           CLOCK;          /**< Offset: 0x18 (R/W  32) MODE2 Clock Value */
+  __I  uint8_t                        Reserved3[4];
+       RtcMode2Alarm                  Mode2Alarm[1];  /**< Offset: 0x20  */
+  __I  uint8_t                        Reserved4[24];
+  __IO RTC_GP_Type                    GP[2];          /**< Offset: 0x40 (R/W  32) General Purpose */
+  __I  uint8_t                        Reserved5[24];
+  __IO RTC_TAMPCTRL_Type              TAMPCTRL;       /**< Offset: 0x60 (R/W  32) Tamper Control */
+  __I  RTC_MODE2_TIMESTAMP_Type       TIMESTAMP;      /**< Offset: 0x64 (R/   32) MODE2 Timestamp */
+  __IO RTC_TAMPID_Type                TAMPID;         /**< Offset: 0x68 (R/W  32) Tamper ID */
+  __IO RTC_TAMPCTRLB_Type             TAMPCTRLB;      /**< Offset: 0x6C (R/W  32) Tamper Control B */
+} RtcMode2;
+
+/** \brief RTC hardware registers */
+typedef union {  /* Real-Time Counter */
+       RtcMode0                       MODE0;          /**< 32-bit Counter with Single 32-bit Compare */
+       RtcMode1                       MODE1;          /**< 16-bit Counter with Two 16-bit Compares */
+       RtcMode2                       MODE2;          /**< Clock/Calendar with Alarm */
+} Rtc;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Real-Time Counter */
+
+#endif /* _SAML10_RTC_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/component/sercom.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/sercom.h
@@ -1,0 +1,1759 @@
+/**
+ * \file
+ *
+ * \brief Component description for SERCOM
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_SERCOM_COMPONENT_H_
+#define _SAML10_SERCOM_COMPONENT_H_
+#define _SAML10_SERCOM_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML10 Serial Communication Interface
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR SERCOM */
+/* ========================================================================== */
+
+#define SERCOM_U2201                      /**< (SERCOM) Module ID */
+#define REV_SERCOM 0x410                  /**< (SERCOM) Module revision */
+
+/* -------- SERCOM_I2CM_CTRLA : (SERCOM Offset: 0x00) (R/W 32) I2CM Control A -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint32_t ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint32_t MODE:3;                    /**< bit:   2..4  Operating Mode                           */
+    uint32_t :2;                        /**< bit:   5..6  Reserved */
+    uint32_t RUNSTDBY:1;                /**< bit:      7  Run in Standby                           */
+    uint32_t :8;                        /**< bit:  8..15  Reserved */
+    uint32_t PINOUT:1;                  /**< bit:     16  Pin Usage                                */
+    uint32_t :3;                        /**< bit: 17..19  Reserved */
+    uint32_t SDAHOLD:2;                 /**< bit: 20..21  SDA Hold Time                            */
+    uint32_t MEXTTOEN:1;                /**< bit:     22  Master SCL Low Extend Timeout            */
+    uint32_t SEXTTOEN:1;                /**< bit:     23  Slave SCL Low Extend Timeout             */
+    uint32_t SPEED:2;                   /**< bit: 24..25  Transfer Speed                           */
+    uint32_t :1;                        /**< bit:     26  Reserved */
+    uint32_t SCLSM:1;                   /**< bit:     27  SCL Clock Stretch Mode                   */
+    uint32_t INACTOUT:2;                /**< bit: 28..29  Inactive Time-Out                        */
+    uint32_t LOWTOUTEN:1;               /**< bit:     30  SCL Low Timeout Enable                   */
+    uint32_t :1;                        /**< bit:     31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SERCOM_I2CM_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_CTRLA_OFFSET            (0x00)                                        /**<  (SERCOM_I2CM_CTRLA) I2CM Control A  Offset */
+#define SERCOM_I2CM_CTRLA_RESETVALUE        _U_(0x00)                                     /**<  (SERCOM_I2CM_CTRLA) I2CM Control A  Reset Value */
+
+#define SERCOM_I2CM_CTRLA_SWRST_Pos         0                                              /**< (SERCOM_I2CM_CTRLA) Software Reset Position */
+#define SERCOM_I2CM_CTRLA_SWRST_Msk         (_U_(0x1) << SERCOM_I2CM_CTRLA_SWRST_Pos)      /**< (SERCOM_I2CM_CTRLA) Software Reset Mask */
+#define SERCOM_I2CM_CTRLA_SWRST             SERCOM_I2CM_CTRLA_SWRST_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_CTRLA_SWRST_Msk instead */
+#define SERCOM_I2CM_CTRLA_ENABLE_Pos        1                                              /**< (SERCOM_I2CM_CTRLA) Enable Position */
+#define SERCOM_I2CM_CTRLA_ENABLE_Msk        (_U_(0x1) << SERCOM_I2CM_CTRLA_ENABLE_Pos)     /**< (SERCOM_I2CM_CTRLA) Enable Mask */
+#define SERCOM_I2CM_CTRLA_ENABLE            SERCOM_I2CM_CTRLA_ENABLE_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_CTRLA_ENABLE_Msk instead */
+#define SERCOM_I2CM_CTRLA_MODE_Pos          2                                              /**< (SERCOM_I2CM_CTRLA) Operating Mode Position */
+#define SERCOM_I2CM_CTRLA_MODE_Msk          (_U_(0x7) << SERCOM_I2CM_CTRLA_MODE_Pos)       /**< (SERCOM_I2CM_CTRLA) Operating Mode Mask */
+#define SERCOM_I2CM_CTRLA_MODE(value)       (SERCOM_I2CM_CTRLA_MODE_Msk & ((value) << SERCOM_I2CM_CTRLA_MODE_Pos))
+#define SERCOM_I2CM_CTRLA_RUNSTDBY_Pos      7                                              /**< (SERCOM_I2CM_CTRLA) Run in Standby Position */
+#define SERCOM_I2CM_CTRLA_RUNSTDBY_Msk      (_U_(0x1) << SERCOM_I2CM_CTRLA_RUNSTDBY_Pos)   /**< (SERCOM_I2CM_CTRLA) Run in Standby Mask */
+#define SERCOM_I2CM_CTRLA_RUNSTDBY          SERCOM_I2CM_CTRLA_RUNSTDBY_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_CTRLA_RUNSTDBY_Msk instead */
+#define SERCOM_I2CM_CTRLA_PINOUT_Pos        16                                             /**< (SERCOM_I2CM_CTRLA) Pin Usage Position */
+#define SERCOM_I2CM_CTRLA_PINOUT_Msk        (_U_(0x1) << SERCOM_I2CM_CTRLA_PINOUT_Pos)     /**< (SERCOM_I2CM_CTRLA) Pin Usage Mask */
+#define SERCOM_I2CM_CTRLA_PINOUT            SERCOM_I2CM_CTRLA_PINOUT_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_CTRLA_PINOUT_Msk instead */
+#define SERCOM_I2CM_CTRLA_SDAHOLD_Pos       20                                             /**< (SERCOM_I2CM_CTRLA) SDA Hold Time Position */
+#define SERCOM_I2CM_CTRLA_SDAHOLD_Msk       (_U_(0x3) << SERCOM_I2CM_CTRLA_SDAHOLD_Pos)    /**< (SERCOM_I2CM_CTRLA) SDA Hold Time Mask */
+#define SERCOM_I2CM_CTRLA_SDAHOLD(value)    (SERCOM_I2CM_CTRLA_SDAHOLD_Msk & ((value) << SERCOM_I2CM_CTRLA_SDAHOLD_Pos))
+#define SERCOM_I2CM_CTRLA_MEXTTOEN_Pos      22                                             /**< (SERCOM_I2CM_CTRLA) Master SCL Low Extend Timeout Position */
+#define SERCOM_I2CM_CTRLA_MEXTTOEN_Msk      (_U_(0x1) << SERCOM_I2CM_CTRLA_MEXTTOEN_Pos)   /**< (SERCOM_I2CM_CTRLA) Master SCL Low Extend Timeout Mask */
+#define SERCOM_I2CM_CTRLA_MEXTTOEN          SERCOM_I2CM_CTRLA_MEXTTOEN_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_CTRLA_MEXTTOEN_Msk instead */
+#define SERCOM_I2CM_CTRLA_SEXTTOEN_Pos      23                                             /**< (SERCOM_I2CM_CTRLA) Slave SCL Low Extend Timeout Position */
+#define SERCOM_I2CM_CTRLA_SEXTTOEN_Msk      (_U_(0x1) << SERCOM_I2CM_CTRLA_SEXTTOEN_Pos)   /**< (SERCOM_I2CM_CTRLA) Slave SCL Low Extend Timeout Mask */
+#define SERCOM_I2CM_CTRLA_SEXTTOEN          SERCOM_I2CM_CTRLA_SEXTTOEN_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_CTRLA_SEXTTOEN_Msk instead */
+#define SERCOM_I2CM_CTRLA_SPEED_Pos         24                                             /**< (SERCOM_I2CM_CTRLA) Transfer Speed Position */
+#define SERCOM_I2CM_CTRLA_SPEED_Msk         (_U_(0x3) << SERCOM_I2CM_CTRLA_SPEED_Pos)      /**< (SERCOM_I2CM_CTRLA) Transfer Speed Mask */
+#define SERCOM_I2CM_CTRLA_SPEED(value)      (SERCOM_I2CM_CTRLA_SPEED_Msk & ((value) << SERCOM_I2CM_CTRLA_SPEED_Pos))
+#define SERCOM_I2CM_CTRLA_SCLSM_Pos         27                                             /**< (SERCOM_I2CM_CTRLA) SCL Clock Stretch Mode Position */
+#define SERCOM_I2CM_CTRLA_SCLSM_Msk         (_U_(0x1) << SERCOM_I2CM_CTRLA_SCLSM_Pos)      /**< (SERCOM_I2CM_CTRLA) SCL Clock Stretch Mode Mask */
+#define SERCOM_I2CM_CTRLA_SCLSM             SERCOM_I2CM_CTRLA_SCLSM_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_CTRLA_SCLSM_Msk instead */
+#define SERCOM_I2CM_CTRLA_INACTOUT_Pos      28                                             /**< (SERCOM_I2CM_CTRLA) Inactive Time-Out Position */
+#define SERCOM_I2CM_CTRLA_INACTOUT_Msk      (_U_(0x3) << SERCOM_I2CM_CTRLA_INACTOUT_Pos)   /**< (SERCOM_I2CM_CTRLA) Inactive Time-Out Mask */
+#define SERCOM_I2CM_CTRLA_INACTOUT(value)   (SERCOM_I2CM_CTRLA_INACTOUT_Msk & ((value) << SERCOM_I2CM_CTRLA_INACTOUT_Pos))
+#define SERCOM_I2CM_CTRLA_LOWTOUTEN_Pos     30                                             /**< (SERCOM_I2CM_CTRLA) SCL Low Timeout Enable Position */
+#define SERCOM_I2CM_CTRLA_LOWTOUTEN_Msk     (_U_(0x1) << SERCOM_I2CM_CTRLA_LOWTOUTEN_Pos)  /**< (SERCOM_I2CM_CTRLA) SCL Low Timeout Enable Mask */
+#define SERCOM_I2CM_CTRLA_LOWTOUTEN         SERCOM_I2CM_CTRLA_LOWTOUTEN_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_CTRLA_LOWTOUTEN_Msk instead */
+#define SERCOM_I2CM_CTRLA_MASK              _U_(0x7BF1009F)                                /**< \deprecated (SERCOM_I2CM_CTRLA) Register MASK  (Use SERCOM_I2CM_CTRLA_Msk instead)  */
+#define SERCOM_I2CM_CTRLA_Msk               _U_(0x7BF1009F)                                /**< (SERCOM_I2CM_CTRLA) Register Mask  */
+
+
+/* -------- SERCOM_I2CS_CTRLA : (SERCOM Offset: 0x00) (R/W 32) I2CS Control A -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint32_t ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint32_t MODE:3;                    /**< bit:   2..4  Operating Mode                           */
+    uint32_t :2;                        /**< bit:   5..6  Reserved */
+    uint32_t RUNSTDBY:1;                /**< bit:      7  Run during Standby                       */
+    uint32_t :8;                        /**< bit:  8..15  Reserved */
+    uint32_t PINOUT:1;                  /**< bit:     16  Pin Usage                                */
+    uint32_t :3;                        /**< bit: 17..19  Reserved */
+    uint32_t SDAHOLD:2;                 /**< bit: 20..21  SDA Hold Time                            */
+    uint32_t :1;                        /**< bit:     22  Reserved */
+    uint32_t SEXTTOEN:1;                /**< bit:     23  Slave SCL Low Extend Timeout             */
+    uint32_t SPEED:2;                   /**< bit: 24..25  Transfer Speed                           */
+    uint32_t :1;                        /**< bit:     26  Reserved */
+    uint32_t SCLSM:1;                   /**< bit:     27  SCL Clock Stretch Mode                   */
+    uint32_t :2;                        /**< bit: 28..29  Reserved */
+    uint32_t LOWTOUTEN:1;               /**< bit:     30  SCL Low Timeout Enable                   */
+    uint32_t :1;                        /**< bit:     31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SERCOM_I2CS_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CS_CTRLA_OFFSET            (0x00)                                        /**<  (SERCOM_I2CS_CTRLA) I2CS Control A  Offset */
+#define SERCOM_I2CS_CTRLA_RESETVALUE        _U_(0x00)                                     /**<  (SERCOM_I2CS_CTRLA) I2CS Control A  Reset Value */
+
+#define SERCOM_I2CS_CTRLA_SWRST_Pos         0                                              /**< (SERCOM_I2CS_CTRLA) Software Reset Position */
+#define SERCOM_I2CS_CTRLA_SWRST_Msk         (_U_(0x1) << SERCOM_I2CS_CTRLA_SWRST_Pos)      /**< (SERCOM_I2CS_CTRLA) Software Reset Mask */
+#define SERCOM_I2CS_CTRLA_SWRST             SERCOM_I2CS_CTRLA_SWRST_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_CTRLA_SWRST_Msk instead */
+#define SERCOM_I2CS_CTRLA_ENABLE_Pos        1                                              /**< (SERCOM_I2CS_CTRLA) Enable Position */
+#define SERCOM_I2CS_CTRLA_ENABLE_Msk        (_U_(0x1) << SERCOM_I2CS_CTRLA_ENABLE_Pos)     /**< (SERCOM_I2CS_CTRLA) Enable Mask */
+#define SERCOM_I2CS_CTRLA_ENABLE            SERCOM_I2CS_CTRLA_ENABLE_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_CTRLA_ENABLE_Msk instead */
+#define SERCOM_I2CS_CTRLA_MODE_Pos          2                                              /**< (SERCOM_I2CS_CTRLA) Operating Mode Position */
+#define SERCOM_I2CS_CTRLA_MODE_Msk          (_U_(0x7) << SERCOM_I2CS_CTRLA_MODE_Pos)       /**< (SERCOM_I2CS_CTRLA) Operating Mode Mask */
+#define SERCOM_I2CS_CTRLA_MODE(value)       (SERCOM_I2CS_CTRLA_MODE_Msk & ((value) << SERCOM_I2CS_CTRLA_MODE_Pos))
+#define SERCOM_I2CS_CTRLA_RUNSTDBY_Pos      7                                              /**< (SERCOM_I2CS_CTRLA) Run during Standby Position */
+#define SERCOM_I2CS_CTRLA_RUNSTDBY_Msk      (_U_(0x1) << SERCOM_I2CS_CTRLA_RUNSTDBY_Pos)   /**< (SERCOM_I2CS_CTRLA) Run during Standby Mask */
+#define SERCOM_I2CS_CTRLA_RUNSTDBY          SERCOM_I2CS_CTRLA_RUNSTDBY_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_CTRLA_RUNSTDBY_Msk instead */
+#define SERCOM_I2CS_CTRLA_PINOUT_Pos        16                                             /**< (SERCOM_I2CS_CTRLA) Pin Usage Position */
+#define SERCOM_I2CS_CTRLA_PINOUT_Msk        (_U_(0x1) << SERCOM_I2CS_CTRLA_PINOUT_Pos)     /**< (SERCOM_I2CS_CTRLA) Pin Usage Mask */
+#define SERCOM_I2CS_CTRLA_PINOUT            SERCOM_I2CS_CTRLA_PINOUT_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_CTRLA_PINOUT_Msk instead */
+#define SERCOM_I2CS_CTRLA_SDAHOLD_Pos       20                                             /**< (SERCOM_I2CS_CTRLA) SDA Hold Time Position */
+#define SERCOM_I2CS_CTRLA_SDAHOLD_Msk       (_U_(0x3) << SERCOM_I2CS_CTRLA_SDAHOLD_Pos)    /**< (SERCOM_I2CS_CTRLA) SDA Hold Time Mask */
+#define SERCOM_I2CS_CTRLA_SDAHOLD(value)    (SERCOM_I2CS_CTRLA_SDAHOLD_Msk & ((value) << SERCOM_I2CS_CTRLA_SDAHOLD_Pos))
+#define SERCOM_I2CS_CTRLA_SEXTTOEN_Pos      23                                             /**< (SERCOM_I2CS_CTRLA) Slave SCL Low Extend Timeout Position */
+#define SERCOM_I2CS_CTRLA_SEXTTOEN_Msk      (_U_(0x1) << SERCOM_I2CS_CTRLA_SEXTTOEN_Pos)   /**< (SERCOM_I2CS_CTRLA) Slave SCL Low Extend Timeout Mask */
+#define SERCOM_I2CS_CTRLA_SEXTTOEN          SERCOM_I2CS_CTRLA_SEXTTOEN_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_CTRLA_SEXTTOEN_Msk instead */
+#define SERCOM_I2CS_CTRLA_SPEED_Pos         24                                             /**< (SERCOM_I2CS_CTRLA) Transfer Speed Position */
+#define SERCOM_I2CS_CTRLA_SPEED_Msk         (_U_(0x3) << SERCOM_I2CS_CTRLA_SPEED_Pos)      /**< (SERCOM_I2CS_CTRLA) Transfer Speed Mask */
+#define SERCOM_I2CS_CTRLA_SPEED(value)      (SERCOM_I2CS_CTRLA_SPEED_Msk & ((value) << SERCOM_I2CS_CTRLA_SPEED_Pos))
+#define SERCOM_I2CS_CTRLA_SCLSM_Pos         27                                             /**< (SERCOM_I2CS_CTRLA) SCL Clock Stretch Mode Position */
+#define SERCOM_I2CS_CTRLA_SCLSM_Msk         (_U_(0x1) << SERCOM_I2CS_CTRLA_SCLSM_Pos)      /**< (SERCOM_I2CS_CTRLA) SCL Clock Stretch Mode Mask */
+#define SERCOM_I2CS_CTRLA_SCLSM             SERCOM_I2CS_CTRLA_SCLSM_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_CTRLA_SCLSM_Msk instead */
+#define SERCOM_I2CS_CTRLA_LOWTOUTEN_Pos     30                                             /**< (SERCOM_I2CS_CTRLA) SCL Low Timeout Enable Position */
+#define SERCOM_I2CS_CTRLA_LOWTOUTEN_Msk     (_U_(0x1) << SERCOM_I2CS_CTRLA_LOWTOUTEN_Pos)  /**< (SERCOM_I2CS_CTRLA) SCL Low Timeout Enable Mask */
+#define SERCOM_I2CS_CTRLA_LOWTOUTEN         SERCOM_I2CS_CTRLA_LOWTOUTEN_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_CTRLA_LOWTOUTEN_Msk instead */
+#define SERCOM_I2CS_CTRLA_MASK              _U_(0x4BB1009F)                                /**< \deprecated (SERCOM_I2CS_CTRLA) Register MASK  (Use SERCOM_I2CS_CTRLA_Msk instead)  */
+#define SERCOM_I2CS_CTRLA_Msk               _U_(0x4BB1009F)                                /**< (SERCOM_I2CS_CTRLA) Register Mask  */
+
+
+/* -------- SERCOM_SPI_CTRLA : (SERCOM Offset: 0x00) (R/W 32) SPI Control A -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint32_t ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint32_t MODE:3;                    /**< bit:   2..4  Operating Mode                           */
+    uint32_t :2;                        /**< bit:   5..6  Reserved */
+    uint32_t RUNSTDBY:1;                /**< bit:      7  Run during Standby                       */
+    uint32_t IBON:1;                    /**< bit:      8  Immediate Buffer Overflow Notification   */
+    uint32_t :7;                        /**< bit:  9..15  Reserved */
+    uint32_t DOPO:2;                    /**< bit: 16..17  Data Out Pinout                          */
+    uint32_t :2;                        /**< bit: 18..19  Reserved */
+    uint32_t DIPO:2;                    /**< bit: 20..21  Data In Pinout                           */
+    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t FORM:4;                    /**< bit: 24..27  Frame Format                             */
+    uint32_t CPHA:1;                    /**< bit:     28  Clock Phase                              */
+    uint32_t CPOL:1;                    /**< bit:     29  Clock Polarity                           */
+    uint32_t DORD:1;                    /**< bit:     30  Data Order                               */
+    uint32_t :1;                        /**< bit:     31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SERCOM_SPI_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_CTRLA_OFFSET             (0x00)                                        /**<  (SERCOM_SPI_CTRLA) SPI Control A  Offset */
+#define SERCOM_SPI_CTRLA_RESETVALUE         _U_(0x00)                                     /**<  (SERCOM_SPI_CTRLA) SPI Control A  Reset Value */
+
+#define SERCOM_SPI_CTRLA_SWRST_Pos          0                                              /**< (SERCOM_SPI_CTRLA) Software Reset Position */
+#define SERCOM_SPI_CTRLA_SWRST_Msk          (_U_(0x1) << SERCOM_SPI_CTRLA_SWRST_Pos)       /**< (SERCOM_SPI_CTRLA) Software Reset Mask */
+#define SERCOM_SPI_CTRLA_SWRST              SERCOM_SPI_CTRLA_SWRST_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_CTRLA_SWRST_Msk instead */
+#define SERCOM_SPI_CTRLA_ENABLE_Pos         1                                              /**< (SERCOM_SPI_CTRLA) Enable Position */
+#define SERCOM_SPI_CTRLA_ENABLE_Msk         (_U_(0x1) << SERCOM_SPI_CTRLA_ENABLE_Pos)      /**< (SERCOM_SPI_CTRLA) Enable Mask */
+#define SERCOM_SPI_CTRLA_ENABLE             SERCOM_SPI_CTRLA_ENABLE_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_CTRLA_ENABLE_Msk instead */
+#define SERCOM_SPI_CTRLA_MODE_Pos           2                                              /**< (SERCOM_SPI_CTRLA) Operating Mode Position */
+#define SERCOM_SPI_CTRLA_MODE_Msk           (_U_(0x7) << SERCOM_SPI_CTRLA_MODE_Pos)        /**< (SERCOM_SPI_CTRLA) Operating Mode Mask */
+#define SERCOM_SPI_CTRLA_MODE(value)        (SERCOM_SPI_CTRLA_MODE_Msk & ((value) << SERCOM_SPI_CTRLA_MODE_Pos))
+#define SERCOM_SPI_CTRLA_RUNSTDBY_Pos       7                                              /**< (SERCOM_SPI_CTRLA) Run during Standby Position */
+#define SERCOM_SPI_CTRLA_RUNSTDBY_Msk       (_U_(0x1) << SERCOM_SPI_CTRLA_RUNSTDBY_Pos)    /**< (SERCOM_SPI_CTRLA) Run during Standby Mask */
+#define SERCOM_SPI_CTRLA_RUNSTDBY           SERCOM_SPI_CTRLA_RUNSTDBY_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_CTRLA_RUNSTDBY_Msk instead */
+#define SERCOM_SPI_CTRLA_IBON_Pos           8                                              /**< (SERCOM_SPI_CTRLA) Immediate Buffer Overflow Notification Position */
+#define SERCOM_SPI_CTRLA_IBON_Msk           (_U_(0x1) << SERCOM_SPI_CTRLA_IBON_Pos)        /**< (SERCOM_SPI_CTRLA) Immediate Buffer Overflow Notification Mask */
+#define SERCOM_SPI_CTRLA_IBON               SERCOM_SPI_CTRLA_IBON_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_CTRLA_IBON_Msk instead */
+#define SERCOM_SPI_CTRLA_DOPO_Pos           16                                             /**< (SERCOM_SPI_CTRLA) Data Out Pinout Position */
+#define SERCOM_SPI_CTRLA_DOPO_Msk           (_U_(0x3) << SERCOM_SPI_CTRLA_DOPO_Pos)        /**< (SERCOM_SPI_CTRLA) Data Out Pinout Mask */
+#define SERCOM_SPI_CTRLA_DOPO(value)        (SERCOM_SPI_CTRLA_DOPO_Msk & ((value) << SERCOM_SPI_CTRLA_DOPO_Pos))
+#define SERCOM_SPI_CTRLA_DIPO_Pos           20                                             /**< (SERCOM_SPI_CTRLA) Data In Pinout Position */
+#define SERCOM_SPI_CTRLA_DIPO_Msk           (_U_(0x3) << SERCOM_SPI_CTRLA_DIPO_Pos)        /**< (SERCOM_SPI_CTRLA) Data In Pinout Mask */
+#define SERCOM_SPI_CTRLA_DIPO(value)        (SERCOM_SPI_CTRLA_DIPO_Msk & ((value) << SERCOM_SPI_CTRLA_DIPO_Pos))
+#define SERCOM_SPI_CTRLA_FORM_Pos           24                                             /**< (SERCOM_SPI_CTRLA) Frame Format Position */
+#define SERCOM_SPI_CTRLA_FORM_Msk           (_U_(0xF) << SERCOM_SPI_CTRLA_FORM_Pos)        /**< (SERCOM_SPI_CTRLA) Frame Format Mask */
+#define SERCOM_SPI_CTRLA_FORM(value)        (SERCOM_SPI_CTRLA_FORM_Msk & ((value) << SERCOM_SPI_CTRLA_FORM_Pos))
+#define SERCOM_SPI_CTRLA_CPHA_Pos           28                                             /**< (SERCOM_SPI_CTRLA) Clock Phase Position */
+#define SERCOM_SPI_CTRLA_CPHA_Msk           (_U_(0x1) << SERCOM_SPI_CTRLA_CPHA_Pos)        /**< (SERCOM_SPI_CTRLA) Clock Phase Mask */
+#define SERCOM_SPI_CTRLA_CPHA               SERCOM_SPI_CTRLA_CPHA_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_CTRLA_CPHA_Msk instead */
+#define SERCOM_SPI_CTRLA_CPOL_Pos           29                                             /**< (SERCOM_SPI_CTRLA) Clock Polarity Position */
+#define SERCOM_SPI_CTRLA_CPOL_Msk           (_U_(0x1) << SERCOM_SPI_CTRLA_CPOL_Pos)        /**< (SERCOM_SPI_CTRLA) Clock Polarity Mask */
+#define SERCOM_SPI_CTRLA_CPOL               SERCOM_SPI_CTRLA_CPOL_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_CTRLA_CPOL_Msk instead */
+#define SERCOM_SPI_CTRLA_DORD_Pos           30                                             /**< (SERCOM_SPI_CTRLA) Data Order Position */
+#define SERCOM_SPI_CTRLA_DORD_Msk           (_U_(0x1) << SERCOM_SPI_CTRLA_DORD_Pos)        /**< (SERCOM_SPI_CTRLA) Data Order Mask */
+#define SERCOM_SPI_CTRLA_DORD               SERCOM_SPI_CTRLA_DORD_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_CTRLA_DORD_Msk instead */
+#define SERCOM_SPI_CTRLA_MASK               _U_(0x7F33019F)                                /**< \deprecated (SERCOM_SPI_CTRLA) Register MASK  (Use SERCOM_SPI_CTRLA_Msk instead)  */
+#define SERCOM_SPI_CTRLA_Msk                _U_(0x7F33019F)                                /**< (SERCOM_SPI_CTRLA) Register Mask  */
+
+
+/* -------- SERCOM_USART_CTRLA : (SERCOM Offset: 0x00) (R/W 32) USART Control A -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint32_t ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint32_t MODE:3;                    /**< bit:   2..4  Operating Mode                           */
+    uint32_t :2;                        /**< bit:   5..6  Reserved */
+    uint32_t RUNSTDBY:1;                /**< bit:      7  Run during Standby                       */
+    uint32_t IBON:1;                    /**< bit:      8  Immediate Buffer Overflow Notification   */
+    uint32_t TXINV:1;                   /**< bit:      9  Transmit Data Invert                     */
+    uint32_t RXINV:1;                   /**< bit:     10  Receive Data Invert                      */
+    uint32_t :2;                        /**< bit: 11..12  Reserved */
+    uint32_t SAMPR:3;                   /**< bit: 13..15  Sample                                   */
+    uint32_t TXPO:2;                    /**< bit: 16..17  Transmit Data Pinout                     */
+    uint32_t :2;                        /**< bit: 18..19  Reserved */
+    uint32_t RXPO:2;                    /**< bit: 20..21  Receive Data Pinout                      */
+    uint32_t SAMPA:2;                   /**< bit: 22..23  Sample Adjustment                        */
+    uint32_t FORM:4;                    /**< bit: 24..27  Frame Format                             */
+    uint32_t CMODE:1;                   /**< bit:     28  Communication Mode                       */
+    uint32_t CPOL:1;                    /**< bit:     29  Clock Polarity                           */
+    uint32_t DORD:1;                    /**< bit:     30  Data Order                               */
+    uint32_t :1;                        /**< bit:     31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SERCOM_USART_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_CTRLA_OFFSET           (0x00)                                        /**<  (SERCOM_USART_CTRLA) USART Control A  Offset */
+#define SERCOM_USART_CTRLA_RESETVALUE       _U_(0x00)                                     /**<  (SERCOM_USART_CTRLA) USART Control A  Reset Value */
+
+#define SERCOM_USART_CTRLA_SWRST_Pos        0                                              /**< (SERCOM_USART_CTRLA) Software Reset Position */
+#define SERCOM_USART_CTRLA_SWRST_Msk        (_U_(0x1) << SERCOM_USART_CTRLA_SWRST_Pos)     /**< (SERCOM_USART_CTRLA) Software Reset Mask */
+#define SERCOM_USART_CTRLA_SWRST            SERCOM_USART_CTRLA_SWRST_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_CTRLA_SWRST_Msk instead */
+#define SERCOM_USART_CTRLA_ENABLE_Pos       1                                              /**< (SERCOM_USART_CTRLA) Enable Position */
+#define SERCOM_USART_CTRLA_ENABLE_Msk       (_U_(0x1) << SERCOM_USART_CTRLA_ENABLE_Pos)    /**< (SERCOM_USART_CTRLA) Enable Mask */
+#define SERCOM_USART_CTRLA_ENABLE           SERCOM_USART_CTRLA_ENABLE_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_CTRLA_ENABLE_Msk instead */
+#define SERCOM_USART_CTRLA_MODE_Pos         2                                              /**< (SERCOM_USART_CTRLA) Operating Mode Position */
+#define SERCOM_USART_CTRLA_MODE_Msk         (_U_(0x7) << SERCOM_USART_CTRLA_MODE_Pos)      /**< (SERCOM_USART_CTRLA) Operating Mode Mask */
+#define SERCOM_USART_CTRLA_MODE(value)      (SERCOM_USART_CTRLA_MODE_Msk & ((value) << SERCOM_USART_CTRLA_MODE_Pos))
+#define SERCOM_USART_CTRLA_RUNSTDBY_Pos     7                                              /**< (SERCOM_USART_CTRLA) Run during Standby Position */
+#define SERCOM_USART_CTRLA_RUNSTDBY_Msk     (_U_(0x1) << SERCOM_USART_CTRLA_RUNSTDBY_Pos)  /**< (SERCOM_USART_CTRLA) Run during Standby Mask */
+#define SERCOM_USART_CTRLA_RUNSTDBY         SERCOM_USART_CTRLA_RUNSTDBY_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_CTRLA_RUNSTDBY_Msk instead */
+#define SERCOM_USART_CTRLA_IBON_Pos         8                                              /**< (SERCOM_USART_CTRLA) Immediate Buffer Overflow Notification Position */
+#define SERCOM_USART_CTRLA_IBON_Msk         (_U_(0x1) << SERCOM_USART_CTRLA_IBON_Pos)      /**< (SERCOM_USART_CTRLA) Immediate Buffer Overflow Notification Mask */
+#define SERCOM_USART_CTRLA_IBON             SERCOM_USART_CTRLA_IBON_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_CTRLA_IBON_Msk instead */
+#define SERCOM_USART_CTRLA_TXINV_Pos        9                                              /**< (SERCOM_USART_CTRLA) Transmit Data Invert Position */
+#define SERCOM_USART_CTRLA_TXINV_Msk        (_U_(0x1) << SERCOM_USART_CTRLA_TXINV_Pos)     /**< (SERCOM_USART_CTRLA) Transmit Data Invert Mask */
+#define SERCOM_USART_CTRLA_TXINV            SERCOM_USART_CTRLA_TXINV_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_CTRLA_TXINV_Msk instead */
+#define SERCOM_USART_CTRLA_RXINV_Pos        10                                             /**< (SERCOM_USART_CTRLA) Receive Data Invert Position */
+#define SERCOM_USART_CTRLA_RXINV_Msk        (_U_(0x1) << SERCOM_USART_CTRLA_RXINV_Pos)     /**< (SERCOM_USART_CTRLA) Receive Data Invert Mask */
+#define SERCOM_USART_CTRLA_RXINV            SERCOM_USART_CTRLA_RXINV_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_CTRLA_RXINV_Msk instead */
+#define SERCOM_USART_CTRLA_SAMPR_Pos        13                                             /**< (SERCOM_USART_CTRLA) Sample Position */
+#define SERCOM_USART_CTRLA_SAMPR_Msk        (_U_(0x7) << SERCOM_USART_CTRLA_SAMPR_Pos)     /**< (SERCOM_USART_CTRLA) Sample Mask */
+#define SERCOM_USART_CTRLA_SAMPR(value)     (SERCOM_USART_CTRLA_SAMPR_Msk & ((value) << SERCOM_USART_CTRLA_SAMPR_Pos))
+#define SERCOM_USART_CTRLA_TXPO_Pos         16                                             /**< (SERCOM_USART_CTRLA) Transmit Data Pinout Position */
+#define SERCOM_USART_CTRLA_TXPO_Msk         (_U_(0x3) << SERCOM_USART_CTRLA_TXPO_Pos)      /**< (SERCOM_USART_CTRLA) Transmit Data Pinout Mask */
+#define SERCOM_USART_CTRLA_TXPO(value)      (SERCOM_USART_CTRLA_TXPO_Msk & ((value) << SERCOM_USART_CTRLA_TXPO_Pos))
+#define SERCOM_USART_CTRLA_RXPO_Pos         20                                             /**< (SERCOM_USART_CTRLA) Receive Data Pinout Position */
+#define SERCOM_USART_CTRLA_RXPO_Msk         (_U_(0x3) << SERCOM_USART_CTRLA_RXPO_Pos)      /**< (SERCOM_USART_CTRLA) Receive Data Pinout Mask */
+#define SERCOM_USART_CTRLA_RXPO(value)      (SERCOM_USART_CTRLA_RXPO_Msk & ((value) << SERCOM_USART_CTRLA_RXPO_Pos))
+#define SERCOM_USART_CTRLA_SAMPA_Pos        22                                             /**< (SERCOM_USART_CTRLA) Sample Adjustment Position */
+#define SERCOM_USART_CTRLA_SAMPA_Msk        (_U_(0x3) << SERCOM_USART_CTRLA_SAMPA_Pos)     /**< (SERCOM_USART_CTRLA) Sample Adjustment Mask */
+#define SERCOM_USART_CTRLA_SAMPA(value)     (SERCOM_USART_CTRLA_SAMPA_Msk & ((value) << SERCOM_USART_CTRLA_SAMPA_Pos))
+#define SERCOM_USART_CTRLA_FORM_Pos         24                                             /**< (SERCOM_USART_CTRLA) Frame Format Position */
+#define SERCOM_USART_CTRLA_FORM_Msk         (_U_(0xF) << SERCOM_USART_CTRLA_FORM_Pos)      /**< (SERCOM_USART_CTRLA) Frame Format Mask */
+#define SERCOM_USART_CTRLA_FORM(value)      (SERCOM_USART_CTRLA_FORM_Msk & ((value) << SERCOM_USART_CTRLA_FORM_Pos))
+#define SERCOM_USART_CTRLA_CMODE_Pos        28                                             /**< (SERCOM_USART_CTRLA) Communication Mode Position */
+#define SERCOM_USART_CTRLA_CMODE_Msk        (_U_(0x1) << SERCOM_USART_CTRLA_CMODE_Pos)     /**< (SERCOM_USART_CTRLA) Communication Mode Mask */
+#define SERCOM_USART_CTRLA_CMODE            SERCOM_USART_CTRLA_CMODE_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_CTRLA_CMODE_Msk instead */
+#define SERCOM_USART_CTRLA_CPOL_Pos         29                                             /**< (SERCOM_USART_CTRLA) Clock Polarity Position */
+#define SERCOM_USART_CTRLA_CPOL_Msk         (_U_(0x1) << SERCOM_USART_CTRLA_CPOL_Pos)      /**< (SERCOM_USART_CTRLA) Clock Polarity Mask */
+#define SERCOM_USART_CTRLA_CPOL             SERCOM_USART_CTRLA_CPOL_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_CTRLA_CPOL_Msk instead */
+#define SERCOM_USART_CTRLA_DORD_Pos         30                                             /**< (SERCOM_USART_CTRLA) Data Order Position */
+#define SERCOM_USART_CTRLA_DORD_Msk         (_U_(0x1) << SERCOM_USART_CTRLA_DORD_Pos)      /**< (SERCOM_USART_CTRLA) Data Order Mask */
+#define SERCOM_USART_CTRLA_DORD             SERCOM_USART_CTRLA_DORD_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_CTRLA_DORD_Msk instead */
+#define SERCOM_USART_CTRLA_MASK             _U_(0x7FF3E79F)                                /**< \deprecated (SERCOM_USART_CTRLA) Register MASK  (Use SERCOM_USART_CTRLA_Msk instead)  */
+#define SERCOM_USART_CTRLA_Msk              _U_(0x7FF3E79F)                                /**< (SERCOM_USART_CTRLA) Register Mask  */
+
+
+/* -------- SERCOM_I2CM_CTRLB : (SERCOM Offset: 0x04) (R/W 32) I2CM Control B -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t SMEN:1;                    /**< bit:      8  Smart Mode Enable                        */
+    uint32_t QCEN:1;                    /**< bit:      9  Quick Command Enable                     */
+    uint32_t :6;                        /**< bit: 10..15  Reserved */
+    uint32_t CMD:2;                     /**< bit: 16..17  Command                                  */
+    uint32_t ACKACT:1;                  /**< bit:     18  Acknowledge Action                       */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SERCOM_I2CM_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_CTRLB_OFFSET            (0x04)                                        /**<  (SERCOM_I2CM_CTRLB) I2CM Control B  Offset */
+#define SERCOM_I2CM_CTRLB_RESETVALUE        _U_(0x00)                                     /**<  (SERCOM_I2CM_CTRLB) I2CM Control B  Reset Value */
+
+#define SERCOM_I2CM_CTRLB_SMEN_Pos          8                                              /**< (SERCOM_I2CM_CTRLB) Smart Mode Enable Position */
+#define SERCOM_I2CM_CTRLB_SMEN_Msk          (_U_(0x1) << SERCOM_I2CM_CTRLB_SMEN_Pos)       /**< (SERCOM_I2CM_CTRLB) Smart Mode Enable Mask */
+#define SERCOM_I2CM_CTRLB_SMEN              SERCOM_I2CM_CTRLB_SMEN_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_CTRLB_SMEN_Msk instead */
+#define SERCOM_I2CM_CTRLB_QCEN_Pos          9                                              /**< (SERCOM_I2CM_CTRLB) Quick Command Enable Position */
+#define SERCOM_I2CM_CTRLB_QCEN_Msk          (_U_(0x1) << SERCOM_I2CM_CTRLB_QCEN_Pos)       /**< (SERCOM_I2CM_CTRLB) Quick Command Enable Mask */
+#define SERCOM_I2CM_CTRLB_QCEN              SERCOM_I2CM_CTRLB_QCEN_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_CTRLB_QCEN_Msk instead */
+#define SERCOM_I2CM_CTRLB_CMD_Pos           16                                             /**< (SERCOM_I2CM_CTRLB) Command Position */
+#define SERCOM_I2CM_CTRLB_CMD_Msk           (_U_(0x3) << SERCOM_I2CM_CTRLB_CMD_Pos)        /**< (SERCOM_I2CM_CTRLB) Command Mask */
+#define SERCOM_I2CM_CTRLB_CMD(value)        (SERCOM_I2CM_CTRLB_CMD_Msk & ((value) << SERCOM_I2CM_CTRLB_CMD_Pos))
+#define SERCOM_I2CM_CTRLB_ACKACT_Pos        18                                             /**< (SERCOM_I2CM_CTRLB) Acknowledge Action Position */
+#define SERCOM_I2CM_CTRLB_ACKACT_Msk        (_U_(0x1) << SERCOM_I2CM_CTRLB_ACKACT_Pos)     /**< (SERCOM_I2CM_CTRLB) Acknowledge Action Mask */
+#define SERCOM_I2CM_CTRLB_ACKACT            SERCOM_I2CM_CTRLB_ACKACT_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_CTRLB_ACKACT_Msk instead */
+#define SERCOM_I2CM_CTRLB_MASK              _U_(0x70300)                                   /**< \deprecated (SERCOM_I2CM_CTRLB) Register MASK  (Use SERCOM_I2CM_CTRLB_Msk instead)  */
+#define SERCOM_I2CM_CTRLB_Msk               _U_(0x70300)                                   /**< (SERCOM_I2CM_CTRLB) Register Mask  */
+
+
+/* -------- SERCOM_I2CS_CTRLB : (SERCOM Offset: 0x04) (R/W 32) I2CS Control B -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t SMEN:1;                    /**< bit:      8  Smart Mode Enable                        */
+    uint32_t GCMD:1;                    /**< bit:      9  PMBus Group Command                      */
+    uint32_t AACKEN:1;                  /**< bit:     10  Automatic Address Acknowledge            */
+    uint32_t :3;                        /**< bit: 11..13  Reserved */
+    uint32_t AMODE:2;                   /**< bit: 14..15  Address Mode                             */
+    uint32_t CMD:2;                     /**< bit: 16..17  Command                                  */
+    uint32_t ACKACT:1;                  /**< bit:     18  Acknowledge Action                       */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SERCOM_I2CS_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CS_CTRLB_OFFSET            (0x04)                                        /**<  (SERCOM_I2CS_CTRLB) I2CS Control B  Offset */
+#define SERCOM_I2CS_CTRLB_RESETVALUE        _U_(0x00)                                     /**<  (SERCOM_I2CS_CTRLB) I2CS Control B  Reset Value */
+
+#define SERCOM_I2CS_CTRLB_SMEN_Pos          8                                              /**< (SERCOM_I2CS_CTRLB) Smart Mode Enable Position */
+#define SERCOM_I2CS_CTRLB_SMEN_Msk          (_U_(0x1) << SERCOM_I2CS_CTRLB_SMEN_Pos)       /**< (SERCOM_I2CS_CTRLB) Smart Mode Enable Mask */
+#define SERCOM_I2CS_CTRLB_SMEN              SERCOM_I2CS_CTRLB_SMEN_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_CTRLB_SMEN_Msk instead */
+#define SERCOM_I2CS_CTRLB_GCMD_Pos          9                                              /**< (SERCOM_I2CS_CTRLB) PMBus Group Command Position */
+#define SERCOM_I2CS_CTRLB_GCMD_Msk          (_U_(0x1) << SERCOM_I2CS_CTRLB_GCMD_Pos)       /**< (SERCOM_I2CS_CTRLB) PMBus Group Command Mask */
+#define SERCOM_I2CS_CTRLB_GCMD              SERCOM_I2CS_CTRLB_GCMD_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_CTRLB_GCMD_Msk instead */
+#define SERCOM_I2CS_CTRLB_AACKEN_Pos        10                                             /**< (SERCOM_I2CS_CTRLB) Automatic Address Acknowledge Position */
+#define SERCOM_I2CS_CTRLB_AACKEN_Msk        (_U_(0x1) << SERCOM_I2CS_CTRLB_AACKEN_Pos)     /**< (SERCOM_I2CS_CTRLB) Automatic Address Acknowledge Mask */
+#define SERCOM_I2CS_CTRLB_AACKEN            SERCOM_I2CS_CTRLB_AACKEN_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_CTRLB_AACKEN_Msk instead */
+#define SERCOM_I2CS_CTRLB_AMODE_Pos         14                                             /**< (SERCOM_I2CS_CTRLB) Address Mode Position */
+#define SERCOM_I2CS_CTRLB_AMODE_Msk         (_U_(0x3) << SERCOM_I2CS_CTRLB_AMODE_Pos)      /**< (SERCOM_I2CS_CTRLB) Address Mode Mask */
+#define SERCOM_I2CS_CTRLB_AMODE(value)      (SERCOM_I2CS_CTRLB_AMODE_Msk & ((value) << SERCOM_I2CS_CTRLB_AMODE_Pos))
+#define SERCOM_I2CS_CTRLB_CMD_Pos           16                                             /**< (SERCOM_I2CS_CTRLB) Command Position */
+#define SERCOM_I2CS_CTRLB_CMD_Msk           (_U_(0x3) << SERCOM_I2CS_CTRLB_CMD_Pos)        /**< (SERCOM_I2CS_CTRLB) Command Mask */
+#define SERCOM_I2CS_CTRLB_CMD(value)        (SERCOM_I2CS_CTRLB_CMD_Msk & ((value) << SERCOM_I2CS_CTRLB_CMD_Pos))
+#define SERCOM_I2CS_CTRLB_ACKACT_Pos        18                                             /**< (SERCOM_I2CS_CTRLB) Acknowledge Action Position */
+#define SERCOM_I2CS_CTRLB_ACKACT_Msk        (_U_(0x1) << SERCOM_I2CS_CTRLB_ACKACT_Pos)     /**< (SERCOM_I2CS_CTRLB) Acknowledge Action Mask */
+#define SERCOM_I2CS_CTRLB_ACKACT            SERCOM_I2CS_CTRLB_ACKACT_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_CTRLB_ACKACT_Msk instead */
+#define SERCOM_I2CS_CTRLB_MASK              _U_(0x7C700)                                   /**< \deprecated (SERCOM_I2CS_CTRLB) Register MASK  (Use SERCOM_I2CS_CTRLB_Msk instead)  */
+#define SERCOM_I2CS_CTRLB_Msk               _U_(0x7C700)                                   /**< (SERCOM_I2CS_CTRLB) Register Mask  */
+
+
+/* -------- SERCOM_SPI_CTRLB : (SERCOM Offset: 0x04) (R/W 32) SPI Control B -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t CHSIZE:3;                  /**< bit:   0..2  Character Size                           */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t PLOADEN:1;                 /**< bit:      6  Data Preload Enable                      */
+    uint32_t :2;                        /**< bit:   7..8  Reserved */
+    uint32_t SSDE:1;                    /**< bit:      9  Slave Select Low Detect Enable           */
+    uint32_t :3;                        /**< bit: 10..12  Reserved */
+    uint32_t MSSEN:1;                   /**< bit:     13  Master Slave Select Enable               */
+    uint32_t AMODE:2;                   /**< bit: 14..15  Address Mode                             */
+    uint32_t :1;                        /**< bit:     16  Reserved */
+    uint32_t RXEN:1;                    /**< bit:     17  Receiver Enable                          */
+    uint32_t :14;                       /**< bit: 18..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SERCOM_SPI_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_CTRLB_OFFSET             (0x04)                                        /**<  (SERCOM_SPI_CTRLB) SPI Control B  Offset */
+#define SERCOM_SPI_CTRLB_RESETVALUE         _U_(0x00)                                     /**<  (SERCOM_SPI_CTRLB) SPI Control B  Reset Value */
+
+#define SERCOM_SPI_CTRLB_CHSIZE_Pos         0                                              /**< (SERCOM_SPI_CTRLB) Character Size Position */
+#define SERCOM_SPI_CTRLB_CHSIZE_Msk         (_U_(0x7) << SERCOM_SPI_CTRLB_CHSIZE_Pos)      /**< (SERCOM_SPI_CTRLB) Character Size Mask */
+#define SERCOM_SPI_CTRLB_CHSIZE(value)      (SERCOM_SPI_CTRLB_CHSIZE_Msk & ((value) << SERCOM_SPI_CTRLB_CHSIZE_Pos))
+#define SERCOM_SPI_CTRLB_PLOADEN_Pos        6                                              /**< (SERCOM_SPI_CTRLB) Data Preload Enable Position */
+#define SERCOM_SPI_CTRLB_PLOADEN_Msk        (_U_(0x1) << SERCOM_SPI_CTRLB_PLOADEN_Pos)     /**< (SERCOM_SPI_CTRLB) Data Preload Enable Mask */
+#define SERCOM_SPI_CTRLB_PLOADEN            SERCOM_SPI_CTRLB_PLOADEN_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_CTRLB_PLOADEN_Msk instead */
+#define SERCOM_SPI_CTRLB_SSDE_Pos           9                                              /**< (SERCOM_SPI_CTRLB) Slave Select Low Detect Enable Position */
+#define SERCOM_SPI_CTRLB_SSDE_Msk           (_U_(0x1) << SERCOM_SPI_CTRLB_SSDE_Pos)        /**< (SERCOM_SPI_CTRLB) Slave Select Low Detect Enable Mask */
+#define SERCOM_SPI_CTRLB_SSDE               SERCOM_SPI_CTRLB_SSDE_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_CTRLB_SSDE_Msk instead */
+#define SERCOM_SPI_CTRLB_MSSEN_Pos          13                                             /**< (SERCOM_SPI_CTRLB) Master Slave Select Enable Position */
+#define SERCOM_SPI_CTRLB_MSSEN_Msk          (_U_(0x1) << SERCOM_SPI_CTRLB_MSSEN_Pos)       /**< (SERCOM_SPI_CTRLB) Master Slave Select Enable Mask */
+#define SERCOM_SPI_CTRLB_MSSEN              SERCOM_SPI_CTRLB_MSSEN_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_CTRLB_MSSEN_Msk instead */
+#define SERCOM_SPI_CTRLB_AMODE_Pos          14                                             /**< (SERCOM_SPI_CTRLB) Address Mode Position */
+#define SERCOM_SPI_CTRLB_AMODE_Msk          (_U_(0x3) << SERCOM_SPI_CTRLB_AMODE_Pos)       /**< (SERCOM_SPI_CTRLB) Address Mode Mask */
+#define SERCOM_SPI_CTRLB_AMODE(value)       (SERCOM_SPI_CTRLB_AMODE_Msk & ((value) << SERCOM_SPI_CTRLB_AMODE_Pos))
+#define SERCOM_SPI_CTRLB_RXEN_Pos           17                                             /**< (SERCOM_SPI_CTRLB) Receiver Enable Position */
+#define SERCOM_SPI_CTRLB_RXEN_Msk           (_U_(0x1) << SERCOM_SPI_CTRLB_RXEN_Pos)        /**< (SERCOM_SPI_CTRLB) Receiver Enable Mask */
+#define SERCOM_SPI_CTRLB_RXEN               SERCOM_SPI_CTRLB_RXEN_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_CTRLB_RXEN_Msk instead */
+#define SERCOM_SPI_CTRLB_MASK               _U_(0x2E247)                                   /**< \deprecated (SERCOM_SPI_CTRLB) Register MASK  (Use SERCOM_SPI_CTRLB_Msk instead)  */
+#define SERCOM_SPI_CTRLB_Msk                _U_(0x2E247)                                   /**< (SERCOM_SPI_CTRLB) Register Mask  */
+
+
+/* -------- SERCOM_USART_CTRLB : (SERCOM Offset: 0x04) (R/W 32) USART Control B -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t CHSIZE:3;                  /**< bit:   0..2  Character Size                           */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t SBMODE:1;                  /**< bit:      6  Stop Bit Mode                            */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t COLDEN:1;                  /**< bit:      8  Collision Detection Enable               */
+    uint32_t SFDE:1;                    /**< bit:      9  Start of Frame Detection Enable          */
+    uint32_t ENC:1;                     /**< bit:     10  Encoding Format                          */
+    uint32_t :2;                        /**< bit: 11..12  Reserved */
+    uint32_t PMODE:1;                   /**< bit:     13  Parity Mode                              */
+    uint32_t :2;                        /**< bit: 14..15  Reserved */
+    uint32_t TXEN:1;                    /**< bit:     16  Transmitter Enable                       */
+    uint32_t RXEN:1;                    /**< bit:     17  Receiver Enable                          */
+    uint32_t :6;                        /**< bit: 18..23  Reserved */
+    uint32_t LINCMD:2;                  /**< bit: 24..25  LIN Command                              */
+    uint32_t :6;                        /**< bit: 26..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SERCOM_USART_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_CTRLB_OFFSET           (0x04)                                        /**<  (SERCOM_USART_CTRLB) USART Control B  Offset */
+#define SERCOM_USART_CTRLB_RESETVALUE       _U_(0x00)                                     /**<  (SERCOM_USART_CTRLB) USART Control B  Reset Value */
+
+#define SERCOM_USART_CTRLB_CHSIZE_Pos       0                                              /**< (SERCOM_USART_CTRLB) Character Size Position */
+#define SERCOM_USART_CTRLB_CHSIZE_Msk       (_U_(0x7) << SERCOM_USART_CTRLB_CHSIZE_Pos)    /**< (SERCOM_USART_CTRLB) Character Size Mask */
+#define SERCOM_USART_CTRLB_CHSIZE(value)    (SERCOM_USART_CTRLB_CHSIZE_Msk & ((value) << SERCOM_USART_CTRLB_CHSIZE_Pos))
+#define SERCOM_USART_CTRLB_SBMODE_Pos       6                                              /**< (SERCOM_USART_CTRLB) Stop Bit Mode Position */
+#define SERCOM_USART_CTRLB_SBMODE_Msk       (_U_(0x1) << SERCOM_USART_CTRLB_SBMODE_Pos)    /**< (SERCOM_USART_CTRLB) Stop Bit Mode Mask */
+#define SERCOM_USART_CTRLB_SBMODE           SERCOM_USART_CTRLB_SBMODE_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_CTRLB_SBMODE_Msk instead */
+#define SERCOM_USART_CTRLB_COLDEN_Pos       8                                              /**< (SERCOM_USART_CTRLB) Collision Detection Enable Position */
+#define SERCOM_USART_CTRLB_COLDEN_Msk       (_U_(0x1) << SERCOM_USART_CTRLB_COLDEN_Pos)    /**< (SERCOM_USART_CTRLB) Collision Detection Enable Mask */
+#define SERCOM_USART_CTRLB_COLDEN           SERCOM_USART_CTRLB_COLDEN_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_CTRLB_COLDEN_Msk instead */
+#define SERCOM_USART_CTRLB_SFDE_Pos         9                                              /**< (SERCOM_USART_CTRLB) Start of Frame Detection Enable Position */
+#define SERCOM_USART_CTRLB_SFDE_Msk         (_U_(0x1) << SERCOM_USART_CTRLB_SFDE_Pos)      /**< (SERCOM_USART_CTRLB) Start of Frame Detection Enable Mask */
+#define SERCOM_USART_CTRLB_SFDE             SERCOM_USART_CTRLB_SFDE_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_CTRLB_SFDE_Msk instead */
+#define SERCOM_USART_CTRLB_ENC_Pos          10                                             /**< (SERCOM_USART_CTRLB) Encoding Format Position */
+#define SERCOM_USART_CTRLB_ENC_Msk          (_U_(0x1) << SERCOM_USART_CTRLB_ENC_Pos)       /**< (SERCOM_USART_CTRLB) Encoding Format Mask */
+#define SERCOM_USART_CTRLB_ENC              SERCOM_USART_CTRLB_ENC_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_CTRLB_ENC_Msk instead */
+#define SERCOM_USART_CTRLB_PMODE_Pos        13                                             /**< (SERCOM_USART_CTRLB) Parity Mode Position */
+#define SERCOM_USART_CTRLB_PMODE_Msk        (_U_(0x1) << SERCOM_USART_CTRLB_PMODE_Pos)     /**< (SERCOM_USART_CTRLB) Parity Mode Mask */
+#define SERCOM_USART_CTRLB_PMODE            SERCOM_USART_CTRLB_PMODE_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_CTRLB_PMODE_Msk instead */
+#define SERCOM_USART_CTRLB_TXEN_Pos         16                                             /**< (SERCOM_USART_CTRLB) Transmitter Enable Position */
+#define SERCOM_USART_CTRLB_TXEN_Msk         (_U_(0x1) << SERCOM_USART_CTRLB_TXEN_Pos)      /**< (SERCOM_USART_CTRLB) Transmitter Enable Mask */
+#define SERCOM_USART_CTRLB_TXEN             SERCOM_USART_CTRLB_TXEN_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_CTRLB_TXEN_Msk instead */
+#define SERCOM_USART_CTRLB_RXEN_Pos         17                                             /**< (SERCOM_USART_CTRLB) Receiver Enable Position */
+#define SERCOM_USART_CTRLB_RXEN_Msk         (_U_(0x1) << SERCOM_USART_CTRLB_RXEN_Pos)      /**< (SERCOM_USART_CTRLB) Receiver Enable Mask */
+#define SERCOM_USART_CTRLB_RXEN             SERCOM_USART_CTRLB_RXEN_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_CTRLB_RXEN_Msk instead */
+#define SERCOM_USART_CTRLB_LINCMD_Pos       24                                             /**< (SERCOM_USART_CTRLB) LIN Command Position */
+#define SERCOM_USART_CTRLB_LINCMD_Msk       (_U_(0x3) << SERCOM_USART_CTRLB_LINCMD_Pos)    /**< (SERCOM_USART_CTRLB) LIN Command Mask */
+#define SERCOM_USART_CTRLB_LINCMD(value)    (SERCOM_USART_CTRLB_LINCMD_Msk & ((value) << SERCOM_USART_CTRLB_LINCMD_Pos))
+#define SERCOM_USART_CTRLB_MASK             _U_(0x3032747)                                 /**< \deprecated (SERCOM_USART_CTRLB) Register MASK  (Use SERCOM_USART_CTRLB_Msk instead)  */
+#define SERCOM_USART_CTRLB_Msk              _U_(0x3032747)                                 /**< (SERCOM_USART_CTRLB) Register Mask  */
+
+
+/* -------- SERCOM_USART_CTRLC : (SERCOM Offset: 0x08) (R/W 32) USART Control C -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t GTIME:3;                   /**< bit:   0..2  Guard Time                               */
+    uint32_t :5;                        /**< bit:   3..7  Reserved */
+    uint32_t BRKLEN:2;                  /**< bit:   8..9  LIN Master Break Length                  */
+    uint32_t HDRDLY:2;                  /**< bit: 10..11  LIN Master Header Delay                  */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t INACK:1;                   /**< bit:     16  Inhibit Not Acknowledge                  */
+    uint32_t DSNACK:1;                  /**< bit:     17  Disable Successive NACK                  */
+    uint32_t :2;                        /**< bit: 18..19  Reserved */
+    uint32_t MAXITER:3;                 /**< bit: 20..22  Maximum Iterations                       */
+    uint32_t :9;                        /**< bit: 23..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SERCOM_USART_CTRLC_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_CTRLC_OFFSET           (0x08)                                        /**<  (SERCOM_USART_CTRLC) USART Control C  Offset */
+#define SERCOM_USART_CTRLC_RESETVALUE       _U_(0x00)                                     /**<  (SERCOM_USART_CTRLC) USART Control C  Reset Value */
+
+#define SERCOM_USART_CTRLC_GTIME_Pos        0                                              /**< (SERCOM_USART_CTRLC) Guard Time Position */
+#define SERCOM_USART_CTRLC_GTIME_Msk        (_U_(0x7) << SERCOM_USART_CTRLC_GTIME_Pos)     /**< (SERCOM_USART_CTRLC) Guard Time Mask */
+#define SERCOM_USART_CTRLC_GTIME(value)     (SERCOM_USART_CTRLC_GTIME_Msk & ((value) << SERCOM_USART_CTRLC_GTIME_Pos))
+#define SERCOM_USART_CTRLC_BRKLEN_Pos       8                                              /**< (SERCOM_USART_CTRLC) LIN Master Break Length Position */
+#define SERCOM_USART_CTRLC_BRKLEN_Msk       (_U_(0x3) << SERCOM_USART_CTRLC_BRKLEN_Pos)    /**< (SERCOM_USART_CTRLC) LIN Master Break Length Mask */
+#define SERCOM_USART_CTRLC_BRKLEN(value)    (SERCOM_USART_CTRLC_BRKLEN_Msk & ((value) << SERCOM_USART_CTRLC_BRKLEN_Pos))
+#define SERCOM_USART_CTRLC_HDRDLY_Pos       10                                             /**< (SERCOM_USART_CTRLC) LIN Master Header Delay Position */
+#define SERCOM_USART_CTRLC_HDRDLY_Msk       (_U_(0x3) << SERCOM_USART_CTRLC_HDRDLY_Pos)    /**< (SERCOM_USART_CTRLC) LIN Master Header Delay Mask */
+#define SERCOM_USART_CTRLC_HDRDLY(value)    (SERCOM_USART_CTRLC_HDRDLY_Msk & ((value) << SERCOM_USART_CTRLC_HDRDLY_Pos))
+#define SERCOM_USART_CTRLC_INACK_Pos        16                                             /**< (SERCOM_USART_CTRLC) Inhibit Not Acknowledge Position */
+#define SERCOM_USART_CTRLC_INACK_Msk        (_U_(0x1) << SERCOM_USART_CTRLC_INACK_Pos)     /**< (SERCOM_USART_CTRLC) Inhibit Not Acknowledge Mask */
+#define SERCOM_USART_CTRLC_INACK            SERCOM_USART_CTRLC_INACK_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_CTRLC_INACK_Msk instead */
+#define SERCOM_USART_CTRLC_DSNACK_Pos       17                                             /**< (SERCOM_USART_CTRLC) Disable Successive NACK Position */
+#define SERCOM_USART_CTRLC_DSNACK_Msk       (_U_(0x1) << SERCOM_USART_CTRLC_DSNACK_Pos)    /**< (SERCOM_USART_CTRLC) Disable Successive NACK Mask */
+#define SERCOM_USART_CTRLC_DSNACK           SERCOM_USART_CTRLC_DSNACK_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_CTRLC_DSNACK_Msk instead */
+#define SERCOM_USART_CTRLC_MAXITER_Pos      20                                             /**< (SERCOM_USART_CTRLC) Maximum Iterations Position */
+#define SERCOM_USART_CTRLC_MAXITER_Msk      (_U_(0x7) << SERCOM_USART_CTRLC_MAXITER_Pos)   /**< (SERCOM_USART_CTRLC) Maximum Iterations Mask */
+#define SERCOM_USART_CTRLC_MAXITER(value)   (SERCOM_USART_CTRLC_MAXITER_Msk & ((value) << SERCOM_USART_CTRLC_MAXITER_Pos))
+#define SERCOM_USART_CTRLC_MASK             _U_(0x730F07)                                  /**< \deprecated (SERCOM_USART_CTRLC) Register MASK  (Use SERCOM_USART_CTRLC_Msk instead)  */
+#define SERCOM_USART_CTRLC_Msk              _U_(0x730F07)                                  /**< (SERCOM_USART_CTRLC) Register Mask  */
+
+
+/* -------- SERCOM_I2CM_BAUD : (SERCOM Offset: 0x0c) (R/W 32) I2CM Baud Rate -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t BAUD:8;                    /**< bit:   0..7  Baud Rate Value                          */
+    uint32_t BAUDLOW:8;                 /**< bit:  8..15  Baud Rate Value Low                      */
+    uint32_t HSBAUD:8;                  /**< bit: 16..23  High Speed Baud Rate Value               */
+    uint32_t HSBAUDLOW:8;               /**< bit: 24..31  High Speed Baud Rate Value Low           */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SERCOM_I2CM_BAUD_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_BAUD_OFFSET             (0x0C)                                        /**<  (SERCOM_I2CM_BAUD) I2CM Baud Rate  Offset */
+#define SERCOM_I2CM_BAUD_RESETVALUE         _U_(0x00)                                     /**<  (SERCOM_I2CM_BAUD) I2CM Baud Rate  Reset Value */
+
+#define SERCOM_I2CM_BAUD_BAUD_Pos           0                                              /**< (SERCOM_I2CM_BAUD) Baud Rate Value Position */
+#define SERCOM_I2CM_BAUD_BAUD_Msk           (_U_(0xFF) << SERCOM_I2CM_BAUD_BAUD_Pos)       /**< (SERCOM_I2CM_BAUD) Baud Rate Value Mask */
+#define SERCOM_I2CM_BAUD_BAUD(value)        (SERCOM_I2CM_BAUD_BAUD_Msk & ((value) << SERCOM_I2CM_BAUD_BAUD_Pos))
+#define SERCOM_I2CM_BAUD_BAUDLOW_Pos        8                                              /**< (SERCOM_I2CM_BAUD) Baud Rate Value Low Position */
+#define SERCOM_I2CM_BAUD_BAUDLOW_Msk        (_U_(0xFF) << SERCOM_I2CM_BAUD_BAUDLOW_Pos)    /**< (SERCOM_I2CM_BAUD) Baud Rate Value Low Mask */
+#define SERCOM_I2CM_BAUD_BAUDLOW(value)     (SERCOM_I2CM_BAUD_BAUDLOW_Msk & ((value) << SERCOM_I2CM_BAUD_BAUDLOW_Pos))
+#define SERCOM_I2CM_BAUD_HSBAUD_Pos         16                                             /**< (SERCOM_I2CM_BAUD) High Speed Baud Rate Value Position */
+#define SERCOM_I2CM_BAUD_HSBAUD_Msk         (_U_(0xFF) << SERCOM_I2CM_BAUD_HSBAUD_Pos)     /**< (SERCOM_I2CM_BAUD) High Speed Baud Rate Value Mask */
+#define SERCOM_I2CM_BAUD_HSBAUD(value)      (SERCOM_I2CM_BAUD_HSBAUD_Msk & ((value) << SERCOM_I2CM_BAUD_HSBAUD_Pos))
+#define SERCOM_I2CM_BAUD_HSBAUDLOW_Pos      24                                             /**< (SERCOM_I2CM_BAUD) High Speed Baud Rate Value Low Position */
+#define SERCOM_I2CM_BAUD_HSBAUDLOW_Msk      (_U_(0xFF) << SERCOM_I2CM_BAUD_HSBAUDLOW_Pos)  /**< (SERCOM_I2CM_BAUD) High Speed Baud Rate Value Low Mask */
+#define SERCOM_I2CM_BAUD_HSBAUDLOW(value)   (SERCOM_I2CM_BAUD_HSBAUDLOW_Msk & ((value) << SERCOM_I2CM_BAUD_HSBAUDLOW_Pos))
+#define SERCOM_I2CM_BAUD_MASK               _U_(0xFFFFFFFF)                                /**< \deprecated (SERCOM_I2CM_BAUD) Register MASK  (Use SERCOM_I2CM_BAUD_Msk instead)  */
+#define SERCOM_I2CM_BAUD_Msk                _U_(0xFFFFFFFF)                                /**< (SERCOM_I2CM_BAUD) Register Mask  */
+
+
+/* -------- SERCOM_SPI_BAUD : (SERCOM Offset: 0x0c) (R/W 8) SPI Baud Rate -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  BAUD:8;                    /**< bit:   0..7  Baud Rate Value                          */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} SERCOM_SPI_BAUD_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_BAUD_OFFSET              (0x0C)                                        /**<  (SERCOM_SPI_BAUD) SPI Baud Rate  Offset */
+#define SERCOM_SPI_BAUD_RESETVALUE          _U_(0x00)                                     /**<  (SERCOM_SPI_BAUD) SPI Baud Rate  Reset Value */
+
+#define SERCOM_SPI_BAUD_BAUD_Pos            0                                              /**< (SERCOM_SPI_BAUD) Baud Rate Value Position */
+#define SERCOM_SPI_BAUD_BAUD_Msk            (_U_(0xFF) << SERCOM_SPI_BAUD_BAUD_Pos)        /**< (SERCOM_SPI_BAUD) Baud Rate Value Mask */
+#define SERCOM_SPI_BAUD_BAUD(value)         (SERCOM_SPI_BAUD_BAUD_Msk & ((value) << SERCOM_SPI_BAUD_BAUD_Pos))
+#define SERCOM_SPI_BAUD_MASK                _U_(0xFF)                                      /**< \deprecated (SERCOM_SPI_BAUD) Register MASK  (Use SERCOM_SPI_BAUD_Msk instead)  */
+#define SERCOM_SPI_BAUD_Msk                 _U_(0xFF)                                      /**< (SERCOM_SPI_BAUD) Register Mask  */
+
+
+/* -------- SERCOM_USART_BAUD : (SERCOM Offset: 0x0c) (R/W 16) USART Baud Rate -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t BAUD:16;                   /**< bit:  0..15  Baud Rate Value                          */
+  } bit;                                /**< Structure used for bit  access */
+  struct { // FRAC mode
+    uint16_t BAUD:13;                   /**< bit:  0..12  Baud Rate Value                          */
+    uint16_t FP:3;                      /**< bit: 13..15  Fractional Part                          */
+  } FRAC;                                /**< Structure used for FRAC mode access */
+  struct { // FRACFP mode
+    uint16_t BAUD:13;                   /**< bit:  0..12  Baud Rate Value                          */
+    uint16_t FP:3;                      /**< bit: 13..15  Fractional Part                          */
+  } FRACFP;                                /**< Structure used for FRACFP mode access */
+  struct { // USARTFP mode
+    uint16_t BAUD:16;                   /**< bit:  0..15  Baud Rate Value                          */
+  } USARTFP;                                /**< Structure used for USARTFP mode access */
+  uint16_t reg;                         /**< Type used for register access */
+} SERCOM_USART_BAUD_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_BAUD_OFFSET            (0x0C)                                        /**<  (SERCOM_USART_BAUD) USART Baud Rate  Offset */
+#define SERCOM_USART_BAUD_RESETVALUE        _U_(0x00)                                     /**<  (SERCOM_USART_BAUD) USART Baud Rate  Reset Value */
+
+#define SERCOM_USART_BAUD_BAUD_Pos          0                                              /**< (SERCOM_USART_BAUD) Baud Rate Value Position */
+#define SERCOM_USART_BAUD_BAUD_Msk          (_U_(0xFFFF) << SERCOM_USART_BAUD_BAUD_Pos)    /**< (SERCOM_USART_BAUD) Baud Rate Value Mask */
+#define SERCOM_USART_BAUD_BAUD(value)       (SERCOM_USART_BAUD_BAUD_Msk & ((value) << SERCOM_USART_BAUD_BAUD_Pos))
+#define SERCOM_USART_BAUD_MASK              _U_(0xFFFF)                                    /**< \deprecated (SERCOM_USART_BAUD) Register MASK  (Use SERCOM_USART_BAUD_Msk instead)  */
+#define SERCOM_USART_BAUD_Msk               _U_(0xFFFF)                                    /**< (SERCOM_USART_BAUD) Register Mask  */
+
+/* FRAC mode */
+#define SERCOM_USART_BAUD_FRAC_BAUD_Pos     0                                              /**< (SERCOM_USART_BAUD) Baud Rate Value Position */
+#define SERCOM_USART_BAUD_FRAC_BAUD_Msk     (_U_(0x1FFF) << SERCOM_USART_BAUD_FRAC_BAUD_Pos)  /**< (SERCOM_USART_BAUD) Baud Rate Value Mask */
+#define SERCOM_USART_BAUD_FRAC_BAUD(value)  (SERCOM_USART_BAUD_FRAC_BAUD_Msk & ((value) << SERCOM_USART_BAUD_FRAC_BAUD_Pos))
+#define SERCOM_USART_BAUD_FRAC_FP_Pos       13                                             /**< (SERCOM_USART_BAUD) Fractional Part Position */
+#define SERCOM_USART_BAUD_FRAC_FP_Msk       (_U_(0x7) << SERCOM_USART_BAUD_FRAC_FP_Pos)    /**< (SERCOM_USART_BAUD) Fractional Part Mask */
+#define SERCOM_USART_BAUD_FRAC_FP(value)    (SERCOM_USART_BAUD_FRAC_FP_Msk & ((value) << SERCOM_USART_BAUD_FRAC_FP_Pos))
+#define SERCOM_USART_BAUD_FRAC_MASK         _U_(0xFFFF)                                    /**< \deprecated (SERCOM_USART_BAUD_FRAC) Register MASK  (Use SERCOM_USART_BAUD_FRAC_Msk instead)  */
+#define SERCOM_USART_BAUD_FRAC_Msk          _U_(0xFFFF)                                    /**< (SERCOM_USART_BAUD_FRAC) Register Mask  */
+
+/* FRACFP mode */
+#define SERCOM_USART_BAUD_FRACFP_BAUD_Pos   0                                              /**< (SERCOM_USART_BAUD) Baud Rate Value Position */
+#define SERCOM_USART_BAUD_FRACFP_BAUD_Msk   (_U_(0x1FFF) << SERCOM_USART_BAUD_FRACFP_BAUD_Pos)  /**< (SERCOM_USART_BAUD) Baud Rate Value Mask */
+#define SERCOM_USART_BAUD_FRACFP_BAUD(value) (SERCOM_USART_BAUD_FRACFP_BAUD_Msk & ((value) << SERCOM_USART_BAUD_FRACFP_BAUD_Pos))
+#define SERCOM_USART_BAUD_FRACFP_FP_Pos     13                                             /**< (SERCOM_USART_BAUD) Fractional Part Position */
+#define SERCOM_USART_BAUD_FRACFP_FP_Msk     (_U_(0x7) << SERCOM_USART_BAUD_FRACFP_FP_Pos)  /**< (SERCOM_USART_BAUD) Fractional Part Mask */
+#define SERCOM_USART_BAUD_FRACFP_FP(value)  (SERCOM_USART_BAUD_FRACFP_FP_Msk & ((value) << SERCOM_USART_BAUD_FRACFP_FP_Pos))
+#define SERCOM_USART_BAUD_FRACFP_MASK       _U_(0xFFFF)                                    /**< \deprecated (SERCOM_USART_BAUD_FRACFP) Register MASK  (Use SERCOM_USART_BAUD_FRACFP_Msk instead)  */
+#define SERCOM_USART_BAUD_FRACFP_Msk        _U_(0xFFFF)                                    /**< (SERCOM_USART_BAUD_FRACFP) Register Mask  */
+
+/* USARTFP mode */
+#define SERCOM_USART_BAUD_USARTFP_BAUD_Pos  0                                              /**< (SERCOM_USART_BAUD) Baud Rate Value Position */
+#define SERCOM_USART_BAUD_USARTFP_BAUD_Msk  (_U_(0xFFFF) << SERCOM_USART_BAUD_USARTFP_BAUD_Pos)  /**< (SERCOM_USART_BAUD) Baud Rate Value Mask */
+#define SERCOM_USART_BAUD_USARTFP_BAUD(value) (SERCOM_USART_BAUD_USARTFP_BAUD_Msk & ((value) << SERCOM_USART_BAUD_USARTFP_BAUD_Pos))
+#define SERCOM_USART_BAUD_USARTFP_MASK      _U_(0xFFFF)                                    /**< \deprecated (SERCOM_USART_BAUD_USARTFP) Register MASK  (Use SERCOM_USART_BAUD_USARTFP_Msk instead)  */
+#define SERCOM_USART_BAUD_USARTFP_Msk       _U_(0xFFFF)                                    /**< (SERCOM_USART_BAUD_USARTFP) Register Mask  */
+
+
+/* -------- SERCOM_USART_RXPL : (SERCOM Offset: 0x0e) (R/W 8) USART Receive Pulse Length -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  RXPL:8;                    /**< bit:   0..7  Receive Pulse Length                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} SERCOM_USART_RXPL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_RXPL_OFFSET            (0x0E)                                        /**<  (SERCOM_USART_RXPL) USART Receive Pulse Length  Offset */
+#define SERCOM_USART_RXPL_RESETVALUE        _U_(0x00)                                     /**<  (SERCOM_USART_RXPL) USART Receive Pulse Length  Reset Value */
+
+#define SERCOM_USART_RXPL_RXPL_Pos          0                                              /**< (SERCOM_USART_RXPL) Receive Pulse Length Position */
+#define SERCOM_USART_RXPL_RXPL_Msk          (_U_(0xFF) << SERCOM_USART_RXPL_RXPL_Pos)      /**< (SERCOM_USART_RXPL) Receive Pulse Length Mask */
+#define SERCOM_USART_RXPL_RXPL(value)       (SERCOM_USART_RXPL_RXPL_Msk & ((value) << SERCOM_USART_RXPL_RXPL_Pos))
+#define SERCOM_USART_RXPL_MASK              _U_(0xFF)                                      /**< \deprecated (SERCOM_USART_RXPL) Register MASK  (Use SERCOM_USART_RXPL_Msk instead)  */
+#define SERCOM_USART_RXPL_Msk               _U_(0xFF)                                      /**< (SERCOM_USART_RXPL) Register Mask  */
+
+
+/* -------- SERCOM_I2CM_INTENCLR : (SERCOM Offset: 0x14) (R/W 8) I2CM Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  MB:1;                      /**< bit:      0  Master On Bus Interrupt Disable          */
+    uint8_t  SB:1;                      /**< bit:      1  Slave On Bus Interrupt Disable           */
+    uint8_t  :5;                        /**< bit:   2..6  Reserved */
+    uint8_t  ERROR:1;                   /**< bit:      7  Combined Error Interrupt Disable         */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} SERCOM_I2CM_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_INTENCLR_OFFSET         (0x14)                                        /**<  (SERCOM_I2CM_INTENCLR) I2CM Interrupt Enable Clear  Offset */
+#define SERCOM_I2CM_INTENCLR_RESETVALUE     _U_(0x00)                                     /**<  (SERCOM_I2CM_INTENCLR) I2CM Interrupt Enable Clear  Reset Value */
+
+#define SERCOM_I2CM_INTENCLR_MB_Pos         0                                              /**< (SERCOM_I2CM_INTENCLR) Master On Bus Interrupt Disable Position */
+#define SERCOM_I2CM_INTENCLR_MB_Msk         (_U_(0x1) << SERCOM_I2CM_INTENCLR_MB_Pos)      /**< (SERCOM_I2CM_INTENCLR) Master On Bus Interrupt Disable Mask */
+#define SERCOM_I2CM_INTENCLR_MB             SERCOM_I2CM_INTENCLR_MB_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_INTENCLR_MB_Msk instead */
+#define SERCOM_I2CM_INTENCLR_SB_Pos         1                                              /**< (SERCOM_I2CM_INTENCLR) Slave On Bus Interrupt Disable Position */
+#define SERCOM_I2CM_INTENCLR_SB_Msk         (_U_(0x1) << SERCOM_I2CM_INTENCLR_SB_Pos)      /**< (SERCOM_I2CM_INTENCLR) Slave On Bus Interrupt Disable Mask */
+#define SERCOM_I2CM_INTENCLR_SB             SERCOM_I2CM_INTENCLR_SB_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_INTENCLR_SB_Msk instead */
+#define SERCOM_I2CM_INTENCLR_ERROR_Pos      7                                              /**< (SERCOM_I2CM_INTENCLR) Combined Error Interrupt Disable Position */
+#define SERCOM_I2CM_INTENCLR_ERROR_Msk      (_U_(0x1) << SERCOM_I2CM_INTENCLR_ERROR_Pos)   /**< (SERCOM_I2CM_INTENCLR) Combined Error Interrupt Disable Mask */
+#define SERCOM_I2CM_INTENCLR_ERROR          SERCOM_I2CM_INTENCLR_ERROR_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_INTENCLR_ERROR_Msk instead */
+#define SERCOM_I2CM_INTENCLR_MASK           _U_(0x83)                                      /**< \deprecated (SERCOM_I2CM_INTENCLR) Register MASK  (Use SERCOM_I2CM_INTENCLR_Msk instead)  */
+#define SERCOM_I2CM_INTENCLR_Msk            _U_(0x83)                                      /**< (SERCOM_I2CM_INTENCLR) Register Mask  */
+
+
+/* -------- SERCOM_I2CS_INTENCLR : (SERCOM Offset: 0x14) (R/W 8) I2CS Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  PREC:1;                    /**< bit:      0  Stop Received Interrupt Disable          */
+    uint8_t  AMATCH:1;                  /**< bit:      1  Address Match Interrupt Disable          */
+    uint8_t  DRDY:1;                    /**< bit:      2  Data Interrupt Disable                   */
+    uint8_t  :4;                        /**< bit:   3..6  Reserved */
+    uint8_t  ERROR:1;                   /**< bit:      7  Combined Error Interrupt Disable         */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} SERCOM_I2CS_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CS_INTENCLR_OFFSET         (0x14)                                        /**<  (SERCOM_I2CS_INTENCLR) I2CS Interrupt Enable Clear  Offset */
+#define SERCOM_I2CS_INTENCLR_RESETVALUE     _U_(0x00)                                     /**<  (SERCOM_I2CS_INTENCLR) I2CS Interrupt Enable Clear  Reset Value */
+
+#define SERCOM_I2CS_INTENCLR_PREC_Pos       0                                              /**< (SERCOM_I2CS_INTENCLR) Stop Received Interrupt Disable Position */
+#define SERCOM_I2CS_INTENCLR_PREC_Msk       (_U_(0x1) << SERCOM_I2CS_INTENCLR_PREC_Pos)    /**< (SERCOM_I2CS_INTENCLR) Stop Received Interrupt Disable Mask */
+#define SERCOM_I2CS_INTENCLR_PREC           SERCOM_I2CS_INTENCLR_PREC_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_INTENCLR_PREC_Msk instead */
+#define SERCOM_I2CS_INTENCLR_AMATCH_Pos     1                                              /**< (SERCOM_I2CS_INTENCLR) Address Match Interrupt Disable Position */
+#define SERCOM_I2CS_INTENCLR_AMATCH_Msk     (_U_(0x1) << SERCOM_I2CS_INTENCLR_AMATCH_Pos)  /**< (SERCOM_I2CS_INTENCLR) Address Match Interrupt Disable Mask */
+#define SERCOM_I2CS_INTENCLR_AMATCH         SERCOM_I2CS_INTENCLR_AMATCH_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_INTENCLR_AMATCH_Msk instead */
+#define SERCOM_I2CS_INTENCLR_DRDY_Pos       2                                              /**< (SERCOM_I2CS_INTENCLR) Data Interrupt Disable Position */
+#define SERCOM_I2CS_INTENCLR_DRDY_Msk       (_U_(0x1) << SERCOM_I2CS_INTENCLR_DRDY_Pos)    /**< (SERCOM_I2CS_INTENCLR) Data Interrupt Disable Mask */
+#define SERCOM_I2CS_INTENCLR_DRDY           SERCOM_I2CS_INTENCLR_DRDY_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_INTENCLR_DRDY_Msk instead */
+#define SERCOM_I2CS_INTENCLR_ERROR_Pos      7                                              /**< (SERCOM_I2CS_INTENCLR) Combined Error Interrupt Disable Position */
+#define SERCOM_I2CS_INTENCLR_ERROR_Msk      (_U_(0x1) << SERCOM_I2CS_INTENCLR_ERROR_Pos)   /**< (SERCOM_I2CS_INTENCLR) Combined Error Interrupt Disable Mask */
+#define SERCOM_I2CS_INTENCLR_ERROR          SERCOM_I2CS_INTENCLR_ERROR_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_INTENCLR_ERROR_Msk instead */
+#define SERCOM_I2CS_INTENCLR_MASK           _U_(0x87)                                      /**< \deprecated (SERCOM_I2CS_INTENCLR) Register MASK  (Use SERCOM_I2CS_INTENCLR_Msk instead)  */
+#define SERCOM_I2CS_INTENCLR_Msk            _U_(0x87)                                      /**< (SERCOM_I2CS_INTENCLR) Register Mask  */
+
+
+/* -------- SERCOM_SPI_INTENCLR : (SERCOM Offset: 0x14) (R/W 8) SPI Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DRE:1;                     /**< bit:      0  Data Register Empty Interrupt Disable    */
+    uint8_t  TXC:1;                     /**< bit:      1  Transmit Complete Interrupt Disable      */
+    uint8_t  RXC:1;                     /**< bit:      2  Receive Complete Interrupt Disable       */
+    uint8_t  SSL:1;                     /**< bit:      3  Slave Select Low Interrupt Disable       */
+    uint8_t  :3;                        /**< bit:   4..6  Reserved */
+    uint8_t  ERROR:1;                   /**< bit:      7  Combined Error Interrupt Disable         */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} SERCOM_SPI_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_INTENCLR_OFFSET          (0x14)                                        /**<  (SERCOM_SPI_INTENCLR) SPI Interrupt Enable Clear  Offset */
+#define SERCOM_SPI_INTENCLR_RESETVALUE      _U_(0x00)                                     /**<  (SERCOM_SPI_INTENCLR) SPI Interrupt Enable Clear  Reset Value */
+
+#define SERCOM_SPI_INTENCLR_DRE_Pos         0                                              /**< (SERCOM_SPI_INTENCLR) Data Register Empty Interrupt Disable Position */
+#define SERCOM_SPI_INTENCLR_DRE_Msk         (_U_(0x1) << SERCOM_SPI_INTENCLR_DRE_Pos)      /**< (SERCOM_SPI_INTENCLR) Data Register Empty Interrupt Disable Mask */
+#define SERCOM_SPI_INTENCLR_DRE             SERCOM_SPI_INTENCLR_DRE_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_INTENCLR_DRE_Msk instead */
+#define SERCOM_SPI_INTENCLR_TXC_Pos         1                                              /**< (SERCOM_SPI_INTENCLR) Transmit Complete Interrupt Disable Position */
+#define SERCOM_SPI_INTENCLR_TXC_Msk         (_U_(0x1) << SERCOM_SPI_INTENCLR_TXC_Pos)      /**< (SERCOM_SPI_INTENCLR) Transmit Complete Interrupt Disable Mask */
+#define SERCOM_SPI_INTENCLR_TXC             SERCOM_SPI_INTENCLR_TXC_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_INTENCLR_TXC_Msk instead */
+#define SERCOM_SPI_INTENCLR_RXC_Pos         2                                              /**< (SERCOM_SPI_INTENCLR) Receive Complete Interrupt Disable Position */
+#define SERCOM_SPI_INTENCLR_RXC_Msk         (_U_(0x1) << SERCOM_SPI_INTENCLR_RXC_Pos)      /**< (SERCOM_SPI_INTENCLR) Receive Complete Interrupt Disable Mask */
+#define SERCOM_SPI_INTENCLR_RXC             SERCOM_SPI_INTENCLR_RXC_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_INTENCLR_RXC_Msk instead */
+#define SERCOM_SPI_INTENCLR_SSL_Pos         3                                              /**< (SERCOM_SPI_INTENCLR) Slave Select Low Interrupt Disable Position */
+#define SERCOM_SPI_INTENCLR_SSL_Msk         (_U_(0x1) << SERCOM_SPI_INTENCLR_SSL_Pos)      /**< (SERCOM_SPI_INTENCLR) Slave Select Low Interrupt Disable Mask */
+#define SERCOM_SPI_INTENCLR_SSL             SERCOM_SPI_INTENCLR_SSL_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_INTENCLR_SSL_Msk instead */
+#define SERCOM_SPI_INTENCLR_ERROR_Pos       7                                              /**< (SERCOM_SPI_INTENCLR) Combined Error Interrupt Disable Position */
+#define SERCOM_SPI_INTENCLR_ERROR_Msk       (_U_(0x1) << SERCOM_SPI_INTENCLR_ERROR_Pos)    /**< (SERCOM_SPI_INTENCLR) Combined Error Interrupt Disable Mask */
+#define SERCOM_SPI_INTENCLR_ERROR           SERCOM_SPI_INTENCLR_ERROR_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_INTENCLR_ERROR_Msk instead */
+#define SERCOM_SPI_INTENCLR_MASK            _U_(0x8F)                                      /**< \deprecated (SERCOM_SPI_INTENCLR) Register MASK  (Use SERCOM_SPI_INTENCLR_Msk instead)  */
+#define SERCOM_SPI_INTENCLR_Msk             _U_(0x8F)                                      /**< (SERCOM_SPI_INTENCLR) Register Mask  */
+
+
+/* -------- SERCOM_USART_INTENCLR : (SERCOM Offset: 0x14) (R/W 8) USART Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DRE:1;                     /**< bit:      0  Data Register Empty Interrupt Disable    */
+    uint8_t  TXC:1;                     /**< bit:      1  Transmit Complete Interrupt Disable      */
+    uint8_t  RXC:1;                     /**< bit:      2  Receive Complete Interrupt Disable       */
+    uint8_t  RXS:1;                     /**< bit:      3  Receive Start Interrupt Disable          */
+    uint8_t  CTSIC:1;                   /**< bit:      4  Clear To Send Input Change Interrupt Disable */
+    uint8_t  RXBRK:1;                   /**< bit:      5  Break Received Interrupt Disable         */
+    uint8_t  :1;                        /**< bit:      6  Reserved */
+    uint8_t  ERROR:1;                   /**< bit:      7  Combined Error Interrupt Disable         */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} SERCOM_USART_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_INTENCLR_OFFSET        (0x14)                                        /**<  (SERCOM_USART_INTENCLR) USART Interrupt Enable Clear  Offset */
+#define SERCOM_USART_INTENCLR_RESETVALUE    _U_(0x00)                                     /**<  (SERCOM_USART_INTENCLR) USART Interrupt Enable Clear  Reset Value */
+
+#define SERCOM_USART_INTENCLR_DRE_Pos       0                                              /**< (SERCOM_USART_INTENCLR) Data Register Empty Interrupt Disable Position */
+#define SERCOM_USART_INTENCLR_DRE_Msk       (_U_(0x1) << SERCOM_USART_INTENCLR_DRE_Pos)    /**< (SERCOM_USART_INTENCLR) Data Register Empty Interrupt Disable Mask */
+#define SERCOM_USART_INTENCLR_DRE           SERCOM_USART_INTENCLR_DRE_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_INTENCLR_DRE_Msk instead */
+#define SERCOM_USART_INTENCLR_TXC_Pos       1                                              /**< (SERCOM_USART_INTENCLR) Transmit Complete Interrupt Disable Position */
+#define SERCOM_USART_INTENCLR_TXC_Msk       (_U_(0x1) << SERCOM_USART_INTENCLR_TXC_Pos)    /**< (SERCOM_USART_INTENCLR) Transmit Complete Interrupt Disable Mask */
+#define SERCOM_USART_INTENCLR_TXC           SERCOM_USART_INTENCLR_TXC_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_INTENCLR_TXC_Msk instead */
+#define SERCOM_USART_INTENCLR_RXC_Pos       2                                              /**< (SERCOM_USART_INTENCLR) Receive Complete Interrupt Disable Position */
+#define SERCOM_USART_INTENCLR_RXC_Msk       (_U_(0x1) << SERCOM_USART_INTENCLR_RXC_Pos)    /**< (SERCOM_USART_INTENCLR) Receive Complete Interrupt Disable Mask */
+#define SERCOM_USART_INTENCLR_RXC           SERCOM_USART_INTENCLR_RXC_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_INTENCLR_RXC_Msk instead */
+#define SERCOM_USART_INTENCLR_RXS_Pos       3                                              /**< (SERCOM_USART_INTENCLR) Receive Start Interrupt Disable Position */
+#define SERCOM_USART_INTENCLR_RXS_Msk       (_U_(0x1) << SERCOM_USART_INTENCLR_RXS_Pos)    /**< (SERCOM_USART_INTENCLR) Receive Start Interrupt Disable Mask */
+#define SERCOM_USART_INTENCLR_RXS           SERCOM_USART_INTENCLR_RXS_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_INTENCLR_RXS_Msk instead */
+#define SERCOM_USART_INTENCLR_CTSIC_Pos     4                                              /**< (SERCOM_USART_INTENCLR) Clear To Send Input Change Interrupt Disable Position */
+#define SERCOM_USART_INTENCLR_CTSIC_Msk     (_U_(0x1) << SERCOM_USART_INTENCLR_CTSIC_Pos)  /**< (SERCOM_USART_INTENCLR) Clear To Send Input Change Interrupt Disable Mask */
+#define SERCOM_USART_INTENCLR_CTSIC         SERCOM_USART_INTENCLR_CTSIC_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_INTENCLR_CTSIC_Msk instead */
+#define SERCOM_USART_INTENCLR_RXBRK_Pos     5                                              /**< (SERCOM_USART_INTENCLR) Break Received Interrupt Disable Position */
+#define SERCOM_USART_INTENCLR_RXBRK_Msk     (_U_(0x1) << SERCOM_USART_INTENCLR_RXBRK_Pos)  /**< (SERCOM_USART_INTENCLR) Break Received Interrupt Disable Mask */
+#define SERCOM_USART_INTENCLR_RXBRK         SERCOM_USART_INTENCLR_RXBRK_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_INTENCLR_RXBRK_Msk instead */
+#define SERCOM_USART_INTENCLR_ERROR_Pos     7                                              /**< (SERCOM_USART_INTENCLR) Combined Error Interrupt Disable Position */
+#define SERCOM_USART_INTENCLR_ERROR_Msk     (_U_(0x1) << SERCOM_USART_INTENCLR_ERROR_Pos)  /**< (SERCOM_USART_INTENCLR) Combined Error Interrupt Disable Mask */
+#define SERCOM_USART_INTENCLR_ERROR         SERCOM_USART_INTENCLR_ERROR_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_INTENCLR_ERROR_Msk instead */
+#define SERCOM_USART_INTENCLR_MASK          _U_(0xBF)                                      /**< \deprecated (SERCOM_USART_INTENCLR) Register MASK  (Use SERCOM_USART_INTENCLR_Msk instead)  */
+#define SERCOM_USART_INTENCLR_Msk           _U_(0xBF)                                      /**< (SERCOM_USART_INTENCLR) Register Mask  */
+
+
+/* -------- SERCOM_I2CM_INTENSET : (SERCOM Offset: 0x16) (R/W 8) I2CM Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  MB:1;                      /**< bit:      0  Master On Bus Interrupt Enable           */
+    uint8_t  SB:1;                      /**< bit:      1  Slave On Bus Interrupt Enable            */
+    uint8_t  :5;                        /**< bit:   2..6  Reserved */
+    uint8_t  ERROR:1;                   /**< bit:      7  Combined Error Interrupt Enable          */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} SERCOM_I2CM_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_INTENSET_OFFSET         (0x16)                                        /**<  (SERCOM_I2CM_INTENSET) I2CM Interrupt Enable Set  Offset */
+#define SERCOM_I2CM_INTENSET_RESETVALUE     _U_(0x00)                                     /**<  (SERCOM_I2CM_INTENSET) I2CM Interrupt Enable Set  Reset Value */
+
+#define SERCOM_I2CM_INTENSET_MB_Pos         0                                              /**< (SERCOM_I2CM_INTENSET) Master On Bus Interrupt Enable Position */
+#define SERCOM_I2CM_INTENSET_MB_Msk         (_U_(0x1) << SERCOM_I2CM_INTENSET_MB_Pos)      /**< (SERCOM_I2CM_INTENSET) Master On Bus Interrupt Enable Mask */
+#define SERCOM_I2CM_INTENSET_MB             SERCOM_I2CM_INTENSET_MB_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_INTENSET_MB_Msk instead */
+#define SERCOM_I2CM_INTENSET_SB_Pos         1                                              /**< (SERCOM_I2CM_INTENSET) Slave On Bus Interrupt Enable Position */
+#define SERCOM_I2CM_INTENSET_SB_Msk         (_U_(0x1) << SERCOM_I2CM_INTENSET_SB_Pos)      /**< (SERCOM_I2CM_INTENSET) Slave On Bus Interrupt Enable Mask */
+#define SERCOM_I2CM_INTENSET_SB             SERCOM_I2CM_INTENSET_SB_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_INTENSET_SB_Msk instead */
+#define SERCOM_I2CM_INTENSET_ERROR_Pos      7                                              /**< (SERCOM_I2CM_INTENSET) Combined Error Interrupt Enable Position */
+#define SERCOM_I2CM_INTENSET_ERROR_Msk      (_U_(0x1) << SERCOM_I2CM_INTENSET_ERROR_Pos)   /**< (SERCOM_I2CM_INTENSET) Combined Error Interrupt Enable Mask */
+#define SERCOM_I2CM_INTENSET_ERROR          SERCOM_I2CM_INTENSET_ERROR_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_INTENSET_ERROR_Msk instead */
+#define SERCOM_I2CM_INTENSET_MASK           _U_(0x83)                                      /**< \deprecated (SERCOM_I2CM_INTENSET) Register MASK  (Use SERCOM_I2CM_INTENSET_Msk instead)  */
+#define SERCOM_I2CM_INTENSET_Msk            _U_(0x83)                                      /**< (SERCOM_I2CM_INTENSET) Register Mask  */
+
+
+/* -------- SERCOM_I2CS_INTENSET : (SERCOM Offset: 0x16) (R/W 8) I2CS Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  PREC:1;                    /**< bit:      0  Stop Received Interrupt Enable           */
+    uint8_t  AMATCH:1;                  /**< bit:      1  Address Match Interrupt Enable           */
+    uint8_t  DRDY:1;                    /**< bit:      2  Data Interrupt Enable                    */
+    uint8_t  :4;                        /**< bit:   3..6  Reserved */
+    uint8_t  ERROR:1;                   /**< bit:      7  Combined Error Interrupt Enable          */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} SERCOM_I2CS_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CS_INTENSET_OFFSET         (0x16)                                        /**<  (SERCOM_I2CS_INTENSET) I2CS Interrupt Enable Set  Offset */
+#define SERCOM_I2CS_INTENSET_RESETVALUE     _U_(0x00)                                     /**<  (SERCOM_I2CS_INTENSET) I2CS Interrupt Enable Set  Reset Value */
+
+#define SERCOM_I2CS_INTENSET_PREC_Pos       0                                              /**< (SERCOM_I2CS_INTENSET) Stop Received Interrupt Enable Position */
+#define SERCOM_I2CS_INTENSET_PREC_Msk       (_U_(0x1) << SERCOM_I2CS_INTENSET_PREC_Pos)    /**< (SERCOM_I2CS_INTENSET) Stop Received Interrupt Enable Mask */
+#define SERCOM_I2CS_INTENSET_PREC           SERCOM_I2CS_INTENSET_PREC_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_INTENSET_PREC_Msk instead */
+#define SERCOM_I2CS_INTENSET_AMATCH_Pos     1                                              /**< (SERCOM_I2CS_INTENSET) Address Match Interrupt Enable Position */
+#define SERCOM_I2CS_INTENSET_AMATCH_Msk     (_U_(0x1) << SERCOM_I2CS_INTENSET_AMATCH_Pos)  /**< (SERCOM_I2CS_INTENSET) Address Match Interrupt Enable Mask */
+#define SERCOM_I2CS_INTENSET_AMATCH         SERCOM_I2CS_INTENSET_AMATCH_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_INTENSET_AMATCH_Msk instead */
+#define SERCOM_I2CS_INTENSET_DRDY_Pos       2                                              /**< (SERCOM_I2CS_INTENSET) Data Interrupt Enable Position */
+#define SERCOM_I2CS_INTENSET_DRDY_Msk       (_U_(0x1) << SERCOM_I2CS_INTENSET_DRDY_Pos)    /**< (SERCOM_I2CS_INTENSET) Data Interrupt Enable Mask */
+#define SERCOM_I2CS_INTENSET_DRDY           SERCOM_I2CS_INTENSET_DRDY_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_INTENSET_DRDY_Msk instead */
+#define SERCOM_I2CS_INTENSET_ERROR_Pos      7                                              /**< (SERCOM_I2CS_INTENSET) Combined Error Interrupt Enable Position */
+#define SERCOM_I2CS_INTENSET_ERROR_Msk      (_U_(0x1) << SERCOM_I2CS_INTENSET_ERROR_Pos)   /**< (SERCOM_I2CS_INTENSET) Combined Error Interrupt Enable Mask */
+#define SERCOM_I2CS_INTENSET_ERROR          SERCOM_I2CS_INTENSET_ERROR_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_INTENSET_ERROR_Msk instead */
+#define SERCOM_I2CS_INTENSET_MASK           _U_(0x87)                                      /**< \deprecated (SERCOM_I2CS_INTENSET) Register MASK  (Use SERCOM_I2CS_INTENSET_Msk instead)  */
+#define SERCOM_I2CS_INTENSET_Msk            _U_(0x87)                                      /**< (SERCOM_I2CS_INTENSET) Register Mask  */
+
+
+/* -------- SERCOM_SPI_INTENSET : (SERCOM Offset: 0x16) (R/W 8) SPI Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DRE:1;                     /**< bit:      0  Data Register Empty Interrupt Enable     */
+    uint8_t  TXC:1;                     /**< bit:      1  Transmit Complete Interrupt Enable       */
+    uint8_t  RXC:1;                     /**< bit:      2  Receive Complete Interrupt Enable        */
+    uint8_t  SSL:1;                     /**< bit:      3  Slave Select Low Interrupt Enable        */
+    uint8_t  :3;                        /**< bit:   4..6  Reserved */
+    uint8_t  ERROR:1;                   /**< bit:      7  Combined Error Interrupt Enable          */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} SERCOM_SPI_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_INTENSET_OFFSET          (0x16)                                        /**<  (SERCOM_SPI_INTENSET) SPI Interrupt Enable Set  Offset */
+#define SERCOM_SPI_INTENSET_RESETVALUE      _U_(0x00)                                     /**<  (SERCOM_SPI_INTENSET) SPI Interrupt Enable Set  Reset Value */
+
+#define SERCOM_SPI_INTENSET_DRE_Pos         0                                              /**< (SERCOM_SPI_INTENSET) Data Register Empty Interrupt Enable Position */
+#define SERCOM_SPI_INTENSET_DRE_Msk         (_U_(0x1) << SERCOM_SPI_INTENSET_DRE_Pos)      /**< (SERCOM_SPI_INTENSET) Data Register Empty Interrupt Enable Mask */
+#define SERCOM_SPI_INTENSET_DRE             SERCOM_SPI_INTENSET_DRE_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_INTENSET_DRE_Msk instead */
+#define SERCOM_SPI_INTENSET_TXC_Pos         1                                              /**< (SERCOM_SPI_INTENSET) Transmit Complete Interrupt Enable Position */
+#define SERCOM_SPI_INTENSET_TXC_Msk         (_U_(0x1) << SERCOM_SPI_INTENSET_TXC_Pos)      /**< (SERCOM_SPI_INTENSET) Transmit Complete Interrupt Enable Mask */
+#define SERCOM_SPI_INTENSET_TXC             SERCOM_SPI_INTENSET_TXC_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_INTENSET_TXC_Msk instead */
+#define SERCOM_SPI_INTENSET_RXC_Pos         2                                              /**< (SERCOM_SPI_INTENSET) Receive Complete Interrupt Enable Position */
+#define SERCOM_SPI_INTENSET_RXC_Msk         (_U_(0x1) << SERCOM_SPI_INTENSET_RXC_Pos)      /**< (SERCOM_SPI_INTENSET) Receive Complete Interrupt Enable Mask */
+#define SERCOM_SPI_INTENSET_RXC             SERCOM_SPI_INTENSET_RXC_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_INTENSET_RXC_Msk instead */
+#define SERCOM_SPI_INTENSET_SSL_Pos         3                                              /**< (SERCOM_SPI_INTENSET) Slave Select Low Interrupt Enable Position */
+#define SERCOM_SPI_INTENSET_SSL_Msk         (_U_(0x1) << SERCOM_SPI_INTENSET_SSL_Pos)      /**< (SERCOM_SPI_INTENSET) Slave Select Low Interrupt Enable Mask */
+#define SERCOM_SPI_INTENSET_SSL             SERCOM_SPI_INTENSET_SSL_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_INTENSET_SSL_Msk instead */
+#define SERCOM_SPI_INTENSET_ERROR_Pos       7                                              /**< (SERCOM_SPI_INTENSET) Combined Error Interrupt Enable Position */
+#define SERCOM_SPI_INTENSET_ERROR_Msk       (_U_(0x1) << SERCOM_SPI_INTENSET_ERROR_Pos)    /**< (SERCOM_SPI_INTENSET) Combined Error Interrupt Enable Mask */
+#define SERCOM_SPI_INTENSET_ERROR           SERCOM_SPI_INTENSET_ERROR_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_INTENSET_ERROR_Msk instead */
+#define SERCOM_SPI_INTENSET_MASK            _U_(0x8F)                                      /**< \deprecated (SERCOM_SPI_INTENSET) Register MASK  (Use SERCOM_SPI_INTENSET_Msk instead)  */
+#define SERCOM_SPI_INTENSET_Msk             _U_(0x8F)                                      /**< (SERCOM_SPI_INTENSET) Register Mask  */
+
+
+/* -------- SERCOM_USART_INTENSET : (SERCOM Offset: 0x16) (R/W 8) USART Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DRE:1;                     /**< bit:      0  Data Register Empty Interrupt Enable     */
+    uint8_t  TXC:1;                     /**< bit:      1  Transmit Complete Interrupt Enable       */
+    uint8_t  RXC:1;                     /**< bit:      2  Receive Complete Interrupt Enable        */
+    uint8_t  RXS:1;                     /**< bit:      3  Receive Start Interrupt Enable           */
+    uint8_t  CTSIC:1;                   /**< bit:      4  Clear To Send Input Change Interrupt Enable */
+    uint8_t  RXBRK:1;                   /**< bit:      5  Break Received Interrupt Enable          */
+    uint8_t  :1;                        /**< bit:      6  Reserved */
+    uint8_t  ERROR:1;                   /**< bit:      7  Combined Error Interrupt Enable          */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} SERCOM_USART_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_INTENSET_OFFSET        (0x16)                                        /**<  (SERCOM_USART_INTENSET) USART Interrupt Enable Set  Offset */
+#define SERCOM_USART_INTENSET_RESETVALUE    _U_(0x00)                                     /**<  (SERCOM_USART_INTENSET) USART Interrupt Enable Set  Reset Value */
+
+#define SERCOM_USART_INTENSET_DRE_Pos       0                                              /**< (SERCOM_USART_INTENSET) Data Register Empty Interrupt Enable Position */
+#define SERCOM_USART_INTENSET_DRE_Msk       (_U_(0x1) << SERCOM_USART_INTENSET_DRE_Pos)    /**< (SERCOM_USART_INTENSET) Data Register Empty Interrupt Enable Mask */
+#define SERCOM_USART_INTENSET_DRE           SERCOM_USART_INTENSET_DRE_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_INTENSET_DRE_Msk instead */
+#define SERCOM_USART_INTENSET_TXC_Pos       1                                              /**< (SERCOM_USART_INTENSET) Transmit Complete Interrupt Enable Position */
+#define SERCOM_USART_INTENSET_TXC_Msk       (_U_(0x1) << SERCOM_USART_INTENSET_TXC_Pos)    /**< (SERCOM_USART_INTENSET) Transmit Complete Interrupt Enable Mask */
+#define SERCOM_USART_INTENSET_TXC           SERCOM_USART_INTENSET_TXC_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_INTENSET_TXC_Msk instead */
+#define SERCOM_USART_INTENSET_RXC_Pos       2                                              /**< (SERCOM_USART_INTENSET) Receive Complete Interrupt Enable Position */
+#define SERCOM_USART_INTENSET_RXC_Msk       (_U_(0x1) << SERCOM_USART_INTENSET_RXC_Pos)    /**< (SERCOM_USART_INTENSET) Receive Complete Interrupt Enable Mask */
+#define SERCOM_USART_INTENSET_RXC           SERCOM_USART_INTENSET_RXC_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_INTENSET_RXC_Msk instead */
+#define SERCOM_USART_INTENSET_RXS_Pos       3                                              /**< (SERCOM_USART_INTENSET) Receive Start Interrupt Enable Position */
+#define SERCOM_USART_INTENSET_RXS_Msk       (_U_(0x1) << SERCOM_USART_INTENSET_RXS_Pos)    /**< (SERCOM_USART_INTENSET) Receive Start Interrupt Enable Mask */
+#define SERCOM_USART_INTENSET_RXS           SERCOM_USART_INTENSET_RXS_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_INTENSET_RXS_Msk instead */
+#define SERCOM_USART_INTENSET_CTSIC_Pos     4                                              /**< (SERCOM_USART_INTENSET) Clear To Send Input Change Interrupt Enable Position */
+#define SERCOM_USART_INTENSET_CTSIC_Msk     (_U_(0x1) << SERCOM_USART_INTENSET_CTSIC_Pos)  /**< (SERCOM_USART_INTENSET) Clear To Send Input Change Interrupt Enable Mask */
+#define SERCOM_USART_INTENSET_CTSIC         SERCOM_USART_INTENSET_CTSIC_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_INTENSET_CTSIC_Msk instead */
+#define SERCOM_USART_INTENSET_RXBRK_Pos     5                                              /**< (SERCOM_USART_INTENSET) Break Received Interrupt Enable Position */
+#define SERCOM_USART_INTENSET_RXBRK_Msk     (_U_(0x1) << SERCOM_USART_INTENSET_RXBRK_Pos)  /**< (SERCOM_USART_INTENSET) Break Received Interrupt Enable Mask */
+#define SERCOM_USART_INTENSET_RXBRK         SERCOM_USART_INTENSET_RXBRK_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_INTENSET_RXBRK_Msk instead */
+#define SERCOM_USART_INTENSET_ERROR_Pos     7                                              /**< (SERCOM_USART_INTENSET) Combined Error Interrupt Enable Position */
+#define SERCOM_USART_INTENSET_ERROR_Msk     (_U_(0x1) << SERCOM_USART_INTENSET_ERROR_Pos)  /**< (SERCOM_USART_INTENSET) Combined Error Interrupt Enable Mask */
+#define SERCOM_USART_INTENSET_ERROR         SERCOM_USART_INTENSET_ERROR_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_INTENSET_ERROR_Msk instead */
+#define SERCOM_USART_INTENSET_MASK          _U_(0xBF)                                      /**< \deprecated (SERCOM_USART_INTENSET) Register MASK  (Use SERCOM_USART_INTENSET_Msk instead)  */
+#define SERCOM_USART_INTENSET_Msk           _U_(0xBF)                                      /**< (SERCOM_USART_INTENSET) Register Mask  */
+
+
+/* -------- SERCOM_I2CM_INTFLAG : (SERCOM Offset: 0x18) (R/W 8) I2CM Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t MB:1;                      /**< bit:      0  Master On Bus Interrupt                  */
+    __I uint8_t SB:1;                      /**< bit:      1  Slave On Bus Interrupt                   */
+    __I uint8_t :5;                        /**< bit:   2..6  Reserved */
+    __I uint8_t ERROR:1;                   /**< bit:      7  Combined Error Interrupt                 */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} SERCOM_I2CM_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_INTFLAG_OFFSET          (0x18)                                        /**<  (SERCOM_I2CM_INTFLAG) I2CM Interrupt Flag Status and Clear  Offset */
+#define SERCOM_I2CM_INTFLAG_RESETVALUE      _U_(0x00)                                     /**<  (SERCOM_I2CM_INTFLAG) I2CM Interrupt Flag Status and Clear  Reset Value */
+
+#define SERCOM_I2CM_INTFLAG_MB_Pos          0                                              /**< (SERCOM_I2CM_INTFLAG) Master On Bus Interrupt Position */
+#define SERCOM_I2CM_INTFLAG_MB_Msk          (_U_(0x1) << SERCOM_I2CM_INTFLAG_MB_Pos)       /**< (SERCOM_I2CM_INTFLAG) Master On Bus Interrupt Mask */
+#define SERCOM_I2CM_INTFLAG_MB              SERCOM_I2CM_INTFLAG_MB_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_INTFLAG_MB_Msk instead */
+#define SERCOM_I2CM_INTFLAG_SB_Pos          1                                              /**< (SERCOM_I2CM_INTFLAG) Slave On Bus Interrupt Position */
+#define SERCOM_I2CM_INTFLAG_SB_Msk          (_U_(0x1) << SERCOM_I2CM_INTFLAG_SB_Pos)       /**< (SERCOM_I2CM_INTFLAG) Slave On Bus Interrupt Mask */
+#define SERCOM_I2CM_INTFLAG_SB              SERCOM_I2CM_INTFLAG_SB_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_INTFLAG_SB_Msk instead */
+#define SERCOM_I2CM_INTFLAG_ERROR_Pos       7                                              /**< (SERCOM_I2CM_INTFLAG) Combined Error Interrupt Position */
+#define SERCOM_I2CM_INTFLAG_ERROR_Msk       (_U_(0x1) << SERCOM_I2CM_INTFLAG_ERROR_Pos)    /**< (SERCOM_I2CM_INTFLAG) Combined Error Interrupt Mask */
+#define SERCOM_I2CM_INTFLAG_ERROR           SERCOM_I2CM_INTFLAG_ERROR_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_INTFLAG_ERROR_Msk instead */
+#define SERCOM_I2CM_INTFLAG_MASK            _U_(0x83)                                      /**< \deprecated (SERCOM_I2CM_INTFLAG) Register MASK  (Use SERCOM_I2CM_INTFLAG_Msk instead)  */
+#define SERCOM_I2CM_INTFLAG_Msk             _U_(0x83)                                      /**< (SERCOM_I2CM_INTFLAG) Register Mask  */
+
+
+/* -------- SERCOM_I2CS_INTFLAG : (SERCOM Offset: 0x18) (R/W 8) I2CS Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t PREC:1;                    /**< bit:      0  Stop Received Interrupt                  */
+    __I uint8_t AMATCH:1;                  /**< bit:      1  Address Match Interrupt                  */
+    __I uint8_t DRDY:1;                    /**< bit:      2  Data Interrupt                           */
+    __I uint8_t :4;                        /**< bit:   3..6  Reserved */
+    __I uint8_t ERROR:1;                   /**< bit:      7  Combined Error Interrupt                 */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} SERCOM_I2CS_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CS_INTFLAG_OFFSET          (0x18)                                        /**<  (SERCOM_I2CS_INTFLAG) I2CS Interrupt Flag Status and Clear  Offset */
+#define SERCOM_I2CS_INTFLAG_RESETVALUE      _U_(0x00)                                     /**<  (SERCOM_I2CS_INTFLAG) I2CS Interrupt Flag Status and Clear  Reset Value */
+
+#define SERCOM_I2CS_INTFLAG_PREC_Pos        0                                              /**< (SERCOM_I2CS_INTFLAG) Stop Received Interrupt Position */
+#define SERCOM_I2CS_INTFLAG_PREC_Msk        (_U_(0x1) << SERCOM_I2CS_INTFLAG_PREC_Pos)     /**< (SERCOM_I2CS_INTFLAG) Stop Received Interrupt Mask */
+#define SERCOM_I2CS_INTFLAG_PREC            SERCOM_I2CS_INTFLAG_PREC_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_INTFLAG_PREC_Msk instead */
+#define SERCOM_I2CS_INTFLAG_AMATCH_Pos      1                                              /**< (SERCOM_I2CS_INTFLAG) Address Match Interrupt Position */
+#define SERCOM_I2CS_INTFLAG_AMATCH_Msk      (_U_(0x1) << SERCOM_I2CS_INTFLAG_AMATCH_Pos)   /**< (SERCOM_I2CS_INTFLAG) Address Match Interrupt Mask */
+#define SERCOM_I2CS_INTFLAG_AMATCH          SERCOM_I2CS_INTFLAG_AMATCH_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_INTFLAG_AMATCH_Msk instead */
+#define SERCOM_I2CS_INTFLAG_DRDY_Pos        2                                              /**< (SERCOM_I2CS_INTFLAG) Data Interrupt Position */
+#define SERCOM_I2CS_INTFLAG_DRDY_Msk        (_U_(0x1) << SERCOM_I2CS_INTFLAG_DRDY_Pos)     /**< (SERCOM_I2CS_INTFLAG) Data Interrupt Mask */
+#define SERCOM_I2CS_INTFLAG_DRDY            SERCOM_I2CS_INTFLAG_DRDY_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_INTFLAG_DRDY_Msk instead */
+#define SERCOM_I2CS_INTFLAG_ERROR_Pos       7                                              /**< (SERCOM_I2CS_INTFLAG) Combined Error Interrupt Position */
+#define SERCOM_I2CS_INTFLAG_ERROR_Msk       (_U_(0x1) << SERCOM_I2CS_INTFLAG_ERROR_Pos)    /**< (SERCOM_I2CS_INTFLAG) Combined Error Interrupt Mask */
+#define SERCOM_I2CS_INTFLAG_ERROR           SERCOM_I2CS_INTFLAG_ERROR_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_INTFLAG_ERROR_Msk instead */
+#define SERCOM_I2CS_INTFLAG_MASK            _U_(0x87)                                      /**< \deprecated (SERCOM_I2CS_INTFLAG) Register MASK  (Use SERCOM_I2CS_INTFLAG_Msk instead)  */
+#define SERCOM_I2CS_INTFLAG_Msk             _U_(0x87)                                      /**< (SERCOM_I2CS_INTFLAG) Register Mask  */
+
+
+/* -------- SERCOM_SPI_INTFLAG : (SERCOM Offset: 0x18) (R/W 8) SPI Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t DRE:1;                     /**< bit:      0  Data Register Empty Interrupt            */
+    __I uint8_t TXC:1;                     /**< bit:      1  Transmit Complete Interrupt              */
+    __I uint8_t RXC:1;                     /**< bit:      2  Receive Complete Interrupt               */
+    __I uint8_t SSL:1;                     /**< bit:      3  Slave Select Low Interrupt Flag          */
+    __I uint8_t :3;                        /**< bit:   4..6  Reserved */
+    __I uint8_t ERROR:1;                   /**< bit:      7  Combined Error Interrupt                 */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} SERCOM_SPI_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_INTFLAG_OFFSET           (0x18)                                        /**<  (SERCOM_SPI_INTFLAG) SPI Interrupt Flag Status and Clear  Offset */
+#define SERCOM_SPI_INTFLAG_RESETVALUE       _U_(0x00)                                     /**<  (SERCOM_SPI_INTFLAG) SPI Interrupt Flag Status and Clear  Reset Value */
+
+#define SERCOM_SPI_INTFLAG_DRE_Pos          0                                              /**< (SERCOM_SPI_INTFLAG) Data Register Empty Interrupt Position */
+#define SERCOM_SPI_INTFLAG_DRE_Msk          (_U_(0x1) << SERCOM_SPI_INTFLAG_DRE_Pos)       /**< (SERCOM_SPI_INTFLAG) Data Register Empty Interrupt Mask */
+#define SERCOM_SPI_INTFLAG_DRE              SERCOM_SPI_INTFLAG_DRE_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_INTFLAG_DRE_Msk instead */
+#define SERCOM_SPI_INTFLAG_TXC_Pos          1                                              /**< (SERCOM_SPI_INTFLAG) Transmit Complete Interrupt Position */
+#define SERCOM_SPI_INTFLAG_TXC_Msk          (_U_(0x1) << SERCOM_SPI_INTFLAG_TXC_Pos)       /**< (SERCOM_SPI_INTFLAG) Transmit Complete Interrupt Mask */
+#define SERCOM_SPI_INTFLAG_TXC              SERCOM_SPI_INTFLAG_TXC_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_INTFLAG_TXC_Msk instead */
+#define SERCOM_SPI_INTFLAG_RXC_Pos          2                                              /**< (SERCOM_SPI_INTFLAG) Receive Complete Interrupt Position */
+#define SERCOM_SPI_INTFLAG_RXC_Msk          (_U_(0x1) << SERCOM_SPI_INTFLAG_RXC_Pos)       /**< (SERCOM_SPI_INTFLAG) Receive Complete Interrupt Mask */
+#define SERCOM_SPI_INTFLAG_RXC              SERCOM_SPI_INTFLAG_RXC_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_INTFLAG_RXC_Msk instead */
+#define SERCOM_SPI_INTFLAG_SSL_Pos          3                                              /**< (SERCOM_SPI_INTFLAG) Slave Select Low Interrupt Flag Position */
+#define SERCOM_SPI_INTFLAG_SSL_Msk          (_U_(0x1) << SERCOM_SPI_INTFLAG_SSL_Pos)       /**< (SERCOM_SPI_INTFLAG) Slave Select Low Interrupt Flag Mask */
+#define SERCOM_SPI_INTFLAG_SSL              SERCOM_SPI_INTFLAG_SSL_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_INTFLAG_SSL_Msk instead */
+#define SERCOM_SPI_INTFLAG_ERROR_Pos        7                                              /**< (SERCOM_SPI_INTFLAG) Combined Error Interrupt Position */
+#define SERCOM_SPI_INTFLAG_ERROR_Msk        (_U_(0x1) << SERCOM_SPI_INTFLAG_ERROR_Pos)     /**< (SERCOM_SPI_INTFLAG) Combined Error Interrupt Mask */
+#define SERCOM_SPI_INTFLAG_ERROR            SERCOM_SPI_INTFLAG_ERROR_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_INTFLAG_ERROR_Msk instead */
+#define SERCOM_SPI_INTFLAG_MASK             _U_(0x8F)                                      /**< \deprecated (SERCOM_SPI_INTFLAG) Register MASK  (Use SERCOM_SPI_INTFLAG_Msk instead)  */
+#define SERCOM_SPI_INTFLAG_Msk              _U_(0x8F)                                      /**< (SERCOM_SPI_INTFLAG) Register Mask  */
+
+
+/* -------- SERCOM_USART_INTFLAG : (SERCOM Offset: 0x18) (R/W 8) USART Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t DRE:1;                     /**< bit:      0  Data Register Empty Interrupt            */
+    __I uint8_t TXC:1;                     /**< bit:      1  Transmit Complete Interrupt              */
+    __I uint8_t RXC:1;                     /**< bit:      2  Receive Complete Interrupt               */
+    __I uint8_t RXS:1;                     /**< bit:      3  Receive Start Interrupt                  */
+    __I uint8_t CTSIC:1;                   /**< bit:      4  Clear To Send Input Change Interrupt     */
+    __I uint8_t RXBRK:1;                   /**< bit:      5  Break Received Interrupt                 */
+    __I uint8_t :1;                        /**< bit:      6  Reserved */
+    __I uint8_t ERROR:1;                   /**< bit:      7  Combined Error Interrupt                 */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} SERCOM_USART_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_INTFLAG_OFFSET         (0x18)                                        /**<  (SERCOM_USART_INTFLAG) USART Interrupt Flag Status and Clear  Offset */
+#define SERCOM_USART_INTFLAG_RESETVALUE     _U_(0x00)                                     /**<  (SERCOM_USART_INTFLAG) USART Interrupt Flag Status and Clear  Reset Value */
+
+#define SERCOM_USART_INTFLAG_DRE_Pos        0                                              /**< (SERCOM_USART_INTFLAG) Data Register Empty Interrupt Position */
+#define SERCOM_USART_INTFLAG_DRE_Msk        (_U_(0x1) << SERCOM_USART_INTFLAG_DRE_Pos)     /**< (SERCOM_USART_INTFLAG) Data Register Empty Interrupt Mask */
+#define SERCOM_USART_INTFLAG_DRE            SERCOM_USART_INTFLAG_DRE_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_INTFLAG_DRE_Msk instead */
+#define SERCOM_USART_INTFLAG_TXC_Pos        1                                              /**< (SERCOM_USART_INTFLAG) Transmit Complete Interrupt Position */
+#define SERCOM_USART_INTFLAG_TXC_Msk        (_U_(0x1) << SERCOM_USART_INTFLAG_TXC_Pos)     /**< (SERCOM_USART_INTFLAG) Transmit Complete Interrupt Mask */
+#define SERCOM_USART_INTFLAG_TXC            SERCOM_USART_INTFLAG_TXC_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_INTFLAG_TXC_Msk instead */
+#define SERCOM_USART_INTFLAG_RXC_Pos        2                                              /**< (SERCOM_USART_INTFLAG) Receive Complete Interrupt Position */
+#define SERCOM_USART_INTFLAG_RXC_Msk        (_U_(0x1) << SERCOM_USART_INTFLAG_RXC_Pos)     /**< (SERCOM_USART_INTFLAG) Receive Complete Interrupt Mask */
+#define SERCOM_USART_INTFLAG_RXC            SERCOM_USART_INTFLAG_RXC_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_INTFLAG_RXC_Msk instead */
+#define SERCOM_USART_INTFLAG_RXS_Pos        3                                              /**< (SERCOM_USART_INTFLAG) Receive Start Interrupt Position */
+#define SERCOM_USART_INTFLAG_RXS_Msk        (_U_(0x1) << SERCOM_USART_INTFLAG_RXS_Pos)     /**< (SERCOM_USART_INTFLAG) Receive Start Interrupt Mask */
+#define SERCOM_USART_INTFLAG_RXS            SERCOM_USART_INTFLAG_RXS_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_INTFLAG_RXS_Msk instead */
+#define SERCOM_USART_INTFLAG_CTSIC_Pos      4                                              /**< (SERCOM_USART_INTFLAG) Clear To Send Input Change Interrupt Position */
+#define SERCOM_USART_INTFLAG_CTSIC_Msk      (_U_(0x1) << SERCOM_USART_INTFLAG_CTSIC_Pos)   /**< (SERCOM_USART_INTFLAG) Clear To Send Input Change Interrupt Mask */
+#define SERCOM_USART_INTFLAG_CTSIC          SERCOM_USART_INTFLAG_CTSIC_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_INTFLAG_CTSIC_Msk instead */
+#define SERCOM_USART_INTFLAG_RXBRK_Pos      5                                              /**< (SERCOM_USART_INTFLAG) Break Received Interrupt Position */
+#define SERCOM_USART_INTFLAG_RXBRK_Msk      (_U_(0x1) << SERCOM_USART_INTFLAG_RXBRK_Pos)   /**< (SERCOM_USART_INTFLAG) Break Received Interrupt Mask */
+#define SERCOM_USART_INTFLAG_RXBRK          SERCOM_USART_INTFLAG_RXBRK_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_INTFLAG_RXBRK_Msk instead */
+#define SERCOM_USART_INTFLAG_ERROR_Pos      7                                              /**< (SERCOM_USART_INTFLAG) Combined Error Interrupt Position */
+#define SERCOM_USART_INTFLAG_ERROR_Msk      (_U_(0x1) << SERCOM_USART_INTFLAG_ERROR_Pos)   /**< (SERCOM_USART_INTFLAG) Combined Error Interrupt Mask */
+#define SERCOM_USART_INTFLAG_ERROR          SERCOM_USART_INTFLAG_ERROR_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_INTFLAG_ERROR_Msk instead */
+#define SERCOM_USART_INTFLAG_MASK           _U_(0xBF)                                      /**< \deprecated (SERCOM_USART_INTFLAG) Register MASK  (Use SERCOM_USART_INTFLAG_Msk instead)  */
+#define SERCOM_USART_INTFLAG_Msk            _U_(0xBF)                                      /**< (SERCOM_USART_INTFLAG) Register Mask  */
+
+
+/* -------- SERCOM_I2CM_STATUS : (SERCOM Offset: 0x1a) (R/W 16) I2CM Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t BUSERR:1;                  /**< bit:      0  Bus Error                                */
+    uint16_t ARBLOST:1;                 /**< bit:      1  Arbitration Lost                         */
+    uint16_t RXNACK:1;                  /**< bit:      2  Received Not Acknowledge                 */
+    uint16_t :1;                        /**< bit:      3  Reserved */
+    uint16_t BUSSTATE:2;                /**< bit:   4..5  Bus State                                */
+    uint16_t LOWTOUT:1;                 /**< bit:      6  SCL Low Timeout                          */
+    uint16_t CLKHOLD:1;                 /**< bit:      7  Clock Hold                               */
+    uint16_t MEXTTOUT:1;                /**< bit:      8  Master SCL Low Extend Timeout            */
+    uint16_t SEXTTOUT:1;                /**< bit:      9  Slave SCL Low Extend Timeout             */
+    uint16_t LENERR:1;                  /**< bit:     10  Length Error                             */
+    uint16_t :5;                        /**< bit: 11..15  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} SERCOM_I2CM_STATUS_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_STATUS_OFFSET           (0x1A)                                        /**<  (SERCOM_I2CM_STATUS) I2CM Status  Offset */
+#define SERCOM_I2CM_STATUS_RESETVALUE       _U_(0x00)                                     /**<  (SERCOM_I2CM_STATUS) I2CM Status  Reset Value */
+
+#define SERCOM_I2CM_STATUS_BUSERR_Pos       0                                              /**< (SERCOM_I2CM_STATUS) Bus Error Position */
+#define SERCOM_I2CM_STATUS_BUSERR_Msk       (_U_(0x1) << SERCOM_I2CM_STATUS_BUSERR_Pos)    /**< (SERCOM_I2CM_STATUS) Bus Error Mask */
+#define SERCOM_I2CM_STATUS_BUSERR           SERCOM_I2CM_STATUS_BUSERR_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_STATUS_BUSERR_Msk instead */
+#define SERCOM_I2CM_STATUS_ARBLOST_Pos      1                                              /**< (SERCOM_I2CM_STATUS) Arbitration Lost Position */
+#define SERCOM_I2CM_STATUS_ARBLOST_Msk      (_U_(0x1) << SERCOM_I2CM_STATUS_ARBLOST_Pos)   /**< (SERCOM_I2CM_STATUS) Arbitration Lost Mask */
+#define SERCOM_I2CM_STATUS_ARBLOST          SERCOM_I2CM_STATUS_ARBLOST_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_STATUS_ARBLOST_Msk instead */
+#define SERCOM_I2CM_STATUS_RXNACK_Pos       2                                              /**< (SERCOM_I2CM_STATUS) Received Not Acknowledge Position */
+#define SERCOM_I2CM_STATUS_RXNACK_Msk       (_U_(0x1) << SERCOM_I2CM_STATUS_RXNACK_Pos)    /**< (SERCOM_I2CM_STATUS) Received Not Acknowledge Mask */
+#define SERCOM_I2CM_STATUS_RXNACK           SERCOM_I2CM_STATUS_RXNACK_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_STATUS_RXNACK_Msk instead */
+#define SERCOM_I2CM_STATUS_BUSSTATE_Pos     4                                              /**< (SERCOM_I2CM_STATUS) Bus State Position */
+#define SERCOM_I2CM_STATUS_BUSSTATE_Msk     (_U_(0x3) << SERCOM_I2CM_STATUS_BUSSTATE_Pos)  /**< (SERCOM_I2CM_STATUS) Bus State Mask */
+#define SERCOM_I2CM_STATUS_BUSSTATE(value)  (SERCOM_I2CM_STATUS_BUSSTATE_Msk & ((value) << SERCOM_I2CM_STATUS_BUSSTATE_Pos))
+#define SERCOM_I2CM_STATUS_LOWTOUT_Pos      6                                              /**< (SERCOM_I2CM_STATUS) SCL Low Timeout Position */
+#define SERCOM_I2CM_STATUS_LOWTOUT_Msk      (_U_(0x1) << SERCOM_I2CM_STATUS_LOWTOUT_Pos)   /**< (SERCOM_I2CM_STATUS) SCL Low Timeout Mask */
+#define SERCOM_I2CM_STATUS_LOWTOUT          SERCOM_I2CM_STATUS_LOWTOUT_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_STATUS_LOWTOUT_Msk instead */
+#define SERCOM_I2CM_STATUS_CLKHOLD_Pos      7                                              /**< (SERCOM_I2CM_STATUS) Clock Hold Position */
+#define SERCOM_I2CM_STATUS_CLKHOLD_Msk      (_U_(0x1) << SERCOM_I2CM_STATUS_CLKHOLD_Pos)   /**< (SERCOM_I2CM_STATUS) Clock Hold Mask */
+#define SERCOM_I2CM_STATUS_CLKHOLD          SERCOM_I2CM_STATUS_CLKHOLD_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_STATUS_CLKHOLD_Msk instead */
+#define SERCOM_I2CM_STATUS_MEXTTOUT_Pos     8                                              /**< (SERCOM_I2CM_STATUS) Master SCL Low Extend Timeout Position */
+#define SERCOM_I2CM_STATUS_MEXTTOUT_Msk     (_U_(0x1) << SERCOM_I2CM_STATUS_MEXTTOUT_Pos)  /**< (SERCOM_I2CM_STATUS) Master SCL Low Extend Timeout Mask */
+#define SERCOM_I2CM_STATUS_MEXTTOUT         SERCOM_I2CM_STATUS_MEXTTOUT_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_STATUS_MEXTTOUT_Msk instead */
+#define SERCOM_I2CM_STATUS_SEXTTOUT_Pos     9                                              /**< (SERCOM_I2CM_STATUS) Slave SCL Low Extend Timeout Position */
+#define SERCOM_I2CM_STATUS_SEXTTOUT_Msk     (_U_(0x1) << SERCOM_I2CM_STATUS_SEXTTOUT_Pos)  /**< (SERCOM_I2CM_STATUS) Slave SCL Low Extend Timeout Mask */
+#define SERCOM_I2CM_STATUS_SEXTTOUT         SERCOM_I2CM_STATUS_SEXTTOUT_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_STATUS_SEXTTOUT_Msk instead */
+#define SERCOM_I2CM_STATUS_LENERR_Pos       10                                             /**< (SERCOM_I2CM_STATUS) Length Error Position */
+#define SERCOM_I2CM_STATUS_LENERR_Msk       (_U_(0x1) << SERCOM_I2CM_STATUS_LENERR_Pos)    /**< (SERCOM_I2CM_STATUS) Length Error Mask */
+#define SERCOM_I2CM_STATUS_LENERR           SERCOM_I2CM_STATUS_LENERR_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_STATUS_LENERR_Msk instead */
+#define SERCOM_I2CM_STATUS_MASK             _U_(0x7F7)                                     /**< \deprecated (SERCOM_I2CM_STATUS) Register MASK  (Use SERCOM_I2CM_STATUS_Msk instead)  */
+#define SERCOM_I2CM_STATUS_Msk              _U_(0x7F7)                                     /**< (SERCOM_I2CM_STATUS) Register Mask  */
+
+
+/* -------- SERCOM_I2CS_STATUS : (SERCOM Offset: 0x1a) (R/W 16) I2CS Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t BUSERR:1;                  /**< bit:      0  Bus Error                                */
+    uint16_t COLL:1;                    /**< bit:      1  Transmit Collision                       */
+    uint16_t RXNACK:1;                  /**< bit:      2  Received Not Acknowledge                 */
+    uint16_t DIR:1;                     /**< bit:      3  Read/Write Direction                     */
+    uint16_t SR:1;                      /**< bit:      4  Repeated Start                           */
+    uint16_t :1;                        /**< bit:      5  Reserved */
+    uint16_t LOWTOUT:1;                 /**< bit:      6  SCL Low Timeout                          */
+    uint16_t CLKHOLD:1;                 /**< bit:      7  Clock Hold                               */
+    uint16_t :1;                        /**< bit:      8  Reserved */
+    uint16_t SEXTTOUT:1;                /**< bit:      9  Slave SCL Low Extend Timeout             */
+    uint16_t HS:1;                      /**< bit:     10  High Speed                               */
+    uint16_t :5;                        /**< bit: 11..15  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} SERCOM_I2CS_STATUS_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CS_STATUS_OFFSET           (0x1A)                                        /**<  (SERCOM_I2CS_STATUS) I2CS Status  Offset */
+#define SERCOM_I2CS_STATUS_RESETVALUE       _U_(0x00)                                     /**<  (SERCOM_I2CS_STATUS) I2CS Status  Reset Value */
+
+#define SERCOM_I2CS_STATUS_BUSERR_Pos       0                                              /**< (SERCOM_I2CS_STATUS) Bus Error Position */
+#define SERCOM_I2CS_STATUS_BUSERR_Msk       (_U_(0x1) << SERCOM_I2CS_STATUS_BUSERR_Pos)    /**< (SERCOM_I2CS_STATUS) Bus Error Mask */
+#define SERCOM_I2CS_STATUS_BUSERR           SERCOM_I2CS_STATUS_BUSERR_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_STATUS_BUSERR_Msk instead */
+#define SERCOM_I2CS_STATUS_COLL_Pos         1                                              /**< (SERCOM_I2CS_STATUS) Transmit Collision Position */
+#define SERCOM_I2CS_STATUS_COLL_Msk         (_U_(0x1) << SERCOM_I2CS_STATUS_COLL_Pos)      /**< (SERCOM_I2CS_STATUS) Transmit Collision Mask */
+#define SERCOM_I2CS_STATUS_COLL             SERCOM_I2CS_STATUS_COLL_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_STATUS_COLL_Msk instead */
+#define SERCOM_I2CS_STATUS_RXNACK_Pos       2                                              /**< (SERCOM_I2CS_STATUS) Received Not Acknowledge Position */
+#define SERCOM_I2CS_STATUS_RXNACK_Msk       (_U_(0x1) << SERCOM_I2CS_STATUS_RXNACK_Pos)    /**< (SERCOM_I2CS_STATUS) Received Not Acknowledge Mask */
+#define SERCOM_I2CS_STATUS_RXNACK           SERCOM_I2CS_STATUS_RXNACK_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_STATUS_RXNACK_Msk instead */
+#define SERCOM_I2CS_STATUS_DIR_Pos          3                                              /**< (SERCOM_I2CS_STATUS) Read/Write Direction Position */
+#define SERCOM_I2CS_STATUS_DIR_Msk          (_U_(0x1) << SERCOM_I2CS_STATUS_DIR_Pos)       /**< (SERCOM_I2CS_STATUS) Read/Write Direction Mask */
+#define SERCOM_I2CS_STATUS_DIR              SERCOM_I2CS_STATUS_DIR_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_STATUS_DIR_Msk instead */
+#define SERCOM_I2CS_STATUS_SR_Pos           4                                              /**< (SERCOM_I2CS_STATUS) Repeated Start Position */
+#define SERCOM_I2CS_STATUS_SR_Msk           (_U_(0x1) << SERCOM_I2CS_STATUS_SR_Pos)        /**< (SERCOM_I2CS_STATUS) Repeated Start Mask */
+#define SERCOM_I2CS_STATUS_SR               SERCOM_I2CS_STATUS_SR_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_STATUS_SR_Msk instead */
+#define SERCOM_I2CS_STATUS_LOWTOUT_Pos      6                                              /**< (SERCOM_I2CS_STATUS) SCL Low Timeout Position */
+#define SERCOM_I2CS_STATUS_LOWTOUT_Msk      (_U_(0x1) << SERCOM_I2CS_STATUS_LOWTOUT_Pos)   /**< (SERCOM_I2CS_STATUS) SCL Low Timeout Mask */
+#define SERCOM_I2CS_STATUS_LOWTOUT          SERCOM_I2CS_STATUS_LOWTOUT_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_STATUS_LOWTOUT_Msk instead */
+#define SERCOM_I2CS_STATUS_CLKHOLD_Pos      7                                              /**< (SERCOM_I2CS_STATUS) Clock Hold Position */
+#define SERCOM_I2CS_STATUS_CLKHOLD_Msk      (_U_(0x1) << SERCOM_I2CS_STATUS_CLKHOLD_Pos)   /**< (SERCOM_I2CS_STATUS) Clock Hold Mask */
+#define SERCOM_I2CS_STATUS_CLKHOLD          SERCOM_I2CS_STATUS_CLKHOLD_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_STATUS_CLKHOLD_Msk instead */
+#define SERCOM_I2CS_STATUS_SEXTTOUT_Pos     9                                              /**< (SERCOM_I2CS_STATUS) Slave SCL Low Extend Timeout Position */
+#define SERCOM_I2CS_STATUS_SEXTTOUT_Msk     (_U_(0x1) << SERCOM_I2CS_STATUS_SEXTTOUT_Pos)  /**< (SERCOM_I2CS_STATUS) Slave SCL Low Extend Timeout Mask */
+#define SERCOM_I2CS_STATUS_SEXTTOUT         SERCOM_I2CS_STATUS_SEXTTOUT_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_STATUS_SEXTTOUT_Msk instead */
+#define SERCOM_I2CS_STATUS_HS_Pos           10                                             /**< (SERCOM_I2CS_STATUS) High Speed Position */
+#define SERCOM_I2CS_STATUS_HS_Msk           (_U_(0x1) << SERCOM_I2CS_STATUS_HS_Pos)        /**< (SERCOM_I2CS_STATUS) High Speed Mask */
+#define SERCOM_I2CS_STATUS_HS               SERCOM_I2CS_STATUS_HS_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_STATUS_HS_Msk instead */
+#define SERCOM_I2CS_STATUS_MASK             _U_(0x6DF)                                     /**< \deprecated (SERCOM_I2CS_STATUS) Register MASK  (Use SERCOM_I2CS_STATUS_Msk instead)  */
+#define SERCOM_I2CS_STATUS_Msk              _U_(0x6DF)                                     /**< (SERCOM_I2CS_STATUS) Register Mask  */
+
+
+/* -------- SERCOM_SPI_STATUS : (SERCOM Offset: 0x1a) (R/W 16) SPI Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t :2;                        /**< bit:   0..1  Reserved */
+    uint16_t BUFOVF:1;                  /**< bit:      2  Buffer Overflow                          */
+    uint16_t :13;                       /**< bit:  3..15  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} SERCOM_SPI_STATUS_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_STATUS_OFFSET            (0x1A)                                        /**<  (SERCOM_SPI_STATUS) SPI Status  Offset */
+#define SERCOM_SPI_STATUS_RESETVALUE        _U_(0x00)                                     /**<  (SERCOM_SPI_STATUS) SPI Status  Reset Value */
+
+#define SERCOM_SPI_STATUS_BUFOVF_Pos        2                                              /**< (SERCOM_SPI_STATUS) Buffer Overflow Position */
+#define SERCOM_SPI_STATUS_BUFOVF_Msk        (_U_(0x1) << SERCOM_SPI_STATUS_BUFOVF_Pos)     /**< (SERCOM_SPI_STATUS) Buffer Overflow Mask */
+#define SERCOM_SPI_STATUS_BUFOVF            SERCOM_SPI_STATUS_BUFOVF_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_STATUS_BUFOVF_Msk instead */
+#define SERCOM_SPI_STATUS_MASK              _U_(0x04)                                      /**< \deprecated (SERCOM_SPI_STATUS) Register MASK  (Use SERCOM_SPI_STATUS_Msk instead)  */
+#define SERCOM_SPI_STATUS_Msk               _U_(0x04)                                      /**< (SERCOM_SPI_STATUS) Register Mask  */
+
+
+/* -------- SERCOM_USART_STATUS : (SERCOM Offset: 0x1a) (R/W 16) USART Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t PERR:1;                    /**< bit:      0  Parity Error                             */
+    uint16_t FERR:1;                    /**< bit:      1  Frame Error                              */
+    uint16_t BUFOVF:1;                  /**< bit:      2  Buffer Overflow                          */
+    uint16_t CTS:1;                     /**< bit:      3  Clear To Send                            */
+    uint16_t ISF:1;                     /**< bit:      4  Inconsistent Sync Field                  */
+    uint16_t COLL:1;                    /**< bit:      5  Collision Detected                       */
+    uint16_t TXE:1;                     /**< bit:      6  Transmitter Empty                        */
+    uint16_t ITER:1;                    /**< bit:      7  Maximum Number of Repetitions Reached    */
+    uint16_t :8;                        /**< bit:  8..15  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} SERCOM_USART_STATUS_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_STATUS_OFFSET          (0x1A)                                        /**<  (SERCOM_USART_STATUS) USART Status  Offset */
+#define SERCOM_USART_STATUS_RESETVALUE      _U_(0x00)                                     /**<  (SERCOM_USART_STATUS) USART Status  Reset Value */
+
+#define SERCOM_USART_STATUS_PERR_Pos        0                                              /**< (SERCOM_USART_STATUS) Parity Error Position */
+#define SERCOM_USART_STATUS_PERR_Msk        (_U_(0x1) << SERCOM_USART_STATUS_PERR_Pos)     /**< (SERCOM_USART_STATUS) Parity Error Mask */
+#define SERCOM_USART_STATUS_PERR            SERCOM_USART_STATUS_PERR_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_STATUS_PERR_Msk instead */
+#define SERCOM_USART_STATUS_FERR_Pos        1                                              /**< (SERCOM_USART_STATUS) Frame Error Position */
+#define SERCOM_USART_STATUS_FERR_Msk        (_U_(0x1) << SERCOM_USART_STATUS_FERR_Pos)     /**< (SERCOM_USART_STATUS) Frame Error Mask */
+#define SERCOM_USART_STATUS_FERR            SERCOM_USART_STATUS_FERR_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_STATUS_FERR_Msk instead */
+#define SERCOM_USART_STATUS_BUFOVF_Pos      2                                              /**< (SERCOM_USART_STATUS) Buffer Overflow Position */
+#define SERCOM_USART_STATUS_BUFOVF_Msk      (_U_(0x1) << SERCOM_USART_STATUS_BUFOVF_Pos)   /**< (SERCOM_USART_STATUS) Buffer Overflow Mask */
+#define SERCOM_USART_STATUS_BUFOVF          SERCOM_USART_STATUS_BUFOVF_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_STATUS_BUFOVF_Msk instead */
+#define SERCOM_USART_STATUS_CTS_Pos         3                                              /**< (SERCOM_USART_STATUS) Clear To Send Position */
+#define SERCOM_USART_STATUS_CTS_Msk         (_U_(0x1) << SERCOM_USART_STATUS_CTS_Pos)      /**< (SERCOM_USART_STATUS) Clear To Send Mask */
+#define SERCOM_USART_STATUS_CTS             SERCOM_USART_STATUS_CTS_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_STATUS_CTS_Msk instead */
+#define SERCOM_USART_STATUS_ISF_Pos         4                                              /**< (SERCOM_USART_STATUS) Inconsistent Sync Field Position */
+#define SERCOM_USART_STATUS_ISF_Msk         (_U_(0x1) << SERCOM_USART_STATUS_ISF_Pos)      /**< (SERCOM_USART_STATUS) Inconsistent Sync Field Mask */
+#define SERCOM_USART_STATUS_ISF             SERCOM_USART_STATUS_ISF_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_STATUS_ISF_Msk instead */
+#define SERCOM_USART_STATUS_COLL_Pos        5                                              /**< (SERCOM_USART_STATUS) Collision Detected Position */
+#define SERCOM_USART_STATUS_COLL_Msk        (_U_(0x1) << SERCOM_USART_STATUS_COLL_Pos)     /**< (SERCOM_USART_STATUS) Collision Detected Mask */
+#define SERCOM_USART_STATUS_COLL            SERCOM_USART_STATUS_COLL_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_STATUS_COLL_Msk instead */
+#define SERCOM_USART_STATUS_TXE_Pos         6                                              /**< (SERCOM_USART_STATUS) Transmitter Empty Position */
+#define SERCOM_USART_STATUS_TXE_Msk         (_U_(0x1) << SERCOM_USART_STATUS_TXE_Pos)      /**< (SERCOM_USART_STATUS) Transmitter Empty Mask */
+#define SERCOM_USART_STATUS_TXE             SERCOM_USART_STATUS_TXE_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_STATUS_TXE_Msk instead */
+#define SERCOM_USART_STATUS_ITER_Pos        7                                              /**< (SERCOM_USART_STATUS) Maximum Number of Repetitions Reached Position */
+#define SERCOM_USART_STATUS_ITER_Msk        (_U_(0x1) << SERCOM_USART_STATUS_ITER_Pos)     /**< (SERCOM_USART_STATUS) Maximum Number of Repetitions Reached Mask */
+#define SERCOM_USART_STATUS_ITER            SERCOM_USART_STATUS_ITER_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_STATUS_ITER_Msk instead */
+#define SERCOM_USART_STATUS_MASK            _U_(0xFF)                                      /**< \deprecated (SERCOM_USART_STATUS) Register MASK  (Use SERCOM_USART_STATUS_Msk instead)  */
+#define SERCOM_USART_STATUS_Msk             _U_(0xFF)                                      /**< (SERCOM_USART_STATUS) Register Mask  */
+
+
+/* -------- SERCOM_I2CM_SYNCBUSY : (SERCOM Offset: 0x1c) (R/ 32) I2CM Synchronization Busy -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SWRST:1;                   /**< bit:      0  Software Reset Synchronization Busy      */
+    uint32_t ENABLE:1;                  /**< bit:      1  SERCOM Enable Synchronization Busy       */
+    uint32_t SYSOP:1;                   /**< bit:      2  System Operation Synchronization Busy    */
+    uint32_t :29;                       /**< bit:  3..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SERCOM_I2CM_SYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_SYNCBUSY_OFFSET         (0x1C)                                        /**<  (SERCOM_I2CM_SYNCBUSY) I2CM Synchronization Busy  Offset */
+#define SERCOM_I2CM_SYNCBUSY_RESETVALUE     _U_(0x00)                                     /**<  (SERCOM_I2CM_SYNCBUSY) I2CM Synchronization Busy  Reset Value */
+
+#define SERCOM_I2CM_SYNCBUSY_SWRST_Pos      0                                              /**< (SERCOM_I2CM_SYNCBUSY) Software Reset Synchronization Busy Position */
+#define SERCOM_I2CM_SYNCBUSY_SWRST_Msk      (_U_(0x1) << SERCOM_I2CM_SYNCBUSY_SWRST_Pos)   /**< (SERCOM_I2CM_SYNCBUSY) Software Reset Synchronization Busy Mask */
+#define SERCOM_I2CM_SYNCBUSY_SWRST          SERCOM_I2CM_SYNCBUSY_SWRST_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_SYNCBUSY_SWRST_Msk instead */
+#define SERCOM_I2CM_SYNCBUSY_ENABLE_Pos     1                                              /**< (SERCOM_I2CM_SYNCBUSY) SERCOM Enable Synchronization Busy Position */
+#define SERCOM_I2CM_SYNCBUSY_ENABLE_Msk     (_U_(0x1) << SERCOM_I2CM_SYNCBUSY_ENABLE_Pos)  /**< (SERCOM_I2CM_SYNCBUSY) SERCOM Enable Synchronization Busy Mask */
+#define SERCOM_I2CM_SYNCBUSY_ENABLE         SERCOM_I2CM_SYNCBUSY_ENABLE_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_SYNCBUSY_ENABLE_Msk instead */
+#define SERCOM_I2CM_SYNCBUSY_SYSOP_Pos      2                                              /**< (SERCOM_I2CM_SYNCBUSY) System Operation Synchronization Busy Position */
+#define SERCOM_I2CM_SYNCBUSY_SYSOP_Msk      (_U_(0x1) << SERCOM_I2CM_SYNCBUSY_SYSOP_Pos)   /**< (SERCOM_I2CM_SYNCBUSY) System Operation Synchronization Busy Mask */
+#define SERCOM_I2CM_SYNCBUSY_SYSOP          SERCOM_I2CM_SYNCBUSY_SYSOP_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_SYNCBUSY_SYSOP_Msk instead */
+#define SERCOM_I2CM_SYNCBUSY_MASK           _U_(0x07)                                      /**< \deprecated (SERCOM_I2CM_SYNCBUSY) Register MASK  (Use SERCOM_I2CM_SYNCBUSY_Msk instead)  */
+#define SERCOM_I2CM_SYNCBUSY_Msk            _U_(0x07)                                      /**< (SERCOM_I2CM_SYNCBUSY) Register Mask  */
+
+
+/* -------- SERCOM_I2CS_SYNCBUSY : (SERCOM Offset: 0x1c) (R/ 32) I2CS Synchronization Busy -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SWRST:1;                   /**< bit:      0  Software Reset Synchronization Busy      */
+    uint32_t ENABLE:1;                  /**< bit:      1  SERCOM Enable Synchronization Busy       */
+    uint32_t :30;                       /**< bit:  2..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SERCOM_I2CS_SYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CS_SYNCBUSY_OFFSET         (0x1C)                                        /**<  (SERCOM_I2CS_SYNCBUSY) I2CS Synchronization Busy  Offset */
+#define SERCOM_I2CS_SYNCBUSY_RESETVALUE     _U_(0x00)                                     /**<  (SERCOM_I2CS_SYNCBUSY) I2CS Synchronization Busy  Reset Value */
+
+#define SERCOM_I2CS_SYNCBUSY_SWRST_Pos      0                                              /**< (SERCOM_I2CS_SYNCBUSY) Software Reset Synchronization Busy Position */
+#define SERCOM_I2CS_SYNCBUSY_SWRST_Msk      (_U_(0x1) << SERCOM_I2CS_SYNCBUSY_SWRST_Pos)   /**< (SERCOM_I2CS_SYNCBUSY) Software Reset Synchronization Busy Mask */
+#define SERCOM_I2CS_SYNCBUSY_SWRST          SERCOM_I2CS_SYNCBUSY_SWRST_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_SYNCBUSY_SWRST_Msk instead */
+#define SERCOM_I2CS_SYNCBUSY_ENABLE_Pos     1                                              /**< (SERCOM_I2CS_SYNCBUSY) SERCOM Enable Synchronization Busy Position */
+#define SERCOM_I2CS_SYNCBUSY_ENABLE_Msk     (_U_(0x1) << SERCOM_I2CS_SYNCBUSY_ENABLE_Pos)  /**< (SERCOM_I2CS_SYNCBUSY) SERCOM Enable Synchronization Busy Mask */
+#define SERCOM_I2CS_SYNCBUSY_ENABLE         SERCOM_I2CS_SYNCBUSY_ENABLE_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_SYNCBUSY_ENABLE_Msk instead */
+#define SERCOM_I2CS_SYNCBUSY_MASK           _U_(0x03)                                      /**< \deprecated (SERCOM_I2CS_SYNCBUSY) Register MASK  (Use SERCOM_I2CS_SYNCBUSY_Msk instead)  */
+#define SERCOM_I2CS_SYNCBUSY_Msk            _U_(0x03)                                      /**< (SERCOM_I2CS_SYNCBUSY) Register Mask  */
+
+
+/* -------- SERCOM_SPI_SYNCBUSY : (SERCOM Offset: 0x1c) (R/ 32) SPI Synchronization Busy -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SWRST:1;                   /**< bit:      0  Software Reset Synchronization Busy      */
+    uint32_t ENABLE:1;                  /**< bit:      1  SERCOM Enable Synchronization Busy       */
+    uint32_t CTRLB:1;                   /**< bit:      2  CTRLB Synchronization Busy               */
+    uint32_t :29;                       /**< bit:  3..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SERCOM_SPI_SYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_SYNCBUSY_OFFSET          (0x1C)                                        /**<  (SERCOM_SPI_SYNCBUSY) SPI Synchronization Busy  Offset */
+#define SERCOM_SPI_SYNCBUSY_RESETVALUE      _U_(0x00)                                     /**<  (SERCOM_SPI_SYNCBUSY) SPI Synchronization Busy  Reset Value */
+
+#define SERCOM_SPI_SYNCBUSY_SWRST_Pos       0                                              /**< (SERCOM_SPI_SYNCBUSY) Software Reset Synchronization Busy Position */
+#define SERCOM_SPI_SYNCBUSY_SWRST_Msk       (_U_(0x1) << SERCOM_SPI_SYNCBUSY_SWRST_Pos)    /**< (SERCOM_SPI_SYNCBUSY) Software Reset Synchronization Busy Mask */
+#define SERCOM_SPI_SYNCBUSY_SWRST           SERCOM_SPI_SYNCBUSY_SWRST_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_SYNCBUSY_SWRST_Msk instead */
+#define SERCOM_SPI_SYNCBUSY_ENABLE_Pos      1                                              /**< (SERCOM_SPI_SYNCBUSY) SERCOM Enable Synchronization Busy Position */
+#define SERCOM_SPI_SYNCBUSY_ENABLE_Msk      (_U_(0x1) << SERCOM_SPI_SYNCBUSY_ENABLE_Pos)   /**< (SERCOM_SPI_SYNCBUSY) SERCOM Enable Synchronization Busy Mask */
+#define SERCOM_SPI_SYNCBUSY_ENABLE          SERCOM_SPI_SYNCBUSY_ENABLE_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_SYNCBUSY_ENABLE_Msk instead */
+#define SERCOM_SPI_SYNCBUSY_CTRLB_Pos       2                                              /**< (SERCOM_SPI_SYNCBUSY) CTRLB Synchronization Busy Position */
+#define SERCOM_SPI_SYNCBUSY_CTRLB_Msk       (_U_(0x1) << SERCOM_SPI_SYNCBUSY_CTRLB_Pos)    /**< (SERCOM_SPI_SYNCBUSY) CTRLB Synchronization Busy Mask */
+#define SERCOM_SPI_SYNCBUSY_CTRLB           SERCOM_SPI_SYNCBUSY_CTRLB_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_SYNCBUSY_CTRLB_Msk instead */
+#define SERCOM_SPI_SYNCBUSY_MASK            _U_(0x07)                                      /**< \deprecated (SERCOM_SPI_SYNCBUSY) Register MASK  (Use SERCOM_SPI_SYNCBUSY_Msk instead)  */
+#define SERCOM_SPI_SYNCBUSY_Msk             _U_(0x07)                                      /**< (SERCOM_SPI_SYNCBUSY) Register Mask  */
+
+
+/* -------- SERCOM_USART_SYNCBUSY : (SERCOM Offset: 0x1c) (R/ 32) USART Synchronization Busy -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SWRST:1;                   /**< bit:      0  Software Reset Synchronization Busy      */
+    uint32_t ENABLE:1;                  /**< bit:      1  SERCOM Enable Synchronization Busy       */
+    uint32_t CTRLB:1;                   /**< bit:      2  CTRLB Synchronization Busy               */
+    uint32_t RXERRCNT:1;                /**< bit:      3  RXERRCNT Synchronization Busy            */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SERCOM_USART_SYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_SYNCBUSY_OFFSET        (0x1C)                                        /**<  (SERCOM_USART_SYNCBUSY) USART Synchronization Busy  Offset */
+#define SERCOM_USART_SYNCBUSY_RESETVALUE    _U_(0x00)                                     /**<  (SERCOM_USART_SYNCBUSY) USART Synchronization Busy  Reset Value */
+
+#define SERCOM_USART_SYNCBUSY_SWRST_Pos     0                                              /**< (SERCOM_USART_SYNCBUSY) Software Reset Synchronization Busy Position */
+#define SERCOM_USART_SYNCBUSY_SWRST_Msk     (_U_(0x1) << SERCOM_USART_SYNCBUSY_SWRST_Pos)  /**< (SERCOM_USART_SYNCBUSY) Software Reset Synchronization Busy Mask */
+#define SERCOM_USART_SYNCBUSY_SWRST         SERCOM_USART_SYNCBUSY_SWRST_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_SYNCBUSY_SWRST_Msk instead */
+#define SERCOM_USART_SYNCBUSY_ENABLE_Pos    1                                              /**< (SERCOM_USART_SYNCBUSY) SERCOM Enable Synchronization Busy Position */
+#define SERCOM_USART_SYNCBUSY_ENABLE_Msk    (_U_(0x1) << SERCOM_USART_SYNCBUSY_ENABLE_Pos)  /**< (SERCOM_USART_SYNCBUSY) SERCOM Enable Synchronization Busy Mask */
+#define SERCOM_USART_SYNCBUSY_ENABLE        SERCOM_USART_SYNCBUSY_ENABLE_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_SYNCBUSY_ENABLE_Msk instead */
+#define SERCOM_USART_SYNCBUSY_CTRLB_Pos     2                                              /**< (SERCOM_USART_SYNCBUSY) CTRLB Synchronization Busy Position */
+#define SERCOM_USART_SYNCBUSY_CTRLB_Msk     (_U_(0x1) << SERCOM_USART_SYNCBUSY_CTRLB_Pos)  /**< (SERCOM_USART_SYNCBUSY) CTRLB Synchronization Busy Mask */
+#define SERCOM_USART_SYNCBUSY_CTRLB         SERCOM_USART_SYNCBUSY_CTRLB_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_SYNCBUSY_CTRLB_Msk instead */
+#define SERCOM_USART_SYNCBUSY_RXERRCNT_Pos  3                                              /**< (SERCOM_USART_SYNCBUSY) RXERRCNT Synchronization Busy Position */
+#define SERCOM_USART_SYNCBUSY_RXERRCNT_Msk  (_U_(0x1) << SERCOM_USART_SYNCBUSY_RXERRCNT_Pos)  /**< (SERCOM_USART_SYNCBUSY) RXERRCNT Synchronization Busy Mask */
+#define SERCOM_USART_SYNCBUSY_RXERRCNT      SERCOM_USART_SYNCBUSY_RXERRCNT_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_SYNCBUSY_RXERRCNT_Msk instead */
+#define SERCOM_USART_SYNCBUSY_MASK          _U_(0x0F)                                      /**< \deprecated (SERCOM_USART_SYNCBUSY) Register MASK  (Use SERCOM_USART_SYNCBUSY_Msk instead)  */
+#define SERCOM_USART_SYNCBUSY_Msk           _U_(0x0F)                                      /**< (SERCOM_USART_SYNCBUSY) Register Mask  */
+
+
+/* -------- SERCOM_USART_RXERRCNT : (SERCOM Offset: 0x20) (R/ 8) USART Receive Error Count -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  uint8_t  reg;                         /**< Type used for register access */
+} SERCOM_USART_RXERRCNT_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_RXERRCNT_OFFSET        (0x20)                                        /**<  (SERCOM_USART_RXERRCNT) USART Receive Error Count  Offset */
+#define SERCOM_USART_RXERRCNT_RESETVALUE    _U_(0x00)                                     /**<  (SERCOM_USART_RXERRCNT) USART Receive Error Count  Reset Value */
+
+#define SERCOM_USART_RXERRCNT_MASK          _U_(0x00)                                      /**< \deprecated (SERCOM_USART_RXERRCNT) Register MASK  (Use SERCOM_USART_RXERRCNT_Msk instead)  */
+#define SERCOM_USART_RXERRCNT_Msk           _U_(0x00)                                      /**< (SERCOM_USART_RXERRCNT) Register Mask  */
+
+
+/* -------- SERCOM_I2CM_ADDR : (SERCOM Offset: 0x24) (R/W 32) I2CM Address -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t ADDR:11;                   /**< bit:  0..10  Address Value                            */
+    uint32_t :2;                        /**< bit: 11..12  Reserved */
+    uint32_t LENEN:1;                   /**< bit:     13  Length Enable                            */
+    uint32_t HS:1;                      /**< bit:     14  High Speed Mode                          */
+    uint32_t TENBITEN:1;                /**< bit:     15  Ten Bit Addressing Enable                */
+    uint32_t LEN:8;                     /**< bit: 16..23  Length                                   */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SERCOM_I2CM_ADDR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_ADDR_OFFSET             (0x24)                                        /**<  (SERCOM_I2CM_ADDR) I2CM Address  Offset */
+#define SERCOM_I2CM_ADDR_RESETVALUE         _U_(0x00)                                     /**<  (SERCOM_I2CM_ADDR) I2CM Address  Reset Value */
+
+#define SERCOM_I2CM_ADDR_ADDR_Pos           0                                              /**< (SERCOM_I2CM_ADDR) Address Value Position */
+#define SERCOM_I2CM_ADDR_ADDR_Msk           (_U_(0x7FF) << SERCOM_I2CM_ADDR_ADDR_Pos)      /**< (SERCOM_I2CM_ADDR) Address Value Mask */
+#define SERCOM_I2CM_ADDR_ADDR(value)        (SERCOM_I2CM_ADDR_ADDR_Msk & ((value) << SERCOM_I2CM_ADDR_ADDR_Pos))
+#define SERCOM_I2CM_ADDR_LENEN_Pos          13                                             /**< (SERCOM_I2CM_ADDR) Length Enable Position */
+#define SERCOM_I2CM_ADDR_LENEN_Msk          (_U_(0x1) << SERCOM_I2CM_ADDR_LENEN_Pos)       /**< (SERCOM_I2CM_ADDR) Length Enable Mask */
+#define SERCOM_I2CM_ADDR_LENEN              SERCOM_I2CM_ADDR_LENEN_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_ADDR_LENEN_Msk instead */
+#define SERCOM_I2CM_ADDR_HS_Pos             14                                             /**< (SERCOM_I2CM_ADDR) High Speed Mode Position */
+#define SERCOM_I2CM_ADDR_HS_Msk             (_U_(0x1) << SERCOM_I2CM_ADDR_HS_Pos)          /**< (SERCOM_I2CM_ADDR) High Speed Mode Mask */
+#define SERCOM_I2CM_ADDR_HS                 SERCOM_I2CM_ADDR_HS_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_ADDR_HS_Msk instead */
+#define SERCOM_I2CM_ADDR_TENBITEN_Pos       15                                             /**< (SERCOM_I2CM_ADDR) Ten Bit Addressing Enable Position */
+#define SERCOM_I2CM_ADDR_TENBITEN_Msk       (_U_(0x1) << SERCOM_I2CM_ADDR_TENBITEN_Pos)    /**< (SERCOM_I2CM_ADDR) Ten Bit Addressing Enable Mask */
+#define SERCOM_I2CM_ADDR_TENBITEN           SERCOM_I2CM_ADDR_TENBITEN_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_ADDR_TENBITEN_Msk instead */
+#define SERCOM_I2CM_ADDR_LEN_Pos            16                                             /**< (SERCOM_I2CM_ADDR) Length Position */
+#define SERCOM_I2CM_ADDR_LEN_Msk            (_U_(0xFF) << SERCOM_I2CM_ADDR_LEN_Pos)        /**< (SERCOM_I2CM_ADDR) Length Mask */
+#define SERCOM_I2CM_ADDR_LEN(value)         (SERCOM_I2CM_ADDR_LEN_Msk & ((value) << SERCOM_I2CM_ADDR_LEN_Pos))
+#define SERCOM_I2CM_ADDR_MASK               _U_(0xFFE7FF)                                  /**< \deprecated (SERCOM_I2CM_ADDR) Register MASK  (Use SERCOM_I2CM_ADDR_Msk instead)  */
+#define SERCOM_I2CM_ADDR_Msk                _U_(0xFFE7FF)                                  /**< (SERCOM_I2CM_ADDR) Register Mask  */
+
+
+/* -------- SERCOM_I2CS_ADDR : (SERCOM Offset: 0x24) (R/W 32) I2CS Address -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t GENCEN:1;                  /**< bit:      0  General Call Address Enable              */
+    uint32_t ADDR:10;                   /**< bit:  1..10  Address Value                            */
+    uint32_t :4;                        /**< bit: 11..14  Reserved */
+    uint32_t TENBITEN:1;                /**< bit:     15  Ten Bit Addressing Enable                */
+    uint32_t :1;                        /**< bit:     16  Reserved */
+    uint32_t ADDRMASK:10;               /**< bit: 17..26  Address Mask                             */
+    uint32_t :5;                        /**< bit: 27..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SERCOM_I2CS_ADDR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CS_ADDR_OFFSET             (0x24)                                        /**<  (SERCOM_I2CS_ADDR) I2CS Address  Offset */
+#define SERCOM_I2CS_ADDR_RESETVALUE         _U_(0x00)                                     /**<  (SERCOM_I2CS_ADDR) I2CS Address  Reset Value */
+
+#define SERCOM_I2CS_ADDR_GENCEN_Pos         0                                              /**< (SERCOM_I2CS_ADDR) General Call Address Enable Position */
+#define SERCOM_I2CS_ADDR_GENCEN_Msk         (_U_(0x1) << SERCOM_I2CS_ADDR_GENCEN_Pos)      /**< (SERCOM_I2CS_ADDR) General Call Address Enable Mask */
+#define SERCOM_I2CS_ADDR_GENCEN             SERCOM_I2CS_ADDR_GENCEN_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_ADDR_GENCEN_Msk instead */
+#define SERCOM_I2CS_ADDR_ADDR_Pos           1                                              /**< (SERCOM_I2CS_ADDR) Address Value Position */
+#define SERCOM_I2CS_ADDR_ADDR_Msk           (_U_(0x3FF) << SERCOM_I2CS_ADDR_ADDR_Pos)      /**< (SERCOM_I2CS_ADDR) Address Value Mask */
+#define SERCOM_I2CS_ADDR_ADDR(value)        (SERCOM_I2CS_ADDR_ADDR_Msk & ((value) << SERCOM_I2CS_ADDR_ADDR_Pos))
+#define SERCOM_I2CS_ADDR_TENBITEN_Pos       15                                             /**< (SERCOM_I2CS_ADDR) Ten Bit Addressing Enable Position */
+#define SERCOM_I2CS_ADDR_TENBITEN_Msk       (_U_(0x1) << SERCOM_I2CS_ADDR_TENBITEN_Pos)    /**< (SERCOM_I2CS_ADDR) Ten Bit Addressing Enable Mask */
+#define SERCOM_I2CS_ADDR_TENBITEN           SERCOM_I2CS_ADDR_TENBITEN_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_ADDR_TENBITEN_Msk instead */
+#define SERCOM_I2CS_ADDR_ADDRMASK_Pos       17                                             /**< (SERCOM_I2CS_ADDR) Address Mask Position */
+#define SERCOM_I2CS_ADDR_ADDRMASK_Msk       (_U_(0x3FF) << SERCOM_I2CS_ADDR_ADDRMASK_Pos)  /**< (SERCOM_I2CS_ADDR) Address Mask Mask */
+#define SERCOM_I2CS_ADDR_ADDRMASK(value)    (SERCOM_I2CS_ADDR_ADDRMASK_Msk & ((value) << SERCOM_I2CS_ADDR_ADDRMASK_Pos))
+#define SERCOM_I2CS_ADDR_Msk                _U_(0x7FE87FF)                                 /**< (SERCOM_I2CS_ADDR) Register Mask  */
+
+
+/* -------- SERCOM_SPI_ADDR : (SERCOM Offset: 0x24) (R/W 32) SPI Address -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t ADDR:8;                    /**< bit:   0..7  Address Value                            */
+    uint32_t :8;                        /**< bit:  8..15  Reserved */
+    uint32_t ADDRMASK:8;                /**< bit: 16..23  Address Mask                             */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SERCOM_SPI_ADDR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_ADDR_OFFSET              (0x24)                                        /**<  (SERCOM_SPI_ADDR) SPI Address  Offset */
+#define SERCOM_SPI_ADDR_RESETVALUE          _U_(0x00)                                     /**<  (SERCOM_SPI_ADDR) SPI Address  Reset Value */
+
+#define SERCOM_SPI_ADDR_ADDR_Pos            0                                              /**< (SERCOM_SPI_ADDR) Address Value Position */
+#define SERCOM_SPI_ADDR_ADDR_Msk            (_U_(0xFF) << SERCOM_SPI_ADDR_ADDR_Pos)        /**< (SERCOM_SPI_ADDR) Address Value Mask */
+#define SERCOM_SPI_ADDR_ADDR(value)         (SERCOM_SPI_ADDR_ADDR_Msk & ((value) << SERCOM_SPI_ADDR_ADDR_Pos))
+#define SERCOM_SPI_ADDR_ADDRMASK_Pos        16                                             /**< (SERCOM_SPI_ADDR) Address Mask Position */
+#define SERCOM_SPI_ADDR_ADDRMASK_Msk        (_U_(0xFF) << SERCOM_SPI_ADDR_ADDRMASK_Pos)    /**< (SERCOM_SPI_ADDR) Address Mask Mask */
+#define SERCOM_SPI_ADDR_ADDRMASK(value)     (SERCOM_SPI_ADDR_ADDRMASK_Msk & ((value) << SERCOM_SPI_ADDR_ADDRMASK_Pos))
+#define SERCOM_SPI_ADDR_Msk                 _U_(0xFF00FF)                                  /**< (SERCOM_SPI_ADDR) Register Mask  */
+
+
+/* -------- SERCOM_I2CM_DATA : (SERCOM Offset: 0x28) (R/W 8) I2CM Data -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DATA:8;                    /**< bit:   0..7  Data Value                               */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} SERCOM_I2CM_DATA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_DATA_OFFSET             (0x28)                                        /**<  (SERCOM_I2CM_DATA) I2CM Data  Offset */
+#define SERCOM_I2CM_DATA_RESETVALUE         _U_(0x00)                                     /**<  (SERCOM_I2CM_DATA) I2CM Data  Reset Value */
+
+#define SERCOM_I2CM_DATA_DATA_Pos           0                                              /**< (SERCOM_I2CM_DATA) Data Value Position */
+#define SERCOM_I2CM_DATA_DATA_Msk           (_U_(0xFF) << SERCOM_I2CM_DATA_DATA_Pos)       /**< (SERCOM_I2CM_DATA) Data Value Mask */
+#define SERCOM_I2CM_DATA_DATA(value)        (SERCOM_I2CM_DATA_DATA_Msk & ((value) << SERCOM_I2CM_DATA_DATA_Pos))
+#define SERCOM_I2CM_DATA_MASK               _U_(0xFF)                                      /**< \deprecated (SERCOM_I2CM_DATA) Register MASK  (Use SERCOM_I2CM_DATA_Msk instead)  */
+#define SERCOM_I2CM_DATA_Msk                _U_(0xFF)                                      /**< (SERCOM_I2CM_DATA) Register Mask  */
+
+
+/* -------- SERCOM_I2CS_DATA : (SERCOM Offset: 0x28) (R/W 8) I2CS Data -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DATA:8;                    /**< bit:   0..7  Data Value                               */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} SERCOM_I2CS_DATA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CS_DATA_OFFSET             (0x28)                                        /**<  (SERCOM_I2CS_DATA) I2CS Data  Offset */
+#define SERCOM_I2CS_DATA_RESETVALUE         _U_(0x00)                                     /**<  (SERCOM_I2CS_DATA) I2CS Data  Reset Value */
+
+#define SERCOM_I2CS_DATA_DATA_Pos           0                                              /**< (SERCOM_I2CS_DATA) Data Value Position */
+#define SERCOM_I2CS_DATA_DATA_Msk           (_U_(0xFF) << SERCOM_I2CS_DATA_DATA_Pos)       /**< (SERCOM_I2CS_DATA) Data Value Mask */
+#define SERCOM_I2CS_DATA_DATA(value)        (SERCOM_I2CS_DATA_DATA_Msk & ((value) << SERCOM_I2CS_DATA_DATA_Pos))
+#define SERCOM_I2CS_DATA_MASK               _U_(0xFF)                                      /**< \deprecated (SERCOM_I2CS_DATA) Register MASK  (Use SERCOM_I2CS_DATA_Msk instead)  */
+#define SERCOM_I2CS_DATA_Msk                _U_(0xFF)                                      /**< (SERCOM_I2CS_DATA) Register Mask  */
+
+
+/* -------- SERCOM_SPI_DATA : (SERCOM Offset: 0x28) (R/W 32) SPI Data -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t DATA:9;                    /**< bit:   0..8  Data Value                               */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SERCOM_SPI_DATA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_DATA_OFFSET              (0x28)                                        /**<  (SERCOM_SPI_DATA) SPI Data  Offset */
+#define SERCOM_SPI_DATA_RESETVALUE          _U_(0x00)                                     /**<  (SERCOM_SPI_DATA) SPI Data  Reset Value */
+
+#define SERCOM_SPI_DATA_DATA_Pos            0                                              /**< (SERCOM_SPI_DATA) Data Value Position */
+#define SERCOM_SPI_DATA_DATA_Msk            (_U_(0x1FF) << SERCOM_SPI_DATA_DATA_Pos)       /**< (SERCOM_SPI_DATA) Data Value Mask */
+#define SERCOM_SPI_DATA_DATA(value)         (SERCOM_SPI_DATA_DATA_Msk & ((value) << SERCOM_SPI_DATA_DATA_Pos))
+#define SERCOM_SPI_DATA_MASK                _U_(0x1FF)                                     /**< \deprecated (SERCOM_SPI_DATA) Register MASK  (Use SERCOM_SPI_DATA_Msk instead)  */
+#define SERCOM_SPI_DATA_Msk                 _U_(0x1FF)                                     /**< (SERCOM_SPI_DATA) Register Mask  */
+
+
+/* -------- SERCOM_USART_DATA : (SERCOM Offset: 0x28) (R/W 16) USART Data -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t DATA:9;                    /**< bit:   0..8  Data Value                               */
+    uint16_t :7;                        /**< bit:  9..15  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} SERCOM_USART_DATA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_DATA_OFFSET            (0x28)                                        /**<  (SERCOM_USART_DATA) USART Data  Offset */
+#define SERCOM_USART_DATA_RESETVALUE        _U_(0x00)                                     /**<  (SERCOM_USART_DATA) USART Data  Reset Value */
+
+#define SERCOM_USART_DATA_DATA_Pos          0                                              /**< (SERCOM_USART_DATA) Data Value Position */
+#define SERCOM_USART_DATA_DATA_Msk          (_U_(0x1FF) << SERCOM_USART_DATA_DATA_Pos)     /**< (SERCOM_USART_DATA) Data Value Mask */
+#define SERCOM_USART_DATA_DATA(value)       (SERCOM_USART_DATA_DATA_Msk & ((value) << SERCOM_USART_DATA_DATA_Pos))
+#define SERCOM_USART_DATA_MASK              _U_(0x1FF)                                     /**< \deprecated (SERCOM_USART_DATA) Register MASK  (Use SERCOM_USART_DATA_Msk instead)  */
+#define SERCOM_USART_DATA_Msk               _U_(0x1FF)                                     /**< (SERCOM_USART_DATA) Register Mask  */
+
+
+/* -------- SERCOM_I2CM_DBGCTRL : (SERCOM Offset: 0x30) (R/W 8) I2CM Debug Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DBGSTOP:1;                 /**< bit:      0  Debug Mode                               */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} SERCOM_I2CM_DBGCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_DBGCTRL_OFFSET          (0x30)                                        /**<  (SERCOM_I2CM_DBGCTRL) I2CM Debug Control  Offset */
+#define SERCOM_I2CM_DBGCTRL_RESETVALUE      _U_(0x00)                                     /**<  (SERCOM_I2CM_DBGCTRL) I2CM Debug Control  Reset Value */
+
+#define SERCOM_I2CM_DBGCTRL_DBGSTOP_Pos     0                                              /**< (SERCOM_I2CM_DBGCTRL) Debug Mode Position */
+#define SERCOM_I2CM_DBGCTRL_DBGSTOP_Msk     (_U_(0x1) << SERCOM_I2CM_DBGCTRL_DBGSTOP_Pos)  /**< (SERCOM_I2CM_DBGCTRL) Debug Mode Mask */
+#define SERCOM_I2CM_DBGCTRL_DBGSTOP         SERCOM_I2CM_DBGCTRL_DBGSTOP_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_DBGCTRL_DBGSTOP_Msk instead */
+#define SERCOM_I2CM_DBGCTRL_MASK            _U_(0x01)                                      /**< \deprecated (SERCOM_I2CM_DBGCTRL) Register MASK  (Use SERCOM_I2CM_DBGCTRL_Msk instead)  */
+#define SERCOM_I2CM_DBGCTRL_Msk             _U_(0x01)                                      /**< (SERCOM_I2CM_DBGCTRL) Register Mask  */
+
+
+/* -------- SERCOM_SPI_DBGCTRL : (SERCOM Offset: 0x30) (R/W 8) SPI Debug Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DBGSTOP:1;                 /**< bit:      0  Debug Mode                               */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} SERCOM_SPI_DBGCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_DBGCTRL_OFFSET           (0x30)                                        /**<  (SERCOM_SPI_DBGCTRL) SPI Debug Control  Offset */
+#define SERCOM_SPI_DBGCTRL_RESETVALUE       _U_(0x00)                                     /**<  (SERCOM_SPI_DBGCTRL) SPI Debug Control  Reset Value */
+
+#define SERCOM_SPI_DBGCTRL_DBGSTOP_Pos      0                                              /**< (SERCOM_SPI_DBGCTRL) Debug Mode Position */
+#define SERCOM_SPI_DBGCTRL_DBGSTOP_Msk      (_U_(0x1) << SERCOM_SPI_DBGCTRL_DBGSTOP_Pos)   /**< (SERCOM_SPI_DBGCTRL) Debug Mode Mask */
+#define SERCOM_SPI_DBGCTRL_DBGSTOP          SERCOM_SPI_DBGCTRL_DBGSTOP_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_DBGCTRL_DBGSTOP_Msk instead */
+#define SERCOM_SPI_DBGCTRL_MASK             _U_(0x01)                                      /**< \deprecated (SERCOM_SPI_DBGCTRL) Register MASK  (Use SERCOM_SPI_DBGCTRL_Msk instead)  */
+#define SERCOM_SPI_DBGCTRL_Msk              _U_(0x01)                                      /**< (SERCOM_SPI_DBGCTRL) Register Mask  */
+
+
+/* -------- SERCOM_USART_DBGCTRL : (SERCOM Offset: 0x30) (R/W 8) USART Debug Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DBGSTOP:1;                 /**< bit:      0  Debug Mode                               */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} SERCOM_USART_DBGCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_DBGCTRL_OFFSET         (0x30)                                        /**<  (SERCOM_USART_DBGCTRL) USART Debug Control  Offset */
+#define SERCOM_USART_DBGCTRL_RESETVALUE     _U_(0x00)                                     /**<  (SERCOM_USART_DBGCTRL) USART Debug Control  Reset Value */
+
+#define SERCOM_USART_DBGCTRL_DBGSTOP_Pos    0                                              /**< (SERCOM_USART_DBGCTRL) Debug Mode Position */
+#define SERCOM_USART_DBGCTRL_DBGSTOP_Msk    (_U_(0x1) << SERCOM_USART_DBGCTRL_DBGSTOP_Pos)  /**< (SERCOM_USART_DBGCTRL) Debug Mode Mask */
+#define SERCOM_USART_DBGCTRL_DBGSTOP        SERCOM_USART_DBGCTRL_DBGSTOP_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_DBGCTRL_DBGSTOP_Msk instead */
+#define SERCOM_USART_DBGCTRL_MASK           _U_(0x01)                                      /**< \deprecated (SERCOM_USART_DBGCTRL) Register MASK  (Use SERCOM_USART_DBGCTRL_Msk instead)  */
+#define SERCOM_USART_DBGCTRL_Msk            _U_(0x01)                                      /**< (SERCOM_USART_DBGCTRL) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief SERCOM hardware registers */
+typedef struct {  /* Serial Communication Interface */
+  __IO SERCOM_I2CM_CTRLA_Type         CTRLA;          /**< Offset: 0x00 (R/W  32) I2CM Control A */
+  __IO SERCOM_I2CM_CTRLB_Type         CTRLB;          /**< Offset: 0x04 (R/W  32) I2CM Control B */
+  __I  uint8_t                        Reserved1[4];
+  __IO SERCOM_I2CM_BAUD_Type          BAUD;           /**< Offset: 0x0C (R/W  32) I2CM Baud Rate */
+  __I  uint8_t                        Reserved2[4];
+  __IO SERCOM_I2CM_INTENCLR_Type      INTENCLR;       /**< Offset: 0x14 (R/W   8) I2CM Interrupt Enable Clear */
+  __I  uint8_t                        Reserved3[1];
+  __IO SERCOM_I2CM_INTENSET_Type      INTENSET;       /**< Offset: 0x16 (R/W   8) I2CM Interrupt Enable Set */
+  __I  uint8_t                        Reserved4[1];
+  __IO SERCOM_I2CM_INTFLAG_Type       INTFLAG;        /**< Offset: 0x18 (R/W   8) I2CM Interrupt Flag Status and Clear */
+  __I  uint8_t                        Reserved5[1];
+  __IO SERCOM_I2CM_STATUS_Type        STATUS;         /**< Offset: 0x1A (R/W  16) I2CM Status */
+  __I  SERCOM_I2CM_SYNCBUSY_Type      SYNCBUSY;       /**< Offset: 0x1C (R/   32) I2CM Synchronization Busy */
+  __I  uint8_t                        Reserved6[4];
+  __IO SERCOM_I2CM_ADDR_Type          ADDR;           /**< Offset: 0x24 (R/W  32) I2CM Address */
+  __IO SERCOM_I2CM_DATA_Type          DATA;           /**< Offset: 0x28 (R/W   8) I2CM Data */
+  __I  uint8_t                        Reserved7[7];
+  __IO SERCOM_I2CM_DBGCTRL_Type       DBGCTRL;        /**< Offset: 0x30 (R/W   8) I2CM Debug Control */
+} SercomI2cm;
+
+/** \brief SERCOM hardware registers */
+typedef struct {  /* Serial Communication Interface */
+  __IO SERCOM_I2CS_CTRLA_Type         CTRLA;          /**< Offset: 0x00 (R/W  32) I2CS Control A */
+  __IO SERCOM_I2CS_CTRLB_Type         CTRLB;          /**< Offset: 0x04 (R/W  32) I2CS Control B */
+  __I  uint8_t                        Reserved1[12];
+  __IO SERCOM_I2CS_INTENCLR_Type      INTENCLR;       /**< Offset: 0x14 (R/W   8) I2CS Interrupt Enable Clear */
+  __I  uint8_t                        Reserved2[1];
+  __IO SERCOM_I2CS_INTENSET_Type      INTENSET;       /**< Offset: 0x16 (R/W   8) I2CS Interrupt Enable Set */
+  __I  uint8_t                        Reserved3[1];
+  __IO SERCOM_I2CS_INTFLAG_Type       INTFLAG;        /**< Offset: 0x18 (R/W   8) I2CS Interrupt Flag Status and Clear */
+  __I  uint8_t                        Reserved4[1];
+  __IO SERCOM_I2CS_STATUS_Type        STATUS;         /**< Offset: 0x1A (R/W  16) I2CS Status */
+  __I  SERCOM_I2CS_SYNCBUSY_Type      SYNCBUSY;       /**< Offset: 0x1C (R/   32) I2CS Synchronization Busy */
+  __I  uint8_t                        Reserved5[4];
+  __IO SERCOM_I2CS_ADDR_Type          ADDR;           /**< Offset: 0x24 (R/W  32) I2CS Address */
+  __IO SERCOM_I2CS_DATA_Type          DATA;           /**< Offset: 0x28 (R/W   8) I2CS Data */
+} SercomI2cs;
+
+/** \brief SERCOM hardware registers */
+typedef struct {  /* Serial Communication Interface */
+  __IO SERCOM_SPI_CTRLA_Type          CTRLA;          /**< Offset: 0x00 (R/W  32) SPI Control A */
+  __IO SERCOM_SPI_CTRLB_Type          CTRLB;          /**< Offset: 0x04 (R/W  32) SPI Control B */
+  __I  uint8_t                        Reserved1[4];
+  __IO SERCOM_SPI_BAUD_Type           BAUD;           /**< Offset: 0x0C (R/W   8) SPI Baud Rate */
+  __I  uint8_t                        Reserved2[7];
+  __IO SERCOM_SPI_INTENCLR_Type       INTENCLR;       /**< Offset: 0x14 (R/W   8) SPI Interrupt Enable Clear */
+  __I  uint8_t                        Reserved3[1];
+  __IO SERCOM_SPI_INTENSET_Type       INTENSET;       /**< Offset: 0x16 (R/W   8) SPI Interrupt Enable Set */
+  __I  uint8_t                        Reserved4[1];
+  __IO SERCOM_SPI_INTFLAG_Type        INTFLAG;        /**< Offset: 0x18 (R/W   8) SPI Interrupt Flag Status and Clear */
+  __I  uint8_t                        Reserved5[1];
+  __IO SERCOM_SPI_STATUS_Type         STATUS;         /**< Offset: 0x1A (R/W  16) SPI Status */
+  __I  SERCOM_SPI_SYNCBUSY_Type       SYNCBUSY;       /**< Offset: 0x1C (R/   32) SPI Synchronization Busy */
+  __I  uint8_t                        Reserved6[4];
+  __IO SERCOM_SPI_ADDR_Type           ADDR;           /**< Offset: 0x24 (R/W  32) SPI Address */
+  __IO SERCOM_SPI_DATA_Type           DATA;           /**< Offset: 0x28 (R/W  32) SPI Data */
+  __I  uint8_t                        Reserved7[4];
+  __IO SERCOM_SPI_DBGCTRL_Type        DBGCTRL;        /**< Offset: 0x30 (R/W   8) SPI Debug Control */
+} SercomSpi;
+
+/** \brief SERCOM hardware registers */
+typedef struct {  /* Serial Communication Interface */
+  __IO SERCOM_USART_CTRLA_Type        CTRLA;          /**< Offset: 0x00 (R/W  32) USART Control A */
+  __IO SERCOM_USART_CTRLB_Type        CTRLB;          /**< Offset: 0x04 (R/W  32) USART Control B */
+  __IO SERCOM_USART_CTRLC_Type        CTRLC;          /**< Offset: 0x08 (R/W  32) USART Control C */
+  __IO SERCOM_USART_BAUD_Type         BAUD;           /**< Offset: 0x0C (R/W  16) USART Baud Rate */
+  __IO SERCOM_USART_RXPL_Type         RXPL;           /**< Offset: 0x0E (R/W   8) USART Receive Pulse Length */
+  __I  uint8_t                        Reserved1[5];
+  __IO SERCOM_USART_INTENCLR_Type     INTENCLR;       /**< Offset: 0x14 (R/W   8) USART Interrupt Enable Clear */
+  __I  uint8_t                        Reserved2[1];
+  __IO SERCOM_USART_INTENSET_Type     INTENSET;       /**< Offset: 0x16 (R/W   8) USART Interrupt Enable Set */
+  __I  uint8_t                        Reserved3[1];
+  __IO SERCOM_USART_INTFLAG_Type      INTFLAG;        /**< Offset: 0x18 (R/W   8) USART Interrupt Flag Status and Clear */
+  __I  uint8_t                        Reserved4[1];
+  __IO SERCOM_USART_STATUS_Type       STATUS;         /**< Offset: 0x1A (R/W  16) USART Status */
+  __I  SERCOM_USART_SYNCBUSY_Type     SYNCBUSY;       /**< Offset: 0x1C (R/   32) USART Synchronization Busy */
+  __I  SERCOM_USART_RXERRCNT_Type     RXERRCNT;       /**< Offset: 0x20 (R/    8) USART Receive Error Count */
+  __I  uint8_t                        Reserved5[7];
+  __IO SERCOM_USART_DATA_Type         DATA;           /**< Offset: 0x28 (R/W  16) USART Data */
+  __I  uint8_t                        Reserved6[6];
+  __IO SERCOM_USART_DBGCTRL_Type      DBGCTRL;        /**< Offset: 0x30 (R/W   8) USART Debug Control */
+} SercomUsart;
+
+/** \brief SERCOM hardware registers */
+typedef union {  /* Serial Communication Interface */
+       SercomI2cm                     I2CM;           /**< I2C Master Mode */
+       SercomI2cs                     I2CS;           /**< I2C Slave Mode */
+       SercomSpi                      SPI;            /**< SPI Mode */
+       SercomUsart                    USART;          /**< USART Mode */
+} Sercom;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Serial Communication Interface */
+
+#endif /* _SAML10_SERCOM_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/component/supc.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/supc.h
@@ -1,0 +1,653 @@
+/**
+ * \file
+ *
+ * \brief Component description for SUPC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_SUPC_COMPONENT_H_
+#define _SAML10_SUPC_COMPONENT_H_
+#define _SAML10_SUPC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML10 Supply Controller
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR SUPC */
+/* ========================================================================== */
+
+#define SUPC_U2117                      /**< (SUPC) Module ID */
+#define REV_SUPC 0x400                  /**< (SUPC) Module revision */
+
+/* -------- SUPC_INTENCLR : (SUPC Offset: 0x00) (R/W 32) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t BOD33RDY:1;                /**< bit:      0  BOD33 Ready                              */
+    uint32_t BOD33DET:1;                /**< bit:      1  BOD33 Detection                          */
+    uint32_t B33SRDY:1;                 /**< bit:      2  BOD33 Synchronization Ready              */
+    uint32_t BOD12RDY:1;                /**< bit:      3  BOD12 Ready                              */
+    uint32_t BOD12DET:1;                /**< bit:      4  BOD12 Detection                          */
+    uint32_t B12SRDY:1;                 /**< bit:      5  BOD12 Synchronization Ready              */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t VREGRDY:1;                 /**< bit:      8  Voltage Regulator Ready                  */
+    uint32_t :1;                        /**< bit:      9  Reserved */
+    uint32_t VCORERDY:1;                /**< bit:     10  VDDCORE Ready                            */
+    uint32_t ULPVREFRDY:1;              /**< bit:     11  ULPVREF Voltage Reference Ready          */
+    uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SUPC_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SUPC_INTENCLR_OFFSET                (0x00)                                        /**<  (SUPC_INTENCLR) Interrupt Enable Clear  Offset */
+#define SUPC_INTENCLR_RESETVALUE            _U_(0x00)                                     /**<  (SUPC_INTENCLR) Interrupt Enable Clear  Reset Value */
+
+#define SUPC_INTENCLR_BOD33RDY_Pos          0                                              /**< (SUPC_INTENCLR) BOD33 Ready Position */
+#define SUPC_INTENCLR_BOD33RDY_Msk          (_U_(0x1) << SUPC_INTENCLR_BOD33RDY_Pos)       /**< (SUPC_INTENCLR) BOD33 Ready Mask */
+#define SUPC_INTENCLR_BOD33RDY              SUPC_INTENCLR_BOD33RDY_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTENCLR_BOD33RDY_Msk instead */
+#define SUPC_INTENCLR_BOD33DET_Pos          1                                              /**< (SUPC_INTENCLR) BOD33 Detection Position */
+#define SUPC_INTENCLR_BOD33DET_Msk          (_U_(0x1) << SUPC_INTENCLR_BOD33DET_Pos)       /**< (SUPC_INTENCLR) BOD33 Detection Mask */
+#define SUPC_INTENCLR_BOD33DET              SUPC_INTENCLR_BOD33DET_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTENCLR_BOD33DET_Msk instead */
+#define SUPC_INTENCLR_B33SRDY_Pos           2                                              /**< (SUPC_INTENCLR) BOD33 Synchronization Ready Position */
+#define SUPC_INTENCLR_B33SRDY_Msk           (_U_(0x1) << SUPC_INTENCLR_B33SRDY_Pos)        /**< (SUPC_INTENCLR) BOD33 Synchronization Ready Mask */
+#define SUPC_INTENCLR_B33SRDY               SUPC_INTENCLR_B33SRDY_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTENCLR_B33SRDY_Msk instead */
+#define SUPC_INTENCLR_BOD12RDY_Pos          3                                              /**< (SUPC_INTENCLR) BOD12 Ready Position */
+#define SUPC_INTENCLR_BOD12RDY_Msk          (_U_(0x1) << SUPC_INTENCLR_BOD12RDY_Pos)       /**< (SUPC_INTENCLR) BOD12 Ready Mask */
+#define SUPC_INTENCLR_BOD12RDY              SUPC_INTENCLR_BOD12RDY_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTENCLR_BOD12RDY_Msk instead */
+#define SUPC_INTENCLR_BOD12DET_Pos          4                                              /**< (SUPC_INTENCLR) BOD12 Detection Position */
+#define SUPC_INTENCLR_BOD12DET_Msk          (_U_(0x1) << SUPC_INTENCLR_BOD12DET_Pos)       /**< (SUPC_INTENCLR) BOD12 Detection Mask */
+#define SUPC_INTENCLR_BOD12DET              SUPC_INTENCLR_BOD12DET_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTENCLR_BOD12DET_Msk instead */
+#define SUPC_INTENCLR_B12SRDY_Pos           5                                              /**< (SUPC_INTENCLR) BOD12 Synchronization Ready Position */
+#define SUPC_INTENCLR_B12SRDY_Msk           (_U_(0x1) << SUPC_INTENCLR_B12SRDY_Pos)        /**< (SUPC_INTENCLR) BOD12 Synchronization Ready Mask */
+#define SUPC_INTENCLR_B12SRDY               SUPC_INTENCLR_B12SRDY_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTENCLR_B12SRDY_Msk instead */
+#define SUPC_INTENCLR_VREGRDY_Pos           8                                              /**< (SUPC_INTENCLR) Voltage Regulator Ready Position */
+#define SUPC_INTENCLR_VREGRDY_Msk           (_U_(0x1) << SUPC_INTENCLR_VREGRDY_Pos)        /**< (SUPC_INTENCLR) Voltage Regulator Ready Mask */
+#define SUPC_INTENCLR_VREGRDY               SUPC_INTENCLR_VREGRDY_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTENCLR_VREGRDY_Msk instead */
+#define SUPC_INTENCLR_VCORERDY_Pos          10                                             /**< (SUPC_INTENCLR) VDDCORE Ready Position */
+#define SUPC_INTENCLR_VCORERDY_Msk          (_U_(0x1) << SUPC_INTENCLR_VCORERDY_Pos)       /**< (SUPC_INTENCLR) VDDCORE Ready Mask */
+#define SUPC_INTENCLR_VCORERDY              SUPC_INTENCLR_VCORERDY_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTENCLR_VCORERDY_Msk instead */
+#define SUPC_INTENCLR_ULPVREFRDY_Pos        11                                             /**< (SUPC_INTENCLR) ULPVREF Voltage Reference Ready Position */
+#define SUPC_INTENCLR_ULPVREFRDY_Msk        (_U_(0x1) << SUPC_INTENCLR_ULPVREFRDY_Pos)     /**< (SUPC_INTENCLR) ULPVREF Voltage Reference Ready Mask */
+#define SUPC_INTENCLR_ULPVREFRDY            SUPC_INTENCLR_ULPVREFRDY_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTENCLR_ULPVREFRDY_Msk instead */
+#define SUPC_INTENCLR_MASK                  _U_(0xD3F)                                     /**< \deprecated (SUPC_INTENCLR) Register MASK  (Use SUPC_INTENCLR_Msk instead)  */
+#define SUPC_INTENCLR_Msk                   _U_(0xD3F)                                     /**< (SUPC_INTENCLR) Register Mask  */
+
+
+/* -------- SUPC_INTENSET : (SUPC Offset: 0x04) (R/W 32) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t BOD33RDY:1;                /**< bit:      0  BOD33 Ready                              */
+    uint32_t BOD33DET:1;                /**< bit:      1  BOD33 Detection                          */
+    uint32_t B33SRDY:1;                 /**< bit:      2  BOD33 Synchronization Ready              */
+    uint32_t BOD12RDY:1;                /**< bit:      3  BOD12 Ready                              */
+    uint32_t BOD12DET:1;                /**< bit:      4  BOD12 Detection                          */
+    uint32_t B12SRDY:1;                 /**< bit:      5  BOD12 Synchronization Ready              */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t VREGRDY:1;                 /**< bit:      8  Voltage Regulator Ready                  */
+    uint32_t :1;                        /**< bit:      9  Reserved */
+    uint32_t VCORERDY:1;                /**< bit:     10  VDDCORE Ready                            */
+    uint32_t ULPVREFRDY:1;              /**< bit:     11  ULPVREF Voltage Reference Ready          */
+    uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SUPC_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SUPC_INTENSET_OFFSET                (0x04)                                        /**<  (SUPC_INTENSET) Interrupt Enable Set  Offset */
+#define SUPC_INTENSET_RESETVALUE            _U_(0x00)                                     /**<  (SUPC_INTENSET) Interrupt Enable Set  Reset Value */
+
+#define SUPC_INTENSET_BOD33RDY_Pos          0                                              /**< (SUPC_INTENSET) BOD33 Ready Position */
+#define SUPC_INTENSET_BOD33RDY_Msk          (_U_(0x1) << SUPC_INTENSET_BOD33RDY_Pos)       /**< (SUPC_INTENSET) BOD33 Ready Mask */
+#define SUPC_INTENSET_BOD33RDY              SUPC_INTENSET_BOD33RDY_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTENSET_BOD33RDY_Msk instead */
+#define SUPC_INTENSET_BOD33DET_Pos          1                                              /**< (SUPC_INTENSET) BOD33 Detection Position */
+#define SUPC_INTENSET_BOD33DET_Msk          (_U_(0x1) << SUPC_INTENSET_BOD33DET_Pos)       /**< (SUPC_INTENSET) BOD33 Detection Mask */
+#define SUPC_INTENSET_BOD33DET              SUPC_INTENSET_BOD33DET_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTENSET_BOD33DET_Msk instead */
+#define SUPC_INTENSET_B33SRDY_Pos           2                                              /**< (SUPC_INTENSET) BOD33 Synchronization Ready Position */
+#define SUPC_INTENSET_B33SRDY_Msk           (_U_(0x1) << SUPC_INTENSET_B33SRDY_Pos)        /**< (SUPC_INTENSET) BOD33 Synchronization Ready Mask */
+#define SUPC_INTENSET_B33SRDY               SUPC_INTENSET_B33SRDY_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTENSET_B33SRDY_Msk instead */
+#define SUPC_INTENSET_BOD12RDY_Pos          3                                              /**< (SUPC_INTENSET) BOD12 Ready Position */
+#define SUPC_INTENSET_BOD12RDY_Msk          (_U_(0x1) << SUPC_INTENSET_BOD12RDY_Pos)       /**< (SUPC_INTENSET) BOD12 Ready Mask */
+#define SUPC_INTENSET_BOD12RDY              SUPC_INTENSET_BOD12RDY_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTENSET_BOD12RDY_Msk instead */
+#define SUPC_INTENSET_BOD12DET_Pos          4                                              /**< (SUPC_INTENSET) BOD12 Detection Position */
+#define SUPC_INTENSET_BOD12DET_Msk          (_U_(0x1) << SUPC_INTENSET_BOD12DET_Pos)       /**< (SUPC_INTENSET) BOD12 Detection Mask */
+#define SUPC_INTENSET_BOD12DET              SUPC_INTENSET_BOD12DET_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTENSET_BOD12DET_Msk instead */
+#define SUPC_INTENSET_B12SRDY_Pos           5                                              /**< (SUPC_INTENSET) BOD12 Synchronization Ready Position */
+#define SUPC_INTENSET_B12SRDY_Msk           (_U_(0x1) << SUPC_INTENSET_B12SRDY_Pos)        /**< (SUPC_INTENSET) BOD12 Synchronization Ready Mask */
+#define SUPC_INTENSET_B12SRDY               SUPC_INTENSET_B12SRDY_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTENSET_B12SRDY_Msk instead */
+#define SUPC_INTENSET_VREGRDY_Pos           8                                              /**< (SUPC_INTENSET) Voltage Regulator Ready Position */
+#define SUPC_INTENSET_VREGRDY_Msk           (_U_(0x1) << SUPC_INTENSET_VREGRDY_Pos)        /**< (SUPC_INTENSET) Voltage Regulator Ready Mask */
+#define SUPC_INTENSET_VREGRDY               SUPC_INTENSET_VREGRDY_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTENSET_VREGRDY_Msk instead */
+#define SUPC_INTENSET_VCORERDY_Pos          10                                             /**< (SUPC_INTENSET) VDDCORE Ready Position */
+#define SUPC_INTENSET_VCORERDY_Msk          (_U_(0x1) << SUPC_INTENSET_VCORERDY_Pos)       /**< (SUPC_INTENSET) VDDCORE Ready Mask */
+#define SUPC_INTENSET_VCORERDY              SUPC_INTENSET_VCORERDY_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTENSET_VCORERDY_Msk instead */
+#define SUPC_INTENSET_ULPVREFRDY_Pos        11                                             /**< (SUPC_INTENSET) ULPVREF Voltage Reference Ready Position */
+#define SUPC_INTENSET_ULPVREFRDY_Msk        (_U_(0x1) << SUPC_INTENSET_ULPVREFRDY_Pos)     /**< (SUPC_INTENSET) ULPVREF Voltage Reference Ready Mask */
+#define SUPC_INTENSET_ULPVREFRDY            SUPC_INTENSET_ULPVREFRDY_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTENSET_ULPVREFRDY_Msk instead */
+#define SUPC_INTENSET_MASK                  _U_(0xD3F)                                     /**< \deprecated (SUPC_INTENSET) Register MASK  (Use SUPC_INTENSET_Msk instead)  */
+#define SUPC_INTENSET_Msk                   _U_(0xD3F)                                     /**< (SUPC_INTENSET) Register Mask  */
+
+
+/* -------- SUPC_INTFLAG : (SUPC Offset: 0x08) (R/W 32) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint32_t BOD33RDY:1;                /**< bit:      0  BOD33 Ready                              */
+    __I uint32_t BOD33DET:1;                /**< bit:      1  BOD33 Detection                          */
+    __I uint32_t B33SRDY:1;                 /**< bit:      2  BOD33 Synchronization Ready              */
+    __I uint32_t BOD12RDY:1;                /**< bit:      3  BOD12 Ready                              */
+    __I uint32_t BOD12DET:1;                /**< bit:      4  BOD12 Detection                          */
+    __I uint32_t B12SRDY:1;                 /**< bit:      5  BOD12 Synchronization Ready              */
+    __I uint32_t :2;                        /**< bit:   6..7  Reserved */
+    __I uint32_t VREGRDY:1;                 /**< bit:      8  Voltage Regulator Ready                  */
+    __I uint32_t :1;                        /**< bit:      9  Reserved */
+    __I uint32_t VCORERDY:1;                /**< bit:     10  VDDCORE Ready                            */
+    __I uint32_t ULPVREFRDY:1;              /**< bit:     11  ULPVREF Voltage Reference Ready          */
+    __I uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SUPC_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SUPC_INTFLAG_OFFSET                 (0x08)                                        /**<  (SUPC_INTFLAG) Interrupt Flag Status and Clear  Offset */
+#define SUPC_INTFLAG_RESETVALUE             _U_(0x00)                                     /**<  (SUPC_INTFLAG) Interrupt Flag Status and Clear  Reset Value */
+
+#define SUPC_INTFLAG_BOD33RDY_Pos           0                                              /**< (SUPC_INTFLAG) BOD33 Ready Position */
+#define SUPC_INTFLAG_BOD33RDY_Msk           (_U_(0x1) << SUPC_INTFLAG_BOD33RDY_Pos)        /**< (SUPC_INTFLAG) BOD33 Ready Mask */
+#define SUPC_INTFLAG_BOD33RDY               SUPC_INTFLAG_BOD33RDY_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTFLAG_BOD33RDY_Msk instead */
+#define SUPC_INTFLAG_BOD33DET_Pos           1                                              /**< (SUPC_INTFLAG) BOD33 Detection Position */
+#define SUPC_INTFLAG_BOD33DET_Msk           (_U_(0x1) << SUPC_INTFLAG_BOD33DET_Pos)        /**< (SUPC_INTFLAG) BOD33 Detection Mask */
+#define SUPC_INTFLAG_BOD33DET               SUPC_INTFLAG_BOD33DET_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTFLAG_BOD33DET_Msk instead */
+#define SUPC_INTFLAG_B33SRDY_Pos            2                                              /**< (SUPC_INTFLAG) BOD33 Synchronization Ready Position */
+#define SUPC_INTFLAG_B33SRDY_Msk            (_U_(0x1) << SUPC_INTFLAG_B33SRDY_Pos)         /**< (SUPC_INTFLAG) BOD33 Synchronization Ready Mask */
+#define SUPC_INTFLAG_B33SRDY                SUPC_INTFLAG_B33SRDY_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTFLAG_B33SRDY_Msk instead */
+#define SUPC_INTFLAG_BOD12RDY_Pos           3                                              /**< (SUPC_INTFLAG) BOD12 Ready Position */
+#define SUPC_INTFLAG_BOD12RDY_Msk           (_U_(0x1) << SUPC_INTFLAG_BOD12RDY_Pos)        /**< (SUPC_INTFLAG) BOD12 Ready Mask */
+#define SUPC_INTFLAG_BOD12RDY               SUPC_INTFLAG_BOD12RDY_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTFLAG_BOD12RDY_Msk instead */
+#define SUPC_INTFLAG_BOD12DET_Pos           4                                              /**< (SUPC_INTFLAG) BOD12 Detection Position */
+#define SUPC_INTFLAG_BOD12DET_Msk           (_U_(0x1) << SUPC_INTFLAG_BOD12DET_Pos)        /**< (SUPC_INTFLAG) BOD12 Detection Mask */
+#define SUPC_INTFLAG_BOD12DET               SUPC_INTFLAG_BOD12DET_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTFLAG_BOD12DET_Msk instead */
+#define SUPC_INTFLAG_B12SRDY_Pos            5                                              /**< (SUPC_INTFLAG) BOD12 Synchronization Ready Position */
+#define SUPC_INTFLAG_B12SRDY_Msk            (_U_(0x1) << SUPC_INTFLAG_B12SRDY_Pos)         /**< (SUPC_INTFLAG) BOD12 Synchronization Ready Mask */
+#define SUPC_INTFLAG_B12SRDY                SUPC_INTFLAG_B12SRDY_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTFLAG_B12SRDY_Msk instead */
+#define SUPC_INTFLAG_VREGRDY_Pos            8                                              /**< (SUPC_INTFLAG) Voltage Regulator Ready Position */
+#define SUPC_INTFLAG_VREGRDY_Msk            (_U_(0x1) << SUPC_INTFLAG_VREGRDY_Pos)         /**< (SUPC_INTFLAG) Voltage Regulator Ready Mask */
+#define SUPC_INTFLAG_VREGRDY                SUPC_INTFLAG_VREGRDY_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTFLAG_VREGRDY_Msk instead */
+#define SUPC_INTFLAG_VCORERDY_Pos           10                                             /**< (SUPC_INTFLAG) VDDCORE Ready Position */
+#define SUPC_INTFLAG_VCORERDY_Msk           (_U_(0x1) << SUPC_INTFLAG_VCORERDY_Pos)        /**< (SUPC_INTFLAG) VDDCORE Ready Mask */
+#define SUPC_INTFLAG_VCORERDY               SUPC_INTFLAG_VCORERDY_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTFLAG_VCORERDY_Msk instead */
+#define SUPC_INTFLAG_ULPVREFRDY_Pos         11                                             /**< (SUPC_INTFLAG) ULPVREF Voltage Reference Ready Position */
+#define SUPC_INTFLAG_ULPVREFRDY_Msk         (_U_(0x1) << SUPC_INTFLAG_ULPVREFRDY_Pos)      /**< (SUPC_INTFLAG) ULPVREF Voltage Reference Ready Mask */
+#define SUPC_INTFLAG_ULPVREFRDY             SUPC_INTFLAG_ULPVREFRDY_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTFLAG_ULPVREFRDY_Msk instead */
+#define SUPC_INTFLAG_MASK                   _U_(0xD3F)                                     /**< \deprecated (SUPC_INTFLAG) Register MASK  (Use SUPC_INTFLAG_Msk instead)  */
+#define SUPC_INTFLAG_Msk                    _U_(0xD3F)                                     /**< (SUPC_INTFLAG) Register Mask  */
+
+
+/* -------- SUPC_STATUS : (SUPC Offset: 0x0c) (R/ 32) Power and Clocks Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t BOD33RDY:1;                /**< bit:      0  BOD33 Ready                              */
+    uint32_t BOD33DET:1;                /**< bit:      1  BOD33 Detection                          */
+    uint32_t B33SRDY:1;                 /**< bit:      2  BOD33 Synchronization Ready              */
+    uint32_t BOD12RDY:1;                /**< bit:      3  BOD12 Ready                              */
+    uint32_t BOD12DET:1;                /**< bit:      4  BOD12 Detection                          */
+    uint32_t B12SRDY:1;                 /**< bit:      5  BOD12 Synchronization Ready              */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t VREGRDY:1;                 /**< bit:      8  Voltage Regulator Ready                  */
+    uint32_t :1;                        /**< bit:      9  Reserved */
+    uint32_t VCORERDY:1;                /**< bit:     10  VDDCORE Ready                            */
+    uint32_t :1;                        /**< bit:     11  Reserved */
+    uint32_t ULPVREFRDY:1;              /**< bit:     12  Low Power Voltage Reference Ready        */
+    uint32_t ULPBIASRDY:1;              /**< bit:     13  Low Power Voltage Bias Ready             */
+    uint32_t :18;                       /**< bit: 14..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SUPC_STATUS_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SUPC_STATUS_OFFSET                  (0x0C)                                        /**<  (SUPC_STATUS) Power and Clocks Status  Offset */
+#define SUPC_STATUS_RESETVALUE              _U_(0x00)                                     /**<  (SUPC_STATUS) Power and Clocks Status  Reset Value */
+
+#define SUPC_STATUS_BOD33RDY_Pos            0                                              /**< (SUPC_STATUS) BOD33 Ready Position */
+#define SUPC_STATUS_BOD33RDY_Msk            (_U_(0x1) << SUPC_STATUS_BOD33RDY_Pos)         /**< (SUPC_STATUS) BOD33 Ready Mask */
+#define SUPC_STATUS_BOD33RDY                SUPC_STATUS_BOD33RDY_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_STATUS_BOD33RDY_Msk instead */
+#define SUPC_STATUS_BOD33DET_Pos            1                                              /**< (SUPC_STATUS) BOD33 Detection Position */
+#define SUPC_STATUS_BOD33DET_Msk            (_U_(0x1) << SUPC_STATUS_BOD33DET_Pos)         /**< (SUPC_STATUS) BOD33 Detection Mask */
+#define SUPC_STATUS_BOD33DET                SUPC_STATUS_BOD33DET_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_STATUS_BOD33DET_Msk instead */
+#define SUPC_STATUS_B33SRDY_Pos             2                                              /**< (SUPC_STATUS) BOD33 Synchronization Ready Position */
+#define SUPC_STATUS_B33SRDY_Msk             (_U_(0x1) << SUPC_STATUS_B33SRDY_Pos)          /**< (SUPC_STATUS) BOD33 Synchronization Ready Mask */
+#define SUPC_STATUS_B33SRDY                 SUPC_STATUS_B33SRDY_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_STATUS_B33SRDY_Msk instead */
+#define SUPC_STATUS_BOD12RDY_Pos            3                                              /**< (SUPC_STATUS) BOD12 Ready Position */
+#define SUPC_STATUS_BOD12RDY_Msk            (_U_(0x1) << SUPC_STATUS_BOD12RDY_Pos)         /**< (SUPC_STATUS) BOD12 Ready Mask */
+#define SUPC_STATUS_BOD12RDY                SUPC_STATUS_BOD12RDY_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_STATUS_BOD12RDY_Msk instead */
+#define SUPC_STATUS_BOD12DET_Pos            4                                              /**< (SUPC_STATUS) BOD12 Detection Position */
+#define SUPC_STATUS_BOD12DET_Msk            (_U_(0x1) << SUPC_STATUS_BOD12DET_Pos)         /**< (SUPC_STATUS) BOD12 Detection Mask */
+#define SUPC_STATUS_BOD12DET                SUPC_STATUS_BOD12DET_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_STATUS_BOD12DET_Msk instead */
+#define SUPC_STATUS_B12SRDY_Pos             5                                              /**< (SUPC_STATUS) BOD12 Synchronization Ready Position */
+#define SUPC_STATUS_B12SRDY_Msk             (_U_(0x1) << SUPC_STATUS_B12SRDY_Pos)          /**< (SUPC_STATUS) BOD12 Synchronization Ready Mask */
+#define SUPC_STATUS_B12SRDY                 SUPC_STATUS_B12SRDY_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_STATUS_B12SRDY_Msk instead */
+#define SUPC_STATUS_VREGRDY_Pos             8                                              /**< (SUPC_STATUS) Voltage Regulator Ready Position */
+#define SUPC_STATUS_VREGRDY_Msk             (_U_(0x1) << SUPC_STATUS_VREGRDY_Pos)          /**< (SUPC_STATUS) Voltage Regulator Ready Mask */
+#define SUPC_STATUS_VREGRDY                 SUPC_STATUS_VREGRDY_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_STATUS_VREGRDY_Msk instead */
+#define SUPC_STATUS_VCORERDY_Pos            10                                             /**< (SUPC_STATUS) VDDCORE Ready Position */
+#define SUPC_STATUS_VCORERDY_Msk            (_U_(0x1) << SUPC_STATUS_VCORERDY_Pos)         /**< (SUPC_STATUS) VDDCORE Ready Mask */
+#define SUPC_STATUS_VCORERDY                SUPC_STATUS_VCORERDY_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_STATUS_VCORERDY_Msk instead */
+#define SUPC_STATUS_ULPVREFRDY_Pos          12                                             /**< (SUPC_STATUS) Low Power Voltage Reference Ready Position */
+#define SUPC_STATUS_ULPVREFRDY_Msk          (_U_(0x1) << SUPC_STATUS_ULPVREFRDY_Pos)       /**< (SUPC_STATUS) Low Power Voltage Reference Ready Mask */
+#define SUPC_STATUS_ULPVREFRDY              SUPC_STATUS_ULPVREFRDY_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_STATUS_ULPVREFRDY_Msk instead */
+#define SUPC_STATUS_ULPBIASRDY_Pos          13                                             /**< (SUPC_STATUS) Low Power Voltage Bias Ready Position */
+#define SUPC_STATUS_ULPBIASRDY_Msk          (_U_(0x1) << SUPC_STATUS_ULPBIASRDY_Pos)       /**< (SUPC_STATUS) Low Power Voltage Bias Ready Mask */
+#define SUPC_STATUS_ULPBIASRDY              SUPC_STATUS_ULPBIASRDY_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_STATUS_ULPBIASRDY_Msk instead */
+#define SUPC_STATUS_MASK                    _U_(0x353F)                                    /**< \deprecated (SUPC_STATUS) Register MASK  (Use SUPC_STATUS_Msk instead)  */
+#define SUPC_STATUS_Msk                     _U_(0x353F)                                    /**< (SUPC_STATUS) Register Mask  */
+
+
+/* -------- SUPC_BOD33 : (SUPC Offset: 0x10) (R/W 32) BOD33 Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint32_t HYST:1;                    /**< bit:      2  Hysteresis Enable                        */
+    uint32_t ACTION:2;                  /**< bit:   3..4  Action when Threshold Crossed            */
+    uint32_t STDBYCFG:1;                /**< bit:      5  Configuration in Standby mode            */
+    uint32_t RUNSTDBY:1;                /**< bit:      6  Run during Standby                       */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t ACTCFG:1;                  /**< bit:      8  Configuration in Active mode             */
+    uint32_t :2;                        /**< bit:  9..10  Reserved */
+    uint32_t REFSEL:1;                  /**< bit:     11  BOD33 Voltage Reference Selection        */
+    uint32_t PSEL:4;                    /**< bit: 12..15  Prescaler Select                         */
+    uint32_t LEVEL:6;                   /**< bit: 16..21  Threshold Level for VDD                  */
+    uint32_t :10;                       /**< bit: 22..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SUPC_BOD33_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SUPC_BOD33_OFFSET                   (0x10)                                        /**<  (SUPC_BOD33) BOD33 Control  Offset */
+#define SUPC_BOD33_RESETVALUE               _U_(0x00)                                     /**<  (SUPC_BOD33) BOD33 Control  Reset Value */
+
+#define SUPC_BOD33_ENABLE_Pos               1                                              /**< (SUPC_BOD33) Enable Position */
+#define SUPC_BOD33_ENABLE_Msk               (_U_(0x1) << SUPC_BOD33_ENABLE_Pos)            /**< (SUPC_BOD33) Enable Mask */
+#define SUPC_BOD33_ENABLE                   SUPC_BOD33_ENABLE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_BOD33_ENABLE_Msk instead */
+#define SUPC_BOD33_HYST_Pos                 2                                              /**< (SUPC_BOD33) Hysteresis Enable Position */
+#define SUPC_BOD33_HYST_Msk                 (_U_(0x1) << SUPC_BOD33_HYST_Pos)              /**< (SUPC_BOD33) Hysteresis Enable Mask */
+#define SUPC_BOD33_HYST                     SUPC_BOD33_HYST_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_BOD33_HYST_Msk instead */
+#define SUPC_BOD33_ACTION_Pos               3                                              /**< (SUPC_BOD33) Action when Threshold Crossed Position */
+#define SUPC_BOD33_ACTION_Msk               (_U_(0x3) << SUPC_BOD33_ACTION_Pos)            /**< (SUPC_BOD33) Action when Threshold Crossed Mask */
+#define SUPC_BOD33_ACTION(value)            (SUPC_BOD33_ACTION_Msk & ((value) << SUPC_BOD33_ACTION_Pos))
+#define   SUPC_BOD33_ACTION_NONE_Val        _U_(0x0)                                       /**< (SUPC_BOD33) No action  */
+#define   SUPC_BOD33_ACTION_RESET_Val       _U_(0x1)                                       /**< (SUPC_BOD33) The BOD33 generates a reset  */
+#define   SUPC_BOD33_ACTION_INT_Val         _U_(0x2)                                       /**< (SUPC_BOD33) The BOD33 generates an interrupt  */
+#define   SUPC_BOD33_ACTION_BKUP_Val        _U_(0x3)                                       /**< (SUPC_BOD33) The BOD33 puts the device in backup sleep mode if VMON=0  */
+#define SUPC_BOD33_ACTION_NONE              (SUPC_BOD33_ACTION_NONE_Val << SUPC_BOD33_ACTION_Pos)  /**< (SUPC_BOD33) No action Position  */
+#define SUPC_BOD33_ACTION_RESET             (SUPC_BOD33_ACTION_RESET_Val << SUPC_BOD33_ACTION_Pos)  /**< (SUPC_BOD33) The BOD33 generates a reset Position  */
+#define SUPC_BOD33_ACTION_INT               (SUPC_BOD33_ACTION_INT_Val << SUPC_BOD33_ACTION_Pos)  /**< (SUPC_BOD33) The BOD33 generates an interrupt Position  */
+#define SUPC_BOD33_ACTION_BKUP              (SUPC_BOD33_ACTION_BKUP_Val << SUPC_BOD33_ACTION_Pos)  /**< (SUPC_BOD33) The BOD33 puts the device in backup sleep mode if VMON=0 Position  */
+#define SUPC_BOD33_STDBYCFG_Pos             5                                              /**< (SUPC_BOD33) Configuration in Standby mode Position */
+#define SUPC_BOD33_STDBYCFG_Msk             (_U_(0x1) << SUPC_BOD33_STDBYCFG_Pos)          /**< (SUPC_BOD33) Configuration in Standby mode Mask */
+#define SUPC_BOD33_STDBYCFG                 SUPC_BOD33_STDBYCFG_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_BOD33_STDBYCFG_Msk instead */
+#define SUPC_BOD33_RUNSTDBY_Pos             6                                              /**< (SUPC_BOD33) Run during Standby Position */
+#define SUPC_BOD33_RUNSTDBY_Msk             (_U_(0x1) << SUPC_BOD33_RUNSTDBY_Pos)          /**< (SUPC_BOD33) Run during Standby Mask */
+#define SUPC_BOD33_RUNSTDBY                 SUPC_BOD33_RUNSTDBY_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_BOD33_RUNSTDBY_Msk instead */
+#define SUPC_BOD33_ACTCFG_Pos               8                                              /**< (SUPC_BOD33) Configuration in Active mode Position */
+#define SUPC_BOD33_ACTCFG_Msk               (_U_(0x1) << SUPC_BOD33_ACTCFG_Pos)            /**< (SUPC_BOD33) Configuration in Active mode Mask */
+#define SUPC_BOD33_ACTCFG                   SUPC_BOD33_ACTCFG_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_BOD33_ACTCFG_Msk instead */
+#define SUPC_BOD33_REFSEL_Pos               11                                             /**< (SUPC_BOD33) BOD33 Voltage Reference Selection Position */
+#define SUPC_BOD33_REFSEL_Msk               (_U_(0x1) << SUPC_BOD33_REFSEL_Pos)            /**< (SUPC_BOD33) BOD33 Voltage Reference Selection Mask */
+#define SUPC_BOD33_REFSEL                   SUPC_BOD33_REFSEL_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_BOD33_REFSEL_Msk instead */
+#define   SUPC_BOD33_REFSEL_SEL_VREFDETREF_Val _U_(0x0)                                       /**< (SUPC_BOD33) Selects VREFDETREF for the BOD33  */
+#define   SUPC_BOD33_REFSEL_SEL_ULPVREF_Val _U_(0x1)                                       /**< (SUPC_BOD33) Selects ULPVREF for the BOD33  */
+#define SUPC_BOD33_REFSEL_SEL_VREFDETREF    (SUPC_BOD33_REFSEL_SEL_VREFDETREF_Val << SUPC_BOD33_REFSEL_Pos)  /**< (SUPC_BOD33) Selects VREFDETREF for the BOD33 Position  */
+#define SUPC_BOD33_REFSEL_SEL_ULPVREF       (SUPC_BOD33_REFSEL_SEL_ULPVREF_Val << SUPC_BOD33_REFSEL_Pos)  /**< (SUPC_BOD33) Selects ULPVREF for the BOD33 Position  */
+#define SUPC_BOD33_PSEL_Pos                 12                                             /**< (SUPC_BOD33) Prescaler Select Position */
+#define SUPC_BOD33_PSEL_Msk                 (_U_(0xF) << SUPC_BOD33_PSEL_Pos)              /**< (SUPC_BOD33) Prescaler Select Mask */
+#define SUPC_BOD33_PSEL(value)              (SUPC_BOD33_PSEL_Msk & ((value) << SUPC_BOD33_PSEL_Pos))
+#define   SUPC_BOD33_PSEL_DIV2_Val          _U_(0x0)                                       /**< (SUPC_BOD33) Divide clock by 2  */
+#define   SUPC_BOD33_PSEL_DIV4_Val          _U_(0x1)                                       /**< (SUPC_BOD33) Divide clock by 4  */
+#define   SUPC_BOD33_PSEL_DIV8_Val          _U_(0x2)                                       /**< (SUPC_BOD33) Divide clock by 8  */
+#define   SUPC_BOD33_PSEL_DIV16_Val         _U_(0x3)                                       /**< (SUPC_BOD33) Divide clock by 16  */
+#define   SUPC_BOD33_PSEL_DIV32_Val         _U_(0x4)                                       /**< (SUPC_BOD33) Divide clock by 32  */
+#define   SUPC_BOD33_PSEL_DIV64_Val         _U_(0x5)                                       /**< (SUPC_BOD33) Divide clock by 64  */
+#define   SUPC_BOD33_PSEL_DIV128_Val        _U_(0x6)                                       /**< (SUPC_BOD33) Divide clock by 128  */
+#define   SUPC_BOD33_PSEL_DIV256_Val        _U_(0x7)                                       /**< (SUPC_BOD33) Divide clock by 256  */
+#define   SUPC_BOD33_PSEL_DIV512_Val        _U_(0x8)                                       /**< (SUPC_BOD33) Divide clock by 512  */
+#define   SUPC_BOD33_PSEL_DIV1024_Val       _U_(0x9)                                       /**< (SUPC_BOD33) Divide clock by 1024  */
+#define   SUPC_BOD33_PSEL_DIV2048_Val       _U_(0xA)                                       /**< (SUPC_BOD33) Divide clock by 2048  */
+#define   SUPC_BOD33_PSEL_DIV4096_Val       _U_(0xB)                                       /**< (SUPC_BOD33) Divide clock by 4096  */
+#define   SUPC_BOD33_PSEL_DIV8192_Val       _U_(0xC)                                       /**< (SUPC_BOD33) Divide clock by 8192  */
+#define   SUPC_BOD33_PSEL_DIV16384_Val      _U_(0xD)                                       /**< (SUPC_BOD33) Divide clock by 16384  */
+#define   SUPC_BOD33_PSEL_DIV32768_Val      _U_(0xE)                                       /**< (SUPC_BOD33) Divide clock by 32768  */
+#define   SUPC_BOD33_PSEL_DIV65536_Val      _U_(0xF)                                       /**< (SUPC_BOD33) Divide clock by 65536  */
+#define SUPC_BOD33_PSEL_DIV2                (SUPC_BOD33_PSEL_DIV2_Val << SUPC_BOD33_PSEL_Pos)  /**< (SUPC_BOD33) Divide clock by 2 Position  */
+#define SUPC_BOD33_PSEL_DIV4                (SUPC_BOD33_PSEL_DIV4_Val << SUPC_BOD33_PSEL_Pos)  /**< (SUPC_BOD33) Divide clock by 4 Position  */
+#define SUPC_BOD33_PSEL_DIV8                (SUPC_BOD33_PSEL_DIV8_Val << SUPC_BOD33_PSEL_Pos)  /**< (SUPC_BOD33) Divide clock by 8 Position  */
+#define SUPC_BOD33_PSEL_DIV16               (SUPC_BOD33_PSEL_DIV16_Val << SUPC_BOD33_PSEL_Pos)  /**< (SUPC_BOD33) Divide clock by 16 Position  */
+#define SUPC_BOD33_PSEL_DIV32               (SUPC_BOD33_PSEL_DIV32_Val << SUPC_BOD33_PSEL_Pos)  /**< (SUPC_BOD33) Divide clock by 32 Position  */
+#define SUPC_BOD33_PSEL_DIV64               (SUPC_BOD33_PSEL_DIV64_Val << SUPC_BOD33_PSEL_Pos)  /**< (SUPC_BOD33) Divide clock by 64 Position  */
+#define SUPC_BOD33_PSEL_DIV128              (SUPC_BOD33_PSEL_DIV128_Val << SUPC_BOD33_PSEL_Pos)  /**< (SUPC_BOD33) Divide clock by 128 Position  */
+#define SUPC_BOD33_PSEL_DIV256              (SUPC_BOD33_PSEL_DIV256_Val << SUPC_BOD33_PSEL_Pos)  /**< (SUPC_BOD33) Divide clock by 256 Position  */
+#define SUPC_BOD33_PSEL_DIV512              (SUPC_BOD33_PSEL_DIV512_Val << SUPC_BOD33_PSEL_Pos)  /**< (SUPC_BOD33) Divide clock by 512 Position  */
+#define SUPC_BOD33_PSEL_DIV1024             (SUPC_BOD33_PSEL_DIV1024_Val << SUPC_BOD33_PSEL_Pos)  /**< (SUPC_BOD33) Divide clock by 1024 Position  */
+#define SUPC_BOD33_PSEL_DIV2048             (SUPC_BOD33_PSEL_DIV2048_Val << SUPC_BOD33_PSEL_Pos)  /**< (SUPC_BOD33) Divide clock by 2048 Position  */
+#define SUPC_BOD33_PSEL_DIV4096             (SUPC_BOD33_PSEL_DIV4096_Val << SUPC_BOD33_PSEL_Pos)  /**< (SUPC_BOD33) Divide clock by 4096 Position  */
+#define SUPC_BOD33_PSEL_DIV8192             (SUPC_BOD33_PSEL_DIV8192_Val << SUPC_BOD33_PSEL_Pos)  /**< (SUPC_BOD33) Divide clock by 8192 Position  */
+#define SUPC_BOD33_PSEL_DIV16384            (SUPC_BOD33_PSEL_DIV16384_Val << SUPC_BOD33_PSEL_Pos)  /**< (SUPC_BOD33) Divide clock by 16384 Position  */
+#define SUPC_BOD33_PSEL_DIV32768            (SUPC_BOD33_PSEL_DIV32768_Val << SUPC_BOD33_PSEL_Pos)  /**< (SUPC_BOD33) Divide clock by 32768 Position  */
+#define SUPC_BOD33_PSEL_DIV65536            (SUPC_BOD33_PSEL_DIV65536_Val << SUPC_BOD33_PSEL_Pos)  /**< (SUPC_BOD33) Divide clock by 65536 Position  */
+#define SUPC_BOD33_LEVEL_Pos                16                                             /**< (SUPC_BOD33) Threshold Level for VDD Position */
+#define SUPC_BOD33_LEVEL_Msk                (_U_(0x3F) << SUPC_BOD33_LEVEL_Pos)            /**< (SUPC_BOD33) Threshold Level for VDD Mask */
+#define SUPC_BOD33_LEVEL(value)             (SUPC_BOD33_LEVEL_Msk & ((value) << SUPC_BOD33_LEVEL_Pos))
+#define SUPC_BOD33_MASK                     _U_(0x3FF97E)                                  /**< \deprecated (SUPC_BOD33) Register MASK  (Use SUPC_BOD33_Msk instead)  */
+#define SUPC_BOD33_Msk                      _U_(0x3FF97E)                                  /**< (SUPC_BOD33) Register Mask  */
+
+
+/* -------- SUPC_BOD12 : (SUPC Offset: 0x14) (R/W 32) BOD12 Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint32_t HYST:1;                    /**< bit:      2  Hysteresis Enable                        */
+    uint32_t ACTION:2;                  /**< bit:   3..4  Action when Threshold Crossed            */
+    uint32_t STDBYCFG:1;                /**< bit:      5  Configuration in Standby mode            */
+    uint32_t RUNSTDBY:1;                /**< bit:      6  Run during Standby                       */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t ACTCFG:1;                  /**< bit:      8  Configuration in Active mode             */
+    uint32_t :3;                        /**< bit:  9..11  Reserved */
+    uint32_t PSEL:4;                    /**< bit: 12..15  Prescaler Select                         */
+    uint32_t LEVEL:6;                   /**< bit: 16..21  Threshold Level                          */
+    uint32_t :10;                       /**< bit: 22..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SUPC_BOD12_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SUPC_BOD12_OFFSET                   (0x14)                                        /**<  (SUPC_BOD12) BOD12 Control  Offset */
+#define SUPC_BOD12_RESETVALUE               _U_(0x00)                                     /**<  (SUPC_BOD12) BOD12 Control  Reset Value */
+
+#define SUPC_BOD12_ENABLE_Pos               1                                              /**< (SUPC_BOD12) Enable Position */
+#define SUPC_BOD12_ENABLE_Msk               (_U_(0x1) << SUPC_BOD12_ENABLE_Pos)            /**< (SUPC_BOD12) Enable Mask */
+#define SUPC_BOD12_ENABLE                   SUPC_BOD12_ENABLE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_BOD12_ENABLE_Msk instead */
+#define SUPC_BOD12_HYST_Pos                 2                                              /**< (SUPC_BOD12) Hysteresis Enable Position */
+#define SUPC_BOD12_HYST_Msk                 (_U_(0x1) << SUPC_BOD12_HYST_Pos)              /**< (SUPC_BOD12) Hysteresis Enable Mask */
+#define SUPC_BOD12_HYST                     SUPC_BOD12_HYST_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_BOD12_HYST_Msk instead */
+#define SUPC_BOD12_ACTION_Pos               3                                              /**< (SUPC_BOD12) Action when Threshold Crossed Position */
+#define SUPC_BOD12_ACTION_Msk               (_U_(0x3) << SUPC_BOD12_ACTION_Pos)            /**< (SUPC_BOD12) Action when Threshold Crossed Mask */
+#define SUPC_BOD12_ACTION(value)            (SUPC_BOD12_ACTION_Msk & ((value) << SUPC_BOD12_ACTION_Pos))
+#define   SUPC_BOD12_ACTION_NONE_Val        _U_(0x0)                                       /**< (SUPC_BOD12) No action  */
+#define   SUPC_BOD12_ACTION_RESET_Val       _U_(0x1)                                       /**< (SUPC_BOD12) The BOD12 generates a reset  */
+#define   SUPC_BOD12_ACTION_INT_Val         _U_(0x2)                                       /**< (SUPC_BOD12) The BOD12 generates an interrupt  */
+#define SUPC_BOD12_ACTION_NONE              (SUPC_BOD12_ACTION_NONE_Val << SUPC_BOD12_ACTION_Pos)  /**< (SUPC_BOD12) No action Position  */
+#define SUPC_BOD12_ACTION_RESET             (SUPC_BOD12_ACTION_RESET_Val << SUPC_BOD12_ACTION_Pos)  /**< (SUPC_BOD12) The BOD12 generates a reset Position  */
+#define SUPC_BOD12_ACTION_INT               (SUPC_BOD12_ACTION_INT_Val << SUPC_BOD12_ACTION_Pos)  /**< (SUPC_BOD12) The BOD12 generates an interrupt Position  */
+#define SUPC_BOD12_STDBYCFG_Pos             5                                              /**< (SUPC_BOD12) Configuration in Standby mode Position */
+#define SUPC_BOD12_STDBYCFG_Msk             (_U_(0x1) << SUPC_BOD12_STDBYCFG_Pos)          /**< (SUPC_BOD12) Configuration in Standby mode Mask */
+#define SUPC_BOD12_STDBYCFG                 SUPC_BOD12_STDBYCFG_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_BOD12_STDBYCFG_Msk instead */
+#define SUPC_BOD12_RUNSTDBY_Pos             6                                              /**< (SUPC_BOD12) Run during Standby Position */
+#define SUPC_BOD12_RUNSTDBY_Msk             (_U_(0x1) << SUPC_BOD12_RUNSTDBY_Pos)          /**< (SUPC_BOD12) Run during Standby Mask */
+#define SUPC_BOD12_RUNSTDBY                 SUPC_BOD12_RUNSTDBY_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_BOD12_RUNSTDBY_Msk instead */
+#define SUPC_BOD12_ACTCFG_Pos               8                                              /**< (SUPC_BOD12) Configuration in Active mode Position */
+#define SUPC_BOD12_ACTCFG_Msk               (_U_(0x1) << SUPC_BOD12_ACTCFG_Pos)            /**< (SUPC_BOD12) Configuration in Active mode Mask */
+#define SUPC_BOD12_ACTCFG                   SUPC_BOD12_ACTCFG_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_BOD12_ACTCFG_Msk instead */
+#define SUPC_BOD12_PSEL_Pos                 12                                             /**< (SUPC_BOD12) Prescaler Select Position */
+#define SUPC_BOD12_PSEL_Msk                 (_U_(0xF) << SUPC_BOD12_PSEL_Pos)              /**< (SUPC_BOD12) Prescaler Select Mask */
+#define SUPC_BOD12_PSEL(value)              (SUPC_BOD12_PSEL_Msk & ((value) << SUPC_BOD12_PSEL_Pos))
+#define   SUPC_BOD12_PSEL_DIV2_Val          _U_(0x0)                                       /**< (SUPC_BOD12) Divide clock by 2  */
+#define   SUPC_BOD12_PSEL_DIV4_Val          _U_(0x1)                                       /**< (SUPC_BOD12) Divide clock by 4  */
+#define   SUPC_BOD12_PSEL_DIV8_Val          _U_(0x2)                                       /**< (SUPC_BOD12) Divide clock by 8  */
+#define   SUPC_BOD12_PSEL_DIV16_Val         _U_(0x3)                                       /**< (SUPC_BOD12) Divide clock by 16  */
+#define   SUPC_BOD12_PSEL_DIV32_Val         _U_(0x4)                                       /**< (SUPC_BOD12) Divide clock by 32  */
+#define   SUPC_BOD12_PSEL_DIV64_Val         _U_(0x5)                                       /**< (SUPC_BOD12) Divide clock by 64  */
+#define   SUPC_BOD12_PSEL_DIV128_Val        _U_(0x6)                                       /**< (SUPC_BOD12) Divide clock by 128  */
+#define   SUPC_BOD12_PSEL_DIV256_Val        _U_(0x7)                                       /**< (SUPC_BOD12) Divide clock by 256  */
+#define   SUPC_BOD12_PSEL_DIV512_Val        _U_(0x8)                                       /**< (SUPC_BOD12) Divide clock by 512  */
+#define   SUPC_BOD12_PSEL_DIV1024_Val       _U_(0x9)                                       /**< (SUPC_BOD12) Divide clock by 1024  */
+#define   SUPC_BOD12_PSEL_DIV2048_Val       _U_(0xA)                                       /**< (SUPC_BOD12) Divide clock by 2048  */
+#define   SUPC_BOD12_PSEL_DIV4096_Val       _U_(0xB)                                       /**< (SUPC_BOD12) Divide clock by 4096  */
+#define   SUPC_BOD12_PSEL_DIV8192_Val       _U_(0xC)                                       /**< (SUPC_BOD12) Divide clock by 8192  */
+#define   SUPC_BOD12_PSEL_DIV16384_Val      _U_(0xD)                                       /**< (SUPC_BOD12) Divide clock by 16384  */
+#define   SUPC_BOD12_PSEL_DIV32768_Val      _U_(0xE)                                       /**< (SUPC_BOD12) Divide clock by 32768  */
+#define   SUPC_BOD12_PSEL_DIV65536_Val      _U_(0xF)                                       /**< (SUPC_BOD12) Divide clock by 65536  */
+#define SUPC_BOD12_PSEL_DIV2                (SUPC_BOD12_PSEL_DIV2_Val << SUPC_BOD12_PSEL_Pos)  /**< (SUPC_BOD12) Divide clock by 2 Position  */
+#define SUPC_BOD12_PSEL_DIV4                (SUPC_BOD12_PSEL_DIV4_Val << SUPC_BOD12_PSEL_Pos)  /**< (SUPC_BOD12) Divide clock by 4 Position  */
+#define SUPC_BOD12_PSEL_DIV8                (SUPC_BOD12_PSEL_DIV8_Val << SUPC_BOD12_PSEL_Pos)  /**< (SUPC_BOD12) Divide clock by 8 Position  */
+#define SUPC_BOD12_PSEL_DIV16               (SUPC_BOD12_PSEL_DIV16_Val << SUPC_BOD12_PSEL_Pos)  /**< (SUPC_BOD12) Divide clock by 16 Position  */
+#define SUPC_BOD12_PSEL_DIV32               (SUPC_BOD12_PSEL_DIV32_Val << SUPC_BOD12_PSEL_Pos)  /**< (SUPC_BOD12) Divide clock by 32 Position  */
+#define SUPC_BOD12_PSEL_DIV64               (SUPC_BOD12_PSEL_DIV64_Val << SUPC_BOD12_PSEL_Pos)  /**< (SUPC_BOD12) Divide clock by 64 Position  */
+#define SUPC_BOD12_PSEL_DIV128              (SUPC_BOD12_PSEL_DIV128_Val << SUPC_BOD12_PSEL_Pos)  /**< (SUPC_BOD12) Divide clock by 128 Position  */
+#define SUPC_BOD12_PSEL_DIV256              (SUPC_BOD12_PSEL_DIV256_Val << SUPC_BOD12_PSEL_Pos)  /**< (SUPC_BOD12) Divide clock by 256 Position  */
+#define SUPC_BOD12_PSEL_DIV512              (SUPC_BOD12_PSEL_DIV512_Val << SUPC_BOD12_PSEL_Pos)  /**< (SUPC_BOD12) Divide clock by 512 Position  */
+#define SUPC_BOD12_PSEL_DIV1024             (SUPC_BOD12_PSEL_DIV1024_Val << SUPC_BOD12_PSEL_Pos)  /**< (SUPC_BOD12) Divide clock by 1024 Position  */
+#define SUPC_BOD12_PSEL_DIV2048             (SUPC_BOD12_PSEL_DIV2048_Val << SUPC_BOD12_PSEL_Pos)  /**< (SUPC_BOD12) Divide clock by 2048 Position  */
+#define SUPC_BOD12_PSEL_DIV4096             (SUPC_BOD12_PSEL_DIV4096_Val << SUPC_BOD12_PSEL_Pos)  /**< (SUPC_BOD12) Divide clock by 4096 Position  */
+#define SUPC_BOD12_PSEL_DIV8192             (SUPC_BOD12_PSEL_DIV8192_Val << SUPC_BOD12_PSEL_Pos)  /**< (SUPC_BOD12) Divide clock by 8192 Position  */
+#define SUPC_BOD12_PSEL_DIV16384            (SUPC_BOD12_PSEL_DIV16384_Val << SUPC_BOD12_PSEL_Pos)  /**< (SUPC_BOD12) Divide clock by 16384 Position  */
+#define SUPC_BOD12_PSEL_DIV32768            (SUPC_BOD12_PSEL_DIV32768_Val << SUPC_BOD12_PSEL_Pos)  /**< (SUPC_BOD12) Divide clock by 32768 Position  */
+#define SUPC_BOD12_PSEL_DIV65536            (SUPC_BOD12_PSEL_DIV65536_Val << SUPC_BOD12_PSEL_Pos)  /**< (SUPC_BOD12) Divide clock by 65536 Position  */
+#define SUPC_BOD12_LEVEL_Pos                16                                             /**< (SUPC_BOD12) Threshold Level Position */
+#define SUPC_BOD12_LEVEL_Msk                (_U_(0x3F) << SUPC_BOD12_LEVEL_Pos)            /**< (SUPC_BOD12) Threshold Level Mask */
+#define SUPC_BOD12_LEVEL(value)             (SUPC_BOD12_LEVEL_Msk & ((value) << SUPC_BOD12_LEVEL_Pos))
+#define SUPC_BOD12_MASK                     _U_(0x3FF17E)                                  /**< \deprecated (SUPC_BOD12) Register MASK  (Use SUPC_BOD12_Msk instead)  */
+#define SUPC_BOD12_Msk                      _U_(0x3FF17E)                                  /**< (SUPC_BOD12) Register Mask  */
+
+
+/* -------- SUPC_VREG : (SUPC Offset: 0x18) (R/W 32) VREG Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint32_t SEL:2;                     /**< bit:   2..3  Voltage Regulator Selection in active mode */
+    uint32_t :1;                        /**< bit:      4  Reserved */
+    uint32_t STDBYPL0:1;                /**< bit:      5  Standby in PL0                           */
+    uint32_t RUNSTDBY:1;                /**< bit:      6  Run during Standby                       */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t LPEFF:1;                   /**< bit:      8  Low Power efficiency                     */
+    uint32_t VREFSEL:1;                 /**< bit:      9  Voltage Regulator Voltage Reference Selection */
+    uint32_t :6;                        /**< bit: 10..15  Reserved */
+    uint32_t VSVSTEP:4;                 /**< bit: 16..19  Voltage Scaling Voltage Step             */
+    uint32_t :4;                        /**< bit: 20..23  Reserved */
+    uint32_t VSPER:8;                   /**< bit: 24..31  Voltage Scaling Period                   */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :5;                        /**< bit:   0..4  Reserved */
+    uint32_t STDBYPL:1;                 /**< bit:      5  Standby in PLx                           */
+    uint32_t :26;                       /**< bit:  6..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} SUPC_VREG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SUPC_VREG_OFFSET                    (0x18)                                        /**<  (SUPC_VREG) VREG Control  Offset */
+#define SUPC_VREG_RESETVALUE                _U_(0x02)                                     /**<  (SUPC_VREG) VREG Control  Reset Value */
+
+#define SUPC_VREG_ENABLE_Pos                1                                              /**< (SUPC_VREG) Enable Position */
+#define SUPC_VREG_ENABLE_Msk                (_U_(0x1) << SUPC_VREG_ENABLE_Pos)             /**< (SUPC_VREG) Enable Mask */
+#define SUPC_VREG_ENABLE                    SUPC_VREG_ENABLE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_VREG_ENABLE_Msk instead */
+#define SUPC_VREG_SEL_Pos                   2                                              /**< (SUPC_VREG) Voltage Regulator Selection in active mode Position */
+#define SUPC_VREG_SEL_Msk                   (_U_(0x3) << SUPC_VREG_SEL_Pos)                /**< (SUPC_VREG) Voltage Regulator Selection in active mode Mask */
+#define SUPC_VREG_SEL(value)                (SUPC_VREG_SEL_Msk & ((value) << SUPC_VREG_SEL_Pos))
+#define   SUPC_VREG_SEL_LDO_Val             _U_(0x0)                                       /**< (SUPC_VREG) LDO selection  */
+#define   SUPC_VREG_SEL_BUCK_Val            _U_(0x1)                                       /**< (SUPC_VREG) Buck selection  */
+#define SUPC_VREG_SEL_LDO                   (SUPC_VREG_SEL_LDO_Val << SUPC_VREG_SEL_Pos)   /**< (SUPC_VREG) LDO selection Position  */
+#define SUPC_VREG_SEL_BUCK                  (SUPC_VREG_SEL_BUCK_Val << SUPC_VREG_SEL_Pos)  /**< (SUPC_VREG) Buck selection Position  */
+#define SUPC_VREG_STDBYPL0_Pos              5                                              /**< (SUPC_VREG) Standby in PL0 Position */
+#define SUPC_VREG_STDBYPL0_Msk              (_U_(0x1) << SUPC_VREG_STDBYPL0_Pos)           /**< (SUPC_VREG) Standby in PL0 Mask */
+#define SUPC_VREG_STDBYPL0                  SUPC_VREG_STDBYPL0_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_VREG_STDBYPL0_Msk instead */
+#define SUPC_VREG_RUNSTDBY_Pos              6                                              /**< (SUPC_VREG) Run during Standby Position */
+#define SUPC_VREG_RUNSTDBY_Msk              (_U_(0x1) << SUPC_VREG_RUNSTDBY_Pos)           /**< (SUPC_VREG) Run during Standby Mask */
+#define SUPC_VREG_RUNSTDBY                  SUPC_VREG_RUNSTDBY_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_VREG_RUNSTDBY_Msk instead */
+#define SUPC_VREG_LPEFF_Pos                 8                                              /**< (SUPC_VREG) Low Power efficiency Position */
+#define SUPC_VREG_LPEFF_Msk                 (_U_(0x1) << SUPC_VREG_LPEFF_Pos)              /**< (SUPC_VREG) Low Power efficiency Mask */
+#define SUPC_VREG_LPEFF                     SUPC_VREG_LPEFF_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_VREG_LPEFF_Msk instead */
+#define SUPC_VREG_VREFSEL_Pos               9                                              /**< (SUPC_VREG) Voltage Regulator Voltage Reference Selection Position */
+#define SUPC_VREG_VREFSEL_Msk               (_U_(0x1) << SUPC_VREG_VREFSEL_Pos)            /**< (SUPC_VREG) Voltage Regulator Voltage Reference Selection Mask */
+#define SUPC_VREG_VREFSEL                   SUPC_VREG_VREFSEL_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_VREG_VREFSEL_Msk instead */
+#define SUPC_VREG_VSVSTEP_Pos               16                                             /**< (SUPC_VREG) Voltage Scaling Voltage Step Position */
+#define SUPC_VREG_VSVSTEP_Msk               (_U_(0xF) << SUPC_VREG_VSVSTEP_Pos)            /**< (SUPC_VREG) Voltage Scaling Voltage Step Mask */
+#define SUPC_VREG_VSVSTEP(value)            (SUPC_VREG_VSVSTEP_Msk & ((value) << SUPC_VREG_VSVSTEP_Pos))
+#define SUPC_VREG_VSPER_Pos                 24                                             /**< (SUPC_VREG) Voltage Scaling Period Position */
+#define SUPC_VREG_VSPER_Msk                 (_U_(0xFF) << SUPC_VREG_VSPER_Pos)             /**< (SUPC_VREG) Voltage Scaling Period Mask */
+#define SUPC_VREG_VSPER(value)              (SUPC_VREG_VSPER_Msk & ((value) << SUPC_VREG_VSPER_Pos))
+#define SUPC_VREG_MASK                      _U_(0xFF0F036E)                                /**< \deprecated (SUPC_VREG) Register MASK  (Use SUPC_VREG_Msk instead)  */
+#define SUPC_VREG_Msk                       _U_(0xFF0F036E)                                /**< (SUPC_VREG) Register Mask  */
+
+#define SUPC_VREG_STDBYPL_Pos               5                                              /**< (SUPC_VREG Position) Standby in PLx */
+#define SUPC_VREG_STDBYPL_Msk               (_U_(0x1) << SUPC_VREG_STDBYPL_Pos)            /**< (SUPC_VREG Mask) STDBYPL */
+#define SUPC_VREG_STDBYPL(value)            (SUPC_VREG_STDBYPL_Msk & ((value) << SUPC_VREG_STDBYPL_Pos))  
+
+/* -------- SUPC_VREF : (SUPC Offset: 0x1c) (R/W 32) VREF Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t TSEN:1;                    /**< bit:      1  Temperature Sensor Output Enable         */
+    uint32_t VREFOE:1;                  /**< bit:      2  Voltage Reference Output Enable          */
+    uint32_t TSSEL:1;                   /**< bit:      3  Temperature Sensor Selection             */
+    uint32_t :2;                        /**< bit:   4..5  Reserved */
+    uint32_t RUNSTDBY:1;                /**< bit:      6  Run during Standby                       */
+    uint32_t ONDEMAND:1;                /**< bit:      7  On Demand Control                        */
+    uint32_t :8;                        /**< bit:  8..15  Reserved */
+    uint32_t SEL:4;                     /**< bit: 16..19  Voltage Reference Selection              */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SUPC_VREF_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SUPC_VREF_OFFSET                    (0x1C)                                        /**<  (SUPC_VREF) VREF Control  Offset */
+#define SUPC_VREF_RESETVALUE                _U_(0x00)                                     /**<  (SUPC_VREF) VREF Control  Reset Value */
+
+#define SUPC_VREF_TSEN_Pos                  1                                              /**< (SUPC_VREF) Temperature Sensor Output Enable Position */
+#define SUPC_VREF_TSEN_Msk                  (_U_(0x1) << SUPC_VREF_TSEN_Pos)               /**< (SUPC_VREF) Temperature Sensor Output Enable Mask */
+#define SUPC_VREF_TSEN                      SUPC_VREF_TSEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_VREF_TSEN_Msk instead */
+#define SUPC_VREF_VREFOE_Pos                2                                              /**< (SUPC_VREF) Voltage Reference Output Enable Position */
+#define SUPC_VREF_VREFOE_Msk                (_U_(0x1) << SUPC_VREF_VREFOE_Pos)             /**< (SUPC_VREF) Voltage Reference Output Enable Mask */
+#define SUPC_VREF_VREFOE                    SUPC_VREF_VREFOE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_VREF_VREFOE_Msk instead */
+#define SUPC_VREF_TSSEL_Pos                 3                                              /**< (SUPC_VREF) Temperature Sensor Selection Position */
+#define SUPC_VREF_TSSEL_Msk                 (_U_(0x1) << SUPC_VREF_TSSEL_Pos)              /**< (SUPC_VREF) Temperature Sensor Selection Mask */
+#define SUPC_VREF_TSSEL                     SUPC_VREF_TSSEL_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_VREF_TSSEL_Msk instead */
+#define SUPC_VREF_RUNSTDBY_Pos              6                                              /**< (SUPC_VREF) Run during Standby Position */
+#define SUPC_VREF_RUNSTDBY_Msk              (_U_(0x1) << SUPC_VREF_RUNSTDBY_Pos)           /**< (SUPC_VREF) Run during Standby Mask */
+#define SUPC_VREF_RUNSTDBY                  SUPC_VREF_RUNSTDBY_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_VREF_RUNSTDBY_Msk instead */
+#define SUPC_VREF_ONDEMAND_Pos              7                                              /**< (SUPC_VREF) On Demand Control Position */
+#define SUPC_VREF_ONDEMAND_Msk              (_U_(0x1) << SUPC_VREF_ONDEMAND_Pos)           /**< (SUPC_VREF) On Demand Control Mask */
+#define SUPC_VREF_ONDEMAND                  SUPC_VREF_ONDEMAND_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_VREF_ONDEMAND_Msk instead */
+#define SUPC_VREF_SEL_Pos                   16                                             /**< (SUPC_VREF) Voltage Reference Selection Position */
+#define SUPC_VREF_SEL_Msk                   (_U_(0xF) << SUPC_VREF_SEL_Pos)                /**< (SUPC_VREF) Voltage Reference Selection Mask */
+#define SUPC_VREF_SEL(value)                (SUPC_VREF_SEL_Msk & ((value) << SUPC_VREF_SEL_Pos))
+#define   SUPC_VREF_SEL_1V0_Val             _U_(0x0)                                       /**< (SUPC_VREF) 1.0V voltage reference typical value  */
+#define   SUPC_VREF_SEL_1V1_Val             _U_(0x1)                                       /**< (SUPC_VREF) 1.1V voltage reference typical value  */
+#define   SUPC_VREF_SEL_1V2_Val             _U_(0x2)                                       /**< (SUPC_VREF) 1.2V voltage reference typical value  */
+#define   SUPC_VREF_SEL_1V25_Val            _U_(0x3)                                       /**< (SUPC_VREF) 1.25V voltage reference typical value  */
+#define   SUPC_VREF_SEL_2V0_Val             _U_(0x4)                                       /**< (SUPC_VREF) 2.0V voltage reference typical value  */
+#define   SUPC_VREF_SEL_2V2_Val             _U_(0x5)                                       /**< (SUPC_VREF) 2.2V voltage reference typical value  */
+#define   SUPC_VREF_SEL_2V4_Val             _U_(0x6)                                       /**< (SUPC_VREF) 2.4V voltage reference typical value  */
+#define   SUPC_VREF_SEL_2V5_Val             _U_(0x7)                                       /**< (SUPC_VREF) 2.5V voltage reference typical value  */
+#define SUPC_VREF_SEL_1V0                   (SUPC_VREF_SEL_1V0_Val << SUPC_VREF_SEL_Pos)   /**< (SUPC_VREF) 1.0V voltage reference typical value Position  */
+#define SUPC_VREF_SEL_1V1                   (SUPC_VREF_SEL_1V1_Val << SUPC_VREF_SEL_Pos)   /**< (SUPC_VREF) 1.1V voltage reference typical value Position  */
+#define SUPC_VREF_SEL_1V2                   (SUPC_VREF_SEL_1V2_Val << SUPC_VREF_SEL_Pos)   /**< (SUPC_VREF) 1.2V voltage reference typical value Position  */
+#define SUPC_VREF_SEL_1V25                  (SUPC_VREF_SEL_1V25_Val << SUPC_VREF_SEL_Pos)  /**< (SUPC_VREF) 1.25V voltage reference typical value Position  */
+#define SUPC_VREF_SEL_2V0                   (SUPC_VREF_SEL_2V0_Val << SUPC_VREF_SEL_Pos)   /**< (SUPC_VREF) 2.0V voltage reference typical value Position  */
+#define SUPC_VREF_SEL_2V2                   (SUPC_VREF_SEL_2V2_Val << SUPC_VREF_SEL_Pos)   /**< (SUPC_VREF) 2.2V voltage reference typical value Position  */
+#define SUPC_VREF_SEL_2V4                   (SUPC_VREF_SEL_2V4_Val << SUPC_VREF_SEL_Pos)   /**< (SUPC_VREF) 2.4V voltage reference typical value Position  */
+#define SUPC_VREF_SEL_2V5                   (SUPC_VREF_SEL_2V5_Val << SUPC_VREF_SEL_Pos)   /**< (SUPC_VREF) 2.5V voltage reference typical value Position  */
+#define SUPC_VREF_MASK                      _U_(0xF00CE)                                   /**< \deprecated (SUPC_VREF) Register MASK  (Use SUPC_VREF_Msk instead)  */
+#define SUPC_VREF_Msk                       _U_(0xF00CE)                                   /**< (SUPC_VREF) Register Mask  */
+
+
+/* -------- SUPC_EVCTRL : (SUPC Offset: 0x2c) (R/W 32) Event Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t BOD33DETEO:1;              /**< bit:      1  BOD33 Detection Event Output Enable      */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t BOD12DETEO:1;              /**< bit:      4  BOD12 Detection Event Output Enable      */
+    uint32_t :27;                       /**< bit:  5..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SUPC_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SUPC_EVCTRL_OFFSET                  (0x2C)                                        /**<  (SUPC_EVCTRL) Event Control  Offset */
+#define SUPC_EVCTRL_RESETVALUE              _U_(0x00)                                     /**<  (SUPC_EVCTRL) Event Control  Reset Value */
+
+#define SUPC_EVCTRL_BOD33DETEO_Pos          1                                              /**< (SUPC_EVCTRL) BOD33 Detection Event Output Enable Position */
+#define SUPC_EVCTRL_BOD33DETEO_Msk          (_U_(0x1) << SUPC_EVCTRL_BOD33DETEO_Pos)       /**< (SUPC_EVCTRL) BOD33 Detection Event Output Enable Mask */
+#define SUPC_EVCTRL_BOD33DETEO              SUPC_EVCTRL_BOD33DETEO_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_EVCTRL_BOD33DETEO_Msk instead */
+#define SUPC_EVCTRL_BOD12DETEO_Pos          4                                              /**< (SUPC_EVCTRL) BOD12 Detection Event Output Enable Position */
+#define SUPC_EVCTRL_BOD12DETEO_Msk          (_U_(0x1) << SUPC_EVCTRL_BOD12DETEO_Pos)       /**< (SUPC_EVCTRL) BOD12 Detection Event Output Enable Mask */
+#define SUPC_EVCTRL_BOD12DETEO              SUPC_EVCTRL_BOD12DETEO_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_EVCTRL_BOD12DETEO_Msk instead */
+#define SUPC_EVCTRL_MASK                    _U_(0x12)                                      /**< \deprecated (SUPC_EVCTRL) Register MASK  (Use SUPC_EVCTRL_Msk instead)  */
+#define SUPC_EVCTRL_Msk                     _U_(0x12)                                      /**< (SUPC_EVCTRL) Register Mask  */
+
+
+/* -------- SUPC_VREGSUSP : (SUPC Offset: 0x30) (R/W 32) VREG Suspend Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t VREGSEN:1;                 /**< bit:      0  Enable Voltage Regulator Suspend         */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SUPC_VREGSUSP_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SUPC_VREGSUSP_OFFSET                (0x30)                                        /**<  (SUPC_VREGSUSP) VREG Suspend Control  Offset */
+#define SUPC_VREGSUSP_RESETVALUE            _U_(0x00)                                     /**<  (SUPC_VREGSUSP) VREG Suspend Control  Reset Value */
+
+#define SUPC_VREGSUSP_VREGSEN_Pos           0                                              /**< (SUPC_VREGSUSP) Enable Voltage Regulator Suspend Position */
+#define SUPC_VREGSUSP_VREGSEN_Msk           (_U_(0x1) << SUPC_VREGSUSP_VREGSEN_Pos)        /**< (SUPC_VREGSUSP) Enable Voltage Regulator Suspend Mask */
+#define SUPC_VREGSUSP_VREGSEN               SUPC_VREGSUSP_VREGSEN_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_VREGSUSP_VREGSEN_Msk instead */
+#define SUPC_VREGSUSP_MASK                  _U_(0x01)                                      /**< \deprecated (SUPC_VREGSUSP) Register MASK  (Use SUPC_VREGSUSP_Msk instead)  */
+#define SUPC_VREGSUSP_Msk                   _U_(0x01)                                      /**< (SUPC_VREGSUSP) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief SUPC hardware registers */
+typedef struct {  /* Supply Controller */
+  __IO SUPC_INTENCLR_Type             INTENCLR;       /**< Offset: 0x00 (R/W  32) Interrupt Enable Clear */
+  __IO SUPC_INTENSET_Type             INTENSET;       /**< Offset: 0x04 (R/W  32) Interrupt Enable Set */
+  __IO SUPC_INTFLAG_Type              INTFLAG;        /**< Offset: 0x08 (R/W  32) Interrupt Flag Status and Clear */
+  __I  SUPC_STATUS_Type               STATUS;         /**< Offset: 0x0C (R/   32) Power and Clocks Status */
+  __IO SUPC_BOD33_Type                BOD33;          /**< Offset: 0x10 (R/W  32) BOD33 Control */
+  __IO SUPC_BOD12_Type                BOD12;          /**< Offset: 0x14 (R/W  32) BOD12 Control */
+  __IO SUPC_VREG_Type                 VREG;           /**< Offset: 0x18 (R/W  32) VREG Control */
+  __IO SUPC_VREF_Type                 VREF;           /**< Offset: 0x1C (R/W  32) VREF Control */
+  __I  uint8_t                        Reserved1[12];
+  __IO SUPC_EVCTRL_Type               EVCTRL;         /**< Offset: 0x2C (R/W  32) Event Control */
+  __IO SUPC_VREGSUSP_Type             VREGSUSP;       /**< Offset: 0x30 (R/W  32) VREG Suspend Control */
+} Supc;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Supply Controller */
+
+#endif /* _SAML10_SUPC_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/component/tc.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/tc.h
@@ -1,0 +1,1027 @@
+/**
+ * \file
+ *
+ * \brief Component description for TC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_TC_COMPONENT_H_
+#define _SAML10_TC_COMPONENT_H_
+#define _SAML10_TC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML10 Basic Timer Counter
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR TC */
+/* ========================================================================== */
+
+#define TC_U2249                      /**< (TC) Module ID */
+#define REV_TC 0x310                  /**< (TC) Module revision */
+
+/* -------- TC_CTRLA : (TC Offset: 0x00) (R/W 32) Control A -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint32_t ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint32_t MODE:2;                    /**< bit:   2..3  Timer Counter Mode                       */
+    uint32_t PRESCSYNC:2;               /**< bit:   4..5  Prescaler and Counter Synchronization    */
+    uint32_t RUNSTDBY:1;                /**< bit:      6  Run during Standby                       */
+    uint32_t ONDEMAND:1;                /**< bit:      7  Clock On Demand                          */
+    uint32_t PRESCALER:3;               /**< bit:  8..10  Prescaler                                */
+    uint32_t ALOCK:1;                   /**< bit:     11  Auto Lock                                */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t CAPTEN0:1;                 /**< bit:     16  Capture Channel 0 Enable                 */
+    uint32_t CAPTEN1:1;                 /**< bit:     17  Capture Channel 1 Enable                 */
+    uint32_t :2;                        /**< bit: 18..19  Reserved */
+    uint32_t COPEN0:1;                  /**< bit:     20  Capture On Pin 0 Enable                  */
+    uint32_t COPEN1:1;                  /**< bit:     21  Capture On Pin 1 Enable                  */
+    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t CAPTMODE0:2;               /**< bit: 24..25  Capture Mode Channel 0                   */
+    uint32_t :1;                        /**< bit:     26  Reserved */
+    uint32_t CAPTMODE1:2;               /**< bit: 27..28  Capture mode Channel 1                   */
+    uint32_t :3;                        /**< bit: 29..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :16;                       /**< bit:  0..15  Reserved */
+    uint32_t CAPTEN:2;                  /**< bit: 16..17  Capture Channel x Enable                 */
+    uint32_t :2;                        /**< bit: 18..19  Reserved */
+    uint32_t COPEN:2;                   /**< bit: 20..21  Capture On Pin x Enable                  */
+    uint32_t :10;                       /**< bit: 22..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_CTRLA_OFFSET                     (0x00)                                        /**<  (TC_CTRLA) Control A  Offset */
+#define TC_CTRLA_RESETVALUE                 _U_(0x00)                                     /**<  (TC_CTRLA) Control A  Reset Value */
+
+#define TC_CTRLA_SWRST_Pos                  0                                              /**< (TC_CTRLA) Software Reset Position */
+#define TC_CTRLA_SWRST_Msk                  (_U_(0x1) << TC_CTRLA_SWRST_Pos)               /**< (TC_CTRLA) Software Reset Mask */
+#define TC_CTRLA_SWRST                      TC_CTRLA_SWRST_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CTRLA_SWRST_Msk instead */
+#define TC_CTRLA_ENABLE_Pos                 1                                              /**< (TC_CTRLA) Enable Position */
+#define TC_CTRLA_ENABLE_Msk                 (_U_(0x1) << TC_CTRLA_ENABLE_Pos)              /**< (TC_CTRLA) Enable Mask */
+#define TC_CTRLA_ENABLE                     TC_CTRLA_ENABLE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CTRLA_ENABLE_Msk instead */
+#define TC_CTRLA_MODE_Pos                   2                                              /**< (TC_CTRLA) Timer Counter Mode Position */
+#define TC_CTRLA_MODE_Msk                   (_U_(0x3) << TC_CTRLA_MODE_Pos)                /**< (TC_CTRLA) Timer Counter Mode Mask */
+#define TC_CTRLA_MODE(value)                (TC_CTRLA_MODE_Msk & ((value) << TC_CTRLA_MODE_Pos))
+#define   TC_CTRLA_MODE_COUNT16_Val         _U_(0x0)                                       /**< (TC_CTRLA) Counter in 16-bit mode  */
+#define   TC_CTRLA_MODE_COUNT8_Val          _U_(0x1)                                       /**< (TC_CTRLA) Counter in 8-bit mode  */
+#define   TC_CTRLA_MODE_COUNT32_Val         _U_(0x2)                                       /**< (TC_CTRLA) Counter in 32-bit mode  */
+#define TC_CTRLA_MODE_COUNT16               (TC_CTRLA_MODE_COUNT16_Val << TC_CTRLA_MODE_Pos)  /**< (TC_CTRLA) Counter in 16-bit mode Position  */
+#define TC_CTRLA_MODE_COUNT8                (TC_CTRLA_MODE_COUNT8_Val << TC_CTRLA_MODE_Pos)  /**< (TC_CTRLA) Counter in 8-bit mode Position  */
+#define TC_CTRLA_MODE_COUNT32               (TC_CTRLA_MODE_COUNT32_Val << TC_CTRLA_MODE_Pos)  /**< (TC_CTRLA) Counter in 32-bit mode Position  */
+#define TC_CTRLA_PRESCSYNC_Pos              4                                              /**< (TC_CTRLA) Prescaler and Counter Synchronization Position */
+#define TC_CTRLA_PRESCSYNC_Msk              (_U_(0x3) << TC_CTRLA_PRESCSYNC_Pos)           /**< (TC_CTRLA) Prescaler and Counter Synchronization Mask */
+#define TC_CTRLA_PRESCSYNC(value)           (TC_CTRLA_PRESCSYNC_Msk & ((value) << TC_CTRLA_PRESCSYNC_Pos))
+#define   TC_CTRLA_PRESCSYNC_GCLK_Val       _U_(0x0)                                       /**< (TC_CTRLA) Reload or reset the counter on next generic clock  */
+#define   TC_CTRLA_PRESCSYNC_PRESC_Val      _U_(0x1)                                       /**< (TC_CTRLA) Reload or reset the counter on next prescaler clock  */
+#define   TC_CTRLA_PRESCSYNC_RESYNC_Val     _U_(0x2)                                       /**< (TC_CTRLA) Reload or reset the counter on next generic clock and reset the prescaler counter  */
+#define TC_CTRLA_PRESCSYNC_GCLK             (TC_CTRLA_PRESCSYNC_GCLK_Val << TC_CTRLA_PRESCSYNC_Pos)  /**< (TC_CTRLA) Reload or reset the counter on next generic clock Position  */
+#define TC_CTRLA_PRESCSYNC_PRESC            (TC_CTRLA_PRESCSYNC_PRESC_Val << TC_CTRLA_PRESCSYNC_Pos)  /**< (TC_CTRLA) Reload or reset the counter on next prescaler clock Position  */
+#define TC_CTRLA_PRESCSYNC_RESYNC           (TC_CTRLA_PRESCSYNC_RESYNC_Val << TC_CTRLA_PRESCSYNC_Pos)  /**< (TC_CTRLA) Reload or reset the counter on next generic clock and reset the prescaler counter Position  */
+#define TC_CTRLA_RUNSTDBY_Pos               6                                              /**< (TC_CTRLA) Run during Standby Position */
+#define TC_CTRLA_RUNSTDBY_Msk               (_U_(0x1) << TC_CTRLA_RUNSTDBY_Pos)            /**< (TC_CTRLA) Run during Standby Mask */
+#define TC_CTRLA_RUNSTDBY                   TC_CTRLA_RUNSTDBY_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CTRLA_RUNSTDBY_Msk instead */
+#define TC_CTRLA_ONDEMAND_Pos               7                                              /**< (TC_CTRLA) Clock On Demand Position */
+#define TC_CTRLA_ONDEMAND_Msk               (_U_(0x1) << TC_CTRLA_ONDEMAND_Pos)            /**< (TC_CTRLA) Clock On Demand Mask */
+#define TC_CTRLA_ONDEMAND                   TC_CTRLA_ONDEMAND_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CTRLA_ONDEMAND_Msk instead */
+#define TC_CTRLA_PRESCALER_Pos              8                                              /**< (TC_CTRLA) Prescaler Position */
+#define TC_CTRLA_PRESCALER_Msk              (_U_(0x7) << TC_CTRLA_PRESCALER_Pos)           /**< (TC_CTRLA) Prescaler Mask */
+#define TC_CTRLA_PRESCALER(value)           (TC_CTRLA_PRESCALER_Msk & ((value) << TC_CTRLA_PRESCALER_Pos))
+#define   TC_CTRLA_PRESCALER_DIV1_Val       _U_(0x0)                                       /**< (TC_CTRLA) Prescaler: GCLK_TC  */
+#define   TC_CTRLA_PRESCALER_DIV2_Val       _U_(0x1)                                       /**< (TC_CTRLA) Prescaler: GCLK_TC/2  */
+#define   TC_CTRLA_PRESCALER_DIV4_Val       _U_(0x2)                                       /**< (TC_CTRLA) Prescaler: GCLK_TC/4  */
+#define   TC_CTRLA_PRESCALER_DIV8_Val       _U_(0x3)                                       /**< (TC_CTRLA) Prescaler: GCLK_TC/8  */
+#define   TC_CTRLA_PRESCALER_DIV16_Val      _U_(0x4)                                       /**< (TC_CTRLA) Prescaler: GCLK_TC/16  */
+#define   TC_CTRLA_PRESCALER_DIV64_Val      _U_(0x5)                                       /**< (TC_CTRLA) Prescaler: GCLK_TC/64  */
+#define   TC_CTRLA_PRESCALER_DIV256_Val     _U_(0x6)                                       /**< (TC_CTRLA) Prescaler: GCLK_TC/256  */
+#define   TC_CTRLA_PRESCALER_DIV1024_Val    _U_(0x7)                                       /**< (TC_CTRLA) Prescaler: GCLK_TC/1024  */
+#define TC_CTRLA_PRESCALER_DIV1             (TC_CTRLA_PRESCALER_DIV1_Val << TC_CTRLA_PRESCALER_Pos)  /**< (TC_CTRLA) Prescaler: GCLK_TC Position  */
+#define TC_CTRLA_PRESCALER_DIV2             (TC_CTRLA_PRESCALER_DIV2_Val << TC_CTRLA_PRESCALER_Pos)  /**< (TC_CTRLA) Prescaler: GCLK_TC/2 Position  */
+#define TC_CTRLA_PRESCALER_DIV4             (TC_CTRLA_PRESCALER_DIV4_Val << TC_CTRLA_PRESCALER_Pos)  /**< (TC_CTRLA) Prescaler: GCLK_TC/4 Position  */
+#define TC_CTRLA_PRESCALER_DIV8             (TC_CTRLA_PRESCALER_DIV8_Val << TC_CTRLA_PRESCALER_Pos)  /**< (TC_CTRLA) Prescaler: GCLK_TC/8 Position  */
+#define TC_CTRLA_PRESCALER_DIV16            (TC_CTRLA_PRESCALER_DIV16_Val << TC_CTRLA_PRESCALER_Pos)  /**< (TC_CTRLA) Prescaler: GCLK_TC/16 Position  */
+#define TC_CTRLA_PRESCALER_DIV64            (TC_CTRLA_PRESCALER_DIV64_Val << TC_CTRLA_PRESCALER_Pos)  /**< (TC_CTRLA) Prescaler: GCLK_TC/64 Position  */
+#define TC_CTRLA_PRESCALER_DIV256           (TC_CTRLA_PRESCALER_DIV256_Val << TC_CTRLA_PRESCALER_Pos)  /**< (TC_CTRLA) Prescaler: GCLK_TC/256 Position  */
+#define TC_CTRLA_PRESCALER_DIV1024          (TC_CTRLA_PRESCALER_DIV1024_Val << TC_CTRLA_PRESCALER_Pos)  /**< (TC_CTRLA) Prescaler: GCLK_TC/1024 Position  */
+#define TC_CTRLA_ALOCK_Pos                  11                                             /**< (TC_CTRLA) Auto Lock Position */
+#define TC_CTRLA_ALOCK_Msk                  (_U_(0x1) << TC_CTRLA_ALOCK_Pos)               /**< (TC_CTRLA) Auto Lock Mask */
+#define TC_CTRLA_ALOCK                      TC_CTRLA_ALOCK_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CTRLA_ALOCK_Msk instead */
+#define TC_CTRLA_CAPTEN0_Pos                16                                             /**< (TC_CTRLA) Capture Channel 0 Enable Position */
+#define TC_CTRLA_CAPTEN0_Msk                (_U_(0x1) << TC_CTRLA_CAPTEN0_Pos)             /**< (TC_CTRLA) Capture Channel 0 Enable Mask */
+#define TC_CTRLA_CAPTEN0                    TC_CTRLA_CAPTEN0_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CTRLA_CAPTEN0_Msk instead */
+#define TC_CTRLA_CAPTEN1_Pos                17                                             /**< (TC_CTRLA) Capture Channel 1 Enable Position */
+#define TC_CTRLA_CAPTEN1_Msk                (_U_(0x1) << TC_CTRLA_CAPTEN1_Pos)             /**< (TC_CTRLA) Capture Channel 1 Enable Mask */
+#define TC_CTRLA_CAPTEN1                    TC_CTRLA_CAPTEN1_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CTRLA_CAPTEN1_Msk instead */
+#define TC_CTRLA_COPEN0_Pos                 20                                             /**< (TC_CTRLA) Capture On Pin 0 Enable Position */
+#define TC_CTRLA_COPEN0_Msk                 (_U_(0x1) << TC_CTRLA_COPEN0_Pos)              /**< (TC_CTRLA) Capture On Pin 0 Enable Mask */
+#define TC_CTRLA_COPEN0                     TC_CTRLA_COPEN0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CTRLA_COPEN0_Msk instead */
+#define TC_CTRLA_COPEN1_Pos                 21                                             /**< (TC_CTRLA) Capture On Pin 1 Enable Position */
+#define TC_CTRLA_COPEN1_Msk                 (_U_(0x1) << TC_CTRLA_COPEN1_Pos)              /**< (TC_CTRLA) Capture On Pin 1 Enable Mask */
+#define TC_CTRLA_COPEN1                     TC_CTRLA_COPEN1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CTRLA_COPEN1_Msk instead */
+#define TC_CTRLA_CAPTMODE0_Pos              24                                             /**< (TC_CTRLA) Capture Mode Channel 0 Position */
+#define TC_CTRLA_CAPTMODE0_Msk              (_U_(0x3) << TC_CTRLA_CAPTMODE0_Pos)           /**< (TC_CTRLA) Capture Mode Channel 0 Mask */
+#define TC_CTRLA_CAPTMODE0(value)           (TC_CTRLA_CAPTMODE0_Msk & ((value) << TC_CTRLA_CAPTMODE0_Pos))
+#define   TC_CTRLA_CAPTMODE0_DEFAULT_Val    _U_(0x0)                                       /**< (TC_CTRLA) Default capture  */
+#define   TC_CTRLA_CAPTMODE0_CAPTMIN_Val    _U_(0x1)                                       /**< (TC_CTRLA) Minimum capture  */
+#define   TC_CTRLA_CAPTMODE0_CAPTMAX_Val    _U_(0x2)                                       /**< (TC_CTRLA) Maximum capture  */
+#define TC_CTRLA_CAPTMODE0_DEFAULT          (TC_CTRLA_CAPTMODE0_DEFAULT_Val << TC_CTRLA_CAPTMODE0_Pos)  /**< (TC_CTRLA) Default capture Position  */
+#define TC_CTRLA_CAPTMODE0_CAPTMIN          (TC_CTRLA_CAPTMODE0_CAPTMIN_Val << TC_CTRLA_CAPTMODE0_Pos)  /**< (TC_CTRLA) Minimum capture Position  */
+#define TC_CTRLA_CAPTMODE0_CAPTMAX          (TC_CTRLA_CAPTMODE0_CAPTMAX_Val << TC_CTRLA_CAPTMODE0_Pos)  /**< (TC_CTRLA) Maximum capture Position  */
+#define TC_CTRLA_CAPTMODE1_Pos              27                                             /**< (TC_CTRLA) Capture mode Channel 1 Position */
+#define TC_CTRLA_CAPTMODE1_Msk              (_U_(0x3) << TC_CTRLA_CAPTMODE1_Pos)           /**< (TC_CTRLA) Capture mode Channel 1 Mask */
+#define TC_CTRLA_CAPTMODE1(value)           (TC_CTRLA_CAPTMODE1_Msk & ((value) << TC_CTRLA_CAPTMODE1_Pos))
+#define   TC_CTRLA_CAPTMODE1_DEFAULT_Val    _U_(0x0)                                       /**< (TC_CTRLA) Default capture  */
+#define   TC_CTRLA_CAPTMODE1_CAPTMIN_Val    _U_(0x1)                                       /**< (TC_CTRLA) Minimum capture  */
+#define   TC_CTRLA_CAPTMODE1_CAPTMAX_Val    _U_(0x2)                                       /**< (TC_CTRLA) Maximum capture  */
+#define TC_CTRLA_CAPTMODE1_DEFAULT          (TC_CTRLA_CAPTMODE1_DEFAULT_Val << TC_CTRLA_CAPTMODE1_Pos)  /**< (TC_CTRLA) Default capture Position  */
+#define TC_CTRLA_CAPTMODE1_CAPTMIN          (TC_CTRLA_CAPTMODE1_CAPTMIN_Val << TC_CTRLA_CAPTMODE1_Pos)  /**< (TC_CTRLA) Minimum capture Position  */
+#define TC_CTRLA_CAPTMODE1_CAPTMAX          (TC_CTRLA_CAPTMODE1_CAPTMAX_Val << TC_CTRLA_CAPTMODE1_Pos)  /**< (TC_CTRLA) Maximum capture Position  */
+#define TC_CTRLA_MASK                       _U_(0x1B330FFF)                                /**< \deprecated (TC_CTRLA) Register MASK  (Use TC_CTRLA_Msk instead)  */
+#define TC_CTRLA_Msk                        _U_(0x1B330FFF)                                /**< (TC_CTRLA) Register Mask  */
+
+#define TC_CTRLA_CAPTEN_Pos                 16                                             /**< (TC_CTRLA Position) Capture Channel x Enable */
+#define TC_CTRLA_CAPTEN_Msk                 (_U_(0x3) << TC_CTRLA_CAPTEN_Pos)              /**< (TC_CTRLA Mask) CAPTEN */
+#define TC_CTRLA_CAPTEN(value)              (TC_CTRLA_CAPTEN_Msk & ((value) << TC_CTRLA_CAPTEN_Pos))  
+#define TC_CTRLA_COPEN_Pos                  20                                             /**< (TC_CTRLA Position) Capture On Pin x Enable */
+#define TC_CTRLA_COPEN_Msk                  (_U_(0x3) << TC_CTRLA_COPEN_Pos)               /**< (TC_CTRLA Mask) COPEN */
+#define TC_CTRLA_COPEN(value)               (TC_CTRLA_COPEN_Msk & ((value) << TC_CTRLA_COPEN_Pos))  
+
+/* -------- TC_CTRLBCLR : (TC Offset: 0x04) (R/W 8) Control B Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DIR:1;                     /**< bit:      0  Counter Direction                        */
+    uint8_t  LUPD:1;                    /**< bit:      1  Lock Update                              */
+    uint8_t  ONESHOT:1;                 /**< bit:      2  One-Shot on Counter                      */
+    uint8_t  :2;                        /**< bit:   3..4  Reserved */
+    uint8_t  CMD:3;                     /**< bit:   5..7  Command                                  */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} TC_CTRLBCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_CTRLBCLR_OFFSET                  (0x04)                                        /**<  (TC_CTRLBCLR) Control B Clear  Offset */
+#define TC_CTRLBCLR_RESETVALUE              _U_(0x00)                                     /**<  (TC_CTRLBCLR) Control B Clear  Reset Value */
+
+#define TC_CTRLBCLR_DIR_Pos                 0                                              /**< (TC_CTRLBCLR) Counter Direction Position */
+#define TC_CTRLBCLR_DIR_Msk                 (_U_(0x1) << TC_CTRLBCLR_DIR_Pos)              /**< (TC_CTRLBCLR) Counter Direction Mask */
+#define TC_CTRLBCLR_DIR                     TC_CTRLBCLR_DIR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CTRLBCLR_DIR_Msk instead */
+#define TC_CTRLBCLR_LUPD_Pos                1                                              /**< (TC_CTRLBCLR) Lock Update Position */
+#define TC_CTRLBCLR_LUPD_Msk                (_U_(0x1) << TC_CTRLBCLR_LUPD_Pos)             /**< (TC_CTRLBCLR) Lock Update Mask */
+#define TC_CTRLBCLR_LUPD                    TC_CTRLBCLR_LUPD_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CTRLBCLR_LUPD_Msk instead */
+#define TC_CTRLBCLR_ONESHOT_Pos             2                                              /**< (TC_CTRLBCLR) One-Shot on Counter Position */
+#define TC_CTRLBCLR_ONESHOT_Msk             (_U_(0x1) << TC_CTRLBCLR_ONESHOT_Pos)          /**< (TC_CTRLBCLR) One-Shot on Counter Mask */
+#define TC_CTRLBCLR_ONESHOT                 TC_CTRLBCLR_ONESHOT_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CTRLBCLR_ONESHOT_Msk instead */
+#define TC_CTRLBCLR_CMD_Pos                 5                                              /**< (TC_CTRLBCLR) Command Position */
+#define TC_CTRLBCLR_CMD_Msk                 (_U_(0x7) << TC_CTRLBCLR_CMD_Pos)              /**< (TC_CTRLBCLR) Command Mask */
+#define TC_CTRLBCLR_CMD(value)              (TC_CTRLBCLR_CMD_Msk & ((value) << TC_CTRLBCLR_CMD_Pos))
+#define   TC_CTRLBCLR_CMD_NONE_Val          _U_(0x0)                                       /**< (TC_CTRLBCLR) No action  */
+#define   TC_CTRLBCLR_CMD_RETRIGGER_Val     _U_(0x1)                                       /**< (TC_CTRLBCLR) Force a start, restart or retrigger  */
+#define   TC_CTRLBCLR_CMD_STOP_Val          _U_(0x2)                                       /**< (TC_CTRLBCLR) Force a stop  */
+#define   TC_CTRLBCLR_CMD_UPDATE_Val        _U_(0x3)                                       /**< (TC_CTRLBCLR) Force update of double-buffered register  */
+#define   TC_CTRLBCLR_CMD_READSYNC_Val      _U_(0x4)                                       /**< (TC_CTRLBCLR) Force a read synchronization of COUNT  */
+#define   TC_CTRLBCLR_CMD_DMAOS_Val         _U_(0x5)                                       /**< (TC_CTRLBCLR) One-shot DMA trigger  */
+#define TC_CTRLBCLR_CMD_NONE                (TC_CTRLBCLR_CMD_NONE_Val << TC_CTRLBCLR_CMD_Pos)  /**< (TC_CTRLBCLR) No action Position  */
+#define TC_CTRLBCLR_CMD_RETRIGGER           (TC_CTRLBCLR_CMD_RETRIGGER_Val << TC_CTRLBCLR_CMD_Pos)  /**< (TC_CTRLBCLR) Force a start, restart or retrigger Position  */
+#define TC_CTRLBCLR_CMD_STOP                (TC_CTRLBCLR_CMD_STOP_Val << TC_CTRLBCLR_CMD_Pos)  /**< (TC_CTRLBCLR) Force a stop Position  */
+#define TC_CTRLBCLR_CMD_UPDATE              (TC_CTRLBCLR_CMD_UPDATE_Val << TC_CTRLBCLR_CMD_Pos)  /**< (TC_CTRLBCLR) Force update of double-buffered register Position  */
+#define TC_CTRLBCLR_CMD_READSYNC            (TC_CTRLBCLR_CMD_READSYNC_Val << TC_CTRLBCLR_CMD_Pos)  /**< (TC_CTRLBCLR) Force a read synchronization of COUNT Position  */
+#define TC_CTRLBCLR_CMD_DMAOS               (TC_CTRLBCLR_CMD_DMAOS_Val << TC_CTRLBCLR_CMD_Pos)  /**< (TC_CTRLBCLR) One-shot DMA trigger Position  */
+#define TC_CTRLBCLR_MASK                    _U_(0xE7)                                      /**< \deprecated (TC_CTRLBCLR) Register MASK  (Use TC_CTRLBCLR_Msk instead)  */
+#define TC_CTRLBCLR_Msk                     _U_(0xE7)                                      /**< (TC_CTRLBCLR) Register Mask  */
+
+
+/* -------- TC_CTRLBSET : (TC Offset: 0x05) (R/W 8) Control B Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DIR:1;                     /**< bit:      0  Counter Direction                        */
+    uint8_t  LUPD:1;                    /**< bit:      1  Lock Update                              */
+    uint8_t  ONESHOT:1;                 /**< bit:      2  One-Shot on Counter                      */
+    uint8_t  :2;                        /**< bit:   3..4  Reserved */
+    uint8_t  CMD:3;                     /**< bit:   5..7  Command                                  */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} TC_CTRLBSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_CTRLBSET_OFFSET                  (0x05)                                        /**<  (TC_CTRLBSET) Control B Set  Offset */
+#define TC_CTRLBSET_RESETVALUE              _U_(0x00)                                     /**<  (TC_CTRLBSET) Control B Set  Reset Value */
+
+#define TC_CTRLBSET_DIR_Pos                 0                                              /**< (TC_CTRLBSET) Counter Direction Position */
+#define TC_CTRLBSET_DIR_Msk                 (_U_(0x1) << TC_CTRLBSET_DIR_Pos)              /**< (TC_CTRLBSET) Counter Direction Mask */
+#define TC_CTRLBSET_DIR                     TC_CTRLBSET_DIR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CTRLBSET_DIR_Msk instead */
+#define TC_CTRLBSET_LUPD_Pos                1                                              /**< (TC_CTRLBSET) Lock Update Position */
+#define TC_CTRLBSET_LUPD_Msk                (_U_(0x1) << TC_CTRLBSET_LUPD_Pos)             /**< (TC_CTRLBSET) Lock Update Mask */
+#define TC_CTRLBSET_LUPD                    TC_CTRLBSET_LUPD_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CTRLBSET_LUPD_Msk instead */
+#define TC_CTRLBSET_ONESHOT_Pos             2                                              /**< (TC_CTRLBSET) One-Shot on Counter Position */
+#define TC_CTRLBSET_ONESHOT_Msk             (_U_(0x1) << TC_CTRLBSET_ONESHOT_Pos)          /**< (TC_CTRLBSET) One-Shot on Counter Mask */
+#define TC_CTRLBSET_ONESHOT                 TC_CTRLBSET_ONESHOT_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CTRLBSET_ONESHOT_Msk instead */
+#define TC_CTRLBSET_CMD_Pos                 5                                              /**< (TC_CTRLBSET) Command Position */
+#define TC_CTRLBSET_CMD_Msk                 (_U_(0x7) << TC_CTRLBSET_CMD_Pos)              /**< (TC_CTRLBSET) Command Mask */
+#define TC_CTRLBSET_CMD(value)              (TC_CTRLBSET_CMD_Msk & ((value) << TC_CTRLBSET_CMD_Pos))
+#define   TC_CTRLBSET_CMD_NONE_Val          _U_(0x0)                                       /**< (TC_CTRLBSET) No action  */
+#define   TC_CTRLBSET_CMD_RETRIGGER_Val     _U_(0x1)                                       /**< (TC_CTRLBSET) Force a start, restart or retrigger  */
+#define   TC_CTRLBSET_CMD_STOP_Val          _U_(0x2)                                       /**< (TC_CTRLBSET) Force a stop  */
+#define   TC_CTRLBSET_CMD_UPDATE_Val        _U_(0x3)                                       /**< (TC_CTRLBSET) Force update of double-buffered register  */
+#define   TC_CTRLBSET_CMD_READSYNC_Val      _U_(0x4)                                       /**< (TC_CTRLBSET) Force a read synchronization of COUNT  */
+#define   TC_CTRLBSET_CMD_DMAOS_Val         _U_(0x5)                                       /**< (TC_CTRLBSET) One-shot DMA trigger  */
+#define TC_CTRLBSET_CMD_NONE                (TC_CTRLBSET_CMD_NONE_Val << TC_CTRLBSET_CMD_Pos)  /**< (TC_CTRLBSET) No action Position  */
+#define TC_CTRLBSET_CMD_RETRIGGER           (TC_CTRLBSET_CMD_RETRIGGER_Val << TC_CTRLBSET_CMD_Pos)  /**< (TC_CTRLBSET) Force a start, restart or retrigger Position  */
+#define TC_CTRLBSET_CMD_STOP                (TC_CTRLBSET_CMD_STOP_Val << TC_CTRLBSET_CMD_Pos)  /**< (TC_CTRLBSET) Force a stop Position  */
+#define TC_CTRLBSET_CMD_UPDATE              (TC_CTRLBSET_CMD_UPDATE_Val << TC_CTRLBSET_CMD_Pos)  /**< (TC_CTRLBSET) Force update of double-buffered register Position  */
+#define TC_CTRLBSET_CMD_READSYNC            (TC_CTRLBSET_CMD_READSYNC_Val << TC_CTRLBSET_CMD_Pos)  /**< (TC_CTRLBSET) Force a read synchronization of COUNT Position  */
+#define TC_CTRLBSET_CMD_DMAOS               (TC_CTRLBSET_CMD_DMAOS_Val << TC_CTRLBSET_CMD_Pos)  /**< (TC_CTRLBSET) One-shot DMA trigger Position  */
+#define TC_CTRLBSET_MASK                    _U_(0xE7)                                      /**< \deprecated (TC_CTRLBSET) Register MASK  (Use TC_CTRLBSET_Msk instead)  */
+#define TC_CTRLBSET_Msk                     _U_(0xE7)                                      /**< (TC_CTRLBSET) Register Mask  */
+
+
+/* -------- TC_EVCTRL : (TC Offset: 0x06) (R/W 16) Event Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t EVACT:3;                   /**< bit:   0..2  Event Action                             */
+    uint16_t :1;                        /**< bit:      3  Reserved */
+    uint16_t TCINV:1;                   /**< bit:      4  TC Event Input Polarity                  */
+    uint16_t TCEI:1;                    /**< bit:      5  TC Event Enable                          */
+    uint16_t :2;                        /**< bit:   6..7  Reserved */
+    uint16_t OVFEO:1;                   /**< bit:      8  Event Output Enable                      */
+    uint16_t :3;                        /**< bit:  9..11  Reserved */
+    uint16_t MCEO0:1;                   /**< bit:     12  MC Event Output Enable 0                 */
+    uint16_t MCEO1:1;                   /**< bit:     13  MC Event Output Enable 1                 */
+    uint16_t :2;                        /**< bit: 14..15  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint16_t :12;                       /**< bit:  0..11  Reserved */
+    uint16_t MCEO:2;                    /**< bit: 12..13  MC Event Output Enable x                 */
+    uint16_t :2;                        /**< bit: 14..15 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint16_t reg;                         /**< Type used for register access */
+} TC_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_EVCTRL_OFFSET                    (0x06)                                        /**<  (TC_EVCTRL) Event Control  Offset */
+#define TC_EVCTRL_RESETVALUE                _U_(0x00)                                     /**<  (TC_EVCTRL) Event Control  Reset Value */
+
+#define TC_EVCTRL_EVACT_Pos                 0                                              /**< (TC_EVCTRL) Event Action Position */
+#define TC_EVCTRL_EVACT_Msk                 (_U_(0x7) << TC_EVCTRL_EVACT_Pos)              /**< (TC_EVCTRL) Event Action Mask */
+#define TC_EVCTRL_EVACT(value)              (TC_EVCTRL_EVACT_Msk & ((value) << TC_EVCTRL_EVACT_Pos))
+#define   TC_EVCTRL_EVACT_OFF_Val           _U_(0x0)                                       /**< (TC_EVCTRL) Event action disabled  */
+#define   TC_EVCTRL_EVACT_RETRIGGER_Val     _U_(0x1)                                       /**< (TC_EVCTRL) Start, restart or retrigger TC on event  */
+#define   TC_EVCTRL_EVACT_COUNT_Val         _U_(0x2)                                       /**< (TC_EVCTRL) Count on event  */
+#define   TC_EVCTRL_EVACT_START_Val         _U_(0x3)                                       /**< (TC_EVCTRL) Start TC on event  */
+#define   TC_EVCTRL_EVACT_STAMP_Val         _U_(0x4)                                       /**< (TC_EVCTRL) Time stamp capture  */
+#define   TC_EVCTRL_EVACT_PPW_Val           _U_(0x5)                                       /**< (TC_EVCTRL) Period catured in CC0, pulse width in CC1  */
+#define   TC_EVCTRL_EVACT_PWP_Val           _U_(0x6)                                       /**< (TC_EVCTRL) Period catured in CC1, pulse width in CC0  */
+#define   TC_EVCTRL_EVACT_PW_Val            _U_(0x7)                                       /**< (TC_EVCTRL) Pulse width capture  */
+#define TC_EVCTRL_EVACT_OFF                 (TC_EVCTRL_EVACT_OFF_Val << TC_EVCTRL_EVACT_Pos)  /**< (TC_EVCTRL) Event action disabled Position  */
+#define TC_EVCTRL_EVACT_RETRIGGER           (TC_EVCTRL_EVACT_RETRIGGER_Val << TC_EVCTRL_EVACT_Pos)  /**< (TC_EVCTRL) Start, restart or retrigger TC on event Position  */
+#define TC_EVCTRL_EVACT_COUNT               (TC_EVCTRL_EVACT_COUNT_Val << TC_EVCTRL_EVACT_Pos)  /**< (TC_EVCTRL) Count on event Position  */
+#define TC_EVCTRL_EVACT_START               (TC_EVCTRL_EVACT_START_Val << TC_EVCTRL_EVACT_Pos)  /**< (TC_EVCTRL) Start TC on event Position  */
+#define TC_EVCTRL_EVACT_STAMP               (TC_EVCTRL_EVACT_STAMP_Val << TC_EVCTRL_EVACT_Pos)  /**< (TC_EVCTRL) Time stamp capture Position  */
+#define TC_EVCTRL_EVACT_PPW                 (TC_EVCTRL_EVACT_PPW_Val << TC_EVCTRL_EVACT_Pos)  /**< (TC_EVCTRL) Period catured in CC0, pulse width in CC1 Position  */
+#define TC_EVCTRL_EVACT_PWP                 (TC_EVCTRL_EVACT_PWP_Val << TC_EVCTRL_EVACT_Pos)  /**< (TC_EVCTRL) Period catured in CC1, pulse width in CC0 Position  */
+#define TC_EVCTRL_EVACT_PW                  (TC_EVCTRL_EVACT_PW_Val << TC_EVCTRL_EVACT_Pos)  /**< (TC_EVCTRL) Pulse width capture Position  */
+#define TC_EVCTRL_TCINV_Pos                 4                                              /**< (TC_EVCTRL) TC Event Input Polarity Position */
+#define TC_EVCTRL_TCINV_Msk                 (_U_(0x1) << TC_EVCTRL_TCINV_Pos)              /**< (TC_EVCTRL) TC Event Input Polarity Mask */
+#define TC_EVCTRL_TCINV                     TC_EVCTRL_TCINV_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_EVCTRL_TCINV_Msk instead */
+#define TC_EVCTRL_TCEI_Pos                  5                                              /**< (TC_EVCTRL) TC Event Enable Position */
+#define TC_EVCTRL_TCEI_Msk                  (_U_(0x1) << TC_EVCTRL_TCEI_Pos)               /**< (TC_EVCTRL) TC Event Enable Mask */
+#define TC_EVCTRL_TCEI                      TC_EVCTRL_TCEI_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_EVCTRL_TCEI_Msk instead */
+#define TC_EVCTRL_OVFEO_Pos                 8                                              /**< (TC_EVCTRL) Event Output Enable Position */
+#define TC_EVCTRL_OVFEO_Msk                 (_U_(0x1) << TC_EVCTRL_OVFEO_Pos)              /**< (TC_EVCTRL) Event Output Enable Mask */
+#define TC_EVCTRL_OVFEO                     TC_EVCTRL_OVFEO_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_EVCTRL_OVFEO_Msk instead */
+#define TC_EVCTRL_MCEO0_Pos                 12                                             /**< (TC_EVCTRL) MC Event Output Enable 0 Position */
+#define TC_EVCTRL_MCEO0_Msk                 (_U_(0x1) << TC_EVCTRL_MCEO0_Pos)              /**< (TC_EVCTRL) MC Event Output Enable 0 Mask */
+#define TC_EVCTRL_MCEO0                     TC_EVCTRL_MCEO0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_EVCTRL_MCEO0_Msk instead */
+#define TC_EVCTRL_MCEO1_Pos                 13                                             /**< (TC_EVCTRL) MC Event Output Enable 1 Position */
+#define TC_EVCTRL_MCEO1_Msk                 (_U_(0x1) << TC_EVCTRL_MCEO1_Pos)              /**< (TC_EVCTRL) MC Event Output Enable 1 Mask */
+#define TC_EVCTRL_MCEO1                     TC_EVCTRL_MCEO1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_EVCTRL_MCEO1_Msk instead */
+#define TC_EVCTRL_MASK                      _U_(0x3137)                                    /**< \deprecated (TC_EVCTRL) Register MASK  (Use TC_EVCTRL_Msk instead)  */
+#define TC_EVCTRL_Msk                       _U_(0x3137)                                    /**< (TC_EVCTRL) Register Mask  */
+
+#define TC_EVCTRL_MCEO_Pos                  12                                             /**< (TC_EVCTRL Position) MC Event Output Enable x */
+#define TC_EVCTRL_MCEO_Msk                  (_U_(0x3) << TC_EVCTRL_MCEO_Pos)               /**< (TC_EVCTRL Mask) MCEO */
+#define TC_EVCTRL_MCEO(value)               (TC_EVCTRL_MCEO_Msk & ((value) << TC_EVCTRL_MCEO_Pos))  
+
+/* -------- TC_INTENCLR : (TC Offset: 0x08) (R/W 8) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  OVF:1;                     /**< bit:      0  OVF Interrupt Disable                    */
+    uint8_t  ERR:1;                     /**< bit:      1  ERR Interrupt Disable                    */
+    uint8_t  :2;                        /**< bit:   2..3  Reserved */
+    uint8_t  MC0:1;                     /**< bit:      4  MC Interrupt Disable 0                   */
+    uint8_t  MC1:1;                     /**< bit:      5  MC Interrupt Disable 1                   */
+    uint8_t  :2;                        /**< bit:   6..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint8_t  :4;                        /**< bit:   0..3  Reserved */
+    uint8_t  MC:2;                      /**< bit:   4..5  MC Interrupt Disable x                   */
+    uint8_t  :2;                        /**< bit:   6..7 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint8_t  reg;                         /**< Type used for register access */
+} TC_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_INTENCLR_OFFSET                  (0x08)                                        /**<  (TC_INTENCLR) Interrupt Enable Clear  Offset */
+#define TC_INTENCLR_RESETVALUE              _U_(0x00)                                     /**<  (TC_INTENCLR) Interrupt Enable Clear  Reset Value */
+
+#define TC_INTENCLR_OVF_Pos                 0                                              /**< (TC_INTENCLR) OVF Interrupt Disable Position */
+#define TC_INTENCLR_OVF_Msk                 (_U_(0x1) << TC_INTENCLR_OVF_Pos)              /**< (TC_INTENCLR) OVF Interrupt Disable Mask */
+#define TC_INTENCLR_OVF                     TC_INTENCLR_OVF_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_INTENCLR_OVF_Msk instead */
+#define TC_INTENCLR_ERR_Pos                 1                                              /**< (TC_INTENCLR) ERR Interrupt Disable Position */
+#define TC_INTENCLR_ERR_Msk                 (_U_(0x1) << TC_INTENCLR_ERR_Pos)              /**< (TC_INTENCLR) ERR Interrupt Disable Mask */
+#define TC_INTENCLR_ERR                     TC_INTENCLR_ERR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_INTENCLR_ERR_Msk instead */
+#define TC_INTENCLR_MC0_Pos                 4                                              /**< (TC_INTENCLR) MC Interrupt Disable 0 Position */
+#define TC_INTENCLR_MC0_Msk                 (_U_(0x1) << TC_INTENCLR_MC0_Pos)              /**< (TC_INTENCLR) MC Interrupt Disable 0 Mask */
+#define TC_INTENCLR_MC0                     TC_INTENCLR_MC0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_INTENCLR_MC0_Msk instead */
+#define TC_INTENCLR_MC1_Pos                 5                                              /**< (TC_INTENCLR) MC Interrupt Disable 1 Position */
+#define TC_INTENCLR_MC1_Msk                 (_U_(0x1) << TC_INTENCLR_MC1_Pos)              /**< (TC_INTENCLR) MC Interrupt Disable 1 Mask */
+#define TC_INTENCLR_MC1                     TC_INTENCLR_MC1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_INTENCLR_MC1_Msk instead */
+#define TC_INTENCLR_MASK                    _U_(0x33)                                      /**< \deprecated (TC_INTENCLR) Register MASK  (Use TC_INTENCLR_Msk instead)  */
+#define TC_INTENCLR_Msk                     _U_(0x33)                                      /**< (TC_INTENCLR) Register Mask  */
+
+#define TC_INTENCLR_MC_Pos                  4                                              /**< (TC_INTENCLR Position) MC Interrupt Disable x */
+#define TC_INTENCLR_MC_Msk                  (_U_(0x3) << TC_INTENCLR_MC_Pos)               /**< (TC_INTENCLR Mask) MC */
+#define TC_INTENCLR_MC(value)               (TC_INTENCLR_MC_Msk & ((value) << TC_INTENCLR_MC_Pos))  
+
+/* -------- TC_INTENSET : (TC Offset: 0x09) (R/W 8) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  OVF:1;                     /**< bit:      0  OVF Interrupt Enable                     */
+    uint8_t  ERR:1;                     /**< bit:      1  ERR Interrupt Enable                     */
+    uint8_t  :2;                        /**< bit:   2..3  Reserved */
+    uint8_t  MC0:1;                     /**< bit:      4  MC Interrupt Enable 0                    */
+    uint8_t  MC1:1;                     /**< bit:      5  MC Interrupt Enable 1                    */
+    uint8_t  :2;                        /**< bit:   6..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint8_t  :4;                        /**< bit:   0..3  Reserved */
+    uint8_t  MC:2;                      /**< bit:   4..5  MC Interrupt Enable x                    */
+    uint8_t  :2;                        /**< bit:   6..7 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint8_t  reg;                         /**< Type used for register access */
+} TC_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_INTENSET_OFFSET                  (0x09)                                        /**<  (TC_INTENSET) Interrupt Enable Set  Offset */
+#define TC_INTENSET_RESETVALUE              _U_(0x00)                                     /**<  (TC_INTENSET) Interrupt Enable Set  Reset Value */
+
+#define TC_INTENSET_OVF_Pos                 0                                              /**< (TC_INTENSET) OVF Interrupt Enable Position */
+#define TC_INTENSET_OVF_Msk                 (_U_(0x1) << TC_INTENSET_OVF_Pos)              /**< (TC_INTENSET) OVF Interrupt Enable Mask */
+#define TC_INTENSET_OVF                     TC_INTENSET_OVF_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_INTENSET_OVF_Msk instead */
+#define TC_INTENSET_ERR_Pos                 1                                              /**< (TC_INTENSET) ERR Interrupt Enable Position */
+#define TC_INTENSET_ERR_Msk                 (_U_(0x1) << TC_INTENSET_ERR_Pos)              /**< (TC_INTENSET) ERR Interrupt Enable Mask */
+#define TC_INTENSET_ERR                     TC_INTENSET_ERR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_INTENSET_ERR_Msk instead */
+#define TC_INTENSET_MC0_Pos                 4                                              /**< (TC_INTENSET) MC Interrupt Enable 0 Position */
+#define TC_INTENSET_MC0_Msk                 (_U_(0x1) << TC_INTENSET_MC0_Pos)              /**< (TC_INTENSET) MC Interrupt Enable 0 Mask */
+#define TC_INTENSET_MC0                     TC_INTENSET_MC0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_INTENSET_MC0_Msk instead */
+#define TC_INTENSET_MC1_Pos                 5                                              /**< (TC_INTENSET) MC Interrupt Enable 1 Position */
+#define TC_INTENSET_MC1_Msk                 (_U_(0x1) << TC_INTENSET_MC1_Pos)              /**< (TC_INTENSET) MC Interrupt Enable 1 Mask */
+#define TC_INTENSET_MC1                     TC_INTENSET_MC1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_INTENSET_MC1_Msk instead */
+#define TC_INTENSET_MASK                    _U_(0x33)                                      /**< \deprecated (TC_INTENSET) Register MASK  (Use TC_INTENSET_Msk instead)  */
+#define TC_INTENSET_Msk                     _U_(0x33)                                      /**< (TC_INTENSET) Register Mask  */
+
+#define TC_INTENSET_MC_Pos                  4                                              /**< (TC_INTENSET Position) MC Interrupt Enable x */
+#define TC_INTENSET_MC_Msk                  (_U_(0x3) << TC_INTENSET_MC_Pos)               /**< (TC_INTENSET Mask) MC */
+#define TC_INTENSET_MC(value)               (TC_INTENSET_MC_Msk & ((value) << TC_INTENSET_MC_Pos))  
+
+/* -------- TC_INTFLAG : (TC Offset: 0x0a) (R/W 8) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t OVF:1;                     /**< bit:      0  OVF Interrupt Flag                       */
+    __I uint8_t ERR:1;                     /**< bit:      1  ERR Interrupt Flag                       */
+    __I uint8_t :2;                        /**< bit:   2..3  Reserved */
+    __I uint8_t MC0:1;                     /**< bit:      4  MC Interrupt Flag 0                      */
+    __I uint8_t MC1:1;                     /**< bit:      5  MC Interrupt Flag 1                      */
+    __I uint8_t :2;                        /**< bit:   6..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    __I uint8_t :4;                        /**< bit:   0..3  Reserved */
+    __I uint8_t MC:2;                      /**< bit:   4..5  MC Interrupt Flag x                      */
+    __I uint8_t :2;                        /**< bit:   6..7 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint8_t  reg;                         /**< Type used for register access */
+} TC_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_INTFLAG_OFFSET                   (0x0A)                                        /**<  (TC_INTFLAG) Interrupt Flag Status and Clear  Offset */
+#define TC_INTFLAG_RESETVALUE               _U_(0x00)                                     /**<  (TC_INTFLAG) Interrupt Flag Status and Clear  Reset Value */
+
+#define TC_INTFLAG_OVF_Pos                  0                                              /**< (TC_INTFLAG) OVF Interrupt Flag Position */
+#define TC_INTFLAG_OVF_Msk                  (_U_(0x1) << TC_INTFLAG_OVF_Pos)               /**< (TC_INTFLAG) OVF Interrupt Flag Mask */
+#define TC_INTFLAG_OVF                      TC_INTFLAG_OVF_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_INTFLAG_OVF_Msk instead */
+#define TC_INTFLAG_ERR_Pos                  1                                              /**< (TC_INTFLAG) ERR Interrupt Flag Position */
+#define TC_INTFLAG_ERR_Msk                  (_U_(0x1) << TC_INTFLAG_ERR_Pos)               /**< (TC_INTFLAG) ERR Interrupt Flag Mask */
+#define TC_INTFLAG_ERR                      TC_INTFLAG_ERR_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_INTFLAG_ERR_Msk instead */
+#define TC_INTFLAG_MC0_Pos                  4                                              /**< (TC_INTFLAG) MC Interrupt Flag 0 Position */
+#define TC_INTFLAG_MC0_Msk                  (_U_(0x1) << TC_INTFLAG_MC0_Pos)               /**< (TC_INTFLAG) MC Interrupt Flag 0 Mask */
+#define TC_INTFLAG_MC0                      TC_INTFLAG_MC0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_INTFLAG_MC0_Msk instead */
+#define TC_INTFLAG_MC1_Pos                  5                                              /**< (TC_INTFLAG) MC Interrupt Flag 1 Position */
+#define TC_INTFLAG_MC1_Msk                  (_U_(0x1) << TC_INTFLAG_MC1_Pos)               /**< (TC_INTFLAG) MC Interrupt Flag 1 Mask */
+#define TC_INTFLAG_MC1                      TC_INTFLAG_MC1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_INTFLAG_MC1_Msk instead */
+#define TC_INTFLAG_MASK                     _U_(0x33)                                      /**< \deprecated (TC_INTFLAG) Register MASK  (Use TC_INTFLAG_Msk instead)  */
+#define TC_INTFLAG_Msk                      _U_(0x33)                                      /**< (TC_INTFLAG) Register Mask  */
+
+#define TC_INTFLAG_MC_Pos                   4                                              /**< (TC_INTFLAG Position) MC Interrupt Flag x */
+#define TC_INTFLAG_MC_Msk                   (_U_(0x3) << TC_INTFLAG_MC_Pos)                /**< (TC_INTFLAG Mask) MC */
+#define TC_INTFLAG_MC(value)                (TC_INTFLAG_MC_Msk & ((value) << TC_INTFLAG_MC_Pos))  
+
+/* -------- TC_STATUS : (TC Offset: 0x0b) (R/W 8) Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  STOP:1;                    /**< bit:      0  Stop Status Flag                         */
+    uint8_t  SLAVE:1;                   /**< bit:      1  Slave Status Flag                        */
+    uint8_t  :1;                        /**< bit:      2  Reserved */
+    uint8_t  PERBUFV:1;                 /**< bit:      3  Synchronization Busy Status              */
+    uint8_t  CCBUFV0:1;                 /**< bit:      4  Compare channel buffer 0 valid           */
+    uint8_t  CCBUFV1:1;                 /**< bit:      5  Compare channel buffer 1 valid           */
+    uint8_t  :2;                        /**< bit:   6..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint8_t  :4;                        /**< bit:   0..3  Reserved */
+    uint8_t  CCBUFV:2;                  /**< bit:   4..5  Compare channel buffer x valid           */
+    uint8_t  :2;                        /**< bit:   6..7 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint8_t  reg;                         /**< Type used for register access */
+} TC_STATUS_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_STATUS_OFFSET                    (0x0B)                                        /**<  (TC_STATUS) Status  Offset */
+#define TC_STATUS_RESETVALUE                _U_(0x01)                                     /**<  (TC_STATUS) Status  Reset Value */
+
+#define TC_STATUS_STOP_Pos                  0                                              /**< (TC_STATUS) Stop Status Flag Position */
+#define TC_STATUS_STOP_Msk                  (_U_(0x1) << TC_STATUS_STOP_Pos)               /**< (TC_STATUS) Stop Status Flag Mask */
+#define TC_STATUS_STOP                      TC_STATUS_STOP_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_STATUS_STOP_Msk instead */
+#define TC_STATUS_SLAVE_Pos                 1                                              /**< (TC_STATUS) Slave Status Flag Position */
+#define TC_STATUS_SLAVE_Msk                 (_U_(0x1) << TC_STATUS_SLAVE_Pos)              /**< (TC_STATUS) Slave Status Flag Mask */
+#define TC_STATUS_SLAVE                     TC_STATUS_SLAVE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_STATUS_SLAVE_Msk instead */
+#define TC_STATUS_PERBUFV_Pos               3                                              /**< (TC_STATUS) Synchronization Busy Status Position */
+#define TC_STATUS_PERBUFV_Msk               (_U_(0x1) << TC_STATUS_PERBUFV_Pos)            /**< (TC_STATUS) Synchronization Busy Status Mask */
+#define TC_STATUS_PERBUFV                   TC_STATUS_PERBUFV_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_STATUS_PERBUFV_Msk instead */
+#define TC_STATUS_CCBUFV0_Pos               4                                              /**< (TC_STATUS) Compare channel buffer 0 valid Position */
+#define TC_STATUS_CCBUFV0_Msk               (_U_(0x1) << TC_STATUS_CCBUFV0_Pos)            /**< (TC_STATUS) Compare channel buffer 0 valid Mask */
+#define TC_STATUS_CCBUFV0                   TC_STATUS_CCBUFV0_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_STATUS_CCBUFV0_Msk instead */
+#define TC_STATUS_CCBUFV1_Pos               5                                              /**< (TC_STATUS) Compare channel buffer 1 valid Position */
+#define TC_STATUS_CCBUFV1_Msk               (_U_(0x1) << TC_STATUS_CCBUFV1_Pos)            /**< (TC_STATUS) Compare channel buffer 1 valid Mask */
+#define TC_STATUS_CCBUFV1                   TC_STATUS_CCBUFV1_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_STATUS_CCBUFV1_Msk instead */
+#define TC_STATUS_MASK                      _U_(0x3B)                                      /**< \deprecated (TC_STATUS) Register MASK  (Use TC_STATUS_Msk instead)  */
+#define TC_STATUS_Msk                       _U_(0x3B)                                      /**< (TC_STATUS) Register Mask  */
+
+#define TC_STATUS_CCBUFV_Pos                4                                              /**< (TC_STATUS Position) Compare channel buffer x valid */
+#define TC_STATUS_CCBUFV_Msk                (_U_(0x3) << TC_STATUS_CCBUFV_Pos)             /**< (TC_STATUS Mask) CCBUFV */
+#define TC_STATUS_CCBUFV(value)             (TC_STATUS_CCBUFV_Msk & ((value) << TC_STATUS_CCBUFV_Pos))  
+
+/* -------- TC_WAVE : (TC Offset: 0x0c) (R/W 8) Waveform Generation Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  WAVEGEN:2;                 /**< bit:   0..1  Waveform Generation Mode                 */
+    uint8_t  :6;                        /**< bit:   2..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} TC_WAVE_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_WAVE_OFFSET                      (0x0C)                                        /**<  (TC_WAVE) Waveform Generation Control  Offset */
+#define TC_WAVE_RESETVALUE                  _U_(0x00)                                     /**<  (TC_WAVE) Waveform Generation Control  Reset Value */
+
+#define TC_WAVE_WAVEGEN_Pos                 0                                              /**< (TC_WAVE) Waveform Generation Mode Position */
+#define TC_WAVE_WAVEGEN_Msk                 (_U_(0x3) << TC_WAVE_WAVEGEN_Pos)              /**< (TC_WAVE) Waveform Generation Mode Mask */
+#define TC_WAVE_WAVEGEN(value)              (TC_WAVE_WAVEGEN_Msk & ((value) << TC_WAVE_WAVEGEN_Pos))
+#define   TC_WAVE_WAVEGEN_NFRQ_Val          _U_(0x0)                                       /**< (TC_WAVE) Normal frequency  */
+#define   TC_WAVE_WAVEGEN_MFRQ_Val          _U_(0x1)                                       /**< (TC_WAVE) Match frequency  */
+#define   TC_WAVE_WAVEGEN_NPWM_Val          _U_(0x2)                                       /**< (TC_WAVE) Normal PWM  */
+#define   TC_WAVE_WAVEGEN_MPWM_Val          _U_(0x3)                                       /**< (TC_WAVE) Match PWM  */
+#define TC_WAVE_WAVEGEN_NFRQ                (TC_WAVE_WAVEGEN_NFRQ_Val << TC_WAVE_WAVEGEN_Pos)  /**< (TC_WAVE) Normal frequency Position  */
+#define TC_WAVE_WAVEGEN_MFRQ                (TC_WAVE_WAVEGEN_MFRQ_Val << TC_WAVE_WAVEGEN_Pos)  /**< (TC_WAVE) Match frequency Position  */
+#define TC_WAVE_WAVEGEN_NPWM                (TC_WAVE_WAVEGEN_NPWM_Val << TC_WAVE_WAVEGEN_Pos)  /**< (TC_WAVE) Normal PWM Position  */
+#define TC_WAVE_WAVEGEN_MPWM                (TC_WAVE_WAVEGEN_MPWM_Val << TC_WAVE_WAVEGEN_Pos)  /**< (TC_WAVE) Match PWM Position  */
+#define TC_WAVE_MASK                        _U_(0x03)                                      /**< \deprecated (TC_WAVE) Register MASK  (Use TC_WAVE_Msk instead)  */
+#define TC_WAVE_Msk                         _U_(0x03)                                      /**< (TC_WAVE) Register Mask  */
+
+
+/* -------- TC_DRVCTRL : (TC Offset: 0x0d) (R/W 8) Control C -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  INVEN0:1;                  /**< bit:      0  Output Waveform Invert Enable 0          */
+    uint8_t  INVEN1:1;                  /**< bit:      1  Output Waveform Invert Enable 1          */
+    uint8_t  :6;                        /**< bit:   2..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint8_t  INVEN:2;                   /**< bit:   0..1  Output Waveform Invert Enable x          */
+    uint8_t  :6;                        /**< bit:   2..7 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint8_t  reg;                         /**< Type used for register access */
+} TC_DRVCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_DRVCTRL_OFFSET                   (0x0D)                                        /**<  (TC_DRVCTRL) Control C  Offset */
+#define TC_DRVCTRL_RESETVALUE               _U_(0x00)                                     /**<  (TC_DRVCTRL) Control C  Reset Value */
+
+#define TC_DRVCTRL_INVEN0_Pos               0                                              /**< (TC_DRVCTRL) Output Waveform Invert Enable 0 Position */
+#define TC_DRVCTRL_INVEN0_Msk               (_U_(0x1) << TC_DRVCTRL_INVEN0_Pos)            /**< (TC_DRVCTRL) Output Waveform Invert Enable 0 Mask */
+#define TC_DRVCTRL_INVEN0                   TC_DRVCTRL_INVEN0_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_DRVCTRL_INVEN0_Msk instead */
+#define TC_DRVCTRL_INVEN1_Pos               1                                              /**< (TC_DRVCTRL) Output Waveform Invert Enable 1 Position */
+#define TC_DRVCTRL_INVEN1_Msk               (_U_(0x1) << TC_DRVCTRL_INVEN1_Pos)            /**< (TC_DRVCTRL) Output Waveform Invert Enable 1 Mask */
+#define TC_DRVCTRL_INVEN1                   TC_DRVCTRL_INVEN1_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_DRVCTRL_INVEN1_Msk instead */
+#define TC_DRVCTRL_MASK                     _U_(0x03)                                      /**< \deprecated (TC_DRVCTRL) Register MASK  (Use TC_DRVCTRL_Msk instead)  */
+#define TC_DRVCTRL_Msk                      _U_(0x03)                                      /**< (TC_DRVCTRL) Register Mask  */
+
+#define TC_DRVCTRL_INVEN_Pos                0                                              /**< (TC_DRVCTRL Position) Output Waveform Invert Enable x */
+#define TC_DRVCTRL_INVEN_Msk                (_U_(0x3) << TC_DRVCTRL_INVEN_Pos)             /**< (TC_DRVCTRL Mask) INVEN */
+#define TC_DRVCTRL_INVEN(value)             (TC_DRVCTRL_INVEN_Msk & ((value) << TC_DRVCTRL_INVEN_Pos))  
+
+/* -------- TC_DBGCTRL : (TC Offset: 0x0f) (R/W 8) Debug Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DBGRUN:1;                  /**< bit:      0  Run During Debug                         */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} TC_DBGCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_DBGCTRL_OFFSET                   (0x0F)                                        /**<  (TC_DBGCTRL) Debug Control  Offset */
+#define TC_DBGCTRL_RESETVALUE               _U_(0x00)                                     /**<  (TC_DBGCTRL) Debug Control  Reset Value */
+
+#define TC_DBGCTRL_DBGRUN_Pos               0                                              /**< (TC_DBGCTRL) Run During Debug Position */
+#define TC_DBGCTRL_DBGRUN_Msk               (_U_(0x1) << TC_DBGCTRL_DBGRUN_Pos)            /**< (TC_DBGCTRL) Run During Debug Mask */
+#define TC_DBGCTRL_DBGRUN                   TC_DBGCTRL_DBGRUN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_DBGCTRL_DBGRUN_Msk instead */
+#define TC_DBGCTRL_MASK                     _U_(0x01)                                      /**< \deprecated (TC_DBGCTRL) Register MASK  (Use TC_DBGCTRL_Msk instead)  */
+#define TC_DBGCTRL_Msk                      _U_(0x01)                                      /**< (TC_DBGCTRL) Register Mask  */
+
+
+/* -------- TC_SYNCBUSY : (TC Offset: 0x10) (R/ 32) Synchronization Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SWRST:1;                   /**< bit:      0  swrst                                    */
+    uint32_t ENABLE:1;                  /**< bit:      1  enable                                   */
+    uint32_t CTRLB:1;                   /**< bit:      2  CTRLB                                    */
+    uint32_t STATUS:1;                  /**< bit:      3  STATUS                                   */
+    uint32_t COUNT:1;                   /**< bit:      4  Counter                                  */
+    uint32_t PER:1;                     /**< bit:      5  Period                                   */
+    uint32_t CC0:1;                     /**< bit:      6  Compare Channel 0                        */
+    uint32_t CC1:1;                     /**< bit:      7  Compare Channel 1                        */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :6;                        /**< bit:   0..5  Reserved */
+    uint32_t CC:2;                      /**< bit:   6..7  Compare Channel x                        */
+    uint32_t :24;                       /**< bit:  8..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_SYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_SYNCBUSY_OFFSET                  (0x10)                                        /**<  (TC_SYNCBUSY) Synchronization Status  Offset */
+#define TC_SYNCBUSY_RESETVALUE              _U_(0x00)                                     /**<  (TC_SYNCBUSY) Synchronization Status  Reset Value */
+
+#define TC_SYNCBUSY_SWRST_Pos               0                                              /**< (TC_SYNCBUSY) swrst Position */
+#define TC_SYNCBUSY_SWRST_Msk               (_U_(0x1) << TC_SYNCBUSY_SWRST_Pos)            /**< (TC_SYNCBUSY) swrst Mask */
+#define TC_SYNCBUSY_SWRST                   TC_SYNCBUSY_SWRST_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_SYNCBUSY_SWRST_Msk instead */
+#define TC_SYNCBUSY_ENABLE_Pos              1                                              /**< (TC_SYNCBUSY) enable Position */
+#define TC_SYNCBUSY_ENABLE_Msk              (_U_(0x1) << TC_SYNCBUSY_ENABLE_Pos)           /**< (TC_SYNCBUSY) enable Mask */
+#define TC_SYNCBUSY_ENABLE                  TC_SYNCBUSY_ENABLE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_SYNCBUSY_ENABLE_Msk instead */
+#define TC_SYNCBUSY_CTRLB_Pos               2                                              /**< (TC_SYNCBUSY) CTRLB Position */
+#define TC_SYNCBUSY_CTRLB_Msk               (_U_(0x1) << TC_SYNCBUSY_CTRLB_Pos)            /**< (TC_SYNCBUSY) CTRLB Mask */
+#define TC_SYNCBUSY_CTRLB                   TC_SYNCBUSY_CTRLB_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_SYNCBUSY_CTRLB_Msk instead */
+#define TC_SYNCBUSY_STATUS_Pos              3                                              /**< (TC_SYNCBUSY) STATUS Position */
+#define TC_SYNCBUSY_STATUS_Msk              (_U_(0x1) << TC_SYNCBUSY_STATUS_Pos)           /**< (TC_SYNCBUSY) STATUS Mask */
+#define TC_SYNCBUSY_STATUS                  TC_SYNCBUSY_STATUS_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_SYNCBUSY_STATUS_Msk instead */
+#define TC_SYNCBUSY_COUNT_Pos               4                                              /**< (TC_SYNCBUSY) Counter Position */
+#define TC_SYNCBUSY_COUNT_Msk               (_U_(0x1) << TC_SYNCBUSY_COUNT_Pos)            /**< (TC_SYNCBUSY) Counter Mask */
+#define TC_SYNCBUSY_COUNT                   TC_SYNCBUSY_COUNT_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_SYNCBUSY_COUNT_Msk instead */
+#define TC_SYNCBUSY_PER_Pos                 5                                              /**< (TC_SYNCBUSY) Period Position */
+#define TC_SYNCBUSY_PER_Msk                 (_U_(0x1) << TC_SYNCBUSY_PER_Pos)              /**< (TC_SYNCBUSY) Period Mask */
+#define TC_SYNCBUSY_PER                     TC_SYNCBUSY_PER_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_SYNCBUSY_PER_Msk instead */
+#define TC_SYNCBUSY_CC0_Pos                 6                                              /**< (TC_SYNCBUSY) Compare Channel 0 Position */
+#define TC_SYNCBUSY_CC0_Msk                 (_U_(0x1) << TC_SYNCBUSY_CC0_Pos)              /**< (TC_SYNCBUSY) Compare Channel 0 Mask */
+#define TC_SYNCBUSY_CC0                     TC_SYNCBUSY_CC0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_SYNCBUSY_CC0_Msk instead */
+#define TC_SYNCBUSY_CC1_Pos                 7                                              /**< (TC_SYNCBUSY) Compare Channel 1 Position */
+#define TC_SYNCBUSY_CC1_Msk                 (_U_(0x1) << TC_SYNCBUSY_CC1_Pos)              /**< (TC_SYNCBUSY) Compare Channel 1 Mask */
+#define TC_SYNCBUSY_CC1                     TC_SYNCBUSY_CC1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_SYNCBUSY_CC1_Msk instead */
+#define TC_SYNCBUSY_MASK                    _U_(0xFF)                                      /**< \deprecated (TC_SYNCBUSY) Register MASK  (Use TC_SYNCBUSY_Msk instead)  */
+#define TC_SYNCBUSY_Msk                     _U_(0xFF)                                      /**< (TC_SYNCBUSY) Register Mask  */
+
+#define TC_SYNCBUSY_CC_Pos                  6                                              /**< (TC_SYNCBUSY Position) Compare Channel x */
+#define TC_SYNCBUSY_CC_Msk                  (_U_(0x3) << TC_SYNCBUSY_CC_Pos)               /**< (TC_SYNCBUSY Mask) CC */
+#define TC_SYNCBUSY_CC(value)               (TC_SYNCBUSY_CC_Msk & ((value) << TC_SYNCBUSY_CC_Pos))  
+
+/* -------- TC_COUNT8_COUNT : (TC Offset: 0x14) (R/W 8) COUNT8 Count -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  COUNT:8;                   /**< bit:   0..7  Counter Value                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} TC_COUNT8_COUNT_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT8_COUNT_OFFSET              (0x14)                                        /**<  (TC_COUNT8_COUNT) COUNT8 Count  Offset */
+#define TC_COUNT8_COUNT_RESETVALUE          _U_(0x00)                                     /**<  (TC_COUNT8_COUNT) COUNT8 Count  Reset Value */
+
+#define TC_COUNT8_COUNT_COUNT_Pos           0                                              /**< (TC_COUNT8_COUNT) Counter Value Position */
+#define TC_COUNT8_COUNT_COUNT_Msk           (_U_(0xFF) << TC_COUNT8_COUNT_COUNT_Pos)       /**< (TC_COUNT8_COUNT) Counter Value Mask */
+#define TC_COUNT8_COUNT_COUNT(value)        (TC_COUNT8_COUNT_COUNT_Msk & ((value) << TC_COUNT8_COUNT_COUNT_Pos))
+#define TC_COUNT8_COUNT_MASK                _U_(0xFF)                                      /**< \deprecated (TC_COUNT8_COUNT) Register MASK  (Use TC_COUNT8_COUNT_Msk instead)  */
+#define TC_COUNT8_COUNT_Msk                 _U_(0xFF)                                      /**< (TC_COUNT8_COUNT) Register Mask  */
+
+
+/* -------- TC_COUNT16_COUNT : (TC Offset: 0x14) (R/W 16) COUNT16 Count -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t COUNT:16;                  /**< bit:  0..15  Counter Value                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} TC_COUNT16_COUNT_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT16_COUNT_OFFSET             (0x14)                                        /**<  (TC_COUNT16_COUNT) COUNT16 Count  Offset */
+#define TC_COUNT16_COUNT_RESETVALUE         _U_(0x00)                                     /**<  (TC_COUNT16_COUNT) COUNT16 Count  Reset Value */
+
+#define TC_COUNT16_COUNT_COUNT_Pos          0                                              /**< (TC_COUNT16_COUNT) Counter Value Position */
+#define TC_COUNT16_COUNT_COUNT_Msk          (_U_(0xFFFF) << TC_COUNT16_COUNT_COUNT_Pos)    /**< (TC_COUNT16_COUNT) Counter Value Mask */
+#define TC_COUNT16_COUNT_COUNT(value)       (TC_COUNT16_COUNT_COUNT_Msk & ((value) << TC_COUNT16_COUNT_COUNT_Pos))
+#define TC_COUNT16_COUNT_MASK               _U_(0xFFFF)                                    /**< \deprecated (TC_COUNT16_COUNT) Register MASK  (Use TC_COUNT16_COUNT_Msk instead)  */
+#define TC_COUNT16_COUNT_Msk                _U_(0xFFFF)                                    /**< (TC_COUNT16_COUNT) Register Mask  */
+
+
+/* -------- TC_COUNT32_COUNT : (TC Offset: 0x14) (R/W 32) COUNT32 Count -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t COUNT:32;                  /**< bit:  0..31  Counter Value                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_COUNT32_COUNT_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT32_COUNT_OFFSET             (0x14)                                        /**<  (TC_COUNT32_COUNT) COUNT32 Count  Offset */
+#define TC_COUNT32_COUNT_RESETVALUE         _U_(0x00)                                     /**<  (TC_COUNT32_COUNT) COUNT32 Count  Reset Value */
+
+#define TC_COUNT32_COUNT_COUNT_Pos          0                                              /**< (TC_COUNT32_COUNT) Counter Value Position */
+#define TC_COUNT32_COUNT_COUNT_Msk          (_U_(0xFFFFFFFF) << TC_COUNT32_COUNT_COUNT_Pos)  /**< (TC_COUNT32_COUNT) Counter Value Mask */
+#define TC_COUNT32_COUNT_COUNT(value)       (TC_COUNT32_COUNT_COUNT_Msk & ((value) << TC_COUNT32_COUNT_COUNT_Pos))
+#define TC_COUNT32_COUNT_MASK               _U_(0xFFFFFFFF)                                /**< \deprecated (TC_COUNT32_COUNT) Register MASK  (Use TC_COUNT32_COUNT_Msk instead)  */
+#define TC_COUNT32_COUNT_Msk                _U_(0xFFFFFFFF)                                /**< (TC_COUNT32_COUNT) Register Mask  */
+
+
+/* -------- TC_COUNT32_PER : (TC Offset: 0x18) (R/W 32) COUNT32 Period -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t PER:32;                    /**< bit:  0..31  Period Value                             */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_COUNT32_PER_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT32_PER_OFFSET               (0x18)                                        /**<  (TC_COUNT32_PER) COUNT32 Period  Offset */
+#define TC_COUNT32_PER_RESETVALUE           _U_(0xFFFFFFFF)                               /**<  (TC_COUNT32_PER) COUNT32 Period  Reset Value */
+
+#define TC_COUNT32_PER_PER_Pos              0                                              /**< (TC_COUNT32_PER) Period Value Position */
+#define TC_COUNT32_PER_PER_Msk              (_U_(0xFFFFFFFF) << TC_COUNT32_PER_PER_Pos)    /**< (TC_COUNT32_PER) Period Value Mask */
+#define TC_COUNT32_PER_PER(value)           (TC_COUNT32_PER_PER_Msk & ((value) << TC_COUNT32_PER_PER_Pos))
+#define TC_COUNT32_PER_MASK                 _U_(0xFFFFFFFF)                                /**< \deprecated (TC_COUNT32_PER) Register MASK  (Use TC_COUNT32_PER_Msk instead)  */
+#define TC_COUNT32_PER_Msk                  _U_(0xFFFFFFFF)                                /**< (TC_COUNT32_PER) Register Mask  */
+
+
+/* -------- TC_COUNT16_PER : (TC Offset: 0x1a) (R/W 16) COUNT16 Period -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t PER:16;                    /**< bit:  0..15  Period Value                             */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} TC_COUNT16_PER_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT16_PER_OFFSET               (0x1A)                                        /**<  (TC_COUNT16_PER) COUNT16 Period  Offset */
+#define TC_COUNT16_PER_RESETVALUE           _U_(0xFFFF)                                   /**<  (TC_COUNT16_PER) COUNT16 Period  Reset Value */
+
+#define TC_COUNT16_PER_PER_Pos              0                                              /**< (TC_COUNT16_PER) Period Value Position */
+#define TC_COUNT16_PER_PER_Msk              (_U_(0xFFFF) << TC_COUNT16_PER_PER_Pos)        /**< (TC_COUNT16_PER) Period Value Mask */
+#define TC_COUNT16_PER_PER(value)           (TC_COUNT16_PER_PER_Msk & ((value) << TC_COUNT16_PER_PER_Pos))
+#define TC_COUNT16_PER_MASK                 _U_(0xFFFF)                                    /**< \deprecated (TC_COUNT16_PER) Register MASK  (Use TC_COUNT16_PER_Msk instead)  */
+#define TC_COUNT16_PER_Msk                  _U_(0xFFFF)                                    /**< (TC_COUNT16_PER) Register Mask  */
+
+
+/* -------- TC_COUNT8_PER : (TC Offset: 0x1b) (R/W 8) COUNT8 Period -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  PER:8;                     /**< bit:   0..7  Period Value                             */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} TC_COUNT8_PER_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT8_PER_OFFSET                (0x1B)                                        /**<  (TC_COUNT8_PER) COUNT8 Period  Offset */
+#define TC_COUNT8_PER_RESETVALUE            _U_(0xFF)                                     /**<  (TC_COUNT8_PER) COUNT8 Period  Reset Value */
+
+#define TC_COUNT8_PER_PER_Pos               0                                              /**< (TC_COUNT8_PER) Period Value Position */
+#define TC_COUNT8_PER_PER_Msk               (_U_(0xFF) << TC_COUNT8_PER_PER_Pos)           /**< (TC_COUNT8_PER) Period Value Mask */
+#define TC_COUNT8_PER_PER(value)            (TC_COUNT8_PER_PER_Msk & ((value) << TC_COUNT8_PER_PER_Pos))
+#define TC_COUNT8_PER_MASK                  _U_(0xFF)                                      /**< \deprecated (TC_COUNT8_PER) Register MASK  (Use TC_COUNT8_PER_Msk instead)  */
+#define TC_COUNT8_PER_Msk                   _U_(0xFF)                                      /**< (TC_COUNT8_PER) Register Mask  */
+
+
+/* -------- TC_COUNT8_CC : (TC Offset: 0x1c) (R/W 8) COUNT8 Compare and Capture -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  CC:8;                      /**< bit:   0..7  Counter/Compare Value                    */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} TC_COUNT8_CC_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT8_CC_OFFSET                 (0x1C)                                        /**<  (TC_COUNT8_CC) COUNT8 Compare and Capture  Offset */
+#define TC_COUNT8_CC_RESETVALUE             _U_(0x00)                                     /**<  (TC_COUNT8_CC) COUNT8 Compare and Capture  Reset Value */
+
+#define TC_COUNT8_CC_CC_Pos                 0                                              /**< (TC_COUNT8_CC) Counter/Compare Value Position */
+#define TC_COUNT8_CC_CC_Msk                 (_U_(0xFF) << TC_COUNT8_CC_CC_Pos)             /**< (TC_COUNT8_CC) Counter/Compare Value Mask */
+#define TC_COUNT8_CC_CC(value)              (TC_COUNT8_CC_CC_Msk & ((value) << TC_COUNT8_CC_CC_Pos))
+#define TC_COUNT8_CC_MASK                   _U_(0xFF)                                      /**< \deprecated (TC_COUNT8_CC) Register MASK  (Use TC_COUNT8_CC_Msk instead)  */
+#define TC_COUNT8_CC_Msk                    _U_(0xFF)                                      /**< (TC_COUNT8_CC) Register Mask  */
+
+
+/* -------- TC_COUNT16_CC : (TC Offset: 0x1c) (R/W 16) COUNT16 Compare and Capture -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t CC:16;                     /**< bit:  0..15  Counter/Compare Value                    */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} TC_COUNT16_CC_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT16_CC_OFFSET                (0x1C)                                        /**<  (TC_COUNT16_CC) COUNT16 Compare and Capture  Offset */
+#define TC_COUNT16_CC_RESETVALUE            _U_(0x00)                                     /**<  (TC_COUNT16_CC) COUNT16 Compare and Capture  Reset Value */
+
+#define TC_COUNT16_CC_CC_Pos                0                                              /**< (TC_COUNT16_CC) Counter/Compare Value Position */
+#define TC_COUNT16_CC_CC_Msk                (_U_(0xFFFF) << TC_COUNT16_CC_CC_Pos)          /**< (TC_COUNT16_CC) Counter/Compare Value Mask */
+#define TC_COUNT16_CC_CC(value)             (TC_COUNT16_CC_CC_Msk & ((value) << TC_COUNT16_CC_CC_Pos))
+#define TC_COUNT16_CC_MASK                  _U_(0xFFFF)                                    /**< \deprecated (TC_COUNT16_CC) Register MASK  (Use TC_COUNT16_CC_Msk instead)  */
+#define TC_COUNT16_CC_Msk                   _U_(0xFFFF)                                    /**< (TC_COUNT16_CC) Register Mask  */
+
+
+/* -------- TC_COUNT32_CC : (TC Offset: 0x1c) (R/W 32) COUNT32 Compare and Capture -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t CC:32;                     /**< bit:  0..31  Counter/Compare Value                    */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_COUNT32_CC_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT32_CC_OFFSET                (0x1C)                                        /**<  (TC_COUNT32_CC) COUNT32 Compare and Capture  Offset */
+#define TC_COUNT32_CC_RESETVALUE            _U_(0x00)                                     /**<  (TC_COUNT32_CC) COUNT32 Compare and Capture  Reset Value */
+
+#define TC_COUNT32_CC_CC_Pos                0                                              /**< (TC_COUNT32_CC) Counter/Compare Value Position */
+#define TC_COUNT32_CC_CC_Msk                (_U_(0xFFFFFFFF) << TC_COUNT32_CC_CC_Pos)      /**< (TC_COUNT32_CC) Counter/Compare Value Mask */
+#define TC_COUNT32_CC_CC(value)             (TC_COUNT32_CC_CC_Msk & ((value) << TC_COUNT32_CC_CC_Pos))
+#define TC_COUNT32_CC_MASK                  _U_(0xFFFFFFFF)                                /**< \deprecated (TC_COUNT32_CC) Register MASK  (Use TC_COUNT32_CC_Msk instead)  */
+#define TC_COUNT32_CC_Msk                   _U_(0xFFFFFFFF)                                /**< (TC_COUNT32_CC) Register Mask  */
+
+
+/* -------- TC_COUNT32_PERBUF : (TC Offset: 0x2c) (R/W 32) COUNT32 Period Buffer -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t PERBUF:32;                 /**< bit:  0..31  Period Buffer Value                      */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_COUNT32_PERBUF_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT32_PERBUF_OFFSET            (0x2C)                                        /**<  (TC_COUNT32_PERBUF) COUNT32 Period Buffer  Offset */
+#define TC_COUNT32_PERBUF_RESETVALUE        _U_(0xFFFFFFFF)                               /**<  (TC_COUNT32_PERBUF) COUNT32 Period Buffer  Reset Value */
+
+#define TC_COUNT32_PERBUF_PERBUF_Pos        0                                              /**< (TC_COUNT32_PERBUF) Period Buffer Value Position */
+#define TC_COUNT32_PERBUF_PERBUF_Msk        (_U_(0xFFFFFFFF) << TC_COUNT32_PERBUF_PERBUF_Pos)  /**< (TC_COUNT32_PERBUF) Period Buffer Value Mask */
+#define TC_COUNT32_PERBUF_PERBUF(value)     (TC_COUNT32_PERBUF_PERBUF_Msk & ((value) << TC_COUNT32_PERBUF_PERBUF_Pos))
+#define TC_COUNT32_PERBUF_MASK              _U_(0xFFFFFFFF)                                /**< \deprecated (TC_COUNT32_PERBUF) Register MASK  (Use TC_COUNT32_PERBUF_Msk instead)  */
+#define TC_COUNT32_PERBUF_Msk               _U_(0xFFFFFFFF)                                /**< (TC_COUNT32_PERBUF) Register Mask  */
+
+
+/* -------- TC_COUNT16_PERBUF : (TC Offset: 0x2e) (R/W 16) COUNT16 Period Buffer -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t PERBUF:16;                 /**< bit:  0..15  Period Buffer Value                      */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} TC_COUNT16_PERBUF_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT16_PERBUF_OFFSET            (0x2E)                                        /**<  (TC_COUNT16_PERBUF) COUNT16 Period Buffer  Offset */
+#define TC_COUNT16_PERBUF_RESETVALUE        _U_(0xFFFF)                                   /**<  (TC_COUNT16_PERBUF) COUNT16 Period Buffer  Reset Value */
+
+#define TC_COUNT16_PERBUF_PERBUF_Pos        0                                              /**< (TC_COUNT16_PERBUF) Period Buffer Value Position */
+#define TC_COUNT16_PERBUF_PERBUF_Msk        (_U_(0xFFFF) << TC_COUNT16_PERBUF_PERBUF_Pos)  /**< (TC_COUNT16_PERBUF) Period Buffer Value Mask */
+#define TC_COUNT16_PERBUF_PERBUF(value)     (TC_COUNT16_PERBUF_PERBUF_Msk & ((value) << TC_COUNT16_PERBUF_PERBUF_Pos))
+#define TC_COUNT16_PERBUF_MASK              _U_(0xFFFF)                                    /**< \deprecated (TC_COUNT16_PERBUF) Register MASK  (Use TC_COUNT16_PERBUF_Msk instead)  */
+#define TC_COUNT16_PERBUF_Msk               _U_(0xFFFF)                                    /**< (TC_COUNT16_PERBUF) Register Mask  */
+
+
+/* -------- TC_COUNT8_PERBUF : (TC Offset: 0x2f) (R/W 8) COUNT8 Period Buffer -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  PERBUF:8;                  /**< bit:   0..7  Period Buffer Value                      */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} TC_COUNT8_PERBUF_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT8_PERBUF_OFFSET             (0x2F)                                        /**<  (TC_COUNT8_PERBUF) COUNT8 Period Buffer  Offset */
+#define TC_COUNT8_PERBUF_RESETVALUE         _U_(0xFF)                                     /**<  (TC_COUNT8_PERBUF) COUNT8 Period Buffer  Reset Value */
+
+#define TC_COUNT8_PERBUF_PERBUF_Pos         0                                              /**< (TC_COUNT8_PERBUF) Period Buffer Value Position */
+#define TC_COUNT8_PERBUF_PERBUF_Msk         (_U_(0xFF) << TC_COUNT8_PERBUF_PERBUF_Pos)     /**< (TC_COUNT8_PERBUF) Period Buffer Value Mask */
+#define TC_COUNT8_PERBUF_PERBUF(value)      (TC_COUNT8_PERBUF_PERBUF_Msk & ((value) << TC_COUNT8_PERBUF_PERBUF_Pos))
+#define TC_COUNT8_PERBUF_MASK               _U_(0xFF)                                      /**< \deprecated (TC_COUNT8_PERBUF) Register MASK  (Use TC_COUNT8_PERBUF_Msk instead)  */
+#define TC_COUNT8_PERBUF_Msk                _U_(0xFF)                                      /**< (TC_COUNT8_PERBUF) Register Mask  */
+
+
+/* -------- TC_COUNT8_CCBUF : (TC Offset: 0x30) (R/W 8) COUNT8 Compare and Capture Buffer -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  CCBUF:8;                   /**< bit:   0..7  Counter/Compare Buffer Value             */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} TC_COUNT8_CCBUF_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT8_CCBUF_OFFSET              (0x30)                                        /**<  (TC_COUNT8_CCBUF) COUNT8 Compare and Capture Buffer  Offset */
+#define TC_COUNT8_CCBUF_RESETVALUE          _U_(0x00)                                     /**<  (TC_COUNT8_CCBUF) COUNT8 Compare and Capture Buffer  Reset Value */
+
+#define TC_COUNT8_CCBUF_CCBUF_Pos           0                                              /**< (TC_COUNT8_CCBUF) Counter/Compare Buffer Value Position */
+#define TC_COUNT8_CCBUF_CCBUF_Msk           (_U_(0xFF) << TC_COUNT8_CCBUF_CCBUF_Pos)       /**< (TC_COUNT8_CCBUF) Counter/Compare Buffer Value Mask */
+#define TC_COUNT8_CCBUF_CCBUF(value)        (TC_COUNT8_CCBUF_CCBUF_Msk & ((value) << TC_COUNT8_CCBUF_CCBUF_Pos))
+#define TC_COUNT8_CCBUF_MASK                _U_(0xFF)                                      /**< \deprecated (TC_COUNT8_CCBUF) Register MASK  (Use TC_COUNT8_CCBUF_Msk instead)  */
+#define TC_COUNT8_CCBUF_Msk                 _U_(0xFF)                                      /**< (TC_COUNT8_CCBUF) Register Mask  */
+
+
+/* -------- TC_COUNT16_CCBUF : (TC Offset: 0x30) (R/W 16) COUNT16 Compare and Capture Buffer -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t CCBUF:16;                  /**< bit:  0..15  Counter/Compare Buffer Value             */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} TC_COUNT16_CCBUF_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT16_CCBUF_OFFSET             (0x30)                                        /**<  (TC_COUNT16_CCBUF) COUNT16 Compare and Capture Buffer  Offset */
+#define TC_COUNT16_CCBUF_RESETVALUE         _U_(0x00)                                     /**<  (TC_COUNT16_CCBUF) COUNT16 Compare and Capture Buffer  Reset Value */
+
+#define TC_COUNT16_CCBUF_CCBUF_Pos          0                                              /**< (TC_COUNT16_CCBUF) Counter/Compare Buffer Value Position */
+#define TC_COUNT16_CCBUF_CCBUF_Msk          (_U_(0xFFFF) << TC_COUNT16_CCBUF_CCBUF_Pos)    /**< (TC_COUNT16_CCBUF) Counter/Compare Buffer Value Mask */
+#define TC_COUNT16_CCBUF_CCBUF(value)       (TC_COUNT16_CCBUF_CCBUF_Msk & ((value) << TC_COUNT16_CCBUF_CCBUF_Pos))
+#define TC_COUNT16_CCBUF_MASK               _U_(0xFFFF)                                    /**< \deprecated (TC_COUNT16_CCBUF) Register MASK  (Use TC_COUNT16_CCBUF_Msk instead)  */
+#define TC_COUNT16_CCBUF_Msk                _U_(0xFFFF)                                    /**< (TC_COUNT16_CCBUF) Register Mask  */
+
+
+/* -------- TC_COUNT32_CCBUF : (TC Offset: 0x30) (R/W 32) COUNT32 Compare and Capture Buffer -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t CCBUF:32;                  /**< bit:  0..31  Counter/Compare Buffer Value             */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_COUNT32_CCBUF_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT32_CCBUF_OFFSET             (0x30)                                        /**<  (TC_COUNT32_CCBUF) COUNT32 Compare and Capture Buffer  Offset */
+#define TC_COUNT32_CCBUF_RESETVALUE         _U_(0x00)                                     /**<  (TC_COUNT32_CCBUF) COUNT32 Compare and Capture Buffer  Reset Value */
+
+#define TC_COUNT32_CCBUF_CCBUF_Pos          0                                              /**< (TC_COUNT32_CCBUF) Counter/Compare Buffer Value Position */
+#define TC_COUNT32_CCBUF_CCBUF_Msk          (_U_(0xFFFFFFFF) << TC_COUNT32_CCBUF_CCBUF_Pos)  /**< (TC_COUNT32_CCBUF) Counter/Compare Buffer Value Mask */
+#define TC_COUNT32_CCBUF_CCBUF(value)       (TC_COUNT32_CCBUF_CCBUF_Msk & ((value) << TC_COUNT32_CCBUF_CCBUF_Pos))
+#define TC_COUNT32_CCBUF_MASK               _U_(0xFFFFFFFF)                                /**< \deprecated (TC_COUNT32_CCBUF) Register MASK  (Use TC_COUNT32_CCBUF_Msk instead)  */
+#define TC_COUNT32_CCBUF_Msk                _U_(0xFFFFFFFF)                                /**< (TC_COUNT32_CCBUF) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief TC hardware registers */
+typedef struct {  /* Basic Timer Counter */
+  __IO TC_CTRLA_Type                  CTRLA;          /**< Offset: 0x00 (R/W  32) Control A */
+  __IO TC_CTRLBCLR_Type               CTRLBCLR;       /**< Offset: 0x04 (R/W   8) Control B Clear */
+  __IO TC_CTRLBSET_Type               CTRLBSET;       /**< Offset: 0x05 (R/W   8) Control B Set */
+  __IO TC_EVCTRL_Type                 EVCTRL;         /**< Offset: 0x06 (R/W  16) Event Control */
+  __IO TC_INTENCLR_Type               INTENCLR;       /**< Offset: 0x08 (R/W   8) Interrupt Enable Clear */
+  __IO TC_INTENSET_Type               INTENSET;       /**< Offset: 0x09 (R/W   8) Interrupt Enable Set */
+  __IO TC_INTFLAG_Type                INTFLAG;        /**< Offset: 0x0A (R/W   8) Interrupt Flag Status and Clear */
+  __IO TC_STATUS_Type                 STATUS;         /**< Offset: 0x0B (R/W   8) Status */
+  __IO TC_WAVE_Type                   WAVE;           /**< Offset: 0x0C (R/W   8) Waveform Generation Control */
+  __IO TC_DRVCTRL_Type                DRVCTRL;        /**< Offset: 0x0D (R/W   8) Control C */
+  __I  uint8_t                        Reserved1[1];
+  __IO TC_DBGCTRL_Type                DBGCTRL;        /**< Offset: 0x0F (R/W   8) Debug Control */
+  __I  TC_SYNCBUSY_Type               SYNCBUSY;       /**< Offset: 0x10 (R/   32) Synchronization Status */
+  __IO TC_COUNT8_COUNT_Type           COUNT;          /**< Offset: 0x14 (R/W   8) COUNT8 Count */
+  __I  uint8_t                        Reserved2[6];
+  __IO TC_COUNT8_PER_Type             PER;            /**< Offset: 0x1B (R/W   8) COUNT8 Period */
+  __IO TC_COUNT8_CC_Type              CC[2];          /**< Offset: 0x1C (R/W   8) COUNT8 Compare and Capture */
+  __I  uint8_t                        Reserved3[17];
+  __IO TC_COUNT8_PERBUF_Type          PERBUF;         /**< Offset: 0x2F (R/W   8) COUNT8 Period Buffer */
+  __IO TC_COUNT8_CCBUF_Type           CCBUF[2];       /**< Offset: 0x30 (R/W   8) COUNT8 Compare and Capture Buffer */
+} TcCount8;
+
+/** \brief TC hardware registers */
+typedef struct {  /* Basic Timer Counter */
+  __IO TC_CTRLA_Type                  CTRLA;          /**< Offset: 0x00 (R/W  32) Control A */
+  __IO TC_CTRLBCLR_Type               CTRLBCLR;       /**< Offset: 0x04 (R/W   8) Control B Clear */
+  __IO TC_CTRLBSET_Type               CTRLBSET;       /**< Offset: 0x05 (R/W   8) Control B Set */
+  __IO TC_EVCTRL_Type                 EVCTRL;         /**< Offset: 0x06 (R/W  16) Event Control */
+  __IO TC_INTENCLR_Type               INTENCLR;       /**< Offset: 0x08 (R/W   8) Interrupt Enable Clear */
+  __IO TC_INTENSET_Type               INTENSET;       /**< Offset: 0x09 (R/W   8) Interrupt Enable Set */
+  __IO TC_INTFLAG_Type                INTFLAG;        /**< Offset: 0x0A (R/W   8) Interrupt Flag Status and Clear */
+  __IO TC_STATUS_Type                 STATUS;         /**< Offset: 0x0B (R/W   8) Status */
+  __IO TC_WAVE_Type                   WAVE;           /**< Offset: 0x0C (R/W   8) Waveform Generation Control */
+  __IO TC_DRVCTRL_Type                DRVCTRL;        /**< Offset: 0x0D (R/W   8) Control C */
+  __I  uint8_t                        Reserved1[1];
+  __IO TC_DBGCTRL_Type                DBGCTRL;        /**< Offset: 0x0F (R/W   8) Debug Control */
+  __I  TC_SYNCBUSY_Type               SYNCBUSY;       /**< Offset: 0x10 (R/   32) Synchronization Status */
+  __IO TC_COUNT16_COUNT_Type          COUNT;          /**< Offset: 0x14 (R/W  16) COUNT16 Count */
+  __I  uint8_t                        Reserved2[4];
+  __IO TC_COUNT16_PER_Type            PER;            /**< Offset: 0x1A (R/W  16) COUNT16 Period */
+  __IO TC_COUNT16_CC_Type             CC[2];          /**< Offset: 0x1C (R/W  16) COUNT16 Compare and Capture */
+  __I  uint8_t                        Reserved3[14];
+  __IO TC_COUNT16_PERBUF_Type         PERBUF;         /**< Offset: 0x2E (R/W  16) COUNT16 Period Buffer */
+  __IO TC_COUNT16_CCBUF_Type          CCBUF[2];       /**< Offset: 0x30 (R/W  16) COUNT16 Compare and Capture Buffer */
+} TcCount16;
+
+/** \brief TC hardware registers */
+typedef struct {  /* Basic Timer Counter */
+  __IO TC_CTRLA_Type                  CTRLA;          /**< Offset: 0x00 (R/W  32) Control A */
+  __IO TC_CTRLBCLR_Type               CTRLBCLR;       /**< Offset: 0x04 (R/W   8) Control B Clear */
+  __IO TC_CTRLBSET_Type               CTRLBSET;       /**< Offset: 0x05 (R/W   8) Control B Set */
+  __IO TC_EVCTRL_Type                 EVCTRL;         /**< Offset: 0x06 (R/W  16) Event Control */
+  __IO TC_INTENCLR_Type               INTENCLR;       /**< Offset: 0x08 (R/W   8) Interrupt Enable Clear */
+  __IO TC_INTENSET_Type               INTENSET;       /**< Offset: 0x09 (R/W   8) Interrupt Enable Set */
+  __IO TC_INTFLAG_Type                INTFLAG;        /**< Offset: 0x0A (R/W   8) Interrupt Flag Status and Clear */
+  __IO TC_STATUS_Type                 STATUS;         /**< Offset: 0x0B (R/W   8) Status */
+  __IO TC_WAVE_Type                   WAVE;           /**< Offset: 0x0C (R/W   8) Waveform Generation Control */
+  __IO TC_DRVCTRL_Type                DRVCTRL;        /**< Offset: 0x0D (R/W   8) Control C */
+  __I  uint8_t                        Reserved1[1];
+  __IO TC_DBGCTRL_Type                DBGCTRL;        /**< Offset: 0x0F (R/W   8) Debug Control */
+  __I  TC_SYNCBUSY_Type               SYNCBUSY;       /**< Offset: 0x10 (R/   32) Synchronization Status */
+  __IO TC_COUNT32_COUNT_Type          COUNT;          /**< Offset: 0x14 (R/W  32) COUNT32 Count */
+  __IO TC_COUNT32_PER_Type            PER;            /**< Offset: 0x18 (R/W  32) COUNT32 Period */
+  __IO TC_COUNT32_CC_Type             CC[2];          /**< Offset: 0x1C (R/W  32) COUNT32 Compare and Capture */
+  __I  uint8_t                        Reserved2[8];
+  __IO TC_COUNT32_PERBUF_Type         PERBUF;         /**< Offset: 0x2C (R/W  32) COUNT32 Period Buffer */
+  __IO TC_COUNT32_CCBUF_Type          CCBUF[2];       /**< Offset: 0x30 (R/W  32) COUNT32 Compare and Capture Buffer */
+} TcCount32;
+
+/** \brief TC hardware registers */
+typedef union {  /* Basic Timer Counter */
+       TcCount8                       COUNT8;         /**< 8-bit Counter Mode */
+       TcCount16                      COUNT16;        /**< 16-bit Counter Mode */
+       TcCount32                      COUNT32;        /**< 32-bit Counter Mode */
+} Tc;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Basic Timer Counter */
+
+#endif /* _SAML10_TC_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/component/tram.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/tram.h
@@ -1,0 +1,316 @@
+/**
+ * \file
+ *
+ * \brief Component description for TRAM
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_TRAM_COMPONENT_H_
+#define _SAML10_TRAM_COMPONENT_H_
+#define _SAML10_TRAM_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML10 TrustRAM
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR TRAM */
+/* ========================================================================== */
+
+#define TRAM_U2801                      /**< (TRAM) Module ID */
+#define REV_TRAM 0x100                  /**< (TRAM) Module revision */
+
+/* -------- TRAM_CTRLA : (TRAM Offset: 0x00) (R/W 8) Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint8_t  ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint8_t  :2;                        /**< bit:   2..3  Reserved */
+    uint8_t  TAMPERS:1;                 /**< bit:      4  Tamper Erase                             */
+    uint8_t  :1;                        /**< bit:      5  Reserved */
+    uint8_t  DRP:1;                     /**< bit:      6  Data Remanence Prevention                */
+    uint8_t  SILACC:1;                  /**< bit:      7  Silent Access                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} TRAM_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRAM_CTRLA_OFFSET                   (0x00)                                        /**<  (TRAM_CTRLA) Control  Offset */
+#define TRAM_CTRLA_RESETVALUE               _U_(0x00)                                     /**<  (TRAM_CTRLA) Control  Reset Value */
+
+#define TRAM_CTRLA_SWRST_Pos                0                                              /**< (TRAM_CTRLA) Software Reset Position */
+#define TRAM_CTRLA_SWRST_Msk                (_U_(0x1) << TRAM_CTRLA_SWRST_Pos)             /**< (TRAM_CTRLA) Software Reset Mask */
+#define TRAM_CTRLA_SWRST                    TRAM_CTRLA_SWRST_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRAM_CTRLA_SWRST_Msk instead */
+#define TRAM_CTRLA_ENABLE_Pos               1                                              /**< (TRAM_CTRLA) Enable Position */
+#define TRAM_CTRLA_ENABLE_Msk               (_U_(0x1) << TRAM_CTRLA_ENABLE_Pos)            /**< (TRAM_CTRLA) Enable Mask */
+#define TRAM_CTRLA_ENABLE                   TRAM_CTRLA_ENABLE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRAM_CTRLA_ENABLE_Msk instead */
+#define TRAM_CTRLA_TAMPERS_Pos              4                                              /**< (TRAM_CTRLA) Tamper Erase Position */
+#define TRAM_CTRLA_TAMPERS_Msk              (_U_(0x1) << TRAM_CTRLA_TAMPERS_Pos)           /**< (TRAM_CTRLA) Tamper Erase Mask */
+#define TRAM_CTRLA_TAMPERS                  TRAM_CTRLA_TAMPERS_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRAM_CTRLA_TAMPERS_Msk instead */
+#define TRAM_CTRLA_DRP_Pos                  6                                              /**< (TRAM_CTRLA) Data Remanence Prevention Position */
+#define TRAM_CTRLA_DRP_Msk                  (_U_(0x1) << TRAM_CTRLA_DRP_Pos)               /**< (TRAM_CTRLA) Data Remanence Prevention Mask */
+#define TRAM_CTRLA_DRP                      TRAM_CTRLA_DRP_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRAM_CTRLA_DRP_Msk instead */
+#define TRAM_CTRLA_SILACC_Pos               7                                              /**< (TRAM_CTRLA) Silent Access Position */
+#define TRAM_CTRLA_SILACC_Msk               (_U_(0x1) << TRAM_CTRLA_SILACC_Pos)            /**< (TRAM_CTRLA) Silent Access Mask */
+#define TRAM_CTRLA_SILACC                   TRAM_CTRLA_SILACC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRAM_CTRLA_SILACC_Msk instead */
+#define TRAM_CTRLA_MASK                     _U_(0xD3)                                      /**< \deprecated (TRAM_CTRLA) Register MASK  (Use TRAM_CTRLA_Msk instead)  */
+#define TRAM_CTRLA_Msk                      _U_(0xD3)                                      /**< (TRAM_CTRLA) Register Mask  */
+
+
+/* -------- TRAM_INTENCLR : (TRAM Offset: 0x04) (R/W 8) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  ERR:1;                     /**< bit:      0  TrustRAM Readout Error Interrupt Enable  */
+    uint8_t  DRP:1;                     /**< bit:      1  Data Remanence Prevention Ended Interrupt Enable */
+    uint8_t  :6;                        /**< bit:   2..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} TRAM_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRAM_INTENCLR_OFFSET                (0x04)                                        /**<  (TRAM_INTENCLR) Interrupt Enable Clear  Offset */
+#define TRAM_INTENCLR_RESETVALUE            _U_(0x00)                                     /**<  (TRAM_INTENCLR) Interrupt Enable Clear  Reset Value */
+
+#define TRAM_INTENCLR_ERR_Pos               0                                              /**< (TRAM_INTENCLR) TrustRAM Readout Error Interrupt Enable Position */
+#define TRAM_INTENCLR_ERR_Msk               (_U_(0x1) << TRAM_INTENCLR_ERR_Pos)            /**< (TRAM_INTENCLR) TrustRAM Readout Error Interrupt Enable Mask */
+#define TRAM_INTENCLR_ERR                   TRAM_INTENCLR_ERR_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRAM_INTENCLR_ERR_Msk instead */
+#define TRAM_INTENCLR_DRP_Pos               1                                              /**< (TRAM_INTENCLR) Data Remanence Prevention Ended Interrupt Enable Position */
+#define TRAM_INTENCLR_DRP_Msk               (_U_(0x1) << TRAM_INTENCLR_DRP_Pos)            /**< (TRAM_INTENCLR) Data Remanence Prevention Ended Interrupt Enable Mask */
+#define TRAM_INTENCLR_DRP                   TRAM_INTENCLR_DRP_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRAM_INTENCLR_DRP_Msk instead */
+#define TRAM_INTENCLR_MASK                  _U_(0x03)                                      /**< \deprecated (TRAM_INTENCLR) Register MASK  (Use TRAM_INTENCLR_Msk instead)  */
+#define TRAM_INTENCLR_Msk                   _U_(0x03)                                      /**< (TRAM_INTENCLR) Register Mask  */
+
+
+/* -------- TRAM_INTENSET : (TRAM Offset: 0x05) (R/W 8) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  ERR:1;                     /**< bit:      0  TrustRAM Readout Error Interrupt Enable  */
+    uint8_t  DRP:1;                     /**< bit:      1  Data Remanence Prevention Ended Interrupt Enable */
+    uint8_t  :6;                        /**< bit:   2..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} TRAM_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRAM_INTENSET_OFFSET                (0x05)                                        /**<  (TRAM_INTENSET) Interrupt Enable Set  Offset */
+#define TRAM_INTENSET_RESETVALUE            _U_(0x00)                                     /**<  (TRAM_INTENSET) Interrupt Enable Set  Reset Value */
+
+#define TRAM_INTENSET_ERR_Pos               0                                              /**< (TRAM_INTENSET) TrustRAM Readout Error Interrupt Enable Position */
+#define TRAM_INTENSET_ERR_Msk               (_U_(0x1) << TRAM_INTENSET_ERR_Pos)            /**< (TRAM_INTENSET) TrustRAM Readout Error Interrupt Enable Mask */
+#define TRAM_INTENSET_ERR                   TRAM_INTENSET_ERR_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRAM_INTENSET_ERR_Msk instead */
+#define TRAM_INTENSET_DRP_Pos               1                                              /**< (TRAM_INTENSET) Data Remanence Prevention Ended Interrupt Enable Position */
+#define TRAM_INTENSET_DRP_Msk               (_U_(0x1) << TRAM_INTENSET_DRP_Pos)            /**< (TRAM_INTENSET) Data Remanence Prevention Ended Interrupt Enable Mask */
+#define TRAM_INTENSET_DRP                   TRAM_INTENSET_DRP_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRAM_INTENSET_DRP_Msk instead */
+#define TRAM_INTENSET_MASK                  _U_(0x03)                                      /**< \deprecated (TRAM_INTENSET) Register MASK  (Use TRAM_INTENSET_Msk instead)  */
+#define TRAM_INTENSET_Msk                   _U_(0x03)                                      /**< (TRAM_INTENSET) Register Mask  */
+
+
+/* -------- TRAM_INTFLAG : (TRAM Offset: 0x06) (R/W 8) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t ERR:1;                     /**< bit:      0  TrustRAM Readout Error                   */
+    __I uint8_t DRP:1;                     /**< bit:      1  Data Remanence Prevention Ended          */
+    __I uint8_t :6;                        /**< bit:   2..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} TRAM_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRAM_INTFLAG_OFFSET                 (0x06)                                        /**<  (TRAM_INTFLAG) Interrupt Flag Status and Clear  Offset */
+#define TRAM_INTFLAG_RESETVALUE             _U_(0x00)                                     /**<  (TRAM_INTFLAG) Interrupt Flag Status and Clear  Reset Value */
+
+#define TRAM_INTFLAG_ERR_Pos                0                                              /**< (TRAM_INTFLAG) TrustRAM Readout Error Position */
+#define TRAM_INTFLAG_ERR_Msk                (_U_(0x1) << TRAM_INTFLAG_ERR_Pos)             /**< (TRAM_INTFLAG) TrustRAM Readout Error Mask */
+#define TRAM_INTFLAG_ERR                    TRAM_INTFLAG_ERR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRAM_INTFLAG_ERR_Msk instead */
+#define TRAM_INTFLAG_DRP_Pos                1                                              /**< (TRAM_INTFLAG) Data Remanence Prevention Ended Position */
+#define TRAM_INTFLAG_DRP_Msk                (_U_(0x1) << TRAM_INTFLAG_DRP_Pos)             /**< (TRAM_INTFLAG) Data Remanence Prevention Ended Mask */
+#define TRAM_INTFLAG_DRP                    TRAM_INTFLAG_DRP_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRAM_INTFLAG_DRP_Msk instead */
+#define TRAM_INTFLAG_MASK                   _U_(0x03)                                      /**< \deprecated (TRAM_INTFLAG) Register MASK  (Use TRAM_INTFLAG_Msk instead)  */
+#define TRAM_INTFLAG_Msk                    _U_(0x03)                                      /**< (TRAM_INTFLAG) Register Mask  */
+
+
+/* -------- TRAM_STATUS : (TRAM Offset: 0x07) (R/ 8) Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  RAMINV:1;                  /**< bit:      0  RAM Inversion Bit                        */
+    uint8_t  DRP:1;                     /**< bit:      1  Data Remanence Prevention Ongoing        */
+    uint8_t  :6;                        /**< bit:   2..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} TRAM_STATUS_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRAM_STATUS_OFFSET                  (0x07)                                        /**<  (TRAM_STATUS) Status  Offset */
+#define TRAM_STATUS_RESETVALUE              _U_(0x00)                                     /**<  (TRAM_STATUS) Status  Reset Value */
+
+#define TRAM_STATUS_RAMINV_Pos              0                                              /**< (TRAM_STATUS) RAM Inversion Bit Position */
+#define TRAM_STATUS_RAMINV_Msk              (_U_(0x1) << TRAM_STATUS_RAMINV_Pos)           /**< (TRAM_STATUS) RAM Inversion Bit Mask */
+#define TRAM_STATUS_RAMINV                  TRAM_STATUS_RAMINV_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRAM_STATUS_RAMINV_Msk instead */
+#define TRAM_STATUS_DRP_Pos                 1                                              /**< (TRAM_STATUS) Data Remanence Prevention Ongoing Position */
+#define TRAM_STATUS_DRP_Msk                 (_U_(0x1) << TRAM_STATUS_DRP_Pos)              /**< (TRAM_STATUS) Data Remanence Prevention Ongoing Mask */
+#define TRAM_STATUS_DRP                     TRAM_STATUS_DRP_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRAM_STATUS_DRP_Msk instead */
+#define TRAM_STATUS_MASK                    _U_(0x03)                                      /**< \deprecated (TRAM_STATUS) Register MASK  (Use TRAM_STATUS_Msk instead)  */
+#define TRAM_STATUS_Msk                     _U_(0x03)                                      /**< (TRAM_STATUS) Register Mask  */
+
+
+/* -------- TRAM_SYNCBUSY : (TRAM Offset: 0x08) (R/ 32) Synchronization Busy Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SWRST:1;                   /**< bit:      0  Software Reset Busy                      */
+    uint32_t ENABLE:1;                  /**< bit:      1  Enable Busy                              */
+    uint32_t :30;                       /**< bit:  2..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TRAM_SYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRAM_SYNCBUSY_OFFSET                (0x08)                                        /**<  (TRAM_SYNCBUSY) Synchronization Busy Status  Offset */
+#define TRAM_SYNCBUSY_RESETVALUE            _U_(0x00)                                     /**<  (TRAM_SYNCBUSY) Synchronization Busy Status  Reset Value */
+
+#define TRAM_SYNCBUSY_SWRST_Pos             0                                              /**< (TRAM_SYNCBUSY) Software Reset Busy Position */
+#define TRAM_SYNCBUSY_SWRST_Msk             (_U_(0x1) << TRAM_SYNCBUSY_SWRST_Pos)          /**< (TRAM_SYNCBUSY) Software Reset Busy Mask */
+#define TRAM_SYNCBUSY_SWRST                 TRAM_SYNCBUSY_SWRST_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRAM_SYNCBUSY_SWRST_Msk instead */
+#define TRAM_SYNCBUSY_ENABLE_Pos            1                                              /**< (TRAM_SYNCBUSY) Enable Busy Position */
+#define TRAM_SYNCBUSY_ENABLE_Msk            (_U_(0x1) << TRAM_SYNCBUSY_ENABLE_Pos)         /**< (TRAM_SYNCBUSY) Enable Busy Mask */
+#define TRAM_SYNCBUSY_ENABLE                TRAM_SYNCBUSY_ENABLE_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRAM_SYNCBUSY_ENABLE_Msk instead */
+#define TRAM_SYNCBUSY_MASK                  _U_(0x03)                                      /**< \deprecated (TRAM_SYNCBUSY) Register MASK  (Use TRAM_SYNCBUSY_Msk instead)  */
+#define TRAM_SYNCBUSY_Msk                   _U_(0x03)                                      /**< (TRAM_SYNCBUSY) Register Mask  */
+
+
+/* -------- TRAM_DSCC : (TRAM Offset: 0x0c) (/W 32) Data Scramble Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t DSCKEY:30;                 /**< bit:  0..29  Data Scramble Key                        */
+    uint32_t :1;                        /**< bit:     30  Reserved */
+    uint32_t DSCEN:1;                   /**< bit:     31  Data Scramble Enable                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TRAM_DSCC_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRAM_DSCC_OFFSET                    (0x0C)                                        /**<  (TRAM_DSCC) Data Scramble Control  Offset */
+#define TRAM_DSCC_RESETVALUE                _U_(0x00)                                     /**<  (TRAM_DSCC) Data Scramble Control  Reset Value */
+
+#define TRAM_DSCC_DSCKEY_Pos                0                                              /**< (TRAM_DSCC) Data Scramble Key Position */
+#define TRAM_DSCC_DSCKEY_Msk                (_U_(0x3FFFFFFF) << TRAM_DSCC_DSCKEY_Pos)      /**< (TRAM_DSCC) Data Scramble Key Mask */
+#define TRAM_DSCC_DSCKEY(value)             (TRAM_DSCC_DSCKEY_Msk & ((value) << TRAM_DSCC_DSCKEY_Pos))
+#define TRAM_DSCC_DSCEN_Pos                 31                                             /**< (TRAM_DSCC) Data Scramble Enable Position */
+#define TRAM_DSCC_DSCEN_Msk                 (_U_(0x1) << TRAM_DSCC_DSCEN_Pos)              /**< (TRAM_DSCC) Data Scramble Enable Mask */
+#define TRAM_DSCC_DSCEN                     TRAM_DSCC_DSCEN_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRAM_DSCC_DSCEN_Msk instead */
+#define TRAM_DSCC_MASK                      _U_(0xBFFFFFFF)                                /**< \deprecated (TRAM_DSCC) Register MASK  (Use TRAM_DSCC_Msk instead)  */
+#define TRAM_DSCC_Msk                       _U_(0xBFFFFFFF)                                /**< (TRAM_DSCC) Register Mask  */
+
+
+/* -------- TRAM_PERMW : (TRAM Offset: 0x10) (/W 8) Permutation Write -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DATA:3;                    /**< bit:   0..2  Permutation Scrambler Data Input         */
+    uint8_t  :5;                        /**< bit:   3..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} TRAM_PERMW_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRAM_PERMW_OFFSET                   (0x10)                                        /**<  (TRAM_PERMW) Permutation Write  Offset */
+#define TRAM_PERMW_RESETVALUE               _U_(0x00)                                     /**<  (TRAM_PERMW) Permutation Write  Reset Value */
+
+#define TRAM_PERMW_DATA_Pos                 0                                              /**< (TRAM_PERMW) Permutation Scrambler Data Input Position */
+#define TRAM_PERMW_DATA_Msk                 (_U_(0x7) << TRAM_PERMW_DATA_Pos)              /**< (TRAM_PERMW) Permutation Scrambler Data Input Mask */
+#define TRAM_PERMW_DATA(value)              (TRAM_PERMW_DATA_Msk & ((value) << TRAM_PERMW_DATA_Pos))
+#define TRAM_PERMW_MASK                     _U_(0x07)                                      /**< \deprecated (TRAM_PERMW) Register MASK  (Use TRAM_PERMW_Msk instead)  */
+#define TRAM_PERMW_Msk                      _U_(0x07)                                      /**< (TRAM_PERMW) Register Mask  */
+
+
+/* -------- TRAM_PERMR : (TRAM Offset: 0x11) (R/ 8) Permutation Read -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DATA:3;                    /**< bit:   0..2  Permutation Scrambler Data Output        */
+    uint8_t  :5;                        /**< bit:   3..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} TRAM_PERMR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRAM_PERMR_OFFSET                   (0x11)                                        /**<  (TRAM_PERMR) Permutation Read  Offset */
+#define TRAM_PERMR_RESETVALUE               _U_(0x00)                                     /**<  (TRAM_PERMR) Permutation Read  Reset Value */
+
+#define TRAM_PERMR_DATA_Pos                 0                                              /**< (TRAM_PERMR) Permutation Scrambler Data Output Position */
+#define TRAM_PERMR_DATA_Msk                 (_U_(0x7) << TRAM_PERMR_DATA_Pos)              /**< (TRAM_PERMR) Permutation Scrambler Data Output Mask */
+#define TRAM_PERMR_DATA(value)              (TRAM_PERMR_DATA_Msk & ((value) << TRAM_PERMR_DATA_Pos))
+#define TRAM_PERMR_MASK                     _U_(0x07)                                      /**< \deprecated (TRAM_PERMR) Register MASK  (Use TRAM_PERMR_Msk instead)  */
+#define TRAM_PERMR_Msk                      _U_(0x07)                                      /**< (TRAM_PERMR) Register Mask  */
+
+
+/* -------- TRAM_RAM : (TRAM Offset: 0x100) (R/W 32) TrustRAM -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t DATA:32;                   /**< bit:  0..31  Trust RAM Data                           */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TRAM_RAM_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRAM_RAM_OFFSET                     (0x100)                                       /**<  (TRAM_RAM) TrustRAM  Offset */
+#define TRAM_RAM_RESETVALUE                 _U_(0x00)                                     /**<  (TRAM_RAM) TrustRAM  Reset Value */
+
+#define TRAM_RAM_DATA_Pos                   0                                              /**< (TRAM_RAM) Trust RAM Data Position */
+#define TRAM_RAM_DATA_Msk                   (_U_(0xFFFFFFFF) << TRAM_RAM_DATA_Pos)         /**< (TRAM_RAM) Trust RAM Data Mask */
+#define TRAM_RAM_DATA(value)                (TRAM_RAM_DATA_Msk & ((value) << TRAM_RAM_DATA_Pos))
+#define TRAM_RAM_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (TRAM_RAM) Register MASK  (Use TRAM_RAM_Msk instead)  */
+#define TRAM_RAM_Msk                        _U_(0xFFFFFFFF)                                /**< (TRAM_RAM) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief TRAM hardware registers */
+typedef struct {  /* TrustRAM */
+  __IO TRAM_CTRLA_Type                CTRLA;          /**< Offset: 0x00 (R/W   8) Control */
+  __I  uint8_t                        Reserved1[3];
+  __IO TRAM_INTENCLR_Type             INTENCLR;       /**< Offset: 0x04 (R/W   8) Interrupt Enable Clear */
+  __IO TRAM_INTENSET_Type             INTENSET;       /**< Offset: 0x05 (R/W   8) Interrupt Enable Set */
+  __IO TRAM_INTFLAG_Type              INTFLAG;        /**< Offset: 0x06 (R/W   8) Interrupt Flag Status and Clear */
+  __I  TRAM_STATUS_Type               STATUS;         /**< Offset: 0x07 (R/    8) Status */
+  __I  TRAM_SYNCBUSY_Type             SYNCBUSY;       /**< Offset: 0x08 (R/   32) Synchronization Busy Status */
+  __O  TRAM_DSCC_Type                 DSCC;           /**< Offset: 0x0C ( /W  32) Data Scramble Control */
+  __O  TRAM_PERMW_Type                PERMW;          /**< Offset: 0x10 ( /W   8) Permutation Write */
+  __I  TRAM_PERMR_Type                PERMR;          /**< Offset: 0x11 (R/    8) Permutation Read */
+  __I  uint8_t                        Reserved2[238];
+  __IO TRAM_RAM_Type                  RAM[64];        /**< Offset: 0x100 (R/W  32) TrustRAM */
+} Tram;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of TrustRAM */
+
+#endif /* _SAML10_TRAM_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/component/trng.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/trng.h
@@ -1,0 +1,194 @@
+/**
+ * \file
+ *
+ * \brief Component description for TRNG
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_TRNG_COMPONENT_H_
+#define _SAML10_TRNG_COMPONENT_H_
+#define _SAML10_TRNG_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML10 True Random Generator
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR TRNG */
+/* ========================================================================== */
+
+#define TRNG_U2242                      /**< (TRNG) Module ID */
+#define REV_TRNG 0x120                  /**< (TRNG) Module revision */
+
+/* -------- TRNG_CTRLA : (TRNG Offset: 0x00) (R/W 8) Control A -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  :1;                        /**< bit:      0  Reserved */
+    uint8_t  ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint8_t  :4;                        /**< bit:   2..5  Reserved */
+    uint8_t  RUNSTDBY:1;                /**< bit:      6  Run in Standby                           */
+    uint8_t  :1;                        /**< bit:      7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} TRNG_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRNG_CTRLA_OFFSET                   (0x00)                                        /**<  (TRNG_CTRLA) Control A  Offset */
+#define TRNG_CTRLA_RESETVALUE               _U_(0x00)                                     /**<  (TRNG_CTRLA) Control A  Reset Value */
+
+#define TRNG_CTRLA_ENABLE_Pos               1                                              /**< (TRNG_CTRLA) Enable Position */
+#define TRNG_CTRLA_ENABLE_Msk               (_U_(0x1) << TRNG_CTRLA_ENABLE_Pos)            /**< (TRNG_CTRLA) Enable Mask */
+#define TRNG_CTRLA_ENABLE                   TRNG_CTRLA_ENABLE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRNG_CTRLA_ENABLE_Msk instead */
+#define TRNG_CTRLA_RUNSTDBY_Pos             6                                              /**< (TRNG_CTRLA) Run in Standby Position */
+#define TRNG_CTRLA_RUNSTDBY_Msk             (_U_(0x1) << TRNG_CTRLA_RUNSTDBY_Pos)          /**< (TRNG_CTRLA) Run in Standby Mask */
+#define TRNG_CTRLA_RUNSTDBY                 TRNG_CTRLA_RUNSTDBY_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRNG_CTRLA_RUNSTDBY_Msk instead */
+#define TRNG_CTRLA_MASK                     _U_(0x42)                                      /**< \deprecated (TRNG_CTRLA) Register MASK  (Use TRNG_CTRLA_Msk instead)  */
+#define TRNG_CTRLA_Msk                      _U_(0x42)                                      /**< (TRNG_CTRLA) Register Mask  */
+
+
+/* -------- TRNG_EVCTRL : (TRNG Offset: 0x04) (R/W 8) Event Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DATARDYEO:1;               /**< bit:      0  Data Ready Event Output                  */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} TRNG_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRNG_EVCTRL_OFFSET                  (0x04)                                        /**<  (TRNG_EVCTRL) Event Control  Offset */
+#define TRNG_EVCTRL_RESETVALUE              _U_(0x00)                                     /**<  (TRNG_EVCTRL) Event Control  Reset Value */
+
+#define TRNG_EVCTRL_DATARDYEO_Pos           0                                              /**< (TRNG_EVCTRL) Data Ready Event Output Position */
+#define TRNG_EVCTRL_DATARDYEO_Msk           (_U_(0x1) << TRNG_EVCTRL_DATARDYEO_Pos)        /**< (TRNG_EVCTRL) Data Ready Event Output Mask */
+#define TRNG_EVCTRL_DATARDYEO               TRNG_EVCTRL_DATARDYEO_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRNG_EVCTRL_DATARDYEO_Msk instead */
+#define TRNG_EVCTRL_MASK                    _U_(0x01)                                      /**< \deprecated (TRNG_EVCTRL) Register MASK  (Use TRNG_EVCTRL_Msk instead)  */
+#define TRNG_EVCTRL_Msk                     _U_(0x01)                                      /**< (TRNG_EVCTRL) Register Mask  */
+
+
+/* -------- TRNG_INTENCLR : (TRNG Offset: 0x08) (R/W 8) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DATARDY:1;                 /**< bit:      0  Data Ready Interrupt Enable              */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} TRNG_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRNG_INTENCLR_OFFSET                (0x08)                                        /**<  (TRNG_INTENCLR) Interrupt Enable Clear  Offset */
+#define TRNG_INTENCLR_RESETVALUE            _U_(0x00)                                     /**<  (TRNG_INTENCLR) Interrupt Enable Clear  Reset Value */
+
+#define TRNG_INTENCLR_DATARDY_Pos           0                                              /**< (TRNG_INTENCLR) Data Ready Interrupt Enable Position */
+#define TRNG_INTENCLR_DATARDY_Msk           (_U_(0x1) << TRNG_INTENCLR_DATARDY_Pos)        /**< (TRNG_INTENCLR) Data Ready Interrupt Enable Mask */
+#define TRNG_INTENCLR_DATARDY               TRNG_INTENCLR_DATARDY_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRNG_INTENCLR_DATARDY_Msk instead */
+#define TRNG_INTENCLR_MASK                  _U_(0x01)                                      /**< \deprecated (TRNG_INTENCLR) Register MASK  (Use TRNG_INTENCLR_Msk instead)  */
+#define TRNG_INTENCLR_Msk                   _U_(0x01)                                      /**< (TRNG_INTENCLR) Register Mask  */
+
+
+/* -------- TRNG_INTENSET : (TRNG Offset: 0x09) (R/W 8) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DATARDY:1;                 /**< bit:      0  Data Ready Interrupt Enable              */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} TRNG_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRNG_INTENSET_OFFSET                (0x09)                                        /**<  (TRNG_INTENSET) Interrupt Enable Set  Offset */
+#define TRNG_INTENSET_RESETVALUE            _U_(0x00)                                     /**<  (TRNG_INTENSET) Interrupt Enable Set  Reset Value */
+
+#define TRNG_INTENSET_DATARDY_Pos           0                                              /**< (TRNG_INTENSET) Data Ready Interrupt Enable Position */
+#define TRNG_INTENSET_DATARDY_Msk           (_U_(0x1) << TRNG_INTENSET_DATARDY_Pos)        /**< (TRNG_INTENSET) Data Ready Interrupt Enable Mask */
+#define TRNG_INTENSET_DATARDY               TRNG_INTENSET_DATARDY_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRNG_INTENSET_DATARDY_Msk instead */
+#define TRNG_INTENSET_MASK                  _U_(0x01)                                      /**< \deprecated (TRNG_INTENSET) Register MASK  (Use TRNG_INTENSET_Msk instead)  */
+#define TRNG_INTENSET_Msk                   _U_(0x01)                                      /**< (TRNG_INTENSET) Register Mask  */
+
+
+/* -------- TRNG_INTFLAG : (TRNG Offset: 0x0a) (R/W 8) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t DATARDY:1;                 /**< bit:      0  Data Ready Interrupt Flag                */
+    __I uint8_t :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} TRNG_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRNG_INTFLAG_OFFSET                 (0x0A)                                        /**<  (TRNG_INTFLAG) Interrupt Flag Status and Clear  Offset */
+#define TRNG_INTFLAG_RESETVALUE             _U_(0x00)                                     /**<  (TRNG_INTFLAG) Interrupt Flag Status and Clear  Reset Value */
+
+#define TRNG_INTFLAG_DATARDY_Pos            0                                              /**< (TRNG_INTFLAG) Data Ready Interrupt Flag Position */
+#define TRNG_INTFLAG_DATARDY_Msk            (_U_(0x1) << TRNG_INTFLAG_DATARDY_Pos)         /**< (TRNG_INTFLAG) Data Ready Interrupt Flag Mask */
+#define TRNG_INTFLAG_DATARDY                TRNG_INTFLAG_DATARDY_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRNG_INTFLAG_DATARDY_Msk instead */
+#define TRNG_INTFLAG_MASK                   _U_(0x01)                                      /**< \deprecated (TRNG_INTFLAG) Register MASK  (Use TRNG_INTFLAG_Msk instead)  */
+#define TRNG_INTFLAG_Msk                    _U_(0x01)                                      /**< (TRNG_INTFLAG) Register Mask  */
+
+
+/* -------- TRNG_DATA : (TRNG Offset: 0x20) (R/ 32) Output Data -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t DATA:32;                   /**< bit:  0..31  Output Data                              */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TRNG_DATA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRNG_DATA_OFFSET                    (0x20)                                        /**<  (TRNG_DATA) Output Data  Offset */
+#define TRNG_DATA_RESETVALUE                _U_(0x00)                                     /**<  (TRNG_DATA) Output Data  Reset Value */
+
+#define TRNG_DATA_DATA_Pos                  0                                              /**< (TRNG_DATA) Output Data Position */
+#define TRNG_DATA_DATA_Msk                  (_U_(0xFFFFFFFF) << TRNG_DATA_DATA_Pos)        /**< (TRNG_DATA) Output Data Mask */
+#define TRNG_DATA_DATA(value)               (TRNG_DATA_DATA_Msk & ((value) << TRNG_DATA_DATA_Pos))
+#define TRNG_DATA_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (TRNG_DATA) Register MASK  (Use TRNG_DATA_Msk instead)  */
+#define TRNG_DATA_Msk                       _U_(0xFFFFFFFF)                                /**< (TRNG_DATA) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief TRNG hardware registers */
+typedef struct {  /* True Random Generator */
+  __IO TRNG_CTRLA_Type                CTRLA;          /**< Offset: 0x00 (R/W   8) Control A */
+  __I  uint8_t                        Reserved1[3];
+  __IO TRNG_EVCTRL_Type               EVCTRL;         /**< Offset: 0x04 (R/W   8) Event Control */
+  __I  uint8_t                        Reserved2[3];
+  __IO TRNG_INTENCLR_Type             INTENCLR;       /**< Offset: 0x08 (R/W   8) Interrupt Enable Clear */
+  __IO TRNG_INTENSET_Type             INTENSET;       /**< Offset: 0x09 (R/W   8) Interrupt Enable Set */
+  __IO TRNG_INTFLAG_Type              INTFLAG;        /**< Offset: 0x0A (R/W   8) Interrupt Flag Status and Clear */
+  __I  uint8_t                        Reserved3[21];
+  __I  TRNG_DATA_Type                 DATA;           /**< Offset: 0x20 (R/   32) Output Data */
+} Trng;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of True Random Generator */
+
+#endif /* _SAML10_TRNG_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/component/wdt.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/wdt.h
@@ -1,0 +1,338 @@
+/**
+ * \file
+ *
+ * \brief Component description for WDT
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_WDT_COMPONENT_H_
+#define _SAML10_WDT_COMPONENT_H_
+#define _SAML10_WDT_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML10 Watchdog Timer
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR WDT */
+/* ========================================================================== */
+
+#define WDT_U2251                      /**< (WDT) Module ID */
+#define REV_WDT 0x200                  /**< (WDT) Module revision */
+
+/* -------- WDT_CTRLA : (WDT Offset: 0x00) (R/W 8) Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  :1;                        /**< bit:      0  Reserved */
+    uint8_t  ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint8_t  WEN:1;                     /**< bit:      2  Watchdog Timer Window Mode Enable        */
+    uint8_t  :3;                        /**< bit:   3..5  Reserved */
+    uint8_t  RUNSTDBY:1;                /**< bit:      6  Run During Standby                       */
+    uint8_t  ALWAYSON:1;                /**< bit:      7  Always-On                                */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} WDT_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_CTRLA_OFFSET                    (0x00)                                        /**<  (WDT_CTRLA) Control  Offset */
+#define WDT_CTRLA_RESETVALUE                _U_(0x00)                                     /**<  (WDT_CTRLA) Control  Reset Value */
+
+#define WDT_CTRLA_ENABLE_Pos                1                                              /**< (WDT_CTRLA) Enable Position */
+#define WDT_CTRLA_ENABLE_Msk                (_U_(0x1) << WDT_CTRLA_ENABLE_Pos)             /**< (WDT_CTRLA) Enable Mask */
+#define WDT_CTRLA_ENABLE                    WDT_CTRLA_ENABLE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use WDT_CTRLA_ENABLE_Msk instead */
+#define WDT_CTRLA_WEN_Pos                   2                                              /**< (WDT_CTRLA) Watchdog Timer Window Mode Enable Position */
+#define WDT_CTRLA_WEN_Msk                   (_U_(0x1) << WDT_CTRLA_WEN_Pos)                /**< (WDT_CTRLA) Watchdog Timer Window Mode Enable Mask */
+#define WDT_CTRLA_WEN                       WDT_CTRLA_WEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use WDT_CTRLA_WEN_Msk instead */
+#define WDT_CTRLA_RUNSTDBY_Pos              6                                              /**< (WDT_CTRLA) Run During Standby Position */
+#define WDT_CTRLA_RUNSTDBY_Msk              (_U_(0x1) << WDT_CTRLA_RUNSTDBY_Pos)           /**< (WDT_CTRLA) Run During Standby Mask */
+#define WDT_CTRLA_RUNSTDBY                  WDT_CTRLA_RUNSTDBY_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use WDT_CTRLA_RUNSTDBY_Msk instead */
+#define WDT_CTRLA_ALWAYSON_Pos              7                                              /**< (WDT_CTRLA) Always-On Position */
+#define WDT_CTRLA_ALWAYSON_Msk              (_U_(0x1) << WDT_CTRLA_ALWAYSON_Pos)           /**< (WDT_CTRLA) Always-On Mask */
+#define WDT_CTRLA_ALWAYSON                  WDT_CTRLA_ALWAYSON_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use WDT_CTRLA_ALWAYSON_Msk instead */
+#define WDT_CTRLA_MASK                      _U_(0xC6)                                      /**< \deprecated (WDT_CTRLA) Register MASK  (Use WDT_CTRLA_Msk instead)  */
+#define WDT_CTRLA_Msk                       _U_(0xC6)                                      /**< (WDT_CTRLA) Register Mask  */
+
+
+/* -------- WDT_CONFIG : (WDT Offset: 0x01) (R/W 8) Configuration -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  PER:4;                     /**< bit:   0..3  Time-Out Period                          */
+    uint8_t  WINDOW:4;                  /**< bit:   4..7  Window Mode Time-Out Period              */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} WDT_CONFIG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_CONFIG_OFFSET                   (0x01)                                        /**<  (WDT_CONFIG) Configuration  Offset */
+#define WDT_CONFIG_RESETVALUE               _U_(0xBB)                                     /**<  (WDT_CONFIG) Configuration  Reset Value */
+
+#define WDT_CONFIG_PER_Pos                  0                                              /**< (WDT_CONFIG) Time-Out Period Position */
+#define WDT_CONFIG_PER_Msk                  (_U_(0xF) << WDT_CONFIG_PER_Pos)               /**< (WDT_CONFIG) Time-Out Period Mask */
+#define WDT_CONFIG_PER(value)               (WDT_CONFIG_PER_Msk & ((value) << WDT_CONFIG_PER_Pos))
+#define   WDT_CONFIG_PER_CYC8_Val           _U_(0x0)                                       /**< (WDT_CONFIG) 8 clock cycles  */
+#define   WDT_CONFIG_PER_CYC16_Val          _U_(0x1)                                       /**< (WDT_CONFIG) 16 clock cycles  */
+#define   WDT_CONFIG_PER_CYC32_Val          _U_(0x2)                                       /**< (WDT_CONFIG) 32 clock cycles  */
+#define   WDT_CONFIG_PER_CYC64_Val          _U_(0x3)                                       /**< (WDT_CONFIG) 64 clock cycles  */
+#define   WDT_CONFIG_PER_CYC128_Val         _U_(0x4)                                       /**< (WDT_CONFIG) 128 clock cycles  */
+#define   WDT_CONFIG_PER_CYC256_Val         _U_(0x5)                                       /**< (WDT_CONFIG) 256 clock cycles  */
+#define   WDT_CONFIG_PER_CYC512_Val         _U_(0x6)                                       /**< (WDT_CONFIG) 512 clock cycles  */
+#define   WDT_CONFIG_PER_CYC1024_Val        _U_(0x7)                                       /**< (WDT_CONFIG) 1024 clock cycles  */
+#define   WDT_CONFIG_PER_CYC2048_Val        _U_(0x8)                                       /**< (WDT_CONFIG) 2048 clock cycles  */
+#define   WDT_CONFIG_PER_CYC4096_Val        _U_(0x9)                                       /**< (WDT_CONFIG) 4096 clock cycles  */
+#define   WDT_CONFIG_PER_CYC8192_Val        _U_(0xA)                                       /**< (WDT_CONFIG) 8192 clock cycles  */
+#define   WDT_CONFIG_PER_CYC16384_Val       _U_(0xB)                                       /**< (WDT_CONFIG) 16384 clock cycles  */
+#define WDT_CONFIG_PER_CYC8                 (WDT_CONFIG_PER_CYC8_Val << WDT_CONFIG_PER_Pos)  /**< (WDT_CONFIG) 8 clock cycles Position  */
+#define WDT_CONFIG_PER_CYC16                (WDT_CONFIG_PER_CYC16_Val << WDT_CONFIG_PER_Pos)  /**< (WDT_CONFIG) 16 clock cycles Position  */
+#define WDT_CONFIG_PER_CYC32                (WDT_CONFIG_PER_CYC32_Val << WDT_CONFIG_PER_Pos)  /**< (WDT_CONFIG) 32 clock cycles Position  */
+#define WDT_CONFIG_PER_CYC64                (WDT_CONFIG_PER_CYC64_Val << WDT_CONFIG_PER_Pos)  /**< (WDT_CONFIG) 64 clock cycles Position  */
+#define WDT_CONFIG_PER_CYC128               (WDT_CONFIG_PER_CYC128_Val << WDT_CONFIG_PER_Pos)  /**< (WDT_CONFIG) 128 clock cycles Position  */
+#define WDT_CONFIG_PER_CYC256               (WDT_CONFIG_PER_CYC256_Val << WDT_CONFIG_PER_Pos)  /**< (WDT_CONFIG) 256 clock cycles Position  */
+#define WDT_CONFIG_PER_CYC512               (WDT_CONFIG_PER_CYC512_Val << WDT_CONFIG_PER_Pos)  /**< (WDT_CONFIG) 512 clock cycles Position  */
+#define WDT_CONFIG_PER_CYC1024              (WDT_CONFIG_PER_CYC1024_Val << WDT_CONFIG_PER_Pos)  /**< (WDT_CONFIG) 1024 clock cycles Position  */
+#define WDT_CONFIG_PER_CYC2048              (WDT_CONFIG_PER_CYC2048_Val << WDT_CONFIG_PER_Pos)  /**< (WDT_CONFIG) 2048 clock cycles Position  */
+#define WDT_CONFIG_PER_CYC4096              (WDT_CONFIG_PER_CYC4096_Val << WDT_CONFIG_PER_Pos)  /**< (WDT_CONFIG) 4096 clock cycles Position  */
+#define WDT_CONFIG_PER_CYC8192              (WDT_CONFIG_PER_CYC8192_Val << WDT_CONFIG_PER_Pos)  /**< (WDT_CONFIG) 8192 clock cycles Position  */
+#define WDT_CONFIG_PER_CYC16384             (WDT_CONFIG_PER_CYC16384_Val << WDT_CONFIG_PER_Pos)  /**< (WDT_CONFIG) 16384 clock cycles Position  */
+#define WDT_CONFIG_WINDOW_Pos               4                                              /**< (WDT_CONFIG) Window Mode Time-Out Period Position */
+#define WDT_CONFIG_WINDOW_Msk               (_U_(0xF) << WDT_CONFIG_WINDOW_Pos)            /**< (WDT_CONFIG) Window Mode Time-Out Period Mask */
+#define WDT_CONFIG_WINDOW(value)            (WDT_CONFIG_WINDOW_Msk & ((value) << WDT_CONFIG_WINDOW_Pos))
+#define   WDT_CONFIG_WINDOW_CYC8_Val        _U_(0x0)                                       /**< (WDT_CONFIG) 8 clock cycles  */
+#define   WDT_CONFIG_WINDOW_CYC16_Val       _U_(0x1)                                       /**< (WDT_CONFIG) 16 clock cycles  */
+#define   WDT_CONFIG_WINDOW_CYC32_Val       _U_(0x2)                                       /**< (WDT_CONFIG) 32 clock cycles  */
+#define   WDT_CONFIG_WINDOW_CYC64_Val       _U_(0x3)                                       /**< (WDT_CONFIG) 64 clock cycles  */
+#define   WDT_CONFIG_WINDOW_CYC128_Val      _U_(0x4)                                       /**< (WDT_CONFIG) 128 clock cycles  */
+#define   WDT_CONFIG_WINDOW_CYC256_Val      _U_(0x5)                                       /**< (WDT_CONFIG) 256 clock cycles  */
+#define   WDT_CONFIG_WINDOW_CYC512_Val      _U_(0x6)                                       /**< (WDT_CONFIG) 512 clock cycles  */
+#define   WDT_CONFIG_WINDOW_CYC1024_Val     _U_(0x7)                                       /**< (WDT_CONFIG) 1024 clock cycles  */
+#define   WDT_CONFIG_WINDOW_CYC2048_Val     _U_(0x8)                                       /**< (WDT_CONFIG) 2048 clock cycles  */
+#define   WDT_CONFIG_WINDOW_CYC4096_Val     _U_(0x9)                                       /**< (WDT_CONFIG) 4096 clock cycles  */
+#define   WDT_CONFIG_WINDOW_CYC8192_Val     _U_(0xA)                                       /**< (WDT_CONFIG) 8192 clock cycles  */
+#define   WDT_CONFIG_WINDOW_CYC16384_Val    _U_(0xB)                                       /**< (WDT_CONFIG) 16384 clock cycles  */
+#define WDT_CONFIG_WINDOW_CYC8              (WDT_CONFIG_WINDOW_CYC8_Val << WDT_CONFIG_WINDOW_Pos)  /**< (WDT_CONFIG) 8 clock cycles Position  */
+#define WDT_CONFIG_WINDOW_CYC16             (WDT_CONFIG_WINDOW_CYC16_Val << WDT_CONFIG_WINDOW_Pos)  /**< (WDT_CONFIG) 16 clock cycles Position  */
+#define WDT_CONFIG_WINDOW_CYC32             (WDT_CONFIG_WINDOW_CYC32_Val << WDT_CONFIG_WINDOW_Pos)  /**< (WDT_CONFIG) 32 clock cycles Position  */
+#define WDT_CONFIG_WINDOW_CYC64             (WDT_CONFIG_WINDOW_CYC64_Val << WDT_CONFIG_WINDOW_Pos)  /**< (WDT_CONFIG) 64 clock cycles Position  */
+#define WDT_CONFIG_WINDOW_CYC128            (WDT_CONFIG_WINDOW_CYC128_Val << WDT_CONFIG_WINDOW_Pos)  /**< (WDT_CONFIG) 128 clock cycles Position  */
+#define WDT_CONFIG_WINDOW_CYC256            (WDT_CONFIG_WINDOW_CYC256_Val << WDT_CONFIG_WINDOW_Pos)  /**< (WDT_CONFIG) 256 clock cycles Position  */
+#define WDT_CONFIG_WINDOW_CYC512            (WDT_CONFIG_WINDOW_CYC512_Val << WDT_CONFIG_WINDOW_Pos)  /**< (WDT_CONFIG) 512 clock cycles Position  */
+#define WDT_CONFIG_WINDOW_CYC1024           (WDT_CONFIG_WINDOW_CYC1024_Val << WDT_CONFIG_WINDOW_Pos)  /**< (WDT_CONFIG) 1024 clock cycles Position  */
+#define WDT_CONFIG_WINDOW_CYC2048           (WDT_CONFIG_WINDOW_CYC2048_Val << WDT_CONFIG_WINDOW_Pos)  /**< (WDT_CONFIG) 2048 clock cycles Position  */
+#define WDT_CONFIG_WINDOW_CYC4096           (WDT_CONFIG_WINDOW_CYC4096_Val << WDT_CONFIG_WINDOW_Pos)  /**< (WDT_CONFIG) 4096 clock cycles Position  */
+#define WDT_CONFIG_WINDOW_CYC8192           (WDT_CONFIG_WINDOW_CYC8192_Val << WDT_CONFIG_WINDOW_Pos)  /**< (WDT_CONFIG) 8192 clock cycles Position  */
+#define WDT_CONFIG_WINDOW_CYC16384          (WDT_CONFIG_WINDOW_CYC16384_Val << WDT_CONFIG_WINDOW_Pos)  /**< (WDT_CONFIG) 16384 clock cycles Position  */
+#define WDT_CONFIG_MASK                     _U_(0xFF)                                      /**< \deprecated (WDT_CONFIG) Register MASK  (Use WDT_CONFIG_Msk instead)  */
+#define WDT_CONFIG_Msk                      _U_(0xFF)                                      /**< (WDT_CONFIG) Register Mask  */
+
+
+/* -------- WDT_EWCTRL : (WDT Offset: 0x02) (R/W 8) Early Warning Interrupt Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  EWOFFSET:4;                /**< bit:   0..3  Early Warning Interrupt Time Offset      */
+    uint8_t  :4;                        /**< bit:   4..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} WDT_EWCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_EWCTRL_OFFSET                   (0x02)                                        /**<  (WDT_EWCTRL) Early Warning Interrupt Control  Offset */
+#define WDT_EWCTRL_RESETVALUE               _U_(0x0B)                                     /**<  (WDT_EWCTRL) Early Warning Interrupt Control  Reset Value */
+
+#define WDT_EWCTRL_EWOFFSET_Pos             0                                              /**< (WDT_EWCTRL) Early Warning Interrupt Time Offset Position */
+#define WDT_EWCTRL_EWOFFSET_Msk             (_U_(0xF) << WDT_EWCTRL_EWOFFSET_Pos)          /**< (WDT_EWCTRL) Early Warning Interrupt Time Offset Mask */
+#define WDT_EWCTRL_EWOFFSET(value)          (WDT_EWCTRL_EWOFFSET_Msk & ((value) << WDT_EWCTRL_EWOFFSET_Pos))
+#define   WDT_EWCTRL_EWOFFSET_CYC8_Val      _U_(0x0)                                       /**< (WDT_EWCTRL) 8 clock cycles  */
+#define   WDT_EWCTRL_EWOFFSET_CYC16_Val     _U_(0x1)                                       /**< (WDT_EWCTRL) 16 clock cycles  */
+#define   WDT_EWCTRL_EWOFFSET_CYC32_Val     _U_(0x2)                                       /**< (WDT_EWCTRL) 32 clock cycles  */
+#define   WDT_EWCTRL_EWOFFSET_CYC64_Val     _U_(0x3)                                       /**< (WDT_EWCTRL) 64 clock cycles  */
+#define   WDT_EWCTRL_EWOFFSET_CYC128_Val    _U_(0x4)                                       /**< (WDT_EWCTRL) 128 clock cycles  */
+#define   WDT_EWCTRL_EWOFFSET_CYC256_Val    _U_(0x5)                                       /**< (WDT_EWCTRL) 256 clock cycles  */
+#define   WDT_EWCTRL_EWOFFSET_CYC512_Val    _U_(0x6)                                       /**< (WDT_EWCTRL) 512 clock cycles  */
+#define   WDT_EWCTRL_EWOFFSET_CYC1024_Val   _U_(0x7)                                       /**< (WDT_EWCTRL) 1024 clock cycles  */
+#define   WDT_EWCTRL_EWOFFSET_CYC2048_Val   _U_(0x8)                                       /**< (WDT_EWCTRL) 2048 clock cycles  */
+#define   WDT_EWCTRL_EWOFFSET_CYC4096_Val   _U_(0x9)                                       /**< (WDT_EWCTRL) 4096 clock cycles  */
+#define   WDT_EWCTRL_EWOFFSET_CYC8192_Val   _U_(0xA)                                       /**< (WDT_EWCTRL) 8192 clock cycles  */
+#define   WDT_EWCTRL_EWOFFSET_CYC16384_Val  _U_(0xB)                                       /**< (WDT_EWCTRL) 16384 clock cycles  */
+#define WDT_EWCTRL_EWOFFSET_CYC8            (WDT_EWCTRL_EWOFFSET_CYC8_Val << WDT_EWCTRL_EWOFFSET_Pos)  /**< (WDT_EWCTRL) 8 clock cycles Position  */
+#define WDT_EWCTRL_EWOFFSET_CYC16           (WDT_EWCTRL_EWOFFSET_CYC16_Val << WDT_EWCTRL_EWOFFSET_Pos)  /**< (WDT_EWCTRL) 16 clock cycles Position  */
+#define WDT_EWCTRL_EWOFFSET_CYC32           (WDT_EWCTRL_EWOFFSET_CYC32_Val << WDT_EWCTRL_EWOFFSET_Pos)  /**< (WDT_EWCTRL) 32 clock cycles Position  */
+#define WDT_EWCTRL_EWOFFSET_CYC64           (WDT_EWCTRL_EWOFFSET_CYC64_Val << WDT_EWCTRL_EWOFFSET_Pos)  /**< (WDT_EWCTRL) 64 clock cycles Position  */
+#define WDT_EWCTRL_EWOFFSET_CYC128          (WDT_EWCTRL_EWOFFSET_CYC128_Val << WDT_EWCTRL_EWOFFSET_Pos)  /**< (WDT_EWCTRL) 128 clock cycles Position  */
+#define WDT_EWCTRL_EWOFFSET_CYC256          (WDT_EWCTRL_EWOFFSET_CYC256_Val << WDT_EWCTRL_EWOFFSET_Pos)  /**< (WDT_EWCTRL) 256 clock cycles Position  */
+#define WDT_EWCTRL_EWOFFSET_CYC512          (WDT_EWCTRL_EWOFFSET_CYC512_Val << WDT_EWCTRL_EWOFFSET_Pos)  /**< (WDT_EWCTRL) 512 clock cycles Position  */
+#define WDT_EWCTRL_EWOFFSET_CYC1024         (WDT_EWCTRL_EWOFFSET_CYC1024_Val << WDT_EWCTRL_EWOFFSET_Pos)  /**< (WDT_EWCTRL) 1024 clock cycles Position  */
+#define WDT_EWCTRL_EWOFFSET_CYC2048         (WDT_EWCTRL_EWOFFSET_CYC2048_Val << WDT_EWCTRL_EWOFFSET_Pos)  /**< (WDT_EWCTRL) 2048 clock cycles Position  */
+#define WDT_EWCTRL_EWOFFSET_CYC4096         (WDT_EWCTRL_EWOFFSET_CYC4096_Val << WDT_EWCTRL_EWOFFSET_Pos)  /**< (WDT_EWCTRL) 4096 clock cycles Position  */
+#define WDT_EWCTRL_EWOFFSET_CYC8192         (WDT_EWCTRL_EWOFFSET_CYC8192_Val << WDT_EWCTRL_EWOFFSET_Pos)  /**< (WDT_EWCTRL) 8192 clock cycles Position  */
+#define WDT_EWCTRL_EWOFFSET_CYC16384        (WDT_EWCTRL_EWOFFSET_CYC16384_Val << WDT_EWCTRL_EWOFFSET_Pos)  /**< (WDT_EWCTRL) 16384 clock cycles Position  */
+#define WDT_EWCTRL_MASK                     _U_(0x0F)                                      /**< \deprecated (WDT_EWCTRL) Register MASK  (Use WDT_EWCTRL_Msk instead)  */
+#define WDT_EWCTRL_Msk                      _U_(0x0F)                                      /**< (WDT_EWCTRL) Register Mask  */
+
+
+/* -------- WDT_INTENCLR : (WDT Offset: 0x04) (R/W 8) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  EW:1;                      /**< bit:      0  Early Warning Interrupt Enable           */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} WDT_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_INTENCLR_OFFSET                 (0x04)                                        /**<  (WDT_INTENCLR) Interrupt Enable Clear  Offset */
+#define WDT_INTENCLR_RESETVALUE             _U_(0x00)                                     /**<  (WDT_INTENCLR) Interrupt Enable Clear  Reset Value */
+
+#define WDT_INTENCLR_EW_Pos                 0                                              /**< (WDT_INTENCLR) Early Warning Interrupt Enable Position */
+#define WDT_INTENCLR_EW_Msk                 (_U_(0x1) << WDT_INTENCLR_EW_Pos)              /**< (WDT_INTENCLR) Early Warning Interrupt Enable Mask */
+#define WDT_INTENCLR_EW                     WDT_INTENCLR_EW_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use WDT_INTENCLR_EW_Msk instead */
+#define WDT_INTENCLR_MASK                   _U_(0x01)                                      /**< \deprecated (WDT_INTENCLR) Register MASK  (Use WDT_INTENCLR_Msk instead)  */
+#define WDT_INTENCLR_Msk                    _U_(0x01)                                      /**< (WDT_INTENCLR) Register Mask  */
+
+
+/* -------- WDT_INTENSET : (WDT Offset: 0x05) (R/W 8) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  EW:1;                      /**< bit:      0  Early Warning Interrupt Enable           */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} WDT_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_INTENSET_OFFSET                 (0x05)                                        /**<  (WDT_INTENSET) Interrupt Enable Set  Offset */
+#define WDT_INTENSET_RESETVALUE             _U_(0x00)                                     /**<  (WDT_INTENSET) Interrupt Enable Set  Reset Value */
+
+#define WDT_INTENSET_EW_Pos                 0                                              /**< (WDT_INTENSET) Early Warning Interrupt Enable Position */
+#define WDT_INTENSET_EW_Msk                 (_U_(0x1) << WDT_INTENSET_EW_Pos)              /**< (WDT_INTENSET) Early Warning Interrupt Enable Mask */
+#define WDT_INTENSET_EW                     WDT_INTENSET_EW_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use WDT_INTENSET_EW_Msk instead */
+#define WDT_INTENSET_MASK                   _U_(0x01)                                      /**< \deprecated (WDT_INTENSET) Register MASK  (Use WDT_INTENSET_Msk instead)  */
+#define WDT_INTENSET_Msk                    _U_(0x01)                                      /**< (WDT_INTENSET) Register Mask  */
+
+
+/* -------- WDT_INTFLAG : (WDT Offset: 0x06) (R/W 8) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t EW:1;                      /**< bit:      0  Early Warning                            */
+    __I uint8_t :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} WDT_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_INTFLAG_OFFSET                  (0x06)                                        /**<  (WDT_INTFLAG) Interrupt Flag Status and Clear  Offset */
+#define WDT_INTFLAG_RESETVALUE              _U_(0x00)                                     /**<  (WDT_INTFLAG) Interrupt Flag Status and Clear  Reset Value */
+
+#define WDT_INTFLAG_EW_Pos                  0                                              /**< (WDT_INTFLAG) Early Warning Position */
+#define WDT_INTFLAG_EW_Msk                  (_U_(0x1) << WDT_INTFLAG_EW_Pos)               /**< (WDT_INTFLAG) Early Warning Mask */
+#define WDT_INTFLAG_EW                      WDT_INTFLAG_EW_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use WDT_INTFLAG_EW_Msk instead */
+#define WDT_INTFLAG_MASK                    _U_(0x01)                                      /**< \deprecated (WDT_INTFLAG) Register MASK  (Use WDT_INTFLAG_Msk instead)  */
+#define WDT_INTFLAG_Msk                     _U_(0x01)                                      /**< (WDT_INTFLAG) Register Mask  */
+
+
+/* -------- WDT_SYNCBUSY : (WDT Offset: 0x08) (R/ 32) Synchronization Busy -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t ENABLE:1;                  /**< bit:      1  Enable Synchronization Busy              */
+    uint32_t WEN:1;                     /**< bit:      2  Window Enable Synchronization Busy       */
+    uint32_t RUNSTDBY:1;                /**< bit:      3  Run During Standby Synchronization Busy  */
+    uint32_t ALWAYSON:1;                /**< bit:      4  Always-On Synchronization Busy           */
+    uint32_t CLEAR:1;                   /**< bit:      5  Clear Synchronization Busy               */
+    uint32_t :26;                       /**< bit:  6..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} WDT_SYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_SYNCBUSY_OFFSET                 (0x08)                                        /**<  (WDT_SYNCBUSY) Synchronization Busy  Offset */
+#define WDT_SYNCBUSY_RESETVALUE             _U_(0x00)                                     /**<  (WDT_SYNCBUSY) Synchronization Busy  Reset Value */
+
+#define WDT_SYNCBUSY_ENABLE_Pos             1                                              /**< (WDT_SYNCBUSY) Enable Synchronization Busy Position */
+#define WDT_SYNCBUSY_ENABLE_Msk             (_U_(0x1) << WDT_SYNCBUSY_ENABLE_Pos)          /**< (WDT_SYNCBUSY) Enable Synchronization Busy Mask */
+#define WDT_SYNCBUSY_ENABLE                 WDT_SYNCBUSY_ENABLE_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use WDT_SYNCBUSY_ENABLE_Msk instead */
+#define WDT_SYNCBUSY_WEN_Pos                2                                              /**< (WDT_SYNCBUSY) Window Enable Synchronization Busy Position */
+#define WDT_SYNCBUSY_WEN_Msk                (_U_(0x1) << WDT_SYNCBUSY_WEN_Pos)             /**< (WDT_SYNCBUSY) Window Enable Synchronization Busy Mask */
+#define WDT_SYNCBUSY_WEN                    WDT_SYNCBUSY_WEN_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use WDT_SYNCBUSY_WEN_Msk instead */
+#define WDT_SYNCBUSY_RUNSTDBY_Pos           3                                              /**< (WDT_SYNCBUSY) Run During Standby Synchronization Busy Position */
+#define WDT_SYNCBUSY_RUNSTDBY_Msk           (_U_(0x1) << WDT_SYNCBUSY_RUNSTDBY_Pos)        /**< (WDT_SYNCBUSY) Run During Standby Synchronization Busy Mask */
+#define WDT_SYNCBUSY_RUNSTDBY               WDT_SYNCBUSY_RUNSTDBY_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use WDT_SYNCBUSY_RUNSTDBY_Msk instead */
+#define WDT_SYNCBUSY_ALWAYSON_Pos           4                                              /**< (WDT_SYNCBUSY) Always-On Synchronization Busy Position */
+#define WDT_SYNCBUSY_ALWAYSON_Msk           (_U_(0x1) << WDT_SYNCBUSY_ALWAYSON_Pos)        /**< (WDT_SYNCBUSY) Always-On Synchronization Busy Mask */
+#define WDT_SYNCBUSY_ALWAYSON               WDT_SYNCBUSY_ALWAYSON_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use WDT_SYNCBUSY_ALWAYSON_Msk instead */
+#define WDT_SYNCBUSY_CLEAR_Pos              5                                              /**< (WDT_SYNCBUSY) Clear Synchronization Busy Position */
+#define WDT_SYNCBUSY_CLEAR_Msk              (_U_(0x1) << WDT_SYNCBUSY_CLEAR_Pos)           /**< (WDT_SYNCBUSY) Clear Synchronization Busy Mask */
+#define WDT_SYNCBUSY_CLEAR                  WDT_SYNCBUSY_CLEAR_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use WDT_SYNCBUSY_CLEAR_Msk instead */
+#define WDT_SYNCBUSY_MASK                   _U_(0x3E)                                      /**< \deprecated (WDT_SYNCBUSY) Register MASK  (Use WDT_SYNCBUSY_Msk instead)  */
+#define WDT_SYNCBUSY_Msk                    _U_(0x3E)                                      /**< (WDT_SYNCBUSY) Register Mask  */
+
+
+/* -------- WDT_CLEAR : (WDT Offset: 0x0c) (/W 8) Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  CLEAR:8;                   /**< bit:   0..7  Watchdog Clear                           */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} WDT_CLEAR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_CLEAR_OFFSET                    (0x0C)                                        /**<  (WDT_CLEAR) Clear  Offset */
+#define WDT_CLEAR_RESETVALUE                _U_(0x00)                                     /**<  (WDT_CLEAR) Clear  Reset Value */
+
+#define WDT_CLEAR_CLEAR_Pos                 0                                              /**< (WDT_CLEAR) Watchdog Clear Position */
+#define WDT_CLEAR_CLEAR_Msk                 (_U_(0xFF) << WDT_CLEAR_CLEAR_Pos)             /**< (WDT_CLEAR) Watchdog Clear Mask */
+#define WDT_CLEAR_CLEAR(value)              (WDT_CLEAR_CLEAR_Msk & ((value) << WDT_CLEAR_CLEAR_Pos))
+#define   WDT_CLEAR_CLEAR_KEY_Val           _U_(0xA5)                                      /**< (WDT_CLEAR) Clear Key  */
+#define WDT_CLEAR_CLEAR_KEY                 (WDT_CLEAR_CLEAR_KEY_Val << WDT_CLEAR_CLEAR_Pos)  /**< (WDT_CLEAR) Clear Key Position  */
+#define WDT_CLEAR_MASK                      _U_(0xFF)                                      /**< \deprecated (WDT_CLEAR) Register MASK  (Use WDT_CLEAR_Msk instead)  */
+#define WDT_CLEAR_Msk                       _U_(0xFF)                                      /**< (WDT_CLEAR) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief WDT hardware registers */
+typedef struct {  /* Watchdog Timer */
+  __IO WDT_CTRLA_Type                 CTRLA;          /**< Offset: 0x00 (R/W   8) Control */
+  __IO WDT_CONFIG_Type                CONFIG;         /**< Offset: 0x01 (R/W   8) Configuration */
+  __IO WDT_EWCTRL_Type                EWCTRL;         /**< Offset: 0x02 (R/W   8) Early Warning Interrupt Control */
+  __I  uint8_t                        Reserved1[1];
+  __IO WDT_INTENCLR_Type              INTENCLR;       /**< Offset: 0x04 (R/W   8) Interrupt Enable Clear */
+  __IO WDT_INTENSET_Type              INTENSET;       /**< Offset: 0x05 (R/W   8) Interrupt Enable Set */
+  __IO WDT_INTFLAG_Type               INTFLAG;        /**< Offset: 0x06 (R/W   8) Interrupt Flag Status and Clear */
+  __I  uint8_t                        Reserved2[1];
+  __I  WDT_SYNCBUSY_Type              SYNCBUSY;       /**< Offset: 0x08 (R/   32) Synchronization Busy */
+  __O  WDT_CLEAR_Type                 CLEAR;          /**< Offset: 0x0C ( /W   8) Clear */
+} Wdt;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Watchdog Timer */
+
+#endif /* _SAML10_WDT_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/instance/ac.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/instance/ac.h
@@ -1,0 +1,83 @@
+/**
+ * \file
+ *
+ * \brief Instance description for AC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_AC_INSTANCE_H_
+#define _SAML10_AC_INSTANCE_H_
+
+/* ========== Register definition for AC peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_AC_CTRLA            (0x40003400) /**< (AC) Control A */
+#define REG_AC_CTRLB            (0x40003401) /**< (AC) Control B */
+#define REG_AC_EVCTRL           (0x40003402) /**< (AC) Event Control */
+#define REG_AC_INTENCLR         (0x40003404) /**< (AC) Interrupt Enable Clear */
+#define REG_AC_INTENSET         (0x40003405) /**< (AC) Interrupt Enable Set */
+#define REG_AC_INTFLAG          (0x40003406) /**< (AC) Interrupt Flag Status and Clear */
+#define REG_AC_STATUSA          (0x40003407) /**< (AC) Status A */
+#define REG_AC_STATUSB          (0x40003408) /**< (AC) Status B */
+#define REG_AC_DBGCTRL          (0x40003409) /**< (AC) Debug Control */
+#define REG_AC_WINCTRL          (0x4000340A) /**< (AC) Window Control */
+#define REG_AC_SCALER           (0x4000340C) /**< (AC) Scaler n */
+#define REG_AC_SCALER0          (0x4000340C) /**< (AC) Scaler 0 */
+#define REG_AC_SCALER1          (0x4000340D) /**< (AC) Scaler 1 */
+#define REG_AC_COMPCTRL         (0x40003410) /**< (AC) Comparator Control n */
+#define REG_AC_COMPCTRL0        (0x40003410) /**< (AC) Comparator Control 0 */
+#define REG_AC_COMPCTRL1        (0x40003414) /**< (AC) Comparator Control 1 */
+#define REG_AC_SYNCBUSY         (0x40003420) /**< (AC) Synchronization Busy */
+
+#else
+
+#define REG_AC_CTRLA            (*(__IO uint8_t*)0x40003400U) /**< (AC) Control A */
+#define REG_AC_CTRLB            (*(__O  uint8_t*)0x40003401U) /**< (AC) Control B */
+#define REG_AC_EVCTRL           (*(__IO uint16_t*)0x40003402U) /**< (AC) Event Control */
+#define REG_AC_INTENCLR         (*(__IO uint8_t*)0x40003404U) /**< (AC) Interrupt Enable Clear */
+#define REG_AC_INTENSET         (*(__IO uint8_t*)0x40003405U) /**< (AC) Interrupt Enable Set */
+#define REG_AC_INTFLAG          (*(__IO uint8_t*)0x40003406U) /**< (AC) Interrupt Flag Status and Clear */
+#define REG_AC_STATUSA          (*(__I  uint8_t*)0x40003407U) /**< (AC) Status A */
+#define REG_AC_STATUSB          (*(__I  uint8_t*)0x40003408U) /**< (AC) Status B */
+#define REG_AC_DBGCTRL          (*(__IO uint8_t*)0x40003409U) /**< (AC) Debug Control */
+#define REG_AC_WINCTRL          (*(__IO uint8_t*)0x4000340AU) /**< (AC) Window Control */
+#define REG_AC_SCALER           (*(__IO uint8_t*)0x4000340CU) /**< (AC) Scaler n */
+#define REG_AC_SCALER0          (*(__IO uint8_t*)0x4000340CU) /**< (AC) Scaler 0 */
+#define REG_AC_SCALER1          (*(__IO uint8_t*)0x4000340DU) /**< (AC) Scaler 1 */
+#define REG_AC_COMPCTRL         (*(__IO uint32_t*)0x40003410U) /**< (AC) Comparator Control n */
+#define REG_AC_COMPCTRL0        (*(__IO uint32_t*)0x40003410U) /**< (AC) Comparator Control 0 */
+#define REG_AC_COMPCTRL1        (*(__IO uint32_t*)0x40003414U) /**< (AC) Comparator Control 1 */
+#define REG_AC_SYNCBUSY         (*(__I  uint32_t*)0x40003420U) /**< (AC) Synchronization Busy */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for AC peripheral ========== */
+#define AC_GCLK_ID                               17         /* Index of Generic Clock */
+#define AC_NUM_CMP                               2          /* Number of comparators */
+#define AC_PAIRS                                 1          /* Number of pairs of comparators */
+#define AC_INSTANCE_ID                           13         
+
+#endif /* _SAML10_AC_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/instance/adc.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/instance/adc.h
@@ -1,0 +1,95 @@
+/**
+ * \file
+ *
+ * \brief Instance description for ADC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_ADC_INSTANCE_H_
+#define _SAML10_ADC_INSTANCE_H_
+
+/* ========== Register definition for ADC peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_ADC_CTRLA           (0x42001C00) /**< (ADC) Control A */
+#define REG_ADC_CTRLB           (0x42001C01) /**< (ADC) Control B */
+#define REG_ADC_REFCTRL         (0x42001C02) /**< (ADC) Reference Control */
+#define REG_ADC_EVCTRL          (0x42001C03) /**< (ADC) Event Control */
+#define REG_ADC_INTENCLR        (0x42001C04) /**< (ADC) Interrupt Enable Clear */
+#define REG_ADC_INTENSET        (0x42001C05) /**< (ADC) Interrupt Enable Set */
+#define REG_ADC_INTFLAG         (0x42001C06) /**< (ADC) Interrupt Flag Status and Clear */
+#define REG_ADC_SEQSTATUS       (0x42001C07) /**< (ADC) Sequence Status */
+#define REG_ADC_INPUTCTRL       (0x42001C08) /**< (ADC) Input Control */
+#define REG_ADC_CTRLC           (0x42001C0A) /**< (ADC) Control C */
+#define REG_ADC_AVGCTRL         (0x42001C0C) /**< (ADC) Average Control */
+#define REG_ADC_SAMPCTRL        (0x42001C0D) /**< (ADC) Sample Time Control */
+#define REG_ADC_WINLT           (0x42001C0E) /**< (ADC) Window Monitor Lower Threshold */
+#define REG_ADC_WINUT           (0x42001C10) /**< (ADC) Window Monitor Upper Threshold */
+#define REG_ADC_GAINCORR        (0x42001C12) /**< (ADC) Gain Correction */
+#define REG_ADC_OFFSETCORR      (0x42001C14) /**< (ADC) Offset Correction */
+#define REG_ADC_SWTRIG          (0x42001C18) /**< (ADC) Software Trigger */
+#define REG_ADC_DBGCTRL         (0x42001C1C) /**< (ADC) Debug Control */
+#define REG_ADC_SYNCBUSY        (0x42001C20) /**< (ADC) Synchronization Busy */
+#define REG_ADC_RESULT          (0x42001C24) /**< (ADC) Result */
+#define REG_ADC_SEQCTRL         (0x42001C28) /**< (ADC) Sequence Control */
+#define REG_ADC_CALIB           (0x42001C2C) /**< (ADC) Calibration */
+
+#else
+
+#define REG_ADC_CTRLA           (*(__IO uint8_t*)0x42001C00U) /**< (ADC) Control A */
+#define REG_ADC_CTRLB           (*(__IO uint8_t*)0x42001C01U) /**< (ADC) Control B */
+#define REG_ADC_REFCTRL         (*(__IO uint8_t*)0x42001C02U) /**< (ADC) Reference Control */
+#define REG_ADC_EVCTRL          (*(__IO uint8_t*)0x42001C03U) /**< (ADC) Event Control */
+#define REG_ADC_INTENCLR        (*(__IO uint8_t*)0x42001C04U) /**< (ADC) Interrupt Enable Clear */
+#define REG_ADC_INTENSET        (*(__IO uint8_t*)0x42001C05U) /**< (ADC) Interrupt Enable Set */
+#define REG_ADC_INTFLAG         (*(__IO uint8_t*)0x42001C06U) /**< (ADC) Interrupt Flag Status and Clear */
+#define REG_ADC_SEQSTATUS       (*(__I  uint8_t*)0x42001C07U) /**< (ADC) Sequence Status */
+#define REG_ADC_INPUTCTRL       (*(__IO uint16_t*)0x42001C08U) /**< (ADC) Input Control */
+#define REG_ADC_CTRLC           (*(__IO uint16_t*)0x42001C0AU) /**< (ADC) Control C */
+#define REG_ADC_AVGCTRL         (*(__IO uint8_t*)0x42001C0CU) /**< (ADC) Average Control */
+#define REG_ADC_SAMPCTRL        (*(__IO uint8_t*)0x42001C0DU) /**< (ADC) Sample Time Control */
+#define REG_ADC_WINLT           (*(__IO uint16_t*)0x42001C0EU) /**< (ADC) Window Monitor Lower Threshold */
+#define REG_ADC_WINUT           (*(__IO uint16_t*)0x42001C10U) /**< (ADC) Window Monitor Upper Threshold */
+#define REG_ADC_GAINCORR        (*(__IO uint16_t*)0x42001C12U) /**< (ADC) Gain Correction */
+#define REG_ADC_OFFSETCORR      (*(__IO uint16_t*)0x42001C14U) /**< (ADC) Offset Correction */
+#define REG_ADC_SWTRIG          (*(__IO uint8_t*)0x42001C18U) /**< (ADC) Software Trigger */
+#define REG_ADC_DBGCTRL         (*(__IO uint8_t*)0x42001C1CU) /**< (ADC) Debug Control */
+#define REG_ADC_SYNCBUSY        (*(__I  uint16_t*)0x42001C20U) /**< (ADC) Synchronization Busy */
+#define REG_ADC_RESULT          (*(__I  uint16_t*)0x42001C24U) /**< (ADC) Result */
+#define REG_ADC_SEQCTRL         (*(__IO uint32_t*)0x42001C28U) /**< (ADC) Sequence Control */
+#define REG_ADC_CALIB           (*(__IO uint16_t*)0x42001C2CU) /**< (ADC) Calibration */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for ADC peripheral ========== */
+#define ADC_DMAC_ID_RESRDY                       19         /* index of DMA RESRDY trigger */
+#define ADC_EXTCHANNEL_MSB                       9          /* Number of external channels */
+#define ADC_GCLK_ID                              16         /* index of Generic Clock */
+#define ADC_INT_CH30                             1          /* Select OPAMP or CTAT on Channel 30 */
+#define ADC_MASTER_SLAVE_MODE                    0          /* ADC Master/Slave Mode */
+#define ADC_INSTANCE_ID                          71         
+
+#endif /* _SAML10_ADC_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/instance/ccl.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/instance/ccl.h
@@ -1,0 +1,61 @@
+/**
+ * \file
+ *
+ * \brief Instance description for CCL
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_CCL_INSTANCE_H_
+#define _SAML10_CCL_INSTANCE_H_
+
+/* ========== Register definition for CCL peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_CCL_CTRL            (0x42002C00) /**< (CCL) Control */
+#define REG_CCL_SEQCTRL         (0x42002C04) /**< (CCL) SEQ Control x */
+#define REG_CCL_SEQCTRL0        (0x42002C04) /**< (CCL) SEQ Control x 0 */
+#define REG_CCL_LUTCTRL         (0x42002C08) /**< (CCL) LUT Control x */
+#define REG_CCL_LUTCTRL0        (0x42002C08) /**< (CCL) LUT Control x 0 */
+#define REG_CCL_LUTCTRL1        (0x42002C0C) /**< (CCL) LUT Control x 1 */
+
+#else
+
+#define REG_CCL_CTRL            (*(__IO uint8_t*)0x42002C00U) /**< (CCL) Control */
+#define REG_CCL_SEQCTRL         (*(__IO uint8_t*)0x42002C04U) /**< (CCL) SEQ Control x */
+#define REG_CCL_SEQCTRL0        (*(__IO uint8_t*)0x42002C04U) /**< (CCL) SEQ Control x 0 */
+#define REG_CCL_LUTCTRL         (*(__IO uint32_t*)0x42002C08U) /**< (CCL) LUT Control x */
+#define REG_CCL_LUTCTRL0        (*(__IO uint32_t*)0x42002C08U) /**< (CCL) LUT Control x 0 */
+#define REG_CCL_LUTCTRL1        (*(__IO uint32_t*)0x42002C0CU) /**< (CCL) LUT Control x 1 */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for CCL peripheral ========== */
+#define CCL_GCLK_ID                              20         /* GCLK index for CCL */
+#define CCL_LUT_NUM                              2          /* Number of LUT in a CCL */
+#define CCL_SEQ_NUM                              1          /* Number of SEQ in a CCL */
+#define CCL_INSTANCE_ID                          75         
+
+#endif /* _SAML10_CCL_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/instance/dac.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/instance/dac.h
@@ -1,0 +1,70 @@
+/**
+ * \file
+ *
+ * \brief Instance description for DAC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_DAC_INSTANCE_H_
+#define _SAML10_DAC_INSTANCE_H_
+
+/* ========== Register definition for DAC peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_DAC_CTRLA           (0x42002000) /**< (DAC) Control A */
+#define REG_DAC_CTRLB           (0x42002001) /**< (DAC) Control B */
+#define REG_DAC_EVCTRL          (0x42002002) /**< (DAC) Event Control */
+#define REG_DAC_INTENCLR        (0x42002004) /**< (DAC) Interrupt Enable Clear */
+#define REG_DAC_INTENSET        (0x42002005) /**< (DAC) Interrupt Enable Set */
+#define REG_DAC_INTFLAG         (0x42002006) /**< (DAC) Interrupt Flag Status and Clear */
+#define REG_DAC_STATUS          (0x42002007) /**< (DAC) Status */
+#define REG_DAC_DATA            (0x42002008) /**< (DAC) Data */
+#define REG_DAC_DATABUF         (0x4200200C) /**< (DAC) Data Buffer */
+#define REG_DAC_SYNCBUSY        (0x42002010) /**< (DAC) Synchronization Busy */
+#define REG_DAC_DBGCTRL         (0x42002014) /**< (DAC) Debug Control */
+
+#else
+
+#define REG_DAC_CTRLA           (*(__IO uint8_t*)0x42002000U) /**< (DAC) Control A */
+#define REG_DAC_CTRLB           (*(__IO uint8_t*)0x42002001U) /**< (DAC) Control B */
+#define REG_DAC_EVCTRL          (*(__IO uint8_t*)0x42002002U) /**< (DAC) Event Control */
+#define REG_DAC_INTENCLR        (*(__IO uint8_t*)0x42002004U) /**< (DAC) Interrupt Enable Clear */
+#define REG_DAC_INTENSET        (*(__IO uint8_t*)0x42002005U) /**< (DAC) Interrupt Enable Set */
+#define REG_DAC_INTFLAG         (*(__IO uint8_t*)0x42002006U) /**< (DAC) Interrupt Flag Status and Clear */
+#define REG_DAC_STATUS          (*(__I  uint8_t*)0x42002007U) /**< (DAC) Status */
+#define REG_DAC_DATA            (*(__O  uint16_t*)0x42002008U) /**< (DAC) Data */
+#define REG_DAC_DATABUF         (*(__O  uint16_t*)0x4200200CU) /**< (DAC) Data Buffer */
+#define REG_DAC_SYNCBUSY        (*(__I  uint32_t*)0x42002010U) /**< (DAC) Synchronization Busy */
+#define REG_DAC_DBGCTRL         (*(__IO uint8_t*)0x42002014U) /**< (DAC) Debug Control */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for DAC peripheral ========== */
+#define DAC_DMAC_ID_EMPTY                        20         /* Index of DMA EMPTY trigger */
+#define DAC_GCLK_ID                              18         
+#define DAC_INSTANCE_ID                          72         
+
+#endif /* _SAML10_DAC_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/instance/dmac.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/instance/dmac.h
@@ -1,0 +1,103 @@
+/**
+ * \file
+ *
+ * \brief Instance description for DMAC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_DMAC_INSTANCE_H_
+#define _SAML10_DMAC_INSTANCE_H_
+
+/* ========== Register definition for DMAC peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_DMAC_CTRL           (0x41006000) /**< (DMAC) Control */
+#define REG_DMAC_CRCCTRL        (0x41006002) /**< (DMAC) CRC Control */
+#define REG_DMAC_CRCDATAIN      (0x41006004) /**< (DMAC) CRC Data Input */
+#define REG_DMAC_CRCCHKSUM      (0x41006008) /**< (DMAC) CRC Checksum */
+#define REG_DMAC_CRCSTATUS      (0x4100600C) /**< (DMAC) CRC Status */
+#define REG_DMAC_DBGCTRL        (0x4100600D) /**< (DMAC) Debug Control */
+#define REG_DMAC_QOSCTRL        (0x4100600E) /**< (DMAC) QOS Control */
+#define REG_DMAC_SWTRIGCTRL     (0x41006010) /**< (DMAC) Software Trigger Control */
+#define REG_DMAC_PRICTRL0       (0x41006014) /**< (DMAC) Priority Control 0 */
+#define REG_DMAC_INTPEND        (0x41006020) /**< (DMAC) Interrupt Pending */
+#define REG_DMAC_INTSTATUS      (0x41006024) /**< (DMAC) Interrupt Status */
+#define REG_DMAC_BUSYCH         (0x41006028) /**< (DMAC) Busy Channels */
+#define REG_DMAC_PENDCH         (0x4100602C) /**< (DMAC) Pending Channels */
+#define REG_DMAC_ACTIVE         (0x41006030) /**< (DMAC) Active Channel and Levels */
+#define REG_DMAC_BASEADDR       (0x41006034) /**< (DMAC) Descriptor Memory Section Base Address */
+#define REG_DMAC_WRBADDR        (0x41006038) /**< (DMAC) Write-Back Memory Section Base Address */
+#define REG_DMAC_CHID           (0x4100603F) /**< (DMAC) Channel ID */
+#define REG_DMAC_CHCTRLA        (0x41006040) /**< (DMAC) Channel Control A */
+#define REG_DMAC_CHCTRLB        (0x41006044) /**< (DMAC) Channel Control B */
+#define REG_DMAC_CHINTENCLR     (0x4100604C) /**< (DMAC) Channel Interrupt Enable Clear */
+#define REG_DMAC_CHINTENSET     (0x4100604D) /**< (DMAC) Channel Interrupt Enable Set */
+#define REG_DMAC_CHINTFLAG      (0x4100604E) /**< (DMAC) Channel Interrupt Flag Status and Clear */
+#define REG_DMAC_CHSTATUS       (0x4100604F) /**< (DMAC) Channel Status */
+
+#else
+
+#define REG_DMAC_CTRL           (*(__IO uint16_t*)0x41006000U) /**< (DMAC) Control */
+#define REG_DMAC_CRCCTRL        (*(__IO uint16_t*)0x41006002U) /**< (DMAC) CRC Control */
+#define REG_DMAC_CRCDATAIN      (*(__IO uint32_t*)0x41006004U) /**< (DMAC) CRC Data Input */
+#define REG_DMAC_CRCCHKSUM      (*(__IO uint32_t*)0x41006008U) /**< (DMAC) CRC Checksum */
+#define REG_DMAC_CRCSTATUS      (*(__IO uint8_t*)0x4100600CU) /**< (DMAC) CRC Status */
+#define REG_DMAC_DBGCTRL        (*(__IO uint8_t*)0x4100600DU) /**< (DMAC) Debug Control */
+#define REG_DMAC_QOSCTRL        (*(__IO uint8_t*)0x4100600EU) /**< (DMAC) QOS Control */
+#define REG_DMAC_SWTRIGCTRL     (*(__IO uint32_t*)0x41006010U) /**< (DMAC) Software Trigger Control */
+#define REG_DMAC_PRICTRL0       (*(__IO uint32_t*)0x41006014U) /**< (DMAC) Priority Control 0 */
+#define REG_DMAC_INTPEND        (*(__IO uint16_t*)0x41006020U) /**< (DMAC) Interrupt Pending */
+#define REG_DMAC_INTSTATUS      (*(__I  uint32_t*)0x41006024U) /**< (DMAC) Interrupt Status */
+#define REG_DMAC_BUSYCH         (*(__I  uint32_t*)0x41006028U) /**< (DMAC) Busy Channels */
+#define REG_DMAC_PENDCH         (*(__I  uint32_t*)0x4100602CU) /**< (DMAC) Pending Channels */
+#define REG_DMAC_ACTIVE         (*(__I  uint32_t*)0x41006030U) /**< (DMAC) Active Channel and Levels */
+#define REG_DMAC_BASEADDR       (*(__IO uint32_t*)0x41006034U) /**< (DMAC) Descriptor Memory Section Base Address */
+#define REG_DMAC_WRBADDR        (*(__IO uint32_t*)0x41006038U) /**< (DMAC) Write-Back Memory Section Base Address */
+#define REG_DMAC_CHID           (*(__IO uint8_t*)0x4100603FU) /**< (DMAC) Channel ID */
+#define REG_DMAC_CHCTRLA        (*(__IO uint8_t*)0x41006040U) /**< (DMAC) Channel Control A */
+#define REG_DMAC_CHCTRLB        (*(__IO uint32_t*)0x41006044U) /**< (DMAC) Channel Control B */
+#define REG_DMAC_CHINTENCLR     (*(__IO uint8_t*)0x4100604CU) /**< (DMAC) Channel Interrupt Enable Clear */
+#define REG_DMAC_CHINTENSET     (*(__IO uint8_t*)0x4100604DU) /**< (DMAC) Channel Interrupt Enable Set */
+#define REG_DMAC_CHINTFLAG      (*(__IO uint8_t*)0x4100604EU) /**< (DMAC) Channel Interrupt Flag Status and Clear */
+#define REG_DMAC_CHSTATUS       (*(__I  uint8_t*)0x4100604FU) /**< (DMAC) Channel Status */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for DMAC peripheral ========== */
+#define DMAC_CH_BITS                             3          /* Number of bits to select channel */
+#define DMAC_CH_NUM                              8          /* Number of channels */
+#define DMAC_EVIN_NUM                            4          /* Number of input events */
+#define DMAC_EVOUT_NUM                           4          /* Number of output events */
+#define DMAC_LVL_BITS                            2          /* Number of bit to select level priority */
+#define DMAC_LVL_NUM                             4          /* Enable priority level number */
+#define DMAC_QOSCTRL_D_RESETVALUE                2          /* QOS dmac ahb interface reset value */
+#define DMAC_QOSCTRL_F_RESETVALUE                2          /* QOS dmac fetch interface reset value */
+#define DMAC_QOSCTRL_WRB_RESETVALUE              2          /* QOS dmac write back interface reset value */
+#define DMAC_TRIG_BITS                           5          /* Number of bits to select trigger source */
+#define DMAC_TRIG_NUM                            24         /* Number of peripheral triggers */
+#define DMAC_INSTANCE_ID                         35         
+
+#endif /* _SAML10_DMAC_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/instance/dsu.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/instance/dsu.h
@@ -1,0 +1,116 @@
+/**
+ * \file
+ *
+ * \brief Instance description for DSU
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_DSU_INSTANCE_H_
+#define _SAML10_DSU_INSTANCE_H_
+
+/* ========== Register definition for DSU peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_DSU_CTRL            (0x41002000) /**< (DSU) Control */
+#define REG_DSU_STATUSA         (0x41002001) /**< (DSU) Status A */
+#define REG_DSU_STATUSB         (0x41002002) /**< (DSU) Status B */
+#define REG_DSU_STATUSC         (0x41002003) /**< (DSU) Status C */
+#define REG_DSU_ADDR            (0x41002004) /**< (DSU) Address */
+#define REG_DSU_LENGTH          (0x41002008) /**< (DSU) Length */
+#define REG_DSU_DATA            (0x4100200C) /**< (DSU) Data */
+#define REG_DSU_DCC             (0x41002010) /**< (DSU) Debug Communication Channel n */
+#define REG_DSU_DCC0            (0x41002010) /**< (DSU) Debug Communication Channel 0 */
+#define REG_DSU_DCC1            (0x41002014) /**< (DSU) Debug Communication Channel 1 */
+#define REG_DSU_DID             (0x41002018) /**< (DSU) Device Identification */
+#define REG_DSU_CFG             (0x4100201C) /**< (DSU) Configuration */
+#define REG_DSU_BCC             (0x41002020) /**< (DSU) Boot ROM Communication Channel n */
+#define REG_DSU_BCC0            (0x41002020) /**< (DSU) Boot ROM Communication Channel 0 */
+#define REG_DSU_BCC1            (0x41002024) /**< (DSU) Boot ROM Communication Channel 1 */
+#define REG_DSU_DCFG            (0x410020F0) /**< (DSU) Device Configuration */
+#define REG_DSU_DCFG0           (0x410020F0) /**< (DSU) Device Configuration 0 */
+#define REG_DSU_DCFG1           (0x410020F4) /**< (DSU) Device Configuration 1 */
+#define REG_DSU_ENTRY0          (0x41003000) /**< (DSU) CoreSight ROM Table Entry 0 */
+#define REG_DSU_ENTRY1          (0x41003004) /**< (DSU) CoreSight ROM Table Entry 1 */
+#define REG_DSU_END             (0x41003008) /**< (DSU) CoreSight ROM Table End */
+#define REG_DSU_MEMTYPE         (0x41003FCC) /**< (DSU) CoreSight ROM Table Memory Type */
+#define REG_DSU_PID4            (0x41003FD0) /**< (DSU) Peripheral Identification 4 */
+#define REG_DSU_PID5            (0x41003FD4) /**< (DSU) Peripheral Identification 5 */
+#define REG_DSU_PID6            (0x41003FD8) /**< (DSU) Peripheral Identification 6 */
+#define REG_DSU_PID7            (0x41003FDC) /**< (DSU) Peripheral Identification 7 */
+#define REG_DSU_PID0            (0x41003FE0) /**< (DSU) Peripheral Identification 0 */
+#define REG_DSU_PID1            (0x41003FE4) /**< (DSU) Peripheral Identification 1 */
+#define REG_DSU_PID2            (0x41003FE8) /**< (DSU) Peripheral Identification 2 */
+#define REG_DSU_PID3            (0x41003FEC) /**< (DSU) Peripheral Identification 3 */
+#define REG_DSU_CID0            (0x41003FF0) /**< (DSU) Component Identification 0 */
+#define REG_DSU_CID1            (0x41003FF4) /**< (DSU) Component Identification 1 */
+#define REG_DSU_CID2            (0x41003FF8) /**< (DSU) Component Identification 2 */
+#define REG_DSU_CID3            (0x41003FFC) /**< (DSU) Component Identification 3 */
+
+#else
+
+#define REG_DSU_CTRL            (*(__O  uint8_t*)0x41002000U) /**< (DSU) Control */
+#define REG_DSU_STATUSA         (*(__IO uint8_t*)0x41002001U) /**< (DSU) Status A */
+#define REG_DSU_STATUSB         (*(__I  uint8_t*)0x41002002U) /**< (DSU) Status B */
+#define REG_DSU_STATUSC         (*(__I  uint8_t*)0x41002003U) /**< (DSU) Status C */
+#define REG_DSU_ADDR            (*(__IO uint32_t*)0x41002004U) /**< (DSU) Address */
+#define REG_DSU_LENGTH          (*(__IO uint32_t*)0x41002008U) /**< (DSU) Length */
+#define REG_DSU_DATA            (*(__IO uint32_t*)0x4100200CU) /**< (DSU) Data */
+#define REG_DSU_DCC             (*(__IO uint32_t*)0x41002010U) /**< (DSU) Debug Communication Channel n */
+#define REG_DSU_DCC0            (*(__IO uint32_t*)0x41002010U) /**< (DSU) Debug Communication Channel 0 */
+#define REG_DSU_DCC1            (*(__IO uint32_t*)0x41002014U) /**< (DSU) Debug Communication Channel 1 */
+#define REG_DSU_DID             (*(__I  uint32_t*)0x41002018U) /**< (DSU) Device Identification */
+#define REG_DSU_CFG             (*(__IO uint32_t*)0x4100201CU) /**< (DSU) Configuration */
+#define REG_DSU_BCC             (*(__IO uint32_t*)0x41002020U) /**< (DSU) Boot ROM Communication Channel n */
+#define REG_DSU_BCC0            (*(__IO uint32_t*)0x41002020U) /**< (DSU) Boot ROM Communication Channel 0 */
+#define REG_DSU_BCC1            (*(__IO uint32_t*)0x41002024U) /**< (DSU) Boot ROM Communication Channel 1 */
+#define REG_DSU_DCFG            (*(__IO uint32_t*)0x410020F0U) /**< (DSU) Device Configuration */
+#define REG_DSU_DCFG0           (*(__IO uint32_t*)0x410020F0U) /**< (DSU) Device Configuration 0 */
+#define REG_DSU_DCFG1           (*(__IO uint32_t*)0x410020F4U) /**< (DSU) Device Configuration 1 */
+#define REG_DSU_ENTRY0          (*(__I  uint32_t*)0x41003000U) /**< (DSU) CoreSight ROM Table Entry 0 */
+#define REG_DSU_ENTRY1          (*(__I  uint32_t*)0x41003004U) /**< (DSU) CoreSight ROM Table Entry 1 */
+#define REG_DSU_END             (*(__I  uint32_t*)0x41003008U) /**< (DSU) CoreSight ROM Table End */
+#define REG_DSU_MEMTYPE         (*(__I  uint32_t*)0x41003FCCU) /**< (DSU) CoreSight ROM Table Memory Type */
+#define REG_DSU_PID4            (*(__I  uint32_t*)0x41003FD0U) /**< (DSU) Peripheral Identification 4 */
+#define REG_DSU_PID5            (*(__I  uint32_t*)0x41003FD4U) /**< (DSU) Peripheral Identification 5 */
+#define REG_DSU_PID6            (*(__I  uint32_t*)0x41003FD8U) /**< (DSU) Peripheral Identification 6 */
+#define REG_DSU_PID7            (*(__I  uint32_t*)0x41003FDCU) /**< (DSU) Peripheral Identification 7 */
+#define REG_DSU_PID0            (*(__I  uint32_t*)0x41003FE0U) /**< (DSU) Peripheral Identification 0 */
+#define REG_DSU_PID1            (*(__I  uint32_t*)0x41003FE4U) /**< (DSU) Peripheral Identification 1 */
+#define REG_DSU_PID2            (*(__I  uint32_t*)0x41003FE8U) /**< (DSU) Peripheral Identification 2 */
+#define REG_DSU_PID3            (*(__I  uint32_t*)0x41003FECU) /**< (DSU) Peripheral Identification 3 */
+#define REG_DSU_CID0            (*(__I  uint32_t*)0x41003FF0U) /**< (DSU) Component Identification 0 */
+#define REG_DSU_CID1            (*(__I  uint32_t*)0x41003FF4U) /**< (DSU) Component Identification 1 */
+#define REG_DSU_CID2            (*(__I  uint32_t*)0x41003FF8U) /**< (DSU) Component Identification 2 */
+#define REG_DSU_CID3            (*(__I  uint32_t*)0x41003FFCU) /**< (DSU) Component Identification 3 */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for DSU peripheral ========== */
+#define DSU_DMAC_ID_DCC0                         2          /* DMAC ID for DCC0 register */
+#define DSU_DMAC_ID_DCC1                         3          /* DMAC ID for DCC1 register */
+#define DSU_INSTANCE_ID                          33         
+
+#endif /* _SAML10_DSU_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/instance/eic.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/instance/eic.h
@@ -1,0 +1,84 @@
+/**
+ * \file
+ *
+ * \brief Instance description for EIC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_EIC_INSTANCE_H_
+#define _SAML10_EIC_INSTANCE_H_
+
+/* ========== Register definition for EIC peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_EIC_CTRLA           (0x40002800) /**< (EIC) Control A */
+#define REG_EIC_NMICTRL         (0x40002801) /**< (EIC) Non-Maskable Interrupt Control */
+#define REG_EIC_NMIFLAG         (0x40002802) /**< (EIC) Non-Maskable Interrupt Flag Status and Clear */
+#define REG_EIC_SYNCBUSY        (0x40002804) /**< (EIC) Synchronization Busy */
+#define REG_EIC_EVCTRL          (0x40002808) /**< (EIC) Event Control */
+#define REG_EIC_INTENCLR        (0x4000280C) /**< (EIC) Interrupt Enable Clear */
+#define REG_EIC_INTENSET        (0x40002810) /**< (EIC) Interrupt Enable Set */
+#define REG_EIC_INTFLAG         (0x40002814) /**< (EIC) Interrupt Flag Status and Clear */
+#define REG_EIC_ASYNCH          (0x40002818) /**< (EIC) External Interrupt Asynchronous Mode */
+#define REG_EIC_CONFIG          (0x4000281C) /**< (EIC) External Interrupt Sense Configuration */
+#define REG_EIC_CONFIG0         (0x4000281C) /**< (EIC) External Interrupt Sense Configuration 0 */
+#define REG_EIC_DEBOUNCEN       (0x40002830) /**< (EIC) Debouncer Enable */
+#define REG_EIC_DPRESCALER      (0x40002834) /**< (EIC) Debouncer Prescaler */
+#define REG_EIC_PINSTATE        (0x40002838) /**< (EIC) Pin State */
+#define REG_EIC_NSCHK           (0x4000283C) /**< (EIC) Non-secure Interrupt Check Enable */
+#define REG_EIC_NONSEC          (0x40002840) /**< (EIC) Non-secure Interrupt */
+
+#else
+
+#define REG_EIC_CTRLA           (*(__IO uint8_t*)0x40002800U) /**< (EIC) Control A */
+#define REG_EIC_NMICTRL         (*(__IO uint8_t*)0x40002801U) /**< (EIC) Non-Maskable Interrupt Control */
+#define REG_EIC_NMIFLAG         (*(__IO uint16_t*)0x40002802U) /**< (EIC) Non-Maskable Interrupt Flag Status and Clear */
+#define REG_EIC_SYNCBUSY        (*(__I  uint32_t*)0x40002804U) /**< (EIC) Synchronization Busy */
+#define REG_EIC_EVCTRL          (*(__IO uint32_t*)0x40002808U) /**< (EIC) Event Control */
+#define REG_EIC_INTENCLR        (*(__IO uint32_t*)0x4000280CU) /**< (EIC) Interrupt Enable Clear */
+#define REG_EIC_INTENSET        (*(__IO uint32_t*)0x40002810U) /**< (EIC) Interrupt Enable Set */
+#define REG_EIC_INTFLAG         (*(__IO uint32_t*)0x40002814U) /**< (EIC) Interrupt Flag Status and Clear */
+#define REG_EIC_ASYNCH          (*(__IO uint32_t*)0x40002818U) /**< (EIC) External Interrupt Asynchronous Mode */
+#define REG_EIC_CONFIG          (*(__IO uint32_t*)0x4000281CU) /**< (EIC) External Interrupt Sense Configuration */
+#define REG_EIC_CONFIG0         (*(__IO uint32_t*)0x4000281CU) /**< (EIC) External Interrupt Sense Configuration 0 */
+#define REG_EIC_DEBOUNCEN       (*(__IO uint32_t*)0x40002830U) /**< (EIC) Debouncer Enable */
+#define REG_EIC_DPRESCALER      (*(__IO uint32_t*)0x40002834U) /**< (EIC) Debouncer Prescaler */
+#define REG_EIC_PINSTATE        (*(__I  uint32_t*)0x40002838U) /**< (EIC) Pin State */
+#define REG_EIC_NSCHK           (*(__IO uint32_t*)0x4000283CU) /**< (EIC) Non-secure Interrupt Check Enable */
+#define REG_EIC_NONSEC          (*(__IO uint32_t*)0x40002840U) /**< (EIC) Non-secure Interrupt */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for EIC peripheral ========== */
+#define EIC_EXTINT_NUM                           8          /* Number of external interrupts */
+#define EIC_GCLK_ID                              3          /* Generic Clock index */
+#define EIC_NUMBER_OF_CONFIG_REGS                1          /* Number of CONFIG registers */
+#define EIC_NUMBER_OF_DPRESCALER_REGS            1          /* Number of DPRESCALER registers */
+#define EIC_NUMBER_OF_INTERRUPTS                 8          /* Number of external interrupts (obsolete) */
+#define EIC_SECURE_IMPLEMENTED                   1          /* Security Configuration implemented? */
+#define EIC_INSTANCE_ID                          10         
+
+#endif /* _SAML10_EIC_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/instance/evsys.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/instance/evsys.h
@@ -1,0 +1,221 @@
+/**
+ * \file
+ *
+ * \brief Instance description for EVSYS
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_EVSYS_INSTANCE_H_
+#define _SAML10_EVSYS_INSTANCE_H_
+
+/* ========== Register definition for EVSYS peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_EVSYS_CHANNEL0      (0x42000020) /**< (EVSYS) Channel 0 Control */
+#define REG_EVSYS_CHINTENCLR0   (0x42000024) /**< (EVSYS) Channel 0 Interrupt Enable Clear */
+#define REG_EVSYS_CHINTENSET0   (0x42000025) /**< (EVSYS) Channel 0 Interrupt Enable Set */
+#define REG_EVSYS_CHINTFLAG0    (0x42000026) /**< (EVSYS) Channel 0 Interrupt Flag Status and Clear */
+#define REG_EVSYS_CHSTATUS0     (0x42000027) /**< (EVSYS) Channel 0 Status */
+#define REG_EVSYS_CHANNEL1      (0x42000028) /**< (EVSYS) Channel 1 Control */
+#define REG_EVSYS_CHINTENCLR1   (0x4200002C) /**< (EVSYS) Channel 1 Interrupt Enable Clear */
+#define REG_EVSYS_CHINTENSET1   (0x4200002D) /**< (EVSYS) Channel 1 Interrupt Enable Set */
+#define REG_EVSYS_CHINTFLAG1    (0x4200002E) /**< (EVSYS) Channel 1 Interrupt Flag Status and Clear */
+#define REG_EVSYS_CHSTATUS1     (0x4200002F) /**< (EVSYS) Channel 1 Status */
+#define REG_EVSYS_CHANNEL2      (0x42000030) /**< (EVSYS) Channel 2 Control */
+#define REG_EVSYS_CHINTENCLR2   (0x42000034) /**< (EVSYS) Channel 2 Interrupt Enable Clear */
+#define REG_EVSYS_CHINTENSET2   (0x42000035) /**< (EVSYS) Channel 2 Interrupt Enable Set */
+#define REG_EVSYS_CHINTFLAG2    (0x42000036) /**< (EVSYS) Channel 2 Interrupt Flag Status and Clear */
+#define REG_EVSYS_CHSTATUS2     (0x42000037) /**< (EVSYS) Channel 2 Status */
+#define REG_EVSYS_CHANNEL3      (0x42000038) /**< (EVSYS) Channel 3 Control */
+#define REG_EVSYS_CHINTENCLR3   (0x4200003C) /**< (EVSYS) Channel 3 Interrupt Enable Clear */
+#define REG_EVSYS_CHINTENSET3   (0x4200003D) /**< (EVSYS) Channel 3 Interrupt Enable Set */
+#define REG_EVSYS_CHINTFLAG3    (0x4200003E) /**< (EVSYS) Channel 3 Interrupt Flag Status and Clear */
+#define REG_EVSYS_CHSTATUS3     (0x4200003F) /**< (EVSYS) Channel 3 Status */
+#define REG_EVSYS_CHANNEL4      (0x42000040) /**< (EVSYS) Channel 4 Control */
+#define REG_EVSYS_CHINTENCLR4   (0x42000044) /**< (EVSYS) Channel 4 Interrupt Enable Clear */
+#define REG_EVSYS_CHINTENSET4   (0x42000045) /**< (EVSYS) Channel 4 Interrupt Enable Set */
+#define REG_EVSYS_CHINTFLAG4    (0x42000046) /**< (EVSYS) Channel 4 Interrupt Flag Status and Clear */
+#define REG_EVSYS_CHSTATUS4     (0x42000047) /**< (EVSYS) Channel 4 Status */
+#define REG_EVSYS_CHANNEL5      (0x42000048) /**< (EVSYS) Channel 5 Control */
+#define REG_EVSYS_CHINTENCLR5   (0x4200004C) /**< (EVSYS) Channel 5 Interrupt Enable Clear */
+#define REG_EVSYS_CHINTENSET5   (0x4200004D) /**< (EVSYS) Channel 5 Interrupt Enable Set */
+#define REG_EVSYS_CHINTFLAG5    (0x4200004E) /**< (EVSYS) Channel 5 Interrupt Flag Status and Clear */
+#define REG_EVSYS_CHSTATUS5     (0x4200004F) /**< (EVSYS) Channel 5 Status */
+#define REG_EVSYS_CHANNEL6      (0x42000050) /**< (EVSYS) Channel 6 Control */
+#define REG_EVSYS_CHINTENCLR6   (0x42000054) /**< (EVSYS) Channel 6 Interrupt Enable Clear */
+#define REG_EVSYS_CHINTENSET6   (0x42000055) /**< (EVSYS) Channel 6 Interrupt Enable Set */
+#define REG_EVSYS_CHINTFLAG6    (0x42000056) /**< (EVSYS) Channel 6 Interrupt Flag Status and Clear */
+#define REG_EVSYS_CHSTATUS6     (0x42000057) /**< (EVSYS) Channel 6 Status */
+#define REG_EVSYS_CHANNEL7      (0x42000058) /**< (EVSYS) Channel 7 Control */
+#define REG_EVSYS_CHINTENCLR7   (0x4200005C) /**< (EVSYS) Channel 7 Interrupt Enable Clear */
+#define REG_EVSYS_CHINTENSET7   (0x4200005D) /**< (EVSYS) Channel 7 Interrupt Enable Set */
+#define REG_EVSYS_CHINTFLAG7    (0x4200005E) /**< (EVSYS) Channel 7 Interrupt Flag Status and Clear */
+#define REG_EVSYS_CHSTATUS7     (0x4200005F) /**< (EVSYS) Channel 7 Status */
+#define REG_EVSYS_CTRLA         (0x42000000) /**< (EVSYS) Control */
+#define REG_EVSYS_SWEVT         (0x42000004) /**< (EVSYS) Software Event */
+#define REG_EVSYS_PRICTRL       (0x42000008) /**< (EVSYS) Priority Control */
+#define REG_EVSYS_INTPEND       (0x42000010) /**< (EVSYS) Channel Pending Interrupt */
+#define REG_EVSYS_INTSTATUS     (0x42000014) /**< (EVSYS) Interrupt Status */
+#define REG_EVSYS_BUSYCH        (0x42000018) /**< (EVSYS) Busy Channels */
+#define REG_EVSYS_READYUSR      (0x4200001C) /**< (EVSYS) Ready Users */
+#define REG_EVSYS_USER          (0x42000120) /**< (EVSYS) User Multiplexer n */
+#define REG_EVSYS_USER0         (0x42000120) /**< (EVSYS) User Multiplexer 0 */
+#define REG_EVSYS_USER1         (0x42000121) /**< (EVSYS) User Multiplexer 1 */
+#define REG_EVSYS_USER2         (0x42000122) /**< (EVSYS) User Multiplexer 2 */
+#define REG_EVSYS_USER3         (0x42000123) /**< (EVSYS) User Multiplexer 3 */
+#define REG_EVSYS_USER4         (0x42000124) /**< (EVSYS) User Multiplexer 4 */
+#define REG_EVSYS_USER5         (0x42000125) /**< (EVSYS) User Multiplexer 5 */
+#define REG_EVSYS_USER6         (0x42000126) /**< (EVSYS) User Multiplexer 6 */
+#define REG_EVSYS_USER7         (0x42000127) /**< (EVSYS) User Multiplexer 7 */
+#define REG_EVSYS_USER8         (0x42000128) /**< (EVSYS) User Multiplexer 8 */
+#define REG_EVSYS_USER9         (0x42000129) /**< (EVSYS) User Multiplexer 9 */
+#define REG_EVSYS_USER10        (0x4200012A) /**< (EVSYS) User Multiplexer 10 */
+#define REG_EVSYS_USER11        (0x4200012B) /**< (EVSYS) User Multiplexer 11 */
+#define REG_EVSYS_USER12        (0x4200012C) /**< (EVSYS) User Multiplexer 12 */
+#define REG_EVSYS_USER13        (0x4200012D) /**< (EVSYS) User Multiplexer 13 */
+#define REG_EVSYS_USER14        (0x4200012E) /**< (EVSYS) User Multiplexer 14 */
+#define REG_EVSYS_USER15        (0x4200012F) /**< (EVSYS) User Multiplexer 15 */
+#define REG_EVSYS_USER16        (0x42000130) /**< (EVSYS) User Multiplexer 16 */
+#define REG_EVSYS_USER17        (0x42000131) /**< (EVSYS) User Multiplexer 17 */
+#define REG_EVSYS_USER18        (0x42000132) /**< (EVSYS) User Multiplexer 18 */
+#define REG_EVSYS_USER19        (0x42000133) /**< (EVSYS) User Multiplexer 19 */
+#define REG_EVSYS_USER20        (0x42000134) /**< (EVSYS) User Multiplexer 20 */
+#define REG_EVSYS_USER21        (0x42000135) /**< (EVSYS) User Multiplexer 21 */
+#define REG_EVSYS_USER22        (0x42000136) /**< (EVSYS) User Multiplexer 22 */
+#define REG_EVSYS_INTENCLR      (0x420001D4) /**< (EVSYS) Interrupt Enable Clear */
+#define REG_EVSYS_INTENSET      (0x420001D5) /**< (EVSYS) Interrupt Enable Set */
+#define REG_EVSYS_INTFLAG       (0x420001D6) /**< (EVSYS) Interrupt Flag Status and Clear */
+#define REG_EVSYS_NONSECCHAN    (0x420001D8) /**< (EVSYS) Channels Security Attribution */
+#define REG_EVSYS_NSCHKCHAN     (0x420001DC) /**< (EVSYS) Non-Secure Channels Check */
+#define REG_EVSYS_NONSECUSER    (0x420001E0) /**< (EVSYS) Users Security Attribution */
+#define REG_EVSYS_NONSECUSER0   (0x420001E0) /**< (EVSYS) Users Security Attribution 0 */
+#define REG_EVSYS_NSCHKUSER     (0x420001F0) /**< (EVSYS) Non-Secure Users Check */
+#define REG_EVSYS_NSCHKUSER0    (0x420001F0) /**< (EVSYS) Non-Secure Users Check 0 */
+
+#else
+
+#define REG_EVSYS_CHANNEL0      (*(__IO uint32_t*)0x42000020U) /**< (EVSYS) Channel 0 Control */
+#define REG_EVSYS_CHINTENCLR0   (*(__IO uint8_t*)0x42000024U) /**< (EVSYS) Channel 0 Interrupt Enable Clear */
+#define REG_EVSYS_CHINTENSET0   (*(__IO uint8_t*)0x42000025U) /**< (EVSYS) Channel 0 Interrupt Enable Set */
+#define REG_EVSYS_CHINTFLAG0    (*(__IO uint8_t*)0x42000026U) /**< (EVSYS) Channel 0 Interrupt Flag Status and Clear */
+#define REG_EVSYS_CHSTATUS0     (*(__I  uint8_t*)0x42000027U) /**< (EVSYS) Channel 0 Status */
+#define REG_EVSYS_CHANNEL1      (*(__IO uint32_t*)0x42000028U) /**< (EVSYS) Channel 1 Control */
+#define REG_EVSYS_CHINTENCLR1   (*(__IO uint8_t*)0x4200002CU) /**< (EVSYS) Channel 1 Interrupt Enable Clear */
+#define REG_EVSYS_CHINTENSET1   (*(__IO uint8_t*)0x4200002DU) /**< (EVSYS) Channel 1 Interrupt Enable Set */
+#define REG_EVSYS_CHINTFLAG1    (*(__IO uint8_t*)0x4200002EU) /**< (EVSYS) Channel 1 Interrupt Flag Status and Clear */
+#define REG_EVSYS_CHSTATUS1     (*(__I  uint8_t*)0x4200002FU) /**< (EVSYS) Channel 1 Status */
+#define REG_EVSYS_CHANNEL2      (*(__IO uint32_t*)0x42000030U) /**< (EVSYS) Channel 2 Control */
+#define REG_EVSYS_CHINTENCLR2   (*(__IO uint8_t*)0x42000034U) /**< (EVSYS) Channel 2 Interrupt Enable Clear */
+#define REG_EVSYS_CHINTENSET2   (*(__IO uint8_t*)0x42000035U) /**< (EVSYS) Channel 2 Interrupt Enable Set */
+#define REG_EVSYS_CHINTFLAG2    (*(__IO uint8_t*)0x42000036U) /**< (EVSYS) Channel 2 Interrupt Flag Status and Clear */
+#define REG_EVSYS_CHSTATUS2     (*(__I  uint8_t*)0x42000037U) /**< (EVSYS) Channel 2 Status */
+#define REG_EVSYS_CHANNEL3      (*(__IO uint32_t*)0x42000038U) /**< (EVSYS) Channel 3 Control */
+#define REG_EVSYS_CHINTENCLR3   (*(__IO uint8_t*)0x4200003CU) /**< (EVSYS) Channel 3 Interrupt Enable Clear */
+#define REG_EVSYS_CHINTENSET3   (*(__IO uint8_t*)0x4200003DU) /**< (EVSYS) Channel 3 Interrupt Enable Set */
+#define REG_EVSYS_CHINTFLAG3    (*(__IO uint8_t*)0x4200003EU) /**< (EVSYS) Channel 3 Interrupt Flag Status and Clear */
+#define REG_EVSYS_CHSTATUS3     (*(__I  uint8_t*)0x4200003FU) /**< (EVSYS) Channel 3 Status */
+#define REG_EVSYS_CHANNEL4      (*(__IO uint32_t*)0x42000040U) /**< (EVSYS) Channel 4 Control */
+#define REG_EVSYS_CHINTENCLR4   (*(__IO uint8_t*)0x42000044U) /**< (EVSYS) Channel 4 Interrupt Enable Clear */
+#define REG_EVSYS_CHINTENSET4   (*(__IO uint8_t*)0x42000045U) /**< (EVSYS) Channel 4 Interrupt Enable Set */
+#define REG_EVSYS_CHINTFLAG4    (*(__IO uint8_t*)0x42000046U) /**< (EVSYS) Channel 4 Interrupt Flag Status and Clear */
+#define REG_EVSYS_CHSTATUS4     (*(__I  uint8_t*)0x42000047U) /**< (EVSYS) Channel 4 Status */
+#define REG_EVSYS_CHANNEL5      (*(__IO uint32_t*)0x42000048U) /**< (EVSYS) Channel 5 Control */
+#define REG_EVSYS_CHINTENCLR5   (*(__IO uint8_t*)0x4200004CU) /**< (EVSYS) Channel 5 Interrupt Enable Clear */
+#define REG_EVSYS_CHINTENSET5   (*(__IO uint8_t*)0x4200004DU) /**< (EVSYS) Channel 5 Interrupt Enable Set */
+#define REG_EVSYS_CHINTFLAG5    (*(__IO uint8_t*)0x4200004EU) /**< (EVSYS) Channel 5 Interrupt Flag Status and Clear */
+#define REG_EVSYS_CHSTATUS5     (*(__I  uint8_t*)0x4200004FU) /**< (EVSYS) Channel 5 Status */
+#define REG_EVSYS_CHANNEL6      (*(__IO uint32_t*)0x42000050U) /**< (EVSYS) Channel 6 Control */
+#define REG_EVSYS_CHINTENCLR6   (*(__IO uint8_t*)0x42000054U) /**< (EVSYS) Channel 6 Interrupt Enable Clear */
+#define REG_EVSYS_CHINTENSET6   (*(__IO uint8_t*)0x42000055U) /**< (EVSYS) Channel 6 Interrupt Enable Set */
+#define REG_EVSYS_CHINTFLAG6    (*(__IO uint8_t*)0x42000056U) /**< (EVSYS) Channel 6 Interrupt Flag Status and Clear */
+#define REG_EVSYS_CHSTATUS6     (*(__I  uint8_t*)0x42000057U) /**< (EVSYS) Channel 6 Status */
+#define REG_EVSYS_CHANNEL7      (*(__IO uint32_t*)0x42000058U) /**< (EVSYS) Channel 7 Control */
+#define REG_EVSYS_CHINTENCLR7   (*(__IO uint8_t*)0x4200005CU) /**< (EVSYS) Channel 7 Interrupt Enable Clear */
+#define REG_EVSYS_CHINTENSET7   (*(__IO uint8_t*)0x4200005DU) /**< (EVSYS) Channel 7 Interrupt Enable Set */
+#define REG_EVSYS_CHINTFLAG7    (*(__IO uint8_t*)0x4200005EU) /**< (EVSYS) Channel 7 Interrupt Flag Status and Clear */
+#define REG_EVSYS_CHSTATUS7     (*(__I  uint8_t*)0x4200005FU) /**< (EVSYS) Channel 7 Status */
+#define REG_EVSYS_CTRLA         (*(__O  uint8_t*)0x42000000U) /**< (EVSYS) Control */
+#define REG_EVSYS_SWEVT         (*(__O  uint32_t*)0x42000004U) /**< (EVSYS) Software Event */
+#define REG_EVSYS_PRICTRL       (*(__IO uint8_t*)0x42000008U) /**< (EVSYS) Priority Control */
+#define REG_EVSYS_INTPEND       (*(__IO uint16_t*)0x42000010U) /**< (EVSYS) Channel Pending Interrupt */
+#define REG_EVSYS_INTSTATUS     (*(__I  uint32_t*)0x42000014U) /**< (EVSYS) Interrupt Status */
+#define REG_EVSYS_BUSYCH        (*(__I  uint32_t*)0x42000018U) /**< (EVSYS) Busy Channels */
+#define REG_EVSYS_READYUSR      (*(__I  uint32_t*)0x4200001CU) /**< (EVSYS) Ready Users */
+#define REG_EVSYS_USER          (*(__IO uint8_t*)0x42000120U) /**< (EVSYS) User Multiplexer n */
+#define REG_EVSYS_USER0         (*(__IO uint8_t*)0x42000120U) /**< (EVSYS) User Multiplexer 0 */
+#define REG_EVSYS_USER1         (*(__IO uint8_t*)0x42000121U) /**< (EVSYS) User Multiplexer 1 */
+#define REG_EVSYS_USER2         (*(__IO uint8_t*)0x42000122U) /**< (EVSYS) User Multiplexer 2 */
+#define REG_EVSYS_USER3         (*(__IO uint8_t*)0x42000123U) /**< (EVSYS) User Multiplexer 3 */
+#define REG_EVSYS_USER4         (*(__IO uint8_t*)0x42000124U) /**< (EVSYS) User Multiplexer 4 */
+#define REG_EVSYS_USER5         (*(__IO uint8_t*)0x42000125U) /**< (EVSYS) User Multiplexer 5 */
+#define REG_EVSYS_USER6         (*(__IO uint8_t*)0x42000126U) /**< (EVSYS) User Multiplexer 6 */
+#define REG_EVSYS_USER7         (*(__IO uint8_t*)0x42000127U) /**< (EVSYS) User Multiplexer 7 */
+#define REG_EVSYS_USER8         (*(__IO uint8_t*)0x42000128U) /**< (EVSYS) User Multiplexer 8 */
+#define REG_EVSYS_USER9         (*(__IO uint8_t*)0x42000129U) /**< (EVSYS) User Multiplexer 9 */
+#define REG_EVSYS_USER10        (*(__IO uint8_t*)0x4200012AU) /**< (EVSYS) User Multiplexer 10 */
+#define REG_EVSYS_USER11        (*(__IO uint8_t*)0x4200012BU) /**< (EVSYS) User Multiplexer 11 */
+#define REG_EVSYS_USER12        (*(__IO uint8_t*)0x4200012CU) /**< (EVSYS) User Multiplexer 12 */
+#define REG_EVSYS_USER13        (*(__IO uint8_t*)0x4200012DU) /**< (EVSYS) User Multiplexer 13 */
+#define REG_EVSYS_USER14        (*(__IO uint8_t*)0x4200012EU) /**< (EVSYS) User Multiplexer 14 */
+#define REG_EVSYS_USER15        (*(__IO uint8_t*)0x4200012FU) /**< (EVSYS) User Multiplexer 15 */
+#define REG_EVSYS_USER16        (*(__IO uint8_t*)0x42000130U) /**< (EVSYS) User Multiplexer 16 */
+#define REG_EVSYS_USER17        (*(__IO uint8_t*)0x42000131U) /**< (EVSYS) User Multiplexer 17 */
+#define REG_EVSYS_USER18        (*(__IO uint8_t*)0x42000132U) /**< (EVSYS) User Multiplexer 18 */
+#define REG_EVSYS_USER19        (*(__IO uint8_t*)0x42000133U) /**< (EVSYS) User Multiplexer 19 */
+#define REG_EVSYS_USER20        (*(__IO uint8_t*)0x42000134U) /**< (EVSYS) User Multiplexer 20 */
+#define REG_EVSYS_USER21        (*(__IO uint8_t*)0x42000135U) /**< (EVSYS) User Multiplexer 21 */
+#define REG_EVSYS_USER22        (*(__IO uint8_t*)0x42000136U) /**< (EVSYS) User Multiplexer 22 */
+#define REG_EVSYS_INTENCLR      (*(__IO uint8_t*)0x420001D4U) /**< (EVSYS) Interrupt Enable Clear */
+#define REG_EVSYS_INTENSET      (*(__IO uint8_t*)0x420001D5U) /**< (EVSYS) Interrupt Enable Set */
+#define REG_EVSYS_INTFLAG       (*(__IO uint8_t*)0x420001D6U) /**< (EVSYS) Interrupt Flag Status and Clear */
+#define REG_EVSYS_NONSECCHAN    (*(__IO uint32_t*)0x420001D8U) /**< (EVSYS) Channels Security Attribution */
+#define REG_EVSYS_NSCHKCHAN     (*(__IO uint32_t*)0x420001DCU) /**< (EVSYS) Non-Secure Channels Check */
+#define REG_EVSYS_NONSECUSER    (*(__IO uint32_t*)0x420001E0U) /**< (EVSYS) Users Security Attribution */
+#define REG_EVSYS_NONSECUSER0   (*(__IO uint32_t*)0x420001E0U) /**< (EVSYS) Users Security Attribution 0 */
+#define REG_EVSYS_NSCHKUSER     (*(__IO uint32_t*)0x420001F0U) /**< (EVSYS) Non-Secure Users Check */
+#define REG_EVSYS_NSCHKUSER0    (*(__IO uint32_t*)0x420001F0U) /**< (EVSYS) Non-Secure Users Check 0 */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for EVSYS peripheral ========== */
+#define EVSYS_ASYNCHRONOUS_CHANNELS              0x000000F0 /* Mask of Only Asynchronous Channels */
+#define EVSYS_CHANNELS                           8          /* Number of Channels */
+#define EVSYS_CHANNELS_BITS                      3          /* Number of bits to select Channel */
+#define EVSYS_GCLK_ID_0                          6          /* Index of Generic Clock 0 */
+#define EVSYS_GCLK_ID_1                          7          /* Index of Generic Clock 1 */
+#define EVSYS_GCLK_ID_2                          8          /* Index of Generic Clock 2 */
+#define EVSYS_GCLK_ID_3                          9          /* Index of Generic Clock 3 */
+#define EVSYS_GENERATORS                         49         /* Total Number of Event Generators */
+#define EVSYS_GENERATORS_BITS                    6          /* Number of bits to select Event Generator */
+#define EVSYS_SECURE_IMPLEMENTED                 1          /* Secure Channels/Users supported? */
+#define EVSYS_SYNCH_NUM                          4          /* Number of Synchronous Channels */
+#define EVSYS_SYNCH_NUM_BITS                     2          /* Number of bits to select Synchronous Channels */
+#define EVSYS_USERS                              23         /* Total Number of Event Users */
+#define EVSYS_USERS_BITS                         5          /* Number of bits to select Event User */
+#define EVSYS_USERS_GROUPS                       1          /* Number of 32-user groups */
+#define EVSYS_INSTANCE_ID                        64         
+
+#endif /* _SAML10_EVSYS_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/instance/freqm.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/instance/freqm.h
@@ -1,0 +1,66 @@
+/**
+ * \file
+ *
+ * \brief Instance description for FREQM
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_FREQM_INSTANCE_H_
+#define _SAML10_FREQM_INSTANCE_H_
+
+/* ========== Register definition for FREQM peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_FREQM_CTRLA         (0x40002C00) /**< (FREQM) Control A Register */
+#define REG_FREQM_CTRLB         (0x40002C01) /**< (FREQM) Control B Register */
+#define REG_FREQM_CFGA          (0x40002C02) /**< (FREQM) Config A register */
+#define REG_FREQM_INTENCLR      (0x40002C08) /**< (FREQM) Interrupt Enable Clear Register */
+#define REG_FREQM_INTENSET      (0x40002C09) /**< (FREQM) Interrupt Enable Set Register */
+#define REG_FREQM_INTFLAG       (0x40002C0A) /**< (FREQM) Interrupt Flag Register */
+#define REG_FREQM_STATUS        (0x40002C0B) /**< (FREQM) Status Register */
+#define REG_FREQM_SYNCBUSY      (0x40002C0C) /**< (FREQM) Synchronization Busy Register */
+#define REG_FREQM_VALUE         (0x40002C10) /**< (FREQM) Count Value Register */
+
+#else
+
+#define REG_FREQM_CTRLA         (*(__IO uint8_t*)0x40002C00U) /**< (FREQM) Control A Register */
+#define REG_FREQM_CTRLB         (*(__O  uint8_t*)0x40002C01U) /**< (FREQM) Control B Register */
+#define REG_FREQM_CFGA          (*(__IO uint16_t*)0x40002C02U) /**< (FREQM) Config A register */
+#define REG_FREQM_INTENCLR      (*(__IO uint8_t*)0x40002C08U) /**< (FREQM) Interrupt Enable Clear Register */
+#define REG_FREQM_INTENSET      (*(__IO uint8_t*)0x40002C09U) /**< (FREQM) Interrupt Enable Set Register */
+#define REG_FREQM_INTFLAG       (*(__IO uint8_t*)0x40002C0AU) /**< (FREQM) Interrupt Flag Register */
+#define REG_FREQM_STATUS        (*(__IO uint8_t*)0x40002C0BU) /**< (FREQM) Status Register */
+#define REG_FREQM_SYNCBUSY      (*(__I  uint32_t*)0x40002C0CU) /**< (FREQM) Synchronization Busy Register */
+#define REG_FREQM_VALUE         (*(__I  uint32_t*)0x40002C10U) /**< (FREQM) Count Value Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for FREQM peripheral ========== */
+#define FREQM_GCLK_ID_MSR                        4          /* Index of measure generic clock */
+#define FREQM_GCLK_ID_REF                        5          /* Index of reference generic clock */
+#define FREQM_INSTANCE_ID                        11         
+
+#endif /* _SAML10_FREQM_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/instance/gclk.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/instance/gclk.h
@@ -1,0 +1,114 @@
+/**
+ * \file
+ *
+ * \brief Instance description for GCLK
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_GCLK_INSTANCE_H_
+#define _SAML10_GCLK_INSTANCE_H_
+
+/* ========== Register definition for GCLK peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_GCLK_CTRLA          (0x40001C00) /**< (GCLK) Control */
+#define REG_GCLK_SYNCBUSY       (0x40001C04) /**< (GCLK) Synchronization Busy */
+#define REG_GCLK_GENCTRL        (0x40001C20) /**< (GCLK) Generic Clock Generator Control */
+#define REG_GCLK_GENCTRL0       (0x40001C20) /**< (GCLK) Generic Clock Generator Control 0 */
+#define REG_GCLK_GENCTRL1       (0x40001C24) /**< (GCLK) Generic Clock Generator Control 1 */
+#define REG_GCLK_GENCTRL2       (0x40001C28) /**< (GCLK) Generic Clock Generator Control 2 */
+#define REG_GCLK_GENCTRL3       (0x40001C2C) /**< (GCLK) Generic Clock Generator Control 3 */
+#define REG_GCLK_GENCTRL4       (0x40001C30) /**< (GCLK) Generic Clock Generator Control 4 */
+#define REG_GCLK_PCHCTRL        (0x40001C80) /**< (GCLK) Peripheral Clock Control */
+#define REG_GCLK_PCHCTRL0       (0x40001C80) /**< (GCLK) Peripheral Clock Control 0 */
+#define REG_GCLK_PCHCTRL1       (0x40001C84) /**< (GCLK) Peripheral Clock Control 1 */
+#define REG_GCLK_PCHCTRL2       (0x40001C88) /**< (GCLK) Peripheral Clock Control 2 */
+#define REG_GCLK_PCHCTRL3       (0x40001C8C) /**< (GCLK) Peripheral Clock Control 3 */
+#define REG_GCLK_PCHCTRL4       (0x40001C90) /**< (GCLK) Peripheral Clock Control 4 */
+#define REG_GCLK_PCHCTRL5       (0x40001C94) /**< (GCLK) Peripheral Clock Control 5 */
+#define REG_GCLK_PCHCTRL6       (0x40001C98) /**< (GCLK) Peripheral Clock Control 6 */
+#define REG_GCLK_PCHCTRL7       (0x40001C9C) /**< (GCLK) Peripheral Clock Control 7 */
+#define REG_GCLK_PCHCTRL8       (0x40001CA0) /**< (GCLK) Peripheral Clock Control 8 */
+#define REG_GCLK_PCHCTRL9       (0x40001CA4) /**< (GCLK) Peripheral Clock Control 9 */
+#define REG_GCLK_PCHCTRL10      (0x40001CA8) /**< (GCLK) Peripheral Clock Control 10 */
+#define REG_GCLK_PCHCTRL11      (0x40001CAC) /**< (GCLK) Peripheral Clock Control 11 */
+#define REG_GCLK_PCHCTRL12      (0x40001CB0) /**< (GCLK) Peripheral Clock Control 12 */
+#define REG_GCLK_PCHCTRL13      (0x40001CB4) /**< (GCLK) Peripheral Clock Control 13 */
+#define REG_GCLK_PCHCTRL14      (0x40001CB8) /**< (GCLK) Peripheral Clock Control 14 */
+#define REG_GCLK_PCHCTRL15      (0x40001CBC) /**< (GCLK) Peripheral Clock Control 15 */
+#define REG_GCLK_PCHCTRL16      (0x40001CC0) /**< (GCLK) Peripheral Clock Control 16 */
+#define REG_GCLK_PCHCTRL17      (0x40001CC4) /**< (GCLK) Peripheral Clock Control 17 */
+#define REG_GCLK_PCHCTRL18      (0x40001CC8) /**< (GCLK) Peripheral Clock Control 18 */
+#define REG_GCLK_PCHCTRL19      (0x40001CCC) /**< (GCLK) Peripheral Clock Control 19 */
+#define REG_GCLK_PCHCTRL20      (0x40001CD0) /**< (GCLK) Peripheral Clock Control 20 */
+
+#else
+
+#define REG_GCLK_CTRLA          (*(__IO uint8_t*)0x40001C00U) /**< (GCLK) Control */
+#define REG_GCLK_SYNCBUSY       (*(__I  uint32_t*)0x40001C04U) /**< (GCLK) Synchronization Busy */
+#define REG_GCLK_GENCTRL        (*(__IO uint32_t*)0x40001C20U) /**< (GCLK) Generic Clock Generator Control */
+#define REG_GCLK_GENCTRL0       (*(__IO uint32_t*)0x40001C20U) /**< (GCLK) Generic Clock Generator Control 0 */
+#define REG_GCLK_GENCTRL1       (*(__IO uint32_t*)0x40001C24U) /**< (GCLK) Generic Clock Generator Control 1 */
+#define REG_GCLK_GENCTRL2       (*(__IO uint32_t*)0x40001C28U) /**< (GCLK) Generic Clock Generator Control 2 */
+#define REG_GCLK_GENCTRL3       (*(__IO uint32_t*)0x40001C2CU) /**< (GCLK) Generic Clock Generator Control 3 */
+#define REG_GCLK_GENCTRL4       (*(__IO uint32_t*)0x40001C30U) /**< (GCLK) Generic Clock Generator Control 4 */
+#define REG_GCLK_PCHCTRL        (*(__IO uint32_t*)0x40001C80U) /**< (GCLK) Peripheral Clock Control */
+#define REG_GCLK_PCHCTRL0       (*(__IO uint32_t*)0x40001C80U) /**< (GCLK) Peripheral Clock Control 0 */
+#define REG_GCLK_PCHCTRL1       (*(__IO uint32_t*)0x40001C84U) /**< (GCLK) Peripheral Clock Control 1 */
+#define REG_GCLK_PCHCTRL2       (*(__IO uint32_t*)0x40001C88U) /**< (GCLK) Peripheral Clock Control 2 */
+#define REG_GCLK_PCHCTRL3       (*(__IO uint32_t*)0x40001C8CU) /**< (GCLK) Peripheral Clock Control 3 */
+#define REG_GCLK_PCHCTRL4       (*(__IO uint32_t*)0x40001C90U) /**< (GCLK) Peripheral Clock Control 4 */
+#define REG_GCLK_PCHCTRL5       (*(__IO uint32_t*)0x40001C94U) /**< (GCLK) Peripheral Clock Control 5 */
+#define REG_GCLK_PCHCTRL6       (*(__IO uint32_t*)0x40001C98U) /**< (GCLK) Peripheral Clock Control 6 */
+#define REG_GCLK_PCHCTRL7       (*(__IO uint32_t*)0x40001C9CU) /**< (GCLK) Peripheral Clock Control 7 */
+#define REG_GCLK_PCHCTRL8       (*(__IO uint32_t*)0x40001CA0U) /**< (GCLK) Peripheral Clock Control 8 */
+#define REG_GCLK_PCHCTRL9       (*(__IO uint32_t*)0x40001CA4U) /**< (GCLK) Peripheral Clock Control 9 */
+#define REG_GCLK_PCHCTRL10      (*(__IO uint32_t*)0x40001CA8U) /**< (GCLK) Peripheral Clock Control 10 */
+#define REG_GCLK_PCHCTRL11      (*(__IO uint32_t*)0x40001CACU) /**< (GCLK) Peripheral Clock Control 11 */
+#define REG_GCLK_PCHCTRL12      (*(__IO uint32_t*)0x40001CB0U) /**< (GCLK) Peripheral Clock Control 12 */
+#define REG_GCLK_PCHCTRL13      (*(__IO uint32_t*)0x40001CB4U) /**< (GCLK) Peripheral Clock Control 13 */
+#define REG_GCLK_PCHCTRL14      (*(__IO uint32_t*)0x40001CB8U) /**< (GCLK) Peripheral Clock Control 14 */
+#define REG_GCLK_PCHCTRL15      (*(__IO uint32_t*)0x40001CBCU) /**< (GCLK) Peripheral Clock Control 15 */
+#define REG_GCLK_PCHCTRL16      (*(__IO uint32_t*)0x40001CC0U) /**< (GCLK) Peripheral Clock Control 16 */
+#define REG_GCLK_PCHCTRL17      (*(__IO uint32_t*)0x40001CC4U) /**< (GCLK) Peripheral Clock Control 17 */
+#define REG_GCLK_PCHCTRL18      (*(__IO uint32_t*)0x40001CC8U) /**< (GCLK) Peripheral Clock Control 18 */
+#define REG_GCLK_PCHCTRL19      (*(__IO uint32_t*)0x40001CCCU) /**< (GCLK) Peripheral Clock Control 19 */
+#define REG_GCLK_PCHCTRL20      (*(__IO uint32_t*)0x40001CD0U) /**< (GCLK) Peripheral Clock Control 20 */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for GCLK peripheral ========== */
+#define GCLK_GENDIV_BITS                         16         
+#define GCLK_GEN_BITS                            3          
+#define GCLK_GEN_NUM                             5          /* Number of Generic Clock Generators */
+#define GCLK_GEN_NUM_MSB                         4          /* Number of Generic Clock Generators - 1 */
+#define GCLK_GEN_SOURCE_NUM_MSB                  7          /* Number of Generic Clock Sources - 1 */
+#define GCLK_NUM                                 21         /* Number of Generic Clock Users */
+#define GCLK_SOURCE_BITS                         3          
+#define GCLK_SOURCE_NUM                          8          /* Number of Generic Clock Sources */
+#define GCLK_INSTANCE_ID                         7          
+
+#endif /* _SAML10_GCLK_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/instance/idau.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/instance/idau.h
@@ -1,0 +1,53 @@
+/**
+ * \file
+ *
+ * \brief Instance description for IDAU
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_IDAU_INSTANCE_H_
+#define _SAML10_IDAU_INSTANCE_H_
+
+/* ========== Register definition for IDAU peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+
+
+#else
+
+
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for IDAU peripheral ========== */
+#define IDAU_GRANULARITY_BOOTPROT                0x100      /* BOOTPROT region granularity */
+#define IDAU_REGION_BOOTROM                      0x09       /* Boot ROM region number */
+#define IDAU_REGION_IOBUS                        0x00       /* IOBUS region number (invalid) */
+#define IDAU_REGION_OTHER                        0x00       /* Others region number (invalid) */
+#define IDAU_REGION_PERIPHERALS                  0x00       /* Peripherals region number (invalid) */
+#define IDAU_INSTANCE_ID                         32         
+
+#endif /* _SAML10_IDAU_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/instance/mclk.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/instance/mclk.h
@@ -1,0 +1,66 @@
+/**
+ * \file
+ *
+ * \brief Instance description for MCLK
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_MCLK_INSTANCE_H_
+#define _SAML10_MCLK_INSTANCE_H_
+
+/* ========== Register definition for MCLK peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_MCLK_CTRLA          (0x40000800) /**< (MCLK) Control */
+#define REG_MCLK_INTENCLR       (0x40000801) /**< (MCLK) Interrupt Enable Clear */
+#define REG_MCLK_INTENSET       (0x40000802) /**< (MCLK) Interrupt Enable Set */
+#define REG_MCLK_INTFLAG        (0x40000803) /**< (MCLK) Interrupt Flag Status and Clear */
+#define REG_MCLK_CPUDIV         (0x40000804) /**< (MCLK) CPU Clock Division */
+#define REG_MCLK_AHBMASK        (0x40000810) /**< (MCLK) AHB Mask */
+#define REG_MCLK_APBAMASK       (0x40000814) /**< (MCLK) APBA Mask */
+#define REG_MCLK_APBBMASK       (0x40000818) /**< (MCLK) APBB Mask */
+#define REG_MCLK_APBCMASK       (0x4000081C) /**< (MCLK) APBC Mask */
+
+#else
+
+#define REG_MCLK_CTRLA          (*(__IO uint8_t*)0x40000800U) /**< (MCLK) Control */
+#define REG_MCLK_INTENCLR       (*(__IO uint8_t*)0x40000801U) /**< (MCLK) Interrupt Enable Clear */
+#define REG_MCLK_INTENSET       (*(__IO uint8_t*)0x40000802U) /**< (MCLK) Interrupt Enable Set */
+#define REG_MCLK_INTFLAG        (*(__IO uint8_t*)0x40000803U) /**< (MCLK) Interrupt Flag Status and Clear */
+#define REG_MCLK_CPUDIV         (*(__IO uint8_t*)0x40000804U) /**< (MCLK) CPU Clock Division */
+#define REG_MCLK_AHBMASK        (*(__IO uint32_t*)0x40000810U) /**< (MCLK) AHB Mask */
+#define REG_MCLK_APBAMASK       (*(__IO uint32_t*)0x40000814U) /**< (MCLK) APBA Mask */
+#define REG_MCLK_APBBMASK       (*(__IO uint32_t*)0x40000818U) /**< (MCLK) APBB Mask */
+#define REG_MCLK_APBCMASK       (*(__IO uint32_t*)0x4000081CU) /**< (MCLK) APBC Mask */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for MCLK peripheral ========== */
+#define MCLK_MCLK_CLK_APB_NUM                    3          
+#define MCLK_SYSTEM_CLOCK                        4000000    /* System Clock Frequency at Reset */
+#define MCLK_INSTANCE_ID                         2          
+
+#endif /* _SAML10_MCLK_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/instance/nvmctrl.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/instance/nvmctrl.h
@@ -1,0 +1,100 @@
+/**
+ * \file
+ *
+ * \brief Instance description for NVMCTRL
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_NVMCTRL_INSTANCE_H_
+#define _SAML10_NVMCTRL_INSTANCE_H_
+
+/* ========== Register definition for NVMCTRL peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_NVMCTRL_CTRLA       (0x41004000) /**< (NVMCTRL) Control A */
+#define REG_NVMCTRL_CTRLB       (0x41004004) /**< (NVMCTRL) Control B */
+#define REG_NVMCTRL_CTRLC       (0x41004008) /**< (NVMCTRL) Control C */
+#define REG_NVMCTRL_EVCTRL      (0x4100400A) /**< (NVMCTRL) Event Control */
+#define REG_NVMCTRL_INTENCLR    (0x4100400C) /**< (NVMCTRL) Interrupt Enable Clear */
+#define REG_NVMCTRL_INTENSET    (0x41004010) /**< (NVMCTRL) Interrupt Enable Set */
+#define REG_NVMCTRL_INTFLAG     (0x41004014) /**< (NVMCTRL) Interrupt Flag Status and Clear */
+#define REG_NVMCTRL_STATUS      (0x41004018) /**< (NVMCTRL) Status */
+#define REG_NVMCTRL_ADDR        (0x4100401C) /**< (NVMCTRL) Address */
+#define REG_NVMCTRL_SULCK       (0x41004020) /**< (NVMCTRL) Secure Unlock Register */
+#define REG_NVMCTRL_NSULCK      (0x41004022) /**< (NVMCTRL) Non-Secure Unlock Register */
+#define REG_NVMCTRL_PARAM       (0x41004024) /**< (NVMCTRL) NVM Parameter */
+#define REG_NVMCTRL_DSCC        (0x41004030) /**< (NVMCTRL) Data Scramble Configuration */
+#define REG_NVMCTRL_SECCTRL     (0x41004034) /**< (NVMCTRL) Security Control */
+#define REG_NVMCTRL_SCFGB       (0x41004038) /**< (NVMCTRL) Secure Boot Configuration */
+#define REG_NVMCTRL_SCFGAD      (0x4100403C) /**< (NVMCTRL) Secure Application and Data Configuration */
+#define REG_NVMCTRL_NONSEC      (0x41004040) /**< (NVMCTRL) Non-secure Write Enable */
+#define REG_NVMCTRL_NSCHK       (0x41004044) /**< (NVMCTRL) Non-secure Write Reference Value */
+
+#else
+
+#define REG_NVMCTRL_CTRLA       (*(__O  uint16_t*)0x41004000U) /**< (NVMCTRL) Control A */
+#define REG_NVMCTRL_CTRLB       (*(__IO uint32_t*)0x41004004U) /**< (NVMCTRL) Control B */
+#define REG_NVMCTRL_CTRLC       (*(__IO uint8_t*)0x41004008U) /**< (NVMCTRL) Control C */
+#define REG_NVMCTRL_EVCTRL      (*(__IO uint8_t*)0x4100400AU) /**< (NVMCTRL) Event Control */
+#define REG_NVMCTRL_INTENCLR    (*(__IO uint8_t*)0x4100400CU) /**< (NVMCTRL) Interrupt Enable Clear */
+#define REG_NVMCTRL_INTENSET    (*(__IO uint8_t*)0x41004010U) /**< (NVMCTRL) Interrupt Enable Set */
+#define REG_NVMCTRL_INTFLAG     (*(__IO uint8_t*)0x41004014U) /**< (NVMCTRL) Interrupt Flag Status and Clear */
+#define REG_NVMCTRL_STATUS      (*(__I  uint16_t*)0x41004018U) /**< (NVMCTRL) Status */
+#define REG_NVMCTRL_ADDR        (*(__IO uint32_t*)0x4100401CU) /**< (NVMCTRL) Address */
+#define REG_NVMCTRL_SULCK       (*(__IO uint16_t*)0x41004020U) /**< (NVMCTRL) Secure Unlock Register */
+#define REG_NVMCTRL_NSULCK      (*(__IO uint16_t*)0x41004022U) /**< (NVMCTRL) Non-Secure Unlock Register */
+#define REG_NVMCTRL_PARAM       (*(__IO uint32_t*)0x41004024U) /**< (NVMCTRL) NVM Parameter */
+#define REG_NVMCTRL_DSCC        (*(__O  uint32_t*)0x41004030U) /**< (NVMCTRL) Data Scramble Configuration */
+#define REG_NVMCTRL_SECCTRL     (*(__IO uint32_t*)0x41004034U) /**< (NVMCTRL) Security Control */
+#define REG_NVMCTRL_SCFGB       (*(__IO uint32_t*)0x41004038U) /**< (NVMCTRL) Secure Boot Configuration */
+#define REG_NVMCTRL_SCFGAD      (*(__IO uint32_t*)0x4100403CU) /**< (NVMCTRL) Secure Application and Data Configuration */
+#define REG_NVMCTRL_NONSEC      (*(__IO uint32_t*)0x41004040U) /**< (NVMCTRL) Non-secure Write Enable */
+#define REG_NVMCTRL_NSCHK       (*(__IO uint32_t*)0x41004044U) /**< (NVMCTRL) Non-secure Write Reference Value */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for NVMCTRL peripheral ========== */
+#define NVMCTRL_DATAFLASH_PAGES                  32         
+#define NVMCTRL_PMSB                             3          
+#define NVMCTRL_PSZ_BITS                         6          
+#define NVMCTRL_ROW_PAGES                        4          
+#define NVMCTRL_SECURE_IMPLEMENTED               1          /* Security Configuration implemented? */
+#define NVMCTRL_FLASH_SIZE                       65536      
+#define NVMCTRL_PAGE_SIZE                        64         
+#define NVMCTRL_PAGES                            1024       
+#define NVMCTRL_PAGES_PR_REGION                  64         
+#define NVMCTRL_PSM_0_FRMFW_FWS_1_MAX_FREQ       12000000   
+#define NVMCTRL_PSM_0_FRMLP_FWS_0_MAX_FREQ       18000000   
+#define NVMCTRL_PSM_0_FRMLP_FWS_1_MAX_FREQ       36000000   
+#define NVMCTRL_PSM_0_FRMHS_FWS_0_MAX_FREQ       25000000   
+#define NVMCTRL_PSM_0_FRMHS_FWS_1_MAX_FREQ       50000000   
+#define NVMCTRL_PSM_1_FRMFW_FWS_1_MAX_FREQ       12000000   
+#define NVMCTRL_PSM_1_FRMLP_FWS_0_MAX_FREQ       8000000    
+#define NVMCTRL_PSM_1_FRMLP_FWS_1_MAX_FREQ       12000000   
+#define NVMCTRL_INSTANCE_ID                      34         
+#define NVMCTRL_ROW_SIZE                         256        
+
+#endif /* _SAML10_NVMCTRL_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/instance/opamp.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/instance/opamp.h
@@ -1,0 +1,60 @@
+/**
+ * \file
+ *
+ * \brief Instance description for OPAMP
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_OPAMP_INSTANCE_H_
+#define _SAML10_OPAMP_INSTANCE_H_
+
+/* ========== Register definition for OPAMP peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_OPAMP_CTRLA         (0x42003000) /**< (OPAMP) Control A */
+#define REG_OPAMP_STATUS        (0x42003002) /**< (OPAMP) Status */
+#define REG_OPAMP_OPAMPCTRL     (0x42003004) /**< (OPAMP) OPAMP n Control */
+#define REG_OPAMP_OPAMPCTRL0    (0x42003004) /**< (OPAMP) OPAMP 0 Control */
+#define REG_OPAMP_OPAMPCTRL1    (0x42003008) /**< (OPAMP) OPAMP 1 Control */
+#define REG_OPAMP_OPAMPCTRL2    (0x4200300C) /**< (OPAMP) OPAMP 2 Control */
+#define REG_OPAMP_RESCTRL       (0x42003010) /**< (OPAMP) Resister Control */
+
+#else
+
+#define REG_OPAMP_CTRLA         (*(__IO uint8_t*)0x42003000U) /**< (OPAMP) Control A */
+#define REG_OPAMP_STATUS        (*(__I  uint8_t*)0x42003002U) /**< (OPAMP) Status */
+#define REG_OPAMP_OPAMPCTRL     (*(__IO uint32_t*)0x42003004U) /**< (OPAMP) OPAMP n Control */
+#define REG_OPAMP_OPAMPCTRL0    (*(__IO uint32_t*)0x42003004U) /**< (OPAMP) OPAMP 0 Control */
+#define REG_OPAMP_OPAMPCTRL1    (*(__IO uint32_t*)0x42003008U) /**< (OPAMP) OPAMP 1 Control */
+#define REG_OPAMP_OPAMPCTRL2    (*(__IO uint32_t*)0x4200300CU) /**< (OPAMP) OPAMP 2 Control */
+#define REG_OPAMP_RESCTRL       (*(__IO uint8_t*)0x42003010U) /**< (OPAMP) Resister Control */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for OPAMP peripheral ========== */
+#define OPAMP_INSTANCE_ID                        76         
+
+#endif /* _SAML10_OPAMP_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/instance/osc32kctrl.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/instance/osc32kctrl.h
@@ -1,0 +1,65 @@
+/**
+ * \file
+ *
+ * \brief Instance description for OSC32KCTRL
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_OSC32KCTRL_INSTANCE_H_
+#define _SAML10_OSC32KCTRL_INSTANCE_H_
+
+/* ========== Register definition for OSC32KCTRL peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_OSC32KCTRL_INTENCLR (0x40001400) /**< (OSC32KCTRL) Interrupt Enable Clear */
+#define REG_OSC32KCTRL_INTENSET (0x40001404) /**< (OSC32KCTRL) Interrupt Enable Set */
+#define REG_OSC32KCTRL_INTFLAG  (0x40001408) /**< (OSC32KCTRL) Interrupt Flag Status and Clear */
+#define REG_OSC32KCTRL_STATUS   (0x4000140C) /**< (OSC32KCTRL) Power and Clocks Status */
+#define REG_OSC32KCTRL_RTCCTRL  (0x40001410) /**< (OSC32KCTRL) RTC Clock Selection */
+#define REG_OSC32KCTRL_XOSC32K  (0x40001414) /**< (OSC32KCTRL) 32kHz External Crystal Oscillator (XOSC32K) Control */
+#define REG_OSC32KCTRL_CFDCTRL  (0x40001416) /**< (OSC32KCTRL) Clock Failure Detector Control */
+#define REG_OSC32KCTRL_EVCTRL   (0x40001417) /**< (OSC32KCTRL) Event Control */
+#define REG_OSC32KCTRL_OSCULP32K (0x4000141C) /**< (OSC32KCTRL) 32kHz Ultra Low Power Internal Oscillator (OSCULP32K) Control */
+
+#else
+
+#define REG_OSC32KCTRL_INTENCLR (*(__IO uint32_t*)0x40001400U) /**< (OSC32KCTRL) Interrupt Enable Clear */
+#define REG_OSC32KCTRL_INTENSET (*(__IO uint32_t*)0x40001404U) /**< (OSC32KCTRL) Interrupt Enable Set */
+#define REG_OSC32KCTRL_INTFLAG  (*(__IO uint32_t*)0x40001408U) /**< (OSC32KCTRL) Interrupt Flag Status and Clear */
+#define REG_OSC32KCTRL_STATUS   (*(__I  uint32_t*)0x4000140CU) /**< (OSC32KCTRL) Power and Clocks Status */
+#define REG_OSC32KCTRL_RTCCTRL  (*(__IO uint8_t*)0x40001410U) /**< (OSC32KCTRL) RTC Clock Selection */
+#define REG_OSC32KCTRL_XOSC32K  (*(__IO uint16_t*)0x40001414U) /**< (OSC32KCTRL) 32kHz External Crystal Oscillator (XOSC32K) Control */
+#define REG_OSC32KCTRL_CFDCTRL  (*(__IO uint8_t*)0x40001416U) /**< (OSC32KCTRL) Clock Failure Detector Control */
+#define REG_OSC32KCTRL_EVCTRL   (*(__IO uint8_t*)0x40001417U) /**< (OSC32KCTRL) Event Control */
+#define REG_OSC32KCTRL_OSCULP32K (*(__IO uint32_t*)0x4000141CU) /**< (OSC32KCTRL) 32kHz Ultra Low Power Internal Oscillator (OSCULP32K) Control */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for OSC32KCTRL peripheral ========== */
+#define OSC32KCTRL_OSC32K_COARSE_CALIB_MSB       0          
+#define OSC32KCTRL_INSTANCE_ID                   5          
+
+#endif /* _SAML10_OSC32KCTRL_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/instance/oscctrl.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/instance/oscctrl.h
@@ -1,0 +1,94 @@
+/**
+ * \file
+ *
+ * \brief Instance description for OSCCTRL
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_OSCCTRL_INSTANCE_H_
+#define _SAML10_OSCCTRL_INSTANCE_H_
+
+/* ========== Register definition for OSCCTRL peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_OSCCTRL_EVCTRL      (0x40001000) /**< (OSCCTRL) Event Control */
+#define REG_OSCCTRL_INTENCLR    (0x40001004) /**< (OSCCTRL) Interrupt Enable Clear */
+#define REG_OSCCTRL_INTENSET    (0x40001008) /**< (OSCCTRL) Interrupt Enable Set */
+#define REG_OSCCTRL_INTFLAG     (0x4000100C) /**< (OSCCTRL) Interrupt Flag Status and Clear */
+#define REG_OSCCTRL_STATUS      (0x40001010) /**< (OSCCTRL) Status */
+#define REG_OSCCTRL_XOSCCTRL    (0x40001014) /**< (OSCCTRL) External Multipurpose Crystal Oscillator (XOSC) Control */
+#define REG_OSCCTRL_CFDPRESC    (0x40001016) /**< (OSCCTRL) Clock Failure Detector Prescaler */
+#define REG_OSCCTRL_OSC16MCTRL  (0x40001018) /**< (OSCCTRL) 16MHz Internal Oscillator (OSC16M) Control */
+#define REG_OSCCTRL_DFLLULPCTRL (0x4000101C) /**< (OSCCTRL) DFLLULP Control */
+#define REG_OSCCTRL_DFLLULPDITHER (0x4000101E) /**< (OSCCTRL) DFLLULP Dither Control */
+#define REG_OSCCTRL_DFLLULPRREQ (0x4000101F) /**< (OSCCTRL) DFLLULP Read Request */
+#define REG_OSCCTRL_DFLLULPDLY  (0x40001020) /**< (OSCCTRL) DFLLULP Delay Value */
+#define REG_OSCCTRL_DFLLULPRATIO (0x40001024) /**< (OSCCTRL) DFLLULP Target Ratio */
+#define REG_OSCCTRL_DFLLULPSYNCBUSY (0x40001028) /**< (OSCCTRL) DFLLULP Synchronization Busy */
+#define REG_OSCCTRL_DPLLCTRLA   (0x4000102C) /**< (OSCCTRL) DPLL Control A */
+#define REG_OSCCTRL_DPLLRATIO   (0x40001030) /**< (OSCCTRL) DPLL Ratio Control */
+#define REG_OSCCTRL_DPLLCTRLB   (0x40001034) /**< (OSCCTRL) DPLL Control B */
+#define REG_OSCCTRL_DPLLPRESC   (0x40001038) /**< (OSCCTRL) DPLL Prescaler */
+#define REG_OSCCTRL_DPLLSYNCBUSY (0x4000103C) /**< (OSCCTRL) DPLL Synchronization Busy */
+#define REG_OSCCTRL_DPLLSTATUS  (0x40001040) /**< (OSCCTRL) DPLL Status */
+
+#else
+
+#define REG_OSCCTRL_EVCTRL      (*(__IO uint8_t*)0x40001000U) /**< (OSCCTRL) Event Control */
+#define REG_OSCCTRL_INTENCLR    (*(__IO uint32_t*)0x40001004U) /**< (OSCCTRL) Interrupt Enable Clear */
+#define REG_OSCCTRL_INTENSET    (*(__IO uint32_t*)0x40001008U) /**< (OSCCTRL) Interrupt Enable Set */
+#define REG_OSCCTRL_INTFLAG     (*(__IO uint32_t*)0x4000100CU) /**< (OSCCTRL) Interrupt Flag Status and Clear */
+#define REG_OSCCTRL_STATUS      (*(__I  uint32_t*)0x40001010U) /**< (OSCCTRL) Status */
+#define REG_OSCCTRL_XOSCCTRL    (*(__IO uint16_t*)0x40001014U) /**< (OSCCTRL) External Multipurpose Crystal Oscillator (XOSC) Control */
+#define REG_OSCCTRL_CFDPRESC    (*(__IO uint8_t*)0x40001016U) /**< (OSCCTRL) Clock Failure Detector Prescaler */
+#define REG_OSCCTRL_OSC16MCTRL  (*(__IO uint8_t*)0x40001018U) /**< (OSCCTRL) 16MHz Internal Oscillator (OSC16M) Control */
+#define REG_OSCCTRL_DFLLULPCTRL (*(__IO uint16_t*)0x4000101CU) /**< (OSCCTRL) DFLLULP Control */
+#define REG_OSCCTRL_DFLLULPDITHER (*(__IO uint8_t*)0x4000101EU) /**< (OSCCTRL) DFLLULP Dither Control */
+#define REG_OSCCTRL_DFLLULPRREQ (*(__IO uint8_t*)0x4000101FU) /**< (OSCCTRL) DFLLULP Read Request */
+#define REG_OSCCTRL_DFLLULPDLY  (*(__IO uint32_t*)0x40001020U) /**< (OSCCTRL) DFLLULP Delay Value */
+#define REG_OSCCTRL_DFLLULPRATIO (*(__IO uint32_t*)0x40001024U) /**< (OSCCTRL) DFLLULP Target Ratio */
+#define REG_OSCCTRL_DFLLULPSYNCBUSY (*(__I  uint32_t*)0x40001028U) /**< (OSCCTRL) DFLLULP Synchronization Busy */
+#define REG_OSCCTRL_DPLLCTRLA   (*(__IO uint8_t*)0x4000102CU) /**< (OSCCTRL) DPLL Control A */
+#define REG_OSCCTRL_DPLLRATIO   (*(__IO uint32_t*)0x40001030U) /**< (OSCCTRL) DPLL Ratio Control */
+#define REG_OSCCTRL_DPLLCTRLB   (*(__IO uint32_t*)0x40001034U) /**< (OSCCTRL) DPLL Control B */
+#define REG_OSCCTRL_DPLLPRESC   (*(__IO uint8_t*)0x40001038U) /**< (OSCCTRL) DPLL Prescaler */
+#define REG_OSCCTRL_DPLLSYNCBUSY (*(__I  uint8_t*)0x4000103CU) /**< (OSCCTRL) DPLL Synchronization Busy */
+#define REG_OSCCTRL_DPLLSTATUS  (*(__I  uint8_t*)0x40001040U) /**< (OSCCTRL) DPLL Status */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for OSCCTRL peripheral ========== */
+#define OSCCTRL_GCLK_ID_DFLLULP                  2          /* Index of Generic Clock for DFLLULP */
+#define OSCCTRL_GCLK_ID_DPLL                     0          /* Index of Generic Clock for DPLL */
+#define OSCCTRL_GCLK_ID_DPLL32K                  1          /* Index of Generic Clock for DPLL 32K */
+#define OSCCTRL_CFD_VERSION                      0x112      
+#define OSCCTRL_DFLLULP_VERSION                  0x100      
+#define OSCCTRL_FDPLL_VERSION                    0x213      
+#define OSCCTRL_OSC16M_VERSION                   0x102      
+#define OSCCTRL_XOSC_VERSION                     0x210      
+#define OSCCTRL_INSTANCE_ID                      4          
+
+#endif /* _SAML10_OSCCTRL_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/instance/pac.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/instance/pac.h
@@ -1,0 +1,82 @@
+/**
+ * \file
+ *
+ * \brief Instance description for PAC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_PAC_INSTANCE_H_
+#define _SAML10_PAC_INSTANCE_H_
+
+/* ========== Register definition for PAC peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_PAC_WRCTRL          (0x40000000) /**< (PAC) Write control */
+#define REG_PAC_EVCTRL          (0x40000004) /**< (PAC) Event control */
+#define REG_PAC_INTENCLR        (0x40000008) /**< (PAC) Interrupt enable clear */
+#define REG_PAC_INTENSET        (0x40000009) /**< (PAC) Interrupt enable set */
+#define REG_PAC_INTFLAGAHB      (0x40000010) /**< (PAC) Bridge interrupt flag status */
+#define REG_PAC_INTFLAGA        (0x40000014) /**< (PAC) Peripheral interrupt flag status - Bridge A */
+#define REG_PAC_INTFLAGB        (0x40000018) /**< (PAC) Peripheral interrupt flag status - Bridge B */
+#define REG_PAC_INTFLAGC        (0x4000001C) /**< (PAC) Peripheral interrupt flag status - Bridge C */
+#define REG_PAC_STATUSA         (0x40000034) /**< (PAC) Peripheral write protection status - Bridge A */
+#define REG_PAC_STATUSB         (0x40000038) /**< (PAC) Peripheral write protection status - Bridge B */
+#define REG_PAC_STATUSC         (0x4000003C) /**< (PAC) Peripheral write protection status - Bridge C */
+#define REG_PAC_NONSECA         (0x40000054) /**< (PAC) Peripheral non-secure status - Bridge A */
+#define REG_PAC_NONSECB         (0x40000058) /**< (PAC) Peripheral non-secure status - Bridge B */
+#define REG_PAC_NONSECC         (0x4000005C) /**< (PAC) Peripheral non-secure status - Bridge C */
+#define REG_PAC_SECLOCKA        (0x40000074) /**< (PAC) Peripheral secure status locked - Bridge A */
+#define REG_PAC_SECLOCKB        (0x40000078) /**< (PAC) Peripheral secure status locked - Bridge B */
+#define REG_PAC_SECLOCKC        (0x4000007C) /**< (PAC) Peripheral secure status locked - Bridge C */
+
+#else
+
+#define REG_PAC_WRCTRL          (*(__IO uint32_t*)0x40000000U) /**< (PAC) Write control */
+#define REG_PAC_EVCTRL          (*(__IO uint8_t*)0x40000004U) /**< (PAC) Event control */
+#define REG_PAC_INTENCLR        (*(__IO uint8_t*)0x40000008U) /**< (PAC) Interrupt enable clear */
+#define REG_PAC_INTENSET        (*(__IO uint8_t*)0x40000009U) /**< (PAC) Interrupt enable set */
+#define REG_PAC_INTFLAGAHB      (*(__IO uint32_t*)0x40000010U) /**< (PAC) Bridge interrupt flag status */
+#define REG_PAC_INTFLAGA        (*(__IO uint32_t*)0x40000014U) /**< (PAC) Peripheral interrupt flag status - Bridge A */
+#define REG_PAC_INTFLAGB        (*(__IO uint32_t*)0x40000018U) /**< (PAC) Peripheral interrupt flag status - Bridge B */
+#define REG_PAC_INTFLAGC        (*(__IO uint32_t*)0x4000001CU) /**< (PAC) Peripheral interrupt flag status - Bridge C */
+#define REG_PAC_STATUSA         (*(__I  uint32_t*)0x40000034U) /**< (PAC) Peripheral write protection status - Bridge A */
+#define REG_PAC_STATUSB         (*(__I  uint32_t*)0x40000038U) /**< (PAC) Peripheral write protection status - Bridge B */
+#define REG_PAC_STATUSC         (*(__I  uint32_t*)0x4000003CU) /**< (PAC) Peripheral write protection status - Bridge C */
+#define REG_PAC_NONSECA         (*(__I  uint32_t*)0x40000054U) /**< (PAC) Peripheral non-secure status - Bridge A */
+#define REG_PAC_NONSECB         (*(__I  uint32_t*)0x40000058U) /**< (PAC) Peripheral non-secure status - Bridge B */
+#define REG_PAC_NONSECC         (*(__I  uint32_t*)0x4000005CU) /**< (PAC) Peripheral non-secure status - Bridge C */
+#define REG_PAC_SECLOCKA        (*(__I  uint32_t*)0x40000074U) /**< (PAC) Peripheral secure status locked - Bridge A */
+#define REG_PAC_SECLOCKB        (*(__I  uint32_t*)0x40000078U) /**< (PAC) Peripheral secure status locked - Bridge B */
+#define REG_PAC_SECLOCKC        (*(__I  uint32_t*)0x4000007CU) /**< (PAC) Peripheral secure status locked - Bridge C */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for PAC peripheral ========== */
+#define PAC_HPB_NUM                              3          /* Number of bridges AHB/APB */
+#define PAC_SECURE_IMPLEMENTED                   1          /* Security Configuration implemented? */
+#define PAC_INSTANCE_ID                          0          
+
+#endif /* _SAML10_PAC_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/instance/pm.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/instance/pm.h
@@ -1,0 +1,62 @@
+/**
+ * \file
+ *
+ * \brief Instance description for PM
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_PM_INSTANCE_H_
+#define _SAML10_PM_INSTANCE_H_
+
+/* ========== Register definition for PM peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_PM_SLEEPCFG         (0x40000401) /**< (PM) Sleep Configuration */
+#define REG_PM_PLCFG            (0x40000402) /**< (PM) Performance Level Configuration */
+#define REG_PM_PWCFG            (0x40000403) /**< (PM) Power Configuration */
+#define REG_PM_INTENCLR         (0x40000404) /**< (PM) Interrupt Enable Clear */
+#define REG_PM_INTENSET         (0x40000405) /**< (PM) Interrupt Enable Set */
+#define REG_PM_INTFLAG          (0x40000406) /**< (PM) Interrupt Flag Status and Clear */
+#define REG_PM_STDBYCFG         (0x40000408) /**< (PM) Standby Configuration */
+
+#else
+
+#define REG_PM_SLEEPCFG         (*(__IO uint8_t*)0x40000401U) /**< (PM) Sleep Configuration */
+#define REG_PM_PLCFG            (*(__IO uint8_t*)0x40000402U) /**< (PM) Performance Level Configuration */
+#define REG_PM_PWCFG            (*(__IO uint8_t*)0x40000403U) /**< (PM) Power Configuration */
+#define REG_PM_INTENCLR         (*(__IO uint8_t*)0x40000404U) /**< (PM) Interrupt Enable Clear */
+#define REG_PM_INTENSET         (*(__IO uint8_t*)0x40000405U) /**< (PM) Interrupt Enable Set */
+#define REG_PM_INTFLAG          (*(__IO uint8_t*)0x40000406U) /**< (PM) Interrupt Flag Status and Clear */
+#define REG_PM_STDBYCFG         (*(__IO uint16_t*)0x40000408U) /**< (PM) Standby Configuration */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for PM peripheral ========== */
+#define PM_BIAS_RAM_HS                           1          /* one if RAM HS can be back biased */
+#define PM_PD_NUM                                1          /* Number of switchable Power Domain */
+#define PM_INSTANCE_ID                           1          
+
+#endif /* _SAML10_PM_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/instance/port.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/instance/port.h
@@ -1,0 +1,93 @@
+/**
+ * \file
+ *
+ * \brief Instance description for PORT
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_PORT_INSTANCE_H_
+#define _SAML10_PORT_INSTANCE_H_
+
+/* ========== Register definition for PORT peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_PORT_DIR0           (0x40003000) /**< (PORT) Data Direction 0 */
+#define REG_PORT_DIRCLR0        (0x40003004) /**< (PORT) Data Direction Clear 0 */
+#define REG_PORT_DIRSET0        (0x40003008) /**< (PORT) Data Direction Set 0 */
+#define REG_PORT_DIRTGL0        (0x4000300C) /**< (PORT) Data Direction Toggle 0 */
+#define REG_PORT_OUT0           (0x40003010) /**< (PORT) Data Output Value 0 */
+#define REG_PORT_OUTCLR0        (0x40003014) /**< (PORT) Data Output Value Clear 0 */
+#define REG_PORT_OUTSET0        (0x40003018) /**< (PORT) Data Output Value Set 0 */
+#define REG_PORT_OUTTGL0        (0x4000301C) /**< (PORT) Data Output Value Toggle 0 */
+#define REG_PORT_IN0            (0x40003020) /**< (PORT) Data Input Value 0 */
+#define REG_PORT_CTRL0          (0x40003024) /**< (PORT) Control 0 */
+#define REG_PORT_WRCONFIG0      (0x40003028) /**< (PORT) Write Configuration 0 */
+#define REG_PORT_EVCTRL0        (0x4000302C) /**< (PORT) Event Input Control 0 */
+#define REG_PORT_PMUX0          (0x40003030) /**< (PORT) Peripheral Multiplexing 0 */
+#define REG_PORT_PINCFG0        (0x40003040) /**< (PORT) Pin Configuration 0 */
+#define REG_PORT_INTENCLR0      (0x40003060) /**< (PORT) Interrupt Enable Clear 0 */
+#define REG_PORT_INTENSET0      (0x40003064) /**< (PORT) Interrupt Enable Set 0 */
+#define REG_PORT_INTFLAG0       (0x40003068) /**< (PORT) Interrupt Flag Status and Clear 0 */
+#define REG_PORT_NONSEC0        (0x4000306C) /**< (PORT) Security Attribution 0 */
+#define REG_PORT_NSCHK0         (0x40003070) /**< (PORT) Security Attribution Check 0 */
+
+#else
+
+#define REG_PORT_DIR0           (*(__IO uint32_t*)0x40003000U) /**< (PORT) Data Direction 0 */
+#define REG_PORT_DIRCLR0        (*(__IO uint32_t*)0x40003004U) /**< (PORT) Data Direction Clear 0 */
+#define REG_PORT_DIRSET0        (*(__IO uint32_t*)0x40003008U) /**< (PORT) Data Direction Set 0 */
+#define REG_PORT_DIRTGL0        (*(__IO uint32_t*)0x4000300CU) /**< (PORT) Data Direction Toggle 0 */
+#define REG_PORT_OUT0           (*(__IO uint32_t*)0x40003010U) /**< (PORT) Data Output Value 0 */
+#define REG_PORT_OUTCLR0        (*(__IO uint32_t*)0x40003014U) /**< (PORT) Data Output Value Clear 0 */
+#define REG_PORT_OUTSET0        (*(__IO uint32_t*)0x40003018U) /**< (PORT) Data Output Value Set 0 */
+#define REG_PORT_OUTTGL0        (*(__IO uint32_t*)0x4000301CU) /**< (PORT) Data Output Value Toggle 0 */
+#define REG_PORT_IN0            (*(__I  uint32_t*)0x40003020U) /**< (PORT) Data Input Value 0 */
+#define REG_PORT_CTRL0          (*(__IO uint32_t*)0x40003024U) /**< (PORT) Control 0 */
+#define REG_PORT_WRCONFIG0      (*(__O  uint32_t*)0x40003028U) /**< (PORT) Write Configuration 0 */
+#define REG_PORT_EVCTRL0        (*(__IO uint32_t*)0x4000302CU) /**< (PORT) Event Input Control 0 */
+#define REG_PORT_PMUX0          (*(__IO uint8_t*)0x40003030U) /**< (PORT) Peripheral Multiplexing 0 */
+#define REG_PORT_PINCFG0        (*(__IO uint8_t*)0x40003040U) /**< (PORT) Pin Configuration 0 */
+#define REG_PORT_INTENCLR0      (*(__IO uint32_t*)0x40003060U) /**< (PORT) Interrupt Enable Clear 0 */
+#define REG_PORT_INTENSET0      (*(__IO uint32_t*)0x40003064U) /**< (PORT) Interrupt Enable Set 0 */
+#define REG_PORT_INTFLAG0       (*(__IO uint32_t*)0x40003068U) /**< (PORT) Interrupt Flag Status and Clear 0 */
+#define REG_PORT_NONSEC0        (*(__IO uint32_t*)0x4000306CU) /**< (PORT) Security Attribution 0 */
+#define REG_PORT_NSCHK0         (*(__IO uint32_t*)0x40003070U) /**< (PORT) Security Attribution Check 0 */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for PORT peripheral ========== */
+#define PORT_BITS                                32         
+#define PORT_DRVSTR                              1          /* DRVSTR supported */
+#define PORT_EV_NUM                              4          
+#define PORT_GROUPS                              1          
+#define PORT_MSB                                 31         
+#define PORT_ODRAIN                              0          /* ODRAIN supported */
+#define PORT_PPP_IMPLEMENTED                     0          /* IOBUS2 implemented? */
+#define PORT_SECURE_IMPLEMENTED                  1          /* Secure I/Os supported? */
+#define PORT_SLEWLIM                             0          /* SLEWLIM supported */
+#define PORT_INSTANCE_ID                         12         
+
+#endif /* _SAML10_PORT_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/instance/ptc.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/instance/ptc.h
@@ -1,0 +1,54 @@
+/**
+ * \file
+ *
+ * \brief Instance description for PTC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_PTC_INSTANCE_H_
+#define _SAML10_PTC_INSTANCE_H_
+
+/* ========== Register definition for PTC peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+
+
+#else
+
+
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for PTC peripheral ========== */
+#define PTC_DMAC_ID_EOC                          21         /* Index of DMA EOC trigger */
+#define PTC_DMAC_ID_SEQ                          22         /* Index of DMA SEQ trigger */
+#define PTC_DMAC_ID_WCOMP                        23         /* Index of DMA WCOMP trigger */
+#define PTC_GCLK_ID                              19         /* Index of Generic Clock */
+#define PTC_LINES_MSB                            19         
+#define PTC_LINES_NUM                            20         /* Number of PTC lines */
+#define PTC_INSTANCE_ID                          73         
+
+#endif /* _SAML10_PTC_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/instance/rstc.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/instance/rstc.h
@@ -1,0 +1,50 @@
+/**
+ * \file
+ *
+ * \brief Instance description for RSTC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_RSTC_INSTANCE_H_
+#define _SAML10_RSTC_INSTANCE_H_
+
+/* ========== Register definition for RSTC peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_RSTC_RCAUSE         (0x40000C00) /**< (RSTC) Reset Cause */
+
+#else
+
+#define REG_RSTC_RCAUSE         (*(__I  uint8_t*)0x40000C00U) /**< (RSTC) Reset Cause */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for RSTC peripheral ========== */
+#define RSTC_BACKUP_IMPLEMENTED                  0          
+#define RSTC_NUMBER_OF_EXTWAKE                   0          /* number of external wakeup line */
+#define RSTC_INSTANCE_ID                         3          
+
+#endif /* _SAML10_RSTC_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/instance/rtc.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/instance/rtc.h
@@ -1,0 +1,140 @@
+/**
+ * \file
+ *
+ * \brief Instance description for RTC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_RTC_INSTANCE_H_
+#define _SAML10_RTC_INSTANCE_H_
+
+/* ========== Register definition for RTC peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_RTC_DBGCTRL         (0x4000240E) /**< (RTC) Debug Control */
+#define REG_RTC_FREQCORR        (0x40002414) /**< (RTC) Frequency Correction */
+#define REG_RTC_GP              (0x40002440) /**< (RTC) General Purpose */
+#define REG_RTC_GP0             (0x40002440) /**< (RTC) General Purpose 0 */
+#define REG_RTC_GP1             (0x40002444) /**< (RTC) General Purpose 1 */
+#define REG_RTC_TAMPCTRL        (0x40002460) /**< (RTC) Tamper Control */
+#define REG_RTC_TAMPID          (0x40002468) /**< (RTC) Tamper ID */
+#define REG_RTC_TAMPCTRLB       (0x4000246C) /**< (RTC) Tamper Control B */
+#define REG_RTC_MODE0_CTRLA     (0x40002400) /**< (RTC) MODE0 Control A */
+#define REG_RTC_MODE0_CTRLB     (0x40002402) /**< (RTC) MODE0 Control B */
+#define REG_RTC_MODE0_EVCTRL    (0x40002404) /**< (RTC) MODE0 Event Control */
+#define REG_RTC_MODE0_INTENCLR  (0x40002408) /**< (RTC) MODE0 Interrupt Enable Clear */
+#define REG_RTC_MODE0_INTENSET  (0x4000240A) /**< (RTC) MODE0 Interrupt Enable Set */
+#define REG_RTC_MODE0_INTFLAG   (0x4000240C) /**< (RTC) MODE0 Interrupt Flag Status and Clear */
+#define REG_RTC_MODE0_SYNCBUSY  (0x40002410) /**< (RTC) MODE0 Synchronization Busy Status */
+#define REG_RTC_MODE0_COUNT     (0x40002418) /**< (RTC) MODE0 Counter Value */
+#define REG_RTC_MODE0_COMP      (0x40002420) /**< (RTC) MODE0 Compare n Value */
+#define REG_RTC_MODE0_COMP0     (0x40002420) /**< (RTC) MODE0 Compare 0 Value */
+#define REG_RTC_MODE0_TIMESTAMP (0x40002464) /**< (RTC) MODE0 Timestamp */
+#define REG_RTC_MODE1_CTRLA     (0x40002400) /**< (RTC) MODE1 Control A */
+#define REG_RTC_MODE1_CTRLB     (0x40002402) /**< (RTC) MODE1 Control B */
+#define REG_RTC_MODE1_EVCTRL    (0x40002404) /**< (RTC) MODE1 Event Control */
+#define REG_RTC_MODE1_INTENCLR  (0x40002408) /**< (RTC) MODE1 Interrupt Enable Clear */
+#define REG_RTC_MODE1_INTENSET  (0x4000240A) /**< (RTC) MODE1 Interrupt Enable Set */
+#define REG_RTC_MODE1_INTFLAG   (0x4000240C) /**< (RTC) MODE1 Interrupt Flag Status and Clear */
+#define REG_RTC_MODE1_SYNCBUSY  (0x40002410) /**< (RTC) MODE1 Synchronization Busy Status */
+#define REG_RTC_MODE1_COUNT     (0x40002418) /**< (RTC) MODE1 Counter Value */
+#define REG_RTC_MODE1_PER       (0x4000241C) /**< (RTC) MODE1 Counter Period */
+#define REG_RTC_MODE1_COMP      (0x40002420) /**< (RTC) MODE1 Compare n Value */
+#define REG_RTC_MODE1_COMP0     (0x40002420) /**< (RTC) MODE1 Compare 0 Value */
+#define REG_RTC_MODE1_COMP1     (0x40002422) /**< (RTC) MODE1 Compare 1 Value */
+#define REG_RTC_MODE1_TIMESTAMP (0x40002464) /**< (RTC) MODE1 Timestamp */
+#define REG_RTC_MODE2_ALARM0    (0x40002420) /**< (RTC) MODE2_ALARM Alarm 0 Value */
+#define REG_RTC_MODE2_MASK0     (0x40002424) /**< (RTC) MODE2_ALARM Alarm 0 Mask */
+#define REG_RTC_MODE2_CTRLA     (0x40002400) /**< (RTC) MODE2 Control A */
+#define REG_RTC_MODE2_CTRLB     (0x40002402) /**< (RTC) MODE2 Control B */
+#define REG_RTC_MODE2_EVCTRL    (0x40002404) /**< (RTC) MODE2 Event Control */
+#define REG_RTC_MODE2_INTENCLR  (0x40002408) /**< (RTC) MODE2 Interrupt Enable Clear */
+#define REG_RTC_MODE2_INTENSET  (0x4000240A) /**< (RTC) MODE2 Interrupt Enable Set */
+#define REG_RTC_MODE2_INTFLAG   (0x4000240C) /**< (RTC) MODE2 Interrupt Flag Status and Clear */
+#define REG_RTC_MODE2_SYNCBUSY  (0x40002410) /**< (RTC) MODE2 Synchronization Busy Status */
+#define REG_RTC_MODE2_CLOCK     (0x40002418) /**< (RTC) MODE2 Clock Value */
+#define REG_RTC_MODE2_TIMESTAMP (0x40002464) /**< (RTC) MODE2 Timestamp */
+
+#else
+
+#define REG_RTC_DBGCTRL         (*(__IO uint8_t*)0x4000240EU) /**< (RTC) Debug Control */
+#define REG_RTC_FREQCORR        (*(__IO uint8_t*)0x40002414U) /**< (RTC) Frequency Correction */
+#define REG_RTC_GP              (*(__IO uint32_t*)0x40002440U) /**< (RTC) General Purpose */
+#define REG_RTC_GP0             (*(__IO uint32_t*)0x40002440U) /**< (RTC) General Purpose 0 */
+#define REG_RTC_GP1             (*(__IO uint32_t*)0x40002444U) /**< (RTC) General Purpose 1 */
+#define REG_RTC_TAMPCTRL        (*(__IO uint32_t*)0x40002460U) /**< (RTC) Tamper Control */
+#define REG_RTC_TAMPID          (*(__IO uint32_t*)0x40002468U) /**< (RTC) Tamper ID */
+#define REG_RTC_TAMPCTRLB       (*(__IO uint32_t*)0x4000246CU) /**< (RTC) Tamper Control B */
+#define REG_RTC_MODE0_CTRLA     (*(__IO uint16_t*)0x40002400U) /**< (RTC) MODE0 Control A */
+#define REG_RTC_MODE0_CTRLB     (*(__IO uint16_t*)0x40002402U) /**< (RTC) MODE0 Control B */
+#define REG_RTC_MODE0_EVCTRL    (*(__IO uint32_t*)0x40002404U) /**< (RTC) MODE0 Event Control */
+#define REG_RTC_MODE0_INTENCLR  (*(__IO uint16_t*)0x40002408U) /**< (RTC) MODE0 Interrupt Enable Clear */
+#define REG_RTC_MODE0_INTENSET  (*(__IO uint16_t*)0x4000240AU) /**< (RTC) MODE0 Interrupt Enable Set */
+#define REG_RTC_MODE0_INTFLAG   (*(__IO uint16_t*)0x4000240CU) /**< (RTC) MODE0 Interrupt Flag Status and Clear */
+#define REG_RTC_MODE0_SYNCBUSY  (*(__I  uint32_t*)0x40002410U) /**< (RTC) MODE0 Synchronization Busy Status */
+#define REG_RTC_MODE0_COUNT     (*(__IO uint32_t*)0x40002418U) /**< (RTC) MODE0 Counter Value */
+#define REG_RTC_MODE0_COMP      (*(__IO uint32_t*)0x40002420U) /**< (RTC) MODE0 Compare n Value */
+#define REG_RTC_MODE0_COMP0     (*(__IO uint32_t*)0x40002420U) /**< (RTC) MODE0 Compare 0 Value */
+#define REG_RTC_MODE0_TIMESTAMP (*(__I  uint32_t*)0x40002464U) /**< (RTC) MODE0 Timestamp */
+#define REG_RTC_MODE1_CTRLA     (*(__IO uint16_t*)0x40002400U) /**< (RTC) MODE1 Control A */
+#define REG_RTC_MODE1_CTRLB     (*(__IO uint16_t*)0x40002402U) /**< (RTC) MODE1 Control B */
+#define REG_RTC_MODE1_EVCTRL    (*(__IO uint32_t*)0x40002404U) /**< (RTC) MODE1 Event Control */
+#define REG_RTC_MODE1_INTENCLR  (*(__IO uint16_t*)0x40002408U) /**< (RTC) MODE1 Interrupt Enable Clear */
+#define REG_RTC_MODE1_INTENSET  (*(__IO uint16_t*)0x4000240AU) /**< (RTC) MODE1 Interrupt Enable Set */
+#define REG_RTC_MODE1_INTFLAG   (*(__IO uint16_t*)0x4000240CU) /**< (RTC) MODE1 Interrupt Flag Status and Clear */
+#define REG_RTC_MODE1_SYNCBUSY  (*(__I  uint32_t*)0x40002410U) /**< (RTC) MODE1 Synchronization Busy Status */
+#define REG_RTC_MODE1_COUNT     (*(__IO uint16_t*)0x40002418U) /**< (RTC) MODE1 Counter Value */
+#define REG_RTC_MODE1_PER       (*(__IO uint16_t*)0x4000241CU) /**< (RTC) MODE1 Counter Period */
+#define REG_RTC_MODE1_COMP      (*(__IO uint16_t*)0x40002420U) /**< (RTC) MODE1 Compare n Value */
+#define REG_RTC_MODE1_COMP0     (*(__IO uint16_t*)0x40002420U) /**< (RTC) MODE1 Compare 0 Value */
+#define REG_RTC_MODE1_COMP1     (*(__IO uint16_t*)0x40002422U) /**< (RTC) MODE1 Compare 1 Value */
+#define REG_RTC_MODE1_TIMESTAMP (*(__I  uint32_t*)0x40002464U) /**< (RTC) MODE1 Timestamp */
+#define REG_RTC_MODE2_ALARM0    (*(__IO uint32_t*)0x40002420U) /**< (RTC) MODE2_ALARM Alarm 0 Value */
+#define REG_RTC_MODE2_MASK0     (*(__IO uint8_t*)0x40002424U) /**< (RTC) MODE2_ALARM Alarm 0 Mask */
+#define REG_RTC_MODE2_CTRLA     (*(__IO uint16_t*)0x40002400U) /**< (RTC) MODE2 Control A */
+#define REG_RTC_MODE2_CTRLB     (*(__IO uint16_t*)0x40002402U) /**< (RTC) MODE2 Control B */
+#define REG_RTC_MODE2_EVCTRL    (*(__IO uint32_t*)0x40002404U) /**< (RTC) MODE2 Event Control */
+#define REG_RTC_MODE2_INTENCLR  (*(__IO uint16_t*)0x40002408U) /**< (RTC) MODE2 Interrupt Enable Clear */
+#define REG_RTC_MODE2_INTENSET  (*(__IO uint16_t*)0x4000240AU) /**< (RTC) MODE2 Interrupt Enable Set */
+#define REG_RTC_MODE2_INTFLAG   (*(__IO uint16_t*)0x4000240CU) /**< (RTC) MODE2 Interrupt Flag Status and Clear */
+#define REG_RTC_MODE2_SYNCBUSY  (*(__I  uint32_t*)0x40002410U) /**< (RTC) MODE2 Synchronization Busy Status */
+#define REG_RTC_MODE2_CLOCK     (*(__IO uint32_t*)0x40002418U) /**< (RTC) MODE2 Clock Value */
+#define REG_RTC_MODE2_TIMESTAMP (*(__I  uint32_t*)0x40002464U) /**< (RTC) MODE2 Timestamp */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for RTC peripheral ========== */
+#define RTC_DMAC_ID_TIMESTAMP                    1          /* DMA RTC timestamp trigger */
+#define RTC_GPR_NUM                              2          /* Number of General-Purpose Registers */
+#define RTC_NUM_OF_ALARMS                        1          /* Number of Alarms */
+#define RTC_NUM_OF_BKREGS                        0          /* Number of Backup Registers */
+#define RTC_NUM_OF_COMP16                        2          /* Number of 16-bit Comparators */
+#define RTC_NUM_OF_COMP32                        1          /* Number of 32-bit Comparators */
+#define RTC_NUM_OF_TAMPERS                       4          /* Number of Tamper Inputs */
+#define RTC_PER_NUM                              8          /* Number of Periodic Intervals */
+#define RTC_INSTANCE_ID                          9          
+
+#endif /* _SAML10_RTC_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/instance/sercom0.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/instance/sercom0.h
@@ -1,0 +1,150 @@
+/**
+ * \file
+ *
+ * \brief Instance description for SERCOM0
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_SERCOM0_INSTANCE_H_
+#define _SAML10_SERCOM0_INSTANCE_H_
+
+/* ========== Register definition for SERCOM0 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_SERCOM0_I2CM_CTRLA  (0x42000400) /**< (SERCOM0) I2CM Control A */
+#define REG_SERCOM0_I2CM_CTRLB  (0x42000404) /**< (SERCOM0) I2CM Control B */
+#define REG_SERCOM0_I2CM_BAUD   (0x4200040C) /**< (SERCOM0) I2CM Baud Rate */
+#define REG_SERCOM0_I2CM_INTENCLR (0x42000414) /**< (SERCOM0) I2CM Interrupt Enable Clear */
+#define REG_SERCOM0_I2CM_INTENSET (0x42000416) /**< (SERCOM0) I2CM Interrupt Enable Set */
+#define REG_SERCOM0_I2CM_INTFLAG (0x42000418) /**< (SERCOM0) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM0_I2CM_STATUS (0x4200041A) /**< (SERCOM0) I2CM Status */
+#define REG_SERCOM0_I2CM_SYNCBUSY (0x4200041C) /**< (SERCOM0) I2CM Synchronization Busy */
+#define REG_SERCOM0_I2CM_ADDR   (0x42000424) /**< (SERCOM0) I2CM Address */
+#define REG_SERCOM0_I2CM_DATA   (0x42000428) /**< (SERCOM0) I2CM Data */
+#define REG_SERCOM0_I2CM_DBGCTRL (0x42000430) /**< (SERCOM0) I2CM Debug Control */
+#define REG_SERCOM0_I2CS_CTRLA  (0x42000400) /**< (SERCOM0) I2CS Control A */
+#define REG_SERCOM0_I2CS_CTRLB  (0x42000404) /**< (SERCOM0) I2CS Control B */
+#define REG_SERCOM0_I2CS_INTENCLR (0x42000414) /**< (SERCOM0) I2CS Interrupt Enable Clear */
+#define REG_SERCOM0_I2CS_INTENSET (0x42000416) /**< (SERCOM0) I2CS Interrupt Enable Set */
+#define REG_SERCOM0_I2CS_INTFLAG (0x42000418) /**< (SERCOM0) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM0_I2CS_STATUS (0x4200041A) /**< (SERCOM0) I2CS Status */
+#define REG_SERCOM0_I2CS_SYNCBUSY (0x4200041C) /**< (SERCOM0) I2CS Synchronization Busy */
+#define REG_SERCOM0_I2CS_ADDR   (0x42000424) /**< (SERCOM0) I2CS Address */
+#define REG_SERCOM0_I2CS_DATA   (0x42000428) /**< (SERCOM0) I2CS Data */
+#define REG_SERCOM0_SPI_CTRLA   (0x42000400) /**< (SERCOM0) SPI Control A */
+#define REG_SERCOM0_SPI_CTRLB   (0x42000404) /**< (SERCOM0) SPI Control B */
+#define REG_SERCOM0_SPI_BAUD    (0x4200040C) /**< (SERCOM0) SPI Baud Rate */
+#define REG_SERCOM0_SPI_INTENCLR (0x42000414) /**< (SERCOM0) SPI Interrupt Enable Clear */
+#define REG_SERCOM0_SPI_INTENSET (0x42000416) /**< (SERCOM0) SPI Interrupt Enable Set */
+#define REG_SERCOM0_SPI_INTFLAG (0x42000418) /**< (SERCOM0) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM0_SPI_STATUS  (0x4200041A) /**< (SERCOM0) SPI Status */
+#define REG_SERCOM0_SPI_SYNCBUSY (0x4200041C) /**< (SERCOM0) SPI Synchronization Busy */
+#define REG_SERCOM0_SPI_ADDR    (0x42000424) /**< (SERCOM0) SPI Address */
+#define REG_SERCOM0_SPI_DATA    (0x42000428) /**< (SERCOM0) SPI Data */
+#define REG_SERCOM0_SPI_DBGCTRL (0x42000430) /**< (SERCOM0) SPI Debug Control */
+#define REG_SERCOM0_USART_CTRLA (0x42000400) /**< (SERCOM0) USART Control A */
+#define REG_SERCOM0_USART_CTRLB (0x42000404) /**< (SERCOM0) USART Control B */
+#define REG_SERCOM0_USART_CTRLC (0x42000408) /**< (SERCOM0) USART Control C */
+#define REG_SERCOM0_USART_BAUD  (0x4200040C) /**< (SERCOM0) USART Baud Rate */
+#define REG_SERCOM0_USART_RXPL  (0x4200040E) /**< (SERCOM0) USART Receive Pulse Length */
+#define REG_SERCOM0_USART_INTENCLR (0x42000414) /**< (SERCOM0) USART Interrupt Enable Clear */
+#define REG_SERCOM0_USART_INTENSET (0x42000416) /**< (SERCOM0) USART Interrupt Enable Set */
+#define REG_SERCOM0_USART_INTFLAG (0x42000418) /**< (SERCOM0) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM0_USART_STATUS (0x4200041A) /**< (SERCOM0) USART Status */
+#define REG_SERCOM0_USART_SYNCBUSY (0x4200041C) /**< (SERCOM0) USART Synchronization Busy */
+#define REG_SERCOM0_USART_RXERRCNT (0x42000420) /**< (SERCOM0) USART Receive Error Count */
+#define REG_SERCOM0_USART_DATA  (0x42000428) /**< (SERCOM0) USART Data */
+#define REG_SERCOM0_USART_DBGCTRL (0x42000430) /**< (SERCOM0) USART Debug Control */
+
+#else
+
+#define REG_SERCOM0_I2CM_CTRLA  (*(__IO uint32_t*)0x42000400U) /**< (SERCOM0) I2CM Control A */
+#define REG_SERCOM0_I2CM_CTRLB  (*(__IO uint32_t*)0x42000404U) /**< (SERCOM0) I2CM Control B */
+#define REG_SERCOM0_I2CM_BAUD   (*(__IO uint32_t*)0x4200040CU) /**< (SERCOM0) I2CM Baud Rate */
+#define REG_SERCOM0_I2CM_INTENCLR (*(__IO uint8_t*)0x42000414U) /**< (SERCOM0) I2CM Interrupt Enable Clear */
+#define REG_SERCOM0_I2CM_INTENSET (*(__IO uint8_t*)0x42000416U) /**< (SERCOM0) I2CM Interrupt Enable Set */
+#define REG_SERCOM0_I2CM_INTFLAG (*(__IO uint8_t*)0x42000418U) /**< (SERCOM0) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM0_I2CM_STATUS (*(__IO uint16_t*)0x4200041AU) /**< (SERCOM0) I2CM Status */
+#define REG_SERCOM0_I2CM_SYNCBUSY (*(__I  uint32_t*)0x4200041CU) /**< (SERCOM0) I2CM Synchronization Busy */
+#define REG_SERCOM0_I2CM_ADDR   (*(__IO uint32_t*)0x42000424U) /**< (SERCOM0) I2CM Address */
+#define REG_SERCOM0_I2CM_DATA   (*(__IO uint8_t*)0x42000428U) /**< (SERCOM0) I2CM Data */
+#define REG_SERCOM0_I2CM_DBGCTRL (*(__IO uint8_t*)0x42000430U) /**< (SERCOM0) I2CM Debug Control */
+#define REG_SERCOM0_I2CS_CTRLA  (*(__IO uint32_t*)0x42000400U) /**< (SERCOM0) I2CS Control A */
+#define REG_SERCOM0_I2CS_CTRLB  (*(__IO uint32_t*)0x42000404U) /**< (SERCOM0) I2CS Control B */
+#define REG_SERCOM0_I2CS_INTENCLR (*(__IO uint8_t*)0x42000414U) /**< (SERCOM0) I2CS Interrupt Enable Clear */
+#define REG_SERCOM0_I2CS_INTENSET (*(__IO uint8_t*)0x42000416U) /**< (SERCOM0) I2CS Interrupt Enable Set */
+#define REG_SERCOM0_I2CS_INTFLAG (*(__IO uint8_t*)0x42000418U) /**< (SERCOM0) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM0_I2CS_STATUS (*(__IO uint16_t*)0x4200041AU) /**< (SERCOM0) I2CS Status */
+#define REG_SERCOM0_I2CS_SYNCBUSY (*(__I  uint32_t*)0x4200041CU) /**< (SERCOM0) I2CS Synchronization Busy */
+#define REG_SERCOM0_I2CS_ADDR   (*(__IO uint32_t*)0x42000424U) /**< (SERCOM0) I2CS Address */
+#define REG_SERCOM0_I2CS_DATA   (*(__IO uint8_t*)0x42000428U) /**< (SERCOM0) I2CS Data */
+#define REG_SERCOM0_SPI_CTRLA   (*(__IO uint32_t*)0x42000400U) /**< (SERCOM0) SPI Control A */
+#define REG_SERCOM0_SPI_CTRLB   (*(__IO uint32_t*)0x42000404U) /**< (SERCOM0) SPI Control B */
+#define REG_SERCOM0_SPI_BAUD    (*(__IO uint8_t*)0x4200040CU) /**< (SERCOM0) SPI Baud Rate */
+#define REG_SERCOM0_SPI_INTENCLR (*(__IO uint8_t*)0x42000414U) /**< (SERCOM0) SPI Interrupt Enable Clear */
+#define REG_SERCOM0_SPI_INTENSET (*(__IO uint8_t*)0x42000416U) /**< (SERCOM0) SPI Interrupt Enable Set */
+#define REG_SERCOM0_SPI_INTFLAG (*(__IO uint8_t*)0x42000418U) /**< (SERCOM0) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM0_SPI_STATUS  (*(__IO uint16_t*)0x4200041AU) /**< (SERCOM0) SPI Status */
+#define REG_SERCOM0_SPI_SYNCBUSY (*(__I  uint32_t*)0x4200041CU) /**< (SERCOM0) SPI Synchronization Busy */
+#define REG_SERCOM0_SPI_ADDR    (*(__IO uint32_t*)0x42000424U) /**< (SERCOM0) SPI Address */
+#define REG_SERCOM0_SPI_DATA    (*(__IO uint32_t*)0x42000428U) /**< (SERCOM0) SPI Data */
+#define REG_SERCOM0_SPI_DBGCTRL (*(__IO uint8_t*)0x42000430U) /**< (SERCOM0) SPI Debug Control */
+#define REG_SERCOM0_USART_CTRLA (*(__IO uint32_t*)0x42000400U) /**< (SERCOM0) USART Control A */
+#define REG_SERCOM0_USART_CTRLB (*(__IO uint32_t*)0x42000404U) /**< (SERCOM0) USART Control B */
+#define REG_SERCOM0_USART_CTRLC (*(__IO uint32_t*)0x42000408U) /**< (SERCOM0) USART Control C */
+#define REG_SERCOM0_USART_BAUD  (*(__IO uint16_t*)0x4200040CU) /**< (SERCOM0) USART Baud Rate */
+#define REG_SERCOM0_USART_RXPL  (*(__IO uint8_t*)0x4200040EU) /**< (SERCOM0) USART Receive Pulse Length */
+#define REG_SERCOM0_USART_INTENCLR (*(__IO uint8_t*)0x42000414U) /**< (SERCOM0) USART Interrupt Enable Clear */
+#define REG_SERCOM0_USART_INTENSET (*(__IO uint8_t*)0x42000416U) /**< (SERCOM0) USART Interrupt Enable Set */
+#define REG_SERCOM0_USART_INTFLAG (*(__IO uint8_t*)0x42000418U) /**< (SERCOM0) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM0_USART_STATUS (*(__IO uint16_t*)0x4200041AU) /**< (SERCOM0) USART Status */
+#define REG_SERCOM0_USART_SYNCBUSY (*(__I  uint32_t*)0x4200041CU) /**< (SERCOM0) USART Synchronization Busy */
+#define REG_SERCOM0_USART_RXERRCNT (*(__I  uint8_t*)0x42000420U) /**< (SERCOM0) USART Receive Error Count */
+#define REG_SERCOM0_USART_DATA  (*(__IO uint16_t*)0x42000428U) /**< (SERCOM0) USART Data */
+#define REG_SERCOM0_USART_DBGCTRL (*(__IO uint8_t*)0x42000430U) /**< (SERCOM0) USART Debug Control */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for SERCOM0 peripheral ========== */
+#define SERCOM0_DMAC_ID_RX                       4          /* Index of DMA RX trigger */
+#define SERCOM0_DMAC_ID_TX                       5          /* Index of DMA TX trigger */
+#define SERCOM0_FIFO_DEPTH_POWER                 1          /* Rx Fifo depth = 2^FIFO_DEPTH_POWER */
+#define SERCOM0_GCLK_ID_CORE                     11         
+#define SERCOM0_GCLK_ID_SLOW                     10         
+#define SERCOM0_INT_MSB                          6          
+#define SERCOM0_PMSB                             3          
+#define SERCOM0_SPI                              1          /* SPI mode implemented? */
+#define SERCOM0_TWIM                             1          /* TWI Master mode implemented? */
+#define SERCOM0_TWIS                             1          /* TWI Slave mode implemented? */
+#define SERCOM0_TWI_HSMODE                       1          /* TWI HighSpeed mode implemented? */
+#define SERCOM0_USART                            1          /* USART mode implemented? */
+#define SERCOM0_USART_AUTOBAUD                   0          /* USART AUTOBAUD mode implemented? */
+#define SERCOM0_USART_ISO7816                    0          /* USART ISO7816 mode implemented? */
+#define SERCOM0_USART_LIN_MASTER                 0          /* USART LIN Master mode implemented? */
+#define SERCOM0_USART_RS485                      0          /* USART RS485 mode implemented? */
+#define SERCOM0_INSTANCE_ID                      65         
+
+#endif /* _SAML10_SERCOM0_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/instance/sercom1.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/instance/sercom1.h
@@ -1,0 +1,150 @@
+/**
+ * \file
+ *
+ * \brief Instance description for SERCOM1
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_SERCOM1_INSTANCE_H_
+#define _SAML10_SERCOM1_INSTANCE_H_
+
+/* ========== Register definition for SERCOM1 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_SERCOM1_I2CM_CTRLA  (0x42000800) /**< (SERCOM1) I2CM Control A */
+#define REG_SERCOM1_I2CM_CTRLB  (0x42000804) /**< (SERCOM1) I2CM Control B */
+#define REG_SERCOM1_I2CM_BAUD   (0x4200080C) /**< (SERCOM1) I2CM Baud Rate */
+#define REG_SERCOM1_I2CM_INTENCLR (0x42000814) /**< (SERCOM1) I2CM Interrupt Enable Clear */
+#define REG_SERCOM1_I2CM_INTENSET (0x42000816) /**< (SERCOM1) I2CM Interrupt Enable Set */
+#define REG_SERCOM1_I2CM_INTFLAG (0x42000818) /**< (SERCOM1) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM1_I2CM_STATUS (0x4200081A) /**< (SERCOM1) I2CM Status */
+#define REG_SERCOM1_I2CM_SYNCBUSY (0x4200081C) /**< (SERCOM1) I2CM Synchronization Busy */
+#define REG_SERCOM1_I2CM_ADDR   (0x42000824) /**< (SERCOM1) I2CM Address */
+#define REG_SERCOM1_I2CM_DATA   (0x42000828) /**< (SERCOM1) I2CM Data */
+#define REG_SERCOM1_I2CM_DBGCTRL (0x42000830) /**< (SERCOM1) I2CM Debug Control */
+#define REG_SERCOM1_I2CS_CTRLA  (0x42000800) /**< (SERCOM1) I2CS Control A */
+#define REG_SERCOM1_I2CS_CTRLB  (0x42000804) /**< (SERCOM1) I2CS Control B */
+#define REG_SERCOM1_I2CS_INTENCLR (0x42000814) /**< (SERCOM1) I2CS Interrupt Enable Clear */
+#define REG_SERCOM1_I2CS_INTENSET (0x42000816) /**< (SERCOM1) I2CS Interrupt Enable Set */
+#define REG_SERCOM1_I2CS_INTFLAG (0x42000818) /**< (SERCOM1) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM1_I2CS_STATUS (0x4200081A) /**< (SERCOM1) I2CS Status */
+#define REG_SERCOM1_I2CS_SYNCBUSY (0x4200081C) /**< (SERCOM1) I2CS Synchronization Busy */
+#define REG_SERCOM1_I2CS_ADDR   (0x42000824) /**< (SERCOM1) I2CS Address */
+#define REG_SERCOM1_I2CS_DATA   (0x42000828) /**< (SERCOM1) I2CS Data */
+#define REG_SERCOM1_SPI_CTRLA   (0x42000800) /**< (SERCOM1) SPI Control A */
+#define REG_SERCOM1_SPI_CTRLB   (0x42000804) /**< (SERCOM1) SPI Control B */
+#define REG_SERCOM1_SPI_BAUD    (0x4200080C) /**< (SERCOM1) SPI Baud Rate */
+#define REG_SERCOM1_SPI_INTENCLR (0x42000814) /**< (SERCOM1) SPI Interrupt Enable Clear */
+#define REG_SERCOM1_SPI_INTENSET (0x42000816) /**< (SERCOM1) SPI Interrupt Enable Set */
+#define REG_SERCOM1_SPI_INTFLAG (0x42000818) /**< (SERCOM1) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM1_SPI_STATUS  (0x4200081A) /**< (SERCOM1) SPI Status */
+#define REG_SERCOM1_SPI_SYNCBUSY (0x4200081C) /**< (SERCOM1) SPI Synchronization Busy */
+#define REG_SERCOM1_SPI_ADDR    (0x42000824) /**< (SERCOM1) SPI Address */
+#define REG_SERCOM1_SPI_DATA    (0x42000828) /**< (SERCOM1) SPI Data */
+#define REG_SERCOM1_SPI_DBGCTRL (0x42000830) /**< (SERCOM1) SPI Debug Control */
+#define REG_SERCOM1_USART_CTRLA (0x42000800) /**< (SERCOM1) USART Control A */
+#define REG_SERCOM1_USART_CTRLB (0x42000804) /**< (SERCOM1) USART Control B */
+#define REG_SERCOM1_USART_CTRLC (0x42000808) /**< (SERCOM1) USART Control C */
+#define REG_SERCOM1_USART_BAUD  (0x4200080C) /**< (SERCOM1) USART Baud Rate */
+#define REG_SERCOM1_USART_RXPL  (0x4200080E) /**< (SERCOM1) USART Receive Pulse Length */
+#define REG_SERCOM1_USART_INTENCLR (0x42000814) /**< (SERCOM1) USART Interrupt Enable Clear */
+#define REG_SERCOM1_USART_INTENSET (0x42000816) /**< (SERCOM1) USART Interrupt Enable Set */
+#define REG_SERCOM1_USART_INTFLAG (0x42000818) /**< (SERCOM1) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM1_USART_STATUS (0x4200081A) /**< (SERCOM1) USART Status */
+#define REG_SERCOM1_USART_SYNCBUSY (0x4200081C) /**< (SERCOM1) USART Synchronization Busy */
+#define REG_SERCOM1_USART_RXERRCNT (0x42000820) /**< (SERCOM1) USART Receive Error Count */
+#define REG_SERCOM1_USART_DATA  (0x42000828) /**< (SERCOM1) USART Data */
+#define REG_SERCOM1_USART_DBGCTRL (0x42000830) /**< (SERCOM1) USART Debug Control */
+
+#else
+
+#define REG_SERCOM1_I2CM_CTRLA  (*(__IO uint32_t*)0x42000800U) /**< (SERCOM1) I2CM Control A */
+#define REG_SERCOM1_I2CM_CTRLB  (*(__IO uint32_t*)0x42000804U) /**< (SERCOM1) I2CM Control B */
+#define REG_SERCOM1_I2CM_BAUD   (*(__IO uint32_t*)0x4200080CU) /**< (SERCOM1) I2CM Baud Rate */
+#define REG_SERCOM1_I2CM_INTENCLR (*(__IO uint8_t*)0x42000814U) /**< (SERCOM1) I2CM Interrupt Enable Clear */
+#define REG_SERCOM1_I2CM_INTENSET (*(__IO uint8_t*)0x42000816U) /**< (SERCOM1) I2CM Interrupt Enable Set */
+#define REG_SERCOM1_I2CM_INTFLAG (*(__IO uint8_t*)0x42000818U) /**< (SERCOM1) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM1_I2CM_STATUS (*(__IO uint16_t*)0x4200081AU) /**< (SERCOM1) I2CM Status */
+#define REG_SERCOM1_I2CM_SYNCBUSY (*(__I  uint32_t*)0x4200081CU) /**< (SERCOM1) I2CM Synchronization Busy */
+#define REG_SERCOM1_I2CM_ADDR   (*(__IO uint32_t*)0x42000824U) /**< (SERCOM1) I2CM Address */
+#define REG_SERCOM1_I2CM_DATA   (*(__IO uint8_t*)0x42000828U) /**< (SERCOM1) I2CM Data */
+#define REG_SERCOM1_I2CM_DBGCTRL (*(__IO uint8_t*)0x42000830U) /**< (SERCOM1) I2CM Debug Control */
+#define REG_SERCOM1_I2CS_CTRLA  (*(__IO uint32_t*)0x42000800U) /**< (SERCOM1) I2CS Control A */
+#define REG_SERCOM1_I2CS_CTRLB  (*(__IO uint32_t*)0x42000804U) /**< (SERCOM1) I2CS Control B */
+#define REG_SERCOM1_I2CS_INTENCLR (*(__IO uint8_t*)0x42000814U) /**< (SERCOM1) I2CS Interrupt Enable Clear */
+#define REG_SERCOM1_I2CS_INTENSET (*(__IO uint8_t*)0x42000816U) /**< (SERCOM1) I2CS Interrupt Enable Set */
+#define REG_SERCOM1_I2CS_INTFLAG (*(__IO uint8_t*)0x42000818U) /**< (SERCOM1) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM1_I2CS_STATUS (*(__IO uint16_t*)0x4200081AU) /**< (SERCOM1) I2CS Status */
+#define REG_SERCOM1_I2CS_SYNCBUSY (*(__I  uint32_t*)0x4200081CU) /**< (SERCOM1) I2CS Synchronization Busy */
+#define REG_SERCOM1_I2CS_ADDR   (*(__IO uint32_t*)0x42000824U) /**< (SERCOM1) I2CS Address */
+#define REG_SERCOM1_I2CS_DATA   (*(__IO uint8_t*)0x42000828U) /**< (SERCOM1) I2CS Data */
+#define REG_SERCOM1_SPI_CTRLA   (*(__IO uint32_t*)0x42000800U) /**< (SERCOM1) SPI Control A */
+#define REG_SERCOM1_SPI_CTRLB   (*(__IO uint32_t*)0x42000804U) /**< (SERCOM1) SPI Control B */
+#define REG_SERCOM1_SPI_BAUD    (*(__IO uint8_t*)0x4200080CU) /**< (SERCOM1) SPI Baud Rate */
+#define REG_SERCOM1_SPI_INTENCLR (*(__IO uint8_t*)0x42000814U) /**< (SERCOM1) SPI Interrupt Enable Clear */
+#define REG_SERCOM1_SPI_INTENSET (*(__IO uint8_t*)0x42000816U) /**< (SERCOM1) SPI Interrupt Enable Set */
+#define REG_SERCOM1_SPI_INTFLAG (*(__IO uint8_t*)0x42000818U) /**< (SERCOM1) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM1_SPI_STATUS  (*(__IO uint16_t*)0x4200081AU) /**< (SERCOM1) SPI Status */
+#define REG_SERCOM1_SPI_SYNCBUSY (*(__I  uint32_t*)0x4200081CU) /**< (SERCOM1) SPI Synchronization Busy */
+#define REG_SERCOM1_SPI_ADDR    (*(__IO uint32_t*)0x42000824U) /**< (SERCOM1) SPI Address */
+#define REG_SERCOM1_SPI_DATA    (*(__IO uint32_t*)0x42000828U) /**< (SERCOM1) SPI Data */
+#define REG_SERCOM1_SPI_DBGCTRL (*(__IO uint8_t*)0x42000830U) /**< (SERCOM1) SPI Debug Control */
+#define REG_SERCOM1_USART_CTRLA (*(__IO uint32_t*)0x42000800U) /**< (SERCOM1) USART Control A */
+#define REG_SERCOM1_USART_CTRLB (*(__IO uint32_t*)0x42000804U) /**< (SERCOM1) USART Control B */
+#define REG_SERCOM1_USART_CTRLC (*(__IO uint32_t*)0x42000808U) /**< (SERCOM1) USART Control C */
+#define REG_SERCOM1_USART_BAUD  (*(__IO uint16_t*)0x4200080CU) /**< (SERCOM1) USART Baud Rate */
+#define REG_SERCOM1_USART_RXPL  (*(__IO uint8_t*)0x4200080EU) /**< (SERCOM1) USART Receive Pulse Length */
+#define REG_SERCOM1_USART_INTENCLR (*(__IO uint8_t*)0x42000814U) /**< (SERCOM1) USART Interrupt Enable Clear */
+#define REG_SERCOM1_USART_INTENSET (*(__IO uint8_t*)0x42000816U) /**< (SERCOM1) USART Interrupt Enable Set */
+#define REG_SERCOM1_USART_INTFLAG (*(__IO uint8_t*)0x42000818U) /**< (SERCOM1) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM1_USART_STATUS (*(__IO uint16_t*)0x4200081AU) /**< (SERCOM1) USART Status */
+#define REG_SERCOM1_USART_SYNCBUSY (*(__I  uint32_t*)0x4200081CU) /**< (SERCOM1) USART Synchronization Busy */
+#define REG_SERCOM1_USART_RXERRCNT (*(__I  uint8_t*)0x42000820U) /**< (SERCOM1) USART Receive Error Count */
+#define REG_SERCOM1_USART_DATA  (*(__IO uint16_t*)0x42000828U) /**< (SERCOM1) USART Data */
+#define REG_SERCOM1_USART_DBGCTRL (*(__IO uint8_t*)0x42000830U) /**< (SERCOM1) USART Debug Control */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for SERCOM1 peripheral ========== */
+#define SERCOM1_DMAC_ID_RX                       6          /* Index of DMA RX trigger */
+#define SERCOM1_DMAC_ID_TX                       7          /* Index of DMA TX trigger */
+#define SERCOM1_FIFO_DEPTH_POWER                 2          /* Rx Fifo depth = 2^FIFO_DEPTH_POWER */
+#define SERCOM1_GCLK_ID_CORE                     12         
+#define SERCOM1_GCLK_ID_SLOW                     10         
+#define SERCOM1_INT_MSB                          6          
+#define SERCOM1_PMSB                             3          
+#define SERCOM1_SPI                              1          /* SPI mode implemented? */
+#define SERCOM1_TWIM                             1          /* TWI Master mode implemented? */
+#define SERCOM1_TWIS                             1          /* TWI Slave mode implemented? */
+#define SERCOM1_TWI_HSMODE                       0          /* TWI HighSpeed mode implemented? */
+#define SERCOM1_USART                            1          /* USART mode implemented? */
+#define SERCOM1_USART_AUTOBAUD                   0          /* USART AUTOBAUD mode implemented? */
+#define SERCOM1_USART_ISO7816                    0          /* USART ISO7816 mode implemented? */
+#define SERCOM1_USART_LIN_MASTER                 0          /* USART LIN Master mode implemented? */
+#define SERCOM1_USART_RS485                      0          /* USART RS485 mode implemented? */
+#define SERCOM1_INSTANCE_ID                      66         
+
+#endif /* _SAML10_SERCOM1_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/instance/sercom2.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/instance/sercom2.h
@@ -1,0 +1,150 @@
+/**
+ * \file
+ *
+ * \brief Instance description for SERCOM2
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_SERCOM2_INSTANCE_H_
+#define _SAML10_SERCOM2_INSTANCE_H_
+
+/* ========== Register definition for SERCOM2 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_SERCOM2_I2CM_CTRLA  (0x42000C00) /**< (SERCOM2) I2CM Control A */
+#define REG_SERCOM2_I2CM_CTRLB  (0x42000C04) /**< (SERCOM2) I2CM Control B */
+#define REG_SERCOM2_I2CM_BAUD   (0x42000C0C) /**< (SERCOM2) I2CM Baud Rate */
+#define REG_SERCOM2_I2CM_INTENCLR (0x42000C14) /**< (SERCOM2) I2CM Interrupt Enable Clear */
+#define REG_SERCOM2_I2CM_INTENSET (0x42000C16) /**< (SERCOM2) I2CM Interrupt Enable Set */
+#define REG_SERCOM2_I2CM_INTFLAG (0x42000C18) /**< (SERCOM2) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM2_I2CM_STATUS (0x42000C1A) /**< (SERCOM2) I2CM Status */
+#define REG_SERCOM2_I2CM_SYNCBUSY (0x42000C1C) /**< (SERCOM2) I2CM Synchronization Busy */
+#define REG_SERCOM2_I2CM_ADDR   (0x42000C24) /**< (SERCOM2) I2CM Address */
+#define REG_SERCOM2_I2CM_DATA   (0x42000C28) /**< (SERCOM2) I2CM Data */
+#define REG_SERCOM2_I2CM_DBGCTRL (0x42000C30) /**< (SERCOM2) I2CM Debug Control */
+#define REG_SERCOM2_I2CS_CTRLA  (0x42000C00) /**< (SERCOM2) I2CS Control A */
+#define REG_SERCOM2_I2CS_CTRLB  (0x42000C04) /**< (SERCOM2) I2CS Control B */
+#define REG_SERCOM2_I2CS_INTENCLR (0x42000C14) /**< (SERCOM2) I2CS Interrupt Enable Clear */
+#define REG_SERCOM2_I2CS_INTENSET (0x42000C16) /**< (SERCOM2) I2CS Interrupt Enable Set */
+#define REG_SERCOM2_I2CS_INTFLAG (0x42000C18) /**< (SERCOM2) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM2_I2CS_STATUS (0x42000C1A) /**< (SERCOM2) I2CS Status */
+#define REG_SERCOM2_I2CS_SYNCBUSY (0x42000C1C) /**< (SERCOM2) I2CS Synchronization Busy */
+#define REG_SERCOM2_I2CS_ADDR   (0x42000C24) /**< (SERCOM2) I2CS Address */
+#define REG_SERCOM2_I2CS_DATA   (0x42000C28) /**< (SERCOM2) I2CS Data */
+#define REG_SERCOM2_SPI_CTRLA   (0x42000C00) /**< (SERCOM2) SPI Control A */
+#define REG_SERCOM2_SPI_CTRLB   (0x42000C04) /**< (SERCOM2) SPI Control B */
+#define REG_SERCOM2_SPI_BAUD    (0x42000C0C) /**< (SERCOM2) SPI Baud Rate */
+#define REG_SERCOM2_SPI_INTENCLR (0x42000C14) /**< (SERCOM2) SPI Interrupt Enable Clear */
+#define REG_SERCOM2_SPI_INTENSET (0x42000C16) /**< (SERCOM2) SPI Interrupt Enable Set */
+#define REG_SERCOM2_SPI_INTFLAG (0x42000C18) /**< (SERCOM2) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM2_SPI_STATUS  (0x42000C1A) /**< (SERCOM2) SPI Status */
+#define REG_SERCOM2_SPI_SYNCBUSY (0x42000C1C) /**< (SERCOM2) SPI Synchronization Busy */
+#define REG_SERCOM2_SPI_ADDR    (0x42000C24) /**< (SERCOM2) SPI Address */
+#define REG_SERCOM2_SPI_DATA    (0x42000C28) /**< (SERCOM2) SPI Data */
+#define REG_SERCOM2_SPI_DBGCTRL (0x42000C30) /**< (SERCOM2) SPI Debug Control */
+#define REG_SERCOM2_USART_CTRLA (0x42000C00) /**< (SERCOM2) USART Control A */
+#define REG_SERCOM2_USART_CTRLB (0x42000C04) /**< (SERCOM2) USART Control B */
+#define REG_SERCOM2_USART_CTRLC (0x42000C08) /**< (SERCOM2) USART Control C */
+#define REG_SERCOM2_USART_BAUD  (0x42000C0C) /**< (SERCOM2) USART Baud Rate */
+#define REG_SERCOM2_USART_RXPL  (0x42000C0E) /**< (SERCOM2) USART Receive Pulse Length */
+#define REG_SERCOM2_USART_INTENCLR (0x42000C14) /**< (SERCOM2) USART Interrupt Enable Clear */
+#define REG_SERCOM2_USART_INTENSET (0x42000C16) /**< (SERCOM2) USART Interrupt Enable Set */
+#define REG_SERCOM2_USART_INTFLAG (0x42000C18) /**< (SERCOM2) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM2_USART_STATUS (0x42000C1A) /**< (SERCOM2) USART Status */
+#define REG_SERCOM2_USART_SYNCBUSY (0x42000C1C) /**< (SERCOM2) USART Synchronization Busy */
+#define REG_SERCOM2_USART_RXERRCNT (0x42000C20) /**< (SERCOM2) USART Receive Error Count */
+#define REG_SERCOM2_USART_DATA  (0x42000C28) /**< (SERCOM2) USART Data */
+#define REG_SERCOM2_USART_DBGCTRL (0x42000C30) /**< (SERCOM2) USART Debug Control */
+
+#else
+
+#define REG_SERCOM2_I2CM_CTRLA  (*(__IO uint32_t*)0x42000C00U) /**< (SERCOM2) I2CM Control A */
+#define REG_SERCOM2_I2CM_CTRLB  (*(__IO uint32_t*)0x42000C04U) /**< (SERCOM2) I2CM Control B */
+#define REG_SERCOM2_I2CM_BAUD   (*(__IO uint32_t*)0x42000C0CU) /**< (SERCOM2) I2CM Baud Rate */
+#define REG_SERCOM2_I2CM_INTENCLR (*(__IO uint8_t*)0x42000C14U) /**< (SERCOM2) I2CM Interrupt Enable Clear */
+#define REG_SERCOM2_I2CM_INTENSET (*(__IO uint8_t*)0x42000C16U) /**< (SERCOM2) I2CM Interrupt Enable Set */
+#define REG_SERCOM2_I2CM_INTFLAG (*(__IO uint8_t*)0x42000C18U) /**< (SERCOM2) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM2_I2CM_STATUS (*(__IO uint16_t*)0x42000C1AU) /**< (SERCOM2) I2CM Status */
+#define REG_SERCOM2_I2CM_SYNCBUSY (*(__I  uint32_t*)0x42000C1CU) /**< (SERCOM2) I2CM Synchronization Busy */
+#define REG_SERCOM2_I2CM_ADDR   (*(__IO uint32_t*)0x42000C24U) /**< (SERCOM2) I2CM Address */
+#define REG_SERCOM2_I2CM_DATA   (*(__IO uint8_t*)0x42000C28U) /**< (SERCOM2) I2CM Data */
+#define REG_SERCOM2_I2CM_DBGCTRL (*(__IO uint8_t*)0x42000C30U) /**< (SERCOM2) I2CM Debug Control */
+#define REG_SERCOM2_I2CS_CTRLA  (*(__IO uint32_t*)0x42000C00U) /**< (SERCOM2) I2CS Control A */
+#define REG_SERCOM2_I2CS_CTRLB  (*(__IO uint32_t*)0x42000C04U) /**< (SERCOM2) I2CS Control B */
+#define REG_SERCOM2_I2CS_INTENCLR (*(__IO uint8_t*)0x42000C14U) /**< (SERCOM2) I2CS Interrupt Enable Clear */
+#define REG_SERCOM2_I2CS_INTENSET (*(__IO uint8_t*)0x42000C16U) /**< (SERCOM2) I2CS Interrupt Enable Set */
+#define REG_SERCOM2_I2CS_INTFLAG (*(__IO uint8_t*)0x42000C18U) /**< (SERCOM2) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM2_I2CS_STATUS (*(__IO uint16_t*)0x42000C1AU) /**< (SERCOM2) I2CS Status */
+#define REG_SERCOM2_I2CS_SYNCBUSY (*(__I  uint32_t*)0x42000C1CU) /**< (SERCOM2) I2CS Synchronization Busy */
+#define REG_SERCOM2_I2CS_ADDR   (*(__IO uint32_t*)0x42000C24U) /**< (SERCOM2) I2CS Address */
+#define REG_SERCOM2_I2CS_DATA   (*(__IO uint8_t*)0x42000C28U) /**< (SERCOM2) I2CS Data */
+#define REG_SERCOM2_SPI_CTRLA   (*(__IO uint32_t*)0x42000C00U) /**< (SERCOM2) SPI Control A */
+#define REG_SERCOM2_SPI_CTRLB   (*(__IO uint32_t*)0x42000C04U) /**< (SERCOM2) SPI Control B */
+#define REG_SERCOM2_SPI_BAUD    (*(__IO uint8_t*)0x42000C0CU) /**< (SERCOM2) SPI Baud Rate */
+#define REG_SERCOM2_SPI_INTENCLR (*(__IO uint8_t*)0x42000C14U) /**< (SERCOM2) SPI Interrupt Enable Clear */
+#define REG_SERCOM2_SPI_INTENSET (*(__IO uint8_t*)0x42000C16U) /**< (SERCOM2) SPI Interrupt Enable Set */
+#define REG_SERCOM2_SPI_INTFLAG (*(__IO uint8_t*)0x42000C18U) /**< (SERCOM2) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM2_SPI_STATUS  (*(__IO uint16_t*)0x42000C1AU) /**< (SERCOM2) SPI Status */
+#define REG_SERCOM2_SPI_SYNCBUSY (*(__I  uint32_t*)0x42000C1CU) /**< (SERCOM2) SPI Synchronization Busy */
+#define REG_SERCOM2_SPI_ADDR    (*(__IO uint32_t*)0x42000C24U) /**< (SERCOM2) SPI Address */
+#define REG_SERCOM2_SPI_DATA    (*(__IO uint32_t*)0x42000C28U) /**< (SERCOM2) SPI Data */
+#define REG_SERCOM2_SPI_DBGCTRL (*(__IO uint8_t*)0x42000C30U) /**< (SERCOM2) SPI Debug Control */
+#define REG_SERCOM2_USART_CTRLA (*(__IO uint32_t*)0x42000C00U) /**< (SERCOM2) USART Control A */
+#define REG_SERCOM2_USART_CTRLB (*(__IO uint32_t*)0x42000C04U) /**< (SERCOM2) USART Control B */
+#define REG_SERCOM2_USART_CTRLC (*(__IO uint32_t*)0x42000C08U) /**< (SERCOM2) USART Control C */
+#define REG_SERCOM2_USART_BAUD  (*(__IO uint16_t*)0x42000C0CU) /**< (SERCOM2) USART Baud Rate */
+#define REG_SERCOM2_USART_RXPL  (*(__IO uint8_t*)0x42000C0EU) /**< (SERCOM2) USART Receive Pulse Length */
+#define REG_SERCOM2_USART_INTENCLR (*(__IO uint8_t*)0x42000C14U) /**< (SERCOM2) USART Interrupt Enable Clear */
+#define REG_SERCOM2_USART_INTENSET (*(__IO uint8_t*)0x42000C16U) /**< (SERCOM2) USART Interrupt Enable Set */
+#define REG_SERCOM2_USART_INTFLAG (*(__IO uint8_t*)0x42000C18U) /**< (SERCOM2) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM2_USART_STATUS (*(__IO uint16_t*)0x42000C1AU) /**< (SERCOM2) USART Status */
+#define REG_SERCOM2_USART_SYNCBUSY (*(__I  uint32_t*)0x42000C1CU) /**< (SERCOM2) USART Synchronization Busy */
+#define REG_SERCOM2_USART_RXERRCNT (*(__I  uint8_t*)0x42000C20U) /**< (SERCOM2) USART Receive Error Count */
+#define REG_SERCOM2_USART_DATA  (*(__IO uint16_t*)0x42000C28U) /**< (SERCOM2) USART Data */
+#define REG_SERCOM2_USART_DBGCTRL (*(__IO uint8_t*)0x42000C30U) /**< (SERCOM2) USART Debug Control */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for SERCOM2 peripheral ========== */
+#define SERCOM2_DMAC_ID_RX                       8          /* Index of DMA RX trigger */
+#define SERCOM2_DMAC_ID_TX                       9          /* Index of DMA TX trigger */
+#define SERCOM2_FIFO_DEPTH_POWER                 1          /* Rx Fifo depth = 2^FIFO_DEPTH_POWER */
+#define SERCOM2_GCLK_ID_CORE                     13         
+#define SERCOM2_GCLK_ID_SLOW                     10         
+#define SERCOM2_INT_MSB                          6          
+#define SERCOM2_PMSB                             3          
+#define SERCOM2_SPI                              1          /* SPI mode implemented? */
+#define SERCOM2_TWIM                             0          /* TWI Master mode implemented? */
+#define SERCOM2_TWIS                             0          /* TWI Slave mode implemented? */
+#define SERCOM2_TWI_HSMODE                       0          /* TWI HighSpeed mode implemented? */
+#define SERCOM2_USART                            1          /* USART mode implemented? */
+#define SERCOM2_USART_AUTOBAUD                   1          /* USART AUTOBAUD mode implemented? */
+#define SERCOM2_USART_ISO7816                    1          /* USART ISO7816 mode implemented? */
+#define SERCOM2_USART_LIN_MASTER                 0          /* USART LIN Master mode implemented? */
+#define SERCOM2_USART_RS485                      1          /* USART RS485 mode implemented? */
+#define SERCOM2_INSTANCE_ID                      67         
+
+#endif /* _SAML10_SERCOM2_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/instance/supc.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/instance/supc.h
@@ -1,0 +1,68 @@
+/**
+ * \file
+ *
+ * \brief Instance description for SUPC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_SUPC_INSTANCE_H_
+#define _SAML10_SUPC_INSTANCE_H_
+
+/* ========== Register definition for SUPC peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_SUPC_INTENCLR       (0x40001800) /**< (SUPC) Interrupt Enable Clear */
+#define REG_SUPC_INTENSET       (0x40001804) /**< (SUPC) Interrupt Enable Set */
+#define REG_SUPC_INTFLAG        (0x40001808) /**< (SUPC) Interrupt Flag Status and Clear */
+#define REG_SUPC_STATUS         (0x4000180C) /**< (SUPC) Power and Clocks Status */
+#define REG_SUPC_BOD33          (0x40001810) /**< (SUPC) BOD33 Control */
+#define REG_SUPC_BOD12          (0x40001814) /**< (SUPC) BOD12 Control */
+#define REG_SUPC_VREG           (0x40001818) /**< (SUPC) VREG Control */
+#define REG_SUPC_VREF           (0x4000181C) /**< (SUPC) VREF Control */
+#define REG_SUPC_EVCTRL         (0x4000182C) /**< (SUPC) Event Control */
+#define REG_SUPC_VREGSUSP       (0x40001830) /**< (SUPC) VREG Suspend Control */
+
+#else
+
+#define REG_SUPC_INTENCLR       (*(__IO uint32_t*)0x40001800U) /**< (SUPC) Interrupt Enable Clear */
+#define REG_SUPC_INTENSET       (*(__IO uint32_t*)0x40001804U) /**< (SUPC) Interrupt Enable Set */
+#define REG_SUPC_INTFLAG        (*(__IO uint32_t*)0x40001808U) /**< (SUPC) Interrupt Flag Status and Clear */
+#define REG_SUPC_STATUS         (*(__I  uint32_t*)0x4000180CU) /**< (SUPC) Power and Clocks Status */
+#define REG_SUPC_BOD33          (*(__IO uint32_t*)0x40001810U) /**< (SUPC) BOD33 Control */
+#define REG_SUPC_BOD12          (*(__IO uint32_t*)0x40001814U) /**< (SUPC) BOD12 Control */
+#define REG_SUPC_VREG           (*(__IO uint32_t*)0x40001818U) /**< (SUPC) VREG Control */
+#define REG_SUPC_VREF           (*(__IO uint32_t*)0x4000181CU) /**< (SUPC) VREF Control */
+#define REG_SUPC_EVCTRL         (*(__IO uint32_t*)0x4000182CU) /**< (SUPC) Event Control */
+#define REG_SUPC_VREGSUSP       (*(__IO uint32_t*)0x40001830U) /**< (SUPC) VREG Suspend Control */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for SUPC peripheral ========== */
+#define SUPC_BOD12_CALIB_MSB                     5          
+#define SUPC_BOD33_CALIB_MSB                     5          
+#define SUPC_INSTANCE_ID                         6          
+
+#endif /* _SAML10_SUPC_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/instance/tc0.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/instance/tc0.h
@@ -1,0 +1,130 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TC0
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_TC0_INSTANCE_H_
+#define _SAML10_TC0_INSTANCE_H_
+
+/* ========== Register definition for TC0 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_TC0_CTRLA           (0x42001000) /**< (TC0) Control A */
+#define REG_TC0_CTRLBCLR        (0x42001004) /**< (TC0) Control B Clear */
+#define REG_TC0_CTRLBSET        (0x42001005) /**< (TC0) Control B Set */
+#define REG_TC0_EVCTRL          (0x42001006) /**< (TC0) Event Control */
+#define REG_TC0_INTENCLR        (0x42001008) /**< (TC0) Interrupt Enable Clear */
+#define REG_TC0_INTENSET        (0x42001009) /**< (TC0) Interrupt Enable Set */
+#define REG_TC0_INTFLAG         (0x4200100A) /**< (TC0) Interrupt Flag Status and Clear */
+#define REG_TC0_STATUS          (0x4200100B) /**< (TC0) Status */
+#define REG_TC0_WAVE            (0x4200100C) /**< (TC0) Waveform Generation Control */
+#define REG_TC0_DRVCTRL         (0x4200100D) /**< (TC0) Control C */
+#define REG_TC0_DBGCTRL         (0x4200100F) /**< (TC0) Debug Control */
+#define REG_TC0_SYNCBUSY        (0x42001010) /**< (TC0) Synchronization Status */
+#define REG_TC0_COUNT8_COUNT    (0x42001014) /**< (TC0) COUNT8 Count */
+#define REG_TC0_COUNT8_PER      (0x4200101B) /**< (TC0) COUNT8 Period */
+#define REG_TC0_COUNT8_CC       (0x4200101C) /**< (TC0) COUNT8 Compare and Capture */
+#define REG_TC0_COUNT8_CC0      (0x4200101C) /**< (TC0) COUNT8 Compare and Capture 0 */
+#define REG_TC0_COUNT8_CC1      (0x4200101D) /**< (TC0) COUNT8 Compare and Capture 1 */
+#define REG_TC0_COUNT8_PERBUF   (0x4200102F) /**< (TC0) COUNT8 Period Buffer */
+#define REG_TC0_COUNT8_CCBUF    (0x42001030) /**< (TC0) COUNT8 Compare and Capture Buffer */
+#define REG_TC0_COUNT8_CCBUF0   (0x42001030) /**< (TC0) COUNT8 Compare and Capture Buffer 0 */
+#define REG_TC0_COUNT8_CCBUF1   (0x42001031) /**< (TC0) COUNT8 Compare and Capture Buffer 1 */
+#define REG_TC0_COUNT16_COUNT   (0x42001014) /**< (TC0) COUNT16 Count */
+#define REG_TC0_COUNT16_PER     (0x4200101A) /**< (TC0) COUNT16 Period */
+#define REG_TC0_COUNT16_CC      (0x4200101C) /**< (TC0) COUNT16 Compare and Capture */
+#define REG_TC0_COUNT16_CC0     (0x4200101C) /**< (TC0) COUNT16 Compare and Capture 0 */
+#define REG_TC0_COUNT16_CC1     (0x4200101E) /**< (TC0) COUNT16 Compare and Capture 1 */
+#define REG_TC0_COUNT16_PERBUF  (0x4200102E) /**< (TC0) COUNT16 Period Buffer */
+#define REG_TC0_COUNT16_CCBUF   (0x42001030) /**< (TC0) COUNT16 Compare and Capture Buffer */
+#define REG_TC0_COUNT16_CCBUF0  (0x42001030) /**< (TC0) COUNT16 Compare and Capture Buffer 0 */
+#define REG_TC0_COUNT16_CCBUF1  (0x42001032) /**< (TC0) COUNT16 Compare and Capture Buffer 1 */
+#define REG_TC0_COUNT32_COUNT   (0x42001014) /**< (TC0) COUNT32 Count */
+#define REG_TC0_COUNT32_PER     (0x42001018) /**< (TC0) COUNT32 Period */
+#define REG_TC0_COUNT32_CC      (0x4200101C) /**< (TC0) COUNT32 Compare and Capture */
+#define REG_TC0_COUNT32_CC0     (0x4200101C) /**< (TC0) COUNT32 Compare and Capture 0 */
+#define REG_TC0_COUNT32_CC1     (0x42001020) /**< (TC0) COUNT32 Compare and Capture 1 */
+#define REG_TC0_COUNT32_PERBUF  (0x4200102C) /**< (TC0) COUNT32 Period Buffer */
+#define REG_TC0_COUNT32_CCBUF   (0x42001030) /**< (TC0) COUNT32 Compare and Capture Buffer */
+#define REG_TC0_COUNT32_CCBUF0  (0x42001030) /**< (TC0) COUNT32 Compare and Capture Buffer 0 */
+#define REG_TC0_COUNT32_CCBUF1  (0x42001034) /**< (TC0) COUNT32 Compare and Capture Buffer 1 */
+
+#else
+
+#define REG_TC0_CTRLA           (*(__IO uint32_t*)0x42001000U) /**< (TC0) Control A */
+#define REG_TC0_CTRLBCLR        (*(__IO uint8_t*)0x42001004U) /**< (TC0) Control B Clear */
+#define REG_TC0_CTRLBSET        (*(__IO uint8_t*)0x42001005U) /**< (TC0) Control B Set */
+#define REG_TC0_EVCTRL          (*(__IO uint16_t*)0x42001006U) /**< (TC0) Event Control */
+#define REG_TC0_INTENCLR        (*(__IO uint8_t*)0x42001008U) /**< (TC0) Interrupt Enable Clear */
+#define REG_TC0_INTENSET        (*(__IO uint8_t*)0x42001009U) /**< (TC0) Interrupt Enable Set */
+#define REG_TC0_INTFLAG         (*(__IO uint8_t*)0x4200100AU) /**< (TC0) Interrupt Flag Status and Clear */
+#define REG_TC0_STATUS          (*(__IO uint8_t*)0x4200100BU) /**< (TC0) Status */
+#define REG_TC0_WAVE            (*(__IO uint8_t*)0x4200100CU) /**< (TC0) Waveform Generation Control */
+#define REG_TC0_DRVCTRL         (*(__IO uint8_t*)0x4200100DU) /**< (TC0) Control C */
+#define REG_TC0_DBGCTRL         (*(__IO uint8_t*)0x4200100FU) /**< (TC0) Debug Control */
+#define REG_TC0_SYNCBUSY        (*(__I  uint32_t*)0x42001010U) /**< (TC0) Synchronization Status */
+#define REG_TC0_COUNT8_COUNT    (*(__IO uint8_t*)0x42001014U) /**< (TC0) COUNT8 Count */
+#define REG_TC0_COUNT8_PER      (*(__IO uint8_t*)0x4200101BU) /**< (TC0) COUNT8 Period */
+#define REG_TC0_COUNT8_CC       (*(__IO uint8_t*)0x4200101CU) /**< (TC0) COUNT8 Compare and Capture */
+#define REG_TC0_COUNT8_CC0      (*(__IO uint8_t*)0x4200101CU) /**< (TC0) COUNT8 Compare and Capture 0 */
+#define REG_TC0_COUNT8_CC1      (*(__IO uint8_t*)0x4200101DU) /**< (TC0) COUNT8 Compare and Capture 1 */
+#define REG_TC0_COUNT8_PERBUF   (*(__IO uint8_t*)0x4200102FU) /**< (TC0) COUNT8 Period Buffer */
+#define REG_TC0_COUNT8_CCBUF    (*(__IO uint8_t*)0x42001030U) /**< (TC0) COUNT8 Compare and Capture Buffer */
+#define REG_TC0_COUNT8_CCBUF0   (*(__IO uint8_t*)0x42001030U) /**< (TC0) COUNT8 Compare and Capture Buffer 0 */
+#define REG_TC0_COUNT8_CCBUF1   (*(__IO uint8_t*)0x42001031U) /**< (TC0) COUNT8 Compare and Capture Buffer 1 */
+#define REG_TC0_COUNT16_COUNT   (*(__IO uint16_t*)0x42001014U) /**< (TC0) COUNT16 Count */
+#define REG_TC0_COUNT16_PER     (*(__IO uint16_t*)0x4200101AU) /**< (TC0) COUNT16 Period */
+#define REG_TC0_COUNT16_CC      (*(__IO uint16_t*)0x4200101CU) /**< (TC0) COUNT16 Compare and Capture */
+#define REG_TC0_COUNT16_CC0     (*(__IO uint16_t*)0x4200101CU) /**< (TC0) COUNT16 Compare and Capture 0 */
+#define REG_TC0_COUNT16_CC1     (*(__IO uint16_t*)0x4200101EU) /**< (TC0) COUNT16 Compare and Capture 1 */
+#define REG_TC0_COUNT16_PERBUF  (*(__IO uint16_t*)0x4200102EU) /**< (TC0) COUNT16 Period Buffer */
+#define REG_TC0_COUNT16_CCBUF   (*(__IO uint16_t*)0x42001030U) /**< (TC0) COUNT16 Compare and Capture Buffer */
+#define REG_TC0_COUNT16_CCBUF0  (*(__IO uint16_t*)0x42001030U) /**< (TC0) COUNT16 Compare and Capture Buffer 0 */
+#define REG_TC0_COUNT16_CCBUF1  (*(__IO uint16_t*)0x42001032U) /**< (TC0) COUNT16 Compare and Capture Buffer 1 */
+#define REG_TC0_COUNT32_COUNT   (*(__IO uint32_t*)0x42001014U) /**< (TC0) COUNT32 Count */
+#define REG_TC0_COUNT32_PER     (*(__IO uint32_t*)0x42001018U) /**< (TC0) COUNT32 Period */
+#define REG_TC0_COUNT32_CC      (*(__IO uint32_t*)0x4200101CU) /**< (TC0) COUNT32 Compare and Capture */
+#define REG_TC0_COUNT32_CC0     (*(__IO uint32_t*)0x4200101CU) /**< (TC0) COUNT32 Compare and Capture 0 */
+#define REG_TC0_COUNT32_CC1     (*(__IO uint32_t*)0x42001020U) /**< (TC0) COUNT32 Compare and Capture 1 */
+#define REG_TC0_COUNT32_PERBUF  (*(__IO uint32_t*)0x4200102CU) /**< (TC0) COUNT32 Period Buffer */
+#define REG_TC0_COUNT32_CCBUF   (*(__IO uint32_t*)0x42001030U) /**< (TC0) COUNT32 Compare and Capture Buffer */
+#define REG_TC0_COUNT32_CCBUF0  (*(__IO uint32_t*)0x42001030U) /**< (TC0) COUNT32 Compare and Capture Buffer 0 */
+#define REG_TC0_COUNT32_CCBUF1  (*(__IO uint32_t*)0x42001034U) /**< (TC0) COUNT32 Compare and Capture Buffer 1 */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for TC0 peripheral ========== */
+#define TC0_CC_NUM                               2          
+#define TC0_DMAC_ID_OVF                          10         /* Indexes of DMA Overflow trigger */
+#define TC0_EXT                                  1          /* Coding of implemented extended features (keep 0 value) */
+#define TC0_GCLK_ID                              14         /* Index of Generic Clock */
+#define TC0_MASTER_SLAVE_MODE                    1          /* TC type 0 : NA, 1 : Master, 2 : Slave */
+#define TC0_OW_NUM                               2          /* Number of Output Waveforms */
+#define TC0_INSTANCE_ID                          68         
+
+#endif /* _SAML10_TC0_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/instance/tc1.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/instance/tc1.h
@@ -1,0 +1,130 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TC1
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_TC1_INSTANCE_H_
+#define _SAML10_TC1_INSTANCE_H_
+
+/* ========== Register definition for TC1 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_TC1_CTRLA           (0x42001400) /**< (TC1) Control A */
+#define REG_TC1_CTRLBCLR        (0x42001404) /**< (TC1) Control B Clear */
+#define REG_TC1_CTRLBSET        (0x42001405) /**< (TC1) Control B Set */
+#define REG_TC1_EVCTRL          (0x42001406) /**< (TC1) Event Control */
+#define REG_TC1_INTENCLR        (0x42001408) /**< (TC1) Interrupt Enable Clear */
+#define REG_TC1_INTENSET        (0x42001409) /**< (TC1) Interrupt Enable Set */
+#define REG_TC1_INTFLAG         (0x4200140A) /**< (TC1) Interrupt Flag Status and Clear */
+#define REG_TC1_STATUS          (0x4200140B) /**< (TC1) Status */
+#define REG_TC1_WAVE            (0x4200140C) /**< (TC1) Waveform Generation Control */
+#define REG_TC1_DRVCTRL         (0x4200140D) /**< (TC1) Control C */
+#define REG_TC1_DBGCTRL         (0x4200140F) /**< (TC1) Debug Control */
+#define REG_TC1_SYNCBUSY        (0x42001410) /**< (TC1) Synchronization Status */
+#define REG_TC1_COUNT8_COUNT    (0x42001414) /**< (TC1) COUNT8 Count */
+#define REG_TC1_COUNT8_PER      (0x4200141B) /**< (TC1) COUNT8 Period */
+#define REG_TC1_COUNT8_CC       (0x4200141C) /**< (TC1) COUNT8 Compare and Capture */
+#define REG_TC1_COUNT8_CC0      (0x4200141C) /**< (TC1) COUNT8 Compare and Capture 0 */
+#define REG_TC1_COUNT8_CC1      (0x4200141D) /**< (TC1) COUNT8 Compare and Capture 1 */
+#define REG_TC1_COUNT8_PERBUF   (0x4200142F) /**< (TC1) COUNT8 Period Buffer */
+#define REG_TC1_COUNT8_CCBUF    (0x42001430) /**< (TC1) COUNT8 Compare and Capture Buffer */
+#define REG_TC1_COUNT8_CCBUF0   (0x42001430) /**< (TC1) COUNT8 Compare and Capture Buffer 0 */
+#define REG_TC1_COUNT8_CCBUF1   (0x42001431) /**< (TC1) COUNT8 Compare and Capture Buffer 1 */
+#define REG_TC1_COUNT16_COUNT   (0x42001414) /**< (TC1) COUNT16 Count */
+#define REG_TC1_COUNT16_PER     (0x4200141A) /**< (TC1) COUNT16 Period */
+#define REG_TC1_COUNT16_CC      (0x4200141C) /**< (TC1) COUNT16 Compare and Capture */
+#define REG_TC1_COUNT16_CC0     (0x4200141C) /**< (TC1) COUNT16 Compare and Capture 0 */
+#define REG_TC1_COUNT16_CC1     (0x4200141E) /**< (TC1) COUNT16 Compare and Capture 1 */
+#define REG_TC1_COUNT16_PERBUF  (0x4200142E) /**< (TC1) COUNT16 Period Buffer */
+#define REG_TC1_COUNT16_CCBUF   (0x42001430) /**< (TC1) COUNT16 Compare and Capture Buffer */
+#define REG_TC1_COUNT16_CCBUF0  (0x42001430) /**< (TC1) COUNT16 Compare and Capture Buffer 0 */
+#define REG_TC1_COUNT16_CCBUF1  (0x42001432) /**< (TC1) COUNT16 Compare and Capture Buffer 1 */
+#define REG_TC1_COUNT32_COUNT   (0x42001414) /**< (TC1) COUNT32 Count */
+#define REG_TC1_COUNT32_PER     (0x42001418) /**< (TC1) COUNT32 Period */
+#define REG_TC1_COUNT32_CC      (0x4200141C) /**< (TC1) COUNT32 Compare and Capture */
+#define REG_TC1_COUNT32_CC0     (0x4200141C) /**< (TC1) COUNT32 Compare and Capture 0 */
+#define REG_TC1_COUNT32_CC1     (0x42001420) /**< (TC1) COUNT32 Compare and Capture 1 */
+#define REG_TC1_COUNT32_PERBUF  (0x4200142C) /**< (TC1) COUNT32 Period Buffer */
+#define REG_TC1_COUNT32_CCBUF   (0x42001430) /**< (TC1) COUNT32 Compare and Capture Buffer */
+#define REG_TC1_COUNT32_CCBUF0  (0x42001430) /**< (TC1) COUNT32 Compare and Capture Buffer 0 */
+#define REG_TC1_COUNT32_CCBUF1  (0x42001434) /**< (TC1) COUNT32 Compare and Capture Buffer 1 */
+
+#else
+
+#define REG_TC1_CTRLA           (*(__IO uint32_t*)0x42001400U) /**< (TC1) Control A */
+#define REG_TC1_CTRLBCLR        (*(__IO uint8_t*)0x42001404U) /**< (TC1) Control B Clear */
+#define REG_TC1_CTRLBSET        (*(__IO uint8_t*)0x42001405U) /**< (TC1) Control B Set */
+#define REG_TC1_EVCTRL          (*(__IO uint16_t*)0x42001406U) /**< (TC1) Event Control */
+#define REG_TC1_INTENCLR        (*(__IO uint8_t*)0x42001408U) /**< (TC1) Interrupt Enable Clear */
+#define REG_TC1_INTENSET        (*(__IO uint8_t*)0x42001409U) /**< (TC1) Interrupt Enable Set */
+#define REG_TC1_INTFLAG         (*(__IO uint8_t*)0x4200140AU) /**< (TC1) Interrupt Flag Status and Clear */
+#define REG_TC1_STATUS          (*(__IO uint8_t*)0x4200140BU) /**< (TC1) Status */
+#define REG_TC1_WAVE            (*(__IO uint8_t*)0x4200140CU) /**< (TC1) Waveform Generation Control */
+#define REG_TC1_DRVCTRL         (*(__IO uint8_t*)0x4200140DU) /**< (TC1) Control C */
+#define REG_TC1_DBGCTRL         (*(__IO uint8_t*)0x4200140FU) /**< (TC1) Debug Control */
+#define REG_TC1_SYNCBUSY        (*(__I  uint32_t*)0x42001410U) /**< (TC1) Synchronization Status */
+#define REG_TC1_COUNT8_COUNT    (*(__IO uint8_t*)0x42001414U) /**< (TC1) COUNT8 Count */
+#define REG_TC1_COUNT8_PER      (*(__IO uint8_t*)0x4200141BU) /**< (TC1) COUNT8 Period */
+#define REG_TC1_COUNT8_CC       (*(__IO uint8_t*)0x4200141CU) /**< (TC1) COUNT8 Compare and Capture */
+#define REG_TC1_COUNT8_CC0      (*(__IO uint8_t*)0x4200141CU) /**< (TC1) COUNT8 Compare and Capture 0 */
+#define REG_TC1_COUNT8_CC1      (*(__IO uint8_t*)0x4200141DU) /**< (TC1) COUNT8 Compare and Capture 1 */
+#define REG_TC1_COUNT8_PERBUF   (*(__IO uint8_t*)0x4200142FU) /**< (TC1) COUNT8 Period Buffer */
+#define REG_TC1_COUNT8_CCBUF    (*(__IO uint8_t*)0x42001430U) /**< (TC1) COUNT8 Compare and Capture Buffer */
+#define REG_TC1_COUNT8_CCBUF0   (*(__IO uint8_t*)0x42001430U) /**< (TC1) COUNT8 Compare and Capture Buffer 0 */
+#define REG_TC1_COUNT8_CCBUF1   (*(__IO uint8_t*)0x42001431U) /**< (TC1) COUNT8 Compare and Capture Buffer 1 */
+#define REG_TC1_COUNT16_COUNT   (*(__IO uint16_t*)0x42001414U) /**< (TC1) COUNT16 Count */
+#define REG_TC1_COUNT16_PER     (*(__IO uint16_t*)0x4200141AU) /**< (TC1) COUNT16 Period */
+#define REG_TC1_COUNT16_CC      (*(__IO uint16_t*)0x4200141CU) /**< (TC1) COUNT16 Compare and Capture */
+#define REG_TC1_COUNT16_CC0     (*(__IO uint16_t*)0x4200141CU) /**< (TC1) COUNT16 Compare and Capture 0 */
+#define REG_TC1_COUNT16_CC1     (*(__IO uint16_t*)0x4200141EU) /**< (TC1) COUNT16 Compare and Capture 1 */
+#define REG_TC1_COUNT16_PERBUF  (*(__IO uint16_t*)0x4200142EU) /**< (TC1) COUNT16 Period Buffer */
+#define REG_TC1_COUNT16_CCBUF   (*(__IO uint16_t*)0x42001430U) /**< (TC1) COUNT16 Compare and Capture Buffer */
+#define REG_TC1_COUNT16_CCBUF0  (*(__IO uint16_t*)0x42001430U) /**< (TC1) COUNT16 Compare and Capture Buffer 0 */
+#define REG_TC1_COUNT16_CCBUF1  (*(__IO uint16_t*)0x42001432U) /**< (TC1) COUNT16 Compare and Capture Buffer 1 */
+#define REG_TC1_COUNT32_COUNT   (*(__IO uint32_t*)0x42001414U) /**< (TC1) COUNT32 Count */
+#define REG_TC1_COUNT32_PER     (*(__IO uint32_t*)0x42001418U) /**< (TC1) COUNT32 Period */
+#define REG_TC1_COUNT32_CC      (*(__IO uint32_t*)0x4200141CU) /**< (TC1) COUNT32 Compare and Capture */
+#define REG_TC1_COUNT32_CC0     (*(__IO uint32_t*)0x4200141CU) /**< (TC1) COUNT32 Compare and Capture 0 */
+#define REG_TC1_COUNT32_CC1     (*(__IO uint32_t*)0x42001420U) /**< (TC1) COUNT32 Compare and Capture 1 */
+#define REG_TC1_COUNT32_PERBUF  (*(__IO uint32_t*)0x4200142CU) /**< (TC1) COUNT32 Period Buffer */
+#define REG_TC1_COUNT32_CCBUF   (*(__IO uint32_t*)0x42001430U) /**< (TC1) COUNT32 Compare and Capture Buffer */
+#define REG_TC1_COUNT32_CCBUF0  (*(__IO uint32_t*)0x42001430U) /**< (TC1) COUNT32 Compare and Capture Buffer 0 */
+#define REG_TC1_COUNT32_CCBUF1  (*(__IO uint32_t*)0x42001434U) /**< (TC1) COUNT32 Compare and Capture Buffer 1 */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for TC1 peripheral ========== */
+#define TC1_CC_NUM                               2          
+#define TC1_DMAC_ID_OVF                          13         /* Indexes of DMA Overflow trigger */
+#define TC1_EXT                                  1          /* Coding of implemented extended features (keep 0 value) */
+#define TC1_GCLK_ID                              14         /* Index of Generic Clock */
+#define TC1_MASTER_SLAVE_MODE                    2          /* TC type 0 : NA, 1 : Master, 2 : Slave */
+#define TC1_OW_NUM                               2          /* Number of Output Waveforms */
+#define TC1_INSTANCE_ID                          69         
+
+#endif /* _SAML10_TC1_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/instance/tc2.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/instance/tc2.h
@@ -1,0 +1,130 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TC2
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_TC2_INSTANCE_H_
+#define _SAML10_TC2_INSTANCE_H_
+
+/* ========== Register definition for TC2 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_TC2_CTRLA           (0x42001800) /**< (TC2) Control A */
+#define REG_TC2_CTRLBCLR        (0x42001804) /**< (TC2) Control B Clear */
+#define REG_TC2_CTRLBSET        (0x42001805) /**< (TC2) Control B Set */
+#define REG_TC2_EVCTRL          (0x42001806) /**< (TC2) Event Control */
+#define REG_TC2_INTENCLR        (0x42001808) /**< (TC2) Interrupt Enable Clear */
+#define REG_TC2_INTENSET        (0x42001809) /**< (TC2) Interrupt Enable Set */
+#define REG_TC2_INTFLAG         (0x4200180A) /**< (TC2) Interrupt Flag Status and Clear */
+#define REG_TC2_STATUS          (0x4200180B) /**< (TC2) Status */
+#define REG_TC2_WAVE            (0x4200180C) /**< (TC2) Waveform Generation Control */
+#define REG_TC2_DRVCTRL         (0x4200180D) /**< (TC2) Control C */
+#define REG_TC2_DBGCTRL         (0x4200180F) /**< (TC2) Debug Control */
+#define REG_TC2_SYNCBUSY        (0x42001810) /**< (TC2) Synchronization Status */
+#define REG_TC2_COUNT8_COUNT    (0x42001814) /**< (TC2) COUNT8 Count */
+#define REG_TC2_COUNT8_PER      (0x4200181B) /**< (TC2) COUNT8 Period */
+#define REG_TC2_COUNT8_CC       (0x4200181C) /**< (TC2) COUNT8 Compare and Capture */
+#define REG_TC2_COUNT8_CC0      (0x4200181C) /**< (TC2) COUNT8 Compare and Capture 0 */
+#define REG_TC2_COUNT8_CC1      (0x4200181D) /**< (TC2) COUNT8 Compare and Capture 1 */
+#define REG_TC2_COUNT8_PERBUF   (0x4200182F) /**< (TC2) COUNT8 Period Buffer */
+#define REG_TC2_COUNT8_CCBUF    (0x42001830) /**< (TC2) COUNT8 Compare and Capture Buffer */
+#define REG_TC2_COUNT8_CCBUF0   (0x42001830) /**< (TC2) COUNT8 Compare and Capture Buffer 0 */
+#define REG_TC2_COUNT8_CCBUF1   (0x42001831) /**< (TC2) COUNT8 Compare and Capture Buffer 1 */
+#define REG_TC2_COUNT16_COUNT   (0x42001814) /**< (TC2) COUNT16 Count */
+#define REG_TC2_COUNT16_PER     (0x4200181A) /**< (TC2) COUNT16 Period */
+#define REG_TC2_COUNT16_CC      (0x4200181C) /**< (TC2) COUNT16 Compare and Capture */
+#define REG_TC2_COUNT16_CC0     (0x4200181C) /**< (TC2) COUNT16 Compare and Capture 0 */
+#define REG_TC2_COUNT16_CC1     (0x4200181E) /**< (TC2) COUNT16 Compare and Capture 1 */
+#define REG_TC2_COUNT16_PERBUF  (0x4200182E) /**< (TC2) COUNT16 Period Buffer */
+#define REG_TC2_COUNT16_CCBUF   (0x42001830) /**< (TC2) COUNT16 Compare and Capture Buffer */
+#define REG_TC2_COUNT16_CCBUF0  (0x42001830) /**< (TC2) COUNT16 Compare and Capture Buffer 0 */
+#define REG_TC2_COUNT16_CCBUF1  (0x42001832) /**< (TC2) COUNT16 Compare and Capture Buffer 1 */
+#define REG_TC2_COUNT32_COUNT   (0x42001814) /**< (TC2) COUNT32 Count */
+#define REG_TC2_COUNT32_PER     (0x42001818) /**< (TC2) COUNT32 Period */
+#define REG_TC2_COUNT32_CC      (0x4200181C) /**< (TC2) COUNT32 Compare and Capture */
+#define REG_TC2_COUNT32_CC0     (0x4200181C) /**< (TC2) COUNT32 Compare and Capture 0 */
+#define REG_TC2_COUNT32_CC1     (0x42001820) /**< (TC2) COUNT32 Compare and Capture 1 */
+#define REG_TC2_COUNT32_PERBUF  (0x4200182C) /**< (TC2) COUNT32 Period Buffer */
+#define REG_TC2_COUNT32_CCBUF   (0x42001830) /**< (TC2) COUNT32 Compare and Capture Buffer */
+#define REG_TC2_COUNT32_CCBUF0  (0x42001830) /**< (TC2) COUNT32 Compare and Capture Buffer 0 */
+#define REG_TC2_COUNT32_CCBUF1  (0x42001834) /**< (TC2) COUNT32 Compare and Capture Buffer 1 */
+
+#else
+
+#define REG_TC2_CTRLA           (*(__IO uint32_t*)0x42001800U) /**< (TC2) Control A */
+#define REG_TC2_CTRLBCLR        (*(__IO uint8_t*)0x42001804U) /**< (TC2) Control B Clear */
+#define REG_TC2_CTRLBSET        (*(__IO uint8_t*)0x42001805U) /**< (TC2) Control B Set */
+#define REG_TC2_EVCTRL          (*(__IO uint16_t*)0x42001806U) /**< (TC2) Event Control */
+#define REG_TC2_INTENCLR        (*(__IO uint8_t*)0x42001808U) /**< (TC2) Interrupt Enable Clear */
+#define REG_TC2_INTENSET        (*(__IO uint8_t*)0x42001809U) /**< (TC2) Interrupt Enable Set */
+#define REG_TC2_INTFLAG         (*(__IO uint8_t*)0x4200180AU) /**< (TC2) Interrupt Flag Status and Clear */
+#define REG_TC2_STATUS          (*(__IO uint8_t*)0x4200180BU) /**< (TC2) Status */
+#define REG_TC2_WAVE            (*(__IO uint8_t*)0x4200180CU) /**< (TC2) Waveform Generation Control */
+#define REG_TC2_DRVCTRL         (*(__IO uint8_t*)0x4200180DU) /**< (TC2) Control C */
+#define REG_TC2_DBGCTRL         (*(__IO uint8_t*)0x4200180FU) /**< (TC2) Debug Control */
+#define REG_TC2_SYNCBUSY        (*(__I  uint32_t*)0x42001810U) /**< (TC2) Synchronization Status */
+#define REG_TC2_COUNT8_COUNT    (*(__IO uint8_t*)0x42001814U) /**< (TC2) COUNT8 Count */
+#define REG_TC2_COUNT8_PER      (*(__IO uint8_t*)0x4200181BU) /**< (TC2) COUNT8 Period */
+#define REG_TC2_COUNT8_CC       (*(__IO uint8_t*)0x4200181CU) /**< (TC2) COUNT8 Compare and Capture */
+#define REG_TC2_COUNT8_CC0      (*(__IO uint8_t*)0x4200181CU) /**< (TC2) COUNT8 Compare and Capture 0 */
+#define REG_TC2_COUNT8_CC1      (*(__IO uint8_t*)0x4200181DU) /**< (TC2) COUNT8 Compare and Capture 1 */
+#define REG_TC2_COUNT8_PERBUF   (*(__IO uint8_t*)0x4200182FU) /**< (TC2) COUNT8 Period Buffer */
+#define REG_TC2_COUNT8_CCBUF    (*(__IO uint8_t*)0x42001830U) /**< (TC2) COUNT8 Compare and Capture Buffer */
+#define REG_TC2_COUNT8_CCBUF0   (*(__IO uint8_t*)0x42001830U) /**< (TC2) COUNT8 Compare and Capture Buffer 0 */
+#define REG_TC2_COUNT8_CCBUF1   (*(__IO uint8_t*)0x42001831U) /**< (TC2) COUNT8 Compare and Capture Buffer 1 */
+#define REG_TC2_COUNT16_COUNT   (*(__IO uint16_t*)0x42001814U) /**< (TC2) COUNT16 Count */
+#define REG_TC2_COUNT16_PER     (*(__IO uint16_t*)0x4200181AU) /**< (TC2) COUNT16 Period */
+#define REG_TC2_COUNT16_CC      (*(__IO uint16_t*)0x4200181CU) /**< (TC2) COUNT16 Compare and Capture */
+#define REG_TC2_COUNT16_CC0     (*(__IO uint16_t*)0x4200181CU) /**< (TC2) COUNT16 Compare and Capture 0 */
+#define REG_TC2_COUNT16_CC1     (*(__IO uint16_t*)0x4200181EU) /**< (TC2) COUNT16 Compare and Capture 1 */
+#define REG_TC2_COUNT16_PERBUF  (*(__IO uint16_t*)0x4200182EU) /**< (TC2) COUNT16 Period Buffer */
+#define REG_TC2_COUNT16_CCBUF   (*(__IO uint16_t*)0x42001830U) /**< (TC2) COUNT16 Compare and Capture Buffer */
+#define REG_TC2_COUNT16_CCBUF0  (*(__IO uint16_t*)0x42001830U) /**< (TC2) COUNT16 Compare and Capture Buffer 0 */
+#define REG_TC2_COUNT16_CCBUF1  (*(__IO uint16_t*)0x42001832U) /**< (TC2) COUNT16 Compare and Capture Buffer 1 */
+#define REG_TC2_COUNT32_COUNT   (*(__IO uint32_t*)0x42001814U) /**< (TC2) COUNT32 Count */
+#define REG_TC2_COUNT32_PER     (*(__IO uint32_t*)0x42001818U) /**< (TC2) COUNT32 Period */
+#define REG_TC2_COUNT32_CC      (*(__IO uint32_t*)0x4200181CU) /**< (TC2) COUNT32 Compare and Capture */
+#define REG_TC2_COUNT32_CC0     (*(__IO uint32_t*)0x4200181CU) /**< (TC2) COUNT32 Compare and Capture 0 */
+#define REG_TC2_COUNT32_CC1     (*(__IO uint32_t*)0x42001820U) /**< (TC2) COUNT32 Compare and Capture 1 */
+#define REG_TC2_COUNT32_PERBUF  (*(__IO uint32_t*)0x4200182CU) /**< (TC2) COUNT32 Period Buffer */
+#define REG_TC2_COUNT32_CCBUF   (*(__IO uint32_t*)0x42001830U) /**< (TC2) COUNT32 Compare and Capture Buffer */
+#define REG_TC2_COUNT32_CCBUF0  (*(__IO uint32_t*)0x42001830U) /**< (TC2) COUNT32 Compare and Capture Buffer 0 */
+#define REG_TC2_COUNT32_CCBUF1  (*(__IO uint32_t*)0x42001834U) /**< (TC2) COUNT32 Compare and Capture Buffer 1 */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for TC2 peripheral ========== */
+#define TC2_CC_NUM                               2          
+#define TC2_DMAC_ID_OVF                          16         /* Indexes of DMA Overflow trigger */
+#define TC2_EXT                                  1          /* Coding of implemented extended features (keep 0 value) */
+#define TC2_GCLK_ID                              15         /* Index of Generic Clock */
+#define TC2_MASTER_SLAVE_MODE                    0          /* TC type 0 : NA, 1 : Master, 2 : Slave */
+#define TC2_OW_NUM                               2          /* Number of Output Waveforms */
+#define TC2_INSTANCE_ID                          70         
+
+#endif /* _SAML10_TC2_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/instance/tram.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/instance/tram.h
@@ -1,0 +1,194 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TRAM
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_TRAM_INSTANCE_H_
+#define _SAML10_TRAM_INSTANCE_H_
+
+/* ========== Register definition for TRAM peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_TRAM_CTRLA          (0x42003400) /**< (TRAM) Control */
+#define REG_TRAM_INTENCLR       (0x42003404) /**< (TRAM) Interrupt Enable Clear */
+#define REG_TRAM_INTENSET       (0x42003405) /**< (TRAM) Interrupt Enable Set */
+#define REG_TRAM_INTFLAG        (0x42003406) /**< (TRAM) Interrupt Flag Status and Clear */
+#define REG_TRAM_STATUS         (0x42003407) /**< (TRAM) Status */
+#define REG_TRAM_SYNCBUSY       (0x42003408) /**< (TRAM) Synchronization Busy Status */
+#define REG_TRAM_DSCC           (0x4200340C) /**< (TRAM) Data Scramble Control */
+#define REG_TRAM_PERMW          (0x42003410) /**< (TRAM) Permutation Write */
+#define REG_TRAM_PERMR          (0x42003411) /**< (TRAM) Permutation Read */
+#define REG_TRAM_RAM            (0x42003500) /**< (TRAM) TrustRAM */
+#define REG_TRAM_RAM0           (0x42003500) /**< (TRAM) TrustRAM 0 */
+#define REG_TRAM_RAM1           (0x42003504) /**< (TRAM) TrustRAM 1 */
+#define REG_TRAM_RAM2           (0x42003508) /**< (TRAM) TrustRAM 2 */
+#define REG_TRAM_RAM3           (0x4200350C) /**< (TRAM) TrustRAM 3 */
+#define REG_TRAM_RAM4           (0x42003510) /**< (TRAM) TrustRAM 4 */
+#define REG_TRAM_RAM5           (0x42003514) /**< (TRAM) TrustRAM 5 */
+#define REG_TRAM_RAM6           (0x42003518) /**< (TRAM) TrustRAM 6 */
+#define REG_TRAM_RAM7           (0x4200351C) /**< (TRAM) TrustRAM 7 */
+#define REG_TRAM_RAM8           (0x42003520) /**< (TRAM) TrustRAM 8 */
+#define REG_TRAM_RAM9           (0x42003524) /**< (TRAM) TrustRAM 9 */
+#define REG_TRAM_RAM10          (0x42003528) /**< (TRAM) TrustRAM 10 */
+#define REG_TRAM_RAM11          (0x4200352C) /**< (TRAM) TrustRAM 11 */
+#define REG_TRAM_RAM12          (0x42003530) /**< (TRAM) TrustRAM 12 */
+#define REG_TRAM_RAM13          (0x42003534) /**< (TRAM) TrustRAM 13 */
+#define REG_TRAM_RAM14          (0x42003538) /**< (TRAM) TrustRAM 14 */
+#define REG_TRAM_RAM15          (0x4200353C) /**< (TRAM) TrustRAM 15 */
+#define REG_TRAM_RAM16          (0x42003540) /**< (TRAM) TrustRAM 16 */
+#define REG_TRAM_RAM17          (0x42003544) /**< (TRAM) TrustRAM 17 */
+#define REG_TRAM_RAM18          (0x42003548) /**< (TRAM) TrustRAM 18 */
+#define REG_TRAM_RAM19          (0x4200354C) /**< (TRAM) TrustRAM 19 */
+#define REG_TRAM_RAM20          (0x42003550) /**< (TRAM) TrustRAM 20 */
+#define REG_TRAM_RAM21          (0x42003554) /**< (TRAM) TrustRAM 21 */
+#define REG_TRAM_RAM22          (0x42003558) /**< (TRAM) TrustRAM 22 */
+#define REG_TRAM_RAM23          (0x4200355C) /**< (TRAM) TrustRAM 23 */
+#define REG_TRAM_RAM24          (0x42003560) /**< (TRAM) TrustRAM 24 */
+#define REG_TRAM_RAM25          (0x42003564) /**< (TRAM) TrustRAM 25 */
+#define REG_TRAM_RAM26          (0x42003568) /**< (TRAM) TrustRAM 26 */
+#define REG_TRAM_RAM27          (0x4200356C) /**< (TRAM) TrustRAM 27 */
+#define REG_TRAM_RAM28          (0x42003570) /**< (TRAM) TrustRAM 28 */
+#define REG_TRAM_RAM29          (0x42003574) /**< (TRAM) TrustRAM 29 */
+#define REG_TRAM_RAM30          (0x42003578) /**< (TRAM) TrustRAM 30 */
+#define REG_TRAM_RAM31          (0x4200357C) /**< (TRAM) TrustRAM 31 */
+#define REG_TRAM_RAM32          (0x42003580) /**< (TRAM) TrustRAM 32 */
+#define REG_TRAM_RAM33          (0x42003584) /**< (TRAM) TrustRAM 33 */
+#define REG_TRAM_RAM34          (0x42003588) /**< (TRAM) TrustRAM 34 */
+#define REG_TRAM_RAM35          (0x4200358C) /**< (TRAM) TrustRAM 35 */
+#define REG_TRAM_RAM36          (0x42003590) /**< (TRAM) TrustRAM 36 */
+#define REG_TRAM_RAM37          (0x42003594) /**< (TRAM) TrustRAM 37 */
+#define REG_TRAM_RAM38          (0x42003598) /**< (TRAM) TrustRAM 38 */
+#define REG_TRAM_RAM39          (0x4200359C) /**< (TRAM) TrustRAM 39 */
+#define REG_TRAM_RAM40          (0x420035A0) /**< (TRAM) TrustRAM 40 */
+#define REG_TRAM_RAM41          (0x420035A4) /**< (TRAM) TrustRAM 41 */
+#define REG_TRAM_RAM42          (0x420035A8) /**< (TRAM) TrustRAM 42 */
+#define REG_TRAM_RAM43          (0x420035AC) /**< (TRAM) TrustRAM 43 */
+#define REG_TRAM_RAM44          (0x420035B0) /**< (TRAM) TrustRAM 44 */
+#define REG_TRAM_RAM45          (0x420035B4) /**< (TRAM) TrustRAM 45 */
+#define REG_TRAM_RAM46          (0x420035B8) /**< (TRAM) TrustRAM 46 */
+#define REG_TRAM_RAM47          (0x420035BC) /**< (TRAM) TrustRAM 47 */
+#define REG_TRAM_RAM48          (0x420035C0) /**< (TRAM) TrustRAM 48 */
+#define REG_TRAM_RAM49          (0x420035C4) /**< (TRAM) TrustRAM 49 */
+#define REG_TRAM_RAM50          (0x420035C8) /**< (TRAM) TrustRAM 50 */
+#define REG_TRAM_RAM51          (0x420035CC) /**< (TRAM) TrustRAM 51 */
+#define REG_TRAM_RAM52          (0x420035D0) /**< (TRAM) TrustRAM 52 */
+#define REG_TRAM_RAM53          (0x420035D4) /**< (TRAM) TrustRAM 53 */
+#define REG_TRAM_RAM54          (0x420035D8) /**< (TRAM) TrustRAM 54 */
+#define REG_TRAM_RAM55          (0x420035DC) /**< (TRAM) TrustRAM 55 */
+#define REG_TRAM_RAM56          (0x420035E0) /**< (TRAM) TrustRAM 56 */
+#define REG_TRAM_RAM57          (0x420035E4) /**< (TRAM) TrustRAM 57 */
+#define REG_TRAM_RAM58          (0x420035E8) /**< (TRAM) TrustRAM 58 */
+#define REG_TRAM_RAM59          (0x420035EC) /**< (TRAM) TrustRAM 59 */
+#define REG_TRAM_RAM60          (0x420035F0) /**< (TRAM) TrustRAM 60 */
+#define REG_TRAM_RAM61          (0x420035F4) /**< (TRAM) TrustRAM 61 */
+#define REG_TRAM_RAM62          (0x420035F8) /**< (TRAM) TrustRAM 62 */
+#define REG_TRAM_RAM63          (0x420035FC) /**< (TRAM) TrustRAM 63 */
+
+#else
+
+#define REG_TRAM_CTRLA          (*(__IO uint8_t*)0x42003400U) /**< (TRAM) Control */
+#define REG_TRAM_INTENCLR       (*(__IO uint8_t*)0x42003404U) /**< (TRAM) Interrupt Enable Clear */
+#define REG_TRAM_INTENSET       (*(__IO uint8_t*)0x42003405U) /**< (TRAM) Interrupt Enable Set */
+#define REG_TRAM_INTFLAG        (*(__IO uint8_t*)0x42003406U) /**< (TRAM) Interrupt Flag Status and Clear */
+#define REG_TRAM_STATUS         (*(__I  uint8_t*)0x42003407U) /**< (TRAM) Status */
+#define REG_TRAM_SYNCBUSY       (*(__I  uint32_t*)0x42003408U) /**< (TRAM) Synchronization Busy Status */
+#define REG_TRAM_DSCC           (*(__O  uint32_t*)0x4200340CU) /**< (TRAM) Data Scramble Control */
+#define REG_TRAM_PERMW          (*(__O  uint8_t*)0x42003410U) /**< (TRAM) Permutation Write */
+#define REG_TRAM_PERMR          (*(__I  uint8_t*)0x42003411U) /**< (TRAM) Permutation Read */
+#define REG_TRAM_RAM            (*(__IO uint32_t*)0x42003500U) /**< (TRAM) TrustRAM */
+#define REG_TRAM_RAM0           (*(__IO uint32_t*)0x42003500U) /**< (TRAM) TrustRAM 0 */
+#define REG_TRAM_RAM1           (*(__IO uint32_t*)0x42003504U) /**< (TRAM) TrustRAM 1 */
+#define REG_TRAM_RAM2           (*(__IO uint32_t*)0x42003508U) /**< (TRAM) TrustRAM 2 */
+#define REG_TRAM_RAM3           (*(__IO uint32_t*)0x4200350CU) /**< (TRAM) TrustRAM 3 */
+#define REG_TRAM_RAM4           (*(__IO uint32_t*)0x42003510U) /**< (TRAM) TrustRAM 4 */
+#define REG_TRAM_RAM5           (*(__IO uint32_t*)0x42003514U) /**< (TRAM) TrustRAM 5 */
+#define REG_TRAM_RAM6           (*(__IO uint32_t*)0x42003518U) /**< (TRAM) TrustRAM 6 */
+#define REG_TRAM_RAM7           (*(__IO uint32_t*)0x4200351CU) /**< (TRAM) TrustRAM 7 */
+#define REG_TRAM_RAM8           (*(__IO uint32_t*)0x42003520U) /**< (TRAM) TrustRAM 8 */
+#define REG_TRAM_RAM9           (*(__IO uint32_t*)0x42003524U) /**< (TRAM) TrustRAM 9 */
+#define REG_TRAM_RAM10          (*(__IO uint32_t*)0x42003528U) /**< (TRAM) TrustRAM 10 */
+#define REG_TRAM_RAM11          (*(__IO uint32_t*)0x4200352CU) /**< (TRAM) TrustRAM 11 */
+#define REG_TRAM_RAM12          (*(__IO uint32_t*)0x42003530U) /**< (TRAM) TrustRAM 12 */
+#define REG_TRAM_RAM13          (*(__IO uint32_t*)0x42003534U) /**< (TRAM) TrustRAM 13 */
+#define REG_TRAM_RAM14          (*(__IO uint32_t*)0x42003538U) /**< (TRAM) TrustRAM 14 */
+#define REG_TRAM_RAM15          (*(__IO uint32_t*)0x4200353CU) /**< (TRAM) TrustRAM 15 */
+#define REG_TRAM_RAM16          (*(__IO uint32_t*)0x42003540U) /**< (TRAM) TrustRAM 16 */
+#define REG_TRAM_RAM17          (*(__IO uint32_t*)0x42003544U) /**< (TRAM) TrustRAM 17 */
+#define REG_TRAM_RAM18          (*(__IO uint32_t*)0x42003548U) /**< (TRAM) TrustRAM 18 */
+#define REG_TRAM_RAM19          (*(__IO uint32_t*)0x4200354CU) /**< (TRAM) TrustRAM 19 */
+#define REG_TRAM_RAM20          (*(__IO uint32_t*)0x42003550U) /**< (TRAM) TrustRAM 20 */
+#define REG_TRAM_RAM21          (*(__IO uint32_t*)0x42003554U) /**< (TRAM) TrustRAM 21 */
+#define REG_TRAM_RAM22          (*(__IO uint32_t*)0x42003558U) /**< (TRAM) TrustRAM 22 */
+#define REG_TRAM_RAM23          (*(__IO uint32_t*)0x4200355CU) /**< (TRAM) TrustRAM 23 */
+#define REG_TRAM_RAM24          (*(__IO uint32_t*)0x42003560U) /**< (TRAM) TrustRAM 24 */
+#define REG_TRAM_RAM25          (*(__IO uint32_t*)0x42003564U) /**< (TRAM) TrustRAM 25 */
+#define REG_TRAM_RAM26          (*(__IO uint32_t*)0x42003568U) /**< (TRAM) TrustRAM 26 */
+#define REG_TRAM_RAM27          (*(__IO uint32_t*)0x4200356CU) /**< (TRAM) TrustRAM 27 */
+#define REG_TRAM_RAM28          (*(__IO uint32_t*)0x42003570U) /**< (TRAM) TrustRAM 28 */
+#define REG_TRAM_RAM29          (*(__IO uint32_t*)0x42003574U) /**< (TRAM) TrustRAM 29 */
+#define REG_TRAM_RAM30          (*(__IO uint32_t*)0x42003578U) /**< (TRAM) TrustRAM 30 */
+#define REG_TRAM_RAM31          (*(__IO uint32_t*)0x4200357CU) /**< (TRAM) TrustRAM 31 */
+#define REG_TRAM_RAM32          (*(__IO uint32_t*)0x42003580U) /**< (TRAM) TrustRAM 32 */
+#define REG_TRAM_RAM33          (*(__IO uint32_t*)0x42003584U) /**< (TRAM) TrustRAM 33 */
+#define REG_TRAM_RAM34          (*(__IO uint32_t*)0x42003588U) /**< (TRAM) TrustRAM 34 */
+#define REG_TRAM_RAM35          (*(__IO uint32_t*)0x4200358CU) /**< (TRAM) TrustRAM 35 */
+#define REG_TRAM_RAM36          (*(__IO uint32_t*)0x42003590U) /**< (TRAM) TrustRAM 36 */
+#define REG_TRAM_RAM37          (*(__IO uint32_t*)0x42003594U) /**< (TRAM) TrustRAM 37 */
+#define REG_TRAM_RAM38          (*(__IO uint32_t*)0x42003598U) /**< (TRAM) TrustRAM 38 */
+#define REG_TRAM_RAM39          (*(__IO uint32_t*)0x4200359CU) /**< (TRAM) TrustRAM 39 */
+#define REG_TRAM_RAM40          (*(__IO uint32_t*)0x420035A0U) /**< (TRAM) TrustRAM 40 */
+#define REG_TRAM_RAM41          (*(__IO uint32_t*)0x420035A4U) /**< (TRAM) TrustRAM 41 */
+#define REG_TRAM_RAM42          (*(__IO uint32_t*)0x420035A8U) /**< (TRAM) TrustRAM 42 */
+#define REG_TRAM_RAM43          (*(__IO uint32_t*)0x420035ACU) /**< (TRAM) TrustRAM 43 */
+#define REG_TRAM_RAM44          (*(__IO uint32_t*)0x420035B0U) /**< (TRAM) TrustRAM 44 */
+#define REG_TRAM_RAM45          (*(__IO uint32_t*)0x420035B4U) /**< (TRAM) TrustRAM 45 */
+#define REG_TRAM_RAM46          (*(__IO uint32_t*)0x420035B8U) /**< (TRAM) TrustRAM 46 */
+#define REG_TRAM_RAM47          (*(__IO uint32_t*)0x420035BCU) /**< (TRAM) TrustRAM 47 */
+#define REG_TRAM_RAM48          (*(__IO uint32_t*)0x420035C0U) /**< (TRAM) TrustRAM 48 */
+#define REG_TRAM_RAM49          (*(__IO uint32_t*)0x420035C4U) /**< (TRAM) TrustRAM 49 */
+#define REG_TRAM_RAM50          (*(__IO uint32_t*)0x420035C8U) /**< (TRAM) TrustRAM 50 */
+#define REG_TRAM_RAM51          (*(__IO uint32_t*)0x420035CCU) /**< (TRAM) TrustRAM 51 */
+#define REG_TRAM_RAM52          (*(__IO uint32_t*)0x420035D0U) /**< (TRAM) TrustRAM 52 */
+#define REG_TRAM_RAM53          (*(__IO uint32_t*)0x420035D4U) /**< (TRAM) TrustRAM 53 */
+#define REG_TRAM_RAM54          (*(__IO uint32_t*)0x420035D8U) /**< (TRAM) TrustRAM 54 */
+#define REG_TRAM_RAM55          (*(__IO uint32_t*)0x420035DCU) /**< (TRAM) TrustRAM 55 */
+#define REG_TRAM_RAM56          (*(__IO uint32_t*)0x420035E0U) /**< (TRAM) TrustRAM 56 */
+#define REG_TRAM_RAM57          (*(__IO uint32_t*)0x420035E4U) /**< (TRAM) TrustRAM 57 */
+#define REG_TRAM_RAM58          (*(__IO uint32_t*)0x420035E8U) /**< (TRAM) TrustRAM 58 */
+#define REG_TRAM_RAM59          (*(__IO uint32_t*)0x420035ECU) /**< (TRAM) TrustRAM 59 */
+#define REG_TRAM_RAM60          (*(__IO uint32_t*)0x420035F0U) /**< (TRAM) TrustRAM 60 */
+#define REG_TRAM_RAM61          (*(__IO uint32_t*)0x420035F4U) /**< (TRAM) TrustRAM 61 */
+#define REG_TRAM_RAM62          (*(__IO uint32_t*)0x420035F8U) /**< (TRAM) TrustRAM 62 */
+#define REG_TRAM_RAM63          (*(__IO uint32_t*)0x420035FCU) /**< (TRAM) TrustRAM 63 */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for TRAM peripheral ========== */
+#define TRAM_INSTANCE_ID                         77         
+
+#endif /* _SAML10_TRAM_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/instance/trng.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/instance/trng.h
@@ -1,0 +1,58 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TRNG
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_TRNG_INSTANCE_H_
+#define _SAML10_TRNG_INSTANCE_H_
+
+/* ========== Register definition for TRNG peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_TRNG_CTRLA          (0x42002800) /**< (TRNG) Control A */
+#define REG_TRNG_EVCTRL         (0x42002804) /**< (TRNG) Event Control */
+#define REG_TRNG_INTENCLR       (0x42002808) /**< (TRNG) Interrupt Enable Clear */
+#define REG_TRNG_INTENSET       (0x42002809) /**< (TRNG) Interrupt Enable Set */
+#define REG_TRNG_INTFLAG        (0x4200280A) /**< (TRNG) Interrupt Flag Status and Clear */
+#define REG_TRNG_DATA           (0x42002820) /**< (TRNG) Output Data */
+
+#else
+
+#define REG_TRNG_CTRLA          (*(__IO uint8_t*)0x42002800U) /**< (TRNG) Control A */
+#define REG_TRNG_EVCTRL         (*(__IO uint8_t*)0x42002804U) /**< (TRNG) Event Control */
+#define REG_TRNG_INTENCLR       (*(__IO uint8_t*)0x42002808U) /**< (TRNG) Interrupt Enable Clear */
+#define REG_TRNG_INTENSET       (*(__IO uint8_t*)0x42002809U) /**< (TRNG) Interrupt Enable Set */
+#define REG_TRNG_INTFLAG        (*(__IO uint8_t*)0x4200280AU) /**< (TRNG) Interrupt Flag Status and Clear */
+#define REG_TRNG_DATA           (*(__I  uint32_t*)0x42002820U) /**< (TRNG) Output Data */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for TRNG peripheral ========== */
+#define TRNG_INSTANCE_ID                         74         
+
+#endif /* _SAML10_TRNG_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/instance/wdt.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/instance/wdt.h
@@ -1,0 +1,62 @@
+/**
+ * \file
+ *
+ * \brief Instance description for WDT
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10_WDT_INSTANCE_H_
+#define _SAML10_WDT_INSTANCE_H_
+
+/* ========== Register definition for WDT peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_WDT_CTRLA           (0x40002000) /**< (WDT) Control */
+#define REG_WDT_CONFIG          (0x40002001) /**< (WDT) Configuration */
+#define REG_WDT_EWCTRL          (0x40002002) /**< (WDT) Early Warning Interrupt Control */
+#define REG_WDT_INTENCLR        (0x40002004) /**< (WDT) Interrupt Enable Clear */
+#define REG_WDT_INTENSET        (0x40002005) /**< (WDT) Interrupt Enable Set */
+#define REG_WDT_INTFLAG         (0x40002006) /**< (WDT) Interrupt Flag Status and Clear */
+#define REG_WDT_SYNCBUSY        (0x40002008) /**< (WDT) Synchronization Busy */
+#define REG_WDT_CLEAR           (0x4000200C) /**< (WDT) Clear */
+
+#else
+
+#define REG_WDT_CTRLA           (*(__IO uint8_t*)0x40002000U) /**< (WDT) Control */
+#define REG_WDT_CONFIG          (*(__IO uint8_t*)0x40002001U) /**< (WDT) Configuration */
+#define REG_WDT_EWCTRL          (*(__IO uint8_t*)0x40002002U) /**< (WDT) Early Warning Interrupt Control */
+#define REG_WDT_INTENCLR        (*(__IO uint8_t*)0x40002004U) /**< (WDT) Interrupt Enable Clear */
+#define REG_WDT_INTENSET        (*(__IO uint8_t*)0x40002005U) /**< (WDT) Interrupt Enable Set */
+#define REG_WDT_INTFLAG         (*(__IO uint8_t*)0x40002006U) /**< (WDT) Interrupt Flag Status and Clear */
+#define REG_WDT_SYNCBUSY        (*(__I  uint32_t*)0x40002008U) /**< (WDT) Synchronization Busy */
+#define REG_WDT_CLEAR           (*(__O  uint8_t*)0x4000200CU) /**< (WDT) Clear */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for WDT peripheral ========== */
+#define WDT_INSTANCE_ID                          8          
+
+#endif /* _SAML10_WDT_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/pio/saml10d14a.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/pio/saml10d14a.h
@@ -1,0 +1,834 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAML10D14A
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:49Z */
+#ifndef _SAML10D14A_PIO_H_
+#define _SAML10D14A_PIO_H_
+
+/* ========== Peripheral I/O pin numbers ========== */
+#define PIN_PA00                    (  0)  /**< Pin Number for PA00 */
+#define PIN_PA01                    (  1)  /**< Pin Number for PA01 */
+#define PIN_PA02                    (  2)  /**< Pin Number for PA02 */
+#define PIN_PA03                    (  3)  /**< Pin Number for PA03 */
+#define PIN_PA04                    (  4)  /**< Pin Number for PA04 */
+#define PIN_PA05                    (  5)  /**< Pin Number for PA05 */
+#define PIN_PA08                    (  8)  /**< Pin Number for PA08 */
+#define PIN_PA14                    ( 14)  /**< Pin Number for PA14 */
+#define PIN_PA15                    ( 15)  /**< Pin Number for PA15 */
+#define PIN_PA16                    ( 16)  /**< Pin Number for PA16 */
+#define PIN_PA17                    ( 17)  /**< Pin Number for PA17 */
+#define PIN_PA18                    ( 18)  /**< Pin Number for PA18 */
+#define PIN_PA19                    ( 19)  /**< Pin Number for PA19 */
+#define PIN_PA22                    ( 22)  /**< Pin Number for PA22 */
+#define PIN_PA23                    ( 23)  /**< Pin Number for PA23 */
+#define PIN_PA30                    ( 30)  /**< Pin Number for PA30 */
+#define PIN_PA31                    ( 31)  /**< Pin Number for PA31 */
+
+
+/* ========== Peripheral I/O masks ========== */
+#define PORT_PA00                   (_U_(1) << 0) /**< PORT Mask for PA00 */
+#define PORT_PA01                   (_U_(1) << 1) /**< PORT Mask for PA01 */
+#define PORT_PA02                   (_U_(1) << 2) /**< PORT Mask for PA02 */
+#define PORT_PA03                   (_U_(1) << 3) /**< PORT Mask for PA03 */
+#define PORT_PA04                   (_U_(1) << 4) /**< PORT Mask for PA04 */
+#define PORT_PA05                   (_U_(1) << 5) /**< PORT Mask for PA05 */
+#define PORT_PA08                   (_U_(1) << 8) /**< PORT Mask for PA08 */
+#define PORT_PA14                   (_U_(1) << 14) /**< PORT Mask for PA14 */
+#define PORT_PA15                   (_U_(1) << 15) /**< PORT Mask for PA15 */
+#define PORT_PA16                   (_U_(1) << 16) /**< PORT Mask for PA16 */
+#define PORT_PA17                   (_U_(1) << 17) /**< PORT Mask for PA17 */
+#define PORT_PA18                   (_U_(1) << 18) /**< PORT Mask for PA18 */
+#define PORT_PA19                   (_U_(1) << 19) /**< PORT Mask for PA19 */
+#define PORT_PA22                   (_U_(1) << 22) /**< PORT Mask for PA22 */
+#define PORT_PA23                   (_U_(1) << 23) /**< PORT Mask for PA23 */
+#define PORT_PA30                   (_U_(1) << 30) /**< PORT Mask for PA30 */
+#define PORT_PA31                   (_U_(1) << 31) /**< PORT Mask for PA31 */
+
+
+/* ========== Peripheral I/O indexes ========== */
+#define PORT_PA00_IDX               (  0)  /**< PORT Index Number for PA00 */
+#define PORT_PA01_IDX               (  1)  /**< PORT Index Number for PA01 */
+#define PORT_PA02_IDX               (  2)  /**< PORT Index Number for PA02 */
+#define PORT_PA03_IDX               (  3)  /**< PORT Index Number for PA03 */
+#define PORT_PA04_IDX               (  4)  /**< PORT Index Number for PA04 */
+#define PORT_PA05_IDX               (  5)  /**< PORT Index Number for PA05 */
+#define PORT_PA08_IDX               (  8)  /**< PORT Index Number for PA08 */
+#define PORT_PA14_IDX               ( 14)  /**< PORT Index Number for PA14 */
+#define PORT_PA15_IDX               ( 15)  /**< PORT Index Number for PA15 */
+#define PORT_PA16_IDX               ( 16)  /**< PORT Index Number for PA16 */
+#define PORT_PA17_IDX               ( 17)  /**< PORT Index Number for PA17 */
+#define PORT_PA18_IDX               ( 18)  /**< PORT Index Number for PA18 */
+#define PORT_PA19_IDX               ( 19)  /**< PORT Index Number for PA19 */
+#define PORT_PA22_IDX               ( 22)  /**< PORT Index Number for PA22 */
+#define PORT_PA23_IDX               ( 23)  /**< PORT Index Number for PA23 */
+#define PORT_PA30_IDX               ( 30)  /**< PORT Index Number for PA30 */
+#define PORT_PA31_IDX               ( 31)  /**< PORT Index Number for PA31 */
+
+/* ========== PORT definition for AC peripheral ========== */
+#define PIN_PA04B_AC_AIN0                          _L_(4)       /**< AC signal: AIN0 on PA04 mux B*/
+#define MUX_PA04B_AC_AIN0                          _L_(1)      
+#define PINMUX_PA04B_AC_AIN0                       ((PIN_PA04B_AC_AIN0 << 16) | MUX_PA04B_AC_AIN0)
+#define PORT_PA04B_AC_AIN0                         (_UL_(1) << 4)
+
+#define PIN_PA05B_AC_AIN1                          _L_(5)       /**< AC signal: AIN1 on PA05 mux B*/
+#define MUX_PA05B_AC_AIN1                          _L_(1)      
+#define PINMUX_PA05B_AC_AIN1                       ((PIN_PA05B_AC_AIN1 << 16) | MUX_PA05B_AC_AIN1)
+#define PORT_PA05B_AC_AIN1                         (_UL_(1) << 5)
+
+#define PIN_PA18H_AC_CMP0                          _L_(18)      /**< AC signal: CMP0 on PA18 mux H*/
+#define MUX_PA18H_AC_CMP0                          _L_(7)      
+#define PINMUX_PA18H_AC_CMP0                       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
+#define PORT_PA18H_AC_CMP0                         (_UL_(1) << 18)
+
+#define PIN_PA19H_AC_CMP1                          _L_(19)      /**< AC signal: CMP1 on PA19 mux H*/
+#define MUX_PA19H_AC_CMP1                          _L_(7)      
+#define PINMUX_PA19H_AC_CMP1                       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
+#define PORT_PA19H_AC_CMP1                         (_UL_(1) << 19)
+
+/* ========== PORT definition for ADC peripheral ========== */
+#define PIN_PA02B_ADC_AIN0                         _L_(2)       /**< ADC signal: AIN0 on PA02 mux B*/
+#define MUX_PA02B_ADC_AIN0                         _L_(1)      
+#define PINMUX_PA02B_ADC_AIN0                      ((PIN_PA02B_ADC_AIN0 << 16) | MUX_PA02B_ADC_AIN0)
+#define PORT_PA02B_ADC_AIN0                        (_UL_(1) << 2)
+
+#define PIN_PA03B_ADC_AIN1                         _L_(3)       /**< ADC signal: AIN1 on PA03 mux B*/
+#define MUX_PA03B_ADC_AIN1                         _L_(1)      
+#define PINMUX_PA03B_ADC_AIN1                      ((PIN_PA03B_ADC_AIN1 << 16) | MUX_PA03B_ADC_AIN1)
+#define PORT_PA03B_ADC_AIN1                        (_UL_(1) << 3)
+
+#define PIN_PA04B_ADC_AIN2                         _L_(4)       /**< ADC signal: AIN2 on PA04 mux B*/
+#define MUX_PA04B_ADC_AIN2                         _L_(1)      
+#define PINMUX_PA04B_ADC_AIN2                      ((PIN_PA04B_ADC_AIN2 << 16) | MUX_PA04B_ADC_AIN2)
+#define PORT_PA04B_ADC_AIN2                        (_UL_(1) << 4)
+
+#define PIN_PA05B_ADC_AIN3                         _L_(5)       /**< ADC signal: AIN3 on PA05 mux B*/
+#define MUX_PA05B_ADC_AIN3                         _L_(1)      
+#define PINMUX_PA05B_ADC_AIN3                      ((PIN_PA05B_ADC_AIN3 << 16) | MUX_PA05B_ADC_AIN3)
+#define PORT_PA05B_ADC_AIN3                        (_UL_(1) << 5)
+
+#define PIN_PA08B_ADC_AIN6                         _L_(8)       /**< ADC signal: AIN6 on PA08 mux B*/
+#define MUX_PA08B_ADC_AIN6                         _L_(1)      
+#define PINMUX_PA08B_ADC_AIN6                      ((PIN_PA08B_ADC_AIN6 << 16) | MUX_PA08B_ADC_AIN6)
+#define PORT_PA08B_ADC_AIN6                        (_UL_(1) << 8)
+
+#define PIN_PA04B_ADC_VREFP                        _L_(4)       /**< ADC signal: VREFP on PA04 mux B*/
+#define MUX_PA04B_ADC_VREFP                        _L_(1)      
+#define PINMUX_PA04B_ADC_VREFP                     ((PIN_PA04B_ADC_VREFP << 16) | MUX_PA04B_ADC_VREFP)
+#define PORT_PA04B_ADC_VREFP                       (_UL_(1) << 4)
+
+/* ========== PORT definition for CCL peripheral ========== */
+#define PIN_PA04I_CCL_IN0                          _L_(4)       /**< CCL signal: IN0 on PA04 mux I*/
+#define MUX_PA04I_CCL_IN0                          _L_(8)      
+#define PINMUX_PA04I_CCL_IN0                       ((PIN_PA04I_CCL_IN0 << 16) | MUX_PA04I_CCL_IN0)
+#define PORT_PA04I_CCL_IN0                         (_UL_(1) << 4)
+
+#define PIN_PA16I_CCL_IN0                          _L_(16)      /**< CCL signal: IN0 on PA16 mux I*/
+#define MUX_PA16I_CCL_IN0                          _L_(8)      
+#define PINMUX_PA16I_CCL_IN0                       ((PIN_PA16I_CCL_IN0 << 16) | MUX_PA16I_CCL_IN0)
+#define PORT_PA16I_CCL_IN0                         (_UL_(1) << 16)
+
+#define PIN_PA05I_CCL_IN1                          _L_(5)       /**< CCL signal: IN1 on PA05 mux I*/
+#define MUX_PA05I_CCL_IN1                          _L_(8)      
+#define PINMUX_PA05I_CCL_IN1                       ((PIN_PA05I_CCL_IN1 << 16) | MUX_PA05I_CCL_IN1)
+#define PORT_PA05I_CCL_IN1                         (_UL_(1) << 5)
+
+#define PIN_PA17I_CCL_IN1                          _L_(17)      /**< CCL signal: IN1 on PA17 mux I*/
+#define MUX_PA17I_CCL_IN1                          _L_(8)      
+#define PINMUX_PA17I_CCL_IN1                       ((PIN_PA17I_CCL_IN1 << 16) | MUX_PA17I_CCL_IN1)
+#define PORT_PA17I_CCL_IN1                         (_UL_(1) << 17)
+
+#define PIN_PA18I_CCL_IN2                          _L_(18)      /**< CCL signal: IN2 on PA18 mux I*/
+#define MUX_PA18I_CCL_IN2                          _L_(8)      
+#define PINMUX_PA18I_CCL_IN2                       ((PIN_PA18I_CCL_IN2 << 16) | MUX_PA18I_CCL_IN2)
+#define PORT_PA18I_CCL_IN2                         (_UL_(1) << 18)
+
+#define PIN_PA08I_CCL_IN3                          _L_(8)       /**< CCL signal: IN3 on PA08 mux I*/
+#define MUX_PA08I_CCL_IN3                          _L_(8)      
+#define PINMUX_PA08I_CCL_IN3                       ((PIN_PA08I_CCL_IN3 << 16) | MUX_PA08I_CCL_IN3)
+#define PORT_PA08I_CCL_IN3                         (_UL_(1) << 8)
+
+#define PIN_PA30I_CCL_IN3                          _L_(30)      /**< CCL signal: IN3 on PA30 mux I*/
+#define MUX_PA30I_CCL_IN3                          _L_(8)      
+#define PINMUX_PA30I_CCL_IN3                       ((PIN_PA30I_CCL_IN3 << 16) | MUX_PA30I_CCL_IN3)
+#define PORT_PA30I_CCL_IN3                         (_UL_(1) << 30)
+
+#define PIN_PA19I_CCL_OUT0                         _L_(19)      /**< CCL signal: OUT0 on PA19 mux I*/
+#define MUX_PA19I_CCL_OUT0                         _L_(8)      
+#define PINMUX_PA19I_CCL_OUT0                      ((PIN_PA19I_CCL_OUT0 << 16) | MUX_PA19I_CCL_OUT0)
+#define PORT_PA19I_CCL_OUT0                        (_UL_(1) << 19)
+
+#define PIN_PA31I_CCL_OUT1                         _L_(31)      /**< CCL signal: OUT1 on PA31 mux I*/
+#define MUX_PA31I_CCL_OUT1                         _L_(8)      
+#define PINMUX_PA31I_CCL_OUT1                      ((PIN_PA31I_CCL_OUT1 << 16) | MUX_PA31I_CCL_OUT1)
+#define PORT_PA31I_CCL_OUT1                        (_UL_(1) << 31)
+
+/* ========== PORT definition for DAC peripheral ========== */
+#define PIN_PA02B_DAC_VOUT                         _L_(2)       /**< DAC signal: VOUT on PA02 mux B*/
+#define MUX_PA02B_DAC_VOUT                         _L_(1)      
+#define PINMUX_PA02B_DAC_VOUT                      ((PIN_PA02B_DAC_VOUT << 16) | MUX_PA02B_DAC_VOUT)
+#define PORT_PA02B_DAC_VOUT                        (_UL_(1) << 2)
+
+#define PIN_PA03B_DAC_VREFP                        _L_(3)       /**< DAC signal: VREFP on PA03 mux B*/
+#define MUX_PA03B_DAC_VREFP                        _L_(1)      
+#define PINMUX_PA03B_DAC_VREFP                     ((PIN_PA03B_DAC_VREFP << 16) | MUX_PA03B_DAC_VREFP)
+#define PORT_PA03B_DAC_VREFP                       (_UL_(1) << 3)
+
+/* ========== PORT definition for EIC peripheral ========== */
+#define PIN_PA19A_EIC_EXTINT0                      _L_(19)      /**< EIC signal: EXTINT0 on PA19 mux A*/
+#define MUX_PA19A_EIC_EXTINT0                      _L_(0)      
+#define PINMUX_PA19A_EIC_EXTINT0                   ((PIN_PA19A_EIC_EXTINT0 << 16) | MUX_PA19A_EIC_EXTINT0)
+#define PORT_PA19A_EIC_EXTINT0                     (_UL_(1) << 19)
+#define PIN_PA19A_EIC_EXTINT_NUM                   _L_(0)       /**< EIC signal: PIN_PA19 External Interrupt Line */
+
+#define PIN_PA00A_EIC_EXTINT0                      _L_(0)       /**< EIC signal: EXTINT0 on PA00 mux A*/
+#define MUX_PA00A_EIC_EXTINT0                      _L_(0)      
+#define PINMUX_PA00A_EIC_EXTINT0                   ((PIN_PA00A_EIC_EXTINT0 << 16) | MUX_PA00A_EIC_EXTINT0)
+#define PORT_PA00A_EIC_EXTINT0                     (_UL_(1) << 0)
+#define PIN_PA00A_EIC_EXTINT_NUM                   _L_(0)       /**< EIC signal: PIN_PA00 External Interrupt Line */
+
+#define PIN_PA22A_EIC_EXTINT1                      _L_(22)      /**< EIC signal: EXTINT1 on PA22 mux A*/
+#define MUX_PA22A_EIC_EXTINT1                      _L_(0)      
+#define PINMUX_PA22A_EIC_EXTINT1                   ((PIN_PA22A_EIC_EXTINT1 << 16) | MUX_PA22A_EIC_EXTINT1)
+#define PORT_PA22A_EIC_EXTINT1                     (_UL_(1) << 22)
+#define PIN_PA22A_EIC_EXTINT_NUM                   _L_(1)       /**< EIC signal: PIN_PA22 External Interrupt Line */
+
+#define PIN_PA01A_EIC_EXTINT1                      _L_(1)       /**< EIC signal: EXTINT1 on PA01 mux A*/
+#define MUX_PA01A_EIC_EXTINT1                      _L_(0)      
+#define PINMUX_PA01A_EIC_EXTINT1                   ((PIN_PA01A_EIC_EXTINT1 << 16) | MUX_PA01A_EIC_EXTINT1)
+#define PORT_PA01A_EIC_EXTINT1                     (_UL_(1) << 1)
+#define PIN_PA01A_EIC_EXTINT_NUM                   _L_(1)       /**< EIC signal: PIN_PA01 External Interrupt Line */
+
+#define PIN_PA02A_EIC_EXTINT2                      _L_(2)       /**< EIC signal: EXTINT2 on PA02 mux A*/
+#define MUX_PA02A_EIC_EXTINT2                      _L_(0)      
+#define PINMUX_PA02A_EIC_EXTINT2                   ((PIN_PA02A_EIC_EXTINT2 << 16) | MUX_PA02A_EIC_EXTINT2)
+#define PORT_PA02A_EIC_EXTINT2                     (_UL_(1) << 2)
+#define PIN_PA02A_EIC_EXTINT_NUM                   _L_(2)       /**< EIC signal: PIN_PA02 External Interrupt Line */
+
+#define PIN_PA23A_EIC_EXTINT2                      _L_(23)      /**< EIC signal: EXTINT2 on PA23 mux A*/
+#define MUX_PA23A_EIC_EXTINT2                      _L_(0)      
+#define PINMUX_PA23A_EIC_EXTINT2                   ((PIN_PA23A_EIC_EXTINT2 << 16) | MUX_PA23A_EIC_EXTINT2)
+#define PORT_PA23A_EIC_EXTINT2                     (_UL_(1) << 23)
+#define PIN_PA23A_EIC_EXTINT_NUM                   _L_(2)       /**< EIC signal: PIN_PA23 External Interrupt Line */
+
+#define PIN_PA03A_EIC_EXTINT3                      _L_(3)       /**< EIC signal: EXTINT3 on PA03 mux A*/
+#define MUX_PA03A_EIC_EXTINT3                      _L_(0)      
+#define PINMUX_PA03A_EIC_EXTINT3                   ((PIN_PA03A_EIC_EXTINT3 << 16) | MUX_PA03A_EIC_EXTINT3)
+#define PORT_PA03A_EIC_EXTINT3                     (_UL_(1) << 3)
+#define PIN_PA03A_EIC_EXTINT_NUM                   _L_(3)       /**< EIC signal: PIN_PA03 External Interrupt Line */
+
+#define PIN_PA14A_EIC_EXTINT3                      _L_(14)      /**< EIC signal: EXTINT3 on PA14 mux A*/
+#define MUX_PA14A_EIC_EXTINT3                      _L_(0)      
+#define PINMUX_PA14A_EIC_EXTINT3                   ((PIN_PA14A_EIC_EXTINT3 << 16) | MUX_PA14A_EIC_EXTINT3)
+#define PORT_PA14A_EIC_EXTINT3                     (_UL_(1) << 14)
+#define PIN_PA14A_EIC_EXTINT_NUM                   _L_(3)       /**< EIC signal: PIN_PA14 External Interrupt Line */
+
+#define PIN_PA04A_EIC_EXTINT4                      _L_(4)       /**< EIC signal: EXTINT4 on PA04 mux A*/
+#define MUX_PA04A_EIC_EXTINT4                      _L_(0)      
+#define PINMUX_PA04A_EIC_EXTINT4                   ((PIN_PA04A_EIC_EXTINT4 << 16) | MUX_PA04A_EIC_EXTINT4)
+#define PORT_PA04A_EIC_EXTINT4                     (_UL_(1) << 4)
+#define PIN_PA04A_EIC_EXTINT_NUM                   _L_(4)       /**< EIC signal: PIN_PA04 External Interrupt Line */
+
+#define PIN_PA15A_EIC_EXTINT4                      _L_(15)      /**< EIC signal: EXTINT4 on PA15 mux A*/
+#define MUX_PA15A_EIC_EXTINT4                      _L_(0)      
+#define PINMUX_PA15A_EIC_EXTINT4                   ((PIN_PA15A_EIC_EXTINT4 << 16) | MUX_PA15A_EIC_EXTINT4)
+#define PORT_PA15A_EIC_EXTINT4                     (_UL_(1) << 15)
+#define PIN_PA15A_EIC_EXTINT_NUM                   _L_(4)       /**< EIC signal: PIN_PA15 External Interrupt Line */
+
+#define PIN_PA05A_EIC_EXTINT5                      _L_(5)       /**< EIC signal: EXTINT5 on PA05 mux A*/
+#define MUX_PA05A_EIC_EXTINT5                      _L_(0)      
+#define PINMUX_PA05A_EIC_EXTINT5                   ((PIN_PA05A_EIC_EXTINT5 << 16) | MUX_PA05A_EIC_EXTINT5)
+#define PORT_PA05A_EIC_EXTINT5                     (_UL_(1) << 5)
+#define PIN_PA05A_EIC_EXTINT_NUM                   _L_(5)       /**< EIC signal: PIN_PA05 External Interrupt Line */
+
+#define PIN_PA16A_EIC_EXTINT5                      _L_(16)      /**< EIC signal: EXTINT5 on PA16 mux A*/
+#define MUX_PA16A_EIC_EXTINT5                      _L_(0)      
+#define PINMUX_PA16A_EIC_EXTINT5                   ((PIN_PA16A_EIC_EXTINT5 << 16) | MUX_PA16A_EIC_EXTINT5)
+#define PORT_PA16A_EIC_EXTINT5                     (_UL_(1) << 16)
+#define PIN_PA16A_EIC_EXTINT_NUM                   _L_(5)       /**< EIC signal: PIN_PA16 External Interrupt Line */
+
+#define PIN_PA17A_EIC_EXTINT6                      _L_(17)      /**< EIC signal: EXTINT6 on PA17 mux A*/
+#define MUX_PA17A_EIC_EXTINT6                      _L_(0)      
+#define PINMUX_PA17A_EIC_EXTINT6                   ((PIN_PA17A_EIC_EXTINT6 << 16) | MUX_PA17A_EIC_EXTINT6)
+#define PORT_PA17A_EIC_EXTINT6                     (_UL_(1) << 17)
+#define PIN_PA17A_EIC_EXTINT_NUM                   _L_(6)       /**< EIC signal: PIN_PA17 External Interrupt Line */
+
+#define PIN_PA30A_EIC_EXTINT6                      _L_(30)      /**< EIC signal: EXTINT6 on PA30 mux A*/
+#define MUX_PA30A_EIC_EXTINT6                      _L_(0)      
+#define PINMUX_PA30A_EIC_EXTINT6                   ((PIN_PA30A_EIC_EXTINT6 << 16) | MUX_PA30A_EIC_EXTINT6)
+#define PORT_PA30A_EIC_EXTINT6                     (_UL_(1) << 30)
+#define PIN_PA30A_EIC_EXTINT_NUM                   _L_(6)       /**< EIC signal: PIN_PA30 External Interrupt Line */
+
+#define PIN_PA18A_EIC_EXTINT7                      _L_(18)      /**< EIC signal: EXTINT7 on PA18 mux A*/
+#define MUX_PA18A_EIC_EXTINT7                      _L_(0)      
+#define PINMUX_PA18A_EIC_EXTINT7                   ((PIN_PA18A_EIC_EXTINT7 << 16) | MUX_PA18A_EIC_EXTINT7)
+#define PORT_PA18A_EIC_EXTINT7                     (_UL_(1) << 18)
+#define PIN_PA18A_EIC_EXTINT_NUM                   _L_(7)       /**< EIC signal: PIN_PA18 External Interrupt Line */
+
+#define PIN_PA31A_EIC_EXTINT7                      _L_(31)      /**< EIC signal: EXTINT7 on PA31 mux A*/
+#define MUX_PA31A_EIC_EXTINT7                      _L_(0)      
+#define PINMUX_PA31A_EIC_EXTINT7                   ((PIN_PA31A_EIC_EXTINT7 << 16) | MUX_PA31A_EIC_EXTINT7)
+#define PORT_PA31A_EIC_EXTINT7                     (_UL_(1) << 31)
+#define PIN_PA31A_EIC_EXTINT_NUM                   _L_(7)       /**< EIC signal: PIN_PA31 External Interrupt Line */
+
+#define PIN_PA08A_EIC_NMI                          _L_(8)       /**< EIC signal: NMI on PA08 mux A*/
+#define MUX_PA08A_EIC_NMI                          _L_(0)      
+#define PINMUX_PA08A_EIC_NMI                       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
+#define PORT_PA08A_EIC_NMI                         (_UL_(1) << 8)
+
+/* ========== PORT definition for GCLK peripheral ========== */
+#define PIN_PA30H_GCLK_IO0                         _L_(30)      /**< GCLK signal: IO0 on PA30 mux H*/
+#define MUX_PA30H_GCLK_IO0                         _L_(7)      
+#define PINMUX_PA30H_GCLK_IO0                      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
+#define PORT_PA30H_GCLK_IO0                        (_UL_(1) << 30)
+
+#define PIN_PA14H_GCLK_IO0                         _L_(14)      /**< GCLK signal: IO0 on PA14 mux H*/
+#define MUX_PA14H_GCLK_IO0                         _L_(7)      
+#define PINMUX_PA14H_GCLK_IO0                      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
+#define PORT_PA14H_GCLK_IO0                        (_UL_(1) << 14)
+
+#define PIN_PA23H_GCLK_IO1                         _L_(23)      /**< GCLK signal: IO1 on PA23 mux H*/
+#define MUX_PA23H_GCLK_IO1                         _L_(7)      
+#define PINMUX_PA23H_GCLK_IO1                      ((PIN_PA23H_GCLK_IO1 << 16) | MUX_PA23H_GCLK_IO1)
+#define PORT_PA23H_GCLK_IO1                        (_UL_(1) << 23)
+
+#define PIN_PA15H_GCLK_IO1                         _L_(15)      /**< GCLK signal: IO1 on PA15 mux H*/
+#define MUX_PA15H_GCLK_IO1                         _L_(7)      
+#define PINMUX_PA15H_GCLK_IO1                      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
+#define PORT_PA15H_GCLK_IO1                        (_UL_(1) << 15)
+
+#define PIN_PA16H_GCLK_IO2                         _L_(16)      /**< GCLK signal: IO2 on PA16 mux H*/
+#define MUX_PA16H_GCLK_IO2                         _L_(7)      
+#define PINMUX_PA16H_GCLK_IO2                      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
+#define PORT_PA16H_GCLK_IO2                        (_UL_(1) << 16)
+
+#define PIN_PA22H_GCLK_IO2                         _L_(22)      /**< GCLK signal: IO2 on PA22 mux H*/
+#define MUX_PA22H_GCLK_IO2                         _L_(7)      
+#define PINMUX_PA22H_GCLK_IO2                      ((PIN_PA22H_GCLK_IO2 << 16) | MUX_PA22H_GCLK_IO2)
+#define PORT_PA22H_GCLK_IO2                        (_UL_(1) << 22)
+
+#define PIN_PA17H_GCLK_IO3                         _L_(17)      /**< GCLK signal: IO3 on PA17 mux H*/
+#define MUX_PA17H_GCLK_IO3                         _L_(7)      
+#define PINMUX_PA17H_GCLK_IO3                      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
+#define PORT_PA17H_GCLK_IO3                        (_UL_(1) << 17)
+
+/* ========== PORT definition for OPAMP peripheral ========== */
+#define PIN_PA02B_OPAMP_OANEG0                     _L_(2)       /**< OPAMP signal: OANEG0 on PA02 mux B*/
+#define MUX_PA02B_OPAMP_OANEG0                     _L_(1)      
+#define PINMUX_PA02B_OPAMP_OANEG0                  ((PIN_PA02B_OPAMP_OANEG0 << 16) | MUX_PA02B_OPAMP_OANEG0)
+#define PORT_PA02B_OPAMP_OANEG0                    (_UL_(1) << 2)
+
+#define PIN_PA00B_OPAMP_OANEG1                     _L_(0)       /**< OPAMP signal: OANEG1 on PA00 mux B*/
+#define MUX_PA00B_OPAMP_OANEG1                     _L_(1)      
+#define PINMUX_PA00B_OPAMP_OANEG1                  ((PIN_PA00B_OPAMP_OANEG1 << 16) | MUX_PA00B_OPAMP_OANEG1)
+#define PORT_PA00B_OPAMP_OANEG1                    (_UL_(1) << 0)
+
+#define PIN_PA03B_OPAMP_OANEG2                     _L_(3)       /**< OPAMP signal: OANEG2 on PA03 mux B*/
+#define MUX_PA03B_OPAMP_OANEG2                     _L_(1)      
+#define PINMUX_PA03B_OPAMP_OANEG2                  ((PIN_PA03B_OPAMP_OANEG2 << 16) | MUX_PA03B_OPAMP_OANEG2)
+#define PORT_PA03B_OPAMP_OANEG2                    (_UL_(1) << 3)
+
+#define PIN_PA04B_OPAMP_OAOUT2                     _L_(4)       /**< OPAMP signal: OAOUT2 on PA04 mux B*/
+#define MUX_PA04B_OPAMP_OAOUT2                     _L_(1)      
+#define PINMUX_PA04B_OPAMP_OAOUT2                  ((PIN_PA04B_OPAMP_OAOUT2 << 16) | MUX_PA04B_OPAMP_OAOUT2)
+#define PORT_PA04B_OPAMP_OAOUT2                    (_UL_(1) << 4)
+
+#define PIN_PA01B_OPAMP_OAPOS1                     _L_(1)       /**< OPAMP signal: OAPOS1 on PA01 mux B*/
+#define MUX_PA01B_OPAMP_OAPOS1                     _L_(1)      
+#define PINMUX_PA01B_OPAMP_OAPOS1                  ((PIN_PA01B_OPAMP_OAPOS1 << 16) | MUX_PA01B_OPAMP_OAPOS1)
+#define PORT_PA01B_OPAMP_OAPOS1                    (_UL_(1) << 1)
+
+#define PIN_PA05B_OPAMP_OAPOS2                     _L_(5)       /**< OPAMP signal: OAPOS2 on PA05 mux B*/
+#define MUX_PA05B_OPAMP_OAPOS2                     _L_(1)      
+#define PINMUX_PA05B_OPAMP_OAPOS2                  ((PIN_PA05B_OPAMP_OAPOS2 << 16) | MUX_PA05B_OPAMP_OAPOS2)
+#define PORT_PA05B_OPAMP_OAPOS2                    (_UL_(1) << 5)
+
+/* ========== PORT definition for PTC peripheral ========== */
+#define PIN_PA00F_PTC_DRV0                         _L_(0)       /**< PTC signal: DRV0 on PA00 mux F*/
+#define MUX_PA00F_PTC_DRV0                         _L_(5)      
+#define PINMUX_PA00F_PTC_DRV0                      ((PIN_PA00F_PTC_DRV0 << 16) | MUX_PA00F_PTC_DRV0)
+#define PORT_PA00F_PTC_DRV0                        (_UL_(1) << 0)
+
+#define PIN_PA01F_PTC_DRV1                         _L_(1)       /**< PTC signal: DRV1 on PA01 mux F*/
+#define MUX_PA01F_PTC_DRV1                         _L_(5)      
+#define PINMUX_PA01F_PTC_DRV1                      ((PIN_PA01F_PTC_DRV1 << 16) | MUX_PA01F_PTC_DRV1)
+#define PORT_PA01F_PTC_DRV1                        (_UL_(1) << 1)
+
+#define PIN_PA02F_PTC_DRV2                         _L_(2)       /**< PTC signal: DRV2 on PA02 mux F*/
+#define MUX_PA02F_PTC_DRV2                         _L_(5)      
+#define PINMUX_PA02F_PTC_DRV2                      ((PIN_PA02F_PTC_DRV2 << 16) | MUX_PA02F_PTC_DRV2)
+#define PORT_PA02F_PTC_DRV2                        (_UL_(1) << 2)
+
+#define PIN_PA03F_PTC_DRV3                         _L_(3)       /**< PTC signal: DRV3 on PA03 mux F*/
+#define MUX_PA03F_PTC_DRV3                         _L_(5)      
+#define PINMUX_PA03F_PTC_DRV3                      ((PIN_PA03F_PTC_DRV3 << 16) | MUX_PA03F_PTC_DRV3)
+#define PORT_PA03F_PTC_DRV3                        (_UL_(1) << 3)
+
+#define PIN_PA05F_PTC_DRV4                         _L_(5)       /**< PTC signal: DRV4 on PA05 mux F*/
+#define MUX_PA05F_PTC_DRV4                         _L_(5)      
+#define PINMUX_PA05F_PTC_DRV4                      ((PIN_PA05F_PTC_DRV4 << 16) | MUX_PA05F_PTC_DRV4)
+#define PORT_PA05F_PTC_DRV4                        (_UL_(1) << 5)
+
+#define PIN_PA08F_PTC_DRV6                         _L_(8)       /**< PTC signal: DRV6 on PA08 mux F*/
+#define MUX_PA08F_PTC_DRV6                         _L_(5)      
+#define PINMUX_PA08F_PTC_DRV6                      ((PIN_PA08F_PTC_DRV6 << 16) | MUX_PA08F_PTC_DRV6)
+#define PORT_PA08F_PTC_DRV6                        (_UL_(1) << 8)
+
+#define PIN_PA14F_PTC_DRV10                        _L_(14)      /**< PTC signal: DRV10 on PA14 mux F*/
+#define MUX_PA14F_PTC_DRV10                        _L_(5)      
+#define PINMUX_PA14F_PTC_DRV10                     ((PIN_PA14F_PTC_DRV10 << 16) | MUX_PA14F_PTC_DRV10)
+#define PORT_PA14F_PTC_DRV10                       (_UL_(1) << 14)
+
+#define PIN_PA15F_PTC_DRV11                        _L_(15)      /**< PTC signal: DRV11 on PA15 mux F*/
+#define MUX_PA15F_PTC_DRV11                        _L_(5)      
+#define PINMUX_PA15F_PTC_DRV11                     ((PIN_PA15F_PTC_DRV11 << 16) | MUX_PA15F_PTC_DRV11)
+#define PORT_PA15F_PTC_DRV11                       (_UL_(1) << 15)
+
+#define PIN_PA16F_PTC_DRV12                        _L_(16)      /**< PTC signal: DRV12 on PA16 mux F*/
+#define MUX_PA16F_PTC_DRV12                        _L_(5)      
+#define PINMUX_PA16F_PTC_DRV12                     ((PIN_PA16F_PTC_DRV12 << 16) | MUX_PA16F_PTC_DRV12)
+#define PORT_PA16F_PTC_DRV12                       (_UL_(1) << 16)
+
+#define PIN_PA17F_PTC_DRV13                        _L_(17)      /**< PTC signal: DRV13 on PA17 mux F*/
+#define MUX_PA17F_PTC_DRV13                        _L_(5)      
+#define PINMUX_PA17F_PTC_DRV13                     ((PIN_PA17F_PTC_DRV13 << 16) | MUX_PA17F_PTC_DRV13)
+#define PORT_PA17F_PTC_DRV13                       (_UL_(1) << 17)
+
+#define PIN_PA18F_PTC_DRV14                        _L_(18)      /**< PTC signal: DRV14 on PA18 mux F*/
+#define MUX_PA18F_PTC_DRV14                        _L_(5)      
+#define PINMUX_PA18F_PTC_DRV14                     ((PIN_PA18F_PTC_DRV14 << 16) | MUX_PA18F_PTC_DRV14)
+#define PORT_PA18F_PTC_DRV14                       (_UL_(1) << 18)
+
+#define PIN_PA19F_PTC_DRV15                        _L_(19)      /**< PTC signal: DRV15 on PA19 mux F*/
+#define MUX_PA19F_PTC_DRV15                        _L_(5)      
+#define PINMUX_PA19F_PTC_DRV15                     ((PIN_PA19F_PTC_DRV15 << 16) | MUX_PA19F_PTC_DRV15)
+#define PORT_PA19F_PTC_DRV15                       (_UL_(1) << 19)
+
+#define PIN_PA22F_PTC_DRV16                        _L_(22)      /**< PTC signal: DRV16 on PA22 mux F*/
+#define MUX_PA22F_PTC_DRV16                        _L_(5)      
+#define PINMUX_PA22F_PTC_DRV16                     ((PIN_PA22F_PTC_DRV16 << 16) | MUX_PA22F_PTC_DRV16)
+#define PORT_PA22F_PTC_DRV16                       (_UL_(1) << 22)
+
+#define PIN_PA23F_PTC_DRV17                        _L_(23)      /**< PTC signal: DRV17 on PA23 mux F*/
+#define MUX_PA23F_PTC_DRV17                        _L_(5)      
+#define PINMUX_PA23F_PTC_DRV17                     ((PIN_PA23F_PTC_DRV17 << 16) | MUX_PA23F_PTC_DRV17)
+#define PORT_PA23F_PTC_DRV17                       (_UL_(1) << 23)
+
+#define PIN_PA30F_PTC_DRV18                        _L_(30)      /**< PTC signal: DRV18 on PA30 mux F*/
+#define MUX_PA30F_PTC_DRV18                        _L_(5)      
+#define PINMUX_PA30F_PTC_DRV18                     ((PIN_PA30F_PTC_DRV18 << 16) | MUX_PA30F_PTC_DRV18)
+#define PORT_PA30F_PTC_DRV18                       (_UL_(1) << 30)
+
+#define PIN_PA31F_PTC_DRV19                        _L_(31)      /**< PTC signal: DRV19 on PA31 mux F*/
+#define MUX_PA31F_PTC_DRV19                        _L_(5)      
+#define PINMUX_PA31F_PTC_DRV19                     ((PIN_PA31F_PTC_DRV19 << 16) | MUX_PA31F_PTC_DRV19)
+#define PORT_PA31F_PTC_DRV19                       (_UL_(1) << 31)
+
+#define PIN_PA03B_PTC_ECI0                         _L_(3)       /**< PTC signal: ECI0 on PA03 mux B*/
+#define MUX_PA03B_PTC_ECI0                         _L_(1)      
+#define PINMUX_PA03B_PTC_ECI0                      ((PIN_PA03B_PTC_ECI0 << 16) | MUX_PA03B_PTC_ECI0)
+#define PORT_PA03B_PTC_ECI0                        (_UL_(1) << 3)
+
+#define PIN_PA04B_PTC_ECI1                         _L_(4)       /**< PTC signal: ECI1 on PA04 mux B*/
+#define MUX_PA04B_PTC_ECI1                         _L_(1)      
+#define PINMUX_PA04B_PTC_ECI1                      ((PIN_PA04B_PTC_ECI1 << 16) | MUX_PA04B_PTC_ECI1)
+#define PORT_PA04B_PTC_ECI1                        (_UL_(1) << 4)
+
+#define PIN_PA05B_PTC_ECI2                         _L_(5)       /**< PTC signal: ECI2 on PA05 mux B*/
+#define MUX_PA05B_PTC_ECI2                         _L_(1)      
+#define PINMUX_PA05B_PTC_ECI2                      ((PIN_PA05B_PTC_ECI2 << 16) | MUX_PA05B_PTC_ECI2)
+#define PORT_PA05B_PTC_ECI2                        (_UL_(1) << 5)
+
+#define PIN_PA00B_PTC_X0                           _L_(0)       /**< PTC signal: X0 on PA00 mux B*/
+#define MUX_PA00B_PTC_X0                           _L_(1)      
+#define PINMUX_PA00B_PTC_X0                        ((PIN_PA00B_PTC_X0 << 16) | MUX_PA00B_PTC_X0)
+#define PORT_PA00B_PTC_X0                          (_UL_(1) << 0)
+
+#define PIN_PA00B_PTC_Y0                           _L_(0)       /**< PTC signal: Y0 on PA00 mux B*/
+#define MUX_PA00B_PTC_Y0                           _L_(1)      
+#define PINMUX_PA00B_PTC_Y0                        ((PIN_PA00B_PTC_Y0 << 16) | MUX_PA00B_PTC_Y0)
+#define PORT_PA00B_PTC_Y0                          (_UL_(1) << 0)
+
+#define PIN_PA01B_PTC_X1                           _L_(1)       /**< PTC signal: X1 on PA01 mux B*/
+#define MUX_PA01B_PTC_X1                           _L_(1)      
+#define PINMUX_PA01B_PTC_X1                        ((PIN_PA01B_PTC_X1 << 16) | MUX_PA01B_PTC_X1)
+#define PORT_PA01B_PTC_X1                          (_UL_(1) << 1)
+
+#define PIN_PA01B_PTC_Y1                           _L_(1)       /**< PTC signal: Y1 on PA01 mux B*/
+#define MUX_PA01B_PTC_Y1                           _L_(1)      
+#define PINMUX_PA01B_PTC_Y1                        ((PIN_PA01B_PTC_Y1 << 16) | MUX_PA01B_PTC_Y1)
+#define PORT_PA01B_PTC_Y1                          (_UL_(1) << 1)
+
+#define PIN_PA02B_PTC_X2                           _L_(2)       /**< PTC signal: X2 on PA02 mux B*/
+#define MUX_PA02B_PTC_X2                           _L_(1)      
+#define PINMUX_PA02B_PTC_X2                        ((PIN_PA02B_PTC_X2 << 16) | MUX_PA02B_PTC_X2)
+#define PORT_PA02B_PTC_X2                          (_UL_(1) << 2)
+
+#define PIN_PA02B_PTC_Y2                           _L_(2)       /**< PTC signal: Y2 on PA02 mux B*/
+#define MUX_PA02B_PTC_Y2                           _L_(1)      
+#define PINMUX_PA02B_PTC_Y2                        ((PIN_PA02B_PTC_Y2 << 16) | MUX_PA02B_PTC_Y2)
+#define PORT_PA02B_PTC_Y2                          (_UL_(1) << 2)
+
+#define PIN_PA03B_PTC_X3                           _L_(3)       /**< PTC signal: X3 on PA03 mux B*/
+#define MUX_PA03B_PTC_X3                           _L_(1)      
+#define PINMUX_PA03B_PTC_X3                        ((PIN_PA03B_PTC_X3 << 16) | MUX_PA03B_PTC_X3)
+#define PORT_PA03B_PTC_X3                          (_UL_(1) << 3)
+
+#define PIN_PA03B_PTC_Y3                           _L_(3)       /**< PTC signal: Y3 on PA03 mux B*/
+#define MUX_PA03B_PTC_Y3                           _L_(1)      
+#define PINMUX_PA03B_PTC_Y3                        ((PIN_PA03B_PTC_Y3 << 16) | MUX_PA03B_PTC_Y3)
+#define PORT_PA03B_PTC_Y3                          (_UL_(1) << 3)
+
+#define PIN_PA05B_PTC_X4                           _L_(5)       /**< PTC signal: X4 on PA05 mux B*/
+#define MUX_PA05B_PTC_X4                           _L_(1)      
+#define PINMUX_PA05B_PTC_X4                        ((PIN_PA05B_PTC_X4 << 16) | MUX_PA05B_PTC_X4)
+#define PORT_PA05B_PTC_X4                          (_UL_(1) << 5)
+
+#define PIN_PA05B_PTC_Y4                           _L_(5)       /**< PTC signal: Y4 on PA05 mux B*/
+#define MUX_PA05B_PTC_Y4                           _L_(1)      
+#define PINMUX_PA05B_PTC_Y4                        ((PIN_PA05B_PTC_Y4 << 16) | MUX_PA05B_PTC_Y4)
+#define PORT_PA05B_PTC_Y4                          (_UL_(1) << 5)
+
+#define PIN_PA08B_PTC_X6                           _L_(8)       /**< PTC signal: X6 on PA08 mux B*/
+#define MUX_PA08B_PTC_X6                           _L_(1)      
+#define PINMUX_PA08B_PTC_X6                        ((PIN_PA08B_PTC_X6 << 16) | MUX_PA08B_PTC_X6)
+#define PORT_PA08B_PTC_X6                          (_UL_(1) << 8)
+
+#define PIN_PA08B_PTC_Y6                           _L_(8)       /**< PTC signal: Y6 on PA08 mux B*/
+#define MUX_PA08B_PTC_Y6                           _L_(1)      
+#define PINMUX_PA08B_PTC_Y6                        ((PIN_PA08B_PTC_Y6 << 16) | MUX_PA08B_PTC_Y6)
+#define PORT_PA08B_PTC_Y6                          (_UL_(1) << 8)
+
+#define PIN_PA14B_PTC_X10                          _L_(14)      /**< PTC signal: X10 on PA14 mux B*/
+#define MUX_PA14B_PTC_X10                          _L_(1)      
+#define PINMUX_PA14B_PTC_X10                       ((PIN_PA14B_PTC_X10 << 16) | MUX_PA14B_PTC_X10)
+#define PORT_PA14B_PTC_X10                         (_UL_(1) << 14)
+
+#define PIN_PA14B_PTC_Y10                          _L_(14)      /**< PTC signal: Y10 on PA14 mux B*/
+#define MUX_PA14B_PTC_Y10                          _L_(1)      
+#define PINMUX_PA14B_PTC_Y10                       ((PIN_PA14B_PTC_Y10 << 16) | MUX_PA14B_PTC_Y10)
+#define PORT_PA14B_PTC_Y10                         (_UL_(1) << 14)
+
+#define PIN_PA15B_PTC_X11                          _L_(15)      /**< PTC signal: X11 on PA15 mux B*/
+#define MUX_PA15B_PTC_X11                          _L_(1)      
+#define PINMUX_PA15B_PTC_X11                       ((PIN_PA15B_PTC_X11 << 16) | MUX_PA15B_PTC_X11)
+#define PORT_PA15B_PTC_X11                         (_UL_(1) << 15)
+
+#define PIN_PA15B_PTC_Y11                          _L_(15)      /**< PTC signal: Y11 on PA15 mux B*/
+#define MUX_PA15B_PTC_Y11                          _L_(1)      
+#define PINMUX_PA15B_PTC_Y11                       ((PIN_PA15B_PTC_Y11 << 16) | MUX_PA15B_PTC_Y11)
+#define PORT_PA15B_PTC_Y11                         (_UL_(1) << 15)
+
+#define PIN_PA16B_PTC_X12                          _L_(16)      /**< PTC signal: X12 on PA16 mux B*/
+#define MUX_PA16B_PTC_X12                          _L_(1)      
+#define PINMUX_PA16B_PTC_X12                       ((PIN_PA16B_PTC_X12 << 16) | MUX_PA16B_PTC_X12)
+#define PORT_PA16B_PTC_X12                         (_UL_(1) << 16)
+
+#define PIN_PA16B_PTC_Y12                          _L_(16)      /**< PTC signal: Y12 on PA16 mux B*/
+#define MUX_PA16B_PTC_Y12                          _L_(1)      
+#define PINMUX_PA16B_PTC_Y12                       ((PIN_PA16B_PTC_Y12 << 16) | MUX_PA16B_PTC_Y12)
+#define PORT_PA16B_PTC_Y12                         (_UL_(1) << 16)
+
+#define PIN_PA17B_PTC_X13                          _L_(17)      /**< PTC signal: X13 on PA17 mux B*/
+#define MUX_PA17B_PTC_X13                          _L_(1)      
+#define PINMUX_PA17B_PTC_X13                       ((PIN_PA17B_PTC_X13 << 16) | MUX_PA17B_PTC_X13)
+#define PORT_PA17B_PTC_X13                         (_UL_(1) << 17)
+
+#define PIN_PA17B_PTC_Y13                          _L_(17)      /**< PTC signal: Y13 on PA17 mux B*/
+#define MUX_PA17B_PTC_Y13                          _L_(1)      
+#define PINMUX_PA17B_PTC_Y13                       ((PIN_PA17B_PTC_Y13 << 16) | MUX_PA17B_PTC_Y13)
+#define PORT_PA17B_PTC_Y13                         (_UL_(1) << 17)
+
+#define PIN_PA18B_PTC_X14                          _L_(18)      /**< PTC signal: X14 on PA18 mux B*/
+#define MUX_PA18B_PTC_X14                          _L_(1)      
+#define PINMUX_PA18B_PTC_X14                       ((PIN_PA18B_PTC_X14 << 16) | MUX_PA18B_PTC_X14)
+#define PORT_PA18B_PTC_X14                         (_UL_(1) << 18)
+
+#define PIN_PA18B_PTC_Y14                          _L_(18)      /**< PTC signal: Y14 on PA18 mux B*/
+#define MUX_PA18B_PTC_Y14                          _L_(1)      
+#define PINMUX_PA18B_PTC_Y14                       ((PIN_PA18B_PTC_Y14 << 16) | MUX_PA18B_PTC_Y14)
+#define PORT_PA18B_PTC_Y14                         (_UL_(1) << 18)
+
+#define PIN_PA19B_PTC_X15                          _L_(19)      /**< PTC signal: X15 on PA19 mux B*/
+#define MUX_PA19B_PTC_X15                          _L_(1)      
+#define PINMUX_PA19B_PTC_X15                       ((PIN_PA19B_PTC_X15 << 16) | MUX_PA19B_PTC_X15)
+#define PORT_PA19B_PTC_X15                         (_UL_(1) << 19)
+
+#define PIN_PA19B_PTC_Y15                          _L_(19)      /**< PTC signal: Y15 on PA19 mux B*/
+#define MUX_PA19B_PTC_Y15                          _L_(1)      
+#define PINMUX_PA19B_PTC_Y15                       ((PIN_PA19B_PTC_Y15 << 16) | MUX_PA19B_PTC_Y15)
+#define PORT_PA19B_PTC_Y15                         (_UL_(1) << 19)
+
+#define PIN_PA22B_PTC_X16                          _L_(22)      /**< PTC signal: X16 on PA22 mux B*/
+#define MUX_PA22B_PTC_X16                          _L_(1)      
+#define PINMUX_PA22B_PTC_X16                       ((PIN_PA22B_PTC_X16 << 16) | MUX_PA22B_PTC_X16)
+#define PORT_PA22B_PTC_X16                         (_UL_(1) << 22)
+
+#define PIN_PA22B_PTC_Y16                          _L_(22)      /**< PTC signal: Y16 on PA22 mux B*/
+#define MUX_PA22B_PTC_Y16                          _L_(1)      
+#define PINMUX_PA22B_PTC_Y16                       ((PIN_PA22B_PTC_Y16 << 16) | MUX_PA22B_PTC_Y16)
+#define PORT_PA22B_PTC_Y16                         (_UL_(1) << 22)
+
+#define PIN_PA23B_PTC_X17                          _L_(23)      /**< PTC signal: X17 on PA23 mux B*/
+#define MUX_PA23B_PTC_X17                          _L_(1)      
+#define PINMUX_PA23B_PTC_X17                       ((PIN_PA23B_PTC_X17 << 16) | MUX_PA23B_PTC_X17)
+#define PORT_PA23B_PTC_X17                         (_UL_(1) << 23)
+
+#define PIN_PA23B_PTC_Y17                          _L_(23)      /**< PTC signal: Y17 on PA23 mux B*/
+#define MUX_PA23B_PTC_Y17                          _L_(1)      
+#define PINMUX_PA23B_PTC_Y17                       ((PIN_PA23B_PTC_Y17 << 16) | MUX_PA23B_PTC_Y17)
+#define PORT_PA23B_PTC_Y17                         (_UL_(1) << 23)
+
+#define PIN_PA30B_PTC_X18                          _L_(30)      /**< PTC signal: X18 on PA30 mux B*/
+#define MUX_PA30B_PTC_X18                          _L_(1)      
+#define PINMUX_PA30B_PTC_X18                       ((PIN_PA30B_PTC_X18 << 16) | MUX_PA30B_PTC_X18)
+#define PORT_PA30B_PTC_X18                         (_UL_(1) << 30)
+
+#define PIN_PA30B_PTC_Y18                          _L_(30)      /**< PTC signal: Y18 on PA30 mux B*/
+#define MUX_PA30B_PTC_Y18                          _L_(1)      
+#define PINMUX_PA30B_PTC_Y18                       ((PIN_PA30B_PTC_Y18 << 16) | MUX_PA30B_PTC_Y18)
+#define PORT_PA30B_PTC_Y18                         (_UL_(1) << 30)
+
+#define PIN_PA31B_PTC_X19                          _L_(31)      /**< PTC signal: X19 on PA31 mux B*/
+#define MUX_PA31B_PTC_X19                          _L_(1)      
+#define PINMUX_PA31B_PTC_X19                       ((PIN_PA31B_PTC_X19 << 16) | MUX_PA31B_PTC_X19)
+#define PORT_PA31B_PTC_X19                         (_UL_(1) << 31)
+
+#define PIN_PA31B_PTC_Y19                          _L_(31)      /**< PTC signal: Y19 on PA31 mux B*/
+#define MUX_PA31B_PTC_Y19                          _L_(1)      
+#define PINMUX_PA31B_PTC_Y19                       ((PIN_PA31B_PTC_Y19 << 16) | MUX_PA31B_PTC_Y19)
+#define PORT_PA31B_PTC_Y19                         (_UL_(1) << 31)
+
+/* ========== PORT definition for RTC peripheral ========== */
+#define PIN_PA08G_RTC_IN0                          _L_(8)       /**< RTC signal: IN0 on PA08 mux G*/
+#define MUX_PA08G_RTC_IN0                          _L_(6)      
+#define PINMUX_PA08G_RTC_IN0                       ((PIN_PA08G_RTC_IN0 << 16) | MUX_PA08G_RTC_IN0)
+#define PORT_PA08G_RTC_IN0                         (_UL_(1) << 8)
+
+#define PIN_PA16G_RTC_IN2                          _L_(16)      /**< RTC signal: IN2 on PA16 mux G*/
+#define MUX_PA16G_RTC_IN2                          _L_(6)      
+#define PINMUX_PA16G_RTC_IN2                       ((PIN_PA16G_RTC_IN2 << 16) | MUX_PA16G_RTC_IN2)
+#define PORT_PA16G_RTC_IN2                         (_UL_(1) << 16)
+
+#define PIN_PA17G_RTC_IN3                          _L_(17)      /**< RTC signal: IN3 on PA17 mux G*/
+#define MUX_PA17G_RTC_IN3                          _L_(6)      
+#define PINMUX_PA17G_RTC_IN3                       ((PIN_PA17G_RTC_IN3 << 16) | MUX_PA17G_RTC_IN3)
+#define PORT_PA17G_RTC_IN3                         (_UL_(1) << 17)
+
+#define PIN_PA18G_RTC_OUT0                         _L_(18)      /**< RTC signal: OUT0 on PA18 mux G*/
+#define MUX_PA18G_RTC_OUT0                         _L_(6)      
+#define PINMUX_PA18G_RTC_OUT0                      ((PIN_PA18G_RTC_OUT0 << 16) | MUX_PA18G_RTC_OUT0)
+#define PORT_PA18G_RTC_OUT0                        (_UL_(1) << 18)
+
+#define PIN_PA19G_RTC_OUT1                         _L_(19)      /**< RTC signal: OUT1 on PA19 mux G*/
+#define MUX_PA19G_RTC_OUT1                         _L_(6)      
+#define PINMUX_PA19G_RTC_OUT1                      ((PIN_PA19G_RTC_OUT1 << 16) | MUX_PA19G_RTC_OUT1)
+#define PORT_PA19G_RTC_OUT1                        (_UL_(1) << 19)
+
+#define PIN_PA22G_RTC_OUT2                         _L_(22)      /**< RTC signal: OUT2 on PA22 mux G*/
+#define MUX_PA22G_RTC_OUT2                         _L_(6)      
+#define PINMUX_PA22G_RTC_OUT2                      ((PIN_PA22G_RTC_OUT2 << 16) | MUX_PA22G_RTC_OUT2)
+#define PORT_PA22G_RTC_OUT2                        (_UL_(1) << 22)
+
+#define PIN_PA23G_RTC_OUT3                         _L_(23)      /**< RTC signal: OUT3 on PA23 mux G*/
+#define MUX_PA23G_RTC_OUT3                         _L_(6)      
+#define PINMUX_PA23G_RTC_OUT3                      ((PIN_PA23G_RTC_OUT3 << 16) | MUX_PA23G_RTC_OUT3)
+#define PORT_PA23G_RTC_OUT3                        (_UL_(1) << 23)
+
+/* ========== PORT definition for SERCOM0 peripheral ========== */
+#define PIN_PA04D_SERCOM0_PAD0                     _L_(4)       /**< SERCOM0 signal: PAD0 on PA04 mux D*/
+#define MUX_PA04D_SERCOM0_PAD0                     _L_(3)      
+#define PINMUX_PA04D_SERCOM0_PAD0                  ((PIN_PA04D_SERCOM0_PAD0 << 16) | MUX_PA04D_SERCOM0_PAD0)
+#define PORT_PA04D_SERCOM0_PAD0                    (_UL_(1) << 4)
+
+#define PIN_PA16D_SERCOM0_PAD0                     _L_(16)      /**< SERCOM0 signal: PAD0 on PA16 mux D*/
+#define MUX_PA16D_SERCOM0_PAD0                     _L_(3)      
+#define PINMUX_PA16D_SERCOM0_PAD0                  ((PIN_PA16D_SERCOM0_PAD0 << 16) | MUX_PA16D_SERCOM0_PAD0)
+#define PORT_PA16D_SERCOM0_PAD0                    (_UL_(1) << 16)
+
+#define PIN_PA22C_SERCOM0_PAD0                     _L_(22)      /**< SERCOM0 signal: PAD0 on PA22 mux C*/
+#define MUX_PA22C_SERCOM0_PAD0                     _L_(2)      
+#define PINMUX_PA22C_SERCOM0_PAD0                  ((PIN_PA22C_SERCOM0_PAD0 << 16) | MUX_PA22C_SERCOM0_PAD0)
+#define PORT_PA22C_SERCOM0_PAD0                    (_UL_(1) << 22)
+
+#define PIN_PA05D_SERCOM0_PAD1                     _L_(5)       /**< SERCOM0 signal: PAD1 on PA05 mux D*/
+#define MUX_PA05D_SERCOM0_PAD1                     _L_(3)      
+#define PINMUX_PA05D_SERCOM0_PAD1                  ((PIN_PA05D_SERCOM0_PAD1 << 16) | MUX_PA05D_SERCOM0_PAD1)
+#define PORT_PA05D_SERCOM0_PAD1                    (_UL_(1) << 5)
+
+#define PIN_PA17D_SERCOM0_PAD1                     _L_(17)      /**< SERCOM0 signal: PAD1 on PA17 mux D*/
+#define MUX_PA17D_SERCOM0_PAD1                     _L_(3)      
+#define PINMUX_PA17D_SERCOM0_PAD1                  ((PIN_PA17D_SERCOM0_PAD1 << 16) | MUX_PA17D_SERCOM0_PAD1)
+#define PORT_PA17D_SERCOM0_PAD1                    (_UL_(1) << 17)
+
+#define PIN_PA23C_SERCOM0_PAD1                     _L_(23)      /**< SERCOM0 signal: PAD1 on PA23 mux C*/
+#define MUX_PA23C_SERCOM0_PAD1                     _L_(2)      
+#define PINMUX_PA23C_SERCOM0_PAD1                  ((PIN_PA23C_SERCOM0_PAD1 << 16) | MUX_PA23C_SERCOM0_PAD1)
+#define PORT_PA23C_SERCOM0_PAD1                    (_UL_(1) << 23)
+
+#define PIN_PA14D_SERCOM0_PAD2                     _L_(14)      /**< SERCOM0 signal: PAD2 on PA14 mux D*/
+#define MUX_PA14D_SERCOM0_PAD2                     _L_(3)      
+#define PINMUX_PA14D_SERCOM0_PAD2                  ((PIN_PA14D_SERCOM0_PAD2 << 16) | MUX_PA14D_SERCOM0_PAD2)
+#define PORT_PA14D_SERCOM0_PAD2                    (_UL_(1) << 14)
+
+#define PIN_PA18D_SERCOM0_PAD2                     _L_(18)      /**< SERCOM0 signal: PAD2 on PA18 mux D*/
+#define MUX_PA18D_SERCOM0_PAD2                     _L_(3)      
+#define PINMUX_PA18D_SERCOM0_PAD2                  ((PIN_PA18D_SERCOM0_PAD2 << 16) | MUX_PA18D_SERCOM0_PAD2)
+#define PORT_PA18D_SERCOM0_PAD2                    (_UL_(1) << 18)
+
+#define PIN_PA02D_SERCOM0_PAD2                     _L_(2)       /**< SERCOM0 signal: PAD2 on PA02 mux D*/
+#define MUX_PA02D_SERCOM0_PAD2                     _L_(3)      
+#define PINMUX_PA02D_SERCOM0_PAD2                  ((PIN_PA02D_SERCOM0_PAD2 << 16) | MUX_PA02D_SERCOM0_PAD2)
+#define PORT_PA02D_SERCOM0_PAD2                    (_UL_(1) << 2)
+
+#define PIN_PA15D_SERCOM0_PAD3                     _L_(15)      /**< SERCOM0 signal: PAD3 on PA15 mux D*/
+#define MUX_PA15D_SERCOM0_PAD3                     _L_(3)      
+#define PINMUX_PA15D_SERCOM0_PAD3                  ((PIN_PA15D_SERCOM0_PAD3 << 16) | MUX_PA15D_SERCOM0_PAD3)
+#define PORT_PA15D_SERCOM0_PAD3                    (_UL_(1) << 15)
+
+#define PIN_PA19D_SERCOM0_PAD3                     _L_(19)      /**< SERCOM0 signal: PAD3 on PA19 mux D*/
+#define MUX_PA19D_SERCOM0_PAD3                     _L_(3)      
+#define PINMUX_PA19D_SERCOM0_PAD3                  ((PIN_PA19D_SERCOM0_PAD3 << 16) | MUX_PA19D_SERCOM0_PAD3)
+#define PORT_PA19D_SERCOM0_PAD3                    (_UL_(1) << 19)
+
+#define PIN_PA03D_SERCOM0_PAD3                     _L_(3)       /**< SERCOM0 signal: PAD3 on PA03 mux D*/
+#define MUX_PA03D_SERCOM0_PAD3                     _L_(3)      
+#define PINMUX_PA03D_SERCOM0_PAD3                  ((PIN_PA03D_SERCOM0_PAD3 << 16) | MUX_PA03D_SERCOM0_PAD3)
+#define PORT_PA03D_SERCOM0_PAD3                    (_UL_(1) << 3)
+
+/* ========== PORT definition for SERCOM1 peripheral ========== */
+#define PIN_PA16C_SERCOM1_PAD0                     _L_(16)      /**< SERCOM1 signal: PAD0 on PA16 mux C*/
+#define MUX_PA16C_SERCOM1_PAD0                     _L_(2)      
+#define PINMUX_PA16C_SERCOM1_PAD0                  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
+#define PORT_PA16C_SERCOM1_PAD0                    (_UL_(1) << 16)
+
+#define PIN_PA08C_SERCOM1_PAD0                     _L_(8)       /**< SERCOM1 signal: PAD0 on PA08 mux C*/
+#define MUX_PA08C_SERCOM1_PAD0                     _L_(2)      
+#define PINMUX_PA08C_SERCOM1_PAD0                  ((PIN_PA08C_SERCOM1_PAD0 << 16) | MUX_PA08C_SERCOM1_PAD0)
+#define PORT_PA08C_SERCOM1_PAD0                    (_UL_(1) << 8)
+
+#define PIN_PA00D_SERCOM1_PAD0                     _L_(0)       /**< SERCOM1 signal: PAD0 on PA00 mux D*/
+#define MUX_PA00D_SERCOM1_PAD0                     _L_(3)      
+#define PINMUX_PA00D_SERCOM1_PAD0                  ((PIN_PA00D_SERCOM1_PAD0 << 16) | MUX_PA00D_SERCOM1_PAD0)
+#define PORT_PA00D_SERCOM1_PAD0                    (_UL_(1) << 0)
+
+#define PIN_PA17C_SERCOM1_PAD1                     _L_(17)      /**< SERCOM1 signal: PAD1 on PA17 mux C*/
+#define MUX_PA17C_SERCOM1_PAD1                     _L_(2)      
+#define PINMUX_PA17C_SERCOM1_PAD1                  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
+#define PORT_PA17C_SERCOM1_PAD1                    (_UL_(1) << 17)
+
+#define PIN_PA01D_SERCOM1_PAD1                     _L_(1)       /**< SERCOM1 signal: PAD1 on PA01 mux D*/
+#define MUX_PA01D_SERCOM1_PAD1                     _L_(3)      
+#define PINMUX_PA01D_SERCOM1_PAD1                  ((PIN_PA01D_SERCOM1_PAD1 << 16) | MUX_PA01D_SERCOM1_PAD1)
+#define PORT_PA01D_SERCOM1_PAD1                    (_UL_(1) << 1)
+
+#define PIN_PA18C_SERCOM1_PAD2                     _L_(18)      /**< SERCOM1 signal: PAD2 on PA18 mux C*/
+#define MUX_PA18C_SERCOM1_PAD2                     _L_(2)      
+#define PINMUX_PA18C_SERCOM1_PAD2                  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
+#define PORT_PA18C_SERCOM1_PAD2                    (_UL_(1) << 18)
+
+#define PIN_PA30D_SERCOM1_PAD2                     _L_(30)      /**< SERCOM1 signal: PAD2 on PA30 mux D*/
+#define MUX_PA30D_SERCOM1_PAD2                     _L_(3)      
+#define PINMUX_PA30D_SERCOM1_PAD2                  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
+#define PORT_PA30D_SERCOM1_PAD2                    (_UL_(1) << 30)
+
+#define PIN_PA19C_SERCOM1_PAD3                     _L_(19)      /**< SERCOM1 signal: PAD3 on PA19 mux C*/
+#define MUX_PA19C_SERCOM1_PAD3                     _L_(2)      
+#define PINMUX_PA19C_SERCOM1_PAD3                  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
+#define PORT_PA19C_SERCOM1_PAD3                    (_UL_(1) << 19)
+
+#define PIN_PA31D_SERCOM1_PAD3                     _L_(31)      /**< SERCOM1 signal: PAD3 on PA31 mux D*/
+#define MUX_PA31D_SERCOM1_PAD3                     _L_(3)      
+#define PINMUX_PA31D_SERCOM1_PAD3                  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
+#define PORT_PA31D_SERCOM1_PAD3                    (_UL_(1) << 31)
+
+/* ========== PORT definition for TC0 peripheral ========== */
+#define PIN_PA04E_TC0_WO0                          _L_(4)       /**< TC0 signal: WO0 on PA04 mux E*/
+#define MUX_PA04E_TC0_WO0                          _L_(4)      
+#define PINMUX_PA04E_TC0_WO0                       ((PIN_PA04E_TC0_WO0 << 16) | MUX_PA04E_TC0_WO0)
+#define PORT_PA04E_TC0_WO0                         (_UL_(1) << 4)
+
+#define PIN_PA14E_TC0_WO0                          _L_(14)      /**< TC0 signal: WO0 on PA14 mux E*/
+#define MUX_PA14E_TC0_WO0                          _L_(4)      
+#define PINMUX_PA14E_TC0_WO0                       ((PIN_PA14E_TC0_WO0 << 16) | MUX_PA14E_TC0_WO0)
+#define PORT_PA14E_TC0_WO0                         (_UL_(1) << 14)
+
+#define PIN_PA22E_TC0_WO0                          _L_(22)      /**< TC0 signal: WO0 on PA22 mux E*/
+#define MUX_PA22E_TC0_WO0                          _L_(4)      
+#define PINMUX_PA22E_TC0_WO0                       ((PIN_PA22E_TC0_WO0 << 16) | MUX_PA22E_TC0_WO0)
+#define PORT_PA22E_TC0_WO0                         (_UL_(1) << 22)
+
+#define PIN_PA05E_TC0_WO1                          _L_(5)       /**< TC0 signal: WO1 on PA05 mux E*/
+#define MUX_PA05E_TC0_WO1                          _L_(4)      
+#define PINMUX_PA05E_TC0_WO1                       ((PIN_PA05E_TC0_WO1 << 16) | MUX_PA05E_TC0_WO1)
+#define PORT_PA05E_TC0_WO1                         (_UL_(1) << 5)
+
+#define PIN_PA15E_TC0_WO1                          _L_(15)      /**< TC0 signal: WO1 on PA15 mux E*/
+#define MUX_PA15E_TC0_WO1                          _L_(4)      
+#define PINMUX_PA15E_TC0_WO1                       ((PIN_PA15E_TC0_WO1 << 16) | MUX_PA15E_TC0_WO1)
+#define PORT_PA15E_TC0_WO1                         (_UL_(1) << 15)
+
+#define PIN_PA23E_TC0_WO1                          _L_(23)      /**< TC0 signal: WO1 on PA23 mux E*/
+#define MUX_PA23E_TC0_WO1                          _L_(4)      
+#define PINMUX_PA23E_TC0_WO1                       ((PIN_PA23E_TC0_WO1 << 16) | MUX_PA23E_TC0_WO1)
+#define PORT_PA23E_TC0_WO1                         (_UL_(1) << 23)
+
+/* ========== PORT definition for TC1 peripheral ========== */
+#define PIN_PA30E_TC1_WO0                          _L_(30)      /**< TC1 signal: WO0 on PA30 mux E*/
+#define MUX_PA30E_TC1_WO0                          _L_(4)      
+#define PINMUX_PA30E_TC1_WO0                       ((PIN_PA30E_TC1_WO0 << 16) | MUX_PA30E_TC1_WO0)
+#define PORT_PA30E_TC1_WO0                         (_UL_(1) << 30)
+
+#define PIN_PA31E_TC1_WO1                          _L_(31)      /**< TC1 signal: WO1 on PA31 mux E*/
+#define MUX_PA31E_TC1_WO1                          _L_(4)      
+#define PINMUX_PA31E_TC1_WO1                       ((PIN_PA31E_TC1_WO1 << 16) | MUX_PA31E_TC1_WO1)
+#define PORT_PA31E_TC1_WO1                         (_UL_(1) << 31)
+
+/* ========== PORT definition for TC2 peripheral ========== */
+#define PIN_PA00E_TC2_WO0                          _L_(0)       /**< TC2 signal: WO0 on PA00 mux E*/
+#define MUX_PA00E_TC2_WO0                          _L_(4)      
+#define PINMUX_PA00E_TC2_WO0                       ((PIN_PA00E_TC2_WO0 << 16) | MUX_PA00E_TC2_WO0)
+#define PORT_PA00E_TC2_WO0                         (_UL_(1) << 0)
+
+#define PIN_PA18E_TC2_WO0                          _L_(18)      /**< TC2 signal: WO0 on PA18 mux E*/
+#define MUX_PA18E_TC2_WO0                          _L_(4)      
+#define PINMUX_PA18E_TC2_WO0                       ((PIN_PA18E_TC2_WO0 << 16) | MUX_PA18E_TC2_WO0)
+#define PORT_PA18E_TC2_WO0                         (_UL_(1) << 18)
+
+#define PIN_PA01E_TC2_WO1                          _L_(1)       /**< TC2 signal: WO1 on PA01 mux E*/
+#define MUX_PA01E_TC2_WO1                          _L_(4)      
+#define PINMUX_PA01E_TC2_WO1                       ((PIN_PA01E_TC2_WO1 << 16) | MUX_PA01E_TC2_WO1)
+#define PORT_PA01E_TC2_WO1                         (_UL_(1) << 1)
+
+#define PIN_PA19E_TC2_WO1                          _L_(19)      /**< TC2 signal: WO1 on PA19 mux E*/
+#define MUX_PA19E_TC2_WO1                          _L_(4)      
+#define PINMUX_PA19E_TC2_WO1                       ((PIN_PA19E_TC2_WO1 << 16) | MUX_PA19E_TC2_WO1)
+#define PORT_PA19E_TC2_WO1                         (_UL_(1) << 19)
+
+
+#endif /* _SAML10D14A_PIO_H_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/pio/saml10d15a.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/pio/saml10d15a.h
@@ -1,0 +1,834 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAML10D15A
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10D15A_PIO_H_
+#define _SAML10D15A_PIO_H_
+
+/* ========== Peripheral I/O pin numbers ========== */
+#define PIN_PA00                    (  0)  /**< Pin Number for PA00 */
+#define PIN_PA01                    (  1)  /**< Pin Number for PA01 */
+#define PIN_PA02                    (  2)  /**< Pin Number for PA02 */
+#define PIN_PA03                    (  3)  /**< Pin Number for PA03 */
+#define PIN_PA04                    (  4)  /**< Pin Number for PA04 */
+#define PIN_PA05                    (  5)  /**< Pin Number for PA05 */
+#define PIN_PA08                    (  8)  /**< Pin Number for PA08 */
+#define PIN_PA14                    ( 14)  /**< Pin Number for PA14 */
+#define PIN_PA15                    ( 15)  /**< Pin Number for PA15 */
+#define PIN_PA16                    ( 16)  /**< Pin Number for PA16 */
+#define PIN_PA17                    ( 17)  /**< Pin Number for PA17 */
+#define PIN_PA18                    ( 18)  /**< Pin Number for PA18 */
+#define PIN_PA19                    ( 19)  /**< Pin Number for PA19 */
+#define PIN_PA22                    ( 22)  /**< Pin Number for PA22 */
+#define PIN_PA23                    ( 23)  /**< Pin Number for PA23 */
+#define PIN_PA30                    ( 30)  /**< Pin Number for PA30 */
+#define PIN_PA31                    ( 31)  /**< Pin Number for PA31 */
+
+
+/* ========== Peripheral I/O masks ========== */
+#define PORT_PA00                   (_U_(1) << 0) /**< PORT Mask for PA00 */
+#define PORT_PA01                   (_U_(1) << 1) /**< PORT Mask for PA01 */
+#define PORT_PA02                   (_U_(1) << 2) /**< PORT Mask for PA02 */
+#define PORT_PA03                   (_U_(1) << 3) /**< PORT Mask for PA03 */
+#define PORT_PA04                   (_U_(1) << 4) /**< PORT Mask for PA04 */
+#define PORT_PA05                   (_U_(1) << 5) /**< PORT Mask for PA05 */
+#define PORT_PA08                   (_U_(1) << 8) /**< PORT Mask for PA08 */
+#define PORT_PA14                   (_U_(1) << 14) /**< PORT Mask for PA14 */
+#define PORT_PA15                   (_U_(1) << 15) /**< PORT Mask for PA15 */
+#define PORT_PA16                   (_U_(1) << 16) /**< PORT Mask for PA16 */
+#define PORT_PA17                   (_U_(1) << 17) /**< PORT Mask for PA17 */
+#define PORT_PA18                   (_U_(1) << 18) /**< PORT Mask for PA18 */
+#define PORT_PA19                   (_U_(1) << 19) /**< PORT Mask for PA19 */
+#define PORT_PA22                   (_U_(1) << 22) /**< PORT Mask for PA22 */
+#define PORT_PA23                   (_U_(1) << 23) /**< PORT Mask for PA23 */
+#define PORT_PA30                   (_U_(1) << 30) /**< PORT Mask for PA30 */
+#define PORT_PA31                   (_U_(1) << 31) /**< PORT Mask for PA31 */
+
+
+/* ========== Peripheral I/O indexes ========== */
+#define PORT_PA00_IDX               (  0)  /**< PORT Index Number for PA00 */
+#define PORT_PA01_IDX               (  1)  /**< PORT Index Number for PA01 */
+#define PORT_PA02_IDX               (  2)  /**< PORT Index Number for PA02 */
+#define PORT_PA03_IDX               (  3)  /**< PORT Index Number for PA03 */
+#define PORT_PA04_IDX               (  4)  /**< PORT Index Number for PA04 */
+#define PORT_PA05_IDX               (  5)  /**< PORT Index Number for PA05 */
+#define PORT_PA08_IDX               (  8)  /**< PORT Index Number for PA08 */
+#define PORT_PA14_IDX               ( 14)  /**< PORT Index Number for PA14 */
+#define PORT_PA15_IDX               ( 15)  /**< PORT Index Number for PA15 */
+#define PORT_PA16_IDX               ( 16)  /**< PORT Index Number for PA16 */
+#define PORT_PA17_IDX               ( 17)  /**< PORT Index Number for PA17 */
+#define PORT_PA18_IDX               ( 18)  /**< PORT Index Number for PA18 */
+#define PORT_PA19_IDX               ( 19)  /**< PORT Index Number for PA19 */
+#define PORT_PA22_IDX               ( 22)  /**< PORT Index Number for PA22 */
+#define PORT_PA23_IDX               ( 23)  /**< PORT Index Number for PA23 */
+#define PORT_PA30_IDX               ( 30)  /**< PORT Index Number for PA30 */
+#define PORT_PA31_IDX               ( 31)  /**< PORT Index Number for PA31 */
+
+/* ========== PORT definition for AC peripheral ========== */
+#define PIN_PA04B_AC_AIN0                          _L_(4)       /**< AC signal: AIN0 on PA04 mux B*/
+#define MUX_PA04B_AC_AIN0                          _L_(1)      
+#define PINMUX_PA04B_AC_AIN0                       ((PIN_PA04B_AC_AIN0 << 16) | MUX_PA04B_AC_AIN0)
+#define PORT_PA04B_AC_AIN0                         (_UL_(1) << 4)
+
+#define PIN_PA05B_AC_AIN1                          _L_(5)       /**< AC signal: AIN1 on PA05 mux B*/
+#define MUX_PA05B_AC_AIN1                          _L_(1)      
+#define PINMUX_PA05B_AC_AIN1                       ((PIN_PA05B_AC_AIN1 << 16) | MUX_PA05B_AC_AIN1)
+#define PORT_PA05B_AC_AIN1                         (_UL_(1) << 5)
+
+#define PIN_PA18H_AC_CMP0                          _L_(18)      /**< AC signal: CMP0 on PA18 mux H*/
+#define MUX_PA18H_AC_CMP0                          _L_(7)      
+#define PINMUX_PA18H_AC_CMP0                       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
+#define PORT_PA18H_AC_CMP0                         (_UL_(1) << 18)
+
+#define PIN_PA19H_AC_CMP1                          _L_(19)      /**< AC signal: CMP1 on PA19 mux H*/
+#define MUX_PA19H_AC_CMP1                          _L_(7)      
+#define PINMUX_PA19H_AC_CMP1                       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
+#define PORT_PA19H_AC_CMP1                         (_UL_(1) << 19)
+
+/* ========== PORT definition for ADC peripheral ========== */
+#define PIN_PA02B_ADC_AIN0                         _L_(2)       /**< ADC signal: AIN0 on PA02 mux B*/
+#define MUX_PA02B_ADC_AIN0                         _L_(1)      
+#define PINMUX_PA02B_ADC_AIN0                      ((PIN_PA02B_ADC_AIN0 << 16) | MUX_PA02B_ADC_AIN0)
+#define PORT_PA02B_ADC_AIN0                        (_UL_(1) << 2)
+
+#define PIN_PA03B_ADC_AIN1                         _L_(3)       /**< ADC signal: AIN1 on PA03 mux B*/
+#define MUX_PA03B_ADC_AIN1                         _L_(1)      
+#define PINMUX_PA03B_ADC_AIN1                      ((PIN_PA03B_ADC_AIN1 << 16) | MUX_PA03B_ADC_AIN1)
+#define PORT_PA03B_ADC_AIN1                        (_UL_(1) << 3)
+
+#define PIN_PA04B_ADC_AIN2                         _L_(4)       /**< ADC signal: AIN2 on PA04 mux B*/
+#define MUX_PA04B_ADC_AIN2                         _L_(1)      
+#define PINMUX_PA04B_ADC_AIN2                      ((PIN_PA04B_ADC_AIN2 << 16) | MUX_PA04B_ADC_AIN2)
+#define PORT_PA04B_ADC_AIN2                        (_UL_(1) << 4)
+
+#define PIN_PA05B_ADC_AIN3                         _L_(5)       /**< ADC signal: AIN3 on PA05 mux B*/
+#define MUX_PA05B_ADC_AIN3                         _L_(1)      
+#define PINMUX_PA05B_ADC_AIN3                      ((PIN_PA05B_ADC_AIN3 << 16) | MUX_PA05B_ADC_AIN3)
+#define PORT_PA05B_ADC_AIN3                        (_UL_(1) << 5)
+
+#define PIN_PA08B_ADC_AIN6                         _L_(8)       /**< ADC signal: AIN6 on PA08 mux B*/
+#define MUX_PA08B_ADC_AIN6                         _L_(1)      
+#define PINMUX_PA08B_ADC_AIN6                      ((PIN_PA08B_ADC_AIN6 << 16) | MUX_PA08B_ADC_AIN6)
+#define PORT_PA08B_ADC_AIN6                        (_UL_(1) << 8)
+
+#define PIN_PA04B_ADC_VREFP                        _L_(4)       /**< ADC signal: VREFP on PA04 mux B*/
+#define MUX_PA04B_ADC_VREFP                        _L_(1)      
+#define PINMUX_PA04B_ADC_VREFP                     ((PIN_PA04B_ADC_VREFP << 16) | MUX_PA04B_ADC_VREFP)
+#define PORT_PA04B_ADC_VREFP                       (_UL_(1) << 4)
+
+/* ========== PORT definition for CCL peripheral ========== */
+#define PIN_PA04I_CCL_IN0                          _L_(4)       /**< CCL signal: IN0 on PA04 mux I*/
+#define MUX_PA04I_CCL_IN0                          _L_(8)      
+#define PINMUX_PA04I_CCL_IN0                       ((PIN_PA04I_CCL_IN0 << 16) | MUX_PA04I_CCL_IN0)
+#define PORT_PA04I_CCL_IN0                         (_UL_(1) << 4)
+
+#define PIN_PA16I_CCL_IN0                          _L_(16)      /**< CCL signal: IN0 on PA16 mux I*/
+#define MUX_PA16I_CCL_IN0                          _L_(8)      
+#define PINMUX_PA16I_CCL_IN0                       ((PIN_PA16I_CCL_IN0 << 16) | MUX_PA16I_CCL_IN0)
+#define PORT_PA16I_CCL_IN0                         (_UL_(1) << 16)
+
+#define PIN_PA05I_CCL_IN1                          _L_(5)       /**< CCL signal: IN1 on PA05 mux I*/
+#define MUX_PA05I_CCL_IN1                          _L_(8)      
+#define PINMUX_PA05I_CCL_IN1                       ((PIN_PA05I_CCL_IN1 << 16) | MUX_PA05I_CCL_IN1)
+#define PORT_PA05I_CCL_IN1                         (_UL_(1) << 5)
+
+#define PIN_PA17I_CCL_IN1                          _L_(17)      /**< CCL signal: IN1 on PA17 mux I*/
+#define MUX_PA17I_CCL_IN1                          _L_(8)      
+#define PINMUX_PA17I_CCL_IN1                       ((PIN_PA17I_CCL_IN1 << 16) | MUX_PA17I_CCL_IN1)
+#define PORT_PA17I_CCL_IN1                         (_UL_(1) << 17)
+
+#define PIN_PA18I_CCL_IN2                          _L_(18)      /**< CCL signal: IN2 on PA18 mux I*/
+#define MUX_PA18I_CCL_IN2                          _L_(8)      
+#define PINMUX_PA18I_CCL_IN2                       ((PIN_PA18I_CCL_IN2 << 16) | MUX_PA18I_CCL_IN2)
+#define PORT_PA18I_CCL_IN2                         (_UL_(1) << 18)
+
+#define PIN_PA08I_CCL_IN3                          _L_(8)       /**< CCL signal: IN3 on PA08 mux I*/
+#define MUX_PA08I_CCL_IN3                          _L_(8)      
+#define PINMUX_PA08I_CCL_IN3                       ((PIN_PA08I_CCL_IN3 << 16) | MUX_PA08I_CCL_IN3)
+#define PORT_PA08I_CCL_IN3                         (_UL_(1) << 8)
+
+#define PIN_PA30I_CCL_IN3                          _L_(30)      /**< CCL signal: IN3 on PA30 mux I*/
+#define MUX_PA30I_CCL_IN3                          _L_(8)      
+#define PINMUX_PA30I_CCL_IN3                       ((PIN_PA30I_CCL_IN3 << 16) | MUX_PA30I_CCL_IN3)
+#define PORT_PA30I_CCL_IN3                         (_UL_(1) << 30)
+
+#define PIN_PA19I_CCL_OUT0                         _L_(19)      /**< CCL signal: OUT0 on PA19 mux I*/
+#define MUX_PA19I_CCL_OUT0                         _L_(8)      
+#define PINMUX_PA19I_CCL_OUT0                      ((PIN_PA19I_CCL_OUT0 << 16) | MUX_PA19I_CCL_OUT0)
+#define PORT_PA19I_CCL_OUT0                        (_UL_(1) << 19)
+
+#define PIN_PA31I_CCL_OUT1                         _L_(31)      /**< CCL signal: OUT1 on PA31 mux I*/
+#define MUX_PA31I_CCL_OUT1                         _L_(8)      
+#define PINMUX_PA31I_CCL_OUT1                      ((PIN_PA31I_CCL_OUT1 << 16) | MUX_PA31I_CCL_OUT1)
+#define PORT_PA31I_CCL_OUT1                        (_UL_(1) << 31)
+
+/* ========== PORT definition for DAC peripheral ========== */
+#define PIN_PA02B_DAC_VOUT                         _L_(2)       /**< DAC signal: VOUT on PA02 mux B*/
+#define MUX_PA02B_DAC_VOUT                         _L_(1)      
+#define PINMUX_PA02B_DAC_VOUT                      ((PIN_PA02B_DAC_VOUT << 16) | MUX_PA02B_DAC_VOUT)
+#define PORT_PA02B_DAC_VOUT                        (_UL_(1) << 2)
+
+#define PIN_PA03B_DAC_VREFP                        _L_(3)       /**< DAC signal: VREFP on PA03 mux B*/
+#define MUX_PA03B_DAC_VREFP                        _L_(1)      
+#define PINMUX_PA03B_DAC_VREFP                     ((PIN_PA03B_DAC_VREFP << 16) | MUX_PA03B_DAC_VREFP)
+#define PORT_PA03B_DAC_VREFP                       (_UL_(1) << 3)
+
+/* ========== PORT definition for EIC peripheral ========== */
+#define PIN_PA19A_EIC_EXTINT0                      _L_(19)      /**< EIC signal: EXTINT0 on PA19 mux A*/
+#define MUX_PA19A_EIC_EXTINT0                      _L_(0)      
+#define PINMUX_PA19A_EIC_EXTINT0                   ((PIN_PA19A_EIC_EXTINT0 << 16) | MUX_PA19A_EIC_EXTINT0)
+#define PORT_PA19A_EIC_EXTINT0                     (_UL_(1) << 19)
+#define PIN_PA19A_EIC_EXTINT_NUM                   _L_(0)       /**< EIC signal: PIN_PA19 External Interrupt Line */
+
+#define PIN_PA00A_EIC_EXTINT0                      _L_(0)       /**< EIC signal: EXTINT0 on PA00 mux A*/
+#define MUX_PA00A_EIC_EXTINT0                      _L_(0)      
+#define PINMUX_PA00A_EIC_EXTINT0                   ((PIN_PA00A_EIC_EXTINT0 << 16) | MUX_PA00A_EIC_EXTINT0)
+#define PORT_PA00A_EIC_EXTINT0                     (_UL_(1) << 0)
+#define PIN_PA00A_EIC_EXTINT_NUM                   _L_(0)       /**< EIC signal: PIN_PA00 External Interrupt Line */
+
+#define PIN_PA22A_EIC_EXTINT1                      _L_(22)      /**< EIC signal: EXTINT1 on PA22 mux A*/
+#define MUX_PA22A_EIC_EXTINT1                      _L_(0)      
+#define PINMUX_PA22A_EIC_EXTINT1                   ((PIN_PA22A_EIC_EXTINT1 << 16) | MUX_PA22A_EIC_EXTINT1)
+#define PORT_PA22A_EIC_EXTINT1                     (_UL_(1) << 22)
+#define PIN_PA22A_EIC_EXTINT_NUM                   _L_(1)       /**< EIC signal: PIN_PA22 External Interrupt Line */
+
+#define PIN_PA01A_EIC_EXTINT1                      _L_(1)       /**< EIC signal: EXTINT1 on PA01 mux A*/
+#define MUX_PA01A_EIC_EXTINT1                      _L_(0)      
+#define PINMUX_PA01A_EIC_EXTINT1                   ((PIN_PA01A_EIC_EXTINT1 << 16) | MUX_PA01A_EIC_EXTINT1)
+#define PORT_PA01A_EIC_EXTINT1                     (_UL_(1) << 1)
+#define PIN_PA01A_EIC_EXTINT_NUM                   _L_(1)       /**< EIC signal: PIN_PA01 External Interrupt Line */
+
+#define PIN_PA02A_EIC_EXTINT2                      _L_(2)       /**< EIC signal: EXTINT2 on PA02 mux A*/
+#define MUX_PA02A_EIC_EXTINT2                      _L_(0)      
+#define PINMUX_PA02A_EIC_EXTINT2                   ((PIN_PA02A_EIC_EXTINT2 << 16) | MUX_PA02A_EIC_EXTINT2)
+#define PORT_PA02A_EIC_EXTINT2                     (_UL_(1) << 2)
+#define PIN_PA02A_EIC_EXTINT_NUM                   _L_(2)       /**< EIC signal: PIN_PA02 External Interrupt Line */
+
+#define PIN_PA23A_EIC_EXTINT2                      _L_(23)      /**< EIC signal: EXTINT2 on PA23 mux A*/
+#define MUX_PA23A_EIC_EXTINT2                      _L_(0)      
+#define PINMUX_PA23A_EIC_EXTINT2                   ((PIN_PA23A_EIC_EXTINT2 << 16) | MUX_PA23A_EIC_EXTINT2)
+#define PORT_PA23A_EIC_EXTINT2                     (_UL_(1) << 23)
+#define PIN_PA23A_EIC_EXTINT_NUM                   _L_(2)       /**< EIC signal: PIN_PA23 External Interrupt Line */
+
+#define PIN_PA03A_EIC_EXTINT3                      _L_(3)       /**< EIC signal: EXTINT3 on PA03 mux A*/
+#define MUX_PA03A_EIC_EXTINT3                      _L_(0)      
+#define PINMUX_PA03A_EIC_EXTINT3                   ((PIN_PA03A_EIC_EXTINT3 << 16) | MUX_PA03A_EIC_EXTINT3)
+#define PORT_PA03A_EIC_EXTINT3                     (_UL_(1) << 3)
+#define PIN_PA03A_EIC_EXTINT_NUM                   _L_(3)       /**< EIC signal: PIN_PA03 External Interrupt Line */
+
+#define PIN_PA14A_EIC_EXTINT3                      _L_(14)      /**< EIC signal: EXTINT3 on PA14 mux A*/
+#define MUX_PA14A_EIC_EXTINT3                      _L_(0)      
+#define PINMUX_PA14A_EIC_EXTINT3                   ((PIN_PA14A_EIC_EXTINT3 << 16) | MUX_PA14A_EIC_EXTINT3)
+#define PORT_PA14A_EIC_EXTINT3                     (_UL_(1) << 14)
+#define PIN_PA14A_EIC_EXTINT_NUM                   _L_(3)       /**< EIC signal: PIN_PA14 External Interrupt Line */
+
+#define PIN_PA04A_EIC_EXTINT4                      _L_(4)       /**< EIC signal: EXTINT4 on PA04 mux A*/
+#define MUX_PA04A_EIC_EXTINT4                      _L_(0)      
+#define PINMUX_PA04A_EIC_EXTINT4                   ((PIN_PA04A_EIC_EXTINT4 << 16) | MUX_PA04A_EIC_EXTINT4)
+#define PORT_PA04A_EIC_EXTINT4                     (_UL_(1) << 4)
+#define PIN_PA04A_EIC_EXTINT_NUM                   _L_(4)       /**< EIC signal: PIN_PA04 External Interrupt Line */
+
+#define PIN_PA15A_EIC_EXTINT4                      _L_(15)      /**< EIC signal: EXTINT4 on PA15 mux A*/
+#define MUX_PA15A_EIC_EXTINT4                      _L_(0)      
+#define PINMUX_PA15A_EIC_EXTINT4                   ((PIN_PA15A_EIC_EXTINT4 << 16) | MUX_PA15A_EIC_EXTINT4)
+#define PORT_PA15A_EIC_EXTINT4                     (_UL_(1) << 15)
+#define PIN_PA15A_EIC_EXTINT_NUM                   _L_(4)       /**< EIC signal: PIN_PA15 External Interrupt Line */
+
+#define PIN_PA05A_EIC_EXTINT5                      _L_(5)       /**< EIC signal: EXTINT5 on PA05 mux A*/
+#define MUX_PA05A_EIC_EXTINT5                      _L_(0)      
+#define PINMUX_PA05A_EIC_EXTINT5                   ((PIN_PA05A_EIC_EXTINT5 << 16) | MUX_PA05A_EIC_EXTINT5)
+#define PORT_PA05A_EIC_EXTINT5                     (_UL_(1) << 5)
+#define PIN_PA05A_EIC_EXTINT_NUM                   _L_(5)       /**< EIC signal: PIN_PA05 External Interrupt Line */
+
+#define PIN_PA16A_EIC_EXTINT5                      _L_(16)      /**< EIC signal: EXTINT5 on PA16 mux A*/
+#define MUX_PA16A_EIC_EXTINT5                      _L_(0)      
+#define PINMUX_PA16A_EIC_EXTINT5                   ((PIN_PA16A_EIC_EXTINT5 << 16) | MUX_PA16A_EIC_EXTINT5)
+#define PORT_PA16A_EIC_EXTINT5                     (_UL_(1) << 16)
+#define PIN_PA16A_EIC_EXTINT_NUM                   _L_(5)       /**< EIC signal: PIN_PA16 External Interrupt Line */
+
+#define PIN_PA17A_EIC_EXTINT6                      _L_(17)      /**< EIC signal: EXTINT6 on PA17 mux A*/
+#define MUX_PA17A_EIC_EXTINT6                      _L_(0)      
+#define PINMUX_PA17A_EIC_EXTINT6                   ((PIN_PA17A_EIC_EXTINT6 << 16) | MUX_PA17A_EIC_EXTINT6)
+#define PORT_PA17A_EIC_EXTINT6                     (_UL_(1) << 17)
+#define PIN_PA17A_EIC_EXTINT_NUM                   _L_(6)       /**< EIC signal: PIN_PA17 External Interrupt Line */
+
+#define PIN_PA30A_EIC_EXTINT6                      _L_(30)      /**< EIC signal: EXTINT6 on PA30 mux A*/
+#define MUX_PA30A_EIC_EXTINT6                      _L_(0)      
+#define PINMUX_PA30A_EIC_EXTINT6                   ((PIN_PA30A_EIC_EXTINT6 << 16) | MUX_PA30A_EIC_EXTINT6)
+#define PORT_PA30A_EIC_EXTINT6                     (_UL_(1) << 30)
+#define PIN_PA30A_EIC_EXTINT_NUM                   _L_(6)       /**< EIC signal: PIN_PA30 External Interrupt Line */
+
+#define PIN_PA18A_EIC_EXTINT7                      _L_(18)      /**< EIC signal: EXTINT7 on PA18 mux A*/
+#define MUX_PA18A_EIC_EXTINT7                      _L_(0)      
+#define PINMUX_PA18A_EIC_EXTINT7                   ((PIN_PA18A_EIC_EXTINT7 << 16) | MUX_PA18A_EIC_EXTINT7)
+#define PORT_PA18A_EIC_EXTINT7                     (_UL_(1) << 18)
+#define PIN_PA18A_EIC_EXTINT_NUM                   _L_(7)       /**< EIC signal: PIN_PA18 External Interrupt Line */
+
+#define PIN_PA31A_EIC_EXTINT7                      _L_(31)      /**< EIC signal: EXTINT7 on PA31 mux A*/
+#define MUX_PA31A_EIC_EXTINT7                      _L_(0)      
+#define PINMUX_PA31A_EIC_EXTINT7                   ((PIN_PA31A_EIC_EXTINT7 << 16) | MUX_PA31A_EIC_EXTINT7)
+#define PORT_PA31A_EIC_EXTINT7                     (_UL_(1) << 31)
+#define PIN_PA31A_EIC_EXTINT_NUM                   _L_(7)       /**< EIC signal: PIN_PA31 External Interrupt Line */
+
+#define PIN_PA08A_EIC_NMI                          _L_(8)       /**< EIC signal: NMI on PA08 mux A*/
+#define MUX_PA08A_EIC_NMI                          _L_(0)      
+#define PINMUX_PA08A_EIC_NMI                       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
+#define PORT_PA08A_EIC_NMI                         (_UL_(1) << 8)
+
+/* ========== PORT definition for GCLK peripheral ========== */
+#define PIN_PA30H_GCLK_IO0                         _L_(30)      /**< GCLK signal: IO0 on PA30 mux H*/
+#define MUX_PA30H_GCLK_IO0                         _L_(7)      
+#define PINMUX_PA30H_GCLK_IO0                      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
+#define PORT_PA30H_GCLK_IO0                        (_UL_(1) << 30)
+
+#define PIN_PA14H_GCLK_IO0                         _L_(14)      /**< GCLK signal: IO0 on PA14 mux H*/
+#define MUX_PA14H_GCLK_IO0                         _L_(7)      
+#define PINMUX_PA14H_GCLK_IO0                      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
+#define PORT_PA14H_GCLK_IO0                        (_UL_(1) << 14)
+
+#define PIN_PA23H_GCLK_IO1                         _L_(23)      /**< GCLK signal: IO1 on PA23 mux H*/
+#define MUX_PA23H_GCLK_IO1                         _L_(7)      
+#define PINMUX_PA23H_GCLK_IO1                      ((PIN_PA23H_GCLK_IO1 << 16) | MUX_PA23H_GCLK_IO1)
+#define PORT_PA23H_GCLK_IO1                        (_UL_(1) << 23)
+
+#define PIN_PA15H_GCLK_IO1                         _L_(15)      /**< GCLK signal: IO1 on PA15 mux H*/
+#define MUX_PA15H_GCLK_IO1                         _L_(7)      
+#define PINMUX_PA15H_GCLK_IO1                      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
+#define PORT_PA15H_GCLK_IO1                        (_UL_(1) << 15)
+
+#define PIN_PA16H_GCLK_IO2                         _L_(16)      /**< GCLK signal: IO2 on PA16 mux H*/
+#define MUX_PA16H_GCLK_IO2                         _L_(7)      
+#define PINMUX_PA16H_GCLK_IO2                      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
+#define PORT_PA16H_GCLK_IO2                        (_UL_(1) << 16)
+
+#define PIN_PA22H_GCLK_IO2                         _L_(22)      /**< GCLK signal: IO2 on PA22 mux H*/
+#define MUX_PA22H_GCLK_IO2                         _L_(7)      
+#define PINMUX_PA22H_GCLK_IO2                      ((PIN_PA22H_GCLK_IO2 << 16) | MUX_PA22H_GCLK_IO2)
+#define PORT_PA22H_GCLK_IO2                        (_UL_(1) << 22)
+
+#define PIN_PA17H_GCLK_IO3                         _L_(17)      /**< GCLK signal: IO3 on PA17 mux H*/
+#define MUX_PA17H_GCLK_IO3                         _L_(7)      
+#define PINMUX_PA17H_GCLK_IO3                      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
+#define PORT_PA17H_GCLK_IO3                        (_UL_(1) << 17)
+
+/* ========== PORT definition for OPAMP peripheral ========== */
+#define PIN_PA02B_OPAMP_OANEG0                     _L_(2)       /**< OPAMP signal: OANEG0 on PA02 mux B*/
+#define MUX_PA02B_OPAMP_OANEG0                     _L_(1)      
+#define PINMUX_PA02B_OPAMP_OANEG0                  ((PIN_PA02B_OPAMP_OANEG0 << 16) | MUX_PA02B_OPAMP_OANEG0)
+#define PORT_PA02B_OPAMP_OANEG0                    (_UL_(1) << 2)
+
+#define PIN_PA00B_OPAMP_OANEG1                     _L_(0)       /**< OPAMP signal: OANEG1 on PA00 mux B*/
+#define MUX_PA00B_OPAMP_OANEG1                     _L_(1)      
+#define PINMUX_PA00B_OPAMP_OANEG1                  ((PIN_PA00B_OPAMP_OANEG1 << 16) | MUX_PA00B_OPAMP_OANEG1)
+#define PORT_PA00B_OPAMP_OANEG1                    (_UL_(1) << 0)
+
+#define PIN_PA03B_OPAMP_OANEG2                     _L_(3)       /**< OPAMP signal: OANEG2 on PA03 mux B*/
+#define MUX_PA03B_OPAMP_OANEG2                     _L_(1)      
+#define PINMUX_PA03B_OPAMP_OANEG2                  ((PIN_PA03B_OPAMP_OANEG2 << 16) | MUX_PA03B_OPAMP_OANEG2)
+#define PORT_PA03B_OPAMP_OANEG2                    (_UL_(1) << 3)
+
+#define PIN_PA04B_OPAMP_OAOUT2                     _L_(4)       /**< OPAMP signal: OAOUT2 on PA04 mux B*/
+#define MUX_PA04B_OPAMP_OAOUT2                     _L_(1)      
+#define PINMUX_PA04B_OPAMP_OAOUT2                  ((PIN_PA04B_OPAMP_OAOUT2 << 16) | MUX_PA04B_OPAMP_OAOUT2)
+#define PORT_PA04B_OPAMP_OAOUT2                    (_UL_(1) << 4)
+
+#define PIN_PA01B_OPAMP_OAPOS1                     _L_(1)       /**< OPAMP signal: OAPOS1 on PA01 mux B*/
+#define MUX_PA01B_OPAMP_OAPOS1                     _L_(1)      
+#define PINMUX_PA01B_OPAMP_OAPOS1                  ((PIN_PA01B_OPAMP_OAPOS1 << 16) | MUX_PA01B_OPAMP_OAPOS1)
+#define PORT_PA01B_OPAMP_OAPOS1                    (_UL_(1) << 1)
+
+#define PIN_PA05B_OPAMP_OAPOS2                     _L_(5)       /**< OPAMP signal: OAPOS2 on PA05 mux B*/
+#define MUX_PA05B_OPAMP_OAPOS2                     _L_(1)      
+#define PINMUX_PA05B_OPAMP_OAPOS2                  ((PIN_PA05B_OPAMP_OAPOS2 << 16) | MUX_PA05B_OPAMP_OAPOS2)
+#define PORT_PA05B_OPAMP_OAPOS2                    (_UL_(1) << 5)
+
+/* ========== PORT definition for PTC peripheral ========== */
+#define PIN_PA00F_PTC_DRV0                         _L_(0)       /**< PTC signal: DRV0 on PA00 mux F*/
+#define MUX_PA00F_PTC_DRV0                         _L_(5)      
+#define PINMUX_PA00F_PTC_DRV0                      ((PIN_PA00F_PTC_DRV0 << 16) | MUX_PA00F_PTC_DRV0)
+#define PORT_PA00F_PTC_DRV0                        (_UL_(1) << 0)
+
+#define PIN_PA01F_PTC_DRV1                         _L_(1)       /**< PTC signal: DRV1 on PA01 mux F*/
+#define MUX_PA01F_PTC_DRV1                         _L_(5)      
+#define PINMUX_PA01F_PTC_DRV1                      ((PIN_PA01F_PTC_DRV1 << 16) | MUX_PA01F_PTC_DRV1)
+#define PORT_PA01F_PTC_DRV1                        (_UL_(1) << 1)
+
+#define PIN_PA02F_PTC_DRV2                         _L_(2)       /**< PTC signal: DRV2 on PA02 mux F*/
+#define MUX_PA02F_PTC_DRV2                         _L_(5)      
+#define PINMUX_PA02F_PTC_DRV2                      ((PIN_PA02F_PTC_DRV2 << 16) | MUX_PA02F_PTC_DRV2)
+#define PORT_PA02F_PTC_DRV2                        (_UL_(1) << 2)
+
+#define PIN_PA03F_PTC_DRV3                         _L_(3)       /**< PTC signal: DRV3 on PA03 mux F*/
+#define MUX_PA03F_PTC_DRV3                         _L_(5)      
+#define PINMUX_PA03F_PTC_DRV3                      ((PIN_PA03F_PTC_DRV3 << 16) | MUX_PA03F_PTC_DRV3)
+#define PORT_PA03F_PTC_DRV3                        (_UL_(1) << 3)
+
+#define PIN_PA05F_PTC_DRV4                         _L_(5)       /**< PTC signal: DRV4 on PA05 mux F*/
+#define MUX_PA05F_PTC_DRV4                         _L_(5)      
+#define PINMUX_PA05F_PTC_DRV4                      ((PIN_PA05F_PTC_DRV4 << 16) | MUX_PA05F_PTC_DRV4)
+#define PORT_PA05F_PTC_DRV4                        (_UL_(1) << 5)
+
+#define PIN_PA08F_PTC_DRV6                         _L_(8)       /**< PTC signal: DRV6 on PA08 mux F*/
+#define MUX_PA08F_PTC_DRV6                         _L_(5)      
+#define PINMUX_PA08F_PTC_DRV6                      ((PIN_PA08F_PTC_DRV6 << 16) | MUX_PA08F_PTC_DRV6)
+#define PORT_PA08F_PTC_DRV6                        (_UL_(1) << 8)
+
+#define PIN_PA14F_PTC_DRV10                        _L_(14)      /**< PTC signal: DRV10 on PA14 mux F*/
+#define MUX_PA14F_PTC_DRV10                        _L_(5)      
+#define PINMUX_PA14F_PTC_DRV10                     ((PIN_PA14F_PTC_DRV10 << 16) | MUX_PA14F_PTC_DRV10)
+#define PORT_PA14F_PTC_DRV10                       (_UL_(1) << 14)
+
+#define PIN_PA15F_PTC_DRV11                        _L_(15)      /**< PTC signal: DRV11 on PA15 mux F*/
+#define MUX_PA15F_PTC_DRV11                        _L_(5)      
+#define PINMUX_PA15F_PTC_DRV11                     ((PIN_PA15F_PTC_DRV11 << 16) | MUX_PA15F_PTC_DRV11)
+#define PORT_PA15F_PTC_DRV11                       (_UL_(1) << 15)
+
+#define PIN_PA16F_PTC_DRV12                        _L_(16)      /**< PTC signal: DRV12 on PA16 mux F*/
+#define MUX_PA16F_PTC_DRV12                        _L_(5)      
+#define PINMUX_PA16F_PTC_DRV12                     ((PIN_PA16F_PTC_DRV12 << 16) | MUX_PA16F_PTC_DRV12)
+#define PORT_PA16F_PTC_DRV12                       (_UL_(1) << 16)
+
+#define PIN_PA17F_PTC_DRV13                        _L_(17)      /**< PTC signal: DRV13 on PA17 mux F*/
+#define MUX_PA17F_PTC_DRV13                        _L_(5)      
+#define PINMUX_PA17F_PTC_DRV13                     ((PIN_PA17F_PTC_DRV13 << 16) | MUX_PA17F_PTC_DRV13)
+#define PORT_PA17F_PTC_DRV13                       (_UL_(1) << 17)
+
+#define PIN_PA18F_PTC_DRV14                        _L_(18)      /**< PTC signal: DRV14 on PA18 mux F*/
+#define MUX_PA18F_PTC_DRV14                        _L_(5)      
+#define PINMUX_PA18F_PTC_DRV14                     ((PIN_PA18F_PTC_DRV14 << 16) | MUX_PA18F_PTC_DRV14)
+#define PORT_PA18F_PTC_DRV14                       (_UL_(1) << 18)
+
+#define PIN_PA19F_PTC_DRV15                        _L_(19)      /**< PTC signal: DRV15 on PA19 mux F*/
+#define MUX_PA19F_PTC_DRV15                        _L_(5)      
+#define PINMUX_PA19F_PTC_DRV15                     ((PIN_PA19F_PTC_DRV15 << 16) | MUX_PA19F_PTC_DRV15)
+#define PORT_PA19F_PTC_DRV15                       (_UL_(1) << 19)
+
+#define PIN_PA22F_PTC_DRV16                        _L_(22)      /**< PTC signal: DRV16 on PA22 mux F*/
+#define MUX_PA22F_PTC_DRV16                        _L_(5)      
+#define PINMUX_PA22F_PTC_DRV16                     ((PIN_PA22F_PTC_DRV16 << 16) | MUX_PA22F_PTC_DRV16)
+#define PORT_PA22F_PTC_DRV16                       (_UL_(1) << 22)
+
+#define PIN_PA23F_PTC_DRV17                        _L_(23)      /**< PTC signal: DRV17 on PA23 mux F*/
+#define MUX_PA23F_PTC_DRV17                        _L_(5)      
+#define PINMUX_PA23F_PTC_DRV17                     ((PIN_PA23F_PTC_DRV17 << 16) | MUX_PA23F_PTC_DRV17)
+#define PORT_PA23F_PTC_DRV17                       (_UL_(1) << 23)
+
+#define PIN_PA30F_PTC_DRV18                        _L_(30)      /**< PTC signal: DRV18 on PA30 mux F*/
+#define MUX_PA30F_PTC_DRV18                        _L_(5)      
+#define PINMUX_PA30F_PTC_DRV18                     ((PIN_PA30F_PTC_DRV18 << 16) | MUX_PA30F_PTC_DRV18)
+#define PORT_PA30F_PTC_DRV18                       (_UL_(1) << 30)
+
+#define PIN_PA31F_PTC_DRV19                        _L_(31)      /**< PTC signal: DRV19 on PA31 mux F*/
+#define MUX_PA31F_PTC_DRV19                        _L_(5)      
+#define PINMUX_PA31F_PTC_DRV19                     ((PIN_PA31F_PTC_DRV19 << 16) | MUX_PA31F_PTC_DRV19)
+#define PORT_PA31F_PTC_DRV19                       (_UL_(1) << 31)
+
+#define PIN_PA03B_PTC_ECI0                         _L_(3)       /**< PTC signal: ECI0 on PA03 mux B*/
+#define MUX_PA03B_PTC_ECI0                         _L_(1)      
+#define PINMUX_PA03B_PTC_ECI0                      ((PIN_PA03B_PTC_ECI0 << 16) | MUX_PA03B_PTC_ECI0)
+#define PORT_PA03B_PTC_ECI0                        (_UL_(1) << 3)
+
+#define PIN_PA04B_PTC_ECI1                         _L_(4)       /**< PTC signal: ECI1 on PA04 mux B*/
+#define MUX_PA04B_PTC_ECI1                         _L_(1)      
+#define PINMUX_PA04B_PTC_ECI1                      ((PIN_PA04B_PTC_ECI1 << 16) | MUX_PA04B_PTC_ECI1)
+#define PORT_PA04B_PTC_ECI1                        (_UL_(1) << 4)
+
+#define PIN_PA05B_PTC_ECI2                         _L_(5)       /**< PTC signal: ECI2 on PA05 mux B*/
+#define MUX_PA05B_PTC_ECI2                         _L_(1)      
+#define PINMUX_PA05B_PTC_ECI2                      ((PIN_PA05B_PTC_ECI2 << 16) | MUX_PA05B_PTC_ECI2)
+#define PORT_PA05B_PTC_ECI2                        (_UL_(1) << 5)
+
+#define PIN_PA00B_PTC_X0                           _L_(0)       /**< PTC signal: X0 on PA00 mux B*/
+#define MUX_PA00B_PTC_X0                           _L_(1)      
+#define PINMUX_PA00B_PTC_X0                        ((PIN_PA00B_PTC_X0 << 16) | MUX_PA00B_PTC_X0)
+#define PORT_PA00B_PTC_X0                          (_UL_(1) << 0)
+
+#define PIN_PA00B_PTC_Y0                           _L_(0)       /**< PTC signal: Y0 on PA00 mux B*/
+#define MUX_PA00B_PTC_Y0                           _L_(1)      
+#define PINMUX_PA00B_PTC_Y0                        ((PIN_PA00B_PTC_Y0 << 16) | MUX_PA00B_PTC_Y0)
+#define PORT_PA00B_PTC_Y0                          (_UL_(1) << 0)
+
+#define PIN_PA01B_PTC_X1                           _L_(1)       /**< PTC signal: X1 on PA01 mux B*/
+#define MUX_PA01B_PTC_X1                           _L_(1)      
+#define PINMUX_PA01B_PTC_X1                        ((PIN_PA01B_PTC_X1 << 16) | MUX_PA01B_PTC_X1)
+#define PORT_PA01B_PTC_X1                          (_UL_(1) << 1)
+
+#define PIN_PA01B_PTC_Y1                           _L_(1)       /**< PTC signal: Y1 on PA01 mux B*/
+#define MUX_PA01B_PTC_Y1                           _L_(1)      
+#define PINMUX_PA01B_PTC_Y1                        ((PIN_PA01B_PTC_Y1 << 16) | MUX_PA01B_PTC_Y1)
+#define PORT_PA01B_PTC_Y1                          (_UL_(1) << 1)
+
+#define PIN_PA02B_PTC_X2                           _L_(2)       /**< PTC signal: X2 on PA02 mux B*/
+#define MUX_PA02B_PTC_X2                           _L_(1)      
+#define PINMUX_PA02B_PTC_X2                        ((PIN_PA02B_PTC_X2 << 16) | MUX_PA02B_PTC_X2)
+#define PORT_PA02B_PTC_X2                          (_UL_(1) << 2)
+
+#define PIN_PA02B_PTC_Y2                           _L_(2)       /**< PTC signal: Y2 on PA02 mux B*/
+#define MUX_PA02B_PTC_Y2                           _L_(1)      
+#define PINMUX_PA02B_PTC_Y2                        ((PIN_PA02B_PTC_Y2 << 16) | MUX_PA02B_PTC_Y2)
+#define PORT_PA02B_PTC_Y2                          (_UL_(1) << 2)
+
+#define PIN_PA03B_PTC_X3                           _L_(3)       /**< PTC signal: X3 on PA03 mux B*/
+#define MUX_PA03B_PTC_X3                           _L_(1)      
+#define PINMUX_PA03B_PTC_X3                        ((PIN_PA03B_PTC_X3 << 16) | MUX_PA03B_PTC_X3)
+#define PORT_PA03B_PTC_X3                          (_UL_(1) << 3)
+
+#define PIN_PA03B_PTC_Y3                           _L_(3)       /**< PTC signal: Y3 on PA03 mux B*/
+#define MUX_PA03B_PTC_Y3                           _L_(1)      
+#define PINMUX_PA03B_PTC_Y3                        ((PIN_PA03B_PTC_Y3 << 16) | MUX_PA03B_PTC_Y3)
+#define PORT_PA03B_PTC_Y3                          (_UL_(1) << 3)
+
+#define PIN_PA05B_PTC_X4                           _L_(5)       /**< PTC signal: X4 on PA05 mux B*/
+#define MUX_PA05B_PTC_X4                           _L_(1)      
+#define PINMUX_PA05B_PTC_X4                        ((PIN_PA05B_PTC_X4 << 16) | MUX_PA05B_PTC_X4)
+#define PORT_PA05B_PTC_X4                          (_UL_(1) << 5)
+
+#define PIN_PA05B_PTC_Y4                           _L_(5)       /**< PTC signal: Y4 on PA05 mux B*/
+#define MUX_PA05B_PTC_Y4                           _L_(1)      
+#define PINMUX_PA05B_PTC_Y4                        ((PIN_PA05B_PTC_Y4 << 16) | MUX_PA05B_PTC_Y4)
+#define PORT_PA05B_PTC_Y4                          (_UL_(1) << 5)
+
+#define PIN_PA08B_PTC_X6                           _L_(8)       /**< PTC signal: X6 on PA08 mux B*/
+#define MUX_PA08B_PTC_X6                           _L_(1)      
+#define PINMUX_PA08B_PTC_X6                        ((PIN_PA08B_PTC_X6 << 16) | MUX_PA08B_PTC_X6)
+#define PORT_PA08B_PTC_X6                          (_UL_(1) << 8)
+
+#define PIN_PA08B_PTC_Y6                           _L_(8)       /**< PTC signal: Y6 on PA08 mux B*/
+#define MUX_PA08B_PTC_Y6                           _L_(1)      
+#define PINMUX_PA08B_PTC_Y6                        ((PIN_PA08B_PTC_Y6 << 16) | MUX_PA08B_PTC_Y6)
+#define PORT_PA08B_PTC_Y6                          (_UL_(1) << 8)
+
+#define PIN_PA14B_PTC_X10                          _L_(14)      /**< PTC signal: X10 on PA14 mux B*/
+#define MUX_PA14B_PTC_X10                          _L_(1)      
+#define PINMUX_PA14B_PTC_X10                       ((PIN_PA14B_PTC_X10 << 16) | MUX_PA14B_PTC_X10)
+#define PORT_PA14B_PTC_X10                         (_UL_(1) << 14)
+
+#define PIN_PA14B_PTC_Y10                          _L_(14)      /**< PTC signal: Y10 on PA14 mux B*/
+#define MUX_PA14B_PTC_Y10                          _L_(1)      
+#define PINMUX_PA14B_PTC_Y10                       ((PIN_PA14B_PTC_Y10 << 16) | MUX_PA14B_PTC_Y10)
+#define PORT_PA14B_PTC_Y10                         (_UL_(1) << 14)
+
+#define PIN_PA15B_PTC_X11                          _L_(15)      /**< PTC signal: X11 on PA15 mux B*/
+#define MUX_PA15B_PTC_X11                          _L_(1)      
+#define PINMUX_PA15B_PTC_X11                       ((PIN_PA15B_PTC_X11 << 16) | MUX_PA15B_PTC_X11)
+#define PORT_PA15B_PTC_X11                         (_UL_(1) << 15)
+
+#define PIN_PA15B_PTC_Y11                          _L_(15)      /**< PTC signal: Y11 on PA15 mux B*/
+#define MUX_PA15B_PTC_Y11                          _L_(1)      
+#define PINMUX_PA15B_PTC_Y11                       ((PIN_PA15B_PTC_Y11 << 16) | MUX_PA15B_PTC_Y11)
+#define PORT_PA15B_PTC_Y11                         (_UL_(1) << 15)
+
+#define PIN_PA16B_PTC_X12                          _L_(16)      /**< PTC signal: X12 on PA16 mux B*/
+#define MUX_PA16B_PTC_X12                          _L_(1)      
+#define PINMUX_PA16B_PTC_X12                       ((PIN_PA16B_PTC_X12 << 16) | MUX_PA16B_PTC_X12)
+#define PORT_PA16B_PTC_X12                         (_UL_(1) << 16)
+
+#define PIN_PA16B_PTC_Y12                          _L_(16)      /**< PTC signal: Y12 on PA16 mux B*/
+#define MUX_PA16B_PTC_Y12                          _L_(1)      
+#define PINMUX_PA16B_PTC_Y12                       ((PIN_PA16B_PTC_Y12 << 16) | MUX_PA16B_PTC_Y12)
+#define PORT_PA16B_PTC_Y12                         (_UL_(1) << 16)
+
+#define PIN_PA17B_PTC_X13                          _L_(17)      /**< PTC signal: X13 on PA17 mux B*/
+#define MUX_PA17B_PTC_X13                          _L_(1)      
+#define PINMUX_PA17B_PTC_X13                       ((PIN_PA17B_PTC_X13 << 16) | MUX_PA17B_PTC_X13)
+#define PORT_PA17B_PTC_X13                         (_UL_(1) << 17)
+
+#define PIN_PA17B_PTC_Y13                          _L_(17)      /**< PTC signal: Y13 on PA17 mux B*/
+#define MUX_PA17B_PTC_Y13                          _L_(1)      
+#define PINMUX_PA17B_PTC_Y13                       ((PIN_PA17B_PTC_Y13 << 16) | MUX_PA17B_PTC_Y13)
+#define PORT_PA17B_PTC_Y13                         (_UL_(1) << 17)
+
+#define PIN_PA18B_PTC_X14                          _L_(18)      /**< PTC signal: X14 on PA18 mux B*/
+#define MUX_PA18B_PTC_X14                          _L_(1)      
+#define PINMUX_PA18B_PTC_X14                       ((PIN_PA18B_PTC_X14 << 16) | MUX_PA18B_PTC_X14)
+#define PORT_PA18B_PTC_X14                         (_UL_(1) << 18)
+
+#define PIN_PA18B_PTC_Y14                          _L_(18)      /**< PTC signal: Y14 on PA18 mux B*/
+#define MUX_PA18B_PTC_Y14                          _L_(1)      
+#define PINMUX_PA18B_PTC_Y14                       ((PIN_PA18B_PTC_Y14 << 16) | MUX_PA18B_PTC_Y14)
+#define PORT_PA18B_PTC_Y14                         (_UL_(1) << 18)
+
+#define PIN_PA19B_PTC_X15                          _L_(19)      /**< PTC signal: X15 on PA19 mux B*/
+#define MUX_PA19B_PTC_X15                          _L_(1)      
+#define PINMUX_PA19B_PTC_X15                       ((PIN_PA19B_PTC_X15 << 16) | MUX_PA19B_PTC_X15)
+#define PORT_PA19B_PTC_X15                         (_UL_(1) << 19)
+
+#define PIN_PA19B_PTC_Y15                          _L_(19)      /**< PTC signal: Y15 on PA19 mux B*/
+#define MUX_PA19B_PTC_Y15                          _L_(1)      
+#define PINMUX_PA19B_PTC_Y15                       ((PIN_PA19B_PTC_Y15 << 16) | MUX_PA19B_PTC_Y15)
+#define PORT_PA19B_PTC_Y15                         (_UL_(1) << 19)
+
+#define PIN_PA22B_PTC_X16                          _L_(22)      /**< PTC signal: X16 on PA22 mux B*/
+#define MUX_PA22B_PTC_X16                          _L_(1)      
+#define PINMUX_PA22B_PTC_X16                       ((PIN_PA22B_PTC_X16 << 16) | MUX_PA22B_PTC_X16)
+#define PORT_PA22B_PTC_X16                         (_UL_(1) << 22)
+
+#define PIN_PA22B_PTC_Y16                          _L_(22)      /**< PTC signal: Y16 on PA22 mux B*/
+#define MUX_PA22B_PTC_Y16                          _L_(1)      
+#define PINMUX_PA22B_PTC_Y16                       ((PIN_PA22B_PTC_Y16 << 16) | MUX_PA22B_PTC_Y16)
+#define PORT_PA22B_PTC_Y16                         (_UL_(1) << 22)
+
+#define PIN_PA23B_PTC_X17                          _L_(23)      /**< PTC signal: X17 on PA23 mux B*/
+#define MUX_PA23B_PTC_X17                          _L_(1)      
+#define PINMUX_PA23B_PTC_X17                       ((PIN_PA23B_PTC_X17 << 16) | MUX_PA23B_PTC_X17)
+#define PORT_PA23B_PTC_X17                         (_UL_(1) << 23)
+
+#define PIN_PA23B_PTC_Y17                          _L_(23)      /**< PTC signal: Y17 on PA23 mux B*/
+#define MUX_PA23B_PTC_Y17                          _L_(1)      
+#define PINMUX_PA23B_PTC_Y17                       ((PIN_PA23B_PTC_Y17 << 16) | MUX_PA23B_PTC_Y17)
+#define PORT_PA23B_PTC_Y17                         (_UL_(1) << 23)
+
+#define PIN_PA30B_PTC_X18                          _L_(30)      /**< PTC signal: X18 on PA30 mux B*/
+#define MUX_PA30B_PTC_X18                          _L_(1)      
+#define PINMUX_PA30B_PTC_X18                       ((PIN_PA30B_PTC_X18 << 16) | MUX_PA30B_PTC_X18)
+#define PORT_PA30B_PTC_X18                         (_UL_(1) << 30)
+
+#define PIN_PA30B_PTC_Y18                          _L_(30)      /**< PTC signal: Y18 on PA30 mux B*/
+#define MUX_PA30B_PTC_Y18                          _L_(1)      
+#define PINMUX_PA30B_PTC_Y18                       ((PIN_PA30B_PTC_Y18 << 16) | MUX_PA30B_PTC_Y18)
+#define PORT_PA30B_PTC_Y18                         (_UL_(1) << 30)
+
+#define PIN_PA31B_PTC_X19                          _L_(31)      /**< PTC signal: X19 on PA31 mux B*/
+#define MUX_PA31B_PTC_X19                          _L_(1)      
+#define PINMUX_PA31B_PTC_X19                       ((PIN_PA31B_PTC_X19 << 16) | MUX_PA31B_PTC_X19)
+#define PORT_PA31B_PTC_X19                         (_UL_(1) << 31)
+
+#define PIN_PA31B_PTC_Y19                          _L_(31)      /**< PTC signal: Y19 on PA31 mux B*/
+#define MUX_PA31B_PTC_Y19                          _L_(1)      
+#define PINMUX_PA31B_PTC_Y19                       ((PIN_PA31B_PTC_Y19 << 16) | MUX_PA31B_PTC_Y19)
+#define PORT_PA31B_PTC_Y19                         (_UL_(1) << 31)
+
+/* ========== PORT definition for RTC peripheral ========== */
+#define PIN_PA08G_RTC_IN0                          _L_(8)       /**< RTC signal: IN0 on PA08 mux G*/
+#define MUX_PA08G_RTC_IN0                          _L_(6)      
+#define PINMUX_PA08G_RTC_IN0                       ((PIN_PA08G_RTC_IN0 << 16) | MUX_PA08G_RTC_IN0)
+#define PORT_PA08G_RTC_IN0                         (_UL_(1) << 8)
+
+#define PIN_PA16G_RTC_IN2                          _L_(16)      /**< RTC signal: IN2 on PA16 mux G*/
+#define MUX_PA16G_RTC_IN2                          _L_(6)      
+#define PINMUX_PA16G_RTC_IN2                       ((PIN_PA16G_RTC_IN2 << 16) | MUX_PA16G_RTC_IN2)
+#define PORT_PA16G_RTC_IN2                         (_UL_(1) << 16)
+
+#define PIN_PA17G_RTC_IN3                          _L_(17)      /**< RTC signal: IN3 on PA17 mux G*/
+#define MUX_PA17G_RTC_IN3                          _L_(6)      
+#define PINMUX_PA17G_RTC_IN3                       ((PIN_PA17G_RTC_IN3 << 16) | MUX_PA17G_RTC_IN3)
+#define PORT_PA17G_RTC_IN3                         (_UL_(1) << 17)
+
+#define PIN_PA18G_RTC_OUT0                         _L_(18)      /**< RTC signal: OUT0 on PA18 mux G*/
+#define MUX_PA18G_RTC_OUT0                         _L_(6)      
+#define PINMUX_PA18G_RTC_OUT0                      ((PIN_PA18G_RTC_OUT0 << 16) | MUX_PA18G_RTC_OUT0)
+#define PORT_PA18G_RTC_OUT0                        (_UL_(1) << 18)
+
+#define PIN_PA19G_RTC_OUT1                         _L_(19)      /**< RTC signal: OUT1 on PA19 mux G*/
+#define MUX_PA19G_RTC_OUT1                         _L_(6)      
+#define PINMUX_PA19G_RTC_OUT1                      ((PIN_PA19G_RTC_OUT1 << 16) | MUX_PA19G_RTC_OUT1)
+#define PORT_PA19G_RTC_OUT1                        (_UL_(1) << 19)
+
+#define PIN_PA22G_RTC_OUT2                         _L_(22)      /**< RTC signal: OUT2 on PA22 mux G*/
+#define MUX_PA22G_RTC_OUT2                         _L_(6)      
+#define PINMUX_PA22G_RTC_OUT2                      ((PIN_PA22G_RTC_OUT2 << 16) | MUX_PA22G_RTC_OUT2)
+#define PORT_PA22G_RTC_OUT2                        (_UL_(1) << 22)
+
+#define PIN_PA23G_RTC_OUT3                         _L_(23)      /**< RTC signal: OUT3 on PA23 mux G*/
+#define MUX_PA23G_RTC_OUT3                         _L_(6)      
+#define PINMUX_PA23G_RTC_OUT3                      ((PIN_PA23G_RTC_OUT3 << 16) | MUX_PA23G_RTC_OUT3)
+#define PORT_PA23G_RTC_OUT3                        (_UL_(1) << 23)
+
+/* ========== PORT definition for SERCOM0 peripheral ========== */
+#define PIN_PA04D_SERCOM0_PAD0                     _L_(4)       /**< SERCOM0 signal: PAD0 on PA04 mux D*/
+#define MUX_PA04D_SERCOM0_PAD0                     _L_(3)      
+#define PINMUX_PA04D_SERCOM0_PAD0                  ((PIN_PA04D_SERCOM0_PAD0 << 16) | MUX_PA04D_SERCOM0_PAD0)
+#define PORT_PA04D_SERCOM0_PAD0                    (_UL_(1) << 4)
+
+#define PIN_PA16D_SERCOM0_PAD0                     _L_(16)      /**< SERCOM0 signal: PAD0 on PA16 mux D*/
+#define MUX_PA16D_SERCOM0_PAD0                     _L_(3)      
+#define PINMUX_PA16D_SERCOM0_PAD0                  ((PIN_PA16D_SERCOM0_PAD0 << 16) | MUX_PA16D_SERCOM0_PAD0)
+#define PORT_PA16D_SERCOM0_PAD0                    (_UL_(1) << 16)
+
+#define PIN_PA22C_SERCOM0_PAD0                     _L_(22)      /**< SERCOM0 signal: PAD0 on PA22 mux C*/
+#define MUX_PA22C_SERCOM0_PAD0                     _L_(2)      
+#define PINMUX_PA22C_SERCOM0_PAD0                  ((PIN_PA22C_SERCOM0_PAD0 << 16) | MUX_PA22C_SERCOM0_PAD0)
+#define PORT_PA22C_SERCOM0_PAD0                    (_UL_(1) << 22)
+
+#define PIN_PA05D_SERCOM0_PAD1                     _L_(5)       /**< SERCOM0 signal: PAD1 on PA05 mux D*/
+#define MUX_PA05D_SERCOM0_PAD1                     _L_(3)      
+#define PINMUX_PA05D_SERCOM0_PAD1                  ((PIN_PA05D_SERCOM0_PAD1 << 16) | MUX_PA05D_SERCOM0_PAD1)
+#define PORT_PA05D_SERCOM0_PAD1                    (_UL_(1) << 5)
+
+#define PIN_PA17D_SERCOM0_PAD1                     _L_(17)      /**< SERCOM0 signal: PAD1 on PA17 mux D*/
+#define MUX_PA17D_SERCOM0_PAD1                     _L_(3)      
+#define PINMUX_PA17D_SERCOM0_PAD1                  ((PIN_PA17D_SERCOM0_PAD1 << 16) | MUX_PA17D_SERCOM0_PAD1)
+#define PORT_PA17D_SERCOM0_PAD1                    (_UL_(1) << 17)
+
+#define PIN_PA23C_SERCOM0_PAD1                     _L_(23)      /**< SERCOM0 signal: PAD1 on PA23 mux C*/
+#define MUX_PA23C_SERCOM0_PAD1                     _L_(2)      
+#define PINMUX_PA23C_SERCOM0_PAD1                  ((PIN_PA23C_SERCOM0_PAD1 << 16) | MUX_PA23C_SERCOM0_PAD1)
+#define PORT_PA23C_SERCOM0_PAD1                    (_UL_(1) << 23)
+
+#define PIN_PA14D_SERCOM0_PAD2                     _L_(14)      /**< SERCOM0 signal: PAD2 on PA14 mux D*/
+#define MUX_PA14D_SERCOM0_PAD2                     _L_(3)      
+#define PINMUX_PA14D_SERCOM0_PAD2                  ((PIN_PA14D_SERCOM0_PAD2 << 16) | MUX_PA14D_SERCOM0_PAD2)
+#define PORT_PA14D_SERCOM0_PAD2                    (_UL_(1) << 14)
+
+#define PIN_PA18D_SERCOM0_PAD2                     _L_(18)      /**< SERCOM0 signal: PAD2 on PA18 mux D*/
+#define MUX_PA18D_SERCOM0_PAD2                     _L_(3)      
+#define PINMUX_PA18D_SERCOM0_PAD2                  ((PIN_PA18D_SERCOM0_PAD2 << 16) | MUX_PA18D_SERCOM0_PAD2)
+#define PORT_PA18D_SERCOM0_PAD2                    (_UL_(1) << 18)
+
+#define PIN_PA02D_SERCOM0_PAD2                     _L_(2)       /**< SERCOM0 signal: PAD2 on PA02 mux D*/
+#define MUX_PA02D_SERCOM0_PAD2                     _L_(3)      
+#define PINMUX_PA02D_SERCOM0_PAD2                  ((PIN_PA02D_SERCOM0_PAD2 << 16) | MUX_PA02D_SERCOM0_PAD2)
+#define PORT_PA02D_SERCOM0_PAD2                    (_UL_(1) << 2)
+
+#define PIN_PA15D_SERCOM0_PAD3                     _L_(15)      /**< SERCOM0 signal: PAD3 on PA15 mux D*/
+#define MUX_PA15D_SERCOM0_PAD3                     _L_(3)      
+#define PINMUX_PA15D_SERCOM0_PAD3                  ((PIN_PA15D_SERCOM0_PAD3 << 16) | MUX_PA15D_SERCOM0_PAD3)
+#define PORT_PA15D_SERCOM0_PAD3                    (_UL_(1) << 15)
+
+#define PIN_PA19D_SERCOM0_PAD3                     _L_(19)      /**< SERCOM0 signal: PAD3 on PA19 mux D*/
+#define MUX_PA19D_SERCOM0_PAD3                     _L_(3)      
+#define PINMUX_PA19D_SERCOM0_PAD3                  ((PIN_PA19D_SERCOM0_PAD3 << 16) | MUX_PA19D_SERCOM0_PAD3)
+#define PORT_PA19D_SERCOM0_PAD3                    (_UL_(1) << 19)
+
+#define PIN_PA03D_SERCOM0_PAD3                     _L_(3)       /**< SERCOM0 signal: PAD3 on PA03 mux D*/
+#define MUX_PA03D_SERCOM0_PAD3                     _L_(3)      
+#define PINMUX_PA03D_SERCOM0_PAD3                  ((PIN_PA03D_SERCOM0_PAD3 << 16) | MUX_PA03D_SERCOM0_PAD3)
+#define PORT_PA03D_SERCOM0_PAD3                    (_UL_(1) << 3)
+
+/* ========== PORT definition for SERCOM1 peripheral ========== */
+#define PIN_PA16C_SERCOM1_PAD0                     _L_(16)      /**< SERCOM1 signal: PAD0 on PA16 mux C*/
+#define MUX_PA16C_SERCOM1_PAD0                     _L_(2)      
+#define PINMUX_PA16C_SERCOM1_PAD0                  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
+#define PORT_PA16C_SERCOM1_PAD0                    (_UL_(1) << 16)
+
+#define PIN_PA08C_SERCOM1_PAD0                     _L_(8)       /**< SERCOM1 signal: PAD0 on PA08 mux C*/
+#define MUX_PA08C_SERCOM1_PAD0                     _L_(2)      
+#define PINMUX_PA08C_SERCOM1_PAD0                  ((PIN_PA08C_SERCOM1_PAD0 << 16) | MUX_PA08C_SERCOM1_PAD0)
+#define PORT_PA08C_SERCOM1_PAD0                    (_UL_(1) << 8)
+
+#define PIN_PA00D_SERCOM1_PAD0                     _L_(0)       /**< SERCOM1 signal: PAD0 on PA00 mux D*/
+#define MUX_PA00D_SERCOM1_PAD0                     _L_(3)      
+#define PINMUX_PA00D_SERCOM1_PAD0                  ((PIN_PA00D_SERCOM1_PAD0 << 16) | MUX_PA00D_SERCOM1_PAD0)
+#define PORT_PA00D_SERCOM1_PAD0                    (_UL_(1) << 0)
+
+#define PIN_PA17C_SERCOM1_PAD1                     _L_(17)      /**< SERCOM1 signal: PAD1 on PA17 mux C*/
+#define MUX_PA17C_SERCOM1_PAD1                     _L_(2)      
+#define PINMUX_PA17C_SERCOM1_PAD1                  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
+#define PORT_PA17C_SERCOM1_PAD1                    (_UL_(1) << 17)
+
+#define PIN_PA01D_SERCOM1_PAD1                     _L_(1)       /**< SERCOM1 signal: PAD1 on PA01 mux D*/
+#define MUX_PA01D_SERCOM1_PAD1                     _L_(3)      
+#define PINMUX_PA01D_SERCOM1_PAD1                  ((PIN_PA01D_SERCOM1_PAD1 << 16) | MUX_PA01D_SERCOM1_PAD1)
+#define PORT_PA01D_SERCOM1_PAD1                    (_UL_(1) << 1)
+
+#define PIN_PA18C_SERCOM1_PAD2                     _L_(18)      /**< SERCOM1 signal: PAD2 on PA18 mux C*/
+#define MUX_PA18C_SERCOM1_PAD2                     _L_(2)      
+#define PINMUX_PA18C_SERCOM1_PAD2                  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
+#define PORT_PA18C_SERCOM1_PAD2                    (_UL_(1) << 18)
+
+#define PIN_PA30D_SERCOM1_PAD2                     _L_(30)      /**< SERCOM1 signal: PAD2 on PA30 mux D*/
+#define MUX_PA30D_SERCOM1_PAD2                     _L_(3)      
+#define PINMUX_PA30D_SERCOM1_PAD2                  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
+#define PORT_PA30D_SERCOM1_PAD2                    (_UL_(1) << 30)
+
+#define PIN_PA19C_SERCOM1_PAD3                     _L_(19)      /**< SERCOM1 signal: PAD3 on PA19 mux C*/
+#define MUX_PA19C_SERCOM1_PAD3                     _L_(2)      
+#define PINMUX_PA19C_SERCOM1_PAD3                  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
+#define PORT_PA19C_SERCOM1_PAD3                    (_UL_(1) << 19)
+
+#define PIN_PA31D_SERCOM1_PAD3                     _L_(31)      /**< SERCOM1 signal: PAD3 on PA31 mux D*/
+#define MUX_PA31D_SERCOM1_PAD3                     _L_(3)      
+#define PINMUX_PA31D_SERCOM1_PAD3                  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
+#define PORT_PA31D_SERCOM1_PAD3                    (_UL_(1) << 31)
+
+/* ========== PORT definition for TC0 peripheral ========== */
+#define PIN_PA04E_TC0_WO0                          _L_(4)       /**< TC0 signal: WO0 on PA04 mux E*/
+#define MUX_PA04E_TC0_WO0                          _L_(4)      
+#define PINMUX_PA04E_TC0_WO0                       ((PIN_PA04E_TC0_WO0 << 16) | MUX_PA04E_TC0_WO0)
+#define PORT_PA04E_TC0_WO0                         (_UL_(1) << 4)
+
+#define PIN_PA14E_TC0_WO0                          _L_(14)      /**< TC0 signal: WO0 on PA14 mux E*/
+#define MUX_PA14E_TC0_WO0                          _L_(4)      
+#define PINMUX_PA14E_TC0_WO0                       ((PIN_PA14E_TC0_WO0 << 16) | MUX_PA14E_TC0_WO0)
+#define PORT_PA14E_TC0_WO0                         (_UL_(1) << 14)
+
+#define PIN_PA22E_TC0_WO0                          _L_(22)      /**< TC0 signal: WO0 on PA22 mux E*/
+#define MUX_PA22E_TC0_WO0                          _L_(4)      
+#define PINMUX_PA22E_TC0_WO0                       ((PIN_PA22E_TC0_WO0 << 16) | MUX_PA22E_TC0_WO0)
+#define PORT_PA22E_TC0_WO0                         (_UL_(1) << 22)
+
+#define PIN_PA05E_TC0_WO1                          _L_(5)       /**< TC0 signal: WO1 on PA05 mux E*/
+#define MUX_PA05E_TC0_WO1                          _L_(4)      
+#define PINMUX_PA05E_TC0_WO1                       ((PIN_PA05E_TC0_WO1 << 16) | MUX_PA05E_TC0_WO1)
+#define PORT_PA05E_TC0_WO1                         (_UL_(1) << 5)
+
+#define PIN_PA15E_TC0_WO1                          _L_(15)      /**< TC0 signal: WO1 on PA15 mux E*/
+#define MUX_PA15E_TC0_WO1                          _L_(4)      
+#define PINMUX_PA15E_TC0_WO1                       ((PIN_PA15E_TC0_WO1 << 16) | MUX_PA15E_TC0_WO1)
+#define PORT_PA15E_TC0_WO1                         (_UL_(1) << 15)
+
+#define PIN_PA23E_TC0_WO1                          _L_(23)      /**< TC0 signal: WO1 on PA23 mux E*/
+#define MUX_PA23E_TC0_WO1                          _L_(4)      
+#define PINMUX_PA23E_TC0_WO1                       ((PIN_PA23E_TC0_WO1 << 16) | MUX_PA23E_TC0_WO1)
+#define PORT_PA23E_TC0_WO1                         (_UL_(1) << 23)
+
+/* ========== PORT definition for TC1 peripheral ========== */
+#define PIN_PA30E_TC1_WO0                          _L_(30)      /**< TC1 signal: WO0 on PA30 mux E*/
+#define MUX_PA30E_TC1_WO0                          _L_(4)      
+#define PINMUX_PA30E_TC1_WO0                       ((PIN_PA30E_TC1_WO0 << 16) | MUX_PA30E_TC1_WO0)
+#define PORT_PA30E_TC1_WO0                         (_UL_(1) << 30)
+
+#define PIN_PA31E_TC1_WO1                          _L_(31)      /**< TC1 signal: WO1 on PA31 mux E*/
+#define MUX_PA31E_TC1_WO1                          _L_(4)      
+#define PINMUX_PA31E_TC1_WO1                       ((PIN_PA31E_TC1_WO1 << 16) | MUX_PA31E_TC1_WO1)
+#define PORT_PA31E_TC1_WO1                         (_UL_(1) << 31)
+
+/* ========== PORT definition for TC2 peripheral ========== */
+#define PIN_PA00E_TC2_WO0                          _L_(0)       /**< TC2 signal: WO0 on PA00 mux E*/
+#define MUX_PA00E_TC2_WO0                          _L_(4)      
+#define PINMUX_PA00E_TC2_WO0                       ((PIN_PA00E_TC2_WO0 << 16) | MUX_PA00E_TC2_WO0)
+#define PORT_PA00E_TC2_WO0                         (_UL_(1) << 0)
+
+#define PIN_PA18E_TC2_WO0                          _L_(18)      /**< TC2 signal: WO0 on PA18 mux E*/
+#define MUX_PA18E_TC2_WO0                          _L_(4)      
+#define PINMUX_PA18E_TC2_WO0                       ((PIN_PA18E_TC2_WO0 << 16) | MUX_PA18E_TC2_WO0)
+#define PORT_PA18E_TC2_WO0                         (_UL_(1) << 18)
+
+#define PIN_PA01E_TC2_WO1                          _L_(1)       /**< TC2 signal: WO1 on PA01 mux E*/
+#define MUX_PA01E_TC2_WO1                          _L_(4)      
+#define PINMUX_PA01E_TC2_WO1                       ((PIN_PA01E_TC2_WO1 << 16) | MUX_PA01E_TC2_WO1)
+#define PORT_PA01E_TC2_WO1                         (_UL_(1) << 1)
+
+#define PIN_PA19E_TC2_WO1                          _L_(19)      /**< TC2 signal: WO1 on PA19 mux E*/
+#define MUX_PA19E_TC2_WO1                          _L_(4)      
+#define PINMUX_PA19E_TC2_WO1                       ((PIN_PA19E_TC2_WO1 << 16) | MUX_PA19E_TC2_WO1)
+#define PORT_PA19E_TC2_WO1                         (_UL_(1) << 19)
+
+
+#endif /* _SAML10D15A_PIO_H_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/pio/saml10d16a.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/pio/saml10d16a.h
@@ -1,0 +1,834 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAML10D16A
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10D16A_PIO_H_
+#define _SAML10D16A_PIO_H_
+
+/* ========== Peripheral I/O pin numbers ========== */
+#define PIN_PA00                    (  0)  /**< Pin Number for PA00 */
+#define PIN_PA01                    (  1)  /**< Pin Number for PA01 */
+#define PIN_PA02                    (  2)  /**< Pin Number for PA02 */
+#define PIN_PA03                    (  3)  /**< Pin Number for PA03 */
+#define PIN_PA04                    (  4)  /**< Pin Number for PA04 */
+#define PIN_PA05                    (  5)  /**< Pin Number for PA05 */
+#define PIN_PA08                    (  8)  /**< Pin Number for PA08 */
+#define PIN_PA14                    ( 14)  /**< Pin Number for PA14 */
+#define PIN_PA15                    ( 15)  /**< Pin Number for PA15 */
+#define PIN_PA16                    ( 16)  /**< Pin Number for PA16 */
+#define PIN_PA17                    ( 17)  /**< Pin Number for PA17 */
+#define PIN_PA18                    ( 18)  /**< Pin Number for PA18 */
+#define PIN_PA19                    ( 19)  /**< Pin Number for PA19 */
+#define PIN_PA22                    ( 22)  /**< Pin Number for PA22 */
+#define PIN_PA23                    ( 23)  /**< Pin Number for PA23 */
+#define PIN_PA30                    ( 30)  /**< Pin Number for PA30 */
+#define PIN_PA31                    ( 31)  /**< Pin Number for PA31 */
+
+
+/* ========== Peripheral I/O masks ========== */
+#define PORT_PA00                   (_U_(1) << 0) /**< PORT Mask for PA00 */
+#define PORT_PA01                   (_U_(1) << 1) /**< PORT Mask for PA01 */
+#define PORT_PA02                   (_U_(1) << 2) /**< PORT Mask for PA02 */
+#define PORT_PA03                   (_U_(1) << 3) /**< PORT Mask for PA03 */
+#define PORT_PA04                   (_U_(1) << 4) /**< PORT Mask for PA04 */
+#define PORT_PA05                   (_U_(1) << 5) /**< PORT Mask for PA05 */
+#define PORT_PA08                   (_U_(1) << 8) /**< PORT Mask for PA08 */
+#define PORT_PA14                   (_U_(1) << 14) /**< PORT Mask for PA14 */
+#define PORT_PA15                   (_U_(1) << 15) /**< PORT Mask for PA15 */
+#define PORT_PA16                   (_U_(1) << 16) /**< PORT Mask for PA16 */
+#define PORT_PA17                   (_U_(1) << 17) /**< PORT Mask for PA17 */
+#define PORT_PA18                   (_U_(1) << 18) /**< PORT Mask for PA18 */
+#define PORT_PA19                   (_U_(1) << 19) /**< PORT Mask for PA19 */
+#define PORT_PA22                   (_U_(1) << 22) /**< PORT Mask for PA22 */
+#define PORT_PA23                   (_U_(1) << 23) /**< PORT Mask for PA23 */
+#define PORT_PA30                   (_U_(1) << 30) /**< PORT Mask for PA30 */
+#define PORT_PA31                   (_U_(1) << 31) /**< PORT Mask for PA31 */
+
+
+/* ========== Peripheral I/O indexes ========== */
+#define PORT_PA00_IDX               (  0)  /**< PORT Index Number for PA00 */
+#define PORT_PA01_IDX               (  1)  /**< PORT Index Number for PA01 */
+#define PORT_PA02_IDX               (  2)  /**< PORT Index Number for PA02 */
+#define PORT_PA03_IDX               (  3)  /**< PORT Index Number for PA03 */
+#define PORT_PA04_IDX               (  4)  /**< PORT Index Number for PA04 */
+#define PORT_PA05_IDX               (  5)  /**< PORT Index Number for PA05 */
+#define PORT_PA08_IDX               (  8)  /**< PORT Index Number for PA08 */
+#define PORT_PA14_IDX               ( 14)  /**< PORT Index Number for PA14 */
+#define PORT_PA15_IDX               ( 15)  /**< PORT Index Number for PA15 */
+#define PORT_PA16_IDX               ( 16)  /**< PORT Index Number for PA16 */
+#define PORT_PA17_IDX               ( 17)  /**< PORT Index Number for PA17 */
+#define PORT_PA18_IDX               ( 18)  /**< PORT Index Number for PA18 */
+#define PORT_PA19_IDX               ( 19)  /**< PORT Index Number for PA19 */
+#define PORT_PA22_IDX               ( 22)  /**< PORT Index Number for PA22 */
+#define PORT_PA23_IDX               ( 23)  /**< PORT Index Number for PA23 */
+#define PORT_PA30_IDX               ( 30)  /**< PORT Index Number for PA30 */
+#define PORT_PA31_IDX               ( 31)  /**< PORT Index Number for PA31 */
+
+/* ========== PORT definition for AC peripheral ========== */
+#define PIN_PA04B_AC_AIN0                          _L_(4)       /**< AC signal: AIN0 on PA04 mux B*/
+#define MUX_PA04B_AC_AIN0                          _L_(1)      
+#define PINMUX_PA04B_AC_AIN0                       ((PIN_PA04B_AC_AIN0 << 16) | MUX_PA04B_AC_AIN0)
+#define PORT_PA04B_AC_AIN0                         (_UL_(1) << 4)
+
+#define PIN_PA05B_AC_AIN1                          _L_(5)       /**< AC signal: AIN1 on PA05 mux B*/
+#define MUX_PA05B_AC_AIN1                          _L_(1)      
+#define PINMUX_PA05B_AC_AIN1                       ((PIN_PA05B_AC_AIN1 << 16) | MUX_PA05B_AC_AIN1)
+#define PORT_PA05B_AC_AIN1                         (_UL_(1) << 5)
+
+#define PIN_PA18H_AC_CMP0                          _L_(18)      /**< AC signal: CMP0 on PA18 mux H*/
+#define MUX_PA18H_AC_CMP0                          _L_(7)      
+#define PINMUX_PA18H_AC_CMP0                       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
+#define PORT_PA18H_AC_CMP0                         (_UL_(1) << 18)
+
+#define PIN_PA19H_AC_CMP1                          _L_(19)      /**< AC signal: CMP1 on PA19 mux H*/
+#define MUX_PA19H_AC_CMP1                          _L_(7)      
+#define PINMUX_PA19H_AC_CMP1                       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
+#define PORT_PA19H_AC_CMP1                         (_UL_(1) << 19)
+
+/* ========== PORT definition for ADC peripheral ========== */
+#define PIN_PA02B_ADC_AIN0                         _L_(2)       /**< ADC signal: AIN0 on PA02 mux B*/
+#define MUX_PA02B_ADC_AIN0                         _L_(1)      
+#define PINMUX_PA02B_ADC_AIN0                      ((PIN_PA02B_ADC_AIN0 << 16) | MUX_PA02B_ADC_AIN0)
+#define PORT_PA02B_ADC_AIN0                        (_UL_(1) << 2)
+
+#define PIN_PA03B_ADC_AIN1                         _L_(3)       /**< ADC signal: AIN1 on PA03 mux B*/
+#define MUX_PA03B_ADC_AIN1                         _L_(1)      
+#define PINMUX_PA03B_ADC_AIN1                      ((PIN_PA03B_ADC_AIN1 << 16) | MUX_PA03B_ADC_AIN1)
+#define PORT_PA03B_ADC_AIN1                        (_UL_(1) << 3)
+
+#define PIN_PA04B_ADC_AIN2                         _L_(4)       /**< ADC signal: AIN2 on PA04 mux B*/
+#define MUX_PA04B_ADC_AIN2                         _L_(1)      
+#define PINMUX_PA04B_ADC_AIN2                      ((PIN_PA04B_ADC_AIN2 << 16) | MUX_PA04B_ADC_AIN2)
+#define PORT_PA04B_ADC_AIN2                        (_UL_(1) << 4)
+
+#define PIN_PA05B_ADC_AIN3                         _L_(5)       /**< ADC signal: AIN3 on PA05 mux B*/
+#define MUX_PA05B_ADC_AIN3                         _L_(1)      
+#define PINMUX_PA05B_ADC_AIN3                      ((PIN_PA05B_ADC_AIN3 << 16) | MUX_PA05B_ADC_AIN3)
+#define PORT_PA05B_ADC_AIN3                        (_UL_(1) << 5)
+
+#define PIN_PA08B_ADC_AIN6                         _L_(8)       /**< ADC signal: AIN6 on PA08 mux B*/
+#define MUX_PA08B_ADC_AIN6                         _L_(1)      
+#define PINMUX_PA08B_ADC_AIN6                      ((PIN_PA08B_ADC_AIN6 << 16) | MUX_PA08B_ADC_AIN6)
+#define PORT_PA08B_ADC_AIN6                        (_UL_(1) << 8)
+
+#define PIN_PA04B_ADC_VREFP                        _L_(4)       /**< ADC signal: VREFP on PA04 mux B*/
+#define MUX_PA04B_ADC_VREFP                        _L_(1)      
+#define PINMUX_PA04B_ADC_VREFP                     ((PIN_PA04B_ADC_VREFP << 16) | MUX_PA04B_ADC_VREFP)
+#define PORT_PA04B_ADC_VREFP                       (_UL_(1) << 4)
+
+/* ========== PORT definition for CCL peripheral ========== */
+#define PIN_PA04I_CCL_IN0                          _L_(4)       /**< CCL signal: IN0 on PA04 mux I*/
+#define MUX_PA04I_CCL_IN0                          _L_(8)      
+#define PINMUX_PA04I_CCL_IN0                       ((PIN_PA04I_CCL_IN0 << 16) | MUX_PA04I_CCL_IN0)
+#define PORT_PA04I_CCL_IN0                         (_UL_(1) << 4)
+
+#define PIN_PA16I_CCL_IN0                          _L_(16)      /**< CCL signal: IN0 on PA16 mux I*/
+#define MUX_PA16I_CCL_IN0                          _L_(8)      
+#define PINMUX_PA16I_CCL_IN0                       ((PIN_PA16I_CCL_IN0 << 16) | MUX_PA16I_CCL_IN0)
+#define PORT_PA16I_CCL_IN0                         (_UL_(1) << 16)
+
+#define PIN_PA05I_CCL_IN1                          _L_(5)       /**< CCL signal: IN1 on PA05 mux I*/
+#define MUX_PA05I_CCL_IN1                          _L_(8)      
+#define PINMUX_PA05I_CCL_IN1                       ((PIN_PA05I_CCL_IN1 << 16) | MUX_PA05I_CCL_IN1)
+#define PORT_PA05I_CCL_IN1                         (_UL_(1) << 5)
+
+#define PIN_PA17I_CCL_IN1                          _L_(17)      /**< CCL signal: IN1 on PA17 mux I*/
+#define MUX_PA17I_CCL_IN1                          _L_(8)      
+#define PINMUX_PA17I_CCL_IN1                       ((PIN_PA17I_CCL_IN1 << 16) | MUX_PA17I_CCL_IN1)
+#define PORT_PA17I_CCL_IN1                         (_UL_(1) << 17)
+
+#define PIN_PA18I_CCL_IN2                          _L_(18)      /**< CCL signal: IN2 on PA18 mux I*/
+#define MUX_PA18I_CCL_IN2                          _L_(8)      
+#define PINMUX_PA18I_CCL_IN2                       ((PIN_PA18I_CCL_IN2 << 16) | MUX_PA18I_CCL_IN2)
+#define PORT_PA18I_CCL_IN2                         (_UL_(1) << 18)
+
+#define PIN_PA08I_CCL_IN3                          _L_(8)       /**< CCL signal: IN3 on PA08 mux I*/
+#define MUX_PA08I_CCL_IN3                          _L_(8)      
+#define PINMUX_PA08I_CCL_IN3                       ((PIN_PA08I_CCL_IN3 << 16) | MUX_PA08I_CCL_IN3)
+#define PORT_PA08I_CCL_IN3                         (_UL_(1) << 8)
+
+#define PIN_PA30I_CCL_IN3                          _L_(30)      /**< CCL signal: IN3 on PA30 mux I*/
+#define MUX_PA30I_CCL_IN3                          _L_(8)      
+#define PINMUX_PA30I_CCL_IN3                       ((PIN_PA30I_CCL_IN3 << 16) | MUX_PA30I_CCL_IN3)
+#define PORT_PA30I_CCL_IN3                         (_UL_(1) << 30)
+
+#define PIN_PA19I_CCL_OUT0                         _L_(19)      /**< CCL signal: OUT0 on PA19 mux I*/
+#define MUX_PA19I_CCL_OUT0                         _L_(8)      
+#define PINMUX_PA19I_CCL_OUT0                      ((PIN_PA19I_CCL_OUT0 << 16) | MUX_PA19I_CCL_OUT0)
+#define PORT_PA19I_CCL_OUT0                        (_UL_(1) << 19)
+
+#define PIN_PA31I_CCL_OUT1                         _L_(31)      /**< CCL signal: OUT1 on PA31 mux I*/
+#define MUX_PA31I_CCL_OUT1                         _L_(8)      
+#define PINMUX_PA31I_CCL_OUT1                      ((PIN_PA31I_CCL_OUT1 << 16) | MUX_PA31I_CCL_OUT1)
+#define PORT_PA31I_CCL_OUT1                        (_UL_(1) << 31)
+
+/* ========== PORT definition for DAC peripheral ========== */
+#define PIN_PA02B_DAC_VOUT                         _L_(2)       /**< DAC signal: VOUT on PA02 mux B*/
+#define MUX_PA02B_DAC_VOUT                         _L_(1)      
+#define PINMUX_PA02B_DAC_VOUT                      ((PIN_PA02B_DAC_VOUT << 16) | MUX_PA02B_DAC_VOUT)
+#define PORT_PA02B_DAC_VOUT                        (_UL_(1) << 2)
+
+#define PIN_PA03B_DAC_VREFP                        _L_(3)       /**< DAC signal: VREFP on PA03 mux B*/
+#define MUX_PA03B_DAC_VREFP                        _L_(1)      
+#define PINMUX_PA03B_DAC_VREFP                     ((PIN_PA03B_DAC_VREFP << 16) | MUX_PA03B_DAC_VREFP)
+#define PORT_PA03B_DAC_VREFP                       (_UL_(1) << 3)
+
+/* ========== PORT definition for EIC peripheral ========== */
+#define PIN_PA19A_EIC_EXTINT0                      _L_(19)      /**< EIC signal: EXTINT0 on PA19 mux A*/
+#define MUX_PA19A_EIC_EXTINT0                      _L_(0)      
+#define PINMUX_PA19A_EIC_EXTINT0                   ((PIN_PA19A_EIC_EXTINT0 << 16) | MUX_PA19A_EIC_EXTINT0)
+#define PORT_PA19A_EIC_EXTINT0                     (_UL_(1) << 19)
+#define PIN_PA19A_EIC_EXTINT_NUM                   _L_(0)       /**< EIC signal: PIN_PA19 External Interrupt Line */
+
+#define PIN_PA00A_EIC_EXTINT0                      _L_(0)       /**< EIC signal: EXTINT0 on PA00 mux A*/
+#define MUX_PA00A_EIC_EXTINT0                      _L_(0)      
+#define PINMUX_PA00A_EIC_EXTINT0                   ((PIN_PA00A_EIC_EXTINT0 << 16) | MUX_PA00A_EIC_EXTINT0)
+#define PORT_PA00A_EIC_EXTINT0                     (_UL_(1) << 0)
+#define PIN_PA00A_EIC_EXTINT_NUM                   _L_(0)       /**< EIC signal: PIN_PA00 External Interrupt Line */
+
+#define PIN_PA22A_EIC_EXTINT1                      _L_(22)      /**< EIC signal: EXTINT1 on PA22 mux A*/
+#define MUX_PA22A_EIC_EXTINT1                      _L_(0)      
+#define PINMUX_PA22A_EIC_EXTINT1                   ((PIN_PA22A_EIC_EXTINT1 << 16) | MUX_PA22A_EIC_EXTINT1)
+#define PORT_PA22A_EIC_EXTINT1                     (_UL_(1) << 22)
+#define PIN_PA22A_EIC_EXTINT_NUM                   _L_(1)       /**< EIC signal: PIN_PA22 External Interrupt Line */
+
+#define PIN_PA01A_EIC_EXTINT1                      _L_(1)       /**< EIC signal: EXTINT1 on PA01 mux A*/
+#define MUX_PA01A_EIC_EXTINT1                      _L_(0)      
+#define PINMUX_PA01A_EIC_EXTINT1                   ((PIN_PA01A_EIC_EXTINT1 << 16) | MUX_PA01A_EIC_EXTINT1)
+#define PORT_PA01A_EIC_EXTINT1                     (_UL_(1) << 1)
+#define PIN_PA01A_EIC_EXTINT_NUM                   _L_(1)       /**< EIC signal: PIN_PA01 External Interrupt Line */
+
+#define PIN_PA02A_EIC_EXTINT2                      _L_(2)       /**< EIC signal: EXTINT2 on PA02 mux A*/
+#define MUX_PA02A_EIC_EXTINT2                      _L_(0)      
+#define PINMUX_PA02A_EIC_EXTINT2                   ((PIN_PA02A_EIC_EXTINT2 << 16) | MUX_PA02A_EIC_EXTINT2)
+#define PORT_PA02A_EIC_EXTINT2                     (_UL_(1) << 2)
+#define PIN_PA02A_EIC_EXTINT_NUM                   _L_(2)       /**< EIC signal: PIN_PA02 External Interrupt Line */
+
+#define PIN_PA23A_EIC_EXTINT2                      _L_(23)      /**< EIC signal: EXTINT2 on PA23 mux A*/
+#define MUX_PA23A_EIC_EXTINT2                      _L_(0)      
+#define PINMUX_PA23A_EIC_EXTINT2                   ((PIN_PA23A_EIC_EXTINT2 << 16) | MUX_PA23A_EIC_EXTINT2)
+#define PORT_PA23A_EIC_EXTINT2                     (_UL_(1) << 23)
+#define PIN_PA23A_EIC_EXTINT_NUM                   _L_(2)       /**< EIC signal: PIN_PA23 External Interrupt Line */
+
+#define PIN_PA03A_EIC_EXTINT3                      _L_(3)       /**< EIC signal: EXTINT3 on PA03 mux A*/
+#define MUX_PA03A_EIC_EXTINT3                      _L_(0)      
+#define PINMUX_PA03A_EIC_EXTINT3                   ((PIN_PA03A_EIC_EXTINT3 << 16) | MUX_PA03A_EIC_EXTINT3)
+#define PORT_PA03A_EIC_EXTINT3                     (_UL_(1) << 3)
+#define PIN_PA03A_EIC_EXTINT_NUM                   _L_(3)       /**< EIC signal: PIN_PA03 External Interrupt Line */
+
+#define PIN_PA14A_EIC_EXTINT3                      _L_(14)      /**< EIC signal: EXTINT3 on PA14 mux A*/
+#define MUX_PA14A_EIC_EXTINT3                      _L_(0)      
+#define PINMUX_PA14A_EIC_EXTINT3                   ((PIN_PA14A_EIC_EXTINT3 << 16) | MUX_PA14A_EIC_EXTINT3)
+#define PORT_PA14A_EIC_EXTINT3                     (_UL_(1) << 14)
+#define PIN_PA14A_EIC_EXTINT_NUM                   _L_(3)       /**< EIC signal: PIN_PA14 External Interrupt Line */
+
+#define PIN_PA04A_EIC_EXTINT4                      _L_(4)       /**< EIC signal: EXTINT4 on PA04 mux A*/
+#define MUX_PA04A_EIC_EXTINT4                      _L_(0)      
+#define PINMUX_PA04A_EIC_EXTINT4                   ((PIN_PA04A_EIC_EXTINT4 << 16) | MUX_PA04A_EIC_EXTINT4)
+#define PORT_PA04A_EIC_EXTINT4                     (_UL_(1) << 4)
+#define PIN_PA04A_EIC_EXTINT_NUM                   _L_(4)       /**< EIC signal: PIN_PA04 External Interrupt Line */
+
+#define PIN_PA15A_EIC_EXTINT4                      _L_(15)      /**< EIC signal: EXTINT4 on PA15 mux A*/
+#define MUX_PA15A_EIC_EXTINT4                      _L_(0)      
+#define PINMUX_PA15A_EIC_EXTINT4                   ((PIN_PA15A_EIC_EXTINT4 << 16) | MUX_PA15A_EIC_EXTINT4)
+#define PORT_PA15A_EIC_EXTINT4                     (_UL_(1) << 15)
+#define PIN_PA15A_EIC_EXTINT_NUM                   _L_(4)       /**< EIC signal: PIN_PA15 External Interrupt Line */
+
+#define PIN_PA05A_EIC_EXTINT5                      _L_(5)       /**< EIC signal: EXTINT5 on PA05 mux A*/
+#define MUX_PA05A_EIC_EXTINT5                      _L_(0)      
+#define PINMUX_PA05A_EIC_EXTINT5                   ((PIN_PA05A_EIC_EXTINT5 << 16) | MUX_PA05A_EIC_EXTINT5)
+#define PORT_PA05A_EIC_EXTINT5                     (_UL_(1) << 5)
+#define PIN_PA05A_EIC_EXTINT_NUM                   _L_(5)       /**< EIC signal: PIN_PA05 External Interrupt Line */
+
+#define PIN_PA16A_EIC_EXTINT5                      _L_(16)      /**< EIC signal: EXTINT5 on PA16 mux A*/
+#define MUX_PA16A_EIC_EXTINT5                      _L_(0)      
+#define PINMUX_PA16A_EIC_EXTINT5                   ((PIN_PA16A_EIC_EXTINT5 << 16) | MUX_PA16A_EIC_EXTINT5)
+#define PORT_PA16A_EIC_EXTINT5                     (_UL_(1) << 16)
+#define PIN_PA16A_EIC_EXTINT_NUM                   _L_(5)       /**< EIC signal: PIN_PA16 External Interrupt Line */
+
+#define PIN_PA17A_EIC_EXTINT6                      _L_(17)      /**< EIC signal: EXTINT6 on PA17 mux A*/
+#define MUX_PA17A_EIC_EXTINT6                      _L_(0)      
+#define PINMUX_PA17A_EIC_EXTINT6                   ((PIN_PA17A_EIC_EXTINT6 << 16) | MUX_PA17A_EIC_EXTINT6)
+#define PORT_PA17A_EIC_EXTINT6                     (_UL_(1) << 17)
+#define PIN_PA17A_EIC_EXTINT_NUM                   _L_(6)       /**< EIC signal: PIN_PA17 External Interrupt Line */
+
+#define PIN_PA30A_EIC_EXTINT6                      _L_(30)      /**< EIC signal: EXTINT6 on PA30 mux A*/
+#define MUX_PA30A_EIC_EXTINT6                      _L_(0)      
+#define PINMUX_PA30A_EIC_EXTINT6                   ((PIN_PA30A_EIC_EXTINT6 << 16) | MUX_PA30A_EIC_EXTINT6)
+#define PORT_PA30A_EIC_EXTINT6                     (_UL_(1) << 30)
+#define PIN_PA30A_EIC_EXTINT_NUM                   _L_(6)       /**< EIC signal: PIN_PA30 External Interrupt Line */
+
+#define PIN_PA18A_EIC_EXTINT7                      _L_(18)      /**< EIC signal: EXTINT7 on PA18 mux A*/
+#define MUX_PA18A_EIC_EXTINT7                      _L_(0)      
+#define PINMUX_PA18A_EIC_EXTINT7                   ((PIN_PA18A_EIC_EXTINT7 << 16) | MUX_PA18A_EIC_EXTINT7)
+#define PORT_PA18A_EIC_EXTINT7                     (_UL_(1) << 18)
+#define PIN_PA18A_EIC_EXTINT_NUM                   _L_(7)       /**< EIC signal: PIN_PA18 External Interrupt Line */
+
+#define PIN_PA31A_EIC_EXTINT7                      _L_(31)      /**< EIC signal: EXTINT7 on PA31 mux A*/
+#define MUX_PA31A_EIC_EXTINT7                      _L_(0)      
+#define PINMUX_PA31A_EIC_EXTINT7                   ((PIN_PA31A_EIC_EXTINT7 << 16) | MUX_PA31A_EIC_EXTINT7)
+#define PORT_PA31A_EIC_EXTINT7                     (_UL_(1) << 31)
+#define PIN_PA31A_EIC_EXTINT_NUM                   _L_(7)       /**< EIC signal: PIN_PA31 External Interrupt Line */
+
+#define PIN_PA08A_EIC_NMI                          _L_(8)       /**< EIC signal: NMI on PA08 mux A*/
+#define MUX_PA08A_EIC_NMI                          _L_(0)      
+#define PINMUX_PA08A_EIC_NMI                       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
+#define PORT_PA08A_EIC_NMI                         (_UL_(1) << 8)
+
+/* ========== PORT definition for GCLK peripheral ========== */
+#define PIN_PA30H_GCLK_IO0                         _L_(30)      /**< GCLK signal: IO0 on PA30 mux H*/
+#define MUX_PA30H_GCLK_IO0                         _L_(7)      
+#define PINMUX_PA30H_GCLK_IO0                      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
+#define PORT_PA30H_GCLK_IO0                        (_UL_(1) << 30)
+
+#define PIN_PA14H_GCLK_IO0                         _L_(14)      /**< GCLK signal: IO0 on PA14 mux H*/
+#define MUX_PA14H_GCLK_IO0                         _L_(7)      
+#define PINMUX_PA14H_GCLK_IO0                      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
+#define PORT_PA14H_GCLK_IO0                        (_UL_(1) << 14)
+
+#define PIN_PA23H_GCLK_IO1                         _L_(23)      /**< GCLK signal: IO1 on PA23 mux H*/
+#define MUX_PA23H_GCLK_IO1                         _L_(7)      
+#define PINMUX_PA23H_GCLK_IO1                      ((PIN_PA23H_GCLK_IO1 << 16) | MUX_PA23H_GCLK_IO1)
+#define PORT_PA23H_GCLK_IO1                        (_UL_(1) << 23)
+
+#define PIN_PA15H_GCLK_IO1                         _L_(15)      /**< GCLK signal: IO1 on PA15 mux H*/
+#define MUX_PA15H_GCLK_IO1                         _L_(7)      
+#define PINMUX_PA15H_GCLK_IO1                      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
+#define PORT_PA15H_GCLK_IO1                        (_UL_(1) << 15)
+
+#define PIN_PA16H_GCLK_IO2                         _L_(16)      /**< GCLK signal: IO2 on PA16 mux H*/
+#define MUX_PA16H_GCLK_IO2                         _L_(7)      
+#define PINMUX_PA16H_GCLK_IO2                      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
+#define PORT_PA16H_GCLK_IO2                        (_UL_(1) << 16)
+
+#define PIN_PA22H_GCLK_IO2                         _L_(22)      /**< GCLK signal: IO2 on PA22 mux H*/
+#define MUX_PA22H_GCLK_IO2                         _L_(7)      
+#define PINMUX_PA22H_GCLK_IO2                      ((PIN_PA22H_GCLK_IO2 << 16) | MUX_PA22H_GCLK_IO2)
+#define PORT_PA22H_GCLK_IO2                        (_UL_(1) << 22)
+
+#define PIN_PA17H_GCLK_IO3                         _L_(17)      /**< GCLK signal: IO3 on PA17 mux H*/
+#define MUX_PA17H_GCLK_IO3                         _L_(7)      
+#define PINMUX_PA17H_GCLK_IO3                      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
+#define PORT_PA17H_GCLK_IO3                        (_UL_(1) << 17)
+
+/* ========== PORT definition for OPAMP peripheral ========== */
+#define PIN_PA02B_OPAMP_OANEG0                     _L_(2)       /**< OPAMP signal: OANEG0 on PA02 mux B*/
+#define MUX_PA02B_OPAMP_OANEG0                     _L_(1)      
+#define PINMUX_PA02B_OPAMP_OANEG0                  ((PIN_PA02B_OPAMP_OANEG0 << 16) | MUX_PA02B_OPAMP_OANEG0)
+#define PORT_PA02B_OPAMP_OANEG0                    (_UL_(1) << 2)
+
+#define PIN_PA00B_OPAMP_OANEG1                     _L_(0)       /**< OPAMP signal: OANEG1 on PA00 mux B*/
+#define MUX_PA00B_OPAMP_OANEG1                     _L_(1)      
+#define PINMUX_PA00B_OPAMP_OANEG1                  ((PIN_PA00B_OPAMP_OANEG1 << 16) | MUX_PA00B_OPAMP_OANEG1)
+#define PORT_PA00B_OPAMP_OANEG1                    (_UL_(1) << 0)
+
+#define PIN_PA03B_OPAMP_OANEG2                     _L_(3)       /**< OPAMP signal: OANEG2 on PA03 mux B*/
+#define MUX_PA03B_OPAMP_OANEG2                     _L_(1)      
+#define PINMUX_PA03B_OPAMP_OANEG2                  ((PIN_PA03B_OPAMP_OANEG2 << 16) | MUX_PA03B_OPAMP_OANEG2)
+#define PORT_PA03B_OPAMP_OANEG2                    (_UL_(1) << 3)
+
+#define PIN_PA04B_OPAMP_OAOUT2                     _L_(4)       /**< OPAMP signal: OAOUT2 on PA04 mux B*/
+#define MUX_PA04B_OPAMP_OAOUT2                     _L_(1)      
+#define PINMUX_PA04B_OPAMP_OAOUT2                  ((PIN_PA04B_OPAMP_OAOUT2 << 16) | MUX_PA04B_OPAMP_OAOUT2)
+#define PORT_PA04B_OPAMP_OAOUT2                    (_UL_(1) << 4)
+
+#define PIN_PA01B_OPAMP_OAPOS1                     _L_(1)       /**< OPAMP signal: OAPOS1 on PA01 mux B*/
+#define MUX_PA01B_OPAMP_OAPOS1                     _L_(1)      
+#define PINMUX_PA01B_OPAMP_OAPOS1                  ((PIN_PA01B_OPAMP_OAPOS1 << 16) | MUX_PA01B_OPAMP_OAPOS1)
+#define PORT_PA01B_OPAMP_OAPOS1                    (_UL_(1) << 1)
+
+#define PIN_PA05B_OPAMP_OAPOS2                     _L_(5)       /**< OPAMP signal: OAPOS2 on PA05 mux B*/
+#define MUX_PA05B_OPAMP_OAPOS2                     _L_(1)      
+#define PINMUX_PA05B_OPAMP_OAPOS2                  ((PIN_PA05B_OPAMP_OAPOS2 << 16) | MUX_PA05B_OPAMP_OAPOS2)
+#define PORT_PA05B_OPAMP_OAPOS2                    (_UL_(1) << 5)
+
+/* ========== PORT definition for PTC peripheral ========== */
+#define PIN_PA00F_PTC_DRV0                         _L_(0)       /**< PTC signal: DRV0 on PA00 mux F*/
+#define MUX_PA00F_PTC_DRV0                         _L_(5)      
+#define PINMUX_PA00F_PTC_DRV0                      ((PIN_PA00F_PTC_DRV0 << 16) | MUX_PA00F_PTC_DRV0)
+#define PORT_PA00F_PTC_DRV0                        (_UL_(1) << 0)
+
+#define PIN_PA01F_PTC_DRV1                         _L_(1)       /**< PTC signal: DRV1 on PA01 mux F*/
+#define MUX_PA01F_PTC_DRV1                         _L_(5)      
+#define PINMUX_PA01F_PTC_DRV1                      ((PIN_PA01F_PTC_DRV1 << 16) | MUX_PA01F_PTC_DRV1)
+#define PORT_PA01F_PTC_DRV1                        (_UL_(1) << 1)
+
+#define PIN_PA02F_PTC_DRV2                         _L_(2)       /**< PTC signal: DRV2 on PA02 mux F*/
+#define MUX_PA02F_PTC_DRV2                         _L_(5)      
+#define PINMUX_PA02F_PTC_DRV2                      ((PIN_PA02F_PTC_DRV2 << 16) | MUX_PA02F_PTC_DRV2)
+#define PORT_PA02F_PTC_DRV2                        (_UL_(1) << 2)
+
+#define PIN_PA03F_PTC_DRV3                         _L_(3)       /**< PTC signal: DRV3 on PA03 mux F*/
+#define MUX_PA03F_PTC_DRV3                         _L_(5)      
+#define PINMUX_PA03F_PTC_DRV3                      ((PIN_PA03F_PTC_DRV3 << 16) | MUX_PA03F_PTC_DRV3)
+#define PORT_PA03F_PTC_DRV3                        (_UL_(1) << 3)
+
+#define PIN_PA05F_PTC_DRV4                         _L_(5)       /**< PTC signal: DRV4 on PA05 mux F*/
+#define MUX_PA05F_PTC_DRV4                         _L_(5)      
+#define PINMUX_PA05F_PTC_DRV4                      ((PIN_PA05F_PTC_DRV4 << 16) | MUX_PA05F_PTC_DRV4)
+#define PORT_PA05F_PTC_DRV4                        (_UL_(1) << 5)
+
+#define PIN_PA08F_PTC_DRV6                         _L_(8)       /**< PTC signal: DRV6 on PA08 mux F*/
+#define MUX_PA08F_PTC_DRV6                         _L_(5)      
+#define PINMUX_PA08F_PTC_DRV6                      ((PIN_PA08F_PTC_DRV6 << 16) | MUX_PA08F_PTC_DRV6)
+#define PORT_PA08F_PTC_DRV6                        (_UL_(1) << 8)
+
+#define PIN_PA14F_PTC_DRV10                        _L_(14)      /**< PTC signal: DRV10 on PA14 mux F*/
+#define MUX_PA14F_PTC_DRV10                        _L_(5)      
+#define PINMUX_PA14F_PTC_DRV10                     ((PIN_PA14F_PTC_DRV10 << 16) | MUX_PA14F_PTC_DRV10)
+#define PORT_PA14F_PTC_DRV10                       (_UL_(1) << 14)
+
+#define PIN_PA15F_PTC_DRV11                        _L_(15)      /**< PTC signal: DRV11 on PA15 mux F*/
+#define MUX_PA15F_PTC_DRV11                        _L_(5)      
+#define PINMUX_PA15F_PTC_DRV11                     ((PIN_PA15F_PTC_DRV11 << 16) | MUX_PA15F_PTC_DRV11)
+#define PORT_PA15F_PTC_DRV11                       (_UL_(1) << 15)
+
+#define PIN_PA16F_PTC_DRV12                        _L_(16)      /**< PTC signal: DRV12 on PA16 mux F*/
+#define MUX_PA16F_PTC_DRV12                        _L_(5)      
+#define PINMUX_PA16F_PTC_DRV12                     ((PIN_PA16F_PTC_DRV12 << 16) | MUX_PA16F_PTC_DRV12)
+#define PORT_PA16F_PTC_DRV12                       (_UL_(1) << 16)
+
+#define PIN_PA17F_PTC_DRV13                        _L_(17)      /**< PTC signal: DRV13 on PA17 mux F*/
+#define MUX_PA17F_PTC_DRV13                        _L_(5)      
+#define PINMUX_PA17F_PTC_DRV13                     ((PIN_PA17F_PTC_DRV13 << 16) | MUX_PA17F_PTC_DRV13)
+#define PORT_PA17F_PTC_DRV13                       (_UL_(1) << 17)
+
+#define PIN_PA18F_PTC_DRV14                        _L_(18)      /**< PTC signal: DRV14 on PA18 mux F*/
+#define MUX_PA18F_PTC_DRV14                        _L_(5)      
+#define PINMUX_PA18F_PTC_DRV14                     ((PIN_PA18F_PTC_DRV14 << 16) | MUX_PA18F_PTC_DRV14)
+#define PORT_PA18F_PTC_DRV14                       (_UL_(1) << 18)
+
+#define PIN_PA19F_PTC_DRV15                        _L_(19)      /**< PTC signal: DRV15 on PA19 mux F*/
+#define MUX_PA19F_PTC_DRV15                        _L_(5)      
+#define PINMUX_PA19F_PTC_DRV15                     ((PIN_PA19F_PTC_DRV15 << 16) | MUX_PA19F_PTC_DRV15)
+#define PORT_PA19F_PTC_DRV15                       (_UL_(1) << 19)
+
+#define PIN_PA22F_PTC_DRV16                        _L_(22)      /**< PTC signal: DRV16 on PA22 mux F*/
+#define MUX_PA22F_PTC_DRV16                        _L_(5)      
+#define PINMUX_PA22F_PTC_DRV16                     ((PIN_PA22F_PTC_DRV16 << 16) | MUX_PA22F_PTC_DRV16)
+#define PORT_PA22F_PTC_DRV16                       (_UL_(1) << 22)
+
+#define PIN_PA23F_PTC_DRV17                        _L_(23)      /**< PTC signal: DRV17 on PA23 mux F*/
+#define MUX_PA23F_PTC_DRV17                        _L_(5)      
+#define PINMUX_PA23F_PTC_DRV17                     ((PIN_PA23F_PTC_DRV17 << 16) | MUX_PA23F_PTC_DRV17)
+#define PORT_PA23F_PTC_DRV17                       (_UL_(1) << 23)
+
+#define PIN_PA30F_PTC_DRV18                        _L_(30)      /**< PTC signal: DRV18 on PA30 mux F*/
+#define MUX_PA30F_PTC_DRV18                        _L_(5)      
+#define PINMUX_PA30F_PTC_DRV18                     ((PIN_PA30F_PTC_DRV18 << 16) | MUX_PA30F_PTC_DRV18)
+#define PORT_PA30F_PTC_DRV18                       (_UL_(1) << 30)
+
+#define PIN_PA31F_PTC_DRV19                        _L_(31)      /**< PTC signal: DRV19 on PA31 mux F*/
+#define MUX_PA31F_PTC_DRV19                        _L_(5)      
+#define PINMUX_PA31F_PTC_DRV19                     ((PIN_PA31F_PTC_DRV19 << 16) | MUX_PA31F_PTC_DRV19)
+#define PORT_PA31F_PTC_DRV19                       (_UL_(1) << 31)
+
+#define PIN_PA03B_PTC_ECI0                         _L_(3)       /**< PTC signal: ECI0 on PA03 mux B*/
+#define MUX_PA03B_PTC_ECI0                         _L_(1)      
+#define PINMUX_PA03B_PTC_ECI0                      ((PIN_PA03B_PTC_ECI0 << 16) | MUX_PA03B_PTC_ECI0)
+#define PORT_PA03B_PTC_ECI0                        (_UL_(1) << 3)
+
+#define PIN_PA04B_PTC_ECI1                         _L_(4)       /**< PTC signal: ECI1 on PA04 mux B*/
+#define MUX_PA04B_PTC_ECI1                         _L_(1)      
+#define PINMUX_PA04B_PTC_ECI1                      ((PIN_PA04B_PTC_ECI1 << 16) | MUX_PA04B_PTC_ECI1)
+#define PORT_PA04B_PTC_ECI1                        (_UL_(1) << 4)
+
+#define PIN_PA05B_PTC_ECI2                         _L_(5)       /**< PTC signal: ECI2 on PA05 mux B*/
+#define MUX_PA05B_PTC_ECI2                         _L_(1)      
+#define PINMUX_PA05B_PTC_ECI2                      ((PIN_PA05B_PTC_ECI2 << 16) | MUX_PA05B_PTC_ECI2)
+#define PORT_PA05B_PTC_ECI2                        (_UL_(1) << 5)
+
+#define PIN_PA00B_PTC_X0                           _L_(0)       /**< PTC signal: X0 on PA00 mux B*/
+#define MUX_PA00B_PTC_X0                           _L_(1)      
+#define PINMUX_PA00B_PTC_X0                        ((PIN_PA00B_PTC_X0 << 16) | MUX_PA00B_PTC_X0)
+#define PORT_PA00B_PTC_X0                          (_UL_(1) << 0)
+
+#define PIN_PA00B_PTC_Y0                           _L_(0)       /**< PTC signal: Y0 on PA00 mux B*/
+#define MUX_PA00B_PTC_Y0                           _L_(1)      
+#define PINMUX_PA00B_PTC_Y0                        ((PIN_PA00B_PTC_Y0 << 16) | MUX_PA00B_PTC_Y0)
+#define PORT_PA00B_PTC_Y0                          (_UL_(1) << 0)
+
+#define PIN_PA01B_PTC_X1                           _L_(1)       /**< PTC signal: X1 on PA01 mux B*/
+#define MUX_PA01B_PTC_X1                           _L_(1)      
+#define PINMUX_PA01B_PTC_X1                        ((PIN_PA01B_PTC_X1 << 16) | MUX_PA01B_PTC_X1)
+#define PORT_PA01B_PTC_X1                          (_UL_(1) << 1)
+
+#define PIN_PA01B_PTC_Y1                           _L_(1)       /**< PTC signal: Y1 on PA01 mux B*/
+#define MUX_PA01B_PTC_Y1                           _L_(1)      
+#define PINMUX_PA01B_PTC_Y1                        ((PIN_PA01B_PTC_Y1 << 16) | MUX_PA01B_PTC_Y1)
+#define PORT_PA01B_PTC_Y1                          (_UL_(1) << 1)
+
+#define PIN_PA02B_PTC_X2                           _L_(2)       /**< PTC signal: X2 on PA02 mux B*/
+#define MUX_PA02B_PTC_X2                           _L_(1)      
+#define PINMUX_PA02B_PTC_X2                        ((PIN_PA02B_PTC_X2 << 16) | MUX_PA02B_PTC_X2)
+#define PORT_PA02B_PTC_X2                          (_UL_(1) << 2)
+
+#define PIN_PA02B_PTC_Y2                           _L_(2)       /**< PTC signal: Y2 on PA02 mux B*/
+#define MUX_PA02B_PTC_Y2                           _L_(1)      
+#define PINMUX_PA02B_PTC_Y2                        ((PIN_PA02B_PTC_Y2 << 16) | MUX_PA02B_PTC_Y2)
+#define PORT_PA02B_PTC_Y2                          (_UL_(1) << 2)
+
+#define PIN_PA03B_PTC_X3                           _L_(3)       /**< PTC signal: X3 on PA03 mux B*/
+#define MUX_PA03B_PTC_X3                           _L_(1)      
+#define PINMUX_PA03B_PTC_X3                        ((PIN_PA03B_PTC_X3 << 16) | MUX_PA03B_PTC_X3)
+#define PORT_PA03B_PTC_X3                          (_UL_(1) << 3)
+
+#define PIN_PA03B_PTC_Y3                           _L_(3)       /**< PTC signal: Y3 on PA03 mux B*/
+#define MUX_PA03B_PTC_Y3                           _L_(1)      
+#define PINMUX_PA03B_PTC_Y3                        ((PIN_PA03B_PTC_Y3 << 16) | MUX_PA03B_PTC_Y3)
+#define PORT_PA03B_PTC_Y3                          (_UL_(1) << 3)
+
+#define PIN_PA05B_PTC_X4                           _L_(5)       /**< PTC signal: X4 on PA05 mux B*/
+#define MUX_PA05B_PTC_X4                           _L_(1)      
+#define PINMUX_PA05B_PTC_X4                        ((PIN_PA05B_PTC_X4 << 16) | MUX_PA05B_PTC_X4)
+#define PORT_PA05B_PTC_X4                          (_UL_(1) << 5)
+
+#define PIN_PA05B_PTC_Y4                           _L_(5)       /**< PTC signal: Y4 on PA05 mux B*/
+#define MUX_PA05B_PTC_Y4                           _L_(1)      
+#define PINMUX_PA05B_PTC_Y4                        ((PIN_PA05B_PTC_Y4 << 16) | MUX_PA05B_PTC_Y4)
+#define PORT_PA05B_PTC_Y4                          (_UL_(1) << 5)
+
+#define PIN_PA08B_PTC_X6                           _L_(8)       /**< PTC signal: X6 on PA08 mux B*/
+#define MUX_PA08B_PTC_X6                           _L_(1)      
+#define PINMUX_PA08B_PTC_X6                        ((PIN_PA08B_PTC_X6 << 16) | MUX_PA08B_PTC_X6)
+#define PORT_PA08B_PTC_X6                          (_UL_(1) << 8)
+
+#define PIN_PA08B_PTC_Y6                           _L_(8)       /**< PTC signal: Y6 on PA08 mux B*/
+#define MUX_PA08B_PTC_Y6                           _L_(1)      
+#define PINMUX_PA08B_PTC_Y6                        ((PIN_PA08B_PTC_Y6 << 16) | MUX_PA08B_PTC_Y6)
+#define PORT_PA08B_PTC_Y6                          (_UL_(1) << 8)
+
+#define PIN_PA14B_PTC_X10                          _L_(14)      /**< PTC signal: X10 on PA14 mux B*/
+#define MUX_PA14B_PTC_X10                          _L_(1)      
+#define PINMUX_PA14B_PTC_X10                       ((PIN_PA14B_PTC_X10 << 16) | MUX_PA14B_PTC_X10)
+#define PORT_PA14B_PTC_X10                         (_UL_(1) << 14)
+
+#define PIN_PA14B_PTC_Y10                          _L_(14)      /**< PTC signal: Y10 on PA14 mux B*/
+#define MUX_PA14B_PTC_Y10                          _L_(1)      
+#define PINMUX_PA14B_PTC_Y10                       ((PIN_PA14B_PTC_Y10 << 16) | MUX_PA14B_PTC_Y10)
+#define PORT_PA14B_PTC_Y10                         (_UL_(1) << 14)
+
+#define PIN_PA15B_PTC_X11                          _L_(15)      /**< PTC signal: X11 on PA15 mux B*/
+#define MUX_PA15B_PTC_X11                          _L_(1)      
+#define PINMUX_PA15B_PTC_X11                       ((PIN_PA15B_PTC_X11 << 16) | MUX_PA15B_PTC_X11)
+#define PORT_PA15B_PTC_X11                         (_UL_(1) << 15)
+
+#define PIN_PA15B_PTC_Y11                          _L_(15)      /**< PTC signal: Y11 on PA15 mux B*/
+#define MUX_PA15B_PTC_Y11                          _L_(1)      
+#define PINMUX_PA15B_PTC_Y11                       ((PIN_PA15B_PTC_Y11 << 16) | MUX_PA15B_PTC_Y11)
+#define PORT_PA15B_PTC_Y11                         (_UL_(1) << 15)
+
+#define PIN_PA16B_PTC_X12                          _L_(16)      /**< PTC signal: X12 on PA16 mux B*/
+#define MUX_PA16B_PTC_X12                          _L_(1)      
+#define PINMUX_PA16B_PTC_X12                       ((PIN_PA16B_PTC_X12 << 16) | MUX_PA16B_PTC_X12)
+#define PORT_PA16B_PTC_X12                         (_UL_(1) << 16)
+
+#define PIN_PA16B_PTC_Y12                          _L_(16)      /**< PTC signal: Y12 on PA16 mux B*/
+#define MUX_PA16B_PTC_Y12                          _L_(1)      
+#define PINMUX_PA16B_PTC_Y12                       ((PIN_PA16B_PTC_Y12 << 16) | MUX_PA16B_PTC_Y12)
+#define PORT_PA16B_PTC_Y12                         (_UL_(1) << 16)
+
+#define PIN_PA17B_PTC_X13                          _L_(17)      /**< PTC signal: X13 on PA17 mux B*/
+#define MUX_PA17B_PTC_X13                          _L_(1)      
+#define PINMUX_PA17B_PTC_X13                       ((PIN_PA17B_PTC_X13 << 16) | MUX_PA17B_PTC_X13)
+#define PORT_PA17B_PTC_X13                         (_UL_(1) << 17)
+
+#define PIN_PA17B_PTC_Y13                          _L_(17)      /**< PTC signal: Y13 on PA17 mux B*/
+#define MUX_PA17B_PTC_Y13                          _L_(1)      
+#define PINMUX_PA17B_PTC_Y13                       ((PIN_PA17B_PTC_Y13 << 16) | MUX_PA17B_PTC_Y13)
+#define PORT_PA17B_PTC_Y13                         (_UL_(1) << 17)
+
+#define PIN_PA18B_PTC_X14                          _L_(18)      /**< PTC signal: X14 on PA18 mux B*/
+#define MUX_PA18B_PTC_X14                          _L_(1)      
+#define PINMUX_PA18B_PTC_X14                       ((PIN_PA18B_PTC_X14 << 16) | MUX_PA18B_PTC_X14)
+#define PORT_PA18B_PTC_X14                         (_UL_(1) << 18)
+
+#define PIN_PA18B_PTC_Y14                          _L_(18)      /**< PTC signal: Y14 on PA18 mux B*/
+#define MUX_PA18B_PTC_Y14                          _L_(1)      
+#define PINMUX_PA18B_PTC_Y14                       ((PIN_PA18B_PTC_Y14 << 16) | MUX_PA18B_PTC_Y14)
+#define PORT_PA18B_PTC_Y14                         (_UL_(1) << 18)
+
+#define PIN_PA19B_PTC_X15                          _L_(19)      /**< PTC signal: X15 on PA19 mux B*/
+#define MUX_PA19B_PTC_X15                          _L_(1)      
+#define PINMUX_PA19B_PTC_X15                       ((PIN_PA19B_PTC_X15 << 16) | MUX_PA19B_PTC_X15)
+#define PORT_PA19B_PTC_X15                         (_UL_(1) << 19)
+
+#define PIN_PA19B_PTC_Y15                          _L_(19)      /**< PTC signal: Y15 on PA19 mux B*/
+#define MUX_PA19B_PTC_Y15                          _L_(1)      
+#define PINMUX_PA19B_PTC_Y15                       ((PIN_PA19B_PTC_Y15 << 16) | MUX_PA19B_PTC_Y15)
+#define PORT_PA19B_PTC_Y15                         (_UL_(1) << 19)
+
+#define PIN_PA22B_PTC_X16                          _L_(22)      /**< PTC signal: X16 on PA22 mux B*/
+#define MUX_PA22B_PTC_X16                          _L_(1)      
+#define PINMUX_PA22B_PTC_X16                       ((PIN_PA22B_PTC_X16 << 16) | MUX_PA22B_PTC_X16)
+#define PORT_PA22B_PTC_X16                         (_UL_(1) << 22)
+
+#define PIN_PA22B_PTC_Y16                          _L_(22)      /**< PTC signal: Y16 on PA22 mux B*/
+#define MUX_PA22B_PTC_Y16                          _L_(1)      
+#define PINMUX_PA22B_PTC_Y16                       ((PIN_PA22B_PTC_Y16 << 16) | MUX_PA22B_PTC_Y16)
+#define PORT_PA22B_PTC_Y16                         (_UL_(1) << 22)
+
+#define PIN_PA23B_PTC_X17                          _L_(23)      /**< PTC signal: X17 on PA23 mux B*/
+#define MUX_PA23B_PTC_X17                          _L_(1)      
+#define PINMUX_PA23B_PTC_X17                       ((PIN_PA23B_PTC_X17 << 16) | MUX_PA23B_PTC_X17)
+#define PORT_PA23B_PTC_X17                         (_UL_(1) << 23)
+
+#define PIN_PA23B_PTC_Y17                          _L_(23)      /**< PTC signal: Y17 on PA23 mux B*/
+#define MUX_PA23B_PTC_Y17                          _L_(1)      
+#define PINMUX_PA23B_PTC_Y17                       ((PIN_PA23B_PTC_Y17 << 16) | MUX_PA23B_PTC_Y17)
+#define PORT_PA23B_PTC_Y17                         (_UL_(1) << 23)
+
+#define PIN_PA30B_PTC_X18                          _L_(30)      /**< PTC signal: X18 on PA30 mux B*/
+#define MUX_PA30B_PTC_X18                          _L_(1)      
+#define PINMUX_PA30B_PTC_X18                       ((PIN_PA30B_PTC_X18 << 16) | MUX_PA30B_PTC_X18)
+#define PORT_PA30B_PTC_X18                         (_UL_(1) << 30)
+
+#define PIN_PA30B_PTC_Y18                          _L_(30)      /**< PTC signal: Y18 on PA30 mux B*/
+#define MUX_PA30B_PTC_Y18                          _L_(1)      
+#define PINMUX_PA30B_PTC_Y18                       ((PIN_PA30B_PTC_Y18 << 16) | MUX_PA30B_PTC_Y18)
+#define PORT_PA30B_PTC_Y18                         (_UL_(1) << 30)
+
+#define PIN_PA31B_PTC_X19                          _L_(31)      /**< PTC signal: X19 on PA31 mux B*/
+#define MUX_PA31B_PTC_X19                          _L_(1)      
+#define PINMUX_PA31B_PTC_X19                       ((PIN_PA31B_PTC_X19 << 16) | MUX_PA31B_PTC_X19)
+#define PORT_PA31B_PTC_X19                         (_UL_(1) << 31)
+
+#define PIN_PA31B_PTC_Y19                          _L_(31)      /**< PTC signal: Y19 on PA31 mux B*/
+#define MUX_PA31B_PTC_Y19                          _L_(1)      
+#define PINMUX_PA31B_PTC_Y19                       ((PIN_PA31B_PTC_Y19 << 16) | MUX_PA31B_PTC_Y19)
+#define PORT_PA31B_PTC_Y19                         (_UL_(1) << 31)
+
+/* ========== PORT definition for RTC peripheral ========== */
+#define PIN_PA08G_RTC_IN0                          _L_(8)       /**< RTC signal: IN0 on PA08 mux G*/
+#define MUX_PA08G_RTC_IN0                          _L_(6)      
+#define PINMUX_PA08G_RTC_IN0                       ((PIN_PA08G_RTC_IN0 << 16) | MUX_PA08G_RTC_IN0)
+#define PORT_PA08G_RTC_IN0                         (_UL_(1) << 8)
+
+#define PIN_PA16G_RTC_IN2                          _L_(16)      /**< RTC signal: IN2 on PA16 mux G*/
+#define MUX_PA16G_RTC_IN2                          _L_(6)      
+#define PINMUX_PA16G_RTC_IN2                       ((PIN_PA16G_RTC_IN2 << 16) | MUX_PA16G_RTC_IN2)
+#define PORT_PA16G_RTC_IN2                         (_UL_(1) << 16)
+
+#define PIN_PA17G_RTC_IN3                          _L_(17)      /**< RTC signal: IN3 on PA17 mux G*/
+#define MUX_PA17G_RTC_IN3                          _L_(6)      
+#define PINMUX_PA17G_RTC_IN3                       ((PIN_PA17G_RTC_IN3 << 16) | MUX_PA17G_RTC_IN3)
+#define PORT_PA17G_RTC_IN3                         (_UL_(1) << 17)
+
+#define PIN_PA18G_RTC_OUT0                         _L_(18)      /**< RTC signal: OUT0 on PA18 mux G*/
+#define MUX_PA18G_RTC_OUT0                         _L_(6)      
+#define PINMUX_PA18G_RTC_OUT0                      ((PIN_PA18G_RTC_OUT0 << 16) | MUX_PA18G_RTC_OUT0)
+#define PORT_PA18G_RTC_OUT0                        (_UL_(1) << 18)
+
+#define PIN_PA19G_RTC_OUT1                         _L_(19)      /**< RTC signal: OUT1 on PA19 mux G*/
+#define MUX_PA19G_RTC_OUT1                         _L_(6)      
+#define PINMUX_PA19G_RTC_OUT1                      ((PIN_PA19G_RTC_OUT1 << 16) | MUX_PA19G_RTC_OUT1)
+#define PORT_PA19G_RTC_OUT1                        (_UL_(1) << 19)
+
+#define PIN_PA22G_RTC_OUT2                         _L_(22)      /**< RTC signal: OUT2 on PA22 mux G*/
+#define MUX_PA22G_RTC_OUT2                         _L_(6)      
+#define PINMUX_PA22G_RTC_OUT2                      ((PIN_PA22G_RTC_OUT2 << 16) | MUX_PA22G_RTC_OUT2)
+#define PORT_PA22G_RTC_OUT2                        (_UL_(1) << 22)
+
+#define PIN_PA23G_RTC_OUT3                         _L_(23)      /**< RTC signal: OUT3 on PA23 mux G*/
+#define MUX_PA23G_RTC_OUT3                         _L_(6)      
+#define PINMUX_PA23G_RTC_OUT3                      ((PIN_PA23G_RTC_OUT3 << 16) | MUX_PA23G_RTC_OUT3)
+#define PORT_PA23G_RTC_OUT3                        (_UL_(1) << 23)
+
+/* ========== PORT definition for SERCOM0 peripheral ========== */
+#define PIN_PA04D_SERCOM0_PAD0                     _L_(4)       /**< SERCOM0 signal: PAD0 on PA04 mux D*/
+#define MUX_PA04D_SERCOM0_PAD0                     _L_(3)      
+#define PINMUX_PA04D_SERCOM0_PAD0                  ((PIN_PA04D_SERCOM0_PAD0 << 16) | MUX_PA04D_SERCOM0_PAD0)
+#define PORT_PA04D_SERCOM0_PAD0                    (_UL_(1) << 4)
+
+#define PIN_PA16D_SERCOM0_PAD0                     _L_(16)      /**< SERCOM0 signal: PAD0 on PA16 mux D*/
+#define MUX_PA16D_SERCOM0_PAD0                     _L_(3)      
+#define PINMUX_PA16D_SERCOM0_PAD0                  ((PIN_PA16D_SERCOM0_PAD0 << 16) | MUX_PA16D_SERCOM0_PAD0)
+#define PORT_PA16D_SERCOM0_PAD0                    (_UL_(1) << 16)
+
+#define PIN_PA22C_SERCOM0_PAD0                     _L_(22)      /**< SERCOM0 signal: PAD0 on PA22 mux C*/
+#define MUX_PA22C_SERCOM0_PAD0                     _L_(2)      
+#define PINMUX_PA22C_SERCOM0_PAD0                  ((PIN_PA22C_SERCOM0_PAD0 << 16) | MUX_PA22C_SERCOM0_PAD0)
+#define PORT_PA22C_SERCOM0_PAD0                    (_UL_(1) << 22)
+
+#define PIN_PA05D_SERCOM0_PAD1                     _L_(5)       /**< SERCOM0 signal: PAD1 on PA05 mux D*/
+#define MUX_PA05D_SERCOM0_PAD1                     _L_(3)      
+#define PINMUX_PA05D_SERCOM0_PAD1                  ((PIN_PA05D_SERCOM0_PAD1 << 16) | MUX_PA05D_SERCOM0_PAD1)
+#define PORT_PA05D_SERCOM0_PAD1                    (_UL_(1) << 5)
+
+#define PIN_PA17D_SERCOM0_PAD1                     _L_(17)      /**< SERCOM0 signal: PAD1 on PA17 mux D*/
+#define MUX_PA17D_SERCOM0_PAD1                     _L_(3)      
+#define PINMUX_PA17D_SERCOM0_PAD1                  ((PIN_PA17D_SERCOM0_PAD1 << 16) | MUX_PA17D_SERCOM0_PAD1)
+#define PORT_PA17D_SERCOM0_PAD1                    (_UL_(1) << 17)
+
+#define PIN_PA23C_SERCOM0_PAD1                     _L_(23)      /**< SERCOM0 signal: PAD1 on PA23 mux C*/
+#define MUX_PA23C_SERCOM0_PAD1                     _L_(2)      
+#define PINMUX_PA23C_SERCOM0_PAD1                  ((PIN_PA23C_SERCOM0_PAD1 << 16) | MUX_PA23C_SERCOM0_PAD1)
+#define PORT_PA23C_SERCOM0_PAD1                    (_UL_(1) << 23)
+
+#define PIN_PA14D_SERCOM0_PAD2                     _L_(14)      /**< SERCOM0 signal: PAD2 on PA14 mux D*/
+#define MUX_PA14D_SERCOM0_PAD2                     _L_(3)      
+#define PINMUX_PA14D_SERCOM0_PAD2                  ((PIN_PA14D_SERCOM0_PAD2 << 16) | MUX_PA14D_SERCOM0_PAD2)
+#define PORT_PA14D_SERCOM0_PAD2                    (_UL_(1) << 14)
+
+#define PIN_PA18D_SERCOM0_PAD2                     _L_(18)      /**< SERCOM0 signal: PAD2 on PA18 mux D*/
+#define MUX_PA18D_SERCOM0_PAD2                     _L_(3)      
+#define PINMUX_PA18D_SERCOM0_PAD2                  ((PIN_PA18D_SERCOM0_PAD2 << 16) | MUX_PA18D_SERCOM0_PAD2)
+#define PORT_PA18D_SERCOM0_PAD2                    (_UL_(1) << 18)
+
+#define PIN_PA02D_SERCOM0_PAD2                     _L_(2)       /**< SERCOM0 signal: PAD2 on PA02 mux D*/
+#define MUX_PA02D_SERCOM0_PAD2                     _L_(3)      
+#define PINMUX_PA02D_SERCOM0_PAD2                  ((PIN_PA02D_SERCOM0_PAD2 << 16) | MUX_PA02D_SERCOM0_PAD2)
+#define PORT_PA02D_SERCOM0_PAD2                    (_UL_(1) << 2)
+
+#define PIN_PA15D_SERCOM0_PAD3                     _L_(15)      /**< SERCOM0 signal: PAD3 on PA15 mux D*/
+#define MUX_PA15D_SERCOM0_PAD3                     _L_(3)      
+#define PINMUX_PA15D_SERCOM0_PAD3                  ((PIN_PA15D_SERCOM0_PAD3 << 16) | MUX_PA15D_SERCOM0_PAD3)
+#define PORT_PA15D_SERCOM0_PAD3                    (_UL_(1) << 15)
+
+#define PIN_PA19D_SERCOM0_PAD3                     _L_(19)      /**< SERCOM0 signal: PAD3 on PA19 mux D*/
+#define MUX_PA19D_SERCOM0_PAD3                     _L_(3)      
+#define PINMUX_PA19D_SERCOM0_PAD3                  ((PIN_PA19D_SERCOM0_PAD3 << 16) | MUX_PA19D_SERCOM0_PAD3)
+#define PORT_PA19D_SERCOM0_PAD3                    (_UL_(1) << 19)
+
+#define PIN_PA03D_SERCOM0_PAD3                     _L_(3)       /**< SERCOM0 signal: PAD3 on PA03 mux D*/
+#define MUX_PA03D_SERCOM0_PAD3                     _L_(3)      
+#define PINMUX_PA03D_SERCOM0_PAD3                  ((PIN_PA03D_SERCOM0_PAD3 << 16) | MUX_PA03D_SERCOM0_PAD3)
+#define PORT_PA03D_SERCOM0_PAD3                    (_UL_(1) << 3)
+
+/* ========== PORT definition for SERCOM1 peripheral ========== */
+#define PIN_PA16C_SERCOM1_PAD0                     _L_(16)      /**< SERCOM1 signal: PAD0 on PA16 mux C*/
+#define MUX_PA16C_SERCOM1_PAD0                     _L_(2)      
+#define PINMUX_PA16C_SERCOM1_PAD0                  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
+#define PORT_PA16C_SERCOM1_PAD0                    (_UL_(1) << 16)
+
+#define PIN_PA08C_SERCOM1_PAD0                     _L_(8)       /**< SERCOM1 signal: PAD0 on PA08 mux C*/
+#define MUX_PA08C_SERCOM1_PAD0                     _L_(2)      
+#define PINMUX_PA08C_SERCOM1_PAD0                  ((PIN_PA08C_SERCOM1_PAD0 << 16) | MUX_PA08C_SERCOM1_PAD0)
+#define PORT_PA08C_SERCOM1_PAD0                    (_UL_(1) << 8)
+
+#define PIN_PA00D_SERCOM1_PAD0                     _L_(0)       /**< SERCOM1 signal: PAD0 on PA00 mux D*/
+#define MUX_PA00D_SERCOM1_PAD0                     _L_(3)      
+#define PINMUX_PA00D_SERCOM1_PAD0                  ((PIN_PA00D_SERCOM1_PAD0 << 16) | MUX_PA00D_SERCOM1_PAD0)
+#define PORT_PA00D_SERCOM1_PAD0                    (_UL_(1) << 0)
+
+#define PIN_PA17C_SERCOM1_PAD1                     _L_(17)      /**< SERCOM1 signal: PAD1 on PA17 mux C*/
+#define MUX_PA17C_SERCOM1_PAD1                     _L_(2)      
+#define PINMUX_PA17C_SERCOM1_PAD1                  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
+#define PORT_PA17C_SERCOM1_PAD1                    (_UL_(1) << 17)
+
+#define PIN_PA01D_SERCOM1_PAD1                     _L_(1)       /**< SERCOM1 signal: PAD1 on PA01 mux D*/
+#define MUX_PA01D_SERCOM1_PAD1                     _L_(3)      
+#define PINMUX_PA01D_SERCOM1_PAD1                  ((PIN_PA01D_SERCOM1_PAD1 << 16) | MUX_PA01D_SERCOM1_PAD1)
+#define PORT_PA01D_SERCOM1_PAD1                    (_UL_(1) << 1)
+
+#define PIN_PA18C_SERCOM1_PAD2                     _L_(18)      /**< SERCOM1 signal: PAD2 on PA18 mux C*/
+#define MUX_PA18C_SERCOM1_PAD2                     _L_(2)      
+#define PINMUX_PA18C_SERCOM1_PAD2                  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
+#define PORT_PA18C_SERCOM1_PAD2                    (_UL_(1) << 18)
+
+#define PIN_PA30D_SERCOM1_PAD2                     _L_(30)      /**< SERCOM1 signal: PAD2 on PA30 mux D*/
+#define MUX_PA30D_SERCOM1_PAD2                     _L_(3)      
+#define PINMUX_PA30D_SERCOM1_PAD2                  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
+#define PORT_PA30D_SERCOM1_PAD2                    (_UL_(1) << 30)
+
+#define PIN_PA19C_SERCOM1_PAD3                     _L_(19)      /**< SERCOM1 signal: PAD3 on PA19 mux C*/
+#define MUX_PA19C_SERCOM1_PAD3                     _L_(2)      
+#define PINMUX_PA19C_SERCOM1_PAD3                  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
+#define PORT_PA19C_SERCOM1_PAD3                    (_UL_(1) << 19)
+
+#define PIN_PA31D_SERCOM1_PAD3                     _L_(31)      /**< SERCOM1 signal: PAD3 on PA31 mux D*/
+#define MUX_PA31D_SERCOM1_PAD3                     _L_(3)      
+#define PINMUX_PA31D_SERCOM1_PAD3                  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
+#define PORT_PA31D_SERCOM1_PAD3                    (_UL_(1) << 31)
+
+/* ========== PORT definition for TC0 peripheral ========== */
+#define PIN_PA04E_TC0_WO0                          _L_(4)       /**< TC0 signal: WO0 on PA04 mux E*/
+#define MUX_PA04E_TC0_WO0                          _L_(4)      
+#define PINMUX_PA04E_TC0_WO0                       ((PIN_PA04E_TC0_WO0 << 16) | MUX_PA04E_TC0_WO0)
+#define PORT_PA04E_TC0_WO0                         (_UL_(1) << 4)
+
+#define PIN_PA14E_TC0_WO0                          _L_(14)      /**< TC0 signal: WO0 on PA14 mux E*/
+#define MUX_PA14E_TC0_WO0                          _L_(4)      
+#define PINMUX_PA14E_TC0_WO0                       ((PIN_PA14E_TC0_WO0 << 16) | MUX_PA14E_TC0_WO0)
+#define PORT_PA14E_TC0_WO0                         (_UL_(1) << 14)
+
+#define PIN_PA22E_TC0_WO0                          _L_(22)      /**< TC0 signal: WO0 on PA22 mux E*/
+#define MUX_PA22E_TC0_WO0                          _L_(4)      
+#define PINMUX_PA22E_TC0_WO0                       ((PIN_PA22E_TC0_WO0 << 16) | MUX_PA22E_TC0_WO0)
+#define PORT_PA22E_TC0_WO0                         (_UL_(1) << 22)
+
+#define PIN_PA05E_TC0_WO1                          _L_(5)       /**< TC0 signal: WO1 on PA05 mux E*/
+#define MUX_PA05E_TC0_WO1                          _L_(4)      
+#define PINMUX_PA05E_TC0_WO1                       ((PIN_PA05E_TC0_WO1 << 16) | MUX_PA05E_TC0_WO1)
+#define PORT_PA05E_TC0_WO1                         (_UL_(1) << 5)
+
+#define PIN_PA15E_TC0_WO1                          _L_(15)      /**< TC0 signal: WO1 on PA15 mux E*/
+#define MUX_PA15E_TC0_WO1                          _L_(4)      
+#define PINMUX_PA15E_TC0_WO1                       ((PIN_PA15E_TC0_WO1 << 16) | MUX_PA15E_TC0_WO1)
+#define PORT_PA15E_TC0_WO1                         (_UL_(1) << 15)
+
+#define PIN_PA23E_TC0_WO1                          _L_(23)      /**< TC0 signal: WO1 on PA23 mux E*/
+#define MUX_PA23E_TC0_WO1                          _L_(4)      
+#define PINMUX_PA23E_TC0_WO1                       ((PIN_PA23E_TC0_WO1 << 16) | MUX_PA23E_TC0_WO1)
+#define PORT_PA23E_TC0_WO1                         (_UL_(1) << 23)
+
+/* ========== PORT definition for TC1 peripheral ========== */
+#define PIN_PA30E_TC1_WO0                          _L_(30)      /**< TC1 signal: WO0 on PA30 mux E*/
+#define MUX_PA30E_TC1_WO0                          _L_(4)      
+#define PINMUX_PA30E_TC1_WO0                       ((PIN_PA30E_TC1_WO0 << 16) | MUX_PA30E_TC1_WO0)
+#define PORT_PA30E_TC1_WO0                         (_UL_(1) << 30)
+
+#define PIN_PA31E_TC1_WO1                          _L_(31)      /**< TC1 signal: WO1 on PA31 mux E*/
+#define MUX_PA31E_TC1_WO1                          _L_(4)      
+#define PINMUX_PA31E_TC1_WO1                       ((PIN_PA31E_TC1_WO1 << 16) | MUX_PA31E_TC1_WO1)
+#define PORT_PA31E_TC1_WO1                         (_UL_(1) << 31)
+
+/* ========== PORT definition for TC2 peripheral ========== */
+#define PIN_PA00E_TC2_WO0                          _L_(0)       /**< TC2 signal: WO0 on PA00 mux E*/
+#define MUX_PA00E_TC2_WO0                          _L_(4)      
+#define PINMUX_PA00E_TC2_WO0                       ((PIN_PA00E_TC2_WO0 << 16) | MUX_PA00E_TC2_WO0)
+#define PORT_PA00E_TC2_WO0                         (_UL_(1) << 0)
+
+#define PIN_PA18E_TC2_WO0                          _L_(18)      /**< TC2 signal: WO0 on PA18 mux E*/
+#define MUX_PA18E_TC2_WO0                          _L_(4)      
+#define PINMUX_PA18E_TC2_WO0                       ((PIN_PA18E_TC2_WO0 << 16) | MUX_PA18E_TC2_WO0)
+#define PORT_PA18E_TC2_WO0                         (_UL_(1) << 18)
+
+#define PIN_PA01E_TC2_WO1                          _L_(1)       /**< TC2 signal: WO1 on PA01 mux E*/
+#define MUX_PA01E_TC2_WO1                          _L_(4)      
+#define PINMUX_PA01E_TC2_WO1                       ((PIN_PA01E_TC2_WO1 << 16) | MUX_PA01E_TC2_WO1)
+#define PORT_PA01E_TC2_WO1                         (_UL_(1) << 1)
+
+#define PIN_PA19E_TC2_WO1                          _L_(19)      /**< TC2 signal: WO1 on PA19 mux E*/
+#define MUX_PA19E_TC2_WO1                          _L_(4)      
+#define PINMUX_PA19E_TC2_WO1                       ((PIN_PA19E_TC2_WO1 << 16) | MUX_PA19E_TC2_WO1)
+#define PORT_PA19E_TC2_WO1                         (_UL_(1) << 19)
+
+
+#endif /* _SAML10D16A_PIO_H_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/pio/saml10e14a.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/pio/saml10e14a.h
@@ -1,0 +1,1167 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAML10E14A
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10E14A_PIO_H_
+#define _SAML10E14A_PIO_H_
+
+/* ========== Peripheral I/O pin numbers ========== */
+#define PIN_PA00                    (  0)  /**< Pin Number for PA00 */
+#define PIN_PA01                    (  1)  /**< Pin Number for PA01 */
+#define PIN_PA02                    (  2)  /**< Pin Number for PA02 */
+#define PIN_PA03                    (  3)  /**< Pin Number for PA03 */
+#define PIN_PA04                    (  4)  /**< Pin Number for PA04 */
+#define PIN_PA05                    (  5)  /**< Pin Number for PA05 */
+#define PIN_PA06                    (  6)  /**< Pin Number for PA06 */
+#define PIN_PA07                    (  7)  /**< Pin Number for PA07 */
+#define PIN_PA08                    (  8)  /**< Pin Number for PA08 */
+#define PIN_PA09                    (  9)  /**< Pin Number for PA09 */
+#define PIN_PA10                    ( 10)  /**< Pin Number for PA10 */
+#define PIN_PA11                    ( 11)  /**< Pin Number for PA11 */
+#define PIN_PA14                    ( 14)  /**< Pin Number for PA14 */
+#define PIN_PA15                    ( 15)  /**< Pin Number for PA15 */
+#define PIN_PA16                    ( 16)  /**< Pin Number for PA16 */
+#define PIN_PA17                    ( 17)  /**< Pin Number for PA17 */
+#define PIN_PA18                    ( 18)  /**< Pin Number for PA18 */
+#define PIN_PA19                    ( 19)  /**< Pin Number for PA19 */
+#define PIN_PA22                    ( 22)  /**< Pin Number for PA22 */
+#define PIN_PA23                    ( 23)  /**< Pin Number for PA23 */
+#define PIN_PA24                    ( 24)  /**< Pin Number for PA24 */
+#define PIN_PA25                    ( 25)  /**< Pin Number for PA25 */
+#define PIN_PA27                    ( 27)  /**< Pin Number for PA27 */
+#define PIN_PA30                    ( 30)  /**< Pin Number for PA30 */
+#define PIN_PA31                    ( 31)  /**< Pin Number for PA31 */
+
+
+/* ========== Peripheral I/O masks ========== */
+#define PORT_PA00                   (_U_(1) << 0) /**< PORT Mask for PA00 */
+#define PORT_PA01                   (_U_(1) << 1) /**< PORT Mask for PA01 */
+#define PORT_PA02                   (_U_(1) << 2) /**< PORT Mask for PA02 */
+#define PORT_PA03                   (_U_(1) << 3) /**< PORT Mask for PA03 */
+#define PORT_PA04                   (_U_(1) << 4) /**< PORT Mask for PA04 */
+#define PORT_PA05                   (_U_(1) << 5) /**< PORT Mask for PA05 */
+#define PORT_PA06                   (_U_(1) << 6) /**< PORT Mask for PA06 */
+#define PORT_PA07                   (_U_(1) << 7) /**< PORT Mask for PA07 */
+#define PORT_PA08                   (_U_(1) << 8) /**< PORT Mask for PA08 */
+#define PORT_PA09                   (_U_(1) << 9) /**< PORT Mask for PA09 */
+#define PORT_PA10                   (_U_(1) << 10) /**< PORT Mask for PA10 */
+#define PORT_PA11                   (_U_(1) << 11) /**< PORT Mask for PA11 */
+#define PORT_PA14                   (_U_(1) << 14) /**< PORT Mask for PA14 */
+#define PORT_PA15                   (_U_(1) << 15) /**< PORT Mask for PA15 */
+#define PORT_PA16                   (_U_(1) << 16) /**< PORT Mask for PA16 */
+#define PORT_PA17                   (_U_(1) << 17) /**< PORT Mask for PA17 */
+#define PORT_PA18                   (_U_(1) << 18) /**< PORT Mask for PA18 */
+#define PORT_PA19                   (_U_(1) << 19) /**< PORT Mask for PA19 */
+#define PORT_PA22                   (_U_(1) << 22) /**< PORT Mask for PA22 */
+#define PORT_PA23                   (_U_(1) << 23) /**< PORT Mask for PA23 */
+#define PORT_PA24                   (_U_(1) << 24) /**< PORT Mask for PA24 */
+#define PORT_PA25                   (_U_(1) << 25) /**< PORT Mask for PA25 */
+#define PORT_PA27                   (_U_(1) << 27) /**< PORT Mask for PA27 */
+#define PORT_PA30                   (_U_(1) << 30) /**< PORT Mask for PA30 */
+#define PORT_PA31                   (_U_(1) << 31) /**< PORT Mask for PA31 */
+
+
+/* ========== Peripheral I/O indexes ========== */
+#define PORT_PA00_IDX               (  0)  /**< PORT Index Number for PA00 */
+#define PORT_PA01_IDX               (  1)  /**< PORT Index Number for PA01 */
+#define PORT_PA02_IDX               (  2)  /**< PORT Index Number for PA02 */
+#define PORT_PA03_IDX               (  3)  /**< PORT Index Number for PA03 */
+#define PORT_PA04_IDX               (  4)  /**< PORT Index Number for PA04 */
+#define PORT_PA05_IDX               (  5)  /**< PORT Index Number for PA05 */
+#define PORT_PA06_IDX               (  6)  /**< PORT Index Number for PA06 */
+#define PORT_PA07_IDX               (  7)  /**< PORT Index Number for PA07 */
+#define PORT_PA08_IDX               (  8)  /**< PORT Index Number for PA08 */
+#define PORT_PA09_IDX               (  9)  /**< PORT Index Number for PA09 */
+#define PORT_PA10_IDX               ( 10)  /**< PORT Index Number for PA10 */
+#define PORT_PA11_IDX               ( 11)  /**< PORT Index Number for PA11 */
+#define PORT_PA14_IDX               ( 14)  /**< PORT Index Number for PA14 */
+#define PORT_PA15_IDX               ( 15)  /**< PORT Index Number for PA15 */
+#define PORT_PA16_IDX               ( 16)  /**< PORT Index Number for PA16 */
+#define PORT_PA17_IDX               ( 17)  /**< PORT Index Number for PA17 */
+#define PORT_PA18_IDX               ( 18)  /**< PORT Index Number for PA18 */
+#define PORT_PA19_IDX               ( 19)  /**< PORT Index Number for PA19 */
+#define PORT_PA22_IDX               ( 22)  /**< PORT Index Number for PA22 */
+#define PORT_PA23_IDX               ( 23)  /**< PORT Index Number for PA23 */
+#define PORT_PA24_IDX               ( 24)  /**< PORT Index Number for PA24 */
+#define PORT_PA25_IDX               ( 25)  /**< PORT Index Number for PA25 */
+#define PORT_PA27_IDX               ( 27)  /**< PORT Index Number for PA27 */
+#define PORT_PA30_IDX               ( 30)  /**< PORT Index Number for PA30 */
+#define PORT_PA31_IDX               ( 31)  /**< PORT Index Number for PA31 */
+
+/* ========== PORT definition for AC peripheral ========== */
+#define PIN_PA04B_AC_AIN0                          _L_(4)       /**< AC signal: AIN0 on PA04 mux B*/
+#define MUX_PA04B_AC_AIN0                          _L_(1)      
+#define PINMUX_PA04B_AC_AIN0                       ((PIN_PA04B_AC_AIN0 << 16) | MUX_PA04B_AC_AIN0)
+#define PORT_PA04B_AC_AIN0                         (_UL_(1) << 4)
+
+#define PIN_PA05B_AC_AIN1                          _L_(5)       /**< AC signal: AIN1 on PA05 mux B*/
+#define MUX_PA05B_AC_AIN1                          _L_(1)      
+#define PINMUX_PA05B_AC_AIN1                       ((PIN_PA05B_AC_AIN1 << 16) | MUX_PA05B_AC_AIN1)
+#define PORT_PA05B_AC_AIN1                         (_UL_(1) << 5)
+
+#define PIN_PA06B_AC_AIN2                          _L_(6)       /**< AC signal: AIN2 on PA06 mux B*/
+#define MUX_PA06B_AC_AIN2                          _L_(1)      
+#define PINMUX_PA06B_AC_AIN2                       ((PIN_PA06B_AC_AIN2 << 16) | MUX_PA06B_AC_AIN2)
+#define PORT_PA06B_AC_AIN2                         (_UL_(1) << 6)
+
+#define PIN_PA07B_AC_AIN3                          _L_(7)       /**< AC signal: AIN3 on PA07 mux B*/
+#define MUX_PA07B_AC_AIN3                          _L_(1)      
+#define PINMUX_PA07B_AC_AIN3                       ((PIN_PA07B_AC_AIN3 << 16) | MUX_PA07B_AC_AIN3)
+#define PORT_PA07B_AC_AIN3                         (_UL_(1) << 7)
+
+#define PIN_PA18H_AC_CMP0                          _L_(18)      /**< AC signal: CMP0 on PA18 mux H*/
+#define MUX_PA18H_AC_CMP0                          _L_(7)      
+#define PINMUX_PA18H_AC_CMP0                       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
+#define PORT_PA18H_AC_CMP0                         (_UL_(1) << 18)
+
+#define PIN_PA19H_AC_CMP1                          _L_(19)      /**< AC signal: CMP1 on PA19 mux H*/
+#define MUX_PA19H_AC_CMP1                          _L_(7)      
+#define PINMUX_PA19H_AC_CMP1                       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
+#define PORT_PA19H_AC_CMP1                         (_UL_(1) << 19)
+
+/* ========== PORT definition for ADC peripheral ========== */
+#define PIN_PA02B_ADC_AIN0                         _L_(2)       /**< ADC signal: AIN0 on PA02 mux B*/
+#define MUX_PA02B_ADC_AIN0                         _L_(1)      
+#define PINMUX_PA02B_ADC_AIN0                      ((PIN_PA02B_ADC_AIN0 << 16) | MUX_PA02B_ADC_AIN0)
+#define PORT_PA02B_ADC_AIN0                        (_UL_(1) << 2)
+
+#define PIN_PA03B_ADC_AIN1                         _L_(3)       /**< ADC signal: AIN1 on PA03 mux B*/
+#define MUX_PA03B_ADC_AIN1                         _L_(1)      
+#define PINMUX_PA03B_ADC_AIN1                      ((PIN_PA03B_ADC_AIN1 << 16) | MUX_PA03B_ADC_AIN1)
+#define PORT_PA03B_ADC_AIN1                        (_UL_(1) << 3)
+
+#define PIN_PA04B_ADC_AIN2                         _L_(4)       /**< ADC signal: AIN2 on PA04 mux B*/
+#define MUX_PA04B_ADC_AIN2                         _L_(1)      
+#define PINMUX_PA04B_ADC_AIN2                      ((PIN_PA04B_ADC_AIN2 << 16) | MUX_PA04B_ADC_AIN2)
+#define PORT_PA04B_ADC_AIN2                        (_UL_(1) << 4)
+
+#define PIN_PA05B_ADC_AIN3                         _L_(5)       /**< ADC signal: AIN3 on PA05 mux B*/
+#define MUX_PA05B_ADC_AIN3                         _L_(1)      
+#define PINMUX_PA05B_ADC_AIN3                      ((PIN_PA05B_ADC_AIN3 << 16) | MUX_PA05B_ADC_AIN3)
+#define PORT_PA05B_ADC_AIN3                        (_UL_(1) << 5)
+
+#define PIN_PA06B_ADC_AIN4                         _L_(6)       /**< ADC signal: AIN4 on PA06 mux B*/
+#define MUX_PA06B_ADC_AIN4                         _L_(1)      
+#define PINMUX_PA06B_ADC_AIN4                      ((PIN_PA06B_ADC_AIN4 << 16) | MUX_PA06B_ADC_AIN4)
+#define PORT_PA06B_ADC_AIN4                        (_UL_(1) << 6)
+
+#define PIN_PA07B_ADC_AIN5                         _L_(7)       /**< ADC signal: AIN5 on PA07 mux B*/
+#define MUX_PA07B_ADC_AIN5                         _L_(1)      
+#define PINMUX_PA07B_ADC_AIN5                      ((PIN_PA07B_ADC_AIN5 << 16) | MUX_PA07B_ADC_AIN5)
+#define PORT_PA07B_ADC_AIN5                        (_UL_(1) << 7)
+
+#define PIN_PA08B_ADC_AIN6                         _L_(8)       /**< ADC signal: AIN6 on PA08 mux B*/
+#define MUX_PA08B_ADC_AIN6                         _L_(1)      
+#define PINMUX_PA08B_ADC_AIN6                      ((PIN_PA08B_ADC_AIN6 << 16) | MUX_PA08B_ADC_AIN6)
+#define PORT_PA08B_ADC_AIN6                        (_UL_(1) << 8)
+
+#define PIN_PA09B_ADC_AIN7                         _L_(9)       /**< ADC signal: AIN7 on PA09 mux B*/
+#define MUX_PA09B_ADC_AIN7                         _L_(1)      
+#define PINMUX_PA09B_ADC_AIN7                      ((PIN_PA09B_ADC_AIN7 << 16) | MUX_PA09B_ADC_AIN7)
+#define PORT_PA09B_ADC_AIN7                        (_UL_(1) << 9)
+
+#define PIN_PA10B_ADC_AIN8                         _L_(10)      /**< ADC signal: AIN8 on PA10 mux B*/
+#define MUX_PA10B_ADC_AIN8                         _L_(1)      
+#define PINMUX_PA10B_ADC_AIN8                      ((PIN_PA10B_ADC_AIN8 << 16) | MUX_PA10B_ADC_AIN8)
+#define PORT_PA10B_ADC_AIN8                        (_UL_(1) << 10)
+
+#define PIN_PA11B_ADC_AIN9                         _L_(11)      /**< ADC signal: AIN9 on PA11 mux B*/
+#define MUX_PA11B_ADC_AIN9                         _L_(1)      
+#define PINMUX_PA11B_ADC_AIN9                      ((PIN_PA11B_ADC_AIN9 << 16) | MUX_PA11B_ADC_AIN9)
+#define PORT_PA11B_ADC_AIN9                        (_UL_(1) << 11)
+
+#define PIN_PA04B_ADC_VREFP                        _L_(4)       /**< ADC signal: VREFP on PA04 mux B*/
+#define MUX_PA04B_ADC_VREFP                        _L_(1)      
+#define PINMUX_PA04B_ADC_VREFP                     ((PIN_PA04B_ADC_VREFP << 16) | MUX_PA04B_ADC_VREFP)
+#define PORT_PA04B_ADC_VREFP                       (_UL_(1) << 4)
+
+/* ========== PORT definition for CCL peripheral ========== */
+#define PIN_PA04I_CCL_IN0                          _L_(4)       /**< CCL signal: IN0 on PA04 mux I*/
+#define MUX_PA04I_CCL_IN0                          _L_(8)      
+#define PINMUX_PA04I_CCL_IN0                       ((PIN_PA04I_CCL_IN0 << 16) | MUX_PA04I_CCL_IN0)
+#define PORT_PA04I_CCL_IN0                         (_UL_(1) << 4)
+
+#define PIN_PA16I_CCL_IN0                          _L_(16)      /**< CCL signal: IN0 on PA16 mux I*/
+#define MUX_PA16I_CCL_IN0                          _L_(8)      
+#define PINMUX_PA16I_CCL_IN0                       ((PIN_PA16I_CCL_IN0 << 16) | MUX_PA16I_CCL_IN0)
+#define PORT_PA16I_CCL_IN0                         (_UL_(1) << 16)
+
+#define PIN_PA05I_CCL_IN1                          _L_(5)       /**< CCL signal: IN1 on PA05 mux I*/
+#define MUX_PA05I_CCL_IN1                          _L_(8)      
+#define PINMUX_PA05I_CCL_IN1                       ((PIN_PA05I_CCL_IN1 << 16) | MUX_PA05I_CCL_IN1)
+#define PORT_PA05I_CCL_IN1                         (_UL_(1) << 5)
+
+#define PIN_PA17I_CCL_IN1                          _L_(17)      /**< CCL signal: IN1 on PA17 mux I*/
+#define MUX_PA17I_CCL_IN1                          _L_(8)      
+#define PINMUX_PA17I_CCL_IN1                       ((PIN_PA17I_CCL_IN1 << 16) | MUX_PA17I_CCL_IN1)
+#define PORT_PA17I_CCL_IN1                         (_UL_(1) << 17)
+
+#define PIN_PA06I_CCL_IN2                          _L_(6)       /**< CCL signal: IN2 on PA06 mux I*/
+#define MUX_PA06I_CCL_IN2                          _L_(8)      
+#define PINMUX_PA06I_CCL_IN2                       ((PIN_PA06I_CCL_IN2 << 16) | MUX_PA06I_CCL_IN2)
+#define PORT_PA06I_CCL_IN2                         (_UL_(1) << 6)
+
+#define PIN_PA18I_CCL_IN2                          _L_(18)      /**< CCL signal: IN2 on PA18 mux I*/
+#define MUX_PA18I_CCL_IN2                          _L_(8)      
+#define PINMUX_PA18I_CCL_IN2                       ((PIN_PA18I_CCL_IN2 << 16) | MUX_PA18I_CCL_IN2)
+#define PORT_PA18I_CCL_IN2                         (_UL_(1) << 18)
+
+#define PIN_PA08I_CCL_IN3                          _L_(8)       /**< CCL signal: IN3 on PA08 mux I*/
+#define MUX_PA08I_CCL_IN3                          _L_(8)      
+#define PINMUX_PA08I_CCL_IN3                       ((PIN_PA08I_CCL_IN3 << 16) | MUX_PA08I_CCL_IN3)
+#define PORT_PA08I_CCL_IN3                         (_UL_(1) << 8)
+
+#define PIN_PA30I_CCL_IN3                          _L_(30)      /**< CCL signal: IN3 on PA30 mux I*/
+#define MUX_PA30I_CCL_IN3                          _L_(8)      
+#define PINMUX_PA30I_CCL_IN3                       ((PIN_PA30I_CCL_IN3 << 16) | MUX_PA30I_CCL_IN3)
+#define PORT_PA30I_CCL_IN3                         (_UL_(1) << 30)
+
+#define PIN_PA09I_CCL_IN4                          _L_(9)       /**< CCL signal: IN4 on PA09 mux I*/
+#define MUX_PA09I_CCL_IN4                          _L_(8)      
+#define PINMUX_PA09I_CCL_IN4                       ((PIN_PA09I_CCL_IN4 << 16) | MUX_PA09I_CCL_IN4)
+#define PORT_PA09I_CCL_IN4                         (_UL_(1) << 9)
+
+#define PIN_PA10I_CCL_IN5                          _L_(10)      /**< CCL signal: IN5 on PA10 mux I*/
+#define MUX_PA10I_CCL_IN5                          _L_(8)      
+#define PINMUX_PA10I_CCL_IN5                       ((PIN_PA10I_CCL_IN5 << 16) | MUX_PA10I_CCL_IN5)
+#define PORT_PA10I_CCL_IN5                         (_UL_(1) << 10)
+
+#define PIN_PA07I_CCL_OUT0                         _L_(7)       /**< CCL signal: OUT0 on PA07 mux I*/
+#define MUX_PA07I_CCL_OUT0                         _L_(8)      
+#define PINMUX_PA07I_CCL_OUT0                      ((PIN_PA07I_CCL_OUT0 << 16) | MUX_PA07I_CCL_OUT0)
+#define PORT_PA07I_CCL_OUT0                        (_UL_(1) << 7)
+
+#define PIN_PA19I_CCL_OUT0                         _L_(19)      /**< CCL signal: OUT0 on PA19 mux I*/
+#define MUX_PA19I_CCL_OUT0                         _L_(8)      
+#define PINMUX_PA19I_CCL_OUT0                      ((PIN_PA19I_CCL_OUT0 << 16) | MUX_PA19I_CCL_OUT0)
+#define PORT_PA19I_CCL_OUT0                        (_UL_(1) << 19)
+
+#define PIN_PA11I_CCL_OUT1                         _L_(11)      /**< CCL signal: OUT1 on PA11 mux I*/
+#define MUX_PA11I_CCL_OUT1                         _L_(8)      
+#define PINMUX_PA11I_CCL_OUT1                      ((PIN_PA11I_CCL_OUT1 << 16) | MUX_PA11I_CCL_OUT1)
+#define PORT_PA11I_CCL_OUT1                        (_UL_(1) << 11)
+
+#define PIN_PA31I_CCL_OUT1                         _L_(31)      /**< CCL signal: OUT1 on PA31 mux I*/
+#define MUX_PA31I_CCL_OUT1                         _L_(8)      
+#define PINMUX_PA31I_CCL_OUT1                      ((PIN_PA31I_CCL_OUT1 << 16) | MUX_PA31I_CCL_OUT1)
+#define PORT_PA31I_CCL_OUT1                        (_UL_(1) << 31)
+
+/* ========== PORT definition for DAC peripheral ========== */
+#define PIN_PA02B_DAC_VOUT                         _L_(2)       /**< DAC signal: VOUT on PA02 mux B*/
+#define MUX_PA02B_DAC_VOUT                         _L_(1)      
+#define PINMUX_PA02B_DAC_VOUT                      ((PIN_PA02B_DAC_VOUT << 16) | MUX_PA02B_DAC_VOUT)
+#define PORT_PA02B_DAC_VOUT                        (_UL_(1) << 2)
+
+#define PIN_PA03B_DAC_VREFP                        _L_(3)       /**< DAC signal: VREFP on PA03 mux B*/
+#define MUX_PA03B_DAC_VREFP                        _L_(1)      
+#define PINMUX_PA03B_DAC_VREFP                     ((PIN_PA03B_DAC_VREFP << 16) | MUX_PA03B_DAC_VREFP)
+#define PORT_PA03B_DAC_VREFP                       (_UL_(1) << 3)
+
+/* ========== PORT definition for EIC peripheral ========== */
+#define PIN_PA09A_EIC_EXTINT0                      _L_(9)       /**< EIC signal: EXTINT0 on PA09 mux A*/
+#define MUX_PA09A_EIC_EXTINT0                      _L_(0)      
+#define PINMUX_PA09A_EIC_EXTINT0                   ((PIN_PA09A_EIC_EXTINT0 << 16) | MUX_PA09A_EIC_EXTINT0)
+#define PORT_PA09A_EIC_EXTINT0                     (_UL_(1) << 9)
+#define PIN_PA09A_EIC_EXTINT_NUM                   _L_(0)       /**< EIC signal: PIN_PA09 External Interrupt Line */
+
+#define PIN_PA19A_EIC_EXTINT0                      _L_(19)      /**< EIC signal: EXTINT0 on PA19 mux A*/
+#define MUX_PA19A_EIC_EXTINT0                      _L_(0)      
+#define PINMUX_PA19A_EIC_EXTINT0                   ((PIN_PA19A_EIC_EXTINT0 << 16) | MUX_PA19A_EIC_EXTINT0)
+#define PORT_PA19A_EIC_EXTINT0                     (_UL_(1) << 19)
+#define PIN_PA19A_EIC_EXTINT_NUM                   _L_(0)       /**< EIC signal: PIN_PA19 External Interrupt Line */
+
+#define PIN_PA00A_EIC_EXTINT0                      _L_(0)       /**< EIC signal: EXTINT0 on PA00 mux A*/
+#define MUX_PA00A_EIC_EXTINT0                      _L_(0)      
+#define PINMUX_PA00A_EIC_EXTINT0                   ((PIN_PA00A_EIC_EXTINT0 << 16) | MUX_PA00A_EIC_EXTINT0)
+#define PORT_PA00A_EIC_EXTINT0                     (_UL_(1) << 0)
+#define PIN_PA00A_EIC_EXTINT_NUM                   _L_(0)       /**< EIC signal: PIN_PA00 External Interrupt Line */
+
+#define PIN_PA10A_EIC_EXTINT1                      _L_(10)      /**< EIC signal: EXTINT1 on PA10 mux A*/
+#define MUX_PA10A_EIC_EXTINT1                      _L_(0)      
+#define PINMUX_PA10A_EIC_EXTINT1                   ((PIN_PA10A_EIC_EXTINT1 << 16) | MUX_PA10A_EIC_EXTINT1)
+#define PORT_PA10A_EIC_EXTINT1                     (_UL_(1) << 10)
+#define PIN_PA10A_EIC_EXTINT_NUM                   _L_(1)       /**< EIC signal: PIN_PA10 External Interrupt Line */
+
+#define PIN_PA22A_EIC_EXTINT1                      _L_(22)      /**< EIC signal: EXTINT1 on PA22 mux A*/
+#define MUX_PA22A_EIC_EXTINT1                      _L_(0)      
+#define PINMUX_PA22A_EIC_EXTINT1                   ((PIN_PA22A_EIC_EXTINT1 << 16) | MUX_PA22A_EIC_EXTINT1)
+#define PORT_PA22A_EIC_EXTINT1                     (_UL_(1) << 22)
+#define PIN_PA22A_EIC_EXTINT_NUM                   _L_(1)       /**< EIC signal: PIN_PA22 External Interrupt Line */
+
+#define PIN_PA01A_EIC_EXTINT1                      _L_(1)       /**< EIC signal: EXTINT1 on PA01 mux A*/
+#define MUX_PA01A_EIC_EXTINT1                      _L_(0)      
+#define PINMUX_PA01A_EIC_EXTINT1                   ((PIN_PA01A_EIC_EXTINT1 << 16) | MUX_PA01A_EIC_EXTINT1)
+#define PORT_PA01A_EIC_EXTINT1                     (_UL_(1) << 1)
+#define PIN_PA01A_EIC_EXTINT_NUM                   _L_(1)       /**< EIC signal: PIN_PA01 External Interrupt Line */
+
+#define PIN_PA02A_EIC_EXTINT2                      _L_(2)       /**< EIC signal: EXTINT2 on PA02 mux A*/
+#define MUX_PA02A_EIC_EXTINT2                      _L_(0)      
+#define PINMUX_PA02A_EIC_EXTINT2                   ((PIN_PA02A_EIC_EXTINT2 << 16) | MUX_PA02A_EIC_EXTINT2)
+#define PORT_PA02A_EIC_EXTINT2                     (_UL_(1) << 2)
+#define PIN_PA02A_EIC_EXTINT_NUM                   _L_(2)       /**< EIC signal: PIN_PA02 External Interrupt Line */
+
+#define PIN_PA11A_EIC_EXTINT2                      _L_(11)      /**< EIC signal: EXTINT2 on PA11 mux A*/
+#define MUX_PA11A_EIC_EXTINT2                      _L_(0)      
+#define PINMUX_PA11A_EIC_EXTINT2                   ((PIN_PA11A_EIC_EXTINT2 << 16) | MUX_PA11A_EIC_EXTINT2)
+#define PORT_PA11A_EIC_EXTINT2                     (_UL_(1) << 11)
+#define PIN_PA11A_EIC_EXTINT_NUM                   _L_(2)       /**< EIC signal: PIN_PA11 External Interrupt Line */
+
+#define PIN_PA23A_EIC_EXTINT2                      _L_(23)      /**< EIC signal: EXTINT2 on PA23 mux A*/
+#define MUX_PA23A_EIC_EXTINT2                      _L_(0)      
+#define PINMUX_PA23A_EIC_EXTINT2                   ((PIN_PA23A_EIC_EXTINT2 << 16) | MUX_PA23A_EIC_EXTINT2)
+#define PORT_PA23A_EIC_EXTINT2                     (_UL_(1) << 23)
+#define PIN_PA23A_EIC_EXTINT_NUM                   _L_(2)       /**< EIC signal: PIN_PA23 External Interrupt Line */
+
+#define PIN_PA03A_EIC_EXTINT3                      _L_(3)       /**< EIC signal: EXTINT3 on PA03 mux A*/
+#define MUX_PA03A_EIC_EXTINT3                      _L_(0)      
+#define PINMUX_PA03A_EIC_EXTINT3                   ((PIN_PA03A_EIC_EXTINT3 << 16) | MUX_PA03A_EIC_EXTINT3)
+#define PORT_PA03A_EIC_EXTINT3                     (_UL_(1) << 3)
+#define PIN_PA03A_EIC_EXTINT_NUM                   _L_(3)       /**< EIC signal: PIN_PA03 External Interrupt Line */
+
+#define PIN_PA14A_EIC_EXTINT3                      _L_(14)      /**< EIC signal: EXTINT3 on PA14 mux A*/
+#define MUX_PA14A_EIC_EXTINT3                      _L_(0)      
+#define PINMUX_PA14A_EIC_EXTINT3                   ((PIN_PA14A_EIC_EXTINT3 << 16) | MUX_PA14A_EIC_EXTINT3)
+#define PORT_PA14A_EIC_EXTINT3                     (_UL_(1) << 14)
+#define PIN_PA14A_EIC_EXTINT_NUM                   _L_(3)       /**< EIC signal: PIN_PA14 External Interrupt Line */
+
+#define PIN_PA24A_EIC_EXTINT3                      _L_(24)      /**< EIC signal: EXTINT3 on PA24 mux A*/
+#define MUX_PA24A_EIC_EXTINT3                      _L_(0)      
+#define PINMUX_PA24A_EIC_EXTINT3                   ((PIN_PA24A_EIC_EXTINT3 << 16) | MUX_PA24A_EIC_EXTINT3)
+#define PORT_PA24A_EIC_EXTINT3                     (_UL_(1) << 24)
+#define PIN_PA24A_EIC_EXTINT_NUM                   _L_(3)       /**< EIC signal: PIN_PA24 External Interrupt Line */
+
+#define PIN_PA04A_EIC_EXTINT4                      _L_(4)       /**< EIC signal: EXTINT4 on PA04 mux A*/
+#define MUX_PA04A_EIC_EXTINT4                      _L_(0)      
+#define PINMUX_PA04A_EIC_EXTINT4                   ((PIN_PA04A_EIC_EXTINT4 << 16) | MUX_PA04A_EIC_EXTINT4)
+#define PORT_PA04A_EIC_EXTINT4                     (_UL_(1) << 4)
+#define PIN_PA04A_EIC_EXTINT_NUM                   _L_(4)       /**< EIC signal: PIN_PA04 External Interrupt Line */
+
+#define PIN_PA15A_EIC_EXTINT4                      _L_(15)      /**< EIC signal: EXTINT4 on PA15 mux A*/
+#define MUX_PA15A_EIC_EXTINT4                      _L_(0)      
+#define PINMUX_PA15A_EIC_EXTINT4                   ((PIN_PA15A_EIC_EXTINT4 << 16) | MUX_PA15A_EIC_EXTINT4)
+#define PORT_PA15A_EIC_EXTINT4                     (_UL_(1) << 15)
+#define PIN_PA15A_EIC_EXTINT_NUM                   _L_(4)       /**< EIC signal: PIN_PA15 External Interrupt Line */
+
+#define PIN_PA25A_EIC_EXTINT4                      _L_(25)      /**< EIC signal: EXTINT4 on PA25 mux A*/
+#define MUX_PA25A_EIC_EXTINT4                      _L_(0)      
+#define PINMUX_PA25A_EIC_EXTINT4                   ((PIN_PA25A_EIC_EXTINT4 << 16) | MUX_PA25A_EIC_EXTINT4)
+#define PORT_PA25A_EIC_EXTINT4                     (_UL_(1) << 25)
+#define PIN_PA25A_EIC_EXTINT_NUM                   _L_(4)       /**< EIC signal: PIN_PA25 External Interrupt Line */
+
+#define PIN_PA05A_EIC_EXTINT5                      _L_(5)       /**< EIC signal: EXTINT5 on PA05 mux A*/
+#define MUX_PA05A_EIC_EXTINT5                      _L_(0)      
+#define PINMUX_PA05A_EIC_EXTINT5                   ((PIN_PA05A_EIC_EXTINT5 << 16) | MUX_PA05A_EIC_EXTINT5)
+#define PORT_PA05A_EIC_EXTINT5                     (_UL_(1) << 5)
+#define PIN_PA05A_EIC_EXTINT_NUM                   _L_(5)       /**< EIC signal: PIN_PA05 External Interrupt Line */
+
+#define PIN_PA16A_EIC_EXTINT5                      _L_(16)      /**< EIC signal: EXTINT5 on PA16 mux A*/
+#define MUX_PA16A_EIC_EXTINT5                      _L_(0)      
+#define PINMUX_PA16A_EIC_EXTINT5                   ((PIN_PA16A_EIC_EXTINT5 << 16) | MUX_PA16A_EIC_EXTINT5)
+#define PORT_PA16A_EIC_EXTINT5                     (_UL_(1) << 16)
+#define PIN_PA16A_EIC_EXTINT_NUM                   _L_(5)       /**< EIC signal: PIN_PA16 External Interrupt Line */
+
+#define PIN_PA27A_EIC_EXTINT5                      _L_(27)      /**< EIC signal: EXTINT5 on PA27 mux A*/
+#define MUX_PA27A_EIC_EXTINT5                      _L_(0)      
+#define PINMUX_PA27A_EIC_EXTINT5                   ((PIN_PA27A_EIC_EXTINT5 << 16) | MUX_PA27A_EIC_EXTINT5)
+#define PORT_PA27A_EIC_EXTINT5                     (_UL_(1) << 27)
+#define PIN_PA27A_EIC_EXTINT_NUM                   _L_(5)       /**< EIC signal: PIN_PA27 External Interrupt Line */
+
+#define PIN_PA06A_EIC_EXTINT6                      _L_(6)       /**< EIC signal: EXTINT6 on PA06 mux A*/
+#define MUX_PA06A_EIC_EXTINT6                      _L_(0)      
+#define PINMUX_PA06A_EIC_EXTINT6                   ((PIN_PA06A_EIC_EXTINT6 << 16) | MUX_PA06A_EIC_EXTINT6)
+#define PORT_PA06A_EIC_EXTINT6                     (_UL_(1) << 6)
+#define PIN_PA06A_EIC_EXTINT_NUM                   _L_(6)       /**< EIC signal: PIN_PA06 External Interrupt Line */
+
+#define PIN_PA17A_EIC_EXTINT6                      _L_(17)      /**< EIC signal: EXTINT6 on PA17 mux A*/
+#define MUX_PA17A_EIC_EXTINT6                      _L_(0)      
+#define PINMUX_PA17A_EIC_EXTINT6                   ((PIN_PA17A_EIC_EXTINT6 << 16) | MUX_PA17A_EIC_EXTINT6)
+#define PORT_PA17A_EIC_EXTINT6                     (_UL_(1) << 17)
+#define PIN_PA17A_EIC_EXTINT_NUM                   _L_(6)       /**< EIC signal: PIN_PA17 External Interrupt Line */
+
+#define PIN_PA30A_EIC_EXTINT6                      _L_(30)      /**< EIC signal: EXTINT6 on PA30 mux A*/
+#define MUX_PA30A_EIC_EXTINT6                      _L_(0)      
+#define PINMUX_PA30A_EIC_EXTINT6                   ((PIN_PA30A_EIC_EXTINT6 << 16) | MUX_PA30A_EIC_EXTINT6)
+#define PORT_PA30A_EIC_EXTINT6                     (_UL_(1) << 30)
+#define PIN_PA30A_EIC_EXTINT_NUM                   _L_(6)       /**< EIC signal: PIN_PA30 External Interrupt Line */
+
+#define PIN_PA07A_EIC_EXTINT7                      _L_(7)       /**< EIC signal: EXTINT7 on PA07 mux A*/
+#define MUX_PA07A_EIC_EXTINT7                      _L_(0)      
+#define PINMUX_PA07A_EIC_EXTINT7                   ((PIN_PA07A_EIC_EXTINT7 << 16) | MUX_PA07A_EIC_EXTINT7)
+#define PORT_PA07A_EIC_EXTINT7                     (_UL_(1) << 7)
+#define PIN_PA07A_EIC_EXTINT_NUM                   _L_(7)       /**< EIC signal: PIN_PA07 External Interrupt Line */
+
+#define PIN_PA18A_EIC_EXTINT7                      _L_(18)      /**< EIC signal: EXTINT7 on PA18 mux A*/
+#define MUX_PA18A_EIC_EXTINT7                      _L_(0)      
+#define PINMUX_PA18A_EIC_EXTINT7                   ((PIN_PA18A_EIC_EXTINT7 << 16) | MUX_PA18A_EIC_EXTINT7)
+#define PORT_PA18A_EIC_EXTINT7                     (_UL_(1) << 18)
+#define PIN_PA18A_EIC_EXTINT_NUM                   _L_(7)       /**< EIC signal: PIN_PA18 External Interrupt Line */
+
+#define PIN_PA31A_EIC_EXTINT7                      _L_(31)      /**< EIC signal: EXTINT7 on PA31 mux A*/
+#define MUX_PA31A_EIC_EXTINT7                      _L_(0)      
+#define PINMUX_PA31A_EIC_EXTINT7                   ((PIN_PA31A_EIC_EXTINT7 << 16) | MUX_PA31A_EIC_EXTINT7)
+#define PORT_PA31A_EIC_EXTINT7                     (_UL_(1) << 31)
+#define PIN_PA31A_EIC_EXTINT_NUM                   _L_(7)       /**< EIC signal: PIN_PA31 External Interrupt Line */
+
+#define PIN_PA08A_EIC_NMI                          _L_(8)       /**< EIC signal: NMI on PA08 mux A*/
+#define MUX_PA08A_EIC_NMI                          _L_(0)      
+#define PINMUX_PA08A_EIC_NMI                       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
+#define PORT_PA08A_EIC_NMI                         (_UL_(1) << 8)
+
+/* ========== PORT definition for GCLK peripheral ========== */
+#define PIN_PA30H_GCLK_IO0                         _L_(30)      /**< GCLK signal: IO0 on PA30 mux H*/
+#define MUX_PA30H_GCLK_IO0                         _L_(7)      
+#define PINMUX_PA30H_GCLK_IO0                      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
+#define PORT_PA30H_GCLK_IO0                        (_UL_(1) << 30)
+
+#define PIN_PA14H_GCLK_IO0                         _L_(14)      /**< GCLK signal: IO0 on PA14 mux H*/
+#define MUX_PA14H_GCLK_IO0                         _L_(7)      
+#define PINMUX_PA14H_GCLK_IO0                      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
+#define PORT_PA14H_GCLK_IO0                        (_UL_(1) << 14)
+
+#define PIN_PA27H_GCLK_IO0                         _L_(27)      /**< GCLK signal: IO0 on PA27 mux H*/
+#define MUX_PA27H_GCLK_IO0                         _L_(7)      
+#define PINMUX_PA27H_GCLK_IO0                      ((PIN_PA27H_GCLK_IO0 << 16) | MUX_PA27H_GCLK_IO0)
+#define PORT_PA27H_GCLK_IO0                        (_UL_(1) << 27)
+
+#define PIN_PA23H_GCLK_IO1                         _L_(23)      /**< GCLK signal: IO1 on PA23 mux H*/
+#define MUX_PA23H_GCLK_IO1                         _L_(7)      
+#define PINMUX_PA23H_GCLK_IO1                      ((PIN_PA23H_GCLK_IO1 << 16) | MUX_PA23H_GCLK_IO1)
+#define PORT_PA23H_GCLK_IO1                        (_UL_(1) << 23)
+
+#define PIN_PA15H_GCLK_IO1                         _L_(15)      /**< GCLK signal: IO1 on PA15 mux H*/
+#define MUX_PA15H_GCLK_IO1                         _L_(7)      
+#define PINMUX_PA15H_GCLK_IO1                      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
+#define PORT_PA15H_GCLK_IO1                        (_UL_(1) << 15)
+
+#define PIN_PA16H_GCLK_IO2                         _L_(16)      /**< GCLK signal: IO2 on PA16 mux H*/
+#define MUX_PA16H_GCLK_IO2                         _L_(7)      
+#define PINMUX_PA16H_GCLK_IO2                      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
+#define PORT_PA16H_GCLK_IO2                        (_UL_(1) << 16)
+
+#define PIN_PA22H_GCLK_IO2                         _L_(22)      /**< GCLK signal: IO2 on PA22 mux H*/
+#define MUX_PA22H_GCLK_IO2                         _L_(7)      
+#define PINMUX_PA22H_GCLK_IO2                      ((PIN_PA22H_GCLK_IO2 << 16) | MUX_PA22H_GCLK_IO2)
+#define PORT_PA22H_GCLK_IO2                        (_UL_(1) << 22)
+
+#define PIN_PA11H_GCLK_IO3                         _L_(11)      /**< GCLK signal: IO3 on PA11 mux H*/
+#define MUX_PA11H_GCLK_IO3                         _L_(7)      
+#define PINMUX_PA11H_GCLK_IO3                      ((PIN_PA11H_GCLK_IO3 << 16) | MUX_PA11H_GCLK_IO3)
+#define PORT_PA11H_GCLK_IO3                        (_UL_(1) << 11)
+
+#define PIN_PA17H_GCLK_IO3                         _L_(17)      /**< GCLK signal: IO3 on PA17 mux H*/
+#define MUX_PA17H_GCLK_IO3                         _L_(7)      
+#define PINMUX_PA17H_GCLK_IO3                      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
+#define PORT_PA17H_GCLK_IO3                        (_UL_(1) << 17)
+
+#define PIN_PA10H_GCLK_IO4                         _L_(10)      /**< GCLK signal: IO4 on PA10 mux H*/
+#define MUX_PA10H_GCLK_IO4                         _L_(7)      
+#define PINMUX_PA10H_GCLK_IO4                      ((PIN_PA10H_GCLK_IO4 << 16) | MUX_PA10H_GCLK_IO4)
+#define PORT_PA10H_GCLK_IO4                        (_UL_(1) << 10)
+
+/* ========== PORT definition for OPAMP peripheral ========== */
+#define PIN_PA02B_OPAMP_OANEG0                     _L_(2)       /**< OPAMP signal: OANEG0 on PA02 mux B*/
+#define MUX_PA02B_OPAMP_OANEG0                     _L_(1)      
+#define PINMUX_PA02B_OPAMP_OANEG0                  ((PIN_PA02B_OPAMP_OANEG0 << 16) | MUX_PA02B_OPAMP_OANEG0)
+#define PORT_PA02B_OPAMP_OANEG0                    (_UL_(1) << 2)
+
+#define PIN_PA00B_OPAMP_OANEG1                     _L_(0)       /**< OPAMP signal: OANEG1 on PA00 mux B*/
+#define MUX_PA00B_OPAMP_OANEG1                     _L_(1)      
+#define PINMUX_PA00B_OPAMP_OANEG1                  ((PIN_PA00B_OPAMP_OANEG1 << 16) | MUX_PA00B_OPAMP_OANEG1)
+#define PORT_PA00B_OPAMP_OANEG1                    (_UL_(1) << 0)
+
+#define PIN_PA03B_OPAMP_OANEG2                     _L_(3)       /**< OPAMP signal: OANEG2 on PA03 mux B*/
+#define MUX_PA03B_OPAMP_OANEG2                     _L_(1)      
+#define PINMUX_PA03B_OPAMP_OANEG2                  ((PIN_PA03B_OPAMP_OANEG2 << 16) | MUX_PA03B_OPAMP_OANEG2)
+#define PORT_PA03B_OPAMP_OANEG2                    (_UL_(1) << 3)
+
+#define PIN_PA07B_OPAMP_OAOUT0                     _L_(7)       /**< OPAMP signal: OAOUT0 on PA07 mux B*/
+#define MUX_PA07B_OPAMP_OAOUT0                     _L_(1)      
+#define PINMUX_PA07B_OPAMP_OAOUT0                  ((PIN_PA07B_OPAMP_OAOUT0 << 16) | MUX_PA07B_OPAMP_OAOUT0)
+#define PORT_PA07B_OPAMP_OAOUT0                    (_UL_(1) << 7)
+
+#define PIN_PA04B_OPAMP_OAOUT2                     _L_(4)       /**< OPAMP signal: OAOUT2 on PA04 mux B*/
+#define MUX_PA04B_OPAMP_OAOUT2                     _L_(1)      
+#define PINMUX_PA04B_OPAMP_OAOUT2                  ((PIN_PA04B_OPAMP_OAOUT2 << 16) | MUX_PA04B_OPAMP_OAOUT2)
+#define PORT_PA04B_OPAMP_OAOUT2                    (_UL_(1) << 4)
+
+#define PIN_PA06B_OPAMP_OAPOS0                     _L_(6)       /**< OPAMP signal: OAPOS0 on PA06 mux B*/
+#define MUX_PA06B_OPAMP_OAPOS0                     _L_(1)      
+#define PINMUX_PA06B_OPAMP_OAPOS0                  ((PIN_PA06B_OPAMP_OAPOS0 << 16) | MUX_PA06B_OPAMP_OAPOS0)
+#define PORT_PA06B_OPAMP_OAPOS0                    (_UL_(1) << 6)
+
+#define PIN_PA01B_OPAMP_OAPOS1                     _L_(1)       /**< OPAMP signal: OAPOS1 on PA01 mux B*/
+#define MUX_PA01B_OPAMP_OAPOS1                     _L_(1)      
+#define PINMUX_PA01B_OPAMP_OAPOS1                  ((PIN_PA01B_OPAMP_OAPOS1 << 16) | MUX_PA01B_OPAMP_OAPOS1)
+#define PORT_PA01B_OPAMP_OAPOS1                    (_UL_(1) << 1)
+
+#define PIN_PA05B_OPAMP_OAPOS2                     _L_(5)       /**< OPAMP signal: OAPOS2 on PA05 mux B*/
+#define MUX_PA05B_OPAMP_OAPOS2                     _L_(1)      
+#define PINMUX_PA05B_OPAMP_OAPOS2                  ((PIN_PA05B_OPAMP_OAPOS2 << 16) | MUX_PA05B_OPAMP_OAPOS2)
+#define PORT_PA05B_OPAMP_OAPOS2                    (_UL_(1) << 5)
+
+/* ========== PORT definition for PTC peripheral ========== */
+#define PIN_PA00F_PTC_DRV0                         _L_(0)       /**< PTC signal: DRV0 on PA00 mux F*/
+#define MUX_PA00F_PTC_DRV0                         _L_(5)      
+#define PINMUX_PA00F_PTC_DRV0                      ((PIN_PA00F_PTC_DRV0 << 16) | MUX_PA00F_PTC_DRV0)
+#define PORT_PA00F_PTC_DRV0                        (_UL_(1) << 0)
+
+#define PIN_PA01F_PTC_DRV1                         _L_(1)       /**< PTC signal: DRV1 on PA01 mux F*/
+#define MUX_PA01F_PTC_DRV1                         _L_(5)      
+#define PINMUX_PA01F_PTC_DRV1                      ((PIN_PA01F_PTC_DRV1 << 16) | MUX_PA01F_PTC_DRV1)
+#define PORT_PA01F_PTC_DRV1                        (_UL_(1) << 1)
+
+#define PIN_PA02F_PTC_DRV2                         _L_(2)       /**< PTC signal: DRV2 on PA02 mux F*/
+#define MUX_PA02F_PTC_DRV2                         _L_(5)      
+#define PINMUX_PA02F_PTC_DRV2                      ((PIN_PA02F_PTC_DRV2 << 16) | MUX_PA02F_PTC_DRV2)
+#define PORT_PA02F_PTC_DRV2                        (_UL_(1) << 2)
+
+#define PIN_PA03F_PTC_DRV3                         _L_(3)       /**< PTC signal: DRV3 on PA03 mux F*/
+#define MUX_PA03F_PTC_DRV3                         _L_(5)      
+#define PINMUX_PA03F_PTC_DRV3                      ((PIN_PA03F_PTC_DRV3 << 16) | MUX_PA03F_PTC_DRV3)
+#define PORT_PA03F_PTC_DRV3                        (_UL_(1) << 3)
+
+#define PIN_PA05F_PTC_DRV4                         _L_(5)       /**< PTC signal: DRV4 on PA05 mux F*/
+#define MUX_PA05F_PTC_DRV4                         _L_(5)      
+#define PINMUX_PA05F_PTC_DRV4                      ((PIN_PA05F_PTC_DRV4 << 16) | MUX_PA05F_PTC_DRV4)
+#define PORT_PA05F_PTC_DRV4                        (_UL_(1) << 5)
+
+#define PIN_PA06F_PTC_DRV5                         _L_(6)       /**< PTC signal: DRV5 on PA06 mux F*/
+#define MUX_PA06F_PTC_DRV5                         _L_(5)      
+#define PINMUX_PA06F_PTC_DRV5                      ((PIN_PA06F_PTC_DRV5 << 16) | MUX_PA06F_PTC_DRV5)
+#define PORT_PA06F_PTC_DRV5                        (_UL_(1) << 6)
+
+#define PIN_PA08F_PTC_DRV6                         _L_(8)       /**< PTC signal: DRV6 on PA08 mux F*/
+#define MUX_PA08F_PTC_DRV6                         _L_(5)      
+#define PINMUX_PA08F_PTC_DRV6                      ((PIN_PA08F_PTC_DRV6 << 16) | MUX_PA08F_PTC_DRV6)
+#define PORT_PA08F_PTC_DRV6                        (_UL_(1) << 8)
+
+#define PIN_PA09F_PTC_DRV7                         _L_(9)       /**< PTC signal: DRV7 on PA09 mux F*/
+#define MUX_PA09F_PTC_DRV7                         _L_(5)      
+#define PINMUX_PA09F_PTC_DRV7                      ((PIN_PA09F_PTC_DRV7 << 16) | MUX_PA09F_PTC_DRV7)
+#define PORT_PA09F_PTC_DRV7                        (_UL_(1) << 9)
+
+#define PIN_PA10F_PTC_DRV8                         _L_(10)      /**< PTC signal: DRV8 on PA10 mux F*/
+#define MUX_PA10F_PTC_DRV8                         _L_(5)      
+#define PINMUX_PA10F_PTC_DRV8                      ((PIN_PA10F_PTC_DRV8 << 16) | MUX_PA10F_PTC_DRV8)
+#define PORT_PA10F_PTC_DRV8                        (_UL_(1) << 10)
+
+#define PIN_PA11F_PTC_DRV9                         _L_(11)      /**< PTC signal: DRV9 on PA11 mux F*/
+#define MUX_PA11F_PTC_DRV9                         _L_(5)      
+#define PINMUX_PA11F_PTC_DRV9                      ((PIN_PA11F_PTC_DRV9 << 16) | MUX_PA11F_PTC_DRV9)
+#define PORT_PA11F_PTC_DRV9                        (_UL_(1) << 11)
+
+#define PIN_PA14F_PTC_DRV10                        _L_(14)      /**< PTC signal: DRV10 on PA14 mux F*/
+#define MUX_PA14F_PTC_DRV10                        _L_(5)      
+#define PINMUX_PA14F_PTC_DRV10                     ((PIN_PA14F_PTC_DRV10 << 16) | MUX_PA14F_PTC_DRV10)
+#define PORT_PA14F_PTC_DRV10                       (_UL_(1) << 14)
+
+#define PIN_PA15F_PTC_DRV11                        _L_(15)      /**< PTC signal: DRV11 on PA15 mux F*/
+#define MUX_PA15F_PTC_DRV11                        _L_(5)      
+#define PINMUX_PA15F_PTC_DRV11                     ((PIN_PA15F_PTC_DRV11 << 16) | MUX_PA15F_PTC_DRV11)
+#define PORT_PA15F_PTC_DRV11                       (_UL_(1) << 15)
+
+#define PIN_PA16F_PTC_DRV12                        _L_(16)      /**< PTC signal: DRV12 on PA16 mux F*/
+#define MUX_PA16F_PTC_DRV12                        _L_(5)      
+#define PINMUX_PA16F_PTC_DRV12                     ((PIN_PA16F_PTC_DRV12 << 16) | MUX_PA16F_PTC_DRV12)
+#define PORT_PA16F_PTC_DRV12                       (_UL_(1) << 16)
+
+#define PIN_PA17F_PTC_DRV13                        _L_(17)      /**< PTC signal: DRV13 on PA17 mux F*/
+#define MUX_PA17F_PTC_DRV13                        _L_(5)      
+#define PINMUX_PA17F_PTC_DRV13                     ((PIN_PA17F_PTC_DRV13 << 16) | MUX_PA17F_PTC_DRV13)
+#define PORT_PA17F_PTC_DRV13                       (_UL_(1) << 17)
+
+#define PIN_PA18F_PTC_DRV14                        _L_(18)      /**< PTC signal: DRV14 on PA18 mux F*/
+#define MUX_PA18F_PTC_DRV14                        _L_(5)      
+#define PINMUX_PA18F_PTC_DRV14                     ((PIN_PA18F_PTC_DRV14 << 16) | MUX_PA18F_PTC_DRV14)
+#define PORT_PA18F_PTC_DRV14                       (_UL_(1) << 18)
+
+#define PIN_PA19F_PTC_DRV15                        _L_(19)      /**< PTC signal: DRV15 on PA19 mux F*/
+#define MUX_PA19F_PTC_DRV15                        _L_(5)      
+#define PINMUX_PA19F_PTC_DRV15                     ((PIN_PA19F_PTC_DRV15 << 16) | MUX_PA19F_PTC_DRV15)
+#define PORT_PA19F_PTC_DRV15                       (_UL_(1) << 19)
+
+#define PIN_PA22F_PTC_DRV16                        _L_(22)      /**< PTC signal: DRV16 on PA22 mux F*/
+#define MUX_PA22F_PTC_DRV16                        _L_(5)      
+#define PINMUX_PA22F_PTC_DRV16                     ((PIN_PA22F_PTC_DRV16 << 16) | MUX_PA22F_PTC_DRV16)
+#define PORT_PA22F_PTC_DRV16                       (_UL_(1) << 22)
+
+#define PIN_PA23F_PTC_DRV17                        _L_(23)      /**< PTC signal: DRV17 on PA23 mux F*/
+#define MUX_PA23F_PTC_DRV17                        _L_(5)      
+#define PINMUX_PA23F_PTC_DRV17                     ((PIN_PA23F_PTC_DRV17 << 16) | MUX_PA23F_PTC_DRV17)
+#define PORT_PA23F_PTC_DRV17                       (_UL_(1) << 23)
+
+#define PIN_PA30F_PTC_DRV18                        _L_(30)      /**< PTC signal: DRV18 on PA30 mux F*/
+#define MUX_PA30F_PTC_DRV18                        _L_(5)      
+#define PINMUX_PA30F_PTC_DRV18                     ((PIN_PA30F_PTC_DRV18 << 16) | MUX_PA30F_PTC_DRV18)
+#define PORT_PA30F_PTC_DRV18                       (_UL_(1) << 30)
+
+#define PIN_PA31F_PTC_DRV19                        _L_(31)      /**< PTC signal: DRV19 on PA31 mux F*/
+#define MUX_PA31F_PTC_DRV19                        _L_(5)      
+#define PINMUX_PA31F_PTC_DRV19                     ((PIN_PA31F_PTC_DRV19 << 16) | MUX_PA31F_PTC_DRV19)
+#define PORT_PA31F_PTC_DRV19                       (_UL_(1) << 31)
+
+#define PIN_PA03B_PTC_ECI0                         _L_(3)       /**< PTC signal: ECI0 on PA03 mux B*/
+#define MUX_PA03B_PTC_ECI0                         _L_(1)      
+#define PINMUX_PA03B_PTC_ECI0                      ((PIN_PA03B_PTC_ECI0 << 16) | MUX_PA03B_PTC_ECI0)
+#define PORT_PA03B_PTC_ECI0                        (_UL_(1) << 3)
+
+#define PIN_PA04B_PTC_ECI1                         _L_(4)       /**< PTC signal: ECI1 on PA04 mux B*/
+#define MUX_PA04B_PTC_ECI1                         _L_(1)      
+#define PINMUX_PA04B_PTC_ECI1                      ((PIN_PA04B_PTC_ECI1 << 16) | MUX_PA04B_PTC_ECI1)
+#define PORT_PA04B_PTC_ECI1                        (_UL_(1) << 4)
+
+#define PIN_PA05B_PTC_ECI2                         _L_(5)       /**< PTC signal: ECI2 on PA05 mux B*/
+#define MUX_PA05B_PTC_ECI2                         _L_(1)      
+#define PINMUX_PA05B_PTC_ECI2                      ((PIN_PA05B_PTC_ECI2 << 16) | MUX_PA05B_PTC_ECI2)
+#define PORT_PA05B_PTC_ECI2                        (_UL_(1) << 5)
+
+#define PIN_PA06B_PTC_ECI3                         _L_(6)       /**< PTC signal: ECI3 on PA06 mux B*/
+#define MUX_PA06B_PTC_ECI3                         _L_(1)      
+#define PINMUX_PA06B_PTC_ECI3                      ((PIN_PA06B_PTC_ECI3 << 16) | MUX_PA06B_PTC_ECI3)
+#define PORT_PA06B_PTC_ECI3                        (_UL_(1) << 6)
+
+#define PIN_PA00B_PTC_X0                           _L_(0)       /**< PTC signal: X0 on PA00 mux B*/
+#define MUX_PA00B_PTC_X0                           _L_(1)      
+#define PINMUX_PA00B_PTC_X0                        ((PIN_PA00B_PTC_X0 << 16) | MUX_PA00B_PTC_X0)
+#define PORT_PA00B_PTC_X0                          (_UL_(1) << 0)
+
+#define PIN_PA00B_PTC_Y0                           _L_(0)       /**< PTC signal: Y0 on PA00 mux B*/
+#define MUX_PA00B_PTC_Y0                           _L_(1)      
+#define PINMUX_PA00B_PTC_Y0                        ((PIN_PA00B_PTC_Y0 << 16) | MUX_PA00B_PTC_Y0)
+#define PORT_PA00B_PTC_Y0                          (_UL_(1) << 0)
+
+#define PIN_PA01B_PTC_X1                           _L_(1)       /**< PTC signal: X1 on PA01 mux B*/
+#define MUX_PA01B_PTC_X1                           _L_(1)      
+#define PINMUX_PA01B_PTC_X1                        ((PIN_PA01B_PTC_X1 << 16) | MUX_PA01B_PTC_X1)
+#define PORT_PA01B_PTC_X1                          (_UL_(1) << 1)
+
+#define PIN_PA01B_PTC_Y1                           _L_(1)       /**< PTC signal: Y1 on PA01 mux B*/
+#define MUX_PA01B_PTC_Y1                           _L_(1)      
+#define PINMUX_PA01B_PTC_Y1                        ((PIN_PA01B_PTC_Y1 << 16) | MUX_PA01B_PTC_Y1)
+#define PORT_PA01B_PTC_Y1                          (_UL_(1) << 1)
+
+#define PIN_PA02B_PTC_X2                           _L_(2)       /**< PTC signal: X2 on PA02 mux B*/
+#define MUX_PA02B_PTC_X2                           _L_(1)      
+#define PINMUX_PA02B_PTC_X2                        ((PIN_PA02B_PTC_X2 << 16) | MUX_PA02B_PTC_X2)
+#define PORT_PA02B_PTC_X2                          (_UL_(1) << 2)
+
+#define PIN_PA02B_PTC_Y2                           _L_(2)       /**< PTC signal: Y2 on PA02 mux B*/
+#define MUX_PA02B_PTC_Y2                           _L_(1)      
+#define PINMUX_PA02B_PTC_Y2                        ((PIN_PA02B_PTC_Y2 << 16) | MUX_PA02B_PTC_Y2)
+#define PORT_PA02B_PTC_Y2                          (_UL_(1) << 2)
+
+#define PIN_PA03B_PTC_X3                           _L_(3)       /**< PTC signal: X3 on PA03 mux B*/
+#define MUX_PA03B_PTC_X3                           _L_(1)      
+#define PINMUX_PA03B_PTC_X3                        ((PIN_PA03B_PTC_X3 << 16) | MUX_PA03B_PTC_X3)
+#define PORT_PA03B_PTC_X3                          (_UL_(1) << 3)
+
+#define PIN_PA03B_PTC_Y3                           _L_(3)       /**< PTC signal: Y3 on PA03 mux B*/
+#define MUX_PA03B_PTC_Y3                           _L_(1)      
+#define PINMUX_PA03B_PTC_Y3                        ((PIN_PA03B_PTC_Y3 << 16) | MUX_PA03B_PTC_Y3)
+#define PORT_PA03B_PTC_Y3                          (_UL_(1) << 3)
+
+#define PIN_PA05B_PTC_X4                           _L_(5)       /**< PTC signal: X4 on PA05 mux B*/
+#define MUX_PA05B_PTC_X4                           _L_(1)      
+#define PINMUX_PA05B_PTC_X4                        ((PIN_PA05B_PTC_X4 << 16) | MUX_PA05B_PTC_X4)
+#define PORT_PA05B_PTC_X4                          (_UL_(1) << 5)
+
+#define PIN_PA05B_PTC_Y4                           _L_(5)       /**< PTC signal: Y4 on PA05 mux B*/
+#define MUX_PA05B_PTC_Y4                           _L_(1)      
+#define PINMUX_PA05B_PTC_Y4                        ((PIN_PA05B_PTC_Y4 << 16) | MUX_PA05B_PTC_Y4)
+#define PORT_PA05B_PTC_Y4                          (_UL_(1) << 5)
+
+#define PIN_PA06B_PTC_X5                           _L_(6)       /**< PTC signal: X5 on PA06 mux B*/
+#define MUX_PA06B_PTC_X5                           _L_(1)      
+#define PINMUX_PA06B_PTC_X5                        ((PIN_PA06B_PTC_X5 << 16) | MUX_PA06B_PTC_X5)
+#define PORT_PA06B_PTC_X5                          (_UL_(1) << 6)
+
+#define PIN_PA06B_PTC_Y5                           _L_(6)       /**< PTC signal: Y5 on PA06 mux B*/
+#define MUX_PA06B_PTC_Y5                           _L_(1)      
+#define PINMUX_PA06B_PTC_Y5                        ((PIN_PA06B_PTC_Y5 << 16) | MUX_PA06B_PTC_Y5)
+#define PORT_PA06B_PTC_Y5                          (_UL_(1) << 6)
+
+#define PIN_PA08B_PTC_X6                           _L_(8)       /**< PTC signal: X6 on PA08 mux B*/
+#define MUX_PA08B_PTC_X6                           _L_(1)      
+#define PINMUX_PA08B_PTC_X6                        ((PIN_PA08B_PTC_X6 << 16) | MUX_PA08B_PTC_X6)
+#define PORT_PA08B_PTC_X6                          (_UL_(1) << 8)
+
+#define PIN_PA08B_PTC_Y6                           _L_(8)       /**< PTC signal: Y6 on PA08 mux B*/
+#define MUX_PA08B_PTC_Y6                           _L_(1)      
+#define PINMUX_PA08B_PTC_Y6                        ((PIN_PA08B_PTC_Y6 << 16) | MUX_PA08B_PTC_Y6)
+#define PORT_PA08B_PTC_Y6                          (_UL_(1) << 8)
+
+#define PIN_PA09B_PTC_X7                           _L_(9)       /**< PTC signal: X7 on PA09 mux B*/
+#define MUX_PA09B_PTC_X7                           _L_(1)      
+#define PINMUX_PA09B_PTC_X7                        ((PIN_PA09B_PTC_X7 << 16) | MUX_PA09B_PTC_X7)
+#define PORT_PA09B_PTC_X7                          (_UL_(1) << 9)
+
+#define PIN_PA09B_PTC_Y7                           _L_(9)       /**< PTC signal: Y7 on PA09 mux B*/
+#define MUX_PA09B_PTC_Y7                           _L_(1)      
+#define PINMUX_PA09B_PTC_Y7                        ((PIN_PA09B_PTC_Y7 << 16) | MUX_PA09B_PTC_Y7)
+#define PORT_PA09B_PTC_Y7                          (_UL_(1) << 9)
+
+#define PIN_PA10B_PTC_X8                           _L_(10)      /**< PTC signal: X8 on PA10 mux B*/
+#define MUX_PA10B_PTC_X8                           _L_(1)      
+#define PINMUX_PA10B_PTC_X8                        ((PIN_PA10B_PTC_X8 << 16) | MUX_PA10B_PTC_X8)
+#define PORT_PA10B_PTC_X8                          (_UL_(1) << 10)
+
+#define PIN_PA10B_PTC_Y8                           _L_(10)      /**< PTC signal: Y8 on PA10 mux B*/
+#define MUX_PA10B_PTC_Y8                           _L_(1)      
+#define PINMUX_PA10B_PTC_Y8                        ((PIN_PA10B_PTC_Y8 << 16) | MUX_PA10B_PTC_Y8)
+#define PORT_PA10B_PTC_Y8                          (_UL_(1) << 10)
+
+#define PIN_PA11B_PTC_X9                           _L_(11)      /**< PTC signal: X9 on PA11 mux B*/
+#define MUX_PA11B_PTC_X9                           _L_(1)      
+#define PINMUX_PA11B_PTC_X9                        ((PIN_PA11B_PTC_X9 << 16) | MUX_PA11B_PTC_X9)
+#define PORT_PA11B_PTC_X9                          (_UL_(1) << 11)
+
+#define PIN_PA11B_PTC_Y9                           _L_(11)      /**< PTC signal: Y9 on PA11 mux B*/
+#define MUX_PA11B_PTC_Y9                           _L_(1)      
+#define PINMUX_PA11B_PTC_Y9                        ((PIN_PA11B_PTC_Y9 << 16) | MUX_PA11B_PTC_Y9)
+#define PORT_PA11B_PTC_Y9                          (_UL_(1) << 11)
+
+#define PIN_PA14B_PTC_X10                          _L_(14)      /**< PTC signal: X10 on PA14 mux B*/
+#define MUX_PA14B_PTC_X10                          _L_(1)      
+#define PINMUX_PA14B_PTC_X10                       ((PIN_PA14B_PTC_X10 << 16) | MUX_PA14B_PTC_X10)
+#define PORT_PA14B_PTC_X10                         (_UL_(1) << 14)
+
+#define PIN_PA14B_PTC_Y10                          _L_(14)      /**< PTC signal: Y10 on PA14 mux B*/
+#define MUX_PA14B_PTC_Y10                          _L_(1)      
+#define PINMUX_PA14B_PTC_Y10                       ((PIN_PA14B_PTC_Y10 << 16) | MUX_PA14B_PTC_Y10)
+#define PORT_PA14B_PTC_Y10                         (_UL_(1) << 14)
+
+#define PIN_PA15B_PTC_X11                          _L_(15)      /**< PTC signal: X11 on PA15 mux B*/
+#define MUX_PA15B_PTC_X11                          _L_(1)      
+#define PINMUX_PA15B_PTC_X11                       ((PIN_PA15B_PTC_X11 << 16) | MUX_PA15B_PTC_X11)
+#define PORT_PA15B_PTC_X11                         (_UL_(1) << 15)
+
+#define PIN_PA15B_PTC_Y11                          _L_(15)      /**< PTC signal: Y11 on PA15 mux B*/
+#define MUX_PA15B_PTC_Y11                          _L_(1)      
+#define PINMUX_PA15B_PTC_Y11                       ((PIN_PA15B_PTC_Y11 << 16) | MUX_PA15B_PTC_Y11)
+#define PORT_PA15B_PTC_Y11                         (_UL_(1) << 15)
+
+#define PIN_PA16B_PTC_X12                          _L_(16)      /**< PTC signal: X12 on PA16 mux B*/
+#define MUX_PA16B_PTC_X12                          _L_(1)      
+#define PINMUX_PA16B_PTC_X12                       ((PIN_PA16B_PTC_X12 << 16) | MUX_PA16B_PTC_X12)
+#define PORT_PA16B_PTC_X12                         (_UL_(1) << 16)
+
+#define PIN_PA16B_PTC_Y12                          _L_(16)      /**< PTC signal: Y12 on PA16 mux B*/
+#define MUX_PA16B_PTC_Y12                          _L_(1)      
+#define PINMUX_PA16B_PTC_Y12                       ((PIN_PA16B_PTC_Y12 << 16) | MUX_PA16B_PTC_Y12)
+#define PORT_PA16B_PTC_Y12                         (_UL_(1) << 16)
+
+#define PIN_PA17B_PTC_X13                          _L_(17)      /**< PTC signal: X13 on PA17 mux B*/
+#define MUX_PA17B_PTC_X13                          _L_(1)      
+#define PINMUX_PA17B_PTC_X13                       ((PIN_PA17B_PTC_X13 << 16) | MUX_PA17B_PTC_X13)
+#define PORT_PA17B_PTC_X13                         (_UL_(1) << 17)
+
+#define PIN_PA17B_PTC_Y13                          _L_(17)      /**< PTC signal: Y13 on PA17 mux B*/
+#define MUX_PA17B_PTC_Y13                          _L_(1)      
+#define PINMUX_PA17B_PTC_Y13                       ((PIN_PA17B_PTC_Y13 << 16) | MUX_PA17B_PTC_Y13)
+#define PORT_PA17B_PTC_Y13                         (_UL_(1) << 17)
+
+#define PIN_PA18B_PTC_X14                          _L_(18)      /**< PTC signal: X14 on PA18 mux B*/
+#define MUX_PA18B_PTC_X14                          _L_(1)      
+#define PINMUX_PA18B_PTC_X14                       ((PIN_PA18B_PTC_X14 << 16) | MUX_PA18B_PTC_X14)
+#define PORT_PA18B_PTC_X14                         (_UL_(1) << 18)
+
+#define PIN_PA18B_PTC_Y14                          _L_(18)      /**< PTC signal: Y14 on PA18 mux B*/
+#define MUX_PA18B_PTC_Y14                          _L_(1)      
+#define PINMUX_PA18B_PTC_Y14                       ((PIN_PA18B_PTC_Y14 << 16) | MUX_PA18B_PTC_Y14)
+#define PORT_PA18B_PTC_Y14                         (_UL_(1) << 18)
+
+#define PIN_PA19B_PTC_X15                          _L_(19)      /**< PTC signal: X15 on PA19 mux B*/
+#define MUX_PA19B_PTC_X15                          _L_(1)      
+#define PINMUX_PA19B_PTC_X15                       ((PIN_PA19B_PTC_X15 << 16) | MUX_PA19B_PTC_X15)
+#define PORT_PA19B_PTC_X15                         (_UL_(1) << 19)
+
+#define PIN_PA19B_PTC_Y15                          _L_(19)      /**< PTC signal: Y15 on PA19 mux B*/
+#define MUX_PA19B_PTC_Y15                          _L_(1)      
+#define PINMUX_PA19B_PTC_Y15                       ((PIN_PA19B_PTC_Y15 << 16) | MUX_PA19B_PTC_Y15)
+#define PORT_PA19B_PTC_Y15                         (_UL_(1) << 19)
+
+#define PIN_PA22B_PTC_X16                          _L_(22)      /**< PTC signal: X16 on PA22 mux B*/
+#define MUX_PA22B_PTC_X16                          _L_(1)      
+#define PINMUX_PA22B_PTC_X16                       ((PIN_PA22B_PTC_X16 << 16) | MUX_PA22B_PTC_X16)
+#define PORT_PA22B_PTC_X16                         (_UL_(1) << 22)
+
+#define PIN_PA22B_PTC_Y16                          _L_(22)      /**< PTC signal: Y16 on PA22 mux B*/
+#define MUX_PA22B_PTC_Y16                          _L_(1)      
+#define PINMUX_PA22B_PTC_Y16                       ((PIN_PA22B_PTC_Y16 << 16) | MUX_PA22B_PTC_Y16)
+#define PORT_PA22B_PTC_Y16                         (_UL_(1) << 22)
+
+#define PIN_PA23B_PTC_X17                          _L_(23)      /**< PTC signal: X17 on PA23 mux B*/
+#define MUX_PA23B_PTC_X17                          _L_(1)      
+#define PINMUX_PA23B_PTC_X17                       ((PIN_PA23B_PTC_X17 << 16) | MUX_PA23B_PTC_X17)
+#define PORT_PA23B_PTC_X17                         (_UL_(1) << 23)
+
+#define PIN_PA23B_PTC_Y17                          _L_(23)      /**< PTC signal: Y17 on PA23 mux B*/
+#define MUX_PA23B_PTC_Y17                          _L_(1)      
+#define PINMUX_PA23B_PTC_Y17                       ((PIN_PA23B_PTC_Y17 << 16) | MUX_PA23B_PTC_Y17)
+#define PORT_PA23B_PTC_Y17                         (_UL_(1) << 23)
+
+#define PIN_PA30B_PTC_X18                          _L_(30)      /**< PTC signal: X18 on PA30 mux B*/
+#define MUX_PA30B_PTC_X18                          _L_(1)      
+#define PINMUX_PA30B_PTC_X18                       ((PIN_PA30B_PTC_X18 << 16) | MUX_PA30B_PTC_X18)
+#define PORT_PA30B_PTC_X18                         (_UL_(1) << 30)
+
+#define PIN_PA30B_PTC_Y18                          _L_(30)      /**< PTC signal: Y18 on PA30 mux B*/
+#define MUX_PA30B_PTC_Y18                          _L_(1)      
+#define PINMUX_PA30B_PTC_Y18                       ((PIN_PA30B_PTC_Y18 << 16) | MUX_PA30B_PTC_Y18)
+#define PORT_PA30B_PTC_Y18                         (_UL_(1) << 30)
+
+#define PIN_PA31B_PTC_X19                          _L_(31)      /**< PTC signal: X19 on PA31 mux B*/
+#define MUX_PA31B_PTC_X19                          _L_(1)      
+#define PINMUX_PA31B_PTC_X19                       ((PIN_PA31B_PTC_X19 << 16) | MUX_PA31B_PTC_X19)
+#define PORT_PA31B_PTC_X19                         (_UL_(1) << 31)
+
+#define PIN_PA31B_PTC_Y19                          _L_(31)      /**< PTC signal: Y19 on PA31 mux B*/
+#define MUX_PA31B_PTC_Y19                          _L_(1)      
+#define PINMUX_PA31B_PTC_Y19                       ((PIN_PA31B_PTC_Y19 << 16) | MUX_PA31B_PTC_Y19)
+#define PORT_PA31B_PTC_Y19                         (_UL_(1) << 31)
+
+/* ========== PORT definition for RTC peripheral ========== */
+#define PIN_PA08G_RTC_IN0                          _L_(8)       /**< RTC signal: IN0 on PA08 mux G*/
+#define MUX_PA08G_RTC_IN0                          _L_(6)      
+#define PINMUX_PA08G_RTC_IN0                       ((PIN_PA08G_RTC_IN0 << 16) | MUX_PA08G_RTC_IN0)
+#define PORT_PA08G_RTC_IN0                         (_UL_(1) << 8)
+
+#define PIN_PA09G_RTC_IN1                          _L_(9)       /**< RTC signal: IN1 on PA09 mux G*/
+#define MUX_PA09G_RTC_IN1                          _L_(6)      
+#define PINMUX_PA09G_RTC_IN1                       ((PIN_PA09G_RTC_IN1 << 16) | MUX_PA09G_RTC_IN1)
+#define PORT_PA09G_RTC_IN1                         (_UL_(1) << 9)
+
+#define PIN_PA16G_RTC_IN2                          _L_(16)      /**< RTC signal: IN2 on PA16 mux G*/
+#define MUX_PA16G_RTC_IN2                          _L_(6)      
+#define PINMUX_PA16G_RTC_IN2                       ((PIN_PA16G_RTC_IN2 << 16) | MUX_PA16G_RTC_IN2)
+#define PORT_PA16G_RTC_IN2                         (_UL_(1) << 16)
+
+#define PIN_PA17G_RTC_IN3                          _L_(17)      /**< RTC signal: IN3 on PA17 mux G*/
+#define MUX_PA17G_RTC_IN3                          _L_(6)      
+#define PINMUX_PA17G_RTC_IN3                       ((PIN_PA17G_RTC_IN3 << 16) | MUX_PA17G_RTC_IN3)
+#define PORT_PA17G_RTC_IN3                         (_UL_(1) << 17)
+
+#define PIN_PA18G_RTC_OUT0                         _L_(18)      /**< RTC signal: OUT0 on PA18 mux G*/
+#define MUX_PA18G_RTC_OUT0                         _L_(6)      
+#define PINMUX_PA18G_RTC_OUT0                      ((PIN_PA18G_RTC_OUT0 << 16) | MUX_PA18G_RTC_OUT0)
+#define PORT_PA18G_RTC_OUT0                        (_UL_(1) << 18)
+
+#define PIN_PA19G_RTC_OUT1                         _L_(19)      /**< RTC signal: OUT1 on PA19 mux G*/
+#define MUX_PA19G_RTC_OUT1                         _L_(6)      
+#define PINMUX_PA19G_RTC_OUT1                      ((PIN_PA19G_RTC_OUT1 << 16) | MUX_PA19G_RTC_OUT1)
+#define PORT_PA19G_RTC_OUT1                        (_UL_(1) << 19)
+
+#define PIN_PA22G_RTC_OUT2                         _L_(22)      /**< RTC signal: OUT2 on PA22 mux G*/
+#define MUX_PA22G_RTC_OUT2                         _L_(6)      
+#define PINMUX_PA22G_RTC_OUT2                      ((PIN_PA22G_RTC_OUT2 << 16) | MUX_PA22G_RTC_OUT2)
+#define PORT_PA22G_RTC_OUT2                        (_UL_(1) << 22)
+
+#define PIN_PA23G_RTC_OUT3                         _L_(23)      /**< RTC signal: OUT3 on PA23 mux G*/
+#define MUX_PA23G_RTC_OUT3                         _L_(6)      
+#define PINMUX_PA23G_RTC_OUT3                      ((PIN_PA23G_RTC_OUT3 << 16) | MUX_PA23G_RTC_OUT3)
+#define PORT_PA23G_RTC_OUT3                        (_UL_(1) << 23)
+
+/* ========== PORT definition for SERCOM0 peripheral ========== */
+#define PIN_PA04D_SERCOM0_PAD0                     _L_(4)       /**< SERCOM0 signal: PAD0 on PA04 mux D*/
+#define MUX_PA04D_SERCOM0_PAD0                     _L_(3)      
+#define PINMUX_PA04D_SERCOM0_PAD0                  ((PIN_PA04D_SERCOM0_PAD0 << 16) | MUX_PA04D_SERCOM0_PAD0)
+#define PORT_PA04D_SERCOM0_PAD0                    (_UL_(1) << 4)
+
+#define PIN_PA16D_SERCOM0_PAD0                     _L_(16)      /**< SERCOM0 signal: PAD0 on PA16 mux D*/
+#define MUX_PA16D_SERCOM0_PAD0                     _L_(3)      
+#define PINMUX_PA16D_SERCOM0_PAD0                  ((PIN_PA16D_SERCOM0_PAD0 << 16) | MUX_PA16D_SERCOM0_PAD0)
+#define PORT_PA16D_SERCOM0_PAD0                    (_UL_(1) << 16)
+
+#define PIN_PA22C_SERCOM0_PAD0                     _L_(22)      /**< SERCOM0 signal: PAD0 on PA22 mux C*/
+#define MUX_PA22C_SERCOM0_PAD0                     _L_(2)      
+#define PINMUX_PA22C_SERCOM0_PAD0                  ((PIN_PA22C_SERCOM0_PAD0 << 16) | MUX_PA22C_SERCOM0_PAD0)
+#define PORT_PA22C_SERCOM0_PAD0                    (_UL_(1) << 22)
+
+#define PIN_PA05D_SERCOM0_PAD1                     _L_(5)       /**< SERCOM0 signal: PAD1 on PA05 mux D*/
+#define MUX_PA05D_SERCOM0_PAD1                     _L_(3)      
+#define PINMUX_PA05D_SERCOM0_PAD1                  ((PIN_PA05D_SERCOM0_PAD1 << 16) | MUX_PA05D_SERCOM0_PAD1)
+#define PORT_PA05D_SERCOM0_PAD1                    (_UL_(1) << 5)
+
+#define PIN_PA17D_SERCOM0_PAD1                     _L_(17)      /**< SERCOM0 signal: PAD1 on PA17 mux D*/
+#define MUX_PA17D_SERCOM0_PAD1                     _L_(3)      
+#define PINMUX_PA17D_SERCOM0_PAD1                  ((PIN_PA17D_SERCOM0_PAD1 << 16) | MUX_PA17D_SERCOM0_PAD1)
+#define PORT_PA17D_SERCOM0_PAD1                    (_UL_(1) << 17)
+
+#define PIN_PA23C_SERCOM0_PAD1                     _L_(23)      /**< SERCOM0 signal: PAD1 on PA23 mux C*/
+#define MUX_PA23C_SERCOM0_PAD1                     _L_(2)      
+#define PINMUX_PA23C_SERCOM0_PAD1                  ((PIN_PA23C_SERCOM0_PAD1 << 16) | MUX_PA23C_SERCOM0_PAD1)
+#define PORT_PA23C_SERCOM0_PAD1                    (_UL_(1) << 23)
+
+#define PIN_PA06D_SERCOM0_PAD2                     _L_(6)       /**< SERCOM0 signal: PAD2 on PA06 mux D*/
+#define MUX_PA06D_SERCOM0_PAD2                     _L_(3)      
+#define PINMUX_PA06D_SERCOM0_PAD2                  ((PIN_PA06D_SERCOM0_PAD2 << 16) | MUX_PA06D_SERCOM0_PAD2)
+#define PORT_PA06D_SERCOM0_PAD2                    (_UL_(1) << 6)
+
+#define PIN_PA14D_SERCOM0_PAD2                     _L_(14)      /**< SERCOM0 signal: PAD2 on PA14 mux D*/
+#define MUX_PA14D_SERCOM0_PAD2                     _L_(3)      
+#define PINMUX_PA14D_SERCOM0_PAD2                  ((PIN_PA14D_SERCOM0_PAD2 << 16) | MUX_PA14D_SERCOM0_PAD2)
+#define PORT_PA14D_SERCOM0_PAD2                    (_UL_(1) << 14)
+
+#define PIN_PA18D_SERCOM0_PAD2                     _L_(18)      /**< SERCOM0 signal: PAD2 on PA18 mux D*/
+#define MUX_PA18D_SERCOM0_PAD2                     _L_(3)      
+#define PINMUX_PA18D_SERCOM0_PAD2                  ((PIN_PA18D_SERCOM0_PAD2 << 16) | MUX_PA18D_SERCOM0_PAD2)
+#define PORT_PA18D_SERCOM0_PAD2                    (_UL_(1) << 18)
+
+#define PIN_PA24C_SERCOM0_PAD2                     _L_(24)      /**< SERCOM0 signal: PAD2 on PA24 mux C*/
+#define MUX_PA24C_SERCOM0_PAD2                     _L_(2)      
+#define PINMUX_PA24C_SERCOM0_PAD2                  ((PIN_PA24C_SERCOM0_PAD2 << 16) | MUX_PA24C_SERCOM0_PAD2)
+#define PORT_PA24C_SERCOM0_PAD2                    (_UL_(1) << 24)
+
+#define PIN_PA02D_SERCOM0_PAD2                     _L_(2)       /**< SERCOM0 signal: PAD2 on PA02 mux D*/
+#define MUX_PA02D_SERCOM0_PAD2                     _L_(3)      
+#define PINMUX_PA02D_SERCOM0_PAD2                  ((PIN_PA02D_SERCOM0_PAD2 << 16) | MUX_PA02D_SERCOM0_PAD2)
+#define PORT_PA02D_SERCOM0_PAD2                    (_UL_(1) << 2)
+
+#define PIN_PA07D_SERCOM0_PAD3                     _L_(7)       /**< SERCOM0 signal: PAD3 on PA07 mux D*/
+#define MUX_PA07D_SERCOM0_PAD3                     _L_(3)      
+#define PINMUX_PA07D_SERCOM0_PAD3                  ((PIN_PA07D_SERCOM0_PAD3 << 16) | MUX_PA07D_SERCOM0_PAD3)
+#define PORT_PA07D_SERCOM0_PAD3                    (_UL_(1) << 7)
+
+#define PIN_PA15D_SERCOM0_PAD3                     _L_(15)      /**< SERCOM0 signal: PAD3 on PA15 mux D*/
+#define MUX_PA15D_SERCOM0_PAD3                     _L_(3)      
+#define PINMUX_PA15D_SERCOM0_PAD3                  ((PIN_PA15D_SERCOM0_PAD3 << 16) | MUX_PA15D_SERCOM0_PAD3)
+#define PORT_PA15D_SERCOM0_PAD3                    (_UL_(1) << 15)
+
+#define PIN_PA19D_SERCOM0_PAD3                     _L_(19)      /**< SERCOM0 signal: PAD3 on PA19 mux D*/
+#define MUX_PA19D_SERCOM0_PAD3                     _L_(3)      
+#define PINMUX_PA19D_SERCOM0_PAD3                  ((PIN_PA19D_SERCOM0_PAD3 << 16) | MUX_PA19D_SERCOM0_PAD3)
+#define PORT_PA19D_SERCOM0_PAD3                    (_UL_(1) << 19)
+
+#define PIN_PA25C_SERCOM0_PAD3                     _L_(25)      /**< SERCOM0 signal: PAD3 on PA25 mux C*/
+#define MUX_PA25C_SERCOM0_PAD3                     _L_(2)      
+#define PINMUX_PA25C_SERCOM0_PAD3                  ((PIN_PA25C_SERCOM0_PAD3 << 16) | MUX_PA25C_SERCOM0_PAD3)
+#define PORT_PA25C_SERCOM0_PAD3                    (_UL_(1) << 25)
+
+#define PIN_PA03D_SERCOM0_PAD3                     _L_(3)       /**< SERCOM0 signal: PAD3 on PA03 mux D*/
+#define MUX_PA03D_SERCOM0_PAD3                     _L_(3)      
+#define PINMUX_PA03D_SERCOM0_PAD3                  ((PIN_PA03D_SERCOM0_PAD3 << 16) | MUX_PA03D_SERCOM0_PAD3)
+#define PORT_PA03D_SERCOM0_PAD3                    (_UL_(1) << 3)
+
+/* ========== PORT definition for SERCOM1 peripheral ========== */
+#define PIN_PA16C_SERCOM1_PAD0                     _L_(16)      /**< SERCOM1 signal: PAD0 on PA16 mux C*/
+#define MUX_PA16C_SERCOM1_PAD0                     _L_(2)      
+#define PINMUX_PA16C_SERCOM1_PAD0                  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
+#define PORT_PA16C_SERCOM1_PAD0                    (_UL_(1) << 16)
+
+#define PIN_PA08C_SERCOM1_PAD0                     _L_(8)       /**< SERCOM1 signal: PAD0 on PA08 mux C*/
+#define MUX_PA08C_SERCOM1_PAD0                     _L_(2)      
+#define PINMUX_PA08C_SERCOM1_PAD0                  ((PIN_PA08C_SERCOM1_PAD0 << 16) | MUX_PA08C_SERCOM1_PAD0)
+#define PORT_PA08C_SERCOM1_PAD0                    (_UL_(1) << 8)
+
+#define PIN_PA00D_SERCOM1_PAD0                     _L_(0)       /**< SERCOM1 signal: PAD0 on PA00 mux D*/
+#define MUX_PA00D_SERCOM1_PAD0                     _L_(3)      
+#define PINMUX_PA00D_SERCOM1_PAD0                  ((PIN_PA00D_SERCOM1_PAD0 << 16) | MUX_PA00D_SERCOM1_PAD0)
+#define PORT_PA00D_SERCOM1_PAD0                    (_UL_(1) << 0)
+
+#define PIN_PA17C_SERCOM1_PAD1                     _L_(17)      /**< SERCOM1 signal: PAD1 on PA17 mux C*/
+#define MUX_PA17C_SERCOM1_PAD1                     _L_(2)      
+#define PINMUX_PA17C_SERCOM1_PAD1                  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
+#define PORT_PA17C_SERCOM1_PAD1                    (_UL_(1) << 17)
+
+#define PIN_PA09C_SERCOM1_PAD1                     _L_(9)       /**< SERCOM1 signal: PAD1 on PA09 mux C*/
+#define MUX_PA09C_SERCOM1_PAD1                     _L_(2)      
+#define PINMUX_PA09C_SERCOM1_PAD1                  ((PIN_PA09C_SERCOM1_PAD1 << 16) | MUX_PA09C_SERCOM1_PAD1)
+#define PORT_PA09C_SERCOM1_PAD1                    (_UL_(1) << 9)
+
+#define PIN_PA01D_SERCOM1_PAD1                     _L_(1)       /**< SERCOM1 signal: PAD1 on PA01 mux D*/
+#define MUX_PA01D_SERCOM1_PAD1                     _L_(3)      
+#define PINMUX_PA01D_SERCOM1_PAD1                  ((PIN_PA01D_SERCOM1_PAD1 << 16) | MUX_PA01D_SERCOM1_PAD1)
+#define PORT_PA01D_SERCOM1_PAD1                    (_UL_(1) << 1)
+
+#define PIN_PA18C_SERCOM1_PAD2                     _L_(18)      /**< SERCOM1 signal: PAD2 on PA18 mux C*/
+#define MUX_PA18C_SERCOM1_PAD2                     _L_(2)      
+#define PINMUX_PA18C_SERCOM1_PAD2                  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
+#define PORT_PA18C_SERCOM1_PAD2                    (_UL_(1) << 18)
+
+#define PIN_PA10C_SERCOM1_PAD2                     _L_(10)      /**< SERCOM1 signal: PAD2 on PA10 mux C*/
+#define MUX_PA10C_SERCOM1_PAD2                     _L_(2)      
+#define PINMUX_PA10C_SERCOM1_PAD2                  ((PIN_PA10C_SERCOM1_PAD2 << 16) | MUX_PA10C_SERCOM1_PAD2)
+#define PORT_PA10C_SERCOM1_PAD2                    (_UL_(1) << 10)
+
+#define PIN_PA30D_SERCOM1_PAD2                     _L_(30)      /**< SERCOM1 signal: PAD2 on PA30 mux D*/
+#define MUX_PA30D_SERCOM1_PAD2                     _L_(3)      
+#define PINMUX_PA30D_SERCOM1_PAD2                  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
+#define PORT_PA30D_SERCOM1_PAD2                    (_UL_(1) << 30)
+
+#define PIN_PA19C_SERCOM1_PAD3                     _L_(19)      /**< SERCOM1 signal: PAD3 on PA19 mux C*/
+#define MUX_PA19C_SERCOM1_PAD3                     _L_(2)      
+#define PINMUX_PA19C_SERCOM1_PAD3                  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
+#define PORT_PA19C_SERCOM1_PAD3                    (_UL_(1) << 19)
+
+#define PIN_PA11C_SERCOM1_PAD3                     _L_(11)      /**< SERCOM1 signal: PAD3 on PA11 mux C*/
+#define MUX_PA11C_SERCOM1_PAD3                     _L_(2)      
+#define PINMUX_PA11C_SERCOM1_PAD3                  ((PIN_PA11C_SERCOM1_PAD3 << 16) | MUX_PA11C_SERCOM1_PAD3)
+#define PORT_PA11C_SERCOM1_PAD3                    (_UL_(1) << 11)
+
+#define PIN_PA31D_SERCOM1_PAD3                     _L_(31)      /**< SERCOM1 signal: PAD3 on PA31 mux D*/
+#define MUX_PA31D_SERCOM1_PAD3                     _L_(3)      
+#define PINMUX_PA31D_SERCOM1_PAD3                  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
+#define PORT_PA31D_SERCOM1_PAD3                    (_UL_(1) << 31)
+
+/* ========== PORT definition for SERCOM2 peripheral ========== */
+#define PIN_PA08D_SERCOM2_PAD0                     _L_(8)       /**< SERCOM2 signal: PAD0 on PA08 mux D*/
+#define MUX_PA08D_SERCOM2_PAD0                     _L_(3)      
+#define PINMUX_PA08D_SERCOM2_PAD0                  ((PIN_PA08D_SERCOM2_PAD0 << 16) | MUX_PA08D_SERCOM2_PAD0)
+#define PORT_PA08D_SERCOM2_PAD0                    (_UL_(1) << 8)
+
+#define PIN_PA22D_SERCOM2_PAD0                     _L_(22)      /**< SERCOM2 signal: PAD0 on PA22 mux D*/
+#define MUX_PA22D_SERCOM2_PAD0                     _L_(3)      
+#define PINMUX_PA22D_SERCOM2_PAD0                  ((PIN_PA22D_SERCOM2_PAD0 << 16) | MUX_PA22D_SERCOM2_PAD0)
+#define PORT_PA22D_SERCOM2_PAD0                    (_UL_(1) << 22)
+
+#define PIN_PA09D_SERCOM2_PAD1                     _L_(9)       /**< SERCOM2 signal: PAD1 on PA09 mux D*/
+#define MUX_PA09D_SERCOM2_PAD1                     _L_(3)      
+#define PINMUX_PA09D_SERCOM2_PAD1                  ((PIN_PA09D_SERCOM2_PAD1 << 16) | MUX_PA09D_SERCOM2_PAD1)
+#define PORT_PA09D_SERCOM2_PAD1                    (_UL_(1) << 9)
+
+#define PIN_PA23D_SERCOM2_PAD1                     _L_(23)      /**< SERCOM2 signal: PAD1 on PA23 mux D*/
+#define MUX_PA23D_SERCOM2_PAD1                     _L_(3)      
+#define PINMUX_PA23D_SERCOM2_PAD1                  ((PIN_PA23D_SERCOM2_PAD1 << 16) | MUX_PA23D_SERCOM2_PAD1)
+#define PORT_PA23D_SERCOM2_PAD1                    (_UL_(1) << 23)
+
+#define PIN_PA10D_SERCOM2_PAD2                     _L_(10)      /**< SERCOM2 signal: PAD2 on PA10 mux D*/
+#define MUX_PA10D_SERCOM2_PAD2                     _L_(3)      
+#define PINMUX_PA10D_SERCOM2_PAD2                  ((PIN_PA10D_SERCOM2_PAD2 << 16) | MUX_PA10D_SERCOM2_PAD2)
+#define PORT_PA10D_SERCOM2_PAD2                    (_UL_(1) << 10)
+
+#define PIN_PA24D_SERCOM2_PAD2                     _L_(24)      /**< SERCOM2 signal: PAD2 on PA24 mux D*/
+#define MUX_PA24D_SERCOM2_PAD2                     _L_(3)      
+#define PINMUX_PA24D_SERCOM2_PAD2                  ((PIN_PA24D_SERCOM2_PAD2 << 16) | MUX_PA24D_SERCOM2_PAD2)
+#define PORT_PA24D_SERCOM2_PAD2                    (_UL_(1) << 24)
+
+#define PIN_PA14C_SERCOM2_PAD2                     _L_(14)      /**< SERCOM2 signal: PAD2 on PA14 mux C*/
+#define MUX_PA14C_SERCOM2_PAD2                     _L_(2)      
+#define PINMUX_PA14C_SERCOM2_PAD2                  ((PIN_PA14C_SERCOM2_PAD2 << 16) | MUX_PA14C_SERCOM2_PAD2)
+#define PORT_PA14C_SERCOM2_PAD2                    (_UL_(1) << 14)
+
+#define PIN_PA11D_SERCOM2_PAD3                     _L_(11)      /**< SERCOM2 signal: PAD3 on PA11 mux D*/
+#define MUX_PA11D_SERCOM2_PAD3                     _L_(3)      
+#define PINMUX_PA11D_SERCOM2_PAD3                  ((PIN_PA11D_SERCOM2_PAD3 << 16) | MUX_PA11D_SERCOM2_PAD3)
+#define PORT_PA11D_SERCOM2_PAD3                    (_UL_(1) << 11)
+
+#define PIN_PA25D_SERCOM2_PAD3                     _L_(25)      /**< SERCOM2 signal: PAD3 on PA25 mux D*/
+#define MUX_PA25D_SERCOM2_PAD3                     _L_(3)      
+#define PINMUX_PA25D_SERCOM2_PAD3                  ((PIN_PA25D_SERCOM2_PAD3 << 16) | MUX_PA25D_SERCOM2_PAD3)
+#define PORT_PA25D_SERCOM2_PAD3                    (_UL_(1) << 25)
+
+#define PIN_PA15C_SERCOM2_PAD3                     _L_(15)      /**< SERCOM2 signal: PAD3 on PA15 mux C*/
+#define MUX_PA15C_SERCOM2_PAD3                     _L_(2)      
+#define PINMUX_PA15C_SERCOM2_PAD3                  ((PIN_PA15C_SERCOM2_PAD3 << 16) | MUX_PA15C_SERCOM2_PAD3)
+#define PORT_PA15C_SERCOM2_PAD3                    (_UL_(1) << 15)
+
+/* ========== PORT definition for TC0 peripheral ========== */
+#define PIN_PA04E_TC0_WO0                          _L_(4)       /**< TC0 signal: WO0 on PA04 mux E*/
+#define MUX_PA04E_TC0_WO0                          _L_(4)      
+#define PINMUX_PA04E_TC0_WO0                       ((PIN_PA04E_TC0_WO0 << 16) | MUX_PA04E_TC0_WO0)
+#define PORT_PA04E_TC0_WO0                         (_UL_(1) << 4)
+
+#define PIN_PA14E_TC0_WO0                          _L_(14)      /**< TC0 signal: WO0 on PA14 mux E*/
+#define MUX_PA14E_TC0_WO0                          _L_(4)      
+#define PINMUX_PA14E_TC0_WO0                       ((PIN_PA14E_TC0_WO0 << 16) | MUX_PA14E_TC0_WO0)
+#define PORT_PA14E_TC0_WO0                         (_UL_(1) << 14)
+
+#define PIN_PA22E_TC0_WO0                          _L_(22)      /**< TC0 signal: WO0 on PA22 mux E*/
+#define MUX_PA22E_TC0_WO0                          _L_(4)      
+#define PINMUX_PA22E_TC0_WO0                       ((PIN_PA22E_TC0_WO0 << 16) | MUX_PA22E_TC0_WO0)
+#define PORT_PA22E_TC0_WO0                         (_UL_(1) << 22)
+
+#define PIN_PA05E_TC0_WO1                          _L_(5)       /**< TC0 signal: WO1 on PA05 mux E*/
+#define MUX_PA05E_TC0_WO1                          _L_(4)      
+#define PINMUX_PA05E_TC0_WO1                       ((PIN_PA05E_TC0_WO1 << 16) | MUX_PA05E_TC0_WO1)
+#define PORT_PA05E_TC0_WO1                         (_UL_(1) << 5)
+
+#define PIN_PA15E_TC0_WO1                          _L_(15)      /**< TC0 signal: WO1 on PA15 mux E*/
+#define MUX_PA15E_TC0_WO1                          _L_(4)      
+#define PINMUX_PA15E_TC0_WO1                       ((PIN_PA15E_TC0_WO1 << 16) | MUX_PA15E_TC0_WO1)
+#define PORT_PA15E_TC0_WO1                         (_UL_(1) << 15)
+
+#define PIN_PA23E_TC0_WO1                          _L_(23)      /**< TC0 signal: WO1 on PA23 mux E*/
+#define MUX_PA23E_TC0_WO1                          _L_(4)      
+#define PINMUX_PA23E_TC0_WO1                       ((PIN_PA23E_TC0_WO1 << 16) | MUX_PA23E_TC0_WO1)
+#define PORT_PA23E_TC0_WO1                         (_UL_(1) << 23)
+
+/* ========== PORT definition for TC1 peripheral ========== */
+#define PIN_PA06E_TC1_WO0                          _L_(6)       /**< TC1 signal: WO0 on PA06 mux E*/
+#define MUX_PA06E_TC1_WO0                          _L_(4)      
+#define PINMUX_PA06E_TC1_WO0                       ((PIN_PA06E_TC1_WO0 << 16) | MUX_PA06E_TC1_WO0)
+#define PORT_PA06E_TC1_WO0                         (_UL_(1) << 6)
+
+#define PIN_PA24E_TC1_WO0                          _L_(24)      /**< TC1 signal: WO0 on PA24 mux E*/
+#define MUX_PA24E_TC1_WO0                          _L_(4)      
+#define PINMUX_PA24E_TC1_WO0                       ((PIN_PA24E_TC1_WO0 << 16) | MUX_PA24E_TC1_WO0)
+#define PORT_PA24E_TC1_WO0                         (_UL_(1) << 24)
+
+#define PIN_PA30E_TC1_WO0                          _L_(30)      /**< TC1 signal: WO0 on PA30 mux E*/
+#define MUX_PA30E_TC1_WO0                          _L_(4)      
+#define PINMUX_PA30E_TC1_WO0                       ((PIN_PA30E_TC1_WO0 << 16) | MUX_PA30E_TC1_WO0)
+#define PORT_PA30E_TC1_WO0                         (_UL_(1) << 30)
+
+#define PIN_PA07E_TC1_WO1                          _L_(7)       /**< TC1 signal: WO1 on PA07 mux E*/
+#define MUX_PA07E_TC1_WO1                          _L_(4)      
+#define PINMUX_PA07E_TC1_WO1                       ((PIN_PA07E_TC1_WO1 << 16) | MUX_PA07E_TC1_WO1)
+#define PORT_PA07E_TC1_WO1                         (_UL_(1) << 7)
+
+#define PIN_PA25E_TC1_WO1                          _L_(25)      /**< TC1 signal: WO1 on PA25 mux E*/
+#define MUX_PA25E_TC1_WO1                          _L_(4)      
+#define PINMUX_PA25E_TC1_WO1                       ((PIN_PA25E_TC1_WO1 << 16) | MUX_PA25E_TC1_WO1)
+#define PORT_PA25E_TC1_WO1                         (_UL_(1) << 25)
+
+#define PIN_PA31E_TC1_WO1                          _L_(31)      /**< TC1 signal: WO1 on PA31 mux E*/
+#define MUX_PA31E_TC1_WO1                          _L_(4)      
+#define PINMUX_PA31E_TC1_WO1                       ((PIN_PA31E_TC1_WO1 << 16) | MUX_PA31E_TC1_WO1)
+#define PORT_PA31E_TC1_WO1                         (_UL_(1) << 31)
+
+/* ========== PORT definition for TC2 peripheral ========== */
+#define PIN_PA00E_TC2_WO0                          _L_(0)       /**< TC2 signal: WO0 on PA00 mux E*/
+#define MUX_PA00E_TC2_WO0                          _L_(4)      
+#define PINMUX_PA00E_TC2_WO0                       ((PIN_PA00E_TC2_WO0 << 16) | MUX_PA00E_TC2_WO0)
+#define PORT_PA00E_TC2_WO0                         (_UL_(1) << 0)
+
+#define PIN_PA18E_TC2_WO0                          _L_(18)      /**< TC2 signal: WO0 on PA18 mux E*/
+#define MUX_PA18E_TC2_WO0                          _L_(4)      
+#define PINMUX_PA18E_TC2_WO0                       ((PIN_PA18E_TC2_WO0 << 16) | MUX_PA18E_TC2_WO0)
+#define PORT_PA18E_TC2_WO0                         (_UL_(1) << 18)
+
+#define PIN_PA01E_TC2_WO1                          _L_(1)       /**< TC2 signal: WO1 on PA01 mux E*/
+#define MUX_PA01E_TC2_WO1                          _L_(4)      
+#define PINMUX_PA01E_TC2_WO1                       ((PIN_PA01E_TC2_WO1 << 16) | MUX_PA01E_TC2_WO1)
+#define PORT_PA01E_TC2_WO1                         (_UL_(1) << 1)
+
+#define PIN_PA19E_TC2_WO1                          _L_(19)      /**< TC2 signal: WO1 on PA19 mux E*/
+#define MUX_PA19E_TC2_WO1                          _L_(4)      
+#define PINMUX_PA19E_TC2_WO1                       ((PIN_PA19E_TC2_WO1 << 16) | MUX_PA19E_TC2_WO1)
+#define PORT_PA19E_TC2_WO1                         (_UL_(1) << 19)
+
+
+#endif /* _SAML10E14A_PIO_H_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/pio/saml10e15a.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/pio/saml10e15a.h
@@ -1,0 +1,1167 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAML10E15A
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10E15A_PIO_H_
+#define _SAML10E15A_PIO_H_
+
+/* ========== Peripheral I/O pin numbers ========== */
+#define PIN_PA00                    (  0)  /**< Pin Number for PA00 */
+#define PIN_PA01                    (  1)  /**< Pin Number for PA01 */
+#define PIN_PA02                    (  2)  /**< Pin Number for PA02 */
+#define PIN_PA03                    (  3)  /**< Pin Number for PA03 */
+#define PIN_PA04                    (  4)  /**< Pin Number for PA04 */
+#define PIN_PA05                    (  5)  /**< Pin Number for PA05 */
+#define PIN_PA06                    (  6)  /**< Pin Number for PA06 */
+#define PIN_PA07                    (  7)  /**< Pin Number for PA07 */
+#define PIN_PA08                    (  8)  /**< Pin Number for PA08 */
+#define PIN_PA09                    (  9)  /**< Pin Number for PA09 */
+#define PIN_PA10                    ( 10)  /**< Pin Number for PA10 */
+#define PIN_PA11                    ( 11)  /**< Pin Number for PA11 */
+#define PIN_PA14                    ( 14)  /**< Pin Number for PA14 */
+#define PIN_PA15                    ( 15)  /**< Pin Number for PA15 */
+#define PIN_PA16                    ( 16)  /**< Pin Number for PA16 */
+#define PIN_PA17                    ( 17)  /**< Pin Number for PA17 */
+#define PIN_PA18                    ( 18)  /**< Pin Number for PA18 */
+#define PIN_PA19                    ( 19)  /**< Pin Number for PA19 */
+#define PIN_PA22                    ( 22)  /**< Pin Number for PA22 */
+#define PIN_PA23                    ( 23)  /**< Pin Number for PA23 */
+#define PIN_PA24                    ( 24)  /**< Pin Number for PA24 */
+#define PIN_PA25                    ( 25)  /**< Pin Number for PA25 */
+#define PIN_PA27                    ( 27)  /**< Pin Number for PA27 */
+#define PIN_PA30                    ( 30)  /**< Pin Number for PA30 */
+#define PIN_PA31                    ( 31)  /**< Pin Number for PA31 */
+
+
+/* ========== Peripheral I/O masks ========== */
+#define PORT_PA00                   (_U_(1) << 0) /**< PORT Mask for PA00 */
+#define PORT_PA01                   (_U_(1) << 1) /**< PORT Mask for PA01 */
+#define PORT_PA02                   (_U_(1) << 2) /**< PORT Mask for PA02 */
+#define PORT_PA03                   (_U_(1) << 3) /**< PORT Mask for PA03 */
+#define PORT_PA04                   (_U_(1) << 4) /**< PORT Mask for PA04 */
+#define PORT_PA05                   (_U_(1) << 5) /**< PORT Mask for PA05 */
+#define PORT_PA06                   (_U_(1) << 6) /**< PORT Mask for PA06 */
+#define PORT_PA07                   (_U_(1) << 7) /**< PORT Mask for PA07 */
+#define PORT_PA08                   (_U_(1) << 8) /**< PORT Mask for PA08 */
+#define PORT_PA09                   (_U_(1) << 9) /**< PORT Mask for PA09 */
+#define PORT_PA10                   (_U_(1) << 10) /**< PORT Mask for PA10 */
+#define PORT_PA11                   (_U_(1) << 11) /**< PORT Mask for PA11 */
+#define PORT_PA14                   (_U_(1) << 14) /**< PORT Mask for PA14 */
+#define PORT_PA15                   (_U_(1) << 15) /**< PORT Mask for PA15 */
+#define PORT_PA16                   (_U_(1) << 16) /**< PORT Mask for PA16 */
+#define PORT_PA17                   (_U_(1) << 17) /**< PORT Mask for PA17 */
+#define PORT_PA18                   (_U_(1) << 18) /**< PORT Mask for PA18 */
+#define PORT_PA19                   (_U_(1) << 19) /**< PORT Mask for PA19 */
+#define PORT_PA22                   (_U_(1) << 22) /**< PORT Mask for PA22 */
+#define PORT_PA23                   (_U_(1) << 23) /**< PORT Mask for PA23 */
+#define PORT_PA24                   (_U_(1) << 24) /**< PORT Mask for PA24 */
+#define PORT_PA25                   (_U_(1) << 25) /**< PORT Mask for PA25 */
+#define PORT_PA27                   (_U_(1) << 27) /**< PORT Mask for PA27 */
+#define PORT_PA30                   (_U_(1) << 30) /**< PORT Mask for PA30 */
+#define PORT_PA31                   (_U_(1) << 31) /**< PORT Mask for PA31 */
+
+
+/* ========== Peripheral I/O indexes ========== */
+#define PORT_PA00_IDX               (  0)  /**< PORT Index Number for PA00 */
+#define PORT_PA01_IDX               (  1)  /**< PORT Index Number for PA01 */
+#define PORT_PA02_IDX               (  2)  /**< PORT Index Number for PA02 */
+#define PORT_PA03_IDX               (  3)  /**< PORT Index Number for PA03 */
+#define PORT_PA04_IDX               (  4)  /**< PORT Index Number for PA04 */
+#define PORT_PA05_IDX               (  5)  /**< PORT Index Number for PA05 */
+#define PORT_PA06_IDX               (  6)  /**< PORT Index Number for PA06 */
+#define PORT_PA07_IDX               (  7)  /**< PORT Index Number for PA07 */
+#define PORT_PA08_IDX               (  8)  /**< PORT Index Number for PA08 */
+#define PORT_PA09_IDX               (  9)  /**< PORT Index Number for PA09 */
+#define PORT_PA10_IDX               ( 10)  /**< PORT Index Number for PA10 */
+#define PORT_PA11_IDX               ( 11)  /**< PORT Index Number for PA11 */
+#define PORT_PA14_IDX               ( 14)  /**< PORT Index Number for PA14 */
+#define PORT_PA15_IDX               ( 15)  /**< PORT Index Number for PA15 */
+#define PORT_PA16_IDX               ( 16)  /**< PORT Index Number for PA16 */
+#define PORT_PA17_IDX               ( 17)  /**< PORT Index Number for PA17 */
+#define PORT_PA18_IDX               ( 18)  /**< PORT Index Number for PA18 */
+#define PORT_PA19_IDX               ( 19)  /**< PORT Index Number for PA19 */
+#define PORT_PA22_IDX               ( 22)  /**< PORT Index Number for PA22 */
+#define PORT_PA23_IDX               ( 23)  /**< PORT Index Number for PA23 */
+#define PORT_PA24_IDX               ( 24)  /**< PORT Index Number for PA24 */
+#define PORT_PA25_IDX               ( 25)  /**< PORT Index Number for PA25 */
+#define PORT_PA27_IDX               ( 27)  /**< PORT Index Number for PA27 */
+#define PORT_PA30_IDX               ( 30)  /**< PORT Index Number for PA30 */
+#define PORT_PA31_IDX               ( 31)  /**< PORT Index Number for PA31 */
+
+/* ========== PORT definition for AC peripheral ========== */
+#define PIN_PA04B_AC_AIN0                          _L_(4)       /**< AC signal: AIN0 on PA04 mux B*/
+#define MUX_PA04B_AC_AIN0                          _L_(1)      
+#define PINMUX_PA04B_AC_AIN0                       ((PIN_PA04B_AC_AIN0 << 16) | MUX_PA04B_AC_AIN0)
+#define PORT_PA04B_AC_AIN0                         (_UL_(1) << 4)
+
+#define PIN_PA05B_AC_AIN1                          _L_(5)       /**< AC signal: AIN1 on PA05 mux B*/
+#define MUX_PA05B_AC_AIN1                          _L_(1)      
+#define PINMUX_PA05B_AC_AIN1                       ((PIN_PA05B_AC_AIN1 << 16) | MUX_PA05B_AC_AIN1)
+#define PORT_PA05B_AC_AIN1                         (_UL_(1) << 5)
+
+#define PIN_PA06B_AC_AIN2                          _L_(6)       /**< AC signal: AIN2 on PA06 mux B*/
+#define MUX_PA06B_AC_AIN2                          _L_(1)      
+#define PINMUX_PA06B_AC_AIN2                       ((PIN_PA06B_AC_AIN2 << 16) | MUX_PA06B_AC_AIN2)
+#define PORT_PA06B_AC_AIN2                         (_UL_(1) << 6)
+
+#define PIN_PA07B_AC_AIN3                          _L_(7)       /**< AC signal: AIN3 on PA07 mux B*/
+#define MUX_PA07B_AC_AIN3                          _L_(1)      
+#define PINMUX_PA07B_AC_AIN3                       ((PIN_PA07B_AC_AIN3 << 16) | MUX_PA07B_AC_AIN3)
+#define PORT_PA07B_AC_AIN3                         (_UL_(1) << 7)
+
+#define PIN_PA18H_AC_CMP0                          _L_(18)      /**< AC signal: CMP0 on PA18 mux H*/
+#define MUX_PA18H_AC_CMP0                          _L_(7)      
+#define PINMUX_PA18H_AC_CMP0                       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
+#define PORT_PA18H_AC_CMP0                         (_UL_(1) << 18)
+
+#define PIN_PA19H_AC_CMP1                          _L_(19)      /**< AC signal: CMP1 on PA19 mux H*/
+#define MUX_PA19H_AC_CMP1                          _L_(7)      
+#define PINMUX_PA19H_AC_CMP1                       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
+#define PORT_PA19H_AC_CMP1                         (_UL_(1) << 19)
+
+/* ========== PORT definition for ADC peripheral ========== */
+#define PIN_PA02B_ADC_AIN0                         _L_(2)       /**< ADC signal: AIN0 on PA02 mux B*/
+#define MUX_PA02B_ADC_AIN0                         _L_(1)      
+#define PINMUX_PA02B_ADC_AIN0                      ((PIN_PA02B_ADC_AIN0 << 16) | MUX_PA02B_ADC_AIN0)
+#define PORT_PA02B_ADC_AIN0                        (_UL_(1) << 2)
+
+#define PIN_PA03B_ADC_AIN1                         _L_(3)       /**< ADC signal: AIN1 on PA03 mux B*/
+#define MUX_PA03B_ADC_AIN1                         _L_(1)      
+#define PINMUX_PA03B_ADC_AIN1                      ((PIN_PA03B_ADC_AIN1 << 16) | MUX_PA03B_ADC_AIN1)
+#define PORT_PA03B_ADC_AIN1                        (_UL_(1) << 3)
+
+#define PIN_PA04B_ADC_AIN2                         _L_(4)       /**< ADC signal: AIN2 on PA04 mux B*/
+#define MUX_PA04B_ADC_AIN2                         _L_(1)      
+#define PINMUX_PA04B_ADC_AIN2                      ((PIN_PA04B_ADC_AIN2 << 16) | MUX_PA04B_ADC_AIN2)
+#define PORT_PA04B_ADC_AIN2                        (_UL_(1) << 4)
+
+#define PIN_PA05B_ADC_AIN3                         _L_(5)       /**< ADC signal: AIN3 on PA05 mux B*/
+#define MUX_PA05B_ADC_AIN3                         _L_(1)      
+#define PINMUX_PA05B_ADC_AIN3                      ((PIN_PA05B_ADC_AIN3 << 16) | MUX_PA05B_ADC_AIN3)
+#define PORT_PA05B_ADC_AIN3                        (_UL_(1) << 5)
+
+#define PIN_PA06B_ADC_AIN4                         _L_(6)       /**< ADC signal: AIN4 on PA06 mux B*/
+#define MUX_PA06B_ADC_AIN4                         _L_(1)      
+#define PINMUX_PA06B_ADC_AIN4                      ((PIN_PA06B_ADC_AIN4 << 16) | MUX_PA06B_ADC_AIN4)
+#define PORT_PA06B_ADC_AIN4                        (_UL_(1) << 6)
+
+#define PIN_PA07B_ADC_AIN5                         _L_(7)       /**< ADC signal: AIN5 on PA07 mux B*/
+#define MUX_PA07B_ADC_AIN5                         _L_(1)      
+#define PINMUX_PA07B_ADC_AIN5                      ((PIN_PA07B_ADC_AIN5 << 16) | MUX_PA07B_ADC_AIN5)
+#define PORT_PA07B_ADC_AIN5                        (_UL_(1) << 7)
+
+#define PIN_PA08B_ADC_AIN6                         _L_(8)       /**< ADC signal: AIN6 on PA08 mux B*/
+#define MUX_PA08B_ADC_AIN6                         _L_(1)      
+#define PINMUX_PA08B_ADC_AIN6                      ((PIN_PA08B_ADC_AIN6 << 16) | MUX_PA08B_ADC_AIN6)
+#define PORT_PA08B_ADC_AIN6                        (_UL_(1) << 8)
+
+#define PIN_PA09B_ADC_AIN7                         _L_(9)       /**< ADC signal: AIN7 on PA09 mux B*/
+#define MUX_PA09B_ADC_AIN7                         _L_(1)      
+#define PINMUX_PA09B_ADC_AIN7                      ((PIN_PA09B_ADC_AIN7 << 16) | MUX_PA09B_ADC_AIN7)
+#define PORT_PA09B_ADC_AIN7                        (_UL_(1) << 9)
+
+#define PIN_PA10B_ADC_AIN8                         _L_(10)      /**< ADC signal: AIN8 on PA10 mux B*/
+#define MUX_PA10B_ADC_AIN8                         _L_(1)      
+#define PINMUX_PA10B_ADC_AIN8                      ((PIN_PA10B_ADC_AIN8 << 16) | MUX_PA10B_ADC_AIN8)
+#define PORT_PA10B_ADC_AIN8                        (_UL_(1) << 10)
+
+#define PIN_PA11B_ADC_AIN9                         _L_(11)      /**< ADC signal: AIN9 on PA11 mux B*/
+#define MUX_PA11B_ADC_AIN9                         _L_(1)      
+#define PINMUX_PA11B_ADC_AIN9                      ((PIN_PA11B_ADC_AIN9 << 16) | MUX_PA11B_ADC_AIN9)
+#define PORT_PA11B_ADC_AIN9                        (_UL_(1) << 11)
+
+#define PIN_PA04B_ADC_VREFP                        _L_(4)       /**< ADC signal: VREFP on PA04 mux B*/
+#define MUX_PA04B_ADC_VREFP                        _L_(1)      
+#define PINMUX_PA04B_ADC_VREFP                     ((PIN_PA04B_ADC_VREFP << 16) | MUX_PA04B_ADC_VREFP)
+#define PORT_PA04B_ADC_VREFP                       (_UL_(1) << 4)
+
+/* ========== PORT definition for CCL peripheral ========== */
+#define PIN_PA04I_CCL_IN0                          _L_(4)       /**< CCL signal: IN0 on PA04 mux I*/
+#define MUX_PA04I_CCL_IN0                          _L_(8)      
+#define PINMUX_PA04I_CCL_IN0                       ((PIN_PA04I_CCL_IN0 << 16) | MUX_PA04I_CCL_IN0)
+#define PORT_PA04I_CCL_IN0                         (_UL_(1) << 4)
+
+#define PIN_PA16I_CCL_IN0                          _L_(16)      /**< CCL signal: IN0 on PA16 mux I*/
+#define MUX_PA16I_CCL_IN0                          _L_(8)      
+#define PINMUX_PA16I_CCL_IN0                       ((PIN_PA16I_CCL_IN0 << 16) | MUX_PA16I_CCL_IN0)
+#define PORT_PA16I_CCL_IN0                         (_UL_(1) << 16)
+
+#define PIN_PA05I_CCL_IN1                          _L_(5)       /**< CCL signal: IN1 on PA05 mux I*/
+#define MUX_PA05I_CCL_IN1                          _L_(8)      
+#define PINMUX_PA05I_CCL_IN1                       ((PIN_PA05I_CCL_IN1 << 16) | MUX_PA05I_CCL_IN1)
+#define PORT_PA05I_CCL_IN1                         (_UL_(1) << 5)
+
+#define PIN_PA17I_CCL_IN1                          _L_(17)      /**< CCL signal: IN1 on PA17 mux I*/
+#define MUX_PA17I_CCL_IN1                          _L_(8)      
+#define PINMUX_PA17I_CCL_IN1                       ((PIN_PA17I_CCL_IN1 << 16) | MUX_PA17I_CCL_IN1)
+#define PORT_PA17I_CCL_IN1                         (_UL_(1) << 17)
+
+#define PIN_PA06I_CCL_IN2                          _L_(6)       /**< CCL signal: IN2 on PA06 mux I*/
+#define MUX_PA06I_CCL_IN2                          _L_(8)      
+#define PINMUX_PA06I_CCL_IN2                       ((PIN_PA06I_CCL_IN2 << 16) | MUX_PA06I_CCL_IN2)
+#define PORT_PA06I_CCL_IN2                         (_UL_(1) << 6)
+
+#define PIN_PA18I_CCL_IN2                          _L_(18)      /**< CCL signal: IN2 on PA18 mux I*/
+#define MUX_PA18I_CCL_IN2                          _L_(8)      
+#define PINMUX_PA18I_CCL_IN2                       ((PIN_PA18I_CCL_IN2 << 16) | MUX_PA18I_CCL_IN2)
+#define PORT_PA18I_CCL_IN2                         (_UL_(1) << 18)
+
+#define PIN_PA08I_CCL_IN3                          _L_(8)       /**< CCL signal: IN3 on PA08 mux I*/
+#define MUX_PA08I_CCL_IN3                          _L_(8)      
+#define PINMUX_PA08I_CCL_IN3                       ((PIN_PA08I_CCL_IN3 << 16) | MUX_PA08I_CCL_IN3)
+#define PORT_PA08I_CCL_IN3                         (_UL_(1) << 8)
+
+#define PIN_PA30I_CCL_IN3                          _L_(30)      /**< CCL signal: IN3 on PA30 mux I*/
+#define MUX_PA30I_CCL_IN3                          _L_(8)      
+#define PINMUX_PA30I_CCL_IN3                       ((PIN_PA30I_CCL_IN3 << 16) | MUX_PA30I_CCL_IN3)
+#define PORT_PA30I_CCL_IN3                         (_UL_(1) << 30)
+
+#define PIN_PA09I_CCL_IN4                          _L_(9)       /**< CCL signal: IN4 on PA09 mux I*/
+#define MUX_PA09I_CCL_IN4                          _L_(8)      
+#define PINMUX_PA09I_CCL_IN4                       ((PIN_PA09I_CCL_IN4 << 16) | MUX_PA09I_CCL_IN4)
+#define PORT_PA09I_CCL_IN4                         (_UL_(1) << 9)
+
+#define PIN_PA10I_CCL_IN5                          _L_(10)      /**< CCL signal: IN5 on PA10 mux I*/
+#define MUX_PA10I_CCL_IN5                          _L_(8)      
+#define PINMUX_PA10I_CCL_IN5                       ((PIN_PA10I_CCL_IN5 << 16) | MUX_PA10I_CCL_IN5)
+#define PORT_PA10I_CCL_IN5                         (_UL_(1) << 10)
+
+#define PIN_PA07I_CCL_OUT0                         _L_(7)       /**< CCL signal: OUT0 on PA07 mux I*/
+#define MUX_PA07I_CCL_OUT0                         _L_(8)      
+#define PINMUX_PA07I_CCL_OUT0                      ((PIN_PA07I_CCL_OUT0 << 16) | MUX_PA07I_CCL_OUT0)
+#define PORT_PA07I_CCL_OUT0                        (_UL_(1) << 7)
+
+#define PIN_PA19I_CCL_OUT0                         _L_(19)      /**< CCL signal: OUT0 on PA19 mux I*/
+#define MUX_PA19I_CCL_OUT0                         _L_(8)      
+#define PINMUX_PA19I_CCL_OUT0                      ((PIN_PA19I_CCL_OUT0 << 16) | MUX_PA19I_CCL_OUT0)
+#define PORT_PA19I_CCL_OUT0                        (_UL_(1) << 19)
+
+#define PIN_PA11I_CCL_OUT1                         _L_(11)      /**< CCL signal: OUT1 on PA11 mux I*/
+#define MUX_PA11I_CCL_OUT1                         _L_(8)      
+#define PINMUX_PA11I_CCL_OUT1                      ((PIN_PA11I_CCL_OUT1 << 16) | MUX_PA11I_CCL_OUT1)
+#define PORT_PA11I_CCL_OUT1                        (_UL_(1) << 11)
+
+#define PIN_PA31I_CCL_OUT1                         _L_(31)      /**< CCL signal: OUT1 on PA31 mux I*/
+#define MUX_PA31I_CCL_OUT1                         _L_(8)      
+#define PINMUX_PA31I_CCL_OUT1                      ((PIN_PA31I_CCL_OUT1 << 16) | MUX_PA31I_CCL_OUT1)
+#define PORT_PA31I_CCL_OUT1                        (_UL_(1) << 31)
+
+/* ========== PORT definition for DAC peripheral ========== */
+#define PIN_PA02B_DAC_VOUT                         _L_(2)       /**< DAC signal: VOUT on PA02 mux B*/
+#define MUX_PA02B_DAC_VOUT                         _L_(1)      
+#define PINMUX_PA02B_DAC_VOUT                      ((PIN_PA02B_DAC_VOUT << 16) | MUX_PA02B_DAC_VOUT)
+#define PORT_PA02B_DAC_VOUT                        (_UL_(1) << 2)
+
+#define PIN_PA03B_DAC_VREFP                        _L_(3)       /**< DAC signal: VREFP on PA03 mux B*/
+#define MUX_PA03B_DAC_VREFP                        _L_(1)      
+#define PINMUX_PA03B_DAC_VREFP                     ((PIN_PA03B_DAC_VREFP << 16) | MUX_PA03B_DAC_VREFP)
+#define PORT_PA03B_DAC_VREFP                       (_UL_(1) << 3)
+
+/* ========== PORT definition for EIC peripheral ========== */
+#define PIN_PA09A_EIC_EXTINT0                      _L_(9)       /**< EIC signal: EXTINT0 on PA09 mux A*/
+#define MUX_PA09A_EIC_EXTINT0                      _L_(0)      
+#define PINMUX_PA09A_EIC_EXTINT0                   ((PIN_PA09A_EIC_EXTINT0 << 16) | MUX_PA09A_EIC_EXTINT0)
+#define PORT_PA09A_EIC_EXTINT0                     (_UL_(1) << 9)
+#define PIN_PA09A_EIC_EXTINT_NUM                   _L_(0)       /**< EIC signal: PIN_PA09 External Interrupt Line */
+
+#define PIN_PA19A_EIC_EXTINT0                      _L_(19)      /**< EIC signal: EXTINT0 on PA19 mux A*/
+#define MUX_PA19A_EIC_EXTINT0                      _L_(0)      
+#define PINMUX_PA19A_EIC_EXTINT0                   ((PIN_PA19A_EIC_EXTINT0 << 16) | MUX_PA19A_EIC_EXTINT0)
+#define PORT_PA19A_EIC_EXTINT0                     (_UL_(1) << 19)
+#define PIN_PA19A_EIC_EXTINT_NUM                   _L_(0)       /**< EIC signal: PIN_PA19 External Interrupt Line */
+
+#define PIN_PA00A_EIC_EXTINT0                      _L_(0)       /**< EIC signal: EXTINT0 on PA00 mux A*/
+#define MUX_PA00A_EIC_EXTINT0                      _L_(0)      
+#define PINMUX_PA00A_EIC_EXTINT0                   ((PIN_PA00A_EIC_EXTINT0 << 16) | MUX_PA00A_EIC_EXTINT0)
+#define PORT_PA00A_EIC_EXTINT0                     (_UL_(1) << 0)
+#define PIN_PA00A_EIC_EXTINT_NUM                   _L_(0)       /**< EIC signal: PIN_PA00 External Interrupt Line */
+
+#define PIN_PA10A_EIC_EXTINT1                      _L_(10)      /**< EIC signal: EXTINT1 on PA10 mux A*/
+#define MUX_PA10A_EIC_EXTINT1                      _L_(0)      
+#define PINMUX_PA10A_EIC_EXTINT1                   ((PIN_PA10A_EIC_EXTINT1 << 16) | MUX_PA10A_EIC_EXTINT1)
+#define PORT_PA10A_EIC_EXTINT1                     (_UL_(1) << 10)
+#define PIN_PA10A_EIC_EXTINT_NUM                   _L_(1)       /**< EIC signal: PIN_PA10 External Interrupt Line */
+
+#define PIN_PA22A_EIC_EXTINT1                      _L_(22)      /**< EIC signal: EXTINT1 on PA22 mux A*/
+#define MUX_PA22A_EIC_EXTINT1                      _L_(0)      
+#define PINMUX_PA22A_EIC_EXTINT1                   ((PIN_PA22A_EIC_EXTINT1 << 16) | MUX_PA22A_EIC_EXTINT1)
+#define PORT_PA22A_EIC_EXTINT1                     (_UL_(1) << 22)
+#define PIN_PA22A_EIC_EXTINT_NUM                   _L_(1)       /**< EIC signal: PIN_PA22 External Interrupt Line */
+
+#define PIN_PA01A_EIC_EXTINT1                      _L_(1)       /**< EIC signal: EXTINT1 on PA01 mux A*/
+#define MUX_PA01A_EIC_EXTINT1                      _L_(0)      
+#define PINMUX_PA01A_EIC_EXTINT1                   ((PIN_PA01A_EIC_EXTINT1 << 16) | MUX_PA01A_EIC_EXTINT1)
+#define PORT_PA01A_EIC_EXTINT1                     (_UL_(1) << 1)
+#define PIN_PA01A_EIC_EXTINT_NUM                   _L_(1)       /**< EIC signal: PIN_PA01 External Interrupt Line */
+
+#define PIN_PA02A_EIC_EXTINT2                      _L_(2)       /**< EIC signal: EXTINT2 on PA02 mux A*/
+#define MUX_PA02A_EIC_EXTINT2                      _L_(0)      
+#define PINMUX_PA02A_EIC_EXTINT2                   ((PIN_PA02A_EIC_EXTINT2 << 16) | MUX_PA02A_EIC_EXTINT2)
+#define PORT_PA02A_EIC_EXTINT2                     (_UL_(1) << 2)
+#define PIN_PA02A_EIC_EXTINT_NUM                   _L_(2)       /**< EIC signal: PIN_PA02 External Interrupt Line */
+
+#define PIN_PA11A_EIC_EXTINT2                      _L_(11)      /**< EIC signal: EXTINT2 on PA11 mux A*/
+#define MUX_PA11A_EIC_EXTINT2                      _L_(0)      
+#define PINMUX_PA11A_EIC_EXTINT2                   ((PIN_PA11A_EIC_EXTINT2 << 16) | MUX_PA11A_EIC_EXTINT2)
+#define PORT_PA11A_EIC_EXTINT2                     (_UL_(1) << 11)
+#define PIN_PA11A_EIC_EXTINT_NUM                   _L_(2)       /**< EIC signal: PIN_PA11 External Interrupt Line */
+
+#define PIN_PA23A_EIC_EXTINT2                      _L_(23)      /**< EIC signal: EXTINT2 on PA23 mux A*/
+#define MUX_PA23A_EIC_EXTINT2                      _L_(0)      
+#define PINMUX_PA23A_EIC_EXTINT2                   ((PIN_PA23A_EIC_EXTINT2 << 16) | MUX_PA23A_EIC_EXTINT2)
+#define PORT_PA23A_EIC_EXTINT2                     (_UL_(1) << 23)
+#define PIN_PA23A_EIC_EXTINT_NUM                   _L_(2)       /**< EIC signal: PIN_PA23 External Interrupt Line */
+
+#define PIN_PA03A_EIC_EXTINT3                      _L_(3)       /**< EIC signal: EXTINT3 on PA03 mux A*/
+#define MUX_PA03A_EIC_EXTINT3                      _L_(0)      
+#define PINMUX_PA03A_EIC_EXTINT3                   ((PIN_PA03A_EIC_EXTINT3 << 16) | MUX_PA03A_EIC_EXTINT3)
+#define PORT_PA03A_EIC_EXTINT3                     (_UL_(1) << 3)
+#define PIN_PA03A_EIC_EXTINT_NUM                   _L_(3)       /**< EIC signal: PIN_PA03 External Interrupt Line */
+
+#define PIN_PA14A_EIC_EXTINT3                      _L_(14)      /**< EIC signal: EXTINT3 on PA14 mux A*/
+#define MUX_PA14A_EIC_EXTINT3                      _L_(0)      
+#define PINMUX_PA14A_EIC_EXTINT3                   ((PIN_PA14A_EIC_EXTINT3 << 16) | MUX_PA14A_EIC_EXTINT3)
+#define PORT_PA14A_EIC_EXTINT3                     (_UL_(1) << 14)
+#define PIN_PA14A_EIC_EXTINT_NUM                   _L_(3)       /**< EIC signal: PIN_PA14 External Interrupt Line */
+
+#define PIN_PA24A_EIC_EXTINT3                      _L_(24)      /**< EIC signal: EXTINT3 on PA24 mux A*/
+#define MUX_PA24A_EIC_EXTINT3                      _L_(0)      
+#define PINMUX_PA24A_EIC_EXTINT3                   ((PIN_PA24A_EIC_EXTINT3 << 16) | MUX_PA24A_EIC_EXTINT3)
+#define PORT_PA24A_EIC_EXTINT3                     (_UL_(1) << 24)
+#define PIN_PA24A_EIC_EXTINT_NUM                   _L_(3)       /**< EIC signal: PIN_PA24 External Interrupt Line */
+
+#define PIN_PA04A_EIC_EXTINT4                      _L_(4)       /**< EIC signal: EXTINT4 on PA04 mux A*/
+#define MUX_PA04A_EIC_EXTINT4                      _L_(0)      
+#define PINMUX_PA04A_EIC_EXTINT4                   ((PIN_PA04A_EIC_EXTINT4 << 16) | MUX_PA04A_EIC_EXTINT4)
+#define PORT_PA04A_EIC_EXTINT4                     (_UL_(1) << 4)
+#define PIN_PA04A_EIC_EXTINT_NUM                   _L_(4)       /**< EIC signal: PIN_PA04 External Interrupt Line */
+
+#define PIN_PA15A_EIC_EXTINT4                      _L_(15)      /**< EIC signal: EXTINT4 on PA15 mux A*/
+#define MUX_PA15A_EIC_EXTINT4                      _L_(0)      
+#define PINMUX_PA15A_EIC_EXTINT4                   ((PIN_PA15A_EIC_EXTINT4 << 16) | MUX_PA15A_EIC_EXTINT4)
+#define PORT_PA15A_EIC_EXTINT4                     (_UL_(1) << 15)
+#define PIN_PA15A_EIC_EXTINT_NUM                   _L_(4)       /**< EIC signal: PIN_PA15 External Interrupt Line */
+
+#define PIN_PA25A_EIC_EXTINT4                      _L_(25)      /**< EIC signal: EXTINT4 on PA25 mux A*/
+#define MUX_PA25A_EIC_EXTINT4                      _L_(0)      
+#define PINMUX_PA25A_EIC_EXTINT4                   ((PIN_PA25A_EIC_EXTINT4 << 16) | MUX_PA25A_EIC_EXTINT4)
+#define PORT_PA25A_EIC_EXTINT4                     (_UL_(1) << 25)
+#define PIN_PA25A_EIC_EXTINT_NUM                   _L_(4)       /**< EIC signal: PIN_PA25 External Interrupt Line */
+
+#define PIN_PA05A_EIC_EXTINT5                      _L_(5)       /**< EIC signal: EXTINT5 on PA05 mux A*/
+#define MUX_PA05A_EIC_EXTINT5                      _L_(0)      
+#define PINMUX_PA05A_EIC_EXTINT5                   ((PIN_PA05A_EIC_EXTINT5 << 16) | MUX_PA05A_EIC_EXTINT5)
+#define PORT_PA05A_EIC_EXTINT5                     (_UL_(1) << 5)
+#define PIN_PA05A_EIC_EXTINT_NUM                   _L_(5)       /**< EIC signal: PIN_PA05 External Interrupt Line */
+
+#define PIN_PA16A_EIC_EXTINT5                      _L_(16)      /**< EIC signal: EXTINT5 on PA16 mux A*/
+#define MUX_PA16A_EIC_EXTINT5                      _L_(0)      
+#define PINMUX_PA16A_EIC_EXTINT5                   ((PIN_PA16A_EIC_EXTINT5 << 16) | MUX_PA16A_EIC_EXTINT5)
+#define PORT_PA16A_EIC_EXTINT5                     (_UL_(1) << 16)
+#define PIN_PA16A_EIC_EXTINT_NUM                   _L_(5)       /**< EIC signal: PIN_PA16 External Interrupt Line */
+
+#define PIN_PA27A_EIC_EXTINT5                      _L_(27)      /**< EIC signal: EXTINT5 on PA27 mux A*/
+#define MUX_PA27A_EIC_EXTINT5                      _L_(0)      
+#define PINMUX_PA27A_EIC_EXTINT5                   ((PIN_PA27A_EIC_EXTINT5 << 16) | MUX_PA27A_EIC_EXTINT5)
+#define PORT_PA27A_EIC_EXTINT5                     (_UL_(1) << 27)
+#define PIN_PA27A_EIC_EXTINT_NUM                   _L_(5)       /**< EIC signal: PIN_PA27 External Interrupt Line */
+
+#define PIN_PA06A_EIC_EXTINT6                      _L_(6)       /**< EIC signal: EXTINT6 on PA06 mux A*/
+#define MUX_PA06A_EIC_EXTINT6                      _L_(0)      
+#define PINMUX_PA06A_EIC_EXTINT6                   ((PIN_PA06A_EIC_EXTINT6 << 16) | MUX_PA06A_EIC_EXTINT6)
+#define PORT_PA06A_EIC_EXTINT6                     (_UL_(1) << 6)
+#define PIN_PA06A_EIC_EXTINT_NUM                   _L_(6)       /**< EIC signal: PIN_PA06 External Interrupt Line */
+
+#define PIN_PA17A_EIC_EXTINT6                      _L_(17)      /**< EIC signal: EXTINT6 on PA17 mux A*/
+#define MUX_PA17A_EIC_EXTINT6                      _L_(0)      
+#define PINMUX_PA17A_EIC_EXTINT6                   ((PIN_PA17A_EIC_EXTINT6 << 16) | MUX_PA17A_EIC_EXTINT6)
+#define PORT_PA17A_EIC_EXTINT6                     (_UL_(1) << 17)
+#define PIN_PA17A_EIC_EXTINT_NUM                   _L_(6)       /**< EIC signal: PIN_PA17 External Interrupt Line */
+
+#define PIN_PA30A_EIC_EXTINT6                      _L_(30)      /**< EIC signal: EXTINT6 on PA30 mux A*/
+#define MUX_PA30A_EIC_EXTINT6                      _L_(0)      
+#define PINMUX_PA30A_EIC_EXTINT6                   ((PIN_PA30A_EIC_EXTINT6 << 16) | MUX_PA30A_EIC_EXTINT6)
+#define PORT_PA30A_EIC_EXTINT6                     (_UL_(1) << 30)
+#define PIN_PA30A_EIC_EXTINT_NUM                   _L_(6)       /**< EIC signal: PIN_PA30 External Interrupt Line */
+
+#define PIN_PA07A_EIC_EXTINT7                      _L_(7)       /**< EIC signal: EXTINT7 on PA07 mux A*/
+#define MUX_PA07A_EIC_EXTINT7                      _L_(0)      
+#define PINMUX_PA07A_EIC_EXTINT7                   ((PIN_PA07A_EIC_EXTINT7 << 16) | MUX_PA07A_EIC_EXTINT7)
+#define PORT_PA07A_EIC_EXTINT7                     (_UL_(1) << 7)
+#define PIN_PA07A_EIC_EXTINT_NUM                   _L_(7)       /**< EIC signal: PIN_PA07 External Interrupt Line */
+
+#define PIN_PA18A_EIC_EXTINT7                      _L_(18)      /**< EIC signal: EXTINT7 on PA18 mux A*/
+#define MUX_PA18A_EIC_EXTINT7                      _L_(0)      
+#define PINMUX_PA18A_EIC_EXTINT7                   ((PIN_PA18A_EIC_EXTINT7 << 16) | MUX_PA18A_EIC_EXTINT7)
+#define PORT_PA18A_EIC_EXTINT7                     (_UL_(1) << 18)
+#define PIN_PA18A_EIC_EXTINT_NUM                   _L_(7)       /**< EIC signal: PIN_PA18 External Interrupt Line */
+
+#define PIN_PA31A_EIC_EXTINT7                      _L_(31)      /**< EIC signal: EXTINT7 on PA31 mux A*/
+#define MUX_PA31A_EIC_EXTINT7                      _L_(0)      
+#define PINMUX_PA31A_EIC_EXTINT7                   ((PIN_PA31A_EIC_EXTINT7 << 16) | MUX_PA31A_EIC_EXTINT7)
+#define PORT_PA31A_EIC_EXTINT7                     (_UL_(1) << 31)
+#define PIN_PA31A_EIC_EXTINT_NUM                   _L_(7)       /**< EIC signal: PIN_PA31 External Interrupt Line */
+
+#define PIN_PA08A_EIC_NMI                          _L_(8)       /**< EIC signal: NMI on PA08 mux A*/
+#define MUX_PA08A_EIC_NMI                          _L_(0)      
+#define PINMUX_PA08A_EIC_NMI                       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
+#define PORT_PA08A_EIC_NMI                         (_UL_(1) << 8)
+
+/* ========== PORT definition for GCLK peripheral ========== */
+#define PIN_PA30H_GCLK_IO0                         _L_(30)      /**< GCLK signal: IO0 on PA30 mux H*/
+#define MUX_PA30H_GCLK_IO0                         _L_(7)      
+#define PINMUX_PA30H_GCLK_IO0                      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
+#define PORT_PA30H_GCLK_IO0                        (_UL_(1) << 30)
+
+#define PIN_PA14H_GCLK_IO0                         _L_(14)      /**< GCLK signal: IO0 on PA14 mux H*/
+#define MUX_PA14H_GCLK_IO0                         _L_(7)      
+#define PINMUX_PA14H_GCLK_IO0                      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
+#define PORT_PA14H_GCLK_IO0                        (_UL_(1) << 14)
+
+#define PIN_PA27H_GCLK_IO0                         _L_(27)      /**< GCLK signal: IO0 on PA27 mux H*/
+#define MUX_PA27H_GCLK_IO0                         _L_(7)      
+#define PINMUX_PA27H_GCLK_IO0                      ((PIN_PA27H_GCLK_IO0 << 16) | MUX_PA27H_GCLK_IO0)
+#define PORT_PA27H_GCLK_IO0                        (_UL_(1) << 27)
+
+#define PIN_PA23H_GCLK_IO1                         _L_(23)      /**< GCLK signal: IO1 on PA23 mux H*/
+#define MUX_PA23H_GCLK_IO1                         _L_(7)      
+#define PINMUX_PA23H_GCLK_IO1                      ((PIN_PA23H_GCLK_IO1 << 16) | MUX_PA23H_GCLK_IO1)
+#define PORT_PA23H_GCLK_IO1                        (_UL_(1) << 23)
+
+#define PIN_PA15H_GCLK_IO1                         _L_(15)      /**< GCLK signal: IO1 on PA15 mux H*/
+#define MUX_PA15H_GCLK_IO1                         _L_(7)      
+#define PINMUX_PA15H_GCLK_IO1                      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
+#define PORT_PA15H_GCLK_IO1                        (_UL_(1) << 15)
+
+#define PIN_PA16H_GCLK_IO2                         _L_(16)      /**< GCLK signal: IO2 on PA16 mux H*/
+#define MUX_PA16H_GCLK_IO2                         _L_(7)      
+#define PINMUX_PA16H_GCLK_IO2                      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
+#define PORT_PA16H_GCLK_IO2                        (_UL_(1) << 16)
+
+#define PIN_PA22H_GCLK_IO2                         _L_(22)      /**< GCLK signal: IO2 on PA22 mux H*/
+#define MUX_PA22H_GCLK_IO2                         _L_(7)      
+#define PINMUX_PA22H_GCLK_IO2                      ((PIN_PA22H_GCLK_IO2 << 16) | MUX_PA22H_GCLK_IO2)
+#define PORT_PA22H_GCLK_IO2                        (_UL_(1) << 22)
+
+#define PIN_PA11H_GCLK_IO3                         _L_(11)      /**< GCLK signal: IO3 on PA11 mux H*/
+#define MUX_PA11H_GCLK_IO3                         _L_(7)      
+#define PINMUX_PA11H_GCLK_IO3                      ((PIN_PA11H_GCLK_IO3 << 16) | MUX_PA11H_GCLK_IO3)
+#define PORT_PA11H_GCLK_IO3                        (_UL_(1) << 11)
+
+#define PIN_PA17H_GCLK_IO3                         _L_(17)      /**< GCLK signal: IO3 on PA17 mux H*/
+#define MUX_PA17H_GCLK_IO3                         _L_(7)      
+#define PINMUX_PA17H_GCLK_IO3                      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
+#define PORT_PA17H_GCLK_IO3                        (_UL_(1) << 17)
+
+#define PIN_PA10H_GCLK_IO4                         _L_(10)      /**< GCLK signal: IO4 on PA10 mux H*/
+#define MUX_PA10H_GCLK_IO4                         _L_(7)      
+#define PINMUX_PA10H_GCLK_IO4                      ((PIN_PA10H_GCLK_IO4 << 16) | MUX_PA10H_GCLK_IO4)
+#define PORT_PA10H_GCLK_IO4                        (_UL_(1) << 10)
+
+/* ========== PORT definition for OPAMP peripheral ========== */
+#define PIN_PA02B_OPAMP_OANEG0                     _L_(2)       /**< OPAMP signal: OANEG0 on PA02 mux B*/
+#define MUX_PA02B_OPAMP_OANEG0                     _L_(1)      
+#define PINMUX_PA02B_OPAMP_OANEG0                  ((PIN_PA02B_OPAMP_OANEG0 << 16) | MUX_PA02B_OPAMP_OANEG0)
+#define PORT_PA02B_OPAMP_OANEG0                    (_UL_(1) << 2)
+
+#define PIN_PA00B_OPAMP_OANEG1                     _L_(0)       /**< OPAMP signal: OANEG1 on PA00 mux B*/
+#define MUX_PA00B_OPAMP_OANEG1                     _L_(1)      
+#define PINMUX_PA00B_OPAMP_OANEG1                  ((PIN_PA00B_OPAMP_OANEG1 << 16) | MUX_PA00B_OPAMP_OANEG1)
+#define PORT_PA00B_OPAMP_OANEG1                    (_UL_(1) << 0)
+
+#define PIN_PA03B_OPAMP_OANEG2                     _L_(3)       /**< OPAMP signal: OANEG2 on PA03 mux B*/
+#define MUX_PA03B_OPAMP_OANEG2                     _L_(1)      
+#define PINMUX_PA03B_OPAMP_OANEG2                  ((PIN_PA03B_OPAMP_OANEG2 << 16) | MUX_PA03B_OPAMP_OANEG2)
+#define PORT_PA03B_OPAMP_OANEG2                    (_UL_(1) << 3)
+
+#define PIN_PA07B_OPAMP_OAOUT0                     _L_(7)       /**< OPAMP signal: OAOUT0 on PA07 mux B*/
+#define MUX_PA07B_OPAMP_OAOUT0                     _L_(1)      
+#define PINMUX_PA07B_OPAMP_OAOUT0                  ((PIN_PA07B_OPAMP_OAOUT0 << 16) | MUX_PA07B_OPAMP_OAOUT0)
+#define PORT_PA07B_OPAMP_OAOUT0                    (_UL_(1) << 7)
+
+#define PIN_PA04B_OPAMP_OAOUT2                     _L_(4)       /**< OPAMP signal: OAOUT2 on PA04 mux B*/
+#define MUX_PA04B_OPAMP_OAOUT2                     _L_(1)      
+#define PINMUX_PA04B_OPAMP_OAOUT2                  ((PIN_PA04B_OPAMP_OAOUT2 << 16) | MUX_PA04B_OPAMP_OAOUT2)
+#define PORT_PA04B_OPAMP_OAOUT2                    (_UL_(1) << 4)
+
+#define PIN_PA06B_OPAMP_OAPOS0                     _L_(6)       /**< OPAMP signal: OAPOS0 on PA06 mux B*/
+#define MUX_PA06B_OPAMP_OAPOS0                     _L_(1)      
+#define PINMUX_PA06B_OPAMP_OAPOS0                  ((PIN_PA06B_OPAMP_OAPOS0 << 16) | MUX_PA06B_OPAMP_OAPOS0)
+#define PORT_PA06B_OPAMP_OAPOS0                    (_UL_(1) << 6)
+
+#define PIN_PA01B_OPAMP_OAPOS1                     _L_(1)       /**< OPAMP signal: OAPOS1 on PA01 mux B*/
+#define MUX_PA01B_OPAMP_OAPOS1                     _L_(1)      
+#define PINMUX_PA01B_OPAMP_OAPOS1                  ((PIN_PA01B_OPAMP_OAPOS1 << 16) | MUX_PA01B_OPAMP_OAPOS1)
+#define PORT_PA01B_OPAMP_OAPOS1                    (_UL_(1) << 1)
+
+#define PIN_PA05B_OPAMP_OAPOS2                     _L_(5)       /**< OPAMP signal: OAPOS2 on PA05 mux B*/
+#define MUX_PA05B_OPAMP_OAPOS2                     _L_(1)      
+#define PINMUX_PA05B_OPAMP_OAPOS2                  ((PIN_PA05B_OPAMP_OAPOS2 << 16) | MUX_PA05B_OPAMP_OAPOS2)
+#define PORT_PA05B_OPAMP_OAPOS2                    (_UL_(1) << 5)
+
+/* ========== PORT definition for PTC peripheral ========== */
+#define PIN_PA00F_PTC_DRV0                         _L_(0)       /**< PTC signal: DRV0 on PA00 mux F*/
+#define MUX_PA00F_PTC_DRV0                         _L_(5)      
+#define PINMUX_PA00F_PTC_DRV0                      ((PIN_PA00F_PTC_DRV0 << 16) | MUX_PA00F_PTC_DRV0)
+#define PORT_PA00F_PTC_DRV0                        (_UL_(1) << 0)
+
+#define PIN_PA01F_PTC_DRV1                         _L_(1)       /**< PTC signal: DRV1 on PA01 mux F*/
+#define MUX_PA01F_PTC_DRV1                         _L_(5)      
+#define PINMUX_PA01F_PTC_DRV1                      ((PIN_PA01F_PTC_DRV1 << 16) | MUX_PA01F_PTC_DRV1)
+#define PORT_PA01F_PTC_DRV1                        (_UL_(1) << 1)
+
+#define PIN_PA02F_PTC_DRV2                         _L_(2)       /**< PTC signal: DRV2 on PA02 mux F*/
+#define MUX_PA02F_PTC_DRV2                         _L_(5)      
+#define PINMUX_PA02F_PTC_DRV2                      ((PIN_PA02F_PTC_DRV2 << 16) | MUX_PA02F_PTC_DRV2)
+#define PORT_PA02F_PTC_DRV2                        (_UL_(1) << 2)
+
+#define PIN_PA03F_PTC_DRV3                         _L_(3)       /**< PTC signal: DRV3 on PA03 mux F*/
+#define MUX_PA03F_PTC_DRV3                         _L_(5)      
+#define PINMUX_PA03F_PTC_DRV3                      ((PIN_PA03F_PTC_DRV3 << 16) | MUX_PA03F_PTC_DRV3)
+#define PORT_PA03F_PTC_DRV3                        (_UL_(1) << 3)
+
+#define PIN_PA05F_PTC_DRV4                         _L_(5)       /**< PTC signal: DRV4 on PA05 mux F*/
+#define MUX_PA05F_PTC_DRV4                         _L_(5)      
+#define PINMUX_PA05F_PTC_DRV4                      ((PIN_PA05F_PTC_DRV4 << 16) | MUX_PA05F_PTC_DRV4)
+#define PORT_PA05F_PTC_DRV4                        (_UL_(1) << 5)
+
+#define PIN_PA06F_PTC_DRV5                         _L_(6)       /**< PTC signal: DRV5 on PA06 mux F*/
+#define MUX_PA06F_PTC_DRV5                         _L_(5)      
+#define PINMUX_PA06F_PTC_DRV5                      ((PIN_PA06F_PTC_DRV5 << 16) | MUX_PA06F_PTC_DRV5)
+#define PORT_PA06F_PTC_DRV5                        (_UL_(1) << 6)
+
+#define PIN_PA08F_PTC_DRV6                         _L_(8)       /**< PTC signal: DRV6 on PA08 mux F*/
+#define MUX_PA08F_PTC_DRV6                         _L_(5)      
+#define PINMUX_PA08F_PTC_DRV6                      ((PIN_PA08F_PTC_DRV6 << 16) | MUX_PA08F_PTC_DRV6)
+#define PORT_PA08F_PTC_DRV6                        (_UL_(1) << 8)
+
+#define PIN_PA09F_PTC_DRV7                         _L_(9)       /**< PTC signal: DRV7 on PA09 mux F*/
+#define MUX_PA09F_PTC_DRV7                         _L_(5)      
+#define PINMUX_PA09F_PTC_DRV7                      ((PIN_PA09F_PTC_DRV7 << 16) | MUX_PA09F_PTC_DRV7)
+#define PORT_PA09F_PTC_DRV7                        (_UL_(1) << 9)
+
+#define PIN_PA10F_PTC_DRV8                         _L_(10)      /**< PTC signal: DRV8 on PA10 mux F*/
+#define MUX_PA10F_PTC_DRV8                         _L_(5)      
+#define PINMUX_PA10F_PTC_DRV8                      ((PIN_PA10F_PTC_DRV8 << 16) | MUX_PA10F_PTC_DRV8)
+#define PORT_PA10F_PTC_DRV8                        (_UL_(1) << 10)
+
+#define PIN_PA11F_PTC_DRV9                         _L_(11)      /**< PTC signal: DRV9 on PA11 mux F*/
+#define MUX_PA11F_PTC_DRV9                         _L_(5)      
+#define PINMUX_PA11F_PTC_DRV9                      ((PIN_PA11F_PTC_DRV9 << 16) | MUX_PA11F_PTC_DRV9)
+#define PORT_PA11F_PTC_DRV9                        (_UL_(1) << 11)
+
+#define PIN_PA14F_PTC_DRV10                        _L_(14)      /**< PTC signal: DRV10 on PA14 mux F*/
+#define MUX_PA14F_PTC_DRV10                        _L_(5)      
+#define PINMUX_PA14F_PTC_DRV10                     ((PIN_PA14F_PTC_DRV10 << 16) | MUX_PA14F_PTC_DRV10)
+#define PORT_PA14F_PTC_DRV10                       (_UL_(1) << 14)
+
+#define PIN_PA15F_PTC_DRV11                        _L_(15)      /**< PTC signal: DRV11 on PA15 mux F*/
+#define MUX_PA15F_PTC_DRV11                        _L_(5)      
+#define PINMUX_PA15F_PTC_DRV11                     ((PIN_PA15F_PTC_DRV11 << 16) | MUX_PA15F_PTC_DRV11)
+#define PORT_PA15F_PTC_DRV11                       (_UL_(1) << 15)
+
+#define PIN_PA16F_PTC_DRV12                        _L_(16)      /**< PTC signal: DRV12 on PA16 mux F*/
+#define MUX_PA16F_PTC_DRV12                        _L_(5)      
+#define PINMUX_PA16F_PTC_DRV12                     ((PIN_PA16F_PTC_DRV12 << 16) | MUX_PA16F_PTC_DRV12)
+#define PORT_PA16F_PTC_DRV12                       (_UL_(1) << 16)
+
+#define PIN_PA17F_PTC_DRV13                        _L_(17)      /**< PTC signal: DRV13 on PA17 mux F*/
+#define MUX_PA17F_PTC_DRV13                        _L_(5)      
+#define PINMUX_PA17F_PTC_DRV13                     ((PIN_PA17F_PTC_DRV13 << 16) | MUX_PA17F_PTC_DRV13)
+#define PORT_PA17F_PTC_DRV13                       (_UL_(1) << 17)
+
+#define PIN_PA18F_PTC_DRV14                        _L_(18)      /**< PTC signal: DRV14 on PA18 mux F*/
+#define MUX_PA18F_PTC_DRV14                        _L_(5)      
+#define PINMUX_PA18F_PTC_DRV14                     ((PIN_PA18F_PTC_DRV14 << 16) | MUX_PA18F_PTC_DRV14)
+#define PORT_PA18F_PTC_DRV14                       (_UL_(1) << 18)
+
+#define PIN_PA19F_PTC_DRV15                        _L_(19)      /**< PTC signal: DRV15 on PA19 mux F*/
+#define MUX_PA19F_PTC_DRV15                        _L_(5)      
+#define PINMUX_PA19F_PTC_DRV15                     ((PIN_PA19F_PTC_DRV15 << 16) | MUX_PA19F_PTC_DRV15)
+#define PORT_PA19F_PTC_DRV15                       (_UL_(1) << 19)
+
+#define PIN_PA22F_PTC_DRV16                        _L_(22)      /**< PTC signal: DRV16 on PA22 mux F*/
+#define MUX_PA22F_PTC_DRV16                        _L_(5)      
+#define PINMUX_PA22F_PTC_DRV16                     ((PIN_PA22F_PTC_DRV16 << 16) | MUX_PA22F_PTC_DRV16)
+#define PORT_PA22F_PTC_DRV16                       (_UL_(1) << 22)
+
+#define PIN_PA23F_PTC_DRV17                        _L_(23)      /**< PTC signal: DRV17 on PA23 mux F*/
+#define MUX_PA23F_PTC_DRV17                        _L_(5)      
+#define PINMUX_PA23F_PTC_DRV17                     ((PIN_PA23F_PTC_DRV17 << 16) | MUX_PA23F_PTC_DRV17)
+#define PORT_PA23F_PTC_DRV17                       (_UL_(1) << 23)
+
+#define PIN_PA30F_PTC_DRV18                        _L_(30)      /**< PTC signal: DRV18 on PA30 mux F*/
+#define MUX_PA30F_PTC_DRV18                        _L_(5)      
+#define PINMUX_PA30F_PTC_DRV18                     ((PIN_PA30F_PTC_DRV18 << 16) | MUX_PA30F_PTC_DRV18)
+#define PORT_PA30F_PTC_DRV18                       (_UL_(1) << 30)
+
+#define PIN_PA31F_PTC_DRV19                        _L_(31)      /**< PTC signal: DRV19 on PA31 mux F*/
+#define MUX_PA31F_PTC_DRV19                        _L_(5)      
+#define PINMUX_PA31F_PTC_DRV19                     ((PIN_PA31F_PTC_DRV19 << 16) | MUX_PA31F_PTC_DRV19)
+#define PORT_PA31F_PTC_DRV19                       (_UL_(1) << 31)
+
+#define PIN_PA03B_PTC_ECI0                         _L_(3)       /**< PTC signal: ECI0 on PA03 mux B*/
+#define MUX_PA03B_PTC_ECI0                         _L_(1)      
+#define PINMUX_PA03B_PTC_ECI0                      ((PIN_PA03B_PTC_ECI0 << 16) | MUX_PA03B_PTC_ECI0)
+#define PORT_PA03B_PTC_ECI0                        (_UL_(1) << 3)
+
+#define PIN_PA04B_PTC_ECI1                         _L_(4)       /**< PTC signal: ECI1 on PA04 mux B*/
+#define MUX_PA04B_PTC_ECI1                         _L_(1)      
+#define PINMUX_PA04B_PTC_ECI1                      ((PIN_PA04B_PTC_ECI1 << 16) | MUX_PA04B_PTC_ECI1)
+#define PORT_PA04B_PTC_ECI1                        (_UL_(1) << 4)
+
+#define PIN_PA05B_PTC_ECI2                         _L_(5)       /**< PTC signal: ECI2 on PA05 mux B*/
+#define MUX_PA05B_PTC_ECI2                         _L_(1)      
+#define PINMUX_PA05B_PTC_ECI2                      ((PIN_PA05B_PTC_ECI2 << 16) | MUX_PA05B_PTC_ECI2)
+#define PORT_PA05B_PTC_ECI2                        (_UL_(1) << 5)
+
+#define PIN_PA06B_PTC_ECI3                         _L_(6)       /**< PTC signal: ECI3 on PA06 mux B*/
+#define MUX_PA06B_PTC_ECI3                         _L_(1)      
+#define PINMUX_PA06B_PTC_ECI3                      ((PIN_PA06B_PTC_ECI3 << 16) | MUX_PA06B_PTC_ECI3)
+#define PORT_PA06B_PTC_ECI3                        (_UL_(1) << 6)
+
+#define PIN_PA00B_PTC_X0                           _L_(0)       /**< PTC signal: X0 on PA00 mux B*/
+#define MUX_PA00B_PTC_X0                           _L_(1)      
+#define PINMUX_PA00B_PTC_X0                        ((PIN_PA00B_PTC_X0 << 16) | MUX_PA00B_PTC_X0)
+#define PORT_PA00B_PTC_X0                          (_UL_(1) << 0)
+
+#define PIN_PA00B_PTC_Y0                           _L_(0)       /**< PTC signal: Y0 on PA00 mux B*/
+#define MUX_PA00B_PTC_Y0                           _L_(1)      
+#define PINMUX_PA00B_PTC_Y0                        ((PIN_PA00B_PTC_Y0 << 16) | MUX_PA00B_PTC_Y0)
+#define PORT_PA00B_PTC_Y0                          (_UL_(1) << 0)
+
+#define PIN_PA01B_PTC_X1                           _L_(1)       /**< PTC signal: X1 on PA01 mux B*/
+#define MUX_PA01B_PTC_X1                           _L_(1)      
+#define PINMUX_PA01B_PTC_X1                        ((PIN_PA01B_PTC_X1 << 16) | MUX_PA01B_PTC_X1)
+#define PORT_PA01B_PTC_X1                          (_UL_(1) << 1)
+
+#define PIN_PA01B_PTC_Y1                           _L_(1)       /**< PTC signal: Y1 on PA01 mux B*/
+#define MUX_PA01B_PTC_Y1                           _L_(1)      
+#define PINMUX_PA01B_PTC_Y1                        ((PIN_PA01B_PTC_Y1 << 16) | MUX_PA01B_PTC_Y1)
+#define PORT_PA01B_PTC_Y1                          (_UL_(1) << 1)
+
+#define PIN_PA02B_PTC_X2                           _L_(2)       /**< PTC signal: X2 on PA02 mux B*/
+#define MUX_PA02B_PTC_X2                           _L_(1)      
+#define PINMUX_PA02B_PTC_X2                        ((PIN_PA02B_PTC_X2 << 16) | MUX_PA02B_PTC_X2)
+#define PORT_PA02B_PTC_X2                          (_UL_(1) << 2)
+
+#define PIN_PA02B_PTC_Y2                           _L_(2)       /**< PTC signal: Y2 on PA02 mux B*/
+#define MUX_PA02B_PTC_Y2                           _L_(1)      
+#define PINMUX_PA02B_PTC_Y2                        ((PIN_PA02B_PTC_Y2 << 16) | MUX_PA02B_PTC_Y2)
+#define PORT_PA02B_PTC_Y2                          (_UL_(1) << 2)
+
+#define PIN_PA03B_PTC_X3                           _L_(3)       /**< PTC signal: X3 on PA03 mux B*/
+#define MUX_PA03B_PTC_X3                           _L_(1)      
+#define PINMUX_PA03B_PTC_X3                        ((PIN_PA03B_PTC_X3 << 16) | MUX_PA03B_PTC_X3)
+#define PORT_PA03B_PTC_X3                          (_UL_(1) << 3)
+
+#define PIN_PA03B_PTC_Y3                           _L_(3)       /**< PTC signal: Y3 on PA03 mux B*/
+#define MUX_PA03B_PTC_Y3                           _L_(1)      
+#define PINMUX_PA03B_PTC_Y3                        ((PIN_PA03B_PTC_Y3 << 16) | MUX_PA03B_PTC_Y3)
+#define PORT_PA03B_PTC_Y3                          (_UL_(1) << 3)
+
+#define PIN_PA05B_PTC_X4                           _L_(5)       /**< PTC signal: X4 on PA05 mux B*/
+#define MUX_PA05B_PTC_X4                           _L_(1)      
+#define PINMUX_PA05B_PTC_X4                        ((PIN_PA05B_PTC_X4 << 16) | MUX_PA05B_PTC_X4)
+#define PORT_PA05B_PTC_X4                          (_UL_(1) << 5)
+
+#define PIN_PA05B_PTC_Y4                           _L_(5)       /**< PTC signal: Y4 on PA05 mux B*/
+#define MUX_PA05B_PTC_Y4                           _L_(1)      
+#define PINMUX_PA05B_PTC_Y4                        ((PIN_PA05B_PTC_Y4 << 16) | MUX_PA05B_PTC_Y4)
+#define PORT_PA05B_PTC_Y4                          (_UL_(1) << 5)
+
+#define PIN_PA06B_PTC_X5                           _L_(6)       /**< PTC signal: X5 on PA06 mux B*/
+#define MUX_PA06B_PTC_X5                           _L_(1)      
+#define PINMUX_PA06B_PTC_X5                        ((PIN_PA06B_PTC_X5 << 16) | MUX_PA06B_PTC_X5)
+#define PORT_PA06B_PTC_X5                          (_UL_(1) << 6)
+
+#define PIN_PA06B_PTC_Y5                           _L_(6)       /**< PTC signal: Y5 on PA06 mux B*/
+#define MUX_PA06B_PTC_Y5                           _L_(1)      
+#define PINMUX_PA06B_PTC_Y5                        ((PIN_PA06B_PTC_Y5 << 16) | MUX_PA06B_PTC_Y5)
+#define PORT_PA06B_PTC_Y5                          (_UL_(1) << 6)
+
+#define PIN_PA08B_PTC_X6                           _L_(8)       /**< PTC signal: X6 on PA08 mux B*/
+#define MUX_PA08B_PTC_X6                           _L_(1)      
+#define PINMUX_PA08B_PTC_X6                        ((PIN_PA08B_PTC_X6 << 16) | MUX_PA08B_PTC_X6)
+#define PORT_PA08B_PTC_X6                          (_UL_(1) << 8)
+
+#define PIN_PA08B_PTC_Y6                           _L_(8)       /**< PTC signal: Y6 on PA08 mux B*/
+#define MUX_PA08B_PTC_Y6                           _L_(1)      
+#define PINMUX_PA08B_PTC_Y6                        ((PIN_PA08B_PTC_Y6 << 16) | MUX_PA08B_PTC_Y6)
+#define PORT_PA08B_PTC_Y6                          (_UL_(1) << 8)
+
+#define PIN_PA09B_PTC_X7                           _L_(9)       /**< PTC signal: X7 on PA09 mux B*/
+#define MUX_PA09B_PTC_X7                           _L_(1)      
+#define PINMUX_PA09B_PTC_X7                        ((PIN_PA09B_PTC_X7 << 16) | MUX_PA09B_PTC_X7)
+#define PORT_PA09B_PTC_X7                          (_UL_(1) << 9)
+
+#define PIN_PA09B_PTC_Y7                           _L_(9)       /**< PTC signal: Y7 on PA09 mux B*/
+#define MUX_PA09B_PTC_Y7                           _L_(1)      
+#define PINMUX_PA09B_PTC_Y7                        ((PIN_PA09B_PTC_Y7 << 16) | MUX_PA09B_PTC_Y7)
+#define PORT_PA09B_PTC_Y7                          (_UL_(1) << 9)
+
+#define PIN_PA10B_PTC_X8                           _L_(10)      /**< PTC signal: X8 on PA10 mux B*/
+#define MUX_PA10B_PTC_X8                           _L_(1)      
+#define PINMUX_PA10B_PTC_X8                        ((PIN_PA10B_PTC_X8 << 16) | MUX_PA10B_PTC_X8)
+#define PORT_PA10B_PTC_X8                          (_UL_(1) << 10)
+
+#define PIN_PA10B_PTC_Y8                           _L_(10)      /**< PTC signal: Y8 on PA10 mux B*/
+#define MUX_PA10B_PTC_Y8                           _L_(1)      
+#define PINMUX_PA10B_PTC_Y8                        ((PIN_PA10B_PTC_Y8 << 16) | MUX_PA10B_PTC_Y8)
+#define PORT_PA10B_PTC_Y8                          (_UL_(1) << 10)
+
+#define PIN_PA11B_PTC_X9                           _L_(11)      /**< PTC signal: X9 on PA11 mux B*/
+#define MUX_PA11B_PTC_X9                           _L_(1)      
+#define PINMUX_PA11B_PTC_X9                        ((PIN_PA11B_PTC_X9 << 16) | MUX_PA11B_PTC_X9)
+#define PORT_PA11B_PTC_X9                          (_UL_(1) << 11)
+
+#define PIN_PA11B_PTC_Y9                           _L_(11)      /**< PTC signal: Y9 on PA11 mux B*/
+#define MUX_PA11B_PTC_Y9                           _L_(1)      
+#define PINMUX_PA11B_PTC_Y9                        ((PIN_PA11B_PTC_Y9 << 16) | MUX_PA11B_PTC_Y9)
+#define PORT_PA11B_PTC_Y9                          (_UL_(1) << 11)
+
+#define PIN_PA14B_PTC_X10                          _L_(14)      /**< PTC signal: X10 on PA14 mux B*/
+#define MUX_PA14B_PTC_X10                          _L_(1)      
+#define PINMUX_PA14B_PTC_X10                       ((PIN_PA14B_PTC_X10 << 16) | MUX_PA14B_PTC_X10)
+#define PORT_PA14B_PTC_X10                         (_UL_(1) << 14)
+
+#define PIN_PA14B_PTC_Y10                          _L_(14)      /**< PTC signal: Y10 on PA14 mux B*/
+#define MUX_PA14B_PTC_Y10                          _L_(1)      
+#define PINMUX_PA14B_PTC_Y10                       ((PIN_PA14B_PTC_Y10 << 16) | MUX_PA14B_PTC_Y10)
+#define PORT_PA14B_PTC_Y10                         (_UL_(1) << 14)
+
+#define PIN_PA15B_PTC_X11                          _L_(15)      /**< PTC signal: X11 on PA15 mux B*/
+#define MUX_PA15B_PTC_X11                          _L_(1)      
+#define PINMUX_PA15B_PTC_X11                       ((PIN_PA15B_PTC_X11 << 16) | MUX_PA15B_PTC_X11)
+#define PORT_PA15B_PTC_X11                         (_UL_(1) << 15)
+
+#define PIN_PA15B_PTC_Y11                          _L_(15)      /**< PTC signal: Y11 on PA15 mux B*/
+#define MUX_PA15B_PTC_Y11                          _L_(1)      
+#define PINMUX_PA15B_PTC_Y11                       ((PIN_PA15B_PTC_Y11 << 16) | MUX_PA15B_PTC_Y11)
+#define PORT_PA15B_PTC_Y11                         (_UL_(1) << 15)
+
+#define PIN_PA16B_PTC_X12                          _L_(16)      /**< PTC signal: X12 on PA16 mux B*/
+#define MUX_PA16B_PTC_X12                          _L_(1)      
+#define PINMUX_PA16B_PTC_X12                       ((PIN_PA16B_PTC_X12 << 16) | MUX_PA16B_PTC_X12)
+#define PORT_PA16B_PTC_X12                         (_UL_(1) << 16)
+
+#define PIN_PA16B_PTC_Y12                          _L_(16)      /**< PTC signal: Y12 on PA16 mux B*/
+#define MUX_PA16B_PTC_Y12                          _L_(1)      
+#define PINMUX_PA16B_PTC_Y12                       ((PIN_PA16B_PTC_Y12 << 16) | MUX_PA16B_PTC_Y12)
+#define PORT_PA16B_PTC_Y12                         (_UL_(1) << 16)
+
+#define PIN_PA17B_PTC_X13                          _L_(17)      /**< PTC signal: X13 on PA17 mux B*/
+#define MUX_PA17B_PTC_X13                          _L_(1)      
+#define PINMUX_PA17B_PTC_X13                       ((PIN_PA17B_PTC_X13 << 16) | MUX_PA17B_PTC_X13)
+#define PORT_PA17B_PTC_X13                         (_UL_(1) << 17)
+
+#define PIN_PA17B_PTC_Y13                          _L_(17)      /**< PTC signal: Y13 on PA17 mux B*/
+#define MUX_PA17B_PTC_Y13                          _L_(1)      
+#define PINMUX_PA17B_PTC_Y13                       ((PIN_PA17B_PTC_Y13 << 16) | MUX_PA17B_PTC_Y13)
+#define PORT_PA17B_PTC_Y13                         (_UL_(1) << 17)
+
+#define PIN_PA18B_PTC_X14                          _L_(18)      /**< PTC signal: X14 on PA18 mux B*/
+#define MUX_PA18B_PTC_X14                          _L_(1)      
+#define PINMUX_PA18B_PTC_X14                       ((PIN_PA18B_PTC_X14 << 16) | MUX_PA18B_PTC_X14)
+#define PORT_PA18B_PTC_X14                         (_UL_(1) << 18)
+
+#define PIN_PA18B_PTC_Y14                          _L_(18)      /**< PTC signal: Y14 on PA18 mux B*/
+#define MUX_PA18B_PTC_Y14                          _L_(1)      
+#define PINMUX_PA18B_PTC_Y14                       ((PIN_PA18B_PTC_Y14 << 16) | MUX_PA18B_PTC_Y14)
+#define PORT_PA18B_PTC_Y14                         (_UL_(1) << 18)
+
+#define PIN_PA19B_PTC_X15                          _L_(19)      /**< PTC signal: X15 on PA19 mux B*/
+#define MUX_PA19B_PTC_X15                          _L_(1)      
+#define PINMUX_PA19B_PTC_X15                       ((PIN_PA19B_PTC_X15 << 16) | MUX_PA19B_PTC_X15)
+#define PORT_PA19B_PTC_X15                         (_UL_(1) << 19)
+
+#define PIN_PA19B_PTC_Y15                          _L_(19)      /**< PTC signal: Y15 on PA19 mux B*/
+#define MUX_PA19B_PTC_Y15                          _L_(1)      
+#define PINMUX_PA19B_PTC_Y15                       ((PIN_PA19B_PTC_Y15 << 16) | MUX_PA19B_PTC_Y15)
+#define PORT_PA19B_PTC_Y15                         (_UL_(1) << 19)
+
+#define PIN_PA22B_PTC_X16                          _L_(22)      /**< PTC signal: X16 on PA22 mux B*/
+#define MUX_PA22B_PTC_X16                          _L_(1)      
+#define PINMUX_PA22B_PTC_X16                       ((PIN_PA22B_PTC_X16 << 16) | MUX_PA22B_PTC_X16)
+#define PORT_PA22B_PTC_X16                         (_UL_(1) << 22)
+
+#define PIN_PA22B_PTC_Y16                          _L_(22)      /**< PTC signal: Y16 on PA22 mux B*/
+#define MUX_PA22B_PTC_Y16                          _L_(1)      
+#define PINMUX_PA22B_PTC_Y16                       ((PIN_PA22B_PTC_Y16 << 16) | MUX_PA22B_PTC_Y16)
+#define PORT_PA22B_PTC_Y16                         (_UL_(1) << 22)
+
+#define PIN_PA23B_PTC_X17                          _L_(23)      /**< PTC signal: X17 on PA23 mux B*/
+#define MUX_PA23B_PTC_X17                          _L_(1)      
+#define PINMUX_PA23B_PTC_X17                       ((PIN_PA23B_PTC_X17 << 16) | MUX_PA23B_PTC_X17)
+#define PORT_PA23B_PTC_X17                         (_UL_(1) << 23)
+
+#define PIN_PA23B_PTC_Y17                          _L_(23)      /**< PTC signal: Y17 on PA23 mux B*/
+#define MUX_PA23B_PTC_Y17                          _L_(1)      
+#define PINMUX_PA23B_PTC_Y17                       ((PIN_PA23B_PTC_Y17 << 16) | MUX_PA23B_PTC_Y17)
+#define PORT_PA23B_PTC_Y17                         (_UL_(1) << 23)
+
+#define PIN_PA30B_PTC_X18                          _L_(30)      /**< PTC signal: X18 on PA30 mux B*/
+#define MUX_PA30B_PTC_X18                          _L_(1)      
+#define PINMUX_PA30B_PTC_X18                       ((PIN_PA30B_PTC_X18 << 16) | MUX_PA30B_PTC_X18)
+#define PORT_PA30B_PTC_X18                         (_UL_(1) << 30)
+
+#define PIN_PA30B_PTC_Y18                          _L_(30)      /**< PTC signal: Y18 on PA30 mux B*/
+#define MUX_PA30B_PTC_Y18                          _L_(1)      
+#define PINMUX_PA30B_PTC_Y18                       ((PIN_PA30B_PTC_Y18 << 16) | MUX_PA30B_PTC_Y18)
+#define PORT_PA30B_PTC_Y18                         (_UL_(1) << 30)
+
+#define PIN_PA31B_PTC_X19                          _L_(31)      /**< PTC signal: X19 on PA31 mux B*/
+#define MUX_PA31B_PTC_X19                          _L_(1)      
+#define PINMUX_PA31B_PTC_X19                       ((PIN_PA31B_PTC_X19 << 16) | MUX_PA31B_PTC_X19)
+#define PORT_PA31B_PTC_X19                         (_UL_(1) << 31)
+
+#define PIN_PA31B_PTC_Y19                          _L_(31)      /**< PTC signal: Y19 on PA31 mux B*/
+#define MUX_PA31B_PTC_Y19                          _L_(1)      
+#define PINMUX_PA31B_PTC_Y19                       ((PIN_PA31B_PTC_Y19 << 16) | MUX_PA31B_PTC_Y19)
+#define PORT_PA31B_PTC_Y19                         (_UL_(1) << 31)
+
+/* ========== PORT definition for RTC peripheral ========== */
+#define PIN_PA08G_RTC_IN0                          _L_(8)       /**< RTC signal: IN0 on PA08 mux G*/
+#define MUX_PA08G_RTC_IN0                          _L_(6)      
+#define PINMUX_PA08G_RTC_IN0                       ((PIN_PA08G_RTC_IN0 << 16) | MUX_PA08G_RTC_IN0)
+#define PORT_PA08G_RTC_IN0                         (_UL_(1) << 8)
+
+#define PIN_PA09G_RTC_IN1                          _L_(9)       /**< RTC signal: IN1 on PA09 mux G*/
+#define MUX_PA09G_RTC_IN1                          _L_(6)      
+#define PINMUX_PA09G_RTC_IN1                       ((PIN_PA09G_RTC_IN1 << 16) | MUX_PA09G_RTC_IN1)
+#define PORT_PA09G_RTC_IN1                         (_UL_(1) << 9)
+
+#define PIN_PA16G_RTC_IN2                          _L_(16)      /**< RTC signal: IN2 on PA16 mux G*/
+#define MUX_PA16G_RTC_IN2                          _L_(6)      
+#define PINMUX_PA16G_RTC_IN2                       ((PIN_PA16G_RTC_IN2 << 16) | MUX_PA16G_RTC_IN2)
+#define PORT_PA16G_RTC_IN2                         (_UL_(1) << 16)
+
+#define PIN_PA17G_RTC_IN3                          _L_(17)      /**< RTC signal: IN3 on PA17 mux G*/
+#define MUX_PA17G_RTC_IN3                          _L_(6)      
+#define PINMUX_PA17G_RTC_IN3                       ((PIN_PA17G_RTC_IN3 << 16) | MUX_PA17G_RTC_IN3)
+#define PORT_PA17G_RTC_IN3                         (_UL_(1) << 17)
+
+#define PIN_PA18G_RTC_OUT0                         _L_(18)      /**< RTC signal: OUT0 on PA18 mux G*/
+#define MUX_PA18G_RTC_OUT0                         _L_(6)      
+#define PINMUX_PA18G_RTC_OUT0                      ((PIN_PA18G_RTC_OUT0 << 16) | MUX_PA18G_RTC_OUT0)
+#define PORT_PA18G_RTC_OUT0                        (_UL_(1) << 18)
+
+#define PIN_PA19G_RTC_OUT1                         _L_(19)      /**< RTC signal: OUT1 on PA19 mux G*/
+#define MUX_PA19G_RTC_OUT1                         _L_(6)      
+#define PINMUX_PA19G_RTC_OUT1                      ((PIN_PA19G_RTC_OUT1 << 16) | MUX_PA19G_RTC_OUT1)
+#define PORT_PA19G_RTC_OUT1                        (_UL_(1) << 19)
+
+#define PIN_PA22G_RTC_OUT2                         _L_(22)      /**< RTC signal: OUT2 on PA22 mux G*/
+#define MUX_PA22G_RTC_OUT2                         _L_(6)      
+#define PINMUX_PA22G_RTC_OUT2                      ((PIN_PA22G_RTC_OUT2 << 16) | MUX_PA22G_RTC_OUT2)
+#define PORT_PA22G_RTC_OUT2                        (_UL_(1) << 22)
+
+#define PIN_PA23G_RTC_OUT3                         _L_(23)      /**< RTC signal: OUT3 on PA23 mux G*/
+#define MUX_PA23G_RTC_OUT3                         _L_(6)      
+#define PINMUX_PA23G_RTC_OUT3                      ((PIN_PA23G_RTC_OUT3 << 16) | MUX_PA23G_RTC_OUT3)
+#define PORT_PA23G_RTC_OUT3                        (_UL_(1) << 23)
+
+/* ========== PORT definition for SERCOM0 peripheral ========== */
+#define PIN_PA04D_SERCOM0_PAD0                     _L_(4)       /**< SERCOM0 signal: PAD0 on PA04 mux D*/
+#define MUX_PA04D_SERCOM0_PAD0                     _L_(3)      
+#define PINMUX_PA04D_SERCOM0_PAD0                  ((PIN_PA04D_SERCOM0_PAD0 << 16) | MUX_PA04D_SERCOM0_PAD0)
+#define PORT_PA04D_SERCOM0_PAD0                    (_UL_(1) << 4)
+
+#define PIN_PA16D_SERCOM0_PAD0                     _L_(16)      /**< SERCOM0 signal: PAD0 on PA16 mux D*/
+#define MUX_PA16D_SERCOM0_PAD0                     _L_(3)      
+#define PINMUX_PA16D_SERCOM0_PAD0                  ((PIN_PA16D_SERCOM0_PAD0 << 16) | MUX_PA16D_SERCOM0_PAD0)
+#define PORT_PA16D_SERCOM0_PAD0                    (_UL_(1) << 16)
+
+#define PIN_PA22C_SERCOM0_PAD0                     _L_(22)      /**< SERCOM0 signal: PAD0 on PA22 mux C*/
+#define MUX_PA22C_SERCOM0_PAD0                     _L_(2)      
+#define PINMUX_PA22C_SERCOM0_PAD0                  ((PIN_PA22C_SERCOM0_PAD0 << 16) | MUX_PA22C_SERCOM0_PAD0)
+#define PORT_PA22C_SERCOM0_PAD0                    (_UL_(1) << 22)
+
+#define PIN_PA05D_SERCOM0_PAD1                     _L_(5)       /**< SERCOM0 signal: PAD1 on PA05 mux D*/
+#define MUX_PA05D_SERCOM0_PAD1                     _L_(3)      
+#define PINMUX_PA05D_SERCOM0_PAD1                  ((PIN_PA05D_SERCOM0_PAD1 << 16) | MUX_PA05D_SERCOM0_PAD1)
+#define PORT_PA05D_SERCOM0_PAD1                    (_UL_(1) << 5)
+
+#define PIN_PA17D_SERCOM0_PAD1                     _L_(17)      /**< SERCOM0 signal: PAD1 on PA17 mux D*/
+#define MUX_PA17D_SERCOM0_PAD1                     _L_(3)      
+#define PINMUX_PA17D_SERCOM0_PAD1                  ((PIN_PA17D_SERCOM0_PAD1 << 16) | MUX_PA17D_SERCOM0_PAD1)
+#define PORT_PA17D_SERCOM0_PAD1                    (_UL_(1) << 17)
+
+#define PIN_PA23C_SERCOM0_PAD1                     _L_(23)      /**< SERCOM0 signal: PAD1 on PA23 mux C*/
+#define MUX_PA23C_SERCOM0_PAD1                     _L_(2)      
+#define PINMUX_PA23C_SERCOM0_PAD1                  ((PIN_PA23C_SERCOM0_PAD1 << 16) | MUX_PA23C_SERCOM0_PAD1)
+#define PORT_PA23C_SERCOM0_PAD1                    (_UL_(1) << 23)
+
+#define PIN_PA06D_SERCOM0_PAD2                     _L_(6)       /**< SERCOM0 signal: PAD2 on PA06 mux D*/
+#define MUX_PA06D_SERCOM0_PAD2                     _L_(3)      
+#define PINMUX_PA06D_SERCOM0_PAD2                  ((PIN_PA06D_SERCOM0_PAD2 << 16) | MUX_PA06D_SERCOM0_PAD2)
+#define PORT_PA06D_SERCOM0_PAD2                    (_UL_(1) << 6)
+
+#define PIN_PA14D_SERCOM0_PAD2                     _L_(14)      /**< SERCOM0 signal: PAD2 on PA14 mux D*/
+#define MUX_PA14D_SERCOM0_PAD2                     _L_(3)      
+#define PINMUX_PA14D_SERCOM0_PAD2                  ((PIN_PA14D_SERCOM0_PAD2 << 16) | MUX_PA14D_SERCOM0_PAD2)
+#define PORT_PA14D_SERCOM0_PAD2                    (_UL_(1) << 14)
+
+#define PIN_PA18D_SERCOM0_PAD2                     _L_(18)      /**< SERCOM0 signal: PAD2 on PA18 mux D*/
+#define MUX_PA18D_SERCOM0_PAD2                     _L_(3)      
+#define PINMUX_PA18D_SERCOM0_PAD2                  ((PIN_PA18D_SERCOM0_PAD2 << 16) | MUX_PA18D_SERCOM0_PAD2)
+#define PORT_PA18D_SERCOM0_PAD2                    (_UL_(1) << 18)
+
+#define PIN_PA24C_SERCOM0_PAD2                     _L_(24)      /**< SERCOM0 signal: PAD2 on PA24 mux C*/
+#define MUX_PA24C_SERCOM0_PAD2                     _L_(2)      
+#define PINMUX_PA24C_SERCOM0_PAD2                  ((PIN_PA24C_SERCOM0_PAD2 << 16) | MUX_PA24C_SERCOM0_PAD2)
+#define PORT_PA24C_SERCOM0_PAD2                    (_UL_(1) << 24)
+
+#define PIN_PA02D_SERCOM0_PAD2                     _L_(2)       /**< SERCOM0 signal: PAD2 on PA02 mux D*/
+#define MUX_PA02D_SERCOM0_PAD2                     _L_(3)      
+#define PINMUX_PA02D_SERCOM0_PAD2                  ((PIN_PA02D_SERCOM0_PAD2 << 16) | MUX_PA02D_SERCOM0_PAD2)
+#define PORT_PA02D_SERCOM0_PAD2                    (_UL_(1) << 2)
+
+#define PIN_PA07D_SERCOM0_PAD3                     _L_(7)       /**< SERCOM0 signal: PAD3 on PA07 mux D*/
+#define MUX_PA07D_SERCOM0_PAD3                     _L_(3)      
+#define PINMUX_PA07D_SERCOM0_PAD3                  ((PIN_PA07D_SERCOM0_PAD3 << 16) | MUX_PA07D_SERCOM0_PAD3)
+#define PORT_PA07D_SERCOM0_PAD3                    (_UL_(1) << 7)
+
+#define PIN_PA15D_SERCOM0_PAD3                     _L_(15)      /**< SERCOM0 signal: PAD3 on PA15 mux D*/
+#define MUX_PA15D_SERCOM0_PAD3                     _L_(3)      
+#define PINMUX_PA15D_SERCOM0_PAD3                  ((PIN_PA15D_SERCOM0_PAD3 << 16) | MUX_PA15D_SERCOM0_PAD3)
+#define PORT_PA15D_SERCOM0_PAD3                    (_UL_(1) << 15)
+
+#define PIN_PA19D_SERCOM0_PAD3                     _L_(19)      /**< SERCOM0 signal: PAD3 on PA19 mux D*/
+#define MUX_PA19D_SERCOM0_PAD3                     _L_(3)      
+#define PINMUX_PA19D_SERCOM0_PAD3                  ((PIN_PA19D_SERCOM0_PAD3 << 16) | MUX_PA19D_SERCOM0_PAD3)
+#define PORT_PA19D_SERCOM0_PAD3                    (_UL_(1) << 19)
+
+#define PIN_PA25C_SERCOM0_PAD3                     _L_(25)      /**< SERCOM0 signal: PAD3 on PA25 mux C*/
+#define MUX_PA25C_SERCOM0_PAD3                     _L_(2)      
+#define PINMUX_PA25C_SERCOM0_PAD3                  ((PIN_PA25C_SERCOM0_PAD3 << 16) | MUX_PA25C_SERCOM0_PAD3)
+#define PORT_PA25C_SERCOM0_PAD3                    (_UL_(1) << 25)
+
+#define PIN_PA03D_SERCOM0_PAD3                     _L_(3)       /**< SERCOM0 signal: PAD3 on PA03 mux D*/
+#define MUX_PA03D_SERCOM0_PAD3                     _L_(3)      
+#define PINMUX_PA03D_SERCOM0_PAD3                  ((PIN_PA03D_SERCOM0_PAD3 << 16) | MUX_PA03D_SERCOM0_PAD3)
+#define PORT_PA03D_SERCOM0_PAD3                    (_UL_(1) << 3)
+
+/* ========== PORT definition for SERCOM1 peripheral ========== */
+#define PIN_PA16C_SERCOM1_PAD0                     _L_(16)      /**< SERCOM1 signal: PAD0 on PA16 mux C*/
+#define MUX_PA16C_SERCOM1_PAD0                     _L_(2)      
+#define PINMUX_PA16C_SERCOM1_PAD0                  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
+#define PORT_PA16C_SERCOM1_PAD0                    (_UL_(1) << 16)
+
+#define PIN_PA08C_SERCOM1_PAD0                     _L_(8)       /**< SERCOM1 signal: PAD0 on PA08 mux C*/
+#define MUX_PA08C_SERCOM1_PAD0                     _L_(2)      
+#define PINMUX_PA08C_SERCOM1_PAD0                  ((PIN_PA08C_SERCOM1_PAD0 << 16) | MUX_PA08C_SERCOM1_PAD0)
+#define PORT_PA08C_SERCOM1_PAD0                    (_UL_(1) << 8)
+
+#define PIN_PA00D_SERCOM1_PAD0                     _L_(0)       /**< SERCOM1 signal: PAD0 on PA00 mux D*/
+#define MUX_PA00D_SERCOM1_PAD0                     _L_(3)      
+#define PINMUX_PA00D_SERCOM1_PAD0                  ((PIN_PA00D_SERCOM1_PAD0 << 16) | MUX_PA00D_SERCOM1_PAD0)
+#define PORT_PA00D_SERCOM1_PAD0                    (_UL_(1) << 0)
+
+#define PIN_PA17C_SERCOM1_PAD1                     _L_(17)      /**< SERCOM1 signal: PAD1 on PA17 mux C*/
+#define MUX_PA17C_SERCOM1_PAD1                     _L_(2)      
+#define PINMUX_PA17C_SERCOM1_PAD1                  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
+#define PORT_PA17C_SERCOM1_PAD1                    (_UL_(1) << 17)
+
+#define PIN_PA09C_SERCOM1_PAD1                     _L_(9)       /**< SERCOM1 signal: PAD1 on PA09 mux C*/
+#define MUX_PA09C_SERCOM1_PAD1                     _L_(2)      
+#define PINMUX_PA09C_SERCOM1_PAD1                  ((PIN_PA09C_SERCOM1_PAD1 << 16) | MUX_PA09C_SERCOM1_PAD1)
+#define PORT_PA09C_SERCOM1_PAD1                    (_UL_(1) << 9)
+
+#define PIN_PA01D_SERCOM1_PAD1                     _L_(1)       /**< SERCOM1 signal: PAD1 on PA01 mux D*/
+#define MUX_PA01D_SERCOM1_PAD1                     _L_(3)      
+#define PINMUX_PA01D_SERCOM1_PAD1                  ((PIN_PA01D_SERCOM1_PAD1 << 16) | MUX_PA01D_SERCOM1_PAD1)
+#define PORT_PA01D_SERCOM1_PAD1                    (_UL_(1) << 1)
+
+#define PIN_PA18C_SERCOM1_PAD2                     _L_(18)      /**< SERCOM1 signal: PAD2 on PA18 mux C*/
+#define MUX_PA18C_SERCOM1_PAD2                     _L_(2)      
+#define PINMUX_PA18C_SERCOM1_PAD2                  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
+#define PORT_PA18C_SERCOM1_PAD2                    (_UL_(1) << 18)
+
+#define PIN_PA10C_SERCOM1_PAD2                     _L_(10)      /**< SERCOM1 signal: PAD2 on PA10 mux C*/
+#define MUX_PA10C_SERCOM1_PAD2                     _L_(2)      
+#define PINMUX_PA10C_SERCOM1_PAD2                  ((PIN_PA10C_SERCOM1_PAD2 << 16) | MUX_PA10C_SERCOM1_PAD2)
+#define PORT_PA10C_SERCOM1_PAD2                    (_UL_(1) << 10)
+
+#define PIN_PA30D_SERCOM1_PAD2                     _L_(30)      /**< SERCOM1 signal: PAD2 on PA30 mux D*/
+#define MUX_PA30D_SERCOM1_PAD2                     _L_(3)      
+#define PINMUX_PA30D_SERCOM1_PAD2                  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
+#define PORT_PA30D_SERCOM1_PAD2                    (_UL_(1) << 30)
+
+#define PIN_PA19C_SERCOM1_PAD3                     _L_(19)      /**< SERCOM1 signal: PAD3 on PA19 mux C*/
+#define MUX_PA19C_SERCOM1_PAD3                     _L_(2)      
+#define PINMUX_PA19C_SERCOM1_PAD3                  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
+#define PORT_PA19C_SERCOM1_PAD3                    (_UL_(1) << 19)
+
+#define PIN_PA11C_SERCOM1_PAD3                     _L_(11)      /**< SERCOM1 signal: PAD3 on PA11 mux C*/
+#define MUX_PA11C_SERCOM1_PAD3                     _L_(2)      
+#define PINMUX_PA11C_SERCOM1_PAD3                  ((PIN_PA11C_SERCOM1_PAD3 << 16) | MUX_PA11C_SERCOM1_PAD3)
+#define PORT_PA11C_SERCOM1_PAD3                    (_UL_(1) << 11)
+
+#define PIN_PA31D_SERCOM1_PAD3                     _L_(31)      /**< SERCOM1 signal: PAD3 on PA31 mux D*/
+#define MUX_PA31D_SERCOM1_PAD3                     _L_(3)      
+#define PINMUX_PA31D_SERCOM1_PAD3                  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
+#define PORT_PA31D_SERCOM1_PAD3                    (_UL_(1) << 31)
+
+/* ========== PORT definition for SERCOM2 peripheral ========== */
+#define PIN_PA08D_SERCOM2_PAD0                     _L_(8)       /**< SERCOM2 signal: PAD0 on PA08 mux D*/
+#define MUX_PA08D_SERCOM2_PAD0                     _L_(3)      
+#define PINMUX_PA08D_SERCOM2_PAD0                  ((PIN_PA08D_SERCOM2_PAD0 << 16) | MUX_PA08D_SERCOM2_PAD0)
+#define PORT_PA08D_SERCOM2_PAD0                    (_UL_(1) << 8)
+
+#define PIN_PA22D_SERCOM2_PAD0                     _L_(22)      /**< SERCOM2 signal: PAD0 on PA22 mux D*/
+#define MUX_PA22D_SERCOM2_PAD0                     _L_(3)      
+#define PINMUX_PA22D_SERCOM2_PAD0                  ((PIN_PA22D_SERCOM2_PAD0 << 16) | MUX_PA22D_SERCOM2_PAD0)
+#define PORT_PA22D_SERCOM2_PAD0                    (_UL_(1) << 22)
+
+#define PIN_PA09D_SERCOM2_PAD1                     _L_(9)       /**< SERCOM2 signal: PAD1 on PA09 mux D*/
+#define MUX_PA09D_SERCOM2_PAD1                     _L_(3)      
+#define PINMUX_PA09D_SERCOM2_PAD1                  ((PIN_PA09D_SERCOM2_PAD1 << 16) | MUX_PA09D_SERCOM2_PAD1)
+#define PORT_PA09D_SERCOM2_PAD1                    (_UL_(1) << 9)
+
+#define PIN_PA23D_SERCOM2_PAD1                     _L_(23)      /**< SERCOM2 signal: PAD1 on PA23 mux D*/
+#define MUX_PA23D_SERCOM2_PAD1                     _L_(3)      
+#define PINMUX_PA23D_SERCOM2_PAD1                  ((PIN_PA23D_SERCOM2_PAD1 << 16) | MUX_PA23D_SERCOM2_PAD1)
+#define PORT_PA23D_SERCOM2_PAD1                    (_UL_(1) << 23)
+
+#define PIN_PA10D_SERCOM2_PAD2                     _L_(10)      /**< SERCOM2 signal: PAD2 on PA10 mux D*/
+#define MUX_PA10D_SERCOM2_PAD2                     _L_(3)      
+#define PINMUX_PA10D_SERCOM2_PAD2                  ((PIN_PA10D_SERCOM2_PAD2 << 16) | MUX_PA10D_SERCOM2_PAD2)
+#define PORT_PA10D_SERCOM2_PAD2                    (_UL_(1) << 10)
+
+#define PIN_PA24D_SERCOM2_PAD2                     _L_(24)      /**< SERCOM2 signal: PAD2 on PA24 mux D*/
+#define MUX_PA24D_SERCOM2_PAD2                     _L_(3)      
+#define PINMUX_PA24D_SERCOM2_PAD2                  ((PIN_PA24D_SERCOM2_PAD2 << 16) | MUX_PA24D_SERCOM2_PAD2)
+#define PORT_PA24D_SERCOM2_PAD2                    (_UL_(1) << 24)
+
+#define PIN_PA14C_SERCOM2_PAD2                     _L_(14)      /**< SERCOM2 signal: PAD2 on PA14 mux C*/
+#define MUX_PA14C_SERCOM2_PAD2                     _L_(2)      
+#define PINMUX_PA14C_SERCOM2_PAD2                  ((PIN_PA14C_SERCOM2_PAD2 << 16) | MUX_PA14C_SERCOM2_PAD2)
+#define PORT_PA14C_SERCOM2_PAD2                    (_UL_(1) << 14)
+
+#define PIN_PA11D_SERCOM2_PAD3                     _L_(11)      /**< SERCOM2 signal: PAD3 on PA11 mux D*/
+#define MUX_PA11D_SERCOM2_PAD3                     _L_(3)      
+#define PINMUX_PA11D_SERCOM2_PAD3                  ((PIN_PA11D_SERCOM2_PAD3 << 16) | MUX_PA11D_SERCOM2_PAD3)
+#define PORT_PA11D_SERCOM2_PAD3                    (_UL_(1) << 11)
+
+#define PIN_PA25D_SERCOM2_PAD3                     _L_(25)      /**< SERCOM2 signal: PAD3 on PA25 mux D*/
+#define MUX_PA25D_SERCOM2_PAD3                     _L_(3)      
+#define PINMUX_PA25D_SERCOM2_PAD3                  ((PIN_PA25D_SERCOM2_PAD3 << 16) | MUX_PA25D_SERCOM2_PAD3)
+#define PORT_PA25D_SERCOM2_PAD3                    (_UL_(1) << 25)
+
+#define PIN_PA15C_SERCOM2_PAD3                     _L_(15)      /**< SERCOM2 signal: PAD3 on PA15 mux C*/
+#define MUX_PA15C_SERCOM2_PAD3                     _L_(2)      
+#define PINMUX_PA15C_SERCOM2_PAD3                  ((PIN_PA15C_SERCOM2_PAD3 << 16) | MUX_PA15C_SERCOM2_PAD3)
+#define PORT_PA15C_SERCOM2_PAD3                    (_UL_(1) << 15)
+
+/* ========== PORT definition for TC0 peripheral ========== */
+#define PIN_PA04E_TC0_WO0                          _L_(4)       /**< TC0 signal: WO0 on PA04 mux E*/
+#define MUX_PA04E_TC0_WO0                          _L_(4)      
+#define PINMUX_PA04E_TC0_WO0                       ((PIN_PA04E_TC0_WO0 << 16) | MUX_PA04E_TC0_WO0)
+#define PORT_PA04E_TC0_WO0                         (_UL_(1) << 4)
+
+#define PIN_PA14E_TC0_WO0                          _L_(14)      /**< TC0 signal: WO0 on PA14 mux E*/
+#define MUX_PA14E_TC0_WO0                          _L_(4)      
+#define PINMUX_PA14E_TC0_WO0                       ((PIN_PA14E_TC0_WO0 << 16) | MUX_PA14E_TC0_WO0)
+#define PORT_PA14E_TC0_WO0                         (_UL_(1) << 14)
+
+#define PIN_PA22E_TC0_WO0                          _L_(22)      /**< TC0 signal: WO0 on PA22 mux E*/
+#define MUX_PA22E_TC0_WO0                          _L_(4)      
+#define PINMUX_PA22E_TC0_WO0                       ((PIN_PA22E_TC0_WO0 << 16) | MUX_PA22E_TC0_WO0)
+#define PORT_PA22E_TC0_WO0                         (_UL_(1) << 22)
+
+#define PIN_PA05E_TC0_WO1                          _L_(5)       /**< TC0 signal: WO1 on PA05 mux E*/
+#define MUX_PA05E_TC0_WO1                          _L_(4)      
+#define PINMUX_PA05E_TC0_WO1                       ((PIN_PA05E_TC0_WO1 << 16) | MUX_PA05E_TC0_WO1)
+#define PORT_PA05E_TC0_WO1                         (_UL_(1) << 5)
+
+#define PIN_PA15E_TC0_WO1                          _L_(15)      /**< TC0 signal: WO1 on PA15 mux E*/
+#define MUX_PA15E_TC0_WO1                          _L_(4)      
+#define PINMUX_PA15E_TC0_WO1                       ((PIN_PA15E_TC0_WO1 << 16) | MUX_PA15E_TC0_WO1)
+#define PORT_PA15E_TC0_WO1                         (_UL_(1) << 15)
+
+#define PIN_PA23E_TC0_WO1                          _L_(23)      /**< TC0 signal: WO1 on PA23 mux E*/
+#define MUX_PA23E_TC0_WO1                          _L_(4)      
+#define PINMUX_PA23E_TC0_WO1                       ((PIN_PA23E_TC0_WO1 << 16) | MUX_PA23E_TC0_WO1)
+#define PORT_PA23E_TC0_WO1                         (_UL_(1) << 23)
+
+/* ========== PORT definition for TC1 peripheral ========== */
+#define PIN_PA06E_TC1_WO0                          _L_(6)       /**< TC1 signal: WO0 on PA06 mux E*/
+#define MUX_PA06E_TC1_WO0                          _L_(4)      
+#define PINMUX_PA06E_TC1_WO0                       ((PIN_PA06E_TC1_WO0 << 16) | MUX_PA06E_TC1_WO0)
+#define PORT_PA06E_TC1_WO0                         (_UL_(1) << 6)
+
+#define PIN_PA24E_TC1_WO0                          _L_(24)      /**< TC1 signal: WO0 on PA24 mux E*/
+#define MUX_PA24E_TC1_WO0                          _L_(4)      
+#define PINMUX_PA24E_TC1_WO0                       ((PIN_PA24E_TC1_WO0 << 16) | MUX_PA24E_TC1_WO0)
+#define PORT_PA24E_TC1_WO0                         (_UL_(1) << 24)
+
+#define PIN_PA30E_TC1_WO0                          _L_(30)      /**< TC1 signal: WO0 on PA30 mux E*/
+#define MUX_PA30E_TC1_WO0                          _L_(4)      
+#define PINMUX_PA30E_TC1_WO0                       ((PIN_PA30E_TC1_WO0 << 16) | MUX_PA30E_TC1_WO0)
+#define PORT_PA30E_TC1_WO0                         (_UL_(1) << 30)
+
+#define PIN_PA07E_TC1_WO1                          _L_(7)       /**< TC1 signal: WO1 on PA07 mux E*/
+#define MUX_PA07E_TC1_WO1                          _L_(4)      
+#define PINMUX_PA07E_TC1_WO1                       ((PIN_PA07E_TC1_WO1 << 16) | MUX_PA07E_TC1_WO1)
+#define PORT_PA07E_TC1_WO1                         (_UL_(1) << 7)
+
+#define PIN_PA25E_TC1_WO1                          _L_(25)      /**< TC1 signal: WO1 on PA25 mux E*/
+#define MUX_PA25E_TC1_WO1                          _L_(4)      
+#define PINMUX_PA25E_TC1_WO1                       ((PIN_PA25E_TC1_WO1 << 16) | MUX_PA25E_TC1_WO1)
+#define PORT_PA25E_TC1_WO1                         (_UL_(1) << 25)
+
+#define PIN_PA31E_TC1_WO1                          _L_(31)      /**< TC1 signal: WO1 on PA31 mux E*/
+#define MUX_PA31E_TC1_WO1                          _L_(4)      
+#define PINMUX_PA31E_TC1_WO1                       ((PIN_PA31E_TC1_WO1 << 16) | MUX_PA31E_TC1_WO1)
+#define PORT_PA31E_TC1_WO1                         (_UL_(1) << 31)
+
+/* ========== PORT definition for TC2 peripheral ========== */
+#define PIN_PA00E_TC2_WO0                          _L_(0)       /**< TC2 signal: WO0 on PA00 mux E*/
+#define MUX_PA00E_TC2_WO0                          _L_(4)      
+#define PINMUX_PA00E_TC2_WO0                       ((PIN_PA00E_TC2_WO0 << 16) | MUX_PA00E_TC2_WO0)
+#define PORT_PA00E_TC2_WO0                         (_UL_(1) << 0)
+
+#define PIN_PA18E_TC2_WO0                          _L_(18)      /**< TC2 signal: WO0 on PA18 mux E*/
+#define MUX_PA18E_TC2_WO0                          _L_(4)      
+#define PINMUX_PA18E_TC2_WO0                       ((PIN_PA18E_TC2_WO0 << 16) | MUX_PA18E_TC2_WO0)
+#define PORT_PA18E_TC2_WO0                         (_UL_(1) << 18)
+
+#define PIN_PA01E_TC2_WO1                          _L_(1)       /**< TC2 signal: WO1 on PA01 mux E*/
+#define MUX_PA01E_TC2_WO1                          _L_(4)      
+#define PINMUX_PA01E_TC2_WO1                       ((PIN_PA01E_TC2_WO1 << 16) | MUX_PA01E_TC2_WO1)
+#define PORT_PA01E_TC2_WO1                         (_UL_(1) << 1)
+
+#define PIN_PA19E_TC2_WO1                          _L_(19)      /**< TC2 signal: WO1 on PA19 mux E*/
+#define MUX_PA19E_TC2_WO1                          _L_(4)      
+#define PINMUX_PA19E_TC2_WO1                       ((PIN_PA19E_TC2_WO1 << 16) | MUX_PA19E_TC2_WO1)
+#define PORT_PA19E_TC2_WO1                         (_UL_(1) << 19)
+
+
+#endif /* _SAML10E15A_PIO_H_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/pio/saml10e16a.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/pio/saml10e16a.h
@@ -1,0 +1,1167 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAML10E16A
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10E16A_PIO_H_
+#define _SAML10E16A_PIO_H_
+
+/* ========== Peripheral I/O pin numbers ========== */
+#define PIN_PA00                    (  0)  /**< Pin Number for PA00 */
+#define PIN_PA01                    (  1)  /**< Pin Number for PA01 */
+#define PIN_PA02                    (  2)  /**< Pin Number for PA02 */
+#define PIN_PA03                    (  3)  /**< Pin Number for PA03 */
+#define PIN_PA04                    (  4)  /**< Pin Number for PA04 */
+#define PIN_PA05                    (  5)  /**< Pin Number for PA05 */
+#define PIN_PA06                    (  6)  /**< Pin Number for PA06 */
+#define PIN_PA07                    (  7)  /**< Pin Number for PA07 */
+#define PIN_PA08                    (  8)  /**< Pin Number for PA08 */
+#define PIN_PA09                    (  9)  /**< Pin Number for PA09 */
+#define PIN_PA10                    ( 10)  /**< Pin Number for PA10 */
+#define PIN_PA11                    ( 11)  /**< Pin Number for PA11 */
+#define PIN_PA14                    ( 14)  /**< Pin Number for PA14 */
+#define PIN_PA15                    ( 15)  /**< Pin Number for PA15 */
+#define PIN_PA16                    ( 16)  /**< Pin Number for PA16 */
+#define PIN_PA17                    ( 17)  /**< Pin Number for PA17 */
+#define PIN_PA18                    ( 18)  /**< Pin Number for PA18 */
+#define PIN_PA19                    ( 19)  /**< Pin Number for PA19 */
+#define PIN_PA22                    ( 22)  /**< Pin Number for PA22 */
+#define PIN_PA23                    ( 23)  /**< Pin Number for PA23 */
+#define PIN_PA24                    ( 24)  /**< Pin Number for PA24 */
+#define PIN_PA25                    ( 25)  /**< Pin Number for PA25 */
+#define PIN_PA27                    ( 27)  /**< Pin Number for PA27 */
+#define PIN_PA30                    ( 30)  /**< Pin Number for PA30 */
+#define PIN_PA31                    ( 31)  /**< Pin Number for PA31 */
+
+
+/* ========== Peripheral I/O masks ========== */
+#define PORT_PA00                   (_U_(1) << 0) /**< PORT Mask for PA00 */
+#define PORT_PA01                   (_U_(1) << 1) /**< PORT Mask for PA01 */
+#define PORT_PA02                   (_U_(1) << 2) /**< PORT Mask for PA02 */
+#define PORT_PA03                   (_U_(1) << 3) /**< PORT Mask for PA03 */
+#define PORT_PA04                   (_U_(1) << 4) /**< PORT Mask for PA04 */
+#define PORT_PA05                   (_U_(1) << 5) /**< PORT Mask for PA05 */
+#define PORT_PA06                   (_U_(1) << 6) /**< PORT Mask for PA06 */
+#define PORT_PA07                   (_U_(1) << 7) /**< PORT Mask for PA07 */
+#define PORT_PA08                   (_U_(1) << 8) /**< PORT Mask for PA08 */
+#define PORT_PA09                   (_U_(1) << 9) /**< PORT Mask for PA09 */
+#define PORT_PA10                   (_U_(1) << 10) /**< PORT Mask for PA10 */
+#define PORT_PA11                   (_U_(1) << 11) /**< PORT Mask for PA11 */
+#define PORT_PA14                   (_U_(1) << 14) /**< PORT Mask for PA14 */
+#define PORT_PA15                   (_U_(1) << 15) /**< PORT Mask for PA15 */
+#define PORT_PA16                   (_U_(1) << 16) /**< PORT Mask for PA16 */
+#define PORT_PA17                   (_U_(1) << 17) /**< PORT Mask for PA17 */
+#define PORT_PA18                   (_U_(1) << 18) /**< PORT Mask for PA18 */
+#define PORT_PA19                   (_U_(1) << 19) /**< PORT Mask for PA19 */
+#define PORT_PA22                   (_U_(1) << 22) /**< PORT Mask for PA22 */
+#define PORT_PA23                   (_U_(1) << 23) /**< PORT Mask for PA23 */
+#define PORT_PA24                   (_U_(1) << 24) /**< PORT Mask for PA24 */
+#define PORT_PA25                   (_U_(1) << 25) /**< PORT Mask for PA25 */
+#define PORT_PA27                   (_U_(1) << 27) /**< PORT Mask for PA27 */
+#define PORT_PA30                   (_U_(1) << 30) /**< PORT Mask for PA30 */
+#define PORT_PA31                   (_U_(1) << 31) /**< PORT Mask for PA31 */
+
+
+/* ========== Peripheral I/O indexes ========== */
+#define PORT_PA00_IDX               (  0)  /**< PORT Index Number for PA00 */
+#define PORT_PA01_IDX               (  1)  /**< PORT Index Number for PA01 */
+#define PORT_PA02_IDX               (  2)  /**< PORT Index Number for PA02 */
+#define PORT_PA03_IDX               (  3)  /**< PORT Index Number for PA03 */
+#define PORT_PA04_IDX               (  4)  /**< PORT Index Number for PA04 */
+#define PORT_PA05_IDX               (  5)  /**< PORT Index Number for PA05 */
+#define PORT_PA06_IDX               (  6)  /**< PORT Index Number for PA06 */
+#define PORT_PA07_IDX               (  7)  /**< PORT Index Number for PA07 */
+#define PORT_PA08_IDX               (  8)  /**< PORT Index Number for PA08 */
+#define PORT_PA09_IDX               (  9)  /**< PORT Index Number for PA09 */
+#define PORT_PA10_IDX               ( 10)  /**< PORT Index Number for PA10 */
+#define PORT_PA11_IDX               ( 11)  /**< PORT Index Number for PA11 */
+#define PORT_PA14_IDX               ( 14)  /**< PORT Index Number for PA14 */
+#define PORT_PA15_IDX               ( 15)  /**< PORT Index Number for PA15 */
+#define PORT_PA16_IDX               ( 16)  /**< PORT Index Number for PA16 */
+#define PORT_PA17_IDX               ( 17)  /**< PORT Index Number for PA17 */
+#define PORT_PA18_IDX               ( 18)  /**< PORT Index Number for PA18 */
+#define PORT_PA19_IDX               ( 19)  /**< PORT Index Number for PA19 */
+#define PORT_PA22_IDX               ( 22)  /**< PORT Index Number for PA22 */
+#define PORT_PA23_IDX               ( 23)  /**< PORT Index Number for PA23 */
+#define PORT_PA24_IDX               ( 24)  /**< PORT Index Number for PA24 */
+#define PORT_PA25_IDX               ( 25)  /**< PORT Index Number for PA25 */
+#define PORT_PA27_IDX               ( 27)  /**< PORT Index Number for PA27 */
+#define PORT_PA30_IDX               ( 30)  /**< PORT Index Number for PA30 */
+#define PORT_PA31_IDX               ( 31)  /**< PORT Index Number for PA31 */
+
+/* ========== PORT definition for AC peripheral ========== */
+#define PIN_PA04B_AC_AIN0                          _L_(4)       /**< AC signal: AIN0 on PA04 mux B*/
+#define MUX_PA04B_AC_AIN0                          _L_(1)      
+#define PINMUX_PA04B_AC_AIN0                       ((PIN_PA04B_AC_AIN0 << 16) | MUX_PA04B_AC_AIN0)
+#define PORT_PA04B_AC_AIN0                         (_UL_(1) << 4)
+
+#define PIN_PA05B_AC_AIN1                          _L_(5)       /**< AC signal: AIN1 on PA05 mux B*/
+#define MUX_PA05B_AC_AIN1                          _L_(1)      
+#define PINMUX_PA05B_AC_AIN1                       ((PIN_PA05B_AC_AIN1 << 16) | MUX_PA05B_AC_AIN1)
+#define PORT_PA05B_AC_AIN1                         (_UL_(1) << 5)
+
+#define PIN_PA06B_AC_AIN2                          _L_(6)       /**< AC signal: AIN2 on PA06 mux B*/
+#define MUX_PA06B_AC_AIN2                          _L_(1)      
+#define PINMUX_PA06B_AC_AIN2                       ((PIN_PA06B_AC_AIN2 << 16) | MUX_PA06B_AC_AIN2)
+#define PORT_PA06B_AC_AIN2                         (_UL_(1) << 6)
+
+#define PIN_PA07B_AC_AIN3                          _L_(7)       /**< AC signal: AIN3 on PA07 mux B*/
+#define MUX_PA07B_AC_AIN3                          _L_(1)      
+#define PINMUX_PA07B_AC_AIN3                       ((PIN_PA07B_AC_AIN3 << 16) | MUX_PA07B_AC_AIN3)
+#define PORT_PA07B_AC_AIN3                         (_UL_(1) << 7)
+
+#define PIN_PA18H_AC_CMP0                          _L_(18)      /**< AC signal: CMP0 on PA18 mux H*/
+#define MUX_PA18H_AC_CMP0                          _L_(7)      
+#define PINMUX_PA18H_AC_CMP0                       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
+#define PORT_PA18H_AC_CMP0                         (_UL_(1) << 18)
+
+#define PIN_PA19H_AC_CMP1                          _L_(19)      /**< AC signal: CMP1 on PA19 mux H*/
+#define MUX_PA19H_AC_CMP1                          _L_(7)      
+#define PINMUX_PA19H_AC_CMP1                       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
+#define PORT_PA19H_AC_CMP1                         (_UL_(1) << 19)
+
+/* ========== PORT definition for ADC peripheral ========== */
+#define PIN_PA02B_ADC_AIN0                         _L_(2)       /**< ADC signal: AIN0 on PA02 mux B*/
+#define MUX_PA02B_ADC_AIN0                         _L_(1)      
+#define PINMUX_PA02B_ADC_AIN0                      ((PIN_PA02B_ADC_AIN0 << 16) | MUX_PA02B_ADC_AIN0)
+#define PORT_PA02B_ADC_AIN0                        (_UL_(1) << 2)
+
+#define PIN_PA03B_ADC_AIN1                         _L_(3)       /**< ADC signal: AIN1 on PA03 mux B*/
+#define MUX_PA03B_ADC_AIN1                         _L_(1)      
+#define PINMUX_PA03B_ADC_AIN1                      ((PIN_PA03B_ADC_AIN1 << 16) | MUX_PA03B_ADC_AIN1)
+#define PORT_PA03B_ADC_AIN1                        (_UL_(1) << 3)
+
+#define PIN_PA04B_ADC_AIN2                         _L_(4)       /**< ADC signal: AIN2 on PA04 mux B*/
+#define MUX_PA04B_ADC_AIN2                         _L_(1)      
+#define PINMUX_PA04B_ADC_AIN2                      ((PIN_PA04B_ADC_AIN2 << 16) | MUX_PA04B_ADC_AIN2)
+#define PORT_PA04B_ADC_AIN2                        (_UL_(1) << 4)
+
+#define PIN_PA05B_ADC_AIN3                         _L_(5)       /**< ADC signal: AIN3 on PA05 mux B*/
+#define MUX_PA05B_ADC_AIN3                         _L_(1)      
+#define PINMUX_PA05B_ADC_AIN3                      ((PIN_PA05B_ADC_AIN3 << 16) | MUX_PA05B_ADC_AIN3)
+#define PORT_PA05B_ADC_AIN3                        (_UL_(1) << 5)
+
+#define PIN_PA06B_ADC_AIN4                         _L_(6)       /**< ADC signal: AIN4 on PA06 mux B*/
+#define MUX_PA06B_ADC_AIN4                         _L_(1)      
+#define PINMUX_PA06B_ADC_AIN4                      ((PIN_PA06B_ADC_AIN4 << 16) | MUX_PA06B_ADC_AIN4)
+#define PORT_PA06B_ADC_AIN4                        (_UL_(1) << 6)
+
+#define PIN_PA07B_ADC_AIN5                         _L_(7)       /**< ADC signal: AIN5 on PA07 mux B*/
+#define MUX_PA07B_ADC_AIN5                         _L_(1)      
+#define PINMUX_PA07B_ADC_AIN5                      ((PIN_PA07B_ADC_AIN5 << 16) | MUX_PA07B_ADC_AIN5)
+#define PORT_PA07B_ADC_AIN5                        (_UL_(1) << 7)
+
+#define PIN_PA08B_ADC_AIN6                         _L_(8)       /**< ADC signal: AIN6 on PA08 mux B*/
+#define MUX_PA08B_ADC_AIN6                         _L_(1)      
+#define PINMUX_PA08B_ADC_AIN6                      ((PIN_PA08B_ADC_AIN6 << 16) | MUX_PA08B_ADC_AIN6)
+#define PORT_PA08B_ADC_AIN6                        (_UL_(1) << 8)
+
+#define PIN_PA09B_ADC_AIN7                         _L_(9)       /**< ADC signal: AIN7 on PA09 mux B*/
+#define MUX_PA09B_ADC_AIN7                         _L_(1)      
+#define PINMUX_PA09B_ADC_AIN7                      ((PIN_PA09B_ADC_AIN7 << 16) | MUX_PA09B_ADC_AIN7)
+#define PORT_PA09B_ADC_AIN7                        (_UL_(1) << 9)
+
+#define PIN_PA10B_ADC_AIN8                         _L_(10)      /**< ADC signal: AIN8 on PA10 mux B*/
+#define MUX_PA10B_ADC_AIN8                         _L_(1)      
+#define PINMUX_PA10B_ADC_AIN8                      ((PIN_PA10B_ADC_AIN8 << 16) | MUX_PA10B_ADC_AIN8)
+#define PORT_PA10B_ADC_AIN8                        (_UL_(1) << 10)
+
+#define PIN_PA11B_ADC_AIN9                         _L_(11)      /**< ADC signal: AIN9 on PA11 mux B*/
+#define MUX_PA11B_ADC_AIN9                         _L_(1)      
+#define PINMUX_PA11B_ADC_AIN9                      ((PIN_PA11B_ADC_AIN9 << 16) | MUX_PA11B_ADC_AIN9)
+#define PORT_PA11B_ADC_AIN9                        (_UL_(1) << 11)
+
+#define PIN_PA04B_ADC_VREFP                        _L_(4)       /**< ADC signal: VREFP on PA04 mux B*/
+#define MUX_PA04B_ADC_VREFP                        _L_(1)      
+#define PINMUX_PA04B_ADC_VREFP                     ((PIN_PA04B_ADC_VREFP << 16) | MUX_PA04B_ADC_VREFP)
+#define PORT_PA04B_ADC_VREFP                       (_UL_(1) << 4)
+
+/* ========== PORT definition for CCL peripheral ========== */
+#define PIN_PA04I_CCL_IN0                          _L_(4)       /**< CCL signal: IN0 on PA04 mux I*/
+#define MUX_PA04I_CCL_IN0                          _L_(8)      
+#define PINMUX_PA04I_CCL_IN0                       ((PIN_PA04I_CCL_IN0 << 16) | MUX_PA04I_CCL_IN0)
+#define PORT_PA04I_CCL_IN0                         (_UL_(1) << 4)
+
+#define PIN_PA16I_CCL_IN0                          _L_(16)      /**< CCL signal: IN0 on PA16 mux I*/
+#define MUX_PA16I_CCL_IN0                          _L_(8)      
+#define PINMUX_PA16I_CCL_IN0                       ((PIN_PA16I_CCL_IN0 << 16) | MUX_PA16I_CCL_IN0)
+#define PORT_PA16I_CCL_IN0                         (_UL_(1) << 16)
+
+#define PIN_PA05I_CCL_IN1                          _L_(5)       /**< CCL signal: IN1 on PA05 mux I*/
+#define MUX_PA05I_CCL_IN1                          _L_(8)      
+#define PINMUX_PA05I_CCL_IN1                       ((PIN_PA05I_CCL_IN1 << 16) | MUX_PA05I_CCL_IN1)
+#define PORT_PA05I_CCL_IN1                         (_UL_(1) << 5)
+
+#define PIN_PA17I_CCL_IN1                          _L_(17)      /**< CCL signal: IN1 on PA17 mux I*/
+#define MUX_PA17I_CCL_IN1                          _L_(8)      
+#define PINMUX_PA17I_CCL_IN1                       ((PIN_PA17I_CCL_IN1 << 16) | MUX_PA17I_CCL_IN1)
+#define PORT_PA17I_CCL_IN1                         (_UL_(1) << 17)
+
+#define PIN_PA06I_CCL_IN2                          _L_(6)       /**< CCL signal: IN2 on PA06 mux I*/
+#define MUX_PA06I_CCL_IN2                          _L_(8)      
+#define PINMUX_PA06I_CCL_IN2                       ((PIN_PA06I_CCL_IN2 << 16) | MUX_PA06I_CCL_IN2)
+#define PORT_PA06I_CCL_IN2                         (_UL_(1) << 6)
+
+#define PIN_PA18I_CCL_IN2                          _L_(18)      /**< CCL signal: IN2 on PA18 mux I*/
+#define MUX_PA18I_CCL_IN2                          _L_(8)      
+#define PINMUX_PA18I_CCL_IN2                       ((PIN_PA18I_CCL_IN2 << 16) | MUX_PA18I_CCL_IN2)
+#define PORT_PA18I_CCL_IN2                         (_UL_(1) << 18)
+
+#define PIN_PA08I_CCL_IN3                          _L_(8)       /**< CCL signal: IN3 on PA08 mux I*/
+#define MUX_PA08I_CCL_IN3                          _L_(8)      
+#define PINMUX_PA08I_CCL_IN3                       ((PIN_PA08I_CCL_IN3 << 16) | MUX_PA08I_CCL_IN3)
+#define PORT_PA08I_CCL_IN3                         (_UL_(1) << 8)
+
+#define PIN_PA30I_CCL_IN3                          _L_(30)      /**< CCL signal: IN3 on PA30 mux I*/
+#define MUX_PA30I_CCL_IN3                          _L_(8)      
+#define PINMUX_PA30I_CCL_IN3                       ((PIN_PA30I_CCL_IN3 << 16) | MUX_PA30I_CCL_IN3)
+#define PORT_PA30I_CCL_IN3                         (_UL_(1) << 30)
+
+#define PIN_PA09I_CCL_IN4                          _L_(9)       /**< CCL signal: IN4 on PA09 mux I*/
+#define MUX_PA09I_CCL_IN4                          _L_(8)      
+#define PINMUX_PA09I_CCL_IN4                       ((PIN_PA09I_CCL_IN4 << 16) | MUX_PA09I_CCL_IN4)
+#define PORT_PA09I_CCL_IN4                         (_UL_(1) << 9)
+
+#define PIN_PA10I_CCL_IN5                          _L_(10)      /**< CCL signal: IN5 on PA10 mux I*/
+#define MUX_PA10I_CCL_IN5                          _L_(8)      
+#define PINMUX_PA10I_CCL_IN5                       ((PIN_PA10I_CCL_IN5 << 16) | MUX_PA10I_CCL_IN5)
+#define PORT_PA10I_CCL_IN5                         (_UL_(1) << 10)
+
+#define PIN_PA07I_CCL_OUT0                         _L_(7)       /**< CCL signal: OUT0 on PA07 mux I*/
+#define MUX_PA07I_CCL_OUT0                         _L_(8)      
+#define PINMUX_PA07I_CCL_OUT0                      ((PIN_PA07I_CCL_OUT0 << 16) | MUX_PA07I_CCL_OUT0)
+#define PORT_PA07I_CCL_OUT0                        (_UL_(1) << 7)
+
+#define PIN_PA19I_CCL_OUT0                         _L_(19)      /**< CCL signal: OUT0 on PA19 mux I*/
+#define MUX_PA19I_CCL_OUT0                         _L_(8)      
+#define PINMUX_PA19I_CCL_OUT0                      ((PIN_PA19I_CCL_OUT0 << 16) | MUX_PA19I_CCL_OUT0)
+#define PORT_PA19I_CCL_OUT0                        (_UL_(1) << 19)
+
+#define PIN_PA11I_CCL_OUT1                         _L_(11)      /**< CCL signal: OUT1 on PA11 mux I*/
+#define MUX_PA11I_CCL_OUT1                         _L_(8)      
+#define PINMUX_PA11I_CCL_OUT1                      ((PIN_PA11I_CCL_OUT1 << 16) | MUX_PA11I_CCL_OUT1)
+#define PORT_PA11I_CCL_OUT1                        (_UL_(1) << 11)
+
+#define PIN_PA31I_CCL_OUT1                         _L_(31)      /**< CCL signal: OUT1 on PA31 mux I*/
+#define MUX_PA31I_CCL_OUT1                         _L_(8)      
+#define PINMUX_PA31I_CCL_OUT1                      ((PIN_PA31I_CCL_OUT1 << 16) | MUX_PA31I_CCL_OUT1)
+#define PORT_PA31I_CCL_OUT1                        (_UL_(1) << 31)
+
+/* ========== PORT definition for DAC peripheral ========== */
+#define PIN_PA02B_DAC_VOUT                         _L_(2)       /**< DAC signal: VOUT on PA02 mux B*/
+#define MUX_PA02B_DAC_VOUT                         _L_(1)      
+#define PINMUX_PA02B_DAC_VOUT                      ((PIN_PA02B_DAC_VOUT << 16) | MUX_PA02B_DAC_VOUT)
+#define PORT_PA02B_DAC_VOUT                        (_UL_(1) << 2)
+
+#define PIN_PA03B_DAC_VREFP                        _L_(3)       /**< DAC signal: VREFP on PA03 mux B*/
+#define MUX_PA03B_DAC_VREFP                        _L_(1)      
+#define PINMUX_PA03B_DAC_VREFP                     ((PIN_PA03B_DAC_VREFP << 16) | MUX_PA03B_DAC_VREFP)
+#define PORT_PA03B_DAC_VREFP                       (_UL_(1) << 3)
+
+/* ========== PORT definition for EIC peripheral ========== */
+#define PIN_PA09A_EIC_EXTINT0                      _L_(9)       /**< EIC signal: EXTINT0 on PA09 mux A*/
+#define MUX_PA09A_EIC_EXTINT0                      _L_(0)      
+#define PINMUX_PA09A_EIC_EXTINT0                   ((PIN_PA09A_EIC_EXTINT0 << 16) | MUX_PA09A_EIC_EXTINT0)
+#define PORT_PA09A_EIC_EXTINT0                     (_UL_(1) << 9)
+#define PIN_PA09A_EIC_EXTINT_NUM                   _L_(0)       /**< EIC signal: PIN_PA09 External Interrupt Line */
+
+#define PIN_PA19A_EIC_EXTINT0                      _L_(19)      /**< EIC signal: EXTINT0 on PA19 mux A*/
+#define MUX_PA19A_EIC_EXTINT0                      _L_(0)      
+#define PINMUX_PA19A_EIC_EXTINT0                   ((PIN_PA19A_EIC_EXTINT0 << 16) | MUX_PA19A_EIC_EXTINT0)
+#define PORT_PA19A_EIC_EXTINT0                     (_UL_(1) << 19)
+#define PIN_PA19A_EIC_EXTINT_NUM                   _L_(0)       /**< EIC signal: PIN_PA19 External Interrupt Line */
+
+#define PIN_PA00A_EIC_EXTINT0                      _L_(0)       /**< EIC signal: EXTINT0 on PA00 mux A*/
+#define MUX_PA00A_EIC_EXTINT0                      _L_(0)      
+#define PINMUX_PA00A_EIC_EXTINT0                   ((PIN_PA00A_EIC_EXTINT0 << 16) | MUX_PA00A_EIC_EXTINT0)
+#define PORT_PA00A_EIC_EXTINT0                     (_UL_(1) << 0)
+#define PIN_PA00A_EIC_EXTINT_NUM                   _L_(0)       /**< EIC signal: PIN_PA00 External Interrupt Line */
+
+#define PIN_PA10A_EIC_EXTINT1                      _L_(10)      /**< EIC signal: EXTINT1 on PA10 mux A*/
+#define MUX_PA10A_EIC_EXTINT1                      _L_(0)      
+#define PINMUX_PA10A_EIC_EXTINT1                   ((PIN_PA10A_EIC_EXTINT1 << 16) | MUX_PA10A_EIC_EXTINT1)
+#define PORT_PA10A_EIC_EXTINT1                     (_UL_(1) << 10)
+#define PIN_PA10A_EIC_EXTINT_NUM                   _L_(1)       /**< EIC signal: PIN_PA10 External Interrupt Line */
+
+#define PIN_PA22A_EIC_EXTINT1                      _L_(22)      /**< EIC signal: EXTINT1 on PA22 mux A*/
+#define MUX_PA22A_EIC_EXTINT1                      _L_(0)      
+#define PINMUX_PA22A_EIC_EXTINT1                   ((PIN_PA22A_EIC_EXTINT1 << 16) | MUX_PA22A_EIC_EXTINT1)
+#define PORT_PA22A_EIC_EXTINT1                     (_UL_(1) << 22)
+#define PIN_PA22A_EIC_EXTINT_NUM                   _L_(1)       /**< EIC signal: PIN_PA22 External Interrupt Line */
+
+#define PIN_PA01A_EIC_EXTINT1                      _L_(1)       /**< EIC signal: EXTINT1 on PA01 mux A*/
+#define MUX_PA01A_EIC_EXTINT1                      _L_(0)      
+#define PINMUX_PA01A_EIC_EXTINT1                   ((PIN_PA01A_EIC_EXTINT1 << 16) | MUX_PA01A_EIC_EXTINT1)
+#define PORT_PA01A_EIC_EXTINT1                     (_UL_(1) << 1)
+#define PIN_PA01A_EIC_EXTINT_NUM                   _L_(1)       /**< EIC signal: PIN_PA01 External Interrupt Line */
+
+#define PIN_PA02A_EIC_EXTINT2                      _L_(2)       /**< EIC signal: EXTINT2 on PA02 mux A*/
+#define MUX_PA02A_EIC_EXTINT2                      _L_(0)      
+#define PINMUX_PA02A_EIC_EXTINT2                   ((PIN_PA02A_EIC_EXTINT2 << 16) | MUX_PA02A_EIC_EXTINT2)
+#define PORT_PA02A_EIC_EXTINT2                     (_UL_(1) << 2)
+#define PIN_PA02A_EIC_EXTINT_NUM                   _L_(2)       /**< EIC signal: PIN_PA02 External Interrupt Line */
+
+#define PIN_PA11A_EIC_EXTINT2                      _L_(11)      /**< EIC signal: EXTINT2 on PA11 mux A*/
+#define MUX_PA11A_EIC_EXTINT2                      _L_(0)      
+#define PINMUX_PA11A_EIC_EXTINT2                   ((PIN_PA11A_EIC_EXTINT2 << 16) | MUX_PA11A_EIC_EXTINT2)
+#define PORT_PA11A_EIC_EXTINT2                     (_UL_(1) << 11)
+#define PIN_PA11A_EIC_EXTINT_NUM                   _L_(2)       /**< EIC signal: PIN_PA11 External Interrupt Line */
+
+#define PIN_PA23A_EIC_EXTINT2                      _L_(23)      /**< EIC signal: EXTINT2 on PA23 mux A*/
+#define MUX_PA23A_EIC_EXTINT2                      _L_(0)      
+#define PINMUX_PA23A_EIC_EXTINT2                   ((PIN_PA23A_EIC_EXTINT2 << 16) | MUX_PA23A_EIC_EXTINT2)
+#define PORT_PA23A_EIC_EXTINT2                     (_UL_(1) << 23)
+#define PIN_PA23A_EIC_EXTINT_NUM                   _L_(2)       /**< EIC signal: PIN_PA23 External Interrupt Line */
+
+#define PIN_PA03A_EIC_EXTINT3                      _L_(3)       /**< EIC signal: EXTINT3 on PA03 mux A*/
+#define MUX_PA03A_EIC_EXTINT3                      _L_(0)      
+#define PINMUX_PA03A_EIC_EXTINT3                   ((PIN_PA03A_EIC_EXTINT3 << 16) | MUX_PA03A_EIC_EXTINT3)
+#define PORT_PA03A_EIC_EXTINT3                     (_UL_(1) << 3)
+#define PIN_PA03A_EIC_EXTINT_NUM                   _L_(3)       /**< EIC signal: PIN_PA03 External Interrupt Line */
+
+#define PIN_PA14A_EIC_EXTINT3                      _L_(14)      /**< EIC signal: EXTINT3 on PA14 mux A*/
+#define MUX_PA14A_EIC_EXTINT3                      _L_(0)      
+#define PINMUX_PA14A_EIC_EXTINT3                   ((PIN_PA14A_EIC_EXTINT3 << 16) | MUX_PA14A_EIC_EXTINT3)
+#define PORT_PA14A_EIC_EXTINT3                     (_UL_(1) << 14)
+#define PIN_PA14A_EIC_EXTINT_NUM                   _L_(3)       /**< EIC signal: PIN_PA14 External Interrupt Line */
+
+#define PIN_PA24A_EIC_EXTINT3                      _L_(24)      /**< EIC signal: EXTINT3 on PA24 mux A*/
+#define MUX_PA24A_EIC_EXTINT3                      _L_(0)      
+#define PINMUX_PA24A_EIC_EXTINT3                   ((PIN_PA24A_EIC_EXTINT3 << 16) | MUX_PA24A_EIC_EXTINT3)
+#define PORT_PA24A_EIC_EXTINT3                     (_UL_(1) << 24)
+#define PIN_PA24A_EIC_EXTINT_NUM                   _L_(3)       /**< EIC signal: PIN_PA24 External Interrupt Line */
+
+#define PIN_PA04A_EIC_EXTINT4                      _L_(4)       /**< EIC signal: EXTINT4 on PA04 mux A*/
+#define MUX_PA04A_EIC_EXTINT4                      _L_(0)      
+#define PINMUX_PA04A_EIC_EXTINT4                   ((PIN_PA04A_EIC_EXTINT4 << 16) | MUX_PA04A_EIC_EXTINT4)
+#define PORT_PA04A_EIC_EXTINT4                     (_UL_(1) << 4)
+#define PIN_PA04A_EIC_EXTINT_NUM                   _L_(4)       /**< EIC signal: PIN_PA04 External Interrupt Line */
+
+#define PIN_PA15A_EIC_EXTINT4                      _L_(15)      /**< EIC signal: EXTINT4 on PA15 mux A*/
+#define MUX_PA15A_EIC_EXTINT4                      _L_(0)      
+#define PINMUX_PA15A_EIC_EXTINT4                   ((PIN_PA15A_EIC_EXTINT4 << 16) | MUX_PA15A_EIC_EXTINT4)
+#define PORT_PA15A_EIC_EXTINT4                     (_UL_(1) << 15)
+#define PIN_PA15A_EIC_EXTINT_NUM                   _L_(4)       /**< EIC signal: PIN_PA15 External Interrupt Line */
+
+#define PIN_PA25A_EIC_EXTINT4                      _L_(25)      /**< EIC signal: EXTINT4 on PA25 mux A*/
+#define MUX_PA25A_EIC_EXTINT4                      _L_(0)      
+#define PINMUX_PA25A_EIC_EXTINT4                   ((PIN_PA25A_EIC_EXTINT4 << 16) | MUX_PA25A_EIC_EXTINT4)
+#define PORT_PA25A_EIC_EXTINT4                     (_UL_(1) << 25)
+#define PIN_PA25A_EIC_EXTINT_NUM                   _L_(4)       /**< EIC signal: PIN_PA25 External Interrupt Line */
+
+#define PIN_PA05A_EIC_EXTINT5                      _L_(5)       /**< EIC signal: EXTINT5 on PA05 mux A*/
+#define MUX_PA05A_EIC_EXTINT5                      _L_(0)      
+#define PINMUX_PA05A_EIC_EXTINT5                   ((PIN_PA05A_EIC_EXTINT5 << 16) | MUX_PA05A_EIC_EXTINT5)
+#define PORT_PA05A_EIC_EXTINT5                     (_UL_(1) << 5)
+#define PIN_PA05A_EIC_EXTINT_NUM                   _L_(5)       /**< EIC signal: PIN_PA05 External Interrupt Line */
+
+#define PIN_PA16A_EIC_EXTINT5                      _L_(16)      /**< EIC signal: EXTINT5 on PA16 mux A*/
+#define MUX_PA16A_EIC_EXTINT5                      _L_(0)      
+#define PINMUX_PA16A_EIC_EXTINT5                   ((PIN_PA16A_EIC_EXTINT5 << 16) | MUX_PA16A_EIC_EXTINT5)
+#define PORT_PA16A_EIC_EXTINT5                     (_UL_(1) << 16)
+#define PIN_PA16A_EIC_EXTINT_NUM                   _L_(5)       /**< EIC signal: PIN_PA16 External Interrupt Line */
+
+#define PIN_PA27A_EIC_EXTINT5                      _L_(27)      /**< EIC signal: EXTINT5 on PA27 mux A*/
+#define MUX_PA27A_EIC_EXTINT5                      _L_(0)      
+#define PINMUX_PA27A_EIC_EXTINT5                   ((PIN_PA27A_EIC_EXTINT5 << 16) | MUX_PA27A_EIC_EXTINT5)
+#define PORT_PA27A_EIC_EXTINT5                     (_UL_(1) << 27)
+#define PIN_PA27A_EIC_EXTINT_NUM                   _L_(5)       /**< EIC signal: PIN_PA27 External Interrupt Line */
+
+#define PIN_PA06A_EIC_EXTINT6                      _L_(6)       /**< EIC signal: EXTINT6 on PA06 mux A*/
+#define MUX_PA06A_EIC_EXTINT6                      _L_(0)      
+#define PINMUX_PA06A_EIC_EXTINT6                   ((PIN_PA06A_EIC_EXTINT6 << 16) | MUX_PA06A_EIC_EXTINT6)
+#define PORT_PA06A_EIC_EXTINT6                     (_UL_(1) << 6)
+#define PIN_PA06A_EIC_EXTINT_NUM                   _L_(6)       /**< EIC signal: PIN_PA06 External Interrupt Line */
+
+#define PIN_PA17A_EIC_EXTINT6                      _L_(17)      /**< EIC signal: EXTINT6 on PA17 mux A*/
+#define MUX_PA17A_EIC_EXTINT6                      _L_(0)      
+#define PINMUX_PA17A_EIC_EXTINT6                   ((PIN_PA17A_EIC_EXTINT6 << 16) | MUX_PA17A_EIC_EXTINT6)
+#define PORT_PA17A_EIC_EXTINT6                     (_UL_(1) << 17)
+#define PIN_PA17A_EIC_EXTINT_NUM                   _L_(6)       /**< EIC signal: PIN_PA17 External Interrupt Line */
+
+#define PIN_PA30A_EIC_EXTINT6                      _L_(30)      /**< EIC signal: EXTINT6 on PA30 mux A*/
+#define MUX_PA30A_EIC_EXTINT6                      _L_(0)      
+#define PINMUX_PA30A_EIC_EXTINT6                   ((PIN_PA30A_EIC_EXTINT6 << 16) | MUX_PA30A_EIC_EXTINT6)
+#define PORT_PA30A_EIC_EXTINT6                     (_UL_(1) << 30)
+#define PIN_PA30A_EIC_EXTINT_NUM                   _L_(6)       /**< EIC signal: PIN_PA30 External Interrupt Line */
+
+#define PIN_PA07A_EIC_EXTINT7                      _L_(7)       /**< EIC signal: EXTINT7 on PA07 mux A*/
+#define MUX_PA07A_EIC_EXTINT7                      _L_(0)      
+#define PINMUX_PA07A_EIC_EXTINT7                   ((PIN_PA07A_EIC_EXTINT7 << 16) | MUX_PA07A_EIC_EXTINT7)
+#define PORT_PA07A_EIC_EXTINT7                     (_UL_(1) << 7)
+#define PIN_PA07A_EIC_EXTINT_NUM                   _L_(7)       /**< EIC signal: PIN_PA07 External Interrupt Line */
+
+#define PIN_PA18A_EIC_EXTINT7                      _L_(18)      /**< EIC signal: EXTINT7 on PA18 mux A*/
+#define MUX_PA18A_EIC_EXTINT7                      _L_(0)      
+#define PINMUX_PA18A_EIC_EXTINT7                   ((PIN_PA18A_EIC_EXTINT7 << 16) | MUX_PA18A_EIC_EXTINT7)
+#define PORT_PA18A_EIC_EXTINT7                     (_UL_(1) << 18)
+#define PIN_PA18A_EIC_EXTINT_NUM                   _L_(7)       /**< EIC signal: PIN_PA18 External Interrupt Line */
+
+#define PIN_PA31A_EIC_EXTINT7                      _L_(31)      /**< EIC signal: EXTINT7 on PA31 mux A*/
+#define MUX_PA31A_EIC_EXTINT7                      _L_(0)      
+#define PINMUX_PA31A_EIC_EXTINT7                   ((PIN_PA31A_EIC_EXTINT7 << 16) | MUX_PA31A_EIC_EXTINT7)
+#define PORT_PA31A_EIC_EXTINT7                     (_UL_(1) << 31)
+#define PIN_PA31A_EIC_EXTINT_NUM                   _L_(7)       /**< EIC signal: PIN_PA31 External Interrupt Line */
+
+#define PIN_PA08A_EIC_NMI                          _L_(8)       /**< EIC signal: NMI on PA08 mux A*/
+#define MUX_PA08A_EIC_NMI                          _L_(0)      
+#define PINMUX_PA08A_EIC_NMI                       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
+#define PORT_PA08A_EIC_NMI                         (_UL_(1) << 8)
+
+/* ========== PORT definition for GCLK peripheral ========== */
+#define PIN_PA30H_GCLK_IO0                         _L_(30)      /**< GCLK signal: IO0 on PA30 mux H*/
+#define MUX_PA30H_GCLK_IO0                         _L_(7)      
+#define PINMUX_PA30H_GCLK_IO0                      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
+#define PORT_PA30H_GCLK_IO0                        (_UL_(1) << 30)
+
+#define PIN_PA14H_GCLK_IO0                         _L_(14)      /**< GCLK signal: IO0 on PA14 mux H*/
+#define MUX_PA14H_GCLK_IO0                         _L_(7)      
+#define PINMUX_PA14H_GCLK_IO0                      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
+#define PORT_PA14H_GCLK_IO0                        (_UL_(1) << 14)
+
+#define PIN_PA27H_GCLK_IO0                         _L_(27)      /**< GCLK signal: IO0 on PA27 mux H*/
+#define MUX_PA27H_GCLK_IO0                         _L_(7)      
+#define PINMUX_PA27H_GCLK_IO0                      ((PIN_PA27H_GCLK_IO0 << 16) | MUX_PA27H_GCLK_IO0)
+#define PORT_PA27H_GCLK_IO0                        (_UL_(1) << 27)
+
+#define PIN_PA23H_GCLK_IO1                         _L_(23)      /**< GCLK signal: IO1 on PA23 mux H*/
+#define MUX_PA23H_GCLK_IO1                         _L_(7)      
+#define PINMUX_PA23H_GCLK_IO1                      ((PIN_PA23H_GCLK_IO1 << 16) | MUX_PA23H_GCLK_IO1)
+#define PORT_PA23H_GCLK_IO1                        (_UL_(1) << 23)
+
+#define PIN_PA15H_GCLK_IO1                         _L_(15)      /**< GCLK signal: IO1 on PA15 mux H*/
+#define MUX_PA15H_GCLK_IO1                         _L_(7)      
+#define PINMUX_PA15H_GCLK_IO1                      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
+#define PORT_PA15H_GCLK_IO1                        (_UL_(1) << 15)
+
+#define PIN_PA16H_GCLK_IO2                         _L_(16)      /**< GCLK signal: IO2 on PA16 mux H*/
+#define MUX_PA16H_GCLK_IO2                         _L_(7)      
+#define PINMUX_PA16H_GCLK_IO2                      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
+#define PORT_PA16H_GCLK_IO2                        (_UL_(1) << 16)
+
+#define PIN_PA22H_GCLK_IO2                         _L_(22)      /**< GCLK signal: IO2 on PA22 mux H*/
+#define MUX_PA22H_GCLK_IO2                         _L_(7)      
+#define PINMUX_PA22H_GCLK_IO2                      ((PIN_PA22H_GCLK_IO2 << 16) | MUX_PA22H_GCLK_IO2)
+#define PORT_PA22H_GCLK_IO2                        (_UL_(1) << 22)
+
+#define PIN_PA11H_GCLK_IO3                         _L_(11)      /**< GCLK signal: IO3 on PA11 mux H*/
+#define MUX_PA11H_GCLK_IO3                         _L_(7)      
+#define PINMUX_PA11H_GCLK_IO3                      ((PIN_PA11H_GCLK_IO3 << 16) | MUX_PA11H_GCLK_IO3)
+#define PORT_PA11H_GCLK_IO3                        (_UL_(1) << 11)
+
+#define PIN_PA17H_GCLK_IO3                         _L_(17)      /**< GCLK signal: IO3 on PA17 mux H*/
+#define MUX_PA17H_GCLK_IO3                         _L_(7)      
+#define PINMUX_PA17H_GCLK_IO3                      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
+#define PORT_PA17H_GCLK_IO3                        (_UL_(1) << 17)
+
+#define PIN_PA10H_GCLK_IO4                         _L_(10)      /**< GCLK signal: IO4 on PA10 mux H*/
+#define MUX_PA10H_GCLK_IO4                         _L_(7)      
+#define PINMUX_PA10H_GCLK_IO4                      ((PIN_PA10H_GCLK_IO4 << 16) | MUX_PA10H_GCLK_IO4)
+#define PORT_PA10H_GCLK_IO4                        (_UL_(1) << 10)
+
+/* ========== PORT definition for OPAMP peripheral ========== */
+#define PIN_PA02B_OPAMP_OANEG0                     _L_(2)       /**< OPAMP signal: OANEG0 on PA02 mux B*/
+#define MUX_PA02B_OPAMP_OANEG0                     _L_(1)      
+#define PINMUX_PA02B_OPAMP_OANEG0                  ((PIN_PA02B_OPAMP_OANEG0 << 16) | MUX_PA02B_OPAMP_OANEG0)
+#define PORT_PA02B_OPAMP_OANEG0                    (_UL_(1) << 2)
+
+#define PIN_PA00B_OPAMP_OANEG1                     _L_(0)       /**< OPAMP signal: OANEG1 on PA00 mux B*/
+#define MUX_PA00B_OPAMP_OANEG1                     _L_(1)      
+#define PINMUX_PA00B_OPAMP_OANEG1                  ((PIN_PA00B_OPAMP_OANEG1 << 16) | MUX_PA00B_OPAMP_OANEG1)
+#define PORT_PA00B_OPAMP_OANEG1                    (_UL_(1) << 0)
+
+#define PIN_PA03B_OPAMP_OANEG2                     _L_(3)       /**< OPAMP signal: OANEG2 on PA03 mux B*/
+#define MUX_PA03B_OPAMP_OANEG2                     _L_(1)      
+#define PINMUX_PA03B_OPAMP_OANEG2                  ((PIN_PA03B_OPAMP_OANEG2 << 16) | MUX_PA03B_OPAMP_OANEG2)
+#define PORT_PA03B_OPAMP_OANEG2                    (_UL_(1) << 3)
+
+#define PIN_PA07B_OPAMP_OAOUT0                     _L_(7)       /**< OPAMP signal: OAOUT0 on PA07 mux B*/
+#define MUX_PA07B_OPAMP_OAOUT0                     _L_(1)      
+#define PINMUX_PA07B_OPAMP_OAOUT0                  ((PIN_PA07B_OPAMP_OAOUT0 << 16) | MUX_PA07B_OPAMP_OAOUT0)
+#define PORT_PA07B_OPAMP_OAOUT0                    (_UL_(1) << 7)
+
+#define PIN_PA04B_OPAMP_OAOUT2                     _L_(4)       /**< OPAMP signal: OAOUT2 on PA04 mux B*/
+#define MUX_PA04B_OPAMP_OAOUT2                     _L_(1)      
+#define PINMUX_PA04B_OPAMP_OAOUT2                  ((PIN_PA04B_OPAMP_OAOUT2 << 16) | MUX_PA04B_OPAMP_OAOUT2)
+#define PORT_PA04B_OPAMP_OAOUT2                    (_UL_(1) << 4)
+
+#define PIN_PA06B_OPAMP_OAPOS0                     _L_(6)       /**< OPAMP signal: OAPOS0 on PA06 mux B*/
+#define MUX_PA06B_OPAMP_OAPOS0                     _L_(1)      
+#define PINMUX_PA06B_OPAMP_OAPOS0                  ((PIN_PA06B_OPAMP_OAPOS0 << 16) | MUX_PA06B_OPAMP_OAPOS0)
+#define PORT_PA06B_OPAMP_OAPOS0                    (_UL_(1) << 6)
+
+#define PIN_PA01B_OPAMP_OAPOS1                     _L_(1)       /**< OPAMP signal: OAPOS1 on PA01 mux B*/
+#define MUX_PA01B_OPAMP_OAPOS1                     _L_(1)      
+#define PINMUX_PA01B_OPAMP_OAPOS1                  ((PIN_PA01B_OPAMP_OAPOS1 << 16) | MUX_PA01B_OPAMP_OAPOS1)
+#define PORT_PA01B_OPAMP_OAPOS1                    (_UL_(1) << 1)
+
+#define PIN_PA05B_OPAMP_OAPOS2                     _L_(5)       /**< OPAMP signal: OAPOS2 on PA05 mux B*/
+#define MUX_PA05B_OPAMP_OAPOS2                     _L_(1)      
+#define PINMUX_PA05B_OPAMP_OAPOS2                  ((PIN_PA05B_OPAMP_OAPOS2 << 16) | MUX_PA05B_OPAMP_OAPOS2)
+#define PORT_PA05B_OPAMP_OAPOS2                    (_UL_(1) << 5)
+
+/* ========== PORT definition for PTC peripheral ========== */
+#define PIN_PA00F_PTC_DRV0                         _L_(0)       /**< PTC signal: DRV0 on PA00 mux F*/
+#define MUX_PA00F_PTC_DRV0                         _L_(5)      
+#define PINMUX_PA00F_PTC_DRV0                      ((PIN_PA00F_PTC_DRV0 << 16) | MUX_PA00F_PTC_DRV0)
+#define PORT_PA00F_PTC_DRV0                        (_UL_(1) << 0)
+
+#define PIN_PA01F_PTC_DRV1                         _L_(1)       /**< PTC signal: DRV1 on PA01 mux F*/
+#define MUX_PA01F_PTC_DRV1                         _L_(5)      
+#define PINMUX_PA01F_PTC_DRV1                      ((PIN_PA01F_PTC_DRV1 << 16) | MUX_PA01F_PTC_DRV1)
+#define PORT_PA01F_PTC_DRV1                        (_UL_(1) << 1)
+
+#define PIN_PA02F_PTC_DRV2                         _L_(2)       /**< PTC signal: DRV2 on PA02 mux F*/
+#define MUX_PA02F_PTC_DRV2                         _L_(5)      
+#define PINMUX_PA02F_PTC_DRV2                      ((PIN_PA02F_PTC_DRV2 << 16) | MUX_PA02F_PTC_DRV2)
+#define PORT_PA02F_PTC_DRV2                        (_UL_(1) << 2)
+
+#define PIN_PA03F_PTC_DRV3                         _L_(3)       /**< PTC signal: DRV3 on PA03 mux F*/
+#define MUX_PA03F_PTC_DRV3                         _L_(5)      
+#define PINMUX_PA03F_PTC_DRV3                      ((PIN_PA03F_PTC_DRV3 << 16) | MUX_PA03F_PTC_DRV3)
+#define PORT_PA03F_PTC_DRV3                        (_UL_(1) << 3)
+
+#define PIN_PA05F_PTC_DRV4                         _L_(5)       /**< PTC signal: DRV4 on PA05 mux F*/
+#define MUX_PA05F_PTC_DRV4                         _L_(5)      
+#define PINMUX_PA05F_PTC_DRV4                      ((PIN_PA05F_PTC_DRV4 << 16) | MUX_PA05F_PTC_DRV4)
+#define PORT_PA05F_PTC_DRV4                        (_UL_(1) << 5)
+
+#define PIN_PA06F_PTC_DRV5                         _L_(6)       /**< PTC signal: DRV5 on PA06 mux F*/
+#define MUX_PA06F_PTC_DRV5                         _L_(5)      
+#define PINMUX_PA06F_PTC_DRV5                      ((PIN_PA06F_PTC_DRV5 << 16) | MUX_PA06F_PTC_DRV5)
+#define PORT_PA06F_PTC_DRV5                        (_UL_(1) << 6)
+
+#define PIN_PA08F_PTC_DRV6                         _L_(8)       /**< PTC signal: DRV6 on PA08 mux F*/
+#define MUX_PA08F_PTC_DRV6                         _L_(5)      
+#define PINMUX_PA08F_PTC_DRV6                      ((PIN_PA08F_PTC_DRV6 << 16) | MUX_PA08F_PTC_DRV6)
+#define PORT_PA08F_PTC_DRV6                        (_UL_(1) << 8)
+
+#define PIN_PA09F_PTC_DRV7                         _L_(9)       /**< PTC signal: DRV7 on PA09 mux F*/
+#define MUX_PA09F_PTC_DRV7                         _L_(5)      
+#define PINMUX_PA09F_PTC_DRV7                      ((PIN_PA09F_PTC_DRV7 << 16) | MUX_PA09F_PTC_DRV7)
+#define PORT_PA09F_PTC_DRV7                        (_UL_(1) << 9)
+
+#define PIN_PA10F_PTC_DRV8                         _L_(10)      /**< PTC signal: DRV8 on PA10 mux F*/
+#define MUX_PA10F_PTC_DRV8                         _L_(5)      
+#define PINMUX_PA10F_PTC_DRV8                      ((PIN_PA10F_PTC_DRV8 << 16) | MUX_PA10F_PTC_DRV8)
+#define PORT_PA10F_PTC_DRV8                        (_UL_(1) << 10)
+
+#define PIN_PA11F_PTC_DRV9                         _L_(11)      /**< PTC signal: DRV9 on PA11 mux F*/
+#define MUX_PA11F_PTC_DRV9                         _L_(5)      
+#define PINMUX_PA11F_PTC_DRV9                      ((PIN_PA11F_PTC_DRV9 << 16) | MUX_PA11F_PTC_DRV9)
+#define PORT_PA11F_PTC_DRV9                        (_UL_(1) << 11)
+
+#define PIN_PA14F_PTC_DRV10                        _L_(14)      /**< PTC signal: DRV10 on PA14 mux F*/
+#define MUX_PA14F_PTC_DRV10                        _L_(5)      
+#define PINMUX_PA14F_PTC_DRV10                     ((PIN_PA14F_PTC_DRV10 << 16) | MUX_PA14F_PTC_DRV10)
+#define PORT_PA14F_PTC_DRV10                       (_UL_(1) << 14)
+
+#define PIN_PA15F_PTC_DRV11                        _L_(15)      /**< PTC signal: DRV11 on PA15 mux F*/
+#define MUX_PA15F_PTC_DRV11                        _L_(5)      
+#define PINMUX_PA15F_PTC_DRV11                     ((PIN_PA15F_PTC_DRV11 << 16) | MUX_PA15F_PTC_DRV11)
+#define PORT_PA15F_PTC_DRV11                       (_UL_(1) << 15)
+
+#define PIN_PA16F_PTC_DRV12                        _L_(16)      /**< PTC signal: DRV12 on PA16 mux F*/
+#define MUX_PA16F_PTC_DRV12                        _L_(5)      
+#define PINMUX_PA16F_PTC_DRV12                     ((PIN_PA16F_PTC_DRV12 << 16) | MUX_PA16F_PTC_DRV12)
+#define PORT_PA16F_PTC_DRV12                       (_UL_(1) << 16)
+
+#define PIN_PA17F_PTC_DRV13                        _L_(17)      /**< PTC signal: DRV13 on PA17 mux F*/
+#define MUX_PA17F_PTC_DRV13                        _L_(5)      
+#define PINMUX_PA17F_PTC_DRV13                     ((PIN_PA17F_PTC_DRV13 << 16) | MUX_PA17F_PTC_DRV13)
+#define PORT_PA17F_PTC_DRV13                       (_UL_(1) << 17)
+
+#define PIN_PA18F_PTC_DRV14                        _L_(18)      /**< PTC signal: DRV14 on PA18 mux F*/
+#define MUX_PA18F_PTC_DRV14                        _L_(5)      
+#define PINMUX_PA18F_PTC_DRV14                     ((PIN_PA18F_PTC_DRV14 << 16) | MUX_PA18F_PTC_DRV14)
+#define PORT_PA18F_PTC_DRV14                       (_UL_(1) << 18)
+
+#define PIN_PA19F_PTC_DRV15                        _L_(19)      /**< PTC signal: DRV15 on PA19 mux F*/
+#define MUX_PA19F_PTC_DRV15                        _L_(5)      
+#define PINMUX_PA19F_PTC_DRV15                     ((PIN_PA19F_PTC_DRV15 << 16) | MUX_PA19F_PTC_DRV15)
+#define PORT_PA19F_PTC_DRV15                       (_UL_(1) << 19)
+
+#define PIN_PA22F_PTC_DRV16                        _L_(22)      /**< PTC signal: DRV16 on PA22 mux F*/
+#define MUX_PA22F_PTC_DRV16                        _L_(5)      
+#define PINMUX_PA22F_PTC_DRV16                     ((PIN_PA22F_PTC_DRV16 << 16) | MUX_PA22F_PTC_DRV16)
+#define PORT_PA22F_PTC_DRV16                       (_UL_(1) << 22)
+
+#define PIN_PA23F_PTC_DRV17                        _L_(23)      /**< PTC signal: DRV17 on PA23 mux F*/
+#define MUX_PA23F_PTC_DRV17                        _L_(5)      
+#define PINMUX_PA23F_PTC_DRV17                     ((PIN_PA23F_PTC_DRV17 << 16) | MUX_PA23F_PTC_DRV17)
+#define PORT_PA23F_PTC_DRV17                       (_UL_(1) << 23)
+
+#define PIN_PA30F_PTC_DRV18                        _L_(30)      /**< PTC signal: DRV18 on PA30 mux F*/
+#define MUX_PA30F_PTC_DRV18                        _L_(5)      
+#define PINMUX_PA30F_PTC_DRV18                     ((PIN_PA30F_PTC_DRV18 << 16) | MUX_PA30F_PTC_DRV18)
+#define PORT_PA30F_PTC_DRV18                       (_UL_(1) << 30)
+
+#define PIN_PA31F_PTC_DRV19                        _L_(31)      /**< PTC signal: DRV19 on PA31 mux F*/
+#define MUX_PA31F_PTC_DRV19                        _L_(5)      
+#define PINMUX_PA31F_PTC_DRV19                     ((PIN_PA31F_PTC_DRV19 << 16) | MUX_PA31F_PTC_DRV19)
+#define PORT_PA31F_PTC_DRV19                       (_UL_(1) << 31)
+
+#define PIN_PA03B_PTC_ECI0                         _L_(3)       /**< PTC signal: ECI0 on PA03 mux B*/
+#define MUX_PA03B_PTC_ECI0                         _L_(1)      
+#define PINMUX_PA03B_PTC_ECI0                      ((PIN_PA03B_PTC_ECI0 << 16) | MUX_PA03B_PTC_ECI0)
+#define PORT_PA03B_PTC_ECI0                        (_UL_(1) << 3)
+
+#define PIN_PA04B_PTC_ECI1                         _L_(4)       /**< PTC signal: ECI1 on PA04 mux B*/
+#define MUX_PA04B_PTC_ECI1                         _L_(1)      
+#define PINMUX_PA04B_PTC_ECI1                      ((PIN_PA04B_PTC_ECI1 << 16) | MUX_PA04B_PTC_ECI1)
+#define PORT_PA04B_PTC_ECI1                        (_UL_(1) << 4)
+
+#define PIN_PA05B_PTC_ECI2                         _L_(5)       /**< PTC signal: ECI2 on PA05 mux B*/
+#define MUX_PA05B_PTC_ECI2                         _L_(1)      
+#define PINMUX_PA05B_PTC_ECI2                      ((PIN_PA05B_PTC_ECI2 << 16) | MUX_PA05B_PTC_ECI2)
+#define PORT_PA05B_PTC_ECI2                        (_UL_(1) << 5)
+
+#define PIN_PA06B_PTC_ECI3                         _L_(6)       /**< PTC signal: ECI3 on PA06 mux B*/
+#define MUX_PA06B_PTC_ECI3                         _L_(1)      
+#define PINMUX_PA06B_PTC_ECI3                      ((PIN_PA06B_PTC_ECI3 << 16) | MUX_PA06B_PTC_ECI3)
+#define PORT_PA06B_PTC_ECI3                        (_UL_(1) << 6)
+
+#define PIN_PA00B_PTC_X0                           _L_(0)       /**< PTC signal: X0 on PA00 mux B*/
+#define MUX_PA00B_PTC_X0                           _L_(1)      
+#define PINMUX_PA00B_PTC_X0                        ((PIN_PA00B_PTC_X0 << 16) | MUX_PA00B_PTC_X0)
+#define PORT_PA00B_PTC_X0                          (_UL_(1) << 0)
+
+#define PIN_PA00B_PTC_Y0                           _L_(0)       /**< PTC signal: Y0 on PA00 mux B*/
+#define MUX_PA00B_PTC_Y0                           _L_(1)      
+#define PINMUX_PA00B_PTC_Y0                        ((PIN_PA00B_PTC_Y0 << 16) | MUX_PA00B_PTC_Y0)
+#define PORT_PA00B_PTC_Y0                          (_UL_(1) << 0)
+
+#define PIN_PA01B_PTC_X1                           _L_(1)       /**< PTC signal: X1 on PA01 mux B*/
+#define MUX_PA01B_PTC_X1                           _L_(1)      
+#define PINMUX_PA01B_PTC_X1                        ((PIN_PA01B_PTC_X1 << 16) | MUX_PA01B_PTC_X1)
+#define PORT_PA01B_PTC_X1                          (_UL_(1) << 1)
+
+#define PIN_PA01B_PTC_Y1                           _L_(1)       /**< PTC signal: Y1 on PA01 mux B*/
+#define MUX_PA01B_PTC_Y1                           _L_(1)      
+#define PINMUX_PA01B_PTC_Y1                        ((PIN_PA01B_PTC_Y1 << 16) | MUX_PA01B_PTC_Y1)
+#define PORT_PA01B_PTC_Y1                          (_UL_(1) << 1)
+
+#define PIN_PA02B_PTC_X2                           _L_(2)       /**< PTC signal: X2 on PA02 mux B*/
+#define MUX_PA02B_PTC_X2                           _L_(1)      
+#define PINMUX_PA02B_PTC_X2                        ((PIN_PA02B_PTC_X2 << 16) | MUX_PA02B_PTC_X2)
+#define PORT_PA02B_PTC_X2                          (_UL_(1) << 2)
+
+#define PIN_PA02B_PTC_Y2                           _L_(2)       /**< PTC signal: Y2 on PA02 mux B*/
+#define MUX_PA02B_PTC_Y2                           _L_(1)      
+#define PINMUX_PA02B_PTC_Y2                        ((PIN_PA02B_PTC_Y2 << 16) | MUX_PA02B_PTC_Y2)
+#define PORT_PA02B_PTC_Y2                          (_UL_(1) << 2)
+
+#define PIN_PA03B_PTC_X3                           _L_(3)       /**< PTC signal: X3 on PA03 mux B*/
+#define MUX_PA03B_PTC_X3                           _L_(1)      
+#define PINMUX_PA03B_PTC_X3                        ((PIN_PA03B_PTC_X3 << 16) | MUX_PA03B_PTC_X3)
+#define PORT_PA03B_PTC_X3                          (_UL_(1) << 3)
+
+#define PIN_PA03B_PTC_Y3                           _L_(3)       /**< PTC signal: Y3 on PA03 mux B*/
+#define MUX_PA03B_PTC_Y3                           _L_(1)      
+#define PINMUX_PA03B_PTC_Y3                        ((PIN_PA03B_PTC_Y3 << 16) | MUX_PA03B_PTC_Y3)
+#define PORT_PA03B_PTC_Y3                          (_UL_(1) << 3)
+
+#define PIN_PA05B_PTC_X4                           _L_(5)       /**< PTC signal: X4 on PA05 mux B*/
+#define MUX_PA05B_PTC_X4                           _L_(1)      
+#define PINMUX_PA05B_PTC_X4                        ((PIN_PA05B_PTC_X4 << 16) | MUX_PA05B_PTC_X4)
+#define PORT_PA05B_PTC_X4                          (_UL_(1) << 5)
+
+#define PIN_PA05B_PTC_Y4                           _L_(5)       /**< PTC signal: Y4 on PA05 mux B*/
+#define MUX_PA05B_PTC_Y4                           _L_(1)      
+#define PINMUX_PA05B_PTC_Y4                        ((PIN_PA05B_PTC_Y4 << 16) | MUX_PA05B_PTC_Y4)
+#define PORT_PA05B_PTC_Y4                          (_UL_(1) << 5)
+
+#define PIN_PA06B_PTC_X5                           _L_(6)       /**< PTC signal: X5 on PA06 mux B*/
+#define MUX_PA06B_PTC_X5                           _L_(1)      
+#define PINMUX_PA06B_PTC_X5                        ((PIN_PA06B_PTC_X5 << 16) | MUX_PA06B_PTC_X5)
+#define PORT_PA06B_PTC_X5                          (_UL_(1) << 6)
+
+#define PIN_PA06B_PTC_Y5                           _L_(6)       /**< PTC signal: Y5 on PA06 mux B*/
+#define MUX_PA06B_PTC_Y5                           _L_(1)      
+#define PINMUX_PA06B_PTC_Y5                        ((PIN_PA06B_PTC_Y5 << 16) | MUX_PA06B_PTC_Y5)
+#define PORT_PA06B_PTC_Y5                          (_UL_(1) << 6)
+
+#define PIN_PA08B_PTC_X6                           _L_(8)       /**< PTC signal: X6 on PA08 mux B*/
+#define MUX_PA08B_PTC_X6                           _L_(1)      
+#define PINMUX_PA08B_PTC_X6                        ((PIN_PA08B_PTC_X6 << 16) | MUX_PA08B_PTC_X6)
+#define PORT_PA08B_PTC_X6                          (_UL_(1) << 8)
+
+#define PIN_PA08B_PTC_Y6                           _L_(8)       /**< PTC signal: Y6 on PA08 mux B*/
+#define MUX_PA08B_PTC_Y6                           _L_(1)      
+#define PINMUX_PA08B_PTC_Y6                        ((PIN_PA08B_PTC_Y6 << 16) | MUX_PA08B_PTC_Y6)
+#define PORT_PA08B_PTC_Y6                          (_UL_(1) << 8)
+
+#define PIN_PA09B_PTC_X7                           _L_(9)       /**< PTC signal: X7 on PA09 mux B*/
+#define MUX_PA09B_PTC_X7                           _L_(1)      
+#define PINMUX_PA09B_PTC_X7                        ((PIN_PA09B_PTC_X7 << 16) | MUX_PA09B_PTC_X7)
+#define PORT_PA09B_PTC_X7                          (_UL_(1) << 9)
+
+#define PIN_PA09B_PTC_Y7                           _L_(9)       /**< PTC signal: Y7 on PA09 mux B*/
+#define MUX_PA09B_PTC_Y7                           _L_(1)      
+#define PINMUX_PA09B_PTC_Y7                        ((PIN_PA09B_PTC_Y7 << 16) | MUX_PA09B_PTC_Y7)
+#define PORT_PA09B_PTC_Y7                          (_UL_(1) << 9)
+
+#define PIN_PA10B_PTC_X8                           _L_(10)      /**< PTC signal: X8 on PA10 mux B*/
+#define MUX_PA10B_PTC_X8                           _L_(1)      
+#define PINMUX_PA10B_PTC_X8                        ((PIN_PA10B_PTC_X8 << 16) | MUX_PA10B_PTC_X8)
+#define PORT_PA10B_PTC_X8                          (_UL_(1) << 10)
+
+#define PIN_PA10B_PTC_Y8                           _L_(10)      /**< PTC signal: Y8 on PA10 mux B*/
+#define MUX_PA10B_PTC_Y8                           _L_(1)      
+#define PINMUX_PA10B_PTC_Y8                        ((PIN_PA10B_PTC_Y8 << 16) | MUX_PA10B_PTC_Y8)
+#define PORT_PA10B_PTC_Y8                          (_UL_(1) << 10)
+
+#define PIN_PA11B_PTC_X9                           _L_(11)      /**< PTC signal: X9 on PA11 mux B*/
+#define MUX_PA11B_PTC_X9                           _L_(1)      
+#define PINMUX_PA11B_PTC_X9                        ((PIN_PA11B_PTC_X9 << 16) | MUX_PA11B_PTC_X9)
+#define PORT_PA11B_PTC_X9                          (_UL_(1) << 11)
+
+#define PIN_PA11B_PTC_Y9                           _L_(11)      /**< PTC signal: Y9 on PA11 mux B*/
+#define MUX_PA11B_PTC_Y9                           _L_(1)      
+#define PINMUX_PA11B_PTC_Y9                        ((PIN_PA11B_PTC_Y9 << 16) | MUX_PA11B_PTC_Y9)
+#define PORT_PA11B_PTC_Y9                          (_UL_(1) << 11)
+
+#define PIN_PA14B_PTC_X10                          _L_(14)      /**< PTC signal: X10 on PA14 mux B*/
+#define MUX_PA14B_PTC_X10                          _L_(1)      
+#define PINMUX_PA14B_PTC_X10                       ((PIN_PA14B_PTC_X10 << 16) | MUX_PA14B_PTC_X10)
+#define PORT_PA14B_PTC_X10                         (_UL_(1) << 14)
+
+#define PIN_PA14B_PTC_Y10                          _L_(14)      /**< PTC signal: Y10 on PA14 mux B*/
+#define MUX_PA14B_PTC_Y10                          _L_(1)      
+#define PINMUX_PA14B_PTC_Y10                       ((PIN_PA14B_PTC_Y10 << 16) | MUX_PA14B_PTC_Y10)
+#define PORT_PA14B_PTC_Y10                         (_UL_(1) << 14)
+
+#define PIN_PA15B_PTC_X11                          _L_(15)      /**< PTC signal: X11 on PA15 mux B*/
+#define MUX_PA15B_PTC_X11                          _L_(1)      
+#define PINMUX_PA15B_PTC_X11                       ((PIN_PA15B_PTC_X11 << 16) | MUX_PA15B_PTC_X11)
+#define PORT_PA15B_PTC_X11                         (_UL_(1) << 15)
+
+#define PIN_PA15B_PTC_Y11                          _L_(15)      /**< PTC signal: Y11 on PA15 mux B*/
+#define MUX_PA15B_PTC_Y11                          _L_(1)      
+#define PINMUX_PA15B_PTC_Y11                       ((PIN_PA15B_PTC_Y11 << 16) | MUX_PA15B_PTC_Y11)
+#define PORT_PA15B_PTC_Y11                         (_UL_(1) << 15)
+
+#define PIN_PA16B_PTC_X12                          _L_(16)      /**< PTC signal: X12 on PA16 mux B*/
+#define MUX_PA16B_PTC_X12                          _L_(1)      
+#define PINMUX_PA16B_PTC_X12                       ((PIN_PA16B_PTC_X12 << 16) | MUX_PA16B_PTC_X12)
+#define PORT_PA16B_PTC_X12                         (_UL_(1) << 16)
+
+#define PIN_PA16B_PTC_Y12                          _L_(16)      /**< PTC signal: Y12 on PA16 mux B*/
+#define MUX_PA16B_PTC_Y12                          _L_(1)      
+#define PINMUX_PA16B_PTC_Y12                       ((PIN_PA16B_PTC_Y12 << 16) | MUX_PA16B_PTC_Y12)
+#define PORT_PA16B_PTC_Y12                         (_UL_(1) << 16)
+
+#define PIN_PA17B_PTC_X13                          _L_(17)      /**< PTC signal: X13 on PA17 mux B*/
+#define MUX_PA17B_PTC_X13                          _L_(1)      
+#define PINMUX_PA17B_PTC_X13                       ((PIN_PA17B_PTC_X13 << 16) | MUX_PA17B_PTC_X13)
+#define PORT_PA17B_PTC_X13                         (_UL_(1) << 17)
+
+#define PIN_PA17B_PTC_Y13                          _L_(17)      /**< PTC signal: Y13 on PA17 mux B*/
+#define MUX_PA17B_PTC_Y13                          _L_(1)      
+#define PINMUX_PA17B_PTC_Y13                       ((PIN_PA17B_PTC_Y13 << 16) | MUX_PA17B_PTC_Y13)
+#define PORT_PA17B_PTC_Y13                         (_UL_(1) << 17)
+
+#define PIN_PA18B_PTC_X14                          _L_(18)      /**< PTC signal: X14 on PA18 mux B*/
+#define MUX_PA18B_PTC_X14                          _L_(1)      
+#define PINMUX_PA18B_PTC_X14                       ((PIN_PA18B_PTC_X14 << 16) | MUX_PA18B_PTC_X14)
+#define PORT_PA18B_PTC_X14                         (_UL_(1) << 18)
+
+#define PIN_PA18B_PTC_Y14                          _L_(18)      /**< PTC signal: Y14 on PA18 mux B*/
+#define MUX_PA18B_PTC_Y14                          _L_(1)      
+#define PINMUX_PA18B_PTC_Y14                       ((PIN_PA18B_PTC_Y14 << 16) | MUX_PA18B_PTC_Y14)
+#define PORT_PA18B_PTC_Y14                         (_UL_(1) << 18)
+
+#define PIN_PA19B_PTC_X15                          _L_(19)      /**< PTC signal: X15 on PA19 mux B*/
+#define MUX_PA19B_PTC_X15                          _L_(1)      
+#define PINMUX_PA19B_PTC_X15                       ((PIN_PA19B_PTC_X15 << 16) | MUX_PA19B_PTC_X15)
+#define PORT_PA19B_PTC_X15                         (_UL_(1) << 19)
+
+#define PIN_PA19B_PTC_Y15                          _L_(19)      /**< PTC signal: Y15 on PA19 mux B*/
+#define MUX_PA19B_PTC_Y15                          _L_(1)      
+#define PINMUX_PA19B_PTC_Y15                       ((PIN_PA19B_PTC_Y15 << 16) | MUX_PA19B_PTC_Y15)
+#define PORT_PA19B_PTC_Y15                         (_UL_(1) << 19)
+
+#define PIN_PA22B_PTC_X16                          _L_(22)      /**< PTC signal: X16 on PA22 mux B*/
+#define MUX_PA22B_PTC_X16                          _L_(1)      
+#define PINMUX_PA22B_PTC_X16                       ((PIN_PA22B_PTC_X16 << 16) | MUX_PA22B_PTC_X16)
+#define PORT_PA22B_PTC_X16                         (_UL_(1) << 22)
+
+#define PIN_PA22B_PTC_Y16                          _L_(22)      /**< PTC signal: Y16 on PA22 mux B*/
+#define MUX_PA22B_PTC_Y16                          _L_(1)      
+#define PINMUX_PA22B_PTC_Y16                       ((PIN_PA22B_PTC_Y16 << 16) | MUX_PA22B_PTC_Y16)
+#define PORT_PA22B_PTC_Y16                         (_UL_(1) << 22)
+
+#define PIN_PA23B_PTC_X17                          _L_(23)      /**< PTC signal: X17 on PA23 mux B*/
+#define MUX_PA23B_PTC_X17                          _L_(1)      
+#define PINMUX_PA23B_PTC_X17                       ((PIN_PA23B_PTC_X17 << 16) | MUX_PA23B_PTC_X17)
+#define PORT_PA23B_PTC_X17                         (_UL_(1) << 23)
+
+#define PIN_PA23B_PTC_Y17                          _L_(23)      /**< PTC signal: Y17 on PA23 mux B*/
+#define MUX_PA23B_PTC_Y17                          _L_(1)      
+#define PINMUX_PA23B_PTC_Y17                       ((PIN_PA23B_PTC_Y17 << 16) | MUX_PA23B_PTC_Y17)
+#define PORT_PA23B_PTC_Y17                         (_UL_(1) << 23)
+
+#define PIN_PA30B_PTC_X18                          _L_(30)      /**< PTC signal: X18 on PA30 mux B*/
+#define MUX_PA30B_PTC_X18                          _L_(1)      
+#define PINMUX_PA30B_PTC_X18                       ((PIN_PA30B_PTC_X18 << 16) | MUX_PA30B_PTC_X18)
+#define PORT_PA30B_PTC_X18                         (_UL_(1) << 30)
+
+#define PIN_PA30B_PTC_Y18                          _L_(30)      /**< PTC signal: Y18 on PA30 mux B*/
+#define MUX_PA30B_PTC_Y18                          _L_(1)      
+#define PINMUX_PA30B_PTC_Y18                       ((PIN_PA30B_PTC_Y18 << 16) | MUX_PA30B_PTC_Y18)
+#define PORT_PA30B_PTC_Y18                         (_UL_(1) << 30)
+
+#define PIN_PA31B_PTC_X19                          _L_(31)      /**< PTC signal: X19 on PA31 mux B*/
+#define MUX_PA31B_PTC_X19                          _L_(1)      
+#define PINMUX_PA31B_PTC_X19                       ((PIN_PA31B_PTC_X19 << 16) | MUX_PA31B_PTC_X19)
+#define PORT_PA31B_PTC_X19                         (_UL_(1) << 31)
+
+#define PIN_PA31B_PTC_Y19                          _L_(31)      /**< PTC signal: Y19 on PA31 mux B*/
+#define MUX_PA31B_PTC_Y19                          _L_(1)      
+#define PINMUX_PA31B_PTC_Y19                       ((PIN_PA31B_PTC_Y19 << 16) | MUX_PA31B_PTC_Y19)
+#define PORT_PA31B_PTC_Y19                         (_UL_(1) << 31)
+
+/* ========== PORT definition for RTC peripheral ========== */
+#define PIN_PA08G_RTC_IN0                          _L_(8)       /**< RTC signal: IN0 on PA08 mux G*/
+#define MUX_PA08G_RTC_IN0                          _L_(6)      
+#define PINMUX_PA08G_RTC_IN0                       ((PIN_PA08G_RTC_IN0 << 16) | MUX_PA08G_RTC_IN0)
+#define PORT_PA08G_RTC_IN0                         (_UL_(1) << 8)
+
+#define PIN_PA09G_RTC_IN1                          _L_(9)       /**< RTC signal: IN1 on PA09 mux G*/
+#define MUX_PA09G_RTC_IN1                          _L_(6)      
+#define PINMUX_PA09G_RTC_IN1                       ((PIN_PA09G_RTC_IN1 << 16) | MUX_PA09G_RTC_IN1)
+#define PORT_PA09G_RTC_IN1                         (_UL_(1) << 9)
+
+#define PIN_PA16G_RTC_IN2                          _L_(16)      /**< RTC signal: IN2 on PA16 mux G*/
+#define MUX_PA16G_RTC_IN2                          _L_(6)      
+#define PINMUX_PA16G_RTC_IN2                       ((PIN_PA16G_RTC_IN2 << 16) | MUX_PA16G_RTC_IN2)
+#define PORT_PA16G_RTC_IN2                         (_UL_(1) << 16)
+
+#define PIN_PA17G_RTC_IN3                          _L_(17)      /**< RTC signal: IN3 on PA17 mux G*/
+#define MUX_PA17G_RTC_IN3                          _L_(6)      
+#define PINMUX_PA17G_RTC_IN3                       ((PIN_PA17G_RTC_IN3 << 16) | MUX_PA17G_RTC_IN3)
+#define PORT_PA17G_RTC_IN3                         (_UL_(1) << 17)
+
+#define PIN_PA18G_RTC_OUT0                         _L_(18)      /**< RTC signal: OUT0 on PA18 mux G*/
+#define MUX_PA18G_RTC_OUT0                         _L_(6)      
+#define PINMUX_PA18G_RTC_OUT0                      ((PIN_PA18G_RTC_OUT0 << 16) | MUX_PA18G_RTC_OUT0)
+#define PORT_PA18G_RTC_OUT0                        (_UL_(1) << 18)
+
+#define PIN_PA19G_RTC_OUT1                         _L_(19)      /**< RTC signal: OUT1 on PA19 mux G*/
+#define MUX_PA19G_RTC_OUT1                         _L_(6)      
+#define PINMUX_PA19G_RTC_OUT1                      ((PIN_PA19G_RTC_OUT1 << 16) | MUX_PA19G_RTC_OUT1)
+#define PORT_PA19G_RTC_OUT1                        (_UL_(1) << 19)
+
+#define PIN_PA22G_RTC_OUT2                         _L_(22)      /**< RTC signal: OUT2 on PA22 mux G*/
+#define MUX_PA22G_RTC_OUT2                         _L_(6)      
+#define PINMUX_PA22G_RTC_OUT2                      ((PIN_PA22G_RTC_OUT2 << 16) | MUX_PA22G_RTC_OUT2)
+#define PORT_PA22G_RTC_OUT2                        (_UL_(1) << 22)
+
+#define PIN_PA23G_RTC_OUT3                         _L_(23)      /**< RTC signal: OUT3 on PA23 mux G*/
+#define MUX_PA23G_RTC_OUT3                         _L_(6)      
+#define PINMUX_PA23G_RTC_OUT3                      ((PIN_PA23G_RTC_OUT3 << 16) | MUX_PA23G_RTC_OUT3)
+#define PORT_PA23G_RTC_OUT3                        (_UL_(1) << 23)
+
+/* ========== PORT definition for SERCOM0 peripheral ========== */
+#define PIN_PA04D_SERCOM0_PAD0                     _L_(4)       /**< SERCOM0 signal: PAD0 on PA04 mux D*/
+#define MUX_PA04D_SERCOM0_PAD0                     _L_(3)      
+#define PINMUX_PA04D_SERCOM0_PAD0                  ((PIN_PA04D_SERCOM0_PAD0 << 16) | MUX_PA04D_SERCOM0_PAD0)
+#define PORT_PA04D_SERCOM0_PAD0                    (_UL_(1) << 4)
+
+#define PIN_PA16D_SERCOM0_PAD0                     _L_(16)      /**< SERCOM0 signal: PAD0 on PA16 mux D*/
+#define MUX_PA16D_SERCOM0_PAD0                     _L_(3)      
+#define PINMUX_PA16D_SERCOM0_PAD0                  ((PIN_PA16D_SERCOM0_PAD0 << 16) | MUX_PA16D_SERCOM0_PAD0)
+#define PORT_PA16D_SERCOM0_PAD0                    (_UL_(1) << 16)
+
+#define PIN_PA22C_SERCOM0_PAD0                     _L_(22)      /**< SERCOM0 signal: PAD0 on PA22 mux C*/
+#define MUX_PA22C_SERCOM0_PAD0                     _L_(2)      
+#define PINMUX_PA22C_SERCOM0_PAD0                  ((PIN_PA22C_SERCOM0_PAD0 << 16) | MUX_PA22C_SERCOM0_PAD0)
+#define PORT_PA22C_SERCOM0_PAD0                    (_UL_(1) << 22)
+
+#define PIN_PA05D_SERCOM0_PAD1                     _L_(5)       /**< SERCOM0 signal: PAD1 on PA05 mux D*/
+#define MUX_PA05D_SERCOM0_PAD1                     _L_(3)      
+#define PINMUX_PA05D_SERCOM0_PAD1                  ((PIN_PA05D_SERCOM0_PAD1 << 16) | MUX_PA05D_SERCOM0_PAD1)
+#define PORT_PA05D_SERCOM0_PAD1                    (_UL_(1) << 5)
+
+#define PIN_PA17D_SERCOM0_PAD1                     _L_(17)      /**< SERCOM0 signal: PAD1 on PA17 mux D*/
+#define MUX_PA17D_SERCOM0_PAD1                     _L_(3)      
+#define PINMUX_PA17D_SERCOM0_PAD1                  ((PIN_PA17D_SERCOM0_PAD1 << 16) | MUX_PA17D_SERCOM0_PAD1)
+#define PORT_PA17D_SERCOM0_PAD1                    (_UL_(1) << 17)
+
+#define PIN_PA23C_SERCOM0_PAD1                     _L_(23)      /**< SERCOM0 signal: PAD1 on PA23 mux C*/
+#define MUX_PA23C_SERCOM0_PAD1                     _L_(2)      
+#define PINMUX_PA23C_SERCOM0_PAD1                  ((PIN_PA23C_SERCOM0_PAD1 << 16) | MUX_PA23C_SERCOM0_PAD1)
+#define PORT_PA23C_SERCOM0_PAD1                    (_UL_(1) << 23)
+
+#define PIN_PA06D_SERCOM0_PAD2                     _L_(6)       /**< SERCOM0 signal: PAD2 on PA06 mux D*/
+#define MUX_PA06D_SERCOM0_PAD2                     _L_(3)      
+#define PINMUX_PA06D_SERCOM0_PAD2                  ((PIN_PA06D_SERCOM0_PAD2 << 16) | MUX_PA06D_SERCOM0_PAD2)
+#define PORT_PA06D_SERCOM0_PAD2                    (_UL_(1) << 6)
+
+#define PIN_PA14D_SERCOM0_PAD2                     _L_(14)      /**< SERCOM0 signal: PAD2 on PA14 mux D*/
+#define MUX_PA14D_SERCOM0_PAD2                     _L_(3)      
+#define PINMUX_PA14D_SERCOM0_PAD2                  ((PIN_PA14D_SERCOM0_PAD2 << 16) | MUX_PA14D_SERCOM0_PAD2)
+#define PORT_PA14D_SERCOM0_PAD2                    (_UL_(1) << 14)
+
+#define PIN_PA18D_SERCOM0_PAD2                     _L_(18)      /**< SERCOM0 signal: PAD2 on PA18 mux D*/
+#define MUX_PA18D_SERCOM0_PAD2                     _L_(3)      
+#define PINMUX_PA18D_SERCOM0_PAD2                  ((PIN_PA18D_SERCOM0_PAD2 << 16) | MUX_PA18D_SERCOM0_PAD2)
+#define PORT_PA18D_SERCOM0_PAD2                    (_UL_(1) << 18)
+
+#define PIN_PA24C_SERCOM0_PAD2                     _L_(24)      /**< SERCOM0 signal: PAD2 on PA24 mux C*/
+#define MUX_PA24C_SERCOM0_PAD2                     _L_(2)      
+#define PINMUX_PA24C_SERCOM0_PAD2                  ((PIN_PA24C_SERCOM0_PAD2 << 16) | MUX_PA24C_SERCOM0_PAD2)
+#define PORT_PA24C_SERCOM0_PAD2                    (_UL_(1) << 24)
+
+#define PIN_PA02D_SERCOM0_PAD2                     _L_(2)       /**< SERCOM0 signal: PAD2 on PA02 mux D*/
+#define MUX_PA02D_SERCOM0_PAD2                     _L_(3)      
+#define PINMUX_PA02D_SERCOM0_PAD2                  ((PIN_PA02D_SERCOM0_PAD2 << 16) | MUX_PA02D_SERCOM0_PAD2)
+#define PORT_PA02D_SERCOM0_PAD2                    (_UL_(1) << 2)
+
+#define PIN_PA07D_SERCOM0_PAD3                     _L_(7)       /**< SERCOM0 signal: PAD3 on PA07 mux D*/
+#define MUX_PA07D_SERCOM0_PAD3                     _L_(3)      
+#define PINMUX_PA07D_SERCOM0_PAD3                  ((PIN_PA07D_SERCOM0_PAD3 << 16) | MUX_PA07D_SERCOM0_PAD3)
+#define PORT_PA07D_SERCOM0_PAD3                    (_UL_(1) << 7)
+
+#define PIN_PA15D_SERCOM0_PAD3                     _L_(15)      /**< SERCOM0 signal: PAD3 on PA15 mux D*/
+#define MUX_PA15D_SERCOM0_PAD3                     _L_(3)      
+#define PINMUX_PA15D_SERCOM0_PAD3                  ((PIN_PA15D_SERCOM0_PAD3 << 16) | MUX_PA15D_SERCOM0_PAD3)
+#define PORT_PA15D_SERCOM0_PAD3                    (_UL_(1) << 15)
+
+#define PIN_PA19D_SERCOM0_PAD3                     _L_(19)      /**< SERCOM0 signal: PAD3 on PA19 mux D*/
+#define MUX_PA19D_SERCOM0_PAD3                     _L_(3)      
+#define PINMUX_PA19D_SERCOM0_PAD3                  ((PIN_PA19D_SERCOM0_PAD3 << 16) | MUX_PA19D_SERCOM0_PAD3)
+#define PORT_PA19D_SERCOM0_PAD3                    (_UL_(1) << 19)
+
+#define PIN_PA25C_SERCOM0_PAD3                     _L_(25)      /**< SERCOM0 signal: PAD3 on PA25 mux C*/
+#define MUX_PA25C_SERCOM0_PAD3                     _L_(2)      
+#define PINMUX_PA25C_SERCOM0_PAD3                  ((PIN_PA25C_SERCOM0_PAD3 << 16) | MUX_PA25C_SERCOM0_PAD3)
+#define PORT_PA25C_SERCOM0_PAD3                    (_UL_(1) << 25)
+
+#define PIN_PA03D_SERCOM0_PAD3                     _L_(3)       /**< SERCOM0 signal: PAD3 on PA03 mux D*/
+#define MUX_PA03D_SERCOM0_PAD3                     _L_(3)      
+#define PINMUX_PA03D_SERCOM0_PAD3                  ((PIN_PA03D_SERCOM0_PAD3 << 16) | MUX_PA03D_SERCOM0_PAD3)
+#define PORT_PA03D_SERCOM0_PAD3                    (_UL_(1) << 3)
+
+/* ========== PORT definition for SERCOM1 peripheral ========== */
+#define PIN_PA16C_SERCOM1_PAD0                     _L_(16)      /**< SERCOM1 signal: PAD0 on PA16 mux C*/
+#define MUX_PA16C_SERCOM1_PAD0                     _L_(2)      
+#define PINMUX_PA16C_SERCOM1_PAD0                  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
+#define PORT_PA16C_SERCOM1_PAD0                    (_UL_(1) << 16)
+
+#define PIN_PA08C_SERCOM1_PAD0                     _L_(8)       /**< SERCOM1 signal: PAD0 on PA08 mux C*/
+#define MUX_PA08C_SERCOM1_PAD0                     _L_(2)      
+#define PINMUX_PA08C_SERCOM1_PAD0                  ((PIN_PA08C_SERCOM1_PAD0 << 16) | MUX_PA08C_SERCOM1_PAD0)
+#define PORT_PA08C_SERCOM1_PAD0                    (_UL_(1) << 8)
+
+#define PIN_PA00D_SERCOM1_PAD0                     _L_(0)       /**< SERCOM1 signal: PAD0 on PA00 mux D*/
+#define MUX_PA00D_SERCOM1_PAD0                     _L_(3)      
+#define PINMUX_PA00D_SERCOM1_PAD0                  ((PIN_PA00D_SERCOM1_PAD0 << 16) | MUX_PA00D_SERCOM1_PAD0)
+#define PORT_PA00D_SERCOM1_PAD0                    (_UL_(1) << 0)
+
+#define PIN_PA17C_SERCOM1_PAD1                     _L_(17)      /**< SERCOM1 signal: PAD1 on PA17 mux C*/
+#define MUX_PA17C_SERCOM1_PAD1                     _L_(2)      
+#define PINMUX_PA17C_SERCOM1_PAD1                  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
+#define PORT_PA17C_SERCOM1_PAD1                    (_UL_(1) << 17)
+
+#define PIN_PA09C_SERCOM1_PAD1                     _L_(9)       /**< SERCOM1 signal: PAD1 on PA09 mux C*/
+#define MUX_PA09C_SERCOM1_PAD1                     _L_(2)      
+#define PINMUX_PA09C_SERCOM1_PAD1                  ((PIN_PA09C_SERCOM1_PAD1 << 16) | MUX_PA09C_SERCOM1_PAD1)
+#define PORT_PA09C_SERCOM1_PAD1                    (_UL_(1) << 9)
+
+#define PIN_PA01D_SERCOM1_PAD1                     _L_(1)       /**< SERCOM1 signal: PAD1 on PA01 mux D*/
+#define MUX_PA01D_SERCOM1_PAD1                     _L_(3)      
+#define PINMUX_PA01D_SERCOM1_PAD1                  ((PIN_PA01D_SERCOM1_PAD1 << 16) | MUX_PA01D_SERCOM1_PAD1)
+#define PORT_PA01D_SERCOM1_PAD1                    (_UL_(1) << 1)
+
+#define PIN_PA18C_SERCOM1_PAD2                     _L_(18)      /**< SERCOM1 signal: PAD2 on PA18 mux C*/
+#define MUX_PA18C_SERCOM1_PAD2                     _L_(2)      
+#define PINMUX_PA18C_SERCOM1_PAD2                  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
+#define PORT_PA18C_SERCOM1_PAD2                    (_UL_(1) << 18)
+
+#define PIN_PA10C_SERCOM1_PAD2                     _L_(10)      /**< SERCOM1 signal: PAD2 on PA10 mux C*/
+#define MUX_PA10C_SERCOM1_PAD2                     _L_(2)      
+#define PINMUX_PA10C_SERCOM1_PAD2                  ((PIN_PA10C_SERCOM1_PAD2 << 16) | MUX_PA10C_SERCOM1_PAD2)
+#define PORT_PA10C_SERCOM1_PAD2                    (_UL_(1) << 10)
+
+#define PIN_PA30D_SERCOM1_PAD2                     _L_(30)      /**< SERCOM1 signal: PAD2 on PA30 mux D*/
+#define MUX_PA30D_SERCOM1_PAD2                     _L_(3)      
+#define PINMUX_PA30D_SERCOM1_PAD2                  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
+#define PORT_PA30D_SERCOM1_PAD2                    (_UL_(1) << 30)
+
+#define PIN_PA19C_SERCOM1_PAD3                     _L_(19)      /**< SERCOM1 signal: PAD3 on PA19 mux C*/
+#define MUX_PA19C_SERCOM1_PAD3                     _L_(2)      
+#define PINMUX_PA19C_SERCOM1_PAD3                  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
+#define PORT_PA19C_SERCOM1_PAD3                    (_UL_(1) << 19)
+
+#define PIN_PA11C_SERCOM1_PAD3                     _L_(11)      /**< SERCOM1 signal: PAD3 on PA11 mux C*/
+#define MUX_PA11C_SERCOM1_PAD3                     _L_(2)      
+#define PINMUX_PA11C_SERCOM1_PAD3                  ((PIN_PA11C_SERCOM1_PAD3 << 16) | MUX_PA11C_SERCOM1_PAD3)
+#define PORT_PA11C_SERCOM1_PAD3                    (_UL_(1) << 11)
+
+#define PIN_PA31D_SERCOM1_PAD3                     _L_(31)      /**< SERCOM1 signal: PAD3 on PA31 mux D*/
+#define MUX_PA31D_SERCOM1_PAD3                     _L_(3)      
+#define PINMUX_PA31D_SERCOM1_PAD3                  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
+#define PORT_PA31D_SERCOM1_PAD3                    (_UL_(1) << 31)
+
+/* ========== PORT definition for SERCOM2 peripheral ========== */
+#define PIN_PA08D_SERCOM2_PAD0                     _L_(8)       /**< SERCOM2 signal: PAD0 on PA08 mux D*/
+#define MUX_PA08D_SERCOM2_PAD0                     _L_(3)      
+#define PINMUX_PA08D_SERCOM2_PAD0                  ((PIN_PA08D_SERCOM2_PAD0 << 16) | MUX_PA08D_SERCOM2_PAD0)
+#define PORT_PA08D_SERCOM2_PAD0                    (_UL_(1) << 8)
+
+#define PIN_PA22D_SERCOM2_PAD0                     _L_(22)      /**< SERCOM2 signal: PAD0 on PA22 mux D*/
+#define MUX_PA22D_SERCOM2_PAD0                     _L_(3)      
+#define PINMUX_PA22D_SERCOM2_PAD0                  ((PIN_PA22D_SERCOM2_PAD0 << 16) | MUX_PA22D_SERCOM2_PAD0)
+#define PORT_PA22D_SERCOM2_PAD0                    (_UL_(1) << 22)
+
+#define PIN_PA09D_SERCOM2_PAD1                     _L_(9)       /**< SERCOM2 signal: PAD1 on PA09 mux D*/
+#define MUX_PA09D_SERCOM2_PAD1                     _L_(3)      
+#define PINMUX_PA09D_SERCOM2_PAD1                  ((PIN_PA09D_SERCOM2_PAD1 << 16) | MUX_PA09D_SERCOM2_PAD1)
+#define PORT_PA09D_SERCOM2_PAD1                    (_UL_(1) << 9)
+
+#define PIN_PA23D_SERCOM2_PAD1                     _L_(23)      /**< SERCOM2 signal: PAD1 on PA23 mux D*/
+#define MUX_PA23D_SERCOM2_PAD1                     _L_(3)      
+#define PINMUX_PA23D_SERCOM2_PAD1                  ((PIN_PA23D_SERCOM2_PAD1 << 16) | MUX_PA23D_SERCOM2_PAD1)
+#define PORT_PA23D_SERCOM2_PAD1                    (_UL_(1) << 23)
+
+#define PIN_PA10D_SERCOM2_PAD2                     _L_(10)      /**< SERCOM2 signal: PAD2 on PA10 mux D*/
+#define MUX_PA10D_SERCOM2_PAD2                     _L_(3)      
+#define PINMUX_PA10D_SERCOM2_PAD2                  ((PIN_PA10D_SERCOM2_PAD2 << 16) | MUX_PA10D_SERCOM2_PAD2)
+#define PORT_PA10D_SERCOM2_PAD2                    (_UL_(1) << 10)
+
+#define PIN_PA24D_SERCOM2_PAD2                     _L_(24)      /**< SERCOM2 signal: PAD2 on PA24 mux D*/
+#define MUX_PA24D_SERCOM2_PAD2                     _L_(3)      
+#define PINMUX_PA24D_SERCOM2_PAD2                  ((PIN_PA24D_SERCOM2_PAD2 << 16) | MUX_PA24D_SERCOM2_PAD2)
+#define PORT_PA24D_SERCOM2_PAD2                    (_UL_(1) << 24)
+
+#define PIN_PA14C_SERCOM2_PAD2                     _L_(14)      /**< SERCOM2 signal: PAD2 on PA14 mux C*/
+#define MUX_PA14C_SERCOM2_PAD2                     _L_(2)      
+#define PINMUX_PA14C_SERCOM2_PAD2                  ((PIN_PA14C_SERCOM2_PAD2 << 16) | MUX_PA14C_SERCOM2_PAD2)
+#define PORT_PA14C_SERCOM2_PAD2                    (_UL_(1) << 14)
+
+#define PIN_PA11D_SERCOM2_PAD3                     _L_(11)      /**< SERCOM2 signal: PAD3 on PA11 mux D*/
+#define MUX_PA11D_SERCOM2_PAD3                     _L_(3)      
+#define PINMUX_PA11D_SERCOM2_PAD3                  ((PIN_PA11D_SERCOM2_PAD3 << 16) | MUX_PA11D_SERCOM2_PAD3)
+#define PORT_PA11D_SERCOM2_PAD3                    (_UL_(1) << 11)
+
+#define PIN_PA25D_SERCOM2_PAD3                     _L_(25)      /**< SERCOM2 signal: PAD3 on PA25 mux D*/
+#define MUX_PA25D_SERCOM2_PAD3                     _L_(3)      
+#define PINMUX_PA25D_SERCOM2_PAD3                  ((PIN_PA25D_SERCOM2_PAD3 << 16) | MUX_PA25D_SERCOM2_PAD3)
+#define PORT_PA25D_SERCOM2_PAD3                    (_UL_(1) << 25)
+
+#define PIN_PA15C_SERCOM2_PAD3                     _L_(15)      /**< SERCOM2 signal: PAD3 on PA15 mux C*/
+#define MUX_PA15C_SERCOM2_PAD3                     _L_(2)      
+#define PINMUX_PA15C_SERCOM2_PAD3                  ((PIN_PA15C_SERCOM2_PAD3 << 16) | MUX_PA15C_SERCOM2_PAD3)
+#define PORT_PA15C_SERCOM2_PAD3                    (_UL_(1) << 15)
+
+/* ========== PORT definition for TC0 peripheral ========== */
+#define PIN_PA04E_TC0_WO0                          _L_(4)       /**< TC0 signal: WO0 on PA04 mux E*/
+#define MUX_PA04E_TC0_WO0                          _L_(4)      
+#define PINMUX_PA04E_TC0_WO0                       ((PIN_PA04E_TC0_WO0 << 16) | MUX_PA04E_TC0_WO0)
+#define PORT_PA04E_TC0_WO0                         (_UL_(1) << 4)
+
+#define PIN_PA14E_TC0_WO0                          _L_(14)      /**< TC0 signal: WO0 on PA14 mux E*/
+#define MUX_PA14E_TC0_WO0                          _L_(4)      
+#define PINMUX_PA14E_TC0_WO0                       ((PIN_PA14E_TC0_WO0 << 16) | MUX_PA14E_TC0_WO0)
+#define PORT_PA14E_TC0_WO0                         (_UL_(1) << 14)
+
+#define PIN_PA22E_TC0_WO0                          _L_(22)      /**< TC0 signal: WO0 on PA22 mux E*/
+#define MUX_PA22E_TC0_WO0                          _L_(4)      
+#define PINMUX_PA22E_TC0_WO0                       ((PIN_PA22E_TC0_WO0 << 16) | MUX_PA22E_TC0_WO0)
+#define PORT_PA22E_TC0_WO0                         (_UL_(1) << 22)
+
+#define PIN_PA05E_TC0_WO1                          _L_(5)       /**< TC0 signal: WO1 on PA05 mux E*/
+#define MUX_PA05E_TC0_WO1                          _L_(4)      
+#define PINMUX_PA05E_TC0_WO1                       ((PIN_PA05E_TC0_WO1 << 16) | MUX_PA05E_TC0_WO1)
+#define PORT_PA05E_TC0_WO1                         (_UL_(1) << 5)
+
+#define PIN_PA15E_TC0_WO1                          _L_(15)      /**< TC0 signal: WO1 on PA15 mux E*/
+#define MUX_PA15E_TC0_WO1                          _L_(4)      
+#define PINMUX_PA15E_TC0_WO1                       ((PIN_PA15E_TC0_WO1 << 16) | MUX_PA15E_TC0_WO1)
+#define PORT_PA15E_TC0_WO1                         (_UL_(1) << 15)
+
+#define PIN_PA23E_TC0_WO1                          _L_(23)      /**< TC0 signal: WO1 on PA23 mux E*/
+#define MUX_PA23E_TC0_WO1                          _L_(4)      
+#define PINMUX_PA23E_TC0_WO1                       ((PIN_PA23E_TC0_WO1 << 16) | MUX_PA23E_TC0_WO1)
+#define PORT_PA23E_TC0_WO1                         (_UL_(1) << 23)
+
+/* ========== PORT definition for TC1 peripheral ========== */
+#define PIN_PA06E_TC1_WO0                          _L_(6)       /**< TC1 signal: WO0 on PA06 mux E*/
+#define MUX_PA06E_TC1_WO0                          _L_(4)      
+#define PINMUX_PA06E_TC1_WO0                       ((PIN_PA06E_TC1_WO0 << 16) | MUX_PA06E_TC1_WO0)
+#define PORT_PA06E_TC1_WO0                         (_UL_(1) << 6)
+
+#define PIN_PA24E_TC1_WO0                          _L_(24)      /**< TC1 signal: WO0 on PA24 mux E*/
+#define MUX_PA24E_TC1_WO0                          _L_(4)      
+#define PINMUX_PA24E_TC1_WO0                       ((PIN_PA24E_TC1_WO0 << 16) | MUX_PA24E_TC1_WO0)
+#define PORT_PA24E_TC1_WO0                         (_UL_(1) << 24)
+
+#define PIN_PA30E_TC1_WO0                          _L_(30)      /**< TC1 signal: WO0 on PA30 mux E*/
+#define MUX_PA30E_TC1_WO0                          _L_(4)      
+#define PINMUX_PA30E_TC1_WO0                       ((PIN_PA30E_TC1_WO0 << 16) | MUX_PA30E_TC1_WO0)
+#define PORT_PA30E_TC1_WO0                         (_UL_(1) << 30)
+
+#define PIN_PA07E_TC1_WO1                          _L_(7)       /**< TC1 signal: WO1 on PA07 mux E*/
+#define MUX_PA07E_TC1_WO1                          _L_(4)      
+#define PINMUX_PA07E_TC1_WO1                       ((PIN_PA07E_TC1_WO1 << 16) | MUX_PA07E_TC1_WO1)
+#define PORT_PA07E_TC1_WO1                         (_UL_(1) << 7)
+
+#define PIN_PA25E_TC1_WO1                          _L_(25)      /**< TC1 signal: WO1 on PA25 mux E*/
+#define MUX_PA25E_TC1_WO1                          _L_(4)      
+#define PINMUX_PA25E_TC1_WO1                       ((PIN_PA25E_TC1_WO1 << 16) | MUX_PA25E_TC1_WO1)
+#define PORT_PA25E_TC1_WO1                         (_UL_(1) << 25)
+
+#define PIN_PA31E_TC1_WO1                          _L_(31)      /**< TC1 signal: WO1 on PA31 mux E*/
+#define MUX_PA31E_TC1_WO1                          _L_(4)      
+#define PINMUX_PA31E_TC1_WO1                       ((PIN_PA31E_TC1_WO1 << 16) | MUX_PA31E_TC1_WO1)
+#define PORT_PA31E_TC1_WO1                         (_UL_(1) << 31)
+
+/* ========== PORT definition for TC2 peripheral ========== */
+#define PIN_PA00E_TC2_WO0                          _L_(0)       /**< TC2 signal: WO0 on PA00 mux E*/
+#define MUX_PA00E_TC2_WO0                          _L_(4)      
+#define PINMUX_PA00E_TC2_WO0                       ((PIN_PA00E_TC2_WO0 << 16) | MUX_PA00E_TC2_WO0)
+#define PORT_PA00E_TC2_WO0                         (_UL_(1) << 0)
+
+#define PIN_PA18E_TC2_WO0                          _L_(18)      /**< TC2 signal: WO0 on PA18 mux E*/
+#define MUX_PA18E_TC2_WO0                          _L_(4)      
+#define PINMUX_PA18E_TC2_WO0                       ((PIN_PA18E_TC2_WO0 << 16) | MUX_PA18E_TC2_WO0)
+#define PORT_PA18E_TC2_WO0                         (_UL_(1) << 18)
+
+#define PIN_PA01E_TC2_WO1                          _L_(1)       /**< TC2 signal: WO1 on PA01 mux E*/
+#define MUX_PA01E_TC2_WO1                          _L_(4)      
+#define PINMUX_PA01E_TC2_WO1                       ((PIN_PA01E_TC2_WO1 << 16) | MUX_PA01E_TC2_WO1)
+#define PORT_PA01E_TC2_WO1                         (_UL_(1) << 1)
+
+#define PIN_PA19E_TC2_WO1                          _L_(19)      /**< TC2 signal: WO1 on PA19 mux E*/
+#define MUX_PA19E_TC2_WO1                          _L_(4)      
+#define PINMUX_PA19E_TC2_WO1                       ((PIN_PA19E_TC2_WO1 << 16) | MUX_PA19E_TC2_WO1)
+#define PORT_PA19E_TC2_WO1                         (_UL_(1) << 19)
+
+
+#endif /* _SAML10E16A_PIO_H_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/sam.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/sam.h
@@ -1,0 +1,50 @@
+/**
+ * \file
+ *
+ * \brief Top level header file
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+#ifndef _SAM_
+#define _SAM_
+
+#if   defined(__SAML10D14A__) || defined(__ATSAML10D14A__)
+  #include "saml10d14a.h"
+#elif defined(__SAML10D15A__) || defined(__ATSAML10D15A__)
+  #include "saml10d15a.h"
+#elif defined(__SAML10D16A__) || defined(__ATSAML10D16A__)
+  #include "saml10d16a.h"
+#elif defined(__SAML10E14A__) || defined(__ATSAML10E14A__)
+  #include "saml10e14a.h"
+#elif defined(__SAML10E15A__) || defined(__ATSAML10E15A__)
+  #include "saml10e15a.h"
+#elif defined(__SAML10E16A__) || defined(__ATSAML10E16A__)
+  #include "saml10e16a.h"
+#else
+  #error Library does not support the specified device
+#endif
+
+#endif /* _SAM_ */
+

--- a/cpu/sam0_common/include/vendor/saml10/include/saml10d14a.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/saml10d14a.h
@@ -1,0 +1,789 @@
+/**
+ * \file
+ *
+ * \brief Header file for ATSAML10D14A
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:49Z */
+#ifndef _SAML10D14A_H_
+#define _SAML10D14A_H_
+
+/** \addtogroup SAML10D14A_definitions SAML10D14A definitions
+  This file defines all structures and symbols for SAML10D14A:
+    - registers and bitfields
+    - peripheral base address
+    - peripheral ID
+    - PIO definitions
+ *  @{
+ */
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/** \defgroup Atmel_glob_defs Atmel Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+
+    \remark
+    CMSIS core has a syntax that differs from this using i.e. __I, __O, or __IO followed by 'uint<size>_t' respective types.
+    Default the header files will follow the CMSIS core syntax.
+ *  @{
+ */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+
+/* IO definitions (access restrictions to peripheral registers) */
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+
+#define CAST(type, value) ((type *)(value)) /**< Pointer Type Conversion Macro for C/C++ */
+#define REG_ACCESS(type, address) (*(type*)(address)) /**< C code: Register value */
+#else /* Assembler */
+#define CAST(type, value) (value) /**< Pointer Type Conversion Macro for Assembler */
+#define REG_ACCESS(type, address) (address) /**< Assembly code: Register address */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !defined(SKIP_INTEGER_LITERALS)
+
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x) x ## U    /**< C code: Unsigned integer literal constant value */
+#define _L_(x) x ## L    /**< C code: Long integer literal constant value */
+#define _UL_(x) x ## UL  /**< C code: Unsigned Long integer literal constant value */
+
+#else /* Assembler */
+
+#define _U_(x) x    /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x) x    /**< Assembler: Long integer literal constant value */
+#define _UL_(x) x   /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* SKIP_INTEGER_LITERALS */
+/** @}  end of Atmel Global Defines */
+
+/** \addtogroup SAML10D14A_cmsis CMSIS Definitions
+ *  @{
+ */
+/* ************************************************************************** */
+/*   CMSIS DEFINITIONS FOR SAML10D14A */
+/* ************************************************************************** */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+/******  CORTEX-M23 Processor Exceptions Numbers ******************************/
+  Reset_IRQn                = -15, /**< 1   Reset Vector, invoked on Power up and warm reset  */
+  NonMaskableInt_IRQn       = -14, /**< 2   Non maskable Interrupt, cannot be stopped or preempted  */
+  HardFault_IRQn            = -13, /**< 3   Hard Fault, all classes of Fault     */
+  SVCall_IRQn               = -5 , /**< 11  System Service Call via SVC instruction  */
+  PendSV_IRQn               = -2 , /**< 14  Pendable request for system service  */
+  SysTick_IRQn              = -1 , /**< 15  System Tick Timer                    */
+/******  SAML10D14A specific Interrupt Numbers ***********************************/
+  SYSTEM_IRQn               = 0  , /**< 0   SAML10D14A Main Clock (MCLK)        */
+  WDT_IRQn                  = 1  , /**< 1   SAML10D14A Watchdog Timer (WDT)     */
+  RTC_IRQn                  = 2  , /**< 2   SAML10D14A Real-Time Counter (RTC)  */
+  EIC_0_IRQn                = 3  , /**< 3   SAML10D14A External Interrupt Controller (EIC) */
+  EIC_1_IRQn                = 4  , /**< 4   SAML10D14A External Interrupt Controller (EIC) */
+  EIC_2_IRQn                = 5  , /**< 5   SAML10D14A External Interrupt Controller (EIC) */
+  EIC_3_IRQn                = 6  , /**< 6   SAML10D14A External Interrupt Controller (EIC) */
+  EIC_OTHER_IRQn            = 7  , /**< 7   SAML10D14A External Interrupt Controller (EIC) */
+  FREQM_IRQn                = 8  , /**< 8   SAML10D14A Frequency Meter (FREQM)  */
+  NVMCTRL_IRQn              = 9  , /**< 9   SAML10D14A Non-Volatile Memory Controller (NVMCTRL) */
+  PORT_IRQn                 = 10 , /**< 10  SAML10D14A Port Module (PORT)       */
+  DMAC_0_IRQn               = 11 , /**< 11  SAML10D14A Direct Memory Access Controller (DMAC) */
+  DMAC_1_IRQn               = 12 , /**< 12  SAML10D14A Direct Memory Access Controller (DMAC) */
+  DMAC_2_IRQn               = 13 , /**< 13  SAML10D14A Direct Memory Access Controller (DMAC) */
+  DMAC_3_IRQn               = 14 , /**< 14  SAML10D14A Direct Memory Access Controller (DMAC) */
+  DMAC_OTHER_IRQn           = 15 , /**< 15  SAML10D14A Direct Memory Access Controller (DMAC) */
+  EVSYS_0_IRQn              = 16 , /**< 16  SAML10D14A Event System Interface (EVSYS) */
+  EVSYS_1_IRQn              = 17 , /**< 17  SAML10D14A Event System Interface (EVSYS) */
+  EVSYS_2_IRQn              = 18 , /**< 18  SAML10D14A Event System Interface (EVSYS) */
+  EVSYS_3_IRQn              = 19 , /**< 19  SAML10D14A Event System Interface (EVSYS) */
+  EVSYS_NSCHK_IRQn          = 20 , /**< 20  SAML10D14A Event System Interface (EVSYS) */
+  PAC_IRQn                  = 21 , /**< 21  SAML10D14A Peripheral Access Controller (PAC) */
+  SERCOM0_0_IRQn            = 22 , /**< 22  SAML10D14A Serial Communication Interface (SERCOM0) */
+  SERCOM0_1_IRQn            = 23 , /**< 23  SAML10D14A Serial Communication Interface (SERCOM0) */
+  SERCOM0_2_IRQn            = 24 , /**< 24  SAML10D14A Serial Communication Interface (SERCOM0) */
+  SERCOM0_OTHER_IRQn        = 25 , /**< 25  SAML10D14A Serial Communication Interface (SERCOM0) */
+  SERCOM1_0_IRQn            = 26 , /**< 26  SAML10D14A Serial Communication Interface (SERCOM1) */
+  SERCOM1_1_IRQn            = 27 , /**< 27  SAML10D14A Serial Communication Interface (SERCOM1) */
+  SERCOM1_2_IRQn            = 28 , /**< 28  SAML10D14A Serial Communication Interface (SERCOM1) */
+  SERCOM1_OTHER_IRQn        = 29 , /**< 29  SAML10D14A Serial Communication Interface (SERCOM1) */
+  TC0_IRQn                  = 34 , /**< 34  SAML10D14A Basic Timer Counter (TC0) */
+  TC1_IRQn                  = 35 , /**< 35  SAML10D14A Basic Timer Counter (TC1) */
+  TC2_IRQn                  = 36 , /**< 36  SAML10D14A Basic Timer Counter (TC2) */
+  ADC_OTHER_IRQn            = 37 , /**< 37  SAML10D14A Analog Digital Converter (ADC) */
+  ADC_RESRDY_IRQn           = 38 , /**< 38  SAML10D14A Analog Digital Converter (ADC) */
+  AC_IRQn                   = 39 , /**< 39  SAML10D14A Analog Comparators (AC)  */
+  DAC_UNDERRUN_A_IRQn       = 40 , /**< 40  SAML10D14A Digital Analog Converter (DAC) */
+  DAC_EMPTY_IRQn            = 41 , /**< 41  SAML10D14A Digital Analog Converter (DAC) */
+  PTC_IRQn                  = 42 , /**< 42  SAML10D14A Peripheral Touch Controller (PTC) */
+  TRNG_IRQn                 = 43 , /**< 43  SAML10D14A True Random Generator (TRNG) */
+  TRAM_IRQn                 = 44 , /**< 44  SAML10D14A TrustRAM (TRAM)          */
+
+  PERIPH_COUNT_IRQn        = 45  /**< Number of peripheral IDs */
+} IRQn_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;                        /* -15 Reset Vector, invoked on Power up and warm reset  */
+  void* pfnNonMaskableInt_Handler;               /* -14 Non maskable Interrupt, cannot be stopped or preempted  */
+  void* pfnHardFault_Handler;                    /* -13 Hard Fault, all classes of Fault     */
+  void* pvReservedC12;
+  void* pvReservedC11;
+  void* pvReservedC10;
+  void* pvReservedC9;
+  void* pvReservedC8;
+  void* pvReservedC7;
+  void* pvReservedC6;
+  void* pfnSVCall_Handler;                       /*  -5 System Service Call via SVC instruction  */
+  void* pvReservedC4;
+  void* pvReservedC3;
+  void* pfnPendSV_Handler;                       /*  -2 Pendable request for system service  */
+  void* pfnSysTick_Handler;                      /*  -1 System Tick Timer                    */
+
+
+  /* Peripheral handlers */
+  void* pfnSYSTEM_Handler;                       /* 0   SAML10D14A Main Clock (MCLK)   */
+  void* pfnWDT_Handler;                          /* 1   SAML10D14A Watchdog Timer (WDT) */
+  void* pfnRTC_Handler;                          /* 2   SAML10D14A Real-Time Counter (RTC) */
+  void* pfnEIC_0_Handler;                        /* 3   SAML10D14A External Interrupt Controller (EIC) */
+  void* pfnEIC_1_Handler;                        /* 4   SAML10D14A External Interrupt Controller (EIC) */
+  void* pfnEIC_2_Handler;                        /* 5   SAML10D14A External Interrupt Controller (EIC) */
+  void* pfnEIC_3_Handler;                        /* 6   SAML10D14A External Interrupt Controller (EIC) */
+  void* pfnEIC_OTHER_Handler;                    /* 7   SAML10D14A External Interrupt Controller (EIC) */
+  void* pfnFREQM_Handler;                        /* 8   SAML10D14A Frequency Meter (FREQM) */
+  void* pfnNVMCTRL_Handler;                      /* 9   SAML10D14A Non-Volatile Memory Controller (NVMCTRL) */
+  void* pfnPORT_Handler;                         /* 10  SAML10D14A Port Module (PORT)  */
+  void* pfnDMAC_0_Handler;                       /* 11  SAML10D14A Direct Memory Access Controller (DMAC) */
+  void* pfnDMAC_1_Handler;                       /* 12  SAML10D14A Direct Memory Access Controller (DMAC) */
+  void* pfnDMAC_2_Handler;                       /* 13  SAML10D14A Direct Memory Access Controller (DMAC) */
+  void* pfnDMAC_3_Handler;                       /* 14  SAML10D14A Direct Memory Access Controller (DMAC) */
+  void* pfnDMAC_OTHER_Handler;                   /* 15  SAML10D14A Direct Memory Access Controller (DMAC) */
+  void* pfnEVSYS_0_Handler;                      /* 16  SAML10D14A Event System Interface (EVSYS) */
+  void* pfnEVSYS_1_Handler;                      /* 17  SAML10D14A Event System Interface (EVSYS) */
+  void* pfnEVSYS_2_Handler;                      /* 18  SAML10D14A Event System Interface (EVSYS) */
+  void* pfnEVSYS_3_Handler;                      /* 19  SAML10D14A Event System Interface (EVSYS) */
+  void* pfnEVSYS_NSCHK_Handler;                  /* 20  SAML10D14A Event System Interface (EVSYS) */
+  void* pfnPAC_Handler;                          /* 21  SAML10D14A Peripheral Access Controller (PAC) */
+  void* pfnSERCOM0_0_Handler;                    /* 22  SAML10D14A Serial Communication Interface (SERCOM0) */
+  void* pfnSERCOM0_1_Handler;                    /* 23  SAML10D14A Serial Communication Interface (SERCOM0) */
+  void* pfnSERCOM0_2_Handler;                    /* 24  SAML10D14A Serial Communication Interface (SERCOM0) */
+  void* pfnSERCOM0_OTHER_Handler;                /* 25  SAML10D14A Serial Communication Interface (SERCOM0) */
+  void* pfnSERCOM1_0_Handler;                    /* 26  SAML10D14A Serial Communication Interface (SERCOM1) */
+  void* pfnSERCOM1_1_Handler;                    /* 27  SAML10D14A Serial Communication Interface (SERCOM1) */
+  void* pfnSERCOM1_2_Handler;                    /* 28  SAML10D14A Serial Communication Interface (SERCOM1) */
+  void* pfnSERCOM1_OTHER_Handler;                /* 29  SAML10D14A Serial Communication Interface (SERCOM1) */
+  void* pvReserved30;
+  void* pvReserved31;
+  void* pvReserved32;
+  void* pvReserved33;
+  void* pfnTC0_Handler;                          /* 34  SAML10D14A Basic Timer Counter (TC0) */
+  void* pfnTC1_Handler;                          /* 35  SAML10D14A Basic Timer Counter (TC1) */
+  void* pfnTC2_Handler;                          /* 36  SAML10D14A Basic Timer Counter (TC2) */
+  void* pfnADC_OTHER_Handler;                    /* 37  SAML10D14A Analog Digital Converter (ADC) */
+  void* pfnADC_RESRDY_Handler;                   /* 38  SAML10D14A Analog Digital Converter (ADC) */
+  void* pfnAC_Handler;                           /* 39  SAML10D14A Analog Comparators (AC) */
+  void* pfnDAC_UNDERRUN_A_Handler;               /* 40  SAML10D14A Digital Analog Converter (DAC) */
+  void* pfnDAC_EMPTY_Handler;                    /* 41  SAML10D14A Digital Analog Converter (DAC) */
+  void* pfnPTC_Handler;                          /* 42  SAML10D14A Peripheral Touch Controller (PTC) */
+  void* pfnTRNG_Handler;                         /* 43  SAML10D14A True Random Generator (TRNG) */
+  void* pfnTRAM_Handler;                         /* 44  SAML10D14A TrustRAM (TRAM)     */
+} DeviceVectors;
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define pfnMemManage_Handler      pfnMemoryManagement_Handler     /**< \deprecated  Backward compatibility for ASF */
+#define pfnDebugMon_Handler       pfnDebugMonitor_Handler         /**< \deprecated  Backward compatibility for ASF */
+#define pfnNMI_Handler            pfnNonMaskableInt_Handler       /**< \deprecated  Backward compatibility for ASF */
+#define pfnSVC_Handler            pfnSVCall_Handler               /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if !defined DONT_USE_PREDEFINED_CORE_HANDLERS
+
+/* CORTEX-M23 core handlers */
+void Reset_Handler                 ( void );
+void NonMaskableInt_Handler        ( void );
+void HardFault_Handler             ( void );
+void SVCall_Handler                ( void );
+void PendSV_Handler                ( void );
+void SysTick_Handler               ( void );
+#endif /* DONT_USE_PREDEFINED_CORE_HANDLERS */
+
+#if !defined DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS
+
+/* Peripherals handlers */
+void AC_Handler                    ( void );
+void ADC_OTHER_Handler             ( void );
+void ADC_RESRDY_Handler            ( void );
+void DAC_EMPTY_Handler             ( void );
+void DAC_UNDERRUN_A_Handler        ( void );
+void DMAC_0_Handler                ( void );
+void DMAC_1_Handler                ( void );
+void DMAC_2_Handler                ( void );
+void DMAC_3_Handler                ( void );
+void DMAC_OTHER_Handler            ( void );
+void EIC_0_Handler                 ( void );
+void EIC_1_Handler                 ( void );
+void EIC_2_Handler                 ( void );
+void EIC_3_Handler                 ( void );
+void EIC_OTHER_Handler             ( void );
+void EVSYS_0_Handler               ( void );
+void EVSYS_1_Handler               ( void );
+void EVSYS_2_Handler               ( void );
+void EVSYS_3_Handler               ( void );
+void EVSYS_NSCHK_Handler           ( void );
+void FREQM_Handler                 ( void );
+void NVMCTRL_Handler               ( void );
+void PAC_Handler                   ( void );
+void PORT_Handler                  ( void );
+void PTC_Handler                   ( void );
+void RTC_Handler                   ( void );
+void SERCOM0_0_Handler             ( void );
+void SERCOM0_1_Handler             ( void );
+void SERCOM0_2_Handler             ( void );
+void SERCOM0_OTHER_Handler         ( void );
+void SERCOM1_0_Handler             ( void );
+void SERCOM1_1_Handler             ( void );
+void SERCOM1_2_Handler             ( void );
+void SERCOM1_OTHER_Handler         ( void );
+void SYSTEM_Handler                ( void );
+void TC0_Handler                   ( void );
+void TC1_Handler                   ( void );
+void TC2_Handler                   ( void );
+void TRAM_Handler                  ( void );
+void TRNG_Handler                  ( void );
+void WDT_Handler                   ( void );
+#endif /* DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS */
+
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define MemManage_Handler         MemoryManagement_Handler        /**< \deprecated  Backward compatibility for ASF */
+#define DebugMon_Handler          DebugMonitor_Handler            /**< \deprecated  Backward compatibility for ASF */
+#define NMI_Handler               NonMaskableInt_Handler          /**< \deprecated  Backward compatibility for ASF */
+#define SVC_Handler               SVCall_Handler                  /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+
+/*
+ * \brief Configuration of the CORTEX-M23 Processor and Core Peripherals
+ */
+
+#define NUM_IRQ                       45 /**< Number of interrupt request lines                                         */
+#define __ARMv8MBL_REV            0x0000 /**< Cortex-M23 Core Revision                                                  */
+#define __ETM_PRESENT                  0 /**< ETM present or not                                                        */
+#define __FPU_PRESENT                  0 /**< FPU present or not                                                        */
+#define __MPU_PRESENT                  1 /**< MPU present or not                                                        */
+#define __MTB_PRESENT                  0 /**< MTB present or not                                                        */
+#define __NVIC_PRIO_BITS               2 /**< Number of Bits used for Priority Levels                                   */
+#define __SAU_PRESENT                  0 /**< SAU present or not                                                        */
+#define __SEC_ENABLED                  0 /**< TrustZone-M enabled or not                                                */
+#define __VTOR_PRESENT                 1 /**< Vector Table Offset Register present or not                               */
+#define __Vendor_SysTickConfig         0 /**< Set to 1 if different SysTick Config is used                              */
+#define __ARCH_ARM                     1
+#define __ARCH_ARM_CORTEX_M            1
+#define __DEVICE_IS_SAM                1
+
+/*
+ * \brief CMSIS includes
+ */
+#include <core_cm23.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_saml10.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/** @}  end of SAML10D14A_cmsis CMSIS Definitions */
+
+/** \defgroup SAML10D14A_api Peripheral Software API
+ *  @{
+ */
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAML10D14A */
+/* ************************************************************************** */
+#include "component/ac.h"
+#include "component/adc.h"
+#include "component/ccl.h"
+#include "component/dac.h"
+#include "component/dmac.h"
+#include "component/dsu.h"
+#include "component/eic.h"
+#include "component/evsys.h"
+#include "component/freqm.h"
+#include "component/gclk.h"
+#include "component/idau.h"
+#include "component/mclk.h"
+#include "component/nvmctrl.h"
+#include "component/opamp.h"
+#include "component/oscctrl.h"
+#include "component/osc32kctrl.h"
+#include "component/pac.h"
+#include "component/pm.h"
+#include "component/port.h"
+#include "component/ptc.h"
+#include "component/rstc.h"
+#include "component/rtc.h"
+#include "component/sercom.h"
+#include "component/supc.h"
+#include "component/tc.h"
+#include "component/tram.h"
+#include "component/trng.h"
+#include "component/wdt.h"
+/** @}  end of Peripheral Software API */
+
+/** \defgroup SAML10D14A_reg Registers Access Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   REGISTER ACCESS DEFINITIONS FOR SAML10D14A */
+/* ************************************************************************** */
+#include "instance/ac.h"
+#include "instance/adc.h"
+#include "instance/ccl.h"
+#include "instance/dac.h"
+#include "instance/dmac.h"
+#include "instance/dsu.h"
+#include "instance/eic.h"
+#include "instance/evsys.h"
+#include "instance/freqm.h"
+#include "instance/gclk.h"
+#include "instance/idau.h"
+#include "instance/mclk.h"
+#include "instance/nvmctrl.h"
+#include "instance/opamp.h"
+#include "instance/oscctrl.h"
+#include "instance/osc32kctrl.h"
+#include "instance/pac.h"
+#include "instance/pm.h"
+#include "instance/port.h"
+#include "instance/ptc.h"
+#include "instance/rstc.h"
+#include "instance/rtc.h"
+#include "instance/sercom0.h"
+#include "instance/sercom1.h"
+#include "instance/supc.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tram.h"
+#include "instance/trng.h"
+#include "instance/wdt.h"
+/** @}  end of Registers Access Definitions */
+
+/** \addtogroup SAML10D14A_id Peripheral Ids Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*  PERIPHERAL ID DEFINITIONS FOR SAML10D14A */
+/* ************************************************************************** */
+#define ID_PAC          (  0) /**< \brief Peripheral Access Controller (PAC) */
+#define ID_PM           (  1) /**< \brief Power Manager (PM) */
+#define ID_MCLK         (  2) /**< \brief Main Clock (MCLK) */
+#define ID_RSTC         (  3) /**< \brief Reset Controller (RSTC) */
+#define ID_OSCCTRL      (  4) /**< \brief Oscillators Control (OSCCTRL) */
+#define ID_OSC32KCTRL   (  5) /**< \brief 32k Oscillators Control (OSC32KCTRL) */
+#define ID_SUPC         (  6) /**< \brief Supply Controller (SUPC) */
+#define ID_GCLK         (  7) /**< \brief Generic Clock Generator (GCLK) */
+#define ID_WDT          (  8) /**< \brief Watchdog Timer (WDT) */
+#define ID_RTC          (  9) /**< \brief Real-Time Counter (RTC) */
+#define ID_EIC          ( 10) /**< \brief External Interrupt Controller (EIC) */
+#define ID_FREQM        ( 11) /**< \brief Frequency Meter (FREQM) */
+#define ID_PORT         ( 12) /**< \brief Port Module (PORT) */
+#define ID_AC           ( 13) /**< \brief Analog Comparators (AC) */
+#define ID_IDAU         ( 32) /**< \brief Implementation Defined Attribution Unit (IDAU) */
+#define ID_DSU          ( 33) /**< \brief Device Service Unit (DSU) */
+#define ID_NVMCTRL      ( 34) /**< \brief Non-Volatile Memory Controller (NVMCTRL) */
+#define ID_DMAC         ( 35) /**< \brief Direct Memory Access Controller (DMAC) */
+#define ID_EVSYS        ( 64) /**< \brief Event System Interface (EVSYS) */
+#define ID_SERCOM0      ( 65) /**< \brief Serial Communication Interface (SERCOM0) */
+#define ID_SERCOM1      ( 66) /**< \brief Serial Communication Interface (SERCOM1) */
+#define ID_TC0          ( 68) /**< \brief Basic Timer Counter (TC0) */
+#define ID_TC1          ( 69) /**< \brief Basic Timer Counter (TC1) */
+#define ID_TC2          ( 70) /**< \brief Basic Timer Counter (TC2) */
+#define ID_ADC          ( 71) /**< \brief Analog Digital Converter (ADC) */
+#define ID_DAC          ( 72) /**< \brief Digital Analog Converter (DAC) */
+#define ID_PTC          ( 73) /**< \brief Peripheral Touch Controller (PTC) */
+#define ID_TRNG         ( 74) /**< \brief True Random Generator (TRNG) */
+#define ID_CCL          ( 75) /**< \brief Configurable Custom Logic (CCL) */
+#define ID_OPAMP        ( 76) /**< \brief Operational Amplifier (OPAMP) */
+#define ID_TRAM         ( 77) /**< \brief TrustRAM (TRAM) */
+
+#define ID_PERIPH_COUNT ( 78) /**< \brief Number of peripheral IDs */
+/** @}  end of Peripheral Ids Definitions */
+
+/** \addtogroup SAML10D14A_base Peripheral Base Address Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   BASE ADDRESS DEFINITIONS FOR SAML10D14A */
+/* ************************************************************************** */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#define AC                     (0x40003400)                   /**< \brief (AC        ) Base Address */
+#define ADC                    (0x42001C00)                   /**< \brief (ADC       ) Base Address */
+#define CCL                    (0x42002C00)                   /**< \brief (CCL       ) Base Address */
+#define DAC                    (0x42002000)                   /**< \brief (DAC       ) Base Address */
+#define DMAC                   (0x41006000)                   /**< \brief (DMAC      ) Base Address */
+#define DSU                    (0x41002000)                   /**< \brief (DSU       ) Base Address */
+#define DSU_EXT                (0x41002100)                   /**< \brief (DSU       ) Base Address */
+#define EIC                    (0x40002800)                   /**< \brief (EIC       ) Base Address */
+#define EVSYS                  (0x42000000)                   /**< \brief (EVSYS     ) Base Address */
+#define FREQM                  (0x40002C00)                   /**< \brief (FREQM     ) Base Address */
+#define GCLK                   (0x40001C00)                   /**< \brief (GCLK      ) Base Address */
+#define IDAU                   (0x41000000)                   /**< \brief (IDAU      ) Base Address */
+#define MCLK                   (0x40000800)                   /**< \brief (MCLK      ) Base Address */
+#define NVMCTRL                (0x41004000)                   /**< \brief (NVMCTRL   ) Base Address */
+#define OPAMP                  (0x42003000)                   /**< \brief (OPAMP     ) Base Address */
+#define OSCCTRL                (0x40001000)                   /**< \brief (OSCCTRL   ) Base Address */
+#define OSC32KCTRL             (0x40001400)                   /**< \brief (OSC32KCTRL) Base Address */
+#define PAC                    (0x40000000)                   /**< \brief (PAC       ) Base Address */
+#define PM                     (0x40000400)                   /**< \brief (PM        ) Base Address */
+#define PORT                   (0x40003000)                   /**< \brief (PORT      ) Base Address */
+#define PORT_IOBUS             (0x60000000)                   /**< \brief (PORT      ) Base Address */
+#define PTC                    (0x42002400)                   /**< \brief (PTC       ) Base Address */
+#define RSTC                   (0x40000C00)                   /**< \brief (RSTC      ) Base Address */
+#define RTC                    (0x40002400)                   /**< \brief (RTC       ) Base Address */
+#define SERCOM0                (0x42000400)                   /**< \brief (SERCOM0   ) Base Address */
+#define SERCOM1                (0x42000800)                   /**< \brief (SERCOM1   ) Base Address */
+#define SUPC                   (0x40001800)                   /**< \brief (SUPC      ) Base Address */
+#define TC0                    (0x42001000)                   /**< \brief (TC0       ) Base Address */
+#define TC1                    (0x42001400)                   /**< \brief (TC1       ) Base Address */
+#define TC2                    (0x42001800)                   /**< \brief (TC2       ) Base Address */
+#define TRAM                   (0x42003400)                   /**< \brief (TRAM      ) Base Address */
+#define TRNG                   (0x42002800)                   /**< \brief (TRNG      ) Base Address */
+#define WDT                    (0x40002000)                   /**< \brief (WDT       ) Base Address */
+
+#else /* For C/C++ compiler */
+
+#define AC                     ((Ac *)0x40003400U)            /**< \brief (AC        ) Base Address */
+#define AC_INST_NUM            1                              /**< \brief (AC        ) Number of instances */
+#define AC_INSTS               { AC }                         /**< \brief (AC        ) Instances List */
+
+#define ADC                    ((Adc *)0x42001C00U)           /**< \brief (ADC       ) Base Address */
+#define ADC_INST_NUM           1                              /**< \brief (ADC       ) Number of instances */
+#define ADC_INSTS              { ADC }                        /**< \brief (ADC       ) Instances List */
+
+#define CCL                    ((Ccl *)0x42002C00U)           /**< \brief (CCL       ) Base Address */
+#define CCL_INST_NUM           1                              /**< \brief (CCL       ) Number of instances */
+#define CCL_INSTS              { CCL }                        /**< \brief (CCL       ) Instances List */
+
+#define DAC                    ((Dac *)0x42002000U)           /**< \brief (DAC       ) Base Address */
+#define DAC_INST_NUM           1                              /**< \brief (DAC       ) Number of instances */
+#define DAC_INSTS              { DAC }                        /**< \brief (DAC       ) Instances List */
+
+#define DMAC                   ((Dmac *)0x41006000U)          /**< \brief (DMAC      ) Base Address */
+#define DMAC_INST_NUM          1                              /**< \brief (DMAC      ) Number of instances */
+#define DMAC_INSTS             { DMAC }                       /**< \brief (DMAC      ) Instances List */
+
+#define DSU                    ((Dsu *)0x41002000U)           /**< \brief (DSU       ) Base Address */
+#define DSU_EXT                ((Dsu *)0x41002100U)           /**< \brief (DSU       ) Base Address */
+#define DSU_INST_NUM           1                              /**< \brief (DSU       ) Number of instances */
+#define DSU_INSTS              { DSU }                        /**< \brief (DSU       ) Instances List */
+
+#define EIC                    ((Eic *)0x40002800U)           /**< \brief (EIC       ) Base Address */
+#define EIC_INST_NUM           1                              /**< \brief (EIC       ) Number of instances */
+#define EIC_INSTS              { EIC }                        /**< \brief (EIC       ) Instances List */
+
+#define EVSYS                  ((Evsys *)0x42000000U)         /**< \brief (EVSYS     ) Base Address */
+#define EVSYS_INST_NUM         1                              /**< \brief (EVSYS     ) Number of instances */
+#define EVSYS_INSTS            { EVSYS }                      /**< \brief (EVSYS     ) Instances List */
+
+#define FREQM                  ((Freqm *)0x40002C00U)         /**< \brief (FREQM     ) Base Address */
+#define FREQM_INST_NUM         1                              /**< \brief (FREQM     ) Number of instances */
+#define FREQM_INSTS            { FREQM }                      /**< \brief (FREQM     ) Instances List */
+
+#define GCLK                   ((Gclk *)0x40001C00U)          /**< \brief (GCLK      ) Base Address */
+#define GCLK_INST_NUM          1                              /**< \brief (GCLK      ) Number of instances */
+#define GCLK_INSTS             { GCLK }                       /**< \brief (GCLK      ) Instances List */
+
+#define IDAU                   ((Idau *)0x41000000U)          /**< \brief (IDAU      ) Base Address */
+#define IDAU_INST_NUM          1                              /**< \brief (IDAU      ) Number of instances */
+#define IDAU_INSTS             { IDAU }                       /**< \brief (IDAU      ) Instances List */
+
+#define MCLK                   ((Mclk *)0x40000800U)          /**< \brief (MCLK      ) Base Address */
+#define MCLK_INST_NUM          1                              /**< \brief (MCLK      ) Number of instances */
+#define MCLK_INSTS             { MCLK }                       /**< \brief (MCLK      ) Instances List */
+
+#define NVMCTRL                ((Nvmctrl *)0x41004000U)       /**< \brief (NVMCTRL   ) Base Address */
+#define NVMCTRL_INST_NUM       1                              /**< \brief (NVMCTRL   ) Number of instances */
+#define NVMCTRL_INSTS          { NVMCTRL }                    /**< \brief (NVMCTRL   ) Instances List */
+
+#define OPAMP                  ((Opamp *)0x42003000U)         /**< \brief (OPAMP     ) Base Address */
+#define OPAMP_INST_NUM         1                              /**< \brief (OPAMP     ) Number of instances */
+#define OPAMP_INSTS            { OPAMP }                      /**< \brief (OPAMP     ) Instances List */
+
+#define OSCCTRL                ((Oscctrl *)0x40001000U)       /**< \brief (OSCCTRL   ) Base Address */
+#define OSCCTRL_INST_NUM       1                              /**< \brief (OSCCTRL   ) Number of instances */
+#define OSCCTRL_INSTS          { OSCCTRL }                    /**< \brief (OSCCTRL   ) Instances List */
+
+#define OSC32KCTRL             ((Osc32kctrl *)0x40001400U)    /**< \brief (OSC32KCTRL) Base Address */
+#define OSC32KCTRL_INST_NUM    1                              /**< \brief (OSC32KCTRL) Number of instances */
+#define OSC32KCTRL_INSTS       { OSC32KCTRL }                 /**< \brief (OSC32KCTRL) Instances List */
+
+#define PAC                    ((Pac *)0x40000000U)           /**< \brief (PAC       ) Base Address */
+#define PAC_INST_NUM           1                              /**< \brief (PAC       ) Number of instances */
+#define PAC_INSTS              { PAC }                        /**< \brief (PAC       ) Instances List */
+
+#define PM                     ((Pm *)0x40000400U)            /**< \brief (PM        ) Base Address */
+#define PM_INST_NUM            1                              /**< \brief (PM        ) Number of instances */
+#define PM_INSTS               { PM }                         /**< \brief (PM        ) Instances List */
+
+#define PORT                   ((Port *)0x40003000U)          /**< \brief (PORT      ) Base Address */
+#define PORT_IOBUS             ((Port *)0x60000000U)          /**< \brief (PORT      ) Base Address */
+#define PORT_INST_NUM          1                              /**< \brief (PORT      ) Number of instances */
+#define PORT_INSTS             { PORT }                       /**< \brief (PORT      ) Instances List */
+
+#define PTC                    ((Ptc *)0x42002400U)           /**< \brief (PTC       ) Base Address */
+#define PTC_INST_NUM           1                              /**< \brief (PTC       ) Number of instances */
+#define PTC_INSTS              { PTC }                        /**< \brief (PTC       ) Instances List */
+
+#define RSTC                   ((Rstc *)0x40000C00U)          /**< \brief (RSTC      ) Base Address */
+#define RSTC_INST_NUM          1                              /**< \brief (RSTC      ) Number of instances */
+#define RSTC_INSTS             { RSTC }                       /**< \brief (RSTC      ) Instances List */
+
+#define RTC                    ((Rtc *)0x40002400U)           /**< \brief (RTC       ) Base Address */
+#define RTC_INST_NUM           1                              /**< \brief (RTC       ) Number of instances */
+#define RTC_INSTS              { RTC }                        /**< \brief (RTC       ) Instances List */
+
+#define SERCOM0                ((Sercom *)0x42000400U)        /**< \brief (SERCOM0   ) Base Address */
+#define SERCOM1                ((Sercom *)0x42000800U)        /**< \brief (SERCOM1   ) Base Address */
+#define SERCOM_INST_NUM        2                              /**< \brief (SERCOM    ) Number of instances */
+#define SERCOM_INSTS           { SERCOM0, SERCOM1 }           /**< \brief (SERCOM    ) Instances List */
+
+#define SUPC                   ((Supc *)0x40001800U)          /**< \brief (SUPC      ) Base Address */
+#define SUPC_INST_NUM          1                              /**< \brief (SUPC      ) Number of instances */
+#define SUPC_INSTS             { SUPC }                       /**< \brief (SUPC      ) Instances List */
+
+#define TC0                    ((Tc *)0x42001000U)            /**< \brief (TC0       ) Base Address */
+#define TC1                    ((Tc *)0x42001400U)            /**< \brief (TC1       ) Base Address */
+#define TC2                    ((Tc *)0x42001800U)            /**< \brief (TC2       ) Base Address */
+#define TC_INST_NUM            3                              /**< \brief (TC        ) Number of instances */
+#define TC_INSTS               { TC0, TC1, TC2 }              /**< \brief (TC        ) Instances List */
+
+#define TRAM                   ((Tram *)0x42003400U)          /**< \brief (TRAM      ) Base Address */
+#define TRAM_INST_NUM          1                              /**< \brief (TRAM      ) Number of instances */
+#define TRAM_INSTS             { TRAM }                       /**< \brief (TRAM      ) Instances List */
+
+#define TRNG                   ((Trng *)0x42002800U)          /**< \brief (TRNG      ) Base Address */
+#define TRNG_INST_NUM          1                              /**< \brief (TRNG      ) Number of instances */
+#define TRNG_INSTS             { TRNG }                       /**< \brief (TRNG      ) Instances List */
+
+#define WDT                    ((Wdt *)0x40002000U)           /**< \brief (WDT       ) Base Address */
+#define WDT_INST_NUM           1                              /**< \brief (WDT       ) Number of instances */
+#define WDT_INSTS              { WDT }                        /**< \brief (WDT       ) Instances List */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Peripheral Base Address Definitions */
+
+/** \addtogroup SAML10D14A_pio Peripheral Pio Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   PIO DEFINITIONS FOR SAML10D14A*/
+/* ************************************************************************** */
+#include "pio/saml10d14a.h"
+/** @}  end of Peripheral Pio Definitions */
+
+/* ************************************************************************** */
+/*   MEMORY MAPPING DEFINITIONS FOR SAML10D14A*/
+/* ************************************************************************** */
+
+#define FLASH_SIZE               _U_(0x00004000)       /*   16kB Memory segment type: flash */
+#define FLASH_PAGE_SIZE          _U_(        64)
+#define FLASH_NB_OF_PAGES        _U_(       256)
+
+#define AUX_SIZE                 _U_(0x00000100)       /*    0kB Memory segment type: fuses */
+#define AUX_PAGE_SIZE            _U_(        64)
+#define AUX_NB_OF_PAGES          _U_(         4)
+
+#define BOCOR_SIZE               _U_(0x00000100)       /*    0kB Memory segment type: fuses */
+#define BOCOR_PAGE_SIZE          _U_(        64)
+#define BOCOR_NB_OF_PAGES        _U_(         4)
+
+#define DATAFLASH_SIZE           _U_(0x00000800)       /*    2kB Memory segment type: flash */
+#define DATAFLASH_PAGE_SIZE      _U_(        64)
+#define DATAFLASH_NB_OF_PAGES    _U_(        32)
+
+#define SW_CALIB_SIZE            _U_(0x00000008)       /*    0kB Memory segment type: fuses */
+#define TEMP_LOG_SIZE            _U_(0x00000008)       /*    0kB Memory segment type: fuses */
+#define USER_PAGE_SIZE           _U_(0x00000100)       /*    0kB Memory segment type: user_page */
+#define USER_PAGE_PAGE_SIZE      _U_(        64)
+#define USER_PAGE_NB_OF_PAGES    _U_(         4)
+
+#define HSRAM_SIZE               _U_(0x00001000)       /*    4kB Memory segment type: ram */
+#define HPB0_SIZE                _U_(0x00008000)       /*   32kB Memory segment type: io */
+#define HPB1_SIZE                _U_(0x00010000)       /*   64kB Memory segment type: io */
+#define HPB2_SIZE                _U_(0x00004000)       /*   16kB Memory segment type: io */
+#define PPB_SIZE                 _U_(0x00100000)       /* 1024kB Memory segment type: io */
+#define SCS_SIZE                 _U_(0x00001000)       /*    4kB Memory segment type: io */
+#define PERIPHERALS_SIZE         _U_(0x20000000)       /* 524288kB Memory segment type: io */
+
+#define FLASH_ADDR               _U_(0x00000000)       /**< FLASH base address (type: flash)*/
+#define AUX_ADDR                 _U_(0x00806000)       /**< AUX base address (type: fuses)*/
+#define BOCOR_ADDR               _U_(0x0080c000)       /**< BOCOR base address (type: fuses)*/
+#define DATAFLASH_ADDR           _U_(0x00400000)       /**< DATAFLASH base address (type: flash)*/
+#define SW_CALIB_ADDR            _U_(0x00806020)       /**< SW_CALIB base address (type: fuses)*/
+#define TEMP_LOG_ADDR            _U_(0x00806038)       /**< TEMP_LOG base address (type: fuses)*/
+#define USER_PAGE_ADDR           _U_(0x00804000)       /**< USER_PAGE base address (type: user_page)*/
+#define HSRAM_ADDR               _U_(0x20000000)       /**< HSRAM base address (type: ram)*/
+#define HPB0_ADDR                _U_(0x40000000)       /**< HPB0 base address (type: io)*/
+#define HPB1_ADDR                _U_(0x41000000)       /**< HPB1 base address (type: io)*/
+#define HPB2_ADDR                _U_(0x42000000)       /**< HPB2 base address (type: io)*/
+#define PPB_ADDR                 _U_(0xe0000000)       /**< PPB base address (type: io)*/
+#define SCS_ADDR                 _U_(0xe000e000)       /**< SCS base address (type: io)*/
+#define PERIPHERALS_ADDR         _U_(0x40000000)       /**< PERIPHERALS base address (type: io)*/
+
+#define NVMCTRL_AUX              AUX_ADDR              /**< \brief \deprecated Old style definition. Use AUX_ADDR instead */
+#define NVMCTRL_BOCOR            BOCOR_ADDR            /**< \brief \deprecated Old style definition. Use BOCOR_ADDR instead */
+#define NVMCTRL_DATAFLASH        DATAFLASH_ADDR        /**< \brief \deprecated Old style definition. Use DATAFLASH_ADDR instead */
+#define NVMCTRL_SW_CALIB         SW_CALIB_ADDR         /**< \brief \deprecated Old style definition. Use SW_CALIB_ADDR instead */
+#define NVMCTRL_TEMP_LOG         TEMP_LOG_ADDR         /**< \brief \deprecated Old style definition. Use TEMP_LOG_ADDR instead */
+#define NVMCTRL_USER             USER_PAGE_ADDR        /**< \brief \deprecated Old style definition. Use USER_PAGE_ADDR instead */
+
+/* ************************************************************************** */
+/**  DEVICE SIGNATURES FOR SAML10D14A */
+/* ************************************************************************** */
+#define DSU_DID                  _UL_(0X20840005)
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAML10D14A */
+/* ************************************************************************** */
+
+/* ************************************************************************** */
+/** Event Generator IDs for SAML10D14A */
+/* ************************************************************************** */
+#define EVENT_ID_GEN_OSCCTRL_XOSC_FAIL                    1 /**< ID for OSCCTRL event generator XOSC_FAIL */
+#define EVENT_ID_GEN_OSC32KCTRL_XOSC32K_FAIL              2 /**< ID for OSC32KCTRL event generator XOSC32K_FAIL */
+#define EVENT_ID_GEN_SUPC_BOD33DET                        3 /**< ID for SUPC event generator BOD33DET */
+#define EVENT_ID_GEN_RTC_PER_0                            4 /**< ID for RTC event generator PER_0 */
+#define EVENT_ID_GEN_RTC_PER_1                            5 /**< ID for RTC event generator PER_1 */
+#define EVENT_ID_GEN_RTC_PER_2                            6 /**< ID for RTC event generator PER_2 */
+#define EVENT_ID_GEN_RTC_PER_3                            7 /**< ID for RTC event generator PER_3 */
+#define EVENT_ID_GEN_RTC_PER_4                            8 /**< ID for RTC event generator PER_4 */
+#define EVENT_ID_GEN_RTC_PER_5                            9 /**< ID for RTC event generator PER_5 */
+#define EVENT_ID_GEN_RTC_PER_6                           10 /**< ID for RTC event generator PER_6 */
+#define EVENT_ID_GEN_RTC_PER_7                           11 /**< ID for RTC event generator PER_7 */
+#define EVENT_ID_GEN_RTC_CMP_0                           12 /**< ID for RTC event generator CMP_0 */
+#define EVENT_ID_GEN_RTC_CMP_1                           13 /**< ID for RTC event generator CMP_1 */
+#define EVENT_ID_GEN_RTC_TAMPER                          14 /**< ID for RTC event generator TAMPER */
+#define EVENT_ID_GEN_RTC_OVF                             15 /**< ID for RTC event generator OVF */
+#define EVENT_ID_GEN_RTC_PERD                            16 /**< ID for RTC event generator PERD */
+#define EVENT_ID_GEN_EIC_EXTINT_0                        17 /**< ID for EIC event generator EXTINT_0 */
+#define EVENT_ID_GEN_EIC_EXTINT_1                        18 /**< ID for EIC event generator EXTINT_1 */
+#define EVENT_ID_GEN_EIC_EXTINT_2                        19 /**< ID for EIC event generator EXTINT_2 */
+#define EVENT_ID_GEN_EIC_EXTINT_3                        20 /**< ID for EIC event generator EXTINT_3 */
+#define EVENT_ID_GEN_EIC_EXTINT_4                        21 /**< ID for EIC event generator EXTINT_4 */
+#define EVENT_ID_GEN_EIC_EXTINT_5                        22 /**< ID for EIC event generator EXTINT_5 */
+#define EVENT_ID_GEN_EIC_EXTINT_6                        23 /**< ID for EIC event generator EXTINT_6 */
+#define EVENT_ID_GEN_EIC_EXTINT_7                        24 /**< ID for EIC event generator EXTINT_7 */
+#define EVENT_ID_GEN_DMAC_CH_0                           25 /**< ID for DMAC event generator CH_0 */
+#define EVENT_ID_GEN_DMAC_CH_1                           26 /**< ID for DMAC event generator CH_1 */
+#define EVENT_ID_GEN_DMAC_CH_2                           27 /**< ID for DMAC event generator CH_2 */
+#define EVENT_ID_GEN_DMAC_CH_3                           28 /**< ID for DMAC event generator CH_3 */
+#define EVENT_ID_GEN_TC0_OVF                             29 /**< ID for TC0 event generator OVF */
+#define EVENT_ID_GEN_TC0_MCX_0                           30 /**< ID for TC0 event generator MCX_0 */
+#define EVENT_ID_GEN_TC0_MCX_1                           31 /**< ID for TC0 event generator MCX_1 */
+#define EVENT_ID_GEN_TC1_OVF                             32 /**< ID for TC1 event generator OVF */
+#define EVENT_ID_GEN_TC1_MCX_0                           33 /**< ID for TC1 event generator MCX_0 */
+#define EVENT_ID_GEN_TC1_MCX_1                           34 /**< ID for TC1 event generator MCX_1 */
+#define EVENT_ID_GEN_TC2_OVF                             35 /**< ID for TC2 event generator OVF */
+#define EVENT_ID_GEN_TC2_MCX_0                           36 /**< ID for TC2 event generator MCX_0 */
+#define EVENT_ID_GEN_TC2_MCX_1                           37 /**< ID for TC2 event generator MCX_1 */
+#define EVENT_ID_GEN_ADC_RESRDY                          38 /**< ID for ADC event generator RESRDY */
+#define EVENT_ID_GEN_ADC_WINMON                          39 /**< ID for ADC event generator WINMON */
+#define EVENT_ID_GEN_AC_COMP_0                           40 /**< ID for AC event generator COMP_0 */
+#define EVENT_ID_GEN_AC_COMP_1                           41 /**< ID for AC event generator COMP_1 */
+#define EVENT_ID_GEN_AC_WIN_0                            42 /**< ID for AC event generator WIN_0 */
+#define EVENT_ID_GEN_DAC_EMPTY                           43 /**< ID for DAC event generator EMPTY */
+#define EVENT_ID_GEN_TRNG_READY                          46 /**< ID for TRNG event generator READY */
+#define EVENT_ID_GEN_CCL_LUTOUT_0                        47 /**< ID for CCL event generator LUTOUT_0 */
+#define EVENT_ID_GEN_CCL_LUTOUT_1                        48 /**< ID for CCL event generator LUTOUT_1 */
+#define EVENT_ID_GEN_PAC_ERR                             49 /**< ID for PAC event generator ERR */
+
+/* ************************************************************************** */
+/** Event User IDs for SAML10D14A */
+/* ************************************************************************** */
+#define EVENT_ID_USER_OSCCTRL_TUNE                        0 /**< ID for OSCCTRL event user TUNE */
+#define EVENT_ID_USER_RTC_TAMPER                          1 /**< ID for RTC event user TAMPER */
+#define EVENT_ID_USER_NVMCTRL_PAGEW                       2 /**< ID for NVMCTRL event user PAGEW */
+#define EVENT_ID_USER_PORT_EV_0                           3 /**< ID for PORT event user EV_0 */
+#define EVENT_ID_USER_PORT_EV_1                           4 /**< ID for PORT event user EV_1 */
+#define EVENT_ID_USER_PORT_EV_2                           5 /**< ID for PORT event user EV_2 */
+#define EVENT_ID_USER_PORT_EV_3                           6 /**< ID for PORT event user EV_3 */
+#define EVENT_ID_USER_DMAC_CH_0                           7 /**< ID for DMAC event user CH_0 */
+#define EVENT_ID_USER_DMAC_CH_1                           8 /**< ID for DMAC event user CH_1 */
+#define EVENT_ID_USER_DMAC_CH_2                           9 /**< ID for DMAC event user CH_2 */
+#define EVENT_ID_USER_DMAC_CH_3                          10 /**< ID for DMAC event user CH_3 */
+#define EVENT_ID_USER_TC0_EVU                            11 /**< ID for TC0 event user EVU */
+#define EVENT_ID_USER_TC1_EVU                            12 /**< ID for TC1 event user EVU */
+#define EVENT_ID_USER_TC2_EVU                            13 /**< ID for TC2 event user EVU */
+#define EVENT_ID_USER_ADC_START                          14 /**< ID for ADC event user START */
+#define EVENT_ID_USER_ADC_SYNC                           15 /**< ID for ADC event user SYNC */
+#define EVENT_ID_USER_AC_SOC_0                           16 /**< ID for AC event user SOC_0 */
+#define EVENT_ID_USER_AC_SOC_1                           17 /**< ID for AC event user SOC_1 */
+#define EVENT_ID_USER_DAC_START                          18 /**< ID for DAC event user START */
+#define EVENT_ID_USER_CCL_LUTIN_0                        21 /**< ID for CCL event user LUTIN_0 */
+#define EVENT_ID_USER_CCL_LUTIN_1                        22 /**< ID for CCL event user LUTIN_1 */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @}  end of SAML10D14A definitions */
+
+
+#endif /* _SAML10D14A_H_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/saml10d15a.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/saml10d15a.h
@@ -1,0 +1,789 @@
+/**
+ * \file
+ *
+ * \brief Header file for ATSAML10D15A
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10D15A_H_
+#define _SAML10D15A_H_
+
+/** \addtogroup SAML10D15A_definitions SAML10D15A definitions
+  This file defines all structures and symbols for SAML10D15A:
+    - registers and bitfields
+    - peripheral base address
+    - peripheral ID
+    - PIO definitions
+ *  @{
+ */
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/** \defgroup Atmel_glob_defs Atmel Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+
+    \remark
+    CMSIS core has a syntax that differs from this using i.e. __I, __O, or __IO followed by 'uint<size>_t' respective types.
+    Default the header files will follow the CMSIS core syntax.
+ *  @{
+ */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+
+/* IO definitions (access restrictions to peripheral registers) */
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+
+#define CAST(type, value) ((type *)(value)) /**< Pointer Type Conversion Macro for C/C++ */
+#define REG_ACCESS(type, address) (*(type*)(address)) /**< C code: Register value */
+#else /* Assembler */
+#define CAST(type, value) (value) /**< Pointer Type Conversion Macro for Assembler */
+#define REG_ACCESS(type, address) (address) /**< Assembly code: Register address */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !defined(SKIP_INTEGER_LITERALS)
+
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x) x ## U    /**< C code: Unsigned integer literal constant value */
+#define _L_(x) x ## L    /**< C code: Long integer literal constant value */
+#define _UL_(x) x ## UL  /**< C code: Unsigned Long integer literal constant value */
+
+#else /* Assembler */
+
+#define _U_(x) x    /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x) x    /**< Assembler: Long integer literal constant value */
+#define _UL_(x) x   /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* SKIP_INTEGER_LITERALS */
+/** @}  end of Atmel Global Defines */
+
+/** \addtogroup SAML10D15A_cmsis CMSIS Definitions
+ *  @{
+ */
+/* ************************************************************************** */
+/*   CMSIS DEFINITIONS FOR SAML10D15A */
+/* ************************************************************************** */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+/******  CORTEX-M23 Processor Exceptions Numbers ******************************/
+  Reset_IRQn                = -15, /**< 1   Reset Vector, invoked on Power up and warm reset  */
+  NonMaskableInt_IRQn       = -14, /**< 2   Non maskable Interrupt, cannot be stopped or preempted  */
+  HardFault_IRQn            = -13, /**< 3   Hard Fault, all classes of Fault     */
+  SVCall_IRQn               = -5 , /**< 11  System Service Call via SVC instruction  */
+  PendSV_IRQn               = -2 , /**< 14  Pendable request for system service  */
+  SysTick_IRQn              = -1 , /**< 15  System Tick Timer                    */
+/******  SAML10D15A specific Interrupt Numbers ***********************************/
+  SYSTEM_IRQn               = 0  , /**< 0   SAML10D15A Main Clock (MCLK)        */
+  WDT_IRQn                  = 1  , /**< 1   SAML10D15A Watchdog Timer (WDT)     */
+  RTC_IRQn                  = 2  , /**< 2   SAML10D15A Real-Time Counter (RTC)  */
+  EIC_0_IRQn                = 3  , /**< 3   SAML10D15A External Interrupt Controller (EIC) */
+  EIC_1_IRQn                = 4  , /**< 4   SAML10D15A External Interrupt Controller (EIC) */
+  EIC_2_IRQn                = 5  , /**< 5   SAML10D15A External Interrupt Controller (EIC) */
+  EIC_3_IRQn                = 6  , /**< 6   SAML10D15A External Interrupt Controller (EIC) */
+  EIC_OTHER_IRQn            = 7  , /**< 7   SAML10D15A External Interrupt Controller (EIC) */
+  FREQM_IRQn                = 8  , /**< 8   SAML10D15A Frequency Meter (FREQM)  */
+  NVMCTRL_IRQn              = 9  , /**< 9   SAML10D15A Non-Volatile Memory Controller (NVMCTRL) */
+  PORT_IRQn                 = 10 , /**< 10  SAML10D15A Port Module (PORT)       */
+  DMAC_0_IRQn               = 11 , /**< 11  SAML10D15A Direct Memory Access Controller (DMAC) */
+  DMAC_1_IRQn               = 12 , /**< 12  SAML10D15A Direct Memory Access Controller (DMAC) */
+  DMAC_2_IRQn               = 13 , /**< 13  SAML10D15A Direct Memory Access Controller (DMAC) */
+  DMAC_3_IRQn               = 14 , /**< 14  SAML10D15A Direct Memory Access Controller (DMAC) */
+  DMAC_OTHER_IRQn           = 15 , /**< 15  SAML10D15A Direct Memory Access Controller (DMAC) */
+  EVSYS_0_IRQn              = 16 , /**< 16  SAML10D15A Event System Interface (EVSYS) */
+  EVSYS_1_IRQn              = 17 , /**< 17  SAML10D15A Event System Interface (EVSYS) */
+  EVSYS_2_IRQn              = 18 , /**< 18  SAML10D15A Event System Interface (EVSYS) */
+  EVSYS_3_IRQn              = 19 , /**< 19  SAML10D15A Event System Interface (EVSYS) */
+  EVSYS_NSCHK_IRQn          = 20 , /**< 20  SAML10D15A Event System Interface (EVSYS) */
+  PAC_IRQn                  = 21 , /**< 21  SAML10D15A Peripheral Access Controller (PAC) */
+  SERCOM0_0_IRQn            = 22 , /**< 22  SAML10D15A Serial Communication Interface (SERCOM0) */
+  SERCOM0_1_IRQn            = 23 , /**< 23  SAML10D15A Serial Communication Interface (SERCOM0) */
+  SERCOM0_2_IRQn            = 24 , /**< 24  SAML10D15A Serial Communication Interface (SERCOM0) */
+  SERCOM0_OTHER_IRQn        = 25 , /**< 25  SAML10D15A Serial Communication Interface (SERCOM0) */
+  SERCOM1_0_IRQn            = 26 , /**< 26  SAML10D15A Serial Communication Interface (SERCOM1) */
+  SERCOM1_1_IRQn            = 27 , /**< 27  SAML10D15A Serial Communication Interface (SERCOM1) */
+  SERCOM1_2_IRQn            = 28 , /**< 28  SAML10D15A Serial Communication Interface (SERCOM1) */
+  SERCOM1_OTHER_IRQn        = 29 , /**< 29  SAML10D15A Serial Communication Interface (SERCOM1) */
+  TC0_IRQn                  = 34 , /**< 34  SAML10D15A Basic Timer Counter (TC0) */
+  TC1_IRQn                  = 35 , /**< 35  SAML10D15A Basic Timer Counter (TC1) */
+  TC2_IRQn                  = 36 , /**< 36  SAML10D15A Basic Timer Counter (TC2) */
+  ADC_OTHER_IRQn            = 37 , /**< 37  SAML10D15A Analog Digital Converter (ADC) */
+  ADC_RESRDY_IRQn           = 38 , /**< 38  SAML10D15A Analog Digital Converter (ADC) */
+  AC_IRQn                   = 39 , /**< 39  SAML10D15A Analog Comparators (AC)  */
+  DAC_UNDERRUN_A_IRQn       = 40 , /**< 40  SAML10D15A Digital Analog Converter (DAC) */
+  DAC_EMPTY_IRQn            = 41 , /**< 41  SAML10D15A Digital Analog Converter (DAC) */
+  PTC_IRQn                  = 42 , /**< 42  SAML10D15A Peripheral Touch Controller (PTC) */
+  TRNG_IRQn                 = 43 , /**< 43  SAML10D15A True Random Generator (TRNG) */
+  TRAM_IRQn                 = 44 , /**< 44  SAML10D15A TrustRAM (TRAM)          */
+
+  PERIPH_COUNT_IRQn        = 45  /**< Number of peripheral IDs */
+} IRQn_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;                        /* -15 Reset Vector, invoked on Power up and warm reset  */
+  void* pfnNonMaskableInt_Handler;               /* -14 Non maskable Interrupt, cannot be stopped or preempted  */
+  void* pfnHardFault_Handler;                    /* -13 Hard Fault, all classes of Fault     */
+  void* pvReservedC12;
+  void* pvReservedC11;
+  void* pvReservedC10;
+  void* pvReservedC9;
+  void* pvReservedC8;
+  void* pvReservedC7;
+  void* pvReservedC6;
+  void* pfnSVCall_Handler;                       /*  -5 System Service Call via SVC instruction  */
+  void* pvReservedC4;
+  void* pvReservedC3;
+  void* pfnPendSV_Handler;                       /*  -2 Pendable request for system service  */
+  void* pfnSysTick_Handler;                      /*  -1 System Tick Timer                    */
+
+
+  /* Peripheral handlers */
+  void* pfnSYSTEM_Handler;                       /* 0   SAML10D15A Main Clock (MCLK)   */
+  void* pfnWDT_Handler;                          /* 1   SAML10D15A Watchdog Timer (WDT) */
+  void* pfnRTC_Handler;                          /* 2   SAML10D15A Real-Time Counter (RTC) */
+  void* pfnEIC_0_Handler;                        /* 3   SAML10D15A External Interrupt Controller (EIC) */
+  void* pfnEIC_1_Handler;                        /* 4   SAML10D15A External Interrupt Controller (EIC) */
+  void* pfnEIC_2_Handler;                        /* 5   SAML10D15A External Interrupt Controller (EIC) */
+  void* pfnEIC_3_Handler;                        /* 6   SAML10D15A External Interrupt Controller (EIC) */
+  void* pfnEIC_OTHER_Handler;                    /* 7   SAML10D15A External Interrupt Controller (EIC) */
+  void* pfnFREQM_Handler;                        /* 8   SAML10D15A Frequency Meter (FREQM) */
+  void* pfnNVMCTRL_Handler;                      /* 9   SAML10D15A Non-Volatile Memory Controller (NVMCTRL) */
+  void* pfnPORT_Handler;                         /* 10  SAML10D15A Port Module (PORT)  */
+  void* pfnDMAC_0_Handler;                       /* 11  SAML10D15A Direct Memory Access Controller (DMAC) */
+  void* pfnDMAC_1_Handler;                       /* 12  SAML10D15A Direct Memory Access Controller (DMAC) */
+  void* pfnDMAC_2_Handler;                       /* 13  SAML10D15A Direct Memory Access Controller (DMAC) */
+  void* pfnDMAC_3_Handler;                       /* 14  SAML10D15A Direct Memory Access Controller (DMAC) */
+  void* pfnDMAC_OTHER_Handler;                   /* 15  SAML10D15A Direct Memory Access Controller (DMAC) */
+  void* pfnEVSYS_0_Handler;                      /* 16  SAML10D15A Event System Interface (EVSYS) */
+  void* pfnEVSYS_1_Handler;                      /* 17  SAML10D15A Event System Interface (EVSYS) */
+  void* pfnEVSYS_2_Handler;                      /* 18  SAML10D15A Event System Interface (EVSYS) */
+  void* pfnEVSYS_3_Handler;                      /* 19  SAML10D15A Event System Interface (EVSYS) */
+  void* pfnEVSYS_NSCHK_Handler;                  /* 20  SAML10D15A Event System Interface (EVSYS) */
+  void* pfnPAC_Handler;                          /* 21  SAML10D15A Peripheral Access Controller (PAC) */
+  void* pfnSERCOM0_0_Handler;                    /* 22  SAML10D15A Serial Communication Interface (SERCOM0) */
+  void* pfnSERCOM0_1_Handler;                    /* 23  SAML10D15A Serial Communication Interface (SERCOM0) */
+  void* pfnSERCOM0_2_Handler;                    /* 24  SAML10D15A Serial Communication Interface (SERCOM0) */
+  void* pfnSERCOM0_OTHER_Handler;                /* 25  SAML10D15A Serial Communication Interface (SERCOM0) */
+  void* pfnSERCOM1_0_Handler;                    /* 26  SAML10D15A Serial Communication Interface (SERCOM1) */
+  void* pfnSERCOM1_1_Handler;                    /* 27  SAML10D15A Serial Communication Interface (SERCOM1) */
+  void* pfnSERCOM1_2_Handler;                    /* 28  SAML10D15A Serial Communication Interface (SERCOM1) */
+  void* pfnSERCOM1_OTHER_Handler;                /* 29  SAML10D15A Serial Communication Interface (SERCOM1) */
+  void* pvReserved30;
+  void* pvReserved31;
+  void* pvReserved32;
+  void* pvReserved33;
+  void* pfnTC0_Handler;                          /* 34  SAML10D15A Basic Timer Counter (TC0) */
+  void* pfnTC1_Handler;                          /* 35  SAML10D15A Basic Timer Counter (TC1) */
+  void* pfnTC2_Handler;                          /* 36  SAML10D15A Basic Timer Counter (TC2) */
+  void* pfnADC_OTHER_Handler;                    /* 37  SAML10D15A Analog Digital Converter (ADC) */
+  void* pfnADC_RESRDY_Handler;                   /* 38  SAML10D15A Analog Digital Converter (ADC) */
+  void* pfnAC_Handler;                           /* 39  SAML10D15A Analog Comparators (AC) */
+  void* pfnDAC_UNDERRUN_A_Handler;               /* 40  SAML10D15A Digital Analog Converter (DAC) */
+  void* pfnDAC_EMPTY_Handler;                    /* 41  SAML10D15A Digital Analog Converter (DAC) */
+  void* pfnPTC_Handler;                          /* 42  SAML10D15A Peripheral Touch Controller (PTC) */
+  void* pfnTRNG_Handler;                         /* 43  SAML10D15A True Random Generator (TRNG) */
+  void* pfnTRAM_Handler;                         /* 44  SAML10D15A TrustRAM (TRAM)     */
+} DeviceVectors;
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define pfnMemManage_Handler      pfnMemoryManagement_Handler     /**< \deprecated  Backward compatibility for ASF */
+#define pfnDebugMon_Handler       pfnDebugMonitor_Handler         /**< \deprecated  Backward compatibility for ASF */
+#define pfnNMI_Handler            pfnNonMaskableInt_Handler       /**< \deprecated  Backward compatibility for ASF */
+#define pfnSVC_Handler            pfnSVCall_Handler               /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if !defined DONT_USE_PREDEFINED_CORE_HANDLERS
+
+/* CORTEX-M23 core handlers */
+void Reset_Handler                 ( void );
+void NonMaskableInt_Handler        ( void );
+void HardFault_Handler             ( void );
+void SVCall_Handler                ( void );
+void PendSV_Handler                ( void );
+void SysTick_Handler               ( void );
+#endif /* DONT_USE_PREDEFINED_CORE_HANDLERS */
+
+#if !defined DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS
+
+/* Peripherals handlers */
+void AC_Handler                    ( void );
+void ADC_OTHER_Handler             ( void );
+void ADC_RESRDY_Handler            ( void );
+void DAC_EMPTY_Handler             ( void );
+void DAC_UNDERRUN_A_Handler        ( void );
+void DMAC_0_Handler                ( void );
+void DMAC_1_Handler                ( void );
+void DMAC_2_Handler                ( void );
+void DMAC_3_Handler                ( void );
+void DMAC_OTHER_Handler            ( void );
+void EIC_0_Handler                 ( void );
+void EIC_1_Handler                 ( void );
+void EIC_2_Handler                 ( void );
+void EIC_3_Handler                 ( void );
+void EIC_OTHER_Handler             ( void );
+void EVSYS_0_Handler               ( void );
+void EVSYS_1_Handler               ( void );
+void EVSYS_2_Handler               ( void );
+void EVSYS_3_Handler               ( void );
+void EVSYS_NSCHK_Handler           ( void );
+void FREQM_Handler                 ( void );
+void NVMCTRL_Handler               ( void );
+void PAC_Handler                   ( void );
+void PORT_Handler                  ( void );
+void PTC_Handler                   ( void );
+void RTC_Handler                   ( void );
+void SERCOM0_0_Handler             ( void );
+void SERCOM0_1_Handler             ( void );
+void SERCOM0_2_Handler             ( void );
+void SERCOM0_OTHER_Handler         ( void );
+void SERCOM1_0_Handler             ( void );
+void SERCOM1_1_Handler             ( void );
+void SERCOM1_2_Handler             ( void );
+void SERCOM1_OTHER_Handler         ( void );
+void SYSTEM_Handler                ( void );
+void TC0_Handler                   ( void );
+void TC1_Handler                   ( void );
+void TC2_Handler                   ( void );
+void TRAM_Handler                  ( void );
+void TRNG_Handler                  ( void );
+void WDT_Handler                   ( void );
+#endif /* DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS */
+
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define MemManage_Handler         MemoryManagement_Handler        /**< \deprecated  Backward compatibility for ASF */
+#define DebugMon_Handler          DebugMonitor_Handler            /**< \deprecated  Backward compatibility for ASF */
+#define NMI_Handler               NonMaskableInt_Handler          /**< \deprecated  Backward compatibility for ASF */
+#define SVC_Handler               SVCall_Handler                  /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+
+/*
+ * \brief Configuration of the CORTEX-M23 Processor and Core Peripherals
+ */
+
+#define NUM_IRQ                       45 /**< Number of interrupt request lines                                         */
+#define __ARMv8MBL_REV            0x0000 /**< Cortex-M23 Core Revision                                                  */
+#define __ETM_PRESENT                  0 /**< ETM present or not                                                        */
+#define __FPU_PRESENT                  0 /**< FPU present or not                                                        */
+#define __MPU_PRESENT                  1 /**< MPU present or not                                                        */
+#define __MTB_PRESENT                  0 /**< MTB present or not                                                        */
+#define __NVIC_PRIO_BITS               2 /**< Number of Bits used for Priority Levels                                   */
+#define __SAU_PRESENT                  0 /**< SAU present or not                                                        */
+#define __SEC_ENABLED                  0 /**< TrustZone-M enabled or not                                                */
+#define __VTOR_PRESENT                 1 /**< Vector Table Offset Register present or not                               */
+#define __Vendor_SysTickConfig         0 /**< Set to 1 if different SysTick Config is used                              */
+#define __ARCH_ARM                     1
+#define __ARCH_ARM_CORTEX_M            1
+#define __DEVICE_IS_SAM                1
+
+/*
+ * \brief CMSIS includes
+ */
+#include <core_cm23.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_saml10.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/** @}  end of SAML10D15A_cmsis CMSIS Definitions */
+
+/** \defgroup SAML10D15A_api Peripheral Software API
+ *  @{
+ */
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAML10D15A */
+/* ************************************************************************** */
+#include "component/ac.h"
+#include "component/adc.h"
+#include "component/ccl.h"
+#include "component/dac.h"
+#include "component/dmac.h"
+#include "component/dsu.h"
+#include "component/eic.h"
+#include "component/evsys.h"
+#include "component/freqm.h"
+#include "component/gclk.h"
+#include "component/idau.h"
+#include "component/mclk.h"
+#include "component/nvmctrl.h"
+#include "component/opamp.h"
+#include "component/oscctrl.h"
+#include "component/osc32kctrl.h"
+#include "component/pac.h"
+#include "component/pm.h"
+#include "component/port.h"
+#include "component/ptc.h"
+#include "component/rstc.h"
+#include "component/rtc.h"
+#include "component/sercom.h"
+#include "component/supc.h"
+#include "component/tc.h"
+#include "component/tram.h"
+#include "component/trng.h"
+#include "component/wdt.h"
+/** @}  end of Peripheral Software API */
+
+/** \defgroup SAML10D15A_reg Registers Access Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   REGISTER ACCESS DEFINITIONS FOR SAML10D15A */
+/* ************************************************************************** */
+#include "instance/ac.h"
+#include "instance/adc.h"
+#include "instance/ccl.h"
+#include "instance/dac.h"
+#include "instance/dmac.h"
+#include "instance/dsu.h"
+#include "instance/eic.h"
+#include "instance/evsys.h"
+#include "instance/freqm.h"
+#include "instance/gclk.h"
+#include "instance/idau.h"
+#include "instance/mclk.h"
+#include "instance/nvmctrl.h"
+#include "instance/opamp.h"
+#include "instance/oscctrl.h"
+#include "instance/osc32kctrl.h"
+#include "instance/pac.h"
+#include "instance/pm.h"
+#include "instance/port.h"
+#include "instance/ptc.h"
+#include "instance/rstc.h"
+#include "instance/rtc.h"
+#include "instance/sercom0.h"
+#include "instance/sercom1.h"
+#include "instance/supc.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tram.h"
+#include "instance/trng.h"
+#include "instance/wdt.h"
+/** @}  end of Registers Access Definitions */
+
+/** \addtogroup SAML10D15A_id Peripheral Ids Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*  PERIPHERAL ID DEFINITIONS FOR SAML10D15A */
+/* ************************************************************************** */
+#define ID_PAC          (  0) /**< \brief Peripheral Access Controller (PAC) */
+#define ID_PM           (  1) /**< \brief Power Manager (PM) */
+#define ID_MCLK         (  2) /**< \brief Main Clock (MCLK) */
+#define ID_RSTC         (  3) /**< \brief Reset Controller (RSTC) */
+#define ID_OSCCTRL      (  4) /**< \brief Oscillators Control (OSCCTRL) */
+#define ID_OSC32KCTRL   (  5) /**< \brief 32k Oscillators Control (OSC32KCTRL) */
+#define ID_SUPC         (  6) /**< \brief Supply Controller (SUPC) */
+#define ID_GCLK         (  7) /**< \brief Generic Clock Generator (GCLK) */
+#define ID_WDT          (  8) /**< \brief Watchdog Timer (WDT) */
+#define ID_RTC          (  9) /**< \brief Real-Time Counter (RTC) */
+#define ID_EIC          ( 10) /**< \brief External Interrupt Controller (EIC) */
+#define ID_FREQM        ( 11) /**< \brief Frequency Meter (FREQM) */
+#define ID_PORT         ( 12) /**< \brief Port Module (PORT) */
+#define ID_AC           ( 13) /**< \brief Analog Comparators (AC) */
+#define ID_IDAU         ( 32) /**< \brief Implementation Defined Attribution Unit (IDAU) */
+#define ID_DSU          ( 33) /**< \brief Device Service Unit (DSU) */
+#define ID_NVMCTRL      ( 34) /**< \brief Non-Volatile Memory Controller (NVMCTRL) */
+#define ID_DMAC         ( 35) /**< \brief Direct Memory Access Controller (DMAC) */
+#define ID_EVSYS        ( 64) /**< \brief Event System Interface (EVSYS) */
+#define ID_SERCOM0      ( 65) /**< \brief Serial Communication Interface (SERCOM0) */
+#define ID_SERCOM1      ( 66) /**< \brief Serial Communication Interface (SERCOM1) */
+#define ID_TC0          ( 68) /**< \brief Basic Timer Counter (TC0) */
+#define ID_TC1          ( 69) /**< \brief Basic Timer Counter (TC1) */
+#define ID_TC2          ( 70) /**< \brief Basic Timer Counter (TC2) */
+#define ID_ADC          ( 71) /**< \brief Analog Digital Converter (ADC) */
+#define ID_DAC          ( 72) /**< \brief Digital Analog Converter (DAC) */
+#define ID_PTC          ( 73) /**< \brief Peripheral Touch Controller (PTC) */
+#define ID_TRNG         ( 74) /**< \brief True Random Generator (TRNG) */
+#define ID_CCL          ( 75) /**< \brief Configurable Custom Logic (CCL) */
+#define ID_OPAMP        ( 76) /**< \brief Operational Amplifier (OPAMP) */
+#define ID_TRAM         ( 77) /**< \brief TrustRAM (TRAM) */
+
+#define ID_PERIPH_COUNT ( 78) /**< \brief Number of peripheral IDs */
+/** @}  end of Peripheral Ids Definitions */
+
+/** \addtogroup SAML10D15A_base Peripheral Base Address Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   BASE ADDRESS DEFINITIONS FOR SAML10D15A */
+/* ************************************************************************** */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#define AC                     (0x40003400)                   /**< \brief (AC        ) Base Address */
+#define ADC                    (0x42001C00)                   /**< \brief (ADC       ) Base Address */
+#define CCL                    (0x42002C00)                   /**< \brief (CCL       ) Base Address */
+#define DAC                    (0x42002000)                   /**< \brief (DAC       ) Base Address */
+#define DMAC                   (0x41006000)                   /**< \brief (DMAC      ) Base Address */
+#define DSU                    (0x41002000)                   /**< \brief (DSU       ) Base Address */
+#define DSU_EXT                (0x41002100)                   /**< \brief (DSU       ) Base Address */
+#define EIC                    (0x40002800)                   /**< \brief (EIC       ) Base Address */
+#define EVSYS                  (0x42000000)                   /**< \brief (EVSYS     ) Base Address */
+#define FREQM                  (0x40002C00)                   /**< \brief (FREQM     ) Base Address */
+#define GCLK                   (0x40001C00)                   /**< \brief (GCLK      ) Base Address */
+#define IDAU                   (0x41000000)                   /**< \brief (IDAU      ) Base Address */
+#define MCLK                   (0x40000800)                   /**< \brief (MCLK      ) Base Address */
+#define NVMCTRL                (0x41004000)                   /**< \brief (NVMCTRL   ) Base Address */
+#define OPAMP                  (0x42003000)                   /**< \brief (OPAMP     ) Base Address */
+#define OSCCTRL                (0x40001000)                   /**< \brief (OSCCTRL   ) Base Address */
+#define OSC32KCTRL             (0x40001400)                   /**< \brief (OSC32KCTRL) Base Address */
+#define PAC                    (0x40000000)                   /**< \brief (PAC       ) Base Address */
+#define PM                     (0x40000400)                   /**< \brief (PM        ) Base Address */
+#define PORT                   (0x40003000)                   /**< \brief (PORT      ) Base Address */
+#define PORT_IOBUS             (0x60000000)                   /**< \brief (PORT      ) Base Address */
+#define PTC                    (0x42002400)                   /**< \brief (PTC       ) Base Address */
+#define RSTC                   (0x40000C00)                   /**< \brief (RSTC      ) Base Address */
+#define RTC                    (0x40002400)                   /**< \brief (RTC       ) Base Address */
+#define SERCOM0                (0x42000400)                   /**< \brief (SERCOM0   ) Base Address */
+#define SERCOM1                (0x42000800)                   /**< \brief (SERCOM1   ) Base Address */
+#define SUPC                   (0x40001800)                   /**< \brief (SUPC      ) Base Address */
+#define TC0                    (0x42001000)                   /**< \brief (TC0       ) Base Address */
+#define TC1                    (0x42001400)                   /**< \brief (TC1       ) Base Address */
+#define TC2                    (0x42001800)                   /**< \brief (TC2       ) Base Address */
+#define TRAM                   (0x42003400)                   /**< \brief (TRAM      ) Base Address */
+#define TRNG                   (0x42002800)                   /**< \brief (TRNG      ) Base Address */
+#define WDT                    (0x40002000)                   /**< \brief (WDT       ) Base Address */
+
+#else /* For C/C++ compiler */
+
+#define AC                     ((Ac *)0x40003400U)            /**< \brief (AC        ) Base Address */
+#define AC_INST_NUM            1                              /**< \brief (AC        ) Number of instances */
+#define AC_INSTS               { AC }                         /**< \brief (AC        ) Instances List */
+
+#define ADC                    ((Adc *)0x42001C00U)           /**< \brief (ADC       ) Base Address */
+#define ADC_INST_NUM           1                              /**< \brief (ADC       ) Number of instances */
+#define ADC_INSTS              { ADC }                        /**< \brief (ADC       ) Instances List */
+
+#define CCL                    ((Ccl *)0x42002C00U)           /**< \brief (CCL       ) Base Address */
+#define CCL_INST_NUM           1                              /**< \brief (CCL       ) Number of instances */
+#define CCL_INSTS              { CCL }                        /**< \brief (CCL       ) Instances List */
+
+#define DAC                    ((Dac *)0x42002000U)           /**< \brief (DAC       ) Base Address */
+#define DAC_INST_NUM           1                              /**< \brief (DAC       ) Number of instances */
+#define DAC_INSTS              { DAC }                        /**< \brief (DAC       ) Instances List */
+
+#define DMAC                   ((Dmac *)0x41006000U)          /**< \brief (DMAC      ) Base Address */
+#define DMAC_INST_NUM          1                              /**< \brief (DMAC      ) Number of instances */
+#define DMAC_INSTS             { DMAC }                       /**< \brief (DMAC      ) Instances List */
+
+#define DSU                    ((Dsu *)0x41002000U)           /**< \brief (DSU       ) Base Address */
+#define DSU_EXT                ((Dsu *)0x41002100U)           /**< \brief (DSU       ) Base Address */
+#define DSU_INST_NUM           1                              /**< \brief (DSU       ) Number of instances */
+#define DSU_INSTS              { DSU }                        /**< \brief (DSU       ) Instances List */
+
+#define EIC                    ((Eic *)0x40002800U)           /**< \brief (EIC       ) Base Address */
+#define EIC_INST_NUM           1                              /**< \brief (EIC       ) Number of instances */
+#define EIC_INSTS              { EIC }                        /**< \brief (EIC       ) Instances List */
+
+#define EVSYS                  ((Evsys *)0x42000000U)         /**< \brief (EVSYS     ) Base Address */
+#define EVSYS_INST_NUM         1                              /**< \brief (EVSYS     ) Number of instances */
+#define EVSYS_INSTS            { EVSYS }                      /**< \brief (EVSYS     ) Instances List */
+
+#define FREQM                  ((Freqm *)0x40002C00U)         /**< \brief (FREQM     ) Base Address */
+#define FREQM_INST_NUM         1                              /**< \brief (FREQM     ) Number of instances */
+#define FREQM_INSTS            { FREQM }                      /**< \brief (FREQM     ) Instances List */
+
+#define GCLK                   ((Gclk *)0x40001C00U)          /**< \brief (GCLK      ) Base Address */
+#define GCLK_INST_NUM          1                              /**< \brief (GCLK      ) Number of instances */
+#define GCLK_INSTS             { GCLK }                       /**< \brief (GCLK      ) Instances List */
+
+#define IDAU                   ((Idau *)0x41000000U)          /**< \brief (IDAU      ) Base Address */
+#define IDAU_INST_NUM          1                              /**< \brief (IDAU      ) Number of instances */
+#define IDAU_INSTS             { IDAU }                       /**< \brief (IDAU      ) Instances List */
+
+#define MCLK                   ((Mclk *)0x40000800U)          /**< \brief (MCLK      ) Base Address */
+#define MCLK_INST_NUM          1                              /**< \brief (MCLK      ) Number of instances */
+#define MCLK_INSTS             { MCLK }                       /**< \brief (MCLK      ) Instances List */
+
+#define NVMCTRL                ((Nvmctrl *)0x41004000U)       /**< \brief (NVMCTRL   ) Base Address */
+#define NVMCTRL_INST_NUM       1                              /**< \brief (NVMCTRL   ) Number of instances */
+#define NVMCTRL_INSTS          { NVMCTRL }                    /**< \brief (NVMCTRL   ) Instances List */
+
+#define OPAMP                  ((Opamp *)0x42003000U)         /**< \brief (OPAMP     ) Base Address */
+#define OPAMP_INST_NUM         1                              /**< \brief (OPAMP     ) Number of instances */
+#define OPAMP_INSTS            { OPAMP }                      /**< \brief (OPAMP     ) Instances List */
+
+#define OSCCTRL                ((Oscctrl *)0x40001000U)       /**< \brief (OSCCTRL   ) Base Address */
+#define OSCCTRL_INST_NUM       1                              /**< \brief (OSCCTRL   ) Number of instances */
+#define OSCCTRL_INSTS          { OSCCTRL }                    /**< \brief (OSCCTRL   ) Instances List */
+
+#define OSC32KCTRL             ((Osc32kctrl *)0x40001400U)    /**< \brief (OSC32KCTRL) Base Address */
+#define OSC32KCTRL_INST_NUM    1                              /**< \brief (OSC32KCTRL) Number of instances */
+#define OSC32KCTRL_INSTS       { OSC32KCTRL }                 /**< \brief (OSC32KCTRL) Instances List */
+
+#define PAC                    ((Pac *)0x40000000U)           /**< \brief (PAC       ) Base Address */
+#define PAC_INST_NUM           1                              /**< \brief (PAC       ) Number of instances */
+#define PAC_INSTS              { PAC }                        /**< \brief (PAC       ) Instances List */
+
+#define PM                     ((Pm *)0x40000400U)            /**< \brief (PM        ) Base Address */
+#define PM_INST_NUM            1                              /**< \brief (PM        ) Number of instances */
+#define PM_INSTS               { PM }                         /**< \brief (PM        ) Instances List */
+
+#define PORT                   ((Port *)0x40003000U)          /**< \brief (PORT      ) Base Address */
+#define PORT_IOBUS             ((Port *)0x60000000U)          /**< \brief (PORT      ) Base Address */
+#define PORT_INST_NUM          1                              /**< \brief (PORT      ) Number of instances */
+#define PORT_INSTS             { PORT }                       /**< \brief (PORT      ) Instances List */
+
+#define PTC                    ((Ptc *)0x42002400U)           /**< \brief (PTC       ) Base Address */
+#define PTC_INST_NUM           1                              /**< \brief (PTC       ) Number of instances */
+#define PTC_INSTS              { PTC }                        /**< \brief (PTC       ) Instances List */
+
+#define RSTC                   ((Rstc *)0x40000C00U)          /**< \brief (RSTC      ) Base Address */
+#define RSTC_INST_NUM          1                              /**< \brief (RSTC      ) Number of instances */
+#define RSTC_INSTS             { RSTC }                       /**< \brief (RSTC      ) Instances List */
+
+#define RTC                    ((Rtc *)0x40002400U)           /**< \brief (RTC       ) Base Address */
+#define RTC_INST_NUM           1                              /**< \brief (RTC       ) Number of instances */
+#define RTC_INSTS              { RTC }                        /**< \brief (RTC       ) Instances List */
+
+#define SERCOM0                ((Sercom *)0x42000400U)        /**< \brief (SERCOM0   ) Base Address */
+#define SERCOM1                ((Sercom *)0x42000800U)        /**< \brief (SERCOM1   ) Base Address */
+#define SERCOM_INST_NUM        2                              /**< \brief (SERCOM    ) Number of instances */
+#define SERCOM_INSTS           { SERCOM0, SERCOM1 }           /**< \brief (SERCOM    ) Instances List */
+
+#define SUPC                   ((Supc *)0x40001800U)          /**< \brief (SUPC      ) Base Address */
+#define SUPC_INST_NUM          1                              /**< \brief (SUPC      ) Number of instances */
+#define SUPC_INSTS             { SUPC }                       /**< \brief (SUPC      ) Instances List */
+
+#define TC0                    ((Tc *)0x42001000U)            /**< \brief (TC0       ) Base Address */
+#define TC1                    ((Tc *)0x42001400U)            /**< \brief (TC1       ) Base Address */
+#define TC2                    ((Tc *)0x42001800U)            /**< \brief (TC2       ) Base Address */
+#define TC_INST_NUM            3                              /**< \brief (TC        ) Number of instances */
+#define TC_INSTS               { TC0, TC1, TC2 }              /**< \brief (TC        ) Instances List */
+
+#define TRAM                   ((Tram *)0x42003400U)          /**< \brief (TRAM      ) Base Address */
+#define TRAM_INST_NUM          1                              /**< \brief (TRAM      ) Number of instances */
+#define TRAM_INSTS             { TRAM }                       /**< \brief (TRAM      ) Instances List */
+
+#define TRNG                   ((Trng *)0x42002800U)          /**< \brief (TRNG      ) Base Address */
+#define TRNG_INST_NUM          1                              /**< \brief (TRNG      ) Number of instances */
+#define TRNG_INSTS             { TRNG }                       /**< \brief (TRNG      ) Instances List */
+
+#define WDT                    ((Wdt *)0x40002000U)           /**< \brief (WDT       ) Base Address */
+#define WDT_INST_NUM           1                              /**< \brief (WDT       ) Number of instances */
+#define WDT_INSTS              { WDT }                        /**< \brief (WDT       ) Instances List */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Peripheral Base Address Definitions */
+
+/** \addtogroup SAML10D15A_pio Peripheral Pio Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   PIO DEFINITIONS FOR SAML10D15A*/
+/* ************************************************************************** */
+#include "pio/saml10d15a.h"
+/** @}  end of Peripheral Pio Definitions */
+
+/* ************************************************************************** */
+/*   MEMORY MAPPING DEFINITIONS FOR SAML10D15A*/
+/* ************************************************************************** */
+
+#define FLASH_SIZE               _U_(0x00008000)       /*   32kB Memory segment type: flash */
+#define FLASH_PAGE_SIZE          _U_(        64)
+#define FLASH_NB_OF_PAGES        _U_(       512)
+
+#define AUX_SIZE                 _U_(0x00000100)       /*    0kB Memory segment type: fuses */
+#define AUX_PAGE_SIZE            _U_(        64)
+#define AUX_NB_OF_PAGES          _U_(         4)
+
+#define BOCOR_SIZE               _U_(0x00000100)       /*    0kB Memory segment type: fuses */
+#define BOCOR_PAGE_SIZE          _U_(        64)
+#define BOCOR_NB_OF_PAGES        _U_(         4)
+
+#define DATAFLASH_SIZE           _U_(0x00000800)       /*    2kB Memory segment type: flash */
+#define DATAFLASH_PAGE_SIZE      _U_(        64)
+#define DATAFLASH_NB_OF_PAGES    _U_(        32)
+
+#define SW_CALIB_SIZE            _U_(0x00000008)       /*    0kB Memory segment type: fuses */
+#define TEMP_LOG_SIZE            _U_(0x00000008)       /*    0kB Memory segment type: fuses */
+#define USER_PAGE_SIZE           _U_(0x00000100)       /*    0kB Memory segment type: user_page */
+#define USER_PAGE_PAGE_SIZE      _U_(        64)
+#define USER_PAGE_NB_OF_PAGES    _U_(         4)
+
+#define HSRAM_SIZE               _U_(0x00002000)       /*    8kB Memory segment type: ram */
+#define HPB0_SIZE                _U_(0x00008000)       /*   32kB Memory segment type: io */
+#define HPB1_SIZE                _U_(0x00010000)       /*   64kB Memory segment type: io */
+#define HPB2_SIZE                _U_(0x00004000)       /*   16kB Memory segment type: io */
+#define PPB_SIZE                 _U_(0x00100000)       /* 1024kB Memory segment type: io */
+#define SCS_SIZE                 _U_(0x00001000)       /*    4kB Memory segment type: io */
+#define PERIPHERALS_SIZE         _U_(0x20000000)       /* 524288kB Memory segment type: io */
+
+#define FLASH_ADDR               _U_(0x00000000)       /**< FLASH base address (type: flash)*/
+#define AUX_ADDR                 _U_(0x00806000)       /**< AUX base address (type: fuses)*/
+#define BOCOR_ADDR               _U_(0x0080c000)       /**< BOCOR base address (type: fuses)*/
+#define DATAFLASH_ADDR           _U_(0x00400000)       /**< DATAFLASH base address (type: flash)*/
+#define SW_CALIB_ADDR            _U_(0x00806020)       /**< SW_CALIB base address (type: fuses)*/
+#define TEMP_LOG_ADDR            _U_(0x00806038)       /**< TEMP_LOG base address (type: fuses)*/
+#define USER_PAGE_ADDR           _U_(0x00804000)       /**< USER_PAGE base address (type: user_page)*/
+#define HSRAM_ADDR               _U_(0x20000000)       /**< HSRAM base address (type: ram)*/
+#define HPB0_ADDR                _U_(0x40000000)       /**< HPB0 base address (type: io)*/
+#define HPB1_ADDR                _U_(0x41000000)       /**< HPB1 base address (type: io)*/
+#define HPB2_ADDR                _U_(0x42000000)       /**< HPB2 base address (type: io)*/
+#define PPB_ADDR                 _U_(0xe0000000)       /**< PPB base address (type: io)*/
+#define SCS_ADDR                 _U_(0xe000e000)       /**< SCS base address (type: io)*/
+#define PERIPHERALS_ADDR         _U_(0x40000000)       /**< PERIPHERALS base address (type: io)*/
+
+#define NVMCTRL_AUX              AUX_ADDR              /**< \brief \deprecated Old style definition. Use AUX_ADDR instead */
+#define NVMCTRL_BOCOR            BOCOR_ADDR            /**< \brief \deprecated Old style definition. Use BOCOR_ADDR instead */
+#define NVMCTRL_DATAFLASH        DATAFLASH_ADDR        /**< \brief \deprecated Old style definition. Use DATAFLASH_ADDR instead */
+#define NVMCTRL_SW_CALIB         SW_CALIB_ADDR         /**< \brief \deprecated Old style definition. Use SW_CALIB_ADDR instead */
+#define NVMCTRL_TEMP_LOG         TEMP_LOG_ADDR         /**< \brief \deprecated Old style definition. Use TEMP_LOG_ADDR instead */
+#define NVMCTRL_USER             USER_PAGE_ADDR        /**< \brief \deprecated Old style definition. Use USER_PAGE_ADDR instead */
+
+/* ************************************************************************** */
+/**  DEVICE SIGNATURES FOR SAML10D15A */
+/* ************************************************************************** */
+#define DSU_DID                  _UL_(0X20840004)
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAML10D15A */
+/* ************************************************************************** */
+
+/* ************************************************************************** */
+/** Event Generator IDs for SAML10D15A */
+/* ************************************************************************** */
+#define EVENT_ID_GEN_OSCCTRL_XOSC_FAIL                    1 /**< ID for OSCCTRL event generator XOSC_FAIL */
+#define EVENT_ID_GEN_OSC32KCTRL_XOSC32K_FAIL              2 /**< ID for OSC32KCTRL event generator XOSC32K_FAIL */
+#define EVENT_ID_GEN_SUPC_BOD33DET                        3 /**< ID for SUPC event generator BOD33DET */
+#define EVENT_ID_GEN_RTC_PER_0                            4 /**< ID for RTC event generator PER_0 */
+#define EVENT_ID_GEN_RTC_PER_1                            5 /**< ID for RTC event generator PER_1 */
+#define EVENT_ID_GEN_RTC_PER_2                            6 /**< ID for RTC event generator PER_2 */
+#define EVENT_ID_GEN_RTC_PER_3                            7 /**< ID for RTC event generator PER_3 */
+#define EVENT_ID_GEN_RTC_PER_4                            8 /**< ID for RTC event generator PER_4 */
+#define EVENT_ID_GEN_RTC_PER_5                            9 /**< ID for RTC event generator PER_5 */
+#define EVENT_ID_GEN_RTC_PER_6                           10 /**< ID for RTC event generator PER_6 */
+#define EVENT_ID_GEN_RTC_PER_7                           11 /**< ID for RTC event generator PER_7 */
+#define EVENT_ID_GEN_RTC_CMP_0                           12 /**< ID for RTC event generator CMP_0 */
+#define EVENT_ID_GEN_RTC_CMP_1                           13 /**< ID for RTC event generator CMP_1 */
+#define EVENT_ID_GEN_RTC_TAMPER                          14 /**< ID for RTC event generator TAMPER */
+#define EVENT_ID_GEN_RTC_OVF                             15 /**< ID for RTC event generator OVF */
+#define EVENT_ID_GEN_RTC_PERD                            16 /**< ID for RTC event generator PERD */
+#define EVENT_ID_GEN_EIC_EXTINT_0                        17 /**< ID for EIC event generator EXTINT_0 */
+#define EVENT_ID_GEN_EIC_EXTINT_1                        18 /**< ID for EIC event generator EXTINT_1 */
+#define EVENT_ID_GEN_EIC_EXTINT_2                        19 /**< ID for EIC event generator EXTINT_2 */
+#define EVENT_ID_GEN_EIC_EXTINT_3                        20 /**< ID for EIC event generator EXTINT_3 */
+#define EVENT_ID_GEN_EIC_EXTINT_4                        21 /**< ID for EIC event generator EXTINT_4 */
+#define EVENT_ID_GEN_EIC_EXTINT_5                        22 /**< ID for EIC event generator EXTINT_5 */
+#define EVENT_ID_GEN_EIC_EXTINT_6                        23 /**< ID for EIC event generator EXTINT_6 */
+#define EVENT_ID_GEN_EIC_EXTINT_7                        24 /**< ID for EIC event generator EXTINT_7 */
+#define EVENT_ID_GEN_DMAC_CH_0                           25 /**< ID for DMAC event generator CH_0 */
+#define EVENT_ID_GEN_DMAC_CH_1                           26 /**< ID for DMAC event generator CH_1 */
+#define EVENT_ID_GEN_DMAC_CH_2                           27 /**< ID for DMAC event generator CH_2 */
+#define EVENT_ID_GEN_DMAC_CH_3                           28 /**< ID for DMAC event generator CH_3 */
+#define EVENT_ID_GEN_TC0_OVF                             29 /**< ID for TC0 event generator OVF */
+#define EVENT_ID_GEN_TC0_MCX_0                           30 /**< ID for TC0 event generator MCX_0 */
+#define EVENT_ID_GEN_TC0_MCX_1                           31 /**< ID for TC0 event generator MCX_1 */
+#define EVENT_ID_GEN_TC1_OVF                             32 /**< ID for TC1 event generator OVF */
+#define EVENT_ID_GEN_TC1_MCX_0                           33 /**< ID for TC1 event generator MCX_0 */
+#define EVENT_ID_GEN_TC1_MCX_1                           34 /**< ID for TC1 event generator MCX_1 */
+#define EVENT_ID_GEN_TC2_OVF                             35 /**< ID for TC2 event generator OVF */
+#define EVENT_ID_GEN_TC2_MCX_0                           36 /**< ID for TC2 event generator MCX_0 */
+#define EVENT_ID_GEN_TC2_MCX_1                           37 /**< ID for TC2 event generator MCX_1 */
+#define EVENT_ID_GEN_ADC_RESRDY                          38 /**< ID for ADC event generator RESRDY */
+#define EVENT_ID_GEN_ADC_WINMON                          39 /**< ID for ADC event generator WINMON */
+#define EVENT_ID_GEN_AC_COMP_0                           40 /**< ID for AC event generator COMP_0 */
+#define EVENT_ID_GEN_AC_COMP_1                           41 /**< ID for AC event generator COMP_1 */
+#define EVENT_ID_GEN_AC_WIN_0                            42 /**< ID for AC event generator WIN_0 */
+#define EVENT_ID_GEN_DAC_EMPTY                           43 /**< ID for DAC event generator EMPTY */
+#define EVENT_ID_GEN_TRNG_READY                          46 /**< ID for TRNG event generator READY */
+#define EVENT_ID_GEN_CCL_LUTOUT_0                        47 /**< ID for CCL event generator LUTOUT_0 */
+#define EVENT_ID_GEN_CCL_LUTOUT_1                        48 /**< ID for CCL event generator LUTOUT_1 */
+#define EVENT_ID_GEN_PAC_ERR                             49 /**< ID for PAC event generator ERR */
+
+/* ************************************************************************** */
+/** Event User IDs for SAML10D15A */
+/* ************************************************************************** */
+#define EVENT_ID_USER_OSCCTRL_TUNE                        0 /**< ID for OSCCTRL event user TUNE */
+#define EVENT_ID_USER_RTC_TAMPER                          1 /**< ID for RTC event user TAMPER */
+#define EVENT_ID_USER_NVMCTRL_PAGEW                       2 /**< ID for NVMCTRL event user PAGEW */
+#define EVENT_ID_USER_PORT_EV_0                           3 /**< ID for PORT event user EV_0 */
+#define EVENT_ID_USER_PORT_EV_1                           4 /**< ID for PORT event user EV_1 */
+#define EVENT_ID_USER_PORT_EV_2                           5 /**< ID for PORT event user EV_2 */
+#define EVENT_ID_USER_PORT_EV_3                           6 /**< ID for PORT event user EV_3 */
+#define EVENT_ID_USER_DMAC_CH_0                           7 /**< ID for DMAC event user CH_0 */
+#define EVENT_ID_USER_DMAC_CH_1                           8 /**< ID for DMAC event user CH_1 */
+#define EVENT_ID_USER_DMAC_CH_2                           9 /**< ID for DMAC event user CH_2 */
+#define EVENT_ID_USER_DMAC_CH_3                          10 /**< ID for DMAC event user CH_3 */
+#define EVENT_ID_USER_TC0_EVU                            11 /**< ID for TC0 event user EVU */
+#define EVENT_ID_USER_TC1_EVU                            12 /**< ID for TC1 event user EVU */
+#define EVENT_ID_USER_TC2_EVU                            13 /**< ID for TC2 event user EVU */
+#define EVENT_ID_USER_ADC_START                          14 /**< ID for ADC event user START */
+#define EVENT_ID_USER_ADC_SYNC                           15 /**< ID for ADC event user SYNC */
+#define EVENT_ID_USER_AC_SOC_0                           16 /**< ID for AC event user SOC_0 */
+#define EVENT_ID_USER_AC_SOC_1                           17 /**< ID for AC event user SOC_1 */
+#define EVENT_ID_USER_DAC_START                          18 /**< ID for DAC event user START */
+#define EVENT_ID_USER_CCL_LUTIN_0                        21 /**< ID for CCL event user LUTIN_0 */
+#define EVENT_ID_USER_CCL_LUTIN_1                        22 /**< ID for CCL event user LUTIN_1 */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @}  end of SAML10D15A definitions */
+
+
+#endif /* _SAML10D15A_H_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/saml10d16a.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/saml10d16a.h
@@ -1,0 +1,789 @@
+/**
+ * \file
+ *
+ * \brief Header file for ATSAML10D16A
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10D16A_H_
+#define _SAML10D16A_H_
+
+/** \addtogroup SAML10D16A_definitions SAML10D16A definitions
+  This file defines all structures and symbols for SAML10D16A:
+    - registers and bitfields
+    - peripheral base address
+    - peripheral ID
+    - PIO definitions
+ *  @{
+ */
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/** \defgroup Atmel_glob_defs Atmel Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+
+    \remark
+    CMSIS core has a syntax that differs from this using i.e. __I, __O, or __IO followed by 'uint<size>_t' respective types.
+    Default the header files will follow the CMSIS core syntax.
+ *  @{
+ */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+
+/* IO definitions (access restrictions to peripheral registers) */
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+
+#define CAST(type, value) ((type *)(value)) /**< Pointer Type Conversion Macro for C/C++ */
+#define REG_ACCESS(type, address) (*(type*)(address)) /**< C code: Register value */
+#else /* Assembler */
+#define CAST(type, value) (value) /**< Pointer Type Conversion Macro for Assembler */
+#define REG_ACCESS(type, address) (address) /**< Assembly code: Register address */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !defined(SKIP_INTEGER_LITERALS)
+
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x) x ## U    /**< C code: Unsigned integer literal constant value */
+#define _L_(x) x ## L    /**< C code: Long integer literal constant value */
+#define _UL_(x) x ## UL  /**< C code: Unsigned Long integer literal constant value */
+
+#else /* Assembler */
+
+#define _U_(x) x    /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x) x    /**< Assembler: Long integer literal constant value */
+#define _UL_(x) x   /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* SKIP_INTEGER_LITERALS */
+/** @}  end of Atmel Global Defines */
+
+/** \addtogroup SAML10D16A_cmsis CMSIS Definitions
+ *  @{
+ */
+/* ************************************************************************** */
+/*   CMSIS DEFINITIONS FOR SAML10D16A */
+/* ************************************************************************** */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+/******  CORTEX-M23 Processor Exceptions Numbers ******************************/
+  Reset_IRQn                = -15, /**< 1   Reset Vector, invoked on Power up and warm reset  */
+  NonMaskableInt_IRQn       = -14, /**< 2   Non maskable Interrupt, cannot be stopped or preempted  */
+  HardFault_IRQn            = -13, /**< 3   Hard Fault, all classes of Fault     */
+  SVCall_IRQn               = -5 , /**< 11  System Service Call via SVC instruction  */
+  PendSV_IRQn               = -2 , /**< 14  Pendable request for system service  */
+  SysTick_IRQn              = -1 , /**< 15  System Tick Timer                    */
+/******  SAML10D16A specific Interrupt Numbers ***********************************/
+  SYSTEM_IRQn               = 0  , /**< 0   SAML10D16A Main Clock (MCLK)        */
+  WDT_IRQn                  = 1  , /**< 1   SAML10D16A Watchdog Timer (WDT)     */
+  RTC_IRQn                  = 2  , /**< 2   SAML10D16A Real-Time Counter (RTC)  */
+  EIC_0_IRQn                = 3  , /**< 3   SAML10D16A External Interrupt Controller (EIC) */
+  EIC_1_IRQn                = 4  , /**< 4   SAML10D16A External Interrupt Controller (EIC) */
+  EIC_2_IRQn                = 5  , /**< 5   SAML10D16A External Interrupt Controller (EIC) */
+  EIC_3_IRQn                = 6  , /**< 6   SAML10D16A External Interrupt Controller (EIC) */
+  EIC_OTHER_IRQn            = 7  , /**< 7   SAML10D16A External Interrupt Controller (EIC) */
+  FREQM_IRQn                = 8  , /**< 8   SAML10D16A Frequency Meter (FREQM)  */
+  NVMCTRL_IRQn              = 9  , /**< 9   SAML10D16A Non-Volatile Memory Controller (NVMCTRL) */
+  PORT_IRQn                 = 10 , /**< 10  SAML10D16A Port Module (PORT)       */
+  DMAC_0_IRQn               = 11 , /**< 11  SAML10D16A Direct Memory Access Controller (DMAC) */
+  DMAC_1_IRQn               = 12 , /**< 12  SAML10D16A Direct Memory Access Controller (DMAC) */
+  DMAC_2_IRQn               = 13 , /**< 13  SAML10D16A Direct Memory Access Controller (DMAC) */
+  DMAC_3_IRQn               = 14 , /**< 14  SAML10D16A Direct Memory Access Controller (DMAC) */
+  DMAC_OTHER_IRQn           = 15 , /**< 15  SAML10D16A Direct Memory Access Controller (DMAC) */
+  EVSYS_0_IRQn              = 16 , /**< 16  SAML10D16A Event System Interface (EVSYS) */
+  EVSYS_1_IRQn              = 17 , /**< 17  SAML10D16A Event System Interface (EVSYS) */
+  EVSYS_2_IRQn              = 18 , /**< 18  SAML10D16A Event System Interface (EVSYS) */
+  EVSYS_3_IRQn              = 19 , /**< 19  SAML10D16A Event System Interface (EVSYS) */
+  EVSYS_NSCHK_IRQn          = 20 , /**< 20  SAML10D16A Event System Interface (EVSYS) */
+  PAC_IRQn                  = 21 , /**< 21  SAML10D16A Peripheral Access Controller (PAC) */
+  SERCOM0_0_IRQn            = 22 , /**< 22  SAML10D16A Serial Communication Interface (SERCOM0) */
+  SERCOM0_1_IRQn            = 23 , /**< 23  SAML10D16A Serial Communication Interface (SERCOM0) */
+  SERCOM0_2_IRQn            = 24 , /**< 24  SAML10D16A Serial Communication Interface (SERCOM0) */
+  SERCOM0_OTHER_IRQn        = 25 , /**< 25  SAML10D16A Serial Communication Interface (SERCOM0) */
+  SERCOM1_0_IRQn            = 26 , /**< 26  SAML10D16A Serial Communication Interface (SERCOM1) */
+  SERCOM1_1_IRQn            = 27 , /**< 27  SAML10D16A Serial Communication Interface (SERCOM1) */
+  SERCOM1_2_IRQn            = 28 , /**< 28  SAML10D16A Serial Communication Interface (SERCOM1) */
+  SERCOM1_OTHER_IRQn        = 29 , /**< 29  SAML10D16A Serial Communication Interface (SERCOM1) */
+  TC0_IRQn                  = 34 , /**< 34  SAML10D16A Basic Timer Counter (TC0) */
+  TC1_IRQn                  = 35 , /**< 35  SAML10D16A Basic Timer Counter (TC1) */
+  TC2_IRQn                  = 36 , /**< 36  SAML10D16A Basic Timer Counter (TC2) */
+  ADC_OTHER_IRQn            = 37 , /**< 37  SAML10D16A Analog Digital Converter (ADC) */
+  ADC_RESRDY_IRQn           = 38 , /**< 38  SAML10D16A Analog Digital Converter (ADC) */
+  AC_IRQn                   = 39 , /**< 39  SAML10D16A Analog Comparators (AC)  */
+  DAC_UNDERRUN_A_IRQn       = 40 , /**< 40  SAML10D16A Digital Analog Converter (DAC) */
+  DAC_EMPTY_IRQn            = 41 , /**< 41  SAML10D16A Digital Analog Converter (DAC) */
+  PTC_IRQn                  = 42 , /**< 42  SAML10D16A Peripheral Touch Controller (PTC) */
+  TRNG_IRQn                 = 43 , /**< 43  SAML10D16A True Random Generator (TRNG) */
+  TRAM_IRQn                 = 44 , /**< 44  SAML10D16A TrustRAM (TRAM)          */
+
+  PERIPH_COUNT_IRQn        = 45  /**< Number of peripheral IDs */
+} IRQn_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;                        /* -15 Reset Vector, invoked on Power up and warm reset  */
+  void* pfnNonMaskableInt_Handler;               /* -14 Non maskable Interrupt, cannot be stopped or preempted  */
+  void* pfnHardFault_Handler;                    /* -13 Hard Fault, all classes of Fault     */
+  void* pvReservedC12;
+  void* pvReservedC11;
+  void* pvReservedC10;
+  void* pvReservedC9;
+  void* pvReservedC8;
+  void* pvReservedC7;
+  void* pvReservedC6;
+  void* pfnSVCall_Handler;                       /*  -5 System Service Call via SVC instruction  */
+  void* pvReservedC4;
+  void* pvReservedC3;
+  void* pfnPendSV_Handler;                       /*  -2 Pendable request for system service  */
+  void* pfnSysTick_Handler;                      /*  -1 System Tick Timer                    */
+
+
+  /* Peripheral handlers */
+  void* pfnSYSTEM_Handler;                       /* 0   SAML10D16A Main Clock (MCLK)   */
+  void* pfnWDT_Handler;                          /* 1   SAML10D16A Watchdog Timer (WDT) */
+  void* pfnRTC_Handler;                          /* 2   SAML10D16A Real-Time Counter (RTC) */
+  void* pfnEIC_0_Handler;                        /* 3   SAML10D16A External Interrupt Controller (EIC) */
+  void* pfnEIC_1_Handler;                        /* 4   SAML10D16A External Interrupt Controller (EIC) */
+  void* pfnEIC_2_Handler;                        /* 5   SAML10D16A External Interrupt Controller (EIC) */
+  void* pfnEIC_3_Handler;                        /* 6   SAML10D16A External Interrupt Controller (EIC) */
+  void* pfnEIC_OTHER_Handler;                    /* 7   SAML10D16A External Interrupt Controller (EIC) */
+  void* pfnFREQM_Handler;                        /* 8   SAML10D16A Frequency Meter (FREQM) */
+  void* pfnNVMCTRL_Handler;                      /* 9   SAML10D16A Non-Volatile Memory Controller (NVMCTRL) */
+  void* pfnPORT_Handler;                         /* 10  SAML10D16A Port Module (PORT)  */
+  void* pfnDMAC_0_Handler;                       /* 11  SAML10D16A Direct Memory Access Controller (DMAC) */
+  void* pfnDMAC_1_Handler;                       /* 12  SAML10D16A Direct Memory Access Controller (DMAC) */
+  void* pfnDMAC_2_Handler;                       /* 13  SAML10D16A Direct Memory Access Controller (DMAC) */
+  void* pfnDMAC_3_Handler;                       /* 14  SAML10D16A Direct Memory Access Controller (DMAC) */
+  void* pfnDMAC_OTHER_Handler;                   /* 15  SAML10D16A Direct Memory Access Controller (DMAC) */
+  void* pfnEVSYS_0_Handler;                      /* 16  SAML10D16A Event System Interface (EVSYS) */
+  void* pfnEVSYS_1_Handler;                      /* 17  SAML10D16A Event System Interface (EVSYS) */
+  void* pfnEVSYS_2_Handler;                      /* 18  SAML10D16A Event System Interface (EVSYS) */
+  void* pfnEVSYS_3_Handler;                      /* 19  SAML10D16A Event System Interface (EVSYS) */
+  void* pfnEVSYS_NSCHK_Handler;                  /* 20  SAML10D16A Event System Interface (EVSYS) */
+  void* pfnPAC_Handler;                          /* 21  SAML10D16A Peripheral Access Controller (PAC) */
+  void* pfnSERCOM0_0_Handler;                    /* 22  SAML10D16A Serial Communication Interface (SERCOM0) */
+  void* pfnSERCOM0_1_Handler;                    /* 23  SAML10D16A Serial Communication Interface (SERCOM0) */
+  void* pfnSERCOM0_2_Handler;                    /* 24  SAML10D16A Serial Communication Interface (SERCOM0) */
+  void* pfnSERCOM0_OTHER_Handler;                /* 25  SAML10D16A Serial Communication Interface (SERCOM0) */
+  void* pfnSERCOM1_0_Handler;                    /* 26  SAML10D16A Serial Communication Interface (SERCOM1) */
+  void* pfnSERCOM1_1_Handler;                    /* 27  SAML10D16A Serial Communication Interface (SERCOM1) */
+  void* pfnSERCOM1_2_Handler;                    /* 28  SAML10D16A Serial Communication Interface (SERCOM1) */
+  void* pfnSERCOM1_OTHER_Handler;                /* 29  SAML10D16A Serial Communication Interface (SERCOM1) */
+  void* pvReserved30;
+  void* pvReserved31;
+  void* pvReserved32;
+  void* pvReserved33;
+  void* pfnTC0_Handler;                          /* 34  SAML10D16A Basic Timer Counter (TC0) */
+  void* pfnTC1_Handler;                          /* 35  SAML10D16A Basic Timer Counter (TC1) */
+  void* pfnTC2_Handler;                          /* 36  SAML10D16A Basic Timer Counter (TC2) */
+  void* pfnADC_OTHER_Handler;                    /* 37  SAML10D16A Analog Digital Converter (ADC) */
+  void* pfnADC_RESRDY_Handler;                   /* 38  SAML10D16A Analog Digital Converter (ADC) */
+  void* pfnAC_Handler;                           /* 39  SAML10D16A Analog Comparators (AC) */
+  void* pfnDAC_UNDERRUN_A_Handler;               /* 40  SAML10D16A Digital Analog Converter (DAC) */
+  void* pfnDAC_EMPTY_Handler;                    /* 41  SAML10D16A Digital Analog Converter (DAC) */
+  void* pfnPTC_Handler;                          /* 42  SAML10D16A Peripheral Touch Controller (PTC) */
+  void* pfnTRNG_Handler;                         /* 43  SAML10D16A True Random Generator (TRNG) */
+  void* pfnTRAM_Handler;                         /* 44  SAML10D16A TrustRAM (TRAM)     */
+} DeviceVectors;
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define pfnMemManage_Handler      pfnMemoryManagement_Handler     /**< \deprecated  Backward compatibility for ASF */
+#define pfnDebugMon_Handler       pfnDebugMonitor_Handler         /**< \deprecated  Backward compatibility for ASF */
+#define pfnNMI_Handler            pfnNonMaskableInt_Handler       /**< \deprecated  Backward compatibility for ASF */
+#define pfnSVC_Handler            pfnSVCall_Handler               /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if !defined DONT_USE_PREDEFINED_CORE_HANDLERS
+
+/* CORTEX-M23 core handlers */
+void Reset_Handler                 ( void );
+void NonMaskableInt_Handler        ( void );
+void HardFault_Handler             ( void );
+void SVCall_Handler                ( void );
+void PendSV_Handler                ( void );
+void SysTick_Handler               ( void );
+#endif /* DONT_USE_PREDEFINED_CORE_HANDLERS */
+
+#if !defined DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS
+
+/* Peripherals handlers */
+void AC_Handler                    ( void );
+void ADC_OTHER_Handler             ( void );
+void ADC_RESRDY_Handler            ( void );
+void DAC_EMPTY_Handler             ( void );
+void DAC_UNDERRUN_A_Handler        ( void );
+void DMAC_0_Handler                ( void );
+void DMAC_1_Handler                ( void );
+void DMAC_2_Handler                ( void );
+void DMAC_3_Handler                ( void );
+void DMAC_OTHER_Handler            ( void );
+void EIC_0_Handler                 ( void );
+void EIC_1_Handler                 ( void );
+void EIC_2_Handler                 ( void );
+void EIC_3_Handler                 ( void );
+void EIC_OTHER_Handler             ( void );
+void EVSYS_0_Handler               ( void );
+void EVSYS_1_Handler               ( void );
+void EVSYS_2_Handler               ( void );
+void EVSYS_3_Handler               ( void );
+void EVSYS_NSCHK_Handler           ( void );
+void FREQM_Handler                 ( void );
+void NVMCTRL_Handler               ( void );
+void PAC_Handler                   ( void );
+void PORT_Handler                  ( void );
+void PTC_Handler                   ( void );
+void RTC_Handler                   ( void );
+void SERCOM0_0_Handler             ( void );
+void SERCOM0_1_Handler             ( void );
+void SERCOM0_2_Handler             ( void );
+void SERCOM0_OTHER_Handler         ( void );
+void SERCOM1_0_Handler             ( void );
+void SERCOM1_1_Handler             ( void );
+void SERCOM1_2_Handler             ( void );
+void SERCOM1_OTHER_Handler         ( void );
+void SYSTEM_Handler                ( void );
+void TC0_Handler                   ( void );
+void TC1_Handler                   ( void );
+void TC2_Handler                   ( void );
+void TRAM_Handler                  ( void );
+void TRNG_Handler                  ( void );
+void WDT_Handler                   ( void );
+#endif /* DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS */
+
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define MemManage_Handler         MemoryManagement_Handler        /**< \deprecated  Backward compatibility for ASF */
+#define DebugMon_Handler          DebugMonitor_Handler            /**< \deprecated  Backward compatibility for ASF */
+#define NMI_Handler               NonMaskableInt_Handler          /**< \deprecated  Backward compatibility for ASF */
+#define SVC_Handler               SVCall_Handler                  /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+
+/*
+ * \brief Configuration of the CORTEX-M23 Processor and Core Peripherals
+ */
+
+#define NUM_IRQ                       45 /**< Number of interrupt request lines                                         */
+#define __ARMv8MBL_REV            0x0000 /**< Cortex-M23 Core Revision                                                  */
+#define __ETM_PRESENT                  0 /**< ETM present or not                                                        */
+#define __FPU_PRESENT                  0 /**< FPU present or not                                                        */
+#define __MPU_PRESENT                  1 /**< MPU present or not                                                        */
+#define __MTB_PRESENT                  0 /**< MTB present or not                                                        */
+#define __NVIC_PRIO_BITS               2 /**< Number of Bits used for Priority Levels                                   */
+#define __SAU_PRESENT                  0 /**< SAU present or not                                                        */
+#define __SEC_ENABLED                  0 /**< TrustZone-M enabled or not                                                */
+#define __VTOR_PRESENT                 1 /**< Vector Table Offset Register present or not                               */
+#define __Vendor_SysTickConfig         0 /**< Set to 1 if different SysTick Config is used                              */
+#define __ARCH_ARM                     1
+#define __ARCH_ARM_CORTEX_M            1
+#define __DEVICE_IS_SAM                1
+
+/*
+ * \brief CMSIS includes
+ */
+#include <core_cm23.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_saml10.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/** @}  end of SAML10D16A_cmsis CMSIS Definitions */
+
+/** \defgroup SAML10D16A_api Peripheral Software API
+ *  @{
+ */
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAML10D16A */
+/* ************************************************************************** */
+#include "component/ac.h"
+#include "component/adc.h"
+#include "component/ccl.h"
+#include "component/dac.h"
+#include "component/dmac.h"
+#include "component/dsu.h"
+#include "component/eic.h"
+#include "component/evsys.h"
+#include "component/freqm.h"
+#include "component/gclk.h"
+#include "component/idau.h"
+#include "component/mclk.h"
+#include "component/nvmctrl.h"
+#include "component/opamp.h"
+#include "component/oscctrl.h"
+#include "component/osc32kctrl.h"
+#include "component/pac.h"
+#include "component/pm.h"
+#include "component/port.h"
+#include "component/ptc.h"
+#include "component/rstc.h"
+#include "component/rtc.h"
+#include "component/sercom.h"
+#include "component/supc.h"
+#include "component/tc.h"
+#include "component/tram.h"
+#include "component/trng.h"
+#include "component/wdt.h"
+/** @}  end of Peripheral Software API */
+
+/** \defgroup SAML10D16A_reg Registers Access Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   REGISTER ACCESS DEFINITIONS FOR SAML10D16A */
+/* ************************************************************************** */
+#include "instance/ac.h"
+#include "instance/adc.h"
+#include "instance/ccl.h"
+#include "instance/dac.h"
+#include "instance/dmac.h"
+#include "instance/dsu.h"
+#include "instance/eic.h"
+#include "instance/evsys.h"
+#include "instance/freqm.h"
+#include "instance/gclk.h"
+#include "instance/idau.h"
+#include "instance/mclk.h"
+#include "instance/nvmctrl.h"
+#include "instance/opamp.h"
+#include "instance/oscctrl.h"
+#include "instance/osc32kctrl.h"
+#include "instance/pac.h"
+#include "instance/pm.h"
+#include "instance/port.h"
+#include "instance/ptc.h"
+#include "instance/rstc.h"
+#include "instance/rtc.h"
+#include "instance/sercom0.h"
+#include "instance/sercom1.h"
+#include "instance/supc.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tram.h"
+#include "instance/trng.h"
+#include "instance/wdt.h"
+/** @}  end of Registers Access Definitions */
+
+/** \addtogroup SAML10D16A_id Peripheral Ids Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*  PERIPHERAL ID DEFINITIONS FOR SAML10D16A */
+/* ************************************************************************** */
+#define ID_PAC          (  0) /**< \brief Peripheral Access Controller (PAC) */
+#define ID_PM           (  1) /**< \brief Power Manager (PM) */
+#define ID_MCLK         (  2) /**< \brief Main Clock (MCLK) */
+#define ID_RSTC         (  3) /**< \brief Reset Controller (RSTC) */
+#define ID_OSCCTRL      (  4) /**< \brief Oscillators Control (OSCCTRL) */
+#define ID_OSC32KCTRL   (  5) /**< \brief 32k Oscillators Control (OSC32KCTRL) */
+#define ID_SUPC         (  6) /**< \brief Supply Controller (SUPC) */
+#define ID_GCLK         (  7) /**< \brief Generic Clock Generator (GCLK) */
+#define ID_WDT          (  8) /**< \brief Watchdog Timer (WDT) */
+#define ID_RTC          (  9) /**< \brief Real-Time Counter (RTC) */
+#define ID_EIC          ( 10) /**< \brief External Interrupt Controller (EIC) */
+#define ID_FREQM        ( 11) /**< \brief Frequency Meter (FREQM) */
+#define ID_PORT         ( 12) /**< \brief Port Module (PORT) */
+#define ID_AC           ( 13) /**< \brief Analog Comparators (AC) */
+#define ID_IDAU         ( 32) /**< \brief Implementation Defined Attribution Unit (IDAU) */
+#define ID_DSU          ( 33) /**< \brief Device Service Unit (DSU) */
+#define ID_NVMCTRL      ( 34) /**< \brief Non-Volatile Memory Controller (NVMCTRL) */
+#define ID_DMAC         ( 35) /**< \brief Direct Memory Access Controller (DMAC) */
+#define ID_EVSYS        ( 64) /**< \brief Event System Interface (EVSYS) */
+#define ID_SERCOM0      ( 65) /**< \brief Serial Communication Interface (SERCOM0) */
+#define ID_SERCOM1      ( 66) /**< \brief Serial Communication Interface (SERCOM1) */
+#define ID_TC0          ( 68) /**< \brief Basic Timer Counter (TC0) */
+#define ID_TC1          ( 69) /**< \brief Basic Timer Counter (TC1) */
+#define ID_TC2          ( 70) /**< \brief Basic Timer Counter (TC2) */
+#define ID_ADC          ( 71) /**< \brief Analog Digital Converter (ADC) */
+#define ID_DAC          ( 72) /**< \brief Digital Analog Converter (DAC) */
+#define ID_PTC          ( 73) /**< \brief Peripheral Touch Controller (PTC) */
+#define ID_TRNG         ( 74) /**< \brief True Random Generator (TRNG) */
+#define ID_CCL          ( 75) /**< \brief Configurable Custom Logic (CCL) */
+#define ID_OPAMP        ( 76) /**< \brief Operational Amplifier (OPAMP) */
+#define ID_TRAM         ( 77) /**< \brief TrustRAM (TRAM) */
+
+#define ID_PERIPH_COUNT ( 78) /**< \brief Number of peripheral IDs */
+/** @}  end of Peripheral Ids Definitions */
+
+/** \addtogroup SAML10D16A_base Peripheral Base Address Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   BASE ADDRESS DEFINITIONS FOR SAML10D16A */
+/* ************************************************************************** */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#define AC                     (0x40003400)                   /**< \brief (AC        ) Base Address */
+#define ADC                    (0x42001C00)                   /**< \brief (ADC       ) Base Address */
+#define CCL                    (0x42002C00)                   /**< \brief (CCL       ) Base Address */
+#define DAC                    (0x42002000)                   /**< \brief (DAC       ) Base Address */
+#define DMAC                   (0x41006000)                   /**< \brief (DMAC      ) Base Address */
+#define DSU                    (0x41002000)                   /**< \brief (DSU       ) Base Address */
+#define DSU_EXT                (0x41002100)                   /**< \brief (DSU       ) Base Address */
+#define EIC                    (0x40002800)                   /**< \brief (EIC       ) Base Address */
+#define EVSYS                  (0x42000000)                   /**< \brief (EVSYS     ) Base Address */
+#define FREQM                  (0x40002C00)                   /**< \brief (FREQM     ) Base Address */
+#define GCLK                   (0x40001C00)                   /**< \brief (GCLK      ) Base Address */
+#define IDAU                   (0x41000000)                   /**< \brief (IDAU      ) Base Address */
+#define MCLK                   (0x40000800)                   /**< \brief (MCLK      ) Base Address */
+#define NVMCTRL                (0x41004000)                   /**< \brief (NVMCTRL   ) Base Address */
+#define OPAMP                  (0x42003000)                   /**< \brief (OPAMP     ) Base Address */
+#define OSCCTRL                (0x40001000)                   /**< \brief (OSCCTRL   ) Base Address */
+#define OSC32KCTRL             (0x40001400)                   /**< \brief (OSC32KCTRL) Base Address */
+#define PAC                    (0x40000000)                   /**< \brief (PAC       ) Base Address */
+#define PM                     (0x40000400)                   /**< \brief (PM        ) Base Address */
+#define PORT                   (0x40003000)                   /**< \brief (PORT      ) Base Address */
+#define PORT_IOBUS             (0x60000000)                   /**< \brief (PORT      ) Base Address */
+#define PTC                    (0x42002400)                   /**< \brief (PTC       ) Base Address */
+#define RSTC                   (0x40000C00)                   /**< \brief (RSTC      ) Base Address */
+#define RTC                    (0x40002400)                   /**< \brief (RTC       ) Base Address */
+#define SERCOM0                (0x42000400)                   /**< \brief (SERCOM0   ) Base Address */
+#define SERCOM1                (0x42000800)                   /**< \brief (SERCOM1   ) Base Address */
+#define SUPC                   (0x40001800)                   /**< \brief (SUPC      ) Base Address */
+#define TC0                    (0x42001000)                   /**< \brief (TC0       ) Base Address */
+#define TC1                    (0x42001400)                   /**< \brief (TC1       ) Base Address */
+#define TC2                    (0x42001800)                   /**< \brief (TC2       ) Base Address */
+#define TRAM                   (0x42003400)                   /**< \brief (TRAM      ) Base Address */
+#define TRNG                   (0x42002800)                   /**< \brief (TRNG      ) Base Address */
+#define WDT                    (0x40002000)                   /**< \brief (WDT       ) Base Address */
+
+#else /* For C/C++ compiler */
+
+#define AC                     ((Ac *)0x40003400U)            /**< \brief (AC        ) Base Address */
+#define AC_INST_NUM            1                              /**< \brief (AC        ) Number of instances */
+#define AC_INSTS               { AC }                         /**< \brief (AC        ) Instances List */
+
+#define ADC                    ((Adc *)0x42001C00U)           /**< \brief (ADC       ) Base Address */
+#define ADC_INST_NUM           1                              /**< \brief (ADC       ) Number of instances */
+#define ADC_INSTS              { ADC }                        /**< \brief (ADC       ) Instances List */
+
+#define CCL                    ((Ccl *)0x42002C00U)           /**< \brief (CCL       ) Base Address */
+#define CCL_INST_NUM           1                              /**< \brief (CCL       ) Number of instances */
+#define CCL_INSTS              { CCL }                        /**< \brief (CCL       ) Instances List */
+
+#define DAC                    ((Dac *)0x42002000U)           /**< \brief (DAC       ) Base Address */
+#define DAC_INST_NUM           1                              /**< \brief (DAC       ) Number of instances */
+#define DAC_INSTS              { DAC }                        /**< \brief (DAC       ) Instances List */
+
+#define DMAC                   ((Dmac *)0x41006000U)          /**< \brief (DMAC      ) Base Address */
+#define DMAC_INST_NUM          1                              /**< \brief (DMAC      ) Number of instances */
+#define DMAC_INSTS             { DMAC }                       /**< \brief (DMAC      ) Instances List */
+
+#define DSU                    ((Dsu *)0x41002000U)           /**< \brief (DSU       ) Base Address */
+#define DSU_EXT                ((Dsu *)0x41002100U)           /**< \brief (DSU       ) Base Address */
+#define DSU_INST_NUM           1                              /**< \brief (DSU       ) Number of instances */
+#define DSU_INSTS              { DSU }                        /**< \brief (DSU       ) Instances List */
+
+#define EIC                    ((Eic *)0x40002800U)           /**< \brief (EIC       ) Base Address */
+#define EIC_INST_NUM           1                              /**< \brief (EIC       ) Number of instances */
+#define EIC_INSTS              { EIC }                        /**< \brief (EIC       ) Instances List */
+
+#define EVSYS                  ((Evsys *)0x42000000U)         /**< \brief (EVSYS     ) Base Address */
+#define EVSYS_INST_NUM         1                              /**< \brief (EVSYS     ) Number of instances */
+#define EVSYS_INSTS            { EVSYS }                      /**< \brief (EVSYS     ) Instances List */
+
+#define FREQM                  ((Freqm *)0x40002C00U)         /**< \brief (FREQM     ) Base Address */
+#define FREQM_INST_NUM         1                              /**< \brief (FREQM     ) Number of instances */
+#define FREQM_INSTS            { FREQM }                      /**< \brief (FREQM     ) Instances List */
+
+#define GCLK                   ((Gclk *)0x40001C00U)          /**< \brief (GCLK      ) Base Address */
+#define GCLK_INST_NUM          1                              /**< \brief (GCLK      ) Number of instances */
+#define GCLK_INSTS             { GCLK }                       /**< \brief (GCLK      ) Instances List */
+
+#define IDAU                   ((Idau *)0x41000000U)          /**< \brief (IDAU      ) Base Address */
+#define IDAU_INST_NUM          1                              /**< \brief (IDAU      ) Number of instances */
+#define IDAU_INSTS             { IDAU }                       /**< \brief (IDAU      ) Instances List */
+
+#define MCLK                   ((Mclk *)0x40000800U)          /**< \brief (MCLK      ) Base Address */
+#define MCLK_INST_NUM          1                              /**< \brief (MCLK      ) Number of instances */
+#define MCLK_INSTS             { MCLK }                       /**< \brief (MCLK      ) Instances List */
+
+#define NVMCTRL                ((Nvmctrl *)0x41004000U)       /**< \brief (NVMCTRL   ) Base Address */
+#define NVMCTRL_INST_NUM       1                              /**< \brief (NVMCTRL   ) Number of instances */
+#define NVMCTRL_INSTS          { NVMCTRL }                    /**< \brief (NVMCTRL   ) Instances List */
+
+#define OPAMP                  ((Opamp *)0x42003000U)         /**< \brief (OPAMP     ) Base Address */
+#define OPAMP_INST_NUM         1                              /**< \brief (OPAMP     ) Number of instances */
+#define OPAMP_INSTS            { OPAMP }                      /**< \brief (OPAMP     ) Instances List */
+
+#define OSCCTRL                ((Oscctrl *)0x40001000U)       /**< \brief (OSCCTRL   ) Base Address */
+#define OSCCTRL_INST_NUM       1                              /**< \brief (OSCCTRL   ) Number of instances */
+#define OSCCTRL_INSTS          { OSCCTRL }                    /**< \brief (OSCCTRL   ) Instances List */
+
+#define OSC32KCTRL             ((Osc32kctrl *)0x40001400U)    /**< \brief (OSC32KCTRL) Base Address */
+#define OSC32KCTRL_INST_NUM    1                              /**< \brief (OSC32KCTRL) Number of instances */
+#define OSC32KCTRL_INSTS       { OSC32KCTRL }                 /**< \brief (OSC32KCTRL) Instances List */
+
+#define PAC                    ((Pac *)0x40000000U)           /**< \brief (PAC       ) Base Address */
+#define PAC_INST_NUM           1                              /**< \brief (PAC       ) Number of instances */
+#define PAC_INSTS              { PAC }                        /**< \brief (PAC       ) Instances List */
+
+#define PM                     ((Pm *)0x40000400U)            /**< \brief (PM        ) Base Address */
+#define PM_INST_NUM            1                              /**< \brief (PM        ) Number of instances */
+#define PM_INSTS               { PM }                         /**< \brief (PM        ) Instances List */
+
+#define PORT                   ((Port *)0x40003000U)          /**< \brief (PORT      ) Base Address */
+#define PORT_IOBUS             ((Port *)0x60000000U)          /**< \brief (PORT      ) Base Address */
+#define PORT_INST_NUM          1                              /**< \brief (PORT      ) Number of instances */
+#define PORT_INSTS             { PORT }                       /**< \brief (PORT      ) Instances List */
+
+#define PTC                    ((Ptc *)0x42002400U)           /**< \brief (PTC       ) Base Address */
+#define PTC_INST_NUM           1                              /**< \brief (PTC       ) Number of instances */
+#define PTC_INSTS              { PTC }                        /**< \brief (PTC       ) Instances List */
+
+#define RSTC                   ((Rstc *)0x40000C00U)          /**< \brief (RSTC      ) Base Address */
+#define RSTC_INST_NUM          1                              /**< \brief (RSTC      ) Number of instances */
+#define RSTC_INSTS             { RSTC }                       /**< \brief (RSTC      ) Instances List */
+
+#define RTC                    ((Rtc *)0x40002400U)           /**< \brief (RTC       ) Base Address */
+#define RTC_INST_NUM           1                              /**< \brief (RTC       ) Number of instances */
+#define RTC_INSTS              { RTC }                        /**< \brief (RTC       ) Instances List */
+
+#define SERCOM0                ((Sercom *)0x42000400U)        /**< \brief (SERCOM0   ) Base Address */
+#define SERCOM1                ((Sercom *)0x42000800U)        /**< \brief (SERCOM1   ) Base Address */
+#define SERCOM_INST_NUM        2                              /**< \brief (SERCOM    ) Number of instances */
+#define SERCOM_INSTS           { SERCOM0, SERCOM1 }           /**< \brief (SERCOM    ) Instances List */
+
+#define SUPC                   ((Supc *)0x40001800U)          /**< \brief (SUPC      ) Base Address */
+#define SUPC_INST_NUM          1                              /**< \brief (SUPC      ) Number of instances */
+#define SUPC_INSTS             { SUPC }                       /**< \brief (SUPC      ) Instances List */
+
+#define TC0                    ((Tc *)0x42001000U)            /**< \brief (TC0       ) Base Address */
+#define TC1                    ((Tc *)0x42001400U)            /**< \brief (TC1       ) Base Address */
+#define TC2                    ((Tc *)0x42001800U)            /**< \brief (TC2       ) Base Address */
+#define TC_INST_NUM            3                              /**< \brief (TC        ) Number of instances */
+#define TC_INSTS               { TC0, TC1, TC2 }              /**< \brief (TC        ) Instances List */
+
+#define TRAM                   ((Tram *)0x42003400U)          /**< \brief (TRAM      ) Base Address */
+#define TRAM_INST_NUM          1                              /**< \brief (TRAM      ) Number of instances */
+#define TRAM_INSTS             { TRAM }                       /**< \brief (TRAM      ) Instances List */
+
+#define TRNG                   ((Trng *)0x42002800U)          /**< \brief (TRNG      ) Base Address */
+#define TRNG_INST_NUM          1                              /**< \brief (TRNG      ) Number of instances */
+#define TRNG_INSTS             { TRNG }                       /**< \brief (TRNG      ) Instances List */
+
+#define WDT                    ((Wdt *)0x40002000U)           /**< \brief (WDT       ) Base Address */
+#define WDT_INST_NUM           1                              /**< \brief (WDT       ) Number of instances */
+#define WDT_INSTS              { WDT }                        /**< \brief (WDT       ) Instances List */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Peripheral Base Address Definitions */
+
+/** \addtogroup SAML10D16A_pio Peripheral Pio Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   PIO DEFINITIONS FOR SAML10D16A*/
+/* ************************************************************************** */
+#include "pio/saml10d16a.h"
+/** @}  end of Peripheral Pio Definitions */
+
+/* ************************************************************************** */
+/*   MEMORY MAPPING DEFINITIONS FOR SAML10D16A*/
+/* ************************************************************************** */
+
+#define FLASH_SIZE               _U_(0x00010000)       /*   64kB Memory segment type: flash */
+#define FLASH_PAGE_SIZE          _U_(        64)
+#define FLASH_NB_OF_PAGES        _U_(      1024)
+
+#define AUX_SIZE                 _U_(0x00000100)       /*    0kB Memory segment type: fuses */
+#define AUX_PAGE_SIZE            _U_(        64)
+#define AUX_NB_OF_PAGES          _U_(         4)
+
+#define BOCOR_SIZE               _U_(0x00000100)       /*    0kB Memory segment type: fuses */
+#define BOCOR_PAGE_SIZE          _U_(        64)
+#define BOCOR_NB_OF_PAGES        _U_(         4)
+
+#define DATAFLASH_SIZE           _U_(0x00000800)       /*    2kB Memory segment type: flash */
+#define DATAFLASH_PAGE_SIZE      _U_(        64)
+#define DATAFLASH_NB_OF_PAGES    _U_(        32)
+
+#define SW_CALIB_SIZE            _U_(0x00000008)       /*    0kB Memory segment type: fuses */
+#define TEMP_LOG_SIZE            _U_(0x00000008)       /*    0kB Memory segment type: fuses */
+#define USER_PAGE_SIZE           _U_(0x00000100)       /*    0kB Memory segment type: user_page */
+#define USER_PAGE_PAGE_SIZE      _U_(        64)
+#define USER_PAGE_NB_OF_PAGES    _U_(         4)
+
+#define HSRAM_SIZE               _U_(0x00004000)       /*   16kB Memory segment type: ram */
+#define HPB0_SIZE                _U_(0x00008000)       /*   32kB Memory segment type: io */
+#define HPB1_SIZE                _U_(0x00010000)       /*   64kB Memory segment type: io */
+#define HPB2_SIZE                _U_(0x00004000)       /*   16kB Memory segment type: io */
+#define PPB_SIZE                 _U_(0x00100000)       /* 1024kB Memory segment type: io */
+#define SCS_SIZE                 _U_(0x00001000)       /*    4kB Memory segment type: io */
+#define PERIPHERALS_SIZE         _U_(0x20000000)       /* 524288kB Memory segment type: io */
+
+#define FLASH_ADDR               _U_(0x00000000)       /**< FLASH base address (type: flash)*/
+#define AUX_ADDR                 _U_(0x00806000)       /**< AUX base address (type: fuses)*/
+#define BOCOR_ADDR               _U_(0x0080c000)       /**< BOCOR base address (type: fuses)*/
+#define DATAFLASH_ADDR           _U_(0x00400000)       /**< DATAFLASH base address (type: flash)*/
+#define SW_CALIB_ADDR            _U_(0x00806020)       /**< SW_CALIB base address (type: fuses)*/
+#define TEMP_LOG_ADDR            _U_(0x00806038)       /**< TEMP_LOG base address (type: fuses)*/
+#define USER_PAGE_ADDR           _U_(0x00804000)       /**< USER_PAGE base address (type: user_page)*/
+#define HSRAM_ADDR               _U_(0x20000000)       /**< HSRAM base address (type: ram)*/
+#define HPB0_ADDR                _U_(0x40000000)       /**< HPB0 base address (type: io)*/
+#define HPB1_ADDR                _U_(0x41000000)       /**< HPB1 base address (type: io)*/
+#define HPB2_ADDR                _U_(0x42000000)       /**< HPB2 base address (type: io)*/
+#define PPB_ADDR                 _U_(0xe0000000)       /**< PPB base address (type: io)*/
+#define SCS_ADDR                 _U_(0xe000e000)       /**< SCS base address (type: io)*/
+#define PERIPHERALS_ADDR         _U_(0x40000000)       /**< PERIPHERALS base address (type: io)*/
+
+#define NVMCTRL_AUX              AUX_ADDR              /**< \brief \deprecated Old style definition. Use AUX_ADDR instead */
+#define NVMCTRL_BOCOR            BOCOR_ADDR            /**< \brief \deprecated Old style definition. Use BOCOR_ADDR instead */
+#define NVMCTRL_DATAFLASH        DATAFLASH_ADDR        /**< \brief \deprecated Old style definition. Use DATAFLASH_ADDR instead */
+#define NVMCTRL_SW_CALIB         SW_CALIB_ADDR         /**< \brief \deprecated Old style definition. Use SW_CALIB_ADDR instead */
+#define NVMCTRL_TEMP_LOG         TEMP_LOG_ADDR         /**< \brief \deprecated Old style definition. Use TEMP_LOG_ADDR instead */
+#define NVMCTRL_USER             USER_PAGE_ADDR        /**< \brief \deprecated Old style definition. Use USER_PAGE_ADDR instead */
+
+/* ************************************************************************** */
+/**  DEVICE SIGNATURES FOR SAML10D16A */
+/* ************************************************************************** */
+#define DSU_DID                  _UL_(0X20840003)
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAML10D16A */
+/* ************************************************************************** */
+
+/* ************************************************************************** */
+/** Event Generator IDs for SAML10D16A */
+/* ************************************************************************** */
+#define EVENT_ID_GEN_OSCCTRL_XOSC_FAIL                    1 /**< ID for OSCCTRL event generator XOSC_FAIL */
+#define EVENT_ID_GEN_OSC32KCTRL_XOSC32K_FAIL              2 /**< ID for OSC32KCTRL event generator XOSC32K_FAIL */
+#define EVENT_ID_GEN_SUPC_BOD33DET                        3 /**< ID for SUPC event generator BOD33DET */
+#define EVENT_ID_GEN_RTC_PER_0                            4 /**< ID for RTC event generator PER_0 */
+#define EVENT_ID_GEN_RTC_PER_1                            5 /**< ID for RTC event generator PER_1 */
+#define EVENT_ID_GEN_RTC_PER_2                            6 /**< ID for RTC event generator PER_2 */
+#define EVENT_ID_GEN_RTC_PER_3                            7 /**< ID for RTC event generator PER_3 */
+#define EVENT_ID_GEN_RTC_PER_4                            8 /**< ID for RTC event generator PER_4 */
+#define EVENT_ID_GEN_RTC_PER_5                            9 /**< ID for RTC event generator PER_5 */
+#define EVENT_ID_GEN_RTC_PER_6                           10 /**< ID for RTC event generator PER_6 */
+#define EVENT_ID_GEN_RTC_PER_7                           11 /**< ID for RTC event generator PER_7 */
+#define EVENT_ID_GEN_RTC_CMP_0                           12 /**< ID for RTC event generator CMP_0 */
+#define EVENT_ID_GEN_RTC_CMP_1                           13 /**< ID for RTC event generator CMP_1 */
+#define EVENT_ID_GEN_RTC_TAMPER                          14 /**< ID for RTC event generator TAMPER */
+#define EVENT_ID_GEN_RTC_OVF                             15 /**< ID for RTC event generator OVF */
+#define EVENT_ID_GEN_RTC_PERD                            16 /**< ID for RTC event generator PERD */
+#define EVENT_ID_GEN_EIC_EXTINT_0                        17 /**< ID for EIC event generator EXTINT_0 */
+#define EVENT_ID_GEN_EIC_EXTINT_1                        18 /**< ID for EIC event generator EXTINT_1 */
+#define EVENT_ID_GEN_EIC_EXTINT_2                        19 /**< ID for EIC event generator EXTINT_2 */
+#define EVENT_ID_GEN_EIC_EXTINT_3                        20 /**< ID for EIC event generator EXTINT_3 */
+#define EVENT_ID_GEN_EIC_EXTINT_4                        21 /**< ID for EIC event generator EXTINT_4 */
+#define EVENT_ID_GEN_EIC_EXTINT_5                        22 /**< ID for EIC event generator EXTINT_5 */
+#define EVENT_ID_GEN_EIC_EXTINT_6                        23 /**< ID for EIC event generator EXTINT_6 */
+#define EVENT_ID_GEN_EIC_EXTINT_7                        24 /**< ID for EIC event generator EXTINT_7 */
+#define EVENT_ID_GEN_DMAC_CH_0                           25 /**< ID for DMAC event generator CH_0 */
+#define EVENT_ID_GEN_DMAC_CH_1                           26 /**< ID for DMAC event generator CH_1 */
+#define EVENT_ID_GEN_DMAC_CH_2                           27 /**< ID for DMAC event generator CH_2 */
+#define EVENT_ID_GEN_DMAC_CH_3                           28 /**< ID for DMAC event generator CH_3 */
+#define EVENT_ID_GEN_TC0_OVF                             29 /**< ID for TC0 event generator OVF */
+#define EVENT_ID_GEN_TC0_MCX_0                           30 /**< ID for TC0 event generator MCX_0 */
+#define EVENT_ID_GEN_TC0_MCX_1                           31 /**< ID for TC0 event generator MCX_1 */
+#define EVENT_ID_GEN_TC1_OVF                             32 /**< ID for TC1 event generator OVF */
+#define EVENT_ID_GEN_TC1_MCX_0                           33 /**< ID for TC1 event generator MCX_0 */
+#define EVENT_ID_GEN_TC1_MCX_1                           34 /**< ID for TC1 event generator MCX_1 */
+#define EVENT_ID_GEN_TC2_OVF                             35 /**< ID for TC2 event generator OVF */
+#define EVENT_ID_GEN_TC2_MCX_0                           36 /**< ID for TC2 event generator MCX_0 */
+#define EVENT_ID_GEN_TC2_MCX_1                           37 /**< ID for TC2 event generator MCX_1 */
+#define EVENT_ID_GEN_ADC_RESRDY                          38 /**< ID for ADC event generator RESRDY */
+#define EVENT_ID_GEN_ADC_WINMON                          39 /**< ID for ADC event generator WINMON */
+#define EVENT_ID_GEN_AC_COMP_0                           40 /**< ID for AC event generator COMP_0 */
+#define EVENT_ID_GEN_AC_COMP_1                           41 /**< ID for AC event generator COMP_1 */
+#define EVENT_ID_GEN_AC_WIN_0                            42 /**< ID for AC event generator WIN_0 */
+#define EVENT_ID_GEN_DAC_EMPTY                           43 /**< ID for DAC event generator EMPTY */
+#define EVENT_ID_GEN_TRNG_READY                          46 /**< ID for TRNG event generator READY */
+#define EVENT_ID_GEN_CCL_LUTOUT_0                        47 /**< ID for CCL event generator LUTOUT_0 */
+#define EVENT_ID_GEN_CCL_LUTOUT_1                        48 /**< ID for CCL event generator LUTOUT_1 */
+#define EVENT_ID_GEN_PAC_ERR                             49 /**< ID for PAC event generator ERR */
+
+/* ************************************************************************** */
+/** Event User IDs for SAML10D16A */
+/* ************************************************************************** */
+#define EVENT_ID_USER_OSCCTRL_TUNE                        0 /**< ID for OSCCTRL event user TUNE */
+#define EVENT_ID_USER_RTC_TAMPER                          1 /**< ID for RTC event user TAMPER */
+#define EVENT_ID_USER_NVMCTRL_PAGEW                       2 /**< ID for NVMCTRL event user PAGEW */
+#define EVENT_ID_USER_PORT_EV_0                           3 /**< ID for PORT event user EV_0 */
+#define EVENT_ID_USER_PORT_EV_1                           4 /**< ID for PORT event user EV_1 */
+#define EVENT_ID_USER_PORT_EV_2                           5 /**< ID for PORT event user EV_2 */
+#define EVENT_ID_USER_PORT_EV_3                           6 /**< ID for PORT event user EV_3 */
+#define EVENT_ID_USER_DMAC_CH_0                           7 /**< ID for DMAC event user CH_0 */
+#define EVENT_ID_USER_DMAC_CH_1                           8 /**< ID for DMAC event user CH_1 */
+#define EVENT_ID_USER_DMAC_CH_2                           9 /**< ID for DMAC event user CH_2 */
+#define EVENT_ID_USER_DMAC_CH_3                          10 /**< ID for DMAC event user CH_3 */
+#define EVENT_ID_USER_TC0_EVU                            11 /**< ID for TC0 event user EVU */
+#define EVENT_ID_USER_TC1_EVU                            12 /**< ID for TC1 event user EVU */
+#define EVENT_ID_USER_TC2_EVU                            13 /**< ID for TC2 event user EVU */
+#define EVENT_ID_USER_ADC_START                          14 /**< ID for ADC event user START */
+#define EVENT_ID_USER_ADC_SYNC                           15 /**< ID for ADC event user SYNC */
+#define EVENT_ID_USER_AC_SOC_0                           16 /**< ID for AC event user SOC_0 */
+#define EVENT_ID_USER_AC_SOC_1                           17 /**< ID for AC event user SOC_1 */
+#define EVENT_ID_USER_DAC_START                          18 /**< ID for DAC event user START */
+#define EVENT_ID_USER_CCL_LUTIN_0                        21 /**< ID for CCL event user LUTIN_0 */
+#define EVENT_ID_USER_CCL_LUTIN_1                        22 /**< ID for CCL event user LUTIN_1 */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @}  end of SAML10D16A definitions */
+
+
+#endif /* _SAML10D16A_H_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/saml10e14a.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/saml10e14a.h
@@ -1,0 +1,801 @@
+/**
+ * \file
+ *
+ * \brief Header file for ATSAML10E14A
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10E14A_H_
+#define _SAML10E14A_H_
+
+/** \addtogroup SAML10E14A_definitions SAML10E14A definitions
+  This file defines all structures and symbols for SAML10E14A:
+    - registers and bitfields
+    - peripheral base address
+    - peripheral ID
+    - PIO definitions
+ *  @{
+ */
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/** \defgroup Atmel_glob_defs Atmel Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+
+    \remark
+    CMSIS core has a syntax that differs from this using i.e. __I, __O, or __IO followed by 'uint<size>_t' respective types.
+    Default the header files will follow the CMSIS core syntax.
+ *  @{
+ */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+
+/* IO definitions (access restrictions to peripheral registers) */
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+
+#define CAST(type, value) ((type *)(value)) /**< Pointer Type Conversion Macro for C/C++ */
+#define REG_ACCESS(type, address) (*(type*)(address)) /**< C code: Register value */
+#else /* Assembler */
+#define CAST(type, value) (value) /**< Pointer Type Conversion Macro for Assembler */
+#define REG_ACCESS(type, address) (address) /**< Assembly code: Register address */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !defined(SKIP_INTEGER_LITERALS)
+
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x) x ## U    /**< C code: Unsigned integer literal constant value */
+#define _L_(x) x ## L    /**< C code: Long integer literal constant value */
+#define _UL_(x) x ## UL  /**< C code: Unsigned Long integer literal constant value */
+
+#else /* Assembler */
+
+#define _U_(x) x    /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x) x    /**< Assembler: Long integer literal constant value */
+#define _UL_(x) x   /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* SKIP_INTEGER_LITERALS */
+/** @}  end of Atmel Global Defines */
+
+/** \addtogroup SAML10E14A_cmsis CMSIS Definitions
+ *  @{
+ */
+/* ************************************************************************** */
+/*   CMSIS DEFINITIONS FOR SAML10E14A */
+/* ************************************************************************** */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+/******  CORTEX-M23 Processor Exceptions Numbers ******************************/
+  Reset_IRQn                = -15, /**< 1   Reset Vector, invoked on Power up and warm reset  */
+  NonMaskableInt_IRQn       = -14, /**< 2   Non maskable Interrupt, cannot be stopped or preempted  */
+  HardFault_IRQn            = -13, /**< 3   Hard Fault, all classes of Fault     */
+  SVCall_IRQn               = -5 , /**< 11  System Service Call via SVC instruction  */
+  PendSV_IRQn               = -2 , /**< 14  Pendable request for system service  */
+  SysTick_IRQn              = -1 , /**< 15  System Tick Timer                    */
+/******  SAML10E14A specific Interrupt Numbers ***********************************/
+  SYSTEM_IRQn               = 0  , /**< 0   SAML10E14A Main Clock (MCLK)        */
+  WDT_IRQn                  = 1  , /**< 1   SAML10E14A Watchdog Timer (WDT)     */
+  RTC_IRQn                  = 2  , /**< 2   SAML10E14A Real-Time Counter (RTC)  */
+  EIC_0_IRQn                = 3  , /**< 3   SAML10E14A External Interrupt Controller (EIC) */
+  EIC_1_IRQn                = 4  , /**< 4   SAML10E14A External Interrupt Controller (EIC) */
+  EIC_2_IRQn                = 5  , /**< 5   SAML10E14A External Interrupt Controller (EIC) */
+  EIC_3_IRQn                = 6  , /**< 6   SAML10E14A External Interrupt Controller (EIC) */
+  EIC_OTHER_IRQn            = 7  , /**< 7   SAML10E14A External Interrupt Controller (EIC) */
+  FREQM_IRQn                = 8  , /**< 8   SAML10E14A Frequency Meter (FREQM)  */
+  NVMCTRL_IRQn              = 9  , /**< 9   SAML10E14A Non-Volatile Memory Controller (NVMCTRL) */
+  PORT_IRQn                 = 10 , /**< 10  SAML10E14A Port Module (PORT)       */
+  DMAC_0_IRQn               = 11 , /**< 11  SAML10E14A Direct Memory Access Controller (DMAC) */
+  DMAC_1_IRQn               = 12 , /**< 12  SAML10E14A Direct Memory Access Controller (DMAC) */
+  DMAC_2_IRQn               = 13 , /**< 13  SAML10E14A Direct Memory Access Controller (DMAC) */
+  DMAC_3_IRQn               = 14 , /**< 14  SAML10E14A Direct Memory Access Controller (DMAC) */
+  DMAC_OTHER_IRQn           = 15 , /**< 15  SAML10E14A Direct Memory Access Controller (DMAC) */
+  EVSYS_0_IRQn              = 16 , /**< 16  SAML10E14A Event System Interface (EVSYS) */
+  EVSYS_1_IRQn              = 17 , /**< 17  SAML10E14A Event System Interface (EVSYS) */
+  EVSYS_2_IRQn              = 18 , /**< 18  SAML10E14A Event System Interface (EVSYS) */
+  EVSYS_3_IRQn              = 19 , /**< 19  SAML10E14A Event System Interface (EVSYS) */
+  EVSYS_NSCHK_IRQn          = 20 , /**< 20  SAML10E14A Event System Interface (EVSYS) */
+  PAC_IRQn                  = 21 , /**< 21  SAML10E14A Peripheral Access Controller (PAC) */
+  SERCOM0_0_IRQn            = 22 , /**< 22  SAML10E14A Serial Communication Interface (SERCOM0) */
+  SERCOM0_1_IRQn            = 23 , /**< 23  SAML10E14A Serial Communication Interface (SERCOM0) */
+  SERCOM0_2_IRQn            = 24 , /**< 24  SAML10E14A Serial Communication Interface (SERCOM0) */
+  SERCOM0_OTHER_IRQn        = 25 , /**< 25  SAML10E14A Serial Communication Interface (SERCOM0) */
+  SERCOM1_0_IRQn            = 26 , /**< 26  SAML10E14A Serial Communication Interface (SERCOM1) */
+  SERCOM1_1_IRQn            = 27 , /**< 27  SAML10E14A Serial Communication Interface (SERCOM1) */
+  SERCOM1_2_IRQn            = 28 , /**< 28  SAML10E14A Serial Communication Interface (SERCOM1) */
+  SERCOM1_OTHER_IRQn        = 29 , /**< 29  SAML10E14A Serial Communication Interface (SERCOM1) */
+  SERCOM2_0_IRQn            = 30 , /**< 30  SAML10E14A Serial Communication Interface (SERCOM2) */
+  SERCOM2_1_IRQn            = 31 , /**< 31  SAML10E14A Serial Communication Interface (SERCOM2) */
+  SERCOM2_2_IRQn            = 32 , /**< 32  SAML10E14A Serial Communication Interface (SERCOM2) */
+  SERCOM2_OTHER_IRQn        = 33 , /**< 33  SAML10E14A Serial Communication Interface (SERCOM2) */
+  TC0_IRQn                  = 34 , /**< 34  SAML10E14A Basic Timer Counter (TC0) */
+  TC1_IRQn                  = 35 , /**< 35  SAML10E14A Basic Timer Counter (TC1) */
+  TC2_IRQn                  = 36 , /**< 36  SAML10E14A Basic Timer Counter (TC2) */
+  ADC_OTHER_IRQn            = 37 , /**< 37  SAML10E14A Analog Digital Converter (ADC) */
+  ADC_RESRDY_IRQn           = 38 , /**< 38  SAML10E14A Analog Digital Converter (ADC) */
+  AC_IRQn                   = 39 , /**< 39  SAML10E14A Analog Comparators (AC)  */
+  DAC_UNDERRUN_A_IRQn       = 40 , /**< 40  SAML10E14A Digital Analog Converter (DAC) */
+  DAC_EMPTY_IRQn            = 41 , /**< 41  SAML10E14A Digital Analog Converter (DAC) */
+  PTC_IRQn                  = 42 , /**< 42  SAML10E14A Peripheral Touch Controller (PTC) */
+  TRNG_IRQn                 = 43 , /**< 43  SAML10E14A True Random Generator (TRNG) */
+  TRAM_IRQn                 = 44 , /**< 44  SAML10E14A TrustRAM (TRAM)          */
+
+  PERIPH_COUNT_IRQn        = 45  /**< Number of peripheral IDs */
+} IRQn_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;                        /* -15 Reset Vector, invoked on Power up and warm reset  */
+  void* pfnNonMaskableInt_Handler;               /* -14 Non maskable Interrupt, cannot be stopped or preempted  */
+  void* pfnHardFault_Handler;                    /* -13 Hard Fault, all classes of Fault     */
+  void* pvReservedC12;
+  void* pvReservedC11;
+  void* pvReservedC10;
+  void* pvReservedC9;
+  void* pvReservedC8;
+  void* pvReservedC7;
+  void* pvReservedC6;
+  void* pfnSVCall_Handler;                       /*  -5 System Service Call via SVC instruction  */
+  void* pvReservedC4;
+  void* pvReservedC3;
+  void* pfnPendSV_Handler;                       /*  -2 Pendable request for system service  */
+  void* pfnSysTick_Handler;                      /*  -1 System Tick Timer                    */
+
+
+  /* Peripheral handlers */
+  void* pfnSYSTEM_Handler;                       /* 0   SAML10E14A Main Clock (MCLK)   */
+  void* pfnWDT_Handler;                          /* 1   SAML10E14A Watchdog Timer (WDT) */
+  void* pfnRTC_Handler;                          /* 2   SAML10E14A Real-Time Counter (RTC) */
+  void* pfnEIC_0_Handler;                        /* 3   SAML10E14A External Interrupt Controller (EIC) */
+  void* pfnEIC_1_Handler;                        /* 4   SAML10E14A External Interrupt Controller (EIC) */
+  void* pfnEIC_2_Handler;                        /* 5   SAML10E14A External Interrupt Controller (EIC) */
+  void* pfnEIC_3_Handler;                        /* 6   SAML10E14A External Interrupt Controller (EIC) */
+  void* pfnEIC_OTHER_Handler;                    /* 7   SAML10E14A External Interrupt Controller (EIC) */
+  void* pfnFREQM_Handler;                        /* 8   SAML10E14A Frequency Meter (FREQM) */
+  void* pfnNVMCTRL_Handler;                      /* 9   SAML10E14A Non-Volatile Memory Controller (NVMCTRL) */
+  void* pfnPORT_Handler;                         /* 10  SAML10E14A Port Module (PORT)  */
+  void* pfnDMAC_0_Handler;                       /* 11  SAML10E14A Direct Memory Access Controller (DMAC) */
+  void* pfnDMAC_1_Handler;                       /* 12  SAML10E14A Direct Memory Access Controller (DMAC) */
+  void* pfnDMAC_2_Handler;                       /* 13  SAML10E14A Direct Memory Access Controller (DMAC) */
+  void* pfnDMAC_3_Handler;                       /* 14  SAML10E14A Direct Memory Access Controller (DMAC) */
+  void* pfnDMAC_OTHER_Handler;                   /* 15  SAML10E14A Direct Memory Access Controller (DMAC) */
+  void* pfnEVSYS_0_Handler;                      /* 16  SAML10E14A Event System Interface (EVSYS) */
+  void* pfnEVSYS_1_Handler;                      /* 17  SAML10E14A Event System Interface (EVSYS) */
+  void* pfnEVSYS_2_Handler;                      /* 18  SAML10E14A Event System Interface (EVSYS) */
+  void* pfnEVSYS_3_Handler;                      /* 19  SAML10E14A Event System Interface (EVSYS) */
+  void* pfnEVSYS_NSCHK_Handler;                  /* 20  SAML10E14A Event System Interface (EVSYS) */
+  void* pfnPAC_Handler;                          /* 21  SAML10E14A Peripheral Access Controller (PAC) */
+  void* pfnSERCOM0_0_Handler;                    /* 22  SAML10E14A Serial Communication Interface (SERCOM0) */
+  void* pfnSERCOM0_1_Handler;                    /* 23  SAML10E14A Serial Communication Interface (SERCOM0) */
+  void* pfnSERCOM0_2_Handler;                    /* 24  SAML10E14A Serial Communication Interface (SERCOM0) */
+  void* pfnSERCOM0_OTHER_Handler;                /* 25  SAML10E14A Serial Communication Interface (SERCOM0) */
+  void* pfnSERCOM1_0_Handler;                    /* 26  SAML10E14A Serial Communication Interface (SERCOM1) */
+  void* pfnSERCOM1_1_Handler;                    /* 27  SAML10E14A Serial Communication Interface (SERCOM1) */
+  void* pfnSERCOM1_2_Handler;                    /* 28  SAML10E14A Serial Communication Interface (SERCOM1) */
+  void* pfnSERCOM1_OTHER_Handler;                /* 29  SAML10E14A Serial Communication Interface (SERCOM1) */
+  void* pfnSERCOM2_0_Handler;                    /* 30  SAML10E14A Serial Communication Interface (SERCOM2) */
+  void* pfnSERCOM2_1_Handler;                    /* 31  SAML10E14A Serial Communication Interface (SERCOM2) */
+  void* pfnSERCOM2_2_Handler;                    /* 32  SAML10E14A Serial Communication Interface (SERCOM2) */
+  void* pfnSERCOM2_OTHER_Handler;                /* 33  SAML10E14A Serial Communication Interface (SERCOM2) */
+  void* pfnTC0_Handler;                          /* 34  SAML10E14A Basic Timer Counter (TC0) */
+  void* pfnTC1_Handler;                          /* 35  SAML10E14A Basic Timer Counter (TC1) */
+  void* pfnTC2_Handler;                          /* 36  SAML10E14A Basic Timer Counter (TC2) */
+  void* pfnADC_OTHER_Handler;                    /* 37  SAML10E14A Analog Digital Converter (ADC) */
+  void* pfnADC_RESRDY_Handler;                   /* 38  SAML10E14A Analog Digital Converter (ADC) */
+  void* pfnAC_Handler;                           /* 39  SAML10E14A Analog Comparators (AC) */
+  void* pfnDAC_UNDERRUN_A_Handler;               /* 40  SAML10E14A Digital Analog Converter (DAC) */
+  void* pfnDAC_EMPTY_Handler;                    /* 41  SAML10E14A Digital Analog Converter (DAC) */
+  void* pfnPTC_Handler;                          /* 42  SAML10E14A Peripheral Touch Controller (PTC) */
+  void* pfnTRNG_Handler;                         /* 43  SAML10E14A True Random Generator (TRNG) */
+  void* pfnTRAM_Handler;                         /* 44  SAML10E14A TrustRAM (TRAM)     */
+} DeviceVectors;
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define pfnMemManage_Handler      pfnMemoryManagement_Handler     /**< \deprecated  Backward compatibility for ASF */
+#define pfnDebugMon_Handler       pfnDebugMonitor_Handler         /**< \deprecated  Backward compatibility for ASF */
+#define pfnNMI_Handler            pfnNonMaskableInt_Handler       /**< \deprecated  Backward compatibility for ASF */
+#define pfnSVC_Handler            pfnSVCall_Handler               /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if !defined DONT_USE_PREDEFINED_CORE_HANDLERS
+
+/* CORTEX-M23 core handlers */
+void Reset_Handler                 ( void );
+void NonMaskableInt_Handler        ( void );
+void HardFault_Handler             ( void );
+void SVCall_Handler                ( void );
+void PendSV_Handler                ( void );
+void SysTick_Handler               ( void );
+#endif /* DONT_USE_PREDEFINED_CORE_HANDLERS */
+
+#if !defined DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS
+
+/* Peripherals handlers */
+void AC_Handler                    ( void );
+void ADC_OTHER_Handler             ( void );
+void ADC_RESRDY_Handler            ( void );
+void DAC_EMPTY_Handler             ( void );
+void DAC_UNDERRUN_A_Handler        ( void );
+void DMAC_0_Handler                ( void );
+void DMAC_1_Handler                ( void );
+void DMAC_2_Handler                ( void );
+void DMAC_3_Handler                ( void );
+void DMAC_OTHER_Handler            ( void );
+void EIC_0_Handler                 ( void );
+void EIC_1_Handler                 ( void );
+void EIC_2_Handler                 ( void );
+void EIC_3_Handler                 ( void );
+void EIC_OTHER_Handler             ( void );
+void EVSYS_0_Handler               ( void );
+void EVSYS_1_Handler               ( void );
+void EVSYS_2_Handler               ( void );
+void EVSYS_3_Handler               ( void );
+void EVSYS_NSCHK_Handler           ( void );
+void FREQM_Handler                 ( void );
+void NVMCTRL_Handler               ( void );
+void PAC_Handler                   ( void );
+void PORT_Handler                  ( void );
+void PTC_Handler                   ( void );
+void RTC_Handler                   ( void );
+void SERCOM0_0_Handler             ( void );
+void SERCOM0_1_Handler             ( void );
+void SERCOM0_2_Handler             ( void );
+void SERCOM0_OTHER_Handler         ( void );
+void SERCOM1_0_Handler             ( void );
+void SERCOM1_1_Handler             ( void );
+void SERCOM1_2_Handler             ( void );
+void SERCOM1_OTHER_Handler         ( void );
+void SERCOM2_0_Handler             ( void );
+void SERCOM2_1_Handler             ( void );
+void SERCOM2_2_Handler             ( void );
+void SERCOM2_OTHER_Handler         ( void );
+void SYSTEM_Handler                ( void );
+void TC0_Handler                   ( void );
+void TC1_Handler                   ( void );
+void TC2_Handler                   ( void );
+void TRAM_Handler                  ( void );
+void TRNG_Handler                  ( void );
+void WDT_Handler                   ( void );
+#endif /* DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS */
+
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define MemManage_Handler         MemoryManagement_Handler        /**< \deprecated  Backward compatibility for ASF */
+#define DebugMon_Handler          DebugMonitor_Handler            /**< \deprecated  Backward compatibility for ASF */
+#define NMI_Handler               NonMaskableInt_Handler          /**< \deprecated  Backward compatibility for ASF */
+#define SVC_Handler               SVCall_Handler                  /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+
+/*
+ * \brief Configuration of the CORTEX-M23 Processor and Core Peripherals
+ */
+
+#define NUM_IRQ                       45 /**< Number of interrupt request lines                                         */
+#define __ARMv8MBL_REV            0x0000 /**< Cortex-M23 Core Revision                                                  */
+#define __ETM_PRESENT                  0 /**< ETM present or not                                                        */
+#define __FPU_PRESENT                  0 /**< FPU present or not                                                        */
+#define __MPU_PRESENT                  1 /**< MPU present or not                                                        */
+#define __MTB_PRESENT                  0 /**< MTB present or not                                                        */
+#define __NVIC_PRIO_BITS               2 /**< Number of Bits used for Priority Levels                                   */
+#define __SAU_PRESENT                  0 /**< SAU present or not                                                        */
+#define __SEC_ENABLED                  0 /**< TrustZone-M enabled or not                                                */
+#define __VTOR_PRESENT                 1 /**< Vector Table Offset Register present or not                               */
+#define __Vendor_SysTickConfig         0 /**< Set to 1 if different SysTick Config is used                              */
+#define __ARCH_ARM                     1
+#define __ARCH_ARM_CORTEX_M            1
+#define __DEVICE_IS_SAM                1
+
+/*
+ * \brief CMSIS includes
+ */
+#include <core_cm23.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_saml10.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/** @}  end of SAML10E14A_cmsis CMSIS Definitions */
+
+/** \defgroup SAML10E14A_api Peripheral Software API
+ *  @{
+ */
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAML10E14A */
+/* ************************************************************************** */
+#include "component/ac.h"
+#include "component/adc.h"
+#include "component/ccl.h"
+#include "component/dac.h"
+#include "component/dmac.h"
+#include "component/dsu.h"
+#include "component/eic.h"
+#include "component/evsys.h"
+#include "component/freqm.h"
+#include "component/gclk.h"
+#include "component/idau.h"
+#include "component/mclk.h"
+#include "component/nvmctrl.h"
+#include "component/opamp.h"
+#include "component/oscctrl.h"
+#include "component/osc32kctrl.h"
+#include "component/pac.h"
+#include "component/pm.h"
+#include "component/port.h"
+#include "component/ptc.h"
+#include "component/rstc.h"
+#include "component/rtc.h"
+#include "component/sercom.h"
+#include "component/supc.h"
+#include "component/tc.h"
+#include "component/tram.h"
+#include "component/trng.h"
+#include "component/wdt.h"
+/** @}  end of Peripheral Software API */
+
+/** \defgroup SAML10E14A_reg Registers Access Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   REGISTER ACCESS DEFINITIONS FOR SAML10E14A */
+/* ************************************************************************** */
+#include "instance/ac.h"
+#include "instance/adc.h"
+#include "instance/ccl.h"
+#include "instance/dac.h"
+#include "instance/dmac.h"
+#include "instance/dsu.h"
+#include "instance/eic.h"
+#include "instance/evsys.h"
+#include "instance/freqm.h"
+#include "instance/gclk.h"
+#include "instance/idau.h"
+#include "instance/mclk.h"
+#include "instance/nvmctrl.h"
+#include "instance/opamp.h"
+#include "instance/oscctrl.h"
+#include "instance/osc32kctrl.h"
+#include "instance/pac.h"
+#include "instance/pm.h"
+#include "instance/port.h"
+#include "instance/ptc.h"
+#include "instance/rstc.h"
+#include "instance/rtc.h"
+#include "instance/sercom0.h"
+#include "instance/sercom1.h"
+#include "instance/sercom2.h"
+#include "instance/supc.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tram.h"
+#include "instance/trng.h"
+#include "instance/wdt.h"
+/** @}  end of Registers Access Definitions */
+
+/** \addtogroup SAML10E14A_id Peripheral Ids Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*  PERIPHERAL ID DEFINITIONS FOR SAML10E14A */
+/* ************************************************************************** */
+#define ID_PAC          (  0) /**< \brief Peripheral Access Controller (PAC) */
+#define ID_PM           (  1) /**< \brief Power Manager (PM) */
+#define ID_MCLK         (  2) /**< \brief Main Clock (MCLK) */
+#define ID_RSTC         (  3) /**< \brief Reset Controller (RSTC) */
+#define ID_OSCCTRL      (  4) /**< \brief Oscillators Control (OSCCTRL) */
+#define ID_OSC32KCTRL   (  5) /**< \brief 32k Oscillators Control (OSC32KCTRL) */
+#define ID_SUPC         (  6) /**< \brief Supply Controller (SUPC) */
+#define ID_GCLK         (  7) /**< \brief Generic Clock Generator (GCLK) */
+#define ID_WDT          (  8) /**< \brief Watchdog Timer (WDT) */
+#define ID_RTC          (  9) /**< \brief Real-Time Counter (RTC) */
+#define ID_EIC          ( 10) /**< \brief External Interrupt Controller (EIC) */
+#define ID_FREQM        ( 11) /**< \brief Frequency Meter (FREQM) */
+#define ID_PORT         ( 12) /**< \brief Port Module (PORT) */
+#define ID_AC           ( 13) /**< \brief Analog Comparators (AC) */
+#define ID_IDAU         ( 32) /**< \brief Implementation Defined Attribution Unit (IDAU) */
+#define ID_DSU          ( 33) /**< \brief Device Service Unit (DSU) */
+#define ID_NVMCTRL      ( 34) /**< \brief Non-Volatile Memory Controller (NVMCTRL) */
+#define ID_DMAC         ( 35) /**< \brief Direct Memory Access Controller (DMAC) */
+#define ID_EVSYS        ( 64) /**< \brief Event System Interface (EVSYS) */
+#define ID_SERCOM0      ( 65) /**< \brief Serial Communication Interface (SERCOM0) */
+#define ID_SERCOM1      ( 66) /**< \brief Serial Communication Interface (SERCOM1) */
+#define ID_SERCOM2      ( 67) /**< \brief Serial Communication Interface (SERCOM2) */
+#define ID_TC0          ( 68) /**< \brief Basic Timer Counter (TC0) */
+#define ID_TC1          ( 69) /**< \brief Basic Timer Counter (TC1) */
+#define ID_TC2          ( 70) /**< \brief Basic Timer Counter (TC2) */
+#define ID_ADC          ( 71) /**< \brief Analog Digital Converter (ADC) */
+#define ID_DAC          ( 72) /**< \brief Digital Analog Converter (DAC) */
+#define ID_PTC          ( 73) /**< \brief Peripheral Touch Controller (PTC) */
+#define ID_TRNG         ( 74) /**< \brief True Random Generator (TRNG) */
+#define ID_CCL          ( 75) /**< \brief Configurable Custom Logic (CCL) */
+#define ID_OPAMP        ( 76) /**< \brief Operational Amplifier (OPAMP) */
+#define ID_TRAM         ( 77) /**< \brief TrustRAM (TRAM) */
+
+#define ID_PERIPH_COUNT ( 78) /**< \brief Number of peripheral IDs */
+/** @}  end of Peripheral Ids Definitions */
+
+/** \addtogroup SAML10E14A_base Peripheral Base Address Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   BASE ADDRESS DEFINITIONS FOR SAML10E14A */
+/* ************************************************************************** */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#define AC                     (0x40003400)                   /**< \brief (AC        ) Base Address */
+#define ADC                    (0x42001C00)                   /**< \brief (ADC       ) Base Address */
+#define CCL                    (0x42002C00)                   /**< \brief (CCL       ) Base Address */
+#define DAC                    (0x42002000)                   /**< \brief (DAC       ) Base Address */
+#define DMAC                   (0x41006000)                   /**< \brief (DMAC      ) Base Address */
+#define DSU                    (0x41002000)                   /**< \brief (DSU       ) Base Address */
+#define DSU_EXT                (0x41002100)                   /**< \brief (DSU       ) Base Address */
+#define EIC                    (0x40002800)                   /**< \brief (EIC       ) Base Address */
+#define EVSYS                  (0x42000000)                   /**< \brief (EVSYS     ) Base Address */
+#define FREQM                  (0x40002C00)                   /**< \brief (FREQM     ) Base Address */
+#define GCLK                   (0x40001C00)                   /**< \brief (GCLK      ) Base Address */
+#define IDAU                   (0x41000000)                   /**< \brief (IDAU      ) Base Address */
+#define MCLK                   (0x40000800)                   /**< \brief (MCLK      ) Base Address */
+#define NVMCTRL                (0x41004000)                   /**< \brief (NVMCTRL   ) Base Address */
+#define OPAMP                  (0x42003000)                   /**< \brief (OPAMP     ) Base Address */
+#define OSCCTRL                (0x40001000)                   /**< \brief (OSCCTRL   ) Base Address */
+#define OSC32KCTRL             (0x40001400)                   /**< \brief (OSC32KCTRL) Base Address */
+#define PAC                    (0x40000000)                   /**< \brief (PAC       ) Base Address */
+#define PM                     (0x40000400)                   /**< \brief (PM        ) Base Address */
+#define PORT                   (0x40003000)                   /**< \brief (PORT      ) Base Address */
+#define PORT_IOBUS             (0x60000000)                   /**< \brief (PORT      ) Base Address */
+#define PTC                    (0x42002400)                   /**< \brief (PTC       ) Base Address */
+#define RSTC                   (0x40000C00)                   /**< \brief (RSTC      ) Base Address */
+#define RTC                    (0x40002400)                   /**< \brief (RTC       ) Base Address */
+#define SERCOM0                (0x42000400)                   /**< \brief (SERCOM0   ) Base Address */
+#define SERCOM1                (0x42000800)                   /**< \brief (SERCOM1   ) Base Address */
+#define SERCOM2                (0x42000C00)                   /**< \brief (SERCOM2   ) Base Address */
+#define SUPC                   (0x40001800)                   /**< \brief (SUPC      ) Base Address */
+#define TC0                    (0x42001000)                   /**< \brief (TC0       ) Base Address */
+#define TC1                    (0x42001400)                   /**< \brief (TC1       ) Base Address */
+#define TC2                    (0x42001800)                   /**< \brief (TC2       ) Base Address */
+#define TRAM                   (0x42003400)                   /**< \brief (TRAM      ) Base Address */
+#define TRNG                   (0x42002800)                   /**< \brief (TRNG      ) Base Address */
+#define WDT                    (0x40002000)                   /**< \brief (WDT       ) Base Address */
+
+#else /* For C/C++ compiler */
+
+#define AC                     ((Ac *)0x40003400U)            /**< \brief (AC        ) Base Address */
+#define AC_INST_NUM            1                              /**< \brief (AC        ) Number of instances */
+#define AC_INSTS               { AC }                         /**< \brief (AC        ) Instances List */
+
+#define ADC                    ((Adc *)0x42001C00U)           /**< \brief (ADC       ) Base Address */
+#define ADC_INST_NUM           1                              /**< \brief (ADC       ) Number of instances */
+#define ADC_INSTS              { ADC }                        /**< \brief (ADC       ) Instances List */
+
+#define CCL                    ((Ccl *)0x42002C00U)           /**< \brief (CCL       ) Base Address */
+#define CCL_INST_NUM           1                              /**< \brief (CCL       ) Number of instances */
+#define CCL_INSTS              { CCL }                        /**< \brief (CCL       ) Instances List */
+
+#define DAC                    ((Dac *)0x42002000U)           /**< \brief (DAC       ) Base Address */
+#define DAC_INST_NUM           1                              /**< \brief (DAC       ) Number of instances */
+#define DAC_INSTS              { DAC }                        /**< \brief (DAC       ) Instances List */
+
+#define DMAC                   ((Dmac *)0x41006000U)          /**< \brief (DMAC      ) Base Address */
+#define DMAC_INST_NUM          1                              /**< \brief (DMAC      ) Number of instances */
+#define DMAC_INSTS             { DMAC }                       /**< \brief (DMAC      ) Instances List */
+
+#define DSU                    ((Dsu *)0x41002000U)           /**< \brief (DSU       ) Base Address */
+#define DSU_EXT                ((Dsu *)0x41002100U)           /**< \brief (DSU       ) Base Address */
+#define DSU_INST_NUM           1                              /**< \brief (DSU       ) Number of instances */
+#define DSU_INSTS              { DSU }                        /**< \brief (DSU       ) Instances List */
+
+#define EIC                    ((Eic *)0x40002800U)           /**< \brief (EIC       ) Base Address */
+#define EIC_INST_NUM           1                              /**< \brief (EIC       ) Number of instances */
+#define EIC_INSTS              { EIC }                        /**< \brief (EIC       ) Instances List */
+
+#define EVSYS                  ((Evsys *)0x42000000U)         /**< \brief (EVSYS     ) Base Address */
+#define EVSYS_INST_NUM         1                              /**< \brief (EVSYS     ) Number of instances */
+#define EVSYS_INSTS            { EVSYS }                      /**< \brief (EVSYS     ) Instances List */
+
+#define FREQM                  ((Freqm *)0x40002C00U)         /**< \brief (FREQM     ) Base Address */
+#define FREQM_INST_NUM         1                              /**< \brief (FREQM     ) Number of instances */
+#define FREQM_INSTS            { FREQM }                      /**< \brief (FREQM     ) Instances List */
+
+#define GCLK                   ((Gclk *)0x40001C00U)          /**< \brief (GCLK      ) Base Address */
+#define GCLK_INST_NUM          1                              /**< \brief (GCLK      ) Number of instances */
+#define GCLK_INSTS             { GCLK }                       /**< \brief (GCLK      ) Instances List */
+
+#define IDAU                   ((Idau *)0x41000000U)          /**< \brief (IDAU      ) Base Address */
+#define IDAU_INST_NUM          1                              /**< \brief (IDAU      ) Number of instances */
+#define IDAU_INSTS             { IDAU }                       /**< \brief (IDAU      ) Instances List */
+
+#define MCLK                   ((Mclk *)0x40000800U)          /**< \brief (MCLK      ) Base Address */
+#define MCLK_INST_NUM          1                              /**< \brief (MCLK      ) Number of instances */
+#define MCLK_INSTS             { MCLK }                       /**< \brief (MCLK      ) Instances List */
+
+#define NVMCTRL                ((Nvmctrl *)0x41004000U)       /**< \brief (NVMCTRL   ) Base Address */
+#define NVMCTRL_INST_NUM       1                              /**< \brief (NVMCTRL   ) Number of instances */
+#define NVMCTRL_INSTS          { NVMCTRL }                    /**< \brief (NVMCTRL   ) Instances List */
+
+#define OPAMP                  ((Opamp *)0x42003000U)         /**< \brief (OPAMP     ) Base Address */
+#define OPAMP_INST_NUM         1                              /**< \brief (OPAMP     ) Number of instances */
+#define OPAMP_INSTS            { OPAMP }                      /**< \brief (OPAMP     ) Instances List */
+
+#define OSCCTRL                ((Oscctrl *)0x40001000U)       /**< \brief (OSCCTRL   ) Base Address */
+#define OSCCTRL_INST_NUM       1                              /**< \brief (OSCCTRL   ) Number of instances */
+#define OSCCTRL_INSTS          { OSCCTRL }                    /**< \brief (OSCCTRL   ) Instances List */
+
+#define OSC32KCTRL             ((Osc32kctrl *)0x40001400U)    /**< \brief (OSC32KCTRL) Base Address */
+#define OSC32KCTRL_INST_NUM    1                              /**< \brief (OSC32KCTRL) Number of instances */
+#define OSC32KCTRL_INSTS       { OSC32KCTRL }                 /**< \brief (OSC32KCTRL) Instances List */
+
+#define PAC                    ((Pac *)0x40000000U)           /**< \brief (PAC       ) Base Address */
+#define PAC_INST_NUM           1                              /**< \brief (PAC       ) Number of instances */
+#define PAC_INSTS              { PAC }                        /**< \brief (PAC       ) Instances List */
+
+#define PM                     ((Pm *)0x40000400U)            /**< \brief (PM        ) Base Address */
+#define PM_INST_NUM            1                              /**< \brief (PM        ) Number of instances */
+#define PM_INSTS               { PM }                         /**< \brief (PM        ) Instances List */
+
+#define PORT                   ((Port *)0x40003000U)          /**< \brief (PORT      ) Base Address */
+#define PORT_IOBUS             ((Port *)0x60000000U)          /**< \brief (PORT      ) Base Address */
+#define PORT_INST_NUM          1                              /**< \brief (PORT      ) Number of instances */
+#define PORT_INSTS             { PORT }                       /**< \brief (PORT      ) Instances List */
+
+#define PTC                    ((Ptc *)0x42002400U)           /**< \brief (PTC       ) Base Address */
+#define PTC_INST_NUM           1                              /**< \brief (PTC       ) Number of instances */
+#define PTC_INSTS              { PTC }                        /**< \brief (PTC       ) Instances List */
+
+#define RSTC                   ((Rstc *)0x40000C00U)          /**< \brief (RSTC      ) Base Address */
+#define RSTC_INST_NUM          1                              /**< \brief (RSTC      ) Number of instances */
+#define RSTC_INSTS             { RSTC }                       /**< \brief (RSTC      ) Instances List */
+
+#define RTC                    ((Rtc *)0x40002400U)           /**< \brief (RTC       ) Base Address */
+#define RTC_INST_NUM           1                              /**< \brief (RTC       ) Number of instances */
+#define RTC_INSTS              { RTC }                        /**< \brief (RTC       ) Instances List */
+
+#define SERCOM0                ((Sercom *)0x42000400U)        /**< \brief (SERCOM0   ) Base Address */
+#define SERCOM1                ((Sercom *)0x42000800U)        /**< \brief (SERCOM1   ) Base Address */
+#define SERCOM2                ((Sercom *)0x42000C00U)        /**< \brief (SERCOM2   ) Base Address */
+#define SERCOM_INST_NUM        3                              /**< \brief (SERCOM    ) Number of instances */
+#define SERCOM_INSTS           { SERCOM0, SERCOM1, SERCOM2 }  /**< \brief (SERCOM    ) Instances List */
+
+#define SUPC                   ((Supc *)0x40001800U)          /**< \brief (SUPC      ) Base Address */
+#define SUPC_INST_NUM          1                              /**< \brief (SUPC      ) Number of instances */
+#define SUPC_INSTS             { SUPC }                       /**< \brief (SUPC      ) Instances List */
+
+#define TC0                    ((Tc *)0x42001000U)            /**< \brief (TC0       ) Base Address */
+#define TC1                    ((Tc *)0x42001400U)            /**< \brief (TC1       ) Base Address */
+#define TC2                    ((Tc *)0x42001800U)            /**< \brief (TC2       ) Base Address */
+#define TC_INST_NUM            3                              /**< \brief (TC        ) Number of instances */
+#define TC_INSTS               { TC0, TC1, TC2 }              /**< \brief (TC        ) Instances List */
+
+#define TRAM                   ((Tram *)0x42003400U)          /**< \brief (TRAM      ) Base Address */
+#define TRAM_INST_NUM          1                              /**< \brief (TRAM      ) Number of instances */
+#define TRAM_INSTS             { TRAM }                       /**< \brief (TRAM      ) Instances List */
+
+#define TRNG                   ((Trng *)0x42002800U)          /**< \brief (TRNG      ) Base Address */
+#define TRNG_INST_NUM          1                              /**< \brief (TRNG      ) Number of instances */
+#define TRNG_INSTS             { TRNG }                       /**< \brief (TRNG      ) Instances List */
+
+#define WDT                    ((Wdt *)0x40002000U)           /**< \brief (WDT       ) Base Address */
+#define WDT_INST_NUM           1                              /**< \brief (WDT       ) Number of instances */
+#define WDT_INSTS              { WDT }                        /**< \brief (WDT       ) Instances List */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Peripheral Base Address Definitions */
+
+/** \addtogroup SAML10E14A_pio Peripheral Pio Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   PIO DEFINITIONS FOR SAML10E14A*/
+/* ************************************************************************** */
+#include "pio/saml10e14a.h"
+/** @}  end of Peripheral Pio Definitions */
+
+/* ************************************************************************** */
+/*   MEMORY MAPPING DEFINITIONS FOR SAML10E14A*/
+/* ************************************************************************** */
+
+#define FLASH_SIZE               _U_(0x00004000)       /*   16kB Memory segment type: flash */
+#define FLASH_PAGE_SIZE          _U_(        64)
+#define FLASH_NB_OF_PAGES        _U_(       256)
+
+#define AUX_SIZE                 _U_(0x00000100)       /*    0kB Memory segment type: fuses */
+#define AUX_PAGE_SIZE            _U_(        64)
+#define AUX_NB_OF_PAGES          _U_(         4)
+
+#define BOCOR_SIZE               _U_(0x00000100)       /*    0kB Memory segment type: fuses */
+#define BOCOR_PAGE_SIZE          _U_(        64)
+#define BOCOR_NB_OF_PAGES        _U_(         4)
+
+#define DATAFLASH_SIZE           _U_(0x00000800)       /*    2kB Memory segment type: flash */
+#define DATAFLASH_PAGE_SIZE      _U_(        64)
+#define DATAFLASH_NB_OF_PAGES    _U_(        32)
+
+#define SW_CALIB_SIZE            _U_(0x00000008)       /*    0kB Memory segment type: fuses */
+#define TEMP_LOG_SIZE            _U_(0x00000008)       /*    0kB Memory segment type: fuses */
+#define USER_PAGE_SIZE           _U_(0x00000100)       /*    0kB Memory segment type: user_page */
+#define USER_PAGE_PAGE_SIZE      _U_(        64)
+#define USER_PAGE_NB_OF_PAGES    _U_(         4)
+
+#define HSRAM_SIZE               _U_(0x00001000)       /*    4kB Memory segment type: ram */
+#define HPB0_SIZE                _U_(0x00008000)       /*   32kB Memory segment type: io */
+#define HPB1_SIZE                _U_(0x00010000)       /*   64kB Memory segment type: io */
+#define HPB2_SIZE                _U_(0x00004000)       /*   16kB Memory segment type: io */
+#define PPB_SIZE                 _U_(0x00100000)       /* 1024kB Memory segment type: io */
+#define SCS_SIZE                 _U_(0x00001000)       /*    4kB Memory segment type: io */
+#define PERIPHERALS_SIZE         _U_(0x20000000)       /* 524288kB Memory segment type: io */
+
+#define FLASH_ADDR               _U_(0x00000000)       /**< FLASH base address (type: flash)*/
+#define AUX_ADDR                 _U_(0x00806000)       /**< AUX base address (type: fuses)*/
+#define BOCOR_ADDR               _U_(0x0080c000)       /**< BOCOR base address (type: fuses)*/
+#define DATAFLASH_ADDR           _U_(0x00400000)       /**< DATAFLASH base address (type: flash)*/
+#define SW_CALIB_ADDR            _U_(0x00806020)       /**< SW_CALIB base address (type: fuses)*/
+#define TEMP_LOG_ADDR            _U_(0x00806038)       /**< TEMP_LOG base address (type: fuses)*/
+#define USER_PAGE_ADDR           _U_(0x00804000)       /**< USER_PAGE base address (type: user_page)*/
+#define HSRAM_ADDR               _U_(0x20000000)       /**< HSRAM base address (type: ram)*/
+#define HPB0_ADDR                _U_(0x40000000)       /**< HPB0 base address (type: io)*/
+#define HPB1_ADDR                _U_(0x41000000)       /**< HPB1 base address (type: io)*/
+#define HPB2_ADDR                _U_(0x42000000)       /**< HPB2 base address (type: io)*/
+#define PPB_ADDR                 _U_(0xe0000000)       /**< PPB base address (type: io)*/
+#define SCS_ADDR                 _U_(0xe000e000)       /**< SCS base address (type: io)*/
+#define PERIPHERALS_ADDR         _U_(0x40000000)       /**< PERIPHERALS base address (type: io)*/
+
+#define NVMCTRL_AUX              AUX_ADDR              /**< \brief \deprecated Old style definition. Use AUX_ADDR instead */
+#define NVMCTRL_BOCOR            BOCOR_ADDR            /**< \brief \deprecated Old style definition. Use BOCOR_ADDR instead */
+#define NVMCTRL_DATAFLASH        DATAFLASH_ADDR        /**< \brief \deprecated Old style definition. Use DATAFLASH_ADDR instead */
+#define NVMCTRL_SW_CALIB         SW_CALIB_ADDR         /**< \brief \deprecated Old style definition. Use SW_CALIB_ADDR instead */
+#define NVMCTRL_TEMP_LOG         TEMP_LOG_ADDR         /**< \brief \deprecated Old style definition. Use TEMP_LOG_ADDR instead */
+#define NVMCTRL_USER             USER_PAGE_ADDR        /**< \brief \deprecated Old style definition. Use USER_PAGE_ADDR instead */
+
+/* ************************************************************************** */
+/**  DEVICE SIGNATURES FOR SAML10E14A */
+/* ************************************************************************** */
+#define DSU_DID                  _UL_(0X20840002)
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAML10E14A */
+/* ************************************************************************** */
+
+/* ************************************************************************** */
+/** Event Generator IDs for SAML10E14A */
+/* ************************************************************************** */
+#define EVENT_ID_GEN_OSCCTRL_XOSC_FAIL                    1 /**< ID for OSCCTRL event generator XOSC_FAIL */
+#define EVENT_ID_GEN_OSC32KCTRL_XOSC32K_FAIL              2 /**< ID for OSC32KCTRL event generator XOSC32K_FAIL */
+#define EVENT_ID_GEN_SUPC_BOD33DET                        3 /**< ID for SUPC event generator BOD33DET */
+#define EVENT_ID_GEN_RTC_PER_0                            4 /**< ID for RTC event generator PER_0 */
+#define EVENT_ID_GEN_RTC_PER_1                            5 /**< ID for RTC event generator PER_1 */
+#define EVENT_ID_GEN_RTC_PER_2                            6 /**< ID for RTC event generator PER_2 */
+#define EVENT_ID_GEN_RTC_PER_3                            7 /**< ID for RTC event generator PER_3 */
+#define EVENT_ID_GEN_RTC_PER_4                            8 /**< ID for RTC event generator PER_4 */
+#define EVENT_ID_GEN_RTC_PER_5                            9 /**< ID for RTC event generator PER_5 */
+#define EVENT_ID_GEN_RTC_PER_6                           10 /**< ID for RTC event generator PER_6 */
+#define EVENT_ID_GEN_RTC_PER_7                           11 /**< ID for RTC event generator PER_7 */
+#define EVENT_ID_GEN_RTC_CMP_0                           12 /**< ID for RTC event generator CMP_0 */
+#define EVENT_ID_GEN_RTC_CMP_1                           13 /**< ID for RTC event generator CMP_1 */
+#define EVENT_ID_GEN_RTC_TAMPER                          14 /**< ID for RTC event generator TAMPER */
+#define EVENT_ID_GEN_RTC_OVF                             15 /**< ID for RTC event generator OVF */
+#define EVENT_ID_GEN_RTC_PERD                            16 /**< ID for RTC event generator PERD */
+#define EVENT_ID_GEN_EIC_EXTINT_0                        17 /**< ID for EIC event generator EXTINT_0 */
+#define EVENT_ID_GEN_EIC_EXTINT_1                        18 /**< ID for EIC event generator EXTINT_1 */
+#define EVENT_ID_GEN_EIC_EXTINT_2                        19 /**< ID for EIC event generator EXTINT_2 */
+#define EVENT_ID_GEN_EIC_EXTINT_3                        20 /**< ID for EIC event generator EXTINT_3 */
+#define EVENT_ID_GEN_EIC_EXTINT_4                        21 /**< ID for EIC event generator EXTINT_4 */
+#define EVENT_ID_GEN_EIC_EXTINT_5                        22 /**< ID for EIC event generator EXTINT_5 */
+#define EVENT_ID_GEN_EIC_EXTINT_6                        23 /**< ID for EIC event generator EXTINT_6 */
+#define EVENT_ID_GEN_EIC_EXTINT_7                        24 /**< ID for EIC event generator EXTINT_7 */
+#define EVENT_ID_GEN_DMAC_CH_0                           25 /**< ID for DMAC event generator CH_0 */
+#define EVENT_ID_GEN_DMAC_CH_1                           26 /**< ID for DMAC event generator CH_1 */
+#define EVENT_ID_GEN_DMAC_CH_2                           27 /**< ID for DMAC event generator CH_2 */
+#define EVENT_ID_GEN_DMAC_CH_3                           28 /**< ID for DMAC event generator CH_3 */
+#define EVENT_ID_GEN_TC0_OVF                             29 /**< ID for TC0 event generator OVF */
+#define EVENT_ID_GEN_TC0_MCX_0                           30 /**< ID for TC0 event generator MCX_0 */
+#define EVENT_ID_GEN_TC0_MCX_1                           31 /**< ID for TC0 event generator MCX_1 */
+#define EVENT_ID_GEN_TC1_OVF                             32 /**< ID for TC1 event generator OVF */
+#define EVENT_ID_GEN_TC1_MCX_0                           33 /**< ID for TC1 event generator MCX_0 */
+#define EVENT_ID_GEN_TC1_MCX_1                           34 /**< ID for TC1 event generator MCX_1 */
+#define EVENT_ID_GEN_TC2_OVF                             35 /**< ID for TC2 event generator OVF */
+#define EVENT_ID_GEN_TC2_MCX_0                           36 /**< ID for TC2 event generator MCX_0 */
+#define EVENT_ID_GEN_TC2_MCX_1                           37 /**< ID for TC2 event generator MCX_1 */
+#define EVENT_ID_GEN_ADC_RESRDY                          38 /**< ID for ADC event generator RESRDY */
+#define EVENT_ID_GEN_ADC_WINMON                          39 /**< ID for ADC event generator WINMON */
+#define EVENT_ID_GEN_AC_COMP_0                           40 /**< ID for AC event generator COMP_0 */
+#define EVENT_ID_GEN_AC_COMP_1                           41 /**< ID for AC event generator COMP_1 */
+#define EVENT_ID_GEN_AC_WIN_0                            42 /**< ID for AC event generator WIN_0 */
+#define EVENT_ID_GEN_DAC_EMPTY                           43 /**< ID for DAC event generator EMPTY */
+#define EVENT_ID_GEN_TRNG_READY                          46 /**< ID for TRNG event generator READY */
+#define EVENT_ID_GEN_CCL_LUTOUT_0                        47 /**< ID for CCL event generator LUTOUT_0 */
+#define EVENT_ID_GEN_CCL_LUTOUT_1                        48 /**< ID for CCL event generator LUTOUT_1 */
+#define EVENT_ID_GEN_PAC_ERR                             49 /**< ID for PAC event generator ERR */
+
+/* ************************************************************************** */
+/** Event User IDs for SAML10E14A */
+/* ************************************************************************** */
+#define EVENT_ID_USER_OSCCTRL_TUNE                        0 /**< ID for OSCCTRL event user TUNE */
+#define EVENT_ID_USER_RTC_TAMPER                          1 /**< ID for RTC event user TAMPER */
+#define EVENT_ID_USER_NVMCTRL_PAGEW                       2 /**< ID for NVMCTRL event user PAGEW */
+#define EVENT_ID_USER_PORT_EV_0                           3 /**< ID for PORT event user EV_0 */
+#define EVENT_ID_USER_PORT_EV_1                           4 /**< ID for PORT event user EV_1 */
+#define EVENT_ID_USER_PORT_EV_2                           5 /**< ID for PORT event user EV_2 */
+#define EVENT_ID_USER_PORT_EV_3                           6 /**< ID for PORT event user EV_3 */
+#define EVENT_ID_USER_DMAC_CH_0                           7 /**< ID for DMAC event user CH_0 */
+#define EVENT_ID_USER_DMAC_CH_1                           8 /**< ID for DMAC event user CH_1 */
+#define EVENT_ID_USER_DMAC_CH_2                           9 /**< ID for DMAC event user CH_2 */
+#define EVENT_ID_USER_DMAC_CH_3                          10 /**< ID for DMAC event user CH_3 */
+#define EVENT_ID_USER_TC0_EVU                            11 /**< ID for TC0 event user EVU */
+#define EVENT_ID_USER_TC1_EVU                            12 /**< ID for TC1 event user EVU */
+#define EVENT_ID_USER_TC2_EVU                            13 /**< ID for TC2 event user EVU */
+#define EVENT_ID_USER_ADC_START                          14 /**< ID for ADC event user START */
+#define EVENT_ID_USER_ADC_SYNC                           15 /**< ID for ADC event user SYNC */
+#define EVENT_ID_USER_AC_SOC_0                           16 /**< ID for AC event user SOC_0 */
+#define EVENT_ID_USER_AC_SOC_1                           17 /**< ID for AC event user SOC_1 */
+#define EVENT_ID_USER_DAC_START                          18 /**< ID for DAC event user START */
+#define EVENT_ID_USER_CCL_LUTIN_0                        21 /**< ID for CCL event user LUTIN_0 */
+#define EVENT_ID_USER_CCL_LUTIN_1                        22 /**< ID for CCL event user LUTIN_1 */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @}  end of SAML10E14A definitions */
+
+
+#endif /* _SAML10E14A_H_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/saml10e15a.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/saml10e15a.h
@@ -1,0 +1,801 @@
+/**
+ * \file
+ *
+ * \brief Header file for ATSAML10E15A
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10E15A_H_
+#define _SAML10E15A_H_
+
+/** \addtogroup SAML10E15A_definitions SAML10E15A definitions
+  This file defines all structures and symbols for SAML10E15A:
+    - registers and bitfields
+    - peripheral base address
+    - peripheral ID
+    - PIO definitions
+ *  @{
+ */
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/** \defgroup Atmel_glob_defs Atmel Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+
+    \remark
+    CMSIS core has a syntax that differs from this using i.e. __I, __O, or __IO followed by 'uint<size>_t' respective types.
+    Default the header files will follow the CMSIS core syntax.
+ *  @{
+ */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+
+/* IO definitions (access restrictions to peripheral registers) */
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+
+#define CAST(type, value) ((type *)(value)) /**< Pointer Type Conversion Macro for C/C++ */
+#define REG_ACCESS(type, address) (*(type*)(address)) /**< C code: Register value */
+#else /* Assembler */
+#define CAST(type, value) (value) /**< Pointer Type Conversion Macro for Assembler */
+#define REG_ACCESS(type, address) (address) /**< Assembly code: Register address */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !defined(SKIP_INTEGER_LITERALS)
+
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x) x ## U    /**< C code: Unsigned integer literal constant value */
+#define _L_(x) x ## L    /**< C code: Long integer literal constant value */
+#define _UL_(x) x ## UL  /**< C code: Unsigned Long integer literal constant value */
+
+#else /* Assembler */
+
+#define _U_(x) x    /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x) x    /**< Assembler: Long integer literal constant value */
+#define _UL_(x) x   /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* SKIP_INTEGER_LITERALS */
+/** @}  end of Atmel Global Defines */
+
+/** \addtogroup SAML10E15A_cmsis CMSIS Definitions
+ *  @{
+ */
+/* ************************************************************************** */
+/*   CMSIS DEFINITIONS FOR SAML10E15A */
+/* ************************************************************************** */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+/******  CORTEX-M23 Processor Exceptions Numbers ******************************/
+  Reset_IRQn                = -15, /**< 1   Reset Vector, invoked on Power up and warm reset  */
+  NonMaskableInt_IRQn       = -14, /**< 2   Non maskable Interrupt, cannot be stopped or preempted  */
+  HardFault_IRQn            = -13, /**< 3   Hard Fault, all classes of Fault     */
+  SVCall_IRQn               = -5 , /**< 11  System Service Call via SVC instruction  */
+  PendSV_IRQn               = -2 , /**< 14  Pendable request for system service  */
+  SysTick_IRQn              = -1 , /**< 15  System Tick Timer                    */
+/******  SAML10E15A specific Interrupt Numbers ***********************************/
+  SYSTEM_IRQn               = 0  , /**< 0   SAML10E15A Main Clock (MCLK)        */
+  WDT_IRQn                  = 1  , /**< 1   SAML10E15A Watchdog Timer (WDT)     */
+  RTC_IRQn                  = 2  , /**< 2   SAML10E15A Real-Time Counter (RTC)  */
+  EIC_0_IRQn                = 3  , /**< 3   SAML10E15A External Interrupt Controller (EIC) */
+  EIC_1_IRQn                = 4  , /**< 4   SAML10E15A External Interrupt Controller (EIC) */
+  EIC_2_IRQn                = 5  , /**< 5   SAML10E15A External Interrupt Controller (EIC) */
+  EIC_3_IRQn                = 6  , /**< 6   SAML10E15A External Interrupt Controller (EIC) */
+  EIC_OTHER_IRQn            = 7  , /**< 7   SAML10E15A External Interrupt Controller (EIC) */
+  FREQM_IRQn                = 8  , /**< 8   SAML10E15A Frequency Meter (FREQM)  */
+  NVMCTRL_IRQn              = 9  , /**< 9   SAML10E15A Non-Volatile Memory Controller (NVMCTRL) */
+  PORT_IRQn                 = 10 , /**< 10  SAML10E15A Port Module (PORT)       */
+  DMAC_0_IRQn               = 11 , /**< 11  SAML10E15A Direct Memory Access Controller (DMAC) */
+  DMAC_1_IRQn               = 12 , /**< 12  SAML10E15A Direct Memory Access Controller (DMAC) */
+  DMAC_2_IRQn               = 13 , /**< 13  SAML10E15A Direct Memory Access Controller (DMAC) */
+  DMAC_3_IRQn               = 14 , /**< 14  SAML10E15A Direct Memory Access Controller (DMAC) */
+  DMAC_OTHER_IRQn           = 15 , /**< 15  SAML10E15A Direct Memory Access Controller (DMAC) */
+  EVSYS_0_IRQn              = 16 , /**< 16  SAML10E15A Event System Interface (EVSYS) */
+  EVSYS_1_IRQn              = 17 , /**< 17  SAML10E15A Event System Interface (EVSYS) */
+  EVSYS_2_IRQn              = 18 , /**< 18  SAML10E15A Event System Interface (EVSYS) */
+  EVSYS_3_IRQn              = 19 , /**< 19  SAML10E15A Event System Interface (EVSYS) */
+  EVSYS_NSCHK_IRQn          = 20 , /**< 20  SAML10E15A Event System Interface (EVSYS) */
+  PAC_IRQn                  = 21 , /**< 21  SAML10E15A Peripheral Access Controller (PAC) */
+  SERCOM0_0_IRQn            = 22 , /**< 22  SAML10E15A Serial Communication Interface (SERCOM0) */
+  SERCOM0_1_IRQn            = 23 , /**< 23  SAML10E15A Serial Communication Interface (SERCOM0) */
+  SERCOM0_2_IRQn            = 24 , /**< 24  SAML10E15A Serial Communication Interface (SERCOM0) */
+  SERCOM0_OTHER_IRQn        = 25 , /**< 25  SAML10E15A Serial Communication Interface (SERCOM0) */
+  SERCOM1_0_IRQn            = 26 , /**< 26  SAML10E15A Serial Communication Interface (SERCOM1) */
+  SERCOM1_1_IRQn            = 27 , /**< 27  SAML10E15A Serial Communication Interface (SERCOM1) */
+  SERCOM1_2_IRQn            = 28 , /**< 28  SAML10E15A Serial Communication Interface (SERCOM1) */
+  SERCOM1_OTHER_IRQn        = 29 , /**< 29  SAML10E15A Serial Communication Interface (SERCOM1) */
+  SERCOM2_0_IRQn            = 30 , /**< 30  SAML10E15A Serial Communication Interface (SERCOM2) */
+  SERCOM2_1_IRQn            = 31 , /**< 31  SAML10E15A Serial Communication Interface (SERCOM2) */
+  SERCOM2_2_IRQn            = 32 , /**< 32  SAML10E15A Serial Communication Interface (SERCOM2) */
+  SERCOM2_OTHER_IRQn        = 33 , /**< 33  SAML10E15A Serial Communication Interface (SERCOM2) */
+  TC0_IRQn                  = 34 , /**< 34  SAML10E15A Basic Timer Counter (TC0) */
+  TC1_IRQn                  = 35 , /**< 35  SAML10E15A Basic Timer Counter (TC1) */
+  TC2_IRQn                  = 36 , /**< 36  SAML10E15A Basic Timer Counter (TC2) */
+  ADC_OTHER_IRQn            = 37 , /**< 37  SAML10E15A Analog Digital Converter (ADC) */
+  ADC_RESRDY_IRQn           = 38 , /**< 38  SAML10E15A Analog Digital Converter (ADC) */
+  AC_IRQn                   = 39 , /**< 39  SAML10E15A Analog Comparators (AC)  */
+  DAC_UNDERRUN_A_IRQn       = 40 , /**< 40  SAML10E15A Digital Analog Converter (DAC) */
+  DAC_EMPTY_IRQn            = 41 , /**< 41  SAML10E15A Digital Analog Converter (DAC) */
+  PTC_IRQn                  = 42 , /**< 42  SAML10E15A Peripheral Touch Controller (PTC) */
+  TRNG_IRQn                 = 43 , /**< 43  SAML10E15A True Random Generator (TRNG) */
+  TRAM_IRQn                 = 44 , /**< 44  SAML10E15A TrustRAM (TRAM)          */
+
+  PERIPH_COUNT_IRQn        = 45  /**< Number of peripheral IDs */
+} IRQn_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;                        /* -15 Reset Vector, invoked on Power up and warm reset  */
+  void* pfnNonMaskableInt_Handler;               /* -14 Non maskable Interrupt, cannot be stopped or preempted  */
+  void* pfnHardFault_Handler;                    /* -13 Hard Fault, all classes of Fault     */
+  void* pvReservedC12;
+  void* pvReservedC11;
+  void* pvReservedC10;
+  void* pvReservedC9;
+  void* pvReservedC8;
+  void* pvReservedC7;
+  void* pvReservedC6;
+  void* pfnSVCall_Handler;                       /*  -5 System Service Call via SVC instruction  */
+  void* pvReservedC4;
+  void* pvReservedC3;
+  void* pfnPendSV_Handler;                       /*  -2 Pendable request for system service  */
+  void* pfnSysTick_Handler;                      /*  -1 System Tick Timer                    */
+
+
+  /* Peripheral handlers */
+  void* pfnSYSTEM_Handler;                       /* 0   SAML10E15A Main Clock (MCLK)   */
+  void* pfnWDT_Handler;                          /* 1   SAML10E15A Watchdog Timer (WDT) */
+  void* pfnRTC_Handler;                          /* 2   SAML10E15A Real-Time Counter (RTC) */
+  void* pfnEIC_0_Handler;                        /* 3   SAML10E15A External Interrupt Controller (EIC) */
+  void* pfnEIC_1_Handler;                        /* 4   SAML10E15A External Interrupt Controller (EIC) */
+  void* pfnEIC_2_Handler;                        /* 5   SAML10E15A External Interrupt Controller (EIC) */
+  void* pfnEIC_3_Handler;                        /* 6   SAML10E15A External Interrupt Controller (EIC) */
+  void* pfnEIC_OTHER_Handler;                    /* 7   SAML10E15A External Interrupt Controller (EIC) */
+  void* pfnFREQM_Handler;                        /* 8   SAML10E15A Frequency Meter (FREQM) */
+  void* pfnNVMCTRL_Handler;                      /* 9   SAML10E15A Non-Volatile Memory Controller (NVMCTRL) */
+  void* pfnPORT_Handler;                         /* 10  SAML10E15A Port Module (PORT)  */
+  void* pfnDMAC_0_Handler;                       /* 11  SAML10E15A Direct Memory Access Controller (DMAC) */
+  void* pfnDMAC_1_Handler;                       /* 12  SAML10E15A Direct Memory Access Controller (DMAC) */
+  void* pfnDMAC_2_Handler;                       /* 13  SAML10E15A Direct Memory Access Controller (DMAC) */
+  void* pfnDMAC_3_Handler;                       /* 14  SAML10E15A Direct Memory Access Controller (DMAC) */
+  void* pfnDMAC_OTHER_Handler;                   /* 15  SAML10E15A Direct Memory Access Controller (DMAC) */
+  void* pfnEVSYS_0_Handler;                      /* 16  SAML10E15A Event System Interface (EVSYS) */
+  void* pfnEVSYS_1_Handler;                      /* 17  SAML10E15A Event System Interface (EVSYS) */
+  void* pfnEVSYS_2_Handler;                      /* 18  SAML10E15A Event System Interface (EVSYS) */
+  void* pfnEVSYS_3_Handler;                      /* 19  SAML10E15A Event System Interface (EVSYS) */
+  void* pfnEVSYS_NSCHK_Handler;                  /* 20  SAML10E15A Event System Interface (EVSYS) */
+  void* pfnPAC_Handler;                          /* 21  SAML10E15A Peripheral Access Controller (PAC) */
+  void* pfnSERCOM0_0_Handler;                    /* 22  SAML10E15A Serial Communication Interface (SERCOM0) */
+  void* pfnSERCOM0_1_Handler;                    /* 23  SAML10E15A Serial Communication Interface (SERCOM0) */
+  void* pfnSERCOM0_2_Handler;                    /* 24  SAML10E15A Serial Communication Interface (SERCOM0) */
+  void* pfnSERCOM0_OTHER_Handler;                /* 25  SAML10E15A Serial Communication Interface (SERCOM0) */
+  void* pfnSERCOM1_0_Handler;                    /* 26  SAML10E15A Serial Communication Interface (SERCOM1) */
+  void* pfnSERCOM1_1_Handler;                    /* 27  SAML10E15A Serial Communication Interface (SERCOM1) */
+  void* pfnSERCOM1_2_Handler;                    /* 28  SAML10E15A Serial Communication Interface (SERCOM1) */
+  void* pfnSERCOM1_OTHER_Handler;                /* 29  SAML10E15A Serial Communication Interface (SERCOM1) */
+  void* pfnSERCOM2_0_Handler;                    /* 30  SAML10E15A Serial Communication Interface (SERCOM2) */
+  void* pfnSERCOM2_1_Handler;                    /* 31  SAML10E15A Serial Communication Interface (SERCOM2) */
+  void* pfnSERCOM2_2_Handler;                    /* 32  SAML10E15A Serial Communication Interface (SERCOM2) */
+  void* pfnSERCOM2_OTHER_Handler;                /* 33  SAML10E15A Serial Communication Interface (SERCOM2) */
+  void* pfnTC0_Handler;                          /* 34  SAML10E15A Basic Timer Counter (TC0) */
+  void* pfnTC1_Handler;                          /* 35  SAML10E15A Basic Timer Counter (TC1) */
+  void* pfnTC2_Handler;                          /* 36  SAML10E15A Basic Timer Counter (TC2) */
+  void* pfnADC_OTHER_Handler;                    /* 37  SAML10E15A Analog Digital Converter (ADC) */
+  void* pfnADC_RESRDY_Handler;                   /* 38  SAML10E15A Analog Digital Converter (ADC) */
+  void* pfnAC_Handler;                           /* 39  SAML10E15A Analog Comparators (AC) */
+  void* pfnDAC_UNDERRUN_A_Handler;               /* 40  SAML10E15A Digital Analog Converter (DAC) */
+  void* pfnDAC_EMPTY_Handler;                    /* 41  SAML10E15A Digital Analog Converter (DAC) */
+  void* pfnPTC_Handler;                          /* 42  SAML10E15A Peripheral Touch Controller (PTC) */
+  void* pfnTRNG_Handler;                         /* 43  SAML10E15A True Random Generator (TRNG) */
+  void* pfnTRAM_Handler;                         /* 44  SAML10E15A TrustRAM (TRAM)     */
+} DeviceVectors;
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define pfnMemManage_Handler      pfnMemoryManagement_Handler     /**< \deprecated  Backward compatibility for ASF */
+#define pfnDebugMon_Handler       pfnDebugMonitor_Handler         /**< \deprecated  Backward compatibility for ASF */
+#define pfnNMI_Handler            pfnNonMaskableInt_Handler       /**< \deprecated  Backward compatibility for ASF */
+#define pfnSVC_Handler            pfnSVCall_Handler               /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if !defined DONT_USE_PREDEFINED_CORE_HANDLERS
+
+/* CORTEX-M23 core handlers */
+void Reset_Handler                 ( void );
+void NonMaskableInt_Handler        ( void );
+void HardFault_Handler             ( void );
+void SVCall_Handler                ( void );
+void PendSV_Handler                ( void );
+void SysTick_Handler               ( void );
+#endif /* DONT_USE_PREDEFINED_CORE_HANDLERS */
+
+#if !defined DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS
+
+/* Peripherals handlers */
+void AC_Handler                    ( void );
+void ADC_OTHER_Handler             ( void );
+void ADC_RESRDY_Handler            ( void );
+void DAC_EMPTY_Handler             ( void );
+void DAC_UNDERRUN_A_Handler        ( void );
+void DMAC_0_Handler                ( void );
+void DMAC_1_Handler                ( void );
+void DMAC_2_Handler                ( void );
+void DMAC_3_Handler                ( void );
+void DMAC_OTHER_Handler            ( void );
+void EIC_0_Handler                 ( void );
+void EIC_1_Handler                 ( void );
+void EIC_2_Handler                 ( void );
+void EIC_3_Handler                 ( void );
+void EIC_OTHER_Handler             ( void );
+void EVSYS_0_Handler               ( void );
+void EVSYS_1_Handler               ( void );
+void EVSYS_2_Handler               ( void );
+void EVSYS_3_Handler               ( void );
+void EVSYS_NSCHK_Handler           ( void );
+void FREQM_Handler                 ( void );
+void NVMCTRL_Handler               ( void );
+void PAC_Handler                   ( void );
+void PORT_Handler                  ( void );
+void PTC_Handler                   ( void );
+void RTC_Handler                   ( void );
+void SERCOM0_0_Handler             ( void );
+void SERCOM0_1_Handler             ( void );
+void SERCOM0_2_Handler             ( void );
+void SERCOM0_OTHER_Handler         ( void );
+void SERCOM1_0_Handler             ( void );
+void SERCOM1_1_Handler             ( void );
+void SERCOM1_2_Handler             ( void );
+void SERCOM1_OTHER_Handler         ( void );
+void SERCOM2_0_Handler             ( void );
+void SERCOM2_1_Handler             ( void );
+void SERCOM2_2_Handler             ( void );
+void SERCOM2_OTHER_Handler         ( void );
+void SYSTEM_Handler                ( void );
+void TC0_Handler                   ( void );
+void TC1_Handler                   ( void );
+void TC2_Handler                   ( void );
+void TRAM_Handler                  ( void );
+void TRNG_Handler                  ( void );
+void WDT_Handler                   ( void );
+#endif /* DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS */
+
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define MemManage_Handler         MemoryManagement_Handler        /**< \deprecated  Backward compatibility for ASF */
+#define DebugMon_Handler          DebugMonitor_Handler            /**< \deprecated  Backward compatibility for ASF */
+#define NMI_Handler               NonMaskableInt_Handler          /**< \deprecated  Backward compatibility for ASF */
+#define SVC_Handler               SVCall_Handler                  /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+
+/*
+ * \brief Configuration of the CORTEX-M23 Processor and Core Peripherals
+ */
+
+#define NUM_IRQ                       45 /**< Number of interrupt request lines                                         */
+#define __ARMv8MBL_REV            0x0000 /**< Cortex-M23 Core Revision                                                  */
+#define __ETM_PRESENT                  0 /**< ETM present or not                                                        */
+#define __FPU_PRESENT                  0 /**< FPU present or not                                                        */
+#define __MPU_PRESENT                  1 /**< MPU present or not                                                        */
+#define __MTB_PRESENT                  0 /**< MTB present or not                                                        */
+#define __NVIC_PRIO_BITS               2 /**< Number of Bits used for Priority Levels                                   */
+#define __SAU_PRESENT                  0 /**< SAU present or not                                                        */
+#define __SEC_ENABLED                  0 /**< TrustZone-M enabled or not                                                */
+#define __VTOR_PRESENT                 1 /**< Vector Table Offset Register present or not                               */
+#define __Vendor_SysTickConfig         0 /**< Set to 1 if different SysTick Config is used                              */
+#define __ARCH_ARM                     1
+#define __ARCH_ARM_CORTEX_M            1
+#define __DEVICE_IS_SAM                1
+
+/*
+ * \brief CMSIS includes
+ */
+#include <core_cm23.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_saml10.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/** @}  end of SAML10E15A_cmsis CMSIS Definitions */
+
+/** \defgroup SAML10E15A_api Peripheral Software API
+ *  @{
+ */
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAML10E15A */
+/* ************************************************************************** */
+#include "component/ac.h"
+#include "component/adc.h"
+#include "component/ccl.h"
+#include "component/dac.h"
+#include "component/dmac.h"
+#include "component/dsu.h"
+#include "component/eic.h"
+#include "component/evsys.h"
+#include "component/freqm.h"
+#include "component/gclk.h"
+#include "component/idau.h"
+#include "component/mclk.h"
+#include "component/nvmctrl.h"
+#include "component/opamp.h"
+#include "component/oscctrl.h"
+#include "component/osc32kctrl.h"
+#include "component/pac.h"
+#include "component/pm.h"
+#include "component/port.h"
+#include "component/ptc.h"
+#include "component/rstc.h"
+#include "component/rtc.h"
+#include "component/sercom.h"
+#include "component/supc.h"
+#include "component/tc.h"
+#include "component/tram.h"
+#include "component/trng.h"
+#include "component/wdt.h"
+/** @}  end of Peripheral Software API */
+
+/** \defgroup SAML10E15A_reg Registers Access Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   REGISTER ACCESS DEFINITIONS FOR SAML10E15A */
+/* ************************************************************************** */
+#include "instance/ac.h"
+#include "instance/adc.h"
+#include "instance/ccl.h"
+#include "instance/dac.h"
+#include "instance/dmac.h"
+#include "instance/dsu.h"
+#include "instance/eic.h"
+#include "instance/evsys.h"
+#include "instance/freqm.h"
+#include "instance/gclk.h"
+#include "instance/idau.h"
+#include "instance/mclk.h"
+#include "instance/nvmctrl.h"
+#include "instance/opamp.h"
+#include "instance/oscctrl.h"
+#include "instance/osc32kctrl.h"
+#include "instance/pac.h"
+#include "instance/pm.h"
+#include "instance/port.h"
+#include "instance/ptc.h"
+#include "instance/rstc.h"
+#include "instance/rtc.h"
+#include "instance/sercom0.h"
+#include "instance/sercom1.h"
+#include "instance/sercom2.h"
+#include "instance/supc.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tram.h"
+#include "instance/trng.h"
+#include "instance/wdt.h"
+/** @}  end of Registers Access Definitions */
+
+/** \addtogroup SAML10E15A_id Peripheral Ids Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*  PERIPHERAL ID DEFINITIONS FOR SAML10E15A */
+/* ************************************************************************** */
+#define ID_PAC          (  0) /**< \brief Peripheral Access Controller (PAC) */
+#define ID_PM           (  1) /**< \brief Power Manager (PM) */
+#define ID_MCLK         (  2) /**< \brief Main Clock (MCLK) */
+#define ID_RSTC         (  3) /**< \brief Reset Controller (RSTC) */
+#define ID_OSCCTRL      (  4) /**< \brief Oscillators Control (OSCCTRL) */
+#define ID_OSC32KCTRL   (  5) /**< \brief 32k Oscillators Control (OSC32KCTRL) */
+#define ID_SUPC         (  6) /**< \brief Supply Controller (SUPC) */
+#define ID_GCLK         (  7) /**< \brief Generic Clock Generator (GCLK) */
+#define ID_WDT          (  8) /**< \brief Watchdog Timer (WDT) */
+#define ID_RTC          (  9) /**< \brief Real-Time Counter (RTC) */
+#define ID_EIC          ( 10) /**< \brief External Interrupt Controller (EIC) */
+#define ID_FREQM        ( 11) /**< \brief Frequency Meter (FREQM) */
+#define ID_PORT         ( 12) /**< \brief Port Module (PORT) */
+#define ID_AC           ( 13) /**< \brief Analog Comparators (AC) */
+#define ID_IDAU         ( 32) /**< \brief Implementation Defined Attribution Unit (IDAU) */
+#define ID_DSU          ( 33) /**< \brief Device Service Unit (DSU) */
+#define ID_NVMCTRL      ( 34) /**< \brief Non-Volatile Memory Controller (NVMCTRL) */
+#define ID_DMAC         ( 35) /**< \brief Direct Memory Access Controller (DMAC) */
+#define ID_EVSYS        ( 64) /**< \brief Event System Interface (EVSYS) */
+#define ID_SERCOM0      ( 65) /**< \brief Serial Communication Interface (SERCOM0) */
+#define ID_SERCOM1      ( 66) /**< \brief Serial Communication Interface (SERCOM1) */
+#define ID_SERCOM2      ( 67) /**< \brief Serial Communication Interface (SERCOM2) */
+#define ID_TC0          ( 68) /**< \brief Basic Timer Counter (TC0) */
+#define ID_TC1          ( 69) /**< \brief Basic Timer Counter (TC1) */
+#define ID_TC2          ( 70) /**< \brief Basic Timer Counter (TC2) */
+#define ID_ADC          ( 71) /**< \brief Analog Digital Converter (ADC) */
+#define ID_DAC          ( 72) /**< \brief Digital Analog Converter (DAC) */
+#define ID_PTC          ( 73) /**< \brief Peripheral Touch Controller (PTC) */
+#define ID_TRNG         ( 74) /**< \brief True Random Generator (TRNG) */
+#define ID_CCL          ( 75) /**< \brief Configurable Custom Logic (CCL) */
+#define ID_OPAMP        ( 76) /**< \brief Operational Amplifier (OPAMP) */
+#define ID_TRAM         ( 77) /**< \brief TrustRAM (TRAM) */
+
+#define ID_PERIPH_COUNT ( 78) /**< \brief Number of peripheral IDs */
+/** @}  end of Peripheral Ids Definitions */
+
+/** \addtogroup SAML10E15A_base Peripheral Base Address Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   BASE ADDRESS DEFINITIONS FOR SAML10E15A */
+/* ************************************************************************** */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#define AC                     (0x40003400)                   /**< \brief (AC        ) Base Address */
+#define ADC                    (0x42001C00)                   /**< \brief (ADC       ) Base Address */
+#define CCL                    (0x42002C00)                   /**< \brief (CCL       ) Base Address */
+#define DAC                    (0x42002000)                   /**< \brief (DAC       ) Base Address */
+#define DMAC                   (0x41006000)                   /**< \brief (DMAC      ) Base Address */
+#define DSU                    (0x41002000)                   /**< \brief (DSU       ) Base Address */
+#define DSU_EXT                (0x41002100)                   /**< \brief (DSU       ) Base Address */
+#define EIC                    (0x40002800)                   /**< \brief (EIC       ) Base Address */
+#define EVSYS                  (0x42000000)                   /**< \brief (EVSYS     ) Base Address */
+#define FREQM                  (0x40002C00)                   /**< \brief (FREQM     ) Base Address */
+#define GCLK                   (0x40001C00)                   /**< \brief (GCLK      ) Base Address */
+#define IDAU                   (0x41000000)                   /**< \brief (IDAU      ) Base Address */
+#define MCLK                   (0x40000800)                   /**< \brief (MCLK      ) Base Address */
+#define NVMCTRL                (0x41004000)                   /**< \brief (NVMCTRL   ) Base Address */
+#define OPAMP                  (0x42003000)                   /**< \brief (OPAMP     ) Base Address */
+#define OSCCTRL                (0x40001000)                   /**< \brief (OSCCTRL   ) Base Address */
+#define OSC32KCTRL             (0x40001400)                   /**< \brief (OSC32KCTRL) Base Address */
+#define PAC                    (0x40000000)                   /**< \brief (PAC       ) Base Address */
+#define PM                     (0x40000400)                   /**< \brief (PM        ) Base Address */
+#define PORT                   (0x40003000)                   /**< \brief (PORT      ) Base Address */
+#define PORT_IOBUS             (0x60000000)                   /**< \brief (PORT      ) Base Address */
+#define PTC                    (0x42002400)                   /**< \brief (PTC       ) Base Address */
+#define RSTC                   (0x40000C00)                   /**< \brief (RSTC      ) Base Address */
+#define RTC                    (0x40002400)                   /**< \brief (RTC       ) Base Address */
+#define SERCOM0                (0x42000400)                   /**< \brief (SERCOM0   ) Base Address */
+#define SERCOM1                (0x42000800)                   /**< \brief (SERCOM1   ) Base Address */
+#define SERCOM2                (0x42000C00)                   /**< \brief (SERCOM2   ) Base Address */
+#define SUPC                   (0x40001800)                   /**< \brief (SUPC      ) Base Address */
+#define TC0                    (0x42001000)                   /**< \brief (TC0       ) Base Address */
+#define TC1                    (0x42001400)                   /**< \brief (TC1       ) Base Address */
+#define TC2                    (0x42001800)                   /**< \brief (TC2       ) Base Address */
+#define TRAM                   (0x42003400)                   /**< \brief (TRAM      ) Base Address */
+#define TRNG                   (0x42002800)                   /**< \brief (TRNG      ) Base Address */
+#define WDT                    (0x40002000)                   /**< \brief (WDT       ) Base Address */
+
+#else /* For C/C++ compiler */
+
+#define AC                     ((Ac *)0x40003400U)            /**< \brief (AC        ) Base Address */
+#define AC_INST_NUM            1                              /**< \brief (AC        ) Number of instances */
+#define AC_INSTS               { AC }                         /**< \brief (AC        ) Instances List */
+
+#define ADC                    ((Adc *)0x42001C00U)           /**< \brief (ADC       ) Base Address */
+#define ADC_INST_NUM           1                              /**< \brief (ADC       ) Number of instances */
+#define ADC_INSTS              { ADC }                        /**< \brief (ADC       ) Instances List */
+
+#define CCL                    ((Ccl *)0x42002C00U)           /**< \brief (CCL       ) Base Address */
+#define CCL_INST_NUM           1                              /**< \brief (CCL       ) Number of instances */
+#define CCL_INSTS              { CCL }                        /**< \brief (CCL       ) Instances List */
+
+#define DAC                    ((Dac *)0x42002000U)           /**< \brief (DAC       ) Base Address */
+#define DAC_INST_NUM           1                              /**< \brief (DAC       ) Number of instances */
+#define DAC_INSTS              { DAC }                        /**< \brief (DAC       ) Instances List */
+
+#define DMAC                   ((Dmac *)0x41006000U)          /**< \brief (DMAC      ) Base Address */
+#define DMAC_INST_NUM          1                              /**< \brief (DMAC      ) Number of instances */
+#define DMAC_INSTS             { DMAC }                       /**< \brief (DMAC      ) Instances List */
+
+#define DSU                    ((Dsu *)0x41002000U)           /**< \brief (DSU       ) Base Address */
+#define DSU_EXT                ((Dsu *)0x41002100U)           /**< \brief (DSU       ) Base Address */
+#define DSU_INST_NUM           1                              /**< \brief (DSU       ) Number of instances */
+#define DSU_INSTS              { DSU }                        /**< \brief (DSU       ) Instances List */
+
+#define EIC                    ((Eic *)0x40002800U)           /**< \brief (EIC       ) Base Address */
+#define EIC_INST_NUM           1                              /**< \brief (EIC       ) Number of instances */
+#define EIC_INSTS              { EIC }                        /**< \brief (EIC       ) Instances List */
+
+#define EVSYS                  ((Evsys *)0x42000000U)         /**< \brief (EVSYS     ) Base Address */
+#define EVSYS_INST_NUM         1                              /**< \brief (EVSYS     ) Number of instances */
+#define EVSYS_INSTS            { EVSYS }                      /**< \brief (EVSYS     ) Instances List */
+
+#define FREQM                  ((Freqm *)0x40002C00U)         /**< \brief (FREQM     ) Base Address */
+#define FREQM_INST_NUM         1                              /**< \brief (FREQM     ) Number of instances */
+#define FREQM_INSTS            { FREQM }                      /**< \brief (FREQM     ) Instances List */
+
+#define GCLK                   ((Gclk *)0x40001C00U)          /**< \brief (GCLK      ) Base Address */
+#define GCLK_INST_NUM          1                              /**< \brief (GCLK      ) Number of instances */
+#define GCLK_INSTS             { GCLK }                       /**< \brief (GCLK      ) Instances List */
+
+#define IDAU                   ((Idau *)0x41000000U)          /**< \brief (IDAU      ) Base Address */
+#define IDAU_INST_NUM          1                              /**< \brief (IDAU      ) Number of instances */
+#define IDAU_INSTS             { IDAU }                       /**< \brief (IDAU      ) Instances List */
+
+#define MCLK                   ((Mclk *)0x40000800U)          /**< \brief (MCLK      ) Base Address */
+#define MCLK_INST_NUM          1                              /**< \brief (MCLK      ) Number of instances */
+#define MCLK_INSTS             { MCLK }                       /**< \brief (MCLK      ) Instances List */
+
+#define NVMCTRL                ((Nvmctrl *)0x41004000U)       /**< \brief (NVMCTRL   ) Base Address */
+#define NVMCTRL_INST_NUM       1                              /**< \brief (NVMCTRL   ) Number of instances */
+#define NVMCTRL_INSTS          { NVMCTRL }                    /**< \brief (NVMCTRL   ) Instances List */
+
+#define OPAMP                  ((Opamp *)0x42003000U)         /**< \brief (OPAMP     ) Base Address */
+#define OPAMP_INST_NUM         1                              /**< \brief (OPAMP     ) Number of instances */
+#define OPAMP_INSTS            { OPAMP }                      /**< \brief (OPAMP     ) Instances List */
+
+#define OSCCTRL                ((Oscctrl *)0x40001000U)       /**< \brief (OSCCTRL   ) Base Address */
+#define OSCCTRL_INST_NUM       1                              /**< \brief (OSCCTRL   ) Number of instances */
+#define OSCCTRL_INSTS          { OSCCTRL }                    /**< \brief (OSCCTRL   ) Instances List */
+
+#define OSC32KCTRL             ((Osc32kctrl *)0x40001400U)    /**< \brief (OSC32KCTRL) Base Address */
+#define OSC32KCTRL_INST_NUM    1                              /**< \brief (OSC32KCTRL) Number of instances */
+#define OSC32KCTRL_INSTS       { OSC32KCTRL }                 /**< \brief (OSC32KCTRL) Instances List */
+
+#define PAC                    ((Pac *)0x40000000U)           /**< \brief (PAC       ) Base Address */
+#define PAC_INST_NUM           1                              /**< \brief (PAC       ) Number of instances */
+#define PAC_INSTS              { PAC }                        /**< \brief (PAC       ) Instances List */
+
+#define PM                     ((Pm *)0x40000400U)            /**< \brief (PM        ) Base Address */
+#define PM_INST_NUM            1                              /**< \brief (PM        ) Number of instances */
+#define PM_INSTS               { PM }                         /**< \brief (PM        ) Instances List */
+
+#define PORT                   ((Port *)0x40003000U)          /**< \brief (PORT      ) Base Address */
+#define PORT_IOBUS             ((Port *)0x60000000U)          /**< \brief (PORT      ) Base Address */
+#define PORT_INST_NUM          1                              /**< \brief (PORT      ) Number of instances */
+#define PORT_INSTS             { PORT }                       /**< \brief (PORT      ) Instances List */
+
+#define PTC                    ((Ptc *)0x42002400U)           /**< \brief (PTC       ) Base Address */
+#define PTC_INST_NUM           1                              /**< \brief (PTC       ) Number of instances */
+#define PTC_INSTS              { PTC }                        /**< \brief (PTC       ) Instances List */
+
+#define RSTC                   ((Rstc *)0x40000C00U)          /**< \brief (RSTC      ) Base Address */
+#define RSTC_INST_NUM          1                              /**< \brief (RSTC      ) Number of instances */
+#define RSTC_INSTS             { RSTC }                       /**< \brief (RSTC      ) Instances List */
+
+#define RTC                    ((Rtc *)0x40002400U)           /**< \brief (RTC       ) Base Address */
+#define RTC_INST_NUM           1                              /**< \brief (RTC       ) Number of instances */
+#define RTC_INSTS              { RTC }                        /**< \brief (RTC       ) Instances List */
+
+#define SERCOM0                ((Sercom *)0x42000400U)        /**< \brief (SERCOM0   ) Base Address */
+#define SERCOM1                ((Sercom *)0x42000800U)        /**< \brief (SERCOM1   ) Base Address */
+#define SERCOM2                ((Sercom *)0x42000C00U)        /**< \brief (SERCOM2   ) Base Address */
+#define SERCOM_INST_NUM        3                              /**< \brief (SERCOM    ) Number of instances */
+#define SERCOM_INSTS           { SERCOM0, SERCOM1, SERCOM2 }  /**< \brief (SERCOM    ) Instances List */
+
+#define SUPC                   ((Supc *)0x40001800U)          /**< \brief (SUPC      ) Base Address */
+#define SUPC_INST_NUM          1                              /**< \brief (SUPC      ) Number of instances */
+#define SUPC_INSTS             { SUPC }                       /**< \brief (SUPC      ) Instances List */
+
+#define TC0                    ((Tc *)0x42001000U)            /**< \brief (TC0       ) Base Address */
+#define TC1                    ((Tc *)0x42001400U)            /**< \brief (TC1       ) Base Address */
+#define TC2                    ((Tc *)0x42001800U)            /**< \brief (TC2       ) Base Address */
+#define TC_INST_NUM            3                              /**< \brief (TC        ) Number of instances */
+#define TC_INSTS               { TC0, TC1, TC2 }              /**< \brief (TC        ) Instances List */
+
+#define TRAM                   ((Tram *)0x42003400U)          /**< \brief (TRAM      ) Base Address */
+#define TRAM_INST_NUM          1                              /**< \brief (TRAM      ) Number of instances */
+#define TRAM_INSTS             { TRAM }                       /**< \brief (TRAM      ) Instances List */
+
+#define TRNG                   ((Trng *)0x42002800U)          /**< \brief (TRNG      ) Base Address */
+#define TRNG_INST_NUM          1                              /**< \brief (TRNG      ) Number of instances */
+#define TRNG_INSTS             { TRNG }                       /**< \brief (TRNG      ) Instances List */
+
+#define WDT                    ((Wdt *)0x40002000U)           /**< \brief (WDT       ) Base Address */
+#define WDT_INST_NUM           1                              /**< \brief (WDT       ) Number of instances */
+#define WDT_INSTS              { WDT }                        /**< \brief (WDT       ) Instances List */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Peripheral Base Address Definitions */
+
+/** \addtogroup SAML10E15A_pio Peripheral Pio Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   PIO DEFINITIONS FOR SAML10E15A*/
+/* ************************************************************************** */
+#include "pio/saml10e15a.h"
+/** @}  end of Peripheral Pio Definitions */
+
+/* ************************************************************************** */
+/*   MEMORY MAPPING DEFINITIONS FOR SAML10E15A*/
+/* ************************************************************************** */
+
+#define FLASH_SIZE               _U_(0x00008000)       /*   32kB Memory segment type: flash */
+#define FLASH_PAGE_SIZE          _U_(        64)
+#define FLASH_NB_OF_PAGES        _U_(       512)
+
+#define AUX_SIZE                 _U_(0x00000100)       /*    0kB Memory segment type: fuses */
+#define AUX_PAGE_SIZE            _U_(        64)
+#define AUX_NB_OF_PAGES          _U_(         4)
+
+#define BOCOR_SIZE               _U_(0x00000100)       /*    0kB Memory segment type: fuses */
+#define BOCOR_PAGE_SIZE          _U_(        64)
+#define BOCOR_NB_OF_PAGES        _U_(         4)
+
+#define DATAFLASH_SIZE           _U_(0x00000800)       /*    2kB Memory segment type: flash */
+#define DATAFLASH_PAGE_SIZE      _U_(        64)
+#define DATAFLASH_NB_OF_PAGES    _U_(        32)
+
+#define SW_CALIB_SIZE            _U_(0x00000008)       /*    0kB Memory segment type: fuses */
+#define TEMP_LOG_SIZE            _U_(0x00000008)       /*    0kB Memory segment type: fuses */
+#define USER_PAGE_SIZE           _U_(0x00000100)       /*    0kB Memory segment type: user_page */
+#define USER_PAGE_PAGE_SIZE      _U_(        64)
+#define USER_PAGE_NB_OF_PAGES    _U_(         4)
+
+#define HSRAM_SIZE               _U_(0x00002000)       /*    8kB Memory segment type: ram */
+#define HPB0_SIZE                _U_(0x00008000)       /*   32kB Memory segment type: io */
+#define HPB1_SIZE                _U_(0x00010000)       /*   64kB Memory segment type: io */
+#define HPB2_SIZE                _U_(0x00004000)       /*   16kB Memory segment type: io */
+#define PPB_SIZE                 _U_(0x00100000)       /* 1024kB Memory segment type: io */
+#define SCS_SIZE                 _U_(0x00001000)       /*    4kB Memory segment type: io */
+#define PERIPHERALS_SIZE         _U_(0x20000000)       /* 524288kB Memory segment type: io */
+
+#define FLASH_ADDR               _U_(0x00000000)       /**< FLASH base address (type: flash)*/
+#define AUX_ADDR                 _U_(0x00806000)       /**< AUX base address (type: fuses)*/
+#define BOCOR_ADDR               _U_(0x0080c000)       /**< BOCOR base address (type: fuses)*/
+#define DATAFLASH_ADDR           _U_(0x00400000)       /**< DATAFLASH base address (type: flash)*/
+#define SW_CALIB_ADDR            _U_(0x00806020)       /**< SW_CALIB base address (type: fuses)*/
+#define TEMP_LOG_ADDR            _U_(0x00806038)       /**< TEMP_LOG base address (type: fuses)*/
+#define USER_PAGE_ADDR           _U_(0x00804000)       /**< USER_PAGE base address (type: user_page)*/
+#define HSRAM_ADDR               _U_(0x20000000)       /**< HSRAM base address (type: ram)*/
+#define HPB0_ADDR                _U_(0x40000000)       /**< HPB0 base address (type: io)*/
+#define HPB1_ADDR                _U_(0x41000000)       /**< HPB1 base address (type: io)*/
+#define HPB2_ADDR                _U_(0x42000000)       /**< HPB2 base address (type: io)*/
+#define PPB_ADDR                 _U_(0xe0000000)       /**< PPB base address (type: io)*/
+#define SCS_ADDR                 _U_(0xe000e000)       /**< SCS base address (type: io)*/
+#define PERIPHERALS_ADDR         _U_(0x40000000)       /**< PERIPHERALS base address (type: io)*/
+
+#define NVMCTRL_AUX              AUX_ADDR              /**< \brief \deprecated Old style definition. Use AUX_ADDR instead */
+#define NVMCTRL_BOCOR            BOCOR_ADDR            /**< \brief \deprecated Old style definition. Use BOCOR_ADDR instead */
+#define NVMCTRL_DATAFLASH        DATAFLASH_ADDR        /**< \brief \deprecated Old style definition. Use DATAFLASH_ADDR instead */
+#define NVMCTRL_SW_CALIB         SW_CALIB_ADDR         /**< \brief \deprecated Old style definition. Use SW_CALIB_ADDR instead */
+#define NVMCTRL_TEMP_LOG         TEMP_LOG_ADDR         /**< \brief \deprecated Old style definition. Use TEMP_LOG_ADDR instead */
+#define NVMCTRL_USER             USER_PAGE_ADDR        /**< \brief \deprecated Old style definition. Use USER_PAGE_ADDR instead */
+
+/* ************************************************************************** */
+/**  DEVICE SIGNATURES FOR SAML10E15A */
+/* ************************************************************************** */
+#define DSU_DID                  _UL_(0X20840001)
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAML10E15A */
+/* ************************************************************************** */
+
+/* ************************************************************************** */
+/** Event Generator IDs for SAML10E15A */
+/* ************************************************************************** */
+#define EVENT_ID_GEN_OSCCTRL_XOSC_FAIL                    1 /**< ID for OSCCTRL event generator XOSC_FAIL */
+#define EVENT_ID_GEN_OSC32KCTRL_XOSC32K_FAIL              2 /**< ID for OSC32KCTRL event generator XOSC32K_FAIL */
+#define EVENT_ID_GEN_SUPC_BOD33DET                        3 /**< ID for SUPC event generator BOD33DET */
+#define EVENT_ID_GEN_RTC_PER_0                            4 /**< ID for RTC event generator PER_0 */
+#define EVENT_ID_GEN_RTC_PER_1                            5 /**< ID for RTC event generator PER_1 */
+#define EVENT_ID_GEN_RTC_PER_2                            6 /**< ID for RTC event generator PER_2 */
+#define EVENT_ID_GEN_RTC_PER_3                            7 /**< ID for RTC event generator PER_3 */
+#define EVENT_ID_GEN_RTC_PER_4                            8 /**< ID for RTC event generator PER_4 */
+#define EVENT_ID_GEN_RTC_PER_5                            9 /**< ID for RTC event generator PER_5 */
+#define EVENT_ID_GEN_RTC_PER_6                           10 /**< ID for RTC event generator PER_6 */
+#define EVENT_ID_GEN_RTC_PER_7                           11 /**< ID for RTC event generator PER_7 */
+#define EVENT_ID_GEN_RTC_CMP_0                           12 /**< ID for RTC event generator CMP_0 */
+#define EVENT_ID_GEN_RTC_CMP_1                           13 /**< ID for RTC event generator CMP_1 */
+#define EVENT_ID_GEN_RTC_TAMPER                          14 /**< ID for RTC event generator TAMPER */
+#define EVENT_ID_GEN_RTC_OVF                             15 /**< ID for RTC event generator OVF */
+#define EVENT_ID_GEN_RTC_PERD                            16 /**< ID for RTC event generator PERD */
+#define EVENT_ID_GEN_EIC_EXTINT_0                        17 /**< ID for EIC event generator EXTINT_0 */
+#define EVENT_ID_GEN_EIC_EXTINT_1                        18 /**< ID for EIC event generator EXTINT_1 */
+#define EVENT_ID_GEN_EIC_EXTINT_2                        19 /**< ID for EIC event generator EXTINT_2 */
+#define EVENT_ID_GEN_EIC_EXTINT_3                        20 /**< ID for EIC event generator EXTINT_3 */
+#define EVENT_ID_GEN_EIC_EXTINT_4                        21 /**< ID for EIC event generator EXTINT_4 */
+#define EVENT_ID_GEN_EIC_EXTINT_5                        22 /**< ID for EIC event generator EXTINT_5 */
+#define EVENT_ID_GEN_EIC_EXTINT_6                        23 /**< ID for EIC event generator EXTINT_6 */
+#define EVENT_ID_GEN_EIC_EXTINT_7                        24 /**< ID for EIC event generator EXTINT_7 */
+#define EVENT_ID_GEN_DMAC_CH_0                           25 /**< ID for DMAC event generator CH_0 */
+#define EVENT_ID_GEN_DMAC_CH_1                           26 /**< ID for DMAC event generator CH_1 */
+#define EVENT_ID_GEN_DMAC_CH_2                           27 /**< ID for DMAC event generator CH_2 */
+#define EVENT_ID_GEN_DMAC_CH_3                           28 /**< ID for DMAC event generator CH_3 */
+#define EVENT_ID_GEN_TC0_OVF                             29 /**< ID for TC0 event generator OVF */
+#define EVENT_ID_GEN_TC0_MCX_0                           30 /**< ID for TC0 event generator MCX_0 */
+#define EVENT_ID_GEN_TC0_MCX_1                           31 /**< ID for TC0 event generator MCX_1 */
+#define EVENT_ID_GEN_TC1_OVF                             32 /**< ID for TC1 event generator OVF */
+#define EVENT_ID_GEN_TC1_MCX_0                           33 /**< ID for TC1 event generator MCX_0 */
+#define EVENT_ID_GEN_TC1_MCX_1                           34 /**< ID for TC1 event generator MCX_1 */
+#define EVENT_ID_GEN_TC2_OVF                             35 /**< ID for TC2 event generator OVF */
+#define EVENT_ID_GEN_TC2_MCX_0                           36 /**< ID for TC2 event generator MCX_0 */
+#define EVENT_ID_GEN_TC2_MCX_1                           37 /**< ID for TC2 event generator MCX_1 */
+#define EVENT_ID_GEN_ADC_RESRDY                          38 /**< ID for ADC event generator RESRDY */
+#define EVENT_ID_GEN_ADC_WINMON                          39 /**< ID for ADC event generator WINMON */
+#define EVENT_ID_GEN_AC_COMP_0                           40 /**< ID for AC event generator COMP_0 */
+#define EVENT_ID_GEN_AC_COMP_1                           41 /**< ID for AC event generator COMP_1 */
+#define EVENT_ID_GEN_AC_WIN_0                            42 /**< ID for AC event generator WIN_0 */
+#define EVENT_ID_GEN_DAC_EMPTY                           43 /**< ID for DAC event generator EMPTY */
+#define EVENT_ID_GEN_TRNG_READY                          46 /**< ID for TRNG event generator READY */
+#define EVENT_ID_GEN_CCL_LUTOUT_0                        47 /**< ID for CCL event generator LUTOUT_0 */
+#define EVENT_ID_GEN_CCL_LUTOUT_1                        48 /**< ID for CCL event generator LUTOUT_1 */
+#define EVENT_ID_GEN_PAC_ERR                             49 /**< ID for PAC event generator ERR */
+
+/* ************************************************************************** */
+/** Event User IDs for SAML10E15A */
+/* ************************************************************************** */
+#define EVENT_ID_USER_OSCCTRL_TUNE                        0 /**< ID for OSCCTRL event user TUNE */
+#define EVENT_ID_USER_RTC_TAMPER                          1 /**< ID for RTC event user TAMPER */
+#define EVENT_ID_USER_NVMCTRL_PAGEW                       2 /**< ID for NVMCTRL event user PAGEW */
+#define EVENT_ID_USER_PORT_EV_0                           3 /**< ID for PORT event user EV_0 */
+#define EVENT_ID_USER_PORT_EV_1                           4 /**< ID for PORT event user EV_1 */
+#define EVENT_ID_USER_PORT_EV_2                           5 /**< ID for PORT event user EV_2 */
+#define EVENT_ID_USER_PORT_EV_3                           6 /**< ID for PORT event user EV_3 */
+#define EVENT_ID_USER_DMAC_CH_0                           7 /**< ID for DMAC event user CH_0 */
+#define EVENT_ID_USER_DMAC_CH_1                           8 /**< ID for DMAC event user CH_1 */
+#define EVENT_ID_USER_DMAC_CH_2                           9 /**< ID for DMAC event user CH_2 */
+#define EVENT_ID_USER_DMAC_CH_3                          10 /**< ID for DMAC event user CH_3 */
+#define EVENT_ID_USER_TC0_EVU                            11 /**< ID for TC0 event user EVU */
+#define EVENT_ID_USER_TC1_EVU                            12 /**< ID for TC1 event user EVU */
+#define EVENT_ID_USER_TC2_EVU                            13 /**< ID for TC2 event user EVU */
+#define EVENT_ID_USER_ADC_START                          14 /**< ID for ADC event user START */
+#define EVENT_ID_USER_ADC_SYNC                           15 /**< ID for ADC event user SYNC */
+#define EVENT_ID_USER_AC_SOC_0                           16 /**< ID for AC event user SOC_0 */
+#define EVENT_ID_USER_AC_SOC_1                           17 /**< ID for AC event user SOC_1 */
+#define EVENT_ID_USER_DAC_START                          18 /**< ID for DAC event user START */
+#define EVENT_ID_USER_CCL_LUTIN_0                        21 /**< ID for CCL event user LUTIN_0 */
+#define EVENT_ID_USER_CCL_LUTIN_1                        22 /**< ID for CCL event user LUTIN_1 */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @}  end of SAML10E15A definitions */
+
+
+#endif /* _SAML10E15A_H_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/saml10e16a.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/saml10e16a.h
@@ -1,0 +1,801 @@
+/**
+ * \file
+ *
+ * \brief Header file for ATSAML10E16A
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:50Z */
+#ifndef _SAML10E16A_H_
+#define _SAML10E16A_H_
+
+/** \addtogroup SAML10E16A_definitions SAML10E16A definitions
+  This file defines all structures and symbols for SAML10E16A:
+    - registers and bitfields
+    - peripheral base address
+    - peripheral ID
+    - PIO definitions
+ *  @{
+ */
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/** \defgroup Atmel_glob_defs Atmel Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+
+    \remark
+    CMSIS core has a syntax that differs from this using i.e. __I, __O, or __IO followed by 'uint<size>_t' respective types.
+    Default the header files will follow the CMSIS core syntax.
+ *  @{
+ */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+
+/* IO definitions (access restrictions to peripheral registers) */
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+
+#define CAST(type, value) ((type *)(value)) /**< Pointer Type Conversion Macro for C/C++ */
+#define REG_ACCESS(type, address) (*(type*)(address)) /**< C code: Register value */
+#else /* Assembler */
+#define CAST(type, value) (value) /**< Pointer Type Conversion Macro for Assembler */
+#define REG_ACCESS(type, address) (address) /**< Assembly code: Register address */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !defined(SKIP_INTEGER_LITERALS)
+
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x) x ## U    /**< C code: Unsigned integer literal constant value */
+#define _L_(x) x ## L    /**< C code: Long integer literal constant value */
+#define _UL_(x) x ## UL  /**< C code: Unsigned Long integer literal constant value */
+
+#else /* Assembler */
+
+#define _U_(x) x    /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x) x    /**< Assembler: Long integer literal constant value */
+#define _UL_(x) x   /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* SKIP_INTEGER_LITERALS */
+/** @}  end of Atmel Global Defines */
+
+/** \addtogroup SAML10E16A_cmsis CMSIS Definitions
+ *  @{
+ */
+/* ************************************************************************** */
+/*   CMSIS DEFINITIONS FOR SAML10E16A */
+/* ************************************************************************** */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+/******  CORTEX-M23 Processor Exceptions Numbers ******************************/
+  Reset_IRQn                = -15, /**< 1   Reset Vector, invoked on Power up and warm reset  */
+  NonMaskableInt_IRQn       = -14, /**< 2   Non maskable Interrupt, cannot be stopped or preempted  */
+  HardFault_IRQn            = -13, /**< 3   Hard Fault, all classes of Fault     */
+  SVCall_IRQn               = -5 , /**< 11  System Service Call via SVC instruction  */
+  PendSV_IRQn               = -2 , /**< 14  Pendable request for system service  */
+  SysTick_IRQn              = -1 , /**< 15  System Tick Timer                    */
+/******  SAML10E16A specific Interrupt Numbers ***********************************/
+  SYSTEM_IRQn               = 0  , /**< 0   SAML10E16A Main Clock (MCLK)        */
+  WDT_IRQn                  = 1  , /**< 1   SAML10E16A Watchdog Timer (WDT)     */
+  RTC_IRQn                  = 2  , /**< 2   SAML10E16A Real-Time Counter (RTC)  */
+  EIC_0_IRQn                = 3  , /**< 3   SAML10E16A External Interrupt Controller (EIC) */
+  EIC_1_IRQn                = 4  , /**< 4   SAML10E16A External Interrupt Controller (EIC) */
+  EIC_2_IRQn                = 5  , /**< 5   SAML10E16A External Interrupt Controller (EIC) */
+  EIC_3_IRQn                = 6  , /**< 6   SAML10E16A External Interrupt Controller (EIC) */
+  EIC_OTHER_IRQn            = 7  , /**< 7   SAML10E16A External Interrupt Controller (EIC) */
+  FREQM_IRQn                = 8  , /**< 8   SAML10E16A Frequency Meter (FREQM)  */
+  NVMCTRL_IRQn              = 9  , /**< 9   SAML10E16A Non-Volatile Memory Controller (NVMCTRL) */
+  PORT_IRQn                 = 10 , /**< 10  SAML10E16A Port Module (PORT)       */
+  DMAC_0_IRQn               = 11 , /**< 11  SAML10E16A Direct Memory Access Controller (DMAC) */
+  DMAC_1_IRQn               = 12 , /**< 12  SAML10E16A Direct Memory Access Controller (DMAC) */
+  DMAC_2_IRQn               = 13 , /**< 13  SAML10E16A Direct Memory Access Controller (DMAC) */
+  DMAC_3_IRQn               = 14 , /**< 14  SAML10E16A Direct Memory Access Controller (DMAC) */
+  DMAC_OTHER_IRQn           = 15 , /**< 15  SAML10E16A Direct Memory Access Controller (DMAC) */
+  EVSYS_0_IRQn              = 16 , /**< 16  SAML10E16A Event System Interface (EVSYS) */
+  EVSYS_1_IRQn              = 17 , /**< 17  SAML10E16A Event System Interface (EVSYS) */
+  EVSYS_2_IRQn              = 18 , /**< 18  SAML10E16A Event System Interface (EVSYS) */
+  EVSYS_3_IRQn              = 19 , /**< 19  SAML10E16A Event System Interface (EVSYS) */
+  EVSYS_NSCHK_IRQn          = 20 , /**< 20  SAML10E16A Event System Interface (EVSYS) */
+  PAC_IRQn                  = 21 , /**< 21  SAML10E16A Peripheral Access Controller (PAC) */
+  SERCOM0_0_IRQn            = 22 , /**< 22  SAML10E16A Serial Communication Interface (SERCOM0) */
+  SERCOM0_1_IRQn            = 23 , /**< 23  SAML10E16A Serial Communication Interface (SERCOM0) */
+  SERCOM0_2_IRQn            = 24 , /**< 24  SAML10E16A Serial Communication Interface (SERCOM0) */
+  SERCOM0_OTHER_IRQn        = 25 , /**< 25  SAML10E16A Serial Communication Interface (SERCOM0) */
+  SERCOM1_0_IRQn            = 26 , /**< 26  SAML10E16A Serial Communication Interface (SERCOM1) */
+  SERCOM1_1_IRQn            = 27 , /**< 27  SAML10E16A Serial Communication Interface (SERCOM1) */
+  SERCOM1_2_IRQn            = 28 , /**< 28  SAML10E16A Serial Communication Interface (SERCOM1) */
+  SERCOM1_OTHER_IRQn        = 29 , /**< 29  SAML10E16A Serial Communication Interface (SERCOM1) */
+  SERCOM2_0_IRQn            = 30 , /**< 30  SAML10E16A Serial Communication Interface (SERCOM2) */
+  SERCOM2_1_IRQn            = 31 , /**< 31  SAML10E16A Serial Communication Interface (SERCOM2) */
+  SERCOM2_2_IRQn            = 32 , /**< 32  SAML10E16A Serial Communication Interface (SERCOM2) */
+  SERCOM2_OTHER_IRQn        = 33 , /**< 33  SAML10E16A Serial Communication Interface (SERCOM2) */
+  TC0_IRQn                  = 34 , /**< 34  SAML10E16A Basic Timer Counter (TC0) */
+  TC1_IRQn                  = 35 , /**< 35  SAML10E16A Basic Timer Counter (TC1) */
+  TC2_IRQn                  = 36 , /**< 36  SAML10E16A Basic Timer Counter (TC2) */
+  ADC_OTHER_IRQn            = 37 , /**< 37  SAML10E16A Analog Digital Converter (ADC) */
+  ADC_RESRDY_IRQn           = 38 , /**< 38  SAML10E16A Analog Digital Converter (ADC) */
+  AC_IRQn                   = 39 , /**< 39  SAML10E16A Analog Comparators (AC)  */
+  DAC_UNDERRUN_A_IRQn       = 40 , /**< 40  SAML10E16A Digital Analog Converter (DAC) */
+  DAC_EMPTY_IRQn            = 41 , /**< 41  SAML10E16A Digital Analog Converter (DAC) */
+  PTC_IRQn                  = 42 , /**< 42  SAML10E16A Peripheral Touch Controller (PTC) */
+  TRNG_IRQn                 = 43 , /**< 43  SAML10E16A True Random Generator (TRNG) */
+  TRAM_IRQn                 = 44 , /**< 44  SAML10E16A TrustRAM (TRAM)          */
+
+  PERIPH_COUNT_IRQn        = 45  /**< Number of peripheral IDs */
+} IRQn_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;                        /* -15 Reset Vector, invoked on Power up and warm reset  */
+  void* pfnNonMaskableInt_Handler;               /* -14 Non maskable Interrupt, cannot be stopped or preempted  */
+  void* pfnHardFault_Handler;                    /* -13 Hard Fault, all classes of Fault     */
+  void* pvReservedC12;
+  void* pvReservedC11;
+  void* pvReservedC10;
+  void* pvReservedC9;
+  void* pvReservedC8;
+  void* pvReservedC7;
+  void* pvReservedC6;
+  void* pfnSVCall_Handler;                       /*  -5 System Service Call via SVC instruction  */
+  void* pvReservedC4;
+  void* pvReservedC3;
+  void* pfnPendSV_Handler;                       /*  -2 Pendable request for system service  */
+  void* pfnSysTick_Handler;                      /*  -1 System Tick Timer                    */
+
+
+  /* Peripheral handlers */
+  void* pfnSYSTEM_Handler;                       /* 0   SAML10E16A Main Clock (MCLK)   */
+  void* pfnWDT_Handler;                          /* 1   SAML10E16A Watchdog Timer (WDT) */
+  void* pfnRTC_Handler;                          /* 2   SAML10E16A Real-Time Counter (RTC) */
+  void* pfnEIC_0_Handler;                        /* 3   SAML10E16A External Interrupt Controller (EIC) */
+  void* pfnEIC_1_Handler;                        /* 4   SAML10E16A External Interrupt Controller (EIC) */
+  void* pfnEIC_2_Handler;                        /* 5   SAML10E16A External Interrupt Controller (EIC) */
+  void* pfnEIC_3_Handler;                        /* 6   SAML10E16A External Interrupt Controller (EIC) */
+  void* pfnEIC_OTHER_Handler;                    /* 7   SAML10E16A External Interrupt Controller (EIC) */
+  void* pfnFREQM_Handler;                        /* 8   SAML10E16A Frequency Meter (FREQM) */
+  void* pfnNVMCTRL_Handler;                      /* 9   SAML10E16A Non-Volatile Memory Controller (NVMCTRL) */
+  void* pfnPORT_Handler;                         /* 10  SAML10E16A Port Module (PORT)  */
+  void* pfnDMAC_0_Handler;                       /* 11  SAML10E16A Direct Memory Access Controller (DMAC) */
+  void* pfnDMAC_1_Handler;                       /* 12  SAML10E16A Direct Memory Access Controller (DMAC) */
+  void* pfnDMAC_2_Handler;                       /* 13  SAML10E16A Direct Memory Access Controller (DMAC) */
+  void* pfnDMAC_3_Handler;                       /* 14  SAML10E16A Direct Memory Access Controller (DMAC) */
+  void* pfnDMAC_OTHER_Handler;                   /* 15  SAML10E16A Direct Memory Access Controller (DMAC) */
+  void* pfnEVSYS_0_Handler;                      /* 16  SAML10E16A Event System Interface (EVSYS) */
+  void* pfnEVSYS_1_Handler;                      /* 17  SAML10E16A Event System Interface (EVSYS) */
+  void* pfnEVSYS_2_Handler;                      /* 18  SAML10E16A Event System Interface (EVSYS) */
+  void* pfnEVSYS_3_Handler;                      /* 19  SAML10E16A Event System Interface (EVSYS) */
+  void* pfnEVSYS_NSCHK_Handler;                  /* 20  SAML10E16A Event System Interface (EVSYS) */
+  void* pfnPAC_Handler;                          /* 21  SAML10E16A Peripheral Access Controller (PAC) */
+  void* pfnSERCOM0_0_Handler;                    /* 22  SAML10E16A Serial Communication Interface (SERCOM0) */
+  void* pfnSERCOM0_1_Handler;                    /* 23  SAML10E16A Serial Communication Interface (SERCOM0) */
+  void* pfnSERCOM0_2_Handler;                    /* 24  SAML10E16A Serial Communication Interface (SERCOM0) */
+  void* pfnSERCOM0_OTHER_Handler;                /* 25  SAML10E16A Serial Communication Interface (SERCOM0) */
+  void* pfnSERCOM1_0_Handler;                    /* 26  SAML10E16A Serial Communication Interface (SERCOM1) */
+  void* pfnSERCOM1_1_Handler;                    /* 27  SAML10E16A Serial Communication Interface (SERCOM1) */
+  void* pfnSERCOM1_2_Handler;                    /* 28  SAML10E16A Serial Communication Interface (SERCOM1) */
+  void* pfnSERCOM1_OTHER_Handler;                /* 29  SAML10E16A Serial Communication Interface (SERCOM1) */
+  void* pfnSERCOM2_0_Handler;                    /* 30  SAML10E16A Serial Communication Interface (SERCOM2) */
+  void* pfnSERCOM2_1_Handler;                    /* 31  SAML10E16A Serial Communication Interface (SERCOM2) */
+  void* pfnSERCOM2_2_Handler;                    /* 32  SAML10E16A Serial Communication Interface (SERCOM2) */
+  void* pfnSERCOM2_OTHER_Handler;                /* 33  SAML10E16A Serial Communication Interface (SERCOM2) */
+  void* pfnTC0_Handler;                          /* 34  SAML10E16A Basic Timer Counter (TC0) */
+  void* pfnTC1_Handler;                          /* 35  SAML10E16A Basic Timer Counter (TC1) */
+  void* pfnTC2_Handler;                          /* 36  SAML10E16A Basic Timer Counter (TC2) */
+  void* pfnADC_OTHER_Handler;                    /* 37  SAML10E16A Analog Digital Converter (ADC) */
+  void* pfnADC_RESRDY_Handler;                   /* 38  SAML10E16A Analog Digital Converter (ADC) */
+  void* pfnAC_Handler;                           /* 39  SAML10E16A Analog Comparators (AC) */
+  void* pfnDAC_UNDERRUN_A_Handler;               /* 40  SAML10E16A Digital Analog Converter (DAC) */
+  void* pfnDAC_EMPTY_Handler;                    /* 41  SAML10E16A Digital Analog Converter (DAC) */
+  void* pfnPTC_Handler;                          /* 42  SAML10E16A Peripheral Touch Controller (PTC) */
+  void* pfnTRNG_Handler;                         /* 43  SAML10E16A True Random Generator (TRNG) */
+  void* pfnTRAM_Handler;                         /* 44  SAML10E16A TrustRAM (TRAM)     */
+} DeviceVectors;
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define pfnMemManage_Handler      pfnMemoryManagement_Handler     /**< \deprecated  Backward compatibility for ASF */
+#define pfnDebugMon_Handler       pfnDebugMonitor_Handler         /**< \deprecated  Backward compatibility for ASF */
+#define pfnNMI_Handler            pfnNonMaskableInt_Handler       /**< \deprecated  Backward compatibility for ASF */
+#define pfnSVC_Handler            pfnSVCall_Handler               /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if !defined DONT_USE_PREDEFINED_CORE_HANDLERS
+
+/* CORTEX-M23 core handlers */
+void Reset_Handler                 ( void );
+void NonMaskableInt_Handler        ( void );
+void HardFault_Handler             ( void );
+void SVCall_Handler                ( void );
+void PendSV_Handler                ( void );
+void SysTick_Handler               ( void );
+#endif /* DONT_USE_PREDEFINED_CORE_HANDLERS */
+
+#if !defined DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS
+
+/* Peripherals handlers */
+void AC_Handler                    ( void );
+void ADC_OTHER_Handler             ( void );
+void ADC_RESRDY_Handler            ( void );
+void DAC_EMPTY_Handler             ( void );
+void DAC_UNDERRUN_A_Handler        ( void );
+void DMAC_0_Handler                ( void );
+void DMAC_1_Handler                ( void );
+void DMAC_2_Handler                ( void );
+void DMAC_3_Handler                ( void );
+void DMAC_OTHER_Handler            ( void );
+void EIC_0_Handler                 ( void );
+void EIC_1_Handler                 ( void );
+void EIC_2_Handler                 ( void );
+void EIC_3_Handler                 ( void );
+void EIC_OTHER_Handler             ( void );
+void EVSYS_0_Handler               ( void );
+void EVSYS_1_Handler               ( void );
+void EVSYS_2_Handler               ( void );
+void EVSYS_3_Handler               ( void );
+void EVSYS_NSCHK_Handler           ( void );
+void FREQM_Handler                 ( void );
+void NVMCTRL_Handler               ( void );
+void PAC_Handler                   ( void );
+void PORT_Handler                  ( void );
+void PTC_Handler                   ( void );
+void RTC_Handler                   ( void );
+void SERCOM0_0_Handler             ( void );
+void SERCOM0_1_Handler             ( void );
+void SERCOM0_2_Handler             ( void );
+void SERCOM0_OTHER_Handler         ( void );
+void SERCOM1_0_Handler             ( void );
+void SERCOM1_1_Handler             ( void );
+void SERCOM1_2_Handler             ( void );
+void SERCOM1_OTHER_Handler         ( void );
+void SERCOM2_0_Handler             ( void );
+void SERCOM2_1_Handler             ( void );
+void SERCOM2_2_Handler             ( void );
+void SERCOM2_OTHER_Handler         ( void );
+void SYSTEM_Handler                ( void );
+void TC0_Handler                   ( void );
+void TC1_Handler                   ( void );
+void TC2_Handler                   ( void );
+void TRAM_Handler                  ( void );
+void TRNG_Handler                  ( void );
+void WDT_Handler                   ( void );
+#endif /* DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS */
+
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define MemManage_Handler         MemoryManagement_Handler        /**< \deprecated  Backward compatibility for ASF */
+#define DebugMon_Handler          DebugMonitor_Handler            /**< \deprecated  Backward compatibility for ASF */
+#define NMI_Handler               NonMaskableInt_Handler          /**< \deprecated  Backward compatibility for ASF */
+#define SVC_Handler               SVCall_Handler                  /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+
+/*
+ * \brief Configuration of the CORTEX-M23 Processor and Core Peripherals
+ */
+
+#define NUM_IRQ                       45 /**< Number of interrupt request lines                                         */
+#define __ARMv8MBL_REV            0x0000 /**< Cortex-M23 Core Revision                                                  */
+#define __ETM_PRESENT                  0 /**< ETM present or not                                                        */
+#define __FPU_PRESENT                  0 /**< FPU present or not                                                        */
+#define __MPU_PRESENT                  1 /**< MPU present or not                                                        */
+#define __MTB_PRESENT                  0 /**< MTB present or not                                                        */
+#define __NVIC_PRIO_BITS               2 /**< Number of Bits used for Priority Levels                                   */
+#define __SAU_PRESENT                  0 /**< SAU present or not                                                        */
+#define __SEC_ENABLED                  0 /**< TrustZone-M enabled or not                                                */
+#define __VTOR_PRESENT                 1 /**< Vector Table Offset Register present or not                               */
+#define __Vendor_SysTickConfig         0 /**< Set to 1 if different SysTick Config is used                              */
+#define __ARCH_ARM                     1
+#define __ARCH_ARM_CORTEX_M            1
+#define __DEVICE_IS_SAM                1
+
+/*
+ * \brief CMSIS includes
+ */
+#include <core_cm23.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_saml10.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/** @}  end of SAML10E16A_cmsis CMSIS Definitions */
+
+/** \defgroup SAML10E16A_api Peripheral Software API
+ *  @{
+ */
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAML10E16A */
+/* ************************************************************************** */
+#include "component/ac.h"
+#include "component/adc.h"
+#include "component/ccl.h"
+#include "component/dac.h"
+#include "component/dmac.h"
+#include "component/dsu.h"
+#include "component/eic.h"
+#include "component/evsys.h"
+#include "component/freqm.h"
+#include "component/gclk.h"
+#include "component/idau.h"
+#include "component/mclk.h"
+#include "component/nvmctrl.h"
+#include "component/opamp.h"
+#include "component/oscctrl.h"
+#include "component/osc32kctrl.h"
+#include "component/pac.h"
+#include "component/pm.h"
+#include "component/port.h"
+#include "component/ptc.h"
+#include "component/rstc.h"
+#include "component/rtc.h"
+#include "component/sercom.h"
+#include "component/supc.h"
+#include "component/tc.h"
+#include "component/tram.h"
+#include "component/trng.h"
+#include "component/wdt.h"
+/** @}  end of Peripheral Software API */
+
+/** \defgroup SAML10E16A_reg Registers Access Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   REGISTER ACCESS DEFINITIONS FOR SAML10E16A */
+/* ************************************************************************** */
+#include "instance/ac.h"
+#include "instance/adc.h"
+#include "instance/ccl.h"
+#include "instance/dac.h"
+#include "instance/dmac.h"
+#include "instance/dsu.h"
+#include "instance/eic.h"
+#include "instance/evsys.h"
+#include "instance/freqm.h"
+#include "instance/gclk.h"
+#include "instance/idau.h"
+#include "instance/mclk.h"
+#include "instance/nvmctrl.h"
+#include "instance/opamp.h"
+#include "instance/oscctrl.h"
+#include "instance/osc32kctrl.h"
+#include "instance/pac.h"
+#include "instance/pm.h"
+#include "instance/port.h"
+#include "instance/ptc.h"
+#include "instance/rstc.h"
+#include "instance/rtc.h"
+#include "instance/sercom0.h"
+#include "instance/sercom1.h"
+#include "instance/sercom2.h"
+#include "instance/supc.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tram.h"
+#include "instance/trng.h"
+#include "instance/wdt.h"
+/** @}  end of Registers Access Definitions */
+
+/** \addtogroup SAML10E16A_id Peripheral Ids Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*  PERIPHERAL ID DEFINITIONS FOR SAML10E16A */
+/* ************************************************************************** */
+#define ID_PAC          (  0) /**< \brief Peripheral Access Controller (PAC) */
+#define ID_PM           (  1) /**< \brief Power Manager (PM) */
+#define ID_MCLK         (  2) /**< \brief Main Clock (MCLK) */
+#define ID_RSTC         (  3) /**< \brief Reset Controller (RSTC) */
+#define ID_OSCCTRL      (  4) /**< \brief Oscillators Control (OSCCTRL) */
+#define ID_OSC32KCTRL   (  5) /**< \brief 32k Oscillators Control (OSC32KCTRL) */
+#define ID_SUPC         (  6) /**< \brief Supply Controller (SUPC) */
+#define ID_GCLK         (  7) /**< \brief Generic Clock Generator (GCLK) */
+#define ID_WDT          (  8) /**< \brief Watchdog Timer (WDT) */
+#define ID_RTC          (  9) /**< \brief Real-Time Counter (RTC) */
+#define ID_EIC          ( 10) /**< \brief External Interrupt Controller (EIC) */
+#define ID_FREQM        ( 11) /**< \brief Frequency Meter (FREQM) */
+#define ID_PORT         ( 12) /**< \brief Port Module (PORT) */
+#define ID_AC           ( 13) /**< \brief Analog Comparators (AC) */
+#define ID_IDAU         ( 32) /**< \brief Implementation Defined Attribution Unit (IDAU) */
+#define ID_DSU          ( 33) /**< \brief Device Service Unit (DSU) */
+#define ID_NVMCTRL      ( 34) /**< \brief Non-Volatile Memory Controller (NVMCTRL) */
+#define ID_DMAC         ( 35) /**< \brief Direct Memory Access Controller (DMAC) */
+#define ID_EVSYS        ( 64) /**< \brief Event System Interface (EVSYS) */
+#define ID_SERCOM0      ( 65) /**< \brief Serial Communication Interface (SERCOM0) */
+#define ID_SERCOM1      ( 66) /**< \brief Serial Communication Interface (SERCOM1) */
+#define ID_SERCOM2      ( 67) /**< \brief Serial Communication Interface (SERCOM2) */
+#define ID_TC0          ( 68) /**< \brief Basic Timer Counter (TC0) */
+#define ID_TC1          ( 69) /**< \brief Basic Timer Counter (TC1) */
+#define ID_TC2          ( 70) /**< \brief Basic Timer Counter (TC2) */
+#define ID_ADC          ( 71) /**< \brief Analog Digital Converter (ADC) */
+#define ID_DAC          ( 72) /**< \brief Digital Analog Converter (DAC) */
+#define ID_PTC          ( 73) /**< \brief Peripheral Touch Controller (PTC) */
+#define ID_TRNG         ( 74) /**< \brief True Random Generator (TRNG) */
+#define ID_CCL          ( 75) /**< \brief Configurable Custom Logic (CCL) */
+#define ID_OPAMP        ( 76) /**< \brief Operational Amplifier (OPAMP) */
+#define ID_TRAM         ( 77) /**< \brief TrustRAM (TRAM) */
+
+#define ID_PERIPH_COUNT ( 78) /**< \brief Number of peripheral IDs */
+/** @}  end of Peripheral Ids Definitions */
+
+/** \addtogroup SAML10E16A_base Peripheral Base Address Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   BASE ADDRESS DEFINITIONS FOR SAML10E16A */
+/* ************************************************************************** */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#define AC                     (0x40003400)                   /**< \brief (AC        ) Base Address */
+#define ADC                    (0x42001C00)                   /**< \brief (ADC       ) Base Address */
+#define CCL                    (0x42002C00)                   /**< \brief (CCL       ) Base Address */
+#define DAC                    (0x42002000)                   /**< \brief (DAC       ) Base Address */
+#define DMAC                   (0x41006000)                   /**< \brief (DMAC      ) Base Address */
+#define DSU                    (0x41002000)                   /**< \brief (DSU       ) Base Address */
+#define DSU_EXT                (0x41002100)                   /**< \brief (DSU       ) Base Address */
+#define EIC                    (0x40002800)                   /**< \brief (EIC       ) Base Address */
+#define EVSYS                  (0x42000000)                   /**< \brief (EVSYS     ) Base Address */
+#define FREQM                  (0x40002C00)                   /**< \brief (FREQM     ) Base Address */
+#define GCLK                   (0x40001C00)                   /**< \brief (GCLK      ) Base Address */
+#define IDAU                   (0x41000000)                   /**< \brief (IDAU      ) Base Address */
+#define MCLK                   (0x40000800)                   /**< \brief (MCLK      ) Base Address */
+#define NVMCTRL                (0x41004000)                   /**< \brief (NVMCTRL   ) Base Address */
+#define OPAMP                  (0x42003000)                   /**< \brief (OPAMP     ) Base Address */
+#define OSCCTRL                (0x40001000)                   /**< \brief (OSCCTRL   ) Base Address */
+#define OSC32KCTRL             (0x40001400)                   /**< \brief (OSC32KCTRL) Base Address */
+#define PAC                    (0x40000000)                   /**< \brief (PAC       ) Base Address */
+#define PM                     (0x40000400)                   /**< \brief (PM        ) Base Address */
+#define PORT                   (0x40003000)                   /**< \brief (PORT      ) Base Address */
+#define PORT_IOBUS             (0x60000000)                   /**< \brief (PORT      ) Base Address */
+#define PTC                    (0x42002400)                   /**< \brief (PTC       ) Base Address */
+#define RSTC                   (0x40000C00)                   /**< \brief (RSTC      ) Base Address */
+#define RTC                    (0x40002400)                   /**< \brief (RTC       ) Base Address */
+#define SERCOM0                (0x42000400)                   /**< \brief (SERCOM0   ) Base Address */
+#define SERCOM1                (0x42000800)                   /**< \brief (SERCOM1   ) Base Address */
+#define SERCOM2                (0x42000C00)                   /**< \brief (SERCOM2   ) Base Address */
+#define SUPC                   (0x40001800)                   /**< \brief (SUPC      ) Base Address */
+#define TC0                    (0x42001000)                   /**< \brief (TC0       ) Base Address */
+#define TC1                    (0x42001400)                   /**< \brief (TC1       ) Base Address */
+#define TC2                    (0x42001800)                   /**< \brief (TC2       ) Base Address */
+#define TRAM                   (0x42003400)                   /**< \brief (TRAM      ) Base Address */
+#define TRNG                   (0x42002800)                   /**< \brief (TRNG      ) Base Address */
+#define WDT                    (0x40002000)                   /**< \brief (WDT       ) Base Address */
+
+#else /* For C/C++ compiler */
+
+#define AC                     ((Ac *)0x40003400U)            /**< \brief (AC        ) Base Address */
+#define AC_INST_NUM            1                              /**< \brief (AC        ) Number of instances */
+#define AC_INSTS               { AC }                         /**< \brief (AC        ) Instances List */
+
+#define ADC                    ((Adc *)0x42001C00U)           /**< \brief (ADC       ) Base Address */
+#define ADC_INST_NUM           1                              /**< \brief (ADC       ) Number of instances */
+#define ADC_INSTS              { ADC }                        /**< \brief (ADC       ) Instances List */
+
+#define CCL                    ((Ccl *)0x42002C00U)           /**< \brief (CCL       ) Base Address */
+#define CCL_INST_NUM           1                              /**< \brief (CCL       ) Number of instances */
+#define CCL_INSTS              { CCL }                        /**< \brief (CCL       ) Instances List */
+
+#define DAC                    ((Dac *)0x42002000U)           /**< \brief (DAC       ) Base Address */
+#define DAC_INST_NUM           1                              /**< \brief (DAC       ) Number of instances */
+#define DAC_INSTS              { DAC }                        /**< \brief (DAC       ) Instances List */
+
+#define DMAC                   ((Dmac *)0x41006000U)          /**< \brief (DMAC      ) Base Address */
+#define DMAC_INST_NUM          1                              /**< \brief (DMAC      ) Number of instances */
+#define DMAC_INSTS             { DMAC }                       /**< \brief (DMAC      ) Instances List */
+
+#define DSU                    ((Dsu *)0x41002000U)           /**< \brief (DSU       ) Base Address */
+#define DSU_EXT                ((Dsu *)0x41002100U)           /**< \brief (DSU       ) Base Address */
+#define DSU_INST_NUM           1                              /**< \brief (DSU       ) Number of instances */
+#define DSU_INSTS              { DSU }                        /**< \brief (DSU       ) Instances List */
+
+#define EIC                    ((Eic *)0x40002800U)           /**< \brief (EIC       ) Base Address */
+#define EIC_INST_NUM           1                              /**< \brief (EIC       ) Number of instances */
+#define EIC_INSTS              { EIC }                        /**< \brief (EIC       ) Instances List */
+
+#define EVSYS                  ((Evsys *)0x42000000U)         /**< \brief (EVSYS     ) Base Address */
+#define EVSYS_INST_NUM         1                              /**< \brief (EVSYS     ) Number of instances */
+#define EVSYS_INSTS            { EVSYS }                      /**< \brief (EVSYS     ) Instances List */
+
+#define FREQM                  ((Freqm *)0x40002C00U)         /**< \brief (FREQM     ) Base Address */
+#define FREQM_INST_NUM         1                              /**< \brief (FREQM     ) Number of instances */
+#define FREQM_INSTS            { FREQM }                      /**< \brief (FREQM     ) Instances List */
+
+#define GCLK                   ((Gclk *)0x40001C00U)          /**< \brief (GCLK      ) Base Address */
+#define GCLK_INST_NUM          1                              /**< \brief (GCLK      ) Number of instances */
+#define GCLK_INSTS             { GCLK }                       /**< \brief (GCLK      ) Instances List */
+
+#define IDAU                   ((Idau *)0x41000000U)          /**< \brief (IDAU      ) Base Address */
+#define IDAU_INST_NUM          1                              /**< \brief (IDAU      ) Number of instances */
+#define IDAU_INSTS             { IDAU }                       /**< \brief (IDAU      ) Instances List */
+
+#define MCLK                   ((Mclk *)0x40000800U)          /**< \brief (MCLK      ) Base Address */
+#define MCLK_INST_NUM          1                              /**< \brief (MCLK      ) Number of instances */
+#define MCLK_INSTS             { MCLK }                       /**< \brief (MCLK      ) Instances List */
+
+#define NVMCTRL                ((Nvmctrl *)0x41004000U)       /**< \brief (NVMCTRL   ) Base Address */
+#define NVMCTRL_INST_NUM       1                              /**< \brief (NVMCTRL   ) Number of instances */
+#define NVMCTRL_INSTS          { NVMCTRL }                    /**< \brief (NVMCTRL   ) Instances List */
+
+#define OPAMP                  ((Opamp *)0x42003000U)         /**< \brief (OPAMP     ) Base Address */
+#define OPAMP_INST_NUM         1                              /**< \brief (OPAMP     ) Number of instances */
+#define OPAMP_INSTS            { OPAMP }                      /**< \brief (OPAMP     ) Instances List */
+
+#define OSCCTRL                ((Oscctrl *)0x40001000U)       /**< \brief (OSCCTRL   ) Base Address */
+#define OSCCTRL_INST_NUM       1                              /**< \brief (OSCCTRL   ) Number of instances */
+#define OSCCTRL_INSTS          { OSCCTRL }                    /**< \brief (OSCCTRL   ) Instances List */
+
+#define OSC32KCTRL             ((Osc32kctrl *)0x40001400U)    /**< \brief (OSC32KCTRL) Base Address */
+#define OSC32KCTRL_INST_NUM    1                              /**< \brief (OSC32KCTRL) Number of instances */
+#define OSC32KCTRL_INSTS       { OSC32KCTRL }                 /**< \brief (OSC32KCTRL) Instances List */
+
+#define PAC                    ((Pac *)0x40000000U)           /**< \brief (PAC       ) Base Address */
+#define PAC_INST_NUM           1                              /**< \brief (PAC       ) Number of instances */
+#define PAC_INSTS              { PAC }                        /**< \brief (PAC       ) Instances List */
+
+#define PM                     ((Pm *)0x40000400U)            /**< \brief (PM        ) Base Address */
+#define PM_INST_NUM            1                              /**< \brief (PM        ) Number of instances */
+#define PM_INSTS               { PM }                         /**< \brief (PM        ) Instances List */
+
+#define PORT                   ((Port *)0x40003000U)          /**< \brief (PORT      ) Base Address */
+#define PORT_IOBUS             ((Port *)0x60000000U)          /**< \brief (PORT      ) Base Address */
+#define PORT_INST_NUM          1                              /**< \brief (PORT      ) Number of instances */
+#define PORT_INSTS             { PORT }                       /**< \brief (PORT      ) Instances List */
+
+#define PTC                    ((Ptc *)0x42002400U)           /**< \brief (PTC       ) Base Address */
+#define PTC_INST_NUM           1                              /**< \brief (PTC       ) Number of instances */
+#define PTC_INSTS              { PTC }                        /**< \brief (PTC       ) Instances List */
+
+#define RSTC                   ((Rstc *)0x40000C00U)          /**< \brief (RSTC      ) Base Address */
+#define RSTC_INST_NUM          1                              /**< \brief (RSTC      ) Number of instances */
+#define RSTC_INSTS             { RSTC }                       /**< \brief (RSTC      ) Instances List */
+
+#define RTC                    ((Rtc *)0x40002400U)           /**< \brief (RTC       ) Base Address */
+#define RTC_INST_NUM           1                              /**< \brief (RTC       ) Number of instances */
+#define RTC_INSTS              { RTC }                        /**< \brief (RTC       ) Instances List */
+
+#define SERCOM0                ((Sercom *)0x42000400U)        /**< \brief (SERCOM0   ) Base Address */
+#define SERCOM1                ((Sercom *)0x42000800U)        /**< \brief (SERCOM1   ) Base Address */
+#define SERCOM2                ((Sercom *)0x42000C00U)        /**< \brief (SERCOM2   ) Base Address */
+#define SERCOM_INST_NUM        3                              /**< \brief (SERCOM    ) Number of instances */
+#define SERCOM_INSTS           { SERCOM0, SERCOM1, SERCOM2 }  /**< \brief (SERCOM    ) Instances List */
+
+#define SUPC                   ((Supc *)0x40001800U)          /**< \brief (SUPC      ) Base Address */
+#define SUPC_INST_NUM          1                              /**< \brief (SUPC      ) Number of instances */
+#define SUPC_INSTS             { SUPC }                       /**< \brief (SUPC      ) Instances List */
+
+#define TC0                    ((Tc *)0x42001000U)            /**< \brief (TC0       ) Base Address */
+#define TC1                    ((Tc *)0x42001400U)            /**< \brief (TC1       ) Base Address */
+#define TC2                    ((Tc *)0x42001800U)            /**< \brief (TC2       ) Base Address */
+#define TC_INST_NUM            3                              /**< \brief (TC        ) Number of instances */
+#define TC_INSTS               { TC0, TC1, TC2 }              /**< \brief (TC        ) Instances List */
+
+#define TRAM                   ((Tram *)0x42003400U)          /**< \brief (TRAM      ) Base Address */
+#define TRAM_INST_NUM          1                              /**< \brief (TRAM      ) Number of instances */
+#define TRAM_INSTS             { TRAM }                       /**< \brief (TRAM      ) Instances List */
+
+#define TRNG                   ((Trng *)0x42002800U)          /**< \brief (TRNG      ) Base Address */
+#define TRNG_INST_NUM          1                              /**< \brief (TRNG      ) Number of instances */
+#define TRNG_INSTS             { TRNG }                       /**< \brief (TRNG      ) Instances List */
+
+#define WDT                    ((Wdt *)0x40002000U)           /**< \brief (WDT       ) Base Address */
+#define WDT_INST_NUM           1                              /**< \brief (WDT       ) Number of instances */
+#define WDT_INSTS              { WDT }                        /**< \brief (WDT       ) Instances List */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Peripheral Base Address Definitions */
+
+/** \addtogroup SAML10E16A_pio Peripheral Pio Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   PIO DEFINITIONS FOR SAML10E16A*/
+/* ************************************************************************** */
+#include "pio/saml10e16a.h"
+/** @}  end of Peripheral Pio Definitions */
+
+/* ************************************************************************** */
+/*   MEMORY MAPPING DEFINITIONS FOR SAML10E16A*/
+/* ************************************************************************** */
+
+#define FLASH_SIZE               _U_(0x00010000)       /*   64kB Memory segment type: flash */
+#define FLASH_PAGE_SIZE          _U_(        64)
+#define FLASH_NB_OF_PAGES        _U_(      1024)
+
+#define AUX_SIZE                 _U_(0x00000100)       /*    0kB Memory segment type: fuses */
+#define AUX_PAGE_SIZE            _U_(        64)
+#define AUX_NB_OF_PAGES          _U_(         4)
+
+#define BOCOR_SIZE               _U_(0x00000100)       /*    0kB Memory segment type: fuses */
+#define BOCOR_PAGE_SIZE          _U_(        64)
+#define BOCOR_NB_OF_PAGES        _U_(         4)
+
+#define DATAFLASH_SIZE           _U_(0x00000800)       /*    2kB Memory segment type: flash */
+#define DATAFLASH_PAGE_SIZE      _U_(        64)
+#define DATAFLASH_NB_OF_PAGES    _U_(        32)
+
+#define SW_CALIB_SIZE            _U_(0x00000008)       /*    0kB Memory segment type: fuses */
+#define TEMP_LOG_SIZE            _U_(0x00000008)       /*    0kB Memory segment type: fuses */
+#define USER_PAGE_SIZE           _U_(0x00000100)       /*    0kB Memory segment type: user_page */
+#define USER_PAGE_PAGE_SIZE      _U_(        64)
+#define USER_PAGE_NB_OF_PAGES    _U_(         4)
+
+#define HSRAM_SIZE               _U_(0x00004000)       /*   16kB Memory segment type: ram */
+#define HPB0_SIZE                _U_(0x00008000)       /*   32kB Memory segment type: io */
+#define HPB1_SIZE                _U_(0x00010000)       /*   64kB Memory segment type: io */
+#define HPB2_SIZE                _U_(0x00004000)       /*   16kB Memory segment type: io */
+#define PPB_SIZE                 _U_(0x00100000)       /* 1024kB Memory segment type: io */
+#define SCS_SIZE                 _U_(0x00001000)       /*    4kB Memory segment type: io */
+#define PERIPHERALS_SIZE         _U_(0x20000000)       /* 524288kB Memory segment type: io */
+
+#define FLASH_ADDR               _U_(0x00000000)       /**< FLASH base address (type: flash)*/
+#define AUX_ADDR                 _U_(0x00806000)       /**< AUX base address (type: fuses)*/
+#define BOCOR_ADDR               _U_(0x0080c000)       /**< BOCOR base address (type: fuses)*/
+#define DATAFLASH_ADDR           _U_(0x00400000)       /**< DATAFLASH base address (type: flash)*/
+#define SW_CALIB_ADDR            _U_(0x00806020)       /**< SW_CALIB base address (type: fuses)*/
+#define TEMP_LOG_ADDR            _U_(0x00806038)       /**< TEMP_LOG base address (type: fuses)*/
+#define USER_PAGE_ADDR           _U_(0x00804000)       /**< USER_PAGE base address (type: user_page)*/
+#define HSRAM_ADDR               _U_(0x20000000)       /**< HSRAM base address (type: ram)*/
+#define HPB0_ADDR                _U_(0x40000000)       /**< HPB0 base address (type: io)*/
+#define HPB1_ADDR                _U_(0x41000000)       /**< HPB1 base address (type: io)*/
+#define HPB2_ADDR                _U_(0x42000000)       /**< HPB2 base address (type: io)*/
+#define PPB_ADDR                 _U_(0xe0000000)       /**< PPB base address (type: io)*/
+#define SCS_ADDR                 _U_(0xe000e000)       /**< SCS base address (type: io)*/
+#define PERIPHERALS_ADDR         _U_(0x40000000)       /**< PERIPHERALS base address (type: io)*/
+
+#define NVMCTRL_AUX              AUX_ADDR              /**< \brief \deprecated Old style definition. Use AUX_ADDR instead */
+#define NVMCTRL_BOCOR            BOCOR_ADDR            /**< \brief \deprecated Old style definition. Use BOCOR_ADDR instead */
+#define NVMCTRL_DATAFLASH        DATAFLASH_ADDR        /**< \brief \deprecated Old style definition. Use DATAFLASH_ADDR instead */
+#define NVMCTRL_SW_CALIB         SW_CALIB_ADDR         /**< \brief \deprecated Old style definition. Use SW_CALIB_ADDR instead */
+#define NVMCTRL_TEMP_LOG         TEMP_LOG_ADDR         /**< \brief \deprecated Old style definition. Use TEMP_LOG_ADDR instead */
+#define NVMCTRL_USER             USER_PAGE_ADDR        /**< \brief \deprecated Old style definition. Use USER_PAGE_ADDR instead */
+
+/* ************************************************************************** */
+/**  DEVICE SIGNATURES FOR SAML10E16A */
+/* ************************************************************************** */
+#define DSU_DID                  _UL_(0X20840000)
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAML10E16A */
+/* ************************************************************************** */
+
+/* ************************************************************************** */
+/** Event Generator IDs for SAML10E16A */
+/* ************************************************************************** */
+#define EVENT_ID_GEN_OSCCTRL_XOSC_FAIL                    1 /**< ID for OSCCTRL event generator XOSC_FAIL */
+#define EVENT_ID_GEN_OSC32KCTRL_XOSC32K_FAIL              2 /**< ID for OSC32KCTRL event generator XOSC32K_FAIL */
+#define EVENT_ID_GEN_SUPC_BOD33DET                        3 /**< ID for SUPC event generator BOD33DET */
+#define EVENT_ID_GEN_RTC_PER_0                            4 /**< ID for RTC event generator PER_0 */
+#define EVENT_ID_GEN_RTC_PER_1                            5 /**< ID for RTC event generator PER_1 */
+#define EVENT_ID_GEN_RTC_PER_2                            6 /**< ID for RTC event generator PER_2 */
+#define EVENT_ID_GEN_RTC_PER_3                            7 /**< ID for RTC event generator PER_3 */
+#define EVENT_ID_GEN_RTC_PER_4                            8 /**< ID for RTC event generator PER_4 */
+#define EVENT_ID_GEN_RTC_PER_5                            9 /**< ID for RTC event generator PER_5 */
+#define EVENT_ID_GEN_RTC_PER_6                           10 /**< ID for RTC event generator PER_6 */
+#define EVENT_ID_GEN_RTC_PER_7                           11 /**< ID for RTC event generator PER_7 */
+#define EVENT_ID_GEN_RTC_CMP_0                           12 /**< ID for RTC event generator CMP_0 */
+#define EVENT_ID_GEN_RTC_CMP_1                           13 /**< ID for RTC event generator CMP_1 */
+#define EVENT_ID_GEN_RTC_TAMPER                          14 /**< ID for RTC event generator TAMPER */
+#define EVENT_ID_GEN_RTC_OVF                             15 /**< ID for RTC event generator OVF */
+#define EVENT_ID_GEN_RTC_PERD                            16 /**< ID for RTC event generator PERD */
+#define EVENT_ID_GEN_EIC_EXTINT_0                        17 /**< ID for EIC event generator EXTINT_0 */
+#define EVENT_ID_GEN_EIC_EXTINT_1                        18 /**< ID for EIC event generator EXTINT_1 */
+#define EVENT_ID_GEN_EIC_EXTINT_2                        19 /**< ID for EIC event generator EXTINT_2 */
+#define EVENT_ID_GEN_EIC_EXTINT_3                        20 /**< ID for EIC event generator EXTINT_3 */
+#define EVENT_ID_GEN_EIC_EXTINT_4                        21 /**< ID for EIC event generator EXTINT_4 */
+#define EVENT_ID_GEN_EIC_EXTINT_5                        22 /**< ID for EIC event generator EXTINT_5 */
+#define EVENT_ID_GEN_EIC_EXTINT_6                        23 /**< ID for EIC event generator EXTINT_6 */
+#define EVENT_ID_GEN_EIC_EXTINT_7                        24 /**< ID for EIC event generator EXTINT_7 */
+#define EVENT_ID_GEN_DMAC_CH_0                           25 /**< ID for DMAC event generator CH_0 */
+#define EVENT_ID_GEN_DMAC_CH_1                           26 /**< ID for DMAC event generator CH_1 */
+#define EVENT_ID_GEN_DMAC_CH_2                           27 /**< ID for DMAC event generator CH_2 */
+#define EVENT_ID_GEN_DMAC_CH_3                           28 /**< ID for DMAC event generator CH_3 */
+#define EVENT_ID_GEN_TC0_OVF                             29 /**< ID for TC0 event generator OVF */
+#define EVENT_ID_GEN_TC0_MCX_0                           30 /**< ID for TC0 event generator MCX_0 */
+#define EVENT_ID_GEN_TC0_MCX_1                           31 /**< ID for TC0 event generator MCX_1 */
+#define EVENT_ID_GEN_TC1_OVF                             32 /**< ID for TC1 event generator OVF */
+#define EVENT_ID_GEN_TC1_MCX_0                           33 /**< ID for TC1 event generator MCX_0 */
+#define EVENT_ID_GEN_TC1_MCX_1                           34 /**< ID for TC1 event generator MCX_1 */
+#define EVENT_ID_GEN_TC2_OVF                             35 /**< ID for TC2 event generator OVF */
+#define EVENT_ID_GEN_TC2_MCX_0                           36 /**< ID for TC2 event generator MCX_0 */
+#define EVENT_ID_GEN_TC2_MCX_1                           37 /**< ID for TC2 event generator MCX_1 */
+#define EVENT_ID_GEN_ADC_RESRDY                          38 /**< ID for ADC event generator RESRDY */
+#define EVENT_ID_GEN_ADC_WINMON                          39 /**< ID for ADC event generator WINMON */
+#define EVENT_ID_GEN_AC_COMP_0                           40 /**< ID for AC event generator COMP_0 */
+#define EVENT_ID_GEN_AC_COMP_1                           41 /**< ID for AC event generator COMP_1 */
+#define EVENT_ID_GEN_AC_WIN_0                            42 /**< ID for AC event generator WIN_0 */
+#define EVENT_ID_GEN_DAC_EMPTY                           43 /**< ID for DAC event generator EMPTY */
+#define EVENT_ID_GEN_TRNG_READY                          46 /**< ID for TRNG event generator READY */
+#define EVENT_ID_GEN_CCL_LUTOUT_0                        47 /**< ID for CCL event generator LUTOUT_0 */
+#define EVENT_ID_GEN_CCL_LUTOUT_1                        48 /**< ID for CCL event generator LUTOUT_1 */
+#define EVENT_ID_GEN_PAC_ERR                             49 /**< ID for PAC event generator ERR */
+
+/* ************************************************************************** */
+/** Event User IDs for SAML10E16A */
+/* ************************************************************************** */
+#define EVENT_ID_USER_OSCCTRL_TUNE                        0 /**< ID for OSCCTRL event user TUNE */
+#define EVENT_ID_USER_RTC_TAMPER                          1 /**< ID for RTC event user TAMPER */
+#define EVENT_ID_USER_NVMCTRL_PAGEW                       2 /**< ID for NVMCTRL event user PAGEW */
+#define EVENT_ID_USER_PORT_EV_0                           3 /**< ID for PORT event user EV_0 */
+#define EVENT_ID_USER_PORT_EV_1                           4 /**< ID for PORT event user EV_1 */
+#define EVENT_ID_USER_PORT_EV_2                           5 /**< ID for PORT event user EV_2 */
+#define EVENT_ID_USER_PORT_EV_3                           6 /**< ID for PORT event user EV_3 */
+#define EVENT_ID_USER_DMAC_CH_0                           7 /**< ID for DMAC event user CH_0 */
+#define EVENT_ID_USER_DMAC_CH_1                           8 /**< ID for DMAC event user CH_1 */
+#define EVENT_ID_USER_DMAC_CH_2                           9 /**< ID for DMAC event user CH_2 */
+#define EVENT_ID_USER_DMAC_CH_3                          10 /**< ID for DMAC event user CH_3 */
+#define EVENT_ID_USER_TC0_EVU                            11 /**< ID for TC0 event user EVU */
+#define EVENT_ID_USER_TC1_EVU                            12 /**< ID for TC1 event user EVU */
+#define EVENT_ID_USER_TC2_EVU                            13 /**< ID for TC2 event user EVU */
+#define EVENT_ID_USER_ADC_START                          14 /**< ID for ADC event user START */
+#define EVENT_ID_USER_ADC_SYNC                           15 /**< ID for ADC event user SYNC */
+#define EVENT_ID_USER_AC_SOC_0                           16 /**< ID for AC event user SOC_0 */
+#define EVENT_ID_USER_AC_SOC_1                           17 /**< ID for AC event user SOC_1 */
+#define EVENT_ID_USER_DAC_START                          18 /**< ID for DAC event user START */
+#define EVENT_ID_USER_CCL_LUTIN_0                        21 /**< ID for CCL event user LUTIN_0 */
+#define EVENT_ID_USER_CCL_LUTIN_1                        22 /**< ID for CCL event user LUTIN_1 */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @}  end of SAML10E16A definitions */
+
+
+#endif /* _SAML10E16A_H_ */

--- a/cpu/sam0_common/include/vendor/saml10/include/system_saml10.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/system_saml10.h
@@ -1,0 +1,48 @@
+/**
+ * \file
+ *
+ * \brief Low-level initialization functions called upon device startup
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+#ifndef _SYSTEM_SAML10_H_INCLUDED_
+#define _SYSTEM_SAML10_H_INCLUDED_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+extern uint32_t SystemCoreClock;   /*!< System Clock Frequency (Core Clock)  */
+
+void SystemInit(void);
+void SystemCoreClockUpdate(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _SYSTEM_SAML10_H_INCLUDED */

--- a/cpu/sam0_common/include/vendor/saml11/include/component-version.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component-version.h
@@ -1,0 +1,64 @@
+/**
+ * \file
+ *
+ * \brief Component version header file
+ *
+ * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+#ifndef _COMPONENT_VERSION_H_INCLUDED
+#define _COMPONENT_VERSION_H_INCLUDED
+
+#define COMPONENT_VERSION_MAJOR 1
+#define COMPONENT_VERSION_MINOR 0
+
+//
+// The COMPONENT_VERSION define is composed of the major and the minor version number.
+//
+// The last four digits of the COMPONENT_VERSION is the minor version with leading zeros.
+// The rest of the COMPONENT_VERSION is the major version.
+//
+#define COMPONENT_VERSION 10000
+
+//
+// The build number does not refer to the component, but to the build number
+// of the device pack that provides the component.
+//
+#define BUILD_NUMBER 91
+
+//
+// The COMPONENT_VERSION_STRING is a string (enclosed in ") that can be used for logging or embedding.
+//
+#define COMPONENT_VERSION_STRING "1.0"
+
+//
+// The COMPONENT_DATE_STRING contains a timestamp of when the pack was generated.
+//
+// The COMPONENT_DATE_STRING is written out using the following strftime pattern.
+//
+//     "%Y-%m-%d %H:%M:%S"
+//
+//
+#define COMPONENT_DATE_STRING "2018-09-27 16:55:59"
+
+#endif/* #ifndef _COMPONENT_VERSION_H_INCLUDED */
+

--- a/cpu/sam0_common/include/vendor/saml11/include/component/ac.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/ac.h
@@ -1,0 +1,661 @@
+/**
+ * \file
+ *
+ * \brief Component description for AC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_AC_COMPONENT_H_
+#define _SAML11_AC_COMPONENT_H_
+#define _SAML11_AC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML11 Analog Comparators
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR AC */
+/* ========================================================================== */
+
+#define AC_U2245                      /**< (AC) Module ID */
+#define REV_AC 0x102                  /**< (AC) Module revision */
+
+/* -------- AC_CTRLA : (AC Offset: 0x00) (R/W 8) Control A -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint8_t  ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint8_t  :6;                        /**< bit:   2..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} AC_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_CTRLA_OFFSET                     (0x00)                                        /**<  (AC_CTRLA) Control A  Offset */
+#define AC_CTRLA_RESETVALUE                 _U_(0x00)                                     /**<  (AC_CTRLA) Control A  Reset Value */
+
+#define AC_CTRLA_SWRST_Pos                  0                                              /**< (AC_CTRLA) Software Reset Position */
+#define AC_CTRLA_SWRST_Msk                  (_U_(0x1) << AC_CTRLA_SWRST_Pos)               /**< (AC_CTRLA) Software Reset Mask */
+#define AC_CTRLA_SWRST                      AC_CTRLA_SWRST_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_CTRLA_SWRST_Msk instead */
+#define AC_CTRLA_ENABLE_Pos                 1                                              /**< (AC_CTRLA) Enable Position */
+#define AC_CTRLA_ENABLE_Msk                 (_U_(0x1) << AC_CTRLA_ENABLE_Pos)              /**< (AC_CTRLA) Enable Mask */
+#define AC_CTRLA_ENABLE                     AC_CTRLA_ENABLE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_CTRLA_ENABLE_Msk instead */
+#define AC_CTRLA_MASK                       _U_(0x03)                                      /**< \deprecated (AC_CTRLA) Register MASK  (Use AC_CTRLA_Msk instead)  */
+#define AC_CTRLA_Msk                        _U_(0x03)                                      /**< (AC_CTRLA) Register Mask  */
+
+
+/* -------- AC_CTRLB : (AC Offset: 0x01) (/W 8) Control B -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  START0:1;                  /**< bit:      0  Comparator 0 Start Comparison            */
+    uint8_t  START1:1;                  /**< bit:      1  Comparator 1 Start Comparison            */
+    uint8_t  :6;                        /**< bit:   2..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint8_t  START:2;                   /**< bit:   0..1  Comparator x Start Comparison            */
+    uint8_t  :6;                        /**< bit:   2..7 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint8_t  reg;                         /**< Type used for register access */
+} AC_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_CTRLB_OFFSET                     (0x01)                                        /**<  (AC_CTRLB) Control B  Offset */
+#define AC_CTRLB_RESETVALUE                 _U_(0x00)                                     /**<  (AC_CTRLB) Control B  Reset Value */
+
+#define AC_CTRLB_START0_Pos                 0                                              /**< (AC_CTRLB) Comparator 0 Start Comparison Position */
+#define AC_CTRLB_START0_Msk                 (_U_(0x1) << AC_CTRLB_START0_Pos)              /**< (AC_CTRLB) Comparator 0 Start Comparison Mask */
+#define AC_CTRLB_START0                     AC_CTRLB_START0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_CTRLB_START0_Msk instead */
+#define AC_CTRLB_START1_Pos                 1                                              /**< (AC_CTRLB) Comparator 1 Start Comparison Position */
+#define AC_CTRLB_START1_Msk                 (_U_(0x1) << AC_CTRLB_START1_Pos)              /**< (AC_CTRLB) Comparator 1 Start Comparison Mask */
+#define AC_CTRLB_START1                     AC_CTRLB_START1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_CTRLB_START1_Msk instead */
+#define AC_CTRLB_MASK                       _U_(0x03)                                      /**< \deprecated (AC_CTRLB) Register MASK  (Use AC_CTRLB_Msk instead)  */
+#define AC_CTRLB_Msk                        _U_(0x03)                                      /**< (AC_CTRLB) Register Mask  */
+
+#define AC_CTRLB_START_Pos                  0                                              /**< (AC_CTRLB Position) Comparator x Start Comparison */
+#define AC_CTRLB_START_Msk                  (_U_(0x3) << AC_CTRLB_START_Pos)               /**< (AC_CTRLB Mask) START */
+#define AC_CTRLB_START(value)               (AC_CTRLB_START_Msk & ((value) << AC_CTRLB_START_Pos))  
+
+/* -------- AC_EVCTRL : (AC Offset: 0x02) (R/W 16) Event Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t COMPEO0:1;                 /**< bit:      0  Comparator 0 Event Output Enable         */
+    uint16_t COMPEO1:1;                 /**< bit:      1  Comparator 1 Event Output Enable         */
+    uint16_t :2;                        /**< bit:   2..3  Reserved */
+    uint16_t WINEO0:1;                  /**< bit:      4  Window 0 Event Output Enable             */
+    uint16_t :3;                        /**< bit:   5..7  Reserved */
+    uint16_t COMPEI0:1;                 /**< bit:      8  Comparator 0 Event Input Enable          */
+    uint16_t COMPEI1:1;                 /**< bit:      9  Comparator 1 Event Input Enable          */
+    uint16_t :2;                        /**< bit: 10..11  Reserved */
+    uint16_t INVEI0:1;                  /**< bit:     12  Comparator 0 Input Event Invert Enable   */
+    uint16_t INVEI1:1;                  /**< bit:     13  Comparator 1 Input Event Invert Enable   */
+    uint16_t :2;                        /**< bit: 14..15  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint16_t COMPEO:2;                  /**< bit:   0..1  Comparator x Event Output Enable         */
+    uint16_t :2;                        /**< bit:   2..3  Reserved */
+    uint16_t WINEO:1;                   /**< bit:      4  Window x Event Output Enable             */
+    uint16_t :3;                        /**< bit:   5..7  Reserved */
+    uint16_t COMPEI:2;                  /**< bit:   8..9  Comparator x Event Input Enable          */
+    uint16_t :2;                        /**< bit: 10..11  Reserved */
+    uint16_t INVEI:2;                   /**< bit: 12..13  Comparator x Input Event Invert Enable   */
+    uint16_t :2;                        /**< bit: 14..15 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint16_t reg;                         /**< Type used for register access */
+} AC_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_EVCTRL_OFFSET                    (0x02)                                        /**<  (AC_EVCTRL) Event Control  Offset */
+#define AC_EVCTRL_RESETVALUE                _U_(0x00)                                     /**<  (AC_EVCTRL) Event Control  Reset Value */
+
+#define AC_EVCTRL_COMPEO0_Pos               0                                              /**< (AC_EVCTRL) Comparator 0 Event Output Enable Position */
+#define AC_EVCTRL_COMPEO0_Msk               (_U_(0x1) << AC_EVCTRL_COMPEO0_Pos)            /**< (AC_EVCTRL) Comparator 0 Event Output Enable Mask */
+#define AC_EVCTRL_COMPEO0                   AC_EVCTRL_COMPEO0_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_EVCTRL_COMPEO0_Msk instead */
+#define AC_EVCTRL_COMPEO1_Pos               1                                              /**< (AC_EVCTRL) Comparator 1 Event Output Enable Position */
+#define AC_EVCTRL_COMPEO1_Msk               (_U_(0x1) << AC_EVCTRL_COMPEO1_Pos)            /**< (AC_EVCTRL) Comparator 1 Event Output Enable Mask */
+#define AC_EVCTRL_COMPEO1                   AC_EVCTRL_COMPEO1_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_EVCTRL_COMPEO1_Msk instead */
+#define AC_EVCTRL_WINEO0_Pos                4                                              /**< (AC_EVCTRL) Window 0 Event Output Enable Position */
+#define AC_EVCTRL_WINEO0_Msk                (_U_(0x1) << AC_EVCTRL_WINEO0_Pos)             /**< (AC_EVCTRL) Window 0 Event Output Enable Mask */
+#define AC_EVCTRL_WINEO0                    AC_EVCTRL_WINEO0_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_EVCTRL_WINEO0_Msk instead */
+#define AC_EVCTRL_COMPEI0_Pos               8                                              /**< (AC_EVCTRL) Comparator 0 Event Input Enable Position */
+#define AC_EVCTRL_COMPEI0_Msk               (_U_(0x1) << AC_EVCTRL_COMPEI0_Pos)            /**< (AC_EVCTRL) Comparator 0 Event Input Enable Mask */
+#define AC_EVCTRL_COMPEI0                   AC_EVCTRL_COMPEI0_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_EVCTRL_COMPEI0_Msk instead */
+#define AC_EVCTRL_COMPEI1_Pos               9                                              /**< (AC_EVCTRL) Comparator 1 Event Input Enable Position */
+#define AC_EVCTRL_COMPEI1_Msk               (_U_(0x1) << AC_EVCTRL_COMPEI1_Pos)            /**< (AC_EVCTRL) Comparator 1 Event Input Enable Mask */
+#define AC_EVCTRL_COMPEI1                   AC_EVCTRL_COMPEI1_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_EVCTRL_COMPEI1_Msk instead */
+#define AC_EVCTRL_INVEI0_Pos                12                                             /**< (AC_EVCTRL) Comparator 0 Input Event Invert Enable Position */
+#define AC_EVCTRL_INVEI0_Msk                (_U_(0x1) << AC_EVCTRL_INVEI0_Pos)             /**< (AC_EVCTRL) Comparator 0 Input Event Invert Enable Mask */
+#define AC_EVCTRL_INVEI0                    AC_EVCTRL_INVEI0_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_EVCTRL_INVEI0_Msk instead */
+#define AC_EVCTRL_INVEI1_Pos                13                                             /**< (AC_EVCTRL) Comparator 1 Input Event Invert Enable Position */
+#define AC_EVCTRL_INVEI1_Msk                (_U_(0x1) << AC_EVCTRL_INVEI1_Pos)             /**< (AC_EVCTRL) Comparator 1 Input Event Invert Enable Mask */
+#define AC_EVCTRL_INVEI1                    AC_EVCTRL_INVEI1_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_EVCTRL_INVEI1_Msk instead */
+#define AC_EVCTRL_MASK                      _U_(0x3313)                                    /**< \deprecated (AC_EVCTRL) Register MASK  (Use AC_EVCTRL_Msk instead)  */
+#define AC_EVCTRL_Msk                       _U_(0x3313)                                    /**< (AC_EVCTRL) Register Mask  */
+
+#define AC_EVCTRL_COMPEO_Pos                0                                              /**< (AC_EVCTRL Position) Comparator x Event Output Enable */
+#define AC_EVCTRL_COMPEO_Msk                (_U_(0x3) << AC_EVCTRL_COMPEO_Pos)             /**< (AC_EVCTRL Mask) COMPEO */
+#define AC_EVCTRL_COMPEO(value)             (AC_EVCTRL_COMPEO_Msk & ((value) << AC_EVCTRL_COMPEO_Pos))  
+#define AC_EVCTRL_WINEO_Pos                 4                                              /**< (AC_EVCTRL Position) Window x Event Output Enable */
+#define AC_EVCTRL_WINEO_Msk                 (_U_(0x1) << AC_EVCTRL_WINEO_Pos)              /**< (AC_EVCTRL Mask) WINEO */
+#define AC_EVCTRL_WINEO(value)              (AC_EVCTRL_WINEO_Msk & ((value) << AC_EVCTRL_WINEO_Pos))  
+#define AC_EVCTRL_COMPEI_Pos                8                                              /**< (AC_EVCTRL Position) Comparator x Event Input Enable */
+#define AC_EVCTRL_COMPEI_Msk                (_U_(0x3) << AC_EVCTRL_COMPEI_Pos)             /**< (AC_EVCTRL Mask) COMPEI */
+#define AC_EVCTRL_COMPEI(value)             (AC_EVCTRL_COMPEI_Msk & ((value) << AC_EVCTRL_COMPEI_Pos))  
+#define AC_EVCTRL_INVEI_Pos                 12                                             /**< (AC_EVCTRL Position) Comparator x Input Event Invert Enable */
+#define AC_EVCTRL_INVEI_Msk                 (_U_(0x3) << AC_EVCTRL_INVEI_Pos)              /**< (AC_EVCTRL Mask) INVEI */
+#define AC_EVCTRL_INVEI(value)              (AC_EVCTRL_INVEI_Msk & ((value) << AC_EVCTRL_INVEI_Pos))  
+
+/* -------- AC_INTENCLR : (AC Offset: 0x04) (R/W 8) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  COMP0:1;                   /**< bit:      0  Comparator 0 Interrupt Enable            */
+    uint8_t  COMP1:1;                   /**< bit:      1  Comparator 1 Interrupt Enable            */
+    uint8_t  :2;                        /**< bit:   2..3  Reserved */
+    uint8_t  WIN0:1;                    /**< bit:      4  Window 0 Interrupt Enable                */
+    uint8_t  :3;                        /**< bit:   5..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint8_t  COMP:2;                    /**< bit:   0..1  Comparator x Interrupt Enable            */
+    uint8_t  :2;                        /**< bit:   2..3  Reserved */
+    uint8_t  WIN:1;                     /**< bit:      4  Window x Interrupt Enable                */
+    uint8_t  :3;                        /**< bit:   5..7 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint8_t  reg;                         /**< Type used for register access */
+} AC_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_INTENCLR_OFFSET                  (0x04)                                        /**<  (AC_INTENCLR) Interrupt Enable Clear  Offset */
+#define AC_INTENCLR_RESETVALUE              _U_(0x00)                                     /**<  (AC_INTENCLR) Interrupt Enable Clear  Reset Value */
+
+#define AC_INTENCLR_COMP0_Pos               0                                              /**< (AC_INTENCLR) Comparator 0 Interrupt Enable Position */
+#define AC_INTENCLR_COMP0_Msk               (_U_(0x1) << AC_INTENCLR_COMP0_Pos)            /**< (AC_INTENCLR) Comparator 0 Interrupt Enable Mask */
+#define AC_INTENCLR_COMP0                   AC_INTENCLR_COMP0_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_INTENCLR_COMP0_Msk instead */
+#define AC_INTENCLR_COMP1_Pos               1                                              /**< (AC_INTENCLR) Comparator 1 Interrupt Enable Position */
+#define AC_INTENCLR_COMP1_Msk               (_U_(0x1) << AC_INTENCLR_COMP1_Pos)            /**< (AC_INTENCLR) Comparator 1 Interrupt Enable Mask */
+#define AC_INTENCLR_COMP1                   AC_INTENCLR_COMP1_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_INTENCLR_COMP1_Msk instead */
+#define AC_INTENCLR_WIN0_Pos                4                                              /**< (AC_INTENCLR) Window 0 Interrupt Enable Position */
+#define AC_INTENCLR_WIN0_Msk                (_U_(0x1) << AC_INTENCLR_WIN0_Pos)             /**< (AC_INTENCLR) Window 0 Interrupt Enable Mask */
+#define AC_INTENCLR_WIN0                    AC_INTENCLR_WIN0_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_INTENCLR_WIN0_Msk instead */
+#define AC_INTENCLR_MASK                    _U_(0x13)                                      /**< \deprecated (AC_INTENCLR) Register MASK  (Use AC_INTENCLR_Msk instead)  */
+#define AC_INTENCLR_Msk                     _U_(0x13)                                      /**< (AC_INTENCLR) Register Mask  */
+
+#define AC_INTENCLR_COMP_Pos                0                                              /**< (AC_INTENCLR Position) Comparator x Interrupt Enable */
+#define AC_INTENCLR_COMP_Msk                (_U_(0x3) << AC_INTENCLR_COMP_Pos)             /**< (AC_INTENCLR Mask) COMP */
+#define AC_INTENCLR_COMP(value)             (AC_INTENCLR_COMP_Msk & ((value) << AC_INTENCLR_COMP_Pos))  
+#define AC_INTENCLR_WIN_Pos                 4                                              /**< (AC_INTENCLR Position) Window x Interrupt Enable */
+#define AC_INTENCLR_WIN_Msk                 (_U_(0x1) << AC_INTENCLR_WIN_Pos)              /**< (AC_INTENCLR Mask) WIN */
+#define AC_INTENCLR_WIN(value)              (AC_INTENCLR_WIN_Msk & ((value) << AC_INTENCLR_WIN_Pos))  
+
+/* -------- AC_INTENSET : (AC Offset: 0x05) (R/W 8) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  COMP0:1;                   /**< bit:      0  Comparator 0 Interrupt Enable            */
+    uint8_t  COMP1:1;                   /**< bit:      1  Comparator 1 Interrupt Enable            */
+    uint8_t  :2;                        /**< bit:   2..3  Reserved */
+    uint8_t  WIN0:1;                    /**< bit:      4  Window 0 Interrupt Enable                */
+    uint8_t  :3;                        /**< bit:   5..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint8_t  COMP:2;                    /**< bit:   0..1  Comparator x Interrupt Enable            */
+    uint8_t  :2;                        /**< bit:   2..3  Reserved */
+    uint8_t  WIN:1;                     /**< bit:      4  Window x Interrupt Enable                */
+    uint8_t  :3;                        /**< bit:   5..7 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint8_t  reg;                         /**< Type used for register access */
+} AC_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_INTENSET_OFFSET                  (0x05)                                        /**<  (AC_INTENSET) Interrupt Enable Set  Offset */
+#define AC_INTENSET_RESETVALUE              _U_(0x00)                                     /**<  (AC_INTENSET) Interrupt Enable Set  Reset Value */
+
+#define AC_INTENSET_COMP0_Pos               0                                              /**< (AC_INTENSET) Comparator 0 Interrupt Enable Position */
+#define AC_INTENSET_COMP0_Msk               (_U_(0x1) << AC_INTENSET_COMP0_Pos)            /**< (AC_INTENSET) Comparator 0 Interrupt Enable Mask */
+#define AC_INTENSET_COMP0                   AC_INTENSET_COMP0_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_INTENSET_COMP0_Msk instead */
+#define AC_INTENSET_COMP1_Pos               1                                              /**< (AC_INTENSET) Comparator 1 Interrupt Enable Position */
+#define AC_INTENSET_COMP1_Msk               (_U_(0x1) << AC_INTENSET_COMP1_Pos)            /**< (AC_INTENSET) Comparator 1 Interrupt Enable Mask */
+#define AC_INTENSET_COMP1                   AC_INTENSET_COMP1_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_INTENSET_COMP1_Msk instead */
+#define AC_INTENSET_WIN0_Pos                4                                              /**< (AC_INTENSET) Window 0 Interrupt Enable Position */
+#define AC_INTENSET_WIN0_Msk                (_U_(0x1) << AC_INTENSET_WIN0_Pos)             /**< (AC_INTENSET) Window 0 Interrupt Enable Mask */
+#define AC_INTENSET_WIN0                    AC_INTENSET_WIN0_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_INTENSET_WIN0_Msk instead */
+#define AC_INTENSET_MASK                    _U_(0x13)                                      /**< \deprecated (AC_INTENSET) Register MASK  (Use AC_INTENSET_Msk instead)  */
+#define AC_INTENSET_Msk                     _U_(0x13)                                      /**< (AC_INTENSET) Register Mask  */
+
+#define AC_INTENSET_COMP_Pos                0                                              /**< (AC_INTENSET Position) Comparator x Interrupt Enable */
+#define AC_INTENSET_COMP_Msk                (_U_(0x3) << AC_INTENSET_COMP_Pos)             /**< (AC_INTENSET Mask) COMP */
+#define AC_INTENSET_COMP(value)             (AC_INTENSET_COMP_Msk & ((value) << AC_INTENSET_COMP_Pos))  
+#define AC_INTENSET_WIN_Pos                 4                                              /**< (AC_INTENSET Position) Window x Interrupt Enable */
+#define AC_INTENSET_WIN_Msk                 (_U_(0x1) << AC_INTENSET_WIN_Pos)              /**< (AC_INTENSET Mask) WIN */
+#define AC_INTENSET_WIN(value)              (AC_INTENSET_WIN_Msk & ((value) << AC_INTENSET_WIN_Pos))  
+
+/* -------- AC_INTFLAG : (AC Offset: 0x06) (R/W 8) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t COMP0:1;                   /**< bit:      0  Comparator 0                             */
+    __I uint8_t COMP1:1;                   /**< bit:      1  Comparator 1                             */
+    __I uint8_t :2;                        /**< bit:   2..3  Reserved */
+    __I uint8_t WIN0:1;                    /**< bit:      4  Window 0                                 */
+    __I uint8_t :3;                        /**< bit:   5..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    __I uint8_t COMP:2;                    /**< bit:   0..1  Comparator x                             */
+    __I uint8_t :2;                        /**< bit:   2..3  Reserved */
+    __I uint8_t WIN:1;                     /**< bit:      4  Window x                                 */
+    __I uint8_t :3;                        /**< bit:   5..7 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint8_t  reg;                         /**< Type used for register access */
+} AC_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_INTFLAG_OFFSET                   (0x06)                                        /**<  (AC_INTFLAG) Interrupt Flag Status and Clear  Offset */
+#define AC_INTFLAG_RESETVALUE               _U_(0x00)                                     /**<  (AC_INTFLAG) Interrupt Flag Status and Clear  Reset Value */
+
+#define AC_INTFLAG_COMP0_Pos                0                                              /**< (AC_INTFLAG) Comparator 0 Position */
+#define AC_INTFLAG_COMP0_Msk                (_U_(0x1) << AC_INTFLAG_COMP0_Pos)             /**< (AC_INTFLAG) Comparator 0 Mask */
+#define AC_INTFLAG_COMP0                    AC_INTFLAG_COMP0_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_INTFLAG_COMP0_Msk instead */
+#define AC_INTFLAG_COMP1_Pos                1                                              /**< (AC_INTFLAG) Comparator 1 Position */
+#define AC_INTFLAG_COMP1_Msk                (_U_(0x1) << AC_INTFLAG_COMP1_Pos)             /**< (AC_INTFLAG) Comparator 1 Mask */
+#define AC_INTFLAG_COMP1                    AC_INTFLAG_COMP1_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_INTFLAG_COMP1_Msk instead */
+#define AC_INTFLAG_WIN0_Pos                 4                                              /**< (AC_INTFLAG) Window 0 Position */
+#define AC_INTFLAG_WIN0_Msk                 (_U_(0x1) << AC_INTFLAG_WIN0_Pos)              /**< (AC_INTFLAG) Window 0 Mask */
+#define AC_INTFLAG_WIN0                     AC_INTFLAG_WIN0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_INTFLAG_WIN0_Msk instead */
+#define AC_INTFLAG_MASK                     _U_(0x13)                                      /**< \deprecated (AC_INTFLAG) Register MASK  (Use AC_INTFLAG_Msk instead)  */
+#define AC_INTFLAG_Msk                      _U_(0x13)                                      /**< (AC_INTFLAG) Register Mask  */
+
+#define AC_INTFLAG_COMP_Pos                 0                                              /**< (AC_INTFLAG Position) Comparator x */
+#define AC_INTFLAG_COMP_Msk                 (_U_(0x3) << AC_INTFLAG_COMP_Pos)              /**< (AC_INTFLAG Mask) COMP */
+#define AC_INTFLAG_COMP(value)              (AC_INTFLAG_COMP_Msk & ((value) << AC_INTFLAG_COMP_Pos))  
+#define AC_INTFLAG_WIN_Pos                  4                                              /**< (AC_INTFLAG Position) Window x */
+#define AC_INTFLAG_WIN_Msk                  (_U_(0x1) << AC_INTFLAG_WIN_Pos)               /**< (AC_INTFLAG Mask) WIN */
+#define AC_INTFLAG_WIN(value)               (AC_INTFLAG_WIN_Msk & ((value) << AC_INTFLAG_WIN_Pos))  
+
+/* -------- AC_STATUSA : (AC Offset: 0x07) (R/ 8) Status A -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  STATE0:1;                  /**< bit:      0  Comparator 0 Current State               */
+    uint8_t  STATE1:1;                  /**< bit:      1  Comparator 1 Current State               */
+    uint8_t  :2;                        /**< bit:   2..3  Reserved */
+    uint8_t  WSTATE0:2;                 /**< bit:   4..5  Window 0 Current State                   */
+    uint8_t  :2;                        /**< bit:   6..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint8_t  STATE:2;                   /**< bit:   0..1  Comparator x Current State               */
+    uint8_t  :6;                        /**< bit:   2..7 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint8_t  reg;                         /**< Type used for register access */
+} AC_STATUSA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_STATUSA_OFFSET                   (0x07)                                        /**<  (AC_STATUSA) Status A  Offset */
+#define AC_STATUSA_RESETVALUE               _U_(0x00)                                     /**<  (AC_STATUSA) Status A  Reset Value */
+
+#define AC_STATUSA_STATE0_Pos               0                                              /**< (AC_STATUSA) Comparator 0 Current State Position */
+#define AC_STATUSA_STATE0_Msk               (_U_(0x1) << AC_STATUSA_STATE0_Pos)            /**< (AC_STATUSA) Comparator 0 Current State Mask */
+#define AC_STATUSA_STATE0                   AC_STATUSA_STATE0_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_STATUSA_STATE0_Msk instead */
+#define AC_STATUSA_STATE1_Pos               1                                              /**< (AC_STATUSA) Comparator 1 Current State Position */
+#define AC_STATUSA_STATE1_Msk               (_U_(0x1) << AC_STATUSA_STATE1_Pos)            /**< (AC_STATUSA) Comparator 1 Current State Mask */
+#define AC_STATUSA_STATE1                   AC_STATUSA_STATE1_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_STATUSA_STATE1_Msk instead */
+#define AC_STATUSA_WSTATE0_Pos              4                                              /**< (AC_STATUSA) Window 0 Current State Position */
+#define AC_STATUSA_WSTATE0_Msk              (_U_(0x3) << AC_STATUSA_WSTATE0_Pos)           /**< (AC_STATUSA) Window 0 Current State Mask */
+#define AC_STATUSA_WSTATE0(value)           (AC_STATUSA_WSTATE0_Msk & ((value) << AC_STATUSA_WSTATE0_Pos))
+#define   AC_STATUSA_WSTATE0_ABOVE_Val      _U_(0x0)                                       /**< (AC_STATUSA) Signal is above window  */
+#define   AC_STATUSA_WSTATE0_INSIDE_Val     _U_(0x1)                                       /**< (AC_STATUSA) Signal is inside window  */
+#define   AC_STATUSA_WSTATE0_BELOW_Val      _U_(0x2)                                       /**< (AC_STATUSA) Signal is below window  */
+#define AC_STATUSA_WSTATE0_ABOVE            (AC_STATUSA_WSTATE0_ABOVE_Val << AC_STATUSA_WSTATE0_Pos)  /**< (AC_STATUSA) Signal is above window Position  */
+#define AC_STATUSA_WSTATE0_INSIDE           (AC_STATUSA_WSTATE0_INSIDE_Val << AC_STATUSA_WSTATE0_Pos)  /**< (AC_STATUSA) Signal is inside window Position  */
+#define AC_STATUSA_WSTATE0_BELOW            (AC_STATUSA_WSTATE0_BELOW_Val << AC_STATUSA_WSTATE0_Pos)  /**< (AC_STATUSA) Signal is below window Position  */
+#define AC_STATUSA_MASK                     _U_(0x33)                                      /**< \deprecated (AC_STATUSA) Register MASK  (Use AC_STATUSA_Msk instead)  */
+#define AC_STATUSA_Msk                      _U_(0x33)                                      /**< (AC_STATUSA) Register Mask  */
+
+#define AC_STATUSA_STATE_Pos                0                                              /**< (AC_STATUSA Position) Comparator x Current State */
+#define AC_STATUSA_STATE_Msk                (_U_(0x3) << AC_STATUSA_STATE_Pos)             /**< (AC_STATUSA Mask) STATE */
+#define AC_STATUSA_STATE(value)             (AC_STATUSA_STATE_Msk & ((value) << AC_STATUSA_STATE_Pos))  
+
+/* -------- AC_STATUSB : (AC Offset: 0x08) (R/ 8) Status B -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  READY0:1;                  /**< bit:      0  Comparator 0 Ready                       */
+    uint8_t  READY1:1;                  /**< bit:      1  Comparator 1 Ready                       */
+    uint8_t  :6;                        /**< bit:   2..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint8_t  READY:2;                   /**< bit:   0..1  Comparator x Ready                       */
+    uint8_t  :6;                        /**< bit:   2..7 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint8_t  reg;                         /**< Type used for register access */
+} AC_STATUSB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_STATUSB_OFFSET                   (0x08)                                        /**<  (AC_STATUSB) Status B  Offset */
+#define AC_STATUSB_RESETVALUE               _U_(0x00)                                     /**<  (AC_STATUSB) Status B  Reset Value */
+
+#define AC_STATUSB_READY0_Pos               0                                              /**< (AC_STATUSB) Comparator 0 Ready Position */
+#define AC_STATUSB_READY0_Msk               (_U_(0x1) << AC_STATUSB_READY0_Pos)            /**< (AC_STATUSB) Comparator 0 Ready Mask */
+#define AC_STATUSB_READY0                   AC_STATUSB_READY0_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_STATUSB_READY0_Msk instead */
+#define AC_STATUSB_READY1_Pos               1                                              /**< (AC_STATUSB) Comparator 1 Ready Position */
+#define AC_STATUSB_READY1_Msk               (_U_(0x1) << AC_STATUSB_READY1_Pos)            /**< (AC_STATUSB) Comparator 1 Ready Mask */
+#define AC_STATUSB_READY1                   AC_STATUSB_READY1_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_STATUSB_READY1_Msk instead */
+#define AC_STATUSB_MASK                     _U_(0x03)                                      /**< \deprecated (AC_STATUSB) Register MASK  (Use AC_STATUSB_Msk instead)  */
+#define AC_STATUSB_Msk                      _U_(0x03)                                      /**< (AC_STATUSB) Register Mask  */
+
+#define AC_STATUSB_READY_Pos                0                                              /**< (AC_STATUSB Position) Comparator x Ready */
+#define AC_STATUSB_READY_Msk                (_U_(0x3) << AC_STATUSB_READY_Pos)             /**< (AC_STATUSB Mask) READY */
+#define AC_STATUSB_READY(value)             (AC_STATUSB_READY_Msk & ((value) << AC_STATUSB_READY_Pos))  
+
+/* -------- AC_DBGCTRL : (AC Offset: 0x09) (R/W 8) Debug Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DBGRUN:1;                  /**< bit:      0  Debug Run                                */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} AC_DBGCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_DBGCTRL_OFFSET                   (0x09)                                        /**<  (AC_DBGCTRL) Debug Control  Offset */
+#define AC_DBGCTRL_RESETVALUE               _U_(0x00)                                     /**<  (AC_DBGCTRL) Debug Control  Reset Value */
+
+#define AC_DBGCTRL_DBGRUN_Pos               0                                              /**< (AC_DBGCTRL) Debug Run Position */
+#define AC_DBGCTRL_DBGRUN_Msk               (_U_(0x1) << AC_DBGCTRL_DBGRUN_Pos)            /**< (AC_DBGCTRL) Debug Run Mask */
+#define AC_DBGCTRL_DBGRUN                   AC_DBGCTRL_DBGRUN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_DBGCTRL_DBGRUN_Msk instead */
+#define AC_DBGCTRL_MASK                     _U_(0x01)                                      /**< \deprecated (AC_DBGCTRL) Register MASK  (Use AC_DBGCTRL_Msk instead)  */
+#define AC_DBGCTRL_Msk                      _U_(0x01)                                      /**< (AC_DBGCTRL) Register Mask  */
+
+
+/* -------- AC_WINCTRL : (AC Offset: 0x0a) (R/W 8) Window Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  WEN0:1;                    /**< bit:      0  Window 0 Mode Enable                     */
+    uint8_t  WINTSEL0:2;                /**< bit:   1..2  Window 0 Interrupt Selection             */
+    uint8_t  :5;                        /**< bit:   3..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint8_t  WEN:1;                     /**< bit:      0  Window x Mode Enable                     */
+    uint8_t  :7;                        /**< bit:   1..7 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint8_t  reg;                         /**< Type used for register access */
+} AC_WINCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_WINCTRL_OFFSET                   (0x0A)                                        /**<  (AC_WINCTRL) Window Control  Offset */
+#define AC_WINCTRL_RESETVALUE               _U_(0x00)                                     /**<  (AC_WINCTRL) Window Control  Reset Value */
+
+#define AC_WINCTRL_WEN0_Pos                 0                                              /**< (AC_WINCTRL) Window 0 Mode Enable Position */
+#define AC_WINCTRL_WEN0_Msk                 (_U_(0x1) << AC_WINCTRL_WEN0_Pos)              /**< (AC_WINCTRL) Window 0 Mode Enable Mask */
+#define AC_WINCTRL_WEN0                     AC_WINCTRL_WEN0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_WINCTRL_WEN0_Msk instead */
+#define AC_WINCTRL_WINTSEL0_Pos             1                                              /**< (AC_WINCTRL) Window 0 Interrupt Selection Position */
+#define AC_WINCTRL_WINTSEL0_Msk             (_U_(0x3) << AC_WINCTRL_WINTSEL0_Pos)          /**< (AC_WINCTRL) Window 0 Interrupt Selection Mask */
+#define AC_WINCTRL_WINTSEL0(value)          (AC_WINCTRL_WINTSEL0_Msk & ((value) << AC_WINCTRL_WINTSEL0_Pos))
+#define   AC_WINCTRL_WINTSEL0_ABOVE_Val     _U_(0x0)                                       /**< (AC_WINCTRL) Interrupt on signal above window  */
+#define   AC_WINCTRL_WINTSEL0_INSIDE_Val    _U_(0x1)                                       /**< (AC_WINCTRL) Interrupt on signal inside window  */
+#define   AC_WINCTRL_WINTSEL0_BELOW_Val     _U_(0x2)                                       /**< (AC_WINCTRL) Interrupt on signal below window  */
+#define   AC_WINCTRL_WINTSEL0_OUTSIDE_Val   _U_(0x3)                                       /**< (AC_WINCTRL) Interrupt on signal outside window  */
+#define AC_WINCTRL_WINTSEL0_ABOVE           (AC_WINCTRL_WINTSEL0_ABOVE_Val << AC_WINCTRL_WINTSEL0_Pos)  /**< (AC_WINCTRL) Interrupt on signal above window Position  */
+#define AC_WINCTRL_WINTSEL0_INSIDE          (AC_WINCTRL_WINTSEL0_INSIDE_Val << AC_WINCTRL_WINTSEL0_Pos)  /**< (AC_WINCTRL) Interrupt on signal inside window Position  */
+#define AC_WINCTRL_WINTSEL0_BELOW           (AC_WINCTRL_WINTSEL0_BELOW_Val << AC_WINCTRL_WINTSEL0_Pos)  /**< (AC_WINCTRL) Interrupt on signal below window Position  */
+#define AC_WINCTRL_WINTSEL0_OUTSIDE         (AC_WINCTRL_WINTSEL0_OUTSIDE_Val << AC_WINCTRL_WINTSEL0_Pos)  /**< (AC_WINCTRL) Interrupt on signal outside window Position  */
+#define AC_WINCTRL_MASK                     _U_(0x07)                                      /**< \deprecated (AC_WINCTRL) Register MASK  (Use AC_WINCTRL_Msk instead)  */
+#define AC_WINCTRL_Msk                      _U_(0x07)                                      /**< (AC_WINCTRL) Register Mask  */
+
+#define AC_WINCTRL_WEN_Pos                  0                                              /**< (AC_WINCTRL Position) Window x Mode Enable */
+#define AC_WINCTRL_WEN_Msk                  (_U_(0x1) << AC_WINCTRL_WEN_Pos)               /**< (AC_WINCTRL Mask) WEN */
+#define AC_WINCTRL_WEN(value)               (AC_WINCTRL_WEN_Msk & ((value) << AC_WINCTRL_WEN_Pos))  
+
+/* -------- AC_SCALER : (AC Offset: 0x0c) (R/W 8) Scaler n -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  VALUE:6;                   /**< bit:   0..5  Scaler Value                             */
+    uint8_t  :2;                        /**< bit:   6..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} AC_SCALER_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_SCALER_OFFSET                    (0x0C)                                        /**<  (AC_SCALER) Scaler n  Offset */
+#define AC_SCALER_RESETVALUE                _U_(0x00)                                     /**<  (AC_SCALER) Scaler n  Reset Value */
+
+#define AC_SCALER_VALUE_Pos                 0                                              /**< (AC_SCALER) Scaler Value Position */
+#define AC_SCALER_VALUE_Msk                 (_U_(0x3F) << AC_SCALER_VALUE_Pos)             /**< (AC_SCALER) Scaler Value Mask */
+#define AC_SCALER_VALUE(value)              (AC_SCALER_VALUE_Msk & ((value) << AC_SCALER_VALUE_Pos))
+#define AC_SCALER_MASK                      _U_(0x3F)                                      /**< \deprecated (AC_SCALER) Register MASK  (Use AC_SCALER_Msk instead)  */
+#define AC_SCALER_Msk                       _U_(0x3F)                                      /**< (AC_SCALER) Register Mask  */
+
+
+/* -------- AC_COMPCTRL : (AC Offset: 0x10) (R/W 32) Comparator Control n -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint32_t SINGLE:1;                  /**< bit:      2  Single-Shot Mode                         */
+    uint32_t INTSEL:2;                  /**< bit:   3..4  Interrupt Selection                      */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t RUNSTDBY:1;                /**< bit:      6  Run in Standby                           */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t MUXNEG:3;                  /**< bit:  8..10  Negative Input Mux Selection             */
+    uint32_t :1;                        /**< bit:     11  Reserved */
+    uint32_t MUXPOS:3;                  /**< bit: 12..14  Positive Input Mux Selection             */
+    uint32_t SWAP:1;                    /**< bit:     15  Swap Inputs and Invert                   */
+    uint32_t SPEED:2;                   /**< bit: 16..17  Speed Selection                          */
+    uint32_t :1;                        /**< bit:     18  Reserved */
+    uint32_t HYSTEN:1;                  /**< bit:     19  Hysteresis Enable                        */
+    uint32_t HYST:2;                    /**< bit: 20..21  Hysteresis Level                         */
+    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t FLEN:3;                    /**< bit: 24..26  Filter Length                            */
+    uint32_t :1;                        /**< bit:     27  Reserved */
+    uint32_t OUT:2;                     /**< bit: 28..29  Output                                   */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AC_COMPCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_COMPCTRL_OFFSET                  (0x10)                                        /**<  (AC_COMPCTRL) Comparator Control n  Offset */
+#define AC_COMPCTRL_RESETVALUE              _U_(0x00)                                     /**<  (AC_COMPCTRL) Comparator Control n  Reset Value */
+
+#define AC_COMPCTRL_ENABLE_Pos              1                                              /**< (AC_COMPCTRL) Enable Position */
+#define AC_COMPCTRL_ENABLE_Msk              (_U_(0x1) << AC_COMPCTRL_ENABLE_Pos)           /**< (AC_COMPCTRL) Enable Mask */
+#define AC_COMPCTRL_ENABLE                  AC_COMPCTRL_ENABLE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_COMPCTRL_ENABLE_Msk instead */
+#define AC_COMPCTRL_SINGLE_Pos              2                                              /**< (AC_COMPCTRL) Single-Shot Mode Position */
+#define AC_COMPCTRL_SINGLE_Msk              (_U_(0x1) << AC_COMPCTRL_SINGLE_Pos)           /**< (AC_COMPCTRL) Single-Shot Mode Mask */
+#define AC_COMPCTRL_SINGLE                  AC_COMPCTRL_SINGLE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_COMPCTRL_SINGLE_Msk instead */
+#define AC_COMPCTRL_INTSEL_Pos              3                                              /**< (AC_COMPCTRL) Interrupt Selection Position */
+#define AC_COMPCTRL_INTSEL_Msk              (_U_(0x3) << AC_COMPCTRL_INTSEL_Pos)           /**< (AC_COMPCTRL) Interrupt Selection Mask */
+#define AC_COMPCTRL_INTSEL(value)           (AC_COMPCTRL_INTSEL_Msk & ((value) << AC_COMPCTRL_INTSEL_Pos))
+#define   AC_COMPCTRL_INTSEL_TOGGLE_Val     _U_(0x0)                                       /**< (AC_COMPCTRL) Interrupt on comparator output toggle  */
+#define   AC_COMPCTRL_INTSEL_RISING_Val     _U_(0x1)                                       /**< (AC_COMPCTRL) Interrupt on comparator output rising  */
+#define   AC_COMPCTRL_INTSEL_FALLING_Val    _U_(0x2)                                       /**< (AC_COMPCTRL) Interrupt on comparator output falling  */
+#define   AC_COMPCTRL_INTSEL_EOC_Val        _U_(0x3)                                       /**< (AC_COMPCTRL) Interrupt on end of comparison (single-shot mode only)  */
+#define AC_COMPCTRL_INTSEL_TOGGLE           (AC_COMPCTRL_INTSEL_TOGGLE_Val << AC_COMPCTRL_INTSEL_Pos)  /**< (AC_COMPCTRL) Interrupt on comparator output toggle Position  */
+#define AC_COMPCTRL_INTSEL_RISING           (AC_COMPCTRL_INTSEL_RISING_Val << AC_COMPCTRL_INTSEL_Pos)  /**< (AC_COMPCTRL) Interrupt on comparator output rising Position  */
+#define AC_COMPCTRL_INTSEL_FALLING          (AC_COMPCTRL_INTSEL_FALLING_Val << AC_COMPCTRL_INTSEL_Pos)  /**< (AC_COMPCTRL) Interrupt on comparator output falling Position  */
+#define AC_COMPCTRL_INTSEL_EOC              (AC_COMPCTRL_INTSEL_EOC_Val << AC_COMPCTRL_INTSEL_Pos)  /**< (AC_COMPCTRL) Interrupt on end of comparison (single-shot mode only) Position  */
+#define AC_COMPCTRL_RUNSTDBY_Pos            6                                              /**< (AC_COMPCTRL) Run in Standby Position */
+#define AC_COMPCTRL_RUNSTDBY_Msk            (_U_(0x1) << AC_COMPCTRL_RUNSTDBY_Pos)         /**< (AC_COMPCTRL) Run in Standby Mask */
+#define AC_COMPCTRL_RUNSTDBY                AC_COMPCTRL_RUNSTDBY_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_COMPCTRL_RUNSTDBY_Msk instead */
+#define AC_COMPCTRL_MUXNEG_Pos              8                                              /**< (AC_COMPCTRL) Negative Input Mux Selection Position */
+#define AC_COMPCTRL_MUXNEG_Msk              (_U_(0x7) << AC_COMPCTRL_MUXNEG_Pos)           /**< (AC_COMPCTRL) Negative Input Mux Selection Mask */
+#define AC_COMPCTRL_MUXNEG(value)           (AC_COMPCTRL_MUXNEG_Msk & ((value) << AC_COMPCTRL_MUXNEG_Pos))
+#define   AC_COMPCTRL_MUXNEG_PIN0_Val       _U_(0x0)                                       /**< (AC_COMPCTRL) I/O pin 0  */
+#define   AC_COMPCTRL_MUXNEG_PIN1_Val       _U_(0x1)                                       /**< (AC_COMPCTRL) I/O pin 1  */
+#define   AC_COMPCTRL_MUXNEG_PIN2_Val       _U_(0x2)                                       /**< (AC_COMPCTRL) I/O pin 2  */
+#define   AC_COMPCTRL_MUXNEG_PIN3_Val       _U_(0x3)                                       /**< (AC_COMPCTRL) I/O pin 3  */
+#define   AC_COMPCTRL_MUXNEG_GND_Val        _U_(0x4)                                       /**< (AC_COMPCTRL) Ground  */
+#define   AC_COMPCTRL_MUXNEG_VSCALE_Val     _U_(0x5)                                       /**< (AC_COMPCTRL) VDD scaler  */
+#define   AC_COMPCTRL_MUXNEG_BANDGAP_Val    _U_(0x6)                                       /**< (AC_COMPCTRL) Internal bandgap voltage  */
+#define   AC_COMPCTRL_MUXNEG_OPAMP_Val      _U_(0x7)                                       /**< (AC_COMPCTRL) OPAMP output (on AC1)  */
+#define   AC_COMPCTRL_MUXNEG_DAC_Val        _U_(0x7)                                       /**< (AC_COMPCTRL) DAC output (on AC0)  */
+#define AC_COMPCTRL_MUXNEG_PIN0             (AC_COMPCTRL_MUXNEG_PIN0_Val << AC_COMPCTRL_MUXNEG_Pos)  /**< (AC_COMPCTRL) I/O pin 0 Position  */
+#define AC_COMPCTRL_MUXNEG_PIN1             (AC_COMPCTRL_MUXNEG_PIN1_Val << AC_COMPCTRL_MUXNEG_Pos)  /**< (AC_COMPCTRL) I/O pin 1 Position  */
+#define AC_COMPCTRL_MUXNEG_PIN2             (AC_COMPCTRL_MUXNEG_PIN2_Val << AC_COMPCTRL_MUXNEG_Pos)  /**< (AC_COMPCTRL) I/O pin 2 Position  */
+#define AC_COMPCTRL_MUXNEG_PIN3             (AC_COMPCTRL_MUXNEG_PIN3_Val << AC_COMPCTRL_MUXNEG_Pos)  /**< (AC_COMPCTRL) I/O pin 3 Position  */
+#define AC_COMPCTRL_MUXNEG_GND              (AC_COMPCTRL_MUXNEG_GND_Val << AC_COMPCTRL_MUXNEG_Pos)  /**< (AC_COMPCTRL) Ground Position  */
+#define AC_COMPCTRL_MUXNEG_VSCALE           (AC_COMPCTRL_MUXNEG_VSCALE_Val << AC_COMPCTRL_MUXNEG_Pos)  /**< (AC_COMPCTRL) VDD scaler Position  */
+#define AC_COMPCTRL_MUXNEG_BANDGAP          (AC_COMPCTRL_MUXNEG_BANDGAP_Val << AC_COMPCTRL_MUXNEG_Pos)  /**< (AC_COMPCTRL) Internal bandgap voltage Position  */
+#define AC_COMPCTRL_MUXNEG_OPAMP            (AC_COMPCTRL_MUXNEG_OPAMP_Val << AC_COMPCTRL_MUXNEG_Pos)  /**< (AC_COMPCTRL) OPAMP output (on AC1) Position  */
+#define AC_COMPCTRL_MUXNEG_DAC              (AC_COMPCTRL_MUXNEG_DAC_Val << AC_COMPCTRL_MUXNEG_Pos)  /**< (AC_COMPCTRL) DAC output (on AC0) Position  */
+#define AC_COMPCTRL_MUXPOS_Pos              12                                             /**< (AC_COMPCTRL) Positive Input Mux Selection Position */
+#define AC_COMPCTRL_MUXPOS_Msk              (_U_(0x7) << AC_COMPCTRL_MUXPOS_Pos)           /**< (AC_COMPCTRL) Positive Input Mux Selection Mask */
+#define AC_COMPCTRL_MUXPOS(value)           (AC_COMPCTRL_MUXPOS_Msk & ((value) << AC_COMPCTRL_MUXPOS_Pos))
+#define   AC_COMPCTRL_MUXPOS_PIN0_Val       _U_(0x0)                                       /**< (AC_COMPCTRL) I/O pin 0  */
+#define   AC_COMPCTRL_MUXPOS_PIN1_Val       _U_(0x1)                                       /**< (AC_COMPCTRL) I/O pin 1  */
+#define   AC_COMPCTRL_MUXPOS_PIN2_Val       _U_(0x2)                                       /**< (AC_COMPCTRL) I/O pin 2  */
+#define   AC_COMPCTRL_MUXPOS_PIN3_Val       _U_(0x3)                                       /**< (AC_COMPCTRL) I/O pin 3  */
+#define   AC_COMPCTRL_MUXPOS_VSCALE_Val     _U_(0x4)                                       /**< (AC_COMPCTRL) VDD Scaler  */
+#define AC_COMPCTRL_MUXPOS_PIN0             (AC_COMPCTRL_MUXPOS_PIN0_Val << AC_COMPCTRL_MUXPOS_Pos)  /**< (AC_COMPCTRL) I/O pin 0 Position  */
+#define AC_COMPCTRL_MUXPOS_PIN1             (AC_COMPCTRL_MUXPOS_PIN1_Val << AC_COMPCTRL_MUXPOS_Pos)  /**< (AC_COMPCTRL) I/O pin 1 Position  */
+#define AC_COMPCTRL_MUXPOS_PIN2             (AC_COMPCTRL_MUXPOS_PIN2_Val << AC_COMPCTRL_MUXPOS_Pos)  /**< (AC_COMPCTRL) I/O pin 2 Position  */
+#define AC_COMPCTRL_MUXPOS_PIN3             (AC_COMPCTRL_MUXPOS_PIN3_Val << AC_COMPCTRL_MUXPOS_Pos)  /**< (AC_COMPCTRL) I/O pin 3 Position  */
+#define AC_COMPCTRL_MUXPOS_VSCALE           (AC_COMPCTRL_MUXPOS_VSCALE_Val << AC_COMPCTRL_MUXPOS_Pos)  /**< (AC_COMPCTRL) VDD Scaler Position  */
+#define AC_COMPCTRL_SWAP_Pos                15                                             /**< (AC_COMPCTRL) Swap Inputs and Invert Position */
+#define AC_COMPCTRL_SWAP_Msk                (_U_(0x1) << AC_COMPCTRL_SWAP_Pos)             /**< (AC_COMPCTRL) Swap Inputs and Invert Mask */
+#define AC_COMPCTRL_SWAP                    AC_COMPCTRL_SWAP_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_COMPCTRL_SWAP_Msk instead */
+#define AC_COMPCTRL_SPEED_Pos               16                                             /**< (AC_COMPCTRL) Speed Selection Position */
+#define AC_COMPCTRL_SPEED_Msk               (_U_(0x3) << AC_COMPCTRL_SPEED_Pos)            /**< (AC_COMPCTRL) Speed Selection Mask */
+#define AC_COMPCTRL_SPEED(value)            (AC_COMPCTRL_SPEED_Msk & ((value) << AC_COMPCTRL_SPEED_Pos))
+#define   AC_COMPCTRL_SPEED_LOW_Val         _U_(0x0)                                       /**< (AC_COMPCTRL) Low speed  */
+#define   AC_COMPCTRL_SPEED_MEDLOW_Val      _U_(0x1)                                       /**< (AC_COMPCTRL) Medium low speed  */
+#define   AC_COMPCTRL_SPEED_MEDHIGH_Val     _U_(0x2)                                       /**< (AC_COMPCTRL) Medium high speed  */
+#define   AC_COMPCTRL_SPEED_HIGH_Val        _U_(0x3)                                       /**< (AC_COMPCTRL) High speed  */
+#define AC_COMPCTRL_SPEED_LOW               (AC_COMPCTRL_SPEED_LOW_Val << AC_COMPCTRL_SPEED_Pos)  /**< (AC_COMPCTRL) Low speed Position  */
+#define AC_COMPCTRL_SPEED_MEDLOW            (AC_COMPCTRL_SPEED_MEDLOW_Val << AC_COMPCTRL_SPEED_Pos)  /**< (AC_COMPCTRL) Medium low speed Position  */
+#define AC_COMPCTRL_SPEED_MEDHIGH           (AC_COMPCTRL_SPEED_MEDHIGH_Val << AC_COMPCTRL_SPEED_Pos)  /**< (AC_COMPCTRL) Medium high speed Position  */
+#define AC_COMPCTRL_SPEED_HIGH              (AC_COMPCTRL_SPEED_HIGH_Val << AC_COMPCTRL_SPEED_Pos)  /**< (AC_COMPCTRL) High speed Position  */
+#define AC_COMPCTRL_HYSTEN_Pos              19                                             /**< (AC_COMPCTRL) Hysteresis Enable Position */
+#define AC_COMPCTRL_HYSTEN_Msk              (_U_(0x1) << AC_COMPCTRL_HYSTEN_Pos)           /**< (AC_COMPCTRL) Hysteresis Enable Mask */
+#define AC_COMPCTRL_HYSTEN                  AC_COMPCTRL_HYSTEN_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_COMPCTRL_HYSTEN_Msk instead */
+#define AC_COMPCTRL_HYST_Pos                20                                             /**< (AC_COMPCTRL) Hysteresis Level Position */
+#define AC_COMPCTRL_HYST_Msk                (_U_(0x3) << AC_COMPCTRL_HYST_Pos)             /**< (AC_COMPCTRL) Hysteresis Level Mask */
+#define AC_COMPCTRL_HYST(value)             (AC_COMPCTRL_HYST_Msk & ((value) << AC_COMPCTRL_HYST_Pos))
+#define   AC_COMPCTRL_HYST_HYST50_Val       _U_(0x0)                                       /**< (AC_COMPCTRL) 50mV  */
+#define   AC_COMPCTRL_HYST_HYST70_Val       _U_(0x1)                                       /**< (AC_COMPCTRL) 70mV  */
+#define   AC_COMPCTRL_HYST_HYST90_Val       _U_(0x2)                                       /**< (AC_COMPCTRL) 90mV  */
+#define   AC_COMPCTRL_HYST_HYST110_Val      _U_(0x3)                                       /**< (AC_COMPCTRL) 110mV  */
+#define AC_COMPCTRL_HYST_HYST50             (AC_COMPCTRL_HYST_HYST50_Val << AC_COMPCTRL_HYST_Pos)  /**< (AC_COMPCTRL) 50mV Position  */
+#define AC_COMPCTRL_HYST_HYST70             (AC_COMPCTRL_HYST_HYST70_Val << AC_COMPCTRL_HYST_Pos)  /**< (AC_COMPCTRL) 70mV Position  */
+#define AC_COMPCTRL_HYST_HYST90             (AC_COMPCTRL_HYST_HYST90_Val << AC_COMPCTRL_HYST_Pos)  /**< (AC_COMPCTRL) 90mV Position  */
+#define AC_COMPCTRL_HYST_HYST110            (AC_COMPCTRL_HYST_HYST110_Val << AC_COMPCTRL_HYST_Pos)  /**< (AC_COMPCTRL) 110mV Position  */
+#define AC_COMPCTRL_FLEN_Pos                24                                             /**< (AC_COMPCTRL) Filter Length Position */
+#define AC_COMPCTRL_FLEN_Msk                (_U_(0x7) << AC_COMPCTRL_FLEN_Pos)             /**< (AC_COMPCTRL) Filter Length Mask */
+#define AC_COMPCTRL_FLEN(value)             (AC_COMPCTRL_FLEN_Msk & ((value) << AC_COMPCTRL_FLEN_Pos))
+#define   AC_COMPCTRL_FLEN_OFF_Val          _U_(0x0)                                       /**< (AC_COMPCTRL) No filtering  */
+#define   AC_COMPCTRL_FLEN_MAJ3_Val         _U_(0x1)                                       /**< (AC_COMPCTRL) 3-bit majority function (2 of 3)  */
+#define   AC_COMPCTRL_FLEN_MAJ5_Val         _U_(0x2)                                       /**< (AC_COMPCTRL) 5-bit majority function (3 of 5)  */
+#define AC_COMPCTRL_FLEN_OFF                (AC_COMPCTRL_FLEN_OFF_Val << AC_COMPCTRL_FLEN_Pos)  /**< (AC_COMPCTRL) No filtering Position  */
+#define AC_COMPCTRL_FLEN_MAJ3               (AC_COMPCTRL_FLEN_MAJ3_Val << AC_COMPCTRL_FLEN_Pos)  /**< (AC_COMPCTRL) 3-bit majority function (2 of 3) Position  */
+#define AC_COMPCTRL_FLEN_MAJ5               (AC_COMPCTRL_FLEN_MAJ5_Val << AC_COMPCTRL_FLEN_Pos)  /**< (AC_COMPCTRL) 5-bit majority function (3 of 5) Position  */
+#define AC_COMPCTRL_OUT_Pos                 28                                             /**< (AC_COMPCTRL) Output Position */
+#define AC_COMPCTRL_OUT_Msk                 (_U_(0x3) << AC_COMPCTRL_OUT_Pos)              /**< (AC_COMPCTRL) Output Mask */
+#define AC_COMPCTRL_OUT(value)              (AC_COMPCTRL_OUT_Msk & ((value) << AC_COMPCTRL_OUT_Pos))
+#define   AC_COMPCTRL_OUT_OFF_Val           _U_(0x0)                                       /**< (AC_COMPCTRL) The output of COMPn is not routed to the COMPn I/O port  */
+#define   AC_COMPCTRL_OUT_ASYNC_Val         _U_(0x1)                                       /**< (AC_COMPCTRL) The asynchronous output of COMPn is routed to the COMPn I/O port  */
+#define   AC_COMPCTRL_OUT_SYNC_Val          _U_(0x2)                                       /**< (AC_COMPCTRL) The synchronous output (including filtering) of COMPn is routed to the COMPn I/O port  */
+#define AC_COMPCTRL_OUT_OFF                 (AC_COMPCTRL_OUT_OFF_Val << AC_COMPCTRL_OUT_Pos)  /**< (AC_COMPCTRL) The output of COMPn is not routed to the COMPn I/O port Position  */
+#define AC_COMPCTRL_OUT_ASYNC               (AC_COMPCTRL_OUT_ASYNC_Val << AC_COMPCTRL_OUT_Pos)  /**< (AC_COMPCTRL) The asynchronous output of COMPn is routed to the COMPn I/O port Position  */
+#define AC_COMPCTRL_OUT_SYNC                (AC_COMPCTRL_OUT_SYNC_Val << AC_COMPCTRL_OUT_Pos)  /**< (AC_COMPCTRL) The synchronous output (including filtering) of COMPn is routed to the COMPn I/O port Position  */
+#define AC_COMPCTRL_MASK                    _U_(0x373BF75E)                                /**< \deprecated (AC_COMPCTRL) Register MASK  (Use AC_COMPCTRL_Msk instead)  */
+#define AC_COMPCTRL_Msk                     _U_(0x373BF75E)                                /**< (AC_COMPCTRL) Register Mask  */
+
+
+/* -------- AC_SYNCBUSY : (AC Offset: 0x20) (R/ 32) Synchronization Busy -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SWRST:1;                   /**< bit:      0  Software Reset Synchronization Busy      */
+    uint32_t ENABLE:1;                  /**< bit:      1  Enable Synchronization Busy              */
+    uint32_t WINCTRL:1;                 /**< bit:      2  WINCTRL Synchronization Busy             */
+    uint32_t COMPCTRL0:1;               /**< bit:      3  COMPCTRL 0 Synchronization Busy          */
+    uint32_t COMPCTRL1:1;               /**< bit:      4  COMPCTRL 1 Synchronization Busy          */
+    uint32_t :27;                       /**< bit:  5..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :3;                        /**< bit:   0..2  Reserved */
+    uint32_t COMPCTRL:2;                /**< bit:   3..4  COMPCTRL x Synchronization Busy          */
+    uint32_t :27;                       /**< bit:  5..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} AC_SYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_SYNCBUSY_OFFSET                  (0x20)                                        /**<  (AC_SYNCBUSY) Synchronization Busy  Offset */
+#define AC_SYNCBUSY_RESETVALUE              _U_(0x00)                                     /**<  (AC_SYNCBUSY) Synchronization Busy  Reset Value */
+
+#define AC_SYNCBUSY_SWRST_Pos               0                                              /**< (AC_SYNCBUSY) Software Reset Synchronization Busy Position */
+#define AC_SYNCBUSY_SWRST_Msk               (_U_(0x1) << AC_SYNCBUSY_SWRST_Pos)            /**< (AC_SYNCBUSY) Software Reset Synchronization Busy Mask */
+#define AC_SYNCBUSY_SWRST                   AC_SYNCBUSY_SWRST_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_SYNCBUSY_SWRST_Msk instead */
+#define AC_SYNCBUSY_ENABLE_Pos              1                                              /**< (AC_SYNCBUSY) Enable Synchronization Busy Position */
+#define AC_SYNCBUSY_ENABLE_Msk              (_U_(0x1) << AC_SYNCBUSY_ENABLE_Pos)           /**< (AC_SYNCBUSY) Enable Synchronization Busy Mask */
+#define AC_SYNCBUSY_ENABLE                  AC_SYNCBUSY_ENABLE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_SYNCBUSY_ENABLE_Msk instead */
+#define AC_SYNCBUSY_WINCTRL_Pos             2                                              /**< (AC_SYNCBUSY) WINCTRL Synchronization Busy Position */
+#define AC_SYNCBUSY_WINCTRL_Msk             (_U_(0x1) << AC_SYNCBUSY_WINCTRL_Pos)          /**< (AC_SYNCBUSY) WINCTRL Synchronization Busy Mask */
+#define AC_SYNCBUSY_WINCTRL                 AC_SYNCBUSY_WINCTRL_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_SYNCBUSY_WINCTRL_Msk instead */
+#define AC_SYNCBUSY_COMPCTRL0_Pos           3                                              /**< (AC_SYNCBUSY) COMPCTRL 0 Synchronization Busy Position */
+#define AC_SYNCBUSY_COMPCTRL0_Msk           (_U_(0x1) << AC_SYNCBUSY_COMPCTRL0_Pos)        /**< (AC_SYNCBUSY) COMPCTRL 0 Synchronization Busy Mask */
+#define AC_SYNCBUSY_COMPCTRL0               AC_SYNCBUSY_COMPCTRL0_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_SYNCBUSY_COMPCTRL0_Msk instead */
+#define AC_SYNCBUSY_COMPCTRL1_Pos           4                                              /**< (AC_SYNCBUSY) COMPCTRL 1 Synchronization Busy Position */
+#define AC_SYNCBUSY_COMPCTRL1_Msk           (_U_(0x1) << AC_SYNCBUSY_COMPCTRL1_Pos)        /**< (AC_SYNCBUSY) COMPCTRL 1 Synchronization Busy Mask */
+#define AC_SYNCBUSY_COMPCTRL1               AC_SYNCBUSY_COMPCTRL1_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use AC_SYNCBUSY_COMPCTRL1_Msk instead */
+#define AC_SYNCBUSY_MASK                    _U_(0x1F)                                      /**< \deprecated (AC_SYNCBUSY) Register MASK  (Use AC_SYNCBUSY_Msk instead)  */
+#define AC_SYNCBUSY_Msk                     _U_(0x1F)                                      /**< (AC_SYNCBUSY) Register Mask  */
+
+#define AC_SYNCBUSY_COMPCTRL_Pos            3                                              /**< (AC_SYNCBUSY Position) COMPCTRL x Synchronization Busy */
+#define AC_SYNCBUSY_COMPCTRL_Msk            (_U_(0x3) << AC_SYNCBUSY_COMPCTRL_Pos)         /**< (AC_SYNCBUSY Mask) COMPCTRL */
+#define AC_SYNCBUSY_COMPCTRL(value)         (AC_SYNCBUSY_COMPCTRL_Msk & ((value) << AC_SYNCBUSY_COMPCTRL_Pos))  
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief AC hardware registers */
+typedef struct {  /* Analog Comparators */
+  __IO AC_CTRLA_Type                  CTRLA;          /**< Offset: 0x00 (R/W   8) Control A */
+  __O  AC_CTRLB_Type                  CTRLB;          /**< Offset: 0x01 ( /W   8) Control B */
+  __IO AC_EVCTRL_Type                 EVCTRL;         /**< Offset: 0x02 (R/W  16) Event Control */
+  __IO AC_INTENCLR_Type               INTENCLR;       /**< Offset: 0x04 (R/W   8) Interrupt Enable Clear */
+  __IO AC_INTENSET_Type               INTENSET;       /**< Offset: 0x05 (R/W   8) Interrupt Enable Set */
+  __IO AC_INTFLAG_Type                INTFLAG;        /**< Offset: 0x06 (R/W   8) Interrupt Flag Status and Clear */
+  __I  AC_STATUSA_Type                STATUSA;        /**< Offset: 0x07 (R/    8) Status A */
+  __I  AC_STATUSB_Type                STATUSB;        /**< Offset: 0x08 (R/    8) Status B */
+  __IO AC_DBGCTRL_Type                DBGCTRL;        /**< Offset: 0x09 (R/W   8) Debug Control */
+  __IO AC_WINCTRL_Type                WINCTRL;        /**< Offset: 0x0A (R/W   8) Window Control */
+  __I  uint8_t                        Reserved1[1];
+  __IO AC_SCALER_Type                 SCALER[2];      /**< Offset: 0x0C (R/W   8) Scaler n */
+  __I  uint8_t                        Reserved2[2];
+  __IO AC_COMPCTRL_Type               COMPCTRL[2];    /**< Offset: 0x10 (R/W  32) Comparator Control n */
+  __I  uint8_t                        Reserved3[8];
+  __I  AC_SYNCBUSY_Type               SYNCBUSY;       /**< Offset: 0x20 (R/   32) Synchronization Busy */
+} Ac;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Analog Comparators */
+
+#endif /* _SAML11_AC_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/component/adc.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/adc.h
@@ -1,0 +1,851 @@
+/**
+ * \file
+ *
+ * \brief Component description for ADC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_ADC_COMPONENT_H_
+#define _SAML11_ADC_COMPONENT_H_
+#define _SAML11_ADC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML11 Analog Digital Converter
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR ADC */
+/* ========================================================================== */
+
+#define ADC_U2247                      /**< (ADC) Module ID */
+#define REV_ADC 0x240                  /**< (ADC) Module revision */
+
+/* -------- ADC_CTRLA : (ADC Offset: 0x00) (R/W 8) Control A -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint8_t  ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint8_t  :3;                        /**< bit:   2..4  Reserved */
+    uint8_t  SLAVEEN:1;                 /**< bit:      5  Slave Enable                             */
+    uint8_t  RUNSTDBY:1;                /**< bit:      6  Run During Standby                       */
+    uint8_t  ONDEMAND:1;                /**< bit:      7  On Demand Control                        */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} ADC_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_CTRLA_OFFSET                    (0x00)                                        /**<  (ADC_CTRLA) Control A  Offset */
+#define ADC_CTRLA_RESETVALUE                _U_(0x00)                                     /**<  (ADC_CTRLA) Control A  Reset Value */
+
+#define ADC_CTRLA_SWRST_Pos                 0                                              /**< (ADC_CTRLA) Software Reset Position */
+#define ADC_CTRLA_SWRST_Msk                 (_U_(0x1) << ADC_CTRLA_SWRST_Pos)              /**< (ADC_CTRLA) Software Reset Mask */
+#define ADC_CTRLA_SWRST                     ADC_CTRLA_SWRST_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_CTRLA_SWRST_Msk instead */
+#define ADC_CTRLA_ENABLE_Pos                1                                              /**< (ADC_CTRLA) Enable Position */
+#define ADC_CTRLA_ENABLE_Msk                (_U_(0x1) << ADC_CTRLA_ENABLE_Pos)             /**< (ADC_CTRLA) Enable Mask */
+#define ADC_CTRLA_ENABLE                    ADC_CTRLA_ENABLE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_CTRLA_ENABLE_Msk instead */
+#define ADC_CTRLA_SLAVEEN_Pos               5                                              /**< (ADC_CTRLA) Slave Enable Position */
+#define ADC_CTRLA_SLAVEEN_Msk               (_U_(0x1) << ADC_CTRLA_SLAVEEN_Pos)            /**< (ADC_CTRLA) Slave Enable Mask */
+#define ADC_CTRLA_SLAVEEN                   ADC_CTRLA_SLAVEEN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_CTRLA_SLAVEEN_Msk instead */
+#define ADC_CTRLA_RUNSTDBY_Pos              6                                              /**< (ADC_CTRLA) Run During Standby Position */
+#define ADC_CTRLA_RUNSTDBY_Msk              (_U_(0x1) << ADC_CTRLA_RUNSTDBY_Pos)           /**< (ADC_CTRLA) Run During Standby Mask */
+#define ADC_CTRLA_RUNSTDBY                  ADC_CTRLA_RUNSTDBY_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_CTRLA_RUNSTDBY_Msk instead */
+#define ADC_CTRLA_ONDEMAND_Pos              7                                              /**< (ADC_CTRLA) On Demand Control Position */
+#define ADC_CTRLA_ONDEMAND_Msk              (_U_(0x1) << ADC_CTRLA_ONDEMAND_Pos)           /**< (ADC_CTRLA) On Demand Control Mask */
+#define ADC_CTRLA_ONDEMAND                  ADC_CTRLA_ONDEMAND_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_CTRLA_ONDEMAND_Msk instead */
+#define ADC_CTRLA_MASK                      _U_(0xE3)                                      /**< \deprecated (ADC_CTRLA) Register MASK  (Use ADC_CTRLA_Msk instead)  */
+#define ADC_CTRLA_Msk                       _U_(0xE3)                                      /**< (ADC_CTRLA) Register Mask  */
+
+
+/* -------- ADC_CTRLB : (ADC Offset: 0x01) (R/W 8) Control B -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  PRESCALER:3;               /**< bit:   0..2  Prescaler Configuration                  */
+    uint8_t  :5;                        /**< bit:   3..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} ADC_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_CTRLB_OFFSET                    (0x01)                                        /**<  (ADC_CTRLB) Control B  Offset */
+#define ADC_CTRLB_RESETVALUE                _U_(0x00)                                     /**<  (ADC_CTRLB) Control B  Reset Value */
+
+#define ADC_CTRLB_PRESCALER_Pos             0                                              /**< (ADC_CTRLB) Prescaler Configuration Position */
+#define ADC_CTRLB_PRESCALER_Msk             (_U_(0x7) << ADC_CTRLB_PRESCALER_Pos)          /**< (ADC_CTRLB) Prescaler Configuration Mask */
+#define ADC_CTRLB_PRESCALER(value)          (ADC_CTRLB_PRESCALER_Msk & ((value) << ADC_CTRLB_PRESCALER_Pos))
+#define   ADC_CTRLB_PRESCALER_DIV2_Val      _U_(0x0)                                       /**< (ADC_CTRLB) Peripheral clock divided by 2  */
+#define   ADC_CTRLB_PRESCALER_DIV4_Val      _U_(0x1)                                       /**< (ADC_CTRLB) Peripheral clock divided by 4  */
+#define   ADC_CTRLB_PRESCALER_DIV8_Val      _U_(0x2)                                       /**< (ADC_CTRLB) Peripheral clock divided by 8  */
+#define   ADC_CTRLB_PRESCALER_DIV16_Val     _U_(0x3)                                       /**< (ADC_CTRLB) Peripheral clock divided by 16  */
+#define   ADC_CTRLB_PRESCALER_DIV32_Val     _U_(0x4)                                       /**< (ADC_CTRLB) Peripheral clock divided by 32  */
+#define   ADC_CTRLB_PRESCALER_DIV64_Val     _U_(0x5)                                       /**< (ADC_CTRLB) Peripheral clock divided by 64  */
+#define   ADC_CTRLB_PRESCALER_DIV128_Val    _U_(0x6)                                       /**< (ADC_CTRLB) Peripheral clock divided by 128  */
+#define   ADC_CTRLB_PRESCALER_DIV256_Val    _U_(0x7)                                       /**< (ADC_CTRLB) Peripheral clock divided by 256  */
+#define ADC_CTRLB_PRESCALER_DIV2            (ADC_CTRLB_PRESCALER_DIV2_Val << ADC_CTRLB_PRESCALER_Pos)  /**< (ADC_CTRLB) Peripheral clock divided by 2 Position  */
+#define ADC_CTRLB_PRESCALER_DIV4            (ADC_CTRLB_PRESCALER_DIV4_Val << ADC_CTRLB_PRESCALER_Pos)  /**< (ADC_CTRLB) Peripheral clock divided by 4 Position  */
+#define ADC_CTRLB_PRESCALER_DIV8            (ADC_CTRLB_PRESCALER_DIV8_Val << ADC_CTRLB_PRESCALER_Pos)  /**< (ADC_CTRLB) Peripheral clock divided by 8 Position  */
+#define ADC_CTRLB_PRESCALER_DIV16           (ADC_CTRLB_PRESCALER_DIV16_Val << ADC_CTRLB_PRESCALER_Pos)  /**< (ADC_CTRLB) Peripheral clock divided by 16 Position  */
+#define ADC_CTRLB_PRESCALER_DIV32           (ADC_CTRLB_PRESCALER_DIV32_Val << ADC_CTRLB_PRESCALER_Pos)  /**< (ADC_CTRLB) Peripheral clock divided by 32 Position  */
+#define ADC_CTRLB_PRESCALER_DIV64           (ADC_CTRLB_PRESCALER_DIV64_Val << ADC_CTRLB_PRESCALER_Pos)  /**< (ADC_CTRLB) Peripheral clock divided by 64 Position  */
+#define ADC_CTRLB_PRESCALER_DIV128          (ADC_CTRLB_PRESCALER_DIV128_Val << ADC_CTRLB_PRESCALER_Pos)  /**< (ADC_CTRLB) Peripheral clock divided by 128 Position  */
+#define ADC_CTRLB_PRESCALER_DIV256          (ADC_CTRLB_PRESCALER_DIV256_Val << ADC_CTRLB_PRESCALER_Pos)  /**< (ADC_CTRLB) Peripheral clock divided by 256 Position  */
+#define ADC_CTRLB_MASK                      _U_(0x07)                                      /**< \deprecated (ADC_CTRLB) Register MASK  (Use ADC_CTRLB_Msk instead)  */
+#define ADC_CTRLB_Msk                       _U_(0x07)                                      /**< (ADC_CTRLB) Register Mask  */
+
+
+/* -------- ADC_REFCTRL : (ADC Offset: 0x02) (R/W 8) Reference Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  REFSEL:4;                  /**< bit:   0..3  Reference Selection                      */
+    uint8_t  :3;                        /**< bit:   4..6  Reserved */
+    uint8_t  REFCOMP:1;                 /**< bit:      7  Reference Buffer Offset Compensation Enable */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} ADC_REFCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_REFCTRL_OFFSET                  (0x02)                                        /**<  (ADC_REFCTRL) Reference Control  Offset */
+#define ADC_REFCTRL_RESETVALUE              _U_(0x00)                                     /**<  (ADC_REFCTRL) Reference Control  Reset Value */
+
+#define ADC_REFCTRL_REFSEL_Pos              0                                              /**< (ADC_REFCTRL) Reference Selection Position */
+#define ADC_REFCTRL_REFSEL_Msk              (_U_(0xF) << ADC_REFCTRL_REFSEL_Pos)           /**< (ADC_REFCTRL) Reference Selection Mask */
+#define ADC_REFCTRL_REFSEL(value)           (ADC_REFCTRL_REFSEL_Msk & ((value) << ADC_REFCTRL_REFSEL_Pos))
+#define   ADC_REFCTRL_REFSEL_INTREF_Val     _U_(0x0)                                       /**< (ADC_REFCTRL) Internal Bandgap Reference  */
+#define   ADC_REFCTRL_REFSEL_INTVCC0_Val    _U_(0x1)                                       /**< (ADC_REFCTRL) 1/1.6 VDDANA  */
+#define   ADC_REFCTRL_REFSEL_INTVCC1_Val    _U_(0x2)                                       /**< (ADC_REFCTRL) 1/2 VDDANA  */
+#define   ADC_REFCTRL_REFSEL_AREFA_Val      _U_(0x3)                                       /**< (ADC_REFCTRL) External Reference  */
+#define   ADC_REFCTRL_REFSEL_AREFB_Val      _U_(0x4)                                       /**< (ADC_REFCTRL) External Reference  */
+#define   ADC_REFCTRL_REFSEL_INTVCC2_Val    _U_(0x5)                                       /**< (ADC_REFCTRL) VCCANA  */
+#define ADC_REFCTRL_REFSEL_INTREF           (ADC_REFCTRL_REFSEL_INTREF_Val << ADC_REFCTRL_REFSEL_Pos)  /**< (ADC_REFCTRL) Internal Bandgap Reference Position  */
+#define ADC_REFCTRL_REFSEL_INTVCC0          (ADC_REFCTRL_REFSEL_INTVCC0_Val << ADC_REFCTRL_REFSEL_Pos)  /**< (ADC_REFCTRL) 1/1.6 VDDANA Position  */
+#define ADC_REFCTRL_REFSEL_INTVCC1          (ADC_REFCTRL_REFSEL_INTVCC1_Val << ADC_REFCTRL_REFSEL_Pos)  /**< (ADC_REFCTRL) 1/2 VDDANA Position  */
+#define ADC_REFCTRL_REFSEL_AREFA            (ADC_REFCTRL_REFSEL_AREFA_Val << ADC_REFCTRL_REFSEL_Pos)  /**< (ADC_REFCTRL) External Reference Position  */
+#define ADC_REFCTRL_REFSEL_AREFB            (ADC_REFCTRL_REFSEL_AREFB_Val << ADC_REFCTRL_REFSEL_Pos)  /**< (ADC_REFCTRL) External Reference Position  */
+#define ADC_REFCTRL_REFSEL_INTVCC2          (ADC_REFCTRL_REFSEL_INTVCC2_Val << ADC_REFCTRL_REFSEL_Pos)  /**< (ADC_REFCTRL) VCCANA Position  */
+#define ADC_REFCTRL_REFCOMP_Pos             7                                              /**< (ADC_REFCTRL) Reference Buffer Offset Compensation Enable Position */
+#define ADC_REFCTRL_REFCOMP_Msk             (_U_(0x1) << ADC_REFCTRL_REFCOMP_Pos)          /**< (ADC_REFCTRL) Reference Buffer Offset Compensation Enable Mask */
+#define ADC_REFCTRL_REFCOMP                 ADC_REFCTRL_REFCOMP_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_REFCTRL_REFCOMP_Msk instead */
+#define ADC_REFCTRL_MASK                    _U_(0x8F)                                      /**< \deprecated (ADC_REFCTRL) Register MASK  (Use ADC_REFCTRL_Msk instead)  */
+#define ADC_REFCTRL_Msk                     _U_(0x8F)                                      /**< (ADC_REFCTRL) Register Mask  */
+
+
+/* -------- ADC_EVCTRL : (ADC Offset: 0x03) (R/W 8) Event Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  FLUSHEI:1;                 /**< bit:      0  Flush Event Input Enable                 */
+    uint8_t  STARTEI:1;                 /**< bit:      1  Start Conversion Event Input Enable      */
+    uint8_t  FLUSHINV:1;                /**< bit:      2  Flush Event Invert Enable                */
+    uint8_t  STARTINV:1;                /**< bit:      3  Satrt Event Invert Enable                */
+    uint8_t  RESRDYEO:1;                /**< bit:      4  Result Ready Event Out                   */
+    uint8_t  WINMONEO:1;                /**< bit:      5  Window Monitor Event Out                 */
+    uint8_t  :2;                        /**< bit:   6..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} ADC_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_EVCTRL_OFFSET                   (0x03)                                        /**<  (ADC_EVCTRL) Event Control  Offset */
+#define ADC_EVCTRL_RESETVALUE               _U_(0x00)                                     /**<  (ADC_EVCTRL) Event Control  Reset Value */
+
+#define ADC_EVCTRL_FLUSHEI_Pos              0                                              /**< (ADC_EVCTRL) Flush Event Input Enable Position */
+#define ADC_EVCTRL_FLUSHEI_Msk              (_U_(0x1) << ADC_EVCTRL_FLUSHEI_Pos)           /**< (ADC_EVCTRL) Flush Event Input Enable Mask */
+#define ADC_EVCTRL_FLUSHEI                  ADC_EVCTRL_FLUSHEI_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_EVCTRL_FLUSHEI_Msk instead */
+#define ADC_EVCTRL_STARTEI_Pos              1                                              /**< (ADC_EVCTRL) Start Conversion Event Input Enable Position */
+#define ADC_EVCTRL_STARTEI_Msk              (_U_(0x1) << ADC_EVCTRL_STARTEI_Pos)           /**< (ADC_EVCTRL) Start Conversion Event Input Enable Mask */
+#define ADC_EVCTRL_STARTEI                  ADC_EVCTRL_STARTEI_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_EVCTRL_STARTEI_Msk instead */
+#define ADC_EVCTRL_FLUSHINV_Pos             2                                              /**< (ADC_EVCTRL) Flush Event Invert Enable Position */
+#define ADC_EVCTRL_FLUSHINV_Msk             (_U_(0x1) << ADC_EVCTRL_FLUSHINV_Pos)          /**< (ADC_EVCTRL) Flush Event Invert Enable Mask */
+#define ADC_EVCTRL_FLUSHINV                 ADC_EVCTRL_FLUSHINV_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_EVCTRL_FLUSHINV_Msk instead */
+#define ADC_EVCTRL_STARTINV_Pos             3                                              /**< (ADC_EVCTRL) Satrt Event Invert Enable Position */
+#define ADC_EVCTRL_STARTINV_Msk             (_U_(0x1) << ADC_EVCTRL_STARTINV_Pos)          /**< (ADC_EVCTRL) Satrt Event Invert Enable Mask */
+#define ADC_EVCTRL_STARTINV                 ADC_EVCTRL_STARTINV_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_EVCTRL_STARTINV_Msk instead */
+#define ADC_EVCTRL_RESRDYEO_Pos             4                                              /**< (ADC_EVCTRL) Result Ready Event Out Position */
+#define ADC_EVCTRL_RESRDYEO_Msk             (_U_(0x1) << ADC_EVCTRL_RESRDYEO_Pos)          /**< (ADC_EVCTRL) Result Ready Event Out Mask */
+#define ADC_EVCTRL_RESRDYEO                 ADC_EVCTRL_RESRDYEO_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_EVCTRL_RESRDYEO_Msk instead */
+#define ADC_EVCTRL_WINMONEO_Pos             5                                              /**< (ADC_EVCTRL) Window Monitor Event Out Position */
+#define ADC_EVCTRL_WINMONEO_Msk             (_U_(0x1) << ADC_EVCTRL_WINMONEO_Pos)          /**< (ADC_EVCTRL) Window Monitor Event Out Mask */
+#define ADC_EVCTRL_WINMONEO                 ADC_EVCTRL_WINMONEO_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_EVCTRL_WINMONEO_Msk instead */
+#define ADC_EVCTRL_MASK                     _U_(0x3F)                                      /**< \deprecated (ADC_EVCTRL) Register MASK  (Use ADC_EVCTRL_Msk instead)  */
+#define ADC_EVCTRL_Msk                      _U_(0x3F)                                      /**< (ADC_EVCTRL) Register Mask  */
+
+
+/* -------- ADC_INTENCLR : (ADC Offset: 0x04) (R/W 8) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  RESRDY:1;                  /**< bit:      0  Result Ready Interrupt Disable           */
+    uint8_t  OVERRUN:1;                 /**< bit:      1  Overrun Interrupt Disable                */
+    uint8_t  WINMON:1;                  /**< bit:      2  Window Monitor Interrupt Disable         */
+    uint8_t  :5;                        /**< bit:   3..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} ADC_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_INTENCLR_OFFSET                 (0x04)                                        /**<  (ADC_INTENCLR) Interrupt Enable Clear  Offset */
+#define ADC_INTENCLR_RESETVALUE             _U_(0x00)                                     /**<  (ADC_INTENCLR) Interrupt Enable Clear  Reset Value */
+
+#define ADC_INTENCLR_RESRDY_Pos             0                                              /**< (ADC_INTENCLR) Result Ready Interrupt Disable Position */
+#define ADC_INTENCLR_RESRDY_Msk             (_U_(0x1) << ADC_INTENCLR_RESRDY_Pos)          /**< (ADC_INTENCLR) Result Ready Interrupt Disable Mask */
+#define ADC_INTENCLR_RESRDY                 ADC_INTENCLR_RESRDY_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_INTENCLR_RESRDY_Msk instead */
+#define ADC_INTENCLR_OVERRUN_Pos            1                                              /**< (ADC_INTENCLR) Overrun Interrupt Disable Position */
+#define ADC_INTENCLR_OVERRUN_Msk            (_U_(0x1) << ADC_INTENCLR_OVERRUN_Pos)         /**< (ADC_INTENCLR) Overrun Interrupt Disable Mask */
+#define ADC_INTENCLR_OVERRUN                ADC_INTENCLR_OVERRUN_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_INTENCLR_OVERRUN_Msk instead */
+#define ADC_INTENCLR_WINMON_Pos             2                                              /**< (ADC_INTENCLR) Window Monitor Interrupt Disable Position */
+#define ADC_INTENCLR_WINMON_Msk             (_U_(0x1) << ADC_INTENCLR_WINMON_Pos)          /**< (ADC_INTENCLR) Window Monitor Interrupt Disable Mask */
+#define ADC_INTENCLR_WINMON                 ADC_INTENCLR_WINMON_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_INTENCLR_WINMON_Msk instead */
+#define ADC_INTENCLR_MASK                   _U_(0x07)                                      /**< \deprecated (ADC_INTENCLR) Register MASK  (Use ADC_INTENCLR_Msk instead)  */
+#define ADC_INTENCLR_Msk                    _U_(0x07)                                      /**< (ADC_INTENCLR) Register Mask  */
+
+
+/* -------- ADC_INTENSET : (ADC Offset: 0x05) (R/W 8) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  RESRDY:1;                  /**< bit:      0  Result Ready Interrupt Enable            */
+    uint8_t  OVERRUN:1;                 /**< bit:      1  Overrun Interrupt Enable                 */
+    uint8_t  WINMON:1;                  /**< bit:      2  Window Monitor Interrupt Enable          */
+    uint8_t  :5;                        /**< bit:   3..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} ADC_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_INTENSET_OFFSET                 (0x05)                                        /**<  (ADC_INTENSET) Interrupt Enable Set  Offset */
+#define ADC_INTENSET_RESETVALUE             _U_(0x00)                                     /**<  (ADC_INTENSET) Interrupt Enable Set  Reset Value */
+
+#define ADC_INTENSET_RESRDY_Pos             0                                              /**< (ADC_INTENSET) Result Ready Interrupt Enable Position */
+#define ADC_INTENSET_RESRDY_Msk             (_U_(0x1) << ADC_INTENSET_RESRDY_Pos)          /**< (ADC_INTENSET) Result Ready Interrupt Enable Mask */
+#define ADC_INTENSET_RESRDY                 ADC_INTENSET_RESRDY_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_INTENSET_RESRDY_Msk instead */
+#define ADC_INTENSET_OVERRUN_Pos            1                                              /**< (ADC_INTENSET) Overrun Interrupt Enable Position */
+#define ADC_INTENSET_OVERRUN_Msk            (_U_(0x1) << ADC_INTENSET_OVERRUN_Pos)         /**< (ADC_INTENSET) Overrun Interrupt Enable Mask */
+#define ADC_INTENSET_OVERRUN                ADC_INTENSET_OVERRUN_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_INTENSET_OVERRUN_Msk instead */
+#define ADC_INTENSET_WINMON_Pos             2                                              /**< (ADC_INTENSET) Window Monitor Interrupt Enable Position */
+#define ADC_INTENSET_WINMON_Msk             (_U_(0x1) << ADC_INTENSET_WINMON_Pos)          /**< (ADC_INTENSET) Window Monitor Interrupt Enable Mask */
+#define ADC_INTENSET_WINMON                 ADC_INTENSET_WINMON_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_INTENSET_WINMON_Msk instead */
+#define ADC_INTENSET_MASK                   _U_(0x07)                                      /**< \deprecated (ADC_INTENSET) Register MASK  (Use ADC_INTENSET_Msk instead)  */
+#define ADC_INTENSET_Msk                    _U_(0x07)                                      /**< (ADC_INTENSET) Register Mask  */
+
+
+/* -------- ADC_INTFLAG : (ADC Offset: 0x06) (R/W 8) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t RESRDY:1;                  /**< bit:      0  Result Ready Interrupt Flag              */
+    __I uint8_t OVERRUN:1;                 /**< bit:      1  Overrun Interrupt Flag                   */
+    __I uint8_t WINMON:1;                  /**< bit:      2  Window Monitor Interrupt Flag            */
+    __I uint8_t :5;                        /**< bit:   3..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} ADC_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_INTFLAG_OFFSET                  (0x06)                                        /**<  (ADC_INTFLAG) Interrupt Flag Status and Clear  Offset */
+#define ADC_INTFLAG_RESETVALUE              _U_(0x00)                                     /**<  (ADC_INTFLAG) Interrupt Flag Status and Clear  Reset Value */
+
+#define ADC_INTFLAG_RESRDY_Pos              0                                              /**< (ADC_INTFLAG) Result Ready Interrupt Flag Position */
+#define ADC_INTFLAG_RESRDY_Msk              (_U_(0x1) << ADC_INTFLAG_RESRDY_Pos)           /**< (ADC_INTFLAG) Result Ready Interrupt Flag Mask */
+#define ADC_INTFLAG_RESRDY                  ADC_INTFLAG_RESRDY_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_INTFLAG_RESRDY_Msk instead */
+#define ADC_INTFLAG_OVERRUN_Pos             1                                              /**< (ADC_INTFLAG) Overrun Interrupt Flag Position */
+#define ADC_INTFLAG_OVERRUN_Msk             (_U_(0x1) << ADC_INTFLAG_OVERRUN_Pos)          /**< (ADC_INTFLAG) Overrun Interrupt Flag Mask */
+#define ADC_INTFLAG_OVERRUN                 ADC_INTFLAG_OVERRUN_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_INTFLAG_OVERRUN_Msk instead */
+#define ADC_INTFLAG_WINMON_Pos              2                                              /**< (ADC_INTFLAG) Window Monitor Interrupt Flag Position */
+#define ADC_INTFLAG_WINMON_Msk              (_U_(0x1) << ADC_INTFLAG_WINMON_Pos)           /**< (ADC_INTFLAG) Window Monitor Interrupt Flag Mask */
+#define ADC_INTFLAG_WINMON                  ADC_INTFLAG_WINMON_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_INTFLAG_WINMON_Msk instead */
+#define ADC_INTFLAG_MASK                    _U_(0x07)                                      /**< \deprecated (ADC_INTFLAG) Register MASK  (Use ADC_INTFLAG_Msk instead)  */
+#define ADC_INTFLAG_Msk                     _U_(0x07)                                      /**< (ADC_INTFLAG) Register Mask  */
+
+
+/* -------- ADC_SEQSTATUS : (ADC Offset: 0x07) (R/ 8) Sequence Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  SEQSTATE:5;                /**< bit:   0..4  Sequence State                           */
+    uint8_t  :2;                        /**< bit:   5..6  Reserved */
+    uint8_t  SEQBUSY:1;                 /**< bit:      7  Sequence Busy                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} ADC_SEQSTATUS_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_SEQSTATUS_OFFSET                (0x07)                                        /**<  (ADC_SEQSTATUS) Sequence Status  Offset */
+#define ADC_SEQSTATUS_RESETVALUE            _U_(0x00)                                     /**<  (ADC_SEQSTATUS) Sequence Status  Reset Value */
+
+#define ADC_SEQSTATUS_SEQSTATE_Pos          0                                              /**< (ADC_SEQSTATUS) Sequence State Position */
+#define ADC_SEQSTATUS_SEQSTATE_Msk          (_U_(0x1F) << ADC_SEQSTATUS_SEQSTATE_Pos)      /**< (ADC_SEQSTATUS) Sequence State Mask */
+#define ADC_SEQSTATUS_SEQSTATE(value)       (ADC_SEQSTATUS_SEQSTATE_Msk & ((value) << ADC_SEQSTATUS_SEQSTATE_Pos))
+#define ADC_SEQSTATUS_SEQBUSY_Pos           7                                              /**< (ADC_SEQSTATUS) Sequence Busy Position */
+#define ADC_SEQSTATUS_SEQBUSY_Msk           (_U_(0x1) << ADC_SEQSTATUS_SEQBUSY_Pos)        /**< (ADC_SEQSTATUS) Sequence Busy Mask */
+#define ADC_SEQSTATUS_SEQBUSY               ADC_SEQSTATUS_SEQBUSY_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_SEQSTATUS_SEQBUSY_Msk instead */
+#define ADC_SEQSTATUS_MASK                  _U_(0x9F)                                      /**< \deprecated (ADC_SEQSTATUS) Register MASK  (Use ADC_SEQSTATUS_Msk instead)  */
+#define ADC_SEQSTATUS_Msk                   _U_(0x9F)                                      /**< (ADC_SEQSTATUS) Register Mask  */
+
+
+/* -------- ADC_INPUTCTRL : (ADC Offset: 0x08) (R/W 16) Input Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t MUXPOS:5;                  /**< bit:   0..4  Positive Mux Input Selection             */
+    uint16_t :3;                        /**< bit:   5..7  Reserved */
+    uint16_t MUXNEG:5;                  /**< bit:  8..12  Negative Mux Input Selection             */
+    uint16_t :3;                        /**< bit: 13..15  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} ADC_INPUTCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_INPUTCTRL_OFFSET                (0x08)                                        /**<  (ADC_INPUTCTRL) Input Control  Offset */
+#define ADC_INPUTCTRL_RESETVALUE            _U_(0x00)                                     /**<  (ADC_INPUTCTRL) Input Control  Reset Value */
+
+#define ADC_INPUTCTRL_MUXPOS_Pos            0                                              /**< (ADC_INPUTCTRL) Positive Mux Input Selection Position */
+#define ADC_INPUTCTRL_MUXPOS_Msk            (_U_(0x1F) << ADC_INPUTCTRL_MUXPOS_Pos)        /**< (ADC_INPUTCTRL) Positive Mux Input Selection Mask */
+#define ADC_INPUTCTRL_MUXPOS(value)         (ADC_INPUTCTRL_MUXPOS_Msk & ((value) << ADC_INPUTCTRL_MUXPOS_Pos))
+#define   ADC_INPUTCTRL_MUXPOS_AIN0_Val     _U_(0x0)                                       /**< (ADC_INPUTCTRL) ADC AIN0 Pin  */
+#define   ADC_INPUTCTRL_MUXPOS_AIN1_Val     _U_(0x1)                                       /**< (ADC_INPUTCTRL) ADC AIN1 Pin  */
+#define   ADC_INPUTCTRL_MUXPOS_AIN2_Val     _U_(0x2)                                       /**< (ADC_INPUTCTRL) ADC AIN2 Pin  */
+#define   ADC_INPUTCTRL_MUXPOS_AIN3_Val     _U_(0x3)                                       /**< (ADC_INPUTCTRL) ADC AIN3 Pin  */
+#define   ADC_INPUTCTRL_MUXPOS_AIN4_Val     _U_(0x4)                                       /**< (ADC_INPUTCTRL) ADC AIN4 Pin  */
+#define   ADC_INPUTCTRL_MUXPOS_AIN5_Val     _U_(0x5)                                       /**< (ADC_INPUTCTRL) ADC AIN5 Pin  */
+#define   ADC_INPUTCTRL_MUXPOS_AIN6_Val     _U_(0x6)                                       /**< (ADC_INPUTCTRL) ADC AIN6 Pin  */
+#define   ADC_INPUTCTRL_MUXPOS_AIN7_Val     _U_(0x7)                                       /**< (ADC_INPUTCTRL) ADC AIN7 Pin  */
+#define   ADC_INPUTCTRL_MUXPOS_AIN8_Val     _U_(0x8)                                       /**< (ADC_INPUTCTRL) ADC AIN8 Pin  */
+#define   ADC_INPUTCTRL_MUXPOS_AIN9_Val     _U_(0x9)                                       /**< (ADC_INPUTCTRL) ADC AIN9 Pin  */
+#define   ADC_INPUTCTRL_MUXPOS_AIN10_Val    _U_(0xA)                                       /**< (ADC_INPUTCTRL) ADC AIN10 Pin  */
+#define   ADC_INPUTCTRL_MUXPOS_AIN11_Val    _U_(0xB)                                       /**< (ADC_INPUTCTRL) ADC AIN11 Pin  */
+#define   ADC_INPUTCTRL_MUXPOS_AIN12_Val    _U_(0xC)                                       /**< (ADC_INPUTCTRL) ADC AIN12 Pin  */
+#define   ADC_INPUTCTRL_MUXPOS_AIN13_Val    _U_(0xD)                                       /**< (ADC_INPUTCTRL) ADC AIN13 Pin  */
+#define   ADC_INPUTCTRL_MUXPOS_AIN14_Val    _U_(0xE)                                       /**< (ADC_INPUTCTRL) ADC AIN14 Pin  */
+#define   ADC_INPUTCTRL_MUXPOS_AIN15_Val    _U_(0xF)                                       /**< (ADC_INPUTCTRL) ADC AIN15 Pin  */
+#define   ADC_INPUTCTRL_MUXPOS_AIN16_Val    _U_(0x10)                                      /**< (ADC_INPUTCTRL) ADC AIN16 Pin  */
+#define   ADC_INPUTCTRL_MUXPOS_AIN17_Val    _U_(0x11)                                      /**< (ADC_INPUTCTRL) ADC AIN17 Pin  */
+#define   ADC_INPUTCTRL_MUXPOS_AIN18_Val    _U_(0x12)                                      /**< (ADC_INPUTCTRL) ADC AIN18 Pin  */
+#define   ADC_INPUTCTRL_MUXPOS_AIN19_Val    _U_(0x13)                                      /**< (ADC_INPUTCTRL) ADC AIN19 Pin  */
+#define   ADC_INPUTCTRL_MUXPOS_AIN20_Val    _U_(0x14)                                      /**< (ADC_INPUTCTRL) ADC AIN20 Pin  */
+#define   ADC_INPUTCTRL_MUXPOS_AIN21_Val    _U_(0x15)                                      /**< (ADC_INPUTCTRL) ADC AIN21 Pin  */
+#define   ADC_INPUTCTRL_MUXPOS_AIN22_Val    _U_(0x16)                                      /**< (ADC_INPUTCTRL) ADC AIN22 Pin  */
+#define   ADC_INPUTCTRL_MUXPOS_AIN23_Val    _U_(0x17)                                      /**< (ADC_INPUTCTRL) ADC AIN23 Pin  */
+#define   ADC_INPUTCTRL_MUXPOS_TEMP_Val     _U_(0x18)                                      /**< (ADC_INPUTCTRL) Temperature Sensor  */
+#define   ADC_INPUTCTRL_MUXPOS_BANDGAP_Val  _U_(0x19)                                      /**< (ADC_INPUTCTRL) Bandgap Voltage  */
+#define   ADC_INPUTCTRL_MUXPOS_SCALEDCOREVCC_Val _U_(0x1A)                                      /**< (ADC_INPUTCTRL) 1/4 Scaled Core Supply  */
+#define   ADC_INPUTCTRL_MUXPOS_SCALEDIOVCC_Val _U_(0x1B)                                      /**< (ADC_INPUTCTRL) 1/4 Scaled I/O Supply  */
+#define   ADC_INPUTCTRL_MUXPOS_DAC_Val      _U_(0x1C)                                      /**< (ADC_INPUTCTRL) DAC Output  */
+#define   ADC_INPUTCTRL_MUXPOS_SCALEDVBAT_Val _U_(0x1D)                                      /**< (ADC_INPUTCTRL) 1/4 Scaled VBAT Supply  */
+#define   ADC_INPUTCTRL_MUXPOS_OPAMP01_Val  _U_(0x1E)                                      /**< (ADC_INPUTCTRL) OPAMP0 or OPAMP1 output  */
+#define   ADC_INPUTCTRL_MUXPOS_OPAMP2_Val   _U_(0x1F)                                      /**< (ADC_INPUTCTRL) OPAMP2 output  */
+#define ADC_INPUTCTRL_MUXPOS_AIN0           (ADC_INPUTCTRL_MUXPOS_AIN0_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) ADC AIN0 Pin Position  */
+#define ADC_INPUTCTRL_MUXPOS_AIN1           (ADC_INPUTCTRL_MUXPOS_AIN1_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) ADC AIN1 Pin Position  */
+#define ADC_INPUTCTRL_MUXPOS_AIN2           (ADC_INPUTCTRL_MUXPOS_AIN2_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) ADC AIN2 Pin Position  */
+#define ADC_INPUTCTRL_MUXPOS_AIN3           (ADC_INPUTCTRL_MUXPOS_AIN3_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) ADC AIN3 Pin Position  */
+#define ADC_INPUTCTRL_MUXPOS_AIN4           (ADC_INPUTCTRL_MUXPOS_AIN4_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) ADC AIN4 Pin Position  */
+#define ADC_INPUTCTRL_MUXPOS_AIN5           (ADC_INPUTCTRL_MUXPOS_AIN5_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) ADC AIN5 Pin Position  */
+#define ADC_INPUTCTRL_MUXPOS_AIN6           (ADC_INPUTCTRL_MUXPOS_AIN6_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) ADC AIN6 Pin Position  */
+#define ADC_INPUTCTRL_MUXPOS_AIN7           (ADC_INPUTCTRL_MUXPOS_AIN7_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) ADC AIN7 Pin Position  */
+#define ADC_INPUTCTRL_MUXPOS_AIN8           (ADC_INPUTCTRL_MUXPOS_AIN8_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) ADC AIN8 Pin Position  */
+#define ADC_INPUTCTRL_MUXPOS_AIN9           (ADC_INPUTCTRL_MUXPOS_AIN9_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) ADC AIN9 Pin Position  */
+#define ADC_INPUTCTRL_MUXPOS_AIN10          (ADC_INPUTCTRL_MUXPOS_AIN10_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) ADC AIN10 Pin Position  */
+#define ADC_INPUTCTRL_MUXPOS_AIN11          (ADC_INPUTCTRL_MUXPOS_AIN11_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) ADC AIN11 Pin Position  */
+#define ADC_INPUTCTRL_MUXPOS_AIN12          (ADC_INPUTCTRL_MUXPOS_AIN12_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) ADC AIN12 Pin Position  */
+#define ADC_INPUTCTRL_MUXPOS_AIN13          (ADC_INPUTCTRL_MUXPOS_AIN13_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) ADC AIN13 Pin Position  */
+#define ADC_INPUTCTRL_MUXPOS_AIN14          (ADC_INPUTCTRL_MUXPOS_AIN14_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) ADC AIN14 Pin Position  */
+#define ADC_INPUTCTRL_MUXPOS_AIN15          (ADC_INPUTCTRL_MUXPOS_AIN15_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) ADC AIN15 Pin Position  */
+#define ADC_INPUTCTRL_MUXPOS_AIN16          (ADC_INPUTCTRL_MUXPOS_AIN16_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) ADC AIN16 Pin Position  */
+#define ADC_INPUTCTRL_MUXPOS_AIN17          (ADC_INPUTCTRL_MUXPOS_AIN17_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) ADC AIN17 Pin Position  */
+#define ADC_INPUTCTRL_MUXPOS_AIN18          (ADC_INPUTCTRL_MUXPOS_AIN18_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) ADC AIN18 Pin Position  */
+#define ADC_INPUTCTRL_MUXPOS_AIN19          (ADC_INPUTCTRL_MUXPOS_AIN19_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) ADC AIN19 Pin Position  */
+#define ADC_INPUTCTRL_MUXPOS_AIN20          (ADC_INPUTCTRL_MUXPOS_AIN20_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) ADC AIN20 Pin Position  */
+#define ADC_INPUTCTRL_MUXPOS_AIN21          (ADC_INPUTCTRL_MUXPOS_AIN21_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) ADC AIN21 Pin Position  */
+#define ADC_INPUTCTRL_MUXPOS_AIN22          (ADC_INPUTCTRL_MUXPOS_AIN22_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) ADC AIN22 Pin Position  */
+#define ADC_INPUTCTRL_MUXPOS_AIN23          (ADC_INPUTCTRL_MUXPOS_AIN23_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) ADC AIN23 Pin Position  */
+#define ADC_INPUTCTRL_MUXPOS_TEMP           (ADC_INPUTCTRL_MUXPOS_TEMP_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) Temperature Sensor Position  */
+#define ADC_INPUTCTRL_MUXPOS_BANDGAP        (ADC_INPUTCTRL_MUXPOS_BANDGAP_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) Bandgap Voltage Position  */
+#define ADC_INPUTCTRL_MUXPOS_SCALEDCOREVCC  (ADC_INPUTCTRL_MUXPOS_SCALEDCOREVCC_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) 1/4 Scaled Core Supply Position  */
+#define ADC_INPUTCTRL_MUXPOS_SCALEDIOVCC    (ADC_INPUTCTRL_MUXPOS_SCALEDIOVCC_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) 1/4 Scaled I/O Supply Position  */
+#define ADC_INPUTCTRL_MUXPOS_DAC            (ADC_INPUTCTRL_MUXPOS_DAC_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) DAC Output Position  */
+#define ADC_INPUTCTRL_MUXPOS_SCALEDVBAT     (ADC_INPUTCTRL_MUXPOS_SCALEDVBAT_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) 1/4 Scaled VBAT Supply Position  */
+#define ADC_INPUTCTRL_MUXPOS_OPAMP01        (ADC_INPUTCTRL_MUXPOS_OPAMP01_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) OPAMP0 or OPAMP1 output Position  */
+#define ADC_INPUTCTRL_MUXPOS_OPAMP2         (ADC_INPUTCTRL_MUXPOS_OPAMP2_Val << ADC_INPUTCTRL_MUXPOS_Pos)  /**< (ADC_INPUTCTRL) OPAMP2 output Position  */
+#define ADC_INPUTCTRL_MUXNEG_Pos            8                                              /**< (ADC_INPUTCTRL) Negative Mux Input Selection Position */
+#define ADC_INPUTCTRL_MUXNEG_Msk            (_U_(0x1F) << ADC_INPUTCTRL_MUXNEG_Pos)        /**< (ADC_INPUTCTRL) Negative Mux Input Selection Mask */
+#define ADC_INPUTCTRL_MUXNEG(value)         (ADC_INPUTCTRL_MUXNEG_Msk & ((value) << ADC_INPUTCTRL_MUXNEG_Pos))
+#define   ADC_INPUTCTRL_MUXNEG_AIN0_Val     _U_(0x0)                                       /**< (ADC_INPUTCTRL) ADC AIN0 Pin  */
+#define   ADC_INPUTCTRL_MUXNEG_AIN1_Val     _U_(0x1)                                       /**< (ADC_INPUTCTRL) ADC AIN1 Pin  */
+#define   ADC_INPUTCTRL_MUXNEG_AIN2_Val     _U_(0x2)                                       /**< (ADC_INPUTCTRL) ADC AIN2 Pin  */
+#define   ADC_INPUTCTRL_MUXNEG_AIN3_Val     _U_(0x3)                                       /**< (ADC_INPUTCTRL) ADC AIN3 Pin  */
+#define   ADC_INPUTCTRL_MUXNEG_AIN4_Val     _U_(0x4)                                       /**< (ADC_INPUTCTRL) ADC AIN4 Pin  */
+#define   ADC_INPUTCTRL_MUXNEG_AIN5_Val     _U_(0x5)                                       /**< (ADC_INPUTCTRL) ADC AIN5 Pin  */
+#define   ADC_INPUTCTRL_MUXNEG_AIN6_Val     _U_(0x6)                                       /**< (ADC_INPUTCTRL) ADC AIN6 Pin  */
+#define   ADC_INPUTCTRL_MUXNEG_AIN7_Val     _U_(0x7)                                       /**< (ADC_INPUTCTRL) ADC AIN7 Pin  */
+#define ADC_INPUTCTRL_MUXNEG_AIN0           (ADC_INPUTCTRL_MUXNEG_AIN0_Val << ADC_INPUTCTRL_MUXNEG_Pos)  /**< (ADC_INPUTCTRL) ADC AIN0 Pin Position  */
+#define ADC_INPUTCTRL_MUXNEG_AIN1           (ADC_INPUTCTRL_MUXNEG_AIN1_Val << ADC_INPUTCTRL_MUXNEG_Pos)  /**< (ADC_INPUTCTRL) ADC AIN1 Pin Position  */
+#define ADC_INPUTCTRL_MUXNEG_AIN2           (ADC_INPUTCTRL_MUXNEG_AIN2_Val << ADC_INPUTCTRL_MUXNEG_Pos)  /**< (ADC_INPUTCTRL) ADC AIN2 Pin Position  */
+#define ADC_INPUTCTRL_MUXNEG_AIN3           (ADC_INPUTCTRL_MUXNEG_AIN3_Val << ADC_INPUTCTRL_MUXNEG_Pos)  /**< (ADC_INPUTCTRL) ADC AIN3 Pin Position  */
+#define ADC_INPUTCTRL_MUXNEG_AIN4           (ADC_INPUTCTRL_MUXNEG_AIN4_Val << ADC_INPUTCTRL_MUXNEG_Pos)  /**< (ADC_INPUTCTRL) ADC AIN4 Pin Position  */
+#define ADC_INPUTCTRL_MUXNEG_AIN5           (ADC_INPUTCTRL_MUXNEG_AIN5_Val << ADC_INPUTCTRL_MUXNEG_Pos)  /**< (ADC_INPUTCTRL) ADC AIN5 Pin Position  */
+#define ADC_INPUTCTRL_MUXNEG_AIN6           (ADC_INPUTCTRL_MUXNEG_AIN6_Val << ADC_INPUTCTRL_MUXNEG_Pos)  /**< (ADC_INPUTCTRL) ADC AIN6 Pin Position  */
+#define ADC_INPUTCTRL_MUXNEG_AIN7           (ADC_INPUTCTRL_MUXNEG_AIN7_Val << ADC_INPUTCTRL_MUXNEG_Pos)  /**< (ADC_INPUTCTRL) ADC AIN7 Pin Position  */
+#define ADC_INPUTCTRL_MASK                  _U_(0x1F1F)                                    /**< \deprecated (ADC_INPUTCTRL) Register MASK  (Use ADC_INPUTCTRL_Msk instead)  */
+#define ADC_INPUTCTRL_Msk                   _U_(0x1F1F)                                    /**< (ADC_INPUTCTRL) Register Mask  */
+
+
+/* -------- ADC_CTRLC : (ADC Offset: 0x0a) (R/W 16) Control C -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t DIFFMODE:1;                /**< bit:      0  Differential Mode                        */
+    uint16_t LEFTADJ:1;                 /**< bit:      1  Left-Adjusted Result                     */
+    uint16_t FREERUN:1;                 /**< bit:      2  Free Running Mode                        */
+    uint16_t CORREN:1;                  /**< bit:      3  Digital Correction Logic Enable          */
+    uint16_t RESSEL:2;                  /**< bit:   4..5  Conversion Result Resolution             */
+    uint16_t :1;                        /**< bit:      6  Reserved */
+    uint16_t R2R:1;                     /**< bit:      7  Rail-to-Rail mode enable                 */
+    uint16_t WINMODE:3;                 /**< bit:  8..10  Window Monitor Mode                      */
+    uint16_t :1;                        /**< bit:     11  Reserved */
+    uint16_t DUALSEL:2;                 /**< bit: 12..13  Dual Mode Trigger Selection              */
+    uint16_t :2;                        /**< bit: 14..15  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} ADC_CTRLC_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_CTRLC_OFFSET                    (0x0A)                                        /**<  (ADC_CTRLC) Control C  Offset */
+#define ADC_CTRLC_RESETVALUE                _U_(0x00)                                     /**<  (ADC_CTRLC) Control C  Reset Value */
+
+#define ADC_CTRLC_DIFFMODE_Pos              0                                              /**< (ADC_CTRLC) Differential Mode Position */
+#define ADC_CTRLC_DIFFMODE_Msk              (_U_(0x1) << ADC_CTRLC_DIFFMODE_Pos)           /**< (ADC_CTRLC) Differential Mode Mask */
+#define ADC_CTRLC_DIFFMODE                  ADC_CTRLC_DIFFMODE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_CTRLC_DIFFMODE_Msk instead */
+#define ADC_CTRLC_LEFTADJ_Pos               1                                              /**< (ADC_CTRLC) Left-Adjusted Result Position */
+#define ADC_CTRLC_LEFTADJ_Msk               (_U_(0x1) << ADC_CTRLC_LEFTADJ_Pos)            /**< (ADC_CTRLC) Left-Adjusted Result Mask */
+#define ADC_CTRLC_LEFTADJ                   ADC_CTRLC_LEFTADJ_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_CTRLC_LEFTADJ_Msk instead */
+#define ADC_CTRLC_FREERUN_Pos               2                                              /**< (ADC_CTRLC) Free Running Mode Position */
+#define ADC_CTRLC_FREERUN_Msk               (_U_(0x1) << ADC_CTRLC_FREERUN_Pos)            /**< (ADC_CTRLC) Free Running Mode Mask */
+#define ADC_CTRLC_FREERUN                   ADC_CTRLC_FREERUN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_CTRLC_FREERUN_Msk instead */
+#define ADC_CTRLC_CORREN_Pos                3                                              /**< (ADC_CTRLC) Digital Correction Logic Enable Position */
+#define ADC_CTRLC_CORREN_Msk                (_U_(0x1) << ADC_CTRLC_CORREN_Pos)             /**< (ADC_CTRLC) Digital Correction Logic Enable Mask */
+#define ADC_CTRLC_CORREN                    ADC_CTRLC_CORREN_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_CTRLC_CORREN_Msk instead */
+#define ADC_CTRLC_RESSEL_Pos                4                                              /**< (ADC_CTRLC) Conversion Result Resolution Position */
+#define ADC_CTRLC_RESSEL_Msk                (_U_(0x3) << ADC_CTRLC_RESSEL_Pos)             /**< (ADC_CTRLC) Conversion Result Resolution Mask */
+#define ADC_CTRLC_RESSEL(value)             (ADC_CTRLC_RESSEL_Msk & ((value) << ADC_CTRLC_RESSEL_Pos))
+#define   ADC_CTRLC_RESSEL_12BIT_Val        _U_(0x0)                                       /**< (ADC_CTRLC) 12-bit result  */
+#define   ADC_CTRLC_RESSEL_16BIT_Val        _U_(0x1)                                       /**< (ADC_CTRLC) For averaging mode output  */
+#define   ADC_CTRLC_RESSEL_10BIT_Val        _U_(0x2)                                       /**< (ADC_CTRLC) 10-bit result  */
+#define   ADC_CTRLC_RESSEL_8BIT_Val         _U_(0x3)                                       /**< (ADC_CTRLC) 8-bit result  */
+#define ADC_CTRLC_RESSEL_12BIT              (ADC_CTRLC_RESSEL_12BIT_Val << ADC_CTRLC_RESSEL_Pos)  /**< (ADC_CTRLC) 12-bit result Position  */
+#define ADC_CTRLC_RESSEL_16BIT              (ADC_CTRLC_RESSEL_16BIT_Val << ADC_CTRLC_RESSEL_Pos)  /**< (ADC_CTRLC) For averaging mode output Position  */
+#define ADC_CTRLC_RESSEL_10BIT              (ADC_CTRLC_RESSEL_10BIT_Val << ADC_CTRLC_RESSEL_Pos)  /**< (ADC_CTRLC) 10-bit result Position  */
+#define ADC_CTRLC_RESSEL_8BIT               (ADC_CTRLC_RESSEL_8BIT_Val << ADC_CTRLC_RESSEL_Pos)  /**< (ADC_CTRLC) 8-bit result Position  */
+#define ADC_CTRLC_R2R_Pos                   7                                              /**< (ADC_CTRLC) Rail-to-Rail mode enable Position */
+#define ADC_CTRLC_R2R_Msk                   (_U_(0x1) << ADC_CTRLC_R2R_Pos)                /**< (ADC_CTRLC) Rail-to-Rail mode enable Mask */
+#define ADC_CTRLC_R2R                       ADC_CTRLC_R2R_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_CTRLC_R2R_Msk instead */
+#define ADC_CTRLC_WINMODE_Pos               8                                              /**< (ADC_CTRLC) Window Monitor Mode Position */
+#define ADC_CTRLC_WINMODE_Msk               (_U_(0x7) << ADC_CTRLC_WINMODE_Pos)            /**< (ADC_CTRLC) Window Monitor Mode Mask */
+#define ADC_CTRLC_WINMODE(value)            (ADC_CTRLC_WINMODE_Msk & ((value) << ADC_CTRLC_WINMODE_Pos))
+#define   ADC_CTRLC_WINMODE_DISABLE_Val     _U_(0x0)                                       /**< (ADC_CTRLC) No window mode (default)  */
+#define   ADC_CTRLC_WINMODE_MODE1_Val       _U_(0x1)                                       /**< (ADC_CTRLC) RESULT > WINLT  */
+#define   ADC_CTRLC_WINMODE_MODE2_Val       _U_(0x2)                                       /**< (ADC_CTRLC) RESULT < WINUT  */
+#define   ADC_CTRLC_WINMODE_MODE3_Val       _U_(0x3)                                       /**< (ADC_CTRLC) WINLT < RESULT < WINUT  */
+#define   ADC_CTRLC_WINMODE_MODE4_Val       _U_(0x4)                                       /**< (ADC_CTRLC) !(WINLT < RESULT < WINUT)  */
+#define ADC_CTRLC_WINMODE_DISABLE           (ADC_CTRLC_WINMODE_DISABLE_Val << ADC_CTRLC_WINMODE_Pos)  /**< (ADC_CTRLC) No window mode (default) Position  */
+#define ADC_CTRLC_WINMODE_MODE1             (ADC_CTRLC_WINMODE_MODE1_Val << ADC_CTRLC_WINMODE_Pos)  /**< (ADC_CTRLC) RESULT > WINLT Position  */
+#define ADC_CTRLC_WINMODE_MODE2             (ADC_CTRLC_WINMODE_MODE2_Val << ADC_CTRLC_WINMODE_Pos)  /**< (ADC_CTRLC) RESULT < WINUT Position  */
+#define ADC_CTRLC_WINMODE_MODE3             (ADC_CTRLC_WINMODE_MODE3_Val << ADC_CTRLC_WINMODE_Pos)  /**< (ADC_CTRLC) WINLT < RESULT < WINUT Position  */
+#define ADC_CTRLC_WINMODE_MODE4             (ADC_CTRLC_WINMODE_MODE4_Val << ADC_CTRLC_WINMODE_Pos)  /**< (ADC_CTRLC) !(WINLT < RESULT < WINUT) Position  */
+#define ADC_CTRLC_DUALSEL_Pos               12                                             /**< (ADC_CTRLC) Dual Mode Trigger Selection Position */
+#define ADC_CTRLC_DUALSEL_Msk               (_U_(0x3) << ADC_CTRLC_DUALSEL_Pos)            /**< (ADC_CTRLC) Dual Mode Trigger Selection Mask */
+#define ADC_CTRLC_DUALSEL(value)            (ADC_CTRLC_DUALSEL_Msk & ((value) << ADC_CTRLC_DUALSEL_Pos))
+#define   ADC_CTRLC_DUALSEL_BOTH_Val        _U_(0x0)                                       /**< (ADC_CTRLC) Start event or software trigger will start a conversion on both ADCs  */
+#define   ADC_CTRLC_DUALSEL_INTERLEAVE_Val  _U_(0x1)                                       /**< (ADC_CTRLC) START event or software trigger will alternatingly start a conversion on ADC0 and ADC1  */
+#define ADC_CTRLC_DUALSEL_BOTH              (ADC_CTRLC_DUALSEL_BOTH_Val << ADC_CTRLC_DUALSEL_Pos)  /**< (ADC_CTRLC) Start event or software trigger will start a conversion on both ADCs Position  */
+#define ADC_CTRLC_DUALSEL_INTERLEAVE        (ADC_CTRLC_DUALSEL_INTERLEAVE_Val << ADC_CTRLC_DUALSEL_Pos)  /**< (ADC_CTRLC) START event or software trigger will alternatingly start a conversion on ADC0 and ADC1 Position  */
+#define ADC_CTRLC_MASK                      _U_(0x37BF)                                    /**< \deprecated (ADC_CTRLC) Register MASK  (Use ADC_CTRLC_Msk instead)  */
+#define ADC_CTRLC_Msk                       _U_(0x37BF)                                    /**< (ADC_CTRLC) Register Mask  */
+
+
+/* -------- ADC_AVGCTRL : (ADC Offset: 0x0c) (R/W 8) Average Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  SAMPLENUM:4;               /**< bit:   0..3  Number of Samples to be Collected        */
+    uint8_t  ADJRES:3;                  /**< bit:   4..6  Adjusting Result / Division Coefficient  */
+    uint8_t  :1;                        /**< bit:      7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} ADC_AVGCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_AVGCTRL_OFFSET                  (0x0C)                                        /**<  (ADC_AVGCTRL) Average Control  Offset */
+#define ADC_AVGCTRL_RESETVALUE              _U_(0x00)                                     /**<  (ADC_AVGCTRL) Average Control  Reset Value */
+
+#define ADC_AVGCTRL_SAMPLENUM_Pos           0                                              /**< (ADC_AVGCTRL) Number of Samples to be Collected Position */
+#define ADC_AVGCTRL_SAMPLENUM_Msk           (_U_(0xF) << ADC_AVGCTRL_SAMPLENUM_Pos)        /**< (ADC_AVGCTRL) Number of Samples to be Collected Mask */
+#define ADC_AVGCTRL_SAMPLENUM(value)        (ADC_AVGCTRL_SAMPLENUM_Msk & ((value) << ADC_AVGCTRL_SAMPLENUM_Pos))
+#define   ADC_AVGCTRL_SAMPLENUM_1_Val       _U_(0x0)                                       /**< (ADC_AVGCTRL) 1 sample  */
+#define   ADC_AVGCTRL_SAMPLENUM_2_Val       _U_(0x1)                                       /**< (ADC_AVGCTRL) 2 samples  */
+#define   ADC_AVGCTRL_SAMPLENUM_4_Val       _U_(0x2)                                       /**< (ADC_AVGCTRL) 4 samples  */
+#define   ADC_AVGCTRL_SAMPLENUM_8_Val       _U_(0x3)                                       /**< (ADC_AVGCTRL) 8 samples  */
+#define   ADC_AVGCTRL_SAMPLENUM_16_Val      _U_(0x4)                                       /**< (ADC_AVGCTRL) 16 samples  */
+#define   ADC_AVGCTRL_SAMPLENUM_32_Val      _U_(0x5)                                       /**< (ADC_AVGCTRL) 32 samples  */
+#define   ADC_AVGCTRL_SAMPLENUM_64_Val      _U_(0x6)                                       /**< (ADC_AVGCTRL) 64 samples  */
+#define   ADC_AVGCTRL_SAMPLENUM_128_Val     _U_(0x7)                                       /**< (ADC_AVGCTRL) 128 samples  */
+#define   ADC_AVGCTRL_SAMPLENUM_256_Val     _U_(0x8)                                       /**< (ADC_AVGCTRL) 256 samples  */
+#define   ADC_AVGCTRL_SAMPLENUM_512_Val     _U_(0x9)                                       /**< (ADC_AVGCTRL) 512 samples  */
+#define   ADC_AVGCTRL_SAMPLENUM_1024_Val    _U_(0xA)                                       /**< (ADC_AVGCTRL) 1024 samples  */
+#define ADC_AVGCTRL_SAMPLENUM_1             (ADC_AVGCTRL_SAMPLENUM_1_Val << ADC_AVGCTRL_SAMPLENUM_Pos)  /**< (ADC_AVGCTRL) 1 sample Position  */
+#define ADC_AVGCTRL_SAMPLENUM_2             (ADC_AVGCTRL_SAMPLENUM_2_Val << ADC_AVGCTRL_SAMPLENUM_Pos)  /**< (ADC_AVGCTRL) 2 samples Position  */
+#define ADC_AVGCTRL_SAMPLENUM_4             (ADC_AVGCTRL_SAMPLENUM_4_Val << ADC_AVGCTRL_SAMPLENUM_Pos)  /**< (ADC_AVGCTRL) 4 samples Position  */
+#define ADC_AVGCTRL_SAMPLENUM_8             (ADC_AVGCTRL_SAMPLENUM_8_Val << ADC_AVGCTRL_SAMPLENUM_Pos)  /**< (ADC_AVGCTRL) 8 samples Position  */
+#define ADC_AVGCTRL_SAMPLENUM_16            (ADC_AVGCTRL_SAMPLENUM_16_Val << ADC_AVGCTRL_SAMPLENUM_Pos)  /**< (ADC_AVGCTRL) 16 samples Position  */
+#define ADC_AVGCTRL_SAMPLENUM_32            (ADC_AVGCTRL_SAMPLENUM_32_Val << ADC_AVGCTRL_SAMPLENUM_Pos)  /**< (ADC_AVGCTRL) 32 samples Position  */
+#define ADC_AVGCTRL_SAMPLENUM_64            (ADC_AVGCTRL_SAMPLENUM_64_Val << ADC_AVGCTRL_SAMPLENUM_Pos)  /**< (ADC_AVGCTRL) 64 samples Position  */
+#define ADC_AVGCTRL_SAMPLENUM_128           (ADC_AVGCTRL_SAMPLENUM_128_Val << ADC_AVGCTRL_SAMPLENUM_Pos)  /**< (ADC_AVGCTRL) 128 samples Position  */
+#define ADC_AVGCTRL_SAMPLENUM_256           (ADC_AVGCTRL_SAMPLENUM_256_Val << ADC_AVGCTRL_SAMPLENUM_Pos)  /**< (ADC_AVGCTRL) 256 samples Position  */
+#define ADC_AVGCTRL_SAMPLENUM_512           (ADC_AVGCTRL_SAMPLENUM_512_Val << ADC_AVGCTRL_SAMPLENUM_Pos)  /**< (ADC_AVGCTRL) 512 samples Position  */
+#define ADC_AVGCTRL_SAMPLENUM_1024          (ADC_AVGCTRL_SAMPLENUM_1024_Val << ADC_AVGCTRL_SAMPLENUM_Pos)  /**< (ADC_AVGCTRL) 1024 samples Position  */
+#define ADC_AVGCTRL_ADJRES_Pos              4                                              /**< (ADC_AVGCTRL) Adjusting Result / Division Coefficient Position */
+#define ADC_AVGCTRL_ADJRES_Msk              (_U_(0x7) << ADC_AVGCTRL_ADJRES_Pos)           /**< (ADC_AVGCTRL) Adjusting Result / Division Coefficient Mask */
+#define ADC_AVGCTRL_ADJRES(value)           (ADC_AVGCTRL_ADJRES_Msk & ((value) << ADC_AVGCTRL_ADJRES_Pos))
+#define ADC_AVGCTRL_MASK                    _U_(0x7F)                                      /**< \deprecated (ADC_AVGCTRL) Register MASK  (Use ADC_AVGCTRL_Msk instead)  */
+#define ADC_AVGCTRL_Msk                     _U_(0x7F)                                      /**< (ADC_AVGCTRL) Register Mask  */
+
+
+/* -------- ADC_SAMPCTRL : (ADC Offset: 0x0d) (R/W 8) Sample Time Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  SAMPLEN:6;                 /**< bit:   0..5  Sampling Time Length                     */
+    uint8_t  :1;                        /**< bit:      6  Reserved */
+    uint8_t  OFFCOMP:1;                 /**< bit:      7  Comparator Offset Compensation Enable    */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} ADC_SAMPCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_SAMPCTRL_OFFSET                 (0x0D)                                        /**<  (ADC_SAMPCTRL) Sample Time Control  Offset */
+#define ADC_SAMPCTRL_RESETVALUE             _U_(0x00)                                     /**<  (ADC_SAMPCTRL) Sample Time Control  Reset Value */
+
+#define ADC_SAMPCTRL_SAMPLEN_Pos            0                                              /**< (ADC_SAMPCTRL) Sampling Time Length Position */
+#define ADC_SAMPCTRL_SAMPLEN_Msk            (_U_(0x3F) << ADC_SAMPCTRL_SAMPLEN_Pos)        /**< (ADC_SAMPCTRL) Sampling Time Length Mask */
+#define ADC_SAMPCTRL_SAMPLEN(value)         (ADC_SAMPCTRL_SAMPLEN_Msk & ((value) << ADC_SAMPCTRL_SAMPLEN_Pos))
+#define ADC_SAMPCTRL_OFFCOMP_Pos            7                                              /**< (ADC_SAMPCTRL) Comparator Offset Compensation Enable Position */
+#define ADC_SAMPCTRL_OFFCOMP_Msk            (_U_(0x1) << ADC_SAMPCTRL_OFFCOMP_Pos)         /**< (ADC_SAMPCTRL) Comparator Offset Compensation Enable Mask */
+#define ADC_SAMPCTRL_OFFCOMP                ADC_SAMPCTRL_OFFCOMP_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_SAMPCTRL_OFFCOMP_Msk instead */
+#define ADC_SAMPCTRL_MASK                   _U_(0xBF)                                      /**< \deprecated (ADC_SAMPCTRL) Register MASK  (Use ADC_SAMPCTRL_Msk instead)  */
+#define ADC_SAMPCTRL_Msk                    _U_(0xBF)                                      /**< (ADC_SAMPCTRL) Register Mask  */
+
+
+/* -------- ADC_WINLT : (ADC Offset: 0x0e) (R/W 16) Window Monitor Lower Threshold -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t WINLT:16;                  /**< bit:  0..15  Window Lower Threshold                   */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} ADC_WINLT_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_WINLT_OFFSET                    (0x0E)                                        /**<  (ADC_WINLT) Window Monitor Lower Threshold  Offset */
+#define ADC_WINLT_RESETVALUE                _U_(0x00)                                     /**<  (ADC_WINLT) Window Monitor Lower Threshold  Reset Value */
+
+#define ADC_WINLT_WINLT_Pos                 0                                              /**< (ADC_WINLT) Window Lower Threshold Position */
+#define ADC_WINLT_WINLT_Msk                 (_U_(0xFFFF) << ADC_WINLT_WINLT_Pos)           /**< (ADC_WINLT) Window Lower Threshold Mask */
+#define ADC_WINLT_WINLT(value)              (ADC_WINLT_WINLT_Msk & ((value) << ADC_WINLT_WINLT_Pos))
+#define ADC_WINLT_MASK                      _U_(0xFFFF)                                    /**< \deprecated (ADC_WINLT) Register MASK  (Use ADC_WINLT_Msk instead)  */
+#define ADC_WINLT_Msk                       _U_(0xFFFF)                                    /**< (ADC_WINLT) Register Mask  */
+
+
+/* -------- ADC_WINUT : (ADC Offset: 0x10) (R/W 16) Window Monitor Upper Threshold -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t WINUT:16;                  /**< bit:  0..15  Window Upper Threshold                   */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} ADC_WINUT_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_WINUT_OFFSET                    (0x10)                                        /**<  (ADC_WINUT) Window Monitor Upper Threshold  Offset */
+#define ADC_WINUT_RESETVALUE                _U_(0x00)                                     /**<  (ADC_WINUT) Window Monitor Upper Threshold  Reset Value */
+
+#define ADC_WINUT_WINUT_Pos                 0                                              /**< (ADC_WINUT) Window Upper Threshold Position */
+#define ADC_WINUT_WINUT_Msk                 (_U_(0xFFFF) << ADC_WINUT_WINUT_Pos)           /**< (ADC_WINUT) Window Upper Threshold Mask */
+#define ADC_WINUT_WINUT(value)              (ADC_WINUT_WINUT_Msk & ((value) << ADC_WINUT_WINUT_Pos))
+#define ADC_WINUT_MASK                      _U_(0xFFFF)                                    /**< \deprecated (ADC_WINUT) Register MASK  (Use ADC_WINUT_Msk instead)  */
+#define ADC_WINUT_Msk                       _U_(0xFFFF)                                    /**< (ADC_WINUT) Register Mask  */
+
+
+/* -------- ADC_GAINCORR : (ADC Offset: 0x12) (R/W 16) Gain Correction -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t GAINCORR:12;               /**< bit:  0..11  Gain Correction Value                    */
+    uint16_t :4;                        /**< bit: 12..15  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} ADC_GAINCORR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_GAINCORR_OFFSET                 (0x12)                                        /**<  (ADC_GAINCORR) Gain Correction  Offset */
+#define ADC_GAINCORR_RESETVALUE             _U_(0x00)                                     /**<  (ADC_GAINCORR) Gain Correction  Reset Value */
+
+#define ADC_GAINCORR_GAINCORR_Pos           0                                              /**< (ADC_GAINCORR) Gain Correction Value Position */
+#define ADC_GAINCORR_GAINCORR_Msk           (_U_(0xFFF) << ADC_GAINCORR_GAINCORR_Pos)      /**< (ADC_GAINCORR) Gain Correction Value Mask */
+#define ADC_GAINCORR_GAINCORR(value)        (ADC_GAINCORR_GAINCORR_Msk & ((value) << ADC_GAINCORR_GAINCORR_Pos))
+#define ADC_GAINCORR_MASK                   _U_(0xFFF)                                     /**< \deprecated (ADC_GAINCORR) Register MASK  (Use ADC_GAINCORR_Msk instead)  */
+#define ADC_GAINCORR_Msk                    _U_(0xFFF)                                     /**< (ADC_GAINCORR) Register Mask  */
+
+
+/* -------- ADC_OFFSETCORR : (ADC Offset: 0x14) (R/W 16) Offset Correction -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t OFFSETCORR:12;             /**< bit:  0..11  Offset Correction Value                  */
+    uint16_t :4;                        /**< bit: 12..15  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} ADC_OFFSETCORR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_OFFSETCORR_OFFSET               (0x14)                                        /**<  (ADC_OFFSETCORR) Offset Correction  Offset */
+#define ADC_OFFSETCORR_RESETVALUE           _U_(0x00)                                     /**<  (ADC_OFFSETCORR) Offset Correction  Reset Value */
+
+#define ADC_OFFSETCORR_OFFSETCORR_Pos       0                                              /**< (ADC_OFFSETCORR) Offset Correction Value Position */
+#define ADC_OFFSETCORR_OFFSETCORR_Msk       (_U_(0xFFF) << ADC_OFFSETCORR_OFFSETCORR_Pos)  /**< (ADC_OFFSETCORR) Offset Correction Value Mask */
+#define ADC_OFFSETCORR_OFFSETCORR(value)    (ADC_OFFSETCORR_OFFSETCORR_Msk & ((value) << ADC_OFFSETCORR_OFFSETCORR_Pos))
+#define ADC_OFFSETCORR_MASK                 _U_(0xFFF)                                     /**< \deprecated (ADC_OFFSETCORR) Register MASK  (Use ADC_OFFSETCORR_Msk instead)  */
+#define ADC_OFFSETCORR_Msk                  _U_(0xFFF)                                     /**< (ADC_OFFSETCORR) Register Mask  */
+
+
+/* -------- ADC_SWTRIG : (ADC Offset: 0x18) (R/W 8) Software Trigger -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  FLUSH:1;                   /**< bit:      0  ADC Flush                                */
+    uint8_t  START:1;                   /**< bit:      1  Start ADC Conversion                     */
+    uint8_t  :6;                        /**< bit:   2..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} ADC_SWTRIG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_SWTRIG_OFFSET                   (0x18)                                        /**<  (ADC_SWTRIG) Software Trigger  Offset */
+#define ADC_SWTRIG_RESETVALUE               _U_(0x00)                                     /**<  (ADC_SWTRIG) Software Trigger  Reset Value */
+
+#define ADC_SWTRIG_FLUSH_Pos                0                                              /**< (ADC_SWTRIG) ADC Flush Position */
+#define ADC_SWTRIG_FLUSH_Msk                (_U_(0x1) << ADC_SWTRIG_FLUSH_Pos)             /**< (ADC_SWTRIG) ADC Flush Mask */
+#define ADC_SWTRIG_FLUSH                    ADC_SWTRIG_FLUSH_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_SWTRIG_FLUSH_Msk instead */
+#define ADC_SWTRIG_START_Pos                1                                              /**< (ADC_SWTRIG) Start ADC Conversion Position */
+#define ADC_SWTRIG_START_Msk                (_U_(0x1) << ADC_SWTRIG_START_Pos)             /**< (ADC_SWTRIG) Start ADC Conversion Mask */
+#define ADC_SWTRIG_START                    ADC_SWTRIG_START_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_SWTRIG_START_Msk instead */
+#define ADC_SWTRIG_MASK                     _U_(0x03)                                      /**< \deprecated (ADC_SWTRIG) Register MASK  (Use ADC_SWTRIG_Msk instead)  */
+#define ADC_SWTRIG_Msk                      _U_(0x03)                                      /**< (ADC_SWTRIG) Register Mask  */
+
+
+/* -------- ADC_DBGCTRL : (ADC Offset: 0x1c) (R/W 8) Debug Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DBGRUN:1;                  /**< bit:      0  Debug Run                                */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} ADC_DBGCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_DBGCTRL_OFFSET                  (0x1C)                                        /**<  (ADC_DBGCTRL) Debug Control  Offset */
+#define ADC_DBGCTRL_RESETVALUE              _U_(0x00)                                     /**<  (ADC_DBGCTRL) Debug Control  Reset Value */
+
+#define ADC_DBGCTRL_DBGRUN_Pos              0                                              /**< (ADC_DBGCTRL) Debug Run Position */
+#define ADC_DBGCTRL_DBGRUN_Msk              (_U_(0x1) << ADC_DBGCTRL_DBGRUN_Pos)           /**< (ADC_DBGCTRL) Debug Run Mask */
+#define ADC_DBGCTRL_DBGRUN                  ADC_DBGCTRL_DBGRUN_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_DBGCTRL_DBGRUN_Msk instead */
+#define ADC_DBGCTRL_MASK                    _U_(0x01)                                      /**< \deprecated (ADC_DBGCTRL) Register MASK  (Use ADC_DBGCTRL_Msk instead)  */
+#define ADC_DBGCTRL_Msk                     _U_(0x01)                                      /**< (ADC_DBGCTRL) Register Mask  */
+
+
+/* -------- ADC_SYNCBUSY : (ADC Offset: 0x20) (R/ 16) Synchronization Busy -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t SWRST:1;                   /**< bit:      0  SWRST Synchronization Busy               */
+    uint16_t ENABLE:1;                  /**< bit:      1  ENABLE Synchronization Busy              */
+    uint16_t INPUTCTRL:1;               /**< bit:      2  INPUTCTRL Synchronization Busy           */
+    uint16_t CTRLC:1;                   /**< bit:      3  CTRLC Synchronization Busy               */
+    uint16_t AVGCTRL:1;                 /**< bit:      4  AVGCTRL Synchronization Busy             */
+    uint16_t SAMPCTRL:1;                /**< bit:      5  SAMPCTRL Synchronization Busy            */
+    uint16_t WINLT:1;                   /**< bit:      6  WINLT Synchronization Busy               */
+    uint16_t WINUT:1;                   /**< bit:      7  WINUT Synchronization Busy               */
+    uint16_t GAINCORR:1;                /**< bit:      8  GAINCORR Synchronization Busy            */
+    uint16_t OFFSETCORR:1;              /**< bit:      9  OFFSETCTRL Synchronization Busy          */
+    uint16_t SWTRIG:1;                  /**< bit:     10  SWTRG Synchronization Busy               */
+    uint16_t :5;                        /**< bit: 11..15  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} ADC_SYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_SYNCBUSY_OFFSET                 (0x20)                                        /**<  (ADC_SYNCBUSY) Synchronization Busy  Offset */
+#define ADC_SYNCBUSY_RESETVALUE             _U_(0x00)                                     /**<  (ADC_SYNCBUSY) Synchronization Busy  Reset Value */
+
+#define ADC_SYNCBUSY_SWRST_Pos              0                                              /**< (ADC_SYNCBUSY) SWRST Synchronization Busy Position */
+#define ADC_SYNCBUSY_SWRST_Msk              (_U_(0x1) << ADC_SYNCBUSY_SWRST_Pos)           /**< (ADC_SYNCBUSY) SWRST Synchronization Busy Mask */
+#define ADC_SYNCBUSY_SWRST                  ADC_SYNCBUSY_SWRST_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_SYNCBUSY_SWRST_Msk instead */
+#define ADC_SYNCBUSY_ENABLE_Pos             1                                              /**< (ADC_SYNCBUSY) ENABLE Synchronization Busy Position */
+#define ADC_SYNCBUSY_ENABLE_Msk             (_U_(0x1) << ADC_SYNCBUSY_ENABLE_Pos)          /**< (ADC_SYNCBUSY) ENABLE Synchronization Busy Mask */
+#define ADC_SYNCBUSY_ENABLE                 ADC_SYNCBUSY_ENABLE_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_SYNCBUSY_ENABLE_Msk instead */
+#define ADC_SYNCBUSY_INPUTCTRL_Pos          2                                              /**< (ADC_SYNCBUSY) INPUTCTRL Synchronization Busy Position */
+#define ADC_SYNCBUSY_INPUTCTRL_Msk          (_U_(0x1) << ADC_SYNCBUSY_INPUTCTRL_Pos)       /**< (ADC_SYNCBUSY) INPUTCTRL Synchronization Busy Mask */
+#define ADC_SYNCBUSY_INPUTCTRL              ADC_SYNCBUSY_INPUTCTRL_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_SYNCBUSY_INPUTCTRL_Msk instead */
+#define ADC_SYNCBUSY_CTRLC_Pos              3                                              /**< (ADC_SYNCBUSY) CTRLC Synchronization Busy Position */
+#define ADC_SYNCBUSY_CTRLC_Msk              (_U_(0x1) << ADC_SYNCBUSY_CTRLC_Pos)           /**< (ADC_SYNCBUSY) CTRLC Synchronization Busy Mask */
+#define ADC_SYNCBUSY_CTRLC                  ADC_SYNCBUSY_CTRLC_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_SYNCBUSY_CTRLC_Msk instead */
+#define ADC_SYNCBUSY_AVGCTRL_Pos            4                                              /**< (ADC_SYNCBUSY) AVGCTRL Synchronization Busy Position */
+#define ADC_SYNCBUSY_AVGCTRL_Msk            (_U_(0x1) << ADC_SYNCBUSY_AVGCTRL_Pos)         /**< (ADC_SYNCBUSY) AVGCTRL Synchronization Busy Mask */
+#define ADC_SYNCBUSY_AVGCTRL                ADC_SYNCBUSY_AVGCTRL_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_SYNCBUSY_AVGCTRL_Msk instead */
+#define ADC_SYNCBUSY_SAMPCTRL_Pos           5                                              /**< (ADC_SYNCBUSY) SAMPCTRL Synchronization Busy Position */
+#define ADC_SYNCBUSY_SAMPCTRL_Msk           (_U_(0x1) << ADC_SYNCBUSY_SAMPCTRL_Pos)        /**< (ADC_SYNCBUSY) SAMPCTRL Synchronization Busy Mask */
+#define ADC_SYNCBUSY_SAMPCTRL               ADC_SYNCBUSY_SAMPCTRL_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_SYNCBUSY_SAMPCTRL_Msk instead */
+#define ADC_SYNCBUSY_WINLT_Pos              6                                              /**< (ADC_SYNCBUSY) WINLT Synchronization Busy Position */
+#define ADC_SYNCBUSY_WINLT_Msk              (_U_(0x1) << ADC_SYNCBUSY_WINLT_Pos)           /**< (ADC_SYNCBUSY) WINLT Synchronization Busy Mask */
+#define ADC_SYNCBUSY_WINLT                  ADC_SYNCBUSY_WINLT_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_SYNCBUSY_WINLT_Msk instead */
+#define ADC_SYNCBUSY_WINUT_Pos              7                                              /**< (ADC_SYNCBUSY) WINUT Synchronization Busy Position */
+#define ADC_SYNCBUSY_WINUT_Msk              (_U_(0x1) << ADC_SYNCBUSY_WINUT_Pos)           /**< (ADC_SYNCBUSY) WINUT Synchronization Busy Mask */
+#define ADC_SYNCBUSY_WINUT                  ADC_SYNCBUSY_WINUT_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_SYNCBUSY_WINUT_Msk instead */
+#define ADC_SYNCBUSY_GAINCORR_Pos           8                                              /**< (ADC_SYNCBUSY) GAINCORR Synchronization Busy Position */
+#define ADC_SYNCBUSY_GAINCORR_Msk           (_U_(0x1) << ADC_SYNCBUSY_GAINCORR_Pos)        /**< (ADC_SYNCBUSY) GAINCORR Synchronization Busy Mask */
+#define ADC_SYNCBUSY_GAINCORR               ADC_SYNCBUSY_GAINCORR_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_SYNCBUSY_GAINCORR_Msk instead */
+#define ADC_SYNCBUSY_OFFSETCORR_Pos         9                                              /**< (ADC_SYNCBUSY) OFFSETCTRL Synchronization Busy Position */
+#define ADC_SYNCBUSY_OFFSETCORR_Msk         (_U_(0x1) << ADC_SYNCBUSY_OFFSETCORR_Pos)      /**< (ADC_SYNCBUSY) OFFSETCTRL Synchronization Busy Mask */
+#define ADC_SYNCBUSY_OFFSETCORR             ADC_SYNCBUSY_OFFSETCORR_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_SYNCBUSY_OFFSETCORR_Msk instead */
+#define ADC_SYNCBUSY_SWTRIG_Pos             10                                             /**< (ADC_SYNCBUSY) SWTRG Synchronization Busy Position */
+#define ADC_SYNCBUSY_SWTRIG_Msk             (_U_(0x1) << ADC_SYNCBUSY_SWTRIG_Pos)          /**< (ADC_SYNCBUSY) SWTRG Synchronization Busy Mask */
+#define ADC_SYNCBUSY_SWTRIG                 ADC_SYNCBUSY_SWTRIG_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use ADC_SYNCBUSY_SWTRIG_Msk instead */
+#define ADC_SYNCBUSY_MASK                   _U_(0x7FF)                                     /**< \deprecated (ADC_SYNCBUSY) Register MASK  (Use ADC_SYNCBUSY_Msk instead)  */
+#define ADC_SYNCBUSY_Msk                    _U_(0x7FF)                                     /**< (ADC_SYNCBUSY) Register Mask  */
+
+
+/* -------- ADC_RESULT : (ADC Offset: 0x24) (R/ 16) Result -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t RESULT:16;                 /**< bit:  0..15  Result Value                             */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} ADC_RESULT_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_RESULT_OFFSET                   (0x24)                                        /**<  (ADC_RESULT) Result  Offset */
+#define ADC_RESULT_RESETVALUE               _U_(0x00)                                     /**<  (ADC_RESULT) Result  Reset Value */
+
+#define ADC_RESULT_RESULT_Pos               0                                              /**< (ADC_RESULT) Result Value Position */
+#define ADC_RESULT_RESULT_Msk               (_U_(0xFFFF) << ADC_RESULT_RESULT_Pos)         /**< (ADC_RESULT) Result Value Mask */
+#define ADC_RESULT_RESULT(value)            (ADC_RESULT_RESULT_Msk & ((value) << ADC_RESULT_RESULT_Pos))
+#define ADC_RESULT_MASK                     _U_(0xFFFF)                                    /**< \deprecated (ADC_RESULT) Register MASK  (Use ADC_RESULT_Msk instead)  */
+#define ADC_RESULT_Msk                      _U_(0xFFFF)                                    /**< (ADC_RESULT) Register Mask  */
+
+
+/* -------- ADC_SEQCTRL : (ADC Offset: 0x28) (R/W 32) Sequence Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SEQEN:32;                  /**< bit:  0..31  Enable Positive Input in the Sequence    */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ADC_SEQCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_SEQCTRL_OFFSET                  (0x28)                                        /**<  (ADC_SEQCTRL) Sequence Control  Offset */
+#define ADC_SEQCTRL_RESETVALUE              _U_(0x00)                                     /**<  (ADC_SEQCTRL) Sequence Control  Reset Value */
+
+#define ADC_SEQCTRL_SEQEN_Pos               0                                              /**< (ADC_SEQCTRL) Enable Positive Input in the Sequence Position */
+#define ADC_SEQCTRL_SEQEN_Msk               (_U_(0xFFFFFFFF) << ADC_SEQCTRL_SEQEN_Pos)     /**< (ADC_SEQCTRL) Enable Positive Input in the Sequence Mask */
+#define ADC_SEQCTRL_SEQEN(value)            (ADC_SEQCTRL_SEQEN_Msk & ((value) << ADC_SEQCTRL_SEQEN_Pos))
+#define ADC_SEQCTRL_MASK                    _U_(0xFFFFFFFF)                                /**< \deprecated (ADC_SEQCTRL) Register MASK  (Use ADC_SEQCTRL_Msk instead)  */
+#define ADC_SEQCTRL_Msk                     _U_(0xFFFFFFFF)                                /**< (ADC_SEQCTRL) Register Mask  */
+
+
+/* -------- ADC_CALIB : (ADC Offset: 0x2c) (R/W 16) Calibration -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t BIASCOMP:3;                /**< bit:   0..2  Bias Comparator Scaling                  */
+    uint16_t :5;                        /**< bit:   3..7  Reserved */
+    uint16_t BIASREFBUF:3;              /**< bit:  8..10  Bias  Reference Buffer Scaling           */
+    uint16_t :5;                        /**< bit: 11..15  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} ADC_CALIB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_CALIB_OFFSET                    (0x2C)                                        /**<  (ADC_CALIB) Calibration  Offset */
+#define ADC_CALIB_RESETVALUE                _U_(0x00)                                     /**<  (ADC_CALIB) Calibration  Reset Value */
+
+#define ADC_CALIB_BIASCOMP_Pos              0                                              /**< (ADC_CALIB) Bias Comparator Scaling Position */
+#define ADC_CALIB_BIASCOMP_Msk              (_U_(0x7) << ADC_CALIB_BIASCOMP_Pos)           /**< (ADC_CALIB) Bias Comparator Scaling Mask */
+#define ADC_CALIB_BIASCOMP(value)           (ADC_CALIB_BIASCOMP_Msk & ((value) << ADC_CALIB_BIASCOMP_Pos))
+#define ADC_CALIB_BIASREFBUF_Pos            8                                              /**< (ADC_CALIB) Bias  Reference Buffer Scaling Position */
+#define ADC_CALIB_BIASREFBUF_Msk            (_U_(0x7) << ADC_CALIB_BIASREFBUF_Pos)         /**< (ADC_CALIB) Bias  Reference Buffer Scaling Mask */
+#define ADC_CALIB_BIASREFBUF(value)         (ADC_CALIB_BIASREFBUF_Msk & ((value) << ADC_CALIB_BIASREFBUF_Pos))
+#define ADC_CALIB_MASK                      _U_(0x707)                                     /**< \deprecated (ADC_CALIB) Register MASK  (Use ADC_CALIB_Msk instead)  */
+#define ADC_CALIB_Msk                       _U_(0x707)                                     /**< (ADC_CALIB) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief ADC hardware registers */
+typedef struct {  /* Analog Digital Converter */
+  __IO ADC_CTRLA_Type                 CTRLA;          /**< Offset: 0x00 (R/W   8) Control A */
+  __IO ADC_CTRLB_Type                 CTRLB;          /**< Offset: 0x01 (R/W   8) Control B */
+  __IO ADC_REFCTRL_Type               REFCTRL;        /**< Offset: 0x02 (R/W   8) Reference Control */
+  __IO ADC_EVCTRL_Type                EVCTRL;         /**< Offset: 0x03 (R/W   8) Event Control */
+  __IO ADC_INTENCLR_Type              INTENCLR;       /**< Offset: 0x04 (R/W   8) Interrupt Enable Clear */
+  __IO ADC_INTENSET_Type              INTENSET;       /**< Offset: 0x05 (R/W   8) Interrupt Enable Set */
+  __IO ADC_INTFLAG_Type               INTFLAG;        /**< Offset: 0x06 (R/W   8) Interrupt Flag Status and Clear */
+  __I  ADC_SEQSTATUS_Type             SEQSTATUS;      /**< Offset: 0x07 (R/    8) Sequence Status */
+  __IO ADC_INPUTCTRL_Type             INPUTCTRL;      /**< Offset: 0x08 (R/W  16) Input Control */
+  __IO ADC_CTRLC_Type                 CTRLC;          /**< Offset: 0x0A (R/W  16) Control C */
+  __IO ADC_AVGCTRL_Type               AVGCTRL;        /**< Offset: 0x0C (R/W   8) Average Control */
+  __IO ADC_SAMPCTRL_Type              SAMPCTRL;       /**< Offset: 0x0D (R/W   8) Sample Time Control */
+  __IO ADC_WINLT_Type                 WINLT;          /**< Offset: 0x0E (R/W  16) Window Monitor Lower Threshold */
+  __IO ADC_WINUT_Type                 WINUT;          /**< Offset: 0x10 (R/W  16) Window Monitor Upper Threshold */
+  __IO ADC_GAINCORR_Type              GAINCORR;       /**< Offset: 0x12 (R/W  16) Gain Correction */
+  __IO ADC_OFFSETCORR_Type            OFFSETCORR;     /**< Offset: 0x14 (R/W  16) Offset Correction */
+  __I  uint8_t                        Reserved1[2];
+  __IO ADC_SWTRIG_Type                SWTRIG;         /**< Offset: 0x18 (R/W   8) Software Trigger */
+  __I  uint8_t                        Reserved2[3];
+  __IO ADC_DBGCTRL_Type               DBGCTRL;        /**< Offset: 0x1C (R/W   8) Debug Control */
+  __I  uint8_t                        Reserved3[3];
+  __I  ADC_SYNCBUSY_Type              SYNCBUSY;       /**< Offset: 0x20 (R/   16) Synchronization Busy */
+  __I  uint8_t                        Reserved4[2];
+  __I  ADC_RESULT_Type                RESULT;         /**< Offset: 0x24 (R/   16) Result */
+  __I  uint8_t                        Reserved5[2];
+  __IO ADC_SEQCTRL_Type               SEQCTRL;        /**< Offset: 0x28 (R/W  32) Sequence Control */
+  __IO ADC_CALIB_Type                 CALIB;          /**< Offset: 0x2C (R/W  16) Calibration */
+} Adc;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Analog Digital Converter */
+
+#endif /* _SAML11_ADC_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/component/ccl.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/ccl.h
@@ -1,0 +1,258 @@
+/**
+ * \file
+ *
+ * \brief Component description for CCL
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_CCL_COMPONENT_H_
+#define _SAML11_CCL_COMPONENT_H_
+#define _SAML11_CCL_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML11 Configurable Custom Logic
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR CCL */
+/* ========================================================================== */
+
+#define CCL_U2225                      /**< (CCL) Module ID */
+#define REV_CCL 0x200                  /**< (CCL) Module revision */
+
+/* -------- CCL_CTRL : (CCL Offset: 0x00) (R/W 8) Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint8_t  ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint8_t  :4;                        /**< bit:   2..5  Reserved */
+    uint8_t  RUNSTDBY:1;                /**< bit:      6  Run in Standby                           */
+    uint8_t  :1;                        /**< bit:      7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} CCL_CTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CCL_CTRL_OFFSET                     (0x00)                                        /**<  (CCL_CTRL) Control  Offset */
+#define CCL_CTRL_RESETVALUE                 _U_(0x00)                                     /**<  (CCL_CTRL) Control  Reset Value */
+
+#define CCL_CTRL_SWRST_Pos                  0                                              /**< (CCL_CTRL) Software Reset Position */
+#define CCL_CTRL_SWRST_Msk                  (_U_(0x1) << CCL_CTRL_SWRST_Pos)               /**< (CCL_CTRL) Software Reset Mask */
+#define CCL_CTRL_SWRST                      CCL_CTRL_SWRST_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use CCL_CTRL_SWRST_Msk instead */
+#define CCL_CTRL_ENABLE_Pos                 1                                              /**< (CCL_CTRL) Enable Position */
+#define CCL_CTRL_ENABLE_Msk                 (_U_(0x1) << CCL_CTRL_ENABLE_Pos)              /**< (CCL_CTRL) Enable Mask */
+#define CCL_CTRL_ENABLE                     CCL_CTRL_ENABLE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use CCL_CTRL_ENABLE_Msk instead */
+#define CCL_CTRL_RUNSTDBY_Pos               6                                              /**< (CCL_CTRL) Run in Standby Position */
+#define CCL_CTRL_RUNSTDBY_Msk               (_U_(0x1) << CCL_CTRL_RUNSTDBY_Pos)            /**< (CCL_CTRL) Run in Standby Mask */
+#define CCL_CTRL_RUNSTDBY                   CCL_CTRL_RUNSTDBY_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use CCL_CTRL_RUNSTDBY_Msk instead */
+#define CCL_CTRL_MASK                       _U_(0x43)                                      /**< \deprecated (CCL_CTRL) Register MASK  (Use CCL_CTRL_Msk instead)  */
+#define CCL_CTRL_Msk                        _U_(0x43)                                      /**< (CCL_CTRL) Register Mask  */
+
+
+/* -------- CCL_SEQCTRL : (CCL Offset: 0x04) (R/W 8) SEQ Control x -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  SEQSEL:4;                  /**< bit:   0..3  Sequential Selection                     */
+    uint8_t  :4;                        /**< bit:   4..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} CCL_SEQCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CCL_SEQCTRL_OFFSET                  (0x04)                                        /**<  (CCL_SEQCTRL) SEQ Control x  Offset */
+#define CCL_SEQCTRL_RESETVALUE              _U_(0x00)                                     /**<  (CCL_SEQCTRL) SEQ Control x  Reset Value */
+
+#define CCL_SEQCTRL_SEQSEL_Pos              0                                              /**< (CCL_SEQCTRL) Sequential Selection Position */
+#define CCL_SEQCTRL_SEQSEL_Msk              (_U_(0xF) << CCL_SEQCTRL_SEQSEL_Pos)           /**< (CCL_SEQCTRL) Sequential Selection Mask */
+#define CCL_SEQCTRL_SEQSEL(value)           (CCL_SEQCTRL_SEQSEL_Msk & ((value) << CCL_SEQCTRL_SEQSEL_Pos))
+#define   CCL_SEQCTRL_SEQSEL_DISABLE_Val    _U_(0x0)                                       /**< (CCL_SEQCTRL) Sequential logic is disabled  */
+#define   CCL_SEQCTRL_SEQSEL_DFF_Val        _U_(0x1)                                       /**< (CCL_SEQCTRL) D flip flop  */
+#define   CCL_SEQCTRL_SEQSEL_JK_Val         _U_(0x2)                                       /**< (CCL_SEQCTRL) JK flip flop  */
+#define   CCL_SEQCTRL_SEQSEL_LATCH_Val      _U_(0x3)                                       /**< (CCL_SEQCTRL) D latch  */
+#define   CCL_SEQCTRL_SEQSEL_RS_Val         _U_(0x4)                                       /**< (CCL_SEQCTRL) RS latch  */
+#define CCL_SEQCTRL_SEQSEL_DISABLE          (CCL_SEQCTRL_SEQSEL_DISABLE_Val << CCL_SEQCTRL_SEQSEL_Pos)  /**< (CCL_SEQCTRL) Sequential logic is disabled Position  */
+#define CCL_SEQCTRL_SEQSEL_DFF              (CCL_SEQCTRL_SEQSEL_DFF_Val << CCL_SEQCTRL_SEQSEL_Pos)  /**< (CCL_SEQCTRL) D flip flop Position  */
+#define CCL_SEQCTRL_SEQSEL_JK               (CCL_SEQCTRL_SEQSEL_JK_Val << CCL_SEQCTRL_SEQSEL_Pos)  /**< (CCL_SEQCTRL) JK flip flop Position  */
+#define CCL_SEQCTRL_SEQSEL_LATCH            (CCL_SEQCTRL_SEQSEL_LATCH_Val << CCL_SEQCTRL_SEQSEL_Pos)  /**< (CCL_SEQCTRL) D latch Position  */
+#define CCL_SEQCTRL_SEQSEL_RS               (CCL_SEQCTRL_SEQSEL_RS_Val << CCL_SEQCTRL_SEQSEL_Pos)  /**< (CCL_SEQCTRL) RS latch Position  */
+#define CCL_SEQCTRL_MASK                    _U_(0x0F)                                      /**< \deprecated (CCL_SEQCTRL) Register MASK  (Use CCL_SEQCTRL_Msk instead)  */
+#define CCL_SEQCTRL_Msk                     _U_(0x0F)                                      /**< (CCL_SEQCTRL) Register Mask  */
+
+
+/* -------- CCL_LUTCTRL : (CCL Offset: 0x08) (R/W 32) LUT Control x -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t ENABLE:1;                  /**< bit:      1  LUT Enable                               */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t FILTSEL:2;                 /**< bit:   4..5  Filter Selection                         */
+    uint32_t :1;                        /**< bit:      6  Reserved */
+    uint32_t EDGESEL:1;                 /**< bit:      7  Edge Selection                           */
+    uint32_t INSEL0:4;                  /**< bit:  8..11  Input Selection 0                        */
+    uint32_t INSEL1:4;                  /**< bit: 12..15  Input Selection 1                        */
+    uint32_t INSEL2:4;                  /**< bit: 16..19  Input Selection 2                        */
+    uint32_t INVEI:1;                   /**< bit:     20  Inverted Event Input Enable              */
+    uint32_t LUTEI:1;                   /**< bit:     21  LUT Event Input Enable                   */
+    uint32_t LUTEO:1;                   /**< bit:     22  LUT Event Output Enable                  */
+    uint32_t :1;                        /**< bit:     23  Reserved */
+    uint32_t TRUTH:8;                   /**< bit: 24..31  Truth Value                              */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} CCL_LUTCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CCL_LUTCTRL_OFFSET                  (0x08)                                        /**<  (CCL_LUTCTRL) LUT Control x  Offset */
+#define CCL_LUTCTRL_RESETVALUE              _U_(0x00)                                     /**<  (CCL_LUTCTRL) LUT Control x  Reset Value */
+
+#define CCL_LUTCTRL_ENABLE_Pos              1                                              /**< (CCL_LUTCTRL) LUT Enable Position */
+#define CCL_LUTCTRL_ENABLE_Msk              (_U_(0x1) << CCL_LUTCTRL_ENABLE_Pos)           /**< (CCL_LUTCTRL) LUT Enable Mask */
+#define CCL_LUTCTRL_ENABLE                  CCL_LUTCTRL_ENABLE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use CCL_LUTCTRL_ENABLE_Msk instead */
+#define CCL_LUTCTRL_FILTSEL_Pos             4                                              /**< (CCL_LUTCTRL) Filter Selection Position */
+#define CCL_LUTCTRL_FILTSEL_Msk             (_U_(0x3) << CCL_LUTCTRL_FILTSEL_Pos)          /**< (CCL_LUTCTRL) Filter Selection Mask */
+#define CCL_LUTCTRL_FILTSEL(value)          (CCL_LUTCTRL_FILTSEL_Msk & ((value) << CCL_LUTCTRL_FILTSEL_Pos))
+#define   CCL_LUTCTRL_FILTSEL_DISABLE_Val   _U_(0x0)                                       /**< (CCL_LUTCTRL) Filter disabled  */
+#define   CCL_LUTCTRL_FILTSEL_SYNCH_Val     _U_(0x1)                                       /**< (CCL_LUTCTRL) Synchronizer enabled  */
+#define   CCL_LUTCTRL_FILTSEL_FILTER_Val    _U_(0x2)                                       /**< (CCL_LUTCTRL) Filter enabled  */
+#define CCL_LUTCTRL_FILTSEL_DISABLE         (CCL_LUTCTRL_FILTSEL_DISABLE_Val << CCL_LUTCTRL_FILTSEL_Pos)  /**< (CCL_LUTCTRL) Filter disabled Position  */
+#define CCL_LUTCTRL_FILTSEL_SYNCH           (CCL_LUTCTRL_FILTSEL_SYNCH_Val << CCL_LUTCTRL_FILTSEL_Pos)  /**< (CCL_LUTCTRL) Synchronizer enabled Position  */
+#define CCL_LUTCTRL_FILTSEL_FILTER          (CCL_LUTCTRL_FILTSEL_FILTER_Val << CCL_LUTCTRL_FILTSEL_Pos)  /**< (CCL_LUTCTRL) Filter enabled Position  */
+#define CCL_LUTCTRL_EDGESEL_Pos             7                                              /**< (CCL_LUTCTRL) Edge Selection Position */
+#define CCL_LUTCTRL_EDGESEL_Msk             (_U_(0x1) << CCL_LUTCTRL_EDGESEL_Pos)          /**< (CCL_LUTCTRL) Edge Selection Mask */
+#define CCL_LUTCTRL_EDGESEL                 CCL_LUTCTRL_EDGESEL_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use CCL_LUTCTRL_EDGESEL_Msk instead */
+#define CCL_LUTCTRL_INSEL0_Pos              8                                              /**< (CCL_LUTCTRL) Input Selection 0 Position */
+#define CCL_LUTCTRL_INSEL0_Msk              (_U_(0xF) << CCL_LUTCTRL_INSEL0_Pos)           /**< (CCL_LUTCTRL) Input Selection 0 Mask */
+#define CCL_LUTCTRL_INSEL0(value)           (CCL_LUTCTRL_INSEL0_Msk & ((value) << CCL_LUTCTRL_INSEL0_Pos))
+#define   CCL_LUTCTRL_INSEL0_MASK_Val       _U_(0x0)                                       /**< (CCL_LUTCTRL) Masked input  */
+#define   CCL_LUTCTRL_INSEL0_FEEDBACK_Val   _U_(0x1)                                       /**< (CCL_LUTCTRL) Feedback input source  */
+#define   CCL_LUTCTRL_INSEL0_LINK_Val       _U_(0x2)                                       /**< (CCL_LUTCTRL) Linked LUT input source  */
+#define   CCL_LUTCTRL_INSEL0_EVENT_Val      _U_(0x3)                                       /**< (CCL_LUTCTRL) Event input source  */
+#define   CCL_LUTCTRL_INSEL0_IO_Val         _U_(0x4)                                       /**< (CCL_LUTCTRL) I/O pin input source  */
+#define   CCL_LUTCTRL_INSEL0_AC_Val         _U_(0x5)                                       /**< (CCL_LUTCTRL) AC input source  */
+#define   CCL_LUTCTRL_INSEL0_TC_Val         _U_(0x6)                                       /**< (CCL_LUTCTRL) TC input source  */
+#define   CCL_LUTCTRL_INSEL0_ALTTC_Val      _U_(0x7)                                       /**< (CCL_LUTCTRL) Alternate TC input source  */
+#define   CCL_LUTCTRL_INSEL0_TCC_Val        _U_(0x8)                                       /**< (CCL_LUTCTRL) TCC input source  */
+#define   CCL_LUTCTRL_INSEL0_SERCOM_Val     _U_(0x9)                                       /**< (CCL_LUTCTRL) SERCOM input source  */
+#define   CCL_LUTCTRL_INSEL0_ALT2TC_Val     _U_(0xA)                                       /**< (CCL_LUTCTRL) Alternate 2 TC input source  */
+#define   CCL_LUTCTRL_INSEL0_ASYNCEVENT_Val _U_(0xB)                                       /**< (CCL_LUTCTRL) Asynchronous event input source. The EVENT input will bypass edge detection logic.  */
+#define CCL_LUTCTRL_INSEL0_MASK             (CCL_LUTCTRL_INSEL0_MASK_Val << CCL_LUTCTRL_INSEL0_Pos)  /**< (CCL_LUTCTRL) Masked input Position  */
+#define CCL_LUTCTRL_INSEL0_FEEDBACK         (CCL_LUTCTRL_INSEL0_FEEDBACK_Val << CCL_LUTCTRL_INSEL0_Pos)  /**< (CCL_LUTCTRL) Feedback input source Position  */
+#define CCL_LUTCTRL_INSEL0_LINK             (CCL_LUTCTRL_INSEL0_LINK_Val << CCL_LUTCTRL_INSEL0_Pos)  /**< (CCL_LUTCTRL) Linked LUT input source Position  */
+#define CCL_LUTCTRL_INSEL0_EVENT            (CCL_LUTCTRL_INSEL0_EVENT_Val << CCL_LUTCTRL_INSEL0_Pos)  /**< (CCL_LUTCTRL) Event input source Position  */
+#define CCL_LUTCTRL_INSEL0_IO               (CCL_LUTCTRL_INSEL0_IO_Val << CCL_LUTCTRL_INSEL0_Pos)  /**< (CCL_LUTCTRL) I/O pin input source Position  */
+#define CCL_LUTCTRL_INSEL0_AC               (CCL_LUTCTRL_INSEL0_AC_Val << CCL_LUTCTRL_INSEL0_Pos)  /**< (CCL_LUTCTRL) AC input source Position  */
+#define CCL_LUTCTRL_INSEL0_TC               (CCL_LUTCTRL_INSEL0_TC_Val << CCL_LUTCTRL_INSEL0_Pos)  /**< (CCL_LUTCTRL) TC input source Position  */
+#define CCL_LUTCTRL_INSEL0_ALTTC            (CCL_LUTCTRL_INSEL0_ALTTC_Val << CCL_LUTCTRL_INSEL0_Pos)  /**< (CCL_LUTCTRL) Alternate TC input source Position  */
+#define CCL_LUTCTRL_INSEL0_TCC              (CCL_LUTCTRL_INSEL0_TCC_Val << CCL_LUTCTRL_INSEL0_Pos)  /**< (CCL_LUTCTRL) TCC input source Position  */
+#define CCL_LUTCTRL_INSEL0_SERCOM           (CCL_LUTCTRL_INSEL0_SERCOM_Val << CCL_LUTCTRL_INSEL0_Pos)  /**< (CCL_LUTCTRL) SERCOM input source Position  */
+#define CCL_LUTCTRL_INSEL0_ALT2TC           (CCL_LUTCTRL_INSEL0_ALT2TC_Val << CCL_LUTCTRL_INSEL0_Pos)  /**< (CCL_LUTCTRL) Alternate 2 TC input source Position  */
+#define CCL_LUTCTRL_INSEL0_ASYNCEVENT       (CCL_LUTCTRL_INSEL0_ASYNCEVENT_Val << CCL_LUTCTRL_INSEL0_Pos)  /**< (CCL_LUTCTRL) Asynchronous event input source. The EVENT input will bypass edge detection logic. Position  */
+#define CCL_LUTCTRL_INSEL1_Pos              12                                             /**< (CCL_LUTCTRL) Input Selection 1 Position */
+#define CCL_LUTCTRL_INSEL1_Msk              (_U_(0xF) << CCL_LUTCTRL_INSEL1_Pos)           /**< (CCL_LUTCTRL) Input Selection 1 Mask */
+#define CCL_LUTCTRL_INSEL1(value)           (CCL_LUTCTRL_INSEL1_Msk & ((value) << CCL_LUTCTRL_INSEL1_Pos))
+#define   CCL_LUTCTRL_INSEL1_MASK_Val       _U_(0x0)                                       /**< (CCL_LUTCTRL) Masked input  */
+#define   CCL_LUTCTRL_INSEL1_FEEDBACK_Val   _U_(0x1)                                       /**< (CCL_LUTCTRL) Feedback input source  */
+#define   CCL_LUTCTRL_INSEL1_LINK_Val       _U_(0x2)                                       /**< (CCL_LUTCTRL) Linked LUT input source  */
+#define   CCL_LUTCTRL_INSEL1_EVENT_Val      _U_(0x3)                                       /**< (CCL_LUTCTRL) Event input source  */
+#define   CCL_LUTCTRL_INSEL1_IO_Val         _U_(0x4)                                       /**< (CCL_LUTCTRL) I/O pin input source  */
+#define   CCL_LUTCTRL_INSEL1_AC_Val         _U_(0x5)                                       /**< (CCL_LUTCTRL) AC input source  */
+#define   CCL_LUTCTRL_INSEL1_TC_Val         _U_(0x6)                                       /**< (CCL_LUTCTRL) TC input source  */
+#define   CCL_LUTCTRL_INSEL1_ALTTC_Val      _U_(0x7)                                       /**< (CCL_LUTCTRL) Alternate TC input source  */
+#define   CCL_LUTCTRL_INSEL1_TCC_Val        _U_(0x8)                                       /**< (CCL_LUTCTRL) TCC input source  */
+#define   CCL_LUTCTRL_INSEL1_SERCOM_Val     _U_(0x9)                                       /**< (CCL_LUTCTRL) SERCOM input source  */
+#define   CCL_LUTCTRL_INSEL1_ALT2TC_Val     _U_(0xA)                                       /**< (CCL_LUTCTRL) Alternate 2 TC input source  */
+#define   CCL_LUTCTRL_INSEL1_ASYNCEVENT_Val _U_(0xB)                                       /**< (CCL_LUTCTRL) Asynchronous event input source. The EVENT input will bypass edge detection logic.  */
+#define CCL_LUTCTRL_INSEL1_MASK             (CCL_LUTCTRL_INSEL1_MASK_Val << CCL_LUTCTRL_INSEL1_Pos)  /**< (CCL_LUTCTRL) Masked input Position  */
+#define CCL_LUTCTRL_INSEL1_FEEDBACK         (CCL_LUTCTRL_INSEL1_FEEDBACK_Val << CCL_LUTCTRL_INSEL1_Pos)  /**< (CCL_LUTCTRL) Feedback input source Position  */
+#define CCL_LUTCTRL_INSEL1_LINK             (CCL_LUTCTRL_INSEL1_LINK_Val << CCL_LUTCTRL_INSEL1_Pos)  /**< (CCL_LUTCTRL) Linked LUT input source Position  */
+#define CCL_LUTCTRL_INSEL1_EVENT            (CCL_LUTCTRL_INSEL1_EVENT_Val << CCL_LUTCTRL_INSEL1_Pos)  /**< (CCL_LUTCTRL) Event input source Position  */
+#define CCL_LUTCTRL_INSEL1_IO               (CCL_LUTCTRL_INSEL1_IO_Val << CCL_LUTCTRL_INSEL1_Pos)  /**< (CCL_LUTCTRL) I/O pin input source Position  */
+#define CCL_LUTCTRL_INSEL1_AC               (CCL_LUTCTRL_INSEL1_AC_Val << CCL_LUTCTRL_INSEL1_Pos)  /**< (CCL_LUTCTRL) AC input source Position  */
+#define CCL_LUTCTRL_INSEL1_TC               (CCL_LUTCTRL_INSEL1_TC_Val << CCL_LUTCTRL_INSEL1_Pos)  /**< (CCL_LUTCTRL) TC input source Position  */
+#define CCL_LUTCTRL_INSEL1_ALTTC            (CCL_LUTCTRL_INSEL1_ALTTC_Val << CCL_LUTCTRL_INSEL1_Pos)  /**< (CCL_LUTCTRL) Alternate TC input source Position  */
+#define CCL_LUTCTRL_INSEL1_TCC              (CCL_LUTCTRL_INSEL1_TCC_Val << CCL_LUTCTRL_INSEL1_Pos)  /**< (CCL_LUTCTRL) TCC input source Position  */
+#define CCL_LUTCTRL_INSEL1_SERCOM           (CCL_LUTCTRL_INSEL1_SERCOM_Val << CCL_LUTCTRL_INSEL1_Pos)  /**< (CCL_LUTCTRL) SERCOM input source Position  */
+#define CCL_LUTCTRL_INSEL1_ALT2TC           (CCL_LUTCTRL_INSEL1_ALT2TC_Val << CCL_LUTCTRL_INSEL1_Pos)  /**< (CCL_LUTCTRL) Alternate 2 TC input source Position  */
+#define CCL_LUTCTRL_INSEL1_ASYNCEVENT       (CCL_LUTCTRL_INSEL1_ASYNCEVENT_Val << CCL_LUTCTRL_INSEL1_Pos)  /**< (CCL_LUTCTRL) Asynchronous event input source. The EVENT input will bypass edge detection logic. Position  */
+#define CCL_LUTCTRL_INSEL2_Pos              16                                             /**< (CCL_LUTCTRL) Input Selection 2 Position */
+#define CCL_LUTCTRL_INSEL2_Msk              (_U_(0xF) << CCL_LUTCTRL_INSEL2_Pos)           /**< (CCL_LUTCTRL) Input Selection 2 Mask */
+#define CCL_LUTCTRL_INSEL2(value)           (CCL_LUTCTRL_INSEL2_Msk & ((value) << CCL_LUTCTRL_INSEL2_Pos))
+#define   CCL_LUTCTRL_INSEL2_MASK_Val       _U_(0x0)                                       /**< (CCL_LUTCTRL) Masked input  */
+#define   CCL_LUTCTRL_INSEL2_FEEDBACK_Val   _U_(0x1)                                       /**< (CCL_LUTCTRL) Feedback input source  */
+#define   CCL_LUTCTRL_INSEL2_LINK_Val       _U_(0x2)                                       /**< (CCL_LUTCTRL) Linked LUT input source  */
+#define   CCL_LUTCTRL_INSEL2_EVENT_Val      _U_(0x3)                                       /**< (CCL_LUTCTRL) Event input source  */
+#define   CCL_LUTCTRL_INSEL2_IO_Val         _U_(0x4)                                       /**< (CCL_LUTCTRL) I/O pin input source  */
+#define   CCL_LUTCTRL_INSEL2_AC_Val         _U_(0x5)                                       /**< (CCL_LUTCTRL) AC input source  */
+#define   CCL_LUTCTRL_INSEL2_TC_Val         _U_(0x6)                                       /**< (CCL_LUTCTRL) TC input source  */
+#define   CCL_LUTCTRL_INSEL2_ALTTC_Val      _U_(0x7)                                       /**< (CCL_LUTCTRL) Alternate TC input source  */
+#define   CCL_LUTCTRL_INSEL2_TCC_Val        _U_(0x8)                                       /**< (CCL_LUTCTRL) TCC input source  */
+#define   CCL_LUTCTRL_INSEL2_SERCOM_Val     _U_(0x9)                                       /**< (CCL_LUTCTRL) SERCOM input source  */
+#define   CCL_LUTCTRL_INSEL2_ALT2TC_Val     _U_(0xA)                                       /**< (CCL_LUTCTRL) Alternate 2 TC input source  */
+#define   CCL_LUTCTRL_INSEL2_ASYNCEVENT_Val _U_(0xB)                                       /**< (CCL_LUTCTRL) Asynchronous event input source. The EVENT input will bypass edge detection logic.  */
+#define CCL_LUTCTRL_INSEL2_MASK             (CCL_LUTCTRL_INSEL2_MASK_Val << CCL_LUTCTRL_INSEL2_Pos)  /**< (CCL_LUTCTRL) Masked input Position  */
+#define CCL_LUTCTRL_INSEL2_FEEDBACK         (CCL_LUTCTRL_INSEL2_FEEDBACK_Val << CCL_LUTCTRL_INSEL2_Pos)  /**< (CCL_LUTCTRL) Feedback input source Position  */
+#define CCL_LUTCTRL_INSEL2_LINK             (CCL_LUTCTRL_INSEL2_LINK_Val << CCL_LUTCTRL_INSEL2_Pos)  /**< (CCL_LUTCTRL) Linked LUT input source Position  */
+#define CCL_LUTCTRL_INSEL2_EVENT            (CCL_LUTCTRL_INSEL2_EVENT_Val << CCL_LUTCTRL_INSEL2_Pos)  /**< (CCL_LUTCTRL) Event input source Position  */
+#define CCL_LUTCTRL_INSEL2_IO               (CCL_LUTCTRL_INSEL2_IO_Val << CCL_LUTCTRL_INSEL2_Pos)  /**< (CCL_LUTCTRL) I/O pin input source Position  */
+#define CCL_LUTCTRL_INSEL2_AC               (CCL_LUTCTRL_INSEL2_AC_Val << CCL_LUTCTRL_INSEL2_Pos)  /**< (CCL_LUTCTRL) AC input source Position  */
+#define CCL_LUTCTRL_INSEL2_TC               (CCL_LUTCTRL_INSEL2_TC_Val << CCL_LUTCTRL_INSEL2_Pos)  /**< (CCL_LUTCTRL) TC input source Position  */
+#define CCL_LUTCTRL_INSEL2_ALTTC            (CCL_LUTCTRL_INSEL2_ALTTC_Val << CCL_LUTCTRL_INSEL2_Pos)  /**< (CCL_LUTCTRL) Alternate TC input source Position  */
+#define CCL_LUTCTRL_INSEL2_TCC              (CCL_LUTCTRL_INSEL2_TCC_Val << CCL_LUTCTRL_INSEL2_Pos)  /**< (CCL_LUTCTRL) TCC input source Position  */
+#define CCL_LUTCTRL_INSEL2_SERCOM           (CCL_LUTCTRL_INSEL2_SERCOM_Val << CCL_LUTCTRL_INSEL2_Pos)  /**< (CCL_LUTCTRL) SERCOM input source Position  */
+#define CCL_LUTCTRL_INSEL2_ALT2TC           (CCL_LUTCTRL_INSEL2_ALT2TC_Val << CCL_LUTCTRL_INSEL2_Pos)  /**< (CCL_LUTCTRL) Alternate 2 TC input source Position  */
+#define CCL_LUTCTRL_INSEL2_ASYNCEVENT       (CCL_LUTCTRL_INSEL2_ASYNCEVENT_Val << CCL_LUTCTRL_INSEL2_Pos)  /**< (CCL_LUTCTRL) Asynchronous event input source. The EVENT input will bypass edge detection logic. Position  */
+#define CCL_LUTCTRL_INVEI_Pos               20                                             /**< (CCL_LUTCTRL) Inverted Event Input Enable Position */
+#define CCL_LUTCTRL_INVEI_Msk               (_U_(0x1) << CCL_LUTCTRL_INVEI_Pos)            /**< (CCL_LUTCTRL) Inverted Event Input Enable Mask */
+#define CCL_LUTCTRL_INVEI                   CCL_LUTCTRL_INVEI_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use CCL_LUTCTRL_INVEI_Msk instead */
+#define CCL_LUTCTRL_LUTEI_Pos               21                                             /**< (CCL_LUTCTRL) LUT Event Input Enable Position */
+#define CCL_LUTCTRL_LUTEI_Msk               (_U_(0x1) << CCL_LUTCTRL_LUTEI_Pos)            /**< (CCL_LUTCTRL) LUT Event Input Enable Mask */
+#define CCL_LUTCTRL_LUTEI                   CCL_LUTCTRL_LUTEI_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use CCL_LUTCTRL_LUTEI_Msk instead */
+#define CCL_LUTCTRL_LUTEO_Pos               22                                             /**< (CCL_LUTCTRL) LUT Event Output Enable Position */
+#define CCL_LUTCTRL_LUTEO_Msk               (_U_(0x1) << CCL_LUTCTRL_LUTEO_Pos)            /**< (CCL_LUTCTRL) LUT Event Output Enable Mask */
+#define CCL_LUTCTRL_LUTEO                   CCL_LUTCTRL_LUTEO_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use CCL_LUTCTRL_LUTEO_Msk instead */
+#define CCL_LUTCTRL_TRUTH_Pos               24                                             /**< (CCL_LUTCTRL) Truth Value Position */
+#define CCL_LUTCTRL_TRUTH_Msk               (_U_(0xFF) << CCL_LUTCTRL_TRUTH_Pos)           /**< (CCL_LUTCTRL) Truth Value Mask */
+#define CCL_LUTCTRL_TRUTH(value)            (CCL_LUTCTRL_TRUTH_Msk & ((value) << CCL_LUTCTRL_TRUTH_Pos))
+#define CCL_LUTCTRL_MASK                    _U_(0xFF7FFFB2)                                /**< \deprecated (CCL_LUTCTRL) Register MASK  (Use CCL_LUTCTRL_Msk instead)  */
+#define CCL_LUTCTRL_Msk                     _U_(0xFF7FFFB2)                                /**< (CCL_LUTCTRL) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief CCL hardware registers */
+typedef struct {  /* Configurable Custom Logic */
+  __IO CCL_CTRL_Type                  CTRL;           /**< Offset: 0x00 (R/W   8) Control */
+  __I  uint8_t                        Reserved1[3];
+  __IO CCL_SEQCTRL_Type               SEQCTRL[1];     /**< Offset: 0x04 (R/W   8) SEQ Control x */
+  __I  uint8_t                        Reserved2[3];
+  __IO CCL_LUTCTRL_Type               LUTCTRL[2];     /**< Offset: 0x08 (R/W  32) LUT Control x */
+} Ccl;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Configurable Custom Logic */
+
+#endif /* _SAML11_CCL_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/component/dac.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/dac.h
@@ -1,0 +1,364 @@
+/**
+ * \file
+ *
+ * \brief Component description for DAC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_DAC_COMPONENT_H_
+#define _SAML11_DAC_COMPONENT_H_
+#define _SAML11_DAC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML11 Digital Analog Converter
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR DAC */
+/* ========================================================================== */
+
+#define DAC_U2214                      /**< (DAC) Module ID */
+#define REV_DAC 0x210                  /**< (DAC) Module revision */
+
+/* -------- DAC_CTRLA : (DAC Offset: 0x00) (R/W 8) Control A -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint8_t  ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint8_t  :4;                        /**< bit:   2..5  Reserved */
+    uint8_t  RUNSTDBY:1;                /**< bit:      6  Run in Standby                           */
+    uint8_t  :1;                        /**< bit:      7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} DAC_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_CTRLA_OFFSET                    (0x00)                                        /**<  (DAC_CTRLA) Control A  Offset */
+#define DAC_CTRLA_RESETVALUE                _U_(0x00)                                     /**<  (DAC_CTRLA) Control A  Reset Value */
+
+#define DAC_CTRLA_SWRST_Pos                 0                                              /**< (DAC_CTRLA) Software Reset Position */
+#define DAC_CTRLA_SWRST_Msk                 (_U_(0x1) << DAC_CTRLA_SWRST_Pos)              /**< (DAC_CTRLA) Software Reset Mask */
+#define DAC_CTRLA_SWRST                     DAC_CTRLA_SWRST_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use DAC_CTRLA_SWRST_Msk instead */
+#define DAC_CTRLA_ENABLE_Pos                1                                              /**< (DAC_CTRLA) Enable Position */
+#define DAC_CTRLA_ENABLE_Msk                (_U_(0x1) << DAC_CTRLA_ENABLE_Pos)             /**< (DAC_CTRLA) Enable Mask */
+#define DAC_CTRLA_ENABLE                    DAC_CTRLA_ENABLE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use DAC_CTRLA_ENABLE_Msk instead */
+#define DAC_CTRLA_RUNSTDBY_Pos              6                                              /**< (DAC_CTRLA) Run in Standby Position */
+#define DAC_CTRLA_RUNSTDBY_Msk              (_U_(0x1) << DAC_CTRLA_RUNSTDBY_Pos)           /**< (DAC_CTRLA) Run in Standby Mask */
+#define DAC_CTRLA_RUNSTDBY                  DAC_CTRLA_RUNSTDBY_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use DAC_CTRLA_RUNSTDBY_Msk instead */
+#define DAC_CTRLA_MASK                      _U_(0x43)                                      /**< \deprecated (DAC_CTRLA) Register MASK  (Use DAC_CTRLA_Msk instead)  */
+#define DAC_CTRLA_Msk                       _U_(0x43)                                      /**< (DAC_CTRLA) Register Mask  */
+
+
+/* -------- DAC_CTRLB : (DAC Offset: 0x01) (R/W 8) Control B -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  EOEN:1;                    /**< bit:      0  External Output Enable                   */
+    uint8_t  IOEN:1;                    /**< bit:      1  Internal Output Enable                   */
+    uint8_t  LEFTADJ:1;                 /**< bit:      2  Left Adjusted Data                       */
+    uint8_t  VPD:1;                     /**< bit:      3  Voltage Pump Disable                     */
+    uint8_t  :1;                        /**< bit:      4  Reserved */
+    uint8_t  DITHER:1;                  /**< bit:      5  Dither Enable                            */
+    uint8_t  REFSEL:2;                  /**< bit:   6..7  Reference Selection                      */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} DAC_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_CTRLB_OFFSET                    (0x01)                                        /**<  (DAC_CTRLB) Control B  Offset */
+#define DAC_CTRLB_RESETVALUE                _U_(0x00)                                     /**<  (DAC_CTRLB) Control B  Reset Value */
+
+#define DAC_CTRLB_EOEN_Pos                  0                                              /**< (DAC_CTRLB) External Output Enable Position */
+#define DAC_CTRLB_EOEN_Msk                  (_U_(0x1) << DAC_CTRLB_EOEN_Pos)               /**< (DAC_CTRLB) External Output Enable Mask */
+#define DAC_CTRLB_EOEN                      DAC_CTRLB_EOEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use DAC_CTRLB_EOEN_Msk instead */
+#define DAC_CTRLB_IOEN_Pos                  1                                              /**< (DAC_CTRLB) Internal Output Enable Position */
+#define DAC_CTRLB_IOEN_Msk                  (_U_(0x1) << DAC_CTRLB_IOEN_Pos)               /**< (DAC_CTRLB) Internal Output Enable Mask */
+#define DAC_CTRLB_IOEN                      DAC_CTRLB_IOEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use DAC_CTRLB_IOEN_Msk instead */
+#define DAC_CTRLB_LEFTADJ_Pos               2                                              /**< (DAC_CTRLB) Left Adjusted Data Position */
+#define DAC_CTRLB_LEFTADJ_Msk               (_U_(0x1) << DAC_CTRLB_LEFTADJ_Pos)            /**< (DAC_CTRLB) Left Adjusted Data Mask */
+#define DAC_CTRLB_LEFTADJ                   DAC_CTRLB_LEFTADJ_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use DAC_CTRLB_LEFTADJ_Msk instead */
+#define DAC_CTRLB_VPD_Pos                   3                                              /**< (DAC_CTRLB) Voltage Pump Disable Position */
+#define DAC_CTRLB_VPD_Msk                   (_U_(0x1) << DAC_CTRLB_VPD_Pos)                /**< (DAC_CTRLB) Voltage Pump Disable Mask */
+#define DAC_CTRLB_VPD                       DAC_CTRLB_VPD_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use DAC_CTRLB_VPD_Msk instead */
+#define DAC_CTRLB_DITHER_Pos                5                                              /**< (DAC_CTRLB) Dither Enable Position */
+#define DAC_CTRLB_DITHER_Msk                (_U_(0x1) << DAC_CTRLB_DITHER_Pos)             /**< (DAC_CTRLB) Dither Enable Mask */
+#define DAC_CTRLB_DITHER                    DAC_CTRLB_DITHER_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use DAC_CTRLB_DITHER_Msk instead */
+#define DAC_CTRLB_REFSEL_Pos                6                                              /**< (DAC_CTRLB) Reference Selection Position */
+#define DAC_CTRLB_REFSEL_Msk                (_U_(0x3) << DAC_CTRLB_REFSEL_Pos)             /**< (DAC_CTRLB) Reference Selection Mask */
+#define DAC_CTRLB_REFSEL(value)             (DAC_CTRLB_REFSEL_Msk & ((value) << DAC_CTRLB_REFSEL_Pos))
+#define   DAC_CTRLB_REFSEL_INT1V_Val        _U_(0x0)                                       /**< (DAC_CTRLB) Internal 1.0V reference  */
+#define   DAC_CTRLB_REFSEL_AVCC_Val         _U_(0x1)                                       /**< (DAC_CTRLB) AVCC  */
+#define   DAC_CTRLB_REFSEL_VREFP_Val        _U_(0x2)                                       /**< (DAC_CTRLB) External reference  */
+#define DAC_CTRLB_REFSEL_INT1V              (DAC_CTRLB_REFSEL_INT1V_Val << DAC_CTRLB_REFSEL_Pos)  /**< (DAC_CTRLB) Internal 1.0V reference Position  */
+#define DAC_CTRLB_REFSEL_AVCC               (DAC_CTRLB_REFSEL_AVCC_Val << DAC_CTRLB_REFSEL_Pos)  /**< (DAC_CTRLB) AVCC Position  */
+#define DAC_CTRLB_REFSEL_VREFP              (DAC_CTRLB_REFSEL_VREFP_Val << DAC_CTRLB_REFSEL_Pos)  /**< (DAC_CTRLB) External reference Position  */
+#define DAC_CTRLB_MASK                      _U_(0xEF)                                      /**< \deprecated (DAC_CTRLB) Register MASK  (Use DAC_CTRLB_Msk instead)  */
+#define DAC_CTRLB_Msk                       _U_(0xEF)                                      /**< (DAC_CTRLB) Register Mask  */
+
+
+/* -------- DAC_EVCTRL : (DAC Offset: 0x02) (R/W 8) Event Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  STARTEI:1;                 /**< bit:      0  Start Conversion Event Input             */
+    uint8_t  EMPTYEO:1;                 /**< bit:      1  Data Buffer Empty Event Output           */
+    uint8_t  INVEI:1;                   /**< bit:      2  Invert Event Input                       */
+    uint8_t  :5;                        /**< bit:   3..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} DAC_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_EVCTRL_OFFSET                   (0x02)                                        /**<  (DAC_EVCTRL) Event Control  Offset */
+#define DAC_EVCTRL_RESETVALUE               _U_(0x00)                                     /**<  (DAC_EVCTRL) Event Control  Reset Value */
+
+#define DAC_EVCTRL_STARTEI_Pos              0                                              /**< (DAC_EVCTRL) Start Conversion Event Input Position */
+#define DAC_EVCTRL_STARTEI_Msk              (_U_(0x1) << DAC_EVCTRL_STARTEI_Pos)           /**< (DAC_EVCTRL) Start Conversion Event Input Mask */
+#define DAC_EVCTRL_STARTEI                  DAC_EVCTRL_STARTEI_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use DAC_EVCTRL_STARTEI_Msk instead */
+#define DAC_EVCTRL_EMPTYEO_Pos              1                                              /**< (DAC_EVCTRL) Data Buffer Empty Event Output Position */
+#define DAC_EVCTRL_EMPTYEO_Msk              (_U_(0x1) << DAC_EVCTRL_EMPTYEO_Pos)           /**< (DAC_EVCTRL) Data Buffer Empty Event Output Mask */
+#define DAC_EVCTRL_EMPTYEO                  DAC_EVCTRL_EMPTYEO_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use DAC_EVCTRL_EMPTYEO_Msk instead */
+#define DAC_EVCTRL_INVEI_Pos                2                                              /**< (DAC_EVCTRL) Invert Event Input Position */
+#define DAC_EVCTRL_INVEI_Msk                (_U_(0x1) << DAC_EVCTRL_INVEI_Pos)             /**< (DAC_EVCTRL) Invert Event Input Mask */
+#define DAC_EVCTRL_INVEI                    DAC_EVCTRL_INVEI_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use DAC_EVCTRL_INVEI_Msk instead */
+#define DAC_EVCTRL_MASK                     _U_(0x07)                                      /**< \deprecated (DAC_EVCTRL) Register MASK  (Use DAC_EVCTRL_Msk instead)  */
+#define DAC_EVCTRL_Msk                      _U_(0x07)                                      /**< (DAC_EVCTRL) Register Mask  */
+
+
+/* -------- DAC_INTENCLR : (DAC Offset: 0x04) (R/W 8) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  UNDERRUN:1;                /**< bit:      0  Underrun Interrupt Enable                */
+    uint8_t  EMPTY:1;                   /**< bit:      1  Data Buffer Empty Interrupt Enable       */
+    uint8_t  :6;                        /**< bit:   2..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} DAC_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_INTENCLR_OFFSET                 (0x04)                                        /**<  (DAC_INTENCLR) Interrupt Enable Clear  Offset */
+#define DAC_INTENCLR_RESETVALUE             _U_(0x00)                                     /**<  (DAC_INTENCLR) Interrupt Enable Clear  Reset Value */
+
+#define DAC_INTENCLR_UNDERRUN_Pos           0                                              /**< (DAC_INTENCLR) Underrun Interrupt Enable Position */
+#define DAC_INTENCLR_UNDERRUN_Msk           (_U_(0x1) << DAC_INTENCLR_UNDERRUN_Pos)        /**< (DAC_INTENCLR) Underrun Interrupt Enable Mask */
+#define DAC_INTENCLR_UNDERRUN               DAC_INTENCLR_UNDERRUN_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use DAC_INTENCLR_UNDERRUN_Msk instead */
+#define DAC_INTENCLR_EMPTY_Pos              1                                              /**< (DAC_INTENCLR) Data Buffer Empty Interrupt Enable Position */
+#define DAC_INTENCLR_EMPTY_Msk              (_U_(0x1) << DAC_INTENCLR_EMPTY_Pos)           /**< (DAC_INTENCLR) Data Buffer Empty Interrupt Enable Mask */
+#define DAC_INTENCLR_EMPTY                  DAC_INTENCLR_EMPTY_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use DAC_INTENCLR_EMPTY_Msk instead */
+#define DAC_INTENCLR_MASK                   _U_(0x03)                                      /**< \deprecated (DAC_INTENCLR) Register MASK  (Use DAC_INTENCLR_Msk instead)  */
+#define DAC_INTENCLR_Msk                    _U_(0x03)                                      /**< (DAC_INTENCLR) Register Mask  */
+
+
+/* -------- DAC_INTENSET : (DAC Offset: 0x05) (R/W 8) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  UNDERRUN:1;                /**< bit:      0  Underrun Interrupt Enable                */
+    uint8_t  EMPTY:1;                   /**< bit:      1  Data Buffer Empty Interrupt Enable       */
+    uint8_t  :6;                        /**< bit:   2..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} DAC_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_INTENSET_OFFSET                 (0x05)                                        /**<  (DAC_INTENSET) Interrupt Enable Set  Offset */
+#define DAC_INTENSET_RESETVALUE             _U_(0x00)                                     /**<  (DAC_INTENSET) Interrupt Enable Set  Reset Value */
+
+#define DAC_INTENSET_UNDERRUN_Pos           0                                              /**< (DAC_INTENSET) Underrun Interrupt Enable Position */
+#define DAC_INTENSET_UNDERRUN_Msk           (_U_(0x1) << DAC_INTENSET_UNDERRUN_Pos)        /**< (DAC_INTENSET) Underrun Interrupt Enable Mask */
+#define DAC_INTENSET_UNDERRUN               DAC_INTENSET_UNDERRUN_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use DAC_INTENSET_UNDERRUN_Msk instead */
+#define DAC_INTENSET_EMPTY_Pos              1                                              /**< (DAC_INTENSET) Data Buffer Empty Interrupt Enable Position */
+#define DAC_INTENSET_EMPTY_Msk              (_U_(0x1) << DAC_INTENSET_EMPTY_Pos)           /**< (DAC_INTENSET) Data Buffer Empty Interrupt Enable Mask */
+#define DAC_INTENSET_EMPTY                  DAC_INTENSET_EMPTY_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use DAC_INTENSET_EMPTY_Msk instead */
+#define DAC_INTENSET_MASK                   _U_(0x03)                                      /**< \deprecated (DAC_INTENSET) Register MASK  (Use DAC_INTENSET_Msk instead)  */
+#define DAC_INTENSET_Msk                    _U_(0x03)                                      /**< (DAC_INTENSET) Register Mask  */
+
+
+/* -------- DAC_INTFLAG : (DAC Offset: 0x06) (R/W 8) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t UNDERRUN:1;                /**< bit:      0  Underrun                                 */
+    __I uint8_t EMPTY:1;                   /**< bit:      1  Data Buffer Empty                        */
+    __I uint8_t :6;                        /**< bit:   2..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} DAC_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_INTFLAG_OFFSET                  (0x06)                                        /**<  (DAC_INTFLAG) Interrupt Flag Status and Clear  Offset */
+#define DAC_INTFLAG_RESETVALUE              _U_(0x00)                                     /**<  (DAC_INTFLAG) Interrupt Flag Status and Clear  Reset Value */
+
+#define DAC_INTFLAG_UNDERRUN_Pos            0                                              /**< (DAC_INTFLAG) Underrun Position */
+#define DAC_INTFLAG_UNDERRUN_Msk            (_U_(0x1) << DAC_INTFLAG_UNDERRUN_Pos)         /**< (DAC_INTFLAG) Underrun Mask */
+#define DAC_INTFLAG_UNDERRUN                DAC_INTFLAG_UNDERRUN_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use DAC_INTFLAG_UNDERRUN_Msk instead */
+#define DAC_INTFLAG_EMPTY_Pos               1                                              /**< (DAC_INTFLAG) Data Buffer Empty Position */
+#define DAC_INTFLAG_EMPTY_Msk               (_U_(0x1) << DAC_INTFLAG_EMPTY_Pos)            /**< (DAC_INTFLAG) Data Buffer Empty Mask */
+#define DAC_INTFLAG_EMPTY                   DAC_INTFLAG_EMPTY_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use DAC_INTFLAG_EMPTY_Msk instead */
+#define DAC_INTFLAG_MASK                    _U_(0x03)                                      /**< \deprecated (DAC_INTFLAG) Register MASK  (Use DAC_INTFLAG_Msk instead)  */
+#define DAC_INTFLAG_Msk                     _U_(0x03)                                      /**< (DAC_INTFLAG) Register Mask  */
+
+
+/* -------- DAC_STATUS : (DAC Offset: 0x07) (R/ 8) Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  READY:1;                   /**< bit:      0  Ready                                    */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} DAC_STATUS_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_STATUS_OFFSET                   (0x07)                                        /**<  (DAC_STATUS) Status  Offset */
+#define DAC_STATUS_RESETVALUE               _U_(0x00)                                     /**<  (DAC_STATUS) Status  Reset Value */
+
+#define DAC_STATUS_READY_Pos                0                                              /**< (DAC_STATUS) Ready Position */
+#define DAC_STATUS_READY_Msk                (_U_(0x1) << DAC_STATUS_READY_Pos)             /**< (DAC_STATUS) Ready Mask */
+#define DAC_STATUS_READY                    DAC_STATUS_READY_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use DAC_STATUS_READY_Msk instead */
+#define DAC_STATUS_MASK                     _U_(0x01)                                      /**< \deprecated (DAC_STATUS) Register MASK  (Use DAC_STATUS_Msk instead)  */
+#define DAC_STATUS_Msk                      _U_(0x01)                                      /**< (DAC_STATUS) Register Mask  */
+
+
+/* -------- DAC_DATA : (DAC Offset: 0x08) (/W 16) Data -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t DATA:16;                   /**< bit:  0..15  Data value to be converted               */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} DAC_DATA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_DATA_OFFSET                     (0x08)                                        /**<  (DAC_DATA) Data  Offset */
+#define DAC_DATA_RESETVALUE                 _U_(0x00)                                     /**<  (DAC_DATA) Data  Reset Value */
+
+#define DAC_DATA_DATA_Pos                   0                                              /**< (DAC_DATA) Data value to be converted Position */
+#define DAC_DATA_DATA_Msk                   (_U_(0xFFFF) << DAC_DATA_DATA_Pos)             /**< (DAC_DATA) Data value to be converted Mask */
+#define DAC_DATA_DATA(value)                (DAC_DATA_DATA_Msk & ((value) << DAC_DATA_DATA_Pos))
+#define DAC_DATA_MASK                       _U_(0xFFFF)                                    /**< \deprecated (DAC_DATA) Register MASK  (Use DAC_DATA_Msk instead)  */
+#define DAC_DATA_Msk                        _U_(0xFFFF)                                    /**< (DAC_DATA) Register Mask  */
+
+
+/* -------- DAC_DATABUF : (DAC Offset: 0x0c) (/W 16) Data Buffer -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t DATABUF:16;                /**< bit:  0..15  Data Buffer                              */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} DAC_DATABUF_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_DATABUF_OFFSET                  (0x0C)                                        /**<  (DAC_DATABUF) Data Buffer  Offset */
+#define DAC_DATABUF_RESETVALUE              _U_(0x00)                                     /**<  (DAC_DATABUF) Data Buffer  Reset Value */
+
+#define DAC_DATABUF_DATABUF_Pos             0                                              /**< (DAC_DATABUF) Data Buffer Position */
+#define DAC_DATABUF_DATABUF_Msk             (_U_(0xFFFF) << DAC_DATABUF_DATABUF_Pos)       /**< (DAC_DATABUF) Data Buffer Mask */
+#define DAC_DATABUF_DATABUF(value)          (DAC_DATABUF_DATABUF_Msk & ((value) << DAC_DATABUF_DATABUF_Pos))
+#define DAC_DATABUF_MASK                    _U_(0xFFFF)                                    /**< \deprecated (DAC_DATABUF) Register MASK  (Use DAC_DATABUF_Msk instead)  */
+#define DAC_DATABUF_Msk                     _U_(0xFFFF)                                    /**< (DAC_DATABUF) Register Mask  */
+
+
+/* -------- DAC_SYNCBUSY : (DAC Offset: 0x10) (R/ 32) Synchronization Busy -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint32_t ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint32_t DATA:1;                    /**< bit:      2  Data                                     */
+    uint32_t DATABUF:1;                 /**< bit:      3  Data Buffer                              */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DAC_SYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_SYNCBUSY_OFFSET                 (0x10)                                        /**<  (DAC_SYNCBUSY) Synchronization Busy  Offset */
+#define DAC_SYNCBUSY_RESETVALUE             _U_(0x00)                                     /**<  (DAC_SYNCBUSY) Synchronization Busy  Reset Value */
+
+#define DAC_SYNCBUSY_SWRST_Pos              0                                              /**< (DAC_SYNCBUSY) Software Reset Position */
+#define DAC_SYNCBUSY_SWRST_Msk              (_U_(0x1) << DAC_SYNCBUSY_SWRST_Pos)           /**< (DAC_SYNCBUSY) Software Reset Mask */
+#define DAC_SYNCBUSY_SWRST                  DAC_SYNCBUSY_SWRST_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use DAC_SYNCBUSY_SWRST_Msk instead */
+#define DAC_SYNCBUSY_ENABLE_Pos             1                                              /**< (DAC_SYNCBUSY) Enable Position */
+#define DAC_SYNCBUSY_ENABLE_Msk             (_U_(0x1) << DAC_SYNCBUSY_ENABLE_Pos)          /**< (DAC_SYNCBUSY) Enable Mask */
+#define DAC_SYNCBUSY_ENABLE                 DAC_SYNCBUSY_ENABLE_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DAC_SYNCBUSY_ENABLE_Msk instead */
+#define DAC_SYNCBUSY_DATA_Pos               2                                              /**< (DAC_SYNCBUSY) Data Position */
+#define DAC_SYNCBUSY_DATA_Msk               (_U_(0x1) << DAC_SYNCBUSY_DATA_Pos)            /**< (DAC_SYNCBUSY) Data Mask */
+#define DAC_SYNCBUSY_DATA                   DAC_SYNCBUSY_DATA_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use DAC_SYNCBUSY_DATA_Msk instead */
+#define DAC_SYNCBUSY_DATABUF_Pos            3                                              /**< (DAC_SYNCBUSY) Data Buffer Position */
+#define DAC_SYNCBUSY_DATABUF_Msk            (_U_(0x1) << DAC_SYNCBUSY_DATABUF_Pos)         /**< (DAC_SYNCBUSY) Data Buffer Mask */
+#define DAC_SYNCBUSY_DATABUF                DAC_SYNCBUSY_DATABUF_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use DAC_SYNCBUSY_DATABUF_Msk instead */
+#define DAC_SYNCBUSY_MASK                   _U_(0x0F)                                      /**< \deprecated (DAC_SYNCBUSY) Register MASK  (Use DAC_SYNCBUSY_Msk instead)  */
+#define DAC_SYNCBUSY_Msk                    _U_(0x0F)                                      /**< (DAC_SYNCBUSY) Register Mask  */
+
+
+/* -------- DAC_DBGCTRL : (DAC Offset: 0x14) (R/W 8) Debug Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DBGRUN:1;                  /**< bit:      0  Debug Run                                */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} DAC_DBGCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_DBGCTRL_OFFSET                  (0x14)                                        /**<  (DAC_DBGCTRL) Debug Control  Offset */
+#define DAC_DBGCTRL_RESETVALUE              _U_(0x00)                                     /**<  (DAC_DBGCTRL) Debug Control  Reset Value */
+
+#define DAC_DBGCTRL_DBGRUN_Pos              0                                              /**< (DAC_DBGCTRL) Debug Run Position */
+#define DAC_DBGCTRL_DBGRUN_Msk              (_U_(0x1) << DAC_DBGCTRL_DBGRUN_Pos)           /**< (DAC_DBGCTRL) Debug Run Mask */
+#define DAC_DBGCTRL_DBGRUN                  DAC_DBGCTRL_DBGRUN_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use DAC_DBGCTRL_DBGRUN_Msk instead */
+#define DAC_DBGCTRL_MASK                    _U_(0x01)                                      /**< \deprecated (DAC_DBGCTRL) Register MASK  (Use DAC_DBGCTRL_Msk instead)  */
+#define DAC_DBGCTRL_Msk                     _U_(0x01)                                      /**< (DAC_DBGCTRL) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief DAC hardware registers */
+typedef struct {  /* Digital Analog Converter */
+  __IO DAC_CTRLA_Type                 CTRLA;          /**< Offset: 0x00 (R/W   8) Control A */
+  __IO DAC_CTRLB_Type                 CTRLB;          /**< Offset: 0x01 (R/W   8) Control B */
+  __IO DAC_EVCTRL_Type                EVCTRL;         /**< Offset: 0x02 (R/W   8) Event Control */
+  __I  uint8_t                        Reserved1[1];
+  __IO DAC_INTENCLR_Type              INTENCLR;       /**< Offset: 0x04 (R/W   8) Interrupt Enable Clear */
+  __IO DAC_INTENSET_Type              INTENSET;       /**< Offset: 0x05 (R/W   8) Interrupt Enable Set */
+  __IO DAC_INTFLAG_Type               INTFLAG;        /**< Offset: 0x06 (R/W   8) Interrupt Flag Status and Clear */
+  __I  DAC_STATUS_Type                STATUS;         /**< Offset: 0x07 (R/    8) Status */
+  __O  DAC_DATA_Type                  DATA;           /**< Offset: 0x08 ( /W  16) Data */
+  __I  uint8_t                        Reserved2[2];
+  __O  DAC_DATABUF_Type               DATABUF;        /**< Offset: 0x0C ( /W  16) Data Buffer */
+  __I  uint8_t                        Reserved3[2];
+  __I  DAC_SYNCBUSY_Type              SYNCBUSY;       /**< Offset: 0x10 (R/   32) Synchronization Busy */
+  __IO DAC_DBGCTRL_Type               DBGCTRL;        /**< Offset: 0x14 (R/W   8) Debug Control */
+} Dac;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Digital Analog Converter */
+
+#endif /* _SAML11_DAC_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/component/dmac.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/dmac.h
@@ -1,0 +1,1158 @@
+/**
+ * \file
+ *
+ * \brief Component description for DMAC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_DMAC_COMPONENT_H_
+#define _SAML11_DMAC_COMPONENT_H_
+#define _SAML11_DMAC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML11 Direct Memory Access Controller
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR DMAC */
+/* ========================================================================== */
+
+#define DMAC_U2223                      /**< (DMAC) Module ID */
+#define REV_DMAC 0x240                  /**< (DMAC) Module revision */
+
+/* -------- DMAC_BTCTRL : (DMAC Offset: 0x00) (R/W 16) Block Transfer Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t VALID:1;                   /**< bit:      0  Descriptor Valid                         */
+    uint16_t EVOSEL:2;                  /**< bit:   1..2  Event Output Selection                   */
+    uint16_t BLOCKACT:2;                /**< bit:   3..4  Block Action                             */
+    uint16_t :3;                        /**< bit:   5..7  Reserved */
+    uint16_t BEATSIZE:2;                /**< bit:   8..9  Beat Size                                */
+    uint16_t SRCINC:1;                  /**< bit:     10  Source Address Increment Enable          */
+    uint16_t DSTINC:1;                  /**< bit:     11  Destination Address Increment Enable     */
+    uint16_t STEPSEL:1;                 /**< bit:     12  Step Selection                           */
+    uint16_t STEPSIZE:3;                /**< bit: 13..15  Address Increment Step Size              */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} DMAC_BTCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_BTCTRL_OFFSET                  (0x00)                                        /**<  (DMAC_BTCTRL) Block Transfer Control  Offset */
+#define DMAC_BTCTRL_RESETVALUE              _U_(0x00)                                     /**<  (DMAC_BTCTRL) Block Transfer Control  Reset Value */
+
+#define DMAC_BTCTRL_VALID_Pos               0                                              /**< (DMAC_BTCTRL) Descriptor Valid Position */
+#define DMAC_BTCTRL_VALID_Msk               (_U_(0x1) << DMAC_BTCTRL_VALID_Pos)            /**< (DMAC_BTCTRL) Descriptor Valid Mask */
+#define DMAC_BTCTRL_VALID                   DMAC_BTCTRL_VALID_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_BTCTRL_VALID_Msk instead */
+#define DMAC_BTCTRL_EVOSEL_Pos              1                                              /**< (DMAC_BTCTRL) Event Output Selection Position */
+#define DMAC_BTCTRL_EVOSEL_Msk              (_U_(0x3) << DMAC_BTCTRL_EVOSEL_Pos)           /**< (DMAC_BTCTRL) Event Output Selection Mask */
+#define DMAC_BTCTRL_EVOSEL(value)           (DMAC_BTCTRL_EVOSEL_Msk & ((value) << DMAC_BTCTRL_EVOSEL_Pos))
+#define   DMAC_BTCTRL_EVOSEL_DISABLE_Val    _U_(0x0)                                       /**< (DMAC_BTCTRL) Event generation disabled  */
+#define   DMAC_BTCTRL_EVOSEL_BLOCK_Val      _U_(0x1)                                       /**< (DMAC_BTCTRL) Event strobe when block transfer complete  */
+#define   DMAC_BTCTRL_EVOSEL_BEAT_Val       _U_(0x3)                                       /**< (DMAC_BTCTRL) Event strobe when beat transfer complete  */
+#define DMAC_BTCTRL_EVOSEL_DISABLE          (DMAC_BTCTRL_EVOSEL_DISABLE_Val << DMAC_BTCTRL_EVOSEL_Pos)  /**< (DMAC_BTCTRL) Event generation disabled Position  */
+#define DMAC_BTCTRL_EVOSEL_BLOCK            (DMAC_BTCTRL_EVOSEL_BLOCK_Val << DMAC_BTCTRL_EVOSEL_Pos)  /**< (DMAC_BTCTRL) Event strobe when block transfer complete Position  */
+#define DMAC_BTCTRL_EVOSEL_BEAT             (DMAC_BTCTRL_EVOSEL_BEAT_Val << DMAC_BTCTRL_EVOSEL_Pos)  /**< (DMAC_BTCTRL) Event strobe when beat transfer complete Position  */
+#define DMAC_BTCTRL_BLOCKACT_Pos            3                                              /**< (DMAC_BTCTRL) Block Action Position */
+#define DMAC_BTCTRL_BLOCKACT_Msk            (_U_(0x3) << DMAC_BTCTRL_BLOCKACT_Pos)         /**< (DMAC_BTCTRL) Block Action Mask */
+#define DMAC_BTCTRL_BLOCKACT(value)         (DMAC_BTCTRL_BLOCKACT_Msk & ((value) << DMAC_BTCTRL_BLOCKACT_Pos))
+#define   DMAC_BTCTRL_BLOCKACT_NOACT_Val    _U_(0x0)                                       /**< (DMAC_BTCTRL) Channel will be disabled if it is the last block transfer in the transaction  */
+#define   DMAC_BTCTRL_BLOCKACT_INT_Val      _U_(0x1)                                       /**< (DMAC_BTCTRL) Channel will be disabled if it is the last block transfer in the transaction and block interrupt  */
+#define   DMAC_BTCTRL_BLOCKACT_SUSPEND_Val  _U_(0x2)                                       /**< (DMAC_BTCTRL) Channel suspend operation is completed  */
+#define   DMAC_BTCTRL_BLOCKACT_BOTH_Val     _U_(0x3)                                       /**< (DMAC_BTCTRL) Both channel suspend operation and block interrupt  */
+#define DMAC_BTCTRL_BLOCKACT_NOACT          (DMAC_BTCTRL_BLOCKACT_NOACT_Val << DMAC_BTCTRL_BLOCKACT_Pos)  /**< (DMAC_BTCTRL) Channel will be disabled if it is the last block transfer in the transaction Position  */
+#define DMAC_BTCTRL_BLOCKACT_INT            (DMAC_BTCTRL_BLOCKACT_INT_Val << DMAC_BTCTRL_BLOCKACT_Pos)  /**< (DMAC_BTCTRL) Channel will be disabled if it is the last block transfer in the transaction and block interrupt Position  */
+#define DMAC_BTCTRL_BLOCKACT_SUSPEND        (DMAC_BTCTRL_BLOCKACT_SUSPEND_Val << DMAC_BTCTRL_BLOCKACT_Pos)  /**< (DMAC_BTCTRL) Channel suspend operation is completed Position  */
+#define DMAC_BTCTRL_BLOCKACT_BOTH           (DMAC_BTCTRL_BLOCKACT_BOTH_Val << DMAC_BTCTRL_BLOCKACT_Pos)  /**< (DMAC_BTCTRL) Both channel suspend operation and block interrupt Position  */
+#define DMAC_BTCTRL_BEATSIZE_Pos            8                                              /**< (DMAC_BTCTRL) Beat Size Position */
+#define DMAC_BTCTRL_BEATSIZE_Msk            (_U_(0x3) << DMAC_BTCTRL_BEATSIZE_Pos)         /**< (DMAC_BTCTRL) Beat Size Mask */
+#define DMAC_BTCTRL_BEATSIZE(value)         (DMAC_BTCTRL_BEATSIZE_Msk & ((value) << DMAC_BTCTRL_BEATSIZE_Pos))
+#define   DMAC_BTCTRL_BEATSIZE_BYTE_Val     _U_(0x0)                                       /**< (DMAC_BTCTRL) 8-bit bus transfer  */
+#define   DMAC_BTCTRL_BEATSIZE_HWORD_Val    _U_(0x1)                                       /**< (DMAC_BTCTRL) 16-bit bus transfer  */
+#define   DMAC_BTCTRL_BEATSIZE_WORD_Val     _U_(0x2)                                       /**< (DMAC_BTCTRL) 32-bit bus transfer  */
+#define DMAC_BTCTRL_BEATSIZE_BYTE           (DMAC_BTCTRL_BEATSIZE_BYTE_Val << DMAC_BTCTRL_BEATSIZE_Pos)  /**< (DMAC_BTCTRL) 8-bit bus transfer Position  */
+#define DMAC_BTCTRL_BEATSIZE_HWORD          (DMAC_BTCTRL_BEATSIZE_HWORD_Val << DMAC_BTCTRL_BEATSIZE_Pos)  /**< (DMAC_BTCTRL) 16-bit bus transfer Position  */
+#define DMAC_BTCTRL_BEATSIZE_WORD           (DMAC_BTCTRL_BEATSIZE_WORD_Val << DMAC_BTCTRL_BEATSIZE_Pos)  /**< (DMAC_BTCTRL) 32-bit bus transfer Position  */
+#define DMAC_BTCTRL_SRCINC_Pos              10                                             /**< (DMAC_BTCTRL) Source Address Increment Enable Position */
+#define DMAC_BTCTRL_SRCINC_Msk              (_U_(0x1) << DMAC_BTCTRL_SRCINC_Pos)           /**< (DMAC_BTCTRL) Source Address Increment Enable Mask */
+#define DMAC_BTCTRL_SRCINC                  DMAC_BTCTRL_SRCINC_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_BTCTRL_SRCINC_Msk instead */
+#define DMAC_BTCTRL_DSTINC_Pos              11                                             /**< (DMAC_BTCTRL) Destination Address Increment Enable Position */
+#define DMAC_BTCTRL_DSTINC_Msk              (_U_(0x1) << DMAC_BTCTRL_DSTINC_Pos)           /**< (DMAC_BTCTRL) Destination Address Increment Enable Mask */
+#define DMAC_BTCTRL_DSTINC                  DMAC_BTCTRL_DSTINC_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_BTCTRL_DSTINC_Msk instead */
+#define DMAC_BTCTRL_STEPSEL_Pos             12                                             /**< (DMAC_BTCTRL) Step Selection Position */
+#define DMAC_BTCTRL_STEPSEL_Msk             (_U_(0x1) << DMAC_BTCTRL_STEPSEL_Pos)          /**< (DMAC_BTCTRL) Step Selection Mask */
+#define DMAC_BTCTRL_STEPSEL                 DMAC_BTCTRL_STEPSEL_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_BTCTRL_STEPSEL_Msk instead */
+#define   DMAC_BTCTRL_STEPSEL_DST_Val       _U_(0x0)                                       /**< (DMAC_BTCTRL) Step size settings apply to the destination address  */
+#define   DMAC_BTCTRL_STEPSEL_SRC_Val       _U_(0x1)                                       /**< (DMAC_BTCTRL) Step size settings apply to the source address  */
+#define DMAC_BTCTRL_STEPSEL_DST             (DMAC_BTCTRL_STEPSEL_DST_Val << DMAC_BTCTRL_STEPSEL_Pos)  /**< (DMAC_BTCTRL) Step size settings apply to the destination address Position  */
+#define DMAC_BTCTRL_STEPSEL_SRC             (DMAC_BTCTRL_STEPSEL_SRC_Val << DMAC_BTCTRL_STEPSEL_Pos)  /**< (DMAC_BTCTRL) Step size settings apply to the source address Position  */
+#define DMAC_BTCTRL_STEPSIZE_Pos            13                                             /**< (DMAC_BTCTRL) Address Increment Step Size Position */
+#define DMAC_BTCTRL_STEPSIZE_Msk            (_U_(0x7) << DMAC_BTCTRL_STEPSIZE_Pos)         /**< (DMAC_BTCTRL) Address Increment Step Size Mask */
+#define DMAC_BTCTRL_STEPSIZE(value)         (DMAC_BTCTRL_STEPSIZE_Msk & ((value) << DMAC_BTCTRL_STEPSIZE_Pos))
+#define   DMAC_BTCTRL_STEPSIZE_X1_Val       _U_(0x0)                                       /**< (DMAC_BTCTRL) Next ADDR = ADDR + (BEATSIZE+1) * 1  */
+#define   DMAC_BTCTRL_STEPSIZE_X2_Val       _U_(0x1)                                       /**< (DMAC_BTCTRL) Next ADDR = ADDR + (BEATSIZE+1) * 2  */
+#define   DMAC_BTCTRL_STEPSIZE_X4_Val       _U_(0x2)                                       /**< (DMAC_BTCTRL) Next ADDR = ADDR + (BEATSIZE+1) * 4  */
+#define   DMAC_BTCTRL_STEPSIZE_X8_Val       _U_(0x3)                                       /**< (DMAC_BTCTRL) Next ADDR = ADDR + (BEATSIZE+1) * 8  */
+#define   DMAC_BTCTRL_STEPSIZE_X16_Val      _U_(0x4)                                       /**< (DMAC_BTCTRL) Next ADDR = ADDR + (BEATSIZE+1) * 16  */
+#define   DMAC_BTCTRL_STEPSIZE_X32_Val      _U_(0x5)                                       /**< (DMAC_BTCTRL) Next ADDR = ADDR + (BEATSIZE+1) * 32  */
+#define   DMAC_BTCTRL_STEPSIZE_X64_Val      _U_(0x6)                                       /**< (DMAC_BTCTRL) Next ADDR = ADDR + (BEATSIZE+1) * 64  */
+#define   DMAC_BTCTRL_STEPSIZE_X128_Val     _U_(0x7)                                       /**< (DMAC_BTCTRL) Next ADDR = ADDR + (BEATSIZE+1) * 128  */
+#define DMAC_BTCTRL_STEPSIZE_X1             (DMAC_BTCTRL_STEPSIZE_X1_Val << DMAC_BTCTRL_STEPSIZE_Pos)  /**< (DMAC_BTCTRL) Next ADDR = ADDR + (BEATSIZE+1) * 1 Position  */
+#define DMAC_BTCTRL_STEPSIZE_X2             (DMAC_BTCTRL_STEPSIZE_X2_Val << DMAC_BTCTRL_STEPSIZE_Pos)  /**< (DMAC_BTCTRL) Next ADDR = ADDR + (BEATSIZE+1) * 2 Position  */
+#define DMAC_BTCTRL_STEPSIZE_X4             (DMAC_BTCTRL_STEPSIZE_X4_Val << DMAC_BTCTRL_STEPSIZE_Pos)  /**< (DMAC_BTCTRL) Next ADDR = ADDR + (BEATSIZE+1) * 4 Position  */
+#define DMAC_BTCTRL_STEPSIZE_X8             (DMAC_BTCTRL_STEPSIZE_X8_Val << DMAC_BTCTRL_STEPSIZE_Pos)  /**< (DMAC_BTCTRL) Next ADDR = ADDR + (BEATSIZE+1) * 8 Position  */
+#define DMAC_BTCTRL_STEPSIZE_X16            (DMAC_BTCTRL_STEPSIZE_X16_Val << DMAC_BTCTRL_STEPSIZE_Pos)  /**< (DMAC_BTCTRL) Next ADDR = ADDR + (BEATSIZE+1) * 16 Position  */
+#define DMAC_BTCTRL_STEPSIZE_X32            (DMAC_BTCTRL_STEPSIZE_X32_Val << DMAC_BTCTRL_STEPSIZE_Pos)  /**< (DMAC_BTCTRL) Next ADDR = ADDR + (BEATSIZE+1) * 32 Position  */
+#define DMAC_BTCTRL_STEPSIZE_X64            (DMAC_BTCTRL_STEPSIZE_X64_Val << DMAC_BTCTRL_STEPSIZE_Pos)  /**< (DMAC_BTCTRL) Next ADDR = ADDR + (BEATSIZE+1) * 64 Position  */
+#define DMAC_BTCTRL_STEPSIZE_X128           (DMAC_BTCTRL_STEPSIZE_X128_Val << DMAC_BTCTRL_STEPSIZE_Pos)  /**< (DMAC_BTCTRL) Next ADDR = ADDR + (BEATSIZE+1) * 128 Position  */
+#define DMAC_BTCTRL_MASK                    _U_(0xFF1F)                                    /**< \deprecated (DMAC_BTCTRL) Register MASK  (Use DMAC_BTCTRL_Msk instead)  */
+#define DMAC_BTCTRL_Msk                     _U_(0xFF1F)                                    /**< (DMAC_BTCTRL) Register Mask  */
+
+
+/* -------- DMAC_BTCNT : (DMAC Offset: 0x02) (R/W 16) Block Transfer Count -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t BTCNT:16;                  /**< bit:  0..15  Block Transfer Count                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} DMAC_BTCNT_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_BTCNT_OFFSET                   (0x02)                                        /**<  (DMAC_BTCNT) Block Transfer Count  Offset */
+
+#define DMAC_BTCNT_BTCNT_Pos                0                                              /**< (DMAC_BTCNT) Block Transfer Count Position */
+#define DMAC_BTCNT_BTCNT_Msk                (_U_(0xFFFF) << DMAC_BTCNT_BTCNT_Pos)          /**< (DMAC_BTCNT) Block Transfer Count Mask */
+#define DMAC_BTCNT_BTCNT(value)             (DMAC_BTCNT_BTCNT_Msk & ((value) << DMAC_BTCNT_BTCNT_Pos))
+#define DMAC_BTCNT_MASK                     _U_(0xFFFF)                                    /**< \deprecated (DMAC_BTCNT) Register MASK  (Use DMAC_BTCNT_Msk instead)  */
+#define DMAC_BTCNT_Msk                      _U_(0xFFFF)                                    /**< (DMAC_BTCNT) Register Mask  */
+
+
+/* -------- DMAC_SRCADDR : (DMAC Offset: 0x04) (R/W 32) Block Transfer Source Address -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SRCADDR:32;                /**< bit:  0..31  Transfer Source Address                  */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DMAC_SRCADDR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_SRCADDR_OFFSET                 (0x04)                                        /**<  (DMAC_SRCADDR) Block Transfer Source Address  Offset */
+
+#define DMAC_SRCADDR_SRCADDR_Pos            0                                              /**< (DMAC_SRCADDR) Transfer Source Address Position */
+#define DMAC_SRCADDR_SRCADDR_Msk            (_U_(0xFFFFFFFF) << DMAC_SRCADDR_SRCADDR_Pos)  /**< (DMAC_SRCADDR) Transfer Source Address Mask */
+#define DMAC_SRCADDR_SRCADDR(value)         (DMAC_SRCADDR_SRCADDR_Msk & ((value) << DMAC_SRCADDR_SRCADDR_Pos))
+#define DMAC_SRCADDR_MASK                   _U_(0xFFFFFFFF)                                /**< \deprecated (DMAC_SRCADDR) Register MASK  (Use DMAC_SRCADDR_Msk instead)  */
+#define DMAC_SRCADDR_Msk                    _U_(0xFFFFFFFF)                                /**< (DMAC_SRCADDR) Register Mask  */
+
+
+/* -------- DMAC_DSTADDR : (DMAC Offset: 0x08) (R/W 32) Block Transfer Destination Address -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t DSTADDR:32;                /**< bit:  0..31  Transfer Destination Address             */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DMAC_DSTADDR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_DSTADDR_OFFSET                 (0x08)                                        /**<  (DMAC_DSTADDR) Block Transfer Destination Address  Offset */
+
+#define DMAC_DSTADDR_DSTADDR_Pos            0                                              /**< (DMAC_DSTADDR) Transfer Destination Address Position */
+#define DMAC_DSTADDR_DSTADDR_Msk            (_U_(0xFFFFFFFF) << DMAC_DSTADDR_DSTADDR_Pos)  /**< (DMAC_DSTADDR) Transfer Destination Address Mask */
+#define DMAC_DSTADDR_DSTADDR(value)         (DMAC_DSTADDR_DSTADDR_Msk & ((value) << DMAC_DSTADDR_DSTADDR_Pos))
+#define DMAC_DSTADDR_MASK                   _U_(0xFFFFFFFF)                                /**< \deprecated (DMAC_DSTADDR) Register MASK  (Use DMAC_DSTADDR_Msk instead)  */
+#define DMAC_DSTADDR_Msk                    _U_(0xFFFFFFFF)                                /**< (DMAC_DSTADDR) Register Mask  */
+
+
+/* -------- DMAC_DESCADDR : (DMAC Offset: 0x0c) (R/W 32) Next Descriptor Address -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t DESCADDR:32;               /**< bit:  0..31  Next Descriptor Address                  */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DMAC_DESCADDR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_DESCADDR_OFFSET                (0x0C)                                        /**<  (DMAC_DESCADDR) Next Descriptor Address  Offset */
+
+#define DMAC_DESCADDR_DESCADDR_Pos          0                                              /**< (DMAC_DESCADDR) Next Descriptor Address Position */
+#define DMAC_DESCADDR_DESCADDR_Msk          (_U_(0xFFFFFFFF) << DMAC_DESCADDR_DESCADDR_Pos)  /**< (DMAC_DESCADDR) Next Descriptor Address Mask */
+#define DMAC_DESCADDR_DESCADDR(value)       (DMAC_DESCADDR_DESCADDR_Msk & ((value) << DMAC_DESCADDR_DESCADDR_Pos))
+#define DMAC_DESCADDR_MASK                  _U_(0xFFFFFFFF)                                /**< \deprecated (DMAC_DESCADDR) Register MASK  (Use DMAC_DESCADDR_Msk instead)  */
+#define DMAC_DESCADDR_Msk                   _U_(0xFFFFFFFF)                                /**< (DMAC_DESCADDR) Register Mask  */
+
+
+/* -------- DMAC_CTRL : (DMAC Offset: 0x00) (R/W 16) Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint16_t DMAENABLE:1;               /**< bit:      1  DMA Enable                               */
+    uint16_t CRCENABLE:1;               /**< bit:      2  CRC Enable                               */
+    uint16_t :5;                        /**< bit:   3..7  Reserved */
+    uint16_t LVLEN0:1;                  /**< bit:      8  Priority Level 0 Enable                  */
+    uint16_t LVLEN1:1;                  /**< bit:      9  Priority Level 1 Enable                  */
+    uint16_t LVLEN2:1;                  /**< bit:     10  Priority Level 2 Enable                  */
+    uint16_t LVLEN3:1;                  /**< bit:     11  Priority Level 3 Enable                  */
+    uint16_t :4;                        /**< bit: 12..15  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint16_t :8;                        /**< bit:   0..7  Reserved */
+    uint16_t LVLEN:4;                   /**< bit:  8..11  Priority Level 3 Enable                  */
+    uint16_t :4;                        /**< bit: 12..15 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint16_t reg;                         /**< Type used for register access */
+} DMAC_CTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_CTRL_OFFSET                    (0x00)                                        /**<  (DMAC_CTRL) Control  Offset */
+#define DMAC_CTRL_RESETVALUE                _U_(0x00)                                     /**<  (DMAC_CTRL) Control  Reset Value */
+
+#define DMAC_CTRL_SWRST_Pos                 0                                              /**< (DMAC_CTRL) Software Reset Position */
+#define DMAC_CTRL_SWRST_Msk                 (_U_(0x1) << DMAC_CTRL_SWRST_Pos)              /**< (DMAC_CTRL) Software Reset Mask */
+#define DMAC_CTRL_SWRST                     DMAC_CTRL_SWRST_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CTRL_SWRST_Msk instead */
+#define DMAC_CTRL_DMAENABLE_Pos             1                                              /**< (DMAC_CTRL) DMA Enable Position */
+#define DMAC_CTRL_DMAENABLE_Msk             (_U_(0x1) << DMAC_CTRL_DMAENABLE_Pos)          /**< (DMAC_CTRL) DMA Enable Mask */
+#define DMAC_CTRL_DMAENABLE                 DMAC_CTRL_DMAENABLE_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CTRL_DMAENABLE_Msk instead */
+#define DMAC_CTRL_CRCENABLE_Pos             2                                              /**< (DMAC_CTRL) CRC Enable Position */
+#define DMAC_CTRL_CRCENABLE_Msk             (_U_(0x1) << DMAC_CTRL_CRCENABLE_Pos)          /**< (DMAC_CTRL) CRC Enable Mask */
+#define DMAC_CTRL_CRCENABLE                 DMAC_CTRL_CRCENABLE_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CTRL_CRCENABLE_Msk instead */
+#define DMAC_CTRL_LVLEN0_Pos                8                                              /**< (DMAC_CTRL) Priority Level 0 Enable Position */
+#define DMAC_CTRL_LVLEN0_Msk                (_U_(0x1) << DMAC_CTRL_LVLEN0_Pos)             /**< (DMAC_CTRL) Priority Level 0 Enable Mask */
+#define DMAC_CTRL_LVLEN0                    DMAC_CTRL_LVLEN0_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CTRL_LVLEN0_Msk instead */
+#define DMAC_CTRL_LVLEN1_Pos                9                                              /**< (DMAC_CTRL) Priority Level 1 Enable Position */
+#define DMAC_CTRL_LVLEN1_Msk                (_U_(0x1) << DMAC_CTRL_LVLEN1_Pos)             /**< (DMAC_CTRL) Priority Level 1 Enable Mask */
+#define DMAC_CTRL_LVLEN1                    DMAC_CTRL_LVLEN1_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CTRL_LVLEN1_Msk instead */
+#define DMAC_CTRL_LVLEN2_Pos                10                                             /**< (DMAC_CTRL) Priority Level 2 Enable Position */
+#define DMAC_CTRL_LVLEN2_Msk                (_U_(0x1) << DMAC_CTRL_LVLEN2_Pos)             /**< (DMAC_CTRL) Priority Level 2 Enable Mask */
+#define DMAC_CTRL_LVLEN2                    DMAC_CTRL_LVLEN2_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CTRL_LVLEN2_Msk instead */
+#define DMAC_CTRL_LVLEN3_Pos                11                                             /**< (DMAC_CTRL) Priority Level 3 Enable Position */
+#define DMAC_CTRL_LVLEN3_Msk                (_U_(0x1) << DMAC_CTRL_LVLEN3_Pos)             /**< (DMAC_CTRL) Priority Level 3 Enable Mask */
+#define DMAC_CTRL_LVLEN3                    DMAC_CTRL_LVLEN3_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CTRL_LVLEN3_Msk instead */
+#define DMAC_CTRL_MASK                      _U_(0xF07)                                     /**< \deprecated (DMAC_CTRL) Register MASK  (Use DMAC_CTRL_Msk instead)  */
+#define DMAC_CTRL_Msk                       _U_(0xF07)                                     /**< (DMAC_CTRL) Register Mask  */
+
+#define DMAC_CTRL_LVLEN_Pos                 8                                              /**< (DMAC_CTRL Position) Priority Level 3 Enable */
+#define DMAC_CTRL_LVLEN_Msk                 (_U_(0xF) << DMAC_CTRL_LVLEN_Pos)              /**< (DMAC_CTRL Mask) LVLEN */
+#define DMAC_CTRL_LVLEN(value)              (DMAC_CTRL_LVLEN_Msk & ((value) << DMAC_CTRL_LVLEN_Pos))  
+
+/* -------- DMAC_CRCCTRL : (DMAC Offset: 0x02) (R/W 16) CRC Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t CRCBEATSIZE:2;             /**< bit:   0..1  CRC Beat Size                            */
+    uint16_t CRCPOLY:2;                 /**< bit:   2..3  CRC Polynomial Type                      */
+    uint16_t :4;                        /**< bit:   4..7  Reserved */
+    uint16_t CRCSRC:6;                  /**< bit:  8..13  CRC Input Source                         */
+    uint16_t :2;                        /**< bit: 14..15  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} DMAC_CRCCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_CRCCTRL_OFFSET                 (0x02)                                        /**<  (DMAC_CRCCTRL) CRC Control  Offset */
+#define DMAC_CRCCTRL_RESETVALUE             _U_(0x00)                                     /**<  (DMAC_CRCCTRL) CRC Control  Reset Value */
+
+#define DMAC_CRCCTRL_CRCBEATSIZE_Pos        0                                              /**< (DMAC_CRCCTRL) CRC Beat Size Position */
+#define DMAC_CRCCTRL_CRCBEATSIZE_Msk        (_U_(0x3) << DMAC_CRCCTRL_CRCBEATSIZE_Pos)     /**< (DMAC_CRCCTRL) CRC Beat Size Mask */
+#define DMAC_CRCCTRL_CRCBEATSIZE(value)     (DMAC_CRCCTRL_CRCBEATSIZE_Msk & ((value) << DMAC_CRCCTRL_CRCBEATSIZE_Pos))
+#define   DMAC_CRCCTRL_CRCBEATSIZE_BYTE_Val _U_(0x0)                                       /**< (DMAC_CRCCTRL) 8-bit bus transfer  */
+#define   DMAC_CRCCTRL_CRCBEATSIZE_HWORD_Val _U_(0x1)                                       /**< (DMAC_CRCCTRL) 16-bit bus transfer  */
+#define   DMAC_CRCCTRL_CRCBEATSIZE_WORD_Val _U_(0x2)                                       /**< (DMAC_CRCCTRL) 32-bit bus transfer  */
+#define DMAC_CRCCTRL_CRCBEATSIZE_BYTE       (DMAC_CRCCTRL_CRCBEATSIZE_BYTE_Val << DMAC_CRCCTRL_CRCBEATSIZE_Pos)  /**< (DMAC_CRCCTRL) 8-bit bus transfer Position  */
+#define DMAC_CRCCTRL_CRCBEATSIZE_HWORD      (DMAC_CRCCTRL_CRCBEATSIZE_HWORD_Val << DMAC_CRCCTRL_CRCBEATSIZE_Pos)  /**< (DMAC_CRCCTRL) 16-bit bus transfer Position  */
+#define DMAC_CRCCTRL_CRCBEATSIZE_WORD       (DMAC_CRCCTRL_CRCBEATSIZE_WORD_Val << DMAC_CRCCTRL_CRCBEATSIZE_Pos)  /**< (DMAC_CRCCTRL) 32-bit bus transfer Position  */
+#define DMAC_CRCCTRL_CRCPOLY_Pos            2                                              /**< (DMAC_CRCCTRL) CRC Polynomial Type Position */
+#define DMAC_CRCCTRL_CRCPOLY_Msk            (_U_(0x3) << DMAC_CRCCTRL_CRCPOLY_Pos)         /**< (DMAC_CRCCTRL) CRC Polynomial Type Mask */
+#define DMAC_CRCCTRL_CRCPOLY(value)         (DMAC_CRCCTRL_CRCPOLY_Msk & ((value) << DMAC_CRCCTRL_CRCPOLY_Pos))
+#define   DMAC_CRCCTRL_CRCPOLY_CRC16_Val    _U_(0x0)                                       /**< (DMAC_CRCCTRL) CRC-16 (CRC-CCITT)  */
+#define   DMAC_CRCCTRL_CRCPOLY_CRC32_Val    _U_(0x1)                                       /**< (DMAC_CRCCTRL) CRC32 (IEEE 802.3)  */
+#define DMAC_CRCCTRL_CRCPOLY_CRC16          (DMAC_CRCCTRL_CRCPOLY_CRC16_Val << DMAC_CRCCTRL_CRCPOLY_Pos)  /**< (DMAC_CRCCTRL) CRC-16 (CRC-CCITT) Position  */
+#define DMAC_CRCCTRL_CRCPOLY_CRC32          (DMAC_CRCCTRL_CRCPOLY_CRC32_Val << DMAC_CRCCTRL_CRCPOLY_Pos)  /**< (DMAC_CRCCTRL) CRC32 (IEEE 802.3) Position  */
+#define DMAC_CRCCTRL_CRCSRC_Pos             8                                              /**< (DMAC_CRCCTRL) CRC Input Source Position */
+#define DMAC_CRCCTRL_CRCSRC_Msk             (_U_(0x3F) << DMAC_CRCCTRL_CRCSRC_Pos)         /**< (DMAC_CRCCTRL) CRC Input Source Mask */
+#define DMAC_CRCCTRL_CRCSRC(value)          (DMAC_CRCCTRL_CRCSRC_Msk & ((value) << DMAC_CRCCTRL_CRCSRC_Pos))
+#define   DMAC_CRCCTRL_CRCSRC_NOACT_Val     _U_(0x0)                                       /**< (DMAC_CRCCTRL) No action  */
+#define   DMAC_CRCCTRL_CRCSRC_IO_Val        _U_(0x1)                                       /**< (DMAC_CRCCTRL) I/O interface  */
+#define DMAC_CRCCTRL_CRCSRC_NOACT           (DMAC_CRCCTRL_CRCSRC_NOACT_Val << DMAC_CRCCTRL_CRCSRC_Pos)  /**< (DMAC_CRCCTRL) No action Position  */
+#define DMAC_CRCCTRL_CRCSRC_IO              (DMAC_CRCCTRL_CRCSRC_IO_Val << DMAC_CRCCTRL_CRCSRC_Pos)  /**< (DMAC_CRCCTRL) I/O interface Position  */
+#define DMAC_CRCCTRL_MASK                   _U_(0x3F0F)                                    /**< \deprecated (DMAC_CRCCTRL) Register MASK  (Use DMAC_CRCCTRL_Msk instead)  */
+#define DMAC_CRCCTRL_Msk                    _U_(0x3F0F)                                    /**< (DMAC_CRCCTRL) Register Mask  */
+
+
+/* -------- DMAC_CRCDATAIN : (DMAC Offset: 0x04) (R/W 32) CRC Data Input -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t CRCDATAIN:32;              /**< bit:  0..31  CRC Data Input                           */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DMAC_CRCDATAIN_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_CRCDATAIN_OFFSET               (0x04)                                        /**<  (DMAC_CRCDATAIN) CRC Data Input  Offset */
+#define DMAC_CRCDATAIN_RESETVALUE           _U_(0x00)                                     /**<  (DMAC_CRCDATAIN) CRC Data Input  Reset Value */
+
+#define DMAC_CRCDATAIN_CRCDATAIN_Pos        0                                              /**< (DMAC_CRCDATAIN) CRC Data Input Position */
+#define DMAC_CRCDATAIN_CRCDATAIN_Msk        (_U_(0xFFFFFFFF) << DMAC_CRCDATAIN_CRCDATAIN_Pos)  /**< (DMAC_CRCDATAIN) CRC Data Input Mask */
+#define DMAC_CRCDATAIN_CRCDATAIN(value)     (DMAC_CRCDATAIN_CRCDATAIN_Msk & ((value) << DMAC_CRCDATAIN_CRCDATAIN_Pos))
+#define DMAC_CRCDATAIN_MASK                 _U_(0xFFFFFFFF)                                /**< \deprecated (DMAC_CRCDATAIN) Register MASK  (Use DMAC_CRCDATAIN_Msk instead)  */
+#define DMAC_CRCDATAIN_Msk                  _U_(0xFFFFFFFF)                                /**< (DMAC_CRCDATAIN) Register Mask  */
+
+
+/* -------- DMAC_CRCCHKSUM : (DMAC Offset: 0x08) (R/W 32) CRC Checksum -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t CRCCHKSUM:32;              /**< bit:  0..31  CRC Checksum                             */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DMAC_CRCCHKSUM_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_CRCCHKSUM_OFFSET               (0x08)                                        /**<  (DMAC_CRCCHKSUM) CRC Checksum  Offset */
+#define DMAC_CRCCHKSUM_RESETVALUE           _U_(0x00)                                     /**<  (DMAC_CRCCHKSUM) CRC Checksum  Reset Value */
+
+#define DMAC_CRCCHKSUM_CRCCHKSUM_Pos        0                                              /**< (DMAC_CRCCHKSUM) CRC Checksum Position */
+#define DMAC_CRCCHKSUM_CRCCHKSUM_Msk        (_U_(0xFFFFFFFF) << DMAC_CRCCHKSUM_CRCCHKSUM_Pos)  /**< (DMAC_CRCCHKSUM) CRC Checksum Mask */
+#define DMAC_CRCCHKSUM_CRCCHKSUM(value)     (DMAC_CRCCHKSUM_CRCCHKSUM_Msk & ((value) << DMAC_CRCCHKSUM_CRCCHKSUM_Pos))
+#define DMAC_CRCCHKSUM_MASK                 _U_(0xFFFFFFFF)                                /**< \deprecated (DMAC_CRCCHKSUM) Register MASK  (Use DMAC_CRCCHKSUM_Msk instead)  */
+#define DMAC_CRCCHKSUM_Msk                  _U_(0xFFFFFFFF)                                /**< (DMAC_CRCCHKSUM) Register Mask  */
+
+
+/* -------- DMAC_CRCSTATUS : (DMAC Offset: 0x0c) (R/W 8) CRC Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  CRCBUSY:1;                 /**< bit:      0  CRC Module Busy                          */
+    uint8_t  CRCZERO:1;                 /**< bit:      1  CRC Zero                                 */
+    uint8_t  :6;                        /**< bit:   2..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} DMAC_CRCSTATUS_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_CRCSTATUS_OFFSET               (0x0C)                                        /**<  (DMAC_CRCSTATUS) CRC Status  Offset */
+#define DMAC_CRCSTATUS_RESETVALUE           _U_(0x00)                                     /**<  (DMAC_CRCSTATUS) CRC Status  Reset Value */
+
+#define DMAC_CRCSTATUS_CRCBUSY_Pos          0                                              /**< (DMAC_CRCSTATUS) CRC Module Busy Position */
+#define DMAC_CRCSTATUS_CRCBUSY_Msk          (_U_(0x1) << DMAC_CRCSTATUS_CRCBUSY_Pos)       /**< (DMAC_CRCSTATUS) CRC Module Busy Mask */
+#define DMAC_CRCSTATUS_CRCBUSY              DMAC_CRCSTATUS_CRCBUSY_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CRCSTATUS_CRCBUSY_Msk instead */
+#define DMAC_CRCSTATUS_CRCZERO_Pos          1                                              /**< (DMAC_CRCSTATUS) CRC Zero Position */
+#define DMAC_CRCSTATUS_CRCZERO_Msk          (_U_(0x1) << DMAC_CRCSTATUS_CRCZERO_Pos)       /**< (DMAC_CRCSTATUS) CRC Zero Mask */
+#define DMAC_CRCSTATUS_CRCZERO              DMAC_CRCSTATUS_CRCZERO_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CRCSTATUS_CRCZERO_Msk instead */
+#define DMAC_CRCSTATUS_MASK                 _U_(0x03)                                      /**< \deprecated (DMAC_CRCSTATUS) Register MASK  (Use DMAC_CRCSTATUS_Msk instead)  */
+#define DMAC_CRCSTATUS_Msk                  _U_(0x03)                                      /**< (DMAC_CRCSTATUS) Register Mask  */
+
+
+/* -------- DMAC_DBGCTRL : (DMAC Offset: 0x0d) (R/W 8) Debug Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DBGRUN:1;                  /**< bit:      0  Debug Run                                */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} DMAC_DBGCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_DBGCTRL_OFFSET                 (0x0D)                                        /**<  (DMAC_DBGCTRL) Debug Control  Offset */
+#define DMAC_DBGCTRL_RESETVALUE             _U_(0x00)                                     /**<  (DMAC_DBGCTRL) Debug Control  Reset Value */
+
+#define DMAC_DBGCTRL_DBGRUN_Pos             0                                              /**< (DMAC_DBGCTRL) Debug Run Position */
+#define DMAC_DBGCTRL_DBGRUN_Msk             (_U_(0x1) << DMAC_DBGCTRL_DBGRUN_Pos)          /**< (DMAC_DBGCTRL) Debug Run Mask */
+#define DMAC_DBGCTRL_DBGRUN                 DMAC_DBGCTRL_DBGRUN_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_DBGCTRL_DBGRUN_Msk instead */
+#define DMAC_DBGCTRL_MASK                   _U_(0x01)                                      /**< \deprecated (DMAC_DBGCTRL) Register MASK  (Use DMAC_DBGCTRL_Msk instead)  */
+#define DMAC_DBGCTRL_Msk                    _U_(0x01)                                      /**< (DMAC_DBGCTRL) Register Mask  */
+
+
+/* -------- DMAC_QOSCTRL : (DMAC Offset: 0x0e) (R/W 8) QOS Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  WRBQOS:2;                  /**< bit:   0..1  Write-Back Quality of Service            */
+    uint8_t  FQOS:2;                    /**< bit:   2..3  Fetch Quality of Service                 */
+    uint8_t  DQOS:2;                    /**< bit:   4..5  Data Transfer Quality of Service         */
+    uint8_t  :2;                        /**< bit:   6..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} DMAC_QOSCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_QOSCTRL_OFFSET                 (0x0E)                                        /**<  (DMAC_QOSCTRL) QOS Control  Offset */
+#define DMAC_QOSCTRL_RESETVALUE             _U_(0x2A)                                     /**<  (DMAC_QOSCTRL) QOS Control  Reset Value */
+
+#define DMAC_QOSCTRL_WRBQOS_Pos             0                                              /**< (DMAC_QOSCTRL) Write-Back Quality of Service Position */
+#define DMAC_QOSCTRL_WRBQOS_Msk             (_U_(0x3) << DMAC_QOSCTRL_WRBQOS_Pos)          /**< (DMAC_QOSCTRL) Write-Back Quality of Service Mask */
+#define DMAC_QOSCTRL_WRBQOS(value)          (DMAC_QOSCTRL_WRBQOS_Msk & ((value) << DMAC_QOSCTRL_WRBQOS_Pos))
+#define   DMAC_QOSCTRL_WRBQOS_DISABLE_Val   _U_(0x0)                                       /**< (DMAC_QOSCTRL) Background (no sensitive operation)  */
+#define   DMAC_QOSCTRL_WRBQOS_LOW_Val       _U_(0x1)                                       /**< (DMAC_QOSCTRL) Sensitive Bandwidth  */
+#define   DMAC_QOSCTRL_WRBQOS_MEDIUM_Val    _U_(0x2)                                       /**< (DMAC_QOSCTRL) Sensitive Latency  */
+#define   DMAC_QOSCTRL_WRBQOS_HIGH_Val      _U_(0x3)                                       /**< (DMAC_QOSCTRL) Critical Latency  */
+#define DMAC_QOSCTRL_WRBQOS_DISABLE         (DMAC_QOSCTRL_WRBQOS_DISABLE_Val << DMAC_QOSCTRL_WRBQOS_Pos)  /**< (DMAC_QOSCTRL) Background (no sensitive operation) Position  */
+#define DMAC_QOSCTRL_WRBQOS_LOW             (DMAC_QOSCTRL_WRBQOS_LOW_Val << DMAC_QOSCTRL_WRBQOS_Pos)  /**< (DMAC_QOSCTRL) Sensitive Bandwidth Position  */
+#define DMAC_QOSCTRL_WRBQOS_MEDIUM          (DMAC_QOSCTRL_WRBQOS_MEDIUM_Val << DMAC_QOSCTRL_WRBQOS_Pos)  /**< (DMAC_QOSCTRL) Sensitive Latency Position  */
+#define DMAC_QOSCTRL_WRBQOS_HIGH            (DMAC_QOSCTRL_WRBQOS_HIGH_Val << DMAC_QOSCTRL_WRBQOS_Pos)  /**< (DMAC_QOSCTRL) Critical Latency Position  */
+#define DMAC_QOSCTRL_FQOS_Pos               2                                              /**< (DMAC_QOSCTRL) Fetch Quality of Service Position */
+#define DMAC_QOSCTRL_FQOS_Msk               (_U_(0x3) << DMAC_QOSCTRL_FQOS_Pos)            /**< (DMAC_QOSCTRL) Fetch Quality of Service Mask */
+#define DMAC_QOSCTRL_FQOS(value)            (DMAC_QOSCTRL_FQOS_Msk & ((value) << DMAC_QOSCTRL_FQOS_Pos))
+#define   DMAC_QOSCTRL_FQOS_DISABLE_Val     _U_(0x0)                                       /**< (DMAC_QOSCTRL) Background (no sensitive operation)  */
+#define   DMAC_QOSCTRL_FQOS_LOW_Val         _U_(0x1)                                       /**< (DMAC_QOSCTRL) Sensitive Bandwidth  */
+#define   DMAC_QOSCTRL_FQOS_MEDIUM_Val      _U_(0x2)                                       /**< (DMAC_QOSCTRL) Sensitive Latency  */
+#define   DMAC_QOSCTRL_FQOS_HIGH_Val        _U_(0x3)                                       /**< (DMAC_QOSCTRL) Critical Latency  */
+#define DMAC_QOSCTRL_FQOS_DISABLE           (DMAC_QOSCTRL_FQOS_DISABLE_Val << DMAC_QOSCTRL_FQOS_Pos)  /**< (DMAC_QOSCTRL) Background (no sensitive operation) Position  */
+#define DMAC_QOSCTRL_FQOS_LOW               (DMAC_QOSCTRL_FQOS_LOW_Val << DMAC_QOSCTRL_FQOS_Pos)  /**< (DMAC_QOSCTRL) Sensitive Bandwidth Position  */
+#define DMAC_QOSCTRL_FQOS_MEDIUM            (DMAC_QOSCTRL_FQOS_MEDIUM_Val << DMAC_QOSCTRL_FQOS_Pos)  /**< (DMAC_QOSCTRL) Sensitive Latency Position  */
+#define DMAC_QOSCTRL_FQOS_HIGH              (DMAC_QOSCTRL_FQOS_HIGH_Val << DMAC_QOSCTRL_FQOS_Pos)  /**< (DMAC_QOSCTRL) Critical Latency Position  */
+#define DMAC_QOSCTRL_DQOS_Pos               4                                              /**< (DMAC_QOSCTRL) Data Transfer Quality of Service Position */
+#define DMAC_QOSCTRL_DQOS_Msk               (_U_(0x3) << DMAC_QOSCTRL_DQOS_Pos)            /**< (DMAC_QOSCTRL) Data Transfer Quality of Service Mask */
+#define DMAC_QOSCTRL_DQOS(value)            (DMAC_QOSCTRL_DQOS_Msk & ((value) << DMAC_QOSCTRL_DQOS_Pos))
+#define   DMAC_QOSCTRL_DQOS_DISABLE_Val     _U_(0x0)                                       /**< (DMAC_QOSCTRL) Background (no sensitive operation)  */
+#define   DMAC_QOSCTRL_DQOS_LOW_Val         _U_(0x1)                                       /**< (DMAC_QOSCTRL) Sensitive Bandwidth  */
+#define   DMAC_QOSCTRL_DQOS_MEDIUM_Val      _U_(0x2)                                       /**< (DMAC_QOSCTRL) Sensitive Latency  */
+#define   DMAC_QOSCTRL_DQOS_HIGH_Val        _U_(0x3)                                       /**< (DMAC_QOSCTRL) Critical Latency  */
+#define DMAC_QOSCTRL_DQOS_DISABLE           (DMAC_QOSCTRL_DQOS_DISABLE_Val << DMAC_QOSCTRL_DQOS_Pos)  /**< (DMAC_QOSCTRL) Background (no sensitive operation) Position  */
+#define DMAC_QOSCTRL_DQOS_LOW               (DMAC_QOSCTRL_DQOS_LOW_Val << DMAC_QOSCTRL_DQOS_Pos)  /**< (DMAC_QOSCTRL) Sensitive Bandwidth Position  */
+#define DMAC_QOSCTRL_DQOS_MEDIUM            (DMAC_QOSCTRL_DQOS_MEDIUM_Val << DMAC_QOSCTRL_DQOS_Pos)  /**< (DMAC_QOSCTRL) Sensitive Latency Position  */
+#define DMAC_QOSCTRL_DQOS_HIGH              (DMAC_QOSCTRL_DQOS_HIGH_Val << DMAC_QOSCTRL_DQOS_Pos)  /**< (DMAC_QOSCTRL) Critical Latency Position  */
+#define DMAC_QOSCTRL_MASK                   _U_(0x3F)                                      /**< \deprecated (DMAC_QOSCTRL) Register MASK  (Use DMAC_QOSCTRL_Msk instead)  */
+#define DMAC_QOSCTRL_Msk                    _U_(0x3F)                                      /**< (DMAC_QOSCTRL) Register Mask  */
+
+
+/* -------- DMAC_SWTRIGCTRL : (DMAC Offset: 0x10) (R/W 32) Software Trigger Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SWTRIG0:1;                 /**< bit:      0  Channel 0 Software Trigger               */
+    uint32_t SWTRIG1:1;                 /**< bit:      1  Channel 1 Software Trigger               */
+    uint32_t SWTRIG2:1;                 /**< bit:      2  Channel 2 Software Trigger               */
+    uint32_t SWTRIG3:1;                 /**< bit:      3  Channel 3 Software Trigger               */
+    uint32_t SWTRIG4:1;                 /**< bit:      4  Channel 4 Software Trigger               */
+    uint32_t SWTRIG5:1;                 /**< bit:      5  Channel 5 Software Trigger               */
+    uint32_t SWTRIG6:1;                 /**< bit:      6  Channel 6 Software Trigger               */
+    uint32_t SWTRIG7:1;                 /**< bit:      7  Channel 7 Software Trigger               */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t SWTRIG:8;                  /**< bit:   0..7  Channel 7 Software Trigger               */
+    uint32_t :24;                       /**< bit:  8..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} DMAC_SWTRIGCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_SWTRIGCTRL_OFFSET              (0x10)                                        /**<  (DMAC_SWTRIGCTRL) Software Trigger Control  Offset */
+#define DMAC_SWTRIGCTRL_RESETVALUE          _U_(0x00)                                     /**<  (DMAC_SWTRIGCTRL) Software Trigger Control  Reset Value */
+
+#define DMAC_SWTRIGCTRL_SWTRIG0_Pos         0                                              /**< (DMAC_SWTRIGCTRL) Channel 0 Software Trigger Position */
+#define DMAC_SWTRIGCTRL_SWTRIG0_Msk         (_U_(0x1) << DMAC_SWTRIGCTRL_SWTRIG0_Pos)      /**< (DMAC_SWTRIGCTRL) Channel 0 Software Trigger Mask */
+#define DMAC_SWTRIGCTRL_SWTRIG0             DMAC_SWTRIGCTRL_SWTRIG0_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_SWTRIGCTRL_SWTRIG0_Msk instead */
+#define DMAC_SWTRIGCTRL_SWTRIG1_Pos         1                                              /**< (DMAC_SWTRIGCTRL) Channel 1 Software Trigger Position */
+#define DMAC_SWTRIGCTRL_SWTRIG1_Msk         (_U_(0x1) << DMAC_SWTRIGCTRL_SWTRIG1_Pos)      /**< (DMAC_SWTRIGCTRL) Channel 1 Software Trigger Mask */
+#define DMAC_SWTRIGCTRL_SWTRIG1             DMAC_SWTRIGCTRL_SWTRIG1_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_SWTRIGCTRL_SWTRIG1_Msk instead */
+#define DMAC_SWTRIGCTRL_SWTRIG2_Pos         2                                              /**< (DMAC_SWTRIGCTRL) Channel 2 Software Trigger Position */
+#define DMAC_SWTRIGCTRL_SWTRIG2_Msk         (_U_(0x1) << DMAC_SWTRIGCTRL_SWTRIG2_Pos)      /**< (DMAC_SWTRIGCTRL) Channel 2 Software Trigger Mask */
+#define DMAC_SWTRIGCTRL_SWTRIG2             DMAC_SWTRIGCTRL_SWTRIG2_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_SWTRIGCTRL_SWTRIG2_Msk instead */
+#define DMAC_SWTRIGCTRL_SWTRIG3_Pos         3                                              /**< (DMAC_SWTRIGCTRL) Channel 3 Software Trigger Position */
+#define DMAC_SWTRIGCTRL_SWTRIG3_Msk         (_U_(0x1) << DMAC_SWTRIGCTRL_SWTRIG3_Pos)      /**< (DMAC_SWTRIGCTRL) Channel 3 Software Trigger Mask */
+#define DMAC_SWTRIGCTRL_SWTRIG3             DMAC_SWTRIGCTRL_SWTRIG3_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_SWTRIGCTRL_SWTRIG3_Msk instead */
+#define DMAC_SWTRIGCTRL_SWTRIG4_Pos         4                                              /**< (DMAC_SWTRIGCTRL) Channel 4 Software Trigger Position */
+#define DMAC_SWTRIGCTRL_SWTRIG4_Msk         (_U_(0x1) << DMAC_SWTRIGCTRL_SWTRIG4_Pos)      /**< (DMAC_SWTRIGCTRL) Channel 4 Software Trigger Mask */
+#define DMAC_SWTRIGCTRL_SWTRIG4             DMAC_SWTRIGCTRL_SWTRIG4_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_SWTRIGCTRL_SWTRIG4_Msk instead */
+#define DMAC_SWTRIGCTRL_SWTRIG5_Pos         5                                              /**< (DMAC_SWTRIGCTRL) Channel 5 Software Trigger Position */
+#define DMAC_SWTRIGCTRL_SWTRIG5_Msk         (_U_(0x1) << DMAC_SWTRIGCTRL_SWTRIG5_Pos)      /**< (DMAC_SWTRIGCTRL) Channel 5 Software Trigger Mask */
+#define DMAC_SWTRIGCTRL_SWTRIG5             DMAC_SWTRIGCTRL_SWTRIG5_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_SWTRIGCTRL_SWTRIG5_Msk instead */
+#define DMAC_SWTRIGCTRL_SWTRIG6_Pos         6                                              /**< (DMAC_SWTRIGCTRL) Channel 6 Software Trigger Position */
+#define DMAC_SWTRIGCTRL_SWTRIG6_Msk         (_U_(0x1) << DMAC_SWTRIGCTRL_SWTRIG6_Pos)      /**< (DMAC_SWTRIGCTRL) Channel 6 Software Trigger Mask */
+#define DMAC_SWTRIGCTRL_SWTRIG6             DMAC_SWTRIGCTRL_SWTRIG6_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_SWTRIGCTRL_SWTRIG6_Msk instead */
+#define DMAC_SWTRIGCTRL_SWTRIG7_Pos         7                                              /**< (DMAC_SWTRIGCTRL) Channel 7 Software Trigger Position */
+#define DMAC_SWTRIGCTRL_SWTRIG7_Msk         (_U_(0x1) << DMAC_SWTRIGCTRL_SWTRIG7_Pos)      /**< (DMAC_SWTRIGCTRL) Channel 7 Software Trigger Mask */
+#define DMAC_SWTRIGCTRL_SWTRIG7             DMAC_SWTRIGCTRL_SWTRIG7_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_SWTRIGCTRL_SWTRIG7_Msk instead */
+#define DMAC_SWTRIGCTRL_MASK                _U_(0xFF)                                      /**< \deprecated (DMAC_SWTRIGCTRL) Register MASK  (Use DMAC_SWTRIGCTRL_Msk instead)  */
+#define DMAC_SWTRIGCTRL_Msk                 _U_(0xFF)                                      /**< (DMAC_SWTRIGCTRL) Register Mask  */
+
+#define DMAC_SWTRIGCTRL_SWTRIG_Pos          0                                              /**< (DMAC_SWTRIGCTRL Position) Channel 7 Software Trigger */
+#define DMAC_SWTRIGCTRL_SWTRIG_Msk          (_U_(0xFF) << DMAC_SWTRIGCTRL_SWTRIG_Pos)      /**< (DMAC_SWTRIGCTRL Mask) SWTRIG */
+#define DMAC_SWTRIGCTRL_SWTRIG(value)       (DMAC_SWTRIGCTRL_SWTRIG_Msk & ((value) << DMAC_SWTRIGCTRL_SWTRIG_Pos))  
+
+/* -------- DMAC_PRICTRL0 : (DMAC Offset: 0x14) (R/W 32) Priority Control 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t LVLPRI0:3;                 /**< bit:   0..2  Level 0 Channel Priority Number          */
+    uint32_t :4;                        /**< bit:   3..6  Reserved */
+    uint32_t RRLVLEN0:1;                /**< bit:      7  Level 0 Round-Robin Scheduling Enable    */
+    uint32_t LVLPRI1:3;                 /**< bit:  8..10  Level 1 Channel Priority Number          */
+    uint32_t :4;                        /**< bit: 11..14  Reserved */
+    uint32_t RRLVLEN1:1;                /**< bit:     15  Level 1 Round-Robin Scheduling Enable    */
+    uint32_t LVLPRI2:3;                 /**< bit: 16..18  Level 2 Channel Priority Number          */
+    uint32_t :4;                        /**< bit: 19..22  Reserved */
+    uint32_t RRLVLEN2:1;                /**< bit:     23  Level 2 Round-Robin Scheduling Enable    */
+    uint32_t LVLPRI3:3;                 /**< bit: 24..26  Level 3 Channel Priority Number          */
+    uint32_t :4;                        /**< bit: 27..30  Reserved */
+    uint32_t RRLVLEN3:1;                /**< bit:     31  Level 3 Round-Robin Scheduling Enable    */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DMAC_PRICTRL0_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_PRICTRL0_OFFSET                (0x14)                                        /**<  (DMAC_PRICTRL0) Priority Control 0  Offset */
+#define DMAC_PRICTRL0_RESETVALUE            _U_(0x00)                                     /**<  (DMAC_PRICTRL0) Priority Control 0  Reset Value */
+
+#define DMAC_PRICTRL0_LVLPRI0_Pos           0                                              /**< (DMAC_PRICTRL0) Level 0 Channel Priority Number Position */
+#define DMAC_PRICTRL0_LVLPRI0_Msk           (_U_(0x7) << DMAC_PRICTRL0_LVLPRI0_Pos)        /**< (DMAC_PRICTRL0) Level 0 Channel Priority Number Mask */
+#define DMAC_PRICTRL0_LVLPRI0(value)        (DMAC_PRICTRL0_LVLPRI0_Msk & ((value) << DMAC_PRICTRL0_LVLPRI0_Pos))
+#define DMAC_PRICTRL0_RRLVLEN0_Pos          7                                              /**< (DMAC_PRICTRL0) Level 0 Round-Robin Scheduling Enable Position */
+#define DMAC_PRICTRL0_RRLVLEN0_Msk          (_U_(0x1) << DMAC_PRICTRL0_RRLVLEN0_Pos)       /**< (DMAC_PRICTRL0) Level 0 Round-Robin Scheduling Enable Mask */
+#define DMAC_PRICTRL0_RRLVLEN0              DMAC_PRICTRL0_RRLVLEN0_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_PRICTRL0_RRLVLEN0_Msk instead */
+#define DMAC_PRICTRL0_LVLPRI1_Pos           8                                              /**< (DMAC_PRICTRL0) Level 1 Channel Priority Number Position */
+#define DMAC_PRICTRL0_LVLPRI1_Msk           (_U_(0x7) << DMAC_PRICTRL0_LVLPRI1_Pos)        /**< (DMAC_PRICTRL0) Level 1 Channel Priority Number Mask */
+#define DMAC_PRICTRL0_LVLPRI1(value)        (DMAC_PRICTRL0_LVLPRI1_Msk & ((value) << DMAC_PRICTRL0_LVLPRI1_Pos))
+#define DMAC_PRICTRL0_RRLVLEN1_Pos          15                                             /**< (DMAC_PRICTRL0) Level 1 Round-Robin Scheduling Enable Position */
+#define DMAC_PRICTRL0_RRLVLEN1_Msk          (_U_(0x1) << DMAC_PRICTRL0_RRLVLEN1_Pos)       /**< (DMAC_PRICTRL0) Level 1 Round-Robin Scheduling Enable Mask */
+#define DMAC_PRICTRL0_RRLVLEN1              DMAC_PRICTRL0_RRLVLEN1_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_PRICTRL0_RRLVLEN1_Msk instead */
+#define DMAC_PRICTRL0_LVLPRI2_Pos           16                                             /**< (DMAC_PRICTRL0) Level 2 Channel Priority Number Position */
+#define DMAC_PRICTRL0_LVLPRI2_Msk           (_U_(0x7) << DMAC_PRICTRL0_LVLPRI2_Pos)        /**< (DMAC_PRICTRL0) Level 2 Channel Priority Number Mask */
+#define DMAC_PRICTRL0_LVLPRI2(value)        (DMAC_PRICTRL0_LVLPRI2_Msk & ((value) << DMAC_PRICTRL0_LVLPRI2_Pos))
+#define DMAC_PRICTRL0_RRLVLEN2_Pos          23                                             /**< (DMAC_PRICTRL0) Level 2 Round-Robin Scheduling Enable Position */
+#define DMAC_PRICTRL0_RRLVLEN2_Msk          (_U_(0x1) << DMAC_PRICTRL0_RRLVLEN2_Pos)       /**< (DMAC_PRICTRL0) Level 2 Round-Robin Scheduling Enable Mask */
+#define DMAC_PRICTRL0_RRLVLEN2              DMAC_PRICTRL0_RRLVLEN2_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_PRICTRL0_RRLVLEN2_Msk instead */
+#define DMAC_PRICTRL0_LVLPRI3_Pos           24                                             /**< (DMAC_PRICTRL0) Level 3 Channel Priority Number Position */
+#define DMAC_PRICTRL0_LVLPRI3_Msk           (_U_(0x7) << DMAC_PRICTRL0_LVLPRI3_Pos)        /**< (DMAC_PRICTRL0) Level 3 Channel Priority Number Mask */
+#define DMAC_PRICTRL0_LVLPRI3(value)        (DMAC_PRICTRL0_LVLPRI3_Msk & ((value) << DMAC_PRICTRL0_LVLPRI3_Pos))
+#define DMAC_PRICTRL0_RRLVLEN3_Pos          31                                             /**< (DMAC_PRICTRL0) Level 3 Round-Robin Scheduling Enable Position */
+#define DMAC_PRICTRL0_RRLVLEN3_Msk          (_U_(0x1) << DMAC_PRICTRL0_RRLVLEN3_Pos)       /**< (DMAC_PRICTRL0) Level 3 Round-Robin Scheduling Enable Mask */
+#define DMAC_PRICTRL0_RRLVLEN3              DMAC_PRICTRL0_RRLVLEN3_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_PRICTRL0_RRLVLEN3_Msk instead */
+#define DMAC_PRICTRL0_MASK                  _U_(0x87878787)                                /**< \deprecated (DMAC_PRICTRL0) Register MASK  (Use DMAC_PRICTRL0_Msk instead)  */
+#define DMAC_PRICTRL0_Msk                   _U_(0x87878787)                                /**< (DMAC_PRICTRL0) Register Mask  */
+
+
+/* -------- DMAC_INTPEND : (DMAC Offset: 0x20) (R/W 16) Interrupt Pending -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t ID:3;                      /**< bit:   0..2  Channel ID                               */
+    uint16_t :5;                        /**< bit:   3..7  Reserved */
+    uint16_t TERR:1;                    /**< bit:      8  Transfer Error                           */
+    uint16_t TCMPL:1;                   /**< bit:      9  Transfer Complete                        */
+    uint16_t SUSP:1;                    /**< bit:     10  Channel Suspend                          */
+    uint16_t :2;                        /**< bit: 11..12  Reserved */
+    uint16_t FERR:1;                    /**< bit:     13  Fetch Error                              */
+    uint16_t BUSY:1;                    /**< bit:     14  Busy                                     */
+    uint16_t PEND:1;                    /**< bit:     15  Pending                                  */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} DMAC_INTPEND_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_INTPEND_OFFSET                 (0x20)                                        /**<  (DMAC_INTPEND) Interrupt Pending  Offset */
+#define DMAC_INTPEND_RESETVALUE             _U_(0x00)                                     /**<  (DMAC_INTPEND) Interrupt Pending  Reset Value */
+
+#define DMAC_INTPEND_ID_Pos                 0                                              /**< (DMAC_INTPEND) Channel ID Position */
+#define DMAC_INTPEND_ID_Msk                 (_U_(0x7) << DMAC_INTPEND_ID_Pos)              /**< (DMAC_INTPEND) Channel ID Mask */
+#define DMAC_INTPEND_ID(value)              (DMAC_INTPEND_ID_Msk & ((value) << DMAC_INTPEND_ID_Pos))
+#define DMAC_INTPEND_TERR_Pos               8                                              /**< (DMAC_INTPEND) Transfer Error Position */
+#define DMAC_INTPEND_TERR_Msk               (_U_(0x1) << DMAC_INTPEND_TERR_Pos)            /**< (DMAC_INTPEND) Transfer Error Mask */
+#define DMAC_INTPEND_TERR                   DMAC_INTPEND_TERR_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_INTPEND_TERR_Msk instead */
+#define DMAC_INTPEND_TCMPL_Pos              9                                              /**< (DMAC_INTPEND) Transfer Complete Position */
+#define DMAC_INTPEND_TCMPL_Msk              (_U_(0x1) << DMAC_INTPEND_TCMPL_Pos)           /**< (DMAC_INTPEND) Transfer Complete Mask */
+#define DMAC_INTPEND_TCMPL                  DMAC_INTPEND_TCMPL_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_INTPEND_TCMPL_Msk instead */
+#define DMAC_INTPEND_SUSP_Pos               10                                             /**< (DMAC_INTPEND) Channel Suspend Position */
+#define DMAC_INTPEND_SUSP_Msk               (_U_(0x1) << DMAC_INTPEND_SUSP_Pos)            /**< (DMAC_INTPEND) Channel Suspend Mask */
+#define DMAC_INTPEND_SUSP                   DMAC_INTPEND_SUSP_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_INTPEND_SUSP_Msk instead */
+#define DMAC_INTPEND_FERR_Pos               13                                             /**< (DMAC_INTPEND) Fetch Error Position */
+#define DMAC_INTPEND_FERR_Msk               (_U_(0x1) << DMAC_INTPEND_FERR_Pos)            /**< (DMAC_INTPEND) Fetch Error Mask */
+#define DMAC_INTPEND_FERR                   DMAC_INTPEND_FERR_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_INTPEND_FERR_Msk instead */
+#define DMAC_INTPEND_BUSY_Pos               14                                             /**< (DMAC_INTPEND) Busy Position */
+#define DMAC_INTPEND_BUSY_Msk               (_U_(0x1) << DMAC_INTPEND_BUSY_Pos)            /**< (DMAC_INTPEND) Busy Mask */
+#define DMAC_INTPEND_BUSY                   DMAC_INTPEND_BUSY_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_INTPEND_BUSY_Msk instead */
+#define DMAC_INTPEND_PEND_Pos               15                                             /**< (DMAC_INTPEND) Pending Position */
+#define DMAC_INTPEND_PEND_Msk               (_U_(0x1) << DMAC_INTPEND_PEND_Pos)            /**< (DMAC_INTPEND) Pending Mask */
+#define DMAC_INTPEND_PEND                   DMAC_INTPEND_PEND_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_INTPEND_PEND_Msk instead */
+#define DMAC_INTPEND_MASK                   _U_(0xE707)                                    /**< \deprecated (DMAC_INTPEND) Register MASK  (Use DMAC_INTPEND_Msk instead)  */
+#define DMAC_INTPEND_Msk                    _U_(0xE707)                                    /**< (DMAC_INTPEND) Register Mask  */
+
+
+/* -------- DMAC_INTSTATUS : (DMAC Offset: 0x24) (R/ 32) Interrupt Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t CHINT0:1;                  /**< bit:      0  Channel 0 Pending Interrupt              */
+    uint32_t CHINT1:1;                  /**< bit:      1  Channel 1 Pending Interrupt              */
+    uint32_t CHINT2:1;                  /**< bit:      2  Channel 2 Pending Interrupt              */
+    uint32_t CHINT3:1;                  /**< bit:      3  Channel 3 Pending Interrupt              */
+    uint32_t CHINT4:1;                  /**< bit:      4  Channel 4 Pending Interrupt              */
+    uint32_t CHINT5:1;                  /**< bit:      5  Channel 5 Pending Interrupt              */
+    uint32_t CHINT6:1;                  /**< bit:      6  Channel 6 Pending Interrupt              */
+    uint32_t CHINT7:1;                  /**< bit:      7  Channel 7 Pending Interrupt              */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t CHINT:8;                   /**< bit:   0..7  Channel 7 Pending Interrupt              */
+    uint32_t :24;                       /**< bit:  8..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} DMAC_INTSTATUS_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_INTSTATUS_OFFSET               (0x24)                                        /**<  (DMAC_INTSTATUS) Interrupt Status  Offset */
+#define DMAC_INTSTATUS_RESETVALUE           _U_(0x00)                                     /**<  (DMAC_INTSTATUS) Interrupt Status  Reset Value */
+
+#define DMAC_INTSTATUS_CHINT0_Pos           0                                              /**< (DMAC_INTSTATUS) Channel 0 Pending Interrupt Position */
+#define DMAC_INTSTATUS_CHINT0_Msk           (_U_(0x1) << DMAC_INTSTATUS_CHINT0_Pos)        /**< (DMAC_INTSTATUS) Channel 0 Pending Interrupt Mask */
+#define DMAC_INTSTATUS_CHINT0               DMAC_INTSTATUS_CHINT0_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_INTSTATUS_CHINT0_Msk instead */
+#define DMAC_INTSTATUS_CHINT1_Pos           1                                              /**< (DMAC_INTSTATUS) Channel 1 Pending Interrupt Position */
+#define DMAC_INTSTATUS_CHINT1_Msk           (_U_(0x1) << DMAC_INTSTATUS_CHINT1_Pos)        /**< (DMAC_INTSTATUS) Channel 1 Pending Interrupt Mask */
+#define DMAC_INTSTATUS_CHINT1               DMAC_INTSTATUS_CHINT1_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_INTSTATUS_CHINT1_Msk instead */
+#define DMAC_INTSTATUS_CHINT2_Pos           2                                              /**< (DMAC_INTSTATUS) Channel 2 Pending Interrupt Position */
+#define DMAC_INTSTATUS_CHINT2_Msk           (_U_(0x1) << DMAC_INTSTATUS_CHINT2_Pos)        /**< (DMAC_INTSTATUS) Channel 2 Pending Interrupt Mask */
+#define DMAC_INTSTATUS_CHINT2               DMAC_INTSTATUS_CHINT2_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_INTSTATUS_CHINT2_Msk instead */
+#define DMAC_INTSTATUS_CHINT3_Pos           3                                              /**< (DMAC_INTSTATUS) Channel 3 Pending Interrupt Position */
+#define DMAC_INTSTATUS_CHINT3_Msk           (_U_(0x1) << DMAC_INTSTATUS_CHINT3_Pos)        /**< (DMAC_INTSTATUS) Channel 3 Pending Interrupt Mask */
+#define DMAC_INTSTATUS_CHINT3               DMAC_INTSTATUS_CHINT3_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_INTSTATUS_CHINT3_Msk instead */
+#define DMAC_INTSTATUS_CHINT4_Pos           4                                              /**< (DMAC_INTSTATUS) Channel 4 Pending Interrupt Position */
+#define DMAC_INTSTATUS_CHINT4_Msk           (_U_(0x1) << DMAC_INTSTATUS_CHINT4_Pos)        /**< (DMAC_INTSTATUS) Channel 4 Pending Interrupt Mask */
+#define DMAC_INTSTATUS_CHINT4               DMAC_INTSTATUS_CHINT4_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_INTSTATUS_CHINT4_Msk instead */
+#define DMAC_INTSTATUS_CHINT5_Pos           5                                              /**< (DMAC_INTSTATUS) Channel 5 Pending Interrupt Position */
+#define DMAC_INTSTATUS_CHINT5_Msk           (_U_(0x1) << DMAC_INTSTATUS_CHINT5_Pos)        /**< (DMAC_INTSTATUS) Channel 5 Pending Interrupt Mask */
+#define DMAC_INTSTATUS_CHINT5               DMAC_INTSTATUS_CHINT5_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_INTSTATUS_CHINT5_Msk instead */
+#define DMAC_INTSTATUS_CHINT6_Pos           6                                              /**< (DMAC_INTSTATUS) Channel 6 Pending Interrupt Position */
+#define DMAC_INTSTATUS_CHINT6_Msk           (_U_(0x1) << DMAC_INTSTATUS_CHINT6_Pos)        /**< (DMAC_INTSTATUS) Channel 6 Pending Interrupt Mask */
+#define DMAC_INTSTATUS_CHINT6               DMAC_INTSTATUS_CHINT6_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_INTSTATUS_CHINT6_Msk instead */
+#define DMAC_INTSTATUS_CHINT7_Pos           7                                              /**< (DMAC_INTSTATUS) Channel 7 Pending Interrupt Position */
+#define DMAC_INTSTATUS_CHINT7_Msk           (_U_(0x1) << DMAC_INTSTATUS_CHINT7_Pos)        /**< (DMAC_INTSTATUS) Channel 7 Pending Interrupt Mask */
+#define DMAC_INTSTATUS_CHINT7               DMAC_INTSTATUS_CHINT7_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_INTSTATUS_CHINT7_Msk instead */
+#define DMAC_INTSTATUS_MASK                 _U_(0xFF)                                      /**< \deprecated (DMAC_INTSTATUS) Register MASK  (Use DMAC_INTSTATUS_Msk instead)  */
+#define DMAC_INTSTATUS_Msk                  _U_(0xFF)                                      /**< (DMAC_INTSTATUS) Register Mask  */
+
+#define DMAC_INTSTATUS_CHINT_Pos            0                                              /**< (DMAC_INTSTATUS Position) Channel 7 Pending Interrupt */
+#define DMAC_INTSTATUS_CHINT_Msk            (_U_(0xFF) << DMAC_INTSTATUS_CHINT_Pos)        /**< (DMAC_INTSTATUS Mask) CHINT */
+#define DMAC_INTSTATUS_CHINT(value)         (DMAC_INTSTATUS_CHINT_Msk & ((value) << DMAC_INTSTATUS_CHINT_Pos))  
+
+/* -------- DMAC_BUSYCH : (DMAC Offset: 0x28) (R/ 32) Busy Channels -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t BUSYCH0:1;                 /**< bit:      0  Busy Channel 0                           */
+    uint32_t BUSYCH1:1;                 /**< bit:      1  Busy Channel 1                           */
+    uint32_t BUSYCH2:1;                 /**< bit:      2  Busy Channel 2                           */
+    uint32_t BUSYCH3:1;                 /**< bit:      3  Busy Channel 3                           */
+    uint32_t BUSYCH4:1;                 /**< bit:      4  Busy Channel 4                           */
+    uint32_t BUSYCH5:1;                 /**< bit:      5  Busy Channel 5                           */
+    uint32_t BUSYCH6:1;                 /**< bit:      6  Busy Channel 6                           */
+    uint32_t BUSYCH7:1;                 /**< bit:      7  Busy Channel 7                           */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t BUSYCH:8;                  /**< bit:   0..7  Busy Channel 7                           */
+    uint32_t :24;                       /**< bit:  8..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} DMAC_BUSYCH_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_BUSYCH_OFFSET                  (0x28)                                        /**<  (DMAC_BUSYCH) Busy Channels  Offset */
+#define DMAC_BUSYCH_RESETVALUE              _U_(0x00)                                     /**<  (DMAC_BUSYCH) Busy Channels  Reset Value */
+
+#define DMAC_BUSYCH_BUSYCH0_Pos             0                                              /**< (DMAC_BUSYCH) Busy Channel 0 Position */
+#define DMAC_BUSYCH_BUSYCH0_Msk             (_U_(0x1) << DMAC_BUSYCH_BUSYCH0_Pos)          /**< (DMAC_BUSYCH) Busy Channel 0 Mask */
+#define DMAC_BUSYCH_BUSYCH0                 DMAC_BUSYCH_BUSYCH0_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_BUSYCH_BUSYCH0_Msk instead */
+#define DMAC_BUSYCH_BUSYCH1_Pos             1                                              /**< (DMAC_BUSYCH) Busy Channel 1 Position */
+#define DMAC_BUSYCH_BUSYCH1_Msk             (_U_(0x1) << DMAC_BUSYCH_BUSYCH1_Pos)          /**< (DMAC_BUSYCH) Busy Channel 1 Mask */
+#define DMAC_BUSYCH_BUSYCH1                 DMAC_BUSYCH_BUSYCH1_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_BUSYCH_BUSYCH1_Msk instead */
+#define DMAC_BUSYCH_BUSYCH2_Pos             2                                              /**< (DMAC_BUSYCH) Busy Channel 2 Position */
+#define DMAC_BUSYCH_BUSYCH2_Msk             (_U_(0x1) << DMAC_BUSYCH_BUSYCH2_Pos)          /**< (DMAC_BUSYCH) Busy Channel 2 Mask */
+#define DMAC_BUSYCH_BUSYCH2                 DMAC_BUSYCH_BUSYCH2_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_BUSYCH_BUSYCH2_Msk instead */
+#define DMAC_BUSYCH_BUSYCH3_Pos             3                                              /**< (DMAC_BUSYCH) Busy Channel 3 Position */
+#define DMAC_BUSYCH_BUSYCH3_Msk             (_U_(0x1) << DMAC_BUSYCH_BUSYCH3_Pos)          /**< (DMAC_BUSYCH) Busy Channel 3 Mask */
+#define DMAC_BUSYCH_BUSYCH3                 DMAC_BUSYCH_BUSYCH3_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_BUSYCH_BUSYCH3_Msk instead */
+#define DMAC_BUSYCH_BUSYCH4_Pos             4                                              /**< (DMAC_BUSYCH) Busy Channel 4 Position */
+#define DMAC_BUSYCH_BUSYCH4_Msk             (_U_(0x1) << DMAC_BUSYCH_BUSYCH4_Pos)          /**< (DMAC_BUSYCH) Busy Channel 4 Mask */
+#define DMAC_BUSYCH_BUSYCH4                 DMAC_BUSYCH_BUSYCH4_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_BUSYCH_BUSYCH4_Msk instead */
+#define DMAC_BUSYCH_BUSYCH5_Pos             5                                              /**< (DMAC_BUSYCH) Busy Channel 5 Position */
+#define DMAC_BUSYCH_BUSYCH5_Msk             (_U_(0x1) << DMAC_BUSYCH_BUSYCH5_Pos)          /**< (DMAC_BUSYCH) Busy Channel 5 Mask */
+#define DMAC_BUSYCH_BUSYCH5                 DMAC_BUSYCH_BUSYCH5_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_BUSYCH_BUSYCH5_Msk instead */
+#define DMAC_BUSYCH_BUSYCH6_Pos             6                                              /**< (DMAC_BUSYCH) Busy Channel 6 Position */
+#define DMAC_BUSYCH_BUSYCH6_Msk             (_U_(0x1) << DMAC_BUSYCH_BUSYCH6_Pos)          /**< (DMAC_BUSYCH) Busy Channel 6 Mask */
+#define DMAC_BUSYCH_BUSYCH6                 DMAC_BUSYCH_BUSYCH6_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_BUSYCH_BUSYCH6_Msk instead */
+#define DMAC_BUSYCH_BUSYCH7_Pos             7                                              /**< (DMAC_BUSYCH) Busy Channel 7 Position */
+#define DMAC_BUSYCH_BUSYCH7_Msk             (_U_(0x1) << DMAC_BUSYCH_BUSYCH7_Pos)          /**< (DMAC_BUSYCH) Busy Channel 7 Mask */
+#define DMAC_BUSYCH_BUSYCH7                 DMAC_BUSYCH_BUSYCH7_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_BUSYCH_BUSYCH7_Msk instead */
+#define DMAC_BUSYCH_MASK                    _U_(0xFF)                                      /**< \deprecated (DMAC_BUSYCH) Register MASK  (Use DMAC_BUSYCH_Msk instead)  */
+#define DMAC_BUSYCH_Msk                     _U_(0xFF)                                      /**< (DMAC_BUSYCH) Register Mask  */
+
+#define DMAC_BUSYCH_BUSYCH_Pos              0                                              /**< (DMAC_BUSYCH Position) Busy Channel 7 */
+#define DMAC_BUSYCH_BUSYCH_Msk              (_U_(0xFF) << DMAC_BUSYCH_BUSYCH_Pos)          /**< (DMAC_BUSYCH Mask) BUSYCH */
+#define DMAC_BUSYCH_BUSYCH(value)           (DMAC_BUSYCH_BUSYCH_Msk & ((value) << DMAC_BUSYCH_BUSYCH_Pos))  
+
+/* -------- DMAC_PENDCH : (DMAC Offset: 0x2c) (R/ 32) Pending Channels -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t PENDCH0:1;                 /**< bit:      0  Pending Channel 0                        */
+    uint32_t PENDCH1:1;                 /**< bit:      1  Pending Channel 1                        */
+    uint32_t PENDCH2:1;                 /**< bit:      2  Pending Channel 2                        */
+    uint32_t PENDCH3:1;                 /**< bit:      3  Pending Channel 3                        */
+    uint32_t PENDCH4:1;                 /**< bit:      4  Pending Channel 4                        */
+    uint32_t PENDCH5:1;                 /**< bit:      5  Pending Channel 5                        */
+    uint32_t PENDCH6:1;                 /**< bit:      6  Pending Channel 6                        */
+    uint32_t PENDCH7:1;                 /**< bit:      7  Pending Channel 7                        */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t PENDCH:8;                  /**< bit:   0..7  Pending Channel 7                        */
+    uint32_t :24;                       /**< bit:  8..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} DMAC_PENDCH_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_PENDCH_OFFSET                  (0x2C)                                        /**<  (DMAC_PENDCH) Pending Channels  Offset */
+#define DMAC_PENDCH_RESETVALUE              _U_(0x00)                                     /**<  (DMAC_PENDCH) Pending Channels  Reset Value */
+
+#define DMAC_PENDCH_PENDCH0_Pos             0                                              /**< (DMAC_PENDCH) Pending Channel 0 Position */
+#define DMAC_PENDCH_PENDCH0_Msk             (_U_(0x1) << DMAC_PENDCH_PENDCH0_Pos)          /**< (DMAC_PENDCH) Pending Channel 0 Mask */
+#define DMAC_PENDCH_PENDCH0                 DMAC_PENDCH_PENDCH0_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_PENDCH_PENDCH0_Msk instead */
+#define DMAC_PENDCH_PENDCH1_Pos             1                                              /**< (DMAC_PENDCH) Pending Channel 1 Position */
+#define DMAC_PENDCH_PENDCH1_Msk             (_U_(0x1) << DMAC_PENDCH_PENDCH1_Pos)          /**< (DMAC_PENDCH) Pending Channel 1 Mask */
+#define DMAC_PENDCH_PENDCH1                 DMAC_PENDCH_PENDCH1_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_PENDCH_PENDCH1_Msk instead */
+#define DMAC_PENDCH_PENDCH2_Pos             2                                              /**< (DMAC_PENDCH) Pending Channel 2 Position */
+#define DMAC_PENDCH_PENDCH2_Msk             (_U_(0x1) << DMAC_PENDCH_PENDCH2_Pos)          /**< (DMAC_PENDCH) Pending Channel 2 Mask */
+#define DMAC_PENDCH_PENDCH2                 DMAC_PENDCH_PENDCH2_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_PENDCH_PENDCH2_Msk instead */
+#define DMAC_PENDCH_PENDCH3_Pos             3                                              /**< (DMAC_PENDCH) Pending Channel 3 Position */
+#define DMAC_PENDCH_PENDCH3_Msk             (_U_(0x1) << DMAC_PENDCH_PENDCH3_Pos)          /**< (DMAC_PENDCH) Pending Channel 3 Mask */
+#define DMAC_PENDCH_PENDCH3                 DMAC_PENDCH_PENDCH3_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_PENDCH_PENDCH3_Msk instead */
+#define DMAC_PENDCH_PENDCH4_Pos             4                                              /**< (DMAC_PENDCH) Pending Channel 4 Position */
+#define DMAC_PENDCH_PENDCH4_Msk             (_U_(0x1) << DMAC_PENDCH_PENDCH4_Pos)          /**< (DMAC_PENDCH) Pending Channel 4 Mask */
+#define DMAC_PENDCH_PENDCH4                 DMAC_PENDCH_PENDCH4_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_PENDCH_PENDCH4_Msk instead */
+#define DMAC_PENDCH_PENDCH5_Pos             5                                              /**< (DMAC_PENDCH) Pending Channel 5 Position */
+#define DMAC_PENDCH_PENDCH5_Msk             (_U_(0x1) << DMAC_PENDCH_PENDCH5_Pos)          /**< (DMAC_PENDCH) Pending Channel 5 Mask */
+#define DMAC_PENDCH_PENDCH5                 DMAC_PENDCH_PENDCH5_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_PENDCH_PENDCH5_Msk instead */
+#define DMAC_PENDCH_PENDCH6_Pos             6                                              /**< (DMAC_PENDCH) Pending Channel 6 Position */
+#define DMAC_PENDCH_PENDCH6_Msk             (_U_(0x1) << DMAC_PENDCH_PENDCH6_Pos)          /**< (DMAC_PENDCH) Pending Channel 6 Mask */
+#define DMAC_PENDCH_PENDCH6                 DMAC_PENDCH_PENDCH6_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_PENDCH_PENDCH6_Msk instead */
+#define DMAC_PENDCH_PENDCH7_Pos             7                                              /**< (DMAC_PENDCH) Pending Channel 7 Position */
+#define DMAC_PENDCH_PENDCH7_Msk             (_U_(0x1) << DMAC_PENDCH_PENDCH7_Pos)          /**< (DMAC_PENDCH) Pending Channel 7 Mask */
+#define DMAC_PENDCH_PENDCH7                 DMAC_PENDCH_PENDCH7_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_PENDCH_PENDCH7_Msk instead */
+#define DMAC_PENDCH_MASK                    _U_(0xFF)                                      /**< \deprecated (DMAC_PENDCH) Register MASK  (Use DMAC_PENDCH_Msk instead)  */
+#define DMAC_PENDCH_Msk                     _U_(0xFF)                                      /**< (DMAC_PENDCH) Register Mask  */
+
+#define DMAC_PENDCH_PENDCH_Pos              0                                              /**< (DMAC_PENDCH Position) Pending Channel 7 */
+#define DMAC_PENDCH_PENDCH_Msk              (_U_(0xFF) << DMAC_PENDCH_PENDCH_Pos)          /**< (DMAC_PENDCH Mask) PENDCH */
+#define DMAC_PENDCH_PENDCH(value)           (DMAC_PENDCH_PENDCH_Msk & ((value) << DMAC_PENDCH_PENDCH_Pos))  
+
+/* -------- DMAC_ACTIVE : (DMAC Offset: 0x30) (R/ 32) Active Channel and Levels -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t LVLEX0:1;                  /**< bit:      0  Level 0 Channel Trigger Request Executing */
+    uint32_t LVLEX1:1;                  /**< bit:      1  Level 1 Channel Trigger Request Executing */
+    uint32_t LVLEX2:1;                  /**< bit:      2  Level 2 Channel Trigger Request Executing */
+    uint32_t LVLEX3:1;                  /**< bit:      3  Level 3 Channel Trigger Request Executing */
+    uint32_t :4;                        /**< bit:   4..7  Reserved */
+    uint32_t ID:5;                      /**< bit:  8..12  Active Channel ID                        */
+    uint32_t :2;                        /**< bit: 13..14  Reserved */
+    uint32_t ABUSY:1;                   /**< bit:     15  Active Channel Busy                      */
+    uint32_t BTCNT:16;                  /**< bit: 16..31  Active Channel Block Transfer Count      */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t LVLEX:4;                   /**< bit:   0..3  Level x Channel Trigger Request Executing */
+    uint32_t :28;                       /**< bit:  4..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} DMAC_ACTIVE_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_ACTIVE_OFFSET                  (0x30)                                        /**<  (DMAC_ACTIVE) Active Channel and Levels  Offset */
+#define DMAC_ACTIVE_RESETVALUE              _U_(0x00)                                     /**<  (DMAC_ACTIVE) Active Channel and Levels  Reset Value */
+
+#define DMAC_ACTIVE_LVLEX0_Pos              0                                              /**< (DMAC_ACTIVE) Level 0 Channel Trigger Request Executing Position */
+#define DMAC_ACTIVE_LVLEX0_Msk              (_U_(0x1) << DMAC_ACTIVE_LVLEX0_Pos)           /**< (DMAC_ACTIVE) Level 0 Channel Trigger Request Executing Mask */
+#define DMAC_ACTIVE_LVLEX0                  DMAC_ACTIVE_LVLEX0_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_ACTIVE_LVLEX0_Msk instead */
+#define DMAC_ACTIVE_LVLEX1_Pos              1                                              /**< (DMAC_ACTIVE) Level 1 Channel Trigger Request Executing Position */
+#define DMAC_ACTIVE_LVLEX1_Msk              (_U_(0x1) << DMAC_ACTIVE_LVLEX1_Pos)           /**< (DMAC_ACTIVE) Level 1 Channel Trigger Request Executing Mask */
+#define DMAC_ACTIVE_LVLEX1                  DMAC_ACTIVE_LVLEX1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_ACTIVE_LVLEX1_Msk instead */
+#define DMAC_ACTIVE_LVLEX2_Pos              2                                              /**< (DMAC_ACTIVE) Level 2 Channel Trigger Request Executing Position */
+#define DMAC_ACTIVE_LVLEX2_Msk              (_U_(0x1) << DMAC_ACTIVE_LVLEX2_Pos)           /**< (DMAC_ACTIVE) Level 2 Channel Trigger Request Executing Mask */
+#define DMAC_ACTIVE_LVLEX2                  DMAC_ACTIVE_LVLEX2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_ACTIVE_LVLEX2_Msk instead */
+#define DMAC_ACTIVE_LVLEX3_Pos              3                                              /**< (DMAC_ACTIVE) Level 3 Channel Trigger Request Executing Position */
+#define DMAC_ACTIVE_LVLEX3_Msk              (_U_(0x1) << DMAC_ACTIVE_LVLEX3_Pos)           /**< (DMAC_ACTIVE) Level 3 Channel Trigger Request Executing Mask */
+#define DMAC_ACTIVE_LVLEX3                  DMAC_ACTIVE_LVLEX3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_ACTIVE_LVLEX3_Msk instead */
+#define DMAC_ACTIVE_ID_Pos                  8                                              /**< (DMAC_ACTIVE) Active Channel ID Position */
+#define DMAC_ACTIVE_ID_Msk                  (_U_(0x1F) << DMAC_ACTIVE_ID_Pos)              /**< (DMAC_ACTIVE) Active Channel ID Mask */
+#define DMAC_ACTIVE_ID(value)               (DMAC_ACTIVE_ID_Msk & ((value) << DMAC_ACTIVE_ID_Pos))
+#define DMAC_ACTIVE_ABUSY_Pos               15                                             /**< (DMAC_ACTIVE) Active Channel Busy Position */
+#define DMAC_ACTIVE_ABUSY_Msk               (_U_(0x1) << DMAC_ACTIVE_ABUSY_Pos)            /**< (DMAC_ACTIVE) Active Channel Busy Mask */
+#define DMAC_ACTIVE_ABUSY                   DMAC_ACTIVE_ABUSY_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_ACTIVE_ABUSY_Msk instead */
+#define DMAC_ACTIVE_BTCNT_Pos               16                                             /**< (DMAC_ACTIVE) Active Channel Block Transfer Count Position */
+#define DMAC_ACTIVE_BTCNT_Msk               (_U_(0xFFFF) << DMAC_ACTIVE_BTCNT_Pos)         /**< (DMAC_ACTIVE) Active Channel Block Transfer Count Mask */
+#define DMAC_ACTIVE_BTCNT(value)            (DMAC_ACTIVE_BTCNT_Msk & ((value) << DMAC_ACTIVE_BTCNT_Pos))
+#define DMAC_ACTIVE_MASK                    _U_(0xFFFF9F0F)                                /**< \deprecated (DMAC_ACTIVE) Register MASK  (Use DMAC_ACTIVE_Msk instead)  */
+#define DMAC_ACTIVE_Msk                     _U_(0xFFFF9F0F)                                /**< (DMAC_ACTIVE) Register Mask  */
+
+#define DMAC_ACTIVE_LVLEX_Pos               0                                              /**< (DMAC_ACTIVE Position) Level x Channel Trigger Request Executing */
+#define DMAC_ACTIVE_LVLEX_Msk               (_U_(0xF) << DMAC_ACTIVE_LVLEX_Pos)            /**< (DMAC_ACTIVE Mask) LVLEX */
+#define DMAC_ACTIVE_LVLEX(value)            (DMAC_ACTIVE_LVLEX_Msk & ((value) << DMAC_ACTIVE_LVLEX_Pos))  
+
+/* -------- DMAC_BASEADDR : (DMAC Offset: 0x34) (R/W 32) Descriptor Memory Section Base Address -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t BASEADDR:32;               /**< bit:  0..31  Descriptor Memory Base Address           */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DMAC_BASEADDR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_BASEADDR_OFFSET                (0x34)                                        /**<  (DMAC_BASEADDR) Descriptor Memory Section Base Address  Offset */
+#define DMAC_BASEADDR_RESETVALUE            _U_(0x00)                                     /**<  (DMAC_BASEADDR) Descriptor Memory Section Base Address  Reset Value */
+
+#define DMAC_BASEADDR_BASEADDR_Pos          0                                              /**< (DMAC_BASEADDR) Descriptor Memory Base Address Position */
+#define DMAC_BASEADDR_BASEADDR_Msk          (_U_(0xFFFFFFFF) << DMAC_BASEADDR_BASEADDR_Pos)  /**< (DMAC_BASEADDR) Descriptor Memory Base Address Mask */
+#define DMAC_BASEADDR_BASEADDR(value)       (DMAC_BASEADDR_BASEADDR_Msk & ((value) << DMAC_BASEADDR_BASEADDR_Pos))
+#define DMAC_BASEADDR_MASK                  _U_(0xFFFFFFFF)                                /**< \deprecated (DMAC_BASEADDR) Register MASK  (Use DMAC_BASEADDR_Msk instead)  */
+#define DMAC_BASEADDR_Msk                   _U_(0xFFFFFFFF)                                /**< (DMAC_BASEADDR) Register Mask  */
+
+
+/* -------- DMAC_WRBADDR : (DMAC Offset: 0x38) (R/W 32) Write-Back Memory Section Base Address -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t WRBADDR:32;                /**< bit:  0..31  Write-Back Memory Base Address           */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DMAC_WRBADDR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_WRBADDR_OFFSET                 (0x38)                                        /**<  (DMAC_WRBADDR) Write-Back Memory Section Base Address  Offset */
+#define DMAC_WRBADDR_RESETVALUE             _U_(0x00)                                     /**<  (DMAC_WRBADDR) Write-Back Memory Section Base Address  Reset Value */
+
+#define DMAC_WRBADDR_WRBADDR_Pos            0                                              /**< (DMAC_WRBADDR) Write-Back Memory Base Address Position */
+#define DMAC_WRBADDR_WRBADDR_Msk            (_U_(0xFFFFFFFF) << DMAC_WRBADDR_WRBADDR_Pos)  /**< (DMAC_WRBADDR) Write-Back Memory Base Address Mask */
+#define DMAC_WRBADDR_WRBADDR(value)         (DMAC_WRBADDR_WRBADDR_Msk & ((value) << DMAC_WRBADDR_WRBADDR_Pos))
+#define DMAC_WRBADDR_MASK                   _U_(0xFFFFFFFF)                                /**< \deprecated (DMAC_WRBADDR) Register MASK  (Use DMAC_WRBADDR_Msk instead)  */
+#define DMAC_WRBADDR_Msk                    _U_(0xFFFFFFFF)                                /**< (DMAC_WRBADDR) Register Mask  */
+
+
+/* -------- DMAC_CHID : (DMAC Offset: 0x3f) (R/W 8) Channel ID -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  ID:3;                      /**< bit:   0..2  Channel ID                               */
+    uint8_t  :5;                        /**< bit:   3..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} DMAC_CHID_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_CHID_OFFSET                    (0x3F)                                        /**<  (DMAC_CHID) Channel ID  Offset */
+#define DMAC_CHID_RESETVALUE                _U_(0x00)                                     /**<  (DMAC_CHID) Channel ID  Reset Value */
+
+#define DMAC_CHID_ID_Pos                    0                                              /**< (DMAC_CHID) Channel ID Position */
+#define DMAC_CHID_ID_Msk                    (_U_(0x7) << DMAC_CHID_ID_Pos)                 /**< (DMAC_CHID) Channel ID Mask */
+#define DMAC_CHID_ID(value)                 (DMAC_CHID_ID_Msk & ((value) << DMAC_CHID_ID_Pos))
+#define DMAC_CHID_MASK                      _U_(0x07)                                      /**< \deprecated (DMAC_CHID) Register MASK  (Use DMAC_CHID_Msk instead)  */
+#define DMAC_CHID_Msk                       _U_(0x07)                                      /**< (DMAC_CHID) Register Mask  */
+
+
+/* -------- DMAC_CHCTRLA : (DMAC Offset: 0x40) (R/W 8) Channel Control A -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  SWRST:1;                   /**< bit:      0  Channel Software Reset                   */
+    uint8_t  ENABLE:1;                  /**< bit:      1  Channel Enable                           */
+    uint8_t  :4;                        /**< bit:   2..5  Reserved */
+    uint8_t  RUNSTDBY:1;                /**< bit:      6  Channel run in standby                   */
+    uint8_t  :1;                        /**< bit:      7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} DMAC_CHCTRLA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_CHCTRLA_OFFSET                 (0x40)                                        /**<  (DMAC_CHCTRLA) Channel Control A  Offset */
+#define DMAC_CHCTRLA_RESETVALUE             _U_(0x00)                                     /**<  (DMAC_CHCTRLA) Channel Control A  Reset Value */
+
+#define DMAC_CHCTRLA_SWRST_Pos              0                                              /**< (DMAC_CHCTRLA) Channel Software Reset Position */
+#define DMAC_CHCTRLA_SWRST_Msk              (_U_(0x1) << DMAC_CHCTRLA_SWRST_Pos)           /**< (DMAC_CHCTRLA) Channel Software Reset Mask */
+#define DMAC_CHCTRLA_SWRST                  DMAC_CHCTRLA_SWRST_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CHCTRLA_SWRST_Msk instead */
+#define DMAC_CHCTRLA_ENABLE_Pos             1                                              /**< (DMAC_CHCTRLA) Channel Enable Position */
+#define DMAC_CHCTRLA_ENABLE_Msk             (_U_(0x1) << DMAC_CHCTRLA_ENABLE_Pos)          /**< (DMAC_CHCTRLA) Channel Enable Mask */
+#define DMAC_CHCTRLA_ENABLE                 DMAC_CHCTRLA_ENABLE_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CHCTRLA_ENABLE_Msk instead */
+#define DMAC_CHCTRLA_RUNSTDBY_Pos           6                                              /**< (DMAC_CHCTRLA) Channel run in standby Position */
+#define DMAC_CHCTRLA_RUNSTDBY_Msk           (_U_(0x1) << DMAC_CHCTRLA_RUNSTDBY_Pos)        /**< (DMAC_CHCTRLA) Channel run in standby Mask */
+#define DMAC_CHCTRLA_RUNSTDBY               DMAC_CHCTRLA_RUNSTDBY_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CHCTRLA_RUNSTDBY_Msk instead */
+#define DMAC_CHCTRLA_MASK                   _U_(0x43)                                      /**< \deprecated (DMAC_CHCTRLA) Register MASK  (Use DMAC_CHCTRLA_Msk instead)  */
+#define DMAC_CHCTRLA_Msk                    _U_(0x43)                                      /**< (DMAC_CHCTRLA) Register Mask  */
+
+
+/* -------- DMAC_CHCTRLB : (DMAC Offset: 0x44) (R/W 32) Channel Control B -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t EVACT:3;                   /**< bit:   0..2  Event Input Action                       */
+    uint32_t EVIE:1;                    /**< bit:      3  Channel Event Input Enable               */
+    uint32_t EVOE:1;                    /**< bit:      4  Channel Event Output Enable              */
+    uint32_t LVL:2;                     /**< bit:   5..6  Channel Arbitration Level                */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t TRIGSRC:5;                 /**< bit:  8..12  Trigger Source                           */
+    uint32_t :9;                        /**< bit: 13..21  Reserved */
+    uint32_t TRIGACT:2;                 /**< bit: 22..23  Trigger Action                           */
+    uint32_t CMD:2;                     /**< bit: 24..25  Software Command                         */
+    uint32_t :6;                        /**< bit: 26..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DMAC_CHCTRLB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_CHCTRLB_OFFSET                 (0x44)                                        /**<  (DMAC_CHCTRLB) Channel Control B  Offset */
+#define DMAC_CHCTRLB_RESETVALUE             _U_(0x00)                                     /**<  (DMAC_CHCTRLB) Channel Control B  Reset Value */
+
+#define DMAC_CHCTRLB_EVACT_Pos              0                                              /**< (DMAC_CHCTRLB) Event Input Action Position */
+#define DMAC_CHCTRLB_EVACT_Msk              (_U_(0x7) << DMAC_CHCTRLB_EVACT_Pos)           /**< (DMAC_CHCTRLB) Event Input Action Mask */
+#define DMAC_CHCTRLB_EVACT(value)           (DMAC_CHCTRLB_EVACT_Msk & ((value) << DMAC_CHCTRLB_EVACT_Pos))
+#define   DMAC_CHCTRLB_EVACT_NOACT_Val      _U_(0x0)                                       /**< (DMAC_CHCTRLB) No action  */
+#define   DMAC_CHCTRLB_EVACT_TRIG_Val       _U_(0x1)                                       /**< (DMAC_CHCTRLB) Transfer and periodic transfer trigger  */
+#define   DMAC_CHCTRLB_EVACT_CTRIG_Val      _U_(0x2)                                       /**< (DMAC_CHCTRLB) Conditional transfer trigger  */
+#define   DMAC_CHCTRLB_EVACT_CBLOCK_Val     _U_(0x3)                                       /**< (DMAC_CHCTRLB) Conditional block transfer  */
+#define   DMAC_CHCTRLB_EVACT_SUSPEND_Val    _U_(0x4)                                       /**< (DMAC_CHCTRLB) Channel suspend operation  */
+#define   DMAC_CHCTRLB_EVACT_RESUME_Val     _U_(0x5)                                       /**< (DMAC_CHCTRLB) Channel resume operation  */
+#define   DMAC_CHCTRLB_EVACT_SSKIP_Val      _U_(0x6)                                       /**< (DMAC_CHCTRLB) Skip next block suspend action  */
+#define DMAC_CHCTRLB_EVACT_NOACT            (DMAC_CHCTRLB_EVACT_NOACT_Val << DMAC_CHCTRLB_EVACT_Pos)  /**< (DMAC_CHCTRLB) No action Position  */
+#define DMAC_CHCTRLB_EVACT_TRIG             (DMAC_CHCTRLB_EVACT_TRIG_Val << DMAC_CHCTRLB_EVACT_Pos)  /**< (DMAC_CHCTRLB) Transfer and periodic transfer trigger Position  */
+#define DMAC_CHCTRLB_EVACT_CTRIG            (DMAC_CHCTRLB_EVACT_CTRIG_Val << DMAC_CHCTRLB_EVACT_Pos)  /**< (DMAC_CHCTRLB) Conditional transfer trigger Position  */
+#define DMAC_CHCTRLB_EVACT_CBLOCK           (DMAC_CHCTRLB_EVACT_CBLOCK_Val << DMAC_CHCTRLB_EVACT_Pos)  /**< (DMAC_CHCTRLB) Conditional block transfer Position  */
+#define DMAC_CHCTRLB_EVACT_SUSPEND          (DMAC_CHCTRLB_EVACT_SUSPEND_Val << DMAC_CHCTRLB_EVACT_Pos)  /**< (DMAC_CHCTRLB) Channel suspend operation Position  */
+#define DMAC_CHCTRLB_EVACT_RESUME           (DMAC_CHCTRLB_EVACT_RESUME_Val << DMAC_CHCTRLB_EVACT_Pos)  /**< (DMAC_CHCTRLB) Channel resume operation Position  */
+#define DMAC_CHCTRLB_EVACT_SSKIP            (DMAC_CHCTRLB_EVACT_SSKIP_Val << DMAC_CHCTRLB_EVACT_Pos)  /**< (DMAC_CHCTRLB) Skip next block suspend action Position  */
+#define DMAC_CHCTRLB_EVIE_Pos               3                                              /**< (DMAC_CHCTRLB) Channel Event Input Enable Position */
+#define DMAC_CHCTRLB_EVIE_Msk               (_U_(0x1) << DMAC_CHCTRLB_EVIE_Pos)            /**< (DMAC_CHCTRLB) Channel Event Input Enable Mask */
+#define DMAC_CHCTRLB_EVIE                   DMAC_CHCTRLB_EVIE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CHCTRLB_EVIE_Msk instead */
+#define DMAC_CHCTRLB_EVOE_Pos               4                                              /**< (DMAC_CHCTRLB) Channel Event Output Enable Position */
+#define DMAC_CHCTRLB_EVOE_Msk               (_U_(0x1) << DMAC_CHCTRLB_EVOE_Pos)            /**< (DMAC_CHCTRLB) Channel Event Output Enable Mask */
+#define DMAC_CHCTRLB_EVOE                   DMAC_CHCTRLB_EVOE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CHCTRLB_EVOE_Msk instead */
+#define DMAC_CHCTRLB_LVL_Pos                5                                              /**< (DMAC_CHCTRLB) Channel Arbitration Level Position */
+#define DMAC_CHCTRLB_LVL_Msk                (_U_(0x3) << DMAC_CHCTRLB_LVL_Pos)             /**< (DMAC_CHCTRLB) Channel Arbitration Level Mask */
+#define DMAC_CHCTRLB_LVL(value)             (DMAC_CHCTRLB_LVL_Msk & ((value) << DMAC_CHCTRLB_LVL_Pos))
+#define DMAC_CHCTRLB_TRIGSRC_Pos            8                                              /**< (DMAC_CHCTRLB) Trigger Source Position */
+#define DMAC_CHCTRLB_TRIGSRC_Msk            (_U_(0x1F) << DMAC_CHCTRLB_TRIGSRC_Pos)        /**< (DMAC_CHCTRLB) Trigger Source Mask */
+#define DMAC_CHCTRLB_TRIGSRC(value)         (DMAC_CHCTRLB_TRIGSRC_Msk & ((value) << DMAC_CHCTRLB_TRIGSRC_Pos))
+#define   DMAC_CHCTRLB_TRIGSRC_DISABLE_Val  _U_(0x0)                                       /**< (DMAC_CHCTRLB) Only software/event triggers  */
+#define DMAC_CHCTRLB_TRIGSRC_DISABLE        (DMAC_CHCTRLB_TRIGSRC_DISABLE_Val << DMAC_CHCTRLB_TRIGSRC_Pos)  /**< (DMAC_CHCTRLB) Only software/event triggers Position  */
+#define DMAC_CHCTRLB_TRIGACT_Pos            22                                             /**< (DMAC_CHCTRLB) Trigger Action Position */
+#define DMAC_CHCTRLB_TRIGACT_Msk            (_U_(0x3) << DMAC_CHCTRLB_TRIGACT_Pos)         /**< (DMAC_CHCTRLB) Trigger Action Mask */
+#define DMAC_CHCTRLB_TRIGACT(value)         (DMAC_CHCTRLB_TRIGACT_Msk & ((value) << DMAC_CHCTRLB_TRIGACT_Pos))
+#define   DMAC_CHCTRLB_TRIGACT_BLOCK_Val    _U_(0x0)                                       /**< (DMAC_CHCTRLB) One trigger required for each block transfer  */
+#define   DMAC_CHCTRLB_TRIGACT_BEAT_Val     _U_(0x2)                                       /**< (DMAC_CHCTRLB) One trigger required for each beat transfer  */
+#define   DMAC_CHCTRLB_TRIGACT_TRANSACTION_Val _U_(0x3)                                       /**< (DMAC_CHCTRLB) One trigger required for each transaction  */
+#define DMAC_CHCTRLB_TRIGACT_BLOCK          (DMAC_CHCTRLB_TRIGACT_BLOCK_Val << DMAC_CHCTRLB_TRIGACT_Pos)  /**< (DMAC_CHCTRLB) One trigger required for each block transfer Position  */
+#define DMAC_CHCTRLB_TRIGACT_BEAT           (DMAC_CHCTRLB_TRIGACT_BEAT_Val << DMAC_CHCTRLB_TRIGACT_Pos)  /**< (DMAC_CHCTRLB) One trigger required for each beat transfer Position  */
+#define DMAC_CHCTRLB_TRIGACT_TRANSACTION    (DMAC_CHCTRLB_TRIGACT_TRANSACTION_Val << DMAC_CHCTRLB_TRIGACT_Pos)  /**< (DMAC_CHCTRLB) One trigger required for each transaction Position  */
+#define DMAC_CHCTRLB_CMD_Pos                24                                             /**< (DMAC_CHCTRLB) Software Command Position */
+#define DMAC_CHCTRLB_CMD_Msk                (_U_(0x3) << DMAC_CHCTRLB_CMD_Pos)             /**< (DMAC_CHCTRLB) Software Command Mask */
+#define DMAC_CHCTRLB_CMD(value)             (DMAC_CHCTRLB_CMD_Msk & ((value) << DMAC_CHCTRLB_CMD_Pos))
+#define   DMAC_CHCTRLB_CMD_NOACT_Val        _U_(0x0)                                       /**< (DMAC_CHCTRLB) No action  */
+#define   DMAC_CHCTRLB_CMD_SUSPEND_Val      _U_(0x1)                                       /**< (DMAC_CHCTRLB) Channel suspend operation  */
+#define   DMAC_CHCTRLB_CMD_RESUME_Val       _U_(0x2)                                       /**< (DMAC_CHCTRLB) Channel resume operation  */
+#define DMAC_CHCTRLB_CMD_NOACT              (DMAC_CHCTRLB_CMD_NOACT_Val << DMAC_CHCTRLB_CMD_Pos)  /**< (DMAC_CHCTRLB) No action Position  */
+#define DMAC_CHCTRLB_CMD_SUSPEND            (DMAC_CHCTRLB_CMD_SUSPEND_Val << DMAC_CHCTRLB_CMD_Pos)  /**< (DMAC_CHCTRLB) Channel suspend operation Position  */
+#define DMAC_CHCTRLB_CMD_RESUME             (DMAC_CHCTRLB_CMD_RESUME_Val << DMAC_CHCTRLB_CMD_Pos)  /**< (DMAC_CHCTRLB) Channel resume operation Position  */
+#define DMAC_CHCTRLB_MASK                   _U_(0x3C01F7F)                                 /**< \deprecated (DMAC_CHCTRLB) Register MASK  (Use DMAC_CHCTRLB_Msk instead)  */
+#define DMAC_CHCTRLB_Msk                    _U_(0x3C01F7F)                                 /**< (DMAC_CHCTRLB) Register Mask  */
+
+
+/* -------- DMAC_CHINTENCLR : (DMAC Offset: 0x4c) (R/W 8) Channel Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  TERR:1;                    /**< bit:      0  Channel Transfer Error Interrupt Enable  */
+    uint8_t  TCMPL:1;                   /**< bit:      1  Channel Transfer Complete Interrupt Enable */
+    uint8_t  SUSP:1;                    /**< bit:      2  Channel Suspend Interrupt Enable         */
+    uint8_t  :5;                        /**< bit:   3..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} DMAC_CHINTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_CHINTENCLR_OFFSET              (0x4C)                                        /**<  (DMAC_CHINTENCLR) Channel Interrupt Enable Clear  Offset */
+#define DMAC_CHINTENCLR_RESETVALUE          _U_(0x00)                                     /**<  (DMAC_CHINTENCLR) Channel Interrupt Enable Clear  Reset Value */
+
+#define DMAC_CHINTENCLR_TERR_Pos            0                                              /**< (DMAC_CHINTENCLR) Channel Transfer Error Interrupt Enable Position */
+#define DMAC_CHINTENCLR_TERR_Msk            (_U_(0x1) << DMAC_CHINTENCLR_TERR_Pos)         /**< (DMAC_CHINTENCLR) Channel Transfer Error Interrupt Enable Mask */
+#define DMAC_CHINTENCLR_TERR                DMAC_CHINTENCLR_TERR_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CHINTENCLR_TERR_Msk instead */
+#define DMAC_CHINTENCLR_TCMPL_Pos           1                                              /**< (DMAC_CHINTENCLR) Channel Transfer Complete Interrupt Enable Position */
+#define DMAC_CHINTENCLR_TCMPL_Msk           (_U_(0x1) << DMAC_CHINTENCLR_TCMPL_Pos)        /**< (DMAC_CHINTENCLR) Channel Transfer Complete Interrupt Enable Mask */
+#define DMAC_CHINTENCLR_TCMPL               DMAC_CHINTENCLR_TCMPL_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CHINTENCLR_TCMPL_Msk instead */
+#define DMAC_CHINTENCLR_SUSP_Pos            2                                              /**< (DMAC_CHINTENCLR) Channel Suspend Interrupt Enable Position */
+#define DMAC_CHINTENCLR_SUSP_Msk            (_U_(0x1) << DMAC_CHINTENCLR_SUSP_Pos)         /**< (DMAC_CHINTENCLR) Channel Suspend Interrupt Enable Mask */
+#define DMAC_CHINTENCLR_SUSP                DMAC_CHINTENCLR_SUSP_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CHINTENCLR_SUSP_Msk instead */
+#define DMAC_CHINTENCLR_MASK                _U_(0x07)                                      /**< \deprecated (DMAC_CHINTENCLR) Register MASK  (Use DMAC_CHINTENCLR_Msk instead)  */
+#define DMAC_CHINTENCLR_Msk                 _U_(0x07)                                      /**< (DMAC_CHINTENCLR) Register Mask  */
+
+
+/* -------- DMAC_CHINTENSET : (DMAC Offset: 0x4d) (R/W 8) Channel Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  TERR:1;                    /**< bit:      0  Channel Transfer Error Interrupt Enable  */
+    uint8_t  TCMPL:1;                   /**< bit:      1  Channel Transfer Complete Interrupt Enable */
+    uint8_t  SUSP:1;                    /**< bit:      2  Channel Suspend Interrupt Enable         */
+    uint8_t  :5;                        /**< bit:   3..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} DMAC_CHINTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_CHINTENSET_OFFSET              (0x4D)                                        /**<  (DMAC_CHINTENSET) Channel Interrupt Enable Set  Offset */
+#define DMAC_CHINTENSET_RESETVALUE          _U_(0x00)                                     /**<  (DMAC_CHINTENSET) Channel Interrupt Enable Set  Reset Value */
+
+#define DMAC_CHINTENSET_TERR_Pos            0                                              /**< (DMAC_CHINTENSET) Channel Transfer Error Interrupt Enable Position */
+#define DMAC_CHINTENSET_TERR_Msk            (_U_(0x1) << DMAC_CHINTENSET_TERR_Pos)         /**< (DMAC_CHINTENSET) Channel Transfer Error Interrupt Enable Mask */
+#define DMAC_CHINTENSET_TERR                DMAC_CHINTENSET_TERR_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CHINTENSET_TERR_Msk instead */
+#define DMAC_CHINTENSET_TCMPL_Pos           1                                              /**< (DMAC_CHINTENSET) Channel Transfer Complete Interrupt Enable Position */
+#define DMAC_CHINTENSET_TCMPL_Msk           (_U_(0x1) << DMAC_CHINTENSET_TCMPL_Pos)        /**< (DMAC_CHINTENSET) Channel Transfer Complete Interrupt Enable Mask */
+#define DMAC_CHINTENSET_TCMPL               DMAC_CHINTENSET_TCMPL_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CHINTENSET_TCMPL_Msk instead */
+#define DMAC_CHINTENSET_SUSP_Pos            2                                              /**< (DMAC_CHINTENSET) Channel Suspend Interrupt Enable Position */
+#define DMAC_CHINTENSET_SUSP_Msk            (_U_(0x1) << DMAC_CHINTENSET_SUSP_Pos)         /**< (DMAC_CHINTENSET) Channel Suspend Interrupt Enable Mask */
+#define DMAC_CHINTENSET_SUSP                DMAC_CHINTENSET_SUSP_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CHINTENSET_SUSP_Msk instead */
+#define DMAC_CHINTENSET_MASK                _U_(0x07)                                      /**< \deprecated (DMAC_CHINTENSET) Register MASK  (Use DMAC_CHINTENSET_Msk instead)  */
+#define DMAC_CHINTENSET_Msk                 _U_(0x07)                                      /**< (DMAC_CHINTENSET) Register Mask  */
+
+
+/* -------- DMAC_CHINTFLAG : (DMAC Offset: 0x4e) (R/W 8) Channel Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t TERR:1;                    /**< bit:      0  Channel Transfer Error                   */
+    __I uint8_t TCMPL:1;                   /**< bit:      1  Channel Transfer Complete                */
+    __I uint8_t SUSP:1;                    /**< bit:      2  Channel Suspend                          */
+    __I uint8_t :5;                        /**< bit:   3..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} DMAC_CHINTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_CHINTFLAG_OFFSET               (0x4E)                                        /**<  (DMAC_CHINTFLAG) Channel Interrupt Flag Status and Clear  Offset */
+#define DMAC_CHINTFLAG_RESETVALUE           _U_(0x00)                                     /**<  (DMAC_CHINTFLAG) Channel Interrupt Flag Status and Clear  Reset Value */
+
+#define DMAC_CHINTFLAG_TERR_Pos             0                                              /**< (DMAC_CHINTFLAG) Channel Transfer Error Position */
+#define DMAC_CHINTFLAG_TERR_Msk             (_U_(0x1) << DMAC_CHINTFLAG_TERR_Pos)          /**< (DMAC_CHINTFLAG) Channel Transfer Error Mask */
+#define DMAC_CHINTFLAG_TERR                 DMAC_CHINTFLAG_TERR_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CHINTFLAG_TERR_Msk instead */
+#define DMAC_CHINTFLAG_TCMPL_Pos            1                                              /**< (DMAC_CHINTFLAG) Channel Transfer Complete Position */
+#define DMAC_CHINTFLAG_TCMPL_Msk            (_U_(0x1) << DMAC_CHINTFLAG_TCMPL_Pos)         /**< (DMAC_CHINTFLAG) Channel Transfer Complete Mask */
+#define DMAC_CHINTFLAG_TCMPL                DMAC_CHINTFLAG_TCMPL_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CHINTFLAG_TCMPL_Msk instead */
+#define DMAC_CHINTFLAG_SUSP_Pos             2                                              /**< (DMAC_CHINTFLAG) Channel Suspend Position */
+#define DMAC_CHINTFLAG_SUSP_Msk             (_U_(0x1) << DMAC_CHINTFLAG_SUSP_Pos)          /**< (DMAC_CHINTFLAG) Channel Suspend Mask */
+#define DMAC_CHINTFLAG_SUSP                 DMAC_CHINTFLAG_SUSP_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CHINTFLAG_SUSP_Msk instead */
+#define DMAC_CHINTFLAG_MASK                 _U_(0x07)                                      /**< \deprecated (DMAC_CHINTFLAG) Register MASK  (Use DMAC_CHINTFLAG_Msk instead)  */
+#define DMAC_CHINTFLAG_Msk                  _U_(0x07)                                      /**< (DMAC_CHINTFLAG) Register Mask  */
+
+
+/* -------- DMAC_CHSTATUS : (DMAC Offset: 0x4f) (R/ 8) Channel Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  PEND:1;                    /**< bit:      0  Channel Pending                          */
+    uint8_t  BUSY:1;                    /**< bit:      1  Channel Busy                             */
+    uint8_t  FERR:1;                    /**< bit:      2  Channel Fetch Error                      */
+    uint8_t  :5;                        /**< bit:   3..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} DMAC_CHSTATUS_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_CHSTATUS_OFFSET                (0x4F)                                        /**<  (DMAC_CHSTATUS) Channel Status  Offset */
+#define DMAC_CHSTATUS_RESETVALUE            _U_(0x00)                                     /**<  (DMAC_CHSTATUS) Channel Status  Reset Value */
+
+#define DMAC_CHSTATUS_PEND_Pos              0                                              /**< (DMAC_CHSTATUS) Channel Pending Position */
+#define DMAC_CHSTATUS_PEND_Msk              (_U_(0x1) << DMAC_CHSTATUS_PEND_Pos)           /**< (DMAC_CHSTATUS) Channel Pending Mask */
+#define DMAC_CHSTATUS_PEND                  DMAC_CHSTATUS_PEND_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CHSTATUS_PEND_Msk instead */
+#define DMAC_CHSTATUS_BUSY_Pos              1                                              /**< (DMAC_CHSTATUS) Channel Busy Position */
+#define DMAC_CHSTATUS_BUSY_Msk              (_U_(0x1) << DMAC_CHSTATUS_BUSY_Pos)           /**< (DMAC_CHSTATUS) Channel Busy Mask */
+#define DMAC_CHSTATUS_BUSY                  DMAC_CHSTATUS_BUSY_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CHSTATUS_BUSY_Msk instead */
+#define DMAC_CHSTATUS_FERR_Pos              2                                              /**< (DMAC_CHSTATUS) Channel Fetch Error Position */
+#define DMAC_CHSTATUS_FERR_Msk              (_U_(0x1) << DMAC_CHSTATUS_FERR_Pos)           /**< (DMAC_CHSTATUS) Channel Fetch Error Mask */
+#define DMAC_CHSTATUS_FERR                  DMAC_CHSTATUS_FERR_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use DMAC_CHSTATUS_FERR_Msk instead */
+#define DMAC_CHSTATUS_MASK                  _U_(0x07)                                      /**< \deprecated (DMAC_CHSTATUS) Register MASK  (Use DMAC_CHSTATUS_Msk instead)  */
+#define DMAC_CHSTATUS_Msk                   _U_(0x07)                                      /**< (DMAC_CHSTATUS) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief DMAC_DESCRIPTOR hardware registers */
+typedef struct {  /* Direct Memory Access Controller */
+  __IO DMAC_BTCTRL_Type               BTCTRL;         /**< Offset: 0x00 (R/W  16) Block Transfer Control */
+  __IO DMAC_BTCNT_Type                BTCNT;          /**< Offset: 0x02 (R/W  16) Block Transfer Count */
+  __IO DMAC_SRCADDR_Type              SRCADDR;        /**< Offset: 0x04 (R/W  32) Block Transfer Source Address */
+  __IO DMAC_DSTADDR_Type              DSTADDR;        /**< Offset: 0x08 (R/W  32) Block Transfer Destination Address */
+  __IO DMAC_DESCADDR_Type             DESCADDR;       /**< Offset: 0x0C (R/W  32) Next Descriptor Address */
+} DmacDescriptor
+#ifdef __GNUC__
+  __attribute__ ((aligned (8)))
+#endif
+;
+
+/** \brief DMAC hardware registers */
+typedef struct {  /* Direct Memory Access Controller */
+  __IO DMAC_CTRL_Type                 CTRL;           /**< Offset: 0x00 (R/W  16) Control */
+  __IO DMAC_CRCCTRL_Type              CRCCTRL;        /**< Offset: 0x02 (R/W  16) CRC Control */
+  __IO DMAC_CRCDATAIN_Type            CRCDATAIN;      /**< Offset: 0x04 (R/W  32) CRC Data Input */
+  __IO DMAC_CRCCHKSUM_Type            CRCCHKSUM;      /**< Offset: 0x08 (R/W  32) CRC Checksum */
+  __IO DMAC_CRCSTATUS_Type            CRCSTATUS;      /**< Offset: 0x0C (R/W   8) CRC Status */
+  __IO DMAC_DBGCTRL_Type              DBGCTRL;        /**< Offset: 0x0D (R/W   8) Debug Control */
+  __IO DMAC_QOSCTRL_Type              QOSCTRL;        /**< Offset: 0x0E (R/W   8) QOS Control */
+  __I  uint8_t                        Reserved1[1];
+  __IO DMAC_SWTRIGCTRL_Type           SWTRIGCTRL;     /**< Offset: 0x10 (R/W  32) Software Trigger Control */
+  __IO DMAC_PRICTRL0_Type             PRICTRL0;       /**< Offset: 0x14 (R/W  32) Priority Control 0 */
+  __I  uint8_t                        Reserved2[8];
+  __IO DMAC_INTPEND_Type              INTPEND;        /**< Offset: 0x20 (R/W  16) Interrupt Pending */
+  __I  uint8_t                        Reserved3[2];
+  __I  DMAC_INTSTATUS_Type            INTSTATUS;      /**< Offset: 0x24 (R/   32) Interrupt Status */
+  __I  DMAC_BUSYCH_Type               BUSYCH;         /**< Offset: 0x28 (R/   32) Busy Channels */
+  __I  DMAC_PENDCH_Type               PENDCH;         /**< Offset: 0x2C (R/   32) Pending Channels */
+  __I  DMAC_ACTIVE_Type               ACTIVE;         /**< Offset: 0x30 (R/   32) Active Channel and Levels */
+  __IO DMAC_BASEADDR_Type             BASEADDR;       /**< Offset: 0x34 (R/W  32) Descriptor Memory Section Base Address */
+  __IO DMAC_WRBADDR_Type              WRBADDR;        /**< Offset: 0x38 (R/W  32) Write-Back Memory Section Base Address */
+  __I  uint8_t                        Reserved4[3];
+  __IO DMAC_CHID_Type                 CHID;           /**< Offset: 0x3F (R/W   8) Channel ID */
+  __IO DMAC_CHCTRLA_Type              CHCTRLA;        /**< Offset: 0x40 (R/W   8) Channel Control A */
+  __I  uint8_t                        Reserved5[3];
+  __IO DMAC_CHCTRLB_Type              CHCTRLB;        /**< Offset: 0x44 (R/W  32) Channel Control B */
+  __I  uint8_t                        Reserved6[4];
+  __IO DMAC_CHINTENCLR_Type           CHINTENCLR;     /**< Offset: 0x4C (R/W   8) Channel Interrupt Enable Clear */
+  __IO DMAC_CHINTENSET_Type           CHINTENSET;     /**< Offset: 0x4D (R/W   8) Channel Interrupt Enable Set */
+  __IO DMAC_CHINTFLAG_Type            CHINTFLAG;      /**< Offset: 0x4E (R/W   8) Channel Interrupt Flag Status and Clear */
+  __I  DMAC_CHSTATUS_Type             CHSTATUS;       /**< Offset: 0x4F (R/    8) Channel Status */
+} Dmac;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** \brief DMAC_DESCRIPTOR memory section attribute */
+#define SECTION_DMAC_DESCRIPTOR
+
+/** @}  end of Direct Memory Access Controller */
+
+#endif /* _SAML11_DMAC_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/component/dsu.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/dsu.h
@@ -1,0 +1,785 @@
+/**
+ * \file
+ *
+ * \brief Component description for DSU
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_DSU_COMPONENT_H_
+#define _SAML11_DSU_COMPONENT_H_
+#define _SAML11_DSU_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML11 Device Service Unit
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR DSU */
+/* ========================================================================== */
+
+#define DSU_U2810                      /**< (DSU) Module ID */
+#define REV_DSU 0x100                  /**< (DSU) Module revision */
+
+/* -------- DSU_CTRL : (DSU Offset: 0x00) (/W 8) Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint8_t  :1;                        /**< bit:      1  Reserved */
+    uint8_t  CRC:1;                     /**< bit:      2  32-bit Cyclic Redundancy Code            */
+    uint8_t  MBIST:1;                   /**< bit:      3  Memory built-in self-test                */
+    uint8_t  :4;                        /**< bit:   4..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} DSU_CTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_CTRL_OFFSET                     (0x00)                                        /**<  (DSU_CTRL) Control  Offset */
+#define DSU_CTRL_RESETVALUE                 _U_(0x00)                                     /**<  (DSU_CTRL) Control  Reset Value */
+
+#define DSU_CTRL_SWRST_Pos                  0                                              /**< (DSU_CTRL) Software Reset Position */
+#define DSU_CTRL_SWRST_Msk                  (_U_(0x1) << DSU_CTRL_SWRST_Pos)               /**< (DSU_CTRL) Software Reset Mask */
+#define DSU_CTRL_SWRST                      DSU_CTRL_SWRST_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use DSU_CTRL_SWRST_Msk instead */
+#define DSU_CTRL_CRC_Pos                    2                                              /**< (DSU_CTRL) 32-bit Cyclic Redundancy Code Position */
+#define DSU_CTRL_CRC_Msk                    (_U_(0x1) << DSU_CTRL_CRC_Pos)                 /**< (DSU_CTRL) 32-bit Cyclic Redundancy Code Mask */
+#define DSU_CTRL_CRC                        DSU_CTRL_CRC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use DSU_CTRL_CRC_Msk instead */
+#define DSU_CTRL_MBIST_Pos                  3                                              /**< (DSU_CTRL) Memory built-in self-test Position */
+#define DSU_CTRL_MBIST_Msk                  (_U_(0x1) << DSU_CTRL_MBIST_Pos)               /**< (DSU_CTRL) Memory built-in self-test Mask */
+#define DSU_CTRL_MBIST                      DSU_CTRL_MBIST_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use DSU_CTRL_MBIST_Msk instead */
+#define DSU_CTRL_MASK                       _U_(0x0D)                                      /**< \deprecated (DSU_CTRL) Register MASK  (Use DSU_CTRL_Msk instead)  */
+#define DSU_CTRL_Msk                        _U_(0x0D)                                      /**< (DSU_CTRL) Register Mask  */
+
+
+/* -------- DSU_STATUSA : (DSU Offset: 0x01) (R/W 8) Status A -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DONE:1;                    /**< bit:      0  Done                                     */
+    uint8_t  CRSTEXT:1;                 /**< bit:      1  CPU Reset Phase Extension                */
+    uint8_t  BERR:1;                    /**< bit:      2  Bus Error                                */
+    uint8_t  FAIL:1;                    /**< bit:      3  Failure                                  */
+    uint8_t  PERR:1;                    /**< bit:      4  Protection Error Detected by the State Machine */
+    uint8_t  BREXT:1;                   /**< bit:      5  BootRom Phase Extension                  */
+    uint8_t  :2;                        /**< bit:   6..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} DSU_STATUSA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_STATUSA_OFFSET                  (0x01)                                        /**<  (DSU_STATUSA) Status A  Offset */
+#define DSU_STATUSA_RESETVALUE              _U_(0x00)                                     /**<  (DSU_STATUSA) Status A  Reset Value */
+
+#define DSU_STATUSA_DONE_Pos                0                                              /**< (DSU_STATUSA) Done Position */
+#define DSU_STATUSA_DONE_Msk                (_U_(0x1) << DSU_STATUSA_DONE_Pos)             /**< (DSU_STATUSA) Done Mask */
+#define DSU_STATUSA_DONE                    DSU_STATUSA_DONE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use DSU_STATUSA_DONE_Msk instead */
+#define DSU_STATUSA_CRSTEXT_Pos             1                                              /**< (DSU_STATUSA) CPU Reset Phase Extension Position */
+#define DSU_STATUSA_CRSTEXT_Msk             (_U_(0x1) << DSU_STATUSA_CRSTEXT_Pos)          /**< (DSU_STATUSA) CPU Reset Phase Extension Mask */
+#define DSU_STATUSA_CRSTEXT                 DSU_STATUSA_CRSTEXT_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DSU_STATUSA_CRSTEXT_Msk instead */
+#define DSU_STATUSA_BERR_Pos                2                                              /**< (DSU_STATUSA) Bus Error Position */
+#define DSU_STATUSA_BERR_Msk                (_U_(0x1) << DSU_STATUSA_BERR_Pos)             /**< (DSU_STATUSA) Bus Error Mask */
+#define DSU_STATUSA_BERR                    DSU_STATUSA_BERR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use DSU_STATUSA_BERR_Msk instead */
+#define DSU_STATUSA_FAIL_Pos                3                                              /**< (DSU_STATUSA) Failure Position */
+#define DSU_STATUSA_FAIL_Msk                (_U_(0x1) << DSU_STATUSA_FAIL_Pos)             /**< (DSU_STATUSA) Failure Mask */
+#define DSU_STATUSA_FAIL                    DSU_STATUSA_FAIL_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use DSU_STATUSA_FAIL_Msk instead */
+#define DSU_STATUSA_PERR_Pos                4                                              /**< (DSU_STATUSA) Protection Error Detected by the State Machine Position */
+#define DSU_STATUSA_PERR_Msk                (_U_(0x1) << DSU_STATUSA_PERR_Pos)             /**< (DSU_STATUSA) Protection Error Detected by the State Machine Mask */
+#define DSU_STATUSA_PERR                    DSU_STATUSA_PERR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use DSU_STATUSA_PERR_Msk instead */
+#define DSU_STATUSA_BREXT_Pos               5                                              /**< (DSU_STATUSA) BootRom Phase Extension Position */
+#define DSU_STATUSA_BREXT_Msk               (_U_(0x1) << DSU_STATUSA_BREXT_Pos)            /**< (DSU_STATUSA) BootRom Phase Extension Mask */
+#define DSU_STATUSA_BREXT                   DSU_STATUSA_BREXT_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use DSU_STATUSA_BREXT_Msk instead */
+#define DSU_STATUSA_MASK                    _U_(0x3F)                                      /**< \deprecated (DSU_STATUSA) Register MASK  (Use DSU_STATUSA_Msk instead)  */
+#define DSU_STATUSA_Msk                     _U_(0x3F)                                      /**< (DSU_STATUSA) Register Mask  */
+
+
+/* -------- DSU_STATUSB : (DSU Offset: 0x02) (R/ 8) Status B -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DAL:2;                     /**< bit:   0..1  Debugger Access Level                    */
+    uint8_t  DBGPRES:1;                 /**< bit:      2  Debugger Present                         */
+    uint8_t  HPE:1;                     /**< bit:      3  Hot-Plugging Enable                      */
+    uint8_t  DCCD0:1;                   /**< bit:      4  Debug Communication Channel 0 Dirty      */
+    uint8_t  DCCD1:1;                   /**< bit:      5  Debug Communication Channel 1 Dirty      */
+    uint8_t  BCCD0:1;                   /**< bit:      6  Boot ROM Communication Channel 0 Dirty   */
+    uint8_t  BCCD1:1;                   /**< bit:      7  Boot ROM Communication Channel 1 Dirty   */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint8_t  :4;                        /**< bit:   0..3  Reserved */
+    uint8_t  DCCD:2;                    /**< bit:   4..5  Debug Communication Channel x Dirty      */
+    uint8_t  BCCD:2;                    /**< bit:   6..7  Boot ROM Communication Channel x Dirty   */
+  } vec;                                /**< Structure used for vec  access  */
+  uint8_t  reg;                         /**< Type used for register access */
+} DSU_STATUSB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_STATUSB_OFFSET                  (0x02)                                        /**<  (DSU_STATUSB) Status B  Offset */
+#define DSU_STATUSB_RESETVALUE              _U_(0x00)                                     /**<  (DSU_STATUSB) Status B  Reset Value */
+
+#define DSU_STATUSB_DAL_Pos                 0                                              /**< (DSU_STATUSB) Debugger Access Level Position */
+#define DSU_STATUSB_DAL_Msk                 (_U_(0x3) << DSU_STATUSB_DAL_Pos)              /**< (DSU_STATUSB) Debugger Access Level Mask */
+#define DSU_STATUSB_DAL(value)              (DSU_STATUSB_DAL_Msk & ((value) << DSU_STATUSB_DAL_Pos))
+#define   DSU_STATUSB_DAL_SECURED_Val       _U_(0x0)                                       /**< (DSU_STATUSB)   */
+#define   DSU_STATUSB_DAL_NS_DEBUG_Val      _U_(0x1)                                       /**< (DSU_STATUSB)   */
+#define   DSU_STATUSB_DAL_FULL_DEBUG_Val    _U_(0x2)                                       /**< (DSU_STATUSB)   */
+#define DSU_STATUSB_DAL_SECURED             (DSU_STATUSB_DAL_SECURED_Val << DSU_STATUSB_DAL_Pos)  /**< (DSU_STATUSB)  Position  */
+#define DSU_STATUSB_DAL_NS_DEBUG            (DSU_STATUSB_DAL_NS_DEBUG_Val << DSU_STATUSB_DAL_Pos)  /**< (DSU_STATUSB)  Position  */
+#define DSU_STATUSB_DAL_FULL_DEBUG          (DSU_STATUSB_DAL_FULL_DEBUG_Val << DSU_STATUSB_DAL_Pos)  /**< (DSU_STATUSB)  Position  */
+#define DSU_STATUSB_DBGPRES_Pos             2                                              /**< (DSU_STATUSB) Debugger Present Position */
+#define DSU_STATUSB_DBGPRES_Msk             (_U_(0x1) << DSU_STATUSB_DBGPRES_Pos)          /**< (DSU_STATUSB) Debugger Present Mask */
+#define DSU_STATUSB_DBGPRES                 DSU_STATUSB_DBGPRES_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use DSU_STATUSB_DBGPRES_Msk instead */
+#define DSU_STATUSB_HPE_Pos                 3                                              /**< (DSU_STATUSB) Hot-Plugging Enable Position */
+#define DSU_STATUSB_HPE_Msk                 (_U_(0x1) << DSU_STATUSB_HPE_Pos)              /**< (DSU_STATUSB) Hot-Plugging Enable Mask */
+#define DSU_STATUSB_HPE                     DSU_STATUSB_HPE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use DSU_STATUSB_HPE_Msk instead */
+#define DSU_STATUSB_DCCD0_Pos               4                                              /**< (DSU_STATUSB) Debug Communication Channel 0 Dirty Position */
+#define DSU_STATUSB_DCCD0_Msk               (_U_(0x1) << DSU_STATUSB_DCCD0_Pos)            /**< (DSU_STATUSB) Debug Communication Channel 0 Dirty Mask */
+#define DSU_STATUSB_DCCD0                   DSU_STATUSB_DCCD0_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use DSU_STATUSB_DCCD0_Msk instead */
+#define DSU_STATUSB_DCCD1_Pos               5                                              /**< (DSU_STATUSB) Debug Communication Channel 1 Dirty Position */
+#define DSU_STATUSB_DCCD1_Msk               (_U_(0x1) << DSU_STATUSB_DCCD1_Pos)            /**< (DSU_STATUSB) Debug Communication Channel 1 Dirty Mask */
+#define DSU_STATUSB_DCCD1                   DSU_STATUSB_DCCD1_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use DSU_STATUSB_DCCD1_Msk instead */
+#define DSU_STATUSB_BCCD0_Pos               6                                              /**< (DSU_STATUSB) Boot ROM Communication Channel 0 Dirty Position */
+#define DSU_STATUSB_BCCD0_Msk               (_U_(0x1) << DSU_STATUSB_BCCD0_Pos)            /**< (DSU_STATUSB) Boot ROM Communication Channel 0 Dirty Mask */
+#define DSU_STATUSB_BCCD0                   DSU_STATUSB_BCCD0_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use DSU_STATUSB_BCCD0_Msk instead */
+#define DSU_STATUSB_BCCD1_Pos               7                                              /**< (DSU_STATUSB) Boot ROM Communication Channel 1 Dirty Position */
+#define DSU_STATUSB_BCCD1_Msk               (_U_(0x1) << DSU_STATUSB_BCCD1_Pos)            /**< (DSU_STATUSB) Boot ROM Communication Channel 1 Dirty Mask */
+#define DSU_STATUSB_BCCD1                   DSU_STATUSB_BCCD1_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use DSU_STATUSB_BCCD1_Msk instead */
+#define DSU_STATUSB_MASK                    _U_(0xFF)                                      /**< \deprecated (DSU_STATUSB) Register MASK  (Use DSU_STATUSB_Msk instead)  */
+#define DSU_STATUSB_Msk                     _U_(0xFF)                                      /**< (DSU_STATUSB) Register Mask  */
+
+#define DSU_STATUSB_DCCD_Pos                4                                              /**< (DSU_STATUSB Position) Debug Communication Channel x Dirty */
+#define DSU_STATUSB_DCCD_Msk                (_U_(0x3) << DSU_STATUSB_DCCD_Pos)             /**< (DSU_STATUSB Mask) DCCD */
+#define DSU_STATUSB_DCCD(value)             (DSU_STATUSB_DCCD_Msk & ((value) << DSU_STATUSB_DCCD_Pos))  
+#define DSU_STATUSB_BCCD_Pos                6                                              /**< (DSU_STATUSB Position) Boot ROM Communication Channel x Dirty */
+#define DSU_STATUSB_BCCD_Msk                (_U_(0x3) << DSU_STATUSB_BCCD_Pos)             /**< (DSU_STATUSB Mask) BCCD */
+#define DSU_STATUSB_BCCD(value)             (DSU_STATUSB_BCCD_Msk & ((value) << DSU_STATUSB_BCCD_Pos))  
+
+/* -------- DSU_STATUSC : (DSU Offset: 0x03) (R/ 8) Status C -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  uint8_t  reg;                         /**< Type used for register access */
+} DSU_STATUSC_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_STATUSC_OFFSET                  (0x03)                                        /**<  (DSU_STATUSC) Status C  Offset */
+#define DSU_STATUSC_RESETVALUE              _U_(0x00)                                     /**<  (DSU_STATUSC) Status C  Reset Value */
+
+#define DSU_STATUSC_MASK                    _U_(0x00)                                      /**< \deprecated (DSU_STATUSC) Register MASK  (Use DSU_STATUSC_Msk instead)  */
+#define DSU_STATUSC_Msk                     _U_(0x00)                                      /**< (DSU_STATUSC) Register Mask  */
+
+
+/* -------- DSU_ADDR : (DSU Offset: 0x04) (R/W 32) Address -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t AMOD:2;                    /**< bit:   0..1  Access Mode                              */
+    uint32_t ADDR:30;                   /**< bit:  2..31  Address                                  */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DSU_ADDR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_ADDR_OFFSET                     (0x04)                                        /**<  (DSU_ADDR) Address  Offset */
+#define DSU_ADDR_RESETVALUE                 _U_(0x00)                                     /**<  (DSU_ADDR) Address  Reset Value */
+
+#define DSU_ADDR_AMOD_Pos                   0                                              /**< (DSU_ADDR) Access Mode Position */
+#define DSU_ADDR_AMOD_Msk                   (_U_(0x3) << DSU_ADDR_AMOD_Pos)                /**< (DSU_ADDR) Access Mode Mask */
+#define DSU_ADDR_AMOD(value)                (DSU_ADDR_AMOD_Msk & ((value) << DSU_ADDR_AMOD_Pos))
+#define DSU_ADDR_ADDR_Pos                   2                                              /**< (DSU_ADDR) Address Position */
+#define DSU_ADDR_ADDR_Msk                   (_U_(0x3FFFFFFF) << DSU_ADDR_ADDR_Pos)         /**< (DSU_ADDR) Address Mask */
+#define DSU_ADDR_ADDR(value)                (DSU_ADDR_ADDR_Msk & ((value) << DSU_ADDR_ADDR_Pos))
+#define DSU_ADDR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (DSU_ADDR) Register MASK  (Use DSU_ADDR_Msk instead)  */
+#define DSU_ADDR_Msk                        _U_(0xFFFFFFFF)                                /**< (DSU_ADDR) Register Mask  */
+
+
+/* -------- DSU_LENGTH : (DSU Offset: 0x08) (R/W 32) Length -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t LENGTH:30;                 /**< bit:  2..31  Length                                   */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DSU_LENGTH_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_LENGTH_OFFSET                   (0x08)                                        /**<  (DSU_LENGTH) Length  Offset */
+#define DSU_LENGTH_RESETVALUE               _U_(0x00)                                     /**<  (DSU_LENGTH) Length  Reset Value */
+
+#define DSU_LENGTH_LENGTH_Pos               2                                              /**< (DSU_LENGTH) Length Position */
+#define DSU_LENGTH_LENGTH_Msk               (_U_(0x3FFFFFFF) << DSU_LENGTH_LENGTH_Pos)     /**< (DSU_LENGTH) Length Mask */
+#define DSU_LENGTH_LENGTH(value)            (DSU_LENGTH_LENGTH_Msk & ((value) << DSU_LENGTH_LENGTH_Pos))
+#define DSU_LENGTH_MASK                     _U_(0xFFFFFFFC)                                /**< \deprecated (DSU_LENGTH) Register MASK  (Use DSU_LENGTH_Msk instead)  */
+#define DSU_LENGTH_Msk                      _U_(0xFFFFFFFC)                                /**< (DSU_LENGTH) Register Mask  */
+
+
+/* -------- DSU_DATA : (DSU Offset: 0x0c) (R/W 32) Data -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t DATA:32;                   /**< bit:  0..31  Data                                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DSU_DATA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_DATA_OFFSET                     (0x0C)                                        /**<  (DSU_DATA) Data  Offset */
+#define DSU_DATA_RESETVALUE                 _U_(0x00)                                     /**<  (DSU_DATA) Data  Reset Value */
+
+#define DSU_DATA_DATA_Pos                   0                                              /**< (DSU_DATA) Data Position */
+#define DSU_DATA_DATA_Msk                   (_U_(0xFFFFFFFF) << DSU_DATA_DATA_Pos)         /**< (DSU_DATA) Data Mask */
+#define DSU_DATA_DATA(value)                (DSU_DATA_DATA_Msk & ((value) << DSU_DATA_DATA_Pos))
+#define DSU_DATA_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (DSU_DATA) Register MASK  (Use DSU_DATA_Msk instead)  */
+#define DSU_DATA_Msk                        _U_(0xFFFFFFFF)                                /**< (DSU_DATA) Register Mask  */
+
+
+/* -------- DSU_DCC : (DSU Offset: 0x10) (R/W 32) Debug Communication Channel n -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t DATA:32;                   /**< bit:  0..31  Data                                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DSU_DCC_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_DCC_OFFSET                      (0x10)                                        /**<  (DSU_DCC) Debug Communication Channel n  Offset */
+#define DSU_DCC_RESETVALUE                  _U_(0x00)                                     /**<  (DSU_DCC) Debug Communication Channel n  Reset Value */
+
+#define DSU_DCC_DATA_Pos                    0                                              /**< (DSU_DCC) Data Position */
+#define DSU_DCC_DATA_Msk                    (_U_(0xFFFFFFFF) << DSU_DCC_DATA_Pos)          /**< (DSU_DCC) Data Mask */
+#define DSU_DCC_DATA(value)                 (DSU_DCC_DATA_Msk & ((value) << DSU_DCC_DATA_Pos))
+#define DSU_DCC_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (DSU_DCC) Register MASK  (Use DSU_DCC_Msk instead)  */
+#define DSU_DCC_Msk                         _U_(0xFFFFFFFF)                                /**< (DSU_DCC) Register Mask  */
+
+
+/* -------- DSU_DID : (DSU Offset: 0x18) (R/ 32) Device Identification -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t DEVSEL:8;                  /**< bit:   0..7  Device Select                            */
+    uint32_t REVISION:4;                /**< bit:  8..11  Revision Number                          */
+    uint32_t DIE:4;                     /**< bit: 12..15  Die Number                               */
+    uint32_t SERIES:6;                  /**< bit: 16..21  Series                                   */
+    uint32_t :1;                        /**< bit:     22  Reserved */
+    uint32_t FAMILY:5;                  /**< bit: 23..27  Family                                   */
+    uint32_t PROCESSOR:4;               /**< bit: 28..31  Processor                                */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DSU_DID_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_DID_OFFSET                      (0x18)                                        /**<  (DSU_DID) Device Identification  Offset */
+#define DSU_DID_RESETVALUE                  _U_(0x20830000)                               /**<  (DSU_DID) Device Identification  Reset Value */
+
+#define DSU_DID_DEVSEL_Pos                  0                                              /**< (DSU_DID) Device Select Position */
+#define DSU_DID_DEVSEL_Msk                  (_U_(0xFF) << DSU_DID_DEVSEL_Pos)              /**< (DSU_DID) Device Select Mask */
+#define DSU_DID_DEVSEL(value)               (DSU_DID_DEVSEL_Msk & ((value) << DSU_DID_DEVSEL_Pos))
+#define DSU_DID_REVISION_Pos                8                                              /**< (DSU_DID) Revision Number Position */
+#define DSU_DID_REVISION_Msk                (_U_(0xF) << DSU_DID_REVISION_Pos)             /**< (DSU_DID) Revision Number Mask */
+#define DSU_DID_REVISION(value)             (DSU_DID_REVISION_Msk & ((value) << DSU_DID_REVISION_Pos))
+#define DSU_DID_DIE_Pos                     12                                             /**< (DSU_DID) Die Number Position */
+#define DSU_DID_DIE_Msk                     (_U_(0xF) << DSU_DID_DIE_Pos)                  /**< (DSU_DID) Die Number Mask */
+#define DSU_DID_DIE(value)                  (DSU_DID_DIE_Msk & ((value) << DSU_DID_DIE_Pos))
+#define DSU_DID_SERIES_Pos                  16                                             /**< (DSU_DID) Series Position */
+#define DSU_DID_SERIES_Msk                  (_U_(0x3F) << DSU_DID_SERIES_Pos)              /**< (DSU_DID) Series Mask */
+#define DSU_DID_SERIES(value)               (DSU_DID_SERIES_Msk & ((value) << DSU_DID_SERIES_Pos))
+#define   DSU_DID_SERIES_0_Val              _U_(0x0)                                       /**< (DSU_DID) Cortex-M0+ processor, basic feature set  */
+#define   DSU_DID_SERIES_1_Val              _U_(0x1)                                       /**< (DSU_DID) Cortex-M0+ processor, USB  */
+#define DSU_DID_SERIES_0                    (DSU_DID_SERIES_0_Val << DSU_DID_SERIES_Pos)   /**< (DSU_DID) Cortex-M0+ processor, basic feature set Position  */
+#define DSU_DID_SERIES_1                    (DSU_DID_SERIES_1_Val << DSU_DID_SERIES_Pos)   /**< (DSU_DID) Cortex-M0+ processor, USB Position  */
+#define DSU_DID_FAMILY_Pos                  23                                             /**< (DSU_DID) Family Position */
+#define DSU_DID_FAMILY_Msk                  (_U_(0x1F) << DSU_DID_FAMILY_Pos)              /**< (DSU_DID) Family Mask */
+#define DSU_DID_FAMILY(value)               (DSU_DID_FAMILY_Msk & ((value) << DSU_DID_FAMILY_Pos))
+#define   DSU_DID_FAMILY_0_Val              _U_(0x0)                                       /**< (DSU_DID) General purpose microcontroller  */
+#define   DSU_DID_FAMILY_1_Val              _U_(0x1)                                       /**< (DSU_DID) PicoPower  */
+#define DSU_DID_FAMILY_0                    (DSU_DID_FAMILY_0_Val << DSU_DID_FAMILY_Pos)   /**< (DSU_DID) General purpose microcontroller Position  */
+#define DSU_DID_FAMILY_1                    (DSU_DID_FAMILY_1_Val << DSU_DID_FAMILY_Pos)   /**< (DSU_DID) PicoPower Position  */
+#define DSU_DID_PROCESSOR_Pos               28                                             /**< (DSU_DID) Processor Position */
+#define DSU_DID_PROCESSOR_Msk               (_U_(0xF) << DSU_DID_PROCESSOR_Pos)            /**< (DSU_DID) Processor Mask */
+#define DSU_DID_PROCESSOR(value)            (DSU_DID_PROCESSOR_Msk & ((value) << DSU_DID_PROCESSOR_Pos))
+#define   DSU_DID_PROCESSOR_CM0P_Val        _U_(0x1)                                       /**< (DSU_DID) Cortex-M0+  */
+#define   DSU_DID_PROCESSOR_CM23_Val        _U_(0x2)                                       /**< (DSU_DID) Cortex-M23  */
+#define   DSU_DID_PROCESSOR_CM3_Val         _U_(0x3)                                       /**< (DSU_DID) Cortex-M3  */
+#define   DSU_DID_PROCESSOR_CM4_Val         _U_(0x5)                                       /**< (DSU_DID) Cortex-M4  */
+#define   DSU_DID_PROCESSOR_CM4F_Val        _U_(0x6)                                       /**< (DSU_DID) Cortex-M4 with FPU  */
+#define   DSU_DID_PROCESSOR_CM33_Val        _U_(0x7)                                       /**< (DSU_DID) Cortex-M33  */
+#define DSU_DID_PROCESSOR_CM0P              (DSU_DID_PROCESSOR_CM0P_Val << DSU_DID_PROCESSOR_Pos)  /**< (DSU_DID) Cortex-M0+ Position  */
+#define DSU_DID_PROCESSOR_CM23              (DSU_DID_PROCESSOR_CM23_Val << DSU_DID_PROCESSOR_Pos)  /**< (DSU_DID) Cortex-M23 Position  */
+#define DSU_DID_PROCESSOR_CM3               (DSU_DID_PROCESSOR_CM3_Val << DSU_DID_PROCESSOR_Pos)  /**< (DSU_DID) Cortex-M3 Position  */
+#define DSU_DID_PROCESSOR_CM4               (DSU_DID_PROCESSOR_CM4_Val << DSU_DID_PROCESSOR_Pos)  /**< (DSU_DID) Cortex-M4 Position  */
+#define DSU_DID_PROCESSOR_CM4F              (DSU_DID_PROCESSOR_CM4F_Val << DSU_DID_PROCESSOR_Pos)  /**< (DSU_DID) Cortex-M4 with FPU Position  */
+#define DSU_DID_PROCESSOR_CM33              (DSU_DID_PROCESSOR_CM33_Val << DSU_DID_PROCESSOR_Pos)  /**< (DSU_DID) Cortex-M33 Position  */
+#define DSU_DID_MASK                        _U_(0xFFBFFFFF)                                /**< \deprecated (DSU_DID) Register MASK  (Use DSU_DID_Msk instead)  */
+#define DSU_DID_Msk                         _U_(0xFFBFFFFF)                                /**< (DSU_DID) Register Mask  */
+
+
+/* -------- DSU_CFG : (DSU Offset: 0x1c) (R/W 32) Configuration -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t LQOS:2;                    /**< bit:   0..1  Latency Quality Of Service               */
+    uint32_t DCCDMALEVEL:2;             /**< bit:   2..3  DMA Trigger Level                        */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DSU_CFG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_CFG_OFFSET                      (0x1C)                                        /**<  (DSU_CFG) Configuration  Offset */
+#define DSU_CFG_RESETVALUE                  _U_(0x02)                                     /**<  (DSU_CFG) Configuration  Reset Value */
+
+#define DSU_CFG_LQOS_Pos                    0                                              /**< (DSU_CFG) Latency Quality Of Service Position */
+#define DSU_CFG_LQOS_Msk                    (_U_(0x3) << DSU_CFG_LQOS_Pos)                 /**< (DSU_CFG) Latency Quality Of Service Mask */
+#define DSU_CFG_LQOS(value)                 (DSU_CFG_LQOS_Msk & ((value) << DSU_CFG_LQOS_Pos))
+#define DSU_CFG_DCCDMALEVEL_Pos             2                                              /**< (DSU_CFG) DMA Trigger Level Position */
+#define DSU_CFG_DCCDMALEVEL_Msk             (_U_(0x3) << DSU_CFG_DCCDMALEVEL_Pos)          /**< (DSU_CFG) DMA Trigger Level Mask */
+#define DSU_CFG_DCCDMALEVEL(value)          (DSU_CFG_DCCDMALEVEL_Msk & ((value) << DSU_CFG_DCCDMALEVEL_Pos))
+#define   DSU_CFG_DCCDMALEVEL_EMPTY_Val     _U_(0x0)                                       /**< (DSU_CFG) Trigger rises when DCC is empty  */
+#define   DSU_CFG_DCCDMALEVEL_FULL_Val      _U_(0x1)                                       /**< (DSU_CFG) Trigger rises when DCC is full  */
+#define DSU_CFG_DCCDMALEVEL_EMPTY           (DSU_CFG_DCCDMALEVEL_EMPTY_Val << DSU_CFG_DCCDMALEVEL_Pos)  /**< (DSU_CFG) Trigger rises when DCC is empty Position  */
+#define DSU_CFG_DCCDMALEVEL_FULL            (DSU_CFG_DCCDMALEVEL_FULL_Val << DSU_CFG_DCCDMALEVEL_Pos)  /**< (DSU_CFG) Trigger rises when DCC is full Position  */
+#define DSU_CFG_MASK                        _U_(0x0F)                                      /**< \deprecated (DSU_CFG) Register MASK  (Use DSU_CFG_Msk instead)  */
+#define DSU_CFG_Msk                         _U_(0x0F)                                      /**< (DSU_CFG) Register Mask  */
+
+
+/* -------- DSU_BCC : (DSU Offset: 0x20) (R/W 32) Boot ROM Communication Channel n -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t DATA:32;                   /**< bit:  0..31  Data                                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DSU_BCC_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_BCC_OFFSET                      (0x20)                                        /**<  (DSU_BCC) Boot ROM Communication Channel n  Offset */
+#define DSU_BCC_RESETVALUE                  _U_(0x00)                                     /**<  (DSU_BCC) Boot ROM Communication Channel n  Reset Value */
+
+#define DSU_BCC_DATA_Pos                    0                                              /**< (DSU_BCC) Data Position */
+#define DSU_BCC_DATA_Msk                    (_U_(0xFFFFFFFF) << DSU_BCC_DATA_Pos)          /**< (DSU_BCC) Data Mask */
+#define DSU_BCC_DATA(value)                 (DSU_BCC_DATA_Msk & ((value) << DSU_BCC_DATA_Pos))
+#define DSU_BCC_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (DSU_BCC) Register MASK  (Use DSU_BCC_Msk instead)  */
+#define DSU_BCC_Msk                         _U_(0xFFFFFFFF)                                /**< (DSU_BCC) Register Mask  */
+
+
+/* -------- DSU_DCFG : (DSU Offset: 0xf0) (R/W 32) Device Configuration -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t DCFG:32;                   /**< bit:  0..31  Device Configuration                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DSU_DCFG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_DCFG_OFFSET                     (0xF0)                                        /**<  (DSU_DCFG) Device Configuration  Offset */
+#define DSU_DCFG_RESETVALUE                 _U_(0x00)                                     /**<  (DSU_DCFG) Device Configuration  Reset Value */
+
+#define DSU_DCFG_DCFG_Pos                   0                                              /**< (DSU_DCFG) Device Configuration Position */
+#define DSU_DCFG_DCFG_Msk                   (_U_(0xFFFFFFFF) << DSU_DCFG_DCFG_Pos)         /**< (DSU_DCFG) Device Configuration Mask */
+#define DSU_DCFG_DCFG(value)                (DSU_DCFG_DCFG_Msk & ((value) << DSU_DCFG_DCFG_Pos))
+#define DSU_DCFG_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (DSU_DCFG) Register MASK  (Use DSU_DCFG_Msk instead)  */
+#define DSU_DCFG_Msk                        _U_(0xFFFFFFFF)                                /**< (DSU_DCFG) Register Mask  */
+
+
+/* -------- DSU_ENTRY0 : (DSU Offset: 0x1000) (R/ 32) CoreSight ROM Table Entry 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t EPRES:1;                   /**< bit:      0  Entry Present                            */
+    uint32_t FMT:1;                     /**< bit:      1  Format                                   */
+    uint32_t :10;                       /**< bit:  2..11  Reserved */
+    uint32_t ADDOFF:20;                 /**< bit: 12..31  Address Offset                           */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DSU_ENTRY0_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_ENTRY0_OFFSET                   (0x1000)                                      /**<  (DSU_ENTRY0) CoreSight ROM Table Entry 0  Offset */
+#define DSU_ENTRY0_RESETVALUE               _U_(0x9F0FC002)                               /**<  (DSU_ENTRY0) CoreSight ROM Table Entry 0  Reset Value */
+
+#define DSU_ENTRY0_EPRES_Pos                0                                              /**< (DSU_ENTRY0) Entry Present Position */
+#define DSU_ENTRY0_EPRES_Msk                (_U_(0x1) << DSU_ENTRY0_EPRES_Pos)             /**< (DSU_ENTRY0) Entry Present Mask */
+#define DSU_ENTRY0_EPRES                    DSU_ENTRY0_EPRES_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use DSU_ENTRY0_EPRES_Msk instead */
+#define DSU_ENTRY0_FMT_Pos                  1                                              /**< (DSU_ENTRY0) Format Position */
+#define DSU_ENTRY0_FMT_Msk                  (_U_(0x1) << DSU_ENTRY0_FMT_Pos)               /**< (DSU_ENTRY0) Format Mask */
+#define DSU_ENTRY0_FMT                      DSU_ENTRY0_FMT_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use DSU_ENTRY0_FMT_Msk instead */
+#define DSU_ENTRY0_ADDOFF_Pos               12                                             /**< (DSU_ENTRY0) Address Offset Position */
+#define DSU_ENTRY0_ADDOFF_Msk               (_U_(0xFFFFF) << DSU_ENTRY0_ADDOFF_Pos)        /**< (DSU_ENTRY0) Address Offset Mask */
+#define DSU_ENTRY0_ADDOFF(value)            (DSU_ENTRY0_ADDOFF_Msk & ((value) << DSU_ENTRY0_ADDOFF_Pos))
+#define DSU_ENTRY0_MASK                     _U_(0xFFFFF003)                                /**< \deprecated (DSU_ENTRY0) Register MASK  (Use DSU_ENTRY0_Msk instead)  */
+#define DSU_ENTRY0_Msk                      _U_(0xFFFFF003)                                /**< (DSU_ENTRY0) Register Mask  */
+
+
+/* -------- DSU_ENTRY1 : (DSU Offset: 0x1004) (R/ 32) CoreSight ROM Table Entry 1 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  uint32_t reg;                         /**< Type used for register access */
+} DSU_ENTRY1_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_ENTRY1_OFFSET                   (0x1004)                                      /**<  (DSU_ENTRY1) CoreSight ROM Table Entry 1  Offset */
+#define DSU_ENTRY1_RESETVALUE               _U_(0x00)                                     /**<  (DSU_ENTRY1) CoreSight ROM Table Entry 1  Reset Value */
+
+#define DSU_ENTRY1_MASK                     _U_(0x00)                                      /**< \deprecated (DSU_ENTRY1) Register MASK  (Use DSU_ENTRY1_Msk instead)  */
+#define DSU_ENTRY1_Msk                      _U_(0x00)                                      /**< (DSU_ENTRY1) Register Mask  */
+
+
+/* -------- DSU_END : (DSU Offset: 0x1008) (R/ 32) CoreSight ROM Table End -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t END:32;                    /**< bit:  0..31  End Marker                               */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DSU_END_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_END_OFFSET                      (0x1008)                                      /**<  (DSU_END) CoreSight ROM Table End  Offset */
+#define DSU_END_RESETVALUE                  _U_(0x00)                                     /**<  (DSU_END) CoreSight ROM Table End  Reset Value */
+
+#define DSU_END_END_Pos                     0                                              /**< (DSU_END) End Marker Position */
+#define DSU_END_END_Msk                     (_U_(0xFFFFFFFF) << DSU_END_END_Pos)           /**< (DSU_END) End Marker Mask */
+#define DSU_END_END(value)                  (DSU_END_END_Msk & ((value) << DSU_END_END_Pos))
+#define DSU_END_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (DSU_END) Register MASK  (Use DSU_END_Msk instead)  */
+#define DSU_END_Msk                         _U_(0xFFFFFFFF)                                /**< (DSU_END) Register Mask  */
+
+
+/* -------- DSU_MEMTYPE : (DSU Offset: 0x1fcc) (R/ 32) CoreSight ROM Table Memory Type -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SMEMP:1;                   /**< bit:      0  System Memory Present                    */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DSU_MEMTYPE_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_MEMTYPE_OFFSET                  (0x1FCC)                                      /**<  (DSU_MEMTYPE) CoreSight ROM Table Memory Type  Offset */
+#define DSU_MEMTYPE_RESETVALUE              _U_(0x00)                                     /**<  (DSU_MEMTYPE) CoreSight ROM Table Memory Type  Reset Value */
+
+#define DSU_MEMTYPE_SMEMP_Pos               0                                              /**< (DSU_MEMTYPE) System Memory Present Position */
+#define DSU_MEMTYPE_SMEMP_Msk               (_U_(0x1) << DSU_MEMTYPE_SMEMP_Pos)            /**< (DSU_MEMTYPE) System Memory Present Mask */
+#define DSU_MEMTYPE_SMEMP                   DSU_MEMTYPE_SMEMP_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use DSU_MEMTYPE_SMEMP_Msk instead */
+#define DSU_MEMTYPE_MASK                    _U_(0x01)                                      /**< \deprecated (DSU_MEMTYPE) Register MASK  (Use DSU_MEMTYPE_Msk instead)  */
+#define DSU_MEMTYPE_Msk                     _U_(0x01)                                      /**< (DSU_MEMTYPE) Register Mask  */
+
+
+/* -------- DSU_PID4 : (DSU Offset: 0x1fd0) (R/ 32) Peripheral Identification 4 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t JEPCC:4;                   /**< bit:   0..3  JEP-106 Continuation Code                */
+    uint32_t FKBC:4;                    /**< bit:   4..7  4KB count                                */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DSU_PID4_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_PID4_OFFSET                     (0x1FD0)                                      /**<  (DSU_PID4) Peripheral Identification 4  Offset */
+#define DSU_PID4_RESETVALUE                 _U_(0x00)                                     /**<  (DSU_PID4) Peripheral Identification 4  Reset Value */
+
+#define DSU_PID4_JEPCC_Pos                  0                                              /**< (DSU_PID4) JEP-106 Continuation Code Position */
+#define DSU_PID4_JEPCC_Msk                  (_U_(0xF) << DSU_PID4_JEPCC_Pos)               /**< (DSU_PID4) JEP-106 Continuation Code Mask */
+#define DSU_PID4_JEPCC(value)               (DSU_PID4_JEPCC_Msk & ((value) << DSU_PID4_JEPCC_Pos))
+#define DSU_PID4_FKBC_Pos                   4                                              /**< (DSU_PID4) 4KB count Position */
+#define DSU_PID4_FKBC_Msk                   (_U_(0xF) << DSU_PID4_FKBC_Pos)                /**< (DSU_PID4) 4KB count Mask */
+#define DSU_PID4_FKBC(value)                (DSU_PID4_FKBC_Msk & ((value) << DSU_PID4_FKBC_Pos))
+#define DSU_PID4_MASK                       _U_(0xFF)                                      /**< \deprecated (DSU_PID4) Register MASK  (Use DSU_PID4_Msk instead)  */
+#define DSU_PID4_Msk                        _U_(0xFF)                                      /**< (DSU_PID4) Register Mask  */
+
+
+/* -------- DSU_PID5 : (DSU Offset: 0x1fd4) (R/ 32) Peripheral Identification 5 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  uint32_t reg;                         /**< Type used for register access */
+} DSU_PID5_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_PID5_OFFSET                     (0x1FD4)                                      /**<  (DSU_PID5) Peripheral Identification 5  Offset */
+#define DSU_PID5_RESETVALUE                 _U_(0x00)                                     /**<  (DSU_PID5) Peripheral Identification 5  Reset Value */
+
+#define DSU_PID5_MASK                       _U_(0x00)                                      /**< \deprecated (DSU_PID5) Register MASK  (Use DSU_PID5_Msk instead)  */
+#define DSU_PID5_Msk                        _U_(0x00)                                      /**< (DSU_PID5) Register Mask  */
+
+
+/* -------- DSU_PID6 : (DSU Offset: 0x1fd8) (R/ 32) Peripheral Identification 6 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  uint32_t reg;                         /**< Type used for register access */
+} DSU_PID6_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_PID6_OFFSET                     (0x1FD8)                                      /**<  (DSU_PID6) Peripheral Identification 6  Offset */
+#define DSU_PID6_RESETVALUE                 _U_(0x00)                                     /**<  (DSU_PID6) Peripheral Identification 6  Reset Value */
+
+#define DSU_PID6_MASK                       _U_(0x00)                                      /**< \deprecated (DSU_PID6) Register MASK  (Use DSU_PID6_Msk instead)  */
+#define DSU_PID6_Msk                        _U_(0x00)                                      /**< (DSU_PID6) Register Mask  */
+
+
+/* -------- DSU_PID7 : (DSU Offset: 0x1fdc) (R/ 32) Peripheral Identification 7 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  uint32_t reg;                         /**< Type used for register access */
+} DSU_PID7_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_PID7_OFFSET                     (0x1FDC)                                      /**<  (DSU_PID7) Peripheral Identification 7  Offset */
+#define DSU_PID7_RESETVALUE                 _U_(0x00)                                     /**<  (DSU_PID7) Peripheral Identification 7  Reset Value */
+
+#define DSU_PID7_MASK                       _U_(0x00)                                      /**< \deprecated (DSU_PID7) Register MASK  (Use DSU_PID7_Msk instead)  */
+#define DSU_PID7_Msk                        _U_(0x00)                                      /**< (DSU_PID7) Register Mask  */
+
+
+/* -------- DSU_PID0 : (DSU Offset: 0x1fe0) (R/ 32) Peripheral Identification 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t PARTNBL:8;                 /**< bit:   0..7  Part Number Low                          */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DSU_PID0_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_PID0_OFFSET                     (0x1FE0)                                      /**<  (DSU_PID0) Peripheral Identification 0  Offset */
+#define DSU_PID0_RESETVALUE                 _U_(0xD0)                                     /**<  (DSU_PID0) Peripheral Identification 0  Reset Value */
+
+#define DSU_PID0_PARTNBL_Pos                0                                              /**< (DSU_PID0) Part Number Low Position */
+#define DSU_PID0_PARTNBL_Msk                (_U_(0xFF) << DSU_PID0_PARTNBL_Pos)            /**< (DSU_PID0) Part Number Low Mask */
+#define DSU_PID0_PARTNBL(value)             (DSU_PID0_PARTNBL_Msk & ((value) << DSU_PID0_PARTNBL_Pos))
+#define DSU_PID0_MASK                       _U_(0xFF)                                      /**< \deprecated (DSU_PID0) Register MASK  (Use DSU_PID0_Msk instead)  */
+#define DSU_PID0_Msk                        _U_(0xFF)                                      /**< (DSU_PID0) Register Mask  */
+
+
+/* -------- DSU_PID1 : (DSU Offset: 0x1fe4) (R/ 32) Peripheral Identification 1 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t PARTNBH:4;                 /**< bit:   0..3  Part Number High                         */
+    uint32_t JEPIDCL:4;                 /**< bit:   4..7  Low part of the JEP-106 Identity Code    */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DSU_PID1_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_PID1_OFFSET                     (0x1FE4)                                      /**<  (DSU_PID1) Peripheral Identification 1  Offset */
+#define DSU_PID1_RESETVALUE                 _U_(0xFC)                                     /**<  (DSU_PID1) Peripheral Identification 1  Reset Value */
+
+#define DSU_PID1_PARTNBH_Pos                0                                              /**< (DSU_PID1) Part Number High Position */
+#define DSU_PID1_PARTNBH_Msk                (_U_(0xF) << DSU_PID1_PARTNBH_Pos)             /**< (DSU_PID1) Part Number High Mask */
+#define DSU_PID1_PARTNBH(value)             (DSU_PID1_PARTNBH_Msk & ((value) << DSU_PID1_PARTNBH_Pos))
+#define DSU_PID1_JEPIDCL_Pos                4                                              /**< (DSU_PID1) Low part of the JEP-106 Identity Code Position */
+#define DSU_PID1_JEPIDCL_Msk                (_U_(0xF) << DSU_PID1_JEPIDCL_Pos)             /**< (DSU_PID1) Low part of the JEP-106 Identity Code Mask */
+#define DSU_PID1_JEPIDCL(value)             (DSU_PID1_JEPIDCL_Msk & ((value) << DSU_PID1_JEPIDCL_Pos))
+#define DSU_PID1_MASK                       _U_(0xFF)                                      /**< \deprecated (DSU_PID1) Register MASK  (Use DSU_PID1_Msk instead)  */
+#define DSU_PID1_Msk                        _U_(0xFF)                                      /**< (DSU_PID1) Register Mask  */
+
+
+/* -------- DSU_PID2 : (DSU Offset: 0x1fe8) (R/ 32) Peripheral Identification 2 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t JEPIDCH:3;                 /**< bit:   0..2  JEP-106 Identity Code High               */
+    uint32_t JEPU:1;                    /**< bit:      3  JEP-106 Identity Code is used            */
+    uint32_t REVISION:4;                /**< bit:   4..7  Revision Number                          */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DSU_PID2_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_PID2_OFFSET                     (0x1FE8)                                      /**<  (DSU_PID2) Peripheral Identification 2  Offset */
+#define DSU_PID2_RESETVALUE                 _U_(0x09)                                     /**<  (DSU_PID2) Peripheral Identification 2  Reset Value */
+
+#define DSU_PID2_JEPIDCH_Pos                0                                              /**< (DSU_PID2) JEP-106 Identity Code High Position */
+#define DSU_PID2_JEPIDCH_Msk                (_U_(0x7) << DSU_PID2_JEPIDCH_Pos)             /**< (DSU_PID2) JEP-106 Identity Code High Mask */
+#define DSU_PID2_JEPIDCH(value)             (DSU_PID2_JEPIDCH_Msk & ((value) << DSU_PID2_JEPIDCH_Pos))
+#define DSU_PID2_JEPU_Pos                   3                                              /**< (DSU_PID2) JEP-106 Identity Code is used Position */
+#define DSU_PID2_JEPU_Msk                   (_U_(0x1) << DSU_PID2_JEPU_Pos)                /**< (DSU_PID2) JEP-106 Identity Code is used Mask */
+#define DSU_PID2_JEPU                       DSU_PID2_JEPU_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use DSU_PID2_JEPU_Msk instead */
+#define DSU_PID2_REVISION_Pos               4                                              /**< (DSU_PID2) Revision Number Position */
+#define DSU_PID2_REVISION_Msk               (_U_(0xF) << DSU_PID2_REVISION_Pos)            /**< (DSU_PID2) Revision Number Mask */
+#define DSU_PID2_REVISION(value)            (DSU_PID2_REVISION_Msk & ((value) << DSU_PID2_REVISION_Pos))
+#define DSU_PID2_MASK                       _U_(0xFF)                                      /**< \deprecated (DSU_PID2) Register MASK  (Use DSU_PID2_Msk instead)  */
+#define DSU_PID2_Msk                        _U_(0xFF)                                      /**< (DSU_PID2) Register Mask  */
+
+
+/* -------- DSU_PID3 : (DSU Offset: 0x1fec) (R/ 32) Peripheral Identification 3 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t CUSMOD:4;                  /**< bit:   0..3  ARM CUSMOD                               */
+    uint32_t REVAND:4;                  /**< bit:   4..7  Revision Number                          */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DSU_PID3_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_PID3_OFFSET                     (0x1FEC)                                      /**<  (DSU_PID3) Peripheral Identification 3  Offset */
+#define DSU_PID3_RESETVALUE                 _U_(0x00)                                     /**<  (DSU_PID3) Peripheral Identification 3  Reset Value */
+
+#define DSU_PID3_CUSMOD_Pos                 0                                              /**< (DSU_PID3) ARM CUSMOD Position */
+#define DSU_PID3_CUSMOD_Msk                 (_U_(0xF) << DSU_PID3_CUSMOD_Pos)              /**< (DSU_PID3) ARM CUSMOD Mask */
+#define DSU_PID3_CUSMOD(value)              (DSU_PID3_CUSMOD_Msk & ((value) << DSU_PID3_CUSMOD_Pos))
+#define DSU_PID3_REVAND_Pos                 4                                              /**< (DSU_PID3) Revision Number Position */
+#define DSU_PID3_REVAND_Msk                 (_U_(0xF) << DSU_PID3_REVAND_Pos)              /**< (DSU_PID3) Revision Number Mask */
+#define DSU_PID3_REVAND(value)              (DSU_PID3_REVAND_Msk & ((value) << DSU_PID3_REVAND_Pos))
+#define DSU_PID3_MASK                       _U_(0xFF)                                      /**< \deprecated (DSU_PID3) Register MASK  (Use DSU_PID3_Msk instead)  */
+#define DSU_PID3_Msk                        _U_(0xFF)                                      /**< (DSU_PID3) Register Mask  */
+
+
+/* -------- DSU_CID0 : (DSU Offset: 0x1ff0) (R/ 32) Component Identification 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t PREAMBLEB0:8;              /**< bit:   0..7  Preamble Byte 0                          */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DSU_CID0_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_CID0_OFFSET                     (0x1FF0)                                      /**<  (DSU_CID0) Component Identification 0  Offset */
+#define DSU_CID0_RESETVALUE                 _U_(0x0D)                                     /**<  (DSU_CID0) Component Identification 0  Reset Value */
+
+#define DSU_CID0_PREAMBLEB0_Pos             0                                              /**< (DSU_CID0) Preamble Byte 0 Position */
+#define DSU_CID0_PREAMBLEB0_Msk             (_U_(0xFF) << DSU_CID0_PREAMBLEB0_Pos)         /**< (DSU_CID0) Preamble Byte 0 Mask */
+#define DSU_CID0_PREAMBLEB0(value)          (DSU_CID0_PREAMBLEB0_Msk & ((value) << DSU_CID0_PREAMBLEB0_Pos))
+#define DSU_CID0_MASK                       _U_(0xFF)                                      /**< \deprecated (DSU_CID0) Register MASK  (Use DSU_CID0_Msk instead)  */
+#define DSU_CID0_Msk                        _U_(0xFF)                                      /**< (DSU_CID0) Register Mask  */
+
+
+/* -------- DSU_CID1 : (DSU Offset: 0x1ff4) (R/ 32) Component Identification 1 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t PREAMBLE:4;                /**< bit:   0..3  Preamble                                 */
+    uint32_t CCLASS:4;                  /**< bit:   4..7  Component Class                          */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DSU_CID1_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_CID1_OFFSET                     (0x1FF4)                                      /**<  (DSU_CID1) Component Identification 1  Offset */
+#define DSU_CID1_RESETVALUE                 _U_(0x10)                                     /**<  (DSU_CID1) Component Identification 1  Reset Value */
+
+#define DSU_CID1_PREAMBLE_Pos               0                                              /**< (DSU_CID1) Preamble Position */
+#define DSU_CID1_PREAMBLE_Msk               (_U_(0xF) << DSU_CID1_PREAMBLE_Pos)            /**< (DSU_CID1) Preamble Mask */
+#define DSU_CID1_PREAMBLE(value)            (DSU_CID1_PREAMBLE_Msk & ((value) << DSU_CID1_PREAMBLE_Pos))
+#define DSU_CID1_CCLASS_Pos                 4                                              /**< (DSU_CID1) Component Class Position */
+#define DSU_CID1_CCLASS_Msk                 (_U_(0xF) << DSU_CID1_CCLASS_Pos)              /**< (DSU_CID1) Component Class Mask */
+#define DSU_CID1_CCLASS(value)              (DSU_CID1_CCLASS_Msk & ((value) << DSU_CID1_CCLASS_Pos))
+#define DSU_CID1_MASK                       _U_(0xFF)                                      /**< \deprecated (DSU_CID1) Register MASK  (Use DSU_CID1_Msk instead)  */
+#define DSU_CID1_Msk                        _U_(0xFF)                                      /**< (DSU_CID1) Register Mask  */
+
+
+/* -------- DSU_CID2 : (DSU Offset: 0x1ff8) (R/ 32) Component Identification 2 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t PREAMBLEB2:8;              /**< bit:   0..7  Preamble Byte 2                          */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DSU_CID2_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_CID2_OFFSET                     (0x1FF8)                                      /**<  (DSU_CID2) Component Identification 2  Offset */
+#define DSU_CID2_RESETVALUE                 _U_(0x05)                                     /**<  (DSU_CID2) Component Identification 2  Reset Value */
+
+#define DSU_CID2_PREAMBLEB2_Pos             0                                              /**< (DSU_CID2) Preamble Byte 2 Position */
+#define DSU_CID2_PREAMBLEB2_Msk             (_U_(0xFF) << DSU_CID2_PREAMBLEB2_Pos)         /**< (DSU_CID2) Preamble Byte 2 Mask */
+#define DSU_CID2_PREAMBLEB2(value)          (DSU_CID2_PREAMBLEB2_Msk & ((value) << DSU_CID2_PREAMBLEB2_Pos))
+#define DSU_CID2_MASK                       _U_(0xFF)                                      /**< \deprecated (DSU_CID2) Register MASK  (Use DSU_CID2_Msk instead)  */
+#define DSU_CID2_Msk                        _U_(0xFF)                                      /**< (DSU_CID2) Register Mask  */
+
+
+/* -------- DSU_CID3 : (DSU Offset: 0x1ffc) (R/ 32) Component Identification 3 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t PREAMBLEB3:8;              /**< bit:   0..7  Preamble Byte 3                          */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DSU_CID3_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_CID3_OFFSET                     (0x1FFC)                                      /**<  (DSU_CID3) Component Identification 3  Offset */
+#define DSU_CID3_RESETVALUE                 _U_(0xB1)                                     /**<  (DSU_CID3) Component Identification 3  Reset Value */
+
+#define DSU_CID3_PREAMBLEB3_Pos             0                                              /**< (DSU_CID3) Preamble Byte 3 Position */
+#define DSU_CID3_PREAMBLEB3_Msk             (_U_(0xFF) << DSU_CID3_PREAMBLEB3_Pos)         /**< (DSU_CID3) Preamble Byte 3 Mask */
+#define DSU_CID3_PREAMBLEB3(value)          (DSU_CID3_PREAMBLEB3_Msk & ((value) << DSU_CID3_PREAMBLEB3_Pos))
+#define DSU_CID3_MASK                       _U_(0xFF)                                      /**< \deprecated (DSU_CID3) Register MASK  (Use DSU_CID3_Msk instead)  */
+#define DSU_CID3_Msk                        _U_(0xFF)                                      /**< (DSU_CID3) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief DSU hardware registers */
+typedef struct {  /* Device Service Unit */
+  __O  DSU_CTRL_Type                  CTRL;           /**< Offset: 0x00 ( /W   8) Control */
+  __IO DSU_STATUSA_Type               STATUSA;        /**< Offset: 0x01 (R/W   8) Status A */
+  __I  DSU_STATUSB_Type               STATUSB;        /**< Offset: 0x02 (R/    8) Status B */
+  __I  DSU_STATUSC_Type               STATUSC;        /**< Offset: 0x03 (R/    8) Status C */
+  __IO DSU_ADDR_Type                  ADDR;           /**< Offset: 0x04 (R/W  32) Address */
+  __IO DSU_LENGTH_Type                LENGTH;         /**< Offset: 0x08 (R/W  32) Length */
+  __IO DSU_DATA_Type                  DATA;           /**< Offset: 0x0C (R/W  32) Data */
+  __IO DSU_DCC_Type                   DCC[2];         /**< Offset: 0x10 (R/W  32) Debug Communication Channel n */
+  __I  DSU_DID_Type                   DID;            /**< Offset: 0x18 (R/   32) Device Identification */
+  __IO DSU_CFG_Type                   CFG;            /**< Offset: 0x1C (R/W  32) Configuration */
+  __IO DSU_BCC_Type                   BCC[2];         /**< Offset: 0x20 (R/W  32) Boot ROM Communication Channel n */
+  __I  uint8_t                        Reserved1[200];
+  __IO DSU_DCFG_Type                  DCFG[2];        /**< Offset: 0xF0 (R/W  32) Device Configuration */
+  __I  uint8_t                        Reserved2[3848];
+  __I  DSU_ENTRY0_Type                ENTRY0;         /**< Offset: 0x1000 (R/   32) CoreSight ROM Table Entry 0 */
+  __I  DSU_ENTRY1_Type                ENTRY1;         /**< Offset: 0x1004 (R/   32) CoreSight ROM Table Entry 1 */
+  __I  DSU_END_Type                   END;            /**< Offset: 0x1008 (R/   32) CoreSight ROM Table End */
+  __I  uint8_t                        Reserved3[4032];
+  __I  DSU_MEMTYPE_Type               MEMTYPE;        /**< Offset: 0x1FCC (R/   32) CoreSight ROM Table Memory Type */
+  __I  DSU_PID4_Type                  PID4;           /**< Offset: 0x1FD0 (R/   32) Peripheral Identification 4 */
+  __I  DSU_PID5_Type                  PID5;           /**< Offset: 0x1FD4 (R/   32) Peripheral Identification 5 */
+  __I  DSU_PID6_Type                  PID6;           /**< Offset: 0x1FD8 (R/   32) Peripheral Identification 6 */
+  __I  DSU_PID7_Type                  PID7;           /**< Offset: 0x1FDC (R/   32) Peripheral Identification 7 */
+  __I  DSU_PID0_Type                  PID0;           /**< Offset: 0x1FE0 (R/   32) Peripheral Identification 0 */
+  __I  DSU_PID1_Type                  PID1;           /**< Offset: 0x1FE4 (R/   32) Peripheral Identification 1 */
+  __I  DSU_PID2_Type                  PID2;           /**< Offset: 0x1FE8 (R/   32) Peripheral Identification 2 */
+  __I  DSU_PID3_Type                  PID3;           /**< Offset: 0x1FEC (R/   32) Peripheral Identification 3 */
+  __I  DSU_CID0_Type                  CID0;           /**< Offset: 0x1FF0 (R/   32) Component Identification 0 */
+  __I  DSU_CID1_Type                  CID1;           /**< Offset: 0x1FF4 (R/   32) Component Identification 1 */
+  __I  DSU_CID2_Type                  CID2;           /**< Offset: 0x1FF8 (R/   32) Component Identification 2 */
+  __I  DSU_CID3_Type                  CID3;           /**< Offset: 0x1FFC (R/   32) Component Identification 3 */
+} Dsu;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Device Service Unit */
+
+#endif /* _SAML11_DSU_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/component/eic.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/eic.h
@@ -1,0 +1,610 @@
+/**
+ * \file
+ *
+ * \brief Component description for EIC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_EIC_COMPONENT_H_
+#define _SAML11_EIC_COMPONENT_H_
+#define _SAML11_EIC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML11 External Interrupt Controller
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR EIC */
+/* ========================================================================== */
+
+#define EIC_U2804                      /**< (EIC) Module ID */
+#define REV_EIC 0x100                  /**< (EIC) Module revision */
+
+/* -------- EIC_CTRLA : (EIC Offset: 0x00) (R/W 8) Control A -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint8_t  ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint8_t  :2;                        /**< bit:   2..3  Reserved */
+    uint8_t  CKSEL:1;                   /**< bit:      4  Clock Selection                          */
+    uint8_t  :3;                        /**< bit:   5..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} EIC_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_CTRLA_OFFSET                    (0x00)                                        /**<  (EIC_CTRLA) Control A  Offset */
+#define EIC_CTRLA_RESETVALUE                _U_(0x00)                                     /**<  (EIC_CTRLA) Control A  Reset Value */
+
+#define EIC_CTRLA_SWRST_Pos                 0                                              /**< (EIC_CTRLA) Software Reset Position */
+#define EIC_CTRLA_SWRST_Msk                 (_U_(0x1) << EIC_CTRLA_SWRST_Pos)              /**< (EIC_CTRLA) Software Reset Mask */
+#define EIC_CTRLA_SWRST                     EIC_CTRLA_SWRST_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use EIC_CTRLA_SWRST_Msk instead */
+#define EIC_CTRLA_ENABLE_Pos                1                                              /**< (EIC_CTRLA) Enable Position */
+#define EIC_CTRLA_ENABLE_Msk                (_U_(0x1) << EIC_CTRLA_ENABLE_Pos)             /**< (EIC_CTRLA) Enable Mask */
+#define EIC_CTRLA_ENABLE                    EIC_CTRLA_ENABLE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use EIC_CTRLA_ENABLE_Msk instead */
+#define EIC_CTRLA_CKSEL_Pos                 4                                              /**< (EIC_CTRLA) Clock Selection Position */
+#define EIC_CTRLA_CKSEL_Msk                 (_U_(0x1) << EIC_CTRLA_CKSEL_Pos)              /**< (EIC_CTRLA) Clock Selection Mask */
+#define EIC_CTRLA_CKSEL                     EIC_CTRLA_CKSEL_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use EIC_CTRLA_CKSEL_Msk instead */
+#define EIC_CTRLA_MASK                      _U_(0x13)                                      /**< \deprecated (EIC_CTRLA) Register MASK  (Use EIC_CTRLA_Msk instead)  */
+#define EIC_CTRLA_Msk                       _U_(0x13)                                      /**< (EIC_CTRLA) Register Mask  */
+
+
+/* -------- EIC_NMICTRL : (EIC Offset: 0x01) (R/W 8) Non-Maskable Interrupt Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  NMISENSE:3;                /**< bit:   0..2  Non-Maskable Interrupt Sense Configuration */
+    uint8_t  NMIFILTEN:1;               /**< bit:      3  Non-Maskable Interrupt Filter Enable     */
+    uint8_t  NMIASYNCH:1;               /**< bit:      4  Asynchronous Edge Detection Mode         */
+    uint8_t  :3;                        /**< bit:   5..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} EIC_NMICTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_NMICTRL_OFFSET                  (0x01)                                        /**<  (EIC_NMICTRL) Non-Maskable Interrupt Control  Offset */
+#define EIC_NMICTRL_RESETVALUE              _U_(0x00)                                     /**<  (EIC_NMICTRL) Non-Maskable Interrupt Control  Reset Value */
+
+#define EIC_NMICTRL_NMISENSE_Pos            0                                              /**< (EIC_NMICTRL) Non-Maskable Interrupt Sense Configuration Position */
+#define EIC_NMICTRL_NMISENSE_Msk            (_U_(0x7) << EIC_NMICTRL_NMISENSE_Pos)         /**< (EIC_NMICTRL) Non-Maskable Interrupt Sense Configuration Mask */
+#define EIC_NMICTRL_NMISENSE(value)         (EIC_NMICTRL_NMISENSE_Msk & ((value) << EIC_NMICTRL_NMISENSE_Pos))
+#define   EIC_NMICTRL_NMISENSE_NONE_Val     _U_(0x0)                                       /**< (EIC_NMICTRL) No detection  */
+#define   EIC_NMICTRL_NMISENSE_RISE_Val     _U_(0x1)                                       /**< (EIC_NMICTRL) Rising-edge detection  */
+#define   EIC_NMICTRL_NMISENSE_FALL_Val     _U_(0x2)                                       /**< (EIC_NMICTRL) Falling-edge detection  */
+#define   EIC_NMICTRL_NMISENSE_BOTH_Val     _U_(0x3)                                       /**< (EIC_NMICTRL) Both-edges detection  */
+#define   EIC_NMICTRL_NMISENSE_HIGH_Val     _U_(0x4)                                       /**< (EIC_NMICTRL) High-level detection  */
+#define   EIC_NMICTRL_NMISENSE_LOW_Val      _U_(0x5)                                       /**< (EIC_NMICTRL) Low-level detection  */
+#define EIC_NMICTRL_NMISENSE_NONE           (EIC_NMICTRL_NMISENSE_NONE_Val << EIC_NMICTRL_NMISENSE_Pos)  /**< (EIC_NMICTRL) No detection Position  */
+#define EIC_NMICTRL_NMISENSE_RISE           (EIC_NMICTRL_NMISENSE_RISE_Val << EIC_NMICTRL_NMISENSE_Pos)  /**< (EIC_NMICTRL) Rising-edge detection Position  */
+#define EIC_NMICTRL_NMISENSE_FALL           (EIC_NMICTRL_NMISENSE_FALL_Val << EIC_NMICTRL_NMISENSE_Pos)  /**< (EIC_NMICTRL) Falling-edge detection Position  */
+#define EIC_NMICTRL_NMISENSE_BOTH           (EIC_NMICTRL_NMISENSE_BOTH_Val << EIC_NMICTRL_NMISENSE_Pos)  /**< (EIC_NMICTRL) Both-edges detection Position  */
+#define EIC_NMICTRL_NMISENSE_HIGH           (EIC_NMICTRL_NMISENSE_HIGH_Val << EIC_NMICTRL_NMISENSE_Pos)  /**< (EIC_NMICTRL) High-level detection Position  */
+#define EIC_NMICTRL_NMISENSE_LOW            (EIC_NMICTRL_NMISENSE_LOW_Val << EIC_NMICTRL_NMISENSE_Pos)  /**< (EIC_NMICTRL) Low-level detection Position  */
+#define EIC_NMICTRL_NMIFILTEN_Pos           3                                              /**< (EIC_NMICTRL) Non-Maskable Interrupt Filter Enable Position */
+#define EIC_NMICTRL_NMIFILTEN_Msk           (_U_(0x1) << EIC_NMICTRL_NMIFILTEN_Pos)        /**< (EIC_NMICTRL) Non-Maskable Interrupt Filter Enable Mask */
+#define EIC_NMICTRL_NMIFILTEN               EIC_NMICTRL_NMIFILTEN_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use EIC_NMICTRL_NMIFILTEN_Msk instead */
+#define EIC_NMICTRL_NMIASYNCH_Pos           4                                              /**< (EIC_NMICTRL) Asynchronous Edge Detection Mode Position */
+#define EIC_NMICTRL_NMIASYNCH_Msk           (_U_(0x1) << EIC_NMICTRL_NMIASYNCH_Pos)        /**< (EIC_NMICTRL) Asynchronous Edge Detection Mode Mask */
+#define EIC_NMICTRL_NMIASYNCH               EIC_NMICTRL_NMIASYNCH_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use EIC_NMICTRL_NMIASYNCH_Msk instead */
+#define EIC_NMICTRL_MASK                    _U_(0x1F)                                      /**< \deprecated (EIC_NMICTRL) Register MASK  (Use EIC_NMICTRL_Msk instead)  */
+#define EIC_NMICTRL_Msk                     _U_(0x1F)                                      /**< (EIC_NMICTRL) Register Mask  */
+
+
+/* -------- EIC_NMIFLAG : (EIC Offset: 0x02) (R/W 16) Non-Maskable Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t NMI:1;                     /**< bit:      0  Non-Maskable Interrupt                   */
+    uint16_t :15;                       /**< bit:  1..15  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} EIC_NMIFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_NMIFLAG_OFFSET                  (0x02)                                        /**<  (EIC_NMIFLAG) Non-Maskable Interrupt Flag Status and Clear  Offset */
+#define EIC_NMIFLAG_RESETVALUE              _U_(0x00)                                     /**<  (EIC_NMIFLAG) Non-Maskable Interrupt Flag Status and Clear  Reset Value */
+
+#define EIC_NMIFLAG_NMI_Pos                 0                                              /**< (EIC_NMIFLAG) Non-Maskable Interrupt Position */
+#define EIC_NMIFLAG_NMI_Msk                 (_U_(0x1) << EIC_NMIFLAG_NMI_Pos)              /**< (EIC_NMIFLAG) Non-Maskable Interrupt Mask */
+#define EIC_NMIFLAG_NMI                     EIC_NMIFLAG_NMI_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use EIC_NMIFLAG_NMI_Msk instead */
+#define EIC_NMIFLAG_MASK                    _U_(0x01)                                      /**< \deprecated (EIC_NMIFLAG) Register MASK  (Use EIC_NMIFLAG_Msk instead)  */
+#define EIC_NMIFLAG_Msk                     _U_(0x01)                                      /**< (EIC_NMIFLAG) Register Mask  */
+
+
+/* -------- EIC_SYNCBUSY : (EIC Offset: 0x04) (R/ 32) Synchronization Busy -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SWRST:1;                   /**< bit:      0  Software Reset Synchronization Busy Status */
+    uint32_t ENABLE:1;                  /**< bit:      1  Enable Synchronization Busy Status       */
+    uint32_t :30;                       /**< bit:  2..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} EIC_SYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_SYNCBUSY_OFFSET                 (0x04)                                        /**<  (EIC_SYNCBUSY) Synchronization Busy  Offset */
+#define EIC_SYNCBUSY_RESETVALUE             _U_(0x00)                                     /**<  (EIC_SYNCBUSY) Synchronization Busy  Reset Value */
+
+#define EIC_SYNCBUSY_SWRST_Pos              0                                              /**< (EIC_SYNCBUSY) Software Reset Synchronization Busy Status Position */
+#define EIC_SYNCBUSY_SWRST_Msk              (_U_(0x1) << EIC_SYNCBUSY_SWRST_Pos)           /**< (EIC_SYNCBUSY) Software Reset Synchronization Busy Status Mask */
+#define EIC_SYNCBUSY_SWRST                  EIC_SYNCBUSY_SWRST_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use EIC_SYNCBUSY_SWRST_Msk instead */
+#define EIC_SYNCBUSY_ENABLE_Pos             1                                              /**< (EIC_SYNCBUSY) Enable Synchronization Busy Status Position */
+#define EIC_SYNCBUSY_ENABLE_Msk             (_U_(0x1) << EIC_SYNCBUSY_ENABLE_Pos)          /**< (EIC_SYNCBUSY) Enable Synchronization Busy Status Mask */
+#define EIC_SYNCBUSY_ENABLE                 EIC_SYNCBUSY_ENABLE_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use EIC_SYNCBUSY_ENABLE_Msk instead */
+#define EIC_SYNCBUSY_MASK                   _U_(0x03)                                      /**< \deprecated (EIC_SYNCBUSY) Register MASK  (Use EIC_SYNCBUSY_Msk instead)  */
+#define EIC_SYNCBUSY_Msk                    _U_(0x03)                                      /**< (EIC_SYNCBUSY) Register Mask  */
+
+
+/* -------- EIC_EVCTRL : (EIC Offset: 0x08) (R/W 32) Event Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t EXTINTEO:8;                /**< bit:   0..7  External Interrupt Event Output Enable   */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} EIC_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_EVCTRL_OFFSET                   (0x08)                                        /**<  (EIC_EVCTRL) Event Control  Offset */
+#define EIC_EVCTRL_RESETVALUE               _U_(0x00)                                     /**<  (EIC_EVCTRL) Event Control  Reset Value */
+
+#define EIC_EVCTRL_EXTINTEO_Pos             0                                              /**< (EIC_EVCTRL) External Interrupt Event Output Enable Position */
+#define EIC_EVCTRL_EXTINTEO_Msk             (_U_(0xFF) << EIC_EVCTRL_EXTINTEO_Pos)         /**< (EIC_EVCTRL) External Interrupt Event Output Enable Mask */
+#define EIC_EVCTRL_EXTINTEO(value)          (EIC_EVCTRL_EXTINTEO_Msk & ((value) << EIC_EVCTRL_EXTINTEO_Pos))
+#define EIC_EVCTRL_MASK                     _U_(0xFF)                                      /**< \deprecated (EIC_EVCTRL) Register MASK  (Use EIC_EVCTRL_Msk instead)  */
+#define EIC_EVCTRL_Msk                      _U_(0xFF)                                      /**< (EIC_EVCTRL) Register Mask  */
+
+
+/* -------- EIC_INTENCLR : (EIC Offset: 0x0c) (R/W 32) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t EXTINT:8;                  /**< bit:   0..7  External Interrupt Enable                */
+    uint32_t :23;                       /**< bit:  8..30  Reserved */
+    uint32_t NSCHK:1;                   /**< bit:     31  Non-secure Check Interrupt Enable        */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} EIC_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_INTENCLR_OFFSET                 (0x0C)                                        /**<  (EIC_INTENCLR) Interrupt Enable Clear  Offset */
+#define EIC_INTENCLR_RESETVALUE             _U_(0x00)                                     /**<  (EIC_INTENCLR) Interrupt Enable Clear  Reset Value */
+
+#define EIC_INTENCLR_EXTINT_Pos             0                                              /**< (EIC_INTENCLR) External Interrupt Enable Position */
+#define EIC_INTENCLR_EXTINT_Msk             (_U_(0xFF) << EIC_INTENCLR_EXTINT_Pos)         /**< (EIC_INTENCLR) External Interrupt Enable Mask */
+#define EIC_INTENCLR_EXTINT(value)          (EIC_INTENCLR_EXTINT_Msk & ((value) << EIC_INTENCLR_EXTINT_Pos))
+#define EIC_INTENCLR_NSCHK_Pos              31                                             /**< (EIC_INTENCLR) Non-secure Check Interrupt Enable Position */
+#define EIC_INTENCLR_NSCHK_Msk              (_U_(0x1) << EIC_INTENCLR_NSCHK_Pos)           /**< (EIC_INTENCLR) Non-secure Check Interrupt Enable Mask */
+#define EIC_INTENCLR_NSCHK                  EIC_INTENCLR_NSCHK_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use EIC_INTENCLR_NSCHK_Msk instead */
+#define EIC_INTENCLR_MASK                   _U_(0x800000FF)                                /**< \deprecated (EIC_INTENCLR) Register MASK  (Use EIC_INTENCLR_Msk instead)  */
+#define EIC_INTENCLR_Msk                    _U_(0x800000FF)                                /**< (EIC_INTENCLR) Register Mask  */
+
+
+/* -------- EIC_INTENSET : (EIC Offset: 0x10) (R/W 32) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t EXTINT:8;                  /**< bit:   0..7  External Interrupt Enable                */
+    uint32_t :23;                       /**< bit:  8..30  Reserved */
+    uint32_t NSCHK:1;                   /**< bit:     31  Non-secure Check Interrupt Enable        */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} EIC_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_INTENSET_OFFSET                 (0x10)                                        /**<  (EIC_INTENSET) Interrupt Enable Set  Offset */
+#define EIC_INTENSET_RESETVALUE             _U_(0x00)                                     /**<  (EIC_INTENSET) Interrupt Enable Set  Reset Value */
+
+#define EIC_INTENSET_EXTINT_Pos             0                                              /**< (EIC_INTENSET) External Interrupt Enable Position */
+#define EIC_INTENSET_EXTINT_Msk             (_U_(0xFF) << EIC_INTENSET_EXTINT_Pos)         /**< (EIC_INTENSET) External Interrupt Enable Mask */
+#define EIC_INTENSET_EXTINT(value)          (EIC_INTENSET_EXTINT_Msk & ((value) << EIC_INTENSET_EXTINT_Pos))
+#define EIC_INTENSET_NSCHK_Pos              31                                             /**< (EIC_INTENSET) Non-secure Check Interrupt Enable Position */
+#define EIC_INTENSET_NSCHK_Msk              (_U_(0x1) << EIC_INTENSET_NSCHK_Pos)           /**< (EIC_INTENSET) Non-secure Check Interrupt Enable Mask */
+#define EIC_INTENSET_NSCHK                  EIC_INTENSET_NSCHK_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use EIC_INTENSET_NSCHK_Msk instead */
+#define EIC_INTENSET_MASK                   _U_(0x800000FF)                                /**< \deprecated (EIC_INTENSET) Register MASK  (Use EIC_INTENSET_Msk instead)  */
+#define EIC_INTENSET_Msk                    _U_(0x800000FF)                                /**< (EIC_INTENSET) Register Mask  */
+
+
+/* -------- EIC_INTFLAG : (EIC Offset: 0x14) (R/W 32) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint32_t EXTINT:8;                  /**< bit:   0..7  External Interrupt                       */
+    __I uint32_t :23;                       /**< bit:  8..30  Reserved */
+    __I uint32_t NSCHK:1;                   /**< bit:     31  Non-secure Check Interrupt               */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} EIC_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_INTFLAG_OFFSET                  (0x14)                                        /**<  (EIC_INTFLAG) Interrupt Flag Status and Clear  Offset */
+#define EIC_INTFLAG_RESETVALUE              _U_(0x00)                                     /**<  (EIC_INTFLAG) Interrupt Flag Status and Clear  Reset Value */
+
+#define EIC_INTFLAG_EXTINT_Pos              0                                              /**< (EIC_INTFLAG) External Interrupt Position */
+#define EIC_INTFLAG_EXTINT_Msk              (_U_(0xFF) << EIC_INTFLAG_EXTINT_Pos)          /**< (EIC_INTFLAG) External Interrupt Mask */
+#define EIC_INTFLAG_EXTINT(value)           (EIC_INTFLAG_EXTINT_Msk & ((value) << EIC_INTFLAG_EXTINT_Pos))
+#define EIC_INTFLAG_NSCHK_Pos               31                                             /**< (EIC_INTFLAG) Non-secure Check Interrupt Position */
+#define EIC_INTFLAG_NSCHK_Msk               (_U_(0x1) << EIC_INTFLAG_NSCHK_Pos)            /**< (EIC_INTFLAG) Non-secure Check Interrupt Mask */
+#define EIC_INTFLAG_NSCHK                   EIC_INTFLAG_NSCHK_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use EIC_INTFLAG_NSCHK_Msk instead */
+#define EIC_INTFLAG_MASK                    _U_(0x800000FF)                                /**< \deprecated (EIC_INTFLAG) Register MASK  (Use EIC_INTFLAG_Msk instead)  */
+#define EIC_INTFLAG_Msk                     _U_(0x800000FF)                                /**< (EIC_INTFLAG) Register Mask  */
+
+
+/* -------- EIC_ASYNCH : (EIC Offset: 0x18) (R/W 32) External Interrupt Asynchronous Mode -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t ASYNCH:8;                  /**< bit:   0..7  Asynchronous Edge Detection Mode         */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} EIC_ASYNCH_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_ASYNCH_OFFSET                   (0x18)                                        /**<  (EIC_ASYNCH) External Interrupt Asynchronous Mode  Offset */
+#define EIC_ASYNCH_RESETVALUE               _U_(0x00)                                     /**<  (EIC_ASYNCH) External Interrupt Asynchronous Mode  Reset Value */
+
+#define EIC_ASYNCH_ASYNCH_Pos               0                                              /**< (EIC_ASYNCH) Asynchronous Edge Detection Mode Position */
+#define EIC_ASYNCH_ASYNCH_Msk               (_U_(0xFF) << EIC_ASYNCH_ASYNCH_Pos)           /**< (EIC_ASYNCH) Asynchronous Edge Detection Mode Mask */
+#define EIC_ASYNCH_ASYNCH(value)            (EIC_ASYNCH_ASYNCH_Msk & ((value) << EIC_ASYNCH_ASYNCH_Pos))
+#define EIC_ASYNCH_MASK                     _U_(0xFF)                                      /**< \deprecated (EIC_ASYNCH) Register MASK  (Use EIC_ASYNCH_Msk instead)  */
+#define EIC_ASYNCH_Msk                      _U_(0xFF)                                      /**< (EIC_ASYNCH) Register Mask  */
+
+
+/* -------- EIC_CONFIG : (EIC Offset: 0x1c) (R/W 32) External Interrupt Sense Configuration -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SENSE0:3;                  /**< bit:   0..2  Input Sense Configuration 0              */
+    uint32_t FILTEN0:1;                 /**< bit:      3  Filter Enable 0                          */
+    uint32_t SENSE1:3;                  /**< bit:   4..6  Input Sense Configuration 1              */
+    uint32_t FILTEN1:1;                 /**< bit:      7  Filter Enable 1                          */
+    uint32_t SENSE2:3;                  /**< bit:  8..10  Input Sense Configuration 2              */
+    uint32_t FILTEN2:1;                 /**< bit:     11  Filter Enable 2                          */
+    uint32_t SENSE3:3;                  /**< bit: 12..14  Input Sense Configuration 3              */
+    uint32_t FILTEN3:1;                 /**< bit:     15  Filter Enable 3                          */
+    uint32_t SENSE4:3;                  /**< bit: 16..18  Input Sense Configuration 4              */
+    uint32_t FILTEN4:1;                 /**< bit:     19  Filter Enable 4                          */
+    uint32_t SENSE5:3;                  /**< bit: 20..22  Input Sense Configuration 5              */
+    uint32_t FILTEN5:1;                 /**< bit:     23  Filter Enable 5                          */
+    uint32_t SENSE6:3;                  /**< bit: 24..26  Input Sense Configuration 6              */
+    uint32_t FILTEN6:1;                 /**< bit:     27  Filter Enable 6                          */
+    uint32_t SENSE7:3;                  /**< bit: 28..30  Input Sense Configuration 7              */
+    uint32_t FILTEN7:1;                 /**< bit:     31  Filter Enable 7                          */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} EIC_CONFIG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_CONFIG_OFFSET                   (0x1C)                                        /**<  (EIC_CONFIG) External Interrupt Sense Configuration  Offset */
+#define EIC_CONFIG_RESETVALUE               _U_(0x00)                                     /**<  (EIC_CONFIG) External Interrupt Sense Configuration  Reset Value */
+
+#define EIC_CONFIG_SENSE0_Pos               0                                              /**< (EIC_CONFIG) Input Sense Configuration 0 Position */
+#define EIC_CONFIG_SENSE0_Msk               (_U_(0x7) << EIC_CONFIG_SENSE0_Pos)            /**< (EIC_CONFIG) Input Sense Configuration 0 Mask */
+#define EIC_CONFIG_SENSE0(value)            (EIC_CONFIG_SENSE0_Msk & ((value) << EIC_CONFIG_SENSE0_Pos))
+#define   EIC_CONFIG_SENSE0_NONE_Val        _U_(0x0)                                       /**< (EIC_CONFIG) No detection  */
+#define   EIC_CONFIG_SENSE0_RISE_Val        _U_(0x1)                                       /**< (EIC_CONFIG) Rising edge detection  */
+#define   EIC_CONFIG_SENSE0_FALL_Val        _U_(0x2)                                       /**< (EIC_CONFIG) Falling edge detection  */
+#define   EIC_CONFIG_SENSE0_BOTH_Val        _U_(0x3)                                       /**< (EIC_CONFIG) Both edges detection  */
+#define   EIC_CONFIG_SENSE0_HIGH_Val        _U_(0x4)                                       /**< (EIC_CONFIG) High level detection  */
+#define   EIC_CONFIG_SENSE0_LOW_Val         _U_(0x5)                                       /**< (EIC_CONFIG) Low level detection  */
+#define EIC_CONFIG_SENSE0_NONE              (EIC_CONFIG_SENSE0_NONE_Val << EIC_CONFIG_SENSE0_Pos)  /**< (EIC_CONFIG) No detection Position  */
+#define EIC_CONFIG_SENSE0_RISE              (EIC_CONFIG_SENSE0_RISE_Val << EIC_CONFIG_SENSE0_Pos)  /**< (EIC_CONFIG) Rising edge detection Position  */
+#define EIC_CONFIG_SENSE0_FALL              (EIC_CONFIG_SENSE0_FALL_Val << EIC_CONFIG_SENSE0_Pos)  /**< (EIC_CONFIG) Falling edge detection Position  */
+#define EIC_CONFIG_SENSE0_BOTH              (EIC_CONFIG_SENSE0_BOTH_Val << EIC_CONFIG_SENSE0_Pos)  /**< (EIC_CONFIG) Both edges detection Position  */
+#define EIC_CONFIG_SENSE0_HIGH              (EIC_CONFIG_SENSE0_HIGH_Val << EIC_CONFIG_SENSE0_Pos)  /**< (EIC_CONFIG) High level detection Position  */
+#define EIC_CONFIG_SENSE0_LOW               (EIC_CONFIG_SENSE0_LOW_Val << EIC_CONFIG_SENSE0_Pos)  /**< (EIC_CONFIG) Low level detection Position  */
+#define EIC_CONFIG_FILTEN0_Pos              3                                              /**< (EIC_CONFIG) Filter Enable 0 Position */
+#define EIC_CONFIG_FILTEN0_Msk              (_U_(0x1) << EIC_CONFIG_FILTEN0_Pos)           /**< (EIC_CONFIG) Filter Enable 0 Mask */
+#define EIC_CONFIG_FILTEN0                  EIC_CONFIG_FILTEN0_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use EIC_CONFIG_FILTEN0_Msk instead */
+#define EIC_CONFIG_SENSE1_Pos               4                                              /**< (EIC_CONFIG) Input Sense Configuration 1 Position */
+#define EIC_CONFIG_SENSE1_Msk               (_U_(0x7) << EIC_CONFIG_SENSE1_Pos)            /**< (EIC_CONFIG) Input Sense Configuration 1 Mask */
+#define EIC_CONFIG_SENSE1(value)            (EIC_CONFIG_SENSE1_Msk & ((value) << EIC_CONFIG_SENSE1_Pos))
+#define   EIC_CONFIG_SENSE1_NONE_Val        _U_(0x0)                                       /**< (EIC_CONFIG) No detection  */
+#define   EIC_CONFIG_SENSE1_RISE_Val        _U_(0x1)                                       /**< (EIC_CONFIG) Rising edge detection  */
+#define   EIC_CONFIG_SENSE1_FALL_Val        _U_(0x2)                                       /**< (EIC_CONFIG) Falling edge detection  */
+#define   EIC_CONFIG_SENSE1_BOTH_Val        _U_(0x3)                                       /**< (EIC_CONFIG) Both edges detection  */
+#define   EIC_CONFIG_SENSE1_HIGH_Val        _U_(0x4)                                       /**< (EIC_CONFIG) High level detection  */
+#define   EIC_CONFIG_SENSE1_LOW_Val         _U_(0x5)                                       /**< (EIC_CONFIG) Low level detection  */
+#define EIC_CONFIG_SENSE1_NONE              (EIC_CONFIG_SENSE1_NONE_Val << EIC_CONFIG_SENSE1_Pos)  /**< (EIC_CONFIG) No detection Position  */
+#define EIC_CONFIG_SENSE1_RISE              (EIC_CONFIG_SENSE1_RISE_Val << EIC_CONFIG_SENSE1_Pos)  /**< (EIC_CONFIG) Rising edge detection Position  */
+#define EIC_CONFIG_SENSE1_FALL              (EIC_CONFIG_SENSE1_FALL_Val << EIC_CONFIG_SENSE1_Pos)  /**< (EIC_CONFIG) Falling edge detection Position  */
+#define EIC_CONFIG_SENSE1_BOTH              (EIC_CONFIG_SENSE1_BOTH_Val << EIC_CONFIG_SENSE1_Pos)  /**< (EIC_CONFIG) Both edges detection Position  */
+#define EIC_CONFIG_SENSE1_HIGH              (EIC_CONFIG_SENSE1_HIGH_Val << EIC_CONFIG_SENSE1_Pos)  /**< (EIC_CONFIG) High level detection Position  */
+#define EIC_CONFIG_SENSE1_LOW               (EIC_CONFIG_SENSE1_LOW_Val << EIC_CONFIG_SENSE1_Pos)  /**< (EIC_CONFIG) Low level detection Position  */
+#define EIC_CONFIG_FILTEN1_Pos              7                                              /**< (EIC_CONFIG) Filter Enable 1 Position */
+#define EIC_CONFIG_FILTEN1_Msk              (_U_(0x1) << EIC_CONFIG_FILTEN1_Pos)           /**< (EIC_CONFIG) Filter Enable 1 Mask */
+#define EIC_CONFIG_FILTEN1                  EIC_CONFIG_FILTEN1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use EIC_CONFIG_FILTEN1_Msk instead */
+#define EIC_CONFIG_SENSE2_Pos               8                                              /**< (EIC_CONFIG) Input Sense Configuration 2 Position */
+#define EIC_CONFIG_SENSE2_Msk               (_U_(0x7) << EIC_CONFIG_SENSE2_Pos)            /**< (EIC_CONFIG) Input Sense Configuration 2 Mask */
+#define EIC_CONFIG_SENSE2(value)            (EIC_CONFIG_SENSE2_Msk & ((value) << EIC_CONFIG_SENSE2_Pos))
+#define   EIC_CONFIG_SENSE2_NONE_Val        _U_(0x0)                                       /**< (EIC_CONFIG) No detection  */
+#define   EIC_CONFIG_SENSE2_RISE_Val        _U_(0x1)                                       /**< (EIC_CONFIG) Rising edge detection  */
+#define   EIC_CONFIG_SENSE2_FALL_Val        _U_(0x2)                                       /**< (EIC_CONFIG) Falling edge detection  */
+#define   EIC_CONFIG_SENSE2_BOTH_Val        _U_(0x3)                                       /**< (EIC_CONFIG) Both edges detection  */
+#define   EIC_CONFIG_SENSE2_HIGH_Val        _U_(0x4)                                       /**< (EIC_CONFIG) High level detection  */
+#define   EIC_CONFIG_SENSE2_LOW_Val         _U_(0x5)                                       /**< (EIC_CONFIG) Low level detection  */
+#define EIC_CONFIG_SENSE2_NONE              (EIC_CONFIG_SENSE2_NONE_Val << EIC_CONFIG_SENSE2_Pos)  /**< (EIC_CONFIG) No detection Position  */
+#define EIC_CONFIG_SENSE2_RISE              (EIC_CONFIG_SENSE2_RISE_Val << EIC_CONFIG_SENSE2_Pos)  /**< (EIC_CONFIG) Rising edge detection Position  */
+#define EIC_CONFIG_SENSE2_FALL              (EIC_CONFIG_SENSE2_FALL_Val << EIC_CONFIG_SENSE2_Pos)  /**< (EIC_CONFIG) Falling edge detection Position  */
+#define EIC_CONFIG_SENSE2_BOTH              (EIC_CONFIG_SENSE2_BOTH_Val << EIC_CONFIG_SENSE2_Pos)  /**< (EIC_CONFIG) Both edges detection Position  */
+#define EIC_CONFIG_SENSE2_HIGH              (EIC_CONFIG_SENSE2_HIGH_Val << EIC_CONFIG_SENSE2_Pos)  /**< (EIC_CONFIG) High level detection Position  */
+#define EIC_CONFIG_SENSE2_LOW               (EIC_CONFIG_SENSE2_LOW_Val << EIC_CONFIG_SENSE2_Pos)  /**< (EIC_CONFIG) Low level detection Position  */
+#define EIC_CONFIG_FILTEN2_Pos              11                                             /**< (EIC_CONFIG) Filter Enable 2 Position */
+#define EIC_CONFIG_FILTEN2_Msk              (_U_(0x1) << EIC_CONFIG_FILTEN2_Pos)           /**< (EIC_CONFIG) Filter Enable 2 Mask */
+#define EIC_CONFIG_FILTEN2                  EIC_CONFIG_FILTEN2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use EIC_CONFIG_FILTEN2_Msk instead */
+#define EIC_CONFIG_SENSE3_Pos               12                                             /**< (EIC_CONFIG) Input Sense Configuration 3 Position */
+#define EIC_CONFIG_SENSE3_Msk               (_U_(0x7) << EIC_CONFIG_SENSE3_Pos)            /**< (EIC_CONFIG) Input Sense Configuration 3 Mask */
+#define EIC_CONFIG_SENSE3(value)            (EIC_CONFIG_SENSE3_Msk & ((value) << EIC_CONFIG_SENSE3_Pos))
+#define   EIC_CONFIG_SENSE3_NONE_Val        _U_(0x0)                                       /**< (EIC_CONFIG) No detection  */
+#define   EIC_CONFIG_SENSE3_RISE_Val        _U_(0x1)                                       /**< (EIC_CONFIG) Rising edge detection  */
+#define   EIC_CONFIG_SENSE3_FALL_Val        _U_(0x2)                                       /**< (EIC_CONFIG) Falling edge detection  */
+#define   EIC_CONFIG_SENSE3_BOTH_Val        _U_(0x3)                                       /**< (EIC_CONFIG) Both edges detection  */
+#define   EIC_CONFIG_SENSE3_HIGH_Val        _U_(0x4)                                       /**< (EIC_CONFIG) High level detection  */
+#define   EIC_CONFIG_SENSE3_LOW_Val         _U_(0x5)                                       /**< (EIC_CONFIG) Low level detection  */
+#define EIC_CONFIG_SENSE3_NONE              (EIC_CONFIG_SENSE3_NONE_Val << EIC_CONFIG_SENSE3_Pos)  /**< (EIC_CONFIG) No detection Position  */
+#define EIC_CONFIG_SENSE3_RISE              (EIC_CONFIG_SENSE3_RISE_Val << EIC_CONFIG_SENSE3_Pos)  /**< (EIC_CONFIG) Rising edge detection Position  */
+#define EIC_CONFIG_SENSE3_FALL              (EIC_CONFIG_SENSE3_FALL_Val << EIC_CONFIG_SENSE3_Pos)  /**< (EIC_CONFIG) Falling edge detection Position  */
+#define EIC_CONFIG_SENSE3_BOTH              (EIC_CONFIG_SENSE3_BOTH_Val << EIC_CONFIG_SENSE3_Pos)  /**< (EIC_CONFIG) Both edges detection Position  */
+#define EIC_CONFIG_SENSE3_HIGH              (EIC_CONFIG_SENSE3_HIGH_Val << EIC_CONFIG_SENSE3_Pos)  /**< (EIC_CONFIG) High level detection Position  */
+#define EIC_CONFIG_SENSE3_LOW               (EIC_CONFIG_SENSE3_LOW_Val << EIC_CONFIG_SENSE3_Pos)  /**< (EIC_CONFIG) Low level detection Position  */
+#define EIC_CONFIG_FILTEN3_Pos              15                                             /**< (EIC_CONFIG) Filter Enable 3 Position */
+#define EIC_CONFIG_FILTEN3_Msk              (_U_(0x1) << EIC_CONFIG_FILTEN3_Pos)           /**< (EIC_CONFIG) Filter Enable 3 Mask */
+#define EIC_CONFIG_FILTEN3                  EIC_CONFIG_FILTEN3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use EIC_CONFIG_FILTEN3_Msk instead */
+#define EIC_CONFIG_SENSE4_Pos               16                                             /**< (EIC_CONFIG) Input Sense Configuration 4 Position */
+#define EIC_CONFIG_SENSE4_Msk               (_U_(0x7) << EIC_CONFIG_SENSE4_Pos)            /**< (EIC_CONFIG) Input Sense Configuration 4 Mask */
+#define EIC_CONFIG_SENSE4(value)            (EIC_CONFIG_SENSE4_Msk & ((value) << EIC_CONFIG_SENSE4_Pos))
+#define   EIC_CONFIG_SENSE4_NONE_Val        _U_(0x0)                                       /**< (EIC_CONFIG) No detection  */
+#define   EIC_CONFIG_SENSE4_RISE_Val        _U_(0x1)                                       /**< (EIC_CONFIG) Rising edge detection  */
+#define   EIC_CONFIG_SENSE4_FALL_Val        _U_(0x2)                                       /**< (EIC_CONFIG) Falling edge detection  */
+#define   EIC_CONFIG_SENSE4_BOTH_Val        _U_(0x3)                                       /**< (EIC_CONFIG) Both edges detection  */
+#define   EIC_CONFIG_SENSE4_HIGH_Val        _U_(0x4)                                       /**< (EIC_CONFIG) High level detection  */
+#define   EIC_CONFIG_SENSE4_LOW_Val         _U_(0x5)                                       /**< (EIC_CONFIG) Low level detection  */
+#define EIC_CONFIG_SENSE4_NONE              (EIC_CONFIG_SENSE4_NONE_Val << EIC_CONFIG_SENSE4_Pos)  /**< (EIC_CONFIG) No detection Position  */
+#define EIC_CONFIG_SENSE4_RISE              (EIC_CONFIG_SENSE4_RISE_Val << EIC_CONFIG_SENSE4_Pos)  /**< (EIC_CONFIG) Rising edge detection Position  */
+#define EIC_CONFIG_SENSE4_FALL              (EIC_CONFIG_SENSE4_FALL_Val << EIC_CONFIG_SENSE4_Pos)  /**< (EIC_CONFIG) Falling edge detection Position  */
+#define EIC_CONFIG_SENSE4_BOTH              (EIC_CONFIG_SENSE4_BOTH_Val << EIC_CONFIG_SENSE4_Pos)  /**< (EIC_CONFIG) Both edges detection Position  */
+#define EIC_CONFIG_SENSE4_HIGH              (EIC_CONFIG_SENSE4_HIGH_Val << EIC_CONFIG_SENSE4_Pos)  /**< (EIC_CONFIG) High level detection Position  */
+#define EIC_CONFIG_SENSE4_LOW               (EIC_CONFIG_SENSE4_LOW_Val << EIC_CONFIG_SENSE4_Pos)  /**< (EIC_CONFIG) Low level detection Position  */
+#define EIC_CONFIG_FILTEN4_Pos              19                                             /**< (EIC_CONFIG) Filter Enable 4 Position */
+#define EIC_CONFIG_FILTEN4_Msk              (_U_(0x1) << EIC_CONFIG_FILTEN4_Pos)           /**< (EIC_CONFIG) Filter Enable 4 Mask */
+#define EIC_CONFIG_FILTEN4                  EIC_CONFIG_FILTEN4_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use EIC_CONFIG_FILTEN4_Msk instead */
+#define EIC_CONFIG_SENSE5_Pos               20                                             /**< (EIC_CONFIG) Input Sense Configuration 5 Position */
+#define EIC_CONFIG_SENSE5_Msk               (_U_(0x7) << EIC_CONFIG_SENSE5_Pos)            /**< (EIC_CONFIG) Input Sense Configuration 5 Mask */
+#define EIC_CONFIG_SENSE5(value)            (EIC_CONFIG_SENSE5_Msk & ((value) << EIC_CONFIG_SENSE5_Pos))
+#define   EIC_CONFIG_SENSE5_NONE_Val        _U_(0x0)                                       /**< (EIC_CONFIG) No detection  */
+#define   EIC_CONFIG_SENSE5_RISE_Val        _U_(0x1)                                       /**< (EIC_CONFIG) Rising edge detection  */
+#define   EIC_CONFIG_SENSE5_FALL_Val        _U_(0x2)                                       /**< (EIC_CONFIG) Falling edge detection  */
+#define   EIC_CONFIG_SENSE5_BOTH_Val        _U_(0x3)                                       /**< (EIC_CONFIG) Both edges detection  */
+#define   EIC_CONFIG_SENSE5_HIGH_Val        _U_(0x4)                                       /**< (EIC_CONFIG) High level detection  */
+#define   EIC_CONFIG_SENSE5_LOW_Val         _U_(0x5)                                       /**< (EIC_CONFIG) Low level detection  */
+#define EIC_CONFIG_SENSE5_NONE              (EIC_CONFIG_SENSE5_NONE_Val << EIC_CONFIG_SENSE5_Pos)  /**< (EIC_CONFIG) No detection Position  */
+#define EIC_CONFIG_SENSE5_RISE              (EIC_CONFIG_SENSE5_RISE_Val << EIC_CONFIG_SENSE5_Pos)  /**< (EIC_CONFIG) Rising edge detection Position  */
+#define EIC_CONFIG_SENSE5_FALL              (EIC_CONFIG_SENSE5_FALL_Val << EIC_CONFIG_SENSE5_Pos)  /**< (EIC_CONFIG) Falling edge detection Position  */
+#define EIC_CONFIG_SENSE5_BOTH              (EIC_CONFIG_SENSE5_BOTH_Val << EIC_CONFIG_SENSE5_Pos)  /**< (EIC_CONFIG) Both edges detection Position  */
+#define EIC_CONFIG_SENSE5_HIGH              (EIC_CONFIG_SENSE5_HIGH_Val << EIC_CONFIG_SENSE5_Pos)  /**< (EIC_CONFIG) High level detection Position  */
+#define EIC_CONFIG_SENSE5_LOW               (EIC_CONFIG_SENSE5_LOW_Val << EIC_CONFIG_SENSE5_Pos)  /**< (EIC_CONFIG) Low level detection Position  */
+#define EIC_CONFIG_FILTEN5_Pos              23                                             /**< (EIC_CONFIG) Filter Enable 5 Position */
+#define EIC_CONFIG_FILTEN5_Msk              (_U_(0x1) << EIC_CONFIG_FILTEN5_Pos)           /**< (EIC_CONFIG) Filter Enable 5 Mask */
+#define EIC_CONFIG_FILTEN5                  EIC_CONFIG_FILTEN5_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use EIC_CONFIG_FILTEN5_Msk instead */
+#define EIC_CONFIG_SENSE6_Pos               24                                             /**< (EIC_CONFIG) Input Sense Configuration 6 Position */
+#define EIC_CONFIG_SENSE6_Msk               (_U_(0x7) << EIC_CONFIG_SENSE6_Pos)            /**< (EIC_CONFIG) Input Sense Configuration 6 Mask */
+#define EIC_CONFIG_SENSE6(value)            (EIC_CONFIG_SENSE6_Msk & ((value) << EIC_CONFIG_SENSE6_Pos))
+#define   EIC_CONFIG_SENSE6_NONE_Val        _U_(0x0)                                       /**< (EIC_CONFIG) No detection  */
+#define   EIC_CONFIG_SENSE6_RISE_Val        _U_(0x1)                                       /**< (EIC_CONFIG) Rising edge detection  */
+#define   EIC_CONFIG_SENSE6_FALL_Val        _U_(0x2)                                       /**< (EIC_CONFIG) Falling edge detection  */
+#define   EIC_CONFIG_SENSE6_BOTH_Val        _U_(0x3)                                       /**< (EIC_CONFIG) Both edges detection  */
+#define   EIC_CONFIG_SENSE6_HIGH_Val        _U_(0x4)                                       /**< (EIC_CONFIG) High level detection  */
+#define   EIC_CONFIG_SENSE6_LOW_Val         _U_(0x5)                                       /**< (EIC_CONFIG) Low level detection  */
+#define EIC_CONFIG_SENSE6_NONE              (EIC_CONFIG_SENSE6_NONE_Val << EIC_CONFIG_SENSE6_Pos)  /**< (EIC_CONFIG) No detection Position  */
+#define EIC_CONFIG_SENSE6_RISE              (EIC_CONFIG_SENSE6_RISE_Val << EIC_CONFIG_SENSE6_Pos)  /**< (EIC_CONFIG) Rising edge detection Position  */
+#define EIC_CONFIG_SENSE6_FALL              (EIC_CONFIG_SENSE6_FALL_Val << EIC_CONFIG_SENSE6_Pos)  /**< (EIC_CONFIG) Falling edge detection Position  */
+#define EIC_CONFIG_SENSE6_BOTH              (EIC_CONFIG_SENSE6_BOTH_Val << EIC_CONFIG_SENSE6_Pos)  /**< (EIC_CONFIG) Both edges detection Position  */
+#define EIC_CONFIG_SENSE6_HIGH              (EIC_CONFIG_SENSE6_HIGH_Val << EIC_CONFIG_SENSE6_Pos)  /**< (EIC_CONFIG) High level detection Position  */
+#define EIC_CONFIG_SENSE6_LOW               (EIC_CONFIG_SENSE6_LOW_Val << EIC_CONFIG_SENSE6_Pos)  /**< (EIC_CONFIG) Low level detection Position  */
+#define EIC_CONFIG_FILTEN6_Pos              27                                             /**< (EIC_CONFIG) Filter Enable 6 Position */
+#define EIC_CONFIG_FILTEN6_Msk              (_U_(0x1) << EIC_CONFIG_FILTEN6_Pos)           /**< (EIC_CONFIG) Filter Enable 6 Mask */
+#define EIC_CONFIG_FILTEN6                  EIC_CONFIG_FILTEN6_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use EIC_CONFIG_FILTEN6_Msk instead */
+#define EIC_CONFIG_SENSE7_Pos               28                                             /**< (EIC_CONFIG) Input Sense Configuration 7 Position */
+#define EIC_CONFIG_SENSE7_Msk               (_U_(0x7) << EIC_CONFIG_SENSE7_Pos)            /**< (EIC_CONFIG) Input Sense Configuration 7 Mask */
+#define EIC_CONFIG_SENSE7(value)            (EIC_CONFIG_SENSE7_Msk & ((value) << EIC_CONFIG_SENSE7_Pos))
+#define   EIC_CONFIG_SENSE7_NONE_Val        _U_(0x0)                                       /**< (EIC_CONFIG) No detection  */
+#define   EIC_CONFIG_SENSE7_RISE_Val        _U_(0x1)                                       /**< (EIC_CONFIG) Rising edge detection  */
+#define   EIC_CONFIG_SENSE7_FALL_Val        _U_(0x2)                                       /**< (EIC_CONFIG) Falling edge detection  */
+#define   EIC_CONFIG_SENSE7_BOTH_Val        _U_(0x3)                                       /**< (EIC_CONFIG) Both edges detection  */
+#define   EIC_CONFIG_SENSE7_HIGH_Val        _U_(0x4)                                       /**< (EIC_CONFIG) High level detection  */
+#define   EIC_CONFIG_SENSE7_LOW_Val         _U_(0x5)                                       /**< (EIC_CONFIG) Low level detection  */
+#define EIC_CONFIG_SENSE7_NONE              (EIC_CONFIG_SENSE7_NONE_Val << EIC_CONFIG_SENSE7_Pos)  /**< (EIC_CONFIG) No detection Position  */
+#define EIC_CONFIG_SENSE7_RISE              (EIC_CONFIG_SENSE7_RISE_Val << EIC_CONFIG_SENSE7_Pos)  /**< (EIC_CONFIG) Rising edge detection Position  */
+#define EIC_CONFIG_SENSE7_FALL              (EIC_CONFIG_SENSE7_FALL_Val << EIC_CONFIG_SENSE7_Pos)  /**< (EIC_CONFIG) Falling edge detection Position  */
+#define EIC_CONFIG_SENSE7_BOTH              (EIC_CONFIG_SENSE7_BOTH_Val << EIC_CONFIG_SENSE7_Pos)  /**< (EIC_CONFIG) Both edges detection Position  */
+#define EIC_CONFIG_SENSE7_HIGH              (EIC_CONFIG_SENSE7_HIGH_Val << EIC_CONFIG_SENSE7_Pos)  /**< (EIC_CONFIG) High level detection Position  */
+#define EIC_CONFIG_SENSE7_LOW               (EIC_CONFIG_SENSE7_LOW_Val << EIC_CONFIG_SENSE7_Pos)  /**< (EIC_CONFIG) Low level detection Position  */
+#define EIC_CONFIG_FILTEN7_Pos              31                                             /**< (EIC_CONFIG) Filter Enable 7 Position */
+#define EIC_CONFIG_FILTEN7_Msk              (_U_(0x1) << EIC_CONFIG_FILTEN7_Pos)           /**< (EIC_CONFIG) Filter Enable 7 Mask */
+#define EIC_CONFIG_FILTEN7                  EIC_CONFIG_FILTEN7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use EIC_CONFIG_FILTEN7_Msk instead */
+#define EIC_CONFIG_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (EIC_CONFIG) Register MASK  (Use EIC_CONFIG_Msk instead)  */
+#define EIC_CONFIG_Msk                      _U_(0xFFFFFFFF)                                /**< (EIC_CONFIG) Register Mask  */
+
+
+/* -------- EIC_DEBOUNCEN : (EIC Offset: 0x30) (R/W 32) Debouncer Enable -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t DEBOUNCEN:8;               /**< bit:   0..7  Debouncer Enable                         */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} EIC_DEBOUNCEN_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_DEBOUNCEN_OFFSET                (0x30)                                        /**<  (EIC_DEBOUNCEN) Debouncer Enable  Offset */
+#define EIC_DEBOUNCEN_RESETVALUE            _U_(0x00)                                     /**<  (EIC_DEBOUNCEN) Debouncer Enable  Reset Value */
+
+#define EIC_DEBOUNCEN_DEBOUNCEN_Pos         0                                              /**< (EIC_DEBOUNCEN) Debouncer Enable Position */
+#define EIC_DEBOUNCEN_DEBOUNCEN_Msk         (_U_(0xFF) << EIC_DEBOUNCEN_DEBOUNCEN_Pos)     /**< (EIC_DEBOUNCEN) Debouncer Enable Mask */
+#define EIC_DEBOUNCEN_DEBOUNCEN(value)      (EIC_DEBOUNCEN_DEBOUNCEN_Msk & ((value) << EIC_DEBOUNCEN_DEBOUNCEN_Pos))
+#define EIC_DEBOUNCEN_MASK                  _U_(0xFF)                                      /**< \deprecated (EIC_DEBOUNCEN) Register MASK  (Use EIC_DEBOUNCEN_Msk instead)  */
+#define EIC_DEBOUNCEN_Msk                   _U_(0xFF)                                      /**< (EIC_DEBOUNCEN) Register Mask  */
+
+
+/* -------- EIC_DPRESCALER : (EIC Offset: 0x34) (R/W 32) Debouncer Prescaler -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t PRESCALER0:3;              /**< bit:   0..2  Debouncer Prescaler                      */
+    uint32_t STATES0:1;                 /**< bit:      3  Debouncer number of states               */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t TICKON:1;                  /**< bit:     16  Pin Sampler frequency selection          */
+    uint32_t :15;                       /**< bit: 17..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :3;                        /**< bit:   0..2  Reserved */
+    uint32_t STATES:1;                  /**< bit:      3  Debouncer number of states               */
+    uint32_t :28;                       /**< bit:  4..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} EIC_DPRESCALER_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_DPRESCALER_OFFSET               (0x34)                                        /**<  (EIC_DPRESCALER) Debouncer Prescaler  Offset */
+#define EIC_DPRESCALER_RESETVALUE           _U_(0x00)                                     /**<  (EIC_DPRESCALER) Debouncer Prescaler  Reset Value */
+
+#define EIC_DPRESCALER_PRESCALER0_Pos       0                                              /**< (EIC_DPRESCALER) Debouncer Prescaler Position */
+#define EIC_DPRESCALER_PRESCALER0_Msk       (_U_(0x7) << EIC_DPRESCALER_PRESCALER0_Pos)    /**< (EIC_DPRESCALER) Debouncer Prescaler Mask */
+#define EIC_DPRESCALER_PRESCALER0(value)    (EIC_DPRESCALER_PRESCALER0_Msk & ((value) << EIC_DPRESCALER_PRESCALER0_Pos))
+#define EIC_DPRESCALER_STATES0_Pos          3                                              /**< (EIC_DPRESCALER) Debouncer number of states Position */
+#define EIC_DPRESCALER_STATES0_Msk          (_U_(0x1) << EIC_DPRESCALER_STATES0_Pos)       /**< (EIC_DPRESCALER) Debouncer number of states Mask */
+#define EIC_DPRESCALER_STATES0              EIC_DPRESCALER_STATES0_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EIC_DPRESCALER_STATES0_Msk instead */
+#define EIC_DPRESCALER_TICKON_Pos           16                                             /**< (EIC_DPRESCALER) Pin Sampler frequency selection Position */
+#define EIC_DPRESCALER_TICKON_Msk           (_U_(0x1) << EIC_DPRESCALER_TICKON_Pos)        /**< (EIC_DPRESCALER) Pin Sampler frequency selection Mask */
+#define EIC_DPRESCALER_TICKON               EIC_DPRESCALER_TICKON_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use EIC_DPRESCALER_TICKON_Msk instead */
+#define EIC_DPRESCALER_MASK                 _U_(0x1000F)                                   /**< \deprecated (EIC_DPRESCALER) Register MASK  (Use EIC_DPRESCALER_Msk instead)  */
+#define EIC_DPRESCALER_Msk                  _U_(0x1000F)                                   /**< (EIC_DPRESCALER) Register Mask  */
+
+#define EIC_DPRESCALER_STATES_Pos           3                                              /**< (EIC_DPRESCALER Position) Debouncer number of states */
+#define EIC_DPRESCALER_STATES_Msk           (_U_(0x1) << EIC_DPRESCALER_STATES_Pos)        /**< (EIC_DPRESCALER Mask) STATES */
+#define EIC_DPRESCALER_STATES(value)        (EIC_DPRESCALER_STATES_Msk & ((value) << EIC_DPRESCALER_STATES_Pos))  
+
+/* -------- EIC_PINSTATE : (EIC Offset: 0x38) (R/ 32) Pin State -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t PINSTATE:8;                /**< bit:   0..7  Pin State                                */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} EIC_PINSTATE_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_PINSTATE_OFFSET                 (0x38)                                        /**<  (EIC_PINSTATE) Pin State  Offset */
+#define EIC_PINSTATE_RESETVALUE             _U_(0x00)                                     /**<  (EIC_PINSTATE) Pin State  Reset Value */
+
+#define EIC_PINSTATE_PINSTATE_Pos           0                                              /**< (EIC_PINSTATE) Pin State Position */
+#define EIC_PINSTATE_PINSTATE_Msk           (_U_(0xFF) << EIC_PINSTATE_PINSTATE_Pos)       /**< (EIC_PINSTATE) Pin State Mask */
+#define EIC_PINSTATE_PINSTATE(value)        (EIC_PINSTATE_PINSTATE_Msk & ((value) << EIC_PINSTATE_PINSTATE_Pos))
+#define EIC_PINSTATE_MASK                   _U_(0xFF)                                      /**< \deprecated (EIC_PINSTATE) Register MASK  (Use EIC_PINSTATE_Msk instead)  */
+#define EIC_PINSTATE_Msk                    _U_(0xFF)                                      /**< (EIC_PINSTATE) Register Mask  */
+
+
+/* -------- EIC_NSCHK : (EIC Offset: 0x3c) (R/W 32) Non-secure Interrupt Check Enable -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t EXTINT:8;                  /**< bit:   0..7  External Interrupt Nonsecure Check Enable */
+    uint32_t :23;                       /**< bit:  8..30  Reserved */
+    uint32_t NMI:1;                     /**< bit:     31  Non-Maskable External Interrupt Nonsecure Check Enable */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} EIC_NSCHK_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_NSCHK_OFFSET                    (0x3C)                                        /**<  (EIC_NSCHK) Non-secure Interrupt Check Enable  Offset */
+#define EIC_NSCHK_RESETVALUE                _U_(0x00)                                     /**<  (EIC_NSCHK) Non-secure Interrupt Check Enable  Reset Value */
+
+#define EIC_NSCHK_EXTINT_Pos                0                                              /**< (EIC_NSCHK) External Interrupt Nonsecure Check Enable Position */
+#define EIC_NSCHK_EXTINT_Msk                (_U_(0xFF) << EIC_NSCHK_EXTINT_Pos)            /**< (EIC_NSCHK) External Interrupt Nonsecure Check Enable Mask */
+#define EIC_NSCHK_EXTINT(value)             (EIC_NSCHK_EXTINT_Msk & ((value) << EIC_NSCHK_EXTINT_Pos))
+#define EIC_NSCHK_NMI_Pos                   31                                             /**< (EIC_NSCHK) Non-Maskable External Interrupt Nonsecure Check Enable Position */
+#define EIC_NSCHK_NMI_Msk                   (_U_(0x1) << EIC_NSCHK_NMI_Pos)                /**< (EIC_NSCHK) Non-Maskable External Interrupt Nonsecure Check Enable Mask */
+#define EIC_NSCHK_NMI                       EIC_NSCHK_NMI_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use EIC_NSCHK_NMI_Msk instead */
+#define EIC_NSCHK_MASK                      _U_(0x800000FF)                                /**< \deprecated (EIC_NSCHK) Register MASK  (Use EIC_NSCHK_Msk instead)  */
+#define EIC_NSCHK_Msk                       _U_(0x800000FF)                                /**< (EIC_NSCHK) Register Mask  */
+
+
+/* -------- EIC_NONSEC : (EIC Offset: 0x40) (R/W 32) Non-secure Interrupt -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t EXTINT:8;                  /**< bit:   0..7  External Interrupt Nonsecure Enable      */
+    uint32_t :23;                       /**< bit:  8..30  Reserved */
+    uint32_t NMI:1;                     /**< bit:     31  Non-Maskable Interrupt Nonsecure Enable  */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} EIC_NONSEC_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_NONSEC_OFFSET                   (0x40)                                        /**<  (EIC_NONSEC) Non-secure Interrupt  Offset */
+#define EIC_NONSEC_RESETVALUE               _U_(0x00)                                     /**<  (EIC_NONSEC) Non-secure Interrupt  Reset Value */
+
+#define EIC_NONSEC_EXTINT_Pos               0                                              /**< (EIC_NONSEC) External Interrupt Nonsecure Enable Position */
+#define EIC_NONSEC_EXTINT_Msk               (_U_(0xFF) << EIC_NONSEC_EXTINT_Pos)           /**< (EIC_NONSEC) External Interrupt Nonsecure Enable Mask */
+#define EIC_NONSEC_EXTINT(value)            (EIC_NONSEC_EXTINT_Msk & ((value) << EIC_NONSEC_EXTINT_Pos))
+#define EIC_NONSEC_NMI_Pos                  31                                             /**< (EIC_NONSEC) Non-Maskable Interrupt Nonsecure Enable Position */
+#define EIC_NONSEC_NMI_Msk                  (_U_(0x1) << EIC_NONSEC_NMI_Pos)               /**< (EIC_NONSEC) Non-Maskable Interrupt Nonsecure Enable Mask */
+#define EIC_NONSEC_NMI                      EIC_NONSEC_NMI_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use EIC_NONSEC_NMI_Msk instead */
+#define EIC_NONSEC_MASK                     _U_(0x800000FF)                                /**< \deprecated (EIC_NONSEC) Register MASK  (Use EIC_NONSEC_Msk instead)  */
+#define EIC_NONSEC_Msk                      _U_(0x800000FF)                                /**< (EIC_NONSEC) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief EIC hardware registers */
+typedef struct {  /* External Interrupt Controller */
+  __IO EIC_CTRLA_Type                 CTRLA;          /**< Offset: 0x00 (R/W   8) Control A */
+  __IO EIC_NMICTRL_Type               NMICTRL;        /**< Offset: 0x01 (R/W   8) Non-Maskable Interrupt Control */
+  __IO EIC_NMIFLAG_Type               NMIFLAG;        /**< Offset: 0x02 (R/W  16) Non-Maskable Interrupt Flag Status and Clear */
+  __I  EIC_SYNCBUSY_Type              SYNCBUSY;       /**< Offset: 0x04 (R/   32) Synchronization Busy */
+  __IO EIC_EVCTRL_Type                EVCTRL;         /**< Offset: 0x08 (R/W  32) Event Control */
+  __IO EIC_INTENCLR_Type              INTENCLR;       /**< Offset: 0x0C (R/W  32) Interrupt Enable Clear */
+  __IO EIC_INTENSET_Type              INTENSET;       /**< Offset: 0x10 (R/W  32) Interrupt Enable Set */
+  __IO EIC_INTFLAG_Type               INTFLAG;        /**< Offset: 0x14 (R/W  32) Interrupt Flag Status and Clear */
+  __IO EIC_ASYNCH_Type                ASYNCH;         /**< Offset: 0x18 (R/W  32) External Interrupt Asynchronous Mode */
+  __IO EIC_CONFIG_Type                CONFIG[1];      /**< Offset: 0x1C (R/W  32) External Interrupt Sense Configuration */
+  __I  uint8_t                        Reserved1[16];
+  __IO EIC_DEBOUNCEN_Type             DEBOUNCEN;      /**< Offset: 0x30 (R/W  32) Debouncer Enable */
+  __IO EIC_DPRESCALER_Type            DPRESCALER;     /**< Offset: 0x34 (R/W  32) Debouncer Prescaler */
+  __I  EIC_PINSTATE_Type              PINSTATE;       /**< Offset: 0x38 (R/   32) Pin State */
+  __IO EIC_NSCHK_Type                 NSCHK;          /**< Offset: 0x3C (R/W  32) Non-secure Interrupt Check Enable */
+  __IO EIC_NONSEC_Type                NONSEC;         /**< Offset: 0x40 (R/W  32) Non-secure Interrupt */
+} Eic;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of External Interrupt Controller */
+
+#endif /* _SAML11_EIC_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/component/evsys.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/evsys.h
@@ -1,0 +1,927 @@
+/**
+ * \file
+ *
+ * \brief Component description for EVSYS
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_EVSYS_COMPONENT_H_
+#define _SAML11_EVSYS_COMPONENT_H_
+#define _SAML11_EVSYS_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML11 Event System Interface
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR EVSYS */
+/* ========================================================================== */
+
+#define EVSYS_U2504                      /**< (EVSYS) Module ID */
+#define REV_EVSYS 0x200                  /**< (EVSYS) Module revision */
+
+/* -------- EVSYS_CHANNEL : (EVSYS Offset: 0x00) (R/W 32) Channel n Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t EVGEN:6;                   /**< bit:   0..5  Event Generator Selection                */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t PATH:2;                    /**< bit:   8..9  Path Selection                           */
+    uint32_t EDGSEL:2;                  /**< bit: 10..11  Edge Detection Selection                 */
+    uint32_t :2;                        /**< bit: 12..13  Reserved */
+    uint32_t RUNSTDBY:1;                /**< bit:     14  Run in standby                           */
+    uint32_t ONDEMAND:1;                /**< bit:     15  Generic Clock On Demand                  */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} EVSYS_CHANNEL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_CHANNEL_OFFSET                (0x00)                                        /**<  (EVSYS_CHANNEL) Channel n Control  Offset */
+#define EVSYS_CHANNEL_RESETVALUE            _U_(0x8000)                                   /**<  (EVSYS_CHANNEL) Channel n Control  Reset Value */
+
+#define EVSYS_CHANNEL_EVGEN_Pos             0                                              /**< (EVSYS_CHANNEL) Event Generator Selection Position */
+#define EVSYS_CHANNEL_EVGEN_Msk             (_U_(0x3F) << EVSYS_CHANNEL_EVGEN_Pos)         /**< (EVSYS_CHANNEL) Event Generator Selection Mask */
+#define EVSYS_CHANNEL_EVGEN(value)          (EVSYS_CHANNEL_EVGEN_Msk & ((value) << EVSYS_CHANNEL_EVGEN_Pos))
+#define EVSYS_CHANNEL_PATH_Pos              8                                              /**< (EVSYS_CHANNEL) Path Selection Position */
+#define EVSYS_CHANNEL_PATH_Msk              (_U_(0x3) << EVSYS_CHANNEL_PATH_Pos)           /**< (EVSYS_CHANNEL) Path Selection Mask */
+#define EVSYS_CHANNEL_PATH(value)           (EVSYS_CHANNEL_PATH_Msk & ((value) << EVSYS_CHANNEL_PATH_Pos))
+#define   EVSYS_CHANNEL_PATH_SYNCHRONOUS_Val _U_(0x0)                                       /**< (EVSYS_CHANNEL) Synchronous path  */
+#define   EVSYS_CHANNEL_PATH_RESYNCHRONIZED_Val _U_(0x1)                                       /**< (EVSYS_CHANNEL) Resynchronized path  */
+#define   EVSYS_CHANNEL_PATH_ASYNCHRONOUS_Val _U_(0x2)                                       /**< (EVSYS_CHANNEL) Asynchronous path  */
+#define EVSYS_CHANNEL_PATH_SYNCHRONOUS      (EVSYS_CHANNEL_PATH_SYNCHRONOUS_Val << EVSYS_CHANNEL_PATH_Pos)  /**< (EVSYS_CHANNEL) Synchronous path Position  */
+#define EVSYS_CHANNEL_PATH_RESYNCHRONIZED   (EVSYS_CHANNEL_PATH_RESYNCHRONIZED_Val << EVSYS_CHANNEL_PATH_Pos)  /**< (EVSYS_CHANNEL) Resynchronized path Position  */
+#define EVSYS_CHANNEL_PATH_ASYNCHRONOUS     (EVSYS_CHANNEL_PATH_ASYNCHRONOUS_Val << EVSYS_CHANNEL_PATH_Pos)  /**< (EVSYS_CHANNEL) Asynchronous path Position  */
+#define EVSYS_CHANNEL_EDGSEL_Pos            10                                             /**< (EVSYS_CHANNEL) Edge Detection Selection Position */
+#define EVSYS_CHANNEL_EDGSEL_Msk            (_U_(0x3) << EVSYS_CHANNEL_EDGSEL_Pos)         /**< (EVSYS_CHANNEL) Edge Detection Selection Mask */
+#define EVSYS_CHANNEL_EDGSEL(value)         (EVSYS_CHANNEL_EDGSEL_Msk & ((value) << EVSYS_CHANNEL_EDGSEL_Pos))
+#define   EVSYS_CHANNEL_EDGSEL_NO_EVT_OUTPUT_Val _U_(0x0)                                       /**< (EVSYS_CHANNEL) No event output when using the resynchronized or synchronous path  */
+#define   EVSYS_CHANNEL_EDGSEL_RISING_EDGE_Val _U_(0x1)                                       /**< (EVSYS_CHANNEL) Event detection only on the rising edge of the signal from the event generator when using the resynchronized or synchronous path  */
+#define   EVSYS_CHANNEL_EDGSEL_FALLING_EDGE_Val _U_(0x2)                                       /**< (EVSYS_CHANNEL) Event detection only on the falling edge of the signal from the event generator when using the resynchronized or synchronous path  */
+#define   EVSYS_CHANNEL_EDGSEL_BOTH_EDGES_Val _U_(0x3)                                       /**< (EVSYS_CHANNEL) Event detection on rising and falling edges of the signal from the event generator when using the resynchronized or synchronous path  */
+#define EVSYS_CHANNEL_EDGSEL_NO_EVT_OUTPUT  (EVSYS_CHANNEL_EDGSEL_NO_EVT_OUTPUT_Val << EVSYS_CHANNEL_EDGSEL_Pos)  /**< (EVSYS_CHANNEL) No event output when using the resynchronized or synchronous path Position  */
+#define EVSYS_CHANNEL_EDGSEL_RISING_EDGE    (EVSYS_CHANNEL_EDGSEL_RISING_EDGE_Val << EVSYS_CHANNEL_EDGSEL_Pos)  /**< (EVSYS_CHANNEL) Event detection only on the rising edge of the signal from the event generator when using the resynchronized or synchronous path Position  */
+#define EVSYS_CHANNEL_EDGSEL_FALLING_EDGE   (EVSYS_CHANNEL_EDGSEL_FALLING_EDGE_Val << EVSYS_CHANNEL_EDGSEL_Pos)  /**< (EVSYS_CHANNEL) Event detection only on the falling edge of the signal from the event generator when using the resynchronized or synchronous path Position  */
+#define EVSYS_CHANNEL_EDGSEL_BOTH_EDGES     (EVSYS_CHANNEL_EDGSEL_BOTH_EDGES_Val << EVSYS_CHANNEL_EDGSEL_Pos)  /**< (EVSYS_CHANNEL) Event detection on rising and falling edges of the signal from the event generator when using the resynchronized or synchronous path Position  */
+#define EVSYS_CHANNEL_RUNSTDBY_Pos          14                                             /**< (EVSYS_CHANNEL) Run in standby Position */
+#define EVSYS_CHANNEL_RUNSTDBY_Msk          (_U_(0x1) << EVSYS_CHANNEL_RUNSTDBY_Pos)       /**< (EVSYS_CHANNEL) Run in standby Mask */
+#define EVSYS_CHANNEL_RUNSTDBY              EVSYS_CHANNEL_RUNSTDBY_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_CHANNEL_RUNSTDBY_Msk instead */
+#define EVSYS_CHANNEL_ONDEMAND_Pos          15                                             /**< (EVSYS_CHANNEL) Generic Clock On Demand Position */
+#define EVSYS_CHANNEL_ONDEMAND_Msk          (_U_(0x1) << EVSYS_CHANNEL_ONDEMAND_Pos)       /**< (EVSYS_CHANNEL) Generic Clock On Demand Mask */
+#define EVSYS_CHANNEL_ONDEMAND              EVSYS_CHANNEL_ONDEMAND_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_CHANNEL_ONDEMAND_Msk instead */
+#define EVSYS_CHANNEL_MASK                  _U_(0xCF3F)                                    /**< \deprecated (EVSYS_CHANNEL) Register MASK  (Use EVSYS_CHANNEL_Msk instead)  */
+#define EVSYS_CHANNEL_Msk                   _U_(0xCF3F)                                    /**< (EVSYS_CHANNEL) Register Mask  */
+
+
+/* -------- EVSYS_CHINTENCLR : (EVSYS Offset: 0x04) (R/W 8) Channel n Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  OVR:1;                     /**< bit:      0  Channel Overrun Interrupt Disable        */
+    uint8_t  EVD:1;                     /**< bit:      1  Channel Event Detected Interrupt Disable */
+    uint8_t  :6;                        /**< bit:   2..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} EVSYS_CHINTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_CHINTENCLR_OFFSET             (0x04)                                        /**<  (EVSYS_CHINTENCLR) Channel n Interrupt Enable Clear  Offset */
+#define EVSYS_CHINTENCLR_RESETVALUE         _U_(0x00)                                     /**<  (EVSYS_CHINTENCLR) Channel n Interrupt Enable Clear  Reset Value */
+
+#define EVSYS_CHINTENCLR_OVR_Pos            0                                              /**< (EVSYS_CHINTENCLR) Channel Overrun Interrupt Disable Position */
+#define EVSYS_CHINTENCLR_OVR_Msk            (_U_(0x1) << EVSYS_CHINTENCLR_OVR_Pos)         /**< (EVSYS_CHINTENCLR) Channel Overrun Interrupt Disable Mask */
+#define EVSYS_CHINTENCLR_OVR                EVSYS_CHINTENCLR_OVR_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_CHINTENCLR_OVR_Msk instead */
+#define EVSYS_CHINTENCLR_EVD_Pos            1                                              /**< (EVSYS_CHINTENCLR) Channel Event Detected Interrupt Disable Position */
+#define EVSYS_CHINTENCLR_EVD_Msk            (_U_(0x1) << EVSYS_CHINTENCLR_EVD_Pos)         /**< (EVSYS_CHINTENCLR) Channel Event Detected Interrupt Disable Mask */
+#define EVSYS_CHINTENCLR_EVD                EVSYS_CHINTENCLR_EVD_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_CHINTENCLR_EVD_Msk instead */
+#define EVSYS_CHINTENCLR_MASK               _U_(0x03)                                      /**< \deprecated (EVSYS_CHINTENCLR) Register MASK  (Use EVSYS_CHINTENCLR_Msk instead)  */
+#define EVSYS_CHINTENCLR_Msk                _U_(0x03)                                      /**< (EVSYS_CHINTENCLR) Register Mask  */
+
+
+/* -------- EVSYS_CHINTENSET : (EVSYS Offset: 0x05) (R/W 8) Channel n Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  OVR:1;                     /**< bit:      0  Channel Overrun Interrupt Enable         */
+    uint8_t  EVD:1;                     /**< bit:      1  Channel Event Detected Interrupt Enable  */
+    uint8_t  :6;                        /**< bit:   2..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} EVSYS_CHINTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_CHINTENSET_OFFSET             (0x05)                                        /**<  (EVSYS_CHINTENSET) Channel n Interrupt Enable Set  Offset */
+#define EVSYS_CHINTENSET_RESETVALUE         _U_(0x00)                                     /**<  (EVSYS_CHINTENSET) Channel n Interrupt Enable Set  Reset Value */
+
+#define EVSYS_CHINTENSET_OVR_Pos            0                                              /**< (EVSYS_CHINTENSET) Channel Overrun Interrupt Enable Position */
+#define EVSYS_CHINTENSET_OVR_Msk            (_U_(0x1) << EVSYS_CHINTENSET_OVR_Pos)         /**< (EVSYS_CHINTENSET) Channel Overrun Interrupt Enable Mask */
+#define EVSYS_CHINTENSET_OVR                EVSYS_CHINTENSET_OVR_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_CHINTENSET_OVR_Msk instead */
+#define EVSYS_CHINTENSET_EVD_Pos            1                                              /**< (EVSYS_CHINTENSET) Channel Event Detected Interrupt Enable Position */
+#define EVSYS_CHINTENSET_EVD_Msk            (_U_(0x1) << EVSYS_CHINTENSET_EVD_Pos)         /**< (EVSYS_CHINTENSET) Channel Event Detected Interrupt Enable Mask */
+#define EVSYS_CHINTENSET_EVD                EVSYS_CHINTENSET_EVD_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_CHINTENSET_EVD_Msk instead */
+#define EVSYS_CHINTENSET_MASK               _U_(0x03)                                      /**< \deprecated (EVSYS_CHINTENSET) Register MASK  (Use EVSYS_CHINTENSET_Msk instead)  */
+#define EVSYS_CHINTENSET_Msk                _U_(0x03)                                      /**< (EVSYS_CHINTENSET) Register Mask  */
+
+
+/* -------- EVSYS_CHINTFLAG : (EVSYS Offset: 0x06) (R/W 8) Channel n Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t OVR:1;                     /**< bit:      0  Channel Overrun                          */
+    __I uint8_t EVD:1;                     /**< bit:      1  Channel Event Detected                   */
+    __I uint8_t :6;                        /**< bit:   2..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} EVSYS_CHINTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_CHINTFLAG_OFFSET              (0x06)                                        /**<  (EVSYS_CHINTFLAG) Channel n Interrupt Flag Status and Clear  Offset */
+#define EVSYS_CHINTFLAG_RESETVALUE          _U_(0x00)                                     /**<  (EVSYS_CHINTFLAG) Channel n Interrupt Flag Status and Clear  Reset Value */
+
+#define EVSYS_CHINTFLAG_OVR_Pos             0                                              /**< (EVSYS_CHINTFLAG) Channel Overrun Position */
+#define EVSYS_CHINTFLAG_OVR_Msk             (_U_(0x1) << EVSYS_CHINTFLAG_OVR_Pos)          /**< (EVSYS_CHINTFLAG) Channel Overrun Mask */
+#define EVSYS_CHINTFLAG_OVR                 EVSYS_CHINTFLAG_OVR_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_CHINTFLAG_OVR_Msk instead */
+#define EVSYS_CHINTFLAG_EVD_Pos             1                                              /**< (EVSYS_CHINTFLAG) Channel Event Detected Position */
+#define EVSYS_CHINTFLAG_EVD_Msk             (_U_(0x1) << EVSYS_CHINTFLAG_EVD_Pos)          /**< (EVSYS_CHINTFLAG) Channel Event Detected Mask */
+#define EVSYS_CHINTFLAG_EVD                 EVSYS_CHINTFLAG_EVD_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_CHINTFLAG_EVD_Msk instead */
+#define EVSYS_CHINTFLAG_MASK                _U_(0x03)                                      /**< \deprecated (EVSYS_CHINTFLAG) Register MASK  (Use EVSYS_CHINTFLAG_Msk instead)  */
+#define EVSYS_CHINTFLAG_Msk                 _U_(0x03)                                      /**< (EVSYS_CHINTFLAG) Register Mask  */
+
+
+/* -------- EVSYS_CHSTATUS : (EVSYS Offset: 0x07) (R/ 8) Channel n Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  RDYUSR:1;                  /**< bit:      0  Ready User                               */
+    uint8_t  BUSYCH:1;                  /**< bit:      1  Busy Channel                             */
+    uint8_t  :6;                        /**< bit:   2..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} EVSYS_CHSTATUS_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_CHSTATUS_OFFSET               (0x07)                                        /**<  (EVSYS_CHSTATUS) Channel n Status  Offset */
+#define EVSYS_CHSTATUS_RESETVALUE           _U_(0x01)                                     /**<  (EVSYS_CHSTATUS) Channel n Status  Reset Value */
+
+#define EVSYS_CHSTATUS_RDYUSR_Pos           0                                              /**< (EVSYS_CHSTATUS) Ready User Position */
+#define EVSYS_CHSTATUS_RDYUSR_Msk           (_U_(0x1) << EVSYS_CHSTATUS_RDYUSR_Pos)        /**< (EVSYS_CHSTATUS) Ready User Mask */
+#define EVSYS_CHSTATUS_RDYUSR               EVSYS_CHSTATUS_RDYUSR_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_CHSTATUS_RDYUSR_Msk instead */
+#define EVSYS_CHSTATUS_BUSYCH_Pos           1                                              /**< (EVSYS_CHSTATUS) Busy Channel Position */
+#define EVSYS_CHSTATUS_BUSYCH_Msk           (_U_(0x1) << EVSYS_CHSTATUS_BUSYCH_Pos)        /**< (EVSYS_CHSTATUS) Busy Channel Mask */
+#define EVSYS_CHSTATUS_BUSYCH               EVSYS_CHSTATUS_BUSYCH_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_CHSTATUS_BUSYCH_Msk instead */
+#define EVSYS_CHSTATUS_MASK                 _U_(0x03)                                      /**< \deprecated (EVSYS_CHSTATUS) Register MASK  (Use EVSYS_CHSTATUS_Msk instead)  */
+#define EVSYS_CHSTATUS_Msk                  _U_(0x03)                                      /**< (EVSYS_CHSTATUS) Register Mask  */
+
+
+/* -------- EVSYS_CTRLA : (EVSYS Offset: 0x00) (/W 8) Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} EVSYS_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_CTRLA_OFFSET                  (0x00)                                        /**<  (EVSYS_CTRLA) Control  Offset */
+#define EVSYS_CTRLA_RESETVALUE              _U_(0x00)                                     /**<  (EVSYS_CTRLA) Control  Reset Value */
+
+#define EVSYS_CTRLA_SWRST_Pos               0                                              /**< (EVSYS_CTRLA) Software Reset Position */
+#define EVSYS_CTRLA_SWRST_Msk               (_U_(0x1) << EVSYS_CTRLA_SWRST_Pos)            /**< (EVSYS_CTRLA) Software Reset Mask */
+#define EVSYS_CTRLA_SWRST                   EVSYS_CTRLA_SWRST_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_CTRLA_SWRST_Msk instead */
+#define EVSYS_CTRLA_MASK                    _U_(0x01)                                      /**< \deprecated (EVSYS_CTRLA) Register MASK  (Use EVSYS_CTRLA_Msk instead)  */
+#define EVSYS_CTRLA_Msk                     _U_(0x01)                                      /**< (EVSYS_CTRLA) Register Mask  */
+
+
+/* -------- EVSYS_SWEVT : (EVSYS Offset: 0x04) (/W 32) Software Event -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t CHANNEL0:1;                /**< bit:      0  Channel 0 Software Selection             */
+    uint32_t CHANNEL1:1;                /**< bit:      1  Channel 1 Software Selection             */
+    uint32_t CHANNEL2:1;                /**< bit:      2  Channel 2 Software Selection             */
+    uint32_t CHANNEL3:1;                /**< bit:      3  Channel 3 Software Selection             */
+    uint32_t CHANNEL4:1;                /**< bit:      4  Channel 4 Software Selection             */
+    uint32_t CHANNEL5:1;                /**< bit:      5  Channel 5 Software Selection             */
+    uint32_t CHANNEL6:1;                /**< bit:      6  Channel 6 Software Selection             */
+    uint32_t CHANNEL7:1;                /**< bit:      7  Channel 7 Software Selection             */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t CHANNEL:8;                 /**< bit:   0..7  Channel 7 Software Selection             */
+    uint32_t :24;                       /**< bit:  8..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} EVSYS_SWEVT_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_SWEVT_OFFSET                  (0x04)                                        /**<  (EVSYS_SWEVT) Software Event  Offset */
+#define EVSYS_SWEVT_RESETVALUE              _U_(0x00)                                     /**<  (EVSYS_SWEVT) Software Event  Reset Value */
+
+#define EVSYS_SWEVT_CHANNEL0_Pos            0                                              /**< (EVSYS_SWEVT) Channel 0 Software Selection Position */
+#define EVSYS_SWEVT_CHANNEL0_Msk            (_U_(0x1) << EVSYS_SWEVT_CHANNEL0_Pos)         /**< (EVSYS_SWEVT) Channel 0 Software Selection Mask */
+#define EVSYS_SWEVT_CHANNEL0                EVSYS_SWEVT_CHANNEL0_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_SWEVT_CHANNEL0_Msk instead */
+#define EVSYS_SWEVT_CHANNEL1_Pos            1                                              /**< (EVSYS_SWEVT) Channel 1 Software Selection Position */
+#define EVSYS_SWEVT_CHANNEL1_Msk            (_U_(0x1) << EVSYS_SWEVT_CHANNEL1_Pos)         /**< (EVSYS_SWEVT) Channel 1 Software Selection Mask */
+#define EVSYS_SWEVT_CHANNEL1                EVSYS_SWEVT_CHANNEL1_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_SWEVT_CHANNEL1_Msk instead */
+#define EVSYS_SWEVT_CHANNEL2_Pos            2                                              /**< (EVSYS_SWEVT) Channel 2 Software Selection Position */
+#define EVSYS_SWEVT_CHANNEL2_Msk            (_U_(0x1) << EVSYS_SWEVT_CHANNEL2_Pos)         /**< (EVSYS_SWEVT) Channel 2 Software Selection Mask */
+#define EVSYS_SWEVT_CHANNEL2                EVSYS_SWEVT_CHANNEL2_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_SWEVT_CHANNEL2_Msk instead */
+#define EVSYS_SWEVT_CHANNEL3_Pos            3                                              /**< (EVSYS_SWEVT) Channel 3 Software Selection Position */
+#define EVSYS_SWEVT_CHANNEL3_Msk            (_U_(0x1) << EVSYS_SWEVT_CHANNEL3_Pos)         /**< (EVSYS_SWEVT) Channel 3 Software Selection Mask */
+#define EVSYS_SWEVT_CHANNEL3                EVSYS_SWEVT_CHANNEL3_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_SWEVT_CHANNEL3_Msk instead */
+#define EVSYS_SWEVT_CHANNEL4_Pos            4                                              /**< (EVSYS_SWEVT) Channel 4 Software Selection Position */
+#define EVSYS_SWEVT_CHANNEL4_Msk            (_U_(0x1) << EVSYS_SWEVT_CHANNEL4_Pos)         /**< (EVSYS_SWEVT) Channel 4 Software Selection Mask */
+#define EVSYS_SWEVT_CHANNEL4                EVSYS_SWEVT_CHANNEL4_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_SWEVT_CHANNEL4_Msk instead */
+#define EVSYS_SWEVT_CHANNEL5_Pos            5                                              /**< (EVSYS_SWEVT) Channel 5 Software Selection Position */
+#define EVSYS_SWEVT_CHANNEL5_Msk            (_U_(0x1) << EVSYS_SWEVT_CHANNEL5_Pos)         /**< (EVSYS_SWEVT) Channel 5 Software Selection Mask */
+#define EVSYS_SWEVT_CHANNEL5                EVSYS_SWEVT_CHANNEL5_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_SWEVT_CHANNEL5_Msk instead */
+#define EVSYS_SWEVT_CHANNEL6_Pos            6                                              /**< (EVSYS_SWEVT) Channel 6 Software Selection Position */
+#define EVSYS_SWEVT_CHANNEL6_Msk            (_U_(0x1) << EVSYS_SWEVT_CHANNEL6_Pos)         /**< (EVSYS_SWEVT) Channel 6 Software Selection Mask */
+#define EVSYS_SWEVT_CHANNEL6                EVSYS_SWEVT_CHANNEL6_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_SWEVT_CHANNEL6_Msk instead */
+#define EVSYS_SWEVT_CHANNEL7_Pos            7                                              /**< (EVSYS_SWEVT) Channel 7 Software Selection Position */
+#define EVSYS_SWEVT_CHANNEL7_Msk            (_U_(0x1) << EVSYS_SWEVT_CHANNEL7_Pos)         /**< (EVSYS_SWEVT) Channel 7 Software Selection Mask */
+#define EVSYS_SWEVT_CHANNEL7                EVSYS_SWEVT_CHANNEL7_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_SWEVT_CHANNEL7_Msk instead */
+#define EVSYS_SWEVT_MASK                    _U_(0xFF)                                      /**< \deprecated (EVSYS_SWEVT) Register MASK  (Use EVSYS_SWEVT_Msk instead)  */
+#define EVSYS_SWEVT_Msk                     _U_(0xFF)                                      /**< (EVSYS_SWEVT) Register Mask  */
+
+#define EVSYS_SWEVT_CHANNEL_Pos             0                                              /**< (EVSYS_SWEVT Position) Channel 7 Software Selection */
+#define EVSYS_SWEVT_CHANNEL_Msk             (_U_(0xFF) << EVSYS_SWEVT_CHANNEL_Pos)         /**< (EVSYS_SWEVT Mask) CHANNEL */
+#define EVSYS_SWEVT_CHANNEL(value)          (EVSYS_SWEVT_CHANNEL_Msk & ((value) << EVSYS_SWEVT_CHANNEL_Pos))  
+
+/* -------- EVSYS_PRICTRL : (EVSYS Offset: 0x08) (R/W 8) Priority Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  PRI:2;                     /**< bit:   0..1  Channel Priority Number                  */
+    uint8_t  :5;                        /**< bit:   2..6  Reserved */
+    uint8_t  RREN:1;                    /**< bit:      7  Round-Robin Scheduling Enable            */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} EVSYS_PRICTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_PRICTRL_OFFSET                (0x08)                                        /**<  (EVSYS_PRICTRL) Priority Control  Offset */
+#define EVSYS_PRICTRL_RESETVALUE            _U_(0x00)                                     /**<  (EVSYS_PRICTRL) Priority Control  Reset Value */
+
+#define EVSYS_PRICTRL_PRI_Pos               0                                              /**< (EVSYS_PRICTRL) Channel Priority Number Position */
+#define EVSYS_PRICTRL_PRI_Msk               (_U_(0x3) << EVSYS_PRICTRL_PRI_Pos)            /**< (EVSYS_PRICTRL) Channel Priority Number Mask */
+#define EVSYS_PRICTRL_PRI(value)            (EVSYS_PRICTRL_PRI_Msk & ((value) << EVSYS_PRICTRL_PRI_Pos))
+#define EVSYS_PRICTRL_RREN_Pos              7                                              /**< (EVSYS_PRICTRL) Round-Robin Scheduling Enable Position */
+#define EVSYS_PRICTRL_RREN_Msk              (_U_(0x1) << EVSYS_PRICTRL_RREN_Pos)           /**< (EVSYS_PRICTRL) Round-Robin Scheduling Enable Mask */
+#define EVSYS_PRICTRL_RREN                  EVSYS_PRICTRL_RREN_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_PRICTRL_RREN_Msk instead */
+#define EVSYS_PRICTRL_MASK                  _U_(0x83)                                      /**< \deprecated (EVSYS_PRICTRL) Register MASK  (Use EVSYS_PRICTRL_Msk instead)  */
+#define EVSYS_PRICTRL_Msk                   _U_(0x83)                                      /**< (EVSYS_PRICTRL) Register Mask  */
+
+
+/* -------- EVSYS_INTPEND : (EVSYS Offset: 0x10) (R/W 16) Channel Pending Interrupt -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t ID:2;                      /**< bit:   0..1  Channel ID                               */
+    uint16_t :6;                        /**< bit:   2..7  Reserved */
+    uint16_t OVR:1;                     /**< bit:      8  Channel Overrun                          */
+    uint16_t EVD:1;                     /**< bit:      9  Channel Event Detected                   */
+    uint16_t :4;                        /**< bit: 10..13  Reserved */
+    uint16_t READY:1;                   /**< bit:     14  Ready                                    */
+    uint16_t BUSY:1;                    /**< bit:     15  Busy                                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} EVSYS_INTPEND_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_INTPEND_OFFSET                (0x10)                                        /**<  (EVSYS_INTPEND) Channel Pending Interrupt  Offset */
+#define EVSYS_INTPEND_RESETVALUE            _U_(0x4000)                                   /**<  (EVSYS_INTPEND) Channel Pending Interrupt  Reset Value */
+
+#define EVSYS_INTPEND_ID_Pos                0                                              /**< (EVSYS_INTPEND) Channel ID Position */
+#define EVSYS_INTPEND_ID_Msk                (_U_(0x3) << EVSYS_INTPEND_ID_Pos)             /**< (EVSYS_INTPEND) Channel ID Mask */
+#define EVSYS_INTPEND_ID(value)             (EVSYS_INTPEND_ID_Msk & ((value) << EVSYS_INTPEND_ID_Pos))
+#define EVSYS_INTPEND_OVR_Pos               8                                              /**< (EVSYS_INTPEND) Channel Overrun Position */
+#define EVSYS_INTPEND_OVR_Msk               (_U_(0x1) << EVSYS_INTPEND_OVR_Pos)            /**< (EVSYS_INTPEND) Channel Overrun Mask */
+#define EVSYS_INTPEND_OVR                   EVSYS_INTPEND_OVR_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_INTPEND_OVR_Msk instead */
+#define EVSYS_INTPEND_EVD_Pos               9                                              /**< (EVSYS_INTPEND) Channel Event Detected Position */
+#define EVSYS_INTPEND_EVD_Msk               (_U_(0x1) << EVSYS_INTPEND_EVD_Pos)            /**< (EVSYS_INTPEND) Channel Event Detected Mask */
+#define EVSYS_INTPEND_EVD                   EVSYS_INTPEND_EVD_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_INTPEND_EVD_Msk instead */
+#define EVSYS_INTPEND_READY_Pos             14                                             /**< (EVSYS_INTPEND) Ready Position */
+#define EVSYS_INTPEND_READY_Msk             (_U_(0x1) << EVSYS_INTPEND_READY_Pos)          /**< (EVSYS_INTPEND) Ready Mask */
+#define EVSYS_INTPEND_READY                 EVSYS_INTPEND_READY_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_INTPEND_READY_Msk instead */
+#define EVSYS_INTPEND_BUSY_Pos              15                                             /**< (EVSYS_INTPEND) Busy Position */
+#define EVSYS_INTPEND_BUSY_Msk              (_U_(0x1) << EVSYS_INTPEND_BUSY_Pos)           /**< (EVSYS_INTPEND) Busy Mask */
+#define EVSYS_INTPEND_BUSY                  EVSYS_INTPEND_BUSY_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_INTPEND_BUSY_Msk instead */
+#define EVSYS_INTPEND_MASK                  _U_(0xC303)                                    /**< \deprecated (EVSYS_INTPEND) Register MASK  (Use EVSYS_INTPEND_Msk instead)  */
+#define EVSYS_INTPEND_Msk                   _U_(0xC303)                                    /**< (EVSYS_INTPEND) Register Mask  */
+
+
+/* -------- EVSYS_INTSTATUS : (EVSYS Offset: 0x14) (R/ 32) Interrupt Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t CHINT0:1;                  /**< bit:      0  Channel 0 Pending Interrupt              */
+    uint32_t CHINT1:1;                  /**< bit:      1  Channel 1 Pending Interrupt              */
+    uint32_t CHINT2:1;                  /**< bit:      2  Channel 2 Pending Interrupt              */
+    uint32_t CHINT3:1;                  /**< bit:      3  Channel 3 Pending Interrupt              */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t CHINT:4;                   /**< bit:   0..3  Channel 3 Pending Interrupt              */
+    uint32_t :28;                       /**< bit:  4..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} EVSYS_INTSTATUS_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_INTSTATUS_OFFSET              (0x14)                                        /**<  (EVSYS_INTSTATUS) Interrupt Status  Offset */
+#define EVSYS_INTSTATUS_RESETVALUE          _U_(0x00)                                     /**<  (EVSYS_INTSTATUS) Interrupt Status  Reset Value */
+
+#define EVSYS_INTSTATUS_CHINT0_Pos          0                                              /**< (EVSYS_INTSTATUS) Channel 0 Pending Interrupt Position */
+#define EVSYS_INTSTATUS_CHINT0_Msk          (_U_(0x1) << EVSYS_INTSTATUS_CHINT0_Pos)       /**< (EVSYS_INTSTATUS) Channel 0 Pending Interrupt Mask */
+#define EVSYS_INTSTATUS_CHINT0              EVSYS_INTSTATUS_CHINT0_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_INTSTATUS_CHINT0_Msk instead */
+#define EVSYS_INTSTATUS_CHINT1_Pos          1                                              /**< (EVSYS_INTSTATUS) Channel 1 Pending Interrupt Position */
+#define EVSYS_INTSTATUS_CHINT1_Msk          (_U_(0x1) << EVSYS_INTSTATUS_CHINT1_Pos)       /**< (EVSYS_INTSTATUS) Channel 1 Pending Interrupt Mask */
+#define EVSYS_INTSTATUS_CHINT1              EVSYS_INTSTATUS_CHINT1_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_INTSTATUS_CHINT1_Msk instead */
+#define EVSYS_INTSTATUS_CHINT2_Pos          2                                              /**< (EVSYS_INTSTATUS) Channel 2 Pending Interrupt Position */
+#define EVSYS_INTSTATUS_CHINT2_Msk          (_U_(0x1) << EVSYS_INTSTATUS_CHINT2_Pos)       /**< (EVSYS_INTSTATUS) Channel 2 Pending Interrupt Mask */
+#define EVSYS_INTSTATUS_CHINT2              EVSYS_INTSTATUS_CHINT2_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_INTSTATUS_CHINT2_Msk instead */
+#define EVSYS_INTSTATUS_CHINT3_Pos          3                                              /**< (EVSYS_INTSTATUS) Channel 3 Pending Interrupt Position */
+#define EVSYS_INTSTATUS_CHINT3_Msk          (_U_(0x1) << EVSYS_INTSTATUS_CHINT3_Pos)       /**< (EVSYS_INTSTATUS) Channel 3 Pending Interrupt Mask */
+#define EVSYS_INTSTATUS_CHINT3              EVSYS_INTSTATUS_CHINT3_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_INTSTATUS_CHINT3_Msk instead */
+#define EVSYS_INTSTATUS_MASK                _U_(0x0F)                                      /**< \deprecated (EVSYS_INTSTATUS) Register MASK  (Use EVSYS_INTSTATUS_Msk instead)  */
+#define EVSYS_INTSTATUS_Msk                 _U_(0x0F)                                      /**< (EVSYS_INTSTATUS) Register Mask  */
+
+#define EVSYS_INTSTATUS_CHINT_Pos           0                                              /**< (EVSYS_INTSTATUS Position) Channel 3 Pending Interrupt */
+#define EVSYS_INTSTATUS_CHINT_Msk           (_U_(0xF) << EVSYS_INTSTATUS_CHINT_Pos)        /**< (EVSYS_INTSTATUS Mask) CHINT */
+#define EVSYS_INTSTATUS_CHINT(value)        (EVSYS_INTSTATUS_CHINT_Msk & ((value) << EVSYS_INTSTATUS_CHINT_Pos))  
+
+/* -------- EVSYS_BUSYCH : (EVSYS Offset: 0x18) (R/ 32) Busy Channels -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t BUSYCH0:1;                 /**< bit:      0  Busy Channel 0                           */
+    uint32_t BUSYCH1:1;                 /**< bit:      1  Busy Channel 1                           */
+    uint32_t BUSYCH2:1;                 /**< bit:      2  Busy Channel 2                           */
+    uint32_t BUSYCH3:1;                 /**< bit:      3  Busy Channel 3                           */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t BUSYCH:4;                  /**< bit:   0..3  Busy Channel 3                           */
+    uint32_t :28;                       /**< bit:  4..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} EVSYS_BUSYCH_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_BUSYCH_OFFSET                 (0x18)                                        /**<  (EVSYS_BUSYCH) Busy Channels  Offset */
+#define EVSYS_BUSYCH_RESETVALUE             _U_(0x00)                                     /**<  (EVSYS_BUSYCH) Busy Channels  Reset Value */
+
+#define EVSYS_BUSYCH_BUSYCH0_Pos            0                                              /**< (EVSYS_BUSYCH) Busy Channel 0 Position */
+#define EVSYS_BUSYCH_BUSYCH0_Msk            (_U_(0x1) << EVSYS_BUSYCH_BUSYCH0_Pos)         /**< (EVSYS_BUSYCH) Busy Channel 0 Mask */
+#define EVSYS_BUSYCH_BUSYCH0                EVSYS_BUSYCH_BUSYCH0_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_BUSYCH_BUSYCH0_Msk instead */
+#define EVSYS_BUSYCH_BUSYCH1_Pos            1                                              /**< (EVSYS_BUSYCH) Busy Channel 1 Position */
+#define EVSYS_BUSYCH_BUSYCH1_Msk            (_U_(0x1) << EVSYS_BUSYCH_BUSYCH1_Pos)         /**< (EVSYS_BUSYCH) Busy Channel 1 Mask */
+#define EVSYS_BUSYCH_BUSYCH1                EVSYS_BUSYCH_BUSYCH1_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_BUSYCH_BUSYCH1_Msk instead */
+#define EVSYS_BUSYCH_BUSYCH2_Pos            2                                              /**< (EVSYS_BUSYCH) Busy Channel 2 Position */
+#define EVSYS_BUSYCH_BUSYCH2_Msk            (_U_(0x1) << EVSYS_BUSYCH_BUSYCH2_Pos)         /**< (EVSYS_BUSYCH) Busy Channel 2 Mask */
+#define EVSYS_BUSYCH_BUSYCH2                EVSYS_BUSYCH_BUSYCH2_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_BUSYCH_BUSYCH2_Msk instead */
+#define EVSYS_BUSYCH_BUSYCH3_Pos            3                                              /**< (EVSYS_BUSYCH) Busy Channel 3 Position */
+#define EVSYS_BUSYCH_BUSYCH3_Msk            (_U_(0x1) << EVSYS_BUSYCH_BUSYCH3_Pos)         /**< (EVSYS_BUSYCH) Busy Channel 3 Mask */
+#define EVSYS_BUSYCH_BUSYCH3                EVSYS_BUSYCH_BUSYCH3_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_BUSYCH_BUSYCH3_Msk instead */
+#define EVSYS_BUSYCH_MASK                   _U_(0x0F)                                      /**< \deprecated (EVSYS_BUSYCH) Register MASK  (Use EVSYS_BUSYCH_Msk instead)  */
+#define EVSYS_BUSYCH_Msk                    _U_(0x0F)                                      /**< (EVSYS_BUSYCH) Register Mask  */
+
+#define EVSYS_BUSYCH_BUSYCH_Pos             0                                              /**< (EVSYS_BUSYCH Position) Busy Channel 3 */
+#define EVSYS_BUSYCH_BUSYCH_Msk             (_U_(0xF) << EVSYS_BUSYCH_BUSYCH_Pos)          /**< (EVSYS_BUSYCH Mask) BUSYCH */
+#define EVSYS_BUSYCH_BUSYCH(value)          (EVSYS_BUSYCH_BUSYCH_Msk & ((value) << EVSYS_BUSYCH_BUSYCH_Pos))  
+
+/* -------- EVSYS_READYUSR : (EVSYS Offset: 0x1c) (R/ 32) Ready Users -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t READYUSR0:1;               /**< bit:      0  Ready User for Channel 0                 */
+    uint32_t READYUSR1:1;               /**< bit:      1  Ready User for Channel 1                 */
+    uint32_t READYUSR2:1;               /**< bit:      2  Ready User for Channel 2                 */
+    uint32_t READYUSR3:1;               /**< bit:      3  Ready User for Channel 3                 */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t READYUSR:4;                /**< bit:   0..3  Ready User for Channel 3                 */
+    uint32_t :28;                       /**< bit:  4..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} EVSYS_READYUSR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_READYUSR_OFFSET               (0x1C)                                        /**<  (EVSYS_READYUSR) Ready Users  Offset */
+#define EVSYS_READYUSR_RESETVALUE           _U_(0xFFFFFFFF)                               /**<  (EVSYS_READYUSR) Ready Users  Reset Value */
+
+#define EVSYS_READYUSR_READYUSR0_Pos        0                                              /**< (EVSYS_READYUSR) Ready User for Channel 0 Position */
+#define EVSYS_READYUSR_READYUSR0_Msk        (_U_(0x1) << EVSYS_READYUSR_READYUSR0_Pos)     /**< (EVSYS_READYUSR) Ready User for Channel 0 Mask */
+#define EVSYS_READYUSR_READYUSR0            EVSYS_READYUSR_READYUSR0_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_READYUSR_READYUSR0_Msk instead */
+#define EVSYS_READYUSR_READYUSR1_Pos        1                                              /**< (EVSYS_READYUSR) Ready User for Channel 1 Position */
+#define EVSYS_READYUSR_READYUSR1_Msk        (_U_(0x1) << EVSYS_READYUSR_READYUSR1_Pos)     /**< (EVSYS_READYUSR) Ready User for Channel 1 Mask */
+#define EVSYS_READYUSR_READYUSR1            EVSYS_READYUSR_READYUSR1_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_READYUSR_READYUSR1_Msk instead */
+#define EVSYS_READYUSR_READYUSR2_Pos        2                                              /**< (EVSYS_READYUSR) Ready User for Channel 2 Position */
+#define EVSYS_READYUSR_READYUSR2_Msk        (_U_(0x1) << EVSYS_READYUSR_READYUSR2_Pos)     /**< (EVSYS_READYUSR) Ready User for Channel 2 Mask */
+#define EVSYS_READYUSR_READYUSR2            EVSYS_READYUSR_READYUSR2_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_READYUSR_READYUSR2_Msk instead */
+#define EVSYS_READYUSR_READYUSR3_Pos        3                                              /**< (EVSYS_READYUSR) Ready User for Channel 3 Position */
+#define EVSYS_READYUSR_READYUSR3_Msk        (_U_(0x1) << EVSYS_READYUSR_READYUSR3_Pos)     /**< (EVSYS_READYUSR) Ready User for Channel 3 Mask */
+#define EVSYS_READYUSR_READYUSR3            EVSYS_READYUSR_READYUSR3_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_READYUSR_READYUSR3_Msk instead */
+#define EVSYS_READYUSR_MASK                 _U_(0x0F)                                      /**< \deprecated (EVSYS_READYUSR) Register MASK  (Use EVSYS_READYUSR_Msk instead)  */
+#define EVSYS_READYUSR_Msk                  _U_(0x0F)                                      /**< (EVSYS_READYUSR) Register Mask  */
+
+#define EVSYS_READYUSR_READYUSR_Pos         0                                              /**< (EVSYS_READYUSR Position) Ready User for Channel 3 */
+#define EVSYS_READYUSR_READYUSR_Msk         (_U_(0xF) << EVSYS_READYUSR_READYUSR_Pos)      /**< (EVSYS_READYUSR Mask) READYUSR */
+#define EVSYS_READYUSR_READYUSR(value)      (EVSYS_READYUSR_READYUSR_Msk & ((value) << EVSYS_READYUSR_READYUSR_Pos))  
+
+/* -------- EVSYS_USER : (EVSYS Offset: 0x120) (R/W 8) User Multiplexer n -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  CHANNEL:4;                 /**< bit:   0..3  Channel Event Selection                  */
+    uint8_t  :4;                        /**< bit:   4..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} EVSYS_USER_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_USER_OFFSET                   (0x120)                                       /**<  (EVSYS_USER) User Multiplexer n  Offset */
+#define EVSYS_USER_RESETVALUE               _U_(0x00)                                     /**<  (EVSYS_USER) User Multiplexer n  Reset Value */
+
+#define EVSYS_USER_CHANNEL_Pos              0                                              /**< (EVSYS_USER) Channel Event Selection Position */
+#define EVSYS_USER_CHANNEL_Msk              (_U_(0xF) << EVSYS_USER_CHANNEL_Pos)           /**< (EVSYS_USER) Channel Event Selection Mask */
+#define EVSYS_USER_CHANNEL(value)           (EVSYS_USER_CHANNEL_Msk & ((value) << EVSYS_USER_CHANNEL_Pos))
+#define EVSYS_USER_MASK                     _U_(0x0F)                                      /**< \deprecated (EVSYS_USER) Register MASK  (Use EVSYS_USER_Msk instead)  */
+#define EVSYS_USER_Msk                      _U_(0x0F)                                      /**< (EVSYS_USER) Register Mask  */
+
+
+/* -------- EVSYS_INTENCLR : (EVSYS Offset: 0x1d4) (R/W 8) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  NSCHK:1;                   /**< bit:      0  Non-Secure Check Interrupt Enable        */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} EVSYS_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_INTENCLR_OFFSET               (0x1D4)                                       /**<  (EVSYS_INTENCLR) Interrupt Enable Clear  Offset */
+#define EVSYS_INTENCLR_RESETVALUE           _U_(0x00)                                     /**<  (EVSYS_INTENCLR) Interrupt Enable Clear  Reset Value */
+
+#define EVSYS_INTENCLR_NSCHK_Pos            0                                              /**< (EVSYS_INTENCLR) Non-Secure Check Interrupt Enable Position */
+#define EVSYS_INTENCLR_NSCHK_Msk            (_U_(0x1) << EVSYS_INTENCLR_NSCHK_Pos)         /**< (EVSYS_INTENCLR) Non-Secure Check Interrupt Enable Mask */
+#define EVSYS_INTENCLR_NSCHK                EVSYS_INTENCLR_NSCHK_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_INTENCLR_NSCHK_Msk instead */
+#define EVSYS_INTENCLR_MASK                 _U_(0x01)                                      /**< \deprecated (EVSYS_INTENCLR) Register MASK  (Use EVSYS_INTENCLR_Msk instead)  */
+#define EVSYS_INTENCLR_Msk                  _U_(0x01)                                      /**< (EVSYS_INTENCLR) Register Mask  */
+
+
+/* -------- EVSYS_INTENSET : (EVSYS Offset: 0x1d5) (R/W 8) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  NSCHK:1;                   /**< bit:      0  Non-Secure Check Interrupt Enable        */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} EVSYS_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_INTENSET_OFFSET               (0x1D5)                                       /**<  (EVSYS_INTENSET) Interrupt Enable Set  Offset */
+#define EVSYS_INTENSET_RESETVALUE           _U_(0x00)                                     /**<  (EVSYS_INTENSET) Interrupt Enable Set  Reset Value */
+
+#define EVSYS_INTENSET_NSCHK_Pos            0                                              /**< (EVSYS_INTENSET) Non-Secure Check Interrupt Enable Position */
+#define EVSYS_INTENSET_NSCHK_Msk            (_U_(0x1) << EVSYS_INTENSET_NSCHK_Pos)         /**< (EVSYS_INTENSET) Non-Secure Check Interrupt Enable Mask */
+#define EVSYS_INTENSET_NSCHK                EVSYS_INTENSET_NSCHK_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_INTENSET_NSCHK_Msk instead */
+#define EVSYS_INTENSET_MASK                 _U_(0x01)                                      /**< \deprecated (EVSYS_INTENSET) Register MASK  (Use EVSYS_INTENSET_Msk instead)  */
+#define EVSYS_INTENSET_Msk                  _U_(0x01)                                      /**< (EVSYS_INTENSET) Register Mask  */
+
+
+/* -------- EVSYS_INTFLAG : (EVSYS Offset: 0x1d6) (R/W 8) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t NSCHK:1;                   /**< bit:      0  Non-Secure Check                         */
+    __I uint8_t :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} EVSYS_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_INTFLAG_OFFSET                (0x1D6)                                       /**<  (EVSYS_INTFLAG) Interrupt Flag Status and Clear  Offset */
+#define EVSYS_INTFLAG_RESETVALUE            _U_(0x00)                                     /**<  (EVSYS_INTFLAG) Interrupt Flag Status and Clear  Reset Value */
+
+#define EVSYS_INTFLAG_NSCHK_Pos             0                                              /**< (EVSYS_INTFLAG) Non-Secure Check Position */
+#define EVSYS_INTFLAG_NSCHK_Msk             (_U_(0x1) << EVSYS_INTFLAG_NSCHK_Pos)          /**< (EVSYS_INTFLAG) Non-Secure Check Mask */
+#define EVSYS_INTFLAG_NSCHK                 EVSYS_INTFLAG_NSCHK_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_INTFLAG_NSCHK_Msk instead */
+#define EVSYS_INTFLAG_MASK                  _U_(0x01)                                      /**< \deprecated (EVSYS_INTFLAG) Register MASK  (Use EVSYS_INTFLAG_Msk instead)  */
+#define EVSYS_INTFLAG_Msk                   _U_(0x01)                                      /**< (EVSYS_INTFLAG) Register Mask  */
+
+
+/* -------- EVSYS_NONSECCHAN : (EVSYS Offset: 0x1d8) (R/W 32) Channels Security Attribution -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t CHANNEL0:1;                /**< bit:      0  Non-Secure for Channel 0                 */
+    uint32_t CHANNEL1:1;                /**< bit:      1  Non-Secure for Channel 1                 */
+    uint32_t CHANNEL2:1;                /**< bit:      2  Non-Secure for Channel 2                 */
+    uint32_t CHANNEL3:1;                /**< bit:      3  Non-Secure for Channel 3                 */
+    uint32_t CHANNEL4:1;                /**< bit:      4  Non-Secure for Channel 4                 */
+    uint32_t CHANNEL5:1;                /**< bit:      5  Non-Secure for Channel 5                 */
+    uint32_t CHANNEL6:1;                /**< bit:      6  Non-Secure for Channel 6                 */
+    uint32_t CHANNEL7:1;                /**< bit:      7  Non-Secure for Channel 7                 */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t CHANNEL:8;                 /**< bit:   0..7  Non-Secure for Channel 7                 */
+    uint32_t :24;                       /**< bit:  8..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} EVSYS_NONSECCHAN_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_NONSECCHAN_OFFSET             (0x1D8)                                       /**<  (EVSYS_NONSECCHAN) Channels Security Attribution  Offset */
+#define EVSYS_NONSECCHAN_RESETVALUE         _U_(0x00)                                     /**<  (EVSYS_NONSECCHAN) Channels Security Attribution  Reset Value */
+
+#define EVSYS_NONSECCHAN_CHANNEL0_Pos       0                                              /**< (EVSYS_NONSECCHAN) Non-Secure for Channel 0 Position */
+#define EVSYS_NONSECCHAN_CHANNEL0_Msk       (_U_(0x1) << EVSYS_NONSECCHAN_CHANNEL0_Pos)    /**< (EVSYS_NONSECCHAN) Non-Secure for Channel 0 Mask */
+#define EVSYS_NONSECCHAN_CHANNEL0           EVSYS_NONSECCHAN_CHANNEL0_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECCHAN_CHANNEL0_Msk instead */
+#define EVSYS_NONSECCHAN_CHANNEL1_Pos       1                                              /**< (EVSYS_NONSECCHAN) Non-Secure for Channel 1 Position */
+#define EVSYS_NONSECCHAN_CHANNEL1_Msk       (_U_(0x1) << EVSYS_NONSECCHAN_CHANNEL1_Pos)    /**< (EVSYS_NONSECCHAN) Non-Secure for Channel 1 Mask */
+#define EVSYS_NONSECCHAN_CHANNEL1           EVSYS_NONSECCHAN_CHANNEL1_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECCHAN_CHANNEL1_Msk instead */
+#define EVSYS_NONSECCHAN_CHANNEL2_Pos       2                                              /**< (EVSYS_NONSECCHAN) Non-Secure for Channel 2 Position */
+#define EVSYS_NONSECCHAN_CHANNEL2_Msk       (_U_(0x1) << EVSYS_NONSECCHAN_CHANNEL2_Pos)    /**< (EVSYS_NONSECCHAN) Non-Secure for Channel 2 Mask */
+#define EVSYS_NONSECCHAN_CHANNEL2           EVSYS_NONSECCHAN_CHANNEL2_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECCHAN_CHANNEL2_Msk instead */
+#define EVSYS_NONSECCHAN_CHANNEL3_Pos       3                                              /**< (EVSYS_NONSECCHAN) Non-Secure for Channel 3 Position */
+#define EVSYS_NONSECCHAN_CHANNEL3_Msk       (_U_(0x1) << EVSYS_NONSECCHAN_CHANNEL3_Pos)    /**< (EVSYS_NONSECCHAN) Non-Secure for Channel 3 Mask */
+#define EVSYS_NONSECCHAN_CHANNEL3           EVSYS_NONSECCHAN_CHANNEL3_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECCHAN_CHANNEL3_Msk instead */
+#define EVSYS_NONSECCHAN_CHANNEL4_Pos       4                                              /**< (EVSYS_NONSECCHAN) Non-Secure for Channel 4 Position */
+#define EVSYS_NONSECCHAN_CHANNEL4_Msk       (_U_(0x1) << EVSYS_NONSECCHAN_CHANNEL4_Pos)    /**< (EVSYS_NONSECCHAN) Non-Secure for Channel 4 Mask */
+#define EVSYS_NONSECCHAN_CHANNEL4           EVSYS_NONSECCHAN_CHANNEL4_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECCHAN_CHANNEL4_Msk instead */
+#define EVSYS_NONSECCHAN_CHANNEL5_Pos       5                                              /**< (EVSYS_NONSECCHAN) Non-Secure for Channel 5 Position */
+#define EVSYS_NONSECCHAN_CHANNEL5_Msk       (_U_(0x1) << EVSYS_NONSECCHAN_CHANNEL5_Pos)    /**< (EVSYS_NONSECCHAN) Non-Secure for Channel 5 Mask */
+#define EVSYS_NONSECCHAN_CHANNEL5           EVSYS_NONSECCHAN_CHANNEL5_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECCHAN_CHANNEL5_Msk instead */
+#define EVSYS_NONSECCHAN_CHANNEL6_Pos       6                                              /**< (EVSYS_NONSECCHAN) Non-Secure for Channel 6 Position */
+#define EVSYS_NONSECCHAN_CHANNEL6_Msk       (_U_(0x1) << EVSYS_NONSECCHAN_CHANNEL6_Pos)    /**< (EVSYS_NONSECCHAN) Non-Secure for Channel 6 Mask */
+#define EVSYS_NONSECCHAN_CHANNEL6           EVSYS_NONSECCHAN_CHANNEL6_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECCHAN_CHANNEL6_Msk instead */
+#define EVSYS_NONSECCHAN_CHANNEL7_Pos       7                                              /**< (EVSYS_NONSECCHAN) Non-Secure for Channel 7 Position */
+#define EVSYS_NONSECCHAN_CHANNEL7_Msk       (_U_(0x1) << EVSYS_NONSECCHAN_CHANNEL7_Pos)    /**< (EVSYS_NONSECCHAN) Non-Secure for Channel 7 Mask */
+#define EVSYS_NONSECCHAN_CHANNEL7           EVSYS_NONSECCHAN_CHANNEL7_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECCHAN_CHANNEL7_Msk instead */
+#define EVSYS_NONSECCHAN_MASK               _U_(0xFF)                                      /**< \deprecated (EVSYS_NONSECCHAN) Register MASK  (Use EVSYS_NONSECCHAN_Msk instead)  */
+#define EVSYS_NONSECCHAN_Msk                _U_(0xFF)                                      /**< (EVSYS_NONSECCHAN) Register Mask  */
+
+#define EVSYS_NONSECCHAN_CHANNEL_Pos        0                                              /**< (EVSYS_NONSECCHAN Position) Non-Secure for Channel 7 */
+#define EVSYS_NONSECCHAN_CHANNEL_Msk        (_U_(0xFF) << EVSYS_NONSECCHAN_CHANNEL_Pos)    /**< (EVSYS_NONSECCHAN Mask) CHANNEL */
+#define EVSYS_NONSECCHAN_CHANNEL(value)     (EVSYS_NONSECCHAN_CHANNEL_Msk & ((value) << EVSYS_NONSECCHAN_CHANNEL_Pos))  
+
+/* -------- EVSYS_NSCHKCHAN : (EVSYS Offset: 0x1dc) (R/W 32) Non-Secure Channels Check -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t CHANNEL0:1;                /**< bit:      0  Channel 0 to be checked as non-secured   */
+    uint32_t CHANNEL1:1;                /**< bit:      1  Channel 1 to be checked as non-secured   */
+    uint32_t CHANNEL2:1;                /**< bit:      2  Channel 2 to be checked as non-secured   */
+    uint32_t CHANNEL3:1;                /**< bit:      3  Channel 3 to be checked as non-secured   */
+    uint32_t CHANNEL4:1;                /**< bit:      4  Channel 4 to be checked as non-secured   */
+    uint32_t CHANNEL5:1;                /**< bit:      5  Channel 5 to be checked as non-secured   */
+    uint32_t CHANNEL6:1;                /**< bit:      6  Channel 6 to be checked as non-secured   */
+    uint32_t CHANNEL7:1;                /**< bit:      7  Channel 7 to be checked as non-secured   */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t CHANNEL:8;                 /**< bit:   0..7  Channel 7 to be checked as non-secured   */
+    uint32_t :24;                       /**< bit:  8..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} EVSYS_NSCHKCHAN_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_NSCHKCHAN_OFFSET              (0x1DC)                                       /**<  (EVSYS_NSCHKCHAN) Non-Secure Channels Check  Offset */
+#define EVSYS_NSCHKCHAN_RESETVALUE          _U_(0x00)                                     /**<  (EVSYS_NSCHKCHAN) Non-Secure Channels Check  Reset Value */
+
+#define EVSYS_NSCHKCHAN_CHANNEL0_Pos        0                                              /**< (EVSYS_NSCHKCHAN) Channel 0 to be checked as non-secured Position */
+#define EVSYS_NSCHKCHAN_CHANNEL0_Msk        (_U_(0x1) << EVSYS_NSCHKCHAN_CHANNEL0_Pos)     /**< (EVSYS_NSCHKCHAN) Channel 0 to be checked as non-secured Mask */
+#define EVSYS_NSCHKCHAN_CHANNEL0            EVSYS_NSCHKCHAN_CHANNEL0_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKCHAN_CHANNEL0_Msk instead */
+#define EVSYS_NSCHKCHAN_CHANNEL1_Pos        1                                              /**< (EVSYS_NSCHKCHAN) Channel 1 to be checked as non-secured Position */
+#define EVSYS_NSCHKCHAN_CHANNEL1_Msk        (_U_(0x1) << EVSYS_NSCHKCHAN_CHANNEL1_Pos)     /**< (EVSYS_NSCHKCHAN) Channel 1 to be checked as non-secured Mask */
+#define EVSYS_NSCHKCHAN_CHANNEL1            EVSYS_NSCHKCHAN_CHANNEL1_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKCHAN_CHANNEL1_Msk instead */
+#define EVSYS_NSCHKCHAN_CHANNEL2_Pos        2                                              /**< (EVSYS_NSCHKCHAN) Channel 2 to be checked as non-secured Position */
+#define EVSYS_NSCHKCHAN_CHANNEL2_Msk        (_U_(0x1) << EVSYS_NSCHKCHAN_CHANNEL2_Pos)     /**< (EVSYS_NSCHKCHAN) Channel 2 to be checked as non-secured Mask */
+#define EVSYS_NSCHKCHAN_CHANNEL2            EVSYS_NSCHKCHAN_CHANNEL2_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKCHAN_CHANNEL2_Msk instead */
+#define EVSYS_NSCHKCHAN_CHANNEL3_Pos        3                                              /**< (EVSYS_NSCHKCHAN) Channel 3 to be checked as non-secured Position */
+#define EVSYS_NSCHKCHAN_CHANNEL3_Msk        (_U_(0x1) << EVSYS_NSCHKCHAN_CHANNEL3_Pos)     /**< (EVSYS_NSCHKCHAN) Channel 3 to be checked as non-secured Mask */
+#define EVSYS_NSCHKCHAN_CHANNEL3            EVSYS_NSCHKCHAN_CHANNEL3_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKCHAN_CHANNEL3_Msk instead */
+#define EVSYS_NSCHKCHAN_CHANNEL4_Pos        4                                              /**< (EVSYS_NSCHKCHAN) Channel 4 to be checked as non-secured Position */
+#define EVSYS_NSCHKCHAN_CHANNEL4_Msk        (_U_(0x1) << EVSYS_NSCHKCHAN_CHANNEL4_Pos)     /**< (EVSYS_NSCHKCHAN) Channel 4 to be checked as non-secured Mask */
+#define EVSYS_NSCHKCHAN_CHANNEL4            EVSYS_NSCHKCHAN_CHANNEL4_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKCHAN_CHANNEL4_Msk instead */
+#define EVSYS_NSCHKCHAN_CHANNEL5_Pos        5                                              /**< (EVSYS_NSCHKCHAN) Channel 5 to be checked as non-secured Position */
+#define EVSYS_NSCHKCHAN_CHANNEL5_Msk        (_U_(0x1) << EVSYS_NSCHKCHAN_CHANNEL5_Pos)     /**< (EVSYS_NSCHKCHAN) Channel 5 to be checked as non-secured Mask */
+#define EVSYS_NSCHKCHAN_CHANNEL5            EVSYS_NSCHKCHAN_CHANNEL5_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKCHAN_CHANNEL5_Msk instead */
+#define EVSYS_NSCHKCHAN_CHANNEL6_Pos        6                                              /**< (EVSYS_NSCHKCHAN) Channel 6 to be checked as non-secured Position */
+#define EVSYS_NSCHKCHAN_CHANNEL6_Msk        (_U_(0x1) << EVSYS_NSCHKCHAN_CHANNEL6_Pos)     /**< (EVSYS_NSCHKCHAN) Channel 6 to be checked as non-secured Mask */
+#define EVSYS_NSCHKCHAN_CHANNEL6            EVSYS_NSCHKCHAN_CHANNEL6_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKCHAN_CHANNEL6_Msk instead */
+#define EVSYS_NSCHKCHAN_CHANNEL7_Pos        7                                              /**< (EVSYS_NSCHKCHAN) Channel 7 to be checked as non-secured Position */
+#define EVSYS_NSCHKCHAN_CHANNEL7_Msk        (_U_(0x1) << EVSYS_NSCHKCHAN_CHANNEL7_Pos)     /**< (EVSYS_NSCHKCHAN) Channel 7 to be checked as non-secured Mask */
+#define EVSYS_NSCHKCHAN_CHANNEL7            EVSYS_NSCHKCHAN_CHANNEL7_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKCHAN_CHANNEL7_Msk instead */
+#define EVSYS_NSCHKCHAN_MASK                _U_(0xFF)                                      /**< \deprecated (EVSYS_NSCHKCHAN) Register MASK  (Use EVSYS_NSCHKCHAN_Msk instead)  */
+#define EVSYS_NSCHKCHAN_Msk                 _U_(0xFF)                                      /**< (EVSYS_NSCHKCHAN) Register Mask  */
+
+#define EVSYS_NSCHKCHAN_CHANNEL_Pos         0                                              /**< (EVSYS_NSCHKCHAN Position) Channel 7 to be checked as non-secured */
+#define EVSYS_NSCHKCHAN_CHANNEL_Msk         (_U_(0xFF) << EVSYS_NSCHKCHAN_CHANNEL_Pos)     /**< (EVSYS_NSCHKCHAN Mask) CHANNEL */
+#define EVSYS_NSCHKCHAN_CHANNEL(value)      (EVSYS_NSCHKCHAN_CHANNEL_Msk & ((value) << EVSYS_NSCHKCHAN_CHANNEL_Pos))  
+
+/* -------- EVSYS_NONSECUSER : (EVSYS Offset: 0x1e0) (R/W 32) Users Security Attribution -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t USER0:1;                   /**< bit:      0  Non-Secure for User 0                    */
+    uint32_t USER1:1;                   /**< bit:      1  Non-Secure for User 1                    */
+    uint32_t USER2:1;                   /**< bit:      2  Non-Secure for User 2                    */
+    uint32_t USER3:1;                   /**< bit:      3  Non-Secure for User 3                    */
+    uint32_t USER4:1;                   /**< bit:      4  Non-Secure for User 4                    */
+    uint32_t USER5:1;                   /**< bit:      5  Non-Secure for User 5                    */
+    uint32_t USER6:1;                   /**< bit:      6  Non-Secure for User 6                    */
+    uint32_t USER7:1;                   /**< bit:      7  Non-Secure for User 7                    */
+    uint32_t USER8:1;                   /**< bit:      8  Non-Secure for User 8                    */
+    uint32_t USER9:1;                   /**< bit:      9  Non-Secure for User 9                    */
+    uint32_t USER10:1;                  /**< bit:     10  Non-Secure for User 10                   */
+    uint32_t USER11:1;                  /**< bit:     11  Non-Secure for User 11                   */
+    uint32_t USER12:1;                  /**< bit:     12  Non-Secure for User 12                   */
+    uint32_t USER13:1;                  /**< bit:     13  Non-Secure for User 13                   */
+    uint32_t USER14:1;                  /**< bit:     14  Non-Secure for User 14                   */
+    uint32_t USER15:1;                  /**< bit:     15  Non-Secure for User 15                   */
+    uint32_t USER16:1;                  /**< bit:     16  Non-Secure for User 16                   */
+    uint32_t USER17:1;                  /**< bit:     17  Non-Secure for User 17                   */
+    uint32_t USER18:1;                  /**< bit:     18  Non-Secure for User 18                   */
+    uint32_t USER19:1;                  /**< bit:     19  Non-Secure for User 19                   */
+    uint32_t USER20:1;                  /**< bit:     20  Non-Secure for User 20                   */
+    uint32_t USER21:1;                  /**< bit:     21  Non-Secure for User 21                   */
+    uint32_t USER22:1;                  /**< bit:     22  Non-Secure for User 22                   */
+    uint32_t :9;                        /**< bit: 23..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t USER:23;                   /**< bit:  0..22  Non-Secure for User 22                   */
+    uint32_t :9;                        /**< bit: 23..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} EVSYS_NONSECUSER_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_NONSECUSER_OFFSET             (0x1E0)                                       /**<  (EVSYS_NONSECUSER) Users Security Attribution  Offset */
+#define EVSYS_NONSECUSER_RESETVALUE         _U_(0x00)                                     /**<  (EVSYS_NONSECUSER) Users Security Attribution  Reset Value */
+
+#define EVSYS_NONSECUSER_USER0_Pos          0                                              /**< (EVSYS_NONSECUSER) Non-Secure for User 0 Position */
+#define EVSYS_NONSECUSER_USER0_Msk          (_U_(0x1) << EVSYS_NONSECUSER_USER0_Pos)       /**< (EVSYS_NONSECUSER) Non-Secure for User 0 Mask */
+#define EVSYS_NONSECUSER_USER0              EVSYS_NONSECUSER_USER0_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECUSER_USER0_Msk instead */
+#define EVSYS_NONSECUSER_USER1_Pos          1                                              /**< (EVSYS_NONSECUSER) Non-Secure for User 1 Position */
+#define EVSYS_NONSECUSER_USER1_Msk          (_U_(0x1) << EVSYS_NONSECUSER_USER1_Pos)       /**< (EVSYS_NONSECUSER) Non-Secure for User 1 Mask */
+#define EVSYS_NONSECUSER_USER1              EVSYS_NONSECUSER_USER1_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECUSER_USER1_Msk instead */
+#define EVSYS_NONSECUSER_USER2_Pos          2                                              /**< (EVSYS_NONSECUSER) Non-Secure for User 2 Position */
+#define EVSYS_NONSECUSER_USER2_Msk          (_U_(0x1) << EVSYS_NONSECUSER_USER2_Pos)       /**< (EVSYS_NONSECUSER) Non-Secure for User 2 Mask */
+#define EVSYS_NONSECUSER_USER2              EVSYS_NONSECUSER_USER2_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECUSER_USER2_Msk instead */
+#define EVSYS_NONSECUSER_USER3_Pos          3                                              /**< (EVSYS_NONSECUSER) Non-Secure for User 3 Position */
+#define EVSYS_NONSECUSER_USER3_Msk          (_U_(0x1) << EVSYS_NONSECUSER_USER3_Pos)       /**< (EVSYS_NONSECUSER) Non-Secure for User 3 Mask */
+#define EVSYS_NONSECUSER_USER3              EVSYS_NONSECUSER_USER3_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECUSER_USER3_Msk instead */
+#define EVSYS_NONSECUSER_USER4_Pos          4                                              /**< (EVSYS_NONSECUSER) Non-Secure for User 4 Position */
+#define EVSYS_NONSECUSER_USER4_Msk          (_U_(0x1) << EVSYS_NONSECUSER_USER4_Pos)       /**< (EVSYS_NONSECUSER) Non-Secure for User 4 Mask */
+#define EVSYS_NONSECUSER_USER4              EVSYS_NONSECUSER_USER4_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECUSER_USER4_Msk instead */
+#define EVSYS_NONSECUSER_USER5_Pos          5                                              /**< (EVSYS_NONSECUSER) Non-Secure for User 5 Position */
+#define EVSYS_NONSECUSER_USER5_Msk          (_U_(0x1) << EVSYS_NONSECUSER_USER5_Pos)       /**< (EVSYS_NONSECUSER) Non-Secure for User 5 Mask */
+#define EVSYS_NONSECUSER_USER5              EVSYS_NONSECUSER_USER5_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECUSER_USER5_Msk instead */
+#define EVSYS_NONSECUSER_USER6_Pos          6                                              /**< (EVSYS_NONSECUSER) Non-Secure for User 6 Position */
+#define EVSYS_NONSECUSER_USER6_Msk          (_U_(0x1) << EVSYS_NONSECUSER_USER6_Pos)       /**< (EVSYS_NONSECUSER) Non-Secure for User 6 Mask */
+#define EVSYS_NONSECUSER_USER6              EVSYS_NONSECUSER_USER6_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECUSER_USER6_Msk instead */
+#define EVSYS_NONSECUSER_USER7_Pos          7                                              /**< (EVSYS_NONSECUSER) Non-Secure for User 7 Position */
+#define EVSYS_NONSECUSER_USER7_Msk          (_U_(0x1) << EVSYS_NONSECUSER_USER7_Pos)       /**< (EVSYS_NONSECUSER) Non-Secure for User 7 Mask */
+#define EVSYS_NONSECUSER_USER7              EVSYS_NONSECUSER_USER7_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECUSER_USER7_Msk instead */
+#define EVSYS_NONSECUSER_USER8_Pos          8                                              /**< (EVSYS_NONSECUSER) Non-Secure for User 8 Position */
+#define EVSYS_NONSECUSER_USER8_Msk          (_U_(0x1) << EVSYS_NONSECUSER_USER8_Pos)       /**< (EVSYS_NONSECUSER) Non-Secure for User 8 Mask */
+#define EVSYS_NONSECUSER_USER8              EVSYS_NONSECUSER_USER8_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECUSER_USER8_Msk instead */
+#define EVSYS_NONSECUSER_USER9_Pos          9                                              /**< (EVSYS_NONSECUSER) Non-Secure for User 9 Position */
+#define EVSYS_NONSECUSER_USER9_Msk          (_U_(0x1) << EVSYS_NONSECUSER_USER9_Pos)       /**< (EVSYS_NONSECUSER) Non-Secure for User 9 Mask */
+#define EVSYS_NONSECUSER_USER9              EVSYS_NONSECUSER_USER9_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECUSER_USER9_Msk instead */
+#define EVSYS_NONSECUSER_USER10_Pos         10                                             /**< (EVSYS_NONSECUSER) Non-Secure for User 10 Position */
+#define EVSYS_NONSECUSER_USER10_Msk         (_U_(0x1) << EVSYS_NONSECUSER_USER10_Pos)      /**< (EVSYS_NONSECUSER) Non-Secure for User 10 Mask */
+#define EVSYS_NONSECUSER_USER10             EVSYS_NONSECUSER_USER10_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECUSER_USER10_Msk instead */
+#define EVSYS_NONSECUSER_USER11_Pos         11                                             /**< (EVSYS_NONSECUSER) Non-Secure for User 11 Position */
+#define EVSYS_NONSECUSER_USER11_Msk         (_U_(0x1) << EVSYS_NONSECUSER_USER11_Pos)      /**< (EVSYS_NONSECUSER) Non-Secure for User 11 Mask */
+#define EVSYS_NONSECUSER_USER11             EVSYS_NONSECUSER_USER11_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECUSER_USER11_Msk instead */
+#define EVSYS_NONSECUSER_USER12_Pos         12                                             /**< (EVSYS_NONSECUSER) Non-Secure for User 12 Position */
+#define EVSYS_NONSECUSER_USER12_Msk         (_U_(0x1) << EVSYS_NONSECUSER_USER12_Pos)      /**< (EVSYS_NONSECUSER) Non-Secure for User 12 Mask */
+#define EVSYS_NONSECUSER_USER12             EVSYS_NONSECUSER_USER12_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECUSER_USER12_Msk instead */
+#define EVSYS_NONSECUSER_USER13_Pos         13                                             /**< (EVSYS_NONSECUSER) Non-Secure for User 13 Position */
+#define EVSYS_NONSECUSER_USER13_Msk         (_U_(0x1) << EVSYS_NONSECUSER_USER13_Pos)      /**< (EVSYS_NONSECUSER) Non-Secure for User 13 Mask */
+#define EVSYS_NONSECUSER_USER13             EVSYS_NONSECUSER_USER13_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECUSER_USER13_Msk instead */
+#define EVSYS_NONSECUSER_USER14_Pos         14                                             /**< (EVSYS_NONSECUSER) Non-Secure for User 14 Position */
+#define EVSYS_NONSECUSER_USER14_Msk         (_U_(0x1) << EVSYS_NONSECUSER_USER14_Pos)      /**< (EVSYS_NONSECUSER) Non-Secure for User 14 Mask */
+#define EVSYS_NONSECUSER_USER14             EVSYS_NONSECUSER_USER14_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECUSER_USER14_Msk instead */
+#define EVSYS_NONSECUSER_USER15_Pos         15                                             /**< (EVSYS_NONSECUSER) Non-Secure for User 15 Position */
+#define EVSYS_NONSECUSER_USER15_Msk         (_U_(0x1) << EVSYS_NONSECUSER_USER15_Pos)      /**< (EVSYS_NONSECUSER) Non-Secure for User 15 Mask */
+#define EVSYS_NONSECUSER_USER15             EVSYS_NONSECUSER_USER15_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECUSER_USER15_Msk instead */
+#define EVSYS_NONSECUSER_USER16_Pos         16                                             /**< (EVSYS_NONSECUSER) Non-Secure for User 16 Position */
+#define EVSYS_NONSECUSER_USER16_Msk         (_U_(0x1) << EVSYS_NONSECUSER_USER16_Pos)      /**< (EVSYS_NONSECUSER) Non-Secure for User 16 Mask */
+#define EVSYS_NONSECUSER_USER16             EVSYS_NONSECUSER_USER16_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECUSER_USER16_Msk instead */
+#define EVSYS_NONSECUSER_USER17_Pos         17                                             /**< (EVSYS_NONSECUSER) Non-Secure for User 17 Position */
+#define EVSYS_NONSECUSER_USER17_Msk         (_U_(0x1) << EVSYS_NONSECUSER_USER17_Pos)      /**< (EVSYS_NONSECUSER) Non-Secure for User 17 Mask */
+#define EVSYS_NONSECUSER_USER17             EVSYS_NONSECUSER_USER17_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECUSER_USER17_Msk instead */
+#define EVSYS_NONSECUSER_USER18_Pos         18                                             /**< (EVSYS_NONSECUSER) Non-Secure for User 18 Position */
+#define EVSYS_NONSECUSER_USER18_Msk         (_U_(0x1) << EVSYS_NONSECUSER_USER18_Pos)      /**< (EVSYS_NONSECUSER) Non-Secure for User 18 Mask */
+#define EVSYS_NONSECUSER_USER18             EVSYS_NONSECUSER_USER18_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECUSER_USER18_Msk instead */
+#define EVSYS_NONSECUSER_USER19_Pos         19                                             /**< (EVSYS_NONSECUSER) Non-Secure for User 19 Position */
+#define EVSYS_NONSECUSER_USER19_Msk         (_U_(0x1) << EVSYS_NONSECUSER_USER19_Pos)      /**< (EVSYS_NONSECUSER) Non-Secure for User 19 Mask */
+#define EVSYS_NONSECUSER_USER19             EVSYS_NONSECUSER_USER19_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECUSER_USER19_Msk instead */
+#define EVSYS_NONSECUSER_USER20_Pos         20                                             /**< (EVSYS_NONSECUSER) Non-Secure for User 20 Position */
+#define EVSYS_NONSECUSER_USER20_Msk         (_U_(0x1) << EVSYS_NONSECUSER_USER20_Pos)      /**< (EVSYS_NONSECUSER) Non-Secure for User 20 Mask */
+#define EVSYS_NONSECUSER_USER20             EVSYS_NONSECUSER_USER20_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECUSER_USER20_Msk instead */
+#define EVSYS_NONSECUSER_USER21_Pos         21                                             /**< (EVSYS_NONSECUSER) Non-Secure for User 21 Position */
+#define EVSYS_NONSECUSER_USER21_Msk         (_U_(0x1) << EVSYS_NONSECUSER_USER21_Pos)      /**< (EVSYS_NONSECUSER) Non-Secure for User 21 Mask */
+#define EVSYS_NONSECUSER_USER21             EVSYS_NONSECUSER_USER21_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECUSER_USER21_Msk instead */
+#define EVSYS_NONSECUSER_USER22_Pos         22                                             /**< (EVSYS_NONSECUSER) Non-Secure for User 22 Position */
+#define EVSYS_NONSECUSER_USER22_Msk         (_U_(0x1) << EVSYS_NONSECUSER_USER22_Pos)      /**< (EVSYS_NONSECUSER) Non-Secure for User 22 Mask */
+#define EVSYS_NONSECUSER_USER22             EVSYS_NONSECUSER_USER22_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NONSECUSER_USER22_Msk instead */
+#define EVSYS_NONSECUSER_MASK               _U_(0x7FFFFF)                                  /**< \deprecated (EVSYS_NONSECUSER) Register MASK  (Use EVSYS_NONSECUSER_Msk instead)  */
+#define EVSYS_NONSECUSER_Msk                _U_(0x7FFFFF)                                  /**< (EVSYS_NONSECUSER) Register Mask  */
+
+#define EVSYS_NONSECUSER_USER_Pos           0                                              /**< (EVSYS_NONSECUSER Position) Non-Secure for User 22 */
+#define EVSYS_NONSECUSER_USER_Msk           (_U_(0x7FFFFF) << EVSYS_NONSECUSER_USER_Pos)   /**< (EVSYS_NONSECUSER Mask) USER */
+#define EVSYS_NONSECUSER_USER(value)        (EVSYS_NONSECUSER_USER_Msk & ((value) << EVSYS_NONSECUSER_USER_Pos))  
+
+/* -------- EVSYS_NSCHKUSER : (EVSYS Offset: 0x1f0) (R/W 32) Non-Secure Users Check -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t USER0:1;                   /**< bit:      0  User 0 to be checked as non-secured      */
+    uint32_t USER1:1;                   /**< bit:      1  User 1 to be checked as non-secured      */
+    uint32_t USER2:1;                   /**< bit:      2  User 2 to be checked as non-secured      */
+    uint32_t USER3:1;                   /**< bit:      3  User 3 to be checked as non-secured      */
+    uint32_t USER4:1;                   /**< bit:      4  User 4 to be checked as non-secured      */
+    uint32_t USER5:1;                   /**< bit:      5  User 5 to be checked as non-secured      */
+    uint32_t USER6:1;                   /**< bit:      6  User 6 to be checked as non-secured      */
+    uint32_t USER7:1;                   /**< bit:      7  User 7 to be checked as non-secured      */
+    uint32_t USER8:1;                   /**< bit:      8  User 8 to be checked as non-secured      */
+    uint32_t USER9:1;                   /**< bit:      9  User 9 to be checked as non-secured      */
+    uint32_t USER10:1;                  /**< bit:     10  User 10 to be checked as non-secured     */
+    uint32_t USER11:1;                  /**< bit:     11  User 11 to be checked as non-secured     */
+    uint32_t USER12:1;                  /**< bit:     12  User 12 to be checked as non-secured     */
+    uint32_t USER13:1;                  /**< bit:     13  User 13 to be checked as non-secured     */
+    uint32_t USER14:1;                  /**< bit:     14  User 14 to be checked as non-secured     */
+    uint32_t USER15:1;                  /**< bit:     15  User 15 to be checked as non-secured     */
+    uint32_t USER16:1;                  /**< bit:     16  User 16 to be checked as non-secured     */
+    uint32_t USER17:1;                  /**< bit:     17  User 17 to be checked as non-secured     */
+    uint32_t USER18:1;                  /**< bit:     18  User 18 to be checked as non-secured     */
+    uint32_t USER19:1;                  /**< bit:     19  User 19 to be checked as non-secured     */
+    uint32_t USER20:1;                  /**< bit:     20  User 20 to be checked as non-secured     */
+    uint32_t USER21:1;                  /**< bit:     21  User 21 to be checked as non-secured     */
+    uint32_t USER22:1;                  /**< bit:     22  User 22 to be checked as non-secured     */
+    uint32_t :9;                        /**< bit: 23..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t USER:23;                   /**< bit:  0..22  User 22 to be checked as non-secured     */
+    uint32_t :9;                        /**< bit: 23..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} EVSYS_NSCHKUSER_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_NSCHKUSER_OFFSET              (0x1F0)                                       /**<  (EVSYS_NSCHKUSER) Non-Secure Users Check  Offset */
+#define EVSYS_NSCHKUSER_RESETVALUE          _U_(0x00)                                     /**<  (EVSYS_NSCHKUSER) Non-Secure Users Check  Reset Value */
+
+#define EVSYS_NSCHKUSER_USER0_Pos           0                                              /**< (EVSYS_NSCHKUSER) User 0 to be checked as non-secured Position */
+#define EVSYS_NSCHKUSER_USER0_Msk           (_U_(0x1) << EVSYS_NSCHKUSER_USER0_Pos)        /**< (EVSYS_NSCHKUSER) User 0 to be checked as non-secured Mask */
+#define EVSYS_NSCHKUSER_USER0               EVSYS_NSCHKUSER_USER0_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKUSER_USER0_Msk instead */
+#define EVSYS_NSCHKUSER_USER1_Pos           1                                              /**< (EVSYS_NSCHKUSER) User 1 to be checked as non-secured Position */
+#define EVSYS_NSCHKUSER_USER1_Msk           (_U_(0x1) << EVSYS_NSCHKUSER_USER1_Pos)        /**< (EVSYS_NSCHKUSER) User 1 to be checked as non-secured Mask */
+#define EVSYS_NSCHKUSER_USER1               EVSYS_NSCHKUSER_USER1_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKUSER_USER1_Msk instead */
+#define EVSYS_NSCHKUSER_USER2_Pos           2                                              /**< (EVSYS_NSCHKUSER) User 2 to be checked as non-secured Position */
+#define EVSYS_NSCHKUSER_USER2_Msk           (_U_(0x1) << EVSYS_NSCHKUSER_USER2_Pos)        /**< (EVSYS_NSCHKUSER) User 2 to be checked as non-secured Mask */
+#define EVSYS_NSCHKUSER_USER2               EVSYS_NSCHKUSER_USER2_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKUSER_USER2_Msk instead */
+#define EVSYS_NSCHKUSER_USER3_Pos           3                                              /**< (EVSYS_NSCHKUSER) User 3 to be checked as non-secured Position */
+#define EVSYS_NSCHKUSER_USER3_Msk           (_U_(0x1) << EVSYS_NSCHKUSER_USER3_Pos)        /**< (EVSYS_NSCHKUSER) User 3 to be checked as non-secured Mask */
+#define EVSYS_NSCHKUSER_USER3               EVSYS_NSCHKUSER_USER3_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKUSER_USER3_Msk instead */
+#define EVSYS_NSCHKUSER_USER4_Pos           4                                              /**< (EVSYS_NSCHKUSER) User 4 to be checked as non-secured Position */
+#define EVSYS_NSCHKUSER_USER4_Msk           (_U_(0x1) << EVSYS_NSCHKUSER_USER4_Pos)        /**< (EVSYS_NSCHKUSER) User 4 to be checked as non-secured Mask */
+#define EVSYS_NSCHKUSER_USER4               EVSYS_NSCHKUSER_USER4_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKUSER_USER4_Msk instead */
+#define EVSYS_NSCHKUSER_USER5_Pos           5                                              /**< (EVSYS_NSCHKUSER) User 5 to be checked as non-secured Position */
+#define EVSYS_NSCHKUSER_USER5_Msk           (_U_(0x1) << EVSYS_NSCHKUSER_USER5_Pos)        /**< (EVSYS_NSCHKUSER) User 5 to be checked as non-secured Mask */
+#define EVSYS_NSCHKUSER_USER5               EVSYS_NSCHKUSER_USER5_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKUSER_USER5_Msk instead */
+#define EVSYS_NSCHKUSER_USER6_Pos           6                                              /**< (EVSYS_NSCHKUSER) User 6 to be checked as non-secured Position */
+#define EVSYS_NSCHKUSER_USER6_Msk           (_U_(0x1) << EVSYS_NSCHKUSER_USER6_Pos)        /**< (EVSYS_NSCHKUSER) User 6 to be checked as non-secured Mask */
+#define EVSYS_NSCHKUSER_USER6               EVSYS_NSCHKUSER_USER6_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKUSER_USER6_Msk instead */
+#define EVSYS_NSCHKUSER_USER7_Pos           7                                              /**< (EVSYS_NSCHKUSER) User 7 to be checked as non-secured Position */
+#define EVSYS_NSCHKUSER_USER7_Msk           (_U_(0x1) << EVSYS_NSCHKUSER_USER7_Pos)        /**< (EVSYS_NSCHKUSER) User 7 to be checked as non-secured Mask */
+#define EVSYS_NSCHKUSER_USER7               EVSYS_NSCHKUSER_USER7_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKUSER_USER7_Msk instead */
+#define EVSYS_NSCHKUSER_USER8_Pos           8                                              /**< (EVSYS_NSCHKUSER) User 8 to be checked as non-secured Position */
+#define EVSYS_NSCHKUSER_USER8_Msk           (_U_(0x1) << EVSYS_NSCHKUSER_USER8_Pos)        /**< (EVSYS_NSCHKUSER) User 8 to be checked as non-secured Mask */
+#define EVSYS_NSCHKUSER_USER8               EVSYS_NSCHKUSER_USER8_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKUSER_USER8_Msk instead */
+#define EVSYS_NSCHKUSER_USER9_Pos           9                                              /**< (EVSYS_NSCHKUSER) User 9 to be checked as non-secured Position */
+#define EVSYS_NSCHKUSER_USER9_Msk           (_U_(0x1) << EVSYS_NSCHKUSER_USER9_Pos)        /**< (EVSYS_NSCHKUSER) User 9 to be checked as non-secured Mask */
+#define EVSYS_NSCHKUSER_USER9               EVSYS_NSCHKUSER_USER9_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKUSER_USER9_Msk instead */
+#define EVSYS_NSCHKUSER_USER10_Pos          10                                             /**< (EVSYS_NSCHKUSER) User 10 to be checked as non-secured Position */
+#define EVSYS_NSCHKUSER_USER10_Msk          (_U_(0x1) << EVSYS_NSCHKUSER_USER10_Pos)       /**< (EVSYS_NSCHKUSER) User 10 to be checked as non-secured Mask */
+#define EVSYS_NSCHKUSER_USER10              EVSYS_NSCHKUSER_USER10_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKUSER_USER10_Msk instead */
+#define EVSYS_NSCHKUSER_USER11_Pos          11                                             /**< (EVSYS_NSCHKUSER) User 11 to be checked as non-secured Position */
+#define EVSYS_NSCHKUSER_USER11_Msk          (_U_(0x1) << EVSYS_NSCHKUSER_USER11_Pos)       /**< (EVSYS_NSCHKUSER) User 11 to be checked as non-secured Mask */
+#define EVSYS_NSCHKUSER_USER11              EVSYS_NSCHKUSER_USER11_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKUSER_USER11_Msk instead */
+#define EVSYS_NSCHKUSER_USER12_Pos          12                                             /**< (EVSYS_NSCHKUSER) User 12 to be checked as non-secured Position */
+#define EVSYS_NSCHKUSER_USER12_Msk          (_U_(0x1) << EVSYS_NSCHKUSER_USER12_Pos)       /**< (EVSYS_NSCHKUSER) User 12 to be checked as non-secured Mask */
+#define EVSYS_NSCHKUSER_USER12              EVSYS_NSCHKUSER_USER12_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKUSER_USER12_Msk instead */
+#define EVSYS_NSCHKUSER_USER13_Pos          13                                             /**< (EVSYS_NSCHKUSER) User 13 to be checked as non-secured Position */
+#define EVSYS_NSCHKUSER_USER13_Msk          (_U_(0x1) << EVSYS_NSCHKUSER_USER13_Pos)       /**< (EVSYS_NSCHKUSER) User 13 to be checked as non-secured Mask */
+#define EVSYS_NSCHKUSER_USER13              EVSYS_NSCHKUSER_USER13_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKUSER_USER13_Msk instead */
+#define EVSYS_NSCHKUSER_USER14_Pos          14                                             /**< (EVSYS_NSCHKUSER) User 14 to be checked as non-secured Position */
+#define EVSYS_NSCHKUSER_USER14_Msk          (_U_(0x1) << EVSYS_NSCHKUSER_USER14_Pos)       /**< (EVSYS_NSCHKUSER) User 14 to be checked as non-secured Mask */
+#define EVSYS_NSCHKUSER_USER14              EVSYS_NSCHKUSER_USER14_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKUSER_USER14_Msk instead */
+#define EVSYS_NSCHKUSER_USER15_Pos          15                                             /**< (EVSYS_NSCHKUSER) User 15 to be checked as non-secured Position */
+#define EVSYS_NSCHKUSER_USER15_Msk          (_U_(0x1) << EVSYS_NSCHKUSER_USER15_Pos)       /**< (EVSYS_NSCHKUSER) User 15 to be checked as non-secured Mask */
+#define EVSYS_NSCHKUSER_USER15              EVSYS_NSCHKUSER_USER15_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKUSER_USER15_Msk instead */
+#define EVSYS_NSCHKUSER_USER16_Pos          16                                             /**< (EVSYS_NSCHKUSER) User 16 to be checked as non-secured Position */
+#define EVSYS_NSCHKUSER_USER16_Msk          (_U_(0x1) << EVSYS_NSCHKUSER_USER16_Pos)       /**< (EVSYS_NSCHKUSER) User 16 to be checked as non-secured Mask */
+#define EVSYS_NSCHKUSER_USER16              EVSYS_NSCHKUSER_USER16_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKUSER_USER16_Msk instead */
+#define EVSYS_NSCHKUSER_USER17_Pos          17                                             /**< (EVSYS_NSCHKUSER) User 17 to be checked as non-secured Position */
+#define EVSYS_NSCHKUSER_USER17_Msk          (_U_(0x1) << EVSYS_NSCHKUSER_USER17_Pos)       /**< (EVSYS_NSCHKUSER) User 17 to be checked as non-secured Mask */
+#define EVSYS_NSCHKUSER_USER17              EVSYS_NSCHKUSER_USER17_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKUSER_USER17_Msk instead */
+#define EVSYS_NSCHKUSER_USER18_Pos          18                                             /**< (EVSYS_NSCHKUSER) User 18 to be checked as non-secured Position */
+#define EVSYS_NSCHKUSER_USER18_Msk          (_U_(0x1) << EVSYS_NSCHKUSER_USER18_Pos)       /**< (EVSYS_NSCHKUSER) User 18 to be checked as non-secured Mask */
+#define EVSYS_NSCHKUSER_USER18              EVSYS_NSCHKUSER_USER18_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKUSER_USER18_Msk instead */
+#define EVSYS_NSCHKUSER_USER19_Pos          19                                             /**< (EVSYS_NSCHKUSER) User 19 to be checked as non-secured Position */
+#define EVSYS_NSCHKUSER_USER19_Msk          (_U_(0x1) << EVSYS_NSCHKUSER_USER19_Pos)       /**< (EVSYS_NSCHKUSER) User 19 to be checked as non-secured Mask */
+#define EVSYS_NSCHKUSER_USER19              EVSYS_NSCHKUSER_USER19_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKUSER_USER19_Msk instead */
+#define EVSYS_NSCHKUSER_USER20_Pos          20                                             /**< (EVSYS_NSCHKUSER) User 20 to be checked as non-secured Position */
+#define EVSYS_NSCHKUSER_USER20_Msk          (_U_(0x1) << EVSYS_NSCHKUSER_USER20_Pos)       /**< (EVSYS_NSCHKUSER) User 20 to be checked as non-secured Mask */
+#define EVSYS_NSCHKUSER_USER20              EVSYS_NSCHKUSER_USER20_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKUSER_USER20_Msk instead */
+#define EVSYS_NSCHKUSER_USER21_Pos          21                                             /**< (EVSYS_NSCHKUSER) User 21 to be checked as non-secured Position */
+#define EVSYS_NSCHKUSER_USER21_Msk          (_U_(0x1) << EVSYS_NSCHKUSER_USER21_Pos)       /**< (EVSYS_NSCHKUSER) User 21 to be checked as non-secured Mask */
+#define EVSYS_NSCHKUSER_USER21              EVSYS_NSCHKUSER_USER21_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKUSER_USER21_Msk instead */
+#define EVSYS_NSCHKUSER_USER22_Pos          22                                             /**< (EVSYS_NSCHKUSER) User 22 to be checked as non-secured Position */
+#define EVSYS_NSCHKUSER_USER22_Msk          (_U_(0x1) << EVSYS_NSCHKUSER_USER22_Pos)       /**< (EVSYS_NSCHKUSER) User 22 to be checked as non-secured Mask */
+#define EVSYS_NSCHKUSER_USER22              EVSYS_NSCHKUSER_USER22_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use EVSYS_NSCHKUSER_USER22_Msk instead */
+#define EVSYS_NSCHKUSER_MASK                _U_(0x7FFFFF)                                  /**< \deprecated (EVSYS_NSCHKUSER) Register MASK  (Use EVSYS_NSCHKUSER_Msk instead)  */
+#define EVSYS_NSCHKUSER_Msk                 _U_(0x7FFFFF)                                  /**< (EVSYS_NSCHKUSER) Register Mask  */
+
+#define EVSYS_NSCHKUSER_USER_Pos            0                                              /**< (EVSYS_NSCHKUSER Position) User 22 to be checked as non-secured */
+#define EVSYS_NSCHKUSER_USER_Msk            (_U_(0x7FFFFF) << EVSYS_NSCHKUSER_USER_Pos)    /**< (EVSYS_NSCHKUSER Mask) USER */
+#define EVSYS_NSCHKUSER_USER(value)         (EVSYS_NSCHKUSER_USER_Msk & ((value) << EVSYS_NSCHKUSER_USER_Pos))  
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief CHANNEL hardware registers */
+typedef struct {  
+  __IO EVSYS_CHANNEL_Type             CHANNEL;        /**< Offset: 0x00 (R/W  32) Channel n Control */
+  __IO EVSYS_CHINTENCLR_Type          CHINTENCLR;     /**< Offset: 0x04 (R/W   8) Channel n Interrupt Enable Clear */
+  __IO EVSYS_CHINTENSET_Type          CHINTENSET;     /**< Offset: 0x05 (R/W   8) Channel n Interrupt Enable Set */
+  __IO EVSYS_CHINTFLAG_Type           CHINTFLAG;      /**< Offset: 0x06 (R/W   8) Channel n Interrupt Flag Status and Clear */
+  __I  EVSYS_CHSTATUS_Type            CHSTATUS;       /**< Offset: 0x07 (R/    8) Channel n Status */
+} EvsysChannel;
+
+/** \brief EVSYS hardware registers */
+typedef struct {  /* Event System Interface */
+  __O  EVSYS_CTRLA_Type               CTRLA;          /**< Offset: 0x00 ( /W   8) Control */
+  __I  uint8_t                        Reserved1[3];
+  __O  EVSYS_SWEVT_Type               SWEVT;          /**< Offset: 0x04 ( /W  32) Software Event */
+  __IO EVSYS_PRICTRL_Type             PRICTRL;        /**< Offset: 0x08 (R/W   8) Priority Control */
+  __I  uint8_t                        Reserved2[7];
+  __IO EVSYS_INTPEND_Type             INTPEND;        /**< Offset: 0x10 (R/W  16) Channel Pending Interrupt */
+  __I  uint8_t                        Reserved3[2];
+  __I  EVSYS_INTSTATUS_Type           INTSTATUS;      /**< Offset: 0x14 (R/   32) Interrupt Status */
+  __I  EVSYS_BUSYCH_Type              BUSYCH;         /**< Offset: 0x18 (R/   32) Busy Channels */
+  __I  EVSYS_READYUSR_Type            READYUSR;       /**< Offset: 0x1C (R/   32) Ready Users */
+       EvsysChannel                   Channel[8];     /**< Offset: 0x20  */
+  __I  uint8_t                        Reserved4[192];
+  __IO EVSYS_USER_Type                USER[23];       /**< Offset: 0x120 (R/W   8) User Multiplexer n */
+  __I  uint8_t                        Reserved5[157];
+  __IO EVSYS_INTENCLR_Type            INTENCLR;       /**< Offset: 0x1D4 (R/W   8) Interrupt Enable Clear */
+  __IO EVSYS_INTENSET_Type            INTENSET;       /**< Offset: 0x1D5 (R/W   8) Interrupt Enable Set */
+  __IO EVSYS_INTFLAG_Type             INTFLAG;        /**< Offset: 0x1D6 (R/W   8) Interrupt Flag Status and Clear */
+  __I  uint8_t                        Reserved6[1];
+  __IO EVSYS_NONSECCHAN_Type          NONSECCHAN;     /**< Offset: 0x1D8 (R/W  32) Channels Security Attribution */
+  __IO EVSYS_NSCHKCHAN_Type           NSCHKCHAN;      /**< Offset: 0x1DC (R/W  32) Non-Secure Channels Check */
+  __IO EVSYS_NONSECUSER_Type          NONSECUSER[1];  /**< Offset: 0x1E0 (R/W  32) Users Security Attribution */
+  __I  uint8_t                        Reserved7[12];
+  __IO EVSYS_NSCHKUSER_Type           NSCHKUSER[1];   /**< Offset: 0x1F0 (R/W  32) Non-Secure Users Check */
+} Evsys;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Event System Interface */
+
+#endif /* _SAML11_EVSYS_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/component/freqm.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/freqm.h
@@ -1,0 +1,269 @@
+/**
+ * \file
+ *
+ * \brief Component description for FREQM
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_FREQM_COMPONENT_H_
+#define _SAML11_FREQM_COMPONENT_H_
+#define _SAML11_FREQM_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML11 Frequency Meter
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR FREQM */
+/* ========================================================================== */
+
+#define FREQM_U2257                      /**< (FREQM) Module ID */
+#define REV_FREQM 0x210                  /**< (FREQM) Module revision */
+
+/* -------- FREQM_CTRLA : (FREQM Offset: 0x00) (R/W 8) Control A Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint8_t  ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint8_t  :6;                        /**< bit:   2..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} FREQM_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define FREQM_CTRLA_OFFSET                  (0x00)                                        /**<  (FREQM_CTRLA) Control A Register  Offset */
+#define FREQM_CTRLA_RESETVALUE              _U_(0x00)                                     /**<  (FREQM_CTRLA) Control A Register  Reset Value */
+
+#define FREQM_CTRLA_SWRST_Pos               0                                              /**< (FREQM_CTRLA) Software Reset Position */
+#define FREQM_CTRLA_SWRST_Msk               (_U_(0x1) << FREQM_CTRLA_SWRST_Pos)            /**< (FREQM_CTRLA) Software Reset Mask */
+#define FREQM_CTRLA_SWRST                   FREQM_CTRLA_SWRST_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use FREQM_CTRLA_SWRST_Msk instead */
+#define FREQM_CTRLA_ENABLE_Pos              1                                              /**< (FREQM_CTRLA) Enable Position */
+#define FREQM_CTRLA_ENABLE_Msk              (_U_(0x1) << FREQM_CTRLA_ENABLE_Pos)           /**< (FREQM_CTRLA) Enable Mask */
+#define FREQM_CTRLA_ENABLE                  FREQM_CTRLA_ENABLE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use FREQM_CTRLA_ENABLE_Msk instead */
+#define FREQM_CTRLA_MASK                    _U_(0x03)                                      /**< \deprecated (FREQM_CTRLA) Register MASK  (Use FREQM_CTRLA_Msk instead)  */
+#define FREQM_CTRLA_Msk                     _U_(0x03)                                      /**< (FREQM_CTRLA) Register Mask  */
+
+
+/* -------- FREQM_CTRLB : (FREQM Offset: 0x01) (/W 8) Control B Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  START:1;                   /**< bit:      0  Start Measurement                        */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} FREQM_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define FREQM_CTRLB_OFFSET                  (0x01)                                        /**<  (FREQM_CTRLB) Control B Register  Offset */
+#define FREQM_CTRLB_RESETVALUE              _U_(0x00)                                     /**<  (FREQM_CTRLB) Control B Register  Reset Value */
+
+#define FREQM_CTRLB_START_Pos               0                                              /**< (FREQM_CTRLB) Start Measurement Position */
+#define FREQM_CTRLB_START_Msk               (_U_(0x1) << FREQM_CTRLB_START_Pos)            /**< (FREQM_CTRLB) Start Measurement Mask */
+#define FREQM_CTRLB_START                   FREQM_CTRLB_START_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use FREQM_CTRLB_START_Msk instead */
+#define FREQM_CTRLB_MASK                    _U_(0x01)                                      /**< \deprecated (FREQM_CTRLB) Register MASK  (Use FREQM_CTRLB_Msk instead)  */
+#define FREQM_CTRLB_Msk                     _U_(0x01)                                      /**< (FREQM_CTRLB) Register Mask  */
+
+
+/* -------- FREQM_CFGA : (FREQM Offset: 0x02) (R/W 16) Config A register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t REFNUM:8;                  /**< bit:   0..7  Number of Reference Clock Cycles         */
+    uint16_t :7;                        /**< bit:  8..14  Reserved */
+    uint16_t DIVREF:1;                  /**< bit:     15  Divide Reference Clock                   */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} FREQM_CFGA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define FREQM_CFGA_OFFSET                   (0x02)                                        /**<  (FREQM_CFGA) Config A register  Offset */
+#define FREQM_CFGA_RESETVALUE               _U_(0x00)                                     /**<  (FREQM_CFGA) Config A register  Reset Value */
+
+#define FREQM_CFGA_REFNUM_Pos               0                                              /**< (FREQM_CFGA) Number of Reference Clock Cycles Position */
+#define FREQM_CFGA_REFNUM_Msk               (_U_(0xFF) << FREQM_CFGA_REFNUM_Pos)           /**< (FREQM_CFGA) Number of Reference Clock Cycles Mask */
+#define FREQM_CFGA_REFNUM(value)            (FREQM_CFGA_REFNUM_Msk & ((value) << FREQM_CFGA_REFNUM_Pos))
+#define FREQM_CFGA_DIVREF_Pos               15                                             /**< (FREQM_CFGA) Divide Reference Clock Position */
+#define FREQM_CFGA_DIVREF_Msk               (_U_(0x1) << FREQM_CFGA_DIVREF_Pos)            /**< (FREQM_CFGA) Divide Reference Clock Mask */
+#define FREQM_CFGA_DIVREF                   FREQM_CFGA_DIVREF_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use FREQM_CFGA_DIVREF_Msk instead */
+#define FREQM_CFGA_MASK                     _U_(0x80FF)                                    /**< \deprecated (FREQM_CFGA) Register MASK  (Use FREQM_CFGA_Msk instead)  */
+#define FREQM_CFGA_Msk                      _U_(0x80FF)                                    /**< (FREQM_CFGA) Register Mask  */
+
+
+/* -------- FREQM_INTENCLR : (FREQM Offset: 0x08) (R/W 8) Interrupt Enable Clear Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DONE:1;                    /**< bit:      0  Measurement Done Interrupt Enable        */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} FREQM_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define FREQM_INTENCLR_OFFSET               (0x08)                                        /**<  (FREQM_INTENCLR) Interrupt Enable Clear Register  Offset */
+#define FREQM_INTENCLR_RESETVALUE           _U_(0x00)                                     /**<  (FREQM_INTENCLR) Interrupt Enable Clear Register  Reset Value */
+
+#define FREQM_INTENCLR_DONE_Pos             0                                              /**< (FREQM_INTENCLR) Measurement Done Interrupt Enable Position */
+#define FREQM_INTENCLR_DONE_Msk             (_U_(0x1) << FREQM_INTENCLR_DONE_Pos)          /**< (FREQM_INTENCLR) Measurement Done Interrupt Enable Mask */
+#define FREQM_INTENCLR_DONE                 FREQM_INTENCLR_DONE_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use FREQM_INTENCLR_DONE_Msk instead */
+#define FREQM_INTENCLR_MASK                 _U_(0x01)                                      /**< \deprecated (FREQM_INTENCLR) Register MASK  (Use FREQM_INTENCLR_Msk instead)  */
+#define FREQM_INTENCLR_Msk                  _U_(0x01)                                      /**< (FREQM_INTENCLR) Register Mask  */
+
+
+/* -------- FREQM_INTENSET : (FREQM Offset: 0x09) (R/W 8) Interrupt Enable Set Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DONE:1;                    /**< bit:      0  Measurement Done Interrupt Enable        */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} FREQM_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define FREQM_INTENSET_OFFSET               (0x09)                                        /**<  (FREQM_INTENSET) Interrupt Enable Set Register  Offset */
+#define FREQM_INTENSET_RESETVALUE           _U_(0x00)                                     /**<  (FREQM_INTENSET) Interrupt Enable Set Register  Reset Value */
+
+#define FREQM_INTENSET_DONE_Pos             0                                              /**< (FREQM_INTENSET) Measurement Done Interrupt Enable Position */
+#define FREQM_INTENSET_DONE_Msk             (_U_(0x1) << FREQM_INTENSET_DONE_Pos)          /**< (FREQM_INTENSET) Measurement Done Interrupt Enable Mask */
+#define FREQM_INTENSET_DONE                 FREQM_INTENSET_DONE_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use FREQM_INTENSET_DONE_Msk instead */
+#define FREQM_INTENSET_MASK                 _U_(0x01)                                      /**< \deprecated (FREQM_INTENSET) Register MASK  (Use FREQM_INTENSET_Msk instead)  */
+#define FREQM_INTENSET_Msk                  _U_(0x01)                                      /**< (FREQM_INTENSET) Register Mask  */
+
+
+/* -------- FREQM_INTFLAG : (FREQM Offset: 0x0a) (R/W 8) Interrupt Flag Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t DONE:1;                    /**< bit:      0  Measurement Done                         */
+    __I uint8_t :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} FREQM_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define FREQM_INTFLAG_OFFSET                (0x0A)                                        /**<  (FREQM_INTFLAG) Interrupt Flag Register  Offset */
+#define FREQM_INTFLAG_RESETVALUE            _U_(0x00)                                     /**<  (FREQM_INTFLAG) Interrupt Flag Register  Reset Value */
+
+#define FREQM_INTFLAG_DONE_Pos              0                                              /**< (FREQM_INTFLAG) Measurement Done Position */
+#define FREQM_INTFLAG_DONE_Msk              (_U_(0x1) << FREQM_INTFLAG_DONE_Pos)           /**< (FREQM_INTFLAG) Measurement Done Mask */
+#define FREQM_INTFLAG_DONE                  FREQM_INTFLAG_DONE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use FREQM_INTFLAG_DONE_Msk instead */
+#define FREQM_INTFLAG_MASK                  _U_(0x01)                                      /**< \deprecated (FREQM_INTFLAG) Register MASK  (Use FREQM_INTFLAG_Msk instead)  */
+#define FREQM_INTFLAG_Msk                   _U_(0x01)                                      /**< (FREQM_INTFLAG) Register Mask  */
+
+
+/* -------- FREQM_STATUS : (FREQM Offset: 0x0b) (R/W 8) Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  BUSY:1;                    /**< bit:      0  FREQM Status                             */
+    uint8_t  OVF:1;                     /**< bit:      1  Sticky Count Value Overflow              */
+    uint8_t  :6;                        /**< bit:   2..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} FREQM_STATUS_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define FREQM_STATUS_OFFSET                 (0x0B)                                        /**<  (FREQM_STATUS) Status Register  Offset */
+#define FREQM_STATUS_RESETVALUE             _U_(0x00)                                     /**<  (FREQM_STATUS) Status Register  Reset Value */
+
+#define FREQM_STATUS_BUSY_Pos               0                                              /**< (FREQM_STATUS) FREQM Status Position */
+#define FREQM_STATUS_BUSY_Msk               (_U_(0x1) << FREQM_STATUS_BUSY_Pos)            /**< (FREQM_STATUS) FREQM Status Mask */
+#define FREQM_STATUS_BUSY                   FREQM_STATUS_BUSY_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use FREQM_STATUS_BUSY_Msk instead */
+#define FREQM_STATUS_OVF_Pos                1                                              /**< (FREQM_STATUS) Sticky Count Value Overflow Position */
+#define FREQM_STATUS_OVF_Msk                (_U_(0x1) << FREQM_STATUS_OVF_Pos)             /**< (FREQM_STATUS) Sticky Count Value Overflow Mask */
+#define FREQM_STATUS_OVF                    FREQM_STATUS_OVF_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use FREQM_STATUS_OVF_Msk instead */
+#define FREQM_STATUS_MASK                   _U_(0x03)                                      /**< \deprecated (FREQM_STATUS) Register MASK  (Use FREQM_STATUS_Msk instead)  */
+#define FREQM_STATUS_Msk                    _U_(0x03)                                      /**< (FREQM_STATUS) Register Mask  */
+
+
+/* -------- FREQM_SYNCBUSY : (FREQM Offset: 0x0c) (R/ 32) Synchronization Busy Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint32_t ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint32_t :30;                       /**< bit:  2..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} FREQM_SYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define FREQM_SYNCBUSY_OFFSET               (0x0C)                                        /**<  (FREQM_SYNCBUSY) Synchronization Busy Register  Offset */
+#define FREQM_SYNCBUSY_RESETVALUE           _U_(0x00)                                     /**<  (FREQM_SYNCBUSY) Synchronization Busy Register  Reset Value */
+
+#define FREQM_SYNCBUSY_SWRST_Pos            0                                              /**< (FREQM_SYNCBUSY) Software Reset Position */
+#define FREQM_SYNCBUSY_SWRST_Msk            (_U_(0x1) << FREQM_SYNCBUSY_SWRST_Pos)         /**< (FREQM_SYNCBUSY) Software Reset Mask */
+#define FREQM_SYNCBUSY_SWRST                FREQM_SYNCBUSY_SWRST_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use FREQM_SYNCBUSY_SWRST_Msk instead */
+#define FREQM_SYNCBUSY_ENABLE_Pos           1                                              /**< (FREQM_SYNCBUSY) Enable Position */
+#define FREQM_SYNCBUSY_ENABLE_Msk           (_U_(0x1) << FREQM_SYNCBUSY_ENABLE_Pos)        /**< (FREQM_SYNCBUSY) Enable Mask */
+#define FREQM_SYNCBUSY_ENABLE               FREQM_SYNCBUSY_ENABLE_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use FREQM_SYNCBUSY_ENABLE_Msk instead */
+#define FREQM_SYNCBUSY_MASK                 _U_(0x03)                                      /**< \deprecated (FREQM_SYNCBUSY) Register MASK  (Use FREQM_SYNCBUSY_Msk instead)  */
+#define FREQM_SYNCBUSY_Msk                  _U_(0x03)                                      /**< (FREQM_SYNCBUSY) Register Mask  */
+
+
+/* -------- FREQM_VALUE : (FREQM Offset: 0x10) (R/ 32) Count Value Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t VALUE:24;                  /**< bit:  0..23  Measurement Value                        */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} FREQM_VALUE_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define FREQM_VALUE_OFFSET                  (0x10)                                        /**<  (FREQM_VALUE) Count Value Register  Offset */
+#define FREQM_VALUE_RESETVALUE              _U_(0x00)                                     /**<  (FREQM_VALUE) Count Value Register  Reset Value */
+
+#define FREQM_VALUE_VALUE_Pos               0                                              /**< (FREQM_VALUE) Measurement Value Position */
+#define FREQM_VALUE_VALUE_Msk               (_U_(0xFFFFFF) << FREQM_VALUE_VALUE_Pos)       /**< (FREQM_VALUE) Measurement Value Mask */
+#define FREQM_VALUE_VALUE(value)            (FREQM_VALUE_VALUE_Msk & ((value) << FREQM_VALUE_VALUE_Pos))
+#define FREQM_VALUE_MASK                    _U_(0xFFFFFF)                                  /**< \deprecated (FREQM_VALUE) Register MASK  (Use FREQM_VALUE_Msk instead)  */
+#define FREQM_VALUE_Msk                     _U_(0xFFFFFF)                                  /**< (FREQM_VALUE) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief FREQM hardware registers */
+typedef struct {  /* Frequency Meter */
+  __IO FREQM_CTRLA_Type               CTRLA;          /**< Offset: 0x00 (R/W   8) Control A Register */
+  __O  FREQM_CTRLB_Type               CTRLB;          /**< Offset: 0x01 ( /W   8) Control B Register */
+  __IO FREQM_CFGA_Type                CFGA;           /**< Offset: 0x02 (R/W  16) Config A register */
+  __I  uint8_t                        Reserved1[4];
+  __IO FREQM_INTENCLR_Type            INTENCLR;       /**< Offset: 0x08 (R/W   8) Interrupt Enable Clear Register */
+  __IO FREQM_INTENSET_Type            INTENSET;       /**< Offset: 0x09 (R/W   8) Interrupt Enable Set Register */
+  __IO FREQM_INTFLAG_Type             INTFLAG;        /**< Offset: 0x0A (R/W   8) Interrupt Flag Register */
+  __IO FREQM_STATUS_Type              STATUS;         /**< Offset: 0x0B (R/W   8) Status Register */
+  __I  FREQM_SYNCBUSY_Type            SYNCBUSY;       /**< Offset: 0x0C (R/   32) Synchronization Busy Register */
+  __I  FREQM_VALUE_Type               VALUE;          /**< Offset: 0x10 (R/   32) Count Value Register */
+} Freqm;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Frequency Meter */
+
+#endif /* _SAML11_FREQM_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/component/gclk.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/gclk.h
@@ -1,0 +1,238 @@
+/**
+ * \file
+ *
+ * \brief Component description for GCLK
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_GCLK_COMPONENT_H_
+#define _SAML11_GCLK_COMPONENT_H_
+#define _SAML11_GCLK_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML11 Generic Clock Generator
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR GCLK */
+/* ========================================================================== */
+
+#define GCLK_U2122                      /**< (GCLK) Module ID */
+#define REV_GCLK 0x112                  /**< (GCLK) Module revision */
+
+/* -------- GCLK_CTRLA : (GCLK Offset: 0x00) (R/W 8) Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} GCLK_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GCLK_CTRLA_OFFSET                   (0x00)                                        /**<  (GCLK_CTRLA) Control  Offset */
+#define GCLK_CTRLA_RESETVALUE               _U_(0x00)                                     /**<  (GCLK_CTRLA) Control  Reset Value */
+
+#define GCLK_CTRLA_SWRST_Pos                0                                              /**< (GCLK_CTRLA) Software Reset Position */
+#define GCLK_CTRLA_SWRST_Msk                (_U_(0x1) << GCLK_CTRLA_SWRST_Pos)             /**< (GCLK_CTRLA) Software Reset Mask */
+#define GCLK_CTRLA_SWRST                    GCLK_CTRLA_SWRST_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GCLK_CTRLA_SWRST_Msk instead */
+#define GCLK_CTRLA_MASK                     _U_(0x01)                                      /**< \deprecated (GCLK_CTRLA) Register MASK  (Use GCLK_CTRLA_Msk instead)  */
+#define GCLK_CTRLA_Msk                      _U_(0x01)                                      /**< (GCLK_CTRLA) Register Mask  */
+
+
+/* -------- GCLK_SYNCBUSY : (GCLK Offset: 0x04) (R/ 32) Synchronization Busy -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SWRST:1;                   /**< bit:      0  Software Reset Synchroniation Busy bit   */
+    uint32_t :1;                        /**< bit:      1  Reserved */
+    uint32_t GENCTRL0:1;                /**< bit:      2  Generic Clock Generator Control 0 Synchronization Busy bit */
+    uint32_t GENCTRL1:1;                /**< bit:      3  Generic Clock Generator Control 1 Synchronization Busy bit */
+    uint32_t GENCTRL2:1;                /**< bit:      4  Generic Clock Generator Control 2 Synchronization Busy bit */
+    uint32_t GENCTRL3:1;                /**< bit:      5  Generic Clock Generator Control 3 Synchronization Busy bit */
+    uint32_t GENCTRL4:1;                /**< bit:      6  Generic Clock Generator Control 4 Synchronization Busy bit */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t GENCTRL:5;                 /**< bit:   2..6  Generic Clock Generator Control 4 Synchronization Busy bit */
+    uint32_t :25;                       /**< bit:  7..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} GCLK_SYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GCLK_SYNCBUSY_OFFSET                (0x04)                                        /**<  (GCLK_SYNCBUSY) Synchronization Busy  Offset */
+#define GCLK_SYNCBUSY_RESETVALUE            _U_(0x00)                                     /**<  (GCLK_SYNCBUSY) Synchronization Busy  Reset Value */
+
+#define GCLK_SYNCBUSY_SWRST_Pos             0                                              /**< (GCLK_SYNCBUSY) Software Reset Synchroniation Busy bit Position */
+#define GCLK_SYNCBUSY_SWRST_Msk             (_U_(0x1) << GCLK_SYNCBUSY_SWRST_Pos)          /**< (GCLK_SYNCBUSY) Software Reset Synchroniation Busy bit Mask */
+#define GCLK_SYNCBUSY_SWRST                 GCLK_SYNCBUSY_SWRST_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use GCLK_SYNCBUSY_SWRST_Msk instead */
+#define GCLK_SYNCBUSY_GENCTRL0_Pos          2                                              /**< (GCLK_SYNCBUSY) Generic Clock Generator Control 0 Synchronization Busy bit Position */
+#define GCLK_SYNCBUSY_GENCTRL0_Msk          (_U_(0x1) << GCLK_SYNCBUSY_GENCTRL0_Pos)       /**< (GCLK_SYNCBUSY) Generic Clock Generator Control 0 Synchronization Busy bit Mask */
+#define GCLK_SYNCBUSY_GENCTRL0              GCLK_SYNCBUSY_GENCTRL0_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use GCLK_SYNCBUSY_GENCTRL0_Msk instead */
+#define GCLK_SYNCBUSY_GENCTRL1_Pos          3                                              /**< (GCLK_SYNCBUSY) Generic Clock Generator Control 1 Synchronization Busy bit Position */
+#define GCLK_SYNCBUSY_GENCTRL1_Msk          (_U_(0x1) << GCLK_SYNCBUSY_GENCTRL1_Pos)       /**< (GCLK_SYNCBUSY) Generic Clock Generator Control 1 Synchronization Busy bit Mask */
+#define GCLK_SYNCBUSY_GENCTRL1              GCLK_SYNCBUSY_GENCTRL1_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use GCLK_SYNCBUSY_GENCTRL1_Msk instead */
+#define GCLK_SYNCBUSY_GENCTRL2_Pos          4                                              /**< (GCLK_SYNCBUSY) Generic Clock Generator Control 2 Synchronization Busy bit Position */
+#define GCLK_SYNCBUSY_GENCTRL2_Msk          (_U_(0x1) << GCLK_SYNCBUSY_GENCTRL2_Pos)       /**< (GCLK_SYNCBUSY) Generic Clock Generator Control 2 Synchronization Busy bit Mask */
+#define GCLK_SYNCBUSY_GENCTRL2              GCLK_SYNCBUSY_GENCTRL2_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use GCLK_SYNCBUSY_GENCTRL2_Msk instead */
+#define GCLK_SYNCBUSY_GENCTRL3_Pos          5                                              /**< (GCLK_SYNCBUSY) Generic Clock Generator Control 3 Synchronization Busy bit Position */
+#define GCLK_SYNCBUSY_GENCTRL3_Msk          (_U_(0x1) << GCLK_SYNCBUSY_GENCTRL3_Pos)       /**< (GCLK_SYNCBUSY) Generic Clock Generator Control 3 Synchronization Busy bit Mask */
+#define GCLK_SYNCBUSY_GENCTRL3              GCLK_SYNCBUSY_GENCTRL3_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use GCLK_SYNCBUSY_GENCTRL3_Msk instead */
+#define GCLK_SYNCBUSY_GENCTRL4_Pos          6                                              /**< (GCLK_SYNCBUSY) Generic Clock Generator Control 4 Synchronization Busy bit Position */
+#define GCLK_SYNCBUSY_GENCTRL4_Msk          (_U_(0x1) << GCLK_SYNCBUSY_GENCTRL4_Pos)       /**< (GCLK_SYNCBUSY) Generic Clock Generator Control 4 Synchronization Busy bit Mask */
+#define GCLK_SYNCBUSY_GENCTRL4              GCLK_SYNCBUSY_GENCTRL4_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use GCLK_SYNCBUSY_GENCTRL4_Msk instead */
+#define GCLK_SYNCBUSY_MASK                  _U_(0x7D)                                      /**< \deprecated (GCLK_SYNCBUSY) Register MASK  (Use GCLK_SYNCBUSY_Msk instead)  */
+#define GCLK_SYNCBUSY_Msk                   _U_(0x7D)                                      /**< (GCLK_SYNCBUSY) Register Mask  */
+
+#define GCLK_SYNCBUSY_GENCTRL_Pos           2                                              /**< (GCLK_SYNCBUSY Position) Generic Clock Generator Control 4 Synchronization Busy bit */
+#define GCLK_SYNCBUSY_GENCTRL_Msk           (_U_(0x1F) << GCLK_SYNCBUSY_GENCTRL_Pos)       /**< (GCLK_SYNCBUSY Mask) GENCTRL */
+#define GCLK_SYNCBUSY_GENCTRL(value)        (GCLK_SYNCBUSY_GENCTRL_Msk & ((value) << GCLK_SYNCBUSY_GENCTRL_Pos))  
+
+/* -------- GCLK_GENCTRL : (GCLK Offset: 0x20) (R/W 32) Generic Clock Generator Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SRC:3;                     /**< bit:   0..2  Source Select                            */
+    uint32_t :5;                        /**< bit:   3..7  Reserved */
+    uint32_t GENEN:1;                   /**< bit:      8  Generic Clock Generator Enable           */
+    uint32_t IDC:1;                     /**< bit:      9  Improve Duty Cycle                       */
+    uint32_t OOV:1;                     /**< bit:     10  Output Off Value                         */
+    uint32_t OE:1;                      /**< bit:     11  Output Enable                            */
+    uint32_t DIVSEL:1;                  /**< bit:     12  Divide Selection                         */
+    uint32_t RUNSTDBY:1;                /**< bit:     13  Run in Standby                           */
+    uint32_t :2;                        /**< bit: 14..15  Reserved */
+    uint32_t DIV:16;                    /**< bit: 16..31  Division Factor                          */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GCLK_GENCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GCLK_GENCTRL_OFFSET                 (0x20)                                        /**<  (GCLK_GENCTRL) Generic Clock Generator Control  Offset */
+#define GCLK_GENCTRL_RESETVALUE             _U_(0x00)                                     /**<  (GCLK_GENCTRL) Generic Clock Generator Control  Reset Value */
+
+#define GCLK_GENCTRL_SRC_Pos                0                                              /**< (GCLK_GENCTRL) Source Select Position */
+#define GCLK_GENCTRL_SRC_Msk                (_U_(0x7) << GCLK_GENCTRL_SRC_Pos)             /**< (GCLK_GENCTRL) Source Select Mask */
+#define GCLK_GENCTRL_SRC(value)             (GCLK_GENCTRL_SRC_Msk & ((value) << GCLK_GENCTRL_SRC_Pos))
+#define   GCLK_GENCTRL_SRC_XOSC_Val         _U_(0x0)                                       /**< (GCLK_GENCTRL) XOSC oscillator output  */
+#define   GCLK_GENCTRL_SRC_GCLKIN_Val       _U_(0x1)                                       /**< (GCLK_GENCTRL) Generator input pad  */
+#define   GCLK_GENCTRL_SRC_GCLKGEN1_Val     _U_(0x2)                                       /**< (GCLK_GENCTRL) Generic clock generator 1 output  */
+#define   GCLK_GENCTRL_SRC_OSCULP32K_Val    _U_(0x3)                                       /**< (GCLK_GENCTRL) OSCULP32K oscillator output  */
+#define   GCLK_GENCTRL_SRC_XOSC32K_Val      _U_(0x4)                                       /**< (GCLK_GENCTRL) XOSC32K oscillator output  */
+#define   GCLK_GENCTRL_SRC_OSC16M_Val       _U_(0x5)                                       /**< (GCLK_GENCTRL) OSC16M oscillator output  */
+#define   GCLK_GENCTRL_SRC_DFLLULP_Val      _U_(0x6)                                       /**< (GCLK_GENCTRL) DFLLULP output  */
+#define   GCLK_GENCTRL_SRC_FDPLL96M_Val     _U_(0x7)                                       /**< (GCLK_GENCTRL) FDPLL output  */
+#define GCLK_GENCTRL_SRC_XOSC               (GCLK_GENCTRL_SRC_XOSC_Val << GCLK_GENCTRL_SRC_Pos)  /**< (GCLK_GENCTRL) XOSC oscillator output Position  */
+#define GCLK_GENCTRL_SRC_GCLKIN             (GCLK_GENCTRL_SRC_GCLKIN_Val << GCLK_GENCTRL_SRC_Pos)  /**< (GCLK_GENCTRL) Generator input pad Position  */
+#define GCLK_GENCTRL_SRC_GCLKGEN1           (GCLK_GENCTRL_SRC_GCLKGEN1_Val << GCLK_GENCTRL_SRC_Pos)  /**< (GCLK_GENCTRL) Generic clock generator 1 output Position  */
+#define GCLK_GENCTRL_SRC_OSCULP32K          (GCLK_GENCTRL_SRC_OSCULP32K_Val << GCLK_GENCTRL_SRC_Pos)  /**< (GCLK_GENCTRL) OSCULP32K oscillator output Position  */
+#define GCLK_GENCTRL_SRC_XOSC32K            (GCLK_GENCTRL_SRC_XOSC32K_Val << GCLK_GENCTRL_SRC_Pos)  /**< (GCLK_GENCTRL) XOSC32K oscillator output Position  */
+#define GCLK_GENCTRL_SRC_OSC16M             (GCLK_GENCTRL_SRC_OSC16M_Val << GCLK_GENCTRL_SRC_Pos)  /**< (GCLK_GENCTRL) OSC16M oscillator output Position  */
+#define GCLK_GENCTRL_SRC_DFLLULP            (GCLK_GENCTRL_SRC_DFLLULP_Val << GCLK_GENCTRL_SRC_Pos)  /**< (GCLK_GENCTRL) DFLLULP output Position  */
+#define GCLK_GENCTRL_SRC_FDPLL96M           (GCLK_GENCTRL_SRC_FDPLL96M_Val << GCLK_GENCTRL_SRC_Pos)  /**< (GCLK_GENCTRL) FDPLL output Position  */
+#define GCLK_GENCTRL_GENEN_Pos              8                                              /**< (GCLK_GENCTRL) Generic Clock Generator Enable Position */
+#define GCLK_GENCTRL_GENEN_Msk              (_U_(0x1) << GCLK_GENCTRL_GENEN_Pos)           /**< (GCLK_GENCTRL) Generic Clock Generator Enable Mask */
+#define GCLK_GENCTRL_GENEN                  GCLK_GENCTRL_GENEN_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use GCLK_GENCTRL_GENEN_Msk instead */
+#define GCLK_GENCTRL_IDC_Pos                9                                              /**< (GCLK_GENCTRL) Improve Duty Cycle Position */
+#define GCLK_GENCTRL_IDC_Msk                (_U_(0x1) << GCLK_GENCTRL_IDC_Pos)             /**< (GCLK_GENCTRL) Improve Duty Cycle Mask */
+#define GCLK_GENCTRL_IDC                    GCLK_GENCTRL_IDC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GCLK_GENCTRL_IDC_Msk instead */
+#define GCLK_GENCTRL_OOV_Pos                10                                             /**< (GCLK_GENCTRL) Output Off Value Position */
+#define GCLK_GENCTRL_OOV_Msk                (_U_(0x1) << GCLK_GENCTRL_OOV_Pos)             /**< (GCLK_GENCTRL) Output Off Value Mask */
+#define GCLK_GENCTRL_OOV                    GCLK_GENCTRL_OOV_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GCLK_GENCTRL_OOV_Msk instead */
+#define GCLK_GENCTRL_OE_Pos                 11                                             /**< (GCLK_GENCTRL) Output Enable Position */
+#define GCLK_GENCTRL_OE_Msk                 (_U_(0x1) << GCLK_GENCTRL_OE_Pos)              /**< (GCLK_GENCTRL) Output Enable Mask */
+#define GCLK_GENCTRL_OE                     GCLK_GENCTRL_OE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GCLK_GENCTRL_OE_Msk instead */
+#define GCLK_GENCTRL_DIVSEL_Pos             12                                             /**< (GCLK_GENCTRL) Divide Selection Position */
+#define GCLK_GENCTRL_DIVSEL_Msk             (_U_(0x1) << GCLK_GENCTRL_DIVSEL_Pos)          /**< (GCLK_GENCTRL) Divide Selection Mask */
+#define GCLK_GENCTRL_DIVSEL                 GCLK_GENCTRL_DIVSEL_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use GCLK_GENCTRL_DIVSEL_Msk instead */
+#define GCLK_GENCTRL_RUNSTDBY_Pos           13                                             /**< (GCLK_GENCTRL) Run in Standby Position */
+#define GCLK_GENCTRL_RUNSTDBY_Msk           (_U_(0x1) << GCLK_GENCTRL_RUNSTDBY_Pos)        /**< (GCLK_GENCTRL) Run in Standby Mask */
+#define GCLK_GENCTRL_RUNSTDBY               GCLK_GENCTRL_RUNSTDBY_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use GCLK_GENCTRL_RUNSTDBY_Msk instead */
+#define GCLK_GENCTRL_DIV_Pos                16                                             /**< (GCLK_GENCTRL) Division Factor Position */
+#define GCLK_GENCTRL_DIV_Msk                (_U_(0xFFFF) << GCLK_GENCTRL_DIV_Pos)          /**< (GCLK_GENCTRL) Division Factor Mask */
+#define GCLK_GENCTRL_DIV(value)             (GCLK_GENCTRL_DIV_Msk & ((value) << GCLK_GENCTRL_DIV_Pos))
+#define GCLK_GENCTRL_MASK                   _U_(0xFFFF3F07)                                /**< \deprecated (GCLK_GENCTRL) Register MASK  (Use GCLK_GENCTRL_Msk instead)  */
+#define GCLK_GENCTRL_Msk                    _U_(0xFFFF3F07)                                /**< (GCLK_GENCTRL) Register Mask  */
+
+
+/* -------- GCLK_PCHCTRL : (GCLK Offset: 0x80) (R/W 32) Peripheral Clock Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t GEN:3;                     /**< bit:   0..2  Generic Clock Generator                  */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t CHEN:1;                    /**< bit:      6  Channel Enable                           */
+    uint32_t WRTLOCK:1;                 /**< bit:      7  Write Lock                               */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GCLK_PCHCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GCLK_PCHCTRL_OFFSET                 (0x80)                                        /**<  (GCLK_PCHCTRL) Peripheral Clock Control  Offset */
+#define GCLK_PCHCTRL_RESETVALUE             _U_(0x00)                                     /**<  (GCLK_PCHCTRL) Peripheral Clock Control  Reset Value */
+
+#define GCLK_PCHCTRL_GEN_Pos                0                                              /**< (GCLK_PCHCTRL) Generic Clock Generator Position */
+#define GCLK_PCHCTRL_GEN_Msk                (_U_(0x7) << GCLK_PCHCTRL_GEN_Pos)             /**< (GCLK_PCHCTRL) Generic Clock Generator Mask */
+#define GCLK_PCHCTRL_GEN(value)             (GCLK_PCHCTRL_GEN_Msk & ((value) << GCLK_PCHCTRL_GEN_Pos))
+#define   GCLK_PCHCTRL_GEN_GCLK0_Val        _U_(0x0)                                       /**< (GCLK_PCHCTRL) Generic clock generator 0  */
+#define   GCLK_PCHCTRL_GEN_GCLK1_Val        _U_(0x1)                                       /**< (GCLK_PCHCTRL) Generic clock generator 1  */
+#define   GCLK_PCHCTRL_GEN_GCLK2_Val        _U_(0x2)                                       /**< (GCLK_PCHCTRL) Generic clock generator 2  */
+#define   GCLK_PCHCTRL_GEN_GCLK3_Val        _U_(0x3)                                       /**< (GCLK_PCHCTRL) Generic clock generator 3  */
+#define   GCLK_PCHCTRL_GEN_GCLK4_Val        _U_(0x4)                                       /**< (GCLK_PCHCTRL) Generic clock generator 4  */
+#define GCLK_PCHCTRL_GEN_GCLK0              (GCLK_PCHCTRL_GEN_GCLK0_Val << GCLK_PCHCTRL_GEN_Pos)  /**< (GCLK_PCHCTRL) Generic clock generator 0 Position  */
+#define GCLK_PCHCTRL_GEN_GCLK1              (GCLK_PCHCTRL_GEN_GCLK1_Val << GCLK_PCHCTRL_GEN_Pos)  /**< (GCLK_PCHCTRL) Generic clock generator 1 Position  */
+#define GCLK_PCHCTRL_GEN_GCLK2              (GCLK_PCHCTRL_GEN_GCLK2_Val << GCLK_PCHCTRL_GEN_Pos)  /**< (GCLK_PCHCTRL) Generic clock generator 2 Position  */
+#define GCLK_PCHCTRL_GEN_GCLK3              (GCLK_PCHCTRL_GEN_GCLK3_Val << GCLK_PCHCTRL_GEN_Pos)  /**< (GCLK_PCHCTRL) Generic clock generator 3 Position  */
+#define GCLK_PCHCTRL_GEN_GCLK4              (GCLK_PCHCTRL_GEN_GCLK4_Val << GCLK_PCHCTRL_GEN_Pos)  /**< (GCLK_PCHCTRL) Generic clock generator 4 Position  */
+#define GCLK_PCHCTRL_CHEN_Pos               6                                              /**< (GCLK_PCHCTRL) Channel Enable Position */
+#define GCLK_PCHCTRL_CHEN_Msk               (_U_(0x1) << GCLK_PCHCTRL_CHEN_Pos)            /**< (GCLK_PCHCTRL) Channel Enable Mask */
+#define GCLK_PCHCTRL_CHEN                   GCLK_PCHCTRL_CHEN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use GCLK_PCHCTRL_CHEN_Msk instead */
+#define GCLK_PCHCTRL_WRTLOCK_Pos            7                                              /**< (GCLK_PCHCTRL) Write Lock Position */
+#define GCLK_PCHCTRL_WRTLOCK_Msk            (_U_(0x1) << GCLK_PCHCTRL_WRTLOCK_Pos)         /**< (GCLK_PCHCTRL) Write Lock Mask */
+#define GCLK_PCHCTRL_WRTLOCK                GCLK_PCHCTRL_WRTLOCK_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use GCLK_PCHCTRL_WRTLOCK_Msk instead */
+#define GCLK_PCHCTRL_MASK                   _U_(0xC7)                                      /**< \deprecated (GCLK_PCHCTRL) Register MASK  (Use GCLK_PCHCTRL_Msk instead)  */
+#define GCLK_PCHCTRL_Msk                    _U_(0xC7)                                      /**< (GCLK_PCHCTRL) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief GCLK hardware registers */
+typedef struct {  /* Generic Clock Generator */
+  __IO GCLK_CTRLA_Type                CTRLA;          /**< Offset: 0x00 (R/W   8) Control */
+  __I  uint8_t                        Reserved1[3];
+  __I  GCLK_SYNCBUSY_Type             SYNCBUSY;       /**< Offset: 0x04 (R/   32) Synchronization Busy */
+  __I  uint8_t                        Reserved2[24];
+  __IO GCLK_GENCTRL_Type              GENCTRL[5];     /**< Offset: 0x20 (R/W  32) Generic Clock Generator Control */
+  __I  uint8_t                        Reserved3[76];
+  __IO GCLK_PCHCTRL_Type              PCHCTRL[21];    /**< Offset: 0x80 (R/W  32) Peripheral Clock Control */
+} Gclk;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Generic Clock Generator */
+
+#endif /* _SAML11_GCLK_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/component/idau.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/idau.h
@@ -1,0 +1,163 @@
+/**
+ * \file
+ *
+ * \brief Component description for IDAU
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_IDAU_COMPONENT_H_
+#define _SAML11_IDAU_COMPONENT_H_
+#define _SAML11_IDAU_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML11 Implementation Defined Attribution Unit
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR IDAU */
+/* ========================================================================== */
+
+#define IDAU_U2803                      /**< (IDAU) Module ID */
+#define REV_IDAU 0x100                  /**< (IDAU) Module revision */
+
+/* -------- IDAU_SECCTRL : (IDAU Offset: 0x01) (R/W 8) SECCTRL -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  :2;                        /**< bit:   0..1  Reserved */
+    uint8_t  RXN:1;                     /**< bit:      2  CPU RAM is eXecute Never                 */
+    uint8_t  :5;                        /**< bit:   3..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} IDAU_SECCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define IDAU_SECCTRL_OFFSET                 (0x01)                                        /**<  (IDAU_SECCTRL) SECCTRL  Offset */
+#define IDAU_SECCTRL_RESETVALUE             _U_(0x03)                                     /**<  (IDAU_SECCTRL) SECCTRL  Reset Value */
+
+#define IDAU_SECCTRL_RXN_Pos                2                                              /**< (IDAU_SECCTRL) CPU RAM is eXecute Never Position */
+#define IDAU_SECCTRL_RXN_Msk                (_U_(0x1) << IDAU_SECCTRL_RXN_Pos)             /**< (IDAU_SECCTRL) CPU RAM is eXecute Never Mask */
+#define IDAU_SECCTRL_RXN                    IDAU_SECCTRL_RXN_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use IDAU_SECCTRL_RXN_Msk instead */
+#define IDAU_SECCTRL_MASK                   _U_(0x04)                                      /**< \deprecated (IDAU_SECCTRL) Register MASK  (Use IDAU_SECCTRL_Msk instead)  */
+#define IDAU_SECCTRL_Msk                    _U_(0x04)                                      /**< (IDAU_SECCTRL) Register Mask  */
+
+
+/* -------- IDAU_SCFGB : (IDAU Offset: 0x04) (R/W 32) SCFGB -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t BS:8;                      /**< bit:   0..7  Boot Secure                              */
+    uint32_t BNSC:6;                    /**< bit:  8..13  Boot Secure, Non-secure Callable         */
+    uint32_t :2;                        /**< bit: 14..15  Reserved */
+    uint32_t BOOTPROT:8;                /**< bit: 16..23  Boot Protection                          */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} IDAU_SCFGB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define IDAU_SCFGB_OFFSET                   (0x04)                                        /**<  (IDAU_SCFGB) SCFGB  Offset */
+#define IDAU_SCFGB_RESETVALUE               _U_(0x00)                                     /**<  (IDAU_SCFGB) SCFGB  Reset Value */
+
+#define IDAU_SCFGB_BS_Pos                   0                                              /**< (IDAU_SCFGB) Boot Secure Position */
+#define IDAU_SCFGB_BS_Msk                   (_U_(0xFF) << IDAU_SCFGB_BS_Pos)               /**< (IDAU_SCFGB) Boot Secure Mask */
+#define IDAU_SCFGB_BS(value)                (IDAU_SCFGB_BS_Msk & ((value) << IDAU_SCFGB_BS_Pos))
+#define IDAU_SCFGB_BNSC_Pos                 8                                              /**< (IDAU_SCFGB) Boot Secure, Non-secure Callable Position */
+#define IDAU_SCFGB_BNSC_Msk                 (_U_(0x3F) << IDAU_SCFGB_BNSC_Pos)             /**< (IDAU_SCFGB) Boot Secure, Non-secure Callable Mask */
+#define IDAU_SCFGB_BNSC(value)              (IDAU_SCFGB_BNSC_Msk & ((value) << IDAU_SCFGB_BNSC_Pos))
+#define IDAU_SCFGB_BOOTPROT_Pos             16                                             /**< (IDAU_SCFGB) Boot Protection Position */
+#define IDAU_SCFGB_BOOTPROT_Msk             (_U_(0xFF) << IDAU_SCFGB_BOOTPROT_Pos)         /**< (IDAU_SCFGB) Boot Protection Mask */
+#define IDAU_SCFGB_BOOTPROT(value)          (IDAU_SCFGB_BOOTPROT_Msk & ((value) << IDAU_SCFGB_BOOTPROT_Pos))
+#define IDAU_SCFGB_MASK                     _U_(0xFF3FFF)                                  /**< \deprecated (IDAU_SCFGB) Register MASK  (Use IDAU_SCFGB_Msk instead)  */
+#define IDAU_SCFGB_Msk                      _U_(0xFF3FFF)                                  /**< (IDAU_SCFGB) Register Mask  */
+
+
+/* -------- IDAU_SCFGA : (IDAU Offset: 0x08) (R/W 32) SCFGA -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t AS:8;                      /**< bit:   0..7  Application Secure                       */
+    uint32_t ANSC:6;                    /**< bit:  8..13  Application Secure, Non-secure Callable  */
+    uint32_t :2;                        /**< bit: 14..15  Reserved */
+    uint32_t DS:4;                      /**< bit: 16..19  DATAFLASH Data Secure                    */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} IDAU_SCFGA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define IDAU_SCFGA_OFFSET                   (0x08)                                        /**<  (IDAU_SCFGA) SCFGA  Offset */
+#define IDAU_SCFGA_RESETVALUE               _U_(0x00)                                     /**<  (IDAU_SCFGA) SCFGA  Reset Value */
+
+#define IDAU_SCFGA_AS_Pos                   0                                              /**< (IDAU_SCFGA) Application Secure Position */
+#define IDAU_SCFGA_AS_Msk                   (_U_(0xFF) << IDAU_SCFGA_AS_Pos)               /**< (IDAU_SCFGA) Application Secure Mask */
+#define IDAU_SCFGA_AS(value)                (IDAU_SCFGA_AS_Msk & ((value) << IDAU_SCFGA_AS_Pos))
+#define IDAU_SCFGA_ANSC_Pos                 8                                              /**< (IDAU_SCFGA) Application Secure, Non-secure Callable Position */
+#define IDAU_SCFGA_ANSC_Msk                 (_U_(0x3F) << IDAU_SCFGA_ANSC_Pos)             /**< (IDAU_SCFGA) Application Secure, Non-secure Callable Mask */
+#define IDAU_SCFGA_ANSC(value)              (IDAU_SCFGA_ANSC_Msk & ((value) << IDAU_SCFGA_ANSC_Pos))
+#define IDAU_SCFGA_DS_Pos                   16                                             /**< (IDAU_SCFGA) DATAFLASH Data Secure Position */
+#define IDAU_SCFGA_DS_Msk                   (_U_(0xF) << IDAU_SCFGA_DS_Pos)                /**< (IDAU_SCFGA) DATAFLASH Data Secure Mask */
+#define IDAU_SCFGA_DS(value)                (IDAU_SCFGA_DS_Msk & ((value) << IDAU_SCFGA_DS_Pos))
+#define IDAU_SCFGA_MASK                     _U_(0xF3FFF)                                   /**< \deprecated (IDAU_SCFGA) Register MASK  (Use IDAU_SCFGA_Msk instead)  */
+#define IDAU_SCFGA_Msk                      _U_(0xF3FFF)                                   /**< (IDAU_SCFGA) Register Mask  */
+
+
+/* -------- IDAU_SCFGR : (IDAU Offset: 0x0c) (R/W 8) SCFGR -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  RS:7;                      /**< bit:   0..6  RAM Secure                               */
+    uint8_t  :1;                        /**< bit:      7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} IDAU_SCFGR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define IDAU_SCFGR_OFFSET                   (0x0C)                                        /**<  (IDAU_SCFGR) SCFGR  Offset */
+#define IDAU_SCFGR_RESETVALUE               _U_(0x00)                                     /**<  (IDAU_SCFGR) SCFGR  Reset Value */
+
+#define IDAU_SCFGR_RS_Pos                   0                                              /**< (IDAU_SCFGR) RAM Secure Position */
+#define IDAU_SCFGR_RS_Msk                   (_U_(0x7F) << IDAU_SCFGR_RS_Pos)               /**< (IDAU_SCFGR) RAM Secure Mask */
+#define IDAU_SCFGR_RS(value)                (IDAU_SCFGR_RS_Msk & ((value) << IDAU_SCFGR_RS_Pos))
+#define IDAU_SCFGR_MASK                     _U_(0x7F)                                      /**< \deprecated (IDAU_SCFGR) Register MASK  (Use IDAU_SCFGR_Msk instead)  */
+#define IDAU_SCFGR_Msk                      _U_(0x7F)                                      /**< (IDAU_SCFGR) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief IDAU hardware registers */
+typedef struct {  /* Implementation Defined Attribution Unit */
+  __I  uint8_t                        Reserved1[1];
+  __IO IDAU_SECCTRL_Type              SECCTRL;        /**< Offset: 0x01 (R/W   8) SECCTRL */
+  __I  uint8_t                        Reserved2[2];
+  __IO IDAU_SCFGB_Type                SCFGB;          /**< Offset: 0x04 (R/W  32) SCFGB */
+  __IO IDAU_SCFGA_Type                SCFGA;          /**< Offset: 0x08 (R/W  32) SCFGA */
+  __IO IDAU_SCFGR_Type                SCFGR;          /**< Offset: 0x0C (R/W   8) SCFGR */
+} Idau;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Implementation Defined Attribution Unit */
+
+#endif /* _SAML11_IDAU_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/component/mclk.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/mclk.h
@@ -1,0 +1,416 @@
+/**
+ * \file
+ *
+ * \brief Component description for MCLK
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_MCLK_COMPONENT_H_
+#define _SAML11_MCLK_COMPONENT_H_
+#define _SAML11_MCLK_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML11 Main Clock
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR MCLK */
+/* ========================================================================== */
+
+#define MCLK_U2234                      /**< (MCLK) Module ID */
+#define REV_MCLK 0x300                  /**< (MCLK) Module revision */
+
+/* -------- MCLK_CTRLA : (MCLK Offset: 0x00) (R/W 8) Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  :2;                        /**< bit:   0..1  Reserved */
+    uint8_t  CKSEL:1;                   /**< bit:      2  Clock Select                             */
+    uint8_t  :5;                        /**< bit:   3..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} MCLK_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCLK_CTRLA_OFFSET                   (0x00)                                        /**<  (MCLK_CTRLA) Control  Offset */
+#define MCLK_CTRLA_RESETVALUE               _U_(0x00)                                     /**<  (MCLK_CTRLA) Control  Reset Value */
+
+#define MCLK_CTRLA_CKSEL_Pos                2                                              /**< (MCLK_CTRLA) Clock Select Position */
+#define MCLK_CTRLA_CKSEL_Msk                (_U_(0x1) << MCLK_CTRLA_CKSEL_Pos)             /**< (MCLK_CTRLA) Clock Select Mask */
+#define MCLK_CTRLA_CKSEL                    MCLK_CTRLA_CKSEL_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_CTRLA_CKSEL_Msk instead */
+#define MCLK_CTRLA_MASK                     _U_(0x04)                                      /**< \deprecated (MCLK_CTRLA) Register MASK  (Use MCLK_CTRLA_Msk instead)  */
+#define MCLK_CTRLA_Msk                      _U_(0x04)                                      /**< (MCLK_CTRLA) Register Mask  */
+
+
+/* -------- MCLK_INTENCLR : (MCLK Offset: 0x01) (R/W 8) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  CKRDY:1;                   /**< bit:      0  Clock Ready Interrupt Enable             */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} MCLK_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCLK_INTENCLR_OFFSET                (0x01)                                        /**<  (MCLK_INTENCLR) Interrupt Enable Clear  Offset */
+#define MCLK_INTENCLR_RESETVALUE            _U_(0x00)                                     /**<  (MCLK_INTENCLR) Interrupt Enable Clear  Reset Value */
+
+#define MCLK_INTENCLR_CKRDY_Pos             0                                              /**< (MCLK_INTENCLR) Clock Ready Interrupt Enable Position */
+#define MCLK_INTENCLR_CKRDY_Msk             (_U_(0x1) << MCLK_INTENCLR_CKRDY_Pos)          /**< (MCLK_INTENCLR) Clock Ready Interrupt Enable Mask */
+#define MCLK_INTENCLR_CKRDY                 MCLK_INTENCLR_CKRDY_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_INTENCLR_CKRDY_Msk instead */
+#define MCLK_INTENCLR_MASK                  _U_(0x01)                                      /**< \deprecated (MCLK_INTENCLR) Register MASK  (Use MCLK_INTENCLR_Msk instead)  */
+#define MCLK_INTENCLR_Msk                   _U_(0x01)                                      /**< (MCLK_INTENCLR) Register Mask  */
+
+
+/* -------- MCLK_INTENSET : (MCLK Offset: 0x02) (R/W 8) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  CKRDY:1;                   /**< bit:      0  Clock Ready Interrupt Enable             */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} MCLK_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCLK_INTENSET_OFFSET                (0x02)                                        /**<  (MCLK_INTENSET) Interrupt Enable Set  Offset */
+#define MCLK_INTENSET_RESETVALUE            _U_(0x00)                                     /**<  (MCLK_INTENSET) Interrupt Enable Set  Reset Value */
+
+#define MCLK_INTENSET_CKRDY_Pos             0                                              /**< (MCLK_INTENSET) Clock Ready Interrupt Enable Position */
+#define MCLK_INTENSET_CKRDY_Msk             (_U_(0x1) << MCLK_INTENSET_CKRDY_Pos)          /**< (MCLK_INTENSET) Clock Ready Interrupt Enable Mask */
+#define MCLK_INTENSET_CKRDY                 MCLK_INTENSET_CKRDY_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_INTENSET_CKRDY_Msk instead */
+#define MCLK_INTENSET_MASK                  _U_(0x01)                                      /**< \deprecated (MCLK_INTENSET) Register MASK  (Use MCLK_INTENSET_Msk instead)  */
+#define MCLK_INTENSET_Msk                   _U_(0x01)                                      /**< (MCLK_INTENSET) Register Mask  */
+
+
+/* -------- MCLK_INTFLAG : (MCLK Offset: 0x03) (R/W 8) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t CKRDY:1;                   /**< bit:      0  Clock Ready                              */
+    __I uint8_t :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} MCLK_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCLK_INTFLAG_OFFSET                 (0x03)                                        /**<  (MCLK_INTFLAG) Interrupt Flag Status and Clear  Offset */
+#define MCLK_INTFLAG_RESETVALUE             _U_(0x01)                                     /**<  (MCLK_INTFLAG) Interrupt Flag Status and Clear  Reset Value */
+
+#define MCLK_INTFLAG_CKRDY_Pos              0                                              /**< (MCLK_INTFLAG) Clock Ready Position */
+#define MCLK_INTFLAG_CKRDY_Msk              (_U_(0x1) << MCLK_INTFLAG_CKRDY_Pos)           /**< (MCLK_INTFLAG) Clock Ready Mask */
+#define MCLK_INTFLAG_CKRDY                  MCLK_INTFLAG_CKRDY_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_INTFLAG_CKRDY_Msk instead */
+#define MCLK_INTFLAG_MASK                   _U_(0x01)                                      /**< \deprecated (MCLK_INTFLAG) Register MASK  (Use MCLK_INTFLAG_Msk instead)  */
+#define MCLK_INTFLAG_Msk                    _U_(0x01)                                      /**< (MCLK_INTFLAG) Register Mask  */
+
+
+/* -------- MCLK_CPUDIV : (MCLK Offset: 0x04) (R/W 8) CPU Clock Division -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  CPUDIV:8;                  /**< bit:   0..7  CPU Clock Division Factor                */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} MCLK_CPUDIV_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCLK_CPUDIV_OFFSET                  (0x04)                                        /**<  (MCLK_CPUDIV) CPU Clock Division  Offset */
+#define MCLK_CPUDIV_RESETVALUE              _U_(0x01)                                     /**<  (MCLK_CPUDIV) CPU Clock Division  Reset Value */
+
+#define MCLK_CPUDIV_CPUDIV_Pos              0                                              /**< (MCLK_CPUDIV) CPU Clock Division Factor Position */
+#define MCLK_CPUDIV_CPUDIV_Msk              (_U_(0xFF) << MCLK_CPUDIV_CPUDIV_Pos)          /**< (MCLK_CPUDIV) CPU Clock Division Factor Mask */
+#define MCLK_CPUDIV_CPUDIV(value)           (MCLK_CPUDIV_CPUDIV_Msk & ((value) << MCLK_CPUDIV_CPUDIV_Pos))
+#define   MCLK_CPUDIV_CPUDIV_DIV1_Val       _U_(0x1)                                       /**< (MCLK_CPUDIV) Divide by 1  */
+#define   MCLK_CPUDIV_CPUDIV_DIV2_Val       _U_(0x2)                                       /**< (MCLK_CPUDIV) Divide by 2  */
+#define   MCLK_CPUDIV_CPUDIV_DIV4_Val       _U_(0x4)                                       /**< (MCLK_CPUDIV) Divide by 4  */
+#define   MCLK_CPUDIV_CPUDIV_DIV8_Val       _U_(0x8)                                       /**< (MCLK_CPUDIV) Divide by 8  */
+#define   MCLK_CPUDIV_CPUDIV_DIV16_Val      _U_(0x10)                                      /**< (MCLK_CPUDIV) Divide by 16  */
+#define   MCLK_CPUDIV_CPUDIV_DIV32_Val      _U_(0x20)                                      /**< (MCLK_CPUDIV) Divide by 32  */
+#define   MCLK_CPUDIV_CPUDIV_DIV64_Val      _U_(0x40)                                      /**< (MCLK_CPUDIV) Divide by 64  */
+#define   MCLK_CPUDIV_CPUDIV_DIV128_Val     _U_(0x80)                                      /**< (MCLK_CPUDIV) Divide by 128  */
+#define MCLK_CPUDIV_CPUDIV_DIV1             (MCLK_CPUDIV_CPUDIV_DIV1_Val << MCLK_CPUDIV_CPUDIV_Pos)  /**< (MCLK_CPUDIV) Divide by 1 Position  */
+#define MCLK_CPUDIV_CPUDIV_DIV2             (MCLK_CPUDIV_CPUDIV_DIV2_Val << MCLK_CPUDIV_CPUDIV_Pos)  /**< (MCLK_CPUDIV) Divide by 2 Position  */
+#define MCLK_CPUDIV_CPUDIV_DIV4             (MCLK_CPUDIV_CPUDIV_DIV4_Val << MCLK_CPUDIV_CPUDIV_Pos)  /**< (MCLK_CPUDIV) Divide by 4 Position  */
+#define MCLK_CPUDIV_CPUDIV_DIV8             (MCLK_CPUDIV_CPUDIV_DIV8_Val << MCLK_CPUDIV_CPUDIV_Pos)  /**< (MCLK_CPUDIV) Divide by 8 Position  */
+#define MCLK_CPUDIV_CPUDIV_DIV16            (MCLK_CPUDIV_CPUDIV_DIV16_Val << MCLK_CPUDIV_CPUDIV_Pos)  /**< (MCLK_CPUDIV) Divide by 16 Position  */
+#define MCLK_CPUDIV_CPUDIV_DIV32            (MCLK_CPUDIV_CPUDIV_DIV32_Val << MCLK_CPUDIV_CPUDIV_Pos)  /**< (MCLK_CPUDIV) Divide by 32 Position  */
+#define MCLK_CPUDIV_CPUDIV_DIV64            (MCLK_CPUDIV_CPUDIV_DIV64_Val << MCLK_CPUDIV_CPUDIV_Pos)  /**< (MCLK_CPUDIV) Divide by 64 Position  */
+#define MCLK_CPUDIV_CPUDIV_DIV128           (MCLK_CPUDIV_CPUDIV_DIV128_Val << MCLK_CPUDIV_CPUDIV_Pos)  /**< (MCLK_CPUDIV) Divide by 128 Position  */
+#define MCLK_CPUDIV_MASK                    _U_(0xFF)                                      /**< \deprecated (MCLK_CPUDIV) Register MASK  (Use MCLK_CPUDIV_Msk instead)  */
+#define MCLK_CPUDIV_Msk                     _U_(0xFF)                                      /**< (MCLK_CPUDIV) Register Mask  */
+
+
+/* -------- MCLK_AHBMASK : (MCLK Offset: 0x10) (R/W 32) AHB Mask -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t HPB0_:1;                   /**< bit:      0  HPB0 AHB Clock Mask                      */
+    uint32_t HPB1_:1;                   /**< bit:      1  HPB1 AHB Clock Mask                      */
+    uint32_t HPB2_:1;                   /**< bit:      2  HPB2 AHB Clock Mask                      */
+    uint32_t DMAC_:1;                   /**< bit:      3  DMAC AHB Clock Mask                      */
+    uint32_t DSU_:1;                    /**< bit:      4  DSU AHB Clock Mask                       */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t PAC_:1;                    /**< bit:      6  PAC AHB Clock Mask                       */
+    uint32_t NVMCTRL_:1;                /**< bit:      7  NVMCTRL AHB Clock Mask                   */
+    uint32_t :4;                        /**< bit:  8..11  Reserved */
+    uint32_t TRAM_:1;                   /**< bit:     12  TRAM AHB Clock Mask                      */
+    uint32_t :19;                       /**< bit: 13..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCLK_AHBMASK_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCLK_AHBMASK_OFFSET                 (0x10)                                        /**<  (MCLK_AHBMASK) AHB Mask  Offset */
+#define MCLK_AHBMASK_RESETVALUE             _U_(0x1FFF)                                   /**<  (MCLK_AHBMASK) AHB Mask  Reset Value */
+
+#define MCLK_AHBMASK_HPB0_Pos               0                                              /**< (MCLK_AHBMASK) HPB0 AHB Clock Mask Position */
+#define MCLK_AHBMASK_HPB0_Msk               (_U_(0x1) << MCLK_AHBMASK_HPB0_Pos)            /**< (MCLK_AHBMASK) HPB0 AHB Clock Mask Mask */
+#define MCLK_AHBMASK_HPB0                   MCLK_AHBMASK_HPB0_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_AHBMASK_HPB0_Msk instead */
+#define MCLK_AHBMASK_HPB1_Pos               1                                              /**< (MCLK_AHBMASK) HPB1 AHB Clock Mask Position */
+#define MCLK_AHBMASK_HPB1_Msk               (_U_(0x1) << MCLK_AHBMASK_HPB1_Pos)            /**< (MCLK_AHBMASK) HPB1 AHB Clock Mask Mask */
+#define MCLK_AHBMASK_HPB1                   MCLK_AHBMASK_HPB1_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_AHBMASK_HPB1_Msk instead */
+#define MCLK_AHBMASK_HPB2_Pos               2                                              /**< (MCLK_AHBMASK) HPB2 AHB Clock Mask Position */
+#define MCLK_AHBMASK_HPB2_Msk               (_U_(0x1) << MCLK_AHBMASK_HPB2_Pos)            /**< (MCLK_AHBMASK) HPB2 AHB Clock Mask Mask */
+#define MCLK_AHBMASK_HPB2                   MCLK_AHBMASK_HPB2_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_AHBMASK_HPB2_Msk instead */
+#define MCLK_AHBMASK_DMAC_Pos               3                                              /**< (MCLK_AHBMASK) DMAC AHB Clock Mask Position */
+#define MCLK_AHBMASK_DMAC_Msk               (_U_(0x1) << MCLK_AHBMASK_DMAC_Pos)            /**< (MCLK_AHBMASK) DMAC AHB Clock Mask Mask */
+#define MCLK_AHBMASK_DMAC                   MCLK_AHBMASK_DMAC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_AHBMASK_DMAC_Msk instead */
+#define MCLK_AHBMASK_DSU_Pos                4                                              /**< (MCLK_AHBMASK) DSU AHB Clock Mask Position */
+#define MCLK_AHBMASK_DSU_Msk                (_U_(0x1) << MCLK_AHBMASK_DSU_Pos)             /**< (MCLK_AHBMASK) DSU AHB Clock Mask Mask */
+#define MCLK_AHBMASK_DSU                    MCLK_AHBMASK_DSU_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_AHBMASK_DSU_Msk instead */
+#define MCLK_AHBMASK_PAC_Pos                6                                              /**< (MCLK_AHBMASK) PAC AHB Clock Mask Position */
+#define MCLK_AHBMASK_PAC_Msk                (_U_(0x1) << MCLK_AHBMASK_PAC_Pos)             /**< (MCLK_AHBMASK) PAC AHB Clock Mask Mask */
+#define MCLK_AHBMASK_PAC                    MCLK_AHBMASK_PAC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_AHBMASK_PAC_Msk instead */
+#define MCLK_AHBMASK_NVMCTRL_Pos            7                                              /**< (MCLK_AHBMASK) NVMCTRL AHB Clock Mask Position */
+#define MCLK_AHBMASK_NVMCTRL_Msk            (_U_(0x1) << MCLK_AHBMASK_NVMCTRL_Pos)         /**< (MCLK_AHBMASK) NVMCTRL AHB Clock Mask Mask */
+#define MCLK_AHBMASK_NVMCTRL                MCLK_AHBMASK_NVMCTRL_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_AHBMASK_NVMCTRL_Msk instead */
+#define MCLK_AHBMASK_TRAM_Pos               12                                             /**< (MCLK_AHBMASK) TRAM AHB Clock Mask Position */
+#define MCLK_AHBMASK_TRAM_Msk               (_U_(0x1) << MCLK_AHBMASK_TRAM_Pos)            /**< (MCLK_AHBMASK) TRAM AHB Clock Mask Mask */
+#define MCLK_AHBMASK_TRAM                   MCLK_AHBMASK_TRAM_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_AHBMASK_TRAM_Msk instead */
+#define MCLK_AHBMASK_MASK                   _U_(0x10DF)                                    /**< \deprecated (MCLK_AHBMASK) Register MASK  (Use MCLK_AHBMASK_Msk instead)  */
+#define MCLK_AHBMASK_Msk                    _U_(0x10DF)                                    /**< (MCLK_AHBMASK) Register Mask  */
+
+#define MCLK_AHBMASK_HPB_Pos                0                                              /**< (MCLK_AHBMASK Position) HPBx AHB Clock Mask */
+#define MCLK_AHBMASK_HPB_Msk                (_U_(0x7) << MCLK_AHBMASK_HPB_Pos)             /**< (MCLK_AHBMASK Mask) HPB */
+#define MCLK_AHBMASK_HPB(value)             (MCLK_AHBMASK_HPB_Msk & ((value) << MCLK_AHBMASK_HPB_Pos))  
+
+/* -------- MCLK_APBAMASK : (MCLK Offset: 0x14) (R/W 32) APBA Mask -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t PAC_:1;                    /**< bit:      0  PAC APB Clock Enable                     */
+    uint32_t PM_:1;                     /**< bit:      1  PM APB Clock Enable                      */
+    uint32_t MCLK_:1;                   /**< bit:      2  MCLK APB Clock Enable                    */
+    uint32_t RSTC_:1;                   /**< bit:      3  RSTC APB Clock Enable                    */
+    uint32_t OSCCTRL_:1;                /**< bit:      4  OSCCTRL APB Clock Enable                 */
+    uint32_t OSC32KCTRL_:1;             /**< bit:      5  OSC32KCTRL APB Clock Enable              */
+    uint32_t SUPC_:1;                   /**< bit:      6  SUPC APB Clock Enable                    */
+    uint32_t GCLK_:1;                   /**< bit:      7  GCLK APB Clock Enable                    */
+    uint32_t WDT_:1;                    /**< bit:      8  WDT APB Clock Enable                     */
+    uint32_t RTC_:1;                    /**< bit:      9  RTC APB Clock Enable                     */
+    uint32_t EIC_:1;                    /**< bit:     10  EIC APB Clock Enable                     */
+    uint32_t FREQM_:1;                  /**< bit:     11  FREQM APB Clock Enable                   */
+    uint32_t PORT_:1;                   /**< bit:     12  PORT APB Clock Enable                    */
+    uint32_t AC_:1;                     /**< bit:     13  AC APB Clock Enable                      */
+    uint32_t :18;                       /**< bit: 14..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCLK_APBAMASK_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCLK_APBAMASK_OFFSET                (0x14)                                        /**<  (MCLK_APBAMASK) APBA Mask  Offset */
+#define MCLK_APBAMASK_RESETVALUE            _U_(0x7FFF)                                   /**<  (MCLK_APBAMASK) APBA Mask  Reset Value */
+
+#define MCLK_APBAMASK_PAC_Pos               0                                              /**< (MCLK_APBAMASK) PAC APB Clock Enable Position */
+#define MCLK_APBAMASK_PAC_Msk               (_U_(0x1) << MCLK_APBAMASK_PAC_Pos)            /**< (MCLK_APBAMASK) PAC APB Clock Enable Mask */
+#define MCLK_APBAMASK_PAC                   MCLK_APBAMASK_PAC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBAMASK_PAC_Msk instead */
+#define MCLK_APBAMASK_PM_Pos                1                                              /**< (MCLK_APBAMASK) PM APB Clock Enable Position */
+#define MCLK_APBAMASK_PM_Msk                (_U_(0x1) << MCLK_APBAMASK_PM_Pos)             /**< (MCLK_APBAMASK) PM APB Clock Enable Mask */
+#define MCLK_APBAMASK_PM                    MCLK_APBAMASK_PM_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBAMASK_PM_Msk instead */
+#define MCLK_APBAMASK_MCLK_Pos              2                                              /**< (MCLK_APBAMASK) MCLK APB Clock Enable Position */
+#define MCLK_APBAMASK_MCLK_Msk              (_U_(0x1) << MCLK_APBAMASK_MCLK_Pos)           /**< (MCLK_APBAMASK) MCLK APB Clock Enable Mask */
+#define MCLK_APBAMASK_MCLK                  MCLK_APBAMASK_MCLK_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBAMASK_MCLK_Msk instead */
+#define MCLK_APBAMASK_RSTC_Pos              3                                              /**< (MCLK_APBAMASK) RSTC APB Clock Enable Position */
+#define MCLK_APBAMASK_RSTC_Msk              (_U_(0x1) << MCLK_APBAMASK_RSTC_Pos)           /**< (MCLK_APBAMASK) RSTC APB Clock Enable Mask */
+#define MCLK_APBAMASK_RSTC                  MCLK_APBAMASK_RSTC_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBAMASK_RSTC_Msk instead */
+#define MCLK_APBAMASK_OSCCTRL_Pos           4                                              /**< (MCLK_APBAMASK) OSCCTRL APB Clock Enable Position */
+#define MCLK_APBAMASK_OSCCTRL_Msk           (_U_(0x1) << MCLK_APBAMASK_OSCCTRL_Pos)        /**< (MCLK_APBAMASK) OSCCTRL APB Clock Enable Mask */
+#define MCLK_APBAMASK_OSCCTRL               MCLK_APBAMASK_OSCCTRL_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBAMASK_OSCCTRL_Msk instead */
+#define MCLK_APBAMASK_OSC32KCTRL_Pos        5                                              /**< (MCLK_APBAMASK) OSC32KCTRL APB Clock Enable Position */
+#define MCLK_APBAMASK_OSC32KCTRL_Msk        (_U_(0x1) << MCLK_APBAMASK_OSC32KCTRL_Pos)     /**< (MCLK_APBAMASK) OSC32KCTRL APB Clock Enable Mask */
+#define MCLK_APBAMASK_OSC32KCTRL            MCLK_APBAMASK_OSC32KCTRL_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBAMASK_OSC32KCTRL_Msk instead */
+#define MCLK_APBAMASK_SUPC_Pos              6                                              /**< (MCLK_APBAMASK) SUPC APB Clock Enable Position */
+#define MCLK_APBAMASK_SUPC_Msk              (_U_(0x1) << MCLK_APBAMASK_SUPC_Pos)           /**< (MCLK_APBAMASK) SUPC APB Clock Enable Mask */
+#define MCLK_APBAMASK_SUPC                  MCLK_APBAMASK_SUPC_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBAMASK_SUPC_Msk instead */
+#define MCLK_APBAMASK_GCLK_Pos              7                                              /**< (MCLK_APBAMASK) GCLK APB Clock Enable Position */
+#define MCLK_APBAMASK_GCLK_Msk              (_U_(0x1) << MCLK_APBAMASK_GCLK_Pos)           /**< (MCLK_APBAMASK) GCLK APB Clock Enable Mask */
+#define MCLK_APBAMASK_GCLK                  MCLK_APBAMASK_GCLK_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBAMASK_GCLK_Msk instead */
+#define MCLK_APBAMASK_WDT_Pos               8                                              /**< (MCLK_APBAMASK) WDT APB Clock Enable Position */
+#define MCLK_APBAMASK_WDT_Msk               (_U_(0x1) << MCLK_APBAMASK_WDT_Pos)            /**< (MCLK_APBAMASK) WDT APB Clock Enable Mask */
+#define MCLK_APBAMASK_WDT                   MCLK_APBAMASK_WDT_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBAMASK_WDT_Msk instead */
+#define MCLK_APBAMASK_RTC_Pos               9                                              /**< (MCLK_APBAMASK) RTC APB Clock Enable Position */
+#define MCLK_APBAMASK_RTC_Msk               (_U_(0x1) << MCLK_APBAMASK_RTC_Pos)            /**< (MCLK_APBAMASK) RTC APB Clock Enable Mask */
+#define MCLK_APBAMASK_RTC                   MCLK_APBAMASK_RTC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBAMASK_RTC_Msk instead */
+#define MCLK_APBAMASK_EIC_Pos               10                                             /**< (MCLK_APBAMASK) EIC APB Clock Enable Position */
+#define MCLK_APBAMASK_EIC_Msk               (_U_(0x1) << MCLK_APBAMASK_EIC_Pos)            /**< (MCLK_APBAMASK) EIC APB Clock Enable Mask */
+#define MCLK_APBAMASK_EIC                   MCLK_APBAMASK_EIC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBAMASK_EIC_Msk instead */
+#define MCLK_APBAMASK_FREQM_Pos             11                                             /**< (MCLK_APBAMASK) FREQM APB Clock Enable Position */
+#define MCLK_APBAMASK_FREQM_Msk             (_U_(0x1) << MCLK_APBAMASK_FREQM_Pos)          /**< (MCLK_APBAMASK) FREQM APB Clock Enable Mask */
+#define MCLK_APBAMASK_FREQM                 MCLK_APBAMASK_FREQM_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBAMASK_FREQM_Msk instead */
+#define MCLK_APBAMASK_PORT_Pos              12                                             /**< (MCLK_APBAMASK) PORT APB Clock Enable Position */
+#define MCLK_APBAMASK_PORT_Msk              (_U_(0x1) << MCLK_APBAMASK_PORT_Pos)           /**< (MCLK_APBAMASK) PORT APB Clock Enable Mask */
+#define MCLK_APBAMASK_PORT                  MCLK_APBAMASK_PORT_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBAMASK_PORT_Msk instead */
+#define MCLK_APBAMASK_AC_Pos                13                                             /**< (MCLK_APBAMASK) AC APB Clock Enable Position */
+#define MCLK_APBAMASK_AC_Msk                (_U_(0x1) << MCLK_APBAMASK_AC_Pos)             /**< (MCLK_APBAMASK) AC APB Clock Enable Mask */
+#define MCLK_APBAMASK_AC                    MCLK_APBAMASK_AC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBAMASK_AC_Msk instead */
+#define MCLK_APBAMASK_MASK                  _U_(0x3FFF)                                    /**< \deprecated (MCLK_APBAMASK) Register MASK  (Use MCLK_APBAMASK_Msk instead)  */
+#define MCLK_APBAMASK_Msk                   _U_(0x3FFF)                                    /**< (MCLK_APBAMASK) Register Mask  */
+
+
+/* -------- MCLK_APBBMASK : (MCLK Offset: 0x18) (R/W 32) APBB Mask -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t IDAU_:1;                   /**< bit:      0  IDAU APB Clock Enable                    */
+    uint32_t DSU_:1;                    /**< bit:      1  DSU APB Clock Enable                     */
+    uint32_t NVMCTRL_:1;                /**< bit:      2  NVMCTRL APB Clock Enable                 */
+    uint32_t :29;                       /**< bit:  3..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCLK_APBBMASK_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCLK_APBBMASK_OFFSET                (0x18)                                        /**<  (MCLK_APBBMASK) APBB Mask  Offset */
+#define MCLK_APBBMASK_RESETVALUE            _U_(0x17)                                     /**<  (MCLK_APBBMASK) APBB Mask  Reset Value */
+
+#define MCLK_APBBMASK_IDAU_Pos              0                                              /**< (MCLK_APBBMASK) IDAU APB Clock Enable Position */
+#define MCLK_APBBMASK_IDAU_Msk              (_U_(0x1) << MCLK_APBBMASK_IDAU_Pos)           /**< (MCLK_APBBMASK) IDAU APB Clock Enable Mask */
+#define MCLK_APBBMASK_IDAU                  MCLK_APBBMASK_IDAU_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBBMASK_IDAU_Msk instead */
+#define MCLK_APBBMASK_DSU_Pos               1                                              /**< (MCLK_APBBMASK) DSU APB Clock Enable Position */
+#define MCLK_APBBMASK_DSU_Msk               (_U_(0x1) << MCLK_APBBMASK_DSU_Pos)            /**< (MCLK_APBBMASK) DSU APB Clock Enable Mask */
+#define MCLK_APBBMASK_DSU                   MCLK_APBBMASK_DSU_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBBMASK_DSU_Msk instead */
+#define MCLK_APBBMASK_NVMCTRL_Pos           2                                              /**< (MCLK_APBBMASK) NVMCTRL APB Clock Enable Position */
+#define MCLK_APBBMASK_NVMCTRL_Msk           (_U_(0x1) << MCLK_APBBMASK_NVMCTRL_Pos)        /**< (MCLK_APBBMASK) NVMCTRL APB Clock Enable Mask */
+#define MCLK_APBBMASK_NVMCTRL               MCLK_APBBMASK_NVMCTRL_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBBMASK_NVMCTRL_Msk instead */
+#define MCLK_APBBMASK_MASK                  _U_(0x07)                                      /**< \deprecated (MCLK_APBBMASK) Register MASK  (Use MCLK_APBBMASK_Msk instead)  */
+#define MCLK_APBBMASK_Msk                   _U_(0x07)                                      /**< (MCLK_APBBMASK) Register Mask  */
+
+
+/* -------- MCLK_APBCMASK : (MCLK Offset: 0x1c) (R/W 32) APBC Mask -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t EVSYS_:1;                  /**< bit:      0  EVSYS APB Clock Enable                   */
+    uint32_t SERCOM0_:1;                /**< bit:      1  SERCOM0 APB Clock Enable                 */
+    uint32_t SERCOM1_:1;                /**< bit:      2  SERCOM1 APB Clock Enable                 */
+    uint32_t SERCOM2_:1;                /**< bit:      3  SERCOM2 APB Clock Enable                 */
+    uint32_t TC0_:1;                    /**< bit:      4  TC0 APB Clock Enable                     */
+    uint32_t TC1_:1;                    /**< bit:      5  TC1 APB Clock Enable                     */
+    uint32_t TC2_:1;                    /**< bit:      6  TC2 APB Clock Enable                     */
+    uint32_t ADC_:1;                    /**< bit:      7  ADC APB Clock Enable                     */
+    uint32_t DAC_:1;                    /**< bit:      8  DAC APB Clock Enable                     */
+    uint32_t PTC_:1;                    /**< bit:      9  PTC APB Clock Enable                     */
+    uint32_t TRNG_:1;                   /**< bit:     10  TRNG APB Clock Enable                    */
+    uint32_t CCL_:1;                    /**< bit:     11  CCL APB Clock Enable                     */
+    uint32_t OPAMP_:1;                  /**< bit:     12  OPAMP APB Clock Enable                   */
+    uint32_t :19;                       /**< bit: 13..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCLK_APBCMASK_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCLK_APBCMASK_OFFSET                (0x1C)                                        /**<  (MCLK_APBCMASK) APBC Mask  Offset */
+#define MCLK_APBCMASK_RESETVALUE            _U_(0x1FFF)                                   /**<  (MCLK_APBCMASK) APBC Mask  Reset Value */
+
+#define MCLK_APBCMASK_EVSYS_Pos             0                                              /**< (MCLK_APBCMASK) EVSYS APB Clock Enable Position */
+#define MCLK_APBCMASK_EVSYS_Msk             (_U_(0x1) << MCLK_APBCMASK_EVSYS_Pos)          /**< (MCLK_APBCMASK) EVSYS APB Clock Enable Mask */
+#define MCLK_APBCMASK_EVSYS                 MCLK_APBCMASK_EVSYS_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBCMASK_EVSYS_Msk instead */
+#define MCLK_APBCMASK_SERCOM0_Pos           1                                              /**< (MCLK_APBCMASK) SERCOM0 APB Clock Enable Position */
+#define MCLK_APBCMASK_SERCOM0_Msk           (_U_(0x1) << MCLK_APBCMASK_SERCOM0_Pos)        /**< (MCLK_APBCMASK) SERCOM0 APB Clock Enable Mask */
+#define MCLK_APBCMASK_SERCOM0               MCLK_APBCMASK_SERCOM0_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBCMASK_SERCOM0_Msk instead */
+#define MCLK_APBCMASK_SERCOM1_Pos           2                                              /**< (MCLK_APBCMASK) SERCOM1 APB Clock Enable Position */
+#define MCLK_APBCMASK_SERCOM1_Msk           (_U_(0x1) << MCLK_APBCMASK_SERCOM1_Pos)        /**< (MCLK_APBCMASK) SERCOM1 APB Clock Enable Mask */
+#define MCLK_APBCMASK_SERCOM1               MCLK_APBCMASK_SERCOM1_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBCMASK_SERCOM1_Msk instead */
+#define MCLK_APBCMASK_SERCOM2_Pos           3                                              /**< (MCLK_APBCMASK) SERCOM2 APB Clock Enable Position */
+#define MCLK_APBCMASK_SERCOM2_Msk           (_U_(0x1) << MCLK_APBCMASK_SERCOM2_Pos)        /**< (MCLK_APBCMASK) SERCOM2 APB Clock Enable Mask */
+#define MCLK_APBCMASK_SERCOM2               MCLK_APBCMASK_SERCOM2_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBCMASK_SERCOM2_Msk instead */
+#define MCLK_APBCMASK_TC0_Pos               4                                              /**< (MCLK_APBCMASK) TC0 APB Clock Enable Position */
+#define MCLK_APBCMASK_TC0_Msk               (_U_(0x1) << MCLK_APBCMASK_TC0_Pos)            /**< (MCLK_APBCMASK) TC0 APB Clock Enable Mask */
+#define MCLK_APBCMASK_TC0                   MCLK_APBCMASK_TC0_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBCMASK_TC0_Msk instead */
+#define MCLK_APBCMASK_TC1_Pos               5                                              /**< (MCLK_APBCMASK) TC1 APB Clock Enable Position */
+#define MCLK_APBCMASK_TC1_Msk               (_U_(0x1) << MCLK_APBCMASK_TC1_Pos)            /**< (MCLK_APBCMASK) TC1 APB Clock Enable Mask */
+#define MCLK_APBCMASK_TC1                   MCLK_APBCMASK_TC1_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBCMASK_TC1_Msk instead */
+#define MCLK_APBCMASK_TC2_Pos               6                                              /**< (MCLK_APBCMASK) TC2 APB Clock Enable Position */
+#define MCLK_APBCMASK_TC2_Msk               (_U_(0x1) << MCLK_APBCMASK_TC2_Pos)            /**< (MCLK_APBCMASK) TC2 APB Clock Enable Mask */
+#define MCLK_APBCMASK_TC2                   MCLK_APBCMASK_TC2_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBCMASK_TC2_Msk instead */
+#define MCLK_APBCMASK_ADC_Pos               7                                              /**< (MCLK_APBCMASK) ADC APB Clock Enable Position */
+#define MCLK_APBCMASK_ADC_Msk               (_U_(0x1) << MCLK_APBCMASK_ADC_Pos)            /**< (MCLK_APBCMASK) ADC APB Clock Enable Mask */
+#define MCLK_APBCMASK_ADC                   MCLK_APBCMASK_ADC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBCMASK_ADC_Msk instead */
+#define MCLK_APBCMASK_DAC_Pos               8                                              /**< (MCLK_APBCMASK) DAC APB Clock Enable Position */
+#define MCLK_APBCMASK_DAC_Msk               (_U_(0x1) << MCLK_APBCMASK_DAC_Pos)            /**< (MCLK_APBCMASK) DAC APB Clock Enable Mask */
+#define MCLK_APBCMASK_DAC                   MCLK_APBCMASK_DAC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBCMASK_DAC_Msk instead */
+#define MCLK_APBCMASK_PTC_Pos               9                                              /**< (MCLK_APBCMASK) PTC APB Clock Enable Position */
+#define MCLK_APBCMASK_PTC_Msk               (_U_(0x1) << MCLK_APBCMASK_PTC_Pos)            /**< (MCLK_APBCMASK) PTC APB Clock Enable Mask */
+#define MCLK_APBCMASK_PTC                   MCLK_APBCMASK_PTC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBCMASK_PTC_Msk instead */
+#define MCLK_APBCMASK_TRNG_Pos              10                                             /**< (MCLK_APBCMASK) TRNG APB Clock Enable Position */
+#define MCLK_APBCMASK_TRNG_Msk              (_U_(0x1) << MCLK_APBCMASK_TRNG_Pos)           /**< (MCLK_APBCMASK) TRNG APB Clock Enable Mask */
+#define MCLK_APBCMASK_TRNG                  MCLK_APBCMASK_TRNG_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBCMASK_TRNG_Msk instead */
+#define MCLK_APBCMASK_CCL_Pos               11                                             /**< (MCLK_APBCMASK) CCL APB Clock Enable Position */
+#define MCLK_APBCMASK_CCL_Msk               (_U_(0x1) << MCLK_APBCMASK_CCL_Pos)            /**< (MCLK_APBCMASK) CCL APB Clock Enable Mask */
+#define MCLK_APBCMASK_CCL                   MCLK_APBCMASK_CCL_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBCMASK_CCL_Msk instead */
+#define MCLK_APBCMASK_OPAMP_Pos             12                                             /**< (MCLK_APBCMASK) OPAMP APB Clock Enable Position */
+#define MCLK_APBCMASK_OPAMP_Msk             (_U_(0x1) << MCLK_APBCMASK_OPAMP_Pos)          /**< (MCLK_APBCMASK) OPAMP APB Clock Enable Mask */
+#define MCLK_APBCMASK_OPAMP                 MCLK_APBCMASK_OPAMP_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCLK_APBCMASK_OPAMP_Msk instead */
+#define MCLK_APBCMASK_MASK                  _U_(0x1FFF)                                    /**< \deprecated (MCLK_APBCMASK) Register MASK  (Use MCLK_APBCMASK_Msk instead)  */
+#define MCLK_APBCMASK_Msk                   _U_(0x1FFF)                                    /**< (MCLK_APBCMASK) Register Mask  */
+
+#define MCLK_APBCMASK_SERCOM_Pos            1                                              /**< (MCLK_APBCMASK Position) SERCOMx APB Clock Enable */
+#define MCLK_APBCMASK_SERCOM_Msk            (_U_(0x7) << MCLK_APBCMASK_SERCOM_Pos)         /**< (MCLK_APBCMASK Mask) SERCOM */
+#define MCLK_APBCMASK_SERCOM(value)         (MCLK_APBCMASK_SERCOM_Msk & ((value) << MCLK_APBCMASK_SERCOM_Pos))  
+#define MCLK_APBCMASK_TC_Pos                4                                              /**< (MCLK_APBCMASK Position) TCx APB Clock Enable */
+#define MCLK_APBCMASK_TC_Msk                (_U_(0x7) << MCLK_APBCMASK_TC_Pos)             /**< (MCLK_APBCMASK Mask) TC */
+#define MCLK_APBCMASK_TC(value)             (MCLK_APBCMASK_TC_Msk & ((value) << MCLK_APBCMASK_TC_Pos))  
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief MCLK hardware registers */
+typedef struct {  /* Main Clock */
+  __IO MCLK_CTRLA_Type                CTRLA;          /**< Offset: 0x00 (R/W   8) Control */
+  __IO MCLK_INTENCLR_Type             INTENCLR;       /**< Offset: 0x01 (R/W   8) Interrupt Enable Clear */
+  __IO MCLK_INTENSET_Type             INTENSET;       /**< Offset: 0x02 (R/W   8) Interrupt Enable Set */
+  __IO MCLK_INTFLAG_Type              INTFLAG;        /**< Offset: 0x03 (R/W   8) Interrupt Flag Status and Clear */
+  __IO MCLK_CPUDIV_Type               CPUDIV;         /**< Offset: 0x04 (R/W   8) CPU Clock Division */
+  __I  uint8_t                        Reserved1[11];
+  __IO MCLK_AHBMASK_Type              AHBMASK;        /**< Offset: 0x10 (R/W  32) AHB Mask */
+  __IO MCLK_APBAMASK_Type             APBAMASK;       /**< Offset: 0x14 (R/W  32) APBA Mask */
+  __IO MCLK_APBBMASK_Type             APBBMASK;       /**< Offset: 0x18 (R/W  32) APBB Mask */
+  __IO MCLK_APBCMASK_Type             APBCMASK;       /**< Offset: 0x1C (R/W  32) APBC Mask */
+} Mclk;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Main Clock */
+
+#endif /* _SAML11_MCLK_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/component/nvmctrl.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/nvmctrl.h
@@ -1,0 +1,1051 @@
+/**
+ * \file
+ *
+ * \brief Component description for NVMCTRL
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_NVMCTRL_COMPONENT_H_
+#define _SAML11_NVMCTRL_COMPONENT_H_
+#define _SAML11_NVMCTRL_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML11 Non-Volatile Memory Controller
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR NVMCTRL */
+/* ========================================================================== */
+
+#define NVMCTRL_U2802                      /**< (NVMCTRL) Module ID */
+#define REV_NVMCTRL 0x100                  /**< (NVMCTRL) Module revision */
+
+/* -------- NVMCTRL_CTRLA : (NVMCTRL Offset: 0x00) (/W 16) Control A -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t CMD:7;                     /**< bit:   0..6  Command                                  */
+    uint16_t :1;                        /**< bit:      7  Reserved */
+    uint16_t CMDEX:8;                   /**< bit:  8..15  Command Execution                        */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} NVMCTRL_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_CTRLA_OFFSET                (0x00)                                        /**<  (NVMCTRL_CTRLA) Control A  Offset */
+#define NVMCTRL_CTRLA_RESETVALUE            _U_(0x00)                                     /**<  (NVMCTRL_CTRLA) Control A  Reset Value */
+
+#define NVMCTRL_CTRLA_CMD_Pos               0                                              /**< (NVMCTRL_CTRLA) Command Position */
+#define NVMCTRL_CTRLA_CMD_Msk               (_U_(0x7F) << NVMCTRL_CTRLA_CMD_Pos)           /**< (NVMCTRL_CTRLA) Command Mask */
+#define NVMCTRL_CTRLA_CMD(value)            (NVMCTRL_CTRLA_CMD_Msk & ((value) << NVMCTRL_CTRLA_CMD_Pos))
+#define   NVMCTRL_CTRLA_CMD_ER_Val          _U_(0x2)                                       /**< (NVMCTRL_CTRLA) Erase Row - Erases the row addressed by the ADDR register.  */
+#define   NVMCTRL_CTRLA_CMD_WP_Val          _U_(0x4)                                       /**< (NVMCTRL_CTRLA) Write Page - Writes the contents of the page buffer to the page addressed by the ADDR register.  */
+#define   NVMCTRL_CTRLA_CMD_SPRM_Val        _U_(0x42)                                      /**< (NVMCTRL_CTRLA) Sets the power reduction mode.  */
+#define   NVMCTRL_CTRLA_CMD_CPRM_Val        _U_(0x43)                                      /**< (NVMCTRL_CTRLA) Clears the power reduction mode.  */
+#define   NVMCTRL_CTRLA_CMD_PBC_Val         _U_(0x44)                                      /**< (NVMCTRL_CTRLA) Page Buffer Clear - Clears the page buffer.  */
+#define   NVMCTRL_CTRLA_CMD_INVALL_Val      _U_(0x46)                                      /**< (NVMCTRL_CTRLA) Invalidate all cache lines.  */
+#define   NVMCTRL_CTRLA_CMD_SDAL0_Val       _U_(0x4B)                                      /**< (NVMCTRL_CTRLA) Set DAL=0  */
+#define   NVMCTRL_CTRLA_CMD_SDAL1_Val       _U_(0x4C)                                      /**< (NVMCTRL_CTRLA) Set DAL=1  */
+#define NVMCTRL_CTRLA_CMD_ER                (NVMCTRL_CTRLA_CMD_ER_Val << NVMCTRL_CTRLA_CMD_Pos)  /**< (NVMCTRL_CTRLA) Erase Row - Erases the row addressed by the ADDR register. Position  */
+#define NVMCTRL_CTRLA_CMD_WP                (NVMCTRL_CTRLA_CMD_WP_Val << NVMCTRL_CTRLA_CMD_Pos)  /**< (NVMCTRL_CTRLA) Write Page - Writes the contents of the page buffer to the page addressed by the ADDR register. Position  */
+#define NVMCTRL_CTRLA_CMD_SPRM              (NVMCTRL_CTRLA_CMD_SPRM_Val << NVMCTRL_CTRLA_CMD_Pos)  /**< (NVMCTRL_CTRLA) Sets the power reduction mode. Position  */
+#define NVMCTRL_CTRLA_CMD_CPRM              (NVMCTRL_CTRLA_CMD_CPRM_Val << NVMCTRL_CTRLA_CMD_Pos)  /**< (NVMCTRL_CTRLA) Clears the power reduction mode. Position  */
+#define NVMCTRL_CTRLA_CMD_PBC               (NVMCTRL_CTRLA_CMD_PBC_Val << NVMCTRL_CTRLA_CMD_Pos)  /**< (NVMCTRL_CTRLA) Page Buffer Clear - Clears the page buffer. Position  */
+#define NVMCTRL_CTRLA_CMD_INVALL            (NVMCTRL_CTRLA_CMD_INVALL_Val << NVMCTRL_CTRLA_CMD_Pos)  /**< (NVMCTRL_CTRLA) Invalidate all cache lines. Position  */
+#define NVMCTRL_CTRLA_CMD_SDAL0             (NVMCTRL_CTRLA_CMD_SDAL0_Val << NVMCTRL_CTRLA_CMD_Pos)  /**< (NVMCTRL_CTRLA) Set DAL=0 Position  */
+#define NVMCTRL_CTRLA_CMD_SDAL1             (NVMCTRL_CTRLA_CMD_SDAL1_Val << NVMCTRL_CTRLA_CMD_Pos)  /**< (NVMCTRL_CTRLA) Set DAL=1 Position  */
+#define NVMCTRL_CTRLA_CMDEX_Pos             8                                              /**< (NVMCTRL_CTRLA) Command Execution Position */
+#define NVMCTRL_CTRLA_CMDEX_Msk             (_U_(0xFF) << NVMCTRL_CTRLA_CMDEX_Pos)         /**< (NVMCTRL_CTRLA) Command Execution Mask */
+#define NVMCTRL_CTRLA_CMDEX(value)          (NVMCTRL_CTRLA_CMDEX_Msk & ((value) << NVMCTRL_CTRLA_CMDEX_Pos))
+#define   NVMCTRL_CTRLA_CMDEX_KEY_Val       _U_(0xA5)                                      /**< (NVMCTRL_CTRLA) Execution Key  */
+#define NVMCTRL_CTRLA_CMDEX_KEY             (NVMCTRL_CTRLA_CMDEX_KEY_Val << NVMCTRL_CTRLA_CMDEX_Pos)  /**< (NVMCTRL_CTRLA) Execution Key Position  */
+#define NVMCTRL_CTRLA_MASK                  _U_(0xFF7F)                                    /**< \deprecated (NVMCTRL_CTRLA) Register MASK  (Use NVMCTRL_CTRLA_Msk instead)  */
+#define NVMCTRL_CTRLA_Msk                   _U_(0xFF7F)                                    /**< (NVMCTRL_CTRLA) Register Mask  */
+
+
+/* -------- NVMCTRL_CTRLB : (NVMCTRL Offset: 0x04) (R/W 32) Control B -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t RWS:4;                     /**< bit:   1..4  NVM Read Wait States                     */
+    uint32_t :3;                        /**< bit:   5..7  Reserved */
+    uint32_t SLEEPPRM:2;                /**< bit:   8..9  Power Reduction Mode during Sleep        */
+    uint32_t :1;                        /**< bit:     10  Reserved */
+    uint32_t FWUP:1;                    /**< bit:     11  fast wake-up                             */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t READMODE:2;                /**< bit: 16..17  NVMCTRL Read Mode                        */
+    uint32_t CACHEDIS:1;                /**< bit:     18  Cache Disable                            */
+    uint32_t QWEN:1;                    /**< bit:     19  Quick Write Enable                       */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} NVMCTRL_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_CTRLB_OFFSET                (0x04)                                        /**<  (NVMCTRL_CTRLB) Control B  Offset */
+#define NVMCTRL_CTRLB_RESETVALUE            _U_(0x00)                                     /**<  (NVMCTRL_CTRLB) Control B  Reset Value */
+
+#define NVMCTRL_CTRLB_RWS_Pos               1                                              /**< (NVMCTRL_CTRLB) NVM Read Wait States Position */
+#define NVMCTRL_CTRLB_RWS_Msk               (_U_(0xF) << NVMCTRL_CTRLB_RWS_Pos)            /**< (NVMCTRL_CTRLB) NVM Read Wait States Mask */
+#define NVMCTRL_CTRLB_RWS(value)            (NVMCTRL_CTRLB_RWS_Msk & ((value) << NVMCTRL_CTRLB_RWS_Pos))
+#define NVMCTRL_CTRLB_SLEEPPRM_Pos          8                                              /**< (NVMCTRL_CTRLB) Power Reduction Mode during Sleep Position */
+#define NVMCTRL_CTRLB_SLEEPPRM_Msk          (_U_(0x3) << NVMCTRL_CTRLB_SLEEPPRM_Pos)       /**< (NVMCTRL_CTRLB) Power Reduction Mode during Sleep Mask */
+#define NVMCTRL_CTRLB_SLEEPPRM(value)       (NVMCTRL_CTRLB_SLEEPPRM_Msk & ((value) << NVMCTRL_CTRLB_SLEEPPRM_Pos))
+#define   NVMCTRL_CTRLB_SLEEPPRM_WAKEONACCESS_Val _U_(0x0)                                       /**< (NVMCTRL_CTRLB) NVM block enters low-power mode when entering sleep.NVM block exits low-power mode upon first access.  */
+#define   NVMCTRL_CTRLB_SLEEPPRM_WAKEUPINSTANT_Val _U_(0x1)                                       /**< (NVMCTRL_CTRLB) NVM block enters low-power mode when entering sleep.NVM block exits low-power mode when exiting sleep.  */
+#define   NVMCTRL_CTRLB_SLEEPPRM_DISABLED_Val _U_(0x3)                                       /**< (NVMCTRL_CTRLB) Auto power reduction disabled.  */
+#define NVMCTRL_CTRLB_SLEEPPRM_WAKEONACCESS (NVMCTRL_CTRLB_SLEEPPRM_WAKEONACCESS_Val << NVMCTRL_CTRLB_SLEEPPRM_Pos)  /**< (NVMCTRL_CTRLB) NVM block enters low-power mode when entering sleep.NVM block exits low-power mode upon first access. Position  */
+#define NVMCTRL_CTRLB_SLEEPPRM_WAKEUPINSTANT (NVMCTRL_CTRLB_SLEEPPRM_WAKEUPINSTANT_Val << NVMCTRL_CTRLB_SLEEPPRM_Pos)  /**< (NVMCTRL_CTRLB) NVM block enters low-power mode when entering sleep.NVM block exits low-power mode when exiting sleep. Position  */
+#define NVMCTRL_CTRLB_SLEEPPRM_DISABLED     (NVMCTRL_CTRLB_SLEEPPRM_DISABLED_Val << NVMCTRL_CTRLB_SLEEPPRM_Pos)  /**< (NVMCTRL_CTRLB) Auto power reduction disabled. Position  */
+#define NVMCTRL_CTRLB_FWUP_Pos              11                                             /**< (NVMCTRL_CTRLB) fast wake-up Position */
+#define NVMCTRL_CTRLB_FWUP_Msk              (_U_(0x1) << NVMCTRL_CTRLB_FWUP_Pos)           /**< (NVMCTRL_CTRLB) fast wake-up Mask */
+#define NVMCTRL_CTRLB_FWUP                  NVMCTRL_CTRLB_FWUP_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_CTRLB_FWUP_Msk instead */
+#define NVMCTRL_CTRLB_READMODE_Pos          16                                             /**< (NVMCTRL_CTRLB) NVMCTRL Read Mode Position */
+#define NVMCTRL_CTRLB_READMODE_Msk          (_U_(0x3) << NVMCTRL_CTRLB_READMODE_Pos)       /**< (NVMCTRL_CTRLB) NVMCTRL Read Mode Mask */
+#define NVMCTRL_CTRLB_READMODE(value)       (NVMCTRL_CTRLB_READMODE_Msk & ((value) << NVMCTRL_CTRLB_READMODE_Pos))
+#define   NVMCTRL_CTRLB_READMODE_NO_MISS_PENALTY_Val _U_(0x0)                                       /**< (NVMCTRL_CTRLB) The NVM Controller (cache system) does not insert wait states on a cache miss. Gives the best system performance.  */
+#define   NVMCTRL_CTRLB_READMODE_LOW_POWER_Val _U_(0x1)                                       /**< (NVMCTRL_CTRLB) Reduces power consumption of the cache system, but inserts a wait state each time there is a cache miss. This mode may not be relevant if CPU performance is required, as the application will be stalled and may lead to increase run time.  */
+#define   NVMCTRL_CTRLB_READMODE_DETERMINISTIC_Val _U_(0x2)                                       /**< (NVMCTRL_CTRLB) The cache system ensures that a cache hit or miss takes the same amount of time, determined by the number of programmed flash wait states. This mode can be used for real-time applications that require deterministic execution timings.  */
+#define NVMCTRL_CTRLB_READMODE_NO_MISS_PENALTY (NVMCTRL_CTRLB_READMODE_NO_MISS_PENALTY_Val << NVMCTRL_CTRLB_READMODE_Pos)  /**< (NVMCTRL_CTRLB) The NVM Controller (cache system) does not insert wait states on a cache miss. Gives the best system performance. Position  */
+#define NVMCTRL_CTRLB_READMODE_LOW_POWER    (NVMCTRL_CTRLB_READMODE_LOW_POWER_Val << NVMCTRL_CTRLB_READMODE_Pos)  /**< (NVMCTRL_CTRLB) Reduces power consumption of the cache system, but inserts a wait state each time there is a cache miss. This mode may not be relevant if CPU performance is required, as the application will be stalled and may lead to increase run time. Position  */
+#define NVMCTRL_CTRLB_READMODE_DETERMINISTIC (NVMCTRL_CTRLB_READMODE_DETERMINISTIC_Val << NVMCTRL_CTRLB_READMODE_Pos)  /**< (NVMCTRL_CTRLB) The cache system ensures that a cache hit or miss takes the same amount of time, determined by the number of programmed flash wait states. This mode can be used for real-time applications that require deterministic execution timings. Position  */
+#define NVMCTRL_CTRLB_CACHEDIS_Pos          18                                             /**< (NVMCTRL_CTRLB) Cache Disable Position */
+#define NVMCTRL_CTRLB_CACHEDIS_Msk          (_U_(0x1) << NVMCTRL_CTRLB_CACHEDIS_Pos)       /**< (NVMCTRL_CTRLB) Cache Disable Mask */
+#define NVMCTRL_CTRLB_CACHEDIS              NVMCTRL_CTRLB_CACHEDIS_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_CTRLB_CACHEDIS_Msk instead */
+#define NVMCTRL_CTRLB_QWEN_Pos              19                                             /**< (NVMCTRL_CTRLB) Quick Write Enable Position */
+#define NVMCTRL_CTRLB_QWEN_Msk              (_U_(0x1) << NVMCTRL_CTRLB_QWEN_Pos)           /**< (NVMCTRL_CTRLB) Quick Write Enable Mask */
+#define NVMCTRL_CTRLB_QWEN                  NVMCTRL_CTRLB_QWEN_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_CTRLB_QWEN_Msk instead */
+#define NVMCTRL_CTRLB_MASK                  _U_(0xF0B1E)                                   /**< \deprecated (NVMCTRL_CTRLB) Register MASK  (Use NVMCTRL_CTRLB_Msk instead)  */
+#define NVMCTRL_CTRLB_Msk                   _U_(0xF0B1E)                                   /**< (NVMCTRL_CTRLB) Register Mask  */
+
+
+/* -------- NVMCTRL_CTRLC : (NVMCTRL Offset: 0x08) (R/W 8) Control C -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  MANW:1;                    /**< bit:      0  Manual Write                             */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} NVMCTRL_CTRLC_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_CTRLC_OFFSET                (0x08)                                        /**<  (NVMCTRL_CTRLC) Control C  Offset */
+#define NVMCTRL_CTRLC_RESETVALUE            _U_(0x01)                                     /**<  (NVMCTRL_CTRLC) Control C  Reset Value */
+
+#define NVMCTRL_CTRLC_MANW_Pos              0                                              /**< (NVMCTRL_CTRLC) Manual Write Position */
+#define NVMCTRL_CTRLC_MANW_Msk              (_U_(0x1) << NVMCTRL_CTRLC_MANW_Pos)           /**< (NVMCTRL_CTRLC) Manual Write Mask */
+#define NVMCTRL_CTRLC_MANW                  NVMCTRL_CTRLC_MANW_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_CTRLC_MANW_Msk instead */
+#define NVMCTRL_CTRLC_MASK                  _U_(0x01)                                      /**< \deprecated (NVMCTRL_CTRLC) Register MASK  (Use NVMCTRL_CTRLC_Msk instead)  */
+#define NVMCTRL_CTRLC_Msk                   _U_(0x01)                                      /**< (NVMCTRL_CTRLC) Register Mask  */
+
+
+/* -------- NVMCTRL_EVCTRL : (NVMCTRL Offset: 0x0a) (R/W 8) Event Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  AUTOWEI:1;                 /**< bit:      0  Auto Write Event Enable                  */
+    uint8_t  AUTOWINV:1;                /**< bit:      1  Auto Write Event Polarity Inverted       */
+    uint8_t  :6;                        /**< bit:   2..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} NVMCTRL_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_EVCTRL_OFFSET               (0x0A)                                        /**<  (NVMCTRL_EVCTRL) Event Control  Offset */
+#define NVMCTRL_EVCTRL_RESETVALUE           _U_(0x00)                                     /**<  (NVMCTRL_EVCTRL) Event Control  Reset Value */
+
+#define NVMCTRL_EVCTRL_AUTOWEI_Pos          0                                              /**< (NVMCTRL_EVCTRL) Auto Write Event Enable Position */
+#define NVMCTRL_EVCTRL_AUTOWEI_Msk          (_U_(0x1) << NVMCTRL_EVCTRL_AUTOWEI_Pos)       /**< (NVMCTRL_EVCTRL) Auto Write Event Enable Mask */
+#define NVMCTRL_EVCTRL_AUTOWEI              NVMCTRL_EVCTRL_AUTOWEI_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_EVCTRL_AUTOWEI_Msk instead */
+#define NVMCTRL_EVCTRL_AUTOWINV_Pos         1                                              /**< (NVMCTRL_EVCTRL) Auto Write Event Polarity Inverted Position */
+#define NVMCTRL_EVCTRL_AUTOWINV_Msk         (_U_(0x1) << NVMCTRL_EVCTRL_AUTOWINV_Pos)      /**< (NVMCTRL_EVCTRL) Auto Write Event Polarity Inverted Mask */
+#define NVMCTRL_EVCTRL_AUTOWINV             NVMCTRL_EVCTRL_AUTOWINV_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_EVCTRL_AUTOWINV_Msk instead */
+#define NVMCTRL_EVCTRL_MASK                 _U_(0x03)                                      /**< \deprecated (NVMCTRL_EVCTRL) Register MASK  (Use NVMCTRL_EVCTRL_Msk instead)  */
+#define NVMCTRL_EVCTRL_Msk                  _U_(0x03)                                      /**< (NVMCTRL_EVCTRL) Register Mask  */
+
+
+/* -------- NVMCTRL_INTENCLR : (NVMCTRL Offset: 0x0c) (R/W 8) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DONE:1;                    /**< bit:      0  NVM Done Interrupt Clear                 */
+    uint8_t  PROGE:1;                   /**< bit:      1  Programming Error Status Interrupt Clear */
+    uint8_t  LOCKE:1;                   /**< bit:      2  Lock Error Status Interrupt Clear        */
+    uint8_t  NVME:1;                    /**< bit:      3  NVM Error Interrupt Clear                */
+    uint8_t  KEYE:1;                    /**< bit:      4  Key Write Error Interrupt Clear          */
+    uint8_t  NSCHK:1;                   /**< bit:      5  NS configuration change detected Interrupt Clear */
+    uint8_t  :2;                        /**< bit:   6..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} NVMCTRL_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_INTENCLR_OFFSET             (0x0C)                                        /**<  (NVMCTRL_INTENCLR) Interrupt Enable Clear  Offset */
+#define NVMCTRL_INTENCLR_RESETVALUE         _U_(0x00)                                     /**<  (NVMCTRL_INTENCLR) Interrupt Enable Clear  Reset Value */
+
+#define NVMCTRL_INTENCLR_DONE_Pos           0                                              /**< (NVMCTRL_INTENCLR) NVM Done Interrupt Clear Position */
+#define NVMCTRL_INTENCLR_DONE_Msk           (_U_(0x1) << NVMCTRL_INTENCLR_DONE_Pos)        /**< (NVMCTRL_INTENCLR) NVM Done Interrupt Clear Mask */
+#define NVMCTRL_INTENCLR_DONE               NVMCTRL_INTENCLR_DONE_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_INTENCLR_DONE_Msk instead */
+#define NVMCTRL_INTENCLR_PROGE_Pos          1                                              /**< (NVMCTRL_INTENCLR) Programming Error Status Interrupt Clear Position */
+#define NVMCTRL_INTENCLR_PROGE_Msk          (_U_(0x1) << NVMCTRL_INTENCLR_PROGE_Pos)       /**< (NVMCTRL_INTENCLR) Programming Error Status Interrupt Clear Mask */
+#define NVMCTRL_INTENCLR_PROGE              NVMCTRL_INTENCLR_PROGE_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_INTENCLR_PROGE_Msk instead */
+#define NVMCTRL_INTENCLR_LOCKE_Pos          2                                              /**< (NVMCTRL_INTENCLR) Lock Error Status Interrupt Clear Position */
+#define NVMCTRL_INTENCLR_LOCKE_Msk          (_U_(0x1) << NVMCTRL_INTENCLR_LOCKE_Pos)       /**< (NVMCTRL_INTENCLR) Lock Error Status Interrupt Clear Mask */
+#define NVMCTRL_INTENCLR_LOCKE              NVMCTRL_INTENCLR_LOCKE_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_INTENCLR_LOCKE_Msk instead */
+#define NVMCTRL_INTENCLR_NVME_Pos           3                                              /**< (NVMCTRL_INTENCLR) NVM Error Interrupt Clear Position */
+#define NVMCTRL_INTENCLR_NVME_Msk           (_U_(0x1) << NVMCTRL_INTENCLR_NVME_Pos)        /**< (NVMCTRL_INTENCLR) NVM Error Interrupt Clear Mask */
+#define NVMCTRL_INTENCLR_NVME               NVMCTRL_INTENCLR_NVME_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_INTENCLR_NVME_Msk instead */
+#define NVMCTRL_INTENCLR_KEYE_Pos           4                                              /**< (NVMCTRL_INTENCLR) Key Write Error Interrupt Clear Position */
+#define NVMCTRL_INTENCLR_KEYE_Msk           (_U_(0x1) << NVMCTRL_INTENCLR_KEYE_Pos)        /**< (NVMCTRL_INTENCLR) Key Write Error Interrupt Clear Mask */
+#define NVMCTRL_INTENCLR_KEYE               NVMCTRL_INTENCLR_KEYE_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_INTENCLR_KEYE_Msk instead */
+#define NVMCTRL_INTENCLR_NSCHK_Pos          5                                              /**< (NVMCTRL_INTENCLR) NS configuration change detected Interrupt Clear Position */
+#define NVMCTRL_INTENCLR_NSCHK_Msk          (_U_(0x1) << NVMCTRL_INTENCLR_NSCHK_Pos)       /**< (NVMCTRL_INTENCLR) NS configuration change detected Interrupt Clear Mask */
+#define NVMCTRL_INTENCLR_NSCHK              NVMCTRL_INTENCLR_NSCHK_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_INTENCLR_NSCHK_Msk instead */
+#define NVMCTRL_INTENCLR_MASK               _U_(0x3F)                                      /**< \deprecated (NVMCTRL_INTENCLR) Register MASK  (Use NVMCTRL_INTENCLR_Msk instead)  */
+#define NVMCTRL_INTENCLR_Msk                _U_(0x3F)                                      /**< (NVMCTRL_INTENCLR) Register Mask  */
+
+
+/* -------- NVMCTRL_INTENSET : (NVMCTRL Offset: 0x10) (R/W 8) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DONE:1;                    /**< bit:      0  NVM Done Interrupt Enable                */
+    uint8_t  PROGE:1;                   /**< bit:      1  Programming Error Status Interrupt Enable */
+    uint8_t  LOCKE:1;                   /**< bit:      2  Lock Error Status Interrupt Enable       */
+    uint8_t  NVME:1;                    /**< bit:      3  NVM Error Interrupt Enable               */
+    uint8_t  KEYE:1;                    /**< bit:      4  Key Write Error Interrupt Enable         */
+    uint8_t  NSCHK:1;                   /**< bit:      5  NS configuration change detected Interrupt Enable */
+    uint8_t  :2;                        /**< bit:   6..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} NVMCTRL_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_INTENSET_OFFSET             (0x10)                                        /**<  (NVMCTRL_INTENSET) Interrupt Enable Set  Offset */
+#define NVMCTRL_INTENSET_RESETVALUE         _U_(0x00)                                     /**<  (NVMCTRL_INTENSET) Interrupt Enable Set  Reset Value */
+
+#define NVMCTRL_INTENSET_DONE_Pos           0                                              /**< (NVMCTRL_INTENSET) NVM Done Interrupt Enable Position */
+#define NVMCTRL_INTENSET_DONE_Msk           (_U_(0x1) << NVMCTRL_INTENSET_DONE_Pos)        /**< (NVMCTRL_INTENSET) NVM Done Interrupt Enable Mask */
+#define NVMCTRL_INTENSET_DONE               NVMCTRL_INTENSET_DONE_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_INTENSET_DONE_Msk instead */
+#define NVMCTRL_INTENSET_PROGE_Pos          1                                              /**< (NVMCTRL_INTENSET) Programming Error Status Interrupt Enable Position */
+#define NVMCTRL_INTENSET_PROGE_Msk          (_U_(0x1) << NVMCTRL_INTENSET_PROGE_Pos)       /**< (NVMCTRL_INTENSET) Programming Error Status Interrupt Enable Mask */
+#define NVMCTRL_INTENSET_PROGE              NVMCTRL_INTENSET_PROGE_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_INTENSET_PROGE_Msk instead */
+#define NVMCTRL_INTENSET_LOCKE_Pos          2                                              /**< (NVMCTRL_INTENSET) Lock Error Status Interrupt Enable Position */
+#define NVMCTRL_INTENSET_LOCKE_Msk          (_U_(0x1) << NVMCTRL_INTENSET_LOCKE_Pos)       /**< (NVMCTRL_INTENSET) Lock Error Status Interrupt Enable Mask */
+#define NVMCTRL_INTENSET_LOCKE              NVMCTRL_INTENSET_LOCKE_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_INTENSET_LOCKE_Msk instead */
+#define NVMCTRL_INTENSET_NVME_Pos           3                                              /**< (NVMCTRL_INTENSET) NVM Error Interrupt Enable Position */
+#define NVMCTRL_INTENSET_NVME_Msk           (_U_(0x1) << NVMCTRL_INTENSET_NVME_Pos)        /**< (NVMCTRL_INTENSET) NVM Error Interrupt Enable Mask */
+#define NVMCTRL_INTENSET_NVME               NVMCTRL_INTENSET_NVME_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_INTENSET_NVME_Msk instead */
+#define NVMCTRL_INTENSET_KEYE_Pos           4                                              /**< (NVMCTRL_INTENSET) Key Write Error Interrupt Enable Position */
+#define NVMCTRL_INTENSET_KEYE_Msk           (_U_(0x1) << NVMCTRL_INTENSET_KEYE_Pos)        /**< (NVMCTRL_INTENSET) Key Write Error Interrupt Enable Mask */
+#define NVMCTRL_INTENSET_KEYE               NVMCTRL_INTENSET_KEYE_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_INTENSET_KEYE_Msk instead */
+#define NVMCTRL_INTENSET_NSCHK_Pos          5                                              /**< (NVMCTRL_INTENSET) NS configuration change detected Interrupt Enable Position */
+#define NVMCTRL_INTENSET_NSCHK_Msk          (_U_(0x1) << NVMCTRL_INTENSET_NSCHK_Pos)       /**< (NVMCTRL_INTENSET) NS configuration change detected Interrupt Enable Mask */
+#define NVMCTRL_INTENSET_NSCHK              NVMCTRL_INTENSET_NSCHK_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_INTENSET_NSCHK_Msk instead */
+#define NVMCTRL_INTENSET_MASK               _U_(0x3F)                                      /**< \deprecated (NVMCTRL_INTENSET) Register MASK  (Use NVMCTRL_INTENSET_Msk instead)  */
+#define NVMCTRL_INTENSET_Msk                _U_(0x3F)                                      /**< (NVMCTRL_INTENSET) Register Mask  */
+
+
+/* -------- NVMCTRL_INTFLAG : (NVMCTRL Offset: 0x14) (R/W 8) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t DONE:1;                    /**< bit:      0  NVM Done                                 */
+    __I uint8_t PROGE:1;                   /**< bit:      1  Programming Error Status                 */
+    __I uint8_t LOCKE:1;                   /**< bit:      2  Lock Error Status                        */
+    __I uint8_t NVME:1;                    /**< bit:      3  NVM Error                                */
+    __I uint8_t KEYE:1;                    /**< bit:      4  KEY Write Error                          */
+    __I uint8_t NSCHK:1;                   /**< bit:      5  NS configuration change detected         */
+    __I uint8_t :2;                        /**< bit:   6..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} NVMCTRL_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_INTFLAG_OFFSET              (0x14)                                        /**<  (NVMCTRL_INTFLAG) Interrupt Flag Status and Clear  Offset */
+#define NVMCTRL_INTFLAG_RESETVALUE          _U_(0x00)                                     /**<  (NVMCTRL_INTFLAG) Interrupt Flag Status and Clear  Reset Value */
+
+#define NVMCTRL_INTFLAG_DONE_Pos            0                                              /**< (NVMCTRL_INTFLAG) NVM Done Position */
+#define NVMCTRL_INTFLAG_DONE_Msk            (_U_(0x1) << NVMCTRL_INTFLAG_DONE_Pos)         /**< (NVMCTRL_INTFLAG) NVM Done Mask */
+#define NVMCTRL_INTFLAG_DONE                NVMCTRL_INTFLAG_DONE_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_INTFLAG_DONE_Msk instead */
+#define NVMCTRL_INTFLAG_PROGE_Pos           1                                              /**< (NVMCTRL_INTFLAG) Programming Error Status Position */
+#define NVMCTRL_INTFLAG_PROGE_Msk           (_U_(0x1) << NVMCTRL_INTFLAG_PROGE_Pos)        /**< (NVMCTRL_INTFLAG) Programming Error Status Mask */
+#define NVMCTRL_INTFLAG_PROGE               NVMCTRL_INTFLAG_PROGE_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_INTFLAG_PROGE_Msk instead */
+#define NVMCTRL_INTFLAG_LOCKE_Pos           2                                              /**< (NVMCTRL_INTFLAG) Lock Error Status Position */
+#define NVMCTRL_INTFLAG_LOCKE_Msk           (_U_(0x1) << NVMCTRL_INTFLAG_LOCKE_Pos)        /**< (NVMCTRL_INTFLAG) Lock Error Status Mask */
+#define NVMCTRL_INTFLAG_LOCKE               NVMCTRL_INTFLAG_LOCKE_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_INTFLAG_LOCKE_Msk instead */
+#define NVMCTRL_INTFLAG_NVME_Pos            3                                              /**< (NVMCTRL_INTFLAG) NVM Error Position */
+#define NVMCTRL_INTFLAG_NVME_Msk            (_U_(0x1) << NVMCTRL_INTFLAG_NVME_Pos)         /**< (NVMCTRL_INTFLAG) NVM Error Mask */
+#define NVMCTRL_INTFLAG_NVME                NVMCTRL_INTFLAG_NVME_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_INTFLAG_NVME_Msk instead */
+#define NVMCTRL_INTFLAG_KEYE_Pos            4                                              /**< (NVMCTRL_INTFLAG) KEY Write Error Position */
+#define NVMCTRL_INTFLAG_KEYE_Msk            (_U_(0x1) << NVMCTRL_INTFLAG_KEYE_Pos)         /**< (NVMCTRL_INTFLAG) KEY Write Error Mask */
+#define NVMCTRL_INTFLAG_KEYE                NVMCTRL_INTFLAG_KEYE_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_INTFLAG_KEYE_Msk instead */
+#define NVMCTRL_INTFLAG_NSCHK_Pos           5                                              /**< (NVMCTRL_INTFLAG) NS configuration change detected Position */
+#define NVMCTRL_INTFLAG_NSCHK_Msk           (_U_(0x1) << NVMCTRL_INTFLAG_NSCHK_Pos)        /**< (NVMCTRL_INTFLAG) NS configuration change detected Mask */
+#define NVMCTRL_INTFLAG_NSCHK               NVMCTRL_INTFLAG_NSCHK_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_INTFLAG_NSCHK_Msk instead */
+#define NVMCTRL_INTFLAG_MASK                _U_(0x3F)                                      /**< \deprecated (NVMCTRL_INTFLAG) Register MASK  (Use NVMCTRL_INTFLAG_Msk instead)  */
+#define NVMCTRL_INTFLAG_Msk                 _U_(0x3F)                                      /**< (NVMCTRL_INTFLAG) Register Mask  */
+
+
+/* -------- NVMCTRL_STATUS : (NVMCTRL Offset: 0x18) (R/ 16) Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t PRM:1;                     /**< bit:      0  Power Reduction Mode                     */
+    uint16_t LOAD:1;                    /**< bit:      1  NVM Page Buffer Active Loading           */
+    uint16_t READY:1;                   /**< bit:      2  NVM Ready                                */
+    uint16_t DALFUSE:2;                 /**< bit:   3..4  Debug Access Level Fuse                  */
+    uint16_t :11;                       /**< bit:  5..15  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} NVMCTRL_STATUS_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_STATUS_OFFSET               (0x18)                                        /**<  (NVMCTRL_STATUS) Status  Offset */
+#define NVMCTRL_STATUS_RESETVALUE           _U_(0x00)                                     /**<  (NVMCTRL_STATUS) Status  Reset Value */
+
+#define NVMCTRL_STATUS_PRM_Pos              0                                              /**< (NVMCTRL_STATUS) Power Reduction Mode Position */
+#define NVMCTRL_STATUS_PRM_Msk              (_U_(0x1) << NVMCTRL_STATUS_PRM_Pos)           /**< (NVMCTRL_STATUS) Power Reduction Mode Mask */
+#define NVMCTRL_STATUS_PRM                  NVMCTRL_STATUS_PRM_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_STATUS_PRM_Msk instead */
+#define NVMCTRL_STATUS_LOAD_Pos             1                                              /**< (NVMCTRL_STATUS) NVM Page Buffer Active Loading Position */
+#define NVMCTRL_STATUS_LOAD_Msk             (_U_(0x1) << NVMCTRL_STATUS_LOAD_Pos)          /**< (NVMCTRL_STATUS) NVM Page Buffer Active Loading Mask */
+#define NVMCTRL_STATUS_LOAD                 NVMCTRL_STATUS_LOAD_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_STATUS_LOAD_Msk instead */
+#define NVMCTRL_STATUS_READY_Pos            2                                              /**< (NVMCTRL_STATUS) NVM Ready Position */
+#define NVMCTRL_STATUS_READY_Msk            (_U_(0x1) << NVMCTRL_STATUS_READY_Pos)         /**< (NVMCTRL_STATUS) NVM Ready Mask */
+#define NVMCTRL_STATUS_READY                NVMCTRL_STATUS_READY_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_STATUS_READY_Msk instead */
+#define NVMCTRL_STATUS_DALFUSE_Pos          3                                              /**< (NVMCTRL_STATUS) Debug Access Level Fuse Position */
+#define NVMCTRL_STATUS_DALFUSE_Msk          (_U_(0x3) << NVMCTRL_STATUS_DALFUSE_Pos)       /**< (NVMCTRL_STATUS) Debug Access Level Fuse Mask */
+#define NVMCTRL_STATUS_DALFUSE(value)       (NVMCTRL_STATUS_DALFUSE_Msk & ((value) << NVMCTRL_STATUS_DALFUSE_Pos))
+#define NVMCTRL_STATUS_MASK                 _U_(0x1F)                                      /**< \deprecated (NVMCTRL_STATUS) Register MASK  (Use NVMCTRL_STATUS_Msk instead)  */
+#define NVMCTRL_STATUS_Msk                  _U_(0x1F)                                      /**< (NVMCTRL_STATUS) Register Mask  */
+
+
+/* -------- NVMCTRL_ADDR : (NVMCTRL Offset: 0x1c) (R/W 32) Address -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t AOFFSET:16;                /**< bit:  0..15  NVM Address Offset In The Selected Array */
+    uint32_t :6;                        /**< bit: 16..21  Reserved */
+    uint32_t ARRAY:2;                   /**< bit: 22..23  Array Select                             */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} NVMCTRL_ADDR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_ADDR_OFFSET                 (0x1C)                                        /**<  (NVMCTRL_ADDR) Address  Offset */
+#define NVMCTRL_ADDR_RESETVALUE             _U_(0x00)                                     /**<  (NVMCTRL_ADDR) Address  Reset Value */
+
+#define NVMCTRL_ADDR_AOFFSET_Pos            0                                              /**< (NVMCTRL_ADDR) NVM Address Offset In The Selected Array Position */
+#define NVMCTRL_ADDR_AOFFSET_Msk            (_U_(0xFFFF) << NVMCTRL_ADDR_AOFFSET_Pos)      /**< (NVMCTRL_ADDR) NVM Address Offset In The Selected Array Mask */
+#define NVMCTRL_ADDR_AOFFSET(value)         (NVMCTRL_ADDR_AOFFSET_Msk & ((value) << NVMCTRL_ADDR_AOFFSET_Pos))
+#define NVMCTRL_ADDR_ARRAY_Pos              22                                             /**< (NVMCTRL_ADDR) Array Select Position */
+#define NVMCTRL_ADDR_ARRAY_Msk              (_U_(0x3) << NVMCTRL_ADDR_ARRAY_Pos)           /**< (NVMCTRL_ADDR) Array Select Mask */
+#define NVMCTRL_ADDR_ARRAY(value)           (NVMCTRL_ADDR_ARRAY_Msk & ((value) << NVMCTRL_ADDR_ARRAY_Pos))
+#define   NVMCTRL_ADDR_ARRAY_FLASH_Val      _U_(0x0)                                       /**< (NVMCTRL_ADDR) FLASH Array  */
+#define   NVMCTRL_ADDR_ARRAY_DATAFLASH_Val  _U_(0x1)                                       /**< (NVMCTRL_ADDR) DATA FLASH Array  */
+#define   NVMCTRL_ADDR_ARRAY_AUX_Val        _U_(0x2)                                       /**< (NVMCTRL_ADDR) Auxilliary Space  */
+#define   NVMCTRL_ADDR_ARRAY_RESERVED_Val   _U_(0x3)                                       /**< (NVMCTRL_ADDR) Reserved Array  */
+#define NVMCTRL_ADDR_ARRAY_FLASH            (NVMCTRL_ADDR_ARRAY_FLASH_Val << NVMCTRL_ADDR_ARRAY_Pos)  /**< (NVMCTRL_ADDR) FLASH Array Position  */
+#define NVMCTRL_ADDR_ARRAY_DATAFLASH        (NVMCTRL_ADDR_ARRAY_DATAFLASH_Val << NVMCTRL_ADDR_ARRAY_Pos)  /**< (NVMCTRL_ADDR) DATA FLASH Array Position  */
+#define NVMCTRL_ADDR_ARRAY_AUX              (NVMCTRL_ADDR_ARRAY_AUX_Val << NVMCTRL_ADDR_ARRAY_Pos)  /**< (NVMCTRL_ADDR) Auxilliary Space Position  */
+#define NVMCTRL_ADDR_ARRAY_RESERVED         (NVMCTRL_ADDR_ARRAY_RESERVED_Val << NVMCTRL_ADDR_ARRAY_Pos)  /**< (NVMCTRL_ADDR) Reserved Array Position  */
+#define NVMCTRL_ADDR_MASK                   _U_(0xC0FFFF)                                  /**< \deprecated (NVMCTRL_ADDR) Register MASK  (Use NVMCTRL_ADDR_Msk instead)  */
+#define NVMCTRL_ADDR_Msk                    _U_(0xC0FFFF)                                  /**< (NVMCTRL_ADDR) Register Mask  */
+
+
+/* -------- NVMCTRL_SULCK : (NVMCTRL Offset: 0x20) (R/W 16) Secure Unlock Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t BS:1;                      /**< bit:      0  Secure Boot Region                       */
+    uint16_t AS:1;                      /**< bit:      1  Secure Application Region                */
+    uint16_t DS:1;                      /**< bit:      2  Data Secure Region                       */
+    uint16_t :5;                        /**< bit:   3..7  Reserved */
+    uint16_t SLKEY:8;                   /**< bit:  8..15  Write Key                                */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} NVMCTRL_SULCK_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_SULCK_OFFSET                (0x20)                                        /**<  (NVMCTRL_SULCK) Secure Unlock Register  Offset */
+
+#define NVMCTRL_SULCK_BS_Pos                0                                              /**< (NVMCTRL_SULCK) Secure Boot Region Position */
+#define NVMCTRL_SULCK_BS_Msk                (_U_(0x1) << NVMCTRL_SULCK_BS_Pos)             /**< (NVMCTRL_SULCK) Secure Boot Region Mask */
+#define NVMCTRL_SULCK_BS                    NVMCTRL_SULCK_BS_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_SULCK_BS_Msk instead */
+#define NVMCTRL_SULCK_AS_Pos                1                                              /**< (NVMCTRL_SULCK) Secure Application Region Position */
+#define NVMCTRL_SULCK_AS_Msk                (_U_(0x1) << NVMCTRL_SULCK_AS_Pos)             /**< (NVMCTRL_SULCK) Secure Application Region Mask */
+#define NVMCTRL_SULCK_AS                    NVMCTRL_SULCK_AS_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_SULCK_AS_Msk instead */
+#define NVMCTRL_SULCK_DS_Pos                2                                              /**< (NVMCTRL_SULCK) Data Secure Region Position */
+#define NVMCTRL_SULCK_DS_Msk                (_U_(0x1) << NVMCTRL_SULCK_DS_Pos)             /**< (NVMCTRL_SULCK) Data Secure Region Mask */
+#define NVMCTRL_SULCK_DS                    NVMCTRL_SULCK_DS_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_SULCK_DS_Msk instead */
+#define NVMCTRL_SULCK_SLKEY_Pos             8                                              /**< (NVMCTRL_SULCK) Write Key Position */
+#define NVMCTRL_SULCK_SLKEY_Msk             (_U_(0xFF) << NVMCTRL_SULCK_SLKEY_Pos)         /**< (NVMCTRL_SULCK) Write Key Mask */
+#define NVMCTRL_SULCK_SLKEY(value)          (NVMCTRL_SULCK_SLKEY_Msk & ((value) << NVMCTRL_SULCK_SLKEY_Pos))
+#define   NVMCTRL_SULCK_SLKEY_KEY_Val       _U_(0xA5)                                      /**< (NVMCTRL_SULCK) Write Key  */
+#define NVMCTRL_SULCK_SLKEY_KEY             (NVMCTRL_SULCK_SLKEY_KEY_Val << NVMCTRL_SULCK_SLKEY_Pos)  /**< (NVMCTRL_SULCK) Write Key Position  */
+#define NVMCTRL_SULCK_MASK                  _U_(0xFF07)                                    /**< \deprecated (NVMCTRL_SULCK) Register MASK  (Use NVMCTRL_SULCK_Msk instead)  */
+#define NVMCTRL_SULCK_Msk                   _U_(0xFF07)                                    /**< (NVMCTRL_SULCK) Register Mask  */
+
+
+/* -------- NVMCTRL_NSULCK : (NVMCTRL Offset: 0x22) (R/W 16) Non-Secure Unlock Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t BNS:1;                     /**< bit:      0  Non-Secure Boot Region                   */
+    uint16_t ANS:1;                     /**< bit:      1  Non-Secure Application Region            */
+    uint16_t DNS:1;                     /**< bit:      2  Non-Secure Data Region                   */
+    uint16_t :5;                        /**< bit:   3..7  Reserved */
+    uint16_t NSLKEY:8;                  /**< bit:  8..15  Write Key                                */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} NVMCTRL_NSULCK_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_NSULCK_OFFSET               (0x22)                                        /**<  (NVMCTRL_NSULCK) Non-Secure Unlock Register  Offset */
+
+#define NVMCTRL_NSULCK_BNS_Pos              0                                              /**< (NVMCTRL_NSULCK) Non-Secure Boot Region Position */
+#define NVMCTRL_NSULCK_BNS_Msk              (_U_(0x1) << NVMCTRL_NSULCK_BNS_Pos)           /**< (NVMCTRL_NSULCK) Non-Secure Boot Region Mask */
+#define NVMCTRL_NSULCK_BNS                  NVMCTRL_NSULCK_BNS_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_NSULCK_BNS_Msk instead */
+#define NVMCTRL_NSULCK_ANS_Pos              1                                              /**< (NVMCTRL_NSULCK) Non-Secure Application Region Position */
+#define NVMCTRL_NSULCK_ANS_Msk              (_U_(0x1) << NVMCTRL_NSULCK_ANS_Pos)           /**< (NVMCTRL_NSULCK) Non-Secure Application Region Mask */
+#define NVMCTRL_NSULCK_ANS                  NVMCTRL_NSULCK_ANS_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_NSULCK_ANS_Msk instead */
+#define NVMCTRL_NSULCK_DNS_Pos              2                                              /**< (NVMCTRL_NSULCK) Non-Secure Data Region Position */
+#define NVMCTRL_NSULCK_DNS_Msk              (_U_(0x1) << NVMCTRL_NSULCK_DNS_Pos)           /**< (NVMCTRL_NSULCK) Non-Secure Data Region Mask */
+#define NVMCTRL_NSULCK_DNS                  NVMCTRL_NSULCK_DNS_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_NSULCK_DNS_Msk instead */
+#define NVMCTRL_NSULCK_NSLKEY_Pos           8                                              /**< (NVMCTRL_NSULCK) Write Key Position */
+#define NVMCTRL_NSULCK_NSLKEY_Msk           (_U_(0xFF) << NVMCTRL_NSULCK_NSLKEY_Pos)       /**< (NVMCTRL_NSULCK) Write Key Mask */
+#define NVMCTRL_NSULCK_NSLKEY(value)        (NVMCTRL_NSULCK_NSLKEY_Msk & ((value) << NVMCTRL_NSULCK_NSLKEY_Pos))
+#define   NVMCTRL_NSULCK_NSLKEY_KEY_Val     _U_(0xA5)                                      /**< (NVMCTRL_NSULCK) Write Key  */
+#define NVMCTRL_NSULCK_NSLKEY_KEY           (NVMCTRL_NSULCK_NSLKEY_KEY_Val << NVMCTRL_NSULCK_NSLKEY_Pos)  /**< (NVMCTRL_NSULCK) Write Key Position  */
+#define NVMCTRL_NSULCK_MASK                 _U_(0xFF07)                                    /**< \deprecated (NVMCTRL_NSULCK) Register MASK  (Use NVMCTRL_NSULCK_Msk instead)  */
+#define NVMCTRL_NSULCK_Msk                  _U_(0xFF07)                                    /**< (NVMCTRL_NSULCK) Register Mask  */
+
+
+/* -------- NVMCTRL_PARAM : (NVMCTRL Offset: 0x24) (R/W 32) NVM Parameter -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t FLASHP:16;                 /**< bit:  0..15  FLASH Pages                              */
+    uint32_t PSZ:3;                     /**< bit: 16..18  Page Size                                */
+    uint32_t :1;                        /**< bit:     19  Reserved */
+    uint32_t DFLASHP:12;                /**< bit: 20..31  DATAFLASH Pages                          */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} NVMCTRL_PARAM_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_PARAM_OFFSET                (0x24)                                        /**<  (NVMCTRL_PARAM) NVM Parameter  Offset */
+#define NVMCTRL_PARAM_RESETVALUE            _U_(0x00)                                     /**<  (NVMCTRL_PARAM) NVM Parameter  Reset Value */
+
+#define NVMCTRL_PARAM_FLASHP_Pos            0                                              /**< (NVMCTRL_PARAM) FLASH Pages Position */
+#define NVMCTRL_PARAM_FLASHP_Msk            (_U_(0xFFFF) << NVMCTRL_PARAM_FLASHP_Pos)      /**< (NVMCTRL_PARAM) FLASH Pages Mask */
+#define NVMCTRL_PARAM_FLASHP(value)         (NVMCTRL_PARAM_FLASHP_Msk & ((value) << NVMCTRL_PARAM_FLASHP_Pos))
+#define NVMCTRL_PARAM_PSZ_Pos               16                                             /**< (NVMCTRL_PARAM) Page Size Position */
+#define NVMCTRL_PARAM_PSZ_Msk               (_U_(0x7) << NVMCTRL_PARAM_PSZ_Pos)            /**< (NVMCTRL_PARAM) Page Size Mask */
+#define NVMCTRL_PARAM_PSZ(value)            (NVMCTRL_PARAM_PSZ_Msk & ((value) << NVMCTRL_PARAM_PSZ_Pos))
+#define   NVMCTRL_PARAM_PSZ_8_Val           _U_(0x0)                                       /**< (NVMCTRL_PARAM) 8 bytes  */
+#define   NVMCTRL_PARAM_PSZ_16_Val          _U_(0x1)                                       /**< (NVMCTRL_PARAM) 16 bytes  */
+#define   NVMCTRL_PARAM_PSZ_32_Val          _U_(0x2)                                       /**< (NVMCTRL_PARAM) 32 bytes  */
+#define   NVMCTRL_PARAM_PSZ_64_Val          _U_(0x3)                                       /**< (NVMCTRL_PARAM) 64 bytes  */
+#define   NVMCTRL_PARAM_PSZ_128_Val         _U_(0x4)                                       /**< (NVMCTRL_PARAM) 128 bytes  */
+#define   NVMCTRL_PARAM_PSZ_256_Val         _U_(0x5)                                       /**< (NVMCTRL_PARAM) 256 bytes  */
+#define   NVMCTRL_PARAM_PSZ_512_Val         _U_(0x6)                                       /**< (NVMCTRL_PARAM) 512 bytes  */
+#define   NVMCTRL_PARAM_PSZ_1024_Val        _U_(0x7)                                       /**< (NVMCTRL_PARAM) 1024 bytes  */
+#define NVMCTRL_PARAM_PSZ_8                 (NVMCTRL_PARAM_PSZ_8_Val << NVMCTRL_PARAM_PSZ_Pos)  /**< (NVMCTRL_PARAM) 8 bytes Position  */
+#define NVMCTRL_PARAM_PSZ_16                (NVMCTRL_PARAM_PSZ_16_Val << NVMCTRL_PARAM_PSZ_Pos)  /**< (NVMCTRL_PARAM) 16 bytes Position  */
+#define NVMCTRL_PARAM_PSZ_32                (NVMCTRL_PARAM_PSZ_32_Val << NVMCTRL_PARAM_PSZ_Pos)  /**< (NVMCTRL_PARAM) 32 bytes Position  */
+#define NVMCTRL_PARAM_PSZ_64                (NVMCTRL_PARAM_PSZ_64_Val << NVMCTRL_PARAM_PSZ_Pos)  /**< (NVMCTRL_PARAM) 64 bytes Position  */
+#define NVMCTRL_PARAM_PSZ_128               (NVMCTRL_PARAM_PSZ_128_Val << NVMCTRL_PARAM_PSZ_Pos)  /**< (NVMCTRL_PARAM) 128 bytes Position  */
+#define NVMCTRL_PARAM_PSZ_256               (NVMCTRL_PARAM_PSZ_256_Val << NVMCTRL_PARAM_PSZ_Pos)  /**< (NVMCTRL_PARAM) 256 bytes Position  */
+#define NVMCTRL_PARAM_PSZ_512               (NVMCTRL_PARAM_PSZ_512_Val << NVMCTRL_PARAM_PSZ_Pos)  /**< (NVMCTRL_PARAM) 512 bytes Position  */
+#define NVMCTRL_PARAM_PSZ_1024              (NVMCTRL_PARAM_PSZ_1024_Val << NVMCTRL_PARAM_PSZ_Pos)  /**< (NVMCTRL_PARAM) 1024 bytes Position  */
+#define NVMCTRL_PARAM_DFLASHP_Pos           20                                             /**< (NVMCTRL_PARAM) DATAFLASH Pages Position */
+#define NVMCTRL_PARAM_DFLASHP_Msk           (_U_(0xFFF) << NVMCTRL_PARAM_DFLASHP_Pos)      /**< (NVMCTRL_PARAM) DATAFLASH Pages Mask */
+#define NVMCTRL_PARAM_DFLASHP(value)        (NVMCTRL_PARAM_DFLASHP_Msk & ((value) << NVMCTRL_PARAM_DFLASHP_Pos))
+#define NVMCTRL_PARAM_MASK                  _U_(0xFFF7FFFF)                                /**< \deprecated (NVMCTRL_PARAM) Register MASK  (Use NVMCTRL_PARAM_Msk instead)  */
+#define NVMCTRL_PARAM_Msk                   _U_(0xFFF7FFFF)                                /**< (NVMCTRL_PARAM) Register Mask  */
+
+
+/* -------- NVMCTRL_DSCC : (NVMCTRL Offset: 0x30) (/W 32) Data Scramble Configuration -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t DSCKEY:30;                 /**< bit:  0..29  Data Scramble Key                        */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} NVMCTRL_DSCC_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_DSCC_OFFSET                 (0x30)                                        /**<  (NVMCTRL_DSCC) Data Scramble Configuration  Offset */
+#define NVMCTRL_DSCC_RESETVALUE             _U_(0x00)                                     /**<  (NVMCTRL_DSCC) Data Scramble Configuration  Reset Value */
+
+#define NVMCTRL_DSCC_DSCKEY_Pos             0                                              /**< (NVMCTRL_DSCC) Data Scramble Key Position */
+#define NVMCTRL_DSCC_DSCKEY_Msk             (_U_(0x3FFFFFFF) << NVMCTRL_DSCC_DSCKEY_Pos)   /**< (NVMCTRL_DSCC) Data Scramble Key Mask */
+#define NVMCTRL_DSCC_DSCKEY(value)          (NVMCTRL_DSCC_DSCKEY_Msk & ((value) << NVMCTRL_DSCC_DSCKEY_Pos))
+#define NVMCTRL_DSCC_MASK                   _U_(0x3FFFFFFF)                                /**< \deprecated (NVMCTRL_DSCC) Register MASK  (Use NVMCTRL_DSCC_Msk instead)  */
+#define NVMCTRL_DSCC_Msk                    _U_(0x3FFFFFFF)                                /**< (NVMCTRL_DSCC) Register Mask  */
+
+
+/* -------- NVMCTRL_SECCTRL : (NVMCTRL Offset: 0x34) (R/W 32) Security Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t TAMPEEN:1;                 /**< bit:      0  Tamper Erase Enable                      */
+    uint32_t :1;                        /**< bit:      1  Reserved */
+    uint32_t SILACC:1;                  /**< bit:      2  Silent Access                            */
+    uint32_t DSCEN:1;                   /**< bit:      3  Data Scramble Enable                     */
+    uint32_t :2;                        /**< bit:   4..5  Reserved */
+    uint32_t DXN:1;                     /**< bit:      6  Data Flash is eXecute Never              */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t TEROW:3;                   /**< bit:  8..10  Tamper Rease Row                         */
+    uint32_t :13;                       /**< bit: 11..23  Reserved */
+    uint32_t KEY:8;                     /**< bit: 24..31  Write Key                                */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} NVMCTRL_SECCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_SECCTRL_OFFSET              (0x34)                                        /**<  (NVMCTRL_SECCTRL) Security Control  Offset */
+#define NVMCTRL_SECCTRL_RESETVALUE          _U_(0x30)                                     /**<  (NVMCTRL_SECCTRL) Security Control  Reset Value */
+
+#define NVMCTRL_SECCTRL_TAMPEEN_Pos         0                                              /**< (NVMCTRL_SECCTRL) Tamper Erase Enable Position */
+#define NVMCTRL_SECCTRL_TAMPEEN_Msk         (_U_(0x1) << NVMCTRL_SECCTRL_TAMPEEN_Pos)      /**< (NVMCTRL_SECCTRL) Tamper Erase Enable Mask */
+#define NVMCTRL_SECCTRL_TAMPEEN             NVMCTRL_SECCTRL_TAMPEEN_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_SECCTRL_TAMPEEN_Msk instead */
+#define NVMCTRL_SECCTRL_SILACC_Pos          2                                              /**< (NVMCTRL_SECCTRL) Silent Access Position */
+#define NVMCTRL_SECCTRL_SILACC_Msk          (_U_(0x1) << NVMCTRL_SECCTRL_SILACC_Pos)       /**< (NVMCTRL_SECCTRL) Silent Access Mask */
+#define NVMCTRL_SECCTRL_SILACC              NVMCTRL_SECCTRL_SILACC_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_SECCTRL_SILACC_Msk instead */
+#define NVMCTRL_SECCTRL_DSCEN_Pos           3                                              /**< (NVMCTRL_SECCTRL) Data Scramble Enable Position */
+#define NVMCTRL_SECCTRL_DSCEN_Msk           (_U_(0x1) << NVMCTRL_SECCTRL_DSCEN_Pos)        /**< (NVMCTRL_SECCTRL) Data Scramble Enable Mask */
+#define NVMCTRL_SECCTRL_DSCEN               NVMCTRL_SECCTRL_DSCEN_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_SECCTRL_DSCEN_Msk instead */
+#define NVMCTRL_SECCTRL_DXN_Pos             6                                              /**< (NVMCTRL_SECCTRL) Data Flash is eXecute Never Position */
+#define NVMCTRL_SECCTRL_DXN_Msk             (_U_(0x1) << NVMCTRL_SECCTRL_DXN_Pos)          /**< (NVMCTRL_SECCTRL) Data Flash is eXecute Never Mask */
+#define NVMCTRL_SECCTRL_DXN                 NVMCTRL_SECCTRL_DXN_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_SECCTRL_DXN_Msk instead */
+#define NVMCTRL_SECCTRL_TEROW_Pos           8                                              /**< (NVMCTRL_SECCTRL) Tamper Rease Row Position */
+#define NVMCTRL_SECCTRL_TEROW_Msk           (_U_(0x7) << NVMCTRL_SECCTRL_TEROW_Pos)        /**< (NVMCTRL_SECCTRL) Tamper Rease Row Mask */
+#define NVMCTRL_SECCTRL_TEROW(value)        (NVMCTRL_SECCTRL_TEROW_Msk & ((value) << NVMCTRL_SECCTRL_TEROW_Pos))
+#define NVMCTRL_SECCTRL_KEY_Pos             24                                             /**< (NVMCTRL_SECCTRL) Write Key Position */
+#define NVMCTRL_SECCTRL_KEY_Msk             (_U_(0xFF) << NVMCTRL_SECCTRL_KEY_Pos)         /**< (NVMCTRL_SECCTRL) Write Key Mask */
+#define NVMCTRL_SECCTRL_KEY(value)          (NVMCTRL_SECCTRL_KEY_Msk & ((value) << NVMCTRL_SECCTRL_KEY_Pos))
+#define   NVMCTRL_SECCTRL_KEY_KEY_Val       _U_(0xA5)                                      /**< (NVMCTRL_SECCTRL) Write Key  */
+#define NVMCTRL_SECCTRL_KEY_KEY             (NVMCTRL_SECCTRL_KEY_KEY_Val << NVMCTRL_SECCTRL_KEY_Pos)  /**< (NVMCTRL_SECCTRL) Write Key Position  */
+#define NVMCTRL_SECCTRL_MASK                _U_(0xFF00074D)                                /**< \deprecated (NVMCTRL_SECCTRL) Register MASK  (Use NVMCTRL_SECCTRL_Msk instead)  */
+#define NVMCTRL_SECCTRL_Msk                 _U_(0xFF00074D)                                /**< (NVMCTRL_SECCTRL) Register Mask  */
+
+
+/* -------- NVMCTRL_SCFGB : (NVMCTRL Offset: 0x38) (R/W 32) Secure Boot Configuration -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t BCREN:1;                   /**< bit:      0  Boot Configuration Row Read Enable       */
+    uint32_t BCWEN:1;                   /**< bit:      1  Boot Configuration Row Write Enable      */
+    uint32_t :30;                       /**< bit:  2..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} NVMCTRL_SCFGB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_SCFGB_OFFSET                (0x38)                                        /**<  (NVMCTRL_SCFGB) Secure Boot Configuration  Offset */
+#define NVMCTRL_SCFGB_RESETVALUE            _U_(0x03)                                     /**<  (NVMCTRL_SCFGB) Secure Boot Configuration  Reset Value */
+
+#define NVMCTRL_SCFGB_BCREN_Pos             0                                              /**< (NVMCTRL_SCFGB) Boot Configuration Row Read Enable Position */
+#define NVMCTRL_SCFGB_BCREN_Msk             (_U_(0x1) << NVMCTRL_SCFGB_BCREN_Pos)          /**< (NVMCTRL_SCFGB) Boot Configuration Row Read Enable Mask */
+#define NVMCTRL_SCFGB_BCREN                 NVMCTRL_SCFGB_BCREN_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_SCFGB_BCREN_Msk instead */
+#define NVMCTRL_SCFGB_BCWEN_Pos             1                                              /**< (NVMCTRL_SCFGB) Boot Configuration Row Write Enable Position */
+#define NVMCTRL_SCFGB_BCWEN_Msk             (_U_(0x1) << NVMCTRL_SCFGB_BCWEN_Pos)          /**< (NVMCTRL_SCFGB) Boot Configuration Row Write Enable Mask */
+#define NVMCTRL_SCFGB_BCWEN                 NVMCTRL_SCFGB_BCWEN_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_SCFGB_BCWEN_Msk instead */
+#define NVMCTRL_SCFGB_MASK                  _U_(0x03)                                      /**< \deprecated (NVMCTRL_SCFGB) Register MASK  (Use NVMCTRL_SCFGB_Msk instead)  */
+#define NVMCTRL_SCFGB_Msk                   _U_(0x03)                                      /**< (NVMCTRL_SCFGB) Register Mask  */
+
+
+/* -------- NVMCTRL_SCFGAD : (NVMCTRL Offset: 0x3c) (R/W 32) Secure Application and Data Configuration -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t URWEN:1;                   /**< bit:      0  User Row Write Enable                    */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} NVMCTRL_SCFGAD_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_SCFGAD_OFFSET               (0x3C)                                        /**<  (NVMCTRL_SCFGAD) Secure Application and Data Configuration  Offset */
+#define NVMCTRL_SCFGAD_RESETVALUE           _U_(0x01)                                     /**<  (NVMCTRL_SCFGAD) Secure Application and Data Configuration  Reset Value */
+
+#define NVMCTRL_SCFGAD_URWEN_Pos            0                                              /**< (NVMCTRL_SCFGAD) User Row Write Enable Position */
+#define NVMCTRL_SCFGAD_URWEN_Msk            (_U_(0x1) << NVMCTRL_SCFGAD_URWEN_Pos)         /**< (NVMCTRL_SCFGAD) User Row Write Enable Mask */
+#define NVMCTRL_SCFGAD_URWEN                NVMCTRL_SCFGAD_URWEN_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_SCFGAD_URWEN_Msk instead */
+#define NVMCTRL_SCFGAD_MASK                 _U_(0x01)                                      /**< \deprecated (NVMCTRL_SCFGAD) Register MASK  (Use NVMCTRL_SCFGAD_Msk instead)  */
+#define NVMCTRL_SCFGAD_Msk                  _U_(0x01)                                      /**< (NVMCTRL_SCFGAD) Register Mask  */
+
+
+/* -------- NVMCTRL_NONSEC : (NVMCTRL Offset: 0x40) (R/W 32) Non-secure Write Enable -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t WRITE:1;                   /**< bit:      0  Non-secure APB alias write enable, non-secure AHB writes to non-secure regions enable */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} NVMCTRL_NONSEC_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_NONSEC_OFFSET               (0x40)                                        /**<  (NVMCTRL_NONSEC) Non-secure Write Enable  Offset */
+#define NVMCTRL_NONSEC_RESETVALUE           _U_(0x01)                                     /**<  (NVMCTRL_NONSEC) Non-secure Write Enable  Reset Value */
+
+#define NVMCTRL_NONSEC_WRITE_Pos            0                                              /**< (NVMCTRL_NONSEC) Non-secure APB alias write enable, non-secure AHB writes to non-secure regions enable Position */
+#define NVMCTRL_NONSEC_WRITE_Msk            (_U_(0x1) << NVMCTRL_NONSEC_WRITE_Pos)         /**< (NVMCTRL_NONSEC) Non-secure APB alias write enable, non-secure AHB writes to non-secure regions enable Mask */
+#define NVMCTRL_NONSEC_WRITE                NVMCTRL_NONSEC_WRITE_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_NONSEC_WRITE_Msk instead */
+#define NVMCTRL_NONSEC_MASK                 _U_(0x01)                                      /**< \deprecated (NVMCTRL_NONSEC) Register MASK  (Use NVMCTRL_NONSEC_Msk instead)  */
+#define NVMCTRL_NONSEC_Msk                  _U_(0x01)                                      /**< (NVMCTRL_NONSEC) Register Mask  */
+
+
+/* -------- NVMCTRL_NSCHK : (NVMCTRL Offset: 0x44) (R/W 32) Non-secure Write Reference Value -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t WRITE:1;                   /**< bit:      0  Reference value to be checked against NONSEC.WRITE */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} NVMCTRL_NSCHK_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_NSCHK_OFFSET                (0x44)                                        /**<  (NVMCTRL_NSCHK) Non-secure Write Reference Value  Offset */
+#define NVMCTRL_NSCHK_RESETVALUE            _U_(0x01)                                     /**<  (NVMCTRL_NSCHK) Non-secure Write Reference Value  Reset Value */
+
+#define NVMCTRL_NSCHK_WRITE_Pos             0                                              /**< (NVMCTRL_NSCHK) Reference value to be checked against NONSEC.WRITE Position */
+#define NVMCTRL_NSCHK_WRITE_Msk             (_U_(0x1) << NVMCTRL_NSCHK_WRITE_Pos)          /**< (NVMCTRL_NSCHK) Reference value to be checked against NONSEC.WRITE Mask */
+#define NVMCTRL_NSCHK_WRITE                 NVMCTRL_NSCHK_WRITE_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use NVMCTRL_NSCHK_WRITE_Msk instead */
+#define NVMCTRL_NSCHK_MASK                  _U_(0x01)                                      /**< \deprecated (NVMCTRL_NSCHK) Register MASK  (Use NVMCTRL_NSCHK_Msk instead)  */
+#define NVMCTRL_NSCHK_Msk                   _U_(0x01)                                      /**< (NVMCTRL_NSCHK) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief NVMCTRL hardware registers */
+typedef struct {  /* Non-Volatile Memory Controller */
+  __O  NVMCTRL_CTRLA_Type             CTRLA;          /**< Offset: 0x00 ( /W  16) Control A */
+  __I  uint8_t                        Reserved1[2];
+  __IO NVMCTRL_CTRLB_Type             CTRLB;          /**< Offset: 0x04 (R/W  32) Control B */
+  __IO NVMCTRL_CTRLC_Type             CTRLC;          /**< Offset: 0x08 (R/W   8) Control C */
+  __I  uint8_t                        Reserved2[1];
+  __IO NVMCTRL_EVCTRL_Type            EVCTRL;         /**< Offset: 0x0A (R/W   8) Event Control */
+  __I  uint8_t                        Reserved3[1];
+  __IO NVMCTRL_INTENCLR_Type          INTENCLR;       /**< Offset: 0x0C (R/W   8) Interrupt Enable Clear */
+  __I  uint8_t                        Reserved4[3];
+  __IO NVMCTRL_INTENSET_Type          INTENSET;       /**< Offset: 0x10 (R/W   8) Interrupt Enable Set */
+  __I  uint8_t                        Reserved5[3];
+  __IO NVMCTRL_INTFLAG_Type           INTFLAG;        /**< Offset: 0x14 (R/W   8) Interrupt Flag Status and Clear */
+  __I  uint8_t                        Reserved6[3];
+  __I  NVMCTRL_STATUS_Type            STATUS;         /**< Offset: 0x18 (R/   16) Status */
+  __I  uint8_t                        Reserved7[2];
+  __IO NVMCTRL_ADDR_Type              ADDR;           /**< Offset: 0x1C (R/W  32) Address */
+  __IO NVMCTRL_SULCK_Type             SULCK;          /**< Offset: 0x20 (R/W  16) Secure Unlock Register */
+  __IO NVMCTRL_NSULCK_Type            NSULCK;         /**< Offset: 0x22 (R/W  16) Non-Secure Unlock Register */
+  __IO NVMCTRL_PARAM_Type             PARAM;          /**< Offset: 0x24 (R/W  32) NVM Parameter */
+  __I  uint8_t                        Reserved8[8];
+  __O  NVMCTRL_DSCC_Type              DSCC;           /**< Offset: 0x30 ( /W  32) Data Scramble Configuration */
+  __IO NVMCTRL_SECCTRL_Type           SECCTRL;        /**< Offset: 0x34 (R/W  32) Security Control */
+  __IO NVMCTRL_SCFGB_Type             SCFGB;          /**< Offset: 0x38 (R/W  32) Secure Boot Configuration */
+  __IO NVMCTRL_SCFGAD_Type            SCFGAD;         /**< Offset: 0x3C (R/W  32) Secure Application and Data Configuration */
+  __IO NVMCTRL_NONSEC_Type            NONSEC;         /**< Offset: 0x40 (R/W  32) Non-secure Write Enable */
+  __IO NVMCTRL_NSCHK_Type             NSCHK;          /**< Offset: 0x44 (R/W  32) Non-secure Write Reference Value */
+} Nvmctrl;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+#if defined (__GNUC__) || defined (__CC_ARM)
+  #define SECTION_AUX                  __attribute__ ((section(".flash")))
+  #define SECTION_BOCOR                __attribute__ ((section(".flash")))
+  #define SECTION_DATAFLASH            __attribute__ ((section(".flash")))
+  #define SECTION_SW_CALIB             __attribute__ ((section(".flash")))
+  #define SECTION_TEMP_LOG             __attribute__ ((section(".flash")))
+  #define SECTION_USER_PAGE            __attribute__ ((section(".flash")))
+
+#elif defined(__ICCARM__)
+  #define SECTION_AUX                  @".flash"
+  #define SECTION_BOCOR                @".flash"
+  #define SECTION_DATAFLASH            @".flash"
+  #define SECTION_SW_CALIB             @".flash"
+  #define SECTION_TEMP_LOG             @".flash"
+  #define SECTION_USER_PAGE            @".flash"
+
+#endif
+  #define SECTION_NVMCTRL_AUX          SECTION_AUX          /**< \brief \deprecated Old style definition. Use SECTION_AUX instead */
+  #define SECTION_NVMCTRL_BOCOR        SECTION_BOCOR        /**< \brief \deprecated Old style definition. Use SECTION_BOCOR instead */
+  #define SECTION_NVMCTRL_DATAFLASH    SECTION_DATAFLASH    /**< \brief \deprecated Old style definition. Use SECTION_DATAFLASH instead */
+  #define SECTION_NVMCTRL_SW_CALIB     SECTION_SW_CALIB     /**< \brief \deprecated Old style definition. Use SECTION_SW_CALIB instead */
+  #define SECTION_NVMCTRL_TEMP_LOG     SECTION_TEMP_LOG     /**< \brief \deprecated Old style definition. Use SECTION_TEMP_LOG instead */
+  #define SECTION_NVMCTRL_USER         SECTION_USER_PAGE    /**< \brief \deprecated Old style definition. Use SECTION_USER_PAGE instead */
+
+/** @}  end of Non-Volatile Memory Controller */
+
+/** \addtogroup fuses_api Peripheral Software API
+ *  @{
+ */
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR NON-VOLATILE FUSES */
+/* ************************************************************************** */
+#define ADC_FUSES_BIASCOMP_ADDR     SW_CALIB_ADDR
+#define ADC_FUSES_BIASCOMP_Pos      3            /**< \brief (SW_CALIB_ADDR) ADC Comparator Scaling */
+#define ADC_FUSES_BIASCOMP_Msk      (_U_(0x7) << ADC_FUSES_BIASCOMP_Pos)
+#define ADC_FUSES_BIASCOMP(value)   (ADC_FUSES_BIASCOMP_Msk & ((value) << ADC_FUSES_BIASCOMP_Pos))
+
+#define ADC_FUSES_BIASREFBUF_ADDR   SW_CALIB_ADDR
+#define ADC_FUSES_BIASREFBUF_Pos    0            /**< \brief (SW_CALIB_ADDR) ADC Bias Reference Buffer Scaling */
+#define ADC_FUSES_BIASREFBUF_Msk    (_U_(0x7) << ADC_FUSES_BIASREFBUF_Pos)
+#define ADC_FUSES_BIASREFBUF(value) (ADC_FUSES_BIASREFBUF_Msk & ((value) << ADC_FUSES_BIASREFBUF_Pos))
+
+#define FUSES_BOD33USERLEVEL_ADDR   USER_PAGE_ADDR
+#define FUSES_BOD33USERLEVEL_Pos    7            /**< \brief (USER_PAGE_ADDR) BOD33 User Level */
+#define FUSES_BOD33USERLEVEL_Msk    (_U_(0x3F) << FUSES_BOD33USERLEVEL_Pos)
+#define FUSES_BOD33USERLEVEL(value) (FUSES_BOD33USERLEVEL_Msk & ((value) << FUSES_BOD33USERLEVEL_Pos))
+
+#define FUSES_BOD33_ACTION_ADDR     USER_PAGE_ADDR
+#define FUSES_BOD33_ACTION_Pos      14           /**< \brief (USER_PAGE_ADDR) BOD33 Action */
+#define FUSES_BOD33_ACTION_Msk      (_U_(0x3) << FUSES_BOD33_ACTION_Pos)
+#define FUSES_BOD33_ACTION(value)   (FUSES_BOD33_ACTION_Msk & ((value) << FUSES_BOD33_ACTION_Pos))
+
+#define FUSES_BOD33_DIS_ADDR        USER_PAGE_ADDR
+#define FUSES_BOD33_DIS_Pos         13           /**< \brief (USER_PAGE_ADDR) BOD33 Disable */
+#define FUSES_BOD33_DIS_Msk         (_U_(0x1) << FUSES_BOD33_DIS_Pos)
+
+#define FUSES_BOD33_HYST_ADDR       (USER_PAGE_ADDR + 4)
+#define FUSES_BOD33_HYST_Pos        9            /**< \brief (USER_PAGE_ADDR) BOD33 Hysteresis */
+#define FUSES_BOD33_HYST_Msk        (_U_(0x1) << FUSES_BOD33_HYST_Pos)
+
+#define FUSES_BOOTROM_BOCORCRC_ADDR (BOCOR_ADDR + 8)
+#define FUSES_BOOTROM_BOCORCRC_Pos  0            /**< \brief (BOCOR_ADDR) CRC for BOCOR0 DWORD */
+#define FUSES_BOOTROM_BOCORCRC_Msk  (_U_(0xFFFFFFFF) << FUSES_BOOTROM_BOCORCRC_Pos)
+#define FUSES_BOOTROM_BOCORCRC(value) (FUSES_BOOTROM_BOCORCRC_Msk & ((value) << FUSES_BOOTROM_BOCORCRC_Pos))
+
+#define FUSES_BOOTROM_BOCORHASH_0_ADDR (BOCOR_ADDR + 224)
+#define FUSES_BOOTROM_BOCORHASH_0_Pos 0            /**< \brief (BOCOR_ADDR) Boot Configuration Row Hash bits 31:0 */
+#define FUSES_BOOTROM_BOCORHASH_0_Msk (_U_(0xFFFFFFFF) << FUSES_BOOTROM_BOCORHASH_0_Pos)
+#define FUSES_BOOTROM_BOCORHASH_0(value) (FUSES_BOOTROM_BOCORHASH_0_Msk & ((value) << FUSES_BOOTROM_BOCORHASH_0_Pos))
+
+#define FUSES_BOOTROM_BOCORHASH_1_ADDR (BOCOR_ADDR + 228)
+#define FUSES_BOOTROM_BOCORHASH_1_Pos 0            /**< \brief (BOCOR_ADDR) Boot Configuration Row Hash bits 63:32 */
+#define FUSES_BOOTROM_BOCORHASH_1_Msk (_U_(0xFFFFFFFF) << FUSES_BOOTROM_BOCORHASH_1_Pos)
+#define FUSES_BOOTROM_BOCORHASH_1(value) (FUSES_BOOTROM_BOCORHASH_1_Msk & ((value) << FUSES_BOOTROM_BOCORHASH_1_Pos))
+
+#define FUSES_BOOTROM_BOCORHASH_2_ADDR (BOCOR_ADDR + 232)
+#define FUSES_BOOTROM_BOCORHASH_2_Pos 0            /**< \brief (BOCOR_ADDR) Boot Configuration Row Hash bits 95:64 */
+#define FUSES_BOOTROM_BOCORHASH_2_Msk (_U_(0xFFFFFFFF) << FUSES_BOOTROM_BOCORHASH_2_Pos)
+#define FUSES_BOOTROM_BOCORHASH_2(value) (FUSES_BOOTROM_BOCORHASH_2_Msk & ((value) << FUSES_BOOTROM_BOCORHASH_2_Pos))
+
+#define FUSES_BOOTROM_BOCORHASH_3_ADDR (BOCOR_ADDR + 236)
+#define FUSES_BOOTROM_BOCORHASH_3_Pos 0            /**< \brief (BOCOR_ADDR) Boot Configuration Row Hash bits 127:96 */
+#define FUSES_BOOTROM_BOCORHASH_3_Msk (_U_(0xFFFFFFFF) << FUSES_BOOTROM_BOCORHASH_3_Pos)
+#define FUSES_BOOTROM_BOCORHASH_3(value) (FUSES_BOOTROM_BOCORHASH_3_Msk & ((value) << FUSES_BOOTROM_BOCORHASH_3_Pos))
+
+#define FUSES_BOOTROM_BOCORHASH_4_ADDR (BOCOR_ADDR + 240)
+#define FUSES_BOOTROM_BOCORHASH_4_Pos 0            /**< \brief (BOCOR_ADDR) Boot Configuration Row Hash bits 159:128 */
+#define FUSES_BOOTROM_BOCORHASH_4_Msk (_U_(0xFFFFFFFF) << FUSES_BOOTROM_BOCORHASH_4_Pos)
+#define FUSES_BOOTROM_BOCORHASH_4(value) (FUSES_BOOTROM_BOCORHASH_4_Msk & ((value) << FUSES_BOOTROM_BOCORHASH_4_Pos))
+
+#define FUSES_BOOTROM_BOCORHASH_5_ADDR (BOCOR_ADDR + 244)
+#define FUSES_BOOTROM_BOCORHASH_5_Pos 0            /**< \brief (BOCOR_ADDR) Boot Configuration Row Hash bits 191:160 */
+#define FUSES_BOOTROM_BOCORHASH_5_Msk (_U_(0xFFFFFFFF) << FUSES_BOOTROM_BOCORHASH_5_Pos)
+#define FUSES_BOOTROM_BOCORHASH_5(value) (FUSES_BOOTROM_BOCORHASH_5_Msk & ((value) << FUSES_BOOTROM_BOCORHASH_5_Pos))
+
+#define FUSES_BOOTROM_BOCORHASH_6_ADDR (BOCOR_ADDR + 248)
+#define FUSES_BOOTROM_BOCORHASH_6_Pos 0            /**< \brief (BOCOR_ADDR) Boot Configuration Row Hash bits 223:192 */
+#define FUSES_BOOTROM_BOCORHASH_6_Msk (_U_(0xFFFFFFFF) << FUSES_BOOTROM_BOCORHASH_6_Pos)
+#define FUSES_BOOTROM_BOCORHASH_6(value) (FUSES_BOOTROM_BOCORHASH_6_Msk & ((value) << FUSES_BOOTROM_BOCORHASH_6_Pos))
+
+#define FUSES_BOOTROM_BOCORHASH_7_ADDR (BOCOR_ADDR + 252)
+#define FUSES_BOOTROM_BOCORHASH_7_Pos 0            /**< \brief (BOCOR_ADDR) Boot Configuration Row Hash bits 255:224 */
+#define FUSES_BOOTROM_BOCORHASH_7_Msk (_U_(0xFFFFFFFF) << FUSES_BOOTROM_BOCORHASH_7_Pos)
+#define FUSES_BOOTROM_BOCORHASH_7(value) (FUSES_BOOTROM_BOCORHASH_7_Msk & ((value) << FUSES_BOOTROM_BOCORHASH_7_Pos))
+
+#define FUSES_BOOTROM_BOOTKEY_0_ADDR (BOCOR_ADDR + 80)
+#define FUSES_BOOTROM_BOOTKEY_0_Pos 0            /**< \brief (BOCOR_ADDR) Secure Boot Key bits 31:0 */
+#define FUSES_BOOTROM_BOOTKEY_0_Msk (_U_(0xFFFFFFFF) << FUSES_BOOTROM_BOOTKEY_0_Pos)
+#define FUSES_BOOTROM_BOOTKEY_0(value) (FUSES_BOOTROM_BOOTKEY_0_Msk & ((value) << FUSES_BOOTROM_BOOTKEY_0_Pos))
+
+#define FUSES_BOOTROM_BOOTKEY_1_ADDR (BOCOR_ADDR + 84)
+#define FUSES_BOOTROM_BOOTKEY_1_Pos 0            /**< \brief (BOCOR_ADDR) Secure Boot Key bits 63:32 */
+#define FUSES_BOOTROM_BOOTKEY_1_Msk (_U_(0xFFFFFFFF) << FUSES_BOOTROM_BOOTKEY_1_Pos)
+#define FUSES_BOOTROM_BOOTKEY_1(value) (FUSES_BOOTROM_BOOTKEY_1_Msk & ((value) << FUSES_BOOTROM_BOOTKEY_1_Pos))
+
+#define FUSES_BOOTROM_BOOTKEY_2_ADDR (BOCOR_ADDR + 88)
+#define FUSES_BOOTROM_BOOTKEY_2_Pos 0            /**< \brief (BOCOR_ADDR) Secure Boot Key bits 95:64 */
+#define FUSES_BOOTROM_BOOTKEY_2_Msk (_U_(0xFFFFFFFF) << FUSES_BOOTROM_BOOTKEY_2_Pos)
+#define FUSES_BOOTROM_BOOTKEY_2(value) (FUSES_BOOTROM_BOOTKEY_2_Msk & ((value) << FUSES_BOOTROM_BOOTKEY_2_Pos))
+
+#define FUSES_BOOTROM_BOOTKEY_3_ADDR (BOCOR_ADDR + 92)
+#define FUSES_BOOTROM_BOOTKEY_3_Pos 0            /**< \brief (BOCOR_ADDR) Secure Boot Key bits 127:96 */
+#define FUSES_BOOTROM_BOOTKEY_3_Msk (_U_(0xFFFFFFFF) << FUSES_BOOTROM_BOOTKEY_3_Pos)
+#define FUSES_BOOTROM_BOOTKEY_3(value) (FUSES_BOOTROM_BOOTKEY_3_Msk & ((value) << FUSES_BOOTROM_BOOTKEY_3_Pos))
+
+#define FUSES_BOOTROM_BOOTKEY_4_ADDR (BOCOR_ADDR + 96)
+#define FUSES_BOOTROM_BOOTKEY_4_Pos 0            /**< \brief (BOCOR_ADDR) Secure Boot Key bits 159:128 */
+#define FUSES_BOOTROM_BOOTKEY_4_Msk (_U_(0xFFFFFFFF) << FUSES_BOOTROM_BOOTKEY_4_Pos)
+#define FUSES_BOOTROM_BOOTKEY_4(value) (FUSES_BOOTROM_BOOTKEY_4_Msk & ((value) << FUSES_BOOTROM_BOOTKEY_4_Pos))
+
+#define FUSES_BOOTROM_BOOTKEY_5_ADDR (BOCOR_ADDR + 100)
+#define FUSES_BOOTROM_BOOTKEY_5_Pos 0            /**< \brief (BOCOR_ADDR) Secure Boot Key bits 191:160 */
+#define FUSES_BOOTROM_BOOTKEY_5_Msk (_U_(0xFFFFFFFF) << FUSES_BOOTROM_BOOTKEY_5_Pos)
+#define FUSES_BOOTROM_BOOTKEY_5(value) (FUSES_BOOTROM_BOOTKEY_5_Msk & ((value) << FUSES_BOOTROM_BOOTKEY_5_Pos))
+
+#define FUSES_BOOTROM_BOOTKEY_6_ADDR (BOCOR_ADDR + 104)
+#define FUSES_BOOTROM_BOOTKEY_6_Pos 0            /**< \brief (BOCOR_ADDR) Secure Boot Key bits 223:192 */
+#define FUSES_BOOTROM_BOOTKEY_6_Msk (_U_(0xFFFFFFFF) << FUSES_BOOTROM_BOOTKEY_6_Pos)
+#define FUSES_BOOTROM_BOOTKEY_6(value) (FUSES_BOOTROM_BOOTKEY_6_Msk & ((value) << FUSES_BOOTROM_BOOTKEY_6_Pos))
+
+#define FUSES_BOOTROM_BOOTKEY_7_ADDR (BOCOR_ADDR + 108)
+#define FUSES_BOOTROM_BOOTKEY_7_Pos 0            /**< \brief (BOCOR_ADDR) Secure Boot Key bits 255:224 */
+#define FUSES_BOOTROM_BOOTKEY_7_Msk (_U_(0xFFFFFFFF) << FUSES_BOOTROM_BOOTKEY_7_Pos)
+#define FUSES_BOOTROM_BOOTKEY_7(value) (FUSES_BOOTROM_BOOTKEY_7_Msk & ((value) << FUSES_BOOTROM_BOOTKEY_7_Pos))
+
+#define FUSES_BOOTROM_BOOTOPT_ADDR  BOCOR_ADDR
+#define FUSES_BOOTROM_BOOTOPT_Pos   24           /**< \brief (BOCOR_ADDR) Boot Option */
+#define FUSES_BOOTROM_BOOTOPT_Msk   (_U_(0xFF) << FUSES_BOOTROM_BOOTOPT_Pos)
+#define FUSES_BOOTROM_BOOTOPT(value) (FUSES_BOOTROM_BOOTOPT_Msk & ((value) << FUSES_BOOTROM_BOOTOPT_Pos))
+
+#define FUSES_BOOTROM_CEKEY0_0_ADDR (BOCOR_ADDR + 16)
+#define FUSES_BOOTROM_CEKEY0_0_Pos  0            /**< \brief (BOCOR_ADDR) Chip Erase Key 0 bits 31:0 */
+#define FUSES_BOOTROM_CEKEY0_0_Msk  (_U_(0xFFFFFFFF) << FUSES_BOOTROM_CEKEY0_0_Pos)
+#define FUSES_BOOTROM_CEKEY0_0(value) (FUSES_BOOTROM_CEKEY0_0_Msk & ((value) << FUSES_BOOTROM_CEKEY0_0_Pos))
+
+#define FUSES_BOOTROM_CEKEY0_1_ADDR (BOCOR_ADDR + 20)
+#define FUSES_BOOTROM_CEKEY0_1_Pos  0            /**< \brief (BOCOR_ADDR) Chip Erase Key 0 bits 63:32 */
+#define FUSES_BOOTROM_CEKEY0_1_Msk  (_U_(0xFFFFFFFF) << FUSES_BOOTROM_CEKEY0_1_Pos)
+#define FUSES_BOOTROM_CEKEY0_1(value) (FUSES_BOOTROM_CEKEY0_1_Msk & ((value) << FUSES_BOOTROM_CEKEY0_1_Pos))
+
+#define FUSES_BOOTROM_CEKEY0_2_ADDR (BOCOR_ADDR + 24)
+#define FUSES_BOOTROM_CEKEY0_2_Pos  0            /**< \brief (BOCOR_ADDR) Chip Erase Key 0 bits 95:64 */
+#define FUSES_BOOTROM_CEKEY0_2_Msk  (_U_(0xFFFFFFFF) << FUSES_BOOTROM_CEKEY0_2_Pos)
+#define FUSES_BOOTROM_CEKEY0_2(value) (FUSES_BOOTROM_CEKEY0_2_Msk & ((value) << FUSES_BOOTROM_CEKEY0_2_Pos))
+
+#define FUSES_BOOTROM_CEKEY0_3_ADDR (BOCOR_ADDR + 28)
+#define FUSES_BOOTROM_CEKEY0_3_Pos  0            /**< \brief (BOCOR_ADDR) Chip Erase Key 0 bits 127:96 */
+#define FUSES_BOOTROM_CEKEY0_3_Msk  (_U_(0xFFFFFFFF) << FUSES_BOOTROM_CEKEY0_3_Pos)
+#define FUSES_BOOTROM_CEKEY0_3(value) (FUSES_BOOTROM_CEKEY0_3_Msk & ((value) << FUSES_BOOTROM_CEKEY0_3_Pos))
+
+#define FUSES_BOOTROM_CEKEY1_0_ADDR (BOCOR_ADDR + 32)
+#define FUSES_BOOTROM_CEKEY1_0_Pos  0            /**< \brief (BOCOR_ADDR) Chip Erase Key 1 bits 31:0 */
+#define FUSES_BOOTROM_CEKEY1_0_Msk  (_U_(0xFFFFFFFF) << FUSES_BOOTROM_CEKEY1_0_Pos)
+#define FUSES_BOOTROM_CEKEY1_0(value) (FUSES_BOOTROM_CEKEY1_0_Msk & ((value) << FUSES_BOOTROM_CEKEY1_0_Pos))
+
+#define FUSES_BOOTROM_CEKEY1_1_ADDR (BOCOR_ADDR + 36)
+#define FUSES_BOOTROM_CEKEY1_1_Pos  0            /**< \brief (BOCOR_ADDR) Chip Erase Key 1 bits 63:32 */
+#define FUSES_BOOTROM_CEKEY1_1_Msk  (_U_(0xFFFFFFFF) << FUSES_BOOTROM_CEKEY1_1_Pos)
+#define FUSES_BOOTROM_CEKEY1_1(value) (FUSES_BOOTROM_CEKEY1_1_Msk & ((value) << FUSES_BOOTROM_CEKEY1_1_Pos))
+
+#define FUSES_BOOTROM_CEKEY1_2_ADDR (BOCOR_ADDR + 40)
+#define FUSES_BOOTROM_CEKEY1_2_Pos  0            /**< \brief (BOCOR_ADDR) Chip Erase Key 1 bits 95:64 */
+#define FUSES_BOOTROM_CEKEY1_2_Msk  (_U_(0xFFFFFFFF) << FUSES_BOOTROM_CEKEY1_2_Pos)
+#define FUSES_BOOTROM_CEKEY1_2(value) (FUSES_BOOTROM_CEKEY1_2_Msk & ((value) << FUSES_BOOTROM_CEKEY1_2_Pos))
+
+#define FUSES_BOOTROM_CEKEY1_3_ADDR (BOCOR_ADDR + 44)
+#define FUSES_BOOTROM_CEKEY1_3_Pos  0            /**< \brief (BOCOR_ADDR) Chip Erase Key 1 bits 127:96 */
+#define FUSES_BOOTROM_CEKEY1_3_Msk  (_U_(0xFFFFFFFF) << FUSES_BOOTROM_CEKEY1_3_Pos)
+#define FUSES_BOOTROM_CEKEY1_3(value) (FUSES_BOOTROM_CEKEY1_3_Msk & ((value) << FUSES_BOOTROM_CEKEY1_3_Pos))
+
+#define FUSES_BOOTROM_CEKEY2_0_ADDR (BOCOR_ADDR + 48)
+#define FUSES_BOOTROM_CEKEY2_0_Pos  0            /**< \brief (BOCOR_ADDR) Chip Erase Key 2 bits 31:0 */
+#define FUSES_BOOTROM_CEKEY2_0_Msk  (_U_(0xFFFFFFFF) << FUSES_BOOTROM_CEKEY2_0_Pos)
+#define FUSES_BOOTROM_CEKEY2_0(value) (FUSES_BOOTROM_CEKEY2_0_Msk & ((value) << FUSES_BOOTROM_CEKEY2_0_Pos))
+
+#define FUSES_BOOTROM_CEKEY2_1_ADDR (BOCOR_ADDR + 52)
+#define FUSES_BOOTROM_CEKEY2_1_Pos  0            /**< \brief (BOCOR_ADDR) Chip Erase Key 2 bits 63:32 */
+#define FUSES_BOOTROM_CEKEY2_1_Msk  (_U_(0xFFFFFFFF) << FUSES_BOOTROM_CEKEY2_1_Pos)
+#define FUSES_BOOTROM_CEKEY2_1(value) (FUSES_BOOTROM_CEKEY2_1_Msk & ((value) << FUSES_BOOTROM_CEKEY2_1_Pos))
+
+#define FUSES_BOOTROM_CEKEY2_2_ADDR (BOCOR_ADDR + 56)
+#define FUSES_BOOTROM_CEKEY2_2_Pos  0            /**< \brief (BOCOR_ADDR) Chip Erase Key 2 bits 95:64 */
+#define FUSES_BOOTROM_CEKEY2_2_Msk  (_U_(0xFFFFFFFF) << FUSES_BOOTROM_CEKEY2_2_Pos)
+#define FUSES_BOOTROM_CEKEY2_2(value) (FUSES_BOOTROM_CEKEY2_2_Msk & ((value) << FUSES_BOOTROM_CEKEY2_2_Pos))
+
+#define FUSES_BOOTROM_CEKEY2_3_ADDR (BOCOR_ADDR + 60)
+#define FUSES_BOOTROM_CEKEY2_3_Pos  0            /**< \brief (BOCOR_ADDR) Chip Erase Key 2 bits 127:96 */
+#define FUSES_BOOTROM_CEKEY2_3_Msk  (_U_(0xFFFFFFFF) << FUSES_BOOTROM_CEKEY2_3_Pos)
+#define FUSES_BOOTROM_CEKEY2_3(value) (FUSES_BOOTROM_CEKEY2_3_Msk & ((value) << FUSES_BOOTROM_CEKEY2_3_Pos))
+
+#define FUSES_BOOTROM_CRCKEY_0_ADDR (BOCOR_ADDR + 64)
+#define FUSES_BOOTROM_CRCKEY_0_Pos  0            /**< \brief (BOCOR_ADDR) CRC Key bits 31:0 */
+#define FUSES_BOOTROM_CRCKEY_0_Msk  (_U_(0xFFFFFFFF) << FUSES_BOOTROM_CRCKEY_0_Pos)
+#define FUSES_BOOTROM_CRCKEY_0(value) (FUSES_BOOTROM_CRCKEY_0_Msk & ((value) << FUSES_BOOTROM_CRCKEY_0_Pos))
+
+#define FUSES_BOOTROM_CRCKEY_1_ADDR (BOCOR_ADDR + 68)
+#define FUSES_BOOTROM_CRCKEY_1_Pos  0            /**< \brief (BOCOR_ADDR) CRC Key bits 63:32 */
+#define FUSES_BOOTROM_CRCKEY_1_Msk  (_U_(0xFFFFFFFF) << FUSES_BOOTROM_CRCKEY_1_Pos)
+#define FUSES_BOOTROM_CRCKEY_1(value) (FUSES_BOOTROM_CRCKEY_1_Msk & ((value) << FUSES_BOOTROM_CRCKEY_1_Pos))
+
+#define FUSES_BOOTROM_CRCKEY_2_ADDR (BOCOR_ADDR + 72)
+#define FUSES_BOOTROM_CRCKEY_2_Pos  0            /**< \brief (BOCOR_ADDR) CRC Key bits 95:64 */
+#define FUSES_BOOTROM_CRCKEY_2_Msk  (_U_(0xFFFFFFFF) << FUSES_BOOTROM_CRCKEY_2_Pos)
+#define FUSES_BOOTROM_CRCKEY_2(value) (FUSES_BOOTROM_CRCKEY_2_Msk & ((value) << FUSES_BOOTROM_CRCKEY_2_Pos))
+
+#define FUSES_BOOTROM_CRCKEY_3_ADDR (BOCOR_ADDR + 76)
+#define FUSES_BOOTROM_CRCKEY_3_Pos  0            /**< \brief (BOCOR_ADDR) CRC Key bits 127:96 */
+#define FUSES_BOOTROM_CRCKEY_3_Msk  (_U_(0xFFFFFFFF) << FUSES_BOOTROM_CRCKEY_3_Pos)
+#define FUSES_BOOTROM_CRCKEY_3(value) (FUSES_BOOTROM_CRCKEY_3_Msk & ((value) << FUSES_BOOTROM_CRCKEY_3_Pos))
+
+#define FUSES_BOOTROM_DXN_ADDR      (USER_PAGE_ADDR + 4)
+#define FUSES_BOOTROM_DXN_Pos       12           /**< \brief (USER_PAGE_ADDR) DATA FLASH is eXecute Never */
+#define FUSES_BOOTROM_DXN_Msk       (_U_(0x1) << FUSES_BOOTROM_DXN_Pos)
+
+#define FUSES_BOOTROM_NONSECA_ADDR  (USER_PAGE_ADDR + 16)
+#define FUSES_BOOTROM_NONSECA_Pos   0            /**< \brief (USER_PAGE_ADDR) NONSEC fuses for the bridgeA peripherals */
+#define FUSES_BOOTROM_NONSECA_Msk   (_U_(0xFFFFFFFF) << FUSES_BOOTROM_NONSECA_Pos)
+#define FUSES_BOOTROM_NONSECA(value) (FUSES_BOOTROM_NONSECA_Msk & ((value) << FUSES_BOOTROM_NONSECA_Pos))
+
+#define FUSES_BOOTROM_NONSECB_ADDR  (USER_PAGE_ADDR + 20)
+#define FUSES_BOOTROM_NONSECB_Pos   0            /**< \brief (USER_PAGE_ADDR) NONSEC fuses for the bridgeB peripherals */
+#define FUSES_BOOTROM_NONSECB_Msk   (_U_(0xFFFFFFFF) << FUSES_BOOTROM_NONSECB_Pos)
+#define FUSES_BOOTROM_NONSECB(value) (FUSES_BOOTROM_NONSECB_Msk & ((value) << FUSES_BOOTROM_NONSECB_Pos))
+
+#define FUSES_BOOTROM_NONSECC_ADDR  (USER_PAGE_ADDR + 24)
+#define FUSES_BOOTROM_NONSECC_Pos   0            /**< \brief (USER_PAGE_ADDR) NONSEC fuses for the bridgeC peripherals */
+#define FUSES_BOOTROM_NONSECC_Msk   (_U_(0xFFFFFFFF) << FUSES_BOOTROM_NONSECC_Pos)
+#define FUSES_BOOTROM_NONSECC(value) (FUSES_BOOTROM_NONSECC_Msk & ((value) << FUSES_BOOTROM_NONSECC_Pos))
+
+#define FUSES_BOOTROM_ROMVERSION_ADDR (BOCOR_ADDR + 12)
+#define FUSES_BOOTROM_ROMVERSION_Pos 0            /**< \brief (BOCOR_ADDR) BOOTROM Version */
+#define FUSES_BOOTROM_ROMVERSION_Msk (_U_(0xFFFFFFFF) << FUSES_BOOTROM_ROMVERSION_Pos)
+#define FUSES_BOOTROM_ROMVERSION(value) (FUSES_BOOTROM_ROMVERSION_Msk & ((value) << FUSES_BOOTROM_ROMVERSION_Pos))
+
+#define FUSES_BOOTROM_RXN_ADDR      (USER_PAGE_ADDR + 4)
+#define FUSES_BOOTROM_RXN_Pos       11           /**< \brief (USER_PAGE_ADDR) RAM is eXecute Never */
+#define FUSES_BOOTROM_RXN_Msk       (_U_(0x1) << FUSES_BOOTROM_RXN_Pos)
+
+#define FUSES_BOOTROM_USERCRC_ADDR  (USER_PAGE_ADDR + 28)
+#define FUSES_BOOTROM_USERCRC_Pos   0            /**< \brief (USER_PAGE_ADDR) CRC for USER[1,2,3] DWORDS */
+#define FUSES_BOOTROM_USERCRC_Msk   (_U_(0xFFFFFFFF) << FUSES_BOOTROM_USERCRC_Pos)
+#define FUSES_BOOTROM_USERCRC(value) (FUSES_BOOTROM_USERCRC_Msk & ((value) << FUSES_BOOTROM_USERCRC_Pos))
+
+#define FUSES_DFLLULP_DIV_PL0_ADDR  SW_CALIB_ADDR
+#define FUSES_DFLLULP_DIV_PL0_Pos   6            /**< \brief (SW_CALIB_ADDR) DFLLULP DIV at PL0 */
+#define FUSES_DFLLULP_DIV_PL0_Msk   (_U_(0x7) << FUSES_DFLLULP_DIV_PL0_Pos)
+#define FUSES_DFLLULP_DIV_PL0(value) (FUSES_DFLLULP_DIV_PL0_Msk & ((value) << FUSES_DFLLULP_DIV_PL0_Pos))
+
+#define FUSES_DFLLULP_DIV_PL2_ADDR  SW_CALIB_ADDR
+#define FUSES_DFLLULP_DIV_PL2_Pos   9            /**< \brief (SW_CALIB_ADDR) DFLLULP DIV at PL2 */
+#define FUSES_DFLLULP_DIV_PL2_Msk   (_U_(0x7) << FUSES_DFLLULP_DIV_PL2_Pos)
+#define FUSES_DFLLULP_DIV_PL2(value) (FUSES_DFLLULP_DIV_PL2_Msk & ((value) << FUSES_DFLLULP_DIV_PL2_Pos))
+
+#define FUSES_HOT_ADC_VAL_PTAT_ADDR (TEMP_LOG_ADDR + 4)
+#define FUSES_HOT_ADC_VAL_PTAT_Pos  20           /**< \brief (TEMP_LOG_ADDR) 12-bit ADC conversion at hot temperature PTAT */
+#define FUSES_HOT_ADC_VAL_PTAT_Msk  (_U_(0xFFF) << FUSES_HOT_ADC_VAL_PTAT_Pos)
+#define FUSES_HOT_ADC_VAL_PTAT(value) (FUSES_HOT_ADC_VAL_PTAT_Msk & ((value) << FUSES_HOT_ADC_VAL_PTAT_Pos))
+
+#define FUSES_HOT_INT1V_VAL_ADDR    (TEMP_LOG_ADDR + 4)
+#define FUSES_HOT_INT1V_VAL_Pos     0            /**< \brief (TEMP_LOG_ADDR) 2's complement of the internal 1V reference drift at hot temperature (versus a 1.0 centered value) */
+#define FUSES_HOT_INT1V_VAL_Msk     (_U_(0xFF) << FUSES_HOT_INT1V_VAL_Pos)
+#define FUSES_HOT_INT1V_VAL(value)  (FUSES_HOT_INT1V_VAL_Msk & ((value) << FUSES_HOT_INT1V_VAL_Pos))
+
+#define FUSES_HOT_TEMP_VAL_DEC_ADDR TEMP_LOG_ADDR
+#define FUSES_HOT_TEMP_VAL_DEC_Pos  20           /**< \brief (TEMP_LOG_ADDR) Decimal part of hot temperature */
+#define FUSES_HOT_TEMP_VAL_DEC_Msk  (_U_(0xF) << FUSES_HOT_TEMP_VAL_DEC_Pos)
+#define FUSES_HOT_TEMP_VAL_DEC(value) (FUSES_HOT_TEMP_VAL_DEC_Msk & ((value) << FUSES_HOT_TEMP_VAL_DEC_Pos))
+
+#define FUSES_HOT_TEMP_VAL_INT_ADDR TEMP_LOG_ADDR
+#define FUSES_HOT_TEMP_VAL_INT_Pos  12           /**< \brief (TEMP_LOG_ADDR) Integer part of hot temperature in oC */
+#define FUSES_HOT_TEMP_VAL_INT_Msk  (_U_(0xFF) << FUSES_HOT_TEMP_VAL_INT_Pos)
+#define FUSES_HOT_TEMP_VAL_INT(value) (FUSES_HOT_TEMP_VAL_INT_Msk & ((value) << FUSES_HOT_TEMP_VAL_INT_Pos))
+
+#define FUSES_ROOM_ADC_VAL_PTAT_ADDR (TEMP_LOG_ADDR + 4)
+#define FUSES_ROOM_ADC_VAL_PTAT_Pos 8            /**< \brief (TEMP_LOG_ADDR) 12-bit ADC conversion at room temperature PTAT */
+#define FUSES_ROOM_ADC_VAL_PTAT_Msk (_U_(0xFFF) << FUSES_ROOM_ADC_VAL_PTAT_Pos)
+#define FUSES_ROOM_ADC_VAL_PTAT(value) (FUSES_ROOM_ADC_VAL_PTAT_Msk & ((value) << FUSES_ROOM_ADC_VAL_PTAT_Pos))
+
+#define FUSES_ROOM_INT1V_VAL_ADDR   TEMP_LOG_ADDR
+#define FUSES_ROOM_INT1V_VAL_Pos    24           /**< \brief (TEMP_LOG_ADDR) 2's complement of the internal 1V reference drift at room temperature (versus a 1.0 centered value) */
+#define FUSES_ROOM_INT1V_VAL_Msk    (_U_(0xFF) << FUSES_ROOM_INT1V_VAL_Pos)
+#define FUSES_ROOM_INT1V_VAL(value) (FUSES_ROOM_INT1V_VAL_Msk & ((value) << FUSES_ROOM_INT1V_VAL_Pos))
+
+#define FUSES_ROOM_TEMP_VAL_DEC_ADDR TEMP_LOG_ADDR
+#define FUSES_ROOM_TEMP_VAL_DEC_Pos 8            /**< \brief (TEMP_LOG_ADDR) Decimal part of room temperature */
+#define FUSES_ROOM_TEMP_VAL_DEC_Msk (_U_(0xF) << FUSES_ROOM_TEMP_VAL_DEC_Pos)
+#define FUSES_ROOM_TEMP_VAL_DEC(value) (FUSES_ROOM_TEMP_VAL_DEC_Msk & ((value) << FUSES_ROOM_TEMP_VAL_DEC_Pos))
+
+#define FUSES_ROOM_TEMP_VAL_INT_ADDR TEMP_LOG_ADDR
+#define FUSES_ROOM_TEMP_VAL_INT_Pos 0            /**< \brief (TEMP_LOG_ADDR) Integer part of room temperature in oC */
+#define FUSES_ROOM_TEMP_VAL_INT_Msk (_U_(0xFF) << FUSES_ROOM_TEMP_VAL_INT_Pos)
+#define FUSES_ROOM_TEMP_VAL_INT(value) (FUSES_ROOM_TEMP_VAL_INT_Msk & ((value) << FUSES_ROOM_TEMP_VAL_INT_Pos))
+
+#define NVMCTRL_FUSES_BCREN_ADDR    (BOCOR_ADDR + 4)
+#define NVMCTRL_FUSES_BCREN_Pos     17           /**< \brief (BOCOR_ADDR) Boot Configuration Read Enable */
+#define NVMCTRL_FUSES_BCREN_Msk     (_U_(0x1) << NVMCTRL_FUSES_BCREN_Pos)
+
+#define NVMCTRL_FUSES_BCWEN_ADDR    (BOCOR_ADDR + 4)
+#define NVMCTRL_FUSES_BCWEN_Pos     16           /**< \brief (BOCOR_ADDR) Boot Configuration Write Enable */
+#define NVMCTRL_FUSES_BCWEN_Msk     (_U_(0x1) << NVMCTRL_FUSES_BCWEN_Pos)
+
+#define NVMCTRL_FUSES_NSULCK_ADDR   USER_PAGE_ADDR
+#define NVMCTRL_FUSES_NSULCK_Pos    3            /**< \brief (USER_PAGE_ADDR) NVM Non-Secure Region Locks */
+#define NVMCTRL_FUSES_NSULCK_Msk    (_U_(0x7) << NVMCTRL_FUSES_NSULCK_Pos)
+#define NVMCTRL_FUSES_NSULCK(value) (NVMCTRL_FUSES_NSULCK_Msk & ((value) << NVMCTRL_FUSES_NSULCK_Pos))
+
+#define NVMCTRL_FUSES_SULCK_ADDR    USER_PAGE_ADDR
+#define NVMCTRL_FUSES_SULCK_Pos     0            /**< \brief (USER_PAGE_ADDR) NVM Secure Region Locks */
+#define NVMCTRL_FUSES_SULCK_Msk     (_U_(0x7) << NVMCTRL_FUSES_SULCK_Pos)
+#define NVMCTRL_FUSES_SULCK(value)  (NVMCTRL_FUSES_SULCK_Msk & ((value) << NVMCTRL_FUSES_SULCK_Pos))
+
+#define NVMCTRL_FUSES_URWEN_ADDR    (USER_PAGE_ADDR + 12)
+#define NVMCTRL_FUSES_URWEN_Pos     0            /**< \brief (USER_PAGE_ADDR) User Row Write Enable */
+#define NVMCTRL_FUSES_URWEN_Msk     (_U_(0x1) << NVMCTRL_FUSES_URWEN_Pos)
+
+#define WDT_FUSES_ALWAYSON_ADDR     USER_PAGE_ADDR
+#define WDT_FUSES_ALWAYSON_Pos      27           /**< \brief (USER_PAGE_ADDR) WDT Always On */
+#define WDT_FUSES_ALWAYSON_Msk      (_U_(0x1) << WDT_FUSES_ALWAYSON_Pos)
+
+#define WDT_FUSES_ENABLE_ADDR       USER_PAGE_ADDR
+#define WDT_FUSES_ENABLE_Pos        26           /**< \brief (USER_PAGE_ADDR) WDT Enable */
+#define WDT_FUSES_ENABLE_Msk        (_U_(0x1) << WDT_FUSES_ENABLE_Pos)
+
+#define WDT_FUSES_EWOFFSET_ADDR     (USER_PAGE_ADDR + 4)
+#define WDT_FUSES_EWOFFSET_Pos      4            /**< \brief (USER_PAGE_ADDR) WDT Early Warning Offset */
+#define WDT_FUSES_EWOFFSET_Msk      (_U_(0xF) << WDT_FUSES_EWOFFSET_Pos)
+#define WDT_FUSES_EWOFFSET(value)   (WDT_FUSES_EWOFFSET_Msk & ((value) << WDT_FUSES_EWOFFSET_Pos))
+
+#define WDT_FUSES_PER_ADDR          USER_PAGE_ADDR
+#define WDT_FUSES_PER_Pos           28           /**< \brief (USER_PAGE_ADDR) WDT Period */
+#define WDT_FUSES_PER_Msk           (_U_(0xF) << WDT_FUSES_PER_Pos)
+#define WDT_FUSES_PER(value)        (WDT_FUSES_PER_Msk & ((value) << WDT_FUSES_PER_Pos))
+
+#define WDT_FUSES_RUNSTDBY_ADDR     USER_PAGE_ADDR
+#define WDT_FUSES_RUNSTDBY_Pos      25           /**< \brief (USER_PAGE_ADDR) WDT Run During Standby */
+#define WDT_FUSES_RUNSTDBY_Msk      (_U_(0x1) << WDT_FUSES_RUNSTDBY_Pos)
+
+#define WDT_FUSES_WEN_ADDR          (USER_PAGE_ADDR + 4)
+#define WDT_FUSES_WEN_Pos           8            /**< \brief (USER_PAGE_ADDR) WDT Window Mode Enable */
+#define WDT_FUSES_WEN_Msk           (_U_(0x1) << WDT_FUSES_WEN_Pos)
+
+#define WDT_FUSES_WINDOW_ADDR       (USER_PAGE_ADDR + 4)
+#define WDT_FUSES_WINDOW_Pos        0            /**< \brief (USER_PAGE_ADDR) WDT Window */
+#define WDT_FUSES_WINDOW_Msk        (_U_(0xF) << WDT_FUSES_WINDOW_Pos)
+#define WDT_FUSES_WINDOW(value)     (WDT_FUSES_WINDOW_Msk & ((value) << WDT_FUSES_WINDOW_Pos))
+
+/** @}  end of Peripheral Software API */
+
+#endif /* _SAML11_NVMCTRL_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/component/opamp.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/opamp.h
@@ -1,0 +1,227 @@
+/**
+ * \file
+ *
+ * \brief Component description for OPAMP
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_OPAMP_COMPONENT_H_
+#define _SAML11_OPAMP_COMPONENT_H_
+#define _SAML11_OPAMP_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML11 Operational Amplifier
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR OPAMP */
+/* ========================================================================== */
+
+#define OPAMP_U2237                      /**< (OPAMP) Module ID */
+#define REV_OPAMP 0x200                  /**< (OPAMP) Module revision */
+
+/* -------- OPAMP_CTRLA : (OPAMP Offset: 0x00) (R/W 8) Control A -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint8_t  ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint8_t  :5;                        /**< bit:   2..6  Reserved */
+    uint8_t  LPMUX:1;                   /**< bit:      7  Low-Power Mux                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} OPAMP_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OPAMP_CTRLA_OFFSET                  (0x00)                                        /**<  (OPAMP_CTRLA) Control A  Offset */
+#define OPAMP_CTRLA_RESETVALUE              _U_(0x00)                                     /**<  (OPAMP_CTRLA) Control A  Reset Value */
+
+#define OPAMP_CTRLA_SWRST_Pos               0                                              /**< (OPAMP_CTRLA) Software Reset Position */
+#define OPAMP_CTRLA_SWRST_Msk               (_U_(0x1) << OPAMP_CTRLA_SWRST_Pos)            /**< (OPAMP_CTRLA) Software Reset Mask */
+#define OPAMP_CTRLA_SWRST                   OPAMP_CTRLA_SWRST_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use OPAMP_CTRLA_SWRST_Msk instead */
+#define OPAMP_CTRLA_ENABLE_Pos              1                                              /**< (OPAMP_CTRLA) Enable Position */
+#define OPAMP_CTRLA_ENABLE_Msk              (_U_(0x1) << OPAMP_CTRLA_ENABLE_Pos)           /**< (OPAMP_CTRLA) Enable Mask */
+#define OPAMP_CTRLA_ENABLE                  OPAMP_CTRLA_ENABLE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use OPAMP_CTRLA_ENABLE_Msk instead */
+#define OPAMP_CTRLA_LPMUX_Pos               7                                              /**< (OPAMP_CTRLA) Low-Power Mux Position */
+#define OPAMP_CTRLA_LPMUX_Msk               (_U_(0x1) << OPAMP_CTRLA_LPMUX_Pos)            /**< (OPAMP_CTRLA) Low-Power Mux Mask */
+#define OPAMP_CTRLA_LPMUX                   OPAMP_CTRLA_LPMUX_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use OPAMP_CTRLA_LPMUX_Msk instead */
+#define OPAMP_CTRLA_MASK                    _U_(0x83)                                      /**< \deprecated (OPAMP_CTRLA) Register MASK  (Use OPAMP_CTRLA_Msk instead)  */
+#define OPAMP_CTRLA_Msk                     _U_(0x83)                                      /**< (OPAMP_CTRLA) Register Mask  */
+
+
+/* -------- OPAMP_STATUS : (OPAMP Offset: 0x02) (R/ 8) Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  READY0:1;                  /**< bit:      0  OPAMP 0 Ready                            */
+    uint8_t  READY1:1;                  /**< bit:      1  OPAMP 1 Ready                            */
+    uint8_t  READY2:1;                  /**< bit:      2  OPAMP 2 Ready                            */
+    uint8_t  :5;                        /**< bit:   3..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint8_t  READY:3;                   /**< bit:   0..2  OPAMP 2 Ready                            */
+    uint8_t  :5;                        /**< bit:   3..7 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint8_t  reg;                         /**< Type used for register access */
+} OPAMP_STATUS_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OPAMP_STATUS_OFFSET                 (0x02)                                        /**<  (OPAMP_STATUS) Status  Offset */
+#define OPAMP_STATUS_RESETVALUE             _U_(0x00)                                     /**<  (OPAMP_STATUS) Status  Reset Value */
+
+#define OPAMP_STATUS_READY0_Pos             0                                              /**< (OPAMP_STATUS) OPAMP 0 Ready Position */
+#define OPAMP_STATUS_READY0_Msk             (_U_(0x1) << OPAMP_STATUS_READY0_Pos)          /**< (OPAMP_STATUS) OPAMP 0 Ready Mask */
+#define OPAMP_STATUS_READY0                 OPAMP_STATUS_READY0_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use OPAMP_STATUS_READY0_Msk instead */
+#define OPAMP_STATUS_READY1_Pos             1                                              /**< (OPAMP_STATUS) OPAMP 1 Ready Position */
+#define OPAMP_STATUS_READY1_Msk             (_U_(0x1) << OPAMP_STATUS_READY1_Pos)          /**< (OPAMP_STATUS) OPAMP 1 Ready Mask */
+#define OPAMP_STATUS_READY1                 OPAMP_STATUS_READY1_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use OPAMP_STATUS_READY1_Msk instead */
+#define OPAMP_STATUS_READY2_Pos             2                                              /**< (OPAMP_STATUS) OPAMP 2 Ready Position */
+#define OPAMP_STATUS_READY2_Msk             (_U_(0x1) << OPAMP_STATUS_READY2_Pos)          /**< (OPAMP_STATUS) OPAMP 2 Ready Mask */
+#define OPAMP_STATUS_READY2                 OPAMP_STATUS_READY2_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use OPAMP_STATUS_READY2_Msk instead */
+#define OPAMP_STATUS_MASK                   _U_(0x07)                                      /**< \deprecated (OPAMP_STATUS) Register MASK  (Use OPAMP_STATUS_Msk instead)  */
+#define OPAMP_STATUS_Msk                    _U_(0x07)                                      /**< (OPAMP_STATUS) Register Mask  */
+
+#define OPAMP_STATUS_READY_Pos              0                                              /**< (OPAMP_STATUS Position) OPAMP 2 Ready */
+#define OPAMP_STATUS_READY_Msk              (_U_(0x7) << OPAMP_STATUS_READY_Pos)           /**< (OPAMP_STATUS Mask) READY */
+#define OPAMP_STATUS_READY(value)           (OPAMP_STATUS_READY_Msk & ((value) << OPAMP_STATUS_READY_Pos))  
+
+/* -------- OPAMP_OPAMPCTRL : (OPAMP Offset: 0x04) (R/W 32) OPAMP n Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t ENABLE:1;                  /**< bit:      1  Operational Amplifier Enable             */
+    uint32_t ANAOUT:1;                  /**< bit:      2  Analog Output                            */
+    uint32_t BIAS:2;                    /**< bit:   3..4  Bias Selection                           */
+    uint32_t RES2VCC:1;                 /**< bit:      5  Resistor ladder To VCC                   */
+    uint32_t RUNSTDBY:1;                /**< bit:      6  Run in Standby                           */
+    uint32_t ONDEMAND:1;                /**< bit:      7  On Demand Control                        */
+    uint32_t RES2OUT:1;                 /**< bit:      8  Resistor ladder To Output                */
+    uint32_t RES1EN:1;                  /**< bit:      9  Resistor 1 Enable                        */
+    uint32_t RES1MUX:3;                 /**< bit: 10..12  Resistor 1 Mux                           */
+    uint32_t POTMUX:3;                  /**< bit: 13..15  Potentiometer Selection                  */
+    uint32_t MUXPOS:4;                  /**< bit: 16..19  Positive Input Mux Selection             */
+    uint32_t MUXNEG:4;                  /**< bit: 20..23  Negative Input Mux Selection             */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} OPAMP_OPAMPCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OPAMP_OPAMPCTRL_OFFSET              (0x04)                                        /**<  (OPAMP_OPAMPCTRL) OPAMP n Control  Offset */
+#define OPAMP_OPAMPCTRL_RESETVALUE          _U_(0x00)                                     /**<  (OPAMP_OPAMPCTRL) OPAMP n Control  Reset Value */
+
+#define OPAMP_OPAMPCTRL_ENABLE_Pos          1                                              /**< (OPAMP_OPAMPCTRL) Operational Amplifier Enable Position */
+#define OPAMP_OPAMPCTRL_ENABLE_Msk          (_U_(0x1) << OPAMP_OPAMPCTRL_ENABLE_Pos)       /**< (OPAMP_OPAMPCTRL) Operational Amplifier Enable Mask */
+#define OPAMP_OPAMPCTRL_ENABLE              OPAMP_OPAMPCTRL_ENABLE_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use OPAMP_OPAMPCTRL_ENABLE_Msk instead */
+#define OPAMP_OPAMPCTRL_ANAOUT_Pos          2                                              /**< (OPAMP_OPAMPCTRL) Analog Output Position */
+#define OPAMP_OPAMPCTRL_ANAOUT_Msk          (_U_(0x1) << OPAMP_OPAMPCTRL_ANAOUT_Pos)       /**< (OPAMP_OPAMPCTRL) Analog Output Mask */
+#define OPAMP_OPAMPCTRL_ANAOUT              OPAMP_OPAMPCTRL_ANAOUT_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use OPAMP_OPAMPCTRL_ANAOUT_Msk instead */
+#define OPAMP_OPAMPCTRL_BIAS_Pos            3                                              /**< (OPAMP_OPAMPCTRL) Bias Selection Position */
+#define OPAMP_OPAMPCTRL_BIAS_Msk            (_U_(0x3) << OPAMP_OPAMPCTRL_BIAS_Pos)         /**< (OPAMP_OPAMPCTRL) Bias Selection Mask */
+#define OPAMP_OPAMPCTRL_BIAS(value)         (OPAMP_OPAMPCTRL_BIAS_Msk & ((value) << OPAMP_OPAMPCTRL_BIAS_Pos))
+#define OPAMP_OPAMPCTRL_RES2VCC_Pos         5                                              /**< (OPAMP_OPAMPCTRL) Resistor ladder To VCC Position */
+#define OPAMP_OPAMPCTRL_RES2VCC_Msk         (_U_(0x1) << OPAMP_OPAMPCTRL_RES2VCC_Pos)      /**< (OPAMP_OPAMPCTRL) Resistor ladder To VCC Mask */
+#define OPAMP_OPAMPCTRL_RES2VCC             OPAMP_OPAMPCTRL_RES2VCC_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use OPAMP_OPAMPCTRL_RES2VCC_Msk instead */
+#define OPAMP_OPAMPCTRL_RUNSTDBY_Pos        6                                              /**< (OPAMP_OPAMPCTRL) Run in Standby Position */
+#define OPAMP_OPAMPCTRL_RUNSTDBY_Msk        (_U_(0x1) << OPAMP_OPAMPCTRL_RUNSTDBY_Pos)     /**< (OPAMP_OPAMPCTRL) Run in Standby Mask */
+#define OPAMP_OPAMPCTRL_RUNSTDBY            OPAMP_OPAMPCTRL_RUNSTDBY_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use OPAMP_OPAMPCTRL_RUNSTDBY_Msk instead */
+#define OPAMP_OPAMPCTRL_ONDEMAND_Pos        7                                              /**< (OPAMP_OPAMPCTRL) On Demand Control Position */
+#define OPAMP_OPAMPCTRL_ONDEMAND_Msk        (_U_(0x1) << OPAMP_OPAMPCTRL_ONDEMAND_Pos)     /**< (OPAMP_OPAMPCTRL) On Demand Control Mask */
+#define OPAMP_OPAMPCTRL_ONDEMAND            OPAMP_OPAMPCTRL_ONDEMAND_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use OPAMP_OPAMPCTRL_ONDEMAND_Msk instead */
+#define OPAMP_OPAMPCTRL_RES2OUT_Pos         8                                              /**< (OPAMP_OPAMPCTRL) Resistor ladder To Output Position */
+#define OPAMP_OPAMPCTRL_RES2OUT_Msk         (_U_(0x1) << OPAMP_OPAMPCTRL_RES2OUT_Pos)      /**< (OPAMP_OPAMPCTRL) Resistor ladder To Output Mask */
+#define OPAMP_OPAMPCTRL_RES2OUT             OPAMP_OPAMPCTRL_RES2OUT_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use OPAMP_OPAMPCTRL_RES2OUT_Msk instead */
+#define OPAMP_OPAMPCTRL_RES1EN_Pos          9                                              /**< (OPAMP_OPAMPCTRL) Resistor 1 Enable Position */
+#define OPAMP_OPAMPCTRL_RES1EN_Msk          (_U_(0x1) << OPAMP_OPAMPCTRL_RES1EN_Pos)       /**< (OPAMP_OPAMPCTRL) Resistor 1 Enable Mask */
+#define OPAMP_OPAMPCTRL_RES1EN              OPAMP_OPAMPCTRL_RES1EN_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use OPAMP_OPAMPCTRL_RES1EN_Msk instead */
+#define OPAMP_OPAMPCTRL_RES1MUX_Pos         10                                             /**< (OPAMP_OPAMPCTRL) Resistor 1 Mux Position */
+#define OPAMP_OPAMPCTRL_RES1MUX_Msk         (_U_(0x7) << OPAMP_OPAMPCTRL_RES1MUX_Pos)      /**< (OPAMP_OPAMPCTRL) Resistor 1 Mux Mask */
+#define OPAMP_OPAMPCTRL_RES1MUX(value)      (OPAMP_OPAMPCTRL_RES1MUX_Msk & ((value) << OPAMP_OPAMPCTRL_RES1MUX_Pos))
+#define OPAMP_OPAMPCTRL_POTMUX_Pos          13                                             /**< (OPAMP_OPAMPCTRL) Potentiometer Selection Position */
+#define OPAMP_OPAMPCTRL_POTMUX_Msk          (_U_(0x7) << OPAMP_OPAMPCTRL_POTMUX_Pos)       /**< (OPAMP_OPAMPCTRL) Potentiometer Selection Mask */
+#define OPAMP_OPAMPCTRL_POTMUX(value)       (OPAMP_OPAMPCTRL_POTMUX_Msk & ((value) << OPAMP_OPAMPCTRL_POTMUX_Pos))
+#define OPAMP_OPAMPCTRL_MUXPOS_Pos          16                                             /**< (OPAMP_OPAMPCTRL) Positive Input Mux Selection Position */
+#define OPAMP_OPAMPCTRL_MUXPOS_Msk          (_U_(0xF) << OPAMP_OPAMPCTRL_MUXPOS_Pos)       /**< (OPAMP_OPAMPCTRL) Positive Input Mux Selection Mask */
+#define OPAMP_OPAMPCTRL_MUXPOS(value)       (OPAMP_OPAMPCTRL_MUXPOS_Msk & ((value) << OPAMP_OPAMPCTRL_MUXPOS_Pos))
+#define OPAMP_OPAMPCTRL_MUXNEG_Pos          20                                             /**< (OPAMP_OPAMPCTRL) Negative Input Mux Selection Position */
+#define OPAMP_OPAMPCTRL_MUXNEG_Msk          (_U_(0xF) << OPAMP_OPAMPCTRL_MUXNEG_Pos)       /**< (OPAMP_OPAMPCTRL) Negative Input Mux Selection Mask */
+#define OPAMP_OPAMPCTRL_MUXNEG(value)       (OPAMP_OPAMPCTRL_MUXNEG_Msk & ((value) << OPAMP_OPAMPCTRL_MUXNEG_Pos))
+#define OPAMP_OPAMPCTRL_MASK                _U_(0xFFFFFE)                                  /**< \deprecated (OPAMP_OPAMPCTRL) Register MASK  (Use OPAMP_OPAMPCTRL_Msk instead)  */
+#define OPAMP_OPAMPCTRL_Msk                 _U_(0xFFFFFE)                                  /**< (OPAMP_OPAMPCTRL) Register Mask  */
+
+
+/* -------- OPAMP_RESCTRL : (OPAMP Offset: 0x10) (R/W 8) Resister Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  RES2OUT:1;                 /**< bit:      0  Resistor ladder To Output                */
+    uint8_t  RES1EN:1;                  /**< bit:      1  Resistor 1 Enable                        */
+    uint8_t  RES1MUX:1;                 /**< bit:      2  Resistor 1 Mux                           */
+    uint8_t  POTMUX:3;                  /**< bit:   3..5  Potentiometer Selection                  */
+    uint8_t  REFBUFLEVEL:2;             /**< bit:   6..7  Reference output voltage level select    */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} OPAMP_RESCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OPAMP_RESCTRL_OFFSET                (0x10)                                        /**<  (OPAMP_RESCTRL) Resister Control  Offset */
+#define OPAMP_RESCTRL_RESETVALUE            _U_(0x00)                                     /**<  (OPAMP_RESCTRL) Resister Control  Reset Value */
+
+#define OPAMP_RESCTRL_RES2OUT_Pos           0                                              /**< (OPAMP_RESCTRL) Resistor ladder To Output Position */
+#define OPAMP_RESCTRL_RES2OUT_Msk           (_U_(0x1) << OPAMP_RESCTRL_RES2OUT_Pos)        /**< (OPAMP_RESCTRL) Resistor ladder To Output Mask */
+#define OPAMP_RESCTRL_RES2OUT               OPAMP_RESCTRL_RES2OUT_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use OPAMP_RESCTRL_RES2OUT_Msk instead */
+#define OPAMP_RESCTRL_RES1EN_Pos            1                                              /**< (OPAMP_RESCTRL) Resistor 1 Enable Position */
+#define OPAMP_RESCTRL_RES1EN_Msk            (_U_(0x1) << OPAMP_RESCTRL_RES1EN_Pos)         /**< (OPAMP_RESCTRL) Resistor 1 Enable Mask */
+#define OPAMP_RESCTRL_RES1EN                OPAMP_RESCTRL_RES1EN_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use OPAMP_RESCTRL_RES1EN_Msk instead */
+#define OPAMP_RESCTRL_RES1MUX_Pos           2                                              /**< (OPAMP_RESCTRL) Resistor 1 Mux Position */
+#define OPAMP_RESCTRL_RES1MUX_Msk           (_U_(0x1) << OPAMP_RESCTRL_RES1MUX_Pos)        /**< (OPAMP_RESCTRL) Resistor 1 Mux Mask */
+#define OPAMP_RESCTRL_RES1MUX               OPAMP_RESCTRL_RES1MUX_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use OPAMP_RESCTRL_RES1MUX_Msk instead */
+#define OPAMP_RESCTRL_POTMUX_Pos            3                                              /**< (OPAMP_RESCTRL) Potentiometer Selection Position */
+#define OPAMP_RESCTRL_POTMUX_Msk            (_U_(0x7) << OPAMP_RESCTRL_POTMUX_Pos)         /**< (OPAMP_RESCTRL) Potentiometer Selection Mask */
+#define OPAMP_RESCTRL_POTMUX(value)         (OPAMP_RESCTRL_POTMUX_Msk & ((value) << OPAMP_RESCTRL_POTMUX_Pos))
+#define OPAMP_RESCTRL_REFBUFLEVEL_Pos       6                                              /**< (OPAMP_RESCTRL) Reference output voltage level select Position */
+#define OPAMP_RESCTRL_REFBUFLEVEL_Msk       (_U_(0x3) << OPAMP_RESCTRL_REFBUFLEVEL_Pos)    /**< (OPAMP_RESCTRL) Reference output voltage level select Mask */
+#define OPAMP_RESCTRL_REFBUFLEVEL(value)    (OPAMP_RESCTRL_REFBUFLEVEL_Msk & ((value) << OPAMP_RESCTRL_REFBUFLEVEL_Pos))
+#define OPAMP_RESCTRL_MASK                  _U_(0xFF)                                      /**< \deprecated (OPAMP_RESCTRL) Register MASK  (Use OPAMP_RESCTRL_Msk instead)  */
+#define OPAMP_RESCTRL_Msk                   _U_(0xFF)                                      /**< (OPAMP_RESCTRL) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief OPAMP hardware registers */
+typedef struct {  /* Operational Amplifier */
+  __IO OPAMP_CTRLA_Type               CTRLA;          /**< Offset: 0x00 (R/W   8) Control A */
+  __I  uint8_t                        Reserved1[1];
+  __I  OPAMP_STATUS_Type              STATUS;         /**< Offset: 0x02 (R/    8) Status */
+  __I  uint8_t                        Reserved2[1];
+  __IO OPAMP_OPAMPCTRL_Type           OPAMPCTRL[3];   /**< Offset: 0x04 (R/W  32) OPAMP n Control */
+  __IO OPAMP_RESCTRL_Type             RESCTRL;        /**< Offset: 0x10 (R/W   8) Resister Control */
+} Opamp;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Operational Amplifier */
+
+#endif /* _SAML11_OPAMP_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/component/osc32kctrl.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/osc32kctrl.h
@@ -1,0 +1,344 @@
+/**
+ * \file
+ *
+ * \brief Component description for OSC32KCTRL
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_OSC32KCTRL_COMPONENT_H_
+#define _SAML11_OSC32KCTRL_COMPONENT_H_
+#define _SAML11_OSC32KCTRL_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML11 32k Oscillators Control
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR OSC32KCTRL */
+/* ========================================================================== */
+
+#define OSC32KCTRL_U2246                      /**< (OSC32KCTRL) Module ID */
+#define REV_OSC32KCTRL 0x400                  /**< (OSC32KCTRL) Module revision */
+
+/* -------- OSC32KCTRL_INTENCLR : (OSC32KCTRL Offset: 0x00) (R/W 32) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t XOSC32KRDY:1;              /**< bit:      0  XOSC32K Ready Interrupt Enable           */
+    uint32_t :1;                        /**< bit:      1  Reserved */
+    uint32_t CLKFAIL:1;                 /**< bit:      2  XOSC32K Clock Failure Detector Interrupt Enable */
+    uint32_t :29;                       /**< bit:  3..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} OSC32KCTRL_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSC32KCTRL_INTENCLR_OFFSET          (0x00)                                        /**<  (OSC32KCTRL_INTENCLR) Interrupt Enable Clear  Offset */
+#define OSC32KCTRL_INTENCLR_RESETVALUE      _U_(0x00)                                     /**<  (OSC32KCTRL_INTENCLR) Interrupt Enable Clear  Reset Value */
+
+#define OSC32KCTRL_INTENCLR_XOSC32KRDY_Pos  0                                              /**< (OSC32KCTRL_INTENCLR) XOSC32K Ready Interrupt Enable Position */
+#define OSC32KCTRL_INTENCLR_XOSC32KRDY_Msk  (_U_(0x1) << OSC32KCTRL_INTENCLR_XOSC32KRDY_Pos)  /**< (OSC32KCTRL_INTENCLR) XOSC32K Ready Interrupt Enable Mask */
+#define OSC32KCTRL_INTENCLR_XOSC32KRDY      OSC32KCTRL_INTENCLR_XOSC32KRDY_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSC32KCTRL_INTENCLR_XOSC32KRDY_Msk instead */
+#define OSC32KCTRL_INTENCLR_CLKFAIL_Pos     2                                              /**< (OSC32KCTRL_INTENCLR) XOSC32K Clock Failure Detector Interrupt Enable Position */
+#define OSC32KCTRL_INTENCLR_CLKFAIL_Msk     (_U_(0x1) << OSC32KCTRL_INTENCLR_CLKFAIL_Pos)  /**< (OSC32KCTRL_INTENCLR) XOSC32K Clock Failure Detector Interrupt Enable Mask */
+#define OSC32KCTRL_INTENCLR_CLKFAIL         OSC32KCTRL_INTENCLR_CLKFAIL_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSC32KCTRL_INTENCLR_CLKFAIL_Msk instead */
+#define OSC32KCTRL_INTENCLR_MASK            _U_(0x05)                                      /**< \deprecated (OSC32KCTRL_INTENCLR) Register MASK  (Use OSC32KCTRL_INTENCLR_Msk instead)  */
+#define OSC32KCTRL_INTENCLR_Msk             _U_(0x05)                                      /**< (OSC32KCTRL_INTENCLR) Register Mask  */
+
+
+/* -------- OSC32KCTRL_INTENSET : (OSC32KCTRL Offset: 0x04) (R/W 32) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t XOSC32KRDY:1;              /**< bit:      0  XOSC32K Ready Interrupt Enable           */
+    uint32_t :1;                        /**< bit:      1  Reserved */
+    uint32_t CLKFAIL:1;                 /**< bit:      2  XOSC32K Clock Failure Detector Interrupt Enable */
+    uint32_t :29;                       /**< bit:  3..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} OSC32KCTRL_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSC32KCTRL_INTENSET_OFFSET          (0x04)                                        /**<  (OSC32KCTRL_INTENSET) Interrupt Enable Set  Offset */
+#define OSC32KCTRL_INTENSET_RESETVALUE      _U_(0x00)                                     /**<  (OSC32KCTRL_INTENSET) Interrupt Enable Set  Reset Value */
+
+#define OSC32KCTRL_INTENSET_XOSC32KRDY_Pos  0                                              /**< (OSC32KCTRL_INTENSET) XOSC32K Ready Interrupt Enable Position */
+#define OSC32KCTRL_INTENSET_XOSC32KRDY_Msk  (_U_(0x1) << OSC32KCTRL_INTENSET_XOSC32KRDY_Pos)  /**< (OSC32KCTRL_INTENSET) XOSC32K Ready Interrupt Enable Mask */
+#define OSC32KCTRL_INTENSET_XOSC32KRDY      OSC32KCTRL_INTENSET_XOSC32KRDY_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSC32KCTRL_INTENSET_XOSC32KRDY_Msk instead */
+#define OSC32KCTRL_INTENSET_CLKFAIL_Pos     2                                              /**< (OSC32KCTRL_INTENSET) XOSC32K Clock Failure Detector Interrupt Enable Position */
+#define OSC32KCTRL_INTENSET_CLKFAIL_Msk     (_U_(0x1) << OSC32KCTRL_INTENSET_CLKFAIL_Pos)  /**< (OSC32KCTRL_INTENSET) XOSC32K Clock Failure Detector Interrupt Enable Mask */
+#define OSC32KCTRL_INTENSET_CLKFAIL         OSC32KCTRL_INTENSET_CLKFAIL_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSC32KCTRL_INTENSET_CLKFAIL_Msk instead */
+#define OSC32KCTRL_INTENSET_MASK            _U_(0x05)                                      /**< \deprecated (OSC32KCTRL_INTENSET) Register MASK  (Use OSC32KCTRL_INTENSET_Msk instead)  */
+#define OSC32KCTRL_INTENSET_Msk             _U_(0x05)                                      /**< (OSC32KCTRL_INTENSET) Register Mask  */
+
+
+/* -------- OSC32KCTRL_INTFLAG : (OSC32KCTRL Offset: 0x08) (R/W 32) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint32_t XOSC32KRDY:1;              /**< bit:      0  XOSC32K Ready                            */
+    __I uint32_t :1;                        /**< bit:      1  Reserved */
+    __I uint32_t CLKFAIL:1;                 /**< bit:      2  XOSC32K Clock Failure Detector           */
+    __I uint32_t :29;                       /**< bit:  3..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} OSC32KCTRL_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSC32KCTRL_INTFLAG_OFFSET           (0x08)                                        /**<  (OSC32KCTRL_INTFLAG) Interrupt Flag Status and Clear  Offset */
+#define OSC32KCTRL_INTFLAG_RESETVALUE       _U_(0x00)                                     /**<  (OSC32KCTRL_INTFLAG) Interrupt Flag Status and Clear  Reset Value */
+
+#define OSC32KCTRL_INTFLAG_XOSC32KRDY_Pos   0                                              /**< (OSC32KCTRL_INTFLAG) XOSC32K Ready Position */
+#define OSC32KCTRL_INTFLAG_XOSC32KRDY_Msk   (_U_(0x1) << OSC32KCTRL_INTFLAG_XOSC32KRDY_Pos)  /**< (OSC32KCTRL_INTFLAG) XOSC32K Ready Mask */
+#define OSC32KCTRL_INTFLAG_XOSC32KRDY       OSC32KCTRL_INTFLAG_XOSC32KRDY_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSC32KCTRL_INTFLAG_XOSC32KRDY_Msk instead */
+#define OSC32KCTRL_INTFLAG_CLKFAIL_Pos      2                                              /**< (OSC32KCTRL_INTFLAG) XOSC32K Clock Failure Detector Position */
+#define OSC32KCTRL_INTFLAG_CLKFAIL_Msk      (_U_(0x1) << OSC32KCTRL_INTFLAG_CLKFAIL_Pos)   /**< (OSC32KCTRL_INTFLAG) XOSC32K Clock Failure Detector Mask */
+#define OSC32KCTRL_INTFLAG_CLKFAIL          OSC32KCTRL_INTFLAG_CLKFAIL_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSC32KCTRL_INTFLAG_CLKFAIL_Msk instead */
+#define OSC32KCTRL_INTFLAG_MASK             _U_(0x05)                                      /**< \deprecated (OSC32KCTRL_INTFLAG) Register MASK  (Use OSC32KCTRL_INTFLAG_Msk instead)  */
+#define OSC32KCTRL_INTFLAG_Msk              _U_(0x05)                                      /**< (OSC32KCTRL_INTFLAG) Register Mask  */
+
+
+/* -------- OSC32KCTRL_STATUS : (OSC32KCTRL Offset: 0x0c) (R/ 32) Power and Clocks Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t XOSC32KRDY:1;              /**< bit:      0  XOSC32K Ready                            */
+    uint32_t :1;                        /**< bit:      1  Reserved */
+    uint32_t CLKFAIL:1;                 /**< bit:      2  XOSC32K Clock Failure Detector           */
+    uint32_t CLKSW:1;                   /**< bit:      3  XOSC32K Clock switch                     */
+    uint32_t ULP32KSW:1;                /**< bit:      4  OSCULP32K Clock Switch                   */
+    uint32_t :27;                       /**< bit:  5..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} OSC32KCTRL_STATUS_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSC32KCTRL_STATUS_OFFSET            (0x0C)                                        /**<  (OSC32KCTRL_STATUS) Power and Clocks Status  Offset */
+#define OSC32KCTRL_STATUS_RESETVALUE        _U_(0x00)                                     /**<  (OSC32KCTRL_STATUS) Power and Clocks Status  Reset Value */
+
+#define OSC32KCTRL_STATUS_XOSC32KRDY_Pos    0                                              /**< (OSC32KCTRL_STATUS) XOSC32K Ready Position */
+#define OSC32KCTRL_STATUS_XOSC32KRDY_Msk    (_U_(0x1) << OSC32KCTRL_STATUS_XOSC32KRDY_Pos)  /**< (OSC32KCTRL_STATUS) XOSC32K Ready Mask */
+#define OSC32KCTRL_STATUS_XOSC32KRDY        OSC32KCTRL_STATUS_XOSC32KRDY_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSC32KCTRL_STATUS_XOSC32KRDY_Msk instead */
+#define OSC32KCTRL_STATUS_CLKFAIL_Pos       2                                              /**< (OSC32KCTRL_STATUS) XOSC32K Clock Failure Detector Position */
+#define OSC32KCTRL_STATUS_CLKFAIL_Msk       (_U_(0x1) << OSC32KCTRL_STATUS_CLKFAIL_Pos)    /**< (OSC32KCTRL_STATUS) XOSC32K Clock Failure Detector Mask */
+#define OSC32KCTRL_STATUS_CLKFAIL           OSC32KCTRL_STATUS_CLKFAIL_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSC32KCTRL_STATUS_CLKFAIL_Msk instead */
+#define OSC32KCTRL_STATUS_CLKSW_Pos         3                                              /**< (OSC32KCTRL_STATUS) XOSC32K Clock switch Position */
+#define OSC32KCTRL_STATUS_CLKSW_Msk         (_U_(0x1) << OSC32KCTRL_STATUS_CLKSW_Pos)      /**< (OSC32KCTRL_STATUS) XOSC32K Clock switch Mask */
+#define OSC32KCTRL_STATUS_CLKSW             OSC32KCTRL_STATUS_CLKSW_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSC32KCTRL_STATUS_CLKSW_Msk instead */
+#define OSC32KCTRL_STATUS_ULP32KSW_Pos      4                                              /**< (OSC32KCTRL_STATUS) OSCULP32K Clock Switch Position */
+#define OSC32KCTRL_STATUS_ULP32KSW_Msk      (_U_(0x1) << OSC32KCTRL_STATUS_ULP32KSW_Pos)   /**< (OSC32KCTRL_STATUS) OSCULP32K Clock Switch Mask */
+#define OSC32KCTRL_STATUS_ULP32KSW          OSC32KCTRL_STATUS_ULP32KSW_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSC32KCTRL_STATUS_ULP32KSW_Msk instead */
+#define OSC32KCTRL_STATUS_MASK              _U_(0x1D)                                      /**< \deprecated (OSC32KCTRL_STATUS) Register MASK  (Use OSC32KCTRL_STATUS_Msk instead)  */
+#define OSC32KCTRL_STATUS_Msk               _U_(0x1D)                                      /**< (OSC32KCTRL_STATUS) Register Mask  */
+
+
+/* -------- OSC32KCTRL_RTCCTRL : (OSC32KCTRL Offset: 0x10) (R/W 8) RTC Clock Selection -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  RTCSEL:3;                  /**< bit:   0..2  RTC Clock Selection                      */
+    uint8_t  :5;                        /**< bit:   3..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} OSC32KCTRL_RTCCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSC32KCTRL_RTCCTRL_OFFSET           (0x10)                                        /**<  (OSC32KCTRL_RTCCTRL) RTC Clock Selection  Offset */
+#define OSC32KCTRL_RTCCTRL_RESETVALUE       _U_(0x00)                                     /**<  (OSC32KCTRL_RTCCTRL) RTC Clock Selection  Reset Value */
+
+#define OSC32KCTRL_RTCCTRL_RTCSEL_Pos       0                                              /**< (OSC32KCTRL_RTCCTRL) RTC Clock Selection Position */
+#define OSC32KCTRL_RTCCTRL_RTCSEL_Msk       (_U_(0x7) << OSC32KCTRL_RTCCTRL_RTCSEL_Pos)    /**< (OSC32KCTRL_RTCCTRL) RTC Clock Selection Mask */
+#define OSC32KCTRL_RTCCTRL_RTCSEL(value)    (OSC32KCTRL_RTCCTRL_RTCSEL_Msk & ((value) << OSC32KCTRL_RTCCTRL_RTCSEL_Pos))
+#define   OSC32KCTRL_RTCCTRL_RTCSEL_ULP1K_Val _U_(0x0)                                       /**< (OSC32KCTRL_RTCCTRL) 1.024kHz from 32kHz internal ULP oscillator  */
+#define   OSC32KCTRL_RTCCTRL_RTCSEL_ULP32K_Val _U_(0x1)                                       /**< (OSC32KCTRL_RTCCTRL) 32.768kHz from 32kHz internal ULP oscillator  */
+#define   OSC32KCTRL_RTCCTRL_RTCSEL_OSC1K_Val _U_(0x2)                                       /**< (OSC32KCTRL_RTCCTRL) 1.024kHz from 32.768kHz internal oscillator  */
+#define   OSC32KCTRL_RTCCTRL_RTCSEL_OSC32K_Val _U_(0x3)                                       /**< (OSC32KCTRL_RTCCTRL) 32.768kHz from 32.768kHz internal oscillator  */
+#define   OSC32KCTRL_RTCCTRL_RTCSEL_XOSC1K_Val _U_(0x4)                                       /**< (OSC32KCTRL_RTCCTRL) 1.024kHz from 32.768kHz internal oscillator  */
+#define   OSC32KCTRL_RTCCTRL_RTCSEL_XOSC32K_Val _U_(0x5)                                       /**< (OSC32KCTRL_RTCCTRL) 32.768kHz from 32.768kHz external crystal oscillator  */
+#define OSC32KCTRL_RTCCTRL_RTCSEL_ULP1K     (OSC32KCTRL_RTCCTRL_RTCSEL_ULP1K_Val << OSC32KCTRL_RTCCTRL_RTCSEL_Pos)  /**< (OSC32KCTRL_RTCCTRL) 1.024kHz from 32kHz internal ULP oscillator Position  */
+#define OSC32KCTRL_RTCCTRL_RTCSEL_ULP32K    (OSC32KCTRL_RTCCTRL_RTCSEL_ULP32K_Val << OSC32KCTRL_RTCCTRL_RTCSEL_Pos)  /**< (OSC32KCTRL_RTCCTRL) 32.768kHz from 32kHz internal ULP oscillator Position  */
+#define OSC32KCTRL_RTCCTRL_RTCSEL_OSC1K     (OSC32KCTRL_RTCCTRL_RTCSEL_OSC1K_Val << OSC32KCTRL_RTCCTRL_RTCSEL_Pos)  /**< (OSC32KCTRL_RTCCTRL) 1.024kHz from 32.768kHz internal oscillator Position  */
+#define OSC32KCTRL_RTCCTRL_RTCSEL_OSC32K    (OSC32KCTRL_RTCCTRL_RTCSEL_OSC32K_Val << OSC32KCTRL_RTCCTRL_RTCSEL_Pos)  /**< (OSC32KCTRL_RTCCTRL) 32.768kHz from 32.768kHz internal oscillator Position  */
+#define OSC32KCTRL_RTCCTRL_RTCSEL_XOSC1K    (OSC32KCTRL_RTCCTRL_RTCSEL_XOSC1K_Val << OSC32KCTRL_RTCCTRL_RTCSEL_Pos)  /**< (OSC32KCTRL_RTCCTRL) 1.024kHz from 32.768kHz internal oscillator Position  */
+#define OSC32KCTRL_RTCCTRL_RTCSEL_XOSC32K   (OSC32KCTRL_RTCCTRL_RTCSEL_XOSC32K_Val << OSC32KCTRL_RTCCTRL_RTCSEL_Pos)  /**< (OSC32KCTRL_RTCCTRL) 32.768kHz from 32.768kHz external crystal oscillator Position  */
+#define OSC32KCTRL_RTCCTRL_MASK             _U_(0x07)                                      /**< \deprecated (OSC32KCTRL_RTCCTRL) Register MASK  (Use OSC32KCTRL_RTCCTRL_Msk instead)  */
+#define OSC32KCTRL_RTCCTRL_Msk              _U_(0x07)                                      /**< (OSC32KCTRL_RTCCTRL) Register Mask  */
+
+
+/* -------- OSC32KCTRL_XOSC32K : (OSC32KCTRL Offset: 0x14) (R/W 16) 32kHz External Crystal Oscillator (XOSC32K) Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t :1;                        /**< bit:      0  Reserved */
+    uint16_t ENABLE:1;                  /**< bit:      1  Oscillator Enable                        */
+    uint16_t XTALEN:1;                  /**< bit:      2  Crystal Oscillator Enable                */
+    uint16_t EN32K:1;                   /**< bit:      3  32kHz Output Enable                      */
+    uint16_t EN1K:1;                    /**< bit:      4  1kHz Output Enable                       */
+    uint16_t :1;                        /**< bit:      5  Reserved */
+    uint16_t RUNSTDBY:1;                /**< bit:      6  Run in Standby                           */
+    uint16_t ONDEMAND:1;                /**< bit:      7  On Demand Control                        */
+    uint16_t STARTUP:3;                 /**< bit:  8..10  Oscillator Start-Up Time                 */
+    uint16_t :1;                        /**< bit:     11  Reserved */
+    uint16_t WRTLOCK:1;                 /**< bit:     12  Write Lock                               */
+    uint16_t :3;                        /**< bit: 13..15  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} OSC32KCTRL_XOSC32K_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSC32KCTRL_XOSC32K_OFFSET           (0x14)                                        /**<  (OSC32KCTRL_XOSC32K) 32kHz External Crystal Oscillator (XOSC32K) Control  Offset */
+#define OSC32KCTRL_XOSC32K_RESETVALUE       _U_(0x80)                                     /**<  (OSC32KCTRL_XOSC32K) 32kHz External Crystal Oscillator (XOSC32K) Control  Reset Value */
+
+#define OSC32KCTRL_XOSC32K_ENABLE_Pos       1                                              /**< (OSC32KCTRL_XOSC32K) Oscillator Enable Position */
+#define OSC32KCTRL_XOSC32K_ENABLE_Msk       (_U_(0x1) << OSC32KCTRL_XOSC32K_ENABLE_Pos)    /**< (OSC32KCTRL_XOSC32K) Oscillator Enable Mask */
+#define OSC32KCTRL_XOSC32K_ENABLE           OSC32KCTRL_XOSC32K_ENABLE_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSC32KCTRL_XOSC32K_ENABLE_Msk instead */
+#define OSC32KCTRL_XOSC32K_XTALEN_Pos       2                                              /**< (OSC32KCTRL_XOSC32K) Crystal Oscillator Enable Position */
+#define OSC32KCTRL_XOSC32K_XTALEN_Msk       (_U_(0x1) << OSC32KCTRL_XOSC32K_XTALEN_Pos)    /**< (OSC32KCTRL_XOSC32K) Crystal Oscillator Enable Mask */
+#define OSC32KCTRL_XOSC32K_XTALEN           OSC32KCTRL_XOSC32K_XTALEN_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSC32KCTRL_XOSC32K_XTALEN_Msk instead */
+#define OSC32KCTRL_XOSC32K_EN32K_Pos        3                                              /**< (OSC32KCTRL_XOSC32K) 32kHz Output Enable Position */
+#define OSC32KCTRL_XOSC32K_EN32K_Msk        (_U_(0x1) << OSC32KCTRL_XOSC32K_EN32K_Pos)     /**< (OSC32KCTRL_XOSC32K) 32kHz Output Enable Mask */
+#define OSC32KCTRL_XOSC32K_EN32K            OSC32KCTRL_XOSC32K_EN32K_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSC32KCTRL_XOSC32K_EN32K_Msk instead */
+#define OSC32KCTRL_XOSC32K_EN1K_Pos         4                                              /**< (OSC32KCTRL_XOSC32K) 1kHz Output Enable Position */
+#define OSC32KCTRL_XOSC32K_EN1K_Msk         (_U_(0x1) << OSC32KCTRL_XOSC32K_EN1K_Pos)      /**< (OSC32KCTRL_XOSC32K) 1kHz Output Enable Mask */
+#define OSC32KCTRL_XOSC32K_EN1K             OSC32KCTRL_XOSC32K_EN1K_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSC32KCTRL_XOSC32K_EN1K_Msk instead */
+#define OSC32KCTRL_XOSC32K_RUNSTDBY_Pos     6                                              /**< (OSC32KCTRL_XOSC32K) Run in Standby Position */
+#define OSC32KCTRL_XOSC32K_RUNSTDBY_Msk     (_U_(0x1) << OSC32KCTRL_XOSC32K_RUNSTDBY_Pos)  /**< (OSC32KCTRL_XOSC32K) Run in Standby Mask */
+#define OSC32KCTRL_XOSC32K_RUNSTDBY         OSC32KCTRL_XOSC32K_RUNSTDBY_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSC32KCTRL_XOSC32K_RUNSTDBY_Msk instead */
+#define OSC32KCTRL_XOSC32K_ONDEMAND_Pos     7                                              /**< (OSC32KCTRL_XOSC32K) On Demand Control Position */
+#define OSC32KCTRL_XOSC32K_ONDEMAND_Msk     (_U_(0x1) << OSC32KCTRL_XOSC32K_ONDEMAND_Pos)  /**< (OSC32KCTRL_XOSC32K) On Demand Control Mask */
+#define OSC32KCTRL_XOSC32K_ONDEMAND         OSC32KCTRL_XOSC32K_ONDEMAND_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSC32KCTRL_XOSC32K_ONDEMAND_Msk instead */
+#define OSC32KCTRL_XOSC32K_STARTUP_Pos      8                                              /**< (OSC32KCTRL_XOSC32K) Oscillator Start-Up Time Position */
+#define OSC32KCTRL_XOSC32K_STARTUP_Msk      (_U_(0x7) << OSC32KCTRL_XOSC32K_STARTUP_Pos)   /**< (OSC32KCTRL_XOSC32K) Oscillator Start-Up Time Mask */
+#define OSC32KCTRL_XOSC32K_STARTUP(value)   (OSC32KCTRL_XOSC32K_STARTUP_Msk & ((value) << OSC32KCTRL_XOSC32K_STARTUP_Pos))
+#define OSC32KCTRL_XOSC32K_WRTLOCK_Pos      12                                             /**< (OSC32KCTRL_XOSC32K) Write Lock Position */
+#define OSC32KCTRL_XOSC32K_WRTLOCK_Msk      (_U_(0x1) << OSC32KCTRL_XOSC32K_WRTLOCK_Pos)   /**< (OSC32KCTRL_XOSC32K) Write Lock Mask */
+#define OSC32KCTRL_XOSC32K_WRTLOCK          OSC32KCTRL_XOSC32K_WRTLOCK_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSC32KCTRL_XOSC32K_WRTLOCK_Msk instead */
+#define OSC32KCTRL_XOSC32K_MASK             _U_(0x17DE)                                    /**< \deprecated (OSC32KCTRL_XOSC32K) Register MASK  (Use OSC32KCTRL_XOSC32K_Msk instead)  */
+#define OSC32KCTRL_XOSC32K_Msk              _U_(0x17DE)                                    /**< (OSC32KCTRL_XOSC32K) Register Mask  */
+
+
+/* -------- OSC32KCTRL_CFDCTRL : (OSC32KCTRL Offset: 0x16) (R/W 8) Clock Failure Detector Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  CFDEN:1;                   /**< bit:      0  Clock Failure Detector Enable            */
+    uint8_t  SWBACK:1;                  /**< bit:      1  Clock Switch Back                        */
+    uint8_t  CFDPRESC:1;                /**< bit:      2  Clock Failure Detector Prescaler         */
+    uint8_t  :5;                        /**< bit:   3..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} OSC32KCTRL_CFDCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSC32KCTRL_CFDCTRL_OFFSET           (0x16)                                        /**<  (OSC32KCTRL_CFDCTRL) Clock Failure Detector Control  Offset */
+#define OSC32KCTRL_CFDCTRL_RESETVALUE       _U_(0x00)                                     /**<  (OSC32KCTRL_CFDCTRL) Clock Failure Detector Control  Reset Value */
+
+#define OSC32KCTRL_CFDCTRL_CFDEN_Pos        0                                              /**< (OSC32KCTRL_CFDCTRL) Clock Failure Detector Enable Position */
+#define OSC32KCTRL_CFDCTRL_CFDEN_Msk        (_U_(0x1) << OSC32KCTRL_CFDCTRL_CFDEN_Pos)     /**< (OSC32KCTRL_CFDCTRL) Clock Failure Detector Enable Mask */
+#define OSC32KCTRL_CFDCTRL_CFDEN            OSC32KCTRL_CFDCTRL_CFDEN_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSC32KCTRL_CFDCTRL_CFDEN_Msk instead */
+#define OSC32KCTRL_CFDCTRL_SWBACK_Pos       1                                              /**< (OSC32KCTRL_CFDCTRL) Clock Switch Back Position */
+#define OSC32KCTRL_CFDCTRL_SWBACK_Msk       (_U_(0x1) << OSC32KCTRL_CFDCTRL_SWBACK_Pos)    /**< (OSC32KCTRL_CFDCTRL) Clock Switch Back Mask */
+#define OSC32KCTRL_CFDCTRL_SWBACK           OSC32KCTRL_CFDCTRL_SWBACK_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSC32KCTRL_CFDCTRL_SWBACK_Msk instead */
+#define OSC32KCTRL_CFDCTRL_CFDPRESC_Pos     2                                              /**< (OSC32KCTRL_CFDCTRL) Clock Failure Detector Prescaler Position */
+#define OSC32KCTRL_CFDCTRL_CFDPRESC_Msk     (_U_(0x1) << OSC32KCTRL_CFDCTRL_CFDPRESC_Pos)  /**< (OSC32KCTRL_CFDCTRL) Clock Failure Detector Prescaler Mask */
+#define OSC32KCTRL_CFDCTRL_CFDPRESC         OSC32KCTRL_CFDCTRL_CFDPRESC_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSC32KCTRL_CFDCTRL_CFDPRESC_Msk instead */
+#define OSC32KCTRL_CFDCTRL_MASK             _U_(0x07)                                      /**< \deprecated (OSC32KCTRL_CFDCTRL) Register MASK  (Use OSC32KCTRL_CFDCTRL_Msk instead)  */
+#define OSC32KCTRL_CFDCTRL_Msk              _U_(0x07)                                      /**< (OSC32KCTRL_CFDCTRL) Register Mask  */
+
+
+/* -------- OSC32KCTRL_EVCTRL : (OSC32KCTRL Offset: 0x17) (R/W 8) Event Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  CFDEO:1;                   /**< bit:      0  Clock Failure Detector Event Output Enable */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} OSC32KCTRL_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSC32KCTRL_EVCTRL_OFFSET            (0x17)                                        /**<  (OSC32KCTRL_EVCTRL) Event Control  Offset */
+#define OSC32KCTRL_EVCTRL_RESETVALUE        _U_(0x00)                                     /**<  (OSC32KCTRL_EVCTRL) Event Control  Reset Value */
+
+#define OSC32KCTRL_EVCTRL_CFDEO_Pos         0                                              /**< (OSC32KCTRL_EVCTRL) Clock Failure Detector Event Output Enable Position */
+#define OSC32KCTRL_EVCTRL_CFDEO_Msk         (_U_(0x1) << OSC32KCTRL_EVCTRL_CFDEO_Pos)      /**< (OSC32KCTRL_EVCTRL) Clock Failure Detector Event Output Enable Mask */
+#define OSC32KCTRL_EVCTRL_CFDEO             OSC32KCTRL_EVCTRL_CFDEO_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSC32KCTRL_EVCTRL_CFDEO_Msk instead */
+#define OSC32KCTRL_EVCTRL_MASK              _U_(0x01)                                      /**< \deprecated (OSC32KCTRL_EVCTRL) Register MASK  (Use OSC32KCTRL_EVCTRL_Msk instead)  */
+#define OSC32KCTRL_EVCTRL_Msk               _U_(0x01)                                      /**< (OSC32KCTRL_EVCTRL) Register Mask  */
+
+
+/* -------- OSC32KCTRL_OSCULP32K : (OSC32KCTRL Offset: 0x1c) (R/W 32) 32kHz Ultra Low Power Internal Oscillator (OSCULP32K) Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t :5;                        /**< bit:   0..4  Reserved */
+    uint32_t ULP32KSW:1;                /**< bit:      5  OSCULP32K Clock Switch Enable            */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t CALIB:5;                   /**< bit:  8..12  Oscillator Calibration                   */
+    uint32_t :2;                        /**< bit: 13..14  Reserved */
+    uint32_t WRTLOCK:1;                 /**< bit:     15  Write Lock                               */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} OSC32KCTRL_OSCULP32K_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSC32KCTRL_OSCULP32K_OFFSET         (0x1C)                                        /**<  (OSC32KCTRL_OSCULP32K) 32kHz Ultra Low Power Internal Oscillator (OSCULP32K) Control  Offset */
+#define OSC32KCTRL_OSCULP32K_RESETVALUE     _U_(0x00)                                     /**<  (OSC32KCTRL_OSCULP32K) 32kHz Ultra Low Power Internal Oscillator (OSCULP32K) Control  Reset Value */
+
+#define OSC32KCTRL_OSCULP32K_ULP32KSW_Pos   5                                              /**< (OSC32KCTRL_OSCULP32K) OSCULP32K Clock Switch Enable Position */
+#define OSC32KCTRL_OSCULP32K_ULP32KSW_Msk   (_U_(0x1) << OSC32KCTRL_OSCULP32K_ULP32KSW_Pos)  /**< (OSC32KCTRL_OSCULP32K) OSCULP32K Clock Switch Enable Mask */
+#define OSC32KCTRL_OSCULP32K_ULP32KSW       OSC32KCTRL_OSCULP32K_ULP32KSW_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSC32KCTRL_OSCULP32K_ULP32KSW_Msk instead */
+#define OSC32KCTRL_OSCULP32K_CALIB_Pos      8                                              /**< (OSC32KCTRL_OSCULP32K) Oscillator Calibration Position */
+#define OSC32KCTRL_OSCULP32K_CALIB_Msk      (_U_(0x1F) << OSC32KCTRL_OSCULP32K_CALIB_Pos)  /**< (OSC32KCTRL_OSCULP32K) Oscillator Calibration Mask */
+#define OSC32KCTRL_OSCULP32K_CALIB(value)   (OSC32KCTRL_OSCULP32K_CALIB_Msk & ((value) << OSC32KCTRL_OSCULP32K_CALIB_Pos))
+#define OSC32KCTRL_OSCULP32K_WRTLOCK_Pos    15                                             /**< (OSC32KCTRL_OSCULP32K) Write Lock Position */
+#define OSC32KCTRL_OSCULP32K_WRTLOCK_Msk    (_U_(0x1) << OSC32KCTRL_OSCULP32K_WRTLOCK_Pos)  /**< (OSC32KCTRL_OSCULP32K) Write Lock Mask */
+#define OSC32KCTRL_OSCULP32K_WRTLOCK        OSC32KCTRL_OSCULP32K_WRTLOCK_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSC32KCTRL_OSCULP32K_WRTLOCK_Msk instead */
+#define OSC32KCTRL_OSCULP32K_MASK           _U_(0x9F20)                                    /**< \deprecated (OSC32KCTRL_OSCULP32K) Register MASK  (Use OSC32KCTRL_OSCULP32K_Msk instead)  */
+#define OSC32KCTRL_OSCULP32K_Msk            _U_(0x9F20)                                    /**< (OSC32KCTRL_OSCULP32K) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief OSC32KCTRL hardware registers */
+typedef struct {  /* 32k Oscillators Control */
+  __IO OSC32KCTRL_INTENCLR_Type       INTENCLR;       /**< Offset: 0x00 (R/W  32) Interrupt Enable Clear */
+  __IO OSC32KCTRL_INTENSET_Type       INTENSET;       /**< Offset: 0x04 (R/W  32) Interrupt Enable Set */
+  __IO OSC32KCTRL_INTFLAG_Type        INTFLAG;        /**< Offset: 0x08 (R/W  32) Interrupt Flag Status and Clear */
+  __I  OSC32KCTRL_STATUS_Type         STATUS;         /**< Offset: 0x0C (R/   32) Power and Clocks Status */
+  __IO OSC32KCTRL_RTCCTRL_Type        RTCCTRL;        /**< Offset: 0x10 (R/W   8) RTC Clock Selection */
+  __I  uint8_t                        Reserved1[3];
+  __IO OSC32KCTRL_XOSC32K_Type        XOSC32K;        /**< Offset: 0x14 (R/W  16) 32kHz External Crystal Oscillator (XOSC32K) Control */
+  __IO OSC32KCTRL_CFDCTRL_Type        CFDCTRL;        /**< Offset: 0x16 (R/W   8) Clock Failure Detector Control */
+  __IO OSC32KCTRL_EVCTRL_Type         EVCTRL;         /**< Offset: 0x17 (R/W   8) Event Control */
+  __I  uint8_t                        Reserved2[4];
+  __IO OSC32KCTRL_OSCULP32K_Type      OSCULP32K;      /**< Offset: 0x1C (R/W  32) 32kHz Ultra Low Power Internal Oscillator (OSCULP32K) Control */
+} Osc32kctrl;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of 32k Oscillators Control */
+
+#endif /* _SAML11_OSC32KCTRL_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/component/oscctrl.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/oscctrl.h
@@ -1,0 +1,878 @@
+/**
+ * \file
+ *
+ * \brief Component description for OSCCTRL
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_OSCCTRL_COMPONENT_H_
+#define _SAML11_OSCCTRL_COMPONENT_H_
+#define _SAML11_OSCCTRL_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML11 Oscillators Control
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR OSCCTRL */
+/* ========================================================================== */
+
+#define OSCCTRL_U2119                      /**< (OSCCTRL) Module ID */
+#define REV_OSCCTRL 0x400                  /**< (OSCCTRL) Module revision */
+
+/* -------- OSCCTRL_EVCTRL : (OSCCTRL Offset: 0x00) (R/W 8) Event Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  CFDEO:1;                   /**< bit:      0  Clock Failure Detector Event Output Enable */
+    uint8_t  TUNEEI:1;                  /**< bit:      1  Tune Event Input Enable                  */
+    uint8_t  TUNEINV:1;                 /**< bit:      2  Tune Event Input Invert                  */
+    uint8_t  :5;                        /**< bit:   3..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} OSCCTRL_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_EVCTRL_OFFSET               (0x00)                                        /**<  (OSCCTRL_EVCTRL) Event Control  Offset */
+#define OSCCTRL_EVCTRL_RESETVALUE           _U_(0x00)                                     /**<  (OSCCTRL_EVCTRL) Event Control  Reset Value */
+
+#define OSCCTRL_EVCTRL_CFDEO_Pos            0                                              /**< (OSCCTRL_EVCTRL) Clock Failure Detector Event Output Enable Position */
+#define OSCCTRL_EVCTRL_CFDEO_Msk            (_U_(0x1) << OSCCTRL_EVCTRL_CFDEO_Pos)         /**< (OSCCTRL_EVCTRL) Clock Failure Detector Event Output Enable Mask */
+#define OSCCTRL_EVCTRL_CFDEO                OSCCTRL_EVCTRL_CFDEO_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_EVCTRL_CFDEO_Msk instead */
+#define OSCCTRL_EVCTRL_TUNEEI_Pos           1                                              /**< (OSCCTRL_EVCTRL) Tune Event Input Enable Position */
+#define OSCCTRL_EVCTRL_TUNEEI_Msk           (_U_(0x1) << OSCCTRL_EVCTRL_TUNEEI_Pos)        /**< (OSCCTRL_EVCTRL) Tune Event Input Enable Mask */
+#define OSCCTRL_EVCTRL_TUNEEI               OSCCTRL_EVCTRL_TUNEEI_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_EVCTRL_TUNEEI_Msk instead */
+#define OSCCTRL_EVCTRL_TUNEINV_Pos          2                                              /**< (OSCCTRL_EVCTRL) Tune Event Input Invert Position */
+#define OSCCTRL_EVCTRL_TUNEINV_Msk          (_U_(0x1) << OSCCTRL_EVCTRL_TUNEINV_Pos)       /**< (OSCCTRL_EVCTRL) Tune Event Input Invert Mask */
+#define OSCCTRL_EVCTRL_TUNEINV              OSCCTRL_EVCTRL_TUNEINV_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_EVCTRL_TUNEINV_Msk instead */
+#define OSCCTRL_EVCTRL_MASK                 _U_(0x07)                                      /**< \deprecated (OSCCTRL_EVCTRL) Register MASK  (Use OSCCTRL_EVCTRL_Msk instead)  */
+#define OSCCTRL_EVCTRL_Msk                  _U_(0x07)                                      /**< (OSCCTRL_EVCTRL) Register Mask  */
+
+
+/* -------- OSCCTRL_INTENCLR : (OSCCTRL Offset: 0x04) (R/W 32) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t XOSCRDY:1;                 /**< bit:      0  XOSC Ready Interrupt Enable              */
+    uint32_t XOSCFAIL:1;                /**< bit:      1  XOSC Clock Failure Detector Interrupt Enable */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t OSC16MRDY:1;               /**< bit:      4  OSC16M Ready Interrupt Enable            */
+    uint32_t :3;                        /**< bit:   5..7  Reserved */
+    uint32_t DFLLULPRDY:1;              /**< bit:      8  DFLLULP Ready interrupt Enable           */
+    uint32_t DFLLULPLOCK:1;             /**< bit:      9  DFLLULP Lock Interrupt Enable            */
+    uint32_t DFLLULPNOLOCK:1;           /**< bit:     10  DFLLULP No Lock Interrupt Enable         */
+    uint32_t :5;                        /**< bit: 11..15  Reserved */
+    uint32_t DPLLLCKR:1;                /**< bit:     16  DPLL Lock Rise Interrupt Enable          */
+    uint32_t DPLLLCKF:1;                /**< bit:     17  DPLL Lock Fall Interrupt Enable          */
+    uint32_t DPLLLTO:1;                 /**< bit:     18  DPLL Lock Timeout Interrupt Enable       */
+    uint32_t DPLLLDRTO:1;               /**< bit:     19  DPLL Loop Divider Ratio Update Complete Interrupt Enable */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} OSCCTRL_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_INTENCLR_OFFSET             (0x04)                                        /**<  (OSCCTRL_INTENCLR) Interrupt Enable Clear  Offset */
+#define OSCCTRL_INTENCLR_RESETVALUE         _U_(0x00)                                     /**<  (OSCCTRL_INTENCLR) Interrupt Enable Clear  Reset Value */
+
+#define OSCCTRL_INTENCLR_XOSCRDY_Pos        0                                              /**< (OSCCTRL_INTENCLR) XOSC Ready Interrupt Enable Position */
+#define OSCCTRL_INTENCLR_XOSCRDY_Msk        (_U_(0x1) << OSCCTRL_INTENCLR_XOSCRDY_Pos)     /**< (OSCCTRL_INTENCLR) XOSC Ready Interrupt Enable Mask */
+#define OSCCTRL_INTENCLR_XOSCRDY            OSCCTRL_INTENCLR_XOSCRDY_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTENCLR_XOSCRDY_Msk instead */
+#define OSCCTRL_INTENCLR_XOSCFAIL_Pos       1                                              /**< (OSCCTRL_INTENCLR) XOSC Clock Failure Detector Interrupt Enable Position */
+#define OSCCTRL_INTENCLR_XOSCFAIL_Msk       (_U_(0x1) << OSCCTRL_INTENCLR_XOSCFAIL_Pos)    /**< (OSCCTRL_INTENCLR) XOSC Clock Failure Detector Interrupt Enable Mask */
+#define OSCCTRL_INTENCLR_XOSCFAIL           OSCCTRL_INTENCLR_XOSCFAIL_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTENCLR_XOSCFAIL_Msk instead */
+#define OSCCTRL_INTENCLR_OSC16MRDY_Pos      4                                              /**< (OSCCTRL_INTENCLR) OSC16M Ready Interrupt Enable Position */
+#define OSCCTRL_INTENCLR_OSC16MRDY_Msk      (_U_(0x1) << OSCCTRL_INTENCLR_OSC16MRDY_Pos)   /**< (OSCCTRL_INTENCLR) OSC16M Ready Interrupt Enable Mask */
+#define OSCCTRL_INTENCLR_OSC16MRDY          OSCCTRL_INTENCLR_OSC16MRDY_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTENCLR_OSC16MRDY_Msk instead */
+#define OSCCTRL_INTENCLR_DFLLULPRDY_Pos     8                                              /**< (OSCCTRL_INTENCLR) DFLLULP Ready interrupt Enable Position */
+#define OSCCTRL_INTENCLR_DFLLULPRDY_Msk     (_U_(0x1) << OSCCTRL_INTENCLR_DFLLULPRDY_Pos)  /**< (OSCCTRL_INTENCLR) DFLLULP Ready interrupt Enable Mask */
+#define OSCCTRL_INTENCLR_DFLLULPRDY         OSCCTRL_INTENCLR_DFLLULPRDY_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTENCLR_DFLLULPRDY_Msk instead */
+#define OSCCTRL_INTENCLR_DFLLULPLOCK_Pos    9                                              /**< (OSCCTRL_INTENCLR) DFLLULP Lock Interrupt Enable Position */
+#define OSCCTRL_INTENCLR_DFLLULPLOCK_Msk    (_U_(0x1) << OSCCTRL_INTENCLR_DFLLULPLOCK_Pos)  /**< (OSCCTRL_INTENCLR) DFLLULP Lock Interrupt Enable Mask */
+#define OSCCTRL_INTENCLR_DFLLULPLOCK        OSCCTRL_INTENCLR_DFLLULPLOCK_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTENCLR_DFLLULPLOCK_Msk instead */
+#define OSCCTRL_INTENCLR_DFLLULPNOLOCK_Pos  10                                             /**< (OSCCTRL_INTENCLR) DFLLULP No Lock Interrupt Enable Position */
+#define OSCCTRL_INTENCLR_DFLLULPNOLOCK_Msk  (_U_(0x1) << OSCCTRL_INTENCLR_DFLLULPNOLOCK_Pos)  /**< (OSCCTRL_INTENCLR) DFLLULP No Lock Interrupt Enable Mask */
+#define OSCCTRL_INTENCLR_DFLLULPNOLOCK      OSCCTRL_INTENCLR_DFLLULPNOLOCK_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTENCLR_DFLLULPNOLOCK_Msk instead */
+#define OSCCTRL_INTENCLR_DPLLLCKR_Pos       16                                             /**< (OSCCTRL_INTENCLR) DPLL Lock Rise Interrupt Enable Position */
+#define OSCCTRL_INTENCLR_DPLLLCKR_Msk       (_U_(0x1) << OSCCTRL_INTENCLR_DPLLLCKR_Pos)    /**< (OSCCTRL_INTENCLR) DPLL Lock Rise Interrupt Enable Mask */
+#define OSCCTRL_INTENCLR_DPLLLCKR           OSCCTRL_INTENCLR_DPLLLCKR_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTENCLR_DPLLLCKR_Msk instead */
+#define OSCCTRL_INTENCLR_DPLLLCKF_Pos       17                                             /**< (OSCCTRL_INTENCLR) DPLL Lock Fall Interrupt Enable Position */
+#define OSCCTRL_INTENCLR_DPLLLCKF_Msk       (_U_(0x1) << OSCCTRL_INTENCLR_DPLLLCKF_Pos)    /**< (OSCCTRL_INTENCLR) DPLL Lock Fall Interrupt Enable Mask */
+#define OSCCTRL_INTENCLR_DPLLLCKF           OSCCTRL_INTENCLR_DPLLLCKF_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTENCLR_DPLLLCKF_Msk instead */
+#define OSCCTRL_INTENCLR_DPLLLTO_Pos        18                                             /**< (OSCCTRL_INTENCLR) DPLL Lock Timeout Interrupt Enable Position */
+#define OSCCTRL_INTENCLR_DPLLLTO_Msk        (_U_(0x1) << OSCCTRL_INTENCLR_DPLLLTO_Pos)     /**< (OSCCTRL_INTENCLR) DPLL Lock Timeout Interrupt Enable Mask */
+#define OSCCTRL_INTENCLR_DPLLLTO            OSCCTRL_INTENCLR_DPLLLTO_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTENCLR_DPLLLTO_Msk instead */
+#define OSCCTRL_INTENCLR_DPLLLDRTO_Pos      19                                             /**< (OSCCTRL_INTENCLR) DPLL Loop Divider Ratio Update Complete Interrupt Enable Position */
+#define OSCCTRL_INTENCLR_DPLLLDRTO_Msk      (_U_(0x1) << OSCCTRL_INTENCLR_DPLLLDRTO_Pos)   /**< (OSCCTRL_INTENCLR) DPLL Loop Divider Ratio Update Complete Interrupt Enable Mask */
+#define OSCCTRL_INTENCLR_DPLLLDRTO          OSCCTRL_INTENCLR_DPLLLDRTO_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTENCLR_DPLLLDRTO_Msk instead */
+#define OSCCTRL_INTENCLR_MASK               _U_(0xF0713)                                   /**< \deprecated (OSCCTRL_INTENCLR) Register MASK  (Use OSCCTRL_INTENCLR_Msk instead)  */
+#define OSCCTRL_INTENCLR_Msk                _U_(0xF0713)                                   /**< (OSCCTRL_INTENCLR) Register Mask  */
+
+
+/* -------- OSCCTRL_INTENSET : (OSCCTRL Offset: 0x08) (R/W 32) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t XOSCRDY:1;                 /**< bit:      0  XOSC Ready Interrupt Enable              */
+    uint32_t XOSCFAIL:1;                /**< bit:      1  XOSC Clock Failure Detector Interrupt Enable */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t OSC16MRDY:1;               /**< bit:      4  OSC16M Ready Interrupt Enable            */
+    uint32_t :3;                        /**< bit:   5..7  Reserved */
+    uint32_t DFLLULPRDY:1;              /**< bit:      8  DFLLULP Ready interrupt Enable           */
+    uint32_t DFLLULPLOCK:1;             /**< bit:      9  DFLLULP Lock Interrupt Enable            */
+    uint32_t DFLLULPNOLOCK:1;           /**< bit:     10  DFLLULP No Lock Interrupt Enable         */
+    uint32_t :5;                        /**< bit: 11..15  Reserved */
+    uint32_t DPLLLCKR:1;                /**< bit:     16  DPLL Lock Rise Interrupt Enable          */
+    uint32_t DPLLLCKF:1;                /**< bit:     17  DPLL Lock Fall Interrupt Enable          */
+    uint32_t DPLLLTO:1;                 /**< bit:     18  DPLL Lock Timeout Interrupt Enable       */
+    uint32_t DPLLLDRTO:1;               /**< bit:     19  DPLL Loop Divider Ratio Update Complete Interrupt Enable */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} OSCCTRL_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_INTENSET_OFFSET             (0x08)                                        /**<  (OSCCTRL_INTENSET) Interrupt Enable Set  Offset */
+#define OSCCTRL_INTENSET_RESETVALUE         _U_(0x00)                                     /**<  (OSCCTRL_INTENSET) Interrupt Enable Set  Reset Value */
+
+#define OSCCTRL_INTENSET_XOSCRDY_Pos        0                                              /**< (OSCCTRL_INTENSET) XOSC Ready Interrupt Enable Position */
+#define OSCCTRL_INTENSET_XOSCRDY_Msk        (_U_(0x1) << OSCCTRL_INTENSET_XOSCRDY_Pos)     /**< (OSCCTRL_INTENSET) XOSC Ready Interrupt Enable Mask */
+#define OSCCTRL_INTENSET_XOSCRDY            OSCCTRL_INTENSET_XOSCRDY_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTENSET_XOSCRDY_Msk instead */
+#define OSCCTRL_INTENSET_XOSCFAIL_Pos       1                                              /**< (OSCCTRL_INTENSET) XOSC Clock Failure Detector Interrupt Enable Position */
+#define OSCCTRL_INTENSET_XOSCFAIL_Msk       (_U_(0x1) << OSCCTRL_INTENSET_XOSCFAIL_Pos)    /**< (OSCCTRL_INTENSET) XOSC Clock Failure Detector Interrupt Enable Mask */
+#define OSCCTRL_INTENSET_XOSCFAIL           OSCCTRL_INTENSET_XOSCFAIL_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTENSET_XOSCFAIL_Msk instead */
+#define OSCCTRL_INTENSET_OSC16MRDY_Pos      4                                              /**< (OSCCTRL_INTENSET) OSC16M Ready Interrupt Enable Position */
+#define OSCCTRL_INTENSET_OSC16MRDY_Msk      (_U_(0x1) << OSCCTRL_INTENSET_OSC16MRDY_Pos)   /**< (OSCCTRL_INTENSET) OSC16M Ready Interrupt Enable Mask */
+#define OSCCTRL_INTENSET_OSC16MRDY          OSCCTRL_INTENSET_OSC16MRDY_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTENSET_OSC16MRDY_Msk instead */
+#define OSCCTRL_INTENSET_DFLLULPRDY_Pos     8                                              /**< (OSCCTRL_INTENSET) DFLLULP Ready interrupt Enable Position */
+#define OSCCTRL_INTENSET_DFLLULPRDY_Msk     (_U_(0x1) << OSCCTRL_INTENSET_DFLLULPRDY_Pos)  /**< (OSCCTRL_INTENSET) DFLLULP Ready interrupt Enable Mask */
+#define OSCCTRL_INTENSET_DFLLULPRDY         OSCCTRL_INTENSET_DFLLULPRDY_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTENSET_DFLLULPRDY_Msk instead */
+#define OSCCTRL_INTENSET_DFLLULPLOCK_Pos    9                                              /**< (OSCCTRL_INTENSET) DFLLULP Lock Interrupt Enable Position */
+#define OSCCTRL_INTENSET_DFLLULPLOCK_Msk    (_U_(0x1) << OSCCTRL_INTENSET_DFLLULPLOCK_Pos)  /**< (OSCCTRL_INTENSET) DFLLULP Lock Interrupt Enable Mask */
+#define OSCCTRL_INTENSET_DFLLULPLOCK        OSCCTRL_INTENSET_DFLLULPLOCK_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTENSET_DFLLULPLOCK_Msk instead */
+#define OSCCTRL_INTENSET_DFLLULPNOLOCK_Pos  10                                             /**< (OSCCTRL_INTENSET) DFLLULP No Lock Interrupt Enable Position */
+#define OSCCTRL_INTENSET_DFLLULPNOLOCK_Msk  (_U_(0x1) << OSCCTRL_INTENSET_DFLLULPNOLOCK_Pos)  /**< (OSCCTRL_INTENSET) DFLLULP No Lock Interrupt Enable Mask */
+#define OSCCTRL_INTENSET_DFLLULPNOLOCK      OSCCTRL_INTENSET_DFLLULPNOLOCK_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTENSET_DFLLULPNOLOCK_Msk instead */
+#define OSCCTRL_INTENSET_DPLLLCKR_Pos       16                                             /**< (OSCCTRL_INTENSET) DPLL Lock Rise Interrupt Enable Position */
+#define OSCCTRL_INTENSET_DPLLLCKR_Msk       (_U_(0x1) << OSCCTRL_INTENSET_DPLLLCKR_Pos)    /**< (OSCCTRL_INTENSET) DPLL Lock Rise Interrupt Enable Mask */
+#define OSCCTRL_INTENSET_DPLLLCKR           OSCCTRL_INTENSET_DPLLLCKR_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTENSET_DPLLLCKR_Msk instead */
+#define OSCCTRL_INTENSET_DPLLLCKF_Pos       17                                             /**< (OSCCTRL_INTENSET) DPLL Lock Fall Interrupt Enable Position */
+#define OSCCTRL_INTENSET_DPLLLCKF_Msk       (_U_(0x1) << OSCCTRL_INTENSET_DPLLLCKF_Pos)    /**< (OSCCTRL_INTENSET) DPLL Lock Fall Interrupt Enable Mask */
+#define OSCCTRL_INTENSET_DPLLLCKF           OSCCTRL_INTENSET_DPLLLCKF_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTENSET_DPLLLCKF_Msk instead */
+#define OSCCTRL_INTENSET_DPLLLTO_Pos        18                                             /**< (OSCCTRL_INTENSET) DPLL Lock Timeout Interrupt Enable Position */
+#define OSCCTRL_INTENSET_DPLLLTO_Msk        (_U_(0x1) << OSCCTRL_INTENSET_DPLLLTO_Pos)     /**< (OSCCTRL_INTENSET) DPLL Lock Timeout Interrupt Enable Mask */
+#define OSCCTRL_INTENSET_DPLLLTO            OSCCTRL_INTENSET_DPLLLTO_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTENSET_DPLLLTO_Msk instead */
+#define OSCCTRL_INTENSET_DPLLLDRTO_Pos      19                                             /**< (OSCCTRL_INTENSET) DPLL Loop Divider Ratio Update Complete Interrupt Enable Position */
+#define OSCCTRL_INTENSET_DPLLLDRTO_Msk      (_U_(0x1) << OSCCTRL_INTENSET_DPLLLDRTO_Pos)   /**< (OSCCTRL_INTENSET) DPLL Loop Divider Ratio Update Complete Interrupt Enable Mask */
+#define OSCCTRL_INTENSET_DPLLLDRTO          OSCCTRL_INTENSET_DPLLLDRTO_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTENSET_DPLLLDRTO_Msk instead */
+#define OSCCTRL_INTENSET_MASK               _U_(0xF0713)                                   /**< \deprecated (OSCCTRL_INTENSET) Register MASK  (Use OSCCTRL_INTENSET_Msk instead)  */
+#define OSCCTRL_INTENSET_Msk                _U_(0xF0713)                                   /**< (OSCCTRL_INTENSET) Register Mask  */
+
+
+/* -------- OSCCTRL_INTFLAG : (OSCCTRL Offset: 0x0c) (R/W 32) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint32_t XOSCRDY:1;                 /**< bit:      0  XOSC Ready                               */
+    __I uint32_t XOSCFAIL:1;                /**< bit:      1  XOSC Clock Failure Detector              */
+    __I uint32_t :2;                        /**< bit:   2..3  Reserved */
+    __I uint32_t OSC16MRDY:1;               /**< bit:      4  OSC16M Ready                             */
+    __I uint32_t :3;                        /**< bit:   5..7  Reserved */
+    __I uint32_t DFLLULPRDY:1;              /**< bit:      8  DFLLULP Ready                            */
+    __I uint32_t DFLLULPLOCK:1;             /**< bit:      9  DFLLULP Lock                             */
+    __I uint32_t DFLLULPNOLOCK:1;           /**< bit:     10  DFLLULP No Lock                          */
+    __I uint32_t :5;                        /**< bit: 11..15  Reserved */
+    __I uint32_t DPLLLCKR:1;                /**< bit:     16  DPLL Lock Rise                           */
+    __I uint32_t DPLLLCKF:1;                /**< bit:     17  DPLL Lock Fall                           */
+    __I uint32_t DPLLLTO:1;                 /**< bit:     18  DPLL Lock Timeout                        */
+    __I uint32_t DPLLLDRTO:1;               /**< bit:     19  DPLL Loop Divider Ratio Update Complete  */
+    __I uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} OSCCTRL_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_INTFLAG_OFFSET              (0x0C)                                        /**<  (OSCCTRL_INTFLAG) Interrupt Flag Status and Clear  Offset */
+#define OSCCTRL_INTFLAG_RESETVALUE          _U_(0x00)                                     /**<  (OSCCTRL_INTFLAG) Interrupt Flag Status and Clear  Reset Value */
+
+#define OSCCTRL_INTFLAG_XOSCRDY_Pos         0                                              /**< (OSCCTRL_INTFLAG) XOSC Ready Position */
+#define OSCCTRL_INTFLAG_XOSCRDY_Msk         (_U_(0x1) << OSCCTRL_INTFLAG_XOSCRDY_Pos)      /**< (OSCCTRL_INTFLAG) XOSC Ready Mask */
+#define OSCCTRL_INTFLAG_XOSCRDY             OSCCTRL_INTFLAG_XOSCRDY_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTFLAG_XOSCRDY_Msk instead */
+#define OSCCTRL_INTFLAG_XOSCFAIL_Pos        1                                              /**< (OSCCTRL_INTFLAG) XOSC Clock Failure Detector Position */
+#define OSCCTRL_INTFLAG_XOSCFAIL_Msk        (_U_(0x1) << OSCCTRL_INTFLAG_XOSCFAIL_Pos)     /**< (OSCCTRL_INTFLAG) XOSC Clock Failure Detector Mask */
+#define OSCCTRL_INTFLAG_XOSCFAIL            OSCCTRL_INTFLAG_XOSCFAIL_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTFLAG_XOSCFAIL_Msk instead */
+#define OSCCTRL_INTFLAG_OSC16MRDY_Pos       4                                              /**< (OSCCTRL_INTFLAG) OSC16M Ready Position */
+#define OSCCTRL_INTFLAG_OSC16MRDY_Msk       (_U_(0x1) << OSCCTRL_INTFLAG_OSC16MRDY_Pos)    /**< (OSCCTRL_INTFLAG) OSC16M Ready Mask */
+#define OSCCTRL_INTFLAG_OSC16MRDY           OSCCTRL_INTFLAG_OSC16MRDY_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTFLAG_OSC16MRDY_Msk instead */
+#define OSCCTRL_INTFLAG_DFLLULPRDY_Pos      8                                              /**< (OSCCTRL_INTFLAG) DFLLULP Ready Position */
+#define OSCCTRL_INTFLAG_DFLLULPRDY_Msk      (_U_(0x1) << OSCCTRL_INTFLAG_DFLLULPRDY_Pos)   /**< (OSCCTRL_INTFLAG) DFLLULP Ready Mask */
+#define OSCCTRL_INTFLAG_DFLLULPRDY          OSCCTRL_INTFLAG_DFLLULPRDY_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTFLAG_DFLLULPRDY_Msk instead */
+#define OSCCTRL_INTFLAG_DFLLULPLOCK_Pos     9                                              /**< (OSCCTRL_INTFLAG) DFLLULP Lock Position */
+#define OSCCTRL_INTFLAG_DFLLULPLOCK_Msk     (_U_(0x1) << OSCCTRL_INTFLAG_DFLLULPLOCK_Pos)  /**< (OSCCTRL_INTFLAG) DFLLULP Lock Mask */
+#define OSCCTRL_INTFLAG_DFLLULPLOCK         OSCCTRL_INTFLAG_DFLLULPLOCK_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTFLAG_DFLLULPLOCK_Msk instead */
+#define OSCCTRL_INTFLAG_DFLLULPNOLOCK_Pos   10                                             /**< (OSCCTRL_INTFLAG) DFLLULP No Lock Position */
+#define OSCCTRL_INTFLAG_DFLLULPNOLOCK_Msk   (_U_(0x1) << OSCCTRL_INTFLAG_DFLLULPNOLOCK_Pos)  /**< (OSCCTRL_INTFLAG) DFLLULP No Lock Mask */
+#define OSCCTRL_INTFLAG_DFLLULPNOLOCK       OSCCTRL_INTFLAG_DFLLULPNOLOCK_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTFLAG_DFLLULPNOLOCK_Msk instead */
+#define OSCCTRL_INTFLAG_DPLLLCKR_Pos        16                                             /**< (OSCCTRL_INTFLAG) DPLL Lock Rise Position */
+#define OSCCTRL_INTFLAG_DPLLLCKR_Msk        (_U_(0x1) << OSCCTRL_INTFLAG_DPLLLCKR_Pos)     /**< (OSCCTRL_INTFLAG) DPLL Lock Rise Mask */
+#define OSCCTRL_INTFLAG_DPLLLCKR            OSCCTRL_INTFLAG_DPLLLCKR_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTFLAG_DPLLLCKR_Msk instead */
+#define OSCCTRL_INTFLAG_DPLLLCKF_Pos        17                                             /**< (OSCCTRL_INTFLAG) DPLL Lock Fall Position */
+#define OSCCTRL_INTFLAG_DPLLLCKF_Msk        (_U_(0x1) << OSCCTRL_INTFLAG_DPLLLCKF_Pos)     /**< (OSCCTRL_INTFLAG) DPLL Lock Fall Mask */
+#define OSCCTRL_INTFLAG_DPLLLCKF            OSCCTRL_INTFLAG_DPLLLCKF_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTFLAG_DPLLLCKF_Msk instead */
+#define OSCCTRL_INTFLAG_DPLLLTO_Pos         18                                             /**< (OSCCTRL_INTFLAG) DPLL Lock Timeout Position */
+#define OSCCTRL_INTFLAG_DPLLLTO_Msk         (_U_(0x1) << OSCCTRL_INTFLAG_DPLLLTO_Pos)      /**< (OSCCTRL_INTFLAG) DPLL Lock Timeout Mask */
+#define OSCCTRL_INTFLAG_DPLLLTO             OSCCTRL_INTFLAG_DPLLLTO_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTFLAG_DPLLLTO_Msk instead */
+#define OSCCTRL_INTFLAG_DPLLLDRTO_Pos       19                                             /**< (OSCCTRL_INTFLAG) DPLL Loop Divider Ratio Update Complete Position */
+#define OSCCTRL_INTFLAG_DPLLLDRTO_Msk       (_U_(0x1) << OSCCTRL_INTFLAG_DPLLLDRTO_Pos)    /**< (OSCCTRL_INTFLAG) DPLL Loop Divider Ratio Update Complete Mask */
+#define OSCCTRL_INTFLAG_DPLLLDRTO           OSCCTRL_INTFLAG_DPLLLDRTO_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_INTFLAG_DPLLLDRTO_Msk instead */
+#define OSCCTRL_INTFLAG_MASK                _U_(0xF0713)                                   /**< \deprecated (OSCCTRL_INTFLAG) Register MASK  (Use OSCCTRL_INTFLAG_Msk instead)  */
+#define OSCCTRL_INTFLAG_Msk                 _U_(0xF0713)                                   /**< (OSCCTRL_INTFLAG) Register Mask  */
+
+
+/* -------- OSCCTRL_STATUS : (OSCCTRL Offset: 0x10) (R/ 32) Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t XOSCRDY:1;                 /**< bit:      0  XOSC Ready                               */
+    uint32_t XOSCFAIL:1;                /**< bit:      1  XOSC Clock Failure Detector              */
+    uint32_t XOSCCKSW:1;                /**< bit:      2  XOSC Clock Switch                        */
+    uint32_t :1;                        /**< bit:      3  Reserved */
+    uint32_t OSC16MRDY:1;               /**< bit:      4  OSC16M Ready                             */
+    uint32_t :3;                        /**< bit:   5..7  Reserved */
+    uint32_t DFLLULPRDY:1;              /**< bit:      8  DFLLULP Ready                            */
+    uint32_t DFLLULPLOCK:1;             /**< bit:      9  DFLLULP Lock                             */
+    uint32_t DFLLULPNOLOCK:1;           /**< bit:     10  DFLLULP No Lock                          */
+    uint32_t :5;                        /**< bit: 11..15  Reserved */
+    uint32_t DPLLLCKR:1;                /**< bit:     16  DPLL Lock Rise                           */
+    uint32_t DPLLLCKF:1;                /**< bit:     17  DPLL Lock Fall                           */
+    uint32_t DPLLTO:1;                  /**< bit:     18  DPLL Lock Timeout                        */
+    uint32_t DPLLLDRTO:1;               /**< bit:     19  DPLL Loop Divider Ratio Update Complete  */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} OSCCTRL_STATUS_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_STATUS_OFFSET               (0x10)                                        /**<  (OSCCTRL_STATUS) Status  Offset */
+#define OSCCTRL_STATUS_RESETVALUE           _U_(0x00)                                     /**<  (OSCCTRL_STATUS) Status  Reset Value */
+
+#define OSCCTRL_STATUS_XOSCRDY_Pos          0                                              /**< (OSCCTRL_STATUS) XOSC Ready Position */
+#define OSCCTRL_STATUS_XOSCRDY_Msk          (_U_(0x1) << OSCCTRL_STATUS_XOSCRDY_Pos)       /**< (OSCCTRL_STATUS) XOSC Ready Mask */
+#define OSCCTRL_STATUS_XOSCRDY              OSCCTRL_STATUS_XOSCRDY_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_STATUS_XOSCRDY_Msk instead */
+#define OSCCTRL_STATUS_XOSCFAIL_Pos         1                                              /**< (OSCCTRL_STATUS) XOSC Clock Failure Detector Position */
+#define OSCCTRL_STATUS_XOSCFAIL_Msk         (_U_(0x1) << OSCCTRL_STATUS_XOSCFAIL_Pos)      /**< (OSCCTRL_STATUS) XOSC Clock Failure Detector Mask */
+#define OSCCTRL_STATUS_XOSCFAIL             OSCCTRL_STATUS_XOSCFAIL_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_STATUS_XOSCFAIL_Msk instead */
+#define OSCCTRL_STATUS_XOSCCKSW_Pos         2                                              /**< (OSCCTRL_STATUS) XOSC Clock Switch Position */
+#define OSCCTRL_STATUS_XOSCCKSW_Msk         (_U_(0x1) << OSCCTRL_STATUS_XOSCCKSW_Pos)      /**< (OSCCTRL_STATUS) XOSC Clock Switch Mask */
+#define OSCCTRL_STATUS_XOSCCKSW             OSCCTRL_STATUS_XOSCCKSW_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_STATUS_XOSCCKSW_Msk instead */
+#define OSCCTRL_STATUS_OSC16MRDY_Pos        4                                              /**< (OSCCTRL_STATUS) OSC16M Ready Position */
+#define OSCCTRL_STATUS_OSC16MRDY_Msk        (_U_(0x1) << OSCCTRL_STATUS_OSC16MRDY_Pos)     /**< (OSCCTRL_STATUS) OSC16M Ready Mask */
+#define OSCCTRL_STATUS_OSC16MRDY            OSCCTRL_STATUS_OSC16MRDY_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_STATUS_OSC16MRDY_Msk instead */
+#define OSCCTRL_STATUS_DFLLULPRDY_Pos       8                                              /**< (OSCCTRL_STATUS) DFLLULP Ready Position */
+#define OSCCTRL_STATUS_DFLLULPRDY_Msk       (_U_(0x1) << OSCCTRL_STATUS_DFLLULPRDY_Pos)    /**< (OSCCTRL_STATUS) DFLLULP Ready Mask */
+#define OSCCTRL_STATUS_DFLLULPRDY           OSCCTRL_STATUS_DFLLULPRDY_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_STATUS_DFLLULPRDY_Msk instead */
+#define OSCCTRL_STATUS_DFLLULPLOCK_Pos      9                                              /**< (OSCCTRL_STATUS) DFLLULP Lock Position */
+#define OSCCTRL_STATUS_DFLLULPLOCK_Msk      (_U_(0x1) << OSCCTRL_STATUS_DFLLULPLOCK_Pos)   /**< (OSCCTRL_STATUS) DFLLULP Lock Mask */
+#define OSCCTRL_STATUS_DFLLULPLOCK          OSCCTRL_STATUS_DFLLULPLOCK_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_STATUS_DFLLULPLOCK_Msk instead */
+#define OSCCTRL_STATUS_DFLLULPNOLOCK_Pos    10                                             /**< (OSCCTRL_STATUS) DFLLULP No Lock Position */
+#define OSCCTRL_STATUS_DFLLULPNOLOCK_Msk    (_U_(0x1) << OSCCTRL_STATUS_DFLLULPNOLOCK_Pos)  /**< (OSCCTRL_STATUS) DFLLULP No Lock Mask */
+#define OSCCTRL_STATUS_DFLLULPNOLOCK        OSCCTRL_STATUS_DFLLULPNOLOCK_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_STATUS_DFLLULPNOLOCK_Msk instead */
+#define OSCCTRL_STATUS_DPLLLCKR_Pos         16                                             /**< (OSCCTRL_STATUS) DPLL Lock Rise Position */
+#define OSCCTRL_STATUS_DPLLLCKR_Msk         (_U_(0x1) << OSCCTRL_STATUS_DPLLLCKR_Pos)      /**< (OSCCTRL_STATUS) DPLL Lock Rise Mask */
+#define OSCCTRL_STATUS_DPLLLCKR             OSCCTRL_STATUS_DPLLLCKR_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_STATUS_DPLLLCKR_Msk instead */
+#define OSCCTRL_STATUS_DPLLLCKF_Pos         17                                             /**< (OSCCTRL_STATUS) DPLL Lock Fall Position */
+#define OSCCTRL_STATUS_DPLLLCKF_Msk         (_U_(0x1) << OSCCTRL_STATUS_DPLLLCKF_Pos)      /**< (OSCCTRL_STATUS) DPLL Lock Fall Mask */
+#define OSCCTRL_STATUS_DPLLLCKF             OSCCTRL_STATUS_DPLLLCKF_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_STATUS_DPLLLCKF_Msk instead */
+#define OSCCTRL_STATUS_DPLLTO_Pos           18                                             /**< (OSCCTRL_STATUS) DPLL Lock Timeout Position */
+#define OSCCTRL_STATUS_DPLLTO_Msk           (_U_(0x1) << OSCCTRL_STATUS_DPLLTO_Pos)        /**< (OSCCTRL_STATUS) DPLL Lock Timeout Mask */
+#define OSCCTRL_STATUS_DPLLTO               OSCCTRL_STATUS_DPLLTO_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_STATUS_DPLLTO_Msk instead */
+#define OSCCTRL_STATUS_DPLLLDRTO_Pos        19                                             /**< (OSCCTRL_STATUS) DPLL Loop Divider Ratio Update Complete Position */
+#define OSCCTRL_STATUS_DPLLLDRTO_Msk        (_U_(0x1) << OSCCTRL_STATUS_DPLLLDRTO_Pos)     /**< (OSCCTRL_STATUS) DPLL Loop Divider Ratio Update Complete Mask */
+#define OSCCTRL_STATUS_DPLLLDRTO            OSCCTRL_STATUS_DPLLLDRTO_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_STATUS_DPLLLDRTO_Msk instead */
+#define OSCCTRL_STATUS_MASK                 _U_(0xF0717)                                   /**< \deprecated (OSCCTRL_STATUS) Register MASK  (Use OSCCTRL_STATUS_Msk instead)  */
+#define OSCCTRL_STATUS_Msk                  _U_(0xF0717)                                   /**< (OSCCTRL_STATUS) Register Mask  */
+
+
+/* -------- OSCCTRL_XOSCCTRL : (OSCCTRL Offset: 0x14) (R/W 16) External Multipurpose Crystal Oscillator (XOSC) Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t :1;                        /**< bit:      0  Reserved */
+    uint16_t ENABLE:1;                  /**< bit:      1  Oscillator Enable                        */
+    uint16_t XTALEN:1;                  /**< bit:      2  Crystal Oscillator Enable                */
+    uint16_t CFDEN:1;                   /**< bit:      3  Clock Failure Detector Enable            */
+    uint16_t SWBEN:1;                   /**< bit:      4  Xosc Clock Switch Enable                 */
+    uint16_t :1;                        /**< bit:      5  Reserved */
+    uint16_t RUNSTDBY:1;                /**< bit:      6  Run in Standby                           */
+    uint16_t ONDEMAND:1;                /**< bit:      7  On Demand Control                        */
+    uint16_t GAIN:3;                    /**< bit:  8..10  Oscillator Gain                          */
+    uint16_t AMPGC:1;                   /**< bit:     11  Automatic Amplitude Gain Control         */
+    uint16_t STARTUP:4;                 /**< bit: 12..15  Start-Up Time                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} OSCCTRL_XOSCCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_XOSCCTRL_OFFSET             (0x14)                                        /**<  (OSCCTRL_XOSCCTRL) External Multipurpose Crystal Oscillator (XOSC) Control  Offset */
+#define OSCCTRL_XOSCCTRL_RESETVALUE         _U_(0x80)                                     /**<  (OSCCTRL_XOSCCTRL) External Multipurpose Crystal Oscillator (XOSC) Control  Reset Value */
+
+#define OSCCTRL_XOSCCTRL_ENABLE_Pos         1                                              /**< (OSCCTRL_XOSCCTRL) Oscillator Enable Position */
+#define OSCCTRL_XOSCCTRL_ENABLE_Msk         (_U_(0x1) << OSCCTRL_XOSCCTRL_ENABLE_Pos)      /**< (OSCCTRL_XOSCCTRL) Oscillator Enable Mask */
+#define OSCCTRL_XOSCCTRL_ENABLE             OSCCTRL_XOSCCTRL_ENABLE_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_XOSCCTRL_ENABLE_Msk instead */
+#define OSCCTRL_XOSCCTRL_XTALEN_Pos         2                                              /**< (OSCCTRL_XOSCCTRL) Crystal Oscillator Enable Position */
+#define OSCCTRL_XOSCCTRL_XTALEN_Msk         (_U_(0x1) << OSCCTRL_XOSCCTRL_XTALEN_Pos)      /**< (OSCCTRL_XOSCCTRL) Crystal Oscillator Enable Mask */
+#define OSCCTRL_XOSCCTRL_XTALEN             OSCCTRL_XOSCCTRL_XTALEN_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_XOSCCTRL_XTALEN_Msk instead */
+#define OSCCTRL_XOSCCTRL_CFDEN_Pos          3                                              /**< (OSCCTRL_XOSCCTRL) Clock Failure Detector Enable Position */
+#define OSCCTRL_XOSCCTRL_CFDEN_Msk          (_U_(0x1) << OSCCTRL_XOSCCTRL_CFDEN_Pos)       /**< (OSCCTRL_XOSCCTRL) Clock Failure Detector Enable Mask */
+#define OSCCTRL_XOSCCTRL_CFDEN              OSCCTRL_XOSCCTRL_CFDEN_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_XOSCCTRL_CFDEN_Msk instead */
+#define OSCCTRL_XOSCCTRL_SWBEN_Pos          4                                              /**< (OSCCTRL_XOSCCTRL) Xosc Clock Switch Enable Position */
+#define OSCCTRL_XOSCCTRL_SWBEN_Msk          (_U_(0x1) << OSCCTRL_XOSCCTRL_SWBEN_Pos)       /**< (OSCCTRL_XOSCCTRL) Xosc Clock Switch Enable Mask */
+#define OSCCTRL_XOSCCTRL_SWBEN              OSCCTRL_XOSCCTRL_SWBEN_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_XOSCCTRL_SWBEN_Msk instead */
+#define OSCCTRL_XOSCCTRL_RUNSTDBY_Pos       6                                              /**< (OSCCTRL_XOSCCTRL) Run in Standby Position */
+#define OSCCTRL_XOSCCTRL_RUNSTDBY_Msk       (_U_(0x1) << OSCCTRL_XOSCCTRL_RUNSTDBY_Pos)    /**< (OSCCTRL_XOSCCTRL) Run in Standby Mask */
+#define OSCCTRL_XOSCCTRL_RUNSTDBY           OSCCTRL_XOSCCTRL_RUNSTDBY_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_XOSCCTRL_RUNSTDBY_Msk instead */
+#define OSCCTRL_XOSCCTRL_ONDEMAND_Pos       7                                              /**< (OSCCTRL_XOSCCTRL) On Demand Control Position */
+#define OSCCTRL_XOSCCTRL_ONDEMAND_Msk       (_U_(0x1) << OSCCTRL_XOSCCTRL_ONDEMAND_Pos)    /**< (OSCCTRL_XOSCCTRL) On Demand Control Mask */
+#define OSCCTRL_XOSCCTRL_ONDEMAND           OSCCTRL_XOSCCTRL_ONDEMAND_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_XOSCCTRL_ONDEMAND_Msk instead */
+#define OSCCTRL_XOSCCTRL_GAIN_Pos           8                                              /**< (OSCCTRL_XOSCCTRL) Oscillator Gain Position */
+#define OSCCTRL_XOSCCTRL_GAIN_Msk           (_U_(0x7) << OSCCTRL_XOSCCTRL_GAIN_Pos)        /**< (OSCCTRL_XOSCCTRL) Oscillator Gain Mask */
+#define OSCCTRL_XOSCCTRL_GAIN(value)        (OSCCTRL_XOSCCTRL_GAIN_Msk & ((value) << OSCCTRL_XOSCCTRL_GAIN_Pos))
+#define OSCCTRL_XOSCCTRL_AMPGC_Pos          11                                             /**< (OSCCTRL_XOSCCTRL) Automatic Amplitude Gain Control Position */
+#define OSCCTRL_XOSCCTRL_AMPGC_Msk          (_U_(0x1) << OSCCTRL_XOSCCTRL_AMPGC_Pos)       /**< (OSCCTRL_XOSCCTRL) Automatic Amplitude Gain Control Mask */
+#define OSCCTRL_XOSCCTRL_AMPGC              OSCCTRL_XOSCCTRL_AMPGC_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_XOSCCTRL_AMPGC_Msk instead */
+#define OSCCTRL_XOSCCTRL_STARTUP_Pos        12                                             /**< (OSCCTRL_XOSCCTRL) Start-Up Time Position */
+#define OSCCTRL_XOSCCTRL_STARTUP_Msk        (_U_(0xF) << OSCCTRL_XOSCCTRL_STARTUP_Pos)     /**< (OSCCTRL_XOSCCTRL) Start-Up Time Mask */
+#define OSCCTRL_XOSCCTRL_STARTUP(value)     (OSCCTRL_XOSCCTRL_STARTUP_Msk & ((value) << OSCCTRL_XOSCCTRL_STARTUP_Pos))
+#define OSCCTRL_XOSCCTRL_MASK               _U_(0xFFDE)                                    /**< \deprecated (OSCCTRL_XOSCCTRL) Register MASK  (Use OSCCTRL_XOSCCTRL_Msk instead)  */
+#define OSCCTRL_XOSCCTRL_Msk                _U_(0xFFDE)                                    /**< (OSCCTRL_XOSCCTRL) Register Mask  */
+
+
+/* -------- OSCCTRL_CFDPRESC : (OSCCTRL Offset: 0x16) (R/W 8) Clock Failure Detector Prescaler -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  CFDPRESC:3;                /**< bit:   0..2  Clock Failure Detector Prescaler         */
+    uint8_t  :5;                        /**< bit:   3..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} OSCCTRL_CFDPRESC_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_CFDPRESC_OFFSET             (0x16)                                        /**<  (OSCCTRL_CFDPRESC) Clock Failure Detector Prescaler  Offset */
+#define OSCCTRL_CFDPRESC_RESETVALUE         _U_(0x00)                                     /**<  (OSCCTRL_CFDPRESC) Clock Failure Detector Prescaler  Reset Value */
+
+#define OSCCTRL_CFDPRESC_CFDPRESC_Pos       0                                              /**< (OSCCTRL_CFDPRESC) Clock Failure Detector Prescaler Position */
+#define OSCCTRL_CFDPRESC_CFDPRESC_Msk       (_U_(0x7) << OSCCTRL_CFDPRESC_CFDPRESC_Pos)    /**< (OSCCTRL_CFDPRESC) Clock Failure Detector Prescaler Mask */
+#define OSCCTRL_CFDPRESC_CFDPRESC(value)    (OSCCTRL_CFDPRESC_CFDPRESC_Msk & ((value) << OSCCTRL_CFDPRESC_CFDPRESC_Pos))
+#define OSCCTRL_CFDPRESC_MASK               _U_(0x07)                                      /**< \deprecated (OSCCTRL_CFDPRESC) Register MASK  (Use OSCCTRL_CFDPRESC_Msk instead)  */
+#define OSCCTRL_CFDPRESC_Msk                _U_(0x07)                                      /**< (OSCCTRL_CFDPRESC) Register Mask  */
+
+
+/* -------- OSCCTRL_OSC16MCTRL : (OSCCTRL Offset: 0x18) (R/W 8) 16MHz Internal Oscillator (OSC16M) Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  :1;                        /**< bit:      0  Reserved */
+    uint8_t  ENABLE:1;                  /**< bit:      1  Oscillator Enable                        */
+    uint8_t  FSEL:2;                    /**< bit:   2..3  Oscillator Frequency Selection           */
+    uint8_t  :2;                        /**< bit:   4..5  Reserved */
+    uint8_t  RUNSTDBY:1;                /**< bit:      6  Run in Standby                           */
+    uint8_t  ONDEMAND:1;                /**< bit:      7  On Demand Control                        */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} OSCCTRL_OSC16MCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_OSC16MCTRL_OFFSET           (0x18)                                        /**<  (OSCCTRL_OSC16MCTRL) 16MHz Internal Oscillator (OSC16M) Control  Offset */
+#define OSCCTRL_OSC16MCTRL_RESETVALUE       _U_(0x82)                                     /**<  (OSCCTRL_OSC16MCTRL) 16MHz Internal Oscillator (OSC16M) Control  Reset Value */
+
+#define OSCCTRL_OSC16MCTRL_ENABLE_Pos       1                                              /**< (OSCCTRL_OSC16MCTRL) Oscillator Enable Position */
+#define OSCCTRL_OSC16MCTRL_ENABLE_Msk       (_U_(0x1) << OSCCTRL_OSC16MCTRL_ENABLE_Pos)    /**< (OSCCTRL_OSC16MCTRL) Oscillator Enable Mask */
+#define OSCCTRL_OSC16MCTRL_ENABLE           OSCCTRL_OSC16MCTRL_ENABLE_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_OSC16MCTRL_ENABLE_Msk instead */
+#define OSCCTRL_OSC16MCTRL_FSEL_Pos         2                                              /**< (OSCCTRL_OSC16MCTRL) Oscillator Frequency Selection Position */
+#define OSCCTRL_OSC16MCTRL_FSEL_Msk         (_U_(0x3) << OSCCTRL_OSC16MCTRL_FSEL_Pos)      /**< (OSCCTRL_OSC16MCTRL) Oscillator Frequency Selection Mask */
+#define OSCCTRL_OSC16MCTRL_FSEL(value)      (OSCCTRL_OSC16MCTRL_FSEL_Msk & ((value) << OSCCTRL_OSC16MCTRL_FSEL_Pos))
+#define   OSCCTRL_OSC16MCTRL_FSEL_4_Val     _U_(0x0)                                       /**< (OSCCTRL_OSC16MCTRL) 4MHz  */
+#define   OSCCTRL_OSC16MCTRL_FSEL_8_Val     _U_(0x1)                                       /**< (OSCCTRL_OSC16MCTRL) 8MHz  */
+#define   OSCCTRL_OSC16MCTRL_FSEL_12_Val    _U_(0x2)                                       /**< (OSCCTRL_OSC16MCTRL) 12MHz  */
+#define   OSCCTRL_OSC16MCTRL_FSEL_16_Val    _U_(0x3)                                       /**< (OSCCTRL_OSC16MCTRL) 16MHz  */
+#define OSCCTRL_OSC16MCTRL_FSEL_4           (OSCCTRL_OSC16MCTRL_FSEL_4_Val << OSCCTRL_OSC16MCTRL_FSEL_Pos)  /**< (OSCCTRL_OSC16MCTRL) 4MHz Position  */
+#define OSCCTRL_OSC16MCTRL_FSEL_8           (OSCCTRL_OSC16MCTRL_FSEL_8_Val << OSCCTRL_OSC16MCTRL_FSEL_Pos)  /**< (OSCCTRL_OSC16MCTRL) 8MHz Position  */
+#define OSCCTRL_OSC16MCTRL_FSEL_12          (OSCCTRL_OSC16MCTRL_FSEL_12_Val << OSCCTRL_OSC16MCTRL_FSEL_Pos)  /**< (OSCCTRL_OSC16MCTRL) 12MHz Position  */
+#define OSCCTRL_OSC16MCTRL_FSEL_16          (OSCCTRL_OSC16MCTRL_FSEL_16_Val << OSCCTRL_OSC16MCTRL_FSEL_Pos)  /**< (OSCCTRL_OSC16MCTRL) 16MHz Position  */
+#define OSCCTRL_OSC16MCTRL_RUNSTDBY_Pos     6                                              /**< (OSCCTRL_OSC16MCTRL) Run in Standby Position */
+#define OSCCTRL_OSC16MCTRL_RUNSTDBY_Msk     (_U_(0x1) << OSCCTRL_OSC16MCTRL_RUNSTDBY_Pos)  /**< (OSCCTRL_OSC16MCTRL) Run in Standby Mask */
+#define OSCCTRL_OSC16MCTRL_RUNSTDBY         OSCCTRL_OSC16MCTRL_RUNSTDBY_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_OSC16MCTRL_RUNSTDBY_Msk instead */
+#define OSCCTRL_OSC16MCTRL_ONDEMAND_Pos     7                                              /**< (OSCCTRL_OSC16MCTRL) On Demand Control Position */
+#define OSCCTRL_OSC16MCTRL_ONDEMAND_Msk     (_U_(0x1) << OSCCTRL_OSC16MCTRL_ONDEMAND_Pos)  /**< (OSCCTRL_OSC16MCTRL) On Demand Control Mask */
+#define OSCCTRL_OSC16MCTRL_ONDEMAND         OSCCTRL_OSC16MCTRL_ONDEMAND_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_OSC16MCTRL_ONDEMAND_Msk instead */
+#define OSCCTRL_OSC16MCTRL_MASK             _U_(0xCE)                                      /**< \deprecated (OSCCTRL_OSC16MCTRL) Register MASK  (Use OSCCTRL_OSC16MCTRL_Msk instead)  */
+#define OSCCTRL_OSC16MCTRL_Msk              _U_(0xCE)                                      /**< (OSCCTRL_OSC16MCTRL) Register Mask  */
+
+
+/* -------- OSCCTRL_DFLLULPCTRL : (OSCCTRL Offset: 0x1c) (R/W 16) DFLLULP Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t :1;                        /**< bit:      0  Reserved */
+    uint16_t ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint16_t :1;                        /**< bit:      2  Reserved */
+    uint16_t BINSE:1;                   /**< bit:      3  Binary Search Enable                     */
+    uint16_t SAFE:1;                    /**< bit:      4  Tuner Safe Mode                          */
+    uint16_t DITHER:1;                  /**< bit:      5  Tuner Dither Mode                        */
+    uint16_t RUNSTDBY:1;                /**< bit:      6  Run in Standby                           */
+    uint16_t ONDEMAND:1;                /**< bit:      7  On Demand                                */
+    uint16_t DIV:3;                     /**< bit:  8..10  Division Factor                          */
+    uint16_t :5;                        /**< bit: 11..15  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} OSCCTRL_DFLLULPCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_DFLLULPCTRL_OFFSET          (0x1C)                                        /**<  (OSCCTRL_DFLLULPCTRL) DFLLULP Control  Offset */
+#define OSCCTRL_DFLLULPCTRL_RESETVALUE      _U_(0x504)                                    /**<  (OSCCTRL_DFLLULPCTRL) DFLLULP Control  Reset Value */
+
+#define OSCCTRL_DFLLULPCTRL_ENABLE_Pos      1                                              /**< (OSCCTRL_DFLLULPCTRL) Enable Position */
+#define OSCCTRL_DFLLULPCTRL_ENABLE_Msk      (_U_(0x1) << OSCCTRL_DFLLULPCTRL_ENABLE_Pos)   /**< (OSCCTRL_DFLLULPCTRL) Enable Mask */
+#define OSCCTRL_DFLLULPCTRL_ENABLE          OSCCTRL_DFLLULPCTRL_ENABLE_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_DFLLULPCTRL_ENABLE_Msk instead */
+#define OSCCTRL_DFLLULPCTRL_BINSE_Pos       3                                              /**< (OSCCTRL_DFLLULPCTRL) Binary Search Enable Position */
+#define OSCCTRL_DFLLULPCTRL_BINSE_Msk       (_U_(0x1) << OSCCTRL_DFLLULPCTRL_BINSE_Pos)    /**< (OSCCTRL_DFLLULPCTRL) Binary Search Enable Mask */
+#define OSCCTRL_DFLLULPCTRL_BINSE           OSCCTRL_DFLLULPCTRL_BINSE_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_DFLLULPCTRL_BINSE_Msk instead */
+#define OSCCTRL_DFLLULPCTRL_SAFE_Pos        4                                              /**< (OSCCTRL_DFLLULPCTRL) Tuner Safe Mode Position */
+#define OSCCTRL_DFLLULPCTRL_SAFE_Msk        (_U_(0x1) << OSCCTRL_DFLLULPCTRL_SAFE_Pos)     /**< (OSCCTRL_DFLLULPCTRL) Tuner Safe Mode Mask */
+#define OSCCTRL_DFLLULPCTRL_SAFE            OSCCTRL_DFLLULPCTRL_SAFE_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_DFLLULPCTRL_SAFE_Msk instead */
+#define OSCCTRL_DFLLULPCTRL_DITHER_Pos      5                                              /**< (OSCCTRL_DFLLULPCTRL) Tuner Dither Mode Position */
+#define OSCCTRL_DFLLULPCTRL_DITHER_Msk      (_U_(0x1) << OSCCTRL_DFLLULPCTRL_DITHER_Pos)   /**< (OSCCTRL_DFLLULPCTRL) Tuner Dither Mode Mask */
+#define OSCCTRL_DFLLULPCTRL_DITHER          OSCCTRL_DFLLULPCTRL_DITHER_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_DFLLULPCTRL_DITHER_Msk instead */
+#define OSCCTRL_DFLLULPCTRL_RUNSTDBY_Pos    6                                              /**< (OSCCTRL_DFLLULPCTRL) Run in Standby Position */
+#define OSCCTRL_DFLLULPCTRL_RUNSTDBY_Msk    (_U_(0x1) << OSCCTRL_DFLLULPCTRL_RUNSTDBY_Pos)  /**< (OSCCTRL_DFLLULPCTRL) Run in Standby Mask */
+#define OSCCTRL_DFLLULPCTRL_RUNSTDBY        OSCCTRL_DFLLULPCTRL_RUNSTDBY_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_DFLLULPCTRL_RUNSTDBY_Msk instead */
+#define OSCCTRL_DFLLULPCTRL_ONDEMAND_Pos    7                                              /**< (OSCCTRL_DFLLULPCTRL) On Demand Position */
+#define OSCCTRL_DFLLULPCTRL_ONDEMAND_Msk    (_U_(0x1) << OSCCTRL_DFLLULPCTRL_ONDEMAND_Pos)  /**< (OSCCTRL_DFLLULPCTRL) On Demand Mask */
+#define OSCCTRL_DFLLULPCTRL_ONDEMAND        OSCCTRL_DFLLULPCTRL_ONDEMAND_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_DFLLULPCTRL_ONDEMAND_Msk instead */
+#define OSCCTRL_DFLLULPCTRL_DIV_Pos         8                                              /**< (OSCCTRL_DFLLULPCTRL) Division Factor Position */
+#define OSCCTRL_DFLLULPCTRL_DIV_Msk         (_U_(0x7) << OSCCTRL_DFLLULPCTRL_DIV_Pos)      /**< (OSCCTRL_DFLLULPCTRL) Division Factor Mask */
+#define OSCCTRL_DFLLULPCTRL_DIV(value)      (OSCCTRL_DFLLULPCTRL_DIV_Msk & ((value) << OSCCTRL_DFLLULPCTRL_DIV_Pos))
+#define   OSCCTRL_DFLLULPCTRL_DIV_DIV1_Val  _U_(0x0)                                       /**< (OSCCTRL_DFLLULPCTRL) Frequency Divided by 1  */
+#define   OSCCTRL_DFLLULPCTRL_DIV_DIV2_Val  _U_(0x1)                                       /**< (OSCCTRL_DFLLULPCTRL) Frequency Divided by 2  */
+#define   OSCCTRL_DFLLULPCTRL_DIV_DIV4_Val  _U_(0x2)                                       /**< (OSCCTRL_DFLLULPCTRL) Frequency Divided by 4  */
+#define   OSCCTRL_DFLLULPCTRL_DIV_DIV8_Val  _U_(0x3)                                       /**< (OSCCTRL_DFLLULPCTRL) Frequency Divided by 8  */
+#define   OSCCTRL_DFLLULPCTRL_DIV_DIV16_Val _U_(0x4)                                       /**< (OSCCTRL_DFLLULPCTRL) Frequency Divided by 16  */
+#define   OSCCTRL_DFLLULPCTRL_DIV_DIV32_Val _U_(0x5)                                       /**< (OSCCTRL_DFLLULPCTRL) Frequency Divided by 32  */
+#define OSCCTRL_DFLLULPCTRL_DIV_DIV1        (OSCCTRL_DFLLULPCTRL_DIV_DIV1_Val << OSCCTRL_DFLLULPCTRL_DIV_Pos)  /**< (OSCCTRL_DFLLULPCTRL) Frequency Divided by 1 Position  */
+#define OSCCTRL_DFLLULPCTRL_DIV_DIV2        (OSCCTRL_DFLLULPCTRL_DIV_DIV2_Val << OSCCTRL_DFLLULPCTRL_DIV_Pos)  /**< (OSCCTRL_DFLLULPCTRL) Frequency Divided by 2 Position  */
+#define OSCCTRL_DFLLULPCTRL_DIV_DIV4        (OSCCTRL_DFLLULPCTRL_DIV_DIV4_Val << OSCCTRL_DFLLULPCTRL_DIV_Pos)  /**< (OSCCTRL_DFLLULPCTRL) Frequency Divided by 4 Position  */
+#define OSCCTRL_DFLLULPCTRL_DIV_DIV8        (OSCCTRL_DFLLULPCTRL_DIV_DIV8_Val << OSCCTRL_DFLLULPCTRL_DIV_Pos)  /**< (OSCCTRL_DFLLULPCTRL) Frequency Divided by 8 Position  */
+#define OSCCTRL_DFLLULPCTRL_DIV_DIV16       (OSCCTRL_DFLLULPCTRL_DIV_DIV16_Val << OSCCTRL_DFLLULPCTRL_DIV_Pos)  /**< (OSCCTRL_DFLLULPCTRL) Frequency Divided by 16 Position  */
+#define OSCCTRL_DFLLULPCTRL_DIV_DIV32       (OSCCTRL_DFLLULPCTRL_DIV_DIV32_Val << OSCCTRL_DFLLULPCTRL_DIV_Pos)  /**< (OSCCTRL_DFLLULPCTRL) Frequency Divided by 32 Position  */
+#define OSCCTRL_DFLLULPCTRL_MASK            _U_(0x7FA)                                     /**< \deprecated (OSCCTRL_DFLLULPCTRL) Register MASK  (Use OSCCTRL_DFLLULPCTRL_Msk instead)  */
+#define OSCCTRL_DFLLULPCTRL_Msk             _U_(0x7FA)                                     /**< (OSCCTRL_DFLLULPCTRL) Register Mask  */
+
+
+/* -------- OSCCTRL_DFLLULPDITHER : (OSCCTRL Offset: 0x1e) (R/W 8) DFLLULP Dither Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  STEP:3;                    /**< bit:   0..2  Dither Step                              */
+    uint8_t  :1;                        /**< bit:      3  Reserved */
+    uint8_t  PER:3;                     /**< bit:   4..6  Dither Period                            */
+    uint8_t  :1;                        /**< bit:      7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} OSCCTRL_DFLLULPDITHER_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_DFLLULPDITHER_OFFSET        (0x1E)                                        /**<  (OSCCTRL_DFLLULPDITHER) DFLLULP Dither Control  Offset */
+#define OSCCTRL_DFLLULPDITHER_RESETVALUE    _U_(0x00)                                     /**<  (OSCCTRL_DFLLULPDITHER) DFLLULP Dither Control  Reset Value */
+
+#define OSCCTRL_DFLLULPDITHER_STEP_Pos      0                                              /**< (OSCCTRL_DFLLULPDITHER) Dither Step Position */
+#define OSCCTRL_DFLLULPDITHER_STEP_Msk      (_U_(0x7) << OSCCTRL_DFLLULPDITHER_STEP_Pos)   /**< (OSCCTRL_DFLLULPDITHER) Dither Step Mask */
+#define OSCCTRL_DFLLULPDITHER_STEP(value)   (OSCCTRL_DFLLULPDITHER_STEP_Msk & ((value) << OSCCTRL_DFLLULPDITHER_STEP_Pos))
+#define   OSCCTRL_DFLLULPDITHER_STEP_STEP1_Val _U_(0x0)                                       /**< (OSCCTRL_DFLLULPDITHER) Dither Step = 1  */
+#define   OSCCTRL_DFLLULPDITHER_STEP_STEP2_Val _U_(0x1)                                       /**< (OSCCTRL_DFLLULPDITHER) Dither Step = 2  */
+#define   OSCCTRL_DFLLULPDITHER_STEP_STEP4_Val _U_(0x2)                                       /**< (OSCCTRL_DFLLULPDITHER) Dither Step = 4  */
+#define   OSCCTRL_DFLLULPDITHER_STEP_STEP8_Val _U_(0x3)                                       /**< (OSCCTRL_DFLLULPDITHER) Dither Step = 8  */
+#define OSCCTRL_DFLLULPDITHER_STEP_STEP1    (OSCCTRL_DFLLULPDITHER_STEP_STEP1_Val << OSCCTRL_DFLLULPDITHER_STEP_Pos)  /**< (OSCCTRL_DFLLULPDITHER) Dither Step = 1 Position  */
+#define OSCCTRL_DFLLULPDITHER_STEP_STEP2    (OSCCTRL_DFLLULPDITHER_STEP_STEP2_Val << OSCCTRL_DFLLULPDITHER_STEP_Pos)  /**< (OSCCTRL_DFLLULPDITHER) Dither Step = 2 Position  */
+#define OSCCTRL_DFLLULPDITHER_STEP_STEP4    (OSCCTRL_DFLLULPDITHER_STEP_STEP4_Val << OSCCTRL_DFLLULPDITHER_STEP_Pos)  /**< (OSCCTRL_DFLLULPDITHER) Dither Step = 4 Position  */
+#define OSCCTRL_DFLLULPDITHER_STEP_STEP8    (OSCCTRL_DFLLULPDITHER_STEP_STEP8_Val << OSCCTRL_DFLLULPDITHER_STEP_Pos)  /**< (OSCCTRL_DFLLULPDITHER) Dither Step = 8 Position  */
+#define OSCCTRL_DFLLULPDITHER_PER_Pos       4                                              /**< (OSCCTRL_DFLLULPDITHER) Dither Period Position */
+#define OSCCTRL_DFLLULPDITHER_PER_Msk       (_U_(0x7) << OSCCTRL_DFLLULPDITHER_PER_Pos)    /**< (OSCCTRL_DFLLULPDITHER) Dither Period Mask */
+#define OSCCTRL_DFLLULPDITHER_PER(value)    (OSCCTRL_DFLLULPDITHER_PER_Msk & ((value) << OSCCTRL_DFLLULPDITHER_PER_Pos))
+#define   OSCCTRL_DFLLULPDITHER_PER_PER1_Val _U_(0x0)                                       /**< (OSCCTRL_DFLLULPDITHER) Dither Over 1 Reference Clock Period  */
+#define   OSCCTRL_DFLLULPDITHER_PER_PER2_Val _U_(0x1)                                       /**< (OSCCTRL_DFLLULPDITHER) Dither Over 2 Reference Clock Period  */
+#define   OSCCTRL_DFLLULPDITHER_PER_PER4_Val _U_(0x2)                                       /**< (OSCCTRL_DFLLULPDITHER) Dither Over 4 Reference Clock Period  */
+#define   OSCCTRL_DFLLULPDITHER_PER_PER8_Val _U_(0x3)                                       /**< (OSCCTRL_DFLLULPDITHER) Dither Over 8 Reference Clock Period  */
+#define   OSCCTRL_DFLLULPDITHER_PER_PER16_Val _U_(0x4)                                       /**< (OSCCTRL_DFLLULPDITHER) Dither Over 16 Reference Clock Period  */
+#define   OSCCTRL_DFLLULPDITHER_PER_PER32_Val _U_(0x5)                                       /**< (OSCCTRL_DFLLULPDITHER) Dither Over 32 Reference Clock Period  */
+#define OSCCTRL_DFLLULPDITHER_PER_PER1      (OSCCTRL_DFLLULPDITHER_PER_PER1_Val << OSCCTRL_DFLLULPDITHER_PER_Pos)  /**< (OSCCTRL_DFLLULPDITHER) Dither Over 1 Reference Clock Period Position  */
+#define OSCCTRL_DFLLULPDITHER_PER_PER2      (OSCCTRL_DFLLULPDITHER_PER_PER2_Val << OSCCTRL_DFLLULPDITHER_PER_Pos)  /**< (OSCCTRL_DFLLULPDITHER) Dither Over 2 Reference Clock Period Position  */
+#define OSCCTRL_DFLLULPDITHER_PER_PER4      (OSCCTRL_DFLLULPDITHER_PER_PER4_Val << OSCCTRL_DFLLULPDITHER_PER_Pos)  /**< (OSCCTRL_DFLLULPDITHER) Dither Over 4 Reference Clock Period Position  */
+#define OSCCTRL_DFLLULPDITHER_PER_PER8      (OSCCTRL_DFLLULPDITHER_PER_PER8_Val << OSCCTRL_DFLLULPDITHER_PER_Pos)  /**< (OSCCTRL_DFLLULPDITHER) Dither Over 8 Reference Clock Period Position  */
+#define OSCCTRL_DFLLULPDITHER_PER_PER16     (OSCCTRL_DFLLULPDITHER_PER_PER16_Val << OSCCTRL_DFLLULPDITHER_PER_Pos)  /**< (OSCCTRL_DFLLULPDITHER) Dither Over 16 Reference Clock Period Position  */
+#define OSCCTRL_DFLLULPDITHER_PER_PER32     (OSCCTRL_DFLLULPDITHER_PER_PER32_Val << OSCCTRL_DFLLULPDITHER_PER_Pos)  /**< (OSCCTRL_DFLLULPDITHER) Dither Over 32 Reference Clock Period Position  */
+#define OSCCTRL_DFLLULPDITHER_MASK          _U_(0x77)                                      /**< \deprecated (OSCCTRL_DFLLULPDITHER) Register MASK  (Use OSCCTRL_DFLLULPDITHER_Msk instead)  */
+#define OSCCTRL_DFLLULPDITHER_Msk           _U_(0x77)                                      /**< (OSCCTRL_DFLLULPDITHER) Register Mask  */
+
+
+/* -------- OSCCTRL_DFLLULPRREQ : (OSCCTRL Offset: 0x1f) (R/W 8) DFLLULP Read Request -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  :7;                        /**< bit:   0..6  Reserved */
+    uint8_t  RREQ:1;                    /**< bit:      7  Read Request                             */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} OSCCTRL_DFLLULPRREQ_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_DFLLULPRREQ_OFFSET          (0x1F)                                        /**<  (OSCCTRL_DFLLULPRREQ) DFLLULP Read Request  Offset */
+#define OSCCTRL_DFLLULPRREQ_RESETVALUE      _U_(0x00)                                     /**<  (OSCCTRL_DFLLULPRREQ) DFLLULP Read Request  Reset Value */
+
+#define OSCCTRL_DFLLULPRREQ_RREQ_Pos        7                                              /**< (OSCCTRL_DFLLULPRREQ) Read Request Position */
+#define OSCCTRL_DFLLULPRREQ_RREQ_Msk        (_U_(0x1) << OSCCTRL_DFLLULPRREQ_RREQ_Pos)     /**< (OSCCTRL_DFLLULPRREQ) Read Request Mask */
+#define OSCCTRL_DFLLULPRREQ_RREQ            OSCCTRL_DFLLULPRREQ_RREQ_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_DFLLULPRREQ_RREQ_Msk instead */
+#define OSCCTRL_DFLLULPRREQ_MASK            _U_(0x80)                                      /**< \deprecated (OSCCTRL_DFLLULPRREQ) Register MASK  (Use OSCCTRL_DFLLULPRREQ_Msk instead)  */
+#define OSCCTRL_DFLLULPRREQ_Msk             _U_(0x80)                                      /**< (OSCCTRL_DFLLULPRREQ) Register Mask  */
+
+
+/* -------- OSCCTRL_DFLLULPDLY : (OSCCTRL Offset: 0x20) (R/W 32) DFLLULP Delay Value -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t DELAY:8;                   /**< bit:   0..7  Delay Value                              */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} OSCCTRL_DFLLULPDLY_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_DFLLULPDLY_OFFSET           (0x20)                                        /**<  (OSCCTRL_DFLLULPDLY) DFLLULP Delay Value  Offset */
+#define OSCCTRL_DFLLULPDLY_RESETVALUE       _U_(0x80)                                     /**<  (OSCCTRL_DFLLULPDLY) DFLLULP Delay Value  Reset Value */
+
+#define OSCCTRL_DFLLULPDLY_DELAY_Pos        0                                              /**< (OSCCTRL_DFLLULPDLY) Delay Value Position */
+#define OSCCTRL_DFLLULPDLY_DELAY_Msk        (_U_(0xFF) << OSCCTRL_DFLLULPDLY_DELAY_Pos)    /**< (OSCCTRL_DFLLULPDLY) Delay Value Mask */
+#define OSCCTRL_DFLLULPDLY_DELAY(value)     (OSCCTRL_DFLLULPDLY_DELAY_Msk & ((value) << OSCCTRL_DFLLULPDLY_DELAY_Pos))
+#define OSCCTRL_DFLLULPDLY_MASK             _U_(0xFF)                                      /**< \deprecated (OSCCTRL_DFLLULPDLY) Register MASK  (Use OSCCTRL_DFLLULPDLY_Msk instead)  */
+#define OSCCTRL_DFLLULPDLY_Msk              _U_(0xFF)                                      /**< (OSCCTRL_DFLLULPDLY) Register Mask  */
+
+
+/* -------- OSCCTRL_DFLLULPRATIO : (OSCCTRL Offset: 0x24) (R/W 32) DFLLULP Target Ratio -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t RATIO:11;                  /**< bit:  0..10  Target Tuner Ratio                       */
+    uint32_t :21;                       /**< bit: 11..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} OSCCTRL_DFLLULPRATIO_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_DFLLULPRATIO_OFFSET         (0x24)                                        /**<  (OSCCTRL_DFLLULPRATIO) DFLLULP Target Ratio  Offset */
+#define OSCCTRL_DFLLULPRATIO_RESETVALUE     _U_(0x00)                                     /**<  (OSCCTRL_DFLLULPRATIO) DFLLULP Target Ratio  Reset Value */
+
+#define OSCCTRL_DFLLULPRATIO_RATIO_Pos      0                                              /**< (OSCCTRL_DFLLULPRATIO) Target Tuner Ratio Position */
+#define OSCCTRL_DFLLULPRATIO_RATIO_Msk      (_U_(0x7FF) << OSCCTRL_DFLLULPRATIO_RATIO_Pos)  /**< (OSCCTRL_DFLLULPRATIO) Target Tuner Ratio Mask */
+#define OSCCTRL_DFLLULPRATIO_RATIO(value)   (OSCCTRL_DFLLULPRATIO_RATIO_Msk & ((value) << OSCCTRL_DFLLULPRATIO_RATIO_Pos))
+#define OSCCTRL_DFLLULPRATIO_MASK           _U_(0x7FF)                                     /**< \deprecated (OSCCTRL_DFLLULPRATIO) Register MASK  (Use OSCCTRL_DFLLULPRATIO_Msk instead)  */
+#define OSCCTRL_DFLLULPRATIO_Msk            _U_(0x7FF)                                     /**< (OSCCTRL_DFLLULPRATIO) Register Mask  */
+
+
+/* -------- OSCCTRL_DFLLULPSYNCBUSY : (OSCCTRL Offset: 0x28) (R/ 32) DFLLULP Synchronization Busy -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t ENABLE:1;                  /**< bit:      1  Enable Bit Synchronization Busy          */
+    uint32_t TUNE:1;                    /**< bit:      2  Tune Bit Synchronization Busy            */
+    uint32_t DELAY:1;                   /**< bit:      3  Delay Register Synchronization Busy      */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} OSCCTRL_DFLLULPSYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_DFLLULPSYNCBUSY_OFFSET      (0x28)                                        /**<  (OSCCTRL_DFLLULPSYNCBUSY) DFLLULP Synchronization Busy  Offset */
+#define OSCCTRL_DFLLULPSYNCBUSY_RESETVALUE  _U_(0x00)                                     /**<  (OSCCTRL_DFLLULPSYNCBUSY) DFLLULP Synchronization Busy  Reset Value */
+
+#define OSCCTRL_DFLLULPSYNCBUSY_ENABLE_Pos  1                                              /**< (OSCCTRL_DFLLULPSYNCBUSY) Enable Bit Synchronization Busy Position */
+#define OSCCTRL_DFLLULPSYNCBUSY_ENABLE_Msk  (_U_(0x1) << OSCCTRL_DFLLULPSYNCBUSY_ENABLE_Pos)  /**< (OSCCTRL_DFLLULPSYNCBUSY) Enable Bit Synchronization Busy Mask */
+#define OSCCTRL_DFLLULPSYNCBUSY_ENABLE      OSCCTRL_DFLLULPSYNCBUSY_ENABLE_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_DFLLULPSYNCBUSY_ENABLE_Msk instead */
+#define OSCCTRL_DFLLULPSYNCBUSY_TUNE_Pos    2                                              /**< (OSCCTRL_DFLLULPSYNCBUSY) Tune Bit Synchronization Busy Position */
+#define OSCCTRL_DFLLULPSYNCBUSY_TUNE_Msk    (_U_(0x1) << OSCCTRL_DFLLULPSYNCBUSY_TUNE_Pos)  /**< (OSCCTRL_DFLLULPSYNCBUSY) Tune Bit Synchronization Busy Mask */
+#define OSCCTRL_DFLLULPSYNCBUSY_TUNE        OSCCTRL_DFLLULPSYNCBUSY_TUNE_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_DFLLULPSYNCBUSY_TUNE_Msk instead */
+#define OSCCTRL_DFLLULPSYNCBUSY_DELAY_Pos   3                                              /**< (OSCCTRL_DFLLULPSYNCBUSY) Delay Register Synchronization Busy Position */
+#define OSCCTRL_DFLLULPSYNCBUSY_DELAY_Msk   (_U_(0x1) << OSCCTRL_DFLLULPSYNCBUSY_DELAY_Pos)  /**< (OSCCTRL_DFLLULPSYNCBUSY) Delay Register Synchronization Busy Mask */
+#define OSCCTRL_DFLLULPSYNCBUSY_DELAY       OSCCTRL_DFLLULPSYNCBUSY_DELAY_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_DFLLULPSYNCBUSY_DELAY_Msk instead */
+#define OSCCTRL_DFLLULPSYNCBUSY_MASK        _U_(0x0E)                                      /**< \deprecated (OSCCTRL_DFLLULPSYNCBUSY) Register MASK  (Use OSCCTRL_DFLLULPSYNCBUSY_Msk instead)  */
+#define OSCCTRL_DFLLULPSYNCBUSY_Msk         _U_(0x0E)                                      /**< (OSCCTRL_DFLLULPSYNCBUSY) Register Mask  */
+
+
+/* -------- OSCCTRL_DPLLCTRLA : (OSCCTRL Offset: 0x2c) (R/W 8) DPLL Control A -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  :1;                        /**< bit:      0  Reserved */
+    uint8_t  ENABLE:1;                  /**< bit:      1  DPLL Enable                              */
+    uint8_t  :4;                        /**< bit:   2..5  Reserved */
+    uint8_t  RUNSTDBY:1;                /**< bit:      6  Run in Standby                           */
+    uint8_t  ONDEMAND:1;                /**< bit:      7  On Demand Clock Activation               */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} OSCCTRL_DPLLCTRLA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_DPLLCTRLA_OFFSET            (0x2C)                                        /**<  (OSCCTRL_DPLLCTRLA) DPLL Control A  Offset */
+#define OSCCTRL_DPLLCTRLA_RESETVALUE        _U_(0x80)                                     /**<  (OSCCTRL_DPLLCTRLA) DPLL Control A  Reset Value */
+
+#define OSCCTRL_DPLLCTRLA_ENABLE_Pos        1                                              /**< (OSCCTRL_DPLLCTRLA) DPLL Enable Position */
+#define OSCCTRL_DPLLCTRLA_ENABLE_Msk        (_U_(0x1) << OSCCTRL_DPLLCTRLA_ENABLE_Pos)     /**< (OSCCTRL_DPLLCTRLA) DPLL Enable Mask */
+#define OSCCTRL_DPLLCTRLA_ENABLE            OSCCTRL_DPLLCTRLA_ENABLE_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_DPLLCTRLA_ENABLE_Msk instead */
+#define OSCCTRL_DPLLCTRLA_RUNSTDBY_Pos      6                                              /**< (OSCCTRL_DPLLCTRLA) Run in Standby Position */
+#define OSCCTRL_DPLLCTRLA_RUNSTDBY_Msk      (_U_(0x1) << OSCCTRL_DPLLCTRLA_RUNSTDBY_Pos)   /**< (OSCCTRL_DPLLCTRLA) Run in Standby Mask */
+#define OSCCTRL_DPLLCTRLA_RUNSTDBY          OSCCTRL_DPLLCTRLA_RUNSTDBY_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_DPLLCTRLA_RUNSTDBY_Msk instead */
+#define OSCCTRL_DPLLCTRLA_ONDEMAND_Pos      7                                              /**< (OSCCTRL_DPLLCTRLA) On Demand Clock Activation Position */
+#define OSCCTRL_DPLLCTRLA_ONDEMAND_Msk      (_U_(0x1) << OSCCTRL_DPLLCTRLA_ONDEMAND_Pos)   /**< (OSCCTRL_DPLLCTRLA) On Demand Clock Activation Mask */
+#define OSCCTRL_DPLLCTRLA_ONDEMAND          OSCCTRL_DPLLCTRLA_ONDEMAND_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_DPLLCTRLA_ONDEMAND_Msk instead */
+#define OSCCTRL_DPLLCTRLA_MASK              _U_(0xC2)                                      /**< \deprecated (OSCCTRL_DPLLCTRLA) Register MASK  (Use OSCCTRL_DPLLCTRLA_Msk instead)  */
+#define OSCCTRL_DPLLCTRLA_Msk               _U_(0xC2)                                      /**< (OSCCTRL_DPLLCTRLA) Register Mask  */
+
+
+/* -------- OSCCTRL_DPLLRATIO : (OSCCTRL Offset: 0x30) (R/W 32) DPLL Ratio Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t LDR:12;                    /**< bit:  0..11  Loop Divider Ratio                       */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t LDRFRAC:4;                 /**< bit: 16..19  Loop Divider Ratio Fractional Part       */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} OSCCTRL_DPLLRATIO_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_DPLLRATIO_OFFSET            (0x30)                                        /**<  (OSCCTRL_DPLLRATIO) DPLL Ratio Control  Offset */
+#define OSCCTRL_DPLLRATIO_RESETVALUE        _U_(0x00)                                     /**<  (OSCCTRL_DPLLRATIO) DPLL Ratio Control  Reset Value */
+
+#define OSCCTRL_DPLLRATIO_LDR_Pos           0                                              /**< (OSCCTRL_DPLLRATIO) Loop Divider Ratio Position */
+#define OSCCTRL_DPLLRATIO_LDR_Msk           (_U_(0xFFF) << OSCCTRL_DPLLRATIO_LDR_Pos)      /**< (OSCCTRL_DPLLRATIO) Loop Divider Ratio Mask */
+#define OSCCTRL_DPLLRATIO_LDR(value)        (OSCCTRL_DPLLRATIO_LDR_Msk & ((value) << OSCCTRL_DPLLRATIO_LDR_Pos))
+#define OSCCTRL_DPLLRATIO_LDRFRAC_Pos       16                                             /**< (OSCCTRL_DPLLRATIO) Loop Divider Ratio Fractional Part Position */
+#define OSCCTRL_DPLLRATIO_LDRFRAC_Msk       (_U_(0xF) << OSCCTRL_DPLLRATIO_LDRFRAC_Pos)    /**< (OSCCTRL_DPLLRATIO) Loop Divider Ratio Fractional Part Mask */
+#define OSCCTRL_DPLLRATIO_LDRFRAC(value)    (OSCCTRL_DPLLRATIO_LDRFRAC_Msk & ((value) << OSCCTRL_DPLLRATIO_LDRFRAC_Pos))
+#define OSCCTRL_DPLLRATIO_MASK              _U_(0xF0FFF)                                   /**< \deprecated (OSCCTRL_DPLLRATIO) Register MASK  (Use OSCCTRL_DPLLRATIO_Msk instead)  */
+#define OSCCTRL_DPLLRATIO_Msk               _U_(0xF0FFF)                                   /**< (OSCCTRL_DPLLRATIO) Register Mask  */
+
+
+/* -------- OSCCTRL_DPLLCTRLB : (OSCCTRL Offset: 0x34) (R/W 32) DPLL Control B -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t FILTER:2;                  /**< bit:   0..1  Proportional Integral Filter Selection   */
+    uint32_t LPEN:1;                    /**< bit:      2  Low-Power Enable                         */
+    uint32_t WUF:1;                     /**< bit:      3  Wake Up Fast                             */
+    uint32_t REFCLK:2;                  /**< bit:   4..5  Reference Clock Selection                */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t LTIME:3;                   /**< bit:  8..10  Lock Time                                */
+    uint32_t :1;                        /**< bit:     11  Reserved */
+    uint32_t LBYPASS:1;                 /**< bit:     12  Lock Bypass                              */
+    uint32_t :3;                        /**< bit: 13..15  Reserved */
+    uint32_t DIV:11;                    /**< bit: 16..26  Clock Divider                            */
+    uint32_t :5;                        /**< bit: 27..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} OSCCTRL_DPLLCTRLB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_DPLLCTRLB_OFFSET            (0x34)                                        /**<  (OSCCTRL_DPLLCTRLB) DPLL Control B  Offset */
+#define OSCCTRL_DPLLCTRLB_RESETVALUE        _U_(0x00)                                     /**<  (OSCCTRL_DPLLCTRLB) DPLL Control B  Reset Value */
+
+#define OSCCTRL_DPLLCTRLB_FILTER_Pos        0                                              /**< (OSCCTRL_DPLLCTRLB) Proportional Integral Filter Selection Position */
+#define OSCCTRL_DPLLCTRLB_FILTER_Msk        (_U_(0x3) << OSCCTRL_DPLLCTRLB_FILTER_Pos)     /**< (OSCCTRL_DPLLCTRLB) Proportional Integral Filter Selection Mask */
+#define OSCCTRL_DPLLCTRLB_FILTER(value)     (OSCCTRL_DPLLCTRLB_FILTER_Msk & ((value) << OSCCTRL_DPLLCTRLB_FILTER_Pos))
+#define   OSCCTRL_DPLLCTRLB_FILTER_Default_Val _U_(0x0)                                       /**< (OSCCTRL_DPLLCTRLB) Default Filter Mode  */
+#define   OSCCTRL_DPLLCTRLB_FILTER_LBFILT_Val _U_(0x1)                                       /**< (OSCCTRL_DPLLCTRLB) Low Bandwidth Filter  */
+#define   OSCCTRL_DPLLCTRLB_FILTER_HBFILT_Val _U_(0x2)                                       /**< (OSCCTRL_DPLLCTRLB) High Bandwidth Filter  */
+#define   OSCCTRL_DPLLCTRLB_FILTER_HDFILT_Val _U_(0x3)                                       /**< (OSCCTRL_DPLLCTRLB) High Damping Filter  */
+#define OSCCTRL_DPLLCTRLB_FILTER_Default    (OSCCTRL_DPLLCTRLB_FILTER_Default_Val << OSCCTRL_DPLLCTRLB_FILTER_Pos)  /**< (OSCCTRL_DPLLCTRLB) Default Filter Mode Position  */
+#define OSCCTRL_DPLLCTRLB_FILTER_LBFILT     (OSCCTRL_DPLLCTRLB_FILTER_LBFILT_Val << OSCCTRL_DPLLCTRLB_FILTER_Pos)  /**< (OSCCTRL_DPLLCTRLB) Low Bandwidth Filter Position  */
+#define OSCCTRL_DPLLCTRLB_FILTER_HBFILT     (OSCCTRL_DPLLCTRLB_FILTER_HBFILT_Val << OSCCTRL_DPLLCTRLB_FILTER_Pos)  /**< (OSCCTRL_DPLLCTRLB) High Bandwidth Filter Position  */
+#define OSCCTRL_DPLLCTRLB_FILTER_HDFILT     (OSCCTRL_DPLLCTRLB_FILTER_HDFILT_Val << OSCCTRL_DPLLCTRLB_FILTER_Pos)  /**< (OSCCTRL_DPLLCTRLB) High Damping Filter Position  */
+#define OSCCTRL_DPLLCTRLB_LPEN_Pos          2                                              /**< (OSCCTRL_DPLLCTRLB) Low-Power Enable Position */
+#define OSCCTRL_DPLLCTRLB_LPEN_Msk          (_U_(0x1) << OSCCTRL_DPLLCTRLB_LPEN_Pos)       /**< (OSCCTRL_DPLLCTRLB) Low-Power Enable Mask */
+#define OSCCTRL_DPLLCTRLB_LPEN              OSCCTRL_DPLLCTRLB_LPEN_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_DPLLCTRLB_LPEN_Msk instead */
+#define OSCCTRL_DPLLCTRLB_WUF_Pos           3                                              /**< (OSCCTRL_DPLLCTRLB) Wake Up Fast Position */
+#define OSCCTRL_DPLLCTRLB_WUF_Msk           (_U_(0x1) << OSCCTRL_DPLLCTRLB_WUF_Pos)        /**< (OSCCTRL_DPLLCTRLB) Wake Up Fast Mask */
+#define OSCCTRL_DPLLCTRLB_WUF               OSCCTRL_DPLLCTRLB_WUF_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_DPLLCTRLB_WUF_Msk instead */
+#define OSCCTRL_DPLLCTRLB_REFCLK_Pos        4                                              /**< (OSCCTRL_DPLLCTRLB) Reference Clock Selection Position */
+#define OSCCTRL_DPLLCTRLB_REFCLK_Msk        (_U_(0x3) << OSCCTRL_DPLLCTRLB_REFCLK_Pos)     /**< (OSCCTRL_DPLLCTRLB) Reference Clock Selection Mask */
+#define OSCCTRL_DPLLCTRLB_REFCLK(value)     (OSCCTRL_DPLLCTRLB_REFCLK_Msk & ((value) << OSCCTRL_DPLLCTRLB_REFCLK_Pos))
+#define   OSCCTRL_DPLLCTRLB_REFCLK_XOSC32K_Val _U_(0x0)                                       /**< (OSCCTRL_DPLLCTRLB) XOSC32K Clock Reference  */
+#define   OSCCTRL_DPLLCTRLB_REFCLK_XOSC_Val _U_(0x1)                                       /**< (OSCCTRL_DPLLCTRLB) XOSC Clock Reference  */
+#define   OSCCTRL_DPLLCTRLB_REFCLK_GCLK_Val _U_(0x2)                                       /**< (OSCCTRL_DPLLCTRLB) GCLK Clock Reference  */
+#define OSCCTRL_DPLLCTRLB_REFCLK_XOSC32K    (OSCCTRL_DPLLCTRLB_REFCLK_XOSC32K_Val << OSCCTRL_DPLLCTRLB_REFCLK_Pos)  /**< (OSCCTRL_DPLLCTRLB) XOSC32K Clock Reference Position  */
+#define OSCCTRL_DPLLCTRLB_REFCLK_XOSC       (OSCCTRL_DPLLCTRLB_REFCLK_XOSC_Val << OSCCTRL_DPLLCTRLB_REFCLK_Pos)  /**< (OSCCTRL_DPLLCTRLB) XOSC Clock Reference Position  */
+#define OSCCTRL_DPLLCTRLB_REFCLK_GCLK       (OSCCTRL_DPLLCTRLB_REFCLK_GCLK_Val << OSCCTRL_DPLLCTRLB_REFCLK_Pos)  /**< (OSCCTRL_DPLLCTRLB) GCLK Clock Reference Position  */
+#define OSCCTRL_DPLLCTRLB_LTIME_Pos         8                                              /**< (OSCCTRL_DPLLCTRLB) Lock Time Position */
+#define OSCCTRL_DPLLCTRLB_LTIME_Msk         (_U_(0x7) << OSCCTRL_DPLLCTRLB_LTIME_Pos)      /**< (OSCCTRL_DPLLCTRLB) Lock Time Mask */
+#define OSCCTRL_DPLLCTRLB_LTIME(value)      (OSCCTRL_DPLLCTRLB_LTIME_Msk & ((value) << OSCCTRL_DPLLCTRLB_LTIME_Pos))
+#define   OSCCTRL_DPLLCTRLB_LTIME_Default_Val _U_(0x0)                                       /**< (OSCCTRL_DPLLCTRLB) No time-out. Automatic lock  */
+#define   OSCCTRL_DPLLCTRLB_LTIME_8MS_Val   _U_(0x4)                                       /**< (OSCCTRL_DPLLCTRLB) Time-out if no lock within 8 ms  */
+#define   OSCCTRL_DPLLCTRLB_LTIME_9MS_Val   _U_(0x5)                                       /**< (OSCCTRL_DPLLCTRLB) Time-out if no lock within 9 ms  */
+#define   OSCCTRL_DPLLCTRLB_LTIME_10MS_Val  _U_(0x6)                                       /**< (OSCCTRL_DPLLCTRLB) Time-out if no lock within 10 ms  */
+#define   OSCCTRL_DPLLCTRLB_LTIME_11MS_Val  _U_(0x7)                                       /**< (OSCCTRL_DPLLCTRLB) Time-out if no lock within 11 ms  */
+#define OSCCTRL_DPLLCTRLB_LTIME_Default     (OSCCTRL_DPLLCTRLB_LTIME_Default_Val << OSCCTRL_DPLLCTRLB_LTIME_Pos)  /**< (OSCCTRL_DPLLCTRLB) No time-out. Automatic lock Position  */
+#define OSCCTRL_DPLLCTRLB_LTIME_8MS         (OSCCTRL_DPLLCTRLB_LTIME_8MS_Val << OSCCTRL_DPLLCTRLB_LTIME_Pos)  /**< (OSCCTRL_DPLLCTRLB) Time-out if no lock within 8 ms Position  */
+#define OSCCTRL_DPLLCTRLB_LTIME_9MS         (OSCCTRL_DPLLCTRLB_LTIME_9MS_Val << OSCCTRL_DPLLCTRLB_LTIME_Pos)  /**< (OSCCTRL_DPLLCTRLB) Time-out if no lock within 9 ms Position  */
+#define OSCCTRL_DPLLCTRLB_LTIME_10MS        (OSCCTRL_DPLLCTRLB_LTIME_10MS_Val << OSCCTRL_DPLLCTRLB_LTIME_Pos)  /**< (OSCCTRL_DPLLCTRLB) Time-out if no lock within 10 ms Position  */
+#define OSCCTRL_DPLLCTRLB_LTIME_11MS        (OSCCTRL_DPLLCTRLB_LTIME_11MS_Val << OSCCTRL_DPLLCTRLB_LTIME_Pos)  /**< (OSCCTRL_DPLLCTRLB) Time-out if no lock within 11 ms Position  */
+#define OSCCTRL_DPLLCTRLB_LBYPASS_Pos       12                                             /**< (OSCCTRL_DPLLCTRLB) Lock Bypass Position */
+#define OSCCTRL_DPLLCTRLB_LBYPASS_Msk       (_U_(0x1) << OSCCTRL_DPLLCTRLB_LBYPASS_Pos)    /**< (OSCCTRL_DPLLCTRLB) Lock Bypass Mask */
+#define OSCCTRL_DPLLCTRLB_LBYPASS           OSCCTRL_DPLLCTRLB_LBYPASS_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_DPLLCTRLB_LBYPASS_Msk instead */
+#define OSCCTRL_DPLLCTRLB_DIV_Pos           16                                             /**< (OSCCTRL_DPLLCTRLB) Clock Divider Position */
+#define OSCCTRL_DPLLCTRLB_DIV_Msk           (_U_(0x7FF) << OSCCTRL_DPLLCTRLB_DIV_Pos)      /**< (OSCCTRL_DPLLCTRLB) Clock Divider Mask */
+#define OSCCTRL_DPLLCTRLB_DIV(value)        (OSCCTRL_DPLLCTRLB_DIV_Msk & ((value) << OSCCTRL_DPLLCTRLB_DIV_Pos))
+#define OSCCTRL_DPLLCTRLB_MASK              _U_(0x7FF173F)                                 /**< \deprecated (OSCCTRL_DPLLCTRLB) Register MASK  (Use OSCCTRL_DPLLCTRLB_Msk instead)  */
+#define OSCCTRL_DPLLCTRLB_Msk               _U_(0x7FF173F)                                 /**< (OSCCTRL_DPLLCTRLB) Register Mask  */
+
+
+/* -------- OSCCTRL_DPLLPRESC : (OSCCTRL Offset: 0x38) (R/W 8) DPLL Prescaler -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  PRESC:2;                   /**< bit:   0..1  Output Clock Prescaler                   */
+    uint8_t  :6;                        /**< bit:   2..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} OSCCTRL_DPLLPRESC_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_DPLLPRESC_OFFSET            (0x38)                                        /**<  (OSCCTRL_DPLLPRESC) DPLL Prescaler  Offset */
+#define OSCCTRL_DPLLPRESC_RESETVALUE        _U_(0x00)                                     /**<  (OSCCTRL_DPLLPRESC) DPLL Prescaler  Reset Value */
+
+#define OSCCTRL_DPLLPRESC_PRESC_Pos         0                                              /**< (OSCCTRL_DPLLPRESC) Output Clock Prescaler Position */
+#define OSCCTRL_DPLLPRESC_PRESC_Msk         (_U_(0x3) << OSCCTRL_DPLLPRESC_PRESC_Pos)      /**< (OSCCTRL_DPLLPRESC) Output Clock Prescaler Mask */
+#define OSCCTRL_DPLLPRESC_PRESC(value)      (OSCCTRL_DPLLPRESC_PRESC_Msk & ((value) << OSCCTRL_DPLLPRESC_PRESC_Pos))
+#define   OSCCTRL_DPLLPRESC_PRESC_DIV1_Val  _U_(0x0)                                       /**< (OSCCTRL_DPLLPRESC) DPLL output is divided by 1  */
+#define   OSCCTRL_DPLLPRESC_PRESC_DIV2_Val  _U_(0x1)                                       /**< (OSCCTRL_DPLLPRESC) DPLL output is divided by 2  */
+#define   OSCCTRL_DPLLPRESC_PRESC_DIV4_Val  _U_(0x2)                                       /**< (OSCCTRL_DPLLPRESC) DPLL output is divided by 4  */
+#define OSCCTRL_DPLLPRESC_PRESC_DIV1        (OSCCTRL_DPLLPRESC_PRESC_DIV1_Val << OSCCTRL_DPLLPRESC_PRESC_Pos)  /**< (OSCCTRL_DPLLPRESC) DPLL output is divided by 1 Position  */
+#define OSCCTRL_DPLLPRESC_PRESC_DIV2        (OSCCTRL_DPLLPRESC_PRESC_DIV2_Val << OSCCTRL_DPLLPRESC_PRESC_Pos)  /**< (OSCCTRL_DPLLPRESC) DPLL output is divided by 2 Position  */
+#define OSCCTRL_DPLLPRESC_PRESC_DIV4        (OSCCTRL_DPLLPRESC_PRESC_DIV4_Val << OSCCTRL_DPLLPRESC_PRESC_Pos)  /**< (OSCCTRL_DPLLPRESC) DPLL output is divided by 4 Position  */
+#define OSCCTRL_DPLLPRESC_MASK              _U_(0x03)                                      /**< \deprecated (OSCCTRL_DPLLPRESC) Register MASK  (Use OSCCTRL_DPLLPRESC_Msk instead)  */
+#define OSCCTRL_DPLLPRESC_Msk               _U_(0x03)                                      /**< (OSCCTRL_DPLLPRESC) Register Mask  */
+
+
+/* -------- OSCCTRL_DPLLSYNCBUSY : (OSCCTRL Offset: 0x3c) (R/ 8) DPLL Synchronization Busy -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  :1;                        /**< bit:      0  Reserved */
+    uint8_t  ENABLE:1;                  /**< bit:      1  DPLL Enable Synchronization Status       */
+    uint8_t  DPLLRATIO:1;               /**< bit:      2  DPLL Loop Divider Ratio Synchronization Status */
+    uint8_t  DPLLPRESC:1;               /**< bit:      3  DPLL Prescaler Synchronization Status    */
+    uint8_t  :4;                        /**< bit:   4..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} OSCCTRL_DPLLSYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_DPLLSYNCBUSY_OFFSET         (0x3C)                                        /**<  (OSCCTRL_DPLLSYNCBUSY) DPLL Synchronization Busy  Offset */
+#define OSCCTRL_DPLLSYNCBUSY_RESETVALUE     _U_(0x00)                                     /**<  (OSCCTRL_DPLLSYNCBUSY) DPLL Synchronization Busy  Reset Value */
+
+#define OSCCTRL_DPLLSYNCBUSY_ENABLE_Pos     1                                              /**< (OSCCTRL_DPLLSYNCBUSY) DPLL Enable Synchronization Status Position */
+#define OSCCTRL_DPLLSYNCBUSY_ENABLE_Msk     (_U_(0x1) << OSCCTRL_DPLLSYNCBUSY_ENABLE_Pos)  /**< (OSCCTRL_DPLLSYNCBUSY) DPLL Enable Synchronization Status Mask */
+#define OSCCTRL_DPLLSYNCBUSY_ENABLE         OSCCTRL_DPLLSYNCBUSY_ENABLE_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_DPLLSYNCBUSY_ENABLE_Msk instead */
+#define OSCCTRL_DPLLSYNCBUSY_DPLLRATIO_Pos  2                                              /**< (OSCCTRL_DPLLSYNCBUSY) DPLL Loop Divider Ratio Synchronization Status Position */
+#define OSCCTRL_DPLLSYNCBUSY_DPLLRATIO_Msk  (_U_(0x1) << OSCCTRL_DPLLSYNCBUSY_DPLLRATIO_Pos)  /**< (OSCCTRL_DPLLSYNCBUSY) DPLL Loop Divider Ratio Synchronization Status Mask */
+#define OSCCTRL_DPLLSYNCBUSY_DPLLRATIO      OSCCTRL_DPLLSYNCBUSY_DPLLRATIO_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_DPLLSYNCBUSY_DPLLRATIO_Msk instead */
+#define OSCCTRL_DPLLSYNCBUSY_DPLLPRESC_Pos  3                                              /**< (OSCCTRL_DPLLSYNCBUSY) DPLL Prescaler Synchronization Status Position */
+#define OSCCTRL_DPLLSYNCBUSY_DPLLPRESC_Msk  (_U_(0x1) << OSCCTRL_DPLLSYNCBUSY_DPLLPRESC_Pos)  /**< (OSCCTRL_DPLLSYNCBUSY) DPLL Prescaler Synchronization Status Mask */
+#define OSCCTRL_DPLLSYNCBUSY_DPLLPRESC      OSCCTRL_DPLLSYNCBUSY_DPLLPRESC_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_DPLLSYNCBUSY_DPLLPRESC_Msk instead */
+#define OSCCTRL_DPLLSYNCBUSY_MASK           _U_(0x0E)                                      /**< \deprecated (OSCCTRL_DPLLSYNCBUSY) Register MASK  (Use OSCCTRL_DPLLSYNCBUSY_Msk instead)  */
+#define OSCCTRL_DPLLSYNCBUSY_Msk            _U_(0x0E)                                      /**< (OSCCTRL_DPLLSYNCBUSY) Register Mask  */
+
+
+/* -------- OSCCTRL_DPLLSTATUS : (OSCCTRL Offset: 0x40) (R/ 8) DPLL Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  LOCK:1;                    /**< bit:      0  DPLL Lock                                */
+    uint8_t  CLKRDY:1;                  /**< bit:      1  DPLL Clock Ready                         */
+    uint8_t  :6;                        /**< bit:   2..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} OSCCTRL_DPLLSTATUS_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_DPLLSTATUS_OFFSET           (0x40)                                        /**<  (OSCCTRL_DPLLSTATUS) DPLL Status  Offset */
+#define OSCCTRL_DPLLSTATUS_RESETVALUE       _U_(0x00)                                     /**<  (OSCCTRL_DPLLSTATUS) DPLL Status  Reset Value */
+
+#define OSCCTRL_DPLLSTATUS_LOCK_Pos         0                                              /**< (OSCCTRL_DPLLSTATUS) DPLL Lock Position */
+#define OSCCTRL_DPLLSTATUS_LOCK_Msk         (_U_(0x1) << OSCCTRL_DPLLSTATUS_LOCK_Pos)      /**< (OSCCTRL_DPLLSTATUS) DPLL Lock Mask */
+#define OSCCTRL_DPLLSTATUS_LOCK             OSCCTRL_DPLLSTATUS_LOCK_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_DPLLSTATUS_LOCK_Msk instead */
+#define OSCCTRL_DPLLSTATUS_CLKRDY_Pos       1                                              /**< (OSCCTRL_DPLLSTATUS) DPLL Clock Ready Position */
+#define OSCCTRL_DPLLSTATUS_CLKRDY_Msk       (_U_(0x1) << OSCCTRL_DPLLSTATUS_CLKRDY_Pos)    /**< (OSCCTRL_DPLLSTATUS) DPLL Clock Ready Mask */
+#define OSCCTRL_DPLLSTATUS_CLKRDY           OSCCTRL_DPLLSTATUS_CLKRDY_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use OSCCTRL_DPLLSTATUS_CLKRDY_Msk instead */
+#define OSCCTRL_DPLLSTATUS_MASK             _U_(0x03)                                      /**< \deprecated (OSCCTRL_DPLLSTATUS) Register MASK  (Use OSCCTRL_DPLLSTATUS_Msk instead)  */
+#define OSCCTRL_DPLLSTATUS_Msk              _U_(0x03)                                      /**< (OSCCTRL_DPLLSTATUS) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief OSCCTRL hardware registers */
+typedef struct {  /* Oscillators Control */
+  __IO OSCCTRL_EVCTRL_Type            EVCTRL;         /**< Offset: 0x00 (R/W   8) Event Control */
+  __I  uint8_t                        Reserved1[3];
+  __IO OSCCTRL_INTENCLR_Type          INTENCLR;       /**< Offset: 0x04 (R/W  32) Interrupt Enable Clear */
+  __IO OSCCTRL_INTENSET_Type          INTENSET;       /**< Offset: 0x08 (R/W  32) Interrupt Enable Set */
+  __IO OSCCTRL_INTFLAG_Type           INTFLAG;        /**< Offset: 0x0C (R/W  32) Interrupt Flag Status and Clear */
+  __I  OSCCTRL_STATUS_Type            STATUS;         /**< Offset: 0x10 (R/   32) Status */
+  __IO OSCCTRL_XOSCCTRL_Type          XOSCCTRL;       /**< Offset: 0x14 (R/W  16) External Multipurpose Crystal Oscillator (XOSC) Control */
+  __IO OSCCTRL_CFDPRESC_Type          CFDPRESC;       /**< Offset: 0x16 (R/W   8) Clock Failure Detector Prescaler */
+  __I  uint8_t                        Reserved2[1];
+  __IO OSCCTRL_OSC16MCTRL_Type        OSC16MCTRL;     /**< Offset: 0x18 (R/W   8) 16MHz Internal Oscillator (OSC16M) Control */
+  __I  uint8_t                        Reserved3[3];
+  __IO OSCCTRL_DFLLULPCTRL_Type       DFLLULPCTRL;    /**< Offset: 0x1C (R/W  16) DFLLULP Control */
+  __IO OSCCTRL_DFLLULPDITHER_Type     DFLLULPDITHER;  /**< Offset: 0x1E (R/W   8) DFLLULP Dither Control */
+  __IO OSCCTRL_DFLLULPRREQ_Type       DFLLULPRREQ;    /**< Offset: 0x1F (R/W   8) DFLLULP Read Request */
+  __IO OSCCTRL_DFLLULPDLY_Type        DFLLULPDLY;     /**< Offset: 0x20 (R/W  32) DFLLULP Delay Value */
+  __IO OSCCTRL_DFLLULPRATIO_Type      DFLLULPRATIO;   /**< Offset: 0x24 (R/W  32) DFLLULP Target Ratio */
+  __I  OSCCTRL_DFLLULPSYNCBUSY_Type   DFLLULPSYNCBUSY; /**< Offset: 0x28 (R/   32) DFLLULP Synchronization Busy */
+  __IO OSCCTRL_DPLLCTRLA_Type         DPLLCTRLA;      /**< Offset: 0x2C (R/W   8) DPLL Control A */
+  __I  uint8_t                        Reserved4[3];
+  __IO OSCCTRL_DPLLRATIO_Type         DPLLRATIO;      /**< Offset: 0x30 (R/W  32) DPLL Ratio Control */
+  __IO OSCCTRL_DPLLCTRLB_Type         DPLLCTRLB;      /**< Offset: 0x34 (R/W  32) DPLL Control B */
+  __IO OSCCTRL_DPLLPRESC_Type         DPLLPRESC;      /**< Offset: 0x38 (R/W   8) DPLL Prescaler */
+  __I  uint8_t                        Reserved5[3];
+  __I  OSCCTRL_DPLLSYNCBUSY_Type      DPLLSYNCBUSY;   /**< Offset: 0x3C (R/    8) DPLL Synchronization Busy */
+  __I  uint8_t                        Reserved6[3];
+  __I  OSCCTRL_DPLLSTATUS_Type        DPLLSTATUS;     /**< Offset: 0x40 (R/    8) DPLL Status */
+} Oscctrl;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Oscillators Control */
+
+#endif /* _SAML11_OSCCTRL_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/component/pac.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/pac.h
@@ -1,0 +1,966 @@
+/**
+ * \file
+ *
+ * \brief Component description for PAC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_PAC_COMPONENT_H_
+#define _SAML11_PAC_COMPONENT_H_
+#define _SAML11_PAC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML11 Peripheral Access Controller
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR PAC */
+/* ========================================================================== */
+
+#define PAC_U2120                      /**< (PAC) Module ID */
+#define REV_PAC 0x200                  /**< (PAC) Module revision */
+
+/* -------- PAC_WRCTRL : (PAC Offset: 0x00) (R/W 32) Write control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t PERID:16;                  /**< bit:  0..15  Peripheral identifier                    */
+    uint32_t KEY:8;                     /**< bit: 16..23  Peripheral access control key            */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PAC_WRCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_WRCTRL_OFFSET                   (0x00)                                        /**<  (PAC_WRCTRL) Write control  Offset */
+#define PAC_WRCTRL_RESETVALUE               _U_(0x00)                                     /**<  (PAC_WRCTRL) Write control  Reset Value */
+
+#define PAC_WRCTRL_PERID_Pos                0                                              /**< (PAC_WRCTRL) Peripheral identifier Position */
+#define PAC_WRCTRL_PERID_Msk                (_U_(0xFFFF) << PAC_WRCTRL_PERID_Pos)          /**< (PAC_WRCTRL) Peripheral identifier Mask */
+#define PAC_WRCTRL_PERID(value)             (PAC_WRCTRL_PERID_Msk & ((value) << PAC_WRCTRL_PERID_Pos))
+#define PAC_WRCTRL_KEY_Pos                  16                                             /**< (PAC_WRCTRL) Peripheral access control key Position */
+#define PAC_WRCTRL_KEY_Msk                  (_U_(0xFF) << PAC_WRCTRL_KEY_Pos)              /**< (PAC_WRCTRL) Peripheral access control key Mask */
+#define PAC_WRCTRL_KEY(value)               (PAC_WRCTRL_KEY_Msk & ((value) << PAC_WRCTRL_KEY_Pos))
+#define   PAC_WRCTRL_KEY_OFF_Val            _U_(0x0)                                       /**< (PAC_WRCTRL) No action  */
+#define   PAC_WRCTRL_KEY_CLR_Val            _U_(0x1)                                       /**< (PAC_WRCTRL) Clear protection  */
+#define   PAC_WRCTRL_KEY_SET_Val            _U_(0x2)                                       /**< (PAC_WRCTRL) Set protection  */
+#define   PAC_WRCTRL_KEY_SETLCK_Val         _U_(0x3)                                       /**< (PAC_WRCTRL) Set and lock protection  */
+#define   PAC_WRCTRL_KEY_SETSEC_Val         _U_(0x4)                                       /**< (PAC_WRCTRL) Set IP secure  */
+#define   PAC_WRCTRL_KEY_SETNONSEC_Val      _U_(0x5)                                       /**< (PAC_WRCTRL) Set IP non-secure  */
+#define   PAC_WRCTRL_KEY_SECLOCK_Val        _U_(0x6)                                       /**< (PAC_WRCTRL) Lock IP security value  */
+#define PAC_WRCTRL_KEY_OFF                  (PAC_WRCTRL_KEY_OFF_Val << PAC_WRCTRL_KEY_Pos)  /**< (PAC_WRCTRL) No action Position  */
+#define PAC_WRCTRL_KEY_CLR                  (PAC_WRCTRL_KEY_CLR_Val << PAC_WRCTRL_KEY_Pos)  /**< (PAC_WRCTRL) Clear protection Position  */
+#define PAC_WRCTRL_KEY_SET                  (PAC_WRCTRL_KEY_SET_Val << PAC_WRCTRL_KEY_Pos)  /**< (PAC_WRCTRL) Set protection Position  */
+#define PAC_WRCTRL_KEY_SETLCK               (PAC_WRCTRL_KEY_SETLCK_Val << PAC_WRCTRL_KEY_Pos)  /**< (PAC_WRCTRL) Set and lock protection Position  */
+#define PAC_WRCTRL_KEY_SETSEC               (PAC_WRCTRL_KEY_SETSEC_Val << PAC_WRCTRL_KEY_Pos)  /**< (PAC_WRCTRL) Set IP secure Position  */
+#define PAC_WRCTRL_KEY_SETNONSEC            (PAC_WRCTRL_KEY_SETNONSEC_Val << PAC_WRCTRL_KEY_Pos)  /**< (PAC_WRCTRL) Set IP non-secure Position  */
+#define PAC_WRCTRL_KEY_SECLOCK              (PAC_WRCTRL_KEY_SECLOCK_Val << PAC_WRCTRL_KEY_Pos)  /**< (PAC_WRCTRL) Lock IP security value Position  */
+#define PAC_WRCTRL_MASK                     _U_(0xFFFFFF)                                  /**< \deprecated (PAC_WRCTRL) Register MASK  (Use PAC_WRCTRL_Msk instead)  */
+#define PAC_WRCTRL_Msk                      _U_(0xFFFFFF)                                  /**< (PAC_WRCTRL) Register Mask  */
+
+
+/* -------- PAC_EVCTRL : (PAC Offset: 0x04) (R/W 8) Event control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  ERREO:1;                   /**< bit:      0  Peripheral acess error event output      */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} PAC_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_EVCTRL_OFFSET                   (0x04)                                        /**<  (PAC_EVCTRL) Event control  Offset */
+#define PAC_EVCTRL_RESETVALUE               _U_(0x00)                                     /**<  (PAC_EVCTRL) Event control  Reset Value */
+
+#define PAC_EVCTRL_ERREO_Pos                0                                              /**< (PAC_EVCTRL) Peripheral acess error event output Position */
+#define PAC_EVCTRL_ERREO_Msk                (_U_(0x1) << PAC_EVCTRL_ERREO_Pos)             /**< (PAC_EVCTRL) Peripheral acess error event output Mask */
+#define PAC_EVCTRL_ERREO                    PAC_EVCTRL_ERREO_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_EVCTRL_ERREO_Msk instead */
+#define PAC_EVCTRL_MASK                     _U_(0x01)                                      /**< \deprecated (PAC_EVCTRL) Register MASK  (Use PAC_EVCTRL_Msk instead)  */
+#define PAC_EVCTRL_Msk                      _U_(0x01)                                      /**< (PAC_EVCTRL) Register Mask  */
+
+
+/* -------- PAC_INTENCLR : (PAC Offset: 0x08) (R/W 8) Interrupt enable clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  ERR:1;                     /**< bit:      0  Peripheral access error interrupt disable */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} PAC_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_INTENCLR_OFFSET                 (0x08)                                        /**<  (PAC_INTENCLR) Interrupt enable clear  Offset */
+#define PAC_INTENCLR_RESETVALUE             _U_(0x00)                                     /**<  (PAC_INTENCLR) Interrupt enable clear  Reset Value */
+
+#define PAC_INTENCLR_ERR_Pos                0                                              /**< (PAC_INTENCLR) Peripheral access error interrupt disable Position */
+#define PAC_INTENCLR_ERR_Msk                (_U_(0x1) << PAC_INTENCLR_ERR_Pos)             /**< (PAC_INTENCLR) Peripheral access error interrupt disable Mask */
+#define PAC_INTENCLR_ERR                    PAC_INTENCLR_ERR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTENCLR_ERR_Msk instead */
+#define PAC_INTENCLR_MASK                   _U_(0x01)                                      /**< \deprecated (PAC_INTENCLR) Register MASK  (Use PAC_INTENCLR_Msk instead)  */
+#define PAC_INTENCLR_Msk                    _U_(0x01)                                      /**< (PAC_INTENCLR) Register Mask  */
+
+
+/* -------- PAC_INTENSET : (PAC Offset: 0x09) (R/W 8) Interrupt enable set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  ERR:1;                     /**< bit:      0  Peripheral access error interrupt enable */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} PAC_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_INTENSET_OFFSET                 (0x09)                                        /**<  (PAC_INTENSET) Interrupt enable set  Offset */
+#define PAC_INTENSET_RESETVALUE             _U_(0x00)                                     /**<  (PAC_INTENSET) Interrupt enable set  Reset Value */
+
+#define PAC_INTENSET_ERR_Pos                0                                              /**< (PAC_INTENSET) Peripheral access error interrupt enable Position */
+#define PAC_INTENSET_ERR_Msk                (_U_(0x1) << PAC_INTENSET_ERR_Pos)             /**< (PAC_INTENSET) Peripheral access error interrupt enable Mask */
+#define PAC_INTENSET_ERR                    PAC_INTENSET_ERR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTENSET_ERR_Msk instead */
+#define PAC_INTENSET_MASK                   _U_(0x01)                                      /**< \deprecated (PAC_INTENSET) Register MASK  (Use PAC_INTENSET_Msk instead)  */
+#define PAC_INTENSET_Msk                    _U_(0x01)                                      /**< (PAC_INTENSET) Register Mask  */
+
+
+/* -------- PAC_INTFLAGAHB : (PAC Offset: 0x10) (R/W 32) Bridge interrupt flag status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint32_t FLASH_:1;                  /**< bit:      0  FLASH                                    */
+    __I uint32_t HPB0_:1;                   /**< bit:      1  HPB0                                     */
+    __I uint32_t HPB1_:1;                   /**< bit:      2  HPB1                                     */
+    __I uint32_t HPB2_:1;                   /**< bit:      3  HPB2                                     */
+    __I uint32_t HSRAMCPU_:1;               /**< bit:      4  HSRAMCPU                                 */
+    __I uint32_t HSRAMDMAC_:1;              /**< bit:      5  HSRAMDMAC                                */
+    __I uint32_t HSRAMDSU_:1;               /**< bit:      6  HSRAMDSU                                 */
+    __I uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PAC_INTFLAGAHB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_INTFLAGAHB_OFFSET               (0x10)                                        /**<  (PAC_INTFLAGAHB) Bridge interrupt flag status  Offset */
+#define PAC_INTFLAGAHB_RESETVALUE           _U_(0x00)                                     /**<  (PAC_INTFLAGAHB) Bridge interrupt flag status  Reset Value */
+
+#define PAC_INTFLAGAHB_FLASH_Pos            0                                              /**< (PAC_INTFLAGAHB) FLASH Position */
+#define PAC_INTFLAGAHB_FLASH_Msk            (_U_(0x1) << PAC_INTFLAGAHB_FLASH_Pos)         /**< (PAC_INTFLAGAHB) FLASH Mask */
+#define PAC_INTFLAGAHB_FLASH                PAC_INTFLAGAHB_FLASH_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGAHB_FLASH_Msk instead */
+#define PAC_INTFLAGAHB_HPB0_Pos             1                                              /**< (PAC_INTFLAGAHB) HPB0 Position */
+#define PAC_INTFLAGAHB_HPB0_Msk             (_U_(0x1) << PAC_INTFLAGAHB_HPB0_Pos)          /**< (PAC_INTFLAGAHB) HPB0 Mask */
+#define PAC_INTFLAGAHB_HPB0                 PAC_INTFLAGAHB_HPB0_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGAHB_HPB0_Msk instead */
+#define PAC_INTFLAGAHB_HPB1_Pos             2                                              /**< (PAC_INTFLAGAHB) HPB1 Position */
+#define PAC_INTFLAGAHB_HPB1_Msk             (_U_(0x1) << PAC_INTFLAGAHB_HPB1_Pos)          /**< (PAC_INTFLAGAHB) HPB1 Mask */
+#define PAC_INTFLAGAHB_HPB1                 PAC_INTFLAGAHB_HPB1_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGAHB_HPB1_Msk instead */
+#define PAC_INTFLAGAHB_HPB2_Pos             3                                              /**< (PAC_INTFLAGAHB) HPB2 Position */
+#define PAC_INTFLAGAHB_HPB2_Msk             (_U_(0x1) << PAC_INTFLAGAHB_HPB2_Pos)          /**< (PAC_INTFLAGAHB) HPB2 Mask */
+#define PAC_INTFLAGAHB_HPB2                 PAC_INTFLAGAHB_HPB2_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGAHB_HPB2_Msk instead */
+#define PAC_INTFLAGAHB_HSRAMCPU_Pos         4                                              /**< (PAC_INTFLAGAHB) HSRAMCPU Position */
+#define PAC_INTFLAGAHB_HSRAMCPU_Msk         (_U_(0x1) << PAC_INTFLAGAHB_HSRAMCPU_Pos)      /**< (PAC_INTFLAGAHB) HSRAMCPU Mask */
+#define PAC_INTFLAGAHB_HSRAMCPU             PAC_INTFLAGAHB_HSRAMCPU_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGAHB_HSRAMCPU_Msk instead */
+#define PAC_INTFLAGAHB_HSRAMDMAC_Pos        5                                              /**< (PAC_INTFLAGAHB) HSRAMDMAC Position */
+#define PAC_INTFLAGAHB_HSRAMDMAC_Msk        (_U_(0x1) << PAC_INTFLAGAHB_HSRAMDMAC_Pos)     /**< (PAC_INTFLAGAHB) HSRAMDMAC Mask */
+#define PAC_INTFLAGAHB_HSRAMDMAC            PAC_INTFLAGAHB_HSRAMDMAC_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGAHB_HSRAMDMAC_Msk instead */
+#define PAC_INTFLAGAHB_HSRAMDSU_Pos         6                                              /**< (PAC_INTFLAGAHB) HSRAMDSU Position */
+#define PAC_INTFLAGAHB_HSRAMDSU_Msk         (_U_(0x1) << PAC_INTFLAGAHB_HSRAMDSU_Pos)      /**< (PAC_INTFLAGAHB) HSRAMDSU Mask */
+#define PAC_INTFLAGAHB_HSRAMDSU             PAC_INTFLAGAHB_HSRAMDSU_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGAHB_HSRAMDSU_Msk instead */
+#define PAC_INTFLAGAHB_MASK                 _U_(0x7F)                                      /**< \deprecated (PAC_INTFLAGAHB) Register MASK  (Use PAC_INTFLAGAHB_Msk instead)  */
+#define PAC_INTFLAGAHB_Msk                  _U_(0x7F)                                      /**< (PAC_INTFLAGAHB) Register Mask  */
+
+#define PAC_INTFLAGAHB_HPB_Pos              1                                              /**< (PAC_INTFLAGAHB Position) HPBx */
+#define PAC_INTFLAGAHB_HPB_Msk              (_U_(0x7) << PAC_INTFLAGAHB_HPB_Pos)           /**< (PAC_INTFLAGAHB Mask) HPB */
+#define PAC_INTFLAGAHB_HPB(value)           (PAC_INTFLAGAHB_HPB_Msk & ((value) << PAC_INTFLAGAHB_HPB_Pos))  
+
+/* -------- PAC_INTFLAGA : (PAC Offset: 0x14) (R/W 32) Peripheral interrupt flag status - Bridge A -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint32_t PAC_:1;                    /**< bit:      0  PAC                                      */
+    __I uint32_t PM_:1;                     /**< bit:      1  PM                                       */
+    __I uint32_t MCLK_:1;                   /**< bit:      2  MCLK                                     */
+    __I uint32_t RSTC_:1;                   /**< bit:      3  RSTC                                     */
+    __I uint32_t OSCCTRL_:1;                /**< bit:      4  OSCCTRL                                  */
+    __I uint32_t OSC32KCTRL_:1;             /**< bit:      5  OSC32KCTRL                               */
+    __I uint32_t SUPC_:1;                   /**< bit:      6  SUPC                                     */
+    __I uint32_t GCLK_:1;                   /**< bit:      7  GCLK                                     */
+    __I uint32_t WDT_:1;                    /**< bit:      8  WDT                                      */
+    __I uint32_t RTC_:1;                    /**< bit:      9  RTC                                      */
+    __I uint32_t EIC_:1;                    /**< bit:     10  EIC                                      */
+    __I uint32_t FREQM_:1;                  /**< bit:     11  FREQM                                    */
+    __I uint32_t PORT_:1;                   /**< bit:     12  PORT                                     */
+    __I uint32_t AC_:1;                     /**< bit:     13  AC                                       */
+    __I uint32_t :18;                       /**< bit: 14..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PAC_INTFLAGA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_INTFLAGA_OFFSET                 (0x14)                                        /**<  (PAC_INTFLAGA) Peripheral interrupt flag status - Bridge A  Offset */
+#define PAC_INTFLAGA_RESETVALUE             _U_(0x00)                                     /**<  (PAC_INTFLAGA) Peripheral interrupt flag status - Bridge A  Reset Value */
+
+#define PAC_INTFLAGA_PAC_Pos                0                                              /**< (PAC_INTFLAGA) PAC Position */
+#define PAC_INTFLAGA_PAC_Msk                (_U_(0x1) << PAC_INTFLAGA_PAC_Pos)             /**< (PAC_INTFLAGA) PAC Mask */
+#define PAC_INTFLAGA_PAC                    PAC_INTFLAGA_PAC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGA_PAC_Msk instead */
+#define PAC_INTFLAGA_PM_Pos                 1                                              /**< (PAC_INTFLAGA) PM Position */
+#define PAC_INTFLAGA_PM_Msk                 (_U_(0x1) << PAC_INTFLAGA_PM_Pos)              /**< (PAC_INTFLAGA) PM Mask */
+#define PAC_INTFLAGA_PM                     PAC_INTFLAGA_PM_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGA_PM_Msk instead */
+#define PAC_INTFLAGA_MCLK_Pos               2                                              /**< (PAC_INTFLAGA) MCLK Position */
+#define PAC_INTFLAGA_MCLK_Msk               (_U_(0x1) << PAC_INTFLAGA_MCLK_Pos)            /**< (PAC_INTFLAGA) MCLK Mask */
+#define PAC_INTFLAGA_MCLK                   PAC_INTFLAGA_MCLK_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGA_MCLK_Msk instead */
+#define PAC_INTFLAGA_RSTC_Pos               3                                              /**< (PAC_INTFLAGA) RSTC Position */
+#define PAC_INTFLAGA_RSTC_Msk               (_U_(0x1) << PAC_INTFLAGA_RSTC_Pos)            /**< (PAC_INTFLAGA) RSTC Mask */
+#define PAC_INTFLAGA_RSTC                   PAC_INTFLAGA_RSTC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGA_RSTC_Msk instead */
+#define PAC_INTFLAGA_OSCCTRL_Pos            4                                              /**< (PAC_INTFLAGA) OSCCTRL Position */
+#define PAC_INTFLAGA_OSCCTRL_Msk            (_U_(0x1) << PAC_INTFLAGA_OSCCTRL_Pos)         /**< (PAC_INTFLAGA) OSCCTRL Mask */
+#define PAC_INTFLAGA_OSCCTRL                PAC_INTFLAGA_OSCCTRL_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGA_OSCCTRL_Msk instead */
+#define PAC_INTFLAGA_OSC32KCTRL_Pos         5                                              /**< (PAC_INTFLAGA) OSC32KCTRL Position */
+#define PAC_INTFLAGA_OSC32KCTRL_Msk         (_U_(0x1) << PAC_INTFLAGA_OSC32KCTRL_Pos)      /**< (PAC_INTFLAGA) OSC32KCTRL Mask */
+#define PAC_INTFLAGA_OSC32KCTRL             PAC_INTFLAGA_OSC32KCTRL_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGA_OSC32KCTRL_Msk instead */
+#define PAC_INTFLAGA_SUPC_Pos               6                                              /**< (PAC_INTFLAGA) SUPC Position */
+#define PAC_INTFLAGA_SUPC_Msk               (_U_(0x1) << PAC_INTFLAGA_SUPC_Pos)            /**< (PAC_INTFLAGA) SUPC Mask */
+#define PAC_INTFLAGA_SUPC                   PAC_INTFLAGA_SUPC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGA_SUPC_Msk instead */
+#define PAC_INTFLAGA_GCLK_Pos               7                                              /**< (PAC_INTFLAGA) GCLK Position */
+#define PAC_INTFLAGA_GCLK_Msk               (_U_(0x1) << PAC_INTFLAGA_GCLK_Pos)            /**< (PAC_INTFLAGA) GCLK Mask */
+#define PAC_INTFLAGA_GCLK                   PAC_INTFLAGA_GCLK_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGA_GCLK_Msk instead */
+#define PAC_INTFLAGA_WDT_Pos                8                                              /**< (PAC_INTFLAGA) WDT Position */
+#define PAC_INTFLAGA_WDT_Msk                (_U_(0x1) << PAC_INTFLAGA_WDT_Pos)             /**< (PAC_INTFLAGA) WDT Mask */
+#define PAC_INTFLAGA_WDT                    PAC_INTFLAGA_WDT_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGA_WDT_Msk instead */
+#define PAC_INTFLAGA_RTC_Pos                9                                              /**< (PAC_INTFLAGA) RTC Position */
+#define PAC_INTFLAGA_RTC_Msk                (_U_(0x1) << PAC_INTFLAGA_RTC_Pos)             /**< (PAC_INTFLAGA) RTC Mask */
+#define PAC_INTFLAGA_RTC                    PAC_INTFLAGA_RTC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGA_RTC_Msk instead */
+#define PAC_INTFLAGA_EIC_Pos                10                                             /**< (PAC_INTFLAGA) EIC Position */
+#define PAC_INTFLAGA_EIC_Msk                (_U_(0x1) << PAC_INTFLAGA_EIC_Pos)             /**< (PAC_INTFLAGA) EIC Mask */
+#define PAC_INTFLAGA_EIC                    PAC_INTFLAGA_EIC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGA_EIC_Msk instead */
+#define PAC_INTFLAGA_FREQM_Pos              11                                             /**< (PAC_INTFLAGA) FREQM Position */
+#define PAC_INTFLAGA_FREQM_Msk              (_U_(0x1) << PAC_INTFLAGA_FREQM_Pos)           /**< (PAC_INTFLAGA) FREQM Mask */
+#define PAC_INTFLAGA_FREQM                  PAC_INTFLAGA_FREQM_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGA_FREQM_Msk instead */
+#define PAC_INTFLAGA_PORT_Pos               12                                             /**< (PAC_INTFLAGA) PORT Position */
+#define PAC_INTFLAGA_PORT_Msk               (_U_(0x1) << PAC_INTFLAGA_PORT_Pos)            /**< (PAC_INTFLAGA) PORT Mask */
+#define PAC_INTFLAGA_PORT                   PAC_INTFLAGA_PORT_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGA_PORT_Msk instead */
+#define PAC_INTFLAGA_AC_Pos                 13                                             /**< (PAC_INTFLAGA) AC Position */
+#define PAC_INTFLAGA_AC_Msk                 (_U_(0x1) << PAC_INTFLAGA_AC_Pos)              /**< (PAC_INTFLAGA) AC Mask */
+#define PAC_INTFLAGA_AC                     PAC_INTFLAGA_AC_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGA_AC_Msk instead */
+#define PAC_INTFLAGA_MASK                   _U_(0x3FFF)                                    /**< \deprecated (PAC_INTFLAGA) Register MASK  (Use PAC_INTFLAGA_Msk instead)  */
+#define PAC_INTFLAGA_Msk                    _U_(0x3FFF)                                    /**< (PAC_INTFLAGA) Register Mask  */
+
+
+/* -------- PAC_INTFLAGB : (PAC Offset: 0x18) (R/W 32) Peripheral interrupt flag status - Bridge B -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint32_t IDAU_:1;                   /**< bit:      0  IDAU                                     */
+    __I uint32_t DSU_:1;                    /**< bit:      1  DSU                                      */
+    __I uint32_t NVMCTRL_:1;                /**< bit:      2  NVMCTRL                                  */
+    __I uint32_t DMAC_:1;                   /**< bit:      3  DMAC                                     */
+    __I uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PAC_INTFLAGB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_INTFLAGB_OFFSET                 (0x18)                                        /**<  (PAC_INTFLAGB) Peripheral interrupt flag status - Bridge B  Offset */
+#define PAC_INTFLAGB_RESETVALUE             _U_(0x00)                                     /**<  (PAC_INTFLAGB) Peripheral interrupt flag status - Bridge B  Reset Value */
+
+#define PAC_INTFLAGB_IDAU_Pos               0                                              /**< (PAC_INTFLAGB) IDAU Position */
+#define PAC_INTFLAGB_IDAU_Msk               (_U_(0x1) << PAC_INTFLAGB_IDAU_Pos)            /**< (PAC_INTFLAGB) IDAU Mask */
+#define PAC_INTFLAGB_IDAU                   PAC_INTFLAGB_IDAU_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGB_IDAU_Msk instead */
+#define PAC_INTFLAGB_DSU_Pos                1                                              /**< (PAC_INTFLAGB) DSU Position */
+#define PAC_INTFLAGB_DSU_Msk                (_U_(0x1) << PAC_INTFLAGB_DSU_Pos)             /**< (PAC_INTFLAGB) DSU Mask */
+#define PAC_INTFLAGB_DSU                    PAC_INTFLAGB_DSU_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGB_DSU_Msk instead */
+#define PAC_INTFLAGB_NVMCTRL_Pos            2                                              /**< (PAC_INTFLAGB) NVMCTRL Position */
+#define PAC_INTFLAGB_NVMCTRL_Msk            (_U_(0x1) << PAC_INTFLAGB_NVMCTRL_Pos)         /**< (PAC_INTFLAGB) NVMCTRL Mask */
+#define PAC_INTFLAGB_NVMCTRL                PAC_INTFLAGB_NVMCTRL_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGB_NVMCTRL_Msk instead */
+#define PAC_INTFLAGB_DMAC_Pos               3                                              /**< (PAC_INTFLAGB) DMAC Position */
+#define PAC_INTFLAGB_DMAC_Msk               (_U_(0x1) << PAC_INTFLAGB_DMAC_Pos)            /**< (PAC_INTFLAGB) DMAC Mask */
+#define PAC_INTFLAGB_DMAC                   PAC_INTFLAGB_DMAC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGB_DMAC_Msk instead */
+#define PAC_INTFLAGB_MASK                   _U_(0x0F)                                      /**< \deprecated (PAC_INTFLAGB) Register MASK  (Use PAC_INTFLAGB_Msk instead)  */
+#define PAC_INTFLAGB_Msk                    _U_(0x0F)                                      /**< (PAC_INTFLAGB) Register Mask  */
+
+
+/* -------- PAC_INTFLAGC : (PAC Offset: 0x1c) (R/W 32) Peripheral interrupt flag status - Bridge C -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint32_t EVSYS_:1;                  /**< bit:      0  EVSYS                                    */
+    __I uint32_t SERCOM0_:1;                /**< bit:      1  SERCOM0                                  */
+    __I uint32_t SERCOM1_:1;                /**< bit:      2  SERCOM1                                  */
+    __I uint32_t SERCOM2_:1;                /**< bit:      3  SERCOM2                                  */
+    __I uint32_t TC0_:1;                    /**< bit:      4  TC0                                      */
+    __I uint32_t TC1_:1;                    /**< bit:      5  TC1                                      */
+    __I uint32_t TC2_:1;                    /**< bit:      6  TC2                                      */
+    __I uint32_t ADC_:1;                    /**< bit:      7  ADC                                      */
+    __I uint32_t DAC_:1;                    /**< bit:      8  DAC                                      */
+    __I uint32_t PTC_:1;                    /**< bit:      9  PTC                                      */
+    __I uint32_t TRNG_:1;                   /**< bit:     10  TRNG                                     */
+    __I uint32_t CCL_:1;                    /**< bit:     11  CCL                                      */
+    __I uint32_t OPAMP_:1;                  /**< bit:     12  OPAMP                                    */
+    __I uint32_t TRAM_:1;                   /**< bit:     13  TRAM                                     */
+    __I uint32_t :18;                       /**< bit: 14..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PAC_INTFLAGC_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_INTFLAGC_OFFSET                 (0x1C)                                        /**<  (PAC_INTFLAGC) Peripheral interrupt flag status - Bridge C  Offset */
+#define PAC_INTFLAGC_RESETVALUE             _U_(0x00)                                     /**<  (PAC_INTFLAGC) Peripheral interrupt flag status - Bridge C  Reset Value */
+
+#define PAC_INTFLAGC_EVSYS_Pos              0                                              /**< (PAC_INTFLAGC) EVSYS Position */
+#define PAC_INTFLAGC_EVSYS_Msk              (_U_(0x1) << PAC_INTFLAGC_EVSYS_Pos)           /**< (PAC_INTFLAGC) EVSYS Mask */
+#define PAC_INTFLAGC_EVSYS                  PAC_INTFLAGC_EVSYS_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGC_EVSYS_Msk instead */
+#define PAC_INTFLAGC_SERCOM0_Pos            1                                              /**< (PAC_INTFLAGC) SERCOM0 Position */
+#define PAC_INTFLAGC_SERCOM0_Msk            (_U_(0x1) << PAC_INTFLAGC_SERCOM0_Pos)         /**< (PAC_INTFLAGC) SERCOM0 Mask */
+#define PAC_INTFLAGC_SERCOM0                PAC_INTFLAGC_SERCOM0_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGC_SERCOM0_Msk instead */
+#define PAC_INTFLAGC_SERCOM1_Pos            2                                              /**< (PAC_INTFLAGC) SERCOM1 Position */
+#define PAC_INTFLAGC_SERCOM1_Msk            (_U_(0x1) << PAC_INTFLAGC_SERCOM1_Pos)         /**< (PAC_INTFLAGC) SERCOM1 Mask */
+#define PAC_INTFLAGC_SERCOM1                PAC_INTFLAGC_SERCOM1_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGC_SERCOM1_Msk instead */
+#define PAC_INTFLAGC_SERCOM2_Pos            3                                              /**< (PAC_INTFLAGC) SERCOM2 Position */
+#define PAC_INTFLAGC_SERCOM2_Msk            (_U_(0x1) << PAC_INTFLAGC_SERCOM2_Pos)         /**< (PAC_INTFLAGC) SERCOM2 Mask */
+#define PAC_INTFLAGC_SERCOM2                PAC_INTFLAGC_SERCOM2_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGC_SERCOM2_Msk instead */
+#define PAC_INTFLAGC_TC0_Pos                4                                              /**< (PAC_INTFLAGC) TC0 Position */
+#define PAC_INTFLAGC_TC0_Msk                (_U_(0x1) << PAC_INTFLAGC_TC0_Pos)             /**< (PAC_INTFLAGC) TC0 Mask */
+#define PAC_INTFLAGC_TC0                    PAC_INTFLAGC_TC0_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGC_TC0_Msk instead */
+#define PAC_INTFLAGC_TC1_Pos                5                                              /**< (PAC_INTFLAGC) TC1 Position */
+#define PAC_INTFLAGC_TC1_Msk                (_U_(0x1) << PAC_INTFLAGC_TC1_Pos)             /**< (PAC_INTFLAGC) TC1 Mask */
+#define PAC_INTFLAGC_TC1                    PAC_INTFLAGC_TC1_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGC_TC1_Msk instead */
+#define PAC_INTFLAGC_TC2_Pos                6                                              /**< (PAC_INTFLAGC) TC2 Position */
+#define PAC_INTFLAGC_TC2_Msk                (_U_(0x1) << PAC_INTFLAGC_TC2_Pos)             /**< (PAC_INTFLAGC) TC2 Mask */
+#define PAC_INTFLAGC_TC2                    PAC_INTFLAGC_TC2_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGC_TC2_Msk instead */
+#define PAC_INTFLAGC_ADC_Pos                7                                              /**< (PAC_INTFLAGC) ADC Position */
+#define PAC_INTFLAGC_ADC_Msk                (_U_(0x1) << PAC_INTFLAGC_ADC_Pos)             /**< (PAC_INTFLAGC) ADC Mask */
+#define PAC_INTFLAGC_ADC                    PAC_INTFLAGC_ADC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGC_ADC_Msk instead */
+#define PAC_INTFLAGC_DAC_Pos                8                                              /**< (PAC_INTFLAGC) DAC Position */
+#define PAC_INTFLAGC_DAC_Msk                (_U_(0x1) << PAC_INTFLAGC_DAC_Pos)             /**< (PAC_INTFLAGC) DAC Mask */
+#define PAC_INTFLAGC_DAC                    PAC_INTFLAGC_DAC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGC_DAC_Msk instead */
+#define PAC_INTFLAGC_PTC_Pos                9                                              /**< (PAC_INTFLAGC) PTC Position */
+#define PAC_INTFLAGC_PTC_Msk                (_U_(0x1) << PAC_INTFLAGC_PTC_Pos)             /**< (PAC_INTFLAGC) PTC Mask */
+#define PAC_INTFLAGC_PTC                    PAC_INTFLAGC_PTC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGC_PTC_Msk instead */
+#define PAC_INTFLAGC_TRNG_Pos               10                                             /**< (PAC_INTFLAGC) TRNG Position */
+#define PAC_INTFLAGC_TRNG_Msk               (_U_(0x1) << PAC_INTFLAGC_TRNG_Pos)            /**< (PAC_INTFLAGC) TRNG Mask */
+#define PAC_INTFLAGC_TRNG                   PAC_INTFLAGC_TRNG_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGC_TRNG_Msk instead */
+#define PAC_INTFLAGC_CCL_Pos                11                                             /**< (PAC_INTFLAGC) CCL Position */
+#define PAC_INTFLAGC_CCL_Msk                (_U_(0x1) << PAC_INTFLAGC_CCL_Pos)             /**< (PAC_INTFLAGC) CCL Mask */
+#define PAC_INTFLAGC_CCL                    PAC_INTFLAGC_CCL_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGC_CCL_Msk instead */
+#define PAC_INTFLAGC_OPAMP_Pos              12                                             /**< (PAC_INTFLAGC) OPAMP Position */
+#define PAC_INTFLAGC_OPAMP_Msk              (_U_(0x1) << PAC_INTFLAGC_OPAMP_Pos)           /**< (PAC_INTFLAGC) OPAMP Mask */
+#define PAC_INTFLAGC_OPAMP                  PAC_INTFLAGC_OPAMP_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGC_OPAMP_Msk instead */
+#define PAC_INTFLAGC_TRAM_Pos               13                                             /**< (PAC_INTFLAGC) TRAM Position */
+#define PAC_INTFLAGC_TRAM_Msk               (_U_(0x1) << PAC_INTFLAGC_TRAM_Pos)            /**< (PAC_INTFLAGC) TRAM Mask */
+#define PAC_INTFLAGC_TRAM                   PAC_INTFLAGC_TRAM_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_INTFLAGC_TRAM_Msk instead */
+#define PAC_INTFLAGC_MASK                   _U_(0x3FFF)                                    /**< \deprecated (PAC_INTFLAGC) Register MASK  (Use PAC_INTFLAGC_Msk instead)  */
+#define PAC_INTFLAGC_Msk                    _U_(0x3FFF)                                    /**< (PAC_INTFLAGC) Register Mask  */
+
+#define PAC_INTFLAGC_SERCOM_Pos             1                                              /**< (PAC_INTFLAGC Position) SERCOMx */
+#define PAC_INTFLAGC_SERCOM_Msk             (_U_(0x7) << PAC_INTFLAGC_SERCOM_Pos)          /**< (PAC_INTFLAGC Mask) SERCOM */
+#define PAC_INTFLAGC_SERCOM(value)          (PAC_INTFLAGC_SERCOM_Msk & ((value) << PAC_INTFLAGC_SERCOM_Pos))  
+#define PAC_INTFLAGC_TC_Pos                 4                                              /**< (PAC_INTFLAGC Position) TCx */
+#define PAC_INTFLAGC_TC_Msk                 (_U_(0x7) << PAC_INTFLAGC_TC_Pos)              /**< (PAC_INTFLAGC Mask) TC */
+#define PAC_INTFLAGC_TC(value)              (PAC_INTFLAGC_TC_Msk & ((value) << PAC_INTFLAGC_TC_Pos))  
+
+/* -------- PAC_STATUSA : (PAC Offset: 0x34) (R/ 32) Peripheral write protection status - Bridge A -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t PAC_:1;                    /**< bit:      0  PAC APB Protect Enable                   */
+    uint32_t PM_:1;                     /**< bit:      1  PM APB Protect Enable                    */
+    uint32_t MCLK_:1;                   /**< bit:      2  MCLK APB Protect Enable                  */
+    uint32_t RSTC_:1;                   /**< bit:      3  RSTC APB Protect Enable                  */
+    uint32_t OSCCTRL_:1;                /**< bit:      4  OSCCTRL APB Protect Enable               */
+    uint32_t OSC32KCTRL_:1;             /**< bit:      5  OSC32KCTRL APB Protect Enable            */
+    uint32_t SUPC_:1;                   /**< bit:      6  SUPC APB Protect Enable                  */
+    uint32_t GCLK_:1;                   /**< bit:      7  GCLK APB Protect Enable                  */
+    uint32_t WDT_:1;                    /**< bit:      8  WDT APB Protect Enable                   */
+    uint32_t RTC_:1;                    /**< bit:      9  RTC APB Protect Enable                   */
+    uint32_t EIC_:1;                    /**< bit:     10  EIC APB Protect Enable                   */
+    uint32_t FREQM_:1;                  /**< bit:     11  FREQM APB Protect Enable                 */
+    uint32_t PORT_:1;                   /**< bit:     12  PORT APB Protect Enable                  */
+    uint32_t AC_:1;                     /**< bit:     13  AC APB Protect Enable                    */
+    uint32_t :18;                       /**< bit: 14..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PAC_STATUSA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_STATUSA_OFFSET                  (0x34)                                        /**<  (PAC_STATUSA) Peripheral write protection status - Bridge A  Offset */
+#define PAC_STATUSA_RESETVALUE              _U_(0xC000)                                   /**<  (PAC_STATUSA) Peripheral write protection status - Bridge A  Reset Value */
+
+#define PAC_STATUSA_PAC_Pos                 0                                              /**< (PAC_STATUSA) PAC APB Protect Enable Position */
+#define PAC_STATUSA_PAC_Msk                 (_U_(0x1) << PAC_STATUSA_PAC_Pos)              /**< (PAC_STATUSA) PAC APB Protect Enable Mask */
+#define PAC_STATUSA_PAC                     PAC_STATUSA_PAC_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSA_PAC_Msk instead */
+#define PAC_STATUSA_PM_Pos                  1                                              /**< (PAC_STATUSA) PM APB Protect Enable Position */
+#define PAC_STATUSA_PM_Msk                  (_U_(0x1) << PAC_STATUSA_PM_Pos)               /**< (PAC_STATUSA) PM APB Protect Enable Mask */
+#define PAC_STATUSA_PM                      PAC_STATUSA_PM_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSA_PM_Msk instead */
+#define PAC_STATUSA_MCLK_Pos                2                                              /**< (PAC_STATUSA) MCLK APB Protect Enable Position */
+#define PAC_STATUSA_MCLK_Msk                (_U_(0x1) << PAC_STATUSA_MCLK_Pos)             /**< (PAC_STATUSA) MCLK APB Protect Enable Mask */
+#define PAC_STATUSA_MCLK                    PAC_STATUSA_MCLK_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSA_MCLK_Msk instead */
+#define PAC_STATUSA_RSTC_Pos                3                                              /**< (PAC_STATUSA) RSTC APB Protect Enable Position */
+#define PAC_STATUSA_RSTC_Msk                (_U_(0x1) << PAC_STATUSA_RSTC_Pos)             /**< (PAC_STATUSA) RSTC APB Protect Enable Mask */
+#define PAC_STATUSA_RSTC                    PAC_STATUSA_RSTC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSA_RSTC_Msk instead */
+#define PAC_STATUSA_OSCCTRL_Pos             4                                              /**< (PAC_STATUSA) OSCCTRL APB Protect Enable Position */
+#define PAC_STATUSA_OSCCTRL_Msk             (_U_(0x1) << PAC_STATUSA_OSCCTRL_Pos)          /**< (PAC_STATUSA) OSCCTRL APB Protect Enable Mask */
+#define PAC_STATUSA_OSCCTRL                 PAC_STATUSA_OSCCTRL_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSA_OSCCTRL_Msk instead */
+#define PAC_STATUSA_OSC32KCTRL_Pos          5                                              /**< (PAC_STATUSA) OSC32KCTRL APB Protect Enable Position */
+#define PAC_STATUSA_OSC32KCTRL_Msk          (_U_(0x1) << PAC_STATUSA_OSC32KCTRL_Pos)       /**< (PAC_STATUSA) OSC32KCTRL APB Protect Enable Mask */
+#define PAC_STATUSA_OSC32KCTRL              PAC_STATUSA_OSC32KCTRL_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSA_OSC32KCTRL_Msk instead */
+#define PAC_STATUSA_SUPC_Pos                6                                              /**< (PAC_STATUSA) SUPC APB Protect Enable Position */
+#define PAC_STATUSA_SUPC_Msk                (_U_(0x1) << PAC_STATUSA_SUPC_Pos)             /**< (PAC_STATUSA) SUPC APB Protect Enable Mask */
+#define PAC_STATUSA_SUPC                    PAC_STATUSA_SUPC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSA_SUPC_Msk instead */
+#define PAC_STATUSA_GCLK_Pos                7                                              /**< (PAC_STATUSA) GCLK APB Protect Enable Position */
+#define PAC_STATUSA_GCLK_Msk                (_U_(0x1) << PAC_STATUSA_GCLK_Pos)             /**< (PAC_STATUSA) GCLK APB Protect Enable Mask */
+#define PAC_STATUSA_GCLK                    PAC_STATUSA_GCLK_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSA_GCLK_Msk instead */
+#define PAC_STATUSA_WDT_Pos                 8                                              /**< (PAC_STATUSA) WDT APB Protect Enable Position */
+#define PAC_STATUSA_WDT_Msk                 (_U_(0x1) << PAC_STATUSA_WDT_Pos)              /**< (PAC_STATUSA) WDT APB Protect Enable Mask */
+#define PAC_STATUSA_WDT                     PAC_STATUSA_WDT_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSA_WDT_Msk instead */
+#define PAC_STATUSA_RTC_Pos                 9                                              /**< (PAC_STATUSA) RTC APB Protect Enable Position */
+#define PAC_STATUSA_RTC_Msk                 (_U_(0x1) << PAC_STATUSA_RTC_Pos)              /**< (PAC_STATUSA) RTC APB Protect Enable Mask */
+#define PAC_STATUSA_RTC                     PAC_STATUSA_RTC_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSA_RTC_Msk instead */
+#define PAC_STATUSA_EIC_Pos                 10                                             /**< (PAC_STATUSA) EIC APB Protect Enable Position */
+#define PAC_STATUSA_EIC_Msk                 (_U_(0x1) << PAC_STATUSA_EIC_Pos)              /**< (PAC_STATUSA) EIC APB Protect Enable Mask */
+#define PAC_STATUSA_EIC                     PAC_STATUSA_EIC_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSA_EIC_Msk instead */
+#define PAC_STATUSA_FREQM_Pos               11                                             /**< (PAC_STATUSA) FREQM APB Protect Enable Position */
+#define PAC_STATUSA_FREQM_Msk               (_U_(0x1) << PAC_STATUSA_FREQM_Pos)            /**< (PAC_STATUSA) FREQM APB Protect Enable Mask */
+#define PAC_STATUSA_FREQM                   PAC_STATUSA_FREQM_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSA_FREQM_Msk instead */
+#define PAC_STATUSA_PORT_Pos                12                                             /**< (PAC_STATUSA) PORT APB Protect Enable Position */
+#define PAC_STATUSA_PORT_Msk                (_U_(0x1) << PAC_STATUSA_PORT_Pos)             /**< (PAC_STATUSA) PORT APB Protect Enable Mask */
+#define PAC_STATUSA_PORT                    PAC_STATUSA_PORT_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSA_PORT_Msk instead */
+#define PAC_STATUSA_AC_Pos                  13                                             /**< (PAC_STATUSA) AC APB Protect Enable Position */
+#define PAC_STATUSA_AC_Msk                  (_U_(0x1) << PAC_STATUSA_AC_Pos)               /**< (PAC_STATUSA) AC APB Protect Enable Mask */
+#define PAC_STATUSA_AC                      PAC_STATUSA_AC_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSA_AC_Msk instead */
+#define PAC_STATUSA_MASK                    _U_(0x3FFF)                                    /**< \deprecated (PAC_STATUSA) Register MASK  (Use PAC_STATUSA_Msk instead)  */
+#define PAC_STATUSA_Msk                     _U_(0x3FFF)                                    /**< (PAC_STATUSA) Register Mask  */
+
+
+/* -------- PAC_STATUSB : (PAC Offset: 0x38) (R/ 32) Peripheral write protection status - Bridge B -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t IDAU_:1;                   /**< bit:      0  IDAU APB Protect Enable                  */
+    uint32_t DSU_:1;                    /**< bit:      1  DSU APB Protect Enable                   */
+    uint32_t NVMCTRL_:1;                /**< bit:      2  NVMCTRL APB Protect Enable               */
+    uint32_t DMAC_:1;                   /**< bit:      3  DMAC APB Protect Enable                  */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PAC_STATUSB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_STATUSB_OFFSET                  (0x38)                                        /**<  (PAC_STATUSB) Peripheral write protection status - Bridge B  Offset */
+#define PAC_STATUSB_RESETVALUE              _U_(0x02)                                     /**<  (PAC_STATUSB) Peripheral write protection status - Bridge B  Reset Value */
+
+#define PAC_STATUSB_IDAU_Pos                0                                              /**< (PAC_STATUSB) IDAU APB Protect Enable Position */
+#define PAC_STATUSB_IDAU_Msk                (_U_(0x1) << PAC_STATUSB_IDAU_Pos)             /**< (PAC_STATUSB) IDAU APB Protect Enable Mask */
+#define PAC_STATUSB_IDAU                    PAC_STATUSB_IDAU_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSB_IDAU_Msk instead */
+#define PAC_STATUSB_DSU_Pos                 1                                              /**< (PAC_STATUSB) DSU APB Protect Enable Position */
+#define PAC_STATUSB_DSU_Msk                 (_U_(0x1) << PAC_STATUSB_DSU_Pos)              /**< (PAC_STATUSB) DSU APB Protect Enable Mask */
+#define PAC_STATUSB_DSU                     PAC_STATUSB_DSU_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSB_DSU_Msk instead */
+#define PAC_STATUSB_NVMCTRL_Pos             2                                              /**< (PAC_STATUSB) NVMCTRL APB Protect Enable Position */
+#define PAC_STATUSB_NVMCTRL_Msk             (_U_(0x1) << PAC_STATUSB_NVMCTRL_Pos)          /**< (PAC_STATUSB) NVMCTRL APB Protect Enable Mask */
+#define PAC_STATUSB_NVMCTRL                 PAC_STATUSB_NVMCTRL_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSB_NVMCTRL_Msk instead */
+#define PAC_STATUSB_DMAC_Pos                3                                              /**< (PAC_STATUSB) DMAC APB Protect Enable Position */
+#define PAC_STATUSB_DMAC_Msk                (_U_(0x1) << PAC_STATUSB_DMAC_Pos)             /**< (PAC_STATUSB) DMAC APB Protect Enable Mask */
+#define PAC_STATUSB_DMAC                    PAC_STATUSB_DMAC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSB_DMAC_Msk instead */
+#define PAC_STATUSB_MASK                    _U_(0x0F)                                      /**< \deprecated (PAC_STATUSB) Register MASK  (Use PAC_STATUSB_Msk instead)  */
+#define PAC_STATUSB_Msk                     _U_(0x0F)                                      /**< (PAC_STATUSB) Register Mask  */
+
+
+/* -------- PAC_STATUSC : (PAC Offset: 0x3c) (R/ 32) Peripheral write protection status - Bridge C -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t EVSYS_:1;                  /**< bit:      0  EVSYS APB Protect Enable                 */
+    uint32_t SERCOM0_:1;                /**< bit:      1  SERCOM0 APB Protect Enable               */
+    uint32_t SERCOM1_:1;                /**< bit:      2  SERCOM1 APB Protect Enable               */
+    uint32_t SERCOM2_:1;                /**< bit:      3  SERCOM2 APB Protect Enable               */
+    uint32_t TC0_:1;                    /**< bit:      4  TC0 APB Protect Enable                   */
+    uint32_t TC1_:1;                    /**< bit:      5  TC1 APB Protect Enable                   */
+    uint32_t TC2_:1;                    /**< bit:      6  TC2 APB Protect Enable                   */
+    uint32_t ADC_:1;                    /**< bit:      7  ADC APB Protect Enable                   */
+    uint32_t DAC_:1;                    /**< bit:      8  DAC APB Protect Enable                   */
+    uint32_t PTC_:1;                    /**< bit:      9  PTC APB Protect Enable                   */
+    uint32_t TRNG_:1;                   /**< bit:     10  TRNG APB Protect Enable                  */
+    uint32_t CCL_:1;                    /**< bit:     11  CCL APB Protect Enable                   */
+    uint32_t OPAMP_:1;                  /**< bit:     12  OPAMP APB Protect Enable                 */
+    uint32_t TRAM_:1;                   /**< bit:     13  TRAM APB Protect Enable                  */
+    uint32_t :18;                       /**< bit: 14..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PAC_STATUSC_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_STATUSC_OFFSET                  (0x3C)                                        /**<  (PAC_STATUSC) Peripheral write protection status - Bridge C  Offset */
+#define PAC_STATUSC_RESETVALUE              _U_(0x00)                                     /**<  (PAC_STATUSC) Peripheral write protection status - Bridge C  Reset Value */
+
+#define PAC_STATUSC_EVSYS_Pos               0                                              /**< (PAC_STATUSC) EVSYS APB Protect Enable Position */
+#define PAC_STATUSC_EVSYS_Msk               (_U_(0x1) << PAC_STATUSC_EVSYS_Pos)            /**< (PAC_STATUSC) EVSYS APB Protect Enable Mask */
+#define PAC_STATUSC_EVSYS                   PAC_STATUSC_EVSYS_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSC_EVSYS_Msk instead */
+#define PAC_STATUSC_SERCOM0_Pos             1                                              /**< (PAC_STATUSC) SERCOM0 APB Protect Enable Position */
+#define PAC_STATUSC_SERCOM0_Msk             (_U_(0x1) << PAC_STATUSC_SERCOM0_Pos)          /**< (PAC_STATUSC) SERCOM0 APB Protect Enable Mask */
+#define PAC_STATUSC_SERCOM0                 PAC_STATUSC_SERCOM0_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSC_SERCOM0_Msk instead */
+#define PAC_STATUSC_SERCOM1_Pos             2                                              /**< (PAC_STATUSC) SERCOM1 APB Protect Enable Position */
+#define PAC_STATUSC_SERCOM1_Msk             (_U_(0x1) << PAC_STATUSC_SERCOM1_Pos)          /**< (PAC_STATUSC) SERCOM1 APB Protect Enable Mask */
+#define PAC_STATUSC_SERCOM1                 PAC_STATUSC_SERCOM1_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSC_SERCOM1_Msk instead */
+#define PAC_STATUSC_SERCOM2_Pos             3                                              /**< (PAC_STATUSC) SERCOM2 APB Protect Enable Position */
+#define PAC_STATUSC_SERCOM2_Msk             (_U_(0x1) << PAC_STATUSC_SERCOM2_Pos)          /**< (PAC_STATUSC) SERCOM2 APB Protect Enable Mask */
+#define PAC_STATUSC_SERCOM2                 PAC_STATUSC_SERCOM2_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSC_SERCOM2_Msk instead */
+#define PAC_STATUSC_TC0_Pos                 4                                              /**< (PAC_STATUSC) TC0 APB Protect Enable Position */
+#define PAC_STATUSC_TC0_Msk                 (_U_(0x1) << PAC_STATUSC_TC0_Pos)              /**< (PAC_STATUSC) TC0 APB Protect Enable Mask */
+#define PAC_STATUSC_TC0                     PAC_STATUSC_TC0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSC_TC0_Msk instead */
+#define PAC_STATUSC_TC1_Pos                 5                                              /**< (PAC_STATUSC) TC1 APB Protect Enable Position */
+#define PAC_STATUSC_TC1_Msk                 (_U_(0x1) << PAC_STATUSC_TC1_Pos)              /**< (PAC_STATUSC) TC1 APB Protect Enable Mask */
+#define PAC_STATUSC_TC1                     PAC_STATUSC_TC1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSC_TC1_Msk instead */
+#define PAC_STATUSC_TC2_Pos                 6                                              /**< (PAC_STATUSC) TC2 APB Protect Enable Position */
+#define PAC_STATUSC_TC2_Msk                 (_U_(0x1) << PAC_STATUSC_TC2_Pos)              /**< (PAC_STATUSC) TC2 APB Protect Enable Mask */
+#define PAC_STATUSC_TC2                     PAC_STATUSC_TC2_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSC_TC2_Msk instead */
+#define PAC_STATUSC_ADC_Pos                 7                                              /**< (PAC_STATUSC) ADC APB Protect Enable Position */
+#define PAC_STATUSC_ADC_Msk                 (_U_(0x1) << PAC_STATUSC_ADC_Pos)              /**< (PAC_STATUSC) ADC APB Protect Enable Mask */
+#define PAC_STATUSC_ADC                     PAC_STATUSC_ADC_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSC_ADC_Msk instead */
+#define PAC_STATUSC_DAC_Pos                 8                                              /**< (PAC_STATUSC) DAC APB Protect Enable Position */
+#define PAC_STATUSC_DAC_Msk                 (_U_(0x1) << PAC_STATUSC_DAC_Pos)              /**< (PAC_STATUSC) DAC APB Protect Enable Mask */
+#define PAC_STATUSC_DAC                     PAC_STATUSC_DAC_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSC_DAC_Msk instead */
+#define PAC_STATUSC_PTC_Pos                 9                                              /**< (PAC_STATUSC) PTC APB Protect Enable Position */
+#define PAC_STATUSC_PTC_Msk                 (_U_(0x1) << PAC_STATUSC_PTC_Pos)              /**< (PAC_STATUSC) PTC APB Protect Enable Mask */
+#define PAC_STATUSC_PTC                     PAC_STATUSC_PTC_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSC_PTC_Msk instead */
+#define PAC_STATUSC_TRNG_Pos                10                                             /**< (PAC_STATUSC) TRNG APB Protect Enable Position */
+#define PAC_STATUSC_TRNG_Msk                (_U_(0x1) << PAC_STATUSC_TRNG_Pos)             /**< (PAC_STATUSC) TRNG APB Protect Enable Mask */
+#define PAC_STATUSC_TRNG                    PAC_STATUSC_TRNG_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSC_TRNG_Msk instead */
+#define PAC_STATUSC_CCL_Pos                 11                                             /**< (PAC_STATUSC) CCL APB Protect Enable Position */
+#define PAC_STATUSC_CCL_Msk                 (_U_(0x1) << PAC_STATUSC_CCL_Pos)              /**< (PAC_STATUSC) CCL APB Protect Enable Mask */
+#define PAC_STATUSC_CCL                     PAC_STATUSC_CCL_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSC_CCL_Msk instead */
+#define PAC_STATUSC_OPAMP_Pos               12                                             /**< (PAC_STATUSC) OPAMP APB Protect Enable Position */
+#define PAC_STATUSC_OPAMP_Msk               (_U_(0x1) << PAC_STATUSC_OPAMP_Pos)            /**< (PAC_STATUSC) OPAMP APB Protect Enable Mask */
+#define PAC_STATUSC_OPAMP                   PAC_STATUSC_OPAMP_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSC_OPAMP_Msk instead */
+#define PAC_STATUSC_TRAM_Pos                13                                             /**< (PAC_STATUSC) TRAM APB Protect Enable Position */
+#define PAC_STATUSC_TRAM_Msk                (_U_(0x1) << PAC_STATUSC_TRAM_Pos)             /**< (PAC_STATUSC) TRAM APB Protect Enable Mask */
+#define PAC_STATUSC_TRAM                    PAC_STATUSC_TRAM_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_STATUSC_TRAM_Msk instead */
+#define PAC_STATUSC_MASK                    _U_(0x3FFF)                                    /**< \deprecated (PAC_STATUSC) Register MASK  (Use PAC_STATUSC_Msk instead)  */
+#define PAC_STATUSC_Msk                     _U_(0x3FFF)                                    /**< (PAC_STATUSC) Register Mask  */
+
+#define PAC_STATUSC_SERCOM_Pos              1                                              /**< (PAC_STATUSC Position) SERCOMx APB Protect Enable */
+#define PAC_STATUSC_SERCOM_Msk              (_U_(0x7) << PAC_STATUSC_SERCOM_Pos)           /**< (PAC_STATUSC Mask) SERCOM */
+#define PAC_STATUSC_SERCOM(value)           (PAC_STATUSC_SERCOM_Msk & ((value) << PAC_STATUSC_SERCOM_Pos))  
+#define PAC_STATUSC_TC_Pos                  4                                              /**< (PAC_STATUSC Position) TCx APB Protect Enable */
+#define PAC_STATUSC_TC_Msk                  (_U_(0x7) << PAC_STATUSC_TC_Pos)               /**< (PAC_STATUSC Mask) TC */
+#define PAC_STATUSC_TC(value)               (PAC_STATUSC_TC_Msk & ((value) << PAC_STATUSC_TC_Pos))  
+
+/* -------- PAC_NONSECA : (PAC Offset: 0x54) (R/ 32) Peripheral non-secure status - Bridge A -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t PAC_:1;                    /**< bit:      0  PAC Non-Secure                           */
+    uint32_t PM_:1;                     /**< bit:      1  PM Non-Secure                            */
+    uint32_t MCLK_:1;                   /**< bit:      2  MCLK Non-Secure                          */
+    uint32_t RSTC_:1;                   /**< bit:      3  RSTC Non-Secure                          */
+    uint32_t OSCCTRL_:1;                /**< bit:      4  OSCCTRL Non-Secure                       */
+    uint32_t OSC32KCTRL_:1;             /**< bit:      5  OSC32KCTRL Non-Secure                    */
+    uint32_t SUPC_:1;                   /**< bit:      6  SUPC Non-Secure                          */
+    uint32_t GCLK_:1;                   /**< bit:      7  GCLK Non-Secure                          */
+    uint32_t WDT_:1;                    /**< bit:      8  WDT Non-Secure                           */
+    uint32_t RTC_:1;                    /**< bit:      9  RTC Non-Secure                           */
+    uint32_t EIC_:1;                    /**< bit:     10  EIC Non-Secure                           */
+    uint32_t FREQM_:1;                  /**< bit:     11  FREQM Non-Secure                         */
+    uint32_t PORT_:1;                   /**< bit:     12  PORT Non-Secure                          */
+    uint32_t AC_:1;                     /**< bit:     13  AC Non-Secure                            */
+    uint32_t :18;                       /**< bit: 14..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PAC_NONSECA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_NONSECA_OFFSET                  (0x54)                                        /**<  (PAC_NONSECA) Peripheral non-secure status - Bridge A  Offset */
+#define PAC_NONSECA_RESETVALUE              _U_(0x00)                                     /**<  (PAC_NONSECA) Peripheral non-secure status - Bridge A  Reset Value */
+
+#define PAC_NONSECA_PAC_Pos                 0                                              /**< (PAC_NONSECA) PAC Non-Secure Position */
+#define PAC_NONSECA_PAC_Msk                 (_U_(0x1) << PAC_NONSECA_PAC_Pos)              /**< (PAC_NONSECA) PAC Non-Secure Mask */
+#define PAC_NONSECA_PAC                     PAC_NONSECA_PAC_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECA_PAC_Msk instead */
+#define PAC_NONSECA_PM_Pos                  1                                              /**< (PAC_NONSECA) PM Non-Secure Position */
+#define PAC_NONSECA_PM_Msk                  (_U_(0x1) << PAC_NONSECA_PM_Pos)               /**< (PAC_NONSECA) PM Non-Secure Mask */
+#define PAC_NONSECA_PM                      PAC_NONSECA_PM_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECA_PM_Msk instead */
+#define PAC_NONSECA_MCLK_Pos                2                                              /**< (PAC_NONSECA) MCLK Non-Secure Position */
+#define PAC_NONSECA_MCLK_Msk                (_U_(0x1) << PAC_NONSECA_MCLK_Pos)             /**< (PAC_NONSECA) MCLK Non-Secure Mask */
+#define PAC_NONSECA_MCLK                    PAC_NONSECA_MCLK_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECA_MCLK_Msk instead */
+#define PAC_NONSECA_RSTC_Pos                3                                              /**< (PAC_NONSECA) RSTC Non-Secure Position */
+#define PAC_NONSECA_RSTC_Msk                (_U_(0x1) << PAC_NONSECA_RSTC_Pos)             /**< (PAC_NONSECA) RSTC Non-Secure Mask */
+#define PAC_NONSECA_RSTC                    PAC_NONSECA_RSTC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECA_RSTC_Msk instead */
+#define PAC_NONSECA_OSCCTRL_Pos             4                                              /**< (PAC_NONSECA) OSCCTRL Non-Secure Position */
+#define PAC_NONSECA_OSCCTRL_Msk             (_U_(0x1) << PAC_NONSECA_OSCCTRL_Pos)          /**< (PAC_NONSECA) OSCCTRL Non-Secure Mask */
+#define PAC_NONSECA_OSCCTRL                 PAC_NONSECA_OSCCTRL_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECA_OSCCTRL_Msk instead */
+#define PAC_NONSECA_OSC32KCTRL_Pos          5                                              /**< (PAC_NONSECA) OSC32KCTRL Non-Secure Position */
+#define PAC_NONSECA_OSC32KCTRL_Msk          (_U_(0x1) << PAC_NONSECA_OSC32KCTRL_Pos)       /**< (PAC_NONSECA) OSC32KCTRL Non-Secure Mask */
+#define PAC_NONSECA_OSC32KCTRL              PAC_NONSECA_OSC32KCTRL_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECA_OSC32KCTRL_Msk instead */
+#define PAC_NONSECA_SUPC_Pos                6                                              /**< (PAC_NONSECA) SUPC Non-Secure Position */
+#define PAC_NONSECA_SUPC_Msk                (_U_(0x1) << PAC_NONSECA_SUPC_Pos)             /**< (PAC_NONSECA) SUPC Non-Secure Mask */
+#define PAC_NONSECA_SUPC                    PAC_NONSECA_SUPC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECA_SUPC_Msk instead */
+#define PAC_NONSECA_GCLK_Pos                7                                              /**< (PAC_NONSECA) GCLK Non-Secure Position */
+#define PAC_NONSECA_GCLK_Msk                (_U_(0x1) << PAC_NONSECA_GCLK_Pos)             /**< (PAC_NONSECA) GCLK Non-Secure Mask */
+#define PAC_NONSECA_GCLK                    PAC_NONSECA_GCLK_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECA_GCLK_Msk instead */
+#define PAC_NONSECA_WDT_Pos                 8                                              /**< (PAC_NONSECA) WDT Non-Secure Position */
+#define PAC_NONSECA_WDT_Msk                 (_U_(0x1) << PAC_NONSECA_WDT_Pos)              /**< (PAC_NONSECA) WDT Non-Secure Mask */
+#define PAC_NONSECA_WDT                     PAC_NONSECA_WDT_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECA_WDT_Msk instead */
+#define PAC_NONSECA_RTC_Pos                 9                                              /**< (PAC_NONSECA) RTC Non-Secure Position */
+#define PAC_NONSECA_RTC_Msk                 (_U_(0x1) << PAC_NONSECA_RTC_Pos)              /**< (PAC_NONSECA) RTC Non-Secure Mask */
+#define PAC_NONSECA_RTC                     PAC_NONSECA_RTC_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECA_RTC_Msk instead */
+#define PAC_NONSECA_EIC_Pos                 10                                             /**< (PAC_NONSECA) EIC Non-Secure Position */
+#define PAC_NONSECA_EIC_Msk                 (_U_(0x1) << PAC_NONSECA_EIC_Pos)              /**< (PAC_NONSECA) EIC Non-Secure Mask */
+#define PAC_NONSECA_EIC                     PAC_NONSECA_EIC_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECA_EIC_Msk instead */
+#define PAC_NONSECA_FREQM_Pos               11                                             /**< (PAC_NONSECA) FREQM Non-Secure Position */
+#define PAC_NONSECA_FREQM_Msk               (_U_(0x1) << PAC_NONSECA_FREQM_Pos)            /**< (PAC_NONSECA) FREQM Non-Secure Mask */
+#define PAC_NONSECA_FREQM                   PAC_NONSECA_FREQM_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECA_FREQM_Msk instead */
+#define PAC_NONSECA_PORT_Pos                12                                             /**< (PAC_NONSECA) PORT Non-Secure Position */
+#define PAC_NONSECA_PORT_Msk                (_U_(0x1) << PAC_NONSECA_PORT_Pos)             /**< (PAC_NONSECA) PORT Non-Secure Mask */
+#define PAC_NONSECA_PORT                    PAC_NONSECA_PORT_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECA_PORT_Msk instead */
+#define PAC_NONSECA_AC_Pos                  13                                             /**< (PAC_NONSECA) AC Non-Secure Position */
+#define PAC_NONSECA_AC_Msk                  (_U_(0x1) << PAC_NONSECA_AC_Pos)               /**< (PAC_NONSECA) AC Non-Secure Mask */
+#define PAC_NONSECA_AC                      PAC_NONSECA_AC_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECA_AC_Msk instead */
+#define PAC_NONSECA_MASK                    _U_(0x3FFF)                                    /**< \deprecated (PAC_NONSECA) Register MASK  (Use PAC_NONSECA_Msk instead)  */
+#define PAC_NONSECA_Msk                     _U_(0x3FFF)                                    /**< (PAC_NONSECA) Register Mask  */
+
+
+/* -------- PAC_NONSECB : (PAC Offset: 0x58) (R/ 32) Peripheral non-secure status - Bridge B -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t IDAU_:1;                   /**< bit:      0  IDAU Non-Secure                          */
+    uint32_t DSU_:1;                    /**< bit:      1  DSU Non-Secure                           */
+    uint32_t NVMCTRL_:1;                /**< bit:      2  NVMCTRL Non-Secure                       */
+    uint32_t DMAC_:1;                   /**< bit:      3  DMAC Non-Secure                          */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PAC_NONSECB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_NONSECB_OFFSET                  (0x58)                                        /**<  (PAC_NONSECB) Peripheral non-secure status - Bridge B  Offset */
+#define PAC_NONSECB_RESETVALUE              _U_(0x02)                                     /**<  (PAC_NONSECB) Peripheral non-secure status - Bridge B  Reset Value */
+
+#define PAC_NONSECB_IDAU_Pos                0                                              /**< (PAC_NONSECB) IDAU Non-Secure Position */
+#define PAC_NONSECB_IDAU_Msk                (_U_(0x1) << PAC_NONSECB_IDAU_Pos)             /**< (PAC_NONSECB) IDAU Non-Secure Mask */
+#define PAC_NONSECB_IDAU                    PAC_NONSECB_IDAU_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECB_IDAU_Msk instead */
+#define PAC_NONSECB_DSU_Pos                 1                                              /**< (PAC_NONSECB) DSU Non-Secure Position */
+#define PAC_NONSECB_DSU_Msk                 (_U_(0x1) << PAC_NONSECB_DSU_Pos)              /**< (PAC_NONSECB) DSU Non-Secure Mask */
+#define PAC_NONSECB_DSU                     PAC_NONSECB_DSU_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECB_DSU_Msk instead */
+#define PAC_NONSECB_NVMCTRL_Pos             2                                              /**< (PAC_NONSECB) NVMCTRL Non-Secure Position */
+#define PAC_NONSECB_NVMCTRL_Msk             (_U_(0x1) << PAC_NONSECB_NVMCTRL_Pos)          /**< (PAC_NONSECB) NVMCTRL Non-Secure Mask */
+#define PAC_NONSECB_NVMCTRL                 PAC_NONSECB_NVMCTRL_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECB_NVMCTRL_Msk instead */
+#define PAC_NONSECB_DMAC_Pos                3                                              /**< (PAC_NONSECB) DMAC Non-Secure Position */
+#define PAC_NONSECB_DMAC_Msk                (_U_(0x1) << PAC_NONSECB_DMAC_Pos)             /**< (PAC_NONSECB) DMAC Non-Secure Mask */
+#define PAC_NONSECB_DMAC                    PAC_NONSECB_DMAC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECB_DMAC_Msk instead */
+#define PAC_NONSECB_MASK                    _U_(0x0F)                                      /**< \deprecated (PAC_NONSECB) Register MASK  (Use PAC_NONSECB_Msk instead)  */
+#define PAC_NONSECB_Msk                     _U_(0x0F)                                      /**< (PAC_NONSECB) Register Mask  */
+
+
+/* -------- PAC_NONSECC : (PAC Offset: 0x5c) (R/ 32) Peripheral non-secure status - Bridge C -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t EVSYS_:1;                  /**< bit:      0  EVSYS Non-Secure                         */
+    uint32_t SERCOM0_:1;                /**< bit:      1  SERCOM0 Non-Secure                       */
+    uint32_t SERCOM1_:1;                /**< bit:      2  SERCOM1 Non-Secure                       */
+    uint32_t SERCOM2_:1;                /**< bit:      3  SERCOM2 Non-Secure                       */
+    uint32_t TC0_:1;                    /**< bit:      4  TC0 Non-Secure                           */
+    uint32_t TC1_:1;                    /**< bit:      5  TC1 Non-Secure                           */
+    uint32_t TC2_:1;                    /**< bit:      6  TC2 Non-Secure                           */
+    uint32_t ADC_:1;                    /**< bit:      7  ADC Non-Secure                           */
+    uint32_t DAC_:1;                    /**< bit:      8  DAC Non-Secure                           */
+    uint32_t PTC_:1;                    /**< bit:      9  PTC Non-Secure                           */
+    uint32_t TRNG_:1;                   /**< bit:     10  TRNG Non-Secure                          */
+    uint32_t CCL_:1;                    /**< bit:     11  CCL Non-Secure                           */
+    uint32_t OPAMP_:1;                  /**< bit:     12  OPAMP Non-Secure                         */
+    uint32_t TRAM_:1;                   /**< bit:     13  TRAM Non-Secure                          */
+    uint32_t :18;                       /**< bit: 14..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PAC_NONSECC_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_NONSECC_OFFSET                  (0x5C)                                        /**<  (PAC_NONSECC) Peripheral non-secure status - Bridge C  Offset */
+#define PAC_NONSECC_RESETVALUE              _U_(0x00)                                     /**<  (PAC_NONSECC) Peripheral non-secure status - Bridge C  Reset Value */
+
+#define PAC_NONSECC_EVSYS_Pos               0                                              /**< (PAC_NONSECC) EVSYS Non-Secure Position */
+#define PAC_NONSECC_EVSYS_Msk               (_U_(0x1) << PAC_NONSECC_EVSYS_Pos)            /**< (PAC_NONSECC) EVSYS Non-Secure Mask */
+#define PAC_NONSECC_EVSYS                   PAC_NONSECC_EVSYS_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECC_EVSYS_Msk instead */
+#define PAC_NONSECC_SERCOM0_Pos             1                                              /**< (PAC_NONSECC) SERCOM0 Non-Secure Position */
+#define PAC_NONSECC_SERCOM0_Msk             (_U_(0x1) << PAC_NONSECC_SERCOM0_Pos)          /**< (PAC_NONSECC) SERCOM0 Non-Secure Mask */
+#define PAC_NONSECC_SERCOM0                 PAC_NONSECC_SERCOM0_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECC_SERCOM0_Msk instead */
+#define PAC_NONSECC_SERCOM1_Pos             2                                              /**< (PAC_NONSECC) SERCOM1 Non-Secure Position */
+#define PAC_NONSECC_SERCOM1_Msk             (_U_(0x1) << PAC_NONSECC_SERCOM1_Pos)          /**< (PAC_NONSECC) SERCOM1 Non-Secure Mask */
+#define PAC_NONSECC_SERCOM1                 PAC_NONSECC_SERCOM1_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECC_SERCOM1_Msk instead */
+#define PAC_NONSECC_SERCOM2_Pos             3                                              /**< (PAC_NONSECC) SERCOM2 Non-Secure Position */
+#define PAC_NONSECC_SERCOM2_Msk             (_U_(0x1) << PAC_NONSECC_SERCOM2_Pos)          /**< (PAC_NONSECC) SERCOM2 Non-Secure Mask */
+#define PAC_NONSECC_SERCOM2                 PAC_NONSECC_SERCOM2_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECC_SERCOM2_Msk instead */
+#define PAC_NONSECC_TC0_Pos                 4                                              /**< (PAC_NONSECC) TC0 Non-Secure Position */
+#define PAC_NONSECC_TC0_Msk                 (_U_(0x1) << PAC_NONSECC_TC0_Pos)              /**< (PAC_NONSECC) TC0 Non-Secure Mask */
+#define PAC_NONSECC_TC0                     PAC_NONSECC_TC0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECC_TC0_Msk instead */
+#define PAC_NONSECC_TC1_Pos                 5                                              /**< (PAC_NONSECC) TC1 Non-Secure Position */
+#define PAC_NONSECC_TC1_Msk                 (_U_(0x1) << PAC_NONSECC_TC1_Pos)              /**< (PAC_NONSECC) TC1 Non-Secure Mask */
+#define PAC_NONSECC_TC1                     PAC_NONSECC_TC1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECC_TC1_Msk instead */
+#define PAC_NONSECC_TC2_Pos                 6                                              /**< (PAC_NONSECC) TC2 Non-Secure Position */
+#define PAC_NONSECC_TC2_Msk                 (_U_(0x1) << PAC_NONSECC_TC2_Pos)              /**< (PAC_NONSECC) TC2 Non-Secure Mask */
+#define PAC_NONSECC_TC2                     PAC_NONSECC_TC2_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECC_TC2_Msk instead */
+#define PAC_NONSECC_ADC_Pos                 7                                              /**< (PAC_NONSECC) ADC Non-Secure Position */
+#define PAC_NONSECC_ADC_Msk                 (_U_(0x1) << PAC_NONSECC_ADC_Pos)              /**< (PAC_NONSECC) ADC Non-Secure Mask */
+#define PAC_NONSECC_ADC                     PAC_NONSECC_ADC_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECC_ADC_Msk instead */
+#define PAC_NONSECC_DAC_Pos                 8                                              /**< (PAC_NONSECC) DAC Non-Secure Position */
+#define PAC_NONSECC_DAC_Msk                 (_U_(0x1) << PAC_NONSECC_DAC_Pos)              /**< (PAC_NONSECC) DAC Non-Secure Mask */
+#define PAC_NONSECC_DAC                     PAC_NONSECC_DAC_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECC_DAC_Msk instead */
+#define PAC_NONSECC_PTC_Pos                 9                                              /**< (PAC_NONSECC) PTC Non-Secure Position */
+#define PAC_NONSECC_PTC_Msk                 (_U_(0x1) << PAC_NONSECC_PTC_Pos)              /**< (PAC_NONSECC) PTC Non-Secure Mask */
+#define PAC_NONSECC_PTC                     PAC_NONSECC_PTC_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECC_PTC_Msk instead */
+#define PAC_NONSECC_TRNG_Pos                10                                             /**< (PAC_NONSECC) TRNG Non-Secure Position */
+#define PAC_NONSECC_TRNG_Msk                (_U_(0x1) << PAC_NONSECC_TRNG_Pos)             /**< (PAC_NONSECC) TRNG Non-Secure Mask */
+#define PAC_NONSECC_TRNG                    PAC_NONSECC_TRNG_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECC_TRNG_Msk instead */
+#define PAC_NONSECC_CCL_Pos                 11                                             /**< (PAC_NONSECC) CCL Non-Secure Position */
+#define PAC_NONSECC_CCL_Msk                 (_U_(0x1) << PAC_NONSECC_CCL_Pos)              /**< (PAC_NONSECC) CCL Non-Secure Mask */
+#define PAC_NONSECC_CCL                     PAC_NONSECC_CCL_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECC_CCL_Msk instead */
+#define PAC_NONSECC_OPAMP_Pos               12                                             /**< (PAC_NONSECC) OPAMP Non-Secure Position */
+#define PAC_NONSECC_OPAMP_Msk               (_U_(0x1) << PAC_NONSECC_OPAMP_Pos)            /**< (PAC_NONSECC) OPAMP Non-Secure Mask */
+#define PAC_NONSECC_OPAMP                   PAC_NONSECC_OPAMP_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECC_OPAMP_Msk instead */
+#define PAC_NONSECC_TRAM_Pos                13                                             /**< (PAC_NONSECC) TRAM Non-Secure Position */
+#define PAC_NONSECC_TRAM_Msk                (_U_(0x1) << PAC_NONSECC_TRAM_Pos)             /**< (PAC_NONSECC) TRAM Non-Secure Mask */
+#define PAC_NONSECC_TRAM                    PAC_NONSECC_TRAM_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_NONSECC_TRAM_Msk instead */
+#define PAC_NONSECC_MASK                    _U_(0x3FFF)                                    /**< \deprecated (PAC_NONSECC) Register MASK  (Use PAC_NONSECC_Msk instead)  */
+#define PAC_NONSECC_Msk                     _U_(0x3FFF)                                    /**< (PAC_NONSECC) Register Mask  */
+
+#define PAC_NONSECC_SERCOM_Pos              1                                              /**< (PAC_NONSECC Position) SERCOMx Non-Secure */
+#define PAC_NONSECC_SERCOM_Msk              (_U_(0x7) << PAC_NONSECC_SERCOM_Pos)           /**< (PAC_NONSECC Mask) SERCOM */
+#define PAC_NONSECC_SERCOM(value)           (PAC_NONSECC_SERCOM_Msk & ((value) << PAC_NONSECC_SERCOM_Pos))  
+#define PAC_NONSECC_TC_Pos                  4                                              /**< (PAC_NONSECC Position) TCx Non-Secure */
+#define PAC_NONSECC_TC_Msk                  (_U_(0x7) << PAC_NONSECC_TC_Pos)               /**< (PAC_NONSECC Mask) TC */
+#define PAC_NONSECC_TC(value)               (PAC_NONSECC_TC_Msk & ((value) << PAC_NONSECC_TC_Pos))  
+
+/* -------- PAC_SECLOCKA : (PAC Offset: 0x74) (R/ 32) Peripheral secure status locked - Bridge A -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t PAC_:1;                    /**< bit:      0  PAC Secure Status Locked                 */
+    uint32_t PM_:1;                     /**< bit:      1  PM Secure Status Locked                  */
+    uint32_t MCLK_:1;                   /**< bit:      2  MCLK Secure Status Locked                */
+    uint32_t RSTC_:1;                   /**< bit:      3  RSTC Secure Status Locked                */
+    uint32_t OSCCTRL_:1;                /**< bit:      4  OSCCTRL Secure Status Locked             */
+    uint32_t OSC32KCTRL_:1;             /**< bit:      5  OSC32KCTRL Secure Status Locked          */
+    uint32_t SUPC_:1;                   /**< bit:      6  SUPC Secure Status Locked                */
+    uint32_t GCLK_:1;                   /**< bit:      7  GCLK Secure Status Locked                */
+    uint32_t WDT_:1;                    /**< bit:      8  WDT Secure Status Locked                 */
+    uint32_t RTC_:1;                    /**< bit:      9  RTC Secure Status Locked                 */
+    uint32_t EIC_:1;                    /**< bit:     10  EIC Secure Status Locked                 */
+    uint32_t FREQM_:1;                  /**< bit:     11  FREQM Secure Status Locked               */
+    uint32_t PORT_:1;                   /**< bit:     12  PORT Secure Status Locked                */
+    uint32_t AC_:1;                     /**< bit:     13  AC Secure Status Locked                  */
+    uint32_t :18;                       /**< bit: 14..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PAC_SECLOCKA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_SECLOCKA_OFFSET                 (0x74)                                        /**<  (PAC_SECLOCKA) Peripheral secure status locked - Bridge A  Offset */
+#define PAC_SECLOCKA_RESETVALUE             _U_(0x00)                                     /**<  (PAC_SECLOCKA) Peripheral secure status locked - Bridge A  Reset Value */
+
+#define PAC_SECLOCKA_PAC_Pos                0                                              /**< (PAC_SECLOCKA) PAC Secure Status Locked Position */
+#define PAC_SECLOCKA_PAC_Msk                (_U_(0x1) << PAC_SECLOCKA_PAC_Pos)             /**< (PAC_SECLOCKA) PAC Secure Status Locked Mask */
+#define PAC_SECLOCKA_PAC                    PAC_SECLOCKA_PAC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKA_PAC_Msk instead */
+#define PAC_SECLOCKA_PM_Pos                 1                                              /**< (PAC_SECLOCKA) PM Secure Status Locked Position */
+#define PAC_SECLOCKA_PM_Msk                 (_U_(0x1) << PAC_SECLOCKA_PM_Pos)              /**< (PAC_SECLOCKA) PM Secure Status Locked Mask */
+#define PAC_SECLOCKA_PM                     PAC_SECLOCKA_PM_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKA_PM_Msk instead */
+#define PAC_SECLOCKA_MCLK_Pos               2                                              /**< (PAC_SECLOCKA) MCLK Secure Status Locked Position */
+#define PAC_SECLOCKA_MCLK_Msk               (_U_(0x1) << PAC_SECLOCKA_MCLK_Pos)            /**< (PAC_SECLOCKA) MCLK Secure Status Locked Mask */
+#define PAC_SECLOCKA_MCLK                   PAC_SECLOCKA_MCLK_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKA_MCLK_Msk instead */
+#define PAC_SECLOCKA_RSTC_Pos               3                                              /**< (PAC_SECLOCKA) RSTC Secure Status Locked Position */
+#define PAC_SECLOCKA_RSTC_Msk               (_U_(0x1) << PAC_SECLOCKA_RSTC_Pos)            /**< (PAC_SECLOCKA) RSTC Secure Status Locked Mask */
+#define PAC_SECLOCKA_RSTC                   PAC_SECLOCKA_RSTC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKA_RSTC_Msk instead */
+#define PAC_SECLOCKA_OSCCTRL_Pos            4                                              /**< (PAC_SECLOCKA) OSCCTRL Secure Status Locked Position */
+#define PAC_SECLOCKA_OSCCTRL_Msk            (_U_(0x1) << PAC_SECLOCKA_OSCCTRL_Pos)         /**< (PAC_SECLOCKA) OSCCTRL Secure Status Locked Mask */
+#define PAC_SECLOCKA_OSCCTRL                PAC_SECLOCKA_OSCCTRL_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKA_OSCCTRL_Msk instead */
+#define PAC_SECLOCKA_OSC32KCTRL_Pos         5                                              /**< (PAC_SECLOCKA) OSC32KCTRL Secure Status Locked Position */
+#define PAC_SECLOCKA_OSC32KCTRL_Msk         (_U_(0x1) << PAC_SECLOCKA_OSC32KCTRL_Pos)      /**< (PAC_SECLOCKA) OSC32KCTRL Secure Status Locked Mask */
+#define PAC_SECLOCKA_OSC32KCTRL             PAC_SECLOCKA_OSC32KCTRL_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKA_OSC32KCTRL_Msk instead */
+#define PAC_SECLOCKA_SUPC_Pos               6                                              /**< (PAC_SECLOCKA) SUPC Secure Status Locked Position */
+#define PAC_SECLOCKA_SUPC_Msk               (_U_(0x1) << PAC_SECLOCKA_SUPC_Pos)            /**< (PAC_SECLOCKA) SUPC Secure Status Locked Mask */
+#define PAC_SECLOCKA_SUPC                   PAC_SECLOCKA_SUPC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKA_SUPC_Msk instead */
+#define PAC_SECLOCKA_GCLK_Pos               7                                              /**< (PAC_SECLOCKA) GCLK Secure Status Locked Position */
+#define PAC_SECLOCKA_GCLK_Msk               (_U_(0x1) << PAC_SECLOCKA_GCLK_Pos)            /**< (PAC_SECLOCKA) GCLK Secure Status Locked Mask */
+#define PAC_SECLOCKA_GCLK                   PAC_SECLOCKA_GCLK_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKA_GCLK_Msk instead */
+#define PAC_SECLOCKA_WDT_Pos                8                                              /**< (PAC_SECLOCKA) WDT Secure Status Locked Position */
+#define PAC_SECLOCKA_WDT_Msk                (_U_(0x1) << PAC_SECLOCKA_WDT_Pos)             /**< (PAC_SECLOCKA) WDT Secure Status Locked Mask */
+#define PAC_SECLOCKA_WDT                    PAC_SECLOCKA_WDT_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKA_WDT_Msk instead */
+#define PAC_SECLOCKA_RTC_Pos                9                                              /**< (PAC_SECLOCKA) RTC Secure Status Locked Position */
+#define PAC_SECLOCKA_RTC_Msk                (_U_(0x1) << PAC_SECLOCKA_RTC_Pos)             /**< (PAC_SECLOCKA) RTC Secure Status Locked Mask */
+#define PAC_SECLOCKA_RTC                    PAC_SECLOCKA_RTC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKA_RTC_Msk instead */
+#define PAC_SECLOCKA_EIC_Pos                10                                             /**< (PAC_SECLOCKA) EIC Secure Status Locked Position */
+#define PAC_SECLOCKA_EIC_Msk                (_U_(0x1) << PAC_SECLOCKA_EIC_Pos)             /**< (PAC_SECLOCKA) EIC Secure Status Locked Mask */
+#define PAC_SECLOCKA_EIC                    PAC_SECLOCKA_EIC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKA_EIC_Msk instead */
+#define PAC_SECLOCKA_FREQM_Pos              11                                             /**< (PAC_SECLOCKA) FREQM Secure Status Locked Position */
+#define PAC_SECLOCKA_FREQM_Msk              (_U_(0x1) << PAC_SECLOCKA_FREQM_Pos)           /**< (PAC_SECLOCKA) FREQM Secure Status Locked Mask */
+#define PAC_SECLOCKA_FREQM                  PAC_SECLOCKA_FREQM_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKA_FREQM_Msk instead */
+#define PAC_SECLOCKA_PORT_Pos               12                                             /**< (PAC_SECLOCKA) PORT Secure Status Locked Position */
+#define PAC_SECLOCKA_PORT_Msk               (_U_(0x1) << PAC_SECLOCKA_PORT_Pos)            /**< (PAC_SECLOCKA) PORT Secure Status Locked Mask */
+#define PAC_SECLOCKA_PORT                   PAC_SECLOCKA_PORT_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKA_PORT_Msk instead */
+#define PAC_SECLOCKA_AC_Pos                 13                                             /**< (PAC_SECLOCKA) AC Secure Status Locked Position */
+#define PAC_SECLOCKA_AC_Msk                 (_U_(0x1) << PAC_SECLOCKA_AC_Pos)              /**< (PAC_SECLOCKA) AC Secure Status Locked Mask */
+#define PAC_SECLOCKA_AC                     PAC_SECLOCKA_AC_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKA_AC_Msk instead */
+#define PAC_SECLOCKA_MASK                   _U_(0x3FFF)                                    /**< \deprecated (PAC_SECLOCKA) Register MASK  (Use PAC_SECLOCKA_Msk instead)  */
+#define PAC_SECLOCKA_Msk                    _U_(0x3FFF)                                    /**< (PAC_SECLOCKA) Register Mask  */
+
+
+/* -------- PAC_SECLOCKB : (PAC Offset: 0x78) (R/ 32) Peripheral secure status locked - Bridge B -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t IDAU_:1;                   /**< bit:      0  IDAU Secure Status Locked                */
+    uint32_t DSU_:1;                    /**< bit:      1  DSU Secure Status Locked                 */
+    uint32_t NVMCTRL_:1;                /**< bit:      2  NVMCTRL Secure Status Locked             */
+    uint32_t DMAC_:1;                   /**< bit:      3  DMAC Secure Status Locked                */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PAC_SECLOCKB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_SECLOCKB_OFFSET                 (0x78)                                        /**<  (PAC_SECLOCKB) Peripheral secure status locked - Bridge B  Offset */
+#define PAC_SECLOCKB_RESETVALUE             _U_(0x03)                                     /**<  (PAC_SECLOCKB) Peripheral secure status locked - Bridge B  Reset Value */
+
+#define PAC_SECLOCKB_IDAU_Pos               0                                              /**< (PAC_SECLOCKB) IDAU Secure Status Locked Position */
+#define PAC_SECLOCKB_IDAU_Msk               (_U_(0x1) << PAC_SECLOCKB_IDAU_Pos)            /**< (PAC_SECLOCKB) IDAU Secure Status Locked Mask */
+#define PAC_SECLOCKB_IDAU                   PAC_SECLOCKB_IDAU_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKB_IDAU_Msk instead */
+#define PAC_SECLOCKB_DSU_Pos                1                                              /**< (PAC_SECLOCKB) DSU Secure Status Locked Position */
+#define PAC_SECLOCKB_DSU_Msk                (_U_(0x1) << PAC_SECLOCKB_DSU_Pos)             /**< (PAC_SECLOCKB) DSU Secure Status Locked Mask */
+#define PAC_SECLOCKB_DSU                    PAC_SECLOCKB_DSU_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKB_DSU_Msk instead */
+#define PAC_SECLOCKB_NVMCTRL_Pos            2                                              /**< (PAC_SECLOCKB) NVMCTRL Secure Status Locked Position */
+#define PAC_SECLOCKB_NVMCTRL_Msk            (_U_(0x1) << PAC_SECLOCKB_NVMCTRL_Pos)         /**< (PAC_SECLOCKB) NVMCTRL Secure Status Locked Mask */
+#define PAC_SECLOCKB_NVMCTRL                PAC_SECLOCKB_NVMCTRL_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKB_NVMCTRL_Msk instead */
+#define PAC_SECLOCKB_DMAC_Pos               3                                              /**< (PAC_SECLOCKB) DMAC Secure Status Locked Position */
+#define PAC_SECLOCKB_DMAC_Msk               (_U_(0x1) << PAC_SECLOCKB_DMAC_Pos)            /**< (PAC_SECLOCKB) DMAC Secure Status Locked Mask */
+#define PAC_SECLOCKB_DMAC                   PAC_SECLOCKB_DMAC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKB_DMAC_Msk instead */
+#define PAC_SECLOCKB_MASK                   _U_(0x0F)                                      /**< \deprecated (PAC_SECLOCKB) Register MASK  (Use PAC_SECLOCKB_Msk instead)  */
+#define PAC_SECLOCKB_Msk                    _U_(0x0F)                                      /**< (PAC_SECLOCKB) Register Mask  */
+
+
+/* -------- PAC_SECLOCKC : (PAC Offset: 0x7c) (R/ 32) Peripheral secure status locked - Bridge C -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t EVSYS_:1;                  /**< bit:      0  EVSYS Secure Status Locked               */
+    uint32_t SERCOM0_:1;                /**< bit:      1  SERCOM0 Secure Status Locked             */
+    uint32_t SERCOM1_:1;                /**< bit:      2  SERCOM1 Secure Status Locked             */
+    uint32_t SERCOM2_:1;                /**< bit:      3  SERCOM2 Secure Status Locked             */
+    uint32_t TC0_:1;                    /**< bit:      4  TC0 Secure Status Locked                 */
+    uint32_t TC1_:1;                    /**< bit:      5  TC1 Secure Status Locked                 */
+    uint32_t TC2_:1;                    /**< bit:      6  TC2 Secure Status Locked                 */
+    uint32_t ADC_:1;                    /**< bit:      7  ADC Secure Status Locked                 */
+    uint32_t DAC_:1;                    /**< bit:      8  DAC Secure Status Locked                 */
+    uint32_t PTC_:1;                    /**< bit:      9  PTC Secure Status Locked                 */
+    uint32_t TRNG_:1;                   /**< bit:     10  TRNG Secure Status Locked                */
+    uint32_t CCL_:1;                    /**< bit:     11  CCL Secure Status Locked                 */
+    uint32_t OPAMP_:1;                  /**< bit:     12  OPAMP Secure Status Locked               */
+    uint32_t TRAM_:1;                   /**< bit:     13  TRAM Secure Status Locked                */
+    uint32_t :18;                       /**< bit: 14..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PAC_SECLOCKC_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_SECLOCKC_OFFSET                 (0x7C)                                        /**<  (PAC_SECLOCKC) Peripheral secure status locked - Bridge C  Offset */
+#define PAC_SECLOCKC_RESETVALUE             _U_(0x00)                                     /**<  (PAC_SECLOCKC) Peripheral secure status locked - Bridge C  Reset Value */
+
+#define PAC_SECLOCKC_EVSYS_Pos              0                                              /**< (PAC_SECLOCKC) EVSYS Secure Status Locked Position */
+#define PAC_SECLOCKC_EVSYS_Msk              (_U_(0x1) << PAC_SECLOCKC_EVSYS_Pos)           /**< (PAC_SECLOCKC) EVSYS Secure Status Locked Mask */
+#define PAC_SECLOCKC_EVSYS                  PAC_SECLOCKC_EVSYS_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKC_EVSYS_Msk instead */
+#define PAC_SECLOCKC_SERCOM0_Pos            1                                              /**< (PAC_SECLOCKC) SERCOM0 Secure Status Locked Position */
+#define PAC_SECLOCKC_SERCOM0_Msk            (_U_(0x1) << PAC_SECLOCKC_SERCOM0_Pos)         /**< (PAC_SECLOCKC) SERCOM0 Secure Status Locked Mask */
+#define PAC_SECLOCKC_SERCOM0                PAC_SECLOCKC_SERCOM0_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKC_SERCOM0_Msk instead */
+#define PAC_SECLOCKC_SERCOM1_Pos            2                                              /**< (PAC_SECLOCKC) SERCOM1 Secure Status Locked Position */
+#define PAC_SECLOCKC_SERCOM1_Msk            (_U_(0x1) << PAC_SECLOCKC_SERCOM1_Pos)         /**< (PAC_SECLOCKC) SERCOM1 Secure Status Locked Mask */
+#define PAC_SECLOCKC_SERCOM1                PAC_SECLOCKC_SERCOM1_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKC_SERCOM1_Msk instead */
+#define PAC_SECLOCKC_SERCOM2_Pos            3                                              /**< (PAC_SECLOCKC) SERCOM2 Secure Status Locked Position */
+#define PAC_SECLOCKC_SERCOM2_Msk            (_U_(0x1) << PAC_SECLOCKC_SERCOM2_Pos)         /**< (PAC_SECLOCKC) SERCOM2 Secure Status Locked Mask */
+#define PAC_SECLOCKC_SERCOM2                PAC_SECLOCKC_SERCOM2_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKC_SERCOM2_Msk instead */
+#define PAC_SECLOCKC_TC0_Pos                4                                              /**< (PAC_SECLOCKC) TC0 Secure Status Locked Position */
+#define PAC_SECLOCKC_TC0_Msk                (_U_(0x1) << PAC_SECLOCKC_TC0_Pos)             /**< (PAC_SECLOCKC) TC0 Secure Status Locked Mask */
+#define PAC_SECLOCKC_TC0                    PAC_SECLOCKC_TC0_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKC_TC0_Msk instead */
+#define PAC_SECLOCKC_TC1_Pos                5                                              /**< (PAC_SECLOCKC) TC1 Secure Status Locked Position */
+#define PAC_SECLOCKC_TC1_Msk                (_U_(0x1) << PAC_SECLOCKC_TC1_Pos)             /**< (PAC_SECLOCKC) TC1 Secure Status Locked Mask */
+#define PAC_SECLOCKC_TC1                    PAC_SECLOCKC_TC1_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKC_TC1_Msk instead */
+#define PAC_SECLOCKC_TC2_Pos                6                                              /**< (PAC_SECLOCKC) TC2 Secure Status Locked Position */
+#define PAC_SECLOCKC_TC2_Msk                (_U_(0x1) << PAC_SECLOCKC_TC2_Pos)             /**< (PAC_SECLOCKC) TC2 Secure Status Locked Mask */
+#define PAC_SECLOCKC_TC2                    PAC_SECLOCKC_TC2_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKC_TC2_Msk instead */
+#define PAC_SECLOCKC_ADC_Pos                7                                              /**< (PAC_SECLOCKC) ADC Secure Status Locked Position */
+#define PAC_SECLOCKC_ADC_Msk                (_U_(0x1) << PAC_SECLOCKC_ADC_Pos)             /**< (PAC_SECLOCKC) ADC Secure Status Locked Mask */
+#define PAC_SECLOCKC_ADC                    PAC_SECLOCKC_ADC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKC_ADC_Msk instead */
+#define PAC_SECLOCKC_DAC_Pos                8                                              /**< (PAC_SECLOCKC) DAC Secure Status Locked Position */
+#define PAC_SECLOCKC_DAC_Msk                (_U_(0x1) << PAC_SECLOCKC_DAC_Pos)             /**< (PAC_SECLOCKC) DAC Secure Status Locked Mask */
+#define PAC_SECLOCKC_DAC                    PAC_SECLOCKC_DAC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKC_DAC_Msk instead */
+#define PAC_SECLOCKC_PTC_Pos                9                                              /**< (PAC_SECLOCKC) PTC Secure Status Locked Position */
+#define PAC_SECLOCKC_PTC_Msk                (_U_(0x1) << PAC_SECLOCKC_PTC_Pos)             /**< (PAC_SECLOCKC) PTC Secure Status Locked Mask */
+#define PAC_SECLOCKC_PTC                    PAC_SECLOCKC_PTC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKC_PTC_Msk instead */
+#define PAC_SECLOCKC_TRNG_Pos               10                                             /**< (PAC_SECLOCKC) TRNG Secure Status Locked Position */
+#define PAC_SECLOCKC_TRNG_Msk               (_U_(0x1) << PAC_SECLOCKC_TRNG_Pos)            /**< (PAC_SECLOCKC) TRNG Secure Status Locked Mask */
+#define PAC_SECLOCKC_TRNG                   PAC_SECLOCKC_TRNG_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKC_TRNG_Msk instead */
+#define PAC_SECLOCKC_CCL_Pos                11                                             /**< (PAC_SECLOCKC) CCL Secure Status Locked Position */
+#define PAC_SECLOCKC_CCL_Msk                (_U_(0x1) << PAC_SECLOCKC_CCL_Pos)             /**< (PAC_SECLOCKC) CCL Secure Status Locked Mask */
+#define PAC_SECLOCKC_CCL                    PAC_SECLOCKC_CCL_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKC_CCL_Msk instead */
+#define PAC_SECLOCKC_OPAMP_Pos              12                                             /**< (PAC_SECLOCKC) OPAMP Secure Status Locked Position */
+#define PAC_SECLOCKC_OPAMP_Msk              (_U_(0x1) << PAC_SECLOCKC_OPAMP_Pos)           /**< (PAC_SECLOCKC) OPAMP Secure Status Locked Mask */
+#define PAC_SECLOCKC_OPAMP                  PAC_SECLOCKC_OPAMP_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKC_OPAMP_Msk instead */
+#define PAC_SECLOCKC_TRAM_Pos               13                                             /**< (PAC_SECLOCKC) TRAM Secure Status Locked Position */
+#define PAC_SECLOCKC_TRAM_Msk               (_U_(0x1) << PAC_SECLOCKC_TRAM_Pos)            /**< (PAC_SECLOCKC) TRAM Secure Status Locked Mask */
+#define PAC_SECLOCKC_TRAM                   PAC_SECLOCKC_TRAM_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PAC_SECLOCKC_TRAM_Msk instead */
+#define PAC_SECLOCKC_MASK                   _U_(0x3FFF)                                    /**< \deprecated (PAC_SECLOCKC) Register MASK  (Use PAC_SECLOCKC_Msk instead)  */
+#define PAC_SECLOCKC_Msk                    _U_(0x3FFF)                                    /**< (PAC_SECLOCKC) Register Mask  */
+
+#define PAC_SECLOCKC_SERCOM_Pos             1                                              /**< (PAC_SECLOCKC Position) SERCOMx Secure Status Locked */
+#define PAC_SECLOCKC_SERCOM_Msk             (_U_(0x7) << PAC_SECLOCKC_SERCOM_Pos)          /**< (PAC_SECLOCKC Mask) SERCOM */
+#define PAC_SECLOCKC_SERCOM(value)          (PAC_SECLOCKC_SERCOM_Msk & ((value) << PAC_SECLOCKC_SERCOM_Pos))  
+#define PAC_SECLOCKC_TC_Pos                 4                                              /**< (PAC_SECLOCKC Position) TCx Secure Status Locked */
+#define PAC_SECLOCKC_TC_Msk                 (_U_(0x7) << PAC_SECLOCKC_TC_Pos)              /**< (PAC_SECLOCKC Mask) TC */
+#define PAC_SECLOCKC_TC(value)              (PAC_SECLOCKC_TC_Msk & ((value) << PAC_SECLOCKC_TC_Pos))  
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief PAC hardware registers */
+typedef struct {  /* Peripheral Access Controller */
+  __IO PAC_WRCTRL_Type                WRCTRL;         /**< Offset: 0x00 (R/W  32) Write control */
+  __IO PAC_EVCTRL_Type                EVCTRL;         /**< Offset: 0x04 (R/W   8) Event control */
+  __I  uint8_t                        Reserved1[3];
+  __IO PAC_INTENCLR_Type              INTENCLR;       /**< Offset: 0x08 (R/W   8) Interrupt enable clear */
+  __IO PAC_INTENSET_Type              INTENSET;       /**< Offset: 0x09 (R/W   8) Interrupt enable set */
+  __I  uint8_t                        Reserved2[6];
+  __IO PAC_INTFLAGAHB_Type            INTFLAGAHB;     /**< Offset: 0x10 (R/W  32) Bridge interrupt flag status */
+  __IO PAC_INTFLAGA_Type              INTFLAGA;       /**< Offset: 0x14 (R/W  32) Peripheral interrupt flag status - Bridge A */
+  __IO PAC_INTFLAGB_Type              INTFLAGB;       /**< Offset: 0x18 (R/W  32) Peripheral interrupt flag status - Bridge B */
+  __IO PAC_INTFLAGC_Type              INTFLAGC;       /**< Offset: 0x1C (R/W  32) Peripheral interrupt flag status - Bridge C */
+  __I  uint8_t                        Reserved3[20];
+  __I  PAC_STATUSA_Type               STATUSA;        /**< Offset: 0x34 (R/   32) Peripheral write protection status - Bridge A */
+  __I  PAC_STATUSB_Type               STATUSB;        /**< Offset: 0x38 (R/   32) Peripheral write protection status - Bridge B */
+  __I  PAC_STATUSC_Type               STATUSC;        /**< Offset: 0x3C (R/   32) Peripheral write protection status - Bridge C */
+  __I  uint8_t                        Reserved4[20];
+  __I  PAC_NONSECA_Type               NONSECA;        /**< Offset: 0x54 (R/   32) Peripheral non-secure status - Bridge A */
+  __I  PAC_NONSECB_Type               NONSECB;        /**< Offset: 0x58 (R/   32) Peripheral non-secure status - Bridge B */
+  __I  PAC_NONSECC_Type               NONSECC;        /**< Offset: 0x5C (R/   32) Peripheral non-secure status - Bridge C */
+  __I  uint8_t                        Reserved5[20];
+  __I  PAC_SECLOCKA_Type              SECLOCKA;       /**< Offset: 0x74 (R/   32) Peripheral secure status locked - Bridge A */
+  __I  PAC_SECLOCKB_Type              SECLOCKB;       /**< Offset: 0x78 (R/   32) Peripheral secure status locked - Bridge B */
+  __I  PAC_SECLOCKC_Type              SECLOCKC;       /**< Offset: 0x7C (R/   32) Peripheral secure status locked - Bridge C */
+} Pac;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Peripheral Access Controller */
+
+#endif /* _SAML11_PAC_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/component/pm.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/pm.h
@@ -1,0 +1,266 @@
+/**
+ * \file
+ *
+ * \brief Component description for PM
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_PM_COMPONENT_H_
+#define _SAML11_PM_COMPONENT_H_
+#define _SAML11_PM_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML11 Power Manager
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR PM */
+/* ========================================================================== */
+
+#define PM_U2240                      /**< (PM) Module ID */
+#define REV_PM 0x310                  /**< (PM) Module revision */
+
+/* -------- PM_SLEEPCFG : (PM Offset: 0x01) (R/W 8) Sleep Configuration -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  SLEEPMODE:3;               /**< bit:   0..2  Sleep Mode                               */
+    uint8_t  :5;                        /**< bit:   3..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} PM_SLEEPCFG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_SLEEPCFG_OFFSET                  (0x01)                                        /**<  (PM_SLEEPCFG) Sleep Configuration  Offset */
+#define PM_SLEEPCFG_RESETVALUE              _U_(0x02)                                     /**<  (PM_SLEEPCFG) Sleep Configuration  Reset Value */
+
+#define PM_SLEEPCFG_SLEEPMODE_Pos           0                                              /**< (PM_SLEEPCFG) Sleep Mode Position */
+#define PM_SLEEPCFG_SLEEPMODE_Msk           (_U_(0x7) << PM_SLEEPCFG_SLEEPMODE_Pos)        /**< (PM_SLEEPCFG) Sleep Mode Mask */
+#define PM_SLEEPCFG_SLEEPMODE(value)        (PM_SLEEPCFG_SLEEPMODE_Msk & ((value) << PM_SLEEPCFG_SLEEPMODE_Pos))
+#define   PM_SLEEPCFG_SLEEPMODE_IDLE_Val    _U_(0x2)                                       /**< (PM_SLEEPCFG) CPU, AHB, APB clocks are OFF  */
+#define   PM_SLEEPCFG_SLEEPMODE_STANDBY_Val _U_(0x4)                                       /**< (PM_SLEEPCFG) All Clocks are OFF  */
+#define   PM_SLEEPCFG_SLEEPMODE_OFF_Val     _U_(0x6)                                       /**< (PM_SLEEPCFG) All power domains are powered OFF  */
+#define PM_SLEEPCFG_SLEEPMODE_IDLE          (PM_SLEEPCFG_SLEEPMODE_IDLE_Val << PM_SLEEPCFG_SLEEPMODE_Pos)  /**< (PM_SLEEPCFG) CPU, AHB, APB clocks are OFF Position  */
+#define PM_SLEEPCFG_SLEEPMODE_STANDBY       (PM_SLEEPCFG_SLEEPMODE_STANDBY_Val << PM_SLEEPCFG_SLEEPMODE_Pos)  /**< (PM_SLEEPCFG) All Clocks are OFF Position  */
+#define PM_SLEEPCFG_SLEEPMODE_OFF           (PM_SLEEPCFG_SLEEPMODE_OFF_Val << PM_SLEEPCFG_SLEEPMODE_Pos)  /**< (PM_SLEEPCFG) All power domains are powered OFF Position  */
+#define PM_SLEEPCFG_MASK                    _U_(0x07)                                      /**< \deprecated (PM_SLEEPCFG) Register MASK  (Use PM_SLEEPCFG_Msk instead)  */
+#define PM_SLEEPCFG_Msk                     _U_(0x07)                                      /**< (PM_SLEEPCFG) Register Mask  */
+
+
+/* -------- PM_PLCFG : (PM Offset: 0x02) (R/W 8) Performance Level Configuration -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  PLSEL:2;                   /**< bit:   0..1  Performance Level Select                 */
+    uint8_t  :5;                        /**< bit:   2..6  Reserved */
+    uint8_t  PLDIS:1;                   /**< bit:      7  Performance Level Disable                */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} PM_PLCFG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_PLCFG_OFFSET                     (0x02)                                        /**<  (PM_PLCFG) Performance Level Configuration  Offset */
+#define PM_PLCFG_RESETVALUE                 _U_(0x00)                                     /**<  (PM_PLCFG) Performance Level Configuration  Reset Value */
+
+#define PM_PLCFG_PLSEL_Pos                  0                                              /**< (PM_PLCFG) Performance Level Select Position */
+#define PM_PLCFG_PLSEL_Msk                  (_U_(0x3) << PM_PLCFG_PLSEL_Pos)               /**< (PM_PLCFG) Performance Level Select Mask */
+#define PM_PLCFG_PLSEL(value)               (PM_PLCFG_PLSEL_Msk & ((value) << PM_PLCFG_PLSEL_Pos))
+#define   PM_PLCFG_PLSEL_PL0_Val            _U_(0x0)                                       /**< (PM_PLCFG) Performance Level 0  */
+#define   PM_PLCFG_PLSEL_PL2_Val            _U_(0x2)                                       /**< (PM_PLCFG) Performance Level 2  */
+#define PM_PLCFG_PLSEL_PL0                  (PM_PLCFG_PLSEL_PL0_Val << PM_PLCFG_PLSEL_Pos)  /**< (PM_PLCFG) Performance Level 0 Position  */
+#define PM_PLCFG_PLSEL_PL2                  (PM_PLCFG_PLSEL_PL2_Val << PM_PLCFG_PLSEL_Pos)  /**< (PM_PLCFG) Performance Level 2 Position  */
+#define PM_PLCFG_PLDIS_Pos                  7                                              /**< (PM_PLCFG) Performance Level Disable Position */
+#define PM_PLCFG_PLDIS_Msk                  (_U_(0x1) << PM_PLCFG_PLDIS_Pos)               /**< (PM_PLCFG) Performance Level Disable Mask */
+#define PM_PLCFG_PLDIS                      PM_PLCFG_PLDIS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PM_PLCFG_PLDIS_Msk instead */
+#define PM_PLCFG_MASK                       _U_(0x83)                                      /**< \deprecated (PM_PLCFG) Register MASK  (Use PM_PLCFG_Msk instead)  */
+#define PM_PLCFG_Msk                        _U_(0x83)                                      /**< (PM_PLCFG) Register Mask  */
+
+
+/* -------- PM_PWCFG : (PM Offset: 0x03) (R/W 8) Power Configuration -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  RAMPSWC:2;                 /**< bit:   0..1  RAM Power Switch Configuration           */
+    uint8_t  :6;                        /**< bit:   2..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} PM_PWCFG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_PWCFG_OFFSET                     (0x03)                                        /**<  (PM_PWCFG) Power Configuration  Offset */
+#define PM_PWCFG_RESETVALUE                 _U_(0x00)                                     /**<  (PM_PWCFG) Power Configuration  Reset Value */
+
+#define PM_PWCFG_RAMPSWC_Pos                0                                              /**< (PM_PWCFG) RAM Power Switch Configuration Position */
+#define PM_PWCFG_RAMPSWC_Msk                (_U_(0x3) << PM_PWCFG_RAMPSWC_Pos)             /**< (PM_PWCFG) RAM Power Switch Configuration Mask */
+#define PM_PWCFG_RAMPSWC(value)             (PM_PWCFG_RAMPSWC_Msk & ((value) << PM_PWCFG_RAMPSWC_Pos))
+#define   PM_PWCFG_RAMPSWC_16KB_Val         _U_(0x0)                                       /**< (PM_PWCFG) 16KB Available  */
+#define   PM_PWCFG_RAMPSWC_12KB_Val         _U_(0x1)                                       /**< (PM_PWCFG) 12KB Available  */
+#define   PM_PWCFG_RAMPSWC_8KB_Val          _U_(0x2)                                       /**< (PM_PWCFG) 8KB Available  */
+#define   PM_PWCFG_RAMPSWC_4KB_Val          _U_(0x3)                                       /**< (PM_PWCFG) 4KB Available  */
+#define PM_PWCFG_RAMPSWC_16KB               (PM_PWCFG_RAMPSWC_16KB_Val << PM_PWCFG_RAMPSWC_Pos)  /**< (PM_PWCFG) 16KB Available Position  */
+#define PM_PWCFG_RAMPSWC_12KB               (PM_PWCFG_RAMPSWC_12KB_Val << PM_PWCFG_RAMPSWC_Pos)  /**< (PM_PWCFG) 12KB Available Position  */
+#define PM_PWCFG_RAMPSWC_8KB                (PM_PWCFG_RAMPSWC_8KB_Val << PM_PWCFG_RAMPSWC_Pos)  /**< (PM_PWCFG) 8KB Available Position  */
+#define PM_PWCFG_RAMPSWC_4KB                (PM_PWCFG_RAMPSWC_4KB_Val << PM_PWCFG_RAMPSWC_Pos)  /**< (PM_PWCFG) 4KB Available Position  */
+#define PM_PWCFG_MASK                       _U_(0x03)                                      /**< \deprecated (PM_PWCFG) Register MASK  (Use PM_PWCFG_Msk instead)  */
+#define PM_PWCFG_Msk                        _U_(0x03)                                      /**< (PM_PWCFG) Register Mask  */
+
+
+/* -------- PM_INTENCLR : (PM Offset: 0x04) (R/W 8) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  PLRDY:1;                   /**< bit:      0  Performance Level Interrupt Enable       */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} PM_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_INTENCLR_OFFSET                  (0x04)                                        /**<  (PM_INTENCLR) Interrupt Enable Clear  Offset */
+#define PM_INTENCLR_RESETVALUE              _U_(0x00)                                     /**<  (PM_INTENCLR) Interrupt Enable Clear  Reset Value */
+
+#define PM_INTENCLR_PLRDY_Pos               0                                              /**< (PM_INTENCLR) Performance Level Interrupt Enable Position */
+#define PM_INTENCLR_PLRDY_Msk               (_U_(0x1) << PM_INTENCLR_PLRDY_Pos)            /**< (PM_INTENCLR) Performance Level Interrupt Enable Mask */
+#define PM_INTENCLR_PLRDY                   PM_INTENCLR_PLRDY_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PM_INTENCLR_PLRDY_Msk instead */
+#define PM_INTENCLR_MASK                    _U_(0x01)                                      /**< \deprecated (PM_INTENCLR) Register MASK  (Use PM_INTENCLR_Msk instead)  */
+#define PM_INTENCLR_Msk                     _U_(0x01)                                      /**< (PM_INTENCLR) Register Mask  */
+
+
+/* -------- PM_INTENSET : (PM Offset: 0x05) (R/W 8) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  PLRDY:1;                   /**< bit:      0  Performance Level Ready interrupt Enable */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} PM_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_INTENSET_OFFSET                  (0x05)                                        /**<  (PM_INTENSET) Interrupt Enable Set  Offset */
+#define PM_INTENSET_RESETVALUE              _U_(0x00)                                     /**<  (PM_INTENSET) Interrupt Enable Set  Reset Value */
+
+#define PM_INTENSET_PLRDY_Pos               0                                              /**< (PM_INTENSET) Performance Level Ready interrupt Enable Position */
+#define PM_INTENSET_PLRDY_Msk               (_U_(0x1) << PM_INTENSET_PLRDY_Pos)            /**< (PM_INTENSET) Performance Level Ready interrupt Enable Mask */
+#define PM_INTENSET_PLRDY                   PM_INTENSET_PLRDY_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PM_INTENSET_PLRDY_Msk instead */
+#define PM_INTENSET_MASK                    _U_(0x01)                                      /**< \deprecated (PM_INTENSET) Register MASK  (Use PM_INTENSET_Msk instead)  */
+#define PM_INTENSET_Msk                     _U_(0x01)                                      /**< (PM_INTENSET) Register Mask  */
+
+
+/* -------- PM_INTFLAG : (PM Offset: 0x06) (R/W 8) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t PLRDY:1;                   /**< bit:      0  Performance Level Ready                  */
+    __I uint8_t :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} PM_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_INTFLAG_OFFSET                   (0x06)                                        /**<  (PM_INTFLAG) Interrupt Flag Status and Clear  Offset */
+#define PM_INTFLAG_RESETVALUE               _U_(0x00)                                     /**<  (PM_INTFLAG) Interrupt Flag Status and Clear  Reset Value */
+
+#define PM_INTFLAG_PLRDY_Pos                0                                              /**< (PM_INTFLAG) Performance Level Ready Position */
+#define PM_INTFLAG_PLRDY_Msk                (_U_(0x1) << PM_INTFLAG_PLRDY_Pos)             /**< (PM_INTFLAG) Performance Level Ready Mask */
+#define PM_INTFLAG_PLRDY                    PM_INTFLAG_PLRDY_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PM_INTFLAG_PLRDY_Msk instead */
+#define PM_INTFLAG_MASK                     _U_(0x01)                                      /**< \deprecated (PM_INTFLAG) Register MASK  (Use PM_INTFLAG_Msk instead)  */
+#define PM_INTFLAG_Msk                      _U_(0x01)                                      /**< (PM_INTFLAG) Register Mask  */
+
+
+/* -------- PM_STDBYCFG : (PM Offset: 0x08) (R/W 16) Standby Configuration -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t PDCFG:1;                   /**< bit:      0  Power Domain Configuration               */
+    uint16_t :3;                        /**< bit:   1..3  Reserved */
+    uint16_t DPGPDSW:1;                 /**< bit:      4  Dynamic Power Gating for PDSW            */
+    uint16_t :1;                        /**< bit:      5  Reserved */
+    uint16_t VREGSMOD:2;                /**< bit:   6..7  Voltage Regulator Standby mode           */
+    uint16_t :2;                        /**< bit:   8..9  Reserved */
+    uint16_t BBIASHS:1;                 /**< bit:     10  Back Bias for HSRAM                      */
+    uint16_t :1;                        /**< bit:     11  Reserved */
+    uint16_t BBIASTR:1;                 /**< bit:     12  Back Bias for Trust RAM                  */
+    uint16_t :3;                        /**< bit: 13..15  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} PM_STDBYCFG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_STDBYCFG_OFFSET                  (0x08)                                        /**<  (PM_STDBYCFG) Standby Configuration  Offset */
+#define PM_STDBYCFG_RESETVALUE              _U_(0x00)                                     /**<  (PM_STDBYCFG) Standby Configuration  Reset Value */
+
+#define PM_STDBYCFG_PDCFG_Pos               0                                              /**< (PM_STDBYCFG) Power Domain Configuration Position */
+#define PM_STDBYCFG_PDCFG_Msk               (_U_(0x1) << PM_STDBYCFG_PDCFG_Pos)            /**< (PM_STDBYCFG) Power Domain Configuration Mask */
+#define PM_STDBYCFG_PDCFG                   PM_STDBYCFG_PDCFG_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PM_STDBYCFG_PDCFG_Msk instead */
+#define   PM_STDBYCFG_PDCFG_DEFAULT_Val     _U_(0x0)                                       /**< (PM_STDBYCFG) PDSW power domain switching is handled by hardware.  */
+#define   PM_STDBYCFG_PDCFG_PDSW_Val        _U_(0x1)                                       /**< (PM_STDBYCFG) PDSW is forced ACTIVE.  */
+#define PM_STDBYCFG_PDCFG_DEFAULT           (PM_STDBYCFG_PDCFG_DEFAULT_Val << PM_STDBYCFG_PDCFG_Pos)  /**< (PM_STDBYCFG) PDSW power domain switching is handled by hardware. Position  */
+#define PM_STDBYCFG_PDCFG_PDSW              (PM_STDBYCFG_PDCFG_PDSW_Val << PM_STDBYCFG_PDCFG_Pos)  /**< (PM_STDBYCFG) PDSW is forced ACTIVE. Position  */
+#define PM_STDBYCFG_DPGPDSW_Pos             4                                              /**< (PM_STDBYCFG) Dynamic Power Gating for PDSW Position */
+#define PM_STDBYCFG_DPGPDSW_Msk             (_U_(0x1) << PM_STDBYCFG_DPGPDSW_Pos)          /**< (PM_STDBYCFG) Dynamic Power Gating for PDSW Mask */
+#define PM_STDBYCFG_DPGPDSW                 PM_STDBYCFG_DPGPDSW_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PM_STDBYCFG_DPGPDSW_Msk instead */
+#define   PM_STDBYCFG_DPGPDSW_0_Val         _U_(0x0)                                       /**< (PM_STDBYCFG) Dynamic Power Gating disabled  */
+#define   PM_STDBYCFG_DPGPDSW_1_Val         _U_(0x1)                                       /**< (PM_STDBYCFG) Dynamic Power Gating enabled  */
+#define PM_STDBYCFG_DPGPDSW_0               (PM_STDBYCFG_DPGPDSW_0_Val << PM_STDBYCFG_DPGPDSW_Pos)  /**< (PM_STDBYCFG) Dynamic Power Gating disabled Position  */
+#define PM_STDBYCFG_DPGPDSW_1               (PM_STDBYCFG_DPGPDSW_1_Val << PM_STDBYCFG_DPGPDSW_Pos)  /**< (PM_STDBYCFG) Dynamic Power Gating enabled Position  */
+#define PM_STDBYCFG_VREGSMOD_Pos            6                                              /**< (PM_STDBYCFG) Voltage Regulator Standby mode Position */
+#define PM_STDBYCFG_VREGSMOD_Msk            (_U_(0x3) << PM_STDBYCFG_VREGSMOD_Pos)         /**< (PM_STDBYCFG) Voltage Regulator Standby mode Mask */
+#define PM_STDBYCFG_VREGSMOD(value)         (PM_STDBYCFG_VREGSMOD_Msk & ((value) << PM_STDBYCFG_VREGSMOD_Pos))
+#define   PM_STDBYCFG_VREGSMOD_AUTO_Val     _U_(0x0)                                       /**< (PM_STDBYCFG) Automatic mode  */
+#define   PM_STDBYCFG_VREGSMOD_PERFORMANCE_Val _U_(0x1)                                       /**< (PM_STDBYCFG) Performance oriented  */
+#define   PM_STDBYCFG_VREGSMOD_LP_Val       _U_(0x2)                                       /**< (PM_STDBYCFG) Low Power oriented  */
+#define PM_STDBYCFG_VREGSMOD_AUTO           (PM_STDBYCFG_VREGSMOD_AUTO_Val << PM_STDBYCFG_VREGSMOD_Pos)  /**< (PM_STDBYCFG) Automatic mode Position  */
+#define PM_STDBYCFG_VREGSMOD_PERFORMANCE    (PM_STDBYCFG_VREGSMOD_PERFORMANCE_Val << PM_STDBYCFG_VREGSMOD_Pos)  /**< (PM_STDBYCFG) Performance oriented Position  */
+#define PM_STDBYCFG_VREGSMOD_LP             (PM_STDBYCFG_VREGSMOD_LP_Val << PM_STDBYCFG_VREGSMOD_Pos)  /**< (PM_STDBYCFG) Low Power oriented Position  */
+#define PM_STDBYCFG_BBIASHS_Pos             10                                             /**< (PM_STDBYCFG) Back Bias for HSRAM Position */
+#define PM_STDBYCFG_BBIASHS_Msk             (_U_(0x1) << PM_STDBYCFG_BBIASHS_Pos)          /**< (PM_STDBYCFG) Back Bias for HSRAM Mask */
+#define PM_STDBYCFG_BBIASHS                 PM_STDBYCFG_BBIASHS_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PM_STDBYCFG_BBIASHS_Msk instead */
+#define PM_STDBYCFG_BBIASTR_Pos             12                                             /**< (PM_STDBYCFG) Back Bias for Trust RAM Position */
+#define PM_STDBYCFG_BBIASTR_Msk             (_U_(0x1) << PM_STDBYCFG_BBIASTR_Pos)          /**< (PM_STDBYCFG) Back Bias for Trust RAM Mask */
+#define PM_STDBYCFG_BBIASTR                 PM_STDBYCFG_BBIASTR_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PM_STDBYCFG_BBIASTR_Msk instead */
+#define PM_STDBYCFG_MASK                    _U_(0x14D1)                                    /**< \deprecated (PM_STDBYCFG) Register MASK  (Use PM_STDBYCFG_Msk instead)  */
+#define PM_STDBYCFG_Msk                     _U_(0x14D1)                                    /**< (PM_STDBYCFG) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief PM hardware registers */
+typedef struct {  /* Power Manager */
+  __I  uint8_t                        Reserved1[1];
+  __IO PM_SLEEPCFG_Type               SLEEPCFG;       /**< Offset: 0x01 (R/W   8) Sleep Configuration */
+  __IO PM_PLCFG_Type                  PLCFG;          /**< Offset: 0x02 (R/W   8) Performance Level Configuration */
+  __IO PM_PWCFG_Type                  PWCFG;          /**< Offset: 0x03 (R/W   8) Power Configuration */
+  __IO PM_INTENCLR_Type               INTENCLR;       /**< Offset: 0x04 (R/W   8) Interrupt Enable Clear */
+  __IO PM_INTENSET_Type               INTENSET;       /**< Offset: 0x05 (R/W   8) Interrupt Enable Set */
+  __IO PM_INTFLAG_Type                INTFLAG;        /**< Offset: 0x06 (R/W   8) Interrupt Flag Status and Clear */
+  __I  uint8_t                        Reserved2[1];
+  __IO PM_STDBYCFG_Type               STDBYCFG;       /**< Offset: 0x08 (R/W  16) Standby Configuration */
+} Pm;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Power Manager */
+
+#endif /* _SAML11_PM_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/component/port.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/port.h
@@ -1,0 +1,566 @@
+/**
+ * \file
+ *
+ * \brief Component description for PORT
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_PORT_COMPONENT_H_
+#define _SAML11_PORT_COMPONENT_H_
+#define _SAML11_PORT_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML11 Port Module
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR PORT */
+/* ========================================================================== */
+
+#define PORT_U2210                      /**< (PORT) Module ID */
+#define REV_PORT 0x300                  /**< (PORT) Module revision */
+
+/* -------- PORT_DIR : (PORT Offset: 0x00) (R/W 32) Data Direction -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t DIR:32;                    /**< bit:  0..31  Port Data Direction                      */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PORT_DIR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_DIR_OFFSET                     (0x00)                                        /**<  (PORT_DIR) Data Direction  Offset */
+#define PORT_DIR_RESETVALUE                 _U_(0x00)                                     /**<  (PORT_DIR) Data Direction  Reset Value */
+
+#define PORT_DIR_DIR_Pos                    0                                              /**< (PORT_DIR) Port Data Direction Position */
+#define PORT_DIR_DIR_Msk                    (_U_(0xFFFFFFFF) << PORT_DIR_DIR_Pos)          /**< (PORT_DIR) Port Data Direction Mask */
+#define PORT_DIR_DIR(value)                 (PORT_DIR_DIR_Msk & ((value) << PORT_DIR_DIR_Pos))
+#define PORT_DIR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (PORT_DIR) Register MASK  (Use PORT_DIR_Msk instead)  */
+#define PORT_DIR_Msk                        _U_(0xFFFFFFFF)                                /**< (PORT_DIR) Register Mask  */
+
+
+/* -------- PORT_DIRCLR : (PORT Offset: 0x04) (R/W 32) Data Direction Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t DIRCLR:32;                 /**< bit:  0..31  Port Data Direction Clear                */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PORT_DIRCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_DIRCLR_OFFSET                  (0x04)                                        /**<  (PORT_DIRCLR) Data Direction Clear  Offset */
+#define PORT_DIRCLR_RESETVALUE              _U_(0x00)                                     /**<  (PORT_DIRCLR) Data Direction Clear  Reset Value */
+
+#define PORT_DIRCLR_DIRCLR_Pos              0                                              /**< (PORT_DIRCLR) Port Data Direction Clear Position */
+#define PORT_DIRCLR_DIRCLR_Msk              (_U_(0xFFFFFFFF) << PORT_DIRCLR_DIRCLR_Pos)    /**< (PORT_DIRCLR) Port Data Direction Clear Mask */
+#define PORT_DIRCLR_DIRCLR(value)           (PORT_DIRCLR_DIRCLR_Msk & ((value) << PORT_DIRCLR_DIRCLR_Pos))
+#define PORT_DIRCLR_MASK                    _U_(0xFFFFFFFF)                                /**< \deprecated (PORT_DIRCLR) Register MASK  (Use PORT_DIRCLR_Msk instead)  */
+#define PORT_DIRCLR_Msk                     _U_(0xFFFFFFFF)                                /**< (PORT_DIRCLR) Register Mask  */
+
+
+/* -------- PORT_DIRSET : (PORT Offset: 0x08) (R/W 32) Data Direction Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t DIRSET:32;                 /**< bit:  0..31  Port Data Direction Set                  */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PORT_DIRSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_DIRSET_OFFSET                  (0x08)                                        /**<  (PORT_DIRSET) Data Direction Set  Offset */
+#define PORT_DIRSET_RESETVALUE              _U_(0x00)                                     /**<  (PORT_DIRSET) Data Direction Set  Reset Value */
+
+#define PORT_DIRSET_DIRSET_Pos              0                                              /**< (PORT_DIRSET) Port Data Direction Set Position */
+#define PORT_DIRSET_DIRSET_Msk              (_U_(0xFFFFFFFF) << PORT_DIRSET_DIRSET_Pos)    /**< (PORT_DIRSET) Port Data Direction Set Mask */
+#define PORT_DIRSET_DIRSET(value)           (PORT_DIRSET_DIRSET_Msk & ((value) << PORT_DIRSET_DIRSET_Pos))
+#define PORT_DIRSET_MASK                    _U_(0xFFFFFFFF)                                /**< \deprecated (PORT_DIRSET) Register MASK  (Use PORT_DIRSET_Msk instead)  */
+#define PORT_DIRSET_Msk                     _U_(0xFFFFFFFF)                                /**< (PORT_DIRSET) Register Mask  */
+
+
+/* -------- PORT_DIRTGL : (PORT Offset: 0x0c) (R/W 32) Data Direction Toggle -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t DIRTGL:32;                 /**< bit:  0..31  Port Data Direction Toggle               */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PORT_DIRTGL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_DIRTGL_OFFSET                  (0x0C)                                        /**<  (PORT_DIRTGL) Data Direction Toggle  Offset */
+#define PORT_DIRTGL_RESETVALUE              _U_(0x00)                                     /**<  (PORT_DIRTGL) Data Direction Toggle  Reset Value */
+
+#define PORT_DIRTGL_DIRTGL_Pos              0                                              /**< (PORT_DIRTGL) Port Data Direction Toggle Position */
+#define PORT_DIRTGL_DIRTGL_Msk              (_U_(0xFFFFFFFF) << PORT_DIRTGL_DIRTGL_Pos)    /**< (PORT_DIRTGL) Port Data Direction Toggle Mask */
+#define PORT_DIRTGL_DIRTGL(value)           (PORT_DIRTGL_DIRTGL_Msk & ((value) << PORT_DIRTGL_DIRTGL_Pos))
+#define PORT_DIRTGL_MASK                    _U_(0xFFFFFFFF)                                /**< \deprecated (PORT_DIRTGL) Register MASK  (Use PORT_DIRTGL_Msk instead)  */
+#define PORT_DIRTGL_Msk                     _U_(0xFFFFFFFF)                                /**< (PORT_DIRTGL) Register Mask  */
+
+
+/* -------- PORT_OUT : (PORT Offset: 0x10) (R/W 32) Data Output Value -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t OUT:32;                    /**< bit:  0..31  PORT Data Output Value                   */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PORT_OUT_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_OUT_OFFSET                     (0x10)                                        /**<  (PORT_OUT) Data Output Value  Offset */
+#define PORT_OUT_RESETVALUE                 _U_(0x00)                                     /**<  (PORT_OUT) Data Output Value  Reset Value */
+
+#define PORT_OUT_OUT_Pos                    0                                              /**< (PORT_OUT) PORT Data Output Value Position */
+#define PORT_OUT_OUT_Msk                    (_U_(0xFFFFFFFF) << PORT_OUT_OUT_Pos)          /**< (PORT_OUT) PORT Data Output Value Mask */
+#define PORT_OUT_OUT(value)                 (PORT_OUT_OUT_Msk & ((value) << PORT_OUT_OUT_Pos))
+#define PORT_OUT_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (PORT_OUT) Register MASK  (Use PORT_OUT_Msk instead)  */
+#define PORT_OUT_Msk                        _U_(0xFFFFFFFF)                                /**< (PORT_OUT) Register Mask  */
+
+
+/* -------- PORT_OUTCLR : (PORT Offset: 0x14) (R/W 32) Data Output Value Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t OUTCLR:32;                 /**< bit:  0..31  PORT Data Output Value Clear             */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PORT_OUTCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_OUTCLR_OFFSET                  (0x14)                                        /**<  (PORT_OUTCLR) Data Output Value Clear  Offset */
+#define PORT_OUTCLR_RESETVALUE              _U_(0x00)                                     /**<  (PORT_OUTCLR) Data Output Value Clear  Reset Value */
+
+#define PORT_OUTCLR_OUTCLR_Pos              0                                              /**< (PORT_OUTCLR) PORT Data Output Value Clear Position */
+#define PORT_OUTCLR_OUTCLR_Msk              (_U_(0xFFFFFFFF) << PORT_OUTCLR_OUTCLR_Pos)    /**< (PORT_OUTCLR) PORT Data Output Value Clear Mask */
+#define PORT_OUTCLR_OUTCLR(value)           (PORT_OUTCLR_OUTCLR_Msk & ((value) << PORT_OUTCLR_OUTCLR_Pos))
+#define PORT_OUTCLR_MASK                    _U_(0xFFFFFFFF)                                /**< \deprecated (PORT_OUTCLR) Register MASK  (Use PORT_OUTCLR_Msk instead)  */
+#define PORT_OUTCLR_Msk                     _U_(0xFFFFFFFF)                                /**< (PORT_OUTCLR) Register Mask  */
+
+
+/* -------- PORT_OUTSET : (PORT Offset: 0x18) (R/W 32) Data Output Value Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t OUTSET:32;                 /**< bit:  0..31  PORT Data Output Value Set               */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PORT_OUTSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_OUTSET_OFFSET                  (0x18)                                        /**<  (PORT_OUTSET) Data Output Value Set  Offset */
+#define PORT_OUTSET_RESETVALUE              _U_(0x00)                                     /**<  (PORT_OUTSET) Data Output Value Set  Reset Value */
+
+#define PORT_OUTSET_OUTSET_Pos              0                                              /**< (PORT_OUTSET) PORT Data Output Value Set Position */
+#define PORT_OUTSET_OUTSET_Msk              (_U_(0xFFFFFFFF) << PORT_OUTSET_OUTSET_Pos)    /**< (PORT_OUTSET) PORT Data Output Value Set Mask */
+#define PORT_OUTSET_OUTSET(value)           (PORT_OUTSET_OUTSET_Msk & ((value) << PORT_OUTSET_OUTSET_Pos))
+#define PORT_OUTSET_MASK                    _U_(0xFFFFFFFF)                                /**< \deprecated (PORT_OUTSET) Register MASK  (Use PORT_OUTSET_Msk instead)  */
+#define PORT_OUTSET_Msk                     _U_(0xFFFFFFFF)                                /**< (PORT_OUTSET) Register Mask  */
+
+
+/* -------- PORT_OUTTGL : (PORT Offset: 0x1c) (R/W 32) Data Output Value Toggle -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t OUTTGL:32;                 /**< bit:  0..31  PORT Data Output Value Toggle            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PORT_OUTTGL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_OUTTGL_OFFSET                  (0x1C)                                        /**<  (PORT_OUTTGL) Data Output Value Toggle  Offset */
+#define PORT_OUTTGL_RESETVALUE              _U_(0x00)                                     /**<  (PORT_OUTTGL) Data Output Value Toggle  Reset Value */
+
+#define PORT_OUTTGL_OUTTGL_Pos              0                                              /**< (PORT_OUTTGL) PORT Data Output Value Toggle Position */
+#define PORT_OUTTGL_OUTTGL_Msk              (_U_(0xFFFFFFFF) << PORT_OUTTGL_OUTTGL_Pos)    /**< (PORT_OUTTGL) PORT Data Output Value Toggle Mask */
+#define PORT_OUTTGL_OUTTGL(value)           (PORT_OUTTGL_OUTTGL_Msk & ((value) << PORT_OUTTGL_OUTTGL_Pos))
+#define PORT_OUTTGL_MASK                    _U_(0xFFFFFFFF)                                /**< \deprecated (PORT_OUTTGL) Register MASK  (Use PORT_OUTTGL_Msk instead)  */
+#define PORT_OUTTGL_Msk                     _U_(0xFFFFFFFF)                                /**< (PORT_OUTTGL) Register Mask  */
+
+
+/* -------- PORT_IN : (PORT Offset: 0x20) (R/ 32) Data Input Value -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t IN:32;                     /**< bit:  0..31  PORT Data Input Value                    */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PORT_IN_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_IN_OFFSET                      (0x20)                                        /**<  (PORT_IN) Data Input Value  Offset */
+#define PORT_IN_RESETVALUE                  _U_(0x00)                                     /**<  (PORT_IN) Data Input Value  Reset Value */
+
+#define PORT_IN_IN_Pos                      0                                              /**< (PORT_IN) PORT Data Input Value Position */
+#define PORT_IN_IN_Msk                      (_U_(0xFFFFFFFF) << PORT_IN_IN_Pos)            /**< (PORT_IN) PORT Data Input Value Mask */
+#define PORT_IN_IN(value)                   (PORT_IN_IN_Msk & ((value) << PORT_IN_IN_Pos))
+#define PORT_IN_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (PORT_IN) Register MASK  (Use PORT_IN_Msk instead)  */
+#define PORT_IN_Msk                         _U_(0xFFFFFFFF)                                /**< (PORT_IN) Register Mask  */
+
+
+/* -------- PORT_CTRL : (PORT Offset: 0x24) (R/W 32) Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SAMPLING:32;               /**< bit:  0..31  Input Sampling Mode                      */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PORT_CTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_CTRL_OFFSET                    (0x24)                                        /**<  (PORT_CTRL) Control  Offset */
+#define PORT_CTRL_RESETVALUE                _U_(0x00)                                     /**<  (PORT_CTRL) Control  Reset Value */
+
+#define PORT_CTRL_SAMPLING_Pos              0                                              /**< (PORT_CTRL) Input Sampling Mode Position */
+#define PORT_CTRL_SAMPLING_Msk              (_U_(0xFFFFFFFF) << PORT_CTRL_SAMPLING_Pos)    /**< (PORT_CTRL) Input Sampling Mode Mask */
+#define PORT_CTRL_SAMPLING(value)           (PORT_CTRL_SAMPLING_Msk & ((value) << PORT_CTRL_SAMPLING_Pos))
+#define PORT_CTRL_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (PORT_CTRL) Register MASK  (Use PORT_CTRL_Msk instead)  */
+#define PORT_CTRL_Msk                       _U_(0xFFFFFFFF)                                /**< (PORT_CTRL) Register Mask  */
+
+
+/* -------- PORT_WRCONFIG : (PORT Offset: 0x28) (/W 32) Write Configuration -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t PINMASK:16;                /**< bit:  0..15  Pin Mask for Multiple Pin Configuration  */
+    uint32_t PMUXEN:1;                  /**< bit:     16  Peripheral Multiplexer Enable            */
+    uint32_t INEN:1;                    /**< bit:     17  Input Enable                             */
+    uint32_t PULLEN:1;                  /**< bit:     18  Pull Enable                              */
+    uint32_t :3;                        /**< bit: 19..21  Reserved */
+    uint32_t DRVSTR:1;                  /**< bit:     22  Output Driver Strength Selection         */
+    uint32_t :1;                        /**< bit:     23  Reserved */
+    uint32_t PMUX:4;                    /**< bit: 24..27  Peripheral Multiplexing                  */
+    uint32_t WRPMUX:1;                  /**< bit:     28  Write PMUX                               */
+    uint32_t :1;                        /**< bit:     29  Reserved */
+    uint32_t WRPINCFG:1;                /**< bit:     30  Write PINCFG                             */
+    uint32_t HWSEL:1;                   /**< bit:     31  Half-Word Select                         */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PORT_WRCONFIG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_WRCONFIG_OFFSET                (0x28)                                        /**<  (PORT_WRCONFIG) Write Configuration  Offset */
+#define PORT_WRCONFIG_RESETVALUE            _U_(0x00)                                     /**<  (PORT_WRCONFIG) Write Configuration  Reset Value */
+
+#define PORT_WRCONFIG_PINMASK_Pos           0                                              /**< (PORT_WRCONFIG) Pin Mask for Multiple Pin Configuration Position */
+#define PORT_WRCONFIG_PINMASK_Msk           (_U_(0xFFFF) << PORT_WRCONFIG_PINMASK_Pos)     /**< (PORT_WRCONFIG) Pin Mask for Multiple Pin Configuration Mask */
+#define PORT_WRCONFIG_PINMASK(value)        (PORT_WRCONFIG_PINMASK_Msk & ((value) << PORT_WRCONFIG_PINMASK_Pos))
+#define PORT_WRCONFIG_PMUXEN_Pos            16                                             /**< (PORT_WRCONFIG) Peripheral Multiplexer Enable Position */
+#define PORT_WRCONFIG_PMUXEN_Msk            (_U_(0x1) << PORT_WRCONFIG_PMUXEN_Pos)         /**< (PORT_WRCONFIG) Peripheral Multiplexer Enable Mask */
+#define PORT_WRCONFIG_PMUXEN                PORT_WRCONFIG_PMUXEN_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PORT_WRCONFIG_PMUXEN_Msk instead */
+#define PORT_WRCONFIG_INEN_Pos              17                                             /**< (PORT_WRCONFIG) Input Enable Position */
+#define PORT_WRCONFIG_INEN_Msk              (_U_(0x1) << PORT_WRCONFIG_INEN_Pos)           /**< (PORT_WRCONFIG) Input Enable Mask */
+#define PORT_WRCONFIG_INEN                  PORT_WRCONFIG_INEN_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PORT_WRCONFIG_INEN_Msk instead */
+#define PORT_WRCONFIG_PULLEN_Pos            18                                             /**< (PORT_WRCONFIG) Pull Enable Position */
+#define PORT_WRCONFIG_PULLEN_Msk            (_U_(0x1) << PORT_WRCONFIG_PULLEN_Pos)         /**< (PORT_WRCONFIG) Pull Enable Mask */
+#define PORT_WRCONFIG_PULLEN                PORT_WRCONFIG_PULLEN_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PORT_WRCONFIG_PULLEN_Msk instead */
+#define PORT_WRCONFIG_DRVSTR_Pos            22                                             /**< (PORT_WRCONFIG) Output Driver Strength Selection Position */
+#define PORT_WRCONFIG_DRVSTR_Msk            (_U_(0x1) << PORT_WRCONFIG_DRVSTR_Pos)         /**< (PORT_WRCONFIG) Output Driver Strength Selection Mask */
+#define PORT_WRCONFIG_DRVSTR                PORT_WRCONFIG_DRVSTR_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PORT_WRCONFIG_DRVSTR_Msk instead */
+#define PORT_WRCONFIG_PMUX_Pos              24                                             /**< (PORT_WRCONFIG) Peripheral Multiplexing Position */
+#define PORT_WRCONFIG_PMUX_Msk              (_U_(0xF) << PORT_WRCONFIG_PMUX_Pos)           /**< (PORT_WRCONFIG) Peripheral Multiplexing Mask */
+#define PORT_WRCONFIG_PMUX(value)           (PORT_WRCONFIG_PMUX_Msk & ((value) << PORT_WRCONFIG_PMUX_Pos))
+#define PORT_WRCONFIG_WRPMUX_Pos            28                                             /**< (PORT_WRCONFIG) Write PMUX Position */
+#define PORT_WRCONFIG_WRPMUX_Msk            (_U_(0x1) << PORT_WRCONFIG_WRPMUX_Pos)         /**< (PORT_WRCONFIG) Write PMUX Mask */
+#define PORT_WRCONFIG_WRPMUX                PORT_WRCONFIG_WRPMUX_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PORT_WRCONFIG_WRPMUX_Msk instead */
+#define PORT_WRCONFIG_WRPINCFG_Pos          30                                             /**< (PORT_WRCONFIG) Write PINCFG Position */
+#define PORT_WRCONFIG_WRPINCFG_Msk          (_U_(0x1) << PORT_WRCONFIG_WRPINCFG_Pos)       /**< (PORT_WRCONFIG) Write PINCFG Mask */
+#define PORT_WRCONFIG_WRPINCFG              PORT_WRCONFIG_WRPINCFG_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use PORT_WRCONFIG_WRPINCFG_Msk instead */
+#define PORT_WRCONFIG_HWSEL_Pos             31                                             /**< (PORT_WRCONFIG) Half-Word Select Position */
+#define PORT_WRCONFIG_HWSEL_Msk             (_U_(0x1) << PORT_WRCONFIG_HWSEL_Pos)          /**< (PORT_WRCONFIG) Half-Word Select Mask */
+#define PORT_WRCONFIG_HWSEL                 PORT_WRCONFIG_HWSEL_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PORT_WRCONFIG_HWSEL_Msk instead */
+#define PORT_WRCONFIG_Msk                   _U_(0xDF47FFFF)                                /**< (PORT_WRCONFIG) Register Mask  */
+
+
+/* -------- PORT_EVCTRL : (PORT Offset: 0x2c) (R/W 32) Event Input Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t PID0:5;                    /**< bit:   0..4  PORT Event Pin Identifier 0              */
+    uint32_t EVACT0:2;                  /**< bit:   5..6  PORT Event Action 0                      */
+    uint32_t PORTEI0:1;                 /**< bit:      7  PORT Event Input Enable 0                */
+    uint32_t PID1:5;                    /**< bit:  8..12  PORT Event Pin Identifier 1              */
+    uint32_t EVACT1:2;                  /**< bit: 13..14  PORT Event Action 1                      */
+    uint32_t PORTEI1:1;                 /**< bit:     15  PORT Event Input Enable 1                */
+    uint32_t PID2:5;                    /**< bit: 16..20  PORT Event Pin Identifier 2              */
+    uint32_t EVACT2:2;                  /**< bit: 21..22  PORT Event Action 2                      */
+    uint32_t PORTEI2:1;                 /**< bit:     23  PORT Event Input Enable 2                */
+    uint32_t PID3:5;                    /**< bit: 24..28  PORT Event Pin Identifier 3              */
+    uint32_t EVACT3:2;                  /**< bit: 29..30  PORT Event Action 3                      */
+    uint32_t PORTEI3:1;                 /**< bit:     31  PORT Event Input Enable 3                */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PORT_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_EVCTRL_OFFSET                  (0x2C)                                        /**<  (PORT_EVCTRL) Event Input Control  Offset */
+#define PORT_EVCTRL_RESETVALUE              _U_(0x00)                                     /**<  (PORT_EVCTRL) Event Input Control  Reset Value */
+
+#define PORT_EVCTRL_PID0_Pos                0                                              /**< (PORT_EVCTRL) PORT Event Pin Identifier 0 Position */
+#define PORT_EVCTRL_PID0_Msk                (_U_(0x1F) << PORT_EVCTRL_PID0_Pos)            /**< (PORT_EVCTRL) PORT Event Pin Identifier 0 Mask */
+#define PORT_EVCTRL_PID0(value)             (PORT_EVCTRL_PID0_Msk & ((value) << PORT_EVCTRL_PID0_Pos))
+#define PORT_EVCTRL_EVACT0_Pos              5                                              /**< (PORT_EVCTRL) PORT Event Action 0 Position */
+#define PORT_EVCTRL_EVACT0_Msk              (_U_(0x3) << PORT_EVCTRL_EVACT0_Pos)           /**< (PORT_EVCTRL) PORT Event Action 0 Mask */
+#define PORT_EVCTRL_EVACT0(value)           (PORT_EVCTRL_EVACT0_Msk & ((value) << PORT_EVCTRL_EVACT0_Pos))
+#define   PORT_EVCTRL_EVACT0_OUT_Val        _U_(0x0)                                       /**< (PORT_EVCTRL) Event output to pin  */
+#define   PORT_EVCTRL_EVACT0_SET_Val        _U_(0x1)                                       /**< (PORT_EVCTRL) Set output register of pin on event  */
+#define   PORT_EVCTRL_EVACT0_CLR_Val        _U_(0x2)                                       /**< (PORT_EVCTRL) Clear output register of pin on event  */
+#define   PORT_EVCTRL_EVACT0_TGL_Val        _U_(0x3)                                       /**< (PORT_EVCTRL) Toggle output register of pin on event  */
+#define PORT_EVCTRL_EVACT0_OUT              (PORT_EVCTRL_EVACT0_OUT_Val << PORT_EVCTRL_EVACT0_Pos)  /**< (PORT_EVCTRL) Event output to pin Position  */
+#define PORT_EVCTRL_EVACT0_SET              (PORT_EVCTRL_EVACT0_SET_Val << PORT_EVCTRL_EVACT0_Pos)  /**< (PORT_EVCTRL) Set output register of pin on event Position  */
+#define PORT_EVCTRL_EVACT0_CLR              (PORT_EVCTRL_EVACT0_CLR_Val << PORT_EVCTRL_EVACT0_Pos)  /**< (PORT_EVCTRL) Clear output register of pin on event Position  */
+#define PORT_EVCTRL_EVACT0_TGL              (PORT_EVCTRL_EVACT0_TGL_Val << PORT_EVCTRL_EVACT0_Pos)  /**< (PORT_EVCTRL) Toggle output register of pin on event Position  */
+#define PORT_EVCTRL_PORTEI0_Pos             7                                              /**< (PORT_EVCTRL) PORT Event Input Enable 0 Position */
+#define PORT_EVCTRL_PORTEI0_Msk             (_U_(0x1) << PORT_EVCTRL_PORTEI0_Pos)          /**< (PORT_EVCTRL) PORT Event Input Enable 0 Mask */
+#define PORT_EVCTRL_PORTEI0                 PORT_EVCTRL_PORTEI0_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PORT_EVCTRL_PORTEI0_Msk instead */
+#define PORT_EVCTRL_PID1_Pos                8                                              /**< (PORT_EVCTRL) PORT Event Pin Identifier 1 Position */
+#define PORT_EVCTRL_PID1_Msk                (_U_(0x1F) << PORT_EVCTRL_PID1_Pos)            /**< (PORT_EVCTRL) PORT Event Pin Identifier 1 Mask */
+#define PORT_EVCTRL_PID1(value)             (PORT_EVCTRL_PID1_Msk & ((value) << PORT_EVCTRL_PID1_Pos))
+#define PORT_EVCTRL_EVACT1_Pos              13                                             /**< (PORT_EVCTRL) PORT Event Action 1 Position */
+#define PORT_EVCTRL_EVACT1_Msk              (_U_(0x3) << PORT_EVCTRL_EVACT1_Pos)           /**< (PORT_EVCTRL) PORT Event Action 1 Mask */
+#define PORT_EVCTRL_EVACT1(value)           (PORT_EVCTRL_EVACT1_Msk & ((value) << PORT_EVCTRL_EVACT1_Pos))
+#define PORT_EVCTRL_PORTEI1_Pos             15                                             /**< (PORT_EVCTRL) PORT Event Input Enable 1 Position */
+#define PORT_EVCTRL_PORTEI1_Msk             (_U_(0x1) << PORT_EVCTRL_PORTEI1_Pos)          /**< (PORT_EVCTRL) PORT Event Input Enable 1 Mask */
+#define PORT_EVCTRL_PORTEI1                 PORT_EVCTRL_PORTEI1_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PORT_EVCTRL_PORTEI1_Msk instead */
+#define PORT_EVCTRL_PID2_Pos                16                                             /**< (PORT_EVCTRL) PORT Event Pin Identifier 2 Position */
+#define PORT_EVCTRL_PID2_Msk                (_U_(0x1F) << PORT_EVCTRL_PID2_Pos)            /**< (PORT_EVCTRL) PORT Event Pin Identifier 2 Mask */
+#define PORT_EVCTRL_PID2(value)             (PORT_EVCTRL_PID2_Msk & ((value) << PORT_EVCTRL_PID2_Pos))
+#define PORT_EVCTRL_EVACT2_Pos              21                                             /**< (PORT_EVCTRL) PORT Event Action 2 Position */
+#define PORT_EVCTRL_EVACT2_Msk              (_U_(0x3) << PORT_EVCTRL_EVACT2_Pos)           /**< (PORT_EVCTRL) PORT Event Action 2 Mask */
+#define PORT_EVCTRL_EVACT2(value)           (PORT_EVCTRL_EVACT2_Msk & ((value) << PORT_EVCTRL_EVACT2_Pos))
+#define PORT_EVCTRL_PORTEI2_Pos             23                                             /**< (PORT_EVCTRL) PORT Event Input Enable 2 Position */
+#define PORT_EVCTRL_PORTEI2_Msk             (_U_(0x1) << PORT_EVCTRL_PORTEI2_Pos)          /**< (PORT_EVCTRL) PORT Event Input Enable 2 Mask */
+#define PORT_EVCTRL_PORTEI2                 PORT_EVCTRL_PORTEI2_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PORT_EVCTRL_PORTEI2_Msk instead */
+#define PORT_EVCTRL_PID3_Pos                24                                             /**< (PORT_EVCTRL) PORT Event Pin Identifier 3 Position */
+#define PORT_EVCTRL_PID3_Msk                (_U_(0x1F) << PORT_EVCTRL_PID3_Pos)            /**< (PORT_EVCTRL) PORT Event Pin Identifier 3 Mask */
+#define PORT_EVCTRL_PID3(value)             (PORT_EVCTRL_PID3_Msk & ((value) << PORT_EVCTRL_PID3_Pos))
+#define PORT_EVCTRL_EVACT3_Pos              29                                             /**< (PORT_EVCTRL) PORT Event Action 3 Position */
+#define PORT_EVCTRL_EVACT3_Msk              (_U_(0x3) << PORT_EVCTRL_EVACT3_Pos)           /**< (PORT_EVCTRL) PORT Event Action 3 Mask */
+#define PORT_EVCTRL_EVACT3(value)           (PORT_EVCTRL_EVACT3_Msk & ((value) << PORT_EVCTRL_EVACT3_Pos))
+#define PORT_EVCTRL_PORTEI3_Pos             31                                             /**< (PORT_EVCTRL) PORT Event Input Enable 3 Position */
+#define PORT_EVCTRL_PORTEI3_Msk             (_U_(0x1) << PORT_EVCTRL_PORTEI3_Pos)          /**< (PORT_EVCTRL) PORT Event Input Enable 3 Mask */
+#define PORT_EVCTRL_PORTEI3                 PORT_EVCTRL_PORTEI3_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PORT_EVCTRL_PORTEI3_Msk instead */
+#define PORT_EVCTRL_MASK                    _U_(0xFFFFFFFF)                                /**< \deprecated (PORT_EVCTRL) Register MASK  (Use PORT_EVCTRL_Msk instead)  */
+#define PORT_EVCTRL_Msk                     _U_(0xFFFFFFFF)                                /**< (PORT_EVCTRL) Register Mask  */
+
+
+/* -------- PORT_PMUX : (PORT Offset: 0x30) (R/W 8) Peripheral Multiplexing -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  PMUXE:4;                   /**< bit:   0..3  Peripheral Multiplexing for Even-Numbered Pin */
+    uint8_t  PMUXO:4;                   /**< bit:   4..7  Peripheral Multiplexing for Odd-Numbered Pin */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} PORT_PMUX_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_PMUX_OFFSET                    (0x30)                                        /**<  (PORT_PMUX) Peripheral Multiplexing  Offset */
+#define PORT_PMUX_RESETVALUE                _U_(0x00)                                     /**<  (PORT_PMUX) Peripheral Multiplexing  Reset Value */
+
+#define PORT_PMUX_PMUXE_Pos                 0                                              /**< (PORT_PMUX) Peripheral Multiplexing for Even-Numbered Pin Position */
+#define PORT_PMUX_PMUXE_Msk                 (_U_(0xF) << PORT_PMUX_PMUXE_Pos)              /**< (PORT_PMUX) Peripheral Multiplexing for Even-Numbered Pin Mask */
+#define PORT_PMUX_PMUXE(value)              (PORT_PMUX_PMUXE_Msk & ((value) << PORT_PMUX_PMUXE_Pos))
+#define PORT_PMUX_PMUXO_Pos                 4                                              /**< (PORT_PMUX) Peripheral Multiplexing for Odd-Numbered Pin Position */
+#define PORT_PMUX_PMUXO_Msk                 (_U_(0xF) << PORT_PMUX_PMUXO_Pos)              /**< (PORT_PMUX) Peripheral Multiplexing for Odd-Numbered Pin Mask */
+#define PORT_PMUX_PMUXO(value)              (PORT_PMUX_PMUXO_Msk & ((value) << PORT_PMUX_PMUXO_Pos))
+#define PORT_PMUX_MASK                      _U_(0xFF)                                      /**< \deprecated (PORT_PMUX) Register MASK  (Use PORT_PMUX_Msk instead)  */
+#define PORT_PMUX_Msk                       _U_(0xFF)                                      /**< (PORT_PMUX) Register Mask  */
+
+
+/* -------- PORT_PINCFG : (PORT Offset: 0x40) (R/W 8) Pin Configuration -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  PMUXEN:1;                  /**< bit:      0  Peripheral Multiplexer Enable            */
+    uint8_t  INEN:1;                    /**< bit:      1  Input Enable                             */
+    uint8_t  PULLEN:1;                  /**< bit:      2  Pull Enable                              */
+    uint8_t  :3;                        /**< bit:   3..5  Reserved */
+    uint8_t  DRVSTR:1;                  /**< bit:      6  Output Driver Strength Selection         */
+    uint8_t  :1;                        /**< bit:      7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} PORT_PINCFG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_PINCFG_OFFSET                  (0x40)                                        /**<  (PORT_PINCFG) Pin Configuration  Offset */
+#define PORT_PINCFG_RESETVALUE              _U_(0x00)                                     /**<  (PORT_PINCFG) Pin Configuration  Reset Value */
+
+#define PORT_PINCFG_PMUXEN_Pos              0                                              /**< (PORT_PINCFG) Peripheral Multiplexer Enable Position */
+#define PORT_PINCFG_PMUXEN_Msk              (_U_(0x1) << PORT_PINCFG_PMUXEN_Pos)           /**< (PORT_PINCFG) Peripheral Multiplexer Enable Mask */
+#define PORT_PINCFG_PMUXEN                  PORT_PINCFG_PMUXEN_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PORT_PINCFG_PMUXEN_Msk instead */
+#define PORT_PINCFG_INEN_Pos                1                                              /**< (PORT_PINCFG) Input Enable Position */
+#define PORT_PINCFG_INEN_Msk                (_U_(0x1) << PORT_PINCFG_INEN_Pos)             /**< (PORT_PINCFG) Input Enable Mask */
+#define PORT_PINCFG_INEN                    PORT_PINCFG_INEN_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PORT_PINCFG_INEN_Msk instead */
+#define PORT_PINCFG_PULLEN_Pos              2                                              /**< (PORT_PINCFG) Pull Enable Position */
+#define PORT_PINCFG_PULLEN_Msk              (_U_(0x1) << PORT_PINCFG_PULLEN_Pos)           /**< (PORT_PINCFG) Pull Enable Mask */
+#define PORT_PINCFG_PULLEN                  PORT_PINCFG_PULLEN_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PORT_PINCFG_PULLEN_Msk instead */
+#define PORT_PINCFG_DRVSTR_Pos              6                                              /**< (PORT_PINCFG) Output Driver Strength Selection Position */
+#define PORT_PINCFG_DRVSTR_Msk              (_U_(0x1) << PORT_PINCFG_DRVSTR_Pos)           /**< (PORT_PINCFG) Output Driver Strength Selection Mask */
+#define PORT_PINCFG_DRVSTR                  PORT_PINCFG_DRVSTR_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PORT_PINCFG_DRVSTR_Msk instead */
+#define PORT_PINCFG_MASK                    _U_(0x47)                                      /**< \deprecated (PORT_PINCFG) Register MASK  (Use PORT_PINCFG_Msk instead)  */
+#define PORT_PINCFG_Msk                     _U_(0x47)                                      /**< (PORT_PINCFG) Register Mask  */
+
+
+/* -------- PORT_INTENCLR : (PORT Offset: 0x60) (R/W 32) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t NSCHK:1;                   /**< bit:      0  Non-Secure Check Interrupt Enable        */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PORT_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_INTENCLR_OFFSET                (0x60)                                        /**<  (PORT_INTENCLR) Interrupt Enable Clear  Offset */
+#define PORT_INTENCLR_RESETVALUE            _U_(0x00)                                     /**<  (PORT_INTENCLR) Interrupt Enable Clear  Reset Value */
+
+#define PORT_INTENCLR_NSCHK_Pos             0                                              /**< (PORT_INTENCLR) Non-Secure Check Interrupt Enable Position */
+#define PORT_INTENCLR_NSCHK_Msk             (_U_(0x1) << PORT_INTENCLR_NSCHK_Pos)          /**< (PORT_INTENCLR) Non-Secure Check Interrupt Enable Mask */
+#define PORT_INTENCLR_NSCHK                 PORT_INTENCLR_NSCHK_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PORT_INTENCLR_NSCHK_Msk instead */
+#define PORT_INTENCLR_MASK                  _U_(0x01)                                      /**< \deprecated (PORT_INTENCLR) Register MASK  (Use PORT_INTENCLR_Msk instead)  */
+#define PORT_INTENCLR_Msk                   _U_(0x01)                                      /**< (PORT_INTENCLR) Register Mask  */
+
+
+/* -------- PORT_INTENSET : (PORT Offset: 0x64) (R/W 32) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t NSCHK:1;                   /**< bit:      0  Non-Secure Check Interrupt Enable        */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PORT_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_INTENSET_OFFSET                (0x64)                                        /**<  (PORT_INTENSET) Interrupt Enable Set  Offset */
+#define PORT_INTENSET_RESETVALUE            _U_(0x00)                                     /**<  (PORT_INTENSET) Interrupt Enable Set  Reset Value */
+
+#define PORT_INTENSET_NSCHK_Pos             0                                              /**< (PORT_INTENSET) Non-Secure Check Interrupt Enable Position */
+#define PORT_INTENSET_NSCHK_Msk             (_U_(0x1) << PORT_INTENSET_NSCHK_Pos)          /**< (PORT_INTENSET) Non-Secure Check Interrupt Enable Mask */
+#define PORT_INTENSET_NSCHK                 PORT_INTENSET_NSCHK_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PORT_INTENSET_NSCHK_Msk instead */
+#define PORT_INTENSET_MASK                  _U_(0x01)                                      /**< \deprecated (PORT_INTENSET) Register MASK  (Use PORT_INTENSET_Msk instead)  */
+#define PORT_INTENSET_Msk                   _U_(0x01)                                      /**< (PORT_INTENSET) Register Mask  */
+
+
+/* -------- PORT_INTFLAG : (PORT Offset: 0x68) (R/W 32) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint32_t NSCHK:1;                   /**< bit:      0  Non-Secure Check                         */
+    __I uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PORT_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_INTFLAG_OFFSET                 (0x68)                                        /**<  (PORT_INTFLAG) Interrupt Flag Status and Clear  Offset */
+#define PORT_INTFLAG_RESETVALUE             _U_(0x00)                                     /**<  (PORT_INTFLAG) Interrupt Flag Status and Clear  Reset Value */
+
+#define PORT_INTFLAG_NSCHK_Pos              0                                              /**< (PORT_INTFLAG) Non-Secure Check Position */
+#define PORT_INTFLAG_NSCHK_Msk              (_U_(0x1) << PORT_INTFLAG_NSCHK_Pos)           /**< (PORT_INTFLAG) Non-Secure Check Mask */
+#define PORT_INTFLAG_NSCHK                  PORT_INTFLAG_NSCHK_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PORT_INTFLAG_NSCHK_Msk instead */
+#define PORT_INTFLAG_MASK                   _U_(0x01)                                      /**< \deprecated (PORT_INTFLAG) Register MASK  (Use PORT_INTFLAG_Msk instead)  */
+#define PORT_INTFLAG_Msk                    _U_(0x01)                                      /**< (PORT_INTFLAG) Register Mask  */
+
+
+/* -------- PORT_NONSEC : (PORT Offset: 0x6c) (R/W 32) Security Attribution -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t NONSEC:32;                 /**< bit:  0..31  Port Security Attribution                */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PORT_NONSEC_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_NONSEC_OFFSET                  (0x6C)                                        /**<  (PORT_NONSEC) Security Attribution  Offset */
+#define PORT_NONSEC_RESETVALUE              _U_(0x00)                                     /**<  (PORT_NONSEC) Security Attribution  Reset Value */
+
+#define PORT_NONSEC_NONSEC_Pos              0                                              /**< (PORT_NONSEC) Port Security Attribution Position */
+#define PORT_NONSEC_NONSEC_Msk              (_U_(0xFFFFFFFF) << PORT_NONSEC_NONSEC_Pos)    /**< (PORT_NONSEC) Port Security Attribution Mask */
+#define PORT_NONSEC_NONSEC(value)           (PORT_NONSEC_NONSEC_Msk & ((value) << PORT_NONSEC_NONSEC_Pos))
+#define PORT_NONSEC_MASK                    _U_(0xFFFFFFFF)                                /**< \deprecated (PORT_NONSEC) Register MASK  (Use PORT_NONSEC_Msk instead)  */
+#define PORT_NONSEC_Msk                     _U_(0xFFFFFFFF)                                /**< (PORT_NONSEC) Register Mask  */
+
+
+/* -------- PORT_NSCHK : (PORT Offset: 0x70) (R/W 32) Security Attribution Check -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t NSCHK:32;                  /**< bit:  0..31  Port Security Attribution Check          */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PORT_NSCHK_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_NSCHK_OFFSET                   (0x70)                                        /**<  (PORT_NSCHK) Security Attribution Check  Offset */
+#define PORT_NSCHK_RESETVALUE               _U_(0x00)                                     /**<  (PORT_NSCHK) Security Attribution Check  Reset Value */
+
+#define PORT_NSCHK_NSCHK_Pos                0                                              /**< (PORT_NSCHK) Port Security Attribution Check Position */
+#define PORT_NSCHK_NSCHK_Msk                (_U_(0xFFFFFFFF) << PORT_NSCHK_NSCHK_Pos)      /**< (PORT_NSCHK) Port Security Attribution Check Mask */
+#define PORT_NSCHK_NSCHK(value)             (PORT_NSCHK_NSCHK_Msk & ((value) << PORT_NSCHK_NSCHK_Pos))
+#define PORT_NSCHK_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (PORT_NSCHK) Register MASK  (Use PORT_NSCHK_Msk instead)  */
+#define PORT_NSCHK_Msk                      _U_(0xFFFFFFFF)                                /**< (PORT_NSCHK) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief GROUP hardware registers */
+typedef struct {  
+  __IO PORT_DIR_Type                  DIR;            /**< Offset: 0x00 (R/W  32) Data Direction */
+  __IO PORT_DIRCLR_Type               DIRCLR;         /**< Offset: 0x04 (R/W  32) Data Direction Clear */
+  __IO PORT_DIRSET_Type               DIRSET;         /**< Offset: 0x08 (R/W  32) Data Direction Set */
+  __IO PORT_DIRTGL_Type               DIRTGL;         /**< Offset: 0x0C (R/W  32) Data Direction Toggle */
+  __IO PORT_OUT_Type                  OUT;            /**< Offset: 0x10 (R/W  32) Data Output Value */
+  __IO PORT_OUTCLR_Type               OUTCLR;         /**< Offset: 0x14 (R/W  32) Data Output Value Clear */
+  __IO PORT_OUTSET_Type               OUTSET;         /**< Offset: 0x18 (R/W  32) Data Output Value Set */
+  __IO PORT_OUTTGL_Type               OUTTGL;         /**< Offset: 0x1C (R/W  32) Data Output Value Toggle */
+  __I  PORT_IN_Type                   IN;             /**< Offset: 0x20 (R/   32) Data Input Value */
+  __IO PORT_CTRL_Type                 CTRL;           /**< Offset: 0x24 (R/W  32) Control */
+  __O  PORT_WRCONFIG_Type             WRCONFIG;       /**< Offset: 0x28 ( /W  32) Write Configuration */
+  __IO PORT_EVCTRL_Type               EVCTRL;         /**< Offset: 0x2C (R/W  32) Event Input Control */
+  __IO PORT_PMUX_Type                 PMUX[16];       /**< Offset: 0x30 (R/W   8) Peripheral Multiplexing */
+  __IO PORT_PINCFG_Type               PINCFG[32];     /**< Offset: 0x40 (R/W   8) Pin Configuration */
+  __IO PORT_INTENCLR_Type             INTENCLR;       /**< Offset: 0x60 (R/W  32) Interrupt Enable Clear */
+  __IO PORT_INTENSET_Type             INTENSET;       /**< Offset: 0x64 (R/W  32) Interrupt Enable Set */
+  __IO PORT_INTFLAG_Type              INTFLAG;        /**< Offset: 0x68 (R/W  32) Interrupt Flag Status and Clear */
+  __IO PORT_NONSEC_Type               NONSEC;         /**< Offset: 0x6C (R/W  32) Security Attribution */
+  __IO PORT_NSCHK_Type                NSCHK;          /**< Offset: 0x70 (R/W  32) Security Attribution Check */
+  __I  uint8_t                        Reserved1[12];
+} PortGroup;
+
+/** \brief PORT hardware registers */
+typedef struct {  /* Port Module */
+       PortGroup                      Group[1];       /**< Offset: 0x00  */
+} Port;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Port Module */
+
+#endif /* _SAML11_PORT_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/component/ptc.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/ptc.h
@@ -1,0 +1,53 @@
+/**
+ * \file
+ *
+ * \brief Component description for PTC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_PTC_COMPONENT_H_
+#define _SAML11_PTC_COMPONENT_H_
+#define _SAML11_PTC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML11 Peripheral Touch Controller
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR PTC */
+/* ========================================================================== */
+
+#define PTC_U2215                      /**< (PTC) Module ID */
+#define REV_PTC 0x500                  /**< (PTC) Module revision */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief No hardware registers defined for PTC */
+typedef void Ptc;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Peripheral Touch Controller */
+
+#endif /* _SAML11_PTC_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/component/rstc.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/rstc.h
@@ -1,0 +1,96 @@
+/**
+ * \file
+ *
+ * \brief Component description for RSTC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_RSTC_COMPONENT_H_
+#define _SAML11_RSTC_COMPONENT_H_
+#define _SAML11_RSTC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML11 Reset Controller
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR RSTC */
+/* ========================================================================== */
+
+#define RSTC_U2239                      /**< (RSTC) Module ID */
+#define REV_RSTC 0x300                  /**< (RSTC) Module revision */
+
+/* -------- RSTC_RCAUSE : (RSTC Offset: 0x00) (R/ 8) Reset Cause -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  POR:1;                     /**< bit:      0  Power On Reset                           */
+    uint8_t  BODCORE:1;                 /**< bit:      1  Brown Out CORE Detector Reset            */
+    uint8_t  BODVDD:1;                  /**< bit:      2  Brown Out VDD Detector Reset             */
+    uint8_t  :1;                        /**< bit:      3  Reserved */
+    uint8_t  EXT:1;                     /**< bit:      4  External Reset                           */
+    uint8_t  WDT:1;                     /**< bit:      5  Watchdog Reset                           */
+    uint8_t  SYST:1;                    /**< bit:      6  System Reset Request                     */
+    uint8_t  :1;                        /**< bit:      7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} RSTC_RCAUSE_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RSTC_RCAUSE_OFFSET                  (0x00)                                        /**<  (RSTC_RCAUSE) Reset Cause  Offset */
+
+#define RSTC_RCAUSE_POR_Pos                 0                                              /**< (RSTC_RCAUSE) Power On Reset Position */
+#define RSTC_RCAUSE_POR_Msk                 (_U_(0x1) << RSTC_RCAUSE_POR_Pos)              /**< (RSTC_RCAUSE) Power On Reset Mask */
+#define RSTC_RCAUSE_POR                     RSTC_RCAUSE_POR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use RSTC_RCAUSE_POR_Msk instead */
+#define RSTC_RCAUSE_BODCORE_Pos             1                                              /**< (RSTC_RCAUSE) Brown Out CORE Detector Reset Position */
+#define RSTC_RCAUSE_BODCORE_Msk             (_U_(0x1) << RSTC_RCAUSE_BODCORE_Pos)          /**< (RSTC_RCAUSE) Brown Out CORE Detector Reset Mask */
+#define RSTC_RCAUSE_BODCORE                 RSTC_RCAUSE_BODCORE_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use RSTC_RCAUSE_BODCORE_Msk instead */
+#define RSTC_RCAUSE_BODVDD_Pos              2                                              /**< (RSTC_RCAUSE) Brown Out VDD Detector Reset Position */
+#define RSTC_RCAUSE_BODVDD_Msk              (_U_(0x1) << RSTC_RCAUSE_BODVDD_Pos)           /**< (RSTC_RCAUSE) Brown Out VDD Detector Reset Mask */
+#define RSTC_RCAUSE_BODVDD                  RSTC_RCAUSE_BODVDD_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use RSTC_RCAUSE_BODVDD_Msk instead */
+#define RSTC_RCAUSE_EXT_Pos                 4                                              /**< (RSTC_RCAUSE) External Reset Position */
+#define RSTC_RCAUSE_EXT_Msk                 (_U_(0x1) << RSTC_RCAUSE_EXT_Pos)              /**< (RSTC_RCAUSE) External Reset Mask */
+#define RSTC_RCAUSE_EXT                     RSTC_RCAUSE_EXT_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use RSTC_RCAUSE_EXT_Msk instead */
+#define RSTC_RCAUSE_WDT_Pos                 5                                              /**< (RSTC_RCAUSE) Watchdog Reset Position */
+#define RSTC_RCAUSE_WDT_Msk                 (_U_(0x1) << RSTC_RCAUSE_WDT_Pos)              /**< (RSTC_RCAUSE) Watchdog Reset Mask */
+#define RSTC_RCAUSE_WDT                     RSTC_RCAUSE_WDT_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use RSTC_RCAUSE_WDT_Msk instead */
+#define RSTC_RCAUSE_SYST_Pos                6                                              /**< (RSTC_RCAUSE) System Reset Request Position */
+#define RSTC_RCAUSE_SYST_Msk                (_U_(0x1) << RSTC_RCAUSE_SYST_Pos)             /**< (RSTC_RCAUSE) System Reset Request Mask */
+#define RSTC_RCAUSE_SYST                    RSTC_RCAUSE_SYST_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use RSTC_RCAUSE_SYST_Msk instead */
+#define RSTC_RCAUSE_MASK                    _U_(0x77)                                      /**< \deprecated (RSTC_RCAUSE) Register MASK  (Use RSTC_RCAUSE_Msk instead)  */
+#define RSTC_RCAUSE_Msk                     _U_(0x77)                                      /**< (RSTC_RCAUSE) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief RSTC hardware registers */
+typedef struct {  /* Reset Controller */
+  __I  RSTC_RCAUSE_Type               RCAUSE;         /**< Offset: 0x00 (R/    8) Reset Cause */
+} Rstc;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Reset Controller */
+
+#endif /* _SAML11_RSTC_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/component/rtc.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/rtc.h
@@ -1,0 +1,2294 @@
+/**
+ * \file
+ *
+ * \brief Component description for RTC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_RTC_COMPONENT_H_
+#define _SAML11_RTC_COMPONENT_H_
+#define _SAML11_RTC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML11 Real-Time Counter
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR RTC */
+/* ========================================================================== */
+
+#define RTC_U2250                      /**< (RTC) Module ID */
+#define REV_RTC 0x300                  /**< (RTC) Module revision */
+
+/* -------- RTC_MODE2_ALARM : (RTC Offset: 0x00) (R/W 32) MODE2_ALARM Alarm n Value -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SECOND:6;                  /**< bit:   0..5  Second                                   */
+    uint32_t MINUTE:6;                  /**< bit:  6..11  Minute                                   */
+    uint32_t HOUR:5;                    /**< bit: 12..16  Hour                                     */
+    uint32_t DAY:5;                     /**< bit: 17..21  Day                                      */
+    uint32_t MONTH:4;                   /**< bit: 22..25  Month                                    */
+    uint32_t YEAR:6;                    /**< bit: 26..31  Year                                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_MODE2_ALARM_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE2_ALARM_OFFSET              (0x00)                                        /**<  (RTC_MODE2_ALARM) MODE2_ALARM Alarm n Value  Offset */
+#define RTC_MODE2_ALARM_RESETVALUE          _U_(0x00)                                     /**<  (RTC_MODE2_ALARM) MODE2_ALARM Alarm n Value  Reset Value */
+
+#define RTC_MODE2_ALARM_SECOND_Pos          0                                              /**< (RTC_MODE2_ALARM) Second Position */
+#define RTC_MODE2_ALARM_SECOND_Msk          (_U_(0x3F) << RTC_MODE2_ALARM_SECOND_Pos)      /**< (RTC_MODE2_ALARM) Second Mask */
+#define RTC_MODE2_ALARM_SECOND(value)       (RTC_MODE2_ALARM_SECOND_Msk & ((value) << RTC_MODE2_ALARM_SECOND_Pos))
+#define RTC_MODE2_ALARM_MINUTE_Pos          6                                              /**< (RTC_MODE2_ALARM) Minute Position */
+#define RTC_MODE2_ALARM_MINUTE_Msk          (_U_(0x3F) << RTC_MODE2_ALARM_MINUTE_Pos)      /**< (RTC_MODE2_ALARM) Minute Mask */
+#define RTC_MODE2_ALARM_MINUTE(value)       (RTC_MODE2_ALARM_MINUTE_Msk & ((value) << RTC_MODE2_ALARM_MINUTE_Pos))
+#define RTC_MODE2_ALARM_HOUR_Pos            12                                             /**< (RTC_MODE2_ALARM) Hour Position */
+#define RTC_MODE2_ALARM_HOUR_Msk            (_U_(0x1F) << RTC_MODE2_ALARM_HOUR_Pos)        /**< (RTC_MODE2_ALARM) Hour Mask */
+#define RTC_MODE2_ALARM_HOUR(value)         (RTC_MODE2_ALARM_HOUR_Msk & ((value) << RTC_MODE2_ALARM_HOUR_Pos))
+#define   RTC_MODE2_ALARM_HOUR_AM_Val       _U_(0x0)                                       /**< (RTC_MODE2_ALARM) Morning hour  */
+#define   RTC_MODE2_ALARM_HOUR_PM_Val       _U_(0x10)                                      /**< (RTC_MODE2_ALARM) Afternoon hour  */
+#define RTC_MODE2_ALARM_HOUR_AM             (RTC_MODE2_ALARM_HOUR_AM_Val << RTC_MODE2_ALARM_HOUR_Pos)  /**< (RTC_MODE2_ALARM) Morning hour Position  */
+#define RTC_MODE2_ALARM_HOUR_PM             (RTC_MODE2_ALARM_HOUR_PM_Val << RTC_MODE2_ALARM_HOUR_Pos)  /**< (RTC_MODE2_ALARM) Afternoon hour Position  */
+#define RTC_MODE2_ALARM_DAY_Pos             17                                             /**< (RTC_MODE2_ALARM) Day Position */
+#define RTC_MODE2_ALARM_DAY_Msk             (_U_(0x1F) << RTC_MODE2_ALARM_DAY_Pos)         /**< (RTC_MODE2_ALARM) Day Mask */
+#define RTC_MODE2_ALARM_DAY(value)          (RTC_MODE2_ALARM_DAY_Msk & ((value) << RTC_MODE2_ALARM_DAY_Pos))
+#define RTC_MODE2_ALARM_MONTH_Pos           22                                             /**< (RTC_MODE2_ALARM) Month Position */
+#define RTC_MODE2_ALARM_MONTH_Msk           (_U_(0xF) << RTC_MODE2_ALARM_MONTH_Pos)        /**< (RTC_MODE2_ALARM) Month Mask */
+#define RTC_MODE2_ALARM_MONTH(value)        (RTC_MODE2_ALARM_MONTH_Msk & ((value) << RTC_MODE2_ALARM_MONTH_Pos))
+#define RTC_MODE2_ALARM_YEAR_Pos            26                                             /**< (RTC_MODE2_ALARM) Year Position */
+#define RTC_MODE2_ALARM_YEAR_Msk            (_U_(0x3F) << RTC_MODE2_ALARM_YEAR_Pos)        /**< (RTC_MODE2_ALARM) Year Mask */
+#define RTC_MODE2_ALARM_YEAR(value)         (RTC_MODE2_ALARM_YEAR_Msk & ((value) << RTC_MODE2_ALARM_YEAR_Pos))
+#define RTC_MODE2_ALARM_MASK                _U_(0xFFFFFFFF)                                /**< \deprecated (RTC_MODE2_ALARM) Register MASK  (Use RTC_MODE2_ALARM_Msk instead)  */
+#define RTC_MODE2_ALARM_Msk                 _U_(0xFFFFFFFF)                                /**< (RTC_MODE2_ALARM) Register Mask  */
+
+
+/* -------- RTC_MODE2_MASK : (RTC Offset: 0x04) (R/W 8) MODE2_ALARM Alarm n Mask -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  SEL:3;                     /**< bit:   0..2  Alarm Mask Selection                     */
+    uint8_t  :5;                        /**< bit:   3..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} RTC_MODE2_MASK_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE2_MASK_OFFSET               (0x04)                                        /**<  (RTC_MODE2_MASK) MODE2_ALARM Alarm n Mask  Offset */
+#define RTC_MODE2_MASK_RESETVALUE           _U_(0x00)                                     /**<  (RTC_MODE2_MASK) MODE2_ALARM Alarm n Mask  Reset Value */
+
+#define RTC_MODE2_MASK_SEL_Pos              0                                              /**< (RTC_MODE2_MASK) Alarm Mask Selection Position */
+#define RTC_MODE2_MASK_SEL_Msk              (_U_(0x7) << RTC_MODE2_MASK_SEL_Pos)           /**< (RTC_MODE2_MASK) Alarm Mask Selection Mask */
+#define RTC_MODE2_MASK_SEL(value)           (RTC_MODE2_MASK_SEL_Msk & ((value) << RTC_MODE2_MASK_SEL_Pos))
+#define   RTC_MODE2_MASK_SEL_OFF_Val        _U_(0x0)                                       /**< (RTC_MODE2_MASK) Alarm Disabled  */
+#define   RTC_MODE2_MASK_SEL_SS_Val         _U_(0x1)                                       /**< (RTC_MODE2_MASK) Match seconds only  */
+#define   RTC_MODE2_MASK_SEL_MMSS_Val       _U_(0x2)                                       /**< (RTC_MODE2_MASK) Match seconds and minutes only  */
+#define   RTC_MODE2_MASK_SEL_HHMMSS_Val     _U_(0x3)                                       /**< (RTC_MODE2_MASK) Match seconds, minutes, and hours only  */
+#define   RTC_MODE2_MASK_SEL_DDHHMMSS_Val   _U_(0x4)                                       /**< (RTC_MODE2_MASK) Match seconds, minutes, hours, and days only  */
+#define   RTC_MODE2_MASK_SEL_MMDDHHMMSS_Val _U_(0x5)                                       /**< (RTC_MODE2_MASK) Match seconds, minutes, hours, days, and months only  */
+#define   RTC_MODE2_MASK_SEL_YYMMDDHHMMSS_Val _U_(0x6)                                       /**< (RTC_MODE2_MASK) Match seconds, minutes, hours, days, months, and years  */
+#define RTC_MODE2_MASK_SEL_OFF              (RTC_MODE2_MASK_SEL_OFF_Val << RTC_MODE2_MASK_SEL_Pos)  /**< (RTC_MODE2_MASK) Alarm Disabled Position  */
+#define RTC_MODE2_MASK_SEL_SS               (RTC_MODE2_MASK_SEL_SS_Val << RTC_MODE2_MASK_SEL_Pos)  /**< (RTC_MODE2_MASK) Match seconds only Position  */
+#define RTC_MODE2_MASK_SEL_MMSS             (RTC_MODE2_MASK_SEL_MMSS_Val << RTC_MODE2_MASK_SEL_Pos)  /**< (RTC_MODE2_MASK) Match seconds and minutes only Position  */
+#define RTC_MODE2_MASK_SEL_HHMMSS           (RTC_MODE2_MASK_SEL_HHMMSS_Val << RTC_MODE2_MASK_SEL_Pos)  /**< (RTC_MODE2_MASK) Match seconds, minutes, and hours only Position  */
+#define RTC_MODE2_MASK_SEL_DDHHMMSS         (RTC_MODE2_MASK_SEL_DDHHMMSS_Val << RTC_MODE2_MASK_SEL_Pos)  /**< (RTC_MODE2_MASK) Match seconds, minutes, hours, and days only Position  */
+#define RTC_MODE2_MASK_SEL_MMDDHHMMSS       (RTC_MODE2_MASK_SEL_MMDDHHMMSS_Val << RTC_MODE2_MASK_SEL_Pos)  /**< (RTC_MODE2_MASK) Match seconds, minutes, hours, days, and months only Position  */
+#define RTC_MODE2_MASK_SEL_YYMMDDHHMMSS     (RTC_MODE2_MASK_SEL_YYMMDDHHMMSS_Val << RTC_MODE2_MASK_SEL_Pos)  /**< (RTC_MODE2_MASK) Match seconds, minutes, hours, days, months, and years Position  */
+#define RTC_MODE2_MASK_MASK                 _U_(0x07)                                      /**< \deprecated (RTC_MODE2_MASK) Register MASK  (Use RTC_MODE2_MASK_Msk instead)  */
+#define RTC_MODE2_MASK_Msk                  _U_(0x07)                                      /**< (RTC_MODE2_MASK) Register Mask  */
+
+
+/* -------- RTC_MODE0_CTRLA : (RTC Offset: 0x00) (R/W 16) MODE0 Control A -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint16_t ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint16_t MODE:2;                    /**< bit:   2..3  Operating Mode                           */
+    uint16_t :3;                        /**< bit:   4..6  Reserved */
+    uint16_t MATCHCLR:1;                /**< bit:      7  Clear on Match                           */
+    uint16_t PRESCALER:4;               /**< bit:  8..11  Prescaler                                */
+    uint16_t :2;                        /**< bit: 12..13  Reserved */
+    uint16_t GPTRST:1;                  /**< bit:     14  GP Registers Reset On Tamper Enable      */
+    uint16_t COUNTSYNC:1;               /**< bit:     15  Count Read Synchronization Enable        */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} RTC_MODE0_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE0_CTRLA_OFFSET              (0x00)                                        /**<  (RTC_MODE0_CTRLA) MODE0 Control A  Offset */
+#define RTC_MODE0_CTRLA_RESETVALUE          _U_(0x00)                                     /**<  (RTC_MODE0_CTRLA) MODE0 Control A  Reset Value */
+
+#define RTC_MODE0_CTRLA_SWRST_Pos           0                                              /**< (RTC_MODE0_CTRLA) Software Reset Position */
+#define RTC_MODE0_CTRLA_SWRST_Msk           (_U_(0x1) << RTC_MODE0_CTRLA_SWRST_Pos)        /**< (RTC_MODE0_CTRLA) Software Reset Mask */
+#define RTC_MODE0_CTRLA_SWRST               RTC_MODE0_CTRLA_SWRST_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_CTRLA_SWRST_Msk instead */
+#define RTC_MODE0_CTRLA_ENABLE_Pos          1                                              /**< (RTC_MODE0_CTRLA) Enable Position */
+#define RTC_MODE0_CTRLA_ENABLE_Msk          (_U_(0x1) << RTC_MODE0_CTRLA_ENABLE_Pos)       /**< (RTC_MODE0_CTRLA) Enable Mask */
+#define RTC_MODE0_CTRLA_ENABLE              RTC_MODE0_CTRLA_ENABLE_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_CTRLA_ENABLE_Msk instead */
+#define RTC_MODE0_CTRLA_MODE_Pos            2                                              /**< (RTC_MODE0_CTRLA) Operating Mode Position */
+#define RTC_MODE0_CTRLA_MODE_Msk            (_U_(0x3) << RTC_MODE0_CTRLA_MODE_Pos)         /**< (RTC_MODE0_CTRLA) Operating Mode Mask */
+#define RTC_MODE0_CTRLA_MODE(value)         (RTC_MODE0_CTRLA_MODE_Msk & ((value) << RTC_MODE0_CTRLA_MODE_Pos))
+#define   RTC_MODE0_CTRLA_MODE_COUNT32_Val  _U_(0x0)                                       /**< (RTC_MODE0_CTRLA) Mode 0: 32-bit Counter  */
+#define   RTC_MODE0_CTRLA_MODE_COUNT16_Val  _U_(0x1)                                       /**< (RTC_MODE0_CTRLA) Mode 1: 16-bit Counter  */
+#define   RTC_MODE0_CTRLA_MODE_CLOCK_Val    _U_(0x2)                                       /**< (RTC_MODE0_CTRLA) Mode 2: Clock/Calendar  */
+#define RTC_MODE0_CTRLA_MODE_COUNT32        (RTC_MODE0_CTRLA_MODE_COUNT32_Val << RTC_MODE0_CTRLA_MODE_Pos)  /**< (RTC_MODE0_CTRLA) Mode 0: 32-bit Counter Position  */
+#define RTC_MODE0_CTRLA_MODE_COUNT16        (RTC_MODE0_CTRLA_MODE_COUNT16_Val << RTC_MODE0_CTRLA_MODE_Pos)  /**< (RTC_MODE0_CTRLA) Mode 1: 16-bit Counter Position  */
+#define RTC_MODE0_CTRLA_MODE_CLOCK          (RTC_MODE0_CTRLA_MODE_CLOCK_Val << RTC_MODE0_CTRLA_MODE_Pos)  /**< (RTC_MODE0_CTRLA) Mode 2: Clock/Calendar Position  */
+#define RTC_MODE0_CTRLA_MATCHCLR_Pos        7                                              /**< (RTC_MODE0_CTRLA) Clear on Match Position */
+#define RTC_MODE0_CTRLA_MATCHCLR_Msk        (_U_(0x1) << RTC_MODE0_CTRLA_MATCHCLR_Pos)     /**< (RTC_MODE0_CTRLA) Clear on Match Mask */
+#define RTC_MODE0_CTRLA_MATCHCLR            RTC_MODE0_CTRLA_MATCHCLR_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_CTRLA_MATCHCLR_Msk instead */
+#define RTC_MODE0_CTRLA_PRESCALER_Pos       8                                              /**< (RTC_MODE0_CTRLA) Prescaler Position */
+#define RTC_MODE0_CTRLA_PRESCALER_Msk       (_U_(0xF) << RTC_MODE0_CTRLA_PRESCALER_Pos)    /**< (RTC_MODE0_CTRLA) Prescaler Mask */
+#define RTC_MODE0_CTRLA_PRESCALER(value)    (RTC_MODE0_CTRLA_PRESCALER_Msk & ((value) << RTC_MODE0_CTRLA_PRESCALER_Pos))
+#define   RTC_MODE0_CTRLA_PRESCALER_OFF_Val _U_(0x0)                                       /**< (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/1  */
+#define   RTC_MODE0_CTRLA_PRESCALER_DIV1_Val _U_(0x1)                                       /**< (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/1  */
+#define   RTC_MODE0_CTRLA_PRESCALER_DIV2_Val _U_(0x2)                                       /**< (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/2  */
+#define   RTC_MODE0_CTRLA_PRESCALER_DIV4_Val _U_(0x3)                                       /**< (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/4  */
+#define   RTC_MODE0_CTRLA_PRESCALER_DIV8_Val _U_(0x4)                                       /**< (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/8  */
+#define   RTC_MODE0_CTRLA_PRESCALER_DIV16_Val _U_(0x5)                                       /**< (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/16  */
+#define   RTC_MODE0_CTRLA_PRESCALER_DIV32_Val _U_(0x6)                                       /**< (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/32  */
+#define   RTC_MODE0_CTRLA_PRESCALER_DIV64_Val _U_(0x7)                                       /**< (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/64  */
+#define   RTC_MODE0_CTRLA_PRESCALER_DIV128_Val _U_(0x8)                                       /**< (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/128  */
+#define   RTC_MODE0_CTRLA_PRESCALER_DIV256_Val _U_(0x9)                                       /**< (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/256  */
+#define   RTC_MODE0_CTRLA_PRESCALER_DIV512_Val _U_(0xA)                                       /**< (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/512  */
+#define   RTC_MODE0_CTRLA_PRESCALER_DIV1024_Val _U_(0xB)                                       /**< (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/1024  */
+#define RTC_MODE0_CTRLA_PRESCALER_OFF       (RTC_MODE0_CTRLA_PRESCALER_OFF_Val << RTC_MODE0_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/1 Position  */
+#define RTC_MODE0_CTRLA_PRESCALER_DIV1      (RTC_MODE0_CTRLA_PRESCALER_DIV1_Val << RTC_MODE0_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/1 Position  */
+#define RTC_MODE0_CTRLA_PRESCALER_DIV2      (RTC_MODE0_CTRLA_PRESCALER_DIV2_Val << RTC_MODE0_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/2 Position  */
+#define RTC_MODE0_CTRLA_PRESCALER_DIV4      (RTC_MODE0_CTRLA_PRESCALER_DIV4_Val << RTC_MODE0_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/4 Position  */
+#define RTC_MODE0_CTRLA_PRESCALER_DIV8      (RTC_MODE0_CTRLA_PRESCALER_DIV8_Val << RTC_MODE0_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/8 Position  */
+#define RTC_MODE0_CTRLA_PRESCALER_DIV16     (RTC_MODE0_CTRLA_PRESCALER_DIV16_Val << RTC_MODE0_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/16 Position  */
+#define RTC_MODE0_CTRLA_PRESCALER_DIV32     (RTC_MODE0_CTRLA_PRESCALER_DIV32_Val << RTC_MODE0_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/32 Position  */
+#define RTC_MODE0_CTRLA_PRESCALER_DIV64     (RTC_MODE0_CTRLA_PRESCALER_DIV64_Val << RTC_MODE0_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/64 Position  */
+#define RTC_MODE0_CTRLA_PRESCALER_DIV128    (RTC_MODE0_CTRLA_PRESCALER_DIV128_Val << RTC_MODE0_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/128 Position  */
+#define RTC_MODE0_CTRLA_PRESCALER_DIV256    (RTC_MODE0_CTRLA_PRESCALER_DIV256_Val << RTC_MODE0_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/256 Position  */
+#define RTC_MODE0_CTRLA_PRESCALER_DIV512    (RTC_MODE0_CTRLA_PRESCALER_DIV512_Val << RTC_MODE0_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/512 Position  */
+#define RTC_MODE0_CTRLA_PRESCALER_DIV1024   (RTC_MODE0_CTRLA_PRESCALER_DIV1024_Val << RTC_MODE0_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/1024 Position  */
+#define RTC_MODE0_CTRLA_GPTRST_Pos          14                                             /**< (RTC_MODE0_CTRLA) GP Registers Reset On Tamper Enable Position */
+#define RTC_MODE0_CTRLA_GPTRST_Msk          (_U_(0x1) << RTC_MODE0_CTRLA_GPTRST_Pos)       /**< (RTC_MODE0_CTRLA) GP Registers Reset On Tamper Enable Mask */
+#define RTC_MODE0_CTRLA_GPTRST              RTC_MODE0_CTRLA_GPTRST_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_CTRLA_GPTRST_Msk instead */
+#define RTC_MODE0_CTRLA_COUNTSYNC_Pos       15                                             /**< (RTC_MODE0_CTRLA) Count Read Synchronization Enable Position */
+#define RTC_MODE0_CTRLA_COUNTSYNC_Msk       (_U_(0x1) << RTC_MODE0_CTRLA_COUNTSYNC_Pos)    /**< (RTC_MODE0_CTRLA) Count Read Synchronization Enable Mask */
+#define RTC_MODE0_CTRLA_COUNTSYNC           RTC_MODE0_CTRLA_COUNTSYNC_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_CTRLA_COUNTSYNC_Msk instead */
+#define RTC_MODE0_CTRLA_MASK                _U_(0xCF8F)                                    /**< \deprecated (RTC_MODE0_CTRLA) Register MASK  (Use RTC_MODE0_CTRLA_Msk instead)  */
+#define RTC_MODE0_CTRLA_Msk                 _U_(0xCF8F)                                    /**< (RTC_MODE0_CTRLA) Register Mask  */
+
+
+/* -------- RTC_MODE1_CTRLA : (RTC Offset: 0x00) (R/W 16) MODE1 Control A -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint16_t ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint16_t MODE:2;                    /**< bit:   2..3  Operating Mode                           */
+    uint16_t :4;                        /**< bit:   4..7  Reserved */
+    uint16_t PRESCALER:4;               /**< bit:  8..11  Prescaler                                */
+    uint16_t :2;                        /**< bit: 12..13  Reserved */
+    uint16_t GPTRST:1;                  /**< bit:     14  GP Registers Reset On Tamper Enable      */
+    uint16_t COUNTSYNC:1;               /**< bit:     15  Count Read Synchronization Enable        */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} RTC_MODE1_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE1_CTRLA_OFFSET              (0x00)                                        /**<  (RTC_MODE1_CTRLA) MODE1 Control A  Offset */
+#define RTC_MODE1_CTRLA_RESETVALUE          _U_(0x00)                                     /**<  (RTC_MODE1_CTRLA) MODE1 Control A  Reset Value */
+
+#define RTC_MODE1_CTRLA_SWRST_Pos           0                                              /**< (RTC_MODE1_CTRLA) Software Reset Position */
+#define RTC_MODE1_CTRLA_SWRST_Msk           (_U_(0x1) << RTC_MODE1_CTRLA_SWRST_Pos)        /**< (RTC_MODE1_CTRLA) Software Reset Mask */
+#define RTC_MODE1_CTRLA_SWRST               RTC_MODE1_CTRLA_SWRST_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_CTRLA_SWRST_Msk instead */
+#define RTC_MODE1_CTRLA_ENABLE_Pos          1                                              /**< (RTC_MODE1_CTRLA) Enable Position */
+#define RTC_MODE1_CTRLA_ENABLE_Msk          (_U_(0x1) << RTC_MODE1_CTRLA_ENABLE_Pos)       /**< (RTC_MODE1_CTRLA) Enable Mask */
+#define RTC_MODE1_CTRLA_ENABLE              RTC_MODE1_CTRLA_ENABLE_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_CTRLA_ENABLE_Msk instead */
+#define RTC_MODE1_CTRLA_MODE_Pos            2                                              /**< (RTC_MODE1_CTRLA) Operating Mode Position */
+#define RTC_MODE1_CTRLA_MODE_Msk            (_U_(0x3) << RTC_MODE1_CTRLA_MODE_Pos)         /**< (RTC_MODE1_CTRLA) Operating Mode Mask */
+#define RTC_MODE1_CTRLA_MODE(value)         (RTC_MODE1_CTRLA_MODE_Msk & ((value) << RTC_MODE1_CTRLA_MODE_Pos))
+#define   RTC_MODE1_CTRLA_MODE_COUNT32_Val  _U_(0x0)                                       /**< (RTC_MODE1_CTRLA) Mode 0: 32-bit Counter  */
+#define   RTC_MODE1_CTRLA_MODE_COUNT16_Val  _U_(0x1)                                       /**< (RTC_MODE1_CTRLA) Mode 1: 16-bit Counter  */
+#define   RTC_MODE1_CTRLA_MODE_CLOCK_Val    _U_(0x2)                                       /**< (RTC_MODE1_CTRLA) Mode 2: Clock/Calendar  */
+#define RTC_MODE1_CTRLA_MODE_COUNT32        (RTC_MODE1_CTRLA_MODE_COUNT32_Val << RTC_MODE1_CTRLA_MODE_Pos)  /**< (RTC_MODE1_CTRLA) Mode 0: 32-bit Counter Position  */
+#define RTC_MODE1_CTRLA_MODE_COUNT16        (RTC_MODE1_CTRLA_MODE_COUNT16_Val << RTC_MODE1_CTRLA_MODE_Pos)  /**< (RTC_MODE1_CTRLA) Mode 1: 16-bit Counter Position  */
+#define RTC_MODE1_CTRLA_MODE_CLOCK          (RTC_MODE1_CTRLA_MODE_CLOCK_Val << RTC_MODE1_CTRLA_MODE_Pos)  /**< (RTC_MODE1_CTRLA) Mode 2: Clock/Calendar Position  */
+#define RTC_MODE1_CTRLA_PRESCALER_Pos       8                                              /**< (RTC_MODE1_CTRLA) Prescaler Position */
+#define RTC_MODE1_CTRLA_PRESCALER_Msk       (_U_(0xF) << RTC_MODE1_CTRLA_PRESCALER_Pos)    /**< (RTC_MODE1_CTRLA) Prescaler Mask */
+#define RTC_MODE1_CTRLA_PRESCALER(value)    (RTC_MODE1_CTRLA_PRESCALER_Msk & ((value) << RTC_MODE1_CTRLA_PRESCALER_Pos))
+#define   RTC_MODE1_CTRLA_PRESCALER_OFF_Val _U_(0x0)                                       /**< (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/1  */
+#define   RTC_MODE1_CTRLA_PRESCALER_DIV1_Val _U_(0x1)                                       /**< (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/1  */
+#define   RTC_MODE1_CTRLA_PRESCALER_DIV2_Val _U_(0x2)                                       /**< (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/2  */
+#define   RTC_MODE1_CTRLA_PRESCALER_DIV4_Val _U_(0x3)                                       /**< (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/4  */
+#define   RTC_MODE1_CTRLA_PRESCALER_DIV8_Val _U_(0x4)                                       /**< (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/8  */
+#define   RTC_MODE1_CTRLA_PRESCALER_DIV16_Val _U_(0x5)                                       /**< (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/16  */
+#define   RTC_MODE1_CTRLA_PRESCALER_DIV32_Val _U_(0x6)                                       /**< (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/32  */
+#define   RTC_MODE1_CTRLA_PRESCALER_DIV64_Val _U_(0x7)                                       /**< (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/64  */
+#define   RTC_MODE1_CTRLA_PRESCALER_DIV128_Val _U_(0x8)                                       /**< (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/128  */
+#define   RTC_MODE1_CTRLA_PRESCALER_DIV256_Val _U_(0x9)                                       /**< (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/256  */
+#define   RTC_MODE1_CTRLA_PRESCALER_DIV512_Val _U_(0xA)                                       /**< (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/512  */
+#define   RTC_MODE1_CTRLA_PRESCALER_DIV1024_Val _U_(0xB)                                       /**< (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/1024  */
+#define RTC_MODE1_CTRLA_PRESCALER_OFF       (RTC_MODE1_CTRLA_PRESCALER_OFF_Val << RTC_MODE1_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/1 Position  */
+#define RTC_MODE1_CTRLA_PRESCALER_DIV1      (RTC_MODE1_CTRLA_PRESCALER_DIV1_Val << RTC_MODE1_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/1 Position  */
+#define RTC_MODE1_CTRLA_PRESCALER_DIV2      (RTC_MODE1_CTRLA_PRESCALER_DIV2_Val << RTC_MODE1_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/2 Position  */
+#define RTC_MODE1_CTRLA_PRESCALER_DIV4      (RTC_MODE1_CTRLA_PRESCALER_DIV4_Val << RTC_MODE1_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/4 Position  */
+#define RTC_MODE1_CTRLA_PRESCALER_DIV8      (RTC_MODE1_CTRLA_PRESCALER_DIV8_Val << RTC_MODE1_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/8 Position  */
+#define RTC_MODE1_CTRLA_PRESCALER_DIV16     (RTC_MODE1_CTRLA_PRESCALER_DIV16_Val << RTC_MODE1_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/16 Position  */
+#define RTC_MODE1_CTRLA_PRESCALER_DIV32     (RTC_MODE1_CTRLA_PRESCALER_DIV32_Val << RTC_MODE1_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/32 Position  */
+#define RTC_MODE1_CTRLA_PRESCALER_DIV64     (RTC_MODE1_CTRLA_PRESCALER_DIV64_Val << RTC_MODE1_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/64 Position  */
+#define RTC_MODE1_CTRLA_PRESCALER_DIV128    (RTC_MODE1_CTRLA_PRESCALER_DIV128_Val << RTC_MODE1_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/128 Position  */
+#define RTC_MODE1_CTRLA_PRESCALER_DIV256    (RTC_MODE1_CTRLA_PRESCALER_DIV256_Val << RTC_MODE1_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/256 Position  */
+#define RTC_MODE1_CTRLA_PRESCALER_DIV512    (RTC_MODE1_CTRLA_PRESCALER_DIV512_Val << RTC_MODE1_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/512 Position  */
+#define RTC_MODE1_CTRLA_PRESCALER_DIV1024   (RTC_MODE1_CTRLA_PRESCALER_DIV1024_Val << RTC_MODE1_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/1024 Position  */
+#define RTC_MODE1_CTRLA_GPTRST_Pos          14                                             /**< (RTC_MODE1_CTRLA) GP Registers Reset On Tamper Enable Position */
+#define RTC_MODE1_CTRLA_GPTRST_Msk          (_U_(0x1) << RTC_MODE1_CTRLA_GPTRST_Pos)       /**< (RTC_MODE1_CTRLA) GP Registers Reset On Tamper Enable Mask */
+#define RTC_MODE1_CTRLA_GPTRST              RTC_MODE1_CTRLA_GPTRST_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_CTRLA_GPTRST_Msk instead */
+#define RTC_MODE1_CTRLA_COUNTSYNC_Pos       15                                             /**< (RTC_MODE1_CTRLA) Count Read Synchronization Enable Position */
+#define RTC_MODE1_CTRLA_COUNTSYNC_Msk       (_U_(0x1) << RTC_MODE1_CTRLA_COUNTSYNC_Pos)    /**< (RTC_MODE1_CTRLA) Count Read Synchronization Enable Mask */
+#define RTC_MODE1_CTRLA_COUNTSYNC           RTC_MODE1_CTRLA_COUNTSYNC_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_CTRLA_COUNTSYNC_Msk instead */
+#define RTC_MODE1_CTRLA_MASK                _U_(0xCF0F)                                    /**< \deprecated (RTC_MODE1_CTRLA) Register MASK  (Use RTC_MODE1_CTRLA_Msk instead)  */
+#define RTC_MODE1_CTRLA_Msk                 _U_(0xCF0F)                                    /**< (RTC_MODE1_CTRLA) Register Mask  */
+
+
+/* -------- RTC_MODE2_CTRLA : (RTC Offset: 0x00) (R/W 16) MODE2 Control A -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint16_t ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint16_t MODE:2;                    /**< bit:   2..3  Operating Mode                           */
+    uint16_t :2;                        /**< bit:   4..5  Reserved */
+    uint16_t CLKREP:1;                  /**< bit:      6  Clock Representation                     */
+    uint16_t MATCHCLR:1;                /**< bit:      7  Clear on Match                           */
+    uint16_t PRESCALER:4;               /**< bit:  8..11  Prescaler                                */
+    uint16_t :2;                        /**< bit: 12..13  Reserved */
+    uint16_t GPTRST:1;                  /**< bit:     14  GP Registers Reset On Tamper Enable      */
+    uint16_t CLOCKSYNC:1;               /**< bit:     15  Clock Read Synchronization Enable        */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} RTC_MODE2_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE2_CTRLA_OFFSET              (0x00)                                        /**<  (RTC_MODE2_CTRLA) MODE2 Control A  Offset */
+#define RTC_MODE2_CTRLA_RESETVALUE          _U_(0x00)                                     /**<  (RTC_MODE2_CTRLA) MODE2 Control A  Reset Value */
+
+#define RTC_MODE2_CTRLA_SWRST_Pos           0                                              /**< (RTC_MODE2_CTRLA) Software Reset Position */
+#define RTC_MODE2_CTRLA_SWRST_Msk           (_U_(0x1) << RTC_MODE2_CTRLA_SWRST_Pos)        /**< (RTC_MODE2_CTRLA) Software Reset Mask */
+#define RTC_MODE2_CTRLA_SWRST               RTC_MODE2_CTRLA_SWRST_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_CTRLA_SWRST_Msk instead */
+#define RTC_MODE2_CTRLA_ENABLE_Pos          1                                              /**< (RTC_MODE2_CTRLA) Enable Position */
+#define RTC_MODE2_CTRLA_ENABLE_Msk          (_U_(0x1) << RTC_MODE2_CTRLA_ENABLE_Pos)       /**< (RTC_MODE2_CTRLA) Enable Mask */
+#define RTC_MODE2_CTRLA_ENABLE              RTC_MODE2_CTRLA_ENABLE_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_CTRLA_ENABLE_Msk instead */
+#define RTC_MODE2_CTRLA_MODE_Pos            2                                              /**< (RTC_MODE2_CTRLA) Operating Mode Position */
+#define RTC_MODE2_CTRLA_MODE_Msk            (_U_(0x3) << RTC_MODE2_CTRLA_MODE_Pos)         /**< (RTC_MODE2_CTRLA) Operating Mode Mask */
+#define RTC_MODE2_CTRLA_MODE(value)         (RTC_MODE2_CTRLA_MODE_Msk & ((value) << RTC_MODE2_CTRLA_MODE_Pos))
+#define   RTC_MODE2_CTRLA_MODE_COUNT32_Val  _U_(0x0)                                       /**< (RTC_MODE2_CTRLA) Mode 0: 32-bit Counter  */
+#define   RTC_MODE2_CTRLA_MODE_COUNT16_Val  _U_(0x1)                                       /**< (RTC_MODE2_CTRLA) Mode 1: 16-bit Counter  */
+#define   RTC_MODE2_CTRLA_MODE_CLOCK_Val    _U_(0x2)                                       /**< (RTC_MODE2_CTRLA) Mode 2: Clock/Calendar  */
+#define RTC_MODE2_CTRLA_MODE_COUNT32        (RTC_MODE2_CTRLA_MODE_COUNT32_Val << RTC_MODE2_CTRLA_MODE_Pos)  /**< (RTC_MODE2_CTRLA) Mode 0: 32-bit Counter Position  */
+#define RTC_MODE2_CTRLA_MODE_COUNT16        (RTC_MODE2_CTRLA_MODE_COUNT16_Val << RTC_MODE2_CTRLA_MODE_Pos)  /**< (RTC_MODE2_CTRLA) Mode 1: 16-bit Counter Position  */
+#define RTC_MODE2_CTRLA_MODE_CLOCK          (RTC_MODE2_CTRLA_MODE_CLOCK_Val << RTC_MODE2_CTRLA_MODE_Pos)  /**< (RTC_MODE2_CTRLA) Mode 2: Clock/Calendar Position  */
+#define RTC_MODE2_CTRLA_CLKREP_Pos          6                                              /**< (RTC_MODE2_CTRLA) Clock Representation Position */
+#define RTC_MODE2_CTRLA_CLKREP_Msk          (_U_(0x1) << RTC_MODE2_CTRLA_CLKREP_Pos)       /**< (RTC_MODE2_CTRLA) Clock Representation Mask */
+#define RTC_MODE2_CTRLA_CLKREP              RTC_MODE2_CTRLA_CLKREP_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_CTRLA_CLKREP_Msk instead */
+#define RTC_MODE2_CTRLA_MATCHCLR_Pos        7                                              /**< (RTC_MODE2_CTRLA) Clear on Match Position */
+#define RTC_MODE2_CTRLA_MATCHCLR_Msk        (_U_(0x1) << RTC_MODE2_CTRLA_MATCHCLR_Pos)     /**< (RTC_MODE2_CTRLA) Clear on Match Mask */
+#define RTC_MODE2_CTRLA_MATCHCLR            RTC_MODE2_CTRLA_MATCHCLR_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_CTRLA_MATCHCLR_Msk instead */
+#define RTC_MODE2_CTRLA_PRESCALER_Pos       8                                              /**< (RTC_MODE2_CTRLA) Prescaler Position */
+#define RTC_MODE2_CTRLA_PRESCALER_Msk       (_U_(0xF) << RTC_MODE2_CTRLA_PRESCALER_Pos)    /**< (RTC_MODE2_CTRLA) Prescaler Mask */
+#define RTC_MODE2_CTRLA_PRESCALER(value)    (RTC_MODE2_CTRLA_PRESCALER_Msk & ((value) << RTC_MODE2_CTRLA_PRESCALER_Pos))
+#define   RTC_MODE2_CTRLA_PRESCALER_OFF_Val _U_(0x0)                                       /**< (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/1  */
+#define   RTC_MODE2_CTRLA_PRESCALER_DIV1_Val _U_(0x1)                                       /**< (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/1  */
+#define   RTC_MODE2_CTRLA_PRESCALER_DIV2_Val _U_(0x2)                                       /**< (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/2  */
+#define   RTC_MODE2_CTRLA_PRESCALER_DIV4_Val _U_(0x3)                                       /**< (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/4  */
+#define   RTC_MODE2_CTRLA_PRESCALER_DIV8_Val _U_(0x4)                                       /**< (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/8  */
+#define   RTC_MODE2_CTRLA_PRESCALER_DIV16_Val _U_(0x5)                                       /**< (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/16  */
+#define   RTC_MODE2_CTRLA_PRESCALER_DIV32_Val _U_(0x6)                                       /**< (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/32  */
+#define   RTC_MODE2_CTRLA_PRESCALER_DIV64_Val _U_(0x7)                                       /**< (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/64  */
+#define   RTC_MODE2_CTRLA_PRESCALER_DIV128_Val _U_(0x8)                                       /**< (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/128  */
+#define   RTC_MODE2_CTRLA_PRESCALER_DIV256_Val _U_(0x9)                                       /**< (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/256  */
+#define   RTC_MODE2_CTRLA_PRESCALER_DIV512_Val _U_(0xA)                                       /**< (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/512  */
+#define   RTC_MODE2_CTRLA_PRESCALER_DIV1024_Val _U_(0xB)                                       /**< (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/1024  */
+#define RTC_MODE2_CTRLA_PRESCALER_OFF       (RTC_MODE2_CTRLA_PRESCALER_OFF_Val << RTC_MODE2_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/1 Position  */
+#define RTC_MODE2_CTRLA_PRESCALER_DIV1      (RTC_MODE2_CTRLA_PRESCALER_DIV1_Val << RTC_MODE2_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/1 Position  */
+#define RTC_MODE2_CTRLA_PRESCALER_DIV2      (RTC_MODE2_CTRLA_PRESCALER_DIV2_Val << RTC_MODE2_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/2 Position  */
+#define RTC_MODE2_CTRLA_PRESCALER_DIV4      (RTC_MODE2_CTRLA_PRESCALER_DIV4_Val << RTC_MODE2_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/4 Position  */
+#define RTC_MODE2_CTRLA_PRESCALER_DIV8      (RTC_MODE2_CTRLA_PRESCALER_DIV8_Val << RTC_MODE2_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/8 Position  */
+#define RTC_MODE2_CTRLA_PRESCALER_DIV16     (RTC_MODE2_CTRLA_PRESCALER_DIV16_Val << RTC_MODE2_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/16 Position  */
+#define RTC_MODE2_CTRLA_PRESCALER_DIV32     (RTC_MODE2_CTRLA_PRESCALER_DIV32_Val << RTC_MODE2_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/32 Position  */
+#define RTC_MODE2_CTRLA_PRESCALER_DIV64     (RTC_MODE2_CTRLA_PRESCALER_DIV64_Val << RTC_MODE2_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/64 Position  */
+#define RTC_MODE2_CTRLA_PRESCALER_DIV128    (RTC_MODE2_CTRLA_PRESCALER_DIV128_Val << RTC_MODE2_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/128 Position  */
+#define RTC_MODE2_CTRLA_PRESCALER_DIV256    (RTC_MODE2_CTRLA_PRESCALER_DIV256_Val << RTC_MODE2_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/256 Position  */
+#define RTC_MODE2_CTRLA_PRESCALER_DIV512    (RTC_MODE2_CTRLA_PRESCALER_DIV512_Val << RTC_MODE2_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/512 Position  */
+#define RTC_MODE2_CTRLA_PRESCALER_DIV1024   (RTC_MODE2_CTRLA_PRESCALER_DIV1024_Val << RTC_MODE2_CTRLA_PRESCALER_Pos)  /**< (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/1024 Position  */
+#define RTC_MODE2_CTRLA_GPTRST_Pos          14                                             /**< (RTC_MODE2_CTRLA) GP Registers Reset On Tamper Enable Position */
+#define RTC_MODE2_CTRLA_GPTRST_Msk          (_U_(0x1) << RTC_MODE2_CTRLA_GPTRST_Pos)       /**< (RTC_MODE2_CTRLA) GP Registers Reset On Tamper Enable Mask */
+#define RTC_MODE2_CTRLA_GPTRST              RTC_MODE2_CTRLA_GPTRST_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_CTRLA_GPTRST_Msk instead */
+#define RTC_MODE2_CTRLA_CLOCKSYNC_Pos       15                                             /**< (RTC_MODE2_CTRLA) Clock Read Synchronization Enable Position */
+#define RTC_MODE2_CTRLA_CLOCKSYNC_Msk       (_U_(0x1) << RTC_MODE2_CTRLA_CLOCKSYNC_Pos)    /**< (RTC_MODE2_CTRLA) Clock Read Synchronization Enable Mask */
+#define RTC_MODE2_CTRLA_CLOCKSYNC           RTC_MODE2_CTRLA_CLOCKSYNC_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_CTRLA_CLOCKSYNC_Msk instead */
+#define RTC_MODE2_CTRLA_MASK                _U_(0xCFCF)                                    /**< \deprecated (RTC_MODE2_CTRLA) Register MASK  (Use RTC_MODE2_CTRLA_Msk instead)  */
+#define RTC_MODE2_CTRLA_Msk                 _U_(0xCFCF)                                    /**< (RTC_MODE2_CTRLA) Register Mask  */
+
+
+/* -------- RTC_MODE0_CTRLB : (RTC Offset: 0x02) (R/W 16) MODE0 Control B -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t GP0EN:1;                   /**< bit:      0  General Purpose 0 Enable                 */
+    uint16_t :3;                        /**< bit:   1..3  Reserved */
+    uint16_t DEBMAJ:1;                  /**< bit:      4  Debouncer Majority Enable                */
+    uint16_t DEBASYNC:1;                /**< bit:      5  Debouncer Asynchronous Enable            */
+    uint16_t RTCOUT:1;                  /**< bit:      6  RTC Output Enable                        */
+    uint16_t DMAEN:1;                   /**< bit:      7  DMA Enable                               */
+    uint16_t DEBF:3;                    /**< bit:  8..10  Debounce Frequency                       */
+    uint16_t :1;                        /**< bit:     11  Reserved */
+    uint16_t ACTF:3;                    /**< bit: 12..14  Active Layer Frequency                   */
+    uint16_t SEPTO:1;                   /**< bit:     15  Separate Tamper Outputs                  */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} RTC_MODE0_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE0_CTRLB_OFFSET              (0x02)                                        /**<  (RTC_MODE0_CTRLB) MODE0 Control B  Offset */
+#define RTC_MODE0_CTRLB_RESETVALUE          _U_(0x00)                                     /**<  (RTC_MODE0_CTRLB) MODE0 Control B  Reset Value */
+
+#define RTC_MODE0_CTRLB_GP0EN_Pos           0                                              /**< (RTC_MODE0_CTRLB) General Purpose 0 Enable Position */
+#define RTC_MODE0_CTRLB_GP0EN_Msk           (_U_(0x1) << RTC_MODE0_CTRLB_GP0EN_Pos)        /**< (RTC_MODE0_CTRLB) General Purpose 0 Enable Mask */
+#define RTC_MODE0_CTRLB_GP0EN               RTC_MODE0_CTRLB_GP0EN_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_CTRLB_GP0EN_Msk instead */
+#define RTC_MODE0_CTRLB_DEBMAJ_Pos          4                                              /**< (RTC_MODE0_CTRLB) Debouncer Majority Enable Position */
+#define RTC_MODE0_CTRLB_DEBMAJ_Msk          (_U_(0x1) << RTC_MODE0_CTRLB_DEBMAJ_Pos)       /**< (RTC_MODE0_CTRLB) Debouncer Majority Enable Mask */
+#define RTC_MODE0_CTRLB_DEBMAJ              RTC_MODE0_CTRLB_DEBMAJ_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_CTRLB_DEBMAJ_Msk instead */
+#define RTC_MODE0_CTRLB_DEBASYNC_Pos        5                                              /**< (RTC_MODE0_CTRLB) Debouncer Asynchronous Enable Position */
+#define RTC_MODE0_CTRLB_DEBASYNC_Msk        (_U_(0x1) << RTC_MODE0_CTRLB_DEBASYNC_Pos)     /**< (RTC_MODE0_CTRLB) Debouncer Asynchronous Enable Mask */
+#define RTC_MODE0_CTRLB_DEBASYNC            RTC_MODE0_CTRLB_DEBASYNC_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_CTRLB_DEBASYNC_Msk instead */
+#define RTC_MODE0_CTRLB_RTCOUT_Pos          6                                              /**< (RTC_MODE0_CTRLB) RTC Output Enable Position */
+#define RTC_MODE0_CTRLB_RTCOUT_Msk          (_U_(0x1) << RTC_MODE0_CTRLB_RTCOUT_Pos)       /**< (RTC_MODE0_CTRLB) RTC Output Enable Mask */
+#define RTC_MODE0_CTRLB_RTCOUT              RTC_MODE0_CTRLB_RTCOUT_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_CTRLB_RTCOUT_Msk instead */
+#define RTC_MODE0_CTRLB_DMAEN_Pos           7                                              /**< (RTC_MODE0_CTRLB) DMA Enable Position */
+#define RTC_MODE0_CTRLB_DMAEN_Msk           (_U_(0x1) << RTC_MODE0_CTRLB_DMAEN_Pos)        /**< (RTC_MODE0_CTRLB) DMA Enable Mask */
+#define RTC_MODE0_CTRLB_DMAEN               RTC_MODE0_CTRLB_DMAEN_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_CTRLB_DMAEN_Msk instead */
+#define RTC_MODE0_CTRLB_DEBF_Pos            8                                              /**< (RTC_MODE0_CTRLB) Debounce Frequency Position */
+#define RTC_MODE0_CTRLB_DEBF_Msk            (_U_(0x7) << RTC_MODE0_CTRLB_DEBF_Pos)         /**< (RTC_MODE0_CTRLB) Debounce Frequency Mask */
+#define RTC_MODE0_CTRLB_DEBF(value)         (RTC_MODE0_CTRLB_DEBF_Msk & ((value) << RTC_MODE0_CTRLB_DEBF_Pos))
+#define   RTC_MODE0_CTRLB_DEBF_DIV2_Val     _U_(0x0)                                       /**< (RTC_MODE0_CTRLB) CLK_RTC_DEB = CLK_RTC/2  */
+#define   RTC_MODE0_CTRLB_DEBF_DIV4_Val     _U_(0x1)                                       /**< (RTC_MODE0_CTRLB) CLK_RTC_DEB = CLK_RTC/4  */
+#define   RTC_MODE0_CTRLB_DEBF_DIV8_Val     _U_(0x2)                                       /**< (RTC_MODE0_CTRLB) CLK_RTC_DEB = CLK_RTC/8  */
+#define   RTC_MODE0_CTRLB_DEBF_DIV16_Val    _U_(0x3)                                       /**< (RTC_MODE0_CTRLB) CLK_RTC_DEB = CLK_RTC/16  */
+#define   RTC_MODE0_CTRLB_DEBF_DIV32_Val    _U_(0x4)                                       /**< (RTC_MODE0_CTRLB) CLK_RTC_DEB = CLK_RTC/32  */
+#define   RTC_MODE0_CTRLB_DEBF_DIV64_Val    _U_(0x5)                                       /**< (RTC_MODE0_CTRLB) CLK_RTC_DEB = CLK_RTC/64  */
+#define   RTC_MODE0_CTRLB_DEBF_DIV128_Val   _U_(0x6)                                       /**< (RTC_MODE0_CTRLB) CLK_RTC_DEB = CLK_RTC/128  */
+#define   RTC_MODE0_CTRLB_DEBF_DIV256_Val   _U_(0x7)                                       /**< (RTC_MODE0_CTRLB) CLK_RTC_DEB = CLK_RTC/256  */
+#define RTC_MODE0_CTRLB_DEBF_DIV2           (RTC_MODE0_CTRLB_DEBF_DIV2_Val << RTC_MODE0_CTRLB_DEBF_Pos)  /**< (RTC_MODE0_CTRLB) CLK_RTC_DEB = CLK_RTC/2 Position  */
+#define RTC_MODE0_CTRLB_DEBF_DIV4           (RTC_MODE0_CTRLB_DEBF_DIV4_Val << RTC_MODE0_CTRLB_DEBF_Pos)  /**< (RTC_MODE0_CTRLB) CLK_RTC_DEB = CLK_RTC/4 Position  */
+#define RTC_MODE0_CTRLB_DEBF_DIV8           (RTC_MODE0_CTRLB_DEBF_DIV8_Val << RTC_MODE0_CTRLB_DEBF_Pos)  /**< (RTC_MODE0_CTRLB) CLK_RTC_DEB = CLK_RTC/8 Position  */
+#define RTC_MODE0_CTRLB_DEBF_DIV16          (RTC_MODE0_CTRLB_DEBF_DIV16_Val << RTC_MODE0_CTRLB_DEBF_Pos)  /**< (RTC_MODE0_CTRLB) CLK_RTC_DEB = CLK_RTC/16 Position  */
+#define RTC_MODE0_CTRLB_DEBF_DIV32          (RTC_MODE0_CTRLB_DEBF_DIV32_Val << RTC_MODE0_CTRLB_DEBF_Pos)  /**< (RTC_MODE0_CTRLB) CLK_RTC_DEB = CLK_RTC/32 Position  */
+#define RTC_MODE0_CTRLB_DEBF_DIV64          (RTC_MODE0_CTRLB_DEBF_DIV64_Val << RTC_MODE0_CTRLB_DEBF_Pos)  /**< (RTC_MODE0_CTRLB) CLK_RTC_DEB = CLK_RTC/64 Position  */
+#define RTC_MODE0_CTRLB_DEBF_DIV128         (RTC_MODE0_CTRLB_DEBF_DIV128_Val << RTC_MODE0_CTRLB_DEBF_Pos)  /**< (RTC_MODE0_CTRLB) CLK_RTC_DEB = CLK_RTC/128 Position  */
+#define RTC_MODE0_CTRLB_DEBF_DIV256         (RTC_MODE0_CTRLB_DEBF_DIV256_Val << RTC_MODE0_CTRLB_DEBF_Pos)  /**< (RTC_MODE0_CTRLB) CLK_RTC_DEB = CLK_RTC/256 Position  */
+#define RTC_MODE0_CTRLB_ACTF_Pos            12                                             /**< (RTC_MODE0_CTRLB) Active Layer Frequency Position */
+#define RTC_MODE0_CTRLB_ACTF_Msk            (_U_(0x7) << RTC_MODE0_CTRLB_ACTF_Pos)         /**< (RTC_MODE0_CTRLB) Active Layer Frequency Mask */
+#define RTC_MODE0_CTRLB_ACTF(value)         (RTC_MODE0_CTRLB_ACTF_Msk & ((value) << RTC_MODE0_CTRLB_ACTF_Pos))
+#define   RTC_MODE0_CTRLB_ACTF_DIV2_Val     _U_(0x0)                                       /**< (RTC_MODE0_CTRLB) CLK_RTC_OUT = CLK_RTC/2  */
+#define   RTC_MODE0_CTRLB_ACTF_DIV4_Val     _U_(0x1)                                       /**< (RTC_MODE0_CTRLB) CLK_RTC_OUT = CLK_RTC/4  */
+#define   RTC_MODE0_CTRLB_ACTF_DIV8_Val     _U_(0x2)                                       /**< (RTC_MODE0_CTRLB) CLK_RTC_OUT = CLK_RTC/8  */
+#define   RTC_MODE0_CTRLB_ACTF_DIV16_Val    _U_(0x3)                                       /**< (RTC_MODE0_CTRLB) CLK_RTC_OUT = CLK_RTC/16  */
+#define   RTC_MODE0_CTRLB_ACTF_DIV32_Val    _U_(0x4)                                       /**< (RTC_MODE0_CTRLB) CLK_RTC_OUT = CLK_RTC/32  */
+#define   RTC_MODE0_CTRLB_ACTF_DIV64_Val    _U_(0x5)                                       /**< (RTC_MODE0_CTRLB) CLK_RTC_OUT = CLK_RTC/64  */
+#define   RTC_MODE0_CTRLB_ACTF_DIV128_Val   _U_(0x6)                                       /**< (RTC_MODE0_CTRLB) CLK_RTC_OUT = CLK_RTC/128  */
+#define   RTC_MODE0_CTRLB_ACTF_DIV256_Val   _U_(0x7)                                       /**< (RTC_MODE0_CTRLB) CLK_RTC_OUT = CLK_RTC/256  */
+#define RTC_MODE0_CTRLB_ACTF_DIV2           (RTC_MODE0_CTRLB_ACTF_DIV2_Val << RTC_MODE0_CTRLB_ACTF_Pos)  /**< (RTC_MODE0_CTRLB) CLK_RTC_OUT = CLK_RTC/2 Position  */
+#define RTC_MODE0_CTRLB_ACTF_DIV4           (RTC_MODE0_CTRLB_ACTF_DIV4_Val << RTC_MODE0_CTRLB_ACTF_Pos)  /**< (RTC_MODE0_CTRLB) CLK_RTC_OUT = CLK_RTC/4 Position  */
+#define RTC_MODE0_CTRLB_ACTF_DIV8           (RTC_MODE0_CTRLB_ACTF_DIV8_Val << RTC_MODE0_CTRLB_ACTF_Pos)  /**< (RTC_MODE0_CTRLB) CLK_RTC_OUT = CLK_RTC/8 Position  */
+#define RTC_MODE0_CTRLB_ACTF_DIV16          (RTC_MODE0_CTRLB_ACTF_DIV16_Val << RTC_MODE0_CTRLB_ACTF_Pos)  /**< (RTC_MODE0_CTRLB) CLK_RTC_OUT = CLK_RTC/16 Position  */
+#define RTC_MODE0_CTRLB_ACTF_DIV32          (RTC_MODE0_CTRLB_ACTF_DIV32_Val << RTC_MODE0_CTRLB_ACTF_Pos)  /**< (RTC_MODE0_CTRLB) CLK_RTC_OUT = CLK_RTC/32 Position  */
+#define RTC_MODE0_CTRLB_ACTF_DIV64          (RTC_MODE0_CTRLB_ACTF_DIV64_Val << RTC_MODE0_CTRLB_ACTF_Pos)  /**< (RTC_MODE0_CTRLB) CLK_RTC_OUT = CLK_RTC/64 Position  */
+#define RTC_MODE0_CTRLB_ACTF_DIV128         (RTC_MODE0_CTRLB_ACTF_DIV128_Val << RTC_MODE0_CTRLB_ACTF_Pos)  /**< (RTC_MODE0_CTRLB) CLK_RTC_OUT = CLK_RTC/128 Position  */
+#define RTC_MODE0_CTRLB_ACTF_DIV256         (RTC_MODE0_CTRLB_ACTF_DIV256_Val << RTC_MODE0_CTRLB_ACTF_Pos)  /**< (RTC_MODE0_CTRLB) CLK_RTC_OUT = CLK_RTC/256 Position  */
+#define RTC_MODE0_CTRLB_SEPTO_Pos           15                                             /**< (RTC_MODE0_CTRLB) Separate Tamper Outputs Position */
+#define RTC_MODE0_CTRLB_SEPTO_Msk           (_U_(0x1) << RTC_MODE0_CTRLB_SEPTO_Pos)        /**< (RTC_MODE0_CTRLB) Separate Tamper Outputs Mask */
+#define RTC_MODE0_CTRLB_SEPTO               RTC_MODE0_CTRLB_SEPTO_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_CTRLB_SEPTO_Msk instead */
+#define RTC_MODE0_CTRLB_MASK                _U_(0xF7F1)                                    /**< \deprecated (RTC_MODE0_CTRLB) Register MASK  (Use RTC_MODE0_CTRLB_Msk instead)  */
+#define RTC_MODE0_CTRLB_Msk                 _U_(0xF7F1)                                    /**< (RTC_MODE0_CTRLB) Register Mask  */
+
+
+/* -------- RTC_MODE1_CTRLB : (RTC Offset: 0x02) (R/W 16) MODE1 Control B -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t GP0EN:1;                   /**< bit:      0  General Purpose 0 Enable                 */
+    uint16_t :3;                        /**< bit:   1..3  Reserved */
+    uint16_t DEBMAJ:1;                  /**< bit:      4  Debouncer Majority Enable                */
+    uint16_t DEBASYNC:1;                /**< bit:      5  Debouncer Asynchronous Enable            */
+    uint16_t RTCOUT:1;                  /**< bit:      6  RTC Output Enable                        */
+    uint16_t DMAEN:1;                   /**< bit:      7  DMA Enable                               */
+    uint16_t DEBF:3;                    /**< bit:  8..10  Debounce Frequency                       */
+    uint16_t :1;                        /**< bit:     11  Reserved */
+    uint16_t ACTF:3;                    /**< bit: 12..14  Active Layer Frequency                   */
+    uint16_t SEPTO:1;                   /**< bit:     15  Separate Tamper Outputs                  */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} RTC_MODE1_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE1_CTRLB_OFFSET              (0x02)                                        /**<  (RTC_MODE1_CTRLB) MODE1 Control B  Offset */
+#define RTC_MODE1_CTRLB_RESETVALUE          _U_(0x00)                                     /**<  (RTC_MODE1_CTRLB) MODE1 Control B  Reset Value */
+
+#define RTC_MODE1_CTRLB_GP0EN_Pos           0                                              /**< (RTC_MODE1_CTRLB) General Purpose 0 Enable Position */
+#define RTC_MODE1_CTRLB_GP0EN_Msk           (_U_(0x1) << RTC_MODE1_CTRLB_GP0EN_Pos)        /**< (RTC_MODE1_CTRLB) General Purpose 0 Enable Mask */
+#define RTC_MODE1_CTRLB_GP0EN               RTC_MODE1_CTRLB_GP0EN_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_CTRLB_GP0EN_Msk instead */
+#define RTC_MODE1_CTRLB_DEBMAJ_Pos          4                                              /**< (RTC_MODE1_CTRLB) Debouncer Majority Enable Position */
+#define RTC_MODE1_CTRLB_DEBMAJ_Msk          (_U_(0x1) << RTC_MODE1_CTRLB_DEBMAJ_Pos)       /**< (RTC_MODE1_CTRLB) Debouncer Majority Enable Mask */
+#define RTC_MODE1_CTRLB_DEBMAJ              RTC_MODE1_CTRLB_DEBMAJ_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_CTRLB_DEBMAJ_Msk instead */
+#define RTC_MODE1_CTRLB_DEBASYNC_Pos        5                                              /**< (RTC_MODE1_CTRLB) Debouncer Asynchronous Enable Position */
+#define RTC_MODE1_CTRLB_DEBASYNC_Msk        (_U_(0x1) << RTC_MODE1_CTRLB_DEBASYNC_Pos)     /**< (RTC_MODE1_CTRLB) Debouncer Asynchronous Enable Mask */
+#define RTC_MODE1_CTRLB_DEBASYNC            RTC_MODE1_CTRLB_DEBASYNC_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_CTRLB_DEBASYNC_Msk instead */
+#define RTC_MODE1_CTRLB_RTCOUT_Pos          6                                              /**< (RTC_MODE1_CTRLB) RTC Output Enable Position */
+#define RTC_MODE1_CTRLB_RTCOUT_Msk          (_U_(0x1) << RTC_MODE1_CTRLB_RTCOUT_Pos)       /**< (RTC_MODE1_CTRLB) RTC Output Enable Mask */
+#define RTC_MODE1_CTRLB_RTCOUT              RTC_MODE1_CTRLB_RTCOUT_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_CTRLB_RTCOUT_Msk instead */
+#define RTC_MODE1_CTRLB_DMAEN_Pos           7                                              /**< (RTC_MODE1_CTRLB) DMA Enable Position */
+#define RTC_MODE1_CTRLB_DMAEN_Msk           (_U_(0x1) << RTC_MODE1_CTRLB_DMAEN_Pos)        /**< (RTC_MODE1_CTRLB) DMA Enable Mask */
+#define RTC_MODE1_CTRLB_DMAEN               RTC_MODE1_CTRLB_DMAEN_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_CTRLB_DMAEN_Msk instead */
+#define RTC_MODE1_CTRLB_DEBF_Pos            8                                              /**< (RTC_MODE1_CTRLB) Debounce Frequency Position */
+#define RTC_MODE1_CTRLB_DEBF_Msk            (_U_(0x7) << RTC_MODE1_CTRLB_DEBF_Pos)         /**< (RTC_MODE1_CTRLB) Debounce Frequency Mask */
+#define RTC_MODE1_CTRLB_DEBF(value)         (RTC_MODE1_CTRLB_DEBF_Msk & ((value) << RTC_MODE1_CTRLB_DEBF_Pos))
+#define   RTC_MODE1_CTRLB_DEBF_DIV2_Val     _U_(0x0)                                       /**< (RTC_MODE1_CTRLB) CLK_RTC_DEB = CLK_RTC/2  */
+#define   RTC_MODE1_CTRLB_DEBF_DIV4_Val     _U_(0x1)                                       /**< (RTC_MODE1_CTRLB) CLK_RTC_DEB = CLK_RTC/4  */
+#define   RTC_MODE1_CTRLB_DEBF_DIV8_Val     _U_(0x2)                                       /**< (RTC_MODE1_CTRLB) CLK_RTC_DEB = CLK_RTC/8  */
+#define   RTC_MODE1_CTRLB_DEBF_DIV16_Val    _U_(0x3)                                       /**< (RTC_MODE1_CTRLB) CLK_RTC_DEB = CLK_RTC/16  */
+#define   RTC_MODE1_CTRLB_DEBF_DIV32_Val    _U_(0x4)                                       /**< (RTC_MODE1_CTRLB) CLK_RTC_DEB = CLK_RTC/32  */
+#define   RTC_MODE1_CTRLB_DEBF_DIV64_Val    _U_(0x5)                                       /**< (RTC_MODE1_CTRLB) CLK_RTC_DEB = CLK_RTC/64  */
+#define   RTC_MODE1_CTRLB_DEBF_DIV128_Val   _U_(0x6)                                       /**< (RTC_MODE1_CTRLB) CLK_RTC_DEB = CLK_RTC/128  */
+#define   RTC_MODE1_CTRLB_DEBF_DIV256_Val   _U_(0x7)                                       /**< (RTC_MODE1_CTRLB) CLK_RTC_DEB = CLK_RTC/256  */
+#define RTC_MODE1_CTRLB_DEBF_DIV2           (RTC_MODE1_CTRLB_DEBF_DIV2_Val << RTC_MODE1_CTRLB_DEBF_Pos)  /**< (RTC_MODE1_CTRLB) CLK_RTC_DEB = CLK_RTC/2 Position  */
+#define RTC_MODE1_CTRLB_DEBF_DIV4           (RTC_MODE1_CTRLB_DEBF_DIV4_Val << RTC_MODE1_CTRLB_DEBF_Pos)  /**< (RTC_MODE1_CTRLB) CLK_RTC_DEB = CLK_RTC/4 Position  */
+#define RTC_MODE1_CTRLB_DEBF_DIV8           (RTC_MODE1_CTRLB_DEBF_DIV8_Val << RTC_MODE1_CTRLB_DEBF_Pos)  /**< (RTC_MODE1_CTRLB) CLK_RTC_DEB = CLK_RTC/8 Position  */
+#define RTC_MODE1_CTRLB_DEBF_DIV16          (RTC_MODE1_CTRLB_DEBF_DIV16_Val << RTC_MODE1_CTRLB_DEBF_Pos)  /**< (RTC_MODE1_CTRLB) CLK_RTC_DEB = CLK_RTC/16 Position  */
+#define RTC_MODE1_CTRLB_DEBF_DIV32          (RTC_MODE1_CTRLB_DEBF_DIV32_Val << RTC_MODE1_CTRLB_DEBF_Pos)  /**< (RTC_MODE1_CTRLB) CLK_RTC_DEB = CLK_RTC/32 Position  */
+#define RTC_MODE1_CTRLB_DEBF_DIV64          (RTC_MODE1_CTRLB_DEBF_DIV64_Val << RTC_MODE1_CTRLB_DEBF_Pos)  /**< (RTC_MODE1_CTRLB) CLK_RTC_DEB = CLK_RTC/64 Position  */
+#define RTC_MODE1_CTRLB_DEBF_DIV128         (RTC_MODE1_CTRLB_DEBF_DIV128_Val << RTC_MODE1_CTRLB_DEBF_Pos)  /**< (RTC_MODE1_CTRLB) CLK_RTC_DEB = CLK_RTC/128 Position  */
+#define RTC_MODE1_CTRLB_DEBF_DIV256         (RTC_MODE1_CTRLB_DEBF_DIV256_Val << RTC_MODE1_CTRLB_DEBF_Pos)  /**< (RTC_MODE1_CTRLB) CLK_RTC_DEB = CLK_RTC/256 Position  */
+#define RTC_MODE1_CTRLB_ACTF_Pos            12                                             /**< (RTC_MODE1_CTRLB) Active Layer Frequency Position */
+#define RTC_MODE1_CTRLB_ACTF_Msk            (_U_(0x7) << RTC_MODE1_CTRLB_ACTF_Pos)         /**< (RTC_MODE1_CTRLB) Active Layer Frequency Mask */
+#define RTC_MODE1_CTRLB_ACTF(value)         (RTC_MODE1_CTRLB_ACTF_Msk & ((value) << RTC_MODE1_CTRLB_ACTF_Pos))
+#define   RTC_MODE1_CTRLB_ACTF_DIV2_Val     _U_(0x0)                                       /**< (RTC_MODE1_CTRLB) CLK_RTC_OUT = CLK_RTC/2  */
+#define   RTC_MODE1_CTRLB_ACTF_DIV4_Val     _U_(0x1)                                       /**< (RTC_MODE1_CTRLB) CLK_RTC_OUT = CLK_RTC/4  */
+#define   RTC_MODE1_CTRLB_ACTF_DIV8_Val     _U_(0x2)                                       /**< (RTC_MODE1_CTRLB) CLK_RTC_OUT = CLK_RTC/8  */
+#define   RTC_MODE1_CTRLB_ACTF_DIV16_Val    _U_(0x3)                                       /**< (RTC_MODE1_CTRLB) CLK_RTC_OUT = CLK_RTC/16  */
+#define   RTC_MODE1_CTRLB_ACTF_DIV32_Val    _U_(0x4)                                       /**< (RTC_MODE1_CTRLB) CLK_RTC_OUT = CLK_RTC/32  */
+#define   RTC_MODE1_CTRLB_ACTF_DIV64_Val    _U_(0x5)                                       /**< (RTC_MODE1_CTRLB) CLK_RTC_OUT = CLK_RTC/64  */
+#define   RTC_MODE1_CTRLB_ACTF_DIV128_Val   _U_(0x6)                                       /**< (RTC_MODE1_CTRLB) CLK_RTC_OUT = CLK_RTC/128  */
+#define   RTC_MODE1_CTRLB_ACTF_DIV256_Val   _U_(0x7)                                       /**< (RTC_MODE1_CTRLB) CLK_RTC_OUT = CLK_RTC/256  */
+#define RTC_MODE1_CTRLB_ACTF_DIV2           (RTC_MODE1_CTRLB_ACTF_DIV2_Val << RTC_MODE1_CTRLB_ACTF_Pos)  /**< (RTC_MODE1_CTRLB) CLK_RTC_OUT = CLK_RTC/2 Position  */
+#define RTC_MODE1_CTRLB_ACTF_DIV4           (RTC_MODE1_CTRLB_ACTF_DIV4_Val << RTC_MODE1_CTRLB_ACTF_Pos)  /**< (RTC_MODE1_CTRLB) CLK_RTC_OUT = CLK_RTC/4 Position  */
+#define RTC_MODE1_CTRLB_ACTF_DIV8           (RTC_MODE1_CTRLB_ACTF_DIV8_Val << RTC_MODE1_CTRLB_ACTF_Pos)  /**< (RTC_MODE1_CTRLB) CLK_RTC_OUT = CLK_RTC/8 Position  */
+#define RTC_MODE1_CTRLB_ACTF_DIV16          (RTC_MODE1_CTRLB_ACTF_DIV16_Val << RTC_MODE1_CTRLB_ACTF_Pos)  /**< (RTC_MODE1_CTRLB) CLK_RTC_OUT = CLK_RTC/16 Position  */
+#define RTC_MODE1_CTRLB_ACTF_DIV32          (RTC_MODE1_CTRLB_ACTF_DIV32_Val << RTC_MODE1_CTRLB_ACTF_Pos)  /**< (RTC_MODE1_CTRLB) CLK_RTC_OUT = CLK_RTC/32 Position  */
+#define RTC_MODE1_CTRLB_ACTF_DIV64          (RTC_MODE1_CTRLB_ACTF_DIV64_Val << RTC_MODE1_CTRLB_ACTF_Pos)  /**< (RTC_MODE1_CTRLB) CLK_RTC_OUT = CLK_RTC/64 Position  */
+#define RTC_MODE1_CTRLB_ACTF_DIV128         (RTC_MODE1_CTRLB_ACTF_DIV128_Val << RTC_MODE1_CTRLB_ACTF_Pos)  /**< (RTC_MODE1_CTRLB) CLK_RTC_OUT = CLK_RTC/128 Position  */
+#define RTC_MODE1_CTRLB_ACTF_DIV256         (RTC_MODE1_CTRLB_ACTF_DIV256_Val << RTC_MODE1_CTRLB_ACTF_Pos)  /**< (RTC_MODE1_CTRLB) CLK_RTC_OUT = CLK_RTC/256 Position  */
+#define RTC_MODE1_CTRLB_SEPTO_Pos           15                                             /**< (RTC_MODE1_CTRLB) Separate Tamper Outputs Position */
+#define RTC_MODE1_CTRLB_SEPTO_Msk           (_U_(0x1) << RTC_MODE1_CTRLB_SEPTO_Pos)        /**< (RTC_MODE1_CTRLB) Separate Tamper Outputs Mask */
+#define RTC_MODE1_CTRLB_SEPTO               RTC_MODE1_CTRLB_SEPTO_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_CTRLB_SEPTO_Msk instead */
+#define RTC_MODE1_CTRLB_MASK                _U_(0xF7F1)                                    /**< \deprecated (RTC_MODE1_CTRLB) Register MASK  (Use RTC_MODE1_CTRLB_Msk instead)  */
+#define RTC_MODE1_CTRLB_Msk                 _U_(0xF7F1)                                    /**< (RTC_MODE1_CTRLB) Register Mask  */
+
+
+/* -------- RTC_MODE2_CTRLB : (RTC Offset: 0x02) (R/W 16) MODE2 Control B -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t GP0EN:1;                   /**< bit:      0  General Purpose 0 Enable                 */
+    uint16_t :3;                        /**< bit:   1..3  Reserved */
+    uint16_t DEBMAJ:1;                  /**< bit:      4  Debouncer Majority Enable                */
+    uint16_t DEBASYNC:1;                /**< bit:      5  Debouncer Asynchronous Enable            */
+    uint16_t RTCOUT:1;                  /**< bit:      6  RTC Output Enable                        */
+    uint16_t DMAEN:1;                   /**< bit:      7  DMA Enable                               */
+    uint16_t DEBF:3;                    /**< bit:  8..10  Debounce Frequency                       */
+    uint16_t :1;                        /**< bit:     11  Reserved */
+    uint16_t ACTF:3;                    /**< bit: 12..14  Active Layer Frequency                   */
+    uint16_t SEPTO:1;                   /**< bit:     15  Separate Tamper Outputs                  */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} RTC_MODE2_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE2_CTRLB_OFFSET              (0x02)                                        /**<  (RTC_MODE2_CTRLB) MODE2 Control B  Offset */
+#define RTC_MODE2_CTRLB_RESETVALUE          _U_(0x00)                                     /**<  (RTC_MODE2_CTRLB) MODE2 Control B  Reset Value */
+
+#define RTC_MODE2_CTRLB_GP0EN_Pos           0                                              /**< (RTC_MODE2_CTRLB) General Purpose 0 Enable Position */
+#define RTC_MODE2_CTRLB_GP0EN_Msk           (_U_(0x1) << RTC_MODE2_CTRLB_GP0EN_Pos)        /**< (RTC_MODE2_CTRLB) General Purpose 0 Enable Mask */
+#define RTC_MODE2_CTRLB_GP0EN               RTC_MODE2_CTRLB_GP0EN_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_CTRLB_GP0EN_Msk instead */
+#define RTC_MODE2_CTRLB_DEBMAJ_Pos          4                                              /**< (RTC_MODE2_CTRLB) Debouncer Majority Enable Position */
+#define RTC_MODE2_CTRLB_DEBMAJ_Msk          (_U_(0x1) << RTC_MODE2_CTRLB_DEBMAJ_Pos)       /**< (RTC_MODE2_CTRLB) Debouncer Majority Enable Mask */
+#define RTC_MODE2_CTRLB_DEBMAJ              RTC_MODE2_CTRLB_DEBMAJ_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_CTRLB_DEBMAJ_Msk instead */
+#define RTC_MODE2_CTRLB_DEBASYNC_Pos        5                                              /**< (RTC_MODE2_CTRLB) Debouncer Asynchronous Enable Position */
+#define RTC_MODE2_CTRLB_DEBASYNC_Msk        (_U_(0x1) << RTC_MODE2_CTRLB_DEBASYNC_Pos)     /**< (RTC_MODE2_CTRLB) Debouncer Asynchronous Enable Mask */
+#define RTC_MODE2_CTRLB_DEBASYNC            RTC_MODE2_CTRLB_DEBASYNC_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_CTRLB_DEBASYNC_Msk instead */
+#define RTC_MODE2_CTRLB_RTCOUT_Pos          6                                              /**< (RTC_MODE2_CTRLB) RTC Output Enable Position */
+#define RTC_MODE2_CTRLB_RTCOUT_Msk          (_U_(0x1) << RTC_MODE2_CTRLB_RTCOUT_Pos)       /**< (RTC_MODE2_CTRLB) RTC Output Enable Mask */
+#define RTC_MODE2_CTRLB_RTCOUT              RTC_MODE2_CTRLB_RTCOUT_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_CTRLB_RTCOUT_Msk instead */
+#define RTC_MODE2_CTRLB_DMAEN_Pos           7                                              /**< (RTC_MODE2_CTRLB) DMA Enable Position */
+#define RTC_MODE2_CTRLB_DMAEN_Msk           (_U_(0x1) << RTC_MODE2_CTRLB_DMAEN_Pos)        /**< (RTC_MODE2_CTRLB) DMA Enable Mask */
+#define RTC_MODE2_CTRLB_DMAEN               RTC_MODE2_CTRLB_DMAEN_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_CTRLB_DMAEN_Msk instead */
+#define RTC_MODE2_CTRLB_DEBF_Pos            8                                              /**< (RTC_MODE2_CTRLB) Debounce Frequency Position */
+#define RTC_MODE2_CTRLB_DEBF_Msk            (_U_(0x7) << RTC_MODE2_CTRLB_DEBF_Pos)         /**< (RTC_MODE2_CTRLB) Debounce Frequency Mask */
+#define RTC_MODE2_CTRLB_DEBF(value)         (RTC_MODE2_CTRLB_DEBF_Msk & ((value) << RTC_MODE2_CTRLB_DEBF_Pos))
+#define   RTC_MODE2_CTRLB_DEBF_DIV2_Val     _U_(0x0)                                       /**< (RTC_MODE2_CTRLB) CLK_RTC_DEB = CLK_RTC/2  */
+#define   RTC_MODE2_CTRLB_DEBF_DIV4_Val     _U_(0x1)                                       /**< (RTC_MODE2_CTRLB) CLK_RTC_DEB = CLK_RTC/4  */
+#define   RTC_MODE2_CTRLB_DEBF_DIV8_Val     _U_(0x2)                                       /**< (RTC_MODE2_CTRLB) CLK_RTC_DEB = CLK_RTC/8  */
+#define   RTC_MODE2_CTRLB_DEBF_DIV16_Val    _U_(0x3)                                       /**< (RTC_MODE2_CTRLB) CLK_RTC_DEB = CLK_RTC/16  */
+#define   RTC_MODE2_CTRLB_DEBF_DIV32_Val    _U_(0x4)                                       /**< (RTC_MODE2_CTRLB) CLK_RTC_DEB = CLK_RTC/32  */
+#define   RTC_MODE2_CTRLB_DEBF_DIV64_Val    _U_(0x5)                                       /**< (RTC_MODE2_CTRLB) CLK_RTC_DEB = CLK_RTC/64  */
+#define   RTC_MODE2_CTRLB_DEBF_DIV128_Val   _U_(0x6)                                       /**< (RTC_MODE2_CTRLB) CLK_RTC_DEB = CLK_RTC/128  */
+#define   RTC_MODE2_CTRLB_DEBF_DIV256_Val   _U_(0x7)                                       /**< (RTC_MODE2_CTRLB) CLK_RTC_DEB = CLK_RTC/256  */
+#define RTC_MODE2_CTRLB_DEBF_DIV2           (RTC_MODE2_CTRLB_DEBF_DIV2_Val << RTC_MODE2_CTRLB_DEBF_Pos)  /**< (RTC_MODE2_CTRLB) CLK_RTC_DEB = CLK_RTC/2 Position  */
+#define RTC_MODE2_CTRLB_DEBF_DIV4           (RTC_MODE2_CTRLB_DEBF_DIV4_Val << RTC_MODE2_CTRLB_DEBF_Pos)  /**< (RTC_MODE2_CTRLB) CLK_RTC_DEB = CLK_RTC/4 Position  */
+#define RTC_MODE2_CTRLB_DEBF_DIV8           (RTC_MODE2_CTRLB_DEBF_DIV8_Val << RTC_MODE2_CTRLB_DEBF_Pos)  /**< (RTC_MODE2_CTRLB) CLK_RTC_DEB = CLK_RTC/8 Position  */
+#define RTC_MODE2_CTRLB_DEBF_DIV16          (RTC_MODE2_CTRLB_DEBF_DIV16_Val << RTC_MODE2_CTRLB_DEBF_Pos)  /**< (RTC_MODE2_CTRLB) CLK_RTC_DEB = CLK_RTC/16 Position  */
+#define RTC_MODE2_CTRLB_DEBF_DIV32          (RTC_MODE2_CTRLB_DEBF_DIV32_Val << RTC_MODE2_CTRLB_DEBF_Pos)  /**< (RTC_MODE2_CTRLB) CLK_RTC_DEB = CLK_RTC/32 Position  */
+#define RTC_MODE2_CTRLB_DEBF_DIV64          (RTC_MODE2_CTRLB_DEBF_DIV64_Val << RTC_MODE2_CTRLB_DEBF_Pos)  /**< (RTC_MODE2_CTRLB) CLK_RTC_DEB = CLK_RTC/64 Position  */
+#define RTC_MODE2_CTRLB_DEBF_DIV128         (RTC_MODE2_CTRLB_DEBF_DIV128_Val << RTC_MODE2_CTRLB_DEBF_Pos)  /**< (RTC_MODE2_CTRLB) CLK_RTC_DEB = CLK_RTC/128 Position  */
+#define RTC_MODE2_CTRLB_DEBF_DIV256         (RTC_MODE2_CTRLB_DEBF_DIV256_Val << RTC_MODE2_CTRLB_DEBF_Pos)  /**< (RTC_MODE2_CTRLB) CLK_RTC_DEB = CLK_RTC/256 Position  */
+#define RTC_MODE2_CTRLB_ACTF_Pos            12                                             /**< (RTC_MODE2_CTRLB) Active Layer Frequency Position */
+#define RTC_MODE2_CTRLB_ACTF_Msk            (_U_(0x7) << RTC_MODE2_CTRLB_ACTF_Pos)         /**< (RTC_MODE2_CTRLB) Active Layer Frequency Mask */
+#define RTC_MODE2_CTRLB_ACTF(value)         (RTC_MODE2_CTRLB_ACTF_Msk & ((value) << RTC_MODE2_CTRLB_ACTF_Pos))
+#define   RTC_MODE2_CTRLB_ACTF_DIV2_Val     _U_(0x0)                                       /**< (RTC_MODE2_CTRLB) CLK_RTC_OUT = CLK_RTC/2  */
+#define   RTC_MODE2_CTRLB_ACTF_DIV4_Val     _U_(0x1)                                       /**< (RTC_MODE2_CTRLB) CLK_RTC_OUT = CLK_RTC/4  */
+#define   RTC_MODE2_CTRLB_ACTF_DIV8_Val     _U_(0x2)                                       /**< (RTC_MODE2_CTRLB) CLK_RTC_OUT = CLK_RTC/8  */
+#define   RTC_MODE2_CTRLB_ACTF_DIV16_Val    _U_(0x3)                                       /**< (RTC_MODE2_CTRLB) CLK_RTC_OUT = CLK_RTC/16  */
+#define   RTC_MODE2_CTRLB_ACTF_DIV32_Val    _U_(0x4)                                       /**< (RTC_MODE2_CTRLB) CLK_RTC_OUT = CLK_RTC/32  */
+#define   RTC_MODE2_CTRLB_ACTF_DIV64_Val    _U_(0x5)                                       /**< (RTC_MODE2_CTRLB) CLK_RTC_OUT = CLK_RTC/64  */
+#define   RTC_MODE2_CTRLB_ACTF_DIV128_Val   _U_(0x6)                                       /**< (RTC_MODE2_CTRLB) CLK_RTC_OUT = CLK_RTC/128  */
+#define   RTC_MODE2_CTRLB_ACTF_DIV256_Val   _U_(0x7)                                       /**< (RTC_MODE2_CTRLB) CLK_RTC_OUT = CLK_RTC/256  */
+#define RTC_MODE2_CTRLB_ACTF_DIV2           (RTC_MODE2_CTRLB_ACTF_DIV2_Val << RTC_MODE2_CTRLB_ACTF_Pos)  /**< (RTC_MODE2_CTRLB) CLK_RTC_OUT = CLK_RTC/2 Position  */
+#define RTC_MODE2_CTRLB_ACTF_DIV4           (RTC_MODE2_CTRLB_ACTF_DIV4_Val << RTC_MODE2_CTRLB_ACTF_Pos)  /**< (RTC_MODE2_CTRLB) CLK_RTC_OUT = CLK_RTC/4 Position  */
+#define RTC_MODE2_CTRLB_ACTF_DIV8           (RTC_MODE2_CTRLB_ACTF_DIV8_Val << RTC_MODE2_CTRLB_ACTF_Pos)  /**< (RTC_MODE2_CTRLB) CLK_RTC_OUT = CLK_RTC/8 Position  */
+#define RTC_MODE2_CTRLB_ACTF_DIV16          (RTC_MODE2_CTRLB_ACTF_DIV16_Val << RTC_MODE2_CTRLB_ACTF_Pos)  /**< (RTC_MODE2_CTRLB) CLK_RTC_OUT = CLK_RTC/16 Position  */
+#define RTC_MODE2_CTRLB_ACTF_DIV32          (RTC_MODE2_CTRLB_ACTF_DIV32_Val << RTC_MODE2_CTRLB_ACTF_Pos)  /**< (RTC_MODE2_CTRLB) CLK_RTC_OUT = CLK_RTC/32 Position  */
+#define RTC_MODE2_CTRLB_ACTF_DIV64          (RTC_MODE2_CTRLB_ACTF_DIV64_Val << RTC_MODE2_CTRLB_ACTF_Pos)  /**< (RTC_MODE2_CTRLB) CLK_RTC_OUT = CLK_RTC/64 Position  */
+#define RTC_MODE2_CTRLB_ACTF_DIV128         (RTC_MODE2_CTRLB_ACTF_DIV128_Val << RTC_MODE2_CTRLB_ACTF_Pos)  /**< (RTC_MODE2_CTRLB) CLK_RTC_OUT = CLK_RTC/128 Position  */
+#define RTC_MODE2_CTRLB_ACTF_DIV256         (RTC_MODE2_CTRLB_ACTF_DIV256_Val << RTC_MODE2_CTRLB_ACTF_Pos)  /**< (RTC_MODE2_CTRLB) CLK_RTC_OUT = CLK_RTC/256 Position  */
+#define RTC_MODE2_CTRLB_SEPTO_Pos           15                                             /**< (RTC_MODE2_CTRLB) Separate Tamper Outputs Position */
+#define RTC_MODE2_CTRLB_SEPTO_Msk           (_U_(0x1) << RTC_MODE2_CTRLB_SEPTO_Pos)        /**< (RTC_MODE2_CTRLB) Separate Tamper Outputs Mask */
+#define RTC_MODE2_CTRLB_SEPTO               RTC_MODE2_CTRLB_SEPTO_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_CTRLB_SEPTO_Msk instead */
+#define RTC_MODE2_CTRLB_MASK                _U_(0xF7F1)                                    /**< \deprecated (RTC_MODE2_CTRLB) Register MASK  (Use RTC_MODE2_CTRLB_Msk instead)  */
+#define RTC_MODE2_CTRLB_Msk                 _U_(0xF7F1)                                    /**< (RTC_MODE2_CTRLB) Register Mask  */
+
+
+/* -------- RTC_MODE0_EVCTRL : (RTC Offset: 0x04) (R/W 32) MODE0 Event Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t PEREO0:1;                  /**< bit:      0  Periodic Interval 0 Event Output Enable  */
+    uint32_t PEREO1:1;                  /**< bit:      1  Periodic Interval 1 Event Output Enable  */
+    uint32_t PEREO2:1;                  /**< bit:      2  Periodic Interval 2 Event Output Enable  */
+    uint32_t PEREO3:1;                  /**< bit:      3  Periodic Interval 3 Event Output Enable  */
+    uint32_t PEREO4:1;                  /**< bit:      4  Periodic Interval 4 Event Output Enable  */
+    uint32_t PEREO5:1;                  /**< bit:      5  Periodic Interval 5 Event Output Enable  */
+    uint32_t PEREO6:1;                  /**< bit:      6  Periodic Interval 6 Event Output Enable  */
+    uint32_t PEREO7:1;                  /**< bit:      7  Periodic Interval 7 Event Output Enable  */
+    uint32_t CMPEO0:1;                  /**< bit:      8  Compare 0 Event Output Enable            */
+    uint32_t :5;                        /**< bit:  9..13  Reserved */
+    uint32_t TAMPEREO:1;                /**< bit:     14  Tamper Event Output Enable               */
+    uint32_t OVFEO:1;                   /**< bit:     15  Overflow Event Output Enable             */
+    uint32_t TAMPEVEI:1;                /**< bit:     16  Tamper Event Input Enable                */
+    uint32_t :7;                        /**< bit: 17..23  Reserved */
+    uint32_t PERDEO:1;                  /**< bit:     24  Periodic Interval Daily Event Output Enable */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t PEREO:8;                   /**< bit:   0..7  Periodic Interval x Event Output Enable  */
+    uint32_t CMPEO:1;                   /**< bit:      8  Compare x Event Output Enable            */
+    uint32_t :23;                       /**< bit:  9..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_MODE0_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE0_EVCTRL_OFFSET             (0x04)                                        /**<  (RTC_MODE0_EVCTRL) MODE0 Event Control  Offset */
+#define RTC_MODE0_EVCTRL_RESETVALUE         _U_(0x00)                                     /**<  (RTC_MODE0_EVCTRL) MODE0 Event Control  Reset Value */
+
+#define RTC_MODE0_EVCTRL_PEREO0_Pos         0                                              /**< (RTC_MODE0_EVCTRL) Periodic Interval 0 Event Output Enable Position */
+#define RTC_MODE0_EVCTRL_PEREO0_Msk         (_U_(0x1) << RTC_MODE0_EVCTRL_PEREO0_Pos)      /**< (RTC_MODE0_EVCTRL) Periodic Interval 0 Event Output Enable Mask */
+#define RTC_MODE0_EVCTRL_PEREO0             RTC_MODE0_EVCTRL_PEREO0_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_EVCTRL_PEREO0_Msk instead */
+#define RTC_MODE0_EVCTRL_PEREO1_Pos         1                                              /**< (RTC_MODE0_EVCTRL) Periodic Interval 1 Event Output Enable Position */
+#define RTC_MODE0_EVCTRL_PEREO1_Msk         (_U_(0x1) << RTC_MODE0_EVCTRL_PEREO1_Pos)      /**< (RTC_MODE0_EVCTRL) Periodic Interval 1 Event Output Enable Mask */
+#define RTC_MODE0_EVCTRL_PEREO1             RTC_MODE0_EVCTRL_PEREO1_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_EVCTRL_PEREO1_Msk instead */
+#define RTC_MODE0_EVCTRL_PEREO2_Pos         2                                              /**< (RTC_MODE0_EVCTRL) Periodic Interval 2 Event Output Enable Position */
+#define RTC_MODE0_EVCTRL_PEREO2_Msk         (_U_(0x1) << RTC_MODE0_EVCTRL_PEREO2_Pos)      /**< (RTC_MODE0_EVCTRL) Periodic Interval 2 Event Output Enable Mask */
+#define RTC_MODE0_EVCTRL_PEREO2             RTC_MODE0_EVCTRL_PEREO2_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_EVCTRL_PEREO2_Msk instead */
+#define RTC_MODE0_EVCTRL_PEREO3_Pos         3                                              /**< (RTC_MODE0_EVCTRL) Periodic Interval 3 Event Output Enable Position */
+#define RTC_MODE0_EVCTRL_PEREO3_Msk         (_U_(0x1) << RTC_MODE0_EVCTRL_PEREO3_Pos)      /**< (RTC_MODE0_EVCTRL) Periodic Interval 3 Event Output Enable Mask */
+#define RTC_MODE0_EVCTRL_PEREO3             RTC_MODE0_EVCTRL_PEREO3_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_EVCTRL_PEREO3_Msk instead */
+#define RTC_MODE0_EVCTRL_PEREO4_Pos         4                                              /**< (RTC_MODE0_EVCTRL) Periodic Interval 4 Event Output Enable Position */
+#define RTC_MODE0_EVCTRL_PEREO4_Msk         (_U_(0x1) << RTC_MODE0_EVCTRL_PEREO4_Pos)      /**< (RTC_MODE0_EVCTRL) Periodic Interval 4 Event Output Enable Mask */
+#define RTC_MODE0_EVCTRL_PEREO4             RTC_MODE0_EVCTRL_PEREO4_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_EVCTRL_PEREO4_Msk instead */
+#define RTC_MODE0_EVCTRL_PEREO5_Pos         5                                              /**< (RTC_MODE0_EVCTRL) Periodic Interval 5 Event Output Enable Position */
+#define RTC_MODE0_EVCTRL_PEREO5_Msk         (_U_(0x1) << RTC_MODE0_EVCTRL_PEREO5_Pos)      /**< (RTC_MODE0_EVCTRL) Periodic Interval 5 Event Output Enable Mask */
+#define RTC_MODE0_EVCTRL_PEREO5             RTC_MODE0_EVCTRL_PEREO5_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_EVCTRL_PEREO5_Msk instead */
+#define RTC_MODE0_EVCTRL_PEREO6_Pos         6                                              /**< (RTC_MODE0_EVCTRL) Periodic Interval 6 Event Output Enable Position */
+#define RTC_MODE0_EVCTRL_PEREO6_Msk         (_U_(0x1) << RTC_MODE0_EVCTRL_PEREO6_Pos)      /**< (RTC_MODE0_EVCTRL) Periodic Interval 6 Event Output Enable Mask */
+#define RTC_MODE0_EVCTRL_PEREO6             RTC_MODE0_EVCTRL_PEREO6_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_EVCTRL_PEREO6_Msk instead */
+#define RTC_MODE0_EVCTRL_PEREO7_Pos         7                                              /**< (RTC_MODE0_EVCTRL) Periodic Interval 7 Event Output Enable Position */
+#define RTC_MODE0_EVCTRL_PEREO7_Msk         (_U_(0x1) << RTC_MODE0_EVCTRL_PEREO7_Pos)      /**< (RTC_MODE0_EVCTRL) Periodic Interval 7 Event Output Enable Mask */
+#define RTC_MODE0_EVCTRL_PEREO7             RTC_MODE0_EVCTRL_PEREO7_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_EVCTRL_PEREO7_Msk instead */
+#define RTC_MODE0_EVCTRL_CMPEO0_Pos         8                                              /**< (RTC_MODE0_EVCTRL) Compare 0 Event Output Enable Position */
+#define RTC_MODE0_EVCTRL_CMPEO0_Msk         (_U_(0x1) << RTC_MODE0_EVCTRL_CMPEO0_Pos)      /**< (RTC_MODE0_EVCTRL) Compare 0 Event Output Enable Mask */
+#define RTC_MODE0_EVCTRL_CMPEO0             RTC_MODE0_EVCTRL_CMPEO0_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_EVCTRL_CMPEO0_Msk instead */
+#define RTC_MODE0_EVCTRL_TAMPEREO_Pos       14                                             /**< (RTC_MODE0_EVCTRL) Tamper Event Output Enable Position */
+#define RTC_MODE0_EVCTRL_TAMPEREO_Msk       (_U_(0x1) << RTC_MODE0_EVCTRL_TAMPEREO_Pos)    /**< (RTC_MODE0_EVCTRL) Tamper Event Output Enable Mask */
+#define RTC_MODE0_EVCTRL_TAMPEREO           RTC_MODE0_EVCTRL_TAMPEREO_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_EVCTRL_TAMPEREO_Msk instead */
+#define RTC_MODE0_EVCTRL_OVFEO_Pos          15                                             /**< (RTC_MODE0_EVCTRL) Overflow Event Output Enable Position */
+#define RTC_MODE0_EVCTRL_OVFEO_Msk          (_U_(0x1) << RTC_MODE0_EVCTRL_OVFEO_Pos)       /**< (RTC_MODE0_EVCTRL) Overflow Event Output Enable Mask */
+#define RTC_MODE0_EVCTRL_OVFEO              RTC_MODE0_EVCTRL_OVFEO_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_EVCTRL_OVFEO_Msk instead */
+#define RTC_MODE0_EVCTRL_TAMPEVEI_Pos       16                                             /**< (RTC_MODE0_EVCTRL) Tamper Event Input Enable Position */
+#define RTC_MODE0_EVCTRL_TAMPEVEI_Msk       (_U_(0x1) << RTC_MODE0_EVCTRL_TAMPEVEI_Pos)    /**< (RTC_MODE0_EVCTRL) Tamper Event Input Enable Mask */
+#define RTC_MODE0_EVCTRL_TAMPEVEI           RTC_MODE0_EVCTRL_TAMPEVEI_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_EVCTRL_TAMPEVEI_Msk instead */
+#define RTC_MODE0_EVCTRL_PERDEO_Pos         24                                             /**< (RTC_MODE0_EVCTRL) Periodic Interval Daily Event Output Enable Position */
+#define RTC_MODE0_EVCTRL_PERDEO_Msk         (_U_(0x1) << RTC_MODE0_EVCTRL_PERDEO_Pos)      /**< (RTC_MODE0_EVCTRL) Periodic Interval Daily Event Output Enable Mask */
+#define RTC_MODE0_EVCTRL_PERDEO             RTC_MODE0_EVCTRL_PERDEO_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_EVCTRL_PERDEO_Msk instead */
+#define RTC_MODE0_EVCTRL_MASK               _U_(0x101C1FF)                                 /**< \deprecated (RTC_MODE0_EVCTRL) Register MASK  (Use RTC_MODE0_EVCTRL_Msk instead)  */
+#define RTC_MODE0_EVCTRL_Msk                _U_(0x101C1FF)                                 /**< (RTC_MODE0_EVCTRL) Register Mask  */
+
+#define RTC_MODE0_EVCTRL_PEREO_Pos          0                                              /**< (RTC_MODE0_EVCTRL Position) Periodic Interval x Event Output Enable */
+#define RTC_MODE0_EVCTRL_PEREO_Msk          (_U_(0xFF) << RTC_MODE0_EVCTRL_PEREO_Pos)      /**< (RTC_MODE0_EVCTRL Mask) PEREO */
+#define RTC_MODE0_EVCTRL_PEREO(value)       (RTC_MODE0_EVCTRL_PEREO_Msk & ((value) << RTC_MODE0_EVCTRL_PEREO_Pos))  
+#define RTC_MODE0_EVCTRL_CMPEO_Pos          8                                              /**< (RTC_MODE0_EVCTRL Position) Compare x Event Output Enable */
+#define RTC_MODE0_EVCTRL_CMPEO_Msk          (_U_(0x1) << RTC_MODE0_EVCTRL_CMPEO_Pos)       /**< (RTC_MODE0_EVCTRL Mask) CMPEO */
+#define RTC_MODE0_EVCTRL_CMPEO(value)       (RTC_MODE0_EVCTRL_CMPEO_Msk & ((value) << RTC_MODE0_EVCTRL_CMPEO_Pos))  
+
+/* -------- RTC_MODE1_EVCTRL : (RTC Offset: 0x04) (R/W 32) MODE1 Event Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t PEREO0:1;                  /**< bit:      0  Periodic Interval 0 Event Output Enable  */
+    uint32_t PEREO1:1;                  /**< bit:      1  Periodic Interval 1 Event Output Enable  */
+    uint32_t PEREO2:1;                  /**< bit:      2  Periodic Interval 2 Event Output Enable  */
+    uint32_t PEREO3:1;                  /**< bit:      3  Periodic Interval 3 Event Output Enable  */
+    uint32_t PEREO4:1;                  /**< bit:      4  Periodic Interval 4 Event Output Enable  */
+    uint32_t PEREO5:1;                  /**< bit:      5  Periodic Interval 5 Event Output Enable  */
+    uint32_t PEREO6:1;                  /**< bit:      6  Periodic Interval 6 Event Output Enable  */
+    uint32_t PEREO7:1;                  /**< bit:      7  Periodic Interval 7 Event Output Enable  */
+    uint32_t CMPEO0:1;                  /**< bit:      8  Compare 0 Event Output Enable            */
+    uint32_t CMPEO1:1;                  /**< bit:      9  Compare 1 Event Output Enable            */
+    uint32_t :4;                        /**< bit: 10..13  Reserved */
+    uint32_t TAMPEREO:1;                /**< bit:     14  Tamper Event Output Enable               */
+    uint32_t OVFEO:1;                   /**< bit:     15  Overflow Event Output Enable             */
+    uint32_t TAMPEVEI:1;                /**< bit:     16  Tamper Event Input Enable                */
+    uint32_t :7;                        /**< bit: 17..23  Reserved */
+    uint32_t PERDEO:1;                  /**< bit:     24  Periodic Interval Daily Event Output Enable */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t PEREO:8;                   /**< bit:   0..7  Periodic Interval x Event Output Enable  */
+    uint32_t CMPEO:2;                   /**< bit:   8..9  Compare x Event Output Enable            */
+    uint32_t :22;                       /**< bit: 10..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_MODE1_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE1_EVCTRL_OFFSET             (0x04)                                        /**<  (RTC_MODE1_EVCTRL) MODE1 Event Control  Offset */
+#define RTC_MODE1_EVCTRL_RESETVALUE         _U_(0x00)                                     /**<  (RTC_MODE1_EVCTRL) MODE1 Event Control  Reset Value */
+
+#define RTC_MODE1_EVCTRL_PEREO0_Pos         0                                              /**< (RTC_MODE1_EVCTRL) Periodic Interval 0 Event Output Enable Position */
+#define RTC_MODE1_EVCTRL_PEREO0_Msk         (_U_(0x1) << RTC_MODE1_EVCTRL_PEREO0_Pos)      /**< (RTC_MODE1_EVCTRL) Periodic Interval 0 Event Output Enable Mask */
+#define RTC_MODE1_EVCTRL_PEREO0             RTC_MODE1_EVCTRL_PEREO0_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_EVCTRL_PEREO0_Msk instead */
+#define RTC_MODE1_EVCTRL_PEREO1_Pos         1                                              /**< (RTC_MODE1_EVCTRL) Periodic Interval 1 Event Output Enable Position */
+#define RTC_MODE1_EVCTRL_PEREO1_Msk         (_U_(0x1) << RTC_MODE1_EVCTRL_PEREO1_Pos)      /**< (RTC_MODE1_EVCTRL) Periodic Interval 1 Event Output Enable Mask */
+#define RTC_MODE1_EVCTRL_PEREO1             RTC_MODE1_EVCTRL_PEREO1_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_EVCTRL_PEREO1_Msk instead */
+#define RTC_MODE1_EVCTRL_PEREO2_Pos         2                                              /**< (RTC_MODE1_EVCTRL) Periodic Interval 2 Event Output Enable Position */
+#define RTC_MODE1_EVCTRL_PEREO2_Msk         (_U_(0x1) << RTC_MODE1_EVCTRL_PEREO2_Pos)      /**< (RTC_MODE1_EVCTRL) Periodic Interval 2 Event Output Enable Mask */
+#define RTC_MODE1_EVCTRL_PEREO2             RTC_MODE1_EVCTRL_PEREO2_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_EVCTRL_PEREO2_Msk instead */
+#define RTC_MODE1_EVCTRL_PEREO3_Pos         3                                              /**< (RTC_MODE1_EVCTRL) Periodic Interval 3 Event Output Enable Position */
+#define RTC_MODE1_EVCTRL_PEREO3_Msk         (_U_(0x1) << RTC_MODE1_EVCTRL_PEREO3_Pos)      /**< (RTC_MODE1_EVCTRL) Periodic Interval 3 Event Output Enable Mask */
+#define RTC_MODE1_EVCTRL_PEREO3             RTC_MODE1_EVCTRL_PEREO3_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_EVCTRL_PEREO3_Msk instead */
+#define RTC_MODE1_EVCTRL_PEREO4_Pos         4                                              /**< (RTC_MODE1_EVCTRL) Periodic Interval 4 Event Output Enable Position */
+#define RTC_MODE1_EVCTRL_PEREO4_Msk         (_U_(0x1) << RTC_MODE1_EVCTRL_PEREO4_Pos)      /**< (RTC_MODE1_EVCTRL) Periodic Interval 4 Event Output Enable Mask */
+#define RTC_MODE1_EVCTRL_PEREO4             RTC_MODE1_EVCTRL_PEREO4_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_EVCTRL_PEREO4_Msk instead */
+#define RTC_MODE1_EVCTRL_PEREO5_Pos         5                                              /**< (RTC_MODE1_EVCTRL) Periodic Interval 5 Event Output Enable Position */
+#define RTC_MODE1_EVCTRL_PEREO5_Msk         (_U_(0x1) << RTC_MODE1_EVCTRL_PEREO5_Pos)      /**< (RTC_MODE1_EVCTRL) Periodic Interval 5 Event Output Enable Mask */
+#define RTC_MODE1_EVCTRL_PEREO5             RTC_MODE1_EVCTRL_PEREO5_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_EVCTRL_PEREO5_Msk instead */
+#define RTC_MODE1_EVCTRL_PEREO6_Pos         6                                              /**< (RTC_MODE1_EVCTRL) Periodic Interval 6 Event Output Enable Position */
+#define RTC_MODE1_EVCTRL_PEREO6_Msk         (_U_(0x1) << RTC_MODE1_EVCTRL_PEREO6_Pos)      /**< (RTC_MODE1_EVCTRL) Periodic Interval 6 Event Output Enable Mask */
+#define RTC_MODE1_EVCTRL_PEREO6             RTC_MODE1_EVCTRL_PEREO6_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_EVCTRL_PEREO6_Msk instead */
+#define RTC_MODE1_EVCTRL_PEREO7_Pos         7                                              /**< (RTC_MODE1_EVCTRL) Periodic Interval 7 Event Output Enable Position */
+#define RTC_MODE1_EVCTRL_PEREO7_Msk         (_U_(0x1) << RTC_MODE1_EVCTRL_PEREO7_Pos)      /**< (RTC_MODE1_EVCTRL) Periodic Interval 7 Event Output Enable Mask */
+#define RTC_MODE1_EVCTRL_PEREO7             RTC_MODE1_EVCTRL_PEREO7_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_EVCTRL_PEREO7_Msk instead */
+#define RTC_MODE1_EVCTRL_CMPEO0_Pos         8                                              /**< (RTC_MODE1_EVCTRL) Compare 0 Event Output Enable Position */
+#define RTC_MODE1_EVCTRL_CMPEO0_Msk         (_U_(0x1) << RTC_MODE1_EVCTRL_CMPEO0_Pos)      /**< (RTC_MODE1_EVCTRL) Compare 0 Event Output Enable Mask */
+#define RTC_MODE1_EVCTRL_CMPEO0             RTC_MODE1_EVCTRL_CMPEO0_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_EVCTRL_CMPEO0_Msk instead */
+#define RTC_MODE1_EVCTRL_CMPEO1_Pos         9                                              /**< (RTC_MODE1_EVCTRL) Compare 1 Event Output Enable Position */
+#define RTC_MODE1_EVCTRL_CMPEO1_Msk         (_U_(0x1) << RTC_MODE1_EVCTRL_CMPEO1_Pos)      /**< (RTC_MODE1_EVCTRL) Compare 1 Event Output Enable Mask */
+#define RTC_MODE1_EVCTRL_CMPEO1             RTC_MODE1_EVCTRL_CMPEO1_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_EVCTRL_CMPEO1_Msk instead */
+#define RTC_MODE1_EVCTRL_TAMPEREO_Pos       14                                             /**< (RTC_MODE1_EVCTRL) Tamper Event Output Enable Position */
+#define RTC_MODE1_EVCTRL_TAMPEREO_Msk       (_U_(0x1) << RTC_MODE1_EVCTRL_TAMPEREO_Pos)    /**< (RTC_MODE1_EVCTRL) Tamper Event Output Enable Mask */
+#define RTC_MODE1_EVCTRL_TAMPEREO           RTC_MODE1_EVCTRL_TAMPEREO_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_EVCTRL_TAMPEREO_Msk instead */
+#define RTC_MODE1_EVCTRL_OVFEO_Pos          15                                             /**< (RTC_MODE1_EVCTRL) Overflow Event Output Enable Position */
+#define RTC_MODE1_EVCTRL_OVFEO_Msk          (_U_(0x1) << RTC_MODE1_EVCTRL_OVFEO_Pos)       /**< (RTC_MODE1_EVCTRL) Overflow Event Output Enable Mask */
+#define RTC_MODE1_EVCTRL_OVFEO              RTC_MODE1_EVCTRL_OVFEO_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_EVCTRL_OVFEO_Msk instead */
+#define RTC_MODE1_EVCTRL_TAMPEVEI_Pos       16                                             /**< (RTC_MODE1_EVCTRL) Tamper Event Input Enable Position */
+#define RTC_MODE1_EVCTRL_TAMPEVEI_Msk       (_U_(0x1) << RTC_MODE1_EVCTRL_TAMPEVEI_Pos)    /**< (RTC_MODE1_EVCTRL) Tamper Event Input Enable Mask */
+#define RTC_MODE1_EVCTRL_TAMPEVEI           RTC_MODE1_EVCTRL_TAMPEVEI_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_EVCTRL_TAMPEVEI_Msk instead */
+#define RTC_MODE1_EVCTRL_PERDEO_Pos         24                                             /**< (RTC_MODE1_EVCTRL) Periodic Interval Daily Event Output Enable Position */
+#define RTC_MODE1_EVCTRL_PERDEO_Msk         (_U_(0x1) << RTC_MODE1_EVCTRL_PERDEO_Pos)      /**< (RTC_MODE1_EVCTRL) Periodic Interval Daily Event Output Enable Mask */
+#define RTC_MODE1_EVCTRL_PERDEO             RTC_MODE1_EVCTRL_PERDEO_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_EVCTRL_PERDEO_Msk instead */
+#define RTC_MODE1_EVCTRL_MASK               _U_(0x101C3FF)                                 /**< \deprecated (RTC_MODE1_EVCTRL) Register MASK  (Use RTC_MODE1_EVCTRL_Msk instead)  */
+#define RTC_MODE1_EVCTRL_Msk                _U_(0x101C3FF)                                 /**< (RTC_MODE1_EVCTRL) Register Mask  */
+
+#define RTC_MODE1_EVCTRL_PEREO_Pos          0                                              /**< (RTC_MODE1_EVCTRL Position) Periodic Interval x Event Output Enable */
+#define RTC_MODE1_EVCTRL_PEREO_Msk          (_U_(0xFF) << RTC_MODE1_EVCTRL_PEREO_Pos)      /**< (RTC_MODE1_EVCTRL Mask) PEREO */
+#define RTC_MODE1_EVCTRL_PEREO(value)       (RTC_MODE1_EVCTRL_PEREO_Msk & ((value) << RTC_MODE1_EVCTRL_PEREO_Pos))  
+#define RTC_MODE1_EVCTRL_CMPEO_Pos          8                                              /**< (RTC_MODE1_EVCTRL Position) Compare x Event Output Enable */
+#define RTC_MODE1_EVCTRL_CMPEO_Msk          (_U_(0x3) << RTC_MODE1_EVCTRL_CMPEO_Pos)       /**< (RTC_MODE1_EVCTRL Mask) CMPEO */
+#define RTC_MODE1_EVCTRL_CMPEO(value)       (RTC_MODE1_EVCTRL_CMPEO_Msk & ((value) << RTC_MODE1_EVCTRL_CMPEO_Pos))  
+
+/* -------- RTC_MODE2_EVCTRL : (RTC Offset: 0x04) (R/W 32) MODE2 Event Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t PEREO0:1;                  /**< bit:      0  Periodic Interval 0 Event Output Enable  */
+    uint32_t PEREO1:1;                  /**< bit:      1  Periodic Interval 1 Event Output Enable  */
+    uint32_t PEREO2:1;                  /**< bit:      2  Periodic Interval 2 Event Output Enable  */
+    uint32_t PEREO3:1;                  /**< bit:      3  Periodic Interval 3 Event Output Enable  */
+    uint32_t PEREO4:1;                  /**< bit:      4  Periodic Interval 4 Event Output Enable  */
+    uint32_t PEREO5:1;                  /**< bit:      5  Periodic Interval 5 Event Output Enable  */
+    uint32_t PEREO6:1;                  /**< bit:      6  Periodic Interval 6 Event Output Enable  */
+    uint32_t PEREO7:1;                  /**< bit:      7  Periodic Interval 7 Event Output Enable  */
+    uint32_t ALARMEO0:1;                /**< bit:      8  Alarm 0 Event Output Enable              */
+    uint32_t :5;                        /**< bit:  9..13  Reserved */
+    uint32_t TAMPEREO:1;                /**< bit:     14  Tamper Event Output Enable               */
+    uint32_t OVFEO:1;                   /**< bit:     15  Overflow Event Output Enable             */
+    uint32_t TAMPEVEI:1;                /**< bit:     16  Tamper Event Input Enable                */
+    uint32_t :7;                        /**< bit: 17..23  Reserved */
+    uint32_t PERDEO:1;                  /**< bit:     24  Periodic Interval Daily Event Output Enable */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t PEREO:8;                   /**< bit:   0..7  Periodic Interval x Event Output Enable  */
+    uint32_t ALARMEO:1;                 /**< bit:      8  Alarm x Event Output Enable              */
+    uint32_t :23;                       /**< bit:  9..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_MODE2_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE2_EVCTRL_OFFSET             (0x04)                                        /**<  (RTC_MODE2_EVCTRL) MODE2 Event Control  Offset */
+#define RTC_MODE2_EVCTRL_RESETVALUE         _U_(0x00)                                     /**<  (RTC_MODE2_EVCTRL) MODE2 Event Control  Reset Value */
+
+#define RTC_MODE2_EVCTRL_PEREO0_Pos         0                                              /**< (RTC_MODE2_EVCTRL) Periodic Interval 0 Event Output Enable Position */
+#define RTC_MODE2_EVCTRL_PEREO0_Msk         (_U_(0x1) << RTC_MODE2_EVCTRL_PEREO0_Pos)      /**< (RTC_MODE2_EVCTRL) Periodic Interval 0 Event Output Enable Mask */
+#define RTC_MODE2_EVCTRL_PEREO0             RTC_MODE2_EVCTRL_PEREO0_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_EVCTRL_PEREO0_Msk instead */
+#define RTC_MODE2_EVCTRL_PEREO1_Pos         1                                              /**< (RTC_MODE2_EVCTRL) Periodic Interval 1 Event Output Enable Position */
+#define RTC_MODE2_EVCTRL_PEREO1_Msk         (_U_(0x1) << RTC_MODE2_EVCTRL_PEREO1_Pos)      /**< (RTC_MODE2_EVCTRL) Periodic Interval 1 Event Output Enable Mask */
+#define RTC_MODE2_EVCTRL_PEREO1             RTC_MODE2_EVCTRL_PEREO1_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_EVCTRL_PEREO1_Msk instead */
+#define RTC_MODE2_EVCTRL_PEREO2_Pos         2                                              /**< (RTC_MODE2_EVCTRL) Periodic Interval 2 Event Output Enable Position */
+#define RTC_MODE2_EVCTRL_PEREO2_Msk         (_U_(0x1) << RTC_MODE2_EVCTRL_PEREO2_Pos)      /**< (RTC_MODE2_EVCTRL) Periodic Interval 2 Event Output Enable Mask */
+#define RTC_MODE2_EVCTRL_PEREO2             RTC_MODE2_EVCTRL_PEREO2_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_EVCTRL_PEREO2_Msk instead */
+#define RTC_MODE2_EVCTRL_PEREO3_Pos         3                                              /**< (RTC_MODE2_EVCTRL) Periodic Interval 3 Event Output Enable Position */
+#define RTC_MODE2_EVCTRL_PEREO3_Msk         (_U_(0x1) << RTC_MODE2_EVCTRL_PEREO3_Pos)      /**< (RTC_MODE2_EVCTRL) Periodic Interval 3 Event Output Enable Mask */
+#define RTC_MODE2_EVCTRL_PEREO3             RTC_MODE2_EVCTRL_PEREO3_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_EVCTRL_PEREO3_Msk instead */
+#define RTC_MODE2_EVCTRL_PEREO4_Pos         4                                              /**< (RTC_MODE2_EVCTRL) Periodic Interval 4 Event Output Enable Position */
+#define RTC_MODE2_EVCTRL_PEREO4_Msk         (_U_(0x1) << RTC_MODE2_EVCTRL_PEREO4_Pos)      /**< (RTC_MODE2_EVCTRL) Periodic Interval 4 Event Output Enable Mask */
+#define RTC_MODE2_EVCTRL_PEREO4             RTC_MODE2_EVCTRL_PEREO4_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_EVCTRL_PEREO4_Msk instead */
+#define RTC_MODE2_EVCTRL_PEREO5_Pos         5                                              /**< (RTC_MODE2_EVCTRL) Periodic Interval 5 Event Output Enable Position */
+#define RTC_MODE2_EVCTRL_PEREO5_Msk         (_U_(0x1) << RTC_MODE2_EVCTRL_PEREO5_Pos)      /**< (RTC_MODE2_EVCTRL) Periodic Interval 5 Event Output Enable Mask */
+#define RTC_MODE2_EVCTRL_PEREO5             RTC_MODE2_EVCTRL_PEREO5_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_EVCTRL_PEREO5_Msk instead */
+#define RTC_MODE2_EVCTRL_PEREO6_Pos         6                                              /**< (RTC_MODE2_EVCTRL) Periodic Interval 6 Event Output Enable Position */
+#define RTC_MODE2_EVCTRL_PEREO6_Msk         (_U_(0x1) << RTC_MODE2_EVCTRL_PEREO6_Pos)      /**< (RTC_MODE2_EVCTRL) Periodic Interval 6 Event Output Enable Mask */
+#define RTC_MODE2_EVCTRL_PEREO6             RTC_MODE2_EVCTRL_PEREO6_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_EVCTRL_PEREO6_Msk instead */
+#define RTC_MODE2_EVCTRL_PEREO7_Pos         7                                              /**< (RTC_MODE2_EVCTRL) Periodic Interval 7 Event Output Enable Position */
+#define RTC_MODE2_EVCTRL_PEREO7_Msk         (_U_(0x1) << RTC_MODE2_EVCTRL_PEREO7_Pos)      /**< (RTC_MODE2_EVCTRL) Periodic Interval 7 Event Output Enable Mask */
+#define RTC_MODE2_EVCTRL_PEREO7             RTC_MODE2_EVCTRL_PEREO7_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_EVCTRL_PEREO7_Msk instead */
+#define RTC_MODE2_EVCTRL_ALARMEO0_Pos       8                                              /**< (RTC_MODE2_EVCTRL) Alarm 0 Event Output Enable Position */
+#define RTC_MODE2_EVCTRL_ALARMEO0_Msk       (_U_(0x1) << RTC_MODE2_EVCTRL_ALARMEO0_Pos)    /**< (RTC_MODE2_EVCTRL) Alarm 0 Event Output Enable Mask */
+#define RTC_MODE2_EVCTRL_ALARMEO0           RTC_MODE2_EVCTRL_ALARMEO0_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_EVCTRL_ALARMEO0_Msk instead */
+#define RTC_MODE2_EVCTRL_TAMPEREO_Pos       14                                             /**< (RTC_MODE2_EVCTRL) Tamper Event Output Enable Position */
+#define RTC_MODE2_EVCTRL_TAMPEREO_Msk       (_U_(0x1) << RTC_MODE2_EVCTRL_TAMPEREO_Pos)    /**< (RTC_MODE2_EVCTRL) Tamper Event Output Enable Mask */
+#define RTC_MODE2_EVCTRL_TAMPEREO           RTC_MODE2_EVCTRL_TAMPEREO_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_EVCTRL_TAMPEREO_Msk instead */
+#define RTC_MODE2_EVCTRL_OVFEO_Pos          15                                             /**< (RTC_MODE2_EVCTRL) Overflow Event Output Enable Position */
+#define RTC_MODE2_EVCTRL_OVFEO_Msk          (_U_(0x1) << RTC_MODE2_EVCTRL_OVFEO_Pos)       /**< (RTC_MODE2_EVCTRL) Overflow Event Output Enable Mask */
+#define RTC_MODE2_EVCTRL_OVFEO              RTC_MODE2_EVCTRL_OVFEO_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_EVCTRL_OVFEO_Msk instead */
+#define RTC_MODE2_EVCTRL_TAMPEVEI_Pos       16                                             /**< (RTC_MODE2_EVCTRL) Tamper Event Input Enable Position */
+#define RTC_MODE2_EVCTRL_TAMPEVEI_Msk       (_U_(0x1) << RTC_MODE2_EVCTRL_TAMPEVEI_Pos)    /**< (RTC_MODE2_EVCTRL) Tamper Event Input Enable Mask */
+#define RTC_MODE2_EVCTRL_TAMPEVEI           RTC_MODE2_EVCTRL_TAMPEVEI_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_EVCTRL_TAMPEVEI_Msk instead */
+#define RTC_MODE2_EVCTRL_PERDEO_Pos         24                                             /**< (RTC_MODE2_EVCTRL) Periodic Interval Daily Event Output Enable Position */
+#define RTC_MODE2_EVCTRL_PERDEO_Msk         (_U_(0x1) << RTC_MODE2_EVCTRL_PERDEO_Pos)      /**< (RTC_MODE2_EVCTRL) Periodic Interval Daily Event Output Enable Mask */
+#define RTC_MODE2_EVCTRL_PERDEO             RTC_MODE2_EVCTRL_PERDEO_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_EVCTRL_PERDEO_Msk instead */
+#define RTC_MODE2_EVCTRL_MASK               _U_(0x101C1FF)                                 /**< \deprecated (RTC_MODE2_EVCTRL) Register MASK  (Use RTC_MODE2_EVCTRL_Msk instead)  */
+#define RTC_MODE2_EVCTRL_Msk                _U_(0x101C1FF)                                 /**< (RTC_MODE2_EVCTRL) Register Mask  */
+
+#define RTC_MODE2_EVCTRL_PEREO_Pos          0                                              /**< (RTC_MODE2_EVCTRL Position) Periodic Interval x Event Output Enable */
+#define RTC_MODE2_EVCTRL_PEREO_Msk          (_U_(0xFF) << RTC_MODE2_EVCTRL_PEREO_Pos)      /**< (RTC_MODE2_EVCTRL Mask) PEREO */
+#define RTC_MODE2_EVCTRL_PEREO(value)       (RTC_MODE2_EVCTRL_PEREO_Msk & ((value) << RTC_MODE2_EVCTRL_PEREO_Pos))  
+#define RTC_MODE2_EVCTRL_ALARMEO_Pos        8                                              /**< (RTC_MODE2_EVCTRL Position) Alarm x Event Output Enable */
+#define RTC_MODE2_EVCTRL_ALARMEO_Msk        (_U_(0x1) << RTC_MODE2_EVCTRL_ALARMEO_Pos)     /**< (RTC_MODE2_EVCTRL Mask) ALARMEO */
+#define RTC_MODE2_EVCTRL_ALARMEO(value)     (RTC_MODE2_EVCTRL_ALARMEO_Msk & ((value) << RTC_MODE2_EVCTRL_ALARMEO_Pos))  
+
+/* -------- RTC_MODE0_INTENCLR : (RTC Offset: 0x08) (R/W 16) MODE0 Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t PER0:1;                    /**< bit:      0  Periodic Interval 0 Interrupt Enable     */
+    uint16_t PER1:1;                    /**< bit:      1  Periodic Interval 1 Interrupt Enable     */
+    uint16_t PER2:1;                    /**< bit:      2  Periodic Interval 2 Interrupt Enable     */
+    uint16_t PER3:1;                    /**< bit:      3  Periodic Interval 3 Interrupt Enable     */
+    uint16_t PER4:1;                    /**< bit:      4  Periodic Interval 4 Interrupt Enable     */
+    uint16_t PER5:1;                    /**< bit:      5  Periodic Interval 5 Interrupt Enable     */
+    uint16_t PER6:1;                    /**< bit:      6  Periodic Interval 6 Interrupt Enable     */
+    uint16_t PER7:1;                    /**< bit:      7  Periodic Interval 7 Interrupt Enable     */
+    uint16_t CMP0:1;                    /**< bit:      8  Compare 0 Interrupt Enable               */
+    uint16_t :5;                        /**< bit:  9..13  Reserved */
+    uint16_t TAMPER:1;                  /**< bit:     14  Tamper Enable                            */
+    uint16_t OVF:1;                     /**< bit:     15  Overflow Interrupt Enable                */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint16_t PER:8;                     /**< bit:   0..7  Periodic Interval x Interrupt Enable     */
+    uint16_t CMP:1;                     /**< bit:      8  Compare x Interrupt Enable               */
+    uint16_t :7;                        /**< bit:  9..15 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint16_t reg;                         /**< Type used for register access */
+} RTC_MODE0_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE0_INTENCLR_OFFSET           (0x08)                                        /**<  (RTC_MODE0_INTENCLR) MODE0 Interrupt Enable Clear  Offset */
+#define RTC_MODE0_INTENCLR_RESETVALUE       _U_(0x00)                                     /**<  (RTC_MODE0_INTENCLR) MODE0 Interrupt Enable Clear  Reset Value */
+
+#define RTC_MODE0_INTENCLR_PER0_Pos         0                                              /**< (RTC_MODE0_INTENCLR) Periodic Interval 0 Interrupt Enable Position */
+#define RTC_MODE0_INTENCLR_PER0_Msk         (_U_(0x1) << RTC_MODE0_INTENCLR_PER0_Pos)      /**< (RTC_MODE0_INTENCLR) Periodic Interval 0 Interrupt Enable Mask */
+#define RTC_MODE0_INTENCLR_PER0             RTC_MODE0_INTENCLR_PER0_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTENCLR_PER0_Msk instead */
+#define RTC_MODE0_INTENCLR_PER1_Pos         1                                              /**< (RTC_MODE0_INTENCLR) Periodic Interval 1 Interrupt Enable Position */
+#define RTC_MODE0_INTENCLR_PER1_Msk         (_U_(0x1) << RTC_MODE0_INTENCLR_PER1_Pos)      /**< (RTC_MODE0_INTENCLR) Periodic Interval 1 Interrupt Enable Mask */
+#define RTC_MODE0_INTENCLR_PER1             RTC_MODE0_INTENCLR_PER1_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTENCLR_PER1_Msk instead */
+#define RTC_MODE0_INTENCLR_PER2_Pos         2                                              /**< (RTC_MODE0_INTENCLR) Periodic Interval 2 Interrupt Enable Position */
+#define RTC_MODE0_INTENCLR_PER2_Msk         (_U_(0x1) << RTC_MODE0_INTENCLR_PER2_Pos)      /**< (RTC_MODE0_INTENCLR) Periodic Interval 2 Interrupt Enable Mask */
+#define RTC_MODE0_INTENCLR_PER2             RTC_MODE0_INTENCLR_PER2_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTENCLR_PER2_Msk instead */
+#define RTC_MODE0_INTENCLR_PER3_Pos         3                                              /**< (RTC_MODE0_INTENCLR) Periodic Interval 3 Interrupt Enable Position */
+#define RTC_MODE0_INTENCLR_PER3_Msk         (_U_(0x1) << RTC_MODE0_INTENCLR_PER3_Pos)      /**< (RTC_MODE0_INTENCLR) Periodic Interval 3 Interrupt Enable Mask */
+#define RTC_MODE0_INTENCLR_PER3             RTC_MODE0_INTENCLR_PER3_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTENCLR_PER3_Msk instead */
+#define RTC_MODE0_INTENCLR_PER4_Pos         4                                              /**< (RTC_MODE0_INTENCLR) Periodic Interval 4 Interrupt Enable Position */
+#define RTC_MODE0_INTENCLR_PER4_Msk         (_U_(0x1) << RTC_MODE0_INTENCLR_PER4_Pos)      /**< (RTC_MODE0_INTENCLR) Periodic Interval 4 Interrupt Enable Mask */
+#define RTC_MODE0_INTENCLR_PER4             RTC_MODE0_INTENCLR_PER4_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTENCLR_PER4_Msk instead */
+#define RTC_MODE0_INTENCLR_PER5_Pos         5                                              /**< (RTC_MODE0_INTENCLR) Periodic Interval 5 Interrupt Enable Position */
+#define RTC_MODE0_INTENCLR_PER5_Msk         (_U_(0x1) << RTC_MODE0_INTENCLR_PER5_Pos)      /**< (RTC_MODE0_INTENCLR) Periodic Interval 5 Interrupt Enable Mask */
+#define RTC_MODE0_INTENCLR_PER5             RTC_MODE0_INTENCLR_PER5_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTENCLR_PER5_Msk instead */
+#define RTC_MODE0_INTENCLR_PER6_Pos         6                                              /**< (RTC_MODE0_INTENCLR) Periodic Interval 6 Interrupt Enable Position */
+#define RTC_MODE0_INTENCLR_PER6_Msk         (_U_(0x1) << RTC_MODE0_INTENCLR_PER6_Pos)      /**< (RTC_MODE0_INTENCLR) Periodic Interval 6 Interrupt Enable Mask */
+#define RTC_MODE0_INTENCLR_PER6             RTC_MODE0_INTENCLR_PER6_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTENCLR_PER6_Msk instead */
+#define RTC_MODE0_INTENCLR_PER7_Pos         7                                              /**< (RTC_MODE0_INTENCLR) Periodic Interval 7 Interrupt Enable Position */
+#define RTC_MODE0_INTENCLR_PER7_Msk         (_U_(0x1) << RTC_MODE0_INTENCLR_PER7_Pos)      /**< (RTC_MODE0_INTENCLR) Periodic Interval 7 Interrupt Enable Mask */
+#define RTC_MODE0_INTENCLR_PER7             RTC_MODE0_INTENCLR_PER7_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTENCLR_PER7_Msk instead */
+#define RTC_MODE0_INTENCLR_CMP0_Pos         8                                              /**< (RTC_MODE0_INTENCLR) Compare 0 Interrupt Enable Position */
+#define RTC_MODE0_INTENCLR_CMP0_Msk         (_U_(0x1) << RTC_MODE0_INTENCLR_CMP0_Pos)      /**< (RTC_MODE0_INTENCLR) Compare 0 Interrupt Enable Mask */
+#define RTC_MODE0_INTENCLR_CMP0             RTC_MODE0_INTENCLR_CMP0_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTENCLR_CMP0_Msk instead */
+#define RTC_MODE0_INTENCLR_TAMPER_Pos       14                                             /**< (RTC_MODE0_INTENCLR) Tamper Enable Position */
+#define RTC_MODE0_INTENCLR_TAMPER_Msk       (_U_(0x1) << RTC_MODE0_INTENCLR_TAMPER_Pos)    /**< (RTC_MODE0_INTENCLR) Tamper Enable Mask */
+#define RTC_MODE0_INTENCLR_TAMPER           RTC_MODE0_INTENCLR_TAMPER_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTENCLR_TAMPER_Msk instead */
+#define RTC_MODE0_INTENCLR_OVF_Pos          15                                             /**< (RTC_MODE0_INTENCLR) Overflow Interrupt Enable Position */
+#define RTC_MODE0_INTENCLR_OVF_Msk          (_U_(0x1) << RTC_MODE0_INTENCLR_OVF_Pos)       /**< (RTC_MODE0_INTENCLR) Overflow Interrupt Enable Mask */
+#define RTC_MODE0_INTENCLR_OVF              RTC_MODE0_INTENCLR_OVF_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTENCLR_OVF_Msk instead */
+#define RTC_MODE0_INTENCLR_MASK             _U_(0xC1FF)                                    /**< \deprecated (RTC_MODE0_INTENCLR) Register MASK  (Use RTC_MODE0_INTENCLR_Msk instead)  */
+#define RTC_MODE0_INTENCLR_Msk              _U_(0xC1FF)                                    /**< (RTC_MODE0_INTENCLR) Register Mask  */
+
+#define RTC_MODE0_INTENCLR_PER_Pos          0                                              /**< (RTC_MODE0_INTENCLR Position) Periodic Interval x Interrupt Enable */
+#define RTC_MODE0_INTENCLR_PER_Msk          (_U_(0xFF) << RTC_MODE0_INTENCLR_PER_Pos)      /**< (RTC_MODE0_INTENCLR Mask) PER */
+#define RTC_MODE0_INTENCLR_PER(value)       (RTC_MODE0_INTENCLR_PER_Msk & ((value) << RTC_MODE0_INTENCLR_PER_Pos))  
+#define RTC_MODE0_INTENCLR_CMP_Pos          8                                              /**< (RTC_MODE0_INTENCLR Position) Compare x Interrupt Enable */
+#define RTC_MODE0_INTENCLR_CMP_Msk          (_U_(0x1) << RTC_MODE0_INTENCLR_CMP_Pos)       /**< (RTC_MODE0_INTENCLR Mask) CMP */
+#define RTC_MODE0_INTENCLR_CMP(value)       (RTC_MODE0_INTENCLR_CMP_Msk & ((value) << RTC_MODE0_INTENCLR_CMP_Pos))  
+
+/* -------- RTC_MODE1_INTENCLR : (RTC Offset: 0x08) (R/W 16) MODE1 Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t PER0:1;                    /**< bit:      0  Periodic Interval 0 Interrupt Enable     */
+    uint16_t PER1:1;                    /**< bit:      1  Periodic Interval 1 Interrupt Enable     */
+    uint16_t PER2:1;                    /**< bit:      2  Periodic Interval 2 Interrupt Enable     */
+    uint16_t PER3:1;                    /**< bit:      3  Periodic Interval 3 Interrupt Enable     */
+    uint16_t PER4:1;                    /**< bit:      4  Periodic Interval 4 Interrupt Enable     */
+    uint16_t PER5:1;                    /**< bit:      5  Periodic Interval 5 Interrupt Enable     */
+    uint16_t PER6:1;                    /**< bit:      6  Periodic Interval 6 Interrupt Enable     */
+    uint16_t PER7:1;                    /**< bit:      7  Periodic Interval 7 Interrupt Enable     */
+    uint16_t CMP0:1;                    /**< bit:      8  Compare 0 Interrupt Enable               */
+    uint16_t CMP1:1;                    /**< bit:      9  Compare 1 Interrupt Enable               */
+    uint16_t :4;                        /**< bit: 10..13  Reserved */
+    uint16_t TAMPER:1;                  /**< bit:     14  Tamper Enable                            */
+    uint16_t OVF:1;                     /**< bit:     15  Overflow Interrupt Enable                */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint16_t PER:8;                     /**< bit:   0..7  Periodic Interval x Interrupt Enable     */
+    uint16_t CMP:2;                     /**< bit:   8..9  Compare x Interrupt Enable               */
+    uint16_t :6;                        /**< bit: 10..15 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint16_t reg;                         /**< Type used for register access */
+} RTC_MODE1_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE1_INTENCLR_OFFSET           (0x08)                                        /**<  (RTC_MODE1_INTENCLR) MODE1 Interrupt Enable Clear  Offset */
+#define RTC_MODE1_INTENCLR_RESETVALUE       _U_(0x00)                                     /**<  (RTC_MODE1_INTENCLR) MODE1 Interrupt Enable Clear  Reset Value */
+
+#define RTC_MODE1_INTENCLR_PER0_Pos         0                                              /**< (RTC_MODE1_INTENCLR) Periodic Interval 0 Interrupt Enable Position */
+#define RTC_MODE1_INTENCLR_PER0_Msk         (_U_(0x1) << RTC_MODE1_INTENCLR_PER0_Pos)      /**< (RTC_MODE1_INTENCLR) Periodic Interval 0 Interrupt Enable Mask */
+#define RTC_MODE1_INTENCLR_PER0             RTC_MODE1_INTENCLR_PER0_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTENCLR_PER0_Msk instead */
+#define RTC_MODE1_INTENCLR_PER1_Pos         1                                              /**< (RTC_MODE1_INTENCLR) Periodic Interval 1 Interrupt Enable Position */
+#define RTC_MODE1_INTENCLR_PER1_Msk         (_U_(0x1) << RTC_MODE1_INTENCLR_PER1_Pos)      /**< (RTC_MODE1_INTENCLR) Periodic Interval 1 Interrupt Enable Mask */
+#define RTC_MODE1_INTENCLR_PER1             RTC_MODE1_INTENCLR_PER1_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTENCLR_PER1_Msk instead */
+#define RTC_MODE1_INTENCLR_PER2_Pos         2                                              /**< (RTC_MODE1_INTENCLR) Periodic Interval 2 Interrupt Enable Position */
+#define RTC_MODE1_INTENCLR_PER2_Msk         (_U_(0x1) << RTC_MODE1_INTENCLR_PER2_Pos)      /**< (RTC_MODE1_INTENCLR) Periodic Interval 2 Interrupt Enable Mask */
+#define RTC_MODE1_INTENCLR_PER2             RTC_MODE1_INTENCLR_PER2_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTENCLR_PER2_Msk instead */
+#define RTC_MODE1_INTENCLR_PER3_Pos         3                                              /**< (RTC_MODE1_INTENCLR) Periodic Interval 3 Interrupt Enable Position */
+#define RTC_MODE1_INTENCLR_PER3_Msk         (_U_(0x1) << RTC_MODE1_INTENCLR_PER3_Pos)      /**< (RTC_MODE1_INTENCLR) Periodic Interval 3 Interrupt Enable Mask */
+#define RTC_MODE1_INTENCLR_PER3             RTC_MODE1_INTENCLR_PER3_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTENCLR_PER3_Msk instead */
+#define RTC_MODE1_INTENCLR_PER4_Pos         4                                              /**< (RTC_MODE1_INTENCLR) Periodic Interval 4 Interrupt Enable Position */
+#define RTC_MODE1_INTENCLR_PER4_Msk         (_U_(0x1) << RTC_MODE1_INTENCLR_PER4_Pos)      /**< (RTC_MODE1_INTENCLR) Periodic Interval 4 Interrupt Enable Mask */
+#define RTC_MODE1_INTENCLR_PER4             RTC_MODE1_INTENCLR_PER4_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTENCLR_PER4_Msk instead */
+#define RTC_MODE1_INTENCLR_PER5_Pos         5                                              /**< (RTC_MODE1_INTENCLR) Periodic Interval 5 Interrupt Enable Position */
+#define RTC_MODE1_INTENCLR_PER5_Msk         (_U_(0x1) << RTC_MODE1_INTENCLR_PER5_Pos)      /**< (RTC_MODE1_INTENCLR) Periodic Interval 5 Interrupt Enable Mask */
+#define RTC_MODE1_INTENCLR_PER5             RTC_MODE1_INTENCLR_PER5_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTENCLR_PER5_Msk instead */
+#define RTC_MODE1_INTENCLR_PER6_Pos         6                                              /**< (RTC_MODE1_INTENCLR) Periodic Interval 6 Interrupt Enable Position */
+#define RTC_MODE1_INTENCLR_PER6_Msk         (_U_(0x1) << RTC_MODE1_INTENCLR_PER6_Pos)      /**< (RTC_MODE1_INTENCLR) Periodic Interval 6 Interrupt Enable Mask */
+#define RTC_MODE1_INTENCLR_PER6             RTC_MODE1_INTENCLR_PER6_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTENCLR_PER6_Msk instead */
+#define RTC_MODE1_INTENCLR_PER7_Pos         7                                              /**< (RTC_MODE1_INTENCLR) Periodic Interval 7 Interrupt Enable Position */
+#define RTC_MODE1_INTENCLR_PER7_Msk         (_U_(0x1) << RTC_MODE1_INTENCLR_PER7_Pos)      /**< (RTC_MODE1_INTENCLR) Periodic Interval 7 Interrupt Enable Mask */
+#define RTC_MODE1_INTENCLR_PER7             RTC_MODE1_INTENCLR_PER7_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTENCLR_PER7_Msk instead */
+#define RTC_MODE1_INTENCLR_CMP0_Pos         8                                              /**< (RTC_MODE1_INTENCLR) Compare 0 Interrupt Enable Position */
+#define RTC_MODE1_INTENCLR_CMP0_Msk         (_U_(0x1) << RTC_MODE1_INTENCLR_CMP0_Pos)      /**< (RTC_MODE1_INTENCLR) Compare 0 Interrupt Enable Mask */
+#define RTC_MODE1_INTENCLR_CMP0             RTC_MODE1_INTENCLR_CMP0_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTENCLR_CMP0_Msk instead */
+#define RTC_MODE1_INTENCLR_CMP1_Pos         9                                              /**< (RTC_MODE1_INTENCLR) Compare 1 Interrupt Enable Position */
+#define RTC_MODE1_INTENCLR_CMP1_Msk         (_U_(0x1) << RTC_MODE1_INTENCLR_CMP1_Pos)      /**< (RTC_MODE1_INTENCLR) Compare 1 Interrupt Enable Mask */
+#define RTC_MODE1_INTENCLR_CMP1             RTC_MODE1_INTENCLR_CMP1_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTENCLR_CMP1_Msk instead */
+#define RTC_MODE1_INTENCLR_TAMPER_Pos       14                                             /**< (RTC_MODE1_INTENCLR) Tamper Enable Position */
+#define RTC_MODE1_INTENCLR_TAMPER_Msk       (_U_(0x1) << RTC_MODE1_INTENCLR_TAMPER_Pos)    /**< (RTC_MODE1_INTENCLR) Tamper Enable Mask */
+#define RTC_MODE1_INTENCLR_TAMPER           RTC_MODE1_INTENCLR_TAMPER_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTENCLR_TAMPER_Msk instead */
+#define RTC_MODE1_INTENCLR_OVF_Pos          15                                             /**< (RTC_MODE1_INTENCLR) Overflow Interrupt Enable Position */
+#define RTC_MODE1_INTENCLR_OVF_Msk          (_U_(0x1) << RTC_MODE1_INTENCLR_OVF_Pos)       /**< (RTC_MODE1_INTENCLR) Overflow Interrupt Enable Mask */
+#define RTC_MODE1_INTENCLR_OVF              RTC_MODE1_INTENCLR_OVF_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTENCLR_OVF_Msk instead */
+#define RTC_MODE1_INTENCLR_MASK             _U_(0xC3FF)                                    /**< \deprecated (RTC_MODE1_INTENCLR) Register MASK  (Use RTC_MODE1_INTENCLR_Msk instead)  */
+#define RTC_MODE1_INTENCLR_Msk              _U_(0xC3FF)                                    /**< (RTC_MODE1_INTENCLR) Register Mask  */
+
+#define RTC_MODE1_INTENCLR_PER_Pos          0                                              /**< (RTC_MODE1_INTENCLR Position) Periodic Interval x Interrupt Enable */
+#define RTC_MODE1_INTENCLR_PER_Msk          (_U_(0xFF) << RTC_MODE1_INTENCLR_PER_Pos)      /**< (RTC_MODE1_INTENCLR Mask) PER */
+#define RTC_MODE1_INTENCLR_PER(value)       (RTC_MODE1_INTENCLR_PER_Msk & ((value) << RTC_MODE1_INTENCLR_PER_Pos))  
+#define RTC_MODE1_INTENCLR_CMP_Pos          8                                              /**< (RTC_MODE1_INTENCLR Position) Compare x Interrupt Enable */
+#define RTC_MODE1_INTENCLR_CMP_Msk          (_U_(0x3) << RTC_MODE1_INTENCLR_CMP_Pos)       /**< (RTC_MODE1_INTENCLR Mask) CMP */
+#define RTC_MODE1_INTENCLR_CMP(value)       (RTC_MODE1_INTENCLR_CMP_Msk & ((value) << RTC_MODE1_INTENCLR_CMP_Pos))  
+
+/* -------- RTC_MODE2_INTENCLR : (RTC Offset: 0x08) (R/W 16) MODE2 Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t PER0:1;                    /**< bit:      0  Periodic Interval 0 Interrupt Enable     */
+    uint16_t PER1:1;                    /**< bit:      1  Periodic Interval 1 Interrupt Enable     */
+    uint16_t PER2:1;                    /**< bit:      2  Periodic Interval 2 Interrupt Enable     */
+    uint16_t PER3:1;                    /**< bit:      3  Periodic Interval 3 Interrupt Enable     */
+    uint16_t PER4:1;                    /**< bit:      4  Periodic Interval 4 Interrupt Enable     */
+    uint16_t PER5:1;                    /**< bit:      5  Periodic Interval 5 Interrupt Enable     */
+    uint16_t PER6:1;                    /**< bit:      6  Periodic Interval 6 Interrupt Enable     */
+    uint16_t PER7:1;                    /**< bit:      7  Periodic Interval 7 Interrupt Enable     */
+    uint16_t ALARM0:1;                  /**< bit:      8  Alarm 0 Interrupt Enable                 */
+    uint16_t :5;                        /**< bit:  9..13  Reserved */
+    uint16_t TAMPER:1;                  /**< bit:     14  Tamper Enable                            */
+    uint16_t OVF:1;                     /**< bit:     15  Overflow Interrupt Enable                */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint16_t PER:8;                     /**< bit:   0..7  Periodic Interval x Interrupt Enable     */
+    uint16_t ALARM:1;                   /**< bit:      8  Alarm x Interrupt Enable                 */
+    uint16_t :7;                        /**< bit:  9..15 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint16_t reg;                         /**< Type used for register access */
+} RTC_MODE2_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE2_INTENCLR_OFFSET           (0x08)                                        /**<  (RTC_MODE2_INTENCLR) MODE2 Interrupt Enable Clear  Offset */
+#define RTC_MODE2_INTENCLR_RESETVALUE       _U_(0x00)                                     /**<  (RTC_MODE2_INTENCLR) MODE2 Interrupt Enable Clear  Reset Value */
+
+#define RTC_MODE2_INTENCLR_PER0_Pos         0                                              /**< (RTC_MODE2_INTENCLR) Periodic Interval 0 Interrupt Enable Position */
+#define RTC_MODE2_INTENCLR_PER0_Msk         (_U_(0x1) << RTC_MODE2_INTENCLR_PER0_Pos)      /**< (RTC_MODE2_INTENCLR) Periodic Interval 0 Interrupt Enable Mask */
+#define RTC_MODE2_INTENCLR_PER0             RTC_MODE2_INTENCLR_PER0_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTENCLR_PER0_Msk instead */
+#define RTC_MODE2_INTENCLR_PER1_Pos         1                                              /**< (RTC_MODE2_INTENCLR) Periodic Interval 1 Interrupt Enable Position */
+#define RTC_MODE2_INTENCLR_PER1_Msk         (_U_(0x1) << RTC_MODE2_INTENCLR_PER1_Pos)      /**< (RTC_MODE2_INTENCLR) Periodic Interval 1 Interrupt Enable Mask */
+#define RTC_MODE2_INTENCLR_PER1             RTC_MODE2_INTENCLR_PER1_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTENCLR_PER1_Msk instead */
+#define RTC_MODE2_INTENCLR_PER2_Pos         2                                              /**< (RTC_MODE2_INTENCLR) Periodic Interval 2 Interrupt Enable Position */
+#define RTC_MODE2_INTENCLR_PER2_Msk         (_U_(0x1) << RTC_MODE2_INTENCLR_PER2_Pos)      /**< (RTC_MODE2_INTENCLR) Periodic Interval 2 Interrupt Enable Mask */
+#define RTC_MODE2_INTENCLR_PER2             RTC_MODE2_INTENCLR_PER2_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTENCLR_PER2_Msk instead */
+#define RTC_MODE2_INTENCLR_PER3_Pos         3                                              /**< (RTC_MODE2_INTENCLR) Periodic Interval 3 Interrupt Enable Position */
+#define RTC_MODE2_INTENCLR_PER3_Msk         (_U_(0x1) << RTC_MODE2_INTENCLR_PER3_Pos)      /**< (RTC_MODE2_INTENCLR) Periodic Interval 3 Interrupt Enable Mask */
+#define RTC_MODE2_INTENCLR_PER3             RTC_MODE2_INTENCLR_PER3_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTENCLR_PER3_Msk instead */
+#define RTC_MODE2_INTENCLR_PER4_Pos         4                                              /**< (RTC_MODE2_INTENCLR) Periodic Interval 4 Interrupt Enable Position */
+#define RTC_MODE2_INTENCLR_PER4_Msk         (_U_(0x1) << RTC_MODE2_INTENCLR_PER4_Pos)      /**< (RTC_MODE2_INTENCLR) Periodic Interval 4 Interrupt Enable Mask */
+#define RTC_MODE2_INTENCLR_PER4             RTC_MODE2_INTENCLR_PER4_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTENCLR_PER4_Msk instead */
+#define RTC_MODE2_INTENCLR_PER5_Pos         5                                              /**< (RTC_MODE2_INTENCLR) Periodic Interval 5 Interrupt Enable Position */
+#define RTC_MODE2_INTENCLR_PER5_Msk         (_U_(0x1) << RTC_MODE2_INTENCLR_PER5_Pos)      /**< (RTC_MODE2_INTENCLR) Periodic Interval 5 Interrupt Enable Mask */
+#define RTC_MODE2_INTENCLR_PER5             RTC_MODE2_INTENCLR_PER5_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTENCLR_PER5_Msk instead */
+#define RTC_MODE2_INTENCLR_PER6_Pos         6                                              /**< (RTC_MODE2_INTENCLR) Periodic Interval 6 Interrupt Enable Position */
+#define RTC_MODE2_INTENCLR_PER6_Msk         (_U_(0x1) << RTC_MODE2_INTENCLR_PER6_Pos)      /**< (RTC_MODE2_INTENCLR) Periodic Interval 6 Interrupt Enable Mask */
+#define RTC_MODE2_INTENCLR_PER6             RTC_MODE2_INTENCLR_PER6_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTENCLR_PER6_Msk instead */
+#define RTC_MODE2_INTENCLR_PER7_Pos         7                                              /**< (RTC_MODE2_INTENCLR) Periodic Interval 7 Interrupt Enable Position */
+#define RTC_MODE2_INTENCLR_PER7_Msk         (_U_(0x1) << RTC_MODE2_INTENCLR_PER7_Pos)      /**< (RTC_MODE2_INTENCLR) Periodic Interval 7 Interrupt Enable Mask */
+#define RTC_MODE2_INTENCLR_PER7             RTC_MODE2_INTENCLR_PER7_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTENCLR_PER7_Msk instead */
+#define RTC_MODE2_INTENCLR_ALARM0_Pos       8                                              /**< (RTC_MODE2_INTENCLR) Alarm 0 Interrupt Enable Position */
+#define RTC_MODE2_INTENCLR_ALARM0_Msk       (_U_(0x1) << RTC_MODE2_INTENCLR_ALARM0_Pos)    /**< (RTC_MODE2_INTENCLR) Alarm 0 Interrupt Enable Mask */
+#define RTC_MODE2_INTENCLR_ALARM0           RTC_MODE2_INTENCLR_ALARM0_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTENCLR_ALARM0_Msk instead */
+#define RTC_MODE2_INTENCLR_TAMPER_Pos       14                                             /**< (RTC_MODE2_INTENCLR) Tamper Enable Position */
+#define RTC_MODE2_INTENCLR_TAMPER_Msk       (_U_(0x1) << RTC_MODE2_INTENCLR_TAMPER_Pos)    /**< (RTC_MODE2_INTENCLR) Tamper Enable Mask */
+#define RTC_MODE2_INTENCLR_TAMPER           RTC_MODE2_INTENCLR_TAMPER_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTENCLR_TAMPER_Msk instead */
+#define RTC_MODE2_INTENCLR_OVF_Pos          15                                             /**< (RTC_MODE2_INTENCLR) Overflow Interrupt Enable Position */
+#define RTC_MODE2_INTENCLR_OVF_Msk          (_U_(0x1) << RTC_MODE2_INTENCLR_OVF_Pos)       /**< (RTC_MODE2_INTENCLR) Overflow Interrupt Enable Mask */
+#define RTC_MODE2_INTENCLR_OVF              RTC_MODE2_INTENCLR_OVF_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTENCLR_OVF_Msk instead */
+#define RTC_MODE2_INTENCLR_MASK             _U_(0xC1FF)                                    /**< \deprecated (RTC_MODE2_INTENCLR) Register MASK  (Use RTC_MODE2_INTENCLR_Msk instead)  */
+#define RTC_MODE2_INTENCLR_Msk              _U_(0xC1FF)                                    /**< (RTC_MODE2_INTENCLR) Register Mask  */
+
+#define RTC_MODE2_INTENCLR_PER_Pos          0                                              /**< (RTC_MODE2_INTENCLR Position) Periodic Interval x Interrupt Enable */
+#define RTC_MODE2_INTENCLR_PER_Msk          (_U_(0xFF) << RTC_MODE2_INTENCLR_PER_Pos)      /**< (RTC_MODE2_INTENCLR Mask) PER */
+#define RTC_MODE2_INTENCLR_PER(value)       (RTC_MODE2_INTENCLR_PER_Msk & ((value) << RTC_MODE2_INTENCLR_PER_Pos))  
+#define RTC_MODE2_INTENCLR_ALARM_Pos        8                                              /**< (RTC_MODE2_INTENCLR Position) Alarm x Interrupt Enable */
+#define RTC_MODE2_INTENCLR_ALARM_Msk        (_U_(0x1) << RTC_MODE2_INTENCLR_ALARM_Pos)     /**< (RTC_MODE2_INTENCLR Mask) ALARM */
+#define RTC_MODE2_INTENCLR_ALARM(value)     (RTC_MODE2_INTENCLR_ALARM_Msk & ((value) << RTC_MODE2_INTENCLR_ALARM_Pos))  
+
+/* -------- RTC_MODE0_INTENSET : (RTC Offset: 0x0a) (R/W 16) MODE0 Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t PER0:1;                    /**< bit:      0  Periodic Interval 0 Interrupt Enable     */
+    uint16_t PER1:1;                    /**< bit:      1  Periodic Interval 1 Interrupt Enable     */
+    uint16_t PER2:1;                    /**< bit:      2  Periodic Interval 2 Interrupt Enable     */
+    uint16_t PER3:1;                    /**< bit:      3  Periodic Interval 3 Interrupt Enable     */
+    uint16_t PER4:1;                    /**< bit:      4  Periodic Interval 4 Interrupt Enable     */
+    uint16_t PER5:1;                    /**< bit:      5  Periodic Interval 5 Interrupt Enable     */
+    uint16_t PER6:1;                    /**< bit:      6  Periodic Interval 6 Interrupt Enable     */
+    uint16_t PER7:1;                    /**< bit:      7  Periodic Interval 7 Interrupt Enable     */
+    uint16_t CMP0:1;                    /**< bit:      8  Compare 0 Interrupt Enable               */
+    uint16_t :5;                        /**< bit:  9..13  Reserved */
+    uint16_t TAMPER:1;                  /**< bit:     14  Tamper Enable                            */
+    uint16_t OVF:1;                     /**< bit:     15  Overflow Interrupt Enable                */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint16_t PER:8;                     /**< bit:   0..7  Periodic Interval x Interrupt Enable     */
+    uint16_t CMP:1;                     /**< bit:      8  Compare x Interrupt Enable               */
+    uint16_t :7;                        /**< bit:  9..15 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint16_t reg;                         /**< Type used for register access */
+} RTC_MODE0_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE0_INTENSET_OFFSET           (0x0A)                                        /**<  (RTC_MODE0_INTENSET) MODE0 Interrupt Enable Set  Offset */
+#define RTC_MODE0_INTENSET_RESETVALUE       _U_(0x00)                                     /**<  (RTC_MODE0_INTENSET) MODE0 Interrupt Enable Set  Reset Value */
+
+#define RTC_MODE0_INTENSET_PER0_Pos         0                                              /**< (RTC_MODE0_INTENSET) Periodic Interval 0 Interrupt Enable Position */
+#define RTC_MODE0_INTENSET_PER0_Msk         (_U_(0x1) << RTC_MODE0_INTENSET_PER0_Pos)      /**< (RTC_MODE0_INTENSET) Periodic Interval 0 Interrupt Enable Mask */
+#define RTC_MODE0_INTENSET_PER0             RTC_MODE0_INTENSET_PER0_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTENSET_PER0_Msk instead */
+#define RTC_MODE0_INTENSET_PER1_Pos         1                                              /**< (RTC_MODE0_INTENSET) Periodic Interval 1 Interrupt Enable Position */
+#define RTC_MODE0_INTENSET_PER1_Msk         (_U_(0x1) << RTC_MODE0_INTENSET_PER1_Pos)      /**< (RTC_MODE0_INTENSET) Periodic Interval 1 Interrupt Enable Mask */
+#define RTC_MODE0_INTENSET_PER1             RTC_MODE0_INTENSET_PER1_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTENSET_PER1_Msk instead */
+#define RTC_MODE0_INTENSET_PER2_Pos         2                                              /**< (RTC_MODE0_INTENSET) Periodic Interval 2 Interrupt Enable Position */
+#define RTC_MODE0_INTENSET_PER2_Msk         (_U_(0x1) << RTC_MODE0_INTENSET_PER2_Pos)      /**< (RTC_MODE0_INTENSET) Periodic Interval 2 Interrupt Enable Mask */
+#define RTC_MODE0_INTENSET_PER2             RTC_MODE0_INTENSET_PER2_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTENSET_PER2_Msk instead */
+#define RTC_MODE0_INTENSET_PER3_Pos         3                                              /**< (RTC_MODE0_INTENSET) Periodic Interval 3 Interrupt Enable Position */
+#define RTC_MODE0_INTENSET_PER3_Msk         (_U_(0x1) << RTC_MODE0_INTENSET_PER3_Pos)      /**< (RTC_MODE0_INTENSET) Periodic Interval 3 Interrupt Enable Mask */
+#define RTC_MODE0_INTENSET_PER3             RTC_MODE0_INTENSET_PER3_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTENSET_PER3_Msk instead */
+#define RTC_MODE0_INTENSET_PER4_Pos         4                                              /**< (RTC_MODE0_INTENSET) Periodic Interval 4 Interrupt Enable Position */
+#define RTC_MODE0_INTENSET_PER4_Msk         (_U_(0x1) << RTC_MODE0_INTENSET_PER4_Pos)      /**< (RTC_MODE0_INTENSET) Periodic Interval 4 Interrupt Enable Mask */
+#define RTC_MODE0_INTENSET_PER4             RTC_MODE0_INTENSET_PER4_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTENSET_PER4_Msk instead */
+#define RTC_MODE0_INTENSET_PER5_Pos         5                                              /**< (RTC_MODE0_INTENSET) Periodic Interval 5 Interrupt Enable Position */
+#define RTC_MODE0_INTENSET_PER5_Msk         (_U_(0x1) << RTC_MODE0_INTENSET_PER5_Pos)      /**< (RTC_MODE0_INTENSET) Periodic Interval 5 Interrupt Enable Mask */
+#define RTC_MODE0_INTENSET_PER5             RTC_MODE0_INTENSET_PER5_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTENSET_PER5_Msk instead */
+#define RTC_MODE0_INTENSET_PER6_Pos         6                                              /**< (RTC_MODE0_INTENSET) Periodic Interval 6 Interrupt Enable Position */
+#define RTC_MODE0_INTENSET_PER6_Msk         (_U_(0x1) << RTC_MODE0_INTENSET_PER6_Pos)      /**< (RTC_MODE0_INTENSET) Periodic Interval 6 Interrupt Enable Mask */
+#define RTC_MODE0_INTENSET_PER6             RTC_MODE0_INTENSET_PER6_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTENSET_PER6_Msk instead */
+#define RTC_MODE0_INTENSET_PER7_Pos         7                                              /**< (RTC_MODE0_INTENSET) Periodic Interval 7 Interrupt Enable Position */
+#define RTC_MODE0_INTENSET_PER7_Msk         (_U_(0x1) << RTC_MODE0_INTENSET_PER7_Pos)      /**< (RTC_MODE0_INTENSET) Periodic Interval 7 Interrupt Enable Mask */
+#define RTC_MODE0_INTENSET_PER7             RTC_MODE0_INTENSET_PER7_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTENSET_PER7_Msk instead */
+#define RTC_MODE0_INTENSET_CMP0_Pos         8                                              /**< (RTC_MODE0_INTENSET) Compare 0 Interrupt Enable Position */
+#define RTC_MODE0_INTENSET_CMP0_Msk         (_U_(0x1) << RTC_MODE0_INTENSET_CMP0_Pos)      /**< (RTC_MODE0_INTENSET) Compare 0 Interrupt Enable Mask */
+#define RTC_MODE0_INTENSET_CMP0             RTC_MODE0_INTENSET_CMP0_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTENSET_CMP0_Msk instead */
+#define RTC_MODE0_INTENSET_TAMPER_Pos       14                                             /**< (RTC_MODE0_INTENSET) Tamper Enable Position */
+#define RTC_MODE0_INTENSET_TAMPER_Msk       (_U_(0x1) << RTC_MODE0_INTENSET_TAMPER_Pos)    /**< (RTC_MODE0_INTENSET) Tamper Enable Mask */
+#define RTC_MODE0_INTENSET_TAMPER           RTC_MODE0_INTENSET_TAMPER_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTENSET_TAMPER_Msk instead */
+#define RTC_MODE0_INTENSET_OVF_Pos          15                                             /**< (RTC_MODE0_INTENSET) Overflow Interrupt Enable Position */
+#define RTC_MODE0_INTENSET_OVF_Msk          (_U_(0x1) << RTC_MODE0_INTENSET_OVF_Pos)       /**< (RTC_MODE0_INTENSET) Overflow Interrupt Enable Mask */
+#define RTC_MODE0_INTENSET_OVF              RTC_MODE0_INTENSET_OVF_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTENSET_OVF_Msk instead */
+#define RTC_MODE0_INTENSET_MASK             _U_(0xC1FF)                                    /**< \deprecated (RTC_MODE0_INTENSET) Register MASK  (Use RTC_MODE0_INTENSET_Msk instead)  */
+#define RTC_MODE0_INTENSET_Msk              _U_(0xC1FF)                                    /**< (RTC_MODE0_INTENSET) Register Mask  */
+
+#define RTC_MODE0_INTENSET_PER_Pos          0                                              /**< (RTC_MODE0_INTENSET Position) Periodic Interval x Interrupt Enable */
+#define RTC_MODE0_INTENSET_PER_Msk          (_U_(0xFF) << RTC_MODE0_INTENSET_PER_Pos)      /**< (RTC_MODE0_INTENSET Mask) PER */
+#define RTC_MODE0_INTENSET_PER(value)       (RTC_MODE0_INTENSET_PER_Msk & ((value) << RTC_MODE0_INTENSET_PER_Pos))  
+#define RTC_MODE0_INTENSET_CMP_Pos          8                                              /**< (RTC_MODE0_INTENSET Position) Compare x Interrupt Enable */
+#define RTC_MODE0_INTENSET_CMP_Msk          (_U_(0x1) << RTC_MODE0_INTENSET_CMP_Pos)       /**< (RTC_MODE0_INTENSET Mask) CMP */
+#define RTC_MODE0_INTENSET_CMP(value)       (RTC_MODE0_INTENSET_CMP_Msk & ((value) << RTC_MODE0_INTENSET_CMP_Pos))  
+
+/* -------- RTC_MODE1_INTENSET : (RTC Offset: 0x0a) (R/W 16) MODE1 Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t PER0:1;                    /**< bit:      0  Periodic Interval 0 Interrupt Enable     */
+    uint16_t PER1:1;                    /**< bit:      1  Periodic Interval 1 Interrupt Enable     */
+    uint16_t PER2:1;                    /**< bit:      2  Periodic Interval 2 Interrupt Enable     */
+    uint16_t PER3:1;                    /**< bit:      3  Periodic Interval 3 Interrupt Enable     */
+    uint16_t PER4:1;                    /**< bit:      4  Periodic Interval 4 Interrupt Enable     */
+    uint16_t PER5:1;                    /**< bit:      5  Periodic Interval 5 Interrupt Enable     */
+    uint16_t PER6:1;                    /**< bit:      6  Periodic Interval 6 Interrupt Enable     */
+    uint16_t PER7:1;                    /**< bit:      7  Periodic Interval 7 Interrupt Enable     */
+    uint16_t CMP0:1;                    /**< bit:      8  Compare 0 Interrupt Enable               */
+    uint16_t CMP1:1;                    /**< bit:      9  Compare 1 Interrupt Enable               */
+    uint16_t :4;                        /**< bit: 10..13  Reserved */
+    uint16_t TAMPER:1;                  /**< bit:     14  Tamper Enable                            */
+    uint16_t OVF:1;                     /**< bit:     15  Overflow Interrupt Enable                */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint16_t PER:8;                     /**< bit:   0..7  Periodic Interval x Interrupt Enable     */
+    uint16_t CMP:2;                     /**< bit:   8..9  Compare x Interrupt Enable               */
+    uint16_t :6;                        /**< bit: 10..15 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint16_t reg;                         /**< Type used for register access */
+} RTC_MODE1_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE1_INTENSET_OFFSET           (0x0A)                                        /**<  (RTC_MODE1_INTENSET) MODE1 Interrupt Enable Set  Offset */
+#define RTC_MODE1_INTENSET_RESETVALUE       _U_(0x00)                                     /**<  (RTC_MODE1_INTENSET) MODE1 Interrupt Enable Set  Reset Value */
+
+#define RTC_MODE1_INTENSET_PER0_Pos         0                                              /**< (RTC_MODE1_INTENSET) Periodic Interval 0 Interrupt Enable Position */
+#define RTC_MODE1_INTENSET_PER0_Msk         (_U_(0x1) << RTC_MODE1_INTENSET_PER0_Pos)      /**< (RTC_MODE1_INTENSET) Periodic Interval 0 Interrupt Enable Mask */
+#define RTC_MODE1_INTENSET_PER0             RTC_MODE1_INTENSET_PER0_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTENSET_PER0_Msk instead */
+#define RTC_MODE1_INTENSET_PER1_Pos         1                                              /**< (RTC_MODE1_INTENSET) Periodic Interval 1 Interrupt Enable Position */
+#define RTC_MODE1_INTENSET_PER1_Msk         (_U_(0x1) << RTC_MODE1_INTENSET_PER1_Pos)      /**< (RTC_MODE1_INTENSET) Periodic Interval 1 Interrupt Enable Mask */
+#define RTC_MODE1_INTENSET_PER1             RTC_MODE1_INTENSET_PER1_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTENSET_PER1_Msk instead */
+#define RTC_MODE1_INTENSET_PER2_Pos         2                                              /**< (RTC_MODE1_INTENSET) Periodic Interval 2 Interrupt Enable Position */
+#define RTC_MODE1_INTENSET_PER2_Msk         (_U_(0x1) << RTC_MODE1_INTENSET_PER2_Pos)      /**< (RTC_MODE1_INTENSET) Periodic Interval 2 Interrupt Enable Mask */
+#define RTC_MODE1_INTENSET_PER2             RTC_MODE1_INTENSET_PER2_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTENSET_PER2_Msk instead */
+#define RTC_MODE1_INTENSET_PER3_Pos         3                                              /**< (RTC_MODE1_INTENSET) Periodic Interval 3 Interrupt Enable Position */
+#define RTC_MODE1_INTENSET_PER3_Msk         (_U_(0x1) << RTC_MODE1_INTENSET_PER3_Pos)      /**< (RTC_MODE1_INTENSET) Periodic Interval 3 Interrupt Enable Mask */
+#define RTC_MODE1_INTENSET_PER3             RTC_MODE1_INTENSET_PER3_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTENSET_PER3_Msk instead */
+#define RTC_MODE1_INTENSET_PER4_Pos         4                                              /**< (RTC_MODE1_INTENSET) Periodic Interval 4 Interrupt Enable Position */
+#define RTC_MODE1_INTENSET_PER4_Msk         (_U_(0x1) << RTC_MODE1_INTENSET_PER4_Pos)      /**< (RTC_MODE1_INTENSET) Periodic Interval 4 Interrupt Enable Mask */
+#define RTC_MODE1_INTENSET_PER4             RTC_MODE1_INTENSET_PER4_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTENSET_PER4_Msk instead */
+#define RTC_MODE1_INTENSET_PER5_Pos         5                                              /**< (RTC_MODE1_INTENSET) Periodic Interval 5 Interrupt Enable Position */
+#define RTC_MODE1_INTENSET_PER5_Msk         (_U_(0x1) << RTC_MODE1_INTENSET_PER5_Pos)      /**< (RTC_MODE1_INTENSET) Periodic Interval 5 Interrupt Enable Mask */
+#define RTC_MODE1_INTENSET_PER5             RTC_MODE1_INTENSET_PER5_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTENSET_PER5_Msk instead */
+#define RTC_MODE1_INTENSET_PER6_Pos         6                                              /**< (RTC_MODE1_INTENSET) Periodic Interval 6 Interrupt Enable Position */
+#define RTC_MODE1_INTENSET_PER6_Msk         (_U_(0x1) << RTC_MODE1_INTENSET_PER6_Pos)      /**< (RTC_MODE1_INTENSET) Periodic Interval 6 Interrupt Enable Mask */
+#define RTC_MODE1_INTENSET_PER6             RTC_MODE1_INTENSET_PER6_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTENSET_PER6_Msk instead */
+#define RTC_MODE1_INTENSET_PER7_Pos         7                                              /**< (RTC_MODE1_INTENSET) Periodic Interval 7 Interrupt Enable Position */
+#define RTC_MODE1_INTENSET_PER7_Msk         (_U_(0x1) << RTC_MODE1_INTENSET_PER7_Pos)      /**< (RTC_MODE1_INTENSET) Periodic Interval 7 Interrupt Enable Mask */
+#define RTC_MODE1_INTENSET_PER7             RTC_MODE1_INTENSET_PER7_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTENSET_PER7_Msk instead */
+#define RTC_MODE1_INTENSET_CMP0_Pos         8                                              /**< (RTC_MODE1_INTENSET) Compare 0 Interrupt Enable Position */
+#define RTC_MODE1_INTENSET_CMP0_Msk         (_U_(0x1) << RTC_MODE1_INTENSET_CMP0_Pos)      /**< (RTC_MODE1_INTENSET) Compare 0 Interrupt Enable Mask */
+#define RTC_MODE1_INTENSET_CMP0             RTC_MODE1_INTENSET_CMP0_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTENSET_CMP0_Msk instead */
+#define RTC_MODE1_INTENSET_CMP1_Pos         9                                              /**< (RTC_MODE1_INTENSET) Compare 1 Interrupt Enable Position */
+#define RTC_MODE1_INTENSET_CMP1_Msk         (_U_(0x1) << RTC_MODE1_INTENSET_CMP1_Pos)      /**< (RTC_MODE1_INTENSET) Compare 1 Interrupt Enable Mask */
+#define RTC_MODE1_INTENSET_CMP1             RTC_MODE1_INTENSET_CMP1_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTENSET_CMP1_Msk instead */
+#define RTC_MODE1_INTENSET_TAMPER_Pos       14                                             /**< (RTC_MODE1_INTENSET) Tamper Enable Position */
+#define RTC_MODE1_INTENSET_TAMPER_Msk       (_U_(0x1) << RTC_MODE1_INTENSET_TAMPER_Pos)    /**< (RTC_MODE1_INTENSET) Tamper Enable Mask */
+#define RTC_MODE1_INTENSET_TAMPER           RTC_MODE1_INTENSET_TAMPER_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTENSET_TAMPER_Msk instead */
+#define RTC_MODE1_INTENSET_OVF_Pos          15                                             /**< (RTC_MODE1_INTENSET) Overflow Interrupt Enable Position */
+#define RTC_MODE1_INTENSET_OVF_Msk          (_U_(0x1) << RTC_MODE1_INTENSET_OVF_Pos)       /**< (RTC_MODE1_INTENSET) Overflow Interrupt Enable Mask */
+#define RTC_MODE1_INTENSET_OVF              RTC_MODE1_INTENSET_OVF_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTENSET_OVF_Msk instead */
+#define RTC_MODE1_INTENSET_MASK             _U_(0xC3FF)                                    /**< \deprecated (RTC_MODE1_INTENSET) Register MASK  (Use RTC_MODE1_INTENSET_Msk instead)  */
+#define RTC_MODE1_INTENSET_Msk              _U_(0xC3FF)                                    /**< (RTC_MODE1_INTENSET) Register Mask  */
+
+#define RTC_MODE1_INTENSET_PER_Pos          0                                              /**< (RTC_MODE1_INTENSET Position) Periodic Interval x Interrupt Enable */
+#define RTC_MODE1_INTENSET_PER_Msk          (_U_(0xFF) << RTC_MODE1_INTENSET_PER_Pos)      /**< (RTC_MODE1_INTENSET Mask) PER */
+#define RTC_MODE1_INTENSET_PER(value)       (RTC_MODE1_INTENSET_PER_Msk & ((value) << RTC_MODE1_INTENSET_PER_Pos))  
+#define RTC_MODE1_INTENSET_CMP_Pos          8                                              /**< (RTC_MODE1_INTENSET Position) Compare x Interrupt Enable */
+#define RTC_MODE1_INTENSET_CMP_Msk          (_U_(0x3) << RTC_MODE1_INTENSET_CMP_Pos)       /**< (RTC_MODE1_INTENSET Mask) CMP */
+#define RTC_MODE1_INTENSET_CMP(value)       (RTC_MODE1_INTENSET_CMP_Msk & ((value) << RTC_MODE1_INTENSET_CMP_Pos))  
+
+/* -------- RTC_MODE2_INTENSET : (RTC Offset: 0x0a) (R/W 16) MODE2 Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t PER0:1;                    /**< bit:      0  Periodic Interval 0 Enable               */
+    uint16_t PER1:1;                    /**< bit:      1  Periodic Interval 1 Enable               */
+    uint16_t PER2:1;                    /**< bit:      2  Periodic Interval 2 Enable               */
+    uint16_t PER3:1;                    /**< bit:      3  Periodic Interval 3 Enable               */
+    uint16_t PER4:1;                    /**< bit:      4  Periodic Interval 4 Enable               */
+    uint16_t PER5:1;                    /**< bit:      5  Periodic Interval 5 Enable               */
+    uint16_t PER6:1;                    /**< bit:      6  Periodic Interval 6 Enable               */
+    uint16_t PER7:1;                    /**< bit:      7  Periodic Interval 7 Enable               */
+    uint16_t ALARM0:1;                  /**< bit:      8  Alarm 0 Interrupt Enable                 */
+    uint16_t :5;                        /**< bit:  9..13  Reserved */
+    uint16_t TAMPER:1;                  /**< bit:     14  Tamper Enable                            */
+    uint16_t OVF:1;                     /**< bit:     15  Overflow Interrupt Enable                */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint16_t PER:8;                     /**< bit:   0..7  Periodic Interval x Enable               */
+    uint16_t ALARM:1;                   /**< bit:      8  Alarm x Interrupt Enable                 */
+    uint16_t :7;                        /**< bit:  9..15 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint16_t reg;                         /**< Type used for register access */
+} RTC_MODE2_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE2_INTENSET_OFFSET           (0x0A)                                        /**<  (RTC_MODE2_INTENSET) MODE2 Interrupt Enable Set  Offset */
+#define RTC_MODE2_INTENSET_RESETVALUE       _U_(0x00)                                     /**<  (RTC_MODE2_INTENSET) MODE2 Interrupt Enable Set  Reset Value */
+
+#define RTC_MODE2_INTENSET_PER0_Pos         0                                              /**< (RTC_MODE2_INTENSET) Periodic Interval 0 Enable Position */
+#define RTC_MODE2_INTENSET_PER0_Msk         (_U_(0x1) << RTC_MODE2_INTENSET_PER0_Pos)      /**< (RTC_MODE2_INTENSET) Periodic Interval 0 Enable Mask */
+#define RTC_MODE2_INTENSET_PER0             RTC_MODE2_INTENSET_PER0_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTENSET_PER0_Msk instead */
+#define RTC_MODE2_INTENSET_PER1_Pos         1                                              /**< (RTC_MODE2_INTENSET) Periodic Interval 1 Enable Position */
+#define RTC_MODE2_INTENSET_PER1_Msk         (_U_(0x1) << RTC_MODE2_INTENSET_PER1_Pos)      /**< (RTC_MODE2_INTENSET) Periodic Interval 1 Enable Mask */
+#define RTC_MODE2_INTENSET_PER1             RTC_MODE2_INTENSET_PER1_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTENSET_PER1_Msk instead */
+#define RTC_MODE2_INTENSET_PER2_Pos         2                                              /**< (RTC_MODE2_INTENSET) Periodic Interval 2 Enable Position */
+#define RTC_MODE2_INTENSET_PER2_Msk         (_U_(0x1) << RTC_MODE2_INTENSET_PER2_Pos)      /**< (RTC_MODE2_INTENSET) Periodic Interval 2 Enable Mask */
+#define RTC_MODE2_INTENSET_PER2             RTC_MODE2_INTENSET_PER2_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTENSET_PER2_Msk instead */
+#define RTC_MODE2_INTENSET_PER3_Pos         3                                              /**< (RTC_MODE2_INTENSET) Periodic Interval 3 Enable Position */
+#define RTC_MODE2_INTENSET_PER3_Msk         (_U_(0x1) << RTC_MODE2_INTENSET_PER3_Pos)      /**< (RTC_MODE2_INTENSET) Periodic Interval 3 Enable Mask */
+#define RTC_MODE2_INTENSET_PER3             RTC_MODE2_INTENSET_PER3_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTENSET_PER3_Msk instead */
+#define RTC_MODE2_INTENSET_PER4_Pos         4                                              /**< (RTC_MODE2_INTENSET) Periodic Interval 4 Enable Position */
+#define RTC_MODE2_INTENSET_PER4_Msk         (_U_(0x1) << RTC_MODE2_INTENSET_PER4_Pos)      /**< (RTC_MODE2_INTENSET) Periodic Interval 4 Enable Mask */
+#define RTC_MODE2_INTENSET_PER4             RTC_MODE2_INTENSET_PER4_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTENSET_PER4_Msk instead */
+#define RTC_MODE2_INTENSET_PER5_Pos         5                                              /**< (RTC_MODE2_INTENSET) Periodic Interval 5 Enable Position */
+#define RTC_MODE2_INTENSET_PER5_Msk         (_U_(0x1) << RTC_MODE2_INTENSET_PER5_Pos)      /**< (RTC_MODE2_INTENSET) Periodic Interval 5 Enable Mask */
+#define RTC_MODE2_INTENSET_PER5             RTC_MODE2_INTENSET_PER5_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTENSET_PER5_Msk instead */
+#define RTC_MODE2_INTENSET_PER6_Pos         6                                              /**< (RTC_MODE2_INTENSET) Periodic Interval 6 Enable Position */
+#define RTC_MODE2_INTENSET_PER6_Msk         (_U_(0x1) << RTC_MODE2_INTENSET_PER6_Pos)      /**< (RTC_MODE2_INTENSET) Periodic Interval 6 Enable Mask */
+#define RTC_MODE2_INTENSET_PER6             RTC_MODE2_INTENSET_PER6_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTENSET_PER6_Msk instead */
+#define RTC_MODE2_INTENSET_PER7_Pos         7                                              /**< (RTC_MODE2_INTENSET) Periodic Interval 7 Enable Position */
+#define RTC_MODE2_INTENSET_PER7_Msk         (_U_(0x1) << RTC_MODE2_INTENSET_PER7_Pos)      /**< (RTC_MODE2_INTENSET) Periodic Interval 7 Enable Mask */
+#define RTC_MODE2_INTENSET_PER7             RTC_MODE2_INTENSET_PER7_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTENSET_PER7_Msk instead */
+#define RTC_MODE2_INTENSET_ALARM0_Pos       8                                              /**< (RTC_MODE2_INTENSET) Alarm 0 Interrupt Enable Position */
+#define RTC_MODE2_INTENSET_ALARM0_Msk       (_U_(0x1) << RTC_MODE2_INTENSET_ALARM0_Pos)    /**< (RTC_MODE2_INTENSET) Alarm 0 Interrupt Enable Mask */
+#define RTC_MODE2_INTENSET_ALARM0           RTC_MODE2_INTENSET_ALARM0_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTENSET_ALARM0_Msk instead */
+#define RTC_MODE2_INTENSET_TAMPER_Pos       14                                             /**< (RTC_MODE2_INTENSET) Tamper Enable Position */
+#define RTC_MODE2_INTENSET_TAMPER_Msk       (_U_(0x1) << RTC_MODE2_INTENSET_TAMPER_Pos)    /**< (RTC_MODE2_INTENSET) Tamper Enable Mask */
+#define RTC_MODE2_INTENSET_TAMPER           RTC_MODE2_INTENSET_TAMPER_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTENSET_TAMPER_Msk instead */
+#define RTC_MODE2_INTENSET_OVF_Pos          15                                             /**< (RTC_MODE2_INTENSET) Overflow Interrupt Enable Position */
+#define RTC_MODE2_INTENSET_OVF_Msk          (_U_(0x1) << RTC_MODE2_INTENSET_OVF_Pos)       /**< (RTC_MODE2_INTENSET) Overflow Interrupt Enable Mask */
+#define RTC_MODE2_INTENSET_OVF              RTC_MODE2_INTENSET_OVF_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTENSET_OVF_Msk instead */
+#define RTC_MODE2_INTENSET_MASK             _U_(0xC1FF)                                    /**< \deprecated (RTC_MODE2_INTENSET) Register MASK  (Use RTC_MODE2_INTENSET_Msk instead)  */
+#define RTC_MODE2_INTENSET_Msk              _U_(0xC1FF)                                    /**< (RTC_MODE2_INTENSET) Register Mask  */
+
+#define RTC_MODE2_INTENSET_PER_Pos          0                                              /**< (RTC_MODE2_INTENSET Position) Periodic Interval x Enable */
+#define RTC_MODE2_INTENSET_PER_Msk          (_U_(0xFF) << RTC_MODE2_INTENSET_PER_Pos)      /**< (RTC_MODE2_INTENSET Mask) PER */
+#define RTC_MODE2_INTENSET_PER(value)       (RTC_MODE2_INTENSET_PER_Msk & ((value) << RTC_MODE2_INTENSET_PER_Pos))  
+#define RTC_MODE2_INTENSET_ALARM_Pos        8                                              /**< (RTC_MODE2_INTENSET Position) Alarm x Interrupt Enable */
+#define RTC_MODE2_INTENSET_ALARM_Msk        (_U_(0x1) << RTC_MODE2_INTENSET_ALARM_Pos)     /**< (RTC_MODE2_INTENSET Mask) ALARM */
+#define RTC_MODE2_INTENSET_ALARM(value)     (RTC_MODE2_INTENSET_ALARM_Msk & ((value) << RTC_MODE2_INTENSET_ALARM_Pos))  
+
+/* -------- RTC_MODE0_INTFLAG : (RTC Offset: 0x0c) (R/W 16) MODE0 Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint16_t PER0:1;                    /**< bit:      0  Periodic Interval 0                      */
+    __I uint16_t PER1:1;                    /**< bit:      1  Periodic Interval 1                      */
+    __I uint16_t PER2:1;                    /**< bit:      2  Periodic Interval 2                      */
+    __I uint16_t PER3:1;                    /**< bit:      3  Periodic Interval 3                      */
+    __I uint16_t PER4:1;                    /**< bit:      4  Periodic Interval 4                      */
+    __I uint16_t PER5:1;                    /**< bit:      5  Periodic Interval 5                      */
+    __I uint16_t PER6:1;                    /**< bit:      6  Periodic Interval 6                      */
+    __I uint16_t PER7:1;                    /**< bit:      7  Periodic Interval 7                      */
+    __I uint16_t CMP0:1;                    /**< bit:      8  Compare 0                                */
+    __I uint16_t :5;                        /**< bit:  9..13  Reserved */
+    __I uint16_t TAMPER:1;                  /**< bit:     14  Tamper                                   */
+    __I uint16_t OVF:1;                     /**< bit:     15  Overflow                                 */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    __I uint16_t PER:8;                     /**< bit:   0..7  Periodic Interval x                      */
+    __I uint16_t CMP:1;                     /**< bit:      8  Compare x                                */
+    __I uint16_t :7;                        /**< bit:  9..15 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint16_t reg;                         /**< Type used for register access */
+} RTC_MODE0_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE0_INTFLAG_OFFSET            (0x0C)                                        /**<  (RTC_MODE0_INTFLAG) MODE0 Interrupt Flag Status and Clear  Offset */
+#define RTC_MODE0_INTFLAG_RESETVALUE        _U_(0x00)                                     /**<  (RTC_MODE0_INTFLAG) MODE0 Interrupt Flag Status and Clear  Reset Value */
+
+#define RTC_MODE0_INTFLAG_PER0_Pos          0                                              /**< (RTC_MODE0_INTFLAG) Periodic Interval 0 Position */
+#define RTC_MODE0_INTFLAG_PER0_Msk          (_U_(0x1) << RTC_MODE0_INTFLAG_PER0_Pos)       /**< (RTC_MODE0_INTFLAG) Periodic Interval 0 Mask */
+#define RTC_MODE0_INTFLAG_PER0              RTC_MODE0_INTFLAG_PER0_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTFLAG_PER0_Msk instead */
+#define RTC_MODE0_INTFLAG_PER1_Pos          1                                              /**< (RTC_MODE0_INTFLAG) Periodic Interval 1 Position */
+#define RTC_MODE0_INTFLAG_PER1_Msk          (_U_(0x1) << RTC_MODE0_INTFLAG_PER1_Pos)       /**< (RTC_MODE0_INTFLAG) Periodic Interval 1 Mask */
+#define RTC_MODE0_INTFLAG_PER1              RTC_MODE0_INTFLAG_PER1_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTFLAG_PER1_Msk instead */
+#define RTC_MODE0_INTFLAG_PER2_Pos          2                                              /**< (RTC_MODE0_INTFLAG) Periodic Interval 2 Position */
+#define RTC_MODE0_INTFLAG_PER2_Msk          (_U_(0x1) << RTC_MODE0_INTFLAG_PER2_Pos)       /**< (RTC_MODE0_INTFLAG) Periodic Interval 2 Mask */
+#define RTC_MODE0_INTFLAG_PER2              RTC_MODE0_INTFLAG_PER2_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTFLAG_PER2_Msk instead */
+#define RTC_MODE0_INTFLAG_PER3_Pos          3                                              /**< (RTC_MODE0_INTFLAG) Periodic Interval 3 Position */
+#define RTC_MODE0_INTFLAG_PER3_Msk          (_U_(0x1) << RTC_MODE0_INTFLAG_PER3_Pos)       /**< (RTC_MODE0_INTFLAG) Periodic Interval 3 Mask */
+#define RTC_MODE0_INTFLAG_PER3              RTC_MODE0_INTFLAG_PER3_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTFLAG_PER3_Msk instead */
+#define RTC_MODE0_INTFLAG_PER4_Pos          4                                              /**< (RTC_MODE0_INTFLAG) Periodic Interval 4 Position */
+#define RTC_MODE0_INTFLAG_PER4_Msk          (_U_(0x1) << RTC_MODE0_INTFLAG_PER4_Pos)       /**< (RTC_MODE0_INTFLAG) Periodic Interval 4 Mask */
+#define RTC_MODE0_INTFLAG_PER4              RTC_MODE0_INTFLAG_PER4_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTFLAG_PER4_Msk instead */
+#define RTC_MODE0_INTFLAG_PER5_Pos          5                                              /**< (RTC_MODE0_INTFLAG) Periodic Interval 5 Position */
+#define RTC_MODE0_INTFLAG_PER5_Msk          (_U_(0x1) << RTC_MODE0_INTFLAG_PER5_Pos)       /**< (RTC_MODE0_INTFLAG) Periodic Interval 5 Mask */
+#define RTC_MODE0_INTFLAG_PER5              RTC_MODE0_INTFLAG_PER5_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTFLAG_PER5_Msk instead */
+#define RTC_MODE0_INTFLAG_PER6_Pos          6                                              /**< (RTC_MODE0_INTFLAG) Periodic Interval 6 Position */
+#define RTC_MODE0_INTFLAG_PER6_Msk          (_U_(0x1) << RTC_MODE0_INTFLAG_PER6_Pos)       /**< (RTC_MODE0_INTFLAG) Periodic Interval 6 Mask */
+#define RTC_MODE0_INTFLAG_PER6              RTC_MODE0_INTFLAG_PER6_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTFLAG_PER6_Msk instead */
+#define RTC_MODE0_INTFLAG_PER7_Pos          7                                              /**< (RTC_MODE0_INTFLAG) Periodic Interval 7 Position */
+#define RTC_MODE0_INTFLAG_PER7_Msk          (_U_(0x1) << RTC_MODE0_INTFLAG_PER7_Pos)       /**< (RTC_MODE0_INTFLAG) Periodic Interval 7 Mask */
+#define RTC_MODE0_INTFLAG_PER7              RTC_MODE0_INTFLAG_PER7_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTFLAG_PER7_Msk instead */
+#define RTC_MODE0_INTFLAG_CMP0_Pos          8                                              /**< (RTC_MODE0_INTFLAG) Compare 0 Position */
+#define RTC_MODE0_INTFLAG_CMP0_Msk          (_U_(0x1) << RTC_MODE0_INTFLAG_CMP0_Pos)       /**< (RTC_MODE0_INTFLAG) Compare 0 Mask */
+#define RTC_MODE0_INTFLAG_CMP0              RTC_MODE0_INTFLAG_CMP0_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTFLAG_CMP0_Msk instead */
+#define RTC_MODE0_INTFLAG_TAMPER_Pos        14                                             /**< (RTC_MODE0_INTFLAG) Tamper Position */
+#define RTC_MODE0_INTFLAG_TAMPER_Msk        (_U_(0x1) << RTC_MODE0_INTFLAG_TAMPER_Pos)     /**< (RTC_MODE0_INTFLAG) Tamper Mask */
+#define RTC_MODE0_INTFLAG_TAMPER            RTC_MODE0_INTFLAG_TAMPER_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTFLAG_TAMPER_Msk instead */
+#define RTC_MODE0_INTFLAG_OVF_Pos           15                                             /**< (RTC_MODE0_INTFLAG) Overflow Position */
+#define RTC_MODE0_INTFLAG_OVF_Msk           (_U_(0x1) << RTC_MODE0_INTFLAG_OVF_Pos)        /**< (RTC_MODE0_INTFLAG) Overflow Mask */
+#define RTC_MODE0_INTFLAG_OVF               RTC_MODE0_INTFLAG_OVF_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_INTFLAG_OVF_Msk instead */
+#define RTC_MODE0_INTFLAG_MASK              _U_(0xC1FF)                                    /**< \deprecated (RTC_MODE0_INTFLAG) Register MASK  (Use RTC_MODE0_INTFLAG_Msk instead)  */
+#define RTC_MODE0_INTFLAG_Msk               _U_(0xC1FF)                                    /**< (RTC_MODE0_INTFLAG) Register Mask  */
+
+#define RTC_MODE0_INTFLAG_PER_Pos           0                                              /**< (RTC_MODE0_INTFLAG Position) Periodic Interval x */
+#define RTC_MODE0_INTFLAG_PER_Msk           (_U_(0xFF) << RTC_MODE0_INTFLAG_PER_Pos)       /**< (RTC_MODE0_INTFLAG Mask) PER */
+#define RTC_MODE0_INTFLAG_PER(value)        (RTC_MODE0_INTFLAG_PER_Msk & ((value) << RTC_MODE0_INTFLAG_PER_Pos))  
+#define RTC_MODE0_INTFLAG_CMP_Pos           8                                              /**< (RTC_MODE0_INTFLAG Position) Compare x */
+#define RTC_MODE0_INTFLAG_CMP_Msk           (_U_(0x1) << RTC_MODE0_INTFLAG_CMP_Pos)        /**< (RTC_MODE0_INTFLAG Mask) CMP */
+#define RTC_MODE0_INTFLAG_CMP(value)        (RTC_MODE0_INTFLAG_CMP_Msk & ((value) << RTC_MODE0_INTFLAG_CMP_Pos))  
+
+/* -------- RTC_MODE1_INTFLAG : (RTC Offset: 0x0c) (R/W 16) MODE1 Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint16_t PER0:1;                    /**< bit:      0  Periodic Interval 0                      */
+    __I uint16_t PER1:1;                    /**< bit:      1  Periodic Interval 1                      */
+    __I uint16_t PER2:1;                    /**< bit:      2  Periodic Interval 2                      */
+    __I uint16_t PER3:1;                    /**< bit:      3  Periodic Interval 3                      */
+    __I uint16_t PER4:1;                    /**< bit:      4  Periodic Interval 4                      */
+    __I uint16_t PER5:1;                    /**< bit:      5  Periodic Interval 5                      */
+    __I uint16_t PER6:1;                    /**< bit:      6  Periodic Interval 6                      */
+    __I uint16_t PER7:1;                    /**< bit:      7  Periodic Interval 7                      */
+    __I uint16_t CMP0:1;                    /**< bit:      8  Compare 0                                */
+    __I uint16_t CMP1:1;                    /**< bit:      9  Compare 1                                */
+    __I uint16_t :4;                        /**< bit: 10..13  Reserved */
+    __I uint16_t TAMPER:1;                  /**< bit:     14  Tamper                                   */
+    __I uint16_t OVF:1;                     /**< bit:     15  Overflow                                 */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    __I uint16_t PER:8;                     /**< bit:   0..7  Periodic Interval x                      */
+    __I uint16_t CMP:2;                     /**< bit:   8..9  Compare x                                */
+    __I uint16_t :6;                        /**< bit: 10..15 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint16_t reg;                         /**< Type used for register access */
+} RTC_MODE1_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE1_INTFLAG_OFFSET            (0x0C)                                        /**<  (RTC_MODE1_INTFLAG) MODE1 Interrupt Flag Status and Clear  Offset */
+#define RTC_MODE1_INTFLAG_RESETVALUE        _U_(0x00)                                     /**<  (RTC_MODE1_INTFLAG) MODE1 Interrupt Flag Status and Clear  Reset Value */
+
+#define RTC_MODE1_INTFLAG_PER0_Pos          0                                              /**< (RTC_MODE1_INTFLAG) Periodic Interval 0 Position */
+#define RTC_MODE1_INTFLAG_PER0_Msk          (_U_(0x1) << RTC_MODE1_INTFLAG_PER0_Pos)       /**< (RTC_MODE1_INTFLAG) Periodic Interval 0 Mask */
+#define RTC_MODE1_INTFLAG_PER0              RTC_MODE1_INTFLAG_PER0_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTFLAG_PER0_Msk instead */
+#define RTC_MODE1_INTFLAG_PER1_Pos          1                                              /**< (RTC_MODE1_INTFLAG) Periodic Interval 1 Position */
+#define RTC_MODE1_INTFLAG_PER1_Msk          (_U_(0x1) << RTC_MODE1_INTFLAG_PER1_Pos)       /**< (RTC_MODE1_INTFLAG) Periodic Interval 1 Mask */
+#define RTC_MODE1_INTFLAG_PER1              RTC_MODE1_INTFLAG_PER1_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTFLAG_PER1_Msk instead */
+#define RTC_MODE1_INTFLAG_PER2_Pos          2                                              /**< (RTC_MODE1_INTFLAG) Periodic Interval 2 Position */
+#define RTC_MODE1_INTFLAG_PER2_Msk          (_U_(0x1) << RTC_MODE1_INTFLAG_PER2_Pos)       /**< (RTC_MODE1_INTFLAG) Periodic Interval 2 Mask */
+#define RTC_MODE1_INTFLAG_PER2              RTC_MODE1_INTFLAG_PER2_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTFLAG_PER2_Msk instead */
+#define RTC_MODE1_INTFLAG_PER3_Pos          3                                              /**< (RTC_MODE1_INTFLAG) Periodic Interval 3 Position */
+#define RTC_MODE1_INTFLAG_PER3_Msk          (_U_(0x1) << RTC_MODE1_INTFLAG_PER3_Pos)       /**< (RTC_MODE1_INTFLAG) Periodic Interval 3 Mask */
+#define RTC_MODE1_INTFLAG_PER3              RTC_MODE1_INTFLAG_PER3_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTFLAG_PER3_Msk instead */
+#define RTC_MODE1_INTFLAG_PER4_Pos          4                                              /**< (RTC_MODE1_INTFLAG) Periodic Interval 4 Position */
+#define RTC_MODE1_INTFLAG_PER4_Msk          (_U_(0x1) << RTC_MODE1_INTFLAG_PER4_Pos)       /**< (RTC_MODE1_INTFLAG) Periodic Interval 4 Mask */
+#define RTC_MODE1_INTFLAG_PER4              RTC_MODE1_INTFLAG_PER4_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTFLAG_PER4_Msk instead */
+#define RTC_MODE1_INTFLAG_PER5_Pos          5                                              /**< (RTC_MODE1_INTFLAG) Periodic Interval 5 Position */
+#define RTC_MODE1_INTFLAG_PER5_Msk          (_U_(0x1) << RTC_MODE1_INTFLAG_PER5_Pos)       /**< (RTC_MODE1_INTFLAG) Periodic Interval 5 Mask */
+#define RTC_MODE1_INTFLAG_PER5              RTC_MODE1_INTFLAG_PER5_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTFLAG_PER5_Msk instead */
+#define RTC_MODE1_INTFLAG_PER6_Pos          6                                              /**< (RTC_MODE1_INTFLAG) Periodic Interval 6 Position */
+#define RTC_MODE1_INTFLAG_PER6_Msk          (_U_(0x1) << RTC_MODE1_INTFLAG_PER6_Pos)       /**< (RTC_MODE1_INTFLAG) Periodic Interval 6 Mask */
+#define RTC_MODE1_INTFLAG_PER6              RTC_MODE1_INTFLAG_PER6_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTFLAG_PER6_Msk instead */
+#define RTC_MODE1_INTFLAG_PER7_Pos          7                                              /**< (RTC_MODE1_INTFLAG) Periodic Interval 7 Position */
+#define RTC_MODE1_INTFLAG_PER7_Msk          (_U_(0x1) << RTC_MODE1_INTFLAG_PER7_Pos)       /**< (RTC_MODE1_INTFLAG) Periodic Interval 7 Mask */
+#define RTC_MODE1_INTFLAG_PER7              RTC_MODE1_INTFLAG_PER7_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTFLAG_PER7_Msk instead */
+#define RTC_MODE1_INTFLAG_CMP0_Pos          8                                              /**< (RTC_MODE1_INTFLAG) Compare 0 Position */
+#define RTC_MODE1_INTFLAG_CMP0_Msk          (_U_(0x1) << RTC_MODE1_INTFLAG_CMP0_Pos)       /**< (RTC_MODE1_INTFLAG) Compare 0 Mask */
+#define RTC_MODE1_INTFLAG_CMP0              RTC_MODE1_INTFLAG_CMP0_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTFLAG_CMP0_Msk instead */
+#define RTC_MODE1_INTFLAG_CMP1_Pos          9                                              /**< (RTC_MODE1_INTFLAG) Compare 1 Position */
+#define RTC_MODE1_INTFLAG_CMP1_Msk          (_U_(0x1) << RTC_MODE1_INTFLAG_CMP1_Pos)       /**< (RTC_MODE1_INTFLAG) Compare 1 Mask */
+#define RTC_MODE1_INTFLAG_CMP1              RTC_MODE1_INTFLAG_CMP1_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTFLAG_CMP1_Msk instead */
+#define RTC_MODE1_INTFLAG_TAMPER_Pos        14                                             /**< (RTC_MODE1_INTFLAG) Tamper Position */
+#define RTC_MODE1_INTFLAG_TAMPER_Msk        (_U_(0x1) << RTC_MODE1_INTFLAG_TAMPER_Pos)     /**< (RTC_MODE1_INTFLAG) Tamper Mask */
+#define RTC_MODE1_INTFLAG_TAMPER            RTC_MODE1_INTFLAG_TAMPER_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTFLAG_TAMPER_Msk instead */
+#define RTC_MODE1_INTFLAG_OVF_Pos           15                                             /**< (RTC_MODE1_INTFLAG) Overflow Position */
+#define RTC_MODE1_INTFLAG_OVF_Msk           (_U_(0x1) << RTC_MODE1_INTFLAG_OVF_Pos)        /**< (RTC_MODE1_INTFLAG) Overflow Mask */
+#define RTC_MODE1_INTFLAG_OVF               RTC_MODE1_INTFLAG_OVF_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_INTFLAG_OVF_Msk instead */
+#define RTC_MODE1_INTFLAG_MASK              _U_(0xC3FF)                                    /**< \deprecated (RTC_MODE1_INTFLAG) Register MASK  (Use RTC_MODE1_INTFLAG_Msk instead)  */
+#define RTC_MODE1_INTFLAG_Msk               _U_(0xC3FF)                                    /**< (RTC_MODE1_INTFLAG) Register Mask  */
+
+#define RTC_MODE1_INTFLAG_PER_Pos           0                                              /**< (RTC_MODE1_INTFLAG Position) Periodic Interval x */
+#define RTC_MODE1_INTFLAG_PER_Msk           (_U_(0xFF) << RTC_MODE1_INTFLAG_PER_Pos)       /**< (RTC_MODE1_INTFLAG Mask) PER */
+#define RTC_MODE1_INTFLAG_PER(value)        (RTC_MODE1_INTFLAG_PER_Msk & ((value) << RTC_MODE1_INTFLAG_PER_Pos))  
+#define RTC_MODE1_INTFLAG_CMP_Pos           8                                              /**< (RTC_MODE1_INTFLAG Position) Compare x */
+#define RTC_MODE1_INTFLAG_CMP_Msk           (_U_(0x3) << RTC_MODE1_INTFLAG_CMP_Pos)        /**< (RTC_MODE1_INTFLAG Mask) CMP */
+#define RTC_MODE1_INTFLAG_CMP(value)        (RTC_MODE1_INTFLAG_CMP_Msk & ((value) << RTC_MODE1_INTFLAG_CMP_Pos))  
+
+/* -------- RTC_MODE2_INTFLAG : (RTC Offset: 0x0c) (R/W 16) MODE2 Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint16_t PER0:1;                    /**< bit:      0  Periodic Interval 0                      */
+    __I uint16_t PER1:1;                    /**< bit:      1  Periodic Interval 1                      */
+    __I uint16_t PER2:1;                    /**< bit:      2  Periodic Interval 2                      */
+    __I uint16_t PER3:1;                    /**< bit:      3  Periodic Interval 3                      */
+    __I uint16_t PER4:1;                    /**< bit:      4  Periodic Interval 4                      */
+    __I uint16_t PER5:1;                    /**< bit:      5  Periodic Interval 5                      */
+    __I uint16_t PER6:1;                    /**< bit:      6  Periodic Interval 6                      */
+    __I uint16_t PER7:1;                    /**< bit:      7  Periodic Interval 7                      */
+    __I uint16_t ALARM0:1;                  /**< bit:      8  Alarm 0                                  */
+    __I uint16_t :5;                        /**< bit:  9..13  Reserved */
+    __I uint16_t TAMPER:1;                  /**< bit:     14  Tamper                                   */
+    __I uint16_t OVF:1;                     /**< bit:     15  Overflow                                 */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    __I uint16_t PER:8;                     /**< bit:   0..7  Periodic Interval x                      */
+    __I uint16_t ALARM:1;                   /**< bit:      8  Alarm x                                  */
+    __I uint16_t :7;                        /**< bit:  9..15 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint16_t reg;                         /**< Type used for register access */
+} RTC_MODE2_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE2_INTFLAG_OFFSET            (0x0C)                                        /**<  (RTC_MODE2_INTFLAG) MODE2 Interrupt Flag Status and Clear  Offset */
+#define RTC_MODE2_INTFLAG_RESETVALUE        _U_(0x00)                                     /**<  (RTC_MODE2_INTFLAG) MODE2 Interrupt Flag Status and Clear  Reset Value */
+
+#define RTC_MODE2_INTFLAG_PER0_Pos          0                                              /**< (RTC_MODE2_INTFLAG) Periodic Interval 0 Position */
+#define RTC_MODE2_INTFLAG_PER0_Msk          (_U_(0x1) << RTC_MODE2_INTFLAG_PER0_Pos)       /**< (RTC_MODE2_INTFLAG) Periodic Interval 0 Mask */
+#define RTC_MODE2_INTFLAG_PER0              RTC_MODE2_INTFLAG_PER0_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTFLAG_PER0_Msk instead */
+#define RTC_MODE2_INTFLAG_PER1_Pos          1                                              /**< (RTC_MODE2_INTFLAG) Periodic Interval 1 Position */
+#define RTC_MODE2_INTFLAG_PER1_Msk          (_U_(0x1) << RTC_MODE2_INTFLAG_PER1_Pos)       /**< (RTC_MODE2_INTFLAG) Periodic Interval 1 Mask */
+#define RTC_MODE2_INTFLAG_PER1              RTC_MODE2_INTFLAG_PER1_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTFLAG_PER1_Msk instead */
+#define RTC_MODE2_INTFLAG_PER2_Pos          2                                              /**< (RTC_MODE2_INTFLAG) Periodic Interval 2 Position */
+#define RTC_MODE2_INTFLAG_PER2_Msk          (_U_(0x1) << RTC_MODE2_INTFLAG_PER2_Pos)       /**< (RTC_MODE2_INTFLAG) Periodic Interval 2 Mask */
+#define RTC_MODE2_INTFLAG_PER2              RTC_MODE2_INTFLAG_PER2_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTFLAG_PER2_Msk instead */
+#define RTC_MODE2_INTFLAG_PER3_Pos          3                                              /**< (RTC_MODE2_INTFLAG) Periodic Interval 3 Position */
+#define RTC_MODE2_INTFLAG_PER3_Msk          (_U_(0x1) << RTC_MODE2_INTFLAG_PER3_Pos)       /**< (RTC_MODE2_INTFLAG) Periodic Interval 3 Mask */
+#define RTC_MODE2_INTFLAG_PER3              RTC_MODE2_INTFLAG_PER3_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTFLAG_PER3_Msk instead */
+#define RTC_MODE2_INTFLAG_PER4_Pos          4                                              /**< (RTC_MODE2_INTFLAG) Periodic Interval 4 Position */
+#define RTC_MODE2_INTFLAG_PER4_Msk          (_U_(0x1) << RTC_MODE2_INTFLAG_PER4_Pos)       /**< (RTC_MODE2_INTFLAG) Periodic Interval 4 Mask */
+#define RTC_MODE2_INTFLAG_PER4              RTC_MODE2_INTFLAG_PER4_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTFLAG_PER4_Msk instead */
+#define RTC_MODE2_INTFLAG_PER5_Pos          5                                              /**< (RTC_MODE2_INTFLAG) Periodic Interval 5 Position */
+#define RTC_MODE2_INTFLAG_PER5_Msk          (_U_(0x1) << RTC_MODE2_INTFLAG_PER5_Pos)       /**< (RTC_MODE2_INTFLAG) Periodic Interval 5 Mask */
+#define RTC_MODE2_INTFLAG_PER5              RTC_MODE2_INTFLAG_PER5_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTFLAG_PER5_Msk instead */
+#define RTC_MODE2_INTFLAG_PER6_Pos          6                                              /**< (RTC_MODE2_INTFLAG) Periodic Interval 6 Position */
+#define RTC_MODE2_INTFLAG_PER6_Msk          (_U_(0x1) << RTC_MODE2_INTFLAG_PER6_Pos)       /**< (RTC_MODE2_INTFLAG) Periodic Interval 6 Mask */
+#define RTC_MODE2_INTFLAG_PER6              RTC_MODE2_INTFLAG_PER6_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTFLAG_PER6_Msk instead */
+#define RTC_MODE2_INTFLAG_PER7_Pos          7                                              /**< (RTC_MODE2_INTFLAG) Periodic Interval 7 Position */
+#define RTC_MODE2_INTFLAG_PER7_Msk          (_U_(0x1) << RTC_MODE2_INTFLAG_PER7_Pos)       /**< (RTC_MODE2_INTFLAG) Periodic Interval 7 Mask */
+#define RTC_MODE2_INTFLAG_PER7              RTC_MODE2_INTFLAG_PER7_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTFLAG_PER7_Msk instead */
+#define RTC_MODE2_INTFLAG_ALARM0_Pos        8                                              /**< (RTC_MODE2_INTFLAG) Alarm 0 Position */
+#define RTC_MODE2_INTFLAG_ALARM0_Msk        (_U_(0x1) << RTC_MODE2_INTFLAG_ALARM0_Pos)     /**< (RTC_MODE2_INTFLAG) Alarm 0 Mask */
+#define RTC_MODE2_INTFLAG_ALARM0            RTC_MODE2_INTFLAG_ALARM0_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTFLAG_ALARM0_Msk instead */
+#define RTC_MODE2_INTFLAG_TAMPER_Pos        14                                             /**< (RTC_MODE2_INTFLAG) Tamper Position */
+#define RTC_MODE2_INTFLAG_TAMPER_Msk        (_U_(0x1) << RTC_MODE2_INTFLAG_TAMPER_Pos)     /**< (RTC_MODE2_INTFLAG) Tamper Mask */
+#define RTC_MODE2_INTFLAG_TAMPER            RTC_MODE2_INTFLAG_TAMPER_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTFLAG_TAMPER_Msk instead */
+#define RTC_MODE2_INTFLAG_OVF_Pos           15                                             /**< (RTC_MODE2_INTFLAG) Overflow Position */
+#define RTC_MODE2_INTFLAG_OVF_Msk           (_U_(0x1) << RTC_MODE2_INTFLAG_OVF_Pos)        /**< (RTC_MODE2_INTFLAG) Overflow Mask */
+#define RTC_MODE2_INTFLAG_OVF               RTC_MODE2_INTFLAG_OVF_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_INTFLAG_OVF_Msk instead */
+#define RTC_MODE2_INTFLAG_MASK              _U_(0xC1FF)                                    /**< \deprecated (RTC_MODE2_INTFLAG) Register MASK  (Use RTC_MODE2_INTFLAG_Msk instead)  */
+#define RTC_MODE2_INTFLAG_Msk               _U_(0xC1FF)                                    /**< (RTC_MODE2_INTFLAG) Register Mask  */
+
+#define RTC_MODE2_INTFLAG_PER_Pos           0                                              /**< (RTC_MODE2_INTFLAG Position) Periodic Interval x */
+#define RTC_MODE2_INTFLAG_PER_Msk           (_U_(0xFF) << RTC_MODE2_INTFLAG_PER_Pos)       /**< (RTC_MODE2_INTFLAG Mask) PER */
+#define RTC_MODE2_INTFLAG_PER(value)        (RTC_MODE2_INTFLAG_PER_Msk & ((value) << RTC_MODE2_INTFLAG_PER_Pos))  
+#define RTC_MODE2_INTFLAG_ALARM_Pos         8                                              /**< (RTC_MODE2_INTFLAG Position) Alarm x */
+#define RTC_MODE2_INTFLAG_ALARM_Msk         (_U_(0x1) << RTC_MODE2_INTFLAG_ALARM_Pos)      /**< (RTC_MODE2_INTFLAG Mask) ALARM */
+#define RTC_MODE2_INTFLAG_ALARM(value)      (RTC_MODE2_INTFLAG_ALARM_Msk & ((value) << RTC_MODE2_INTFLAG_ALARM_Pos))  
+
+/* -------- RTC_DBGCTRL : (RTC Offset: 0x0e) (R/W 8) Debug Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DBGRUN:1;                  /**< bit:      0  Run During Debug                         */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} RTC_DBGCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_DBGCTRL_OFFSET                  (0x0E)                                        /**<  (RTC_DBGCTRL) Debug Control  Offset */
+#define RTC_DBGCTRL_RESETVALUE              _U_(0x00)                                     /**<  (RTC_DBGCTRL) Debug Control  Reset Value */
+
+#define RTC_DBGCTRL_DBGRUN_Pos              0                                              /**< (RTC_DBGCTRL) Run During Debug Position */
+#define RTC_DBGCTRL_DBGRUN_Msk              (_U_(0x1) << RTC_DBGCTRL_DBGRUN_Pos)           /**< (RTC_DBGCTRL) Run During Debug Mask */
+#define RTC_DBGCTRL_DBGRUN                  RTC_DBGCTRL_DBGRUN_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_DBGCTRL_DBGRUN_Msk instead */
+#define RTC_DBGCTRL_MASK                    _U_(0x01)                                      /**< \deprecated (RTC_DBGCTRL) Register MASK  (Use RTC_DBGCTRL_Msk instead)  */
+#define RTC_DBGCTRL_Msk                     _U_(0x01)                                      /**< (RTC_DBGCTRL) Register Mask  */
+
+
+/* -------- RTC_MODE0_SYNCBUSY : (RTC Offset: 0x10) (R/ 32) MODE0 Synchronization Busy Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SWRST:1;                   /**< bit:      0  Software Reset Busy                      */
+    uint32_t ENABLE:1;                  /**< bit:      1  Enable Bit Busy                          */
+    uint32_t FREQCORR:1;                /**< bit:      2  FREQCORR Register Busy                   */
+    uint32_t COUNT:1;                   /**< bit:      3  COUNT Register Busy                      */
+    uint32_t :1;                        /**< bit:      4  Reserved */
+    uint32_t COMP0:1;                   /**< bit:      5  COMP 0 Register Busy                     */
+    uint32_t :9;                        /**< bit:  6..14  Reserved */
+    uint32_t COUNTSYNC:1;               /**< bit:     15  Count Synchronization Enable Bit Busy    */
+    uint32_t GP0:1;                     /**< bit:     16  General Purpose 0 Register Busy          */
+    uint32_t GP1:1;                     /**< bit:     17  General Purpose 1 Register Busy          */
+    uint32_t :14;                       /**< bit: 18..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :5;                        /**< bit:   0..4  Reserved */
+    uint32_t COMP:1;                    /**< bit:      5  COMP x Register Busy                     */
+    uint32_t :10;                       /**< bit:  6..15  Reserved */
+    uint32_t GP:2;                      /**< bit: 16..17  General Purpose x Register Busy          */
+    uint32_t :14;                       /**< bit: 18..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_MODE0_SYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE0_SYNCBUSY_OFFSET           (0x10)                                        /**<  (RTC_MODE0_SYNCBUSY) MODE0 Synchronization Busy Status  Offset */
+#define RTC_MODE0_SYNCBUSY_RESETVALUE       _U_(0x00)                                     /**<  (RTC_MODE0_SYNCBUSY) MODE0 Synchronization Busy Status  Reset Value */
+
+#define RTC_MODE0_SYNCBUSY_SWRST_Pos        0                                              /**< (RTC_MODE0_SYNCBUSY) Software Reset Busy Position */
+#define RTC_MODE0_SYNCBUSY_SWRST_Msk        (_U_(0x1) << RTC_MODE0_SYNCBUSY_SWRST_Pos)     /**< (RTC_MODE0_SYNCBUSY) Software Reset Busy Mask */
+#define RTC_MODE0_SYNCBUSY_SWRST            RTC_MODE0_SYNCBUSY_SWRST_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_SYNCBUSY_SWRST_Msk instead */
+#define RTC_MODE0_SYNCBUSY_ENABLE_Pos       1                                              /**< (RTC_MODE0_SYNCBUSY) Enable Bit Busy Position */
+#define RTC_MODE0_SYNCBUSY_ENABLE_Msk       (_U_(0x1) << RTC_MODE0_SYNCBUSY_ENABLE_Pos)    /**< (RTC_MODE0_SYNCBUSY) Enable Bit Busy Mask */
+#define RTC_MODE0_SYNCBUSY_ENABLE           RTC_MODE0_SYNCBUSY_ENABLE_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_SYNCBUSY_ENABLE_Msk instead */
+#define RTC_MODE0_SYNCBUSY_FREQCORR_Pos     2                                              /**< (RTC_MODE0_SYNCBUSY) FREQCORR Register Busy Position */
+#define RTC_MODE0_SYNCBUSY_FREQCORR_Msk     (_U_(0x1) << RTC_MODE0_SYNCBUSY_FREQCORR_Pos)  /**< (RTC_MODE0_SYNCBUSY) FREQCORR Register Busy Mask */
+#define RTC_MODE0_SYNCBUSY_FREQCORR         RTC_MODE0_SYNCBUSY_FREQCORR_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_SYNCBUSY_FREQCORR_Msk instead */
+#define RTC_MODE0_SYNCBUSY_COUNT_Pos        3                                              /**< (RTC_MODE0_SYNCBUSY) COUNT Register Busy Position */
+#define RTC_MODE0_SYNCBUSY_COUNT_Msk        (_U_(0x1) << RTC_MODE0_SYNCBUSY_COUNT_Pos)     /**< (RTC_MODE0_SYNCBUSY) COUNT Register Busy Mask */
+#define RTC_MODE0_SYNCBUSY_COUNT            RTC_MODE0_SYNCBUSY_COUNT_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_SYNCBUSY_COUNT_Msk instead */
+#define RTC_MODE0_SYNCBUSY_COMP0_Pos        5                                              /**< (RTC_MODE0_SYNCBUSY) COMP 0 Register Busy Position */
+#define RTC_MODE0_SYNCBUSY_COMP0_Msk        (_U_(0x1) << RTC_MODE0_SYNCBUSY_COMP0_Pos)     /**< (RTC_MODE0_SYNCBUSY) COMP 0 Register Busy Mask */
+#define RTC_MODE0_SYNCBUSY_COMP0            RTC_MODE0_SYNCBUSY_COMP0_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_SYNCBUSY_COMP0_Msk instead */
+#define RTC_MODE0_SYNCBUSY_COUNTSYNC_Pos    15                                             /**< (RTC_MODE0_SYNCBUSY) Count Synchronization Enable Bit Busy Position */
+#define RTC_MODE0_SYNCBUSY_COUNTSYNC_Msk    (_U_(0x1) << RTC_MODE0_SYNCBUSY_COUNTSYNC_Pos)  /**< (RTC_MODE0_SYNCBUSY) Count Synchronization Enable Bit Busy Mask */
+#define RTC_MODE0_SYNCBUSY_COUNTSYNC        RTC_MODE0_SYNCBUSY_COUNTSYNC_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_SYNCBUSY_COUNTSYNC_Msk instead */
+#define RTC_MODE0_SYNCBUSY_GP0_Pos          16                                             /**< (RTC_MODE0_SYNCBUSY) General Purpose 0 Register Busy Position */
+#define RTC_MODE0_SYNCBUSY_GP0_Msk          (_U_(0x1) << RTC_MODE0_SYNCBUSY_GP0_Pos)       /**< (RTC_MODE0_SYNCBUSY) General Purpose 0 Register Busy Mask */
+#define RTC_MODE0_SYNCBUSY_GP0              RTC_MODE0_SYNCBUSY_GP0_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_SYNCBUSY_GP0_Msk instead */
+#define RTC_MODE0_SYNCBUSY_GP1_Pos          17                                             /**< (RTC_MODE0_SYNCBUSY) General Purpose 1 Register Busy Position */
+#define RTC_MODE0_SYNCBUSY_GP1_Msk          (_U_(0x1) << RTC_MODE0_SYNCBUSY_GP1_Pos)       /**< (RTC_MODE0_SYNCBUSY) General Purpose 1 Register Busy Mask */
+#define RTC_MODE0_SYNCBUSY_GP1              RTC_MODE0_SYNCBUSY_GP1_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE0_SYNCBUSY_GP1_Msk instead */
+#define RTC_MODE0_SYNCBUSY_MASK             _U_(0x3802F)                                   /**< \deprecated (RTC_MODE0_SYNCBUSY) Register MASK  (Use RTC_MODE0_SYNCBUSY_Msk instead)  */
+#define RTC_MODE0_SYNCBUSY_Msk              _U_(0x3802F)                                   /**< (RTC_MODE0_SYNCBUSY) Register Mask  */
+
+#define RTC_MODE0_SYNCBUSY_COMP_Pos         5                                              /**< (RTC_MODE0_SYNCBUSY Position) COMP x Register Busy */
+#define RTC_MODE0_SYNCBUSY_COMP_Msk         (_U_(0x1) << RTC_MODE0_SYNCBUSY_COMP_Pos)      /**< (RTC_MODE0_SYNCBUSY Mask) COMP */
+#define RTC_MODE0_SYNCBUSY_COMP(value)      (RTC_MODE0_SYNCBUSY_COMP_Msk & ((value) << RTC_MODE0_SYNCBUSY_COMP_Pos))  
+#define RTC_MODE0_SYNCBUSY_GP_Pos           16                                             /**< (RTC_MODE0_SYNCBUSY Position) General Purpose x Register Busy */
+#define RTC_MODE0_SYNCBUSY_GP_Msk           (_U_(0x3) << RTC_MODE0_SYNCBUSY_GP_Pos)        /**< (RTC_MODE0_SYNCBUSY Mask) GP */
+#define RTC_MODE0_SYNCBUSY_GP(value)        (RTC_MODE0_SYNCBUSY_GP_Msk & ((value) << RTC_MODE0_SYNCBUSY_GP_Pos))  
+
+/* -------- RTC_MODE1_SYNCBUSY : (RTC Offset: 0x10) (R/ 32) MODE1 Synchronization Busy Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SWRST:1;                   /**< bit:      0  Software Reset Bit Busy                  */
+    uint32_t ENABLE:1;                  /**< bit:      1  Enable Bit Busy                          */
+    uint32_t FREQCORR:1;                /**< bit:      2  FREQCORR Register Busy                   */
+    uint32_t COUNT:1;                   /**< bit:      3  COUNT Register Busy                      */
+    uint32_t PER:1;                     /**< bit:      4  PER Register Busy                        */
+    uint32_t COMP0:1;                   /**< bit:      5  COMP 0 Register Busy                     */
+    uint32_t COMP1:1;                   /**< bit:      6  COMP 1 Register Busy                     */
+    uint32_t :8;                        /**< bit:  7..14  Reserved */
+    uint32_t COUNTSYNC:1;               /**< bit:     15  Count Synchronization Enable Bit Busy    */
+    uint32_t GP0:1;                     /**< bit:     16  General Purpose 0 Register Busy          */
+    uint32_t GP1:1;                     /**< bit:     17  General Purpose 1 Register Busy          */
+    uint32_t :14;                       /**< bit: 18..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :5;                        /**< bit:   0..4  Reserved */
+    uint32_t COMP:2;                    /**< bit:   5..6  COMP x Register Busy                     */
+    uint32_t :9;                        /**< bit:  7..15  Reserved */
+    uint32_t GP:2;                      /**< bit: 16..17  General Purpose x Register Busy          */
+    uint32_t :14;                       /**< bit: 18..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_MODE1_SYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE1_SYNCBUSY_OFFSET           (0x10)                                        /**<  (RTC_MODE1_SYNCBUSY) MODE1 Synchronization Busy Status  Offset */
+#define RTC_MODE1_SYNCBUSY_RESETVALUE       _U_(0x00)                                     /**<  (RTC_MODE1_SYNCBUSY) MODE1 Synchronization Busy Status  Reset Value */
+
+#define RTC_MODE1_SYNCBUSY_SWRST_Pos        0                                              /**< (RTC_MODE1_SYNCBUSY) Software Reset Bit Busy Position */
+#define RTC_MODE1_SYNCBUSY_SWRST_Msk        (_U_(0x1) << RTC_MODE1_SYNCBUSY_SWRST_Pos)     /**< (RTC_MODE1_SYNCBUSY) Software Reset Bit Busy Mask */
+#define RTC_MODE1_SYNCBUSY_SWRST            RTC_MODE1_SYNCBUSY_SWRST_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_SYNCBUSY_SWRST_Msk instead */
+#define RTC_MODE1_SYNCBUSY_ENABLE_Pos       1                                              /**< (RTC_MODE1_SYNCBUSY) Enable Bit Busy Position */
+#define RTC_MODE1_SYNCBUSY_ENABLE_Msk       (_U_(0x1) << RTC_MODE1_SYNCBUSY_ENABLE_Pos)    /**< (RTC_MODE1_SYNCBUSY) Enable Bit Busy Mask */
+#define RTC_MODE1_SYNCBUSY_ENABLE           RTC_MODE1_SYNCBUSY_ENABLE_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_SYNCBUSY_ENABLE_Msk instead */
+#define RTC_MODE1_SYNCBUSY_FREQCORR_Pos     2                                              /**< (RTC_MODE1_SYNCBUSY) FREQCORR Register Busy Position */
+#define RTC_MODE1_SYNCBUSY_FREQCORR_Msk     (_U_(0x1) << RTC_MODE1_SYNCBUSY_FREQCORR_Pos)  /**< (RTC_MODE1_SYNCBUSY) FREQCORR Register Busy Mask */
+#define RTC_MODE1_SYNCBUSY_FREQCORR         RTC_MODE1_SYNCBUSY_FREQCORR_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_SYNCBUSY_FREQCORR_Msk instead */
+#define RTC_MODE1_SYNCBUSY_COUNT_Pos        3                                              /**< (RTC_MODE1_SYNCBUSY) COUNT Register Busy Position */
+#define RTC_MODE1_SYNCBUSY_COUNT_Msk        (_U_(0x1) << RTC_MODE1_SYNCBUSY_COUNT_Pos)     /**< (RTC_MODE1_SYNCBUSY) COUNT Register Busy Mask */
+#define RTC_MODE1_SYNCBUSY_COUNT            RTC_MODE1_SYNCBUSY_COUNT_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_SYNCBUSY_COUNT_Msk instead */
+#define RTC_MODE1_SYNCBUSY_PER_Pos          4                                              /**< (RTC_MODE1_SYNCBUSY) PER Register Busy Position */
+#define RTC_MODE1_SYNCBUSY_PER_Msk          (_U_(0x1) << RTC_MODE1_SYNCBUSY_PER_Pos)       /**< (RTC_MODE1_SYNCBUSY) PER Register Busy Mask */
+#define RTC_MODE1_SYNCBUSY_PER              RTC_MODE1_SYNCBUSY_PER_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_SYNCBUSY_PER_Msk instead */
+#define RTC_MODE1_SYNCBUSY_COMP0_Pos        5                                              /**< (RTC_MODE1_SYNCBUSY) COMP 0 Register Busy Position */
+#define RTC_MODE1_SYNCBUSY_COMP0_Msk        (_U_(0x1) << RTC_MODE1_SYNCBUSY_COMP0_Pos)     /**< (RTC_MODE1_SYNCBUSY) COMP 0 Register Busy Mask */
+#define RTC_MODE1_SYNCBUSY_COMP0            RTC_MODE1_SYNCBUSY_COMP0_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_SYNCBUSY_COMP0_Msk instead */
+#define RTC_MODE1_SYNCBUSY_COMP1_Pos        6                                              /**< (RTC_MODE1_SYNCBUSY) COMP 1 Register Busy Position */
+#define RTC_MODE1_SYNCBUSY_COMP1_Msk        (_U_(0x1) << RTC_MODE1_SYNCBUSY_COMP1_Pos)     /**< (RTC_MODE1_SYNCBUSY) COMP 1 Register Busy Mask */
+#define RTC_MODE1_SYNCBUSY_COMP1            RTC_MODE1_SYNCBUSY_COMP1_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_SYNCBUSY_COMP1_Msk instead */
+#define RTC_MODE1_SYNCBUSY_COUNTSYNC_Pos    15                                             /**< (RTC_MODE1_SYNCBUSY) Count Synchronization Enable Bit Busy Position */
+#define RTC_MODE1_SYNCBUSY_COUNTSYNC_Msk    (_U_(0x1) << RTC_MODE1_SYNCBUSY_COUNTSYNC_Pos)  /**< (RTC_MODE1_SYNCBUSY) Count Synchronization Enable Bit Busy Mask */
+#define RTC_MODE1_SYNCBUSY_COUNTSYNC        RTC_MODE1_SYNCBUSY_COUNTSYNC_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_SYNCBUSY_COUNTSYNC_Msk instead */
+#define RTC_MODE1_SYNCBUSY_GP0_Pos          16                                             /**< (RTC_MODE1_SYNCBUSY) General Purpose 0 Register Busy Position */
+#define RTC_MODE1_SYNCBUSY_GP0_Msk          (_U_(0x1) << RTC_MODE1_SYNCBUSY_GP0_Pos)       /**< (RTC_MODE1_SYNCBUSY) General Purpose 0 Register Busy Mask */
+#define RTC_MODE1_SYNCBUSY_GP0              RTC_MODE1_SYNCBUSY_GP0_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_SYNCBUSY_GP0_Msk instead */
+#define RTC_MODE1_SYNCBUSY_GP1_Pos          17                                             /**< (RTC_MODE1_SYNCBUSY) General Purpose 1 Register Busy Position */
+#define RTC_MODE1_SYNCBUSY_GP1_Msk          (_U_(0x1) << RTC_MODE1_SYNCBUSY_GP1_Pos)       /**< (RTC_MODE1_SYNCBUSY) General Purpose 1 Register Busy Mask */
+#define RTC_MODE1_SYNCBUSY_GP1              RTC_MODE1_SYNCBUSY_GP1_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE1_SYNCBUSY_GP1_Msk instead */
+#define RTC_MODE1_SYNCBUSY_MASK             _U_(0x3807F)                                   /**< \deprecated (RTC_MODE1_SYNCBUSY) Register MASK  (Use RTC_MODE1_SYNCBUSY_Msk instead)  */
+#define RTC_MODE1_SYNCBUSY_Msk              _U_(0x3807F)                                   /**< (RTC_MODE1_SYNCBUSY) Register Mask  */
+
+#define RTC_MODE1_SYNCBUSY_COMP_Pos         5                                              /**< (RTC_MODE1_SYNCBUSY Position) COMP x Register Busy */
+#define RTC_MODE1_SYNCBUSY_COMP_Msk         (_U_(0x3) << RTC_MODE1_SYNCBUSY_COMP_Pos)      /**< (RTC_MODE1_SYNCBUSY Mask) COMP */
+#define RTC_MODE1_SYNCBUSY_COMP(value)      (RTC_MODE1_SYNCBUSY_COMP_Msk & ((value) << RTC_MODE1_SYNCBUSY_COMP_Pos))  
+#define RTC_MODE1_SYNCBUSY_GP_Pos           16                                             /**< (RTC_MODE1_SYNCBUSY Position) General Purpose x Register Busy */
+#define RTC_MODE1_SYNCBUSY_GP_Msk           (_U_(0x3) << RTC_MODE1_SYNCBUSY_GP_Pos)        /**< (RTC_MODE1_SYNCBUSY Mask) GP */
+#define RTC_MODE1_SYNCBUSY_GP(value)        (RTC_MODE1_SYNCBUSY_GP_Msk & ((value) << RTC_MODE1_SYNCBUSY_GP_Pos))  
+
+/* -------- RTC_MODE2_SYNCBUSY : (RTC Offset: 0x10) (R/ 32) MODE2 Synchronization Busy Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SWRST:1;                   /**< bit:      0  Software Reset Bit Busy                  */
+    uint32_t ENABLE:1;                  /**< bit:      1  Enable Bit Busy                          */
+    uint32_t FREQCORR:1;                /**< bit:      2  FREQCORR Register Busy                   */
+    uint32_t CLOCK:1;                   /**< bit:      3  CLOCK Register Busy                      */
+    uint32_t :1;                        /**< bit:      4  Reserved */
+    uint32_t ALARM0:1;                  /**< bit:      5  ALARM 0 Register Busy                    */
+    uint32_t :5;                        /**< bit:  6..10  Reserved */
+    uint32_t MASK0:1;                   /**< bit:     11  MASK 0 Register Busy                     */
+    uint32_t :3;                        /**< bit: 12..14  Reserved */
+    uint32_t CLOCKSYNC:1;               /**< bit:     15  Clock Synchronization Enable Bit Busy    */
+    uint32_t GP0:1;                     /**< bit:     16  General Purpose 0 Register Busy          */
+    uint32_t GP1:1;                     /**< bit:     17  General Purpose 1 Register Busy          */
+    uint32_t :14;                       /**< bit: 18..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :5;                        /**< bit:   0..4  Reserved */
+    uint32_t ALARM:1;                   /**< bit:      5  ALARM x Register Busy                    */
+    uint32_t :5;                        /**< bit:  6..10  Reserved */
+    uint32_t MASK:1;                    /**< bit:     11  MASK x Register Busy                     */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t GP:2;                      /**< bit: 16..17  General Purpose x Register Busy          */
+    uint32_t :14;                       /**< bit: 18..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_MODE2_SYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE2_SYNCBUSY_OFFSET           (0x10)                                        /**<  (RTC_MODE2_SYNCBUSY) MODE2 Synchronization Busy Status  Offset */
+#define RTC_MODE2_SYNCBUSY_RESETVALUE       _U_(0x00)                                     /**<  (RTC_MODE2_SYNCBUSY) MODE2 Synchronization Busy Status  Reset Value */
+
+#define RTC_MODE2_SYNCBUSY_SWRST_Pos        0                                              /**< (RTC_MODE2_SYNCBUSY) Software Reset Bit Busy Position */
+#define RTC_MODE2_SYNCBUSY_SWRST_Msk        (_U_(0x1) << RTC_MODE2_SYNCBUSY_SWRST_Pos)     /**< (RTC_MODE2_SYNCBUSY) Software Reset Bit Busy Mask */
+#define RTC_MODE2_SYNCBUSY_SWRST            RTC_MODE2_SYNCBUSY_SWRST_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_SYNCBUSY_SWRST_Msk instead */
+#define RTC_MODE2_SYNCBUSY_ENABLE_Pos       1                                              /**< (RTC_MODE2_SYNCBUSY) Enable Bit Busy Position */
+#define RTC_MODE2_SYNCBUSY_ENABLE_Msk       (_U_(0x1) << RTC_MODE2_SYNCBUSY_ENABLE_Pos)    /**< (RTC_MODE2_SYNCBUSY) Enable Bit Busy Mask */
+#define RTC_MODE2_SYNCBUSY_ENABLE           RTC_MODE2_SYNCBUSY_ENABLE_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_SYNCBUSY_ENABLE_Msk instead */
+#define RTC_MODE2_SYNCBUSY_FREQCORR_Pos     2                                              /**< (RTC_MODE2_SYNCBUSY) FREQCORR Register Busy Position */
+#define RTC_MODE2_SYNCBUSY_FREQCORR_Msk     (_U_(0x1) << RTC_MODE2_SYNCBUSY_FREQCORR_Pos)  /**< (RTC_MODE2_SYNCBUSY) FREQCORR Register Busy Mask */
+#define RTC_MODE2_SYNCBUSY_FREQCORR         RTC_MODE2_SYNCBUSY_FREQCORR_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_SYNCBUSY_FREQCORR_Msk instead */
+#define RTC_MODE2_SYNCBUSY_CLOCK_Pos        3                                              /**< (RTC_MODE2_SYNCBUSY) CLOCK Register Busy Position */
+#define RTC_MODE2_SYNCBUSY_CLOCK_Msk        (_U_(0x1) << RTC_MODE2_SYNCBUSY_CLOCK_Pos)     /**< (RTC_MODE2_SYNCBUSY) CLOCK Register Busy Mask */
+#define RTC_MODE2_SYNCBUSY_CLOCK            RTC_MODE2_SYNCBUSY_CLOCK_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_SYNCBUSY_CLOCK_Msk instead */
+#define RTC_MODE2_SYNCBUSY_ALARM0_Pos       5                                              /**< (RTC_MODE2_SYNCBUSY) ALARM 0 Register Busy Position */
+#define RTC_MODE2_SYNCBUSY_ALARM0_Msk       (_U_(0x1) << RTC_MODE2_SYNCBUSY_ALARM0_Pos)    /**< (RTC_MODE2_SYNCBUSY) ALARM 0 Register Busy Mask */
+#define RTC_MODE2_SYNCBUSY_ALARM0           RTC_MODE2_SYNCBUSY_ALARM0_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_SYNCBUSY_ALARM0_Msk instead */
+#define RTC_MODE2_SYNCBUSY_MASK0_Pos        11                                             /**< (RTC_MODE2_SYNCBUSY) MASK 0 Register Busy Position */
+#define RTC_MODE2_SYNCBUSY_MASK0_Msk        (_U_(0x1) << RTC_MODE2_SYNCBUSY_MASK0_Pos)     /**< (RTC_MODE2_SYNCBUSY) MASK 0 Register Busy Mask */
+#define RTC_MODE2_SYNCBUSY_MASK0            RTC_MODE2_SYNCBUSY_MASK0_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_SYNCBUSY_MASK0_Msk instead */
+#define RTC_MODE2_SYNCBUSY_CLOCKSYNC_Pos    15                                             /**< (RTC_MODE2_SYNCBUSY) Clock Synchronization Enable Bit Busy Position */
+#define RTC_MODE2_SYNCBUSY_CLOCKSYNC_Msk    (_U_(0x1) << RTC_MODE2_SYNCBUSY_CLOCKSYNC_Pos)  /**< (RTC_MODE2_SYNCBUSY) Clock Synchronization Enable Bit Busy Mask */
+#define RTC_MODE2_SYNCBUSY_CLOCKSYNC        RTC_MODE2_SYNCBUSY_CLOCKSYNC_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_SYNCBUSY_CLOCKSYNC_Msk instead */
+#define RTC_MODE2_SYNCBUSY_GP0_Pos          16                                             /**< (RTC_MODE2_SYNCBUSY) General Purpose 0 Register Busy Position */
+#define RTC_MODE2_SYNCBUSY_GP0_Msk          (_U_(0x1) << RTC_MODE2_SYNCBUSY_GP0_Pos)       /**< (RTC_MODE2_SYNCBUSY) General Purpose 0 Register Busy Mask */
+#define RTC_MODE2_SYNCBUSY_GP0              RTC_MODE2_SYNCBUSY_GP0_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_SYNCBUSY_GP0_Msk instead */
+#define RTC_MODE2_SYNCBUSY_GP1_Pos          17                                             /**< (RTC_MODE2_SYNCBUSY) General Purpose 1 Register Busy Position */
+#define RTC_MODE2_SYNCBUSY_GP1_Msk          (_U_(0x1) << RTC_MODE2_SYNCBUSY_GP1_Pos)       /**< (RTC_MODE2_SYNCBUSY) General Purpose 1 Register Busy Mask */
+#define RTC_MODE2_SYNCBUSY_GP1              RTC_MODE2_SYNCBUSY_GP1_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MODE2_SYNCBUSY_GP1_Msk instead */
+#define RTC_MODE2_SYNCBUSY_Msk              _U_(0x3882F)                                   /**< (RTC_MODE2_SYNCBUSY) Register Mask  */
+
+#define RTC_MODE2_SYNCBUSY_ALARM_Pos        5                                              /**< (RTC_MODE2_SYNCBUSY Position) ALARM x Register Busy */
+#define RTC_MODE2_SYNCBUSY_ALARM_Msk        (_U_(0x1) << RTC_MODE2_SYNCBUSY_ALARM_Pos)     /**< (RTC_MODE2_SYNCBUSY Mask) ALARM */
+#define RTC_MODE2_SYNCBUSY_ALARM(value)     (RTC_MODE2_SYNCBUSY_ALARM_Msk & ((value) << RTC_MODE2_SYNCBUSY_ALARM_Pos))  
+#define RTC_MODE2_SYNCBUSY_MASK_Pos         11                                             /**< (RTC_MODE2_SYNCBUSY Position) MASK x Register Busy */
+#define RTC_MODE2_SYNCBUSY_MASK_Msk         (_U_(0x1) << RTC_MODE2_SYNCBUSY_MASK_Pos)      /**< (RTC_MODE2_SYNCBUSY Mask) MASK */
+#define RTC_MODE2_SYNCBUSY_MASK(value)      (RTC_MODE2_SYNCBUSY_MASK_Msk & ((value) << RTC_MODE2_SYNCBUSY_MASK_Pos))  
+#define RTC_MODE2_SYNCBUSY_GP_Pos           16                                             /**< (RTC_MODE2_SYNCBUSY Position) General Purpose x Register Busy */
+#define RTC_MODE2_SYNCBUSY_GP_Msk           (_U_(0x3) << RTC_MODE2_SYNCBUSY_GP_Pos)        /**< (RTC_MODE2_SYNCBUSY Mask) GP */
+#define RTC_MODE2_SYNCBUSY_GP(value)        (RTC_MODE2_SYNCBUSY_GP_Msk & ((value) << RTC_MODE2_SYNCBUSY_GP_Pos))  
+
+/* -------- RTC_FREQCORR : (RTC Offset: 0x14) (R/W 8) Frequency Correction -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  VALUE:7;                   /**< bit:   0..6  Correction Value                         */
+    uint8_t  SIGN:1;                    /**< bit:      7  Correction Sign                          */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} RTC_FREQCORR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_FREQCORR_OFFSET                 (0x14)                                        /**<  (RTC_FREQCORR) Frequency Correction  Offset */
+#define RTC_FREQCORR_RESETVALUE             _U_(0x00)                                     /**<  (RTC_FREQCORR) Frequency Correction  Reset Value */
+
+#define RTC_FREQCORR_VALUE_Pos              0                                              /**< (RTC_FREQCORR) Correction Value Position */
+#define RTC_FREQCORR_VALUE_Msk              (_U_(0x7F) << RTC_FREQCORR_VALUE_Pos)          /**< (RTC_FREQCORR) Correction Value Mask */
+#define RTC_FREQCORR_VALUE(value)           (RTC_FREQCORR_VALUE_Msk & ((value) << RTC_FREQCORR_VALUE_Pos))
+#define RTC_FREQCORR_SIGN_Pos               7                                              /**< (RTC_FREQCORR) Correction Sign Position */
+#define RTC_FREQCORR_SIGN_Msk               (_U_(0x1) << RTC_FREQCORR_SIGN_Pos)            /**< (RTC_FREQCORR) Correction Sign Mask */
+#define RTC_FREQCORR_SIGN                   RTC_FREQCORR_SIGN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_FREQCORR_SIGN_Msk instead */
+#define RTC_FREQCORR_MASK                   _U_(0xFF)                                      /**< \deprecated (RTC_FREQCORR) Register MASK  (Use RTC_FREQCORR_Msk instead)  */
+#define RTC_FREQCORR_Msk                    _U_(0xFF)                                      /**< (RTC_FREQCORR) Register Mask  */
+
+
+/* -------- RTC_MODE0_COUNT : (RTC Offset: 0x18) (R/W 32) MODE0 Counter Value -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t COUNT:32;                  /**< bit:  0..31  Counter Value                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_MODE0_COUNT_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE0_COUNT_OFFSET              (0x18)                                        /**<  (RTC_MODE0_COUNT) MODE0 Counter Value  Offset */
+#define RTC_MODE0_COUNT_RESETVALUE          _U_(0x00)                                     /**<  (RTC_MODE0_COUNT) MODE0 Counter Value  Reset Value */
+
+#define RTC_MODE0_COUNT_COUNT_Pos           0                                              /**< (RTC_MODE0_COUNT) Counter Value Position */
+#define RTC_MODE0_COUNT_COUNT_Msk           (_U_(0xFFFFFFFF) << RTC_MODE0_COUNT_COUNT_Pos)  /**< (RTC_MODE0_COUNT) Counter Value Mask */
+#define RTC_MODE0_COUNT_COUNT(value)        (RTC_MODE0_COUNT_COUNT_Msk & ((value) << RTC_MODE0_COUNT_COUNT_Pos))
+#define RTC_MODE0_COUNT_MASK                _U_(0xFFFFFFFF)                                /**< \deprecated (RTC_MODE0_COUNT) Register MASK  (Use RTC_MODE0_COUNT_Msk instead)  */
+#define RTC_MODE0_COUNT_Msk                 _U_(0xFFFFFFFF)                                /**< (RTC_MODE0_COUNT) Register Mask  */
+
+
+/* -------- RTC_MODE1_COUNT : (RTC Offset: 0x18) (R/W 16) MODE1 Counter Value -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t COUNT:16;                  /**< bit:  0..15  Counter Value                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} RTC_MODE1_COUNT_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE1_COUNT_OFFSET              (0x18)                                        /**<  (RTC_MODE1_COUNT) MODE1 Counter Value  Offset */
+#define RTC_MODE1_COUNT_RESETVALUE          _U_(0x00)                                     /**<  (RTC_MODE1_COUNT) MODE1 Counter Value  Reset Value */
+
+#define RTC_MODE1_COUNT_COUNT_Pos           0                                              /**< (RTC_MODE1_COUNT) Counter Value Position */
+#define RTC_MODE1_COUNT_COUNT_Msk           (_U_(0xFFFF) << RTC_MODE1_COUNT_COUNT_Pos)     /**< (RTC_MODE1_COUNT) Counter Value Mask */
+#define RTC_MODE1_COUNT_COUNT(value)        (RTC_MODE1_COUNT_COUNT_Msk & ((value) << RTC_MODE1_COUNT_COUNT_Pos))
+#define RTC_MODE1_COUNT_MASK                _U_(0xFFFF)                                    /**< \deprecated (RTC_MODE1_COUNT) Register MASK  (Use RTC_MODE1_COUNT_Msk instead)  */
+#define RTC_MODE1_COUNT_Msk                 _U_(0xFFFF)                                    /**< (RTC_MODE1_COUNT) Register Mask  */
+
+
+/* -------- RTC_MODE2_CLOCK : (RTC Offset: 0x18) (R/W 32) MODE2 Clock Value -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SECOND:6;                  /**< bit:   0..5  Second                                   */
+    uint32_t MINUTE:6;                  /**< bit:  6..11  Minute                                   */
+    uint32_t HOUR:5;                    /**< bit: 12..16  Hour                                     */
+    uint32_t DAY:5;                     /**< bit: 17..21  Day                                      */
+    uint32_t MONTH:4;                   /**< bit: 22..25  Month                                    */
+    uint32_t YEAR:6;                    /**< bit: 26..31  Year                                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_MODE2_CLOCK_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE2_CLOCK_OFFSET              (0x18)                                        /**<  (RTC_MODE2_CLOCK) MODE2 Clock Value  Offset */
+#define RTC_MODE2_CLOCK_RESETVALUE          _U_(0x00)                                     /**<  (RTC_MODE2_CLOCK) MODE2 Clock Value  Reset Value */
+
+#define RTC_MODE2_CLOCK_SECOND_Pos          0                                              /**< (RTC_MODE2_CLOCK) Second Position */
+#define RTC_MODE2_CLOCK_SECOND_Msk          (_U_(0x3F) << RTC_MODE2_CLOCK_SECOND_Pos)      /**< (RTC_MODE2_CLOCK) Second Mask */
+#define RTC_MODE2_CLOCK_SECOND(value)       (RTC_MODE2_CLOCK_SECOND_Msk & ((value) << RTC_MODE2_CLOCK_SECOND_Pos))
+#define RTC_MODE2_CLOCK_MINUTE_Pos          6                                              /**< (RTC_MODE2_CLOCK) Minute Position */
+#define RTC_MODE2_CLOCK_MINUTE_Msk          (_U_(0x3F) << RTC_MODE2_CLOCK_MINUTE_Pos)      /**< (RTC_MODE2_CLOCK) Minute Mask */
+#define RTC_MODE2_CLOCK_MINUTE(value)       (RTC_MODE2_CLOCK_MINUTE_Msk & ((value) << RTC_MODE2_CLOCK_MINUTE_Pos))
+#define RTC_MODE2_CLOCK_HOUR_Pos            12                                             /**< (RTC_MODE2_CLOCK) Hour Position */
+#define RTC_MODE2_CLOCK_HOUR_Msk            (_U_(0x1F) << RTC_MODE2_CLOCK_HOUR_Pos)        /**< (RTC_MODE2_CLOCK) Hour Mask */
+#define RTC_MODE2_CLOCK_HOUR(value)         (RTC_MODE2_CLOCK_HOUR_Msk & ((value) << RTC_MODE2_CLOCK_HOUR_Pos))
+#define RTC_MODE2_CLOCK_DAY_Pos             17                                             /**< (RTC_MODE2_CLOCK) Day Position */
+#define RTC_MODE2_CLOCK_DAY_Msk             (_U_(0x1F) << RTC_MODE2_CLOCK_DAY_Pos)         /**< (RTC_MODE2_CLOCK) Day Mask */
+#define RTC_MODE2_CLOCK_DAY(value)          (RTC_MODE2_CLOCK_DAY_Msk & ((value) << RTC_MODE2_CLOCK_DAY_Pos))
+#define RTC_MODE2_CLOCK_MONTH_Pos           22                                             /**< (RTC_MODE2_CLOCK) Month Position */
+#define RTC_MODE2_CLOCK_MONTH_Msk           (_U_(0xF) << RTC_MODE2_CLOCK_MONTH_Pos)        /**< (RTC_MODE2_CLOCK) Month Mask */
+#define RTC_MODE2_CLOCK_MONTH(value)        (RTC_MODE2_CLOCK_MONTH_Msk & ((value) << RTC_MODE2_CLOCK_MONTH_Pos))
+#define RTC_MODE2_CLOCK_YEAR_Pos            26                                             /**< (RTC_MODE2_CLOCK) Year Position */
+#define RTC_MODE2_CLOCK_YEAR_Msk            (_U_(0x3F) << RTC_MODE2_CLOCK_YEAR_Pos)        /**< (RTC_MODE2_CLOCK) Year Mask */
+#define RTC_MODE2_CLOCK_YEAR(value)         (RTC_MODE2_CLOCK_YEAR_Msk & ((value) << RTC_MODE2_CLOCK_YEAR_Pos))
+#define RTC_MODE2_CLOCK_MASK                _U_(0xFFFFFFFF)                                /**< \deprecated (RTC_MODE2_CLOCK) Register MASK  (Use RTC_MODE2_CLOCK_Msk instead)  */
+#define RTC_MODE2_CLOCK_Msk                 _U_(0xFFFFFFFF)                                /**< (RTC_MODE2_CLOCK) Register Mask  */
+
+
+/* -------- RTC_MODE1_PER : (RTC Offset: 0x1c) (R/W 16) MODE1 Counter Period -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t PER:16;                    /**< bit:  0..15  Counter Period                           */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} RTC_MODE1_PER_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE1_PER_OFFSET                (0x1C)                                        /**<  (RTC_MODE1_PER) MODE1 Counter Period  Offset */
+#define RTC_MODE1_PER_RESETVALUE            _U_(0x00)                                     /**<  (RTC_MODE1_PER) MODE1 Counter Period  Reset Value */
+
+#define RTC_MODE1_PER_PER_Pos               0                                              /**< (RTC_MODE1_PER) Counter Period Position */
+#define RTC_MODE1_PER_PER_Msk               (_U_(0xFFFF) << RTC_MODE1_PER_PER_Pos)         /**< (RTC_MODE1_PER) Counter Period Mask */
+#define RTC_MODE1_PER_PER(value)            (RTC_MODE1_PER_PER_Msk & ((value) << RTC_MODE1_PER_PER_Pos))
+#define RTC_MODE1_PER_MASK                  _U_(0xFFFF)                                    /**< \deprecated (RTC_MODE1_PER) Register MASK  (Use RTC_MODE1_PER_Msk instead)  */
+#define RTC_MODE1_PER_Msk                   _U_(0xFFFF)                                    /**< (RTC_MODE1_PER) Register Mask  */
+
+
+/* -------- RTC_MODE0_COMP : (RTC Offset: 0x20) (R/W 32) MODE0 Compare n Value -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t COMP:32;                   /**< bit:  0..31  Compare Value                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_MODE0_COMP_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE0_COMP_OFFSET               (0x20)                                        /**<  (RTC_MODE0_COMP) MODE0 Compare n Value  Offset */
+#define RTC_MODE0_COMP_RESETVALUE           _U_(0x00)                                     /**<  (RTC_MODE0_COMP) MODE0 Compare n Value  Reset Value */
+
+#define RTC_MODE0_COMP_COMP_Pos             0                                              /**< (RTC_MODE0_COMP) Compare Value Position */
+#define RTC_MODE0_COMP_COMP_Msk             (_U_(0xFFFFFFFF) << RTC_MODE0_COMP_COMP_Pos)   /**< (RTC_MODE0_COMP) Compare Value Mask */
+#define RTC_MODE0_COMP_COMP(value)          (RTC_MODE0_COMP_COMP_Msk & ((value) << RTC_MODE0_COMP_COMP_Pos))
+#define RTC_MODE0_COMP_MASK                 _U_(0xFFFFFFFF)                                /**< \deprecated (RTC_MODE0_COMP) Register MASK  (Use RTC_MODE0_COMP_Msk instead)  */
+#define RTC_MODE0_COMP_Msk                  _U_(0xFFFFFFFF)                                /**< (RTC_MODE0_COMP) Register Mask  */
+
+
+/* -------- RTC_MODE1_COMP : (RTC Offset: 0x20) (R/W 16) MODE1 Compare n Value -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t COMP:16;                   /**< bit:  0..15  Compare Value                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} RTC_MODE1_COMP_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE1_COMP_OFFSET               (0x20)                                        /**<  (RTC_MODE1_COMP) MODE1 Compare n Value  Offset */
+#define RTC_MODE1_COMP_RESETVALUE           _U_(0x00)                                     /**<  (RTC_MODE1_COMP) MODE1 Compare n Value  Reset Value */
+
+#define RTC_MODE1_COMP_COMP_Pos             0                                              /**< (RTC_MODE1_COMP) Compare Value Position */
+#define RTC_MODE1_COMP_COMP_Msk             (_U_(0xFFFF) << RTC_MODE1_COMP_COMP_Pos)       /**< (RTC_MODE1_COMP) Compare Value Mask */
+#define RTC_MODE1_COMP_COMP(value)          (RTC_MODE1_COMP_COMP_Msk & ((value) << RTC_MODE1_COMP_COMP_Pos))
+#define RTC_MODE1_COMP_MASK                 _U_(0xFFFF)                                    /**< \deprecated (RTC_MODE1_COMP) Register MASK  (Use RTC_MODE1_COMP_Msk instead)  */
+#define RTC_MODE1_COMP_Msk                  _U_(0xFFFF)                                    /**< (RTC_MODE1_COMP) Register Mask  */
+
+
+/* -------- RTC_GP : (RTC Offset: 0x40) (R/W 32) General Purpose -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t GP:32;                     /**< bit:  0..31  General Purpose                          */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_GP_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_GP_OFFSET                       (0x40)                                        /**<  (RTC_GP) General Purpose  Offset */
+#define RTC_GP_RESETVALUE                   _U_(0x00)                                     /**<  (RTC_GP) General Purpose  Reset Value */
+
+#define RTC_GP_GP_Pos                       0                                              /**< (RTC_GP) General Purpose Position */
+#define RTC_GP_GP_Msk                       (_U_(0xFFFFFFFF) << RTC_GP_GP_Pos)             /**< (RTC_GP) General Purpose Mask */
+#define RTC_GP_GP(value)                    (RTC_GP_GP_Msk & ((value) << RTC_GP_GP_Pos)) 
+#define RTC_GP_MASK                         _U_(0xFFFFFFFF)                                /**< \deprecated (RTC_GP) Register MASK  (Use RTC_GP_Msk instead)  */
+#define RTC_GP_Msk                          _U_(0xFFFFFFFF)                                /**< (RTC_GP) Register Mask  */
+
+
+/* -------- RTC_TAMPCTRL : (RTC Offset: 0x60) (R/W 32) Tamper Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t IN0ACT:2;                  /**< bit:   0..1  Tamper Input 0 Action                    */
+    uint32_t IN1ACT:2;                  /**< bit:   2..3  Tamper Input 1 Action                    */
+    uint32_t IN2ACT:2;                  /**< bit:   4..5  Tamper Input 2 Action                    */
+    uint32_t IN3ACT:2;                  /**< bit:   6..7  Tamper Input 3 Action                    */
+    uint32_t :8;                        /**< bit:  8..15  Reserved */
+    uint32_t TAMLVL0:1;                 /**< bit:     16  Tamper Level Select 0                    */
+    uint32_t TAMLVL1:1;                 /**< bit:     17  Tamper Level Select 1                    */
+    uint32_t TAMLVL2:1;                 /**< bit:     18  Tamper Level Select 2                    */
+    uint32_t TAMLVL3:1;                 /**< bit:     19  Tamper Level Select 3                    */
+    uint32_t :4;                        /**< bit: 20..23  Reserved */
+    uint32_t DEBNC0:1;                  /**< bit:     24  Debouncer Enable 0                       */
+    uint32_t DEBNC1:1;                  /**< bit:     25  Debouncer Enable 1                       */
+    uint32_t DEBNC2:1;                  /**< bit:     26  Debouncer Enable 2                       */
+    uint32_t DEBNC3:1;                  /**< bit:     27  Debouncer Enable 3                       */
+    uint32_t :4;                        /**< bit: 28..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :16;                       /**< bit:  0..15  Reserved */
+    uint32_t TAMLVL:4;                  /**< bit: 16..19  Tamper Level Select x                    */
+    uint32_t :4;                        /**< bit: 20..23  Reserved */
+    uint32_t DEBNC:4;                   /**< bit: 24..27  Debouncer Enable 3                       */
+    uint32_t :4;                        /**< bit: 28..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_TAMPCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_TAMPCTRL_OFFSET                 (0x60)                                        /**<  (RTC_TAMPCTRL) Tamper Control  Offset */
+#define RTC_TAMPCTRL_RESETVALUE             _U_(0x00)                                     /**<  (RTC_TAMPCTRL) Tamper Control  Reset Value */
+
+#define RTC_TAMPCTRL_IN0ACT_Pos             0                                              /**< (RTC_TAMPCTRL) Tamper Input 0 Action Position */
+#define RTC_TAMPCTRL_IN0ACT_Msk             (_U_(0x3) << RTC_TAMPCTRL_IN0ACT_Pos)          /**< (RTC_TAMPCTRL) Tamper Input 0 Action Mask */
+#define RTC_TAMPCTRL_IN0ACT(value)          (RTC_TAMPCTRL_IN0ACT_Msk & ((value) << RTC_TAMPCTRL_IN0ACT_Pos))
+#define   RTC_TAMPCTRL_IN0ACT_OFF_Val       _U_(0x0)                                       /**< (RTC_TAMPCTRL) Off (Disabled)  */
+#define   RTC_TAMPCTRL_IN0ACT_WAKE_Val      _U_(0x1)                                       /**< (RTC_TAMPCTRL) Wake and set Tamper flag  */
+#define   RTC_TAMPCTRL_IN0ACT_CAPTURE_Val   _U_(0x2)                                       /**< (RTC_TAMPCTRL) Capture timestamp and set Tamper flag  */
+#define   RTC_TAMPCTRL_IN0ACT_ACTL_Val      _U_(0x3)                                       /**< (RTC_TAMPCTRL) Compare IN0 to OUT. When a mismatch occurs, capture timestamp and set Tamper flag  */
+#define RTC_TAMPCTRL_IN0ACT_OFF             (RTC_TAMPCTRL_IN0ACT_OFF_Val << RTC_TAMPCTRL_IN0ACT_Pos)  /**< (RTC_TAMPCTRL) Off (Disabled) Position  */
+#define RTC_TAMPCTRL_IN0ACT_WAKE            (RTC_TAMPCTRL_IN0ACT_WAKE_Val << RTC_TAMPCTRL_IN0ACT_Pos)  /**< (RTC_TAMPCTRL) Wake and set Tamper flag Position  */
+#define RTC_TAMPCTRL_IN0ACT_CAPTURE         (RTC_TAMPCTRL_IN0ACT_CAPTURE_Val << RTC_TAMPCTRL_IN0ACT_Pos)  /**< (RTC_TAMPCTRL) Capture timestamp and set Tamper flag Position  */
+#define RTC_TAMPCTRL_IN0ACT_ACTL            (RTC_TAMPCTRL_IN0ACT_ACTL_Val << RTC_TAMPCTRL_IN0ACT_Pos)  /**< (RTC_TAMPCTRL) Compare IN0 to OUT. When a mismatch occurs, capture timestamp and set Tamper flag Position  */
+#define RTC_TAMPCTRL_IN1ACT_Pos             2                                              /**< (RTC_TAMPCTRL) Tamper Input 1 Action Position */
+#define RTC_TAMPCTRL_IN1ACT_Msk             (_U_(0x3) << RTC_TAMPCTRL_IN1ACT_Pos)          /**< (RTC_TAMPCTRL) Tamper Input 1 Action Mask */
+#define RTC_TAMPCTRL_IN1ACT(value)          (RTC_TAMPCTRL_IN1ACT_Msk & ((value) << RTC_TAMPCTRL_IN1ACT_Pos))
+#define   RTC_TAMPCTRL_IN1ACT_OFF_Val       _U_(0x0)                                       /**< (RTC_TAMPCTRL) Off (Disabled)  */
+#define   RTC_TAMPCTRL_IN1ACT_WAKE_Val      _U_(0x1)                                       /**< (RTC_TAMPCTRL) Wake and set Tamper flag  */
+#define   RTC_TAMPCTRL_IN1ACT_CAPTURE_Val   _U_(0x2)                                       /**< (RTC_TAMPCTRL) Capture timestamp and set Tamper flag  */
+#define   RTC_TAMPCTRL_IN1ACT_ACTL_Val      _U_(0x3)                                       /**< (RTC_TAMPCTRL) Compare IN1 to OUT. When a mismatch occurs, capture timestamp and set Tamper flag  */
+#define RTC_TAMPCTRL_IN1ACT_OFF             (RTC_TAMPCTRL_IN1ACT_OFF_Val << RTC_TAMPCTRL_IN1ACT_Pos)  /**< (RTC_TAMPCTRL) Off (Disabled) Position  */
+#define RTC_TAMPCTRL_IN1ACT_WAKE            (RTC_TAMPCTRL_IN1ACT_WAKE_Val << RTC_TAMPCTRL_IN1ACT_Pos)  /**< (RTC_TAMPCTRL) Wake and set Tamper flag Position  */
+#define RTC_TAMPCTRL_IN1ACT_CAPTURE         (RTC_TAMPCTRL_IN1ACT_CAPTURE_Val << RTC_TAMPCTRL_IN1ACT_Pos)  /**< (RTC_TAMPCTRL) Capture timestamp and set Tamper flag Position  */
+#define RTC_TAMPCTRL_IN1ACT_ACTL            (RTC_TAMPCTRL_IN1ACT_ACTL_Val << RTC_TAMPCTRL_IN1ACT_Pos)  /**< (RTC_TAMPCTRL) Compare IN1 to OUT. When a mismatch occurs, capture timestamp and set Tamper flag Position  */
+#define RTC_TAMPCTRL_IN2ACT_Pos             4                                              /**< (RTC_TAMPCTRL) Tamper Input 2 Action Position */
+#define RTC_TAMPCTRL_IN2ACT_Msk             (_U_(0x3) << RTC_TAMPCTRL_IN2ACT_Pos)          /**< (RTC_TAMPCTRL) Tamper Input 2 Action Mask */
+#define RTC_TAMPCTRL_IN2ACT(value)          (RTC_TAMPCTRL_IN2ACT_Msk & ((value) << RTC_TAMPCTRL_IN2ACT_Pos))
+#define   RTC_TAMPCTRL_IN2ACT_OFF_Val       _U_(0x0)                                       /**< (RTC_TAMPCTRL) Off (Disabled)  */
+#define   RTC_TAMPCTRL_IN2ACT_WAKE_Val      _U_(0x1)                                       /**< (RTC_TAMPCTRL) Wake and set Tamper flag  */
+#define   RTC_TAMPCTRL_IN2ACT_CAPTURE_Val   _U_(0x2)                                       /**< (RTC_TAMPCTRL) Capture timestamp and set Tamper flag  */
+#define   RTC_TAMPCTRL_IN2ACT_ACTL_Val      _U_(0x3)                                       /**< (RTC_TAMPCTRL) Compare IN2 to OUT. When a mismatch occurs, capture timestamp and set Tamper flag  */
+#define RTC_TAMPCTRL_IN2ACT_OFF             (RTC_TAMPCTRL_IN2ACT_OFF_Val << RTC_TAMPCTRL_IN2ACT_Pos)  /**< (RTC_TAMPCTRL) Off (Disabled) Position  */
+#define RTC_TAMPCTRL_IN2ACT_WAKE            (RTC_TAMPCTRL_IN2ACT_WAKE_Val << RTC_TAMPCTRL_IN2ACT_Pos)  /**< (RTC_TAMPCTRL) Wake and set Tamper flag Position  */
+#define RTC_TAMPCTRL_IN2ACT_CAPTURE         (RTC_TAMPCTRL_IN2ACT_CAPTURE_Val << RTC_TAMPCTRL_IN2ACT_Pos)  /**< (RTC_TAMPCTRL) Capture timestamp and set Tamper flag Position  */
+#define RTC_TAMPCTRL_IN2ACT_ACTL            (RTC_TAMPCTRL_IN2ACT_ACTL_Val << RTC_TAMPCTRL_IN2ACT_Pos)  /**< (RTC_TAMPCTRL) Compare IN2 to OUT. When a mismatch occurs, capture timestamp and set Tamper flag Position  */
+#define RTC_TAMPCTRL_IN3ACT_Pos             6                                              /**< (RTC_TAMPCTRL) Tamper Input 3 Action Position */
+#define RTC_TAMPCTRL_IN3ACT_Msk             (_U_(0x3) << RTC_TAMPCTRL_IN3ACT_Pos)          /**< (RTC_TAMPCTRL) Tamper Input 3 Action Mask */
+#define RTC_TAMPCTRL_IN3ACT(value)          (RTC_TAMPCTRL_IN3ACT_Msk & ((value) << RTC_TAMPCTRL_IN3ACT_Pos))
+#define   RTC_TAMPCTRL_IN3ACT_OFF_Val       _U_(0x0)                                       /**< (RTC_TAMPCTRL) Off (Disabled)  */
+#define   RTC_TAMPCTRL_IN3ACT_WAKE_Val      _U_(0x1)                                       /**< (RTC_TAMPCTRL) Wake and set Tamper flag  */
+#define   RTC_TAMPCTRL_IN3ACT_CAPTURE_Val   _U_(0x2)                                       /**< (RTC_TAMPCTRL) Capture timestamp and set Tamper flag  */
+#define   RTC_TAMPCTRL_IN3ACT_ACTL_Val      _U_(0x3)                                       /**< (RTC_TAMPCTRL) Compare IN3 to OUT. When a mismatch occurs, capture timestamp and set Tamper flag  */
+#define RTC_TAMPCTRL_IN3ACT_OFF             (RTC_TAMPCTRL_IN3ACT_OFF_Val << RTC_TAMPCTRL_IN3ACT_Pos)  /**< (RTC_TAMPCTRL) Off (Disabled) Position  */
+#define RTC_TAMPCTRL_IN3ACT_WAKE            (RTC_TAMPCTRL_IN3ACT_WAKE_Val << RTC_TAMPCTRL_IN3ACT_Pos)  /**< (RTC_TAMPCTRL) Wake and set Tamper flag Position  */
+#define RTC_TAMPCTRL_IN3ACT_CAPTURE         (RTC_TAMPCTRL_IN3ACT_CAPTURE_Val << RTC_TAMPCTRL_IN3ACT_Pos)  /**< (RTC_TAMPCTRL) Capture timestamp and set Tamper flag Position  */
+#define RTC_TAMPCTRL_IN3ACT_ACTL            (RTC_TAMPCTRL_IN3ACT_ACTL_Val << RTC_TAMPCTRL_IN3ACT_Pos)  /**< (RTC_TAMPCTRL) Compare IN3 to OUT. When a mismatch occurs, capture timestamp and set Tamper flag Position  */
+#define RTC_TAMPCTRL_TAMLVL0_Pos            16                                             /**< (RTC_TAMPCTRL) Tamper Level Select 0 Position */
+#define RTC_TAMPCTRL_TAMLVL0_Msk            (_U_(0x1) << RTC_TAMPCTRL_TAMLVL0_Pos)         /**< (RTC_TAMPCTRL) Tamper Level Select 0 Mask */
+#define RTC_TAMPCTRL_TAMLVL0                RTC_TAMPCTRL_TAMLVL0_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_TAMPCTRL_TAMLVL0_Msk instead */
+#define RTC_TAMPCTRL_TAMLVL1_Pos            17                                             /**< (RTC_TAMPCTRL) Tamper Level Select 1 Position */
+#define RTC_TAMPCTRL_TAMLVL1_Msk            (_U_(0x1) << RTC_TAMPCTRL_TAMLVL1_Pos)         /**< (RTC_TAMPCTRL) Tamper Level Select 1 Mask */
+#define RTC_TAMPCTRL_TAMLVL1                RTC_TAMPCTRL_TAMLVL1_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_TAMPCTRL_TAMLVL1_Msk instead */
+#define RTC_TAMPCTRL_TAMLVL2_Pos            18                                             /**< (RTC_TAMPCTRL) Tamper Level Select 2 Position */
+#define RTC_TAMPCTRL_TAMLVL2_Msk            (_U_(0x1) << RTC_TAMPCTRL_TAMLVL2_Pos)         /**< (RTC_TAMPCTRL) Tamper Level Select 2 Mask */
+#define RTC_TAMPCTRL_TAMLVL2                RTC_TAMPCTRL_TAMLVL2_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_TAMPCTRL_TAMLVL2_Msk instead */
+#define RTC_TAMPCTRL_TAMLVL3_Pos            19                                             /**< (RTC_TAMPCTRL) Tamper Level Select 3 Position */
+#define RTC_TAMPCTRL_TAMLVL3_Msk            (_U_(0x1) << RTC_TAMPCTRL_TAMLVL3_Pos)         /**< (RTC_TAMPCTRL) Tamper Level Select 3 Mask */
+#define RTC_TAMPCTRL_TAMLVL3                RTC_TAMPCTRL_TAMLVL3_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_TAMPCTRL_TAMLVL3_Msk instead */
+#define RTC_TAMPCTRL_DEBNC0_Pos             24                                             /**< (RTC_TAMPCTRL) Debouncer Enable 0 Position */
+#define RTC_TAMPCTRL_DEBNC0_Msk             (_U_(0x1) << RTC_TAMPCTRL_DEBNC0_Pos)          /**< (RTC_TAMPCTRL) Debouncer Enable 0 Mask */
+#define RTC_TAMPCTRL_DEBNC0                 RTC_TAMPCTRL_DEBNC0_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_TAMPCTRL_DEBNC0_Msk instead */
+#define RTC_TAMPCTRL_DEBNC1_Pos             25                                             /**< (RTC_TAMPCTRL) Debouncer Enable 1 Position */
+#define RTC_TAMPCTRL_DEBNC1_Msk             (_U_(0x1) << RTC_TAMPCTRL_DEBNC1_Pos)          /**< (RTC_TAMPCTRL) Debouncer Enable 1 Mask */
+#define RTC_TAMPCTRL_DEBNC1                 RTC_TAMPCTRL_DEBNC1_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_TAMPCTRL_DEBNC1_Msk instead */
+#define RTC_TAMPCTRL_DEBNC2_Pos             26                                             /**< (RTC_TAMPCTRL) Debouncer Enable 2 Position */
+#define RTC_TAMPCTRL_DEBNC2_Msk             (_U_(0x1) << RTC_TAMPCTRL_DEBNC2_Pos)          /**< (RTC_TAMPCTRL) Debouncer Enable 2 Mask */
+#define RTC_TAMPCTRL_DEBNC2                 RTC_TAMPCTRL_DEBNC2_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_TAMPCTRL_DEBNC2_Msk instead */
+#define RTC_TAMPCTRL_DEBNC3_Pos             27                                             /**< (RTC_TAMPCTRL) Debouncer Enable 3 Position */
+#define RTC_TAMPCTRL_DEBNC3_Msk             (_U_(0x1) << RTC_TAMPCTRL_DEBNC3_Pos)          /**< (RTC_TAMPCTRL) Debouncer Enable 3 Mask */
+#define RTC_TAMPCTRL_DEBNC3                 RTC_TAMPCTRL_DEBNC3_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_TAMPCTRL_DEBNC3_Msk instead */
+#define RTC_TAMPCTRL_MASK                   _U_(0xF0F00FF)                                 /**< \deprecated (RTC_TAMPCTRL) Register MASK  (Use RTC_TAMPCTRL_Msk instead)  */
+#define RTC_TAMPCTRL_Msk                    _U_(0xF0F00FF)                                 /**< (RTC_TAMPCTRL) Register Mask  */
+
+#define RTC_TAMPCTRL_TAMLVL_Pos             16                                             /**< (RTC_TAMPCTRL Position) Tamper Level Select x */
+#define RTC_TAMPCTRL_TAMLVL_Msk             (_U_(0xF) << RTC_TAMPCTRL_TAMLVL_Pos)          /**< (RTC_TAMPCTRL Mask) TAMLVL */
+#define RTC_TAMPCTRL_TAMLVL(value)          (RTC_TAMPCTRL_TAMLVL_Msk & ((value) << RTC_TAMPCTRL_TAMLVL_Pos))  
+#define RTC_TAMPCTRL_DEBNC_Pos              24                                             /**< (RTC_TAMPCTRL Position) Debouncer Enable 3 */
+#define RTC_TAMPCTRL_DEBNC_Msk              (_U_(0xF) << RTC_TAMPCTRL_DEBNC_Pos)           /**< (RTC_TAMPCTRL Mask) DEBNC */
+#define RTC_TAMPCTRL_DEBNC(value)           (RTC_TAMPCTRL_DEBNC_Msk & ((value) << RTC_TAMPCTRL_DEBNC_Pos))  
+
+/* -------- RTC_MODE0_TIMESTAMP : (RTC Offset: 0x64) (R/ 32) MODE0 Timestamp -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t COUNT:32;                  /**< bit:  0..31  Count Timestamp Value                    */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_MODE0_TIMESTAMP_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE0_TIMESTAMP_OFFSET          (0x64)                                        /**<  (RTC_MODE0_TIMESTAMP) MODE0 Timestamp  Offset */
+#define RTC_MODE0_TIMESTAMP_RESETVALUE      _U_(0x00)                                     /**<  (RTC_MODE0_TIMESTAMP) MODE0 Timestamp  Reset Value */
+
+#define RTC_MODE0_TIMESTAMP_COUNT_Pos       0                                              /**< (RTC_MODE0_TIMESTAMP) Count Timestamp Value Position */
+#define RTC_MODE0_TIMESTAMP_COUNT_Msk       (_U_(0xFFFFFFFF) << RTC_MODE0_TIMESTAMP_COUNT_Pos)  /**< (RTC_MODE0_TIMESTAMP) Count Timestamp Value Mask */
+#define RTC_MODE0_TIMESTAMP_COUNT(value)    (RTC_MODE0_TIMESTAMP_COUNT_Msk & ((value) << RTC_MODE0_TIMESTAMP_COUNT_Pos))
+#define RTC_MODE0_TIMESTAMP_MASK            _U_(0xFFFFFFFF)                                /**< \deprecated (RTC_MODE0_TIMESTAMP) Register MASK  (Use RTC_MODE0_TIMESTAMP_Msk instead)  */
+#define RTC_MODE0_TIMESTAMP_Msk             _U_(0xFFFFFFFF)                                /**< (RTC_MODE0_TIMESTAMP) Register Mask  */
+
+
+/* -------- RTC_MODE1_TIMESTAMP : (RTC Offset: 0x64) (R/ 32) MODE1 Timestamp -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t COUNT:16;                  /**< bit:  0..15  Count Timestamp Value                    */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_MODE1_TIMESTAMP_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE1_TIMESTAMP_OFFSET          (0x64)                                        /**<  (RTC_MODE1_TIMESTAMP) MODE1 Timestamp  Offset */
+#define RTC_MODE1_TIMESTAMP_RESETVALUE      _U_(0x00)                                     /**<  (RTC_MODE1_TIMESTAMP) MODE1 Timestamp  Reset Value */
+
+#define RTC_MODE1_TIMESTAMP_COUNT_Pos       0                                              /**< (RTC_MODE1_TIMESTAMP) Count Timestamp Value Position */
+#define RTC_MODE1_TIMESTAMP_COUNT_Msk       (_U_(0xFFFF) << RTC_MODE1_TIMESTAMP_COUNT_Pos)  /**< (RTC_MODE1_TIMESTAMP) Count Timestamp Value Mask */
+#define RTC_MODE1_TIMESTAMP_COUNT(value)    (RTC_MODE1_TIMESTAMP_COUNT_Msk & ((value) << RTC_MODE1_TIMESTAMP_COUNT_Pos))
+#define RTC_MODE1_TIMESTAMP_MASK            _U_(0xFFFF)                                    /**< \deprecated (RTC_MODE1_TIMESTAMP) Register MASK  (Use RTC_MODE1_TIMESTAMP_Msk instead)  */
+#define RTC_MODE1_TIMESTAMP_Msk             _U_(0xFFFF)                                    /**< (RTC_MODE1_TIMESTAMP) Register Mask  */
+
+
+/* -------- RTC_MODE2_TIMESTAMP : (RTC Offset: 0x64) (R/ 32) MODE2 Timestamp -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SECOND:6;                  /**< bit:   0..5  Second Timestamp Value                   */
+    uint32_t MINUTE:6;                  /**< bit:  6..11  Minute Timestamp Value                   */
+    uint32_t HOUR:5;                    /**< bit: 12..16  Hour Timestamp Value                     */
+    uint32_t DAY:5;                     /**< bit: 17..21  Day Timestamp Value                      */
+    uint32_t MONTH:4;                   /**< bit: 22..25  Month Timestamp Value                    */
+    uint32_t YEAR:6;                    /**< bit: 26..31  Year Timestamp Value                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_MODE2_TIMESTAMP_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE2_TIMESTAMP_OFFSET          (0x64)                                        /**<  (RTC_MODE2_TIMESTAMP) MODE2 Timestamp  Offset */
+#define RTC_MODE2_TIMESTAMP_RESETVALUE      _U_(0x00)                                     /**<  (RTC_MODE2_TIMESTAMP) MODE2 Timestamp  Reset Value */
+
+#define RTC_MODE2_TIMESTAMP_SECOND_Pos      0                                              /**< (RTC_MODE2_TIMESTAMP) Second Timestamp Value Position */
+#define RTC_MODE2_TIMESTAMP_SECOND_Msk      (_U_(0x3F) << RTC_MODE2_TIMESTAMP_SECOND_Pos)  /**< (RTC_MODE2_TIMESTAMP) Second Timestamp Value Mask */
+#define RTC_MODE2_TIMESTAMP_SECOND(value)   (RTC_MODE2_TIMESTAMP_SECOND_Msk & ((value) << RTC_MODE2_TIMESTAMP_SECOND_Pos))
+#define RTC_MODE2_TIMESTAMP_MINUTE_Pos      6                                              /**< (RTC_MODE2_TIMESTAMP) Minute Timestamp Value Position */
+#define RTC_MODE2_TIMESTAMP_MINUTE_Msk      (_U_(0x3F) << RTC_MODE2_TIMESTAMP_MINUTE_Pos)  /**< (RTC_MODE2_TIMESTAMP) Minute Timestamp Value Mask */
+#define RTC_MODE2_TIMESTAMP_MINUTE(value)   (RTC_MODE2_TIMESTAMP_MINUTE_Msk & ((value) << RTC_MODE2_TIMESTAMP_MINUTE_Pos))
+#define RTC_MODE2_TIMESTAMP_HOUR_Pos        12                                             /**< (RTC_MODE2_TIMESTAMP) Hour Timestamp Value Position */
+#define RTC_MODE2_TIMESTAMP_HOUR_Msk        (_U_(0x1F) << RTC_MODE2_TIMESTAMP_HOUR_Pos)    /**< (RTC_MODE2_TIMESTAMP) Hour Timestamp Value Mask */
+#define RTC_MODE2_TIMESTAMP_HOUR(value)     (RTC_MODE2_TIMESTAMP_HOUR_Msk & ((value) << RTC_MODE2_TIMESTAMP_HOUR_Pos))
+#define RTC_MODE2_TIMESTAMP_DAY_Pos         17                                             /**< (RTC_MODE2_TIMESTAMP) Day Timestamp Value Position */
+#define RTC_MODE2_TIMESTAMP_DAY_Msk         (_U_(0x1F) << RTC_MODE2_TIMESTAMP_DAY_Pos)     /**< (RTC_MODE2_TIMESTAMP) Day Timestamp Value Mask */
+#define RTC_MODE2_TIMESTAMP_DAY(value)      (RTC_MODE2_TIMESTAMP_DAY_Msk & ((value) << RTC_MODE2_TIMESTAMP_DAY_Pos))
+#define RTC_MODE2_TIMESTAMP_MONTH_Pos       22                                             /**< (RTC_MODE2_TIMESTAMP) Month Timestamp Value Position */
+#define RTC_MODE2_TIMESTAMP_MONTH_Msk       (_U_(0xF) << RTC_MODE2_TIMESTAMP_MONTH_Pos)    /**< (RTC_MODE2_TIMESTAMP) Month Timestamp Value Mask */
+#define RTC_MODE2_TIMESTAMP_MONTH(value)    (RTC_MODE2_TIMESTAMP_MONTH_Msk & ((value) << RTC_MODE2_TIMESTAMP_MONTH_Pos))
+#define RTC_MODE2_TIMESTAMP_YEAR_Pos        26                                             /**< (RTC_MODE2_TIMESTAMP) Year Timestamp Value Position */
+#define RTC_MODE2_TIMESTAMP_YEAR_Msk        (_U_(0x3F) << RTC_MODE2_TIMESTAMP_YEAR_Pos)    /**< (RTC_MODE2_TIMESTAMP) Year Timestamp Value Mask */
+#define RTC_MODE2_TIMESTAMP_YEAR(value)     (RTC_MODE2_TIMESTAMP_YEAR_Msk & ((value) << RTC_MODE2_TIMESTAMP_YEAR_Pos))
+#define RTC_MODE2_TIMESTAMP_MASK            _U_(0xFFFFFFFF)                                /**< \deprecated (RTC_MODE2_TIMESTAMP) Register MASK  (Use RTC_MODE2_TIMESTAMP_Msk instead)  */
+#define RTC_MODE2_TIMESTAMP_Msk             _U_(0xFFFFFFFF)                                /**< (RTC_MODE2_TIMESTAMP) Register Mask  */
+
+
+/* -------- RTC_TAMPID : (RTC Offset: 0x68) (R/W 32) Tamper ID -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t TAMPID0:1;                 /**< bit:      0  Tamper Input 0 Detected                  */
+    uint32_t TAMPID1:1;                 /**< bit:      1  Tamper Input 1 Detected                  */
+    uint32_t TAMPID2:1;                 /**< bit:      2  Tamper Input 2 Detected                  */
+    uint32_t TAMPID3:1;                 /**< bit:      3  Tamper Input 3 Detected                  */
+    uint32_t :27;                       /**< bit:  4..30  Reserved */
+    uint32_t TAMPEVT:1;                 /**< bit:     31  Tamper Event Detected                    */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t TAMPID:4;                  /**< bit:   0..3  Tamper Input x Detected                  */
+    uint32_t :28;                       /**< bit:  4..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_TAMPID_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_TAMPID_OFFSET                   (0x68)                                        /**<  (RTC_TAMPID) Tamper ID  Offset */
+#define RTC_TAMPID_RESETVALUE               _U_(0x00)                                     /**<  (RTC_TAMPID) Tamper ID  Reset Value */
+
+#define RTC_TAMPID_TAMPID0_Pos              0                                              /**< (RTC_TAMPID) Tamper Input 0 Detected Position */
+#define RTC_TAMPID_TAMPID0_Msk              (_U_(0x1) << RTC_TAMPID_TAMPID0_Pos)           /**< (RTC_TAMPID) Tamper Input 0 Detected Mask */
+#define RTC_TAMPID_TAMPID0                  RTC_TAMPID_TAMPID0_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_TAMPID_TAMPID0_Msk instead */
+#define RTC_TAMPID_TAMPID1_Pos              1                                              /**< (RTC_TAMPID) Tamper Input 1 Detected Position */
+#define RTC_TAMPID_TAMPID1_Msk              (_U_(0x1) << RTC_TAMPID_TAMPID1_Pos)           /**< (RTC_TAMPID) Tamper Input 1 Detected Mask */
+#define RTC_TAMPID_TAMPID1                  RTC_TAMPID_TAMPID1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_TAMPID_TAMPID1_Msk instead */
+#define RTC_TAMPID_TAMPID2_Pos              2                                              /**< (RTC_TAMPID) Tamper Input 2 Detected Position */
+#define RTC_TAMPID_TAMPID2_Msk              (_U_(0x1) << RTC_TAMPID_TAMPID2_Pos)           /**< (RTC_TAMPID) Tamper Input 2 Detected Mask */
+#define RTC_TAMPID_TAMPID2                  RTC_TAMPID_TAMPID2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_TAMPID_TAMPID2_Msk instead */
+#define RTC_TAMPID_TAMPID3_Pos              3                                              /**< (RTC_TAMPID) Tamper Input 3 Detected Position */
+#define RTC_TAMPID_TAMPID3_Msk              (_U_(0x1) << RTC_TAMPID_TAMPID3_Pos)           /**< (RTC_TAMPID) Tamper Input 3 Detected Mask */
+#define RTC_TAMPID_TAMPID3                  RTC_TAMPID_TAMPID3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_TAMPID_TAMPID3_Msk instead */
+#define RTC_TAMPID_TAMPEVT_Pos              31                                             /**< (RTC_TAMPID) Tamper Event Detected Position */
+#define RTC_TAMPID_TAMPEVT_Msk              (_U_(0x1) << RTC_TAMPID_TAMPEVT_Pos)           /**< (RTC_TAMPID) Tamper Event Detected Mask */
+#define RTC_TAMPID_TAMPEVT                  RTC_TAMPID_TAMPEVT_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_TAMPID_TAMPEVT_Msk instead */
+#define RTC_TAMPID_MASK                     _U_(0x8000000F)                                /**< \deprecated (RTC_TAMPID) Register MASK  (Use RTC_TAMPID_Msk instead)  */
+#define RTC_TAMPID_Msk                      _U_(0x8000000F)                                /**< (RTC_TAMPID) Register Mask  */
+
+#define RTC_TAMPID_TAMPID_Pos               0                                              /**< (RTC_TAMPID Position) Tamper Input x Detected */
+#define RTC_TAMPID_TAMPID_Msk               (_U_(0xF) << RTC_TAMPID_TAMPID_Pos)            /**< (RTC_TAMPID Mask) TAMPID */
+#define RTC_TAMPID_TAMPID(value)            (RTC_TAMPID_TAMPID_Msk & ((value) << RTC_TAMPID_TAMPID_Pos))  
+
+/* -------- RTC_TAMPCTRLB : (RTC Offset: 0x6c) (R/W 32) Tamper Control B -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t ALSI0:1;                   /**< bit:      0  Active Layer Select Internal 0           */
+    uint32_t ALSI1:1;                   /**< bit:      1  Active Layer Select Internal 1           */
+    uint32_t ALSI2:1;                   /**< bit:      2  Active Layer Select Internal 2           */
+    uint32_t ALSI3:1;                   /**< bit:      3  Active Layer Select Internal 3           */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t ALSI:4;                    /**< bit:   0..3  Active Layer Select Internal 3           */
+    uint32_t :28;                       /**< bit:  4..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_TAMPCTRLB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_TAMPCTRLB_OFFSET                (0x6C)                                        /**<  (RTC_TAMPCTRLB) Tamper Control B  Offset */
+#define RTC_TAMPCTRLB_RESETVALUE            _U_(0x00)                                     /**<  (RTC_TAMPCTRLB) Tamper Control B  Reset Value */
+
+#define RTC_TAMPCTRLB_ALSI0_Pos             0                                              /**< (RTC_TAMPCTRLB) Active Layer Select Internal 0 Position */
+#define RTC_TAMPCTRLB_ALSI0_Msk             (_U_(0x1) << RTC_TAMPCTRLB_ALSI0_Pos)          /**< (RTC_TAMPCTRLB) Active Layer Select Internal 0 Mask */
+#define RTC_TAMPCTRLB_ALSI0                 RTC_TAMPCTRLB_ALSI0_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_TAMPCTRLB_ALSI0_Msk instead */
+#define RTC_TAMPCTRLB_ALSI1_Pos             1                                              /**< (RTC_TAMPCTRLB) Active Layer Select Internal 1 Position */
+#define RTC_TAMPCTRLB_ALSI1_Msk             (_U_(0x1) << RTC_TAMPCTRLB_ALSI1_Pos)          /**< (RTC_TAMPCTRLB) Active Layer Select Internal 1 Mask */
+#define RTC_TAMPCTRLB_ALSI1                 RTC_TAMPCTRLB_ALSI1_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_TAMPCTRLB_ALSI1_Msk instead */
+#define RTC_TAMPCTRLB_ALSI2_Pos             2                                              /**< (RTC_TAMPCTRLB) Active Layer Select Internal 2 Position */
+#define RTC_TAMPCTRLB_ALSI2_Msk             (_U_(0x1) << RTC_TAMPCTRLB_ALSI2_Pos)          /**< (RTC_TAMPCTRLB) Active Layer Select Internal 2 Mask */
+#define RTC_TAMPCTRLB_ALSI2                 RTC_TAMPCTRLB_ALSI2_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_TAMPCTRLB_ALSI2_Msk instead */
+#define RTC_TAMPCTRLB_ALSI3_Pos             3                                              /**< (RTC_TAMPCTRLB) Active Layer Select Internal 3 Position */
+#define RTC_TAMPCTRLB_ALSI3_Msk             (_U_(0x1) << RTC_TAMPCTRLB_ALSI3_Pos)          /**< (RTC_TAMPCTRLB) Active Layer Select Internal 3 Mask */
+#define RTC_TAMPCTRLB_ALSI3                 RTC_TAMPCTRLB_ALSI3_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_TAMPCTRLB_ALSI3_Msk instead */
+#define RTC_TAMPCTRLB_MASK                  _U_(0x0F)                                      /**< \deprecated (RTC_TAMPCTRLB) Register MASK  (Use RTC_TAMPCTRLB_Msk instead)  */
+#define RTC_TAMPCTRLB_Msk                   _U_(0x0F)                                      /**< (RTC_TAMPCTRLB) Register Mask  */
+
+#define RTC_TAMPCTRLB_ALSI_Pos              0                                              /**< (RTC_TAMPCTRLB Position) Active Layer Select Internal 3 */
+#define RTC_TAMPCTRLB_ALSI_Msk              (_U_(0xF) << RTC_TAMPCTRLB_ALSI_Pos)           /**< (RTC_TAMPCTRLB Mask) ALSI */
+#define RTC_TAMPCTRLB_ALSI(value)           (RTC_TAMPCTRLB_ALSI_Msk & ((value) << RTC_TAMPCTRLB_ALSI_Pos))  
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief MODE2_ALARM hardware registers */
+typedef struct {  
+  __IO RTC_MODE2_ALARM_Type           ALARM;          /**< Offset: 0x00 (R/W  32) MODE2_ALARM Alarm n Value */
+  __IO RTC_MODE2_MASK_Type            MASK;           /**< Offset: 0x04 (R/W   8) MODE2_ALARM Alarm n Mask */
+  __I  uint8_t                        Reserved1[3];
+} RtcMode2Alarm;
+
+/** \brief RTC hardware registers */
+typedef struct {  /* Real-Time Counter */
+  __IO RTC_MODE0_CTRLA_Type           CTRLA;          /**< Offset: 0x00 (R/W  16) MODE0 Control A */
+  __IO RTC_MODE0_CTRLB_Type           CTRLB;          /**< Offset: 0x02 (R/W  16) MODE0 Control B */
+  __IO RTC_MODE0_EVCTRL_Type          EVCTRL;         /**< Offset: 0x04 (R/W  32) MODE0 Event Control */
+  __IO RTC_MODE0_INTENCLR_Type        INTENCLR;       /**< Offset: 0x08 (R/W  16) MODE0 Interrupt Enable Clear */
+  __IO RTC_MODE0_INTENSET_Type        INTENSET;       /**< Offset: 0x0A (R/W  16) MODE0 Interrupt Enable Set */
+  __IO RTC_MODE0_INTFLAG_Type         INTFLAG;        /**< Offset: 0x0C (R/W  16) MODE0 Interrupt Flag Status and Clear */
+  __IO RTC_DBGCTRL_Type               DBGCTRL;        /**< Offset: 0x0E (R/W   8) Debug Control */
+  __I  uint8_t                        Reserved1[1];
+  __I  RTC_MODE0_SYNCBUSY_Type        SYNCBUSY;       /**< Offset: 0x10 (R/   32) MODE0 Synchronization Busy Status */
+  __IO RTC_FREQCORR_Type              FREQCORR;       /**< Offset: 0x14 (R/W   8) Frequency Correction */
+  __I  uint8_t                        Reserved2[3];
+  __IO RTC_MODE0_COUNT_Type           COUNT;          /**< Offset: 0x18 (R/W  32) MODE0 Counter Value */
+  __I  uint8_t                        Reserved3[4];
+  __IO RTC_MODE0_COMP_Type            COMP[1];        /**< Offset: 0x20 (R/W  32) MODE0 Compare n Value */
+  __I  uint8_t                        Reserved4[28];
+  __IO RTC_GP_Type                    GP[2];          /**< Offset: 0x40 (R/W  32) General Purpose */
+  __I  uint8_t                        Reserved5[24];
+  __IO RTC_TAMPCTRL_Type              TAMPCTRL;       /**< Offset: 0x60 (R/W  32) Tamper Control */
+  __I  RTC_MODE0_TIMESTAMP_Type       TIMESTAMP;      /**< Offset: 0x64 (R/   32) MODE0 Timestamp */
+  __IO RTC_TAMPID_Type                TAMPID;         /**< Offset: 0x68 (R/W  32) Tamper ID */
+  __IO RTC_TAMPCTRLB_Type             TAMPCTRLB;      /**< Offset: 0x6C (R/W  32) Tamper Control B */
+} RtcMode0;
+
+/** \brief RTC hardware registers */
+typedef struct {  /* Real-Time Counter */
+  __IO RTC_MODE1_CTRLA_Type           CTRLA;          /**< Offset: 0x00 (R/W  16) MODE1 Control A */
+  __IO RTC_MODE1_CTRLB_Type           CTRLB;          /**< Offset: 0x02 (R/W  16) MODE1 Control B */
+  __IO RTC_MODE1_EVCTRL_Type          EVCTRL;         /**< Offset: 0x04 (R/W  32) MODE1 Event Control */
+  __IO RTC_MODE1_INTENCLR_Type        INTENCLR;       /**< Offset: 0x08 (R/W  16) MODE1 Interrupt Enable Clear */
+  __IO RTC_MODE1_INTENSET_Type        INTENSET;       /**< Offset: 0x0A (R/W  16) MODE1 Interrupt Enable Set */
+  __IO RTC_MODE1_INTFLAG_Type         INTFLAG;        /**< Offset: 0x0C (R/W  16) MODE1 Interrupt Flag Status and Clear */
+  __IO RTC_DBGCTRL_Type               DBGCTRL;        /**< Offset: 0x0E (R/W   8) Debug Control */
+  __I  uint8_t                        Reserved1[1];
+  __I  RTC_MODE1_SYNCBUSY_Type        SYNCBUSY;       /**< Offset: 0x10 (R/   32) MODE1 Synchronization Busy Status */
+  __IO RTC_FREQCORR_Type              FREQCORR;       /**< Offset: 0x14 (R/W   8) Frequency Correction */
+  __I  uint8_t                        Reserved2[3];
+  __IO RTC_MODE1_COUNT_Type           COUNT;          /**< Offset: 0x18 (R/W  16) MODE1 Counter Value */
+  __I  uint8_t                        Reserved3[2];
+  __IO RTC_MODE1_PER_Type             PER;            /**< Offset: 0x1C (R/W  16) MODE1 Counter Period */
+  __I  uint8_t                        Reserved4[2];
+  __IO RTC_MODE1_COMP_Type            COMP[2];        /**< Offset: 0x20 (R/W  16) MODE1 Compare n Value */
+  __I  uint8_t                        Reserved5[28];
+  __IO RTC_GP_Type                    GP[2];          /**< Offset: 0x40 (R/W  32) General Purpose */
+  __I  uint8_t                        Reserved6[24];
+  __IO RTC_TAMPCTRL_Type              TAMPCTRL;       /**< Offset: 0x60 (R/W  32) Tamper Control */
+  __I  RTC_MODE1_TIMESTAMP_Type       TIMESTAMP;      /**< Offset: 0x64 (R/   32) MODE1 Timestamp */
+  __IO RTC_TAMPID_Type                TAMPID;         /**< Offset: 0x68 (R/W  32) Tamper ID */
+  __IO RTC_TAMPCTRLB_Type             TAMPCTRLB;      /**< Offset: 0x6C (R/W  32) Tamper Control B */
+} RtcMode1;
+
+/** \brief RTC hardware registers */
+typedef struct {  /* Real-Time Counter */
+  __IO RTC_MODE2_CTRLA_Type           CTRLA;          /**< Offset: 0x00 (R/W  16) MODE2 Control A */
+  __IO RTC_MODE2_CTRLB_Type           CTRLB;          /**< Offset: 0x02 (R/W  16) MODE2 Control B */
+  __IO RTC_MODE2_EVCTRL_Type          EVCTRL;         /**< Offset: 0x04 (R/W  32) MODE2 Event Control */
+  __IO RTC_MODE2_INTENCLR_Type        INTENCLR;       /**< Offset: 0x08 (R/W  16) MODE2 Interrupt Enable Clear */
+  __IO RTC_MODE2_INTENSET_Type        INTENSET;       /**< Offset: 0x0A (R/W  16) MODE2 Interrupt Enable Set */
+  __IO RTC_MODE2_INTFLAG_Type         INTFLAG;        /**< Offset: 0x0C (R/W  16) MODE2 Interrupt Flag Status and Clear */
+  __IO RTC_DBGCTRL_Type               DBGCTRL;        /**< Offset: 0x0E (R/W   8) Debug Control */
+  __I  uint8_t                        Reserved1[1];
+  __I  RTC_MODE2_SYNCBUSY_Type        SYNCBUSY;       /**< Offset: 0x10 (R/   32) MODE2 Synchronization Busy Status */
+  __IO RTC_FREQCORR_Type              FREQCORR;       /**< Offset: 0x14 (R/W   8) Frequency Correction */
+  __I  uint8_t                        Reserved2[3];
+  __IO RTC_MODE2_CLOCK_Type           CLOCK;          /**< Offset: 0x18 (R/W  32) MODE2 Clock Value */
+  __I  uint8_t                        Reserved3[4];
+       RtcMode2Alarm                  Mode2Alarm[1];  /**< Offset: 0x20  */
+  __I  uint8_t                        Reserved4[24];
+  __IO RTC_GP_Type                    GP[2];          /**< Offset: 0x40 (R/W  32) General Purpose */
+  __I  uint8_t                        Reserved5[24];
+  __IO RTC_TAMPCTRL_Type              TAMPCTRL;       /**< Offset: 0x60 (R/W  32) Tamper Control */
+  __I  RTC_MODE2_TIMESTAMP_Type       TIMESTAMP;      /**< Offset: 0x64 (R/   32) MODE2 Timestamp */
+  __IO RTC_TAMPID_Type                TAMPID;         /**< Offset: 0x68 (R/W  32) Tamper ID */
+  __IO RTC_TAMPCTRLB_Type             TAMPCTRLB;      /**< Offset: 0x6C (R/W  32) Tamper Control B */
+} RtcMode2;
+
+/** \brief RTC hardware registers */
+typedef union {  /* Real-Time Counter */
+       RtcMode0                       MODE0;          /**< 32-bit Counter with Single 32-bit Compare */
+       RtcMode1                       MODE1;          /**< 16-bit Counter with Two 16-bit Compares */
+       RtcMode2                       MODE2;          /**< Clock/Calendar with Alarm */
+} Rtc;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Real-Time Counter */
+
+#endif /* _SAML11_RTC_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/component/sercom.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/sercom.h
@@ -1,0 +1,1759 @@
+/**
+ * \file
+ *
+ * \brief Component description for SERCOM
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_SERCOM_COMPONENT_H_
+#define _SAML11_SERCOM_COMPONENT_H_
+#define _SAML11_SERCOM_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML11 Serial Communication Interface
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR SERCOM */
+/* ========================================================================== */
+
+#define SERCOM_U2201                      /**< (SERCOM) Module ID */
+#define REV_SERCOM 0x410                  /**< (SERCOM) Module revision */
+
+/* -------- SERCOM_I2CM_CTRLA : (SERCOM Offset: 0x00) (R/W 32) I2CM Control A -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint32_t ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint32_t MODE:3;                    /**< bit:   2..4  Operating Mode                           */
+    uint32_t :2;                        /**< bit:   5..6  Reserved */
+    uint32_t RUNSTDBY:1;                /**< bit:      7  Run in Standby                           */
+    uint32_t :8;                        /**< bit:  8..15  Reserved */
+    uint32_t PINOUT:1;                  /**< bit:     16  Pin Usage                                */
+    uint32_t :3;                        /**< bit: 17..19  Reserved */
+    uint32_t SDAHOLD:2;                 /**< bit: 20..21  SDA Hold Time                            */
+    uint32_t MEXTTOEN:1;                /**< bit:     22  Master SCL Low Extend Timeout            */
+    uint32_t SEXTTOEN:1;                /**< bit:     23  Slave SCL Low Extend Timeout             */
+    uint32_t SPEED:2;                   /**< bit: 24..25  Transfer Speed                           */
+    uint32_t :1;                        /**< bit:     26  Reserved */
+    uint32_t SCLSM:1;                   /**< bit:     27  SCL Clock Stretch Mode                   */
+    uint32_t INACTOUT:2;                /**< bit: 28..29  Inactive Time-Out                        */
+    uint32_t LOWTOUTEN:1;               /**< bit:     30  SCL Low Timeout Enable                   */
+    uint32_t :1;                        /**< bit:     31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SERCOM_I2CM_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_CTRLA_OFFSET            (0x00)                                        /**<  (SERCOM_I2CM_CTRLA) I2CM Control A  Offset */
+#define SERCOM_I2CM_CTRLA_RESETVALUE        _U_(0x00)                                     /**<  (SERCOM_I2CM_CTRLA) I2CM Control A  Reset Value */
+
+#define SERCOM_I2CM_CTRLA_SWRST_Pos         0                                              /**< (SERCOM_I2CM_CTRLA) Software Reset Position */
+#define SERCOM_I2CM_CTRLA_SWRST_Msk         (_U_(0x1) << SERCOM_I2CM_CTRLA_SWRST_Pos)      /**< (SERCOM_I2CM_CTRLA) Software Reset Mask */
+#define SERCOM_I2CM_CTRLA_SWRST             SERCOM_I2CM_CTRLA_SWRST_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_CTRLA_SWRST_Msk instead */
+#define SERCOM_I2CM_CTRLA_ENABLE_Pos        1                                              /**< (SERCOM_I2CM_CTRLA) Enable Position */
+#define SERCOM_I2CM_CTRLA_ENABLE_Msk        (_U_(0x1) << SERCOM_I2CM_CTRLA_ENABLE_Pos)     /**< (SERCOM_I2CM_CTRLA) Enable Mask */
+#define SERCOM_I2CM_CTRLA_ENABLE            SERCOM_I2CM_CTRLA_ENABLE_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_CTRLA_ENABLE_Msk instead */
+#define SERCOM_I2CM_CTRLA_MODE_Pos          2                                              /**< (SERCOM_I2CM_CTRLA) Operating Mode Position */
+#define SERCOM_I2CM_CTRLA_MODE_Msk          (_U_(0x7) << SERCOM_I2CM_CTRLA_MODE_Pos)       /**< (SERCOM_I2CM_CTRLA) Operating Mode Mask */
+#define SERCOM_I2CM_CTRLA_MODE(value)       (SERCOM_I2CM_CTRLA_MODE_Msk & ((value) << SERCOM_I2CM_CTRLA_MODE_Pos))
+#define SERCOM_I2CM_CTRLA_RUNSTDBY_Pos      7                                              /**< (SERCOM_I2CM_CTRLA) Run in Standby Position */
+#define SERCOM_I2CM_CTRLA_RUNSTDBY_Msk      (_U_(0x1) << SERCOM_I2CM_CTRLA_RUNSTDBY_Pos)   /**< (SERCOM_I2CM_CTRLA) Run in Standby Mask */
+#define SERCOM_I2CM_CTRLA_RUNSTDBY          SERCOM_I2CM_CTRLA_RUNSTDBY_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_CTRLA_RUNSTDBY_Msk instead */
+#define SERCOM_I2CM_CTRLA_PINOUT_Pos        16                                             /**< (SERCOM_I2CM_CTRLA) Pin Usage Position */
+#define SERCOM_I2CM_CTRLA_PINOUT_Msk        (_U_(0x1) << SERCOM_I2CM_CTRLA_PINOUT_Pos)     /**< (SERCOM_I2CM_CTRLA) Pin Usage Mask */
+#define SERCOM_I2CM_CTRLA_PINOUT            SERCOM_I2CM_CTRLA_PINOUT_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_CTRLA_PINOUT_Msk instead */
+#define SERCOM_I2CM_CTRLA_SDAHOLD_Pos       20                                             /**< (SERCOM_I2CM_CTRLA) SDA Hold Time Position */
+#define SERCOM_I2CM_CTRLA_SDAHOLD_Msk       (_U_(0x3) << SERCOM_I2CM_CTRLA_SDAHOLD_Pos)    /**< (SERCOM_I2CM_CTRLA) SDA Hold Time Mask */
+#define SERCOM_I2CM_CTRLA_SDAHOLD(value)    (SERCOM_I2CM_CTRLA_SDAHOLD_Msk & ((value) << SERCOM_I2CM_CTRLA_SDAHOLD_Pos))
+#define SERCOM_I2CM_CTRLA_MEXTTOEN_Pos      22                                             /**< (SERCOM_I2CM_CTRLA) Master SCL Low Extend Timeout Position */
+#define SERCOM_I2CM_CTRLA_MEXTTOEN_Msk      (_U_(0x1) << SERCOM_I2CM_CTRLA_MEXTTOEN_Pos)   /**< (SERCOM_I2CM_CTRLA) Master SCL Low Extend Timeout Mask */
+#define SERCOM_I2CM_CTRLA_MEXTTOEN          SERCOM_I2CM_CTRLA_MEXTTOEN_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_CTRLA_MEXTTOEN_Msk instead */
+#define SERCOM_I2CM_CTRLA_SEXTTOEN_Pos      23                                             /**< (SERCOM_I2CM_CTRLA) Slave SCL Low Extend Timeout Position */
+#define SERCOM_I2CM_CTRLA_SEXTTOEN_Msk      (_U_(0x1) << SERCOM_I2CM_CTRLA_SEXTTOEN_Pos)   /**< (SERCOM_I2CM_CTRLA) Slave SCL Low Extend Timeout Mask */
+#define SERCOM_I2CM_CTRLA_SEXTTOEN          SERCOM_I2CM_CTRLA_SEXTTOEN_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_CTRLA_SEXTTOEN_Msk instead */
+#define SERCOM_I2CM_CTRLA_SPEED_Pos         24                                             /**< (SERCOM_I2CM_CTRLA) Transfer Speed Position */
+#define SERCOM_I2CM_CTRLA_SPEED_Msk         (_U_(0x3) << SERCOM_I2CM_CTRLA_SPEED_Pos)      /**< (SERCOM_I2CM_CTRLA) Transfer Speed Mask */
+#define SERCOM_I2CM_CTRLA_SPEED(value)      (SERCOM_I2CM_CTRLA_SPEED_Msk & ((value) << SERCOM_I2CM_CTRLA_SPEED_Pos))
+#define SERCOM_I2CM_CTRLA_SCLSM_Pos         27                                             /**< (SERCOM_I2CM_CTRLA) SCL Clock Stretch Mode Position */
+#define SERCOM_I2CM_CTRLA_SCLSM_Msk         (_U_(0x1) << SERCOM_I2CM_CTRLA_SCLSM_Pos)      /**< (SERCOM_I2CM_CTRLA) SCL Clock Stretch Mode Mask */
+#define SERCOM_I2CM_CTRLA_SCLSM             SERCOM_I2CM_CTRLA_SCLSM_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_CTRLA_SCLSM_Msk instead */
+#define SERCOM_I2CM_CTRLA_INACTOUT_Pos      28                                             /**< (SERCOM_I2CM_CTRLA) Inactive Time-Out Position */
+#define SERCOM_I2CM_CTRLA_INACTOUT_Msk      (_U_(0x3) << SERCOM_I2CM_CTRLA_INACTOUT_Pos)   /**< (SERCOM_I2CM_CTRLA) Inactive Time-Out Mask */
+#define SERCOM_I2CM_CTRLA_INACTOUT(value)   (SERCOM_I2CM_CTRLA_INACTOUT_Msk & ((value) << SERCOM_I2CM_CTRLA_INACTOUT_Pos))
+#define SERCOM_I2CM_CTRLA_LOWTOUTEN_Pos     30                                             /**< (SERCOM_I2CM_CTRLA) SCL Low Timeout Enable Position */
+#define SERCOM_I2CM_CTRLA_LOWTOUTEN_Msk     (_U_(0x1) << SERCOM_I2CM_CTRLA_LOWTOUTEN_Pos)  /**< (SERCOM_I2CM_CTRLA) SCL Low Timeout Enable Mask */
+#define SERCOM_I2CM_CTRLA_LOWTOUTEN         SERCOM_I2CM_CTRLA_LOWTOUTEN_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_CTRLA_LOWTOUTEN_Msk instead */
+#define SERCOM_I2CM_CTRLA_MASK              _U_(0x7BF1009F)                                /**< \deprecated (SERCOM_I2CM_CTRLA) Register MASK  (Use SERCOM_I2CM_CTRLA_Msk instead)  */
+#define SERCOM_I2CM_CTRLA_Msk               _U_(0x7BF1009F)                                /**< (SERCOM_I2CM_CTRLA) Register Mask  */
+
+
+/* -------- SERCOM_I2CS_CTRLA : (SERCOM Offset: 0x00) (R/W 32) I2CS Control A -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint32_t ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint32_t MODE:3;                    /**< bit:   2..4  Operating Mode                           */
+    uint32_t :2;                        /**< bit:   5..6  Reserved */
+    uint32_t RUNSTDBY:1;                /**< bit:      7  Run during Standby                       */
+    uint32_t :8;                        /**< bit:  8..15  Reserved */
+    uint32_t PINOUT:1;                  /**< bit:     16  Pin Usage                                */
+    uint32_t :3;                        /**< bit: 17..19  Reserved */
+    uint32_t SDAHOLD:2;                 /**< bit: 20..21  SDA Hold Time                            */
+    uint32_t :1;                        /**< bit:     22  Reserved */
+    uint32_t SEXTTOEN:1;                /**< bit:     23  Slave SCL Low Extend Timeout             */
+    uint32_t SPEED:2;                   /**< bit: 24..25  Transfer Speed                           */
+    uint32_t :1;                        /**< bit:     26  Reserved */
+    uint32_t SCLSM:1;                   /**< bit:     27  SCL Clock Stretch Mode                   */
+    uint32_t :2;                        /**< bit: 28..29  Reserved */
+    uint32_t LOWTOUTEN:1;               /**< bit:     30  SCL Low Timeout Enable                   */
+    uint32_t :1;                        /**< bit:     31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SERCOM_I2CS_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CS_CTRLA_OFFSET            (0x00)                                        /**<  (SERCOM_I2CS_CTRLA) I2CS Control A  Offset */
+#define SERCOM_I2CS_CTRLA_RESETVALUE        _U_(0x00)                                     /**<  (SERCOM_I2CS_CTRLA) I2CS Control A  Reset Value */
+
+#define SERCOM_I2CS_CTRLA_SWRST_Pos         0                                              /**< (SERCOM_I2CS_CTRLA) Software Reset Position */
+#define SERCOM_I2CS_CTRLA_SWRST_Msk         (_U_(0x1) << SERCOM_I2CS_CTRLA_SWRST_Pos)      /**< (SERCOM_I2CS_CTRLA) Software Reset Mask */
+#define SERCOM_I2CS_CTRLA_SWRST             SERCOM_I2CS_CTRLA_SWRST_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_CTRLA_SWRST_Msk instead */
+#define SERCOM_I2CS_CTRLA_ENABLE_Pos        1                                              /**< (SERCOM_I2CS_CTRLA) Enable Position */
+#define SERCOM_I2CS_CTRLA_ENABLE_Msk        (_U_(0x1) << SERCOM_I2CS_CTRLA_ENABLE_Pos)     /**< (SERCOM_I2CS_CTRLA) Enable Mask */
+#define SERCOM_I2CS_CTRLA_ENABLE            SERCOM_I2CS_CTRLA_ENABLE_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_CTRLA_ENABLE_Msk instead */
+#define SERCOM_I2CS_CTRLA_MODE_Pos          2                                              /**< (SERCOM_I2CS_CTRLA) Operating Mode Position */
+#define SERCOM_I2CS_CTRLA_MODE_Msk          (_U_(0x7) << SERCOM_I2CS_CTRLA_MODE_Pos)       /**< (SERCOM_I2CS_CTRLA) Operating Mode Mask */
+#define SERCOM_I2CS_CTRLA_MODE(value)       (SERCOM_I2CS_CTRLA_MODE_Msk & ((value) << SERCOM_I2CS_CTRLA_MODE_Pos))
+#define SERCOM_I2CS_CTRLA_RUNSTDBY_Pos      7                                              /**< (SERCOM_I2CS_CTRLA) Run during Standby Position */
+#define SERCOM_I2CS_CTRLA_RUNSTDBY_Msk      (_U_(0x1) << SERCOM_I2CS_CTRLA_RUNSTDBY_Pos)   /**< (SERCOM_I2CS_CTRLA) Run during Standby Mask */
+#define SERCOM_I2CS_CTRLA_RUNSTDBY          SERCOM_I2CS_CTRLA_RUNSTDBY_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_CTRLA_RUNSTDBY_Msk instead */
+#define SERCOM_I2CS_CTRLA_PINOUT_Pos        16                                             /**< (SERCOM_I2CS_CTRLA) Pin Usage Position */
+#define SERCOM_I2CS_CTRLA_PINOUT_Msk        (_U_(0x1) << SERCOM_I2CS_CTRLA_PINOUT_Pos)     /**< (SERCOM_I2CS_CTRLA) Pin Usage Mask */
+#define SERCOM_I2CS_CTRLA_PINOUT            SERCOM_I2CS_CTRLA_PINOUT_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_CTRLA_PINOUT_Msk instead */
+#define SERCOM_I2CS_CTRLA_SDAHOLD_Pos       20                                             /**< (SERCOM_I2CS_CTRLA) SDA Hold Time Position */
+#define SERCOM_I2CS_CTRLA_SDAHOLD_Msk       (_U_(0x3) << SERCOM_I2CS_CTRLA_SDAHOLD_Pos)    /**< (SERCOM_I2CS_CTRLA) SDA Hold Time Mask */
+#define SERCOM_I2CS_CTRLA_SDAHOLD(value)    (SERCOM_I2CS_CTRLA_SDAHOLD_Msk & ((value) << SERCOM_I2CS_CTRLA_SDAHOLD_Pos))
+#define SERCOM_I2CS_CTRLA_SEXTTOEN_Pos      23                                             /**< (SERCOM_I2CS_CTRLA) Slave SCL Low Extend Timeout Position */
+#define SERCOM_I2CS_CTRLA_SEXTTOEN_Msk      (_U_(0x1) << SERCOM_I2CS_CTRLA_SEXTTOEN_Pos)   /**< (SERCOM_I2CS_CTRLA) Slave SCL Low Extend Timeout Mask */
+#define SERCOM_I2CS_CTRLA_SEXTTOEN          SERCOM_I2CS_CTRLA_SEXTTOEN_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_CTRLA_SEXTTOEN_Msk instead */
+#define SERCOM_I2CS_CTRLA_SPEED_Pos         24                                             /**< (SERCOM_I2CS_CTRLA) Transfer Speed Position */
+#define SERCOM_I2CS_CTRLA_SPEED_Msk         (_U_(0x3) << SERCOM_I2CS_CTRLA_SPEED_Pos)      /**< (SERCOM_I2CS_CTRLA) Transfer Speed Mask */
+#define SERCOM_I2CS_CTRLA_SPEED(value)      (SERCOM_I2CS_CTRLA_SPEED_Msk & ((value) << SERCOM_I2CS_CTRLA_SPEED_Pos))
+#define SERCOM_I2CS_CTRLA_SCLSM_Pos         27                                             /**< (SERCOM_I2CS_CTRLA) SCL Clock Stretch Mode Position */
+#define SERCOM_I2CS_CTRLA_SCLSM_Msk         (_U_(0x1) << SERCOM_I2CS_CTRLA_SCLSM_Pos)      /**< (SERCOM_I2CS_CTRLA) SCL Clock Stretch Mode Mask */
+#define SERCOM_I2CS_CTRLA_SCLSM             SERCOM_I2CS_CTRLA_SCLSM_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_CTRLA_SCLSM_Msk instead */
+#define SERCOM_I2CS_CTRLA_LOWTOUTEN_Pos     30                                             /**< (SERCOM_I2CS_CTRLA) SCL Low Timeout Enable Position */
+#define SERCOM_I2CS_CTRLA_LOWTOUTEN_Msk     (_U_(0x1) << SERCOM_I2CS_CTRLA_LOWTOUTEN_Pos)  /**< (SERCOM_I2CS_CTRLA) SCL Low Timeout Enable Mask */
+#define SERCOM_I2CS_CTRLA_LOWTOUTEN         SERCOM_I2CS_CTRLA_LOWTOUTEN_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_CTRLA_LOWTOUTEN_Msk instead */
+#define SERCOM_I2CS_CTRLA_MASK              _U_(0x4BB1009F)                                /**< \deprecated (SERCOM_I2CS_CTRLA) Register MASK  (Use SERCOM_I2CS_CTRLA_Msk instead)  */
+#define SERCOM_I2CS_CTRLA_Msk               _U_(0x4BB1009F)                                /**< (SERCOM_I2CS_CTRLA) Register Mask  */
+
+
+/* -------- SERCOM_SPI_CTRLA : (SERCOM Offset: 0x00) (R/W 32) SPI Control A -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint32_t ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint32_t MODE:3;                    /**< bit:   2..4  Operating Mode                           */
+    uint32_t :2;                        /**< bit:   5..6  Reserved */
+    uint32_t RUNSTDBY:1;                /**< bit:      7  Run during Standby                       */
+    uint32_t IBON:1;                    /**< bit:      8  Immediate Buffer Overflow Notification   */
+    uint32_t :7;                        /**< bit:  9..15  Reserved */
+    uint32_t DOPO:2;                    /**< bit: 16..17  Data Out Pinout                          */
+    uint32_t :2;                        /**< bit: 18..19  Reserved */
+    uint32_t DIPO:2;                    /**< bit: 20..21  Data In Pinout                           */
+    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t FORM:4;                    /**< bit: 24..27  Frame Format                             */
+    uint32_t CPHA:1;                    /**< bit:     28  Clock Phase                              */
+    uint32_t CPOL:1;                    /**< bit:     29  Clock Polarity                           */
+    uint32_t DORD:1;                    /**< bit:     30  Data Order                               */
+    uint32_t :1;                        /**< bit:     31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SERCOM_SPI_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_CTRLA_OFFSET             (0x00)                                        /**<  (SERCOM_SPI_CTRLA) SPI Control A  Offset */
+#define SERCOM_SPI_CTRLA_RESETVALUE         _U_(0x00)                                     /**<  (SERCOM_SPI_CTRLA) SPI Control A  Reset Value */
+
+#define SERCOM_SPI_CTRLA_SWRST_Pos          0                                              /**< (SERCOM_SPI_CTRLA) Software Reset Position */
+#define SERCOM_SPI_CTRLA_SWRST_Msk          (_U_(0x1) << SERCOM_SPI_CTRLA_SWRST_Pos)       /**< (SERCOM_SPI_CTRLA) Software Reset Mask */
+#define SERCOM_SPI_CTRLA_SWRST              SERCOM_SPI_CTRLA_SWRST_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_CTRLA_SWRST_Msk instead */
+#define SERCOM_SPI_CTRLA_ENABLE_Pos         1                                              /**< (SERCOM_SPI_CTRLA) Enable Position */
+#define SERCOM_SPI_CTRLA_ENABLE_Msk         (_U_(0x1) << SERCOM_SPI_CTRLA_ENABLE_Pos)      /**< (SERCOM_SPI_CTRLA) Enable Mask */
+#define SERCOM_SPI_CTRLA_ENABLE             SERCOM_SPI_CTRLA_ENABLE_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_CTRLA_ENABLE_Msk instead */
+#define SERCOM_SPI_CTRLA_MODE_Pos           2                                              /**< (SERCOM_SPI_CTRLA) Operating Mode Position */
+#define SERCOM_SPI_CTRLA_MODE_Msk           (_U_(0x7) << SERCOM_SPI_CTRLA_MODE_Pos)        /**< (SERCOM_SPI_CTRLA) Operating Mode Mask */
+#define SERCOM_SPI_CTRLA_MODE(value)        (SERCOM_SPI_CTRLA_MODE_Msk & ((value) << SERCOM_SPI_CTRLA_MODE_Pos))
+#define SERCOM_SPI_CTRLA_RUNSTDBY_Pos       7                                              /**< (SERCOM_SPI_CTRLA) Run during Standby Position */
+#define SERCOM_SPI_CTRLA_RUNSTDBY_Msk       (_U_(0x1) << SERCOM_SPI_CTRLA_RUNSTDBY_Pos)    /**< (SERCOM_SPI_CTRLA) Run during Standby Mask */
+#define SERCOM_SPI_CTRLA_RUNSTDBY           SERCOM_SPI_CTRLA_RUNSTDBY_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_CTRLA_RUNSTDBY_Msk instead */
+#define SERCOM_SPI_CTRLA_IBON_Pos           8                                              /**< (SERCOM_SPI_CTRLA) Immediate Buffer Overflow Notification Position */
+#define SERCOM_SPI_CTRLA_IBON_Msk           (_U_(0x1) << SERCOM_SPI_CTRLA_IBON_Pos)        /**< (SERCOM_SPI_CTRLA) Immediate Buffer Overflow Notification Mask */
+#define SERCOM_SPI_CTRLA_IBON               SERCOM_SPI_CTRLA_IBON_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_CTRLA_IBON_Msk instead */
+#define SERCOM_SPI_CTRLA_DOPO_Pos           16                                             /**< (SERCOM_SPI_CTRLA) Data Out Pinout Position */
+#define SERCOM_SPI_CTRLA_DOPO_Msk           (_U_(0x3) << SERCOM_SPI_CTRLA_DOPO_Pos)        /**< (SERCOM_SPI_CTRLA) Data Out Pinout Mask */
+#define SERCOM_SPI_CTRLA_DOPO(value)        (SERCOM_SPI_CTRLA_DOPO_Msk & ((value) << SERCOM_SPI_CTRLA_DOPO_Pos))
+#define SERCOM_SPI_CTRLA_DIPO_Pos           20                                             /**< (SERCOM_SPI_CTRLA) Data In Pinout Position */
+#define SERCOM_SPI_CTRLA_DIPO_Msk           (_U_(0x3) << SERCOM_SPI_CTRLA_DIPO_Pos)        /**< (SERCOM_SPI_CTRLA) Data In Pinout Mask */
+#define SERCOM_SPI_CTRLA_DIPO(value)        (SERCOM_SPI_CTRLA_DIPO_Msk & ((value) << SERCOM_SPI_CTRLA_DIPO_Pos))
+#define SERCOM_SPI_CTRLA_FORM_Pos           24                                             /**< (SERCOM_SPI_CTRLA) Frame Format Position */
+#define SERCOM_SPI_CTRLA_FORM_Msk           (_U_(0xF) << SERCOM_SPI_CTRLA_FORM_Pos)        /**< (SERCOM_SPI_CTRLA) Frame Format Mask */
+#define SERCOM_SPI_CTRLA_FORM(value)        (SERCOM_SPI_CTRLA_FORM_Msk & ((value) << SERCOM_SPI_CTRLA_FORM_Pos))
+#define SERCOM_SPI_CTRLA_CPHA_Pos           28                                             /**< (SERCOM_SPI_CTRLA) Clock Phase Position */
+#define SERCOM_SPI_CTRLA_CPHA_Msk           (_U_(0x1) << SERCOM_SPI_CTRLA_CPHA_Pos)        /**< (SERCOM_SPI_CTRLA) Clock Phase Mask */
+#define SERCOM_SPI_CTRLA_CPHA               SERCOM_SPI_CTRLA_CPHA_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_CTRLA_CPHA_Msk instead */
+#define SERCOM_SPI_CTRLA_CPOL_Pos           29                                             /**< (SERCOM_SPI_CTRLA) Clock Polarity Position */
+#define SERCOM_SPI_CTRLA_CPOL_Msk           (_U_(0x1) << SERCOM_SPI_CTRLA_CPOL_Pos)        /**< (SERCOM_SPI_CTRLA) Clock Polarity Mask */
+#define SERCOM_SPI_CTRLA_CPOL               SERCOM_SPI_CTRLA_CPOL_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_CTRLA_CPOL_Msk instead */
+#define SERCOM_SPI_CTRLA_DORD_Pos           30                                             /**< (SERCOM_SPI_CTRLA) Data Order Position */
+#define SERCOM_SPI_CTRLA_DORD_Msk           (_U_(0x1) << SERCOM_SPI_CTRLA_DORD_Pos)        /**< (SERCOM_SPI_CTRLA) Data Order Mask */
+#define SERCOM_SPI_CTRLA_DORD               SERCOM_SPI_CTRLA_DORD_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_CTRLA_DORD_Msk instead */
+#define SERCOM_SPI_CTRLA_MASK               _U_(0x7F33019F)                                /**< \deprecated (SERCOM_SPI_CTRLA) Register MASK  (Use SERCOM_SPI_CTRLA_Msk instead)  */
+#define SERCOM_SPI_CTRLA_Msk                _U_(0x7F33019F)                                /**< (SERCOM_SPI_CTRLA) Register Mask  */
+
+
+/* -------- SERCOM_USART_CTRLA : (SERCOM Offset: 0x00) (R/W 32) USART Control A -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint32_t ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint32_t MODE:3;                    /**< bit:   2..4  Operating Mode                           */
+    uint32_t :2;                        /**< bit:   5..6  Reserved */
+    uint32_t RUNSTDBY:1;                /**< bit:      7  Run during Standby                       */
+    uint32_t IBON:1;                    /**< bit:      8  Immediate Buffer Overflow Notification   */
+    uint32_t TXINV:1;                   /**< bit:      9  Transmit Data Invert                     */
+    uint32_t RXINV:1;                   /**< bit:     10  Receive Data Invert                      */
+    uint32_t :2;                        /**< bit: 11..12  Reserved */
+    uint32_t SAMPR:3;                   /**< bit: 13..15  Sample                                   */
+    uint32_t TXPO:2;                    /**< bit: 16..17  Transmit Data Pinout                     */
+    uint32_t :2;                        /**< bit: 18..19  Reserved */
+    uint32_t RXPO:2;                    /**< bit: 20..21  Receive Data Pinout                      */
+    uint32_t SAMPA:2;                   /**< bit: 22..23  Sample Adjustment                        */
+    uint32_t FORM:4;                    /**< bit: 24..27  Frame Format                             */
+    uint32_t CMODE:1;                   /**< bit:     28  Communication Mode                       */
+    uint32_t CPOL:1;                    /**< bit:     29  Clock Polarity                           */
+    uint32_t DORD:1;                    /**< bit:     30  Data Order                               */
+    uint32_t :1;                        /**< bit:     31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SERCOM_USART_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_CTRLA_OFFSET           (0x00)                                        /**<  (SERCOM_USART_CTRLA) USART Control A  Offset */
+#define SERCOM_USART_CTRLA_RESETVALUE       _U_(0x00)                                     /**<  (SERCOM_USART_CTRLA) USART Control A  Reset Value */
+
+#define SERCOM_USART_CTRLA_SWRST_Pos        0                                              /**< (SERCOM_USART_CTRLA) Software Reset Position */
+#define SERCOM_USART_CTRLA_SWRST_Msk        (_U_(0x1) << SERCOM_USART_CTRLA_SWRST_Pos)     /**< (SERCOM_USART_CTRLA) Software Reset Mask */
+#define SERCOM_USART_CTRLA_SWRST            SERCOM_USART_CTRLA_SWRST_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_CTRLA_SWRST_Msk instead */
+#define SERCOM_USART_CTRLA_ENABLE_Pos       1                                              /**< (SERCOM_USART_CTRLA) Enable Position */
+#define SERCOM_USART_CTRLA_ENABLE_Msk       (_U_(0x1) << SERCOM_USART_CTRLA_ENABLE_Pos)    /**< (SERCOM_USART_CTRLA) Enable Mask */
+#define SERCOM_USART_CTRLA_ENABLE           SERCOM_USART_CTRLA_ENABLE_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_CTRLA_ENABLE_Msk instead */
+#define SERCOM_USART_CTRLA_MODE_Pos         2                                              /**< (SERCOM_USART_CTRLA) Operating Mode Position */
+#define SERCOM_USART_CTRLA_MODE_Msk         (_U_(0x7) << SERCOM_USART_CTRLA_MODE_Pos)      /**< (SERCOM_USART_CTRLA) Operating Mode Mask */
+#define SERCOM_USART_CTRLA_MODE(value)      (SERCOM_USART_CTRLA_MODE_Msk & ((value) << SERCOM_USART_CTRLA_MODE_Pos))
+#define SERCOM_USART_CTRLA_RUNSTDBY_Pos     7                                              /**< (SERCOM_USART_CTRLA) Run during Standby Position */
+#define SERCOM_USART_CTRLA_RUNSTDBY_Msk     (_U_(0x1) << SERCOM_USART_CTRLA_RUNSTDBY_Pos)  /**< (SERCOM_USART_CTRLA) Run during Standby Mask */
+#define SERCOM_USART_CTRLA_RUNSTDBY         SERCOM_USART_CTRLA_RUNSTDBY_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_CTRLA_RUNSTDBY_Msk instead */
+#define SERCOM_USART_CTRLA_IBON_Pos         8                                              /**< (SERCOM_USART_CTRLA) Immediate Buffer Overflow Notification Position */
+#define SERCOM_USART_CTRLA_IBON_Msk         (_U_(0x1) << SERCOM_USART_CTRLA_IBON_Pos)      /**< (SERCOM_USART_CTRLA) Immediate Buffer Overflow Notification Mask */
+#define SERCOM_USART_CTRLA_IBON             SERCOM_USART_CTRLA_IBON_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_CTRLA_IBON_Msk instead */
+#define SERCOM_USART_CTRLA_TXINV_Pos        9                                              /**< (SERCOM_USART_CTRLA) Transmit Data Invert Position */
+#define SERCOM_USART_CTRLA_TXINV_Msk        (_U_(0x1) << SERCOM_USART_CTRLA_TXINV_Pos)     /**< (SERCOM_USART_CTRLA) Transmit Data Invert Mask */
+#define SERCOM_USART_CTRLA_TXINV            SERCOM_USART_CTRLA_TXINV_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_CTRLA_TXINV_Msk instead */
+#define SERCOM_USART_CTRLA_RXINV_Pos        10                                             /**< (SERCOM_USART_CTRLA) Receive Data Invert Position */
+#define SERCOM_USART_CTRLA_RXINV_Msk        (_U_(0x1) << SERCOM_USART_CTRLA_RXINV_Pos)     /**< (SERCOM_USART_CTRLA) Receive Data Invert Mask */
+#define SERCOM_USART_CTRLA_RXINV            SERCOM_USART_CTRLA_RXINV_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_CTRLA_RXINV_Msk instead */
+#define SERCOM_USART_CTRLA_SAMPR_Pos        13                                             /**< (SERCOM_USART_CTRLA) Sample Position */
+#define SERCOM_USART_CTRLA_SAMPR_Msk        (_U_(0x7) << SERCOM_USART_CTRLA_SAMPR_Pos)     /**< (SERCOM_USART_CTRLA) Sample Mask */
+#define SERCOM_USART_CTRLA_SAMPR(value)     (SERCOM_USART_CTRLA_SAMPR_Msk & ((value) << SERCOM_USART_CTRLA_SAMPR_Pos))
+#define SERCOM_USART_CTRLA_TXPO_Pos         16                                             /**< (SERCOM_USART_CTRLA) Transmit Data Pinout Position */
+#define SERCOM_USART_CTRLA_TXPO_Msk         (_U_(0x3) << SERCOM_USART_CTRLA_TXPO_Pos)      /**< (SERCOM_USART_CTRLA) Transmit Data Pinout Mask */
+#define SERCOM_USART_CTRLA_TXPO(value)      (SERCOM_USART_CTRLA_TXPO_Msk & ((value) << SERCOM_USART_CTRLA_TXPO_Pos))
+#define SERCOM_USART_CTRLA_RXPO_Pos         20                                             /**< (SERCOM_USART_CTRLA) Receive Data Pinout Position */
+#define SERCOM_USART_CTRLA_RXPO_Msk         (_U_(0x3) << SERCOM_USART_CTRLA_RXPO_Pos)      /**< (SERCOM_USART_CTRLA) Receive Data Pinout Mask */
+#define SERCOM_USART_CTRLA_RXPO(value)      (SERCOM_USART_CTRLA_RXPO_Msk & ((value) << SERCOM_USART_CTRLA_RXPO_Pos))
+#define SERCOM_USART_CTRLA_SAMPA_Pos        22                                             /**< (SERCOM_USART_CTRLA) Sample Adjustment Position */
+#define SERCOM_USART_CTRLA_SAMPA_Msk        (_U_(0x3) << SERCOM_USART_CTRLA_SAMPA_Pos)     /**< (SERCOM_USART_CTRLA) Sample Adjustment Mask */
+#define SERCOM_USART_CTRLA_SAMPA(value)     (SERCOM_USART_CTRLA_SAMPA_Msk & ((value) << SERCOM_USART_CTRLA_SAMPA_Pos))
+#define SERCOM_USART_CTRLA_FORM_Pos         24                                             /**< (SERCOM_USART_CTRLA) Frame Format Position */
+#define SERCOM_USART_CTRLA_FORM_Msk         (_U_(0xF) << SERCOM_USART_CTRLA_FORM_Pos)      /**< (SERCOM_USART_CTRLA) Frame Format Mask */
+#define SERCOM_USART_CTRLA_FORM(value)      (SERCOM_USART_CTRLA_FORM_Msk & ((value) << SERCOM_USART_CTRLA_FORM_Pos))
+#define SERCOM_USART_CTRLA_CMODE_Pos        28                                             /**< (SERCOM_USART_CTRLA) Communication Mode Position */
+#define SERCOM_USART_CTRLA_CMODE_Msk        (_U_(0x1) << SERCOM_USART_CTRLA_CMODE_Pos)     /**< (SERCOM_USART_CTRLA) Communication Mode Mask */
+#define SERCOM_USART_CTRLA_CMODE            SERCOM_USART_CTRLA_CMODE_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_CTRLA_CMODE_Msk instead */
+#define SERCOM_USART_CTRLA_CPOL_Pos         29                                             /**< (SERCOM_USART_CTRLA) Clock Polarity Position */
+#define SERCOM_USART_CTRLA_CPOL_Msk         (_U_(0x1) << SERCOM_USART_CTRLA_CPOL_Pos)      /**< (SERCOM_USART_CTRLA) Clock Polarity Mask */
+#define SERCOM_USART_CTRLA_CPOL             SERCOM_USART_CTRLA_CPOL_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_CTRLA_CPOL_Msk instead */
+#define SERCOM_USART_CTRLA_DORD_Pos         30                                             /**< (SERCOM_USART_CTRLA) Data Order Position */
+#define SERCOM_USART_CTRLA_DORD_Msk         (_U_(0x1) << SERCOM_USART_CTRLA_DORD_Pos)      /**< (SERCOM_USART_CTRLA) Data Order Mask */
+#define SERCOM_USART_CTRLA_DORD             SERCOM_USART_CTRLA_DORD_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_CTRLA_DORD_Msk instead */
+#define SERCOM_USART_CTRLA_MASK             _U_(0x7FF3E79F)                                /**< \deprecated (SERCOM_USART_CTRLA) Register MASK  (Use SERCOM_USART_CTRLA_Msk instead)  */
+#define SERCOM_USART_CTRLA_Msk              _U_(0x7FF3E79F)                                /**< (SERCOM_USART_CTRLA) Register Mask  */
+
+
+/* -------- SERCOM_I2CM_CTRLB : (SERCOM Offset: 0x04) (R/W 32) I2CM Control B -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t SMEN:1;                    /**< bit:      8  Smart Mode Enable                        */
+    uint32_t QCEN:1;                    /**< bit:      9  Quick Command Enable                     */
+    uint32_t :6;                        /**< bit: 10..15  Reserved */
+    uint32_t CMD:2;                     /**< bit: 16..17  Command                                  */
+    uint32_t ACKACT:1;                  /**< bit:     18  Acknowledge Action                       */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SERCOM_I2CM_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_CTRLB_OFFSET            (0x04)                                        /**<  (SERCOM_I2CM_CTRLB) I2CM Control B  Offset */
+#define SERCOM_I2CM_CTRLB_RESETVALUE        _U_(0x00)                                     /**<  (SERCOM_I2CM_CTRLB) I2CM Control B  Reset Value */
+
+#define SERCOM_I2CM_CTRLB_SMEN_Pos          8                                              /**< (SERCOM_I2CM_CTRLB) Smart Mode Enable Position */
+#define SERCOM_I2CM_CTRLB_SMEN_Msk          (_U_(0x1) << SERCOM_I2CM_CTRLB_SMEN_Pos)       /**< (SERCOM_I2CM_CTRLB) Smart Mode Enable Mask */
+#define SERCOM_I2CM_CTRLB_SMEN              SERCOM_I2CM_CTRLB_SMEN_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_CTRLB_SMEN_Msk instead */
+#define SERCOM_I2CM_CTRLB_QCEN_Pos          9                                              /**< (SERCOM_I2CM_CTRLB) Quick Command Enable Position */
+#define SERCOM_I2CM_CTRLB_QCEN_Msk          (_U_(0x1) << SERCOM_I2CM_CTRLB_QCEN_Pos)       /**< (SERCOM_I2CM_CTRLB) Quick Command Enable Mask */
+#define SERCOM_I2CM_CTRLB_QCEN              SERCOM_I2CM_CTRLB_QCEN_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_CTRLB_QCEN_Msk instead */
+#define SERCOM_I2CM_CTRLB_CMD_Pos           16                                             /**< (SERCOM_I2CM_CTRLB) Command Position */
+#define SERCOM_I2CM_CTRLB_CMD_Msk           (_U_(0x3) << SERCOM_I2CM_CTRLB_CMD_Pos)        /**< (SERCOM_I2CM_CTRLB) Command Mask */
+#define SERCOM_I2CM_CTRLB_CMD(value)        (SERCOM_I2CM_CTRLB_CMD_Msk & ((value) << SERCOM_I2CM_CTRLB_CMD_Pos))
+#define SERCOM_I2CM_CTRLB_ACKACT_Pos        18                                             /**< (SERCOM_I2CM_CTRLB) Acknowledge Action Position */
+#define SERCOM_I2CM_CTRLB_ACKACT_Msk        (_U_(0x1) << SERCOM_I2CM_CTRLB_ACKACT_Pos)     /**< (SERCOM_I2CM_CTRLB) Acknowledge Action Mask */
+#define SERCOM_I2CM_CTRLB_ACKACT            SERCOM_I2CM_CTRLB_ACKACT_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_CTRLB_ACKACT_Msk instead */
+#define SERCOM_I2CM_CTRLB_MASK              _U_(0x70300)                                   /**< \deprecated (SERCOM_I2CM_CTRLB) Register MASK  (Use SERCOM_I2CM_CTRLB_Msk instead)  */
+#define SERCOM_I2CM_CTRLB_Msk               _U_(0x70300)                                   /**< (SERCOM_I2CM_CTRLB) Register Mask  */
+
+
+/* -------- SERCOM_I2CS_CTRLB : (SERCOM Offset: 0x04) (R/W 32) I2CS Control B -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t SMEN:1;                    /**< bit:      8  Smart Mode Enable                        */
+    uint32_t GCMD:1;                    /**< bit:      9  PMBus Group Command                      */
+    uint32_t AACKEN:1;                  /**< bit:     10  Automatic Address Acknowledge            */
+    uint32_t :3;                        /**< bit: 11..13  Reserved */
+    uint32_t AMODE:2;                   /**< bit: 14..15  Address Mode                             */
+    uint32_t CMD:2;                     /**< bit: 16..17  Command                                  */
+    uint32_t ACKACT:1;                  /**< bit:     18  Acknowledge Action                       */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SERCOM_I2CS_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CS_CTRLB_OFFSET            (0x04)                                        /**<  (SERCOM_I2CS_CTRLB) I2CS Control B  Offset */
+#define SERCOM_I2CS_CTRLB_RESETVALUE        _U_(0x00)                                     /**<  (SERCOM_I2CS_CTRLB) I2CS Control B  Reset Value */
+
+#define SERCOM_I2CS_CTRLB_SMEN_Pos          8                                              /**< (SERCOM_I2CS_CTRLB) Smart Mode Enable Position */
+#define SERCOM_I2CS_CTRLB_SMEN_Msk          (_U_(0x1) << SERCOM_I2CS_CTRLB_SMEN_Pos)       /**< (SERCOM_I2CS_CTRLB) Smart Mode Enable Mask */
+#define SERCOM_I2CS_CTRLB_SMEN              SERCOM_I2CS_CTRLB_SMEN_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_CTRLB_SMEN_Msk instead */
+#define SERCOM_I2CS_CTRLB_GCMD_Pos          9                                              /**< (SERCOM_I2CS_CTRLB) PMBus Group Command Position */
+#define SERCOM_I2CS_CTRLB_GCMD_Msk          (_U_(0x1) << SERCOM_I2CS_CTRLB_GCMD_Pos)       /**< (SERCOM_I2CS_CTRLB) PMBus Group Command Mask */
+#define SERCOM_I2CS_CTRLB_GCMD              SERCOM_I2CS_CTRLB_GCMD_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_CTRLB_GCMD_Msk instead */
+#define SERCOM_I2CS_CTRLB_AACKEN_Pos        10                                             /**< (SERCOM_I2CS_CTRLB) Automatic Address Acknowledge Position */
+#define SERCOM_I2CS_CTRLB_AACKEN_Msk        (_U_(0x1) << SERCOM_I2CS_CTRLB_AACKEN_Pos)     /**< (SERCOM_I2CS_CTRLB) Automatic Address Acknowledge Mask */
+#define SERCOM_I2CS_CTRLB_AACKEN            SERCOM_I2CS_CTRLB_AACKEN_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_CTRLB_AACKEN_Msk instead */
+#define SERCOM_I2CS_CTRLB_AMODE_Pos         14                                             /**< (SERCOM_I2CS_CTRLB) Address Mode Position */
+#define SERCOM_I2CS_CTRLB_AMODE_Msk         (_U_(0x3) << SERCOM_I2CS_CTRLB_AMODE_Pos)      /**< (SERCOM_I2CS_CTRLB) Address Mode Mask */
+#define SERCOM_I2CS_CTRLB_AMODE(value)      (SERCOM_I2CS_CTRLB_AMODE_Msk & ((value) << SERCOM_I2CS_CTRLB_AMODE_Pos))
+#define SERCOM_I2CS_CTRLB_CMD_Pos           16                                             /**< (SERCOM_I2CS_CTRLB) Command Position */
+#define SERCOM_I2CS_CTRLB_CMD_Msk           (_U_(0x3) << SERCOM_I2CS_CTRLB_CMD_Pos)        /**< (SERCOM_I2CS_CTRLB) Command Mask */
+#define SERCOM_I2CS_CTRLB_CMD(value)        (SERCOM_I2CS_CTRLB_CMD_Msk & ((value) << SERCOM_I2CS_CTRLB_CMD_Pos))
+#define SERCOM_I2CS_CTRLB_ACKACT_Pos        18                                             /**< (SERCOM_I2CS_CTRLB) Acknowledge Action Position */
+#define SERCOM_I2CS_CTRLB_ACKACT_Msk        (_U_(0x1) << SERCOM_I2CS_CTRLB_ACKACT_Pos)     /**< (SERCOM_I2CS_CTRLB) Acknowledge Action Mask */
+#define SERCOM_I2CS_CTRLB_ACKACT            SERCOM_I2CS_CTRLB_ACKACT_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_CTRLB_ACKACT_Msk instead */
+#define SERCOM_I2CS_CTRLB_MASK              _U_(0x7C700)                                   /**< \deprecated (SERCOM_I2CS_CTRLB) Register MASK  (Use SERCOM_I2CS_CTRLB_Msk instead)  */
+#define SERCOM_I2CS_CTRLB_Msk               _U_(0x7C700)                                   /**< (SERCOM_I2CS_CTRLB) Register Mask  */
+
+
+/* -------- SERCOM_SPI_CTRLB : (SERCOM Offset: 0x04) (R/W 32) SPI Control B -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t CHSIZE:3;                  /**< bit:   0..2  Character Size                           */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t PLOADEN:1;                 /**< bit:      6  Data Preload Enable                      */
+    uint32_t :2;                        /**< bit:   7..8  Reserved */
+    uint32_t SSDE:1;                    /**< bit:      9  Slave Select Low Detect Enable           */
+    uint32_t :3;                        /**< bit: 10..12  Reserved */
+    uint32_t MSSEN:1;                   /**< bit:     13  Master Slave Select Enable               */
+    uint32_t AMODE:2;                   /**< bit: 14..15  Address Mode                             */
+    uint32_t :1;                        /**< bit:     16  Reserved */
+    uint32_t RXEN:1;                    /**< bit:     17  Receiver Enable                          */
+    uint32_t :14;                       /**< bit: 18..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SERCOM_SPI_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_CTRLB_OFFSET             (0x04)                                        /**<  (SERCOM_SPI_CTRLB) SPI Control B  Offset */
+#define SERCOM_SPI_CTRLB_RESETVALUE         _U_(0x00)                                     /**<  (SERCOM_SPI_CTRLB) SPI Control B  Reset Value */
+
+#define SERCOM_SPI_CTRLB_CHSIZE_Pos         0                                              /**< (SERCOM_SPI_CTRLB) Character Size Position */
+#define SERCOM_SPI_CTRLB_CHSIZE_Msk         (_U_(0x7) << SERCOM_SPI_CTRLB_CHSIZE_Pos)      /**< (SERCOM_SPI_CTRLB) Character Size Mask */
+#define SERCOM_SPI_CTRLB_CHSIZE(value)      (SERCOM_SPI_CTRLB_CHSIZE_Msk & ((value) << SERCOM_SPI_CTRLB_CHSIZE_Pos))
+#define SERCOM_SPI_CTRLB_PLOADEN_Pos        6                                              /**< (SERCOM_SPI_CTRLB) Data Preload Enable Position */
+#define SERCOM_SPI_CTRLB_PLOADEN_Msk        (_U_(0x1) << SERCOM_SPI_CTRLB_PLOADEN_Pos)     /**< (SERCOM_SPI_CTRLB) Data Preload Enable Mask */
+#define SERCOM_SPI_CTRLB_PLOADEN            SERCOM_SPI_CTRLB_PLOADEN_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_CTRLB_PLOADEN_Msk instead */
+#define SERCOM_SPI_CTRLB_SSDE_Pos           9                                              /**< (SERCOM_SPI_CTRLB) Slave Select Low Detect Enable Position */
+#define SERCOM_SPI_CTRLB_SSDE_Msk           (_U_(0x1) << SERCOM_SPI_CTRLB_SSDE_Pos)        /**< (SERCOM_SPI_CTRLB) Slave Select Low Detect Enable Mask */
+#define SERCOM_SPI_CTRLB_SSDE               SERCOM_SPI_CTRLB_SSDE_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_CTRLB_SSDE_Msk instead */
+#define SERCOM_SPI_CTRLB_MSSEN_Pos          13                                             /**< (SERCOM_SPI_CTRLB) Master Slave Select Enable Position */
+#define SERCOM_SPI_CTRLB_MSSEN_Msk          (_U_(0x1) << SERCOM_SPI_CTRLB_MSSEN_Pos)       /**< (SERCOM_SPI_CTRLB) Master Slave Select Enable Mask */
+#define SERCOM_SPI_CTRLB_MSSEN              SERCOM_SPI_CTRLB_MSSEN_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_CTRLB_MSSEN_Msk instead */
+#define SERCOM_SPI_CTRLB_AMODE_Pos          14                                             /**< (SERCOM_SPI_CTRLB) Address Mode Position */
+#define SERCOM_SPI_CTRLB_AMODE_Msk          (_U_(0x3) << SERCOM_SPI_CTRLB_AMODE_Pos)       /**< (SERCOM_SPI_CTRLB) Address Mode Mask */
+#define SERCOM_SPI_CTRLB_AMODE(value)       (SERCOM_SPI_CTRLB_AMODE_Msk & ((value) << SERCOM_SPI_CTRLB_AMODE_Pos))
+#define SERCOM_SPI_CTRLB_RXEN_Pos           17                                             /**< (SERCOM_SPI_CTRLB) Receiver Enable Position */
+#define SERCOM_SPI_CTRLB_RXEN_Msk           (_U_(0x1) << SERCOM_SPI_CTRLB_RXEN_Pos)        /**< (SERCOM_SPI_CTRLB) Receiver Enable Mask */
+#define SERCOM_SPI_CTRLB_RXEN               SERCOM_SPI_CTRLB_RXEN_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_CTRLB_RXEN_Msk instead */
+#define SERCOM_SPI_CTRLB_MASK               _U_(0x2E247)                                   /**< \deprecated (SERCOM_SPI_CTRLB) Register MASK  (Use SERCOM_SPI_CTRLB_Msk instead)  */
+#define SERCOM_SPI_CTRLB_Msk                _U_(0x2E247)                                   /**< (SERCOM_SPI_CTRLB) Register Mask  */
+
+
+/* -------- SERCOM_USART_CTRLB : (SERCOM Offset: 0x04) (R/W 32) USART Control B -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t CHSIZE:3;                  /**< bit:   0..2  Character Size                           */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t SBMODE:1;                  /**< bit:      6  Stop Bit Mode                            */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t COLDEN:1;                  /**< bit:      8  Collision Detection Enable               */
+    uint32_t SFDE:1;                    /**< bit:      9  Start of Frame Detection Enable          */
+    uint32_t ENC:1;                     /**< bit:     10  Encoding Format                          */
+    uint32_t :2;                        /**< bit: 11..12  Reserved */
+    uint32_t PMODE:1;                   /**< bit:     13  Parity Mode                              */
+    uint32_t :2;                        /**< bit: 14..15  Reserved */
+    uint32_t TXEN:1;                    /**< bit:     16  Transmitter Enable                       */
+    uint32_t RXEN:1;                    /**< bit:     17  Receiver Enable                          */
+    uint32_t :6;                        /**< bit: 18..23  Reserved */
+    uint32_t LINCMD:2;                  /**< bit: 24..25  LIN Command                              */
+    uint32_t :6;                        /**< bit: 26..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SERCOM_USART_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_CTRLB_OFFSET           (0x04)                                        /**<  (SERCOM_USART_CTRLB) USART Control B  Offset */
+#define SERCOM_USART_CTRLB_RESETVALUE       _U_(0x00)                                     /**<  (SERCOM_USART_CTRLB) USART Control B  Reset Value */
+
+#define SERCOM_USART_CTRLB_CHSIZE_Pos       0                                              /**< (SERCOM_USART_CTRLB) Character Size Position */
+#define SERCOM_USART_CTRLB_CHSIZE_Msk       (_U_(0x7) << SERCOM_USART_CTRLB_CHSIZE_Pos)    /**< (SERCOM_USART_CTRLB) Character Size Mask */
+#define SERCOM_USART_CTRLB_CHSIZE(value)    (SERCOM_USART_CTRLB_CHSIZE_Msk & ((value) << SERCOM_USART_CTRLB_CHSIZE_Pos))
+#define SERCOM_USART_CTRLB_SBMODE_Pos       6                                              /**< (SERCOM_USART_CTRLB) Stop Bit Mode Position */
+#define SERCOM_USART_CTRLB_SBMODE_Msk       (_U_(0x1) << SERCOM_USART_CTRLB_SBMODE_Pos)    /**< (SERCOM_USART_CTRLB) Stop Bit Mode Mask */
+#define SERCOM_USART_CTRLB_SBMODE           SERCOM_USART_CTRLB_SBMODE_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_CTRLB_SBMODE_Msk instead */
+#define SERCOM_USART_CTRLB_COLDEN_Pos       8                                              /**< (SERCOM_USART_CTRLB) Collision Detection Enable Position */
+#define SERCOM_USART_CTRLB_COLDEN_Msk       (_U_(0x1) << SERCOM_USART_CTRLB_COLDEN_Pos)    /**< (SERCOM_USART_CTRLB) Collision Detection Enable Mask */
+#define SERCOM_USART_CTRLB_COLDEN           SERCOM_USART_CTRLB_COLDEN_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_CTRLB_COLDEN_Msk instead */
+#define SERCOM_USART_CTRLB_SFDE_Pos         9                                              /**< (SERCOM_USART_CTRLB) Start of Frame Detection Enable Position */
+#define SERCOM_USART_CTRLB_SFDE_Msk         (_U_(0x1) << SERCOM_USART_CTRLB_SFDE_Pos)      /**< (SERCOM_USART_CTRLB) Start of Frame Detection Enable Mask */
+#define SERCOM_USART_CTRLB_SFDE             SERCOM_USART_CTRLB_SFDE_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_CTRLB_SFDE_Msk instead */
+#define SERCOM_USART_CTRLB_ENC_Pos          10                                             /**< (SERCOM_USART_CTRLB) Encoding Format Position */
+#define SERCOM_USART_CTRLB_ENC_Msk          (_U_(0x1) << SERCOM_USART_CTRLB_ENC_Pos)       /**< (SERCOM_USART_CTRLB) Encoding Format Mask */
+#define SERCOM_USART_CTRLB_ENC              SERCOM_USART_CTRLB_ENC_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_CTRLB_ENC_Msk instead */
+#define SERCOM_USART_CTRLB_PMODE_Pos        13                                             /**< (SERCOM_USART_CTRLB) Parity Mode Position */
+#define SERCOM_USART_CTRLB_PMODE_Msk        (_U_(0x1) << SERCOM_USART_CTRLB_PMODE_Pos)     /**< (SERCOM_USART_CTRLB) Parity Mode Mask */
+#define SERCOM_USART_CTRLB_PMODE            SERCOM_USART_CTRLB_PMODE_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_CTRLB_PMODE_Msk instead */
+#define SERCOM_USART_CTRLB_TXEN_Pos         16                                             /**< (SERCOM_USART_CTRLB) Transmitter Enable Position */
+#define SERCOM_USART_CTRLB_TXEN_Msk         (_U_(0x1) << SERCOM_USART_CTRLB_TXEN_Pos)      /**< (SERCOM_USART_CTRLB) Transmitter Enable Mask */
+#define SERCOM_USART_CTRLB_TXEN             SERCOM_USART_CTRLB_TXEN_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_CTRLB_TXEN_Msk instead */
+#define SERCOM_USART_CTRLB_RXEN_Pos         17                                             /**< (SERCOM_USART_CTRLB) Receiver Enable Position */
+#define SERCOM_USART_CTRLB_RXEN_Msk         (_U_(0x1) << SERCOM_USART_CTRLB_RXEN_Pos)      /**< (SERCOM_USART_CTRLB) Receiver Enable Mask */
+#define SERCOM_USART_CTRLB_RXEN             SERCOM_USART_CTRLB_RXEN_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_CTRLB_RXEN_Msk instead */
+#define SERCOM_USART_CTRLB_LINCMD_Pos       24                                             /**< (SERCOM_USART_CTRLB) LIN Command Position */
+#define SERCOM_USART_CTRLB_LINCMD_Msk       (_U_(0x3) << SERCOM_USART_CTRLB_LINCMD_Pos)    /**< (SERCOM_USART_CTRLB) LIN Command Mask */
+#define SERCOM_USART_CTRLB_LINCMD(value)    (SERCOM_USART_CTRLB_LINCMD_Msk & ((value) << SERCOM_USART_CTRLB_LINCMD_Pos))
+#define SERCOM_USART_CTRLB_MASK             _U_(0x3032747)                                 /**< \deprecated (SERCOM_USART_CTRLB) Register MASK  (Use SERCOM_USART_CTRLB_Msk instead)  */
+#define SERCOM_USART_CTRLB_Msk              _U_(0x3032747)                                 /**< (SERCOM_USART_CTRLB) Register Mask  */
+
+
+/* -------- SERCOM_USART_CTRLC : (SERCOM Offset: 0x08) (R/W 32) USART Control C -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t GTIME:3;                   /**< bit:   0..2  Guard Time                               */
+    uint32_t :5;                        /**< bit:   3..7  Reserved */
+    uint32_t BRKLEN:2;                  /**< bit:   8..9  LIN Master Break Length                  */
+    uint32_t HDRDLY:2;                  /**< bit: 10..11  LIN Master Header Delay                  */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t INACK:1;                   /**< bit:     16  Inhibit Not Acknowledge                  */
+    uint32_t DSNACK:1;                  /**< bit:     17  Disable Successive NACK                  */
+    uint32_t :2;                        /**< bit: 18..19  Reserved */
+    uint32_t MAXITER:3;                 /**< bit: 20..22  Maximum Iterations                       */
+    uint32_t :9;                        /**< bit: 23..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SERCOM_USART_CTRLC_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_CTRLC_OFFSET           (0x08)                                        /**<  (SERCOM_USART_CTRLC) USART Control C  Offset */
+#define SERCOM_USART_CTRLC_RESETVALUE       _U_(0x00)                                     /**<  (SERCOM_USART_CTRLC) USART Control C  Reset Value */
+
+#define SERCOM_USART_CTRLC_GTIME_Pos        0                                              /**< (SERCOM_USART_CTRLC) Guard Time Position */
+#define SERCOM_USART_CTRLC_GTIME_Msk        (_U_(0x7) << SERCOM_USART_CTRLC_GTIME_Pos)     /**< (SERCOM_USART_CTRLC) Guard Time Mask */
+#define SERCOM_USART_CTRLC_GTIME(value)     (SERCOM_USART_CTRLC_GTIME_Msk & ((value) << SERCOM_USART_CTRLC_GTIME_Pos))
+#define SERCOM_USART_CTRLC_BRKLEN_Pos       8                                              /**< (SERCOM_USART_CTRLC) LIN Master Break Length Position */
+#define SERCOM_USART_CTRLC_BRKLEN_Msk       (_U_(0x3) << SERCOM_USART_CTRLC_BRKLEN_Pos)    /**< (SERCOM_USART_CTRLC) LIN Master Break Length Mask */
+#define SERCOM_USART_CTRLC_BRKLEN(value)    (SERCOM_USART_CTRLC_BRKLEN_Msk & ((value) << SERCOM_USART_CTRLC_BRKLEN_Pos))
+#define SERCOM_USART_CTRLC_HDRDLY_Pos       10                                             /**< (SERCOM_USART_CTRLC) LIN Master Header Delay Position */
+#define SERCOM_USART_CTRLC_HDRDLY_Msk       (_U_(0x3) << SERCOM_USART_CTRLC_HDRDLY_Pos)    /**< (SERCOM_USART_CTRLC) LIN Master Header Delay Mask */
+#define SERCOM_USART_CTRLC_HDRDLY(value)    (SERCOM_USART_CTRLC_HDRDLY_Msk & ((value) << SERCOM_USART_CTRLC_HDRDLY_Pos))
+#define SERCOM_USART_CTRLC_INACK_Pos        16                                             /**< (SERCOM_USART_CTRLC) Inhibit Not Acknowledge Position */
+#define SERCOM_USART_CTRLC_INACK_Msk        (_U_(0x1) << SERCOM_USART_CTRLC_INACK_Pos)     /**< (SERCOM_USART_CTRLC) Inhibit Not Acknowledge Mask */
+#define SERCOM_USART_CTRLC_INACK            SERCOM_USART_CTRLC_INACK_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_CTRLC_INACK_Msk instead */
+#define SERCOM_USART_CTRLC_DSNACK_Pos       17                                             /**< (SERCOM_USART_CTRLC) Disable Successive NACK Position */
+#define SERCOM_USART_CTRLC_DSNACK_Msk       (_U_(0x1) << SERCOM_USART_CTRLC_DSNACK_Pos)    /**< (SERCOM_USART_CTRLC) Disable Successive NACK Mask */
+#define SERCOM_USART_CTRLC_DSNACK           SERCOM_USART_CTRLC_DSNACK_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_CTRLC_DSNACK_Msk instead */
+#define SERCOM_USART_CTRLC_MAXITER_Pos      20                                             /**< (SERCOM_USART_CTRLC) Maximum Iterations Position */
+#define SERCOM_USART_CTRLC_MAXITER_Msk      (_U_(0x7) << SERCOM_USART_CTRLC_MAXITER_Pos)   /**< (SERCOM_USART_CTRLC) Maximum Iterations Mask */
+#define SERCOM_USART_CTRLC_MAXITER(value)   (SERCOM_USART_CTRLC_MAXITER_Msk & ((value) << SERCOM_USART_CTRLC_MAXITER_Pos))
+#define SERCOM_USART_CTRLC_MASK             _U_(0x730F07)                                  /**< \deprecated (SERCOM_USART_CTRLC) Register MASK  (Use SERCOM_USART_CTRLC_Msk instead)  */
+#define SERCOM_USART_CTRLC_Msk              _U_(0x730F07)                                  /**< (SERCOM_USART_CTRLC) Register Mask  */
+
+
+/* -------- SERCOM_I2CM_BAUD : (SERCOM Offset: 0x0c) (R/W 32) I2CM Baud Rate -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t BAUD:8;                    /**< bit:   0..7  Baud Rate Value                          */
+    uint32_t BAUDLOW:8;                 /**< bit:  8..15  Baud Rate Value Low                      */
+    uint32_t HSBAUD:8;                  /**< bit: 16..23  High Speed Baud Rate Value               */
+    uint32_t HSBAUDLOW:8;               /**< bit: 24..31  High Speed Baud Rate Value Low           */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SERCOM_I2CM_BAUD_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_BAUD_OFFSET             (0x0C)                                        /**<  (SERCOM_I2CM_BAUD) I2CM Baud Rate  Offset */
+#define SERCOM_I2CM_BAUD_RESETVALUE         _U_(0x00)                                     /**<  (SERCOM_I2CM_BAUD) I2CM Baud Rate  Reset Value */
+
+#define SERCOM_I2CM_BAUD_BAUD_Pos           0                                              /**< (SERCOM_I2CM_BAUD) Baud Rate Value Position */
+#define SERCOM_I2CM_BAUD_BAUD_Msk           (_U_(0xFF) << SERCOM_I2CM_BAUD_BAUD_Pos)       /**< (SERCOM_I2CM_BAUD) Baud Rate Value Mask */
+#define SERCOM_I2CM_BAUD_BAUD(value)        (SERCOM_I2CM_BAUD_BAUD_Msk & ((value) << SERCOM_I2CM_BAUD_BAUD_Pos))
+#define SERCOM_I2CM_BAUD_BAUDLOW_Pos        8                                              /**< (SERCOM_I2CM_BAUD) Baud Rate Value Low Position */
+#define SERCOM_I2CM_BAUD_BAUDLOW_Msk        (_U_(0xFF) << SERCOM_I2CM_BAUD_BAUDLOW_Pos)    /**< (SERCOM_I2CM_BAUD) Baud Rate Value Low Mask */
+#define SERCOM_I2CM_BAUD_BAUDLOW(value)     (SERCOM_I2CM_BAUD_BAUDLOW_Msk & ((value) << SERCOM_I2CM_BAUD_BAUDLOW_Pos))
+#define SERCOM_I2CM_BAUD_HSBAUD_Pos         16                                             /**< (SERCOM_I2CM_BAUD) High Speed Baud Rate Value Position */
+#define SERCOM_I2CM_BAUD_HSBAUD_Msk         (_U_(0xFF) << SERCOM_I2CM_BAUD_HSBAUD_Pos)     /**< (SERCOM_I2CM_BAUD) High Speed Baud Rate Value Mask */
+#define SERCOM_I2CM_BAUD_HSBAUD(value)      (SERCOM_I2CM_BAUD_HSBAUD_Msk & ((value) << SERCOM_I2CM_BAUD_HSBAUD_Pos))
+#define SERCOM_I2CM_BAUD_HSBAUDLOW_Pos      24                                             /**< (SERCOM_I2CM_BAUD) High Speed Baud Rate Value Low Position */
+#define SERCOM_I2CM_BAUD_HSBAUDLOW_Msk      (_U_(0xFF) << SERCOM_I2CM_BAUD_HSBAUDLOW_Pos)  /**< (SERCOM_I2CM_BAUD) High Speed Baud Rate Value Low Mask */
+#define SERCOM_I2CM_BAUD_HSBAUDLOW(value)   (SERCOM_I2CM_BAUD_HSBAUDLOW_Msk & ((value) << SERCOM_I2CM_BAUD_HSBAUDLOW_Pos))
+#define SERCOM_I2CM_BAUD_MASK               _U_(0xFFFFFFFF)                                /**< \deprecated (SERCOM_I2CM_BAUD) Register MASK  (Use SERCOM_I2CM_BAUD_Msk instead)  */
+#define SERCOM_I2CM_BAUD_Msk                _U_(0xFFFFFFFF)                                /**< (SERCOM_I2CM_BAUD) Register Mask  */
+
+
+/* -------- SERCOM_SPI_BAUD : (SERCOM Offset: 0x0c) (R/W 8) SPI Baud Rate -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  BAUD:8;                    /**< bit:   0..7  Baud Rate Value                          */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} SERCOM_SPI_BAUD_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_BAUD_OFFSET              (0x0C)                                        /**<  (SERCOM_SPI_BAUD) SPI Baud Rate  Offset */
+#define SERCOM_SPI_BAUD_RESETVALUE          _U_(0x00)                                     /**<  (SERCOM_SPI_BAUD) SPI Baud Rate  Reset Value */
+
+#define SERCOM_SPI_BAUD_BAUD_Pos            0                                              /**< (SERCOM_SPI_BAUD) Baud Rate Value Position */
+#define SERCOM_SPI_BAUD_BAUD_Msk            (_U_(0xFF) << SERCOM_SPI_BAUD_BAUD_Pos)        /**< (SERCOM_SPI_BAUD) Baud Rate Value Mask */
+#define SERCOM_SPI_BAUD_BAUD(value)         (SERCOM_SPI_BAUD_BAUD_Msk & ((value) << SERCOM_SPI_BAUD_BAUD_Pos))
+#define SERCOM_SPI_BAUD_MASK                _U_(0xFF)                                      /**< \deprecated (SERCOM_SPI_BAUD) Register MASK  (Use SERCOM_SPI_BAUD_Msk instead)  */
+#define SERCOM_SPI_BAUD_Msk                 _U_(0xFF)                                      /**< (SERCOM_SPI_BAUD) Register Mask  */
+
+
+/* -------- SERCOM_USART_BAUD : (SERCOM Offset: 0x0c) (R/W 16) USART Baud Rate -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t BAUD:16;                   /**< bit:  0..15  Baud Rate Value                          */
+  } bit;                                /**< Structure used for bit  access */
+  struct { // FRAC mode
+    uint16_t BAUD:13;                   /**< bit:  0..12  Baud Rate Value                          */
+    uint16_t FP:3;                      /**< bit: 13..15  Fractional Part                          */
+  } FRAC;                                /**< Structure used for FRAC mode access */
+  struct { // FRACFP mode
+    uint16_t BAUD:13;                   /**< bit:  0..12  Baud Rate Value                          */
+    uint16_t FP:3;                      /**< bit: 13..15  Fractional Part                          */
+  } FRACFP;                                /**< Structure used for FRACFP mode access */
+  struct { // USARTFP mode
+    uint16_t BAUD:16;                   /**< bit:  0..15  Baud Rate Value                          */
+  } USARTFP;                                /**< Structure used for USARTFP mode access */
+  uint16_t reg;                         /**< Type used for register access */
+} SERCOM_USART_BAUD_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_BAUD_OFFSET            (0x0C)                                        /**<  (SERCOM_USART_BAUD) USART Baud Rate  Offset */
+#define SERCOM_USART_BAUD_RESETVALUE        _U_(0x00)                                     /**<  (SERCOM_USART_BAUD) USART Baud Rate  Reset Value */
+
+#define SERCOM_USART_BAUD_BAUD_Pos          0                                              /**< (SERCOM_USART_BAUD) Baud Rate Value Position */
+#define SERCOM_USART_BAUD_BAUD_Msk          (_U_(0xFFFF) << SERCOM_USART_BAUD_BAUD_Pos)    /**< (SERCOM_USART_BAUD) Baud Rate Value Mask */
+#define SERCOM_USART_BAUD_BAUD(value)       (SERCOM_USART_BAUD_BAUD_Msk & ((value) << SERCOM_USART_BAUD_BAUD_Pos))
+#define SERCOM_USART_BAUD_MASK              _U_(0xFFFF)                                    /**< \deprecated (SERCOM_USART_BAUD) Register MASK  (Use SERCOM_USART_BAUD_Msk instead)  */
+#define SERCOM_USART_BAUD_Msk               _U_(0xFFFF)                                    /**< (SERCOM_USART_BAUD) Register Mask  */
+
+/* FRAC mode */
+#define SERCOM_USART_BAUD_FRAC_BAUD_Pos     0                                              /**< (SERCOM_USART_BAUD) Baud Rate Value Position */
+#define SERCOM_USART_BAUD_FRAC_BAUD_Msk     (_U_(0x1FFF) << SERCOM_USART_BAUD_FRAC_BAUD_Pos)  /**< (SERCOM_USART_BAUD) Baud Rate Value Mask */
+#define SERCOM_USART_BAUD_FRAC_BAUD(value)  (SERCOM_USART_BAUD_FRAC_BAUD_Msk & ((value) << SERCOM_USART_BAUD_FRAC_BAUD_Pos))
+#define SERCOM_USART_BAUD_FRAC_FP_Pos       13                                             /**< (SERCOM_USART_BAUD) Fractional Part Position */
+#define SERCOM_USART_BAUD_FRAC_FP_Msk       (_U_(0x7) << SERCOM_USART_BAUD_FRAC_FP_Pos)    /**< (SERCOM_USART_BAUD) Fractional Part Mask */
+#define SERCOM_USART_BAUD_FRAC_FP(value)    (SERCOM_USART_BAUD_FRAC_FP_Msk & ((value) << SERCOM_USART_BAUD_FRAC_FP_Pos))
+#define SERCOM_USART_BAUD_FRAC_MASK         _U_(0xFFFF)                                    /**< \deprecated (SERCOM_USART_BAUD_FRAC) Register MASK  (Use SERCOM_USART_BAUD_FRAC_Msk instead)  */
+#define SERCOM_USART_BAUD_FRAC_Msk          _U_(0xFFFF)                                    /**< (SERCOM_USART_BAUD_FRAC) Register Mask  */
+
+/* FRACFP mode */
+#define SERCOM_USART_BAUD_FRACFP_BAUD_Pos   0                                              /**< (SERCOM_USART_BAUD) Baud Rate Value Position */
+#define SERCOM_USART_BAUD_FRACFP_BAUD_Msk   (_U_(0x1FFF) << SERCOM_USART_BAUD_FRACFP_BAUD_Pos)  /**< (SERCOM_USART_BAUD) Baud Rate Value Mask */
+#define SERCOM_USART_BAUD_FRACFP_BAUD(value) (SERCOM_USART_BAUD_FRACFP_BAUD_Msk & ((value) << SERCOM_USART_BAUD_FRACFP_BAUD_Pos))
+#define SERCOM_USART_BAUD_FRACFP_FP_Pos     13                                             /**< (SERCOM_USART_BAUD) Fractional Part Position */
+#define SERCOM_USART_BAUD_FRACFP_FP_Msk     (_U_(0x7) << SERCOM_USART_BAUD_FRACFP_FP_Pos)  /**< (SERCOM_USART_BAUD) Fractional Part Mask */
+#define SERCOM_USART_BAUD_FRACFP_FP(value)  (SERCOM_USART_BAUD_FRACFP_FP_Msk & ((value) << SERCOM_USART_BAUD_FRACFP_FP_Pos))
+#define SERCOM_USART_BAUD_FRACFP_MASK       _U_(0xFFFF)                                    /**< \deprecated (SERCOM_USART_BAUD_FRACFP) Register MASK  (Use SERCOM_USART_BAUD_FRACFP_Msk instead)  */
+#define SERCOM_USART_BAUD_FRACFP_Msk        _U_(0xFFFF)                                    /**< (SERCOM_USART_BAUD_FRACFP) Register Mask  */
+
+/* USARTFP mode */
+#define SERCOM_USART_BAUD_USARTFP_BAUD_Pos  0                                              /**< (SERCOM_USART_BAUD) Baud Rate Value Position */
+#define SERCOM_USART_BAUD_USARTFP_BAUD_Msk  (_U_(0xFFFF) << SERCOM_USART_BAUD_USARTFP_BAUD_Pos)  /**< (SERCOM_USART_BAUD) Baud Rate Value Mask */
+#define SERCOM_USART_BAUD_USARTFP_BAUD(value) (SERCOM_USART_BAUD_USARTFP_BAUD_Msk & ((value) << SERCOM_USART_BAUD_USARTFP_BAUD_Pos))
+#define SERCOM_USART_BAUD_USARTFP_MASK      _U_(0xFFFF)                                    /**< \deprecated (SERCOM_USART_BAUD_USARTFP) Register MASK  (Use SERCOM_USART_BAUD_USARTFP_Msk instead)  */
+#define SERCOM_USART_BAUD_USARTFP_Msk       _U_(0xFFFF)                                    /**< (SERCOM_USART_BAUD_USARTFP) Register Mask  */
+
+
+/* -------- SERCOM_USART_RXPL : (SERCOM Offset: 0x0e) (R/W 8) USART Receive Pulse Length -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  RXPL:8;                    /**< bit:   0..7  Receive Pulse Length                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} SERCOM_USART_RXPL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_RXPL_OFFSET            (0x0E)                                        /**<  (SERCOM_USART_RXPL) USART Receive Pulse Length  Offset */
+#define SERCOM_USART_RXPL_RESETVALUE        _U_(0x00)                                     /**<  (SERCOM_USART_RXPL) USART Receive Pulse Length  Reset Value */
+
+#define SERCOM_USART_RXPL_RXPL_Pos          0                                              /**< (SERCOM_USART_RXPL) Receive Pulse Length Position */
+#define SERCOM_USART_RXPL_RXPL_Msk          (_U_(0xFF) << SERCOM_USART_RXPL_RXPL_Pos)      /**< (SERCOM_USART_RXPL) Receive Pulse Length Mask */
+#define SERCOM_USART_RXPL_RXPL(value)       (SERCOM_USART_RXPL_RXPL_Msk & ((value) << SERCOM_USART_RXPL_RXPL_Pos))
+#define SERCOM_USART_RXPL_MASK              _U_(0xFF)                                      /**< \deprecated (SERCOM_USART_RXPL) Register MASK  (Use SERCOM_USART_RXPL_Msk instead)  */
+#define SERCOM_USART_RXPL_Msk               _U_(0xFF)                                      /**< (SERCOM_USART_RXPL) Register Mask  */
+
+
+/* -------- SERCOM_I2CM_INTENCLR : (SERCOM Offset: 0x14) (R/W 8) I2CM Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  MB:1;                      /**< bit:      0  Master On Bus Interrupt Disable          */
+    uint8_t  SB:1;                      /**< bit:      1  Slave On Bus Interrupt Disable           */
+    uint8_t  :5;                        /**< bit:   2..6  Reserved */
+    uint8_t  ERROR:1;                   /**< bit:      7  Combined Error Interrupt Disable         */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} SERCOM_I2CM_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_INTENCLR_OFFSET         (0x14)                                        /**<  (SERCOM_I2CM_INTENCLR) I2CM Interrupt Enable Clear  Offset */
+#define SERCOM_I2CM_INTENCLR_RESETVALUE     _U_(0x00)                                     /**<  (SERCOM_I2CM_INTENCLR) I2CM Interrupt Enable Clear  Reset Value */
+
+#define SERCOM_I2CM_INTENCLR_MB_Pos         0                                              /**< (SERCOM_I2CM_INTENCLR) Master On Bus Interrupt Disable Position */
+#define SERCOM_I2CM_INTENCLR_MB_Msk         (_U_(0x1) << SERCOM_I2CM_INTENCLR_MB_Pos)      /**< (SERCOM_I2CM_INTENCLR) Master On Bus Interrupt Disable Mask */
+#define SERCOM_I2CM_INTENCLR_MB             SERCOM_I2CM_INTENCLR_MB_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_INTENCLR_MB_Msk instead */
+#define SERCOM_I2CM_INTENCLR_SB_Pos         1                                              /**< (SERCOM_I2CM_INTENCLR) Slave On Bus Interrupt Disable Position */
+#define SERCOM_I2CM_INTENCLR_SB_Msk         (_U_(0x1) << SERCOM_I2CM_INTENCLR_SB_Pos)      /**< (SERCOM_I2CM_INTENCLR) Slave On Bus Interrupt Disable Mask */
+#define SERCOM_I2CM_INTENCLR_SB             SERCOM_I2CM_INTENCLR_SB_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_INTENCLR_SB_Msk instead */
+#define SERCOM_I2CM_INTENCLR_ERROR_Pos      7                                              /**< (SERCOM_I2CM_INTENCLR) Combined Error Interrupt Disable Position */
+#define SERCOM_I2CM_INTENCLR_ERROR_Msk      (_U_(0x1) << SERCOM_I2CM_INTENCLR_ERROR_Pos)   /**< (SERCOM_I2CM_INTENCLR) Combined Error Interrupt Disable Mask */
+#define SERCOM_I2CM_INTENCLR_ERROR          SERCOM_I2CM_INTENCLR_ERROR_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_INTENCLR_ERROR_Msk instead */
+#define SERCOM_I2CM_INTENCLR_MASK           _U_(0x83)                                      /**< \deprecated (SERCOM_I2CM_INTENCLR) Register MASK  (Use SERCOM_I2CM_INTENCLR_Msk instead)  */
+#define SERCOM_I2CM_INTENCLR_Msk            _U_(0x83)                                      /**< (SERCOM_I2CM_INTENCLR) Register Mask  */
+
+
+/* -------- SERCOM_I2CS_INTENCLR : (SERCOM Offset: 0x14) (R/W 8) I2CS Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  PREC:1;                    /**< bit:      0  Stop Received Interrupt Disable          */
+    uint8_t  AMATCH:1;                  /**< bit:      1  Address Match Interrupt Disable          */
+    uint8_t  DRDY:1;                    /**< bit:      2  Data Interrupt Disable                   */
+    uint8_t  :4;                        /**< bit:   3..6  Reserved */
+    uint8_t  ERROR:1;                   /**< bit:      7  Combined Error Interrupt Disable         */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} SERCOM_I2CS_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CS_INTENCLR_OFFSET         (0x14)                                        /**<  (SERCOM_I2CS_INTENCLR) I2CS Interrupt Enable Clear  Offset */
+#define SERCOM_I2CS_INTENCLR_RESETVALUE     _U_(0x00)                                     /**<  (SERCOM_I2CS_INTENCLR) I2CS Interrupt Enable Clear  Reset Value */
+
+#define SERCOM_I2CS_INTENCLR_PREC_Pos       0                                              /**< (SERCOM_I2CS_INTENCLR) Stop Received Interrupt Disable Position */
+#define SERCOM_I2CS_INTENCLR_PREC_Msk       (_U_(0x1) << SERCOM_I2CS_INTENCLR_PREC_Pos)    /**< (SERCOM_I2CS_INTENCLR) Stop Received Interrupt Disable Mask */
+#define SERCOM_I2CS_INTENCLR_PREC           SERCOM_I2CS_INTENCLR_PREC_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_INTENCLR_PREC_Msk instead */
+#define SERCOM_I2CS_INTENCLR_AMATCH_Pos     1                                              /**< (SERCOM_I2CS_INTENCLR) Address Match Interrupt Disable Position */
+#define SERCOM_I2CS_INTENCLR_AMATCH_Msk     (_U_(0x1) << SERCOM_I2CS_INTENCLR_AMATCH_Pos)  /**< (SERCOM_I2CS_INTENCLR) Address Match Interrupt Disable Mask */
+#define SERCOM_I2CS_INTENCLR_AMATCH         SERCOM_I2CS_INTENCLR_AMATCH_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_INTENCLR_AMATCH_Msk instead */
+#define SERCOM_I2CS_INTENCLR_DRDY_Pos       2                                              /**< (SERCOM_I2CS_INTENCLR) Data Interrupt Disable Position */
+#define SERCOM_I2CS_INTENCLR_DRDY_Msk       (_U_(0x1) << SERCOM_I2CS_INTENCLR_DRDY_Pos)    /**< (SERCOM_I2CS_INTENCLR) Data Interrupt Disable Mask */
+#define SERCOM_I2CS_INTENCLR_DRDY           SERCOM_I2CS_INTENCLR_DRDY_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_INTENCLR_DRDY_Msk instead */
+#define SERCOM_I2CS_INTENCLR_ERROR_Pos      7                                              /**< (SERCOM_I2CS_INTENCLR) Combined Error Interrupt Disable Position */
+#define SERCOM_I2CS_INTENCLR_ERROR_Msk      (_U_(0x1) << SERCOM_I2CS_INTENCLR_ERROR_Pos)   /**< (SERCOM_I2CS_INTENCLR) Combined Error Interrupt Disable Mask */
+#define SERCOM_I2CS_INTENCLR_ERROR          SERCOM_I2CS_INTENCLR_ERROR_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_INTENCLR_ERROR_Msk instead */
+#define SERCOM_I2CS_INTENCLR_MASK           _U_(0x87)                                      /**< \deprecated (SERCOM_I2CS_INTENCLR) Register MASK  (Use SERCOM_I2CS_INTENCLR_Msk instead)  */
+#define SERCOM_I2CS_INTENCLR_Msk            _U_(0x87)                                      /**< (SERCOM_I2CS_INTENCLR) Register Mask  */
+
+
+/* -------- SERCOM_SPI_INTENCLR : (SERCOM Offset: 0x14) (R/W 8) SPI Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DRE:1;                     /**< bit:      0  Data Register Empty Interrupt Disable    */
+    uint8_t  TXC:1;                     /**< bit:      1  Transmit Complete Interrupt Disable      */
+    uint8_t  RXC:1;                     /**< bit:      2  Receive Complete Interrupt Disable       */
+    uint8_t  SSL:1;                     /**< bit:      3  Slave Select Low Interrupt Disable       */
+    uint8_t  :3;                        /**< bit:   4..6  Reserved */
+    uint8_t  ERROR:1;                   /**< bit:      7  Combined Error Interrupt Disable         */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} SERCOM_SPI_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_INTENCLR_OFFSET          (0x14)                                        /**<  (SERCOM_SPI_INTENCLR) SPI Interrupt Enable Clear  Offset */
+#define SERCOM_SPI_INTENCLR_RESETVALUE      _U_(0x00)                                     /**<  (SERCOM_SPI_INTENCLR) SPI Interrupt Enable Clear  Reset Value */
+
+#define SERCOM_SPI_INTENCLR_DRE_Pos         0                                              /**< (SERCOM_SPI_INTENCLR) Data Register Empty Interrupt Disable Position */
+#define SERCOM_SPI_INTENCLR_DRE_Msk         (_U_(0x1) << SERCOM_SPI_INTENCLR_DRE_Pos)      /**< (SERCOM_SPI_INTENCLR) Data Register Empty Interrupt Disable Mask */
+#define SERCOM_SPI_INTENCLR_DRE             SERCOM_SPI_INTENCLR_DRE_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_INTENCLR_DRE_Msk instead */
+#define SERCOM_SPI_INTENCLR_TXC_Pos         1                                              /**< (SERCOM_SPI_INTENCLR) Transmit Complete Interrupt Disable Position */
+#define SERCOM_SPI_INTENCLR_TXC_Msk         (_U_(0x1) << SERCOM_SPI_INTENCLR_TXC_Pos)      /**< (SERCOM_SPI_INTENCLR) Transmit Complete Interrupt Disable Mask */
+#define SERCOM_SPI_INTENCLR_TXC             SERCOM_SPI_INTENCLR_TXC_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_INTENCLR_TXC_Msk instead */
+#define SERCOM_SPI_INTENCLR_RXC_Pos         2                                              /**< (SERCOM_SPI_INTENCLR) Receive Complete Interrupt Disable Position */
+#define SERCOM_SPI_INTENCLR_RXC_Msk         (_U_(0x1) << SERCOM_SPI_INTENCLR_RXC_Pos)      /**< (SERCOM_SPI_INTENCLR) Receive Complete Interrupt Disable Mask */
+#define SERCOM_SPI_INTENCLR_RXC             SERCOM_SPI_INTENCLR_RXC_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_INTENCLR_RXC_Msk instead */
+#define SERCOM_SPI_INTENCLR_SSL_Pos         3                                              /**< (SERCOM_SPI_INTENCLR) Slave Select Low Interrupt Disable Position */
+#define SERCOM_SPI_INTENCLR_SSL_Msk         (_U_(0x1) << SERCOM_SPI_INTENCLR_SSL_Pos)      /**< (SERCOM_SPI_INTENCLR) Slave Select Low Interrupt Disable Mask */
+#define SERCOM_SPI_INTENCLR_SSL             SERCOM_SPI_INTENCLR_SSL_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_INTENCLR_SSL_Msk instead */
+#define SERCOM_SPI_INTENCLR_ERROR_Pos       7                                              /**< (SERCOM_SPI_INTENCLR) Combined Error Interrupt Disable Position */
+#define SERCOM_SPI_INTENCLR_ERROR_Msk       (_U_(0x1) << SERCOM_SPI_INTENCLR_ERROR_Pos)    /**< (SERCOM_SPI_INTENCLR) Combined Error Interrupt Disable Mask */
+#define SERCOM_SPI_INTENCLR_ERROR           SERCOM_SPI_INTENCLR_ERROR_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_INTENCLR_ERROR_Msk instead */
+#define SERCOM_SPI_INTENCLR_MASK            _U_(0x8F)                                      /**< \deprecated (SERCOM_SPI_INTENCLR) Register MASK  (Use SERCOM_SPI_INTENCLR_Msk instead)  */
+#define SERCOM_SPI_INTENCLR_Msk             _U_(0x8F)                                      /**< (SERCOM_SPI_INTENCLR) Register Mask  */
+
+
+/* -------- SERCOM_USART_INTENCLR : (SERCOM Offset: 0x14) (R/W 8) USART Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DRE:1;                     /**< bit:      0  Data Register Empty Interrupt Disable    */
+    uint8_t  TXC:1;                     /**< bit:      1  Transmit Complete Interrupt Disable      */
+    uint8_t  RXC:1;                     /**< bit:      2  Receive Complete Interrupt Disable       */
+    uint8_t  RXS:1;                     /**< bit:      3  Receive Start Interrupt Disable          */
+    uint8_t  CTSIC:1;                   /**< bit:      4  Clear To Send Input Change Interrupt Disable */
+    uint8_t  RXBRK:1;                   /**< bit:      5  Break Received Interrupt Disable         */
+    uint8_t  :1;                        /**< bit:      6  Reserved */
+    uint8_t  ERROR:1;                   /**< bit:      7  Combined Error Interrupt Disable         */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} SERCOM_USART_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_INTENCLR_OFFSET        (0x14)                                        /**<  (SERCOM_USART_INTENCLR) USART Interrupt Enable Clear  Offset */
+#define SERCOM_USART_INTENCLR_RESETVALUE    _U_(0x00)                                     /**<  (SERCOM_USART_INTENCLR) USART Interrupt Enable Clear  Reset Value */
+
+#define SERCOM_USART_INTENCLR_DRE_Pos       0                                              /**< (SERCOM_USART_INTENCLR) Data Register Empty Interrupt Disable Position */
+#define SERCOM_USART_INTENCLR_DRE_Msk       (_U_(0x1) << SERCOM_USART_INTENCLR_DRE_Pos)    /**< (SERCOM_USART_INTENCLR) Data Register Empty Interrupt Disable Mask */
+#define SERCOM_USART_INTENCLR_DRE           SERCOM_USART_INTENCLR_DRE_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_INTENCLR_DRE_Msk instead */
+#define SERCOM_USART_INTENCLR_TXC_Pos       1                                              /**< (SERCOM_USART_INTENCLR) Transmit Complete Interrupt Disable Position */
+#define SERCOM_USART_INTENCLR_TXC_Msk       (_U_(0x1) << SERCOM_USART_INTENCLR_TXC_Pos)    /**< (SERCOM_USART_INTENCLR) Transmit Complete Interrupt Disable Mask */
+#define SERCOM_USART_INTENCLR_TXC           SERCOM_USART_INTENCLR_TXC_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_INTENCLR_TXC_Msk instead */
+#define SERCOM_USART_INTENCLR_RXC_Pos       2                                              /**< (SERCOM_USART_INTENCLR) Receive Complete Interrupt Disable Position */
+#define SERCOM_USART_INTENCLR_RXC_Msk       (_U_(0x1) << SERCOM_USART_INTENCLR_RXC_Pos)    /**< (SERCOM_USART_INTENCLR) Receive Complete Interrupt Disable Mask */
+#define SERCOM_USART_INTENCLR_RXC           SERCOM_USART_INTENCLR_RXC_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_INTENCLR_RXC_Msk instead */
+#define SERCOM_USART_INTENCLR_RXS_Pos       3                                              /**< (SERCOM_USART_INTENCLR) Receive Start Interrupt Disable Position */
+#define SERCOM_USART_INTENCLR_RXS_Msk       (_U_(0x1) << SERCOM_USART_INTENCLR_RXS_Pos)    /**< (SERCOM_USART_INTENCLR) Receive Start Interrupt Disable Mask */
+#define SERCOM_USART_INTENCLR_RXS           SERCOM_USART_INTENCLR_RXS_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_INTENCLR_RXS_Msk instead */
+#define SERCOM_USART_INTENCLR_CTSIC_Pos     4                                              /**< (SERCOM_USART_INTENCLR) Clear To Send Input Change Interrupt Disable Position */
+#define SERCOM_USART_INTENCLR_CTSIC_Msk     (_U_(0x1) << SERCOM_USART_INTENCLR_CTSIC_Pos)  /**< (SERCOM_USART_INTENCLR) Clear To Send Input Change Interrupt Disable Mask */
+#define SERCOM_USART_INTENCLR_CTSIC         SERCOM_USART_INTENCLR_CTSIC_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_INTENCLR_CTSIC_Msk instead */
+#define SERCOM_USART_INTENCLR_RXBRK_Pos     5                                              /**< (SERCOM_USART_INTENCLR) Break Received Interrupt Disable Position */
+#define SERCOM_USART_INTENCLR_RXBRK_Msk     (_U_(0x1) << SERCOM_USART_INTENCLR_RXBRK_Pos)  /**< (SERCOM_USART_INTENCLR) Break Received Interrupt Disable Mask */
+#define SERCOM_USART_INTENCLR_RXBRK         SERCOM_USART_INTENCLR_RXBRK_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_INTENCLR_RXBRK_Msk instead */
+#define SERCOM_USART_INTENCLR_ERROR_Pos     7                                              /**< (SERCOM_USART_INTENCLR) Combined Error Interrupt Disable Position */
+#define SERCOM_USART_INTENCLR_ERROR_Msk     (_U_(0x1) << SERCOM_USART_INTENCLR_ERROR_Pos)  /**< (SERCOM_USART_INTENCLR) Combined Error Interrupt Disable Mask */
+#define SERCOM_USART_INTENCLR_ERROR         SERCOM_USART_INTENCLR_ERROR_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_INTENCLR_ERROR_Msk instead */
+#define SERCOM_USART_INTENCLR_MASK          _U_(0xBF)                                      /**< \deprecated (SERCOM_USART_INTENCLR) Register MASK  (Use SERCOM_USART_INTENCLR_Msk instead)  */
+#define SERCOM_USART_INTENCLR_Msk           _U_(0xBF)                                      /**< (SERCOM_USART_INTENCLR) Register Mask  */
+
+
+/* -------- SERCOM_I2CM_INTENSET : (SERCOM Offset: 0x16) (R/W 8) I2CM Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  MB:1;                      /**< bit:      0  Master On Bus Interrupt Enable           */
+    uint8_t  SB:1;                      /**< bit:      1  Slave On Bus Interrupt Enable            */
+    uint8_t  :5;                        /**< bit:   2..6  Reserved */
+    uint8_t  ERROR:1;                   /**< bit:      7  Combined Error Interrupt Enable          */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} SERCOM_I2CM_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_INTENSET_OFFSET         (0x16)                                        /**<  (SERCOM_I2CM_INTENSET) I2CM Interrupt Enable Set  Offset */
+#define SERCOM_I2CM_INTENSET_RESETVALUE     _U_(0x00)                                     /**<  (SERCOM_I2CM_INTENSET) I2CM Interrupt Enable Set  Reset Value */
+
+#define SERCOM_I2CM_INTENSET_MB_Pos         0                                              /**< (SERCOM_I2CM_INTENSET) Master On Bus Interrupt Enable Position */
+#define SERCOM_I2CM_INTENSET_MB_Msk         (_U_(0x1) << SERCOM_I2CM_INTENSET_MB_Pos)      /**< (SERCOM_I2CM_INTENSET) Master On Bus Interrupt Enable Mask */
+#define SERCOM_I2CM_INTENSET_MB             SERCOM_I2CM_INTENSET_MB_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_INTENSET_MB_Msk instead */
+#define SERCOM_I2CM_INTENSET_SB_Pos         1                                              /**< (SERCOM_I2CM_INTENSET) Slave On Bus Interrupt Enable Position */
+#define SERCOM_I2CM_INTENSET_SB_Msk         (_U_(0x1) << SERCOM_I2CM_INTENSET_SB_Pos)      /**< (SERCOM_I2CM_INTENSET) Slave On Bus Interrupt Enable Mask */
+#define SERCOM_I2CM_INTENSET_SB             SERCOM_I2CM_INTENSET_SB_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_INTENSET_SB_Msk instead */
+#define SERCOM_I2CM_INTENSET_ERROR_Pos      7                                              /**< (SERCOM_I2CM_INTENSET) Combined Error Interrupt Enable Position */
+#define SERCOM_I2CM_INTENSET_ERROR_Msk      (_U_(0x1) << SERCOM_I2CM_INTENSET_ERROR_Pos)   /**< (SERCOM_I2CM_INTENSET) Combined Error Interrupt Enable Mask */
+#define SERCOM_I2CM_INTENSET_ERROR          SERCOM_I2CM_INTENSET_ERROR_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_INTENSET_ERROR_Msk instead */
+#define SERCOM_I2CM_INTENSET_MASK           _U_(0x83)                                      /**< \deprecated (SERCOM_I2CM_INTENSET) Register MASK  (Use SERCOM_I2CM_INTENSET_Msk instead)  */
+#define SERCOM_I2CM_INTENSET_Msk            _U_(0x83)                                      /**< (SERCOM_I2CM_INTENSET) Register Mask  */
+
+
+/* -------- SERCOM_I2CS_INTENSET : (SERCOM Offset: 0x16) (R/W 8) I2CS Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  PREC:1;                    /**< bit:      0  Stop Received Interrupt Enable           */
+    uint8_t  AMATCH:1;                  /**< bit:      1  Address Match Interrupt Enable           */
+    uint8_t  DRDY:1;                    /**< bit:      2  Data Interrupt Enable                    */
+    uint8_t  :4;                        /**< bit:   3..6  Reserved */
+    uint8_t  ERROR:1;                   /**< bit:      7  Combined Error Interrupt Enable          */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} SERCOM_I2CS_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CS_INTENSET_OFFSET         (0x16)                                        /**<  (SERCOM_I2CS_INTENSET) I2CS Interrupt Enable Set  Offset */
+#define SERCOM_I2CS_INTENSET_RESETVALUE     _U_(0x00)                                     /**<  (SERCOM_I2CS_INTENSET) I2CS Interrupt Enable Set  Reset Value */
+
+#define SERCOM_I2CS_INTENSET_PREC_Pos       0                                              /**< (SERCOM_I2CS_INTENSET) Stop Received Interrupt Enable Position */
+#define SERCOM_I2CS_INTENSET_PREC_Msk       (_U_(0x1) << SERCOM_I2CS_INTENSET_PREC_Pos)    /**< (SERCOM_I2CS_INTENSET) Stop Received Interrupt Enable Mask */
+#define SERCOM_I2CS_INTENSET_PREC           SERCOM_I2CS_INTENSET_PREC_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_INTENSET_PREC_Msk instead */
+#define SERCOM_I2CS_INTENSET_AMATCH_Pos     1                                              /**< (SERCOM_I2CS_INTENSET) Address Match Interrupt Enable Position */
+#define SERCOM_I2CS_INTENSET_AMATCH_Msk     (_U_(0x1) << SERCOM_I2CS_INTENSET_AMATCH_Pos)  /**< (SERCOM_I2CS_INTENSET) Address Match Interrupt Enable Mask */
+#define SERCOM_I2CS_INTENSET_AMATCH         SERCOM_I2CS_INTENSET_AMATCH_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_INTENSET_AMATCH_Msk instead */
+#define SERCOM_I2CS_INTENSET_DRDY_Pos       2                                              /**< (SERCOM_I2CS_INTENSET) Data Interrupt Enable Position */
+#define SERCOM_I2CS_INTENSET_DRDY_Msk       (_U_(0x1) << SERCOM_I2CS_INTENSET_DRDY_Pos)    /**< (SERCOM_I2CS_INTENSET) Data Interrupt Enable Mask */
+#define SERCOM_I2CS_INTENSET_DRDY           SERCOM_I2CS_INTENSET_DRDY_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_INTENSET_DRDY_Msk instead */
+#define SERCOM_I2CS_INTENSET_ERROR_Pos      7                                              /**< (SERCOM_I2CS_INTENSET) Combined Error Interrupt Enable Position */
+#define SERCOM_I2CS_INTENSET_ERROR_Msk      (_U_(0x1) << SERCOM_I2CS_INTENSET_ERROR_Pos)   /**< (SERCOM_I2CS_INTENSET) Combined Error Interrupt Enable Mask */
+#define SERCOM_I2CS_INTENSET_ERROR          SERCOM_I2CS_INTENSET_ERROR_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_INTENSET_ERROR_Msk instead */
+#define SERCOM_I2CS_INTENSET_MASK           _U_(0x87)                                      /**< \deprecated (SERCOM_I2CS_INTENSET) Register MASK  (Use SERCOM_I2CS_INTENSET_Msk instead)  */
+#define SERCOM_I2CS_INTENSET_Msk            _U_(0x87)                                      /**< (SERCOM_I2CS_INTENSET) Register Mask  */
+
+
+/* -------- SERCOM_SPI_INTENSET : (SERCOM Offset: 0x16) (R/W 8) SPI Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DRE:1;                     /**< bit:      0  Data Register Empty Interrupt Enable     */
+    uint8_t  TXC:1;                     /**< bit:      1  Transmit Complete Interrupt Enable       */
+    uint8_t  RXC:1;                     /**< bit:      2  Receive Complete Interrupt Enable        */
+    uint8_t  SSL:1;                     /**< bit:      3  Slave Select Low Interrupt Enable        */
+    uint8_t  :3;                        /**< bit:   4..6  Reserved */
+    uint8_t  ERROR:1;                   /**< bit:      7  Combined Error Interrupt Enable          */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} SERCOM_SPI_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_INTENSET_OFFSET          (0x16)                                        /**<  (SERCOM_SPI_INTENSET) SPI Interrupt Enable Set  Offset */
+#define SERCOM_SPI_INTENSET_RESETVALUE      _U_(0x00)                                     /**<  (SERCOM_SPI_INTENSET) SPI Interrupt Enable Set  Reset Value */
+
+#define SERCOM_SPI_INTENSET_DRE_Pos         0                                              /**< (SERCOM_SPI_INTENSET) Data Register Empty Interrupt Enable Position */
+#define SERCOM_SPI_INTENSET_DRE_Msk         (_U_(0x1) << SERCOM_SPI_INTENSET_DRE_Pos)      /**< (SERCOM_SPI_INTENSET) Data Register Empty Interrupt Enable Mask */
+#define SERCOM_SPI_INTENSET_DRE             SERCOM_SPI_INTENSET_DRE_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_INTENSET_DRE_Msk instead */
+#define SERCOM_SPI_INTENSET_TXC_Pos         1                                              /**< (SERCOM_SPI_INTENSET) Transmit Complete Interrupt Enable Position */
+#define SERCOM_SPI_INTENSET_TXC_Msk         (_U_(0x1) << SERCOM_SPI_INTENSET_TXC_Pos)      /**< (SERCOM_SPI_INTENSET) Transmit Complete Interrupt Enable Mask */
+#define SERCOM_SPI_INTENSET_TXC             SERCOM_SPI_INTENSET_TXC_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_INTENSET_TXC_Msk instead */
+#define SERCOM_SPI_INTENSET_RXC_Pos         2                                              /**< (SERCOM_SPI_INTENSET) Receive Complete Interrupt Enable Position */
+#define SERCOM_SPI_INTENSET_RXC_Msk         (_U_(0x1) << SERCOM_SPI_INTENSET_RXC_Pos)      /**< (SERCOM_SPI_INTENSET) Receive Complete Interrupt Enable Mask */
+#define SERCOM_SPI_INTENSET_RXC             SERCOM_SPI_INTENSET_RXC_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_INTENSET_RXC_Msk instead */
+#define SERCOM_SPI_INTENSET_SSL_Pos         3                                              /**< (SERCOM_SPI_INTENSET) Slave Select Low Interrupt Enable Position */
+#define SERCOM_SPI_INTENSET_SSL_Msk         (_U_(0x1) << SERCOM_SPI_INTENSET_SSL_Pos)      /**< (SERCOM_SPI_INTENSET) Slave Select Low Interrupt Enable Mask */
+#define SERCOM_SPI_INTENSET_SSL             SERCOM_SPI_INTENSET_SSL_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_INTENSET_SSL_Msk instead */
+#define SERCOM_SPI_INTENSET_ERROR_Pos       7                                              /**< (SERCOM_SPI_INTENSET) Combined Error Interrupt Enable Position */
+#define SERCOM_SPI_INTENSET_ERROR_Msk       (_U_(0x1) << SERCOM_SPI_INTENSET_ERROR_Pos)    /**< (SERCOM_SPI_INTENSET) Combined Error Interrupt Enable Mask */
+#define SERCOM_SPI_INTENSET_ERROR           SERCOM_SPI_INTENSET_ERROR_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_INTENSET_ERROR_Msk instead */
+#define SERCOM_SPI_INTENSET_MASK            _U_(0x8F)                                      /**< \deprecated (SERCOM_SPI_INTENSET) Register MASK  (Use SERCOM_SPI_INTENSET_Msk instead)  */
+#define SERCOM_SPI_INTENSET_Msk             _U_(0x8F)                                      /**< (SERCOM_SPI_INTENSET) Register Mask  */
+
+
+/* -------- SERCOM_USART_INTENSET : (SERCOM Offset: 0x16) (R/W 8) USART Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DRE:1;                     /**< bit:      0  Data Register Empty Interrupt Enable     */
+    uint8_t  TXC:1;                     /**< bit:      1  Transmit Complete Interrupt Enable       */
+    uint8_t  RXC:1;                     /**< bit:      2  Receive Complete Interrupt Enable        */
+    uint8_t  RXS:1;                     /**< bit:      3  Receive Start Interrupt Enable           */
+    uint8_t  CTSIC:1;                   /**< bit:      4  Clear To Send Input Change Interrupt Enable */
+    uint8_t  RXBRK:1;                   /**< bit:      5  Break Received Interrupt Enable          */
+    uint8_t  :1;                        /**< bit:      6  Reserved */
+    uint8_t  ERROR:1;                   /**< bit:      7  Combined Error Interrupt Enable          */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} SERCOM_USART_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_INTENSET_OFFSET        (0x16)                                        /**<  (SERCOM_USART_INTENSET) USART Interrupt Enable Set  Offset */
+#define SERCOM_USART_INTENSET_RESETVALUE    _U_(0x00)                                     /**<  (SERCOM_USART_INTENSET) USART Interrupt Enable Set  Reset Value */
+
+#define SERCOM_USART_INTENSET_DRE_Pos       0                                              /**< (SERCOM_USART_INTENSET) Data Register Empty Interrupt Enable Position */
+#define SERCOM_USART_INTENSET_DRE_Msk       (_U_(0x1) << SERCOM_USART_INTENSET_DRE_Pos)    /**< (SERCOM_USART_INTENSET) Data Register Empty Interrupt Enable Mask */
+#define SERCOM_USART_INTENSET_DRE           SERCOM_USART_INTENSET_DRE_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_INTENSET_DRE_Msk instead */
+#define SERCOM_USART_INTENSET_TXC_Pos       1                                              /**< (SERCOM_USART_INTENSET) Transmit Complete Interrupt Enable Position */
+#define SERCOM_USART_INTENSET_TXC_Msk       (_U_(0x1) << SERCOM_USART_INTENSET_TXC_Pos)    /**< (SERCOM_USART_INTENSET) Transmit Complete Interrupt Enable Mask */
+#define SERCOM_USART_INTENSET_TXC           SERCOM_USART_INTENSET_TXC_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_INTENSET_TXC_Msk instead */
+#define SERCOM_USART_INTENSET_RXC_Pos       2                                              /**< (SERCOM_USART_INTENSET) Receive Complete Interrupt Enable Position */
+#define SERCOM_USART_INTENSET_RXC_Msk       (_U_(0x1) << SERCOM_USART_INTENSET_RXC_Pos)    /**< (SERCOM_USART_INTENSET) Receive Complete Interrupt Enable Mask */
+#define SERCOM_USART_INTENSET_RXC           SERCOM_USART_INTENSET_RXC_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_INTENSET_RXC_Msk instead */
+#define SERCOM_USART_INTENSET_RXS_Pos       3                                              /**< (SERCOM_USART_INTENSET) Receive Start Interrupt Enable Position */
+#define SERCOM_USART_INTENSET_RXS_Msk       (_U_(0x1) << SERCOM_USART_INTENSET_RXS_Pos)    /**< (SERCOM_USART_INTENSET) Receive Start Interrupt Enable Mask */
+#define SERCOM_USART_INTENSET_RXS           SERCOM_USART_INTENSET_RXS_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_INTENSET_RXS_Msk instead */
+#define SERCOM_USART_INTENSET_CTSIC_Pos     4                                              /**< (SERCOM_USART_INTENSET) Clear To Send Input Change Interrupt Enable Position */
+#define SERCOM_USART_INTENSET_CTSIC_Msk     (_U_(0x1) << SERCOM_USART_INTENSET_CTSIC_Pos)  /**< (SERCOM_USART_INTENSET) Clear To Send Input Change Interrupt Enable Mask */
+#define SERCOM_USART_INTENSET_CTSIC         SERCOM_USART_INTENSET_CTSIC_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_INTENSET_CTSIC_Msk instead */
+#define SERCOM_USART_INTENSET_RXBRK_Pos     5                                              /**< (SERCOM_USART_INTENSET) Break Received Interrupt Enable Position */
+#define SERCOM_USART_INTENSET_RXBRK_Msk     (_U_(0x1) << SERCOM_USART_INTENSET_RXBRK_Pos)  /**< (SERCOM_USART_INTENSET) Break Received Interrupt Enable Mask */
+#define SERCOM_USART_INTENSET_RXBRK         SERCOM_USART_INTENSET_RXBRK_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_INTENSET_RXBRK_Msk instead */
+#define SERCOM_USART_INTENSET_ERROR_Pos     7                                              /**< (SERCOM_USART_INTENSET) Combined Error Interrupt Enable Position */
+#define SERCOM_USART_INTENSET_ERROR_Msk     (_U_(0x1) << SERCOM_USART_INTENSET_ERROR_Pos)  /**< (SERCOM_USART_INTENSET) Combined Error Interrupt Enable Mask */
+#define SERCOM_USART_INTENSET_ERROR         SERCOM_USART_INTENSET_ERROR_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_INTENSET_ERROR_Msk instead */
+#define SERCOM_USART_INTENSET_MASK          _U_(0xBF)                                      /**< \deprecated (SERCOM_USART_INTENSET) Register MASK  (Use SERCOM_USART_INTENSET_Msk instead)  */
+#define SERCOM_USART_INTENSET_Msk           _U_(0xBF)                                      /**< (SERCOM_USART_INTENSET) Register Mask  */
+
+
+/* -------- SERCOM_I2CM_INTFLAG : (SERCOM Offset: 0x18) (R/W 8) I2CM Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t MB:1;                      /**< bit:      0  Master On Bus Interrupt                  */
+    __I uint8_t SB:1;                      /**< bit:      1  Slave On Bus Interrupt                   */
+    __I uint8_t :5;                        /**< bit:   2..6  Reserved */
+    __I uint8_t ERROR:1;                   /**< bit:      7  Combined Error Interrupt                 */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} SERCOM_I2CM_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_INTFLAG_OFFSET          (0x18)                                        /**<  (SERCOM_I2CM_INTFLAG) I2CM Interrupt Flag Status and Clear  Offset */
+#define SERCOM_I2CM_INTFLAG_RESETVALUE      _U_(0x00)                                     /**<  (SERCOM_I2CM_INTFLAG) I2CM Interrupt Flag Status and Clear  Reset Value */
+
+#define SERCOM_I2CM_INTFLAG_MB_Pos          0                                              /**< (SERCOM_I2CM_INTFLAG) Master On Bus Interrupt Position */
+#define SERCOM_I2CM_INTFLAG_MB_Msk          (_U_(0x1) << SERCOM_I2CM_INTFLAG_MB_Pos)       /**< (SERCOM_I2CM_INTFLAG) Master On Bus Interrupt Mask */
+#define SERCOM_I2CM_INTFLAG_MB              SERCOM_I2CM_INTFLAG_MB_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_INTFLAG_MB_Msk instead */
+#define SERCOM_I2CM_INTFLAG_SB_Pos          1                                              /**< (SERCOM_I2CM_INTFLAG) Slave On Bus Interrupt Position */
+#define SERCOM_I2CM_INTFLAG_SB_Msk          (_U_(0x1) << SERCOM_I2CM_INTFLAG_SB_Pos)       /**< (SERCOM_I2CM_INTFLAG) Slave On Bus Interrupt Mask */
+#define SERCOM_I2CM_INTFLAG_SB              SERCOM_I2CM_INTFLAG_SB_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_INTFLAG_SB_Msk instead */
+#define SERCOM_I2CM_INTFLAG_ERROR_Pos       7                                              /**< (SERCOM_I2CM_INTFLAG) Combined Error Interrupt Position */
+#define SERCOM_I2CM_INTFLAG_ERROR_Msk       (_U_(0x1) << SERCOM_I2CM_INTFLAG_ERROR_Pos)    /**< (SERCOM_I2CM_INTFLAG) Combined Error Interrupt Mask */
+#define SERCOM_I2CM_INTFLAG_ERROR           SERCOM_I2CM_INTFLAG_ERROR_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_INTFLAG_ERROR_Msk instead */
+#define SERCOM_I2CM_INTFLAG_MASK            _U_(0x83)                                      /**< \deprecated (SERCOM_I2CM_INTFLAG) Register MASK  (Use SERCOM_I2CM_INTFLAG_Msk instead)  */
+#define SERCOM_I2CM_INTFLAG_Msk             _U_(0x83)                                      /**< (SERCOM_I2CM_INTFLAG) Register Mask  */
+
+
+/* -------- SERCOM_I2CS_INTFLAG : (SERCOM Offset: 0x18) (R/W 8) I2CS Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t PREC:1;                    /**< bit:      0  Stop Received Interrupt                  */
+    __I uint8_t AMATCH:1;                  /**< bit:      1  Address Match Interrupt                  */
+    __I uint8_t DRDY:1;                    /**< bit:      2  Data Interrupt                           */
+    __I uint8_t :4;                        /**< bit:   3..6  Reserved */
+    __I uint8_t ERROR:1;                   /**< bit:      7  Combined Error Interrupt                 */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} SERCOM_I2CS_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CS_INTFLAG_OFFSET          (0x18)                                        /**<  (SERCOM_I2CS_INTFLAG) I2CS Interrupt Flag Status and Clear  Offset */
+#define SERCOM_I2CS_INTFLAG_RESETVALUE      _U_(0x00)                                     /**<  (SERCOM_I2CS_INTFLAG) I2CS Interrupt Flag Status and Clear  Reset Value */
+
+#define SERCOM_I2CS_INTFLAG_PREC_Pos        0                                              /**< (SERCOM_I2CS_INTFLAG) Stop Received Interrupt Position */
+#define SERCOM_I2CS_INTFLAG_PREC_Msk        (_U_(0x1) << SERCOM_I2CS_INTFLAG_PREC_Pos)     /**< (SERCOM_I2CS_INTFLAG) Stop Received Interrupt Mask */
+#define SERCOM_I2CS_INTFLAG_PREC            SERCOM_I2CS_INTFLAG_PREC_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_INTFLAG_PREC_Msk instead */
+#define SERCOM_I2CS_INTFLAG_AMATCH_Pos      1                                              /**< (SERCOM_I2CS_INTFLAG) Address Match Interrupt Position */
+#define SERCOM_I2CS_INTFLAG_AMATCH_Msk      (_U_(0x1) << SERCOM_I2CS_INTFLAG_AMATCH_Pos)   /**< (SERCOM_I2CS_INTFLAG) Address Match Interrupt Mask */
+#define SERCOM_I2CS_INTFLAG_AMATCH          SERCOM_I2CS_INTFLAG_AMATCH_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_INTFLAG_AMATCH_Msk instead */
+#define SERCOM_I2CS_INTFLAG_DRDY_Pos        2                                              /**< (SERCOM_I2CS_INTFLAG) Data Interrupt Position */
+#define SERCOM_I2CS_INTFLAG_DRDY_Msk        (_U_(0x1) << SERCOM_I2CS_INTFLAG_DRDY_Pos)     /**< (SERCOM_I2CS_INTFLAG) Data Interrupt Mask */
+#define SERCOM_I2CS_INTFLAG_DRDY            SERCOM_I2CS_INTFLAG_DRDY_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_INTFLAG_DRDY_Msk instead */
+#define SERCOM_I2CS_INTFLAG_ERROR_Pos       7                                              /**< (SERCOM_I2CS_INTFLAG) Combined Error Interrupt Position */
+#define SERCOM_I2CS_INTFLAG_ERROR_Msk       (_U_(0x1) << SERCOM_I2CS_INTFLAG_ERROR_Pos)    /**< (SERCOM_I2CS_INTFLAG) Combined Error Interrupt Mask */
+#define SERCOM_I2CS_INTFLAG_ERROR           SERCOM_I2CS_INTFLAG_ERROR_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_INTFLAG_ERROR_Msk instead */
+#define SERCOM_I2CS_INTFLAG_MASK            _U_(0x87)                                      /**< \deprecated (SERCOM_I2CS_INTFLAG) Register MASK  (Use SERCOM_I2CS_INTFLAG_Msk instead)  */
+#define SERCOM_I2CS_INTFLAG_Msk             _U_(0x87)                                      /**< (SERCOM_I2CS_INTFLAG) Register Mask  */
+
+
+/* -------- SERCOM_SPI_INTFLAG : (SERCOM Offset: 0x18) (R/W 8) SPI Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t DRE:1;                     /**< bit:      0  Data Register Empty Interrupt            */
+    __I uint8_t TXC:1;                     /**< bit:      1  Transmit Complete Interrupt              */
+    __I uint8_t RXC:1;                     /**< bit:      2  Receive Complete Interrupt               */
+    __I uint8_t SSL:1;                     /**< bit:      3  Slave Select Low Interrupt Flag          */
+    __I uint8_t :3;                        /**< bit:   4..6  Reserved */
+    __I uint8_t ERROR:1;                   /**< bit:      7  Combined Error Interrupt                 */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} SERCOM_SPI_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_INTFLAG_OFFSET           (0x18)                                        /**<  (SERCOM_SPI_INTFLAG) SPI Interrupt Flag Status and Clear  Offset */
+#define SERCOM_SPI_INTFLAG_RESETVALUE       _U_(0x00)                                     /**<  (SERCOM_SPI_INTFLAG) SPI Interrupt Flag Status and Clear  Reset Value */
+
+#define SERCOM_SPI_INTFLAG_DRE_Pos          0                                              /**< (SERCOM_SPI_INTFLAG) Data Register Empty Interrupt Position */
+#define SERCOM_SPI_INTFLAG_DRE_Msk          (_U_(0x1) << SERCOM_SPI_INTFLAG_DRE_Pos)       /**< (SERCOM_SPI_INTFLAG) Data Register Empty Interrupt Mask */
+#define SERCOM_SPI_INTFLAG_DRE              SERCOM_SPI_INTFLAG_DRE_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_INTFLAG_DRE_Msk instead */
+#define SERCOM_SPI_INTFLAG_TXC_Pos          1                                              /**< (SERCOM_SPI_INTFLAG) Transmit Complete Interrupt Position */
+#define SERCOM_SPI_INTFLAG_TXC_Msk          (_U_(0x1) << SERCOM_SPI_INTFLAG_TXC_Pos)       /**< (SERCOM_SPI_INTFLAG) Transmit Complete Interrupt Mask */
+#define SERCOM_SPI_INTFLAG_TXC              SERCOM_SPI_INTFLAG_TXC_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_INTFLAG_TXC_Msk instead */
+#define SERCOM_SPI_INTFLAG_RXC_Pos          2                                              /**< (SERCOM_SPI_INTFLAG) Receive Complete Interrupt Position */
+#define SERCOM_SPI_INTFLAG_RXC_Msk          (_U_(0x1) << SERCOM_SPI_INTFLAG_RXC_Pos)       /**< (SERCOM_SPI_INTFLAG) Receive Complete Interrupt Mask */
+#define SERCOM_SPI_INTFLAG_RXC              SERCOM_SPI_INTFLAG_RXC_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_INTFLAG_RXC_Msk instead */
+#define SERCOM_SPI_INTFLAG_SSL_Pos          3                                              /**< (SERCOM_SPI_INTFLAG) Slave Select Low Interrupt Flag Position */
+#define SERCOM_SPI_INTFLAG_SSL_Msk          (_U_(0x1) << SERCOM_SPI_INTFLAG_SSL_Pos)       /**< (SERCOM_SPI_INTFLAG) Slave Select Low Interrupt Flag Mask */
+#define SERCOM_SPI_INTFLAG_SSL              SERCOM_SPI_INTFLAG_SSL_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_INTFLAG_SSL_Msk instead */
+#define SERCOM_SPI_INTFLAG_ERROR_Pos        7                                              /**< (SERCOM_SPI_INTFLAG) Combined Error Interrupt Position */
+#define SERCOM_SPI_INTFLAG_ERROR_Msk        (_U_(0x1) << SERCOM_SPI_INTFLAG_ERROR_Pos)     /**< (SERCOM_SPI_INTFLAG) Combined Error Interrupt Mask */
+#define SERCOM_SPI_INTFLAG_ERROR            SERCOM_SPI_INTFLAG_ERROR_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_INTFLAG_ERROR_Msk instead */
+#define SERCOM_SPI_INTFLAG_MASK             _U_(0x8F)                                      /**< \deprecated (SERCOM_SPI_INTFLAG) Register MASK  (Use SERCOM_SPI_INTFLAG_Msk instead)  */
+#define SERCOM_SPI_INTFLAG_Msk              _U_(0x8F)                                      /**< (SERCOM_SPI_INTFLAG) Register Mask  */
+
+
+/* -------- SERCOM_USART_INTFLAG : (SERCOM Offset: 0x18) (R/W 8) USART Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t DRE:1;                     /**< bit:      0  Data Register Empty Interrupt            */
+    __I uint8_t TXC:1;                     /**< bit:      1  Transmit Complete Interrupt              */
+    __I uint8_t RXC:1;                     /**< bit:      2  Receive Complete Interrupt               */
+    __I uint8_t RXS:1;                     /**< bit:      3  Receive Start Interrupt                  */
+    __I uint8_t CTSIC:1;                   /**< bit:      4  Clear To Send Input Change Interrupt     */
+    __I uint8_t RXBRK:1;                   /**< bit:      5  Break Received Interrupt                 */
+    __I uint8_t :1;                        /**< bit:      6  Reserved */
+    __I uint8_t ERROR:1;                   /**< bit:      7  Combined Error Interrupt                 */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} SERCOM_USART_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_INTFLAG_OFFSET         (0x18)                                        /**<  (SERCOM_USART_INTFLAG) USART Interrupt Flag Status and Clear  Offset */
+#define SERCOM_USART_INTFLAG_RESETVALUE     _U_(0x00)                                     /**<  (SERCOM_USART_INTFLAG) USART Interrupt Flag Status and Clear  Reset Value */
+
+#define SERCOM_USART_INTFLAG_DRE_Pos        0                                              /**< (SERCOM_USART_INTFLAG) Data Register Empty Interrupt Position */
+#define SERCOM_USART_INTFLAG_DRE_Msk        (_U_(0x1) << SERCOM_USART_INTFLAG_DRE_Pos)     /**< (SERCOM_USART_INTFLAG) Data Register Empty Interrupt Mask */
+#define SERCOM_USART_INTFLAG_DRE            SERCOM_USART_INTFLAG_DRE_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_INTFLAG_DRE_Msk instead */
+#define SERCOM_USART_INTFLAG_TXC_Pos        1                                              /**< (SERCOM_USART_INTFLAG) Transmit Complete Interrupt Position */
+#define SERCOM_USART_INTFLAG_TXC_Msk        (_U_(0x1) << SERCOM_USART_INTFLAG_TXC_Pos)     /**< (SERCOM_USART_INTFLAG) Transmit Complete Interrupt Mask */
+#define SERCOM_USART_INTFLAG_TXC            SERCOM_USART_INTFLAG_TXC_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_INTFLAG_TXC_Msk instead */
+#define SERCOM_USART_INTFLAG_RXC_Pos        2                                              /**< (SERCOM_USART_INTFLAG) Receive Complete Interrupt Position */
+#define SERCOM_USART_INTFLAG_RXC_Msk        (_U_(0x1) << SERCOM_USART_INTFLAG_RXC_Pos)     /**< (SERCOM_USART_INTFLAG) Receive Complete Interrupt Mask */
+#define SERCOM_USART_INTFLAG_RXC            SERCOM_USART_INTFLAG_RXC_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_INTFLAG_RXC_Msk instead */
+#define SERCOM_USART_INTFLAG_RXS_Pos        3                                              /**< (SERCOM_USART_INTFLAG) Receive Start Interrupt Position */
+#define SERCOM_USART_INTFLAG_RXS_Msk        (_U_(0x1) << SERCOM_USART_INTFLAG_RXS_Pos)     /**< (SERCOM_USART_INTFLAG) Receive Start Interrupt Mask */
+#define SERCOM_USART_INTFLAG_RXS            SERCOM_USART_INTFLAG_RXS_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_INTFLAG_RXS_Msk instead */
+#define SERCOM_USART_INTFLAG_CTSIC_Pos      4                                              /**< (SERCOM_USART_INTFLAG) Clear To Send Input Change Interrupt Position */
+#define SERCOM_USART_INTFLAG_CTSIC_Msk      (_U_(0x1) << SERCOM_USART_INTFLAG_CTSIC_Pos)   /**< (SERCOM_USART_INTFLAG) Clear To Send Input Change Interrupt Mask */
+#define SERCOM_USART_INTFLAG_CTSIC          SERCOM_USART_INTFLAG_CTSIC_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_INTFLAG_CTSIC_Msk instead */
+#define SERCOM_USART_INTFLAG_RXBRK_Pos      5                                              /**< (SERCOM_USART_INTFLAG) Break Received Interrupt Position */
+#define SERCOM_USART_INTFLAG_RXBRK_Msk      (_U_(0x1) << SERCOM_USART_INTFLAG_RXBRK_Pos)   /**< (SERCOM_USART_INTFLAG) Break Received Interrupt Mask */
+#define SERCOM_USART_INTFLAG_RXBRK          SERCOM_USART_INTFLAG_RXBRK_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_INTFLAG_RXBRK_Msk instead */
+#define SERCOM_USART_INTFLAG_ERROR_Pos      7                                              /**< (SERCOM_USART_INTFLAG) Combined Error Interrupt Position */
+#define SERCOM_USART_INTFLAG_ERROR_Msk      (_U_(0x1) << SERCOM_USART_INTFLAG_ERROR_Pos)   /**< (SERCOM_USART_INTFLAG) Combined Error Interrupt Mask */
+#define SERCOM_USART_INTFLAG_ERROR          SERCOM_USART_INTFLAG_ERROR_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_INTFLAG_ERROR_Msk instead */
+#define SERCOM_USART_INTFLAG_MASK           _U_(0xBF)                                      /**< \deprecated (SERCOM_USART_INTFLAG) Register MASK  (Use SERCOM_USART_INTFLAG_Msk instead)  */
+#define SERCOM_USART_INTFLAG_Msk            _U_(0xBF)                                      /**< (SERCOM_USART_INTFLAG) Register Mask  */
+
+
+/* -------- SERCOM_I2CM_STATUS : (SERCOM Offset: 0x1a) (R/W 16) I2CM Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t BUSERR:1;                  /**< bit:      0  Bus Error                                */
+    uint16_t ARBLOST:1;                 /**< bit:      1  Arbitration Lost                         */
+    uint16_t RXNACK:1;                  /**< bit:      2  Received Not Acknowledge                 */
+    uint16_t :1;                        /**< bit:      3  Reserved */
+    uint16_t BUSSTATE:2;                /**< bit:   4..5  Bus State                                */
+    uint16_t LOWTOUT:1;                 /**< bit:      6  SCL Low Timeout                          */
+    uint16_t CLKHOLD:1;                 /**< bit:      7  Clock Hold                               */
+    uint16_t MEXTTOUT:1;                /**< bit:      8  Master SCL Low Extend Timeout            */
+    uint16_t SEXTTOUT:1;                /**< bit:      9  Slave SCL Low Extend Timeout             */
+    uint16_t LENERR:1;                  /**< bit:     10  Length Error                             */
+    uint16_t :5;                        /**< bit: 11..15  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} SERCOM_I2CM_STATUS_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_STATUS_OFFSET           (0x1A)                                        /**<  (SERCOM_I2CM_STATUS) I2CM Status  Offset */
+#define SERCOM_I2CM_STATUS_RESETVALUE       _U_(0x00)                                     /**<  (SERCOM_I2CM_STATUS) I2CM Status  Reset Value */
+
+#define SERCOM_I2CM_STATUS_BUSERR_Pos       0                                              /**< (SERCOM_I2CM_STATUS) Bus Error Position */
+#define SERCOM_I2CM_STATUS_BUSERR_Msk       (_U_(0x1) << SERCOM_I2CM_STATUS_BUSERR_Pos)    /**< (SERCOM_I2CM_STATUS) Bus Error Mask */
+#define SERCOM_I2CM_STATUS_BUSERR           SERCOM_I2CM_STATUS_BUSERR_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_STATUS_BUSERR_Msk instead */
+#define SERCOM_I2CM_STATUS_ARBLOST_Pos      1                                              /**< (SERCOM_I2CM_STATUS) Arbitration Lost Position */
+#define SERCOM_I2CM_STATUS_ARBLOST_Msk      (_U_(0x1) << SERCOM_I2CM_STATUS_ARBLOST_Pos)   /**< (SERCOM_I2CM_STATUS) Arbitration Lost Mask */
+#define SERCOM_I2CM_STATUS_ARBLOST          SERCOM_I2CM_STATUS_ARBLOST_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_STATUS_ARBLOST_Msk instead */
+#define SERCOM_I2CM_STATUS_RXNACK_Pos       2                                              /**< (SERCOM_I2CM_STATUS) Received Not Acknowledge Position */
+#define SERCOM_I2CM_STATUS_RXNACK_Msk       (_U_(0x1) << SERCOM_I2CM_STATUS_RXNACK_Pos)    /**< (SERCOM_I2CM_STATUS) Received Not Acknowledge Mask */
+#define SERCOM_I2CM_STATUS_RXNACK           SERCOM_I2CM_STATUS_RXNACK_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_STATUS_RXNACK_Msk instead */
+#define SERCOM_I2CM_STATUS_BUSSTATE_Pos     4                                              /**< (SERCOM_I2CM_STATUS) Bus State Position */
+#define SERCOM_I2CM_STATUS_BUSSTATE_Msk     (_U_(0x3) << SERCOM_I2CM_STATUS_BUSSTATE_Pos)  /**< (SERCOM_I2CM_STATUS) Bus State Mask */
+#define SERCOM_I2CM_STATUS_BUSSTATE(value)  (SERCOM_I2CM_STATUS_BUSSTATE_Msk & ((value) << SERCOM_I2CM_STATUS_BUSSTATE_Pos))
+#define SERCOM_I2CM_STATUS_LOWTOUT_Pos      6                                              /**< (SERCOM_I2CM_STATUS) SCL Low Timeout Position */
+#define SERCOM_I2CM_STATUS_LOWTOUT_Msk      (_U_(0x1) << SERCOM_I2CM_STATUS_LOWTOUT_Pos)   /**< (SERCOM_I2CM_STATUS) SCL Low Timeout Mask */
+#define SERCOM_I2CM_STATUS_LOWTOUT          SERCOM_I2CM_STATUS_LOWTOUT_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_STATUS_LOWTOUT_Msk instead */
+#define SERCOM_I2CM_STATUS_CLKHOLD_Pos      7                                              /**< (SERCOM_I2CM_STATUS) Clock Hold Position */
+#define SERCOM_I2CM_STATUS_CLKHOLD_Msk      (_U_(0x1) << SERCOM_I2CM_STATUS_CLKHOLD_Pos)   /**< (SERCOM_I2CM_STATUS) Clock Hold Mask */
+#define SERCOM_I2CM_STATUS_CLKHOLD          SERCOM_I2CM_STATUS_CLKHOLD_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_STATUS_CLKHOLD_Msk instead */
+#define SERCOM_I2CM_STATUS_MEXTTOUT_Pos     8                                              /**< (SERCOM_I2CM_STATUS) Master SCL Low Extend Timeout Position */
+#define SERCOM_I2CM_STATUS_MEXTTOUT_Msk     (_U_(0x1) << SERCOM_I2CM_STATUS_MEXTTOUT_Pos)  /**< (SERCOM_I2CM_STATUS) Master SCL Low Extend Timeout Mask */
+#define SERCOM_I2CM_STATUS_MEXTTOUT         SERCOM_I2CM_STATUS_MEXTTOUT_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_STATUS_MEXTTOUT_Msk instead */
+#define SERCOM_I2CM_STATUS_SEXTTOUT_Pos     9                                              /**< (SERCOM_I2CM_STATUS) Slave SCL Low Extend Timeout Position */
+#define SERCOM_I2CM_STATUS_SEXTTOUT_Msk     (_U_(0x1) << SERCOM_I2CM_STATUS_SEXTTOUT_Pos)  /**< (SERCOM_I2CM_STATUS) Slave SCL Low Extend Timeout Mask */
+#define SERCOM_I2CM_STATUS_SEXTTOUT         SERCOM_I2CM_STATUS_SEXTTOUT_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_STATUS_SEXTTOUT_Msk instead */
+#define SERCOM_I2CM_STATUS_LENERR_Pos       10                                             /**< (SERCOM_I2CM_STATUS) Length Error Position */
+#define SERCOM_I2CM_STATUS_LENERR_Msk       (_U_(0x1) << SERCOM_I2CM_STATUS_LENERR_Pos)    /**< (SERCOM_I2CM_STATUS) Length Error Mask */
+#define SERCOM_I2CM_STATUS_LENERR           SERCOM_I2CM_STATUS_LENERR_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_STATUS_LENERR_Msk instead */
+#define SERCOM_I2CM_STATUS_MASK             _U_(0x7F7)                                     /**< \deprecated (SERCOM_I2CM_STATUS) Register MASK  (Use SERCOM_I2CM_STATUS_Msk instead)  */
+#define SERCOM_I2CM_STATUS_Msk              _U_(0x7F7)                                     /**< (SERCOM_I2CM_STATUS) Register Mask  */
+
+
+/* -------- SERCOM_I2CS_STATUS : (SERCOM Offset: 0x1a) (R/W 16) I2CS Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t BUSERR:1;                  /**< bit:      0  Bus Error                                */
+    uint16_t COLL:1;                    /**< bit:      1  Transmit Collision                       */
+    uint16_t RXNACK:1;                  /**< bit:      2  Received Not Acknowledge                 */
+    uint16_t DIR:1;                     /**< bit:      3  Read/Write Direction                     */
+    uint16_t SR:1;                      /**< bit:      4  Repeated Start                           */
+    uint16_t :1;                        /**< bit:      5  Reserved */
+    uint16_t LOWTOUT:1;                 /**< bit:      6  SCL Low Timeout                          */
+    uint16_t CLKHOLD:1;                 /**< bit:      7  Clock Hold                               */
+    uint16_t :1;                        /**< bit:      8  Reserved */
+    uint16_t SEXTTOUT:1;                /**< bit:      9  Slave SCL Low Extend Timeout             */
+    uint16_t HS:1;                      /**< bit:     10  High Speed                               */
+    uint16_t :5;                        /**< bit: 11..15  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} SERCOM_I2CS_STATUS_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CS_STATUS_OFFSET           (0x1A)                                        /**<  (SERCOM_I2CS_STATUS) I2CS Status  Offset */
+#define SERCOM_I2CS_STATUS_RESETVALUE       _U_(0x00)                                     /**<  (SERCOM_I2CS_STATUS) I2CS Status  Reset Value */
+
+#define SERCOM_I2CS_STATUS_BUSERR_Pos       0                                              /**< (SERCOM_I2CS_STATUS) Bus Error Position */
+#define SERCOM_I2CS_STATUS_BUSERR_Msk       (_U_(0x1) << SERCOM_I2CS_STATUS_BUSERR_Pos)    /**< (SERCOM_I2CS_STATUS) Bus Error Mask */
+#define SERCOM_I2CS_STATUS_BUSERR           SERCOM_I2CS_STATUS_BUSERR_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_STATUS_BUSERR_Msk instead */
+#define SERCOM_I2CS_STATUS_COLL_Pos         1                                              /**< (SERCOM_I2CS_STATUS) Transmit Collision Position */
+#define SERCOM_I2CS_STATUS_COLL_Msk         (_U_(0x1) << SERCOM_I2CS_STATUS_COLL_Pos)      /**< (SERCOM_I2CS_STATUS) Transmit Collision Mask */
+#define SERCOM_I2CS_STATUS_COLL             SERCOM_I2CS_STATUS_COLL_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_STATUS_COLL_Msk instead */
+#define SERCOM_I2CS_STATUS_RXNACK_Pos       2                                              /**< (SERCOM_I2CS_STATUS) Received Not Acknowledge Position */
+#define SERCOM_I2CS_STATUS_RXNACK_Msk       (_U_(0x1) << SERCOM_I2CS_STATUS_RXNACK_Pos)    /**< (SERCOM_I2CS_STATUS) Received Not Acknowledge Mask */
+#define SERCOM_I2CS_STATUS_RXNACK           SERCOM_I2CS_STATUS_RXNACK_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_STATUS_RXNACK_Msk instead */
+#define SERCOM_I2CS_STATUS_DIR_Pos          3                                              /**< (SERCOM_I2CS_STATUS) Read/Write Direction Position */
+#define SERCOM_I2CS_STATUS_DIR_Msk          (_U_(0x1) << SERCOM_I2CS_STATUS_DIR_Pos)       /**< (SERCOM_I2CS_STATUS) Read/Write Direction Mask */
+#define SERCOM_I2CS_STATUS_DIR              SERCOM_I2CS_STATUS_DIR_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_STATUS_DIR_Msk instead */
+#define SERCOM_I2CS_STATUS_SR_Pos           4                                              /**< (SERCOM_I2CS_STATUS) Repeated Start Position */
+#define SERCOM_I2CS_STATUS_SR_Msk           (_U_(0x1) << SERCOM_I2CS_STATUS_SR_Pos)        /**< (SERCOM_I2CS_STATUS) Repeated Start Mask */
+#define SERCOM_I2CS_STATUS_SR               SERCOM_I2CS_STATUS_SR_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_STATUS_SR_Msk instead */
+#define SERCOM_I2CS_STATUS_LOWTOUT_Pos      6                                              /**< (SERCOM_I2CS_STATUS) SCL Low Timeout Position */
+#define SERCOM_I2CS_STATUS_LOWTOUT_Msk      (_U_(0x1) << SERCOM_I2CS_STATUS_LOWTOUT_Pos)   /**< (SERCOM_I2CS_STATUS) SCL Low Timeout Mask */
+#define SERCOM_I2CS_STATUS_LOWTOUT          SERCOM_I2CS_STATUS_LOWTOUT_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_STATUS_LOWTOUT_Msk instead */
+#define SERCOM_I2CS_STATUS_CLKHOLD_Pos      7                                              /**< (SERCOM_I2CS_STATUS) Clock Hold Position */
+#define SERCOM_I2CS_STATUS_CLKHOLD_Msk      (_U_(0x1) << SERCOM_I2CS_STATUS_CLKHOLD_Pos)   /**< (SERCOM_I2CS_STATUS) Clock Hold Mask */
+#define SERCOM_I2CS_STATUS_CLKHOLD          SERCOM_I2CS_STATUS_CLKHOLD_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_STATUS_CLKHOLD_Msk instead */
+#define SERCOM_I2CS_STATUS_SEXTTOUT_Pos     9                                              /**< (SERCOM_I2CS_STATUS) Slave SCL Low Extend Timeout Position */
+#define SERCOM_I2CS_STATUS_SEXTTOUT_Msk     (_U_(0x1) << SERCOM_I2CS_STATUS_SEXTTOUT_Pos)  /**< (SERCOM_I2CS_STATUS) Slave SCL Low Extend Timeout Mask */
+#define SERCOM_I2CS_STATUS_SEXTTOUT         SERCOM_I2CS_STATUS_SEXTTOUT_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_STATUS_SEXTTOUT_Msk instead */
+#define SERCOM_I2CS_STATUS_HS_Pos           10                                             /**< (SERCOM_I2CS_STATUS) High Speed Position */
+#define SERCOM_I2CS_STATUS_HS_Msk           (_U_(0x1) << SERCOM_I2CS_STATUS_HS_Pos)        /**< (SERCOM_I2CS_STATUS) High Speed Mask */
+#define SERCOM_I2CS_STATUS_HS               SERCOM_I2CS_STATUS_HS_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_STATUS_HS_Msk instead */
+#define SERCOM_I2CS_STATUS_MASK             _U_(0x6DF)                                     /**< \deprecated (SERCOM_I2CS_STATUS) Register MASK  (Use SERCOM_I2CS_STATUS_Msk instead)  */
+#define SERCOM_I2CS_STATUS_Msk              _U_(0x6DF)                                     /**< (SERCOM_I2CS_STATUS) Register Mask  */
+
+
+/* -------- SERCOM_SPI_STATUS : (SERCOM Offset: 0x1a) (R/W 16) SPI Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t :2;                        /**< bit:   0..1  Reserved */
+    uint16_t BUFOVF:1;                  /**< bit:      2  Buffer Overflow                          */
+    uint16_t :13;                       /**< bit:  3..15  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} SERCOM_SPI_STATUS_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_STATUS_OFFSET            (0x1A)                                        /**<  (SERCOM_SPI_STATUS) SPI Status  Offset */
+#define SERCOM_SPI_STATUS_RESETVALUE        _U_(0x00)                                     /**<  (SERCOM_SPI_STATUS) SPI Status  Reset Value */
+
+#define SERCOM_SPI_STATUS_BUFOVF_Pos        2                                              /**< (SERCOM_SPI_STATUS) Buffer Overflow Position */
+#define SERCOM_SPI_STATUS_BUFOVF_Msk        (_U_(0x1) << SERCOM_SPI_STATUS_BUFOVF_Pos)     /**< (SERCOM_SPI_STATUS) Buffer Overflow Mask */
+#define SERCOM_SPI_STATUS_BUFOVF            SERCOM_SPI_STATUS_BUFOVF_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_STATUS_BUFOVF_Msk instead */
+#define SERCOM_SPI_STATUS_MASK              _U_(0x04)                                      /**< \deprecated (SERCOM_SPI_STATUS) Register MASK  (Use SERCOM_SPI_STATUS_Msk instead)  */
+#define SERCOM_SPI_STATUS_Msk               _U_(0x04)                                      /**< (SERCOM_SPI_STATUS) Register Mask  */
+
+
+/* -------- SERCOM_USART_STATUS : (SERCOM Offset: 0x1a) (R/W 16) USART Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t PERR:1;                    /**< bit:      0  Parity Error                             */
+    uint16_t FERR:1;                    /**< bit:      1  Frame Error                              */
+    uint16_t BUFOVF:1;                  /**< bit:      2  Buffer Overflow                          */
+    uint16_t CTS:1;                     /**< bit:      3  Clear To Send                            */
+    uint16_t ISF:1;                     /**< bit:      4  Inconsistent Sync Field                  */
+    uint16_t COLL:1;                    /**< bit:      5  Collision Detected                       */
+    uint16_t TXE:1;                     /**< bit:      6  Transmitter Empty                        */
+    uint16_t ITER:1;                    /**< bit:      7  Maximum Number of Repetitions Reached    */
+    uint16_t :8;                        /**< bit:  8..15  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} SERCOM_USART_STATUS_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_STATUS_OFFSET          (0x1A)                                        /**<  (SERCOM_USART_STATUS) USART Status  Offset */
+#define SERCOM_USART_STATUS_RESETVALUE      _U_(0x00)                                     /**<  (SERCOM_USART_STATUS) USART Status  Reset Value */
+
+#define SERCOM_USART_STATUS_PERR_Pos        0                                              /**< (SERCOM_USART_STATUS) Parity Error Position */
+#define SERCOM_USART_STATUS_PERR_Msk        (_U_(0x1) << SERCOM_USART_STATUS_PERR_Pos)     /**< (SERCOM_USART_STATUS) Parity Error Mask */
+#define SERCOM_USART_STATUS_PERR            SERCOM_USART_STATUS_PERR_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_STATUS_PERR_Msk instead */
+#define SERCOM_USART_STATUS_FERR_Pos        1                                              /**< (SERCOM_USART_STATUS) Frame Error Position */
+#define SERCOM_USART_STATUS_FERR_Msk        (_U_(0x1) << SERCOM_USART_STATUS_FERR_Pos)     /**< (SERCOM_USART_STATUS) Frame Error Mask */
+#define SERCOM_USART_STATUS_FERR            SERCOM_USART_STATUS_FERR_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_STATUS_FERR_Msk instead */
+#define SERCOM_USART_STATUS_BUFOVF_Pos      2                                              /**< (SERCOM_USART_STATUS) Buffer Overflow Position */
+#define SERCOM_USART_STATUS_BUFOVF_Msk      (_U_(0x1) << SERCOM_USART_STATUS_BUFOVF_Pos)   /**< (SERCOM_USART_STATUS) Buffer Overflow Mask */
+#define SERCOM_USART_STATUS_BUFOVF          SERCOM_USART_STATUS_BUFOVF_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_STATUS_BUFOVF_Msk instead */
+#define SERCOM_USART_STATUS_CTS_Pos         3                                              /**< (SERCOM_USART_STATUS) Clear To Send Position */
+#define SERCOM_USART_STATUS_CTS_Msk         (_U_(0x1) << SERCOM_USART_STATUS_CTS_Pos)      /**< (SERCOM_USART_STATUS) Clear To Send Mask */
+#define SERCOM_USART_STATUS_CTS             SERCOM_USART_STATUS_CTS_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_STATUS_CTS_Msk instead */
+#define SERCOM_USART_STATUS_ISF_Pos         4                                              /**< (SERCOM_USART_STATUS) Inconsistent Sync Field Position */
+#define SERCOM_USART_STATUS_ISF_Msk         (_U_(0x1) << SERCOM_USART_STATUS_ISF_Pos)      /**< (SERCOM_USART_STATUS) Inconsistent Sync Field Mask */
+#define SERCOM_USART_STATUS_ISF             SERCOM_USART_STATUS_ISF_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_STATUS_ISF_Msk instead */
+#define SERCOM_USART_STATUS_COLL_Pos        5                                              /**< (SERCOM_USART_STATUS) Collision Detected Position */
+#define SERCOM_USART_STATUS_COLL_Msk        (_U_(0x1) << SERCOM_USART_STATUS_COLL_Pos)     /**< (SERCOM_USART_STATUS) Collision Detected Mask */
+#define SERCOM_USART_STATUS_COLL            SERCOM_USART_STATUS_COLL_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_STATUS_COLL_Msk instead */
+#define SERCOM_USART_STATUS_TXE_Pos         6                                              /**< (SERCOM_USART_STATUS) Transmitter Empty Position */
+#define SERCOM_USART_STATUS_TXE_Msk         (_U_(0x1) << SERCOM_USART_STATUS_TXE_Pos)      /**< (SERCOM_USART_STATUS) Transmitter Empty Mask */
+#define SERCOM_USART_STATUS_TXE             SERCOM_USART_STATUS_TXE_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_STATUS_TXE_Msk instead */
+#define SERCOM_USART_STATUS_ITER_Pos        7                                              /**< (SERCOM_USART_STATUS) Maximum Number of Repetitions Reached Position */
+#define SERCOM_USART_STATUS_ITER_Msk        (_U_(0x1) << SERCOM_USART_STATUS_ITER_Pos)     /**< (SERCOM_USART_STATUS) Maximum Number of Repetitions Reached Mask */
+#define SERCOM_USART_STATUS_ITER            SERCOM_USART_STATUS_ITER_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_STATUS_ITER_Msk instead */
+#define SERCOM_USART_STATUS_MASK            _U_(0xFF)                                      /**< \deprecated (SERCOM_USART_STATUS) Register MASK  (Use SERCOM_USART_STATUS_Msk instead)  */
+#define SERCOM_USART_STATUS_Msk             _U_(0xFF)                                      /**< (SERCOM_USART_STATUS) Register Mask  */
+
+
+/* -------- SERCOM_I2CM_SYNCBUSY : (SERCOM Offset: 0x1c) (R/ 32) I2CM Synchronization Busy -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SWRST:1;                   /**< bit:      0  Software Reset Synchronization Busy      */
+    uint32_t ENABLE:1;                  /**< bit:      1  SERCOM Enable Synchronization Busy       */
+    uint32_t SYSOP:1;                   /**< bit:      2  System Operation Synchronization Busy    */
+    uint32_t :29;                       /**< bit:  3..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SERCOM_I2CM_SYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_SYNCBUSY_OFFSET         (0x1C)                                        /**<  (SERCOM_I2CM_SYNCBUSY) I2CM Synchronization Busy  Offset */
+#define SERCOM_I2CM_SYNCBUSY_RESETVALUE     _U_(0x00)                                     /**<  (SERCOM_I2CM_SYNCBUSY) I2CM Synchronization Busy  Reset Value */
+
+#define SERCOM_I2CM_SYNCBUSY_SWRST_Pos      0                                              /**< (SERCOM_I2CM_SYNCBUSY) Software Reset Synchronization Busy Position */
+#define SERCOM_I2CM_SYNCBUSY_SWRST_Msk      (_U_(0x1) << SERCOM_I2CM_SYNCBUSY_SWRST_Pos)   /**< (SERCOM_I2CM_SYNCBUSY) Software Reset Synchronization Busy Mask */
+#define SERCOM_I2CM_SYNCBUSY_SWRST          SERCOM_I2CM_SYNCBUSY_SWRST_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_SYNCBUSY_SWRST_Msk instead */
+#define SERCOM_I2CM_SYNCBUSY_ENABLE_Pos     1                                              /**< (SERCOM_I2CM_SYNCBUSY) SERCOM Enable Synchronization Busy Position */
+#define SERCOM_I2CM_SYNCBUSY_ENABLE_Msk     (_U_(0x1) << SERCOM_I2CM_SYNCBUSY_ENABLE_Pos)  /**< (SERCOM_I2CM_SYNCBUSY) SERCOM Enable Synchronization Busy Mask */
+#define SERCOM_I2CM_SYNCBUSY_ENABLE         SERCOM_I2CM_SYNCBUSY_ENABLE_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_SYNCBUSY_ENABLE_Msk instead */
+#define SERCOM_I2CM_SYNCBUSY_SYSOP_Pos      2                                              /**< (SERCOM_I2CM_SYNCBUSY) System Operation Synchronization Busy Position */
+#define SERCOM_I2CM_SYNCBUSY_SYSOP_Msk      (_U_(0x1) << SERCOM_I2CM_SYNCBUSY_SYSOP_Pos)   /**< (SERCOM_I2CM_SYNCBUSY) System Operation Synchronization Busy Mask */
+#define SERCOM_I2CM_SYNCBUSY_SYSOP          SERCOM_I2CM_SYNCBUSY_SYSOP_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_SYNCBUSY_SYSOP_Msk instead */
+#define SERCOM_I2CM_SYNCBUSY_MASK           _U_(0x07)                                      /**< \deprecated (SERCOM_I2CM_SYNCBUSY) Register MASK  (Use SERCOM_I2CM_SYNCBUSY_Msk instead)  */
+#define SERCOM_I2CM_SYNCBUSY_Msk            _U_(0x07)                                      /**< (SERCOM_I2CM_SYNCBUSY) Register Mask  */
+
+
+/* -------- SERCOM_I2CS_SYNCBUSY : (SERCOM Offset: 0x1c) (R/ 32) I2CS Synchronization Busy -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SWRST:1;                   /**< bit:      0  Software Reset Synchronization Busy      */
+    uint32_t ENABLE:1;                  /**< bit:      1  SERCOM Enable Synchronization Busy       */
+    uint32_t :30;                       /**< bit:  2..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SERCOM_I2CS_SYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CS_SYNCBUSY_OFFSET         (0x1C)                                        /**<  (SERCOM_I2CS_SYNCBUSY) I2CS Synchronization Busy  Offset */
+#define SERCOM_I2CS_SYNCBUSY_RESETVALUE     _U_(0x00)                                     /**<  (SERCOM_I2CS_SYNCBUSY) I2CS Synchronization Busy  Reset Value */
+
+#define SERCOM_I2CS_SYNCBUSY_SWRST_Pos      0                                              /**< (SERCOM_I2CS_SYNCBUSY) Software Reset Synchronization Busy Position */
+#define SERCOM_I2CS_SYNCBUSY_SWRST_Msk      (_U_(0x1) << SERCOM_I2CS_SYNCBUSY_SWRST_Pos)   /**< (SERCOM_I2CS_SYNCBUSY) Software Reset Synchronization Busy Mask */
+#define SERCOM_I2CS_SYNCBUSY_SWRST          SERCOM_I2CS_SYNCBUSY_SWRST_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_SYNCBUSY_SWRST_Msk instead */
+#define SERCOM_I2CS_SYNCBUSY_ENABLE_Pos     1                                              /**< (SERCOM_I2CS_SYNCBUSY) SERCOM Enable Synchronization Busy Position */
+#define SERCOM_I2CS_SYNCBUSY_ENABLE_Msk     (_U_(0x1) << SERCOM_I2CS_SYNCBUSY_ENABLE_Pos)  /**< (SERCOM_I2CS_SYNCBUSY) SERCOM Enable Synchronization Busy Mask */
+#define SERCOM_I2CS_SYNCBUSY_ENABLE         SERCOM_I2CS_SYNCBUSY_ENABLE_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_SYNCBUSY_ENABLE_Msk instead */
+#define SERCOM_I2CS_SYNCBUSY_MASK           _U_(0x03)                                      /**< \deprecated (SERCOM_I2CS_SYNCBUSY) Register MASK  (Use SERCOM_I2CS_SYNCBUSY_Msk instead)  */
+#define SERCOM_I2CS_SYNCBUSY_Msk            _U_(0x03)                                      /**< (SERCOM_I2CS_SYNCBUSY) Register Mask  */
+
+
+/* -------- SERCOM_SPI_SYNCBUSY : (SERCOM Offset: 0x1c) (R/ 32) SPI Synchronization Busy -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SWRST:1;                   /**< bit:      0  Software Reset Synchronization Busy      */
+    uint32_t ENABLE:1;                  /**< bit:      1  SERCOM Enable Synchronization Busy       */
+    uint32_t CTRLB:1;                   /**< bit:      2  CTRLB Synchronization Busy               */
+    uint32_t :29;                       /**< bit:  3..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SERCOM_SPI_SYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_SYNCBUSY_OFFSET          (0x1C)                                        /**<  (SERCOM_SPI_SYNCBUSY) SPI Synchronization Busy  Offset */
+#define SERCOM_SPI_SYNCBUSY_RESETVALUE      _U_(0x00)                                     /**<  (SERCOM_SPI_SYNCBUSY) SPI Synchronization Busy  Reset Value */
+
+#define SERCOM_SPI_SYNCBUSY_SWRST_Pos       0                                              /**< (SERCOM_SPI_SYNCBUSY) Software Reset Synchronization Busy Position */
+#define SERCOM_SPI_SYNCBUSY_SWRST_Msk       (_U_(0x1) << SERCOM_SPI_SYNCBUSY_SWRST_Pos)    /**< (SERCOM_SPI_SYNCBUSY) Software Reset Synchronization Busy Mask */
+#define SERCOM_SPI_SYNCBUSY_SWRST           SERCOM_SPI_SYNCBUSY_SWRST_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_SYNCBUSY_SWRST_Msk instead */
+#define SERCOM_SPI_SYNCBUSY_ENABLE_Pos      1                                              /**< (SERCOM_SPI_SYNCBUSY) SERCOM Enable Synchronization Busy Position */
+#define SERCOM_SPI_SYNCBUSY_ENABLE_Msk      (_U_(0x1) << SERCOM_SPI_SYNCBUSY_ENABLE_Pos)   /**< (SERCOM_SPI_SYNCBUSY) SERCOM Enable Synchronization Busy Mask */
+#define SERCOM_SPI_SYNCBUSY_ENABLE          SERCOM_SPI_SYNCBUSY_ENABLE_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_SYNCBUSY_ENABLE_Msk instead */
+#define SERCOM_SPI_SYNCBUSY_CTRLB_Pos       2                                              /**< (SERCOM_SPI_SYNCBUSY) CTRLB Synchronization Busy Position */
+#define SERCOM_SPI_SYNCBUSY_CTRLB_Msk       (_U_(0x1) << SERCOM_SPI_SYNCBUSY_CTRLB_Pos)    /**< (SERCOM_SPI_SYNCBUSY) CTRLB Synchronization Busy Mask */
+#define SERCOM_SPI_SYNCBUSY_CTRLB           SERCOM_SPI_SYNCBUSY_CTRLB_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_SYNCBUSY_CTRLB_Msk instead */
+#define SERCOM_SPI_SYNCBUSY_MASK            _U_(0x07)                                      /**< \deprecated (SERCOM_SPI_SYNCBUSY) Register MASK  (Use SERCOM_SPI_SYNCBUSY_Msk instead)  */
+#define SERCOM_SPI_SYNCBUSY_Msk             _U_(0x07)                                      /**< (SERCOM_SPI_SYNCBUSY) Register Mask  */
+
+
+/* -------- SERCOM_USART_SYNCBUSY : (SERCOM Offset: 0x1c) (R/ 32) USART Synchronization Busy -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SWRST:1;                   /**< bit:      0  Software Reset Synchronization Busy      */
+    uint32_t ENABLE:1;                  /**< bit:      1  SERCOM Enable Synchronization Busy       */
+    uint32_t CTRLB:1;                   /**< bit:      2  CTRLB Synchronization Busy               */
+    uint32_t RXERRCNT:1;                /**< bit:      3  RXERRCNT Synchronization Busy            */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SERCOM_USART_SYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_SYNCBUSY_OFFSET        (0x1C)                                        /**<  (SERCOM_USART_SYNCBUSY) USART Synchronization Busy  Offset */
+#define SERCOM_USART_SYNCBUSY_RESETVALUE    _U_(0x00)                                     /**<  (SERCOM_USART_SYNCBUSY) USART Synchronization Busy  Reset Value */
+
+#define SERCOM_USART_SYNCBUSY_SWRST_Pos     0                                              /**< (SERCOM_USART_SYNCBUSY) Software Reset Synchronization Busy Position */
+#define SERCOM_USART_SYNCBUSY_SWRST_Msk     (_U_(0x1) << SERCOM_USART_SYNCBUSY_SWRST_Pos)  /**< (SERCOM_USART_SYNCBUSY) Software Reset Synchronization Busy Mask */
+#define SERCOM_USART_SYNCBUSY_SWRST         SERCOM_USART_SYNCBUSY_SWRST_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_SYNCBUSY_SWRST_Msk instead */
+#define SERCOM_USART_SYNCBUSY_ENABLE_Pos    1                                              /**< (SERCOM_USART_SYNCBUSY) SERCOM Enable Synchronization Busy Position */
+#define SERCOM_USART_SYNCBUSY_ENABLE_Msk    (_U_(0x1) << SERCOM_USART_SYNCBUSY_ENABLE_Pos)  /**< (SERCOM_USART_SYNCBUSY) SERCOM Enable Synchronization Busy Mask */
+#define SERCOM_USART_SYNCBUSY_ENABLE        SERCOM_USART_SYNCBUSY_ENABLE_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_SYNCBUSY_ENABLE_Msk instead */
+#define SERCOM_USART_SYNCBUSY_CTRLB_Pos     2                                              /**< (SERCOM_USART_SYNCBUSY) CTRLB Synchronization Busy Position */
+#define SERCOM_USART_SYNCBUSY_CTRLB_Msk     (_U_(0x1) << SERCOM_USART_SYNCBUSY_CTRLB_Pos)  /**< (SERCOM_USART_SYNCBUSY) CTRLB Synchronization Busy Mask */
+#define SERCOM_USART_SYNCBUSY_CTRLB         SERCOM_USART_SYNCBUSY_CTRLB_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_SYNCBUSY_CTRLB_Msk instead */
+#define SERCOM_USART_SYNCBUSY_RXERRCNT_Pos  3                                              /**< (SERCOM_USART_SYNCBUSY) RXERRCNT Synchronization Busy Position */
+#define SERCOM_USART_SYNCBUSY_RXERRCNT_Msk  (_U_(0x1) << SERCOM_USART_SYNCBUSY_RXERRCNT_Pos)  /**< (SERCOM_USART_SYNCBUSY) RXERRCNT Synchronization Busy Mask */
+#define SERCOM_USART_SYNCBUSY_RXERRCNT      SERCOM_USART_SYNCBUSY_RXERRCNT_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_SYNCBUSY_RXERRCNT_Msk instead */
+#define SERCOM_USART_SYNCBUSY_MASK          _U_(0x0F)                                      /**< \deprecated (SERCOM_USART_SYNCBUSY) Register MASK  (Use SERCOM_USART_SYNCBUSY_Msk instead)  */
+#define SERCOM_USART_SYNCBUSY_Msk           _U_(0x0F)                                      /**< (SERCOM_USART_SYNCBUSY) Register Mask  */
+
+
+/* -------- SERCOM_USART_RXERRCNT : (SERCOM Offset: 0x20) (R/ 8) USART Receive Error Count -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  uint8_t  reg;                         /**< Type used for register access */
+} SERCOM_USART_RXERRCNT_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_RXERRCNT_OFFSET        (0x20)                                        /**<  (SERCOM_USART_RXERRCNT) USART Receive Error Count  Offset */
+#define SERCOM_USART_RXERRCNT_RESETVALUE    _U_(0x00)                                     /**<  (SERCOM_USART_RXERRCNT) USART Receive Error Count  Reset Value */
+
+#define SERCOM_USART_RXERRCNT_MASK          _U_(0x00)                                      /**< \deprecated (SERCOM_USART_RXERRCNT) Register MASK  (Use SERCOM_USART_RXERRCNT_Msk instead)  */
+#define SERCOM_USART_RXERRCNT_Msk           _U_(0x00)                                      /**< (SERCOM_USART_RXERRCNT) Register Mask  */
+
+
+/* -------- SERCOM_I2CM_ADDR : (SERCOM Offset: 0x24) (R/W 32) I2CM Address -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t ADDR:11;                   /**< bit:  0..10  Address Value                            */
+    uint32_t :2;                        /**< bit: 11..12  Reserved */
+    uint32_t LENEN:1;                   /**< bit:     13  Length Enable                            */
+    uint32_t HS:1;                      /**< bit:     14  High Speed Mode                          */
+    uint32_t TENBITEN:1;                /**< bit:     15  Ten Bit Addressing Enable                */
+    uint32_t LEN:8;                     /**< bit: 16..23  Length                                   */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SERCOM_I2CM_ADDR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_ADDR_OFFSET             (0x24)                                        /**<  (SERCOM_I2CM_ADDR) I2CM Address  Offset */
+#define SERCOM_I2CM_ADDR_RESETVALUE         _U_(0x00)                                     /**<  (SERCOM_I2CM_ADDR) I2CM Address  Reset Value */
+
+#define SERCOM_I2CM_ADDR_ADDR_Pos           0                                              /**< (SERCOM_I2CM_ADDR) Address Value Position */
+#define SERCOM_I2CM_ADDR_ADDR_Msk           (_U_(0x7FF) << SERCOM_I2CM_ADDR_ADDR_Pos)      /**< (SERCOM_I2CM_ADDR) Address Value Mask */
+#define SERCOM_I2CM_ADDR_ADDR(value)        (SERCOM_I2CM_ADDR_ADDR_Msk & ((value) << SERCOM_I2CM_ADDR_ADDR_Pos))
+#define SERCOM_I2CM_ADDR_LENEN_Pos          13                                             /**< (SERCOM_I2CM_ADDR) Length Enable Position */
+#define SERCOM_I2CM_ADDR_LENEN_Msk          (_U_(0x1) << SERCOM_I2CM_ADDR_LENEN_Pos)       /**< (SERCOM_I2CM_ADDR) Length Enable Mask */
+#define SERCOM_I2CM_ADDR_LENEN              SERCOM_I2CM_ADDR_LENEN_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_ADDR_LENEN_Msk instead */
+#define SERCOM_I2CM_ADDR_HS_Pos             14                                             /**< (SERCOM_I2CM_ADDR) High Speed Mode Position */
+#define SERCOM_I2CM_ADDR_HS_Msk             (_U_(0x1) << SERCOM_I2CM_ADDR_HS_Pos)          /**< (SERCOM_I2CM_ADDR) High Speed Mode Mask */
+#define SERCOM_I2CM_ADDR_HS                 SERCOM_I2CM_ADDR_HS_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_ADDR_HS_Msk instead */
+#define SERCOM_I2CM_ADDR_TENBITEN_Pos       15                                             /**< (SERCOM_I2CM_ADDR) Ten Bit Addressing Enable Position */
+#define SERCOM_I2CM_ADDR_TENBITEN_Msk       (_U_(0x1) << SERCOM_I2CM_ADDR_TENBITEN_Pos)    /**< (SERCOM_I2CM_ADDR) Ten Bit Addressing Enable Mask */
+#define SERCOM_I2CM_ADDR_TENBITEN           SERCOM_I2CM_ADDR_TENBITEN_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_ADDR_TENBITEN_Msk instead */
+#define SERCOM_I2CM_ADDR_LEN_Pos            16                                             /**< (SERCOM_I2CM_ADDR) Length Position */
+#define SERCOM_I2CM_ADDR_LEN_Msk            (_U_(0xFF) << SERCOM_I2CM_ADDR_LEN_Pos)        /**< (SERCOM_I2CM_ADDR) Length Mask */
+#define SERCOM_I2CM_ADDR_LEN(value)         (SERCOM_I2CM_ADDR_LEN_Msk & ((value) << SERCOM_I2CM_ADDR_LEN_Pos))
+#define SERCOM_I2CM_ADDR_MASK               _U_(0xFFE7FF)                                  /**< \deprecated (SERCOM_I2CM_ADDR) Register MASK  (Use SERCOM_I2CM_ADDR_Msk instead)  */
+#define SERCOM_I2CM_ADDR_Msk                _U_(0xFFE7FF)                                  /**< (SERCOM_I2CM_ADDR) Register Mask  */
+
+
+/* -------- SERCOM_I2CS_ADDR : (SERCOM Offset: 0x24) (R/W 32) I2CS Address -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t GENCEN:1;                  /**< bit:      0  General Call Address Enable              */
+    uint32_t ADDR:10;                   /**< bit:  1..10  Address Value                            */
+    uint32_t :4;                        /**< bit: 11..14  Reserved */
+    uint32_t TENBITEN:1;                /**< bit:     15  Ten Bit Addressing Enable                */
+    uint32_t :1;                        /**< bit:     16  Reserved */
+    uint32_t ADDRMASK:10;               /**< bit: 17..26  Address Mask                             */
+    uint32_t :5;                        /**< bit: 27..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SERCOM_I2CS_ADDR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CS_ADDR_OFFSET             (0x24)                                        /**<  (SERCOM_I2CS_ADDR) I2CS Address  Offset */
+#define SERCOM_I2CS_ADDR_RESETVALUE         _U_(0x00)                                     /**<  (SERCOM_I2CS_ADDR) I2CS Address  Reset Value */
+
+#define SERCOM_I2CS_ADDR_GENCEN_Pos         0                                              /**< (SERCOM_I2CS_ADDR) General Call Address Enable Position */
+#define SERCOM_I2CS_ADDR_GENCEN_Msk         (_U_(0x1) << SERCOM_I2CS_ADDR_GENCEN_Pos)      /**< (SERCOM_I2CS_ADDR) General Call Address Enable Mask */
+#define SERCOM_I2CS_ADDR_GENCEN             SERCOM_I2CS_ADDR_GENCEN_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_ADDR_GENCEN_Msk instead */
+#define SERCOM_I2CS_ADDR_ADDR_Pos           1                                              /**< (SERCOM_I2CS_ADDR) Address Value Position */
+#define SERCOM_I2CS_ADDR_ADDR_Msk           (_U_(0x3FF) << SERCOM_I2CS_ADDR_ADDR_Pos)      /**< (SERCOM_I2CS_ADDR) Address Value Mask */
+#define SERCOM_I2CS_ADDR_ADDR(value)        (SERCOM_I2CS_ADDR_ADDR_Msk & ((value) << SERCOM_I2CS_ADDR_ADDR_Pos))
+#define SERCOM_I2CS_ADDR_TENBITEN_Pos       15                                             /**< (SERCOM_I2CS_ADDR) Ten Bit Addressing Enable Position */
+#define SERCOM_I2CS_ADDR_TENBITEN_Msk       (_U_(0x1) << SERCOM_I2CS_ADDR_TENBITEN_Pos)    /**< (SERCOM_I2CS_ADDR) Ten Bit Addressing Enable Mask */
+#define SERCOM_I2CS_ADDR_TENBITEN           SERCOM_I2CS_ADDR_TENBITEN_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CS_ADDR_TENBITEN_Msk instead */
+#define SERCOM_I2CS_ADDR_ADDRMASK_Pos       17                                             /**< (SERCOM_I2CS_ADDR) Address Mask Position */
+#define SERCOM_I2CS_ADDR_ADDRMASK_Msk       (_U_(0x3FF) << SERCOM_I2CS_ADDR_ADDRMASK_Pos)  /**< (SERCOM_I2CS_ADDR) Address Mask Mask */
+#define SERCOM_I2CS_ADDR_ADDRMASK(value)    (SERCOM_I2CS_ADDR_ADDRMASK_Msk & ((value) << SERCOM_I2CS_ADDR_ADDRMASK_Pos))
+#define SERCOM_I2CS_ADDR_Msk                _U_(0x7FE87FF)                                 /**< (SERCOM_I2CS_ADDR) Register Mask  */
+
+
+/* -------- SERCOM_SPI_ADDR : (SERCOM Offset: 0x24) (R/W 32) SPI Address -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t ADDR:8;                    /**< bit:   0..7  Address Value                            */
+    uint32_t :8;                        /**< bit:  8..15  Reserved */
+    uint32_t ADDRMASK:8;                /**< bit: 16..23  Address Mask                             */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SERCOM_SPI_ADDR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_ADDR_OFFSET              (0x24)                                        /**<  (SERCOM_SPI_ADDR) SPI Address  Offset */
+#define SERCOM_SPI_ADDR_RESETVALUE          _U_(0x00)                                     /**<  (SERCOM_SPI_ADDR) SPI Address  Reset Value */
+
+#define SERCOM_SPI_ADDR_ADDR_Pos            0                                              /**< (SERCOM_SPI_ADDR) Address Value Position */
+#define SERCOM_SPI_ADDR_ADDR_Msk            (_U_(0xFF) << SERCOM_SPI_ADDR_ADDR_Pos)        /**< (SERCOM_SPI_ADDR) Address Value Mask */
+#define SERCOM_SPI_ADDR_ADDR(value)         (SERCOM_SPI_ADDR_ADDR_Msk & ((value) << SERCOM_SPI_ADDR_ADDR_Pos))
+#define SERCOM_SPI_ADDR_ADDRMASK_Pos        16                                             /**< (SERCOM_SPI_ADDR) Address Mask Position */
+#define SERCOM_SPI_ADDR_ADDRMASK_Msk        (_U_(0xFF) << SERCOM_SPI_ADDR_ADDRMASK_Pos)    /**< (SERCOM_SPI_ADDR) Address Mask Mask */
+#define SERCOM_SPI_ADDR_ADDRMASK(value)     (SERCOM_SPI_ADDR_ADDRMASK_Msk & ((value) << SERCOM_SPI_ADDR_ADDRMASK_Pos))
+#define SERCOM_SPI_ADDR_Msk                 _U_(0xFF00FF)                                  /**< (SERCOM_SPI_ADDR) Register Mask  */
+
+
+/* -------- SERCOM_I2CM_DATA : (SERCOM Offset: 0x28) (R/W 8) I2CM Data -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DATA:8;                    /**< bit:   0..7  Data Value                               */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} SERCOM_I2CM_DATA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_DATA_OFFSET             (0x28)                                        /**<  (SERCOM_I2CM_DATA) I2CM Data  Offset */
+#define SERCOM_I2CM_DATA_RESETVALUE         _U_(0x00)                                     /**<  (SERCOM_I2CM_DATA) I2CM Data  Reset Value */
+
+#define SERCOM_I2CM_DATA_DATA_Pos           0                                              /**< (SERCOM_I2CM_DATA) Data Value Position */
+#define SERCOM_I2CM_DATA_DATA_Msk           (_U_(0xFF) << SERCOM_I2CM_DATA_DATA_Pos)       /**< (SERCOM_I2CM_DATA) Data Value Mask */
+#define SERCOM_I2CM_DATA_DATA(value)        (SERCOM_I2CM_DATA_DATA_Msk & ((value) << SERCOM_I2CM_DATA_DATA_Pos))
+#define SERCOM_I2CM_DATA_MASK               _U_(0xFF)                                      /**< \deprecated (SERCOM_I2CM_DATA) Register MASK  (Use SERCOM_I2CM_DATA_Msk instead)  */
+#define SERCOM_I2CM_DATA_Msk                _U_(0xFF)                                      /**< (SERCOM_I2CM_DATA) Register Mask  */
+
+
+/* -------- SERCOM_I2CS_DATA : (SERCOM Offset: 0x28) (R/W 8) I2CS Data -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DATA:8;                    /**< bit:   0..7  Data Value                               */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} SERCOM_I2CS_DATA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CS_DATA_OFFSET             (0x28)                                        /**<  (SERCOM_I2CS_DATA) I2CS Data  Offset */
+#define SERCOM_I2CS_DATA_RESETVALUE         _U_(0x00)                                     /**<  (SERCOM_I2CS_DATA) I2CS Data  Reset Value */
+
+#define SERCOM_I2CS_DATA_DATA_Pos           0                                              /**< (SERCOM_I2CS_DATA) Data Value Position */
+#define SERCOM_I2CS_DATA_DATA_Msk           (_U_(0xFF) << SERCOM_I2CS_DATA_DATA_Pos)       /**< (SERCOM_I2CS_DATA) Data Value Mask */
+#define SERCOM_I2CS_DATA_DATA(value)        (SERCOM_I2CS_DATA_DATA_Msk & ((value) << SERCOM_I2CS_DATA_DATA_Pos))
+#define SERCOM_I2CS_DATA_MASK               _U_(0xFF)                                      /**< \deprecated (SERCOM_I2CS_DATA) Register MASK  (Use SERCOM_I2CS_DATA_Msk instead)  */
+#define SERCOM_I2CS_DATA_Msk                _U_(0xFF)                                      /**< (SERCOM_I2CS_DATA) Register Mask  */
+
+
+/* -------- SERCOM_SPI_DATA : (SERCOM Offset: 0x28) (R/W 32) SPI Data -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t DATA:9;                    /**< bit:   0..8  Data Value                               */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SERCOM_SPI_DATA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_DATA_OFFSET              (0x28)                                        /**<  (SERCOM_SPI_DATA) SPI Data  Offset */
+#define SERCOM_SPI_DATA_RESETVALUE          _U_(0x00)                                     /**<  (SERCOM_SPI_DATA) SPI Data  Reset Value */
+
+#define SERCOM_SPI_DATA_DATA_Pos            0                                              /**< (SERCOM_SPI_DATA) Data Value Position */
+#define SERCOM_SPI_DATA_DATA_Msk            (_U_(0x1FF) << SERCOM_SPI_DATA_DATA_Pos)       /**< (SERCOM_SPI_DATA) Data Value Mask */
+#define SERCOM_SPI_DATA_DATA(value)         (SERCOM_SPI_DATA_DATA_Msk & ((value) << SERCOM_SPI_DATA_DATA_Pos))
+#define SERCOM_SPI_DATA_MASK                _U_(0x1FF)                                     /**< \deprecated (SERCOM_SPI_DATA) Register MASK  (Use SERCOM_SPI_DATA_Msk instead)  */
+#define SERCOM_SPI_DATA_Msk                 _U_(0x1FF)                                     /**< (SERCOM_SPI_DATA) Register Mask  */
+
+
+/* -------- SERCOM_USART_DATA : (SERCOM Offset: 0x28) (R/W 16) USART Data -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t DATA:9;                    /**< bit:   0..8  Data Value                               */
+    uint16_t :7;                        /**< bit:  9..15  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} SERCOM_USART_DATA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_DATA_OFFSET            (0x28)                                        /**<  (SERCOM_USART_DATA) USART Data  Offset */
+#define SERCOM_USART_DATA_RESETVALUE        _U_(0x00)                                     /**<  (SERCOM_USART_DATA) USART Data  Reset Value */
+
+#define SERCOM_USART_DATA_DATA_Pos          0                                              /**< (SERCOM_USART_DATA) Data Value Position */
+#define SERCOM_USART_DATA_DATA_Msk          (_U_(0x1FF) << SERCOM_USART_DATA_DATA_Pos)     /**< (SERCOM_USART_DATA) Data Value Mask */
+#define SERCOM_USART_DATA_DATA(value)       (SERCOM_USART_DATA_DATA_Msk & ((value) << SERCOM_USART_DATA_DATA_Pos))
+#define SERCOM_USART_DATA_MASK              _U_(0x1FF)                                     /**< \deprecated (SERCOM_USART_DATA) Register MASK  (Use SERCOM_USART_DATA_Msk instead)  */
+#define SERCOM_USART_DATA_Msk               _U_(0x1FF)                                     /**< (SERCOM_USART_DATA) Register Mask  */
+
+
+/* -------- SERCOM_I2CM_DBGCTRL : (SERCOM Offset: 0x30) (R/W 8) I2CM Debug Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DBGSTOP:1;                 /**< bit:      0  Debug Mode                               */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} SERCOM_I2CM_DBGCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_DBGCTRL_OFFSET          (0x30)                                        /**<  (SERCOM_I2CM_DBGCTRL) I2CM Debug Control  Offset */
+#define SERCOM_I2CM_DBGCTRL_RESETVALUE      _U_(0x00)                                     /**<  (SERCOM_I2CM_DBGCTRL) I2CM Debug Control  Reset Value */
+
+#define SERCOM_I2CM_DBGCTRL_DBGSTOP_Pos     0                                              /**< (SERCOM_I2CM_DBGCTRL) Debug Mode Position */
+#define SERCOM_I2CM_DBGCTRL_DBGSTOP_Msk     (_U_(0x1) << SERCOM_I2CM_DBGCTRL_DBGSTOP_Pos)  /**< (SERCOM_I2CM_DBGCTRL) Debug Mode Mask */
+#define SERCOM_I2CM_DBGCTRL_DBGSTOP         SERCOM_I2CM_DBGCTRL_DBGSTOP_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_I2CM_DBGCTRL_DBGSTOP_Msk instead */
+#define SERCOM_I2CM_DBGCTRL_MASK            _U_(0x01)                                      /**< \deprecated (SERCOM_I2CM_DBGCTRL) Register MASK  (Use SERCOM_I2CM_DBGCTRL_Msk instead)  */
+#define SERCOM_I2CM_DBGCTRL_Msk             _U_(0x01)                                      /**< (SERCOM_I2CM_DBGCTRL) Register Mask  */
+
+
+/* -------- SERCOM_SPI_DBGCTRL : (SERCOM Offset: 0x30) (R/W 8) SPI Debug Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DBGSTOP:1;                 /**< bit:      0  Debug Mode                               */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} SERCOM_SPI_DBGCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_DBGCTRL_OFFSET           (0x30)                                        /**<  (SERCOM_SPI_DBGCTRL) SPI Debug Control  Offset */
+#define SERCOM_SPI_DBGCTRL_RESETVALUE       _U_(0x00)                                     /**<  (SERCOM_SPI_DBGCTRL) SPI Debug Control  Reset Value */
+
+#define SERCOM_SPI_DBGCTRL_DBGSTOP_Pos      0                                              /**< (SERCOM_SPI_DBGCTRL) Debug Mode Position */
+#define SERCOM_SPI_DBGCTRL_DBGSTOP_Msk      (_U_(0x1) << SERCOM_SPI_DBGCTRL_DBGSTOP_Pos)   /**< (SERCOM_SPI_DBGCTRL) Debug Mode Mask */
+#define SERCOM_SPI_DBGCTRL_DBGSTOP          SERCOM_SPI_DBGCTRL_DBGSTOP_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_SPI_DBGCTRL_DBGSTOP_Msk instead */
+#define SERCOM_SPI_DBGCTRL_MASK             _U_(0x01)                                      /**< \deprecated (SERCOM_SPI_DBGCTRL) Register MASK  (Use SERCOM_SPI_DBGCTRL_Msk instead)  */
+#define SERCOM_SPI_DBGCTRL_Msk              _U_(0x01)                                      /**< (SERCOM_SPI_DBGCTRL) Register Mask  */
+
+
+/* -------- SERCOM_USART_DBGCTRL : (SERCOM Offset: 0x30) (R/W 8) USART Debug Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DBGSTOP:1;                 /**< bit:      0  Debug Mode                               */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} SERCOM_USART_DBGCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_DBGCTRL_OFFSET         (0x30)                                        /**<  (SERCOM_USART_DBGCTRL) USART Debug Control  Offset */
+#define SERCOM_USART_DBGCTRL_RESETVALUE     _U_(0x00)                                     /**<  (SERCOM_USART_DBGCTRL) USART Debug Control  Reset Value */
+
+#define SERCOM_USART_DBGCTRL_DBGSTOP_Pos    0                                              /**< (SERCOM_USART_DBGCTRL) Debug Mode Position */
+#define SERCOM_USART_DBGCTRL_DBGSTOP_Msk    (_U_(0x1) << SERCOM_USART_DBGCTRL_DBGSTOP_Pos)  /**< (SERCOM_USART_DBGCTRL) Debug Mode Mask */
+#define SERCOM_USART_DBGCTRL_DBGSTOP        SERCOM_USART_DBGCTRL_DBGSTOP_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SERCOM_USART_DBGCTRL_DBGSTOP_Msk instead */
+#define SERCOM_USART_DBGCTRL_MASK           _U_(0x01)                                      /**< \deprecated (SERCOM_USART_DBGCTRL) Register MASK  (Use SERCOM_USART_DBGCTRL_Msk instead)  */
+#define SERCOM_USART_DBGCTRL_Msk            _U_(0x01)                                      /**< (SERCOM_USART_DBGCTRL) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief SERCOM hardware registers */
+typedef struct {  /* Serial Communication Interface */
+  __IO SERCOM_I2CM_CTRLA_Type         CTRLA;          /**< Offset: 0x00 (R/W  32) I2CM Control A */
+  __IO SERCOM_I2CM_CTRLB_Type         CTRLB;          /**< Offset: 0x04 (R/W  32) I2CM Control B */
+  __I  uint8_t                        Reserved1[4];
+  __IO SERCOM_I2CM_BAUD_Type          BAUD;           /**< Offset: 0x0C (R/W  32) I2CM Baud Rate */
+  __I  uint8_t                        Reserved2[4];
+  __IO SERCOM_I2CM_INTENCLR_Type      INTENCLR;       /**< Offset: 0x14 (R/W   8) I2CM Interrupt Enable Clear */
+  __I  uint8_t                        Reserved3[1];
+  __IO SERCOM_I2CM_INTENSET_Type      INTENSET;       /**< Offset: 0x16 (R/W   8) I2CM Interrupt Enable Set */
+  __I  uint8_t                        Reserved4[1];
+  __IO SERCOM_I2CM_INTFLAG_Type       INTFLAG;        /**< Offset: 0x18 (R/W   8) I2CM Interrupt Flag Status and Clear */
+  __I  uint8_t                        Reserved5[1];
+  __IO SERCOM_I2CM_STATUS_Type        STATUS;         /**< Offset: 0x1A (R/W  16) I2CM Status */
+  __I  SERCOM_I2CM_SYNCBUSY_Type      SYNCBUSY;       /**< Offset: 0x1C (R/   32) I2CM Synchronization Busy */
+  __I  uint8_t                        Reserved6[4];
+  __IO SERCOM_I2CM_ADDR_Type          ADDR;           /**< Offset: 0x24 (R/W  32) I2CM Address */
+  __IO SERCOM_I2CM_DATA_Type          DATA;           /**< Offset: 0x28 (R/W   8) I2CM Data */
+  __I  uint8_t                        Reserved7[7];
+  __IO SERCOM_I2CM_DBGCTRL_Type       DBGCTRL;        /**< Offset: 0x30 (R/W   8) I2CM Debug Control */
+} SercomI2cm;
+
+/** \brief SERCOM hardware registers */
+typedef struct {  /* Serial Communication Interface */
+  __IO SERCOM_I2CS_CTRLA_Type         CTRLA;          /**< Offset: 0x00 (R/W  32) I2CS Control A */
+  __IO SERCOM_I2CS_CTRLB_Type         CTRLB;          /**< Offset: 0x04 (R/W  32) I2CS Control B */
+  __I  uint8_t                        Reserved1[12];
+  __IO SERCOM_I2CS_INTENCLR_Type      INTENCLR;       /**< Offset: 0x14 (R/W   8) I2CS Interrupt Enable Clear */
+  __I  uint8_t                        Reserved2[1];
+  __IO SERCOM_I2CS_INTENSET_Type      INTENSET;       /**< Offset: 0x16 (R/W   8) I2CS Interrupt Enable Set */
+  __I  uint8_t                        Reserved3[1];
+  __IO SERCOM_I2CS_INTFLAG_Type       INTFLAG;        /**< Offset: 0x18 (R/W   8) I2CS Interrupt Flag Status and Clear */
+  __I  uint8_t                        Reserved4[1];
+  __IO SERCOM_I2CS_STATUS_Type        STATUS;         /**< Offset: 0x1A (R/W  16) I2CS Status */
+  __I  SERCOM_I2CS_SYNCBUSY_Type      SYNCBUSY;       /**< Offset: 0x1C (R/   32) I2CS Synchronization Busy */
+  __I  uint8_t                        Reserved5[4];
+  __IO SERCOM_I2CS_ADDR_Type          ADDR;           /**< Offset: 0x24 (R/W  32) I2CS Address */
+  __IO SERCOM_I2CS_DATA_Type          DATA;           /**< Offset: 0x28 (R/W   8) I2CS Data */
+} SercomI2cs;
+
+/** \brief SERCOM hardware registers */
+typedef struct {  /* Serial Communication Interface */
+  __IO SERCOM_SPI_CTRLA_Type          CTRLA;          /**< Offset: 0x00 (R/W  32) SPI Control A */
+  __IO SERCOM_SPI_CTRLB_Type          CTRLB;          /**< Offset: 0x04 (R/W  32) SPI Control B */
+  __I  uint8_t                        Reserved1[4];
+  __IO SERCOM_SPI_BAUD_Type           BAUD;           /**< Offset: 0x0C (R/W   8) SPI Baud Rate */
+  __I  uint8_t                        Reserved2[7];
+  __IO SERCOM_SPI_INTENCLR_Type       INTENCLR;       /**< Offset: 0x14 (R/W   8) SPI Interrupt Enable Clear */
+  __I  uint8_t                        Reserved3[1];
+  __IO SERCOM_SPI_INTENSET_Type       INTENSET;       /**< Offset: 0x16 (R/W   8) SPI Interrupt Enable Set */
+  __I  uint8_t                        Reserved4[1];
+  __IO SERCOM_SPI_INTFLAG_Type        INTFLAG;        /**< Offset: 0x18 (R/W   8) SPI Interrupt Flag Status and Clear */
+  __I  uint8_t                        Reserved5[1];
+  __IO SERCOM_SPI_STATUS_Type         STATUS;         /**< Offset: 0x1A (R/W  16) SPI Status */
+  __I  SERCOM_SPI_SYNCBUSY_Type       SYNCBUSY;       /**< Offset: 0x1C (R/   32) SPI Synchronization Busy */
+  __I  uint8_t                        Reserved6[4];
+  __IO SERCOM_SPI_ADDR_Type           ADDR;           /**< Offset: 0x24 (R/W  32) SPI Address */
+  __IO SERCOM_SPI_DATA_Type           DATA;           /**< Offset: 0x28 (R/W  32) SPI Data */
+  __I  uint8_t                        Reserved7[4];
+  __IO SERCOM_SPI_DBGCTRL_Type        DBGCTRL;        /**< Offset: 0x30 (R/W   8) SPI Debug Control */
+} SercomSpi;
+
+/** \brief SERCOM hardware registers */
+typedef struct {  /* Serial Communication Interface */
+  __IO SERCOM_USART_CTRLA_Type        CTRLA;          /**< Offset: 0x00 (R/W  32) USART Control A */
+  __IO SERCOM_USART_CTRLB_Type        CTRLB;          /**< Offset: 0x04 (R/W  32) USART Control B */
+  __IO SERCOM_USART_CTRLC_Type        CTRLC;          /**< Offset: 0x08 (R/W  32) USART Control C */
+  __IO SERCOM_USART_BAUD_Type         BAUD;           /**< Offset: 0x0C (R/W  16) USART Baud Rate */
+  __IO SERCOM_USART_RXPL_Type         RXPL;           /**< Offset: 0x0E (R/W   8) USART Receive Pulse Length */
+  __I  uint8_t                        Reserved1[5];
+  __IO SERCOM_USART_INTENCLR_Type     INTENCLR;       /**< Offset: 0x14 (R/W   8) USART Interrupt Enable Clear */
+  __I  uint8_t                        Reserved2[1];
+  __IO SERCOM_USART_INTENSET_Type     INTENSET;       /**< Offset: 0x16 (R/W   8) USART Interrupt Enable Set */
+  __I  uint8_t                        Reserved3[1];
+  __IO SERCOM_USART_INTFLAG_Type      INTFLAG;        /**< Offset: 0x18 (R/W   8) USART Interrupt Flag Status and Clear */
+  __I  uint8_t                        Reserved4[1];
+  __IO SERCOM_USART_STATUS_Type       STATUS;         /**< Offset: 0x1A (R/W  16) USART Status */
+  __I  SERCOM_USART_SYNCBUSY_Type     SYNCBUSY;       /**< Offset: 0x1C (R/   32) USART Synchronization Busy */
+  __I  SERCOM_USART_RXERRCNT_Type     RXERRCNT;       /**< Offset: 0x20 (R/    8) USART Receive Error Count */
+  __I  uint8_t                        Reserved5[7];
+  __IO SERCOM_USART_DATA_Type         DATA;           /**< Offset: 0x28 (R/W  16) USART Data */
+  __I  uint8_t                        Reserved6[6];
+  __IO SERCOM_USART_DBGCTRL_Type      DBGCTRL;        /**< Offset: 0x30 (R/W   8) USART Debug Control */
+} SercomUsart;
+
+/** \brief SERCOM hardware registers */
+typedef union {  /* Serial Communication Interface */
+       SercomI2cm                     I2CM;           /**< I2C Master Mode */
+       SercomI2cs                     I2CS;           /**< I2C Slave Mode */
+       SercomSpi                      SPI;            /**< SPI Mode */
+       SercomUsart                    USART;          /**< USART Mode */
+} Sercom;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Serial Communication Interface */
+
+#endif /* _SAML11_SERCOM_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/component/supc.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/supc.h
@@ -1,0 +1,653 @@
+/**
+ * \file
+ *
+ * \brief Component description for SUPC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_SUPC_COMPONENT_H_
+#define _SAML11_SUPC_COMPONENT_H_
+#define _SAML11_SUPC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML11 Supply Controller
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR SUPC */
+/* ========================================================================== */
+
+#define SUPC_U2117                      /**< (SUPC) Module ID */
+#define REV_SUPC 0x400                  /**< (SUPC) Module revision */
+
+/* -------- SUPC_INTENCLR : (SUPC Offset: 0x00) (R/W 32) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t BOD33RDY:1;                /**< bit:      0  BOD33 Ready                              */
+    uint32_t BOD33DET:1;                /**< bit:      1  BOD33 Detection                          */
+    uint32_t B33SRDY:1;                 /**< bit:      2  BOD33 Synchronization Ready              */
+    uint32_t BOD12RDY:1;                /**< bit:      3  BOD12 Ready                              */
+    uint32_t BOD12DET:1;                /**< bit:      4  BOD12 Detection                          */
+    uint32_t B12SRDY:1;                 /**< bit:      5  BOD12 Synchronization Ready              */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t VREGRDY:1;                 /**< bit:      8  Voltage Regulator Ready                  */
+    uint32_t :1;                        /**< bit:      9  Reserved */
+    uint32_t VCORERDY:1;                /**< bit:     10  VDDCORE Ready                            */
+    uint32_t ULPVREFRDY:1;              /**< bit:     11  ULPVREF Voltage Reference Ready          */
+    uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SUPC_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SUPC_INTENCLR_OFFSET                (0x00)                                        /**<  (SUPC_INTENCLR) Interrupt Enable Clear  Offset */
+#define SUPC_INTENCLR_RESETVALUE            _U_(0x00)                                     /**<  (SUPC_INTENCLR) Interrupt Enable Clear  Reset Value */
+
+#define SUPC_INTENCLR_BOD33RDY_Pos          0                                              /**< (SUPC_INTENCLR) BOD33 Ready Position */
+#define SUPC_INTENCLR_BOD33RDY_Msk          (_U_(0x1) << SUPC_INTENCLR_BOD33RDY_Pos)       /**< (SUPC_INTENCLR) BOD33 Ready Mask */
+#define SUPC_INTENCLR_BOD33RDY              SUPC_INTENCLR_BOD33RDY_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTENCLR_BOD33RDY_Msk instead */
+#define SUPC_INTENCLR_BOD33DET_Pos          1                                              /**< (SUPC_INTENCLR) BOD33 Detection Position */
+#define SUPC_INTENCLR_BOD33DET_Msk          (_U_(0x1) << SUPC_INTENCLR_BOD33DET_Pos)       /**< (SUPC_INTENCLR) BOD33 Detection Mask */
+#define SUPC_INTENCLR_BOD33DET              SUPC_INTENCLR_BOD33DET_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTENCLR_BOD33DET_Msk instead */
+#define SUPC_INTENCLR_B33SRDY_Pos           2                                              /**< (SUPC_INTENCLR) BOD33 Synchronization Ready Position */
+#define SUPC_INTENCLR_B33SRDY_Msk           (_U_(0x1) << SUPC_INTENCLR_B33SRDY_Pos)        /**< (SUPC_INTENCLR) BOD33 Synchronization Ready Mask */
+#define SUPC_INTENCLR_B33SRDY               SUPC_INTENCLR_B33SRDY_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTENCLR_B33SRDY_Msk instead */
+#define SUPC_INTENCLR_BOD12RDY_Pos          3                                              /**< (SUPC_INTENCLR) BOD12 Ready Position */
+#define SUPC_INTENCLR_BOD12RDY_Msk          (_U_(0x1) << SUPC_INTENCLR_BOD12RDY_Pos)       /**< (SUPC_INTENCLR) BOD12 Ready Mask */
+#define SUPC_INTENCLR_BOD12RDY              SUPC_INTENCLR_BOD12RDY_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTENCLR_BOD12RDY_Msk instead */
+#define SUPC_INTENCLR_BOD12DET_Pos          4                                              /**< (SUPC_INTENCLR) BOD12 Detection Position */
+#define SUPC_INTENCLR_BOD12DET_Msk          (_U_(0x1) << SUPC_INTENCLR_BOD12DET_Pos)       /**< (SUPC_INTENCLR) BOD12 Detection Mask */
+#define SUPC_INTENCLR_BOD12DET              SUPC_INTENCLR_BOD12DET_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTENCLR_BOD12DET_Msk instead */
+#define SUPC_INTENCLR_B12SRDY_Pos           5                                              /**< (SUPC_INTENCLR) BOD12 Synchronization Ready Position */
+#define SUPC_INTENCLR_B12SRDY_Msk           (_U_(0x1) << SUPC_INTENCLR_B12SRDY_Pos)        /**< (SUPC_INTENCLR) BOD12 Synchronization Ready Mask */
+#define SUPC_INTENCLR_B12SRDY               SUPC_INTENCLR_B12SRDY_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTENCLR_B12SRDY_Msk instead */
+#define SUPC_INTENCLR_VREGRDY_Pos           8                                              /**< (SUPC_INTENCLR) Voltage Regulator Ready Position */
+#define SUPC_INTENCLR_VREGRDY_Msk           (_U_(0x1) << SUPC_INTENCLR_VREGRDY_Pos)        /**< (SUPC_INTENCLR) Voltage Regulator Ready Mask */
+#define SUPC_INTENCLR_VREGRDY               SUPC_INTENCLR_VREGRDY_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTENCLR_VREGRDY_Msk instead */
+#define SUPC_INTENCLR_VCORERDY_Pos          10                                             /**< (SUPC_INTENCLR) VDDCORE Ready Position */
+#define SUPC_INTENCLR_VCORERDY_Msk          (_U_(0x1) << SUPC_INTENCLR_VCORERDY_Pos)       /**< (SUPC_INTENCLR) VDDCORE Ready Mask */
+#define SUPC_INTENCLR_VCORERDY              SUPC_INTENCLR_VCORERDY_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTENCLR_VCORERDY_Msk instead */
+#define SUPC_INTENCLR_ULPVREFRDY_Pos        11                                             /**< (SUPC_INTENCLR) ULPVREF Voltage Reference Ready Position */
+#define SUPC_INTENCLR_ULPVREFRDY_Msk        (_U_(0x1) << SUPC_INTENCLR_ULPVREFRDY_Pos)     /**< (SUPC_INTENCLR) ULPVREF Voltage Reference Ready Mask */
+#define SUPC_INTENCLR_ULPVREFRDY            SUPC_INTENCLR_ULPVREFRDY_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTENCLR_ULPVREFRDY_Msk instead */
+#define SUPC_INTENCLR_MASK                  _U_(0xD3F)                                     /**< \deprecated (SUPC_INTENCLR) Register MASK  (Use SUPC_INTENCLR_Msk instead)  */
+#define SUPC_INTENCLR_Msk                   _U_(0xD3F)                                     /**< (SUPC_INTENCLR) Register Mask  */
+
+
+/* -------- SUPC_INTENSET : (SUPC Offset: 0x04) (R/W 32) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t BOD33RDY:1;                /**< bit:      0  BOD33 Ready                              */
+    uint32_t BOD33DET:1;                /**< bit:      1  BOD33 Detection                          */
+    uint32_t B33SRDY:1;                 /**< bit:      2  BOD33 Synchronization Ready              */
+    uint32_t BOD12RDY:1;                /**< bit:      3  BOD12 Ready                              */
+    uint32_t BOD12DET:1;                /**< bit:      4  BOD12 Detection                          */
+    uint32_t B12SRDY:1;                 /**< bit:      5  BOD12 Synchronization Ready              */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t VREGRDY:1;                 /**< bit:      8  Voltage Regulator Ready                  */
+    uint32_t :1;                        /**< bit:      9  Reserved */
+    uint32_t VCORERDY:1;                /**< bit:     10  VDDCORE Ready                            */
+    uint32_t ULPVREFRDY:1;              /**< bit:     11  ULPVREF Voltage Reference Ready          */
+    uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SUPC_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SUPC_INTENSET_OFFSET                (0x04)                                        /**<  (SUPC_INTENSET) Interrupt Enable Set  Offset */
+#define SUPC_INTENSET_RESETVALUE            _U_(0x00)                                     /**<  (SUPC_INTENSET) Interrupt Enable Set  Reset Value */
+
+#define SUPC_INTENSET_BOD33RDY_Pos          0                                              /**< (SUPC_INTENSET) BOD33 Ready Position */
+#define SUPC_INTENSET_BOD33RDY_Msk          (_U_(0x1) << SUPC_INTENSET_BOD33RDY_Pos)       /**< (SUPC_INTENSET) BOD33 Ready Mask */
+#define SUPC_INTENSET_BOD33RDY              SUPC_INTENSET_BOD33RDY_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTENSET_BOD33RDY_Msk instead */
+#define SUPC_INTENSET_BOD33DET_Pos          1                                              /**< (SUPC_INTENSET) BOD33 Detection Position */
+#define SUPC_INTENSET_BOD33DET_Msk          (_U_(0x1) << SUPC_INTENSET_BOD33DET_Pos)       /**< (SUPC_INTENSET) BOD33 Detection Mask */
+#define SUPC_INTENSET_BOD33DET              SUPC_INTENSET_BOD33DET_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTENSET_BOD33DET_Msk instead */
+#define SUPC_INTENSET_B33SRDY_Pos           2                                              /**< (SUPC_INTENSET) BOD33 Synchronization Ready Position */
+#define SUPC_INTENSET_B33SRDY_Msk           (_U_(0x1) << SUPC_INTENSET_B33SRDY_Pos)        /**< (SUPC_INTENSET) BOD33 Synchronization Ready Mask */
+#define SUPC_INTENSET_B33SRDY               SUPC_INTENSET_B33SRDY_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTENSET_B33SRDY_Msk instead */
+#define SUPC_INTENSET_BOD12RDY_Pos          3                                              /**< (SUPC_INTENSET) BOD12 Ready Position */
+#define SUPC_INTENSET_BOD12RDY_Msk          (_U_(0x1) << SUPC_INTENSET_BOD12RDY_Pos)       /**< (SUPC_INTENSET) BOD12 Ready Mask */
+#define SUPC_INTENSET_BOD12RDY              SUPC_INTENSET_BOD12RDY_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTENSET_BOD12RDY_Msk instead */
+#define SUPC_INTENSET_BOD12DET_Pos          4                                              /**< (SUPC_INTENSET) BOD12 Detection Position */
+#define SUPC_INTENSET_BOD12DET_Msk          (_U_(0x1) << SUPC_INTENSET_BOD12DET_Pos)       /**< (SUPC_INTENSET) BOD12 Detection Mask */
+#define SUPC_INTENSET_BOD12DET              SUPC_INTENSET_BOD12DET_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTENSET_BOD12DET_Msk instead */
+#define SUPC_INTENSET_B12SRDY_Pos           5                                              /**< (SUPC_INTENSET) BOD12 Synchronization Ready Position */
+#define SUPC_INTENSET_B12SRDY_Msk           (_U_(0x1) << SUPC_INTENSET_B12SRDY_Pos)        /**< (SUPC_INTENSET) BOD12 Synchronization Ready Mask */
+#define SUPC_INTENSET_B12SRDY               SUPC_INTENSET_B12SRDY_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTENSET_B12SRDY_Msk instead */
+#define SUPC_INTENSET_VREGRDY_Pos           8                                              /**< (SUPC_INTENSET) Voltage Regulator Ready Position */
+#define SUPC_INTENSET_VREGRDY_Msk           (_U_(0x1) << SUPC_INTENSET_VREGRDY_Pos)        /**< (SUPC_INTENSET) Voltage Regulator Ready Mask */
+#define SUPC_INTENSET_VREGRDY               SUPC_INTENSET_VREGRDY_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTENSET_VREGRDY_Msk instead */
+#define SUPC_INTENSET_VCORERDY_Pos          10                                             /**< (SUPC_INTENSET) VDDCORE Ready Position */
+#define SUPC_INTENSET_VCORERDY_Msk          (_U_(0x1) << SUPC_INTENSET_VCORERDY_Pos)       /**< (SUPC_INTENSET) VDDCORE Ready Mask */
+#define SUPC_INTENSET_VCORERDY              SUPC_INTENSET_VCORERDY_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTENSET_VCORERDY_Msk instead */
+#define SUPC_INTENSET_ULPVREFRDY_Pos        11                                             /**< (SUPC_INTENSET) ULPVREF Voltage Reference Ready Position */
+#define SUPC_INTENSET_ULPVREFRDY_Msk        (_U_(0x1) << SUPC_INTENSET_ULPVREFRDY_Pos)     /**< (SUPC_INTENSET) ULPVREF Voltage Reference Ready Mask */
+#define SUPC_INTENSET_ULPVREFRDY            SUPC_INTENSET_ULPVREFRDY_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTENSET_ULPVREFRDY_Msk instead */
+#define SUPC_INTENSET_MASK                  _U_(0xD3F)                                     /**< \deprecated (SUPC_INTENSET) Register MASK  (Use SUPC_INTENSET_Msk instead)  */
+#define SUPC_INTENSET_Msk                   _U_(0xD3F)                                     /**< (SUPC_INTENSET) Register Mask  */
+
+
+/* -------- SUPC_INTFLAG : (SUPC Offset: 0x08) (R/W 32) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint32_t BOD33RDY:1;                /**< bit:      0  BOD33 Ready                              */
+    __I uint32_t BOD33DET:1;                /**< bit:      1  BOD33 Detection                          */
+    __I uint32_t B33SRDY:1;                 /**< bit:      2  BOD33 Synchronization Ready              */
+    __I uint32_t BOD12RDY:1;                /**< bit:      3  BOD12 Ready                              */
+    __I uint32_t BOD12DET:1;                /**< bit:      4  BOD12 Detection                          */
+    __I uint32_t B12SRDY:1;                 /**< bit:      5  BOD12 Synchronization Ready              */
+    __I uint32_t :2;                        /**< bit:   6..7  Reserved */
+    __I uint32_t VREGRDY:1;                 /**< bit:      8  Voltage Regulator Ready                  */
+    __I uint32_t :1;                        /**< bit:      9  Reserved */
+    __I uint32_t VCORERDY:1;                /**< bit:     10  VDDCORE Ready                            */
+    __I uint32_t ULPVREFRDY:1;              /**< bit:     11  ULPVREF Voltage Reference Ready          */
+    __I uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SUPC_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SUPC_INTFLAG_OFFSET                 (0x08)                                        /**<  (SUPC_INTFLAG) Interrupt Flag Status and Clear  Offset */
+#define SUPC_INTFLAG_RESETVALUE             _U_(0x00)                                     /**<  (SUPC_INTFLAG) Interrupt Flag Status and Clear  Reset Value */
+
+#define SUPC_INTFLAG_BOD33RDY_Pos           0                                              /**< (SUPC_INTFLAG) BOD33 Ready Position */
+#define SUPC_INTFLAG_BOD33RDY_Msk           (_U_(0x1) << SUPC_INTFLAG_BOD33RDY_Pos)        /**< (SUPC_INTFLAG) BOD33 Ready Mask */
+#define SUPC_INTFLAG_BOD33RDY               SUPC_INTFLAG_BOD33RDY_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTFLAG_BOD33RDY_Msk instead */
+#define SUPC_INTFLAG_BOD33DET_Pos           1                                              /**< (SUPC_INTFLAG) BOD33 Detection Position */
+#define SUPC_INTFLAG_BOD33DET_Msk           (_U_(0x1) << SUPC_INTFLAG_BOD33DET_Pos)        /**< (SUPC_INTFLAG) BOD33 Detection Mask */
+#define SUPC_INTFLAG_BOD33DET               SUPC_INTFLAG_BOD33DET_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTFLAG_BOD33DET_Msk instead */
+#define SUPC_INTFLAG_B33SRDY_Pos            2                                              /**< (SUPC_INTFLAG) BOD33 Synchronization Ready Position */
+#define SUPC_INTFLAG_B33SRDY_Msk            (_U_(0x1) << SUPC_INTFLAG_B33SRDY_Pos)         /**< (SUPC_INTFLAG) BOD33 Synchronization Ready Mask */
+#define SUPC_INTFLAG_B33SRDY                SUPC_INTFLAG_B33SRDY_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTFLAG_B33SRDY_Msk instead */
+#define SUPC_INTFLAG_BOD12RDY_Pos           3                                              /**< (SUPC_INTFLAG) BOD12 Ready Position */
+#define SUPC_INTFLAG_BOD12RDY_Msk           (_U_(0x1) << SUPC_INTFLAG_BOD12RDY_Pos)        /**< (SUPC_INTFLAG) BOD12 Ready Mask */
+#define SUPC_INTFLAG_BOD12RDY               SUPC_INTFLAG_BOD12RDY_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTFLAG_BOD12RDY_Msk instead */
+#define SUPC_INTFLAG_BOD12DET_Pos           4                                              /**< (SUPC_INTFLAG) BOD12 Detection Position */
+#define SUPC_INTFLAG_BOD12DET_Msk           (_U_(0x1) << SUPC_INTFLAG_BOD12DET_Pos)        /**< (SUPC_INTFLAG) BOD12 Detection Mask */
+#define SUPC_INTFLAG_BOD12DET               SUPC_INTFLAG_BOD12DET_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTFLAG_BOD12DET_Msk instead */
+#define SUPC_INTFLAG_B12SRDY_Pos            5                                              /**< (SUPC_INTFLAG) BOD12 Synchronization Ready Position */
+#define SUPC_INTFLAG_B12SRDY_Msk            (_U_(0x1) << SUPC_INTFLAG_B12SRDY_Pos)         /**< (SUPC_INTFLAG) BOD12 Synchronization Ready Mask */
+#define SUPC_INTFLAG_B12SRDY                SUPC_INTFLAG_B12SRDY_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTFLAG_B12SRDY_Msk instead */
+#define SUPC_INTFLAG_VREGRDY_Pos            8                                              /**< (SUPC_INTFLAG) Voltage Regulator Ready Position */
+#define SUPC_INTFLAG_VREGRDY_Msk            (_U_(0x1) << SUPC_INTFLAG_VREGRDY_Pos)         /**< (SUPC_INTFLAG) Voltage Regulator Ready Mask */
+#define SUPC_INTFLAG_VREGRDY                SUPC_INTFLAG_VREGRDY_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTFLAG_VREGRDY_Msk instead */
+#define SUPC_INTFLAG_VCORERDY_Pos           10                                             /**< (SUPC_INTFLAG) VDDCORE Ready Position */
+#define SUPC_INTFLAG_VCORERDY_Msk           (_U_(0x1) << SUPC_INTFLAG_VCORERDY_Pos)        /**< (SUPC_INTFLAG) VDDCORE Ready Mask */
+#define SUPC_INTFLAG_VCORERDY               SUPC_INTFLAG_VCORERDY_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTFLAG_VCORERDY_Msk instead */
+#define SUPC_INTFLAG_ULPVREFRDY_Pos         11                                             /**< (SUPC_INTFLAG) ULPVREF Voltage Reference Ready Position */
+#define SUPC_INTFLAG_ULPVREFRDY_Msk         (_U_(0x1) << SUPC_INTFLAG_ULPVREFRDY_Pos)      /**< (SUPC_INTFLAG) ULPVREF Voltage Reference Ready Mask */
+#define SUPC_INTFLAG_ULPVREFRDY             SUPC_INTFLAG_ULPVREFRDY_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_INTFLAG_ULPVREFRDY_Msk instead */
+#define SUPC_INTFLAG_MASK                   _U_(0xD3F)                                     /**< \deprecated (SUPC_INTFLAG) Register MASK  (Use SUPC_INTFLAG_Msk instead)  */
+#define SUPC_INTFLAG_Msk                    _U_(0xD3F)                                     /**< (SUPC_INTFLAG) Register Mask  */
+
+
+/* -------- SUPC_STATUS : (SUPC Offset: 0x0c) (R/ 32) Power and Clocks Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t BOD33RDY:1;                /**< bit:      0  BOD33 Ready                              */
+    uint32_t BOD33DET:1;                /**< bit:      1  BOD33 Detection                          */
+    uint32_t B33SRDY:1;                 /**< bit:      2  BOD33 Synchronization Ready              */
+    uint32_t BOD12RDY:1;                /**< bit:      3  BOD12 Ready                              */
+    uint32_t BOD12DET:1;                /**< bit:      4  BOD12 Detection                          */
+    uint32_t B12SRDY:1;                 /**< bit:      5  BOD12 Synchronization Ready              */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t VREGRDY:1;                 /**< bit:      8  Voltage Regulator Ready                  */
+    uint32_t :1;                        /**< bit:      9  Reserved */
+    uint32_t VCORERDY:1;                /**< bit:     10  VDDCORE Ready                            */
+    uint32_t :1;                        /**< bit:     11  Reserved */
+    uint32_t ULPVREFRDY:1;              /**< bit:     12  Low Power Voltage Reference Ready        */
+    uint32_t ULPBIASRDY:1;              /**< bit:     13  Low Power Voltage Bias Ready             */
+    uint32_t :18;                       /**< bit: 14..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SUPC_STATUS_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SUPC_STATUS_OFFSET                  (0x0C)                                        /**<  (SUPC_STATUS) Power and Clocks Status  Offset */
+#define SUPC_STATUS_RESETVALUE              _U_(0x00)                                     /**<  (SUPC_STATUS) Power and Clocks Status  Reset Value */
+
+#define SUPC_STATUS_BOD33RDY_Pos            0                                              /**< (SUPC_STATUS) BOD33 Ready Position */
+#define SUPC_STATUS_BOD33RDY_Msk            (_U_(0x1) << SUPC_STATUS_BOD33RDY_Pos)         /**< (SUPC_STATUS) BOD33 Ready Mask */
+#define SUPC_STATUS_BOD33RDY                SUPC_STATUS_BOD33RDY_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_STATUS_BOD33RDY_Msk instead */
+#define SUPC_STATUS_BOD33DET_Pos            1                                              /**< (SUPC_STATUS) BOD33 Detection Position */
+#define SUPC_STATUS_BOD33DET_Msk            (_U_(0x1) << SUPC_STATUS_BOD33DET_Pos)         /**< (SUPC_STATUS) BOD33 Detection Mask */
+#define SUPC_STATUS_BOD33DET                SUPC_STATUS_BOD33DET_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_STATUS_BOD33DET_Msk instead */
+#define SUPC_STATUS_B33SRDY_Pos             2                                              /**< (SUPC_STATUS) BOD33 Synchronization Ready Position */
+#define SUPC_STATUS_B33SRDY_Msk             (_U_(0x1) << SUPC_STATUS_B33SRDY_Pos)          /**< (SUPC_STATUS) BOD33 Synchronization Ready Mask */
+#define SUPC_STATUS_B33SRDY                 SUPC_STATUS_B33SRDY_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_STATUS_B33SRDY_Msk instead */
+#define SUPC_STATUS_BOD12RDY_Pos            3                                              /**< (SUPC_STATUS) BOD12 Ready Position */
+#define SUPC_STATUS_BOD12RDY_Msk            (_U_(0x1) << SUPC_STATUS_BOD12RDY_Pos)         /**< (SUPC_STATUS) BOD12 Ready Mask */
+#define SUPC_STATUS_BOD12RDY                SUPC_STATUS_BOD12RDY_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_STATUS_BOD12RDY_Msk instead */
+#define SUPC_STATUS_BOD12DET_Pos            4                                              /**< (SUPC_STATUS) BOD12 Detection Position */
+#define SUPC_STATUS_BOD12DET_Msk            (_U_(0x1) << SUPC_STATUS_BOD12DET_Pos)         /**< (SUPC_STATUS) BOD12 Detection Mask */
+#define SUPC_STATUS_BOD12DET                SUPC_STATUS_BOD12DET_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_STATUS_BOD12DET_Msk instead */
+#define SUPC_STATUS_B12SRDY_Pos             5                                              /**< (SUPC_STATUS) BOD12 Synchronization Ready Position */
+#define SUPC_STATUS_B12SRDY_Msk             (_U_(0x1) << SUPC_STATUS_B12SRDY_Pos)          /**< (SUPC_STATUS) BOD12 Synchronization Ready Mask */
+#define SUPC_STATUS_B12SRDY                 SUPC_STATUS_B12SRDY_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_STATUS_B12SRDY_Msk instead */
+#define SUPC_STATUS_VREGRDY_Pos             8                                              /**< (SUPC_STATUS) Voltage Regulator Ready Position */
+#define SUPC_STATUS_VREGRDY_Msk             (_U_(0x1) << SUPC_STATUS_VREGRDY_Pos)          /**< (SUPC_STATUS) Voltage Regulator Ready Mask */
+#define SUPC_STATUS_VREGRDY                 SUPC_STATUS_VREGRDY_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_STATUS_VREGRDY_Msk instead */
+#define SUPC_STATUS_VCORERDY_Pos            10                                             /**< (SUPC_STATUS) VDDCORE Ready Position */
+#define SUPC_STATUS_VCORERDY_Msk            (_U_(0x1) << SUPC_STATUS_VCORERDY_Pos)         /**< (SUPC_STATUS) VDDCORE Ready Mask */
+#define SUPC_STATUS_VCORERDY                SUPC_STATUS_VCORERDY_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_STATUS_VCORERDY_Msk instead */
+#define SUPC_STATUS_ULPVREFRDY_Pos          12                                             /**< (SUPC_STATUS) Low Power Voltage Reference Ready Position */
+#define SUPC_STATUS_ULPVREFRDY_Msk          (_U_(0x1) << SUPC_STATUS_ULPVREFRDY_Pos)       /**< (SUPC_STATUS) Low Power Voltage Reference Ready Mask */
+#define SUPC_STATUS_ULPVREFRDY              SUPC_STATUS_ULPVREFRDY_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_STATUS_ULPVREFRDY_Msk instead */
+#define SUPC_STATUS_ULPBIASRDY_Pos          13                                             /**< (SUPC_STATUS) Low Power Voltage Bias Ready Position */
+#define SUPC_STATUS_ULPBIASRDY_Msk          (_U_(0x1) << SUPC_STATUS_ULPBIASRDY_Pos)       /**< (SUPC_STATUS) Low Power Voltage Bias Ready Mask */
+#define SUPC_STATUS_ULPBIASRDY              SUPC_STATUS_ULPBIASRDY_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_STATUS_ULPBIASRDY_Msk instead */
+#define SUPC_STATUS_MASK                    _U_(0x353F)                                    /**< \deprecated (SUPC_STATUS) Register MASK  (Use SUPC_STATUS_Msk instead)  */
+#define SUPC_STATUS_Msk                     _U_(0x353F)                                    /**< (SUPC_STATUS) Register Mask  */
+
+
+/* -------- SUPC_BOD33 : (SUPC Offset: 0x10) (R/W 32) BOD33 Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint32_t HYST:1;                    /**< bit:      2  Hysteresis Enable                        */
+    uint32_t ACTION:2;                  /**< bit:   3..4  Action when Threshold Crossed            */
+    uint32_t STDBYCFG:1;                /**< bit:      5  Configuration in Standby mode            */
+    uint32_t RUNSTDBY:1;                /**< bit:      6  Run during Standby                       */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t ACTCFG:1;                  /**< bit:      8  Configuration in Active mode             */
+    uint32_t :2;                        /**< bit:  9..10  Reserved */
+    uint32_t REFSEL:1;                  /**< bit:     11  BOD33 Voltage Reference Selection        */
+    uint32_t PSEL:4;                    /**< bit: 12..15  Prescaler Select                         */
+    uint32_t LEVEL:6;                   /**< bit: 16..21  Threshold Level for VDD                  */
+    uint32_t :10;                       /**< bit: 22..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SUPC_BOD33_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SUPC_BOD33_OFFSET                   (0x10)                                        /**<  (SUPC_BOD33) BOD33 Control  Offset */
+#define SUPC_BOD33_RESETVALUE               _U_(0x00)                                     /**<  (SUPC_BOD33) BOD33 Control  Reset Value */
+
+#define SUPC_BOD33_ENABLE_Pos               1                                              /**< (SUPC_BOD33) Enable Position */
+#define SUPC_BOD33_ENABLE_Msk               (_U_(0x1) << SUPC_BOD33_ENABLE_Pos)            /**< (SUPC_BOD33) Enable Mask */
+#define SUPC_BOD33_ENABLE                   SUPC_BOD33_ENABLE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_BOD33_ENABLE_Msk instead */
+#define SUPC_BOD33_HYST_Pos                 2                                              /**< (SUPC_BOD33) Hysteresis Enable Position */
+#define SUPC_BOD33_HYST_Msk                 (_U_(0x1) << SUPC_BOD33_HYST_Pos)              /**< (SUPC_BOD33) Hysteresis Enable Mask */
+#define SUPC_BOD33_HYST                     SUPC_BOD33_HYST_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_BOD33_HYST_Msk instead */
+#define SUPC_BOD33_ACTION_Pos               3                                              /**< (SUPC_BOD33) Action when Threshold Crossed Position */
+#define SUPC_BOD33_ACTION_Msk               (_U_(0x3) << SUPC_BOD33_ACTION_Pos)            /**< (SUPC_BOD33) Action when Threshold Crossed Mask */
+#define SUPC_BOD33_ACTION(value)            (SUPC_BOD33_ACTION_Msk & ((value) << SUPC_BOD33_ACTION_Pos))
+#define   SUPC_BOD33_ACTION_NONE_Val        _U_(0x0)                                       /**< (SUPC_BOD33) No action  */
+#define   SUPC_BOD33_ACTION_RESET_Val       _U_(0x1)                                       /**< (SUPC_BOD33) The BOD33 generates a reset  */
+#define   SUPC_BOD33_ACTION_INT_Val         _U_(0x2)                                       /**< (SUPC_BOD33) The BOD33 generates an interrupt  */
+#define   SUPC_BOD33_ACTION_BKUP_Val        _U_(0x3)                                       /**< (SUPC_BOD33) The BOD33 puts the device in backup sleep mode if VMON=0  */
+#define SUPC_BOD33_ACTION_NONE              (SUPC_BOD33_ACTION_NONE_Val << SUPC_BOD33_ACTION_Pos)  /**< (SUPC_BOD33) No action Position  */
+#define SUPC_BOD33_ACTION_RESET             (SUPC_BOD33_ACTION_RESET_Val << SUPC_BOD33_ACTION_Pos)  /**< (SUPC_BOD33) The BOD33 generates a reset Position  */
+#define SUPC_BOD33_ACTION_INT               (SUPC_BOD33_ACTION_INT_Val << SUPC_BOD33_ACTION_Pos)  /**< (SUPC_BOD33) The BOD33 generates an interrupt Position  */
+#define SUPC_BOD33_ACTION_BKUP              (SUPC_BOD33_ACTION_BKUP_Val << SUPC_BOD33_ACTION_Pos)  /**< (SUPC_BOD33) The BOD33 puts the device in backup sleep mode if VMON=0 Position  */
+#define SUPC_BOD33_STDBYCFG_Pos             5                                              /**< (SUPC_BOD33) Configuration in Standby mode Position */
+#define SUPC_BOD33_STDBYCFG_Msk             (_U_(0x1) << SUPC_BOD33_STDBYCFG_Pos)          /**< (SUPC_BOD33) Configuration in Standby mode Mask */
+#define SUPC_BOD33_STDBYCFG                 SUPC_BOD33_STDBYCFG_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_BOD33_STDBYCFG_Msk instead */
+#define SUPC_BOD33_RUNSTDBY_Pos             6                                              /**< (SUPC_BOD33) Run during Standby Position */
+#define SUPC_BOD33_RUNSTDBY_Msk             (_U_(0x1) << SUPC_BOD33_RUNSTDBY_Pos)          /**< (SUPC_BOD33) Run during Standby Mask */
+#define SUPC_BOD33_RUNSTDBY                 SUPC_BOD33_RUNSTDBY_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_BOD33_RUNSTDBY_Msk instead */
+#define SUPC_BOD33_ACTCFG_Pos               8                                              /**< (SUPC_BOD33) Configuration in Active mode Position */
+#define SUPC_BOD33_ACTCFG_Msk               (_U_(0x1) << SUPC_BOD33_ACTCFG_Pos)            /**< (SUPC_BOD33) Configuration in Active mode Mask */
+#define SUPC_BOD33_ACTCFG                   SUPC_BOD33_ACTCFG_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_BOD33_ACTCFG_Msk instead */
+#define SUPC_BOD33_REFSEL_Pos               11                                             /**< (SUPC_BOD33) BOD33 Voltage Reference Selection Position */
+#define SUPC_BOD33_REFSEL_Msk               (_U_(0x1) << SUPC_BOD33_REFSEL_Pos)            /**< (SUPC_BOD33) BOD33 Voltage Reference Selection Mask */
+#define SUPC_BOD33_REFSEL                   SUPC_BOD33_REFSEL_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_BOD33_REFSEL_Msk instead */
+#define   SUPC_BOD33_REFSEL_SEL_VREFDETREF_Val _U_(0x0)                                       /**< (SUPC_BOD33) Selects VREFDETREF for the BOD33  */
+#define   SUPC_BOD33_REFSEL_SEL_ULPVREF_Val _U_(0x1)                                       /**< (SUPC_BOD33) Selects ULPVREF for the BOD33  */
+#define SUPC_BOD33_REFSEL_SEL_VREFDETREF    (SUPC_BOD33_REFSEL_SEL_VREFDETREF_Val << SUPC_BOD33_REFSEL_Pos)  /**< (SUPC_BOD33) Selects VREFDETREF for the BOD33 Position  */
+#define SUPC_BOD33_REFSEL_SEL_ULPVREF       (SUPC_BOD33_REFSEL_SEL_ULPVREF_Val << SUPC_BOD33_REFSEL_Pos)  /**< (SUPC_BOD33) Selects ULPVREF for the BOD33 Position  */
+#define SUPC_BOD33_PSEL_Pos                 12                                             /**< (SUPC_BOD33) Prescaler Select Position */
+#define SUPC_BOD33_PSEL_Msk                 (_U_(0xF) << SUPC_BOD33_PSEL_Pos)              /**< (SUPC_BOD33) Prescaler Select Mask */
+#define SUPC_BOD33_PSEL(value)              (SUPC_BOD33_PSEL_Msk & ((value) << SUPC_BOD33_PSEL_Pos))
+#define   SUPC_BOD33_PSEL_DIV2_Val          _U_(0x0)                                       /**< (SUPC_BOD33) Divide clock by 2  */
+#define   SUPC_BOD33_PSEL_DIV4_Val          _U_(0x1)                                       /**< (SUPC_BOD33) Divide clock by 4  */
+#define   SUPC_BOD33_PSEL_DIV8_Val          _U_(0x2)                                       /**< (SUPC_BOD33) Divide clock by 8  */
+#define   SUPC_BOD33_PSEL_DIV16_Val         _U_(0x3)                                       /**< (SUPC_BOD33) Divide clock by 16  */
+#define   SUPC_BOD33_PSEL_DIV32_Val         _U_(0x4)                                       /**< (SUPC_BOD33) Divide clock by 32  */
+#define   SUPC_BOD33_PSEL_DIV64_Val         _U_(0x5)                                       /**< (SUPC_BOD33) Divide clock by 64  */
+#define   SUPC_BOD33_PSEL_DIV128_Val        _U_(0x6)                                       /**< (SUPC_BOD33) Divide clock by 128  */
+#define   SUPC_BOD33_PSEL_DIV256_Val        _U_(0x7)                                       /**< (SUPC_BOD33) Divide clock by 256  */
+#define   SUPC_BOD33_PSEL_DIV512_Val        _U_(0x8)                                       /**< (SUPC_BOD33) Divide clock by 512  */
+#define   SUPC_BOD33_PSEL_DIV1024_Val       _U_(0x9)                                       /**< (SUPC_BOD33) Divide clock by 1024  */
+#define   SUPC_BOD33_PSEL_DIV2048_Val       _U_(0xA)                                       /**< (SUPC_BOD33) Divide clock by 2048  */
+#define   SUPC_BOD33_PSEL_DIV4096_Val       _U_(0xB)                                       /**< (SUPC_BOD33) Divide clock by 4096  */
+#define   SUPC_BOD33_PSEL_DIV8192_Val       _U_(0xC)                                       /**< (SUPC_BOD33) Divide clock by 8192  */
+#define   SUPC_BOD33_PSEL_DIV16384_Val      _U_(0xD)                                       /**< (SUPC_BOD33) Divide clock by 16384  */
+#define   SUPC_BOD33_PSEL_DIV32768_Val      _U_(0xE)                                       /**< (SUPC_BOD33) Divide clock by 32768  */
+#define   SUPC_BOD33_PSEL_DIV65536_Val      _U_(0xF)                                       /**< (SUPC_BOD33) Divide clock by 65536  */
+#define SUPC_BOD33_PSEL_DIV2                (SUPC_BOD33_PSEL_DIV2_Val << SUPC_BOD33_PSEL_Pos)  /**< (SUPC_BOD33) Divide clock by 2 Position  */
+#define SUPC_BOD33_PSEL_DIV4                (SUPC_BOD33_PSEL_DIV4_Val << SUPC_BOD33_PSEL_Pos)  /**< (SUPC_BOD33) Divide clock by 4 Position  */
+#define SUPC_BOD33_PSEL_DIV8                (SUPC_BOD33_PSEL_DIV8_Val << SUPC_BOD33_PSEL_Pos)  /**< (SUPC_BOD33) Divide clock by 8 Position  */
+#define SUPC_BOD33_PSEL_DIV16               (SUPC_BOD33_PSEL_DIV16_Val << SUPC_BOD33_PSEL_Pos)  /**< (SUPC_BOD33) Divide clock by 16 Position  */
+#define SUPC_BOD33_PSEL_DIV32               (SUPC_BOD33_PSEL_DIV32_Val << SUPC_BOD33_PSEL_Pos)  /**< (SUPC_BOD33) Divide clock by 32 Position  */
+#define SUPC_BOD33_PSEL_DIV64               (SUPC_BOD33_PSEL_DIV64_Val << SUPC_BOD33_PSEL_Pos)  /**< (SUPC_BOD33) Divide clock by 64 Position  */
+#define SUPC_BOD33_PSEL_DIV128              (SUPC_BOD33_PSEL_DIV128_Val << SUPC_BOD33_PSEL_Pos)  /**< (SUPC_BOD33) Divide clock by 128 Position  */
+#define SUPC_BOD33_PSEL_DIV256              (SUPC_BOD33_PSEL_DIV256_Val << SUPC_BOD33_PSEL_Pos)  /**< (SUPC_BOD33) Divide clock by 256 Position  */
+#define SUPC_BOD33_PSEL_DIV512              (SUPC_BOD33_PSEL_DIV512_Val << SUPC_BOD33_PSEL_Pos)  /**< (SUPC_BOD33) Divide clock by 512 Position  */
+#define SUPC_BOD33_PSEL_DIV1024             (SUPC_BOD33_PSEL_DIV1024_Val << SUPC_BOD33_PSEL_Pos)  /**< (SUPC_BOD33) Divide clock by 1024 Position  */
+#define SUPC_BOD33_PSEL_DIV2048             (SUPC_BOD33_PSEL_DIV2048_Val << SUPC_BOD33_PSEL_Pos)  /**< (SUPC_BOD33) Divide clock by 2048 Position  */
+#define SUPC_BOD33_PSEL_DIV4096             (SUPC_BOD33_PSEL_DIV4096_Val << SUPC_BOD33_PSEL_Pos)  /**< (SUPC_BOD33) Divide clock by 4096 Position  */
+#define SUPC_BOD33_PSEL_DIV8192             (SUPC_BOD33_PSEL_DIV8192_Val << SUPC_BOD33_PSEL_Pos)  /**< (SUPC_BOD33) Divide clock by 8192 Position  */
+#define SUPC_BOD33_PSEL_DIV16384            (SUPC_BOD33_PSEL_DIV16384_Val << SUPC_BOD33_PSEL_Pos)  /**< (SUPC_BOD33) Divide clock by 16384 Position  */
+#define SUPC_BOD33_PSEL_DIV32768            (SUPC_BOD33_PSEL_DIV32768_Val << SUPC_BOD33_PSEL_Pos)  /**< (SUPC_BOD33) Divide clock by 32768 Position  */
+#define SUPC_BOD33_PSEL_DIV65536            (SUPC_BOD33_PSEL_DIV65536_Val << SUPC_BOD33_PSEL_Pos)  /**< (SUPC_BOD33) Divide clock by 65536 Position  */
+#define SUPC_BOD33_LEVEL_Pos                16                                             /**< (SUPC_BOD33) Threshold Level for VDD Position */
+#define SUPC_BOD33_LEVEL_Msk                (_U_(0x3F) << SUPC_BOD33_LEVEL_Pos)            /**< (SUPC_BOD33) Threshold Level for VDD Mask */
+#define SUPC_BOD33_LEVEL(value)             (SUPC_BOD33_LEVEL_Msk & ((value) << SUPC_BOD33_LEVEL_Pos))
+#define SUPC_BOD33_MASK                     _U_(0x3FF97E)                                  /**< \deprecated (SUPC_BOD33) Register MASK  (Use SUPC_BOD33_Msk instead)  */
+#define SUPC_BOD33_Msk                      _U_(0x3FF97E)                                  /**< (SUPC_BOD33) Register Mask  */
+
+
+/* -------- SUPC_BOD12 : (SUPC Offset: 0x14) (R/W 32) BOD12 Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint32_t HYST:1;                    /**< bit:      2  Hysteresis Enable                        */
+    uint32_t ACTION:2;                  /**< bit:   3..4  Action when Threshold Crossed            */
+    uint32_t STDBYCFG:1;                /**< bit:      5  Configuration in Standby mode            */
+    uint32_t RUNSTDBY:1;                /**< bit:      6  Run during Standby                       */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t ACTCFG:1;                  /**< bit:      8  Configuration in Active mode             */
+    uint32_t :3;                        /**< bit:  9..11  Reserved */
+    uint32_t PSEL:4;                    /**< bit: 12..15  Prescaler Select                         */
+    uint32_t LEVEL:6;                   /**< bit: 16..21  Threshold Level                          */
+    uint32_t :10;                       /**< bit: 22..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SUPC_BOD12_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SUPC_BOD12_OFFSET                   (0x14)                                        /**<  (SUPC_BOD12) BOD12 Control  Offset */
+#define SUPC_BOD12_RESETVALUE               _U_(0x00)                                     /**<  (SUPC_BOD12) BOD12 Control  Reset Value */
+
+#define SUPC_BOD12_ENABLE_Pos               1                                              /**< (SUPC_BOD12) Enable Position */
+#define SUPC_BOD12_ENABLE_Msk               (_U_(0x1) << SUPC_BOD12_ENABLE_Pos)            /**< (SUPC_BOD12) Enable Mask */
+#define SUPC_BOD12_ENABLE                   SUPC_BOD12_ENABLE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_BOD12_ENABLE_Msk instead */
+#define SUPC_BOD12_HYST_Pos                 2                                              /**< (SUPC_BOD12) Hysteresis Enable Position */
+#define SUPC_BOD12_HYST_Msk                 (_U_(0x1) << SUPC_BOD12_HYST_Pos)              /**< (SUPC_BOD12) Hysteresis Enable Mask */
+#define SUPC_BOD12_HYST                     SUPC_BOD12_HYST_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_BOD12_HYST_Msk instead */
+#define SUPC_BOD12_ACTION_Pos               3                                              /**< (SUPC_BOD12) Action when Threshold Crossed Position */
+#define SUPC_BOD12_ACTION_Msk               (_U_(0x3) << SUPC_BOD12_ACTION_Pos)            /**< (SUPC_BOD12) Action when Threshold Crossed Mask */
+#define SUPC_BOD12_ACTION(value)            (SUPC_BOD12_ACTION_Msk & ((value) << SUPC_BOD12_ACTION_Pos))
+#define   SUPC_BOD12_ACTION_NONE_Val        _U_(0x0)                                       /**< (SUPC_BOD12) No action  */
+#define   SUPC_BOD12_ACTION_RESET_Val       _U_(0x1)                                       /**< (SUPC_BOD12) The BOD12 generates a reset  */
+#define   SUPC_BOD12_ACTION_INT_Val         _U_(0x2)                                       /**< (SUPC_BOD12) The BOD12 generates an interrupt  */
+#define SUPC_BOD12_ACTION_NONE              (SUPC_BOD12_ACTION_NONE_Val << SUPC_BOD12_ACTION_Pos)  /**< (SUPC_BOD12) No action Position  */
+#define SUPC_BOD12_ACTION_RESET             (SUPC_BOD12_ACTION_RESET_Val << SUPC_BOD12_ACTION_Pos)  /**< (SUPC_BOD12) The BOD12 generates a reset Position  */
+#define SUPC_BOD12_ACTION_INT               (SUPC_BOD12_ACTION_INT_Val << SUPC_BOD12_ACTION_Pos)  /**< (SUPC_BOD12) The BOD12 generates an interrupt Position  */
+#define SUPC_BOD12_STDBYCFG_Pos             5                                              /**< (SUPC_BOD12) Configuration in Standby mode Position */
+#define SUPC_BOD12_STDBYCFG_Msk             (_U_(0x1) << SUPC_BOD12_STDBYCFG_Pos)          /**< (SUPC_BOD12) Configuration in Standby mode Mask */
+#define SUPC_BOD12_STDBYCFG                 SUPC_BOD12_STDBYCFG_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_BOD12_STDBYCFG_Msk instead */
+#define SUPC_BOD12_RUNSTDBY_Pos             6                                              /**< (SUPC_BOD12) Run during Standby Position */
+#define SUPC_BOD12_RUNSTDBY_Msk             (_U_(0x1) << SUPC_BOD12_RUNSTDBY_Pos)          /**< (SUPC_BOD12) Run during Standby Mask */
+#define SUPC_BOD12_RUNSTDBY                 SUPC_BOD12_RUNSTDBY_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_BOD12_RUNSTDBY_Msk instead */
+#define SUPC_BOD12_ACTCFG_Pos               8                                              /**< (SUPC_BOD12) Configuration in Active mode Position */
+#define SUPC_BOD12_ACTCFG_Msk               (_U_(0x1) << SUPC_BOD12_ACTCFG_Pos)            /**< (SUPC_BOD12) Configuration in Active mode Mask */
+#define SUPC_BOD12_ACTCFG                   SUPC_BOD12_ACTCFG_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_BOD12_ACTCFG_Msk instead */
+#define SUPC_BOD12_PSEL_Pos                 12                                             /**< (SUPC_BOD12) Prescaler Select Position */
+#define SUPC_BOD12_PSEL_Msk                 (_U_(0xF) << SUPC_BOD12_PSEL_Pos)              /**< (SUPC_BOD12) Prescaler Select Mask */
+#define SUPC_BOD12_PSEL(value)              (SUPC_BOD12_PSEL_Msk & ((value) << SUPC_BOD12_PSEL_Pos))
+#define   SUPC_BOD12_PSEL_DIV2_Val          _U_(0x0)                                       /**< (SUPC_BOD12) Divide clock by 2  */
+#define   SUPC_BOD12_PSEL_DIV4_Val          _U_(0x1)                                       /**< (SUPC_BOD12) Divide clock by 4  */
+#define   SUPC_BOD12_PSEL_DIV8_Val          _U_(0x2)                                       /**< (SUPC_BOD12) Divide clock by 8  */
+#define   SUPC_BOD12_PSEL_DIV16_Val         _U_(0x3)                                       /**< (SUPC_BOD12) Divide clock by 16  */
+#define   SUPC_BOD12_PSEL_DIV32_Val         _U_(0x4)                                       /**< (SUPC_BOD12) Divide clock by 32  */
+#define   SUPC_BOD12_PSEL_DIV64_Val         _U_(0x5)                                       /**< (SUPC_BOD12) Divide clock by 64  */
+#define   SUPC_BOD12_PSEL_DIV128_Val        _U_(0x6)                                       /**< (SUPC_BOD12) Divide clock by 128  */
+#define   SUPC_BOD12_PSEL_DIV256_Val        _U_(0x7)                                       /**< (SUPC_BOD12) Divide clock by 256  */
+#define   SUPC_BOD12_PSEL_DIV512_Val        _U_(0x8)                                       /**< (SUPC_BOD12) Divide clock by 512  */
+#define   SUPC_BOD12_PSEL_DIV1024_Val       _U_(0x9)                                       /**< (SUPC_BOD12) Divide clock by 1024  */
+#define   SUPC_BOD12_PSEL_DIV2048_Val       _U_(0xA)                                       /**< (SUPC_BOD12) Divide clock by 2048  */
+#define   SUPC_BOD12_PSEL_DIV4096_Val       _U_(0xB)                                       /**< (SUPC_BOD12) Divide clock by 4096  */
+#define   SUPC_BOD12_PSEL_DIV8192_Val       _U_(0xC)                                       /**< (SUPC_BOD12) Divide clock by 8192  */
+#define   SUPC_BOD12_PSEL_DIV16384_Val      _U_(0xD)                                       /**< (SUPC_BOD12) Divide clock by 16384  */
+#define   SUPC_BOD12_PSEL_DIV32768_Val      _U_(0xE)                                       /**< (SUPC_BOD12) Divide clock by 32768  */
+#define   SUPC_BOD12_PSEL_DIV65536_Val      _U_(0xF)                                       /**< (SUPC_BOD12) Divide clock by 65536  */
+#define SUPC_BOD12_PSEL_DIV2                (SUPC_BOD12_PSEL_DIV2_Val << SUPC_BOD12_PSEL_Pos)  /**< (SUPC_BOD12) Divide clock by 2 Position  */
+#define SUPC_BOD12_PSEL_DIV4                (SUPC_BOD12_PSEL_DIV4_Val << SUPC_BOD12_PSEL_Pos)  /**< (SUPC_BOD12) Divide clock by 4 Position  */
+#define SUPC_BOD12_PSEL_DIV8                (SUPC_BOD12_PSEL_DIV8_Val << SUPC_BOD12_PSEL_Pos)  /**< (SUPC_BOD12) Divide clock by 8 Position  */
+#define SUPC_BOD12_PSEL_DIV16               (SUPC_BOD12_PSEL_DIV16_Val << SUPC_BOD12_PSEL_Pos)  /**< (SUPC_BOD12) Divide clock by 16 Position  */
+#define SUPC_BOD12_PSEL_DIV32               (SUPC_BOD12_PSEL_DIV32_Val << SUPC_BOD12_PSEL_Pos)  /**< (SUPC_BOD12) Divide clock by 32 Position  */
+#define SUPC_BOD12_PSEL_DIV64               (SUPC_BOD12_PSEL_DIV64_Val << SUPC_BOD12_PSEL_Pos)  /**< (SUPC_BOD12) Divide clock by 64 Position  */
+#define SUPC_BOD12_PSEL_DIV128              (SUPC_BOD12_PSEL_DIV128_Val << SUPC_BOD12_PSEL_Pos)  /**< (SUPC_BOD12) Divide clock by 128 Position  */
+#define SUPC_BOD12_PSEL_DIV256              (SUPC_BOD12_PSEL_DIV256_Val << SUPC_BOD12_PSEL_Pos)  /**< (SUPC_BOD12) Divide clock by 256 Position  */
+#define SUPC_BOD12_PSEL_DIV512              (SUPC_BOD12_PSEL_DIV512_Val << SUPC_BOD12_PSEL_Pos)  /**< (SUPC_BOD12) Divide clock by 512 Position  */
+#define SUPC_BOD12_PSEL_DIV1024             (SUPC_BOD12_PSEL_DIV1024_Val << SUPC_BOD12_PSEL_Pos)  /**< (SUPC_BOD12) Divide clock by 1024 Position  */
+#define SUPC_BOD12_PSEL_DIV2048             (SUPC_BOD12_PSEL_DIV2048_Val << SUPC_BOD12_PSEL_Pos)  /**< (SUPC_BOD12) Divide clock by 2048 Position  */
+#define SUPC_BOD12_PSEL_DIV4096             (SUPC_BOD12_PSEL_DIV4096_Val << SUPC_BOD12_PSEL_Pos)  /**< (SUPC_BOD12) Divide clock by 4096 Position  */
+#define SUPC_BOD12_PSEL_DIV8192             (SUPC_BOD12_PSEL_DIV8192_Val << SUPC_BOD12_PSEL_Pos)  /**< (SUPC_BOD12) Divide clock by 8192 Position  */
+#define SUPC_BOD12_PSEL_DIV16384            (SUPC_BOD12_PSEL_DIV16384_Val << SUPC_BOD12_PSEL_Pos)  /**< (SUPC_BOD12) Divide clock by 16384 Position  */
+#define SUPC_BOD12_PSEL_DIV32768            (SUPC_BOD12_PSEL_DIV32768_Val << SUPC_BOD12_PSEL_Pos)  /**< (SUPC_BOD12) Divide clock by 32768 Position  */
+#define SUPC_BOD12_PSEL_DIV65536            (SUPC_BOD12_PSEL_DIV65536_Val << SUPC_BOD12_PSEL_Pos)  /**< (SUPC_BOD12) Divide clock by 65536 Position  */
+#define SUPC_BOD12_LEVEL_Pos                16                                             /**< (SUPC_BOD12) Threshold Level Position */
+#define SUPC_BOD12_LEVEL_Msk                (_U_(0x3F) << SUPC_BOD12_LEVEL_Pos)            /**< (SUPC_BOD12) Threshold Level Mask */
+#define SUPC_BOD12_LEVEL(value)             (SUPC_BOD12_LEVEL_Msk & ((value) << SUPC_BOD12_LEVEL_Pos))
+#define SUPC_BOD12_MASK                     _U_(0x3FF17E)                                  /**< \deprecated (SUPC_BOD12) Register MASK  (Use SUPC_BOD12_Msk instead)  */
+#define SUPC_BOD12_Msk                      _U_(0x3FF17E)                                  /**< (SUPC_BOD12) Register Mask  */
+
+
+/* -------- SUPC_VREG : (SUPC Offset: 0x18) (R/W 32) VREG Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint32_t SEL:2;                     /**< bit:   2..3  Voltage Regulator Selection in active mode */
+    uint32_t :1;                        /**< bit:      4  Reserved */
+    uint32_t STDBYPL0:1;                /**< bit:      5  Standby in PL0                           */
+    uint32_t RUNSTDBY:1;                /**< bit:      6  Run during Standby                       */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t LPEFF:1;                   /**< bit:      8  Low Power efficiency                     */
+    uint32_t VREFSEL:1;                 /**< bit:      9  Voltage Regulator Voltage Reference Selection */
+    uint32_t :6;                        /**< bit: 10..15  Reserved */
+    uint32_t VSVSTEP:4;                 /**< bit: 16..19  Voltage Scaling Voltage Step             */
+    uint32_t :4;                        /**< bit: 20..23  Reserved */
+    uint32_t VSPER:8;                   /**< bit: 24..31  Voltage Scaling Period                   */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :5;                        /**< bit:   0..4  Reserved */
+    uint32_t STDBYPL:1;                 /**< bit:      5  Standby in PLx                           */
+    uint32_t :26;                       /**< bit:  6..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} SUPC_VREG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SUPC_VREG_OFFSET                    (0x18)                                        /**<  (SUPC_VREG) VREG Control  Offset */
+#define SUPC_VREG_RESETVALUE                _U_(0x02)                                     /**<  (SUPC_VREG) VREG Control  Reset Value */
+
+#define SUPC_VREG_ENABLE_Pos                1                                              /**< (SUPC_VREG) Enable Position */
+#define SUPC_VREG_ENABLE_Msk                (_U_(0x1) << SUPC_VREG_ENABLE_Pos)             /**< (SUPC_VREG) Enable Mask */
+#define SUPC_VREG_ENABLE                    SUPC_VREG_ENABLE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_VREG_ENABLE_Msk instead */
+#define SUPC_VREG_SEL_Pos                   2                                              /**< (SUPC_VREG) Voltage Regulator Selection in active mode Position */
+#define SUPC_VREG_SEL_Msk                   (_U_(0x3) << SUPC_VREG_SEL_Pos)                /**< (SUPC_VREG) Voltage Regulator Selection in active mode Mask */
+#define SUPC_VREG_SEL(value)                (SUPC_VREG_SEL_Msk & ((value) << SUPC_VREG_SEL_Pos))
+#define   SUPC_VREG_SEL_LDO_Val             _U_(0x0)                                       /**< (SUPC_VREG) LDO selection  */
+#define   SUPC_VREG_SEL_BUCK_Val            _U_(0x1)                                       /**< (SUPC_VREG) Buck selection  */
+#define SUPC_VREG_SEL_LDO                   (SUPC_VREG_SEL_LDO_Val << SUPC_VREG_SEL_Pos)   /**< (SUPC_VREG) LDO selection Position  */
+#define SUPC_VREG_SEL_BUCK                  (SUPC_VREG_SEL_BUCK_Val << SUPC_VREG_SEL_Pos)  /**< (SUPC_VREG) Buck selection Position  */
+#define SUPC_VREG_STDBYPL0_Pos              5                                              /**< (SUPC_VREG) Standby in PL0 Position */
+#define SUPC_VREG_STDBYPL0_Msk              (_U_(0x1) << SUPC_VREG_STDBYPL0_Pos)           /**< (SUPC_VREG) Standby in PL0 Mask */
+#define SUPC_VREG_STDBYPL0                  SUPC_VREG_STDBYPL0_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_VREG_STDBYPL0_Msk instead */
+#define SUPC_VREG_RUNSTDBY_Pos              6                                              /**< (SUPC_VREG) Run during Standby Position */
+#define SUPC_VREG_RUNSTDBY_Msk              (_U_(0x1) << SUPC_VREG_RUNSTDBY_Pos)           /**< (SUPC_VREG) Run during Standby Mask */
+#define SUPC_VREG_RUNSTDBY                  SUPC_VREG_RUNSTDBY_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_VREG_RUNSTDBY_Msk instead */
+#define SUPC_VREG_LPEFF_Pos                 8                                              /**< (SUPC_VREG) Low Power efficiency Position */
+#define SUPC_VREG_LPEFF_Msk                 (_U_(0x1) << SUPC_VREG_LPEFF_Pos)              /**< (SUPC_VREG) Low Power efficiency Mask */
+#define SUPC_VREG_LPEFF                     SUPC_VREG_LPEFF_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_VREG_LPEFF_Msk instead */
+#define SUPC_VREG_VREFSEL_Pos               9                                              /**< (SUPC_VREG) Voltage Regulator Voltage Reference Selection Position */
+#define SUPC_VREG_VREFSEL_Msk               (_U_(0x1) << SUPC_VREG_VREFSEL_Pos)            /**< (SUPC_VREG) Voltage Regulator Voltage Reference Selection Mask */
+#define SUPC_VREG_VREFSEL                   SUPC_VREG_VREFSEL_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_VREG_VREFSEL_Msk instead */
+#define SUPC_VREG_VSVSTEP_Pos               16                                             /**< (SUPC_VREG) Voltage Scaling Voltage Step Position */
+#define SUPC_VREG_VSVSTEP_Msk               (_U_(0xF) << SUPC_VREG_VSVSTEP_Pos)            /**< (SUPC_VREG) Voltage Scaling Voltage Step Mask */
+#define SUPC_VREG_VSVSTEP(value)            (SUPC_VREG_VSVSTEP_Msk & ((value) << SUPC_VREG_VSVSTEP_Pos))
+#define SUPC_VREG_VSPER_Pos                 24                                             /**< (SUPC_VREG) Voltage Scaling Period Position */
+#define SUPC_VREG_VSPER_Msk                 (_U_(0xFF) << SUPC_VREG_VSPER_Pos)             /**< (SUPC_VREG) Voltage Scaling Period Mask */
+#define SUPC_VREG_VSPER(value)              (SUPC_VREG_VSPER_Msk & ((value) << SUPC_VREG_VSPER_Pos))
+#define SUPC_VREG_MASK                      _U_(0xFF0F036E)                                /**< \deprecated (SUPC_VREG) Register MASK  (Use SUPC_VREG_Msk instead)  */
+#define SUPC_VREG_Msk                       _U_(0xFF0F036E)                                /**< (SUPC_VREG) Register Mask  */
+
+#define SUPC_VREG_STDBYPL_Pos               5                                              /**< (SUPC_VREG Position) Standby in PLx */
+#define SUPC_VREG_STDBYPL_Msk               (_U_(0x1) << SUPC_VREG_STDBYPL_Pos)            /**< (SUPC_VREG Mask) STDBYPL */
+#define SUPC_VREG_STDBYPL(value)            (SUPC_VREG_STDBYPL_Msk & ((value) << SUPC_VREG_STDBYPL_Pos))  
+
+/* -------- SUPC_VREF : (SUPC Offset: 0x1c) (R/W 32) VREF Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t TSEN:1;                    /**< bit:      1  Temperature Sensor Output Enable         */
+    uint32_t VREFOE:1;                  /**< bit:      2  Voltage Reference Output Enable          */
+    uint32_t TSSEL:1;                   /**< bit:      3  Temperature Sensor Selection             */
+    uint32_t :2;                        /**< bit:   4..5  Reserved */
+    uint32_t RUNSTDBY:1;                /**< bit:      6  Run during Standby                       */
+    uint32_t ONDEMAND:1;                /**< bit:      7  On Demand Control                        */
+    uint32_t :8;                        /**< bit:  8..15  Reserved */
+    uint32_t SEL:4;                     /**< bit: 16..19  Voltage Reference Selection              */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SUPC_VREF_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SUPC_VREF_OFFSET                    (0x1C)                                        /**<  (SUPC_VREF) VREF Control  Offset */
+#define SUPC_VREF_RESETVALUE                _U_(0x00)                                     /**<  (SUPC_VREF) VREF Control  Reset Value */
+
+#define SUPC_VREF_TSEN_Pos                  1                                              /**< (SUPC_VREF) Temperature Sensor Output Enable Position */
+#define SUPC_VREF_TSEN_Msk                  (_U_(0x1) << SUPC_VREF_TSEN_Pos)               /**< (SUPC_VREF) Temperature Sensor Output Enable Mask */
+#define SUPC_VREF_TSEN                      SUPC_VREF_TSEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_VREF_TSEN_Msk instead */
+#define SUPC_VREF_VREFOE_Pos                2                                              /**< (SUPC_VREF) Voltage Reference Output Enable Position */
+#define SUPC_VREF_VREFOE_Msk                (_U_(0x1) << SUPC_VREF_VREFOE_Pos)             /**< (SUPC_VREF) Voltage Reference Output Enable Mask */
+#define SUPC_VREF_VREFOE                    SUPC_VREF_VREFOE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_VREF_VREFOE_Msk instead */
+#define SUPC_VREF_TSSEL_Pos                 3                                              /**< (SUPC_VREF) Temperature Sensor Selection Position */
+#define SUPC_VREF_TSSEL_Msk                 (_U_(0x1) << SUPC_VREF_TSSEL_Pos)              /**< (SUPC_VREF) Temperature Sensor Selection Mask */
+#define SUPC_VREF_TSSEL                     SUPC_VREF_TSSEL_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_VREF_TSSEL_Msk instead */
+#define SUPC_VREF_RUNSTDBY_Pos              6                                              /**< (SUPC_VREF) Run during Standby Position */
+#define SUPC_VREF_RUNSTDBY_Msk              (_U_(0x1) << SUPC_VREF_RUNSTDBY_Pos)           /**< (SUPC_VREF) Run during Standby Mask */
+#define SUPC_VREF_RUNSTDBY                  SUPC_VREF_RUNSTDBY_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_VREF_RUNSTDBY_Msk instead */
+#define SUPC_VREF_ONDEMAND_Pos              7                                              /**< (SUPC_VREF) On Demand Control Position */
+#define SUPC_VREF_ONDEMAND_Msk              (_U_(0x1) << SUPC_VREF_ONDEMAND_Pos)           /**< (SUPC_VREF) On Demand Control Mask */
+#define SUPC_VREF_ONDEMAND                  SUPC_VREF_ONDEMAND_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_VREF_ONDEMAND_Msk instead */
+#define SUPC_VREF_SEL_Pos                   16                                             /**< (SUPC_VREF) Voltage Reference Selection Position */
+#define SUPC_VREF_SEL_Msk                   (_U_(0xF) << SUPC_VREF_SEL_Pos)                /**< (SUPC_VREF) Voltage Reference Selection Mask */
+#define SUPC_VREF_SEL(value)                (SUPC_VREF_SEL_Msk & ((value) << SUPC_VREF_SEL_Pos))
+#define   SUPC_VREF_SEL_1V0_Val             _U_(0x0)                                       /**< (SUPC_VREF) 1.0V voltage reference typical value  */
+#define   SUPC_VREF_SEL_1V1_Val             _U_(0x1)                                       /**< (SUPC_VREF) 1.1V voltage reference typical value  */
+#define   SUPC_VREF_SEL_1V2_Val             _U_(0x2)                                       /**< (SUPC_VREF) 1.2V voltage reference typical value  */
+#define   SUPC_VREF_SEL_1V25_Val            _U_(0x3)                                       /**< (SUPC_VREF) 1.25V voltage reference typical value  */
+#define   SUPC_VREF_SEL_2V0_Val             _U_(0x4)                                       /**< (SUPC_VREF) 2.0V voltage reference typical value  */
+#define   SUPC_VREF_SEL_2V2_Val             _U_(0x5)                                       /**< (SUPC_VREF) 2.2V voltage reference typical value  */
+#define   SUPC_VREF_SEL_2V4_Val             _U_(0x6)                                       /**< (SUPC_VREF) 2.4V voltage reference typical value  */
+#define   SUPC_VREF_SEL_2V5_Val             _U_(0x7)                                       /**< (SUPC_VREF) 2.5V voltage reference typical value  */
+#define SUPC_VREF_SEL_1V0                   (SUPC_VREF_SEL_1V0_Val << SUPC_VREF_SEL_Pos)   /**< (SUPC_VREF) 1.0V voltage reference typical value Position  */
+#define SUPC_VREF_SEL_1V1                   (SUPC_VREF_SEL_1V1_Val << SUPC_VREF_SEL_Pos)   /**< (SUPC_VREF) 1.1V voltage reference typical value Position  */
+#define SUPC_VREF_SEL_1V2                   (SUPC_VREF_SEL_1V2_Val << SUPC_VREF_SEL_Pos)   /**< (SUPC_VREF) 1.2V voltage reference typical value Position  */
+#define SUPC_VREF_SEL_1V25                  (SUPC_VREF_SEL_1V25_Val << SUPC_VREF_SEL_Pos)  /**< (SUPC_VREF) 1.25V voltage reference typical value Position  */
+#define SUPC_VREF_SEL_2V0                   (SUPC_VREF_SEL_2V0_Val << SUPC_VREF_SEL_Pos)   /**< (SUPC_VREF) 2.0V voltage reference typical value Position  */
+#define SUPC_VREF_SEL_2V2                   (SUPC_VREF_SEL_2V2_Val << SUPC_VREF_SEL_Pos)   /**< (SUPC_VREF) 2.2V voltage reference typical value Position  */
+#define SUPC_VREF_SEL_2V4                   (SUPC_VREF_SEL_2V4_Val << SUPC_VREF_SEL_Pos)   /**< (SUPC_VREF) 2.4V voltage reference typical value Position  */
+#define SUPC_VREF_SEL_2V5                   (SUPC_VREF_SEL_2V5_Val << SUPC_VREF_SEL_Pos)   /**< (SUPC_VREF) 2.5V voltage reference typical value Position  */
+#define SUPC_VREF_MASK                      _U_(0xF00CE)                                   /**< \deprecated (SUPC_VREF) Register MASK  (Use SUPC_VREF_Msk instead)  */
+#define SUPC_VREF_Msk                       _U_(0xF00CE)                                   /**< (SUPC_VREF) Register Mask  */
+
+
+/* -------- SUPC_EVCTRL : (SUPC Offset: 0x2c) (R/W 32) Event Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t BOD33DETEO:1;              /**< bit:      1  BOD33 Detection Event Output Enable      */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t BOD12DETEO:1;              /**< bit:      4  BOD12 Detection Event Output Enable      */
+    uint32_t :27;                       /**< bit:  5..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SUPC_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SUPC_EVCTRL_OFFSET                  (0x2C)                                        /**<  (SUPC_EVCTRL) Event Control  Offset */
+#define SUPC_EVCTRL_RESETVALUE              _U_(0x00)                                     /**<  (SUPC_EVCTRL) Event Control  Reset Value */
+
+#define SUPC_EVCTRL_BOD33DETEO_Pos          1                                              /**< (SUPC_EVCTRL) BOD33 Detection Event Output Enable Position */
+#define SUPC_EVCTRL_BOD33DETEO_Msk          (_U_(0x1) << SUPC_EVCTRL_BOD33DETEO_Pos)       /**< (SUPC_EVCTRL) BOD33 Detection Event Output Enable Mask */
+#define SUPC_EVCTRL_BOD33DETEO              SUPC_EVCTRL_BOD33DETEO_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_EVCTRL_BOD33DETEO_Msk instead */
+#define SUPC_EVCTRL_BOD12DETEO_Pos          4                                              /**< (SUPC_EVCTRL) BOD12 Detection Event Output Enable Position */
+#define SUPC_EVCTRL_BOD12DETEO_Msk          (_U_(0x1) << SUPC_EVCTRL_BOD12DETEO_Pos)       /**< (SUPC_EVCTRL) BOD12 Detection Event Output Enable Mask */
+#define SUPC_EVCTRL_BOD12DETEO              SUPC_EVCTRL_BOD12DETEO_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_EVCTRL_BOD12DETEO_Msk instead */
+#define SUPC_EVCTRL_MASK                    _U_(0x12)                                      /**< \deprecated (SUPC_EVCTRL) Register MASK  (Use SUPC_EVCTRL_Msk instead)  */
+#define SUPC_EVCTRL_Msk                     _U_(0x12)                                      /**< (SUPC_EVCTRL) Register Mask  */
+
+
+/* -------- SUPC_VREGSUSP : (SUPC Offset: 0x30) (R/W 32) VREG Suspend Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t VREGSEN:1;                 /**< bit:      0  Enable Voltage Regulator Suspend         */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SUPC_VREGSUSP_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SUPC_VREGSUSP_OFFSET                (0x30)                                        /**<  (SUPC_VREGSUSP) VREG Suspend Control  Offset */
+#define SUPC_VREGSUSP_RESETVALUE            _U_(0x00)                                     /**<  (SUPC_VREGSUSP) VREG Suspend Control  Reset Value */
+
+#define SUPC_VREGSUSP_VREGSEN_Pos           0                                              /**< (SUPC_VREGSUSP) Enable Voltage Regulator Suspend Position */
+#define SUPC_VREGSUSP_VREGSEN_Msk           (_U_(0x1) << SUPC_VREGSUSP_VREGSEN_Pos)        /**< (SUPC_VREGSUSP) Enable Voltage Regulator Suspend Mask */
+#define SUPC_VREGSUSP_VREGSEN               SUPC_VREGSUSP_VREGSEN_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_VREGSUSP_VREGSEN_Msk instead */
+#define SUPC_VREGSUSP_MASK                  _U_(0x01)                                      /**< \deprecated (SUPC_VREGSUSP) Register MASK  (Use SUPC_VREGSUSP_Msk instead)  */
+#define SUPC_VREGSUSP_Msk                   _U_(0x01)                                      /**< (SUPC_VREGSUSP) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief SUPC hardware registers */
+typedef struct {  /* Supply Controller */
+  __IO SUPC_INTENCLR_Type             INTENCLR;       /**< Offset: 0x00 (R/W  32) Interrupt Enable Clear */
+  __IO SUPC_INTENSET_Type             INTENSET;       /**< Offset: 0x04 (R/W  32) Interrupt Enable Set */
+  __IO SUPC_INTFLAG_Type              INTFLAG;        /**< Offset: 0x08 (R/W  32) Interrupt Flag Status and Clear */
+  __I  SUPC_STATUS_Type               STATUS;         /**< Offset: 0x0C (R/   32) Power and Clocks Status */
+  __IO SUPC_BOD33_Type                BOD33;          /**< Offset: 0x10 (R/W  32) BOD33 Control */
+  __IO SUPC_BOD12_Type                BOD12;          /**< Offset: 0x14 (R/W  32) BOD12 Control */
+  __IO SUPC_VREG_Type                 VREG;           /**< Offset: 0x18 (R/W  32) VREG Control */
+  __IO SUPC_VREF_Type                 VREF;           /**< Offset: 0x1C (R/W  32) VREF Control */
+  __I  uint8_t                        Reserved1[12];
+  __IO SUPC_EVCTRL_Type               EVCTRL;         /**< Offset: 0x2C (R/W  32) Event Control */
+  __IO SUPC_VREGSUSP_Type             VREGSUSP;       /**< Offset: 0x30 (R/W  32) VREG Suspend Control */
+} Supc;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Supply Controller */
+
+#endif /* _SAML11_SUPC_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/component/tc.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/tc.h
@@ -1,0 +1,1027 @@
+/**
+ * \file
+ *
+ * \brief Component description for TC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_TC_COMPONENT_H_
+#define _SAML11_TC_COMPONENT_H_
+#define _SAML11_TC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML11 Basic Timer Counter
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR TC */
+/* ========================================================================== */
+
+#define TC_U2249                      /**< (TC) Module ID */
+#define REV_TC 0x310                  /**< (TC) Module revision */
+
+/* -------- TC_CTRLA : (TC Offset: 0x00) (R/W 32) Control A -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint32_t ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint32_t MODE:2;                    /**< bit:   2..3  Timer Counter Mode                       */
+    uint32_t PRESCSYNC:2;               /**< bit:   4..5  Prescaler and Counter Synchronization    */
+    uint32_t RUNSTDBY:1;                /**< bit:      6  Run during Standby                       */
+    uint32_t ONDEMAND:1;                /**< bit:      7  Clock On Demand                          */
+    uint32_t PRESCALER:3;               /**< bit:  8..10  Prescaler                                */
+    uint32_t ALOCK:1;                   /**< bit:     11  Auto Lock                                */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t CAPTEN0:1;                 /**< bit:     16  Capture Channel 0 Enable                 */
+    uint32_t CAPTEN1:1;                 /**< bit:     17  Capture Channel 1 Enable                 */
+    uint32_t :2;                        /**< bit: 18..19  Reserved */
+    uint32_t COPEN0:1;                  /**< bit:     20  Capture On Pin 0 Enable                  */
+    uint32_t COPEN1:1;                  /**< bit:     21  Capture On Pin 1 Enable                  */
+    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t CAPTMODE0:2;               /**< bit: 24..25  Capture Mode Channel 0                   */
+    uint32_t :1;                        /**< bit:     26  Reserved */
+    uint32_t CAPTMODE1:2;               /**< bit: 27..28  Capture mode Channel 1                   */
+    uint32_t :3;                        /**< bit: 29..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :16;                       /**< bit:  0..15  Reserved */
+    uint32_t CAPTEN:2;                  /**< bit: 16..17  Capture Channel x Enable                 */
+    uint32_t :2;                        /**< bit: 18..19  Reserved */
+    uint32_t COPEN:2;                   /**< bit: 20..21  Capture On Pin x Enable                  */
+    uint32_t :10;                       /**< bit: 22..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_CTRLA_OFFSET                     (0x00)                                        /**<  (TC_CTRLA) Control A  Offset */
+#define TC_CTRLA_RESETVALUE                 _U_(0x00)                                     /**<  (TC_CTRLA) Control A  Reset Value */
+
+#define TC_CTRLA_SWRST_Pos                  0                                              /**< (TC_CTRLA) Software Reset Position */
+#define TC_CTRLA_SWRST_Msk                  (_U_(0x1) << TC_CTRLA_SWRST_Pos)               /**< (TC_CTRLA) Software Reset Mask */
+#define TC_CTRLA_SWRST                      TC_CTRLA_SWRST_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CTRLA_SWRST_Msk instead */
+#define TC_CTRLA_ENABLE_Pos                 1                                              /**< (TC_CTRLA) Enable Position */
+#define TC_CTRLA_ENABLE_Msk                 (_U_(0x1) << TC_CTRLA_ENABLE_Pos)              /**< (TC_CTRLA) Enable Mask */
+#define TC_CTRLA_ENABLE                     TC_CTRLA_ENABLE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CTRLA_ENABLE_Msk instead */
+#define TC_CTRLA_MODE_Pos                   2                                              /**< (TC_CTRLA) Timer Counter Mode Position */
+#define TC_CTRLA_MODE_Msk                   (_U_(0x3) << TC_CTRLA_MODE_Pos)                /**< (TC_CTRLA) Timer Counter Mode Mask */
+#define TC_CTRLA_MODE(value)                (TC_CTRLA_MODE_Msk & ((value) << TC_CTRLA_MODE_Pos))
+#define   TC_CTRLA_MODE_COUNT16_Val         _U_(0x0)                                       /**< (TC_CTRLA) Counter in 16-bit mode  */
+#define   TC_CTRLA_MODE_COUNT8_Val          _U_(0x1)                                       /**< (TC_CTRLA) Counter in 8-bit mode  */
+#define   TC_CTRLA_MODE_COUNT32_Val         _U_(0x2)                                       /**< (TC_CTRLA) Counter in 32-bit mode  */
+#define TC_CTRLA_MODE_COUNT16               (TC_CTRLA_MODE_COUNT16_Val << TC_CTRLA_MODE_Pos)  /**< (TC_CTRLA) Counter in 16-bit mode Position  */
+#define TC_CTRLA_MODE_COUNT8                (TC_CTRLA_MODE_COUNT8_Val << TC_CTRLA_MODE_Pos)  /**< (TC_CTRLA) Counter in 8-bit mode Position  */
+#define TC_CTRLA_MODE_COUNT32               (TC_CTRLA_MODE_COUNT32_Val << TC_CTRLA_MODE_Pos)  /**< (TC_CTRLA) Counter in 32-bit mode Position  */
+#define TC_CTRLA_PRESCSYNC_Pos              4                                              /**< (TC_CTRLA) Prescaler and Counter Synchronization Position */
+#define TC_CTRLA_PRESCSYNC_Msk              (_U_(0x3) << TC_CTRLA_PRESCSYNC_Pos)           /**< (TC_CTRLA) Prescaler and Counter Synchronization Mask */
+#define TC_CTRLA_PRESCSYNC(value)           (TC_CTRLA_PRESCSYNC_Msk & ((value) << TC_CTRLA_PRESCSYNC_Pos))
+#define   TC_CTRLA_PRESCSYNC_GCLK_Val       _U_(0x0)                                       /**< (TC_CTRLA) Reload or reset the counter on next generic clock  */
+#define   TC_CTRLA_PRESCSYNC_PRESC_Val      _U_(0x1)                                       /**< (TC_CTRLA) Reload or reset the counter on next prescaler clock  */
+#define   TC_CTRLA_PRESCSYNC_RESYNC_Val     _U_(0x2)                                       /**< (TC_CTRLA) Reload or reset the counter on next generic clock and reset the prescaler counter  */
+#define TC_CTRLA_PRESCSYNC_GCLK             (TC_CTRLA_PRESCSYNC_GCLK_Val << TC_CTRLA_PRESCSYNC_Pos)  /**< (TC_CTRLA) Reload or reset the counter on next generic clock Position  */
+#define TC_CTRLA_PRESCSYNC_PRESC            (TC_CTRLA_PRESCSYNC_PRESC_Val << TC_CTRLA_PRESCSYNC_Pos)  /**< (TC_CTRLA) Reload or reset the counter on next prescaler clock Position  */
+#define TC_CTRLA_PRESCSYNC_RESYNC           (TC_CTRLA_PRESCSYNC_RESYNC_Val << TC_CTRLA_PRESCSYNC_Pos)  /**< (TC_CTRLA) Reload or reset the counter on next generic clock and reset the prescaler counter Position  */
+#define TC_CTRLA_RUNSTDBY_Pos               6                                              /**< (TC_CTRLA) Run during Standby Position */
+#define TC_CTRLA_RUNSTDBY_Msk               (_U_(0x1) << TC_CTRLA_RUNSTDBY_Pos)            /**< (TC_CTRLA) Run during Standby Mask */
+#define TC_CTRLA_RUNSTDBY                   TC_CTRLA_RUNSTDBY_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CTRLA_RUNSTDBY_Msk instead */
+#define TC_CTRLA_ONDEMAND_Pos               7                                              /**< (TC_CTRLA) Clock On Demand Position */
+#define TC_CTRLA_ONDEMAND_Msk               (_U_(0x1) << TC_CTRLA_ONDEMAND_Pos)            /**< (TC_CTRLA) Clock On Demand Mask */
+#define TC_CTRLA_ONDEMAND                   TC_CTRLA_ONDEMAND_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CTRLA_ONDEMAND_Msk instead */
+#define TC_CTRLA_PRESCALER_Pos              8                                              /**< (TC_CTRLA) Prescaler Position */
+#define TC_CTRLA_PRESCALER_Msk              (_U_(0x7) << TC_CTRLA_PRESCALER_Pos)           /**< (TC_CTRLA) Prescaler Mask */
+#define TC_CTRLA_PRESCALER(value)           (TC_CTRLA_PRESCALER_Msk & ((value) << TC_CTRLA_PRESCALER_Pos))
+#define   TC_CTRLA_PRESCALER_DIV1_Val       _U_(0x0)                                       /**< (TC_CTRLA) Prescaler: GCLK_TC  */
+#define   TC_CTRLA_PRESCALER_DIV2_Val       _U_(0x1)                                       /**< (TC_CTRLA) Prescaler: GCLK_TC/2  */
+#define   TC_CTRLA_PRESCALER_DIV4_Val       _U_(0x2)                                       /**< (TC_CTRLA) Prescaler: GCLK_TC/4  */
+#define   TC_CTRLA_PRESCALER_DIV8_Val       _U_(0x3)                                       /**< (TC_CTRLA) Prescaler: GCLK_TC/8  */
+#define   TC_CTRLA_PRESCALER_DIV16_Val      _U_(0x4)                                       /**< (TC_CTRLA) Prescaler: GCLK_TC/16  */
+#define   TC_CTRLA_PRESCALER_DIV64_Val      _U_(0x5)                                       /**< (TC_CTRLA) Prescaler: GCLK_TC/64  */
+#define   TC_CTRLA_PRESCALER_DIV256_Val     _U_(0x6)                                       /**< (TC_CTRLA) Prescaler: GCLK_TC/256  */
+#define   TC_CTRLA_PRESCALER_DIV1024_Val    _U_(0x7)                                       /**< (TC_CTRLA) Prescaler: GCLK_TC/1024  */
+#define TC_CTRLA_PRESCALER_DIV1             (TC_CTRLA_PRESCALER_DIV1_Val << TC_CTRLA_PRESCALER_Pos)  /**< (TC_CTRLA) Prescaler: GCLK_TC Position  */
+#define TC_CTRLA_PRESCALER_DIV2             (TC_CTRLA_PRESCALER_DIV2_Val << TC_CTRLA_PRESCALER_Pos)  /**< (TC_CTRLA) Prescaler: GCLK_TC/2 Position  */
+#define TC_CTRLA_PRESCALER_DIV4             (TC_CTRLA_PRESCALER_DIV4_Val << TC_CTRLA_PRESCALER_Pos)  /**< (TC_CTRLA) Prescaler: GCLK_TC/4 Position  */
+#define TC_CTRLA_PRESCALER_DIV8             (TC_CTRLA_PRESCALER_DIV8_Val << TC_CTRLA_PRESCALER_Pos)  /**< (TC_CTRLA) Prescaler: GCLK_TC/8 Position  */
+#define TC_CTRLA_PRESCALER_DIV16            (TC_CTRLA_PRESCALER_DIV16_Val << TC_CTRLA_PRESCALER_Pos)  /**< (TC_CTRLA) Prescaler: GCLK_TC/16 Position  */
+#define TC_CTRLA_PRESCALER_DIV64            (TC_CTRLA_PRESCALER_DIV64_Val << TC_CTRLA_PRESCALER_Pos)  /**< (TC_CTRLA) Prescaler: GCLK_TC/64 Position  */
+#define TC_CTRLA_PRESCALER_DIV256           (TC_CTRLA_PRESCALER_DIV256_Val << TC_CTRLA_PRESCALER_Pos)  /**< (TC_CTRLA) Prescaler: GCLK_TC/256 Position  */
+#define TC_CTRLA_PRESCALER_DIV1024          (TC_CTRLA_PRESCALER_DIV1024_Val << TC_CTRLA_PRESCALER_Pos)  /**< (TC_CTRLA) Prescaler: GCLK_TC/1024 Position  */
+#define TC_CTRLA_ALOCK_Pos                  11                                             /**< (TC_CTRLA) Auto Lock Position */
+#define TC_CTRLA_ALOCK_Msk                  (_U_(0x1) << TC_CTRLA_ALOCK_Pos)               /**< (TC_CTRLA) Auto Lock Mask */
+#define TC_CTRLA_ALOCK                      TC_CTRLA_ALOCK_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CTRLA_ALOCK_Msk instead */
+#define TC_CTRLA_CAPTEN0_Pos                16                                             /**< (TC_CTRLA) Capture Channel 0 Enable Position */
+#define TC_CTRLA_CAPTEN0_Msk                (_U_(0x1) << TC_CTRLA_CAPTEN0_Pos)             /**< (TC_CTRLA) Capture Channel 0 Enable Mask */
+#define TC_CTRLA_CAPTEN0                    TC_CTRLA_CAPTEN0_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CTRLA_CAPTEN0_Msk instead */
+#define TC_CTRLA_CAPTEN1_Pos                17                                             /**< (TC_CTRLA) Capture Channel 1 Enable Position */
+#define TC_CTRLA_CAPTEN1_Msk                (_U_(0x1) << TC_CTRLA_CAPTEN1_Pos)             /**< (TC_CTRLA) Capture Channel 1 Enable Mask */
+#define TC_CTRLA_CAPTEN1                    TC_CTRLA_CAPTEN1_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CTRLA_CAPTEN1_Msk instead */
+#define TC_CTRLA_COPEN0_Pos                 20                                             /**< (TC_CTRLA) Capture On Pin 0 Enable Position */
+#define TC_CTRLA_COPEN0_Msk                 (_U_(0x1) << TC_CTRLA_COPEN0_Pos)              /**< (TC_CTRLA) Capture On Pin 0 Enable Mask */
+#define TC_CTRLA_COPEN0                     TC_CTRLA_COPEN0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CTRLA_COPEN0_Msk instead */
+#define TC_CTRLA_COPEN1_Pos                 21                                             /**< (TC_CTRLA) Capture On Pin 1 Enable Position */
+#define TC_CTRLA_COPEN1_Msk                 (_U_(0x1) << TC_CTRLA_COPEN1_Pos)              /**< (TC_CTRLA) Capture On Pin 1 Enable Mask */
+#define TC_CTRLA_COPEN1                     TC_CTRLA_COPEN1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CTRLA_COPEN1_Msk instead */
+#define TC_CTRLA_CAPTMODE0_Pos              24                                             /**< (TC_CTRLA) Capture Mode Channel 0 Position */
+#define TC_CTRLA_CAPTMODE0_Msk              (_U_(0x3) << TC_CTRLA_CAPTMODE0_Pos)           /**< (TC_CTRLA) Capture Mode Channel 0 Mask */
+#define TC_CTRLA_CAPTMODE0(value)           (TC_CTRLA_CAPTMODE0_Msk & ((value) << TC_CTRLA_CAPTMODE0_Pos))
+#define   TC_CTRLA_CAPTMODE0_DEFAULT_Val    _U_(0x0)                                       /**< (TC_CTRLA) Default capture  */
+#define   TC_CTRLA_CAPTMODE0_CAPTMIN_Val    _U_(0x1)                                       /**< (TC_CTRLA) Minimum capture  */
+#define   TC_CTRLA_CAPTMODE0_CAPTMAX_Val    _U_(0x2)                                       /**< (TC_CTRLA) Maximum capture  */
+#define TC_CTRLA_CAPTMODE0_DEFAULT          (TC_CTRLA_CAPTMODE0_DEFAULT_Val << TC_CTRLA_CAPTMODE0_Pos)  /**< (TC_CTRLA) Default capture Position  */
+#define TC_CTRLA_CAPTMODE0_CAPTMIN          (TC_CTRLA_CAPTMODE0_CAPTMIN_Val << TC_CTRLA_CAPTMODE0_Pos)  /**< (TC_CTRLA) Minimum capture Position  */
+#define TC_CTRLA_CAPTMODE0_CAPTMAX          (TC_CTRLA_CAPTMODE0_CAPTMAX_Val << TC_CTRLA_CAPTMODE0_Pos)  /**< (TC_CTRLA) Maximum capture Position  */
+#define TC_CTRLA_CAPTMODE1_Pos              27                                             /**< (TC_CTRLA) Capture mode Channel 1 Position */
+#define TC_CTRLA_CAPTMODE1_Msk              (_U_(0x3) << TC_CTRLA_CAPTMODE1_Pos)           /**< (TC_CTRLA) Capture mode Channel 1 Mask */
+#define TC_CTRLA_CAPTMODE1(value)           (TC_CTRLA_CAPTMODE1_Msk & ((value) << TC_CTRLA_CAPTMODE1_Pos))
+#define   TC_CTRLA_CAPTMODE1_DEFAULT_Val    _U_(0x0)                                       /**< (TC_CTRLA) Default capture  */
+#define   TC_CTRLA_CAPTMODE1_CAPTMIN_Val    _U_(0x1)                                       /**< (TC_CTRLA) Minimum capture  */
+#define   TC_CTRLA_CAPTMODE1_CAPTMAX_Val    _U_(0x2)                                       /**< (TC_CTRLA) Maximum capture  */
+#define TC_CTRLA_CAPTMODE1_DEFAULT          (TC_CTRLA_CAPTMODE1_DEFAULT_Val << TC_CTRLA_CAPTMODE1_Pos)  /**< (TC_CTRLA) Default capture Position  */
+#define TC_CTRLA_CAPTMODE1_CAPTMIN          (TC_CTRLA_CAPTMODE1_CAPTMIN_Val << TC_CTRLA_CAPTMODE1_Pos)  /**< (TC_CTRLA) Minimum capture Position  */
+#define TC_CTRLA_CAPTMODE1_CAPTMAX          (TC_CTRLA_CAPTMODE1_CAPTMAX_Val << TC_CTRLA_CAPTMODE1_Pos)  /**< (TC_CTRLA) Maximum capture Position  */
+#define TC_CTRLA_MASK                       _U_(0x1B330FFF)                                /**< \deprecated (TC_CTRLA) Register MASK  (Use TC_CTRLA_Msk instead)  */
+#define TC_CTRLA_Msk                        _U_(0x1B330FFF)                                /**< (TC_CTRLA) Register Mask  */
+
+#define TC_CTRLA_CAPTEN_Pos                 16                                             /**< (TC_CTRLA Position) Capture Channel x Enable */
+#define TC_CTRLA_CAPTEN_Msk                 (_U_(0x3) << TC_CTRLA_CAPTEN_Pos)              /**< (TC_CTRLA Mask) CAPTEN */
+#define TC_CTRLA_CAPTEN(value)              (TC_CTRLA_CAPTEN_Msk & ((value) << TC_CTRLA_CAPTEN_Pos))  
+#define TC_CTRLA_COPEN_Pos                  20                                             /**< (TC_CTRLA Position) Capture On Pin x Enable */
+#define TC_CTRLA_COPEN_Msk                  (_U_(0x3) << TC_CTRLA_COPEN_Pos)               /**< (TC_CTRLA Mask) COPEN */
+#define TC_CTRLA_COPEN(value)               (TC_CTRLA_COPEN_Msk & ((value) << TC_CTRLA_COPEN_Pos))  
+
+/* -------- TC_CTRLBCLR : (TC Offset: 0x04) (R/W 8) Control B Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DIR:1;                     /**< bit:      0  Counter Direction                        */
+    uint8_t  LUPD:1;                    /**< bit:      1  Lock Update                              */
+    uint8_t  ONESHOT:1;                 /**< bit:      2  One-Shot on Counter                      */
+    uint8_t  :2;                        /**< bit:   3..4  Reserved */
+    uint8_t  CMD:3;                     /**< bit:   5..7  Command                                  */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} TC_CTRLBCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_CTRLBCLR_OFFSET                  (0x04)                                        /**<  (TC_CTRLBCLR) Control B Clear  Offset */
+#define TC_CTRLBCLR_RESETVALUE              _U_(0x00)                                     /**<  (TC_CTRLBCLR) Control B Clear  Reset Value */
+
+#define TC_CTRLBCLR_DIR_Pos                 0                                              /**< (TC_CTRLBCLR) Counter Direction Position */
+#define TC_CTRLBCLR_DIR_Msk                 (_U_(0x1) << TC_CTRLBCLR_DIR_Pos)              /**< (TC_CTRLBCLR) Counter Direction Mask */
+#define TC_CTRLBCLR_DIR                     TC_CTRLBCLR_DIR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CTRLBCLR_DIR_Msk instead */
+#define TC_CTRLBCLR_LUPD_Pos                1                                              /**< (TC_CTRLBCLR) Lock Update Position */
+#define TC_CTRLBCLR_LUPD_Msk                (_U_(0x1) << TC_CTRLBCLR_LUPD_Pos)             /**< (TC_CTRLBCLR) Lock Update Mask */
+#define TC_CTRLBCLR_LUPD                    TC_CTRLBCLR_LUPD_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CTRLBCLR_LUPD_Msk instead */
+#define TC_CTRLBCLR_ONESHOT_Pos             2                                              /**< (TC_CTRLBCLR) One-Shot on Counter Position */
+#define TC_CTRLBCLR_ONESHOT_Msk             (_U_(0x1) << TC_CTRLBCLR_ONESHOT_Pos)          /**< (TC_CTRLBCLR) One-Shot on Counter Mask */
+#define TC_CTRLBCLR_ONESHOT                 TC_CTRLBCLR_ONESHOT_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CTRLBCLR_ONESHOT_Msk instead */
+#define TC_CTRLBCLR_CMD_Pos                 5                                              /**< (TC_CTRLBCLR) Command Position */
+#define TC_CTRLBCLR_CMD_Msk                 (_U_(0x7) << TC_CTRLBCLR_CMD_Pos)              /**< (TC_CTRLBCLR) Command Mask */
+#define TC_CTRLBCLR_CMD(value)              (TC_CTRLBCLR_CMD_Msk & ((value) << TC_CTRLBCLR_CMD_Pos))
+#define   TC_CTRLBCLR_CMD_NONE_Val          _U_(0x0)                                       /**< (TC_CTRLBCLR) No action  */
+#define   TC_CTRLBCLR_CMD_RETRIGGER_Val     _U_(0x1)                                       /**< (TC_CTRLBCLR) Force a start, restart or retrigger  */
+#define   TC_CTRLBCLR_CMD_STOP_Val          _U_(0x2)                                       /**< (TC_CTRLBCLR) Force a stop  */
+#define   TC_CTRLBCLR_CMD_UPDATE_Val        _U_(0x3)                                       /**< (TC_CTRLBCLR) Force update of double-buffered register  */
+#define   TC_CTRLBCLR_CMD_READSYNC_Val      _U_(0x4)                                       /**< (TC_CTRLBCLR) Force a read synchronization of COUNT  */
+#define   TC_CTRLBCLR_CMD_DMAOS_Val         _U_(0x5)                                       /**< (TC_CTRLBCLR) One-shot DMA trigger  */
+#define TC_CTRLBCLR_CMD_NONE                (TC_CTRLBCLR_CMD_NONE_Val << TC_CTRLBCLR_CMD_Pos)  /**< (TC_CTRLBCLR) No action Position  */
+#define TC_CTRLBCLR_CMD_RETRIGGER           (TC_CTRLBCLR_CMD_RETRIGGER_Val << TC_CTRLBCLR_CMD_Pos)  /**< (TC_CTRLBCLR) Force a start, restart or retrigger Position  */
+#define TC_CTRLBCLR_CMD_STOP                (TC_CTRLBCLR_CMD_STOP_Val << TC_CTRLBCLR_CMD_Pos)  /**< (TC_CTRLBCLR) Force a stop Position  */
+#define TC_CTRLBCLR_CMD_UPDATE              (TC_CTRLBCLR_CMD_UPDATE_Val << TC_CTRLBCLR_CMD_Pos)  /**< (TC_CTRLBCLR) Force update of double-buffered register Position  */
+#define TC_CTRLBCLR_CMD_READSYNC            (TC_CTRLBCLR_CMD_READSYNC_Val << TC_CTRLBCLR_CMD_Pos)  /**< (TC_CTRLBCLR) Force a read synchronization of COUNT Position  */
+#define TC_CTRLBCLR_CMD_DMAOS               (TC_CTRLBCLR_CMD_DMAOS_Val << TC_CTRLBCLR_CMD_Pos)  /**< (TC_CTRLBCLR) One-shot DMA trigger Position  */
+#define TC_CTRLBCLR_MASK                    _U_(0xE7)                                      /**< \deprecated (TC_CTRLBCLR) Register MASK  (Use TC_CTRLBCLR_Msk instead)  */
+#define TC_CTRLBCLR_Msk                     _U_(0xE7)                                      /**< (TC_CTRLBCLR) Register Mask  */
+
+
+/* -------- TC_CTRLBSET : (TC Offset: 0x05) (R/W 8) Control B Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DIR:1;                     /**< bit:      0  Counter Direction                        */
+    uint8_t  LUPD:1;                    /**< bit:      1  Lock Update                              */
+    uint8_t  ONESHOT:1;                 /**< bit:      2  One-Shot on Counter                      */
+    uint8_t  :2;                        /**< bit:   3..4  Reserved */
+    uint8_t  CMD:3;                     /**< bit:   5..7  Command                                  */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} TC_CTRLBSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_CTRLBSET_OFFSET                  (0x05)                                        /**<  (TC_CTRLBSET) Control B Set  Offset */
+#define TC_CTRLBSET_RESETVALUE              _U_(0x00)                                     /**<  (TC_CTRLBSET) Control B Set  Reset Value */
+
+#define TC_CTRLBSET_DIR_Pos                 0                                              /**< (TC_CTRLBSET) Counter Direction Position */
+#define TC_CTRLBSET_DIR_Msk                 (_U_(0x1) << TC_CTRLBSET_DIR_Pos)              /**< (TC_CTRLBSET) Counter Direction Mask */
+#define TC_CTRLBSET_DIR                     TC_CTRLBSET_DIR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CTRLBSET_DIR_Msk instead */
+#define TC_CTRLBSET_LUPD_Pos                1                                              /**< (TC_CTRLBSET) Lock Update Position */
+#define TC_CTRLBSET_LUPD_Msk                (_U_(0x1) << TC_CTRLBSET_LUPD_Pos)             /**< (TC_CTRLBSET) Lock Update Mask */
+#define TC_CTRLBSET_LUPD                    TC_CTRLBSET_LUPD_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CTRLBSET_LUPD_Msk instead */
+#define TC_CTRLBSET_ONESHOT_Pos             2                                              /**< (TC_CTRLBSET) One-Shot on Counter Position */
+#define TC_CTRLBSET_ONESHOT_Msk             (_U_(0x1) << TC_CTRLBSET_ONESHOT_Pos)          /**< (TC_CTRLBSET) One-Shot on Counter Mask */
+#define TC_CTRLBSET_ONESHOT                 TC_CTRLBSET_ONESHOT_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CTRLBSET_ONESHOT_Msk instead */
+#define TC_CTRLBSET_CMD_Pos                 5                                              /**< (TC_CTRLBSET) Command Position */
+#define TC_CTRLBSET_CMD_Msk                 (_U_(0x7) << TC_CTRLBSET_CMD_Pos)              /**< (TC_CTRLBSET) Command Mask */
+#define TC_CTRLBSET_CMD(value)              (TC_CTRLBSET_CMD_Msk & ((value) << TC_CTRLBSET_CMD_Pos))
+#define   TC_CTRLBSET_CMD_NONE_Val          _U_(0x0)                                       /**< (TC_CTRLBSET) No action  */
+#define   TC_CTRLBSET_CMD_RETRIGGER_Val     _U_(0x1)                                       /**< (TC_CTRLBSET) Force a start, restart or retrigger  */
+#define   TC_CTRLBSET_CMD_STOP_Val          _U_(0x2)                                       /**< (TC_CTRLBSET) Force a stop  */
+#define   TC_CTRLBSET_CMD_UPDATE_Val        _U_(0x3)                                       /**< (TC_CTRLBSET) Force update of double-buffered register  */
+#define   TC_CTRLBSET_CMD_READSYNC_Val      _U_(0x4)                                       /**< (TC_CTRLBSET) Force a read synchronization of COUNT  */
+#define   TC_CTRLBSET_CMD_DMAOS_Val         _U_(0x5)                                       /**< (TC_CTRLBSET) One-shot DMA trigger  */
+#define TC_CTRLBSET_CMD_NONE                (TC_CTRLBSET_CMD_NONE_Val << TC_CTRLBSET_CMD_Pos)  /**< (TC_CTRLBSET) No action Position  */
+#define TC_CTRLBSET_CMD_RETRIGGER           (TC_CTRLBSET_CMD_RETRIGGER_Val << TC_CTRLBSET_CMD_Pos)  /**< (TC_CTRLBSET) Force a start, restart or retrigger Position  */
+#define TC_CTRLBSET_CMD_STOP                (TC_CTRLBSET_CMD_STOP_Val << TC_CTRLBSET_CMD_Pos)  /**< (TC_CTRLBSET) Force a stop Position  */
+#define TC_CTRLBSET_CMD_UPDATE              (TC_CTRLBSET_CMD_UPDATE_Val << TC_CTRLBSET_CMD_Pos)  /**< (TC_CTRLBSET) Force update of double-buffered register Position  */
+#define TC_CTRLBSET_CMD_READSYNC            (TC_CTRLBSET_CMD_READSYNC_Val << TC_CTRLBSET_CMD_Pos)  /**< (TC_CTRLBSET) Force a read synchronization of COUNT Position  */
+#define TC_CTRLBSET_CMD_DMAOS               (TC_CTRLBSET_CMD_DMAOS_Val << TC_CTRLBSET_CMD_Pos)  /**< (TC_CTRLBSET) One-shot DMA trigger Position  */
+#define TC_CTRLBSET_MASK                    _U_(0xE7)                                      /**< \deprecated (TC_CTRLBSET) Register MASK  (Use TC_CTRLBSET_Msk instead)  */
+#define TC_CTRLBSET_Msk                     _U_(0xE7)                                      /**< (TC_CTRLBSET) Register Mask  */
+
+
+/* -------- TC_EVCTRL : (TC Offset: 0x06) (R/W 16) Event Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t EVACT:3;                   /**< bit:   0..2  Event Action                             */
+    uint16_t :1;                        /**< bit:      3  Reserved */
+    uint16_t TCINV:1;                   /**< bit:      4  TC Event Input Polarity                  */
+    uint16_t TCEI:1;                    /**< bit:      5  TC Event Enable                          */
+    uint16_t :2;                        /**< bit:   6..7  Reserved */
+    uint16_t OVFEO:1;                   /**< bit:      8  Event Output Enable                      */
+    uint16_t :3;                        /**< bit:  9..11  Reserved */
+    uint16_t MCEO0:1;                   /**< bit:     12  MC Event Output Enable 0                 */
+    uint16_t MCEO1:1;                   /**< bit:     13  MC Event Output Enable 1                 */
+    uint16_t :2;                        /**< bit: 14..15  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint16_t :12;                       /**< bit:  0..11  Reserved */
+    uint16_t MCEO:2;                    /**< bit: 12..13  MC Event Output Enable x                 */
+    uint16_t :2;                        /**< bit: 14..15 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint16_t reg;                         /**< Type used for register access */
+} TC_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_EVCTRL_OFFSET                    (0x06)                                        /**<  (TC_EVCTRL) Event Control  Offset */
+#define TC_EVCTRL_RESETVALUE                _U_(0x00)                                     /**<  (TC_EVCTRL) Event Control  Reset Value */
+
+#define TC_EVCTRL_EVACT_Pos                 0                                              /**< (TC_EVCTRL) Event Action Position */
+#define TC_EVCTRL_EVACT_Msk                 (_U_(0x7) << TC_EVCTRL_EVACT_Pos)              /**< (TC_EVCTRL) Event Action Mask */
+#define TC_EVCTRL_EVACT(value)              (TC_EVCTRL_EVACT_Msk & ((value) << TC_EVCTRL_EVACT_Pos))
+#define   TC_EVCTRL_EVACT_OFF_Val           _U_(0x0)                                       /**< (TC_EVCTRL) Event action disabled  */
+#define   TC_EVCTRL_EVACT_RETRIGGER_Val     _U_(0x1)                                       /**< (TC_EVCTRL) Start, restart or retrigger TC on event  */
+#define   TC_EVCTRL_EVACT_COUNT_Val         _U_(0x2)                                       /**< (TC_EVCTRL) Count on event  */
+#define   TC_EVCTRL_EVACT_START_Val         _U_(0x3)                                       /**< (TC_EVCTRL) Start TC on event  */
+#define   TC_EVCTRL_EVACT_STAMP_Val         _U_(0x4)                                       /**< (TC_EVCTRL) Time stamp capture  */
+#define   TC_EVCTRL_EVACT_PPW_Val           _U_(0x5)                                       /**< (TC_EVCTRL) Period catured in CC0, pulse width in CC1  */
+#define   TC_EVCTRL_EVACT_PWP_Val           _U_(0x6)                                       /**< (TC_EVCTRL) Period catured in CC1, pulse width in CC0  */
+#define   TC_EVCTRL_EVACT_PW_Val            _U_(0x7)                                       /**< (TC_EVCTRL) Pulse width capture  */
+#define TC_EVCTRL_EVACT_OFF                 (TC_EVCTRL_EVACT_OFF_Val << TC_EVCTRL_EVACT_Pos)  /**< (TC_EVCTRL) Event action disabled Position  */
+#define TC_EVCTRL_EVACT_RETRIGGER           (TC_EVCTRL_EVACT_RETRIGGER_Val << TC_EVCTRL_EVACT_Pos)  /**< (TC_EVCTRL) Start, restart or retrigger TC on event Position  */
+#define TC_EVCTRL_EVACT_COUNT               (TC_EVCTRL_EVACT_COUNT_Val << TC_EVCTRL_EVACT_Pos)  /**< (TC_EVCTRL) Count on event Position  */
+#define TC_EVCTRL_EVACT_START               (TC_EVCTRL_EVACT_START_Val << TC_EVCTRL_EVACT_Pos)  /**< (TC_EVCTRL) Start TC on event Position  */
+#define TC_EVCTRL_EVACT_STAMP               (TC_EVCTRL_EVACT_STAMP_Val << TC_EVCTRL_EVACT_Pos)  /**< (TC_EVCTRL) Time stamp capture Position  */
+#define TC_EVCTRL_EVACT_PPW                 (TC_EVCTRL_EVACT_PPW_Val << TC_EVCTRL_EVACT_Pos)  /**< (TC_EVCTRL) Period catured in CC0, pulse width in CC1 Position  */
+#define TC_EVCTRL_EVACT_PWP                 (TC_EVCTRL_EVACT_PWP_Val << TC_EVCTRL_EVACT_Pos)  /**< (TC_EVCTRL) Period catured in CC1, pulse width in CC0 Position  */
+#define TC_EVCTRL_EVACT_PW                  (TC_EVCTRL_EVACT_PW_Val << TC_EVCTRL_EVACT_Pos)  /**< (TC_EVCTRL) Pulse width capture Position  */
+#define TC_EVCTRL_TCINV_Pos                 4                                              /**< (TC_EVCTRL) TC Event Input Polarity Position */
+#define TC_EVCTRL_TCINV_Msk                 (_U_(0x1) << TC_EVCTRL_TCINV_Pos)              /**< (TC_EVCTRL) TC Event Input Polarity Mask */
+#define TC_EVCTRL_TCINV                     TC_EVCTRL_TCINV_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_EVCTRL_TCINV_Msk instead */
+#define TC_EVCTRL_TCEI_Pos                  5                                              /**< (TC_EVCTRL) TC Event Enable Position */
+#define TC_EVCTRL_TCEI_Msk                  (_U_(0x1) << TC_EVCTRL_TCEI_Pos)               /**< (TC_EVCTRL) TC Event Enable Mask */
+#define TC_EVCTRL_TCEI                      TC_EVCTRL_TCEI_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_EVCTRL_TCEI_Msk instead */
+#define TC_EVCTRL_OVFEO_Pos                 8                                              /**< (TC_EVCTRL) Event Output Enable Position */
+#define TC_EVCTRL_OVFEO_Msk                 (_U_(0x1) << TC_EVCTRL_OVFEO_Pos)              /**< (TC_EVCTRL) Event Output Enable Mask */
+#define TC_EVCTRL_OVFEO                     TC_EVCTRL_OVFEO_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_EVCTRL_OVFEO_Msk instead */
+#define TC_EVCTRL_MCEO0_Pos                 12                                             /**< (TC_EVCTRL) MC Event Output Enable 0 Position */
+#define TC_EVCTRL_MCEO0_Msk                 (_U_(0x1) << TC_EVCTRL_MCEO0_Pos)              /**< (TC_EVCTRL) MC Event Output Enable 0 Mask */
+#define TC_EVCTRL_MCEO0                     TC_EVCTRL_MCEO0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_EVCTRL_MCEO0_Msk instead */
+#define TC_EVCTRL_MCEO1_Pos                 13                                             /**< (TC_EVCTRL) MC Event Output Enable 1 Position */
+#define TC_EVCTRL_MCEO1_Msk                 (_U_(0x1) << TC_EVCTRL_MCEO1_Pos)              /**< (TC_EVCTRL) MC Event Output Enable 1 Mask */
+#define TC_EVCTRL_MCEO1                     TC_EVCTRL_MCEO1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_EVCTRL_MCEO1_Msk instead */
+#define TC_EVCTRL_MASK                      _U_(0x3137)                                    /**< \deprecated (TC_EVCTRL) Register MASK  (Use TC_EVCTRL_Msk instead)  */
+#define TC_EVCTRL_Msk                       _U_(0x3137)                                    /**< (TC_EVCTRL) Register Mask  */
+
+#define TC_EVCTRL_MCEO_Pos                  12                                             /**< (TC_EVCTRL Position) MC Event Output Enable x */
+#define TC_EVCTRL_MCEO_Msk                  (_U_(0x3) << TC_EVCTRL_MCEO_Pos)               /**< (TC_EVCTRL Mask) MCEO */
+#define TC_EVCTRL_MCEO(value)               (TC_EVCTRL_MCEO_Msk & ((value) << TC_EVCTRL_MCEO_Pos))  
+
+/* -------- TC_INTENCLR : (TC Offset: 0x08) (R/W 8) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  OVF:1;                     /**< bit:      0  OVF Interrupt Disable                    */
+    uint8_t  ERR:1;                     /**< bit:      1  ERR Interrupt Disable                    */
+    uint8_t  :2;                        /**< bit:   2..3  Reserved */
+    uint8_t  MC0:1;                     /**< bit:      4  MC Interrupt Disable 0                   */
+    uint8_t  MC1:1;                     /**< bit:      5  MC Interrupt Disable 1                   */
+    uint8_t  :2;                        /**< bit:   6..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint8_t  :4;                        /**< bit:   0..3  Reserved */
+    uint8_t  MC:2;                      /**< bit:   4..5  MC Interrupt Disable x                   */
+    uint8_t  :2;                        /**< bit:   6..7 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint8_t  reg;                         /**< Type used for register access */
+} TC_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_INTENCLR_OFFSET                  (0x08)                                        /**<  (TC_INTENCLR) Interrupt Enable Clear  Offset */
+#define TC_INTENCLR_RESETVALUE              _U_(0x00)                                     /**<  (TC_INTENCLR) Interrupt Enable Clear  Reset Value */
+
+#define TC_INTENCLR_OVF_Pos                 0                                              /**< (TC_INTENCLR) OVF Interrupt Disable Position */
+#define TC_INTENCLR_OVF_Msk                 (_U_(0x1) << TC_INTENCLR_OVF_Pos)              /**< (TC_INTENCLR) OVF Interrupt Disable Mask */
+#define TC_INTENCLR_OVF                     TC_INTENCLR_OVF_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_INTENCLR_OVF_Msk instead */
+#define TC_INTENCLR_ERR_Pos                 1                                              /**< (TC_INTENCLR) ERR Interrupt Disable Position */
+#define TC_INTENCLR_ERR_Msk                 (_U_(0x1) << TC_INTENCLR_ERR_Pos)              /**< (TC_INTENCLR) ERR Interrupt Disable Mask */
+#define TC_INTENCLR_ERR                     TC_INTENCLR_ERR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_INTENCLR_ERR_Msk instead */
+#define TC_INTENCLR_MC0_Pos                 4                                              /**< (TC_INTENCLR) MC Interrupt Disable 0 Position */
+#define TC_INTENCLR_MC0_Msk                 (_U_(0x1) << TC_INTENCLR_MC0_Pos)              /**< (TC_INTENCLR) MC Interrupt Disable 0 Mask */
+#define TC_INTENCLR_MC0                     TC_INTENCLR_MC0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_INTENCLR_MC0_Msk instead */
+#define TC_INTENCLR_MC1_Pos                 5                                              /**< (TC_INTENCLR) MC Interrupt Disable 1 Position */
+#define TC_INTENCLR_MC1_Msk                 (_U_(0x1) << TC_INTENCLR_MC1_Pos)              /**< (TC_INTENCLR) MC Interrupt Disable 1 Mask */
+#define TC_INTENCLR_MC1                     TC_INTENCLR_MC1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_INTENCLR_MC1_Msk instead */
+#define TC_INTENCLR_MASK                    _U_(0x33)                                      /**< \deprecated (TC_INTENCLR) Register MASK  (Use TC_INTENCLR_Msk instead)  */
+#define TC_INTENCLR_Msk                     _U_(0x33)                                      /**< (TC_INTENCLR) Register Mask  */
+
+#define TC_INTENCLR_MC_Pos                  4                                              /**< (TC_INTENCLR Position) MC Interrupt Disable x */
+#define TC_INTENCLR_MC_Msk                  (_U_(0x3) << TC_INTENCLR_MC_Pos)               /**< (TC_INTENCLR Mask) MC */
+#define TC_INTENCLR_MC(value)               (TC_INTENCLR_MC_Msk & ((value) << TC_INTENCLR_MC_Pos))  
+
+/* -------- TC_INTENSET : (TC Offset: 0x09) (R/W 8) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  OVF:1;                     /**< bit:      0  OVF Interrupt Enable                     */
+    uint8_t  ERR:1;                     /**< bit:      1  ERR Interrupt Enable                     */
+    uint8_t  :2;                        /**< bit:   2..3  Reserved */
+    uint8_t  MC0:1;                     /**< bit:      4  MC Interrupt Enable 0                    */
+    uint8_t  MC1:1;                     /**< bit:      5  MC Interrupt Enable 1                    */
+    uint8_t  :2;                        /**< bit:   6..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint8_t  :4;                        /**< bit:   0..3  Reserved */
+    uint8_t  MC:2;                      /**< bit:   4..5  MC Interrupt Enable x                    */
+    uint8_t  :2;                        /**< bit:   6..7 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint8_t  reg;                         /**< Type used for register access */
+} TC_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_INTENSET_OFFSET                  (0x09)                                        /**<  (TC_INTENSET) Interrupt Enable Set  Offset */
+#define TC_INTENSET_RESETVALUE              _U_(0x00)                                     /**<  (TC_INTENSET) Interrupt Enable Set  Reset Value */
+
+#define TC_INTENSET_OVF_Pos                 0                                              /**< (TC_INTENSET) OVF Interrupt Enable Position */
+#define TC_INTENSET_OVF_Msk                 (_U_(0x1) << TC_INTENSET_OVF_Pos)              /**< (TC_INTENSET) OVF Interrupt Enable Mask */
+#define TC_INTENSET_OVF                     TC_INTENSET_OVF_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_INTENSET_OVF_Msk instead */
+#define TC_INTENSET_ERR_Pos                 1                                              /**< (TC_INTENSET) ERR Interrupt Enable Position */
+#define TC_INTENSET_ERR_Msk                 (_U_(0x1) << TC_INTENSET_ERR_Pos)              /**< (TC_INTENSET) ERR Interrupt Enable Mask */
+#define TC_INTENSET_ERR                     TC_INTENSET_ERR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_INTENSET_ERR_Msk instead */
+#define TC_INTENSET_MC0_Pos                 4                                              /**< (TC_INTENSET) MC Interrupt Enable 0 Position */
+#define TC_INTENSET_MC0_Msk                 (_U_(0x1) << TC_INTENSET_MC0_Pos)              /**< (TC_INTENSET) MC Interrupt Enable 0 Mask */
+#define TC_INTENSET_MC0                     TC_INTENSET_MC0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_INTENSET_MC0_Msk instead */
+#define TC_INTENSET_MC1_Pos                 5                                              /**< (TC_INTENSET) MC Interrupt Enable 1 Position */
+#define TC_INTENSET_MC1_Msk                 (_U_(0x1) << TC_INTENSET_MC1_Pos)              /**< (TC_INTENSET) MC Interrupt Enable 1 Mask */
+#define TC_INTENSET_MC1                     TC_INTENSET_MC1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_INTENSET_MC1_Msk instead */
+#define TC_INTENSET_MASK                    _U_(0x33)                                      /**< \deprecated (TC_INTENSET) Register MASK  (Use TC_INTENSET_Msk instead)  */
+#define TC_INTENSET_Msk                     _U_(0x33)                                      /**< (TC_INTENSET) Register Mask  */
+
+#define TC_INTENSET_MC_Pos                  4                                              /**< (TC_INTENSET Position) MC Interrupt Enable x */
+#define TC_INTENSET_MC_Msk                  (_U_(0x3) << TC_INTENSET_MC_Pos)               /**< (TC_INTENSET Mask) MC */
+#define TC_INTENSET_MC(value)               (TC_INTENSET_MC_Msk & ((value) << TC_INTENSET_MC_Pos))  
+
+/* -------- TC_INTFLAG : (TC Offset: 0x0a) (R/W 8) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t OVF:1;                     /**< bit:      0  OVF Interrupt Flag                       */
+    __I uint8_t ERR:1;                     /**< bit:      1  ERR Interrupt Flag                       */
+    __I uint8_t :2;                        /**< bit:   2..3  Reserved */
+    __I uint8_t MC0:1;                     /**< bit:      4  MC Interrupt Flag 0                      */
+    __I uint8_t MC1:1;                     /**< bit:      5  MC Interrupt Flag 1                      */
+    __I uint8_t :2;                        /**< bit:   6..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    __I uint8_t :4;                        /**< bit:   0..3  Reserved */
+    __I uint8_t MC:2;                      /**< bit:   4..5  MC Interrupt Flag x                      */
+    __I uint8_t :2;                        /**< bit:   6..7 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint8_t  reg;                         /**< Type used for register access */
+} TC_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_INTFLAG_OFFSET                   (0x0A)                                        /**<  (TC_INTFLAG) Interrupt Flag Status and Clear  Offset */
+#define TC_INTFLAG_RESETVALUE               _U_(0x00)                                     /**<  (TC_INTFLAG) Interrupt Flag Status and Clear  Reset Value */
+
+#define TC_INTFLAG_OVF_Pos                  0                                              /**< (TC_INTFLAG) OVF Interrupt Flag Position */
+#define TC_INTFLAG_OVF_Msk                  (_U_(0x1) << TC_INTFLAG_OVF_Pos)               /**< (TC_INTFLAG) OVF Interrupt Flag Mask */
+#define TC_INTFLAG_OVF                      TC_INTFLAG_OVF_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_INTFLAG_OVF_Msk instead */
+#define TC_INTFLAG_ERR_Pos                  1                                              /**< (TC_INTFLAG) ERR Interrupt Flag Position */
+#define TC_INTFLAG_ERR_Msk                  (_U_(0x1) << TC_INTFLAG_ERR_Pos)               /**< (TC_INTFLAG) ERR Interrupt Flag Mask */
+#define TC_INTFLAG_ERR                      TC_INTFLAG_ERR_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_INTFLAG_ERR_Msk instead */
+#define TC_INTFLAG_MC0_Pos                  4                                              /**< (TC_INTFLAG) MC Interrupt Flag 0 Position */
+#define TC_INTFLAG_MC0_Msk                  (_U_(0x1) << TC_INTFLAG_MC0_Pos)               /**< (TC_INTFLAG) MC Interrupt Flag 0 Mask */
+#define TC_INTFLAG_MC0                      TC_INTFLAG_MC0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_INTFLAG_MC0_Msk instead */
+#define TC_INTFLAG_MC1_Pos                  5                                              /**< (TC_INTFLAG) MC Interrupt Flag 1 Position */
+#define TC_INTFLAG_MC1_Msk                  (_U_(0x1) << TC_INTFLAG_MC1_Pos)               /**< (TC_INTFLAG) MC Interrupt Flag 1 Mask */
+#define TC_INTFLAG_MC1                      TC_INTFLAG_MC1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_INTFLAG_MC1_Msk instead */
+#define TC_INTFLAG_MASK                     _U_(0x33)                                      /**< \deprecated (TC_INTFLAG) Register MASK  (Use TC_INTFLAG_Msk instead)  */
+#define TC_INTFLAG_Msk                      _U_(0x33)                                      /**< (TC_INTFLAG) Register Mask  */
+
+#define TC_INTFLAG_MC_Pos                   4                                              /**< (TC_INTFLAG Position) MC Interrupt Flag x */
+#define TC_INTFLAG_MC_Msk                   (_U_(0x3) << TC_INTFLAG_MC_Pos)                /**< (TC_INTFLAG Mask) MC */
+#define TC_INTFLAG_MC(value)                (TC_INTFLAG_MC_Msk & ((value) << TC_INTFLAG_MC_Pos))  
+
+/* -------- TC_STATUS : (TC Offset: 0x0b) (R/W 8) Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  STOP:1;                    /**< bit:      0  Stop Status Flag                         */
+    uint8_t  SLAVE:1;                   /**< bit:      1  Slave Status Flag                        */
+    uint8_t  :1;                        /**< bit:      2  Reserved */
+    uint8_t  PERBUFV:1;                 /**< bit:      3  Synchronization Busy Status              */
+    uint8_t  CCBUFV0:1;                 /**< bit:      4  Compare channel buffer 0 valid           */
+    uint8_t  CCBUFV1:1;                 /**< bit:      5  Compare channel buffer 1 valid           */
+    uint8_t  :2;                        /**< bit:   6..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint8_t  :4;                        /**< bit:   0..3  Reserved */
+    uint8_t  CCBUFV:2;                  /**< bit:   4..5  Compare channel buffer x valid           */
+    uint8_t  :2;                        /**< bit:   6..7 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint8_t  reg;                         /**< Type used for register access */
+} TC_STATUS_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_STATUS_OFFSET                    (0x0B)                                        /**<  (TC_STATUS) Status  Offset */
+#define TC_STATUS_RESETVALUE                _U_(0x01)                                     /**<  (TC_STATUS) Status  Reset Value */
+
+#define TC_STATUS_STOP_Pos                  0                                              /**< (TC_STATUS) Stop Status Flag Position */
+#define TC_STATUS_STOP_Msk                  (_U_(0x1) << TC_STATUS_STOP_Pos)               /**< (TC_STATUS) Stop Status Flag Mask */
+#define TC_STATUS_STOP                      TC_STATUS_STOP_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_STATUS_STOP_Msk instead */
+#define TC_STATUS_SLAVE_Pos                 1                                              /**< (TC_STATUS) Slave Status Flag Position */
+#define TC_STATUS_SLAVE_Msk                 (_U_(0x1) << TC_STATUS_SLAVE_Pos)              /**< (TC_STATUS) Slave Status Flag Mask */
+#define TC_STATUS_SLAVE                     TC_STATUS_SLAVE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_STATUS_SLAVE_Msk instead */
+#define TC_STATUS_PERBUFV_Pos               3                                              /**< (TC_STATUS) Synchronization Busy Status Position */
+#define TC_STATUS_PERBUFV_Msk               (_U_(0x1) << TC_STATUS_PERBUFV_Pos)            /**< (TC_STATUS) Synchronization Busy Status Mask */
+#define TC_STATUS_PERBUFV                   TC_STATUS_PERBUFV_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_STATUS_PERBUFV_Msk instead */
+#define TC_STATUS_CCBUFV0_Pos               4                                              /**< (TC_STATUS) Compare channel buffer 0 valid Position */
+#define TC_STATUS_CCBUFV0_Msk               (_U_(0x1) << TC_STATUS_CCBUFV0_Pos)            /**< (TC_STATUS) Compare channel buffer 0 valid Mask */
+#define TC_STATUS_CCBUFV0                   TC_STATUS_CCBUFV0_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_STATUS_CCBUFV0_Msk instead */
+#define TC_STATUS_CCBUFV1_Pos               5                                              /**< (TC_STATUS) Compare channel buffer 1 valid Position */
+#define TC_STATUS_CCBUFV1_Msk               (_U_(0x1) << TC_STATUS_CCBUFV1_Pos)            /**< (TC_STATUS) Compare channel buffer 1 valid Mask */
+#define TC_STATUS_CCBUFV1                   TC_STATUS_CCBUFV1_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_STATUS_CCBUFV1_Msk instead */
+#define TC_STATUS_MASK                      _U_(0x3B)                                      /**< \deprecated (TC_STATUS) Register MASK  (Use TC_STATUS_Msk instead)  */
+#define TC_STATUS_Msk                       _U_(0x3B)                                      /**< (TC_STATUS) Register Mask  */
+
+#define TC_STATUS_CCBUFV_Pos                4                                              /**< (TC_STATUS Position) Compare channel buffer x valid */
+#define TC_STATUS_CCBUFV_Msk                (_U_(0x3) << TC_STATUS_CCBUFV_Pos)             /**< (TC_STATUS Mask) CCBUFV */
+#define TC_STATUS_CCBUFV(value)             (TC_STATUS_CCBUFV_Msk & ((value) << TC_STATUS_CCBUFV_Pos))  
+
+/* -------- TC_WAVE : (TC Offset: 0x0c) (R/W 8) Waveform Generation Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  WAVEGEN:2;                 /**< bit:   0..1  Waveform Generation Mode                 */
+    uint8_t  :6;                        /**< bit:   2..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} TC_WAVE_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_WAVE_OFFSET                      (0x0C)                                        /**<  (TC_WAVE) Waveform Generation Control  Offset */
+#define TC_WAVE_RESETVALUE                  _U_(0x00)                                     /**<  (TC_WAVE) Waveform Generation Control  Reset Value */
+
+#define TC_WAVE_WAVEGEN_Pos                 0                                              /**< (TC_WAVE) Waveform Generation Mode Position */
+#define TC_WAVE_WAVEGEN_Msk                 (_U_(0x3) << TC_WAVE_WAVEGEN_Pos)              /**< (TC_WAVE) Waveform Generation Mode Mask */
+#define TC_WAVE_WAVEGEN(value)              (TC_WAVE_WAVEGEN_Msk & ((value) << TC_WAVE_WAVEGEN_Pos))
+#define   TC_WAVE_WAVEGEN_NFRQ_Val          _U_(0x0)                                       /**< (TC_WAVE) Normal frequency  */
+#define   TC_WAVE_WAVEGEN_MFRQ_Val          _U_(0x1)                                       /**< (TC_WAVE) Match frequency  */
+#define   TC_WAVE_WAVEGEN_NPWM_Val          _U_(0x2)                                       /**< (TC_WAVE) Normal PWM  */
+#define   TC_WAVE_WAVEGEN_MPWM_Val          _U_(0x3)                                       /**< (TC_WAVE) Match PWM  */
+#define TC_WAVE_WAVEGEN_NFRQ                (TC_WAVE_WAVEGEN_NFRQ_Val << TC_WAVE_WAVEGEN_Pos)  /**< (TC_WAVE) Normal frequency Position  */
+#define TC_WAVE_WAVEGEN_MFRQ                (TC_WAVE_WAVEGEN_MFRQ_Val << TC_WAVE_WAVEGEN_Pos)  /**< (TC_WAVE) Match frequency Position  */
+#define TC_WAVE_WAVEGEN_NPWM                (TC_WAVE_WAVEGEN_NPWM_Val << TC_WAVE_WAVEGEN_Pos)  /**< (TC_WAVE) Normal PWM Position  */
+#define TC_WAVE_WAVEGEN_MPWM                (TC_WAVE_WAVEGEN_MPWM_Val << TC_WAVE_WAVEGEN_Pos)  /**< (TC_WAVE) Match PWM Position  */
+#define TC_WAVE_MASK                        _U_(0x03)                                      /**< \deprecated (TC_WAVE) Register MASK  (Use TC_WAVE_Msk instead)  */
+#define TC_WAVE_Msk                         _U_(0x03)                                      /**< (TC_WAVE) Register Mask  */
+
+
+/* -------- TC_DRVCTRL : (TC Offset: 0x0d) (R/W 8) Control C -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  INVEN0:1;                  /**< bit:      0  Output Waveform Invert Enable 0          */
+    uint8_t  INVEN1:1;                  /**< bit:      1  Output Waveform Invert Enable 1          */
+    uint8_t  :6;                        /**< bit:   2..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint8_t  INVEN:2;                   /**< bit:   0..1  Output Waveform Invert Enable x          */
+    uint8_t  :6;                        /**< bit:   2..7 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint8_t  reg;                         /**< Type used for register access */
+} TC_DRVCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_DRVCTRL_OFFSET                   (0x0D)                                        /**<  (TC_DRVCTRL) Control C  Offset */
+#define TC_DRVCTRL_RESETVALUE               _U_(0x00)                                     /**<  (TC_DRVCTRL) Control C  Reset Value */
+
+#define TC_DRVCTRL_INVEN0_Pos               0                                              /**< (TC_DRVCTRL) Output Waveform Invert Enable 0 Position */
+#define TC_DRVCTRL_INVEN0_Msk               (_U_(0x1) << TC_DRVCTRL_INVEN0_Pos)            /**< (TC_DRVCTRL) Output Waveform Invert Enable 0 Mask */
+#define TC_DRVCTRL_INVEN0                   TC_DRVCTRL_INVEN0_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_DRVCTRL_INVEN0_Msk instead */
+#define TC_DRVCTRL_INVEN1_Pos               1                                              /**< (TC_DRVCTRL) Output Waveform Invert Enable 1 Position */
+#define TC_DRVCTRL_INVEN1_Msk               (_U_(0x1) << TC_DRVCTRL_INVEN1_Pos)            /**< (TC_DRVCTRL) Output Waveform Invert Enable 1 Mask */
+#define TC_DRVCTRL_INVEN1                   TC_DRVCTRL_INVEN1_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_DRVCTRL_INVEN1_Msk instead */
+#define TC_DRVCTRL_MASK                     _U_(0x03)                                      /**< \deprecated (TC_DRVCTRL) Register MASK  (Use TC_DRVCTRL_Msk instead)  */
+#define TC_DRVCTRL_Msk                      _U_(0x03)                                      /**< (TC_DRVCTRL) Register Mask  */
+
+#define TC_DRVCTRL_INVEN_Pos                0                                              /**< (TC_DRVCTRL Position) Output Waveform Invert Enable x */
+#define TC_DRVCTRL_INVEN_Msk                (_U_(0x3) << TC_DRVCTRL_INVEN_Pos)             /**< (TC_DRVCTRL Mask) INVEN */
+#define TC_DRVCTRL_INVEN(value)             (TC_DRVCTRL_INVEN_Msk & ((value) << TC_DRVCTRL_INVEN_Pos))  
+
+/* -------- TC_DBGCTRL : (TC Offset: 0x0f) (R/W 8) Debug Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DBGRUN:1;                  /**< bit:      0  Run During Debug                         */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} TC_DBGCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_DBGCTRL_OFFSET                   (0x0F)                                        /**<  (TC_DBGCTRL) Debug Control  Offset */
+#define TC_DBGCTRL_RESETVALUE               _U_(0x00)                                     /**<  (TC_DBGCTRL) Debug Control  Reset Value */
+
+#define TC_DBGCTRL_DBGRUN_Pos               0                                              /**< (TC_DBGCTRL) Run During Debug Position */
+#define TC_DBGCTRL_DBGRUN_Msk               (_U_(0x1) << TC_DBGCTRL_DBGRUN_Pos)            /**< (TC_DBGCTRL) Run During Debug Mask */
+#define TC_DBGCTRL_DBGRUN                   TC_DBGCTRL_DBGRUN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_DBGCTRL_DBGRUN_Msk instead */
+#define TC_DBGCTRL_MASK                     _U_(0x01)                                      /**< \deprecated (TC_DBGCTRL) Register MASK  (Use TC_DBGCTRL_Msk instead)  */
+#define TC_DBGCTRL_Msk                      _U_(0x01)                                      /**< (TC_DBGCTRL) Register Mask  */
+
+
+/* -------- TC_SYNCBUSY : (TC Offset: 0x10) (R/ 32) Synchronization Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SWRST:1;                   /**< bit:      0  swrst                                    */
+    uint32_t ENABLE:1;                  /**< bit:      1  enable                                   */
+    uint32_t CTRLB:1;                   /**< bit:      2  CTRLB                                    */
+    uint32_t STATUS:1;                  /**< bit:      3  STATUS                                   */
+    uint32_t COUNT:1;                   /**< bit:      4  Counter                                  */
+    uint32_t PER:1;                     /**< bit:      5  Period                                   */
+    uint32_t CC0:1;                     /**< bit:      6  Compare Channel 0                        */
+    uint32_t CC1:1;                     /**< bit:      7  Compare Channel 1                        */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :6;                        /**< bit:   0..5  Reserved */
+    uint32_t CC:2;                      /**< bit:   6..7  Compare Channel x                        */
+    uint32_t :24;                       /**< bit:  8..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_SYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_SYNCBUSY_OFFSET                  (0x10)                                        /**<  (TC_SYNCBUSY) Synchronization Status  Offset */
+#define TC_SYNCBUSY_RESETVALUE              _U_(0x00)                                     /**<  (TC_SYNCBUSY) Synchronization Status  Reset Value */
+
+#define TC_SYNCBUSY_SWRST_Pos               0                                              /**< (TC_SYNCBUSY) swrst Position */
+#define TC_SYNCBUSY_SWRST_Msk               (_U_(0x1) << TC_SYNCBUSY_SWRST_Pos)            /**< (TC_SYNCBUSY) swrst Mask */
+#define TC_SYNCBUSY_SWRST                   TC_SYNCBUSY_SWRST_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_SYNCBUSY_SWRST_Msk instead */
+#define TC_SYNCBUSY_ENABLE_Pos              1                                              /**< (TC_SYNCBUSY) enable Position */
+#define TC_SYNCBUSY_ENABLE_Msk              (_U_(0x1) << TC_SYNCBUSY_ENABLE_Pos)           /**< (TC_SYNCBUSY) enable Mask */
+#define TC_SYNCBUSY_ENABLE                  TC_SYNCBUSY_ENABLE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_SYNCBUSY_ENABLE_Msk instead */
+#define TC_SYNCBUSY_CTRLB_Pos               2                                              /**< (TC_SYNCBUSY) CTRLB Position */
+#define TC_SYNCBUSY_CTRLB_Msk               (_U_(0x1) << TC_SYNCBUSY_CTRLB_Pos)            /**< (TC_SYNCBUSY) CTRLB Mask */
+#define TC_SYNCBUSY_CTRLB                   TC_SYNCBUSY_CTRLB_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_SYNCBUSY_CTRLB_Msk instead */
+#define TC_SYNCBUSY_STATUS_Pos              3                                              /**< (TC_SYNCBUSY) STATUS Position */
+#define TC_SYNCBUSY_STATUS_Msk              (_U_(0x1) << TC_SYNCBUSY_STATUS_Pos)           /**< (TC_SYNCBUSY) STATUS Mask */
+#define TC_SYNCBUSY_STATUS                  TC_SYNCBUSY_STATUS_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_SYNCBUSY_STATUS_Msk instead */
+#define TC_SYNCBUSY_COUNT_Pos               4                                              /**< (TC_SYNCBUSY) Counter Position */
+#define TC_SYNCBUSY_COUNT_Msk               (_U_(0x1) << TC_SYNCBUSY_COUNT_Pos)            /**< (TC_SYNCBUSY) Counter Mask */
+#define TC_SYNCBUSY_COUNT                   TC_SYNCBUSY_COUNT_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_SYNCBUSY_COUNT_Msk instead */
+#define TC_SYNCBUSY_PER_Pos                 5                                              /**< (TC_SYNCBUSY) Period Position */
+#define TC_SYNCBUSY_PER_Msk                 (_U_(0x1) << TC_SYNCBUSY_PER_Pos)              /**< (TC_SYNCBUSY) Period Mask */
+#define TC_SYNCBUSY_PER                     TC_SYNCBUSY_PER_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_SYNCBUSY_PER_Msk instead */
+#define TC_SYNCBUSY_CC0_Pos                 6                                              /**< (TC_SYNCBUSY) Compare Channel 0 Position */
+#define TC_SYNCBUSY_CC0_Msk                 (_U_(0x1) << TC_SYNCBUSY_CC0_Pos)              /**< (TC_SYNCBUSY) Compare Channel 0 Mask */
+#define TC_SYNCBUSY_CC0                     TC_SYNCBUSY_CC0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_SYNCBUSY_CC0_Msk instead */
+#define TC_SYNCBUSY_CC1_Pos                 7                                              /**< (TC_SYNCBUSY) Compare Channel 1 Position */
+#define TC_SYNCBUSY_CC1_Msk                 (_U_(0x1) << TC_SYNCBUSY_CC1_Pos)              /**< (TC_SYNCBUSY) Compare Channel 1 Mask */
+#define TC_SYNCBUSY_CC1                     TC_SYNCBUSY_CC1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_SYNCBUSY_CC1_Msk instead */
+#define TC_SYNCBUSY_MASK                    _U_(0xFF)                                      /**< \deprecated (TC_SYNCBUSY) Register MASK  (Use TC_SYNCBUSY_Msk instead)  */
+#define TC_SYNCBUSY_Msk                     _U_(0xFF)                                      /**< (TC_SYNCBUSY) Register Mask  */
+
+#define TC_SYNCBUSY_CC_Pos                  6                                              /**< (TC_SYNCBUSY Position) Compare Channel x */
+#define TC_SYNCBUSY_CC_Msk                  (_U_(0x3) << TC_SYNCBUSY_CC_Pos)               /**< (TC_SYNCBUSY Mask) CC */
+#define TC_SYNCBUSY_CC(value)               (TC_SYNCBUSY_CC_Msk & ((value) << TC_SYNCBUSY_CC_Pos))  
+
+/* -------- TC_COUNT8_COUNT : (TC Offset: 0x14) (R/W 8) COUNT8 Count -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  COUNT:8;                   /**< bit:   0..7  Counter Value                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} TC_COUNT8_COUNT_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT8_COUNT_OFFSET              (0x14)                                        /**<  (TC_COUNT8_COUNT) COUNT8 Count  Offset */
+#define TC_COUNT8_COUNT_RESETVALUE          _U_(0x00)                                     /**<  (TC_COUNT8_COUNT) COUNT8 Count  Reset Value */
+
+#define TC_COUNT8_COUNT_COUNT_Pos           0                                              /**< (TC_COUNT8_COUNT) Counter Value Position */
+#define TC_COUNT8_COUNT_COUNT_Msk           (_U_(0xFF) << TC_COUNT8_COUNT_COUNT_Pos)       /**< (TC_COUNT8_COUNT) Counter Value Mask */
+#define TC_COUNT8_COUNT_COUNT(value)        (TC_COUNT8_COUNT_COUNT_Msk & ((value) << TC_COUNT8_COUNT_COUNT_Pos))
+#define TC_COUNT8_COUNT_MASK                _U_(0xFF)                                      /**< \deprecated (TC_COUNT8_COUNT) Register MASK  (Use TC_COUNT8_COUNT_Msk instead)  */
+#define TC_COUNT8_COUNT_Msk                 _U_(0xFF)                                      /**< (TC_COUNT8_COUNT) Register Mask  */
+
+
+/* -------- TC_COUNT16_COUNT : (TC Offset: 0x14) (R/W 16) COUNT16 Count -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t COUNT:16;                  /**< bit:  0..15  Counter Value                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} TC_COUNT16_COUNT_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT16_COUNT_OFFSET             (0x14)                                        /**<  (TC_COUNT16_COUNT) COUNT16 Count  Offset */
+#define TC_COUNT16_COUNT_RESETVALUE         _U_(0x00)                                     /**<  (TC_COUNT16_COUNT) COUNT16 Count  Reset Value */
+
+#define TC_COUNT16_COUNT_COUNT_Pos          0                                              /**< (TC_COUNT16_COUNT) Counter Value Position */
+#define TC_COUNT16_COUNT_COUNT_Msk          (_U_(0xFFFF) << TC_COUNT16_COUNT_COUNT_Pos)    /**< (TC_COUNT16_COUNT) Counter Value Mask */
+#define TC_COUNT16_COUNT_COUNT(value)       (TC_COUNT16_COUNT_COUNT_Msk & ((value) << TC_COUNT16_COUNT_COUNT_Pos))
+#define TC_COUNT16_COUNT_MASK               _U_(0xFFFF)                                    /**< \deprecated (TC_COUNT16_COUNT) Register MASK  (Use TC_COUNT16_COUNT_Msk instead)  */
+#define TC_COUNT16_COUNT_Msk                _U_(0xFFFF)                                    /**< (TC_COUNT16_COUNT) Register Mask  */
+
+
+/* -------- TC_COUNT32_COUNT : (TC Offset: 0x14) (R/W 32) COUNT32 Count -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t COUNT:32;                  /**< bit:  0..31  Counter Value                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_COUNT32_COUNT_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT32_COUNT_OFFSET             (0x14)                                        /**<  (TC_COUNT32_COUNT) COUNT32 Count  Offset */
+#define TC_COUNT32_COUNT_RESETVALUE         _U_(0x00)                                     /**<  (TC_COUNT32_COUNT) COUNT32 Count  Reset Value */
+
+#define TC_COUNT32_COUNT_COUNT_Pos          0                                              /**< (TC_COUNT32_COUNT) Counter Value Position */
+#define TC_COUNT32_COUNT_COUNT_Msk          (_U_(0xFFFFFFFF) << TC_COUNT32_COUNT_COUNT_Pos)  /**< (TC_COUNT32_COUNT) Counter Value Mask */
+#define TC_COUNT32_COUNT_COUNT(value)       (TC_COUNT32_COUNT_COUNT_Msk & ((value) << TC_COUNT32_COUNT_COUNT_Pos))
+#define TC_COUNT32_COUNT_MASK               _U_(0xFFFFFFFF)                                /**< \deprecated (TC_COUNT32_COUNT) Register MASK  (Use TC_COUNT32_COUNT_Msk instead)  */
+#define TC_COUNT32_COUNT_Msk                _U_(0xFFFFFFFF)                                /**< (TC_COUNT32_COUNT) Register Mask  */
+
+
+/* -------- TC_COUNT32_PER : (TC Offset: 0x18) (R/W 32) COUNT32 Period -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t PER:32;                    /**< bit:  0..31  Period Value                             */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_COUNT32_PER_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT32_PER_OFFSET               (0x18)                                        /**<  (TC_COUNT32_PER) COUNT32 Period  Offset */
+#define TC_COUNT32_PER_RESETVALUE           _U_(0xFFFFFFFF)                               /**<  (TC_COUNT32_PER) COUNT32 Period  Reset Value */
+
+#define TC_COUNT32_PER_PER_Pos              0                                              /**< (TC_COUNT32_PER) Period Value Position */
+#define TC_COUNT32_PER_PER_Msk              (_U_(0xFFFFFFFF) << TC_COUNT32_PER_PER_Pos)    /**< (TC_COUNT32_PER) Period Value Mask */
+#define TC_COUNT32_PER_PER(value)           (TC_COUNT32_PER_PER_Msk & ((value) << TC_COUNT32_PER_PER_Pos))
+#define TC_COUNT32_PER_MASK                 _U_(0xFFFFFFFF)                                /**< \deprecated (TC_COUNT32_PER) Register MASK  (Use TC_COUNT32_PER_Msk instead)  */
+#define TC_COUNT32_PER_Msk                  _U_(0xFFFFFFFF)                                /**< (TC_COUNT32_PER) Register Mask  */
+
+
+/* -------- TC_COUNT16_PER : (TC Offset: 0x1a) (R/W 16) COUNT16 Period -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t PER:16;                    /**< bit:  0..15  Period Value                             */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} TC_COUNT16_PER_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT16_PER_OFFSET               (0x1A)                                        /**<  (TC_COUNT16_PER) COUNT16 Period  Offset */
+#define TC_COUNT16_PER_RESETVALUE           _U_(0xFFFF)                                   /**<  (TC_COUNT16_PER) COUNT16 Period  Reset Value */
+
+#define TC_COUNT16_PER_PER_Pos              0                                              /**< (TC_COUNT16_PER) Period Value Position */
+#define TC_COUNT16_PER_PER_Msk              (_U_(0xFFFF) << TC_COUNT16_PER_PER_Pos)        /**< (TC_COUNT16_PER) Period Value Mask */
+#define TC_COUNT16_PER_PER(value)           (TC_COUNT16_PER_PER_Msk & ((value) << TC_COUNT16_PER_PER_Pos))
+#define TC_COUNT16_PER_MASK                 _U_(0xFFFF)                                    /**< \deprecated (TC_COUNT16_PER) Register MASK  (Use TC_COUNT16_PER_Msk instead)  */
+#define TC_COUNT16_PER_Msk                  _U_(0xFFFF)                                    /**< (TC_COUNT16_PER) Register Mask  */
+
+
+/* -------- TC_COUNT8_PER : (TC Offset: 0x1b) (R/W 8) COUNT8 Period -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  PER:8;                     /**< bit:   0..7  Period Value                             */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} TC_COUNT8_PER_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT8_PER_OFFSET                (0x1B)                                        /**<  (TC_COUNT8_PER) COUNT8 Period  Offset */
+#define TC_COUNT8_PER_RESETVALUE            _U_(0xFF)                                     /**<  (TC_COUNT8_PER) COUNT8 Period  Reset Value */
+
+#define TC_COUNT8_PER_PER_Pos               0                                              /**< (TC_COUNT8_PER) Period Value Position */
+#define TC_COUNT8_PER_PER_Msk               (_U_(0xFF) << TC_COUNT8_PER_PER_Pos)           /**< (TC_COUNT8_PER) Period Value Mask */
+#define TC_COUNT8_PER_PER(value)            (TC_COUNT8_PER_PER_Msk & ((value) << TC_COUNT8_PER_PER_Pos))
+#define TC_COUNT8_PER_MASK                  _U_(0xFF)                                      /**< \deprecated (TC_COUNT8_PER) Register MASK  (Use TC_COUNT8_PER_Msk instead)  */
+#define TC_COUNT8_PER_Msk                   _U_(0xFF)                                      /**< (TC_COUNT8_PER) Register Mask  */
+
+
+/* -------- TC_COUNT8_CC : (TC Offset: 0x1c) (R/W 8) COUNT8 Compare and Capture -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  CC:8;                      /**< bit:   0..7  Counter/Compare Value                    */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} TC_COUNT8_CC_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT8_CC_OFFSET                 (0x1C)                                        /**<  (TC_COUNT8_CC) COUNT8 Compare and Capture  Offset */
+#define TC_COUNT8_CC_RESETVALUE             _U_(0x00)                                     /**<  (TC_COUNT8_CC) COUNT8 Compare and Capture  Reset Value */
+
+#define TC_COUNT8_CC_CC_Pos                 0                                              /**< (TC_COUNT8_CC) Counter/Compare Value Position */
+#define TC_COUNT8_CC_CC_Msk                 (_U_(0xFF) << TC_COUNT8_CC_CC_Pos)             /**< (TC_COUNT8_CC) Counter/Compare Value Mask */
+#define TC_COUNT8_CC_CC(value)              (TC_COUNT8_CC_CC_Msk & ((value) << TC_COUNT8_CC_CC_Pos))
+#define TC_COUNT8_CC_MASK                   _U_(0xFF)                                      /**< \deprecated (TC_COUNT8_CC) Register MASK  (Use TC_COUNT8_CC_Msk instead)  */
+#define TC_COUNT8_CC_Msk                    _U_(0xFF)                                      /**< (TC_COUNT8_CC) Register Mask  */
+
+
+/* -------- TC_COUNT16_CC : (TC Offset: 0x1c) (R/W 16) COUNT16 Compare and Capture -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t CC:16;                     /**< bit:  0..15  Counter/Compare Value                    */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} TC_COUNT16_CC_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT16_CC_OFFSET                (0x1C)                                        /**<  (TC_COUNT16_CC) COUNT16 Compare and Capture  Offset */
+#define TC_COUNT16_CC_RESETVALUE            _U_(0x00)                                     /**<  (TC_COUNT16_CC) COUNT16 Compare and Capture  Reset Value */
+
+#define TC_COUNT16_CC_CC_Pos                0                                              /**< (TC_COUNT16_CC) Counter/Compare Value Position */
+#define TC_COUNT16_CC_CC_Msk                (_U_(0xFFFF) << TC_COUNT16_CC_CC_Pos)          /**< (TC_COUNT16_CC) Counter/Compare Value Mask */
+#define TC_COUNT16_CC_CC(value)             (TC_COUNT16_CC_CC_Msk & ((value) << TC_COUNT16_CC_CC_Pos))
+#define TC_COUNT16_CC_MASK                  _U_(0xFFFF)                                    /**< \deprecated (TC_COUNT16_CC) Register MASK  (Use TC_COUNT16_CC_Msk instead)  */
+#define TC_COUNT16_CC_Msk                   _U_(0xFFFF)                                    /**< (TC_COUNT16_CC) Register Mask  */
+
+
+/* -------- TC_COUNT32_CC : (TC Offset: 0x1c) (R/W 32) COUNT32 Compare and Capture -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t CC:32;                     /**< bit:  0..31  Counter/Compare Value                    */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_COUNT32_CC_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT32_CC_OFFSET                (0x1C)                                        /**<  (TC_COUNT32_CC) COUNT32 Compare and Capture  Offset */
+#define TC_COUNT32_CC_RESETVALUE            _U_(0x00)                                     /**<  (TC_COUNT32_CC) COUNT32 Compare and Capture  Reset Value */
+
+#define TC_COUNT32_CC_CC_Pos                0                                              /**< (TC_COUNT32_CC) Counter/Compare Value Position */
+#define TC_COUNT32_CC_CC_Msk                (_U_(0xFFFFFFFF) << TC_COUNT32_CC_CC_Pos)      /**< (TC_COUNT32_CC) Counter/Compare Value Mask */
+#define TC_COUNT32_CC_CC(value)             (TC_COUNT32_CC_CC_Msk & ((value) << TC_COUNT32_CC_CC_Pos))
+#define TC_COUNT32_CC_MASK                  _U_(0xFFFFFFFF)                                /**< \deprecated (TC_COUNT32_CC) Register MASK  (Use TC_COUNT32_CC_Msk instead)  */
+#define TC_COUNT32_CC_Msk                   _U_(0xFFFFFFFF)                                /**< (TC_COUNT32_CC) Register Mask  */
+
+
+/* -------- TC_COUNT32_PERBUF : (TC Offset: 0x2c) (R/W 32) COUNT32 Period Buffer -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t PERBUF:32;                 /**< bit:  0..31  Period Buffer Value                      */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_COUNT32_PERBUF_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT32_PERBUF_OFFSET            (0x2C)                                        /**<  (TC_COUNT32_PERBUF) COUNT32 Period Buffer  Offset */
+#define TC_COUNT32_PERBUF_RESETVALUE        _U_(0xFFFFFFFF)                               /**<  (TC_COUNT32_PERBUF) COUNT32 Period Buffer  Reset Value */
+
+#define TC_COUNT32_PERBUF_PERBUF_Pos        0                                              /**< (TC_COUNT32_PERBUF) Period Buffer Value Position */
+#define TC_COUNT32_PERBUF_PERBUF_Msk        (_U_(0xFFFFFFFF) << TC_COUNT32_PERBUF_PERBUF_Pos)  /**< (TC_COUNT32_PERBUF) Period Buffer Value Mask */
+#define TC_COUNT32_PERBUF_PERBUF(value)     (TC_COUNT32_PERBUF_PERBUF_Msk & ((value) << TC_COUNT32_PERBUF_PERBUF_Pos))
+#define TC_COUNT32_PERBUF_MASK              _U_(0xFFFFFFFF)                                /**< \deprecated (TC_COUNT32_PERBUF) Register MASK  (Use TC_COUNT32_PERBUF_Msk instead)  */
+#define TC_COUNT32_PERBUF_Msk               _U_(0xFFFFFFFF)                                /**< (TC_COUNT32_PERBUF) Register Mask  */
+
+
+/* -------- TC_COUNT16_PERBUF : (TC Offset: 0x2e) (R/W 16) COUNT16 Period Buffer -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t PERBUF:16;                 /**< bit:  0..15  Period Buffer Value                      */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} TC_COUNT16_PERBUF_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT16_PERBUF_OFFSET            (0x2E)                                        /**<  (TC_COUNT16_PERBUF) COUNT16 Period Buffer  Offset */
+#define TC_COUNT16_PERBUF_RESETVALUE        _U_(0xFFFF)                                   /**<  (TC_COUNT16_PERBUF) COUNT16 Period Buffer  Reset Value */
+
+#define TC_COUNT16_PERBUF_PERBUF_Pos        0                                              /**< (TC_COUNT16_PERBUF) Period Buffer Value Position */
+#define TC_COUNT16_PERBUF_PERBUF_Msk        (_U_(0xFFFF) << TC_COUNT16_PERBUF_PERBUF_Pos)  /**< (TC_COUNT16_PERBUF) Period Buffer Value Mask */
+#define TC_COUNT16_PERBUF_PERBUF(value)     (TC_COUNT16_PERBUF_PERBUF_Msk & ((value) << TC_COUNT16_PERBUF_PERBUF_Pos))
+#define TC_COUNT16_PERBUF_MASK              _U_(0xFFFF)                                    /**< \deprecated (TC_COUNT16_PERBUF) Register MASK  (Use TC_COUNT16_PERBUF_Msk instead)  */
+#define TC_COUNT16_PERBUF_Msk               _U_(0xFFFF)                                    /**< (TC_COUNT16_PERBUF) Register Mask  */
+
+
+/* -------- TC_COUNT8_PERBUF : (TC Offset: 0x2f) (R/W 8) COUNT8 Period Buffer -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  PERBUF:8;                  /**< bit:   0..7  Period Buffer Value                      */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} TC_COUNT8_PERBUF_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT8_PERBUF_OFFSET             (0x2F)                                        /**<  (TC_COUNT8_PERBUF) COUNT8 Period Buffer  Offset */
+#define TC_COUNT8_PERBUF_RESETVALUE         _U_(0xFF)                                     /**<  (TC_COUNT8_PERBUF) COUNT8 Period Buffer  Reset Value */
+
+#define TC_COUNT8_PERBUF_PERBUF_Pos         0                                              /**< (TC_COUNT8_PERBUF) Period Buffer Value Position */
+#define TC_COUNT8_PERBUF_PERBUF_Msk         (_U_(0xFF) << TC_COUNT8_PERBUF_PERBUF_Pos)     /**< (TC_COUNT8_PERBUF) Period Buffer Value Mask */
+#define TC_COUNT8_PERBUF_PERBUF(value)      (TC_COUNT8_PERBUF_PERBUF_Msk & ((value) << TC_COUNT8_PERBUF_PERBUF_Pos))
+#define TC_COUNT8_PERBUF_MASK               _U_(0xFF)                                      /**< \deprecated (TC_COUNT8_PERBUF) Register MASK  (Use TC_COUNT8_PERBUF_Msk instead)  */
+#define TC_COUNT8_PERBUF_Msk                _U_(0xFF)                                      /**< (TC_COUNT8_PERBUF) Register Mask  */
+
+
+/* -------- TC_COUNT8_CCBUF : (TC Offset: 0x30) (R/W 8) COUNT8 Compare and Capture Buffer -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  CCBUF:8;                   /**< bit:   0..7  Counter/Compare Buffer Value             */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} TC_COUNT8_CCBUF_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT8_CCBUF_OFFSET              (0x30)                                        /**<  (TC_COUNT8_CCBUF) COUNT8 Compare and Capture Buffer  Offset */
+#define TC_COUNT8_CCBUF_RESETVALUE          _U_(0x00)                                     /**<  (TC_COUNT8_CCBUF) COUNT8 Compare and Capture Buffer  Reset Value */
+
+#define TC_COUNT8_CCBUF_CCBUF_Pos           0                                              /**< (TC_COUNT8_CCBUF) Counter/Compare Buffer Value Position */
+#define TC_COUNT8_CCBUF_CCBUF_Msk           (_U_(0xFF) << TC_COUNT8_CCBUF_CCBUF_Pos)       /**< (TC_COUNT8_CCBUF) Counter/Compare Buffer Value Mask */
+#define TC_COUNT8_CCBUF_CCBUF(value)        (TC_COUNT8_CCBUF_CCBUF_Msk & ((value) << TC_COUNT8_CCBUF_CCBUF_Pos))
+#define TC_COUNT8_CCBUF_MASK                _U_(0xFF)                                      /**< \deprecated (TC_COUNT8_CCBUF) Register MASK  (Use TC_COUNT8_CCBUF_Msk instead)  */
+#define TC_COUNT8_CCBUF_Msk                 _U_(0xFF)                                      /**< (TC_COUNT8_CCBUF) Register Mask  */
+
+
+/* -------- TC_COUNT16_CCBUF : (TC Offset: 0x30) (R/W 16) COUNT16 Compare and Capture Buffer -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint16_t CCBUF:16;                  /**< bit:  0..15  Counter/Compare Buffer Value             */
+  } bit;                                /**< Structure used for bit  access */
+  uint16_t reg;                         /**< Type used for register access */
+} TC_COUNT16_CCBUF_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT16_CCBUF_OFFSET             (0x30)                                        /**<  (TC_COUNT16_CCBUF) COUNT16 Compare and Capture Buffer  Offset */
+#define TC_COUNT16_CCBUF_RESETVALUE         _U_(0x00)                                     /**<  (TC_COUNT16_CCBUF) COUNT16 Compare and Capture Buffer  Reset Value */
+
+#define TC_COUNT16_CCBUF_CCBUF_Pos          0                                              /**< (TC_COUNT16_CCBUF) Counter/Compare Buffer Value Position */
+#define TC_COUNT16_CCBUF_CCBUF_Msk          (_U_(0xFFFF) << TC_COUNT16_CCBUF_CCBUF_Pos)    /**< (TC_COUNT16_CCBUF) Counter/Compare Buffer Value Mask */
+#define TC_COUNT16_CCBUF_CCBUF(value)       (TC_COUNT16_CCBUF_CCBUF_Msk & ((value) << TC_COUNT16_CCBUF_CCBUF_Pos))
+#define TC_COUNT16_CCBUF_MASK               _U_(0xFFFF)                                    /**< \deprecated (TC_COUNT16_CCBUF) Register MASK  (Use TC_COUNT16_CCBUF_Msk instead)  */
+#define TC_COUNT16_CCBUF_Msk                _U_(0xFFFF)                                    /**< (TC_COUNT16_CCBUF) Register Mask  */
+
+
+/* -------- TC_COUNT32_CCBUF : (TC Offset: 0x30) (R/W 32) COUNT32 Compare and Capture Buffer -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t CCBUF:32;                  /**< bit:  0..31  Counter/Compare Buffer Value             */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_COUNT32_CCBUF_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT32_CCBUF_OFFSET             (0x30)                                        /**<  (TC_COUNT32_CCBUF) COUNT32 Compare and Capture Buffer  Offset */
+#define TC_COUNT32_CCBUF_RESETVALUE         _U_(0x00)                                     /**<  (TC_COUNT32_CCBUF) COUNT32 Compare and Capture Buffer  Reset Value */
+
+#define TC_COUNT32_CCBUF_CCBUF_Pos          0                                              /**< (TC_COUNT32_CCBUF) Counter/Compare Buffer Value Position */
+#define TC_COUNT32_CCBUF_CCBUF_Msk          (_U_(0xFFFFFFFF) << TC_COUNT32_CCBUF_CCBUF_Pos)  /**< (TC_COUNT32_CCBUF) Counter/Compare Buffer Value Mask */
+#define TC_COUNT32_CCBUF_CCBUF(value)       (TC_COUNT32_CCBUF_CCBUF_Msk & ((value) << TC_COUNT32_CCBUF_CCBUF_Pos))
+#define TC_COUNT32_CCBUF_MASK               _U_(0xFFFFFFFF)                                /**< \deprecated (TC_COUNT32_CCBUF) Register MASK  (Use TC_COUNT32_CCBUF_Msk instead)  */
+#define TC_COUNT32_CCBUF_Msk                _U_(0xFFFFFFFF)                                /**< (TC_COUNT32_CCBUF) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief TC hardware registers */
+typedef struct {  /* Basic Timer Counter */
+  __IO TC_CTRLA_Type                  CTRLA;          /**< Offset: 0x00 (R/W  32) Control A */
+  __IO TC_CTRLBCLR_Type               CTRLBCLR;       /**< Offset: 0x04 (R/W   8) Control B Clear */
+  __IO TC_CTRLBSET_Type               CTRLBSET;       /**< Offset: 0x05 (R/W   8) Control B Set */
+  __IO TC_EVCTRL_Type                 EVCTRL;         /**< Offset: 0x06 (R/W  16) Event Control */
+  __IO TC_INTENCLR_Type               INTENCLR;       /**< Offset: 0x08 (R/W   8) Interrupt Enable Clear */
+  __IO TC_INTENSET_Type               INTENSET;       /**< Offset: 0x09 (R/W   8) Interrupt Enable Set */
+  __IO TC_INTFLAG_Type                INTFLAG;        /**< Offset: 0x0A (R/W   8) Interrupt Flag Status and Clear */
+  __IO TC_STATUS_Type                 STATUS;         /**< Offset: 0x0B (R/W   8) Status */
+  __IO TC_WAVE_Type                   WAVE;           /**< Offset: 0x0C (R/W   8) Waveform Generation Control */
+  __IO TC_DRVCTRL_Type                DRVCTRL;        /**< Offset: 0x0D (R/W   8) Control C */
+  __I  uint8_t                        Reserved1[1];
+  __IO TC_DBGCTRL_Type                DBGCTRL;        /**< Offset: 0x0F (R/W   8) Debug Control */
+  __I  TC_SYNCBUSY_Type               SYNCBUSY;       /**< Offset: 0x10 (R/   32) Synchronization Status */
+  __IO TC_COUNT8_COUNT_Type           COUNT;          /**< Offset: 0x14 (R/W   8) COUNT8 Count */
+  __I  uint8_t                        Reserved2[6];
+  __IO TC_COUNT8_PER_Type             PER;            /**< Offset: 0x1B (R/W   8) COUNT8 Period */
+  __IO TC_COUNT8_CC_Type              CC[2];          /**< Offset: 0x1C (R/W   8) COUNT8 Compare and Capture */
+  __I  uint8_t                        Reserved3[17];
+  __IO TC_COUNT8_PERBUF_Type          PERBUF;         /**< Offset: 0x2F (R/W   8) COUNT8 Period Buffer */
+  __IO TC_COUNT8_CCBUF_Type           CCBUF[2];       /**< Offset: 0x30 (R/W   8) COUNT8 Compare and Capture Buffer */
+} TcCount8;
+
+/** \brief TC hardware registers */
+typedef struct {  /* Basic Timer Counter */
+  __IO TC_CTRLA_Type                  CTRLA;          /**< Offset: 0x00 (R/W  32) Control A */
+  __IO TC_CTRLBCLR_Type               CTRLBCLR;       /**< Offset: 0x04 (R/W   8) Control B Clear */
+  __IO TC_CTRLBSET_Type               CTRLBSET;       /**< Offset: 0x05 (R/W   8) Control B Set */
+  __IO TC_EVCTRL_Type                 EVCTRL;         /**< Offset: 0x06 (R/W  16) Event Control */
+  __IO TC_INTENCLR_Type               INTENCLR;       /**< Offset: 0x08 (R/W   8) Interrupt Enable Clear */
+  __IO TC_INTENSET_Type               INTENSET;       /**< Offset: 0x09 (R/W   8) Interrupt Enable Set */
+  __IO TC_INTFLAG_Type                INTFLAG;        /**< Offset: 0x0A (R/W   8) Interrupt Flag Status and Clear */
+  __IO TC_STATUS_Type                 STATUS;         /**< Offset: 0x0B (R/W   8) Status */
+  __IO TC_WAVE_Type                   WAVE;           /**< Offset: 0x0C (R/W   8) Waveform Generation Control */
+  __IO TC_DRVCTRL_Type                DRVCTRL;        /**< Offset: 0x0D (R/W   8) Control C */
+  __I  uint8_t                        Reserved1[1];
+  __IO TC_DBGCTRL_Type                DBGCTRL;        /**< Offset: 0x0F (R/W   8) Debug Control */
+  __I  TC_SYNCBUSY_Type               SYNCBUSY;       /**< Offset: 0x10 (R/   32) Synchronization Status */
+  __IO TC_COUNT16_COUNT_Type          COUNT;          /**< Offset: 0x14 (R/W  16) COUNT16 Count */
+  __I  uint8_t                        Reserved2[4];
+  __IO TC_COUNT16_PER_Type            PER;            /**< Offset: 0x1A (R/W  16) COUNT16 Period */
+  __IO TC_COUNT16_CC_Type             CC[2];          /**< Offset: 0x1C (R/W  16) COUNT16 Compare and Capture */
+  __I  uint8_t                        Reserved3[14];
+  __IO TC_COUNT16_PERBUF_Type         PERBUF;         /**< Offset: 0x2E (R/W  16) COUNT16 Period Buffer */
+  __IO TC_COUNT16_CCBUF_Type          CCBUF[2];       /**< Offset: 0x30 (R/W  16) COUNT16 Compare and Capture Buffer */
+} TcCount16;
+
+/** \brief TC hardware registers */
+typedef struct {  /* Basic Timer Counter */
+  __IO TC_CTRLA_Type                  CTRLA;          /**< Offset: 0x00 (R/W  32) Control A */
+  __IO TC_CTRLBCLR_Type               CTRLBCLR;       /**< Offset: 0x04 (R/W   8) Control B Clear */
+  __IO TC_CTRLBSET_Type               CTRLBSET;       /**< Offset: 0x05 (R/W   8) Control B Set */
+  __IO TC_EVCTRL_Type                 EVCTRL;         /**< Offset: 0x06 (R/W  16) Event Control */
+  __IO TC_INTENCLR_Type               INTENCLR;       /**< Offset: 0x08 (R/W   8) Interrupt Enable Clear */
+  __IO TC_INTENSET_Type               INTENSET;       /**< Offset: 0x09 (R/W   8) Interrupt Enable Set */
+  __IO TC_INTFLAG_Type                INTFLAG;        /**< Offset: 0x0A (R/W   8) Interrupt Flag Status and Clear */
+  __IO TC_STATUS_Type                 STATUS;         /**< Offset: 0x0B (R/W   8) Status */
+  __IO TC_WAVE_Type                   WAVE;           /**< Offset: 0x0C (R/W   8) Waveform Generation Control */
+  __IO TC_DRVCTRL_Type                DRVCTRL;        /**< Offset: 0x0D (R/W   8) Control C */
+  __I  uint8_t                        Reserved1[1];
+  __IO TC_DBGCTRL_Type                DBGCTRL;        /**< Offset: 0x0F (R/W   8) Debug Control */
+  __I  TC_SYNCBUSY_Type               SYNCBUSY;       /**< Offset: 0x10 (R/   32) Synchronization Status */
+  __IO TC_COUNT32_COUNT_Type          COUNT;          /**< Offset: 0x14 (R/W  32) COUNT32 Count */
+  __IO TC_COUNT32_PER_Type            PER;            /**< Offset: 0x18 (R/W  32) COUNT32 Period */
+  __IO TC_COUNT32_CC_Type             CC[2];          /**< Offset: 0x1C (R/W  32) COUNT32 Compare and Capture */
+  __I  uint8_t                        Reserved2[8];
+  __IO TC_COUNT32_PERBUF_Type         PERBUF;         /**< Offset: 0x2C (R/W  32) COUNT32 Period Buffer */
+  __IO TC_COUNT32_CCBUF_Type          CCBUF[2];       /**< Offset: 0x30 (R/W  32) COUNT32 Compare and Capture Buffer */
+} TcCount32;
+
+/** \brief TC hardware registers */
+typedef union {  /* Basic Timer Counter */
+       TcCount8                       COUNT8;         /**< 8-bit Counter Mode */
+       TcCount16                      COUNT16;        /**< 16-bit Counter Mode */
+       TcCount32                      COUNT32;        /**< 32-bit Counter Mode */
+} Tc;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Basic Timer Counter */
+
+#endif /* _SAML11_TC_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/component/tram.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/tram.h
@@ -1,0 +1,316 @@
+/**
+ * \file
+ *
+ * \brief Component description for TRAM
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_TRAM_COMPONENT_H_
+#define _SAML11_TRAM_COMPONENT_H_
+#define _SAML11_TRAM_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML11 TrustRAM
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR TRAM */
+/* ========================================================================== */
+
+#define TRAM_U2801                      /**< (TRAM) Module ID */
+#define REV_TRAM 0x100                  /**< (TRAM) Module revision */
+
+/* -------- TRAM_CTRLA : (TRAM Offset: 0x00) (R/W 8) Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint8_t  ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint8_t  :2;                        /**< bit:   2..3  Reserved */
+    uint8_t  TAMPERS:1;                 /**< bit:      4  Tamper Erase                             */
+    uint8_t  :1;                        /**< bit:      5  Reserved */
+    uint8_t  DRP:1;                     /**< bit:      6  Data Remanence Prevention                */
+    uint8_t  SILACC:1;                  /**< bit:      7  Silent Access                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} TRAM_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRAM_CTRLA_OFFSET                   (0x00)                                        /**<  (TRAM_CTRLA) Control  Offset */
+#define TRAM_CTRLA_RESETVALUE               _U_(0x00)                                     /**<  (TRAM_CTRLA) Control  Reset Value */
+
+#define TRAM_CTRLA_SWRST_Pos                0                                              /**< (TRAM_CTRLA) Software Reset Position */
+#define TRAM_CTRLA_SWRST_Msk                (_U_(0x1) << TRAM_CTRLA_SWRST_Pos)             /**< (TRAM_CTRLA) Software Reset Mask */
+#define TRAM_CTRLA_SWRST                    TRAM_CTRLA_SWRST_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRAM_CTRLA_SWRST_Msk instead */
+#define TRAM_CTRLA_ENABLE_Pos               1                                              /**< (TRAM_CTRLA) Enable Position */
+#define TRAM_CTRLA_ENABLE_Msk               (_U_(0x1) << TRAM_CTRLA_ENABLE_Pos)            /**< (TRAM_CTRLA) Enable Mask */
+#define TRAM_CTRLA_ENABLE                   TRAM_CTRLA_ENABLE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRAM_CTRLA_ENABLE_Msk instead */
+#define TRAM_CTRLA_TAMPERS_Pos              4                                              /**< (TRAM_CTRLA) Tamper Erase Position */
+#define TRAM_CTRLA_TAMPERS_Msk              (_U_(0x1) << TRAM_CTRLA_TAMPERS_Pos)           /**< (TRAM_CTRLA) Tamper Erase Mask */
+#define TRAM_CTRLA_TAMPERS                  TRAM_CTRLA_TAMPERS_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRAM_CTRLA_TAMPERS_Msk instead */
+#define TRAM_CTRLA_DRP_Pos                  6                                              /**< (TRAM_CTRLA) Data Remanence Prevention Position */
+#define TRAM_CTRLA_DRP_Msk                  (_U_(0x1) << TRAM_CTRLA_DRP_Pos)               /**< (TRAM_CTRLA) Data Remanence Prevention Mask */
+#define TRAM_CTRLA_DRP                      TRAM_CTRLA_DRP_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRAM_CTRLA_DRP_Msk instead */
+#define TRAM_CTRLA_SILACC_Pos               7                                              /**< (TRAM_CTRLA) Silent Access Position */
+#define TRAM_CTRLA_SILACC_Msk               (_U_(0x1) << TRAM_CTRLA_SILACC_Pos)            /**< (TRAM_CTRLA) Silent Access Mask */
+#define TRAM_CTRLA_SILACC                   TRAM_CTRLA_SILACC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRAM_CTRLA_SILACC_Msk instead */
+#define TRAM_CTRLA_MASK                     _U_(0xD3)                                      /**< \deprecated (TRAM_CTRLA) Register MASK  (Use TRAM_CTRLA_Msk instead)  */
+#define TRAM_CTRLA_Msk                      _U_(0xD3)                                      /**< (TRAM_CTRLA) Register Mask  */
+
+
+/* -------- TRAM_INTENCLR : (TRAM Offset: 0x04) (R/W 8) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  ERR:1;                     /**< bit:      0  TrustRAM Readout Error Interrupt Enable  */
+    uint8_t  DRP:1;                     /**< bit:      1  Data Remanence Prevention Ended Interrupt Enable */
+    uint8_t  :6;                        /**< bit:   2..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} TRAM_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRAM_INTENCLR_OFFSET                (0x04)                                        /**<  (TRAM_INTENCLR) Interrupt Enable Clear  Offset */
+#define TRAM_INTENCLR_RESETVALUE            _U_(0x00)                                     /**<  (TRAM_INTENCLR) Interrupt Enable Clear  Reset Value */
+
+#define TRAM_INTENCLR_ERR_Pos               0                                              /**< (TRAM_INTENCLR) TrustRAM Readout Error Interrupt Enable Position */
+#define TRAM_INTENCLR_ERR_Msk               (_U_(0x1) << TRAM_INTENCLR_ERR_Pos)            /**< (TRAM_INTENCLR) TrustRAM Readout Error Interrupt Enable Mask */
+#define TRAM_INTENCLR_ERR                   TRAM_INTENCLR_ERR_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRAM_INTENCLR_ERR_Msk instead */
+#define TRAM_INTENCLR_DRP_Pos               1                                              /**< (TRAM_INTENCLR) Data Remanence Prevention Ended Interrupt Enable Position */
+#define TRAM_INTENCLR_DRP_Msk               (_U_(0x1) << TRAM_INTENCLR_DRP_Pos)            /**< (TRAM_INTENCLR) Data Remanence Prevention Ended Interrupt Enable Mask */
+#define TRAM_INTENCLR_DRP                   TRAM_INTENCLR_DRP_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRAM_INTENCLR_DRP_Msk instead */
+#define TRAM_INTENCLR_MASK                  _U_(0x03)                                      /**< \deprecated (TRAM_INTENCLR) Register MASK  (Use TRAM_INTENCLR_Msk instead)  */
+#define TRAM_INTENCLR_Msk                   _U_(0x03)                                      /**< (TRAM_INTENCLR) Register Mask  */
+
+
+/* -------- TRAM_INTENSET : (TRAM Offset: 0x05) (R/W 8) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  ERR:1;                     /**< bit:      0  TrustRAM Readout Error Interrupt Enable  */
+    uint8_t  DRP:1;                     /**< bit:      1  Data Remanence Prevention Ended Interrupt Enable */
+    uint8_t  :6;                        /**< bit:   2..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} TRAM_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRAM_INTENSET_OFFSET                (0x05)                                        /**<  (TRAM_INTENSET) Interrupt Enable Set  Offset */
+#define TRAM_INTENSET_RESETVALUE            _U_(0x00)                                     /**<  (TRAM_INTENSET) Interrupt Enable Set  Reset Value */
+
+#define TRAM_INTENSET_ERR_Pos               0                                              /**< (TRAM_INTENSET) TrustRAM Readout Error Interrupt Enable Position */
+#define TRAM_INTENSET_ERR_Msk               (_U_(0x1) << TRAM_INTENSET_ERR_Pos)            /**< (TRAM_INTENSET) TrustRAM Readout Error Interrupt Enable Mask */
+#define TRAM_INTENSET_ERR                   TRAM_INTENSET_ERR_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRAM_INTENSET_ERR_Msk instead */
+#define TRAM_INTENSET_DRP_Pos               1                                              /**< (TRAM_INTENSET) Data Remanence Prevention Ended Interrupt Enable Position */
+#define TRAM_INTENSET_DRP_Msk               (_U_(0x1) << TRAM_INTENSET_DRP_Pos)            /**< (TRAM_INTENSET) Data Remanence Prevention Ended Interrupt Enable Mask */
+#define TRAM_INTENSET_DRP                   TRAM_INTENSET_DRP_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRAM_INTENSET_DRP_Msk instead */
+#define TRAM_INTENSET_MASK                  _U_(0x03)                                      /**< \deprecated (TRAM_INTENSET) Register MASK  (Use TRAM_INTENSET_Msk instead)  */
+#define TRAM_INTENSET_Msk                   _U_(0x03)                                      /**< (TRAM_INTENSET) Register Mask  */
+
+
+/* -------- TRAM_INTFLAG : (TRAM Offset: 0x06) (R/W 8) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t ERR:1;                     /**< bit:      0  TrustRAM Readout Error                   */
+    __I uint8_t DRP:1;                     /**< bit:      1  Data Remanence Prevention Ended          */
+    __I uint8_t :6;                        /**< bit:   2..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} TRAM_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRAM_INTFLAG_OFFSET                 (0x06)                                        /**<  (TRAM_INTFLAG) Interrupt Flag Status and Clear  Offset */
+#define TRAM_INTFLAG_RESETVALUE             _U_(0x00)                                     /**<  (TRAM_INTFLAG) Interrupt Flag Status and Clear  Reset Value */
+
+#define TRAM_INTFLAG_ERR_Pos                0                                              /**< (TRAM_INTFLAG) TrustRAM Readout Error Position */
+#define TRAM_INTFLAG_ERR_Msk                (_U_(0x1) << TRAM_INTFLAG_ERR_Pos)             /**< (TRAM_INTFLAG) TrustRAM Readout Error Mask */
+#define TRAM_INTFLAG_ERR                    TRAM_INTFLAG_ERR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRAM_INTFLAG_ERR_Msk instead */
+#define TRAM_INTFLAG_DRP_Pos                1                                              /**< (TRAM_INTFLAG) Data Remanence Prevention Ended Position */
+#define TRAM_INTFLAG_DRP_Msk                (_U_(0x1) << TRAM_INTFLAG_DRP_Pos)             /**< (TRAM_INTFLAG) Data Remanence Prevention Ended Mask */
+#define TRAM_INTFLAG_DRP                    TRAM_INTFLAG_DRP_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRAM_INTFLAG_DRP_Msk instead */
+#define TRAM_INTFLAG_MASK                   _U_(0x03)                                      /**< \deprecated (TRAM_INTFLAG) Register MASK  (Use TRAM_INTFLAG_Msk instead)  */
+#define TRAM_INTFLAG_Msk                    _U_(0x03)                                      /**< (TRAM_INTFLAG) Register Mask  */
+
+
+/* -------- TRAM_STATUS : (TRAM Offset: 0x07) (R/ 8) Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  RAMINV:1;                  /**< bit:      0  RAM Inversion Bit                        */
+    uint8_t  DRP:1;                     /**< bit:      1  Data Remanence Prevention Ongoing        */
+    uint8_t  :6;                        /**< bit:   2..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} TRAM_STATUS_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRAM_STATUS_OFFSET                  (0x07)                                        /**<  (TRAM_STATUS) Status  Offset */
+#define TRAM_STATUS_RESETVALUE              _U_(0x00)                                     /**<  (TRAM_STATUS) Status  Reset Value */
+
+#define TRAM_STATUS_RAMINV_Pos              0                                              /**< (TRAM_STATUS) RAM Inversion Bit Position */
+#define TRAM_STATUS_RAMINV_Msk              (_U_(0x1) << TRAM_STATUS_RAMINV_Pos)           /**< (TRAM_STATUS) RAM Inversion Bit Mask */
+#define TRAM_STATUS_RAMINV                  TRAM_STATUS_RAMINV_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRAM_STATUS_RAMINV_Msk instead */
+#define TRAM_STATUS_DRP_Pos                 1                                              /**< (TRAM_STATUS) Data Remanence Prevention Ongoing Position */
+#define TRAM_STATUS_DRP_Msk                 (_U_(0x1) << TRAM_STATUS_DRP_Pos)              /**< (TRAM_STATUS) Data Remanence Prevention Ongoing Mask */
+#define TRAM_STATUS_DRP                     TRAM_STATUS_DRP_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRAM_STATUS_DRP_Msk instead */
+#define TRAM_STATUS_MASK                    _U_(0x03)                                      /**< \deprecated (TRAM_STATUS) Register MASK  (Use TRAM_STATUS_Msk instead)  */
+#define TRAM_STATUS_Msk                     _U_(0x03)                                      /**< (TRAM_STATUS) Register Mask  */
+
+
+/* -------- TRAM_SYNCBUSY : (TRAM Offset: 0x08) (R/ 32) Synchronization Busy Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t SWRST:1;                   /**< bit:      0  Software Reset Busy                      */
+    uint32_t ENABLE:1;                  /**< bit:      1  Enable Busy                              */
+    uint32_t :30;                       /**< bit:  2..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TRAM_SYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRAM_SYNCBUSY_OFFSET                (0x08)                                        /**<  (TRAM_SYNCBUSY) Synchronization Busy Status  Offset */
+#define TRAM_SYNCBUSY_RESETVALUE            _U_(0x00)                                     /**<  (TRAM_SYNCBUSY) Synchronization Busy Status  Reset Value */
+
+#define TRAM_SYNCBUSY_SWRST_Pos             0                                              /**< (TRAM_SYNCBUSY) Software Reset Busy Position */
+#define TRAM_SYNCBUSY_SWRST_Msk             (_U_(0x1) << TRAM_SYNCBUSY_SWRST_Pos)          /**< (TRAM_SYNCBUSY) Software Reset Busy Mask */
+#define TRAM_SYNCBUSY_SWRST                 TRAM_SYNCBUSY_SWRST_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRAM_SYNCBUSY_SWRST_Msk instead */
+#define TRAM_SYNCBUSY_ENABLE_Pos            1                                              /**< (TRAM_SYNCBUSY) Enable Busy Position */
+#define TRAM_SYNCBUSY_ENABLE_Msk            (_U_(0x1) << TRAM_SYNCBUSY_ENABLE_Pos)         /**< (TRAM_SYNCBUSY) Enable Busy Mask */
+#define TRAM_SYNCBUSY_ENABLE                TRAM_SYNCBUSY_ENABLE_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRAM_SYNCBUSY_ENABLE_Msk instead */
+#define TRAM_SYNCBUSY_MASK                  _U_(0x03)                                      /**< \deprecated (TRAM_SYNCBUSY) Register MASK  (Use TRAM_SYNCBUSY_Msk instead)  */
+#define TRAM_SYNCBUSY_Msk                   _U_(0x03)                                      /**< (TRAM_SYNCBUSY) Register Mask  */
+
+
+/* -------- TRAM_DSCC : (TRAM Offset: 0x0c) (/W 32) Data Scramble Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t DSCKEY:30;                 /**< bit:  0..29  Data Scramble Key                        */
+    uint32_t :1;                        /**< bit:     30  Reserved */
+    uint32_t DSCEN:1;                   /**< bit:     31  Data Scramble Enable                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TRAM_DSCC_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRAM_DSCC_OFFSET                    (0x0C)                                        /**<  (TRAM_DSCC) Data Scramble Control  Offset */
+#define TRAM_DSCC_RESETVALUE                _U_(0x00)                                     /**<  (TRAM_DSCC) Data Scramble Control  Reset Value */
+
+#define TRAM_DSCC_DSCKEY_Pos                0                                              /**< (TRAM_DSCC) Data Scramble Key Position */
+#define TRAM_DSCC_DSCKEY_Msk                (_U_(0x3FFFFFFF) << TRAM_DSCC_DSCKEY_Pos)      /**< (TRAM_DSCC) Data Scramble Key Mask */
+#define TRAM_DSCC_DSCKEY(value)             (TRAM_DSCC_DSCKEY_Msk & ((value) << TRAM_DSCC_DSCKEY_Pos))
+#define TRAM_DSCC_DSCEN_Pos                 31                                             /**< (TRAM_DSCC) Data Scramble Enable Position */
+#define TRAM_DSCC_DSCEN_Msk                 (_U_(0x1) << TRAM_DSCC_DSCEN_Pos)              /**< (TRAM_DSCC) Data Scramble Enable Mask */
+#define TRAM_DSCC_DSCEN                     TRAM_DSCC_DSCEN_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRAM_DSCC_DSCEN_Msk instead */
+#define TRAM_DSCC_MASK                      _U_(0xBFFFFFFF)                                /**< \deprecated (TRAM_DSCC) Register MASK  (Use TRAM_DSCC_Msk instead)  */
+#define TRAM_DSCC_Msk                       _U_(0xBFFFFFFF)                                /**< (TRAM_DSCC) Register Mask  */
+
+
+/* -------- TRAM_PERMW : (TRAM Offset: 0x10) (/W 8) Permutation Write -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DATA:3;                    /**< bit:   0..2  Permutation Scrambler Data Input         */
+    uint8_t  :5;                        /**< bit:   3..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} TRAM_PERMW_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRAM_PERMW_OFFSET                   (0x10)                                        /**<  (TRAM_PERMW) Permutation Write  Offset */
+#define TRAM_PERMW_RESETVALUE               _U_(0x00)                                     /**<  (TRAM_PERMW) Permutation Write  Reset Value */
+
+#define TRAM_PERMW_DATA_Pos                 0                                              /**< (TRAM_PERMW) Permutation Scrambler Data Input Position */
+#define TRAM_PERMW_DATA_Msk                 (_U_(0x7) << TRAM_PERMW_DATA_Pos)              /**< (TRAM_PERMW) Permutation Scrambler Data Input Mask */
+#define TRAM_PERMW_DATA(value)              (TRAM_PERMW_DATA_Msk & ((value) << TRAM_PERMW_DATA_Pos))
+#define TRAM_PERMW_MASK                     _U_(0x07)                                      /**< \deprecated (TRAM_PERMW) Register MASK  (Use TRAM_PERMW_Msk instead)  */
+#define TRAM_PERMW_Msk                      _U_(0x07)                                      /**< (TRAM_PERMW) Register Mask  */
+
+
+/* -------- TRAM_PERMR : (TRAM Offset: 0x11) (R/ 8) Permutation Read -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DATA:3;                    /**< bit:   0..2  Permutation Scrambler Data Output        */
+    uint8_t  :5;                        /**< bit:   3..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} TRAM_PERMR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRAM_PERMR_OFFSET                   (0x11)                                        /**<  (TRAM_PERMR) Permutation Read  Offset */
+#define TRAM_PERMR_RESETVALUE               _U_(0x00)                                     /**<  (TRAM_PERMR) Permutation Read  Reset Value */
+
+#define TRAM_PERMR_DATA_Pos                 0                                              /**< (TRAM_PERMR) Permutation Scrambler Data Output Position */
+#define TRAM_PERMR_DATA_Msk                 (_U_(0x7) << TRAM_PERMR_DATA_Pos)              /**< (TRAM_PERMR) Permutation Scrambler Data Output Mask */
+#define TRAM_PERMR_DATA(value)              (TRAM_PERMR_DATA_Msk & ((value) << TRAM_PERMR_DATA_Pos))
+#define TRAM_PERMR_MASK                     _U_(0x07)                                      /**< \deprecated (TRAM_PERMR) Register MASK  (Use TRAM_PERMR_Msk instead)  */
+#define TRAM_PERMR_Msk                      _U_(0x07)                                      /**< (TRAM_PERMR) Register Mask  */
+
+
+/* -------- TRAM_RAM : (TRAM Offset: 0x100) (R/W 32) TrustRAM -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t DATA:32;                   /**< bit:  0..31  Trust RAM Data                           */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TRAM_RAM_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRAM_RAM_OFFSET                     (0x100)                                       /**<  (TRAM_RAM) TrustRAM  Offset */
+#define TRAM_RAM_RESETVALUE                 _U_(0x00)                                     /**<  (TRAM_RAM) TrustRAM  Reset Value */
+
+#define TRAM_RAM_DATA_Pos                   0                                              /**< (TRAM_RAM) Trust RAM Data Position */
+#define TRAM_RAM_DATA_Msk                   (_U_(0xFFFFFFFF) << TRAM_RAM_DATA_Pos)         /**< (TRAM_RAM) Trust RAM Data Mask */
+#define TRAM_RAM_DATA(value)                (TRAM_RAM_DATA_Msk & ((value) << TRAM_RAM_DATA_Pos))
+#define TRAM_RAM_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (TRAM_RAM) Register MASK  (Use TRAM_RAM_Msk instead)  */
+#define TRAM_RAM_Msk                        _U_(0xFFFFFFFF)                                /**< (TRAM_RAM) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief TRAM hardware registers */
+typedef struct {  /* TrustRAM */
+  __IO TRAM_CTRLA_Type                CTRLA;          /**< Offset: 0x00 (R/W   8) Control */
+  __I  uint8_t                        Reserved1[3];
+  __IO TRAM_INTENCLR_Type             INTENCLR;       /**< Offset: 0x04 (R/W   8) Interrupt Enable Clear */
+  __IO TRAM_INTENSET_Type             INTENSET;       /**< Offset: 0x05 (R/W   8) Interrupt Enable Set */
+  __IO TRAM_INTFLAG_Type              INTFLAG;        /**< Offset: 0x06 (R/W   8) Interrupt Flag Status and Clear */
+  __I  TRAM_STATUS_Type               STATUS;         /**< Offset: 0x07 (R/    8) Status */
+  __I  TRAM_SYNCBUSY_Type             SYNCBUSY;       /**< Offset: 0x08 (R/   32) Synchronization Busy Status */
+  __O  TRAM_DSCC_Type                 DSCC;           /**< Offset: 0x0C ( /W  32) Data Scramble Control */
+  __O  TRAM_PERMW_Type                PERMW;          /**< Offset: 0x10 ( /W   8) Permutation Write */
+  __I  TRAM_PERMR_Type                PERMR;          /**< Offset: 0x11 (R/    8) Permutation Read */
+  __I  uint8_t                        Reserved2[238];
+  __IO TRAM_RAM_Type                  RAM[64];        /**< Offset: 0x100 (R/W  32) TrustRAM */
+} Tram;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of TrustRAM */
+
+#endif /* _SAML11_TRAM_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/component/trng.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/trng.h
@@ -1,0 +1,194 @@
+/**
+ * \file
+ *
+ * \brief Component description for TRNG
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_TRNG_COMPONENT_H_
+#define _SAML11_TRNG_COMPONENT_H_
+#define _SAML11_TRNG_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML11 True Random Generator
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR TRNG */
+/* ========================================================================== */
+
+#define TRNG_U2242                      /**< (TRNG) Module ID */
+#define REV_TRNG 0x120                  /**< (TRNG) Module revision */
+
+/* -------- TRNG_CTRLA : (TRNG Offset: 0x00) (R/W 8) Control A -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  :1;                        /**< bit:      0  Reserved */
+    uint8_t  ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint8_t  :4;                        /**< bit:   2..5  Reserved */
+    uint8_t  RUNSTDBY:1;                /**< bit:      6  Run in Standby                           */
+    uint8_t  :1;                        /**< bit:      7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} TRNG_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRNG_CTRLA_OFFSET                   (0x00)                                        /**<  (TRNG_CTRLA) Control A  Offset */
+#define TRNG_CTRLA_RESETVALUE               _U_(0x00)                                     /**<  (TRNG_CTRLA) Control A  Reset Value */
+
+#define TRNG_CTRLA_ENABLE_Pos               1                                              /**< (TRNG_CTRLA) Enable Position */
+#define TRNG_CTRLA_ENABLE_Msk               (_U_(0x1) << TRNG_CTRLA_ENABLE_Pos)            /**< (TRNG_CTRLA) Enable Mask */
+#define TRNG_CTRLA_ENABLE                   TRNG_CTRLA_ENABLE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRNG_CTRLA_ENABLE_Msk instead */
+#define TRNG_CTRLA_RUNSTDBY_Pos             6                                              /**< (TRNG_CTRLA) Run in Standby Position */
+#define TRNG_CTRLA_RUNSTDBY_Msk             (_U_(0x1) << TRNG_CTRLA_RUNSTDBY_Pos)          /**< (TRNG_CTRLA) Run in Standby Mask */
+#define TRNG_CTRLA_RUNSTDBY                 TRNG_CTRLA_RUNSTDBY_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRNG_CTRLA_RUNSTDBY_Msk instead */
+#define TRNG_CTRLA_MASK                     _U_(0x42)                                      /**< \deprecated (TRNG_CTRLA) Register MASK  (Use TRNG_CTRLA_Msk instead)  */
+#define TRNG_CTRLA_Msk                      _U_(0x42)                                      /**< (TRNG_CTRLA) Register Mask  */
+
+
+/* -------- TRNG_EVCTRL : (TRNG Offset: 0x04) (R/W 8) Event Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DATARDYEO:1;               /**< bit:      0  Data Ready Event Output                  */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} TRNG_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRNG_EVCTRL_OFFSET                  (0x04)                                        /**<  (TRNG_EVCTRL) Event Control  Offset */
+#define TRNG_EVCTRL_RESETVALUE              _U_(0x00)                                     /**<  (TRNG_EVCTRL) Event Control  Reset Value */
+
+#define TRNG_EVCTRL_DATARDYEO_Pos           0                                              /**< (TRNG_EVCTRL) Data Ready Event Output Position */
+#define TRNG_EVCTRL_DATARDYEO_Msk           (_U_(0x1) << TRNG_EVCTRL_DATARDYEO_Pos)        /**< (TRNG_EVCTRL) Data Ready Event Output Mask */
+#define TRNG_EVCTRL_DATARDYEO               TRNG_EVCTRL_DATARDYEO_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRNG_EVCTRL_DATARDYEO_Msk instead */
+#define TRNG_EVCTRL_MASK                    _U_(0x01)                                      /**< \deprecated (TRNG_EVCTRL) Register MASK  (Use TRNG_EVCTRL_Msk instead)  */
+#define TRNG_EVCTRL_Msk                     _U_(0x01)                                      /**< (TRNG_EVCTRL) Register Mask  */
+
+
+/* -------- TRNG_INTENCLR : (TRNG Offset: 0x08) (R/W 8) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DATARDY:1;                 /**< bit:      0  Data Ready Interrupt Enable              */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} TRNG_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRNG_INTENCLR_OFFSET                (0x08)                                        /**<  (TRNG_INTENCLR) Interrupt Enable Clear  Offset */
+#define TRNG_INTENCLR_RESETVALUE            _U_(0x00)                                     /**<  (TRNG_INTENCLR) Interrupt Enable Clear  Reset Value */
+
+#define TRNG_INTENCLR_DATARDY_Pos           0                                              /**< (TRNG_INTENCLR) Data Ready Interrupt Enable Position */
+#define TRNG_INTENCLR_DATARDY_Msk           (_U_(0x1) << TRNG_INTENCLR_DATARDY_Pos)        /**< (TRNG_INTENCLR) Data Ready Interrupt Enable Mask */
+#define TRNG_INTENCLR_DATARDY               TRNG_INTENCLR_DATARDY_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRNG_INTENCLR_DATARDY_Msk instead */
+#define TRNG_INTENCLR_MASK                  _U_(0x01)                                      /**< \deprecated (TRNG_INTENCLR) Register MASK  (Use TRNG_INTENCLR_Msk instead)  */
+#define TRNG_INTENCLR_Msk                   _U_(0x01)                                      /**< (TRNG_INTENCLR) Register Mask  */
+
+
+/* -------- TRNG_INTENSET : (TRNG Offset: 0x09) (R/W 8) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  DATARDY:1;                 /**< bit:      0  Data Ready Interrupt Enable              */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} TRNG_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRNG_INTENSET_OFFSET                (0x09)                                        /**<  (TRNG_INTENSET) Interrupt Enable Set  Offset */
+#define TRNG_INTENSET_RESETVALUE            _U_(0x00)                                     /**<  (TRNG_INTENSET) Interrupt Enable Set  Reset Value */
+
+#define TRNG_INTENSET_DATARDY_Pos           0                                              /**< (TRNG_INTENSET) Data Ready Interrupt Enable Position */
+#define TRNG_INTENSET_DATARDY_Msk           (_U_(0x1) << TRNG_INTENSET_DATARDY_Pos)        /**< (TRNG_INTENSET) Data Ready Interrupt Enable Mask */
+#define TRNG_INTENSET_DATARDY               TRNG_INTENSET_DATARDY_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRNG_INTENSET_DATARDY_Msk instead */
+#define TRNG_INTENSET_MASK                  _U_(0x01)                                      /**< \deprecated (TRNG_INTENSET) Register MASK  (Use TRNG_INTENSET_Msk instead)  */
+#define TRNG_INTENSET_Msk                   _U_(0x01)                                      /**< (TRNG_INTENSET) Register Mask  */
+
+
+/* -------- TRNG_INTFLAG : (TRNG Offset: 0x0a) (R/W 8) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t DATARDY:1;                 /**< bit:      0  Data Ready Interrupt Flag                */
+    __I uint8_t :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} TRNG_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRNG_INTFLAG_OFFSET                 (0x0A)                                        /**<  (TRNG_INTFLAG) Interrupt Flag Status and Clear  Offset */
+#define TRNG_INTFLAG_RESETVALUE             _U_(0x00)                                     /**<  (TRNG_INTFLAG) Interrupt Flag Status and Clear  Reset Value */
+
+#define TRNG_INTFLAG_DATARDY_Pos            0                                              /**< (TRNG_INTFLAG) Data Ready Interrupt Flag Position */
+#define TRNG_INTFLAG_DATARDY_Msk            (_U_(0x1) << TRNG_INTFLAG_DATARDY_Pos)         /**< (TRNG_INTFLAG) Data Ready Interrupt Flag Mask */
+#define TRNG_INTFLAG_DATARDY                TRNG_INTFLAG_DATARDY_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRNG_INTFLAG_DATARDY_Msk instead */
+#define TRNG_INTFLAG_MASK                   _U_(0x01)                                      /**< \deprecated (TRNG_INTFLAG) Register MASK  (Use TRNG_INTFLAG_Msk instead)  */
+#define TRNG_INTFLAG_Msk                    _U_(0x01)                                      /**< (TRNG_INTFLAG) Register Mask  */
+
+
+/* -------- TRNG_DATA : (TRNG Offset: 0x20) (R/ 32) Output Data -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t DATA:32;                   /**< bit:  0..31  Output Data                              */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TRNG_DATA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRNG_DATA_OFFSET                    (0x20)                                        /**<  (TRNG_DATA) Output Data  Offset */
+#define TRNG_DATA_RESETVALUE                _U_(0x00)                                     /**<  (TRNG_DATA) Output Data  Reset Value */
+
+#define TRNG_DATA_DATA_Pos                  0                                              /**< (TRNG_DATA) Output Data Position */
+#define TRNG_DATA_DATA_Msk                  (_U_(0xFFFFFFFF) << TRNG_DATA_DATA_Pos)        /**< (TRNG_DATA) Output Data Mask */
+#define TRNG_DATA_DATA(value)               (TRNG_DATA_DATA_Msk & ((value) << TRNG_DATA_DATA_Pos))
+#define TRNG_DATA_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (TRNG_DATA) Register MASK  (Use TRNG_DATA_Msk instead)  */
+#define TRNG_DATA_Msk                       _U_(0xFFFFFFFF)                                /**< (TRNG_DATA) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief TRNG hardware registers */
+typedef struct {  /* True Random Generator */
+  __IO TRNG_CTRLA_Type                CTRLA;          /**< Offset: 0x00 (R/W   8) Control A */
+  __I  uint8_t                        Reserved1[3];
+  __IO TRNG_EVCTRL_Type               EVCTRL;         /**< Offset: 0x04 (R/W   8) Event Control */
+  __I  uint8_t                        Reserved2[3];
+  __IO TRNG_INTENCLR_Type             INTENCLR;       /**< Offset: 0x08 (R/W   8) Interrupt Enable Clear */
+  __IO TRNG_INTENSET_Type             INTENSET;       /**< Offset: 0x09 (R/W   8) Interrupt Enable Set */
+  __IO TRNG_INTFLAG_Type              INTFLAG;        /**< Offset: 0x0A (R/W   8) Interrupt Flag Status and Clear */
+  __I  uint8_t                        Reserved3[21];
+  __I  TRNG_DATA_Type                 DATA;           /**< Offset: 0x20 (R/   32) Output Data */
+} Trng;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of True Random Generator */
+
+#endif /* _SAML11_TRNG_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/component/wdt.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/wdt.h
@@ -1,0 +1,338 @@
+/**
+ * \file
+ *
+ * \brief Component description for WDT
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_WDT_COMPONENT_H_
+#define _SAML11_WDT_COMPONENT_H_
+#define _SAML11_WDT_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAML_SAML11 Watchdog Timer
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR WDT */
+/* ========================================================================== */
+
+#define WDT_U2251                      /**< (WDT) Module ID */
+#define REV_WDT 0x200                  /**< (WDT) Module revision */
+
+/* -------- WDT_CTRLA : (WDT Offset: 0x00) (R/W 8) Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  :1;                        /**< bit:      0  Reserved */
+    uint8_t  ENABLE:1;                  /**< bit:      1  Enable                                   */
+    uint8_t  WEN:1;                     /**< bit:      2  Watchdog Timer Window Mode Enable        */
+    uint8_t  :3;                        /**< bit:   3..5  Reserved */
+    uint8_t  RUNSTDBY:1;                /**< bit:      6  Run During Standby                       */
+    uint8_t  ALWAYSON:1;                /**< bit:      7  Always-On                                */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} WDT_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_CTRLA_OFFSET                    (0x00)                                        /**<  (WDT_CTRLA) Control  Offset */
+#define WDT_CTRLA_RESETVALUE                _U_(0x00)                                     /**<  (WDT_CTRLA) Control  Reset Value */
+
+#define WDT_CTRLA_ENABLE_Pos                1                                              /**< (WDT_CTRLA) Enable Position */
+#define WDT_CTRLA_ENABLE_Msk                (_U_(0x1) << WDT_CTRLA_ENABLE_Pos)             /**< (WDT_CTRLA) Enable Mask */
+#define WDT_CTRLA_ENABLE                    WDT_CTRLA_ENABLE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use WDT_CTRLA_ENABLE_Msk instead */
+#define WDT_CTRLA_WEN_Pos                   2                                              /**< (WDT_CTRLA) Watchdog Timer Window Mode Enable Position */
+#define WDT_CTRLA_WEN_Msk                   (_U_(0x1) << WDT_CTRLA_WEN_Pos)                /**< (WDT_CTRLA) Watchdog Timer Window Mode Enable Mask */
+#define WDT_CTRLA_WEN                       WDT_CTRLA_WEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use WDT_CTRLA_WEN_Msk instead */
+#define WDT_CTRLA_RUNSTDBY_Pos              6                                              /**< (WDT_CTRLA) Run During Standby Position */
+#define WDT_CTRLA_RUNSTDBY_Msk              (_U_(0x1) << WDT_CTRLA_RUNSTDBY_Pos)           /**< (WDT_CTRLA) Run During Standby Mask */
+#define WDT_CTRLA_RUNSTDBY                  WDT_CTRLA_RUNSTDBY_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use WDT_CTRLA_RUNSTDBY_Msk instead */
+#define WDT_CTRLA_ALWAYSON_Pos              7                                              /**< (WDT_CTRLA) Always-On Position */
+#define WDT_CTRLA_ALWAYSON_Msk              (_U_(0x1) << WDT_CTRLA_ALWAYSON_Pos)           /**< (WDT_CTRLA) Always-On Mask */
+#define WDT_CTRLA_ALWAYSON                  WDT_CTRLA_ALWAYSON_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use WDT_CTRLA_ALWAYSON_Msk instead */
+#define WDT_CTRLA_MASK                      _U_(0xC6)                                      /**< \deprecated (WDT_CTRLA) Register MASK  (Use WDT_CTRLA_Msk instead)  */
+#define WDT_CTRLA_Msk                       _U_(0xC6)                                      /**< (WDT_CTRLA) Register Mask  */
+
+
+/* -------- WDT_CONFIG : (WDT Offset: 0x01) (R/W 8) Configuration -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  PER:4;                     /**< bit:   0..3  Time-Out Period                          */
+    uint8_t  WINDOW:4;                  /**< bit:   4..7  Window Mode Time-Out Period              */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} WDT_CONFIG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_CONFIG_OFFSET                   (0x01)                                        /**<  (WDT_CONFIG) Configuration  Offset */
+#define WDT_CONFIG_RESETVALUE               _U_(0xBB)                                     /**<  (WDT_CONFIG) Configuration  Reset Value */
+
+#define WDT_CONFIG_PER_Pos                  0                                              /**< (WDT_CONFIG) Time-Out Period Position */
+#define WDT_CONFIG_PER_Msk                  (_U_(0xF) << WDT_CONFIG_PER_Pos)               /**< (WDT_CONFIG) Time-Out Period Mask */
+#define WDT_CONFIG_PER(value)               (WDT_CONFIG_PER_Msk & ((value) << WDT_CONFIG_PER_Pos))
+#define   WDT_CONFIG_PER_CYC8_Val           _U_(0x0)                                       /**< (WDT_CONFIG) 8 clock cycles  */
+#define   WDT_CONFIG_PER_CYC16_Val          _U_(0x1)                                       /**< (WDT_CONFIG) 16 clock cycles  */
+#define   WDT_CONFIG_PER_CYC32_Val          _U_(0x2)                                       /**< (WDT_CONFIG) 32 clock cycles  */
+#define   WDT_CONFIG_PER_CYC64_Val          _U_(0x3)                                       /**< (WDT_CONFIG) 64 clock cycles  */
+#define   WDT_CONFIG_PER_CYC128_Val         _U_(0x4)                                       /**< (WDT_CONFIG) 128 clock cycles  */
+#define   WDT_CONFIG_PER_CYC256_Val         _U_(0x5)                                       /**< (WDT_CONFIG) 256 clock cycles  */
+#define   WDT_CONFIG_PER_CYC512_Val         _U_(0x6)                                       /**< (WDT_CONFIG) 512 clock cycles  */
+#define   WDT_CONFIG_PER_CYC1024_Val        _U_(0x7)                                       /**< (WDT_CONFIG) 1024 clock cycles  */
+#define   WDT_CONFIG_PER_CYC2048_Val        _U_(0x8)                                       /**< (WDT_CONFIG) 2048 clock cycles  */
+#define   WDT_CONFIG_PER_CYC4096_Val        _U_(0x9)                                       /**< (WDT_CONFIG) 4096 clock cycles  */
+#define   WDT_CONFIG_PER_CYC8192_Val        _U_(0xA)                                       /**< (WDT_CONFIG) 8192 clock cycles  */
+#define   WDT_CONFIG_PER_CYC16384_Val       _U_(0xB)                                       /**< (WDT_CONFIG) 16384 clock cycles  */
+#define WDT_CONFIG_PER_CYC8                 (WDT_CONFIG_PER_CYC8_Val << WDT_CONFIG_PER_Pos)  /**< (WDT_CONFIG) 8 clock cycles Position  */
+#define WDT_CONFIG_PER_CYC16                (WDT_CONFIG_PER_CYC16_Val << WDT_CONFIG_PER_Pos)  /**< (WDT_CONFIG) 16 clock cycles Position  */
+#define WDT_CONFIG_PER_CYC32                (WDT_CONFIG_PER_CYC32_Val << WDT_CONFIG_PER_Pos)  /**< (WDT_CONFIG) 32 clock cycles Position  */
+#define WDT_CONFIG_PER_CYC64                (WDT_CONFIG_PER_CYC64_Val << WDT_CONFIG_PER_Pos)  /**< (WDT_CONFIG) 64 clock cycles Position  */
+#define WDT_CONFIG_PER_CYC128               (WDT_CONFIG_PER_CYC128_Val << WDT_CONFIG_PER_Pos)  /**< (WDT_CONFIG) 128 clock cycles Position  */
+#define WDT_CONFIG_PER_CYC256               (WDT_CONFIG_PER_CYC256_Val << WDT_CONFIG_PER_Pos)  /**< (WDT_CONFIG) 256 clock cycles Position  */
+#define WDT_CONFIG_PER_CYC512               (WDT_CONFIG_PER_CYC512_Val << WDT_CONFIG_PER_Pos)  /**< (WDT_CONFIG) 512 clock cycles Position  */
+#define WDT_CONFIG_PER_CYC1024              (WDT_CONFIG_PER_CYC1024_Val << WDT_CONFIG_PER_Pos)  /**< (WDT_CONFIG) 1024 clock cycles Position  */
+#define WDT_CONFIG_PER_CYC2048              (WDT_CONFIG_PER_CYC2048_Val << WDT_CONFIG_PER_Pos)  /**< (WDT_CONFIG) 2048 clock cycles Position  */
+#define WDT_CONFIG_PER_CYC4096              (WDT_CONFIG_PER_CYC4096_Val << WDT_CONFIG_PER_Pos)  /**< (WDT_CONFIG) 4096 clock cycles Position  */
+#define WDT_CONFIG_PER_CYC8192              (WDT_CONFIG_PER_CYC8192_Val << WDT_CONFIG_PER_Pos)  /**< (WDT_CONFIG) 8192 clock cycles Position  */
+#define WDT_CONFIG_PER_CYC16384             (WDT_CONFIG_PER_CYC16384_Val << WDT_CONFIG_PER_Pos)  /**< (WDT_CONFIG) 16384 clock cycles Position  */
+#define WDT_CONFIG_WINDOW_Pos               4                                              /**< (WDT_CONFIG) Window Mode Time-Out Period Position */
+#define WDT_CONFIG_WINDOW_Msk               (_U_(0xF) << WDT_CONFIG_WINDOW_Pos)            /**< (WDT_CONFIG) Window Mode Time-Out Period Mask */
+#define WDT_CONFIG_WINDOW(value)            (WDT_CONFIG_WINDOW_Msk & ((value) << WDT_CONFIG_WINDOW_Pos))
+#define   WDT_CONFIG_WINDOW_CYC8_Val        _U_(0x0)                                       /**< (WDT_CONFIG) 8 clock cycles  */
+#define   WDT_CONFIG_WINDOW_CYC16_Val       _U_(0x1)                                       /**< (WDT_CONFIG) 16 clock cycles  */
+#define   WDT_CONFIG_WINDOW_CYC32_Val       _U_(0x2)                                       /**< (WDT_CONFIG) 32 clock cycles  */
+#define   WDT_CONFIG_WINDOW_CYC64_Val       _U_(0x3)                                       /**< (WDT_CONFIG) 64 clock cycles  */
+#define   WDT_CONFIG_WINDOW_CYC128_Val      _U_(0x4)                                       /**< (WDT_CONFIG) 128 clock cycles  */
+#define   WDT_CONFIG_WINDOW_CYC256_Val      _U_(0x5)                                       /**< (WDT_CONFIG) 256 clock cycles  */
+#define   WDT_CONFIG_WINDOW_CYC512_Val      _U_(0x6)                                       /**< (WDT_CONFIG) 512 clock cycles  */
+#define   WDT_CONFIG_WINDOW_CYC1024_Val     _U_(0x7)                                       /**< (WDT_CONFIG) 1024 clock cycles  */
+#define   WDT_CONFIG_WINDOW_CYC2048_Val     _U_(0x8)                                       /**< (WDT_CONFIG) 2048 clock cycles  */
+#define   WDT_CONFIG_WINDOW_CYC4096_Val     _U_(0x9)                                       /**< (WDT_CONFIG) 4096 clock cycles  */
+#define   WDT_CONFIG_WINDOW_CYC8192_Val     _U_(0xA)                                       /**< (WDT_CONFIG) 8192 clock cycles  */
+#define   WDT_CONFIG_WINDOW_CYC16384_Val    _U_(0xB)                                       /**< (WDT_CONFIG) 16384 clock cycles  */
+#define WDT_CONFIG_WINDOW_CYC8              (WDT_CONFIG_WINDOW_CYC8_Val << WDT_CONFIG_WINDOW_Pos)  /**< (WDT_CONFIG) 8 clock cycles Position  */
+#define WDT_CONFIG_WINDOW_CYC16             (WDT_CONFIG_WINDOW_CYC16_Val << WDT_CONFIG_WINDOW_Pos)  /**< (WDT_CONFIG) 16 clock cycles Position  */
+#define WDT_CONFIG_WINDOW_CYC32             (WDT_CONFIG_WINDOW_CYC32_Val << WDT_CONFIG_WINDOW_Pos)  /**< (WDT_CONFIG) 32 clock cycles Position  */
+#define WDT_CONFIG_WINDOW_CYC64             (WDT_CONFIG_WINDOW_CYC64_Val << WDT_CONFIG_WINDOW_Pos)  /**< (WDT_CONFIG) 64 clock cycles Position  */
+#define WDT_CONFIG_WINDOW_CYC128            (WDT_CONFIG_WINDOW_CYC128_Val << WDT_CONFIG_WINDOW_Pos)  /**< (WDT_CONFIG) 128 clock cycles Position  */
+#define WDT_CONFIG_WINDOW_CYC256            (WDT_CONFIG_WINDOW_CYC256_Val << WDT_CONFIG_WINDOW_Pos)  /**< (WDT_CONFIG) 256 clock cycles Position  */
+#define WDT_CONFIG_WINDOW_CYC512            (WDT_CONFIG_WINDOW_CYC512_Val << WDT_CONFIG_WINDOW_Pos)  /**< (WDT_CONFIG) 512 clock cycles Position  */
+#define WDT_CONFIG_WINDOW_CYC1024           (WDT_CONFIG_WINDOW_CYC1024_Val << WDT_CONFIG_WINDOW_Pos)  /**< (WDT_CONFIG) 1024 clock cycles Position  */
+#define WDT_CONFIG_WINDOW_CYC2048           (WDT_CONFIG_WINDOW_CYC2048_Val << WDT_CONFIG_WINDOW_Pos)  /**< (WDT_CONFIG) 2048 clock cycles Position  */
+#define WDT_CONFIG_WINDOW_CYC4096           (WDT_CONFIG_WINDOW_CYC4096_Val << WDT_CONFIG_WINDOW_Pos)  /**< (WDT_CONFIG) 4096 clock cycles Position  */
+#define WDT_CONFIG_WINDOW_CYC8192           (WDT_CONFIG_WINDOW_CYC8192_Val << WDT_CONFIG_WINDOW_Pos)  /**< (WDT_CONFIG) 8192 clock cycles Position  */
+#define WDT_CONFIG_WINDOW_CYC16384          (WDT_CONFIG_WINDOW_CYC16384_Val << WDT_CONFIG_WINDOW_Pos)  /**< (WDT_CONFIG) 16384 clock cycles Position  */
+#define WDT_CONFIG_MASK                     _U_(0xFF)                                      /**< \deprecated (WDT_CONFIG) Register MASK  (Use WDT_CONFIG_Msk instead)  */
+#define WDT_CONFIG_Msk                      _U_(0xFF)                                      /**< (WDT_CONFIG) Register Mask  */
+
+
+/* -------- WDT_EWCTRL : (WDT Offset: 0x02) (R/W 8) Early Warning Interrupt Control -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  EWOFFSET:4;                /**< bit:   0..3  Early Warning Interrupt Time Offset      */
+    uint8_t  :4;                        /**< bit:   4..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} WDT_EWCTRL_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_EWCTRL_OFFSET                   (0x02)                                        /**<  (WDT_EWCTRL) Early Warning Interrupt Control  Offset */
+#define WDT_EWCTRL_RESETVALUE               _U_(0x0B)                                     /**<  (WDT_EWCTRL) Early Warning Interrupt Control  Reset Value */
+
+#define WDT_EWCTRL_EWOFFSET_Pos             0                                              /**< (WDT_EWCTRL) Early Warning Interrupt Time Offset Position */
+#define WDT_EWCTRL_EWOFFSET_Msk             (_U_(0xF) << WDT_EWCTRL_EWOFFSET_Pos)          /**< (WDT_EWCTRL) Early Warning Interrupt Time Offset Mask */
+#define WDT_EWCTRL_EWOFFSET(value)          (WDT_EWCTRL_EWOFFSET_Msk & ((value) << WDT_EWCTRL_EWOFFSET_Pos))
+#define   WDT_EWCTRL_EWOFFSET_CYC8_Val      _U_(0x0)                                       /**< (WDT_EWCTRL) 8 clock cycles  */
+#define   WDT_EWCTRL_EWOFFSET_CYC16_Val     _U_(0x1)                                       /**< (WDT_EWCTRL) 16 clock cycles  */
+#define   WDT_EWCTRL_EWOFFSET_CYC32_Val     _U_(0x2)                                       /**< (WDT_EWCTRL) 32 clock cycles  */
+#define   WDT_EWCTRL_EWOFFSET_CYC64_Val     _U_(0x3)                                       /**< (WDT_EWCTRL) 64 clock cycles  */
+#define   WDT_EWCTRL_EWOFFSET_CYC128_Val    _U_(0x4)                                       /**< (WDT_EWCTRL) 128 clock cycles  */
+#define   WDT_EWCTRL_EWOFFSET_CYC256_Val    _U_(0x5)                                       /**< (WDT_EWCTRL) 256 clock cycles  */
+#define   WDT_EWCTRL_EWOFFSET_CYC512_Val    _U_(0x6)                                       /**< (WDT_EWCTRL) 512 clock cycles  */
+#define   WDT_EWCTRL_EWOFFSET_CYC1024_Val   _U_(0x7)                                       /**< (WDT_EWCTRL) 1024 clock cycles  */
+#define   WDT_EWCTRL_EWOFFSET_CYC2048_Val   _U_(0x8)                                       /**< (WDT_EWCTRL) 2048 clock cycles  */
+#define   WDT_EWCTRL_EWOFFSET_CYC4096_Val   _U_(0x9)                                       /**< (WDT_EWCTRL) 4096 clock cycles  */
+#define   WDT_EWCTRL_EWOFFSET_CYC8192_Val   _U_(0xA)                                       /**< (WDT_EWCTRL) 8192 clock cycles  */
+#define   WDT_EWCTRL_EWOFFSET_CYC16384_Val  _U_(0xB)                                       /**< (WDT_EWCTRL) 16384 clock cycles  */
+#define WDT_EWCTRL_EWOFFSET_CYC8            (WDT_EWCTRL_EWOFFSET_CYC8_Val << WDT_EWCTRL_EWOFFSET_Pos)  /**< (WDT_EWCTRL) 8 clock cycles Position  */
+#define WDT_EWCTRL_EWOFFSET_CYC16           (WDT_EWCTRL_EWOFFSET_CYC16_Val << WDT_EWCTRL_EWOFFSET_Pos)  /**< (WDT_EWCTRL) 16 clock cycles Position  */
+#define WDT_EWCTRL_EWOFFSET_CYC32           (WDT_EWCTRL_EWOFFSET_CYC32_Val << WDT_EWCTRL_EWOFFSET_Pos)  /**< (WDT_EWCTRL) 32 clock cycles Position  */
+#define WDT_EWCTRL_EWOFFSET_CYC64           (WDT_EWCTRL_EWOFFSET_CYC64_Val << WDT_EWCTRL_EWOFFSET_Pos)  /**< (WDT_EWCTRL) 64 clock cycles Position  */
+#define WDT_EWCTRL_EWOFFSET_CYC128          (WDT_EWCTRL_EWOFFSET_CYC128_Val << WDT_EWCTRL_EWOFFSET_Pos)  /**< (WDT_EWCTRL) 128 clock cycles Position  */
+#define WDT_EWCTRL_EWOFFSET_CYC256          (WDT_EWCTRL_EWOFFSET_CYC256_Val << WDT_EWCTRL_EWOFFSET_Pos)  /**< (WDT_EWCTRL) 256 clock cycles Position  */
+#define WDT_EWCTRL_EWOFFSET_CYC512          (WDT_EWCTRL_EWOFFSET_CYC512_Val << WDT_EWCTRL_EWOFFSET_Pos)  /**< (WDT_EWCTRL) 512 clock cycles Position  */
+#define WDT_EWCTRL_EWOFFSET_CYC1024         (WDT_EWCTRL_EWOFFSET_CYC1024_Val << WDT_EWCTRL_EWOFFSET_Pos)  /**< (WDT_EWCTRL) 1024 clock cycles Position  */
+#define WDT_EWCTRL_EWOFFSET_CYC2048         (WDT_EWCTRL_EWOFFSET_CYC2048_Val << WDT_EWCTRL_EWOFFSET_Pos)  /**< (WDT_EWCTRL) 2048 clock cycles Position  */
+#define WDT_EWCTRL_EWOFFSET_CYC4096         (WDT_EWCTRL_EWOFFSET_CYC4096_Val << WDT_EWCTRL_EWOFFSET_Pos)  /**< (WDT_EWCTRL) 4096 clock cycles Position  */
+#define WDT_EWCTRL_EWOFFSET_CYC8192         (WDT_EWCTRL_EWOFFSET_CYC8192_Val << WDT_EWCTRL_EWOFFSET_Pos)  /**< (WDT_EWCTRL) 8192 clock cycles Position  */
+#define WDT_EWCTRL_EWOFFSET_CYC16384        (WDT_EWCTRL_EWOFFSET_CYC16384_Val << WDT_EWCTRL_EWOFFSET_Pos)  /**< (WDT_EWCTRL) 16384 clock cycles Position  */
+#define WDT_EWCTRL_MASK                     _U_(0x0F)                                      /**< \deprecated (WDT_EWCTRL) Register MASK  (Use WDT_EWCTRL_Msk instead)  */
+#define WDT_EWCTRL_Msk                      _U_(0x0F)                                      /**< (WDT_EWCTRL) Register Mask  */
+
+
+/* -------- WDT_INTENCLR : (WDT Offset: 0x04) (R/W 8) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  EW:1;                      /**< bit:      0  Early Warning Interrupt Enable           */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} WDT_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_INTENCLR_OFFSET                 (0x04)                                        /**<  (WDT_INTENCLR) Interrupt Enable Clear  Offset */
+#define WDT_INTENCLR_RESETVALUE             _U_(0x00)                                     /**<  (WDT_INTENCLR) Interrupt Enable Clear  Reset Value */
+
+#define WDT_INTENCLR_EW_Pos                 0                                              /**< (WDT_INTENCLR) Early Warning Interrupt Enable Position */
+#define WDT_INTENCLR_EW_Msk                 (_U_(0x1) << WDT_INTENCLR_EW_Pos)              /**< (WDT_INTENCLR) Early Warning Interrupt Enable Mask */
+#define WDT_INTENCLR_EW                     WDT_INTENCLR_EW_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use WDT_INTENCLR_EW_Msk instead */
+#define WDT_INTENCLR_MASK                   _U_(0x01)                                      /**< \deprecated (WDT_INTENCLR) Register MASK  (Use WDT_INTENCLR_Msk instead)  */
+#define WDT_INTENCLR_Msk                    _U_(0x01)                                      /**< (WDT_INTENCLR) Register Mask  */
+
+
+/* -------- WDT_INTENSET : (WDT Offset: 0x05) (R/W 8) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  EW:1;                      /**< bit:      0  Early Warning Interrupt Enable           */
+    uint8_t  :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} WDT_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_INTENSET_OFFSET                 (0x05)                                        /**<  (WDT_INTENSET) Interrupt Enable Set  Offset */
+#define WDT_INTENSET_RESETVALUE             _U_(0x00)                                     /**<  (WDT_INTENSET) Interrupt Enable Set  Reset Value */
+
+#define WDT_INTENSET_EW_Pos                 0                                              /**< (WDT_INTENSET) Early Warning Interrupt Enable Position */
+#define WDT_INTENSET_EW_Msk                 (_U_(0x1) << WDT_INTENSET_EW_Pos)              /**< (WDT_INTENSET) Early Warning Interrupt Enable Mask */
+#define WDT_INTENSET_EW                     WDT_INTENSET_EW_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use WDT_INTENSET_EW_Msk instead */
+#define WDT_INTENSET_MASK                   _U_(0x01)                                      /**< \deprecated (WDT_INTENSET) Register MASK  (Use WDT_INTENSET_Msk instead)  */
+#define WDT_INTENSET_Msk                    _U_(0x01)                                      /**< (WDT_INTENSET) Register Mask  */
+
+
+/* -------- WDT_INTFLAG : (WDT Offset: 0x06) (R/W 8) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t EW:1;                      /**< bit:      0  Early Warning                            */
+    __I uint8_t :7;                        /**< bit:   1..7  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} WDT_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_INTFLAG_OFFSET                  (0x06)                                        /**<  (WDT_INTFLAG) Interrupt Flag Status and Clear  Offset */
+#define WDT_INTFLAG_RESETVALUE              _U_(0x00)                                     /**<  (WDT_INTFLAG) Interrupt Flag Status and Clear  Reset Value */
+
+#define WDT_INTFLAG_EW_Pos                  0                                              /**< (WDT_INTFLAG) Early Warning Position */
+#define WDT_INTFLAG_EW_Msk                  (_U_(0x1) << WDT_INTFLAG_EW_Pos)               /**< (WDT_INTFLAG) Early Warning Mask */
+#define WDT_INTFLAG_EW                      WDT_INTFLAG_EW_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use WDT_INTFLAG_EW_Msk instead */
+#define WDT_INTFLAG_MASK                    _U_(0x01)                                      /**< \deprecated (WDT_INTFLAG) Register MASK  (Use WDT_INTFLAG_Msk instead)  */
+#define WDT_INTFLAG_Msk                     _U_(0x01)                                      /**< (WDT_INTFLAG) Register Mask  */
+
+
+/* -------- WDT_SYNCBUSY : (WDT Offset: 0x08) (R/ 32) Synchronization Busy -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t ENABLE:1;                  /**< bit:      1  Enable Synchronization Busy              */
+    uint32_t WEN:1;                     /**< bit:      2  Window Enable Synchronization Busy       */
+    uint32_t RUNSTDBY:1;                /**< bit:      3  Run During Standby Synchronization Busy  */
+    uint32_t ALWAYSON:1;                /**< bit:      4  Always-On Synchronization Busy           */
+    uint32_t CLEAR:1;                   /**< bit:      5  Clear Synchronization Busy               */
+    uint32_t :26;                       /**< bit:  6..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} WDT_SYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_SYNCBUSY_OFFSET                 (0x08)                                        /**<  (WDT_SYNCBUSY) Synchronization Busy  Offset */
+#define WDT_SYNCBUSY_RESETVALUE             _U_(0x00)                                     /**<  (WDT_SYNCBUSY) Synchronization Busy  Reset Value */
+
+#define WDT_SYNCBUSY_ENABLE_Pos             1                                              /**< (WDT_SYNCBUSY) Enable Synchronization Busy Position */
+#define WDT_SYNCBUSY_ENABLE_Msk             (_U_(0x1) << WDT_SYNCBUSY_ENABLE_Pos)          /**< (WDT_SYNCBUSY) Enable Synchronization Busy Mask */
+#define WDT_SYNCBUSY_ENABLE                 WDT_SYNCBUSY_ENABLE_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use WDT_SYNCBUSY_ENABLE_Msk instead */
+#define WDT_SYNCBUSY_WEN_Pos                2                                              /**< (WDT_SYNCBUSY) Window Enable Synchronization Busy Position */
+#define WDT_SYNCBUSY_WEN_Msk                (_U_(0x1) << WDT_SYNCBUSY_WEN_Pos)             /**< (WDT_SYNCBUSY) Window Enable Synchronization Busy Mask */
+#define WDT_SYNCBUSY_WEN                    WDT_SYNCBUSY_WEN_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use WDT_SYNCBUSY_WEN_Msk instead */
+#define WDT_SYNCBUSY_RUNSTDBY_Pos           3                                              /**< (WDT_SYNCBUSY) Run During Standby Synchronization Busy Position */
+#define WDT_SYNCBUSY_RUNSTDBY_Msk           (_U_(0x1) << WDT_SYNCBUSY_RUNSTDBY_Pos)        /**< (WDT_SYNCBUSY) Run During Standby Synchronization Busy Mask */
+#define WDT_SYNCBUSY_RUNSTDBY               WDT_SYNCBUSY_RUNSTDBY_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use WDT_SYNCBUSY_RUNSTDBY_Msk instead */
+#define WDT_SYNCBUSY_ALWAYSON_Pos           4                                              /**< (WDT_SYNCBUSY) Always-On Synchronization Busy Position */
+#define WDT_SYNCBUSY_ALWAYSON_Msk           (_U_(0x1) << WDT_SYNCBUSY_ALWAYSON_Pos)        /**< (WDT_SYNCBUSY) Always-On Synchronization Busy Mask */
+#define WDT_SYNCBUSY_ALWAYSON               WDT_SYNCBUSY_ALWAYSON_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use WDT_SYNCBUSY_ALWAYSON_Msk instead */
+#define WDT_SYNCBUSY_CLEAR_Pos              5                                              /**< (WDT_SYNCBUSY) Clear Synchronization Busy Position */
+#define WDT_SYNCBUSY_CLEAR_Msk              (_U_(0x1) << WDT_SYNCBUSY_CLEAR_Pos)           /**< (WDT_SYNCBUSY) Clear Synchronization Busy Mask */
+#define WDT_SYNCBUSY_CLEAR                  WDT_SYNCBUSY_CLEAR_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use WDT_SYNCBUSY_CLEAR_Msk instead */
+#define WDT_SYNCBUSY_MASK                   _U_(0x3E)                                      /**< \deprecated (WDT_SYNCBUSY) Register MASK  (Use WDT_SYNCBUSY_Msk instead)  */
+#define WDT_SYNCBUSY_Msk                    _U_(0x3E)                                      /**< (WDT_SYNCBUSY) Register Mask  */
+
+
+/* -------- WDT_CLEAR : (WDT Offset: 0x0c) (/W 8) Clear -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { 
+  struct {
+    uint8_t  CLEAR:8;                   /**< bit:   0..7  Watchdog Clear                           */
+  } bit;                                /**< Structure used for bit  access */
+  uint8_t  reg;                         /**< Type used for register access */
+} WDT_CLEAR_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_CLEAR_OFFSET                    (0x0C)                                        /**<  (WDT_CLEAR) Clear  Offset */
+#define WDT_CLEAR_RESETVALUE                _U_(0x00)                                     /**<  (WDT_CLEAR) Clear  Reset Value */
+
+#define WDT_CLEAR_CLEAR_Pos                 0                                              /**< (WDT_CLEAR) Watchdog Clear Position */
+#define WDT_CLEAR_CLEAR_Msk                 (_U_(0xFF) << WDT_CLEAR_CLEAR_Pos)             /**< (WDT_CLEAR) Watchdog Clear Mask */
+#define WDT_CLEAR_CLEAR(value)              (WDT_CLEAR_CLEAR_Msk & ((value) << WDT_CLEAR_CLEAR_Pos))
+#define   WDT_CLEAR_CLEAR_KEY_Val           _U_(0xA5)                                      /**< (WDT_CLEAR) Clear Key  */
+#define WDT_CLEAR_CLEAR_KEY                 (WDT_CLEAR_CLEAR_KEY_Val << WDT_CLEAR_CLEAR_Pos)  /**< (WDT_CLEAR) Clear Key Position  */
+#define WDT_CLEAR_MASK                      _U_(0xFF)                                      /**< \deprecated (WDT_CLEAR) Register MASK  (Use WDT_CLEAR_Msk instead)  */
+#define WDT_CLEAR_Msk                       _U_(0xFF)                                      /**< (WDT_CLEAR) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief WDT hardware registers */
+typedef struct {  /* Watchdog Timer */
+  __IO WDT_CTRLA_Type                 CTRLA;          /**< Offset: 0x00 (R/W   8) Control */
+  __IO WDT_CONFIG_Type                CONFIG;         /**< Offset: 0x01 (R/W   8) Configuration */
+  __IO WDT_EWCTRL_Type                EWCTRL;         /**< Offset: 0x02 (R/W   8) Early Warning Interrupt Control */
+  __I  uint8_t                        Reserved1[1];
+  __IO WDT_INTENCLR_Type              INTENCLR;       /**< Offset: 0x04 (R/W   8) Interrupt Enable Clear */
+  __IO WDT_INTENSET_Type              INTENSET;       /**< Offset: 0x05 (R/W   8) Interrupt Enable Set */
+  __IO WDT_INTFLAG_Type               INTFLAG;        /**< Offset: 0x06 (R/W   8) Interrupt Flag Status and Clear */
+  __I  uint8_t                        Reserved2[1];
+  __I  WDT_SYNCBUSY_Type              SYNCBUSY;       /**< Offset: 0x08 (R/   32) Synchronization Busy */
+  __O  WDT_CLEAR_Type                 CLEAR;          /**< Offset: 0x0C ( /W   8) Clear */
+} Wdt;
+
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Watchdog Timer */
+
+#endif /* _SAML11_WDT_COMPONENT_H_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/instance/ac.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/instance/ac.h
@@ -1,0 +1,83 @@
+/**
+ * \file
+ *
+ * \brief Instance description for AC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_AC_INSTANCE_H_
+#define _SAML11_AC_INSTANCE_H_
+
+/* ========== Register definition for AC peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_AC_CTRLA            (0x40003400) /**< (AC) Control A */
+#define REG_AC_CTRLB            (0x40003401) /**< (AC) Control B */
+#define REG_AC_EVCTRL           (0x40003402) /**< (AC) Event Control */
+#define REG_AC_INTENCLR         (0x40003404) /**< (AC) Interrupt Enable Clear */
+#define REG_AC_INTENSET         (0x40003405) /**< (AC) Interrupt Enable Set */
+#define REG_AC_INTFLAG          (0x40003406) /**< (AC) Interrupt Flag Status and Clear */
+#define REG_AC_STATUSA          (0x40003407) /**< (AC) Status A */
+#define REG_AC_STATUSB          (0x40003408) /**< (AC) Status B */
+#define REG_AC_DBGCTRL          (0x40003409) /**< (AC) Debug Control */
+#define REG_AC_WINCTRL          (0x4000340A) /**< (AC) Window Control */
+#define REG_AC_SCALER           (0x4000340C) /**< (AC) Scaler n */
+#define REG_AC_SCALER0          (0x4000340C) /**< (AC) Scaler 0 */
+#define REG_AC_SCALER1          (0x4000340D) /**< (AC) Scaler 1 */
+#define REG_AC_COMPCTRL         (0x40003410) /**< (AC) Comparator Control n */
+#define REG_AC_COMPCTRL0        (0x40003410) /**< (AC) Comparator Control 0 */
+#define REG_AC_COMPCTRL1        (0x40003414) /**< (AC) Comparator Control 1 */
+#define REG_AC_SYNCBUSY         (0x40003420) /**< (AC) Synchronization Busy */
+
+#else
+
+#define REG_AC_CTRLA            (*(__IO uint8_t*)0x40003400U) /**< (AC) Control A */
+#define REG_AC_CTRLB            (*(__O  uint8_t*)0x40003401U) /**< (AC) Control B */
+#define REG_AC_EVCTRL           (*(__IO uint16_t*)0x40003402U) /**< (AC) Event Control */
+#define REG_AC_INTENCLR         (*(__IO uint8_t*)0x40003404U) /**< (AC) Interrupt Enable Clear */
+#define REG_AC_INTENSET         (*(__IO uint8_t*)0x40003405U) /**< (AC) Interrupt Enable Set */
+#define REG_AC_INTFLAG          (*(__IO uint8_t*)0x40003406U) /**< (AC) Interrupt Flag Status and Clear */
+#define REG_AC_STATUSA          (*(__I  uint8_t*)0x40003407U) /**< (AC) Status A */
+#define REG_AC_STATUSB          (*(__I  uint8_t*)0x40003408U) /**< (AC) Status B */
+#define REG_AC_DBGCTRL          (*(__IO uint8_t*)0x40003409U) /**< (AC) Debug Control */
+#define REG_AC_WINCTRL          (*(__IO uint8_t*)0x4000340AU) /**< (AC) Window Control */
+#define REG_AC_SCALER           (*(__IO uint8_t*)0x4000340CU) /**< (AC) Scaler n */
+#define REG_AC_SCALER0          (*(__IO uint8_t*)0x4000340CU) /**< (AC) Scaler 0 */
+#define REG_AC_SCALER1          (*(__IO uint8_t*)0x4000340DU) /**< (AC) Scaler 1 */
+#define REG_AC_COMPCTRL         (*(__IO uint32_t*)0x40003410U) /**< (AC) Comparator Control n */
+#define REG_AC_COMPCTRL0        (*(__IO uint32_t*)0x40003410U) /**< (AC) Comparator Control 0 */
+#define REG_AC_COMPCTRL1        (*(__IO uint32_t*)0x40003414U) /**< (AC) Comparator Control 1 */
+#define REG_AC_SYNCBUSY         (*(__I  uint32_t*)0x40003420U) /**< (AC) Synchronization Busy */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for AC peripheral ========== */
+#define AC_GCLK_ID                               17         /* Index of Generic Clock */
+#define AC_NUM_CMP                               2          /* Number of comparators */
+#define AC_PAIRS                                 1          /* Number of pairs of comparators */
+#define AC_INSTANCE_ID                           13         
+
+#endif /* _SAML11_AC_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/instance/adc.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/instance/adc.h
@@ -1,0 +1,95 @@
+/**
+ * \file
+ *
+ * \brief Instance description for ADC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_ADC_INSTANCE_H_
+#define _SAML11_ADC_INSTANCE_H_
+
+/* ========== Register definition for ADC peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_ADC_CTRLA           (0x42001C00) /**< (ADC) Control A */
+#define REG_ADC_CTRLB           (0x42001C01) /**< (ADC) Control B */
+#define REG_ADC_REFCTRL         (0x42001C02) /**< (ADC) Reference Control */
+#define REG_ADC_EVCTRL          (0x42001C03) /**< (ADC) Event Control */
+#define REG_ADC_INTENCLR        (0x42001C04) /**< (ADC) Interrupt Enable Clear */
+#define REG_ADC_INTENSET        (0x42001C05) /**< (ADC) Interrupt Enable Set */
+#define REG_ADC_INTFLAG         (0x42001C06) /**< (ADC) Interrupt Flag Status and Clear */
+#define REG_ADC_SEQSTATUS       (0x42001C07) /**< (ADC) Sequence Status */
+#define REG_ADC_INPUTCTRL       (0x42001C08) /**< (ADC) Input Control */
+#define REG_ADC_CTRLC           (0x42001C0A) /**< (ADC) Control C */
+#define REG_ADC_AVGCTRL         (0x42001C0C) /**< (ADC) Average Control */
+#define REG_ADC_SAMPCTRL        (0x42001C0D) /**< (ADC) Sample Time Control */
+#define REG_ADC_WINLT           (0x42001C0E) /**< (ADC) Window Monitor Lower Threshold */
+#define REG_ADC_WINUT           (0x42001C10) /**< (ADC) Window Monitor Upper Threshold */
+#define REG_ADC_GAINCORR        (0x42001C12) /**< (ADC) Gain Correction */
+#define REG_ADC_OFFSETCORR      (0x42001C14) /**< (ADC) Offset Correction */
+#define REG_ADC_SWTRIG          (0x42001C18) /**< (ADC) Software Trigger */
+#define REG_ADC_DBGCTRL         (0x42001C1C) /**< (ADC) Debug Control */
+#define REG_ADC_SYNCBUSY        (0x42001C20) /**< (ADC) Synchronization Busy */
+#define REG_ADC_RESULT          (0x42001C24) /**< (ADC) Result */
+#define REG_ADC_SEQCTRL         (0x42001C28) /**< (ADC) Sequence Control */
+#define REG_ADC_CALIB           (0x42001C2C) /**< (ADC) Calibration */
+
+#else
+
+#define REG_ADC_CTRLA           (*(__IO uint8_t*)0x42001C00U) /**< (ADC) Control A */
+#define REG_ADC_CTRLB           (*(__IO uint8_t*)0x42001C01U) /**< (ADC) Control B */
+#define REG_ADC_REFCTRL         (*(__IO uint8_t*)0x42001C02U) /**< (ADC) Reference Control */
+#define REG_ADC_EVCTRL          (*(__IO uint8_t*)0x42001C03U) /**< (ADC) Event Control */
+#define REG_ADC_INTENCLR        (*(__IO uint8_t*)0x42001C04U) /**< (ADC) Interrupt Enable Clear */
+#define REG_ADC_INTENSET        (*(__IO uint8_t*)0x42001C05U) /**< (ADC) Interrupt Enable Set */
+#define REG_ADC_INTFLAG         (*(__IO uint8_t*)0x42001C06U) /**< (ADC) Interrupt Flag Status and Clear */
+#define REG_ADC_SEQSTATUS       (*(__I  uint8_t*)0x42001C07U) /**< (ADC) Sequence Status */
+#define REG_ADC_INPUTCTRL       (*(__IO uint16_t*)0x42001C08U) /**< (ADC) Input Control */
+#define REG_ADC_CTRLC           (*(__IO uint16_t*)0x42001C0AU) /**< (ADC) Control C */
+#define REG_ADC_AVGCTRL         (*(__IO uint8_t*)0x42001C0CU) /**< (ADC) Average Control */
+#define REG_ADC_SAMPCTRL        (*(__IO uint8_t*)0x42001C0DU) /**< (ADC) Sample Time Control */
+#define REG_ADC_WINLT           (*(__IO uint16_t*)0x42001C0EU) /**< (ADC) Window Monitor Lower Threshold */
+#define REG_ADC_WINUT           (*(__IO uint16_t*)0x42001C10U) /**< (ADC) Window Monitor Upper Threshold */
+#define REG_ADC_GAINCORR        (*(__IO uint16_t*)0x42001C12U) /**< (ADC) Gain Correction */
+#define REG_ADC_OFFSETCORR      (*(__IO uint16_t*)0x42001C14U) /**< (ADC) Offset Correction */
+#define REG_ADC_SWTRIG          (*(__IO uint8_t*)0x42001C18U) /**< (ADC) Software Trigger */
+#define REG_ADC_DBGCTRL         (*(__IO uint8_t*)0x42001C1CU) /**< (ADC) Debug Control */
+#define REG_ADC_SYNCBUSY        (*(__I  uint16_t*)0x42001C20U) /**< (ADC) Synchronization Busy */
+#define REG_ADC_RESULT          (*(__I  uint16_t*)0x42001C24U) /**< (ADC) Result */
+#define REG_ADC_SEQCTRL         (*(__IO uint32_t*)0x42001C28U) /**< (ADC) Sequence Control */
+#define REG_ADC_CALIB           (*(__IO uint16_t*)0x42001C2CU) /**< (ADC) Calibration */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for ADC peripheral ========== */
+#define ADC_DMAC_ID_RESRDY                       19         /* index of DMA RESRDY trigger */
+#define ADC_EXTCHANNEL_MSB                       9          /* Number of external channels */
+#define ADC_GCLK_ID                              16         /* index of Generic Clock */
+#define ADC_INT_CH30                             1          /* Select OPAMP or CTAT on Channel 30 */
+#define ADC_MASTER_SLAVE_MODE                    0          /* ADC Master/Slave Mode */
+#define ADC_INSTANCE_ID                          71         
+
+#endif /* _SAML11_ADC_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/instance/ccl.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/instance/ccl.h
@@ -1,0 +1,61 @@
+/**
+ * \file
+ *
+ * \brief Instance description for CCL
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_CCL_INSTANCE_H_
+#define _SAML11_CCL_INSTANCE_H_
+
+/* ========== Register definition for CCL peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_CCL_CTRL            (0x42002C00) /**< (CCL) Control */
+#define REG_CCL_SEQCTRL         (0x42002C04) /**< (CCL) SEQ Control x */
+#define REG_CCL_SEQCTRL0        (0x42002C04) /**< (CCL) SEQ Control x 0 */
+#define REG_CCL_LUTCTRL         (0x42002C08) /**< (CCL) LUT Control x */
+#define REG_CCL_LUTCTRL0        (0x42002C08) /**< (CCL) LUT Control x 0 */
+#define REG_CCL_LUTCTRL1        (0x42002C0C) /**< (CCL) LUT Control x 1 */
+
+#else
+
+#define REG_CCL_CTRL            (*(__IO uint8_t*)0x42002C00U) /**< (CCL) Control */
+#define REG_CCL_SEQCTRL         (*(__IO uint8_t*)0x42002C04U) /**< (CCL) SEQ Control x */
+#define REG_CCL_SEQCTRL0        (*(__IO uint8_t*)0x42002C04U) /**< (CCL) SEQ Control x 0 */
+#define REG_CCL_LUTCTRL         (*(__IO uint32_t*)0x42002C08U) /**< (CCL) LUT Control x */
+#define REG_CCL_LUTCTRL0        (*(__IO uint32_t*)0x42002C08U) /**< (CCL) LUT Control x 0 */
+#define REG_CCL_LUTCTRL1        (*(__IO uint32_t*)0x42002C0CU) /**< (CCL) LUT Control x 1 */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for CCL peripheral ========== */
+#define CCL_GCLK_ID                              20         /* GCLK index for CCL */
+#define CCL_LUT_NUM                              2          /* Number of LUT in a CCL */
+#define CCL_SEQ_NUM                              1          /* Number of SEQ in a CCL */
+#define CCL_INSTANCE_ID                          75         
+
+#endif /* _SAML11_CCL_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/instance/dac.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/instance/dac.h
@@ -1,0 +1,70 @@
+/**
+ * \file
+ *
+ * \brief Instance description for DAC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_DAC_INSTANCE_H_
+#define _SAML11_DAC_INSTANCE_H_
+
+/* ========== Register definition for DAC peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_DAC_CTRLA           (0x42002000) /**< (DAC) Control A */
+#define REG_DAC_CTRLB           (0x42002001) /**< (DAC) Control B */
+#define REG_DAC_EVCTRL          (0x42002002) /**< (DAC) Event Control */
+#define REG_DAC_INTENCLR        (0x42002004) /**< (DAC) Interrupt Enable Clear */
+#define REG_DAC_INTENSET        (0x42002005) /**< (DAC) Interrupt Enable Set */
+#define REG_DAC_INTFLAG         (0x42002006) /**< (DAC) Interrupt Flag Status and Clear */
+#define REG_DAC_STATUS          (0x42002007) /**< (DAC) Status */
+#define REG_DAC_DATA            (0x42002008) /**< (DAC) Data */
+#define REG_DAC_DATABUF         (0x4200200C) /**< (DAC) Data Buffer */
+#define REG_DAC_SYNCBUSY        (0x42002010) /**< (DAC) Synchronization Busy */
+#define REG_DAC_DBGCTRL         (0x42002014) /**< (DAC) Debug Control */
+
+#else
+
+#define REG_DAC_CTRLA           (*(__IO uint8_t*)0x42002000U) /**< (DAC) Control A */
+#define REG_DAC_CTRLB           (*(__IO uint8_t*)0x42002001U) /**< (DAC) Control B */
+#define REG_DAC_EVCTRL          (*(__IO uint8_t*)0x42002002U) /**< (DAC) Event Control */
+#define REG_DAC_INTENCLR        (*(__IO uint8_t*)0x42002004U) /**< (DAC) Interrupt Enable Clear */
+#define REG_DAC_INTENSET        (*(__IO uint8_t*)0x42002005U) /**< (DAC) Interrupt Enable Set */
+#define REG_DAC_INTFLAG         (*(__IO uint8_t*)0x42002006U) /**< (DAC) Interrupt Flag Status and Clear */
+#define REG_DAC_STATUS          (*(__I  uint8_t*)0x42002007U) /**< (DAC) Status */
+#define REG_DAC_DATA            (*(__O  uint16_t*)0x42002008U) /**< (DAC) Data */
+#define REG_DAC_DATABUF         (*(__O  uint16_t*)0x4200200CU) /**< (DAC) Data Buffer */
+#define REG_DAC_SYNCBUSY        (*(__I  uint32_t*)0x42002010U) /**< (DAC) Synchronization Busy */
+#define REG_DAC_DBGCTRL         (*(__IO uint8_t*)0x42002014U) /**< (DAC) Debug Control */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for DAC peripheral ========== */
+#define DAC_DMAC_ID_EMPTY                        20         /* Index of DMA EMPTY trigger */
+#define DAC_GCLK_ID                              18         
+#define DAC_INSTANCE_ID                          72         
+
+#endif /* _SAML11_DAC_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/instance/dmac.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/instance/dmac.h
@@ -1,0 +1,103 @@
+/**
+ * \file
+ *
+ * \brief Instance description for DMAC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_DMAC_INSTANCE_H_
+#define _SAML11_DMAC_INSTANCE_H_
+
+/* ========== Register definition for DMAC peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_DMAC_CTRL           (0x41006000) /**< (DMAC) Control */
+#define REG_DMAC_CRCCTRL        (0x41006002) /**< (DMAC) CRC Control */
+#define REG_DMAC_CRCDATAIN      (0x41006004) /**< (DMAC) CRC Data Input */
+#define REG_DMAC_CRCCHKSUM      (0x41006008) /**< (DMAC) CRC Checksum */
+#define REG_DMAC_CRCSTATUS      (0x4100600C) /**< (DMAC) CRC Status */
+#define REG_DMAC_DBGCTRL        (0x4100600D) /**< (DMAC) Debug Control */
+#define REG_DMAC_QOSCTRL        (0x4100600E) /**< (DMAC) QOS Control */
+#define REG_DMAC_SWTRIGCTRL     (0x41006010) /**< (DMAC) Software Trigger Control */
+#define REG_DMAC_PRICTRL0       (0x41006014) /**< (DMAC) Priority Control 0 */
+#define REG_DMAC_INTPEND        (0x41006020) /**< (DMAC) Interrupt Pending */
+#define REG_DMAC_INTSTATUS      (0x41006024) /**< (DMAC) Interrupt Status */
+#define REG_DMAC_BUSYCH         (0x41006028) /**< (DMAC) Busy Channels */
+#define REG_DMAC_PENDCH         (0x4100602C) /**< (DMAC) Pending Channels */
+#define REG_DMAC_ACTIVE         (0x41006030) /**< (DMAC) Active Channel and Levels */
+#define REG_DMAC_BASEADDR       (0x41006034) /**< (DMAC) Descriptor Memory Section Base Address */
+#define REG_DMAC_WRBADDR        (0x41006038) /**< (DMAC) Write-Back Memory Section Base Address */
+#define REG_DMAC_CHID           (0x4100603F) /**< (DMAC) Channel ID */
+#define REG_DMAC_CHCTRLA        (0x41006040) /**< (DMAC) Channel Control A */
+#define REG_DMAC_CHCTRLB        (0x41006044) /**< (DMAC) Channel Control B */
+#define REG_DMAC_CHINTENCLR     (0x4100604C) /**< (DMAC) Channel Interrupt Enable Clear */
+#define REG_DMAC_CHINTENSET     (0x4100604D) /**< (DMAC) Channel Interrupt Enable Set */
+#define REG_DMAC_CHINTFLAG      (0x4100604E) /**< (DMAC) Channel Interrupt Flag Status and Clear */
+#define REG_DMAC_CHSTATUS       (0x4100604F) /**< (DMAC) Channel Status */
+
+#else
+
+#define REG_DMAC_CTRL           (*(__IO uint16_t*)0x41006000U) /**< (DMAC) Control */
+#define REG_DMAC_CRCCTRL        (*(__IO uint16_t*)0x41006002U) /**< (DMAC) CRC Control */
+#define REG_DMAC_CRCDATAIN      (*(__IO uint32_t*)0x41006004U) /**< (DMAC) CRC Data Input */
+#define REG_DMAC_CRCCHKSUM      (*(__IO uint32_t*)0x41006008U) /**< (DMAC) CRC Checksum */
+#define REG_DMAC_CRCSTATUS      (*(__IO uint8_t*)0x4100600CU) /**< (DMAC) CRC Status */
+#define REG_DMAC_DBGCTRL        (*(__IO uint8_t*)0x4100600DU) /**< (DMAC) Debug Control */
+#define REG_DMAC_QOSCTRL        (*(__IO uint8_t*)0x4100600EU) /**< (DMAC) QOS Control */
+#define REG_DMAC_SWTRIGCTRL     (*(__IO uint32_t*)0x41006010U) /**< (DMAC) Software Trigger Control */
+#define REG_DMAC_PRICTRL0       (*(__IO uint32_t*)0x41006014U) /**< (DMAC) Priority Control 0 */
+#define REG_DMAC_INTPEND        (*(__IO uint16_t*)0x41006020U) /**< (DMAC) Interrupt Pending */
+#define REG_DMAC_INTSTATUS      (*(__I  uint32_t*)0x41006024U) /**< (DMAC) Interrupt Status */
+#define REG_DMAC_BUSYCH         (*(__I  uint32_t*)0x41006028U) /**< (DMAC) Busy Channels */
+#define REG_DMAC_PENDCH         (*(__I  uint32_t*)0x4100602CU) /**< (DMAC) Pending Channels */
+#define REG_DMAC_ACTIVE         (*(__I  uint32_t*)0x41006030U) /**< (DMAC) Active Channel and Levels */
+#define REG_DMAC_BASEADDR       (*(__IO uint32_t*)0x41006034U) /**< (DMAC) Descriptor Memory Section Base Address */
+#define REG_DMAC_WRBADDR        (*(__IO uint32_t*)0x41006038U) /**< (DMAC) Write-Back Memory Section Base Address */
+#define REG_DMAC_CHID           (*(__IO uint8_t*)0x4100603FU) /**< (DMAC) Channel ID */
+#define REG_DMAC_CHCTRLA        (*(__IO uint8_t*)0x41006040U) /**< (DMAC) Channel Control A */
+#define REG_DMAC_CHCTRLB        (*(__IO uint32_t*)0x41006044U) /**< (DMAC) Channel Control B */
+#define REG_DMAC_CHINTENCLR     (*(__IO uint8_t*)0x4100604CU) /**< (DMAC) Channel Interrupt Enable Clear */
+#define REG_DMAC_CHINTENSET     (*(__IO uint8_t*)0x4100604DU) /**< (DMAC) Channel Interrupt Enable Set */
+#define REG_DMAC_CHINTFLAG      (*(__IO uint8_t*)0x4100604EU) /**< (DMAC) Channel Interrupt Flag Status and Clear */
+#define REG_DMAC_CHSTATUS       (*(__I  uint8_t*)0x4100604FU) /**< (DMAC) Channel Status */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for DMAC peripheral ========== */
+#define DMAC_CH_BITS                             3          /* Number of bits to select channel */
+#define DMAC_CH_NUM                              8          /* Number of channels */
+#define DMAC_EVIN_NUM                            4          /* Number of input events */
+#define DMAC_EVOUT_NUM                           4          /* Number of output events */
+#define DMAC_LVL_BITS                            2          /* Number of bit to select level priority */
+#define DMAC_LVL_NUM                             4          /* Enable priority level number */
+#define DMAC_QOSCTRL_D_RESETVALUE                2          /* QOS dmac ahb interface reset value */
+#define DMAC_QOSCTRL_F_RESETVALUE                2          /* QOS dmac fetch interface reset value */
+#define DMAC_QOSCTRL_WRB_RESETVALUE              2          /* QOS dmac write back interface reset value */
+#define DMAC_TRIG_BITS                           5          /* Number of bits to select trigger source */
+#define DMAC_TRIG_NUM                            24         /* Number of peripheral triggers */
+#define DMAC_INSTANCE_ID                         35         
+
+#endif /* _SAML11_DMAC_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/instance/dsu.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/instance/dsu.h
@@ -1,0 +1,116 @@
+/**
+ * \file
+ *
+ * \brief Instance description for DSU
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_DSU_INSTANCE_H_
+#define _SAML11_DSU_INSTANCE_H_
+
+/* ========== Register definition for DSU peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_DSU_CTRL            (0x41002000) /**< (DSU) Control */
+#define REG_DSU_STATUSA         (0x41002001) /**< (DSU) Status A */
+#define REG_DSU_STATUSB         (0x41002002) /**< (DSU) Status B */
+#define REG_DSU_STATUSC         (0x41002003) /**< (DSU) Status C */
+#define REG_DSU_ADDR            (0x41002004) /**< (DSU) Address */
+#define REG_DSU_LENGTH          (0x41002008) /**< (DSU) Length */
+#define REG_DSU_DATA            (0x4100200C) /**< (DSU) Data */
+#define REG_DSU_DCC             (0x41002010) /**< (DSU) Debug Communication Channel n */
+#define REG_DSU_DCC0            (0x41002010) /**< (DSU) Debug Communication Channel 0 */
+#define REG_DSU_DCC1            (0x41002014) /**< (DSU) Debug Communication Channel 1 */
+#define REG_DSU_DID             (0x41002018) /**< (DSU) Device Identification */
+#define REG_DSU_CFG             (0x4100201C) /**< (DSU) Configuration */
+#define REG_DSU_BCC             (0x41002020) /**< (DSU) Boot ROM Communication Channel n */
+#define REG_DSU_BCC0            (0x41002020) /**< (DSU) Boot ROM Communication Channel 0 */
+#define REG_DSU_BCC1            (0x41002024) /**< (DSU) Boot ROM Communication Channel 1 */
+#define REG_DSU_DCFG            (0x410020F0) /**< (DSU) Device Configuration */
+#define REG_DSU_DCFG0           (0x410020F0) /**< (DSU) Device Configuration 0 */
+#define REG_DSU_DCFG1           (0x410020F4) /**< (DSU) Device Configuration 1 */
+#define REG_DSU_ENTRY0          (0x41003000) /**< (DSU) CoreSight ROM Table Entry 0 */
+#define REG_DSU_ENTRY1          (0x41003004) /**< (DSU) CoreSight ROM Table Entry 1 */
+#define REG_DSU_END             (0x41003008) /**< (DSU) CoreSight ROM Table End */
+#define REG_DSU_MEMTYPE         (0x41003FCC) /**< (DSU) CoreSight ROM Table Memory Type */
+#define REG_DSU_PID4            (0x41003FD0) /**< (DSU) Peripheral Identification 4 */
+#define REG_DSU_PID5            (0x41003FD4) /**< (DSU) Peripheral Identification 5 */
+#define REG_DSU_PID6            (0x41003FD8) /**< (DSU) Peripheral Identification 6 */
+#define REG_DSU_PID7            (0x41003FDC) /**< (DSU) Peripheral Identification 7 */
+#define REG_DSU_PID0            (0x41003FE0) /**< (DSU) Peripheral Identification 0 */
+#define REG_DSU_PID1            (0x41003FE4) /**< (DSU) Peripheral Identification 1 */
+#define REG_DSU_PID2            (0x41003FE8) /**< (DSU) Peripheral Identification 2 */
+#define REG_DSU_PID3            (0x41003FEC) /**< (DSU) Peripheral Identification 3 */
+#define REG_DSU_CID0            (0x41003FF0) /**< (DSU) Component Identification 0 */
+#define REG_DSU_CID1            (0x41003FF4) /**< (DSU) Component Identification 1 */
+#define REG_DSU_CID2            (0x41003FF8) /**< (DSU) Component Identification 2 */
+#define REG_DSU_CID3            (0x41003FFC) /**< (DSU) Component Identification 3 */
+
+#else
+
+#define REG_DSU_CTRL            (*(__O  uint8_t*)0x41002000U) /**< (DSU) Control */
+#define REG_DSU_STATUSA         (*(__IO uint8_t*)0x41002001U) /**< (DSU) Status A */
+#define REG_DSU_STATUSB         (*(__I  uint8_t*)0x41002002U) /**< (DSU) Status B */
+#define REG_DSU_STATUSC         (*(__I  uint8_t*)0x41002003U) /**< (DSU) Status C */
+#define REG_DSU_ADDR            (*(__IO uint32_t*)0x41002004U) /**< (DSU) Address */
+#define REG_DSU_LENGTH          (*(__IO uint32_t*)0x41002008U) /**< (DSU) Length */
+#define REG_DSU_DATA            (*(__IO uint32_t*)0x4100200CU) /**< (DSU) Data */
+#define REG_DSU_DCC             (*(__IO uint32_t*)0x41002010U) /**< (DSU) Debug Communication Channel n */
+#define REG_DSU_DCC0            (*(__IO uint32_t*)0x41002010U) /**< (DSU) Debug Communication Channel 0 */
+#define REG_DSU_DCC1            (*(__IO uint32_t*)0x41002014U) /**< (DSU) Debug Communication Channel 1 */
+#define REG_DSU_DID             (*(__I  uint32_t*)0x41002018U) /**< (DSU) Device Identification */
+#define REG_DSU_CFG             (*(__IO uint32_t*)0x4100201CU) /**< (DSU) Configuration */
+#define REG_DSU_BCC             (*(__IO uint32_t*)0x41002020U) /**< (DSU) Boot ROM Communication Channel n */
+#define REG_DSU_BCC0            (*(__IO uint32_t*)0x41002020U) /**< (DSU) Boot ROM Communication Channel 0 */
+#define REG_DSU_BCC1            (*(__IO uint32_t*)0x41002024U) /**< (DSU) Boot ROM Communication Channel 1 */
+#define REG_DSU_DCFG            (*(__IO uint32_t*)0x410020F0U) /**< (DSU) Device Configuration */
+#define REG_DSU_DCFG0           (*(__IO uint32_t*)0x410020F0U) /**< (DSU) Device Configuration 0 */
+#define REG_DSU_DCFG1           (*(__IO uint32_t*)0x410020F4U) /**< (DSU) Device Configuration 1 */
+#define REG_DSU_ENTRY0          (*(__I  uint32_t*)0x41003000U) /**< (DSU) CoreSight ROM Table Entry 0 */
+#define REG_DSU_ENTRY1          (*(__I  uint32_t*)0x41003004U) /**< (DSU) CoreSight ROM Table Entry 1 */
+#define REG_DSU_END             (*(__I  uint32_t*)0x41003008U) /**< (DSU) CoreSight ROM Table End */
+#define REG_DSU_MEMTYPE         (*(__I  uint32_t*)0x41003FCCU) /**< (DSU) CoreSight ROM Table Memory Type */
+#define REG_DSU_PID4            (*(__I  uint32_t*)0x41003FD0U) /**< (DSU) Peripheral Identification 4 */
+#define REG_DSU_PID5            (*(__I  uint32_t*)0x41003FD4U) /**< (DSU) Peripheral Identification 5 */
+#define REG_DSU_PID6            (*(__I  uint32_t*)0x41003FD8U) /**< (DSU) Peripheral Identification 6 */
+#define REG_DSU_PID7            (*(__I  uint32_t*)0x41003FDCU) /**< (DSU) Peripheral Identification 7 */
+#define REG_DSU_PID0            (*(__I  uint32_t*)0x41003FE0U) /**< (DSU) Peripheral Identification 0 */
+#define REG_DSU_PID1            (*(__I  uint32_t*)0x41003FE4U) /**< (DSU) Peripheral Identification 1 */
+#define REG_DSU_PID2            (*(__I  uint32_t*)0x41003FE8U) /**< (DSU) Peripheral Identification 2 */
+#define REG_DSU_PID3            (*(__I  uint32_t*)0x41003FECU) /**< (DSU) Peripheral Identification 3 */
+#define REG_DSU_CID0            (*(__I  uint32_t*)0x41003FF0U) /**< (DSU) Component Identification 0 */
+#define REG_DSU_CID1            (*(__I  uint32_t*)0x41003FF4U) /**< (DSU) Component Identification 1 */
+#define REG_DSU_CID2            (*(__I  uint32_t*)0x41003FF8U) /**< (DSU) Component Identification 2 */
+#define REG_DSU_CID3            (*(__I  uint32_t*)0x41003FFCU) /**< (DSU) Component Identification 3 */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for DSU peripheral ========== */
+#define DSU_DMAC_ID_DCC0                         2          /* DMAC ID for DCC0 register */
+#define DSU_DMAC_ID_DCC1                         3          /* DMAC ID for DCC1 register */
+#define DSU_INSTANCE_ID                          33         
+
+#endif /* _SAML11_DSU_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/instance/eic.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/instance/eic.h
@@ -1,0 +1,84 @@
+/**
+ * \file
+ *
+ * \brief Instance description for EIC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_EIC_INSTANCE_H_
+#define _SAML11_EIC_INSTANCE_H_
+
+/* ========== Register definition for EIC peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_EIC_CTRLA           (0x40002800) /**< (EIC) Control A */
+#define REG_EIC_NMICTRL         (0x40002801) /**< (EIC) Non-Maskable Interrupt Control */
+#define REG_EIC_NMIFLAG         (0x40002802) /**< (EIC) Non-Maskable Interrupt Flag Status and Clear */
+#define REG_EIC_SYNCBUSY        (0x40002804) /**< (EIC) Synchronization Busy */
+#define REG_EIC_EVCTRL          (0x40002808) /**< (EIC) Event Control */
+#define REG_EIC_INTENCLR        (0x4000280C) /**< (EIC) Interrupt Enable Clear */
+#define REG_EIC_INTENSET        (0x40002810) /**< (EIC) Interrupt Enable Set */
+#define REG_EIC_INTFLAG         (0x40002814) /**< (EIC) Interrupt Flag Status and Clear */
+#define REG_EIC_ASYNCH          (0x40002818) /**< (EIC) External Interrupt Asynchronous Mode */
+#define REG_EIC_CONFIG          (0x4000281C) /**< (EIC) External Interrupt Sense Configuration */
+#define REG_EIC_CONFIG0         (0x4000281C) /**< (EIC) External Interrupt Sense Configuration 0 */
+#define REG_EIC_DEBOUNCEN       (0x40002830) /**< (EIC) Debouncer Enable */
+#define REG_EIC_DPRESCALER      (0x40002834) /**< (EIC) Debouncer Prescaler */
+#define REG_EIC_PINSTATE        (0x40002838) /**< (EIC) Pin State */
+#define REG_EIC_NSCHK           (0x4000283C) /**< (EIC) Non-secure Interrupt Check Enable */
+#define REG_EIC_NONSEC          (0x40002840) /**< (EIC) Non-secure Interrupt */
+
+#else
+
+#define REG_EIC_CTRLA           (*(__IO uint8_t*)0x40002800U) /**< (EIC) Control A */
+#define REG_EIC_NMICTRL         (*(__IO uint8_t*)0x40002801U) /**< (EIC) Non-Maskable Interrupt Control */
+#define REG_EIC_NMIFLAG         (*(__IO uint16_t*)0x40002802U) /**< (EIC) Non-Maskable Interrupt Flag Status and Clear */
+#define REG_EIC_SYNCBUSY        (*(__I  uint32_t*)0x40002804U) /**< (EIC) Synchronization Busy */
+#define REG_EIC_EVCTRL          (*(__IO uint32_t*)0x40002808U) /**< (EIC) Event Control */
+#define REG_EIC_INTENCLR        (*(__IO uint32_t*)0x4000280CU) /**< (EIC) Interrupt Enable Clear */
+#define REG_EIC_INTENSET        (*(__IO uint32_t*)0x40002810U) /**< (EIC) Interrupt Enable Set */
+#define REG_EIC_INTFLAG         (*(__IO uint32_t*)0x40002814U) /**< (EIC) Interrupt Flag Status and Clear */
+#define REG_EIC_ASYNCH          (*(__IO uint32_t*)0x40002818U) /**< (EIC) External Interrupt Asynchronous Mode */
+#define REG_EIC_CONFIG          (*(__IO uint32_t*)0x4000281CU) /**< (EIC) External Interrupt Sense Configuration */
+#define REG_EIC_CONFIG0         (*(__IO uint32_t*)0x4000281CU) /**< (EIC) External Interrupt Sense Configuration 0 */
+#define REG_EIC_DEBOUNCEN       (*(__IO uint32_t*)0x40002830U) /**< (EIC) Debouncer Enable */
+#define REG_EIC_DPRESCALER      (*(__IO uint32_t*)0x40002834U) /**< (EIC) Debouncer Prescaler */
+#define REG_EIC_PINSTATE        (*(__I  uint32_t*)0x40002838U) /**< (EIC) Pin State */
+#define REG_EIC_NSCHK           (*(__IO uint32_t*)0x4000283CU) /**< (EIC) Non-secure Interrupt Check Enable */
+#define REG_EIC_NONSEC          (*(__IO uint32_t*)0x40002840U) /**< (EIC) Non-secure Interrupt */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for EIC peripheral ========== */
+#define EIC_EXTINT_NUM                           8          /* Number of external interrupts */
+#define EIC_GCLK_ID                              3          /* Generic Clock index */
+#define EIC_NUMBER_OF_CONFIG_REGS                1          /* Number of CONFIG registers */
+#define EIC_NUMBER_OF_DPRESCALER_REGS            1          /* Number of DPRESCALER registers */
+#define EIC_NUMBER_OF_INTERRUPTS                 8          /* Number of external interrupts (obsolete) */
+#define EIC_SECURE_IMPLEMENTED                   1          /* Security Configuration implemented? */
+#define EIC_INSTANCE_ID                          10         
+
+#endif /* _SAML11_EIC_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/instance/evsys.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/instance/evsys.h
@@ -1,0 +1,221 @@
+/**
+ * \file
+ *
+ * \brief Instance description for EVSYS
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_EVSYS_INSTANCE_H_
+#define _SAML11_EVSYS_INSTANCE_H_
+
+/* ========== Register definition for EVSYS peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_EVSYS_CHANNEL0      (0x42000020) /**< (EVSYS) Channel 0 Control */
+#define REG_EVSYS_CHINTENCLR0   (0x42000024) /**< (EVSYS) Channel 0 Interrupt Enable Clear */
+#define REG_EVSYS_CHINTENSET0   (0x42000025) /**< (EVSYS) Channel 0 Interrupt Enable Set */
+#define REG_EVSYS_CHINTFLAG0    (0x42000026) /**< (EVSYS) Channel 0 Interrupt Flag Status and Clear */
+#define REG_EVSYS_CHSTATUS0     (0x42000027) /**< (EVSYS) Channel 0 Status */
+#define REG_EVSYS_CHANNEL1      (0x42000028) /**< (EVSYS) Channel 1 Control */
+#define REG_EVSYS_CHINTENCLR1   (0x4200002C) /**< (EVSYS) Channel 1 Interrupt Enable Clear */
+#define REG_EVSYS_CHINTENSET1   (0x4200002D) /**< (EVSYS) Channel 1 Interrupt Enable Set */
+#define REG_EVSYS_CHINTFLAG1    (0x4200002E) /**< (EVSYS) Channel 1 Interrupt Flag Status and Clear */
+#define REG_EVSYS_CHSTATUS1     (0x4200002F) /**< (EVSYS) Channel 1 Status */
+#define REG_EVSYS_CHANNEL2      (0x42000030) /**< (EVSYS) Channel 2 Control */
+#define REG_EVSYS_CHINTENCLR2   (0x42000034) /**< (EVSYS) Channel 2 Interrupt Enable Clear */
+#define REG_EVSYS_CHINTENSET2   (0x42000035) /**< (EVSYS) Channel 2 Interrupt Enable Set */
+#define REG_EVSYS_CHINTFLAG2    (0x42000036) /**< (EVSYS) Channel 2 Interrupt Flag Status and Clear */
+#define REG_EVSYS_CHSTATUS2     (0x42000037) /**< (EVSYS) Channel 2 Status */
+#define REG_EVSYS_CHANNEL3      (0x42000038) /**< (EVSYS) Channel 3 Control */
+#define REG_EVSYS_CHINTENCLR3   (0x4200003C) /**< (EVSYS) Channel 3 Interrupt Enable Clear */
+#define REG_EVSYS_CHINTENSET3   (0x4200003D) /**< (EVSYS) Channel 3 Interrupt Enable Set */
+#define REG_EVSYS_CHINTFLAG3    (0x4200003E) /**< (EVSYS) Channel 3 Interrupt Flag Status and Clear */
+#define REG_EVSYS_CHSTATUS3     (0x4200003F) /**< (EVSYS) Channel 3 Status */
+#define REG_EVSYS_CHANNEL4      (0x42000040) /**< (EVSYS) Channel 4 Control */
+#define REG_EVSYS_CHINTENCLR4   (0x42000044) /**< (EVSYS) Channel 4 Interrupt Enable Clear */
+#define REG_EVSYS_CHINTENSET4   (0x42000045) /**< (EVSYS) Channel 4 Interrupt Enable Set */
+#define REG_EVSYS_CHINTFLAG4    (0x42000046) /**< (EVSYS) Channel 4 Interrupt Flag Status and Clear */
+#define REG_EVSYS_CHSTATUS4     (0x42000047) /**< (EVSYS) Channel 4 Status */
+#define REG_EVSYS_CHANNEL5      (0x42000048) /**< (EVSYS) Channel 5 Control */
+#define REG_EVSYS_CHINTENCLR5   (0x4200004C) /**< (EVSYS) Channel 5 Interrupt Enable Clear */
+#define REG_EVSYS_CHINTENSET5   (0x4200004D) /**< (EVSYS) Channel 5 Interrupt Enable Set */
+#define REG_EVSYS_CHINTFLAG5    (0x4200004E) /**< (EVSYS) Channel 5 Interrupt Flag Status and Clear */
+#define REG_EVSYS_CHSTATUS5     (0x4200004F) /**< (EVSYS) Channel 5 Status */
+#define REG_EVSYS_CHANNEL6      (0x42000050) /**< (EVSYS) Channel 6 Control */
+#define REG_EVSYS_CHINTENCLR6   (0x42000054) /**< (EVSYS) Channel 6 Interrupt Enable Clear */
+#define REG_EVSYS_CHINTENSET6   (0x42000055) /**< (EVSYS) Channel 6 Interrupt Enable Set */
+#define REG_EVSYS_CHINTFLAG6    (0x42000056) /**< (EVSYS) Channel 6 Interrupt Flag Status and Clear */
+#define REG_EVSYS_CHSTATUS6     (0x42000057) /**< (EVSYS) Channel 6 Status */
+#define REG_EVSYS_CHANNEL7      (0x42000058) /**< (EVSYS) Channel 7 Control */
+#define REG_EVSYS_CHINTENCLR7   (0x4200005C) /**< (EVSYS) Channel 7 Interrupt Enable Clear */
+#define REG_EVSYS_CHINTENSET7   (0x4200005D) /**< (EVSYS) Channel 7 Interrupt Enable Set */
+#define REG_EVSYS_CHINTFLAG7    (0x4200005E) /**< (EVSYS) Channel 7 Interrupt Flag Status and Clear */
+#define REG_EVSYS_CHSTATUS7     (0x4200005F) /**< (EVSYS) Channel 7 Status */
+#define REG_EVSYS_CTRLA         (0x42000000) /**< (EVSYS) Control */
+#define REG_EVSYS_SWEVT         (0x42000004) /**< (EVSYS) Software Event */
+#define REG_EVSYS_PRICTRL       (0x42000008) /**< (EVSYS) Priority Control */
+#define REG_EVSYS_INTPEND       (0x42000010) /**< (EVSYS) Channel Pending Interrupt */
+#define REG_EVSYS_INTSTATUS     (0x42000014) /**< (EVSYS) Interrupt Status */
+#define REG_EVSYS_BUSYCH        (0x42000018) /**< (EVSYS) Busy Channels */
+#define REG_EVSYS_READYUSR      (0x4200001C) /**< (EVSYS) Ready Users */
+#define REG_EVSYS_USER          (0x42000120) /**< (EVSYS) User Multiplexer n */
+#define REG_EVSYS_USER0         (0x42000120) /**< (EVSYS) User Multiplexer 0 */
+#define REG_EVSYS_USER1         (0x42000121) /**< (EVSYS) User Multiplexer 1 */
+#define REG_EVSYS_USER2         (0x42000122) /**< (EVSYS) User Multiplexer 2 */
+#define REG_EVSYS_USER3         (0x42000123) /**< (EVSYS) User Multiplexer 3 */
+#define REG_EVSYS_USER4         (0x42000124) /**< (EVSYS) User Multiplexer 4 */
+#define REG_EVSYS_USER5         (0x42000125) /**< (EVSYS) User Multiplexer 5 */
+#define REG_EVSYS_USER6         (0x42000126) /**< (EVSYS) User Multiplexer 6 */
+#define REG_EVSYS_USER7         (0x42000127) /**< (EVSYS) User Multiplexer 7 */
+#define REG_EVSYS_USER8         (0x42000128) /**< (EVSYS) User Multiplexer 8 */
+#define REG_EVSYS_USER9         (0x42000129) /**< (EVSYS) User Multiplexer 9 */
+#define REG_EVSYS_USER10        (0x4200012A) /**< (EVSYS) User Multiplexer 10 */
+#define REG_EVSYS_USER11        (0x4200012B) /**< (EVSYS) User Multiplexer 11 */
+#define REG_EVSYS_USER12        (0x4200012C) /**< (EVSYS) User Multiplexer 12 */
+#define REG_EVSYS_USER13        (0x4200012D) /**< (EVSYS) User Multiplexer 13 */
+#define REG_EVSYS_USER14        (0x4200012E) /**< (EVSYS) User Multiplexer 14 */
+#define REG_EVSYS_USER15        (0x4200012F) /**< (EVSYS) User Multiplexer 15 */
+#define REG_EVSYS_USER16        (0x42000130) /**< (EVSYS) User Multiplexer 16 */
+#define REG_EVSYS_USER17        (0x42000131) /**< (EVSYS) User Multiplexer 17 */
+#define REG_EVSYS_USER18        (0x42000132) /**< (EVSYS) User Multiplexer 18 */
+#define REG_EVSYS_USER19        (0x42000133) /**< (EVSYS) User Multiplexer 19 */
+#define REG_EVSYS_USER20        (0x42000134) /**< (EVSYS) User Multiplexer 20 */
+#define REG_EVSYS_USER21        (0x42000135) /**< (EVSYS) User Multiplexer 21 */
+#define REG_EVSYS_USER22        (0x42000136) /**< (EVSYS) User Multiplexer 22 */
+#define REG_EVSYS_INTENCLR      (0x420001D4) /**< (EVSYS) Interrupt Enable Clear */
+#define REG_EVSYS_INTENSET      (0x420001D5) /**< (EVSYS) Interrupt Enable Set */
+#define REG_EVSYS_INTFLAG       (0x420001D6) /**< (EVSYS) Interrupt Flag Status and Clear */
+#define REG_EVSYS_NONSECCHAN    (0x420001D8) /**< (EVSYS) Channels Security Attribution */
+#define REG_EVSYS_NSCHKCHAN     (0x420001DC) /**< (EVSYS) Non-Secure Channels Check */
+#define REG_EVSYS_NONSECUSER    (0x420001E0) /**< (EVSYS) Users Security Attribution */
+#define REG_EVSYS_NONSECUSER0   (0x420001E0) /**< (EVSYS) Users Security Attribution 0 */
+#define REG_EVSYS_NSCHKUSER     (0x420001F0) /**< (EVSYS) Non-Secure Users Check */
+#define REG_EVSYS_NSCHKUSER0    (0x420001F0) /**< (EVSYS) Non-Secure Users Check 0 */
+
+#else
+
+#define REG_EVSYS_CHANNEL0      (*(__IO uint32_t*)0x42000020U) /**< (EVSYS) Channel 0 Control */
+#define REG_EVSYS_CHINTENCLR0   (*(__IO uint8_t*)0x42000024U) /**< (EVSYS) Channel 0 Interrupt Enable Clear */
+#define REG_EVSYS_CHINTENSET0   (*(__IO uint8_t*)0x42000025U) /**< (EVSYS) Channel 0 Interrupt Enable Set */
+#define REG_EVSYS_CHINTFLAG0    (*(__IO uint8_t*)0x42000026U) /**< (EVSYS) Channel 0 Interrupt Flag Status and Clear */
+#define REG_EVSYS_CHSTATUS0     (*(__I  uint8_t*)0x42000027U) /**< (EVSYS) Channel 0 Status */
+#define REG_EVSYS_CHANNEL1      (*(__IO uint32_t*)0x42000028U) /**< (EVSYS) Channel 1 Control */
+#define REG_EVSYS_CHINTENCLR1   (*(__IO uint8_t*)0x4200002CU) /**< (EVSYS) Channel 1 Interrupt Enable Clear */
+#define REG_EVSYS_CHINTENSET1   (*(__IO uint8_t*)0x4200002DU) /**< (EVSYS) Channel 1 Interrupt Enable Set */
+#define REG_EVSYS_CHINTFLAG1    (*(__IO uint8_t*)0x4200002EU) /**< (EVSYS) Channel 1 Interrupt Flag Status and Clear */
+#define REG_EVSYS_CHSTATUS1     (*(__I  uint8_t*)0x4200002FU) /**< (EVSYS) Channel 1 Status */
+#define REG_EVSYS_CHANNEL2      (*(__IO uint32_t*)0x42000030U) /**< (EVSYS) Channel 2 Control */
+#define REG_EVSYS_CHINTENCLR2   (*(__IO uint8_t*)0x42000034U) /**< (EVSYS) Channel 2 Interrupt Enable Clear */
+#define REG_EVSYS_CHINTENSET2   (*(__IO uint8_t*)0x42000035U) /**< (EVSYS) Channel 2 Interrupt Enable Set */
+#define REG_EVSYS_CHINTFLAG2    (*(__IO uint8_t*)0x42000036U) /**< (EVSYS) Channel 2 Interrupt Flag Status and Clear */
+#define REG_EVSYS_CHSTATUS2     (*(__I  uint8_t*)0x42000037U) /**< (EVSYS) Channel 2 Status */
+#define REG_EVSYS_CHANNEL3      (*(__IO uint32_t*)0x42000038U) /**< (EVSYS) Channel 3 Control */
+#define REG_EVSYS_CHINTENCLR3   (*(__IO uint8_t*)0x4200003CU) /**< (EVSYS) Channel 3 Interrupt Enable Clear */
+#define REG_EVSYS_CHINTENSET3   (*(__IO uint8_t*)0x4200003DU) /**< (EVSYS) Channel 3 Interrupt Enable Set */
+#define REG_EVSYS_CHINTFLAG3    (*(__IO uint8_t*)0x4200003EU) /**< (EVSYS) Channel 3 Interrupt Flag Status and Clear */
+#define REG_EVSYS_CHSTATUS3     (*(__I  uint8_t*)0x4200003FU) /**< (EVSYS) Channel 3 Status */
+#define REG_EVSYS_CHANNEL4      (*(__IO uint32_t*)0x42000040U) /**< (EVSYS) Channel 4 Control */
+#define REG_EVSYS_CHINTENCLR4   (*(__IO uint8_t*)0x42000044U) /**< (EVSYS) Channel 4 Interrupt Enable Clear */
+#define REG_EVSYS_CHINTENSET4   (*(__IO uint8_t*)0x42000045U) /**< (EVSYS) Channel 4 Interrupt Enable Set */
+#define REG_EVSYS_CHINTFLAG4    (*(__IO uint8_t*)0x42000046U) /**< (EVSYS) Channel 4 Interrupt Flag Status and Clear */
+#define REG_EVSYS_CHSTATUS4     (*(__I  uint8_t*)0x42000047U) /**< (EVSYS) Channel 4 Status */
+#define REG_EVSYS_CHANNEL5      (*(__IO uint32_t*)0x42000048U) /**< (EVSYS) Channel 5 Control */
+#define REG_EVSYS_CHINTENCLR5   (*(__IO uint8_t*)0x4200004CU) /**< (EVSYS) Channel 5 Interrupt Enable Clear */
+#define REG_EVSYS_CHINTENSET5   (*(__IO uint8_t*)0x4200004DU) /**< (EVSYS) Channel 5 Interrupt Enable Set */
+#define REG_EVSYS_CHINTFLAG5    (*(__IO uint8_t*)0x4200004EU) /**< (EVSYS) Channel 5 Interrupt Flag Status and Clear */
+#define REG_EVSYS_CHSTATUS5     (*(__I  uint8_t*)0x4200004FU) /**< (EVSYS) Channel 5 Status */
+#define REG_EVSYS_CHANNEL6      (*(__IO uint32_t*)0x42000050U) /**< (EVSYS) Channel 6 Control */
+#define REG_EVSYS_CHINTENCLR6   (*(__IO uint8_t*)0x42000054U) /**< (EVSYS) Channel 6 Interrupt Enable Clear */
+#define REG_EVSYS_CHINTENSET6   (*(__IO uint8_t*)0x42000055U) /**< (EVSYS) Channel 6 Interrupt Enable Set */
+#define REG_EVSYS_CHINTFLAG6    (*(__IO uint8_t*)0x42000056U) /**< (EVSYS) Channel 6 Interrupt Flag Status and Clear */
+#define REG_EVSYS_CHSTATUS6     (*(__I  uint8_t*)0x42000057U) /**< (EVSYS) Channel 6 Status */
+#define REG_EVSYS_CHANNEL7      (*(__IO uint32_t*)0x42000058U) /**< (EVSYS) Channel 7 Control */
+#define REG_EVSYS_CHINTENCLR7   (*(__IO uint8_t*)0x4200005CU) /**< (EVSYS) Channel 7 Interrupt Enable Clear */
+#define REG_EVSYS_CHINTENSET7   (*(__IO uint8_t*)0x4200005DU) /**< (EVSYS) Channel 7 Interrupt Enable Set */
+#define REG_EVSYS_CHINTFLAG7    (*(__IO uint8_t*)0x4200005EU) /**< (EVSYS) Channel 7 Interrupt Flag Status and Clear */
+#define REG_EVSYS_CHSTATUS7     (*(__I  uint8_t*)0x4200005FU) /**< (EVSYS) Channel 7 Status */
+#define REG_EVSYS_CTRLA         (*(__O  uint8_t*)0x42000000U) /**< (EVSYS) Control */
+#define REG_EVSYS_SWEVT         (*(__O  uint32_t*)0x42000004U) /**< (EVSYS) Software Event */
+#define REG_EVSYS_PRICTRL       (*(__IO uint8_t*)0x42000008U) /**< (EVSYS) Priority Control */
+#define REG_EVSYS_INTPEND       (*(__IO uint16_t*)0x42000010U) /**< (EVSYS) Channel Pending Interrupt */
+#define REG_EVSYS_INTSTATUS     (*(__I  uint32_t*)0x42000014U) /**< (EVSYS) Interrupt Status */
+#define REG_EVSYS_BUSYCH        (*(__I  uint32_t*)0x42000018U) /**< (EVSYS) Busy Channels */
+#define REG_EVSYS_READYUSR      (*(__I  uint32_t*)0x4200001CU) /**< (EVSYS) Ready Users */
+#define REG_EVSYS_USER          (*(__IO uint8_t*)0x42000120U) /**< (EVSYS) User Multiplexer n */
+#define REG_EVSYS_USER0         (*(__IO uint8_t*)0x42000120U) /**< (EVSYS) User Multiplexer 0 */
+#define REG_EVSYS_USER1         (*(__IO uint8_t*)0x42000121U) /**< (EVSYS) User Multiplexer 1 */
+#define REG_EVSYS_USER2         (*(__IO uint8_t*)0x42000122U) /**< (EVSYS) User Multiplexer 2 */
+#define REG_EVSYS_USER3         (*(__IO uint8_t*)0x42000123U) /**< (EVSYS) User Multiplexer 3 */
+#define REG_EVSYS_USER4         (*(__IO uint8_t*)0x42000124U) /**< (EVSYS) User Multiplexer 4 */
+#define REG_EVSYS_USER5         (*(__IO uint8_t*)0x42000125U) /**< (EVSYS) User Multiplexer 5 */
+#define REG_EVSYS_USER6         (*(__IO uint8_t*)0x42000126U) /**< (EVSYS) User Multiplexer 6 */
+#define REG_EVSYS_USER7         (*(__IO uint8_t*)0x42000127U) /**< (EVSYS) User Multiplexer 7 */
+#define REG_EVSYS_USER8         (*(__IO uint8_t*)0x42000128U) /**< (EVSYS) User Multiplexer 8 */
+#define REG_EVSYS_USER9         (*(__IO uint8_t*)0x42000129U) /**< (EVSYS) User Multiplexer 9 */
+#define REG_EVSYS_USER10        (*(__IO uint8_t*)0x4200012AU) /**< (EVSYS) User Multiplexer 10 */
+#define REG_EVSYS_USER11        (*(__IO uint8_t*)0x4200012BU) /**< (EVSYS) User Multiplexer 11 */
+#define REG_EVSYS_USER12        (*(__IO uint8_t*)0x4200012CU) /**< (EVSYS) User Multiplexer 12 */
+#define REG_EVSYS_USER13        (*(__IO uint8_t*)0x4200012DU) /**< (EVSYS) User Multiplexer 13 */
+#define REG_EVSYS_USER14        (*(__IO uint8_t*)0x4200012EU) /**< (EVSYS) User Multiplexer 14 */
+#define REG_EVSYS_USER15        (*(__IO uint8_t*)0x4200012FU) /**< (EVSYS) User Multiplexer 15 */
+#define REG_EVSYS_USER16        (*(__IO uint8_t*)0x42000130U) /**< (EVSYS) User Multiplexer 16 */
+#define REG_EVSYS_USER17        (*(__IO uint8_t*)0x42000131U) /**< (EVSYS) User Multiplexer 17 */
+#define REG_EVSYS_USER18        (*(__IO uint8_t*)0x42000132U) /**< (EVSYS) User Multiplexer 18 */
+#define REG_EVSYS_USER19        (*(__IO uint8_t*)0x42000133U) /**< (EVSYS) User Multiplexer 19 */
+#define REG_EVSYS_USER20        (*(__IO uint8_t*)0x42000134U) /**< (EVSYS) User Multiplexer 20 */
+#define REG_EVSYS_USER21        (*(__IO uint8_t*)0x42000135U) /**< (EVSYS) User Multiplexer 21 */
+#define REG_EVSYS_USER22        (*(__IO uint8_t*)0x42000136U) /**< (EVSYS) User Multiplexer 22 */
+#define REG_EVSYS_INTENCLR      (*(__IO uint8_t*)0x420001D4U) /**< (EVSYS) Interrupt Enable Clear */
+#define REG_EVSYS_INTENSET      (*(__IO uint8_t*)0x420001D5U) /**< (EVSYS) Interrupt Enable Set */
+#define REG_EVSYS_INTFLAG       (*(__IO uint8_t*)0x420001D6U) /**< (EVSYS) Interrupt Flag Status and Clear */
+#define REG_EVSYS_NONSECCHAN    (*(__IO uint32_t*)0x420001D8U) /**< (EVSYS) Channels Security Attribution */
+#define REG_EVSYS_NSCHKCHAN     (*(__IO uint32_t*)0x420001DCU) /**< (EVSYS) Non-Secure Channels Check */
+#define REG_EVSYS_NONSECUSER    (*(__IO uint32_t*)0x420001E0U) /**< (EVSYS) Users Security Attribution */
+#define REG_EVSYS_NONSECUSER0   (*(__IO uint32_t*)0x420001E0U) /**< (EVSYS) Users Security Attribution 0 */
+#define REG_EVSYS_NSCHKUSER     (*(__IO uint32_t*)0x420001F0U) /**< (EVSYS) Non-Secure Users Check */
+#define REG_EVSYS_NSCHKUSER0    (*(__IO uint32_t*)0x420001F0U) /**< (EVSYS) Non-Secure Users Check 0 */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for EVSYS peripheral ========== */
+#define EVSYS_ASYNCHRONOUS_CHANNELS              0x000000F0 /* Mask of Only Asynchronous Channels */
+#define EVSYS_CHANNELS                           8          /* Number of Channels */
+#define EVSYS_CHANNELS_BITS                      3          /* Number of bits to select Channel */
+#define EVSYS_GCLK_ID_0                          6          /* Index of Generic Clock 0 */
+#define EVSYS_GCLK_ID_1                          7          /* Index of Generic Clock 1 */
+#define EVSYS_GCLK_ID_2                          8          /* Index of Generic Clock 2 */
+#define EVSYS_GCLK_ID_3                          9          /* Index of Generic Clock 3 */
+#define EVSYS_GENERATORS                         49         /* Total Number of Event Generators */
+#define EVSYS_GENERATORS_BITS                    6          /* Number of bits to select Event Generator */
+#define EVSYS_SECURE_IMPLEMENTED                 1          /* Secure Channels/Users supported? */
+#define EVSYS_SYNCH_NUM                          4          /* Number of Synchronous Channels */
+#define EVSYS_SYNCH_NUM_BITS                     2          /* Number of bits to select Synchronous Channels */
+#define EVSYS_USERS                              23         /* Total Number of Event Users */
+#define EVSYS_USERS_BITS                         5          /* Number of bits to select Event User */
+#define EVSYS_USERS_GROUPS                       1          /* Number of 32-user groups */
+#define EVSYS_INSTANCE_ID                        64         
+
+#endif /* _SAML11_EVSYS_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/instance/freqm.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/instance/freqm.h
@@ -1,0 +1,66 @@
+/**
+ * \file
+ *
+ * \brief Instance description for FREQM
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_FREQM_INSTANCE_H_
+#define _SAML11_FREQM_INSTANCE_H_
+
+/* ========== Register definition for FREQM peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_FREQM_CTRLA         (0x40002C00) /**< (FREQM) Control A Register */
+#define REG_FREQM_CTRLB         (0x40002C01) /**< (FREQM) Control B Register */
+#define REG_FREQM_CFGA          (0x40002C02) /**< (FREQM) Config A register */
+#define REG_FREQM_INTENCLR      (0x40002C08) /**< (FREQM) Interrupt Enable Clear Register */
+#define REG_FREQM_INTENSET      (0x40002C09) /**< (FREQM) Interrupt Enable Set Register */
+#define REG_FREQM_INTFLAG       (0x40002C0A) /**< (FREQM) Interrupt Flag Register */
+#define REG_FREQM_STATUS        (0x40002C0B) /**< (FREQM) Status Register */
+#define REG_FREQM_SYNCBUSY      (0x40002C0C) /**< (FREQM) Synchronization Busy Register */
+#define REG_FREQM_VALUE         (0x40002C10) /**< (FREQM) Count Value Register */
+
+#else
+
+#define REG_FREQM_CTRLA         (*(__IO uint8_t*)0x40002C00U) /**< (FREQM) Control A Register */
+#define REG_FREQM_CTRLB         (*(__O  uint8_t*)0x40002C01U) /**< (FREQM) Control B Register */
+#define REG_FREQM_CFGA          (*(__IO uint16_t*)0x40002C02U) /**< (FREQM) Config A register */
+#define REG_FREQM_INTENCLR      (*(__IO uint8_t*)0x40002C08U) /**< (FREQM) Interrupt Enable Clear Register */
+#define REG_FREQM_INTENSET      (*(__IO uint8_t*)0x40002C09U) /**< (FREQM) Interrupt Enable Set Register */
+#define REG_FREQM_INTFLAG       (*(__IO uint8_t*)0x40002C0AU) /**< (FREQM) Interrupt Flag Register */
+#define REG_FREQM_STATUS        (*(__IO uint8_t*)0x40002C0BU) /**< (FREQM) Status Register */
+#define REG_FREQM_SYNCBUSY      (*(__I  uint32_t*)0x40002C0CU) /**< (FREQM) Synchronization Busy Register */
+#define REG_FREQM_VALUE         (*(__I  uint32_t*)0x40002C10U) /**< (FREQM) Count Value Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for FREQM peripheral ========== */
+#define FREQM_GCLK_ID_MSR                        4          /* Index of measure generic clock */
+#define FREQM_GCLK_ID_REF                        5          /* Index of reference generic clock */
+#define FREQM_INSTANCE_ID                        11         
+
+#endif /* _SAML11_FREQM_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/instance/gclk.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/instance/gclk.h
@@ -1,0 +1,114 @@
+/**
+ * \file
+ *
+ * \brief Instance description for GCLK
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_GCLK_INSTANCE_H_
+#define _SAML11_GCLK_INSTANCE_H_
+
+/* ========== Register definition for GCLK peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_GCLK_CTRLA          (0x40001C00) /**< (GCLK) Control */
+#define REG_GCLK_SYNCBUSY       (0x40001C04) /**< (GCLK) Synchronization Busy */
+#define REG_GCLK_GENCTRL        (0x40001C20) /**< (GCLK) Generic Clock Generator Control */
+#define REG_GCLK_GENCTRL0       (0x40001C20) /**< (GCLK) Generic Clock Generator Control 0 */
+#define REG_GCLK_GENCTRL1       (0x40001C24) /**< (GCLK) Generic Clock Generator Control 1 */
+#define REG_GCLK_GENCTRL2       (0x40001C28) /**< (GCLK) Generic Clock Generator Control 2 */
+#define REG_GCLK_GENCTRL3       (0x40001C2C) /**< (GCLK) Generic Clock Generator Control 3 */
+#define REG_GCLK_GENCTRL4       (0x40001C30) /**< (GCLK) Generic Clock Generator Control 4 */
+#define REG_GCLK_PCHCTRL        (0x40001C80) /**< (GCLK) Peripheral Clock Control */
+#define REG_GCLK_PCHCTRL0       (0x40001C80) /**< (GCLK) Peripheral Clock Control 0 */
+#define REG_GCLK_PCHCTRL1       (0x40001C84) /**< (GCLK) Peripheral Clock Control 1 */
+#define REG_GCLK_PCHCTRL2       (0x40001C88) /**< (GCLK) Peripheral Clock Control 2 */
+#define REG_GCLK_PCHCTRL3       (0x40001C8C) /**< (GCLK) Peripheral Clock Control 3 */
+#define REG_GCLK_PCHCTRL4       (0x40001C90) /**< (GCLK) Peripheral Clock Control 4 */
+#define REG_GCLK_PCHCTRL5       (0x40001C94) /**< (GCLK) Peripheral Clock Control 5 */
+#define REG_GCLK_PCHCTRL6       (0x40001C98) /**< (GCLK) Peripheral Clock Control 6 */
+#define REG_GCLK_PCHCTRL7       (0x40001C9C) /**< (GCLK) Peripheral Clock Control 7 */
+#define REG_GCLK_PCHCTRL8       (0x40001CA0) /**< (GCLK) Peripheral Clock Control 8 */
+#define REG_GCLK_PCHCTRL9       (0x40001CA4) /**< (GCLK) Peripheral Clock Control 9 */
+#define REG_GCLK_PCHCTRL10      (0x40001CA8) /**< (GCLK) Peripheral Clock Control 10 */
+#define REG_GCLK_PCHCTRL11      (0x40001CAC) /**< (GCLK) Peripheral Clock Control 11 */
+#define REG_GCLK_PCHCTRL12      (0x40001CB0) /**< (GCLK) Peripheral Clock Control 12 */
+#define REG_GCLK_PCHCTRL13      (0x40001CB4) /**< (GCLK) Peripheral Clock Control 13 */
+#define REG_GCLK_PCHCTRL14      (0x40001CB8) /**< (GCLK) Peripheral Clock Control 14 */
+#define REG_GCLK_PCHCTRL15      (0x40001CBC) /**< (GCLK) Peripheral Clock Control 15 */
+#define REG_GCLK_PCHCTRL16      (0x40001CC0) /**< (GCLK) Peripheral Clock Control 16 */
+#define REG_GCLK_PCHCTRL17      (0x40001CC4) /**< (GCLK) Peripheral Clock Control 17 */
+#define REG_GCLK_PCHCTRL18      (0x40001CC8) /**< (GCLK) Peripheral Clock Control 18 */
+#define REG_GCLK_PCHCTRL19      (0x40001CCC) /**< (GCLK) Peripheral Clock Control 19 */
+#define REG_GCLK_PCHCTRL20      (0x40001CD0) /**< (GCLK) Peripheral Clock Control 20 */
+
+#else
+
+#define REG_GCLK_CTRLA          (*(__IO uint8_t*)0x40001C00U) /**< (GCLK) Control */
+#define REG_GCLK_SYNCBUSY       (*(__I  uint32_t*)0x40001C04U) /**< (GCLK) Synchronization Busy */
+#define REG_GCLK_GENCTRL        (*(__IO uint32_t*)0x40001C20U) /**< (GCLK) Generic Clock Generator Control */
+#define REG_GCLK_GENCTRL0       (*(__IO uint32_t*)0x40001C20U) /**< (GCLK) Generic Clock Generator Control 0 */
+#define REG_GCLK_GENCTRL1       (*(__IO uint32_t*)0x40001C24U) /**< (GCLK) Generic Clock Generator Control 1 */
+#define REG_GCLK_GENCTRL2       (*(__IO uint32_t*)0x40001C28U) /**< (GCLK) Generic Clock Generator Control 2 */
+#define REG_GCLK_GENCTRL3       (*(__IO uint32_t*)0x40001C2CU) /**< (GCLK) Generic Clock Generator Control 3 */
+#define REG_GCLK_GENCTRL4       (*(__IO uint32_t*)0x40001C30U) /**< (GCLK) Generic Clock Generator Control 4 */
+#define REG_GCLK_PCHCTRL        (*(__IO uint32_t*)0x40001C80U) /**< (GCLK) Peripheral Clock Control */
+#define REG_GCLK_PCHCTRL0       (*(__IO uint32_t*)0x40001C80U) /**< (GCLK) Peripheral Clock Control 0 */
+#define REG_GCLK_PCHCTRL1       (*(__IO uint32_t*)0x40001C84U) /**< (GCLK) Peripheral Clock Control 1 */
+#define REG_GCLK_PCHCTRL2       (*(__IO uint32_t*)0x40001C88U) /**< (GCLK) Peripheral Clock Control 2 */
+#define REG_GCLK_PCHCTRL3       (*(__IO uint32_t*)0x40001C8CU) /**< (GCLK) Peripheral Clock Control 3 */
+#define REG_GCLK_PCHCTRL4       (*(__IO uint32_t*)0x40001C90U) /**< (GCLK) Peripheral Clock Control 4 */
+#define REG_GCLK_PCHCTRL5       (*(__IO uint32_t*)0x40001C94U) /**< (GCLK) Peripheral Clock Control 5 */
+#define REG_GCLK_PCHCTRL6       (*(__IO uint32_t*)0x40001C98U) /**< (GCLK) Peripheral Clock Control 6 */
+#define REG_GCLK_PCHCTRL7       (*(__IO uint32_t*)0x40001C9CU) /**< (GCLK) Peripheral Clock Control 7 */
+#define REG_GCLK_PCHCTRL8       (*(__IO uint32_t*)0x40001CA0U) /**< (GCLK) Peripheral Clock Control 8 */
+#define REG_GCLK_PCHCTRL9       (*(__IO uint32_t*)0x40001CA4U) /**< (GCLK) Peripheral Clock Control 9 */
+#define REG_GCLK_PCHCTRL10      (*(__IO uint32_t*)0x40001CA8U) /**< (GCLK) Peripheral Clock Control 10 */
+#define REG_GCLK_PCHCTRL11      (*(__IO uint32_t*)0x40001CACU) /**< (GCLK) Peripheral Clock Control 11 */
+#define REG_GCLK_PCHCTRL12      (*(__IO uint32_t*)0x40001CB0U) /**< (GCLK) Peripheral Clock Control 12 */
+#define REG_GCLK_PCHCTRL13      (*(__IO uint32_t*)0x40001CB4U) /**< (GCLK) Peripheral Clock Control 13 */
+#define REG_GCLK_PCHCTRL14      (*(__IO uint32_t*)0x40001CB8U) /**< (GCLK) Peripheral Clock Control 14 */
+#define REG_GCLK_PCHCTRL15      (*(__IO uint32_t*)0x40001CBCU) /**< (GCLK) Peripheral Clock Control 15 */
+#define REG_GCLK_PCHCTRL16      (*(__IO uint32_t*)0x40001CC0U) /**< (GCLK) Peripheral Clock Control 16 */
+#define REG_GCLK_PCHCTRL17      (*(__IO uint32_t*)0x40001CC4U) /**< (GCLK) Peripheral Clock Control 17 */
+#define REG_GCLK_PCHCTRL18      (*(__IO uint32_t*)0x40001CC8U) /**< (GCLK) Peripheral Clock Control 18 */
+#define REG_GCLK_PCHCTRL19      (*(__IO uint32_t*)0x40001CCCU) /**< (GCLK) Peripheral Clock Control 19 */
+#define REG_GCLK_PCHCTRL20      (*(__IO uint32_t*)0x40001CD0U) /**< (GCLK) Peripheral Clock Control 20 */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for GCLK peripheral ========== */
+#define GCLK_GENDIV_BITS                         16         
+#define GCLK_GEN_BITS                            3          
+#define GCLK_GEN_NUM                             5          /* Number of Generic Clock Generators */
+#define GCLK_GEN_NUM_MSB                         4          /* Number of Generic Clock Generators - 1 */
+#define GCLK_GEN_SOURCE_NUM_MSB                  7          /* Number of Generic Clock Sources - 1 */
+#define GCLK_NUM                                 21         /* Number of Generic Clock Users */
+#define GCLK_SOURCE_BITS                         3          
+#define GCLK_SOURCE_NUM                          8          /* Number of Generic Clock Sources */
+#define GCLK_INSTANCE_ID                         7          
+
+#endif /* _SAML11_GCLK_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/instance/idau.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/instance/idau.h
@@ -1,0 +1,79 @@
+/**
+ * \file
+ *
+ * \brief Instance description for IDAU
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_IDAU_INSTANCE_H_
+#define _SAML11_IDAU_INSTANCE_H_
+
+/* ========== Register definition for IDAU peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_IDAU_SECCTRL        (0x41000001) /**< (IDAU) SECCTRL */
+#define REG_IDAU_SCFGB          (0x41000004) /**< (IDAU) SCFGB */
+#define REG_IDAU_SCFGA          (0x41000008) /**< (IDAU) SCFGA */
+#define REG_IDAU_SCFGR          (0x4100000C) /**< (IDAU) SCFGR */
+
+#else
+
+#define REG_IDAU_SECCTRL        (*(__IO uint8_t*)0x41000001U) /**< (IDAU) SECCTRL */
+#define REG_IDAU_SCFGB          (*(__IO uint32_t*)0x41000004U) /**< (IDAU) SCFGB */
+#define REG_IDAU_SCFGA          (*(__IO uint32_t*)0x41000008U) /**< (IDAU) SCFGA */
+#define REG_IDAU_SCFGR          (*(__IO uint8_t*)0x4100000CU) /**< (IDAU) SCFGR */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for IDAU peripheral ========== */
+#define IDAU_CRYA_AES_DECRYPT_T                  0x02001908 /* crya_aes_decryp_t function address */
+#define IDAU_CRYA_AES_ENCRYPT_T                  0x02001904 /* crya_aes_encryp_t function address */
+#define IDAU_CRYA_GF_MULT128                     0x0200190C /* crya_gf_mult128 function address */
+#define IDAU_CRYA_SHA_PROCESS                    0x02001900 /* crya_sha_process function address */
+#define IDAU_GRANULARITY_ANSC                    0x20       /* Application Non-Secure Callable region granularity */
+#define IDAU_GRANULARITY_AS                      0x100      /* Application Secure region granularity */
+#define IDAU_GRANULARITY_BNSC                    0x20       /* Boot Flash Non-Secure Callable region granularity */
+#define IDAU_GRANULARITY_BOOTPROT                0x100      /* BOOTPROT region granularity */
+#define IDAU_GRANULARITY_BS                      0x100      /* Boot Flash Secure region granularity */
+#define IDAU_GRANULARITY_DS                      0x100      /* DS region granularity */
+#define IDAU_GRANULARITY_RS                      0x80       /* RAM Secure region granularity */
+#define IDAU_REGION_ANS                          0x06       /* Flash Non-Secure APPLICATION region number */
+#define IDAU_REGION_ANSC                         0x05       /* Flash Non-Secure Callable APPLICATION region number */
+#define IDAU_REGION_AS                           0x04       /* Flash Secure APPLICATION region number */
+#define IDAU_REGION_BNS                          0x03       /* Flash Non-Secure BOOT region number */
+#define IDAU_REGION_BNSC                         0x02       /* Flash Non-Secure Callable BOOT region number */
+#define IDAU_REGION_BOOTROM                      0x09       /* Boot ROM region number */
+#define IDAU_REGION_BS                           0x01       /* Flash Secure BOOT region number */
+#define IDAU_REGION_DNS                          0x08       /* Non-Secure DATA Flash region number */
+#define IDAU_REGION_DS                           0x07       /* Secure DATA Flash region number */
+#define IDAU_REGION_IOBUS                        0x00       /* IOBUS region number (invalid) */
+#define IDAU_REGION_OTHER                        0x00       /* Others region number (invalid) */
+#define IDAU_REGION_PERIPHERALS                  0x00       /* Peripherals region number (invalid) */
+#define IDAU_REGION_RNS                          0x0B       /* Non-Secure SRAM region number */
+#define IDAU_REGION_RS                           0x0A       /* Secure SRAM region number */
+#define IDAU_INSTANCE_ID                         32         
+
+#endif /* _SAML11_IDAU_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/instance/mclk.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/instance/mclk.h
@@ -1,0 +1,66 @@
+/**
+ * \file
+ *
+ * \brief Instance description for MCLK
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_MCLK_INSTANCE_H_
+#define _SAML11_MCLK_INSTANCE_H_
+
+/* ========== Register definition for MCLK peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_MCLK_CTRLA          (0x40000800) /**< (MCLK) Control */
+#define REG_MCLK_INTENCLR       (0x40000801) /**< (MCLK) Interrupt Enable Clear */
+#define REG_MCLK_INTENSET       (0x40000802) /**< (MCLK) Interrupt Enable Set */
+#define REG_MCLK_INTFLAG        (0x40000803) /**< (MCLK) Interrupt Flag Status and Clear */
+#define REG_MCLK_CPUDIV         (0x40000804) /**< (MCLK) CPU Clock Division */
+#define REG_MCLK_AHBMASK        (0x40000810) /**< (MCLK) AHB Mask */
+#define REG_MCLK_APBAMASK       (0x40000814) /**< (MCLK) APBA Mask */
+#define REG_MCLK_APBBMASK       (0x40000818) /**< (MCLK) APBB Mask */
+#define REG_MCLK_APBCMASK       (0x4000081C) /**< (MCLK) APBC Mask */
+
+#else
+
+#define REG_MCLK_CTRLA          (*(__IO uint8_t*)0x40000800U) /**< (MCLK) Control */
+#define REG_MCLK_INTENCLR       (*(__IO uint8_t*)0x40000801U) /**< (MCLK) Interrupt Enable Clear */
+#define REG_MCLK_INTENSET       (*(__IO uint8_t*)0x40000802U) /**< (MCLK) Interrupt Enable Set */
+#define REG_MCLK_INTFLAG        (*(__IO uint8_t*)0x40000803U) /**< (MCLK) Interrupt Flag Status and Clear */
+#define REG_MCLK_CPUDIV         (*(__IO uint8_t*)0x40000804U) /**< (MCLK) CPU Clock Division */
+#define REG_MCLK_AHBMASK        (*(__IO uint32_t*)0x40000810U) /**< (MCLK) AHB Mask */
+#define REG_MCLK_APBAMASK       (*(__IO uint32_t*)0x40000814U) /**< (MCLK) APBA Mask */
+#define REG_MCLK_APBBMASK       (*(__IO uint32_t*)0x40000818U) /**< (MCLK) APBB Mask */
+#define REG_MCLK_APBCMASK       (*(__IO uint32_t*)0x4000081CU) /**< (MCLK) APBC Mask */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for MCLK peripheral ========== */
+#define MCLK_MCLK_CLK_APB_NUM                    3          
+#define MCLK_SYSTEM_CLOCK                        4000000    /* System Clock Frequency at Reset */
+#define MCLK_INSTANCE_ID                         2          
+
+#endif /* _SAML11_MCLK_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/instance/nvmctrl.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/instance/nvmctrl.h
@@ -1,0 +1,99 @@
+/**
+ * \file
+ *
+ * \brief Instance description for NVMCTRL
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_NVMCTRL_INSTANCE_H_
+#define _SAML11_NVMCTRL_INSTANCE_H_
+
+/* ========== Register definition for NVMCTRL peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_NVMCTRL_CTRLA       (0x41004000) /**< (NVMCTRL) Control A */
+#define REG_NVMCTRL_CTRLB       (0x41004004) /**< (NVMCTRL) Control B */
+#define REG_NVMCTRL_CTRLC       (0x41004008) /**< (NVMCTRL) Control C */
+#define REG_NVMCTRL_EVCTRL      (0x4100400A) /**< (NVMCTRL) Event Control */
+#define REG_NVMCTRL_INTENCLR    (0x4100400C) /**< (NVMCTRL) Interrupt Enable Clear */
+#define REG_NVMCTRL_INTENSET    (0x41004010) /**< (NVMCTRL) Interrupt Enable Set */
+#define REG_NVMCTRL_INTFLAG     (0x41004014) /**< (NVMCTRL) Interrupt Flag Status and Clear */
+#define REG_NVMCTRL_STATUS      (0x41004018) /**< (NVMCTRL) Status */
+#define REG_NVMCTRL_ADDR        (0x4100401C) /**< (NVMCTRL) Address */
+#define REG_NVMCTRL_SULCK       (0x41004020) /**< (NVMCTRL) Secure Unlock Register */
+#define REG_NVMCTRL_NSULCK      (0x41004022) /**< (NVMCTRL) Non-Secure Unlock Register */
+#define REG_NVMCTRL_PARAM       (0x41004024) /**< (NVMCTRL) NVM Parameter */
+#define REG_NVMCTRL_DSCC        (0x41004030) /**< (NVMCTRL) Data Scramble Configuration */
+#define REG_NVMCTRL_SECCTRL     (0x41004034) /**< (NVMCTRL) Security Control */
+#define REG_NVMCTRL_SCFGB       (0x41004038) /**< (NVMCTRL) Secure Boot Configuration */
+#define REG_NVMCTRL_SCFGAD      (0x4100403C) /**< (NVMCTRL) Secure Application and Data Configuration */
+#define REG_NVMCTRL_NONSEC      (0x41004040) /**< (NVMCTRL) Non-secure Write Enable */
+#define REG_NVMCTRL_NSCHK       (0x41004044) /**< (NVMCTRL) Non-secure Write Reference Value */
+
+#else
+
+#define REG_NVMCTRL_CTRLA       (*(__O  uint16_t*)0x41004000U) /**< (NVMCTRL) Control A */
+#define REG_NVMCTRL_CTRLB       (*(__IO uint32_t*)0x41004004U) /**< (NVMCTRL) Control B */
+#define REG_NVMCTRL_CTRLC       (*(__IO uint8_t*)0x41004008U) /**< (NVMCTRL) Control C */
+#define REG_NVMCTRL_EVCTRL      (*(__IO uint8_t*)0x4100400AU) /**< (NVMCTRL) Event Control */
+#define REG_NVMCTRL_INTENCLR    (*(__IO uint8_t*)0x4100400CU) /**< (NVMCTRL) Interrupt Enable Clear */
+#define REG_NVMCTRL_INTENSET    (*(__IO uint8_t*)0x41004010U) /**< (NVMCTRL) Interrupt Enable Set */
+#define REG_NVMCTRL_INTFLAG     (*(__IO uint8_t*)0x41004014U) /**< (NVMCTRL) Interrupt Flag Status and Clear */
+#define REG_NVMCTRL_STATUS      (*(__I  uint16_t*)0x41004018U) /**< (NVMCTRL) Status */
+#define REG_NVMCTRL_ADDR        (*(__IO uint32_t*)0x4100401CU) /**< (NVMCTRL) Address */
+#define REG_NVMCTRL_SULCK       (*(__IO uint16_t*)0x41004020U) /**< (NVMCTRL) Secure Unlock Register */
+#define REG_NVMCTRL_NSULCK      (*(__IO uint16_t*)0x41004022U) /**< (NVMCTRL) Non-Secure Unlock Register */
+#define REG_NVMCTRL_PARAM       (*(__IO uint32_t*)0x41004024U) /**< (NVMCTRL) NVM Parameter */
+#define REG_NVMCTRL_DSCC        (*(__O  uint32_t*)0x41004030U) /**< (NVMCTRL) Data Scramble Configuration */
+#define REG_NVMCTRL_SECCTRL     (*(__IO uint32_t*)0x41004034U) /**< (NVMCTRL) Security Control */
+#define REG_NVMCTRL_SCFGB       (*(__IO uint32_t*)0x41004038U) /**< (NVMCTRL) Secure Boot Configuration */
+#define REG_NVMCTRL_SCFGAD      (*(__IO uint32_t*)0x4100403CU) /**< (NVMCTRL) Secure Application and Data Configuration */
+#define REG_NVMCTRL_NONSEC      (*(__IO uint32_t*)0x41004040U) /**< (NVMCTRL) Non-secure Write Enable */
+#define REG_NVMCTRL_NSCHK       (*(__IO uint32_t*)0x41004044U) /**< (NVMCTRL) Non-secure Write Reference Value */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for NVMCTRL peripheral ========== */
+#define NVMCTRL_DATAFLASH_PAGES                  32         
+#define NVMCTRL_PMSB                             3          
+#define NVMCTRL_PSZ_BITS                         6          
+#define NVMCTRL_ROW_PAGES                        4          
+#define NVMCTRL_SECURE_IMPLEMENTED               1          /* Security Configuration implemented? */
+#define NVMCTRL_FLASH_SIZE                       65536      
+#define NVMCTRL_PAGE_SIZE                        64         
+#define NVMCTRL_PAGES                            1024       
+#define NVMCTRL_PAGES_PR_REGION                  64         
+#define NVMCTRL_PSM_0_FRMFW_FWS_1_MAX_FREQ       12000000   
+#define NVMCTRL_PSM_0_FRMLP_FWS_0_MAX_FREQ       18000000   
+#define NVMCTRL_PSM_0_FRMLP_FWS_1_MAX_FREQ       36000000   
+#define NVMCTRL_PSM_0_FRMHS_FWS_0_MAX_FREQ       25000000   
+#define NVMCTRL_PSM_0_FRMHS_FWS_1_MAX_FREQ       50000000   
+#define NVMCTRL_PSM_1_FRMFW_FWS_1_MAX_FREQ       12000000   
+#define NVMCTRL_PSM_1_FRMLP_FWS_0_MAX_FREQ       8000000    
+#define NVMCTRL_PSM_1_FRMLP_FWS_1_MAX_FREQ       12000000   
+#define NVMCTRL_INSTANCE_ID                      34         
+
+#endif /* _SAML11_NVMCTRL_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/instance/opamp.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/instance/opamp.h
@@ -1,0 +1,60 @@
+/**
+ * \file
+ *
+ * \brief Instance description for OPAMP
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_OPAMP_INSTANCE_H_
+#define _SAML11_OPAMP_INSTANCE_H_
+
+/* ========== Register definition for OPAMP peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_OPAMP_CTRLA         (0x42003000) /**< (OPAMP) Control A */
+#define REG_OPAMP_STATUS        (0x42003002) /**< (OPAMP) Status */
+#define REG_OPAMP_OPAMPCTRL     (0x42003004) /**< (OPAMP) OPAMP n Control */
+#define REG_OPAMP_OPAMPCTRL0    (0x42003004) /**< (OPAMP) OPAMP 0 Control */
+#define REG_OPAMP_OPAMPCTRL1    (0x42003008) /**< (OPAMP) OPAMP 1 Control */
+#define REG_OPAMP_OPAMPCTRL2    (0x4200300C) /**< (OPAMP) OPAMP 2 Control */
+#define REG_OPAMP_RESCTRL       (0x42003010) /**< (OPAMP) Resister Control */
+
+#else
+
+#define REG_OPAMP_CTRLA         (*(__IO uint8_t*)0x42003000U) /**< (OPAMP) Control A */
+#define REG_OPAMP_STATUS        (*(__I  uint8_t*)0x42003002U) /**< (OPAMP) Status */
+#define REG_OPAMP_OPAMPCTRL     (*(__IO uint32_t*)0x42003004U) /**< (OPAMP) OPAMP n Control */
+#define REG_OPAMP_OPAMPCTRL0    (*(__IO uint32_t*)0x42003004U) /**< (OPAMP) OPAMP 0 Control */
+#define REG_OPAMP_OPAMPCTRL1    (*(__IO uint32_t*)0x42003008U) /**< (OPAMP) OPAMP 1 Control */
+#define REG_OPAMP_OPAMPCTRL2    (*(__IO uint32_t*)0x4200300CU) /**< (OPAMP) OPAMP 2 Control */
+#define REG_OPAMP_RESCTRL       (*(__IO uint8_t*)0x42003010U) /**< (OPAMP) Resister Control */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for OPAMP peripheral ========== */
+#define OPAMP_INSTANCE_ID                        76         
+
+#endif /* _SAML11_OPAMP_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/instance/osc32kctrl.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/instance/osc32kctrl.h
@@ -1,0 +1,65 @@
+/**
+ * \file
+ *
+ * \brief Instance description for OSC32KCTRL
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_OSC32KCTRL_INSTANCE_H_
+#define _SAML11_OSC32KCTRL_INSTANCE_H_
+
+/* ========== Register definition for OSC32KCTRL peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_OSC32KCTRL_INTENCLR (0x40001400) /**< (OSC32KCTRL) Interrupt Enable Clear */
+#define REG_OSC32KCTRL_INTENSET (0x40001404) /**< (OSC32KCTRL) Interrupt Enable Set */
+#define REG_OSC32KCTRL_INTFLAG  (0x40001408) /**< (OSC32KCTRL) Interrupt Flag Status and Clear */
+#define REG_OSC32KCTRL_STATUS   (0x4000140C) /**< (OSC32KCTRL) Power and Clocks Status */
+#define REG_OSC32KCTRL_RTCCTRL  (0x40001410) /**< (OSC32KCTRL) RTC Clock Selection */
+#define REG_OSC32KCTRL_XOSC32K  (0x40001414) /**< (OSC32KCTRL) 32kHz External Crystal Oscillator (XOSC32K) Control */
+#define REG_OSC32KCTRL_CFDCTRL  (0x40001416) /**< (OSC32KCTRL) Clock Failure Detector Control */
+#define REG_OSC32KCTRL_EVCTRL   (0x40001417) /**< (OSC32KCTRL) Event Control */
+#define REG_OSC32KCTRL_OSCULP32K (0x4000141C) /**< (OSC32KCTRL) 32kHz Ultra Low Power Internal Oscillator (OSCULP32K) Control */
+
+#else
+
+#define REG_OSC32KCTRL_INTENCLR (*(__IO uint32_t*)0x40001400U) /**< (OSC32KCTRL) Interrupt Enable Clear */
+#define REG_OSC32KCTRL_INTENSET (*(__IO uint32_t*)0x40001404U) /**< (OSC32KCTRL) Interrupt Enable Set */
+#define REG_OSC32KCTRL_INTFLAG  (*(__IO uint32_t*)0x40001408U) /**< (OSC32KCTRL) Interrupt Flag Status and Clear */
+#define REG_OSC32KCTRL_STATUS   (*(__I  uint32_t*)0x4000140CU) /**< (OSC32KCTRL) Power and Clocks Status */
+#define REG_OSC32KCTRL_RTCCTRL  (*(__IO uint8_t*)0x40001410U) /**< (OSC32KCTRL) RTC Clock Selection */
+#define REG_OSC32KCTRL_XOSC32K  (*(__IO uint16_t*)0x40001414U) /**< (OSC32KCTRL) 32kHz External Crystal Oscillator (XOSC32K) Control */
+#define REG_OSC32KCTRL_CFDCTRL  (*(__IO uint8_t*)0x40001416U) /**< (OSC32KCTRL) Clock Failure Detector Control */
+#define REG_OSC32KCTRL_EVCTRL   (*(__IO uint8_t*)0x40001417U) /**< (OSC32KCTRL) Event Control */
+#define REG_OSC32KCTRL_OSCULP32K (*(__IO uint32_t*)0x4000141CU) /**< (OSC32KCTRL) 32kHz Ultra Low Power Internal Oscillator (OSCULP32K) Control */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for OSC32KCTRL peripheral ========== */
+#define OSC32KCTRL_OSC32K_COARSE_CALIB_MSB       0          
+#define OSC32KCTRL_INSTANCE_ID                   5          
+
+#endif /* _SAML11_OSC32KCTRL_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/instance/oscctrl.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/instance/oscctrl.h
@@ -1,0 +1,94 @@
+/**
+ * \file
+ *
+ * \brief Instance description for OSCCTRL
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_OSCCTRL_INSTANCE_H_
+#define _SAML11_OSCCTRL_INSTANCE_H_
+
+/* ========== Register definition for OSCCTRL peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_OSCCTRL_EVCTRL      (0x40001000) /**< (OSCCTRL) Event Control */
+#define REG_OSCCTRL_INTENCLR    (0x40001004) /**< (OSCCTRL) Interrupt Enable Clear */
+#define REG_OSCCTRL_INTENSET    (0x40001008) /**< (OSCCTRL) Interrupt Enable Set */
+#define REG_OSCCTRL_INTFLAG     (0x4000100C) /**< (OSCCTRL) Interrupt Flag Status and Clear */
+#define REG_OSCCTRL_STATUS      (0x40001010) /**< (OSCCTRL) Status */
+#define REG_OSCCTRL_XOSCCTRL    (0x40001014) /**< (OSCCTRL) External Multipurpose Crystal Oscillator (XOSC) Control */
+#define REG_OSCCTRL_CFDPRESC    (0x40001016) /**< (OSCCTRL) Clock Failure Detector Prescaler */
+#define REG_OSCCTRL_OSC16MCTRL  (0x40001018) /**< (OSCCTRL) 16MHz Internal Oscillator (OSC16M) Control */
+#define REG_OSCCTRL_DFLLULPCTRL (0x4000101C) /**< (OSCCTRL) DFLLULP Control */
+#define REG_OSCCTRL_DFLLULPDITHER (0x4000101E) /**< (OSCCTRL) DFLLULP Dither Control */
+#define REG_OSCCTRL_DFLLULPRREQ (0x4000101F) /**< (OSCCTRL) DFLLULP Read Request */
+#define REG_OSCCTRL_DFLLULPDLY  (0x40001020) /**< (OSCCTRL) DFLLULP Delay Value */
+#define REG_OSCCTRL_DFLLULPRATIO (0x40001024) /**< (OSCCTRL) DFLLULP Target Ratio */
+#define REG_OSCCTRL_DFLLULPSYNCBUSY (0x40001028) /**< (OSCCTRL) DFLLULP Synchronization Busy */
+#define REG_OSCCTRL_DPLLCTRLA   (0x4000102C) /**< (OSCCTRL) DPLL Control A */
+#define REG_OSCCTRL_DPLLRATIO   (0x40001030) /**< (OSCCTRL) DPLL Ratio Control */
+#define REG_OSCCTRL_DPLLCTRLB   (0x40001034) /**< (OSCCTRL) DPLL Control B */
+#define REG_OSCCTRL_DPLLPRESC   (0x40001038) /**< (OSCCTRL) DPLL Prescaler */
+#define REG_OSCCTRL_DPLLSYNCBUSY (0x4000103C) /**< (OSCCTRL) DPLL Synchronization Busy */
+#define REG_OSCCTRL_DPLLSTATUS  (0x40001040) /**< (OSCCTRL) DPLL Status */
+
+#else
+
+#define REG_OSCCTRL_EVCTRL      (*(__IO uint8_t*)0x40001000U) /**< (OSCCTRL) Event Control */
+#define REG_OSCCTRL_INTENCLR    (*(__IO uint32_t*)0x40001004U) /**< (OSCCTRL) Interrupt Enable Clear */
+#define REG_OSCCTRL_INTENSET    (*(__IO uint32_t*)0x40001008U) /**< (OSCCTRL) Interrupt Enable Set */
+#define REG_OSCCTRL_INTFLAG     (*(__IO uint32_t*)0x4000100CU) /**< (OSCCTRL) Interrupt Flag Status and Clear */
+#define REG_OSCCTRL_STATUS      (*(__I  uint32_t*)0x40001010U) /**< (OSCCTRL) Status */
+#define REG_OSCCTRL_XOSCCTRL    (*(__IO uint16_t*)0x40001014U) /**< (OSCCTRL) External Multipurpose Crystal Oscillator (XOSC) Control */
+#define REG_OSCCTRL_CFDPRESC    (*(__IO uint8_t*)0x40001016U) /**< (OSCCTRL) Clock Failure Detector Prescaler */
+#define REG_OSCCTRL_OSC16MCTRL  (*(__IO uint8_t*)0x40001018U) /**< (OSCCTRL) 16MHz Internal Oscillator (OSC16M) Control */
+#define REG_OSCCTRL_DFLLULPCTRL (*(__IO uint16_t*)0x4000101CU) /**< (OSCCTRL) DFLLULP Control */
+#define REG_OSCCTRL_DFLLULPDITHER (*(__IO uint8_t*)0x4000101EU) /**< (OSCCTRL) DFLLULP Dither Control */
+#define REG_OSCCTRL_DFLLULPRREQ (*(__IO uint8_t*)0x4000101FU) /**< (OSCCTRL) DFLLULP Read Request */
+#define REG_OSCCTRL_DFLLULPDLY  (*(__IO uint32_t*)0x40001020U) /**< (OSCCTRL) DFLLULP Delay Value */
+#define REG_OSCCTRL_DFLLULPRATIO (*(__IO uint32_t*)0x40001024U) /**< (OSCCTRL) DFLLULP Target Ratio */
+#define REG_OSCCTRL_DFLLULPSYNCBUSY (*(__I  uint32_t*)0x40001028U) /**< (OSCCTRL) DFLLULP Synchronization Busy */
+#define REG_OSCCTRL_DPLLCTRLA   (*(__IO uint8_t*)0x4000102CU) /**< (OSCCTRL) DPLL Control A */
+#define REG_OSCCTRL_DPLLRATIO   (*(__IO uint32_t*)0x40001030U) /**< (OSCCTRL) DPLL Ratio Control */
+#define REG_OSCCTRL_DPLLCTRLB   (*(__IO uint32_t*)0x40001034U) /**< (OSCCTRL) DPLL Control B */
+#define REG_OSCCTRL_DPLLPRESC   (*(__IO uint8_t*)0x40001038U) /**< (OSCCTRL) DPLL Prescaler */
+#define REG_OSCCTRL_DPLLSYNCBUSY (*(__I  uint8_t*)0x4000103CU) /**< (OSCCTRL) DPLL Synchronization Busy */
+#define REG_OSCCTRL_DPLLSTATUS  (*(__I  uint8_t*)0x40001040U) /**< (OSCCTRL) DPLL Status */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for OSCCTRL peripheral ========== */
+#define OSCCTRL_GCLK_ID_DFLLULP                  2          /* Index of Generic Clock for DFLLULP */
+#define OSCCTRL_GCLK_ID_DPLL                     0          /* Index of Generic Clock for DPLL */
+#define OSCCTRL_GCLK_ID_DPLL32K                  1          /* Index of Generic Clock for DPLL 32K */
+#define OSCCTRL_CFD_VERSION                      0x112      
+#define OSCCTRL_DFLLULP_VERSION                  0x100      
+#define OSCCTRL_FDPLL_VERSION                    0x213      
+#define OSCCTRL_OSC16M_VERSION                   0x102      
+#define OSCCTRL_XOSC_VERSION                     0x210      
+#define OSCCTRL_INSTANCE_ID                      4          
+
+#endif /* _SAML11_OSCCTRL_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/instance/pac.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/instance/pac.h
@@ -1,0 +1,82 @@
+/**
+ * \file
+ *
+ * \brief Instance description for PAC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_PAC_INSTANCE_H_
+#define _SAML11_PAC_INSTANCE_H_
+
+/* ========== Register definition for PAC peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_PAC_WRCTRL          (0x40000000) /**< (PAC) Write control */
+#define REG_PAC_EVCTRL          (0x40000004) /**< (PAC) Event control */
+#define REG_PAC_INTENCLR        (0x40000008) /**< (PAC) Interrupt enable clear */
+#define REG_PAC_INTENSET        (0x40000009) /**< (PAC) Interrupt enable set */
+#define REG_PAC_INTFLAGAHB      (0x40000010) /**< (PAC) Bridge interrupt flag status */
+#define REG_PAC_INTFLAGA        (0x40000014) /**< (PAC) Peripheral interrupt flag status - Bridge A */
+#define REG_PAC_INTFLAGB        (0x40000018) /**< (PAC) Peripheral interrupt flag status - Bridge B */
+#define REG_PAC_INTFLAGC        (0x4000001C) /**< (PAC) Peripheral interrupt flag status - Bridge C */
+#define REG_PAC_STATUSA         (0x40000034) /**< (PAC) Peripheral write protection status - Bridge A */
+#define REG_PAC_STATUSB         (0x40000038) /**< (PAC) Peripheral write protection status - Bridge B */
+#define REG_PAC_STATUSC         (0x4000003C) /**< (PAC) Peripheral write protection status - Bridge C */
+#define REG_PAC_NONSECA         (0x40000054) /**< (PAC) Peripheral non-secure status - Bridge A */
+#define REG_PAC_NONSECB         (0x40000058) /**< (PAC) Peripheral non-secure status - Bridge B */
+#define REG_PAC_NONSECC         (0x4000005C) /**< (PAC) Peripheral non-secure status - Bridge C */
+#define REG_PAC_SECLOCKA        (0x40000074) /**< (PAC) Peripheral secure status locked - Bridge A */
+#define REG_PAC_SECLOCKB        (0x40000078) /**< (PAC) Peripheral secure status locked - Bridge B */
+#define REG_PAC_SECLOCKC        (0x4000007C) /**< (PAC) Peripheral secure status locked - Bridge C */
+
+#else
+
+#define REG_PAC_WRCTRL          (*(__IO uint32_t*)0x40000000U) /**< (PAC) Write control */
+#define REG_PAC_EVCTRL          (*(__IO uint8_t*)0x40000004U) /**< (PAC) Event control */
+#define REG_PAC_INTENCLR        (*(__IO uint8_t*)0x40000008U) /**< (PAC) Interrupt enable clear */
+#define REG_PAC_INTENSET        (*(__IO uint8_t*)0x40000009U) /**< (PAC) Interrupt enable set */
+#define REG_PAC_INTFLAGAHB      (*(__IO uint32_t*)0x40000010U) /**< (PAC) Bridge interrupt flag status */
+#define REG_PAC_INTFLAGA        (*(__IO uint32_t*)0x40000014U) /**< (PAC) Peripheral interrupt flag status - Bridge A */
+#define REG_PAC_INTFLAGB        (*(__IO uint32_t*)0x40000018U) /**< (PAC) Peripheral interrupt flag status - Bridge B */
+#define REG_PAC_INTFLAGC        (*(__IO uint32_t*)0x4000001CU) /**< (PAC) Peripheral interrupt flag status - Bridge C */
+#define REG_PAC_STATUSA         (*(__I  uint32_t*)0x40000034U) /**< (PAC) Peripheral write protection status - Bridge A */
+#define REG_PAC_STATUSB         (*(__I  uint32_t*)0x40000038U) /**< (PAC) Peripheral write protection status - Bridge B */
+#define REG_PAC_STATUSC         (*(__I  uint32_t*)0x4000003CU) /**< (PAC) Peripheral write protection status - Bridge C */
+#define REG_PAC_NONSECA         (*(__I  uint32_t*)0x40000054U) /**< (PAC) Peripheral non-secure status - Bridge A */
+#define REG_PAC_NONSECB         (*(__I  uint32_t*)0x40000058U) /**< (PAC) Peripheral non-secure status - Bridge B */
+#define REG_PAC_NONSECC         (*(__I  uint32_t*)0x4000005CU) /**< (PAC) Peripheral non-secure status - Bridge C */
+#define REG_PAC_SECLOCKA        (*(__I  uint32_t*)0x40000074U) /**< (PAC) Peripheral secure status locked - Bridge A */
+#define REG_PAC_SECLOCKB        (*(__I  uint32_t*)0x40000078U) /**< (PAC) Peripheral secure status locked - Bridge B */
+#define REG_PAC_SECLOCKC        (*(__I  uint32_t*)0x4000007CU) /**< (PAC) Peripheral secure status locked - Bridge C */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for PAC peripheral ========== */
+#define PAC_HPB_NUM                              3          /* Number of bridges AHB/APB */
+#define PAC_SECURE_IMPLEMENTED                   1          /* Security Configuration implemented? */
+#define PAC_INSTANCE_ID                          0          
+
+#endif /* _SAML11_PAC_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/instance/pm.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/instance/pm.h
@@ -1,0 +1,62 @@
+/**
+ * \file
+ *
+ * \brief Instance description for PM
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_PM_INSTANCE_H_
+#define _SAML11_PM_INSTANCE_H_
+
+/* ========== Register definition for PM peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_PM_SLEEPCFG         (0x40000401) /**< (PM) Sleep Configuration */
+#define REG_PM_PLCFG            (0x40000402) /**< (PM) Performance Level Configuration */
+#define REG_PM_PWCFG            (0x40000403) /**< (PM) Power Configuration */
+#define REG_PM_INTENCLR         (0x40000404) /**< (PM) Interrupt Enable Clear */
+#define REG_PM_INTENSET         (0x40000405) /**< (PM) Interrupt Enable Set */
+#define REG_PM_INTFLAG          (0x40000406) /**< (PM) Interrupt Flag Status and Clear */
+#define REG_PM_STDBYCFG         (0x40000408) /**< (PM) Standby Configuration */
+
+#else
+
+#define REG_PM_SLEEPCFG         (*(__IO uint8_t*)0x40000401U) /**< (PM) Sleep Configuration */
+#define REG_PM_PLCFG            (*(__IO uint8_t*)0x40000402U) /**< (PM) Performance Level Configuration */
+#define REG_PM_PWCFG            (*(__IO uint8_t*)0x40000403U) /**< (PM) Power Configuration */
+#define REG_PM_INTENCLR         (*(__IO uint8_t*)0x40000404U) /**< (PM) Interrupt Enable Clear */
+#define REG_PM_INTENSET         (*(__IO uint8_t*)0x40000405U) /**< (PM) Interrupt Enable Set */
+#define REG_PM_INTFLAG          (*(__IO uint8_t*)0x40000406U) /**< (PM) Interrupt Flag Status and Clear */
+#define REG_PM_STDBYCFG         (*(__IO uint16_t*)0x40000408U) /**< (PM) Standby Configuration */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for PM peripheral ========== */
+#define PM_BIAS_RAM_HS                           1          /* one if RAM HS can be back biased */
+#define PM_PD_NUM                                1          /* Number of switchable Power Domain */
+#define PM_INSTANCE_ID                           1          
+
+#endif /* _SAML11_PM_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/instance/port.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/instance/port.h
@@ -1,0 +1,93 @@
+/**
+ * \file
+ *
+ * \brief Instance description for PORT
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_PORT_INSTANCE_H_
+#define _SAML11_PORT_INSTANCE_H_
+
+/* ========== Register definition for PORT peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_PORT_DIR0           (0x40003000) /**< (PORT) Data Direction 0 */
+#define REG_PORT_DIRCLR0        (0x40003004) /**< (PORT) Data Direction Clear 0 */
+#define REG_PORT_DIRSET0        (0x40003008) /**< (PORT) Data Direction Set 0 */
+#define REG_PORT_DIRTGL0        (0x4000300C) /**< (PORT) Data Direction Toggle 0 */
+#define REG_PORT_OUT0           (0x40003010) /**< (PORT) Data Output Value 0 */
+#define REG_PORT_OUTCLR0        (0x40003014) /**< (PORT) Data Output Value Clear 0 */
+#define REG_PORT_OUTSET0        (0x40003018) /**< (PORT) Data Output Value Set 0 */
+#define REG_PORT_OUTTGL0        (0x4000301C) /**< (PORT) Data Output Value Toggle 0 */
+#define REG_PORT_IN0            (0x40003020) /**< (PORT) Data Input Value 0 */
+#define REG_PORT_CTRL0          (0x40003024) /**< (PORT) Control 0 */
+#define REG_PORT_WRCONFIG0      (0x40003028) /**< (PORT) Write Configuration 0 */
+#define REG_PORT_EVCTRL0        (0x4000302C) /**< (PORT) Event Input Control 0 */
+#define REG_PORT_PMUX0          (0x40003030) /**< (PORT) Peripheral Multiplexing 0 */
+#define REG_PORT_PINCFG0        (0x40003040) /**< (PORT) Pin Configuration 0 */
+#define REG_PORT_INTENCLR0      (0x40003060) /**< (PORT) Interrupt Enable Clear 0 */
+#define REG_PORT_INTENSET0      (0x40003064) /**< (PORT) Interrupt Enable Set 0 */
+#define REG_PORT_INTFLAG0       (0x40003068) /**< (PORT) Interrupt Flag Status and Clear 0 */
+#define REG_PORT_NONSEC0        (0x4000306C) /**< (PORT) Security Attribution 0 */
+#define REG_PORT_NSCHK0         (0x40003070) /**< (PORT) Security Attribution Check 0 */
+
+#else
+
+#define REG_PORT_DIR0           (*(__IO uint32_t*)0x40003000U) /**< (PORT) Data Direction 0 */
+#define REG_PORT_DIRCLR0        (*(__IO uint32_t*)0x40003004U) /**< (PORT) Data Direction Clear 0 */
+#define REG_PORT_DIRSET0        (*(__IO uint32_t*)0x40003008U) /**< (PORT) Data Direction Set 0 */
+#define REG_PORT_DIRTGL0        (*(__IO uint32_t*)0x4000300CU) /**< (PORT) Data Direction Toggle 0 */
+#define REG_PORT_OUT0           (*(__IO uint32_t*)0x40003010U) /**< (PORT) Data Output Value 0 */
+#define REG_PORT_OUTCLR0        (*(__IO uint32_t*)0x40003014U) /**< (PORT) Data Output Value Clear 0 */
+#define REG_PORT_OUTSET0        (*(__IO uint32_t*)0x40003018U) /**< (PORT) Data Output Value Set 0 */
+#define REG_PORT_OUTTGL0        (*(__IO uint32_t*)0x4000301CU) /**< (PORT) Data Output Value Toggle 0 */
+#define REG_PORT_IN0            (*(__I  uint32_t*)0x40003020U) /**< (PORT) Data Input Value 0 */
+#define REG_PORT_CTRL0          (*(__IO uint32_t*)0x40003024U) /**< (PORT) Control 0 */
+#define REG_PORT_WRCONFIG0      (*(__O  uint32_t*)0x40003028U) /**< (PORT) Write Configuration 0 */
+#define REG_PORT_EVCTRL0        (*(__IO uint32_t*)0x4000302CU) /**< (PORT) Event Input Control 0 */
+#define REG_PORT_PMUX0          (*(__IO uint8_t*)0x40003030U) /**< (PORT) Peripheral Multiplexing 0 */
+#define REG_PORT_PINCFG0        (*(__IO uint8_t*)0x40003040U) /**< (PORT) Pin Configuration 0 */
+#define REG_PORT_INTENCLR0      (*(__IO uint32_t*)0x40003060U) /**< (PORT) Interrupt Enable Clear 0 */
+#define REG_PORT_INTENSET0      (*(__IO uint32_t*)0x40003064U) /**< (PORT) Interrupt Enable Set 0 */
+#define REG_PORT_INTFLAG0       (*(__IO uint32_t*)0x40003068U) /**< (PORT) Interrupt Flag Status and Clear 0 */
+#define REG_PORT_NONSEC0        (*(__IO uint32_t*)0x4000306CU) /**< (PORT) Security Attribution 0 */
+#define REG_PORT_NSCHK0         (*(__IO uint32_t*)0x40003070U) /**< (PORT) Security Attribution Check 0 */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for PORT peripheral ========== */
+#define PORT_BITS                                32         
+#define PORT_DRVSTR                              1          /* DRVSTR supported */
+#define PORT_EV_NUM                              4          
+#define PORT_GROUPS                              1          
+#define PORT_MSB                                 31         
+#define PORT_ODRAIN                              0          /* ODRAIN supported */
+#define PORT_PPP_IMPLEMENTED                     0          /* IOBUS2 implemented? */
+#define PORT_SECURE_IMPLEMENTED                  1          /* Secure I/Os supported? */
+#define PORT_SLEWLIM                             0          /* SLEWLIM supported */
+#define PORT_INSTANCE_ID                         12         
+
+#endif /* _SAML11_PORT_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/instance/ptc.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/instance/ptc.h
@@ -1,0 +1,54 @@
+/**
+ * \file
+ *
+ * \brief Instance description for PTC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_PTC_INSTANCE_H_
+#define _SAML11_PTC_INSTANCE_H_
+
+/* ========== Register definition for PTC peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+
+
+#else
+
+
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for PTC peripheral ========== */
+#define PTC_DMAC_ID_EOC                          21         /* Index of DMA EOC trigger */
+#define PTC_DMAC_ID_SEQ                          22         /* Index of DMA SEQ trigger */
+#define PTC_DMAC_ID_WCOMP                        23         /* Index of DMA WCOMP trigger */
+#define PTC_GCLK_ID                              19         /* Index of Generic Clock */
+#define PTC_LINES_MSB                            19         
+#define PTC_LINES_NUM                            20         /* Number of PTC lines */
+#define PTC_INSTANCE_ID                          73         
+
+#endif /* _SAML11_PTC_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/instance/rstc.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/instance/rstc.h
@@ -1,0 +1,50 @@
+/**
+ * \file
+ *
+ * \brief Instance description for RSTC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_RSTC_INSTANCE_H_
+#define _SAML11_RSTC_INSTANCE_H_
+
+/* ========== Register definition for RSTC peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_RSTC_RCAUSE         (0x40000C00) /**< (RSTC) Reset Cause */
+
+#else
+
+#define REG_RSTC_RCAUSE         (*(__I  uint8_t*)0x40000C00U) /**< (RSTC) Reset Cause */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for RSTC peripheral ========== */
+#define RSTC_BACKUP_IMPLEMENTED                  0          
+#define RSTC_NUMBER_OF_EXTWAKE                   0          /* number of external wakeup line */
+#define RSTC_INSTANCE_ID                         3          
+
+#endif /* _SAML11_RSTC_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/instance/rtc.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/instance/rtc.h
@@ -1,0 +1,140 @@
+/**
+ * \file
+ *
+ * \brief Instance description for RTC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_RTC_INSTANCE_H_
+#define _SAML11_RTC_INSTANCE_H_
+
+/* ========== Register definition for RTC peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_RTC_DBGCTRL         (0x4000240E) /**< (RTC) Debug Control */
+#define REG_RTC_FREQCORR        (0x40002414) /**< (RTC) Frequency Correction */
+#define REG_RTC_GP              (0x40002440) /**< (RTC) General Purpose */
+#define REG_RTC_GP0             (0x40002440) /**< (RTC) General Purpose 0 */
+#define REG_RTC_GP1             (0x40002444) /**< (RTC) General Purpose 1 */
+#define REG_RTC_TAMPCTRL        (0x40002460) /**< (RTC) Tamper Control */
+#define REG_RTC_TAMPID          (0x40002468) /**< (RTC) Tamper ID */
+#define REG_RTC_TAMPCTRLB       (0x4000246C) /**< (RTC) Tamper Control B */
+#define REG_RTC_MODE0_CTRLA     (0x40002400) /**< (RTC) MODE0 Control A */
+#define REG_RTC_MODE0_CTRLB     (0x40002402) /**< (RTC) MODE0 Control B */
+#define REG_RTC_MODE0_EVCTRL    (0x40002404) /**< (RTC) MODE0 Event Control */
+#define REG_RTC_MODE0_INTENCLR  (0x40002408) /**< (RTC) MODE0 Interrupt Enable Clear */
+#define REG_RTC_MODE0_INTENSET  (0x4000240A) /**< (RTC) MODE0 Interrupt Enable Set */
+#define REG_RTC_MODE0_INTFLAG   (0x4000240C) /**< (RTC) MODE0 Interrupt Flag Status and Clear */
+#define REG_RTC_MODE0_SYNCBUSY  (0x40002410) /**< (RTC) MODE0 Synchronization Busy Status */
+#define REG_RTC_MODE0_COUNT     (0x40002418) /**< (RTC) MODE0 Counter Value */
+#define REG_RTC_MODE0_COMP      (0x40002420) /**< (RTC) MODE0 Compare n Value */
+#define REG_RTC_MODE0_COMP0     (0x40002420) /**< (RTC) MODE0 Compare 0 Value */
+#define REG_RTC_MODE0_TIMESTAMP (0x40002464) /**< (RTC) MODE0 Timestamp */
+#define REG_RTC_MODE1_CTRLA     (0x40002400) /**< (RTC) MODE1 Control A */
+#define REG_RTC_MODE1_CTRLB     (0x40002402) /**< (RTC) MODE1 Control B */
+#define REG_RTC_MODE1_EVCTRL    (0x40002404) /**< (RTC) MODE1 Event Control */
+#define REG_RTC_MODE1_INTENCLR  (0x40002408) /**< (RTC) MODE1 Interrupt Enable Clear */
+#define REG_RTC_MODE1_INTENSET  (0x4000240A) /**< (RTC) MODE1 Interrupt Enable Set */
+#define REG_RTC_MODE1_INTFLAG   (0x4000240C) /**< (RTC) MODE1 Interrupt Flag Status and Clear */
+#define REG_RTC_MODE1_SYNCBUSY  (0x40002410) /**< (RTC) MODE1 Synchronization Busy Status */
+#define REG_RTC_MODE1_COUNT     (0x40002418) /**< (RTC) MODE1 Counter Value */
+#define REG_RTC_MODE1_PER       (0x4000241C) /**< (RTC) MODE1 Counter Period */
+#define REG_RTC_MODE1_COMP      (0x40002420) /**< (RTC) MODE1 Compare n Value */
+#define REG_RTC_MODE1_COMP0     (0x40002420) /**< (RTC) MODE1 Compare 0 Value */
+#define REG_RTC_MODE1_COMP1     (0x40002422) /**< (RTC) MODE1 Compare 1 Value */
+#define REG_RTC_MODE1_TIMESTAMP (0x40002464) /**< (RTC) MODE1 Timestamp */
+#define REG_RTC_MODE2_ALARM0    (0x40002420) /**< (RTC) MODE2_ALARM Alarm 0 Value */
+#define REG_RTC_MODE2_MASK0     (0x40002424) /**< (RTC) MODE2_ALARM Alarm 0 Mask */
+#define REG_RTC_MODE2_CTRLA     (0x40002400) /**< (RTC) MODE2 Control A */
+#define REG_RTC_MODE2_CTRLB     (0x40002402) /**< (RTC) MODE2 Control B */
+#define REG_RTC_MODE2_EVCTRL    (0x40002404) /**< (RTC) MODE2 Event Control */
+#define REG_RTC_MODE2_INTENCLR  (0x40002408) /**< (RTC) MODE2 Interrupt Enable Clear */
+#define REG_RTC_MODE2_INTENSET  (0x4000240A) /**< (RTC) MODE2 Interrupt Enable Set */
+#define REG_RTC_MODE2_INTFLAG   (0x4000240C) /**< (RTC) MODE2 Interrupt Flag Status and Clear */
+#define REG_RTC_MODE2_SYNCBUSY  (0x40002410) /**< (RTC) MODE2 Synchronization Busy Status */
+#define REG_RTC_MODE2_CLOCK     (0x40002418) /**< (RTC) MODE2 Clock Value */
+#define REG_RTC_MODE2_TIMESTAMP (0x40002464) /**< (RTC) MODE2 Timestamp */
+
+#else
+
+#define REG_RTC_DBGCTRL         (*(__IO uint8_t*)0x4000240EU) /**< (RTC) Debug Control */
+#define REG_RTC_FREQCORR        (*(__IO uint8_t*)0x40002414U) /**< (RTC) Frequency Correction */
+#define REG_RTC_GP              (*(__IO uint32_t*)0x40002440U) /**< (RTC) General Purpose */
+#define REG_RTC_GP0             (*(__IO uint32_t*)0x40002440U) /**< (RTC) General Purpose 0 */
+#define REG_RTC_GP1             (*(__IO uint32_t*)0x40002444U) /**< (RTC) General Purpose 1 */
+#define REG_RTC_TAMPCTRL        (*(__IO uint32_t*)0x40002460U) /**< (RTC) Tamper Control */
+#define REG_RTC_TAMPID          (*(__IO uint32_t*)0x40002468U) /**< (RTC) Tamper ID */
+#define REG_RTC_TAMPCTRLB       (*(__IO uint32_t*)0x4000246CU) /**< (RTC) Tamper Control B */
+#define REG_RTC_MODE0_CTRLA     (*(__IO uint16_t*)0x40002400U) /**< (RTC) MODE0 Control A */
+#define REG_RTC_MODE0_CTRLB     (*(__IO uint16_t*)0x40002402U) /**< (RTC) MODE0 Control B */
+#define REG_RTC_MODE0_EVCTRL    (*(__IO uint32_t*)0x40002404U) /**< (RTC) MODE0 Event Control */
+#define REG_RTC_MODE0_INTENCLR  (*(__IO uint16_t*)0x40002408U) /**< (RTC) MODE0 Interrupt Enable Clear */
+#define REG_RTC_MODE0_INTENSET  (*(__IO uint16_t*)0x4000240AU) /**< (RTC) MODE0 Interrupt Enable Set */
+#define REG_RTC_MODE0_INTFLAG   (*(__IO uint16_t*)0x4000240CU) /**< (RTC) MODE0 Interrupt Flag Status and Clear */
+#define REG_RTC_MODE0_SYNCBUSY  (*(__I  uint32_t*)0x40002410U) /**< (RTC) MODE0 Synchronization Busy Status */
+#define REG_RTC_MODE0_COUNT     (*(__IO uint32_t*)0x40002418U) /**< (RTC) MODE0 Counter Value */
+#define REG_RTC_MODE0_COMP      (*(__IO uint32_t*)0x40002420U) /**< (RTC) MODE0 Compare n Value */
+#define REG_RTC_MODE0_COMP0     (*(__IO uint32_t*)0x40002420U) /**< (RTC) MODE0 Compare 0 Value */
+#define REG_RTC_MODE0_TIMESTAMP (*(__I  uint32_t*)0x40002464U) /**< (RTC) MODE0 Timestamp */
+#define REG_RTC_MODE1_CTRLA     (*(__IO uint16_t*)0x40002400U) /**< (RTC) MODE1 Control A */
+#define REG_RTC_MODE1_CTRLB     (*(__IO uint16_t*)0x40002402U) /**< (RTC) MODE1 Control B */
+#define REG_RTC_MODE1_EVCTRL    (*(__IO uint32_t*)0x40002404U) /**< (RTC) MODE1 Event Control */
+#define REG_RTC_MODE1_INTENCLR  (*(__IO uint16_t*)0x40002408U) /**< (RTC) MODE1 Interrupt Enable Clear */
+#define REG_RTC_MODE1_INTENSET  (*(__IO uint16_t*)0x4000240AU) /**< (RTC) MODE1 Interrupt Enable Set */
+#define REG_RTC_MODE1_INTFLAG   (*(__IO uint16_t*)0x4000240CU) /**< (RTC) MODE1 Interrupt Flag Status and Clear */
+#define REG_RTC_MODE1_SYNCBUSY  (*(__I  uint32_t*)0x40002410U) /**< (RTC) MODE1 Synchronization Busy Status */
+#define REG_RTC_MODE1_COUNT     (*(__IO uint16_t*)0x40002418U) /**< (RTC) MODE1 Counter Value */
+#define REG_RTC_MODE1_PER       (*(__IO uint16_t*)0x4000241CU) /**< (RTC) MODE1 Counter Period */
+#define REG_RTC_MODE1_COMP      (*(__IO uint16_t*)0x40002420U) /**< (RTC) MODE1 Compare n Value */
+#define REG_RTC_MODE1_COMP0     (*(__IO uint16_t*)0x40002420U) /**< (RTC) MODE1 Compare 0 Value */
+#define REG_RTC_MODE1_COMP1     (*(__IO uint16_t*)0x40002422U) /**< (RTC) MODE1 Compare 1 Value */
+#define REG_RTC_MODE1_TIMESTAMP (*(__I  uint32_t*)0x40002464U) /**< (RTC) MODE1 Timestamp */
+#define REG_RTC_MODE2_ALARM0    (*(__IO uint32_t*)0x40002420U) /**< (RTC) MODE2_ALARM Alarm 0 Value */
+#define REG_RTC_MODE2_MASK0     (*(__IO uint8_t*)0x40002424U) /**< (RTC) MODE2_ALARM Alarm 0 Mask */
+#define REG_RTC_MODE2_CTRLA     (*(__IO uint16_t*)0x40002400U) /**< (RTC) MODE2 Control A */
+#define REG_RTC_MODE2_CTRLB     (*(__IO uint16_t*)0x40002402U) /**< (RTC) MODE2 Control B */
+#define REG_RTC_MODE2_EVCTRL    (*(__IO uint32_t*)0x40002404U) /**< (RTC) MODE2 Event Control */
+#define REG_RTC_MODE2_INTENCLR  (*(__IO uint16_t*)0x40002408U) /**< (RTC) MODE2 Interrupt Enable Clear */
+#define REG_RTC_MODE2_INTENSET  (*(__IO uint16_t*)0x4000240AU) /**< (RTC) MODE2 Interrupt Enable Set */
+#define REG_RTC_MODE2_INTFLAG   (*(__IO uint16_t*)0x4000240CU) /**< (RTC) MODE2 Interrupt Flag Status and Clear */
+#define REG_RTC_MODE2_SYNCBUSY  (*(__I  uint32_t*)0x40002410U) /**< (RTC) MODE2 Synchronization Busy Status */
+#define REG_RTC_MODE2_CLOCK     (*(__IO uint32_t*)0x40002418U) /**< (RTC) MODE2 Clock Value */
+#define REG_RTC_MODE2_TIMESTAMP (*(__I  uint32_t*)0x40002464U) /**< (RTC) MODE2 Timestamp */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for RTC peripheral ========== */
+#define RTC_DMAC_ID_TIMESTAMP                    1          /* DMA RTC timestamp trigger */
+#define RTC_GPR_NUM                              2          /* Number of General-Purpose Registers */
+#define RTC_NUM_OF_ALARMS                        1          /* Number of Alarms */
+#define RTC_NUM_OF_BKREGS                        0          /* Number of Backup Registers */
+#define RTC_NUM_OF_COMP16                        2          /* Number of 16-bit Comparators */
+#define RTC_NUM_OF_COMP32                        1          /* Number of 32-bit Comparators */
+#define RTC_NUM_OF_TAMPERS                       4          /* Number of Tamper Inputs */
+#define RTC_PER_NUM                              8          /* Number of Periodic Intervals */
+#define RTC_INSTANCE_ID                          9          
+
+#endif /* _SAML11_RTC_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/instance/sercom0.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/instance/sercom0.h
@@ -1,0 +1,150 @@
+/**
+ * \file
+ *
+ * \brief Instance description for SERCOM0
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_SERCOM0_INSTANCE_H_
+#define _SAML11_SERCOM0_INSTANCE_H_
+
+/* ========== Register definition for SERCOM0 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_SERCOM0_I2CM_CTRLA  (0x42000400) /**< (SERCOM0) I2CM Control A */
+#define REG_SERCOM0_I2CM_CTRLB  (0x42000404) /**< (SERCOM0) I2CM Control B */
+#define REG_SERCOM0_I2CM_BAUD   (0x4200040C) /**< (SERCOM0) I2CM Baud Rate */
+#define REG_SERCOM0_I2CM_INTENCLR (0x42000414) /**< (SERCOM0) I2CM Interrupt Enable Clear */
+#define REG_SERCOM0_I2CM_INTENSET (0x42000416) /**< (SERCOM0) I2CM Interrupt Enable Set */
+#define REG_SERCOM0_I2CM_INTFLAG (0x42000418) /**< (SERCOM0) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM0_I2CM_STATUS (0x4200041A) /**< (SERCOM0) I2CM Status */
+#define REG_SERCOM0_I2CM_SYNCBUSY (0x4200041C) /**< (SERCOM0) I2CM Synchronization Busy */
+#define REG_SERCOM0_I2CM_ADDR   (0x42000424) /**< (SERCOM0) I2CM Address */
+#define REG_SERCOM0_I2CM_DATA   (0x42000428) /**< (SERCOM0) I2CM Data */
+#define REG_SERCOM0_I2CM_DBGCTRL (0x42000430) /**< (SERCOM0) I2CM Debug Control */
+#define REG_SERCOM0_I2CS_CTRLA  (0x42000400) /**< (SERCOM0) I2CS Control A */
+#define REG_SERCOM0_I2CS_CTRLB  (0x42000404) /**< (SERCOM0) I2CS Control B */
+#define REG_SERCOM0_I2CS_INTENCLR (0x42000414) /**< (SERCOM0) I2CS Interrupt Enable Clear */
+#define REG_SERCOM0_I2CS_INTENSET (0x42000416) /**< (SERCOM0) I2CS Interrupt Enable Set */
+#define REG_SERCOM0_I2CS_INTFLAG (0x42000418) /**< (SERCOM0) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM0_I2CS_STATUS (0x4200041A) /**< (SERCOM0) I2CS Status */
+#define REG_SERCOM0_I2CS_SYNCBUSY (0x4200041C) /**< (SERCOM0) I2CS Synchronization Busy */
+#define REG_SERCOM0_I2CS_ADDR   (0x42000424) /**< (SERCOM0) I2CS Address */
+#define REG_SERCOM0_I2CS_DATA   (0x42000428) /**< (SERCOM0) I2CS Data */
+#define REG_SERCOM0_SPI_CTRLA   (0x42000400) /**< (SERCOM0) SPI Control A */
+#define REG_SERCOM0_SPI_CTRLB   (0x42000404) /**< (SERCOM0) SPI Control B */
+#define REG_SERCOM0_SPI_BAUD    (0x4200040C) /**< (SERCOM0) SPI Baud Rate */
+#define REG_SERCOM0_SPI_INTENCLR (0x42000414) /**< (SERCOM0) SPI Interrupt Enable Clear */
+#define REG_SERCOM0_SPI_INTENSET (0x42000416) /**< (SERCOM0) SPI Interrupt Enable Set */
+#define REG_SERCOM0_SPI_INTFLAG (0x42000418) /**< (SERCOM0) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM0_SPI_STATUS  (0x4200041A) /**< (SERCOM0) SPI Status */
+#define REG_SERCOM0_SPI_SYNCBUSY (0x4200041C) /**< (SERCOM0) SPI Synchronization Busy */
+#define REG_SERCOM0_SPI_ADDR    (0x42000424) /**< (SERCOM0) SPI Address */
+#define REG_SERCOM0_SPI_DATA    (0x42000428) /**< (SERCOM0) SPI Data */
+#define REG_SERCOM0_SPI_DBGCTRL (0x42000430) /**< (SERCOM0) SPI Debug Control */
+#define REG_SERCOM0_USART_CTRLA (0x42000400) /**< (SERCOM0) USART Control A */
+#define REG_SERCOM0_USART_CTRLB (0x42000404) /**< (SERCOM0) USART Control B */
+#define REG_SERCOM0_USART_CTRLC (0x42000408) /**< (SERCOM0) USART Control C */
+#define REG_SERCOM0_USART_BAUD  (0x4200040C) /**< (SERCOM0) USART Baud Rate */
+#define REG_SERCOM0_USART_RXPL  (0x4200040E) /**< (SERCOM0) USART Receive Pulse Length */
+#define REG_SERCOM0_USART_INTENCLR (0x42000414) /**< (SERCOM0) USART Interrupt Enable Clear */
+#define REG_SERCOM0_USART_INTENSET (0x42000416) /**< (SERCOM0) USART Interrupt Enable Set */
+#define REG_SERCOM0_USART_INTFLAG (0x42000418) /**< (SERCOM0) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM0_USART_STATUS (0x4200041A) /**< (SERCOM0) USART Status */
+#define REG_SERCOM0_USART_SYNCBUSY (0x4200041C) /**< (SERCOM0) USART Synchronization Busy */
+#define REG_SERCOM0_USART_RXERRCNT (0x42000420) /**< (SERCOM0) USART Receive Error Count */
+#define REG_SERCOM0_USART_DATA  (0x42000428) /**< (SERCOM0) USART Data */
+#define REG_SERCOM0_USART_DBGCTRL (0x42000430) /**< (SERCOM0) USART Debug Control */
+
+#else
+
+#define REG_SERCOM0_I2CM_CTRLA  (*(__IO uint32_t*)0x42000400U) /**< (SERCOM0) I2CM Control A */
+#define REG_SERCOM0_I2CM_CTRLB  (*(__IO uint32_t*)0x42000404U) /**< (SERCOM0) I2CM Control B */
+#define REG_SERCOM0_I2CM_BAUD   (*(__IO uint32_t*)0x4200040CU) /**< (SERCOM0) I2CM Baud Rate */
+#define REG_SERCOM0_I2CM_INTENCLR (*(__IO uint8_t*)0x42000414U) /**< (SERCOM0) I2CM Interrupt Enable Clear */
+#define REG_SERCOM0_I2CM_INTENSET (*(__IO uint8_t*)0x42000416U) /**< (SERCOM0) I2CM Interrupt Enable Set */
+#define REG_SERCOM0_I2CM_INTFLAG (*(__IO uint8_t*)0x42000418U) /**< (SERCOM0) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM0_I2CM_STATUS (*(__IO uint16_t*)0x4200041AU) /**< (SERCOM0) I2CM Status */
+#define REG_SERCOM0_I2CM_SYNCBUSY (*(__I  uint32_t*)0x4200041CU) /**< (SERCOM0) I2CM Synchronization Busy */
+#define REG_SERCOM0_I2CM_ADDR   (*(__IO uint32_t*)0x42000424U) /**< (SERCOM0) I2CM Address */
+#define REG_SERCOM0_I2CM_DATA   (*(__IO uint8_t*)0x42000428U) /**< (SERCOM0) I2CM Data */
+#define REG_SERCOM0_I2CM_DBGCTRL (*(__IO uint8_t*)0x42000430U) /**< (SERCOM0) I2CM Debug Control */
+#define REG_SERCOM0_I2CS_CTRLA  (*(__IO uint32_t*)0x42000400U) /**< (SERCOM0) I2CS Control A */
+#define REG_SERCOM0_I2CS_CTRLB  (*(__IO uint32_t*)0x42000404U) /**< (SERCOM0) I2CS Control B */
+#define REG_SERCOM0_I2CS_INTENCLR (*(__IO uint8_t*)0x42000414U) /**< (SERCOM0) I2CS Interrupt Enable Clear */
+#define REG_SERCOM0_I2CS_INTENSET (*(__IO uint8_t*)0x42000416U) /**< (SERCOM0) I2CS Interrupt Enable Set */
+#define REG_SERCOM0_I2CS_INTFLAG (*(__IO uint8_t*)0x42000418U) /**< (SERCOM0) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM0_I2CS_STATUS (*(__IO uint16_t*)0x4200041AU) /**< (SERCOM0) I2CS Status */
+#define REG_SERCOM0_I2CS_SYNCBUSY (*(__I  uint32_t*)0x4200041CU) /**< (SERCOM0) I2CS Synchronization Busy */
+#define REG_SERCOM0_I2CS_ADDR   (*(__IO uint32_t*)0x42000424U) /**< (SERCOM0) I2CS Address */
+#define REG_SERCOM0_I2CS_DATA   (*(__IO uint8_t*)0x42000428U) /**< (SERCOM0) I2CS Data */
+#define REG_SERCOM0_SPI_CTRLA   (*(__IO uint32_t*)0x42000400U) /**< (SERCOM0) SPI Control A */
+#define REG_SERCOM0_SPI_CTRLB   (*(__IO uint32_t*)0x42000404U) /**< (SERCOM0) SPI Control B */
+#define REG_SERCOM0_SPI_BAUD    (*(__IO uint8_t*)0x4200040CU) /**< (SERCOM0) SPI Baud Rate */
+#define REG_SERCOM0_SPI_INTENCLR (*(__IO uint8_t*)0x42000414U) /**< (SERCOM0) SPI Interrupt Enable Clear */
+#define REG_SERCOM0_SPI_INTENSET (*(__IO uint8_t*)0x42000416U) /**< (SERCOM0) SPI Interrupt Enable Set */
+#define REG_SERCOM0_SPI_INTFLAG (*(__IO uint8_t*)0x42000418U) /**< (SERCOM0) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM0_SPI_STATUS  (*(__IO uint16_t*)0x4200041AU) /**< (SERCOM0) SPI Status */
+#define REG_SERCOM0_SPI_SYNCBUSY (*(__I  uint32_t*)0x4200041CU) /**< (SERCOM0) SPI Synchronization Busy */
+#define REG_SERCOM0_SPI_ADDR    (*(__IO uint32_t*)0x42000424U) /**< (SERCOM0) SPI Address */
+#define REG_SERCOM0_SPI_DATA    (*(__IO uint32_t*)0x42000428U) /**< (SERCOM0) SPI Data */
+#define REG_SERCOM0_SPI_DBGCTRL (*(__IO uint8_t*)0x42000430U) /**< (SERCOM0) SPI Debug Control */
+#define REG_SERCOM0_USART_CTRLA (*(__IO uint32_t*)0x42000400U) /**< (SERCOM0) USART Control A */
+#define REG_SERCOM0_USART_CTRLB (*(__IO uint32_t*)0x42000404U) /**< (SERCOM0) USART Control B */
+#define REG_SERCOM0_USART_CTRLC (*(__IO uint32_t*)0x42000408U) /**< (SERCOM0) USART Control C */
+#define REG_SERCOM0_USART_BAUD  (*(__IO uint16_t*)0x4200040CU) /**< (SERCOM0) USART Baud Rate */
+#define REG_SERCOM0_USART_RXPL  (*(__IO uint8_t*)0x4200040EU) /**< (SERCOM0) USART Receive Pulse Length */
+#define REG_SERCOM0_USART_INTENCLR (*(__IO uint8_t*)0x42000414U) /**< (SERCOM0) USART Interrupt Enable Clear */
+#define REG_SERCOM0_USART_INTENSET (*(__IO uint8_t*)0x42000416U) /**< (SERCOM0) USART Interrupt Enable Set */
+#define REG_SERCOM0_USART_INTFLAG (*(__IO uint8_t*)0x42000418U) /**< (SERCOM0) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM0_USART_STATUS (*(__IO uint16_t*)0x4200041AU) /**< (SERCOM0) USART Status */
+#define REG_SERCOM0_USART_SYNCBUSY (*(__I  uint32_t*)0x4200041CU) /**< (SERCOM0) USART Synchronization Busy */
+#define REG_SERCOM0_USART_RXERRCNT (*(__I  uint8_t*)0x42000420U) /**< (SERCOM0) USART Receive Error Count */
+#define REG_SERCOM0_USART_DATA  (*(__IO uint16_t*)0x42000428U) /**< (SERCOM0) USART Data */
+#define REG_SERCOM0_USART_DBGCTRL (*(__IO uint8_t*)0x42000430U) /**< (SERCOM0) USART Debug Control */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for SERCOM0 peripheral ========== */
+#define SERCOM0_DMAC_ID_RX                       4          /* Index of DMA RX trigger */
+#define SERCOM0_DMAC_ID_TX                       5          /* Index of DMA TX trigger */
+#define SERCOM0_FIFO_DEPTH_POWER                 1          /* Rx Fifo depth = 2^FIFO_DEPTH_POWER */
+#define SERCOM0_GCLK_ID_CORE                     11         
+#define SERCOM0_GCLK_ID_SLOW                     10         
+#define SERCOM0_INT_MSB                          6          
+#define SERCOM0_PMSB                             3          
+#define SERCOM0_SPI                              1          /* SPI mode implemented? */
+#define SERCOM0_TWIM                             1          /* TWI Master mode implemented? */
+#define SERCOM0_TWIS                             1          /* TWI Slave mode implemented? */
+#define SERCOM0_TWI_HSMODE                       1          /* TWI HighSpeed mode implemented? */
+#define SERCOM0_USART                            1          /* USART mode implemented? */
+#define SERCOM0_USART_AUTOBAUD                   0          /* USART AUTOBAUD mode implemented? */
+#define SERCOM0_USART_ISO7816                    0          /* USART ISO7816 mode implemented? */
+#define SERCOM0_USART_LIN_MASTER                 0          /* USART LIN Master mode implemented? */
+#define SERCOM0_USART_RS485                      0          /* USART RS485 mode implemented? */
+#define SERCOM0_INSTANCE_ID                      65         
+
+#endif /* _SAML11_SERCOM0_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/instance/sercom1.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/instance/sercom1.h
@@ -1,0 +1,150 @@
+/**
+ * \file
+ *
+ * \brief Instance description for SERCOM1
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_SERCOM1_INSTANCE_H_
+#define _SAML11_SERCOM1_INSTANCE_H_
+
+/* ========== Register definition for SERCOM1 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_SERCOM1_I2CM_CTRLA  (0x42000800) /**< (SERCOM1) I2CM Control A */
+#define REG_SERCOM1_I2CM_CTRLB  (0x42000804) /**< (SERCOM1) I2CM Control B */
+#define REG_SERCOM1_I2CM_BAUD   (0x4200080C) /**< (SERCOM1) I2CM Baud Rate */
+#define REG_SERCOM1_I2CM_INTENCLR (0x42000814) /**< (SERCOM1) I2CM Interrupt Enable Clear */
+#define REG_SERCOM1_I2CM_INTENSET (0x42000816) /**< (SERCOM1) I2CM Interrupt Enable Set */
+#define REG_SERCOM1_I2CM_INTFLAG (0x42000818) /**< (SERCOM1) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM1_I2CM_STATUS (0x4200081A) /**< (SERCOM1) I2CM Status */
+#define REG_SERCOM1_I2CM_SYNCBUSY (0x4200081C) /**< (SERCOM1) I2CM Synchronization Busy */
+#define REG_SERCOM1_I2CM_ADDR   (0x42000824) /**< (SERCOM1) I2CM Address */
+#define REG_SERCOM1_I2CM_DATA   (0x42000828) /**< (SERCOM1) I2CM Data */
+#define REG_SERCOM1_I2CM_DBGCTRL (0x42000830) /**< (SERCOM1) I2CM Debug Control */
+#define REG_SERCOM1_I2CS_CTRLA  (0x42000800) /**< (SERCOM1) I2CS Control A */
+#define REG_SERCOM1_I2CS_CTRLB  (0x42000804) /**< (SERCOM1) I2CS Control B */
+#define REG_SERCOM1_I2CS_INTENCLR (0x42000814) /**< (SERCOM1) I2CS Interrupt Enable Clear */
+#define REG_SERCOM1_I2CS_INTENSET (0x42000816) /**< (SERCOM1) I2CS Interrupt Enable Set */
+#define REG_SERCOM1_I2CS_INTFLAG (0x42000818) /**< (SERCOM1) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM1_I2CS_STATUS (0x4200081A) /**< (SERCOM1) I2CS Status */
+#define REG_SERCOM1_I2CS_SYNCBUSY (0x4200081C) /**< (SERCOM1) I2CS Synchronization Busy */
+#define REG_SERCOM1_I2CS_ADDR   (0x42000824) /**< (SERCOM1) I2CS Address */
+#define REG_SERCOM1_I2CS_DATA   (0x42000828) /**< (SERCOM1) I2CS Data */
+#define REG_SERCOM1_SPI_CTRLA   (0x42000800) /**< (SERCOM1) SPI Control A */
+#define REG_SERCOM1_SPI_CTRLB   (0x42000804) /**< (SERCOM1) SPI Control B */
+#define REG_SERCOM1_SPI_BAUD    (0x4200080C) /**< (SERCOM1) SPI Baud Rate */
+#define REG_SERCOM1_SPI_INTENCLR (0x42000814) /**< (SERCOM1) SPI Interrupt Enable Clear */
+#define REG_SERCOM1_SPI_INTENSET (0x42000816) /**< (SERCOM1) SPI Interrupt Enable Set */
+#define REG_SERCOM1_SPI_INTFLAG (0x42000818) /**< (SERCOM1) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM1_SPI_STATUS  (0x4200081A) /**< (SERCOM1) SPI Status */
+#define REG_SERCOM1_SPI_SYNCBUSY (0x4200081C) /**< (SERCOM1) SPI Synchronization Busy */
+#define REG_SERCOM1_SPI_ADDR    (0x42000824) /**< (SERCOM1) SPI Address */
+#define REG_SERCOM1_SPI_DATA    (0x42000828) /**< (SERCOM1) SPI Data */
+#define REG_SERCOM1_SPI_DBGCTRL (0x42000830) /**< (SERCOM1) SPI Debug Control */
+#define REG_SERCOM1_USART_CTRLA (0x42000800) /**< (SERCOM1) USART Control A */
+#define REG_SERCOM1_USART_CTRLB (0x42000804) /**< (SERCOM1) USART Control B */
+#define REG_SERCOM1_USART_CTRLC (0x42000808) /**< (SERCOM1) USART Control C */
+#define REG_SERCOM1_USART_BAUD  (0x4200080C) /**< (SERCOM1) USART Baud Rate */
+#define REG_SERCOM1_USART_RXPL  (0x4200080E) /**< (SERCOM1) USART Receive Pulse Length */
+#define REG_SERCOM1_USART_INTENCLR (0x42000814) /**< (SERCOM1) USART Interrupt Enable Clear */
+#define REG_SERCOM1_USART_INTENSET (0x42000816) /**< (SERCOM1) USART Interrupt Enable Set */
+#define REG_SERCOM1_USART_INTFLAG (0x42000818) /**< (SERCOM1) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM1_USART_STATUS (0x4200081A) /**< (SERCOM1) USART Status */
+#define REG_SERCOM1_USART_SYNCBUSY (0x4200081C) /**< (SERCOM1) USART Synchronization Busy */
+#define REG_SERCOM1_USART_RXERRCNT (0x42000820) /**< (SERCOM1) USART Receive Error Count */
+#define REG_SERCOM1_USART_DATA  (0x42000828) /**< (SERCOM1) USART Data */
+#define REG_SERCOM1_USART_DBGCTRL (0x42000830) /**< (SERCOM1) USART Debug Control */
+
+#else
+
+#define REG_SERCOM1_I2CM_CTRLA  (*(__IO uint32_t*)0x42000800U) /**< (SERCOM1) I2CM Control A */
+#define REG_SERCOM1_I2CM_CTRLB  (*(__IO uint32_t*)0x42000804U) /**< (SERCOM1) I2CM Control B */
+#define REG_SERCOM1_I2CM_BAUD   (*(__IO uint32_t*)0x4200080CU) /**< (SERCOM1) I2CM Baud Rate */
+#define REG_SERCOM1_I2CM_INTENCLR (*(__IO uint8_t*)0x42000814U) /**< (SERCOM1) I2CM Interrupt Enable Clear */
+#define REG_SERCOM1_I2CM_INTENSET (*(__IO uint8_t*)0x42000816U) /**< (SERCOM1) I2CM Interrupt Enable Set */
+#define REG_SERCOM1_I2CM_INTFLAG (*(__IO uint8_t*)0x42000818U) /**< (SERCOM1) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM1_I2CM_STATUS (*(__IO uint16_t*)0x4200081AU) /**< (SERCOM1) I2CM Status */
+#define REG_SERCOM1_I2CM_SYNCBUSY (*(__I  uint32_t*)0x4200081CU) /**< (SERCOM1) I2CM Synchronization Busy */
+#define REG_SERCOM1_I2CM_ADDR   (*(__IO uint32_t*)0x42000824U) /**< (SERCOM1) I2CM Address */
+#define REG_SERCOM1_I2CM_DATA   (*(__IO uint8_t*)0x42000828U) /**< (SERCOM1) I2CM Data */
+#define REG_SERCOM1_I2CM_DBGCTRL (*(__IO uint8_t*)0x42000830U) /**< (SERCOM1) I2CM Debug Control */
+#define REG_SERCOM1_I2CS_CTRLA  (*(__IO uint32_t*)0x42000800U) /**< (SERCOM1) I2CS Control A */
+#define REG_SERCOM1_I2CS_CTRLB  (*(__IO uint32_t*)0x42000804U) /**< (SERCOM1) I2CS Control B */
+#define REG_SERCOM1_I2CS_INTENCLR (*(__IO uint8_t*)0x42000814U) /**< (SERCOM1) I2CS Interrupt Enable Clear */
+#define REG_SERCOM1_I2CS_INTENSET (*(__IO uint8_t*)0x42000816U) /**< (SERCOM1) I2CS Interrupt Enable Set */
+#define REG_SERCOM1_I2CS_INTFLAG (*(__IO uint8_t*)0x42000818U) /**< (SERCOM1) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM1_I2CS_STATUS (*(__IO uint16_t*)0x4200081AU) /**< (SERCOM1) I2CS Status */
+#define REG_SERCOM1_I2CS_SYNCBUSY (*(__I  uint32_t*)0x4200081CU) /**< (SERCOM1) I2CS Synchronization Busy */
+#define REG_SERCOM1_I2CS_ADDR   (*(__IO uint32_t*)0x42000824U) /**< (SERCOM1) I2CS Address */
+#define REG_SERCOM1_I2CS_DATA   (*(__IO uint8_t*)0x42000828U) /**< (SERCOM1) I2CS Data */
+#define REG_SERCOM1_SPI_CTRLA   (*(__IO uint32_t*)0x42000800U) /**< (SERCOM1) SPI Control A */
+#define REG_SERCOM1_SPI_CTRLB   (*(__IO uint32_t*)0x42000804U) /**< (SERCOM1) SPI Control B */
+#define REG_SERCOM1_SPI_BAUD    (*(__IO uint8_t*)0x4200080CU) /**< (SERCOM1) SPI Baud Rate */
+#define REG_SERCOM1_SPI_INTENCLR (*(__IO uint8_t*)0x42000814U) /**< (SERCOM1) SPI Interrupt Enable Clear */
+#define REG_SERCOM1_SPI_INTENSET (*(__IO uint8_t*)0x42000816U) /**< (SERCOM1) SPI Interrupt Enable Set */
+#define REG_SERCOM1_SPI_INTFLAG (*(__IO uint8_t*)0x42000818U) /**< (SERCOM1) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM1_SPI_STATUS  (*(__IO uint16_t*)0x4200081AU) /**< (SERCOM1) SPI Status */
+#define REG_SERCOM1_SPI_SYNCBUSY (*(__I  uint32_t*)0x4200081CU) /**< (SERCOM1) SPI Synchronization Busy */
+#define REG_SERCOM1_SPI_ADDR    (*(__IO uint32_t*)0x42000824U) /**< (SERCOM1) SPI Address */
+#define REG_SERCOM1_SPI_DATA    (*(__IO uint32_t*)0x42000828U) /**< (SERCOM1) SPI Data */
+#define REG_SERCOM1_SPI_DBGCTRL (*(__IO uint8_t*)0x42000830U) /**< (SERCOM1) SPI Debug Control */
+#define REG_SERCOM1_USART_CTRLA (*(__IO uint32_t*)0x42000800U) /**< (SERCOM1) USART Control A */
+#define REG_SERCOM1_USART_CTRLB (*(__IO uint32_t*)0x42000804U) /**< (SERCOM1) USART Control B */
+#define REG_SERCOM1_USART_CTRLC (*(__IO uint32_t*)0x42000808U) /**< (SERCOM1) USART Control C */
+#define REG_SERCOM1_USART_BAUD  (*(__IO uint16_t*)0x4200080CU) /**< (SERCOM1) USART Baud Rate */
+#define REG_SERCOM1_USART_RXPL  (*(__IO uint8_t*)0x4200080EU) /**< (SERCOM1) USART Receive Pulse Length */
+#define REG_SERCOM1_USART_INTENCLR (*(__IO uint8_t*)0x42000814U) /**< (SERCOM1) USART Interrupt Enable Clear */
+#define REG_SERCOM1_USART_INTENSET (*(__IO uint8_t*)0x42000816U) /**< (SERCOM1) USART Interrupt Enable Set */
+#define REG_SERCOM1_USART_INTFLAG (*(__IO uint8_t*)0x42000818U) /**< (SERCOM1) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM1_USART_STATUS (*(__IO uint16_t*)0x4200081AU) /**< (SERCOM1) USART Status */
+#define REG_SERCOM1_USART_SYNCBUSY (*(__I  uint32_t*)0x4200081CU) /**< (SERCOM1) USART Synchronization Busy */
+#define REG_SERCOM1_USART_RXERRCNT (*(__I  uint8_t*)0x42000820U) /**< (SERCOM1) USART Receive Error Count */
+#define REG_SERCOM1_USART_DATA  (*(__IO uint16_t*)0x42000828U) /**< (SERCOM1) USART Data */
+#define REG_SERCOM1_USART_DBGCTRL (*(__IO uint8_t*)0x42000830U) /**< (SERCOM1) USART Debug Control */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for SERCOM1 peripheral ========== */
+#define SERCOM1_DMAC_ID_RX                       6          /* Index of DMA RX trigger */
+#define SERCOM1_DMAC_ID_TX                       7          /* Index of DMA TX trigger */
+#define SERCOM1_FIFO_DEPTH_POWER                 2          /* Rx Fifo depth = 2^FIFO_DEPTH_POWER */
+#define SERCOM1_GCLK_ID_CORE                     12         
+#define SERCOM1_GCLK_ID_SLOW                     10         
+#define SERCOM1_INT_MSB                          6          
+#define SERCOM1_PMSB                             3          
+#define SERCOM1_SPI                              1          /* SPI mode implemented? */
+#define SERCOM1_TWIM                             1          /* TWI Master mode implemented? */
+#define SERCOM1_TWIS                             1          /* TWI Slave mode implemented? */
+#define SERCOM1_TWI_HSMODE                       0          /* TWI HighSpeed mode implemented? */
+#define SERCOM1_USART                            1          /* USART mode implemented? */
+#define SERCOM1_USART_AUTOBAUD                   0          /* USART AUTOBAUD mode implemented? */
+#define SERCOM1_USART_ISO7816                    0          /* USART ISO7816 mode implemented? */
+#define SERCOM1_USART_LIN_MASTER                 0          /* USART LIN Master mode implemented? */
+#define SERCOM1_USART_RS485                      0          /* USART RS485 mode implemented? */
+#define SERCOM1_INSTANCE_ID                      66         
+
+#endif /* _SAML11_SERCOM1_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/instance/sercom2.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/instance/sercom2.h
@@ -1,0 +1,150 @@
+/**
+ * \file
+ *
+ * \brief Instance description for SERCOM2
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_SERCOM2_INSTANCE_H_
+#define _SAML11_SERCOM2_INSTANCE_H_
+
+/* ========== Register definition for SERCOM2 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_SERCOM2_I2CM_CTRLA  (0x42000C00) /**< (SERCOM2) I2CM Control A */
+#define REG_SERCOM2_I2CM_CTRLB  (0x42000C04) /**< (SERCOM2) I2CM Control B */
+#define REG_SERCOM2_I2CM_BAUD   (0x42000C0C) /**< (SERCOM2) I2CM Baud Rate */
+#define REG_SERCOM2_I2CM_INTENCLR (0x42000C14) /**< (SERCOM2) I2CM Interrupt Enable Clear */
+#define REG_SERCOM2_I2CM_INTENSET (0x42000C16) /**< (SERCOM2) I2CM Interrupt Enable Set */
+#define REG_SERCOM2_I2CM_INTFLAG (0x42000C18) /**< (SERCOM2) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM2_I2CM_STATUS (0x42000C1A) /**< (SERCOM2) I2CM Status */
+#define REG_SERCOM2_I2CM_SYNCBUSY (0x42000C1C) /**< (SERCOM2) I2CM Synchronization Busy */
+#define REG_SERCOM2_I2CM_ADDR   (0x42000C24) /**< (SERCOM2) I2CM Address */
+#define REG_SERCOM2_I2CM_DATA   (0x42000C28) /**< (SERCOM2) I2CM Data */
+#define REG_SERCOM2_I2CM_DBGCTRL (0x42000C30) /**< (SERCOM2) I2CM Debug Control */
+#define REG_SERCOM2_I2CS_CTRLA  (0x42000C00) /**< (SERCOM2) I2CS Control A */
+#define REG_SERCOM2_I2CS_CTRLB  (0x42000C04) /**< (SERCOM2) I2CS Control B */
+#define REG_SERCOM2_I2CS_INTENCLR (0x42000C14) /**< (SERCOM2) I2CS Interrupt Enable Clear */
+#define REG_SERCOM2_I2CS_INTENSET (0x42000C16) /**< (SERCOM2) I2CS Interrupt Enable Set */
+#define REG_SERCOM2_I2CS_INTFLAG (0x42000C18) /**< (SERCOM2) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM2_I2CS_STATUS (0x42000C1A) /**< (SERCOM2) I2CS Status */
+#define REG_SERCOM2_I2CS_SYNCBUSY (0x42000C1C) /**< (SERCOM2) I2CS Synchronization Busy */
+#define REG_SERCOM2_I2CS_ADDR   (0x42000C24) /**< (SERCOM2) I2CS Address */
+#define REG_SERCOM2_I2CS_DATA   (0x42000C28) /**< (SERCOM2) I2CS Data */
+#define REG_SERCOM2_SPI_CTRLA   (0x42000C00) /**< (SERCOM2) SPI Control A */
+#define REG_SERCOM2_SPI_CTRLB   (0x42000C04) /**< (SERCOM2) SPI Control B */
+#define REG_SERCOM2_SPI_BAUD    (0x42000C0C) /**< (SERCOM2) SPI Baud Rate */
+#define REG_SERCOM2_SPI_INTENCLR (0x42000C14) /**< (SERCOM2) SPI Interrupt Enable Clear */
+#define REG_SERCOM2_SPI_INTENSET (0x42000C16) /**< (SERCOM2) SPI Interrupt Enable Set */
+#define REG_SERCOM2_SPI_INTFLAG (0x42000C18) /**< (SERCOM2) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM2_SPI_STATUS  (0x42000C1A) /**< (SERCOM2) SPI Status */
+#define REG_SERCOM2_SPI_SYNCBUSY (0x42000C1C) /**< (SERCOM2) SPI Synchronization Busy */
+#define REG_SERCOM2_SPI_ADDR    (0x42000C24) /**< (SERCOM2) SPI Address */
+#define REG_SERCOM2_SPI_DATA    (0x42000C28) /**< (SERCOM2) SPI Data */
+#define REG_SERCOM2_SPI_DBGCTRL (0x42000C30) /**< (SERCOM2) SPI Debug Control */
+#define REG_SERCOM2_USART_CTRLA (0x42000C00) /**< (SERCOM2) USART Control A */
+#define REG_SERCOM2_USART_CTRLB (0x42000C04) /**< (SERCOM2) USART Control B */
+#define REG_SERCOM2_USART_CTRLC (0x42000C08) /**< (SERCOM2) USART Control C */
+#define REG_SERCOM2_USART_BAUD  (0x42000C0C) /**< (SERCOM2) USART Baud Rate */
+#define REG_SERCOM2_USART_RXPL  (0x42000C0E) /**< (SERCOM2) USART Receive Pulse Length */
+#define REG_SERCOM2_USART_INTENCLR (0x42000C14) /**< (SERCOM2) USART Interrupt Enable Clear */
+#define REG_SERCOM2_USART_INTENSET (0x42000C16) /**< (SERCOM2) USART Interrupt Enable Set */
+#define REG_SERCOM2_USART_INTFLAG (0x42000C18) /**< (SERCOM2) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM2_USART_STATUS (0x42000C1A) /**< (SERCOM2) USART Status */
+#define REG_SERCOM2_USART_SYNCBUSY (0x42000C1C) /**< (SERCOM2) USART Synchronization Busy */
+#define REG_SERCOM2_USART_RXERRCNT (0x42000C20) /**< (SERCOM2) USART Receive Error Count */
+#define REG_SERCOM2_USART_DATA  (0x42000C28) /**< (SERCOM2) USART Data */
+#define REG_SERCOM2_USART_DBGCTRL (0x42000C30) /**< (SERCOM2) USART Debug Control */
+
+#else
+
+#define REG_SERCOM2_I2CM_CTRLA  (*(__IO uint32_t*)0x42000C00U) /**< (SERCOM2) I2CM Control A */
+#define REG_SERCOM2_I2CM_CTRLB  (*(__IO uint32_t*)0x42000C04U) /**< (SERCOM2) I2CM Control B */
+#define REG_SERCOM2_I2CM_BAUD   (*(__IO uint32_t*)0x42000C0CU) /**< (SERCOM2) I2CM Baud Rate */
+#define REG_SERCOM2_I2CM_INTENCLR (*(__IO uint8_t*)0x42000C14U) /**< (SERCOM2) I2CM Interrupt Enable Clear */
+#define REG_SERCOM2_I2CM_INTENSET (*(__IO uint8_t*)0x42000C16U) /**< (SERCOM2) I2CM Interrupt Enable Set */
+#define REG_SERCOM2_I2CM_INTFLAG (*(__IO uint8_t*)0x42000C18U) /**< (SERCOM2) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM2_I2CM_STATUS (*(__IO uint16_t*)0x42000C1AU) /**< (SERCOM2) I2CM Status */
+#define REG_SERCOM2_I2CM_SYNCBUSY (*(__I  uint32_t*)0x42000C1CU) /**< (SERCOM2) I2CM Synchronization Busy */
+#define REG_SERCOM2_I2CM_ADDR   (*(__IO uint32_t*)0x42000C24U) /**< (SERCOM2) I2CM Address */
+#define REG_SERCOM2_I2CM_DATA   (*(__IO uint8_t*)0x42000C28U) /**< (SERCOM2) I2CM Data */
+#define REG_SERCOM2_I2CM_DBGCTRL (*(__IO uint8_t*)0x42000C30U) /**< (SERCOM2) I2CM Debug Control */
+#define REG_SERCOM2_I2CS_CTRLA  (*(__IO uint32_t*)0x42000C00U) /**< (SERCOM2) I2CS Control A */
+#define REG_SERCOM2_I2CS_CTRLB  (*(__IO uint32_t*)0x42000C04U) /**< (SERCOM2) I2CS Control B */
+#define REG_SERCOM2_I2CS_INTENCLR (*(__IO uint8_t*)0x42000C14U) /**< (SERCOM2) I2CS Interrupt Enable Clear */
+#define REG_SERCOM2_I2CS_INTENSET (*(__IO uint8_t*)0x42000C16U) /**< (SERCOM2) I2CS Interrupt Enable Set */
+#define REG_SERCOM2_I2CS_INTFLAG (*(__IO uint8_t*)0x42000C18U) /**< (SERCOM2) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM2_I2CS_STATUS (*(__IO uint16_t*)0x42000C1AU) /**< (SERCOM2) I2CS Status */
+#define REG_SERCOM2_I2CS_SYNCBUSY (*(__I  uint32_t*)0x42000C1CU) /**< (SERCOM2) I2CS Synchronization Busy */
+#define REG_SERCOM2_I2CS_ADDR   (*(__IO uint32_t*)0x42000C24U) /**< (SERCOM2) I2CS Address */
+#define REG_SERCOM2_I2CS_DATA   (*(__IO uint8_t*)0x42000C28U) /**< (SERCOM2) I2CS Data */
+#define REG_SERCOM2_SPI_CTRLA   (*(__IO uint32_t*)0x42000C00U) /**< (SERCOM2) SPI Control A */
+#define REG_SERCOM2_SPI_CTRLB   (*(__IO uint32_t*)0x42000C04U) /**< (SERCOM2) SPI Control B */
+#define REG_SERCOM2_SPI_BAUD    (*(__IO uint8_t*)0x42000C0CU) /**< (SERCOM2) SPI Baud Rate */
+#define REG_SERCOM2_SPI_INTENCLR (*(__IO uint8_t*)0x42000C14U) /**< (SERCOM2) SPI Interrupt Enable Clear */
+#define REG_SERCOM2_SPI_INTENSET (*(__IO uint8_t*)0x42000C16U) /**< (SERCOM2) SPI Interrupt Enable Set */
+#define REG_SERCOM2_SPI_INTFLAG (*(__IO uint8_t*)0x42000C18U) /**< (SERCOM2) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM2_SPI_STATUS  (*(__IO uint16_t*)0x42000C1AU) /**< (SERCOM2) SPI Status */
+#define REG_SERCOM2_SPI_SYNCBUSY (*(__I  uint32_t*)0x42000C1CU) /**< (SERCOM2) SPI Synchronization Busy */
+#define REG_SERCOM2_SPI_ADDR    (*(__IO uint32_t*)0x42000C24U) /**< (SERCOM2) SPI Address */
+#define REG_SERCOM2_SPI_DATA    (*(__IO uint32_t*)0x42000C28U) /**< (SERCOM2) SPI Data */
+#define REG_SERCOM2_SPI_DBGCTRL (*(__IO uint8_t*)0x42000C30U) /**< (SERCOM2) SPI Debug Control */
+#define REG_SERCOM2_USART_CTRLA (*(__IO uint32_t*)0x42000C00U) /**< (SERCOM2) USART Control A */
+#define REG_SERCOM2_USART_CTRLB (*(__IO uint32_t*)0x42000C04U) /**< (SERCOM2) USART Control B */
+#define REG_SERCOM2_USART_CTRLC (*(__IO uint32_t*)0x42000C08U) /**< (SERCOM2) USART Control C */
+#define REG_SERCOM2_USART_BAUD  (*(__IO uint16_t*)0x42000C0CU) /**< (SERCOM2) USART Baud Rate */
+#define REG_SERCOM2_USART_RXPL  (*(__IO uint8_t*)0x42000C0EU) /**< (SERCOM2) USART Receive Pulse Length */
+#define REG_SERCOM2_USART_INTENCLR (*(__IO uint8_t*)0x42000C14U) /**< (SERCOM2) USART Interrupt Enable Clear */
+#define REG_SERCOM2_USART_INTENSET (*(__IO uint8_t*)0x42000C16U) /**< (SERCOM2) USART Interrupt Enable Set */
+#define REG_SERCOM2_USART_INTFLAG (*(__IO uint8_t*)0x42000C18U) /**< (SERCOM2) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM2_USART_STATUS (*(__IO uint16_t*)0x42000C1AU) /**< (SERCOM2) USART Status */
+#define REG_SERCOM2_USART_SYNCBUSY (*(__I  uint32_t*)0x42000C1CU) /**< (SERCOM2) USART Synchronization Busy */
+#define REG_SERCOM2_USART_RXERRCNT (*(__I  uint8_t*)0x42000C20U) /**< (SERCOM2) USART Receive Error Count */
+#define REG_SERCOM2_USART_DATA  (*(__IO uint16_t*)0x42000C28U) /**< (SERCOM2) USART Data */
+#define REG_SERCOM2_USART_DBGCTRL (*(__IO uint8_t*)0x42000C30U) /**< (SERCOM2) USART Debug Control */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for SERCOM2 peripheral ========== */
+#define SERCOM2_DMAC_ID_RX                       8          /* Index of DMA RX trigger */
+#define SERCOM2_DMAC_ID_TX                       9          /* Index of DMA TX trigger */
+#define SERCOM2_FIFO_DEPTH_POWER                 1          /* Rx Fifo depth = 2^FIFO_DEPTH_POWER */
+#define SERCOM2_GCLK_ID_CORE                     13         
+#define SERCOM2_GCLK_ID_SLOW                     10         
+#define SERCOM2_INT_MSB                          6          
+#define SERCOM2_PMSB                             3          
+#define SERCOM2_SPI                              1          /* SPI mode implemented? */
+#define SERCOM2_TWIM                             0          /* TWI Master mode implemented? */
+#define SERCOM2_TWIS                             0          /* TWI Slave mode implemented? */
+#define SERCOM2_TWI_HSMODE                       0          /* TWI HighSpeed mode implemented? */
+#define SERCOM2_USART                            1          /* USART mode implemented? */
+#define SERCOM2_USART_AUTOBAUD                   1          /* USART AUTOBAUD mode implemented? */
+#define SERCOM2_USART_ISO7816                    1          /* USART ISO7816 mode implemented? */
+#define SERCOM2_USART_LIN_MASTER                 0          /* USART LIN Master mode implemented? */
+#define SERCOM2_USART_RS485                      1          /* USART RS485 mode implemented? */
+#define SERCOM2_INSTANCE_ID                      67         
+
+#endif /* _SAML11_SERCOM2_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/instance/supc.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/instance/supc.h
@@ -1,0 +1,68 @@
+/**
+ * \file
+ *
+ * \brief Instance description for SUPC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_SUPC_INSTANCE_H_
+#define _SAML11_SUPC_INSTANCE_H_
+
+/* ========== Register definition for SUPC peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_SUPC_INTENCLR       (0x40001800) /**< (SUPC) Interrupt Enable Clear */
+#define REG_SUPC_INTENSET       (0x40001804) /**< (SUPC) Interrupt Enable Set */
+#define REG_SUPC_INTFLAG        (0x40001808) /**< (SUPC) Interrupt Flag Status and Clear */
+#define REG_SUPC_STATUS         (0x4000180C) /**< (SUPC) Power and Clocks Status */
+#define REG_SUPC_BOD33          (0x40001810) /**< (SUPC) BOD33 Control */
+#define REG_SUPC_BOD12          (0x40001814) /**< (SUPC) BOD12 Control */
+#define REG_SUPC_VREG           (0x40001818) /**< (SUPC) VREG Control */
+#define REG_SUPC_VREF           (0x4000181C) /**< (SUPC) VREF Control */
+#define REG_SUPC_EVCTRL         (0x4000182C) /**< (SUPC) Event Control */
+#define REG_SUPC_VREGSUSP       (0x40001830) /**< (SUPC) VREG Suspend Control */
+
+#else
+
+#define REG_SUPC_INTENCLR       (*(__IO uint32_t*)0x40001800U) /**< (SUPC) Interrupt Enable Clear */
+#define REG_SUPC_INTENSET       (*(__IO uint32_t*)0x40001804U) /**< (SUPC) Interrupt Enable Set */
+#define REG_SUPC_INTFLAG        (*(__IO uint32_t*)0x40001808U) /**< (SUPC) Interrupt Flag Status and Clear */
+#define REG_SUPC_STATUS         (*(__I  uint32_t*)0x4000180CU) /**< (SUPC) Power and Clocks Status */
+#define REG_SUPC_BOD33          (*(__IO uint32_t*)0x40001810U) /**< (SUPC) BOD33 Control */
+#define REG_SUPC_BOD12          (*(__IO uint32_t*)0x40001814U) /**< (SUPC) BOD12 Control */
+#define REG_SUPC_VREG           (*(__IO uint32_t*)0x40001818U) /**< (SUPC) VREG Control */
+#define REG_SUPC_VREF           (*(__IO uint32_t*)0x4000181CU) /**< (SUPC) VREF Control */
+#define REG_SUPC_EVCTRL         (*(__IO uint32_t*)0x4000182CU) /**< (SUPC) Event Control */
+#define REG_SUPC_VREGSUSP       (*(__IO uint32_t*)0x40001830U) /**< (SUPC) VREG Suspend Control */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for SUPC peripheral ========== */
+#define SUPC_BOD12_CALIB_MSB                     5          
+#define SUPC_BOD33_CALIB_MSB                     5          
+#define SUPC_INSTANCE_ID                         6          
+
+#endif /* _SAML11_SUPC_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/instance/tc0.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/instance/tc0.h
@@ -1,0 +1,130 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TC0
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_TC0_INSTANCE_H_
+#define _SAML11_TC0_INSTANCE_H_
+
+/* ========== Register definition for TC0 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_TC0_CTRLA           (0x42001000) /**< (TC0) Control A */
+#define REG_TC0_CTRLBCLR        (0x42001004) /**< (TC0) Control B Clear */
+#define REG_TC0_CTRLBSET        (0x42001005) /**< (TC0) Control B Set */
+#define REG_TC0_EVCTRL          (0x42001006) /**< (TC0) Event Control */
+#define REG_TC0_INTENCLR        (0x42001008) /**< (TC0) Interrupt Enable Clear */
+#define REG_TC0_INTENSET        (0x42001009) /**< (TC0) Interrupt Enable Set */
+#define REG_TC0_INTFLAG         (0x4200100A) /**< (TC0) Interrupt Flag Status and Clear */
+#define REG_TC0_STATUS          (0x4200100B) /**< (TC0) Status */
+#define REG_TC0_WAVE            (0x4200100C) /**< (TC0) Waveform Generation Control */
+#define REG_TC0_DRVCTRL         (0x4200100D) /**< (TC0) Control C */
+#define REG_TC0_DBGCTRL         (0x4200100F) /**< (TC0) Debug Control */
+#define REG_TC0_SYNCBUSY        (0x42001010) /**< (TC0) Synchronization Status */
+#define REG_TC0_COUNT8_COUNT    (0x42001014) /**< (TC0) COUNT8 Count */
+#define REG_TC0_COUNT8_PER      (0x4200101B) /**< (TC0) COUNT8 Period */
+#define REG_TC0_COUNT8_CC       (0x4200101C) /**< (TC0) COUNT8 Compare and Capture */
+#define REG_TC0_COUNT8_CC0      (0x4200101C) /**< (TC0) COUNT8 Compare and Capture 0 */
+#define REG_TC0_COUNT8_CC1      (0x4200101D) /**< (TC0) COUNT8 Compare and Capture 1 */
+#define REG_TC0_COUNT8_PERBUF   (0x4200102F) /**< (TC0) COUNT8 Period Buffer */
+#define REG_TC0_COUNT8_CCBUF    (0x42001030) /**< (TC0) COUNT8 Compare and Capture Buffer */
+#define REG_TC0_COUNT8_CCBUF0   (0x42001030) /**< (TC0) COUNT8 Compare and Capture Buffer 0 */
+#define REG_TC0_COUNT8_CCBUF1   (0x42001031) /**< (TC0) COUNT8 Compare and Capture Buffer 1 */
+#define REG_TC0_COUNT16_COUNT   (0x42001014) /**< (TC0) COUNT16 Count */
+#define REG_TC0_COUNT16_PER     (0x4200101A) /**< (TC0) COUNT16 Period */
+#define REG_TC0_COUNT16_CC      (0x4200101C) /**< (TC0) COUNT16 Compare and Capture */
+#define REG_TC0_COUNT16_CC0     (0x4200101C) /**< (TC0) COUNT16 Compare and Capture 0 */
+#define REG_TC0_COUNT16_CC1     (0x4200101E) /**< (TC0) COUNT16 Compare and Capture 1 */
+#define REG_TC0_COUNT16_PERBUF  (0x4200102E) /**< (TC0) COUNT16 Period Buffer */
+#define REG_TC0_COUNT16_CCBUF   (0x42001030) /**< (TC0) COUNT16 Compare and Capture Buffer */
+#define REG_TC0_COUNT16_CCBUF0  (0x42001030) /**< (TC0) COUNT16 Compare and Capture Buffer 0 */
+#define REG_TC0_COUNT16_CCBUF1  (0x42001032) /**< (TC0) COUNT16 Compare and Capture Buffer 1 */
+#define REG_TC0_COUNT32_COUNT   (0x42001014) /**< (TC0) COUNT32 Count */
+#define REG_TC0_COUNT32_PER     (0x42001018) /**< (TC0) COUNT32 Period */
+#define REG_TC0_COUNT32_CC      (0x4200101C) /**< (TC0) COUNT32 Compare and Capture */
+#define REG_TC0_COUNT32_CC0     (0x4200101C) /**< (TC0) COUNT32 Compare and Capture 0 */
+#define REG_TC0_COUNT32_CC1     (0x42001020) /**< (TC0) COUNT32 Compare and Capture 1 */
+#define REG_TC0_COUNT32_PERBUF  (0x4200102C) /**< (TC0) COUNT32 Period Buffer */
+#define REG_TC0_COUNT32_CCBUF   (0x42001030) /**< (TC0) COUNT32 Compare and Capture Buffer */
+#define REG_TC0_COUNT32_CCBUF0  (0x42001030) /**< (TC0) COUNT32 Compare and Capture Buffer 0 */
+#define REG_TC0_COUNT32_CCBUF1  (0x42001034) /**< (TC0) COUNT32 Compare and Capture Buffer 1 */
+
+#else
+
+#define REG_TC0_CTRLA           (*(__IO uint32_t*)0x42001000U) /**< (TC0) Control A */
+#define REG_TC0_CTRLBCLR        (*(__IO uint8_t*)0x42001004U) /**< (TC0) Control B Clear */
+#define REG_TC0_CTRLBSET        (*(__IO uint8_t*)0x42001005U) /**< (TC0) Control B Set */
+#define REG_TC0_EVCTRL          (*(__IO uint16_t*)0x42001006U) /**< (TC0) Event Control */
+#define REG_TC0_INTENCLR        (*(__IO uint8_t*)0x42001008U) /**< (TC0) Interrupt Enable Clear */
+#define REG_TC0_INTENSET        (*(__IO uint8_t*)0x42001009U) /**< (TC0) Interrupt Enable Set */
+#define REG_TC0_INTFLAG         (*(__IO uint8_t*)0x4200100AU) /**< (TC0) Interrupt Flag Status and Clear */
+#define REG_TC0_STATUS          (*(__IO uint8_t*)0x4200100BU) /**< (TC0) Status */
+#define REG_TC0_WAVE            (*(__IO uint8_t*)0x4200100CU) /**< (TC0) Waveform Generation Control */
+#define REG_TC0_DRVCTRL         (*(__IO uint8_t*)0x4200100DU) /**< (TC0) Control C */
+#define REG_TC0_DBGCTRL         (*(__IO uint8_t*)0x4200100FU) /**< (TC0) Debug Control */
+#define REG_TC0_SYNCBUSY        (*(__I  uint32_t*)0x42001010U) /**< (TC0) Synchronization Status */
+#define REG_TC0_COUNT8_COUNT    (*(__IO uint8_t*)0x42001014U) /**< (TC0) COUNT8 Count */
+#define REG_TC0_COUNT8_PER      (*(__IO uint8_t*)0x4200101BU) /**< (TC0) COUNT8 Period */
+#define REG_TC0_COUNT8_CC       (*(__IO uint8_t*)0x4200101CU) /**< (TC0) COUNT8 Compare and Capture */
+#define REG_TC0_COUNT8_CC0      (*(__IO uint8_t*)0x4200101CU) /**< (TC0) COUNT8 Compare and Capture 0 */
+#define REG_TC0_COUNT8_CC1      (*(__IO uint8_t*)0x4200101DU) /**< (TC0) COUNT8 Compare and Capture 1 */
+#define REG_TC0_COUNT8_PERBUF   (*(__IO uint8_t*)0x4200102FU) /**< (TC0) COUNT8 Period Buffer */
+#define REG_TC0_COUNT8_CCBUF    (*(__IO uint8_t*)0x42001030U) /**< (TC0) COUNT8 Compare and Capture Buffer */
+#define REG_TC0_COUNT8_CCBUF0   (*(__IO uint8_t*)0x42001030U) /**< (TC0) COUNT8 Compare and Capture Buffer 0 */
+#define REG_TC0_COUNT8_CCBUF1   (*(__IO uint8_t*)0x42001031U) /**< (TC0) COUNT8 Compare and Capture Buffer 1 */
+#define REG_TC0_COUNT16_COUNT   (*(__IO uint16_t*)0x42001014U) /**< (TC0) COUNT16 Count */
+#define REG_TC0_COUNT16_PER     (*(__IO uint16_t*)0x4200101AU) /**< (TC0) COUNT16 Period */
+#define REG_TC0_COUNT16_CC      (*(__IO uint16_t*)0x4200101CU) /**< (TC0) COUNT16 Compare and Capture */
+#define REG_TC0_COUNT16_CC0     (*(__IO uint16_t*)0x4200101CU) /**< (TC0) COUNT16 Compare and Capture 0 */
+#define REG_TC0_COUNT16_CC1     (*(__IO uint16_t*)0x4200101EU) /**< (TC0) COUNT16 Compare and Capture 1 */
+#define REG_TC0_COUNT16_PERBUF  (*(__IO uint16_t*)0x4200102EU) /**< (TC0) COUNT16 Period Buffer */
+#define REG_TC0_COUNT16_CCBUF   (*(__IO uint16_t*)0x42001030U) /**< (TC0) COUNT16 Compare and Capture Buffer */
+#define REG_TC0_COUNT16_CCBUF0  (*(__IO uint16_t*)0x42001030U) /**< (TC0) COUNT16 Compare and Capture Buffer 0 */
+#define REG_TC0_COUNT16_CCBUF1  (*(__IO uint16_t*)0x42001032U) /**< (TC0) COUNT16 Compare and Capture Buffer 1 */
+#define REG_TC0_COUNT32_COUNT   (*(__IO uint32_t*)0x42001014U) /**< (TC0) COUNT32 Count */
+#define REG_TC0_COUNT32_PER     (*(__IO uint32_t*)0x42001018U) /**< (TC0) COUNT32 Period */
+#define REG_TC0_COUNT32_CC      (*(__IO uint32_t*)0x4200101CU) /**< (TC0) COUNT32 Compare and Capture */
+#define REG_TC0_COUNT32_CC0     (*(__IO uint32_t*)0x4200101CU) /**< (TC0) COUNT32 Compare and Capture 0 */
+#define REG_TC0_COUNT32_CC1     (*(__IO uint32_t*)0x42001020U) /**< (TC0) COUNT32 Compare and Capture 1 */
+#define REG_TC0_COUNT32_PERBUF  (*(__IO uint32_t*)0x4200102CU) /**< (TC0) COUNT32 Period Buffer */
+#define REG_TC0_COUNT32_CCBUF   (*(__IO uint32_t*)0x42001030U) /**< (TC0) COUNT32 Compare and Capture Buffer */
+#define REG_TC0_COUNT32_CCBUF0  (*(__IO uint32_t*)0x42001030U) /**< (TC0) COUNT32 Compare and Capture Buffer 0 */
+#define REG_TC0_COUNT32_CCBUF1  (*(__IO uint32_t*)0x42001034U) /**< (TC0) COUNT32 Compare and Capture Buffer 1 */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for TC0 peripheral ========== */
+#define TC0_CC_NUM                               2          
+#define TC0_DMAC_ID_OVF                          10         /* Indexes of DMA Overflow trigger */
+#define TC0_EXT                                  1          /* Coding of implemented extended features (keep 0 value) */
+#define TC0_GCLK_ID                              14         /* Index of Generic Clock */
+#define TC0_MASTER_SLAVE_MODE                    1          /* TC type 0 : NA, 1 : Master, 2 : Slave */
+#define TC0_OW_NUM                               2          /* Number of Output Waveforms */
+#define TC0_INSTANCE_ID                          68         
+
+#endif /* _SAML11_TC0_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/instance/tc1.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/instance/tc1.h
@@ -1,0 +1,130 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TC1
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_TC1_INSTANCE_H_
+#define _SAML11_TC1_INSTANCE_H_
+
+/* ========== Register definition for TC1 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_TC1_CTRLA           (0x42001400) /**< (TC1) Control A */
+#define REG_TC1_CTRLBCLR        (0x42001404) /**< (TC1) Control B Clear */
+#define REG_TC1_CTRLBSET        (0x42001405) /**< (TC1) Control B Set */
+#define REG_TC1_EVCTRL          (0x42001406) /**< (TC1) Event Control */
+#define REG_TC1_INTENCLR        (0x42001408) /**< (TC1) Interrupt Enable Clear */
+#define REG_TC1_INTENSET        (0x42001409) /**< (TC1) Interrupt Enable Set */
+#define REG_TC1_INTFLAG         (0x4200140A) /**< (TC1) Interrupt Flag Status and Clear */
+#define REG_TC1_STATUS          (0x4200140B) /**< (TC1) Status */
+#define REG_TC1_WAVE            (0x4200140C) /**< (TC1) Waveform Generation Control */
+#define REG_TC1_DRVCTRL         (0x4200140D) /**< (TC1) Control C */
+#define REG_TC1_DBGCTRL         (0x4200140F) /**< (TC1) Debug Control */
+#define REG_TC1_SYNCBUSY        (0x42001410) /**< (TC1) Synchronization Status */
+#define REG_TC1_COUNT8_COUNT    (0x42001414) /**< (TC1) COUNT8 Count */
+#define REG_TC1_COUNT8_PER      (0x4200141B) /**< (TC1) COUNT8 Period */
+#define REG_TC1_COUNT8_CC       (0x4200141C) /**< (TC1) COUNT8 Compare and Capture */
+#define REG_TC1_COUNT8_CC0      (0x4200141C) /**< (TC1) COUNT8 Compare and Capture 0 */
+#define REG_TC1_COUNT8_CC1      (0x4200141D) /**< (TC1) COUNT8 Compare and Capture 1 */
+#define REG_TC1_COUNT8_PERBUF   (0x4200142F) /**< (TC1) COUNT8 Period Buffer */
+#define REG_TC1_COUNT8_CCBUF    (0x42001430) /**< (TC1) COUNT8 Compare and Capture Buffer */
+#define REG_TC1_COUNT8_CCBUF0   (0x42001430) /**< (TC1) COUNT8 Compare and Capture Buffer 0 */
+#define REG_TC1_COUNT8_CCBUF1   (0x42001431) /**< (TC1) COUNT8 Compare and Capture Buffer 1 */
+#define REG_TC1_COUNT16_COUNT   (0x42001414) /**< (TC1) COUNT16 Count */
+#define REG_TC1_COUNT16_PER     (0x4200141A) /**< (TC1) COUNT16 Period */
+#define REG_TC1_COUNT16_CC      (0x4200141C) /**< (TC1) COUNT16 Compare and Capture */
+#define REG_TC1_COUNT16_CC0     (0x4200141C) /**< (TC1) COUNT16 Compare and Capture 0 */
+#define REG_TC1_COUNT16_CC1     (0x4200141E) /**< (TC1) COUNT16 Compare and Capture 1 */
+#define REG_TC1_COUNT16_PERBUF  (0x4200142E) /**< (TC1) COUNT16 Period Buffer */
+#define REG_TC1_COUNT16_CCBUF   (0x42001430) /**< (TC1) COUNT16 Compare and Capture Buffer */
+#define REG_TC1_COUNT16_CCBUF0  (0x42001430) /**< (TC1) COUNT16 Compare and Capture Buffer 0 */
+#define REG_TC1_COUNT16_CCBUF1  (0x42001432) /**< (TC1) COUNT16 Compare and Capture Buffer 1 */
+#define REG_TC1_COUNT32_COUNT   (0x42001414) /**< (TC1) COUNT32 Count */
+#define REG_TC1_COUNT32_PER     (0x42001418) /**< (TC1) COUNT32 Period */
+#define REG_TC1_COUNT32_CC      (0x4200141C) /**< (TC1) COUNT32 Compare and Capture */
+#define REG_TC1_COUNT32_CC0     (0x4200141C) /**< (TC1) COUNT32 Compare and Capture 0 */
+#define REG_TC1_COUNT32_CC1     (0x42001420) /**< (TC1) COUNT32 Compare and Capture 1 */
+#define REG_TC1_COUNT32_PERBUF  (0x4200142C) /**< (TC1) COUNT32 Period Buffer */
+#define REG_TC1_COUNT32_CCBUF   (0x42001430) /**< (TC1) COUNT32 Compare and Capture Buffer */
+#define REG_TC1_COUNT32_CCBUF0  (0x42001430) /**< (TC1) COUNT32 Compare and Capture Buffer 0 */
+#define REG_TC1_COUNT32_CCBUF1  (0x42001434) /**< (TC1) COUNT32 Compare and Capture Buffer 1 */
+
+#else
+
+#define REG_TC1_CTRLA           (*(__IO uint32_t*)0x42001400U) /**< (TC1) Control A */
+#define REG_TC1_CTRLBCLR        (*(__IO uint8_t*)0x42001404U) /**< (TC1) Control B Clear */
+#define REG_TC1_CTRLBSET        (*(__IO uint8_t*)0x42001405U) /**< (TC1) Control B Set */
+#define REG_TC1_EVCTRL          (*(__IO uint16_t*)0x42001406U) /**< (TC1) Event Control */
+#define REG_TC1_INTENCLR        (*(__IO uint8_t*)0x42001408U) /**< (TC1) Interrupt Enable Clear */
+#define REG_TC1_INTENSET        (*(__IO uint8_t*)0x42001409U) /**< (TC1) Interrupt Enable Set */
+#define REG_TC1_INTFLAG         (*(__IO uint8_t*)0x4200140AU) /**< (TC1) Interrupt Flag Status and Clear */
+#define REG_TC1_STATUS          (*(__IO uint8_t*)0x4200140BU) /**< (TC1) Status */
+#define REG_TC1_WAVE            (*(__IO uint8_t*)0x4200140CU) /**< (TC1) Waveform Generation Control */
+#define REG_TC1_DRVCTRL         (*(__IO uint8_t*)0x4200140DU) /**< (TC1) Control C */
+#define REG_TC1_DBGCTRL         (*(__IO uint8_t*)0x4200140FU) /**< (TC1) Debug Control */
+#define REG_TC1_SYNCBUSY        (*(__I  uint32_t*)0x42001410U) /**< (TC1) Synchronization Status */
+#define REG_TC1_COUNT8_COUNT    (*(__IO uint8_t*)0x42001414U) /**< (TC1) COUNT8 Count */
+#define REG_TC1_COUNT8_PER      (*(__IO uint8_t*)0x4200141BU) /**< (TC1) COUNT8 Period */
+#define REG_TC1_COUNT8_CC       (*(__IO uint8_t*)0x4200141CU) /**< (TC1) COUNT8 Compare and Capture */
+#define REG_TC1_COUNT8_CC0      (*(__IO uint8_t*)0x4200141CU) /**< (TC1) COUNT8 Compare and Capture 0 */
+#define REG_TC1_COUNT8_CC1      (*(__IO uint8_t*)0x4200141DU) /**< (TC1) COUNT8 Compare and Capture 1 */
+#define REG_TC1_COUNT8_PERBUF   (*(__IO uint8_t*)0x4200142FU) /**< (TC1) COUNT8 Period Buffer */
+#define REG_TC1_COUNT8_CCBUF    (*(__IO uint8_t*)0x42001430U) /**< (TC1) COUNT8 Compare and Capture Buffer */
+#define REG_TC1_COUNT8_CCBUF0   (*(__IO uint8_t*)0x42001430U) /**< (TC1) COUNT8 Compare and Capture Buffer 0 */
+#define REG_TC1_COUNT8_CCBUF1   (*(__IO uint8_t*)0x42001431U) /**< (TC1) COUNT8 Compare and Capture Buffer 1 */
+#define REG_TC1_COUNT16_COUNT   (*(__IO uint16_t*)0x42001414U) /**< (TC1) COUNT16 Count */
+#define REG_TC1_COUNT16_PER     (*(__IO uint16_t*)0x4200141AU) /**< (TC1) COUNT16 Period */
+#define REG_TC1_COUNT16_CC      (*(__IO uint16_t*)0x4200141CU) /**< (TC1) COUNT16 Compare and Capture */
+#define REG_TC1_COUNT16_CC0     (*(__IO uint16_t*)0x4200141CU) /**< (TC1) COUNT16 Compare and Capture 0 */
+#define REG_TC1_COUNT16_CC1     (*(__IO uint16_t*)0x4200141EU) /**< (TC1) COUNT16 Compare and Capture 1 */
+#define REG_TC1_COUNT16_PERBUF  (*(__IO uint16_t*)0x4200142EU) /**< (TC1) COUNT16 Period Buffer */
+#define REG_TC1_COUNT16_CCBUF   (*(__IO uint16_t*)0x42001430U) /**< (TC1) COUNT16 Compare and Capture Buffer */
+#define REG_TC1_COUNT16_CCBUF0  (*(__IO uint16_t*)0x42001430U) /**< (TC1) COUNT16 Compare and Capture Buffer 0 */
+#define REG_TC1_COUNT16_CCBUF1  (*(__IO uint16_t*)0x42001432U) /**< (TC1) COUNT16 Compare and Capture Buffer 1 */
+#define REG_TC1_COUNT32_COUNT   (*(__IO uint32_t*)0x42001414U) /**< (TC1) COUNT32 Count */
+#define REG_TC1_COUNT32_PER     (*(__IO uint32_t*)0x42001418U) /**< (TC1) COUNT32 Period */
+#define REG_TC1_COUNT32_CC      (*(__IO uint32_t*)0x4200141CU) /**< (TC1) COUNT32 Compare and Capture */
+#define REG_TC1_COUNT32_CC0     (*(__IO uint32_t*)0x4200141CU) /**< (TC1) COUNT32 Compare and Capture 0 */
+#define REG_TC1_COUNT32_CC1     (*(__IO uint32_t*)0x42001420U) /**< (TC1) COUNT32 Compare and Capture 1 */
+#define REG_TC1_COUNT32_PERBUF  (*(__IO uint32_t*)0x4200142CU) /**< (TC1) COUNT32 Period Buffer */
+#define REG_TC1_COUNT32_CCBUF   (*(__IO uint32_t*)0x42001430U) /**< (TC1) COUNT32 Compare and Capture Buffer */
+#define REG_TC1_COUNT32_CCBUF0  (*(__IO uint32_t*)0x42001430U) /**< (TC1) COUNT32 Compare and Capture Buffer 0 */
+#define REG_TC1_COUNT32_CCBUF1  (*(__IO uint32_t*)0x42001434U) /**< (TC1) COUNT32 Compare and Capture Buffer 1 */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for TC1 peripheral ========== */
+#define TC1_CC_NUM                               2          
+#define TC1_DMAC_ID_OVF                          13         /* Indexes of DMA Overflow trigger */
+#define TC1_EXT                                  1          /* Coding of implemented extended features (keep 0 value) */
+#define TC1_GCLK_ID                              14         /* Index of Generic Clock */
+#define TC1_MASTER_SLAVE_MODE                    2          /* TC type 0 : NA, 1 : Master, 2 : Slave */
+#define TC1_OW_NUM                               2          /* Number of Output Waveforms */
+#define TC1_INSTANCE_ID                          69         
+
+#endif /* _SAML11_TC1_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/instance/tc2.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/instance/tc2.h
@@ -1,0 +1,130 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TC2
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_TC2_INSTANCE_H_
+#define _SAML11_TC2_INSTANCE_H_
+
+/* ========== Register definition for TC2 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_TC2_CTRLA           (0x42001800) /**< (TC2) Control A */
+#define REG_TC2_CTRLBCLR        (0x42001804) /**< (TC2) Control B Clear */
+#define REG_TC2_CTRLBSET        (0x42001805) /**< (TC2) Control B Set */
+#define REG_TC2_EVCTRL          (0x42001806) /**< (TC2) Event Control */
+#define REG_TC2_INTENCLR        (0x42001808) /**< (TC2) Interrupt Enable Clear */
+#define REG_TC2_INTENSET        (0x42001809) /**< (TC2) Interrupt Enable Set */
+#define REG_TC2_INTFLAG         (0x4200180A) /**< (TC2) Interrupt Flag Status and Clear */
+#define REG_TC2_STATUS          (0x4200180B) /**< (TC2) Status */
+#define REG_TC2_WAVE            (0x4200180C) /**< (TC2) Waveform Generation Control */
+#define REG_TC2_DRVCTRL         (0x4200180D) /**< (TC2) Control C */
+#define REG_TC2_DBGCTRL         (0x4200180F) /**< (TC2) Debug Control */
+#define REG_TC2_SYNCBUSY        (0x42001810) /**< (TC2) Synchronization Status */
+#define REG_TC2_COUNT8_COUNT    (0x42001814) /**< (TC2) COUNT8 Count */
+#define REG_TC2_COUNT8_PER      (0x4200181B) /**< (TC2) COUNT8 Period */
+#define REG_TC2_COUNT8_CC       (0x4200181C) /**< (TC2) COUNT8 Compare and Capture */
+#define REG_TC2_COUNT8_CC0      (0x4200181C) /**< (TC2) COUNT8 Compare and Capture 0 */
+#define REG_TC2_COUNT8_CC1      (0x4200181D) /**< (TC2) COUNT8 Compare and Capture 1 */
+#define REG_TC2_COUNT8_PERBUF   (0x4200182F) /**< (TC2) COUNT8 Period Buffer */
+#define REG_TC2_COUNT8_CCBUF    (0x42001830) /**< (TC2) COUNT8 Compare and Capture Buffer */
+#define REG_TC2_COUNT8_CCBUF0   (0x42001830) /**< (TC2) COUNT8 Compare and Capture Buffer 0 */
+#define REG_TC2_COUNT8_CCBUF1   (0x42001831) /**< (TC2) COUNT8 Compare and Capture Buffer 1 */
+#define REG_TC2_COUNT16_COUNT   (0x42001814) /**< (TC2) COUNT16 Count */
+#define REG_TC2_COUNT16_PER     (0x4200181A) /**< (TC2) COUNT16 Period */
+#define REG_TC2_COUNT16_CC      (0x4200181C) /**< (TC2) COUNT16 Compare and Capture */
+#define REG_TC2_COUNT16_CC0     (0x4200181C) /**< (TC2) COUNT16 Compare and Capture 0 */
+#define REG_TC2_COUNT16_CC1     (0x4200181E) /**< (TC2) COUNT16 Compare and Capture 1 */
+#define REG_TC2_COUNT16_PERBUF  (0x4200182E) /**< (TC2) COUNT16 Period Buffer */
+#define REG_TC2_COUNT16_CCBUF   (0x42001830) /**< (TC2) COUNT16 Compare and Capture Buffer */
+#define REG_TC2_COUNT16_CCBUF0  (0x42001830) /**< (TC2) COUNT16 Compare and Capture Buffer 0 */
+#define REG_TC2_COUNT16_CCBUF1  (0x42001832) /**< (TC2) COUNT16 Compare and Capture Buffer 1 */
+#define REG_TC2_COUNT32_COUNT   (0x42001814) /**< (TC2) COUNT32 Count */
+#define REG_TC2_COUNT32_PER     (0x42001818) /**< (TC2) COUNT32 Period */
+#define REG_TC2_COUNT32_CC      (0x4200181C) /**< (TC2) COUNT32 Compare and Capture */
+#define REG_TC2_COUNT32_CC0     (0x4200181C) /**< (TC2) COUNT32 Compare and Capture 0 */
+#define REG_TC2_COUNT32_CC1     (0x42001820) /**< (TC2) COUNT32 Compare and Capture 1 */
+#define REG_TC2_COUNT32_PERBUF  (0x4200182C) /**< (TC2) COUNT32 Period Buffer */
+#define REG_TC2_COUNT32_CCBUF   (0x42001830) /**< (TC2) COUNT32 Compare and Capture Buffer */
+#define REG_TC2_COUNT32_CCBUF0  (0x42001830) /**< (TC2) COUNT32 Compare and Capture Buffer 0 */
+#define REG_TC2_COUNT32_CCBUF1  (0x42001834) /**< (TC2) COUNT32 Compare and Capture Buffer 1 */
+
+#else
+
+#define REG_TC2_CTRLA           (*(__IO uint32_t*)0x42001800U) /**< (TC2) Control A */
+#define REG_TC2_CTRLBCLR        (*(__IO uint8_t*)0x42001804U) /**< (TC2) Control B Clear */
+#define REG_TC2_CTRLBSET        (*(__IO uint8_t*)0x42001805U) /**< (TC2) Control B Set */
+#define REG_TC2_EVCTRL          (*(__IO uint16_t*)0x42001806U) /**< (TC2) Event Control */
+#define REG_TC2_INTENCLR        (*(__IO uint8_t*)0x42001808U) /**< (TC2) Interrupt Enable Clear */
+#define REG_TC2_INTENSET        (*(__IO uint8_t*)0x42001809U) /**< (TC2) Interrupt Enable Set */
+#define REG_TC2_INTFLAG         (*(__IO uint8_t*)0x4200180AU) /**< (TC2) Interrupt Flag Status and Clear */
+#define REG_TC2_STATUS          (*(__IO uint8_t*)0x4200180BU) /**< (TC2) Status */
+#define REG_TC2_WAVE            (*(__IO uint8_t*)0x4200180CU) /**< (TC2) Waveform Generation Control */
+#define REG_TC2_DRVCTRL         (*(__IO uint8_t*)0x4200180DU) /**< (TC2) Control C */
+#define REG_TC2_DBGCTRL         (*(__IO uint8_t*)0x4200180FU) /**< (TC2) Debug Control */
+#define REG_TC2_SYNCBUSY        (*(__I  uint32_t*)0x42001810U) /**< (TC2) Synchronization Status */
+#define REG_TC2_COUNT8_COUNT    (*(__IO uint8_t*)0x42001814U) /**< (TC2) COUNT8 Count */
+#define REG_TC2_COUNT8_PER      (*(__IO uint8_t*)0x4200181BU) /**< (TC2) COUNT8 Period */
+#define REG_TC2_COUNT8_CC       (*(__IO uint8_t*)0x4200181CU) /**< (TC2) COUNT8 Compare and Capture */
+#define REG_TC2_COUNT8_CC0      (*(__IO uint8_t*)0x4200181CU) /**< (TC2) COUNT8 Compare and Capture 0 */
+#define REG_TC2_COUNT8_CC1      (*(__IO uint8_t*)0x4200181DU) /**< (TC2) COUNT8 Compare and Capture 1 */
+#define REG_TC2_COUNT8_PERBUF   (*(__IO uint8_t*)0x4200182FU) /**< (TC2) COUNT8 Period Buffer */
+#define REG_TC2_COUNT8_CCBUF    (*(__IO uint8_t*)0x42001830U) /**< (TC2) COUNT8 Compare and Capture Buffer */
+#define REG_TC2_COUNT8_CCBUF0   (*(__IO uint8_t*)0x42001830U) /**< (TC2) COUNT8 Compare and Capture Buffer 0 */
+#define REG_TC2_COUNT8_CCBUF1   (*(__IO uint8_t*)0x42001831U) /**< (TC2) COUNT8 Compare and Capture Buffer 1 */
+#define REG_TC2_COUNT16_COUNT   (*(__IO uint16_t*)0x42001814U) /**< (TC2) COUNT16 Count */
+#define REG_TC2_COUNT16_PER     (*(__IO uint16_t*)0x4200181AU) /**< (TC2) COUNT16 Period */
+#define REG_TC2_COUNT16_CC      (*(__IO uint16_t*)0x4200181CU) /**< (TC2) COUNT16 Compare and Capture */
+#define REG_TC2_COUNT16_CC0     (*(__IO uint16_t*)0x4200181CU) /**< (TC2) COUNT16 Compare and Capture 0 */
+#define REG_TC2_COUNT16_CC1     (*(__IO uint16_t*)0x4200181EU) /**< (TC2) COUNT16 Compare and Capture 1 */
+#define REG_TC2_COUNT16_PERBUF  (*(__IO uint16_t*)0x4200182EU) /**< (TC2) COUNT16 Period Buffer */
+#define REG_TC2_COUNT16_CCBUF   (*(__IO uint16_t*)0x42001830U) /**< (TC2) COUNT16 Compare and Capture Buffer */
+#define REG_TC2_COUNT16_CCBUF0  (*(__IO uint16_t*)0x42001830U) /**< (TC2) COUNT16 Compare and Capture Buffer 0 */
+#define REG_TC2_COUNT16_CCBUF1  (*(__IO uint16_t*)0x42001832U) /**< (TC2) COUNT16 Compare and Capture Buffer 1 */
+#define REG_TC2_COUNT32_COUNT   (*(__IO uint32_t*)0x42001814U) /**< (TC2) COUNT32 Count */
+#define REG_TC2_COUNT32_PER     (*(__IO uint32_t*)0x42001818U) /**< (TC2) COUNT32 Period */
+#define REG_TC2_COUNT32_CC      (*(__IO uint32_t*)0x4200181CU) /**< (TC2) COUNT32 Compare and Capture */
+#define REG_TC2_COUNT32_CC0     (*(__IO uint32_t*)0x4200181CU) /**< (TC2) COUNT32 Compare and Capture 0 */
+#define REG_TC2_COUNT32_CC1     (*(__IO uint32_t*)0x42001820U) /**< (TC2) COUNT32 Compare and Capture 1 */
+#define REG_TC2_COUNT32_PERBUF  (*(__IO uint32_t*)0x4200182CU) /**< (TC2) COUNT32 Period Buffer */
+#define REG_TC2_COUNT32_CCBUF   (*(__IO uint32_t*)0x42001830U) /**< (TC2) COUNT32 Compare and Capture Buffer */
+#define REG_TC2_COUNT32_CCBUF0  (*(__IO uint32_t*)0x42001830U) /**< (TC2) COUNT32 Compare and Capture Buffer 0 */
+#define REG_TC2_COUNT32_CCBUF1  (*(__IO uint32_t*)0x42001834U) /**< (TC2) COUNT32 Compare and Capture Buffer 1 */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for TC2 peripheral ========== */
+#define TC2_CC_NUM                               2          
+#define TC2_DMAC_ID_OVF                          16         /* Indexes of DMA Overflow trigger */
+#define TC2_EXT                                  1          /* Coding of implemented extended features (keep 0 value) */
+#define TC2_GCLK_ID                              15         /* Index of Generic Clock */
+#define TC2_MASTER_SLAVE_MODE                    0          /* TC type 0 : NA, 1 : Master, 2 : Slave */
+#define TC2_OW_NUM                               2          /* Number of Output Waveforms */
+#define TC2_INSTANCE_ID                          70         
+
+#endif /* _SAML11_TC2_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/instance/tram.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/instance/tram.h
@@ -1,0 +1,194 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TRAM
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_TRAM_INSTANCE_H_
+#define _SAML11_TRAM_INSTANCE_H_
+
+/* ========== Register definition for TRAM peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_TRAM_CTRLA          (0x42003400) /**< (TRAM) Control */
+#define REG_TRAM_INTENCLR       (0x42003404) /**< (TRAM) Interrupt Enable Clear */
+#define REG_TRAM_INTENSET       (0x42003405) /**< (TRAM) Interrupt Enable Set */
+#define REG_TRAM_INTFLAG        (0x42003406) /**< (TRAM) Interrupt Flag Status and Clear */
+#define REG_TRAM_STATUS         (0x42003407) /**< (TRAM) Status */
+#define REG_TRAM_SYNCBUSY       (0x42003408) /**< (TRAM) Synchronization Busy Status */
+#define REG_TRAM_DSCC           (0x4200340C) /**< (TRAM) Data Scramble Control */
+#define REG_TRAM_PERMW          (0x42003410) /**< (TRAM) Permutation Write */
+#define REG_TRAM_PERMR          (0x42003411) /**< (TRAM) Permutation Read */
+#define REG_TRAM_RAM            (0x42003500) /**< (TRAM) TrustRAM */
+#define REG_TRAM_RAM0           (0x42003500) /**< (TRAM) TrustRAM 0 */
+#define REG_TRAM_RAM1           (0x42003504) /**< (TRAM) TrustRAM 1 */
+#define REG_TRAM_RAM2           (0x42003508) /**< (TRAM) TrustRAM 2 */
+#define REG_TRAM_RAM3           (0x4200350C) /**< (TRAM) TrustRAM 3 */
+#define REG_TRAM_RAM4           (0x42003510) /**< (TRAM) TrustRAM 4 */
+#define REG_TRAM_RAM5           (0x42003514) /**< (TRAM) TrustRAM 5 */
+#define REG_TRAM_RAM6           (0x42003518) /**< (TRAM) TrustRAM 6 */
+#define REG_TRAM_RAM7           (0x4200351C) /**< (TRAM) TrustRAM 7 */
+#define REG_TRAM_RAM8           (0x42003520) /**< (TRAM) TrustRAM 8 */
+#define REG_TRAM_RAM9           (0x42003524) /**< (TRAM) TrustRAM 9 */
+#define REG_TRAM_RAM10          (0x42003528) /**< (TRAM) TrustRAM 10 */
+#define REG_TRAM_RAM11          (0x4200352C) /**< (TRAM) TrustRAM 11 */
+#define REG_TRAM_RAM12          (0x42003530) /**< (TRAM) TrustRAM 12 */
+#define REG_TRAM_RAM13          (0x42003534) /**< (TRAM) TrustRAM 13 */
+#define REG_TRAM_RAM14          (0x42003538) /**< (TRAM) TrustRAM 14 */
+#define REG_TRAM_RAM15          (0x4200353C) /**< (TRAM) TrustRAM 15 */
+#define REG_TRAM_RAM16          (0x42003540) /**< (TRAM) TrustRAM 16 */
+#define REG_TRAM_RAM17          (0x42003544) /**< (TRAM) TrustRAM 17 */
+#define REG_TRAM_RAM18          (0x42003548) /**< (TRAM) TrustRAM 18 */
+#define REG_TRAM_RAM19          (0x4200354C) /**< (TRAM) TrustRAM 19 */
+#define REG_TRAM_RAM20          (0x42003550) /**< (TRAM) TrustRAM 20 */
+#define REG_TRAM_RAM21          (0x42003554) /**< (TRAM) TrustRAM 21 */
+#define REG_TRAM_RAM22          (0x42003558) /**< (TRAM) TrustRAM 22 */
+#define REG_TRAM_RAM23          (0x4200355C) /**< (TRAM) TrustRAM 23 */
+#define REG_TRAM_RAM24          (0x42003560) /**< (TRAM) TrustRAM 24 */
+#define REG_TRAM_RAM25          (0x42003564) /**< (TRAM) TrustRAM 25 */
+#define REG_TRAM_RAM26          (0x42003568) /**< (TRAM) TrustRAM 26 */
+#define REG_TRAM_RAM27          (0x4200356C) /**< (TRAM) TrustRAM 27 */
+#define REG_TRAM_RAM28          (0x42003570) /**< (TRAM) TrustRAM 28 */
+#define REG_TRAM_RAM29          (0x42003574) /**< (TRAM) TrustRAM 29 */
+#define REG_TRAM_RAM30          (0x42003578) /**< (TRAM) TrustRAM 30 */
+#define REG_TRAM_RAM31          (0x4200357C) /**< (TRAM) TrustRAM 31 */
+#define REG_TRAM_RAM32          (0x42003580) /**< (TRAM) TrustRAM 32 */
+#define REG_TRAM_RAM33          (0x42003584) /**< (TRAM) TrustRAM 33 */
+#define REG_TRAM_RAM34          (0x42003588) /**< (TRAM) TrustRAM 34 */
+#define REG_TRAM_RAM35          (0x4200358C) /**< (TRAM) TrustRAM 35 */
+#define REG_TRAM_RAM36          (0x42003590) /**< (TRAM) TrustRAM 36 */
+#define REG_TRAM_RAM37          (0x42003594) /**< (TRAM) TrustRAM 37 */
+#define REG_TRAM_RAM38          (0x42003598) /**< (TRAM) TrustRAM 38 */
+#define REG_TRAM_RAM39          (0x4200359C) /**< (TRAM) TrustRAM 39 */
+#define REG_TRAM_RAM40          (0x420035A0) /**< (TRAM) TrustRAM 40 */
+#define REG_TRAM_RAM41          (0x420035A4) /**< (TRAM) TrustRAM 41 */
+#define REG_TRAM_RAM42          (0x420035A8) /**< (TRAM) TrustRAM 42 */
+#define REG_TRAM_RAM43          (0x420035AC) /**< (TRAM) TrustRAM 43 */
+#define REG_TRAM_RAM44          (0x420035B0) /**< (TRAM) TrustRAM 44 */
+#define REG_TRAM_RAM45          (0x420035B4) /**< (TRAM) TrustRAM 45 */
+#define REG_TRAM_RAM46          (0x420035B8) /**< (TRAM) TrustRAM 46 */
+#define REG_TRAM_RAM47          (0x420035BC) /**< (TRAM) TrustRAM 47 */
+#define REG_TRAM_RAM48          (0x420035C0) /**< (TRAM) TrustRAM 48 */
+#define REG_TRAM_RAM49          (0x420035C4) /**< (TRAM) TrustRAM 49 */
+#define REG_TRAM_RAM50          (0x420035C8) /**< (TRAM) TrustRAM 50 */
+#define REG_TRAM_RAM51          (0x420035CC) /**< (TRAM) TrustRAM 51 */
+#define REG_TRAM_RAM52          (0x420035D0) /**< (TRAM) TrustRAM 52 */
+#define REG_TRAM_RAM53          (0x420035D4) /**< (TRAM) TrustRAM 53 */
+#define REG_TRAM_RAM54          (0x420035D8) /**< (TRAM) TrustRAM 54 */
+#define REG_TRAM_RAM55          (0x420035DC) /**< (TRAM) TrustRAM 55 */
+#define REG_TRAM_RAM56          (0x420035E0) /**< (TRAM) TrustRAM 56 */
+#define REG_TRAM_RAM57          (0x420035E4) /**< (TRAM) TrustRAM 57 */
+#define REG_TRAM_RAM58          (0x420035E8) /**< (TRAM) TrustRAM 58 */
+#define REG_TRAM_RAM59          (0x420035EC) /**< (TRAM) TrustRAM 59 */
+#define REG_TRAM_RAM60          (0x420035F0) /**< (TRAM) TrustRAM 60 */
+#define REG_TRAM_RAM61          (0x420035F4) /**< (TRAM) TrustRAM 61 */
+#define REG_TRAM_RAM62          (0x420035F8) /**< (TRAM) TrustRAM 62 */
+#define REG_TRAM_RAM63          (0x420035FC) /**< (TRAM) TrustRAM 63 */
+
+#else
+
+#define REG_TRAM_CTRLA          (*(__IO uint8_t*)0x42003400U) /**< (TRAM) Control */
+#define REG_TRAM_INTENCLR       (*(__IO uint8_t*)0x42003404U) /**< (TRAM) Interrupt Enable Clear */
+#define REG_TRAM_INTENSET       (*(__IO uint8_t*)0x42003405U) /**< (TRAM) Interrupt Enable Set */
+#define REG_TRAM_INTFLAG        (*(__IO uint8_t*)0x42003406U) /**< (TRAM) Interrupt Flag Status and Clear */
+#define REG_TRAM_STATUS         (*(__I  uint8_t*)0x42003407U) /**< (TRAM) Status */
+#define REG_TRAM_SYNCBUSY       (*(__I  uint32_t*)0x42003408U) /**< (TRAM) Synchronization Busy Status */
+#define REG_TRAM_DSCC           (*(__O  uint32_t*)0x4200340CU) /**< (TRAM) Data Scramble Control */
+#define REG_TRAM_PERMW          (*(__O  uint8_t*)0x42003410U) /**< (TRAM) Permutation Write */
+#define REG_TRAM_PERMR          (*(__I  uint8_t*)0x42003411U) /**< (TRAM) Permutation Read */
+#define REG_TRAM_RAM            (*(__IO uint32_t*)0x42003500U) /**< (TRAM) TrustRAM */
+#define REG_TRAM_RAM0           (*(__IO uint32_t*)0x42003500U) /**< (TRAM) TrustRAM 0 */
+#define REG_TRAM_RAM1           (*(__IO uint32_t*)0x42003504U) /**< (TRAM) TrustRAM 1 */
+#define REG_TRAM_RAM2           (*(__IO uint32_t*)0x42003508U) /**< (TRAM) TrustRAM 2 */
+#define REG_TRAM_RAM3           (*(__IO uint32_t*)0x4200350CU) /**< (TRAM) TrustRAM 3 */
+#define REG_TRAM_RAM4           (*(__IO uint32_t*)0x42003510U) /**< (TRAM) TrustRAM 4 */
+#define REG_TRAM_RAM5           (*(__IO uint32_t*)0x42003514U) /**< (TRAM) TrustRAM 5 */
+#define REG_TRAM_RAM6           (*(__IO uint32_t*)0x42003518U) /**< (TRAM) TrustRAM 6 */
+#define REG_TRAM_RAM7           (*(__IO uint32_t*)0x4200351CU) /**< (TRAM) TrustRAM 7 */
+#define REG_TRAM_RAM8           (*(__IO uint32_t*)0x42003520U) /**< (TRAM) TrustRAM 8 */
+#define REG_TRAM_RAM9           (*(__IO uint32_t*)0x42003524U) /**< (TRAM) TrustRAM 9 */
+#define REG_TRAM_RAM10          (*(__IO uint32_t*)0x42003528U) /**< (TRAM) TrustRAM 10 */
+#define REG_TRAM_RAM11          (*(__IO uint32_t*)0x4200352CU) /**< (TRAM) TrustRAM 11 */
+#define REG_TRAM_RAM12          (*(__IO uint32_t*)0x42003530U) /**< (TRAM) TrustRAM 12 */
+#define REG_TRAM_RAM13          (*(__IO uint32_t*)0x42003534U) /**< (TRAM) TrustRAM 13 */
+#define REG_TRAM_RAM14          (*(__IO uint32_t*)0x42003538U) /**< (TRAM) TrustRAM 14 */
+#define REG_TRAM_RAM15          (*(__IO uint32_t*)0x4200353CU) /**< (TRAM) TrustRAM 15 */
+#define REG_TRAM_RAM16          (*(__IO uint32_t*)0x42003540U) /**< (TRAM) TrustRAM 16 */
+#define REG_TRAM_RAM17          (*(__IO uint32_t*)0x42003544U) /**< (TRAM) TrustRAM 17 */
+#define REG_TRAM_RAM18          (*(__IO uint32_t*)0x42003548U) /**< (TRAM) TrustRAM 18 */
+#define REG_TRAM_RAM19          (*(__IO uint32_t*)0x4200354CU) /**< (TRAM) TrustRAM 19 */
+#define REG_TRAM_RAM20          (*(__IO uint32_t*)0x42003550U) /**< (TRAM) TrustRAM 20 */
+#define REG_TRAM_RAM21          (*(__IO uint32_t*)0x42003554U) /**< (TRAM) TrustRAM 21 */
+#define REG_TRAM_RAM22          (*(__IO uint32_t*)0x42003558U) /**< (TRAM) TrustRAM 22 */
+#define REG_TRAM_RAM23          (*(__IO uint32_t*)0x4200355CU) /**< (TRAM) TrustRAM 23 */
+#define REG_TRAM_RAM24          (*(__IO uint32_t*)0x42003560U) /**< (TRAM) TrustRAM 24 */
+#define REG_TRAM_RAM25          (*(__IO uint32_t*)0x42003564U) /**< (TRAM) TrustRAM 25 */
+#define REG_TRAM_RAM26          (*(__IO uint32_t*)0x42003568U) /**< (TRAM) TrustRAM 26 */
+#define REG_TRAM_RAM27          (*(__IO uint32_t*)0x4200356CU) /**< (TRAM) TrustRAM 27 */
+#define REG_TRAM_RAM28          (*(__IO uint32_t*)0x42003570U) /**< (TRAM) TrustRAM 28 */
+#define REG_TRAM_RAM29          (*(__IO uint32_t*)0x42003574U) /**< (TRAM) TrustRAM 29 */
+#define REG_TRAM_RAM30          (*(__IO uint32_t*)0x42003578U) /**< (TRAM) TrustRAM 30 */
+#define REG_TRAM_RAM31          (*(__IO uint32_t*)0x4200357CU) /**< (TRAM) TrustRAM 31 */
+#define REG_TRAM_RAM32          (*(__IO uint32_t*)0x42003580U) /**< (TRAM) TrustRAM 32 */
+#define REG_TRAM_RAM33          (*(__IO uint32_t*)0x42003584U) /**< (TRAM) TrustRAM 33 */
+#define REG_TRAM_RAM34          (*(__IO uint32_t*)0x42003588U) /**< (TRAM) TrustRAM 34 */
+#define REG_TRAM_RAM35          (*(__IO uint32_t*)0x4200358CU) /**< (TRAM) TrustRAM 35 */
+#define REG_TRAM_RAM36          (*(__IO uint32_t*)0x42003590U) /**< (TRAM) TrustRAM 36 */
+#define REG_TRAM_RAM37          (*(__IO uint32_t*)0x42003594U) /**< (TRAM) TrustRAM 37 */
+#define REG_TRAM_RAM38          (*(__IO uint32_t*)0x42003598U) /**< (TRAM) TrustRAM 38 */
+#define REG_TRAM_RAM39          (*(__IO uint32_t*)0x4200359CU) /**< (TRAM) TrustRAM 39 */
+#define REG_TRAM_RAM40          (*(__IO uint32_t*)0x420035A0U) /**< (TRAM) TrustRAM 40 */
+#define REG_TRAM_RAM41          (*(__IO uint32_t*)0x420035A4U) /**< (TRAM) TrustRAM 41 */
+#define REG_TRAM_RAM42          (*(__IO uint32_t*)0x420035A8U) /**< (TRAM) TrustRAM 42 */
+#define REG_TRAM_RAM43          (*(__IO uint32_t*)0x420035ACU) /**< (TRAM) TrustRAM 43 */
+#define REG_TRAM_RAM44          (*(__IO uint32_t*)0x420035B0U) /**< (TRAM) TrustRAM 44 */
+#define REG_TRAM_RAM45          (*(__IO uint32_t*)0x420035B4U) /**< (TRAM) TrustRAM 45 */
+#define REG_TRAM_RAM46          (*(__IO uint32_t*)0x420035B8U) /**< (TRAM) TrustRAM 46 */
+#define REG_TRAM_RAM47          (*(__IO uint32_t*)0x420035BCU) /**< (TRAM) TrustRAM 47 */
+#define REG_TRAM_RAM48          (*(__IO uint32_t*)0x420035C0U) /**< (TRAM) TrustRAM 48 */
+#define REG_TRAM_RAM49          (*(__IO uint32_t*)0x420035C4U) /**< (TRAM) TrustRAM 49 */
+#define REG_TRAM_RAM50          (*(__IO uint32_t*)0x420035C8U) /**< (TRAM) TrustRAM 50 */
+#define REG_TRAM_RAM51          (*(__IO uint32_t*)0x420035CCU) /**< (TRAM) TrustRAM 51 */
+#define REG_TRAM_RAM52          (*(__IO uint32_t*)0x420035D0U) /**< (TRAM) TrustRAM 52 */
+#define REG_TRAM_RAM53          (*(__IO uint32_t*)0x420035D4U) /**< (TRAM) TrustRAM 53 */
+#define REG_TRAM_RAM54          (*(__IO uint32_t*)0x420035D8U) /**< (TRAM) TrustRAM 54 */
+#define REG_TRAM_RAM55          (*(__IO uint32_t*)0x420035DCU) /**< (TRAM) TrustRAM 55 */
+#define REG_TRAM_RAM56          (*(__IO uint32_t*)0x420035E0U) /**< (TRAM) TrustRAM 56 */
+#define REG_TRAM_RAM57          (*(__IO uint32_t*)0x420035E4U) /**< (TRAM) TrustRAM 57 */
+#define REG_TRAM_RAM58          (*(__IO uint32_t*)0x420035E8U) /**< (TRAM) TrustRAM 58 */
+#define REG_TRAM_RAM59          (*(__IO uint32_t*)0x420035ECU) /**< (TRAM) TrustRAM 59 */
+#define REG_TRAM_RAM60          (*(__IO uint32_t*)0x420035F0U) /**< (TRAM) TrustRAM 60 */
+#define REG_TRAM_RAM61          (*(__IO uint32_t*)0x420035F4U) /**< (TRAM) TrustRAM 61 */
+#define REG_TRAM_RAM62          (*(__IO uint32_t*)0x420035F8U) /**< (TRAM) TrustRAM 62 */
+#define REG_TRAM_RAM63          (*(__IO uint32_t*)0x420035FCU) /**< (TRAM) TrustRAM 63 */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for TRAM peripheral ========== */
+#define TRAM_INSTANCE_ID                         77         
+
+#endif /* _SAML11_TRAM_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/instance/trng.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/instance/trng.h
@@ -1,0 +1,58 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TRNG
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_TRNG_INSTANCE_H_
+#define _SAML11_TRNG_INSTANCE_H_
+
+/* ========== Register definition for TRNG peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_TRNG_CTRLA          (0x42002800) /**< (TRNG) Control A */
+#define REG_TRNG_EVCTRL         (0x42002804) /**< (TRNG) Event Control */
+#define REG_TRNG_INTENCLR       (0x42002808) /**< (TRNG) Interrupt Enable Clear */
+#define REG_TRNG_INTENSET       (0x42002809) /**< (TRNG) Interrupt Enable Set */
+#define REG_TRNG_INTFLAG        (0x4200280A) /**< (TRNG) Interrupt Flag Status and Clear */
+#define REG_TRNG_DATA           (0x42002820) /**< (TRNG) Output Data */
+
+#else
+
+#define REG_TRNG_CTRLA          (*(__IO uint8_t*)0x42002800U) /**< (TRNG) Control A */
+#define REG_TRNG_EVCTRL         (*(__IO uint8_t*)0x42002804U) /**< (TRNG) Event Control */
+#define REG_TRNG_INTENCLR       (*(__IO uint8_t*)0x42002808U) /**< (TRNG) Interrupt Enable Clear */
+#define REG_TRNG_INTENSET       (*(__IO uint8_t*)0x42002809U) /**< (TRNG) Interrupt Enable Set */
+#define REG_TRNG_INTFLAG        (*(__IO uint8_t*)0x4200280AU) /**< (TRNG) Interrupt Flag Status and Clear */
+#define REG_TRNG_DATA           (*(__I  uint32_t*)0x42002820U) /**< (TRNG) Output Data */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for TRNG peripheral ========== */
+#define TRNG_INSTANCE_ID                         74         
+
+#endif /* _SAML11_TRNG_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/instance/wdt.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/instance/wdt.h
@@ -1,0 +1,62 @@
+/**
+ * \file
+ *
+ * \brief Instance description for WDT
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11_WDT_INSTANCE_H_
+#define _SAML11_WDT_INSTANCE_H_
+
+/* ========== Register definition for WDT peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_WDT_CTRLA           (0x40002000) /**< (WDT) Control */
+#define REG_WDT_CONFIG          (0x40002001) /**< (WDT) Configuration */
+#define REG_WDT_EWCTRL          (0x40002002) /**< (WDT) Early Warning Interrupt Control */
+#define REG_WDT_INTENCLR        (0x40002004) /**< (WDT) Interrupt Enable Clear */
+#define REG_WDT_INTENSET        (0x40002005) /**< (WDT) Interrupt Enable Set */
+#define REG_WDT_INTFLAG         (0x40002006) /**< (WDT) Interrupt Flag Status and Clear */
+#define REG_WDT_SYNCBUSY        (0x40002008) /**< (WDT) Synchronization Busy */
+#define REG_WDT_CLEAR           (0x4000200C) /**< (WDT) Clear */
+
+#else
+
+#define REG_WDT_CTRLA           (*(__IO uint8_t*)0x40002000U) /**< (WDT) Control */
+#define REG_WDT_CONFIG          (*(__IO uint8_t*)0x40002001U) /**< (WDT) Configuration */
+#define REG_WDT_EWCTRL          (*(__IO uint8_t*)0x40002002U) /**< (WDT) Early Warning Interrupt Control */
+#define REG_WDT_INTENCLR        (*(__IO uint8_t*)0x40002004U) /**< (WDT) Interrupt Enable Clear */
+#define REG_WDT_INTENSET        (*(__IO uint8_t*)0x40002005U) /**< (WDT) Interrupt Enable Set */
+#define REG_WDT_INTFLAG         (*(__IO uint8_t*)0x40002006U) /**< (WDT) Interrupt Flag Status and Clear */
+#define REG_WDT_SYNCBUSY        (*(__I  uint32_t*)0x40002008U) /**< (WDT) Synchronization Busy */
+#define REG_WDT_CLEAR           (*(__O  uint8_t*)0x4000200CU) /**< (WDT) Clear */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for WDT peripheral ========== */
+#define WDT_INSTANCE_ID                          8          
+
+#endif /* _SAML11_WDT_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/pio/saml11d14a.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/pio/saml11d14a.h
@@ -1,0 +1,834 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAML11D14A
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11D14A_PIO_H_
+#define _SAML11D14A_PIO_H_
+
+/* ========== Peripheral I/O pin numbers ========== */
+#define PIN_PA00                    (  0)  /**< Pin Number for PA00 */
+#define PIN_PA01                    (  1)  /**< Pin Number for PA01 */
+#define PIN_PA02                    (  2)  /**< Pin Number for PA02 */
+#define PIN_PA03                    (  3)  /**< Pin Number for PA03 */
+#define PIN_PA04                    (  4)  /**< Pin Number for PA04 */
+#define PIN_PA05                    (  5)  /**< Pin Number for PA05 */
+#define PIN_PA08                    (  8)  /**< Pin Number for PA08 */
+#define PIN_PA14                    ( 14)  /**< Pin Number for PA14 */
+#define PIN_PA15                    ( 15)  /**< Pin Number for PA15 */
+#define PIN_PA16                    ( 16)  /**< Pin Number for PA16 */
+#define PIN_PA17                    ( 17)  /**< Pin Number for PA17 */
+#define PIN_PA18                    ( 18)  /**< Pin Number for PA18 */
+#define PIN_PA19                    ( 19)  /**< Pin Number for PA19 */
+#define PIN_PA22                    ( 22)  /**< Pin Number for PA22 */
+#define PIN_PA23                    ( 23)  /**< Pin Number for PA23 */
+#define PIN_PA30                    ( 30)  /**< Pin Number for PA30 */
+#define PIN_PA31                    ( 31)  /**< Pin Number for PA31 */
+
+
+/* ========== Peripheral I/O masks ========== */
+#define PORT_PA00                   (_U_(1) << 0) /**< PORT Mask for PA00 */
+#define PORT_PA01                   (_U_(1) << 1) /**< PORT Mask for PA01 */
+#define PORT_PA02                   (_U_(1) << 2) /**< PORT Mask for PA02 */
+#define PORT_PA03                   (_U_(1) << 3) /**< PORT Mask for PA03 */
+#define PORT_PA04                   (_U_(1) << 4) /**< PORT Mask for PA04 */
+#define PORT_PA05                   (_U_(1) << 5) /**< PORT Mask for PA05 */
+#define PORT_PA08                   (_U_(1) << 8) /**< PORT Mask for PA08 */
+#define PORT_PA14                   (_U_(1) << 14) /**< PORT Mask for PA14 */
+#define PORT_PA15                   (_U_(1) << 15) /**< PORT Mask for PA15 */
+#define PORT_PA16                   (_U_(1) << 16) /**< PORT Mask for PA16 */
+#define PORT_PA17                   (_U_(1) << 17) /**< PORT Mask for PA17 */
+#define PORT_PA18                   (_U_(1) << 18) /**< PORT Mask for PA18 */
+#define PORT_PA19                   (_U_(1) << 19) /**< PORT Mask for PA19 */
+#define PORT_PA22                   (_U_(1) << 22) /**< PORT Mask for PA22 */
+#define PORT_PA23                   (_U_(1) << 23) /**< PORT Mask for PA23 */
+#define PORT_PA30                   (_U_(1) << 30) /**< PORT Mask for PA30 */
+#define PORT_PA31                   (_U_(1) << 31) /**< PORT Mask for PA31 */
+
+
+/* ========== Peripheral I/O indexes ========== */
+#define PORT_PA00_IDX               (  0)  /**< PORT Index Number for PA00 */
+#define PORT_PA01_IDX               (  1)  /**< PORT Index Number for PA01 */
+#define PORT_PA02_IDX               (  2)  /**< PORT Index Number for PA02 */
+#define PORT_PA03_IDX               (  3)  /**< PORT Index Number for PA03 */
+#define PORT_PA04_IDX               (  4)  /**< PORT Index Number for PA04 */
+#define PORT_PA05_IDX               (  5)  /**< PORT Index Number for PA05 */
+#define PORT_PA08_IDX               (  8)  /**< PORT Index Number for PA08 */
+#define PORT_PA14_IDX               ( 14)  /**< PORT Index Number for PA14 */
+#define PORT_PA15_IDX               ( 15)  /**< PORT Index Number for PA15 */
+#define PORT_PA16_IDX               ( 16)  /**< PORT Index Number for PA16 */
+#define PORT_PA17_IDX               ( 17)  /**< PORT Index Number for PA17 */
+#define PORT_PA18_IDX               ( 18)  /**< PORT Index Number for PA18 */
+#define PORT_PA19_IDX               ( 19)  /**< PORT Index Number for PA19 */
+#define PORT_PA22_IDX               ( 22)  /**< PORT Index Number for PA22 */
+#define PORT_PA23_IDX               ( 23)  /**< PORT Index Number for PA23 */
+#define PORT_PA30_IDX               ( 30)  /**< PORT Index Number for PA30 */
+#define PORT_PA31_IDX               ( 31)  /**< PORT Index Number for PA31 */
+
+/* ========== PORT definition for AC peripheral ========== */
+#define PIN_PA04B_AC_AIN0                          _L_(4)       /**< AC signal: AIN0 on PA04 mux B*/
+#define MUX_PA04B_AC_AIN0                          _L_(1)      
+#define PINMUX_PA04B_AC_AIN0                       ((PIN_PA04B_AC_AIN0 << 16) | MUX_PA04B_AC_AIN0)
+#define PORT_PA04B_AC_AIN0                         (_UL_(1) << 4)
+
+#define PIN_PA05B_AC_AIN1                          _L_(5)       /**< AC signal: AIN1 on PA05 mux B*/
+#define MUX_PA05B_AC_AIN1                          _L_(1)      
+#define PINMUX_PA05B_AC_AIN1                       ((PIN_PA05B_AC_AIN1 << 16) | MUX_PA05B_AC_AIN1)
+#define PORT_PA05B_AC_AIN1                         (_UL_(1) << 5)
+
+#define PIN_PA18H_AC_CMP0                          _L_(18)      /**< AC signal: CMP0 on PA18 mux H*/
+#define MUX_PA18H_AC_CMP0                          _L_(7)      
+#define PINMUX_PA18H_AC_CMP0                       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
+#define PORT_PA18H_AC_CMP0                         (_UL_(1) << 18)
+
+#define PIN_PA19H_AC_CMP1                          _L_(19)      /**< AC signal: CMP1 on PA19 mux H*/
+#define MUX_PA19H_AC_CMP1                          _L_(7)      
+#define PINMUX_PA19H_AC_CMP1                       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
+#define PORT_PA19H_AC_CMP1                         (_UL_(1) << 19)
+
+/* ========== PORT definition for ADC peripheral ========== */
+#define PIN_PA02B_ADC_AIN0                         _L_(2)       /**< ADC signal: AIN0 on PA02 mux B*/
+#define MUX_PA02B_ADC_AIN0                         _L_(1)      
+#define PINMUX_PA02B_ADC_AIN0                      ((PIN_PA02B_ADC_AIN0 << 16) | MUX_PA02B_ADC_AIN0)
+#define PORT_PA02B_ADC_AIN0                        (_UL_(1) << 2)
+
+#define PIN_PA03B_ADC_AIN1                         _L_(3)       /**< ADC signal: AIN1 on PA03 mux B*/
+#define MUX_PA03B_ADC_AIN1                         _L_(1)      
+#define PINMUX_PA03B_ADC_AIN1                      ((PIN_PA03B_ADC_AIN1 << 16) | MUX_PA03B_ADC_AIN1)
+#define PORT_PA03B_ADC_AIN1                        (_UL_(1) << 3)
+
+#define PIN_PA04B_ADC_AIN2                         _L_(4)       /**< ADC signal: AIN2 on PA04 mux B*/
+#define MUX_PA04B_ADC_AIN2                         _L_(1)      
+#define PINMUX_PA04B_ADC_AIN2                      ((PIN_PA04B_ADC_AIN2 << 16) | MUX_PA04B_ADC_AIN2)
+#define PORT_PA04B_ADC_AIN2                        (_UL_(1) << 4)
+
+#define PIN_PA05B_ADC_AIN3                         _L_(5)       /**< ADC signal: AIN3 on PA05 mux B*/
+#define MUX_PA05B_ADC_AIN3                         _L_(1)      
+#define PINMUX_PA05B_ADC_AIN3                      ((PIN_PA05B_ADC_AIN3 << 16) | MUX_PA05B_ADC_AIN3)
+#define PORT_PA05B_ADC_AIN3                        (_UL_(1) << 5)
+
+#define PIN_PA08B_ADC_AIN6                         _L_(8)       /**< ADC signal: AIN6 on PA08 mux B*/
+#define MUX_PA08B_ADC_AIN6                         _L_(1)      
+#define PINMUX_PA08B_ADC_AIN6                      ((PIN_PA08B_ADC_AIN6 << 16) | MUX_PA08B_ADC_AIN6)
+#define PORT_PA08B_ADC_AIN6                        (_UL_(1) << 8)
+
+#define PIN_PA04B_ADC_VREFP                        _L_(4)       /**< ADC signal: VREFP on PA04 mux B*/
+#define MUX_PA04B_ADC_VREFP                        _L_(1)      
+#define PINMUX_PA04B_ADC_VREFP                     ((PIN_PA04B_ADC_VREFP << 16) | MUX_PA04B_ADC_VREFP)
+#define PORT_PA04B_ADC_VREFP                       (_UL_(1) << 4)
+
+/* ========== PORT definition for CCL peripheral ========== */
+#define PIN_PA04I_CCL_IN0                          _L_(4)       /**< CCL signal: IN0 on PA04 mux I*/
+#define MUX_PA04I_CCL_IN0                          _L_(8)      
+#define PINMUX_PA04I_CCL_IN0                       ((PIN_PA04I_CCL_IN0 << 16) | MUX_PA04I_CCL_IN0)
+#define PORT_PA04I_CCL_IN0                         (_UL_(1) << 4)
+
+#define PIN_PA16I_CCL_IN0                          _L_(16)      /**< CCL signal: IN0 on PA16 mux I*/
+#define MUX_PA16I_CCL_IN0                          _L_(8)      
+#define PINMUX_PA16I_CCL_IN0                       ((PIN_PA16I_CCL_IN0 << 16) | MUX_PA16I_CCL_IN0)
+#define PORT_PA16I_CCL_IN0                         (_UL_(1) << 16)
+
+#define PIN_PA05I_CCL_IN1                          _L_(5)       /**< CCL signal: IN1 on PA05 mux I*/
+#define MUX_PA05I_CCL_IN1                          _L_(8)      
+#define PINMUX_PA05I_CCL_IN1                       ((PIN_PA05I_CCL_IN1 << 16) | MUX_PA05I_CCL_IN1)
+#define PORT_PA05I_CCL_IN1                         (_UL_(1) << 5)
+
+#define PIN_PA17I_CCL_IN1                          _L_(17)      /**< CCL signal: IN1 on PA17 mux I*/
+#define MUX_PA17I_CCL_IN1                          _L_(8)      
+#define PINMUX_PA17I_CCL_IN1                       ((PIN_PA17I_CCL_IN1 << 16) | MUX_PA17I_CCL_IN1)
+#define PORT_PA17I_CCL_IN1                         (_UL_(1) << 17)
+
+#define PIN_PA18I_CCL_IN2                          _L_(18)      /**< CCL signal: IN2 on PA18 mux I*/
+#define MUX_PA18I_CCL_IN2                          _L_(8)      
+#define PINMUX_PA18I_CCL_IN2                       ((PIN_PA18I_CCL_IN2 << 16) | MUX_PA18I_CCL_IN2)
+#define PORT_PA18I_CCL_IN2                         (_UL_(1) << 18)
+
+#define PIN_PA08I_CCL_IN3                          _L_(8)       /**< CCL signal: IN3 on PA08 mux I*/
+#define MUX_PA08I_CCL_IN3                          _L_(8)      
+#define PINMUX_PA08I_CCL_IN3                       ((PIN_PA08I_CCL_IN3 << 16) | MUX_PA08I_CCL_IN3)
+#define PORT_PA08I_CCL_IN3                         (_UL_(1) << 8)
+
+#define PIN_PA30I_CCL_IN3                          _L_(30)      /**< CCL signal: IN3 on PA30 mux I*/
+#define MUX_PA30I_CCL_IN3                          _L_(8)      
+#define PINMUX_PA30I_CCL_IN3                       ((PIN_PA30I_CCL_IN3 << 16) | MUX_PA30I_CCL_IN3)
+#define PORT_PA30I_CCL_IN3                         (_UL_(1) << 30)
+
+#define PIN_PA19I_CCL_OUT0                         _L_(19)      /**< CCL signal: OUT0 on PA19 mux I*/
+#define MUX_PA19I_CCL_OUT0                         _L_(8)      
+#define PINMUX_PA19I_CCL_OUT0                      ((PIN_PA19I_CCL_OUT0 << 16) | MUX_PA19I_CCL_OUT0)
+#define PORT_PA19I_CCL_OUT0                        (_UL_(1) << 19)
+
+#define PIN_PA31I_CCL_OUT1                         _L_(31)      /**< CCL signal: OUT1 on PA31 mux I*/
+#define MUX_PA31I_CCL_OUT1                         _L_(8)      
+#define PINMUX_PA31I_CCL_OUT1                      ((PIN_PA31I_CCL_OUT1 << 16) | MUX_PA31I_CCL_OUT1)
+#define PORT_PA31I_CCL_OUT1                        (_UL_(1) << 31)
+
+/* ========== PORT definition for DAC peripheral ========== */
+#define PIN_PA02B_DAC_VOUT                         _L_(2)       /**< DAC signal: VOUT on PA02 mux B*/
+#define MUX_PA02B_DAC_VOUT                         _L_(1)      
+#define PINMUX_PA02B_DAC_VOUT                      ((PIN_PA02B_DAC_VOUT << 16) | MUX_PA02B_DAC_VOUT)
+#define PORT_PA02B_DAC_VOUT                        (_UL_(1) << 2)
+
+#define PIN_PA03B_DAC_VREFP                        _L_(3)       /**< DAC signal: VREFP on PA03 mux B*/
+#define MUX_PA03B_DAC_VREFP                        _L_(1)      
+#define PINMUX_PA03B_DAC_VREFP                     ((PIN_PA03B_DAC_VREFP << 16) | MUX_PA03B_DAC_VREFP)
+#define PORT_PA03B_DAC_VREFP                       (_UL_(1) << 3)
+
+/* ========== PORT definition for EIC peripheral ========== */
+#define PIN_PA19A_EIC_EXTINT0                      _L_(19)      /**< EIC signal: EXTINT0 on PA19 mux A*/
+#define MUX_PA19A_EIC_EXTINT0                      _L_(0)      
+#define PINMUX_PA19A_EIC_EXTINT0                   ((PIN_PA19A_EIC_EXTINT0 << 16) | MUX_PA19A_EIC_EXTINT0)
+#define PORT_PA19A_EIC_EXTINT0                     (_UL_(1) << 19)
+#define PIN_PA19A_EIC_EXTINT_NUM                   _L_(0)       /**< EIC signal: PIN_PA19 External Interrupt Line */
+
+#define PIN_PA00A_EIC_EXTINT0                      _L_(0)       /**< EIC signal: EXTINT0 on PA00 mux A*/
+#define MUX_PA00A_EIC_EXTINT0                      _L_(0)      
+#define PINMUX_PA00A_EIC_EXTINT0                   ((PIN_PA00A_EIC_EXTINT0 << 16) | MUX_PA00A_EIC_EXTINT0)
+#define PORT_PA00A_EIC_EXTINT0                     (_UL_(1) << 0)
+#define PIN_PA00A_EIC_EXTINT_NUM                   _L_(0)       /**< EIC signal: PIN_PA00 External Interrupt Line */
+
+#define PIN_PA22A_EIC_EXTINT1                      _L_(22)      /**< EIC signal: EXTINT1 on PA22 mux A*/
+#define MUX_PA22A_EIC_EXTINT1                      _L_(0)      
+#define PINMUX_PA22A_EIC_EXTINT1                   ((PIN_PA22A_EIC_EXTINT1 << 16) | MUX_PA22A_EIC_EXTINT1)
+#define PORT_PA22A_EIC_EXTINT1                     (_UL_(1) << 22)
+#define PIN_PA22A_EIC_EXTINT_NUM                   _L_(1)       /**< EIC signal: PIN_PA22 External Interrupt Line */
+
+#define PIN_PA01A_EIC_EXTINT1                      _L_(1)       /**< EIC signal: EXTINT1 on PA01 mux A*/
+#define MUX_PA01A_EIC_EXTINT1                      _L_(0)      
+#define PINMUX_PA01A_EIC_EXTINT1                   ((PIN_PA01A_EIC_EXTINT1 << 16) | MUX_PA01A_EIC_EXTINT1)
+#define PORT_PA01A_EIC_EXTINT1                     (_UL_(1) << 1)
+#define PIN_PA01A_EIC_EXTINT_NUM                   _L_(1)       /**< EIC signal: PIN_PA01 External Interrupt Line */
+
+#define PIN_PA02A_EIC_EXTINT2                      _L_(2)       /**< EIC signal: EXTINT2 on PA02 mux A*/
+#define MUX_PA02A_EIC_EXTINT2                      _L_(0)      
+#define PINMUX_PA02A_EIC_EXTINT2                   ((PIN_PA02A_EIC_EXTINT2 << 16) | MUX_PA02A_EIC_EXTINT2)
+#define PORT_PA02A_EIC_EXTINT2                     (_UL_(1) << 2)
+#define PIN_PA02A_EIC_EXTINT_NUM                   _L_(2)       /**< EIC signal: PIN_PA02 External Interrupt Line */
+
+#define PIN_PA23A_EIC_EXTINT2                      _L_(23)      /**< EIC signal: EXTINT2 on PA23 mux A*/
+#define MUX_PA23A_EIC_EXTINT2                      _L_(0)      
+#define PINMUX_PA23A_EIC_EXTINT2                   ((PIN_PA23A_EIC_EXTINT2 << 16) | MUX_PA23A_EIC_EXTINT2)
+#define PORT_PA23A_EIC_EXTINT2                     (_UL_(1) << 23)
+#define PIN_PA23A_EIC_EXTINT_NUM                   _L_(2)       /**< EIC signal: PIN_PA23 External Interrupt Line */
+
+#define PIN_PA03A_EIC_EXTINT3                      _L_(3)       /**< EIC signal: EXTINT3 on PA03 mux A*/
+#define MUX_PA03A_EIC_EXTINT3                      _L_(0)      
+#define PINMUX_PA03A_EIC_EXTINT3                   ((PIN_PA03A_EIC_EXTINT3 << 16) | MUX_PA03A_EIC_EXTINT3)
+#define PORT_PA03A_EIC_EXTINT3                     (_UL_(1) << 3)
+#define PIN_PA03A_EIC_EXTINT_NUM                   _L_(3)       /**< EIC signal: PIN_PA03 External Interrupt Line */
+
+#define PIN_PA14A_EIC_EXTINT3                      _L_(14)      /**< EIC signal: EXTINT3 on PA14 mux A*/
+#define MUX_PA14A_EIC_EXTINT3                      _L_(0)      
+#define PINMUX_PA14A_EIC_EXTINT3                   ((PIN_PA14A_EIC_EXTINT3 << 16) | MUX_PA14A_EIC_EXTINT3)
+#define PORT_PA14A_EIC_EXTINT3                     (_UL_(1) << 14)
+#define PIN_PA14A_EIC_EXTINT_NUM                   _L_(3)       /**< EIC signal: PIN_PA14 External Interrupt Line */
+
+#define PIN_PA04A_EIC_EXTINT4                      _L_(4)       /**< EIC signal: EXTINT4 on PA04 mux A*/
+#define MUX_PA04A_EIC_EXTINT4                      _L_(0)      
+#define PINMUX_PA04A_EIC_EXTINT4                   ((PIN_PA04A_EIC_EXTINT4 << 16) | MUX_PA04A_EIC_EXTINT4)
+#define PORT_PA04A_EIC_EXTINT4                     (_UL_(1) << 4)
+#define PIN_PA04A_EIC_EXTINT_NUM                   _L_(4)       /**< EIC signal: PIN_PA04 External Interrupt Line */
+
+#define PIN_PA15A_EIC_EXTINT4                      _L_(15)      /**< EIC signal: EXTINT4 on PA15 mux A*/
+#define MUX_PA15A_EIC_EXTINT4                      _L_(0)      
+#define PINMUX_PA15A_EIC_EXTINT4                   ((PIN_PA15A_EIC_EXTINT4 << 16) | MUX_PA15A_EIC_EXTINT4)
+#define PORT_PA15A_EIC_EXTINT4                     (_UL_(1) << 15)
+#define PIN_PA15A_EIC_EXTINT_NUM                   _L_(4)       /**< EIC signal: PIN_PA15 External Interrupt Line */
+
+#define PIN_PA05A_EIC_EXTINT5                      _L_(5)       /**< EIC signal: EXTINT5 on PA05 mux A*/
+#define MUX_PA05A_EIC_EXTINT5                      _L_(0)      
+#define PINMUX_PA05A_EIC_EXTINT5                   ((PIN_PA05A_EIC_EXTINT5 << 16) | MUX_PA05A_EIC_EXTINT5)
+#define PORT_PA05A_EIC_EXTINT5                     (_UL_(1) << 5)
+#define PIN_PA05A_EIC_EXTINT_NUM                   _L_(5)       /**< EIC signal: PIN_PA05 External Interrupt Line */
+
+#define PIN_PA16A_EIC_EXTINT5                      _L_(16)      /**< EIC signal: EXTINT5 on PA16 mux A*/
+#define MUX_PA16A_EIC_EXTINT5                      _L_(0)      
+#define PINMUX_PA16A_EIC_EXTINT5                   ((PIN_PA16A_EIC_EXTINT5 << 16) | MUX_PA16A_EIC_EXTINT5)
+#define PORT_PA16A_EIC_EXTINT5                     (_UL_(1) << 16)
+#define PIN_PA16A_EIC_EXTINT_NUM                   _L_(5)       /**< EIC signal: PIN_PA16 External Interrupt Line */
+
+#define PIN_PA17A_EIC_EXTINT6                      _L_(17)      /**< EIC signal: EXTINT6 on PA17 mux A*/
+#define MUX_PA17A_EIC_EXTINT6                      _L_(0)      
+#define PINMUX_PA17A_EIC_EXTINT6                   ((PIN_PA17A_EIC_EXTINT6 << 16) | MUX_PA17A_EIC_EXTINT6)
+#define PORT_PA17A_EIC_EXTINT6                     (_UL_(1) << 17)
+#define PIN_PA17A_EIC_EXTINT_NUM                   _L_(6)       /**< EIC signal: PIN_PA17 External Interrupt Line */
+
+#define PIN_PA30A_EIC_EXTINT6                      _L_(30)      /**< EIC signal: EXTINT6 on PA30 mux A*/
+#define MUX_PA30A_EIC_EXTINT6                      _L_(0)      
+#define PINMUX_PA30A_EIC_EXTINT6                   ((PIN_PA30A_EIC_EXTINT6 << 16) | MUX_PA30A_EIC_EXTINT6)
+#define PORT_PA30A_EIC_EXTINT6                     (_UL_(1) << 30)
+#define PIN_PA30A_EIC_EXTINT_NUM                   _L_(6)       /**< EIC signal: PIN_PA30 External Interrupt Line */
+
+#define PIN_PA18A_EIC_EXTINT7                      _L_(18)      /**< EIC signal: EXTINT7 on PA18 mux A*/
+#define MUX_PA18A_EIC_EXTINT7                      _L_(0)      
+#define PINMUX_PA18A_EIC_EXTINT7                   ((PIN_PA18A_EIC_EXTINT7 << 16) | MUX_PA18A_EIC_EXTINT7)
+#define PORT_PA18A_EIC_EXTINT7                     (_UL_(1) << 18)
+#define PIN_PA18A_EIC_EXTINT_NUM                   _L_(7)       /**< EIC signal: PIN_PA18 External Interrupt Line */
+
+#define PIN_PA31A_EIC_EXTINT7                      _L_(31)      /**< EIC signal: EXTINT7 on PA31 mux A*/
+#define MUX_PA31A_EIC_EXTINT7                      _L_(0)      
+#define PINMUX_PA31A_EIC_EXTINT7                   ((PIN_PA31A_EIC_EXTINT7 << 16) | MUX_PA31A_EIC_EXTINT7)
+#define PORT_PA31A_EIC_EXTINT7                     (_UL_(1) << 31)
+#define PIN_PA31A_EIC_EXTINT_NUM                   _L_(7)       /**< EIC signal: PIN_PA31 External Interrupt Line */
+
+#define PIN_PA08A_EIC_NMI                          _L_(8)       /**< EIC signal: NMI on PA08 mux A*/
+#define MUX_PA08A_EIC_NMI                          _L_(0)      
+#define PINMUX_PA08A_EIC_NMI                       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
+#define PORT_PA08A_EIC_NMI                         (_UL_(1) << 8)
+
+/* ========== PORT definition for GCLK peripheral ========== */
+#define PIN_PA30H_GCLK_IO0                         _L_(30)      /**< GCLK signal: IO0 on PA30 mux H*/
+#define MUX_PA30H_GCLK_IO0                         _L_(7)      
+#define PINMUX_PA30H_GCLK_IO0                      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
+#define PORT_PA30H_GCLK_IO0                        (_UL_(1) << 30)
+
+#define PIN_PA14H_GCLK_IO0                         _L_(14)      /**< GCLK signal: IO0 on PA14 mux H*/
+#define MUX_PA14H_GCLK_IO0                         _L_(7)      
+#define PINMUX_PA14H_GCLK_IO0                      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
+#define PORT_PA14H_GCLK_IO0                        (_UL_(1) << 14)
+
+#define PIN_PA23H_GCLK_IO1                         _L_(23)      /**< GCLK signal: IO1 on PA23 mux H*/
+#define MUX_PA23H_GCLK_IO1                         _L_(7)      
+#define PINMUX_PA23H_GCLK_IO1                      ((PIN_PA23H_GCLK_IO1 << 16) | MUX_PA23H_GCLK_IO1)
+#define PORT_PA23H_GCLK_IO1                        (_UL_(1) << 23)
+
+#define PIN_PA15H_GCLK_IO1                         _L_(15)      /**< GCLK signal: IO1 on PA15 mux H*/
+#define MUX_PA15H_GCLK_IO1                         _L_(7)      
+#define PINMUX_PA15H_GCLK_IO1                      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
+#define PORT_PA15H_GCLK_IO1                        (_UL_(1) << 15)
+
+#define PIN_PA16H_GCLK_IO2                         _L_(16)      /**< GCLK signal: IO2 on PA16 mux H*/
+#define MUX_PA16H_GCLK_IO2                         _L_(7)      
+#define PINMUX_PA16H_GCLK_IO2                      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
+#define PORT_PA16H_GCLK_IO2                        (_UL_(1) << 16)
+
+#define PIN_PA22H_GCLK_IO2                         _L_(22)      /**< GCLK signal: IO2 on PA22 mux H*/
+#define MUX_PA22H_GCLK_IO2                         _L_(7)      
+#define PINMUX_PA22H_GCLK_IO2                      ((PIN_PA22H_GCLK_IO2 << 16) | MUX_PA22H_GCLK_IO2)
+#define PORT_PA22H_GCLK_IO2                        (_UL_(1) << 22)
+
+#define PIN_PA17H_GCLK_IO3                         _L_(17)      /**< GCLK signal: IO3 on PA17 mux H*/
+#define MUX_PA17H_GCLK_IO3                         _L_(7)      
+#define PINMUX_PA17H_GCLK_IO3                      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
+#define PORT_PA17H_GCLK_IO3                        (_UL_(1) << 17)
+
+/* ========== PORT definition for OPAMP peripheral ========== */
+#define PIN_PA02B_OPAMP_OANEG0                     _L_(2)       /**< OPAMP signal: OANEG0 on PA02 mux B*/
+#define MUX_PA02B_OPAMP_OANEG0                     _L_(1)      
+#define PINMUX_PA02B_OPAMP_OANEG0                  ((PIN_PA02B_OPAMP_OANEG0 << 16) | MUX_PA02B_OPAMP_OANEG0)
+#define PORT_PA02B_OPAMP_OANEG0                    (_UL_(1) << 2)
+
+#define PIN_PA00B_OPAMP_OANEG1                     _L_(0)       /**< OPAMP signal: OANEG1 on PA00 mux B*/
+#define MUX_PA00B_OPAMP_OANEG1                     _L_(1)      
+#define PINMUX_PA00B_OPAMP_OANEG1                  ((PIN_PA00B_OPAMP_OANEG1 << 16) | MUX_PA00B_OPAMP_OANEG1)
+#define PORT_PA00B_OPAMP_OANEG1                    (_UL_(1) << 0)
+
+#define PIN_PA03B_OPAMP_OANEG2                     _L_(3)       /**< OPAMP signal: OANEG2 on PA03 mux B*/
+#define MUX_PA03B_OPAMP_OANEG2                     _L_(1)      
+#define PINMUX_PA03B_OPAMP_OANEG2                  ((PIN_PA03B_OPAMP_OANEG2 << 16) | MUX_PA03B_OPAMP_OANEG2)
+#define PORT_PA03B_OPAMP_OANEG2                    (_UL_(1) << 3)
+
+#define PIN_PA04B_OPAMP_OAOUT2                     _L_(4)       /**< OPAMP signal: OAOUT2 on PA04 mux B*/
+#define MUX_PA04B_OPAMP_OAOUT2                     _L_(1)      
+#define PINMUX_PA04B_OPAMP_OAOUT2                  ((PIN_PA04B_OPAMP_OAOUT2 << 16) | MUX_PA04B_OPAMP_OAOUT2)
+#define PORT_PA04B_OPAMP_OAOUT2                    (_UL_(1) << 4)
+
+#define PIN_PA01B_OPAMP_OAPOS1                     _L_(1)       /**< OPAMP signal: OAPOS1 on PA01 mux B*/
+#define MUX_PA01B_OPAMP_OAPOS1                     _L_(1)      
+#define PINMUX_PA01B_OPAMP_OAPOS1                  ((PIN_PA01B_OPAMP_OAPOS1 << 16) | MUX_PA01B_OPAMP_OAPOS1)
+#define PORT_PA01B_OPAMP_OAPOS1                    (_UL_(1) << 1)
+
+#define PIN_PA05B_OPAMP_OAPOS2                     _L_(5)       /**< OPAMP signal: OAPOS2 on PA05 mux B*/
+#define MUX_PA05B_OPAMP_OAPOS2                     _L_(1)      
+#define PINMUX_PA05B_OPAMP_OAPOS2                  ((PIN_PA05B_OPAMP_OAPOS2 << 16) | MUX_PA05B_OPAMP_OAPOS2)
+#define PORT_PA05B_OPAMP_OAPOS2                    (_UL_(1) << 5)
+
+/* ========== PORT definition for PTC peripheral ========== */
+#define PIN_PA00F_PTC_DRV0                         _L_(0)       /**< PTC signal: DRV0 on PA00 mux F*/
+#define MUX_PA00F_PTC_DRV0                         _L_(5)      
+#define PINMUX_PA00F_PTC_DRV0                      ((PIN_PA00F_PTC_DRV0 << 16) | MUX_PA00F_PTC_DRV0)
+#define PORT_PA00F_PTC_DRV0                        (_UL_(1) << 0)
+
+#define PIN_PA01F_PTC_DRV1                         _L_(1)       /**< PTC signal: DRV1 on PA01 mux F*/
+#define MUX_PA01F_PTC_DRV1                         _L_(5)      
+#define PINMUX_PA01F_PTC_DRV1                      ((PIN_PA01F_PTC_DRV1 << 16) | MUX_PA01F_PTC_DRV1)
+#define PORT_PA01F_PTC_DRV1                        (_UL_(1) << 1)
+
+#define PIN_PA02F_PTC_DRV2                         _L_(2)       /**< PTC signal: DRV2 on PA02 mux F*/
+#define MUX_PA02F_PTC_DRV2                         _L_(5)      
+#define PINMUX_PA02F_PTC_DRV2                      ((PIN_PA02F_PTC_DRV2 << 16) | MUX_PA02F_PTC_DRV2)
+#define PORT_PA02F_PTC_DRV2                        (_UL_(1) << 2)
+
+#define PIN_PA03F_PTC_DRV3                         _L_(3)       /**< PTC signal: DRV3 on PA03 mux F*/
+#define MUX_PA03F_PTC_DRV3                         _L_(5)      
+#define PINMUX_PA03F_PTC_DRV3                      ((PIN_PA03F_PTC_DRV3 << 16) | MUX_PA03F_PTC_DRV3)
+#define PORT_PA03F_PTC_DRV3                        (_UL_(1) << 3)
+
+#define PIN_PA05F_PTC_DRV4                         _L_(5)       /**< PTC signal: DRV4 on PA05 mux F*/
+#define MUX_PA05F_PTC_DRV4                         _L_(5)      
+#define PINMUX_PA05F_PTC_DRV4                      ((PIN_PA05F_PTC_DRV4 << 16) | MUX_PA05F_PTC_DRV4)
+#define PORT_PA05F_PTC_DRV4                        (_UL_(1) << 5)
+
+#define PIN_PA08F_PTC_DRV6                         _L_(8)       /**< PTC signal: DRV6 on PA08 mux F*/
+#define MUX_PA08F_PTC_DRV6                         _L_(5)      
+#define PINMUX_PA08F_PTC_DRV6                      ((PIN_PA08F_PTC_DRV6 << 16) | MUX_PA08F_PTC_DRV6)
+#define PORT_PA08F_PTC_DRV6                        (_UL_(1) << 8)
+
+#define PIN_PA14F_PTC_DRV10                        _L_(14)      /**< PTC signal: DRV10 on PA14 mux F*/
+#define MUX_PA14F_PTC_DRV10                        _L_(5)      
+#define PINMUX_PA14F_PTC_DRV10                     ((PIN_PA14F_PTC_DRV10 << 16) | MUX_PA14F_PTC_DRV10)
+#define PORT_PA14F_PTC_DRV10                       (_UL_(1) << 14)
+
+#define PIN_PA15F_PTC_DRV11                        _L_(15)      /**< PTC signal: DRV11 on PA15 mux F*/
+#define MUX_PA15F_PTC_DRV11                        _L_(5)      
+#define PINMUX_PA15F_PTC_DRV11                     ((PIN_PA15F_PTC_DRV11 << 16) | MUX_PA15F_PTC_DRV11)
+#define PORT_PA15F_PTC_DRV11                       (_UL_(1) << 15)
+
+#define PIN_PA16F_PTC_DRV12                        _L_(16)      /**< PTC signal: DRV12 on PA16 mux F*/
+#define MUX_PA16F_PTC_DRV12                        _L_(5)      
+#define PINMUX_PA16F_PTC_DRV12                     ((PIN_PA16F_PTC_DRV12 << 16) | MUX_PA16F_PTC_DRV12)
+#define PORT_PA16F_PTC_DRV12                       (_UL_(1) << 16)
+
+#define PIN_PA17F_PTC_DRV13                        _L_(17)      /**< PTC signal: DRV13 on PA17 mux F*/
+#define MUX_PA17F_PTC_DRV13                        _L_(5)      
+#define PINMUX_PA17F_PTC_DRV13                     ((PIN_PA17F_PTC_DRV13 << 16) | MUX_PA17F_PTC_DRV13)
+#define PORT_PA17F_PTC_DRV13                       (_UL_(1) << 17)
+
+#define PIN_PA18F_PTC_DRV14                        _L_(18)      /**< PTC signal: DRV14 on PA18 mux F*/
+#define MUX_PA18F_PTC_DRV14                        _L_(5)      
+#define PINMUX_PA18F_PTC_DRV14                     ((PIN_PA18F_PTC_DRV14 << 16) | MUX_PA18F_PTC_DRV14)
+#define PORT_PA18F_PTC_DRV14                       (_UL_(1) << 18)
+
+#define PIN_PA19F_PTC_DRV15                        _L_(19)      /**< PTC signal: DRV15 on PA19 mux F*/
+#define MUX_PA19F_PTC_DRV15                        _L_(5)      
+#define PINMUX_PA19F_PTC_DRV15                     ((PIN_PA19F_PTC_DRV15 << 16) | MUX_PA19F_PTC_DRV15)
+#define PORT_PA19F_PTC_DRV15                       (_UL_(1) << 19)
+
+#define PIN_PA22F_PTC_DRV16                        _L_(22)      /**< PTC signal: DRV16 on PA22 mux F*/
+#define MUX_PA22F_PTC_DRV16                        _L_(5)      
+#define PINMUX_PA22F_PTC_DRV16                     ((PIN_PA22F_PTC_DRV16 << 16) | MUX_PA22F_PTC_DRV16)
+#define PORT_PA22F_PTC_DRV16                       (_UL_(1) << 22)
+
+#define PIN_PA23F_PTC_DRV17                        _L_(23)      /**< PTC signal: DRV17 on PA23 mux F*/
+#define MUX_PA23F_PTC_DRV17                        _L_(5)      
+#define PINMUX_PA23F_PTC_DRV17                     ((PIN_PA23F_PTC_DRV17 << 16) | MUX_PA23F_PTC_DRV17)
+#define PORT_PA23F_PTC_DRV17                       (_UL_(1) << 23)
+
+#define PIN_PA30F_PTC_DRV18                        _L_(30)      /**< PTC signal: DRV18 on PA30 mux F*/
+#define MUX_PA30F_PTC_DRV18                        _L_(5)      
+#define PINMUX_PA30F_PTC_DRV18                     ((PIN_PA30F_PTC_DRV18 << 16) | MUX_PA30F_PTC_DRV18)
+#define PORT_PA30F_PTC_DRV18                       (_UL_(1) << 30)
+
+#define PIN_PA31F_PTC_DRV19                        _L_(31)      /**< PTC signal: DRV19 on PA31 mux F*/
+#define MUX_PA31F_PTC_DRV19                        _L_(5)      
+#define PINMUX_PA31F_PTC_DRV19                     ((PIN_PA31F_PTC_DRV19 << 16) | MUX_PA31F_PTC_DRV19)
+#define PORT_PA31F_PTC_DRV19                       (_UL_(1) << 31)
+
+#define PIN_PA03B_PTC_ECI0                         _L_(3)       /**< PTC signal: ECI0 on PA03 mux B*/
+#define MUX_PA03B_PTC_ECI0                         _L_(1)      
+#define PINMUX_PA03B_PTC_ECI0                      ((PIN_PA03B_PTC_ECI0 << 16) | MUX_PA03B_PTC_ECI0)
+#define PORT_PA03B_PTC_ECI0                        (_UL_(1) << 3)
+
+#define PIN_PA04B_PTC_ECI1                         _L_(4)       /**< PTC signal: ECI1 on PA04 mux B*/
+#define MUX_PA04B_PTC_ECI1                         _L_(1)      
+#define PINMUX_PA04B_PTC_ECI1                      ((PIN_PA04B_PTC_ECI1 << 16) | MUX_PA04B_PTC_ECI1)
+#define PORT_PA04B_PTC_ECI1                        (_UL_(1) << 4)
+
+#define PIN_PA05B_PTC_ECI2                         _L_(5)       /**< PTC signal: ECI2 on PA05 mux B*/
+#define MUX_PA05B_PTC_ECI2                         _L_(1)      
+#define PINMUX_PA05B_PTC_ECI2                      ((PIN_PA05B_PTC_ECI2 << 16) | MUX_PA05B_PTC_ECI2)
+#define PORT_PA05B_PTC_ECI2                        (_UL_(1) << 5)
+
+#define PIN_PA00B_PTC_X0                           _L_(0)       /**< PTC signal: X0 on PA00 mux B*/
+#define MUX_PA00B_PTC_X0                           _L_(1)      
+#define PINMUX_PA00B_PTC_X0                        ((PIN_PA00B_PTC_X0 << 16) | MUX_PA00B_PTC_X0)
+#define PORT_PA00B_PTC_X0                          (_UL_(1) << 0)
+
+#define PIN_PA00B_PTC_Y0                           _L_(0)       /**< PTC signal: Y0 on PA00 mux B*/
+#define MUX_PA00B_PTC_Y0                           _L_(1)      
+#define PINMUX_PA00B_PTC_Y0                        ((PIN_PA00B_PTC_Y0 << 16) | MUX_PA00B_PTC_Y0)
+#define PORT_PA00B_PTC_Y0                          (_UL_(1) << 0)
+
+#define PIN_PA01B_PTC_X1                           _L_(1)       /**< PTC signal: X1 on PA01 mux B*/
+#define MUX_PA01B_PTC_X1                           _L_(1)      
+#define PINMUX_PA01B_PTC_X1                        ((PIN_PA01B_PTC_X1 << 16) | MUX_PA01B_PTC_X1)
+#define PORT_PA01B_PTC_X1                          (_UL_(1) << 1)
+
+#define PIN_PA01B_PTC_Y1                           _L_(1)       /**< PTC signal: Y1 on PA01 mux B*/
+#define MUX_PA01B_PTC_Y1                           _L_(1)      
+#define PINMUX_PA01B_PTC_Y1                        ((PIN_PA01B_PTC_Y1 << 16) | MUX_PA01B_PTC_Y1)
+#define PORT_PA01B_PTC_Y1                          (_UL_(1) << 1)
+
+#define PIN_PA02B_PTC_X2                           _L_(2)       /**< PTC signal: X2 on PA02 mux B*/
+#define MUX_PA02B_PTC_X2                           _L_(1)      
+#define PINMUX_PA02B_PTC_X2                        ((PIN_PA02B_PTC_X2 << 16) | MUX_PA02B_PTC_X2)
+#define PORT_PA02B_PTC_X2                          (_UL_(1) << 2)
+
+#define PIN_PA02B_PTC_Y2                           _L_(2)       /**< PTC signal: Y2 on PA02 mux B*/
+#define MUX_PA02B_PTC_Y2                           _L_(1)      
+#define PINMUX_PA02B_PTC_Y2                        ((PIN_PA02B_PTC_Y2 << 16) | MUX_PA02B_PTC_Y2)
+#define PORT_PA02B_PTC_Y2                          (_UL_(1) << 2)
+
+#define PIN_PA03B_PTC_X3                           _L_(3)       /**< PTC signal: X3 on PA03 mux B*/
+#define MUX_PA03B_PTC_X3                           _L_(1)      
+#define PINMUX_PA03B_PTC_X3                        ((PIN_PA03B_PTC_X3 << 16) | MUX_PA03B_PTC_X3)
+#define PORT_PA03B_PTC_X3                          (_UL_(1) << 3)
+
+#define PIN_PA03B_PTC_Y3                           _L_(3)       /**< PTC signal: Y3 on PA03 mux B*/
+#define MUX_PA03B_PTC_Y3                           _L_(1)      
+#define PINMUX_PA03B_PTC_Y3                        ((PIN_PA03B_PTC_Y3 << 16) | MUX_PA03B_PTC_Y3)
+#define PORT_PA03B_PTC_Y3                          (_UL_(1) << 3)
+
+#define PIN_PA05B_PTC_X4                           _L_(5)       /**< PTC signal: X4 on PA05 mux B*/
+#define MUX_PA05B_PTC_X4                           _L_(1)      
+#define PINMUX_PA05B_PTC_X4                        ((PIN_PA05B_PTC_X4 << 16) | MUX_PA05B_PTC_X4)
+#define PORT_PA05B_PTC_X4                          (_UL_(1) << 5)
+
+#define PIN_PA05B_PTC_Y4                           _L_(5)       /**< PTC signal: Y4 on PA05 mux B*/
+#define MUX_PA05B_PTC_Y4                           _L_(1)      
+#define PINMUX_PA05B_PTC_Y4                        ((PIN_PA05B_PTC_Y4 << 16) | MUX_PA05B_PTC_Y4)
+#define PORT_PA05B_PTC_Y4                          (_UL_(1) << 5)
+
+#define PIN_PA08B_PTC_X6                           _L_(8)       /**< PTC signal: X6 on PA08 mux B*/
+#define MUX_PA08B_PTC_X6                           _L_(1)      
+#define PINMUX_PA08B_PTC_X6                        ((PIN_PA08B_PTC_X6 << 16) | MUX_PA08B_PTC_X6)
+#define PORT_PA08B_PTC_X6                          (_UL_(1) << 8)
+
+#define PIN_PA08B_PTC_Y6                           _L_(8)       /**< PTC signal: Y6 on PA08 mux B*/
+#define MUX_PA08B_PTC_Y6                           _L_(1)      
+#define PINMUX_PA08B_PTC_Y6                        ((PIN_PA08B_PTC_Y6 << 16) | MUX_PA08B_PTC_Y6)
+#define PORT_PA08B_PTC_Y6                          (_UL_(1) << 8)
+
+#define PIN_PA14B_PTC_X10                          _L_(14)      /**< PTC signal: X10 on PA14 mux B*/
+#define MUX_PA14B_PTC_X10                          _L_(1)      
+#define PINMUX_PA14B_PTC_X10                       ((PIN_PA14B_PTC_X10 << 16) | MUX_PA14B_PTC_X10)
+#define PORT_PA14B_PTC_X10                         (_UL_(1) << 14)
+
+#define PIN_PA14B_PTC_Y10                          _L_(14)      /**< PTC signal: Y10 on PA14 mux B*/
+#define MUX_PA14B_PTC_Y10                          _L_(1)      
+#define PINMUX_PA14B_PTC_Y10                       ((PIN_PA14B_PTC_Y10 << 16) | MUX_PA14B_PTC_Y10)
+#define PORT_PA14B_PTC_Y10                         (_UL_(1) << 14)
+
+#define PIN_PA15B_PTC_X11                          _L_(15)      /**< PTC signal: X11 on PA15 mux B*/
+#define MUX_PA15B_PTC_X11                          _L_(1)      
+#define PINMUX_PA15B_PTC_X11                       ((PIN_PA15B_PTC_X11 << 16) | MUX_PA15B_PTC_X11)
+#define PORT_PA15B_PTC_X11                         (_UL_(1) << 15)
+
+#define PIN_PA15B_PTC_Y11                          _L_(15)      /**< PTC signal: Y11 on PA15 mux B*/
+#define MUX_PA15B_PTC_Y11                          _L_(1)      
+#define PINMUX_PA15B_PTC_Y11                       ((PIN_PA15B_PTC_Y11 << 16) | MUX_PA15B_PTC_Y11)
+#define PORT_PA15B_PTC_Y11                         (_UL_(1) << 15)
+
+#define PIN_PA16B_PTC_X12                          _L_(16)      /**< PTC signal: X12 on PA16 mux B*/
+#define MUX_PA16B_PTC_X12                          _L_(1)      
+#define PINMUX_PA16B_PTC_X12                       ((PIN_PA16B_PTC_X12 << 16) | MUX_PA16B_PTC_X12)
+#define PORT_PA16B_PTC_X12                         (_UL_(1) << 16)
+
+#define PIN_PA16B_PTC_Y12                          _L_(16)      /**< PTC signal: Y12 on PA16 mux B*/
+#define MUX_PA16B_PTC_Y12                          _L_(1)      
+#define PINMUX_PA16B_PTC_Y12                       ((PIN_PA16B_PTC_Y12 << 16) | MUX_PA16B_PTC_Y12)
+#define PORT_PA16B_PTC_Y12                         (_UL_(1) << 16)
+
+#define PIN_PA17B_PTC_X13                          _L_(17)      /**< PTC signal: X13 on PA17 mux B*/
+#define MUX_PA17B_PTC_X13                          _L_(1)      
+#define PINMUX_PA17B_PTC_X13                       ((PIN_PA17B_PTC_X13 << 16) | MUX_PA17B_PTC_X13)
+#define PORT_PA17B_PTC_X13                         (_UL_(1) << 17)
+
+#define PIN_PA17B_PTC_Y13                          _L_(17)      /**< PTC signal: Y13 on PA17 mux B*/
+#define MUX_PA17B_PTC_Y13                          _L_(1)      
+#define PINMUX_PA17B_PTC_Y13                       ((PIN_PA17B_PTC_Y13 << 16) | MUX_PA17B_PTC_Y13)
+#define PORT_PA17B_PTC_Y13                         (_UL_(1) << 17)
+
+#define PIN_PA18B_PTC_X14                          _L_(18)      /**< PTC signal: X14 on PA18 mux B*/
+#define MUX_PA18B_PTC_X14                          _L_(1)      
+#define PINMUX_PA18B_PTC_X14                       ((PIN_PA18B_PTC_X14 << 16) | MUX_PA18B_PTC_X14)
+#define PORT_PA18B_PTC_X14                         (_UL_(1) << 18)
+
+#define PIN_PA18B_PTC_Y14                          _L_(18)      /**< PTC signal: Y14 on PA18 mux B*/
+#define MUX_PA18B_PTC_Y14                          _L_(1)      
+#define PINMUX_PA18B_PTC_Y14                       ((PIN_PA18B_PTC_Y14 << 16) | MUX_PA18B_PTC_Y14)
+#define PORT_PA18B_PTC_Y14                         (_UL_(1) << 18)
+
+#define PIN_PA19B_PTC_X15                          _L_(19)      /**< PTC signal: X15 on PA19 mux B*/
+#define MUX_PA19B_PTC_X15                          _L_(1)      
+#define PINMUX_PA19B_PTC_X15                       ((PIN_PA19B_PTC_X15 << 16) | MUX_PA19B_PTC_X15)
+#define PORT_PA19B_PTC_X15                         (_UL_(1) << 19)
+
+#define PIN_PA19B_PTC_Y15                          _L_(19)      /**< PTC signal: Y15 on PA19 mux B*/
+#define MUX_PA19B_PTC_Y15                          _L_(1)      
+#define PINMUX_PA19B_PTC_Y15                       ((PIN_PA19B_PTC_Y15 << 16) | MUX_PA19B_PTC_Y15)
+#define PORT_PA19B_PTC_Y15                         (_UL_(1) << 19)
+
+#define PIN_PA22B_PTC_X16                          _L_(22)      /**< PTC signal: X16 on PA22 mux B*/
+#define MUX_PA22B_PTC_X16                          _L_(1)      
+#define PINMUX_PA22B_PTC_X16                       ((PIN_PA22B_PTC_X16 << 16) | MUX_PA22B_PTC_X16)
+#define PORT_PA22B_PTC_X16                         (_UL_(1) << 22)
+
+#define PIN_PA22B_PTC_Y16                          _L_(22)      /**< PTC signal: Y16 on PA22 mux B*/
+#define MUX_PA22B_PTC_Y16                          _L_(1)      
+#define PINMUX_PA22B_PTC_Y16                       ((PIN_PA22B_PTC_Y16 << 16) | MUX_PA22B_PTC_Y16)
+#define PORT_PA22B_PTC_Y16                         (_UL_(1) << 22)
+
+#define PIN_PA23B_PTC_X17                          _L_(23)      /**< PTC signal: X17 on PA23 mux B*/
+#define MUX_PA23B_PTC_X17                          _L_(1)      
+#define PINMUX_PA23B_PTC_X17                       ((PIN_PA23B_PTC_X17 << 16) | MUX_PA23B_PTC_X17)
+#define PORT_PA23B_PTC_X17                         (_UL_(1) << 23)
+
+#define PIN_PA23B_PTC_Y17                          _L_(23)      /**< PTC signal: Y17 on PA23 mux B*/
+#define MUX_PA23B_PTC_Y17                          _L_(1)      
+#define PINMUX_PA23B_PTC_Y17                       ((PIN_PA23B_PTC_Y17 << 16) | MUX_PA23B_PTC_Y17)
+#define PORT_PA23B_PTC_Y17                         (_UL_(1) << 23)
+
+#define PIN_PA30B_PTC_X18                          _L_(30)      /**< PTC signal: X18 on PA30 mux B*/
+#define MUX_PA30B_PTC_X18                          _L_(1)      
+#define PINMUX_PA30B_PTC_X18                       ((PIN_PA30B_PTC_X18 << 16) | MUX_PA30B_PTC_X18)
+#define PORT_PA30B_PTC_X18                         (_UL_(1) << 30)
+
+#define PIN_PA30B_PTC_Y18                          _L_(30)      /**< PTC signal: Y18 on PA30 mux B*/
+#define MUX_PA30B_PTC_Y18                          _L_(1)      
+#define PINMUX_PA30B_PTC_Y18                       ((PIN_PA30B_PTC_Y18 << 16) | MUX_PA30B_PTC_Y18)
+#define PORT_PA30B_PTC_Y18                         (_UL_(1) << 30)
+
+#define PIN_PA31B_PTC_X19                          _L_(31)      /**< PTC signal: X19 on PA31 mux B*/
+#define MUX_PA31B_PTC_X19                          _L_(1)      
+#define PINMUX_PA31B_PTC_X19                       ((PIN_PA31B_PTC_X19 << 16) | MUX_PA31B_PTC_X19)
+#define PORT_PA31B_PTC_X19                         (_UL_(1) << 31)
+
+#define PIN_PA31B_PTC_Y19                          _L_(31)      /**< PTC signal: Y19 on PA31 mux B*/
+#define MUX_PA31B_PTC_Y19                          _L_(1)      
+#define PINMUX_PA31B_PTC_Y19                       ((PIN_PA31B_PTC_Y19 << 16) | MUX_PA31B_PTC_Y19)
+#define PORT_PA31B_PTC_Y19                         (_UL_(1) << 31)
+
+/* ========== PORT definition for RTC peripheral ========== */
+#define PIN_PA08G_RTC_IN0                          _L_(8)       /**< RTC signal: IN0 on PA08 mux G*/
+#define MUX_PA08G_RTC_IN0                          _L_(6)      
+#define PINMUX_PA08G_RTC_IN0                       ((PIN_PA08G_RTC_IN0 << 16) | MUX_PA08G_RTC_IN0)
+#define PORT_PA08G_RTC_IN0                         (_UL_(1) << 8)
+
+#define PIN_PA16G_RTC_IN2                          _L_(16)      /**< RTC signal: IN2 on PA16 mux G*/
+#define MUX_PA16G_RTC_IN2                          _L_(6)      
+#define PINMUX_PA16G_RTC_IN2                       ((PIN_PA16G_RTC_IN2 << 16) | MUX_PA16G_RTC_IN2)
+#define PORT_PA16G_RTC_IN2                         (_UL_(1) << 16)
+
+#define PIN_PA17G_RTC_IN3                          _L_(17)      /**< RTC signal: IN3 on PA17 mux G*/
+#define MUX_PA17G_RTC_IN3                          _L_(6)      
+#define PINMUX_PA17G_RTC_IN3                       ((PIN_PA17G_RTC_IN3 << 16) | MUX_PA17G_RTC_IN3)
+#define PORT_PA17G_RTC_IN3                         (_UL_(1) << 17)
+
+#define PIN_PA18G_RTC_OUT0                         _L_(18)      /**< RTC signal: OUT0 on PA18 mux G*/
+#define MUX_PA18G_RTC_OUT0                         _L_(6)      
+#define PINMUX_PA18G_RTC_OUT0                      ((PIN_PA18G_RTC_OUT0 << 16) | MUX_PA18G_RTC_OUT0)
+#define PORT_PA18G_RTC_OUT0                        (_UL_(1) << 18)
+
+#define PIN_PA19G_RTC_OUT1                         _L_(19)      /**< RTC signal: OUT1 on PA19 mux G*/
+#define MUX_PA19G_RTC_OUT1                         _L_(6)      
+#define PINMUX_PA19G_RTC_OUT1                      ((PIN_PA19G_RTC_OUT1 << 16) | MUX_PA19G_RTC_OUT1)
+#define PORT_PA19G_RTC_OUT1                        (_UL_(1) << 19)
+
+#define PIN_PA22G_RTC_OUT2                         _L_(22)      /**< RTC signal: OUT2 on PA22 mux G*/
+#define MUX_PA22G_RTC_OUT2                         _L_(6)      
+#define PINMUX_PA22G_RTC_OUT2                      ((PIN_PA22G_RTC_OUT2 << 16) | MUX_PA22G_RTC_OUT2)
+#define PORT_PA22G_RTC_OUT2                        (_UL_(1) << 22)
+
+#define PIN_PA23G_RTC_OUT3                         _L_(23)      /**< RTC signal: OUT3 on PA23 mux G*/
+#define MUX_PA23G_RTC_OUT3                         _L_(6)      
+#define PINMUX_PA23G_RTC_OUT3                      ((PIN_PA23G_RTC_OUT3 << 16) | MUX_PA23G_RTC_OUT3)
+#define PORT_PA23G_RTC_OUT3                        (_UL_(1) << 23)
+
+/* ========== PORT definition for SERCOM0 peripheral ========== */
+#define PIN_PA04D_SERCOM0_PAD0                     _L_(4)       /**< SERCOM0 signal: PAD0 on PA04 mux D*/
+#define MUX_PA04D_SERCOM0_PAD0                     _L_(3)      
+#define PINMUX_PA04D_SERCOM0_PAD0                  ((PIN_PA04D_SERCOM0_PAD0 << 16) | MUX_PA04D_SERCOM0_PAD0)
+#define PORT_PA04D_SERCOM0_PAD0                    (_UL_(1) << 4)
+
+#define PIN_PA16D_SERCOM0_PAD0                     _L_(16)      /**< SERCOM0 signal: PAD0 on PA16 mux D*/
+#define MUX_PA16D_SERCOM0_PAD0                     _L_(3)      
+#define PINMUX_PA16D_SERCOM0_PAD0                  ((PIN_PA16D_SERCOM0_PAD0 << 16) | MUX_PA16D_SERCOM0_PAD0)
+#define PORT_PA16D_SERCOM0_PAD0                    (_UL_(1) << 16)
+
+#define PIN_PA22C_SERCOM0_PAD0                     _L_(22)      /**< SERCOM0 signal: PAD0 on PA22 mux C*/
+#define MUX_PA22C_SERCOM0_PAD0                     _L_(2)      
+#define PINMUX_PA22C_SERCOM0_PAD0                  ((PIN_PA22C_SERCOM0_PAD0 << 16) | MUX_PA22C_SERCOM0_PAD0)
+#define PORT_PA22C_SERCOM0_PAD0                    (_UL_(1) << 22)
+
+#define PIN_PA05D_SERCOM0_PAD1                     _L_(5)       /**< SERCOM0 signal: PAD1 on PA05 mux D*/
+#define MUX_PA05D_SERCOM0_PAD1                     _L_(3)      
+#define PINMUX_PA05D_SERCOM0_PAD1                  ((PIN_PA05D_SERCOM0_PAD1 << 16) | MUX_PA05D_SERCOM0_PAD1)
+#define PORT_PA05D_SERCOM0_PAD1                    (_UL_(1) << 5)
+
+#define PIN_PA17D_SERCOM0_PAD1                     _L_(17)      /**< SERCOM0 signal: PAD1 on PA17 mux D*/
+#define MUX_PA17D_SERCOM0_PAD1                     _L_(3)      
+#define PINMUX_PA17D_SERCOM0_PAD1                  ((PIN_PA17D_SERCOM0_PAD1 << 16) | MUX_PA17D_SERCOM0_PAD1)
+#define PORT_PA17D_SERCOM0_PAD1                    (_UL_(1) << 17)
+
+#define PIN_PA23C_SERCOM0_PAD1                     _L_(23)      /**< SERCOM0 signal: PAD1 on PA23 mux C*/
+#define MUX_PA23C_SERCOM0_PAD1                     _L_(2)      
+#define PINMUX_PA23C_SERCOM0_PAD1                  ((PIN_PA23C_SERCOM0_PAD1 << 16) | MUX_PA23C_SERCOM0_PAD1)
+#define PORT_PA23C_SERCOM0_PAD1                    (_UL_(1) << 23)
+
+#define PIN_PA14D_SERCOM0_PAD2                     _L_(14)      /**< SERCOM0 signal: PAD2 on PA14 mux D*/
+#define MUX_PA14D_SERCOM0_PAD2                     _L_(3)      
+#define PINMUX_PA14D_SERCOM0_PAD2                  ((PIN_PA14D_SERCOM0_PAD2 << 16) | MUX_PA14D_SERCOM0_PAD2)
+#define PORT_PA14D_SERCOM0_PAD2                    (_UL_(1) << 14)
+
+#define PIN_PA18D_SERCOM0_PAD2                     _L_(18)      /**< SERCOM0 signal: PAD2 on PA18 mux D*/
+#define MUX_PA18D_SERCOM0_PAD2                     _L_(3)      
+#define PINMUX_PA18D_SERCOM0_PAD2                  ((PIN_PA18D_SERCOM0_PAD2 << 16) | MUX_PA18D_SERCOM0_PAD2)
+#define PORT_PA18D_SERCOM0_PAD2                    (_UL_(1) << 18)
+
+#define PIN_PA02D_SERCOM0_PAD2                     _L_(2)       /**< SERCOM0 signal: PAD2 on PA02 mux D*/
+#define MUX_PA02D_SERCOM0_PAD2                     _L_(3)      
+#define PINMUX_PA02D_SERCOM0_PAD2                  ((PIN_PA02D_SERCOM0_PAD2 << 16) | MUX_PA02D_SERCOM0_PAD2)
+#define PORT_PA02D_SERCOM0_PAD2                    (_UL_(1) << 2)
+
+#define PIN_PA15D_SERCOM0_PAD3                     _L_(15)      /**< SERCOM0 signal: PAD3 on PA15 mux D*/
+#define MUX_PA15D_SERCOM0_PAD3                     _L_(3)      
+#define PINMUX_PA15D_SERCOM0_PAD3                  ((PIN_PA15D_SERCOM0_PAD3 << 16) | MUX_PA15D_SERCOM0_PAD3)
+#define PORT_PA15D_SERCOM0_PAD3                    (_UL_(1) << 15)
+
+#define PIN_PA19D_SERCOM0_PAD3                     _L_(19)      /**< SERCOM0 signal: PAD3 on PA19 mux D*/
+#define MUX_PA19D_SERCOM0_PAD3                     _L_(3)      
+#define PINMUX_PA19D_SERCOM0_PAD3                  ((PIN_PA19D_SERCOM0_PAD3 << 16) | MUX_PA19D_SERCOM0_PAD3)
+#define PORT_PA19D_SERCOM0_PAD3                    (_UL_(1) << 19)
+
+#define PIN_PA03D_SERCOM0_PAD3                     _L_(3)       /**< SERCOM0 signal: PAD3 on PA03 mux D*/
+#define MUX_PA03D_SERCOM0_PAD3                     _L_(3)      
+#define PINMUX_PA03D_SERCOM0_PAD3                  ((PIN_PA03D_SERCOM0_PAD3 << 16) | MUX_PA03D_SERCOM0_PAD3)
+#define PORT_PA03D_SERCOM0_PAD3                    (_UL_(1) << 3)
+
+/* ========== PORT definition for SERCOM1 peripheral ========== */
+#define PIN_PA16C_SERCOM1_PAD0                     _L_(16)      /**< SERCOM1 signal: PAD0 on PA16 mux C*/
+#define MUX_PA16C_SERCOM1_PAD0                     _L_(2)      
+#define PINMUX_PA16C_SERCOM1_PAD0                  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
+#define PORT_PA16C_SERCOM1_PAD0                    (_UL_(1) << 16)
+
+#define PIN_PA08C_SERCOM1_PAD0                     _L_(8)       /**< SERCOM1 signal: PAD0 on PA08 mux C*/
+#define MUX_PA08C_SERCOM1_PAD0                     _L_(2)      
+#define PINMUX_PA08C_SERCOM1_PAD0                  ((PIN_PA08C_SERCOM1_PAD0 << 16) | MUX_PA08C_SERCOM1_PAD0)
+#define PORT_PA08C_SERCOM1_PAD0                    (_UL_(1) << 8)
+
+#define PIN_PA00D_SERCOM1_PAD0                     _L_(0)       /**< SERCOM1 signal: PAD0 on PA00 mux D*/
+#define MUX_PA00D_SERCOM1_PAD0                     _L_(3)      
+#define PINMUX_PA00D_SERCOM1_PAD0                  ((PIN_PA00D_SERCOM1_PAD0 << 16) | MUX_PA00D_SERCOM1_PAD0)
+#define PORT_PA00D_SERCOM1_PAD0                    (_UL_(1) << 0)
+
+#define PIN_PA17C_SERCOM1_PAD1                     _L_(17)      /**< SERCOM1 signal: PAD1 on PA17 mux C*/
+#define MUX_PA17C_SERCOM1_PAD1                     _L_(2)      
+#define PINMUX_PA17C_SERCOM1_PAD1                  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
+#define PORT_PA17C_SERCOM1_PAD1                    (_UL_(1) << 17)
+
+#define PIN_PA01D_SERCOM1_PAD1                     _L_(1)       /**< SERCOM1 signal: PAD1 on PA01 mux D*/
+#define MUX_PA01D_SERCOM1_PAD1                     _L_(3)      
+#define PINMUX_PA01D_SERCOM1_PAD1                  ((PIN_PA01D_SERCOM1_PAD1 << 16) | MUX_PA01D_SERCOM1_PAD1)
+#define PORT_PA01D_SERCOM1_PAD1                    (_UL_(1) << 1)
+
+#define PIN_PA18C_SERCOM1_PAD2                     _L_(18)      /**< SERCOM1 signal: PAD2 on PA18 mux C*/
+#define MUX_PA18C_SERCOM1_PAD2                     _L_(2)      
+#define PINMUX_PA18C_SERCOM1_PAD2                  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
+#define PORT_PA18C_SERCOM1_PAD2                    (_UL_(1) << 18)
+
+#define PIN_PA30D_SERCOM1_PAD2                     _L_(30)      /**< SERCOM1 signal: PAD2 on PA30 mux D*/
+#define MUX_PA30D_SERCOM1_PAD2                     _L_(3)      
+#define PINMUX_PA30D_SERCOM1_PAD2                  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
+#define PORT_PA30D_SERCOM1_PAD2                    (_UL_(1) << 30)
+
+#define PIN_PA19C_SERCOM1_PAD3                     _L_(19)      /**< SERCOM1 signal: PAD3 on PA19 mux C*/
+#define MUX_PA19C_SERCOM1_PAD3                     _L_(2)      
+#define PINMUX_PA19C_SERCOM1_PAD3                  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
+#define PORT_PA19C_SERCOM1_PAD3                    (_UL_(1) << 19)
+
+#define PIN_PA31D_SERCOM1_PAD3                     _L_(31)      /**< SERCOM1 signal: PAD3 on PA31 mux D*/
+#define MUX_PA31D_SERCOM1_PAD3                     _L_(3)      
+#define PINMUX_PA31D_SERCOM1_PAD3                  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
+#define PORT_PA31D_SERCOM1_PAD3                    (_UL_(1) << 31)
+
+/* ========== PORT definition for TC0 peripheral ========== */
+#define PIN_PA04E_TC0_WO0                          _L_(4)       /**< TC0 signal: WO0 on PA04 mux E*/
+#define MUX_PA04E_TC0_WO0                          _L_(4)      
+#define PINMUX_PA04E_TC0_WO0                       ((PIN_PA04E_TC0_WO0 << 16) | MUX_PA04E_TC0_WO0)
+#define PORT_PA04E_TC0_WO0                         (_UL_(1) << 4)
+
+#define PIN_PA14E_TC0_WO0                          _L_(14)      /**< TC0 signal: WO0 on PA14 mux E*/
+#define MUX_PA14E_TC0_WO0                          _L_(4)      
+#define PINMUX_PA14E_TC0_WO0                       ((PIN_PA14E_TC0_WO0 << 16) | MUX_PA14E_TC0_WO0)
+#define PORT_PA14E_TC0_WO0                         (_UL_(1) << 14)
+
+#define PIN_PA22E_TC0_WO0                          _L_(22)      /**< TC0 signal: WO0 on PA22 mux E*/
+#define MUX_PA22E_TC0_WO0                          _L_(4)      
+#define PINMUX_PA22E_TC0_WO0                       ((PIN_PA22E_TC0_WO0 << 16) | MUX_PA22E_TC0_WO0)
+#define PORT_PA22E_TC0_WO0                         (_UL_(1) << 22)
+
+#define PIN_PA05E_TC0_WO1                          _L_(5)       /**< TC0 signal: WO1 on PA05 mux E*/
+#define MUX_PA05E_TC0_WO1                          _L_(4)      
+#define PINMUX_PA05E_TC0_WO1                       ((PIN_PA05E_TC0_WO1 << 16) | MUX_PA05E_TC0_WO1)
+#define PORT_PA05E_TC0_WO1                         (_UL_(1) << 5)
+
+#define PIN_PA15E_TC0_WO1                          _L_(15)      /**< TC0 signal: WO1 on PA15 mux E*/
+#define MUX_PA15E_TC0_WO1                          _L_(4)      
+#define PINMUX_PA15E_TC0_WO1                       ((PIN_PA15E_TC0_WO1 << 16) | MUX_PA15E_TC0_WO1)
+#define PORT_PA15E_TC0_WO1                         (_UL_(1) << 15)
+
+#define PIN_PA23E_TC0_WO1                          _L_(23)      /**< TC0 signal: WO1 on PA23 mux E*/
+#define MUX_PA23E_TC0_WO1                          _L_(4)      
+#define PINMUX_PA23E_TC0_WO1                       ((PIN_PA23E_TC0_WO1 << 16) | MUX_PA23E_TC0_WO1)
+#define PORT_PA23E_TC0_WO1                         (_UL_(1) << 23)
+
+/* ========== PORT definition for TC1 peripheral ========== */
+#define PIN_PA30E_TC1_WO0                          _L_(30)      /**< TC1 signal: WO0 on PA30 mux E*/
+#define MUX_PA30E_TC1_WO0                          _L_(4)      
+#define PINMUX_PA30E_TC1_WO0                       ((PIN_PA30E_TC1_WO0 << 16) | MUX_PA30E_TC1_WO0)
+#define PORT_PA30E_TC1_WO0                         (_UL_(1) << 30)
+
+#define PIN_PA31E_TC1_WO1                          _L_(31)      /**< TC1 signal: WO1 on PA31 mux E*/
+#define MUX_PA31E_TC1_WO1                          _L_(4)      
+#define PINMUX_PA31E_TC1_WO1                       ((PIN_PA31E_TC1_WO1 << 16) | MUX_PA31E_TC1_WO1)
+#define PORT_PA31E_TC1_WO1                         (_UL_(1) << 31)
+
+/* ========== PORT definition for TC2 peripheral ========== */
+#define PIN_PA00E_TC2_WO0                          _L_(0)       /**< TC2 signal: WO0 on PA00 mux E*/
+#define MUX_PA00E_TC2_WO0                          _L_(4)      
+#define PINMUX_PA00E_TC2_WO0                       ((PIN_PA00E_TC2_WO0 << 16) | MUX_PA00E_TC2_WO0)
+#define PORT_PA00E_TC2_WO0                         (_UL_(1) << 0)
+
+#define PIN_PA18E_TC2_WO0                          _L_(18)      /**< TC2 signal: WO0 on PA18 mux E*/
+#define MUX_PA18E_TC2_WO0                          _L_(4)      
+#define PINMUX_PA18E_TC2_WO0                       ((PIN_PA18E_TC2_WO0 << 16) | MUX_PA18E_TC2_WO0)
+#define PORT_PA18E_TC2_WO0                         (_UL_(1) << 18)
+
+#define PIN_PA01E_TC2_WO1                          _L_(1)       /**< TC2 signal: WO1 on PA01 mux E*/
+#define MUX_PA01E_TC2_WO1                          _L_(4)      
+#define PINMUX_PA01E_TC2_WO1                       ((PIN_PA01E_TC2_WO1 << 16) | MUX_PA01E_TC2_WO1)
+#define PORT_PA01E_TC2_WO1                         (_UL_(1) << 1)
+
+#define PIN_PA19E_TC2_WO1                          _L_(19)      /**< TC2 signal: WO1 on PA19 mux E*/
+#define MUX_PA19E_TC2_WO1                          _L_(4)      
+#define PINMUX_PA19E_TC2_WO1                       ((PIN_PA19E_TC2_WO1 << 16) | MUX_PA19E_TC2_WO1)
+#define PORT_PA19E_TC2_WO1                         (_UL_(1) << 19)
+
+
+#endif /* _SAML11D14A_PIO_H_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/pio/saml11d15a.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/pio/saml11d15a.h
@@ -1,0 +1,834 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAML11D15A
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11D15A_PIO_H_
+#define _SAML11D15A_PIO_H_
+
+/* ========== Peripheral I/O pin numbers ========== */
+#define PIN_PA00                    (  0)  /**< Pin Number for PA00 */
+#define PIN_PA01                    (  1)  /**< Pin Number for PA01 */
+#define PIN_PA02                    (  2)  /**< Pin Number for PA02 */
+#define PIN_PA03                    (  3)  /**< Pin Number for PA03 */
+#define PIN_PA04                    (  4)  /**< Pin Number for PA04 */
+#define PIN_PA05                    (  5)  /**< Pin Number for PA05 */
+#define PIN_PA08                    (  8)  /**< Pin Number for PA08 */
+#define PIN_PA14                    ( 14)  /**< Pin Number for PA14 */
+#define PIN_PA15                    ( 15)  /**< Pin Number for PA15 */
+#define PIN_PA16                    ( 16)  /**< Pin Number for PA16 */
+#define PIN_PA17                    ( 17)  /**< Pin Number for PA17 */
+#define PIN_PA18                    ( 18)  /**< Pin Number for PA18 */
+#define PIN_PA19                    ( 19)  /**< Pin Number for PA19 */
+#define PIN_PA22                    ( 22)  /**< Pin Number for PA22 */
+#define PIN_PA23                    ( 23)  /**< Pin Number for PA23 */
+#define PIN_PA30                    ( 30)  /**< Pin Number for PA30 */
+#define PIN_PA31                    ( 31)  /**< Pin Number for PA31 */
+
+
+/* ========== Peripheral I/O masks ========== */
+#define PORT_PA00                   (_U_(1) << 0) /**< PORT Mask for PA00 */
+#define PORT_PA01                   (_U_(1) << 1) /**< PORT Mask for PA01 */
+#define PORT_PA02                   (_U_(1) << 2) /**< PORT Mask for PA02 */
+#define PORT_PA03                   (_U_(1) << 3) /**< PORT Mask for PA03 */
+#define PORT_PA04                   (_U_(1) << 4) /**< PORT Mask for PA04 */
+#define PORT_PA05                   (_U_(1) << 5) /**< PORT Mask for PA05 */
+#define PORT_PA08                   (_U_(1) << 8) /**< PORT Mask for PA08 */
+#define PORT_PA14                   (_U_(1) << 14) /**< PORT Mask for PA14 */
+#define PORT_PA15                   (_U_(1) << 15) /**< PORT Mask for PA15 */
+#define PORT_PA16                   (_U_(1) << 16) /**< PORT Mask for PA16 */
+#define PORT_PA17                   (_U_(1) << 17) /**< PORT Mask for PA17 */
+#define PORT_PA18                   (_U_(1) << 18) /**< PORT Mask for PA18 */
+#define PORT_PA19                   (_U_(1) << 19) /**< PORT Mask for PA19 */
+#define PORT_PA22                   (_U_(1) << 22) /**< PORT Mask for PA22 */
+#define PORT_PA23                   (_U_(1) << 23) /**< PORT Mask for PA23 */
+#define PORT_PA30                   (_U_(1) << 30) /**< PORT Mask for PA30 */
+#define PORT_PA31                   (_U_(1) << 31) /**< PORT Mask for PA31 */
+
+
+/* ========== Peripheral I/O indexes ========== */
+#define PORT_PA00_IDX               (  0)  /**< PORT Index Number for PA00 */
+#define PORT_PA01_IDX               (  1)  /**< PORT Index Number for PA01 */
+#define PORT_PA02_IDX               (  2)  /**< PORT Index Number for PA02 */
+#define PORT_PA03_IDX               (  3)  /**< PORT Index Number for PA03 */
+#define PORT_PA04_IDX               (  4)  /**< PORT Index Number for PA04 */
+#define PORT_PA05_IDX               (  5)  /**< PORT Index Number for PA05 */
+#define PORT_PA08_IDX               (  8)  /**< PORT Index Number for PA08 */
+#define PORT_PA14_IDX               ( 14)  /**< PORT Index Number for PA14 */
+#define PORT_PA15_IDX               ( 15)  /**< PORT Index Number for PA15 */
+#define PORT_PA16_IDX               ( 16)  /**< PORT Index Number for PA16 */
+#define PORT_PA17_IDX               ( 17)  /**< PORT Index Number for PA17 */
+#define PORT_PA18_IDX               ( 18)  /**< PORT Index Number for PA18 */
+#define PORT_PA19_IDX               ( 19)  /**< PORT Index Number for PA19 */
+#define PORT_PA22_IDX               ( 22)  /**< PORT Index Number for PA22 */
+#define PORT_PA23_IDX               ( 23)  /**< PORT Index Number for PA23 */
+#define PORT_PA30_IDX               ( 30)  /**< PORT Index Number for PA30 */
+#define PORT_PA31_IDX               ( 31)  /**< PORT Index Number for PA31 */
+
+/* ========== PORT definition for AC peripheral ========== */
+#define PIN_PA04B_AC_AIN0                          _L_(4)       /**< AC signal: AIN0 on PA04 mux B*/
+#define MUX_PA04B_AC_AIN0                          _L_(1)      
+#define PINMUX_PA04B_AC_AIN0                       ((PIN_PA04B_AC_AIN0 << 16) | MUX_PA04B_AC_AIN0)
+#define PORT_PA04B_AC_AIN0                         (_UL_(1) << 4)
+
+#define PIN_PA05B_AC_AIN1                          _L_(5)       /**< AC signal: AIN1 on PA05 mux B*/
+#define MUX_PA05B_AC_AIN1                          _L_(1)      
+#define PINMUX_PA05B_AC_AIN1                       ((PIN_PA05B_AC_AIN1 << 16) | MUX_PA05B_AC_AIN1)
+#define PORT_PA05B_AC_AIN1                         (_UL_(1) << 5)
+
+#define PIN_PA18H_AC_CMP0                          _L_(18)      /**< AC signal: CMP0 on PA18 mux H*/
+#define MUX_PA18H_AC_CMP0                          _L_(7)      
+#define PINMUX_PA18H_AC_CMP0                       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
+#define PORT_PA18H_AC_CMP0                         (_UL_(1) << 18)
+
+#define PIN_PA19H_AC_CMP1                          _L_(19)      /**< AC signal: CMP1 on PA19 mux H*/
+#define MUX_PA19H_AC_CMP1                          _L_(7)      
+#define PINMUX_PA19H_AC_CMP1                       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
+#define PORT_PA19H_AC_CMP1                         (_UL_(1) << 19)
+
+/* ========== PORT definition for ADC peripheral ========== */
+#define PIN_PA02B_ADC_AIN0                         _L_(2)       /**< ADC signal: AIN0 on PA02 mux B*/
+#define MUX_PA02B_ADC_AIN0                         _L_(1)      
+#define PINMUX_PA02B_ADC_AIN0                      ((PIN_PA02B_ADC_AIN0 << 16) | MUX_PA02B_ADC_AIN0)
+#define PORT_PA02B_ADC_AIN0                        (_UL_(1) << 2)
+
+#define PIN_PA03B_ADC_AIN1                         _L_(3)       /**< ADC signal: AIN1 on PA03 mux B*/
+#define MUX_PA03B_ADC_AIN1                         _L_(1)      
+#define PINMUX_PA03B_ADC_AIN1                      ((PIN_PA03B_ADC_AIN1 << 16) | MUX_PA03B_ADC_AIN1)
+#define PORT_PA03B_ADC_AIN1                        (_UL_(1) << 3)
+
+#define PIN_PA04B_ADC_AIN2                         _L_(4)       /**< ADC signal: AIN2 on PA04 mux B*/
+#define MUX_PA04B_ADC_AIN2                         _L_(1)      
+#define PINMUX_PA04B_ADC_AIN2                      ((PIN_PA04B_ADC_AIN2 << 16) | MUX_PA04B_ADC_AIN2)
+#define PORT_PA04B_ADC_AIN2                        (_UL_(1) << 4)
+
+#define PIN_PA05B_ADC_AIN3                         _L_(5)       /**< ADC signal: AIN3 on PA05 mux B*/
+#define MUX_PA05B_ADC_AIN3                         _L_(1)      
+#define PINMUX_PA05B_ADC_AIN3                      ((PIN_PA05B_ADC_AIN3 << 16) | MUX_PA05B_ADC_AIN3)
+#define PORT_PA05B_ADC_AIN3                        (_UL_(1) << 5)
+
+#define PIN_PA08B_ADC_AIN6                         _L_(8)       /**< ADC signal: AIN6 on PA08 mux B*/
+#define MUX_PA08B_ADC_AIN6                         _L_(1)      
+#define PINMUX_PA08B_ADC_AIN6                      ((PIN_PA08B_ADC_AIN6 << 16) | MUX_PA08B_ADC_AIN6)
+#define PORT_PA08B_ADC_AIN6                        (_UL_(1) << 8)
+
+#define PIN_PA04B_ADC_VREFP                        _L_(4)       /**< ADC signal: VREFP on PA04 mux B*/
+#define MUX_PA04B_ADC_VREFP                        _L_(1)      
+#define PINMUX_PA04B_ADC_VREFP                     ((PIN_PA04B_ADC_VREFP << 16) | MUX_PA04B_ADC_VREFP)
+#define PORT_PA04B_ADC_VREFP                       (_UL_(1) << 4)
+
+/* ========== PORT definition for CCL peripheral ========== */
+#define PIN_PA04I_CCL_IN0                          _L_(4)       /**< CCL signal: IN0 on PA04 mux I*/
+#define MUX_PA04I_CCL_IN0                          _L_(8)      
+#define PINMUX_PA04I_CCL_IN0                       ((PIN_PA04I_CCL_IN0 << 16) | MUX_PA04I_CCL_IN0)
+#define PORT_PA04I_CCL_IN0                         (_UL_(1) << 4)
+
+#define PIN_PA16I_CCL_IN0                          _L_(16)      /**< CCL signal: IN0 on PA16 mux I*/
+#define MUX_PA16I_CCL_IN0                          _L_(8)      
+#define PINMUX_PA16I_CCL_IN0                       ((PIN_PA16I_CCL_IN0 << 16) | MUX_PA16I_CCL_IN0)
+#define PORT_PA16I_CCL_IN0                         (_UL_(1) << 16)
+
+#define PIN_PA05I_CCL_IN1                          _L_(5)       /**< CCL signal: IN1 on PA05 mux I*/
+#define MUX_PA05I_CCL_IN1                          _L_(8)      
+#define PINMUX_PA05I_CCL_IN1                       ((PIN_PA05I_CCL_IN1 << 16) | MUX_PA05I_CCL_IN1)
+#define PORT_PA05I_CCL_IN1                         (_UL_(1) << 5)
+
+#define PIN_PA17I_CCL_IN1                          _L_(17)      /**< CCL signal: IN1 on PA17 mux I*/
+#define MUX_PA17I_CCL_IN1                          _L_(8)      
+#define PINMUX_PA17I_CCL_IN1                       ((PIN_PA17I_CCL_IN1 << 16) | MUX_PA17I_CCL_IN1)
+#define PORT_PA17I_CCL_IN1                         (_UL_(1) << 17)
+
+#define PIN_PA18I_CCL_IN2                          _L_(18)      /**< CCL signal: IN2 on PA18 mux I*/
+#define MUX_PA18I_CCL_IN2                          _L_(8)      
+#define PINMUX_PA18I_CCL_IN2                       ((PIN_PA18I_CCL_IN2 << 16) | MUX_PA18I_CCL_IN2)
+#define PORT_PA18I_CCL_IN2                         (_UL_(1) << 18)
+
+#define PIN_PA08I_CCL_IN3                          _L_(8)       /**< CCL signal: IN3 on PA08 mux I*/
+#define MUX_PA08I_CCL_IN3                          _L_(8)      
+#define PINMUX_PA08I_CCL_IN3                       ((PIN_PA08I_CCL_IN3 << 16) | MUX_PA08I_CCL_IN3)
+#define PORT_PA08I_CCL_IN3                         (_UL_(1) << 8)
+
+#define PIN_PA30I_CCL_IN3                          _L_(30)      /**< CCL signal: IN3 on PA30 mux I*/
+#define MUX_PA30I_CCL_IN3                          _L_(8)      
+#define PINMUX_PA30I_CCL_IN3                       ((PIN_PA30I_CCL_IN3 << 16) | MUX_PA30I_CCL_IN3)
+#define PORT_PA30I_CCL_IN3                         (_UL_(1) << 30)
+
+#define PIN_PA19I_CCL_OUT0                         _L_(19)      /**< CCL signal: OUT0 on PA19 mux I*/
+#define MUX_PA19I_CCL_OUT0                         _L_(8)      
+#define PINMUX_PA19I_CCL_OUT0                      ((PIN_PA19I_CCL_OUT0 << 16) | MUX_PA19I_CCL_OUT0)
+#define PORT_PA19I_CCL_OUT0                        (_UL_(1) << 19)
+
+#define PIN_PA31I_CCL_OUT1                         _L_(31)      /**< CCL signal: OUT1 on PA31 mux I*/
+#define MUX_PA31I_CCL_OUT1                         _L_(8)      
+#define PINMUX_PA31I_CCL_OUT1                      ((PIN_PA31I_CCL_OUT1 << 16) | MUX_PA31I_CCL_OUT1)
+#define PORT_PA31I_CCL_OUT1                        (_UL_(1) << 31)
+
+/* ========== PORT definition for DAC peripheral ========== */
+#define PIN_PA02B_DAC_VOUT                         _L_(2)       /**< DAC signal: VOUT on PA02 mux B*/
+#define MUX_PA02B_DAC_VOUT                         _L_(1)      
+#define PINMUX_PA02B_DAC_VOUT                      ((PIN_PA02B_DAC_VOUT << 16) | MUX_PA02B_DAC_VOUT)
+#define PORT_PA02B_DAC_VOUT                        (_UL_(1) << 2)
+
+#define PIN_PA03B_DAC_VREFP                        _L_(3)       /**< DAC signal: VREFP on PA03 mux B*/
+#define MUX_PA03B_DAC_VREFP                        _L_(1)      
+#define PINMUX_PA03B_DAC_VREFP                     ((PIN_PA03B_DAC_VREFP << 16) | MUX_PA03B_DAC_VREFP)
+#define PORT_PA03B_DAC_VREFP                       (_UL_(1) << 3)
+
+/* ========== PORT definition for EIC peripheral ========== */
+#define PIN_PA19A_EIC_EXTINT0                      _L_(19)      /**< EIC signal: EXTINT0 on PA19 mux A*/
+#define MUX_PA19A_EIC_EXTINT0                      _L_(0)      
+#define PINMUX_PA19A_EIC_EXTINT0                   ((PIN_PA19A_EIC_EXTINT0 << 16) | MUX_PA19A_EIC_EXTINT0)
+#define PORT_PA19A_EIC_EXTINT0                     (_UL_(1) << 19)
+#define PIN_PA19A_EIC_EXTINT_NUM                   _L_(0)       /**< EIC signal: PIN_PA19 External Interrupt Line */
+
+#define PIN_PA00A_EIC_EXTINT0                      _L_(0)       /**< EIC signal: EXTINT0 on PA00 mux A*/
+#define MUX_PA00A_EIC_EXTINT0                      _L_(0)      
+#define PINMUX_PA00A_EIC_EXTINT0                   ((PIN_PA00A_EIC_EXTINT0 << 16) | MUX_PA00A_EIC_EXTINT0)
+#define PORT_PA00A_EIC_EXTINT0                     (_UL_(1) << 0)
+#define PIN_PA00A_EIC_EXTINT_NUM                   _L_(0)       /**< EIC signal: PIN_PA00 External Interrupt Line */
+
+#define PIN_PA22A_EIC_EXTINT1                      _L_(22)      /**< EIC signal: EXTINT1 on PA22 mux A*/
+#define MUX_PA22A_EIC_EXTINT1                      _L_(0)      
+#define PINMUX_PA22A_EIC_EXTINT1                   ((PIN_PA22A_EIC_EXTINT1 << 16) | MUX_PA22A_EIC_EXTINT1)
+#define PORT_PA22A_EIC_EXTINT1                     (_UL_(1) << 22)
+#define PIN_PA22A_EIC_EXTINT_NUM                   _L_(1)       /**< EIC signal: PIN_PA22 External Interrupt Line */
+
+#define PIN_PA01A_EIC_EXTINT1                      _L_(1)       /**< EIC signal: EXTINT1 on PA01 mux A*/
+#define MUX_PA01A_EIC_EXTINT1                      _L_(0)      
+#define PINMUX_PA01A_EIC_EXTINT1                   ((PIN_PA01A_EIC_EXTINT1 << 16) | MUX_PA01A_EIC_EXTINT1)
+#define PORT_PA01A_EIC_EXTINT1                     (_UL_(1) << 1)
+#define PIN_PA01A_EIC_EXTINT_NUM                   _L_(1)       /**< EIC signal: PIN_PA01 External Interrupt Line */
+
+#define PIN_PA02A_EIC_EXTINT2                      _L_(2)       /**< EIC signal: EXTINT2 on PA02 mux A*/
+#define MUX_PA02A_EIC_EXTINT2                      _L_(0)      
+#define PINMUX_PA02A_EIC_EXTINT2                   ((PIN_PA02A_EIC_EXTINT2 << 16) | MUX_PA02A_EIC_EXTINT2)
+#define PORT_PA02A_EIC_EXTINT2                     (_UL_(1) << 2)
+#define PIN_PA02A_EIC_EXTINT_NUM                   _L_(2)       /**< EIC signal: PIN_PA02 External Interrupt Line */
+
+#define PIN_PA23A_EIC_EXTINT2                      _L_(23)      /**< EIC signal: EXTINT2 on PA23 mux A*/
+#define MUX_PA23A_EIC_EXTINT2                      _L_(0)      
+#define PINMUX_PA23A_EIC_EXTINT2                   ((PIN_PA23A_EIC_EXTINT2 << 16) | MUX_PA23A_EIC_EXTINT2)
+#define PORT_PA23A_EIC_EXTINT2                     (_UL_(1) << 23)
+#define PIN_PA23A_EIC_EXTINT_NUM                   _L_(2)       /**< EIC signal: PIN_PA23 External Interrupt Line */
+
+#define PIN_PA03A_EIC_EXTINT3                      _L_(3)       /**< EIC signal: EXTINT3 on PA03 mux A*/
+#define MUX_PA03A_EIC_EXTINT3                      _L_(0)      
+#define PINMUX_PA03A_EIC_EXTINT3                   ((PIN_PA03A_EIC_EXTINT3 << 16) | MUX_PA03A_EIC_EXTINT3)
+#define PORT_PA03A_EIC_EXTINT3                     (_UL_(1) << 3)
+#define PIN_PA03A_EIC_EXTINT_NUM                   _L_(3)       /**< EIC signal: PIN_PA03 External Interrupt Line */
+
+#define PIN_PA14A_EIC_EXTINT3                      _L_(14)      /**< EIC signal: EXTINT3 on PA14 mux A*/
+#define MUX_PA14A_EIC_EXTINT3                      _L_(0)      
+#define PINMUX_PA14A_EIC_EXTINT3                   ((PIN_PA14A_EIC_EXTINT3 << 16) | MUX_PA14A_EIC_EXTINT3)
+#define PORT_PA14A_EIC_EXTINT3                     (_UL_(1) << 14)
+#define PIN_PA14A_EIC_EXTINT_NUM                   _L_(3)       /**< EIC signal: PIN_PA14 External Interrupt Line */
+
+#define PIN_PA04A_EIC_EXTINT4                      _L_(4)       /**< EIC signal: EXTINT4 on PA04 mux A*/
+#define MUX_PA04A_EIC_EXTINT4                      _L_(0)      
+#define PINMUX_PA04A_EIC_EXTINT4                   ((PIN_PA04A_EIC_EXTINT4 << 16) | MUX_PA04A_EIC_EXTINT4)
+#define PORT_PA04A_EIC_EXTINT4                     (_UL_(1) << 4)
+#define PIN_PA04A_EIC_EXTINT_NUM                   _L_(4)       /**< EIC signal: PIN_PA04 External Interrupt Line */
+
+#define PIN_PA15A_EIC_EXTINT4                      _L_(15)      /**< EIC signal: EXTINT4 on PA15 mux A*/
+#define MUX_PA15A_EIC_EXTINT4                      _L_(0)      
+#define PINMUX_PA15A_EIC_EXTINT4                   ((PIN_PA15A_EIC_EXTINT4 << 16) | MUX_PA15A_EIC_EXTINT4)
+#define PORT_PA15A_EIC_EXTINT4                     (_UL_(1) << 15)
+#define PIN_PA15A_EIC_EXTINT_NUM                   _L_(4)       /**< EIC signal: PIN_PA15 External Interrupt Line */
+
+#define PIN_PA05A_EIC_EXTINT5                      _L_(5)       /**< EIC signal: EXTINT5 on PA05 mux A*/
+#define MUX_PA05A_EIC_EXTINT5                      _L_(0)      
+#define PINMUX_PA05A_EIC_EXTINT5                   ((PIN_PA05A_EIC_EXTINT5 << 16) | MUX_PA05A_EIC_EXTINT5)
+#define PORT_PA05A_EIC_EXTINT5                     (_UL_(1) << 5)
+#define PIN_PA05A_EIC_EXTINT_NUM                   _L_(5)       /**< EIC signal: PIN_PA05 External Interrupt Line */
+
+#define PIN_PA16A_EIC_EXTINT5                      _L_(16)      /**< EIC signal: EXTINT5 on PA16 mux A*/
+#define MUX_PA16A_EIC_EXTINT5                      _L_(0)      
+#define PINMUX_PA16A_EIC_EXTINT5                   ((PIN_PA16A_EIC_EXTINT5 << 16) | MUX_PA16A_EIC_EXTINT5)
+#define PORT_PA16A_EIC_EXTINT5                     (_UL_(1) << 16)
+#define PIN_PA16A_EIC_EXTINT_NUM                   _L_(5)       /**< EIC signal: PIN_PA16 External Interrupt Line */
+
+#define PIN_PA17A_EIC_EXTINT6                      _L_(17)      /**< EIC signal: EXTINT6 on PA17 mux A*/
+#define MUX_PA17A_EIC_EXTINT6                      _L_(0)      
+#define PINMUX_PA17A_EIC_EXTINT6                   ((PIN_PA17A_EIC_EXTINT6 << 16) | MUX_PA17A_EIC_EXTINT6)
+#define PORT_PA17A_EIC_EXTINT6                     (_UL_(1) << 17)
+#define PIN_PA17A_EIC_EXTINT_NUM                   _L_(6)       /**< EIC signal: PIN_PA17 External Interrupt Line */
+
+#define PIN_PA30A_EIC_EXTINT6                      _L_(30)      /**< EIC signal: EXTINT6 on PA30 mux A*/
+#define MUX_PA30A_EIC_EXTINT6                      _L_(0)      
+#define PINMUX_PA30A_EIC_EXTINT6                   ((PIN_PA30A_EIC_EXTINT6 << 16) | MUX_PA30A_EIC_EXTINT6)
+#define PORT_PA30A_EIC_EXTINT6                     (_UL_(1) << 30)
+#define PIN_PA30A_EIC_EXTINT_NUM                   _L_(6)       /**< EIC signal: PIN_PA30 External Interrupt Line */
+
+#define PIN_PA18A_EIC_EXTINT7                      _L_(18)      /**< EIC signal: EXTINT7 on PA18 mux A*/
+#define MUX_PA18A_EIC_EXTINT7                      _L_(0)      
+#define PINMUX_PA18A_EIC_EXTINT7                   ((PIN_PA18A_EIC_EXTINT7 << 16) | MUX_PA18A_EIC_EXTINT7)
+#define PORT_PA18A_EIC_EXTINT7                     (_UL_(1) << 18)
+#define PIN_PA18A_EIC_EXTINT_NUM                   _L_(7)       /**< EIC signal: PIN_PA18 External Interrupt Line */
+
+#define PIN_PA31A_EIC_EXTINT7                      _L_(31)      /**< EIC signal: EXTINT7 on PA31 mux A*/
+#define MUX_PA31A_EIC_EXTINT7                      _L_(0)      
+#define PINMUX_PA31A_EIC_EXTINT7                   ((PIN_PA31A_EIC_EXTINT7 << 16) | MUX_PA31A_EIC_EXTINT7)
+#define PORT_PA31A_EIC_EXTINT7                     (_UL_(1) << 31)
+#define PIN_PA31A_EIC_EXTINT_NUM                   _L_(7)       /**< EIC signal: PIN_PA31 External Interrupt Line */
+
+#define PIN_PA08A_EIC_NMI                          _L_(8)       /**< EIC signal: NMI on PA08 mux A*/
+#define MUX_PA08A_EIC_NMI                          _L_(0)      
+#define PINMUX_PA08A_EIC_NMI                       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
+#define PORT_PA08A_EIC_NMI                         (_UL_(1) << 8)
+
+/* ========== PORT definition for GCLK peripheral ========== */
+#define PIN_PA30H_GCLK_IO0                         _L_(30)      /**< GCLK signal: IO0 on PA30 mux H*/
+#define MUX_PA30H_GCLK_IO0                         _L_(7)      
+#define PINMUX_PA30H_GCLK_IO0                      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
+#define PORT_PA30H_GCLK_IO0                        (_UL_(1) << 30)
+
+#define PIN_PA14H_GCLK_IO0                         _L_(14)      /**< GCLK signal: IO0 on PA14 mux H*/
+#define MUX_PA14H_GCLK_IO0                         _L_(7)      
+#define PINMUX_PA14H_GCLK_IO0                      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
+#define PORT_PA14H_GCLK_IO0                        (_UL_(1) << 14)
+
+#define PIN_PA23H_GCLK_IO1                         _L_(23)      /**< GCLK signal: IO1 on PA23 mux H*/
+#define MUX_PA23H_GCLK_IO1                         _L_(7)      
+#define PINMUX_PA23H_GCLK_IO1                      ((PIN_PA23H_GCLK_IO1 << 16) | MUX_PA23H_GCLK_IO1)
+#define PORT_PA23H_GCLK_IO1                        (_UL_(1) << 23)
+
+#define PIN_PA15H_GCLK_IO1                         _L_(15)      /**< GCLK signal: IO1 on PA15 mux H*/
+#define MUX_PA15H_GCLK_IO1                         _L_(7)      
+#define PINMUX_PA15H_GCLK_IO1                      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
+#define PORT_PA15H_GCLK_IO1                        (_UL_(1) << 15)
+
+#define PIN_PA16H_GCLK_IO2                         _L_(16)      /**< GCLK signal: IO2 on PA16 mux H*/
+#define MUX_PA16H_GCLK_IO2                         _L_(7)      
+#define PINMUX_PA16H_GCLK_IO2                      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
+#define PORT_PA16H_GCLK_IO2                        (_UL_(1) << 16)
+
+#define PIN_PA22H_GCLK_IO2                         _L_(22)      /**< GCLK signal: IO2 on PA22 mux H*/
+#define MUX_PA22H_GCLK_IO2                         _L_(7)      
+#define PINMUX_PA22H_GCLK_IO2                      ((PIN_PA22H_GCLK_IO2 << 16) | MUX_PA22H_GCLK_IO2)
+#define PORT_PA22H_GCLK_IO2                        (_UL_(1) << 22)
+
+#define PIN_PA17H_GCLK_IO3                         _L_(17)      /**< GCLK signal: IO3 on PA17 mux H*/
+#define MUX_PA17H_GCLK_IO3                         _L_(7)      
+#define PINMUX_PA17H_GCLK_IO3                      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
+#define PORT_PA17H_GCLK_IO3                        (_UL_(1) << 17)
+
+/* ========== PORT definition for OPAMP peripheral ========== */
+#define PIN_PA02B_OPAMP_OANEG0                     _L_(2)       /**< OPAMP signal: OANEG0 on PA02 mux B*/
+#define MUX_PA02B_OPAMP_OANEG0                     _L_(1)      
+#define PINMUX_PA02B_OPAMP_OANEG0                  ((PIN_PA02B_OPAMP_OANEG0 << 16) | MUX_PA02B_OPAMP_OANEG0)
+#define PORT_PA02B_OPAMP_OANEG0                    (_UL_(1) << 2)
+
+#define PIN_PA00B_OPAMP_OANEG1                     _L_(0)       /**< OPAMP signal: OANEG1 on PA00 mux B*/
+#define MUX_PA00B_OPAMP_OANEG1                     _L_(1)      
+#define PINMUX_PA00B_OPAMP_OANEG1                  ((PIN_PA00B_OPAMP_OANEG1 << 16) | MUX_PA00B_OPAMP_OANEG1)
+#define PORT_PA00B_OPAMP_OANEG1                    (_UL_(1) << 0)
+
+#define PIN_PA03B_OPAMP_OANEG2                     _L_(3)       /**< OPAMP signal: OANEG2 on PA03 mux B*/
+#define MUX_PA03B_OPAMP_OANEG2                     _L_(1)      
+#define PINMUX_PA03B_OPAMP_OANEG2                  ((PIN_PA03B_OPAMP_OANEG2 << 16) | MUX_PA03B_OPAMP_OANEG2)
+#define PORT_PA03B_OPAMP_OANEG2                    (_UL_(1) << 3)
+
+#define PIN_PA04B_OPAMP_OAOUT2                     _L_(4)       /**< OPAMP signal: OAOUT2 on PA04 mux B*/
+#define MUX_PA04B_OPAMP_OAOUT2                     _L_(1)      
+#define PINMUX_PA04B_OPAMP_OAOUT2                  ((PIN_PA04B_OPAMP_OAOUT2 << 16) | MUX_PA04B_OPAMP_OAOUT2)
+#define PORT_PA04B_OPAMP_OAOUT2                    (_UL_(1) << 4)
+
+#define PIN_PA01B_OPAMP_OAPOS1                     _L_(1)       /**< OPAMP signal: OAPOS1 on PA01 mux B*/
+#define MUX_PA01B_OPAMP_OAPOS1                     _L_(1)      
+#define PINMUX_PA01B_OPAMP_OAPOS1                  ((PIN_PA01B_OPAMP_OAPOS1 << 16) | MUX_PA01B_OPAMP_OAPOS1)
+#define PORT_PA01B_OPAMP_OAPOS1                    (_UL_(1) << 1)
+
+#define PIN_PA05B_OPAMP_OAPOS2                     _L_(5)       /**< OPAMP signal: OAPOS2 on PA05 mux B*/
+#define MUX_PA05B_OPAMP_OAPOS2                     _L_(1)      
+#define PINMUX_PA05B_OPAMP_OAPOS2                  ((PIN_PA05B_OPAMP_OAPOS2 << 16) | MUX_PA05B_OPAMP_OAPOS2)
+#define PORT_PA05B_OPAMP_OAPOS2                    (_UL_(1) << 5)
+
+/* ========== PORT definition for PTC peripheral ========== */
+#define PIN_PA00F_PTC_DRV0                         _L_(0)       /**< PTC signal: DRV0 on PA00 mux F*/
+#define MUX_PA00F_PTC_DRV0                         _L_(5)      
+#define PINMUX_PA00F_PTC_DRV0                      ((PIN_PA00F_PTC_DRV0 << 16) | MUX_PA00F_PTC_DRV0)
+#define PORT_PA00F_PTC_DRV0                        (_UL_(1) << 0)
+
+#define PIN_PA01F_PTC_DRV1                         _L_(1)       /**< PTC signal: DRV1 on PA01 mux F*/
+#define MUX_PA01F_PTC_DRV1                         _L_(5)      
+#define PINMUX_PA01F_PTC_DRV1                      ((PIN_PA01F_PTC_DRV1 << 16) | MUX_PA01F_PTC_DRV1)
+#define PORT_PA01F_PTC_DRV1                        (_UL_(1) << 1)
+
+#define PIN_PA02F_PTC_DRV2                         _L_(2)       /**< PTC signal: DRV2 on PA02 mux F*/
+#define MUX_PA02F_PTC_DRV2                         _L_(5)      
+#define PINMUX_PA02F_PTC_DRV2                      ((PIN_PA02F_PTC_DRV2 << 16) | MUX_PA02F_PTC_DRV2)
+#define PORT_PA02F_PTC_DRV2                        (_UL_(1) << 2)
+
+#define PIN_PA03F_PTC_DRV3                         _L_(3)       /**< PTC signal: DRV3 on PA03 mux F*/
+#define MUX_PA03F_PTC_DRV3                         _L_(5)      
+#define PINMUX_PA03F_PTC_DRV3                      ((PIN_PA03F_PTC_DRV3 << 16) | MUX_PA03F_PTC_DRV3)
+#define PORT_PA03F_PTC_DRV3                        (_UL_(1) << 3)
+
+#define PIN_PA05F_PTC_DRV4                         _L_(5)       /**< PTC signal: DRV4 on PA05 mux F*/
+#define MUX_PA05F_PTC_DRV4                         _L_(5)      
+#define PINMUX_PA05F_PTC_DRV4                      ((PIN_PA05F_PTC_DRV4 << 16) | MUX_PA05F_PTC_DRV4)
+#define PORT_PA05F_PTC_DRV4                        (_UL_(1) << 5)
+
+#define PIN_PA08F_PTC_DRV6                         _L_(8)       /**< PTC signal: DRV6 on PA08 mux F*/
+#define MUX_PA08F_PTC_DRV6                         _L_(5)      
+#define PINMUX_PA08F_PTC_DRV6                      ((PIN_PA08F_PTC_DRV6 << 16) | MUX_PA08F_PTC_DRV6)
+#define PORT_PA08F_PTC_DRV6                        (_UL_(1) << 8)
+
+#define PIN_PA14F_PTC_DRV10                        _L_(14)      /**< PTC signal: DRV10 on PA14 mux F*/
+#define MUX_PA14F_PTC_DRV10                        _L_(5)      
+#define PINMUX_PA14F_PTC_DRV10                     ((PIN_PA14F_PTC_DRV10 << 16) | MUX_PA14F_PTC_DRV10)
+#define PORT_PA14F_PTC_DRV10                       (_UL_(1) << 14)
+
+#define PIN_PA15F_PTC_DRV11                        _L_(15)      /**< PTC signal: DRV11 on PA15 mux F*/
+#define MUX_PA15F_PTC_DRV11                        _L_(5)      
+#define PINMUX_PA15F_PTC_DRV11                     ((PIN_PA15F_PTC_DRV11 << 16) | MUX_PA15F_PTC_DRV11)
+#define PORT_PA15F_PTC_DRV11                       (_UL_(1) << 15)
+
+#define PIN_PA16F_PTC_DRV12                        _L_(16)      /**< PTC signal: DRV12 on PA16 mux F*/
+#define MUX_PA16F_PTC_DRV12                        _L_(5)      
+#define PINMUX_PA16F_PTC_DRV12                     ((PIN_PA16F_PTC_DRV12 << 16) | MUX_PA16F_PTC_DRV12)
+#define PORT_PA16F_PTC_DRV12                       (_UL_(1) << 16)
+
+#define PIN_PA17F_PTC_DRV13                        _L_(17)      /**< PTC signal: DRV13 on PA17 mux F*/
+#define MUX_PA17F_PTC_DRV13                        _L_(5)      
+#define PINMUX_PA17F_PTC_DRV13                     ((PIN_PA17F_PTC_DRV13 << 16) | MUX_PA17F_PTC_DRV13)
+#define PORT_PA17F_PTC_DRV13                       (_UL_(1) << 17)
+
+#define PIN_PA18F_PTC_DRV14                        _L_(18)      /**< PTC signal: DRV14 on PA18 mux F*/
+#define MUX_PA18F_PTC_DRV14                        _L_(5)      
+#define PINMUX_PA18F_PTC_DRV14                     ((PIN_PA18F_PTC_DRV14 << 16) | MUX_PA18F_PTC_DRV14)
+#define PORT_PA18F_PTC_DRV14                       (_UL_(1) << 18)
+
+#define PIN_PA19F_PTC_DRV15                        _L_(19)      /**< PTC signal: DRV15 on PA19 mux F*/
+#define MUX_PA19F_PTC_DRV15                        _L_(5)      
+#define PINMUX_PA19F_PTC_DRV15                     ((PIN_PA19F_PTC_DRV15 << 16) | MUX_PA19F_PTC_DRV15)
+#define PORT_PA19F_PTC_DRV15                       (_UL_(1) << 19)
+
+#define PIN_PA22F_PTC_DRV16                        _L_(22)      /**< PTC signal: DRV16 on PA22 mux F*/
+#define MUX_PA22F_PTC_DRV16                        _L_(5)      
+#define PINMUX_PA22F_PTC_DRV16                     ((PIN_PA22F_PTC_DRV16 << 16) | MUX_PA22F_PTC_DRV16)
+#define PORT_PA22F_PTC_DRV16                       (_UL_(1) << 22)
+
+#define PIN_PA23F_PTC_DRV17                        _L_(23)      /**< PTC signal: DRV17 on PA23 mux F*/
+#define MUX_PA23F_PTC_DRV17                        _L_(5)      
+#define PINMUX_PA23F_PTC_DRV17                     ((PIN_PA23F_PTC_DRV17 << 16) | MUX_PA23F_PTC_DRV17)
+#define PORT_PA23F_PTC_DRV17                       (_UL_(1) << 23)
+
+#define PIN_PA30F_PTC_DRV18                        _L_(30)      /**< PTC signal: DRV18 on PA30 mux F*/
+#define MUX_PA30F_PTC_DRV18                        _L_(5)      
+#define PINMUX_PA30F_PTC_DRV18                     ((PIN_PA30F_PTC_DRV18 << 16) | MUX_PA30F_PTC_DRV18)
+#define PORT_PA30F_PTC_DRV18                       (_UL_(1) << 30)
+
+#define PIN_PA31F_PTC_DRV19                        _L_(31)      /**< PTC signal: DRV19 on PA31 mux F*/
+#define MUX_PA31F_PTC_DRV19                        _L_(5)      
+#define PINMUX_PA31F_PTC_DRV19                     ((PIN_PA31F_PTC_DRV19 << 16) | MUX_PA31F_PTC_DRV19)
+#define PORT_PA31F_PTC_DRV19                       (_UL_(1) << 31)
+
+#define PIN_PA03B_PTC_ECI0                         _L_(3)       /**< PTC signal: ECI0 on PA03 mux B*/
+#define MUX_PA03B_PTC_ECI0                         _L_(1)      
+#define PINMUX_PA03B_PTC_ECI0                      ((PIN_PA03B_PTC_ECI0 << 16) | MUX_PA03B_PTC_ECI0)
+#define PORT_PA03B_PTC_ECI0                        (_UL_(1) << 3)
+
+#define PIN_PA04B_PTC_ECI1                         _L_(4)       /**< PTC signal: ECI1 on PA04 mux B*/
+#define MUX_PA04B_PTC_ECI1                         _L_(1)      
+#define PINMUX_PA04B_PTC_ECI1                      ((PIN_PA04B_PTC_ECI1 << 16) | MUX_PA04B_PTC_ECI1)
+#define PORT_PA04B_PTC_ECI1                        (_UL_(1) << 4)
+
+#define PIN_PA05B_PTC_ECI2                         _L_(5)       /**< PTC signal: ECI2 on PA05 mux B*/
+#define MUX_PA05B_PTC_ECI2                         _L_(1)      
+#define PINMUX_PA05B_PTC_ECI2                      ((PIN_PA05B_PTC_ECI2 << 16) | MUX_PA05B_PTC_ECI2)
+#define PORT_PA05B_PTC_ECI2                        (_UL_(1) << 5)
+
+#define PIN_PA00B_PTC_X0                           _L_(0)       /**< PTC signal: X0 on PA00 mux B*/
+#define MUX_PA00B_PTC_X0                           _L_(1)      
+#define PINMUX_PA00B_PTC_X0                        ((PIN_PA00B_PTC_X0 << 16) | MUX_PA00B_PTC_X0)
+#define PORT_PA00B_PTC_X0                          (_UL_(1) << 0)
+
+#define PIN_PA00B_PTC_Y0                           _L_(0)       /**< PTC signal: Y0 on PA00 mux B*/
+#define MUX_PA00B_PTC_Y0                           _L_(1)      
+#define PINMUX_PA00B_PTC_Y0                        ((PIN_PA00B_PTC_Y0 << 16) | MUX_PA00B_PTC_Y0)
+#define PORT_PA00B_PTC_Y0                          (_UL_(1) << 0)
+
+#define PIN_PA01B_PTC_X1                           _L_(1)       /**< PTC signal: X1 on PA01 mux B*/
+#define MUX_PA01B_PTC_X1                           _L_(1)      
+#define PINMUX_PA01B_PTC_X1                        ((PIN_PA01B_PTC_X1 << 16) | MUX_PA01B_PTC_X1)
+#define PORT_PA01B_PTC_X1                          (_UL_(1) << 1)
+
+#define PIN_PA01B_PTC_Y1                           _L_(1)       /**< PTC signal: Y1 on PA01 mux B*/
+#define MUX_PA01B_PTC_Y1                           _L_(1)      
+#define PINMUX_PA01B_PTC_Y1                        ((PIN_PA01B_PTC_Y1 << 16) | MUX_PA01B_PTC_Y1)
+#define PORT_PA01B_PTC_Y1                          (_UL_(1) << 1)
+
+#define PIN_PA02B_PTC_X2                           _L_(2)       /**< PTC signal: X2 on PA02 mux B*/
+#define MUX_PA02B_PTC_X2                           _L_(1)      
+#define PINMUX_PA02B_PTC_X2                        ((PIN_PA02B_PTC_X2 << 16) | MUX_PA02B_PTC_X2)
+#define PORT_PA02B_PTC_X2                          (_UL_(1) << 2)
+
+#define PIN_PA02B_PTC_Y2                           _L_(2)       /**< PTC signal: Y2 on PA02 mux B*/
+#define MUX_PA02B_PTC_Y2                           _L_(1)      
+#define PINMUX_PA02B_PTC_Y2                        ((PIN_PA02B_PTC_Y2 << 16) | MUX_PA02B_PTC_Y2)
+#define PORT_PA02B_PTC_Y2                          (_UL_(1) << 2)
+
+#define PIN_PA03B_PTC_X3                           _L_(3)       /**< PTC signal: X3 on PA03 mux B*/
+#define MUX_PA03B_PTC_X3                           _L_(1)      
+#define PINMUX_PA03B_PTC_X3                        ((PIN_PA03B_PTC_X3 << 16) | MUX_PA03B_PTC_X3)
+#define PORT_PA03B_PTC_X3                          (_UL_(1) << 3)
+
+#define PIN_PA03B_PTC_Y3                           _L_(3)       /**< PTC signal: Y3 on PA03 mux B*/
+#define MUX_PA03B_PTC_Y3                           _L_(1)      
+#define PINMUX_PA03B_PTC_Y3                        ((PIN_PA03B_PTC_Y3 << 16) | MUX_PA03B_PTC_Y3)
+#define PORT_PA03B_PTC_Y3                          (_UL_(1) << 3)
+
+#define PIN_PA05B_PTC_X4                           _L_(5)       /**< PTC signal: X4 on PA05 mux B*/
+#define MUX_PA05B_PTC_X4                           _L_(1)      
+#define PINMUX_PA05B_PTC_X4                        ((PIN_PA05B_PTC_X4 << 16) | MUX_PA05B_PTC_X4)
+#define PORT_PA05B_PTC_X4                          (_UL_(1) << 5)
+
+#define PIN_PA05B_PTC_Y4                           _L_(5)       /**< PTC signal: Y4 on PA05 mux B*/
+#define MUX_PA05B_PTC_Y4                           _L_(1)      
+#define PINMUX_PA05B_PTC_Y4                        ((PIN_PA05B_PTC_Y4 << 16) | MUX_PA05B_PTC_Y4)
+#define PORT_PA05B_PTC_Y4                          (_UL_(1) << 5)
+
+#define PIN_PA08B_PTC_X6                           _L_(8)       /**< PTC signal: X6 on PA08 mux B*/
+#define MUX_PA08B_PTC_X6                           _L_(1)      
+#define PINMUX_PA08B_PTC_X6                        ((PIN_PA08B_PTC_X6 << 16) | MUX_PA08B_PTC_X6)
+#define PORT_PA08B_PTC_X6                          (_UL_(1) << 8)
+
+#define PIN_PA08B_PTC_Y6                           _L_(8)       /**< PTC signal: Y6 on PA08 mux B*/
+#define MUX_PA08B_PTC_Y6                           _L_(1)      
+#define PINMUX_PA08B_PTC_Y6                        ((PIN_PA08B_PTC_Y6 << 16) | MUX_PA08B_PTC_Y6)
+#define PORT_PA08B_PTC_Y6                          (_UL_(1) << 8)
+
+#define PIN_PA14B_PTC_X10                          _L_(14)      /**< PTC signal: X10 on PA14 mux B*/
+#define MUX_PA14B_PTC_X10                          _L_(1)      
+#define PINMUX_PA14B_PTC_X10                       ((PIN_PA14B_PTC_X10 << 16) | MUX_PA14B_PTC_X10)
+#define PORT_PA14B_PTC_X10                         (_UL_(1) << 14)
+
+#define PIN_PA14B_PTC_Y10                          _L_(14)      /**< PTC signal: Y10 on PA14 mux B*/
+#define MUX_PA14B_PTC_Y10                          _L_(1)      
+#define PINMUX_PA14B_PTC_Y10                       ((PIN_PA14B_PTC_Y10 << 16) | MUX_PA14B_PTC_Y10)
+#define PORT_PA14B_PTC_Y10                         (_UL_(1) << 14)
+
+#define PIN_PA15B_PTC_X11                          _L_(15)      /**< PTC signal: X11 on PA15 mux B*/
+#define MUX_PA15B_PTC_X11                          _L_(1)      
+#define PINMUX_PA15B_PTC_X11                       ((PIN_PA15B_PTC_X11 << 16) | MUX_PA15B_PTC_X11)
+#define PORT_PA15B_PTC_X11                         (_UL_(1) << 15)
+
+#define PIN_PA15B_PTC_Y11                          _L_(15)      /**< PTC signal: Y11 on PA15 mux B*/
+#define MUX_PA15B_PTC_Y11                          _L_(1)      
+#define PINMUX_PA15B_PTC_Y11                       ((PIN_PA15B_PTC_Y11 << 16) | MUX_PA15B_PTC_Y11)
+#define PORT_PA15B_PTC_Y11                         (_UL_(1) << 15)
+
+#define PIN_PA16B_PTC_X12                          _L_(16)      /**< PTC signal: X12 on PA16 mux B*/
+#define MUX_PA16B_PTC_X12                          _L_(1)      
+#define PINMUX_PA16B_PTC_X12                       ((PIN_PA16B_PTC_X12 << 16) | MUX_PA16B_PTC_X12)
+#define PORT_PA16B_PTC_X12                         (_UL_(1) << 16)
+
+#define PIN_PA16B_PTC_Y12                          _L_(16)      /**< PTC signal: Y12 on PA16 mux B*/
+#define MUX_PA16B_PTC_Y12                          _L_(1)      
+#define PINMUX_PA16B_PTC_Y12                       ((PIN_PA16B_PTC_Y12 << 16) | MUX_PA16B_PTC_Y12)
+#define PORT_PA16B_PTC_Y12                         (_UL_(1) << 16)
+
+#define PIN_PA17B_PTC_X13                          _L_(17)      /**< PTC signal: X13 on PA17 mux B*/
+#define MUX_PA17B_PTC_X13                          _L_(1)      
+#define PINMUX_PA17B_PTC_X13                       ((PIN_PA17B_PTC_X13 << 16) | MUX_PA17B_PTC_X13)
+#define PORT_PA17B_PTC_X13                         (_UL_(1) << 17)
+
+#define PIN_PA17B_PTC_Y13                          _L_(17)      /**< PTC signal: Y13 on PA17 mux B*/
+#define MUX_PA17B_PTC_Y13                          _L_(1)      
+#define PINMUX_PA17B_PTC_Y13                       ((PIN_PA17B_PTC_Y13 << 16) | MUX_PA17B_PTC_Y13)
+#define PORT_PA17B_PTC_Y13                         (_UL_(1) << 17)
+
+#define PIN_PA18B_PTC_X14                          _L_(18)      /**< PTC signal: X14 on PA18 mux B*/
+#define MUX_PA18B_PTC_X14                          _L_(1)      
+#define PINMUX_PA18B_PTC_X14                       ((PIN_PA18B_PTC_X14 << 16) | MUX_PA18B_PTC_X14)
+#define PORT_PA18B_PTC_X14                         (_UL_(1) << 18)
+
+#define PIN_PA18B_PTC_Y14                          _L_(18)      /**< PTC signal: Y14 on PA18 mux B*/
+#define MUX_PA18B_PTC_Y14                          _L_(1)      
+#define PINMUX_PA18B_PTC_Y14                       ((PIN_PA18B_PTC_Y14 << 16) | MUX_PA18B_PTC_Y14)
+#define PORT_PA18B_PTC_Y14                         (_UL_(1) << 18)
+
+#define PIN_PA19B_PTC_X15                          _L_(19)      /**< PTC signal: X15 on PA19 mux B*/
+#define MUX_PA19B_PTC_X15                          _L_(1)      
+#define PINMUX_PA19B_PTC_X15                       ((PIN_PA19B_PTC_X15 << 16) | MUX_PA19B_PTC_X15)
+#define PORT_PA19B_PTC_X15                         (_UL_(1) << 19)
+
+#define PIN_PA19B_PTC_Y15                          _L_(19)      /**< PTC signal: Y15 on PA19 mux B*/
+#define MUX_PA19B_PTC_Y15                          _L_(1)      
+#define PINMUX_PA19B_PTC_Y15                       ((PIN_PA19B_PTC_Y15 << 16) | MUX_PA19B_PTC_Y15)
+#define PORT_PA19B_PTC_Y15                         (_UL_(1) << 19)
+
+#define PIN_PA22B_PTC_X16                          _L_(22)      /**< PTC signal: X16 on PA22 mux B*/
+#define MUX_PA22B_PTC_X16                          _L_(1)      
+#define PINMUX_PA22B_PTC_X16                       ((PIN_PA22B_PTC_X16 << 16) | MUX_PA22B_PTC_X16)
+#define PORT_PA22B_PTC_X16                         (_UL_(1) << 22)
+
+#define PIN_PA22B_PTC_Y16                          _L_(22)      /**< PTC signal: Y16 on PA22 mux B*/
+#define MUX_PA22B_PTC_Y16                          _L_(1)      
+#define PINMUX_PA22B_PTC_Y16                       ((PIN_PA22B_PTC_Y16 << 16) | MUX_PA22B_PTC_Y16)
+#define PORT_PA22B_PTC_Y16                         (_UL_(1) << 22)
+
+#define PIN_PA23B_PTC_X17                          _L_(23)      /**< PTC signal: X17 on PA23 mux B*/
+#define MUX_PA23B_PTC_X17                          _L_(1)      
+#define PINMUX_PA23B_PTC_X17                       ((PIN_PA23B_PTC_X17 << 16) | MUX_PA23B_PTC_X17)
+#define PORT_PA23B_PTC_X17                         (_UL_(1) << 23)
+
+#define PIN_PA23B_PTC_Y17                          _L_(23)      /**< PTC signal: Y17 on PA23 mux B*/
+#define MUX_PA23B_PTC_Y17                          _L_(1)      
+#define PINMUX_PA23B_PTC_Y17                       ((PIN_PA23B_PTC_Y17 << 16) | MUX_PA23B_PTC_Y17)
+#define PORT_PA23B_PTC_Y17                         (_UL_(1) << 23)
+
+#define PIN_PA30B_PTC_X18                          _L_(30)      /**< PTC signal: X18 on PA30 mux B*/
+#define MUX_PA30B_PTC_X18                          _L_(1)      
+#define PINMUX_PA30B_PTC_X18                       ((PIN_PA30B_PTC_X18 << 16) | MUX_PA30B_PTC_X18)
+#define PORT_PA30B_PTC_X18                         (_UL_(1) << 30)
+
+#define PIN_PA30B_PTC_Y18                          _L_(30)      /**< PTC signal: Y18 on PA30 mux B*/
+#define MUX_PA30B_PTC_Y18                          _L_(1)      
+#define PINMUX_PA30B_PTC_Y18                       ((PIN_PA30B_PTC_Y18 << 16) | MUX_PA30B_PTC_Y18)
+#define PORT_PA30B_PTC_Y18                         (_UL_(1) << 30)
+
+#define PIN_PA31B_PTC_X19                          _L_(31)      /**< PTC signal: X19 on PA31 mux B*/
+#define MUX_PA31B_PTC_X19                          _L_(1)      
+#define PINMUX_PA31B_PTC_X19                       ((PIN_PA31B_PTC_X19 << 16) | MUX_PA31B_PTC_X19)
+#define PORT_PA31B_PTC_X19                         (_UL_(1) << 31)
+
+#define PIN_PA31B_PTC_Y19                          _L_(31)      /**< PTC signal: Y19 on PA31 mux B*/
+#define MUX_PA31B_PTC_Y19                          _L_(1)      
+#define PINMUX_PA31B_PTC_Y19                       ((PIN_PA31B_PTC_Y19 << 16) | MUX_PA31B_PTC_Y19)
+#define PORT_PA31B_PTC_Y19                         (_UL_(1) << 31)
+
+/* ========== PORT definition for RTC peripheral ========== */
+#define PIN_PA08G_RTC_IN0                          _L_(8)       /**< RTC signal: IN0 on PA08 mux G*/
+#define MUX_PA08G_RTC_IN0                          _L_(6)      
+#define PINMUX_PA08G_RTC_IN0                       ((PIN_PA08G_RTC_IN0 << 16) | MUX_PA08G_RTC_IN0)
+#define PORT_PA08G_RTC_IN0                         (_UL_(1) << 8)
+
+#define PIN_PA16G_RTC_IN2                          _L_(16)      /**< RTC signal: IN2 on PA16 mux G*/
+#define MUX_PA16G_RTC_IN2                          _L_(6)      
+#define PINMUX_PA16G_RTC_IN2                       ((PIN_PA16G_RTC_IN2 << 16) | MUX_PA16G_RTC_IN2)
+#define PORT_PA16G_RTC_IN2                         (_UL_(1) << 16)
+
+#define PIN_PA17G_RTC_IN3                          _L_(17)      /**< RTC signal: IN3 on PA17 mux G*/
+#define MUX_PA17G_RTC_IN3                          _L_(6)      
+#define PINMUX_PA17G_RTC_IN3                       ((PIN_PA17G_RTC_IN3 << 16) | MUX_PA17G_RTC_IN3)
+#define PORT_PA17G_RTC_IN3                         (_UL_(1) << 17)
+
+#define PIN_PA18G_RTC_OUT0                         _L_(18)      /**< RTC signal: OUT0 on PA18 mux G*/
+#define MUX_PA18G_RTC_OUT0                         _L_(6)      
+#define PINMUX_PA18G_RTC_OUT0                      ((PIN_PA18G_RTC_OUT0 << 16) | MUX_PA18G_RTC_OUT0)
+#define PORT_PA18G_RTC_OUT0                        (_UL_(1) << 18)
+
+#define PIN_PA19G_RTC_OUT1                         _L_(19)      /**< RTC signal: OUT1 on PA19 mux G*/
+#define MUX_PA19G_RTC_OUT1                         _L_(6)      
+#define PINMUX_PA19G_RTC_OUT1                      ((PIN_PA19G_RTC_OUT1 << 16) | MUX_PA19G_RTC_OUT1)
+#define PORT_PA19G_RTC_OUT1                        (_UL_(1) << 19)
+
+#define PIN_PA22G_RTC_OUT2                         _L_(22)      /**< RTC signal: OUT2 on PA22 mux G*/
+#define MUX_PA22G_RTC_OUT2                         _L_(6)      
+#define PINMUX_PA22G_RTC_OUT2                      ((PIN_PA22G_RTC_OUT2 << 16) | MUX_PA22G_RTC_OUT2)
+#define PORT_PA22G_RTC_OUT2                        (_UL_(1) << 22)
+
+#define PIN_PA23G_RTC_OUT3                         _L_(23)      /**< RTC signal: OUT3 on PA23 mux G*/
+#define MUX_PA23G_RTC_OUT3                         _L_(6)      
+#define PINMUX_PA23G_RTC_OUT3                      ((PIN_PA23G_RTC_OUT3 << 16) | MUX_PA23G_RTC_OUT3)
+#define PORT_PA23G_RTC_OUT3                        (_UL_(1) << 23)
+
+/* ========== PORT definition for SERCOM0 peripheral ========== */
+#define PIN_PA04D_SERCOM0_PAD0                     _L_(4)       /**< SERCOM0 signal: PAD0 on PA04 mux D*/
+#define MUX_PA04D_SERCOM0_PAD0                     _L_(3)      
+#define PINMUX_PA04D_SERCOM0_PAD0                  ((PIN_PA04D_SERCOM0_PAD0 << 16) | MUX_PA04D_SERCOM0_PAD0)
+#define PORT_PA04D_SERCOM0_PAD0                    (_UL_(1) << 4)
+
+#define PIN_PA16D_SERCOM0_PAD0                     _L_(16)      /**< SERCOM0 signal: PAD0 on PA16 mux D*/
+#define MUX_PA16D_SERCOM0_PAD0                     _L_(3)      
+#define PINMUX_PA16D_SERCOM0_PAD0                  ((PIN_PA16D_SERCOM0_PAD0 << 16) | MUX_PA16D_SERCOM0_PAD0)
+#define PORT_PA16D_SERCOM0_PAD0                    (_UL_(1) << 16)
+
+#define PIN_PA22C_SERCOM0_PAD0                     _L_(22)      /**< SERCOM0 signal: PAD0 on PA22 mux C*/
+#define MUX_PA22C_SERCOM0_PAD0                     _L_(2)      
+#define PINMUX_PA22C_SERCOM0_PAD0                  ((PIN_PA22C_SERCOM0_PAD0 << 16) | MUX_PA22C_SERCOM0_PAD0)
+#define PORT_PA22C_SERCOM0_PAD0                    (_UL_(1) << 22)
+
+#define PIN_PA05D_SERCOM0_PAD1                     _L_(5)       /**< SERCOM0 signal: PAD1 on PA05 mux D*/
+#define MUX_PA05D_SERCOM0_PAD1                     _L_(3)      
+#define PINMUX_PA05D_SERCOM0_PAD1                  ((PIN_PA05D_SERCOM0_PAD1 << 16) | MUX_PA05D_SERCOM0_PAD1)
+#define PORT_PA05D_SERCOM0_PAD1                    (_UL_(1) << 5)
+
+#define PIN_PA17D_SERCOM0_PAD1                     _L_(17)      /**< SERCOM0 signal: PAD1 on PA17 mux D*/
+#define MUX_PA17D_SERCOM0_PAD1                     _L_(3)      
+#define PINMUX_PA17D_SERCOM0_PAD1                  ((PIN_PA17D_SERCOM0_PAD1 << 16) | MUX_PA17D_SERCOM0_PAD1)
+#define PORT_PA17D_SERCOM0_PAD1                    (_UL_(1) << 17)
+
+#define PIN_PA23C_SERCOM0_PAD1                     _L_(23)      /**< SERCOM0 signal: PAD1 on PA23 mux C*/
+#define MUX_PA23C_SERCOM0_PAD1                     _L_(2)      
+#define PINMUX_PA23C_SERCOM0_PAD1                  ((PIN_PA23C_SERCOM0_PAD1 << 16) | MUX_PA23C_SERCOM0_PAD1)
+#define PORT_PA23C_SERCOM0_PAD1                    (_UL_(1) << 23)
+
+#define PIN_PA14D_SERCOM0_PAD2                     _L_(14)      /**< SERCOM0 signal: PAD2 on PA14 mux D*/
+#define MUX_PA14D_SERCOM0_PAD2                     _L_(3)      
+#define PINMUX_PA14D_SERCOM0_PAD2                  ((PIN_PA14D_SERCOM0_PAD2 << 16) | MUX_PA14D_SERCOM0_PAD2)
+#define PORT_PA14D_SERCOM0_PAD2                    (_UL_(1) << 14)
+
+#define PIN_PA18D_SERCOM0_PAD2                     _L_(18)      /**< SERCOM0 signal: PAD2 on PA18 mux D*/
+#define MUX_PA18D_SERCOM0_PAD2                     _L_(3)      
+#define PINMUX_PA18D_SERCOM0_PAD2                  ((PIN_PA18D_SERCOM0_PAD2 << 16) | MUX_PA18D_SERCOM0_PAD2)
+#define PORT_PA18D_SERCOM0_PAD2                    (_UL_(1) << 18)
+
+#define PIN_PA02D_SERCOM0_PAD2                     _L_(2)       /**< SERCOM0 signal: PAD2 on PA02 mux D*/
+#define MUX_PA02D_SERCOM0_PAD2                     _L_(3)      
+#define PINMUX_PA02D_SERCOM0_PAD2                  ((PIN_PA02D_SERCOM0_PAD2 << 16) | MUX_PA02D_SERCOM0_PAD2)
+#define PORT_PA02D_SERCOM0_PAD2                    (_UL_(1) << 2)
+
+#define PIN_PA15D_SERCOM0_PAD3                     _L_(15)      /**< SERCOM0 signal: PAD3 on PA15 mux D*/
+#define MUX_PA15D_SERCOM0_PAD3                     _L_(3)      
+#define PINMUX_PA15D_SERCOM0_PAD3                  ((PIN_PA15D_SERCOM0_PAD3 << 16) | MUX_PA15D_SERCOM0_PAD3)
+#define PORT_PA15D_SERCOM0_PAD3                    (_UL_(1) << 15)
+
+#define PIN_PA19D_SERCOM0_PAD3                     _L_(19)      /**< SERCOM0 signal: PAD3 on PA19 mux D*/
+#define MUX_PA19D_SERCOM0_PAD3                     _L_(3)      
+#define PINMUX_PA19D_SERCOM0_PAD3                  ((PIN_PA19D_SERCOM0_PAD3 << 16) | MUX_PA19D_SERCOM0_PAD3)
+#define PORT_PA19D_SERCOM0_PAD3                    (_UL_(1) << 19)
+
+#define PIN_PA03D_SERCOM0_PAD3                     _L_(3)       /**< SERCOM0 signal: PAD3 on PA03 mux D*/
+#define MUX_PA03D_SERCOM0_PAD3                     _L_(3)      
+#define PINMUX_PA03D_SERCOM0_PAD3                  ((PIN_PA03D_SERCOM0_PAD3 << 16) | MUX_PA03D_SERCOM0_PAD3)
+#define PORT_PA03D_SERCOM0_PAD3                    (_UL_(1) << 3)
+
+/* ========== PORT definition for SERCOM1 peripheral ========== */
+#define PIN_PA16C_SERCOM1_PAD0                     _L_(16)      /**< SERCOM1 signal: PAD0 on PA16 mux C*/
+#define MUX_PA16C_SERCOM1_PAD0                     _L_(2)      
+#define PINMUX_PA16C_SERCOM1_PAD0                  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
+#define PORT_PA16C_SERCOM1_PAD0                    (_UL_(1) << 16)
+
+#define PIN_PA08C_SERCOM1_PAD0                     _L_(8)       /**< SERCOM1 signal: PAD0 on PA08 mux C*/
+#define MUX_PA08C_SERCOM1_PAD0                     _L_(2)      
+#define PINMUX_PA08C_SERCOM1_PAD0                  ((PIN_PA08C_SERCOM1_PAD0 << 16) | MUX_PA08C_SERCOM1_PAD0)
+#define PORT_PA08C_SERCOM1_PAD0                    (_UL_(1) << 8)
+
+#define PIN_PA00D_SERCOM1_PAD0                     _L_(0)       /**< SERCOM1 signal: PAD0 on PA00 mux D*/
+#define MUX_PA00D_SERCOM1_PAD0                     _L_(3)      
+#define PINMUX_PA00D_SERCOM1_PAD0                  ((PIN_PA00D_SERCOM1_PAD0 << 16) | MUX_PA00D_SERCOM1_PAD0)
+#define PORT_PA00D_SERCOM1_PAD0                    (_UL_(1) << 0)
+
+#define PIN_PA17C_SERCOM1_PAD1                     _L_(17)      /**< SERCOM1 signal: PAD1 on PA17 mux C*/
+#define MUX_PA17C_SERCOM1_PAD1                     _L_(2)      
+#define PINMUX_PA17C_SERCOM1_PAD1                  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
+#define PORT_PA17C_SERCOM1_PAD1                    (_UL_(1) << 17)
+
+#define PIN_PA01D_SERCOM1_PAD1                     _L_(1)       /**< SERCOM1 signal: PAD1 on PA01 mux D*/
+#define MUX_PA01D_SERCOM1_PAD1                     _L_(3)      
+#define PINMUX_PA01D_SERCOM1_PAD1                  ((PIN_PA01D_SERCOM1_PAD1 << 16) | MUX_PA01D_SERCOM1_PAD1)
+#define PORT_PA01D_SERCOM1_PAD1                    (_UL_(1) << 1)
+
+#define PIN_PA18C_SERCOM1_PAD2                     _L_(18)      /**< SERCOM1 signal: PAD2 on PA18 mux C*/
+#define MUX_PA18C_SERCOM1_PAD2                     _L_(2)      
+#define PINMUX_PA18C_SERCOM1_PAD2                  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
+#define PORT_PA18C_SERCOM1_PAD2                    (_UL_(1) << 18)
+
+#define PIN_PA30D_SERCOM1_PAD2                     _L_(30)      /**< SERCOM1 signal: PAD2 on PA30 mux D*/
+#define MUX_PA30D_SERCOM1_PAD2                     _L_(3)      
+#define PINMUX_PA30D_SERCOM1_PAD2                  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
+#define PORT_PA30D_SERCOM1_PAD2                    (_UL_(1) << 30)
+
+#define PIN_PA19C_SERCOM1_PAD3                     _L_(19)      /**< SERCOM1 signal: PAD3 on PA19 mux C*/
+#define MUX_PA19C_SERCOM1_PAD3                     _L_(2)      
+#define PINMUX_PA19C_SERCOM1_PAD3                  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
+#define PORT_PA19C_SERCOM1_PAD3                    (_UL_(1) << 19)
+
+#define PIN_PA31D_SERCOM1_PAD3                     _L_(31)      /**< SERCOM1 signal: PAD3 on PA31 mux D*/
+#define MUX_PA31D_SERCOM1_PAD3                     _L_(3)      
+#define PINMUX_PA31D_SERCOM1_PAD3                  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
+#define PORT_PA31D_SERCOM1_PAD3                    (_UL_(1) << 31)
+
+/* ========== PORT definition for TC0 peripheral ========== */
+#define PIN_PA04E_TC0_WO0                          _L_(4)       /**< TC0 signal: WO0 on PA04 mux E*/
+#define MUX_PA04E_TC0_WO0                          _L_(4)      
+#define PINMUX_PA04E_TC0_WO0                       ((PIN_PA04E_TC0_WO0 << 16) | MUX_PA04E_TC0_WO0)
+#define PORT_PA04E_TC0_WO0                         (_UL_(1) << 4)
+
+#define PIN_PA14E_TC0_WO0                          _L_(14)      /**< TC0 signal: WO0 on PA14 mux E*/
+#define MUX_PA14E_TC0_WO0                          _L_(4)      
+#define PINMUX_PA14E_TC0_WO0                       ((PIN_PA14E_TC0_WO0 << 16) | MUX_PA14E_TC0_WO0)
+#define PORT_PA14E_TC0_WO0                         (_UL_(1) << 14)
+
+#define PIN_PA22E_TC0_WO0                          _L_(22)      /**< TC0 signal: WO0 on PA22 mux E*/
+#define MUX_PA22E_TC0_WO0                          _L_(4)      
+#define PINMUX_PA22E_TC0_WO0                       ((PIN_PA22E_TC0_WO0 << 16) | MUX_PA22E_TC0_WO0)
+#define PORT_PA22E_TC0_WO0                         (_UL_(1) << 22)
+
+#define PIN_PA05E_TC0_WO1                          _L_(5)       /**< TC0 signal: WO1 on PA05 mux E*/
+#define MUX_PA05E_TC0_WO1                          _L_(4)      
+#define PINMUX_PA05E_TC0_WO1                       ((PIN_PA05E_TC0_WO1 << 16) | MUX_PA05E_TC0_WO1)
+#define PORT_PA05E_TC0_WO1                         (_UL_(1) << 5)
+
+#define PIN_PA15E_TC0_WO1                          _L_(15)      /**< TC0 signal: WO1 on PA15 mux E*/
+#define MUX_PA15E_TC0_WO1                          _L_(4)      
+#define PINMUX_PA15E_TC0_WO1                       ((PIN_PA15E_TC0_WO1 << 16) | MUX_PA15E_TC0_WO1)
+#define PORT_PA15E_TC0_WO1                         (_UL_(1) << 15)
+
+#define PIN_PA23E_TC0_WO1                          _L_(23)      /**< TC0 signal: WO1 on PA23 mux E*/
+#define MUX_PA23E_TC0_WO1                          _L_(4)      
+#define PINMUX_PA23E_TC0_WO1                       ((PIN_PA23E_TC0_WO1 << 16) | MUX_PA23E_TC0_WO1)
+#define PORT_PA23E_TC0_WO1                         (_UL_(1) << 23)
+
+/* ========== PORT definition for TC1 peripheral ========== */
+#define PIN_PA30E_TC1_WO0                          _L_(30)      /**< TC1 signal: WO0 on PA30 mux E*/
+#define MUX_PA30E_TC1_WO0                          _L_(4)      
+#define PINMUX_PA30E_TC1_WO0                       ((PIN_PA30E_TC1_WO0 << 16) | MUX_PA30E_TC1_WO0)
+#define PORT_PA30E_TC1_WO0                         (_UL_(1) << 30)
+
+#define PIN_PA31E_TC1_WO1                          _L_(31)      /**< TC1 signal: WO1 on PA31 mux E*/
+#define MUX_PA31E_TC1_WO1                          _L_(4)      
+#define PINMUX_PA31E_TC1_WO1                       ((PIN_PA31E_TC1_WO1 << 16) | MUX_PA31E_TC1_WO1)
+#define PORT_PA31E_TC1_WO1                         (_UL_(1) << 31)
+
+/* ========== PORT definition for TC2 peripheral ========== */
+#define PIN_PA00E_TC2_WO0                          _L_(0)       /**< TC2 signal: WO0 on PA00 mux E*/
+#define MUX_PA00E_TC2_WO0                          _L_(4)      
+#define PINMUX_PA00E_TC2_WO0                       ((PIN_PA00E_TC2_WO0 << 16) | MUX_PA00E_TC2_WO0)
+#define PORT_PA00E_TC2_WO0                         (_UL_(1) << 0)
+
+#define PIN_PA18E_TC2_WO0                          _L_(18)      /**< TC2 signal: WO0 on PA18 mux E*/
+#define MUX_PA18E_TC2_WO0                          _L_(4)      
+#define PINMUX_PA18E_TC2_WO0                       ((PIN_PA18E_TC2_WO0 << 16) | MUX_PA18E_TC2_WO0)
+#define PORT_PA18E_TC2_WO0                         (_UL_(1) << 18)
+
+#define PIN_PA01E_TC2_WO1                          _L_(1)       /**< TC2 signal: WO1 on PA01 mux E*/
+#define MUX_PA01E_TC2_WO1                          _L_(4)      
+#define PINMUX_PA01E_TC2_WO1                       ((PIN_PA01E_TC2_WO1 << 16) | MUX_PA01E_TC2_WO1)
+#define PORT_PA01E_TC2_WO1                         (_UL_(1) << 1)
+
+#define PIN_PA19E_TC2_WO1                          _L_(19)      /**< TC2 signal: WO1 on PA19 mux E*/
+#define MUX_PA19E_TC2_WO1                          _L_(4)      
+#define PINMUX_PA19E_TC2_WO1                       ((PIN_PA19E_TC2_WO1 << 16) | MUX_PA19E_TC2_WO1)
+#define PORT_PA19E_TC2_WO1                         (_UL_(1) << 19)
+
+
+#endif /* _SAML11D15A_PIO_H_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/pio/saml11d16a.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/pio/saml11d16a.h
@@ -1,0 +1,834 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAML11D16A
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11D16A_PIO_H_
+#define _SAML11D16A_PIO_H_
+
+/* ========== Peripheral I/O pin numbers ========== */
+#define PIN_PA00                    (  0)  /**< Pin Number for PA00 */
+#define PIN_PA01                    (  1)  /**< Pin Number for PA01 */
+#define PIN_PA02                    (  2)  /**< Pin Number for PA02 */
+#define PIN_PA03                    (  3)  /**< Pin Number for PA03 */
+#define PIN_PA04                    (  4)  /**< Pin Number for PA04 */
+#define PIN_PA05                    (  5)  /**< Pin Number for PA05 */
+#define PIN_PA08                    (  8)  /**< Pin Number for PA08 */
+#define PIN_PA14                    ( 14)  /**< Pin Number for PA14 */
+#define PIN_PA15                    ( 15)  /**< Pin Number for PA15 */
+#define PIN_PA16                    ( 16)  /**< Pin Number for PA16 */
+#define PIN_PA17                    ( 17)  /**< Pin Number for PA17 */
+#define PIN_PA18                    ( 18)  /**< Pin Number for PA18 */
+#define PIN_PA19                    ( 19)  /**< Pin Number for PA19 */
+#define PIN_PA22                    ( 22)  /**< Pin Number for PA22 */
+#define PIN_PA23                    ( 23)  /**< Pin Number for PA23 */
+#define PIN_PA30                    ( 30)  /**< Pin Number for PA30 */
+#define PIN_PA31                    ( 31)  /**< Pin Number for PA31 */
+
+
+/* ========== Peripheral I/O masks ========== */
+#define PORT_PA00                   (_U_(1) << 0) /**< PORT Mask for PA00 */
+#define PORT_PA01                   (_U_(1) << 1) /**< PORT Mask for PA01 */
+#define PORT_PA02                   (_U_(1) << 2) /**< PORT Mask for PA02 */
+#define PORT_PA03                   (_U_(1) << 3) /**< PORT Mask for PA03 */
+#define PORT_PA04                   (_U_(1) << 4) /**< PORT Mask for PA04 */
+#define PORT_PA05                   (_U_(1) << 5) /**< PORT Mask for PA05 */
+#define PORT_PA08                   (_U_(1) << 8) /**< PORT Mask for PA08 */
+#define PORT_PA14                   (_U_(1) << 14) /**< PORT Mask for PA14 */
+#define PORT_PA15                   (_U_(1) << 15) /**< PORT Mask for PA15 */
+#define PORT_PA16                   (_U_(1) << 16) /**< PORT Mask for PA16 */
+#define PORT_PA17                   (_U_(1) << 17) /**< PORT Mask for PA17 */
+#define PORT_PA18                   (_U_(1) << 18) /**< PORT Mask for PA18 */
+#define PORT_PA19                   (_U_(1) << 19) /**< PORT Mask for PA19 */
+#define PORT_PA22                   (_U_(1) << 22) /**< PORT Mask for PA22 */
+#define PORT_PA23                   (_U_(1) << 23) /**< PORT Mask for PA23 */
+#define PORT_PA30                   (_U_(1) << 30) /**< PORT Mask for PA30 */
+#define PORT_PA31                   (_U_(1) << 31) /**< PORT Mask for PA31 */
+
+
+/* ========== Peripheral I/O indexes ========== */
+#define PORT_PA00_IDX               (  0)  /**< PORT Index Number for PA00 */
+#define PORT_PA01_IDX               (  1)  /**< PORT Index Number for PA01 */
+#define PORT_PA02_IDX               (  2)  /**< PORT Index Number for PA02 */
+#define PORT_PA03_IDX               (  3)  /**< PORT Index Number for PA03 */
+#define PORT_PA04_IDX               (  4)  /**< PORT Index Number for PA04 */
+#define PORT_PA05_IDX               (  5)  /**< PORT Index Number for PA05 */
+#define PORT_PA08_IDX               (  8)  /**< PORT Index Number for PA08 */
+#define PORT_PA14_IDX               ( 14)  /**< PORT Index Number for PA14 */
+#define PORT_PA15_IDX               ( 15)  /**< PORT Index Number for PA15 */
+#define PORT_PA16_IDX               ( 16)  /**< PORT Index Number for PA16 */
+#define PORT_PA17_IDX               ( 17)  /**< PORT Index Number for PA17 */
+#define PORT_PA18_IDX               ( 18)  /**< PORT Index Number for PA18 */
+#define PORT_PA19_IDX               ( 19)  /**< PORT Index Number for PA19 */
+#define PORT_PA22_IDX               ( 22)  /**< PORT Index Number for PA22 */
+#define PORT_PA23_IDX               ( 23)  /**< PORT Index Number for PA23 */
+#define PORT_PA30_IDX               ( 30)  /**< PORT Index Number for PA30 */
+#define PORT_PA31_IDX               ( 31)  /**< PORT Index Number for PA31 */
+
+/* ========== PORT definition for AC peripheral ========== */
+#define PIN_PA04B_AC_AIN0                          _L_(4)       /**< AC signal: AIN0 on PA04 mux B*/
+#define MUX_PA04B_AC_AIN0                          _L_(1)      
+#define PINMUX_PA04B_AC_AIN0                       ((PIN_PA04B_AC_AIN0 << 16) | MUX_PA04B_AC_AIN0)
+#define PORT_PA04B_AC_AIN0                         (_UL_(1) << 4)
+
+#define PIN_PA05B_AC_AIN1                          _L_(5)       /**< AC signal: AIN1 on PA05 mux B*/
+#define MUX_PA05B_AC_AIN1                          _L_(1)      
+#define PINMUX_PA05B_AC_AIN1                       ((PIN_PA05B_AC_AIN1 << 16) | MUX_PA05B_AC_AIN1)
+#define PORT_PA05B_AC_AIN1                         (_UL_(1) << 5)
+
+#define PIN_PA18H_AC_CMP0                          _L_(18)      /**< AC signal: CMP0 on PA18 mux H*/
+#define MUX_PA18H_AC_CMP0                          _L_(7)      
+#define PINMUX_PA18H_AC_CMP0                       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
+#define PORT_PA18H_AC_CMP0                         (_UL_(1) << 18)
+
+#define PIN_PA19H_AC_CMP1                          _L_(19)      /**< AC signal: CMP1 on PA19 mux H*/
+#define MUX_PA19H_AC_CMP1                          _L_(7)      
+#define PINMUX_PA19H_AC_CMP1                       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
+#define PORT_PA19H_AC_CMP1                         (_UL_(1) << 19)
+
+/* ========== PORT definition for ADC peripheral ========== */
+#define PIN_PA02B_ADC_AIN0                         _L_(2)       /**< ADC signal: AIN0 on PA02 mux B*/
+#define MUX_PA02B_ADC_AIN0                         _L_(1)      
+#define PINMUX_PA02B_ADC_AIN0                      ((PIN_PA02B_ADC_AIN0 << 16) | MUX_PA02B_ADC_AIN0)
+#define PORT_PA02B_ADC_AIN0                        (_UL_(1) << 2)
+
+#define PIN_PA03B_ADC_AIN1                         _L_(3)       /**< ADC signal: AIN1 on PA03 mux B*/
+#define MUX_PA03B_ADC_AIN1                         _L_(1)      
+#define PINMUX_PA03B_ADC_AIN1                      ((PIN_PA03B_ADC_AIN1 << 16) | MUX_PA03B_ADC_AIN1)
+#define PORT_PA03B_ADC_AIN1                        (_UL_(1) << 3)
+
+#define PIN_PA04B_ADC_AIN2                         _L_(4)       /**< ADC signal: AIN2 on PA04 mux B*/
+#define MUX_PA04B_ADC_AIN2                         _L_(1)      
+#define PINMUX_PA04B_ADC_AIN2                      ((PIN_PA04B_ADC_AIN2 << 16) | MUX_PA04B_ADC_AIN2)
+#define PORT_PA04B_ADC_AIN2                        (_UL_(1) << 4)
+
+#define PIN_PA05B_ADC_AIN3                         _L_(5)       /**< ADC signal: AIN3 on PA05 mux B*/
+#define MUX_PA05B_ADC_AIN3                         _L_(1)      
+#define PINMUX_PA05B_ADC_AIN3                      ((PIN_PA05B_ADC_AIN3 << 16) | MUX_PA05B_ADC_AIN3)
+#define PORT_PA05B_ADC_AIN3                        (_UL_(1) << 5)
+
+#define PIN_PA08B_ADC_AIN6                         _L_(8)       /**< ADC signal: AIN6 on PA08 mux B*/
+#define MUX_PA08B_ADC_AIN6                         _L_(1)      
+#define PINMUX_PA08B_ADC_AIN6                      ((PIN_PA08B_ADC_AIN6 << 16) | MUX_PA08B_ADC_AIN6)
+#define PORT_PA08B_ADC_AIN6                        (_UL_(1) << 8)
+
+#define PIN_PA04B_ADC_VREFP                        _L_(4)       /**< ADC signal: VREFP on PA04 mux B*/
+#define MUX_PA04B_ADC_VREFP                        _L_(1)      
+#define PINMUX_PA04B_ADC_VREFP                     ((PIN_PA04B_ADC_VREFP << 16) | MUX_PA04B_ADC_VREFP)
+#define PORT_PA04B_ADC_VREFP                       (_UL_(1) << 4)
+
+/* ========== PORT definition for CCL peripheral ========== */
+#define PIN_PA04I_CCL_IN0                          _L_(4)       /**< CCL signal: IN0 on PA04 mux I*/
+#define MUX_PA04I_CCL_IN0                          _L_(8)      
+#define PINMUX_PA04I_CCL_IN0                       ((PIN_PA04I_CCL_IN0 << 16) | MUX_PA04I_CCL_IN0)
+#define PORT_PA04I_CCL_IN0                         (_UL_(1) << 4)
+
+#define PIN_PA16I_CCL_IN0                          _L_(16)      /**< CCL signal: IN0 on PA16 mux I*/
+#define MUX_PA16I_CCL_IN0                          _L_(8)      
+#define PINMUX_PA16I_CCL_IN0                       ((PIN_PA16I_CCL_IN0 << 16) | MUX_PA16I_CCL_IN0)
+#define PORT_PA16I_CCL_IN0                         (_UL_(1) << 16)
+
+#define PIN_PA05I_CCL_IN1                          _L_(5)       /**< CCL signal: IN1 on PA05 mux I*/
+#define MUX_PA05I_CCL_IN1                          _L_(8)      
+#define PINMUX_PA05I_CCL_IN1                       ((PIN_PA05I_CCL_IN1 << 16) | MUX_PA05I_CCL_IN1)
+#define PORT_PA05I_CCL_IN1                         (_UL_(1) << 5)
+
+#define PIN_PA17I_CCL_IN1                          _L_(17)      /**< CCL signal: IN1 on PA17 mux I*/
+#define MUX_PA17I_CCL_IN1                          _L_(8)      
+#define PINMUX_PA17I_CCL_IN1                       ((PIN_PA17I_CCL_IN1 << 16) | MUX_PA17I_CCL_IN1)
+#define PORT_PA17I_CCL_IN1                         (_UL_(1) << 17)
+
+#define PIN_PA18I_CCL_IN2                          _L_(18)      /**< CCL signal: IN2 on PA18 mux I*/
+#define MUX_PA18I_CCL_IN2                          _L_(8)      
+#define PINMUX_PA18I_CCL_IN2                       ((PIN_PA18I_CCL_IN2 << 16) | MUX_PA18I_CCL_IN2)
+#define PORT_PA18I_CCL_IN2                         (_UL_(1) << 18)
+
+#define PIN_PA08I_CCL_IN3                          _L_(8)       /**< CCL signal: IN3 on PA08 mux I*/
+#define MUX_PA08I_CCL_IN3                          _L_(8)      
+#define PINMUX_PA08I_CCL_IN3                       ((PIN_PA08I_CCL_IN3 << 16) | MUX_PA08I_CCL_IN3)
+#define PORT_PA08I_CCL_IN3                         (_UL_(1) << 8)
+
+#define PIN_PA30I_CCL_IN3                          _L_(30)      /**< CCL signal: IN3 on PA30 mux I*/
+#define MUX_PA30I_CCL_IN3                          _L_(8)      
+#define PINMUX_PA30I_CCL_IN3                       ((PIN_PA30I_CCL_IN3 << 16) | MUX_PA30I_CCL_IN3)
+#define PORT_PA30I_CCL_IN3                         (_UL_(1) << 30)
+
+#define PIN_PA19I_CCL_OUT0                         _L_(19)      /**< CCL signal: OUT0 on PA19 mux I*/
+#define MUX_PA19I_CCL_OUT0                         _L_(8)      
+#define PINMUX_PA19I_CCL_OUT0                      ((PIN_PA19I_CCL_OUT0 << 16) | MUX_PA19I_CCL_OUT0)
+#define PORT_PA19I_CCL_OUT0                        (_UL_(1) << 19)
+
+#define PIN_PA31I_CCL_OUT1                         _L_(31)      /**< CCL signal: OUT1 on PA31 mux I*/
+#define MUX_PA31I_CCL_OUT1                         _L_(8)      
+#define PINMUX_PA31I_CCL_OUT1                      ((PIN_PA31I_CCL_OUT1 << 16) | MUX_PA31I_CCL_OUT1)
+#define PORT_PA31I_CCL_OUT1                        (_UL_(1) << 31)
+
+/* ========== PORT definition for DAC peripheral ========== */
+#define PIN_PA02B_DAC_VOUT                         _L_(2)       /**< DAC signal: VOUT on PA02 mux B*/
+#define MUX_PA02B_DAC_VOUT                         _L_(1)      
+#define PINMUX_PA02B_DAC_VOUT                      ((PIN_PA02B_DAC_VOUT << 16) | MUX_PA02B_DAC_VOUT)
+#define PORT_PA02B_DAC_VOUT                        (_UL_(1) << 2)
+
+#define PIN_PA03B_DAC_VREFP                        _L_(3)       /**< DAC signal: VREFP on PA03 mux B*/
+#define MUX_PA03B_DAC_VREFP                        _L_(1)      
+#define PINMUX_PA03B_DAC_VREFP                     ((PIN_PA03B_DAC_VREFP << 16) | MUX_PA03B_DAC_VREFP)
+#define PORT_PA03B_DAC_VREFP                       (_UL_(1) << 3)
+
+/* ========== PORT definition for EIC peripheral ========== */
+#define PIN_PA19A_EIC_EXTINT0                      _L_(19)      /**< EIC signal: EXTINT0 on PA19 mux A*/
+#define MUX_PA19A_EIC_EXTINT0                      _L_(0)      
+#define PINMUX_PA19A_EIC_EXTINT0                   ((PIN_PA19A_EIC_EXTINT0 << 16) | MUX_PA19A_EIC_EXTINT0)
+#define PORT_PA19A_EIC_EXTINT0                     (_UL_(1) << 19)
+#define PIN_PA19A_EIC_EXTINT_NUM                   _L_(0)       /**< EIC signal: PIN_PA19 External Interrupt Line */
+
+#define PIN_PA00A_EIC_EXTINT0                      _L_(0)       /**< EIC signal: EXTINT0 on PA00 mux A*/
+#define MUX_PA00A_EIC_EXTINT0                      _L_(0)      
+#define PINMUX_PA00A_EIC_EXTINT0                   ((PIN_PA00A_EIC_EXTINT0 << 16) | MUX_PA00A_EIC_EXTINT0)
+#define PORT_PA00A_EIC_EXTINT0                     (_UL_(1) << 0)
+#define PIN_PA00A_EIC_EXTINT_NUM                   _L_(0)       /**< EIC signal: PIN_PA00 External Interrupt Line */
+
+#define PIN_PA22A_EIC_EXTINT1                      _L_(22)      /**< EIC signal: EXTINT1 on PA22 mux A*/
+#define MUX_PA22A_EIC_EXTINT1                      _L_(0)      
+#define PINMUX_PA22A_EIC_EXTINT1                   ((PIN_PA22A_EIC_EXTINT1 << 16) | MUX_PA22A_EIC_EXTINT1)
+#define PORT_PA22A_EIC_EXTINT1                     (_UL_(1) << 22)
+#define PIN_PA22A_EIC_EXTINT_NUM                   _L_(1)       /**< EIC signal: PIN_PA22 External Interrupt Line */
+
+#define PIN_PA01A_EIC_EXTINT1                      _L_(1)       /**< EIC signal: EXTINT1 on PA01 mux A*/
+#define MUX_PA01A_EIC_EXTINT1                      _L_(0)      
+#define PINMUX_PA01A_EIC_EXTINT1                   ((PIN_PA01A_EIC_EXTINT1 << 16) | MUX_PA01A_EIC_EXTINT1)
+#define PORT_PA01A_EIC_EXTINT1                     (_UL_(1) << 1)
+#define PIN_PA01A_EIC_EXTINT_NUM                   _L_(1)       /**< EIC signal: PIN_PA01 External Interrupt Line */
+
+#define PIN_PA02A_EIC_EXTINT2                      _L_(2)       /**< EIC signal: EXTINT2 on PA02 mux A*/
+#define MUX_PA02A_EIC_EXTINT2                      _L_(0)      
+#define PINMUX_PA02A_EIC_EXTINT2                   ((PIN_PA02A_EIC_EXTINT2 << 16) | MUX_PA02A_EIC_EXTINT2)
+#define PORT_PA02A_EIC_EXTINT2                     (_UL_(1) << 2)
+#define PIN_PA02A_EIC_EXTINT_NUM                   _L_(2)       /**< EIC signal: PIN_PA02 External Interrupt Line */
+
+#define PIN_PA23A_EIC_EXTINT2                      _L_(23)      /**< EIC signal: EXTINT2 on PA23 mux A*/
+#define MUX_PA23A_EIC_EXTINT2                      _L_(0)      
+#define PINMUX_PA23A_EIC_EXTINT2                   ((PIN_PA23A_EIC_EXTINT2 << 16) | MUX_PA23A_EIC_EXTINT2)
+#define PORT_PA23A_EIC_EXTINT2                     (_UL_(1) << 23)
+#define PIN_PA23A_EIC_EXTINT_NUM                   _L_(2)       /**< EIC signal: PIN_PA23 External Interrupt Line */
+
+#define PIN_PA03A_EIC_EXTINT3                      _L_(3)       /**< EIC signal: EXTINT3 on PA03 mux A*/
+#define MUX_PA03A_EIC_EXTINT3                      _L_(0)      
+#define PINMUX_PA03A_EIC_EXTINT3                   ((PIN_PA03A_EIC_EXTINT3 << 16) | MUX_PA03A_EIC_EXTINT3)
+#define PORT_PA03A_EIC_EXTINT3                     (_UL_(1) << 3)
+#define PIN_PA03A_EIC_EXTINT_NUM                   _L_(3)       /**< EIC signal: PIN_PA03 External Interrupt Line */
+
+#define PIN_PA14A_EIC_EXTINT3                      _L_(14)      /**< EIC signal: EXTINT3 on PA14 mux A*/
+#define MUX_PA14A_EIC_EXTINT3                      _L_(0)      
+#define PINMUX_PA14A_EIC_EXTINT3                   ((PIN_PA14A_EIC_EXTINT3 << 16) | MUX_PA14A_EIC_EXTINT3)
+#define PORT_PA14A_EIC_EXTINT3                     (_UL_(1) << 14)
+#define PIN_PA14A_EIC_EXTINT_NUM                   _L_(3)       /**< EIC signal: PIN_PA14 External Interrupt Line */
+
+#define PIN_PA04A_EIC_EXTINT4                      _L_(4)       /**< EIC signal: EXTINT4 on PA04 mux A*/
+#define MUX_PA04A_EIC_EXTINT4                      _L_(0)      
+#define PINMUX_PA04A_EIC_EXTINT4                   ((PIN_PA04A_EIC_EXTINT4 << 16) | MUX_PA04A_EIC_EXTINT4)
+#define PORT_PA04A_EIC_EXTINT4                     (_UL_(1) << 4)
+#define PIN_PA04A_EIC_EXTINT_NUM                   _L_(4)       /**< EIC signal: PIN_PA04 External Interrupt Line */
+
+#define PIN_PA15A_EIC_EXTINT4                      _L_(15)      /**< EIC signal: EXTINT4 on PA15 mux A*/
+#define MUX_PA15A_EIC_EXTINT4                      _L_(0)      
+#define PINMUX_PA15A_EIC_EXTINT4                   ((PIN_PA15A_EIC_EXTINT4 << 16) | MUX_PA15A_EIC_EXTINT4)
+#define PORT_PA15A_EIC_EXTINT4                     (_UL_(1) << 15)
+#define PIN_PA15A_EIC_EXTINT_NUM                   _L_(4)       /**< EIC signal: PIN_PA15 External Interrupt Line */
+
+#define PIN_PA05A_EIC_EXTINT5                      _L_(5)       /**< EIC signal: EXTINT5 on PA05 mux A*/
+#define MUX_PA05A_EIC_EXTINT5                      _L_(0)      
+#define PINMUX_PA05A_EIC_EXTINT5                   ((PIN_PA05A_EIC_EXTINT5 << 16) | MUX_PA05A_EIC_EXTINT5)
+#define PORT_PA05A_EIC_EXTINT5                     (_UL_(1) << 5)
+#define PIN_PA05A_EIC_EXTINT_NUM                   _L_(5)       /**< EIC signal: PIN_PA05 External Interrupt Line */
+
+#define PIN_PA16A_EIC_EXTINT5                      _L_(16)      /**< EIC signal: EXTINT5 on PA16 mux A*/
+#define MUX_PA16A_EIC_EXTINT5                      _L_(0)      
+#define PINMUX_PA16A_EIC_EXTINT5                   ((PIN_PA16A_EIC_EXTINT5 << 16) | MUX_PA16A_EIC_EXTINT5)
+#define PORT_PA16A_EIC_EXTINT5                     (_UL_(1) << 16)
+#define PIN_PA16A_EIC_EXTINT_NUM                   _L_(5)       /**< EIC signal: PIN_PA16 External Interrupt Line */
+
+#define PIN_PA17A_EIC_EXTINT6                      _L_(17)      /**< EIC signal: EXTINT6 on PA17 mux A*/
+#define MUX_PA17A_EIC_EXTINT6                      _L_(0)      
+#define PINMUX_PA17A_EIC_EXTINT6                   ((PIN_PA17A_EIC_EXTINT6 << 16) | MUX_PA17A_EIC_EXTINT6)
+#define PORT_PA17A_EIC_EXTINT6                     (_UL_(1) << 17)
+#define PIN_PA17A_EIC_EXTINT_NUM                   _L_(6)       /**< EIC signal: PIN_PA17 External Interrupt Line */
+
+#define PIN_PA30A_EIC_EXTINT6                      _L_(30)      /**< EIC signal: EXTINT6 on PA30 mux A*/
+#define MUX_PA30A_EIC_EXTINT6                      _L_(0)      
+#define PINMUX_PA30A_EIC_EXTINT6                   ((PIN_PA30A_EIC_EXTINT6 << 16) | MUX_PA30A_EIC_EXTINT6)
+#define PORT_PA30A_EIC_EXTINT6                     (_UL_(1) << 30)
+#define PIN_PA30A_EIC_EXTINT_NUM                   _L_(6)       /**< EIC signal: PIN_PA30 External Interrupt Line */
+
+#define PIN_PA18A_EIC_EXTINT7                      _L_(18)      /**< EIC signal: EXTINT7 on PA18 mux A*/
+#define MUX_PA18A_EIC_EXTINT7                      _L_(0)      
+#define PINMUX_PA18A_EIC_EXTINT7                   ((PIN_PA18A_EIC_EXTINT7 << 16) | MUX_PA18A_EIC_EXTINT7)
+#define PORT_PA18A_EIC_EXTINT7                     (_UL_(1) << 18)
+#define PIN_PA18A_EIC_EXTINT_NUM                   _L_(7)       /**< EIC signal: PIN_PA18 External Interrupt Line */
+
+#define PIN_PA31A_EIC_EXTINT7                      _L_(31)      /**< EIC signal: EXTINT7 on PA31 mux A*/
+#define MUX_PA31A_EIC_EXTINT7                      _L_(0)      
+#define PINMUX_PA31A_EIC_EXTINT7                   ((PIN_PA31A_EIC_EXTINT7 << 16) | MUX_PA31A_EIC_EXTINT7)
+#define PORT_PA31A_EIC_EXTINT7                     (_UL_(1) << 31)
+#define PIN_PA31A_EIC_EXTINT_NUM                   _L_(7)       /**< EIC signal: PIN_PA31 External Interrupt Line */
+
+#define PIN_PA08A_EIC_NMI                          _L_(8)       /**< EIC signal: NMI on PA08 mux A*/
+#define MUX_PA08A_EIC_NMI                          _L_(0)      
+#define PINMUX_PA08A_EIC_NMI                       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
+#define PORT_PA08A_EIC_NMI                         (_UL_(1) << 8)
+
+/* ========== PORT definition for GCLK peripheral ========== */
+#define PIN_PA30H_GCLK_IO0                         _L_(30)      /**< GCLK signal: IO0 on PA30 mux H*/
+#define MUX_PA30H_GCLK_IO0                         _L_(7)      
+#define PINMUX_PA30H_GCLK_IO0                      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
+#define PORT_PA30H_GCLK_IO0                        (_UL_(1) << 30)
+
+#define PIN_PA14H_GCLK_IO0                         _L_(14)      /**< GCLK signal: IO0 on PA14 mux H*/
+#define MUX_PA14H_GCLK_IO0                         _L_(7)      
+#define PINMUX_PA14H_GCLK_IO0                      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
+#define PORT_PA14H_GCLK_IO0                        (_UL_(1) << 14)
+
+#define PIN_PA23H_GCLK_IO1                         _L_(23)      /**< GCLK signal: IO1 on PA23 mux H*/
+#define MUX_PA23H_GCLK_IO1                         _L_(7)      
+#define PINMUX_PA23H_GCLK_IO1                      ((PIN_PA23H_GCLK_IO1 << 16) | MUX_PA23H_GCLK_IO1)
+#define PORT_PA23H_GCLK_IO1                        (_UL_(1) << 23)
+
+#define PIN_PA15H_GCLK_IO1                         _L_(15)      /**< GCLK signal: IO1 on PA15 mux H*/
+#define MUX_PA15H_GCLK_IO1                         _L_(7)      
+#define PINMUX_PA15H_GCLK_IO1                      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
+#define PORT_PA15H_GCLK_IO1                        (_UL_(1) << 15)
+
+#define PIN_PA16H_GCLK_IO2                         _L_(16)      /**< GCLK signal: IO2 on PA16 mux H*/
+#define MUX_PA16H_GCLK_IO2                         _L_(7)      
+#define PINMUX_PA16H_GCLK_IO2                      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
+#define PORT_PA16H_GCLK_IO2                        (_UL_(1) << 16)
+
+#define PIN_PA22H_GCLK_IO2                         _L_(22)      /**< GCLK signal: IO2 on PA22 mux H*/
+#define MUX_PA22H_GCLK_IO2                         _L_(7)      
+#define PINMUX_PA22H_GCLK_IO2                      ((PIN_PA22H_GCLK_IO2 << 16) | MUX_PA22H_GCLK_IO2)
+#define PORT_PA22H_GCLK_IO2                        (_UL_(1) << 22)
+
+#define PIN_PA17H_GCLK_IO3                         _L_(17)      /**< GCLK signal: IO3 on PA17 mux H*/
+#define MUX_PA17H_GCLK_IO3                         _L_(7)      
+#define PINMUX_PA17H_GCLK_IO3                      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
+#define PORT_PA17H_GCLK_IO3                        (_UL_(1) << 17)
+
+/* ========== PORT definition for OPAMP peripheral ========== */
+#define PIN_PA02B_OPAMP_OANEG0                     _L_(2)       /**< OPAMP signal: OANEG0 on PA02 mux B*/
+#define MUX_PA02B_OPAMP_OANEG0                     _L_(1)      
+#define PINMUX_PA02B_OPAMP_OANEG0                  ((PIN_PA02B_OPAMP_OANEG0 << 16) | MUX_PA02B_OPAMP_OANEG0)
+#define PORT_PA02B_OPAMP_OANEG0                    (_UL_(1) << 2)
+
+#define PIN_PA00B_OPAMP_OANEG1                     _L_(0)       /**< OPAMP signal: OANEG1 on PA00 mux B*/
+#define MUX_PA00B_OPAMP_OANEG1                     _L_(1)      
+#define PINMUX_PA00B_OPAMP_OANEG1                  ((PIN_PA00B_OPAMP_OANEG1 << 16) | MUX_PA00B_OPAMP_OANEG1)
+#define PORT_PA00B_OPAMP_OANEG1                    (_UL_(1) << 0)
+
+#define PIN_PA03B_OPAMP_OANEG2                     _L_(3)       /**< OPAMP signal: OANEG2 on PA03 mux B*/
+#define MUX_PA03B_OPAMP_OANEG2                     _L_(1)      
+#define PINMUX_PA03B_OPAMP_OANEG2                  ((PIN_PA03B_OPAMP_OANEG2 << 16) | MUX_PA03B_OPAMP_OANEG2)
+#define PORT_PA03B_OPAMP_OANEG2                    (_UL_(1) << 3)
+
+#define PIN_PA04B_OPAMP_OAOUT2                     _L_(4)       /**< OPAMP signal: OAOUT2 on PA04 mux B*/
+#define MUX_PA04B_OPAMP_OAOUT2                     _L_(1)      
+#define PINMUX_PA04B_OPAMP_OAOUT2                  ((PIN_PA04B_OPAMP_OAOUT2 << 16) | MUX_PA04B_OPAMP_OAOUT2)
+#define PORT_PA04B_OPAMP_OAOUT2                    (_UL_(1) << 4)
+
+#define PIN_PA01B_OPAMP_OAPOS1                     _L_(1)       /**< OPAMP signal: OAPOS1 on PA01 mux B*/
+#define MUX_PA01B_OPAMP_OAPOS1                     _L_(1)      
+#define PINMUX_PA01B_OPAMP_OAPOS1                  ((PIN_PA01B_OPAMP_OAPOS1 << 16) | MUX_PA01B_OPAMP_OAPOS1)
+#define PORT_PA01B_OPAMP_OAPOS1                    (_UL_(1) << 1)
+
+#define PIN_PA05B_OPAMP_OAPOS2                     _L_(5)       /**< OPAMP signal: OAPOS2 on PA05 mux B*/
+#define MUX_PA05B_OPAMP_OAPOS2                     _L_(1)      
+#define PINMUX_PA05B_OPAMP_OAPOS2                  ((PIN_PA05B_OPAMP_OAPOS2 << 16) | MUX_PA05B_OPAMP_OAPOS2)
+#define PORT_PA05B_OPAMP_OAPOS2                    (_UL_(1) << 5)
+
+/* ========== PORT definition for PTC peripheral ========== */
+#define PIN_PA00F_PTC_DRV0                         _L_(0)       /**< PTC signal: DRV0 on PA00 mux F*/
+#define MUX_PA00F_PTC_DRV0                         _L_(5)      
+#define PINMUX_PA00F_PTC_DRV0                      ((PIN_PA00F_PTC_DRV0 << 16) | MUX_PA00F_PTC_DRV0)
+#define PORT_PA00F_PTC_DRV0                        (_UL_(1) << 0)
+
+#define PIN_PA01F_PTC_DRV1                         _L_(1)       /**< PTC signal: DRV1 on PA01 mux F*/
+#define MUX_PA01F_PTC_DRV1                         _L_(5)      
+#define PINMUX_PA01F_PTC_DRV1                      ((PIN_PA01F_PTC_DRV1 << 16) | MUX_PA01F_PTC_DRV1)
+#define PORT_PA01F_PTC_DRV1                        (_UL_(1) << 1)
+
+#define PIN_PA02F_PTC_DRV2                         _L_(2)       /**< PTC signal: DRV2 on PA02 mux F*/
+#define MUX_PA02F_PTC_DRV2                         _L_(5)      
+#define PINMUX_PA02F_PTC_DRV2                      ((PIN_PA02F_PTC_DRV2 << 16) | MUX_PA02F_PTC_DRV2)
+#define PORT_PA02F_PTC_DRV2                        (_UL_(1) << 2)
+
+#define PIN_PA03F_PTC_DRV3                         _L_(3)       /**< PTC signal: DRV3 on PA03 mux F*/
+#define MUX_PA03F_PTC_DRV3                         _L_(5)      
+#define PINMUX_PA03F_PTC_DRV3                      ((PIN_PA03F_PTC_DRV3 << 16) | MUX_PA03F_PTC_DRV3)
+#define PORT_PA03F_PTC_DRV3                        (_UL_(1) << 3)
+
+#define PIN_PA05F_PTC_DRV4                         _L_(5)       /**< PTC signal: DRV4 on PA05 mux F*/
+#define MUX_PA05F_PTC_DRV4                         _L_(5)      
+#define PINMUX_PA05F_PTC_DRV4                      ((PIN_PA05F_PTC_DRV4 << 16) | MUX_PA05F_PTC_DRV4)
+#define PORT_PA05F_PTC_DRV4                        (_UL_(1) << 5)
+
+#define PIN_PA08F_PTC_DRV6                         _L_(8)       /**< PTC signal: DRV6 on PA08 mux F*/
+#define MUX_PA08F_PTC_DRV6                         _L_(5)      
+#define PINMUX_PA08F_PTC_DRV6                      ((PIN_PA08F_PTC_DRV6 << 16) | MUX_PA08F_PTC_DRV6)
+#define PORT_PA08F_PTC_DRV6                        (_UL_(1) << 8)
+
+#define PIN_PA14F_PTC_DRV10                        _L_(14)      /**< PTC signal: DRV10 on PA14 mux F*/
+#define MUX_PA14F_PTC_DRV10                        _L_(5)      
+#define PINMUX_PA14F_PTC_DRV10                     ((PIN_PA14F_PTC_DRV10 << 16) | MUX_PA14F_PTC_DRV10)
+#define PORT_PA14F_PTC_DRV10                       (_UL_(1) << 14)
+
+#define PIN_PA15F_PTC_DRV11                        _L_(15)      /**< PTC signal: DRV11 on PA15 mux F*/
+#define MUX_PA15F_PTC_DRV11                        _L_(5)      
+#define PINMUX_PA15F_PTC_DRV11                     ((PIN_PA15F_PTC_DRV11 << 16) | MUX_PA15F_PTC_DRV11)
+#define PORT_PA15F_PTC_DRV11                       (_UL_(1) << 15)
+
+#define PIN_PA16F_PTC_DRV12                        _L_(16)      /**< PTC signal: DRV12 on PA16 mux F*/
+#define MUX_PA16F_PTC_DRV12                        _L_(5)      
+#define PINMUX_PA16F_PTC_DRV12                     ((PIN_PA16F_PTC_DRV12 << 16) | MUX_PA16F_PTC_DRV12)
+#define PORT_PA16F_PTC_DRV12                       (_UL_(1) << 16)
+
+#define PIN_PA17F_PTC_DRV13                        _L_(17)      /**< PTC signal: DRV13 on PA17 mux F*/
+#define MUX_PA17F_PTC_DRV13                        _L_(5)      
+#define PINMUX_PA17F_PTC_DRV13                     ((PIN_PA17F_PTC_DRV13 << 16) | MUX_PA17F_PTC_DRV13)
+#define PORT_PA17F_PTC_DRV13                       (_UL_(1) << 17)
+
+#define PIN_PA18F_PTC_DRV14                        _L_(18)      /**< PTC signal: DRV14 on PA18 mux F*/
+#define MUX_PA18F_PTC_DRV14                        _L_(5)      
+#define PINMUX_PA18F_PTC_DRV14                     ((PIN_PA18F_PTC_DRV14 << 16) | MUX_PA18F_PTC_DRV14)
+#define PORT_PA18F_PTC_DRV14                       (_UL_(1) << 18)
+
+#define PIN_PA19F_PTC_DRV15                        _L_(19)      /**< PTC signal: DRV15 on PA19 mux F*/
+#define MUX_PA19F_PTC_DRV15                        _L_(5)      
+#define PINMUX_PA19F_PTC_DRV15                     ((PIN_PA19F_PTC_DRV15 << 16) | MUX_PA19F_PTC_DRV15)
+#define PORT_PA19F_PTC_DRV15                       (_UL_(1) << 19)
+
+#define PIN_PA22F_PTC_DRV16                        _L_(22)      /**< PTC signal: DRV16 on PA22 mux F*/
+#define MUX_PA22F_PTC_DRV16                        _L_(5)      
+#define PINMUX_PA22F_PTC_DRV16                     ((PIN_PA22F_PTC_DRV16 << 16) | MUX_PA22F_PTC_DRV16)
+#define PORT_PA22F_PTC_DRV16                       (_UL_(1) << 22)
+
+#define PIN_PA23F_PTC_DRV17                        _L_(23)      /**< PTC signal: DRV17 on PA23 mux F*/
+#define MUX_PA23F_PTC_DRV17                        _L_(5)      
+#define PINMUX_PA23F_PTC_DRV17                     ((PIN_PA23F_PTC_DRV17 << 16) | MUX_PA23F_PTC_DRV17)
+#define PORT_PA23F_PTC_DRV17                       (_UL_(1) << 23)
+
+#define PIN_PA30F_PTC_DRV18                        _L_(30)      /**< PTC signal: DRV18 on PA30 mux F*/
+#define MUX_PA30F_PTC_DRV18                        _L_(5)      
+#define PINMUX_PA30F_PTC_DRV18                     ((PIN_PA30F_PTC_DRV18 << 16) | MUX_PA30F_PTC_DRV18)
+#define PORT_PA30F_PTC_DRV18                       (_UL_(1) << 30)
+
+#define PIN_PA31F_PTC_DRV19                        _L_(31)      /**< PTC signal: DRV19 on PA31 mux F*/
+#define MUX_PA31F_PTC_DRV19                        _L_(5)      
+#define PINMUX_PA31F_PTC_DRV19                     ((PIN_PA31F_PTC_DRV19 << 16) | MUX_PA31F_PTC_DRV19)
+#define PORT_PA31F_PTC_DRV19                       (_UL_(1) << 31)
+
+#define PIN_PA03B_PTC_ECI0                         _L_(3)       /**< PTC signal: ECI0 on PA03 mux B*/
+#define MUX_PA03B_PTC_ECI0                         _L_(1)      
+#define PINMUX_PA03B_PTC_ECI0                      ((PIN_PA03B_PTC_ECI0 << 16) | MUX_PA03B_PTC_ECI0)
+#define PORT_PA03B_PTC_ECI0                        (_UL_(1) << 3)
+
+#define PIN_PA04B_PTC_ECI1                         _L_(4)       /**< PTC signal: ECI1 on PA04 mux B*/
+#define MUX_PA04B_PTC_ECI1                         _L_(1)      
+#define PINMUX_PA04B_PTC_ECI1                      ((PIN_PA04B_PTC_ECI1 << 16) | MUX_PA04B_PTC_ECI1)
+#define PORT_PA04B_PTC_ECI1                        (_UL_(1) << 4)
+
+#define PIN_PA05B_PTC_ECI2                         _L_(5)       /**< PTC signal: ECI2 on PA05 mux B*/
+#define MUX_PA05B_PTC_ECI2                         _L_(1)      
+#define PINMUX_PA05B_PTC_ECI2                      ((PIN_PA05B_PTC_ECI2 << 16) | MUX_PA05B_PTC_ECI2)
+#define PORT_PA05B_PTC_ECI2                        (_UL_(1) << 5)
+
+#define PIN_PA00B_PTC_X0                           _L_(0)       /**< PTC signal: X0 on PA00 mux B*/
+#define MUX_PA00B_PTC_X0                           _L_(1)      
+#define PINMUX_PA00B_PTC_X0                        ((PIN_PA00B_PTC_X0 << 16) | MUX_PA00B_PTC_X0)
+#define PORT_PA00B_PTC_X0                          (_UL_(1) << 0)
+
+#define PIN_PA00B_PTC_Y0                           _L_(0)       /**< PTC signal: Y0 on PA00 mux B*/
+#define MUX_PA00B_PTC_Y0                           _L_(1)      
+#define PINMUX_PA00B_PTC_Y0                        ((PIN_PA00B_PTC_Y0 << 16) | MUX_PA00B_PTC_Y0)
+#define PORT_PA00B_PTC_Y0                          (_UL_(1) << 0)
+
+#define PIN_PA01B_PTC_X1                           _L_(1)       /**< PTC signal: X1 on PA01 mux B*/
+#define MUX_PA01B_PTC_X1                           _L_(1)      
+#define PINMUX_PA01B_PTC_X1                        ((PIN_PA01B_PTC_X1 << 16) | MUX_PA01B_PTC_X1)
+#define PORT_PA01B_PTC_X1                          (_UL_(1) << 1)
+
+#define PIN_PA01B_PTC_Y1                           _L_(1)       /**< PTC signal: Y1 on PA01 mux B*/
+#define MUX_PA01B_PTC_Y1                           _L_(1)      
+#define PINMUX_PA01B_PTC_Y1                        ((PIN_PA01B_PTC_Y1 << 16) | MUX_PA01B_PTC_Y1)
+#define PORT_PA01B_PTC_Y1                          (_UL_(1) << 1)
+
+#define PIN_PA02B_PTC_X2                           _L_(2)       /**< PTC signal: X2 on PA02 mux B*/
+#define MUX_PA02B_PTC_X2                           _L_(1)      
+#define PINMUX_PA02B_PTC_X2                        ((PIN_PA02B_PTC_X2 << 16) | MUX_PA02B_PTC_X2)
+#define PORT_PA02B_PTC_X2                          (_UL_(1) << 2)
+
+#define PIN_PA02B_PTC_Y2                           _L_(2)       /**< PTC signal: Y2 on PA02 mux B*/
+#define MUX_PA02B_PTC_Y2                           _L_(1)      
+#define PINMUX_PA02B_PTC_Y2                        ((PIN_PA02B_PTC_Y2 << 16) | MUX_PA02B_PTC_Y2)
+#define PORT_PA02B_PTC_Y2                          (_UL_(1) << 2)
+
+#define PIN_PA03B_PTC_X3                           _L_(3)       /**< PTC signal: X3 on PA03 mux B*/
+#define MUX_PA03B_PTC_X3                           _L_(1)      
+#define PINMUX_PA03B_PTC_X3                        ((PIN_PA03B_PTC_X3 << 16) | MUX_PA03B_PTC_X3)
+#define PORT_PA03B_PTC_X3                          (_UL_(1) << 3)
+
+#define PIN_PA03B_PTC_Y3                           _L_(3)       /**< PTC signal: Y3 on PA03 mux B*/
+#define MUX_PA03B_PTC_Y3                           _L_(1)      
+#define PINMUX_PA03B_PTC_Y3                        ((PIN_PA03B_PTC_Y3 << 16) | MUX_PA03B_PTC_Y3)
+#define PORT_PA03B_PTC_Y3                          (_UL_(1) << 3)
+
+#define PIN_PA05B_PTC_X4                           _L_(5)       /**< PTC signal: X4 on PA05 mux B*/
+#define MUX_PA05B_PTC_X4                           _L_(1)      
+#define PINMUX_PA05B_PTC_X4                        ((PIN_PA05B_PTC_X4 << 16) | MUX_PA05B_PTC_X4)
+#define PORT_PA05B_PTC_X4                          (_UL_(1) << 5)
+
+#define PIN_PA05B_PTC_Y4                           _L_(5)       /**< PTC signal: Y4 on PA05 mux B*/
+#define MUX_PA05B_PTC_Y4                           _L_(1)      
+#define PINMUX_PA05B_PTC_Y4                        ((PIN_PA05B_PTC_Y4 << 16) | MUX_PA05B_PTC_Y4)
+#define PORT_PA05B_PTC_Y4                          (_UL_(1) << 5)
+
+#define PIN_PA08B_PTC_X6                           _L_(8)       /**< PTC signal: X6 on PA08 mux B*/
+#define MUX_PA08B_PTC_X6                           _L_(1)      
+#define PINMUX_PA08B_PTC_X6                        ((PIN_PA08B_PTC_X6 << 16) | MUX_PA08B_PTC_X6)
+#define PORT_PA08B_PTC_X6                          (_UL_(1) << 8)
+
+#define PIN_PA08B_PTC_Y6                           _L_(8)       /**< PTC signal: Y6 on PA08 mux B*/
+#define MUX_PA08B_PTC_Y6                           _L_(1)      
+#define PINMUX_PA08B_PTC_Y6                        ((PIN_PA08B_PTC_Y6 << 16) | MUX_PA08B_PTC_Y6)
+#define PORT_PA08B_PTC_Y6                          (_UL_(1) << 8)
+
+#define PIN_PA14B_PTC_X10                          _L_(14)      /**< PTC signal: X10 on PA14 mux B*/
+#define MUX_PA14B_PTC_X10                          _L_(1)      
+#define PINMUX_PA14B_PTC_X10                       ((PIN_PA14B_PTC_X10 << 16) | MUX_PA14B_PTC_X10)
+#define PORT_PA14B_PTC_X10                         (_UL_(1) << 14)
+
+#define PIN_PA14B_PTC_Y10                          _L_(14)      /**< PTC signal: Y10 on PA14 mux B*/
+#define MUX_PA14B_PTC_Y10                          _L_(1)      
+#define PINMUX_PA14B_PTC_Y10                       ((PIN_PA14B_PTC_Y10 << 16) | MUX_PA14B_PTC_Y10)
+#define PORT_PA14B_PTC_Y10                         (_UL_(1) << 14)
+
+#define PIN_PA15B_PTC_X11                          _L_(15)      /**< PTC signal: X11 on PA15 mux B*/
+#define MUX_PA15B_PTC_X11                          _L_(1)      
+#define PINMUX_PA15B_PTC_X11                       ((PIN_PA15B_PTC_X11 << 16) | MUX_PA15B_PTC_X11)
+#define PORT_PA15B_PTC_X11                         (_UL_(1) << 15)
+
+#define PIN_PA15B_PTC_Y11                          _L_(15)      /**< PTC signal: Y11 on PA15 mux B*/
+#define MUX_PA15B_PTC_Y11                          _L_(1)      
+#define PINMUX_PA15B_PTC_Y11                       ((PIN_PA15B_PTC_Y11 << 16) | MUX_PA15B_PTC_Y11)
+#define PORT_PA15B_PTC_Y11                         (_UL_(1) << 15)
+
+#define PIN_PA16B_PTC_X12                          _L_(16)      /**< PTC signal: X12 on PA16 mux B*/
+#define MUX_PA16B_PTC_X12                          _L_(1)      
+#define PINMUX_PA16B_PTC_X12                       ((PIN_PA16B_PTC_X12 << 16) | MUX_PA16B_PTC_X12)
+#define PORT_PA16B_PTC_X12                         (_UL_(1) << 16)
+
+#define PIN_PA16B_PTC_Y12                          _L_(16)      /**< PTC signal: Y12 on PA16 mux B*/
+#define MUX_PA16B_PTC_Y12                          _L_(1)      
+#define PINMUX_PA16B_PTC_Y12                       ((PIN_PA16B_PTC_Y12 << 16) | MUX_PA16B_PTC_Y12)
+#define PORT_PA16B_PTC_Y12                         (_UL_(1) << 16)
+
+#define PIN_PA17B_PTC_X13                          _L_(17)      /**< PTC signal: X13 on PA17 mux B*/
+#define MUX_PA17B_PTC_X13                          _L_(1)      
+#define PINMUX_PA17B_PTC_X13                       ((PIN_PA17B_PTC_X13 << 16) | MUX_PA17B_PTC_X13)
+#define PORT_PA17B_PTC_X13                         (_UL_(1) << 17)
+
+#define PIN_PA17B_PTC_Y13                          _L_(17)      /**< PTC signal: Y13 on PA17 mux B*/
+#define MUX_PA17B_PTC_Y13                          _L_(1)      
+#define PINMUX_PA17B_PTC_Y13                       ((PIN_PA17B_PTC_Y13 << 16) | MUX_PA17B_PTC_Y13)
+#define PORT_PA17B_PTC_Y13                         (_UL_(1) << 17)
+
+#define PIN_PA18B_PTC_X14                          _L_(18)      /**< PTC signal: X14 on PA18 mux B*/
+#define MUX_PA18B_PTC_X14                          _L_(1)      
+#define PINMUX_PA18B_PTC_X14                       ((PIN_PA18B_PTC_X14 << 16) | MUX_PA18B_PTC_X14)
+#define PORT_PA18B_PTC_X14                         (_UL_(1) << 18)
+
+#define PIN_PA18B_PTC_Y14                          _L_(18)      /**< PTC signal: Y14 on PA18 mux B*/
+#define MUX_PA18B_PTC_Y14                          _L_(1)      
+#define PINMUX_PA18B_PTC_Y14                       ((PIN_PA18B_PTC_Y14 << 16) | MUX_PA18B_PTC_Y14)
+#define PORT_PA18B_PTC_Y14                         (_UL_(1) << 18)
+
+#define PIN_PA19B_PTC_X15                          _L_(19)      /**< PTC signal: X15 on PA19 mux B*/
+#define MUX_PA19B_PTC_X15                          _L_(1)      
+#define PINMUX_PA19B_PTC_X15                       ((PIN_PA19B_PTC_X15 << 16) | MUX_PA19B_PTC_X15)
+#define PORT_PA19B_PTC_X15                         (_UL_(1) << 19)
+
+#define PIN_PA19B_PTC_Y15                          _L_(19)      /**< PTC signal: Y15 on PA19 mux B*/
+#define MUX_PA19B_PTC_Y15                          _L_(1)      
+#define PINMUX_PA19B_PTC_Y15                       ((PIN_PA19B_PTC_Y15 << 16) | MUX_PA19B_PTC_Y15)
+#define PORT_PA19B_PTC_Y15                         (_UL_(1) << 19)
+
+#define PIN_PA22B_PTC_X16                          _L_(22)      /**< PTC signal: X16 on PA22 mux B*/
+#define MUX_PA22B_PTC_X16                          _L_(1)      
+#define PINMUX_PA22B_PTC_X16                       ((PIN_PA22B_PTC_X16 << 16) | MUX_PA22B_PTC_X16)
+#define PORT_PA22B_PTC_X16                         (_UL_(1) << 22)
+
+#define PIN_PA22B_PTC_Y16                          _L_(22)      /**< PTC signal: Y16 on PA22 mux B*/
+#define MUX_PA22B_PTC_Y16                          _L_(1)      
+#define PINMUX_PA22B_PTC_Y16                       ((PIN_PA22B_PTC_Y16 << 16) | MUX_PA22B_PTC_Y16)
+#define PORT_PA22B_PTC_Y16                         (_UL_(1) << 22)
+
+#define PIN_PA23B_PTC_X17                          _L_(23)      /**< PTC signal: X17 on PA23 mux B*/
+#define MUX_PA23B_PTC_X17                          _L_(1)      
+#define PINMUX_PA23B_PTC_X17                       ((PIN_PA23B_PTC_X17 << 16) | MUX_PA23B_PTC_X17)
+#define PORT_PA23B_PTC_X17                         (_UL_(1) << 23)
+
+#define PIN_PA23B_PTC_Y17                          _L_(23)      /**< PTC signal: Y17 on PA23 mux B*/
+#define MUX_PA23B_PTC_Y17                          _L_(1)      
+#define PINMUX_PA23B_PTC_Y17                       ((PIN_PA23B_PTC_Y17 << 16) | MUX_PA23B_PTC_Y17)
+#define PORT_PA23B_PTC_Y17                         (_UL_(1) << 23)
+
+#define PIN_PA30B_PTC_X18                          _L_(30)      /**< PTC signal: X18 on PA30 mux B*/
+#define MUX_PA30B_PTC_X18                          _L_(1)      
+#define PINMUX_PA30B_PTC_X18                       ((PIN_PA30B_PTC_X18 << 16) | MUX_PA30B_PTC_X18)
+#define PORT_PA30B_PTC_X18                         (_UL_(1) << 30)
+
+#define PIN_PA30B_PTC_Y18                          _L_(30)      /**< PTC signal: Y18 on PA30 mux B*/
+#define MUX_PA30B_PTC_Y18                          _L_(1)      
+#define PINMUX_PA30B_PTC_Y18                       ((PIN_PA30B_PTC_Y18 << 16) | MUX_PA30B_PTC_Y18)
+#define PORT_PA30B_PTC_Y18                         (_UL_(1) << 30)
+
+#define PIN_PA31B_PTC_X19                          _L_(31)      /**< PTC signal: X19 on PA31 mux B*/
+#define MUX_PA31B_PTC_X19                          _L_(1)      
+#define PINMUX_PA31B_PTC_X19                       ((PIN_PA31B_PTC_X19 << 16) | MUX_PA31B_PTC_X19)
+#define PORT_PA31B_PTC_X19                         (_UL_(1) << 31)
+
+#define PIN_PA31B_PTC_Y19                          _L_(31)      /**< PTC signal: Y19 on PA31 mux B*/
+#define MUX_PA31B_PTC_Y19                          _L_(1)      
+#define PINMUX_PA31B_PTC_Y19                       ((PIN_PA31B_PTC_Y19 << 16) | MUX_PA31B_PTC_Y19)
+#define PORT_PA31B_PTC_Y19                         (_UL_(1) << 31)
+
+/* ========== PORT definition for RTC peripheral ========== */
+#define PIN_PA08G_RTC_IN0                          _L_(8)       /**< RTC signal: IN0 on PA08 mux G*/
+#define MUX_PA08G_RTC_IN0                          _L_(6)      
+#define PINMUX_PA08G_RTC_IN0                       ((PIN_PA08G_RTC_IN0 << 16) | MUX_PA08G_RTC_IN0)
+#define PORT_PA08G_RTC_IN0                         (_UL_(1) << 8)
+
+#define PIN_PA16G_RTC_IN2                          _L_(16)      /**< RTC signal: IN2 on PA16 mux G*/
+#define MUX_PA16G_RTC_IN2                          _L_(6)      
+#define PINMUX_PA16G_RTC_IN2                       ((PIN_PA16G_RTC_IN2 << 16) | MUX_PA16G_RTC_IN2)
+#define PORT_PA16G_RTC_IN2                         (_UL_(1) << 16)
+
+#define PIN_PA17G_RTC_IN3                          _L_(17)      /**< RTC signal: IN3 on PA17 mux G*/
+#define MUX_PA17G_RTC_IN3                          _L_(6)      
+#define PINMUX_PA17G_RTC_IN3                       ((PIN_PA17G_RTC_IN3 << 16) | MUX_PA17G_RTC_IN3)
+#define PORT_PA17G_RTC_IN3                         (_UL_(1) << 17)
+
+#define PIN_PA18G_RTC_OUT0                         _L_(18)      /**< RTC signal: OUT0 on PA18 mux G*/
+#define MUX_PA18G_RTC_OUT0                         _L_(6)      
+#define PINMUX_PA18G_RTC_OUT0                      ((PIN_PA18G_RTC_OUT0 << 16) | MUX_PA18G_RTC_OUT0)
+#define PORT_PA18G_RTC_OUT0                        (_UL_(1) << 18)
+
+#define PIN_PA19G_RTC_OUT1                         _L_(19)      /**< RTC signal: OUT1 on PA19 mux G*/
+#define MUX_PA19G_RTC_OUT1                         _L_(6)      
+#define PINMUX_PA19G_RTC_OUT1                      ((PIN_PA19G_RTC_OUT1 << 16) | MUX_PA19G_RTC_OUT1)
+#define PORT_PA19G_RTC_OUT1                        (_UL_(1) << 19)
+
+#define PIN_PA22G_RTC_OUT2                         _L_(22)      /**< RTC signal: OUT2 on PA22 mux G*/
+#define MUX_PA22G_RTC_OUT2                         _L_(6)      
+#define PINMUX_PA22G_RTC_OUT2                      ((PIN_PA22G_RTC_OUT2 << 16) | MUX_PA22G_RTC_OUT2)
+#define PORT_PA22G_RTC_OUT2                        (_UL_(1) << 22)
+
+#define PIN_PA23G_RTC_OUT3                         _L_(23)      /**< RTC signal: OUT3 on PA23 mux G*/
+#define MUX_PA23G_RTC_OUT3                         _L_(6)      
+#define PINMUX_PA23G_RTC_OUT3                      ((PIN_PA23G_RTC_OUT3 << 16) | MUX_PA23G_RTC_OUT3)
+#define PORT_PA23G_RTC_OUT3                        (_UL_(1) << 23)
+
+/* ========== PORT definition for SERCOM0 peripheral ========== */
+#define PIN_PA04D_SERCOM0_PAD0                     _L_(4)       /**< SERCOM0 signal: PAD0 on PA04 mux D*/
+#define MUX_PA04D_SERCOM0_PAD0                     _L_(3)      
+#define PINMUX_PA04D_SERCOM0_PAD0                  ((PIN_PA04D_SERCOM0_PAD0 << 16) | MUX_PA04D_SERCOM0_PAD0)
+#define PORT_PA04D_SERCOM0_PAD0                    (_UL_(1) << 4)
+
+#define PIN_PA16D_SERCOM0_PAD0                     _L_(16)      /**< SERCOM0 signal: PAD0 on PA16 mux D*/
+#define MUX_PA16D_SERCOM0_PAD0                     _L_(3)      
+#define PINMUX_PA16D_SERCOM0_PAD0                  ((PIN_PA16D_SERCOM0_PAD0 << 16) | MUX_PA16D_SERCOM0_PAD0)
+#define PORT_PA16D_SERCOM0_PAD0                    (_UL_(1) << 16)
+
+#define PIN_PA22C_SERCOM0_PAD0                     _L_(22)      /**< SERCOM0 signal: PAD0 on PA22 mux C*/
+#define MUX_PA22C_SERCOM0_PAD0                     _L_(2)      
+#define PINMUX_PA22C_SERCOM0_PAD0                  ((PIN_PA22C_SERCOM0_PAD0 << 16) | MUX_PA22C_SERCOM0_PAD0)
+#define PORT_PA22C_SERCOM0_PAD0                    (_UL_(1) << 22)
+
+#define PIN_PA05D_SERCOM0_PAD1                     _L_(5)       /**< SERCOM0 signal: PAD1 on PA05 mux D*/
+#define MUX_PA05D_SERCOM0_PAD1                     _L_(3)      
+#define PINMUX_PA05D_SERCOM0_PAD1                  ((PIN_PA05D_SERCOM0_PAD1 << 16) | MUX_PA05D_SERCOM0_PAD1)
+#define PORT_PA05D_SERCOM0_PAD1                    (_UL_(1) << 5)
+
+#define PIN_PA17D_SERCOM0_PAD1                     _L_(17)      /**< SERCOM0 signal: PAD1 on PA17 mux D*/
+#define MUX_PA17D_SERCOM0_PAD1                     _L_(3)      
+#define PINMUX_PA17D_SERCOM0_PAD1                  ((PIN_PA17D_SERCOM0_PAD1 << 16) | MUX_PA17D_SERCOM0_PAD1)
+#define PORT_PA17D_SERCOM0_PAD1                    (_UL_(1) << 17)
+
+#define PIN_PA23C_SERCOM0_PAD1                     _L_(23)      /**< SERCOM0 signal: PAD1 on PA23 mux C*/
+#define MUX_PA23C_SERCOM0_PAD1                     _L_(2)      
+#define PINMUX_PA23C_SERCOM0_PAD1                  ((PIN_PA23C_SERCOM0_PAD1 << 16) | MUX_PA23C_SERCOM0_PAD1)
+#define PORT_PA23C_SERCOM0_PAD1                    (_UL_(1) << 23)
+
+#define PIN_PA14D_SERCOM0_PAD2                     _L_(14)      /**< SERCOM0 signal: PAD2 on PA14 mux D*/
+#define MUX_PA14D_SERCOM0_PAD2                     _L_(3)      
+#define PINMUX_PA14D_SERCOM0_PAD2                  ((PIN_PA14D_SERCOM0_PAD2 << 16) | MUX_PA14D_SERCOM0_PAD2)
+#define PORT_PA14D_SERCOM0_PAD2                    (_UL_(1) << 14)
+
+#define PIN_PA18D_SERCOM0_PAD2                     _L_(18)      /**< SERCOM0 signal: PAD2 on PA18 mux D*/
+#define MUX_PA18D_SERCOM0_PAD2                     _L_(3)      
+#define PINMUX_PA18D_SERCOM0_PAD2                  ((PIN_PA18D_SERCOM0_PAD2 << 16) | MUX_PA18D_SERCOM0_PAD2)
+#define PORT_PA18D_SERCOM0_PAD2                    (_UL_(1) << 18)
+
+#define PIN_PA02D_SERCOM0_PAD2                     _L_(2)       /**< SERCOM0 signal: PAD2 on PA02 mux D*/
+#define MUX_PA02D_SERCOM0_PAD2                     _L_(3)      
+#define PINMUX_PA02D_SERCOM0_PAD2                  ((PIN_PA02D_SERCOM0_PAD2 << 16) | MUX_PA02D_SERCOM0_PAD2)
+#define PORT_PA02D_SERCOM0_PAD2                    (_UL_(1) << 2)
+
+#define PIN_PA15D_SERCOM0_PAD3                     _L_(15)      /**< SERCOM0 signal: PAD3 on PA15 mux D*/
+#define MUX_PA15D_SERCOM0_PAD3                     _L_(3)      
+#define PINMUX_PA15D_SERCOM0_PAD3                  ((PIN_PA15D_SERCOM0_PAD3 << 16) | MUX_PA15D_SERCOM0_PAD3)
+#define PORT_PA15D_SERCOM0_PAD3                    (_UL_(1) << 15)
+
+#define PIN_PA19D_SERCOM0_PAD3                     _L_(19)      /**< SERCOM0 signal: PAD3 on PA19 mux D*/
+#define MUX_PA19D_SERCOM0_PAD3                     _L_(3)      
+#define PINMUX_PA19D_SERCOM0_PAD3                  ((PIN_PA19D_SERCOM0_PAD3 << 16) | MUX_PA19D_SERCOM0_PAD3)
+#define PORT_PA19D_SERCOM0_PAD3                    (_UL_(1) << 19)
+
+#define PIN_PA03D_SERCOM0_PAD3                     _L_(3)       /**< SERCOM0 signal: PAD3 on PA03 mux D*/
+#define MUX_PA03D_SERCOM0_PAD3                     _L_(3)      
+#define PINMUX_PA03D_SERCOM0_PAD3                  ((PIN_PA03D_SERCOM0_PAD3 << 16) | MUX_PA03D_SERCOM0_PAD3)
+#define PORT_PA03D_SERCOM0_PAD3                    (_UL_(1) << 3)
+
+/* ========== PORT definition for SERCOM1 peripheral ========== */
+#define PIN_PA16C_SERCOM1_PAD0                     _L_(16)      /**< SERCOM1 signal: PAD0 on PA16 mux C*/
+#define MUX_PA16C_SERCOM1_PAD0                     _L_(2)      
+#define PINMUX_PA16C_SERCOM1_PAD0                  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
+#define PORT_PA16C_SERCOM1_PAD0                    (_UL_(1) << 16)
+
+#define PIN_PA08C_SERCOM1_PAD0                     _L_(8)       /**< SERCOM1 signal: PAD0 on PA08 mux C*/
+#define MUX_PA08C_SERCOM1_PAD0                     _L_(2)      
+#define PINMUX_PA08C_SERCOM1_PAD0                  ((PIN_PA08C_SERCOM1_PAD0 << 16) | MUX_PA08C_SERCOM1_PAD0)
+#define PORT_PA08C_SERCOM1_PAD0                    (_UL_(1) << 8)
+
+#define PIN_PA00D_SERCOM1_PAD0                     _L_(0)       /**< SERCOM1 signal: PAD0 on PA00 mux D*/
+#define MUX_PA00D_SERCOM1_PAD0                     _L_(3)      
+#define PINMUX_PA00D_SERCOM1_PAD0                  ((PIN_PA00D_SERCOM1_PAD0 << 16) | MUX_PA00D_SERCOM1_PAD0)
+#define PORT_PA00D_SERCOM1_PAD0                    (_UL_(1) << 0)
+
+#define PIN_PA17C_SERCOM1_PAD1                     _L_(17)      /**< SERCOM1 signal: PAD1 on PA17 mux C*/
+#define MUX_PA17C_SERCOM1_PAD1                     _L_(2)      
+#define PINMUX_PA17C_SERCOM1_PAD1                  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
+#define PORT_PA17C_SERCOM1_PAD1                    (_UL_(1) << 17)
+
+#define PIN_PA01D_SERCOM1_PAD1                     _L_(1)       /**< SERCOM1 signal: PAD1 on PA01 mux D*/
+#define MUX_PA01D_SERCOM1_PAD1                     _L_(3)      
+#define PINMUX_PA01D_SERCOM1_PAD1                  ((PIN_PA01D_SERCOM1_PAD1 << 16) | MUX_PA01D_SERCOM1_PAD1)
+#define PORT_PA01D_SERCOM1_PAD1                    (_UL_(1) << 1)
+
+#define PIN_PA18C_SERCOM1_PAD2                     _L_(18)      /**< SERCOM1 signal: PAD2 on PA18 mux C*/
+#define MUX_PA18C_SERCOM1_PAD2                     _L_(2)      
+#define PINMUX_PA18C_SERCOM1_PAD2                  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
+#define PORT_PA18C_SERCOM1_PAD2                    (_UL_(1) << 18)
+
+#define PIN_PA30D_SERCOM1_PAD2                     _L_(30)      /**< SERCOM1 signal: PAD2 on PA30 mux D*/
+#define MUX_PA30D_SERCOM1_PAD2                     _L_(3)      
+#define PINMUX_PA30D_SERCOM1_PAD2                  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
+#define PORT_PA30D_SERCOM1_PAD2                    (_UL_(1) << 30)
+
+#define PIN_PA19C_SERCOM1_PAD3                     _L_(19)      /**< SERCOM1 signal: PAD3 on PA19 mux C*/
+#define MUX_PA19C_SERCOM1_PAD3                     _L_(2)      
+#define PINMUX_PA19C_SERCOM1_PAD3                  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
+#define PORT_PA19C_SERCOM1_PAD3                    (_UL_(1) << 19)
+
+#define PIN_PA31D_SERCOM1_PAD3                     _L_(31)      /**< SERCOM1 signal: PAD3 on PA31 mux D*/
+#define MUX_PA31D_SERCOM1_PAD3                     _L_(3)      
+#define PINMUX_PA31D_SERCOM1_PAD3                  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
+#define PORT_PA31D_SERCOM1_PAD3                    (_UL_(1) << 31)
+
+/* ========== PORT definition for TC0 peripheral ========== */
+#define PIN_PA04E_TC0_WO0                          _L_(4)       /**< TC0 signal: WO0 on PA04 mux E*/
+#define MUX_PA04E_TC0_WO0                          _L_(4)      
+#define PINMUX_PA04E_TC0_WO0                       ((PIN_PA04E_TC0_WO0 << 16) | MUX_PA04E_TC0_WO0)
+#define PORT_PA04E_TC0_WO0                         (_UL_(1) << 4)
+
+#define PIN_PA14E_TC0_WO0                          _L_(14)      /**< TC0 signal: WO0 on PA14 mux E*/
+#define MUX_PA14E_TC0_WO0                          _L_(4)      
+#define PINMUX_PA14E_TC0_WO0                       ((PIN_PA14E_TC0_WO0 << 16) | MUX_PA14E_TC0_WO0)
+#define PORT_PA14E_TC0_WO0                         (_UL_(1) << 14)
+
+#define PIN_PA22E_TC0_WO0                          _L_(22)      /**< TC0 signal: WO0 on PA22 mux E*/
+#define MUX_PA22E_TC0_WO0                          _L_(4)      
+#define PINMUX_PA22E_TC0_WO0                       ((PIN_PA22E_TC0_WO0 << 16) | MUX_PA22E_TC0_WO0)
+#define PORT_PA22E_TC0_WO0                         (_UL_(1) << 22)
+
+#define PIN_PA05E_TC0_WO1                          _L_(5)       /**< TC0 signal: WO1 on PA05 mux E*/
+#define MUX_PA05E_TC0_WO1                          _L_(4)      
+#define PINMUX_PA05E_TC0_WO1                       ((PIN_PA05E_TC0_WO1 << 16) | MUX_PA05E_TC0_WO1)
+#define PORT_PA05E_TC0_WO1                         (_UL_(1) << 5)
+
+#define PIN_PA15E_TC0_WO1                          _L_(15)      /**< TC0 signal: WO1 on PA15 mux E*/
+#define MUX_PA15E_TC0_WO1                          _L_(4)      
+#define PINMUX_PA15E_TC0_WO1                       ((PIN_PA15E_TC0_WO1 << 16) | MUX_PA15E_TC0_WO1)
+#define PORT_PA15E_TC0_WO1                         (_UL_(1) << 15)
+
+#define PIN_PA23E_TC0_WO1                          _L_(23)      /**< TC0 signal: WO1 on PA23 mux E*/
+#define MUX_PA23E_TC0_WO1                          _L_(4)      
+#define PINMUX_PA23E_TC0_WO1                       ((PIN_PA23E_TC0_WO1 << 16) | MUX_PA23E_TC0_WO1)
+#define PORT_PA23E_TC0_WO1                         (_UL_(1) << 23)
+
+/* ========== PORT definition for TC1 peripheral ========== */
+#define PIN_PA30E_TC1_WO0                          _L_(30)      /**< TC1 signal: WO0 on PA30 mux E*/
+#define MUX_PA30E_TC1_WO0                          _L_(4)      
+#define PINMUX_PA30E_TC1_WO0                       ((PIN_PA30E_TC1_WO0 << 16) | MUX_PA30E_TC1_WO0)
+#define PORT_PA30E_TC1_WO0                         (_UL_(1) << 30)
+
+#define PIN_PA31E_TC1_WO1                          _L_(31)      /**< TC1 signal: WO1 on PA31 mux E*/
+#define MUX_PA31E_TC1_WO1                          _L_(4)      
+#define PINMUX_PA31E_TC1_WO1                       ((PIN_PA31E_TC1_WO1 << 16) | MUX_PA31E_TC1_WO1)
+#define PORT_PA31E_TC1_WO1                         (_UL_(1) << 31)
+
+/* ========== PORT definition for TC2 peripheral ========== */
+#define PIN_PA00E_TC2_WO0                          _L_(0)       /**< TC2 signal: WO0 on PA00 mux E*/
+#define MUX_PA00E_TC2_WO0                          _L_(4)      
+#define PINMUX_PA00E_TC2_WO0                       ((PIN_PA00E_TC2_WO0 << 16) | MUX_PA00E_TC2_WO0)
+#define PORT_PA00E_TC2_WO0                         (_UL_(1) << 0)
+
+#define PIN_PA18E_TC2_WO0                          _L_(18)      /**< TC2 signal: WO0 on PA18 mux E*/
+#define MUX_PA18E_TC2_WO0                          _L_(4)      
+#define PINMUX_PA18E_TC2_WO0                       ((PIN_PA18E_TC2_WO0 << 16) | MUX_PA18E_TC2_WO0)
+#define PORT_PA18E_TC2_WO0                         (_UL_(1) << 18)
+
+#define PIN_PA01E_TC2_WO1                          _L_(1)       /**< TC2 signal: WO1 on PA01 mux E*/
+#define MUX_PA01E_TC2_WO1                          _L_(4)      
+#define PINMUX_PA01E_TC2_WO1                       ((PIN_PA01E_TC2_WO1 << 16) | MUX_PA01E_TC2_WO1)
+#define PORT_PA01E_TC2_WO1                         (_UL_(1) << 1)
+
+#define PIN_PA19E_TC2_WO1                          _L_(19)      /**< TC2 signal: WO1 on PA19 mux E*/
+#define MUX_PA19E_TC2_WO1                          _L_(4)      
+#define PINMUX_PA19E_TC2_WO1                       ((PIN_PA19E_TC2_WO1 << 16) | MUX_PA19E_TC2_WO1)
+#define PORT_PA19E_TC2_WO1                         (_UL_(1) << 19)
+
+
+#endif /* _SAML11D16A_PIO_H_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/pio/saml11e14a.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/pio/saml11e14a.h
@@ -1,0 +1,1167 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAML11E14A
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11E14A_PIO_H_
+#define _SAML11E14A_PIO_H_
+
+/* ========== Peripheral I/O pin numbers ========== */
+#define PIN_PA00                    (  0)  /**< Pin Number for PA00 */
+#define PIN_PA01                    (  1)  /**< Pin Number for PA01 */
+#define PIN_PA02                    (  2)  /**< Pin Number for PA02 */
+#define PIN_PA03                    (  3)  /**< Pin Number for PA03 */
+#define PIN_PA04                    (  4)  /**< Pin Number for PA04 */
+#define PIN_PA05                    (  5)  /**< Pin Number for PA05 */
+#define PIN_PA06                    (  6)  /**< Pin Number for PA06 */
+#define PIN_PA07                    (  7)  /**< Pin Number for PA07 */
+#define PIN_PA08                    (  8)  /**< Pin Number for PA08 */
+#define PIN_PA09                    (  9)  /**< Pin Number for PA09 */
+#define PIN_PA10                    ( 10)  /**< Pin Number for PA10 */
+#define PIN_PA11                    ( 11)  /**< Pin Number for PA11 */
+#define PIN_PA14                    ( 14)  /**< Pin Number for PA14 */
+#define PIN_PA15                    ( 15)  /**< Pin Number for PA15 */
+#define PIN_PA16                    ( 16)  /**< Pin Number for PA16 */
+#define PIN_PA17                    ( 17)  /**< Pin Number for PA17 */
+#define PIN_PA18                    ( 18)  /**< Pin Number for PA18 */
+#define PIN_PA19                    ( 19)  /**< Pin Number for PA19 */
+#define PIN_PA22                    ( 22)  /**< Pin Number for PA22 */
+#define PIN_PA23                    ( 23)  /**< Pin Number for PA23 */
+#define PIN_PA24                    ( 24)  /**< Pin Number for PA24 */
+#define PIN_PA25                    ( 25)  /**< Pin Number for PA25 */
+#define PIN_PA27                    ( 27)  /**< Pin Number for PA27 */
+#define PIN_PA30                    ( 30)  /**< Pin Number for PA30 */
+#define PIN_PA31                    ( 31)  /**< Pin Number for PA31 */
+
+
+/* ========== Peripheral I/O masks ========== */
+#define PORT_PA00                   (_U_(1) << 0) /**< PORT Mask for PA00 */
+#define PORT_PA01                   (_U_(1) << 1) /**< PORT Mask for PA01 */
+#define PORT_PA02                   (_U_(1) << 2) /**< PORT Mask for PA02 */
+#define PORT_PA03                   (_U_(1) << 3) /**< PORT Mask for PA03 */
+#define PORT_PA04                   (_U_(1) << 4) /**< PORT Mask for PA04 */
+#define PORT_PA05                   (_U_(1) << 5) /**< PORT Mask for PA05 */
+#define PORT_PA06                   (_U_(1) << 6) /**< PORT Mask for PA06 */
+#define PORT_PA07                   (_U_(1) << 7) /**< PORT Mask for PA07 */
+#define PORT_PA08                   (_U_(1) << 8) /**< PORT Mask for PA08 */
+#define PORT_PA09                   (_U_(1) << 9) /**< PORT Mask for PA09 */
+#define PORT_PA10                   (_U_(1) << 10) /**< PORT Mask for PA10 */
+#define PORT_PA11                   (_U_(1) << 11) /**< PORT Mask for PA11 */
+#define PORT_PA14                   (_U_(1) << 14) /**< PORT Mask for PA14 */
+#define PORT_PA15                   (_U_(1) << 15) /**< PORT Mask for PA15 */
+#define PORT_PA16                   (_U_(1) << 16) /**< PORT Mask for PA16 */
+#define PORT_PA17                   (_U_(1) << 17) /**< PORT Mask for PA17 */
+#define PORT_PA18                   (_U_(1) << 18) /**< PORT Mask for PA18 */
+#define PORT_PA19                   (_U_(1) << 19) /**< PORT Mask for PA19 */
+#define PORT_PA22                   (_U_(1) << 22) /**< PORT Mask for PA22 */
+#define PORT_PA23                   (_U_(1) << 23) /**< PORT Mask for PA23 */
+#define PORT_PA24                   (_U_(1) << 24) /**< PORT Mask for PA24 */
+#define PORT_PA25                   (_U_(1) << 25) /**< PORT Mask for PA25 */
+#define PORT_PA27                   (_U_(1) << 27) /**< PORT Mask for PA27 */
+#define PORT_PA30                   (_U_(1) << 30) /**< PORT Mask for PA30 */
+#define PORT_PA31                   (_U_(1) << 31) /**< PORT Mask for PA31 */
+
+
+/* ========== Peripheral I/O indexes ========== */
+#define PORT_PA00_IDX               (  0)  /**< PORT Index Number for PA00 */
+#define PORT_PA01_IDX               (  1)  /**< PORT Index Number for PA01 */
+#define PORT_PA02_IDX               (  2)  /**< PORT Index Number for PA02 */
+#define PORT_PA03_IDX               (  3)  /**< PORT Index Number for PA03 */
+#define PORT_PA04_IDX               (  4)  /**< PORT Index Number for PA04 */
+#define PORT_PA05_IDX               (  5)  /**< PORT Index Number for PA05 */
+#define PORT_PA06_IDX               (  6)  /**< PORT Index Number for PA06 */
+#define PORT_PA07_IDX               (  7)  /**< PORT Index Number for PA07 */
+#define PORT_PA08_IDX               (  8)  /**< PORT Index Number for PA08 */
+#define PORT_PA09_IDX               (  9)  /**< PORT Index Number for PA09 */
+#define PORT_PA10_IDX               ( 10)  /**< PORT Index Number for PA10 */
+#define PORT_PA11_IDX               ( 11)  /**< PORT Index Number for PA11 */
+#define PORT_PA14_IDX               ( 14)  /**< PORT Index Number for PA14 */
+#define PORT_PA15_IDX               ( 15)  /**< PORT Index Number for PA15 */
+#define PORT_PA16_IDX               ( 16)  /**< PORT Index Number for PA16 */
+#define PORT_PA17_IDX               ( 17)  /**< PORT Index Number for PA17 */
+#define PORT_PA18_IDX               ( 18)  /**< PORT Index Number for PA18 */
+#define PORT_PA19_IDX               ( 19)  /**< PORT Index Number for PA19 */
+#define PORT_PA22_IDX               ( 22)  /**< PORT Index Number for PA22 */
+#define PORT_PA23_IDX               ( 23)  /**< PORT Index Number for PA23 */
+#define PORT_PA24_IDX               ( 24)  /**< PORT Index Number for PA24 */
+#define PORT_PA25_IDX               ( 25)  /**< PORT Index Number for PA25 */
+#define PORT_PA27_IDX               ( 27)  /**< PORT Index Number for PA27 */
+#define PORT_PA30_IDX               ( 30)  /**< PORT Index Number for PA30 */
+#define PORT_PA31_IDX               ( 31)  /**< PORT Index Number for PA31 */
+
+/* ========== PORT definition for AC peripheral ========== */
+#define PIN_PA04B_AC_AIN0                          _L_(4)       /**< AC signal: AIN0 on PA04 mux B*/
+#define MUX_PA04B_AC_AIN0                          _L_(1)      
+#define PINMUX_PA04B_AC_AIN0                       ((PIN_PA04B_AC_AIN0 << 16) | MUX_PA04B_AC_AIN0)
+#define PORT_PA04B_AC_AIN0                         (_UL_(1) << 4)
+
+#define PIN_PA05B_AC_AIN1                          _L_(5)       /**< AC signal: AIN1 on PA05 mux B*/
+#define MUX_PA05B_AC_AIN1                          _L_(1)      
+#define PINMUX_PA05B_AC_AIN1                       ((PIN_PA05B_AC_AIN1 << 16) | MUX_PA05B_AC_AIN1)
+#define PORT_PA05B_AC_AIN1                         (_UL_(1) << 5)
+
+#define PIN_PA06B_AC_AIN2                          _L_(6)       /**< AC signal: AIN2 on PA06 mux B*/
+#define MUX_PA06B_AC_AIN2                          _L_(1)      
+#define PINMUX_PA06B_AC_AIN2                       ((PIN_PA06B_AC_AIN2 << 16) | MUX_PA06B_AC_AIN2)
+#define PORT_PA06B_AC_AIN2                         (_UL_(1) << 6)
+
+#define PIN_PA07B_AC_AIN3                          _L_(7)       /**< AC signal: AIN3 on PA07 mux B*/
+#define MUX_PA07B_AC_AIN3                          _L_(1)      
+#define PINMUX_PA07B_AC_AIN3                       ((PIN_PA07B_AC_AIN3 << 16) | MUX_PA07B_AC_AIN3)
+#define PORT_PA07B_AC_AIN3                         (_UL_(1) << 7)
+
+#define PIN_PA18H_AC_CMP0                          _L_(18)      /**< AC signal: CMP0 on PA18 mux H*/
+#define MUX_PA18H_AC_CMP0                          _L_(7)      
+#define PINMUX_PA18H_AC_CMP0                       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
+#define PORT_PA18H_AC_CMP0                         (_UL_(1) << 18)
+
+#define PIN_PA19H_AC_CMP1                          _L_(19)      /**< AC signal: CMP1 on PA19 mux H*/
+#define MUX_PA19H_AC_CMP1                          _L_(7)      
+#define PINMUX_PA19H_AC_CMP1                       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
+#define PORT_PA19H_AC_CMP1                         (_UL_(1) << 19)
+
+/* ========== PORT definition for ADC peripheral ========== */
+#define PIN_PA02B_ADC_AIN0                         _L_(2)       /**< ADC signal: AIN0 on PA02 mux B*/
+#define MUX_PA02B_ADC_AIN0                         _L_(1)      
+#define PINMUX_PA02B_ADC_AIN0                      ((PIN_PA02B_ADC_AIN0 << 16) | MUX_PA02B_ADC_AIN0)
+#define PORT_PA02B_ADC_AIN0                        (_UL_(1) << 2)
+
+#define PIN_PA03B_ADC_AIN1                         _L_(3)       /**< ADC signal: AIN1 on PA03 mux B*/
+#define MUX_PA03B_ADC_AIN1                         _L_(1)      
+#define PINMUX_PA03B_ADC_AIN1                      ((PIN_PA03B_ADC_AIN1 << 16) | MUX_PA03B_ADC_AIN1)
+#define PORT_PA03B_ADC_AIN1                        (_UL_(1) << 3)
+
+#define PIN_PA04B_ADC_AIN2                         _L_(4)       /**< ADC signal: AIN2 on PA04 mux B*/
+#define MUX_PA04B_ADC_AIN2                         _L_(1)      
+#define PINMUX_PA04B_ADC_AIN2                      ((PIN_PA04B_ADC_AIN2 << 16) | MUX_PA04B_ADC_AIN2)
+#define PORT_PA04B_ADC_AIN2                        (_UL_(1) << 4)
+
+#define PIN_PA05B_ADC_AIN3                         _L_(5)       /**< ADC signal: AIN3 on PA05 mux B*/
+#define MUX_PA05B_ADC_AIN3                         _L_(1)      
+#define PINMUX_PA05B_ADC_AIN3                      ((PIN_PA05B_ADC_AIN3 << 16) | MUX_PA05B_ADC_AIN3)
+#define PORT_PA05B_ADC_AIN3                        (_UL_(1) << 5)
+
+#define PIN_PA06B_ADC_AIN4                         _L_(6)       /**< ADC signal: AIN4 on PA06 mux B*/
+#define MUX_PA06B_ADC_AIN4                         _L_(1)      
+#define PINMUX_PA06B_ADC_AIN4                      ((PIN_PA06B_ADC_AIN4 << 16) | MUX_PA06B_ADC_AIN4)
+#define PORT_PA06B_ADC_AIN4                        (_UL_(1) << 6)
+
+#define PIN_PA07B_ADC_AIN5                         _L_(7)       /**< ADC signal: AIN5 on PA07 mux B*/
+#define MUX_PA07B_ADC_AIN5                         _L_(1)      
+#define PINMUX_PA07B_ADC_AIN5                      ((PIN_PA07B_ADC_AIN5 << 16) | MUX_PA07B_ADC_AIN5)
+#define PORT_PA07B_ADC_AIN5                        (_UL_(1) << 7)
+
+#define PIN_PA08B_ADC_AIN6                         _L_(8)       /**< ADC signal: AIN6 on PA08 mux B*/
+#define MUX_PA08B_ADC_AIN6                         _L_(1)      
+#define PINMUX_PA08B_ADC_AIN6                      ((PIN_PA08B_ADC_AIN6 << 16) | MUX_PA08B_ADC_AIN6)
+#define PORT_PA08B_ADC_AIN6                        (_UL_(1) << 8)
+
+#define PIN_PA09B_ADC_AIN7                         _L_(9)       /**< ADC signal: AIN7 on PA09 mux B*/
+#define MUX_PA09B_ADC_AIN7                         _L_(1)      
+#define PINMUX_PA09B_ADC_AIN7                      ((PIN_PA09B_ADC_AIN7 << 16) | MUX_PA09B_ADC_AIN7)
+#define PORT_PA09B_ADC_AIN7                        (_UL_(1) << 9)
+
+#define PIN_PA10B_ADC_AIN8                         _L_(10)      /**< ADC signal: AIN8 on PA10 mux B*/
+#define MUX_PA10B_ADC_AIN8                         _L_(1)      
+#define PINMUX_PA10B_ADC_AIN8                      ((PIN_PA10B_ADC_AIN8 << 16) | MUX_PA10B_ADC_AIN8)
+#define PORT_PA10B_ADC_AIN8                        (_UL_(1) << 10)
+
+#define PIN_PA11B_ADC_AIN9                         _L_(11)      /**< ADC signal: AIN9 on PA11 mux B*/
+#define MUX_PA11B_ADC_AIN9                         _L_(1)      
+#define PINMUX_PA11B_ADC_AIN9                      ((PIN_PA11B_ADC_AIN9 << 16) | MUX_PA11B_ADC_AIN9)
+#define PORT_PA11B_ADC_AIN9                        (_UL_(1) << 11)
+
+#define PIN_PA04B_ADC_VREFP                        _L_(4)       /**< ADC signal: VREFP on PA04 mux B*/
+#define MUX_PA04B_ADC_VREFP                        _L_(1)      
+#define PINMUX_PA04B_ADC_VREFP                     ((PIN_PA04B_ADC_VREFP << 16) | MUX_PA04B_ADC_VREFP)
+#define PORT_PA04B_ADC_VREFP                       (_UL_(1) << 4)
+
+/* ========== PORT definition for CCL peripheral ========== */
+#define PIN_PA04I_CCL_IN0                          _L_(4)       /**< CCL signal: IN0 on PA04 mux I*/
+#define MUX_PA04I_CCL_IN0                          _L_(8)      
+#define PINMUX_PA04I_CCL_IN0                       ((PIN_PA04I_CCL_IN0 << 16) | MUX_PA04I_CCL_IN0)
+#define PORT_PA04I_CCL_IN0                         (_UL_(1) << 4)
+
+#define PIN_PA16I_CCL_IN0                          _L_(16)      /**< CCL signal: IN0 on PA16 mux I*/
+#define MUX_PA16I_CCL_IN0                          _L_(8)      
+#define PINMUX_PA16I_CCL_IN0                       ((PIN_PA16I_CCL_IN0 << 16) | MUX_PA16I_CCL_IN0)
+#define PORT_PA16I_CCL_IN0                         (_UL_(1) << 16)
+
+#define PIN_PA05I_CCL_IN1                          _L_(5)       /**< CCL signal: IN1 on PA05 mux I*/
+#define MUX_PA05I_CCL_IN1                          _L_(8)      
+#define PINMUX_PA05I_CCL_IN1                       ((PIN_PA05I_CCL_IN1 << 16) | MUX_PA05I_CCL_IN1)
+#define PORT_PA05I_CCL_IN1                         (_UL_(1) << 5)
+
+#define PIN_PA17I_CCL_IN1                          _L_(17)      /**< CCL signal: IN1 on PA17 mux I*/
+#define MUX_PA17I_CCL_IN1                          _L_(8)      
+#define PINMUX_PA17I_CCL_IN1                       ((PIN_PA17I_CCL_IN1 << 16) | MUX_PA17I_CCL_IN1)
+#define PORT_PA17I_CCL_IN1                         (_UL_(1) << 17)
+
+#define PIN_PA06I_CCL_IN2                          _L_(6)       /**< CCL signal: IN2 on PA06 mux I*/
+#define MUX_PA06I_CCL_IN2                          _L_(8)      
+#define PINMUX_PA06I_CCL_IN2                       ((PIN_PA06I_CCL_IN2 << 16) | MUX_PA06I_CCL_IN2)
+#define PORT_PA06I_CCL_IN2                         (_UL_(1) << 6)
+
+#define PIN_PA18I_CCL_IN2                          _L_(18)      /**< CCL signal: IN2 on PA18 mux I*/
+#define MUX_PA18I_CCL_IN2                          _L_(8)      
+#define PINMUX_PA18I_CCL_IN2                       ((PIN_PA18I_CCL_IN2 << 16) | MUX_PA18I_CCL_IN2)
+#define PORT_PA18I_CCL_IN2                         (_UL_(1) << 18)
+
+#define PIN_PA08I_CCL_IN3                          _L_(8)       /**< CCL signal: IN3 on PA08 mux I*/
+#define MUX_PA08I_CCL_IN3                          _L_(8)      
+#define PINMUX_PA08I_CCL_IN3                       ((PIN_PA08I_CCL_IN3 << 16) | MUX_PA08I_CCL_IN3)
+#define PORT_PA08I_CCL_IN3                         (_UL_(1) << 8)
+
+#define PIN_PA30I_CCL_IN3                          _L_(30)      /**< CCL signal: IN3 on PA30 mux I*/
+#define MUX_PA30I_CCL_IN3                          _L_(8)      
+#define PINMUX_PA30I_CCL_IN3                       ((PIN_PA30I_CCL_IN3 << 16) | MUX_PA30I_CCL_IN3)
+#define PORT_PA30I_CCL_IN3                         (_UL_(1) << 30)
+
+#define PIN_PA09I_CCL_IN4                          _L_(9)       /**< CCL signal: IN4 on PA09 mux I*/
+#define MUX_PA09I_CCL_IN4                          _L_(8)      
+#define PINMUX_PA09I_CCL_IN4                       ((PIN_PA09I_CCL_IN4 << 16) | MUX_PA09I_CCL_IN4)
+#define PORT_PA09I_CCL_IN4                         (_UL_(1) << 9)
+
+#define PIN_PA10I_CCL_IN5                          _L_(10)      /**< CCL signal: IN5 on PA10 mux I*/
+#define MUX_PA10I_CCL_IN5                          _L_(8)      
+#define PINMUX_PA10I_CCL_IN5                       ((PIN_PA10I_CCL_IN5 << 16) | MUX_PA10I_CCL_IN5)
+#define PORT_PA10I_CCL_IN5                         (_UL_(1) << 10)
+
+#define PIN_PA07I_CCL_OUT0                         _L_(7)       /**< CCL signal: OUT0 on PA07 mux I*/
+#define MUX_PA07I_CCL_OUT0                         _L_(8)      
+#define PINMUX_PA07I_CCL_OUT0                      ((PIN_PA07I_CCL_OUT0 << 16) | MUX_PA07I_CCL_OUT0)
+#define PORT_PA07I_CCL_OUT0                        (_UL_(1) << 7)
+
+#define PIN_PA19I_CCL_OUT0                         _L_(19)      /**< CCL signal: OUT0 on PA19 mux I*/
+#define MUX_PA19I_CCL_OUT0                         _L_(8)      
+#define PINMUX_PA19I_CCL_OUT0                      ((PIN_PA19I_CCL_OUT0 << 16) | MUX_PA19I_CCL_OUT0)
+#define PORT_PA19I_CCL_OUT0                        (_UL_(1) << 19)
+
+#define PIN_PA11I_CCL_OUT1                         _L_(11)      /**< CCL signal: OUT1 on PA11 mux I*/
+#define MUX_PA11I_CCL_OUT1                         _L_(8)      
+#define PINMUX_PA11I_CCL_OUT1                      ((PIN_PA11I_CCL_OUT1 << 16) | MUX_PA11I_CCL_OUT1)
+#define PORT_PA11I_CCL_OUT1                        (_UL_(1) << 11)
+
+#define PIN_PA31I_CCL_OUT1                         _L_(31)      /**< CCL signal: OUT1 on PA31 mux I*/
+#define MUX_PA31I_CCL_OUT1                         _L_(8)      
+#define PINMUX_PA31I_CCL_OUT1                      ((PIN_PA31I_CCL_OUT1 << 16) | MUX_PA31I_CCL_OUT1)
+#define PORT_PA31I_CCL_OUT1                        (_UL_(1) << 31)
+
+/* ========== PORT definition for DAC peripheral ========== */
+#define PIN_PA02B_DAC_VOUT                         _L_(2)       /**< DAC signal: VOUT on PA02 mux B*/
+#define MUX_PA02B_DAC_VOUT                         _L_(1)      
+#define PINMUX_PA02B_DAC_VOUT                      ((PIN_PA02B_DAC_VOUT << 16) | MUX_PA02B_DAC_VOUT)
+#define PORT_PA02B_DAC_VOUT                        (_UL_(1) << 2)
+
+#define PIN_PA03B_DAC_VREFP                        _L_(3)       /**< DAC signal: VREFP on PA03 mux B*/
+#define MUX_PA03B_DAC_VREFP                        _L_(1)      
+#define PINMUX_PA03B_DAC_VREFP                     ((PIN_PA03B_DAC_VREFP << 16) | MUX_PA03B_DAC_VREFP)
+#define PORT_PA03B_DAC_VREFP                       (_UL_(1) << 3)
+
+/* ========== PORT definition for EIC peripheral ========== */
+#define PIN_PA09A_EIC_EXTINT0                      _L_(9)       /**< EIC signal: EXTINT0 on PA09 mux A*/
+#define MUX_PA09A_EIC_EXTINT0                      _L_(0)      
+#define PINMUX_PA09A_EIC_EXTINT0                   ((PIN_PA09A_EIC_EXTINT0 << 16) | MUX_PA09A_EIC_EXTINT0)
+#define PORT_PA09A_EIC_EXTINT0                     (_UL_(1) << 9)
+#define PIN_PA09A_EIC_EXTINT_NUM                   _L_(0)       /**< EIC signal: PIN_PA09 External Interrupt Line */
+
+#define PIN_PA19A_EIC_EXTINT0                      _L_(19)      /**< EIC signal: EXTINT0 on PA19 mux A*/
+#define MUX_PA19A_EIC_EXTINT0                      _L_(0)      
+#define PINMUX_PA19A_EIC_EXTINT0                   ((PIN_PA19A_EIC_EXTINT0 << 16) | MUX_PA19A_EIC_EXTINT0)
+#define PORT_PA19A_EIC_EXTINT0                     (_UL_(1) << 19)
+#define PIN_PA19A_EIC_EXTINT_NUM                   _L_(0)       /**< EIC signal: PIN_PA19 External Interrupt Line */
+
+#define PIN_PA00A_EIC_EXTINT0                      _L_(0)       /**< EIC signal: EXTINT0 on PA00 mux A*/
+#define MUX_PA00A_EIC_EXTINT0                      _L_(0)      
+#define PINMUX_PA00A_EIC_EXTINT0                   ((PIN_PA00A_EIC_EXTINT0 << 16) | MUX_PA00A_EIC_EXTINT0)
+#define PORT_PA00A_EIC_EXTINT0                     (_UL_(1) << 0)
+#define PIN_PA00A_EIC_EXTINT_NUM                   _L_(0)       /**< EIC signal: PIN_PA00 External Interrupt Line */
+
+#define PIN_PA10A_EIC_EXTINT1                      _L_(10)      /**< EIC signal: EXTINT1 on PA10 mux A*/
+#define MUX_PA10A_EIC_EXTINT1                      _L_(0)      
+#define PINMUX_PA10A_EIC_EXTINT1                   ((PIN_PA10A_EIC_EXTINT1 << 16) | MUX_PA10A_EIC_EXTINT1)
+#define PORT_PA10A_EIC_EXTINT1                     (_UL_(1) << 10)
+#define PIN_PA10A_EIC_EXTINT_NUM                   _L_(1)       /**< EIC signal: PIN_PA10 External Interrupt Line */
+
+#define PIN_PA22A_EIC_EXTINT1                      _L_(22)      /**< EIC signal: EXTINT1 on PA22 mux A*/
+#define MUX_PA22A_EIC_EXTINT1                      _L_(0)      
+#define PINMUX_PA22A_EIC_EXTINT1                   ((PIN_PA22A_EIC_EXTINT1 << 16) | MUX_PA22A_EIC_EXTINT1)
+#define PORT_PA22A_EIC_EXTINT1                     (_UL_(1) << 22)
+#define PIN_PA22A_EIC_EXTINT_NUM                   _L_(1)       /**< EIC signal: PIN_PA22 External Interrupt Line */
+
+#define PIN_PA01A_EIC_EXTINT1                      _L_(1)       /**< EIC signal: EXTINT1 on PA01 mux A*/
+#define MUX_PA01A_EIC_EXTINT1                      _L_(0)      
+#define PINMUX_PA01A_EIC_EXTINT1                   ((PIN_PA01A_EIC_EXTINT1 << 16) | MUX_PA01A_EIC_EXTINT1)
+#define PORT_PA01A_EIC_EXTINT1                     (_UL_(1) << 1)
+#define PIN_PA01A_EIC_EXTINT_NUM                   _L_(1)       /**< EIC signal: PIN_PA01 External Interrupt Line */
+
+#define PIN_PA02A_EIC_EXTINT2                      _L_(2)       /**< EIC signal: EXTINT2 on PA02 mux A*/
+#define MUX_PA02A_EIC_EXTINT2                      _L_(0)      
+#define PINMUX_PA02A_EIC_EXTINT2                   ((PIN_PA02A_EIC_EXTINT2 << 16) | MUX_PA02A_EIC_EXTINT2)
+#define PORT_PA02A_EIC_EXTINT2                     (_UL_(1) << 2)
+#define PIN_PA02A_EIC_EXTINT_NUM                   _L_(2)       /**< EIC signal: PIN_PA02 External Interrupt Line */
+
+#define PIN_PA11A_EIC_EXTINT2                      _L_(11)      /**< EIC signal: EXTINT2 on PA11 mux A*/
+#define MUX_PA11A_EIC_EXTINT2                      _L_(0)      
+#define PINMUX_PA11A_EIC_EXTINT2                   ((PIN_PA11A_EIC_EXTINT2 << 16) | MUX_PA11A_EIC_EXTINT2)
+#define PORT_PA11A_EIC_EXTINT2                     (_UL_(1) << 11)
+#define PIN_PA11A_EIC_EXTINT_NUM                   _L_(2)       /**< EIC signal: PIN_PA11 External Interrupt Line */
+
+#define PIN_PA23A_EIC_EXTINT2                      _L_(23)      /**< EIC signal: EXTINT2 on PA23 mux A*/
+#define MUX_PA23A_EIC_EXTINT2                      _L_(0)      
+#define PINMUX_PA23A_EIC_EXTINT2                   ((PIN_PA23A_EIC_EXTINT2 << 16) | MUX_PA23A_EIC_EXTINT2)
+#define PORT_PA23A_EIC_EXTINT2                     (_UL_(1) << 23)
+#define PIN_PA23A_EIC_EXTINT_NUM                   _L_(2)       /**< EIC signal: PIN_PA23 External Interrupt Line */
+
+#define PIN_PA03A_EIC_EXTINT3                      _L_(3)       /**< EIC signal: EXTINT3 on PA03 mux A*/
+#define MUX_PA03A_EIC_EXTINT3                      _L_(0)      
+#define PINMUX_PA03A_EIC_EXTINT3                   ((PIN_PA03A_EIC_EXTINT3 << 16) | MUX_PA03A_EIC_EXTINT3)
+#define PORT_PA03A_EIC_EXTINT3                     (_UL_(1) << 3)
+#define PIN_PA03A_EIC_EXTINT_NUM                   _L_(3)       /**< EIC signal: PIN_PA03 External Interrupt Line */
+
+#define PIN_PA14A_EIC_EXTINT3                      _L_(14)      /**< EIC signal: EXTINT3 on PA14 mux A*/
+#define MUX_PA14A_EIC_EXTINT3                      _L_(0)      
+#define PINMUX_PA14A_EIC_EXTINT3                   ((PIN_PA14A_EIC_EXTINT3 << 16) | MUX_PA14A_EIC_EXTINT3)
+#define PORT_PA14A_EIC_EXTINT3                     (_UL_(1) << 14)
+#define PIN_PA14A_EIC_EXTINT_NUM                   _L_(3)       /**< EIC signal: PIN_PA14 External Interrupt Line */
+
+#define PIN_PA24A_EIC_EXTINT3                      _L_(24)      /**< EIC signal: EXTINT3 on PA24 mux A*/
+#define MUX_PA24A_EIC_EXTINT3                      _L_(0)      
+#define PINMUX_PA24A_EIC_EXTINT3                   ((PIN_PA24A_EIC_EXTINT3 << 16) | MUX_PA24A_EIC_EXTINT3)
+#define PORT_PA24A_EIC_EXTINT3                     (_UL_(1) << 24)
+#define PIN_PA24A_EIC_EXTINT_NUM                   _L_(3)       /**< EIC signal: PIN_PA24 External Interrupt Line */
+
+#define PIN_PA04A_EIC_EXTINT4                      _L_(4)       /**< EIC signal: EXTINT4 on PA04 mux A*/
+#define MUX_PA04A_EIC_EXTINT4                      _L_(0)      
+#define PINMUX_PA04A_EIC_EXTINT4                   ((PIN_PA04A_EIC_EXTINT4 << 16) | MUX_PA04A_EIC_EXTINT4)
+#define PORT_PA04A_EIC_EXTINT4                     (_UL_(1) << 4)
+#define PIN_PA04A_EIC_EXTINT_NUM                   _L_(4)       /**< EIC signal: PIN_PA04 External Interrupt Line */
+
+#define PIN_PA15A_EIC_EXTINT4                      _L_(15)      /**< EIC signal: EXTINT4 on PA15 mux A*/
+#define MUX_PA15A_EIC_EXTINT4                      _L_(0)      
+#define PINMUX_PA15A_EIC_EXTINT4                   ((PIN_PA15A_EIC_EXTINT4 << 16) | MUX_PA15A_EIC_EXTINT4)
+#define PORT_PA15A_EIC_EXTINT4                     (_UL_(1) << 15)
+#define PIN_PA15A_EIC_EXTINT_NUM                   _L_(4)       /**< EIC signal: PIN_PA15 External Interrupt Line */
+
+#define PIN_PA25A_EIC_EXTINT4                      _L_(25)      /**< EIC signal: EXTINT4 on PA25 mux A*/
+#define MUX_PA25A_EIC_EXTINT4                      _L_(0)      
+#define PINMUX_PA25A_EIC_EXTINT4                   ((PIN_PA25A_EIC_EXTINT4 << 16) | MUX_PA25A_EIC_EXTINT4)
+#define PORT_PA25A_EIC_EXTINT4                     (_UL_(1) << 25)
+#define PIN_PA25A_EIC_EXTINT_NUM                   _L_(4)       /**< EIC signal: PIN_PA25 External Interrupt Line */
+
+#define PIN_PA05A_EIC_EXTINT5                      _L_(5)       /**< EIC signal: EXTINT5 on PA05 mux A*/
+#define MUX_PA05A_EIC_EXTINT5                      _L_(0)      
+#define PINMUX_PA05A_EIC_EXTINT5                   ((PIN_PA05A_EIC_EXTINT5 << 16) | MUX_PA05A_EIC_EXTINT5)
+#define PORT_PA05A_EIC_EXTINT5                     (_UL_(1) << 5)
+#define PIN_PA05A_EIC_EXTINT_NUM                   _L_(5)       /**< EIC signal: PIN_PA05 External Interrupt Line */
+
+#define PIN_PA16A_EIC_EXTINT5                      _L_(16)      /**< EIC signal: EXTINT5 on PA16 mux A*/
+#define MUX_PA16A_EIC_EXTINT5                      _L_(0)      
+#define PINMUX_PA16A_EIC_EXTINT5                   ((PIN_PA16A_EIC_EXTINT5 << 16) | MUX_PA16A_EIC_EXTINT5)
+#define PORT_PA16A_EIC_EXTINT5                     (_UL_(1) << 16)
+#define PIN_PA16A_EIC_EXTINT_NUM                   _L_(5)       /**< EIC signal: PIN_PA16 External Interrupt Line */
+
+#define PIN_PA27A_EIC_EXTINT5                      _L_(27)      /**< EIC signal: EXTINT5 on PA27 mux A*/
+#define MUX_PA27A_EIC_EXTINT5                      _L_(0)      
+#define PINMUX_PA27A_EIC_EXTINT5                   ((PIN_PA27A_EIC_EXTINT5 << 16) | MUX_PA27A_EIC_EXTINT5)
+#define PORT_PA27A_EIC_EXTINT5                     (_UL_(1) << 27)
+#define PIN_PA27A_EIC_EXTINT_NUM                   _L_(5)       /**< EIC signal: PIN_PA27 External Interrupt Line */
+
+#define PIN_PA06A_EIC_EXTINT6                      _L_(6)       /**< EIC signal: EXTINT6 on PA06 mux A*/
+#define MUX_PA06A_EIC_EXTINT6                      _L_(0)      
+#define PINMUX_PA06A_EIC_EXTINT6                   ((PIN_PA06A_EIC_EXTINT6 << 16) | MUX_PA06A_EIC_EXTINT6)
+#define PORT_PA06A_EIC_EXTINT6                     (_UL_(1) << 6)
+#define PIN_PA06A_EIC_EXTINT_NUM                   _L_(6)       /**< EIC signal: PIN_PA06 External Interrupt Line */
+
+#define PIN_PA17A_EIC_EXTINT6                      _L_(17)      /**< EIC signal: EXTINT6 on PA17 mux A*/
+#define MUX_PA17A_EIC_EXTINT6                      _L_(0)      
+#define PINMUX_PA17A_EIC_EXTINT6                   ((PIN_PA17A_EIC_EXTINT6 << 16) | MUX_PA17A_EIC_EXTINT6)
+#define PORT_PA17A_EIC_EXTINT6                     (_UL_(1) << 17)
+#define PIN_PA17A_EIC_EXTINT_NUM                   _L_(6)       /**< EIC signal: PIN_PA17 External Interrupt Line */
+
+#define PIN_PA30A_EIC_EXTINT6                      _L_(30)      /**< EIC signal: EXTINT6 on PA30 mux A*/
+#define MUX_PA30A_EIC_EXTINT6                      _L_(0)      
+#define PINMUX_PA30A_EIC_EXTINT6                   ((PIN_PA30A_EIC_EXTINT6 << 16) | MUX_PA30A_EIC_EXTINT6)
+#define PORT_PA30A_EIC_EXTINT6                     (_UL_(1) << 30)
+#define PIN_PA30A_EIC_EXTINT_NUM                   _L_(6)       /**< EIC signal: PIN_PA30 External Interrupt Line */
+
+#define PIN_PA07A_EIC_EXTINT7                      _L_(7)       /**< EIC signal: EXTINT7 on PA07 mux A*/
+#define MUX_PA07A_EIC_EXTINT7                      _L_(0)      
+#define PINMUX_PA07A_EIC_EXTINT7                   ((PIN_PA07A_EIC_EXTINT7 << 16) | MUX_PA07A_EIC_EXTINT7)
+#define PORT_PA07A_EIC_EXTINT7                     (_UL_(1) << 7)
+#define PIN_PA07A_EIC_EXTINT_NUM                   _L_(7)       /**< EIC signal: PIN_PA07 External Interrupt Line */
+
+#define PIN_PA18A_EIC_EXTINT7                      _L_(18)      /**< EIC signal: EXTINT7 on PA18 mux A*/
+#define MUX_PA18A_EIC_EXTINT7                      _L_(0)      
+#define PINMUX_PA18A_EIC_EXTINT7                   ((PIN_PA18A_EIC_EXTINT7 << 16) | MUX_PA18A_EIC_EXTINT7)
+#define PORT_PA18A_EIC_EXTINT7                     (_UL_(1) << 18)
+#define PIN_PA18A_EIC_EXTINT_NUM                   _L_(7)       /**< EIC signal: PIN_PA18 External Interrupt Line */
+
+#define PIN_PA31A_EIC_EXTINT7                      _L_(31)      /**< EIC signal: EXTINT7 on PA31 mux A*/
+#define MUX_PA31A_EIC_EXTINT7                      _L_(0)      
+#define PINMUX_PA31A_EIC_EXTINT7                   ((PIN_PA31A_EIC_EXTINT7 << 16) | MUX_PA31A_EIC_EXTINT7)
+#define PORT_PA31A_EIC_EXTINT7                     (_UL_(1) << 31)
+#define PIN_PA31A_EIC_EXTINT_NUM                   _L_(7)       /**< EIC signal: PIN_PA31 External Interrupt Line */
+
+#define PIN_PA08A_EIC_NMI                          _L_(8)       /**< EIC signal: NMI on PA08 mux A*/
+#define MUX_PA08A_EIC_NMI                          _L_(0)      
+#define PINMUX_PA08A_EIC_NMI                       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
+#define PORT_PA08A_EIC_NMI                         (_UL_(1) << 8)
+
+/* ========== PORT definition for GCLK peripheral ========== */
+#define PIN_PA30H_GCLK_IO0                         _L_(30)      /**< GCLK signal: IO0 on PA30 mux H*/
+#define MUX_PA30H_GCLK_IO0                         _L_(7)      
+#define PINMUX_PA30H_GCLK_IO0                      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
+#define PORT_PA30H_GCLK_IO0                        (_UL_(1) << 30)
+
+#define PIN_PA14H_GCLK_IO0                         _L_(14)      /**< GCLK signal: IO0 on PA14 mux H*/
+#define MUX_PA14H_GCLK_IO0                         _L_(7)      
+#define PINMUX_PA14H_GCLK_IO0                      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
+#define PORT_PA14H_GCLK_IO0                        (_UL_(1) << 14)
+
+#define PIN_PA27H_GCLK_IO0                         _L_(27)      /**< GCLK signal: IO0 on PA27 mux H*/
+#define MUX_PA27H_GCLK_IO0                         _L_(7)      
+#define PINMUX_PA27H_GCLK_IO0                      ((PIN_PA27H_GCLK_IO0 << 16) | MUX_PA27H_GCLK_IO0)
+#define PORT_PA27H_GCLK_IO0                        (_UL_(1) << 27)
+
+#define PIN_PA23H_GCLK_IO1                         _L_(23)      /**< GCLK signal: IO1 on PA23 mux H*/
+#define MUX_PA23H_GCLK_IO1                         _L_(7)      
+#define PINMUX_PA23H_GCLK_IO1                      ((PIN_PA23H_GCLK_IO1 << 16) | MUX_PA23H_GCLK_IO1)
+#define PORT_PA23H_GCLK_IO1                        (_UL_(1) << 23)
+
+#define PIN_PA15H_GCLK_IO1                         _L_(15)      /**< GCLK signal: IO1 on PA15 mux H*/
+#define MUX_PA15H_GCLK_IO1                         _L_(7)      
+#define PINMUX_PA15H_GCLK_IO1                      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
+#define PORT_PA15H_GCLK_IO1                        (_UL_(1) << 15)
+
+#define PIN_PA16H_GCLK_IO2                         _L_(16)      /**< GCLK signal: IO2 on PA16 mux H*/
+#define MUX_PA16H_GCLK_IO2                         _L_(7)      
+#define PINMUX_PA16H_GCLK_IO2                      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
+#define PORT_PA16H_GCLK_IO2                        (_UL_(1) << 16)
+
+#define PIN_PA22H_GCLK_IO2                         _L_(22)      /**< GCLK signal: IO2 on PA22 mux H*/
+#define MUX_PA22H_GCLK_IO2                         _L_(7)      
+#define PINMUX_PA22H_GCLK_IO2                      ((PIN_PA22H_GCLK_IO2 << 16) | MUX_PA22H_GCLK_IO2)
+#define PORT_PA22H_GCLK_IO2                        (_UL_(1) << 22)
+
+#define PIN_PA11H_GCLK_IO3                         _L_(11)      /**< GCLK signal: IO3 on PA11 mux H*/
+#define MUX_PA11H_GCLK_IO3                         _L_(7)      
+#define PINMUX_PA11H_GCLK_IO3                      ((PIN_PA11H_GCLK_IO3 << 16) | MUX_PA11H_GCLK_IO3)
+#define PORT_PA11H_GCLK_IO3                        (_UL_(1) << 11)
+
+#define PIN_PA17H_GCLK_IO3                         _L_(17)      /**< GCLK signal: IO3 on PA17 mux H*/
+#define MUX_PA17H_GCLK_IO3                         _L_(7)      
+#define PINMUX_PA17H_GCLK_IO3                      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
+#define PORT_PA17H_GCLK_IO3                        (_UL_(1) << 17)
+
+#define PIN_PA10H_GCLK_IO4                         _L_(10)      /**< GCLK signal: IO4 on PA10 mux H*/
+#define MUX_PA10H_GCLK_IO4                         _L_(7)      
+#define PINMUX_PA10H_GCLK_IO4                      ((PIN_PA10H_GCLK_IO4 << 16) | MUX_PA10H_GCLK_IO4)
+#define PORT_PA10H_GCLK_IO4                        (_UL_(1) << 10)
+
+/* ========== PORT definition for OPAMP peripheral ========== */
+#define PIN_PA02B_OPAMP_OANEG0                     _L_(2)       /**< OPAMP signal: OANEG0 on PA02 mux B*/
+#define MUX_PA02B_OPAMP_OANEG0                     _L_(1)      
+#define PINMUX_PA02B_OPAMP_OANEG0                  ((PIN_PA02B_OPAMP_OANEG0 << 16) | MUX_PA02B_OPAMP_OANEG0)
+#define PORT_PA02B_OPAMP_OANEG0                    (_UL_(1) << 2)
+
+#define PIN_PA00B_OPAMP_OANEG1                     _L_(0)       /**< OPAMP signal: OANEG1 on PA00 mux B*/
+#define MUX_PA00B_OPAMP_OANEG1                     _L_(1)      
+#define PINMUX_PA00B_OPAMP_OANEG1                  ((PIN_PA00B_OPAMP_OANEG1 << 16) | MUX_PA00B_OPAMP_OANEG1)
+#define PORT_PA00B_OPAMP_OANEG1                    (_UL_(1) << 0)
+
+#define PIN_PA03B_OPAMP_OANEG2                     _L_(3)       /**< OPAMP signal: OANEG2 on PA03 mux B*/
+#define MUX_PA03B_OPAMP_OANEG2                     _L_(1)      
+#define PINMUX_PA03B_OPAMP_OANEG2                  ((PIN_PA03B_OPAMP_OANEG2 << 16) | MUX_PA03B_OPAMP_OANEG2)
+#define PORT_PA03B_OPAMP_OANEG2                    (_UL_(1) << 3)
+
+#define PIN_PA07B_OPAMP_OAOUT0                     _L_(7)       /**< OPAMP signal: OAOUT0 on PA07 mux B*/
+#define MUX_PA07B_OPAMP_OAOUT0                     _L_(1)      
+#define PINMUX_PA07B_OPAMP_OAOUT0                  ((PIN_PA07B_OPAMP_OAOUT0 << 16) | MUX_PA07B_OPAMP_OAOUT0)
+#define PORT_PA07B_OPAMP_OAOUT0                    (_UL_(1) << 7)
+
+#define PIN_PA04B_OPAMP_OAOUT2                     _L_(4)       /**< OPAMP signal: OAOUT2 on PA04 mux B*/
+#define MUX_PA04B_OPAMP_OAOUT2                     _L_(1)      
+#define PINMUX_PA04B_OPAMP_OAOUT2                  ((PIN_PA04B_OPAMP_OAOUT2 << 16) | MUX_PA04B_OPAMP_OAOUT2)
+#define PORT_PA04B_OPAMP_OAOUT2                    (_UL_(1) << 4)
+
+#define PIN_PA06B_OPAMP_OAPOS0                     _L_(6)       /**< OPAMP signal: OAPOS0 on PA06 mux B*/
+#define MUX_PA06B_OPAMP_OAPOS0                     _L_(1)      
+#define PINMUX_PA06B_OPAMP_OAPOS0                  ((PIN_PA06B_OPAMP_OAPOS0 << 16) | MUX_PA06B_OPAMP_OAPOS0)
+#define PORT_PA06B_OPAMP_OAPOS0                    (_UL_(1) << 6)
+
+#define PIN_PA01B_OPAMP_OAPOS1                     _L_(1)       /**< OPAMP signal: OAPOS1 on PA01 mux B*/
+#define MUX_PA01B_OPAMP_OAPOS1                     _L_(1)      
+#define PINMUX_PA01B_OPAMP_OAPOS1                  ((PIN_PA01B_OPAMP_OAPOS1 << 16) | MUX_PA01B_OPAMP_OAPOS1)
+#define PORT_PA01B_OPAMP_OAPOS1                    (_UL_(1) << 1)
+
+#define PIN_PA05B_OPAMP_OAPOS2                     _L_(5)       /**< OPAMP signal: OAPOS2 on PA05 mux B*/
+#define MUX_PA05B_OPAMP_OAPOS2                     _L_(1)      
+#define PINMUX_PA05B_OPAMP_OAPOS2                  ((PIN_PA05B_OPAMP_OAPOS2 << 16) | MUX_PA05B_OPAMP_OAPOS2)
+#define PORT_PA05B_OPAMP_OAPOS2                    (_UL_(1) << 5)
+
+/* ========== PORT definition for PTC peripheral ========== */
+#define PIN_PA00F_PTC_DRV0                         _L_(0)       /**< PTC signal: DRV0 on PA00 mux F*/
+#define MUX_PA00F_PTC_DRV0                         _L_(5)      
+#define PINMUX_PA00F_PTC_DRV0                      ((PIN_PA00F_PTC_DRV0 << 16) | MUX_PA00F_PTC_DRV0)
+#define PORT_PA00F_PTC_DRV0                        (_UL_(1) << 0)
+
+#define PIN_PA01F_PTC_DRV1                         _L_(1)       /**< PTC signal: DRV1 on PA01 mux F*/
+#define MUX_PA01F_PTC_DRV1                         _L_(5)      
+#define PINMUX_PA01F_PTC_DRV1                      ((PIN_PA01F_PTC_DRV1 << 16) | MUX_PA01F_PTC_DRV1)
+#define PORT_PA01F_PTC_DRV1                        (_UL_(1) << 1)
+
+#define PIN_PA02F_PTC_DRV2                         _L_(2)       /**< PTC signal: DRV2 on PA02 mux F*/
+#define MUX_PA02F_PTC_DRV2                         _L_(5)      
+#define PINMUX_PA02F_PTC_DRV2                      ((PIN_PA02F_PTC_DRV2 << 16) | MUX_PA02F_PTC_DRV2)
+#define PORT_PA02F_PTC_DRV2                        (_UL_(1) << 2)
+
+#define PIN_PA03F_PTC_DRV3                         _L_(3)       /**< PTC signal: DRV3 on PA03 mux F*/
+#define MUX_PA03F_PTC_DRV3                         _L_(5)      
+#define PINMUX_PA03F_PTC_DRV3                      ((PIN_PA03F_PTC_DRV3 << 16) | MUX_PA03F_PTC_DRV3)
+#define PORT_PA03F_PTC_DRV3                        (_UL_(1) << 3)
+
+#define PIN_PA05F_PTC_DRV4                         _L_(5)       /**< PTC signal: DRV4 on PA05 mux F*/
+#define MUX_PA05F_PTC_DRV4                         _L_(5)      
+#define PINMUX_PA05F_PTC_DRV4                      ((PIN_PA05F_PTC_DRV4 << 16) | MUX_PA05F_PTC_DRV4)
+#define PORT_PA05F_PTC_DRV4                        (_UL_(1) << 5)
+
+#define PIN_PA06F_PTC_DRV5                         _L_(6)       /**< PTC signal: DRV5 on PA06 mux F*/
+#define MUX_PA06F_PTC_DRV5                         _L_(5)      
+#define PINMUX_PA06F_PTC_DRV5                      ((PIN_PA06F_PTC_DRV5 << 16) | MUX_PA06F_PTC_DRV5)
+#define PORT_PA06F_PTC_DRV5                        (_UL_(1) << 6)
+
+#define PIN_PA08F_PTC_DRV6                         _L_(8)       /**< PTC signal: DRV6 on PA08 mux F*/
+#define MUX_PA08F_PTC_DRV6                         _L_(5)      
+#define PINMUX_PA08F_PTC_DRV6                      ((PIN_PA08F_PTC_DRV6 << 16) | MUX_PA08F_PTC_DRV6)
+#define PORT_PA08F_PTC_DRV6                        (_UL_(1) << 8)
+
+#define PIN_PA09F_PTC_DRV7                         _L_(9)       /**< PTC signal: DRV7 on PA09 mux F*/
+#define MUX_PA09F_PTC_DRV7                         _L_(5)      
+#define PINMUX_PA09F_PTC_DRV7                      ((PIN_PA09F_PTC_DRV7 << 16) | MUX_PA09F_PTC_DRV7)
+#define PORT_PA09F_PTC_DRV7                        (_UL_(1) << 9)
+
+#define PIN_PA10F_PTC_DRV8                         _L_(10)      /**< PTC signal: DRV8 on PA10 mux F*/
+#define MUX_PA10F_PTC_DRV8                         _L_(5)      
+#define PINMUX_PA10F_PTC_DRV8                      ((PIN_PA10F_PTC_DRV8 << 16) | MUX_PA10F_PTC_DRV8)
+#define PORT_PA10F_PTC_DRV8                        (_UL_(1) << 10)
+
+#define PIN_PA11F_PTC_DRV9                         _L_(11)      /**< PTC signal: DRV9 on PA11 mux F*/
+#define MUX_PA11F_PTC_DRV9                         _L_(5)      
+#define PINMUX_PA11F_PTC_DRV9                      ((PIN_PA11F_PTC_DRV9 << 16) | MUX_PA11F_PTC_DRV9)
+#define PORT_PA11F_PTC_DRV9                        (_UL_(1) << 11)
+
+#define PIN_PA14F_PTC_DRV10                        _L_(14)      /**< PTC signal: DRV10 on PA14 mux F*/
+#define MUX_PA14F_PTC_DRV10                        _L_(5)      
+#define PINMUX_PA14F_PTC_DRV10                     ((PIN_PA14F_PTC_DRV10 << 16) | MUX_PA14F_PTC_DRV10)
+#define PORT_PA14F_PTC_DRV10                       (_UL_(1) << 14)
+
+#define PIN_PA15F_PTC_DRV11                        _L_(15)      /**< PTC signal: DRV11 on PA15 mux F*/
+#define MUX_PA15F_PTC_DRV11                        _L_(5)      
+#define PINMUX_PA15F_PTC_DRV11                     ((PIN_PA15F_PTC_DRV11 << 16) | MUX_PA15F_PTC_DRV11)
+#define PORT_PA15F_PTC_DRV11                       (_UL_(1) << 15)
+
+#define PIN_PA16F_PTC_DRV12                        _L_(16)      /**< PTC signal: DRV12 on PA16 mux F*/
+#define MUX_PA16F_PTC_DRV12                        _L_(5)      
+#define PINMUX_PA16F_PTC_DRV12                     ((PIN_PA16F_PTC_DRV12 << 16) | MUX_PA16F_PTC_DRV12)
+#define PORT_PA16F_PTC_DRV12                       (_UL_(1) << 16)
+
+#define PIN_PA17F_PTC_DRV13                        _L_(17)      /**< PTC signal: DRV13 on PA17 mux F*/
+#define MUX_PA17F_PTC_DRV13                        _L_(5)      
+#define PINMUX_PA17F_PTC_DRV13                     ((PIN_PA17F_PTC_DRV13 << 16) | MUX_PA17F_PTC_DRV13)
+#define PORT_PA17F_PTC_DRV13                       (_UL_(1) << 17)
+
+#define PIN_PA18F_PTC_DRV14                        _L_(18)      /**< PTC signal: DRV14 on PA18 mux F*/
+#define MUX_PA18F_PTC_DRV14                        _L_(5)      
+#define PINMUX_PA18F_PTC_DRV14                     ((PIN_PA18F_PTC_DRV14 << 16) | MUX_PA18F_PTC_DRV14)
+#define PORT_PA18F_PTC_DRV14                       (_UL_(1) << 18)
+
+#define PIN_PA19F_PTC_DRV15                        _L_(19)      /**< PTC signal: DRV15 on PA19 mux F*/
+#define MUX_PA19F_PTC_DRV15                        _L_(5)      
+#define PINMUX_PA19F_PTC_DRV15                     ((PIN_PA19F_PTC_DRV15 << 16) | MUX_PA19F_PTC_DRV15)
+#define PORT_PA19F_PTC_DRV15                       (_UL_(1) << 19)
+
+#define PIN_PA22F_PTC_DRV16                        _L_(22)      /**< PTC signal: DRV16 on PA22 mux F*/
+#define MUX_PA22F_PTC_DRV16                        _L_(5)      
+#define PINMUX_PA22F_PTC_DRV16                     ((PIN_PA22F_PTC_DRV16 << 16) | MUX_PA22F_PTC_DRV16)
+#define PORT_PA22F_PTC_DRV16                       (_UL_(1) << 22)
+
+#define PIN_PA23F_PTC_DRV17                        _L_(23)      /**< PTC signal: DRV17 on PA23 mux F*/
+#define MUX_PA23F_PTC_DRV17                        _L_(5)      
+#define PINMUX_PA23F_PTC_DRV17                     ((PIN_PA23F_PTC_DRV17 << 16) | MUX_PA23F_PTC_DRV17)
+#define PORT_PA23F_PTC_DRV17                       (_UL_(1) << 23)
+
+#define PIN_PA30F_PTC_DRV18                        _L_(30)      /**< PTC signal: DRV18 on PA30 mux F*/
+#define MUX_PA30F_PTC_DRV18                        _L_(5)      
+#define PINMUX_PA30F_PTC_DRV18                     ((PIN_PA30F_PTC_DRV18 << 16) | MUX_PA30F_PTC_DRV18)
+#define PORT_PA30F_PTC_DRV18                       (_UL_(1) << 30)
+
+#define PIN_PA31F_PTC_DRV19                        _L_(31)      /**< PTC signal: DRV19 on PA31 mux F*/
+#define MUX_PA31F_PTC_DRV19                        _L_(5)      
+#define PINMUX_PA31F_PTC_DRV19                     ((PIN_PA31F_PTC_DRV19 << 16) | MUX_PA31F_PTC_DRV19)
+#define PORT_PA31F_PTC_DRV19                       (_UL_(1) << 31)
+
+#define PIN_PA03B_PTC_ECI0                         _L_(3)       /**< PTC signal: ECI0 on PA03 mux B*/
+#define MUX_PA03B_PTC_ECI0                         _L_(1)      
+#define PINMUX_PA03B_PTC_ECI0                      ((PIN_PA03B_PTC_ECI0 << 16) | MUX_PA03B_PTC_ECI0)
+#define PORT_PA03B_PTC_ECI0                        (_UL_(1) << 3)
+
+#define PIN_PA04B_PTC_ECI1                         _L_(4)       /**< PTC signal: ECI1 on PA04 mux B*/
+#define MUX_PA04B_PTC_ECI1                         _L_(1)      
+#define PINMUX_PA04B_PTC_ECI1                      ((PIN_PA04B_PTC_ECI1 << 16) | MUX_PA04B_PTC_ECI1)
+#define PORT_PA04B_PTC_ECI1                        (_UL_(1) << 4)
+
+#define PIN_PA05B_PTC_ECI2                         _L_(5)       /**< PTC signal: ECI2 on PA05 mux B*/
+#define MUX_PA05B_PTC_ECI2                         _L_(1)      
+#define PINMUX_PA05B_PTC_ECI2                      ((PIN_PA05B_PTC_ECI2 << 16) | MUX_PA05B_PTC_ECI2)
+#define PORT_PA05B_PTC_ECI2                        (_UL_(1) << 5)
+
+#define PIN_PA06B_PTC_ECI3                         _L_(6)       /**< PTC signal: ECI3 on PA06 mux B*/
+#define MUX_PA06B_PTC_ECI3                         _L_(1)      
+#define PINMUX_PA06B_PTC_ECI3                      ((PIN_PA06B_PTC_ECI3 << 16) | MUX_PA06B_PTC_ECI3)
+#define PORT_PA06B_PTC_ECI3                        (_UL_(1) << 6)
+
+#define PIN_PA00B_PTC_X0                           _L_(0)       /**< PTC signal: X0 on PA00 mux B*/
+#define MUX_PA00B_PTC_X0                           _L_(1)      
+#define PINMUX_PA00B_PTC_X0                        ((PIN_PA00B_PTC_X0 << 16) | MUX_PA00B_PTC_X0)
+#define PORT_PA00B_PTC_X0                          (_UL_(1) << 0)
+
+#define PIN_PA00B_PTC_Y0                           _L_(0)       /**< PTC signal: Y0 on PA00 mux B*/
+#define MUX_PA00B_PTC_Y0                           _L_(1)      
+#define PINMUX_PA00B_PTC_Y0                        ((PIN_PA00B_PTC_Y0 << 16) | MUX_PA00B_PTC_Y0)
+#define PORT_PA00B_PTC_Y0                          (_UL_(1) << 0)
+
+#define PIN_PA01B_PTC_X1                           _L_(1)       /**< PTC signal: X1 on PA01 mux B*/
+#define MUX_PA01B_PTC_X1                           _L_(1)      
+#define PINMUX_PA01B_PTC_X1                        ((PIN_PA01B_PTC_X1 << 16) | MUX_PA01B_PTC_X1)
+#define PORT_PA01B_PTC_X1                          (_UL_(1) << 1)
+
+#define PIN_PA01B_PTC_Y1                           _L_(1)       /**< PTC signal: Y1 on PA01 mux B*/
+#define MUX_PA01B_PTC_Y1                           _L_(1)      
+#define PINMUX_PA01B_PTC_Y1                        ((PIN_PA01B_PTC_Y1 << 16) | MUX_PA01B_PTC_Y1)
+#define PORT_PA01B_PTC_Y1                          (_UL_(1) << 1)
+
+#define PIN_PA02B_PTC_X2                           _L_(2)       /**< PTC signal: X2 on PA02 mux B*/
+#define MUX_PA02B_PTC_X2                           _L_(1)      
+#define PINMUX_PA02B_PTC_X2                        ((PIN_PA02B_PTC_X2 << 16) | MUX_PA02B_PTC_X2)
+#define PORT_PA02B_PTC_X2                          (_UL_(1) << 2)
+
+#define PIN_PA02B_PTC_Y2                           _L_(2)       /**< PTC signal: Y2 on PA02 mux B*/
+#define MUX_PA02B_PTC_Y2                           _L_(1)      
+#define PINMUX_PA02B_PTC_Y2                        ((PIN_PA02B_PTC_Y2 << 16) | MUX_PA02B_PTC_Y2)
+#define PORT_PA02B_PTC_Y2                          (_UL_(1) << 2)
+
+#define PIN_PA03B_PTC_X3                           _L_(3)       /**< PTC signal: X3 on PA03 mux B*/
+#define MUX_PA03B_PTC_X3                           _L_(1)      
+#define PINMUX_PA03B_PTC_X3                        ((PIN_PA03B_PTC_X3 << 16) | MUX_PA03B_PTC_X3)
+#define PORT_PA03B_PTC_X3                          (_UL_(1) << 3)
+
+#define PIN_PA03B_PTC_Y3                           _L_(3)       /**< PTC signal: Y3 on PA03 mux B*/
+#define MUX_PA03B_PTC_Y3                           _L_(1)      
+#define PINMUX_PA03B_PTC_Y3                        ((PIN_PA03B_PTC_Y3 << 16) | MUX_PA03B_PTC_Y3)
+#define PORT_PA03B_PTC_Y3                          (_UL_(1) << 3)
+
+#define PIN_PA05B_PTC_X4                           _L_(5)       /**< PTC signal: X4 on PA05 mux B*/
+#define MUX_PA05B_PTC_X4                           _L_(1)      
+#define PINMUX_PA05B_PTC_X4                        ((PIN_PA05B_PTC_X4 << 16) | MUX_PA05B_PTC_X4)
+#define PORT_PA05B_PTC_X4                          (_UL_(1) << 5)
+
+#define PIN_PA05B_PTC_Y4                           _L_(5)       /**< PTC signal: Y4 on PA05 mux B*/
+#define MUX_PA05B_PTC_Y4                           _L_(1)      
+#define PINMUX_PA05B_PTC_Y4                        ((PIN_PA05B_PTC_Y4 << 16) | MUX_PA05B_PTC_Y4)
+#define PORT_PA05B_PTC_Y4                          (_UL_(1) << 5)
+
+#define PIN_PA06B_PTC_X5                           _L_(6)       /**< PTC signal: X5 on PA06 mux B*/
+#define MUX_PA06B_PTC_X5                           _L_(1)      
+#define PINMUX_PA06B_PTC_X5                        ((PIN_PA06B_PTC_X5 << 16) | MUX_PA06B_PTC_X5)
+#define PORT_PA06B_PTC_X5                          (_UL_(1) << 6)
+
+#define PIN_PA06B_PTC_Y5                           _L_(6)       /**< PTC signal: Y5 on PA06 mux B*/
+#define MUX_PA06B_PTC_Y5                           _L_(1)      
+#define PINMUX_PA06B_PTC_Y5                        ((PIN_PA06B_PTC_Y5 << 16) | MUX_PA06B_PTC_Y5)
+#define PORT_PA06B_PTC_Y5                          (_UL_(1) << 6)
+
+#define PIN_PA08B_PTC_X6                           _L_(8)       /**< PTC signal: X6 on PA08 mux B*/
+#define MUX_PA08B_PTC_X6                           _L_(1)      
+#define PINMUX_PA08B_PTC_X6                        ((PIN_PA08B_PTC_X6 << 16) | MUX_PA08B_PTC_X6)
+#define PORT_PA08B_PTC_X6                          (_UL_(1) << 8)
+
+#define PIN_PA08B_PTC_Y6                           _L_(8)       /**< PTC signal: Y6 on PA08 mux B*/
+#define MUX_PA08B_PTC_Y6                           _L_(1)      
+#define PINMUX_PA08B_PTC_Y6                        ((PIN_PA08B_PTC_Y6 << 16) | MUX_PA08B_PTC_Y6)
+#define PORT_PA08B_PTC_Y6                          (_UL_(1) << 8)
+
+#define PIN_PA09B_PTC_X7                           _L_(9)       /**< PTC signal: X7 on PA09 mux B*/
+#define MUX_PA09B_PTC_X7                           _L_(1)      
+#define PINMUX_PA09B_PTC_X7                        ((PIN_PA09B_PTC_X7 << 16) | MUX_PA09B_PTC_X7)
+#define PORT_PA09B_PTC_X7                          (_UL_(1) << 9)
+
+#define PIN_PA09B_PTC_Y7                           _L_(9)       /**< PTC signal: Y7 on PA09 mux B*/
+#define MUX_PA09B_PTC_Y7                           _L_(1)      
+#define PINMUX_PA09B_PTC_Y7                        ((PIN_PA09B_PTC_Y7 << 16) | MUX_PA09B_PTC_Y7)
+#define PORT_PA09B_PTC_Y7                          (_UL_(1) << 9)
+
+#define PIN_PA10B_PTC_X8                           _L_(10)      /**< PTC signal: X8 on PA10 mux B*/
+#define MUX_PA10B_PTC_X8                           _L_(1)      
+#define PINMUX_PA10B_PTC_X8                        ((PIN_PA10B_PTC_X8 << 16) | MUX_PA10B_PTC_X8)
+#define PORT_PA10B_PTC_X8                          (_UL_(1) << 10)
+
+#define PIN_PA10B_PTC_Y8                           _L_(10)      /**< PTC signal: Y8 on PA10 mux B*/
+#define MUX_PA10B_PTC_Y8                           _L_(1)      
+#define PINMUX_PA10B_PTC_Y8                        ((PIN_PA10B_PTC_Y8 << 16) | MUX_PA10B_PTC_Y8)
+#define PORT_PA10B_PTC_Y8                          (_UL_(1) << 10)
+
+#define PIN_PA11B_PTC_X9                           _L_(11)      /**< PTC signal: X9 on PA11 mux B*/
+#define MUX_PA11B_PTC_X9                           _L_(1)      
+#define PINMUX_PA11B_PTC_X9                        ((PIN_PA11B_PTC_X9 << 16) | MUX_PA11B_PTC_X9)
+#define PORT_PA11B_PTC_X9                          (_UL_(1) << 11)
+
+#define PIN_PA11B_PTC_Y9                           _L_(11)      /**< PTC signal: Y9 on PA11 mux B*/
+#define MUX_PA11B_PTC_Y9                           _L_(1)      
+#define PINMUX_PA11B_PTC_Y9                        ((PIN_PA11B_PTC_Y9 << 16) | MUX_PA11B_PTC_Y9)
+#define PORT_PA11B_PTC_Y9                          (_UL_(1) << 11)
+
+#define PIN_PA14B_PTC_X10                          _L_(14)      /**< PTC signal: X10 on PA14 mux B*/
+#define MUX_PA14B_PTC_X10                          _L_(1)      
+#define PINMUX_PA14B_PTC_X10                       ((PIN_PA14B_PTC_X10 << 16) | MUX_PA14B_PTC_X10)
+#define PORT_PA14B_PTC_X10                         (_UL_(1) << 14)
+
+#define PIN_PA14B_PTC_Y10                          _L_(14)      /**< PTC signal: Y10 on PA14 mux B*/
+#define MUX_PA14B_PTC_Y10                          _L_(1)      
+#define PINMUX_PA14B_PTC_Y10                       ((PIN_PA14B_PTC_Y10 << 16) | MUX_PA14B_PTC_Y10)
+#define PORT_PA14B_PTC_Y10                         (_UL_(1) << 14)
+
+#define PIN_PA15B_PTC_X11                          _L_(15)      /**< PTC signal: X11 on PA15 mux B*/
+#define MUX_PA15B_PTC_X11                          _L_(1)      
+#define PINMUX_PA15B_PTC_X11                       ((PIN_PA15B_PTC_X11 << 16) | MUX_PA15B_PTC_X11)
+#define PORT_PA15B_PTC_X11                         (_UL_(1) << 15)
+
+#define PIN_PA15B_PTC_Y11                          _L_(15)      /**< PTC signal: Y11 on PA15 mux B*/
+#define MUX_PA15B_PTC_Y11                          _L_(1)      
+#define PINMUX_PA15B_PTC_Y11                       ((PIN_PA15B_PTC_Y11 << 16) | MUX_PA15B_PTC_Y11)
+#define PORT_PA15B_PTC_Y11                         (_UL_(1) << 15)
+
+#define PIN_PA16B_PTC_X12                          _L_(16)      /**< PTC signal: X12 on PA16 mux B*/
+#define MUX_PA16B_PTC_X12                          _L_(1)      
+#define PINMUX_PA16B_PTC_X12                       ((PIN_PA16B_PTC_X12 << 16) | MUX_PA16B_PTC_X12)
+#define PORT_PA16B_PTC_X12                         (_UL_(1) << 16)
+
+#define PIN_PA16B_PTC_Y12                          _L_(16)      /**< PTC signal: Y12 on PA16 mux B*/
+#define MUX_PA16B_PTC_Y12                          _L_(1)      
+#define PINMUX_PA16B_PTC_Y12                       ((PIN_PA16B_PTC_Y12 << 16) | MUX_PA16B_PTC_Y12)
+#define PORT_PA16B_PTC_Y12                         (_UL_(1) << 16)
+
+#define PIN_PA17B_PTC_X13                          _L_(17)      /**< PTC signal: X13 on PA17 mux B*/
+#define MUX_PA17B_PTC_X13                          _L_(1)      
+#define PINMUX_PA17B_PTC_X13                       ((PIN_PA17B_PTC_X13 << 16) | MUX_PA17B_PTC_X13)
+#define PORT_PA17B_PTC_X13                         (_UL_(1) << 17)
+
+#define PIN_PA17B_PTC_Y13                          _L_(17)      /**< PTC signal: Y13 on PA17 mux B*/
+#define MUX_PA17B_PTC_Y13                          _L_(1)      
+#define PINMUX_PA17B_PTC_Y13                       ((PIN_PA17B_PTC_Y13 << 16) | MUX_PA17B_PTC_Y13)
+#define PORT_PA17B_PTC_Y13                         (_UL_(1) << 17)
+
+#define PIN_PA18B_PTC_X14                          _L_(18)      /**< PTC signal: X14 on PA18 mux B*/
+#define MUX_PA18B_PTC_X14                          _L_(1)      
+#define PINMUX_PA18B_PTC_X14                       ((PIN_PA18B_PTC_X14 << 16) | MUX_PA18B_PTC_X14)
+#define PORT_PA18B_PTC_X14                         (_UL_(1) << 18)
+
+#define PIN_PA18B_PTC_Y14                          _L_(18)      /**< PTC signal: Y14 on PA18 mux B*/
+#define MUX_PA18B_PTC_Y14                          _L_(1)      
+#define PINMUX_PA18B_PTC_Y14                       ((PIN_PA18B_PTC_Y14 << 16) | MUX_PA18B_PTC_Y14)
+#define PORT_PA18B_PTC_Y14                         (_UL_(1) << 18)
+
+#define PIN_PA19B_PTC_X15                          _L_(19)      /**< PTC signal: X15 on PA19 mux B*/
+#define MUX_PA19B_PTC_X15                          _L_(1)      
+#define PINMUX_PA19B_PTC_X15                       ((PIN_PA19B_PTC_X15 << 16) | MUX_PA19B_PTC_X15)
+#define PORT_PA19B_PTC_X15                         (_UL_(1) << 19)
+
+#define PIN_PA19B_PTC_Y15                          _L_(19)      /**< PTC signal: Y15 on PA19 mux B*/
+#define MUX_PA19B_PTC_Y15                          _L_(1)      
+#define PINMUX_PA19B_PTC_Y15                       ((PIN_PA19B_PTC_Y15 << 16) | MUX_PA19B_PTC_Y15)
+#define PORT_PA19B_PTC_Y15                         (_UL_(1) << 19)
+
+#define PIN_PA22B_PTC_X16                          _L_(22)      /**< PTC signal: X16 on PA22 mux B*/
+#define MUX_PA22B_PTC_X16                          _L_(1)      
+#define PINMUX_PA22B_PTC_X16                       ((PIN_PA22B_PTC_X16 << 16) | MUX_PA22B_PTC_X16)
+#define PORT_PA22B_PTC_X16                         (_UL_(1) << 22)
+
+#define PIN_PA22B_PTC_Y16                          _L_(22)      /**< PTC signal: Y16 on PA22 mux B*/
+#define MUX_PA22B_PTC_Y16                          _L_(1)      
+#define PINMUX_PA22B_PTC_Y16                       ((PIN_PA22B_PTC_Y16 << 16) | MUX_PA22B_PTC_Y16)
+#define PORT_PA22B_PTC_Y16                         (_UL_(1) << 22)
+
+#define PIN_PA23B_PTC_X17                          _L_(23)      /**< PTC signal: X17 on PA23 mux B*/
+#define MUX_PA23B_PTC_X17                          _L_(1)      
+#define PINMUX_PA23B_PTC_X17                       ((PIN_PA23B_PTC_X17 << 16) | MUX_PA23B_PTC_X17)
+#define PORT_PA23B_PTC_X17                         (_UL_(1) << 23)
+
+#define PIN_PA23B_PTC_Y17                          _L_(23)      /**< PTC signal: Y17 on PA23 mux B*/
+#define MUX_PA23B_PTC_Y17                          _L_(1)      
+#define PINMUX_PA23B_PTC_Y17                       ((PIN_PA23B_PTC_Y17 << 16) | MUX_PA23B_PTC_Y17)
+#define PORT_PA23B_PTC_Y17                         (_UL_(1) << 23)
+
+#define PIN_PA30B_PTC_X18                          _L_(30)      /**< PTC signal: X18 on PA30 mux B*/
+#define MUX_PA30B_PTC_X18                          _L_(1)      
+#define PINMUX_PA30B_PTC_X18                       ((PIN_PA30B_PTC_X18 << 16) | MUX_PA30B_PTC_X18)
+#define PORT_PA30B_PTC_X18                         (_UL_(1) << 30)
+
+#define PIN_PA30B_PTC_Y18                          _L_(30)      /**< PTC signal: Y18 on PA30 mux B*/
+#define MUX_PA30B_PTC_Y18                          _L_(1)      
+#define PINMUX_PA30B_PTC_Y18                       ((PIN_PA30B_PTC_Y18 << 16) | MUX_PA30B_PTC_Y18)
+#define PORT_PA30B_PTC_Y18                         (_UL_(1) << 30)
+
+#define PIN_PA31B_PTC_X19                          _L_(31)      /**< PTC signal: X19 on PA31 mux B*/
+#define MUX_PA31B_PTC_X19                          _L_(1)      
+#define PINMUX_PA31B_PTC_X19                       ((PIN_PA31B_PTC_X19 << 16) | MUX_PA31B_PTC_X19)
+#define PORT_PA31B_PTC_X19                         (_UL_(1) << 31)
+
+#define PIN_PA31B_PTC_Y19                          _L_(31)      /**< PTC signal: Y19 on PA31 mux B*/
+#define MUX_PA31B_PTC_Y19                          _L_(1)      
+#define PINMUX_PA31B_PTC_Y19                       ((PIN_PA31B_PTC_Y19 << 16) | MUX_PA31B_PTC_Y19)
+#define PORT_PA31B_PTC_Y19                         (_UL_(1) << 31)
+
+/* ========== PORT definition for RTC peripheral ========== */
+#define PIN_PA08G_RTC_IN0                          _L_(8)       /**< RTC signal: IN0 on PA08 mux G*/
+#define MUX_PA08G_RTC_IN0                          _L_(6)      
+#define PINMUX_PA08G_RTC_IN0                       ((PIN_PA08G_RTC_IN0 << 16) | MUX_PA08G_RTC_IN0)
+#define PORT_PA08G_RTC_IN0                         (_UL_(1) << 8)
+
+#define PIN_PA09G_RTC_IN1                          _L_(9)       /**< RTC signal: IN1 on PA09 mux G*/
+#define MUX_PA09G_RTC_IN1                          _L_(6)      
+#define PINMUX_PA09G_RTC_IN1                       ((PIN_PA09G_RTC_IN1 << 16) | MUX_PA09G_RTC_IN1)
+#define PORT_PA09G_RTC_IN1                         (_UL_(1) << 9)
+
+#define PIN_PA16G_RTC_IN2                          _L_(16)      /**< RTC signal: IN2 on PA16 mux G*/
+#define MUX_PA16G_RTC_IN2                          _L_(6)      
+#define PINMUX_PA16G_RTC_IN2                       ((PIN_PA16G_RTC_IN2 << 16) | MUX_PA16G_RTC_IN2)
+#define PORT_PA16G_RTC_IN2                         (_UL_(1) << 16)
+
+#define PIN_PA17G_RTC_IN3                          _L_(17)      /**< RTC signal: IN3 on PA17 mux G*/
+#define MUX_PA17G_RTC_IN3                          _L_(6)      
+#define PINMUX_PA17G_RTC_IN3                       ((PIN_PA17G_RTC_IN3 << 16) | MUX_PA17G_RTC_IN3)
+#define PORT_PA17G_RTC_IN3                         (_UL_(1) << 17)
+
+#define PIN_PA18G_RTC_OUT0                         _L_(18)      /**< RTC signal: OUT0 on PA18 mux G*/
+#define MUX_PA18G_RTC_OUT0                         _L_(6)      
+#define PINMUX_PA18G_RTC_OUT0                      ((PIN_PA18G_RTC_OUT0 << 16) | MUX_PA18G_RTC_OUT0)
+#define PORT_PA18G_RTC_OUT0                        (_UL_(1) << 18)
+
+#define PIN_PA19G_RTC_OUT1                         _L_(19)      /**< RTC signal: OUT1 on PA19 mux G*/
+#define MUX_PA19G_RTC_OUT1                         _L_(6)      
+#define PINMUX_PA19G_RTC_OUT1                      ((PIN_PA19G_RTC_OUT1 << 16) | MUX_PA19G_RTC_OUT1)
+#define PORT_PA19G_RTC_OUT1                        (_UL_(1) << 19)
+
+#define PIN_PA22G_RTC_OUT2                         _L_(22)      /**< RTC signal: OUT2 on PA22 mux G*/
+#define MUX_PA22G_RTC_OUT2                         _L_(6)      
+#define PINMUX_PA22G_RTC_OUT2                      ((PIN_PA22G_RTC_OUT2 << 16) | MUX_PA22G_RTC_OUT2)
+#define PORT_PA22G_RTC_OUT2                        (_UL_(1) << 22)
+
+#define PIN_PA23G_RTC_OUT3                         _L_(23)      /**< RTC signal: OUT3 on PA23 mux G*/
+#define MUX_PA23G_RTC_OUT3                         _L_(6)      
+#define PINMUX_PA23G_RTC_OUT3                      ((PIN_PA23G_RTC_OUT3 << 16) | MUX_PA23G_RTC_OUT3)
+#define PORT_PA23G_RTC_OUT3                        (_UL_(1) << 23)
+
+/* ========== PORT definition for SERCOM0 peripheral ========== */
+#define PIN_PA04D_SERCOM0_PAD0                     _L_(4)       /**< SERCOM0 signal: PAD0 on PA04 mux D*/
+#define MUX_PA04D_SERCOM0_PAD0                     _L_(3)      
+#define PINMUX_PA04D_SERCOM0_PAD0                  ((PIN_PA04D_SERCOM0_PAD0 << 16) | MUX_PA04D_SERCOM0_PAD0)
+#define PORT_PA04D_SERCOM0_PAD0                    (_UL_(1) << 4)
+
+#define PIN_PA16D_SERCOM0_PAD0                     _L_(16)      /**< SERCOM0 signal: PAD0 on PA16 mux D*/
+#define MUX_PA16D_SERCOM0_PAD0                     _L_(3)      
+#define PINMUX_PA16D_SERCOM0_PAD0                  ((PIN_PA16D_SERCOM0_PAD0 << 16) | MUX_PA16D_SERCOM0_PAD0)
+#define PORT_PA16D_SERCOM0_PAD0                    (_UL_(1) << 16)
+
+#define PIN_PA22C_SERCOM0_PAD0                     _L_(22)      /**< SERCOM0 signal: PAD0 on PA22 mux C*/
+#define MUX_PA22C_SERCOM0_PAD0                     _L_(2)      
+#define PINMUX_PA22C_SERCOM0_PAD0                  ((PIN_PA22C_SERCOM0_PAD0 << 16) | MUX_PA22C_SERCOM0_PAD0)
+#define PORT_PA22C_SERCOM0_PAD0                    (_UL_(1) << 22)
+
+#define PIN_PA05D_SERCOM0_PAD1                     _L_(5)       /**< SERCOM0 signal: PAD1 on PA05 mux D*/
+#define MUX_PA05D_SERCOM0_PAD1                     _L_(3)      
+#define PINMUX_PA05D_SERCOM0_PAD1                  ((PIN_PA05D_SERCOM0_PAD1 << 16) | MUX_PA05D_SERCOM0_PAD1)
+#define PORT_PA05D_SERCOM0_PAD1                    (_UL_(1) << 5)
+
+#define PIN_PA17D_SERCOM0_PAD1                     _L_(17)      /**< SERCOM0 signal: PAD1 on PA17 mux D*/
+#define MUX_PA17D_SERCOM0_PAD1                     _L_(3)      
+#define PINMUX_PA17D_SERCOM0_PAD1                  ((PIN_PA17D_SERCOM0_PAD1 << 16) | MUX_PA17D_SERCOM0_PAD1)
+#define PORT_PA17D_SERCOM0_PAD1                    (_UL_(1) << 17)
+
+#define PIN_PA23C_SERCOM0_PAD1                     _L_(23)      /**< SERCOM0 signal: PAD1 on PA23 mux C*/
+#define MUX_PA23C_SERCOM0_PAD1                     _L_(2)      
+#define PINMUX_PA23C_SERCOM0_PAD1                  ((PIN_PA23C_SERCOM0_PAD1 << 16) | MUX_PA23C_SERCOM0_PAD1)
+#define PORT_PA23C_SERCOM0_PAD1                    (_UL_(1) << 23)
+
+#define PIN_PA06D_SERCOM0_PAD2                     _L_(6)       /**< SERCOM0 signal: PAD2 on PA06 mux D*/
+#define MUX_PA06D_SERCOM0_PAD2                     _L_(3)      
+#define PINMUX_PA06D_SERCOM0_PAD2                  ((PIN_PA06D_SERCOM0_PAD2 << 16) | MUX_PA06D_SERCOM0_PAD2)
+#define PORT_PA06D_SERCOM0_PAD2                    (_UL_(1) << 6)
+
+#define PIN_PA14D_SERCOM0_PAD2                     _L_(14)      /**< SERCOM0 signal: PAD2 on PA14 mux D*/
+#define MUX_PA14D_SERCOM0_PAD2                     _L_(3)      
+#define PINMUX_PA14D_SERCOM0_PAD2                  ((PIN_PA14D_SERCOM0_PAD2 << 16) | MUX_PA14D_SERCOM0_PAD2)
+#define PORT_PA14D_SERCOM0_PAD2                    (_UL_(1) << 14)
+
+#define PIN_PA18D_SERCOM0_PAD2                     _L_(18)      /**< SERCOM0 signal: PAD2 on PA18 mux D*/
+#define MUX_PA18D_SERCOM0_PAD2                     _L_(3)      
+#define PINMUX_PA18D_SERCOM0_PAD2                  ((PIN_PA18D_SERCOM0_PAD2 << 16) | MUX_PA18D_SERCOM0_PAD2)
+#define PORT_PA18D_SERCOM0_PAD2                    (_UL_(1) << 18)
+
+#define PIN_PA24C_SERCOM0_PAD2                     _L_(24)      /**< SERCOM0 signal: PAD2 on PA24 mux C*/
+#define MUX_PA24C_SERCOM0_PAD2                     _L_(2)      
+#define PINMUX_PA24C_SERCOM0_PAD2                  ((PIN_PA24C_SERCOM0_PAD2 << 16) | MUX_PA24C_SERCOM0_PAD2)
+#define PORT_PA24C_SERCOM0_PAD2                    (_UL_(1) << 24)
+
+#define PIN_PA02D_SERCOM0_PAD2                     _L_(2)       /**< SERCOM0 signal: PAD2 on PA02 mux D*/
+#define MUX_PA02D_SERCOM0_PAD2                     _L_(3)      
+#define PINMUX_PA02D_SERCOM0_PAD2                  ((PIN_PA02D_SERCOM0_PAD2 << 16) | MUX_PA02D_SERCOM0_PAD2)
+#define PORT_PA02D_SERCOM0_PAD2                    (_UL_(1) << 2)
+
+#define PIN_PA07D_SERCOM0_PAD3                     _L_(7)       /**< SERCOM0 signal: PAD3 on PA07 mux D*/
+#define MUX_PA07D_SERCOM0_PAD3                     _L_(3)      
+#define PINMUX_PA07D_SERCOM0_PAD3                  ((PIN_PA07D_SERCOM0_PAD3 << 16) | MUX_PA07D_SERCOM0_PAD3)
+#define PORT_PA07D_SERCOM0_PAD3                    (_UL_(1) << 7)
+
+#define PIN_PA15D_SERCOM0_PAD3                     _L_(15)      /**< SERCOM0 signal: PAD3 on PA15 mux D*/
+#define MUX_PA15D_SERCOM0_PAD3                     _L_(3)      
+#define PINMUX_PA15D_SERCOM0_PAD3                  ((PIN_PA15D_SERCOM0_PAD3 << 16) | MUX_PA15D_SERCOM0_PAD3)
+#define PORT_PA15D_SERCOM0_PAD3                    (_UL_(1) << 15)
+
+#define PIN_PA19D_SERCOM0_PAD3                     _L_(19)      /**< SERCOM0 signal: PAD3 on PA19 mux D*/
+#define MUX_PA19D_SERCOM0_PAD3                     _L_(3)      
+#define PINMUX_PA19D_SERCOM0_PAD3                  ((PIN_PA19D_SERCOM0_PAD3 << 16) | MUX_PA19D_SERCOM0_PAD3)
+#define PORT_PA19D_SERCOM0_PAD3                    (_UL_(1) << 19)
+
+#define PIN_PA25C_SERCOM0_PAD3                     _L_(25)      /**< SERCOM0 signal: PAD3 on PA25 mux C*/
+#define MUX_PA25C_SERCOM0_PAD3                     _L_(2)      
+#define PINMUX_PA25C_SERCOM0_PAD3                  ((PIN_PA25C_SERCOM0_PAD3 << 16) | MUX_PA25C_SERCOM0_PAD3)
+#define PORT_PA25C_SERCOM0_PAD3                    (_UL_(1) << 25)
+
+#define PIN_PA03D_SERCOM0_PAD3                     _L_(3)       /**< SERCOM0 signal: PAD3 on PA03 mux D*/
+#define MUX_PA03D_SERCOM0_PAD3                     _L_(3)      
+#define PINMUX_PA03D_SERCOM0_PAD3                  ((PIN_PA03D_SERCOM0_PAD3 << 16) | MUX_PA03D_SERCOM0_PAD3)
+#define PORT_PA03D_SERCOM0_PAD3                    (_UL_(1) << 3)
+
+/* ========== PORT definition for SERCOM1 peripheral ========== */
+#define PIN_PA16C_SERCOM1_PAD0                     _L_(16)      /**< SERCOM1 signal: PAD0 on PA16 mux C*/
+#define MUX_PA16C_SERCOM1_PAD0                     _L_(2)      
+#define PINMUX_PA16C_SERCOM1_PAD0                  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
+#define PORT_PA16C_SERCOM1_PAD0                    (_UL_(1) << 16)
+
+#define PIN_PA08C_SERCOM1_PAD0                     _L_(8)       /**< SERCOM1 signal: PAD0 on PA08 mux C*/
+#define MUX_PA08C_SERCOM1_PAD0                     _L_(2)      
+#define PINMUX_PA08C_SERCOM1_PAD0                  ((PIN_PA08C_SERCOM1_PAD0 << 16) | MUX_PA08C_SERCOM1_PAD0)
+#define PORT_PA08C_SERCOM1_PAD0                    (_UL_(1) << 8)
+
+#define PIN_PA00D_SERCOM1_PAD0                     _L_(0)       /**< SERCOM1 signal: PAD0 on PA00 mux D*/
+#define MUX_PA00D_SERCOM1_PAD0                     _L_(3)      
+#define PINMUX_PA00D_SERCOM1_PAD0                  ((PIN_PA00D_SERCOM1_PAD0 << 16) | MUX_PA00D_SERCOM1_PAD0)
+#define PORT_PA00D_SERCOM1_PAD0                    (_UL_(1) << 0)
+
+#define PIN_PA17C_SERCOM1_PAD1                     _L_(17)      /**< SERCOM1 signal: PAD1 on PA17 mux C*/
+#define MUX_PA17C_SERCOM1_PAD1                     _L_(2)      
+#define PINMUX_PA17C_SERCOM1_PAD1                  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
+#define PORT_PA17C_SERCOM1_PAD1                    (_UL_(1) << 17)
+
+#define PIN_PA09C_SERCOM1_PAD1                     _L_(9)       /**< SERCOM1 signal: PAD1 on PA09 mux C*/
+#define MUX_PA09C_SERCOM1_PAD1                     _L_(2)      
+#define PINMUX_PA09C_SERCOM1_PAD1                  ((PIN_PA09C_SERCOM1_PAD1 << 16) | MUX_PA09C_SERCOM1_PAD1)
+#define PORT_PA09C_SERCOM1_PAD1                    (_UL_(1) << 9)
+
+#define PIN_PA01D_SERCOM1_PAD1                     _L_(1)       /**< SERCOM1 signal: PAD1 on PA01 mux D*/
+#define MUX_PA01D_SERCOM1_PAD1                     _L_(3)      
+#define PINMUX_PA01D_SERCOM1_PAD1                  ((PIN_PA01D_SERCOM1_PAD1 << 16) | MUX_PA01D_SERCOM1_PAD1)
+#define PORT_PA01D_SERCOM1_PAD1                    (_UL_(1) << 1)
+
+#define PIN_PA18C_SERCOM1_PAD2                     _L_(18)      /**< SERCOM1 signal: PAD2 on PA18 mux C*/
+#define MUX_PA18C_SERCOM1_PAD2                     _L_(2)      
+#define PINMUX_PA18C_SERCOM1_PAD2                  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
+#define PORT_PA18C_SERCOM1_PAD2                    (_UL_(1) << 18)
+
+#define PIN_PA10C_SERCOM1_PAD2                     _L_(10)      /**< SERCOM1 signal: PAD2 on PA10 mux C*/
+#define MUX_PA10C_SERCOM1_PAD2                     _L_(2)      
+#define PINMUX_PA10C_SERCOM1_PAD2                  ((PIN_PA10C_SERCOM1_PAD2 << 16) | MUX_PA10C_SERCOM1_PAD2)
+#define PORT_PA10C_SERCOM1_PAD2                    (_UL_(1) << 10)
+
+#define PIN_PA30D_SERCOM1_PAD2                     _L_(30)      /**< SERCOM1 signal: PAD2 on PA30 mux D*/
+#define MUX_PA30D_SERCOM1_PAD2                     _L_(3)      
+#define PINMUX_PA30D_SERCOM1_PAD2                  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
+#define PORT_PA30D_SERCOM1_PAD2                    (_UL_(1) << 30)
+
+#define PIN_PA19C_SERCOM1_PAD3                     _L_(19)      /**< SERCOM1 signal: PAD3 on PA19 mux C*/
+#define MUX_PA19C_SERCOM1_PAD3                     _L_(2)      
+#define PINMUX_PA19C_SERCOM1_PAD3                  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
+#define PORT_PA19C_SERCOM1_PAD3                    (_UL_(1) << 19)
+
+#define PIN_PA11C_SERCOM1_PAD3                     _L_(11)      /**< SERCOM1 signal: PAD3 on PA11 mux C*/
+#define MUX_PA11C_SERCOM1_PAD3                     _L_(2)      
+#define PINMUX_PA11C_SERCOM1_PAD3                  ((PIN_PA11C_SERCOM1_PAD3 << 16) | MUX_PA11C_SERCOM1_PAD3)
+#define PORT_PA11C_SERCOM1_PAD3                    (_UL_(1) << 11)
+
+#define PIN_PA31D_SERCOM1_PAD3                     _L_(31)      /**< SERCOM1 signal: PAD3 on PA31 mux D*/
+#define MUX_PA31D_SERCOM1_PAD3                     _L_(3)      
+#define PINMUX_PA31D_SERCOM1_PAD3                  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
+#define PORT_PA31D_SERCOM1_PAD3                    (_UL_(1) << 31)
+
+/* ========== PORT definition for SERCOM2 peripheral ========== */
+#define PIN_PA08D_SERCOM2_PAD0                     _L_(8)       /**< SERCOM2 signal: PAD0 on PA08 mux D*/
+#define MUX_PA08D_SERCOM2_PAD0                     _L_(3)      
+#define PINMUX_PA08D_SERCOM2_PAD0                  ((PIN_PA08D_SERCOM2_PAD0 << 16) | MUX_PA08D_SERCOM2_PAD0)
+#define PORT_PA08D_SERCOM2_PAD0                    (_UL_(1) << 8)
+
+#define PIN_PA22D_SERCOM2_PAD0                     _L_(22)      /**< SERCOM2 signal: PAD0 on PA22 mux D*/
+#define MUX_PA22D_SERCOM2_PAD0                     _L_(3)      
+#define PINMUX_PA22D_SERCOM2_PAD0                  ((PIN_PA22D_SERCOM2_PAD0 << 16) | MUX_PA22D_SERCOM2_PAD0)
+#define PORT_PA22D_SERCOM2_PAD0                    (_UL_(1) << 22)
+
+#define PIN_PA09D_SERCOM2_PAD1                     _L_(9)       /**< SERCOM2 signal: PAD1 on PA09 mux D*/
+#define MUX_PA09D_SERCOM2_PAD1                     _L_(3)      
+#define PINMUX_PA09D_SERCOM2_PAD1                  ((PIN_PA09D_SERCOM2_PAD1 << 16) | MUX_PA09D_SERCOM2_PAD1)
+#define PORT_PA09D_SERCOM2_PAD1                    (_UL_(1) << 9)
+
+#define PIN_PA23D_SERCOM2_PAD1                     _L_(23)      /**< SERCOM2 signal: PAD1 on PA23 mux D*/
+#define MUX_PA23D_SERCOM2_PAD1                     _L_(3)      
+#define PINMUX_PA23D_SERCOM2_PAD1                  ((PIN_PA23D_SERCOM2_PAD1 << 16) | MUX_PA23D_SERCOM2_PAD1)
+#define PORT_PA23D_SERCOM2_PAD1                    (_UL_(1) << 23)
+
+#define PIN_PA10D_SERCOM2_PAD2                     _L_(10)      /**< SERCOM2 signal: PAD2 on PA10 mux D*/
+#define MUX_PA10D_SERCOM2_PAD2                     _L_(3)      
+#define PINMUX_PA10D_SERCOM2_PAD2                  ((PIN_PA10D_SERCOM2_PAD2 << 16) | MUX_PA10D_SERCOM2_PAD2)
+#define PORT_PA10D_SERCOM2_PAD2                    (_UL_(1) << 10)
+
+#define PIN_PA24D_SERCOM2_PAD2                     _L_(24)      /**< SERCOM2 signal: PAD2 on PA24 mux D*/
+#define MUX_PA24D_SERCOM2_PAD2                     _L_(3)      
+#define PINMUX_PA24D_SERCOM2_PAD2                  ((PIN_PA24D_SERCOM2_PAD2 << 16) | MUX_PA24D_SERCOM2_PAD2)
+#define PORT_PA24D_SERCOM2_PAD2                    (_UL_(1) << 24)
+
+#define PIN_PA14C_SERCOM2_PAD2                     _L_(14)      /**< SERCOM2 signal: PAD2 on PA14 mux C*/
+#define MUX_PA14C_SERCOM2_PAD2                     _L_(2)      
+#define PINMUX_PA14C_SERCOM2_PAD2                  ((PIN_PA14C_SERCOM2_PAD2 << 16) | MUX_PA14C_SERCOM2_PAD2)
+#define PORT_PA14C_SERCOM2_PAD2                    (_UL_(1) << 14)
+
+#define PIN_PA11D_SERCOM2_PAD3                     _L_(11)      /**< SERCOM2 signal: PAD3 on PA11 mux D*/
+#define MUX_PA11D_SERCOM2_PAD3                     _L_(3)      
+#define PINMUX_PA11D_SERCOM2_PAD3                  ((PIN_PA11D_SERCOM2_PAD3 << 16) | MUX_PA11D_SERCOM2_PAD3)
+#define PORT_PA11D_SERCOM2_PAD3                    (_UL_(1) << 11)
+
+#define PIN_PA25D_SERCOM2_PAD3                     _L_(25)      /**< SERCOM2 signal: PAD3 on PA25 mux D*/
+#define MUX_PA25D_SERCOM2_PAD3                     _L_(3)      
+#define PINMUX_PA25D_SERCOM2_PAD3                  ((PIN_PA25D_SERCOM2_PAD3 << 16) | MUX_PA25D_SERCOM2_PAD3)
+#define PORT_PA25D_SERCOM2_PAD3                    (_UL_(1) << 25)
+
+#define PIN_PA15C_SERCOM2_PAD3                     _L_(15)      /**< SERCOM2 signal: PAD3 on PA15 mux C*/
+#define MUX_PA15C_SERCOM2_PAD3                     _L_(2)      
+#define PINMUX_PA15C_SERCOM2_PAD3                  ((PIN_PA15C_SERCOM2_PAD3 << 16) | MUX_PA15C_SERCOM2_PAD3)
+#define PORT_PA15C_SERCOM2_PAD3                    (_UL_(1) << 15)
+
+/* ========== PORT definition for TC0 peripheral ========== */
+#define PIN_PA04E_TC0_WO0                          _L_(4)       /**< TC0 signal: WO0 on PA04 mux E*/
+#define MUX_PA04E_TC0_WO0                          _L_(4)      
+#define PINMUX_PA04E_TC0_WO0                       ((PIN_PA04E_TC0_WO0 << 16) | MUX_PA04E_TC0_WO0)
+#define PORT_PA04E_TC0_WO0                         (_UL_(1) << 4)
+
+#define PIN_PA14E_TC0_WO0                          _L_(14)      /**< TC0 signal: WO0 on PA14 mux E*/
+#define MUX_PA14E_TC0_WO0                          _L_(4)      
+#define PINMUX_PA14E_TC0_WO0                       ((PIN_PA14E_TC0_WO0 << 16) | MUX_PA14E_TC0_WO0)
+#define PORT_PA14E_TC0_WO0                         (_UL_(1) << 14)
+
+#define PIN_PA22E_TC0_WO0                          _L_(22)      /**< TC0 signal: WO0 on PA22 mux E*/
+#define MUX_PA22E_TC0_WO0                          _L_(4)      
+#define PINMUX_PA22E_TC0_WO0                       ((PIN_PA22E_TC0_WO0 << 16) | MUX_PA22E_TC0_WO0)
+#define PORT_PA22E_TC0_WO0                         (_UL_(1) << 22)
+
+#define PIN_PA05E_TC0_WO1                          _L_(5)       /**< TC0 signal: WO1 on PA05 mux E*/
+#define MUX_PA05E_TC0_WO1                          _L_(4)      
+#define PINMUX_PA05E_TC0_WO1                       ((PIN_PA05E_TC0_WO1 << 16) | MUX_PA05E_TC0_WO1)
+#define PORT_PA05E_TC0_WO1                         (_UL_(1) << 5)
+
+#define PIN_PA15E_TC0_WO1                          _L_(15)      /**< TC0 signal: WO1 on PA15 mux E*/
+#define MUX_PA15E_TC0_WO1                          _L_(4)      
+#define PINMUX_PA15E_TC0_WO1                       ((PIN_PA15E_TC0_WO1 << 16) | MUX_PA15E_TC0_WO1)
+#define PORT_PA15E_TC0_WO1                         (_UL_(1) << 15)
+
+#define PIN_PA23E_TC0_WO1                          _L_(23)      /**< TC0 signal: WO1 on PA23 mux E*/
+#define MUX_PA23E_TC0_WO1                          _L_(4)      
+#define PINMUX_PA23E_TC0_WO1                       ((PIN_PA23E_TC0_WO1 << 16) | MUX_PA23E_TC0_WO1)
+#define PORT_PA23E_TC0_WO1                         (_UL_(1) << 23)
+
+/* ========== PORT definition for TC1 peripheral ========== */
+#define PIN_PA06E_TC1_WO0                          _L_(6)       /**< TC1 signal: WO0 on PA06 mux E*/
+#define MUX_PA06E_TC1_WO0                          _L_(4)      
+#define PINMUX_PA06E_TC1_WO0                       ((PIN_PA06E_TC1_WO0 << 16) | MUX_PA06E_TC1_WO0)
+#define PORT_PA06E_TC1_WO0                         (_UL_(1) << 6)
+
+#define PIN_PA24E_TC1_WO0                          _L_(24)      /**< TC1 signal: WO0 on PA24 mux E*/
+#define MUX_PA24E_TC1_WO0                          _L_(4)      
+#define PINMUX_PA24E_TC1_WO0                       ((PIN_PA24E_TC1_WO0 << 16) | MUX_PA24E_TC1_WO0)
+#define PORT_PA24E_TC1_WO0                         (_UL_(1) << 24)
+
+#define PIN_PA30E_TC1_WO0                          _L_(30)      /**< TC1 signal: WO0 on PA30 mux E*/
+#define MUX_PA30E_TC1_WO0                          _L_(4)      
+#define PINMUX_PA30E_TC1_WO0                       ((PIN_PA30E_TC1_WO0 << 16) | MUX_PA30E_TC1_WO0)
+#define PORT_PA30E_TC1_WO0                         (_UL_(1) << 30)
+
+#define PIN_PA07E_TC1_WO1                          _L_(7)       /**< TC1 signal: WO1 on PA07 mux E*/
+#define MUX_PA07E_TC1_WO1                          _L_(4)      
+#define PINMUX_PA07E_TC1_WO1                       ((PIN_PA07E_TC1_WO1 << 16) | MUX_PA07E_TC1_WO1)
+#define PORT_PA07E_TC1_WO1                         (_UL_(1) << 7)
+
+#define PIN_PA25E_TC1_WO1                          _L_(25)      /**< TC1 signal: WO1 on PA25 mux E*/
+#define MUX_PA25E_TC1_WO1                          _L_(4)      
+#define PINMUX_PA25E_TC1_WO1                       ((PIN_PA25E_TC1_WO1 << 16) | MUX_PA25E_TC1_WO1)
+#define PORT_PA25E_TC1_WO1                         (_UL_(1) << 25)
+
+#define PIN_PA31E_TC1_WO1                          _L_(31)      /**< TC1 signal: WO1 on PA31 mux E*/
+#define MUX_PA31E_TC1_WO1                          _L_(4)      
+#define PINMUX_PA31E_TC1_WO1                       ((PIN_PA31E_TC1_WO1 << 16) | MUX_PA31E_TC1_WO1)
+#define PORT_PA31E_TC1_WO1                         (_UL_(1) << 31)
+
+/* ========== PORT definition for TC2 peripheral ========== */
+#define PIN_PA00E_TC2_WO0                          _L_(0)       /**< TC2 signal: WO0 on PA00 mux E*/
+#define MUX_PA00E_TC2_WO0                          _L_(4)      
+#define PINMUX_PA00E_TC2_WO0                       ((PIN_PA00E_TC2_WO0 << 16) | MUX_PA00E_TC2_WO0)
+#define PORT_PA00E_TC2_WO0                         (_UL_(1) << 0)
+
+#define PIN_PA18E_TC2_WO0                          _L_(18)      /**< TC2 signal: WO0 on PA18 mux E*/
+#define MUX_PA18E_TC2_WO0                          _L_(4)      
+#define PINMUX_PA18E_TC2_WO0                       ((PIN_PA18E_TC2_WO0 << 16) | MUX_PA18E_TC2_WO0)
+#define PORT_PA18E_TC2_WO0                         (_UL_(1) << 18)
+
+#define PIN_PA01E_TC2_WO1                          _L_(1)       /**< TC2 signal: WO1 on PA01 mux E*/
+#define MUX_PA01E_TC2_WO1                          _L_(4)      
+#define PINMUX_PA01E_TC2_WO1                       ((PIN_PA01E_TC2_WO1 << 16) | MUX_PA01E_TC2_WO1)
+#define PORT_PA01E_TC2_WO1                         (_UL_(1) << 1)
+
+#define PIN_PA19E_TC2_WO1                          _L_(19)      /**< TC2 signal: WO1 on PA19 mux E*/
+#define MUX_PA19E_TC2_WO1                          _L_(4)      
+#define PINMUX_PA19E_TC2_WO1                       ((PIN_PA19E_TC2_WO1 << 16) | MUX_PA19E_TC2_WO1)
+#define PORT_PA19E_TC2_WO1                         (_UL_(1) << 19)
+
+
+#endif /* _SAML11E14A_PIO_H_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/pio/saml11e15a.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/pio/saml11e15a.h
@@ -1,0 +1,1167 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAML11E15A
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11E15A_PIO_H_
+#define _SAML11E15A_PIO_H_
+
+/* ========== Peripheral I/O pin numbers ========== */
+#define PIN_PA00                    (  0)  /**< Pin Number for PA00 */
+#define PIN_PA01                    (  1)  /**< Pin Number for PA01 */
+#define PIN_PA02                    (  2)  /**< Pin Number for PA02 */
+#define PIN_PA03                    (  3)  /**< Pin Number for PA03 */
+#define PIN_PA04                    (  4)  /**< Pin Number for PA04 */
+#define PIN_PA05                    (  5)  /**< Pin Number for PA05 */
+#define PIN_PA06                    (  6)  /**< Pin Number for PA06 */
+#define PIN_PA07                    (  7)  /**< Pin Number for PA07 */
+#define PIN_PA08                    (  8)  /**< Pin Number for PA08 */
+#define PIN_PA09                    (  9)  /**< Pin Number for PA09 */
+#define PIN_PA10                    ( 10)  /**< Pin Number for PA10 */
+#define PIN_PA11                    ( 11)  /**< Pin Number for PA11 */
+#define PIN_PA14                    ( 14)  /**< Pin Number for PA14 */
+#define PIN_PA15                    ( 15)  /**< Pin Number for PA15 */
+#define PIN_PA16                    ( 16)  /**< Pin Number for PA16 */
+#define PIN_PA17                    ( 17)  /**< Pin Number for PA17 */
+#define PIN_PA18                    ( 18)  /**< Pin Number for PA18 */
+#define PIN_PA19                    ( 19)  /**< Pin Number for PA19 */
+#define PIN_PA22                    ( 22)  /**< Pin Number for PA22 */
+#define PIN_PA23                    ( 23)  /**< Pin Number for PA23 */
+#define PIN_PA24                    ( 24)  /**< Pin Number for PA24 */
+#define PIN_PA25                    ( 25)  /**< Pin Number for PA25 */
+#define PIN_PA27                    ( 27)  /**< Pin Number for PA27 */
+#define PIN_PA30                    ( 30)  /**< Pin Number for PA30 */
+#define PIN_PA31                    ( 31)  /**< Pin Number for PA31 */
+
+
+/* ========== Peripheral I/O masks ========== */
+#define PORT_PA00                   (_U_(1) << 0) /**< PORT Mask for PA00 */
+#define PORT_PA01                   (_U_(1) << 1) /**< PORT Mask for PA01 */
+#define PORT_PA02                   (_U_(1) << 2) /**< PORT Mask for PA02 */
+#define PORT_PA03                   (_U_(1) << 3) /**< PORT Mask for PA03 */
+#define PORT_PA04                   (_U_(1) << 4) /**< PORT Mask for PA04 */
+#define PORT_PA05                   (_U_(1) << 5) /**< PORT Mask for PA05 */
+#define PORT_PA06                   (_U_(1) << 6) /**< PORT Mask for PA06 */
+#define PORT_PA07                   (_U_(1) << 7) /**< PORT Mask for PA07 */
+#define PORT_PA08                   (_U_(1) << 8) /**< PORT Mask for PA08 */
+#define PORT_PA09                   (_U_(1) << 9) /**< PORT Mask for PA09 */
+#define PORT_PA10                   (_U_(1) << 10) /**< PORT Mask for PA10 */
+#define PORT_PA11                   (_U_(1) << 11) /**< PORT Mask for PA11 */
+#define PORT_PA14                   (_U_(1) << 14) /**< PORT Mask for PA14 */
+#define PORT_PA15                   (_U_(1) << 15) /**< PORT Mask for PA15 */
+#define PORT_PA16                   (_U_(1) << 16) /**< PORT Mask for PA16 */
+#define PORT_PA17                   (_U_(1) << 17) /**< PORT Mask for PA17 */
+#define PORT_PA18                   (_U_(1) << 18) /**< PORT Mask for PA18 */
+#define PORT_PA19                   (_U_(1) << 19) /**< PORT Mask for PA19 */
+#define PORT_PA22                   (_U_(1) << 22) /**< PORT Mask for PA22 */
+#define PORT_PA23                   (_U_(1) << 23) /**< PORT Mask for PA23 */
+#define PORT_PA24                   (_U_(1) << 24) /**< PORT Mask for PA24 */
+#define PORT_PA25                   (_U_(1) << 25) /**< PORT Mask for PA25 */
+#define PORT_PA27                   (_U_(1) << 27) /**< PORT Mask for PA27 */
+#define PORT_PA30                   (_U_(1) << 30) /**< PORT Mask for PA30 */
+#define PORT_PA31                   (_U_(1) << 31) /**< PORT Mask for PA31 */
+
+
+/* ========== Peripheral I/O indexes ========== */
+#define PORT_PA00_IDX               (  0)  /**< PORT Index Number for PA00 */
+#define PORT_PA01_IDX               (  1)  /**< PORT Index Number for PA01 */
+#define PORT_PA02_IDX               (  2)  /**< PORT Index Number for PA02 */
+#define PORT_PA03_IDX               (  3)  /**< PORT Index Number for PA03 */
+#define PORT_PA04_IDX               (  4)  /**< PORT Index Number for PA04 */
+#define PORT_PA05_IDX               (  5)  /**< PORT Index Number for PA05 */
+#define PORT_PA06_IDX               (  6)  /**< PORT Index Number for PA06 */
+#define PORT_PA07_IDX               (  7)  /**< PORT Index Number for PA07 */
+#define PORT_PA08_IDX               (  8)  /**< PORT Index Number for PA08 */
+#define PORT_PA09_IDX               (  9)  /**< PORT Index Number for PA09 */
+#define PORT_PA10_IDX               ( 10)  /**< PORT Index Number for PA10 */
+#define PORT_PA11_IDX               ( 11)  /**< PORT Index Number for PA11 */
+#define PORT_PA14_IDX               ( 14)  /**< PORT Index Number for PA14 */
+#define PORT_PA15_IDX               ( 15)  /**< PORT Index Number for PA15 */
+#define PORT_PA16_IDX               ( 16)  /**< PORT Index Number for PA16 */
+#define PORT_PA17_IDX               ( 17)  /**< PORT Index Number for PA17 */
+#define PORT_PA18_IDX               ( 18)  /**< PORT Index Number for PA18 */
+#define PORT_PA19_IDX               ( 19)  /**< PORT Index Number for PA19 */
+#define PORT_PA22_IDX               ( 22)  /**< PORT Index Number for PA22 */
+#define PORT_PA23_IDX               ( 23)  /**< PORT Index Number for PA23 */
+#define PORT_PA24_IDX               ( 24)  /**< PORT Index Number for PA24 */
+#define PORT_PA25_IDX               ( 25)  /**< PORT Index Number for PA25 */
+#define PORT_PA27_IDX               ( 27)  /**< PORT Index Number for PA27 */
+#define PORT_PA30_IDX               ( 30)  /**< PORT Index Number for PA30 */
+#define PORT_PA31_IDX               ( 31)  /**< PORT Index Number for PA31 */
+
+/* ========== PORT definition for AC peripheral ========== */
+#define PIN_PA04B_AC_AIN0                          _L_(4)       /**< AC signal: AIN0 on PA04 mux B*/
+#define MUX_PA04B_AC_AIN0                          _L_(1)      
+#define PINMUX_PA04B_AC_AIN0                       ((PIN_PA04B_AC_AIN0 << 16) | MUX_PA04B_AC_AIN0)
+#define PORT_PA04B_AC_AIN0                         (_UL_(1) << 4)
+
+#define PIN_PA05B_AC_AIN1                          _L_(5)       /**< AC signal: AIN1 on PA05 mux B*/
+#define MUX_PA05B_AC_AIN1                          _L_(1)      
+#define PINMUX_PA05B_AC_AIN1                       ((PIN_PA05B_AC_AIN1 << 16) | MUX_PA05B_AC_AIN1)
+#define PORT_PA05B_AC_AIN1                         (_UL_(1) << 5)
+
+#define PIN_PA06B_AC_AIN2                          _L_(6)       /**< AC signal: AIN2 on PA06 mux B*/
+#define MUX_PA06B_AC_AIN2                          _L_(1)      
+#define PINMUX_PA06B_AC_AIN2                       ((PIN_PA06B_AC_AIN2 << 16) | MUX_PA06B_AC_AIN2)
+#define PORT_PA06B_AC_AIN2                         (_UL_(1) << 6)
+
+#define PIN_PA07B_AC_AIN3                          _L_(7)       /**< AC signal: AIN3 on PA07 mux B*/
+#define MUX_PA07B_AC_AIN3                          _L_(1)      
+#define PINMUX_PA07B_AC_AIN3                       ((PIN_PA07B_AC_AIN3 << 16) | MUX_PA07B_AC_AIN3)
+#define PORT_PA07B_AC_AIN3                         (_UL_(1) << 7)
+
+#define PIN_PA18H_AC_CMP0                          _L_(18)      /**< AC signal: CMP0 on PA18 mux H*/
+#define MUX_PA18H_AC_CMP0                          _L_(7)      
+#define PINMUX_PA18H_AC_CMP0                       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
+#define PORT_PA18H_AC_CMP0                         (_UL_(1) << 18)
+
+#define PIN_PA19H_AC_CMP1                          _L_(19)      /**< AC signal: CMP1 on PA19 mux H*/
+#define MUX_PA19H_AC_CMP1                          _L_(7)      
+#define PINMUX_PA19H_AC_CMP1                       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
+#define PORT_PA19H_AC_CMP1                         (_UL_(1) << 19)
+
+/* ========== PORT definition for ADC peripheral ========== */
+#define PIN_PA02B_ADC_AIN0                         _L_(2)       /**< ADC signal: AIN0 on PA02 mux B*/
+#define MUX_PA02B_ADC_AIN0                         _L_(1)      
+#define PINMUX_PA02B_ADC_AIN0                      ((PIN_PA02B_ADC_AIN0 << 16) | MUX_PA02B_ADC_AIN0)
+#define PORT_PA02B_ADC_AIN0                        (_UL_(1) << 2)
+
+#define PIN_PA03B_ADC_AIN1                         _L_(3)       /**< ADC signal: AIN1 on PA03 mux B*/
+#define MUX_PA03B_ADC_AIN1                         _L_(1)      
+#define PINMUX_PA03B_ADC_AIN1                      ((PIN_PA03B_ADC_AIN1 << 16) | MUX_PA03B_ADC_AIN1)
+#define PORT_PA03B_ADC_AIN1                        (_UL_(1) << 3)
+
+#define PIN_PA04B_ADC_AIN2                         _L_(4)       /**< ADC signal: AIN2 on PA04 mux B*/
+#define MUX_PA04B_ADC_AIN2                         _L_(1)      
+#define PINMUX_PA04B_ADC_AIN2                      ((PIN_PA04B_ADC_AIN2 << 16) | MUX_PA04B_ADC_AIN2)
+#define PORT_PA04B_ADC_AIN2                        (_UL_(1) << 4)
+
+#define PIN_PA05B_ADC_AIN3                         _L_(5)       /**< ADC signal: AIN3 on PA05 mux B*/
+#define MUX_PA05B_ADC_AIN3                         _L_(1)      
+#define PINMUX_PA05B_ADC_AIN3                      ((PIN_PA05B_ADC_AIN3 << 16) | MUX_PA05B_ADC_AIN3)
+#define PORT_PA05B_ADC_AIN3                        (_UL_(1) << 5)
+
+#define PIN_PA06B_ADC_AIN4                         _L_(6)       /**< ADC signal: AIN4 on PA06 mux B*/
+#define MUX_PA06B_ADC_AIN4                         _L_(1)      
+#define PINMUX_PA06B_ADC_AIN4                      ((PIN_PA06B_ADC_AIN4 << 16) | MUX_PA06B_ADC_AIN4)
+#define PORT_PA06B_ADC_AIN4                        (_UL_(1) << 6)
+
+#define PIN_PA07B_ADC_AIN5                         _L_(7)       /**< ADC signal: AIN5 on PA07 mux B*/
+#define MUX_PA07B_ADC_AIN5                         _L_(1)      
+#define PINMUX_PA07B_ADC_AIN5                      ((PIN_PA07B_ADC_AIN5 << 16) | MUX_PA07B_ADC_AIN5)
+#define PORT_PA07B_ADC_AIN5                        (_UL_(1) << 7)
+
+#define PIN_PA08B_ADC_AIN6                         _L_(8)       /**< ADC signal: AIN6 on PA08 mux B*/
+#define MUX_PA08B_ADC_AIN6                         _L_(1)      
+#define PINMUX_PA08B_ADC_AIN6                      ((PIN_PA08B_ADC_AIN6 << 16) | MUX_PA08B_ADC_AIN6)
+#define PORT_PA08B_ADC_AIN6                        (_UL_(1) << 8)
+
+#define PIN_PA09B_ADC_AIN7                         _L_(9)       /**< ADC signal: AIN7 on PA09 mux B*/
+#define MUX_PA09B_ADC_AIN7                         _L_(1)      
+#define PINMUX_PA09B_ADC_AIN7                      ((PIN_PA09B_ADC_AIN7 << 16) | MUX_PA09B_ADC_AIN7)
+#define PORT_PA09B_ADC_AIN7                        (_UL_(1) << 9)
+
+#define PIN_PA10B_ADC_AIN8                         _L_(10)      /**< ADC signal: AIN8 on PA10 mux B*/
+#define MUX_PA10B_ADC_AIN8                         _L_(1)      
+#define PINMUX_PA10B_ADC_AIN8                      ((PIN_PA10B_ADC_AIN8 << 16) | MUX_PA10B_ADC_AIN8)
+#define PORT_PA10B_ADC_AIN8                        (_UL_(1) << 10)
+
+#define PIN_PA11B_ADC_AIN9                         _L_(11)      /**< ADC signal: AIN9 on PA11 mux B*/
+#define MUX_PA11B_ADC_AIN9                         _L_(1)      
+#define PINMUX_PA11B_ADC_AIN9                      ((PIN_PA11B_ADC_AIN9 << 16) | MUX_PA11B_ADC_AIN9)
+#define PORT_PA11B_ADC_AIN9                        (_UL_(1) << 11)
+
+#define PIN_PA04B_ADC_VREFP                        _L_(4)       /**< ADC signal: VREFP on PA04 mux B*/
+#define MUX_PA04B_ADC_VREFP                        _L_(1)      
+#define PINMUX_PA04B_ADC_VREFP                     ((PIN_PA04B_ADC_VREFP << 16) | MUX_PA04B_ADC_VREFP)
+#define PORT_PA04B_ADC_VREFP                       (_UL_(1) << 4)
+
+/* ========== PORT definition for CCL peripheral ========== */
+#define PIN_PA04I_CCL_IN0                          _L_(4)       /**< CCL signal: IN0 on PA04 mux I*/
+#define MUX_PA04I_CCL_IN0                          _L_(8)      
+#define PINMUX_PA04I_CCL_IN0                       ((PIN_PA04I_CCL_IN0 << 16) | MUX_PA04I_CCL_IN0)
+#define PORT_PA04I_CCL_IN0                         (_UL_(1) << 4)
+
+#define PIN_PA16I_CCL_IN0                          _L_(16)      /**< CCL signal: IN0 on PA16 mux I*/
+#define MUX_PA16I_CCL_IN0                          _L_(8)      
+#define PINMUX_PA16I_CCL_IN0                       ((PIN_PA16I_CCL_IN0 << 16) | MUX_PA16I_CCL_IN0)
+#define PORT_PA16I_CCL_IN0                         (_UL_(1) << 16)
+
+#define PIN_PA05I_CCL_IN1                          _L_(5)       /**< CCL signal: IN1 on PA05 mux I*/
+#define MUX_PA05I_CCL_IN1                          _L_(8)      
+#define PINMUX_PA05I_CCL_IN1                       ((PIN_PA05I_CCL_IN1 << 16) | MUX_PA05I_CCL_IN1)
+#define PORT_PA05I_CCL_IN1                         (_UL_(1) << 5)
+
+#define PIN_PA17I_CCL_IN1                          _L_(17)      /**< CCL signal: IN1 on PA17 mux I*/
+#define MUX_PA17I_CCL_IN1                          _L_(8)      
+#define PINMUX_PA17I_CCL_IN1                       ((PIN_PA17I_CCL_IN1 << 16) | MUX_PA17I_CCL_IN1)
+#define PORT_PA17I_CCL_IN1                         (_UL_(1) << 17)
+
+#define PIN_PA06I_CCL_IN2                          _L_(6)       /**< CCL signal: IN2 on PA06 mux I*/
+#define MUX_PA06I_CCL_IN2                          _L_(8)      
+#define PINMUX_PA06I_CCL_IN2                       ((PIN_PA06I_CCL_IN2 << 16) | MUX_PA06I_CCL_IN2)
+#define PORT_PA06I_CCL_IN2                         (_UL_(1) << 6)
+
+#define PIN_PA18I_CCL_IN2                          _L_(18)      /**< CCL signal: IN2 on PA18 mux I*/
+#define MUX_PA18I_CCL_IN2                          _L_(8)      
+#define PINMUX_PA18I_CCL_IN2                       ((PIN_PA18I_CCL_IN2 << 16) | MUX_PA18I_CCL_IN2)
+#define PORT_PA18I_CCL_IN2                         (_UL_(1) << 18)
+
+#define PIN_PA08I_CCL_IN3                          _L_(8)       /**< CCL signal: IN3 on PA08 mux I*/
+#define MUX_PA08I_CCL_IN3                          _L_(8)      
+#define PINMUX_PA08I_CCL_IN3                       ((PIN_PA08I_CCL_IN3 << 16) | MUX_PA08I_CCL_IN3)
+#define PORT_PA08I_CCL_IN3                         (_UL_(1) << 8)
+
+#define PIN_PA30I_CCL_IN3                          _L_(30)      /**< CCL signal: IN3 on PA30 mux I*/
+#define MUX_PA30I_CCL_IN3                          _L_(8)      
+#define PINMUX_PA30I_CCL_IN3                       ((PIN_PA30I_CCL_IN3 << 16) | MUX_PA30I_CCL_IN3)
+#define PORT_PA30I_CCL_IN3                         (_UL_(1) << 30)
+
+#define PIN_PA09I_CCL_IN4                          _L_(9)       /**< CCL signal: IN4 on PA09 mux I*/
+#define MUX_PA09I_CCL_IN4                          _L_(8)      
+#define PINMUX_PA09I_CCL_IN4                       ((PIN_PA09I_CCL_IN4 << 16) | MUX_PA09I_CCL_IN4)
+#define PORT_PA09I_CCL_IN4                         (_UL_(1) << 9)
+
+#define PIN_PA10I_CCL_IN5                          _L_(10)      /**< CCL signal: IN5 on PA10 mux I*/
+#define MUX_PA10I_CCL_IN5                          _L_(8)      
+#define PINMUX_PA10I_CCL_IN5                       ((PIN_PA10I_CCL_IN5 << 16) | MUX_PA10I_CCL_IN5)
+#define PORT_PA10I_CCL_IN5                         (_UL_(1) << 10)
+
+#define PIN_PA07I_CCL_OUT0                         _L_(7)       /**< CCL signal: OUT0 on PA07 mux I*/
+#define MUX_PA07I_CCL_OUT0                         _L_(8)      
+#define PINMUX_PA07I_CCL_OUT0                      ((PIN_PA07I_CCL_OUT0 << 16) | MUX_PA07I_CCL_OUT0)
+#define PORT_PA07I_CCL_OUT0                        (_UL_(1) << 7)
+
+#define PIN_PA19I_CCL_OUT0                         _L_(19)      /**< CCL signal: OUT0 on PA19 mux I*/
+#define MUX_PA19I_CCL_OUT0                         _L_(8)      
+#define PINMUX_PA19I_CCL_OUT0                      ((PIN_PA19I_CCL_OUT0 << 16) | MUX_PA19I_CCL_OUT0)
+#define PORT_PA19I_CCL_OUT0                        (_UL_(1) << 19)
+
+#define PIN_PA11I_CCL_OUT1                         _L_(11)      /**< CCL signal: OUT1 on PA11 mux I*/
+#define MUX_PA11I_CCL_OUT1                         _L_(8)      
+#define PINMUX_PA11I_CCL_OUT1                      ((PIN_PA11I_CCL_OUT1 << 16) | MUX_PA11I_CCL_OUT1)
+#define PORT_PA11I_CCL_OUT1                        (_UL_(1) << 11)
+
+#define PIN_PA31I_CCL_OUT1                         _L_(31)      /**< CCL signal: OUT1 on PA31 mux I*/
+#define MUX_PA31I_CCL_OUT1                         _L_(8)      
+#define PINMUX_PA31I_CCL_OUT1                      ((PIN_PA31I_CCL_OUT1 << 16) | MUX_PA31I_CCL_OUT1)
+#define PORT_PA31I_CCL_OUT1                        (_UL_(1) << 31)
+
+/* ========== PORT definition for DAC peripheral ========== */
+#define PIN_PA02B_DAC_VOUT                         _L_(2)       /**< DAC signal: VOUT on PA02 mux B*/
+#define MUX_PA02B_DAC_VOUT                         _L_(1)      
+#define PINMUX_PA02B_DAC_VOUT                      ((PIN_PA02B_DAC_VOUT << 16) | MUX_PA02B_DAC_VOUT)
+#define PORT_PA02B_DAC_VOUT                        (_UL_(1) << 2)
+
+#define PIN_PA03B_DAC_VREFP                        _L_(3)       /**< DAC signal: VREFP on PA03 mux B*/
+#define MUX_PA03B_DAC_VREFP                        _L_(1)      
+#define PINMUX_PA03B_DAC_VREFP                     ((PIN_PA03B_DAC_VREFP << 16) | MUX_PA03B_DAC_VREFP)
+#define PORT_PA03B_DAC_VREFP                       (_UL_(1) << 3)
+
+/* ========== PORT definition for EIC peripheral ========== */
+#define PIN_PA09A_EIC_EXTINT0                      _L_(9)       /**< EIC signal: EXTINT0 on PA09 mux A*/
+#define MUX_PA09A_EIC_EXTINT0                      _L_(0)      
+#define PINMUX_PA09A_EIC_EXTINT0                   ((PIN_PA09A_EIC_EXTINT0 << 16) | MUX_PA09A_EIC_EXTINT0)
+#define PORT_PA09A_EIC_EXTINT0                     (_UL_(1) << 9)
+#define PIN_PA09A_EIC_EXTINT_NUM                   _L_(0)       /**< EIC signal: PIN_PA09 External Interrupt Line */
+
+#define PIN_PA19A_EIC_EXTINT0                      _L_(19)      /**< EIC signal: EXTINT0 on PA19 mux A*/
+#define MUX_PA19A_EIC_EXTINT0                      _L_(0)      
+#define PINMUX_PA19A_EIC_EXTINT0                   ((PIN_PA19A_EIC_EXTINT0 << 16) | MUX_PA19A_EIC_EXTINT0)
+#define PORT_PA19A_EIC_EXTINT0                     (_UL_(1) << 19)
+#define PIN_PA19A_EIC_EXTINT_NUM                   _L_(0)       /**< EIC signal: PIN_PA19 External Interrupt Line */
+
+#define PIN_PA00A_EIC_EXTINT0                      _L_(0)       /**< EIC signal: EXTINT0 on PA00 mux A*/
+#define MUX_PA00A_EIC_EXTINT0                      _L_(0)      
+#define PINMUX_PA00A_EIC_EXTINT0                   ((PIN_PA00A_EIC_EXTINT0 << 16) | MUX_PA00A_EIC_EXTINT0)
+#define PORT_PA00A_EIC_EXTINT0                     (_UL_(1) << 0)
+#define PIN_PA00A_EIC_EXTINT_NUM                   _L_(0)       /**< EIC signal: PIN_PA00 External Interrupt Line */
+
+#define PIN_PA10A_EIC_EXTINT1                      _L_(10)      /**< EIC signal: EXTINT1 on PA10 mux A*/
+#define MUX_PA10A_EIC_EXTINT1                      _L_(0)      
+#define PINMUX_PA10A_EIC_EXTINT1                   ((PIN_PA10A_EIC_EXTINT1 << 16) | MUX_PA10A_EIC_EXTINT1)
+#define PORT_PA10A_EIC_EXTINT1                     (_UL_(1) << 10)
+#define PIN_PA10A_EIC_EXTINT_NUM                   _L_(1)       /**< EIC signal: PIN_PA10 External Interrupt Line */
+
+#define PIN_PA22A_EIC_EXTINT1                      _L_(22)      /**< EIC signal: EXTINT1 on PA22 mux A*/
+#define MUX_PA22A_EIC_EXTINT1                      _L_(0)      
+#define PINMUX_PA22A_EIC_EXTINT1                   ((PIN_PA22A_EIC_EXTINT1 << 16) | MUX_PA22A_EIC_EXTINT1)
+#define PORT_PA22A_EIC_EXTINT1                     (_UL_(1) << 22)
+#define PIN_PA22A_EIC_EXTINT_NUM                   _L_(1)       /**< EIC signal: PIN_PA22 External Interrupt Line */
+
+#define PIN_PA01A_EIC_EXTINT1                      _L_(1)       /**< EIC signal: EXTINT1 on PA01 mux A*/
+#define MUX_PA01A_EIC_EXTINT1                      _L_(0)      
+#define PINMUX_PA01A_EIC_EXTINT1                   ((PIN_PA01A_EIC_EXTINT1 << 16) | MUX_PA01A_EIC_EXTINT1)
+#define PORT_PA01A_EIC_EXTINT1                     (_UL_(1) << 1)
+#define PIN_PA01A_EIC_EXTINT_NUM                   _L_(1)       /**< EIC signal: PIN_PA01 External Interrupt Line */
+
+#define PIN_PA02A_EIC_EXTINT2                      _L_(2)       /**< EIC signal: EXTINT2 on PA02 mux A*/
+#define MUX_PA02A_EIC_EXTINT2                      _L_(0)      
+#define PINMUX_PA02A_EIC_EXTINT2                   ((PIN_PA02A_EIC_EXTINT2 << 16) | MUX_PA02A_EIC_EXTINT2)
+#define PORT_PA02A_EIC_EXTINT2                     (_UL_(1) << 2)
+#define PIN_PA02A_EIC_EXTINT_NUM                   _L_(2)       /**< EIC signal: PIN_PA02 External Interrupt Line */
+
+#define PIN_PA11A_EIC_EXTINT2                      _L_(11)      /**< EIC signal: EXTINT2 on PA11 mux A*/
+#define MUX_PA11A_EIC_EXTINT2                      _L_(0)      
+#define PINMUX_PA11A_EIC_EXTINT2                   ((PIN_PA11A_EIC_EXTINT2 << 16) | MUX_PA11A_EIC_EXTINT2)
+#define PORT_PA11A_EIC_EXTINT2                     (_UL_(1) << 11)
+#define PIN_PA11A_EIC_EXTINT_NUM                   _L_(2)       /**< EIC signal: PIN_PA11 External Interrupt Line */
+
+#define PIN_PA23A_EIC_EXTINT2                      _L_(23)      /**< EIC signal: EXTINT2 on PA23 mux A*/
+#define MUX_PA23A_EIC_EXTINT2                      _L_(0)      
+#define PINMUX_PA23A_EIC_EXTINT2                   ((PIN_PA23A_EIC_EXTINT2 << 16) | MUX_PA23A_EIC_EXTINT2)
+#define PORT_PA23A_EIC_EXTINT2                     (_UL_(1) << 23)
+#define PIN_PA23A_EIC_EXTINT_NUM                   _L_(2)       /**< EIC signal: PIN_PA23 External Interrupt Line */
+
+#define PIN_PA03A_EIC_EXTINT3                      _L_(3)       /**< EIC signal: EXTINT3 on PA03 mux A*/
+#define MUX_PA03A_EIC_EXTINT3                      _L_(0)      
+#define PINMUX_PA03A_EIC_EXTINT3                   ((PIN_PA03A_EIC_EXTINT3 << 16) | MUX_PA03A_EIC_EXTINT3)
+#define PORT_PA03A_EIC_EXTINT3                     (_UL_(1) << 3)
+#define PIN_PA03A_EIC_EXTINT_NUM                   _L_(3)       /**< EIC signal: PIN_PA03 External Interrupt Line */
+
+#define PIN_PA14A_EIC_EXTINT3                      _L_(14)      /**< EIC signal: EXTINT3 on PA14 mux A*/
+#define MUX_PA14A_EIC_EXTINT3                      _L_(0)      
+#define PINMUX_PA14A_EIC_EXTINT3                   ((PIN_PA14A_EIC_EXTINT3 << 16) | MUX_PA14A_EIC_EXTINT3)
+#define PORT_PA14A_EIC_EXTINT3                     (_UL_(1) << 14)
+#define PIN_PA14A_EIC_EXTINT_NUM                   _L_(3)       /**< EIC signal: PIN_PA14 External Interrupt Line */
+
+#define PIN_PA24A_EIC_EXTINT3                      _L_(24)      /**< EIC signal: EXTINT3 on PA24 mux A*/
+#define MUX_PA24A_EIC_EXTINT3                      _L_(0)      
+#define PINMUX_PA24A_EIC_EXTINT3                   ((PIN_PA24A_EIC_EXTINT3 << 16) | MUX_PA24A_EIC_EXTINT3)
+#define PORT_PA24A_EIC_EXTINT3                     (_UL_(1) << 24)
+#define PIN_PA24A_EIC_EXTINT_NUM                   _L_(3)       /**< EIC signal: PIN_PA24 External Interrupt Line */
+
+#define PIN_PA04A_EIC_EXTINT4                      _L_(4)       /**< EIC signal: EXTINT4 on PA04 mux A*/
+#define MUX_PA04A_EIC_EXTINT4                      _L_(0)      
+#define PINMUX_PA04A_EIC_EXTINT4                   ((PIN_PA04A_EIC_EXTINT4 << 16) | MUX_PA04A_EIC_EXTINT4)
+#define PORT_PA04A_EIC_EXTINT4                     (_UL_(1) << 4)
+#define PIN_PA04A_EIC_EXTINT_NUM                   _L_(4)       /**< EIC signal: PIN_PA04 External Interrupt Line */
+
+#define PIN_PA15A_EIC_EXTINT4                      _L_(15)      /**< EIC signal: EXTINT4 on PA15 mux A*/
+#define MUX_PA15A_EIC_EXTINT4                      _L_(0)      
+#define PINMUX_PA15A_EIC_EXTINT4                   ((PIN_PA15A_EIC_EXTINT4 << 16) | MUX_PA15A_EIC_EXTINT4)
+#define PORT_PA15A_EIC_EXTINT4                     (_UL_(1) << 15)
+#define PIN_PA15A_EIC_EXTINT_NUM                   _L_(4)       /**< EIC signal: PIN_PA15 External Interrupt Line */
+
+#define PIN_PA25A_EIC_EXTINT4                      _L_(25)      /**< EIC signal: EXTINT4 on PA25 mux A*/
+#define MUX_PA25A_EIC_EXTINT4                      _L_(0)      
+#define PINMUX_PA25A_EIC_EXTINT4                   ((PIN_PA25A_EIC_EXTINT4 << 16) | MUX_PA25A_EIC_EXTINT4)
+#define PORT_PA25A_EIC_EXTINT4                     (_UL_(1) << 25)
+#define PIN_PA25A_EIC_EXTINT_NUM                   _L_(4)       /**< EIC signal: PIN_PA25 External Interrupt Line */
+
+#define PIN_PA05A_EIC_EXTINT5                      _L_(5)       /**< EIC signal: EXTINT5 on PA05 mux A*/
+#define MUX_PA05A_EIC_EXTINT5                      _L_(0)      
+#define PINMUX_PA05A_EIC_EXTINT5                   ((PIN_PA05A_EIC_EXTINT5 << 16) | MUX_PA05A_EIC_EXTINT5)
+#define PORT_PA05A_EIC_EXTINT5                     (_UL_(1) << 5)
+#define PIN_PA05A_EIC_EXTINT_NUM                   _L_(5)       /**< EIC signal: PIN_PA05 External Interrupt Line */
+
+#define PIN_PA16A_EIC_EXTINT5                      _L_(16)      /**< EIC signal: EXTINT5 on PA16 mux A*/
+#define MUX_PA16A_EIC_EXTINT5                      _L_(0)      
+#define PINMUX_PA16A_EIC_EXTINT5                   ((PIN_PA16A_EIC_EXTINT5 << 16) | MUX_PA16A_EIC_EXTINT5)
+#define PORT_PA16A_EIC_EXTINT5                     (_UL_(1) << 16)
+#define PIN_PA16A_EIC_EXTINT_NUM                   _L_(5)       /**< EIC signal: PIN_PA16 External Interrupt Line */
+
+#define PIN_PA27A_EIC_EXTINT5                      _L_(27)      /**< EIC signal: EXTINT5 on PA27 mux A*/
+#define MUX_PA27A_EIC_EXTINT5                      _L_(0)      
+#define PINMUX_PA27A_EIC_EXTINT5                   ((PIN_PA27A_EIC_EXTINT5 << 16) | MUX_PA27A_EIC_EXTINT5)
+#define PORT_PA27A_EIC_EXTINT5                     (_UL_(1) << 27)
+#define PIN_PA27A_EIC_EXTINT_NUM                   _L_(5)       /**< EIC signal: PIN_PA27 External Interrupt Line */
+
+#define PIN_PA06A_EIC_EXTINT6                      _L_(6)       /**< EIC signal: EXTINT6 on PA06 mux A*/
+#define MUX_PA06A_EIC_EXTINT6                      _L_(0)      
+#define PINMUX_PA06A_EIC_EXTINT6                   ((PIN_PA06A_EIC_EXTINT6 << 16) | MUX_PA06A_EIC_EXTINT6)
+#define PORT_PA06A_EIC_EXTINT6                     (_UL_(1) << 6)
+#define PIN_PA06A_EIC_EXTINT_NUM                   _L_(6)       /**< EIC signal: PIN_PA06 External Interrupt Line */
+
+#define PIN_PA17A_EIC_EXTINT6                      _L_(17)      /**< EIC signal: EXTINT6 on PA17 mux A*/
+#define MUX_PA17A_EIC_EXTINT6                      _L_(0)      
+#define PINMUX_PA17A_EIC_EXTINT6                   ((PIN_PA17A_EIC_EXTINT6 << 16) | MUX_PA17A_EIC_EXTINT6)
+#define PORT_PA17A_EIC_EXTINT6                     (_UL_(1) << 17)
+#define PIN_PA17A_EIC_EXTINT_NUM                   _L_(6)       /**< EIC signal: PIN_PA17 External Interrupt Line */
+
+#define PIN_PA30A_EIC_EXTINT6                      _L_(30)      /**< EIC signal: EXTINT6 on PA30 mux A*/
+#define MUX_PA30A_EIC_EXTINT6                      _L_(0)      
+#define PINMUX_PA30A_EIC_EXTINT6                   ((PIN_PA30A_EIC_EXTINT6 << 16) | MUX_PA30A_EIC_EXTINT6)
+#define PORT_PA30A_EIC_EXTINT6                     (_UL_(1) << 30)
+#define PIN_PA30A_EIC_EXTINT_NUM                   _L_(6)       /**< EIC signal: PIN_PA30 External Interrupt Line */
+
+#define PIN_PA07A_EIC_EXTINT7                      _L_(7)       /**< EIC signal: EXTINT7 on PA07 mux A*/
+#define MUX_PA07A_EIC_EXTINT7                      _L_(0)      
+#define PINMUX_PA07A_EIC_EXTINT7                   ((PIN_PA07A_EIC_EXTINT7 << 16) | MUX_PA07A_EIC_EXTINT7)
+#define PORT_PA07A_EIC_EXTINT7                     (_UL_(1) << 7)
+#define PIN_PA07A_EIC_EXTINT_NUM                   _L_(7)       /**< EIC signal: PIN_PA07 External Interrupt Line */
+
+#define PIN_PA18A_EIC_EXTINT7                      _L_(18)      /**< EIC signal: EXTINT7 on PA18 mux A*/
+#define MUX_PA18A_EIC_EXTINT7                      _L_(0)      
+#define PINMUX_PA18A_EIC_EXTINT7                   ((PIN_PA18A_EIC_EXTINT7 << 16) | MUX_PA18A_EIC_EXTINT7)
+#define PORT_PA18A_EIC_EXTINT7                     (_UL_(1) << 18)
+#define PIN_PA18A_EIC_EXTINT_NUM                   _L_(7)       /**< EIC signal: PIN_PA18 External Interrupt Line */
+
+#define PIN_PA31A_EIC_EXTINT7                      _L_(31)      /**< EIC signal: EXTINT7 on PA31 mux A*/
+#define MUX_PA31A_EIC_EXTINT7                      _L_(0)      
+#define PINMUX_PA31A_EIC_EXTINT7                   ((PIN_PA31A_EIC_EXTINT7 << 16) | MUX_PA31A_EIC_EXTINT7)
+#define PORT_PA31A_EIC_EXTINT7                     (_UL_(1) << 31)
+#define PIN_PA31A_EIC_EXTINT_NUM                   _L_(7)       /**< EIC signal: PIN_PA31 External Interrupt Line */
+
+#define PIN_PA08A_EIC_NMI                          _L_(8)       /**< EIC signal: NMI on PA08 mux A*/
+#define MUX_PA08A_EIC_NMI                          _L_(0)      
+#define PINMUX_PA08A_EIC_NMI                       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
+#define PORT_PA08A_EIC_NMI                         (_UL_(1) << 8)
+
+/* ========== PORT definition for GCLK peripheral ========== */
+#define PIN_PA30H_GCLK_IO0                         _L_(30)      /**< GCLK signal: IO0 on PA30 mux H*/
+#define MUX_PA30H_GCLK_IO0                         _L_(7)      
+#define PINMUX_PA30H_GCLK_IO0                      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
+#define PORT_PA30H_GCLK_IO0                        (_UL_(1) << 30)
+
+#define PIN_PA14H_GCLK_IO0                         _L_(14)      /**< GCLK signal: IO0 on PA14 mux H*/
+#define MUX_PA14H_GCLK_IO0                         _L_(7)      
+#define PINMUX_PA14H_GCLK_IO0                      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
+#define PORT_PA14H_GCLK_IO0                        (_UL_(1) << 14)
+
+#define PIN_PA27H_GCLK_IO0                         _L_(27)      /**< GCLK signal: IO0 on PA27 mux H*/
+#define MUX_PA27H_GCLK_IO0                         _L_(7)      
+#define PINMUX_PA27H_GCLK_IO0                      ((PIN_PA27H_GCLK_IO0 << 16) | MUX_PA27H_GCLK_IO0)
+#define PORT_PA27H_GCLK_IO0                        (_UL_(1) << 27)
+
+#define PIN_PA23H_GCLK_IO1                         _L_(23)      /**< GCLK signal: IO1 on PA23 mux H*/
+#define MUX_PA23H_GCLK_IO1                         _L_(7)      
+#define PINMUX_PA23H_GCLK_IO1                      ((PIN_PA23H_GCLK_IO1 << 16) | MUX_PA23H_GCLK_IO1)
+#define PORT_PA23H_GCLK_IO1                        (_UL_(1) << 23)
+
+#define PIN_PA15H_GCLK_IO1                         _L_(15)      /**< GCLK signal: IO1 on PA15 mux H*/
+#define MUX_PA15H_GCLK_IO1                         _L_(7)      
+#define PINMUX_PA15H_GCLK_IO1                      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
+#define PORT_PA15H_GCLK_IO1                        (_UL_(1) << 15)
+
+#define PIN_PA16H_GCLK_IO2                         _L_(16)      /**< GCLK signal: IO2 on PA16 mux H*/
+#define MUX_PA16H_GCLK_IO2                         _L_(7)      
+#define PINMUX_PA16H_GCLK_IO2                      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
+#define PORT_PA16H_GCLK_IO2                        (_UL_(1) << 16)
+
+#define PIN_PA22H_GCLK_IO2                         _L_(22)      /**< GCLK signal: IO2 on PA22 mux H*/
+#define MUX_PA22H_GCLK_IO2                         _L_(7)      
+#define PINMUX_PA22H_GCLK_IO2                      ((PIN_PA22H_GCLK_IO2 << 16) | MUX_PA22H_GCLK_IO2)
+#define PORT_PA22H_GCLK_IO2                        (_UL_(1) << 22)
+
+#define PIN_PA11H_GCLK_IO3                         _L_(11)      /**< GCLK signal: IO3 on PA11 mux H*/
+#define MUX_PA11H_GCLK_IO3                         _L_(7)      
+#define PINMUX_PA11H_GCLK_IO3                      ((PIN_PA11H_GCLK_IO3 << 16) | MUX_PA11H_GCLK_IO3)
+#define PORT_PA11H_GCLK_IO3                        (_UL_(1) << 11)
+
+#define PIN_PA17H_GCLK_IO3                         _L_(17)      /**< GCLK signal: IO3 on PA17 mux H*/
+#define MUX_PA17H_GCLK_IO3                         _L_(7)      
+#define PINMUX_PA17H_GCLK_IO3                      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
+#define PORT_PA17H_GCLK_IO3                        (_UL_(1) << 17)
+
+#define PIN_PA10H_GCLK_IO4                         _L_(10)      /**< GCLK signal: IO4 on PA10 mux H*/
+#define MUX_PA10H_GCLK_IO4                         _L_(7)      
+#define PINMUX_PA10H_GCLK_IO4                      ((PIN_PA10H_GCLK_IO4 << 16) | MUX_PA10H_GCLK_IO4)
+#define PORT_PA10H_GCLK_IO4                        (_UL_(1) << 10)
+
+/* ========== PORT definition for OPAMP peripheral ========== */
+#define PIN_PA02B_OPAMP_OANEG0                     _L_(2)       /**< OPAMP signal: OANEG0 on PA02 mux B*/
+#define MUX_PA02B_OPAMP_OANEG0                     _L_(1)      
+#define PINMUX_PA02B_OPAMP_OANEG0                  ((PIN_PA02B_OPAMP_OANEG0 << 16) | MUX_PA02B_OPAMP_OANEG0)
+#define PORT_PA02B_OPAMP_OANEG0                    (_UL_(1) << 2)
+
+#define PIN_PA00B_OPAMP_OANEG1                     _L_(0)       /**< OPAMP signal: OANEG1 on PA00 mux B*/
+#define MUX_PA00B_OPAMP_OANEG1                     _L_(1)      
+#define PINMUX_PA00B_OPAMP_OANEG1                  ((PIN_PA00B_OPAMP_OANEG1 << 16) | MUX_PA00B_OPAMP_OANEG1)
+#define PORT_PA00B_OPAMP_OANEG1                    (_UL_(1) << 0)
+
+#define PIN_PA03B_OPAMP_OANEG2                     _L_(3)       /**< OPAMP signal: OANEG2 on PA03 mux B*/
+#define MUX_PA03B_OPAMP_OANEG2                     _L_(1)      
+#define PINMUX_PA03B_OPAMP_OANEG2                  ((PIN_PA03B_OPAMP_OANEG2 << 16) | MUX_PA03B_OPAMP_OANEG2)
+#define PORT_PA03B_OPAMP_OANEG2                    (_UL_(1) << 3)
+
+#define PIN_PA07B_OPAMP_OAOUT0                     _L_(7)       /**< OPAMP signal: OAOUT0 on PA07 mux B*/
+#define MUX_PA07B_OPAMP_OAOUT0                     _L_(1)      
+#define PINMUX_PA07B_OPAMP_OAOUT0                  ((PIN_PA07B_OPAMP_OAOUT0 << 16) | MUX_PA07B_OPAMP_OAOUT0)
+#define PORT_PA07B_OPAMP_OAOUT0                    (_UL_(1) << 7)
+
+#define PIN_PA04B_OPAMP_OAOUT2                     _L_(4)       /**< OPAMP signal: OAOUT2 on PA04 mux B*/
+#define MUX_PA04B_OPAMP_OAOUT2                     _L_(1)      
+#define PINMUX_PA04B_OPAMP_OAOUT2                  ((PIN_PA04B_OPAMP_OAOUT2 << 16) | MUX_PA04B_OPAMP_OAOUT2)
+#define PORT_PA04B_OPAMP_OAOUT2                    (_UL_(1) << 4)
+
+#define PIN_PA06B_OPAMP_OAPOS0                     _L_(6)       /**< OPAMP signal: OAPOS0 on PA06 mux B*/
+#define MUX_PA06B_OPAMP_OAPOS0                     _L_(1)      
+#define PINMUX_PA06B_OPAMP_OAPOS0                  ((PIN_PA06B_OPAMP_OAPOS0 << 16) | MUX_PA06B_OPAMP_OAPOS0)
+#define PORT_PA06B_OPAMP_OAPOS0                    (_UL_(1) << 6)
+
+#define PIN_PA01B_OPAMP_OAPOS1                     _L_(1)       /**< OPAMP signal: OAPOS1 on PA01 mux B*/
+#define MUX_PA01B_OPAMP_OAPOS1                     _L_(1)      
+#define PINMUX_PA01B_OPAMP_OAPOS1                  ((PIN_PA01B_OPAMP_OAPOS1 << 16) | MUX_PA01B_OPAMP_OAPOS1)
+#define PORT_PA01B_OPAMP_OAPOS1                    (_UL_(1) << 1)
+
+#define PIN_PA05B_OPAMP_OAPOS2                     _L_(5)       /**< OPAMP signal: OAPOS2 on PA05 mux B*/
+#define MUX_PA05B_OPAMP_OAPOS2                     _L_(1)      
+#define PINMUX_PA05B_OPAMP_OAPOS2                  ((PIN_PA05B_OPAMP_OAPOS2 << 16) | MUX_PA05B_OPAMP_OAPOS2)
+#define PORT_PA05B_OPAMP_OAPOS2                    (_UL_(1) << 5)
+
+/* ========== PORT definition for PTC peripheral ========== */
+#define PIN_PA00F_PTC_DRV0                         _L_(0)       /**< PTC signal: DRV0 on PA00 mux F*/
+#define MUX_PA00F_PTC_DRV0                         _L_(5)      
+#define PINMUX_PA00F_PTC_DRV0                      ((PIN_PA00F_PTC_DRV0 << 16) | MUX_PA00F_PTC_DRV0)
+#define PORT_PA00F_PTC_DRV0                        (_UL_(1) << 0)
+
+#define PIN_PA01F_PTC_DRV1                         _L_(1)       /**< PTC signal: DRV1 on PA01 mux F*/
+#define MUX_PA01F_PTC_DRV1                         _L_(5)      
+#define PINMUX_PA01F_PTC_DRV1                      ((PIN_PA01F_PTC_DRV1 << 16) | MUX_PA01F_PTC_DRV1)
+#define PORT_PA01F_PTC_DRV1                        (_UL_(1) << 1)
+
+#define PIN_PA02F_PTC_DRV2                         _L_(2)       /**< PTC signal: DRV2 on PA02 mux F*/
+#define MUX_PA02F_PTC_DRV2                         _L_(5)      
+#define PINMUX_PA02F_PTC_DRV2                      ((PIN_PA02F_PTC_DRV2 << 16) | MUX_PA02F_PTC_DRV2)
+#define PORT_PA02F_PTC_DRV2                        (_UL_(1) << 2)
+
+#define PIN_PA03F_PTC_DRV3                         _L_(3)       /**< PTC signal: DRV3 on PA03 mux F*/
+#define MUX_PA03F_PTC_DRV3                         _L_(5)      
+#define PINMUX_PA03F_PTC_DRV3                      ((PIN_PA03F_PTC_DRV3 << 16) | MUX_PA03F_PTC_DRV3)
+#define PORT_PA03F_PTC_DRV3                        (_UL_(1) << 3)
+
+#define PIN_PA05F_PTC_DRV4                         _L_(5)       /**< PTC signal: DRV4 on PA05 mux F*/
+#define MUX_PA05F_PTC_DRV4                         _L_(5)      
+#define PINMUX_PA05F_PTC_DRV4                      ((PIN_PA05F_PTC_DRV4 << 16) | MUX_PA05F_PTC_DRV4)
+#define PORT_PA05F_PTC_DRV4                        (_UL_(1) << 5)
+
+#define PIN_PA06F_PTC_DRV5                         _L_(6)       /**< PTC signal: DRV5 on PA06 mux F*/
+#define MUX_PA06F_PTC_DRV5                         _L_(5)      
+#define PINMUX_PA06F_PTC_DRV5                      ((PIN_PA06F_PTC_DRV5 << 16) | MUX_PA06F_PTC_DRV5)
+#define PORT_PA06F_PTC_DRV5                        (_UL_(1) << 6)
+
+#define PIN_PA08F_PTC_DRV6                         _L_(8)       /**< PTC signal: DRV6 on PA08 mux F*/
+#define MUX_PA08F_PTC_DRV6                         _L_(5)      
+#define PINMUX_PA08F_PTC_DRV6                      ((PIN_PA08F_PTC_DRV6 << 16) | MUX_PA08F_PTC_DRV6)
+#define PORT_PA08F_PTC_DRV6                        (_UL_(1) << 8)
+
+#define PIN_PA09F_PTC_DRV7                         _L_(9)       /**< PTC signal: DRV7 on PA09 mux F*/
+#define MUX_PA09F_PTC_DRV7                         _L_(5)      
+#define PINMUX_PA09F_PTC_DRV7                      ((PIN_PA09F_PTC_DRV7 << 16) | MUX_PA09F_PTC_DRV7)
+#define PORT_PA09F_PTC_DRV7                        (_UL_(1) << 9)
+
+#define PIN_PA10F_PTC_DRV8                         _L_(10)      /**< PTC signal: DRV8 on PA10 mux F*/
+#define MUX_PA10F_PTC_DRV8                         _L_(5)      
+#define PINMUX_PA10F_PTC_DRV8                      ((PIN_PA10F_PTC_DRV8 << 16) | MUX_PA10F_PTC_DRV8)
+#define PORT_PA10F_PTC_DRV8                        (_UL_(1) << 10)
+
+#define PIN_PA11F_PTC_DRV9                         _L_(11)      /**< PTC signal: DRV9 on PA11 mux F*/
+#define MUX_PA11F_PTC_DRV9                         _L_(5)      
+#define PINMUX_PA11F_PTC_DRV9                      ((PIN_PA11F_PTC_DRV9 << 16) | MUX_PA11F_PTC_DRV9)
+#define PORT_PA11F_PTC_DRV9                        (_UL_(1) << 11)
+
+#define PIN_PA14F_PTC_DRV10                        _L_(14)      /**< PTC signal: DRV10 on PA14 mux F*/
+#define MUX_PA14F_PTC_DRV10                        _L_(5)      
+#define PINMUX_PA14F_PTC_DRV10                     ((PIN_PA14F_PTC_DRV10 << 16) | MUX_PA14F_PTC_DRV10)
+#define PORT_PA14F_PTC_DRV10                       (_UL_(1) << 14)
+
+#define PIN_PA15F_PTC_DRV11                        _L_(15)      /**< PTC signal: DRV11 on PA15 mux F*/
+#define MUX_PA15F_PTC_DRV11                        _L_(5)      
+#define PINMUX_PA15F_PTC_DRV11                     ((PIN_PA15F_PTC_DRV11 << 16) | MUX_PA15F_PTC_DRV11)
+#define PORT_PA15F_PTC_DRV11                       (_UL_(1) << 15)
+
+#define PIN_PA16F_PTC_DRV12                        _L_(16)      /**< PTC signal: DRV12 on PA16 mux F*/
+#define MUX_PA16F_PTC_DRV12                        _L_(5)      
+#define PINMUX_PA16F_PTC_DRV12                     ((PIN_PA16F_PTC_DRV12 << 16) | MUX_PA16F_PTC_DRV12)
+#define PORT_PA16F_PTC_DRV12                       (_UL_(1) << 16)
+
+#define PIN_PA17F_PTC_DRV13                        _L_(17)      /**< PTC signal: DRV13 on PA17 mux F*/
+#define MUX_PA17F_PTC_DRV13                        _L_(5)      
+#define PINMUX_PA17F_PTC_DRV13                     ((PIN_PA17F_PTC_DRV13 << 16) | MUX_PA17F_PTC_DRV13)
+#define PORT_PA17F_PTC_DRV13                       (_UL_(1) << 17)
+
+#define PIN_PA18F_PTC_DRV14                        _L_(18)      /**< PTC signal: DRV14 on PA18 mux F*/
+#define MUX_PA18F_PTC_DRV14                        _L_(5)      
+#define PINMUX_PA18F_PTC_DRV14                     ((PIN_PA18F_PTC_DRV14 << 16) | MUX_PA18F_PTC_DRV14)
+#define PORT_PA18F_PTC_DRV14                       (_UL_(1) << 18)
+
+#define PIN_PA19F_PTC_DRV15                        _L_(19)      /**< PTC signal: DRV15 on PA19 mux F*/
+#define MUX_PA19F_PTC_DRV15                        _L_(5)      
+#define PINMUX_PA19F_PTC_DRV15                     ((PIN_PA19F_PTC_DRV15 << 16) | MUX_PA19F_PTC_DRV15)
+#define PORT_PA19F_PTC_DRV15                       (_UL_(1) << 19)
+
+#define PIN_PA22F_PTC_DRV16                        _L_(22)      /**< PTC signal: DRV16 on PA22 mux F*/
+#define MUX_PA22F_PTC_DRV16                        _L_(5)      
+#define PINMUX_PA22F_PTC_DRV16                     ((PIN_PA22F_PTC_DRV16 << 16) | MUX_PA22F_PTC_DRV16)
+#define PORT_PA22F_PTC_DRV16                       (_UL_(1) << 22)
+
+#define PIN_PA23F_PTC_DRV17                        _L_(23)      /**< PTC signal: DRV17 on PA23 mux F*/
+#define MUX_PA23F_PTC_DRV17                        _L_(5)      
+#define PINMUX_PA23F_PTC_DRV17                     ((PIN_PA23F_PTC_DRV17 << 16) | MUX_PA23F_PTC_DRV17)
+#define PORT_PA23F_PTC_DRV17                       (_UL_(1) << 23)
+
+#define PIN_PA30F_PTC_DRV18                        _L_(30)      /**< PTC signal: DRV18 on PA30 mux F*/
+#define MUX_PA30F_PTC_DRV18                        _L_(5)      
+#define PINMUX_PA30F_PTC_DRV18                     ((PIN_PA30F_PTC_DRV18 << 16) | MUX_PA30F_PTC_DRV18)
+#define PORT_PA30F_PTC_DRV18                       (_UL_(1) << 30)
+
+#define PIN_PA31F_PTC_DRV19                        _L_(31)      /**< PTC signal: DRV19 on PA31 mux F*/
+#define MUX_PA31F_PTC_DRV19                        _L_(5)      
+#define PINMUX_PA31F_PTC_DRV19                     ((PIN_PA31F_PTC_DRV19 << 16) | MUX_PA31F_PTC_DRV19)
+#define PORT_PA31F_PTC_DRV19                       (_UL_(1) << 31)
+
+#define PIN_PA03B_PTC_ECI0                         _L_(3)       /**< PTC signal: ECI0 on PA03 mux B*/
+#define MUX_PA03B_PTC_ECI0                         _L_(1)      
+#define PINMUX_PA03B_PTC_ECI0                      ((PIN_PA03B_PTC_ECI0 << 16) | MUX_PA03B_PTC_ECI0)
+#define PORT_PA03B_PTC_ECI0                        (_UL_(1) << 3)
+
+#define PIN_PA04B_PTC_ECI1                         _L_(4)       /**< PTC signal: ECI1 on PA04 mux B*/
+#define MUX_PA04B_PTC_ECI1                         _L_(1)      
+#define PINMUX_PA04B_PTC_ECI1                      ((PIN_PA04B_PTC_ECI1 << 16) | MUX_PA04B_PTC_ECI1)
+#define PORT_PA04B_PTC_ECI1                        (_UL_(1) << 4)
+
+#define PIN_PA05B_PTC_ECI2                         _L_(5)       /**< PTC signal: ECI2 on PA05 mux B*/
+#define MUX_PA05B_PTC_ECI2                         _L_(1)      
+#define PINMUX_PA05B_PTC_ECI2                      ((PIN_PA05B_PTC_ECI2 << 16) | MUX_PA05B_PTC_ECI2)
+#define PORT_PA05B_PTC_ECI2                        (_UL_(1) << 5)
+
+#define PIN_PA06B_PTC_ECI3                         _L_(6)       /**< PTC signal: ECI3 on PA06 mux B*/
+#define MUX_PA06B_PTC_ECI3                         _L_(1)      
+#define PINMUX_PA06B_PTC_ECI3                      ((PIN_PA06B_PTC_ECI3 << 16) | MUX_PA06B_PTC_ECI3)
+#define PORT_PA06B_PTC_ECI3                        (_UL_(1) << 6)
+
+#define PIN_PA00B_PTC_X0                           _L_(0)       /**< PTC signal: X0 on PA00 mux B*/
+#define MUX_PA00B_PTC_X0                           _L_(1)      
+#define PINMUX_PA00B_PTC_X0                        ((PIN_PA00B_PTC_X0 << 16) | MUX_PA00B_PTC_X0)
+#define PORT_PA00B_PTC_X0                          (_UL_(1) << 0)
+
+#define PIN_PA00B_PTC_Y0                           _L_(0)       /**< PTC signal: Y0 on PA00 mux B*/
+#define MUX_PA00B_PTC_Y0                           _L_(1)      
+#define PINMUX_PA00B_PTC_Y0                        ((PIN_PA00B_PTC_Y0 << 16) | MUX_PA00B_PTC_Y0)
+#define PORT_PA00B_PTC_Y0                          (_UL_(1) << 0)
+
+#define PIN_PA01B_PTC_X1                           _L_(1)       /**< PTC signal: X1 on PA01 mux B*/
+#define MUX_PA01B_PTC_X1                           _L_(1)      
+#define PINMUX_PA01B_PTC_X1                        ((PIN_PA01B_PTC_X1 << 16) | MUX_PA01B_PTC_X1)
+#define PORT_PA01B_PTC_X1                          (_UL_(1) << 1)
+
+#define PIN_PA01B_PTC_Y1                           _L_(1)       /**< PTC signal: Y1 on PA01 mux B*/
+#define MUX_PA01B_PTC_Y1                           _L_(1)      
+#define PINMUX_PA01B_PTC_Y1                        ((PIN_PA01B_PTC_Y1 << 16) | MUX_PA01B_PTC_Y1)
+#define PORT_PA01B_PTC_Y1                          (_UL_(1) << 1)
+
+#define PIN_PA02B_PTC_X2                           _L_(2)       /**< PTC signal: X2 on PA02 mux B*/
+#define MUX_PA02B_PTC_X2                           _L_(1)      
+#define PINMUX_PA02B_PTC_X2                        ((PIN_PA02B_PTC_X2 << 16) | MUX_PA02B_PTC_X2)
+#define PORT_PA02B_PTC_X2                          (_UL_(1) << 2)
+
+#define PIN_PA02B_PTC_Y2                           _L_(2)       /**< PTC signal: Y2 on PA02 mux B*/
+#define MUX_PA02B_PTC_Y2                           _L_(1)      
+#define PINMUX_PA02B_PTC_Y2                        ((PIN_PA02B_PTC_Y2 << 16) | MUX_PA02B_PTC_Y2)
+#define PORT_PA02B_PTC_Y2                          (_UL_(1) << 2)
+
+#define PIN_PA03B_PTC_X3                           _L_(3)       /**< PTC signal: X3 on PA03 mux B*/
+#define MUX_PA03B_PTC_X3                           _L_(1)      
+#define PINMUX_PA03B_PTC_X3                        ((PIN_PA03B_PTC_X3 << 16) | MUX_PA03B_PTC_X3)
+#define PORT_PA03B_PTC_X3                          (_UL_(1) << 3)
+
+#define PIN_PA03B_PTC_Y3                           _L_(3)       /**< PTC signal: Y3 on PA03 mux B*/
+#define MUX_PA03B_PTC_Y3                           _L_(1)      
+#define PINMUX_PA03B_PTC_Y3                        ((PIN_PA03B_PTC_Y3 << 16) | MUX_PA03B_PTC_Y3)
+#define PORT_PA03B_PTC_Y3                          (_UL_(1) << 3)
+
+#define PIN_PA05B_PTC_X4                           _L_(5)       /**< PTC signal: X4 on PA05 mux B*/
+#define MUX_PA05B_PTC_X4                           _L_(1)      
+#define PINMUX_PA05B_PTC_X4                        ((PIN_PA05B_PTC_X4 << 16) | MUX_PA05B_PTC_X4)
+#define PORT_PA05B_PTC_X4                          (_UL_(1) << 5)
+
+#define PIN_PA05B_PTC_Y4                           _L_(5)       /**< PTC signal: Y4 on PA05 mux B*/
+#define MUX_PA05B_PTC_Y4                           _L_(1)      
+#define PINMUX_PA05B_PTC_Y4                        ((PIN_PA05B_PTC_Y4 << 16) | MUX_PA05B_PTC_Y4)
+#define PORT_PA05B_PTC_Y4                          (_UL_(1) << 5)
+
+#define PIN_PA06B_PTC_X5                           _L_(6)       /**< PTC signal: X5 on PA06 mux B*/
+#define MUX_PA06B_PTC_X5                           _L_(1)      
+#define PINMUX_PA06B_PTC_X5                        ((PIN_PA06B_PTC_X5 << 16) | MUX_PA06B_PTC_X5)
+#define PORT_PA06B_PTC_X5                          (_UL_(1) << 6)
+
+#define PIN_PA06B_PTC_Y5                           _L_(6)       /**< PTC signal: Y5 on PA06 mux B*/
+#define MUX_PA06B_PTC_Y5                           _L_(1)      
+#define PINMUX_PA06B_PTC_Y5                        ((PIN_PA06B_PTC_Y5 << 16) | MUX_PA06B_PTC_Y5)
+#define PORT_PA06B_PTC_Y5                          (_UL_(1) << 6)
+
+#define PIN_PA08B_PTC_X6                           _L_(8)       /**< PTC signal: X6 on PA08 mux B*/
+#define MUX_PA08B_PTC_X6                           _L_(1)      
+#define PINMUX_PA08B_PTC_X6                        ((PIN_PA08B_PTC_X6 << 16) | MUX_PA08B_PTC_X6)
+#define PORT_PA08B_PTC_X6                          (_UL_(1) << 8)
+
+#define PIN_PA08B_PTC_Y6                           _L_(8)       /**< PTC signal: Y6 on PA08 mux B*/
+#define MUX_PA08B_PTC_Y6                           _L_(1)      
+#define PINMUX_PA08B_PTC_Y6                        ((PIN_PA08B_PTC_Y6 << 16) | MUX_PA08B_PTC_Y6)
+#define PORT_PA08B_PTC_Y6                          (_UL_(1) << 8)
+
+#define PIN_PA09B_PTC_X7                           _L_(9)       /**< PTC signal: X7 on PA09 mux B*/
+#define MUX_PA09B_PTC_X7                           _L_(1)      
+#define PINMUX_PA09B_PTC_X7                        ((PIN_PA09B_PTC_X7 << 16) | MUX_PA09B_PTC_X7)
+#define PORT_PA09B_PTC_X7                          (_UL_(1) << 9)
+
+#define PIN_PA09B_PTC_Y7                           _L_(9)       /**< PTC signal: Y7 on PA09 mux B*/
+#define MUX_PA09B_PTC_Y7                           _L_(1)      
+#define PINMUX_PA09B_PTC_Y7                        ((PIN_PA09B_PTC_Y7 << 16) | MUX_PA09B_PTC_Y7)
+#define PORT_PA09B_PTC_Y7                          (_UL_(1) << 9)
+
+#define PIN_PA10B_PTC_X8                           _L_(10)      /**< PTC signal: X8 on PA10 mux B*/
+#define MUX_PA10B_PTC_X8                           _L_(1)      
+#define PINMUX_PA10B_PTC_X8                        ((PIN_PA10B_PTC_X8 << 16) | MUX_PA10B_PTC_X8)
+#define PORT_PA10B_PTC_X8                          (_UL_(1) << 10)
+
+#define PIN_PA10B_PTC_Y8                           _L_(10)      /**< PTC signal: Y8 on PA10 mux B*/
+#define MUX_PA10B_PTC_Y8                           _L_(1)      
+#define PINMUX_PA10B_PTC_Y8                        ((PIN_PA10B_PTC_Y8 << 16) | MUX_PA10B_PTC_Y8)
+#define PORT_PA10B_PTC_Y8                          (_UL_(1) << 10)
+
+#define PIN_PA11B_PTC_X9                           _L_(11)      /**< PTC signal: X9 on PA11 mux B*/
+#define MUX_PA11B_PTC_X9                           _L_(1)      
+#define PINMUX_PA11B_PTC_X9                        ((PIN_PA11B_PTC_X9 << 16) | MUX_PA11B_PTC_X9)
+#define PORT_PA11B_PTC_X9                          (_UL_(1) << 11)
+
+#define PIN_PA11B_PTC_Y9                           _L_(11)      /**< PTC signal: Y9 on PA11 mux B*/
+#define MUX_PA11B_PTC_Y9                           _L_(1)      
+#define PINMUX_PA11B_PTC_Y9                        ((PIN_PA11B_PTC_Y9 << 16) | MUX_PA11B_PTC_Y9)
+#define PORT_PA11B_PTC_Y9                          (_UL_(1) << 11)
+
+#define PIN_PA14B_PTC_X10                          _L_(14)      /**< PTC signal: X10 on PA14 mux B*/
+#define MUX_PA14B_PTC_X10                          _L_(1)      
+#define PINMUX_PA14B_PTC_X10                       ((PIN_PA14B_PTC_X10 << 16) | MUX_PA14B_PTC_X10)
+#define PORT_PA14B_PTC_X10                         (_UL_(1) << 14)
+
+#define PIN_PA14B_PTC_Y10                          _L_(14)      /**< PTC signal: Y10 on PA14 mux B*/
+#define MUX_PA14B_PTC_Y10                          _L_(1)      
+#define PINMUX_PA14B_PTC_Y10                       ((PIN_PA14B_PTC_Y10 << 16) | MUX_PA14B_PTC_Y10)
+#define PORT_PA14B_PTC_Y10                         (_UL_(1) << 14)
+
+#define PIN_PA15B_PTC_X11                          _L_(15)      /**< PTC signal: X11 on PA15 mux B*/
+#define MUX_PA15B_PTC_X11                          _L_(1)      
+#define PINMUX_PA15B_PTC_X11                       ((PIN_PA15B_PTC_X11 << 16) | MUX_PA15B_PTC_X11)
+#define PORT_PA15B_PTC_X11                         (_UL_(1) << 15)
+
+#define PIN_PA15B_PTC_Y11                          _L_(15)      /**< PTC signal: Y11 on PA15 mux B*/
+#define MUX_PA15B_PTC_Y11                          _L_(1)      
+#define PINMUX_PA15B_PTC_Y11                       ((PIN_PA15B_PTC_Y11 << 16) | MUX_PA15B_PTC_Y11)
+#define PORT_PA15B_PTC_Y11                         (_UL_(1) << 15)
+
+#define PIN_PA16B_PTC_X12                          _L_(16)      /**< PTC signal: X12 on PA16 mux B*/
+#define MUX_PA16B_PTC_X12                          _L_(1)      
+#define PINMUX_PA16B_PTC_X12                       ((PIN_PA16B_PTC_X12 << 16) | MUX_PA16B_PTC_X12)
+#define PORT_PA16B_PTC_X12                         (_UL_(1) << 16)
+
+#define PIN_PA16B_PTC_Y12                          _L_(16)      /**< PTC signal: Y12 on PA16 mux B*/
+#define MUX_PA16B_PTC_Y12                          _L_(1)      
+#define PINMUX_PA16B_PTC_Y12                       ((PIN_PA16B_PTC_Y12 << 16) | MUX_PA16B_PTC_Y12)
+#define PORT_PA16B_PTC_Y12                         (_UL_(1) << 16)
+
+#define PIN_PA17B_PTC_X13                          _L_(17)      /**< PTC signal: X13 on PA17 mux B*/
+#define MUX_PA17B_PTC_X13                          _L_(1)      
+#define PINMUX_PA17B_PTC_X13                       ((PIN_PA17B_PTC_X13 << 16) | MUX_PA17B_PTC_X13)
+#define PORT_PA17B_PTC_X13                         (_UL_(1) << 17)
+
+#define PIN_PA17B_PTC_Y13                          _L_(17)      /**< PTC signal: Y13 on PA17 mux B*/
+#define MUX_PA17B_PTC_Y13                          _L_(1)      
+#define PINMUX_PA17B_PTC_Y13                       ((PIN_PA17B_PTC_Y13 << 16) | MUX_PA17B_PTC_Y13)
+#define PORT_PA17B_PTC_Y13                         (_UL_(1) << 17)
+
+#define PIN_PA18B_PTC_X14                          _L_(18)      /**< PTC signal: X14 on PA18 mux B*/
+#define MUX_PA18B_PTC_X14                          _L_(1)      
+#define PINMUX_PA18B_PTC_X14                       ((PIN_PA18B_PTC_X14 << 16) | MUX_PA18B_PTC_X14)
+#define PORT_PA18B_PTC_X14                         (_UL_(1) << 18)
+
+#define PIN_PA18B_PTC_Y14                          _L_(18)      /**< PTC signal: Y14 on PA18 mux B*/
+#define MUX_PA18B_PTC_Y14                          _L_(1)      
+#define PINMUX_PA18B_PTC_Y14                       ((PIN_PA18B_PTC_Y14 << 16) | MUX_PA18B_PTC_Y14)
+#define PORT_PA18B_PTC_Y14                         (_UL_(1) << 18)
+
+#define PIN_PA19B_PTC_X15                          _L_(19)      /**< PTC signal: X15 on PA19 mux B*/
+#define MUX_PA19B_PTC_X15                          _L_(1)      
+#define PINMUX_PA19B_PTC_X15                       ((PIN_PA19B_PTC_X15 << 16) | MUX_PA19B_PTC_X15)
+#define PORT_PA19B_PTC_X15                         (_UL_(1) << 19)
+
+#define PIN_PA19B_PTC_Y15                          _L_(19)      /**< PTC signal: Y15 on PA19 mux B*/
+#define MUX_PA19B_PTC_Y15                          _L_(1)      
+#define PINMUX_PA19B_PTC_Y15                       ((PIN_PA19B_PTC_Y15 << 16) | MUX_PA19B_PTC_Y15)
+#define PORT_PA19B_PTC_Y15                         (_UL_(1) << 19)
+
+#define PIN_PA22B_PTC_X16                          _L_(22)      /**< PTC signal: X16 on PA22 mux B*/
+#define MUX_PA22B_PTC_X16                          _L_(1)      
+#define PINMUX_PA22B_PTC_X16                       ((PIN_PA22B_PTC_X16 << 16) | MUX_PA22B_PTC_X16)
+#define PORT_PA22B_PTC_X16                         (_UL_(1) << 22)
+
+#define PIN_PA22B_PTC_Y16                          _L_(22)      /**< PTC signal: Y16 on PA22 mux B*/
+#define MUX_PA22B_PTC_Y16                          _L_(1)      
+#define PINMUX_PA22B_PTC_Y16                       ((PIN_PA22B_PTC_Y16 << 16) | MUX_PA22B_PTC_Y16)
+#define PORT_PA22B_PTC_Y16                         (_UL_(1) << 22)
+
+#define PIN_PA23B_PTC_X17                          _L_(23)      /**< PTC signal: X17 on PA23 mux B*/
+#define MUX_PA23B_PTC_X17                          _L_(1)      
+#define PINMUX_PA23B_PTC_X17                       ((PIN_PA23B_PTC_X17 << 16) | MUX_PA23B_PTC_X17)
+#define PORT_PA23B_PTC_X17                         (_UL_(1) << 23)
+
+#define PIN_PA23B_PTC_Y17                          _L_(23)      /**< PTC signal: Y17 on PA23 mux B*/
+#define MUX_PA23B_PTC_Y17                          _L_(1)      
+#define PINMUX_PA23B_PTC_Y17                       ((PIN_PA23B_PTC_Y17 << 16) | MUX_PA23B_PTC_Y17)
+#define PORT_PA23B_PTC_Y17                         (_UL_(1) << 23)
+
+#define PIN_PA30B_PTC_X18                          _L_(30)      /**< PTC signal: X18 on PA30 mux B*/
+#define MUX_PA30B_PTC_X18                          _L_(1)      
+#define PINMUX_PA30B_PTC_X18                       ((PIN_PA30B_PTC_X18 << 16) | MUX_PA30B_PTC_X18)
+#define PORT_PA30B_PTC_X18                         (_UL_(1) << 30)
+
+#define PIN_PA30B_PTC_Y18                          _L_(30)      /**< PTC signal: Y18 on PA30 mux B*/
+#define MUX_PA30B_PTC_Y18                          _L_(1)      
+#define PINMUX_PA30B_PTC_Y18                       ((PIN_PA30B_PTC_Y18 << 16) | MUX_PA30B_PTC_Y18)
+#define PORT_PA30B_PTC_Y18                         (_UL_(1) << 30)
+
+#define PIN_PA31B_PTC_X19                          _L_(31)      /**< PTC signal: X19 on PA31 mux B*/
+#define MUX_PA31B_PTC_X19                          _L_(1)      
+#define PINMUX_PA31B_PTC_X19                       ((PIN_PA31B_PTC_X19 << 16) | MUX_PA31B_PTC_X19)
+#define PORT_PA31B_PTC_X19                         (_UL_(1) << 31)
+
+#define PIN_PA31B_PTC_Y19                          _L_(31)      /**< PTC signal: Y19 on PA31 mux B*/
+#define MUX_PA31B_PTC_Y19                          _L_(1)      
+#define PINMUX_PA31B_PTC_Y19                       ((PIN_PA31B_PTC_Y19 << 16) | MUX_PA31B_PTC_Y19)
+#define PORT_PA31B_PTC_Y19                         (_UL_(1) << 31)
+
+/* ========== PORT definition for RTC peripheral ========== */
+#define PIN_PA08G_RTC_IN0                          _L_(8)       /**< RTC signal: IN0 on PA08 mux G*/
+#define MUX_PA08G_RTC_IN0                          _L_(6)      
+#define PINMUX_PA08G_RTC_IN0                       ((PIN_PA08G_RTC_IN0 << 16) | MUX_PA08G_RTC_IN0)
+#define PORT_PA08G_RTC_IN0                         (_UL_(1) << 8)
+
+#define PIN_PA09G_RTC_IN1                          _L_(9)       /**< RTC signal: IN1 on PA09 mux G*/
+#define MUX_PA09G_RTC_IN1                          _L_(6)      
+#define PINMUX_PA09G_RTC_IN1                       ((PIN_PA09G_RTC_IN1 << 16) | MUX_PA09G_RTC_IN1)
+#define PORT_PA09G_RTC_IN1                         (_UL_(1) << 9)
+
+#define PIN_PA16G_RTC_IN2                          _L_(16)      /**< RTC signal: IN2 on PA16 mux G*/
+#define MUX_PA16G_RTC_IN2                          _L_(6)      
+#define PINMUX_PA16G_RTC_IN2                       ((PIN_PA16G_RTC_IN2 << 16) | MUX_PA16G_RTC_IN2)
+#define PORT_PA16G_RTC_IN2                         (_UL_(1) << 16)
+
+#define PIN_PA17G_RTC_IN3                          _L_(17)      /**< RTC signal: IN3 on PA17 mux G*/
+#define MUX_PA17G_RTC_IN3                          _L_(6)      
+#define PINMUX_PA17G_RTC_IN3                       ((PIN_PA17G_RTC_IN3 << 16) | MUX_PA17G_RTC_IN3)
+#define PORT_PA17G_RTC_IN3                         (_UL_(1) << 17)
+
+#define PIN_PA18G_RTC_OUT0                         _L_(18)      /**< RTC signal: OUT0 on PA18 mux G*/
+#define MUX_PA18G_RTC_OUT0                         _L_(6)      
+#define PINMUX_PA18G_RTC_OUT0                      ((PIN_PA18G_RTC_OUT0 << 16) | MUX_PA18G_RTC_OUT0)
+#define PORT_PA18G_RTC_OUT0                        (_UL_(1) << 18)
+
+#define PIN_PA19G_RTC_OUT1                         _L_(19)      /**< RTC signal: OUT1 on PA19 mux G*/
+#define MUX_PA19G_RTC_OUT1                         _L_(6)      
+#define PINMUX_PA19G_RTC_OUT1                      ((PIN_PA19G_RTC_OUT1 << 16) | MUX_PA19G_RTC_OUT1)
+#define PORT_PA19G_RTC_OUT1                        (_UL_(1) << 19)
+
+#define PIN_PA22G_RTC_OUT2                         _L_(22)      /**< RTC signal: OUT2 on PA22 mux G*/
+#define MUX_PA22G_RTC_OUT2                         _L_(6)      
+#define PINMUX_PA22G_RTC_OUT2                      ((PIN_PA22G_RTC_OUT2 << 16) | MUX_PA22G_RTC_OUT2)
+#define PORT_PA22G_RTC_OUT2                        (_UL_(1) << 22)
+
+#define PIN_PA23G_RTC_OUT3                         _L_(23)      /**< RTC signal: OUT3 on PA23 mux G*/
+#define MUX_PA23G_RTC_OUT3                         _L_(6)      
+#define PINMUX_PA23G_RTC_OUT3                      ((PIN_PA23G_RTC_OUT3 << 16) | MUX_PA23G_RTC_OUT3)
+#define PORT_PA23G_RTC_OUT3                        (_UL_(1) << 23)
+
+/* ========== PORT definition for SERCOM0 peripheral ========== */
+#define PIN_PA04D_SERCOM0_PAD0                     _L_(4)       /**< SERCOM0 signal: PAD0 on PA04 mux D*/
+#define MUX_PA04D_SERCOM0_PAD0                     _L_(3)      
+#define PINMUX_PA04D_SERCOM0_PAD0                  ((PIN_PA04D_SERCOM0_PAD0 << 16) | MUX_PA04D_SERCOM0_PAD0)
+#define PORT_PA04D_SERCOM0_PAD0                    (_UL_(1) << 4)
+
+#define PIN_PA16D_SERCOM0_PAD0                     _L_(16)      /**< SERCOM0 signal: PAD0 on PA16 mux D*/
+#define MUX_PA16D_SERCOM0_PAD0                     _L_(3)      
+#define PINMUX_PA16D_SERCOM0_PAD0                  ((PIN_PA16D_SERCOM0_PAD0 << 16) | MUX_PA16D_SERCOM0_PAD0)
+#define PORT_PA16D_SERCOM0_PAD0                    (_UL_(1) << 16)
+
+#define PIN_PA22C_SERCOM0_PAD0                     _L_(22)      /**< SERCOM0 signal: PAD0 on PA22 mux C*/
+#define MUX_PA22C_SERCOM0_PAD0                     _L_(2)      
+#define PINMUX_PA22C_SERCOM0_PAD0                  ((PIN_PA22C_SERCOM0_PAD0 << 16) | MUX_PA22C_SERCOM0_PAD0)
+#define PORT_PA22C_SERCOM0_PAD0                    (_UL_(1) << 22)
+
+#define PIN_PA05D_SERCOM0_PAD1                     _L_(5)       /**< SERCOM0 signal: PAD1 on PA05 mux D*/
+#define MUX_PA05D_SERCOM0_PAD1                     _L_(3)      
+#define PINMUX_PA05D_SERCOM0_PAD1                  ((PIN_PA05D_SERCOM0_PAD1 << 16) | MUX_PA05D_SERCOM0_PAD1)
+#define PORT_PA05D_SERCOM0_PAD1                    (_UL_(1) << 5)
+
+#define PIN_PA17D_SERCOM0_PAD1                     _L_(17)      /**< SERCOM0 signal: PAD1 on PA17 mux D*/
+#define MUX_PA17D_SERCOM0_PAD1                     _L_(3)      
+#define PINMUX_PA17D_SERCOM0_PAD1                  ((PIN_PA17D_SERCOM0_PAD1 << 16) | MUX_PA17D_SERCOM0_PAD1)
+#define PORT_PA17D_SERCOM0_PAD1                    (_UL_(1) << 17)
+
+#define PIN_PA23C_SERCOM0_PAD1                     _L_(23)      /**< SERCOM0 signal: PAD1 on PA23 mux C*/
+#define MUX_PA23C_SERCOM0_PAD1                     _L_(2)      
+#define PINMUX_PA23C_SERCOM0_PAD1                  ((PIN_PA23C_SERCOM0_PAD1 << 16) | MUX_PA23C_SERCOM0_PAD1)
+#define PORT_PA23C_SERCOM0_PAD1                    (_UL_(1) << 23)
+
+#define PIN_PA06D_SERCOM0_PAD2                     _L_(6)       /**< SERCOM0 signal: PAD2 on PA06 mux D*/
+#define MUX_PA06D_SERCOM0_PAD2                     _L_(3)      
+#define PINMUX_PA06D_SERCOM0_PAD2                  ((PIN_PA06D_SERCOM0_PAD2 << 16) | MUX_PA06D_SERCOM0_PAD2)
+#define PORT_PA06D_SERCOM0_PAD2                    (_UL_(1) << 6)
+
+#define PIN_PA14D_SERCOM0_PAD2                     _L_(14)      /**< SERCOM0 signal: PAD2 on PA14 mux D*/
+#define MUX_PA14D_SERCOM0_PAD2                     _L_(3)      
+#define PINMUX_PA14D_SERCOM0_PAD2                  ((PIN_PA14D_SERCOM0_PAD2 << 16) | MUX_PA14D_SERCOM0_PAD2)
+#define PORT_PA14D_SERCOM0_PAD2                    (_UL_(1) << 14)
+
+#define PIN_PA18D_SERCOM0_PAD2                     _L_(18)      /**< SERCOM0 signal: PAD2 on PA18 mux D*/
+#define MUX_PA18D_SERCOM0_PAD2                     _L_(3)      
+#define PINMUX_PA18D_SERCOM0_PAD2                  ((PIN_PA18D_SERCOM0_PAD2 << 16) | MUX_PA18D_SERCOM0_PAD2)
+#define PORT_PA18D_SERCOM0_PAD2                    (_UL_(1) << 18)
+
+#define PIN_PA24C_SERCOM0_PAD2                     _L_(24)      /**< SERCOM0 signal: PAD2 on PA24 mux C*/
+#define MUX_PA24C_SERCOM0_PAD2                     _L_(2)      
+#define PINMUX_PA24C_SERCOM0_PAD2                  ((PIN_PA24C_SERCOM0_PAD2 << 16) | MUX_PA24C_SERCOM0_PAD2)
+#define PORT_PA24C_SERCOM0_PAD2                    (_UL_(1) << 24)
+
+#define PIN_PA02D_SERCOM0_PAD2                     _L_(2)       /**< SERCOM0 signal: PAD2 on PA02 mux D*/
+#define MUX_PA02D_SERCOM0_PAD2                     _L_(3)      
+#define PINMUX_PA02D_SERCOM0_PAD2                  ((PIN_PA02D_SERCOM0_PAD2 << 16) | MUX_PA02D_SERCOM0_PAD2)
+#define PORT_PA02D_SERCOM0_PAD2                    (_UL_(1) << 2)
+
+#define PIN_PA07D_SERCOM0_PAD3                     _L_(7)       /**< SERCOM0 signal: PAD3 on PA07 mux D*/
+#define MUX_PA07D_SERCOM0_PAD3                     _L_(3)      
+#define PINMUX_PA07D_SERCOM0_PAD3                  ((PIN_PA07D_SERCOM0_PAD3 << 16) | MUX_PA07D_SERCOM0_PAD3)
+#define PORT_PA07D_SERCOM0_PAD3                    (_UL_(1) << 7)
+
+#define PIN_PA15D_SERCOM0_PAD3                     _L_(15)      /**< SERCOM0 signal: PAD3 on PA15 mux D*/
+#define MUX_PA15D_SERCOM0_PAD3                     _L_(3)      
+#define PINMUX_PA15D_SERCOM0_PAD3                  ((PIN_PA15D_SERCOM0_PAD3 << 16) | MUX_PA15D_SERCOM0_PAD3)
+#define PORT_PA15D_SERCOM0_PAD3                    (_UL_(1) << 15)
+
+#define PIN_PA19D_SERCOM0_PAD3                     _L_(19)      /**< SERCOM0 signal: PAD3 on PA19 mux D*/
+#define MUX_PA19D_SERCOM0_PAD3                     _L_(3)      
+#define PINMUX_PA19D_SERCOM0_PAD3                  ((PIN_PA19D_SERCOM0_PAD3 << 16) | MUX_PA19D_SERCOM0_PAD3)
+#define PORT_PA19D_SERCOM0_PAD3                    (_UL_(1) << 19)
+
+#define PIN_PA25C_SERCOM0_PAD3                     _L_(25)      /**< SERCOM0 signal: PAD3 on PA25 mux C*/
+#define MUX_PA25C_SERCOM0_PAD3                     _L_(2)      
+#define PINMUX_PA25C_SERCOM0_PAD3                  ((PIN_PA25C_SERCOM0_PAD3 << 16) | MUX_PA25C_SERCOM0_PAD3)
+#define PORT_PA25C_SERCOM0_PAD3                    (_UL_(1) << 25)
+
+#define PIN_PA03D_SERCOM0_PAD3                     _L_(3)       /**< SERCOM0 signal: PAD3 on PA03 mux D*/
+#define MUX_PA03D_SERCOM0_PAD3                     _L_(3)      
+#define PINMUX_PA03D_SERCOM0_PAD3                  ((PIN_PA03D_SERCOM0_PAD3 << 16) | MUX_PA03D_SERCOM0_PAD3)
+#define PORT_PA03D_SERCOM0_PAD3                    (_UL_(1) << 3)
+
+/* ========== PORT definition for SERCOM1 peripheral ========== */
+#define PIN_PA16C_SERCOM1_PAD0                     _L_(16)      /**< SERCOM1 signal: PAD0 on PA16 mux C*/
+#define MUX_PA16C_SERCOM1_PAD0                     _L_(2)      
+#define PINMUX_PA16C_SERCOM1_PAD0                  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
+#define PORT_PA16C_SERCOM1_PAD0                    (_UL_(1) << 16)
+
+#define PIN_PA08C_SERCOM1_PAD0                     _L_(8)       /**< SERCOM1 signal: PAD0 on PA08 mux C*/
+#define MUX_PA08C_SERCOM1_PAD0                     _L_(2)      
+#define PINMUX_PA08C_SERCOM1_PAD0                  ((PIN_PA08C_SERCOM1_PAD0 << 16) | MUX_PA08C_SERCOM1_PAD0)
+#define PORT_PA08C_SERCOM1_PAD0                    (_UL_(1) << 8)
+
+#define PIN_PA00D_SERCOM1_PAD0                     _L_(0)       /**< SERCOM1 signal: PAD0 on PA00 mux D*/
+#define MUX_PA00D_SERCOM1_PAD0                     _L_(3)      
+#define PINMUX_PA00D_SERCOM1_PAD0                  ((PIN_PA00D_SERCOM1_PAD0 << 16) | MUX_PA00D_SERCOM1_PAD0)
+#define PORT_PA00D_SERCOM1_PAD0                    (_UL_(1) << 0)
+
+#define PIN_PA17C_SERCOM1_PAD1                     _L_(17)      /**< SERCOM1 signal: PAD1 on PA17 mux C*/
+#define MUX_PA17C_SERCOM1_PAD1                     _L_(2)      
+#define PINMUX_PA17C_SERCOM1_PAD1                  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
+#define PORT_PA17C_SERCOM1_PAD1                    (_UL_(1) << 17)
+
+#define PIN_PA09C_SERCOM1_PAD1                     _L_(9)       /**< SERCOM1 signal: PAD1 on PA09 mux C*/
+#define MUX_PA09C_SERCOM1_PAD1                     _L_(2)      
+#define PINMUX_PA09C_SERCOM1_PAD1                  ((PIN_PA09C_SERCOM1_PAD1 << 16) | MUX_PA09C_SERCOM1_PAD1)
+#define PORT_PA09C_SERCOM1_PAD1                    (_UL_(1) << 9)
+
+#define PIN_PA01D_SERCOM1_PAD1                     _L_(1)       /**< SERCOM1 signal: PAD1 on PA01 mux D*/
+#define MUX_PA01D_SERCOM1_PAD1                     _L_(3)      
+#define PINMUX_PA01D_SERCOM1_PAD1                  ((PIN_PA01D_SERCOM1_PAD1 << 16) | MUX_PA01D_SERCOM1_PAD1)
+#define PORT_PA01D_SERCOM1_PAD1                    (_UL_(1) << 1)
+
+#define PIN_PA18C_SERCOM1_PAD2                     _L_(18)      /**< SERCOM1 signal: PAD2 on PA18 mux C*/
+#define MUX_PA18C_SERCOM1_PAD2                     _L_(2)      
+#define PINMUX_PA18C_SERCOM1_PAD2                  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
+#define PORT_PA18C_SERCOM1_PAD2                    (_UL_(1) << 18)
+
+#define PIN_PA10C_SERCOM1_PAD2                     _L_(10)      /**< SERCOM1 signal: PAD2 on PA10 mux C*/
+#define MUX_PA10C_SERCOM1_PAD2                     _L_(2)      
+#define PINMUX_PA10C_SERCOM1_PAD2                  ((PIN_PA10C_SERCOM1_PAD2 << 16) | MUX_PA10C_SERCOM1_PAD2)
+#define PORT_PA10C_SERCOM1_PAD2                    (_UL_(1) << 10)
+
+#define PIN_PA30D_SERCOM1_PAD2                     _L_(30)      /**< SERCOM1 signal: PAD2 on PA30 mux D*/
+#define MUX_PA30D_SERCOM1_PAD2                     _L_(3)      
+#define PINMUX_PA30D_SERCOM1_PAD2                  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
+#define PORT_PA30D_SERCOM1_PAD2                    (_UL_(1) << 30)
+
+#define PIN_PA19C_SERCOM1_PAD3                     _L_(19)      /**< SERCOM1 signal: PAD3 on PA19 mux C*/
+#define MUX_PA19C_SERCOM1_PAD3                     _L_(2)      
+#define PINMUX_PA19C_SERCOM1_PAD3                  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
+#define PORT_PA19C_SERCOM1_PAD3                    (_UL_(1) << 19)
+
+#define PIN_PA11C_SERCOM1_PAD3                     _L_(11)      /**< SERCOM1 signal: PAD3 on PA11 mux C*/
+#define MUX_PA11C_SERCOM1_PAD3                     _L_(2)      
+#define PINMUX_PA11C_SERCOM1_PAD3                  ((PIN_PA11C_SERCOM1_PAD3 << 16) | MUX_PA11C_SERCOM1_PAD3)
+#define PORT_PA11C_SERCOM1_PAD3                    (_UL_(1) << 11)
+
+#define PIN_PA31D_SERCOM1_PAD3                     _L_(31)      /**< SERCOM1 signal: PAD3 on PA31 mux D*/
+#define MUX_PA31D_SERCOM1_PAD3                     _L_(3)      
+#define PINMUX_PA31D_SERCOM1_PAD3                  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
+#define PORT_PA31D_SERCOM1_PAD3                    (_UL_(1) << 31)
+
+/* ========== PORT definition for SERCOM2 peripheral ========== */
+#define PIN_PA08D_SERCOM2_PAD0                     _L_(8)       /**< SERCOM2 signal: PAD0 on PA08 mux D*/
+#define MUX_PA08D_SERCOM2_PAD0                     _L_(3)      
+#define PINMUX_PA08D_SERCOM2_PAD0                  ((PIN_PA08D_SERCOM2_PAD0 << 16) | MUX_PA08D_SERCOM2_PAD0)
+#define PORT_PA08D_SERCOM2_PAD0                    (_UL_(1) << 8)
+
+#define PIN_PA22D_SERCOM2_PAD0                     _L_(22)      /**< SERCOM2 signal: PAD0 on PA22 mux D*/
+#define MUX_PA22D_SERCOM2_PAD0                     _L_(3)      
+#define PINMUX_PA22D_SERCOM2_PAD0                  ((PIN_PA22D_SERCOM2_PAD0 << 16) | MUX_PA22D_SERCOM2_PAD0)
+#define PORT_PA22D_SERCOM2_PAD0                    (_UL_(1) << 22)
+
+#define PIN_PA09D_SERCOM2_PAD1                     _L_(9)       /**< SERCOM2 signal: PAD1 on PA09 mux D*/
+#define MUX_PA09D_SERCOM2_PAD1                     _L_(3)      
+#define PINMUX_PA09D_SERCOM2_PAD1                  ((PIN_PA09D_SERCOM2_PAD1 << 16) | MUX_PA09D_SERCOM2_PAD1)
+#define PORT_PA09D_SERCOM2_PAD1                    (_UL_(1) << 9)
+
+#define PIN_PA23D_SERCOM2_PAD1                     _L_(23)      /**< SERCOM2 signal: PAD1 on PA23 mux D*/
+#define MUX_PA23D_SERCOM2_PAD1                     _L_(3)      
+#define PINMUX_PA23D_SERCOM2_PAD1                  ((PIN_PA23D_SERCOM2_PAD1 << 16) | MUX_PA23D_SERCOM2_PAD1)
+#define PORT_PA23D_SERCOM2_PAD1                    (_UL_(1) << 23)
+
+#define PIN_PA10D_SERCOM2_PAD2                     _L_(10)      /**< SERCOM2 signal: PAD2 on PA10 mux D*/
+#define MUX_PA10D_SERCOM2_PAD2                     _L_(3)      
+#define PINMUX_PA10D_SERCOM2_PAD2                  ((PIN_PA10D_SERCOM2_PAD2 << 16) | MUX_PA10D_SERCOM2_PAD2)
+#define PORT_PA10D_SERCOM2_PAD2                    (_UL_(1) << 10)
+
+#define PIN_PA24D_SERCOM2_PAD2                     _L_(24)      /**< SERCOM2 signal: PAD2 on PA24 mux D*/
+#define MUX_PA24D_SERCOM2_PAD2                     _L_(3)      
+#define PINMUX_PA24D_SERCOM2_PAD2                  ((PIN_PA24D_SERCOM2_PAD2 << 16) | MUX_PA24D_SERCOM2_PAD2)
+#define PORT_PA24D_SERCOM2_PAD2                    (_UL_(1) << 24)
+
+#define PIN_PA14C_SERCOM2_PAD2                     _L_(14)      /**< SERCOM2 signal: PAD2 on PA14 mux C*/
+#define MUX_PA14C_SERCOM2_PAD2                     _L_(2)      
+#define PINMUX_PA14C_SERCOM2_PAD2                  ((PIN_PA14C_SERCOM2_PAD2 << 16) | MUX_PA14C_SERCOM2_PAD2)
+#define PORT_PA14C_SERCOM2_PAD2                    (_UL_(1) << 14)
+
+#define PIN_PA11D_SERCOM2_PAD3                     _L_(11)      /**< SERCOM2 signal: PAD3 on PA11 mux D*/
+#define MUX_PA11D_SERCOM2_PAD3                     _L_(3)      
+#define PINMUX_PA11D_SERCOM2_PAD3                  ((PIN_PA11D_SERCOM2_PAD3 << 16) | MUX_PA11D_SERCOM2_PAD3)
+#define PORT_PA11D_SERCOM2_PAD3                    (_UL_(1) << 11)
+
+#define PIN_PA25D_SERCOM2_PAD3                     _L_(25)      /**< SERCOM2 signal: PAD3 on PA25 mux D*/
+#define MUX_PA25D_SERCOM2_PAD3                     _L_(3)      
+#define PINMUX_PA25D_SERCOM2_PAD3                  ((PIN_PA25D_SERCOM2_PAD3 << 16) | MUX_PA25D_SERCOM2_PAD3)
+#define PORT_PA25D_SERCOM2_PAD3                    (_UL_(1) << 25)
+
+#define PIN_PA15C_SERCOM2_PAD3                     _L_(15)      /**< SERCOM2 signal: PAD3 on PA15 mux C*/
+#define MUX_PA15C_SERCOM2_PAD3                     _L_(2)      
+#define PINMUX_PA15C_SERCOM2_PAD3                  ((PIN_PA15C_SERCOM2_PAD3 << 16) | MUX_PA15C_SERCOM2_PAD3)
+#define PORT_PA15C_SERCOM2_PAD3                    (_UL_(1) << 15)
+
+/* ========== PORT definition for TC0 peripheral ========== */
+#define PIN_PA04E_TC0_WO0                          _L_(4)       /**< TC0 signal: WO0 on PA04 mux E*/
+#define MUX_PA04E_TC0_WO0                          _L_(4)      
+#define PINMUX_PA04E_TC0_WO0                       ((PIN_PA04E_TC0_WO0 << 16) | MUX_PA04E_TC0_WO0)
+#define PORT_PA04E_TC0_WO0                         (_UL_(1) << 4)
+
+#define PIN_PA14E_TC0_WO0                          _L_(14)      /**< TC0 signal: WO0 on PA14 mux E*/
+#define MUX_PA14E_TC0_WO0                          _L_(4)      
+#define PINMUX_PA14E_TC0_WO0                       ((PIN_PA14E_TC0_WO0 << 16) | MUX_PA14E_TC0_WO0)
+#define PORT_PA14E_TC0_WO0                         (_UL_(1) << 14)
+
+#define PIN_PA22E_TC0_WO0                          _L_(22)      /**< TC0 signal: WO0 on PA22 mux E*/
+#define MUX_PA22E_TC0_WO0                          _L_(4)      
+#define PINMUX_PA22E_TC0_WO0                       ((PIN_PA22E_TC0_WO0 << 16) | MUX_PA22E_TC0_WO0)
+#define PORT_PA22E_TC0_WO0                         (_UL_(1) << 22)
+
+#define PIN_PA05E_TC0_WO1                          _L_(5)       /**< TC0 signal: WO1 on PA05 mux E*/
+#define MUX_PA05E_TC0_WO1                          _L_(4)      
+#define PINMUX_PA05E_TC0_WO1                       ((PIN_PA05E_TC0_WO1 << 16) | MUX_PA05E_TC0_WO1)
+#define PORT_PA05E_TC0_WO1                         (_UL_(1) << 5)
+
+#define PIN_PA15E_TC0_WO1                          _L_(15)      /**< TC0 signal: WO1 on PA15 mux E*/
+#define MUX_PA15E_TC0_WO1                          _L_(4)      
+#define PINMUX_PA15E_TC0_WO1                       ((PIN_PA15E_TC0_WO1 << 16) | MUX_PA15E_TC0_WO1)
+#define PORT_PA15E_TC0_WO1                         (_UL_(1) << 15)
+
+#define PIN_PA23E_TC0_WO1                          _L_(23)      /**< TC0 signal: WO1 on PA23 mux E*/
+#define MUX_PA23E_TC0_WO1                          _L_(4)      
+#define PINMUX_PA23E_TC0_WO1                       ((PIN_PA23E_TC0_WO1 << 16) | MUX_PA23E_TC0_WO1)
+#define PORT_PA23E_TC0_WO1                         (_UL_(1) << 23)
+
+/* ========== PORT definition for TC1 peripheral ========== */
+#define PIN_PA06E_TC1_WO0                          _L_(6)       /**< TC1 signal: WO0 on PA06 mux E*/
+#define MUX_PA06E_TC1_WO0                          _L_(4)      
+#define PINMUX_PA06E_TC1_WO0                       ((PIN_PA06E_TC1_WO0 << 16) | MUX_PA06E_TC1_WO0)
+#define PORT_PA06E_TC1_WO0                         (_UL_(1) << 6)
+
+#define PIN_PA24E_TC1_WO0                          _L_(24)      /**< TC1 signal: WO0 on PA24 mux E*/
+#define MUX_PA24E_TC1_WO0                          _L_(4)      
+#define PINMUX_PA24E_TC1_WO0                       ((PIN_PA24E_TC1_WO0 << 16) | MUX_PA24E_TC1_WO0)
+#define PORT_PA24E_TC1_WO0                         (_UL_(1) << 24)
+
+#define PIN_PA30E_TC1_WO0                          _L_(30)      /**< TC1 signal: WO0 on PA30 mux E*/
+#define MUX_PA30E_TC1_WO0                          _L_(4)      
+#define PINMUX_PA30E_TC1_WO0                       ((PIN_PA30E_TC1_WO0 << 16) | MUX_PA30E_TC1_WO0)
+#define PORT_PA30E_TC1_WO0                         (_UL_(1) << 30)
+
+#define PIN_PA07E_TC1_WO1                          _L_(7)       /**< TC1 signal: WO1 on PA07 mux E*/
+#define MUX_PA07E_TC1_WO1                          _L_(4)      
+#define PINMUX_PA07E_TC1_WO1                       ((PIN_PA07E_TC1_WO1 << 16) | MUX_PA07E_TC1_WO1)
+#define PORT_PA07E_TC1_WO1                         (_UL_(1) << 7)
+
+#define PIN_PA25E_TC1_WO1                          _L_(25)      /**< TC1 signal: WO1 on PA25 mux E*/
+#define MUX_PA25E_TC1_WO1                          _L_(4)      
+#define PINMUX_PA25E_TC1_WO1                       ((PIN_PA25E_TC1_WO1 << 16) | MUX_PA25E_TC1_WO1)
+#define PORT_PA25E_TC1_WO1                         (_UL_(1) << 25)
+
+#define PIN_PA31E_TC1_WO1                          _L_(31)      /**< TC1 signal: WO1 on PA31 mux E*/
+#define MUX_PA31E_TC1_WO1                          _L_(4)      
+#define PINMUX_PA31E_TC1_WO1                       ((PIN_PA31E_TC1_WO1 << 16) | MUX_PA31E_TC1_WO1)
+#define PORT_PA31E_TC1_WO1                         (_UL_(1) << 31)
+
+/* ========== PORT definition for TC2 peripheral ========== */
+#define PIN_PA00E_TC2_WO0                          _L_(0)       /**< TC2 signal: WO0 on PA00 mux E*/
+#define MUX_PA00E_TC2_WO0                          _L_(4)      
+#define PINMUX_PA00E_TC2_WO0                       ((PIN_PA00E_TC2_WO0 << 16) | MUX_PA00E_TC2_WO0)
+#define PORT_PA00E_TC2_WO0                         (_UL_(1) << 0)
+
+#define PIN_PA18E_TC2_WO0                          _L_(18)      /**< TC2 signal: WO0 on PA18 mux E*/
+#define MUX_PA18E_TC2_WO0                          _L_(4)      
+#define PINMUX_PA18E_TC2_WO0                       ((PIN_PA18E_TC2_WO0 << 16) | MUX_PA18E_TC2_WO0)
+#define PORT_PA18E_TC2_WO0                         (_UL_(1) << 18)
+
+#define PIN_PA01E_TC2_WO1                          _L_(1)       /**< TC2 signal: WO1 on PA01 mux E*/
+#define MUX_PA01E_TC2_WO1                          _L_(4)      
+#define PINMUX_PA01E_TC2_WO1                       ((PIN_PA01E_TC2_WO1 << 16) | MUX_PA01E_TC2_WO1)
+#define PORT_PA01E_TC2_WO1                         (_UL_(1) << 1)
+
+#define PIN_PA19E_TC2_WO1                          _L_(19)      /**< TC2 signal: WO1 on PA19 mux E*/
+#define MUX_PA19E_TC2_WO1                          _L_(4)      
+#define PINMUX_PA19E_TC2_WO1                       ((PIN_PA19E_TC2_WO1 << 16) | MUX_PA19E_TC2_WO1)
+#define PORT_PA19E_TC2_WO1                         (_UL_(1) << 19)
+
+
+#endif /* _SAML11E15A_PIO_H_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/pio/saml11e16a.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/pio/saml11e16a.h
@@ -1,0 +1,1167 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAML11E16A
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11E16A_PIO_H_
+#define _SAML11E16A_PIO_H_
+
+/* ========== Peripheral I/O pin numbers ========== */
+#define PIN_PA00                    (  0)  /**< Pin Number for PA00 */
+#define PIN_PA01                    (  1)  /**< Pin Number for PA01 */
+#define PIN_PA02                    (  2)  /**< Pin Number for PA02 */
+#define PIN_PA03                    (  3)  /**< Pin Number for PA03 */
+#define PIN_PA04                    (  4)  /**< Pin Number for PA04 */
+#define PIN_PA05                    (  5)  /**< Pin Number for PA05 */
+#define PIN_PA06                    (  6)  /**< Pin Number for PA06 */
+#define PIN_PA07                    (  7)  /**< Pin Number for PA07 */
+#define PIN_PA08                    (  8)  /**< Pin Number for PA08 */
+#define PIN_PA09                    (  9)  /**< Pin Number for PA09 */
+#define PIN_PA10                    ( 10)  /**< Pin Number for PA10 */
+#define PIN_PA11                    ( 11)  /**< Pin Number for PA11 */
+#define PIN_PA14                    ( 14)  /**< Pin Number for PA14 */
+#define PIN_PA15                    ( 15)  /**< Pin Number for PA15 */
+#define PIN_PA16                    ( 16)  /**< Pin Number for PA16 */
+#define PIN_PA17                    ( 17)  /**< Pin Number for PA17 */
+#define PIN_PA18                    ( 18)  /**< Pin Number for PA18 */
+#define PIN_PA19                    ( 19)  /**< Pin Number for PA19 */
+#define PIN_PA22                    ( 22)  /**< Pin Number for PA22 */
+#define PIN_PA23                    ( 23)  /**< Pin Number for PA23 */
+#define PIN_PA24                    ( 24)  /**< Pin Number for PA24 */
+#define PIN_PA25                    ( 25)  /**< Pin Number for PA25 */
+#define PIN_PA27                    ( 27)  /**< Pin Number for PA27 */
+#define PIN_PA30                    ( 30)  /**< Pin Number for PA30 */
+#define PIN_PA31                    ( 31)  /**< Pin Number for PA31 */
+
+
+/* ========== Peripheral I/O masks ========== */
+#define PORT_PA00                   (_U_(1) << 0) /**< PORT Mask for PA00 */
+#define PORT_PA01                   (_U_(1) << 1) /**< PORT Mask for PA01 */
+#define PORT_PA02                   (_U_(1) << 2) /**< PORT Mask for PA02 */
+#define PORT_PA03                   (_U_(1) << 3) /**< PORT Mask for PA03 */
+#define PORT_PA04                   (_U_(1) << 4) /**< PORT Mask for PA04 */
+#define PORT_PA05                   (_U_(1) << 5) /**< PORT Mask for PA05 */
+#define PORT_PA06                   (_U_(1) << 6) /**< PORT Mask for PA06 */
+#define PORT_PA07                   (_U_(1) << 7) /**< PORT Mask for PA07 */
+#define PORT_PA08                   (_U_(1) << 8) /**< PORT Mask for PA08 */
+#define PORT_PA09                   (_U_(1) << 9) /**< PORT Mask for PA09 */
+#define PORT_PA10                   (_U_(1) << 10) /**< PORT Mask for PA10 */
+#define PORT_PA11                   (_U_(1) << 11) /**< PORT Mask for PA11 */
+#define PORT_PA14                   (_U_(1) << 14) /**< PORT Mask for PA14 */
+#define PORT_PA15                   (_U_(1) << 15) /**< PORT Mask for PA15 */
+#define PORT_PA16                   (_U_(1) << 16) /**< PORT Mask for PA16 */
+#define PORT_PA17                   (_U_(1) << 17) /**< PORT Mask for PA17 */
+#define PORT_PA18                   (_U_(1) << 18) /**< PORT Mask for PA18 */
+#define PORT_PA19                   (_U_(1) << 19) /**< PORT Mask for PA19 */
+#define PORT_PA22                   (_U_(1) << 22) /**< PORT Mask for PA22 */
+#define PORT_PA23                   (_U_(1) << 23) /**< PORT Mask for PA23 */
+#define PORT_PA24                   (_U_(1) << 24) /**< PORT Mask for PA24 */
+#define PORT_PA25                   (_U_(1) << 25) /**< PORT Mask for PA25 */
+#define PORT_PA27                   (_U_(1) << 27) /**< PORT Mask for PA27 */
+#define PORT_PA30                   (_U_(1) << 30) /**< PORT Mask for PA30 */
+#define PORT_PA31                   (_U_(1) << 31) /**< PORT Mask for PA31 */
+
+
+/* ========== Peripheral I/O indexes ========== */
+#define PORT_PA00_IDX               (  0)  /**< PORT Index Number for PA00 */
+#define PORT_PA01_IDX               (  1)  /**< PORT Index Number for PA01 */
+#define PORT_PA02_IDX               (  2)  /**< PORT Index Number for PA02 */
+#define PORT_PA03_IDX               (  3)  /**< PORT Index Number for PA03 */
+#define PORT_PA04_IDX               (  4)  /**< PORT Index Number for PA04 */
+#define PORT_PA05_IDX               (  5)  /**< PORT Index Number for PA05 */
+#define PORT_PA06_IDX               (  6)  /**< PORT Index Number for PA06 */
+#define PORT_PA07_IDX               (  7)  /**< PORT Index Number for PA07 */
+#define PORT_PA08_IDX               (  8)  /**< PORT Index Number for PA08 */
+#define PORT_PA09_IDX               (  9)  /**< PORT Index Number for PA09 */
+#define PORT_PA10_IDX               ( 10)  /**< PORT Index Number for PA10 */
+#define PORT_PA11_IDX               ( 11)  /**< PORT Index Number for PA11 */
+#define PORT_PA14_IDX               ( 14)  /**< PORT Index Number for PA14 */
+#define PORT_PA15_IDX               ( 15)  /**< PORT Index Number for PA15 */
+#define PORT_PA16_IDX               ( 16)  /**< PORT Index Number for PA16 */
+#define PORT_PA17_IDX               ( 17)  /**< PORT Index Number for PA17 */
+#define PORT_PA18_IDX               ( 18)  /**< PORT Index Number for PA18 */
+#define PORT_PA19_IDX               ( 19)  /**< PORT Index Number for PA19 */
+#define PORT_PA22_IDX               ( 22)  /**< PORT Index Number for PA22 */
+#define PORT_PA23_IDX               ( 23)  /**< PORT Index Number for PA23 */
+#define PORT_PA24_IDX               ( 24)  /**< PORT Index Number for PA24 */
+#define PORT_PA25_IDX               ( 25)  /**< PORT Index Number for PA25 */
+#define PORT_PA27_IDX               ( 27)  /**< PORT Index Number for PA27 */
+#define PORT_PA30_IDX               ( 30)  /**< PORT Index Number for PA30 */
+#define PORT_PA31_IDX               ( 31)  /**< PORT Index Number for PA31 */
+
+/* ========== PORT definition for AC peripheral ========== */
+#define PIN_PA04B_AC_AIN0                          _L_(4)       /**< AC signal: AIN0 on PA04 mux B*/
+#define MUX_PA04B_AC_AIN0                          _L_(1)      
+#define PINMUX_PA04B_AC_AIN0                       ((PIN_PA04B_AC_AIN0 << 16) | MUX_PA04B_AC_AIN0)
+#define PORT_PA04B_AC_AIN0                         (_UL_(1) << 4)
+
+#define PIN_PA05B_AC_AIN1                          _L_(5)       /**< AC signal: AIN1 on PA05 mux B*/
+#define MUX_PA05B_AC_AIN1                          _L_(1)      
+#define PINMUX_PA05B_AC_AIN1                       ((PIN_PA05B_AC_AIN1 << 16) | MUX_PA05B_AC_AIN1)
+#define PORT_PA05B_AC_AIN1                         (_UL_(1) << 5)
+
+#define PIN_PA06B_AC_AIN2                          _L_(6)       /**< AC signal: AIN2 on PA06 mux B*/
+#define MUX_PA06B_AC_AIN2                          _L_(1)      
+#define PINMUX_PA06B_AC_AIN2                       ((PIN_PA06B_AC_AIN2 << 16) | MUX_PA06B_AC_AIN2)
+#define PORT_PA06B_AC_AIN2                         (_UL_(1) << 6)
+
+#define PIN_PA07B_AC_AIN3                          _L_(7)       /**< AC signal: AIN3 on PA07 mux B*/
+#define MUX_PA07B_AC_AIN3                          _L_(1)      
+#define PINMUX_PA07B_AC_AIN3                       ((PIN_PA07B_AC_AIN3 << 16) | MUX_PA07B_AC_AIN3)
+#define PORT_PA07B_AC_AIN3                         (_UL_(1) << 7)
+
+#define PIN_PA18H_AC_CMP0                          _L_(18)      /**< AC signal: CMP0 on PA18 mux H*/
+#define MUX_PA18H_AC_CMP0                          _L_(7)      
+#define PINMUX_PA18H_AC_CMP0                       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
+#define PORT_PA18H_AC_CMP0                         (_UL_(1) << 18)
+
+#define PIN_PA19H_AC_CMP1                          _L_(19)      /**< AC signal: CMP1 on PA19 mux H*/
+#define MUX_PA19H_AC_CMP1                          _L_(7)      
+#define PINMUX_PA19H_AC_CMP1                       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
+#define PORT_PA19H_AC_CMP1                         (_UL_(1) << 19)
+
+/* ========== PORT definition for ADC peripheral ========== */
+#define PIN_PA02B_ADC_AIN0                         _L_(2)       /**< ADC signal: AIN0 on PA02 mux B*/
+#define MUX_PA02B_ADC_AIN0                         _L_(1)      
+#define PINMUX_PA02B_ADC_AIN0                      ((PIN_PA02B_ADC_AIN0 << 16) | MUX_PA02B_ADC_AIN0)
+#define PORT_PA02B_ADC_AIN0                        (_UL_(1) << 2)
+
+#define PIN_PA03B_ADC_AIN1                         _L_(3)       /**< ADC signal: AIN1 on PA03 mux B*/
+#define MUX_PA03B_ADC_AIN1                         _L_(1)      
+#define PINMUX_PA03B_ADC_AIN1                      ((PIN_PA03B_ADC_AIN1 << 16) | MUX_PA03B_ADC_AIN1)
+#define PORT_PA03B_ADC_AIN1                        (_UL_(1) << 3)
+
+#define PIN_PA04B_ADC_AIN2                         _L_(4)       /**< ADC signal: AIN2 on PA04 mux B*/
+#define MUX_PA04B_ADC_AIN2                         _L_(1)      
+#define PINMUX_PA04B_ADC_AIN2                      ((PIN_PA04B_ADC_AIN2 << 16) | MUX_PA04B_ADC_AIN2)
+#define PORT_PA04B_ADC_AIN2                        (_UL_(1) << 4)
+
+#define PIN_PA05B_ADC_AIN3                         _L_(5)       /**< ADC signal: AIN3 on PA05 mux B*/
+#define MUX_PA05B_ADC_AIN3                         _L_(1)      
+#define PINMUX_PA05B_ADC_AIN3                      ((PIN_PA05B_ADC_AIN3 << 16) | MUX_PA05B_ADC_AIN3)
+#define PORT_PA05B_ADC_AIN3                        (_UL_(1) << 5)
+
+#define PIN_PA06B_ADC_AIN4                         _L_(6)       /**< ADC signal: AIN4 on PA06 mux B*/
+#define MUX_PA06B_ADC_AIN4                         _L_(1)      
+#define PINMUX_PA06B_ADC_AIN4                      ((PIN_PA06B_ADC_AIN4 << 16) | MUX_PA06B_ADC_AIN4)
+#define PORT_PA06B_ADC_AIN4                        (_UL_(1) << 6)
+
+#define PIN_PA07B_ADC_AIN5                         _L_(7)       /**< ADC signal: AIN5 on PA07 mux B*/
+#define MUX_PA07B_ADC_AIN5                         _L_(1)      
+#define PINMUX_PA07B_ADC_AIN5                      ((PIN_PA07B_ADC_AIN5 << 16) | MUX_PA07B_ADC_AIN5)
+#define PORT_PA07B_ADC_AIN5                        (_UL_(1) << 7)
+
+#define PIN_PA08B_ADC_AIN6                         _L_(8)       /**< ADC signal: AIN6 on PA08 mux B*/
+#define MUX_PA08B_ADC_AIN6                         _L_(1)      
+#define PINMUX_PA08B_ADC_AIN6                      ((PIN_PA08B_ADC_AIN6 << 16) | MUX_PA08B_ADC_AIN6)
+#define PORT_PA08B_ADC_AIN6                        (_UL_(1) << 8)
+
+#define PIN_PA09B_ADC_AIN7                         _L_(9)       /**< ADC signal: AIN7 on PA09 mux B*/
+#define MUX_PA09B_ADC_AIN7                         _L_(1)      
+#define PINMUX_PA09B_ADC_AIN7                      ((PIN_PA09B_ADC_AIN7 << 16) | MUX_PA09B_ADC_AIN7)
+#define PORT_PA09B_ADC_AIN7                        (_UL_(1) << 9)
+
+#define PIN_PA10B_ADC_AIN8                         _L_(10)      /**< ADC signal: AIN8 on PA10 mux B*/
+#define MUX_PA10B_ADC_AIN8                         _L_(1)      
+#define PINMUX_PA10B_ADC_AIN8                      ((PIN_PA10B_ADC_AIN8 << 16) | MUX_PA10B_ADC_AIN8)
+#define PORT_PA10B_ADC_AIN8                        (_UL_(1) << 10)
+
+#define PIN_PA11B_ADC_AIN9                         _L_(11)      /**< ADC signal: AIN9 on PA11 mux B*/
+#define MUX_PA11B_ADC_AIN9                         _L_(1)      
+#define PINMUX_PA11B_ADC_AIN9                      ((PIN_PA11B_ADC_AIN9 << 16) | MUX_PA11B_ADC_AIN9)
+#define PORT_PA11B_ADC_AIN9                        (_UL_(1) << 11)
+
+#define PIN_PA04B_ADC_VREFP                        _L_(4)       /**< ADC signal: VREFP on PA04 mux B*/
+#define MUX_PA04B_ADC_VREFP                        _L_(1)      
+#define PINMUX_PA04B_ADC_VREFP                     ((PIN_PA04B_ADC_VREFP << 16) | MUX_PA04B_ADC_VREFP)
+#define PORT_PA04B_ADC_VREFP                       (_UL_(1) << 4)
+
+/* ========== PORT definition for CCL peripheral ========== */
+#define PIN_PA04I_CCL_IN0                          _L_(4)       /**< CCL signal: IN0 on PA04 mux I*/
+#define MUX_PA04I_CCL_IN0                          _L_(8)      
+#define PINMUX_PA04I_CCL_IN0                       ((PIN_PA04I_CCL_IN0 << 16) | MUX_PA04I_CCL_IN0)
+#define PORT_PA04I_CCL_IN0                         (_UL_(1) << 4)
+
+#define PIN_PA16I_CCL_IN0                          _L_(16)      /**< CCL signal: IN0 on PA16 mux I*/
+#define MUX_PA16I_CCL_IN0                          _L_(8)      
+#define PINMUX_PA16I_CCL_IN0                       ((PIN_PA16I_CCL_IN0 << 16) | MUX_PA16I_CCL_IN0)
+#define PORT_PA16I_CCL_IN0                         (_UL_(1) << 16)
+
+#define PIN_PA05I_CCL_IN1                          _L_(5)       /**< CCL signal: IN1 on PA05 mux I*/
+#define MUX_PA05I_CCL_IN1                          _L_(8)      
+#define PINMUX_PA05I_CCL_IN1                       ((PIN_PA05I_CCL_IN1 << 16) | MUX_PA05I_CCL_IN1)
+#define PORT_PA05I_CCL_IN1                         (_UL_(1) << 5)
+
+#define PIN_PA17I_CCL_IN1                          _L_(17)      /**< CCL signal: IN1 on PA17 mux I*/
+#define MUX_PA17I_CCL_IN1                          _L_(8)      
+#define PINMUX_PA17I_CCL_IN1                       ((PIN_PA17I_CCL_IN1 << 16) | MUX_PA17I_CCL_IN1)
+#define PORT_PA17I_CCL_IN1                         (_UL_(1) << 17)
+
+#define PIN_PA06I_CCL_IN2                          _L_(6)       /**< CCL signal: IN2 on PA06 mux I*/
+#define MUX_PA06I_CCL_IN2                          _L_(8)      
+#define PINMUX_PA06I_CCL_IN2                       ((PIN_PA06I_CCL_IN2 << 16) | MUX_PA06I_CCL_IN2)
+#define PORT_PA06I_CCL_IN2                         (_UL_(1) << 6)
+
+#define PIN_PA18I_CCL_IN2                          _L_(18)      /**< CCL signal: IN2 on PA18 mux I*/
+#define MUX_PA18I_CCL_IN2                          _L_(8)      
+#define PINMUX_PA18I_CCL_IN2                       ((PIN_PA18I_CCL_IN2 << 16) | MUX_PA18I_CCL_IN2)
+#define PORT_PA18I_CCL_IN2                         (_UL_(1) << 18)
+
+#define PIN_PA08I_CCL_IN3                          _L_(8)       /**< CCL signal: IN3 on PA08 mux I*/
+#define MUX_PA08I_CCL_IN3                          _L_(8)      
+#define PINMUX_PA08I_CCL_IN3                       ((PIN_PA08I_CCL_IN3 << 16) | MUX_PA08I_CCL_IN3)
+#define PORT_PA08I_CCL_IN3                         (_UL_(1) << 8)
+
+#define PIN_PA30I_CCL_IN3                          _L_(30)      /**< CCL signal: IN3 on PA30 mux I*/
+#define MUX_PA30I_CCL_IN3                          _L_(8)      
+#define PINMUX_PA30I_CCL_IN3                       ((PIN_PA30I_CCL_IN3 << 16) | MUX_PA30I_CCL_IN3)
+#define PORT_PA30I_CCL_IN3                         (_UL_(1) << 30)
+
+#define PIN_PA09I_CCL_IN4                          _L_(9)       /**< CCL signal: IN4 on PA09 mux I*/
+#define MUX_PA09I_CCL_IN4                          _L_(8)      
+#define PINMUX_PA09I_CCL_IN4                       ((PIN_PA09I_CCL_IN4 << 16) | MUX_PA09I_CCL_IN4)
+#define PORT_PA09I_CCL_IN4                         (_UL_(1) << 9)
+
+#define PIN_PA10I_CCL_IN5                          _L_(10)      /**< CCL signal: IN5 on PA10 mux I*/
+#define MUX_PA10I_CCL_IN5                          _L_(8)      
+#define PINMUX_PA10I_CCL_IN5                       ((PIN_PA10I_CCL_IN5 << 16) | MUX_PA10I_CCL_IN5)
+#define PORT_PA10I_CCL_IN5                         (_UL_(1) << 10)
+
+#define PIN_PA07I_CCL_OUT0                         _L_(7)       /**< CCL signal: OUT0 on PA07 mux I*/
+#define MUX_PA07I_CCL_OUT0                         _L_(8)      
+#define PINMUX_PA07I_CCL_OUT0                      ((PIN_PA07I_CCL_OUT0 << 16) | MUX_PA07I_CCL_OUT0)
+#define PORT_PA07I_CCL_OUT0                        (_UL_(1) << 7)
+
+#define PIN_PA19I_CCL_OUT0                         _L_(19)      /**< CCL signal: OUT0 on PA19 mux I*/
+#define MUX_PA19I_CCL_OUT0                         _L_(8)      
+#define PINMUX_PA19I_CCL_OUT0                      ((PIN_PA19I_CCL_OUT0 << 16) | MUX_PA19I_CCL_OUT0)
+#define PORT_PA19I_CCL_OUT0                        (_UL_(1) << 19)
+
+#define PIN_PA11I_CCL_OUT1                         _L_(11)      /**< CCL signal: OUT1 on PA11 mux I*/
+#define MUX_PA11I_CCL_OUT1                         _L_(8)      
+#define PINMUX_PA11I_CCL_OUT1                      ((PIN_PA11I_CCL_OUT1 << 16) | MUX_PA11I_CCL_OUT1)
+#define PORT_PA11I_CCL_OUT1                        (_UL_(1) << 11)
+
+#define PIN_PA31I_CCL_OUT1                         _L_(31)      /**< CCL signal: OUT1 on PA31 mux I*/
+#define MUX_PA31I_CCL_OUT1                         _L_(8)      
+#define PINMUX_PA31I_CCL_OUT1                      ((PIN_PA31I_CCL_OUT1 << 16) | MUX_PA31I_CCL_OUT1)
+#define PORT_PA31I_CCL_OUT1                        (_UL_(1) << 31)
+
+/* ========== PORT definition for DAC peripheral ========== */
+#define PIN_PA02B_DAC_VOUT                         _L_(2)       /**< DAC signal: VOUT on PA02 mux B*/
+#define MUX_PA02B_DAC_VOUT                         _L_(1)      
+#define PINMUX_PA02B_DAC_VOUT                      ((PIN_PA02B_DAC_VOUT << 16) | MUX_PA02B_DAC_VOUT)
+#define PORT_PA02B_DAC_VOUT                        (_UL_(1) << 2)
+
+#define PIN_PA03B_DAC_VREFP                        _L_(3)       /**< DAC signal: VREFP on PA03 mux B*/
+#define MUX_PA03B_DAC_VREFP                        _L_(1)      
+#define PINMUX_PA03B_DAC_VREFP                     ((PIN_PA03B_DAC_VREFP << 16) | MUX_PA03B_DAC_VREFP)
+#define PORT_PA03B_DAC_VREFP                       (_UL_(1) << 3)
+
+/* ========== PORT definition for EIC peripheral ========== */
+#define PIN_PA09A_EIC_EXTINT0                      _L_(9)       /**< EIC signal: EXTINT0 on PA09 mux A*/
+#define MUX_PA09A_EIC_EXTINT0                      _L_(0)      
+#define PINMUX_PA09A_EIC_EXTINT0                   ((PIN_PA09A_EIC_EXTINT0 << 16) | MUX_PA09A_EIC_EXTINT0)
+#define PORT_PA09A_EIC_EXTINT0                     (_UL_(1) << 9)
+#define PIN_PA09A_EIC_EXTINT_NUM                   _L_(0)       /**< EIC signal: PIN_PA09 External Interrupt Line */
+
+#define PIN_PA19A_EIC_EXTINT0                      _L_(19)      /**< EIC signal: EXTINT0 on PA19 mux A*/
+#define MUX_PA19A_EIC_EXTINT0                      _L_(0)      
+#define PINMUX_PA19A_EIC_EXTINT0                   ((PIN_PA19A_EIC_EXTINT0 << 16) | MUX_PA19A_EIC_EXTINT0)
+#define PORT_PA19A_EIC_EXTINT0                     (_UL_(1) << 19)
+#define PIN_PA19A_EIC_EXTINT_NUM                   _L_(0)       /**< EIC signal: PIN_PA19 External Interrupt Line */
+
+#define PIN_PA00A_EIC_EXTINT0                      _L_(0)       /**< EIC signal: EXTINT0 on PA00 mux A*/
+#define MUX_PA00A_EIC_EXTINT0                      _L_(0)      
+#define PINMUX_PA00A_EIC_EXTINT0                   ((PIN_PA00A_EIC_EXTINT0 << 16) | MUX_PA00A_EIC_EXTINT0)
+#define PORT_PA00A_EIC_EXTINT0                     (_UL_(1) << 0)
+#define PIN_PA00A_EIC_EXTINT_NUM                   _L_(0)       /**< EIC signal: PIN_PA00 External Interrupt Line */
+
+#define PIN_PA10A_EIC_EXTINT1                      _L_(10)      /**< EIC signal: EXTINT1 on PA10 mux A*/
+#define MUX_PA10A_EIC_EXTINT1                      _L_(0)      
+#define PINMUX_PA10A_EIC_EXTINT1                   ((PIN_PA10A_EIC_EXTINT1 << 16) | MUX_PA10A_EIC_EXTINT1)
+#define PORT_PA10A_EIC_EXTINT1                     (_UL_(1) << 10)
+#define PIN_PA10A_EIC_EXTINT_NUM                   _L_(1)       /**< EIC signal: PIN_PA10 External Interrupt Line */
+
+#define PIN_PA22A_EIC_EXTINT1                      _L_(22)      /**< EIC signal: EXTINT1 on PA22 mux A*/
+#define MUX_PA22A_EIC_EXTINT1                      _L_(0)      
+#define PINMUX_PA22A_EIC_EXTINT1                   ((PIN_PA22A_EIC_EXTINT1 << 16) | MUX_PA22A_EIC_EXTINT1)
+#define PORT_PA22A_EIC_EXTINT1                     (_UL_(1) << 22)
+#define PIN_PA22A_EIC_EXTINT_NUM                   _L_(1)       /**< EIC signal: PIN_PA22 External Interrupt Line */
+
+#define PIN_PA01A_EIC_EXTINT1                      _L_(1)       /**< EIC signal: EXTINT1 on PA01 mux A*/
+#define MUX_PA01A_EIC_EXTINT1                      _L_(0)      
+#define PINMUX_PA01A_EIC_EXTINT1                   ((PIN_PA01A_EIC_EXTINT1 << 16) | MUX_PA01A_EIC_EXTINT1)
+#define PORT_PA01A_EIC_EXTINT1                     (_UL_(1) << 1)
+#define PIN_PA01A_EIC_EXTINT_NUM                   _L_(1)       /**< EIC signal: PIN_PA01 External Interrupt Line */
+
+#define PIN_PA02A_EIC_EXTINT2                      _L_(2)       /**< EIC signal: EXTINT2 on PA02 mux A*/
+#define MUX_PA02A_EIC_EXTINT2                      _L_(0)      
+#define PINMUX_PA02A_EIC_EXTINT2                   ((PIN_PA02A_EIC_EXTINT2 << 16) | MUX_PA02A_EIC_EXTINT2)
+#define PORT_PA02A_EIC_EXTINT2                     (_UL_(1) << 2)
+#define PIN_PA02A_EIC_EXTINT_NUM                   _L_(2)       /**< EIC signal: PIN_PA02 External Interrupt Line */
+
+#define PIN_PA11A_EIC_EXTINT2                      _L_(11)      /**< EIC signal: EXTINT2 on PA11 mux A*/
+#define MUX_PA11A_EIC_EXTINT2                      _L_(0)      
+#define PINMUX_PA11A_EIC_EXTINT2                   ((PIN_PA11A_EIC_EXTINT2 << 16) | MUX_PA11A_EIC_EXTINT2)
+#define PORT_PA11A_EIC_EXTINT2                     (_UL_(1) << 11)
+#define PIN_PA11A_EIC_EXTINT_NUM                   _L_(2)       /**< EIC signal: PIN_PA11 External Interrupt Line */
+
+#define PIN_PA23A_EIC_EXTINT2                      _L_(23)      /**< EIC signal: EXTINT2 on PA23 mux A*/
+#define MUX_PA23A_EIC_EXTINT2                      _L_(0)      
+#define PINMUX_PA23A_EIC_EXTINT2                   ((PIN_PA23A_EIC_EXTINT2 << 16) | MUX_PA23A_EIC_EXTINT2)
+#define PORT_PA23A_EIC_EXTINT2                     (_UL_(1) << 23)
+#define PIN_PA23A_EIC_EXTINT_NUM                   _L_(2)       /**< EIC signal: PIN_PA23 External Interrupt Line */
+
+#define PIN_PA03A_EIC_EXTINT3                      _L_(3)       /**< EIC signal: EXTINT3 on PA03 mux A*/
+#define MUX_PA03A_EIC_EXTINT3                      _L_(0)      
+#define PINMUX_PA03A_EIC_EXTINT3                   ((PIN_PA03A_EIC_EXTINT3 << 16) | MUX_PA03A_EIC_EXTINT3)
+#define PORT_PA03A_EIC_EXTINT3                     (_UL_(1) << 3)
+#define PIN_PA03A_EIC_EXTINT_NUM                   _L_(3)       /**< EIC signal: PIN_PA03 External Interrupt Line */
+
+#define PIN_PA14A_EIC_EXTINT3                      _L_(14)      /**< EIC signal: EXTINT3 on PA14 mux A*/
+#define MUX_PA14A_EIC_EXTINT3                      _L_(0)      
+#define PINMUX_PA14A_EIC_EXTINT3                   ((PIN_PA14A_EIC_EXTINT3 << 16) | MUX_PA14A_EIC_EXTINT3)
+#define PORT_PA14A_EIC_EXTINT3                     (_UL_(1) << 14)
+#define PIN_PA14A_EIC_EXTINT_NUM                   _L_(3)       /**< EIC signal: PIN_PA14 External Interrupt Line */
+
+#define PIN_PA24A_EIC_EXTINT3                      _L_(24)      /**< EIC signal: EXTINT3 on PA24 mux A*/
+#define MUX_PA24A_EIC_EXTINT3                      _L_(0)      
+#define PINMUX_PA24A_EIC_EXTINT3                   ((PIN_PA24A_EIC_EXTINT3 << 16) | MUX_PA24A_EIC_EXTINT3)
+#define PORT_PA24A_EIC_EXTINT3                     (_UL_(1) << 24)
+#define PIN_PA24A_EIC_EXTINT_NUM                   _L_(3)       /**< EIC signal: PIN_PA24 External Interrupt Line */
+
+#define PIN_PA04A_EIC_EXTINT4                      _L_(4)       /**< EIC signal: EXTINT4 on PA04 mux A*/
+#define MUX_PA04A_EIC_EXTINT4                      _L_(0)      
+#define PINMUX_PA04A_EIC_EXTINT4                   ((PIN_PA04A_EIC_EXTINT4 << 16) | MUX_PA04A_EIC_EXTINT4)
+#define PORT_PA04A_EIC_EXTINT4                     (_UL_(1) << 4)
+#define PIN_PA04A_EIC_EXTINT_NUM                   _L_(4)       /**< EIC signal: PIN_PA04 External Interrupt Line */
+
+#define PIN_PA15A_EIC_EXTINT4                      _L_(15)      /**< EIC signal: EXTINT4 on PA15 mux A*/
+#define MUX_PA15A_EIC_EXTINT4                      _L_(0)      
+#define PINMUX_PA15A_EIC_EXTINT4                   ((PIN_PA15A_EIC_EXTINT4 << 16) | MUX_PA15A_EIC_EXTINT4)
+#define PORT_PA15A_EIC_EXTINT4                     (_UL_(1) << 15)
+#define PIN_PA15A_EIC_EXTINT_NUM                   _L_(4)       /**< EIC signal: PIN_PA15 External Interrupt Line */
+
+#define PIN_PA25A_EIC_EXTINT4                      _L_(25)      /**< EIC signal: EXTINT4 on PA25 mux A*/
+#define MUX_PA25A_EIC_EXTINT4                      _L_(0)      
+#define PINMUX_PA25A_EIC_EXTINT4                   ((PIN_PA25A_EIC_EXTINT4 << 16) | MUX_PA25A_EIC_EXTINT4)
+#define PORT_PA25A_EIC_EXTINT4                     (_UL_(1) << 25)
+#define PIN_PA25A_EIC_EXTINT_NUM                   _L_(4)       /**< EIC signal: PIN_PA25 External Interrupt Line */
+
+#define PIN_PA05A_EIC_EXTINT5                      _L_(5)       /**< EIC signal: EXTINT5 on PA05 mux A*/
+#define MUX_PA05A_EIC_EXTINT5                      _L_(0)      
+#define PINMUX_PA05A_EIC_EXTINT5                   ((PIN_PA05A_EIC_EXTINT5 << 16) | MUX_PA05A_EIC_EXTINT5)
+#define PORT_PA05A_EIC_EXTINT5                     (_UL_(1) << 5)
+#define PIN_PA05A_EIC_EXTINT_NUM                   _L_(5)       /**< EIC signal: PIN_PA05 External Interrupt Line */
+
+#define PIN_PA16A_EIC_EXTINT5                      _L_(16)      /**< EIC signal: EXTINT5 on PA16 mux A*/
+#define MUX_PA16A_EIC_EXTINT5                      _L_(0)      
+#define PINMUX_PA16A_EIC_EXTINT5                   ((PIN_PA16A_EIC_EXTINT5 << 16) | MUX_PA16A_EIC_EXTINT5)
+#define PORT_PA16A_EIC_EXTINT5                     (_UL_(1) << 16)
+#define PIN_PA16A_EIC_EXTINT_NUM                   _L_(5)       /**< EIC signal: PIN_PA16 External Interrupt Line */
+
+#define PIN_PA27A_EIC_EXTINT5                      _L_(27)      /**< EIC signal: EXTINT5 on PA27 mux A*/
+#define MUX_PA27A_EIC_EXTINT5                      _L_(0)      
+#define PINMUX_PA27A_EIC_EXTINT5                   ((PIN_PA27A_EIC_EXTINT5 << 16) | MUX_PA27A_EIC_EXTINT5)
+#define PORT_PA27A_EIC_EXTINT5                     (_UL_(1) << 27)
+#define PIN_PA27A_EIC_EXTINT_NUM                   _L_(5)       /**< EIC signal: PIN_PA27 External Interrupt Line */
+
+#define PIN_PA06A_EIC_EXTINT6                      _L_(6)       /**< EIC signal: EXTINT6 on PA06 mux A*/
+#define MUX_PA06A_EIC_EXTINT6                      _L_(0)      
+#define PINMUX_PA06A_EIC_EXTINT6                   ((PIN_PA06A_EIC_EXTINT6 << 16) | MUX_PA06A_EIC_EXTINT6)
+#define PORT_PA06A_EIC_EXTINT6                     (_UL_(1) << 6)
+#define PIN_PA06A_EIC_EXTINT_NUM                   _L_(6)       /**< EIC signal: PIN_PA06 External Interrupt Line */
+
+#define PIN_PA17A_EIC_EXTINT6                      _L_(17)      /**< EIC signal: EXTINT6 on PA17 mux A*/
+#define MUX_PA17A_EIC_EXTINT6                      _L_(0)      
+#define PINMUX_PA17A_EIC_EXTINT6                   ((PIN_PA17A_EIC_EXTINT6 << 16) | MUX_PA17A_EIC_EXTINT6)
+#define PORT_PA17A_EIC_EXTINT6                     (_UL_(1) << 17)
+#define PIN_PA17A_EIC_EXTINT_NUM                   _L_(6)       /**< EIC signal: PIN_PA17 External Interrupt Line */
+
+#define PIN_PA30A_EIC_EXTINT6                      _L_(30)      /**< EIC signal: EXTINT6 on PA30 mux A*/
+#define MUX_PA30A_EIC_EXTINT6                      _L_(0)      
+#define PINMUX_PA30A_EIC_EXTINT6                   ((PIN_PA30A_EIC_EXTINT6 << 16) | MUX_PA30A_EIC_EXTINT6)
+#define PORT_PA30A_EIC_EXTINT6                     (_UL_(1) << 30)
+#define PIN_PA30A_EIC_EXTINT_NUM                   _L_(6)       /**< EIC signal: PIN_PA30 External Interrupt Line */
+
+#define PIN_PA07A_EIC_EXTINT7                      _L_(7)       /**< EIC signal: EXTINT7 on PA07 mux A*/
+#define MUX_PA07A_EIC_EXTINT7                      _L_(0)      
+#define PINMUX_PA07A_EIC_EXTINT7                   ((PIN_PA07A_EIC_EXTINT7 << 16) | MUX_PA07A_EIC_EXTINT7)
+#define PORT_PA07A_EIC_EXTINT7                     (_UL_(1) << 7)
+#define PIN_PA07A_EIC_EXTINT_NUM                   _L_(7)       /**< EIC signal: PIN_PA07 External Interrupt Line */
+
+#define PIN_PA18A_EIC_EXTINT7                      _L_(18)      /**< EIC signal: EXTINT7 on PA18 mux A*/
+#define MUX_PA18A_EIC_EXTINT7                      _L_(0)      
+#define PINMUX_PA18A_EIC_EXTINT7                   ((PIN_PA18A_EIC_EXTINT7 << 16) | MUX_PA18A_EIC_EXTINT7)
+#define PORT_PA18A_EIC_EXTINT7                     (_UL_(1) << 18)
+#define PIN_PA18A_EIC_EXTINT_NUM                   _L_(7)       /**< EIC signal: PIN_PA18 External Interrupt Line */
+
+#define PIN_PA31A_EIC_EXTINT7                      _L_(31)      /**< EIC signal: EXTINT7 on PA31 mux A*/
+#define MUX_PA31A_EIC_EXTINT7                      _L_(0)      
+#define PINMUX_PA31A_EIC_EXTINT7                   ((PIN_PA31A_EIC_EXTINT7 << 16) | MUX_PA31A_EIC_EXTINT7)
+#define PORT_PA31A_EIC_EXTINT7                     (_UL_(1) << 31)
+#define PIN_PA31A_EIC_EXTINT_NUM                   _L_(7)       /**< EIC signal: PIN_PA31 External Interrupt Line */
+
+#define PIN_PA08A_EIC_NMI                          _L_(8)       /**< EIC signal: NMI on PA08 mux A*/
+#define MUX_PA08A_EIC_NMI                          _L_(0)      
+#define PINMUX_PA08A_EIC_NMI                       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
+#define PORT_PA08A_EIC_NMI                         (_UL_(1) << 8)
+
+/* ========== PORT definition for GCLK peripheral ========== */
+#define PIN_PA30H_GCLK_IO0                         _L_(30)      /**< GCLK signal: IO0 on PA30 mux H*/
+#define MUX_PA30H_GCLK_IO0                         _L_(7)      
+#define PINMUX_PA30H_GCLK_IO0                      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
+#define PORT_PA30H_GCLK_IO0                        (_UL_(1) << 30)
+
+#define PIN_PA14H_GCLK_IO0                         _L_(14)      /**< GCLK signal: IO0 on PA14 mux H*/
+#define MUX_PA14H_GCLK_IO0                         _L_(7)      
+#define PINMUX_PA14H_GCLK_IO0                      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
+#define PORT_PA14H_GCLK_IO0                        (_UL_(1) << 14)
+
+#define PIN_PA27H_GCLK_IO0                         _L_(27)      /**< GCLK signal: IO0 on PA27 mux H*/
+#define MUX_PA27H_GCLK_IO0                         _L_(7)      
+#define PINMUX_PA27H_GCLK_IO0                      ((PIN_PA27H_GCLK_IO0 << 16) | MUX_PA27H_GCLK_IO0)
+#define PORT_PA27H_GCLK_IO0                        (_UL_(1) << 27)
+
+#define PIN_PA23H_GCLK_IO1                         _L_(23)      /**< GCLK signal: IO1 on PA23 mux H*/
+#define MUX_PA23H_GCLK_IO1                         _L_(7)      
+#define PINMUX_PA23H_GCLK_IO1                      ((PIN_PA23H_GCLK_IO1 << 16) | MUX_PA23H_GCLK_IO1)
+#define PORT_PA23H_GCLK_IO1                        (_UL_(1) << 23)
+
+#define PIN_PA15H_GCLK_IO1                         _L_(15)      /**< GCLK signal: IO1 on PA15 mux H*/
+#define MUX_PA15H_GCLK_IO1                         _L_(7)      
+#define PINMUX_PA15H_GCLK_IO1                      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
+#define PORT_PA15H_GCLK_IO1                        (_UL_(1) << 15)
+
+#define PIN_PA16H_GCLK_IO2                         _L_(16)      /**< GCLK signal: IO2 on PA16 mux H*/
+#define MUX_PA16H_GCLK_IO2                         _L_(7)      
+#define PINMUX_PA16H_GCLK_IO2                      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
+#define PORT_PA16H_GCLK_IO2                        (_UL_(1) << 16)
+
+#define PIN_PA22H_GCLK_IO2                         _L_(22)      /**< GCLK signal: IO2 on PA22 mux H*/
+#define MUX_PA22H_GCLK_IO2                         _L_(7)      
+#define PINMUX_PA22H_GCLK_IO2                      ((PIN_PA22H_GCLK_IO2 << 16) | MUX_PA22H_GCLK_IO2)
+#define PORT_PA22H_GCLK_IO2                        (_UL_(1) << 22)
+
+#define PIN_PA11H_GCLK_IO3                         _L_(11)      /**< GCLK signal: IO3 on PA11 mux H*/
+#define MUX_PA11H_GCLK_IO3                         _L_(7)      
+#define PINMUX_PA11H_GCLK_IO3                      ((PIN_PA11H_GCLK_IO3 << 16) | MUX_PA11H_GCLK_IO3)
+#define PORT_PA11H_GCLK_IO3                        (_UL_(1) << 11)
+
+#define PIN_PA17H_GCLK_IO3                         _L_(17)      /**< GCLK signal: IO3 on PA17 mux H*/
+#define MUX_PA17H_GCLK_IO3                         _L_(7)      
+#define PINMUX_PA17H_GCLK_IO3                      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
+#define PORT_PA17H_GCLK_IO3                        (_UL_(1) << 17)
+
+#define PIN_PA10H_GCLK_IO4                         _L_(10)      /**< GCLK signal: IO4 on PA10 mux H*/
+#define MUX_PA10H_GCLK_IO4                         _L_(7)      
+#define PINMUX_PA10H_GCLK_IO4                      ((PIN_PA10H_GCLK_IO4 << 16) | MUX_PA10H_GCLK_IO4)
+#define PORT_PA10H_GCLK_IO4                        (_UL_(1) << 10)
+
+/* ========== PORT definition for OPAMP peripheral ========== */
+#define PIN_PA02B_OPAMP_OANEG0                     _L_(2)       /**< OPAMP signal: OANEG0 on PA02 mux B*/
+#define MUX_PA02B_OPAMP_OANEG0                     _L_(1)      
+#define PINMUX_PA02B_OPAMP_OANEG0                  ((PIN_PA02B_OPAMP_OANEG0 << 16) | MUX_PA02B_OPAMP_OANEG0)
+#define PORT_PA02B_OPAMP_OANEG0                    (_UL_(1) << 2)
+
+#define PIN_PA00B_OPAMP_OANEG1                     _L_(0)       /**< OPAMP signal: OANEG1 on PA00 mux B*/
+#define MUX_PA00B_OPAMP_OANEG1                     _L_(1)      
+#define PINMUX_PA00B_OPAMP_OANEG1                  ((PIN_PA00B_OPAMP_OANEG1 << 16) | MUX_PA00B_OPAMP_OANEG1)
+#define PORT_PA00B_OPAMP_OANEG1                    (_UL_(1) << 0)
+
+#define PIN_PA03B_OPAMP_OANEG2                     _L_(3)       /**< OPAMP signal: OANEG2 on PA03 mux B*/
+#define MUX_PA03B_OPAMP_OANEG2                     _L_(1)      
+#define PINMUX_PA03B_OPAMP_OANEG2                  ((PIN_PA03B_OPAMP_OANEG2 << 16) | MUX_PA03B_OPAMP_OANEG2)
+#define PORT_PA03B_OPAMP_OANEG2                    (_UL_(1) << 3)
+
+#define PIN_PA07B_OPAMP_OAOUT0                     _L_(7)       /**< OPAMP signal: OAOUT0 on PA07 mux B*/
+#define MUX_PA07B_OPAMP_OAOUT0                     _L_(1)      
+#define PINMUX_PA07B_OPAMP_OAOUT0                  ((PIN_PA07B_OPAMP_OAOUT0 << 16) | MUX_PA07B_OPAMP_OAOUT0)
+#define PORT_PA07B_OPAMP_OAOUT0                    (_UL_(1) << 7)
+
+#define PIN_PA04B_OPAMP_OAOUT2                     _L_(4)       /**< OPAMP signal: OAOUT2 on PA04 mux B*/
+#define MUX_PA04B_OPAMP_OAOUT2                     _L_(1)      
+#define PINMUX_PA04B_OPAMP_OAOUT2                  ((PIN_PA04B_OPAMP_OAOUT2 << 16) | MUX_PA04B_OPAMP_OAOUT2)
+#define PORT_PA04B_OPAMP_OAOUT2                    (_UL_(1) << 4)
+
+#define PIN_PA06B_OPAMP_OAPOS0                     _L_(6)       /**< OPAMP signal: OAPOS0 on PA06 mux B*/
+#define MUX_PA06B_OPAMP_OAPOS0                     _L_(1)      
+#define PINMUX_PA06B_OPAMP_OAPOS0                  ((PIN_PA06B_OPAMP_OAPOS0 << 16) | MUX_PA06B_OPAMP_OAPOS0)
+#define PORT_PA06B_OPAMP_OAPOS0                    (_UL_(1) << 6)
+
+#define PIN_PA01B_OPAMP_OAPOS1                     _L_(1)       /**< OPAMP signal: OAPOS1 on PA01 mux B*/
+#define MUX_PA01B_OPAMP_OAPOS1                     _L_(1)      
+#define PINMUX_PA01B_OPAMP_OAPOS1                  ((PIN_PA01B_OPAMP_OAPOS1 << 16) | MUX_PA01B_OPAMP_OAPOS1)
+#define PORT_PA01B_OPAMP_OAPOS1                    (_UL_(1) << 1)
+
+#define PIN_PA05B_OPAMP_OAPOS2                     _L_(5)       /**< OPAMP signal: OAPOS2 on PA05 mux B*/
+#define MUX_PA05B_OPAMP_OAPOS2                     _L_(1)      
+#define PINMUX_PA05B_OPAMP_OAPOS2                  ((PIN_PA05B_OPAMP_OAPOS2 << 16) | MUX_PA05B_OPAMP_OAPOS2)
+#define PORT_PA05B_OPAMP_OAPOS2                    (_UL_(1) << 5)
+
+/* ========== PORT definition for PTC peripheral ========== */
+#define PIN_PA00F_PTC_DRV0                         _L_(0)       /**< PTC signal: DRV0 on PA00 mux F*/
+#define MUX_PA00F_PTC_DRV0                         _L_(5)      
+#define PINMUX_PA00F_PTC_DRV0                      ((PIN_PA00F_PTC_DRV0 << 16) | MUX_PA00F_PTC_DRV0)
+#define PORT_PA00F_PTC_DRV0                        (_UL_(1) << 0)
+
+#define PIN_PA01F_PTC_DRV1                         _L_(1)       /**< PTC signal: DRV1 on PA01 mux F*/
+#define MUX_PA01F_PTC_DRV1                         _L_(5)      
+#define PINMUX_PA01F_PTC_DRV1                      ((PIN_PA01F_PTC_DRV1 << 16) | MUX_PA01F_PTC_DRV1)
+#define PORT_PA01F_PTC_DRV1                        (_UL_(1) << 1)
+
+#define PIN_PA02F_PTC_DRV2                         _L_(2)       /**< PTC signal: DRV2 on PA02 mux F*/
+#define MUX_PA02F_PTC_DRV2                         _L_(5)      
+#define PINMUX_PA02F_PTC_DRV2                      ((PIN_PA02F_PTC_DRV2 << 16) | MUX_PA02F_PTC_DRV2)
+#define PORT_PA02F_PTC_DRV2                        (_UL_(1) << 2)
+
+#define PIN_PA03F_PTC_DRV3                         _L_(3)       /**< PTC signal: DRV3 on PA03 mux F*/
+#define MUX_PA03F_PTC_DRV3                         _L_(5)      
+#define PINMUX_PA03F_PTC_DRV3                      ((PIN_PA03F_PTC_DRV3 << 16) | MUX_PA03F_PTC_DRV3)
+#define PORT_PA03F_PTC_DRV3                        (_UL_(1) << 3)
+
+#define PIN_PA05F_PTC_DRV4                         _L_(5)       /**< PTC signal: DRV4 on PA05 mux F*/
+#define MUX_PA05F_PTC_DRV4                         _L_(5)      
+#define PINMUX_PA05F_PTC_DRV4                      ((PIN_PA05F_PTC_DRV4 << 16) | MUX_PA05F_PTC_DRV4)
+#define PORT_PA05F_PTC_DRV4                        (_UL_(1) << 5)
+
+#define PIN_PA06F_PTC_DRV5                         _L_(6)       /**< PTC signal: DRV5 on PA06 mux F*/
+#define MUX_PA06F_PTC_DRV5                         _L_(5)      
+#define PINMUX_PA06F_PTC_DRV5                      ((PIN_PA06F_PTC_DRV5 << 16) | MUX_PA06F_PTC_DRV5)
+#define PORT_PA06F_PTC_DRV5                        (_UL_(1) << 6)
+
+#define PIN_PA08F_PTC_DRV6                         _L_(8)       /**< PTC signal: DRV6 on PA08 mux F*/
+#define MUX_PA08F_PTC_DRV6                         _L_(5)      
+#define PINMUX_PA08F_PTC_DRV6                      ((PIN_PA08F_PTC_DRV6 << 16) | MUX_PA08F_PTC_DRV6)
+#define PORT_PA08F_PTC_DRV6                        (_UL_(1) << 8)
+
+#define PIN_PA09F_PTC_DRV7                         _L_(9)       /**< PTC signal: DRV7 on PA09 mux F*/
+#define MUX_PA09F_PTC_DRV7                         _L_(5)      
+#define PINMUX_PA09F_PTC_DRV7                      ((PIN_PA09F_PTC_DRV7 << 16) | MUX_PA09F_PTC_DRV7)
+#define PORT_PA09F_PTC_DRV7                        (_UL_(1) << 9)
+
+#define PIN_PA10F_PTC_DRV8                         _L_(10)      /**< PTC signal: DRV8 on PA10 mux F*/
+#define MUX_PA10F_PTC_DRV8                         _L_(5)      
+#define PINMUX_PA10F_PTC_DRV8                      ((PIN_PA10F_PTC_DRV8 << 16) | MUX_PA10F_PTC_DRV8)
+#define PORT_PA10F_PTC_DRV8                        (_UL_(1) << 10)
+
+#define PIN_PA11F_PTC_DRV9                         _L_(11)      /**< PTC signal: DRV9 on PA11 mux F*/
+#define MUX_PA11F_PTC_DRV9                         _L_(5)      
+#define PINMUX_PA11F_PTC_DRV9                      ((PIN_PA11F_PTC_DRV9 << 16) | MUX_PA11F_PTC_DRV9)
+#define PORT_PA11F_PTC_DRV9                        (_UL_(1) << 11)
+
+#define PIN_PA14F_PTC_DRV10                        _L_(14)      /**< PTC signal: DRV10 on PA14 mux F*/
+#define MUX_PA14F_PTC_DRV10                        _L_(5)      
+#define PINMUX_PA14F_PTC_DRV10                     ((PIN_PA14F_PTC_DRV10 << 16) | MUX_PA14F_PTC_DRV10)
+#define PORT_PA14F_PTC_DRV10                       (_UL_(1) << 14)
+
+#define PIN_PA15F_PTC_DRV11                        _L_(15)      /**< PTC signal: DRV11 on PA15 mux F*/
+#define MUX_PA15F_PTC_DRV11                        _L_(5)      
+#define PINMUX_PA15F_PTC_DRV11                     ((PIN_PA15F_PTC_DRV11 << 16) | MUX_PA15F_PTC_DRV11)
+#define PORT_PA15F_PTC_DRV11                       (_UL_(1) << 15)
+
+#define PIN_PA16F_PTC_DRV12                        _L_(16)      /**< PTC signal: DRV12 on PA16 mux F*/
+#define MUX_PA16F_PTC_DRV12                        _L_(5)      
+#define PINMUX_PA16F_PTC_DRV12                     ((PIN_PA16F_PTC_DRV12 << 16) | MUX_PA16F_PTC_DRV12)
+#define PORT_PA16F_PTC_DRV12                       (_UL_(1) << 16)
+
+#define PIN_PA17F_PTC_DRV13                        _L_(17)      /**< PTC signal: DRV13 on PA17 mux F*/
+#define MUX_PA17F_PTC_DRV13                        _L_(5)      
+#define PINMUX_PA17F_PTC_DRV13                     ((PIN_PA17F_PTC_DRV13 << 16) | MUX_PA17F_PTC_DRV13)
+#define PORT_PA17F_PTC_DRV13                       (_UL_(1) << 17)
+
+#define PIN_PA18F_PTC_DRV14                        _L_(18)      /**< PTC signal: DRV14 on PA18 mux F*/
+#define MUX_PA18F_PTC_DRV14                        _L_(5)      
+#define PINMUX_PA18F_PTC_DRV14                     ((PIN_PA18F_PTC_DRV14 << 16) | MUX_PA18F_PTC_DRV14)
+#define PORT_PA18F_PTC_DRV14                       (_UL_(1) << 18)
+
+#define PIN_PA19F_PTC_DRV15                        _L_(19)      /**< PTC signal: DRV15 on PA19 mux F*/
+#define MUX_PA19F_PTC_DRV15                        _L_(5)      
+#define PINMUX_PA19F_PTC_DRV15                     ((PIN_PA19F_PTC_DRV15 << 16) | MUX_PA19F_PTC_DRV15)
+#define PORT_PA19F_PTC_DRV15                       (_UL_(1) << 19)
+
+#define PIN_PA22F_PTC_DRV16                        _L_(22)      /**< PTC signal: DRV16 on PA22 mux F*/
+#define MUX_PA22F_PTC_DRV16                        _L_(5)      
+#define PINMUX_PA22F_PTC_DRV16                     ((PIN_PA22F_PTC_DRV16 << 16) | MUX_PA22F_PTC_DRV16)
+#define PORT_PA22F_PTC_DRV16                       (_UL_(1) << 22)
+
+#define PIN_PA23F_PTC_DRV17                        _L_(23)      /**< PTC signal: DRV17 on PA23 mux F*/
+#define MUX_PA23F_PTC_DRV17                        _L_(5)      
+#define PINMUX_PA23F_PTC_DRV17                     ((PIN_PA23F_PTC_DRV17 << 16) | MUX_PA23F_PTC_DRV17)
+#define PORT_PA23F_PTC_DRV17                       (_UL_(1) << 23)
+
+#define PIN_PA30F_PTC_DRV18                        _L_(30)      /**< PTC signal: DRV18 on PA30 mux F*/
+#define MUX_PA30F_PTC_DRV18                        _L_(5)      
+#define PINMUX_PA30F_PTC_DRV18                     ((PIN_PA30F_PTC_DRV18 << 16) | MUX_PA30F_PTC_DRV18)
+#define PORT_PA30F_PTC_DRV18                       (_UL_(1) << 30)
+
+#define PIN_PA31F_PTC_DRV19                        _L_(31)      /**< PTC signal: DRV19 on PA31 mux F*/
+#define MUX_PA31F_PTC_DRV19                        _L_(5)      
+#define PINMUX_PA31F_PTC_DRV19                     ((PIN_PA31F_PTC_DRV19 << 16) | MUX_PA31F_PTC_DRV19)
+#define PORT_PA31F_PTC_DRV19                       (_UL_(1) << 31)
+
+#define PIN_PA03B_PTC_ECI0                         _L_(3)       /**< PTC signal: ECI0 on PA03 mux B*/
+#define MUX_PA03B_PTC_ECI0                         _L_(1)      
+#define PINMUX_PA03B_PTC_ECI0                      ((PIN_PA03B_PTC_ECI0 << 16) | MUX_PA03B_PTC_ECI0)
+#define PORT_PA03B_PTC_ECI0                        (_UL_(1) << 3)
+
+#define PIN_PA04B_PTC_ECI1                         _L_(4)       /**< PTC signal: ECI1 on PA04 mux B*/
+#define MUX_PA04B_PTC_ECI1                         _L_(1)      
+#define PINMUX_PA04B_PTC_ECI1                      ((PIN_PA04B_PTC_ECI1 << 16) | MUX_PA04B_PTC_ECI1)
+#define PORT_PA04B_PTC_ECI1                        (_UL_(1) << 4)
+
+#define PIN_PA05B_PTC_ECI2                         _L_(5)       /**< PTC signal: ECI2 on PA05 mux B*/
+#define MUX_PA05B_PTC_ECI2                         _L_(1)      
+#define PINMUX_PA05B_PTC_ECI2                      ((PIN_PA05B_PTC_ECI2 << 16) | MUX_PA05B_PTC_ECI2)
+#define PORT_PA05B_PTC_ECI2                        (_UL_(1) << 5)
+
+#define PIN_PA06B_PTC_ECI3                         _L_(6)       /**< PTC signal: ECI3 on PA06 mux B*/
+#define MUX_PA06B_PTC_ECI3                         _L_(1)      
+#define PINMUX_PA06B_PTC_ECI3                      ((PIN_PA06B_PTC_ECI3 << 16) | MUX_PA06B_PTC_ECI3)
+#define PORT_PA06B_PTC_ECI3                        (_UL_(1) << 6)
+
+#define PIN_PA00B_PTC_X0                           _L_(0)       /**< PTC signal: X0 on PA00 mux B*/
+#define MUX_PA00B_PTC_X0                           _L_(1)      
+#define PINMUX_PA00B_PTC_X0                        ((PIN_PA00B_PTC_X0 << 16) | MUX_PA00B_PTC_X0)
+#define PORT_PA00B_PTC_X0                          (_UL_(1) << 0)
+
+#define PIN_PA00B_PTC_Y0                           _L_(0)       /**< PTC signal: Y0 on PA00 mux B*/
+#define MUX_PA00B_PTC_Y0                           _L_(1)      
+#define PINMUX_PA00B_PTC_Y0                        ((PIN_PA00B_PTC_Y0 << 16) | MUX_PA00B_PTC_Y0)
+#define PORT_PA00B_PTC_Y0                          (_UL_(1) << 0)
+
+#define PIN_PA01B_PTC_X1                           _L_(1)       /**< PTC signal: X1 on PA01 mux B*/
+#define MUX_PA01B_PTC_X1                           _L_(1)      
+#define PINMUX_PA01B_PTC_X1                        ((PIN_PA01B_PTC_X1 << 16) | MUX_PA01B_PTC_X1)
+#define PORT_PA01B_PTC_X1                          (_UL_(1) << 1)
+
+#define PIN_PA01B_PTC_Y1                           _L_(1)       /**< PTC signal: Y1 on PA01 mux B*/
+#define MUX_PA01B_PTC_Y1                           _L_(1)      
+#define PINMUX_PA01B_PTC_Y1                        ((PIN_PA01B_PTC_Y1 << 16) | MUX_PA01B_PTC_Y1)
+#define PORT_PA01B_PTC_Y1                          (_UL_(1) << 1)
+
+#define PIN_PA02B_PTC_X2                           _L_(2)       /**< PTC signal: X2 on PA02 mux B*/
+#define MUX_PA02B_PTC_X2                           _L_(1)      
+#define PINMUX_PA02B_PTC_X2                        ((PIN_PA02B_PTC_X2 << 16) | MUX_PA02B_PTC_X2)
+#define PORT_PA02B_PTC_X2                          (_UL_(1) << 2)
+
+#define PIN_PA02B_PTC_Y2                           _L_(2)       /**< PTC signal: Y2 on PA02 mux B*/
+#define MUX_PA02B_PTC_Y2                           _L_(1)      
+#define PINMUX_PA02B_PTC_Y2                        ((PIN_PA02B_PTC_Y2 << 16) | MUX_PA02B_PTC_Y2)
+#define PORT_PA02B_PTC_Y2                          (_UL_(1) << 2)
+
+#define PIN_PA03B_PTC_X3                           _L_(3)       /**< PTC signal: X3 on PA03 mux B*/
+#define MUX_PA03B_PTC_X3                           _L_(1)      
+#define PINMUX_PA03B_PTC_X3                        ((PIN_PA03B_PTC_X3 << 16) | MUX_PA03B_PTC_X3)
+#define PORT_PA03B_PTC_X3                          (_UL_(1) << 3)
+
+#define PIN_PA03B_PTC_Y3                           _L_(3)       /**< PTC signal: Y3 on PA03 mux B*/
+#define MUX_PA03B_PTC_Y3                           _L_(1)      
+#define PINMUX_PA03B_PTC_Y3                        ((PIN_PA03B_PTC_Y3 << 16) | MUX_PA03B_PTC_Y3)
+#define PORT_PA03B_PTC_Y3                          (_UL_(1) << 3)
+
+#define PIN_PA05B_PTC_X4                           _L_(5)       /**< PTC signal: X4 on PA05 mux B*/
+#define MUX_PA05B_PTC_X4                           _L_(1)      
+#define PINMUX_PA05B_PTC_X4                        ((PIN_PA05B_PTC_X4 << 16) | MUX_PA05B_PTC_X4)
+#define PORT_PA05B_PTC_X4                          (_UL_(1) << 5)
+
+#define PIN_PA05B_PTC_Y4                           _L_(5)       /**< PTC signal: Y4 on PA05 mux B*/
+#define MUX_PA05B_PTC_Y4                           _L_(1)      
+#define PINMUX_PA05B_PTC_Y4                        ((PIN_PA05B_PTC_Y4 << 16) | MUX_PA05B_PTC_Y4)
+#define PORT_PA05B_PTC_Y4                          (_UL_(1) << 5)
+
+#define PIN_PA06B_PTC_X5                           _L_(6)       /**< PTC signal: X5 on PA06 mux B*/
+#define MUX_PA06B_PTC_X5                           _L_(1)      
+#define PINMUX_PA06B_PTC_X5                        ((PIN_PA06B_PTC_X5 << 16) | MUX_PA06B_PTC_X5)
+#define PORT_PA06B_PTC_X5                          (_UL_(1) << 6)
+
+#define PIN_PA06B_PTC_Y5                           _L_(6)       /**< PTC signal: Y5 on PA06 mux B*/
+#define MUX_PA06B_PTC_Y5                           _L_(1)      
+#define PINMUX_PA06B_PTC_Y5                        ((PIN_PA06B_PTC_Y5 << 16) | MUX_PA06B_PTC_Y5)
+#define PORT_PA06B_PTC_Y5                          (_UL_(1) << 6)
+
+#define PIN_PA08B_PTC_X6                           _L_(8)       /**< PTC signal: X6 on PA08 mux B*/
+#define MUX_PA08B_PTC_X6                           _L_(1)      
+#define PINMUX_PA08B_PTC_X6                        ((PIN_PA08B_PTC_X6 << 16) | MUX_PA08B_PTC_X6)
+#define PORT_PA08B_PTC_X6                          (_UL_(1) << 8)
+
+#define PIN_PA08B_PTC_Y6                           _L_(8)       /**< PTC signal: Y6 on PA08 mux B*/
+#define MUX_PA08B_PTC_Y6                           _L_(1)      
+#define PINMUX_PA08B_PTC_Y6                        ((PIN_PA08B_PTC_Y6 << 16) | MUX_PA08B_PTC_Y6)
+#define PORT_PA08B_PTC_Y6                          (_UL_(1) << 8)
+
+#define PIN_PA09B_PTC_X7                           _L_(9)       /**< PTC signal: X7 on PA09 mux B*/
+#define MUX_PA09B_PTC_X7                           _L_(1)      
+#define PINMUX_PA09B_PTC_X7                        ((PIN_PA09B_PTC_X7 << 16) | MUX_PA09B_PTC_X7)
+#define PORT_PA09B_PTC_X7                          (_UL_(1) << 9)
+
+#define PIN_PA09B_PTC_Y7                           _L_(9)       /**< PTC signal: Y7 on PA09 mux B*/
+#define MUX_PA09B_PTC_Y7                           _L_(1)      
+#define PINMUX_PA09B_PTC_Y7                        ((PIN_PA09B_PTC_Y7 << 16) | MUX_PA09B_PTC_Y7)
+#define PORT_PA09B_PTC_Y7                          (_UL_(1) << 9)
+
+#define PIN_PA10B_PTC_X8                           _L_(10)      /**< PTC signal: X8 on PA10 mux B*/
+#define MUX_PA10B_PTC_X8                           _L_(1)      
+#define PINMUX_PA10B_PTC_X8                        ((PIN_PA10B_PTC_X8 << 16) | MUX_PA10B_PTC_X8)
+#define PORT_PA10B_PTC_X8                          (_UL_(1) << 10)
+
+#define PIN_PA10B_PTC_Y8                           _L_(10)      /**< PTC signal: Y8 on PA10 mux B*/
+#define MUX_PA10B_PTC_Y8                           _L_(1)      
+#define PINMUX_PA10B_PTC_Y8                        ((PIN_PA10B_PTC_Y8 << 16) | MUX_PA10B_PTC_Y8)
+#define PORT_PA10B_PTC_Y8                          (_UL_(1) << 10)
+
+#define PIN_PA11B_PTC_X9                           _L_(11)      /**< PTC signal: X9 on PA11 mux B*/
+#define MUX_PA11B_PTC_X9                           _L_(1)      
+#define PINMUX_PA11B_PTC_X9                        ((PIN_PA11B_PTC_X9 << 16) | MUX_PA11B_PTC_X9)
+#define PORT_PA11B_PTC_X9                          (_UL_(1) << 11)
+
+#define PIN_PA11B_PTC_Y9                           _L_(11)      /**< PTC signal: Y9 on PA11 mux B*/
+#define MUX_PA11B_PTC_Y9                           _L_(1)      
+#define PINMUX_PA11B_PTC_Y9                        ((PIN_PA11B_PTC_Y9 << 16) | MUX_PA11B_PTC_Y9)
+#define PORT_PA11B_PTC_Y9                          (_UL_(1) << 11)
+
+#define PIN_PA14B_PTC_X10                          _L_(14)      /**< PTC signal: X10 on PA14 mux B*/
+#define MUX_PA14B_PTC_X10                          _L_(1)      
+#define PINMUX_PA14B_PTC_X10                       ((PIN_PA14B_PTC_X10 << 16) | MUX_PA14B_PTC_X10)
+#define PORT_PA14B_PTC_X10                         (_UL_(1) << 14)
+
+#define PIN_PA14B_PTC_Y10                          _L_(14)      /**< PTC signal: Y10 on PA14 mux B*/
+#define MUX_PA14B_PTC_Y10                          _L_(1)      
+#define PINMUX_PA14B_PTC_Y10                       ((PIN_PA14B_PTC_Y10 << 16) | MUX_PA14B_PTC_Y10)
+#define PORT_PA14B_PTC_Y10                         (_UL_(1) << 14)
+
+#define PIN_PA15B_PTC_X11                          _L_(15)      /**< PTC signal: X11 on PA15 mux B*/
+#define MUX_PA15B_PTC_X11                          _L_(1)      
+#define PINMUX_PA15B_PTC_X11                       ((PIN_PA15B_PTC_X11 << 16) | MUX_PA15B_PTC_X11)
+#define PORT_PA15B_PTC_X11                         (_UL_(1) << 15)
+
+#define PIN_PA15B_PTC_Y11                          _L_(15)      /**< PTC signal: Y11 on PA15 mux B*/
+#define MUX_PA15B_PTC_Y11                          _L_(1)      
+#define PINMUX_PA15B_PTC_Y11                       ((PIN_PA15B_PTC_Y11 << 16) | MUX_PA15B_PTC_Y11)
+#define PORT_PA15B_PTC_Y11                         (_UL_(1) << 15)
+
+#define PIN_PA16B_PTC_X12                          _L_(16)      /**< PTC signal: X12 on PA16 mux B*/
+#define MUX_PA16B_PTC_X12                          _L_(1)      
+#define PINMUX_PA16B_PTC_X12                       ((PIN_PA16B_PTC_X12 << 16) | MUX_PA16B_PTC_X12)
+#define PORT_PA16B_PTC_X12                         (_UL_(1) << 16)
+
+#define PIN_PA16B_PTC_Y12                          _L_(16)      /**< PTC signal: Y12 on PA16 mux B*/
+#define MUX_PA16B_PTC_Y12                          _L_(1)      
+#define PINMUX_PA16B_PTC_Y12                       ((PIN_PA16B_PTC_Y12 << 16) | MUX_PA16B_PTC_Y12)
+#define PORT_PA16B_PTC_Y12                         (_UL_(1) << 16)
+
+#define PIN_PA17B_PTC_X13                          _L_(17)      /**< PTC signal: X13 on PA17 mux B*/
+#define MUX_PA17B_PTC_X13                          _L_(1)      
+#define PINMUX_PA17B_PTC_X13                       ((PIN_PA17B_PTC_X13 << 16) | MUX_PA17B_PTC_X13)
+#define PORT_PA17B_PTC_X13                         (_UL_(1) << 17)
+
+#define PIN_PA17B_PTC_Y13                          _L_(17)      /**< PTC signal: Y13 on PA17 mux B*/
+#define MUX_PA17B_PTC_Y13                          _L_(1)      
+#define PINMUX_PA17B_PTC_Y13                       ((PIN_PA17B_PTC_Y13 << 16) | MUX_PA17B_PTC_Y13)
+#define PORT_PA17B_PTC_Y13                         (_UL_(1) << 17)
+
+#define PIN_PA18B_PTC_X14                          _L_(18)      /**< PTC signal: X14 on PA18 mux B*/
+#define MUX_PA18B_PTC_X14                          _L_(1)      
+#define PINMUX_PA18B_PTC_X14                       ((PIN_PA18B_PTC_X14 << 16) | MUX_PA18B_PTC_X14)
+#define PORT_PA18B_PTC_X14                         (_UL_(1) << 18)
+
+#define PIN_PA18B_PTC_Y14                          _L_(18)      /**< PTC signal: Y14 on PA18 mux B*/
+#define MUX_PA18B_PTC_Y14                          _L_(1)      
+#define PINMUX_PA18B_PTC_Y14                       ((PIN_PA18B_PTC_Y14 << 16) | MUX_PA18B_PTC_Y14)
+#define PORT_PA18B_PTC_Y14                         (_UL_(1) << 18)
+
+#define PIN_PA19B_PTC_X15                          _L_(19)      /**< PTC signal: X15 on PA19 mux B*/
+#define MUX_PA19B_PTC_X15                          _L_(1)      
+#define PINMUX_PA19B_PTC_X15                       ((PIN_PA19B_PTC_X15 << 16) | MUX_PA19B_PTC_X15)
+#define PORT_PA19B_PTC_X15                         (_UL_(1) << 19)
+
+#define PIN_PA19B_PTC_Y15                          _L_(19)      /**< PTC signal: Y15 on PA19 mux B*/
+#define MUX_PA19B_PTC_Y15                          _L_(1)      
+#define PINMUX_PA19B_PTC_Y15                       ((PIN_PA19B_PTC_Y15 << 16) | MUX_PA19B_PTC_Y15)
+#define PORT_PA19B_PTC_Y15                         (_UL_(1) << 19)
+
+#define PIN_PA22B_PTC_X16                          _L_(22)      /**< PTC signal: X16 on PA22 mux B*/
+#define MUX_PA22B_PTC_X16                          _L_(1)      
+#define PINMUX_PA22B_PTC_X16                       ((PIN_PA22B_PTC_X16 << 16) | MUX_PA22B_PTC_X16)
+#define PORT_PA22B_PTC_X16                         (_UL_(1) << 22)
+
+#define PIN_PA22B_PTC_Y16                          _L_(22)      /**< PTC signal: Y16 on PA22 mux B*/
+#define MUX_PA22B_PTC_Y16                          _L_(1)      
+#define PINMUX_PA22B_PTC_Y16                       ((PIN_PA22B_PTC_Y16 << 16) | MUX_PA22B_PTC_Y16)
+#define PORT_PA22B_PTC_Y16                         (_UL_(1) << 22)
+
+#define PIN_PA23B_PTC_X17                          _L_(23)      /**< PTC signal: X17 on PA23 mux B*/
+#define MUX_PA23B_PTC_X17                          _L_(1)      
+#define PINMUX_PA23B_PTC_X17                       ((PIN_PA23B_PTC_X17 << 16) | MUX_PA23B_PTC_X17)
+#define PORT_PA23B_PTC_X17                         (_UL_(1) << 23)
+
+#define PIN_PA23B_PTC_Y17                          _L_(23)      /**< PTC signal: Y17 on PA23 mux B*/
+#define MUX_PA23B_PTC_Y17                          _L_(1)      
+#define PINMUX_PA23B_PTC_Y17                       ((PIN_PA23B_PTC_Y17 << 16) | MUX_PA23B_PTC_Y17)
+#define PORT_PA23B_PTC_Y17                         (_UL_(1) << 23)
+
+#define PIN_PA30B_PTC_X18                          _L_(30)      /**< PTC signal: X18 on PA30 mux B*/
+#define MUX_PA30B_PTC_X18                          _L_(1)      
+#define PINMUX_PA30B_PTC_X18                       ((PIN_PA30B_PTC_X18 << 16) | MUX_PA30B_PTC_X18)
+#define PORT_PA30B_PTC_X18                         (_UL_(1) << 30)
+
+#define PIN_PA30B_PTC_Y18                          _L_(30)      /**< PTC signal: Y18 on PA30 mux B*/
+#define MUX_PA30B_PTC_Y18                          _L_(1)      
+#define PINMUX_PA30B_PTC_Y18                       ((PIN_PA30B_PTC_Y18 << 16) | MUX_PA30B_PTC_Y18)
+#define PORT_PA30B_PTC_Y18                         (_UL_(1) << 30)
+
+#define PIN_PA31B_PTC_X19                          _L_(31)      /**< PTC signal: X19 on PA31 mux B*/
+#define MUX_PA31B_PTC_X19                          _L_(1)      
+#define PINMUX_PA31B_PTC_X19                       ((PIN_PA31B_PTC_X19 << 16) | MUX_PA31B_PTC_X19)
+#define PORT_PA31B_PTC_X19                         (_UL_(1) << 31)
+
+#define PIN_PA31B_PTC_Y19                          _L_(31)      /**< PTC signal: Y19 on PA31 mux B*/
+#define MUX_PA31B_PTC_Y19                          _L_(1)      
+#define PINMUX_PA31B_PTC_Y19                       ((PIN_PA31B_PTC_Y19 << 16) | MUX_PA31B_PTC_Y19)
+#define PORT_PA31B_PTC_Y19                         (_UL_(1) << 31)
+
+/* ========== PORT definition for RTC peripheral ========== */
+#define PIN_PA08G_RTC_IN0                          _L_(8)       /**< RTC signal: IN0 on PA08 mux G*/
+#define MUX_PA08G_RTC_IN0                          _L_(6)      
+#define PINMUX_PA08G_RTC_IN0                       ((PIN_PA08G_RTC_IN0 << 16) | MUX_PA08G_RTC_IN0)
+#define PORT_PA08G_RTC_IN0                         (_UL_(1) << 8)
+
+#define PIN_PA09G_RTC_IN1                          _L_(9)       /**< RTC signal: IN1 on PA09 mux G*/
+#define MUX_PA09G_RTC_IN1                          _L_(6)      
+#define PINMUX_PA09G_RTC_IN1                       ((PIN_PA09G_RTC_IN1 << 16) | MUX_PA09G_RTC_IN1)
+#define PORT_PA09G_RTC_IN1                         (_UL_(1) << 9)
+
+#define PIN_PA16G_RTC_IN2                          _L_(16)      /**< RTC signal: IN2 on PA16 mux G*/
+#define MUX_PA16G_RTC_IN2                          _L_(6)      
+#define PINMUX_PA16G_RTC_IN2                       ((PIN_PA16G_RTC_IN2 << 16) | MUX_PA16G_RTC_IN2)
+#define PORT_PA16G_RTC_IN2                         (_UL_(1) << 16)
+
+#define PIN_PA17G_RTC_IN3                          _L_(17)      /**< RTC signal: IN3 on PA17 mux G*/
+#define MUX_PA17G_RTC_IN3                          _L_(6)      
+#define PINMUX_PA17G_RTC_IN3                       ((PIN_PA17G_RTC_IN3 << 16) | MUX_PA17G_RTC_IN3)
+#define PORT_PA17G_RTC_IN3                         (_UL_(1) << 17)
+
+#define PIN_PA18G_RTC_OUT0                         _L_(18)      /**< RTC signal: OUT0 on PA18 mux G*/
+#define MUX_PA18G_RTC_OUT0                         _L_(6)      
+#define PINMUX_PA18G_RTC_OUT0                      ((PIN_PA18G_RTC_OUT0 << 16) | MUX_PA18G_RTC_OUT0)
+#define PORT_PA18G_RTC_OUT0                        (_UL_(1) << 18)
+
+#define PIN_PA19G_RTC_OUT1                         _L_(19)      /**< RTC signal: OUT1 on PA19 mux G*/
+#define MUX_PA19G_RTC_OUT1                         _L_(6)      
+#define PINMUX_PA19G_RTC_OUT1                      ((PIN_PA19G_RTC_OUT1 << 16) | MUX_PA19G_RTC_OUT1)
+#define PORT_PA19G_RTC_OUT1                        (_UL_(1) << 19)
+
+#define PIN_PA22G_RTC_OUT2                         _L_(22)      /**< RTC signal: OUT2 on PA22 mux G*/
+#define MUX_PA22G_RTC_OUT2                         _L_(6)      
+#define PINMUX_PA22G_RTC_OUT2                      ((PIN_PA22G_RTC_OUT2 << 16) | MUX_PA22G_RTC_OUT2)
+#define PORT_PA22G_RTC_OUT2                        (_UL_(1) << 22)
+
+#define PIN_PA23G_RTC_OUT3                         _L_(23)      /**< RTC signal: OUT3 on PA23 mux G*/
+#define MUX_PA23G_RTC_OUT3                         _L_(6)      
+#define PINMUX_PA23G_RTC_OUT3                      ((PIN_PA23G_RTC_OUT3 << 16) | MUX_PA23G_RTC_OUT3)
+#define PORT_PA23G_RTC_OUT3                        (_UL_(1) << 23)
+
+/* ========== PORT definition for SERCOM0 peripheral ========== */
+#define PIN_PA04D_SERCOM0_PAD0                     _L_(4)       /**< SERCOM0 signal: PAD0 on PA04 mux D*/
+#define MUX_PA04D_SERCOM0_PAD0                     _L_(3)      
+#define PINMUX_PA04D_SERCOM0_PAD0                  ((PIN_PA04D_SERCOM0_PAD0 << 16) | MUX_PA04D_SERCOM0_PAD0)
+#define PORT_PA04D_SERCOM0_PAD0                    (_UL_(1) << 4)
+
+#define PIN_PA16D_SERCOM0_PAD0                     _L_(16)      /**< SERCOM0 signal: PAD0 on PA16 mux D*/
+#define MUX_PA16D_SERCOM0_PAD0                     _L_(3)      
+#define PINMUX_PA16D_SERCOM0_PAD0                  ((PIN_PA16D_SERCOM0_PAD0 << 16) | MUX_PA16D_SERCOM0_PAD0)
+#define PORT_PA16D_SERCOM0_PAD0                    (_UL_(1) << 16)
+
+#define PIN_PA22C_SERCOM0_PAD0                     _L_(22)      /**< SERCOM0 signal: PAD0 on PA22 mux C*/
+#define MUX_PA22C_SERCOM0_PAD0                     _L_(2)      
+#define PINMUX_PA22C_SERCOM0_PAD0                  ((PIN_PA22C_SERCOM0_PAD0 << 16) | MUX_PA22C_SERCOM0_PAD0)
+#define PORT_PA22C_SERCOM0_PAD0                    (_UL_(1) << 22)
+
+#define PIN_PA05D_SERCOM0_PAD1                     _L_(5)       /**< SERCOM0 signal: PAD1 on PA05 mux D*/
+#define MUX_PA05D_SERCOM0_PAD1                     _L_(3)      
+#define PINMUX_PA05D_SERCOM0_PAD1                  ((PIN_PA05D_SERCOM0_PAD1 << 16) | MUX_PA05D_SERCOM0_PAD1)
+#define PORT_PA05D_SERCOM0_PAD1                    (_UL_(1) << 5)
+
+#define PIN_PA17D_SERCOM0_PAD1                     _L_(17)      /**< SERCOM0 signal: PAD1 on PA17 mux D*/
+#define MUX_PA17D_SERCOM0_PAD1                     _L_(3)      
+#define PINMUX_PA17D_SERCOM0_PAD1                  ((PIN_PA17D_SERCOM0_PAD1 << 16) | MUX_PA17D_SERCOM0_PAD1)
+#define PORT_PA17D_SERCOM0_PAD1                    (_UL_(1) << 17)
+
+#define PIN_PA23C_SERCOM0_PAD1                     _L_(23)      /**< SERCOM0 signal: PAD1 on PA23 mux C*/
+#define MUX_PA23C_SERCOM0_PAD1                     _L_(2)      
+#define PINMUX_PA23C_SERCOM0_PAD1                  ((PIN_PA23C_SERCOM0_PAD1 << 16) | MUX_PA23C_SERCOM0_PAD1)
+#define PORT_PA23C_SERCOM0_PAD1                    (_UL_(1) << 23)
+
+#define PIN_PA06D_SERCOM0_PAD2                     _L_(6)       /**< SERCOM0 signal: PAD2 on PA06 mux D*/
+#define MUX_PA06D_SERCOM0_PAD2                     _L_(3)      
+#define PINMUX_PA06D_SERCOM0_PAD2                  ((PIN_PA06D_SERCOM0_PAD2 << 16) | MUX_PA06D_SERCOM0_PAD2)
+#define PORT_PA06D_SERCOM0_PAD2                    (_UL_(1) << 6)
+
+#define PIN_PA14D_SERCOM0_PAD2                     _L_(14)      /**< SERCOM0 signal: PAD2 on PA14 mux D*/
+#define MUX_PA14D_SERCOM0_PAD2                     _L_(3)      
+#define PINMUX_PA14D_SERCOM0_PAD2                  ((PIN_PA14D_SERCOM0_PAD2 << 16) | MUX_PA14D_SERCOM0_PAD2)
+#define PORT_PA14D_SERCOM0_PAD2                    (_UL_(1) << 14)
+
+#define PIN_PA18D_SERCOM0_PAD2                     _L_(18)      /**< SERCOM0 signal: PAD2 on PA18 mux D*/
+#define MUX_PA18D_SERCOM0_PAD2                     _L_(3)      
+#define PINMUX_PA18D_SERCOM0_PAD2                  ((PIN_PA18D_SERCOM0_PAD2 << 16) | MUX_PA18D_SERCOM0_PAD2)
+#define PORT_PA18D_SERCOM0_PAD2                    (_UL_(1) << 18)
+
+#define PIN_PA24C_SERCOM0_PAD2                     _L_(24)      /**< SERCOM0 signal: PAD2 on PA24 mux C*/
+#define MUX_PA24C_SERCOM0_PAD2                     _L_(2)      
+#define PINMUX_PA24C_SERCOM0_PAD2                  ((PIN_PA24C_SERCOM0_PAD2 << 16) | MUX_PA24C_SERCOM0_PAD2)
+#define PORT_PA24C_SERCOM0_PAD2                    (_UL_(1) << 24)
+
+#define PIN_PA02D_SERCOM0_PAD2                     _L_(2)       /**< SERCOM0 signal: PAD2 on PA02 mux D*/
+#define MUX_PA02D_SERCOM0_PAD2                     _L_(3)      
+#define PINMUX_PA02D_SERCOM0_PAD2                  ((PIN_PA02D_SERCOM0_PAD2 << 16) | MUX_PA02D_SERCOM0_PAD2)
+#define PORT_PA02D_SERCOM0_PAD2                    (_UL_(1) << 2)
+
+#define PIN_PA07D_SERCOM0_PAD3                     _L_(7)       /**< SERCOM0 signal: PAD3 on PA07 mux D*/
+#define MUX_PA07D_SERCOM0_PAD3                     _L_(3)      
+#define PINMUX_PA07D_SERCOM0_PAD3                  ((PIN_PA07D_SERCOM0_PAD3 << 16) | MUX_PA07D_SERCOM0_PAD3)
+#define PORT_PA07D_SERCOM0_PAD3                    (_UL_(1) << 7)
+
+#define PIN_PA15D_SERCOM0_PAD3                     _L_(15)      /**< SERCOM0 signal: PAD3 on PA15 mux D*/
+#define MUX_PA15D_SERCOM0_PAD3                     _L_(3)      
+#define PINMUX_PA15D_SERCOM0_PAD3                  ((PIN_PA15D_SERCOM0_PAD3 << 16) | MUX_PA15D_SERCOM0_PAD3)
+#define PORT_PA15D_SERCOM0_PAD3                    (_UL_(1) << 15)
+
+#define PIN_PA19D_SERCOM0_PAD3                     _L_(19)      /**< SERCOM0 signal: PAD3 on PA19 mux D*/
+#define MUX_PA19D_SERCOM0_PAD3                     _L_(3)      
+#define PINMUX_PA19D_SERCOM0_PAD3                  ((PIN_PA19D_SERCOM0_PAD3 << 16) | MUX_PA19D_SERCOM0_PAD3)
+#define PORT_PA19D_SERCOM0_PAD3                    (_UL_(1) << 19)
+
+#define PIN_PA25C_SERCOM0_PAD3                     _L_(25)      /**< SERCOM0 signal: PAD3 on PA25 mux C*/
+#define MUX_PA25C_SERCOM0_PAD3                     _L_(2)      
+#define PINMUX_PA25C_SERCOM0_PAD3                  ((PIN_PA25C_SERCOM0_PAD3 << 16) | MUX_PA25C_SERCOM0_PAD3)
+#define PORT_PA25C_SERCOM0_PAD3                    (_UL_(1) << 25)
+
+#define PIN_PA03D_SERCOM0_PAD3                     _L_(3)       /**< SERCOM0 signal: PAD3 on PA03 mux D*/
+#define MUX_PA03D_SERCOM0_PAD3                     _L_(3)      
+#define PINMUX_PA03D_SERCOM0_PAD3                  ((PIN_PA03D_SERCOM0_PAD3 << 16) | MUX_PA03D_SERCOM0_PAD3)
+#define PORT_PA03D_SERCOM0_PAD3                    (_UL_(1) << 3)
+
+/* ========== PORT definition for SERCOM1 peripheral ========== */
+#define PIN_PA16C_SERCOM1_PAD0                     _L_(16)      /**< SERCOM1 signal: PAD0 on PA16 mux C*/
+#define MUX_PA16C_SERCOM1_PAD0                     _L_(2)      
+#define PINMUX_PA16C_SERCOM1_PAD0                  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
+#define PORT_PA16C_SERCOM1_PAD0                    (_UL_(1) << 16)
+
+#define PIN_PA08C_SERCOM1_PAD0                     _L_(8)       /**< SERCOM1 signal: PAD0 on PA08 mux C*/
+#define MUX_PA08C_SERCOM1_PAD0                     _L_(2)      
+#define PINMUX_PA08C_SERCOM1_PAD0                  ((PIN_PA08C_SERCOM1_PAD0 << 16) | MUX_PA08C_SERCOM1_PAD0)
+#define PORT_PA08C_SERCOM1_PAD0                    (_UL_(1) << 8)
+
+#define PIN_PA00D_SERCOM1_PAD0                     _L_(0)       /**< SERCOM1 signal: PAD0 on PA00 mux D*/
+#define MUX_PA00D_SERCOM1_PAD0                     _L_(3)      
+#define PINMUX_PA00D_SERCOM1_PAD0                  ((PIN_PA00D_SERCOM1_PAD0 << 16) | MUX_PA00D_SERCOM1_PAD0)
+#define PORT_PA00D_SERCOM1_PAD0                    (_UL_(1) << 0)
+
+#define PIN_PA17C_SERCOM1_PAD1                     _L_(17)      /**< SERCOM1 signal: PAD1 on PA17 mux C*/
+#define MUX_PA17C_SERCOM1_PAD1                     _L_(2)      
+#define PINMUX_PA17C_SERCOM1_PAD1                  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
+#define PORT_PA17C_SERCOM1_PAD1                    (_UL_(1) << 17)
+
+#define PIN_PA09C_SERCOM1_PAD1                     _L_(9)       /**< SERCOM1 signal: PAD1 on PA09 mux C*/
+#define MUX_PA09C_SERCOM1_PAD1                     _L_(2)      
+#define PINMUX_PA09C_SERCOM1_PAD1                  ((PIN_PA09C_SERCOM1_PAD1 << 16) | MUX_PA09C_SERCOM1_PAD1)
+#define PORT_PA09C_SERCOM1_PAD1                    (_UL_(1) << 9)
+
+#define PIN_PA01D_SERCOM1_PAD1                     _L_(1)       /**< SERCOM1 signal: PAD1 on PA01 mux D*/
+#define MUX_PA01D_SERCOM1_PAD1                     _L_(3)      
+#define PINMUX_PA01D_SERCOM1_PAD1                  ((PIN_PA01D_SERCOM1_PAD1 << 16) | MUX_PA01D_SERCOM1_PAD1)
+#define PORT_PA01D_SERCOM1_PAD1                    (_UL_(1) << 1)
+
+#define PIN_PA18C_SERCOM1_PAD2                     _L_(18)      /**< SERCOM1 signal: PAD2 on PA18 mux C*/
+#define MUX_PA18C_SERCOM1_PAD2                     _L_(2)      
+#define PINMUX_PA18C_SERCOM1_PAD2                  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
+#define PORT_PA18C_SERCOM1_PAD2                    (_UL_(1) << 18)
+
+#define PIN_PA10C_SERCOM1_PAD2                     _L_(10)      /**< SERCOM1 signal: PAD2 on PA10 mux C*/
+#define MUX_PA10C_SERCOM1_PAD2                     _L_(2)      
+#define PINMUX_PA10C_SERCOM1_PAD2                  ((PIN_PA10C_SERCOM1_PAD2 << 16) | MUX_PA10C_SERCOM1_PAD2)
+#define PORT_PA10C_SERCOM1_PAD2                    (_UL_(1) << 10)
+
+#define PIN_PA30D_SERCOM1_PAD2                     _L_(30)      /**< SERCOM1 signal: PAD2 on PA30 mux D*/
+#define MUX_PA30D_SERCOM1_PAD2                     _L_(3)      
+#define PINMUX_PA30D_SERCOM1_PAD2                  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
+#define PORT_PA30D_SERCOM1_PAD2                    (_UL_(1) << 30)
+
+#define PIN_PA19C_SERCOM1_PAD3                     _L_(19)      /**< SERCOM1 signal: PAD3 on PA19 mux C*/
+#define MUX_PA19C_SERCOM1_PAD3                     _L_(2)      
+#define PINMUX_PA19C_SERCOM1_PAD3                  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
+#define PORT_PA19C_SERCOM1_PAD3                    (_UL_(1) << 19)
+
+#define PIN_PA11C_SERCOM1_PAD3                     _L_(11)      /**< SERCOM1 signal: PAD3 on PA11 mux C*/
+#define MUX_PA11C_SERCOM1_PAD3                     _L_(2)      
+#define PINMUX_PA11C_SERCOM1_PAD3                  ((PIN_PA11C_SERCOM1_PAD3 << 16) | MUX_PA11C_SERCOM1_PAD3)
+#define PORT_PA11C_SERCOM1_PAD3                    (_UL_(1) << 11)
+
+#define PIN_PA31D_SERCOM1_PAD3                     _L_(31)      /**< SERCOM1 signal: PAD3 on PA31 mux D*/
+#define MUX_PA31D_SERCOM1_PAD3                     _L_(3)      
+#define PINMUX_PA31D_SERCOM1_PAD3                  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
+#define PORT_PA31D_SERCOM1_PAD3                    (_UL_(1) << 31)
+
+/* ========== PORT definition for SERCOM2 peripheral ========== */
+#define PIN_PA08D_SERCOM2_PAD0                     _L_(8)       /**< SERCOM2 signal: PAD0 on PA08 mux D*/
+#define MUX_PA08D_SERCOM2_PAD0                     _L_(3)      
+#define PINMUX_PA08D_SERCOM2_PAD0                  ((PIN_PA08D_SERCOM2_PAD0 << 16) | MUX_PA08D_SERCOM2_PAD0)
+#define PORT_PA08D_SERCOM2_PAD0                    (_UL_(1) << 8)
+
+#define PIN_PA22D_SERCOM2_PAD0                     _L_(22)      /**< SERCOM2 signal: PAD0 on PA22 mux D*/
+#define MUX_PA22D_SERCOM2_PAD0                     _L_(3)      
+#define PINMUX_PA22D_SERCOM2_PAD0                  ((PIN_PA22D_SERCOM2_PAD0 << 16) | MUX_PA22D_SERCOM2_PAD0)
+#define PORT_PA22D_SERCOM2_PAD0                    (_UL_(1) << 22)
+
+#define PIN_PA09D_SERCOM2_PAD1                     _L_(9)       /**< SERCOM2 signal: PAD1 on PA09 mux D*/
+#define MUX_PA09D_SERCOM2_PAD1                     _L_(3)      
+#define PINMUX_PA09D_SERCOM2_PAD1                  ((PIN_PA09D_SERCOM2_PAD1 << 16) | MUX_PA09D_SERCOM2_PAD1)
+#define PORT_PA09D_SERCOM2_PAD1                    (_UL_(1) << 9)
+
+#define PIN_PA23D_SERCOM2_PAD1                     _L_(23)      /**< SERCOM2 signal: PAD1 on PA23 mux D*/
+#define MUX_PA23D_SERCOM2_PAD1                     _L_(3)      
+#define PINMUX_PA23D_SERCOM2_PAD1                  ((PIN_PA23D_SERCOM2_PAD1 << 16) | MUX_PA23D_SERCOM2_PAD1)
+#define PORT_PA23D_SERCOM2_PAD1                    (_UL_(1) << 23)
+
+#define PIN_PA10D_SERCOM2_PAD2                     _L_(10)      /**< SERCOM2 signal: PAD2 on PA10 mux D*/
+#define MUX_PA10D_SERCOM2_PAD2                     _L_(3)      
+#define PINMUX_PA10D_SERCOM2_PAD2                  ((PIN_PA10D_SERCOM2_PAD2 << 16) | MUX_PA10D_SERCOM2_PAD2)
+#define PORT_PA10D_SERCOM2_PAD2                    (_UL_(1) << 10)
+
+#define PIN_PA24D_SERCOM2_PAD2                     _L_(24)      /**< SERCOM2 signal: PAD2 on PA24 mux D*/
+#define MUX_PA24D_SERCOM2_PAD2                     _L_(3)      
+#define PINMUX_PA24D_SERCOM2_PAD2                  ((PIN_PA24D_SERCOM2_PAD2 << 16) | MUX_PA24D_SERCOM2_PAD2)
+#define PORT_PA24D_SERCOM2_PAD2                    (_UL_(1) << 24)
+
+#define PIN_PA14C_SERCOM2_PAD2                     _L_(14)      /**< SERCOM2 signal: PAD2 on PA14 mux C*/
+#define MUX_PA14C_SERCOM2_PAD2                     _L_(2)      
+#define PINMUX_PA14C_SERCOM2_PAD2                  ((PIN_PA14C_SERCOM2_PAD2 << 16) | MUX_PA14C_SERCOM2_PAD2)
+#define PORT_PA14C_SERCOM2_PAD2                    (_UL_(1) << 14)
+
+#define PIN_PA11D_SERCOM2_PAD3                     _L_(11)      /**< SERCOM2 signal: PAD3 on PA11 mux D*/
+#define MUX_PA11D_SERCOM2_PAD3                     _L_(3)      
+#define PINMUX_PA11D_SERCOM2_PAD3                  ((PIN_PA11D_SERCOM2_PAD3 << 16) | MUX_PA11D_SERCOM2_PAD3)
+#define PORT_PA11D_SERCOM2_PAD3                    (_UL_(1) << 11)
+
+#define PIN_PA25D_SERCOM2_PAD3                     _L_(25)      /**< SERCOM2 signal: PAD3 on PA25 mux D*/
+#define MUX_PA25D_SERCOM2_PAD3                     _L_(3)      
+#define PINMUX_PA25D_SERCOM2_PAD3                  ((PIN_PA25D_SERCOM2_PAD3 << 16) | MUX_PA25D_SERCOM2_PAD3)
+#define PORT_PA25D_SERCOM2_PAD3                    (_UL_(1) << 25)
+
+#define PIN_PA15C_SERCOM2_PAD3                     _L_(15)      /**< SERCOM2 signal: PAD3 on PA15 mux C*/
+#define MUX_PA15C_SERCOM2_PAD3                     _L_(2)      
+#define PINMUX_PA15C_SERCOM2_PAD3                  ((PIN_PA15C_SERCOM2_PAD3 << 16) | MUX_PA15C_SERCOM2_PAD3)
+#define PORT_PA15C_SERCOM2_PAD3                    (_UL_(1) << 15)
+
+/* ========== PORT definition for TC0 peripheral ========== */
+#define PIN_PA04E_TC0_WO0                          _L_(4)       /**< TC0 signal: WO0 on PA04 mux E*/
+#define MUX_PA04E_TC0_WO0                          _L_(4)      
+#define PINMUX_PA04E_TC0_WO0                       ((PIN_PA04E_TC0_WO0 << 16) | MUX_PA04E_TC0_WO0)
+#define PORT_PA04E_TC0_WO0                         (_UL_(1) << 4)
+
+#define PIN_PA14E_TC0_WO0                          _L_(14)      /**< TC0 signal: WO0 on PA14 mux E*/
+#define MUX_PA14E_TC0_WO0                          _L_(4)      
+#define PINMUX_PA14E_TC0_WO0                       ((PIN_PA14E_TC0_WO0 << 16) | MUX_PA14E_TC0_WO0)
+#define PORT_PA14E_TC0_WO0                         (_UL_(1) << 14)
+
+#define PIN_PA22E_TC0_WO0                          _L_(22)      /**< TC0 signal: WO0 on PA22 mux E*/
+#define MUX_PA22E_TC0_WO0                          _L_(4)      
+#define PINMUX_PA22E_TC0_WO0                       ((PIN_PA22E_TC0_WO0 << 16) | MUX_PA22E_TC0_WO0)
+#define PORT_PA22E_TC0_WO0                         (_UL_(1) << 22)
+
+#define PIN_PA05E_TC0_WO1                          _L_(5)       /**< TC0 signal: WO1 on PA05 mux E*/
+#define MUX_PA05E_TC0_WO1                          _L_(4)      
+#define PINMUX_PA05E_TC0_WO1                       ((PIN_PA05E_TC0_WO1 << 16) | MUX_PA05E_TC0_WO1)
+#define PORT_PA05E_TC0_WO1                         (_UL_(1) << 5)
+
+#define PIN_PA15E_TC0_WO1                          _L_(15)      /**< TC0 signal: WO1 on PA15 mux E*/
+#define MUX_PA15E_TC0_WO1                          _L_(4)      
+#define PINMUX_PA15E_TC0_WO1                       ((PIN_PA15E_TC0_WO1 << 16) | MUX_PA15E_TC0_WO1)
+#define PORT_PA15E_TC0_WO1                         (_UL_(1) << 15)
+
+#define PIN_PA23E_TC0_WO1                          _L_(23)      /**< TC0 signal: WO1 on PA23 mux E*/
+#define MUX_PA23E_TC0_WO1                          _L_(4)      
+#define PINMUX_PA23E_TC0_WO1                       ((PIN_PA23E_TC0_WO1 << 16) | MUX_PA23E_TC0_WO1)
+#define PORT_PA23E_TC0_WO1                         (_UL_(1) << 23)
+
+/* ========== PORT definition for TC1 peripheral ========== */
+#define PIN_PA06E_TC1_WO0                          _L_(6)       /**< TC1 signal: WO0 on PA06 mux E*/
+#define MUX_PA06E_TC1_WO0                          _L_(4)      
+#define PINMUX_PA06E_TC1_WO0                       ((PIN_PA06E_TC1_WO0 << 16) | MUX_PA06E_TC1_WO0)
+#define PORT_PA06E_TC1_WO0                         (_UL_(1) << 6)
+
+#define PIN_PA24E_TC1_WO0                          _L_(24)      /**< TC1 signal: WO0 on PA24 mux E*/
+#define MUX_PA24E_TC1_WO0                          _L_(4)      
+#define PINMUX_PA24E_TC1_WO0                       ((PIN_PA24E_TC1_WO0 << 16) | MUX_PA24E_TC1_WO0)
+#define PORT_PA24E_TC1_WO0                         (_UL_(1) << 24)
+
+#define PIN_PA30E_TC1_WO0                          _L_(30)      /**< TC1 signal: WO0 on PA30 mux E*/
+#define MUX_PA30E_TC1_WO0                          _L_(4)      
+#define PINMUX_PA30E_TC1_WO0                       ((PIN_PA30E_TC1_WO0 << 16) | MUX_PA30E_TC1_WO0)
+#define PORT_PA30E_TC1_WO0                         (_UL_(1) << 30)
+
+#define PIN_PA07E_TC1_WO1                          _L_(7)       /**< TC1 signal: WO1 on PA07 mux E*/
+#define MUX_PA07E_TC1_WO1                          _L_(4)      
+#define PINMUX_PA07E_TC1_WO1                       ((PIN_PA07E_TC1_WO1 << 16) | MUX_PA07E_TC1_WO1)
+#define PORT_PA07E_TC1_WO1                         (_UL_(1) << 7)
+
+#define PIN_PA25E_TC1_WO1                          _L_(25)      /**< TC1 signal: WO1 on PA25 mux E*/
+#define MUX_PA25E_TC1_WO1                          _L_(4)      
+#define PINMUX_PA25E_TC1_WO1                       ((PIN_PA25E_TC1_WO1 << 16) | MUX_PA25E_TC1_WO1)
+#define PORT_PA25E_TC1_WO1                         (_UL_(1) << 25)
+
+#define PIN_PA31E_TC1_WO1                          _L_(31)      /**< TC1 signal: WO1 on PA31 mux E*/
+#define MUX_PA31E_TC1_WO1                          _L_(4)      
+#define PINMUX_PA31E_TC1_WO1                       ((PIN_PA31E_TC1_WO1 << 16) | MUX_PA31E_TC1_WO1)
+#define PORT_PA31E_TC1_WO1                         (_UL_(1) << 31)
+
+/* ========== PORT definition for TC2 peripheral ========== */
+#define PIN_PA00E_TC2_WO0                          _L_(0)       /**< TC2 signal: WO0 on PA00 mux E*/
+#define MUX_PA00E_TC2_WO0                          _L_(4)      
+#define PINMUX_PA00E_TC2_WO0                       ((PIN_PA00E_TC2_WO0 << 16) | MUX_PA00E_TC2_WO0)
+#define PORT_PA00E_TC2_WO0                         (_UL_(1) << 0)
+
+#define PIN_PA18E_TC2_WO0                          _L_(18)      /**< TC2 signal: WO0 on PA18 mux E*/
+#define MUX_PA18E_TC2_WO0                          _L_(4)      
+#define PINMUX_PA18E_TC2_WO0                       ((PIN_PA18E_TC2_WO0 << 16) | MUX_PA18E_TC2_WO0)
+#define PORT_PA18E_TC2_WO0                         (_UL_(1) << 18)
+
+#define PIN_PA01E_TC2_WO1                          _L_(1)       /**< TC2 signal: WO1 on PA01 mux E*/
+#define MUX_PA01E_TC2_WO1                          _L_(4)      
+#define PINMUX_PA01E_TC2_WO1                       ((PIN_PA01E_TC2_WO1 << 16) | MUX_PA01E_TC2_WO1)
+#define PORT_PA01E_TC2_WO1                         (_UL_(1) << 1)
+
+#define PIN_PA19E_TC2_WO1                          _L_(19)      /**< TC2 signal: WO1 on PA19 mux E*/
+#define MUX_PA19E_TC2_WO1                          _L_(4)      
+#define PINMUX_PA19E_TC2_WO1                       ((PIN_PA19E_TC2_WO1 << 16) | MUX_PA19E_TC2_WO1)
+#define PORT_PA19E_TC2_WO1                         (_UL_(1) << 19)
+
+
+#endif /* _SAML11E16A_PIO_H_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/sam.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/sam.h
@@ -1,0 +1,50 @@
+/**
+ * \file
+ *
+ * \brief Top level header file
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+#ifndef _SAM_
+#define _SAM_
+
+#if   defined(__SAML11D14A__) || defined(__ATSAML11D14A__)
+  #include "saml11d14a.h"
+#elif defined(__SAML11D15A__) || defined(__ATSAML11D15A__)
+  #include "saml11d15a.h"
+#elif defined(__SAML11D16A__) || defined(__ATSAML11D16A__)
+  #include "saml11d16a.h"
+#elif defined(__SAML11E14A__) || defined(__ATSAML11E14A__)
+  #include "saml11e14a.h"
+#elif defined(__SAML11E15A__) || defined(__ATSAML11E15A__)
+  #include "saml11e15a.h"
+#elif defined(__SAML11E16A__) || defined(__ATSAML11E16A__)
+  #include "saml11e16a.h"
+#else
+  #error Library does not support the specified device
+#endif
+
+#endif /* _SAM_ */
+

--- a/cpu/sam0_common/include/vendor/saml11/include/saml11d14a.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/saml11d14a.h
@@ -1,0 +1,802 @@
+/**
+ * \file
+ *
+ * \brief Header file for ATSAML11D14A
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11D14A_H_
+#define _SAML11D14A_H_
+
+/** \addtogroup SAML11D14A_definitions SAML11D14A definitions
+  This file defines all structures and symbols for SAML11D14A:
+    - registers and bitfields
+    - peripheral base address
+    - peripheral ID
+    - PIO definitions
+ *  @{
+ */
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/** \defgroup Atmel_glob_defs Atmel Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+
+    \remark
+    CMSIS core has a syntax that differs from this using i.e. __I, __O, or __IO followed by 'uint<size>_t' respective types.
+    Default the header files will follow the CMSIS core syntax.
+ *  @{
+ */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+
+/* IO definitions (access restrictions to peripheral registers) */
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+
+#define CAST(type, value) ((type *)(value)) /**< Pointer Type Conversion Macro for C/C++ */
+#define REG_ACCESS(type, address) (*(type*)(address)) /**< C code: Register value */
+#else /* Assembler */
+#define CAST(type, value) (value) /**< Pointer Type Conversion Macro for Assembler */
+#define REG_ACCESS(type, address) (address) /**< Assembly code: Register address */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !defined(SKIP_INTEGER_LITERALS)
+
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x) x ## U    /**< C code: Unsigned integer literal constant value */
+#define _L_(x) x ## L    /**< C code: Long integer literal constant value */
+#define _UL_(x) x ## UL  /**< C code: Unsigned Long integer literal constant value */
+
+#else /* Assembler */
+
+#define _U_(x) x    /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x) x    /**< Assembler: Long integer literal constant value */
+#define _UL_(x) x   /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* SKIP_INTEGER_LITERALS */
+/** @}  end of Atmel Global Defines */
+
+/** \addtogroup SAML11D14A_cmsis CMSIS Definitions
+ *  @{
+ */
+/* ************************************************************************** */
+/*   CMSIS DEFINITIONS FOR SAML11D14A */
+/* ************************************************************************** */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+/******  CORTEX-M23 Processor Exceptions Numbers ******************************/
+  Reset_IRQn                = -15, /**< 1   Reset Vector, invoked on Power up and warm reset  */
+  NonMaskableInt_IRQn       = -14, /**< 2   Non maskable Interrupt, cannot be stopped or preempted  */
+  HardFault_IRQn            = -13, /**< 3   Hard Fault, all classes of Fault     */
+  SVCall_IRQn               = -5 , /**< 11  System Service Call via SVC instruction  */
+  PendSV_IRQn               = -2 , /**< 14  Pendable request for system service  */
+  SysTick_IRQn              = -1 , /**< 15  System Tick Timer                    */
+/******  SAML11D14A specific Interrupt Numbers ***********************************/
+  SYSTEM_IRQn               = 0  , /**< 0   SAML11D14A Main Clock (MCLK)        */
+  WDT_IRQn                  = 1  , /**< 1   SAML11D14A Watchdog Timer (WDT)     */
+  RTC_IRQn                  = 2  , /**< 2   SAML11D14A Real-Time Counter (RTC)  */
+  EIC_0_IRQn                = 3  , /**< 3   SAML11D14A External Interrupt Controller (EIC) */
+  EIC_1_IRQn                = 4  , /**< 4   SAML11D14A External Interrupt Controller (EIC) */
+  EIC_2_IRQn                = 5  , /**< 5   SAML11D14A External Interrupt Controller (EIC) */
+  EIC_3_IRQn                = 6  , /**< 6   SAML11D14A External Interrupt Controller (EIC) */
+  EIC_OTHER_IRQn            = 7  , /**< 7   SAML11D14A External Interrupt Controller (EIC) */
+  FREQM_IRQn                = 8  , /**< 8   SAML11D14A Frequency Meter (FREQM)  */
+  NVMCTRL_IRQn              = 9  , /**< 9   SAML11D14A Non-Volatile Memory Controller (NVMCTRL) */
+  PORT_IRQn                 = 10 , /**< 10  SAML11D14A Port Module (PORT)       */
+  DMAC_0_IRQn               = 11 , /**< 11  SAML11D14A Direct Memory Access Controller (DMAC) */
+  DMAC_1_IRQn               = 12 , /**< 12  SAML11D14A Direct Memory Access Controller (DMAC) */
+  DMAC_2_IRQn               = 13 , /**< 13  SAML11D14A Direct Memory Access Controller (DMAC) */
+  DMAC_3_IRQn               = 14 , /**< 14  SAML11D14A Direct Memory Access Controller (DMAC) */
+  DMAC_OTHER_IRQn           = 15 , /**< 15  SAML11D14A Direct Memory Access Controller (DMAC) */
+  EVSYS_0_IRQn              = 16 , /**< 16  SAML11D14A Event System Interface (EVSYS) */
+  EVSYS_1_IRQn              = 17 , /**< 17  SAML11D14A Event System Interface (EVSYS) */
+  EVSYS_2_IRQn              = 18 , /**< 18  SAML11D14A Event System Interface (EVSYS) */
+  EVSYS_3_IRQn              = 19 , /**< 19  SAML11D14A Event System Interface (EVSYS) */
+  EVSYS_NSCHK_IRQn          = 20 , /**< 20  SAML11D14A Event System Interface (EVSYS) */
+  PAC_IRQn                  = 21 , /**< 21  SAML11D14A Peripheral Access Controller (PAC) */
+  SERCOM0_0_IRQn            = 22 , /**< 22  SAML11D14A Serial Communication Interface (SERCOM0) */
+  SERCOM0_1_IRQn            = 23 , /**< 23  SAML11D14A Serial Communication Interface (SERCOM0) */
+  SERCOM0_2_IRQn            = 24 , /**< 24  SAML11D14A Serial Communication Interface (SERCOM0) */
+  SERCOM0_OTHER_IRQn        = 25 , /**< 25  SAML11D14A Serial Communication Interface (SERCOM0) */
+  SERCOM1_0_IRQn            = 26 , /**< 26  SAML11D14A Serial Communication Interface (SERCOM1) */
+  SERCOM1_1_IRQn            = 27 , /**< 27  SAML11D14A Serial Communication Interface (SERCOM1) */
+  SERCOM1_2_IRQn            = 28 , /**< 28  SAML11D14A Serial Communication Interface (SERCOM1) */
+  SERCOM1_OTHER_IRQn        = 29 , /**< 29  SAML11D14A Serial Communication Interface (SERCOM1) */
+  TC0_IRQn                  = 34 , /**< 34  SAML11D14A Basic Timer Counter (TC0) */
+  TC1_IRQn                  = 35 , /**< 35  SAML11D14A Basic Timer Counter (TC1) */
+  TC2_IRQn                  = 36 , /**< 36  SAML11D14A Basic Timer Counter (TC2) */
+  ADC_OTHER_IRQn            = 37 , /**< 37  SAML11D14A Analog Digital Converter (ADC) */
+  ADC_RESRDY_IRQn           = 38 , /**< 38  SAML11D14A Analog Digital Converter (ADC) */
+  AC_IRQn                   = 39 , /**< 39  SAML11D14A Analog Comparators (AC)  */
+  DAC_UNDERRUN_A_IRQn       = 40 , /**< 40  SAML11D14A Digital Analog Converter (DAC) */
+  DAC_EMPTY_IRQn            = 41 , /**< 41  SAML11D14A Digital Analog Converter (DAC) */
+  PTC_IRQn                  = 42 , /**< 42  SAML11D14A Peripheral Touch Controller (PTC) */
+  TRNG_IRQn                 = 43 , /**< 43  SAML11D14A True Random Generator (TRNG) */
+  TRAM_IRQn                 = 44 , /**< 44  SAML11D14A TrustRAM (TRAM)          */
+
+  PERIPH_COUNT_IRQn        = 45  /**< Number of peripheral IDs */
+} IRQn_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;                        /* -15 Reset Vector, invoked on Power up and warm reset  */
+  void* pfnNonMaskableInt_Handler;               /* -14 Non maskable Interrupt, cannot be stopped or preempted  */
+  void* pfnHardFault_Handler;                    /* -13 Hard Fault, all classes of Fault     */
+  void* pvReservedC12;
+  void* pvReservedC11;
+  void* pvReservedC10;
+  void* pvReservedC9;
+  void* pvReservedC8;
+  void* pvReservedC7;
+  void* pvReservedC6;
+  void* pfnSVCall_Handler;                       /*  -5 System Service Call via SVC instruction  */
+  void* pvReservedC4;
+  void* pvReservedC3;
+  void* pfnPendSV_Handler;                       /*  -2 Pendable request for system service  */
+  void* pfnSysTick_Handler;                      /*  -1 System Tick Timer                    */
+
+
+  /* Peripheral handlers */
+  void* pfnSYSTEM_Handler;                       /* 0   SAML11D14A Main Clock (MCLK)   */
+  void* pfnWDT_Handler;                          /* 1   SAML11D14A Watchdog Timer (WDT) */
+  void* pfnRTC_Handler;                          /* 2   SAML11D14A Real-Time Counter (RTC) */
+  void* pfnEIC_0_Handler;                        /* 3   SAML11D14A External Interrupt Controller (EIC) */
+  void* pfnEIC_1_Handler;                        /* 4   SAML11D14A External Interrupt Controller (EIC) */
+  void* pfnEIC_2_Handler;                        /* 5   SAML11D14A External Interrupt Controller (EIC) */
+  void* pfnEIC_3_Handler;                        /* 6   SAML11D14A External Interrupt Controller (EIC) */
+  void* pfnEIC_OTHER_Handler;                    /* 7   SAML11D14A External Interrupt Controller (EIC) */
+  void* pfnFREQM_Handler;                        /* 8   SAML11D14A Frequency Meter (FREQM) */
+  void* pfnNVMCTRL_Handler;                      /* 9   SAML11D14A Non-Volatile Memory Controller (NVMCTRL) */
+  void* pfnPORT_Handler;                         /* 10  SAML11D14A Port Module (PORT)  */
+  void* pfnDMAC_0_Handler;                       /* 11  SAML11D14A Direct Memory Access Controller (DMAC) */
+  void* pfnDMAC_1_Handler;                       /* 12  SAML11D14A Direct Memory Access Controller (DMAC) */
+  void* pfnDMAC_2_Handler;                       /* 13  SAML11D14A Direct Memory Access Controller (DMAC) */
+  void* pfnDMAC_3_Handler;                       /* 14  SAML11D14A Direct Memory Access Controller (DMAC) */
+  void* pfnDMAC_OTHER_Handler;                   /* 15  SAML11D14A Direct Memory Access Controller (DMAC) */
+  void* pfnEVSYS_0_Handler;                      /* 16  SAML11D14A Event System Interface (EVSYS) */
+  void* pfnEVSYS_1_Handler;                      /* 17  SAML11D14A Event System Interface (EVSYS) */
+  void* pfnEVSYS_2_Handler;                      /* 18  SAML11D14A Event System Interface (EVSYS) */
+  void* pfnEVSYS_3_Handler;                      /* 19  SAML11D14A Event System Interface (EVSYS) */
+  void* pfnEVSYS_NSCHK_Handler;                  /* 20  SAML11D14A Event System Interface (EVSYS) */
+  void* pfnPAC_Handler;                          /* 21  SAML11D14A Peripheral Access Controller (PAC) */
+  void* pfnSERCOM0_0_Handler;                    /* 22  SAML11D14A Serial Communication Interface (SERCOM0) */
+  void* pfnSERCOM0_1_Handler;                    /* 23  SAML11D14A Serial Communication Interface (SERCOM0) */
+  void* pfnSERCOM0_2_Handler;                    /* 24  SAML11D14A Serial Communication Interface (SERCOM0) */
+  void* pfnSERCOM0_OTHER_Handler;                /* 25  SAML11D14A Serial Communication Interface (SERCOM0) */
+  void* pfnSERCOM1_0_Handler;                    /* 26  SAML11D14A Serial Communication Interface (SERCOM1) */
+  void* pfnSERCOM1_1_Handler;                    /* 27  SAML11D14A Serial Communication Interface (SERCOM1) */
+  void* pfnSERCOM1_2_Handler;                    /* 28  SAML11D14A Serial Communication Interface (SERCOM1) */
+  void* pfnSERCOM1_OTHER_Handler;                /* 29  SAML11D14A Serial Communication Interface (SERCOM1) */
+  void* pvReserved30;
+  void* pvReserved31;
+  void* pvReserved32;
+  void* pvReserved33;
+  void* pfnTC0_Handler;                          /* 34  SAML11D14A Basic Timer Counter (TC0) */
+  void* pfnTC1_Handler;                          /* 35  SAML11D14A Basic Timer Counter (TC1) */
+  void* pfnTC2_Handler;                          /* 36  SAML11D14A Basic Timer Counter (TC2) */
+  void* pfnADC_OTHER_Handler;                    /* 37  SAML11D14A Analog Digital Converter (ADC) */
+  void* pfnADC_RESRDY_Handler;                   /* 38  SAML11D14A Analog Digital Converter (ADC) */
+  void* pfnAC_Handler;                           /* 39  SAML11D14A Analog Comparators (AC) */
+  void* pfnDAC_UNDERRUN_A_Handler;               /* 40  SAML11D14A Digital Analog Converter (DAC) */
+  void* pfnDAC_EMPTY_Handler;                    /* 41  SAML11D14A Digital Analog Converter (DAC) */
+  void* pfnPTC_Handler;                          /* 42  SAML11D14A Peripheral Touch Controller (PTC) */
+  void* pfnTRNG_Handler;                         /* 43  SAML11D14A True Random Generator (TRNG) */
+  void* pfnTRAM_Handler;                         /* 44  SAML11D14A TrustRAM (TRAM)     */
+} DeviceVectors;
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define pfnMemManage_Handler      pfnMemoryManagement_Handler     /**< \deprecated  Backward compatibility for ASF */
+#define pfnDebugMon_Handler       pfnDebugMonitor_Handler         /**< \deprecated  Backward compatibility for ASF */
+#define pfnNMI_Handler            pfnNonMaskableInt_Handler       /**< \deprecated  Backward compatibility for ASF */
+#define pfnSVC_Handler            pfnSVCall_Handler               /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if !defined DONT_USE_PREDEFINED_CORE_HANDLERS
+
+/* CORTEX-M23 core handlers */
+void Reset_Handler                 ( void );
+void NonMaskableInt_Handler        ( void );
+void HardFault_Handler             ( void );
+void SVCall_Handler                ( void );
+void PendSV_Handler                ( void );
+void SysTick_Handler               ( void );
+#endif /* DONT_USE_PREDEFINED_CORE_HANDLERS */
+
+#if !defined DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS
+
+/* Peripherals handlers */
+void AC_Handler                    ( void );
+void ADC_OTHER_Handler             ( void );
+void ADC_RESRDY_Handler            ( void );
+void DAC_EMPTY_Handler             ( void );
+void DAC_UNDERRUN_A_Handler        ( void );
+void DMAC_0_Handler                ( void );
+void DMAC_1_Handler                ( void );
+void DMAC_2_Handler                ( void );
+void DMAC_3_Handler                ( void );
+void DMAC_OTHER_Handler            ( void );
+void EIC_0_Handler                 ( void );
+void EIC_1_Handler                 ( void );
+void EIC_2_Handler                 ( void );
+void EIC_3_Handler                 ( void );
+void EIC_OTHER_Handler             ( void );
+void EVSYS_0_Handler               ( void );
+void EVSYS_1_Handler               ( void );
+void EVSYS_2_Handler               ( void );
+void EVSYS_3_Handler               ( void );
+void EVSYS_NSCHK_Handler           ( void );
+void FREQM_Handler                 ( void );
+void NVMCTRL_Handler               ( void );
+void PAC_Handler                   ( void );
+void PORT_Handler                  ( void );
+void PTC_Handler                   ( void );
+void RTC_Handler                   ( void );
+void SERCOM0_0_Handler             ( void );
+void SERCOM0_1_Handler             ( void );
+void SERCOM0_2_Handler             ( void );
+void SERCOM0_OTHER_Handler         ( void );
+void SERCOM1_0_Handler             ( void );
+void SERCOM1_1_Handler             ( void );
+void SERCOM1_2_Handler             ( void );
+void SERCOM1_OTHER_Handler         ( void );
+void SYSTEM_Handler                ( void );
+void TC0_Handler                   ( void );
+void TC1_Handler                   ( void );
+void TC2_Handler                   ( void );
+void TRAM_Handler                  ( void );
+void TRNG_Handler                  ( void );
+void WDT_Handler                   ( void );
+#endif /* DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS */
+
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define MemManage_Handler         MemoryManagement_Handler        /**< \deprecated  Backward compatibility for ASF */
+#define DebugMon_Handler          DebugMonitor_Handler            /**< \deprecated  Backward compatibility for ASF */
+#define NMI_Handler               NonMaskableInt_Handler          /**< \deprecated  Backward compatibility for ASF */
+#define SVC_Handler               SVCall_Handler                  /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+
+/*
+ * \brief Configuration of the CORTEX-M23 Processor and Core Peripherals
+ */
+
+#define NUM_IRQ                       45 /**< Number of interrupt request lines                                         */
+#define __ARMv8MBL_REV            0x0000 /**< Cortex-M23 Core Revision                                                  */
+#define __ETM_PRESENT                  0 /**< ETM present or not                                                        */
+#define __FPU_PRESENT                  0 /**< FPU present or not                                                        */
+#define __MPU_PRESENT                  1 /**< MPU present or not                                                        */
+#define __MTB_PRESENT                  0 /**< MTB present or not                                                        */
+#define __NVIC_PRIO_BITS               2 /**< Number of Bits used for Priority Levels                                   */
+#define __SAU_PRESENT                  0 /**< SAU present or not                                                        */
+#define __SEC_ENABLED                  0 /**< TrustZone-M enabled or not                                                */
+#define __VTOR_PRESENT                 1 /**< Vector Table Offset Register present or not                               */
+#define __Vendor_SysTickConfig         0 /**< Set to 1 if different SysTick Config is used                              */
+#define __ARCH_ARM                     1
+#define __ARCH_ARM_CORTEX_M            1
+#define __DEVICE_IS_SAM                1
+#define __TZ_PRESENT                   1
+
+/*
+ * \brief CMSIS includes
+ */
+#include <core_cm23.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_saml11.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/** @}  end of SAML11D14A_cmsis CMSIS Definitions */
+
+/** \defgroup SAML11D14A_api Peripheral Software API
+ *  @{
+ */
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAML11D14A */
+/* ************************************************************************** */
+#include "component/ac.h"
+#include "component/adc.h"
+#include "component/ccl.h"
+#include "component/dac.h"
+#include "component/dmac.h"
+#include "component/dsu.h"
+#include "component/eic.h"
+#include "component/evsys.h"
+#include "component/freqm.h"
+#include "component/gclk.h"
+#include "component/idau.h"
+#include "component/mclk.h"
+#include "component/nvmctrl.h"
+#include "component/opamp.h"
+#include "component/oscctrl.h"
+#include "component/osc32kctrl.h"
+#include "component/pac.h"
+#include "component/pm.h"
+#include "component/port.h"
+#include "component/ptc.h"
+#include "component/rstc.h"
+#include "component/rtc.h"
+#include "component/sercom.h"
+#include "component/supc.h"
+#include "component/tc.h"
+#include "component/tram.h"
+#include "component/trng.h"
+#include "component/wdt.h"
+/** @}  end of Peripheral Software API */
+
+/** \defgroup SAML11D14A_reg Registers Access Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   REGISTER ACCESS DEFINITIONS FOR SAML11D14A */
+/* ************************************************************************** */
+#include "instance/ac.h"
+#include "instance/adc.h"
+#include "instance/ccl.h"
+#include "instance/dac.h"
+#include "instance/dmac.h"
+#include "instance/dsu.h"
+#include "instance/eic.h"
+#include "instance/evsys.h"
+#include "instance/freqm.h"
+#include "instance/gclk.h"
+#include "instance/idau.h"
+#include "instance/mclk.h"
+#include "instance/nvmctrl.h"
+#include "instance/opamp.h"
+#include "instance/oscctrl.h"
+#include "instance/osc32kctrl.h"
+#include "instance/pac.h"
+#include "instance/pm.h"
+#include "instance/port.h"
+#include "instance/ptc.h"
+#include "instance/rstc.h"
+#include "instance/rtc.h"
+#include "instance/sercom0.h"
+#include "instance/sercom1.h"
+#include "instance/supc.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tram.h"
+#include "instance/trng.h"
+#include "instance/wdt.h"
+/** @}  end of Registers Access Definitions */
+
+/** \addtogroup SAML11D14A_id Peripheral Ids Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*  PERIPHERAL ID DEFINITIONS FOR SAML11D14A */
+/* ************************************************************************** */
+#define ID_PAC          (  0) /**< \brief Peripheral Access Controller (PAC) */
+#define ID_PM           (  1) /**< \brief Power Manager (PM) */
+#define ID_MCLK         (  2) /**< \brief Main Clock (MCLK) */
+#define ID_RSTC         (  3) /**< \brief Reset Controller (RSTC) */
+#define ID_OSCCTRL      (  4) /**< \brief Oscillators Control (OSCCTRL) */
+#define ID_OSC32KCTRL   (  5) /**< \brief 32k Oscillators Control (OSC32KCTRL) */
+#define ID_SUPC         (  6) /**< \brief Supply Controller (SUPC) */
+#define ID_GCLK         (  7) /**< \brief Generic Clock Generator (GCLK) */
+#define ID_WDT          (  8) /**< \brief Watchdog Timer (WDT) */
+#define ID_RTC          (  9) /**< \brief Real-Time Counter (RTC) */
+#define ID_EIC          ( 10) /**< \brief External Interrupt Controller (EIC) */
+#define ID_FREQM        ( 11) /**< \brief Frequency Meter (FREQM) */
+#define ID_PORT         ( 12) /**< \brief Port Module (PORT) */
+#define ID_AC           ( 13) /**< \brief Analog Comparators (AC) */
+#define ID_IDAU         ( 32) /**< \brief Implementation Defined Attribution Unit (IDAU) */
+#define ID_DSU          ( 33) /**< \brief Device Service Unit (DSU) */
+#define ID_NVMCTRL      ( 34) /**< \brief Non-Volatile Memory Controller (NVMCTRL) */
+#define ID_DMAC         ( 35) /**< \brief Direct Memory Access Controller (DMAC) */
+#define ID_EVSYS        ( 64) /**< \brief Event System Interface (EVSYS) */
+#define ID_SERCOM0      ( 65) /**< \brief Serial Communication Interface (SERCOM0) */
+#define ID_SERCOM1      ( 66) /**< \brief Serial Communication Interface (SERCOM1) */
+#define ID_TC0          ( 68) /**< \brief Basic Timer Counter (TC0) */
+#define ID_TC1          ( 69) /**< \brief Basic Timer Counter (TC1) */
+#define ID_TC2          ( 70) /**< \brief Basic Timer Counter (TC2) */
+#define ID_ADC          ( 71) /**< \brief Analog Digital Converter (ADC) */
+#define ID_DAC          ( 72) /**< \brief Digital Analog Converter (DAC) */
+#define ID_PTC          ( 73) /**< \brief Peripheral Touch Controller (PTC) */
+#define ID_TRNG         ( 74) /**< \brief True Random Generator (TRNG) */
+#define ID_CCL          ( 75) /**< \brief Configurable Custom Logic (CCL) */
+#define ID_OPAMP        ( 76) /**< \brief Operational Amplifier (OPAMP) */
+#define ID_TRAM         ( 77) /**< \brief TrustRAM (TRAM) */
+
+#define ID_PERIPH_COUNT ( 78) /**< \brief Number of peripheral IDs */
+/** @}  end of Peripheral Ids Definitions */
+
+/** \addtogroup SAML11D14A_base Peripheral Base Address Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   BASE ADDRESS DEFINITIONS FOR SAML11D14A */
+/* ************************************************************************** */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#define AC                     (0x40003400)                   /**< \brief (AC        ) Base Address */
+#define ADC                    (0x42001C00)                   /**< \brief (ADC       ) Base Address */
+#define CCL                    (0x42002C00)                   /**< \brief (CCL       ) Base Address */
+#define DAC                    (0x42002000)                   /**< \brief (DAC       ) Base Address */
+#define DMAC                   (0x41006000)                   /**< \brief (DMAC      ) Base Address */
+#define DSU                    (0x41002000)                   /**< \brief (DSU       ) Base Address */
+#define DSU_EXT                (0x41002100)                   /**< \brief (DSU       ) Base Address */
+#define EIC                    (0x40002800)                   /**< \brief (EIC       ) Base Address */
+#define EIC_SEC                (0x40002A00)                   /**< \brief (EIC       ) Base Address */
+#define EVSYS                  (0x42000000)                   /**< \brief (EVSYS     ) Base Address */
+#define EVSYS_SEC              (0x42000200)                   /**< \brief (EVSYS     ) Base Address */
+#define FREQM                  (0x40002C00)                   /**< \brief (FREQM     ) Base Address */
+#define GCLK                   (0x40001C00)                   /**< \brief (GCLK      ) Base Address */
+#define IDAU                   (0x41000000)                   /**< \brief (IDAU      ) Base Address */
+#define MCLK                   (0x40000800)                   /**< \brief (MCLK      ) Base Address */
+#define NVMCTRL                (0x41004000)                   /**< \brief (NVMCTRL   ) Base Address */
+#define NVMCTRL_SEC            (0x41005000)                   /**< \brief (NVMCTRL   ) Base Address */
+#define OPAMP                  (0x42003000)                   /**< \brief (OPAMP     ) Base Address */
+#define OSCCTRL                (0x40001000)                   /**< \brief (OSCCTRL   ) Base Address */
+#define OSC32KCTRL             (0x40001400)                   /**< \brief (OSC32KCTRL) Base Address */
+#define PAC                    (0x40000000)                   /**< \brief (PAC       ) Base Address */
+#define PAC_SEC                (0x40000200)                   /**< \brief (PAC       ) Base Address */
+#define PM                     (0x40000400)                   /**< \brief (PM        ) Base Address */
+#define PORT                   (0x40003000)                   /**< \brief (PORT      ) Base Address */
+#define PORT_SEC               (0x40003200)                   /**< \brief (PORT      ) Base Address */
+#define PORT_IOBUS             (0x60000000)                   /**< \brief (PORT      ) Base Address */
+#define PORT_IOBUS_SEC         (0x60000200)                   /**< \brief (PORT      ) Base Address */
+#define PTC                    (0x42002400)                   /**< \brief (PTC       ) Base Address */
+#define RSTC                   (0x40000C00)                   /**< \brief (RSTC      ) Base Address */
+#define RTC                    (0x40002400)                   /**< \brief (RTC       ) Base Address */
+#define SERCOM0                (0x42000400)                   /**< \brief (SERCOM0   ) Base Address */
+#define SERCOM1                (0x42000800)                   /**< \brief (SERCOM1   ) Base Address */
+#define SUPC                   (0x40001800)                   /**< \brief (SUPC      ) Base Address */
+#define TC0                    (0x42001000)                   /**< \brief (TC0       ) Base Address */
+#define TC1                    (0x42001400)                   /**< \brief (TC1       ) Base Address */
+#define TC2                    (0x42001800)                   /**< \brief (TC2       ) Base Address */
+#define TRAM                   (0x42003400)                   /**< \brief (TRAM      ) Base Address */
+#define TRNG                   (0x42002800)                   /**< \brief (TRNG      ) Base Address */
+#define WDT                    (0x40002000)                   /**< \brief (WDT       ) Base Address */
+
+#else /* For C/C++ compiler */
+
+#define AC                     ((Ac *)0x40003400U)            /**< \brief (AC        ) Base Address */
+#define AC_INST_NUM            1                              /**< \brief (AC        ) Number of instances */
+#define AC_INSTS               { AC }                         /**< \brief (AC        ) Instances List */
+
+#define ADC                    ((Adc *)0x42001C00U)           /**< \brief (ADC       ) Base Address */
+#define ADC_INST_NUM           1                              /**< \brief (ADC       ) Number of instances */
+#define ADC_INSTS              { ADC }                        /**< \brief (ADC       ) Instances List */
+
+#define CCL                    ((Ccl *)0x42002C00U)           /**< \brief (CCL       ) Base Address */
+#define CCL_INST_NUM           1                              /**< \brief (CCL       ) Number of instances */
+#define CCL_INSTS              { CCL }                        /**< \brief (CCL       ) Instances List */
+
+#define DAC                    ((Dac *)0x42002000U)           /**< \brief (DAC       ) Base Address */
+#define DAC_INST_NUM           1                              /**< \brief (DAC       ) Number of instances */
+#define DAC_INSTS              { DAC }                        /**< \brief (DAC       ) Instances List */
+
+#define DMAC                   ((Dmac *)0x41006000U)          /**< \brief (DMAC      ) Base Address */
+#define DMAC_INST_NUM          1                              /**< \brief (DMAC      ) Number of instances */
+#define DMAC_INSTS             { DMAC }                       /**< \brief (DMAC      ) Instances List */
+
+#define DSU                    ((Dsu *)0x41002000U)           /**< \brief (DSU       ) Base Address */
+#define DSU_EXT                ((Dsu *)0x41002100U)           /**< \brief (DSU       ) Base Address */
+#define DSU_INST_NUM           1                              /**< \brief (DSU       ) Number of instances */
+#define DSU_INSTS              { DSU }                        /**< \brief (DSU       ) Instances List */
+
+#define EIC                    ((Eic *)0x40002800U)           /**< \brief (EIC       ) Base Address */
+#define EIC_SEC                ((Eic *)0x40002A00U)           /**< \brief (EIC       ) Base Address */
+#define EIC_INST_NUM           1                              /**< \brief (EIC       ) Number of instances */
+#define EIC_INSTS              { EIC }                        /**< \brief (EIC       ) Instances List */
+
+#define EVSYS                  ((Evsys *)0x42000000U)         /**< \brief (EVSYS     ) Base Address */
+#define EVSYS_SEC              ((Evsys *)0x42000200U)         /**< \brief (EVSYS     ) Base Address */
+#define EVSYS_INST_NUM         1                              /**< \brief (EVSYS     ) Number of instances */
+#define EVSYS_INSTS            { EVSYS }                      /**< \brief (EVSYS     ) Instances List */
+
+#define FREQM                  ((Freqm *)0x40002C00U)         /**< \brief (FREQM     ) Base Address */
+#define FREQM_INST_NUM         1                              /**< \brief (FREQM     ) Number of instances */
+#define FREQM_INSTS            { FREQM }                      /**< \brief (FREQM     ) Instances List */
+
+#define GCLK                   ((Gclk *)0x40001C00U)          /**< \brief (GCLK      ) Base Address */
+#define GCLK_INST_NUM          1                              /**< \brief (GCLK      ) Number of instances */
+#define GCLK_INSTS             { GCLK }                       /**< \brief (GCLK      ) Instances List */
+
+#define IDAU                   ((Idau *)0x41000000U)          /**< \brief (IDAU      ) Base Address */
+#define IDAU_INST_NUM          1                              /**< \brief (IDAU      ) Number of instances */
+#define IDAU_INSTS             { IDAU }                       /**< \brief (IDAU      ) Instances List */
+
+#define MCLK                   ((Mclk *)0x40000800U)          /**< \brief (MCLK      ) Base Address */
+#define MCLK_INST_NUM          1                              /**< \brief (MCLK      ) Number of instances */
+#define MCLK_INSTS             { MCLK }                       /**< \brief (MCLK      ) Instances List */
+
+#define NVMCTRL                ((Nvmctrl *)0x41004000U)       /**< \brief (NVMCTRL   ) Base Address */
+#define NVMCTRL_SEC            ((Nvmctrl *)0x41005000U)       /**< \brief (NVMCTRL   ) Base Address */
+#define NVMCTRL_INST_NUM       1                              /**< \brief (NVMCTRL   ) Number of instances */
+#define NVMCTRL_INSTS          { NVMCTRL }                    /**< \brief (NVMCTRL   ) Instances List */
+
+#define OPAMP                  ((Opamp *)0x42003000U)         /**< \brief (OPAMP     ) Base Address */
+#define OPAMP_INST_NUM         1                              /**< \brief (OPAMP     ) Number of instances */
+#define OPAMP_INSTS            { OPAMP }                      /**< \brief (OPAMP     ) Instances List */
+
+#define OSCCTRL                ((Oscctrl *)0x40001000U)       /**< \brief (OSCCTRL   ) Base Address */
+#define OSCCTRL_INST_NUM       1                              /**< \brief (OSCCTRL   ) Number of instances */
+#define OSCCTRL_INSTS          { OSCCTRL }                    /**< \brief (OSCCTRL   ) Instances List */
+
+#define OSC32KCTRL             ((Osc32kctrl *)0x40001400U)    /**< \brief (OSC32KCTRL) Base Address */
+#define OSC32KCTRL_INST_NUM    1                              /**< \brief (OSC32KCTRL) Number of instances */
+#define OSC32KCTRL_INSTS       { OSC32KCTRL }                 /**< \brief (OSC32KCTRL) Instances List */
+
+#define PAC                    ((Pac *)0x40000000U)           /**< \brief (PAC       ) Base Address */
+#define PAC_SEC                ((Pac *)0x40000200U)           /**< \brief (PAC       ) Base Address */
+#define PAC_INST_NUM           1                              /**< \brief (PAC       ) Number of instances */
+#define PAC_INSTS              { PAC }                        /**< \brief (PAC       ) Instances List */
+
+#define PM                     ((Pm *)0x40000400U)            /**< \brief (PM        ) Base Address */
+#define PM_INST_NUM            1                              /**< \brief (PM        ) Number of instances */
+#define PM_INSTS               { PM }                         /**< \brief (PM        ) Instances List */
+
+#define PORT                   ((Port *)0x40003000U)          /**< \brief (PORT      ) Base Address */
+#define PORT_SEC               ((Port *)0x40003200U)          /**< \brief (PORT      ) Base Address */
+#define PORT_IOBUS             ((Port *)0x60000000U)          /**< \brief (PORT      ) Base Address */
+#define PORT_IOBUS_SEC         ((Port *)0x60000200U)          /**< \brief (PORT      ) Base Address */
+#define PORT_INST_NUM          1                              /**< \brief (PORT      ) Number of instances */
+#define PORT_INSTS             { PORT }                       /**< \brief (PORT      ) Instances List */
+
+#define PTC                    ((Ptc *)0x42002400U)           /**< \brief (PTC       ) Base Address */
+#define PTC_INST_NUM           1                              /**< \brief (PTC       ) Number of instances */
+#define PTC_INSTS              { PTC }                        /**< \brief (PTC       ) Instances List */
+
+#define RSTC                   ((Rstc *)0x40000C00U)          /**< \brief (RSTC      ) Base Address */
+#define RSTC_INST_NUM          1                              /**< \brief (RSTC      ) Number of instances */
+#define RSTC_INSTS             { RSTC }                       /**< \brief (RSTC      ) Instances List */
+
+#define RTC                    ((Rtc *)0x40002400U)           /**< \brief (RTC       ) Base Address */
+#define RTC_INST_NUM           1                              /**< \brief (RTC       ) Number of instances */
+#define RTC_INSTS              { RTC }                        /**< \brief (RTC       ) Instances List */
+
+#define SERCOM0                ((Sercom *)0x42000400U)        /**< \brief (SERCOM0   ) Base Address */
+#define SERCOM1                ((Sercom *)0x42000800U)        /**< \brief (SERCOM1   ) Base Address */
+#define SERCOM_INST_NUM        2                              /**< \brief (SERCOM    ) Number of instances */
+#define SERCOM_INSTS           { SERCOM0, SERCOM1 }           /**< \brief (SERCOM    ) Instances List */
+
+#define SUPC                   ((Supc *)0x40001800U)          /**< \brief (SUPC      ) Base Address */
+#define SUPC_INST_NUM          1                              /**< \brief (SUPC      ) Number of instances */
+#define SUPC_INSTS             { SUPC }                       /**< \brief (SUPC      ) Instances List */
+
+#define TC0                    ((Tc *)0x42001000U)            /**< \brief (TC0       ) Base Address */
+#define TC1                    ((Tc *)0x42001400U)            /**< \brief (TC1       ) Base Address */
+#define TC2                    ((Tc *)0x42001800U)            /**< \brief (TC2       ) Base Address */
+#define TC_INST_NUM            3                              /**< \brief (TC        ) Number of instances */
+#define TC_INSTS               { TC0, TC1, TC2 }              /**< \brief (TC        ) Instances List */
+
+#define TRAM                   ((Tram *)0x42003400U)          /**< \brief (TRAM      ) Base Address */
+#define TRAM_INST_NUM          1                              /**< \brief (TRAM      ) Number of instances */
+#define TRAM_INSTS             { TRAM }                       /**< \brief (TRAM      ) Instances List */
+
+#define TRNG                   ((Trng *)0x42002800U)          /**< \brief (TRNG      ) Base Address */
+#define TRNG_INST_NUM          1                              /**< \brief (TRNG      ) Number of instances */
+#define TRNG_INSTS             { TRNG }                       /**< \brief (TRNG      ) Instances List */
+
+#define WDT                    ((Wdt *)0x40002000U)           /**< \brief (WDT       ) Base Address */
+#define WDT_INST_NUM           1                              /**< \brief (WDT       ) Number of instances */
+#define WDT_INSTS              { WDT }                        /**< \brief (WDT       ) Instances List */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Peripheral Base Address Definitions */
+
+/** \addtogroup SAML11D14A_pio Peripheral Pio Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   PIO DEFINITIONS FOR SAML11D14A*/
+/* ************************************************************************** */
+#include "pio/saml11d14a.h"
+/** @}  end of Peripheral Pio Definitions */
+
+/* ************************************************************************** */
+/*   MEMORY MAPPING DEFINITIONS FOR SAML11D14A*/
+/* ************************************************************************** */
+
+#define FLASH_SIZE               _U_(0x00004000)       /*   16kB Memory segment type: flash */
+#define FLASH_PAGE_SIZE          _U_(        64)
+#define FLASH_NB_OF_PAGES        _U_(       256)
+
+#define AUX_SIZE                 _U_(0x00000100)       /*    0kB Memory segment type: fuses */
+#define AUX_PAGE_SIZE            _U_(        64)
+#define AUX_NB_OF_PAGES          _U_(         4)
+
+#define BOCOR_SIZE               _U_(0x00000100)       /*    0kB Memory segment type: fuses */
+#define BOCOR_PAGE_SIZE          _U_(        64)
+#define BOCOR_NB_OF_PAGES        _U_(         4)
+
+#define DATAFLASH_SIZE           _U_(0x00000800)       /*    2kB Memory segment type: flash */
+#define DATAFLASH_PAGE_SIZE      _U_(        64)
+#define DATAFLASH_NB_OF_PAGES    _U_(        32)
+
+#define SW_CALIB_SIZE            _U_(0x00000008)       /*    0kB Memory segment type: fuses */
+#define TEMP_LOG_SIZE            _U_(0x00000008)       /*    0kB Memory segment type: fuses */
+#define USER_PAGE_SIZE           _U_(0x00000100)       /*    0kB Memory segment type: user_page */
+#define USER_PAGE_PAGE_SIZE      _U_(        64)
+#define USER_PAGE_NB_OF_PAGES    _U_(         4)
+
+#define HSRAM_SIZE               _U_(0x00002000)       /*    8kB Memory segment type: ram */
+#define HPB0_SIZE                _U_(0x00008000)       /*   32kB Memory segment type: io */
+#define HPB1_SIZE                _U_(0x00010000)       /*   64kB Memory segment type: io */
+#define HPB2_SIZE                _U_(0x00004000)       /*   16kB Memory segment type: io */
+#define PPB_SIZE                 _U_(0x00100000)       /* 1024kB Memory segment type: io */
+#define SCS_SIZE                 _U_(0x00001000)       /*    4kB Memory segment type: io */
+#define PERIPHERALS_SIZE         _U_(0x20000000)       /* 524288kB Memory segment type: io */
+
+#define FLASH_ADDR               _U_(0x00000000)       /**< FLASH base address (type: flash)*/
+#define AUX_ADDR                 _U_(0x00806000)       /**< AUX base address (type: fuses)*/
+#define BOCOR_ADDR               _U_(0x0080c000)       /**< BOCOR base address (type: fuses)*/
+#define DATAFLASH_ADDR           _U_(0x00400000)       /**< DATAFLASH base address (type: flash)*/
+#define SW_CALIB_ADDR            _U_(0x00806020)       /**< SW_CALIB base address (type: fuses)*/
+#define TEMP_LOG_ADDR            _U_(0x00806038)       /**< TEMP_LOG base address (type: fuses)*/
+#define USER_PAGE_ADDR           _U_(0x00804000)       /**< USER_PAGE base address (type: user_page)*/
+#define HSRAM_ADDR               _U_(0x20000000)       /**< HSRAM base address (type: ram)*/
+#define HPB0_ADDR                _U_(0x40000000)       /**< HPB0 base address (type: io)*/
+#define HPB1_ADDR                _U_(0x41000000)       /**< HPB1 base address (type: io)*/
+#define HPB2_ADDR                _U_(0x42000000)       /**< HPB2 base address (type: io)*/
+#define PPB_ADDR                 _U_(0xe0000000)       /**< PPB base address (type: io)*/
+#define SCS_ADDR                 _U_(0xe000e000)       /**< SCS base address (type: io)*/
+#define PERIPHERALS_ADDR         _U_(0x40000000)       /**< PERIPHERALS base address (type: io)*/
+
+#define NVMCTRL_AUX              AUX_ADDR              /**< \brief \deprecated Old style definition. Use AUX_ADDR instead */
+#define NVMCTRL_BOCOR            BOCOR_ADDR            /**< \brief \deprecated Old style definition. Use BOCOR_ADDR instead */
+#define NVMCTRL_DATAFLASH        DATAFLASH_ADDR        /**< \brief \deprecated Old style definition. Use DATAFLASH_ADDR instead */
+#define NVMCTRL_SW_CALIB         SW_CALIB_ADDR         /**< \brief \deprecated Old style definition. Use SW_CALIB_ADDR instead */
+#define NVMCTRL_TEMP_LOG         TEMP_LOG_ADDR         /**< \brief \deprecated Old style definition. Use TEMP_LOG_ADDR instead */
+#define NVMCTRL_USER             USER_PAGE_ADDR        /**< \brief \deprecated Old style definition. Use USER_PAGE_ADDR instead */
+
+/* ************************************************************************** */
+/**  DEVICE SIGNATURES FOR SAML11D14A */
+/* ************************************************************************** */
+#define DSU_DID                  _UL_(0X20830005)
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAML11D14A */
+/* ************************************************************************** */
+
+/* ************************************************************************** */
+/** Event Generator IDs for SAML11D14A */
+/* ************************************************************************** */
+#define EVENT_ID_GEN_OSCCTRL_XOSC_FAIL                    1 /**< ID for OSCCTRL event generator XOSC_FAIL */
+#define EVENT_ID_GEN_OSC32KCTRL_XOSC32K_FAIL              2 /**< ID for OSC32KCTRL event generator XOSC32K_FAIL */
+#define EVENT_ID_GEN_SUPC_BOD33DET                        3 /**< ID for SUPC event generator BOD33DET */
+#define EVENT_ID_GEN_RTC_PER_0                            4 /**< ID for RTC event generator PER_0 */
+#define EVENT_ID_GEN_RTC_PER_1                            5 /**< ID for RTC event generator PER_1 */
+#define EVENT_ID_GEN_RTC_PER_2                            6 /**< ID for RTC event generator PER_2 */
+#define EVENT_ID_GEN_RTC_PER_3                            7 /**< ID for RTC event generator PER_3 */
+#define EVENT_ID_GEN_RTC_PER_4                            8 /**< ID for RTC event generator PER_4 */
+#define EVENT_ID_GEN_RTC_PER_5                            9 /**< ID for RTC event generator PER_5 */
+#define EVENT_ID_GEN_RTC_PER_6                           10 /**< ID for RTC event generator PER_6 */
+#define EVENT_ID_GEN_RTC_PER_7                           11 /**< ID for RTC event generator PER_7 */
+#define EVENT_ID_GEN_RTC_CMP_0                           12 /**< ID for RTC event generator CMP_0 */
+#define EVENT_ID_GEN_RTC_CMP_1                           13 /**< ID for RTC event generator CMP_1 */
+#define EVENT_ID_GEN_RTC_TAMPER                          14 /**< ID for RTC event generator TAMPER */
+#define EVENT_ID_GEN_RTC_OVF                             15 /**< ID for RTC event generator OVF */
+#define EVENT_ID_GEN_RTC_PERD                            16 /**< ID for RTC event generator PERD */
+#define EVENT_ID_GEN_EIC_EXTINT_0                        17 /**< ID for EIC event generator EXTINT_0 */
+#define EVENT_ID_GEN_EIC_EXTINT_1                        18 /**< ID for EIC event generator EXTINT_1 */
+#define EVENT_ID_GEN_EIC_EXTINT_2                        19 /**< ID for EIC event generator EXTINT_2 */
+#define EVENT_ID_GEN_EIC_EXTINT_3                        20 /**< ID for EIC event generator EXTINT_3 */
+#define EVENT_ID_GEN_EIC_EXTINT_4                        21 /**< ID for EIC event generator EXTINT_4 */
+#define EVENT_ID_GEN_EIC_EXTINT_5                        22 /**< ID for EIC event generator EXTINT_5 */
+#define EVENT_ID_GEN_EIC_EXTINT_6                        23 /**< ID for EIC event generator EXTINT_6 */
+#define EVENT_ID_GEN_EIC_EXTINT_7                        24 /**< ID for EIC event generator EXTINT_7 */
+#define EVENT_ID_GEN_DMAC_CH_0                           25 /**< ID for DMAC event generator CH_0 */
+#define EVENT_ID_GEN_DMAC_CH_1                           26 /**< ID for DMAC event generator CH_1 */
+#define EVENT_ID_GEN_DMAC_CH_2                           27 /**< ID for DMAC event generator CH_2 */
+#define EVENT_ID_GEN_DMAC_CH_3                           28 /**< ID for DMAC event generator CH_3 */
+#define EVENT_ID_GEN_TC0_OVF                             29 /**< ID for TC0 event generator OVF */
+#define EVENT_ID_GEN_TC0_MCX_0                           30 /**< ID for TC0 event generator MCX_0 */
+#define EVENT_ID_GEN_TC0_MCX_1                           31 /**< ID for TC0 event generator MCX_1 */
+#define EVENT_ID_GEN_TC1_OVF                             32 /**< ID for TC1 event generator OVF */
+#define EVENT_ID_GEN_TC1_MCX_0                           33 /**< ID for TC1 event generator MCX_0 */
+#define EVENT_ID_GEN_TC1_MCX_1                           34 /**< ID for TC1 event generator MCX_1 */
+#define EVENT_ID_GEN_TC2_OVF                             35 /**< ID for TC2 event generator OVF */
+#define EVENT_ID_GEN_TC2_MCX_0                           36 /**< ID for TC2 event generator MCX_0 */
+#define EVENT_ID_GEN_TC2_MCX_1                           37 /**< ID for TC2 event generator MCX_1 */
+#define EVENT_ID_GEN_ADC_RESRDY                          38 /**< ID for ADC event generator RESRDY */
+#define EVENT_ID_GEN_ADC_WINMON                          39 /**< ID for ADC event generator WINMON */
+#define EVENT_ID_GEN_AC_COMP_0                           40 /**< ID for AC event generator COMP_0 */
+#define EVENT_ID_GEN_AC_COMP_1                           41 /**< ID for AC event generator COMP_1 */
+#define EVENT_ID_GEN_AC_WIN_0                            42 /**< ID for AC event generator WIN_0 */
+#define EVENT_ID_GEN_DAC_EMPTY                           43 /**< ID for DAC event generator EMPTY */
+#define EVENT_ID_GEN_TRNG_READY                          46 /**< ID for TRNG event generator READY */
+#define EVENT_ID_GEN_CCL_LUTOUT_0                        47 /**< ID for CCL event generator LUTOUT_0 */
+#define EVENT_ID_GEN_CCL_LUTOUT_1                        48 /**< ID for CCL event generator LUTOUT_1 */
+#define EVENT_ID_GEN_PAC_ERR                             49 /**< ID for PAC event generator ERR */
+
+/* ************************************************************************** */
+/** Event User IDs for SAML11D14A */
+/* ************************************************************************** */
+#define EVENT_ID_USER_OSCCTRL_TUNE                        0 /**< ID for OSCCTRL event user TUNE */
+#define EVENT_ID_USER_RTC_TAMPER                          1 /**< ID for RTC event user TAMPER */
+#define EVENT_ID_USER_NVMCTRL_PAGEW                       2 /**< ID for NVMCTRL event user PAGEW */
+#define EVENT_ID_USER_PORT_EV_0                           3 /**< ID for PORT event user EV_0 */
+#define EVENT_ID_USER_PORT_EV_1                           4 /**< ID for PORT event user EV_1 */
+#define EVENT_ID_USER_PORT_EV_2                           5 /**< ID for PORT event user EV_2 */
+#define EVENT_ID_USER_PORT_EV_3                           6 /**< ID for PORT event user EV_3 */
+#define EVENT_ID_USER_DMAC_CH_0                           7 /**< ID for DMAC event user CH_0 */
+#define EVENT_ID_USER_DMAC_CH_1                           8 /**< ID for DMAC event user CH_1 */
+#define EVENT_ID_USER_DMAC_CH_2                           9 /**< ID for DMAC event user CH_2 */
+#define EVENT_ID_USER_DMAC_CH_3                          10 /**< ID for DMAC event user CH_3 */
+#define EVENT_ID_USER_TC0_EVU                            11 /**< ID for TC0 event user EVU */
+#define EVENT_ID_USER_TC1_EVU                            12 /**< ID for TC1 event user EVU */
+#define EVENT_ID_USER_TC2_EVU                            13 /**< ID for TC2 event user EVU */
+#define EVENT_ID_USER_ADC_START                          14 /**< ID for ADC event user START */
+#define EVENT_ID_USER_ADC_SYNC                           15 /**< ID for ADC event user SYNC */
+#define EVENT_ID_USER_AC_SOC_0                           16 /**< ID for AC event user SOC_0 */
+#define EVENT_ID_USER_AC_SOC_1                           17 /**< ID for AC event user SOC_1 */
+#define EVENT_ID_USER_DAC_START                          18 /**< ID for DAC event user START */
+#define EVENT_ID_USER_CCL_LUTIN_0                        21 /**< ID for CCL event user LUTIN_0 */
+#define EVENT_ID_USER_CCL_LUTIN_1                        22 /**< ID for CCL event user LUTIN_1 */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @}  end of SAML11D14A definitions */
+
+
+#endif /* _SAML11D14A_H_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/saml11d15a.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/saml11d15a.h
@@ -1,0 +1,802 @@
+/**
+ * \file
+ *
+ * \brief Header file for ATSAML11D15A
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11D15A_H_
+#define _SAML11D15A_H_
+
+/** \addtogroup SAML11D15A_definitions SAML11D15A definitions
+  This file defines all structures and symbols for SAML11D15A:
+    - registers and bitfields
+    - peripheral base address
+    - peripheral ID
+    - PIO definitions
+ *  @{
+ */
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/** \defgroup Atmel_glob_defs Atmel Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+
+    \remark
+    CMSIS core has a syntax that differs from this using i.e. __I, __O, or __IO followed by 'uint<size>_t' respective types.
+    Default the header files will follow the CMSIS core syntax.
+ *  @{
+ */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+
+/* IO definitions (access restrictions to peripheral registers) */
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+
+#define CAST(type, value) ((type *)(value)) /**< Pointer Type Conversion Macro for C/C++ */
+#define REG_ACCESS(type, address) (*(type*)(address)) /**< C code: Register value */
+#else /* Assembler */
+#define CAST(type, value) (value) /**< Pointer Type Conversion Macro for Assembler */
+#define REG_ACCESS(type, address) (address) /**< Assembly code: Register address */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !defined(SKIP_INTEGER_LITERALS)
+
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x) x ## U    /**< C code: Unsigned integer literal constant value */
+#define _L_(x) x ## L    /**< C code: Long integer literal constant value */
+#define _UL_(x) x ## UL  /**< C code: Unsigned Long integer literal constant value */
+
+#else /* Assembler */
+
+#define _U_(x) x    /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x) x    /**< Assembler: Long integer literal constant value */
+#define _UL_(x) x   /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* SKIP_INTEGER_LITERALS */
+/** @}  end of Atmel Global Defines */
+
+/** \addtogroup SAML11D15A_cmsis CMSIS Definitions
+ *  @{
+ */
+/* ************************************************************************** */
+/*   CMSIS DEFINITIONS FOR SAML11D15A */
+/* ************************************************************************** */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+/******  CORTEX-M23 Processor Exceptions Numbers ******************************/
+  Reset_IRQn                = -15, /**< 1   Reset Vector, invoked on Power up and warm reset  */
+  NonMaskableInt_IRQn       = -14, /**< 2   Non maskable Interrupt, cannot be stopped or preempted  */
+  HardFault_IRQn            = -13, /**< 3   Hard Fault, all classes of Fault     */
+  SVCall_IRQn               = -5 , /**< 11  System Service Call via SVC instruction  */
+  PendSV_IRQn               = -2 , /**< 14  Pendable request for system service  */
+  SysTick_IRQn              = -1 , /**< 15  System Tick Timer                    */
+/******  SAML11D15A specific Interrupt Numbers ***********************************/
+  SYSTEM_IRQn               = 0  , /**< 0   SAML11D15A Main Clock (MCLK)        */
+  WDT_IRQn                  = 1  , /**< 1   SAML11D15A Watchdog Timer (WDT)     */
+  RTC_IRQn                  = 2  , /**< 2   SAML11D15A Real-Time Counter (RTC)  */
+  EIC_0_IRQn                = 3  , /**< 3   SAML11D15A External Interrupt Controller (EIC) */
+  EIC_1_IRQn                = 4  , /**< 4   SAML11D15A External Interrupt Controller (EIC) */
+  EIC_2_IRQn                = 5  , /**< 5   SAML11D15A External Interrupt Controller (EIC) */
+  EIC_3_IRQn                = 6  , /**< 6   SAML11D15A External Interrupt Controller (EIC) */
+  EIC_OTHER_IRQn            = 7  , /**< 7   SAML11D15A External Interrupt Controller (EIC) */
+  FREQM_IRQn                = 8  , /**< 8   SAML11D15A Frequency Meter (FREQM)  */
+  NVMCTRL_IRQn              = 9  , /**< 9   SAML11D15A Non-Volatile Memory Controller (NVMCTRL) */
+  PORT_IRQn                 = 10 , /**< 10  SAML11D15A Port Module (PORT)       */
+  DMAC_0_IRQn               = 11 , /**< 11  SAML11D15A Direct Memory Access Controller (DMAC) */
+  DMAC_1_IRQn               = 12 , /**< 12  SAML11D15A Direct Memory Access Controller (DMAC) */
+  DMAC_2_IRQn               = 13 , /**< 13  SAML11D15A Direct Memory Access Controller (DMAC) */
+  DMAC_3_IRQn               = 14 , /**< 14  SAML11D15A Direct Memory Access Controller (DMAC) */
+  DMAC_OTHER_IRQn           = 15 , /**< 15  SAML11D15A Direct Memory Access Controller (DMAC) */
+  EVSYS_0_IRQn              = 16 , /**< 16  SAML11D15A Event System Interface (EVSYS) */
+  EVSYS_1_IRQn              = 17 , /**< 17  SAML11D15A Event System Interface (EVSYS) */
+  EVSYS_2_IRQn              = 18 , /**< 18  SAML11D15A Event System Interface (EVSYS) */
+  EVSYS_3_IRQn              = 19 , /**< 19  SAML11D15A Event System Interface (EVSYS) */
+  EVSYS_NSCHK_IRQn          = 20 , /**< 20  SAML11D15A Event System Interface (EVSYS) */
+  PAC_IRQn                  = 21 , /**< 21  SAML11D15A Peripheral Access Controller (PAC) */
+  SERCOM0_0_IRQn            = 22 , /**< 22  SAML11D15A Serial Communication Interface (SERCOM0) */
+  SERCOM0_1_IRQn            = 23 , /**< 23  SAML11D15A Serial Communication Interface (SERCOM0) */
+  SERCOM0_2_IRQn            = 24 , /**< 24  SAML11D15A Serial Communication Interface (SERCOM0) */
+  SERCOM0_OTHER_IRQn        = 25 , /**< 25  SAML11D15A Serial Communication Interface (SERCOM0) */
+  SERCOM1_0_IRQn            = 26 , /**< 26  SAML11D15A Serial Communication Interface (SERCOM1) */
+  SERCOM1_1_IRQn            = 27 , /**< 27  SAML11D15A Serial Communication Interface (SERCOM1) */
+  SERCOM1_2_IRQn            = 28 , /**< 28  SAML11D15A Serial Communication Interface (SERCOM1) */
+  SERCOM1_OTHER_IRQn        = 29 , /**< 29  SAML11D15A Serial Communication Interface (SERCOM1) */
+  TC0_IRQn                  = 34 , /**< 34  SAML11D15A Basic Timer Counter (TC0) */
+  TC1_IRQn                  = 35 , /**< 35  SAML11D15A Basic Timer Counter (TC1) */
+  TC2_IRQn                  = 36 , /**< 36  SAML11D15A Basic Timer Counter (TC2) */
+  ADC_OTHER_IRQn            = 37 , /**< 37  SAML11D15A Analog Digital Converter (ADC) */
+  ADC_RESRDY_IRQn           = 38 , /**< 38  SAML11D15A Analog Digital Converter (ADC) */
+  AC_IRQn                   = 39 , /**< 39  SAML11D15A Analog Comparators (AC)  */
+  DAC_UNDERRUN_A_IRQn       = 40 , /**< 40  SAML11D15A Digital Analog Converter (DAC) */
+  DAC_EMPTY_IRQn            = 41 , /**< 41  SAML11D15A Digital Analog Converter (DAC) */
+  PTC_IRQn                  = 42 , /**< 42  SAML11D15A Peripheral Touch Controller (PTC) */
+  TRNG_IRQn                 = 43 , /**< 43  SAML11D15A True Random Generator (TRNG) */
+  TRAM_IRQn                 = 44 , /**< 44  SAML11D15A TrustRAM (TRAM)          */
+
+  PERIPH_COUNT_IRQn        = 45  /**< Number of peripheral IDs */
+} IRQn_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;                        /* -15 Reset Vector, invoked on Power up and warm reset  */
+  void* pfnNonMaskableInt_Handler;               /* -14 Non maskable Interrupt, cannot be stopped or preempted  */
+  void* pfnHardFault_Handler;                    /* -13 Hard Fault, all classes of Fault     */
+  void* pvReservedC12;
+  void* pvReservedC11;
+  void* pvReservedC10;
+  void* pvReservedC9;
+  void* pvReservedC8;
+  void* pvReservedC7;
+  void* pvReservedC6;
+  void* pfnSVCall_Handler;                       /*  -5 System Service Call via SVC instruction  */
+  void* pvReservedC4;
+  void* pvReservedC3;
+  void* pfnPendSV_Handler;                       /*  -2 Pendable request for system service  */
+  void* pfnSysTick_Handler;                      /*  -1 System Tick Timer                    */
+
+
+  /* Peripheral handlers */
+  void* pfnSYSTEM_Handler;                       /* 0   SAML11D15A Main Clock (MCLK)   */
+  void* pfnWDT_Handler;                          /* 1   SAML11D15A Watchdog Timer (WDT) */
+  void* pfnRTC_Handler;                          /* 2   SAML11D15A Real-Time Counter (RTC) */
+  void* pfnEIC_0_Handler;                        /* 3   SAML11D15A External Interrupt Controller (EIC) */
+  void* pfnEIC_1_Handler;                        /* 4   SAML11D15A External Interrupt Controller (EIC) */
+  void* pfnEIC_2_Handler;                        /* 5   SAML11D15A External Interrupt Controller (EIC) */
+  void* pfnEIC_3_Handler;                        /* 6   SAML11D15A External Interrupt Controller (EIC) */
+  void* pfnEIC_OTHER_Handler;                    /* 7   SAML11D15A External Interrupt Controller (EIC) */
+  void* pfnFREQM_Handler;                        /* 8   SAML11D15A Frequency Meter (FREQM) */
+  void* pfnNVMCTRL_Handler;                      /* 9   SAML11D15A Non-Volatile Memory Controller (NVMCTRL) */
+  void* pfnPORT_Handler;                         /* 10  SAML11D15A Port Module (PORT)  */
+  void* pfnDMAC_0_Handler;                       /* 11  SAML11D15A Direct Memory Access Controller (DMAC) */
+  void* pfnDMAC_1_Handler;                       /* 12  SAML11D15A Direct Memory Access Controller (DMAC) */
+  void* pfnDMAC_2_Handler;                       /* 13  SAML11D15A Direct Memory Access Controller (DMAC) */
+  void* pfnDMAC_3_Handler;                       /* 14  SAML11D15A Direct Memory Access Controller (DMAC) */
+  void* pfnDMAC_OTHER_Handler;                   /* 15  SAML11D15A Direct Memory Access Controller (DMAC) */
+  void* pfnEVSYS_0_Handler;                      /* 16  SAML11D15A Event System Interface (EVSYS) */
+  void* pfnEVSYS_1_Handler;                      /* 17  SAML11D15A Event System Interface (EVSYS) */
+  void* pfnEVSYS_2_Handler;                      /* 18  SAML11D15A Event System Interface (EVSYS) */
+  void* pfnEVSYS_3_Handler;                      /* 19  SAML11D15A Event System Interface (EVSYS) */
+  void* pfnEVSYS_NSCHK_Handler;                  /* 20  SAML11D15A Event System Interface (EVSYS) */
+  void* pfnPAC_Handler;                          /* 21  SAML11D15A Peripheral Access Controller (PAC) */
+  void* pfnSERCOM0_0_Handler;                    /* 22  SAML11D15A Serial Communication Interface (SERCOM0) */
+  void* pfnSERCOM0_1_Handler;                    /* 23  SAML11D15A Serial Communication Interface (SERCOM0) */
+  void* pfnSERCOM0_2_Handler;                    /* 24  SAML11D15A Serial Communication Interface (SERCOM0) */
+  void* pfnSERCOM0_OTHER_Handler;                /* 25  SAML11D15A Serial Communication Interface (SERCOM0) */
+  void* pfnSERCOM1_0_Handler;                    /* 26  SAML11D15A Serial Communication Interface (SERCOM1) */
+  void* pfnSERCOM1_1_Handler;                    /* 27  SAML11D15A Serial Communication Interface (SERCOM1) */
+  void* pfnSERCOM1_2_Handler;                    /* 28  SAML11D15A Serial Communication Interface (SERCOM1) */
+  void* pfnSERCOM1_OTHER_Handler;                /* 29  SAML11D15A Serial Communication Interface (SERCOM1) */
+  void* pvReserved30;
+  void* pvReserved31;
+  void* pvReserved32;
+  void* pvReserved33;
+  void* pfnTC0_Handler;                          /* 34  SAML11D15A Basic Timer Counter (TC0) */
+  void* pfnTC1_Handler;                          /* 35  SAML11D15A Basic Timer Counter (TC1) */
+  void* pfnTC2_Handler;                          /* 36  SAML11D15A Basic Timer Counter (TC2) */
+  void* pfnADC_OTHER_Handler;                    /* 37  SAML11D15A Analog Digital Converter (ADC) */
+  void* pfnADC_RESRDY_Handler;                   /* 38  SAML11D15A Analog Digital Converter (ADC) */
+  void* pfnAC_Handler;                           /* 39  SAML11D15A Analog Comparators (AC) */
+  void* pfnDAC_UNDERRUN_A_Handler;               /* 40  SAML11D15A Digital Analog Converter (DAC) */
+  void* pfnDAC_EMPTY_Handler;                    /* 41  SAML11D15A Digital Analog Converter (DAC) */
+  void* pfnPTC_Handler;                          /* 42  SAML11D15A Peripheral Touch Controller (PTC) */
+  void* pfnTRNG_Handler;                         /* 43  SAML11D15A True Random Generator (TRNG) */
+  void* pfnTRAM_Handler;                         /* 44  SAML11D15A TrustRAM (TRAM)     */
+} DeviceVectors;
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define pfnMemManage_Handler      pfnMemoryManagement_Handler     /**< \deprecated  Backward compatibility for ASF */
+#define pfnDebugMon_Handler       pfnDebugMonitor_Handler         /**< \deprecated  Backward compatibility for ASF */
+#define pfnNMI_Handler            pfnNonMaskableInt_Handler       /**< \deprecated  Backward compatibility for ASF */
+#define pfnSVC_Handler            pfnSVCall_Handler               /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if !defined DONT_USE_PREDEFINED_CORE_HANDLERS
+
+/* CORTEX-M23 core handlers */
+void Reset_Handler                 ( void );
+void NonMaskableInt_Handler        ( void );
+void HardFault_Handler             ( void );
+void SVCall_Handler                ( void );
+void PendSV_Handler                ( void );
+void SysTick_Handler               ( void );
+#endif /* DONT_USE_PREDEFINED_CORE_HANDLERS */
+
+#if !defined DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS
+
+/* Peripherals handlers */
+void AC_Handler                    ( void );
+void ADC_OTHER_Handler             ( void );
+void ADC_RESRDY_Handler            ( void );
+void DAC_EMPTY_Handler             ( void );
+void DAC_UNDERRUN_A_Handler        ( void );
+void DMAC_0_Handler                ( void );
+void DMAC_1_Handler                ( void );
+void DMAC_2_Handler                ( void );
+void DMAC_3_Handler                ( void );
+void DMAC_OTHER_Handler            ( void );
+void EIC_0_Handler                 ( void );
+void EIC_1_Handler                 ( void );
+void EIC_2_Handler                 ( void );
+void EIC_3_Handler                 ( void );
+void EIC_OTHER_Handler             ( void );
+void EVSYS_0_Handler               ( void );
+void EVSYS_1_Handler               ( void );
+void EVSYS_2_Handler               ( void );
+void EVSYS_3_Handler               ( void );
+void EVSYS_NSCHK_Handler           ( void );
+void FREQM_Handler                 ( void );
+void NVMCTRL_Handler               ( void );
+void PAC_Handler                   ( void );
+void PORT_Handler                  ( void );
+void PTC_Handler                   ( void );
+void RTC_Handler                   ( void );
+void SERCOM0_0_Handler             ( void );
+void SERCOM0_1_Handler             ( void );
+void SERCOM0_2_Handler             ( void );
+void SERCOM0_OTHER_Handler         ( void );
+void SERCOM1_0_Handler             ( void );
+void SERCOM1_1_Handler             ( void );
+void SERCOM1_2_Handler             ( void );
+void SERCOM1_OTHER_Handler         ( void );
+void SYSTEM_Handler                ( void );
+void TC0_Handler                   ( void );
+void TC1_Handler                   ( void );
+void TC2_Handler                   ( void );
+void TRAM_Handler                  ( void );
+void TRNG_Handler                  ( void );
+void WDT_Handler                   ( void );
+#endif /* DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS */
+
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define MemManage_Handler         MemoryManagement_Handler        /**< \deprecated  Backward compatibility for ASF */
+#define DebugMon_Handler          DebugMonitor_Handler            /**< \deprecated  Backward compatibility for ASF */
+#define NMI_Handler               NonMaskableInt_Handler          /**< \deprecated  Backward compatibility for ASF */
+#define SVC_Handler               SVCall_Handler                  /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+
+/*
+ * \brief Configuration of the CORTEX-M23 Processor and Core Peripherals
+ */
+
+#define NUM_IRQ                       45 /**< Number of interrupt request lines                                         */
+#define __ARMv8MBL_REV            0x0000 /**< Cortex-M23 Core Revision                                                  */
+#define __ETM_PRESENT                  0 /**< ETM present or not                                                        */
+#define __FPU_PRESENT                  0 /**< FPU present or not                                                        */
+#define __MPU_PRESENT                  1 /**< MPU present or not                                                        */
+#define __MTB_PRESENT                  0 /**< MTB present or not                                                        */
+#define __NVIC_PRIO_BITS               2 /**< Number of Bits used for Priority Levels                                   */
+#define __SAU_PRESENT                  0 /**< SAU present or not                                                        */
+#define __SEC_ENABLED                  0 /**< TrustZone-M enabled or not                                                */
+#define __VTOR_PRESENT                 1 /**< Vector Table Offset Register present or not                               */
+#define __Vendor_SysTickConfig         0 /**< Set to 1 if different SysTick Config is used                              */
+#define __ARCH_ARM                     1
+#define __ARCH_ARM_CORTEX_M            1
+#define __DEVICE_IS_SAM                1
+#define __TZ_PRESENT                   1
+
+/*
+ * \brief CMSIS includes
+ */
+#include <core_cm23.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_saml11.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/** @}  end of SAML11D15A_cmsis CMSIS Definitions */
+
+/** \defgroup SAML11D15A_api Peripheral Software API
+ *  @{
+ */
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAML11D15A */
+/* ************************************************************************** */
+#include "component/ac.h"
+#include "component/adc.h"
+#include "component/ccl.h"
+#include "component/dac.h"
+#include "component/dmac.h"
+#include "component/dsu.h"
+#include "component/eic.h"
+#include "component/evsys.h"
+#include "component/freqm.h"
+#include "component/gclk.h"
+#include "component/idau.h"
+#include "component/mclk.h"
+#include "component/nvmctrl.h"
+#include "component/opamp.h"
+#include "component/oscctrl.h"
+#include "component/osc32kctrl.h"
+#include "component/pac.h"
+#include "component/pm.h"
+#include "component/port.h"
+#include "component/ptc.h"
+#include "component/rstc.h"
+#include "component/rtc.h"
+#include "component/sercom.h"
+#include "component/supc.h"
+#include "component/tc.h"
+#include "component/tram.h"
+#include "component/trng.h"
+#include "component/wdt.h"
+/** @}  end of Peripheral Software API */
+
+/** \defgroup SAML11D15A_reg Registers Access Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   REGISTER ACCESS DEFINITIONS FOR SAML11D15A */
+/* ************************************************************************** */
+#include "instance/ac.h"
+#include "instance/adc.h"
+#include "instance/ccl.h"
+#include "instance/dac.h"
+#include "instance/dmac.h"
+#include "instance/dsu.h"
+#include "instance/eic.h"
+#include "instance/evsys.h"
+#include "instance/freqm.h"
+#include "instance/gclk.h"
+#include "instance/idau.h"
+#include "instance/mclk.h"
+#include "instance/nvmctrl.h"
+#include "instance/opamp.h"
+#include "instance/oscctrl.h"
+#include "instance/osc32kctrl.h"
+#include "instance/pac.h"
+#include "instance/pm.h"
+#include "instance/port.h"
+#include "instance/ptc.h"
+#include "instance/rstc.h"
+#include "instance/rtc.h"
+#include "instance/sercom0.h"
+#include "instance/sercom1.h"
+#include "instance/supc.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tram.h"
+#include "instance/trng.h"
+#include "instance/wdt.h"
+/** @}  end of Registers Access Definitions */
+
+/** \addtogroup SAML11D15A_id Peripheral Ids Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*  PERIPHERAL ID DEFINITIONS FOR SAML11D15A */
+/* ************************************************************************** */
+#define ID_PAC          (  0) /**< \brief Peripheral Access Controller (PAC) */
+#define ID_PM           (  1) /**< \brief Power Manager (PM) */
+#define ID_MCLK         (  2) /**< \brief Main Clock (MCLK) */
+#define ID_RSTC         (  3) /**< \brief Reset Controller (RSTC) */
+#define ID_OSCCTRL      (  4) /**< \brief Oscillators Control (OSCCTRL) */
+#define ID_OSC32KCTRL   (  5) /**< \brief 32k Oscillators Control (OSC32KCTRL) */
+#define ID_SUPC         (  6) /**< \brief Supply Controller (SUPC) */
+#define ID_GCLK         (  7) /**< \brief Generic Clock Generator (GCLK) */
+#define ID_WDT          (  8) /**< \brief Watchdog Timer (WDT) */
+#define ID_RTC          (  9) /**< \brief Real-Time Counter (RTC) */
+#define ID_EIC          ( 10) /**< \brief External Interrupt Controller (EIC) */
+#define ID_FREQM        ( 11) /**< \brief Frequency Meter (FREQM) */
+#define ID_PORT         ( 12) /**< \brief Port Module (PORT) */
+#define ID_AC           ( 13) /**< \brief Analog Comparators (AC) */
+#define ID_IDAU         ( 32) /**< \brief Implementation Defined Attribution Unit (IDAU) */
+#define ID_DSU          ( 33) /**< \brief Device Service Unit (DSU) */
+#define ID_NVMCTRL      ( 34) /**< \brief Non-Volatile Memory Controller (NVMCTRL) */
+#define ID_DMAC         ( 35) /**< \brief Direct Memory Access Controller (DMAC) */
+#define ID_EVSYS        ( 64) /**< \brief Event System Interface (EVSYS) */
+#define ID_SERCOM0      ( 65) /**< \brief Serial Communication Interface (SERCOM0) */
+#define ID_SERCOM1      ( 66) /**< \brief Serial Communication Interface (SERCOM1) */
+#define ID_TC0          ( 68) /**< \brief Basic Timer Counter (TC0) */
+#define ID_TC1          ( 69) /**< \brief Basic Timer Counter (TC1) */
+#define ID_TC2          ( 70) /**< \brief Basic Timer Counter (TC2) */
+#define ID_ADC          ( 71) /**< \brief Analog Digital Converter (ADC) */
+#define ID_DAC          ( 72) /**< \brief Digital Analog Converter (DAC) */
+#define ID_PTC          ( 73) /**< \brief Peripheral Touch Controller (PTC) */
+#define ID_TRNG         ( 74) /**< \brief True Random Generator (TRNG) */
+#define ID_CCL          ( 75) /**< \brief Configurable Custom Logic (CCL) */
+#define ID_OPAMP        ( 76) /**< \brief Operational Amplifier (OPAMP) */
+#define ID_TRAM         ( 77) /**< \brief TrustRAM (TRAM) */
+
+#define ID_PERIPH_COUNT ( 78) /**< \brief Number of peripheral IDs */
+/** @}  end of Peripheral Ids Definitions */
+
+/** \addtogroup SAML11D15A_base Peripheral Base Address Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   BASE ADDRESS DEFINITIONS FOR SAML11D15A */
+/* ************************************************************************** */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#define AC                     (0x40003400)                   /**< \brief (AC        ) Base Address */
+#define ADC                    (0x42001C00)                   /**< \brief (ADC       ) Base Address */
+#define CCL                    (0x42002C00)                   /**< \brief (CCL       ) Base Address */
+#define DAC                    (0x42002000)                   /**< \brief (DAC       ) Base Address */
+#define DMAC                   (0x41006000)                   /**< \brief (DMAC      ) Base Address */
+#define DSU                    (0x41002000)                   /**< \brief (DSU       ) Base Address */
+#define DSU_EXT                (0x41002100)                   /**< \brief (DSU       ) Base Address */
+#define EIC                    (0x40002800)                   /**< \brief (EIC       ) Base Address */
+#define EIC_SEC                (0x40002A00)                   /**< \brief (EIC       ) Base Address */
+#define EVSYS                  (0x42000000)                   /**< \brief (EVSYS     ) Base Address */
+#define EVSYS_SEC              (0x42000200)                   /**< \brief (EVSYS     ) Base Address */
+#define FREQM                  (0x40002C00)                   /**< \brief (FREQM     ) Base Address */
+#define GCLK                   (0x40001C00)                   /**< \brief (GCLK      ) Base Address */
+#define IDAU                   (0x41000000)                   /**< \brief (IDAU      ) Base Address */
+#define MCLK                   (0x40000800)                   /**< \brief (MCLK      ) Base Address */
+#define NVMCTRL                (0x41004000)                   /**< \brief (NVMCTRL   ) Base Address */
+#define NVMCTRL_SEC            (0x41005000)                   /**< \brief (NVMCTRL   ) Base Address */
+#define OPAMP                  (0x42003000)                   /**< \brief (OPAMP     ) Base Address */
+#define OSCCTRL                (0x40001000)                   /**< \brief (OSCCTRL   ) Base Address */
+#define OSC32KCTRL             (0x40001400)                   /**< \brief (OSC32KCTRL) Base Address */
+#define PAC                    (0x40000000)                   /**< \brief (PAC       ) Base Address */
+#define PAC_SEC                (0x40000200)                   /**< \brief (PAC       ) Base Address */
+#define PM                     (0x40000400)                   /**< \brief (PM        ) Base Address */
+#define PORT                   (0x40003000)                   /**< \brief (PORT      ) Base Address */
+#define PORT_SEC               (0x40003200)                   /**< \brief (PORT      ) Base Address */
+#define PORT_IOBUS             (0x60000000)                   /**< \brief (PORT      ) Base Address */
+#define PORT_IOBUS_SEC         (0x60000200)                   /**< \brief (PORT      ) Base Address */
+#define PTC                    (0x42002400)                   /**< \brief (PTC       ) Base Address */
+#define RSTC                   (0x40000C00)                   /**< \brief (RSTC      ) Base Address */
+#define RTC                    (0x40002400)                   /**< \brief (RTC       ) Base Address */
+#define SERCOM0                (0x42000400)                   /**< \brief (SERCOM0   ) Base Address */
+#define SERCOM1                (0x42000800)                   /**< \brief (SERCOM1   ) Base Address */
+#define SUPC                   (0x40001800)                   /**< \brief (SUPC      ) Base Address */
+#define TC0                    (0x42001000)                   /**< \brief (TC0       ) Base Address */
+#define TC1                    (0x42001400)                   /**< \brief (TC1       ) Base Address */
+#define TC2                    (0x42001800)                   /**< \brief (TC2       ) Base Address */
+#define TRAM                   (0x42003400)                   /**< \brief (TRAM      ) Base Address */
+#define TRNG                   (0x42002800)                   /**< \brief (TRNG      ) Base Address */
+#define WDT                    (0x40002000)                   /**< \brief (WDT       ) Base Address */
+
+#else /* For C/C++ compiler */
+
+#define AC                     ((Ac *)0x40003400U)            /**< \brief (AC        ) Base Address */
+#define AC_INST_NUM            1                              /**< \brief (AC        ) Number of instances */
+#define AC_INSTS               { AC }                         /**< \brief (AC        ) Instances List */
+
+#define ADC                    ((Adc *)0x42001C00U)           /**< \brief (ADC       ) Base Address */
+#define ADC_INST_NUM           1                              /**< \brief (ADC       ) Number of instances */
+#define ADC_INSTS              { ADC }                        /**< \brief (ADC       ) Instances List */
+
+#define CCL                    ((Ccl *)0x42002C00U)           /**< \brief (CCL       ) Base Address */
+#define CCL_INST_NUM           1                              /**< \brief (CCL       ) Number of instances */
+#define CCL_INSTS              { CCL }                        /**< \brief (CCL       ) Instances List */
+
+#define DAC                    ((Dac *)0x42002000U)           /**< \brief (DAC       ) Base Address */
+#define DAC_INST_NUM           1                              /**< \brief (DAC       ) Number of instances */
+#define DAC_INSTS              { DAC }                        /**< \brief (DAC       ) Instances List */
+
+#define DMAC                   ((Dmac *)0x41006000U)          /**< \brief (DMAC      ) Base Address */
+#define DMAC_INST_NUM          1                              /**< \brief (DMAC      ) Number of instances */
+#define DMAC_INSTS             { DMAC }                       /**< \brief (DMAC      ) Instances List */
+
+#define DSU                    ((Dsu *)0x41002000U)           /**< \brief (DSU       ) Base Address */
+#define DSU_EXT                ((Dsu *)0x41002100U)           /**< \brief (DSU       ) Base Address */
+#define DSU_INST_NUM           1                              /**< \brief (DSU       ) Number of instances */
+#define DSU_INSTS              { DSU }                        /**< \brief (DSU       ) Instances List */
+
+#define EIC                    ((Eic *)0x40002800U)           /**< \brief (EIC       ) Base Address */
+#define EIC_SEC                ((Eic *)0x40002A00U)           /**< \brief (EIC       ) Base Address */
+#define EIC_INST_NUM           1                              /**< \brief (EIC       ) Number of instances */
+#define EIC_INSTS              { EIC }                        /**< \brief (EIC       ) Instances List */
+
+#define EVSYS                  ((Evsys *)0x42000000U)         /**< \brief (EVSYS     ) Base Address */
+#define EVSYS_SEC              ((Evsys *)0x42000200U)         /**< \brief (EVSYS     ) Base Address */
+#define EVSYS_INST_NUM         1                              /**< \brief (EVSYS     ) Number of instances */
+#define EVSYS_INSTS            { EVSYS }                      /**< \brief (EVSYS     ) Instances List */
+
+#define FREQM                  ((Freqm *)0x40002C00U)         /**< \brief (FREQM     ) Base Address */
+#define FREQM_INST_NUM         1                              /**< \brief (FREQM     ) Number of instances */
+#define FREQM_INSTS            { FREQM }                      /**< \brief (FREQM     ) Instances List */
+
+#define GCLK                   ((Gclk *)0x40001C00U)          /**< \brief (GCLK      ) Base Address */
+#define GCLK_INST_NUM          1                              /**< \brief (GCLK      ) Number of instances */
+#define GCLK_INSTS             { GCLK }                       /**< \brief (GCLK      ) Instances List */
+
+#define IDAU                   ((Idau *)0x41000000U)          /**< \brief (IDAU      ) Base Address */
+#define IDAU_INST_NUM          1                              /**< \brief (IDAU      ) Number of instances */
+#define IDAU_INSTS             { IDAU }                       /**< \brief (IDAU      ) Instances List */
+
+#define MCLK                   ((Mclk *)0x40000800U)          /**< \brief (MCLK      ) Base Address */
+#define MCLK_INST_NUM          1                              /**< \brief (MCLK      ) Number of instances */
+#define MCLK_INSTS             { MCLK }                       /**< \brief (MCLK      ) Instances List */
+
+#define NVMCTRL                ((Nvmctrl *)0x41004000U)       /**< \brief (NVMCTRL   ) Base Address */
+#define NVMCTRL_SEC            ((Nvmctrl *)0x41005000U)       /**< \brief (NVMCTRL   ) Base Address */
+#define NVMCTRL_INST_NUM       1                              /**< \brief (NVMCTRL   ) Number of instances */
+#define NVMCTRL_INSTS          { NVMCTRL }                    /**< \brief (NVMCTRL   ) Instances List */
+
+#define OPAMP                  ((Opamp *)0x42003000U)         /**< \brief (OPAMP     ) Base Address */
+#define OPAMP_INST_NUM         1                              /**< \brief (OPAMP     ) Number of instances */
+#define OPAMP_INSTS            { OPAMP }                      /**< \brief (OPAMP     ) Instances List */
+
+#define OSCCTRL                ((Oscctrl *)0x40001000U)       /**< \brief (OSCCTRL   ) Base Address */
+#define OSCCTRL_INST_NUM       1                              /**< \brief (OSCCTRL   ) Number of instances */
+#define OSCCTRL_INSTS          { OSCCTRL }                    /**< \brief (OSCCTRL   ) Instances List */
+
+#define OSC32KCTRL             ((Osc32kctrl *)0x40001400U)    /**< \brief (OSC32KCTRL) Base Address */
+#define OSC32KCTRL_INST_NUM    1                              /**< \brief (OSC32KCTRL) Number of instances */
+#define OSC32KCTRL_INSTS       { OSC32KCTRL }                 /**< \brief (OSC32KCTRL) Instances List */
+
+#define PAC                    ((Pac *)0x40000000U)           /**< \brief (PAC       ) Base Address */
+#define PAC_SEC                ((Pac *)0x40000200U)           /**< \brief (PAC       ) Base Address */
+#define PAC_INST_NUM           1                              /**< \brief (PAC       ) Number of instances */
+#define PAC_INSTS              { PAC }                        /**< \brief (PAC       ) Instances List */
+
+#define PM                     ((Pm *)0x40000400U)            /**< \brief (PM        ) Base Address */
+#define PM_INST_NUM            1                              /**< \brief (PM        ) Number of instances */
+#define PM_INSTS               { PM }                         /**< \brief (PM        ) Instances List */
+
+#define PORT                   ((Port *)0x40003000U)          /**< \brief (PORT      ) Base Address */
+#define PORT_SEC               ((Port *)0x40003200U)          /**< \brief (PORT      ) Base Address */
+#define PORT_IOBUS             ((Port *)0x60000000U)          /**< \brief (PORT      ) Base Address */
+#define PORT_IOBUS_SEC         ((Port *)0x60000200U)          /**< \brief (PORT      ) Base Address */
+#define PORT_INST_NUM          1                              /**< \brief (PORT      ) Number of instances */
+#define PORT_INSTS             { PORT }                       /**< \brief (PORT      ) Instances List */
+
+#define PTC                    ((Ptc *)0x42002400U)           /**< \brief (PTC       ) Base Address */
+#define PTC_INST_NUM           1                              /**< \brief (PTC       ) Number of instances */
+#define PTC_INSTS              { PTC }                        /**< \brief (PTC       ) Instances List */
+
+#define RSTC                   ((Rstc *)0x40000C00U)          /**< \brief (RSTC      ) Base Address */
+#define RSTC_INST_NUM          1                              /**< \brief (RSTC      ) Number of instances */
+#define RSTC_INSTS             { RSTC }                       /**< \brief (RSTC      ) Instances List */
+
+#define RTC                    ((Rtc *)0x40002400U)           /**< \brief (RTC       ) Base Address */
+#define RTC_INST_NUM           1                              /**< \brief (RTC       ) Number of instances */
+#define RTC_INSTS              { RTC }                        /**< \brief (RTC       ) Instances List */
+
+#define SERCOM0                ((Sercom *)0x42000400U)        /**< \brief (SERCOM0   ) Base Address */
+#define SERCOM1                ((Sercom *)0x42000800U)        /**< \brief (SERCOM1   ) Base Address */
+#define SERCOM_INST_NUM        2                              /**< \brief (SERCOM    ) Number of instances */
+#define SERCOM_INSTS           { SERCOM0, SERCOM1 }           /**< \brief (SERCOM    ) Instances List */
+
+#define SUPC                   ((Supc *)0x40001800U)          /**< \brief (SUPC      ) Base Address */
+#define SUPC_INST_NUM          1                              /**< \brief (SUPC      ) Number of instances */
+#define SUPC_INSTS             { SUPC }                       /**< \brief (SUPC      ) Instances List */
+
+#define TC0                    ((Tc *)0x42001000U)            /**< \brief (TC0       ) Base Address */
+#define TC1                    ((Tc *)0x42001400U)            /**< \brief (TC1       ) Base Address */
+#define TC2                    ((Tc *)0x42001800U)            /**< \brief (TC2       ) Base Address */
+#define TC_INST_NUM            3                              /**< \brief (TC        ) Number of instances */
+#define TC_INSTS               { TC0, TC1, TC2 }              /**< \brief (TC        ) Instances List */
+
+#define TRAM                   ((Tram *)0x42003400U)          /**< \brief (TRAM      ) Base Address */
+#define TRAM_INST_NUM          1                              /**< \brief (TRAM      ) Number of instances */
+#define TRAM_INSTS             { TRAM }                       /**< \brief (TRAM      ) Instances List */
+
+#define TRNG                   ((Trng *)0x42002800U)          /**< \brief (TRNG      ) Base Address */
+#define TRNG_INST_NUM          1                              /**< \brief (TRNG      ) Number of instances */
+#define TRNG_INSTS             { TRNG }                       /**< \brief (TRNG      ) Instances List */
+
+#define WDT                    ((Wdt *)0x40002000U)           /**< \brief (WDT       ) Base Address */
+#define WDT_INST_NUM           1                              /**< \brief (WDT       ) Number of instances */
+#define WDT_INSTS              { WDT }                        /**< \brief (WDT       ) Instances List */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Peripheral Base Address Definitions */
+
+/** \addtogroup SAML11D15A_pio Peripheral Pio Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   PIO DEFINITIONS FOR SAML11D15A*/
+/* ************************************************************************** */
+#include "pio/saml11d15a.h"
+/** @}  end of Peripheral Pio Definitions */
+
+/* ************************************************************************** */
+/*   MEMORY MAPPING DEFINITIONS FOR SAML11D15A*/
+/* ************************************************************************** */
+
+#define FLASH_SIZE               _U_(0x00008000)       /*   32kB Memory segment type: flash */
+#define FLASH_PAGE_SIZE          _U_(        64)
+#define FLASH_NB_OF_PAGES        _U_(       512)
+
+#define AUX_SIZE                 _U_(0x00000100)       /*    0kB Memory segment type: fuses */
+#define AUX_PAGE_SIZE            _U_(        64)
+#define AUX_NB_OF_PAGES          _U_(         4)
+
+#define BOCOR_SIZE               _U_(0x00000100)       /*    0kB Memory segment type: fuses */
+#define BOCOR_PAGE_SIZE          _U_(        64)
+#define BOCOR_NB_OF_PAGES        _U_(         4)
+
+#define DATAFLASH_SIZE           _U_(0x00000800)       /*    2kB Memory segment type: flash */
+#define DATAFLASH_PAGE_SIZE      _U_(        64)
+#define DATAFLASH_NB_OF_PAGES    _U_(        32)
+
+#define SW_CALIB_SIZE            _U_(0x00000008)       /*    0kB Memory segment type: fuses */
+#define TEMP_LOG_SIZE            _U_(0x00000008)       /*    0kB Memory segment type: fuses */
+#define USER_PAGE_SIZE           _U_(0x00000100)       /*    0kB Memory segment type: user_page */
+#define USER_PAGE_PAGE_SIZE      _U_(        64)
+#define USER_PAGE_NB_OF_PAGES    _U_(         4)
+
+#define HSRAM_SIZE               _U_(0x00002000)       /*    8kB Memory segment type: ram */
+#define HPB0_SIZE                _U_(0x00008000)       /*   32kB Memory segment type: io */
+#define HPB1_SIZE                _U_(0x00010000)       /*   64kB Memory segment type: io */
+#define HPB2_SIZE                _U_(0x00004000)       /*   16kB Memory segment type: io */
+#define PPB_SIZE                 _U_(0x00100000)       /* 1024kB Memory segment type: io */
+#define SCS_SIZE                 _U_(0x00001000)       /*    4kB Memory segment type: io */
+#define PERIPHERALS_SIZE         _U_(0x20000000)       /* 524288kB Memory segment type: io */
+
+#define FLASH_ADDR               _U_(0x00000000)       /**< FLASH base address (type: flash)*/
+#define AUX_ADDR                 _U_(0x00806000)       /**< AUX base address (type: fuses)*/
+#define BOCOR_ADDR               _U_(0x0080c000)       /**< BOCOR base address (type: fuses)*/
+#define DATAFLASH_ADDR           _U_(0x00400000)       /**< DATAFLASH base address (type: flash)*/
+#define SW_CALIB_ADDR            _U_(0x00806020)       /**< SW_CALIB base address (type: fuses)*/
+#define TEMP_LOG_ADDR            _U_(0x00806038)       /**< TEMP_LOG base address (type: fuses)*/
+#define USER_PAGE_ADDR           _U_(0x00804000)       /**< USER_PAGE base address (type: user_page)*/
+#define HSRAM_ADDR               _U_(0x20000000)       /**< HSRAM base address (type: ram)*/
+#define HPB0_ADDR                _U_(0x40000000)       /**< HPB0 base address (type: io)*/
+#define HPB1_ADDR                _U_(0x41000000)       /**< HPB1 base address (type: io)*/
+#define HPB2_ADDR                _U_(0x42000000)       /**< HPB2 base address (type: io)*/
+#define PPB_ADDR                 _U_(0xe0000000)       /**< PPB base address (type: io)*/
+#define SCS_ADDR                 _U_(0xe000e000)       /**< SCS base address (type: io)*/
+#define PERIPHERALS_ADDR         _U_(0x40000000)       /**< PERIPHERALS base address (type: io)*/
+
+#define NVMCTRL_AUX              AUX_ADDR              /**< \brief \deprecated Old style definition. Use AUX_ADDR instead */
+#define NVMCTRL_BOCOR            BOCOR_ADDR            /**< \brief \deprecated Old style definition. Use BOCOR_ADDR instead */
+#define NVMCTRL_DATAFLASH        DATAFLASH_ADDR        /**< \brief \deprecated Old style definition. Use DATAFLASH_ADDR instead */
+#define NVMCTRL_SW_CALIB         SW_CALIB_ADDR         /**< \brief \deprecated Old style definition. Use SW_CALIB_ADDR instead */
+#define NVMCTRL_TEMP_LOG         TEMP_LOG_ADDR         /**< \brief \deprecated Old style definition. Use TEMP_LOG_ADDR instead */
+#define NVMCTRL_USER             USER_PAGE_ADDR        /**< \brief \deprecated Old style definition. Use USER_PAGE_ADDR instead */
+
+/* ************************************************************************** */
+/**  DEVICE SIGNATURES FOR SAML11D15A */
+/* ************************************************************************** */
+#define DSU_DID                  _UL_(0X20830004)
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAML11D15A */
+/* ************************************************************************** */
+
+/* ************************************************************************** */
+/** Event Generator IDs for SAML11D15A */
+/* ************************************************************************** */
+#define EVENT_ID_GEN_OSCCTRL_XOSC_FAIL                    1 /**< ID for OSCCTRL event generator XOSC_FAIL */
+#define EVENT_ID_GEN_OSC32KCTRL_XOSC32K_FAIL              2 /**< ID for OSC32KCTRL event generator XOSC32K_FAIL */
+#define EVENT_ID_GEN_SUPC_BOD33DET                        3 /**< ID for SUPC event generator BOD33DET */
+#define EVENT_ID_GEN_RTC_PER_0                            4 /**< ID for RTC event generator PER_0 */
+#define EVENT_ID_GEN_RTC_PER_1                            5 /**< ID for RTC event generator PER_1 */
+#define EVENT_ID_GEN_RTC_PER_2                            6 /**< ID for RTC event generator PER_2 */
+#define EVENT_ID_GEN_RTC_PER_3                            7 /**< ID for RTC event generator PER_3 */
+#define EVENT_ID_GEN_RTC_PER_4                            8 /**< ID for RTC event generator PER_4 */
+#define EVENT_ID_GEN_RTC_PER_5                            9 /**< ID for RTC event generator PER_5 */
+#define EVENT_ID_GEN_RTC_PER_6                           10 /**< ID for RTC event generator PER_6 */
+#define EVENT_ID_GEN_RTC_PER_7                           11 /**< ID for RTC event generator PER_7 */
+#define EVENT_ID_GEN_RTC_CMP_0                           12 /**< ID for RTC event generator CMP_0 */
+#define EVENT_ID_GEN_RTC_CMP_1                           13 /**< ID for RTC event generator CMP_1 */
+#define EVENT_ID_GEN_RTC_TAMPER                          14 /**< ID for RTC event generator TAMPER */
+#define EVENT_ID_GEN_RTC_OVF                             15 /**< ID for RTC event generator OVF */
+#define EVENT_ID_GEN_RTC_PERD                            16 /**< ID for RTC event generator PERD */
+#define EVENT_ID_GEN_EIC_EXTINT_0                        17 /**< ID for EIC event generator EXTINT_0 */
+#define EVENT_ID_GEN_EIC_EXTINT_1                        18 /**< ID for EIC event generator EXTINT_1 */
+#define EVENT_ID_GEN_EIC_EXTINT_2                        19 /**< ID for EIC event generator EXTINT_2 */
+#define EVENT_ID_GEN_EIC_EXTINT_3                        20 /**< ID for EIC event generator EXTINT_3 */
+#define EVENT_ID_GEN_EIC_EXTINT_4                        21 /**< ID for EIC event generator EXTINT_4 */
+#define EVENT_ID_GEN_EIC_EXTINT_5                        22 /**< ID for EIC event generator EXTINT_5 */
+#define EVENT_ID_GEN_EIC_EXTINT_6                        23 /**< ID for EIC event generator EXTINT_6 */
+#define EVENT_ID_GEN_EIC_EXTINT_7                        24 /**< ID for EIC event generator EXTINT_7 */
+#define EVENT_ID_GEN_DMAC_CH_0                           25 /**< ID for DMAC event generator CH_0 */
+#define EVENT_ID_GEN_DMAC_CH_1                           26 /**< ID for DMAC event generator CH_1 */
+#define EVENT_ID_GEN_DMAC_CH_2                           27 /**< ID for DMAC event generator CH_2 */
+#define EVENT_ID_GEN_DMAC_CH_3                           28 /**< ID for DMAC event generator CH_3 */
+#define EVENT_ID_GEN_TC0_OVF                             29 /**< ID for TC0 event generator OVF */
+#define EVENT_ID_GEN_TC0_MCX_0                           30 /**< ID for TC0 event generator MCX_0 */
+#define EVENT_ID_GEN_TC0_MCX_1                           31 /**< ID for TC0 event generator MCX_1 */
+#define EVENT_ID_GEN_TC1_OVF                             32 /**< ID for TC1 event generator OVF */
+#define EVENT_ID_GEN_TC1_MCX_0                           33 /**< ID for TC1 event generator MCX_0 */
+#define EVENT_ID_GEN_TC1_MCX_1                           34 /**< ID for TC1 event generator MCX_1 */
+#define EVENT_ID_GEN_TC2_OVF                             35 /**< ID for TC2 event generator OVF */
+#define EVENT_ID_GEN_TC2_MCX_0                           36 /**< ID for TC2 event generator MCX_0 */
+#define EVENT_ID_GEN_TC2_MCX_1                           37 /**< ID for TC2 event generator MCX_1 */
+#define EVENT_ID_GEN_ADC_RESRDY                          38 /**< ID for ADC event generator RESRDY */
+#define EVENT_ID_GEN_ADC_WINMON                          39 /**< ID for ADC event generator WINMON */
+#define EVENT_ID_GEN_AC_COMP_0                           40 /**< ID for AC event generator COMP_0 */
+#define EVENT_ID_GEN_AC_COMP_1                           41 /**< ID for AC event generator COMP_1 */
+#define EVENT_ID_GEN_AC_WIN_0                            42 /**< ID for AC event generator WIN_0 */
+#define EVENT_ID_GEN_DAC_EMPTY                           43 /**< ID for DAC event generator EMPTY */
+#define EVENT_ID_GEN_TRNG_READY                          46 /**< ID for TRNG event generator READY */
+#define EVENT_ID_GEN_CCL_LUTOUT_0                        47 /**< ID for CCL event generator LUTOUT_0 */
+#define EVENT_ID_GEN_CCL_LUTOUT_1                        48 /**< ID for CCL event generator LUTOUT_1 */
+#define EVENT_ID_GEN_PAC_ERR                             49 /**< ID for PAC event generator ERR */
+
+/* ************************************************************************** */
+/** Event User IDs for SAML11D15A */
+/* ************************************************************************** */
+#define EVENT_ID_USER_OSCCTRL_TUNE                        0 /**< ID for OSCCTRL event user TUNE */
+#define EVENT_ID_USER_RTC_TAMPER                          1 /**< ID for RTC event user TAMPER */
+#define EVENT_ID_USER_NVMCTRL_PAGEW                       2 /**< ID for NVMCTRL event user PAGEW */
+#define EVENT_ID_USER_PORT_EV_0                           3 /**< ID for PORT event user EV_0 */
+#define EVENT_ID_USER_PORT_EV_1                           4 /**< ID for PORT event user EV_1 */
+#define EVENT_ID_USER_PORT_EV_2                           5 /**< ID for PORT event user EV_2 */
+#define EVENT_ID_USER_PORT_EV_3                           6 /**< ID for PORT event user EV_3 */
+#define EVENT_ID_USER_DMAC_CH_0                           7 /**< ID for DMAC event user CH_0 */
+#define EVENT_ID_USER_DMAC_CH_1                           8 /**< ID for DMAC event user CH_1 */
+#define EVENT_ID_USER_DMAC_CH_2                           9 /**< ID for DMAC event user CH_2 */
+#define EVENT_ID_USER_DMAC_CH_3                          10 /**< ID for DMAC event user CH_3 */
+#define EVENT_ID_USER_TC0_EVU                            11 /**< ID for TC0 event user EVU */
+#define EVENT_ID_USER_TC1_EVU                            12 /**< ID for TC1 event user EVU */
+#define EVENT_ID_USER_TC2_EVU                            13 /**< ID for TC2 event user EVU */
+#define EVENT_ID_USER_ADC_START                          14 /**< ID for ADC event user START */
+#define EVENT_ID_USER_ADC_SYNC                           15 /**< ID for ADC event user SYNC */
+#define EVENT_ID_USER_AC_SOC_0                           16 /**< ID for AC event user SOC_0 */
+#define EVENT_ID_USER_AC_SOC_1                           17 /**< ID for AC event user SOC_1 */
+#define EVENT_ID_USER_DAC_START                          18 /**< ID for DAC event user START */
+#define EVENT_ID_USER_CCL_LUTIN_0                        21 /**< ID for CCL event user LUTIN_0 */
+#define EVENT_ID_USER_CCL_LUTIN_1                        22 /**< ID for CCL event user LUTIN_1 */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @}  end of SAML11D15A definitions */
+
+
+#endif /* _SAML11D15A_H_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/saml11d16a.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/saml11d16a.h
@@ -1,0 +1,802 @@
+/**
+ * \file
+ *
+ * \brief Header file for ATSAML11D16A
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11D16A_H_
+#define _SAML11D16A_H_
+
+/** \addtogroup SAML11D16A_definitions SAML11D16A definitions
+  This file defines all structures and symbols for SAML11D16A:
+    - registers and bitfields
+    - peripheral base address
+    - peripheral ID
+    - PIO definitions
+ *  @{
+ */
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/** \defgroup Atmel_glob_defs Atmel Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+
+    \remark
+    CMSIS core has a syntax that differs from this using i.e. __I, __O, or __IO followed by 'uint<size>_t' respective types.
+    Default the header files will follow the CMSIS core syntax.
+ *  @{
+ */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+
+/* IO definitions (access restrictions to peripheral registers) */
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+
+#define CAST(type, value) ((type *)(value)) /**< Pointer Type Conversion Macro for C/C++ */
+#define REG_ACCESS(type, address) (*(type*)(address)) /**< C code: Register value */
+#else /* Assembler */
+#define CAST(type, value) (value) /**< Pointer Type Conversion Macro for Assembler */
+#define REG_ACCESS(type, address) (address) /**< Assembly code: Register address */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !defined(SKIP_INTEGER_LITERALS)
+
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x) x ## U    /**< C code: Unsigned integer literal constant value */
+#define _L_(x) x ## L    /**< C code: Long integer literal constant value */
+#define _UL_(x) x ## UL  /**< C code: Unsigned Long integer literal constant value */
+
+#else /* Assembler */
+
+#define _U_(x) x    /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x) x    /**< Assembler: Long integer literal constant value */
+#define _UL_(x) x   /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* SKIP_INTEGER_LITERALS */
+/** @}  end of Atmel Global Defines */
+
+/** \addtogroup SAML11D16A_cmsis CMSIS Definitions
+ *  @{
+ */
+/* ************************************************************************** */
+/*   CMSIS DEFINITIONS FOR SAML11D16A */
+/* ************************************************************************** */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+/******  CORTEX-M23 Processor Exceptions Numbers ******************************/
+  Reset_IRQn                = -15, /**< 1   Reset Vector, invoked on Power up and warm reset  */
+  NonMaskableInt_IRQn       = -14, /**< 2   Non maskable Interrupt, cannot be stopped or preempted  */
+  HardFault_IRQn            = -13, /**< 3   Hard Fault, all classes of Fault     */
+  SVCall_IRQn               = -5 , /**< 11  System Service Call via SVC instruction  */
+  PendSV_IRQn               = -2 , /**< 14  Pendable request for system service  */
+  SysTick_IRQn              = -1 , /**< 15  System Tick Timer                    */
+/******  SAML11D16A specific Interrupt Numbers ***********************************/
+  SYSTEM_IRQn               = 0  , /**< 0   SAML11D16A Main Clock (MCLK)        */
+  WDT_IRQn                  = 1  , /**< 1   SAML11D16A Watchdog Timer (WDT)     */
+  RTC_IRQn                  = 2  , /**< 2   SAML11D16A Real-Time Counter (RTC)  */
+  EIC_0_IRQn                = 3  , /**< 3   SAML11D16A External Interrupt Controller (EIC) */
+  EIC_1_IRQn                = 4  , /**< 4   SAML11D16A External Interrupt Controller (EIC) */
+  EIC_2_IRQn                = 5  , /**< 5   SAML11D16A External Interrupt Controller (EIC) */
+  EIC_3_IRQn                = 6  , /**< 6   SAML11D16A External Interrupt Controller (EIC) */
+  EIC_OTHER_IRQn            = 7  , /**< 7   SAML11D16A External Interrupt Controller (EIC) */
+  FREQM_IRQn                = 8  , /**< 8   SAML11D16A Frequency Meter (FREQM)  */
+  NVMCTRL_IRQn              = 9  , /**< 9   SAML11D16A Non-Volatile Memory Controller (NVMCTRL) */
+  PORT_IRQn                 = 10 , /**< 10  SAML11D16A Port Module (PORT)       */
+  DMAC_0_IRQn               = 11 , /**< 11  SAML11D16A Direct Memory Access Controller (DMAC) */
+  DMAC_1_IRQn               = 12 , /**< 12  SAML11D16A Direct Memory Access Controller (DMAC) */
+  DMAC_2_IRQn               = 13 , /**< 13  SAML11D16A Direct Memory Access Controller (DMAC) */
+  DMAC_3_IRQn               = 14 , /**< 14  SAML11D16A Direct Memory Access Controller (DMAC) */
+  DMAC_OTHER_IRQn           = 15 , /**< 15  SAML11D16A Direct Memory Access Controller (DMAC) */
+  EVSYS_0_IRQn              = 16 , /**< 16  SAML11D16A Event System Interface (EVSYS) */
+  EVSYS_1_IRQn              = 17 , /**< 17  SAML11D16A Event System Interface (EVSYS) */
+  EVSYS_2_IRQn              = 18 , /**< 18  SAML11D16A Event System Interface (EVSYS) */
+  EVSYS_3_IRQn              = 19 , /**< 19  SAML11D16A Event System Interface (EVSYS) */
+  EVSYS_NSCHK_IRQn          = 20 , /**< 20  SAML11D16A Event System Interface (EVSYS) */
+  PAC_IRQn                  = 21 , /**< 21  SAML11D16A Peripheral Access Controller (PAC) */
+  SERCOM0_0_IRQn            = 22 , /**< 22  SAML11D16A Serial Communication Interface (SERCOM0) */
+  SERCOM0_1_IRQn            = 23 , /**< 23  SAML11D16A Serial Communication Interface (SERCOM0) */
+  SERCOM0_2_IRQn            = 24 , /**< 24  SAML11D16A Serial Communication Interface (SERCOM0) */
+  SERCOM0_OTHER_IRQn        = 25 , /**< 25  SAML11D16A Serial Communication Interface (SERCOM0) */
+  SERCOM1_0_IRQn            = 26 , /**< 26  SAML11D16A Serial Communication Interface (SERCOM1) */
+  SERCOM1_1_IRQn            = 27 , /**< 27  SAML11D16A Serial Communication Interface (SERCOM1) */
+  SERCOM1_2_IRQn            = 28 , /**< 28  SAML11D16A Serial Communication Interface (SERCOM1) */
+  SERCOM1_OTHER_IRQn        = 29 , /**< 29  SAML11D16A Serial Communication Interface (SERCOM1) */
+  TC0_IRQn                  = 34 , /**< 34  SAML11D16A Basic Timer Counter (TC0) */
+  TC1_IRQn                  = 35 , /**< 35  SAML11D16A Basic Timer Counter (TC1) */
+  TC2_IRQn                  = 36 , /**< 36  SAML11D16A Basic Timer Counter (TC2) */
+  ADC_OTHER_IRQn            = 37 , /**< 37  SAML11D16A Analog Digital Converter (ADC) */
+  ADC_RESRDY_IRQn           = 38 , /**< 38  SAML11D16A Analog Digital Converter (ADC) */
+  AC_IRQn                   = 39 , /**< 39  SAML11D16A Analog Comparators (AC)  */
+  DAC_UNDERRUN_A_IRQn       = 40 , /**< 40  SAML11D16A Digital Analog Converter (DAC) */
+  DAC_EMPTY_IRQn            = 41 , /**< 41  SAML11D16A Digital Analog Converter (DAC) */
+  PTC_IRQn                  = 42 , /**< 42  SAML11D16A Peripheral Touch Controller (PTC) */
+  TRNG_IRQn                 = 43 , /**< 43  SAML11D16A True Random Generator (TRNG) */
+  TRAM_IRQn                 = 44 , /**< 44  SAML11D16A TrustRAM (TRAM)          */
+
+  PERIPH_COUNT_IRQn        = 45  /**< Number of peripheral IDs */
+} IRQn_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;                        /* -15 Reset Vector, invoked on Power up and warm reset  */
+  void* pfnNonMaskableInt_Handler;               /* -14 Non maskable Interrupt, cannot be stopped or preempted  */
+  void* pfnHardFault_Handler;                    /* -13 Hard Fault, all classes of Fault     */
+  void* pvReservedC12;
+  void* pvReservedC11;
+  void* pvReservedC10;
+  void* pvReservedC9;
+  void* pvReservedC8;
+  void* pvReservedC7;
+  void* pvReservedC6;
+  void* pfnSVCall_Handler;                       /*  -5 System Service Call via SVC instruction  */
+  void* pvReservedC4;
+  void* pvReservedC3;
+  void* pfnPendSV_Handler;                       /*  -2 Pendable request for system service  */
+  void* pfnSysTick_Handler;                      /*  -1 System Tick Timer                    */
+
+
+  /* Peripheral handlers */
+  void* pfnSYSTEM_Handler;                       /* 0   SAML11D16A Main Clock (MCLK)   */
+  void* pfnWDT_Handler;                          /* 1   SAML11D16A Watchdog Timer (WDT) */
+  void* pfnRTC_Handler;                          /* 2   SAML11D16A Real-Time Counter (RTC) */
+  void* pfnEIC_0_Handler;                        /* 3   SAML11D16A External Interrupt Controller (EIC) */
+  void* pfnEIC_1_Handler;                        /* 4   SAML11D16A External Interrupt Controller (EIC) */
+  void* pfnEIC_2_Handler;                        /* 5   SAML11D16A External Interrupt Controller (EIC) */
+  void* pfnEIC_3_Handler;                        /* 6   SAML11D16A External Interrupt Controller (EIC) */
+  void* pfnEIC_OTHER_Handler;                    /* 7   SAML11D16A External Interrupt Controller (EIC) */
+  void* pfnFREQM_Handler;                        /* 8   SAML11D16A Frequency Meter (FREQM) */
+  void* pfnNVMCTRL_Handler;                      /* 9   SAML11D16A Non-Volatile Memory Controller (NVMCTRL) */
+  void* pfnPORT_Handler;                         /* 10  SAML11D16A Port Module (PORT)  */
+  void* pfnDMAC_0_Handler;                       /* 11  SAML11D16A Direct Memory Access Controller (DMAC) */
+  void* pfnDMAC_1_Handler;                       /* 12  SAML11D16A Direct Memory Access Controller (DMAC) */
+  void* pfnDMAC_2_Handler;                       /* 13  SAML11D16A Direct Memory Access Controller (DMAC) */
+  void* pfnDMAC_3_Handler;                       /* 14  SAML11D16A Direct Memory Access Controller (DMAC) */
+  void* pfnDMAC_OTHER_Handler;                   /* 15  SAML11D16A Direct Memory Access Controller (DMAC) */
+  void* pfnEVSYS_0_Handler;                      /* 16  SAML11D16A Event System Interface (EVSYS) */
+  void* pfnEVSYS_1_Handler;                      /* 17  SAML11D16A Event System Interface (EVSYS) */
+  void* pfnEVSYS_2_Handler;                      /* 18  SAML11D16A Event System Interface (EVSYS) */
+  void* pfnEVSYS_3_Handler;                      /* 19  SAML11D16A Event System Interface (EVSYS) */
+  void* pfnEVSYS_NSCHK_Handler;                  /* 20  SAML11D16A Event System Interface (EVSYS) */
+  void* pfnPAC_Handler;                          /* 21  SAML11D16A Peripheral Access Controller (PAC) */
+  void* pfnSERCOM0_0_Handler;                    /* 22  SAML11D16A Serial Communication Interface (SERCOM0) */
+  void* pfnSERCOM0_1_Handler;                    /* 23  SAML11D16A Serial Communication Interface (SERCOM0) */
+  void* pfnSERCOM0_2_Handler;                    /* 24  SAML11D16A Serial Communication Interface (SERCOM0) */
+  void* pfnSERCOM0_OTHER_Handler;                /* 25  SAML11D16A Serial Communication Interface (SERCOM0) */
+  void* pfnSERCOM1_0_Handler;                    /* 26  SAML11D16A Serial Communication Interface (SERCOM1) */
+  void* pfnSERCOM1_1_Handler;                    /* 27  SAML11D16A Serial Communication Interface (SERCOM1) */
+  void* pfnSERCOM1_2_Handler;                    /* 28  SAML11D16A Serial Communication Interface (SERCOM1) */
+  void* pfnSERCOM1_OTHER_Handler;                /* 29  SAML11D16A Serial Communication Interface (SERCOM1) */
+  void* pvReserved30;
+  void* pvReserved31;
+  void* pvReserved32;
+  void* pvReserved33;
+  void* pfnTC0_Handler;                          /* 34  SAML11D16A Basic Timer Counter (TC0) */
+  void* pfnTC1_Handler;                          /* 35  SAML11D16A Basic Timer Counter (TC1) */
+  void* pfnTC2_Handler;                          /* 36  SAML11D16A Basic Timer Counter (TC2) */
+  void* pfnADC_OTHER_Handler;                    /* 37  SAML11D16A Analog Digital Converter (ADC) */
+  void* pfnADC_RESRDY_Handler;                   /* 38  SAML11D16A Analog Digital Converter (ADC) */
+  void* pfnAC_Handler;                           /* 39  SAML11D16A Analog Comparators (AC) */
+  void* pfnDAC_UNDERRUN_A_Handler;               /* 40  SAML11D16A Digital Analog Converter (DAC) */
+  void* pfnDAC_EMPTY_Handler;                    /* 41  SAML11D16A Digital Analog Converter (DAC) */
+  void* pfnPTC_Handler;                          /* 42  SAML11D16A Peripheral Touch Controller (PTC) */
+  void* pfnTRNG_Handler;                         /* 43  SAML11D16A True Random Generator (TRNG) */
+  void* pfnTRAM_Handler;                         /* 44  SAML11D16A TrustRAM (TRAM)     */
+} DeviceVectors;
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define pfnMemManage_Handler      pfnMemoryManagement_Handler     /**< \deprecated  Backward compatibility for ASF */
+#define pfnDebugMon_Handler       pfnDebugMonitor_Handler         /**< \deprecated  Backward compatibility for ASF */
+#define pfnNMI_Handler            pfnNonMaskableInt_Handler       /**< \deprecated  Backward compatibility for ASF */
+#define pfnSVC_Handler            pfnSVCall_Handler               /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if !defined DONT_USE_PREDEFINED_CORE_HANDLERS
+
+/* CORTEX-M23 core handlers */
+void Reset_Handler                 ( void );
+void NonMaskableInt_Handler        ( void );
+void HardFault_Handler             ( void );
+void SVCall_Handler                ( void );
+void PendSV_Handler                ( void );
+void SysTick_Handler               ( void );
+#endif /* DONT_USE_PREDEFINED_CORE_HANDLERS */
+
+#if !defined DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS
+
+/* Peripherals handlers */
+void AC_Handler                    ( void );
+void ADC_OTHER_Handler             ( void );
+void ADC_RESRDY_Handler            ( void );
+void DAC_EMPTY_Handler             ( void );
+void DAC_UNDERRUN_A_Handler        ( void );
+void DMAC_0_Handler                ( void );
+void DMAC_1_Handler                ( void );
+void DMAC_2_Handler                ( void );
+void DMAC_3_Handler                ( void );
+void DMAC_OTHER_Handler            ( void );
+void EIC_0_Handler                 ( void );
+void EIC_1_Handler                 ( void );
+void EIC_2_Handler                 ( void );
+void EIC_3_Handler                 ( void );
+void EIC_OTHER_Handler             ( void );
+void EVSYS_0_Handler               ( void );
+void EVSYS_1_Handler               ( void );
+void EVSYS_2_Handler               ( void );
+void EVSYS_3_Handler               ( void );
+void EVSYS_NSCHK_Handler           ( void );
+void FREQM_Handler                 ( void );
+void NVMCTRL_Handler               ( void );
+void PAC_Handler                   ( void );
+void PORT_Handler                  ( void );
+void PTC_Handler                   ( void );
+void RTC_Handler                   ( void );
+void SERCOM0_0_Handler             ( void );
+void SERCOM0_1_Handler             ( void );
+void SERCOM0_2_Handler             ( void );
+void SERCOM0_OTHER_Handler         ( void );
+void SERCOM1_0_Handler             ( void );
+void SERCOM1_1_Handler             ( void );
+void SERCOM1_2_Handler             ( void );
+void SERCOM1_OTHER_Handler         ( void );
+void SYSTEM_Handler                ( void );
+void TC0_Handler                   ( void );
+void TC1_Handler                   ( void );
+void TC2_Handler                   ( void );
+void TRAM_Handler                  ( void );
+void TRNG_Handler                  ( void );
+void WDT_Handler                   ( void );
+#endif /* DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS */
+
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define MemManage_Handler         MemoryManagement_Handler        /**< \deprecated  Backward compatibility for ASF */
+#define DebugMon_Handler          DebugMonitor_Handler            /**< \deprecated  Backward compatibility for ASF */
+#define NMI_Handler               NonMaskableInt_Handler          /**< \deprecated  Backward compatibility for ASF */
+#define SVC_Handler               SVCall_Handler                  /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+
+/*
+ * \brief Configuration of the CORTEX-M23 Processor and Core Peripherals
+ */
+
+#define NUM_IRQ                       45 /**< Number of interrupt request lines                                         */
+#define __ARMv8MBL_REV            0x0000 /**< Cortex-M23 Core Revision                                                  */
+#define __ETM_PRESENT                  0 /**< ETM present or not                                                        */
+#define __FPU_PRESENT                  0 /**< FPU present or not                                                        */
+#define __MPU_PRESENT                  1 /**< MPU present or not                                                        */
+#define __MTB_PRESENT                  0 /**< MTB present or not                                                        */
+#define __NVIC_PRIO_BITS               2 /**< Number of Bits used for Priority Levels                                   */
+#define __SAU_PRESENT                  0 /**< SAU present or not                                                        */
+#define __SEC_ENABLED                  0 /**< TrustZone-M enabled or not                                                */
+#define __VTOR_PRESENT                 1 /**< Vector Table Offset Register present or not                               */
+#define __Vendor_SysTickConfig         0 /**< Set to 1 if different SysTick Config is used                              */
+#define __ARCH_ARM                     1
+#define __ARCH_ARM_CORTEX_M            1
+#define __DEVICE_IS_SAM                1
+#define __TZ_PRESENT                   1
+
+/*
+ * \brief CMSIS includes
+ */
+#include <core_cm23.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_saml11.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/** @}  end of SAML11D16A_cmsis CMSIS Definitions */
+
+/** \defgroup SAML11D16A_api Peripheral Software API
+ *  @{
+ */
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAML11D16A */
+/* ************************************************************************** */
+#include "component/ac.h"
+#include "component/adc.h"
+#include "component/ccl.h"
+#include "component/dac.h"
+#include "component/dmac.h"
+#include "component/dsu.h"
+#include "component/eic.h"
+#include "component/evsys.h"
+#include "component/freqm.h"
+#include "component/gclk.h"
+#include "component/idau.h"
+#include "component/mclk.h"
+#include "component/nvmctrl.h"
+#include "component/opamp.h"
+#include "component/oscctrl.h"
+#include "component/osc32kctrl.h"
+#include "component/pac.h"
+#include "component/pm.h"
+#include "component/port.h"
+#include "component/ptc.h"
+#include "component/rstc.h"
+#include "component/rtc.h"
+#include "component/sercom.h"
+#include "component/supc.h"
+#include "component/tc.h"
+#include "component/tram.h"
+#include "component/trng.h"
+#include "component/wdt.h"
+/** @}  end of Peripheral Software API */
+
+/** \defgroup SAML11D16A_reg Registers Access Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   REGISTER ACCESS DEFINITIONS FOR SAML11D16A */
+/* ************************************************************************** */
+#include "instance/ac.h"
+#include "instance/adc.h"
+#include "instance/ccl.h"
+#include "instance/dac.h"
+#include "instance/dmac.h"
+#include "instance/dsu.h"
+#include "instance/eic.h"
+#include "instance/evsys.h"
+#include "instance/freqm.h"
+#include "instance/gclk.h"
+#include "instance/idau.h"
+#include "instance/mclk.h"
+#include "instance/nvmctrl.h"
+#include "instance/opamp.h"
+#include "instance/oscctrl.h"
+#include "instance/osc32kctrl.h"
+#include "instance/pac.h"
+#include "instance/pm.h"
+#include "instance/port.h"
+#include "instance/ptc.h"
+#include "instance/rstc.h"
+#include "instance/rtc.h"
+#include "instance/sercom0.h"
+#include "instance/sercom1.h"
+#include "instance/supc.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tram.h"
+#include "instance/trng.h"
+#include "instance/wdt.h"
+/** @}  end of Registers Access Definitions */
+
+/** \addtogroup SAML11D16A_id Peripheral Ids Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*  PERIPHERAL ID DEFINITIONS FOR SAML11D16A */
+/* ************************************************************************** */
+#define ID_PAC          (  0) /**< \brief Peripheral Access Controller (PAC) */
+#define ID_PM           (  1) /**< \brief Power Manager (PM) */
+#define ID_MCLK         (  2) /**< \brief Main Clock (MCLK) */
+#define ID_RSTC         (  3) /**< \brief Reset Controller (RSTC) */
+#define ID_OSCCTRL      (  4) /**< \brief Oscillators Control (OSCCTRL) */
+#define ID_OSC32KCTRL   (  5) /**< \brief 32k Oscillators Control (OSC32KCTRL) */
+#define ID_SUPC         (  6) /**< \brief Supply Controller (SUPC) */
+#define ID_GCLK         (  7) /**< \brief Generic Clock Generator (GCLK) */
+#define ID_WDT          (  8) /**< \brief Watchdog Timer (WDT) */
+#define ID_RTC          (  9) /**< \brief Real-Time Counter (RTC) */
+#define ID_EIC          ( 10) /**< \brief External Interrupt Controller (EIC) */
+#define ID_FREQM        ( 11) /**< \brief Frequency Meter (FREQM) */
+#define ID_PORT         ( 12) /**< \brief Port Module (PORT) */
+#define ID_AC           ( 13) /**< \brief Analog Comparators (AC) */
+#define ID_IDAU         ( 32) /**< \brief Implementation Defined Attribution Unit (IDAU) */
+#define ID_DSU          ( 33) /**< \brief Device Service Unit (DSU) */
+#define ID_NVMCTRL      ( 34) /**< \brief Non-Volatile Memory Controller (NVMCTRL) */
+#define ID_DMAC         ( 35) /**< \brief Direct Memory Access Controller (DMAC) */
+#define ID_EVSYS        ( 64) /**< \brief Event System Interface (EVSYS) */
+#define ID_SERCOM0      ( 65) /**< \brief Serial Communication Interface (SERCOM0) */
+#define ID_SERCOM1      ( 66) /**< \brief Serial Communication Interface (SERCOM1) */
+#define ID_TC0          ( 68) /**< \brief Basic Timer Counter (TC0) */
+#define ID_TC1          ( 69) /**< \brief Basic Timer Counter (TC1) */
+#define ID_TC2          ( 70) /**< \brief Basic Timer Counter (TC2) */
+#define ID_ADC          ( 71) /**< \brief Analog Digital Converter (ADC) */
+#define ID_DAC          ( 72) /**< \brief Digital Analog Converter (DAC) */
+#define ID_PTC          ( 73) /**< \brief Peripheral Touch Controller (PTC) */
+#define ID_TRNG         ( 74) /**< \brief True Random Generator (TRNG) */
+#define ID_CCL          ( 75) /**< \brief Configurable Custom Logic (CCL) */
+#define ID_OPAMP        ( 76) /**< \brief Operational Amplifier (OPAMP) */
+#define ID_TRAM         ( 77) /**< \brief TrustRAM (TRAM) */
+
+#define ID_PERIPH_COUNT ( 78) /**< \brief Number of peripheral IDs */
+/** @}  end of Peripheral Ids Definitions */
+
+/** \addtogroup SAML11D16A_base Peripheral Base Address Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   BASE ADDRESS DEFINITIONS FOR SAML11D16A */
+/* ************************************************************************** */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#define AC                     (0x40003400)                   /**< \brief (AC        ) Base Address */
+#define ADC                    (0x42001C00)                   /**< \brief (ADC       ) Base Address */
+#define CCL                    (0x42002C00)                   /**< \brief (CCL       ) Base Address */
+#define DAC                    (0x42002000)                   /**< \brief (DAC       ) Base Address */
+#define DMAC                   (0x41006000)                   /**< \brief (DMAC      ) Base Address */
+#define DSU                    (0x41002000)                   /**< \brief (DSU       ) Base Address */
+#define DSU_EXT                (0x41002100)                   /**< \brief (DSU       ) Base Address */
+#define EIC                    (0x40002800)                   /**< \brief (EIC       ) Base Address */
+#define EIC_SEC                (0x40002A00)                   /**< \brief (EIC       ) Base Address */
+#define EVSYS                  (0x42000000)                   /**< \brief (EVSYS     ) Base Address */
+#define EVSYS_SEC              (0x42000200)                   /**< \brief (EVSYS     ) Base Address */
+#define FREQM                  (0x40002C00)                   /**< \brief (FREQM     ) Base Address */
+#define GCLK                   (0x40001C00)                   /**< \brief (GCLK      ) Base Address */
+#define IDAU                   (0x41000000)                   /**< \brief (IDAU      ) Base Address */
+#define MCLK                   (0x40000800)                   /**< \brief (MCLK      ) Base Address */
+#define NVMCTRL                (0x41004000)                   /**< \brief (NVMCTRL   ) Base Address */
+#define NVMCTRL_SEC            (0x41005000)                   /**< \brief (NVMCTRL   ) Base Address */
+#define OPAMP                  (0x42003000)                   /**< \brief (OPAMP     ) Base Address */
+#define OSCCTRL                (0x40001000)                   /**< \brief (OSCCTRL   ) Base Address */
+#define OSC32KCTRL             (0x40001400)                   /**< \brief (OSC32KCTRL) Base Address */
+#define PAC                    (0x40000000)                   /**< \brief (PAC       ) Base Address */
+#define PAC_SEC                (0x40000200)                   /**< \brief (PAC       ) Base Address */
+#define PM                     (0x40000400)                   /**< \brief (PM        ) Base Address */
+#define PORT                   (0x40003000)                   /**< \brief (PORT      ) Base Address */
+#define PORT_SEC               (0x40003200)                   /**< \brief (PORT      ) Base Address */
+#define PORT_IOBUS             (0x60000000)                   /**< \brief (PORT      ) Base Address */
+#define PORT_IOBUS_SEC         (0x60000200)                   /**< \brief (PORT      ) Base Address */
+#define PTC                    (0x42002400)                   /**< \brief (PTC       ) Base Address */
+#define RSTC                   (0x40000C00)                   /**< \brief (RSTC      ) Base Address */
+#define RTC                    (0x40002400)                   /**< \brief (RTC       ) Base Address */
+#define SERCOM0                (0x42000400)                   /**< \brief (SERCOM0   ) Base Address */
+#define SERCOM1                (0x42000800)                   /**< \brief (SERCOM1   ) Base Address */
+#define SUPC                   (0x40001800)                   /**< \brief (SUPC      ) Base Address */
+#define TC0                    (0x42001000)                   /**< \brief (TC0       ) Base Address */
+#define TC1                    (0x42001400)                   /**< \brief (TC1       ) Base Address */
+#define TC2                    (0x42001800)                   /**< \brief (TC2       ) Base Address */
+#define TRAM                   (0x42003400)                   /**< \brief (TRAM      ) Base Address */
+#define TRNG                   (0x42002800)                   /**< \brief (TRNG      ) Base Address */
+#define WDT                    (0x40002000)                   /**< \brief (WDT       ) Base Address */
+
+#else /* For C/C++ compiler */
+
+#define AC                     ((Ac *)0x40003400U)            /**< \brief (AC        ) Base Address */
+#define AC_INST_NUM            1                              /**< \brief (AC        ) Number of instances */
+#define AC_INSTS               { AC }                         /**< \brief (AC        ) Instances List */
+
+#define ADC                    ((Adc *)0x42001C00U)           /**< \brief (ADC       ) Base Address */
+#define ADC_INST_NUM           1                              /**< \brief (ADC       ) Number of instances */
+#define ADC_INSTS              { ADC }                        /**< \brief (ADC       ) Instances List */
+
+#define CCL                    ((Ccl *)0x42002C00U)           /**< \brief (CCL       ) Base Address */
+#define CCL_INST_NUM           1                              /**< \brief (CCL       ) Number of instances */
+#define CCL_INSTS              { CCL }                        /**< \brief (CCL       ) Instances List */
+
+#define DAC                    ((Dac *)0x42002000U)           /**< \brief (DAC       ) Base Address */
+#define DAC_INST_NUM           1                              /**< \brief (DAC       ) Number of instances */
+#define DAC_INSTS              { DAC }                        /**< \brief (DAC       ) Instances List */
+
+#define DMAC                   ((Dmac *)0x41006000U)          /**< \brief (DMAC      ) Base Address */
+#define DMAC_INST_NUM          1                              /**< \brief (DMAC      ) Number of instances */
+#define DMAC_INSTS             { DMAC }                       /**< \brief (DMAC      ) Instances List */
+
+#define DSU                    ((Dsu *)0x41002000U)           /**< \brief (DSU       ) Base Address */
+#define DSU_EXT                ((Dsu *)0x41002100U)           /**< \brief (DSU       ) Base Address */
+#define DSU_INST_NUM           1                              /**< \brief (DSU       ) Number of instances */
+#define DSU_INSTS              { DSU }                        /**< \brief (DSU       ) Instances List */
+
+#define EIC                    ((Eic *)0x40002800U)           /**< \brief (EIC       ) Base Address */
+#define EIC_SEC                ((Eic *)0x40002A00U)           /**< \brief (EIC       ) Base Address */
+#define EIC_INST_NUM           1                              /**< \brief (EIC       ) Number of instances */
+#define EIC_INSTS              { EIC }                        /**< \brief (EIC       ) Instances List */
+
+#define EVSYS                  ((Evsys *)0x42000000U)         /**< \brief (EVSYS     ) Base Address */
+#define EVSYS_SEC              ((Evsys *)0x42000200U)         /**< \brief (EVSYS     ) Base Address */
+#define EVSYS_INST_NUM         1                              /**< \brief (EVSYS     ) Number of instances */
+#define EVSYS_INSTS            { EVSYS }                      /**< \brief (EVSYS     ) Instances List */
+
+#define FREQM                  ((Freqm *)0x40002C00U)         /**< \brief (FREQM     ) Base Address */
+#define FREQM_INST_NUM         1                              /**< \brief (FREQM     ) Number of instances */
+#define FREQM_INSTS            { FREQM }                      /**< \brief (FREQM     ) Instances List */
+
+#define GCLK                   ((Gclk *)0x40001C00U)          /**< \brief (GCLK      ) Base Address */
+#define GCLK_INST_NUM          1                              /**< \brief (GCLK      ) Number of instances */
+#define GCLK_INSTS             { GCLK }                       /**< \brief (GCLK      ) Instances List */
+
+#define IDAU                   ((Idau *)0x41000000U)          /**< \brief (IDAU      ) Base Address */
+#define IDAU_INST_NUM          1                              /**< \brief (IDAU      ) Number of instances */
+#define IDAU_INSTS             { IDAU }                       /**< \brief (IDAU      ) Instances List */
+
+#define MCLK                   ((Mclk *)0x40000800U)          /**< \brief (MCLK      ) Base Address */
+#define MCLK_INST_NUM          1                              /**< \brief (MCLK      ) Number of instances */
+#define MCLK_INSTS             { MCLK }                       /**< \brief (MCLK      ) Instances List */
+
+#define NVMCTRL                ((Nvmctrl *)0x41004000U)       /**< \brief (NVMCTRL   ) Base Address */
+#define NVMCTRL_SEC            ((Nvmctrl *)0x41005000U)       /**< \brief (NVMCTRL   ) Base Address */
+#define NVMCTRL_INST_NUM       1                              /**< \brief (NVMCTRL   ) Number of instances */
+#define NVMCTRL_INSTS          { NVMCTRL }                    /**< \brief (NVMCTRL   ) Instances List */
+
+#define OPAMP                  ((Opamp *)0x42003000U)         /**< \brief (OPAMP     ) Base Address */
+#define OPAMP_INST_NUM         1                              /**< \brief (OPAMP     ) Number of instances */
+#define OPAMP_INSTS            { OPAMP }                      /**< \brief (OPAMP     ) Instances List */
+
+#define OSCCTRL                ((Oscctrl *)0x40001000U)       /**< \brief (OSCCTRL   ) Base Address */
+#define OSCCTRL_INST_NUM       1                              /**< \brief (OSCCTRL   ) Number of instances */
+#define OSCCTRL_INSTS          { OSCCTRL }                    /**< \brief (OSCCTRL   ) Instances List */
+
+#define OSC32KCTRL             ((Osc32kctrl *)0x40001400U)    /**< \brief (OSC32KCTRL) Base Address */
+#define OSC32KCTRL_INST_NUM    1                              /**< \brief (OSC32KCTRL) Number of instances */
+#define OSC32KCTRL_INSTS       { OSC32KCTRL }                 /**< \brief (OSC32KCTRL) Instances List */
+
+#define PAC                    ((Pac *)0x40000000U)           /**< \brief (PAC       ) Base Address */
+#define PAC_SEC                ((Pac *)0x40000200U)           /**< \brief (PAC       ) Base Address */
+#define PAC_INST_NUM           1                              /**< \brief (PAC       ) Number of instances */
+#define PAC_INSTS              { PAC }                        /**< \brief (PAC       ) Instances List */
+
+#define PM                     ((Pm *)0x40000400U)            /**< \brief (PM        ) Base Address */
+#define PM_INST_NUM            1                              /**< \brief (PM        ) Number of instances */
+#define PM_INSTS               { PM }                         /**< \brief (PM        ) Instances List */
+
+#define PORT                   ((Port *)0x40003000U)          /**< \brief (PORT      ) Base Address */
+#define PORT_SEC               ((Port *)0x40003200U)          /**< \brief (PORT      ) Base Address */
+#define PORT_IOBUS             ((Port *)0x60000000U)          /**< \brief (PORT      ) Base Address */
+#define PORT_IOBUS_SEC         ((Port *)0x60000200U)          /**< \brief (PORT      ) Base Address */
+#define PORT_INST_NUM          1                              /**< \brief (PORT      ) Number of instances */
+#define PORT_INSTS             { PORT }                       /**< \brief (PORT      ) Instances List */
+
+#define PTC                    ((Ptc *)0x42002400U)           /**< \brief (PTC       ) Base Address */
+#define PTC_INST_NUM           1                              /**< \brief (PTC       ) Number of instances */
+#define PTC_INSTS              { PTC }                        /**< \brief (PTC       ) Instances List */
+
+#define RSTC                   ((Rstc *)0x40000C00U)          /**< \brief (RSTC      ) Base Address */
+#define RSTC_INST_NUM          1                              /**< \brief (RSTC      ) Number of instances */
+#define RSTC_INSTS             { RSTC }                       /**< \brief (RSTC      ) Instances List */
+
+#define RTC                    ((Rtc *)0x40002400U)           /**< \brief (RTC       ) Base Address */
+#define RTC_INST_NUM           1                              /**< \brief (RTC       ) Number of instances */
+#define RTC_INSTS              { RTC }                        /**< \brief (RTC       ) Instances List */
+
+#define SERCOM0                ((Sercom *)0x42000400U)        /**< \brief (SERCOM0   ) Base Address */
+#define SERCOM1                ((Sercom *)0x42000800U)        /**< \brief (SERCOM1   ) Base Address */
+#define SERCOM_INST_NUM        2                              /**< \brief (SERCOM    ) Number of instances */
+#define SERCOM_INSTS           { SERCOM0, SERCOM1 }           /**< \brief (SERCOM    ) Instances List */
+
+#define SUPC                   ((Supc *)0x40001800U)          /**< \brief (SUPC      ) Base Address */
+#define SUPC_INST_NUM          1                              /**< \brief (SUPC      ) Number of instances */
+#define SUPC_INSTS             { SUPC }                       /**< \brief (SUPC      ) Instances List */
+
+#define TC0                    ((Tc *)0x42001000U)            /**< \brief (TC0       ) Base Address */
+#define TC1                    ((Tc *)0x42001400U)            /**< \brief (TC1       ) Base Address */
+#define TC2                    ((Tc *)0x42001800U)            /**< \brief (TC2       ) Base Address */
+#define TC_INST_NUM            3                              /**< \brief (TC        ) Number of instances */
+#define TC_INSTS               { TC0, TC1, TC2 }              /**< \brief (TC        ) Instances List */
+
+#define TRAM                   ((Tram *)0x42003400U)          /**< \brief (TRAM      ) Base Address */
+#define TRAM_INST_NUM          1                              /**< \brief (TRAM      ) Number of instances */
+#define TRAM_INSTS             { TRAM }                       /**< \brief (TRAM      ) Instances List */
+
+#define TRNG                   ((Trng *)0x42002800U)          /**< \brief (TRNG      ) Base Address */
+#define TRNG_INST_NUM          1                              /**< \brief (TRNG      ) Number of instances */
+#define TRNG_INSTS             { TRNG }                       /**< \brief (TRNG      ) Instances List */
+
+#define WDT                    ((Wdt *)0x40002000U)           /**< \brief (WDT       ) Base Address */
+#define WDT_INST_NUM           1                              /**< \brief (WDT       ) Number of instances */
+#define WDT_INSTS              { WDT }                        /**< \brief (WDT       ) Instances List */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Peripheral Base Address Definitions */
+
+/** \addtogroup SAML11D16A_pio Peripheral Pio Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   PIO DEFINITIONS FOR SAML11D16A*/
+/* ************************************************************************** */
+#include "pio/saml11d16a.h"
+/** @}  end of Peripheral Pio Definitions */
+
+/* ************************************************************************** */
+/*   MEMORY MAPPING DEFINITIONS FOR SAML11D16A*/
+/* ************************************************************************** */
+
+#define FLASH_SIZE               _U_(0x00010000)       /*   64kB Memory segment type: flash */
+#define FLASH_PAGE_SIZE          _U_(        64)
+#define FLASH_NB_OF_PAGES        _U_(      1024)
+
+#define AUX_SIZE                 _U_(0x00000100)       /*    0kB Memory segment type: fuses */
+#define AUX_PAGE_SIZE            _U_(        64)
+#define AUX_NB_OF_PAGES          _U_(         4)
+
+#define BOCOR_SIZE               _U_(0x00000100)       /*    0kB Memory segment type: fuses */
+#define BOCOR_PAGE_SIZE          _U_(        64)
+#define BOCOR_NB_OF_PAGES        _U_(         4)
+
+#define DATAFLASH_SIZE           _U_(0x00000800)       /*    2kB Memory segment type: flash */
+#define DATAFLASH_PAGE_SIZE      _U_(        64)
+#define DATAFLASH_NB_OF_PAGES    _U_(        32)
+
+#define SW_CALIB_SIZE            _U_(0x00000008)       /*    0kB Memory segment type: fuses */
+#define TEMP_LOG_SIZE            _U_(0x00000008)       /*    0kB Memory segment type: fuses */
+#define USER_PAGE_SIZE           _U_(0x00000100)       /*    0kB Memory segment type: user_page */
+#define USER_PAGE_PAGE_SIZE      _U_(        64)
+#define USER_PAGE_NB_OF_PAGES    _U_(         4)
+
+#define HSRAM_SIZE               _U_(0x00004000)       /*   16kB Memory segment type: ram */
+#define HPB0_SIZE                _U_(0x00008000)       /*   32kB Memory segment type: io */
+#define HPB1_SIZE                _U_(0x00010000)       /*   64kB Memory segment type: io */
+#define HPB2_SIZE                _U_(0x00004000)       /*   16kB Memory segment type: io */
+#define PPB_SIZE                 _U_(0x00100000)       /* 1024kB Memory segment type: io */
+#define SCS_SIZE                 _U_(0x00001000)       /*    4kB Memory segment type: io */
+#define PERIPHERALS_SIZE         _U_(0x20000000)       /* 524288kB Memory segment type: io */
+
+#define FLASH_ADDR               _U_(0x00000000)       /**< FLASH base address (type: flash)*/
+#define AUX_ADDR                 _U_(0x00806000)       /**< AUX base address (type: fuses)*/
+#define BOCOR_ADDR               _U_(0x0080c000)       /**< BOCOR base address (type: fuses)*/
+#define DATAFLASH_ADDR           _U_(0x00400000)       /**< DATAFLASH base address (type: flash)*/
+#define SW_CALIB_ADDR            _U_(0x00806020)       /**< SW_CALIB base address (type: fuses)*/
+#define TEMP_LOG_ADDR            _U_(0x00806038)       /**< TEMP_LOG base address (type: fuses)*/
+#define USER_PAGE_ADDR           _U_(0x00804000)       /**< USER_PAGE base address (type: user_page)*/
+#define HSRAM_ADDR               _U_(0x20000000)       /**< HSRAM base address (type: ram)*/
+#define HPB0_ADDR                _U_(0x40000000)       /**< HPB0 base address (type: io)*/
+#define HPB1_ADDR                _U_(0x41000000)       /**< HPB1 base address (type: io)*/
+#define HPB2_ADDR                _U_(0x42000000)       /**< HPB2 base address (type: io)*/
+#define PPB_ADDR                 _U_(0xe0000000)       /**< PPB base address (type: io)*/
+#define SCS_ADDR                 _U_(0xe000e000)       /**< SCS base address (type: io)*/
+#define PERIPHERALS_ADDR         _U_(0x40000000)       /**< PERIPHERALS base address (type: io)*/
+
+#define NVMCTRL_AUX              AUX_ADDR              /**< \brief \deprecated Old style definition. Use AUX_ADDR instead */
+#define NVMCTRL_BOCOR            BOCOR_ADDR            /**< \brief \deprecated Old style definition. Use BOCOR_ADDR instead */
+#define NVMCTRL_DATAFLASH        DATAFLASH_ADDR        /**< \brief \deprecated Old style definition. Use DATAFLASH_ADDR instead */
+#define NVMCTRL_SW_CALIB         SW_CALIB_ADDR         /**< \brief \deprecated Old style definition. Use SW_CALIB_ADDR instead */
+#define NVMCTRL_TEMP_LOG         TEMP_LOG_ADDR         /**< \brief \deprecated Old style definition. Use TEMP_LOG_ADDR instead */
+#define NVMCTRL_USER             USER_PAGE_ADDR        /**< \brief \deprecated Old style definition. Use USER_PAGE_ADDR instead */
+
+/* ************************************************************************** */
+/**  DEVICE SIGNATURES FOR SAML11D16A */
+/* ************************************************************************** */
+#define DSU_DID                  _UL_(0X20830003)
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAML11D16A */
+/* ************************************************************************** */
+
+/* ************************************************************************** */
+/** Event Generator IDs for SAML11D16A */
+/* ************************************************************************** */
+#define EVENT_ID_GEN_OSCCTRL_XOSC_FAIL                    1 /**< ID for OSCCTRL event generator XOSC_FAIL */
+#define EVENT_ID_GEN_OSC32KCTRL_XOSC32K_FAIL              2 /**< ID for OSC32KCTRL event generator XOSC32K_FAIL */
+#define EVENT_ID_GEN_SUPC_BOD33DET                        3 /**< ID for SUPC event generator BOD33DET */
+#define EVENT_ID_GEN_RTC_PER_0                            4 /**< ID for RTC event generator PER_0 */
+#define EVENT_ID_GEN_RTC_PER_1                            5 /**< ID for RTC event generator PER_1 */
+#define EVENT_ID_GEN_RTC_PER_2                            6 /**< ID for RTC event generator PER_2 */
+#define EVENT_ID_GEN_RTC_PER_3                            7 /**< ID for RTC event generator PER_3 */
+#define EVENT_ID_GEN_RTC_PER_4                            8 /**< ID for RTC event generator PER_4 */
+#define EVENT_ID_GEN_RTC_PER_5                            9 /**< ID for RTC event generator PER_5 */
+#define EVENT_ID_GEN_RTC_PER_6                           10 /**< ID for RTC event generator PER_6 */
+#define EVENT_ID_GEN_RTC_PER_7                           11 /**< ID for RTC event generator PER_7 */
+#define EVENT_ID_GEN_RTC_CMP_0                           12 /**< ID for RTC event generator CMP_0 */
+#define EVENT_ID_GEN_RTC_CMP_1                           13 /**< ID for RTC event generator CMP_1 */
+#define EVENT_ID_GEN_RTC_TAMPER                          14 /**< ID for RTC event generator TAMPER */
+#define EVENT_ID_GEN_RTC_OVF                             15 /**< ID for RTC event generator OVF */
+#define EVENT_ID_GEN_RTC_PERD                            16 /**< ID for RTC event generator PERD */
+#define EVENT_ID_GEN_EIC_EXTINT_0                        17 /**< ID for EIC event generator EXTINT_0 */
+#define EVENT_ID_GEN_EIC_EXTINT_1                        18 /**< ID for EIC event generator EXTINT_1 */
+#define EVENT_ID_GEN_EIC_EXTINT_2                        19 /**< ID for EIC event generator EXTINT_2 */
+#define EVENT_ID_GEN_EIC_EXTINT_3                        20 /**< ID for EIC event generator EXTINT_3 */
+#define EVENT_ID_GEN_EIC_EXTINT_4                        21 /**< ID for EIC event generator EXTINT_4 */
+#define EVENT_ID_GEN_EIC_EXTINT_5                        22 /**< ID for EIC event generator EXTINT_5 */
+#define EVENT_ID_GEN_EIC_EXTINT_6                        23 /**< ID for EIC event generator EXTINT_6 */
+#define EVENT_ID_GEN_EIC_EXTINT_7                        24 /**< ID for EIC event generator EXTINT_7 */
+#define EVENT_ID_GEN_DMAC_CH_0                           25 /**< ID for DMAC event generator CH_0 */
+#define EVENT_ID_GEN_DMAC_CH_1                           26 /**< ID for DMAC event generator CH_1 */
+#define EVENT_ID_GEN_DMAC_CH_2                           27 /**< ID for DMAC event generator CH_2 */
+#define EVENT_ID_GEN_DMAC_CH_3                           28 /**< ID for DMAC event generator CH_3 */
+#define EVENT_ID_GEN_TC0_OVF                             29 /**< ID for TC0 event generator OVF */
+#define EVENT_ID_GEN_TC0_MCX_0                           30 /**< ID for TC0 event generator MCX_0 */
+#define EVENT_ID_GEN_TC0_MCX_1                           31 /**< ID for TC0 event generator MCX_1 */
+#define EVENT_ID_GEN_TC1_OVF                             32 /**< ID for TC1 event generator OVF */
+#define EVENT_ID_GEN_TC1_MCX_0                           33 /**< ID for TC1 event generator MCX_0 */
+#define EVENT_ID_GEN_TC1_MCX_1                           34 /**< ID for TC1 event generator MCX_1 */
+#define EVENT_ID_GEN_TC2_OVF                             35 /**< ID for TC2 event generator OVF */
+#define EVENT_ID_GEN_TC2_MCX_0                           36 /**< ID for TC2 event generator MCX_0 */
+#define EVENT_ID_GEN_TC2_MCX_1                           37 /**< ID for TC2 event generator MCX_1 */
+#define EVENT_ID_GEN_ADC_RESRDY                          38 /**< ID for ADC event generator RESRDY */
+#define EVENT_ID_GEN_ADC_WINMON                          39 /**< ID for ADC event generator WINMON */
+#define EVENT_ID_GEN_AC_COMP_0                           40 /**< ID for AC event generator COMP_0 */
+#define EVENT_ID_GEN_AC_COMP_1                           41 /**< ID for AC event generator COMP_1 */
+#define EVENT_ID_GEN_AC_WIN_0                            42 /**< ID for AC event generator WIN_0 */
+#define EVENT_ID_GEN_DAC_EMPTY                           43 /**< ID for DAC event generator EMPTY */
+#define EVENT_ID_GEN_TRNG_READY                          46 /**< ID for TRNG event generator READY */
+#define EVENT_ID_GEN_CCL_LUTOUT_0                        47 /**< ID for CCL event generator LUTOUT_0 */
+#define EVENT_ID_GEN_CCL_LUTOUT_1                        48 /**< ID for CCL event generator LUTOUT_1 */
+#define EVENT_ID_GEN_PAC_ERR                             49 /**< ID for PAC event generator ERR */
+
+/* ************************************************************************** */
+/** Event User IDs for SAML11D16A */
+/* ************************************************************************** */
+#define EVENT_ID_USER_OSCCTRL_TUNE                        0 /**< ID for OSCCTRL event user TUNE */
+#define EVENT_ID_USER_RTC_TAMPER                          1 /**< ID for RTC event user TAMPER */
+#define EVENT_ID_USER_NVMCTRL_PAGEW                       2 /**< ID for NVMCTRL event user PAGEW */
+#define EVENT_ID_USER_PORT_EV_0                           3 /**< ID for PORT event user EV_0 */
+#define EVENT_ID_USER_PORT_EV_1                           4 /**< ID for PORT event user EV_1 */
+#define EVENT_ID_USER_PORT_EV_2                           5 /**< ID for PORT event user EV_2 */
+#define EVENT_ID_USER_PORT_EV_3                           6 /**< ID for PORT event user EV_3 */
+#define EVENT_ID_USER_DMAC_CH_0                           7 /**< ID for DMAC event user CH_0 */
+#define EVENT_ID_USER_DMAC_CH_1                           8 /**< ID for DMAC event user CH_1 */
+#define EVENT_ID_USER_DMAC_CH_2                           9 /**< ID for DMAC event user CH_2 */
+#define EVENT_ID_USER_DMAC_CH_3                          10 /**< ID for DMAC event user CH_3 */
+#define EVENT_ID_USER_TC0_EVU                            11 /**< ID for TC0 event user EVU */
+#define EVENT_ID_USER_TC1_EVU                            12 /**< ID for TC1 event user EVU */
+#define EVENT_ID_USER_TC2_EVU                            13 /**< ID for TC2 event user EVU */
+#define EVENT_ID_USER_ADC_START                          14 /**< ID for ADC event user START */
+#define EVENT_ID_USER_ADC_SYNC                           15 /**< ID for ADC event user SYNC */
+#define EVENT_ID_USER_AC_SOC_0                           16 /**< ID for AC event user SOC_0 */
+#define EVENT_ID_USER_AC_SOC_1                           17 /**< ID for AC event user SOC_1 */
+#define EVENT_ID_USER_DAC_START                          18 /**< ID for DAC event user START */
+#define EVENT_ID_USER_CCL_LUTIN_0                        21 /**< ID for CCL event user LUTIN_0 */
+#define EVENT_ID_USER_CCL_LUTIN_1                        22 /**< ID for CCL event user LUTIN_1 */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @}  end of SAML11D16A definitions */
+
+
+#endif /* _SAML11D16A_H_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/saml11e14a.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/saml11e14a.h
@@ -1,0 +1,814 @@
+/**
+ * \file
+ *
+ * \brief Header file for ATSAML11E14A
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11E14A_H_
+#define _SAML11E14A_H_
+
+/** \addtogroup SAML11E14A_definitions SAML11E14A definitions
+  This file defines all structures and symbols for SAML11E14A:
+    - registers and bitfields
+    - peripheral base address
+    - peripheral ID
+    - PIO definitions
+ *  @{
+ */
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/** \defgroup Atmel_glob_defs Atmel Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+
+    \remark
+    CMSIS core has a syntax that differs from this using i.e. __I, __O, or __IO followed by 'uint<size>_t' respective types.
+    Default the header files will follow the CMSIS core syntax.
+ *  @{
+ */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+
+/* IO definitions (access restrictions to peripheral registers) */
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+
+#define CAST(type, value) ((type *)(value)) /**< Pointer Type Conversion Macro for C/C++ */
+#define REG_ACCESS(type, address) (*(type*)(address)) /**< C code: Register value */
+#else /* Assembler */
+#define CAST(type, value) (value) /**< Pointer Type Conversion Macro for Assembler */
+#define REG_ACCESS(type, address) (address) /**< Assembly code: Register address */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !defined(SKIP_INTEGER_LITERALS)
+
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x) x ## U    /**< C code: Unsigned integer literal constant value */
+#define _L_(x) x ## L    /**< C code: Long integer literal constant value */
+#define _UL_(x) x ## UL  /**< C code: Unsigned Long integer literal constant value */
+
+#else /* Assembler */
+
+#define _U_(x) x    /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x) x    /**< Assembler: Long integer literal constant value */
+#define _UL_(x) x   /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* SKIP_INTEGER_LITERALS */
+/** @}  end of Atmel Global Defines */
+
+/** \addtogroup SAML11E14A_cmsis CMSIS Definitions
+ *  @{
+ */
+/* ************************************************************************** */
+/*   CMSIS DEFINITIONS FOR SAML11E14A */
+/* ************************************************************************** */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+/******  CORTEX-M23 Processor Exceptions Numbers ******************************/
+  Reset_IRQn                = -15, /**< 1   Reset Vector, invoked on Power up and warm reset  */
+  NonMaskableInt_IRQn       = -14, /**< 2   Non maskable Interrupt, cannot be stopped or preempted  */
+  HardFault_IRQn            = -13, /**< 3   Hard Fault, all classes of Fault     */
+  SVCall_IRQn               = -5 , /**< 11  System Service Call via SVC instruction  */
+  PendSV_IRQn               = -2 , /**< 14  Pendable request for system service  */
+  SysTick_IRQn              = -1 , /**< 15  System Tick Timer                    */
+/******  SAML11E14A specific Interrupt Numbers ***********************************/
+  SYSTEM_IRQn               = 0  , /**< 0   SAML11E14A Main Clock (MCLK)        */
+  WDT_IRQn                  = 1  , /**< 1   SAML11E14A Watchdog Timer (WDT)     */
+  RTC_IRQn                  = 2  , /**< 2   SAML11E14A Real-Time Counter (RTC)  */
+  EIC_0_IRQn                = 3  , /**< 3   SAML11E14A External Interrupt Controller (EIC) */
+  EIC_1_IRQn                = 4  , /**< 4   SAML11E14A External Interrupt Controller (EIC) */
+  EIC_2_IRQn                = 5  , /**< 5   SAML11E14A External Interrupt Controller (EIC) */
+  EIC_3_IRQn                = 6  , /**< 6   SAML11E14A External Interrupt Controller (EIC) */
+  EIC_OTHER_IRQn            = 7  , /**< 7   SAML11E14A External Interrupt Controller (EIC) */
+  FREQM_IRQn                = 8  , /**< 8   SAML11E14A Frequency Meter (FREQM)  */
+  NVMCTRL_IRQn              = 9  , /**< 9   SAML11E14A Non-Volatile Memory Controller (NVMCTRL) */
+  PORT_IRQn                 = 10 , /**< 10  SAML11E14A Port Module (PORT)       */
+  DMAC_0_IRQn               = 11 , /**< 11  SAML11E14A Direct Memory Access Controller (DMAC) */
+  DMAC_1_IRQn               = 12 , /**< 12  SAML11E14A Direct Memory Access Controller (DMAC) */
+  DMAC_2_IRQn               = 13 , /**< 13  SAML11E14A Direct Memory Access Controller (DMAC) */
+  DMAC_3_IRQn               = 14 , /**< 14  SAML11E14A Direct Memory Access Controller (DMAC) */
+  DMAC_OTHER_IRQn           = 15 , /**< 15  SAML11E14A Direct Memory Access Controller (DMAC) */
+  EVSYS_0_IRQn              = 16 , /**< 16  SAML11E14A Event System Interface (EVSYS) */
+  EVSYS_1_IRQn              = 17 , /**< 17  SAML11E14A Event System Interface (EVSYS) */
+  EVSYS_2_IRQn              = 18 , /**< 18  SAML11E14A Event System Interface (EVSYS) */
+  EVSYS_3_IRQn              = 19 , /**< 19  SAML11E14A Event System Interface (EVSYS) */
+  EVSYS_NSCHK_IRQn          = 20 , /**< 20  SAML11E14A Event System Interface (EVSYS) */
+  PAC_IRQn                  = 21 , /**< 21  SAML11E14A Peripheral Access Controller (PAC) */
+  SERCOM0_0_IRQn            = 22 , /**< 22  SAML11E14A Serial Communication Interface (SERCOM0) */
+  SERCOM0_1_IRQn            = 23 , /**< 23  SAML11E14A Serial Communication Interface (SERCOM0) */
+  SERCOM0_2_IRQn            = 24 , /**< 24  SAML11E14A Serial Communication Interface (SERCOM0) */
+  SERCOM0_OTHER_IRQn        = 25 , /**< 25  SAML11E14A Serial Communication Interface (SERCOM0) */
+  SERCOM1_0_IRQn            = 26 , /**< 26  SAML11E14A Serial Communication Interface (SERCOM1) */
+  SERCOM1_1_IRQn            = 27 , /**< 27  SAML11E14A Serial Communication Interface (SERCOM1) */
+  SERCOM1_2_IRQn            = 28 , /**< 28  SAML11E14A Serial Communication Interface (SERCOM1) */
+  SERCOM1_OTHER_IRQn        = 29 , /**< 29  SAML11E14A Serial Communication Interface (SERCOM1) */
+  SERCOM2_0_IRQn            = 30 , /**< 30  SAML11E14A Serial Communication Interface (SERCOM2) */
+  SERCOM2_1_IRQn            = 31 , /**< 31  SAML11E14A Serial Communication Interface (SERCOM2) */
+  SERCOM2_2_IRQn            = 32 , /**< 32  SAML11E14A Serial Communication Interface (SERCOM2) */
+  SERCOM2_OTHER_IRQn        = 33 , /**< 33  SAML11E14A Serial Communication Interface (SERCOM2) */
+  TC0_IRQn                  = 34 , /**< 34  SAML11E14A Basic Timer Counter (TC0) */
+  TC1_IRQn                  = 35 , /**< 35  SAML11E14A Basic Timer Counter (TC1) */
+  TC2_IRQn                  = 36 , /**< 36  SAML11E14A Basic Timer Counter (TC2) */
+  ADC_OTHER_IRQn            = 37 , /**< 37  SAML11E14A Analog Digital Converter (ADC) */
+  ADC_RESRDY_IRQn           = 38 , /**< 38  SAML11E14A Analog Digital Converter (ADC) */
+  AC_IRQn                   = 39 , /**< 39  SAML11E14A Analog Comparators (AC)  */
+  DAC_UNDERRUN_A_IRQn       = 40 , /**< 40  SAML11E14A Digital Analog Converter (DAC) */
+  DAC_EMPTY_IRQn            = 41 , /**< 41  SAML11E14A Digital Analog Converter (DAC) */
+  PTC_IRQn                  = 42 , /**< 42  SAML11E14A Peripheral Touch Controller (PTC) */
+  TRNG_IRQn                 = 43 , /**< 43  SAML11E14A True Random Generator (TRNG) */
+  TRAM_IRQn                 = 44 , /**< 44  SAML11E14A TrustRAM (TRAM)          */
+
+  PERIPH_COUNT_IRQn        = 45  /**< Number of peripheral IDs */
+} IRQn_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;                        /* -15 Reset Vector, invoked on Power up and warm reset  */
+  void* pfnNonMaskableInt_Handler;               /* -14 Non maskable Interrupt, cannot be stopped or preempted  */
+  void* pfnHardFault_Handler;                    /* -13 Hard Fault, all classes of Fault     */
+  void* pvReservedC12;
+  void* pvReservedC11;
+  void* pvReservedC10;
+  void* pvReservedC9;
+  void* pvReservedC8;
+  void* pvReservedC7;
+  void* pvReservedC6;
+  void* pfnSVCall_Handler;                       /*  -5 System Service Call via SVC instruction  */
+  void* pvReservedC4;
+  void* pvReservedC3;
+  void* pfnPendSV_Handler;                       /*  -2 Pendable request for system service  */
+  void* pfnSysTick_Handler;                      /*  -1 System Tick Timer                    */
+
+
+  /* Peripheral handlers */
+  void* pfnSYSTEM_Handler;                       /* 0   SAML11E14A Main Clock (MCLK)   */
+  void* pfnWDT_Handler;                          /* 1   SAML11E14A Watchdog Timer (WDT) */
+  void* pfnRTC_Handler;                          /* 2   SAML11E14A Real-Time Counter (RTC) */
+  void* pfnEIC_0_Handler;                        /* 3   SAML11E14A External Interrupt Controller (EIC) */
+  void* pfnEIC_1_Handler;                        /* 4   SAML11E14A External Interrupt Controller (EIC) */
+  void* pfnEIC_2_Handler;                        /* 5   SAML11E14A External Interrupt Controller (EIC) */
+  void* pfnEIC_3_Handler;                        /* 6   SAML11E14A External Interrupt Controller (EIC) */
+  void* pfnEIC_OTHER_Handler;                    /* 7   SAML11E14A External Interrupt Controller (EIC) */
+  void* pfnFREQM_Handler;                        /* 8   SAML11E14A Frequency Meter (FREQM) */
+  void* pfnNVMCTRL_Handler;                      /* 9   SAML11E14A Non-Volatile Memory Controller (NVMCTRL) */
+  void* pfnPORT_Handler;                         /* 10  SAML11E14A Port Module (PORT)  */
+  void* pfnDMAC_0_Handler;                       /* 11  SAML11E14A Direct Memory Access Controller (DMAC) */
+  void* pfnDMAC_1_Handler;                       /* 12  SAML11E14A Direct Memory Access Controller (DMAC) */
+  void* pfnDMAC_2_Handler;                       /* 13  SAML11E14A Direct Memory Access Controller (DMAC) */
+  void* pfnDMAC_3_Handler;                       /* 14  SAML11E14A Direct Memory Access Controller (DMAC) */
+  void* pfnDMAC_OTHER_Handler;                   /* 15  SAML11E14A Direct Memory Access Controller (DMAC) */
+  void* pfnEVSYS_0_Handler;                      /* 16  SAML11E14A Event System Interface (EVSYS) */
+  void* pfnEVSYS_1_Handler;                      /* 17  SAML11E14A Event System Interface (EVSYS) */
+  void* pfnEVSYS_2_Handler;                      /* 18  SAML11E14A Event System Interface (EVSYS) */
+  void* pfnEVSYS_3_Handler;                      /* 19  SAML11E14A Event System Interface (EVSYS) */
+  void* pfnEVSYS_NSCHK_Handler;                  /* 20  SAML11E14A Event System Interface (EVSYS) */
+  void* pfnPAC_Handler;                          /* 21  SAML11E14A Peripheral Access Controller (PAC) */
+  void* pfnSERCOM0_0_Handler;                    /* 22  SAML11E14A Serial Communication Interface (SERCOM0) */
+  void* pfnSERCOM0_1_Handler;                    /* 23  SAML11E14A Serial Communication Interface (SERCOM0) */
+  void* pfnSERCOM0_2_Handler;                    /* 24  SAML11E14A Serial Communication Interface (SERCOM0) */
+  void* pfnSERCOM0_OTHER_Handler;                /* 25  SAML11E14A Serial Communication Interface (SERCOM0) */
+  void* pfnSERCOM1_0_Handler;                    /* 26  SAML11E14A Serial Communication Interface (SERCOM1) */
+  void* pfnSERCOM1_1_Handler;                    /* 27  SAML11E14A Serial Communication Interface (SERCOM1) */
+  void* pfnSERCOM1_2_Handler;                    /* 28  SAML11E14A Serial Communication Interface (SERCOM1) */
+  void* pfnSERCOM1_OTHER_Handler;                /* 29  SAML11E14A Serial Communication Interface (SERCOM1) */
+  void* pfnSERCOM2_0_Handler;                    /* 30  SAML11E14A Serial Communication Interface (SERCOM2) */
+  void* pfnSERCOM2_1_Handler;                    /* 31  SAML11E14A Serial Communication Interface (SERCOM2) */
+  void* pfnSERCOM2_2_Handler;                    /* 32  SAML11E14A Serial Communication Interface (SERCOM2) */
+  void* pfnSERCOM2_OTHER_Handler;                /* 33  SAML11E14A Serial Communication Interface (SERCOM2) */
+  void* pfnTC0_Handler;                          /* 34  SAML11E14A Basic Timer Counter (TC0) */
+  void* pfnTC1_Handler;                          /* 35  SAML11E14A Basic Timer Counter (TC1) */
+  void* pfnTC2_Handler;                          /* 36  SAML11E14A Basic Timer Counter (TC2) */
+  void* pfnADC_OTHER_Handler;                    /* 37  SAML11E14A Analog Digital Converter (ADC) */
+  void* pfnADC_RESRDY_Handler;                   /* 38  SAML11E14A Analog Digital Converter (ADC) */
+  void* pfnAC_Handler;                           /* 39  SAML11E14A Analog Comparators (AC) */
+  void* pfnDAC_UNDERRUN_A_Handler;               /* 40  SAML11E14A Digital Analog Converter (DAC) */
+  void* pfnDAC_EMPTY_Handler;                    /* 41  SAML11E14A Digital Analog Converter (DAC) */
+  void* pfnPTC_Handler;                          /* 42  SAML11E14A Peripheral Touch Controller (PTC) */
+  void* pfnTRNG_Handler;                         /* 43  SAML11E14A True Random Generator (TRNG) */
+  void* pfnTRAM_Handler;                         /* 44  SAML11E14A TrustRAM (TRAM)     */
+} DeviceVectors;
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define pfnMemManage_Handler      pfnMemoryManagement_Handler     /**< \deprecated  Backward compatibility for ASF */
+#define pfnDebugMon_Handler       pfnDebugMonitor_Handler         /**< \deprecated  Backward compatibility for ASF */
+#define pfnNMI_Handler            pfnNonMaskableInt_Handler       /**< \deprecated  Backward compatibility for ASF */
+#define pfnSVC_Handler            pfnSVCall_Handler               /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if !defined DONT_USE_PREDEFINED_CORE_HANDLERS
+
+/* CORTEX-M23 core handlers */
+void Reset_Handler                 ( void );
+void NonMaskableInt_Handler        ( void );
+void HardFault_Handler             ( void );
+void SVCall_Handler                ( void );
+void PendSV_Handler                ( void );
+void SysTick_Handler               ( void );
+#endif /* DONT_USE_PREDEFINED_CORE_HANDLERS */
+
+#if !defined DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS
+
+/* Peripherals handlers */
+void AC_Handler                    ( void );
+void ADC_OTHER_Handler             ( void );
+void ADC_RESRDY_Handler            ( void );
+void DAC_EMPTY_Handler             ( void );
+void DAC_UNDERRUN_A_Handler        ( void );
+void DMAC_0_Handler                ( void );
+void DMAC_1_Handler                ( void );
+void DMAC_2_Handler                ( void );
+void DMAC_3_Handler                ( void );
+void DMAC_OTHER_Handler            ( void );
+void EIC_0_Handler                 ( void );
+void EIC_1_Handler                 ( void );
+void EIC_2_Handler                 ( void );
+void EIC_3_Handler                 ( void );
+void EIC_OTHER_Handler             ( void );
+void EVSYS_0_Handler               ( void );
+void EVSYS_1_Handler               ( void );
+void EVSYS_2_Handler               ( void );
+void EVSYS_3_Handler               ( void );
+void EVSYS_NSCHK_Handler           ( void );
+void FREQM_Handler                 ( void );
+void NVMCTRL_Handler               ( void );
+void PAC_Handler                   ( void );
+void PORT_Handler                  ( void );
+void PTC_Handler                   ( void );
+void RTC_Handler                   ( void );
+void SERCOM0_0_Handler             ( void );
+void SERCOM0_1_Handler             ( void );
+void SERCOM0_2_Handler             ( void );
+void SERCOM0_OTHER_Handler         ( void );
+void SERCOM1_0_Handler             ( void );
+void SERCOM1_1_Handler             ( void );
+void SERCOM1_2_Handler             ( void );
+void SERCOM1_OTHER_Handler         ( void );
+void SERCOM2_0_Handler             ( void );
+void SERCOM2_1_Handler             ( void );
+void SERCOM2_2_Handler             ( void );
+void SERCOM2_OTHER_Handler         ( void );
+void SYSTEM_Handler                ( void );
+void TC0_Handler                   ( void );
+void TC1_Handler                   ( void );
+void TC2_Handler                   ( void );
+void TRAM_Handler                  ( void );
+void TRNG_Handler                  ( void );
+void WDT_Handler                   ( void );
+#endif /* DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS */
+
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define MemManage_Handler         MemoryManagement_Handler        /**< \deprecated  Backward compatibility for ASF */
+#define DebugMon_Handler          DebugMonitor_Handler            /**< \deprecated  Backward compatibility for ASF */
+#define NMI_Handler               NonMaskableInt_Handler          /**< \deprecated  Backward compatibility for ASF */
+#define SVC_Handler               SVCall_Handler                  /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+
+/*
+ * \brief Configuration of the CORTEX-M23 Processor and Core Peripherals
+ */
+
+#define NUM_IRQ                       45 /**< Number of interrupt request lines                                         */
+#define __ARMv8MBL_REV            0x0000 /**< Cortex-M23 Core Revision                                                  */
+#define __ETM_PRESENT                  0 /**< ETM present or not                                                        */
+#define __FPU_PRESENT                  0 /**< FPU present or not                                                        */
+#define __MPU_PRESENT                  1 /**< MPU present or not                                                        */
+#define __MTB_PRESENT                  0 /**< MTB present or not                                                        */
+#define __NVIC_PRIO_BITS               2 /**< Number of Bits used for Priority Levels                                   */
+#define __SAU_PRESENT                  0 /**< SAU present or not                                                        */
+#define __SEC_ENABLED                  0 /**< TrustZone-M enabled or not                                                */
+#define __VTOR_PRESENT                 1 /**< Vector Table Offset Register present or not                               */
+#define __Vendor_SysTickConfig         0 /**< Set to 1 if different SysTick Config is used                              */
+#define __ARCH_ARM                     1
+#define __ARCH_ARM_CORTEX_M            1
+#define __DEVICE_IS_SAM                1
+#define __TZ_PRESENT                   1
+
+/*
+ * \brief CMSIS includes
+ */
+#include <core_cm23.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_saml11.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/** @}  end of SAML11E14A_cmsis CMSIS Definitions */
+
+/** \defgroup SAML11E14A_api Peripheral Software API
+ *  @{
+ */
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAML11E14A */
+/* ************************************************************************** */
+#include "component/ac.h"
+#include "component/adc.h"
+#include "component/ccl.h"
+#include "component/dac.h"
+#include "component/dmac.h"
+#include "component/dsu.h"
+#include "component/eic.h"
+#include "component/evsys.h"
+#include "component/freqm.h"
+#include "component/gclk.h"
+#include "component/idau.h"
+#include "component/mclk.h"
+#include "component/nvmctrl.h"
+#include "component/opamp.h"
+#include "component/oscctrl.h"
+#include "component/osc32kctrl.h"
+#include "component/pac.h"
+#include "component/pm.h"
+#include "component/port.h"
+#include "component/ptc.h"
+#include "component/rstc.h"
+#include "component/rtc.h"
+#include "component/sercom.h"
+#include "component/supc.h"
+#include "component/tc.h"
+#include "component/tram.h"
+#include "component/trng.h"
+#include "component/wdt.h"
+/** @}  end of Peripheral Software API */
+
+/** \defgroup SAML11E14A_reg Registers Access Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   REGISTER ACCESS DEFINITIONS FOR SAML11E14A */
+/* ************************************************************************** */
+#include "instance/ac.h"
+#include "instance/adc.h"
+#include "instance/ccl.h"
+#include "instance/dac.h"
+#include "instance/dmac.h"
+#include "instance/dsu.h"
+#include "instance/eic.h"
+#include "instance/evsys.h"
+#include "instance/freqm.h"
+#include "instance/gclk.h"
+#include "instance/idau.h"
+#include "instance/mclk.h"
+#include "instance/nvmctrl.h"
+#include "instance/opamp.h"
+#include "instance/oscctrl.h"
+#include "instance/osc32kctrl.h"
+#include "instance/pac.h"
+#include "instance/pm.h"
+#include "instance/port.h"
+#include "instance/ptc.h"
+#include "instance/rstc.h"
+#include "instance/rtc.h"
+#include "instance/sercom0.h"
+#include "instance/sercom1.h"
+#include "instance/sercom2.h"
+#include "instance/supc.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tram.h"
+#include "instance/trng.h"
+#include "instance/wdt.h"
+/** @}  end of Registers Access Definitions */
+
+/** \addtogroup SAML11E14A_id Peripheral Ids Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*  PERIPHERAL ID DEFINITIONS FOR SAML11E14A */
+/* ************************************************************************** */
+#define ID_PAC          (  0) /**< \brief Peripheral Access Controller (PAC) */
+#define ID_PM           (  1) /**< \brief Power Manager (PM) */
+#define ID_MCLK         (  2) /**< \brief Main Clock (MCLK) */
+#define ID_RSTC         (  3) /**< \brief Reset Controller (RSTC) */
+#define ID_OSCCTRL      (  4) /**< \brief Oscillators Control (OSCCTRL) */
+#define ID_OSC32KCTRL   (  5) /**< \brief 32k Oscillators Control (OSC32KCTRL) */
+#define ID_SUPC         (  6) /**< \brief Supply Controller (SUPC) */
+#define ID_GCLK         (  7) /**< \brief Generic Clock Generator (GCLK) */
+#define ID_WDT          (  8) /**< \brief Watchdog Timer (WDT) */
+#define ID_RTC          (  9) /**< \brief Real-Time Counter (RTC) */
+#define ID_EIC          ( 10) /**< \brief External Interrupt Controller (EIC) */
+#define ID_FREQM        ( 11) /**< \brief Frequency Meter (FREQM) */
+#define ID_PORT         ( 12) /**< \brief Port Module (PORT) */
+#define ID_AC           ( 13) /**< \brief Analog Comparators (AC) */
+#define ID_IDAU         ( 32) /**< \brief Implementation Defined Attribution Unit (IDAU) */
+#define ID_DSU          ( 33) /**< \brief Device Service Unit (DSU) */
+#define ID_NVMCTRL      ( 34) /**< \brief Non-Volatile Memory Controller (NVMCTRL) */
+#define ID_DMAC         ( 35) /**< \brief Direct Memory Access Controller (DMAC) */
+#define ID_EVSYS        ( 64) /**< \brief Event System Interface (EVSYS) */
+#define ID_SERCOM0      ( 65) /**< \brief Serial Communication Interface (SERCOM0) */
+#define ID_SERCOM1      ( 66) /**< \brief Serial Communication Interface (SERCOM1) */
+#define ID_SERCOM2      ( 67) /**< \brief Serial Communication Interface (SERCOM2) */
+#define ID_TC0          ( 68) /**< \brief Basic Timer Counter (TC0) */
+#define ID_TC1          ( 69) /**< \brief Basic Timer Counter (TC1) */
+#define ID_TC2          ( 70) /**< \brief Basic Timer Counter (TC2) */
+#define ID_ADC          ( 71) /**< \brief Analog Digital Converter (ADC) */
+#define ID_DAC          ( 72) /**< \brief Digital Analog Converter (DAC) */
+#define ID_PTC          ( 73) /**< \brief Peripheral Touch Controller (PTC) */
+#define ID_TRNG         ( 74) /**< \brief True Random Generator (TRNG) */
+#define ID_CCL          ( 75) /**< \brief Configurable Custom Logic (CCL) */
+#define ID_OPAMP        ( 76) /**< \brief Operational Amplifier (OPAMP) */
+#define ID_TRAM         ( 77) /**< \brief TrustRAM (TRAM) */
+
+#define ID_PERIPH_COUNT ( 78) /**< \brief Number of peripheral IDs */
+/** @}  end of Peripheral Ids Definitions */
+
+/** \addtogroup SAML11E14A_base Peripheral Base Address Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   BASE ADDRESS DEFINITIONS FOR SAML11E14A */
+/* ************************************************************************** */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#define AC                     (0x40003400)                   /**< \brief (AC        ) Base Address */
+#define ADC                    (0x42001C00)                   /**< \brief (ADC       ) Base Address */
+#define CCL                    (0x42002C00)                   /**< \brief (CCL       ) Base Address */
+#define DAC                    (0x42002000)                   /**< \brief (DAC       ) Base Address */
+#define DMAC                   (0x41006000)                   /**< \brief (DMAC      ) Base Address */
+#define DSU                    (0x41002000)                   /**< \brief (DSU       ) Base Address */
+#define DSU_EXT                (0x41002100)                   /**< \brief (DSU       ) Base Address */
+#define EIC                    (0x40002800)                   /**< \brief (EIC       ) Base Address */
+#define EIC_SEC                (0x40002A00)                   /**< \brief (EIC       ) Base Address */
+#define EVSYS                  (0x42000000)                   /**< \brief (EVSYS     ) Base Address */
+#define EVSYS_SEC              (0x42000200)                   /**< \brief (EVSYS     ) Base Address */
+#define FREQM                  (0x40002C00)                   /**< \brief (FREQM     ) Base Address */
+#define GCLK                   (0x40001C00)                   /**< \brief (GCLK      ) Base Address */
+#define IDAU                   (0x41000000)                   /**< \brief (IDAU      ) Base Address */
+#define MCLK                   (0x40000800)                   /**< \brief (MCLK      ) Base Address */
+#define NVMCTRL                (0x41004000)                   /**< \brief (NVMCTRL   ) Base Address */
+#define NVMCTRL_SEC            (0x41005000)                   /**< \brief (NVMCTRL   ) Base Address */
+#define OPAMP                  (0x42003000)                   /**< \brief (OPAMP     ) Base Address */
+#define OSCCTRL                (0x40001000)                   /**< \brief (OSCCTRL   ) Base Address */
+#define OSC32KCTRL             (0x40001400)                   /**< \brief (OSC32KCTRL) Base Address */
+#define PAC                    (0x40000000)                   /**< \brief (PAC       ) Base Address */
+#define PAC_SEC                (0x40000200)                   /**< \brief (PAC       ) Base Address */
+#define PM                     (0x40000400)                   /**< \brief (PM        ) Base Address */
+#define PORT                   (0x40003000)                   /**< \brief (PORT      ) Base Address */
+#define PORT_SEC               (0x40003200)                   /**< \brief (PORT      ) Base Address */
+#define PORT_IOBUS             (0x60000000)                   /**< \brief (PORT      ) Base Address */
+#define PORT_IOBUS_SEC         (0x60000200)                   /**< \brief (PORT      ) Base Address */
+#define PTC                    (0x42002400)                   /**< \brief (PTC       ) Base Address */
+#define RSTC                   (0x40000C00)                   /**< \brief (RSTC      ) Base Address */
+#define RTC                    (0x40002400)                   /**< \brief (RTC       ) Base Address */
+#define SERCOM0                (0x42000400)                   /**< \brief (SERCOM0   ) Base Address */
+#define SERCOM1                (0x42000800)                   /**< \brief (SERCOM1   ) Base Address */
+#define SERCOM2                (0x42000C00)                   /**< \brief (SERCOM2   ) Base Address */
+#define SUPC                   (0x40001800)                   /**< \brief (SUPC      ) Base Address */
+#define TC0                    (0x42001000)                   /**< \brief (TC0       ) Base Address */
+#define TC1                    (0x42001400)                   /**< \brief (TC1       ) Base Address */
+#define TC2                    (0x42001800)                   /**< \brief (TC2       ) Base Address */
+#define TRAM                   (0x42003400)                   /**< \brief (TRAM      ) Base Address */
+#define TRNG                   (0x42002800)                   /**< \brief (TRNG      ) Base Address */
+#define WDT                    (0x40002000)                   /**< \brief (WDT       ) Base Address */
+
+#else /* For C/C++ compiler */
+
+#define AC                     ((Ac *)0x40003400U)            /**< \brief (AC        ) Base Address */
+#define AC_INST_NUM            1                              /**< \brief (AC        ) Number of instances */
+#define AC_INSTS               { AC }                         /**< \brief (AC        ) Instances List */
+
+#define ADC                    ((Adc *)0x42001C00U)           /**< \brief (ADC       ) Base Address */
+#define ADC_INST_NUM           1                              /**< \brief (ADC       ) Number of instances */
+#define ADC_INSTS              { ADC }                        /**< \brief (ADC       ) Instances List */
+
+#define CCL                    ((Ccl *)0x42002C00U)           /**< \brief (CCL       ) Base Address */
+#define CCL_INST_NUM           1                              /**< \brief (CCL       ) Number of instances */
+#define CCL_INSTS              { CCL }                        /**< \brief (CCL       ) Instances List */
+
+#define DAC                    ((Dac *)0x42002000U)           /**< \brief (DAC       ) Base Address */
+#define DAC_INST_NUM           1                              /**< \brief (DAC       ) Number of instances */
+#define DAC_INSTS              { DAC }                        /**< \brief (DAC       ) Instances List */
+
+#define DMAC                   ((Dmac *)0x41006000U)          /**< \brief (DMAC      ) Base Address */
+#define DMAC_INST_NUM          1                              /**< \brief (DMAC      ) Number of instances */
+#define DMAC_INSTS             { DMAC }                       /**< \brief (DMAC      ) Instances List */
+
+#define DSU                    ((Dsu *)0x41002000U)           /**< \brief (DSU       ) Base Address */
+#define DSU_EXT                ((Dsu *)0x41002100U)           /**< \brief (DSU       ) Base Address */
+#define DSU_INST_NUM           1                              /**< \brief (DSU       ) Number of instances */
+#define DSU_INSTS              { DSU }                        /**< \brief (DSU       ) Instances List */
+
+#define EIC                    ((Eic *)0x40002800U)           /**< \brief (EIC       ) Base Address */
+#define EIC_SEC                ((Eic *)0x40002A00U)           /**< \brief (EIC       ) Base Address */
+#define EIC_INST_NUM           1                              /**< \brief (EIC       ) Number of instances */
+#define EIC_INSTS              { EIC }                        /**< \brief (EIC       ) Instances List */
+
+#define EVSYS                  ((Evsys *)0x42000000U)         /**< \brief (EVSYS     ) Base Address */
+#define EVSYS_SEC              ((Evsys *)0x42000200U)         /**< \brief (EVSYS     ) Base Address */
+#define EVSYS_INST_NUM         1                              /**< \brief (EVSYS     ) Number of instances */
+#define EVSYS_INSTS            { EVSYS }                      /**< \brief (EVSYS     ) Instances List */
+
+#define FREQM                  ((Freqm *)0x40002C00U)         /**< \brief (FREQM     ) Base Address */
+#define FREQM_INST_NUM         1                              /**< \brief (FREQM     ) Number of instances */
+#define FREQM_INSTS            { FREQM }                      /**< \brief (FREQM     ) Instances List */
+
+#define GCLK                   ((Gclk *)0x40001C00U)          /**< \brief (GCLK      ) Base Address */
+#define GCLK_INST_NUM          1                              /**< \brief (GCLK      ) Number of instances */
+#define GCLK_INSTS             { GCLK }                       /**< \brief (GCLK      ) Instances List */
+
+#define IDAU                   ((Idau *)0x41000000U)          /**< \brief (IDAU      ) Base Address */
+#define IDAU_INST_NUM          1                              /**< \brief (IDAU      ) Number of instances */
+#define IDAU_INSTS             { IDAU }                       /**< \brief (IDAU      ) Instances List */
+
+#define MCLK                   ((Mclk *)0x40000800U)          /**< \brief (MCLK      ) Base Address */
+#define MCLK_INST_NUM          1                              /**< \brief (MCLK      ) Number of instances */
+#define MCLK_INSTS             { MCLK }                       /**< \brief (MCLK      ) Instances List */
+
+#define NVMCTRL                ((Nvmctrl *)0x41004000U)       /**< \brief (NVMCTRL   ) Base Address */
+#define NVMCTRL_SEC            ((Nvmctrl *)0x41005000U)       /**< \brief (NVMCTRL   ) Base Address */
+#define NVMCTRL_INST_NUM       1                              /**< \brief (NVMCTRL   ) Number of instances */
+#define NVMCTRL_INSTS          { NVMCTRL }                    /**< \brief (NVMCTRL   ) Instances List */
+
+#define OPAMP                  ((Opamp *)0x42003000U)         /**< \brief (OPAMP     ) Base Address */
+#define OPAMP_INST_NUM         1                              /**< \brief (OPAMP     ) Number of instances */
+#define OPAMP_INSTS            { OPAMP }                      /**< \brief (OPAMP     ) Instances List */
+
+#define OSCCTRL                ((Oscctrl *)0x40001000U)       /**< \brief (OSCCTRL   ) Base Address */
+#define OSCCTRL_INST_NUM       1                              /**< \brief (OSCCTRL   ) Number of instances */
+#define OSCCTRL_INSTS          { OSCCTRL }                    /**< \brief (OSCCTRL   ) Instances List */
+
+#define OSC32KCTRL             ((Osc32kctrl *)0x40001400U)    /**< \brief (OSC32KCTRL) Base Address */
+#define OSC32KCTRL_INST_NUM    1                              /**< \brief (OSC32KCTRL) Number of instances */
+#define OSC32KCTRL_INSTS       { OSC32KCTRL }                 /**< \brief (OSC32KCTRL) Instances List */
+
+#define PAC                    ((Pac *)0x40000000U)           /**< \brief (PAC       ) Base Address */
+#define PAC_SEC                ((Pac *)0x40000200U)           /**< \brief (PAC       ) Base Address */
+#define PAC_INST_NUM           1                              /**< \brief (PAC       ) Number of instances */
+#define PAC_INSTS              { PAC }                        /**< \brief (PAC       ) Instances List */
+
+#define PM                     ((Pm *)0x40000400U)            /**< \brief (PM        ) Base Address */
+#define PM_INST_NUM            1                              /**< \brief (PM        ) Number of instances */
+#define PM_INSTS               { PM }                         /**< \brief (PM        ) Instances List */
+
+#define PORT                   ((Port *)0x40003000U)          /**< \brief (PORT      ) Base Address */
+#define PORT_SEC               ((Port *)0x40003200U)          /**< \brief (PORT      ) Base Address */
+#define PORT_IOBUS             ((Port *)0x60000000U)          /**< \brief (PORT      ) Base Address */
+#define PORT_IOBUS_SEC         ((Port *)0x60000200U)          /**< \brief (PORT      ) Base Address */
+#define PORT_INST_NUM          1                              /**< \brief (PORT      ) Number of instances */
+#define PORT_INSTS             { PORT }                       /**< \brief (PORT      ) Instances List */
+
+#define PTC                    ((Ptc *)0x42002400U)           /**< \brief (PTC       ) Base Address */
+#define PTC_INST_NUM           1                              /**< \brief (PTC       ) Number of instances */
+#define PTC_INSTS              { PTC }                        /**< \brief (PTC       ) Instances List */
+
+#define RSTC                   ((Rstc *)0x40000C00U)          /**< \brief (RSTC      ) Base Address */
+#define RSTC_INST_NUM          1                              /**< \brief (RSTC      ) Number of instances */
+#define RSTC_INSTS             { RSTC }                       /**< \brief (RSTC      ) Instances List */
+
+#define RTC                    ((Rtc *)0x40002400U)           /**< \brief (RTC       ) Base Address */
+#define RTC_INST_NUM           1                              /**< \brief (RTC       ) Number of instances */
+#define RTC_INSTS              { RTC }                        /**< \brief (RTC       ) Instances List */
+
+#define SERCOM0                ((Sercom *)0x42000400U)        /**< \brief (SERCOM0   ) Base Address */
+#define SERCOM1                ((Sercom *)0x42000800U)        /**< \brief (SERCOM1   ) Base Address */
+#define SERCOM2                ((Sercom *)0x42000C00U)        /**< \brief (SERCOM2   ) Base Address */
+#define SERCOM_INST_NUM        3                              /**< \brief (SERCOM    ) Number of instances */
+#define SERCOM_INSTS           { SERCOM0, SERCOM1, SERCOM2 }  /**< \brief (SERCOM    ) Instances List */
+
+#define SUPC                   ((Supc *)0x40001800U)          /**< \brief (SUPC      ) Base Address */
+#define SUPC_INST_NUM          1                              /**< \brief (SUPC      ) Number of instances */
+#define SUPC_INSTS             { SUPC }                       /**< \brief (SUPC      ) Instances List */
+
+#define TC0                    ((Tc *)0x42001000U)            /**< \brief (TC0       ) Base Address */
+#define TC1                    ((Tc *)0x42001400U)            /**< \brief (TC1       ) Base Address */
+#define TC2                    ((Tc *)0x42001800U)            /**< \brief (TC2       ) Base Address */
+#define TC_INST_NUM            3                              /**< \brief (TC        ) Number of instances */
+#define TC_INSTS               { TC0, TC1, TC2 }              /**< \brief (TC        ) Instances List */
+
+#define TRAM                   ((Tram *)0x42003400U)          /**< \brief (TRAM      ) Base Address */
+#define TRAM_INST_NUM          1                              /**< \brief (TRAM      ) Number of instances */
+#define TRAM_INSTS             { TRAM }                       /**< \brief (TRAM      ) Instances List */
+
+#define TRNG                   ((Trng *)0x42002800U)          /**< \brief (TRNG      ) Base Address */
+#define TRNG_INST_NUM          1                              /**< \brief (TRNG      ) Number of instances */
+#define TRNG_INSTS             { TRNG }                       /**< \brief (TRNG      ) Instances List */
+
+#define WDT                    ((Wdt *)0x40002000U)           /**< \brief (WDT       ) Base Address */
+#define WDT_INST_NUM           1                              /**< \brief (WDT       ) Number of instances */
+#define WDT_INSTS              { WDT }                        /**< \brief (WDT       ) Instances List */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Peripheral Base Address Definitions */
+
+/** \addtogroup SAML11E14A_pio Peripheral Pio Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   PIO DEFINITIONS FOR SAML11E14A*/
+/* ************************************************************************** */
+#include "pio/saml11e14a.h"
+/** @}  end of Peripheral Pio Definitions */
+
+/* ************************************************************************** */
+/*   MEMORY MAPPING DEFINITIONS FOR SAML11E14A*/
+/* ************************************************************************** */
+
+#define FLASH_SIZE               _U_(0x00004000)       /*   16kB Memory segment type: flash */
+#define FLASH_PAGE_SIZE          _U_(        64)
+#define FLASH_NB_OF_PAGES        _U_(       256)
+
+#define AUX_SIZE                 _U_(0x00000100)       /*    0kB Memory segment type: fuses */
+#define AUX_PAGE_SIZE            _U_(        64)
+#define AUX_NB_OF_PAGES          _U_(         4)
+
+#define BOCOR_SIZE               _U_(0x00000100)       /*    0kB Memory segment type: fuses */
+#define BOCOR_PAGE_SIZE          _U_(        64)
+#define BOCOR_NB_OF_PAGES        _U_(         4)
+
+#define DATAFLASH_SIZE           _U_(0x00000800)       /*    2kB Memory segment type: flash */
+#define DATAFLASH_PAGE_SIZE      _U_(        64)
+#define DATAFLASH_NB_OF_PAGES    _U_(        32)
+
+#define SW_CALIB_SIZE            _U_(0x00000008)       /*    0kB Memory segment type: fuses */
+#define TEMP_LOG_SIZE            _U_(0x00000008)       /*    0kB Memory segment type: fuses */
+#define USER_PAGE_SIZE           _U_(0x00000100)       /*    0kB Memory segment type: user_page */
+#define USER_PAGE_PAGE_SIZE      _U_(        64)
+#define USER_PAGE_NB_OF_PAGES    _U_(         4)
+
+#define HSRAM_SIZE               _U_(0x00002000)       /*    8kB Memory segment type: ram */
+#define HPB0_SIZE                _U_(0x00008000)       /*   32kB Memory segment type: io */
+#define HPB1_SIZE                _U_(0x00010000)       /*   64kB Memory segment type: io */
+#define HPB2_SIZE                _U_(0x00004000)       /*   16kB Memory segment type: io */
+#define PPB_SIZE                 _U_(0x00100000)       /* 1024kB Memory segment type: io */
+#define SCS_SIZE                 _U_(0x00001000)       /*    4kB Memory segment type: io */
+#define PERIPHERALS_SIZE         _U_(0x20000000)       /* 524288kB Memory segment type: io */
+
+#define FLASH_ADDR               _U_(0x00000000)       /**< FLASH base address (type: flash)*/
+#define AUX_ADDR                 _U_(0x00806000)       /**< AUX base address (type: fuses)*/
+#define BOCOR_ADDR               _U_(0x0080c000)       /**< BOCOR base address (type: fuses)*/
+#define DATAFLASH_ADDR           _U_(0x00400000)       /**< DATAFLASH base address (type: flash)*/
+#define SW_CALIB_ADDR            _U_(0x00806020)       /**< SW_CALIB base address (type: fuses)*/
+#define TEMP_LOG_ADDR            _U_(0x00806038)       /**< TEMP_LOG base address (type: fuses)*/
+#define USER_PAGE_ADDR           _U_(0x00804000)       /**< USER_PAGE base address (type: user_page)*/
+#define HSRAM_ADDR               _U_(0x20000000)       /**< HSRAM base address (type: ram)*/
+#define HPB0_ADDR                _U_(0x40000000)       /**< HPB0 base address (type: io)*/
+#define HPB1_ADDR                _U_(0x41000000)       /**< HPB1 base address (type: io)*/
+#define HPB2_ADDR                _U_(0x42000000)       /**< HPB2 base address (type: io)*/
+#define PPB_ADDR                 _U_(0xe0000000)       /**< PPB base address (type: io)*/
+#define SCS_ADDR                 _U_(0xe000e000)       /**< SCS base address (type: io)*/
+#define PERIPHERALS_ADDR         _U_(0x40000000)       /**< PERIPHERALS base address (type: io)*/
+
+#define NVMCTRL_AUX              AUX_ADDR              /**< \brief \deprecated Old style definition. Use AUX_ADDR instead */
+#define NVMCTRL_BOCOR            BOCOR_ADDR            /**< \brief \deprecated Old style definition. Use BOCOR_ADDR instead */
+#define NVMCTRL_DATAFLASH        DATAFLASH_ADDR        /**< \brief \deprecated Old style definition. Use DATAFLASH_ADDR instead */
+#define NVMCTRL_SW_CALIB         SW_CALIB_ADDR         /**< \brief \deprecated Old style definition. Use SW_CALIB_ADDR instead */
+#define NVMCTRL_TEMP_LOG         TEMP_LOG_ADDR         /**< \brief \deprecated Old style definition. Use TEMP_LOG_ADDR instead */
+#define NVMCTRL_USER             USER_PAGE_ADDR        /**< \brief \deprecated Old style definition. Use USER_PAGE_ADDR instead */
+
+/* ************************************************************************** */
+/**  DEVICE SIGNATURES FOR SAML11E14A */
+/* ************************************************************************** */
+#define DSU_DID                  _UL_(0X20830002)
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAML11E14A */
+/* ************************************************************************** */
+
+/* ************************************************************************** */
+/** Event Generator IDs for SAML11E14A */
+/* ************************************************************************** */
+#define EVENT_ID_GEN_OSCCTRL_XOSC_FAIL                    1 /**< ID for OSCCTRL event generator XOSC_FAIL */
+#define EVENT_ID_GEN_OSC32KCTRL_XOSC32K_FAIL              2 /**< ID for OSC32KCTRL event generator XOSC32K_FAIL */
+#define EVENT_ID_GEN_SUPC_BOD33DET                        3 /**< ID for SUPC event generator BOD33DET */
+#define EVENT_ID_GEN_RTC_PER_0                            4 /**< ID for RTC event generator PER_0 */
+#define EVENT_ID_GEN_RTC_PER_1                            5 /**< ID for RTC event generator PER_1 */
+#define EVENT_ID_GEN_RTC_PER_2                            6 /**< ID for RTC event generator PER_2 */
+#define EVENT_ID_GEN_RTC_PER_3                            7 /**< ID for RTC event generator PER_3 */
+#define EVENT_ID_GEN_RTC_PER_4                            8 /**< ID for RTC event generator PER_4 */
+#define EVENT_ID_GEN_RTC_PER_5                            9 /**< ID for RTC event generator PER_5 */
+#define EVENT_ID_GEN_RTC_PER_6                           10 /**< ID for RTC event generator PER_6 */
+#define EVENT_ID_GEN_RTC_PER_7                           11 /**< ID for RTC event generator PER_7 */
+#define EVENT_ID_GEN_RTC_CMP_0                           12 /**< ID for RTC event generator CMP_0 */
+#define EVENT_ID_GEN_RTC_CMP_1                           13 /**< ID for RTC event generator CMP_1 */
+#define EVENT_ID_GEN_RTC_TAMPER                          14 /**< ID for RTC event generator TAMPER */
+#define EVENT_ID_GEN_RTC_OVF                             15 /**< ID for RTC event generator OVF */
+#define EVENT_ID_GEN_RTC_PERD                            16 /**< ID for RTC event generator PERD */
+#define EVENT_ID_GEN_EIC_EXTINT_0                        17 /**< ID for EIC event generator EXTINT_0 */
+#define EVENT_ID_GEN_EIC_EXTINT_1                        18 /**< ID for EIC event generator EXTINT_1 */
+#define EVENT_ID_GEN_EIC_EXTINT_2                        19 /**< ID for EIC event generator EXTINT_2 */
+#define EVENT_ID_GEN_EIC_EXTINT_3                        20 /**< ID for EIC event generator EXTINT_3 */
+#define EVENT_ID_GEN_EIC_EXTINT_4                        21 /**< ID for EIC event generator EXTINT_4 */
+#define EVENT_ID_GEN_EIC_EXTINT_5                        22 /**< ID for EIC event generator EXTINT_5 */
+#define EVENT_ID_GEN_EIC_EXTINT_6                        23 /**< ID for EIC event generator EXTINT_6 */
+#define EVENT_ID_GEN_EIC_EXTINT_7                        24 /**< ID for EIC event generator EXTINT_7 */
+#define EVENT_ID_GEN_DMAC_CH_0                           25 /**< ID for DMAC event generator CH_0 */
+#define EVENT_ID_GEN_DMAC_CH_1                           26 /**< ID for DMAC event generator CH_1 */
+#define EVENT_ID_GEN_DMAC_CH_2                           27 /**< ID for DMAC event generator CH_2 */
+#define EVENT_ID_GEN_DMAC_CH_3                           28 /**< ID for DMAC event generator CH_3 */
+#define EVENT_ID_GEN_TC0_OVF                             29 /**< ID for TC0 event generator OVF */
+#define EVENT_ID_GEN_TC0_MCX_0                           30 /**< ID for TC0 event generator MCX_0 */
+#define EVENT_ID_GEN_TC0_MCX_1                           31 /**< ID for TC0 event generator MCX_1 */
+#define EVENT_ID_GEN_TC1_OVF                             32 /**< ID for TC1 event generator OVF */
+#define EVENT_ID_GEN_TC1_MCX_0                           33 /**< ID for TC1 event generator MCX_0 */
+#define EVENT_ID_GEN_TC1_MCX_1                           34 /**< ID for TC1 event generator MCX_1 */
+#define EVENT_ID_GEN_TC2_OVF                             35 /**< ID for TC2 event generator OVF */
+#define EVENT_ID_GEN_TC2_MCX_0                           36 /**< ID for TC2 event generator MCX_0 */
+#define EVENT_ID_GEN_TC2_MCX_1                           37 /**< ID for TC2 event generator MCX_1 */
+#define EVENT_ID_GEN_ADC_RESRDY                          38 /**< ID for ADC event generator RESRDY */
+#define EVENT_ID_GEN_ADC_WINMON                          39 /**< ID for ADC event generator WINMON */
+#define EVENT_ID_GEN_AC_COMP_0                           40 /**< ID for AC event generator COMP_0 */
+#define EVENT_ID_GEN_AC_COMP_1                           41 /**< ID for AC event generator COMP_1 */
+#define EVENT_ID_GEN_AC_WIN_0                            42 /**< ID for AC event generator WIN_0 */
+#define EVENT_ID_GEN_DAC_EMPTY                           43 /**< ID for DAC event generator EMPTY */
+#define EVENT_ID_GEN_TRNG_READY                          46 /**< ID for TRNG event generator READY */
+#define EVENT_ID_GEN_CCL_LUTOUT_0                        47 /**< ID for CCL event generator LUTOUT_0 */
+#define EVENT_ID_GEN_CCL_LUTOUT_1                        48 /**< ID for CCL event generator LUTOUT_1 */
+#define EVENT_ID_GEN_PAC_ERR                             49 /**< ID for PAC event generator ERR */
+
+/* ************************************************************************** */
+/** Event User IDs for SAML11E14A */
+/* ************************************************************************** */
+#define EVENT_ID_USER_OSCCTRL_TUNE                        0 /**< ID for OSCCTRL event user TUNE */
+#define EVENT_ID_USER_RTC_TAMPER                          1 /**< ID for RTC event user TAMPER */
+#define EVENT_ID_USER_NVMCTRL_PAGEW                       2 /**< ID for NVMCTRL event user PAGEW */
+#define EVENT_ID_USER_PORT_EV_0                           3 /**< ID for PORT event user EV_0 */
+#define EVENT_ID_USER_PORT_EV_1                           4 /**< ID for PORT event user EV_1 */
+#define EVENT_ID_USER_PORT_EV_2                           5 /**< ID for PORT event user EV_2 */
+#define EVENT_ID_USER_PORT_EV_3                           6 /**< ID for PORT event user EV_3 */
+#define EVENT_ID_USER_DMAC_CH_0                           7 /**< ID for DMAC event user CH_0 */
+#define EVENT_ID_USER_DMAC_CH_1                           8 /**< ID for DMAC event user CH_1 */
+#define EVENT_ID_USER_DMAC_CH_2                           9 /**< ID for DMAC event user CH_2 */
+#define EVENT_ID_USER_DMAC_CH_3                          10 /**< ID for DMAC event user CH_3 */
+#define EVENT_ID_USER_TC0_EVU                            11 /**< ID for TC0 event user EVU */
+#define EVENT_ID_USER_TC1_EVU                            12 /**< ID for TC1 event user EVU */
+#define EVENT_ID_USER_TC2_EVU                            13 /**< ID for TC2 event user EVU */
+#define EVENT_ID_USER_ADC_START                          14 /**< ID for ADC event user START */
+#define EVENT_ID_USER_ADC_SYNC                           15 /**< ID for ADC event user SYNC */
+#define EVENT_ID_USER_AC_SOC_0                           16 /**< ID for AC event user SOC_0 */
+#define EVENT_ID_USER_AC_SOC_1                           17 /**< ID for AC event user SOC_1 */
+#define EVENT_ID_USER_DAC_START                          18 /**< ID for DAC event user START */
+#define EVENT_ID_USER_CCL_LUTIN_0                        21 /**< ID for CCL event user LUTIN_0 */
+#define EVENT_ID_USER_CCL_LUTIN_1                        22 /**< ID for CCL event user LUTIN_1 */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @}  end of SAML11E14A definitions */
+
+
+#endif /* _SAML11E14A_H_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/saml11e15a.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/saml11e15a.h
@@ -1,0 +1,814 @@
+/**
+ * \file
+ *
+ * \brief Header file for ATSAML11E15A
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11E15A_H_
+#define _SAML11E15A_H_
+
+/** \addtogroup SAML11E15A_definitions SAML11E15A definitions
+  This file defines all structures and symbols for SAML11E15A:
+    - registers and bitfields
+    - peripheral base address
+    - peripheral ID
+    - PIO definitions
+ *  @{
+ */
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/** \defgroup Atmel_glob_defs Atmel Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+
+    \remark
+    CMSIS core has a syntax that differs from this using i.e. __I, __O, or __IO followed by 'uint<size>_t' respective types.
+    Default the header files will follow the CMSIS core syntax.
+ *  @{
+ */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+
+/* IO definitions (access restrictions to peripheral registers) */
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+
+#define CAST(type, value) ((type *)(value)) /**< Pointer Type Conversion Macro for C/C++ */
+#define REG_ACCESS(type, address) (*(type*)(address)) /**< C code: Register value */
+#else /* Assembler */
+#define CAST(type, value) (value) /**< Pointer Type Conversion Macro for Assembler */
+#define REG_ACCESS(type, address) (address) /**< Assembly code: Register address */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !defined(SKIP_INTEGER_LITERALS)
+
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x) x ## U    /**< C code: Unsigned integer literal constant value */
+#define _L_(x) x ## L    /**< C code: Long integer literal constant value */
+#define _UL_(x) x ## UL  /**< C code: Unsigned Long integer literal constant value */
+
+#else /* Assembler */
+
+#define _U_(x) x    /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x) x    /**< Assembler: Long integer literal constant value */
+#define _UL_(x) x   /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* SKIP_INTEGER_LITERALS */
+/** @}  end of Atmel Global Defines */
+
+/** \addtogroup SAML11E15A_cmsis CMSIS Definitions
+ *  @{
+ */
+/* ************************************************************************** */
+/*   CMSIS DEFINITIONS FOR SAML11E15A */
+/* ************************************************************************** */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+/******  CORTEX-M23 Processor Exceptions Numbers ******************************/
+  Reset_IRQn                = -15, /**< 1   Reset Vector, invoked on Power up and warm reset  */
+  NonMaskableInt_IRQn       = -14, /**< 2   Non maskable Interrupt, cannot be stopped or preempted  */
+  HardFault_IRQn            = -13, /**< 3   Hard Fault, all classes of Fault     */
+  SVCall_IRQn               = -5 , /**< 11  System Service Call via SVC instruction  */
+  PendSV_IRQn               = -2 , /**< 14  Pendable request for system service  */
+  SysTick_IRQn              = -1 , /**< 15  System Tick Timer                    */
+/******  SAML11E15A specific Interrupt Numbers ***********************************/
+  SYSTEM_IRQn               = 0  , /**< 0   SAML11E15A Main Clock (MCLK)        */
+  WDT_IRQn                  = 1  , /**< 1   SAML11E15A Watchdog Timer (WDT)     */
+  RTC_IRQn                  = 2  , /**< 2   SAML11E15A Real-Time Counter (RTC)  */
+  EIC_0_IRQn                = 3  , /**< 3   SAML11E15A External Interrupt Controller (EIC) */
+  EIC_1_IRQn                = 4  , /**< 4   SAML11E15A External Interrupt Controller (EIC) */
+  EIC_2_IRQn                = 5  , /**< 5   SAML11E15A External Interrupt Controller (EIC) */
+  EIC_3_IRQn                = 6  , /**< 6   SAML11E15A External Interrupt Controller (EIC) */
+  EIC_OTHER_IRQn            = 7  , /**< 7   SAML11E15A External Interrupt Controller (EIC) */
+  FREQM_IRQn                = 8  , /**< 8   SAML11E15A Frequency Meter (FREQM)  */
+  NVMCTRL_IRQn              = 9  , /**< 9   SAML11E15A Non-Volatile Memory Controller (NVMCTRL) */
+  PORT_IRQn                 = 10 , /**< 10  SAML11E15A Port Module (PORT)       */
+  DMAC_0_IRQn               = 11 , /**< 11  SAML11E15A Direct Memory Access Controller (DMAC) */
+  DMAC_1_IRQn               = 12 , /**< 12  SAML11E15A Direct Memory Access Controller (DMAC) */
+  DMAC_2_IRQn               = 13 , /**< 13  SAML11E15A Direct Memory Access Controller (DMAC) */
+  DMAC_3_IRQn               = 14 , /**< 14  SAML11E15A Direct Memory Access Controller (DMAC) */
+  DMAC_OTHER_IRQn           = 15 , /**< 15  SAML11E15A Direct Memory Access Controller (DMAC) */
+  EVSYS_0_IRQn              = 16 , /**< 16  SAML11E15A Event System Interface (EVSYS) */
+  EVSYS_1_IRQn              = 17 , /**< 17  SAML11E15A Event System Interface (EVSYS) */
+  EVSYS_2_IRQn              = 18 , /**< 18  SAML11E15A Event System Interface (EVSYS) */
+  EVSYS_3_IRQn              = 19 , /**< 19  SAML11E15A Event System Interface (EVSYS) */
+  EVSYS_NSCHK_IRQn          = 20 , /**< 20  SAML11E15A Event System Interface (EVSYS) */
+  PAC_IRQn                  = 21 , /**< 21  SAML11E15A Peripheral Access Controller (PAC) */
+  SERCOM0_0_IRQn            = 22 , /**< 22  SAML11E15A Serial Communication Interface (SERCOM0) */
+  SERCOM0_1_IRQn            = 23 , /**< 23  SAML11E15A Serial Communication Interface (SERCOM0) */
+  SERCOM0_2_IRQn            = 24 , /**< 24  SAML11E15A Serial Communication Interface (SERCOM0) */
+  SERCOM0_OTHER_IRQn        = 25 , /**< 25  SAML11E15A Serial Communication Interface (SERCOM0) */
+  SERCOM1_0_IRQn            = 26 , /**< 26  SAML11E15A Serial Communication Interface (SERCOM1) */
+  SERCOM1_1_IRQn            = 27 , /**< 27  SAML11E15A Serial Communication Interface (SERCOM1) */
+  SERCOM1_2_IRQn            = 28 , /**< 28  SAML11E15A Serial Communication Interface (SERCOM1) */
+  SERCOM1_OTHER_IRQn        = 29 , /**< 29  SAML11E15A Serial Communication Interface (SERCOM1) */
+  SERCOM2_0_IRQn            = 30 , /**< 30  SAML11E15A Serial Communication Interface (SERCOM2) */
+  SERCOM2_1_IRQn            = 31 , /**< 31  SAML11E15A Serial Communication Interface (SERCOM2) */
+  SERCOM2_2_IRQn            = 32 , /**< 32  SAML11E15A Serial Communication Interface (SERCOM2) */
+  SERCOM2_OTHER_IRQn        = 33 , /**< 33  SAML11E15A Serial Communication Interface (SERCOM2) */
+  TC0_IRQn                  = 34 , /**< 34  SAML11E15A Basic Timer Counter (TC0) */
+  TC1_IRQn                  = 35 , /**< 35  SAML11E15A Basic Timer Counter (TC1) */
+  TC2_IRQn                  = 36 , /**< 36  SAML11E15A Basic Timer Counter (TC2) */
+  ADC_OTHER_IRQn            = 37 , /**< 37  SAML11E15A Analog Digital Converter (ADC) */
+  ADC_RESRDY_IRQn           = 38 , /**< 38  SAML11E15A Analog Digital Converter (ADC) */
+  AC_IRQn                   = 39 , /**< 39  SAML11E15A Analog Comparators (AC)  */
+  DAC_UNDERRUN_A_IRQn       = 40 , /**< 40  SAML11E15A Digital Analog Converter (DAC) */
+  DAC_EMPTY_IRQn            = 41 , /**< 41  SAML11E15A Digital Analog Converter (DAC) */
+  PTC_IRQn                  = 42 , /**< 42  SAML11E15A Peripheral Touch Controller (PTC) */
+  TRNG_IRQn                 = 43 , /**< 43  SAML11E15A True Random Generator (TRNG) */
+  TRAM_IRQn                 = 44 , /**< 44  SAML11E15A TrustRAM (TRAM)          */
+
+  PERIPH_COUNT_IRQn        = 45  /**< Number of peripheral IDs */
+} IRQn_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;                        /* -15 Reset Vector, invoked on Power up and warm reset  */
+  void* pfnNonMaskableInt_Handler;               /* -14 Non maskable Interrupt, cannot be stopped or preempted  */
+  void* pfnHardFault_Handler;                    /* -13 Hard Fault, all classes of Fault     */
+  void* pvReservedC12;
+  void* pvReservedC11;
+  void* pvReservedC10;
+  void* pvReservedC9;
+  void* pvReservedC8;
+  void* pvReservedC7;
+  void* pvReservedC6;
+  void* pfnSVCall_Handler;                       /*  -5 System Service Call via SVC instruction  */
+  void* pvReservedC4;
+  void* pvReservedC3;
+  void* pfnPendSV_Handler;                       /*  -2 Pendable request for system service  */
+  void* pfnSysTick_Handler;                      /*  -1 System Tick Timer                    */
+
+
+  /* Peripheral handlers */
+  void* pfnSYSTEM_Handler;                       /* 0   SAML11E15A Main Clock (MCLK)   */
+  void* pfnWDT_Handler;                          /* 1   SAML11E15A Watchdog Timer (WDT) */
+  void* pfnRTC_Handler;                          /* 2   SAML11E15A Real-Time Counter (RTC) */
+  void* pfnEIC_0_Handler;                        /* 3   SAML11E15A External Interrupt Controller (EIC) */
+  void* pfnEIC_1_Handler;                        /* 4   SAML11E15A External Interrupt Controller (EIC) */
+  void* pfnEIC_2_Handler;                        /* 5   SAML11E15A External Interrupt Controller (EIC) */
+  void* pfnEIC_3_Handler;                        /* 6   SAML11E15A External Interrupt Controller (EIC) */
+  void* pfnEIC_OTHER_Handler;                    /* 7   SAML11E15A External Interrupt Controller (EIC) */
+  void* pfnFREQM_Handler;                        /* 8   SAML11E15A Frequency Meter (FREQM) */
+  void* pfnNVMCTRL_Handler;                      /* 9   SAML11E15A Non-Volatile Memory Controller (NVMCTRL) */
+  void* pfnPORT_Handler;                         /* 10  SAML11E15A Port Module (PORT)  */
+  void* pfnDMAC_0_Handler;                       /* 11  SAML11E15A Direct Memory Access Controller (DMAC) */
+  void* pfnDMAC_1_Handler;                       /* 12  SAML11E15A Direct Memory Access Controller (DMAC) */
+  void* pfnDMAC_2_Handler;                       /* 13  SAML11E15A Direct Memory Access Controller (DMAC) */
+  void* pfnDMAC_3_Handler;                       /* 14  SAML11E15A Direct Memory Access Controller (DMAC) */
+  void* pfnDMAC_OTHER_Handler;                   /* 15  SAML11E15A Direct Memory Access Controller (DMAC) */
+  void* pfnEVSYS_0_Handler;                      /* 16  SAML11E15A Event System Interface (EVSYS) */
+  void* pfnEVSYS_1_Handler;                      /* 17  SAML11E15A Event System Interface (EVSYS) */
+  void* pfnEVSYS_2_Handler;                      /* 18  SAML11E15A Event System Interface (EVSYS) */
+  void* pfnEVSYS_3_Handler;                      /* 19  SAML11E15A Event System Interface (EVSYS) */
+  void* pfnEVSYS_NSCHK_Handler;                  /* 20  SAML11E15A Event System Interface (EVSYS) */
+  void* pfnPAC_Handler;                          /* 21  SAML11E15A Peripheral Access Controller (PAC) */
+  void* pfnSERCOM0_0_Handler;                    /* 22  SAML11E15A Serial Communication Interface (SERCOM0) */
+  void* pfnSERCOM0_1_Handler;                    /* 23  SAML11E15A Serial Communication Interface (SERCOM0) */
+  void* pfnSERCOM0_2_Handler;                    /* 24  SAML11E15A Serial Communication Interface (SERCOM0) */
+  void* pfnSERCOM0_OTHER_Handler;                /* 25  SAML11E15A Serial Communication Interface (SERCOM0) */
+  void* pfnSERCOM1_0_Handler;                    /* 26  SAML11E15A Serial Communication Interface (SERCOM1) */
+  void* pfnSERCOM1_1_Handler;                    /* 27  SAML11E15A Serial Communication Interface (SERCOM1) */
+  void* pfnSERCOM1_2_Handler;                    /* 28  SAML11E15A Serial Communication Interface (SERCOM1) */
+  void* pfnSERCOM1_OTHER_Handler;                /* 29  SAML11E15A Serial Communication Interface (SERCOM1) */
+  void* pfnSERCOM2_0_Handler;                    /* 30  SAML11E15A Serial Communication Interface (SERCOM2) */
+  void* pfnSERCOM2_1_Handler;                    /* 31  SAML11E15A Serial Communication Interface (SERCOM2) */
+  void* pfnSERCOM2_2_Handler;                    /* 32  SAML11E15A Serial Communication Interface (SERCOM2) */
+  void* pfnSERCOM2_OTHER_Handler;                /* 33  SAML11E15A Serial Communication Interface (SERCOM2) */
+  void* pfnTC0_Handler;                          /* 34  SAML11E15A Basic Timer Counter (TC0) */
+  void* pfnTC1_Handler;                          /* 35  SAML11E15A Basic Timer Counter (TC1) */
+  void* pfnTC2_Handler;                          /* 36  SAML11E15A Basic Timer Counter (TC2) */
+  void* pfnADC_OTHER_Handler;                    /* 37  SAML11E15A Analog Digital Converter (ADC) */
+  void* pfnADC_RESRDY_Handler;                   /* 38  SAML11E15A Analog Digital Converter (ADC) */
+  void* pfnAC_Handler;                           /* 39  SAML11E15A Analog Comparators (AC) */
+  void* pfnDAC_UNDERRUN_A_Handler;               /* 40  SAML11E15A Digital Analog Converter (DAC) */
+  void* pfnDAC_EMPTY_Handler;                    /* 41  SAML11E15A Digital Analog Converter (DAC) */
+  void* pfnPTC_Handler;                          /* 42  SAML11E15A Peripheral Touch Controller (PTC) */
+  void* pfnTRNG_Handler;                         /* 43  SAML11E15A True Random Generator (TRNG) */
+  void* pfnTRAM_Handler;                         /* 44  SAML11E15A TrustRAM (TRAM)     */
+} DeviceVectors;
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define pfnMemManage_Handler      pfnMemoryManagement_Handler     /**< \deprecated  Backward compatibility for ASF */
+#define pfnDebugMon_Handler       pfnDebugMonitor_Handler         /**< \deprecated  Backward compatibility for ASF */
+#define pfnNMI_Handler            pfnNonMaskableInt_Handler       /**< \deprecated  Backward compatibility for ASF */
+#define pfnSVC_Handler            pfnSVCall_Handler               /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if !defined DONT_USE_PREDEFINED_CORE_HANDLERS
+
+/* CORTEX-M23 core handlers */
+void Reset_Handler                 ( void );
+void NonMaskableInt_Handler        ( void );
+void HardFault_Handler             ( void );
+void SVCall_Handler                ( void );
+void PendSV_Handler                ( void );
+void SysTick_Handler               ( void );
+#endif /* DONT_USE_PREDEFINED_CORE_HANDLERS */
+
+#if !defined DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS
+
+/* Peripherals handlers */
+void AC_Handler                    ( void );
+void ADC_OTHER_Handler             ( void );
+void ADC_RESRDY_Handler            ( void );
+void DAC_EMPTY_Handler             ( void );
+void DAC_UNDERRUN_A_Handler        ( void );
+void DMAC_0_Handler                ( void );
+void DMAC_1_Handler                ( void );
+void DMAC_2_Handler                ( void );
+void DMAC_3_Handler                ( void );
+void DMAC_OTHER_Handler            ( void );
+void EIC_0_Handler                 ( void );
+void EIC_1_Handler                 ( void );
+void EIC_2_Handler                 ( void );
+void EIC_3_Handler                 ( void );
+void EIC_OTHER_Handler             ( void );
+void EVSYS_0_Handler               ( void );
+void EVSYS_1_Handler               ( void );
+void EVSYS_2_Handler               ( void );
+void EVSYS_3_Handler               ( void );
+void EVSYS_NSCHK_Handler           ( void );
+void FREQM_Handler                 ( void );
+void NVMCTRL_Handler               ( void );
+void PAC_Handler                   ( void );
+void PORT_Handler                  ( void );
+void PTC_Handler                   ( void );
+void RTC_Handler                   ( void );
+void SERCOM0_0_Handler             ( void );
+void SERCOM0_1_Handler             ( void );
+void SERCOM0_2_Handler             ( void );
+void SERCOM0_OTHER_Handler         ( void );
+void SERCOM1_0_Handler             ( void );
+void SERCOM1_1_Handler             ( void );
+void SERCOM1_2_Handler             ( void );
+void SERCOM1_OTHER_Handler         ( void );
+void SERCOM2_0_Handler             ( void );
+void SERCOM2_1_Handler             ( void );
+void SERCOM2_2_Handler             ( void );
+void SERCOM2_OTHER_Handler         ( void );
+void SYSTEM_Handler                ( void );
+void TC0_Handler                   ( void );
+void TC1_Handler                   ( void );
+void TC2_Handler                   ( void );
+void TRAM_Handler                  ( void );
+void TRNG_Handler                  ( void );
+void WDT_Handler                   ( void );
+#endif /* DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS */
+
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define MemManage_Handler         MemoryManagement_Handler        /**< \deprecated  Backward compatibility for ASF */
+#define DebugMon_Handler          DebugMonitor_Handler            /**< \deprecated  Backward compatibility for ASF */
+#define NMI_Handler               NonMaskableInt_Handler          /**< \deprecated  Backward compatibility for ASF */
+#define SVC_Handler               SVCall_Handler                  /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+
+/*
+ * \brief Configuration of the CORTEX-M23 Processor and Core Peripherals
+ */
+
+#define NUM_IRQ                       45 /**< Number of interrupt request lines                                         */
+#define __ARMv8MBL_REV            0x0000 /**< Cortex-M23 Core Revision                                                  */
+#define __ETM_PRESENT                  0 /**< ETM present or not                                                        */
+#define __FPU_PRESENT                  0 /**< FPU present or not                                                        */
+#define __MPU_PRESENT                  1 /**< MPU present or not                                                        */
+#define __MTB_PRESENT                  0 /**< MTB present or not                                                        */
+#define __NVIC_PRIO_BITS               2 /**< Number of Bits used for Priority Levels                                   */
+#define __SAU_PRESENT                  0 /**< SAU present or not                                                        */
+#define __SEC_ENABLED                  0 /**< TrustZone-M enabled or not                                                */
+#define __VTOR_PRESENT                 1 /**< Vector Table Offset Register present or not                               */
+#define __Vendor_SysTickConfig         0 /**< Set to 1 if different SysTick Config is used                              */
+#define __ARCH_ARM                     1
+#define __ARCH_ARM_CORTEX_M            1
+#define __DEVICE_IS_SAM                1
+#define __TZ_PRESENT                   1
+
+/*
+ * \brief CMSIS includes
+ */
+#include <core_cm23.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_saml11.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/** @}  end of SAML11E15A_cmsis CMSIS Definitions */
+
+/** \defgroup SAML11E15A_api Peripheral Software API
+ *  @{
+ */
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAML11E15A */
+/* ************************************************************************** */
+#include "component/ac.h"
+#include "component/adc.h"
+#include "component/ccl.h"
+#include "component/dac.h"
+#include "component/dmac.h"
+#include "component/dsu.h"
+#include "component/eic.h"
+#include "component/evsys.h"
+#include "component/freqm.h"
+#include "component/gclk.h"
+#include "component/idau.h"
+#include "component/mclk.h"
+#include "component/nvmctrl.h"
+#include "component/opamp.h"
+#include "component/oscctrl.h"
+#include "component/osc32kctrl.h"
+#include "component/pac.h"
+#include "component/pm.h"
+#include "component/port.h"
+#include "component/ptc.h"
+#include "component/rstc.h"
+#include "component/rtc.h"
+#include "component/sercom.h"
+#include "component/supc.h"
+#include "component/tc.h"
+#include "component/tram.h"
+#include "component/trng.h"
+#include "component/wdt.h"
+/** @}  end of Peripheral Software API */
+
+/** \defgroup SAML11E15A_reg Registers Access Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   REGISTER ACCESS DEFINITIONS FOR SAML11E15A */
+/* ************************************************************************** */
+#include "instance/ac.h"
+#include "instance/adc.h"
+#include "instance/ccl.h"
+#include "instance/dac.h"
+#include "instance/dmac.h"
+#include "instance/dsu.h"
+#include "instance/eic.h"
+#include "instance/evsys.h"
+#include "instance/freqm.h"
+#include "instance/gclk.h"
+#include "instance/idau.h"
+#include "instance/mclk.h"
+#include "instance/nvmctrl.h"
+#include "instance/opamp.h"
+#include "instance/oscctrl.h"
+#include "instance/osc32kctrl.h"
+#include "instance/pac.h"
+#include "instance/pm.h"
+#include "instance/port.h"
+#include "instance/ptc.h"
+#include "instance/rstc.h"
+#include "instance/rtc.h"
+#include "instance/sercom0.h"
+#include "instance/sercom1.h"
+#include "instance/sercom2.h"
+#include "instance/supc.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tram.h"
+#include "instance/trng.h"
+#include "instance/wdt.h"
+/** @}  end of Registers Access Definitions */
+
+/** \addtogroup SAML11E15A_id Peripheral Ids Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*  PERIPHERAL ID DEFINITIONS FOR SAML11E15A */
+/* ************************************************************************** */
+#define ID_PAC          (  0) /**< \brief Peripheral Access Controller (PAC) */
+#define ID_PM           (  1) /**< \brief Power Manager (PM) */
+#define ID_MCLK         (  2) /**< \brief Main Clock (MCLK) */
+#define ID_RSTC         (  3) /**< \brief Reset Controller (RSTC) */
+#define ID_OSCCTRL      (  4) /**< \brief Oscillators Control (OSCCTRL) */
+#define ID_OSC32KCTRL   (  5) /**< \brief 32k Oscillators Control (OSC32KCTRL) */
+#define ID_SUPC         (  6) /**< \brief Supply Controller (SUPC) */
+#define ID_GCLK         (  7) /**< \brief Generic Clock Generator (GCLK) */
+#define ID_WDT          (  8) /**< \brief Watchdog Timer (WDT) */
+#define ID_RTC          (  9) /**< \brief Real-Time Counter (RTC) */
+#define ID_EIC          ( 10) /**< \brief External Interrupt Controller (EIC) */
+#define ID_FREQM        ( 11) /**< \brief Frequency Meter (FREQM) */
+#define ID_PORT         ( 12) /**< \brief Port Module (PORT) */
+#define ID_AC           ( 13) /**< \brief Analog Comparators (AC) */
+#define ID_IDAU         ( 32) /**< \brief Implementation Defined Attribution Unit (IDAU) */
+#define ID_DSU          ( 33) /**< \brief Device Service Unit (DSU) */
+#define ID_NVMCTRL      ( 34) /**< \brief Non-Volatile Memory Controller (NVMCTRL) */
+#define ID_DMAC         ( 35) /**< \brief Direct Memory Access Controller (DMAC) */
+#define ID_EVSYS        ( 64) /**< \brief Event System Interface (EVSYS) */
+#define ID_SERCOM0      ( 65) /**< \brief Serial Communication Interface (SERCOM0) */
+#define ID_SERCOM1      ( 66) /**< \brief Serial Communication Interface (SERCOM1) */
+#define ID_SERCOM2      ( 67) /**< \brief Serial Communication Interface (SERCOM2) */
+#define ID_TC0          ( 68) /**< \brief Basic Timer Counter (TC0) */
+#define ID_TC1          ( 69) /**< \brief Basic Timer Counter (TC1) */
+#define ID_TC2          ( 70) /**< \brief Basic Timer Counter (TC2) */
+#define ID_ADC          ( 71) /**< \brief Analog Digital Converter (ADC) */
+#define ID_DAC          ( 72) /**< \brief Digital Analog Converter (DAC) */
+#define ID_PTC          ( 73) /**< \brief Peripheral Touch Controller (PTC) */
+#define ID_TRNG         ( 74) /**< \brief True Random Generator (TRNG) */
+#define ID_CCL          ( 75) /**< \brief Configurable Custom Logic (CCL) */
+#define ID_OPAMP        ( 76) /**< \brief Operational Amplifier (OPAMP) */
+#define ID_TRAM         ( 77) /**< \brief TrustRAM (TRAM) */
+
+#define ID_PERIPH_COUNT ( 78) /**< \brief Number of peripheral IDs */
+/** @}  end of Peripheral Ids Definitions */
+
+/** \addtogroup SAML11E15A_base Peripheral Base Address Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   BASE ADDRESS DEFINITIONS FOR SAML11E15A */
+/* ************************************************************************** */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#define AC                     (0x40003400)                   /**< \brief (AC        ) Base Address */
+#define ADC                    (0x42001C00)                   /**< \brief (ADC       ) Base Address */
+#define CCL                    (0x42002C00)                   /**< \brief (CCL       ) Base Address */
+#define DAC                    (0x42002000)                   /**< \brief (DAC       ) Base Address */
+#define DMAC                   (0x41006000)                   /**< \brief (DMAC      ) Base Address */
+#define DSU                    (0x41002000)                   /**< \brief (DSU       ) Base Address */
+#define DSU_EXT                (0x41002100)                   /**< \brief (DSU       ) Base Address */
+#define EIC                    (0x40002800)                   /**< \brief (EIC       ) Base Address */
+#define EIC_SEC                (0x40002A00)                   /**< \brief (EIC       ) Base Address */
+#define EVSYS                  (0x42000000)                   /**< \brief (EVSYS     ) Base Address */
+#define EVSYS_SEC              (0x42000200)                   /**< \brief (EVSYS     ) Base Address */
+#define FREQM                  (0x40002C00)                   /**< \brief (FREQM     ) Base Address */
+#define GCLK                   (0x40001C00)                   /**< \brief (GCLK      ) Base Address */
+#define IDAU                   (0x41000000)                   /**< \brief (IDAU      ) Base Address */
+#define MCLK                   (0x40000800)                   /**< \brief (MCLK      ) Base Address */
+#define NVMCTRL                (0x41004000)                   /**< \brief (NVMCTRL   ) Base Address */
+#define NVMCTRL_SEC            (0x41005000)                   /**< \brief (NVMCTRL   ) Base Address */
+#define OPAMP                  (0x42003000)                   /**< \brief (OPAMP     ) Base Address */
+#define OSCCTRL                (0x40001000)                   /**< \brief (OSCCTRL   ) Base Address */
+#define OSC32KCTRL             (0x40001400)                   /**< \brief (OSC32KCTRL) Base Address */
+#define PAC                    (0x40000000)                   /**< \brief (PAC       ) Base Address */
+#define PAC_SEC                (0x40000200)                   /**< \brief (PAC       ) Base Address */
+#define PM                     (0x40000400)                   /**< \brief (PM        ) Base Address */
+#define PORT                   (0x40003000)                   /**< \brief (PORT      ) Base Address */
+#define PORT_SEC               (0x40003200)                   /**< \brief (PORT      ) Base Address */
+#define PORT_IOBUS             (0x60000000)                   /**< \brief (PORT      ) Base Address */
+#define PORT_IOBUS_SEC         (0x60000200)                   /**< \brief (PORT      ) Base Address */
+#define PTC                    (0x42002400)                   /**< \brief (PTC       ) Base Address */
+#define RSTC                   (0x40000C00)                   /**< \brief (RSTC      ) Base Address */
+#define RTC                    (0x40002400)                   /**< \brief (RTC       ) Base Address */
+#define SERCOM0                (0x42000400)                   /**< \brief (SERCOM0   ) Base Address */
+#define SERCOM1                (0x42000800)                   /**< \brief (SERCOM1   ) Base Address */
+#define SERCOM2                (0x42000C00)                   /**< \brief (SERCOM2   ) Base Address */
+#define SUPC                   (0x40001800)                   /**< \brief (SUPC      ) Base Address */
+#define TC0                    (0x42001000)                   /**< \brief (TC0       ) Base Address */
+#define TC1                    (0x42001400)                   /**< \brief (TC1       ) Base Address */
+#define TC2                    (0x42001800)                   /**< \brief (TC2       ) Base Address */
+#define TRAM                   (0x42003400)                   /**< \brief (TRAM      ) Base Address */
+#define TRNG                   (0x42002800)                   /**< \brief (TRNG      ) Base Address */
+#define WDT                    (0x40002000)                   /**< \brief (WDT       ) Base Address */
+
+#else /* For C/C++ compiler */
+
+#define AC                     ((Ac *)0x40003400U)            /**< \brief (AC        ) Base Address */
+#define AC_INST_NUM            1                              /**< \brief (AC        ) Number of instances */
+#define AC_INSTS               { AC }                         /**< \brief (AC        ) Instances List */
+
+#define ADC                    ((Adc *)0x42001C00U)           /**< \brief (ADC       ) Base Address */
+#define ADC_INST_NUM           1                              /**< \brief (ADC       ) Number of instances */
+#define ADC_INSTS              { ADC }                        /**< \brief (ADC       ) Instances List */
+
+#define CCL                    ((Ccl *)0x42002C00U)           /**< \brief (CCL       ) Base Address */
+#define CCL_INST_NUM           1                              /**< \brief (CCL       ) Number of instances */
+#define CCL_INSTS              { CCL }                        /**< \brief (CCL       ) Instances List */
+
+#define DAC                    ((Dac *)0x42002000U)           /**< \brief (DAC       ) Base Address */
+#define DAC_INST_NUM           1                              /**< \brief (DAC       ) Number of instances */
+#define DAC_INSTS              { DAC }                        /**< \brief (DAC       ) Instances List */
+
+#define DMAC                   ((Dmac *)0x41006000U)          /**< \brief (DMAC      ) Base Address */
+#define DMAC_INST_NUM          1                              /**< \brief (DMAC      ) Number of instances */
+#define DMAC_INSTS             { DMAC }                       /**< \brief (DMAC      ) Instances List */
+
+#define DSU                    ((Dsu *)0x41002000U)           /**< \brief (DSU       ) Base Address */
+#define DSU_EXT                ((Dsu *)0x41002100U)           /**< \brief (DSU       ) Base Address */
+#define DSU_INST_NUM           1                              /**< \brief (DSU       ) Number of instances */
+#define DSU_INSTS              { DSU }                        /**< \brief (DSU       ) Instances List */
+
+#define EIC                    ((Eic *)0x40002800U)           /**< \brief (EIC       ) Base Address */
+#define EIC_SEC                ((Eic *)0x40002A00U)           /**< \brief (EIC       ) Base Address */
+#define EIC_INST_NUM           1                              /**< \brief (EIC       ) Number of instances */
+#define EIC_INSTS              { EIC }                        /**< \brief (EIC       ) Instances List */
+
+#define EVSYS                  ((Evsys *)0x42000000U)         /**< \brief (EVSYS     ) Base Address */
+#define EVSYS_SEC              ((Evsys *)0x42000200U)         /**< \brief (EVSYS     ) Base Address */
+#define EVSYS_INST_NUM         1                              /**< \brief (EVSYS     ) Number of instances */
+#define EVSYS_INSTS            { EVSYS }                      /**< \brief (EVSYS     ) Instances List */
+
+#define FREQM                  ((Freqm *)0x40002C00U)         /**< \brief (FREQM     ) Base Address */
+#define FREQM_INST_NUM         1                              /**< \brief (FREQM     ) Number of instances */
+#define FREQM_INSTS            { FREQM }                      /**< \brief (FREQM     ) Instances List */
+
+#define GCLK                   ((Gclk *)0x40001C00U)          /**< \brief (GCLK      ) Base Address */
+#define GCLK_INST_NUM          1                              /**< \brief (GCLK      ) Number of instances */
+#define GCLK_INSTS             { GCLK }                       /**< \brief (GCLK      ) Instances List */
+
+#define IDAU                   ((Idau *)0x41000000U)          /**< \brief (IDAU      ) Base Address */
+#define IDAU_INST_NUM          1                              /**< \brief (IDAU      ) Number of instances */
+#define IDAU_INSTS             { IDAU }                       /**< \brief (IDAU      ) Instances List */
+
+#define MCLK                   ((Mclk *)0x40000800U)          /**< \brief (MCLK      ) Base Address */
+#define MCLK_INST_NUM          1                              /**< \brief (MCLK      ) Number of instances */
+#define MCLK_INSTS             { MCLK }                       /**< \brief (MCLK      ) Instances List */
+
+#define NVMCTRL                ((Nvmctrl *)0x41004000U)       /**< \brief (NVMCTRL   ) Base Address */
+#define NVMCTRL_SEC            ((Nvmctrl *)0x41005000U)       /**< \brief (NVMCTRL   ) Base Address */
+#define NVMCTRL_INST_NUM       1                              /**< \brief (NVMCTRL   ) Number of instances */
+#define NVMCTRL_INSTS          { NVMCTRL }                    /**< \brief (NVMCTRL   ) Instances List */
+
+#define OPAMP                  ((Opamp *)0x42003000U)         /**< \brief (OPAMP     ) Base Address */
+#define OPAMP_INST_NUM         1                              /**< \brief (OPAMP     ) Number of instances */
+#define OPAMP_INSTS            { OPAMP }                      /**< \brief (OPAMP     ) Instances List */
+
+#define OSCCTRL                ((Oscctrl *)0x40001000U)       /**< \brief (OSCCTRL   ) Base Address */
+#define OSCCTRL_INST_NUM       1                              /**< \brief (OSCCTRL   ) Number of instances */
+#define OSCCTRL_INSTS          { OSCCTRL }                    /**< \brief (OSCCTRL   ) Instances List */
+
+#define OSC32KCTRL             ((Osc32kctrl *)0x40001400U)    /**< \brief (OSC32KCTRL) Base Address */
+#define OSC32KCTRL_INST_NUM    1                              /**< \brief (OSC32KCTRL) Number of instances */
+#define OSC32KCTRL_INSTS       { OSC32KCTRL }                 /**< \brief (OSC32KCTRL) Instances List */
+
+#define PAC                    ((Pac *)0x40000000U)           /**< \brief (PAC       ) Base Address */
+#define PAC_SEC                ((Pac *)0x40000200U)           /**< \brief (PAC       ) Base Address */
+#define PAC_INST_NUM           1                              /**< \brief (PAC       ) Number of instances */
+#define PAC_INSTS              { PAC }                        /**< \brief (PAC       ) Instances List */
+
+#define PM                     ((Pm *)0x40000400U)            /**< \brief (PM        ) Base Address */
+#define PM_INST_NUM            1                              /**< \brief (PM        ) Number of instances */
+#define PM_INSTS               { PM }                         /**< \brief (PM        ) Instances List */
+
+#define PORT                   ((Port *)0x40003000U)          /**< \brief (PORT      ) Base Address */
+#define PORT_SEC               ((Port *)0x40003200U)          /**< \brief (PORT      ) Base Address */
+#define PORT_IOBUS             ((Port *)0x60000000U)          /**< \brief (PORT      ) Base Address */
+#define PORT_IOBUS_SEC         ((Port *)0x60000200U)          /**< \brief (PORT      ) Base Address */
+#define PORT_INST_NUM          1                              /**< \brief (PORT      ) Number of instances */
+#define PORT_INSTS             { PORT }                       /**< \brief (PORT      ) Instances List */
+
+#define PTC                    ((Ptc *)0x42002400U)           /**< \brief (PTC       ) Base Address */
+#define PTC_INST_NUM           1                              /**< \brief (PTC       ) Number of instances */
+#define PTC_INSTS              { PTC }                        /**< \brief (PTC       ) Instances List */
+
+#define RSTC                   ((Rstc *)0x40000C00U)          /**< \brief (RSTC      ) Base Address */
+#define RSTC_INST_NUM          1                              /**< \brief (RSTC      ) Number of instances */
+#define RSTC_INSTS             { RSTC }                       /**< \brief (RSTC      ) Instances List */
+
+#define RTC                    ((Rtc *)0x40002400U)           /**< \brief (RTC       ) Base Address */
+#define RTC_INST_NUM           1                              /**< \brief (RTC       ) Number of instances */
+#define RTC_INSTS              { RTC }                        /**< \brief (RTC       ) Instances List */
+
+#define SERCOM0                ((Sercom *)0x42000400U)        /**< \brief (SERCOM0   ) Base Address */
+#define SERCOM1                ((Sercom *)0x42000800U)        /**< \brief (SERCOM1   ) Base Address */
+#define SERCOM2                ((Sercom *)0x42000C00U)        /**< \brief (SERCOM2   ) Base Address */
+#define SERCOM_INST_NUM        3                              /**< \brief (SERCOM    ) Number of instances */
+#define SERCOM_INSTS           { SERCOM0, SERCOM1, SERCOM2 }  /**< \brief (SERCOM    ) Instances List */
+
+#define SUPC                   ((Supc *)0x40001800U)          /**< \brief (SUPC      ) Base Address */
+#define SUPC_INST_NUM          1                              /**< \brief (SUPC      ) Number of instances */
+#define SUPC_INSTS             { SUPC }                       /**< \brief (SUPC      ) Instances List */
+
+#define TC0                    ((Tc *)0x42001000U)            /**< \brief (TC0       ) Base Address */
+#define TC1                    ((Tc *)0x42001400U)            /**< \brief (TC1       ) Base Address */
+#define TC2                    ((Tc *)0x42001800U)            /**< \brief (TC2       ) Base Address */
+#define TC_INST_NUM            3                              /**< \brief (TC        ) Number of instances */
+#define TC_INSTS               { TC0, TC1, TC2 }              /**< \brief (TC        ) Instances List */
+
+#define TRAM                   ((Tram *)0x42003400U)          /**< \brief (TRAM      ) Base Address */
+#define TRAM_INST_NUM          1                              /**< \brief (TRAM      ) Number of instances */
+#define TRAM_INSTS             { TRAM }                       /**< \brief (TRAM      ) Instances List */
+
+#define TRNG                   ((Trng *)0x42002800U)          /**< \brief (TRNG      ) Base Address */
+#define TRNG_INST_NUM          1                              /**< \brief (TRNG      ) Number of instances */
+#define TRNG_INSTS             { TRNG }                       /**< \brief (TRNG      ) Instances List */
+
+#define WDT                    ((Wdt *)0x40002000U)           /**< \brief (WDT       ) Base Address */
+#define WDT_INST_NUM           1                              /**< \brief (WDT       ) Number of instances */
+#define WDT_INSTS              { WDT }                        /**< \brief (WDT       ) Instances List */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Peripheral Base Address Definitions */
+
+/** \addtogroup SAML11E15A_pio Peripheral Pio Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   PIO DEFINITIONS FOR SAML11E15A*/
+/* ************************************************************************** */
+#include "pio/saml11e15a.h"
+/** @}  end of Peripheral Pio Definitions */
+
+/* ************************************************************************** */
+/*   MEMORY MAPPING DEFINITIONS FOR SAML11E15A*/
+/* ************************************************************************** */
+
+#define FLASH_SIZE               _U_(0x00008000)       /*   32kB Memory segment type: flash */
+#define FLASH_PAGE_SIZE          _U_(        64)
+#define FLASH_NB_OF_PAGES        _U_(       512)
+
+#define AUX_SIZE                 _U_(0x00000100)       /*    0kB Memory segment type: fuses */
+#define AUX_PAGE_SIZE            _U_(        64)
+#define AUX_NB_OF_PAGES          _U_(         4)
+
+#define BOCOR_SIZE               _U_(0x00000100)       /*    0kB Memory segment type: fuses */
+#define BOCOR_PAGE_SIZE          _U_(        64)
+#define BOCOR_NB_OF_PAGES        _U_(         4)
+
+#define DATAFLASH_SIZE           _U_(0x00000800)       /*    2kB Memory segment type: flash */
+#define DATAFLASH_PAGE_SIZE      _U_(        64)
+#define DATAFLASH_NB_OF_PAGES    _U_(        32)
+
+#define SW_CALIB_SIZE            _U_(0x00000008)       /*    0kB Memory segment type: fuses */
+#define TEMP_LOG_SIZE            _U_(0x00000008)       /*    0kB Memory segment type: fuses */
+#define USER_PAGE_SIZE           _U_(0x00000100)       /*    0kB Memory segment type: user_page */
+#define USER_PAGE_PAGE_SIZE      _U_(        64)
+#define USER_PAGE_NB_OF_PAGES    _U_(         4)
+
+#define HSRAM_SIZE               _U_(0x00002000)       /*    8kB Memory segment type: ram */
+#define HPB0_SIZE                _U_(0x00008000)       /*   32kB Memory segment type: io */
+#define HPB1_SIZE                _U_(0x00010000)       /*   64kB Memory segment type: io */
+#define HPB2_SIZE                _U_(0x00004000)       /*   16kB Memory segment type: io */
+#define PPB_SIZE                 _U_(0x00100000)       /* 1024kB Memory segment type: io */
+#define SCS_SIZE                 _U_(0x00001000)       /*    4kB Memory segment type: io */
+#define PERIPHERALS_SIZE         _U_(0x20000000)       /* 524288kB Memory segment type: io */
+
+#define FLASH_ADDR               _U_(0x00000000)       /**< FLASH base address (type: flash)*/
+#define AUX_ADDR                 _U_(0x00806000)       /**< AUX base address (type: fuses)*/
+#define BOCOR_ADDR               _U_(0x0080c000)       /**< BOCOR base address (type: fuses)*/
+#define DATAFLASH_ADDR           _U_(0x00400000)       /**< DATAFLASH base address (type: flash)*/
+#define SW_CALIB_ADDR            _U_(0x00806020)       /**< SW_CALIB base address (type: fuses)*/
+#define TEMP_LOG_ADDR            _U_(0x00806038)       /**< TEMP_LOG base address (type: fuses)*/
+#define USER_PAGE_ADDR           _U_(0x00804000)       /**< USER_PAGE base address (type: user_page)*/
+#define HSRAM_ADDR               _U_(0x20000000)       /**< HSRAM base address (type: ram)*/
+#define HPB0_ADDR                _U_(0x40000000)       /**< HPB0 base address (type: io)*/
+#define HPB1_ADDR                _U_(0x41000000)       /**< HPB1 base address (type: io)*/
+#define HPB2_ADDR                _U_(0x42000000)       /**< HPB2 base address (type: io)*/
+#define PPB_ADDR                 _U_(0xe0000000)       /**< PPB base address (type: io)*/
+#define SCS_ADDR                 _U_(0xe000e000)       /**< SCS base address (type: io)*/
+#define PERIPHERALS_ADDR         _U_(0x40000000)       /**< PERIPHERALS base address (type: io)*/
+
+#define NVMCTRL_AUX              AUX_ADDR              /**< \brief \deprecated Old style definition. Use AUX_ADDR instead */
+#define NVMCTRL_BOCOR            BOCOR_ADDR            /**< \brief \deprecated Old style definition. Use BOCOR_ADDR instead */
+#define NVMCTRL_DATAFLASH        DATAFLASH_ADDR        /**< \brief \deprecated Old style definition. Use DATAFLASH_ADDR instead */
+#define NVMCTRL_SW_CALIB         SW_CALIB_ADDR         /**< \brief \deprecated Old style definition. Use SW_CALIB_ADDR instead */
+#define NVMCTRL_TEMP_LOG         TEMP_LOG_ADDR         /**< \brief \deprecated Old style definition. Use TEMP_LOG_ADDR instead */
+#define NVMCTRL_USER             USER_PAGE_ADDR        /**< \brief \deprecated Old style definition. Use USER_PAGE_ADDR instead */
+
+/* ************************************************************************** */
+/**  DEVICE SIGNATURES FOR SAML11E15A */
+/* ************************************************************************** */
+#define DSU_DID                  _UL_(0X20830001)
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAML11E15A */
+/* ************************************************************************** */
+
+/* ************************************************************************** */
+/** Event Generator IDs for SAML11E15A */
+/* ************************************************************************** */
+#define EVENT_ID_GEN_OSCCTRL_XOSC_FAIL                    1 /**< ID for OSCCTRL event generator XOSC_FAIL */
+#define EVENT_ID_GEN_OSC32KCTRL_XOSC32K_FAIL              2 /**< ID for OSC32KCTRL event generator XOSC32K_FAIL */
+#define EVENT_ID_GEN_SUPC_BOD33DET                        3 /**< ID for SUPC event generator BOD33DET */
+#define EVENT_ID_GEN_RTC_PER_0                            4 /**< ID for RTC event generator PER_0 */
+#define EVENT_ID_GEN_RTC_PER_1                            5 /**< ID for RTC event generator PER_1 */
+#define EVENT_ID_GEN_RTC_PER_2                            6 /**< ID for RTC event generator PER_2 */
+#define EVENT_ID_GEN_RTC_PER_3                            7 /**< ID for RTC event generator PER_3 */
+#define EVENT_ID_GEN_RTC_PER_4                            8 /**< ID for RTC event generator PER_4 */
+#define EVENT_ID_GEN_RTC_PER_5                            9 /**< ID for RTC event generator PER_5 */
+#define EVENT_ID_GEN_RTC_PER_6                           10 /**< ID for RTC event generator PER_6 */
+#define EVENT_ID_GEN_RTC_PER_7                           11 /**< ID for RTC event generator PER_7 */
+#define EVENT_ID_GEN_RTC_CMP_0                           12 /**< ID for RTC event generator CMP_0 */
+#define EVENT_ID_GEN_RTC_CMP_1                           13 /**< ID for RTC event generator CMP_1 */
+#define EVENT_ID_GEN_RTC_TAMPER                          14 /**< ID for RTC event generator TAMPER */
+#define EVENT_ID_GEN_RTC_OVF                             15 /**< ID for RTC event generator OVF */
+#define EVENT_ID_GEN_RTC_PERD                            16 /**< ID for RTC event generator PERD */
+#define EVENT_ID_GEN_EIC_EXTINT_0                        17 /**< ID for EIC event generator EXTINT_0 */
+#define EVENT_ID_GEN_EIC_EXTINT_1                        18 /**< ID for EIC event generator EXTINT_1 */
+#define EVENT_ID_GEN_EIC_EXTINT_2                        19 /**< ID for EIC event generator EXTINT_2 */
+#define EVENT_ID_GEN_EIC_EXTINT_3                        20 /**< ID for EIC event generator EXTINT_3 */
+#define EVENT_ID_GEN_EIC_EXTINT_4                        21 /**< ID for EIC event generator EXTINT_4 */
+#define EVENT_ID_GEN_EIC_EXTINT_5                        22 /**< ID for EIC event generator EXTINT_5 */
+#define EVENT_ID_GEN_EIC_EXTINT_6                        23 /**< ID for EIC event generator EXTINT_6 */
+#define EVENT_ID_GEN_EIC_EXTINT_7                        24 /**< ID for EIC event generator EXTINT_7 */
+#define EVENT_ID_GEN_DMAC_CH_0                           25 /**< ID for DMAC event generator CH_0 */
+#define EVENT_ID_GEN_DMAC_CH_1                           26 /**< ID for DMAC event generator CH_1 */
+#define EVENT_ID_GEN_DMAC_CH_2                           27 /**< ID for DMAC event generator CH_2 */
+#define EVENT_ID_GEN_DMAC_CH_3                           28 /**< ID for DMAC event generator CH_3 */
+#define EVENT_ID_GEN_TC0_OVF                             29 /**< ID for TC0 event generator OVF */
+#define EVENT_ID_GEN_TC0_MCX_0                           30 /**< ID for TC0 event generator MCX_0 */
+#define EVENT_ID_GEN_TC0_MCX_1                           31 /**< ID for TC0 event generator MCX_1 */
+#define EVENT_ID_GEN_TC1_OVF                             32 /**< ID for TC1 event generator OVF */
+#define EVENT_ID_GEN_TC1_MCX_0                           33 /**< ID for TC1 event generator MCX_0 */
+#define EVENT_ID_GEN_TC1_MCX_1                           34 /**< ID for TC1 event generator MCX_1 */
+#define EVENT_ID_GEN_TC2_OVF                             35 /**< ID for TC2 event generator OVF */
+#define EVENT_ID_GEN_TC2_MCX_0                           36 /**< ID for TC2 event generator MCX_0 */
+#define EVENT_ID_GEN_TC2_MCX_1                           37 /**< ID for TC2 event generator MCX_1 */
+#define EVENT_ID_GEN_ADC_RESRDY                          38 /**< ID for ADC event generator RESRDY */
+#define EVENT_ID_GEN_ADC_WINMON                          39 /**< ID for ADC event generator WINMON */
+#define EVENT_ID_GEN_AC_COMP_0                           40 /**< ID for AC event generator COMP_0 */
+#define EVENT_ID_GEN_AC_COMP_1                           41 /**< ID for AC event generator COMP_1 */
+#define EVENT_ID_GEN_AC_WIN_0                            42 /**< ID for AC event generator WIN_0 */
+#define EVENT_ID_GEN_DAC_EMPTY                           43 /**< ID for DAC event generator EMPTY */
+#define EVENT_ID_GEN_TRNG_READY                          46 /**< ID for TRNG event generator READY */
+#define EVENT_ID_GEN_CCL_LUTOUT_0                        47 /**< ID for CCL event generator LUTOUT_0 */
+#define EVENT_ID_GEN_CCL_LUTOUT_1                        48 /**< ID for CCL event generator LUTOUT_1 */
+#define EVENT_ID_GEN_PAC_ERR                             49 /**< ID for PAC event generator ERR */
+
+/* ************************************************************************** */
+/** Event User IDs for SAML11E15A */
+/* ************************************************************************** */
+#define EVENT_ID_USER_OSCCTRL_TUNE                        0 /**< ID for OSCCTRL event user TUNE */
+#define EVENT_ID_USER_RTC_TAMPER                          1 /**< ID for RTC event user TAMPER */
+#define EVENT_ID_USER_NVMCTRL_PAGEW                       2 /**< ID for NVMCTRL event user PAGEW */
+#define EVENT_ID_USER_PORT_EV_0                           3 /**< ID for PORT event user EV_0 */
+#define EVENT_ID_USER_PORT_EV_1                           4 /**< ID for PORT event user EV_1 */
+#define EVENT_ID_USER_PORT_EV_2                           5 /**< ID for PORT event user EV_2 */
+#define EVENT_ID_USER_PORT_EV_3                           6 /**< ID for PORT event user EV_3 */
+#define EVENT_ID_USER_DMAC_CH_0                           7 /**< ID for DMAC event user CH_0 */
+#define EVENT_ID_USER_DMAC_CH_1                           8 /**< ID for DMAC event user CH_1 */
+#define EVENT_ID_USER_DMAC_CH_2                           9 /**< ID for DMAC event user CH_2 */
+#define EVENT_ID_USER_DMAC_CH_3                          10 /**< ID for DMAC event user CH_3 */
+#define EVENT_ID_USER_TC0_EVU                            11 /**< ID for TC0 event user EVU */
+#define EVENT_ID_USER_TC1_EVU                            12 /**< ID for TC1 event user EVU */
+#define EVENT_ID_USER_TC2_EVU                            13 /**< ID for TC2 event user EVU */
+#define EVENT_ID_USER_ADC_START                          14 /**< ID for ADC event user START */
+#define EVENT_ID_USER_ADC_SYNC                           15 /**< ID for ADC event user SYNC */
+#define EVENT_ID_USER_AC_SOC_0                           16 /**< ID for AC event user SOC_0 */
+#define EVENT_ID_USER_AC_SOC_1                           17 /**< ID for AC event user SOC_1 */
+#define EVENT_ID_USER_DAC_START                          18 /**< ID for DAC event user START */
+#define EVENT_ID_USER_CCL_LUTIN_0                        21 /**< ID for CCL event user LUTIN_0 */
+#define EVENT_ID_USER_CCL_LUTIN_1                        22 /**< ID for CCL event user LUTIN_1 */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @}  end of SAML11E15A definitions */
+
+
+#endif /* _SAML11E15A_H_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/saml11e16a.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/saml11e16a.h
@@ -1,0 +1,814 @@
+/**
+ * \file
+ *
+ * \brief Header file for ATSAML11E16A
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2018-08-31T13:51:56Z */
+#ifndef _SAML11E16A_H_
+#define _SAML11E16A_H_
+
+/** \addtogroup SAML11E16A_definitions SAML11E16A definitions
+  This file defines all structures and symbols for SAML11E16A:
+    - registers and bitfields
+    - peripheral base address
+    - peripheral ID
+    - PIO definitions
+ *  @{
+ */
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/** \defgroup Atmel_glob_defs Atmel Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+
+    \remark
+    CMSIS core has a syntax that differs from this using i.e. __I, __O, or __IO followed by 'uint<size>_t' respective types.
+    Default the header files will follow the CMSIS core syntax.
+ *  @{
+ */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+
+/* IO definitions (access restrictions to peripheral registers) */
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+
+#define CAST(type, value) ((type *)(value)) /**< Pointer Type Conversion Macro for C/C++ */
+#define REG_ACCESS(type, address) (*(type*)(address)) /**< C code: Register value */
+#else /* Assembler */
+#define CAST(type, value) (value) /**< Pointer Type Conversion Macro for Assembler */
+#define REG_ACCESS(type, address) (address) /**< Assembly code: Register address */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !defined(SKIP_INTEGER_LITERALS)
+
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x) x ## U    /**< C code: Unsigned integer literal constant value */
+#define _L_(x) x ## L    /**< C code: Long integer literal constant value */
+#define _UL_(x) x ## UL  /**< C code: Unsigned Long integer literal constant value */
+
+#else /* Assembler */
+
+#define _U_(x) x    /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x) x    /**< Assembler: Long integer literal constant value */
+#define _UL_(x) x   /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* SKIP_INTEGER_LITERALS */
+/** @}  end of Atmel Global Defines */
+
+/** \addtogroup SAML11E16A_cmsis CMSIS Definitions
+ *  @{
+ */
+/* ************************************************************************** */
+/*   CMSIS DEFINITIONS FOR SAML11E16A */
+/* ************************************************************************** */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+/******  CORTEX-M23 Processor Exceptions Numbers ******************************/
+  Reset_IRQn                = -15, /**< 1   Reset Vector, invoked on Power up and warm reset  */
+  NonMaskableInt_IRQn       = -14, /**< 2   Non maskable Interrupt, cannot be stopped or preempted  */
+  HardFault_IRQn            = -13, /**< 3   Hard Fault, all classes of Fault     */
+  SVCall_IRQn               = -5 , /**< 11  System Service Call via SVC instruction  */
+  PendSV_IRQn               = -2 , /**< 14  Pendable request for system service  */
+  SysTick_IRQn              = -1 , /**< 15  System Tick Timer                    */
+/******  SAML11E16A specific Interrupt Numbers ***********************************/
+  SYSTEM_IRQn               = 0  , /**< 0   SAML11E16A Main Clock (MCLK)        */
+  WDT_IRQn                  = 1  , /**< 1   SAML11E16A Watchdog Timer (WDT)     */
+  RTC_IRQn                  = 2  , /**< 2   SAML11E16A Real-Time Counter (RTC)  */
+  EIC_0_IRQn                = 3  , /**< 3   SAML11E16A External Interrupt Controller (EIC) */
+  EIC_1_IRQn                = 4  , /**< 4   SAML11E16A External Interrupt Controller (EIC) */
+  EIC_2_IRQn                = 5  , /**< 5   SAML11E16A External Interrupt Controller (EIC) */
+  EIC_3_IRQn                = 6  , /**< 6   SAML11E16A External Interrupt Controller (EIC) */
+  EIC_OTHER_IRQn            = 7  , /**< 7   SAML11E16A External Interrupt Controller (EIC) */
+  FREQM_IRQn                = 8  , /**< 8   SAML11E16A Frequency Meter (FREQM)  */
+  NVMCTRL_IRQn              = 9  , /**< 9   SAML11E16A Non-Volatile Memory Controller (NVMCTRL) */
+  PORT_IRQn                 = 10 , /**< 10  SAML11E16A Port Module (PORT)       */
+  DMAC_0_IRQn               = 11 , /**< 11  SAML11E16A Direct Memory Access Controller (DMAC) */
+  DMAC_1_IRQn               = 12 , /**< 12  SAML11E16A Direct Memory Access Controller (DMAC) */
+  DMAC_2_IRQn               = 13 , /**< 13  SAML11E16A Direct Memory Access Controller (DMAC) */
+  DMAC_3_IRQn               = 14 , /**< 14  SAML11E16A Direct Memory Access Controller (DMAC) */
+  DMAC_OTHER_IRQn           = 15 , /**< 15  SAML11E16A Direct Memory Access Controller (DMAC) */
+  EVSYS_0_IRQn              = 16 , /**< 16  SAML11E16A Event System Interface (EVSYS) */
+  EVSYS_1_IRQn              = 17 , /**< 17  SAML11E16A Event System Interface (EVSYS) */
+  EVSYS_2_IRQn              = 18 , /**< 18  SAML11E16A Event System Interface (EVSYS) */
+  EVSYS_3_IRQn              = 19 , /**< 19  SAML11E16A Event System Interface (EVSYS) */
+  EVSYS_NSCHK_IRQn          = 20 , /**< 20  SAML11E16A Event System Interface (EVSYS) */
+  PAC_IRQn                  = 21 , /**< 21  SAML11E16A Peripheral Access Controller (PAC) */
+  SERCOM0_0_IRQn            = 22 , /**< 22  SAML11E16A Serial Communication Interface (SERCOM0) */
+  SERCOM0_1_IRQn            = 23 , /**< 23  SAML11E16A Serial Communication Interface (SERCOM0) */
+  SERCOM0_2_IRQn            = 24 , /**< 24  SAML11E16A Serial Communication Interface (SERCOM0) */
+  SERCOM0_OTHER_IRQn        = 25 , /**< 25  SAML11E16A Serial Communication Interface (SERCOM0) */
+  SERCOM1_0_IRQn            = 26 , /**< 26  SAML11E16A Serial Communication Interface (SERCOM1) */
+  SERCOM1_1_IRQn            = 27 , /**< 27  SAML11E16A Serial Communication Interface (SERCOM1) */
+  SERCOM1_2_IRQn            = 28 , /**< 28  SAML11E16A Serial Communication Interface (SERCOM1) */
+  SERCOM1_OTHER_IRQn        = 29 , /**< 29  SAML11E16A Serial Communication Interface (SERCOM1) */
+  SERCOM2_0_IRQn            = 30 , /**< 30  SAML11E16A Serial Communication Interface (SERCOM2) */
+  SERCOM2_1_IRQn            = 31 , /**< 31  SAML11E16A Serial Communication Interface (SERCOM2) */
+  SERCOM2_2_IRQn            = 32 , /**< 32  SAML11E16A Serial Communication Interface (SERCOM2) */
+  SERCOM2_OTHER_IRQn        = 33 , /**< 33  SAML11E16A Serial Communication Interface (SERCOM2) */
+  TC0_IRQn                  = 34 , /**< 34  SAML11E16A Basic Timer Counter (TC0) */
+  TC1_IRQn                  = 35 , /**< 35  SAML11E16A Basic Timer Counter (TC1) */
+  TC2_IRQn                  = 36 , /**< 36  SAML11E16A Basic Timer Counter (TC2) */
+  ADC_OTHER_IRQn            = 37 , /**< 37  SAML11E16A Analog Digital Converter (ADC) */
+  ADC_RESRDY_IRQn           = 38 , /**< 38  SAML11E16A Analog Digital Converter (ADC) */
+  AC_IRQn                   = 39 , /**< 39  SAML11E16A Analog Comparators (AC)  */
+  DAC_UNDERRUN_A_IRQn       = 40 , /**< 40  SAML11E16A Digital Analog Converter (DAC) */
+  DAC_EMPTY_IRQn            = 41 , /**< 41  SAML11E16A Digital Analog Converter (DAC) */
+  PTC_IRQn                  = 42 , /**< 42  SAML11E16A Peripheral Touch Controller (PTC) */
+  TRNG_IRQn                 = 43 , /**< 43  SAML11E16A True Random Generator (TRNG) */
+  TRAM_IRQn                 = 44 , /**< 44  SAML11E16A TrustRAM (TRAM)          */
+
+  PERIPH_COUNT_IRQn        = 45  /**< Number of peripheral IDs */
+} IRQn_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;                        /* -15 Reset Vector, invoked on Power up and warm reset  */
+  void* pfnNonMaskableInt_Handler;               /* -14 Non maskable Interrupt, cannot be stopped or preempted  */
+  void* pfnHardFault_Handler;                    /* -13 Hard Fault, all classes of Fault     */
+  void* pvReservedC12;
+  void* pvReservedC11;
+  void* pvReservedC10;
+  void* pvReservedC9;
+  void* pvReservedC8;
+  void* pvReservedC7;
+  void* pvReservedC6;
+  void* pfnSVCall_Handler;                       /*  -5 System Service Call via SVC instruction  */
+  void* pvReservedC4;
+  void* pvReservedC3;
+  void* pfnPendSV_Handler;                       /*  -2 Pendable request for system service  */
+  void* pfnSysTick_Handler;                      /*  -1 System Tick Timer                    */
+
+
+  /* Peripheral handlers */
+  void* pfnSYSTEM_Handler;                       /* 0   SAML11E16A Main Clock (MCLK)   */
+  void* pfnWDT_Handler;                          /* 1   SAML11E16A Watchdog Timer (WDT) */
+  void* pfnRTC_Handler;                          /* 2   SAML11E16A Real-Time Counter (RTC) */
+  void* pfnEIC_0_Handler;                        /* 3   SAML11E16A External Interrupt Controller (EIC) */
+  void* pfnEIC_1_Handler;                        /* 4   SAML11E16A External Interrupt Controller (EIC) */
+  void* pfnEIC_2_Handler;                        /* 5   SAML11E16A External Interrupt Controller (EIC) */
+  void* pfnEIC_3_Handler;                        /* 6   SAML11E16A External Interrupt Controller (EIC) */
+  void* pfnEIC_OTHER_Handler;                    /* 7   SAML11E16A External Interrupt Controller (EIC) */
+  void* pfnFREQM_Handler;                        /* 8   SAML11E16A Frequency Meter (FREQM) */
+  void* pfnNVMCTRL_Handler;                      /* 9   SAML11E16A Non-Volatile Memory Controller (NVMCTRL) */
+  void* pfnPORT_Handler;                         /* 10  SAML11E16A Port Module (PORT)  */
+  void* pfnDMAC_0_Handler;                       /* 11  SAML11E16A Direct Memory Access Controller (DMAC) */
+  void* pfnDMAC_1_Handler;                       /* 12  SAML11E16A Direct Memory Access Controller (DMAC) */
+  void* pfnDMAC_2_Handler;                       /* 13  SAML11E16A Direct Memory Access Controller (DMAC) */
+  void* pfnDMAC_3_Handler;                       /* 14  SAML11E16A Direct Memory Access Controller (DMAC) */
+  void* pfnDMAC_OTHER_Handler;                   /* 15  SAML11E16A Direct Memory Access Controller (DMAC) */
+  void* pfnEVSYS_0_Handler;                      /* 16  SAML11E16A Event System Interface (EVSYS) */
+  void* pfnEVSYS_1_Handler;                      /* 17  SAML11E16A Event System Interface (EVSYS) */
+  void* pfnEVSYS_2_Handler;                      /* 18  SAML11E16A Event System Interface (EVSYS) */
+  void* pfnEVSYS_3_Handler;                      /* 19  SAML11E16A Event System Interface (EVSYS) */
+  void* pfnEVSYS_NSCHK_Handler;                  /* 20  SAML11E16A Event System Interface (EVSYS) */
+  void* pfnPAC_Handler;                          /* 21  SAML11E16A Peripheral Access Controller (PAC) */
+  void* pfnSERCOM0_0_Handler;                    /* 22  SAML11E16A Serial Communication Interface (SERCOM0) */
+  void* pfnSERCOM0_1_Handler;                    /* 23  SAML11E16A Serial Communication Interface (SERCOM0) */
+  void* pfnSERCOM0_2_Handler;                    /* 24  SAML11E16A Serial Communication Interface (SERCOM0) */
+  void* pfnSERCOM0_OTHER_Handler;                /* 25  SAML11E16A Serial Communication Interface (SERCOM0) */
+  void* pfnSERCOM1_0_Handler;                    /* 26  SAML11E16A Serial Communication Interface (SERCOM1) */
+  void* pfnSERCOM1_1_Handler;                    /* 27  SAML11E16A Serial Communication Interface (SERCOM1) */
+  void* pfnSERCOM1_2_Handler;                    /* 28  SAML11E16A Serial Communication Interface (SERCOM1) */
+  void* pfnSERCOM1_OTHER_Handler;                /* 29  SAML11E16A Serial Communication Interface (SERCOM1) */
+  void* pfnSERCOM2_0_Handler;                    /* 30  SAML11E16A Serial Communication Interface (SERCOM2) */
+  void* pfnSERCOM2_1_Handler;                    /* 31  SAML11E16A Serial Communication Interface (SERCOM2) */
+  void* pfnSERCOM2_2_Handler;                    /* 32  SAML11E16A Serial Communication Interface (SERCOM2) */
+  void* pfnSERCOM2_OTHER_Handler;                /* 33  SAML11E16A Serial Communication Interface (SERCOM2) */
+  void* pfnTC0_Handler;                          /* 34  SAML11E16A Basic Timer Counter (TC0) */
+  void* pfnTC1_Handler;                          /* 35  SAML11E16A Basic Timer Counter (TC1) */
+  void* pfnTC2_Handler;                          /* 36  SAML11E16A Basic Timer Counter (TC2) */
+  void* pfnADC_OTHER_Handler;                    /* 37  SAML11E16A Analog Digital Converter (ADC) */
+  void* pfnADC_RESRDY_Handler;                   /* 38  SAML11E16A Analog Digital Converter (ADC) */
+  void* pfnAC_Handler;                           /* 39  SAML11E16A Analog Comparators (AC) */
+  void* pfnDAC_UNDERRUN_A_Handler;               /* 40  SAML11E16A Digital Analog Converter (DAC) */
+  void* pfnDAC_EMPTY_Handler;                    /* 41  SAML11E16A Digital Analog Converter (DAC) */
+  void* pfnPTC_Handler;                          /* 42  SAML11E16A Peripheral Touch Controller (PTC) */
+  void* pfnTRNG_Handler;                         /* 43  SAML11E16A True Random Generator (TRNG) */
+  void* pfnTRAM_Handler;                         /* 44  SAML11E16A TrustRAM (TRAM)     */
+} DeviceVectors;
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define pfnMemManage_Handler      pfnMemoryManagement_Handler     /**< \deprecated  Backward compatibility for ASF */
+#define pfnDebugMon_Handler       pfnDebugMonitor_Handler         /**< \deprecated  Backward compatibility for ASF */
+#define pfnNMI_Handler            pfnNonMaskableInt_Handler       /**< \deprecated  Backward compatibility for ASF */
+#define pfnSVC_Handler            pfnSVCall_Handler               /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if !defined DONT_USE_PREDEFINED_CORE_HANDLERS
+
+/* CORTEX-M23 core handlers */
+void Reset_Handler                 ( void );
+void NonMaskableInt_Handler        ( void );
+void HardFault_Handler             ( void );
+void SVCall_Handler                ( void );
+void PendSV_Handler                ( void );
+void SysTick_Handler               ( void );
+#endif /* DONT_USE_PREDEFINED_CORE_HANDLERS */
+
+#if !defined DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS
+
+/* Peripherals handlers */
+void AC_Handler                    ( void );
+void ADC_OTHER_Handler             ( void );
+void ADC_RESRDY_Handler            ( void );
+void DAC_EMPTY_Handler             ( void );
+void DAC_UNDERRUN_A_Handler        ( void );
+void DMAC_0_Handler                ( void );
+void DMAC_1_Handler                ( void );
+void DMAC_2_Handler                ( void );
+void DMAC_3_Handler                ( void );
+void DMAC_OTHER_Handler            ( void );
+void EIC_0_Handler                 ( void );
+void EIC_1_Handler                 ( void );
+void EIC_2_Handler                 ( void );
+void EIC_3_Handler                 ( void );
+void EIC_OTHER_Handler             ( void );
+void EVSYS_0_Handler               ( void );
+void EVSYS_1_Handler               ( void );
+void EVSYS_2_Handler               ( void );
+void EVSYS_3_Handler               ( void );
+void EVSYS_NSCHK_Handler           ( void );
+void FREQM_Handler                 ( void );
+void NVMCTRL_Handler               ( void );
+void PAC_Handler                   ( void );
+void PORT_Handler                  ( void );
+void PTC_Handler                   ( void );
+void RTC_Handler                   ( void );
+void SERCOM0_0_Handler             ( void );
+void SERCOM0_1_Handler             ( void );
+void SERCOM0_2_Handler             ( void );
+void SERCOM0_OTHER_Handler         ( void );
+void SERCOM1_0_Handler             ( void );
+void SERCOM1_1_Handler             ( void );
+void SERCOM1_2_Handler             ( void );
+void SERCOM1_OTHER_Handler         ( void );
+void SERCOM2_0_Handler             ( void );
+void SERCOM2_1_Handler             ( void );
+void SERCOM2_2_Handler             ( void );
+void SERCOM2_OTHER_Handler         ( void );
+void SYSTEM_Handler                ( void );
+void TC0_Handler                   ( void );
+void TC1_Handler                   ( void );
+void TC2_Handler                   ( void );
+void TRAM_Handler                  ( void );
+void TRNG_Handler                  ( void );
+void WDT_Handler                   ( void );
+#endif /* DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS */
+
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define MemManage_Handler         MemoryManagement_Handler        /**< \deprecated  Backward compatibility for ASF */
+#define DebugMon_Handler          DebugMonitor_Handler            /**< \deprecated  Backward compatibility for ASF */
+#define NMI_Handler               NonMaskableInt_Handler          /**< \deprecated  Backward compatibility for ASF */
+#define SVC_Handler               SVCall_Handler                  /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+
+/*
+ * \brief Configuration of the CORTEX-M23 Processor and Core Peripherals
+ */
+
+#define NUM_IRQ                       45 /**< Number of interrupt request lines                                         */
+#define __ARMv8MBL_REV            0x0000 /**< Cortex-M23 Core Revision                                                  */
+#define __ETM_PRESENT                  0 /**< ETM present or not                                                        */
+#define __FPU_PRESENT                  0 /**< FPU present or not                                                        */
+#define __MPU_PRESENT                  1 /**< MPU present or not                                                        */
+#define __MTB_PRESENT                  0 /**< MTB present or not                                                        */
+#define __NVIC_PRIO_BITS               2 /**< Number of Bits used for Priority Levels                                   */
+#define __SAU_PRESENT                  0 /**< SAU present or not                                                        */
+#define __SEC_ENABLED                  0 /**< TrustZone-M enabled or not                                                */
+#define __VTOR_PRESENT                 1 /**< Vector Table Offset Register present or not                               */
+#define __Vendor_SysTickConfig         0 /**< Set to 1 if different SysTick Config is used                              */
+#define __ARCH_ARM                     1
+#define __ARCH_ARM_CORTEX_M            1
+#define __DEVICE_IS_SAM                1
+#define __TZ_PRESENT                   1
+
+/*
+ * \brief CMSIS includes
+ */
+#include <core_cm23.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_saml11.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/** @}  end of SAML11E16A_cmsis CMSIS Definitions */
+
+/** \defgroup SAML11E16A_api Peripheral Software API
+ *  @{
+ */
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAML11E16A */
+/* ************************************************************************** */
+#include "component/ac.h"
+#include "component/adc.h"
+#include "component/ccl.h"
+#include "component/dac.h"
+#include "component/dmac.h"
+#include "component/dsu.h"
+#include "component/eic.h"
+#include "component/evsys.h"
+#include "component/freqm.h"
+#include "component/gclk.h"
+#include "component/idau.h"
+#include "component/mclk.h"
+#include "component/nvmctrl.h"
+#include "component/opamp.h"
+#include "component/oscctrl.h"
+#include "component/osc32kctrl.h"
+#include "component/pac.h"
+#include "component/pm.h"
+#include "component/port.h"
+#include "component/ptc.h"
+#include "component/rstc.h"
+#include "component/rtc.h"
+#include "component/sercom.h"
+#include "component/supc.h"
+#include "component/tc.h"
+#include "component/tram.h"
+#include "component/trng.h"
+#include "component/wdt.h"
+/** @}  end of Peripheral Software API */
+
+/** \defgroup SAML11E16A_reg Registers Access Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   REGISTER ACCESS DEFINITIONS FOR SAML11E16A */
+/* ************************************************************************** */
+#include "instance/ac.h"
+#include "instance/adc.h"
+#include "instance/ccl.h"
+#include "instance/dac.h"
+#include "instance/dmac.h"
+#include "instance/dsu.h"
+#include "instance/eic.h"
+#include "instance/evsys.h"
+#include "instance/freqm.h"
+#include "instance/gclk.h"
+#include "instance/idau.h"
+#include "instance/mclk.h"
+#include "instance/nvmctrl.h"
+#include "instance/opamp.h"
+#include "instance/oscctrl.h"
+#include "instance/osc32kctrl.h"
+#include "instance/pac.h"
+#include "instance/pm.h"
+#include "instance/port.h"
+#include "instance/ptc.h"
+#include "instance/rstc.h"
+#include "instance/rtc.h"
+#include "instance/sercom0.h"
+#include "instance/sercom1.h"
+#include "instance/sercom2.h"
+#include "instance/supc.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tram.h"
+#include "instance/trng.h"
+#include "instance/wdt.h"
+/** @}  end of Registers Access Definitions */
+
+/** \addtogroup SAML11E16A_id Peripheral Ids Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*  PERIPHERAL ID DEFINITIONS FOR SAML11E16A */
+/* ************************************************************************** */
+#define ID_PAC          (  0) /**< \brief Peripheral Access Controller (PAC) */
+#define ID_PM           (  1) /**< \brief Power Manager (PM) */
+#define ID_MCLK         (  2) /**< \brief Main Clock (MCLK) */
+#define ID_RSTC         (  3) /**< \brief Reset Controller (RSTC) */
+#define ID_OSCCTRL      (  4) /**< \brief Oscillators Control (OSCCTRL) */
+#define ID_OSC32KCTRL   (  5) /**< \brief 32k Oscillators Control (OSC32KCTRL) */
+#define ID_SUPC         (  6) /**< \brief Supply Controller (SUPC) */
+#define ID_GCLK         (  7) /**< \brief Generic Clock Generator (GCLK) */
+#define ID_WDT          (  8) /**< \brief Watchdog Timer (WDT) */
+#define ID_RTC          (  9) /**< \brief Real-Time Counter (RTC) */
+#define ID_EIC          ( 10) /**< \brief External Interrupt Controller (EIC) */
+#define ID_FREQM        ( 11) /**< \brief Frequency Meter (FREQM) */
+#define ID_PORT         ( 12) /**< \brief Port Module (PORT) */
+#define ID_AC           ( 13) /**< \brief Analog Comparators (AC) */
+#define ID_IDAU         ( 32) /**< \brief Implementation Defined Attribution Unit (IDAU) */
+#define ID_DSU          ( 33) /**< \brief Device Service Unit (DSU) */
+#define ID_NVMCTRL      ( 34) /**< \brief Non-Volatile Memory Controller (NVMCTRL) */
+#define ID_DMAC         ( 35) /**< \brief Direct Memory Access Controller (DMAC) */
+#define ID_EVSYS        ( 64) /**< \brief Event System Interface (EVSYS) */
+#define ID_SERCOM0      ( 65) /**< \brief Serial Communication Interface (SERCOM0) */
+#define ID_SERCOM1      ( 66) /**< \brief Serial Communication Interface (SERCOM1) */
+#define ID_SERCOM2      ( 67) /**< \brief Serial Communication Interface (SERCOM2) */
+#define ID_TC0          ( 68) /**< \brief Basic Timer Counter (TC0) */
+#define ID_TC1          ( 69) /**< \brief Basic Timer Counter (TC1) */
+#define ID_TC2          ( 70) /**< \brief Basic Timer Counter (TC2) */
+#define ID_ADC          ( 71) /**< \brief Analog Digital Converter (ADC) */
+#define ID_DAC          ( 72) /**< \brief Digital Analog Converter (DAC) */
+#define ID_PTC          ( 73) /**< \brief Peripheral Touch Controller (PTC) */
+#define ID_TRNG         ( 74) /**< \brief True Random Generator (TRNG) */
+#define ID_CCL          ( 75) /**< \brief Configurable Custom Logic (CCL) */
+#define ID_OPAMP        ( 76) /**< \brief Operational Amplifier (OPAMP) */
+#define ID_TRAM         ( 77) /**< \brief TrustRAM (TRAM) */
+
+#define ID_PERIPH_COUNT ( 78) /**< \brief Number of peripheral IDs */
+/** @}  end of Peripheral Ids Definitions */
+
+/** \addtogroup SAML11E16A_base Peripheral Base Address Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   BASE ADDRESS DEFINITIONS FOR SAML11E16A */
+/* ************************************************************************** */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#define AC                     (0x40003400)                   /**< \brief (AC        ) Base Address */
+#define ADC                    (0x42001C00)                   /**< \brief (ADC       ) Base Address */
+#define CCL                    (0x42002C00)                   /**< \brief (CCL       ) Base Address */
+#define DAC                    (0x42002000)                   /**< \brief (DAC       ) Base Address */
+#define DMAC                   (0x41006000)                   /**< \brief (DMAC      ) Base Address */
+#define DSU                    (0x41002000)                   /**< \brief (DSU       ) Base Address */
+#define DSU_EXT                (0x41002100)                   /**< \brief (DSU       ) Base Address */
+#define EIC                    (0x40002800)                   /**< \brief (EIC       ) Base Address */
+#define EIC_SEC                (0x40002A00)                   /**< \brief (EIC       ) Base Address */
+#define EVSYS                  (0x42000000)                   /**< \brief (EVSYS     ) Base Address */
+#define EVSYS_SEC              (0x42000200)                   /**< \brief (EVSYS     ) Base Address */
+#define FREQM                  (0x40002C00)                   /**< \brief (FREQM     ) Base Address */
+#define GCLK                   (0x40001C00)                   /**< \brief (GCLK      ) Base Address */
+#define IDAU                   (0x41000000)                   /**< \brief (IDAU      ) Base Address */
+#define MCLK                   (0x40000800)                   /**< \brief (MCLK      ) Base Address */
+#define NVMCTRL                (0x41004000)                   /**< \brief (NVMCTRL   ) Base Address */
+#define NVMCTRL_SEC            (0x41005000)                   /**< \brief (NVMCTRL   ) Base Address */
+#define OPAMP                  (0x42003000)                   /**< \brief (OPAMP     ) Base Address */
+#define OSCCTRL                (0x40001000)                   /**< \brief (OSCCTRL   ) Base Address */
+#define OSC32KCTRL             (0x40001400)                   /**< \brief (OSC32KCTRL) Base Address */
+#define PAC                    (0x40000000)                   /**< \brief (PAC       ) Base Address */
+#define PAC_SEC                (0x40000200)                   /**< \brief (PAC       ) Base Address */
+#define PM                     (0x40000400)                   /**< \brief (PM        ) Base Address */
+#define PORT                   (0x40003000)                   /**< \brief (PORT      ) Base Address */
+#define PORT_SEC               (0x40003200)                   /**< \brief (PORT      ) Base Address */
+#define PORT_IOBUS             (0x60000000)                   /**< \brief (PORT      ) Base Address */
+#define PORT_IOBUS_SEC         (0x60000200)                   /**< \brief (PORT      ) Base Address */
+#define PTC                    (0x42002400)                   /**< \brief (PTC       ) Base Address */
+#define RSTC                   (0x40000C00)                   /**< \brief (RSTC      ) Base Address */
+#define RTC                    (0x40002400)                   /**< \brief (RTC       ) Base Address */
+#define SERCOM0                (0x42000400)                   /**< \brief (SERCOM0   ) Base Address */
+#define SERCOM1                (0x42000800)                   /**< \brief (SERCOM1   ) Base Address */
+#define SERCOM2                (0x42000C00)                   /**< \brief (SERCOM2   ) Base Address */
+#define SUPC                   (0x40001800)                   /**< \brief (SUPC      ) Base Address */
+#define TC0                    (0x42001000)                   /**< \brief (TC0       ) Base Address */
+#define TC1                    (0x42001400)                   /**< \brief (TC1       ) Base Address */
+#define TC2                    (0x42001800)                   /**< \brief (TC2       ) Base Address */
+#define TRAM                   (0x42003400)                   /**< \brief (TRAM      ) Base Address */
+#define TRNG                   (0x42002800)                   /**< \brief (TRNG      ) Base Address */
+#define WDT                    (0x40002000)                   /**< \brief (WDT       ) Base Address */
+
+#else /* For C/C++ compiler */
+
+#define AC                     ((Ac *)0x40003400U)            /**< \brief (AC        ) Base Address */
+#define AC_INST_NUM            1                              /**< \brief (AC        ) Number of instances */
+#define AC_INSTS               { AC }                         /**< \brief (AC        ) Instances List */
+
+#define ADC                    ((Adc *)0x42001C00U)           /**< \brief (ADC       ) Base Address */
+#define ADC_INST_NUM           1                              /**< \brief (ADC       ) Number of instances */
+#define ADC_INSTS              { ADC }                        /**< \brief (ADC       ) Instances List */
+
+#define CCL                    ((Ccl *)0x42002C00U)           /**< \brief (CCL       ) Base Address */
+#define CCL_INST_NUM           1                              /**< \brief (CCL       ) Number of instances */
+#define CCL_INSTS              { CCL }                        /**< \brief (CCL       ) Instances List */
+
+#define DAC                    ((Dac *)0x42002000U)           /**< \brief (DAC       ) Base Address */
+#define DAC_INST_NUM           1                              /**< \brief (DAC       ) Number of instances */
+#define DAC_INSTS              { DAC }                        /**< \brief (DAC       ) Instances List */
+
+#define DMAC                   ((Dmac *)0x41006000U)          /**< \brief (DMAC      ) Base Address */
+#define DMAC_INST_NUM          1                              /**< \brief (DMAC      ) Number of instances */
+#define DMAC_INSTS             { DMAC }                       /**< \brief (DMAC      ) Instances List */
+
+#define DSU                    ((Dsu *)0x41002000U)           /**< \brief (DSU       ) Base Address */
+#define DSU_EXT                ((Dsu *)0x41002100U)           /**< \brief (DSU       ) Base Address */
+#define DSU_INST_NUM           1                              /**< \brief (DSU       ) Number of instances */
+#define DSU_INSTS              { DSU }                        /**< \brief (DSU       ) Instances List */
+
+#define EIC                    ((Eic *)0x40002800U)           /**< \brief (EIC       ) Base Address */
+#define EIC_SEC                ((Eic *)0x40002A00U)           /**< \brief (EIC       ) Base Address */
+#define EIC_INST_NUM           1                              /**< \brief (EIC       ) Number of instances */
+#define EIC_INSTS              { EIC }                        /**< \brief (EIC       ) Instances List */
+
+#define EVSYS                  ((Evsys *)0x42000000U)         /**< \brief (EVSYS     ) Base Address */
+#define EVSYS_SEC              ((Evsys *)0x42000200U)         /**< \brief (EVSYS     ) Base Address */
+#define EVSYS_INST_NUM         1                              /**< \brief (EVSYS     ) Number of instances */
+#define EVSYS_INSTS            { EVSYS }                      /**< \brief (EVSYS     ) Instances List */
+
+#define FREQM                  ((Freqm *)0x40002C00U)         /**< \brief (FREQM     ) Base Address */
+#define FREQM_INST_NUM         1                              /**< \brief (FREQM     ) Number of instances */
+#define FREQM_INSTS            { FREQM }                      /**< \brief (FREQM     ) Instances List */
+
+#define GCLK                   ((Gclk *)0x40001C00U)          /**< \brief (GCLK      ) Base Address */
+#define GCLK_INST_NUM          1                              /**< \brief (GCLK      ) Number of instances */
+#define GCLK_INSTS             { GCLK }                       /**< \brief (GCLK      ) Instances List */
+
+#define IDAU                   ((Idau *)0x41000000U)          /**< \brief (IDAU      ) Base Address */
+#define IDAU_INST_NUM          1                              /**< \brief (IDAU      ) Number of instances */
+#define IDAU_INSTS             { IDAU }                       /**< \brief (IDAU      ) Instances List */
+
+#define MCLK                   ((Mclk *)0x40000800U)          /**< \brief (MCLK      ) Base Address */
+#define MCLK_INST_NUM          1                              /**< \brief (MCLK      ) Number of instances */
+#define MCLK_INSTS             { MCLK }                       /**< \brief (MCLK      ) Instances List */
+
+#define NVMCTRL                ((Nvmctrl *)0x41004000U)       /**< \brief (NVMCTRL   ) Base Address */
+#define NVMCTRL_SEC            ((Nvmctrl *)0x41005000U)       /**< \brief (NVMCTRL   ) Base Address */
+#define NVMCTRL_INST_NUM       1                              /**< \brief (NVMCTRL   ) Number of instances */
+#define NVMCTRL_INSTS          { NVMCTRL }                    /**< \brief (NVMCTRL   ) Instances List */
+
+#define OPAMP                  ((Opamp *)0x42003000U)         /**< \brief (OPAMP     ) Base Address */
+#define OPAMP_INST_NUM         1                              /**< \brief (OPAMP     ) Number of instances */
+#define OPAMP_INSTS            { OPAMP }                      /**< \brief (OPAMP     ) Instances List */
+
+#define OSCCTRL                ((Oscctrl *)0x40001000U)       /**< \brief (OSCCTRL   ) Base Address */
+#define OSCCTRL_INST_NUM       1                              /**< \brief (OSCCTRL   ) Number of instances */
+#define OSCCTRL_INSTS          { OSCCTRL }                    /**< \brief (OSCCTRL   ) Instances List */
+
+#define OSC32KCTRL             ((Osc32kctrl *)0x40001400U)    /**< \brief (OSC32KCTRL) Base Address */
+#define OSC32KCTRL_INST_NUM    1                              /**< \brief (OSC32KCTRL) Number of instances */
+#define OSC32KCTRL_INSTS       { OSC32KCTRL }                 /**< \brief (OSC32KCTRL) Instances List */
+
+#define PAC                    ((Pac *)0x40000000U)           /**< \brief (PAC       ) Base Address */
+#define PAC_SEC                ((Pac *)0x40000200U)           /**< \brief (PAC       ) Base Address */
+#define PAC_INST_NUM           1                              /**< \brief (PAC       ) Number of instances */
+#define PAC_INSTS              { PAC }                        /**< \brief (PAC       ) Instances List */
+
+#define PM                     ((Pm *)0x40000400U)            /**< \brief (PM        ) Base Address */
+#define PM_INST_NUM            1                              /**< \brief (PM        ) Number of instances */
+#define PM_INSTS               { PM }                         /**< \brief (PM        ) Instances List */
+
+#define PORT                   ((Port *)0x40003000U)          /**< \brief (PORT      ) Base Address */
+#define PORT_SEC               ((Port *)0x40003200U)          /**< \brief (PORT      ) Base Address */
+#define PORT_IOBUS             ((Port *)0x60000000U)          /**< \brief (PORT      ) Base Address */
+#define PORT_IOBUS_SEC         ((Port *)0x60000200U)          /**< \brief (PORT      ) Base Address */
+#define PORT_INST_NUM          1                              /**< \brief (PORT      ) Number of instances */
+#define PORT_INSTS             { PORT }                       /**< \brief (PORT      ) Instances List */
+
+#define PTC                    ((Ptc *)0x42002400U)           /**< \brief (PTC       ) Base Address */
+#define PTC_INST_NUM           1                              /**< \brief (PTC       ) Number of instances */
+#define PTC_INSTS              { PTC }                        /**< \brief (PTC       ) Instances List */
+
+#define RSTC                   ((Rstc *)0x40000C00U)          /**< \brief (RSTC      ) Base Address */
+#define RSTC_INST_NUM          1                              /**< \brief (RSTC      ) Number of instances */
+#define RSTC_INSTS             { RSTC }                       /**< \brief (RSTC      ) Instances List */
+
+#define RTC                    ((Rtc *)0x40002400U)           /**< \brief (RTC       ) Base Address */
+#define RTC_INST_NUM           1                              /**< \brief (RTC       ) Number of instances */
+#define RTC_INSTS              { RTC }                        /**< \brief (RTC       ) Instances List */
+
+#define SERCOM0                ((Sercom *)0x42000400U)        /**< \brief (SERCOM0   ) Base Address */
+#define SERCOM1                ((Sercom *)0x42000800U)        /**< \brief (SERCOM1   ) Base Address */
+#define SERCOM2                ((Sercom *)0x42000C00U)        /**< \brief (SERCOM2   ) Base Address */
+#define SERCOM_INST_NUM        3                              /**< \brief (SERCOM    ) Number of instances */
+#define SERCOM_INSTS           { SERCOM0, SERCOM1, SERCOM2 }  /**< \brief (SERCOM    ) Instances List */
+
+#define SUPC                   ((Supc *)0x40001800U)          /**< \brief (SUPC      ) Base Address */
+#define SUPC_INST_NUM          1                              /**< \brief (SUPC      ) Number of instances */
+#define SUPC_INSTS             { SUPC }                       /**< \brief (SUPC      ) Instances List */
+
+#define TC0                    ((Tc *)0x42001000U)            /**< \brief (TC0       ) Base Address */
+#define TC1                    ((Tc *)0x42001400U)            /**< \brief (TC1       ) Base Address */
+#define TC2                    ((Tc *)0x42001800U)            /**< \brief (TC2       ) Base Address */
+#define TC_INST_NUM            3                              /**< \brief (TC        ) Number of instances */
+#define TC_INSTS               { TC0, TC1, TC2 }              /**< \brief (TC        ) Instances List */
+
+#define TRAM                   ((Tram *)0x42003400U)          /**< \brief (TRAM      ) Base Address */
+#define TRAM_INST_NUM          1                              /**< \brief (TRAM      ) Number of instances */
+#define TRAM_INSTS             { TRAM }                       /**< \brief (TRAM      ) Instances List */
+
+#define TRNG                   ((Trng *)0x42002800U)          /**< \brief (TRNG      ) Base Address */
+#define TRNG_INST_NUM          1                              /**< \brief (TRNG      ) Number of instances */
+#define TRNG_INSTS             { TRNG }                       /**< \brief (TRNG      ) Instances List */
+
+#define WDT                    ((Wdt *)0x40002000U)           /**< \brief (WDT       ) Base Address */
+#define WDT_INST_NUM           1                              /**< \brief (WDT       ) Number of instances */
+#define WDT_INSTS              { WDT }                        /**< \brief (WDT       ) Instances List */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Peripheral Base Address Definitions */
+
+/** \addtogroup SAML11E16A_pio Peripheral Pio Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   PIO DEFINITIONS FOR SAML11E16A*/
+/* ************************************************************************** */
+#include "pio/saml11e16a.h"
+/** @}  end of Peripheral Pio Definitions */
+
+/* ************************************************************************** */
+/*   MEMORY MAPPING DEFINITIONS FOR SAML11E16A*/
+/* ************************************************************************** */
+
+#define FLASH_SIZE               _U_(0x00010000)       /*   64kB Memory segment type: flash */
+#define FLASH_PAGE_SIZE          _U_(        64)
+#define FLASH_NB_OF_PAGES        _U_(      1024)
+
+#define AUX_SIZE                 _U_(0x00000100)       /*    0kB Memory segment type: fuses */
+#define AUX_PAGE_SIZE            _U_(        64)
+#define AUX_NB_OF_PAGES          _U_(         4)
+
+#define BOCOR_SIZE               _U_(0x00000100)       /*    0kB Memory segment type: fuses */
+#define BOCOR_PAGE_SIZE          _U_(        64)
+#define BOCOR_NB_OF_PAGES        _U_(         4)
+
+#define DATAFLASH_SIZE           _U_(0x00000800)       /*    2kB Memory segment type: flash */
+#define DATAFLASH_PAGE_SIZE      _U_(        64)
+#define DATAFLASH_NB_OF_PAGES    _U_(        32)
+
+#define SW_CALIB_SIZE            _U_(0x00000008)       /*    0kB Memory segment type: fuses */
+#define TEMP_LOG_SIZE            _U_(0x00000008)       /*    0kB Memory segment type: fuses */
+#define USER_PAGE_SIZE           _U_(0x00000100)       /*    0kB Memory segment type: user_page */
+#define USER_PAGE_PAGE_SIZE      _U_(        64)
+#define USER_PAGE_NB_OF_PAGES    _U_(         4)
+
+#define HSRAM_SIZE               _U_(0x00004000)       /*   16kB Memory segment type: ram */
+#define HPB0_SIZE                _U_(0x00008000)       /*   32kB Memory segment type: io */
+#define HPB1_SIZE                _U_(0x00010000)       /*   64kB Memory segment type: io */
+#define HPB2_SIZE                _U_(0x00004000)       /*   16kB Memory segment type: io */
+#define PPB_SIZE                 _U_(0x00100000)       /* 1024kB Memory segment type: io */
+#define SCS_SIZE                 _U_(0x00001000)       /*    4kB Memory segment type: io */
+#define PERIPHERALS_SIZE         _U_(0x20000000)       /* 524288kB Memory segment type: io */
+
+#define FLASH_ADDR               _U_(0x00000000)       /**< FLASH base address (type: flash)*/
+#define AUX_ADDR                 _U_(0x00806000)       /**< AUX base address (type: fuses)*/
+#define BOCOR_ADDR               _U_(0x0080c000)       /**< BOCOR base address (type: fuses)*/
+#define DATAFLASH_ADDR           _U_(0x00400000)       /**< DATAFLASH base address (type: flash)*/
+#define SW_CALIB_ADDR            _U_(0x00806020)       /**< SW_CALIB base address (type: fuses)*/
+#define TEMP_LOG_ADDR            _U_(0x00806038)       /**< TEMP_LOG base address (type: fuses)*/
+#define USER_PAGE_ADDR           _U_(0x00804000)       /**< USER_PAGE base address (type: user_page)*/
+#define HSRAM_ADDR               _U_(0x20000000)       /**< HSRAM base address (type: ram)*/
+#define HPB0_ADDR                _U_(0x40000000)       /**< HPB0 base address (type: io)*/
+#define HPB1_ADDR                _U_(0x41000000)       /**< HPB1 base address (type: io)*/
+#define HPB2_ADDR                _U_(0x42000000)       /**< HPB2 base address (type: io)*/
+#define PPB_ADDR                 _U_(0xe0000000)       /**< PPB base address (type: io)*/
+#define SCS_ADDR                 _U_(0xe000e000)       /**< SCS base address (type: io)*/
+#define PERIPHERALS_ADDR         _U_(0x40000000)       /**< PERIPHERALS base address (type: io)*/
+
+#define NVMCTRL_AUX              AUX_ADDR              /**< \brief \deprecated Old style definition. Use AUX_ADDR instead */
+#define NVMCTRL_BOCOR            BOCOR_ADDR            /**< \brief \deprecated Old style definition. Use BOCOR_ADDR instead */
+#define NVMCTRL_DATAFLASH        DATAFLASH_ADDR        /**< \brief \deprecated Old style definition. Use DATAFLASH_ADDR instead */
+#define NVMCTRL_SW_CALIB         SW_CALIB_ADDR         /**< \brief \deprecated Old style definition. Use SW_CALIB_ADDR instead */
+#define NVMCTRL_TEMP_LOG         TEMP_LOG_ADDR         /**< \brief \deprecated Old style definition. Use TEMP_LOG_ADDR instead */
+#define NVMCTRL_USER             USER_PAGE_ADDR        /**< \brief \deprecated Old style definition. Use USER_PAGE_ADDR instead */
+
+/* ************************************************************************** */
+/**  DEVICE SIGNATURES FOR SAML11E16A */
+/* ************************************************************************** */
+#define DSU_DID                  _UL_(0X20830000)
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAML11E16A */
+/* ************************************************************************** */
+
+/* ************************************************************************** */
+/** Event Generator IDs for SAML11E16A */
+/* ************************************************************************** */
+#define EVENT_ID_GEN_OSCCTRL_XOSC_FAIL                    1 /**< ID for OSCCTRL event generator XOSC_FAIL */
+#define EVENT_ID_GEN_OSC32KCTRL_XOSC32K_FAIL              2 /**< ID for OSC32KCTRL event generator XOSC32K_FAIL */
+#define EVENT_ID_GEN_SUPC_BOD33DET                        3 /**< ID for SUPC event generator BOD33DET */
+#define EVENT_ID_GEN_RTC_PER_0                            4 /**< ID for RTC event generator PER_0 */
+#define EVENT_ID_GEN_RTC_PER_1                            5 /**< ID for RTC event generator PER_1 */
+#define EVENT_ID_GEN_RTC_PER_2                            6 /**< ID for RTC event generator PER_2 */
+#define EVENT_ID_GEN_RTC_PER_3                            7 /**< ID for RTC event generator PER_3 */
+#define EVENT_ID_GEN_RTC_PER_4                            8 /**< ID for RTC event generator PER_4 */
+#define EVENT_ID_GEN_RTC_PER_5                            9 /**< ID for RTC event generator PER_5 */
+#define EVENT_ID_GEN_RTC_PER_6                           10 /**< ID for RTC event generator PER_6 */
+#define EVENT_ID_GEN_RTC_PER_7                           11 /**< ID for RTC event generator PER_7 */
+#define EVENT_ID_GEN_RTC_CMP_0                           12 /**< ID for RTC event generator CMP_0 */
+#define EVENT_ID_GEN_RTC_CMP_1                           13 /**< ID for RTC event generator CMP_1 */
+#define EVENT_ID_GEN_RTC_TAMPER                          14 /**< ID for RTC event generator TAMPER */
+#define EVENT_ID_GEN_RTC_OVF                             15 /**< ID for RTC event generator OVF */
+#define EVENT_ID_GEN_RTC_PERD                            16 /**< ID for RTC event generator PERD */
+#define EVENT_ID_GEN_EIC_EXTINT_0                        17 /**< ID for EIC event generator EXTINT_0 */
+#define EVENT_ID_GEN_EIC_EXTINT_1                        18 /**< ID for EIC event generator EXTINT_1 */
+#define EVENT_ID_GEN_EIC_EXTINT_2                        19 /**< ID for EIC event generator EXTINT_2 */
+#define EVENT_ID_GEN_EIC_EXTINT_3                        20 /**< ID for EIC event generator EXTINT_3 */
+#define EVENT_ID_GEN_EIC_EXTINT_4                        21 /**< ID for EIC event generator EXTINT_4 */
+#define EVENT_ID_GEN_EIC_EXTINT_5                        22 /**< ID for EIC event generator EXTINT_5 */
+#define EVENT_ID_GEN_EIC_EXTINT_6                        23 /**< ID for EIC event generator EXTINT_6 */
+#define EVENT_ID_GEN_EIC_EXTINT_7                        24 /**< ID for EIC event generator EXTINT_7 */
+#define EVENT_ID_GEN_DMAC_CH_0                           25 /**< ID for DMAC event generator CH_0 */
+#define EVENT_ID_GEN_DMAC_CH_1                           26 /**< ID for DMAC event generator CH_1 */
+#define EVENT_ID_GEN_DMAC_CH_2                           27 /**< ID for DMAC event generator CH_2 */
+#define EVENT_ID_GEN_DMAC_CH_3                           28 /**< ID for DMAC event generator CH_3 */
+#define EVENT_ID_GEN_TC0_OVF                             29 /**< ID for TC0 event generator OVF */
+#define EVENT_ID_GEN_TC0_MCX_0                           30 /**< ID for TC0 event generator MCX_0 */
+#define EVENT_ID_GEN_TC0_MCX_1                           31 /**< ID for TC0 event generator MCX_1 */
+#define EVENT_ID_GEN_TC1_OVF                             32 /**< ID for TC1 event generator OVF */
+#define EVENT_ID_GEN_TC1_MCX_0                           33 /**< ID for TC1 event generator MCX_0 */
+#define EVENT_ID_GEN_TC1_MCX_1                           34 /**< ID for TC1 event generator MCX_1 */
+#define EVENT_ID_GEN_TC2_OVF                             35 /**< ID for TC2 event generator OVF */
+#define EVENT_ID_GEN_TC2_MCX_0                           36 /**< ID for TC2 event generator MCX_0 */
+#define EVENT_ID_GEN_TC2_MCX_1                           37 /**< ID for TC2 event generator MCX_1 */
+#define EVENT_ID_GEN_ADC_RESRDY                          38 /**< ID for ADC event generator RESRDY */
+#define EVENT_ID_GEN_ADC_WINMON                          39 /**< ID for ADC event generator WINMON */
+#define EVENT_ID_GEN_AC_COMP_0                           40 /**< ID for AC event generator COMP_0 */
+#define EVENT_ID_GEN_AC_COMP_1                           41 /**< ID for AC event generator COMP_1 */
+#define EVENT_ID_GEN_AC_WIN_0                            42 /**< ID for AC event generator WIN_0 */
+#define EVENT_ID_GEN_DAC_EMPTY                           43 /**< ID for DAC event generator EMPTY */
+#define EVENT_ID_GEN_TRNG_READY                          46 /**< ID for TRNG event generator READY */
+#define EVENT_ID_GEN_CCL_LUTOUT_0                        47 /**< ID for CCL event generator LUTOUT_0 */
+#define EVENT_ID_GEN_CCL_LUTOUT_1                        48 /**< ID for CCL event generator LUTOUT_1 */
+#define EVENT_ID_GEN_PAC_ERR                             49 /**< ID for PAC event generator ERR */
+
+/* ************************************************************************** */
+/** Event User IDs for SAML11E16A */
+/* ************************************************************************** */
+#define EVENT_ID_USER_OSCCTRL_TUNE                        0 /**< ID for OSCCTRL event user TUNE */
+#define EVENT_ID_USER_RTC_TAMPER                          1 /**< ID for RTC event user TAMPER */
+#define EVENT_ID_USER_NVMCTRL_PAGEW                       2 /**< ID for NVMCTRL event user PAGEW */
+#define EVENT_ID_USER_PORT_EV_0                           3 /**< ID for PORT event user EV_0 */
+#define EVENT_ID_USER_PORT_EV_1                           4 /**< ID for PORT event user EV_1 */
+#define EVENT_ID_USER_PORT_EV_2                           5 /**< ID for PORT event user EV_2 */
+#define EVENT_ID_USER_PORT_EV_3                           6 /**< ID for PORT event user EV_3 */
+#define EVENT_ID_USER_DMAC_CH_0                           7 /**< ID for DMAC event user CH_0 */
+#define EVENT_ID_USER_DMAC_CH_1                           8 /**< ID for DMAC event user CH_1 */
+#define EVENT_ID_USER_DMAC_CH_2                           9 /**< ID for DMAC event user CH_2 */
+#define EVENT_ID_USER_DMAC_CH_3                          10 /**< ID for DMAC event user CH_3 */
+#define EVENT_ID_USER_TC0_EVU                            11 /**< ID for TC0 event user EVU */
+#define EVENT_ID_USER_TC1_EVU                            12 /**< ID for TC1 event user EVU */
+#define EVENT_ID_USER_TC2_EVU                            13 /**< ID for TC2 event user EVU */
+#define EVENT_ID_USER_ADC_START                          14 /**< ID for ADC event user START */
+#define EVENT_ID_USER_ADC_SYNC                           15 /**< ID for ADC event user SYNC */
+#define EVENT_ID_USER_AC_SOC_0                           16 /**< ID for AC event user SOC_0 */
+#define EVENT_ID_USER_AC_SOC_1                           17 /**< ID for AC event user SOC_1 */
+#define EVENT_ID_USER_DAC_START                          18 /**< ID for DAC event user START */
+#define EVENT_ID_USER_CCL_LUTIN_0                        21 /**< ID for CCL event user LUTIN_0 */
+#define EVENT_ID_USER_CCL_LUTIN_1                        22 /**< ID for CCL event user LUTIN_1 */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @}  end of SAML11E16A definitions */
+
+
+#endif /* _SAML11E16A_H_ */

--- a/cpu/sam0_common/include/vendor/saml11/include/system_saml11.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/system_saml11.h
@@ -1,0 +1,48 @@
+/**
+ * \file
+ *
+ * \brief Low-level initialization functions called upon device startup
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+#ifndef _SYSTEM_SAML11_H_INCLUDED_
+#define _SYSTEM_SAML11_H_INCLUDED_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+extern uint32_t SystemCoreClock;   /*!< System Clock Frequency (Core Clock)  */
+
+void SystemInit(void);
+void SystemCoreClockUpdate(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _SYSTEM_SAML11_H_INCLUDED */

--- a/cpu/sam0_common/periph/adc.c
+++ b/cpu/sam0_common/periph/adc.c
@@ -121,7 +121,11 @@ static int _adc_configure(adc_res_t res)
     }
 #else /* CPU_SAML21 */
     /* Power on */
+#ifdef CPU_SAML1X
+    MCLK->APBCMASK.reg |= MCLK_APBCMASK_ADC;
+#else
     MCLK->APBDMASK.reg |= MCLK_APBDMASK_ADC;
+#endif
     /* GCLK Setup */
     GCLK->PCHCTRL[ADC_GCLK_ID].reg = GCLK_PCHCTRL_CHEN | GCLK_PCHCTRL_GEN_GCLK0;
     /* Set Voltage Reference */

--- a/cpu/sam0_common/periph/gpio.c
+++ b/cpu/sam0_common/periph/gpio.c
@@ -37,10 +37,24 @@
 #define MODE_PINCFG_MASK            (0x06)
 
 #ifdef MODULE_PERIPH_GPIO_IRQ
+
 /**
  * @brief   Number of external interrupt lines
  */
+#ifdef CPU_SAML1X
+#define NUMOF_IRQS                  (8U)
+#else
 #define NUMOF_IRQS                  (16U)
+#endif
+
+/**
+ * @brief   External Interrupts Controller selection macros
+ */
+#ifdef CPU_FAM_SAML11
+#define _EIC EIC_SEC
+#else
+#define _EIC EIC
+#endif
 
 static gpio_isr_ctx_t gpio_config[NUMOF_IRQS];
 #endif /* MODULE_PERIPH_GPIO_IRQ */
@@ -181,26 +195,31 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     MCLK->APBAMASK.reg |= MCLK_APBAMASK_EIC;
     GCLK->PCHCTRL[EIC_GCLK_ID].reg = GCLK_PCHCTRL_CHEN | GCLK_PCHCTRL_GEN_GCLK0;
     /* disable the EIC module*/
-    EIC->CTRLA.reg = 0;
-    while (EIC->SYNCBUSY.reg & EIC_SYNCBUSY_ENABLE) {}
+    _EIC->CTRLA.reg = 0;
+    while (_EIC->SYNCBUSY.reg & EIC_SYNCBUSY_ENABLE) {}
 #endif
     /* configure the active flank */
-    EIC->CONFIG[exti >> 3].reg &= ~(0xf << ((exti & 0x7) * 4));
-    EIC->CONFIG[exti >> 3].reg |=  (flank << ((exti & 0x7) * 4));
+    _EIC->CONFIG[exti >> 3].reg &= ~(0xf << ((exti & 0x7) * 4));
+    _EIC->CONFIG[exti >> 3].reg |=  (flank << ((exti & 0x7) * 4));
     /* enable the global EIC interrupt */
+#ifdef CPU_SAML1X
+    /* EXTI[4..7] are binded to EIC_OTHER_IRQn */
+    NVIC_EnableIRQ((exti > 3 )? EIC_OTHER_IRQn : (EIC_0_IRQn + exti));
+#else
     NVIC_EnableIRQ(EIC_IRQn);
+#endif
     /* clear interrupt flag and enable the interrupt line and line wakeup */
-    EIC->INTFLAG.reg = (1 << exti);
-    EIC->INTENSET.reg = (1 << exti);
+    _EIC->INTFLAG.reg = (1 << exti);
+    _EIC->INTENSET.reg = (1 << exti);
 #ifdef CPU_FAM_SAMD21
-    EIC->WAKEUP.reg |= (1 << exti);
+    _EIC->WAKEUP.reg |= (1 << exti);
     /* enable the EIC module*/
-    EIC->CTRL.reg = EIC_CTRL_ENABLE;
-    while (EIC->STATUS.reg & EIC_STATUS_SYNCBUSY) {}
+    _EIC->CTRL.reg = EIC_CTRL_ENABLE;
+    while (_EIC->STATUS.reg & EIC_STATUS_SYNCBUSY) {}
 #else /* CPU_FAM_SAML21 */
     /* enable the EIC module*/
-    EIC->CTRLA.reg = EIC_CTRLA_ENABLE;
-    while (EIC->SYNCBUSY.reg & EIC_SYNCBUSY_ENABLE) {}
+    _EIC->CTRLA.reg = EIC_CTRLA_ENABLE;
+    while (_EIC->SYNCBUSY.reg & EIC_SYNCBUSY_ENABLE) {}
 #endif
     return 0;
 }
@@ -211,7 +230,7 @@ void gpio_irq_enable(gpio_t pin)
     if (exti == -1) {
         return;
     }
-    EIC->INTENSET.reg = (1 << exti);
+    _EIC->INTENSET.reg = (1 << exti);
 }
 
 void gpio_irq_disable(gpio_t pin)
@@ -220,17 +239,45 @@ void gpio_irq_disable(gpio_t pin)
     if (exti == -1) {
         return;
     }
-    EIC->INTENCLR.reg = (1 << exti);
+    _EIC->INTENCLR.reg = (1 << exti);
 }
 
 void isr_eic(void)
 {
     for (unsigned i = 0; i < NUMOF_IRQS; i++) {
-        if (EIC->INTFLAG.reg & (1 << i)) {
-            EIC->INTFLAG.reg = (1 << i);
+        if (_EIC->INTFLAG.reg & (1 << i)) {
+            _EIC->INTFLAG.reg = (1 << i);
             gpio_config[i].cb(gpio_config[i].arg);
         }
     }
     cortexm_isr_end();
 }
+
+#ifdef CPU_SAML1X
+void isr_eic0(void)
+{
+    isr_eic();
+}
+
+void isr_eic1(void)
+{
+    isr_eic();
+}
+
+void isr_eic2(void)
+{
+    isr_eic();
+}
+
+void isr_eic3(void)
+{
+    isr_eic();
+}
+
+void isr_eic_other(void)
+{
+    isr_eic();
+}
+#endif /* CPU_SAML1X */
+
 #endif /* MODULE_PERIPH_GPIO_IRQ */

--- a/cpu/sam0_common/periph/i2c.c
+++ b/cpu/sam0_common/periph/i2c.c
@@ -44,7 +44,7 @@
 #define BUSSTATE_OWNER SERCOM_I2CM_STATUS_BUSSTATE(2)
 #define BUSSTATE_BUSY SERCOM_I2CM_STATUS_BUSSTATE(3)
 
-#if defined(CPU_FAM_SAML21) || defined(CPU_FAM_SAMR30)
+#if defined(CPU_SAML21) || defined(CPU_SAML1X)
 #define SERCOM_I2CM_CTRLA_MODE_I2C_MASTER SERCOM_I2CM_CTRLA_MODE(5)
 #endif
 
@@ -98,6 +98,10 @@ void i2c_init(i2c_t dev)
                   SERCOM0_GCLK_ID_SLOW : SERCOM5_GCLK_ID_SLOW)].reg =
     (GCLK_PCHCTRL_CHEN | i2c_config[dev].gclk_src  );
     while (GCLK->SYNCBUSY.bit.GENCTRL) {}
+#elif defined (CPU_SAML1X)
+    GCLK->PCHCTRL[SERCOM0_GCLK_ID_SLOW].reg = (GCLK_PCHCTRL_CHEN |
+                                              i2c_config[dev].gclk_src  );
+     while (GCLK->SYNCBUSY.bit.GENCTRL0) {}
 #else
     /* GCLK_SERCOMx_SLOW is shared for all sercom */
     GCLK->CLKCTRL.reg = (GCLK_CLKCTRL_CLKEN |

--- a/cpu/sam0_common/periph/spi.c
+++ b/cpu/sam0_common/periph/spi.c
@@ -50,7 +50,7 @@ static inline void poweron(spi_t bus)
 {
 #if defined(CPU_FAM_SAMD21)
     PM->APBCMASK.reg |= (PM_APBCMASK_SERCOM0 << sercom_id(dev(bus)));
-#elif defined(CPU_FAM_SAML21) || defined(CPU_FAM_SAMR30)
+#elif defined(CPU_SAML21) || defined(CPU_SAML1X)
     MCLK->APBCMASK.reg |= (MCLK_APBCMASK_SERCOM0 << sercom_id(dev(bus)));
 #endif
 }
@@ -59,7 +59,7 @@ static inline void poweroff(spi_t bus)
 {
 #if defined(CPU_FAM_SAMD21)
     PM->APBCMASK.reg &= ~(PM_APBCMASK_SERCOM0 << sercom_id(dev(bus)));
-#elif defined(CPU_FAM_SAML21) || defined(CPU_FAM_SAMR30)
+#elif defined(CPU_SAML21) || defined(CPU_SAML1X)
     MCLK->APBCMASK.reg &= ~(MCLK_APBCMASK_SERCOM0 << sercom_id(dev(bus)));
 #endif
 }
@@ -88,7 +88,7 @@ void spi_init(spi_t bus)
     GCLK->CLKCTRL.reg = (GCLK_CLKCTRL_CLKEN | GCLK_CLKCTRL_GEN_GCLK0 |
                          (SERCOM0_GCLK_ID_CORE + sercom_id(dev(bus))));
     while (GCLK->STATUS.reg & GCLK_STATUS_SYNCBUSY) {}
-#elif defined(CPU_FAM_SAML21) || defined(CPU_FAM_SAMR30)
+#elif defined(CPU_SAML21) || defined(CPU_SAML1X)
     GCLK->PCHCTRL[SERCOM0_GCLK_ID_CORE + sercom_id(dev(bus))].reg =
                                 (GCLK_PCHCTRL_CHEN | GCLK_PCHCTRL_GEN_GCLK0);
 #endif

--- a/cpu/sam0_common/periph/uart.c
+++ b/cpu/sam0_common/periph/uart.c
@@ -99,7 +99,11 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
     if ((rx_cb) && (uart_config[uart].rx_pin != GPIO_UNDEF)) {
         uart_ctx[uart].rx_cb = rx_cb;
         uart_ctx[uart].arg = arg;
+#if defined (CPU_SAML1X)
+        NVIC_EnableIRQ(SERCOM0_2_IRQn + (sercom_id(dev(uart)) * 4));
+#else
         NVIC_EnableIRQ(SERCOM0_IRQn + sercom_id(dev(uart)));
+#endif
         dev(uart)->CTRLB.reg |= SERCOM_USART_CTRLB_RXEN;
         dev(uart)->INTENSET.reg |= SERCOM_USART_INTENSET_RXC;
         /* set wakeup receive from sleep if enabled */

--- a/cpu/saml1x/Makefile
+++ b/cpu/saml1x/Makefile
@@ -1,0 +1,10 @@
+# define the module that is build
+MODULE = cpu
+
+# add a list of subdirectories, that should also be build
+DIRS = periph $(RIOTCPU)/cortexm_common $(RIOTCPU)/sam0_common
+
+# (file triggers compiler bug. see #5775)
+SRC_NOLTO += vectors.c
+
+include $(RIOTBASE)/Makefile.base

--- a/cpu/saml1x/Makefile.features
+++ b/cpu/saml1x/Makefile.features
@@ -1,0 +1,1 @@
+include $(RIOTCPU)/sam0_common/Makefile.features

--- a/cpu/saml1x/Makefile.include
+++ b/cpu/saml1x/Makefile.include
@@ -1,0 +1,4 @@
+export CPU_ARCH = cortex-m23
+
+include $(RIOTCPU)/sam0_common/Makefile.include
+include $(RIOTMAKE)/arch/cortexm.inc.mk

--- a/cpu/saml1x/cpu.c
+++ b/cpu/saml1x/cpu.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2018 Mesotic SAS
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_saml1x
+ * @{
+ *
+ * @file        cpu.c
+ * @brief       Implementation of the CPU initialization for Microchip
+ *              SAML10/SAML11 MCUs
+ *
+ * @author      Dylan Laduranty <dylan.laduranty@mesotic.com>
+ * @}
+ */
+
+#include "cpu.h"
+#include "periph/init.h"
+#include "board.h"
+
+static void _gclk_setup(int gclk, uint32_t reg)
+{
+    GCLK->GENCTRL[gclk].reg = reg;
+    while (GCLK->SYNCBUSY.reg & GCLK_SYNCBUSY_GENCTRL(gclk)) {}
+}
+
+/**
+ * @brief Initialize the CPU, set IRQ priorities, clocks
+ */
+void cpu_init(void)
+{
+    /* initialize the Cortex-M core */
+    cortexm_init();
+
+    /* turn on only needed APB peripherals */
+    MCLK->APBAMASK.reg = MCLK_APBAMASK_MCLK
+                         | MCLK_APBAMASK_OSCCTRL
+                         | MCLK_APBAMASK_GCLK
+#ifdef MODULE_PERIPH_GPIO_IRQ
+                         | MCLK_APBAMASK_EIC
+#endif
+#ifdef MODULE_PERIPH_GPIO
+                         | MCLK_APBAMASK_PORT
+#endif
+                         ;
+
+    /* Software reset the GCLK module to ensure it is re-initialized correctly */
+    GCLK->CTRLA.reg = GCLK_CTRLA_SWRST;
+    while (GCLK->CTRLA.reg & GCLK_CTRLA_SWRST) {}
+    while (GCLK->SYNCBUSY.reg & GCLK_SYNCBUSY_SWRST) {}
+
+    /* set OSC16M to 16MHz */
+    OSCCTRL->OSC16MCTRL.bit.FSEL = 3;
+    OSCCTRL->OSC16MCTRL.bit.ONDEMAND = 0;
+    OSCCTRL->OSC16MCTRL.bit.RUNSTDBY = 0;
+
+    /* Setup GCLK generators */
+    _gclk_setup(0, GCLK_GENCTRL_GENEN | GCLK_GENCTRL_SRC_OSC16M);
+
+#ifdef MODULE_PERIPH_PM
+    /* enable power managemet module */
+    MCLK->APBAMASK.reg |= MCLK_APBAMASK_PM;
+#endif
+
+    /* trigger static peripheral initialization */
+    periph_init();
+}

--- a/cpu/saml1x/doc.txt
+++ b/cpu/saml1x/doc.txt
@@ -1,0 +1,9 @@
+/**
+ * @defgroup        cpu_saml1x Microchip SAML10/SAML11
+ * @ingroup         cpu
+ * @brief           Microchip SAML1x Cortex-M23 MCU specific implementation.
+ *
+ * This module contains Microchip SAML10/SAML11 specific code and definition.
+ *
+ * @see cpu_saml1x
+ */

--- a/cpu/saml1x/include/periph_cpu.h
+++ b/cpu/saml1x/include/periph_cpu.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2018 Mesotic SAS
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup         cpu_saml1x
+ * @brief           CPU specific definitions for internal peripheral handling
+ * @{
+ *
+ * @file
+ * @brief           CPU specific definitions for internal peripheral handling
+ *
+ * @author          Dylan Laduranty <dylan.laduranty@mesotic.com>
+ */
+
+#ifndef PERIPH_CPU_H
+#define PERIPH_CPU_H
+
+#include "periph_cpu_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Mapping of pins to EXTI lines, -1 means not EXTI possible
+ */
+static const int8_t exti_config[1][32] = {
+    { 0,  1,  2,  3,  4,  5,  6,  7, -1, 0,  1,  2, -1, -1, 3, 4,
+      5,  6,  7,  0, -1, -1,  1,  2,  3, 4, -1,  5, -1, -1, 6, 7},
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CPU_H */
+/** @} */

--- a/cpu/saml1x/periph/Makefile
+++ b/cpu/saml1x/periph/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTMAKE)/periph.mk

--- a/cpu/saml1x/periph/pm.c
+++ b/cpu/saml1x/periph/pm.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2017 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_saml21
+ * @ingroup     drivers_periph_pm
+ * @{
+ *
+ * @file
+ * @brief       Implementation of the kernels power management interface
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * @}
+ */
+
+#include "periph/pm.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+void pm_set(unsigned mode)
+{
+    if (mode < PM_NUM_MODES) {
+        uint32_t _mode;
+
+        switch (mode) {
+            case 0:
+                DEBUG("pm_set(): setting STANDBY mode.\n");
+                _mode = PM_SLEEPCFG_SLEEPMODE_STANDBY;
+                break;
+            default: /* Falls through */
+            case 1:
+                DEBUG("pm_set(): setting IDLE mode.\n");
+                _mode = PM_SLEEPCFG_SLEEPMODE_IDLE;
+                break;
+        }
+
+        /* write sleep configuration */
+        PM->SLEEPCFG.bit.SLEEPMODE = _mode;
+        /* make sure value has been set */
+        while (PM->SLEEPCFG.bit.SLEEPMODE != _mode) {}
+    }
+
+    cortexm_sleep(0);
+}

--- a/cpu/saml1x/periph/rtc.c
+++ b/cpu/saml1x/periph/rtc.c
@@ -1,0 +1,236 @@
+/*
+ * Copyright (C) 2014 Baptiste CLENET
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_saml21
+ * @ingroup     drivers_periph_rtc
+ * @{
+ * @file
+ * @brief       Low-level RTC driver implementation
+ * @author      Baptiste Clenet <bapclenet@gmail.com>
+ * @autor       ported to SAML21 by FWX <FWX@dialine.fr>
+ * @}
+ */
+
+#include <time.h>
+#include "cpu.h"
+#include "periph/rtc.h"
+#include "periph_conf.h"
+
+/* SAML21 rev B needs an extra bit, which in rev A defaults to 1, but isn't
+ * visible. Thus define it here. */
+#ifndef RTC_MODE2_CTRLA_CLOCKSYNC
+#define RTC_MODE2_CTRLA_CLOCKSYNC_Pos   15
+#define RTC_MODE2_CTRLA_CLOCKSYNC       (0x1ul << RTC_MODE2_CTRLA_CLOCKSYNC_Pos)
+#endif
+
+typedef struct {
+    rtc_alarm_cb_t cb;        /**< callback called from RTC interrupt */
+    void *arg;                /**< argument passed to the callback */
+} rtc_state_t;
+
+static rtc_state_t rtc_callback;
+
+/* At 1Hz, RTC goes till 63 years (2^5, see 17.8.22 in datasheet)
+* reference_year is set to 100 (offset) to be in our current time (2000)
+* Thanks to this, the user will be able to set time in 2000's*/
+static uint16_t reference_year = 100;
+
+void rtc_init(void)
+{
+    /* Turn on power manager for RTC */
+    MCLK->APBAMASK.reg |= MCLK_APBAMASK_RTC | MCLK_APBAMASK_OSC32KCTRL;
+    /* DISABLE RTC MASTER */
+    rtc_poweroff();
+
+
+#if EXTERNAL_OSC32_SOURCE
+
+    /* RTC uses External 32,768KHz Oscillator */
+    OSC32KCTRL->XOSC32K.reg = OSC32KCTRL_XOSC32K_XTALEN
+                            | OSC32KCTRL_XOSC32K_EN1K
+                            | OSC32KCTRL_XOSC32K_RUNSTDBY
+                            | OSC32KCTRL_XOSC32K_ENABLE;
+
+    /* Wait XOSC32K Ready */
+    while (OSC32KCTRL->STATUS.bit.XOSC32KRDY==0);
+
+    /* RTC source clock is external oscillator at 1kHz */
+    OSC32KCTRL->RTCCTRL.reg = OSC32KCTRL_RTCCTRL_RTCSEL_XOSC1K;
+
+#endif /* EXTERNAL_OSC32_SOURCE */
+
+#if INTERNAL_OSC32_SOURCE
+ uint32_t * pCalibrationArea;
+ uint32_t osc32kcal;
+
+    /* Read OSC32KCAL, calibration data for OSC32 !!! */
+    pCalibrationArea = (uint32_t*) NVMCTRL_OTP5;
+    osc32kcal = ( (*pCalibrationArea) & 0x1FC0 ) >> 6;
+
+    /* RTC use Low Power Internal Oscillator at 1kHz */
+    OSC32KCTRL->OSC32K.reg = OSC32KCTRL_OSC32K_RUNSTDBY
+                           | OSC32KCTRL_OSC32K_EN1K
+                           | OSC32KCTRL_OSC32K_CALIB(osc32kcal)
+                           | OSC32KCTRL_OSC32K_ENABLE;
+
+    /* Wait OSC32K Ready */
+    while (OSC32KCTRL->STATUS.bit.OSC32KRDY==0);
+
+    /* RTC uses internal 32,768KHz Oscillator */
+    OSC32KCTRL->RTCCTRL.reg = OSC32KCTRL_RTCCTRL_RTCSEL_OSC1K;
+
+
+#endif /* INTERNAL_OSC32_SOURCE */
+
+#if ULTRA_LOW_POWER_INTERNAL_OSC_SOURCE
+
+    /* RTC uses Ultra Low Power internal 32,768KHz Oscillator */
+    OSC32KCTRL->RTCCTRL.reg = OSC32KCTRL_RTCCTRL_RTCSEL_ULP1K;
+
+#endif /* ULTRA_LOW_POWER_INTERNAL_OSC_SOURCE */
+
+    /* Software Reset the RTC */
+    RTC->MODE2.CTRLA.bit.SWRST = 1;
+    /* Wait end of reset */
+    while (RTC->MODE2.CTRLA.bit.SWRST);
+
+    /* RTC config with RTC_MODE2_CTRL_CLKREP = 0 (24h) */
+    RTC->MODE2.CTRLA.reg = RTC_MODE2_CTRLA_PRESCALER_DIV1024 |  /* CLK_RTC_CNT = 1KHz / 1024 -> 1Hz */
+                           RTC_MODE2_CTRLA_CLOCKSYNC         |  /* Clock Read Synchronization Enable */
+                           RTC_MODE2_CTRLA_MODE_CLOCK;          /* Mode 2: Clock/Calendar */
+
+    /* Clear interrupt flags */
+    RTC->MODE2.INTFLAG.reg |= RTC_MODE2_INTFLAG_OVF;
+    RTC->MODE2.INTFLAG.reg |= RTC_MODE2_INTFLAG_ALARM0;
+
+    rtc_poweron();
+}
+
+int rtc_set_time(struct tm *time)
+{
+    if ((time->tm_year < reference_year) || (time->tm_year > reference_year + 63)) {
+        return -1;
+    }
+    else {
+        while (RTC->MODE2.SYNCBUSY.bit.CLOCK);
+        RTC->MODE2.CLOCK.reg = RTC_MODE2_CLOCK_YEAR(time->tm_year - reference_year)
+                             | RTC_MODE2_CLOCK_MONTH(time->tm_mon + 1)
+                             | RTC_MODE2_CLOCK_DAY(time->tm_mday)
+                             | RTC_MODE2_CLOCK_HOUR(time->tm_hour)
+                             | RTC_MODE2_CLOCK_MINUTE(time->tm_min)
+                             | RTC_MODE2_CLOCK_SECOND(time->tm_sec);
+        while (RTC->MODE2.SYNCBUSY.bit.CLOCK);
+    }
+   return 0;
+}
+
+int rtc_get_time(struct tm *time)
+{
+ RTC_MODE2_CLOCK_Type clock;
+
+    /* Read register in one time */
+    clock.reg = RTC->MODE2.CLOCK.reg;
+
+    time->tm_year = clock.bit.YEAR + reference_year;
+    if ((time->tm_year < reference_year) || (time->tm_year > (reference_year + 63))) {
+        return -1;
+    }
+    time->tm_mon = clock.bit.MONTH - 1;
+    time->tm_mday = clock.bit.DAY;
+    time->tm_hour = clock.bit.HOUR;
+    time->tm_min = clock.bit.MINUTE;
+    time->tm_sec = clock.bit.SECOND;
+    return 0;
+}
+
+int rtc_set_alarm(struct tm *time, rtc_alarm_cb_t cb, void *arg)
+{
+    rtc_clear_alarm();
+    if ((time->tm_year < reference_year) || (time->tm_year > (reference_year + 63))) {
+        return -2;
+    }
+    else {
+        RTC->MODE2.Mode2Alarm[0].ALARM.reg = RTC_MODE2_ALARM_YEAR(time->tm_year - reference_year)
+                                           | RTC_MODE2_ALARM_MONTH(time->tm_mon + 1)
+                                           | RTC_MODE2_ALARM_DAY(time->tm_mday)
+                                           | RTC_MODE2_ALARM_HOUR(time->tm_hour)
+                                           | RTC_MODE2_ALARM_MINUTE(time->tm_min)
+                                           | RTC_MODE2_ALARM_SECOND(time->tm_sec);
+        RTC->MODE2.Mode2Alarm[0].MASK.reg = RTC_MODE2_MASK_SEL(6);
+        while (RTC->MODE2.SYNCBUSY.bit.ALARM0);
+    }
+
+    /* Setup interrupt */
+    NVIC_EnableIRQ(RTC_IRQn);
+
+    /* Enable IRQ */
+    rtc_callback.cb = cb;
+    rtc_callback.arg = arg;
+    RTC->MODE2.INTFLAG.reg |= RTC_MODE2_INTFLAG_ALARM0;
+    RTC->MODE2.INTENSET.bit.ALARM0 = 1;
+
+    return 0;
+}
+
+int rtc_get_alarm(struct tm *time)
+{
+ RTC_MODE2_ALARM_Type alarm;
+
+    /* Read alarm register in one time */
+    alarm.reg = RTC->MODE2.Mode2Alarm[0].ALARM.reg;
+
+    time->tm_year = alarm.bit.YEAR + reference_year;
+    if ((time->tm_year < reference_year) || (time->tm_year > (reference_year + 63))) {
+        return -1;
+    }
+    time->tm_mon = alarm.bit.MONTH - 1;
+    time->tm_mday = alarm.bit.DAY;
+    time->tm_hour = alarm.bit.HOUR;
+    time->tm_min = alarm.bit.MINUTE;
+    time->tm_sec = alarm.bit.SECOND;
+
+    return 0;
+}
+
+void rtc_clear_alarm(void)
+{
+    /* disable interrupt */
+    RTC->MODE2.INTENCLR.bit.ALARM0 = 1;
+    rtc_callback.cb = NULL;
+    rtc_callback.arg = NULL;
+}
+
+void rtc_poweron(void)
+{
+    RTC->MODE2.CTRLA.bit.ENABLE = 1;
+    while (RTC->MODE2.SYNCBUSY.bit.ENABLE);
+}
+
+void rtc_poweroff(void)
+{
+    RTC->MODE2.CTRLA.bit.ENABLE = 0;
+    while (RTC->MODE2.SYNCBUSY.bit.ENABLE);
+}
+
+void isr_rtc(void)
+{
+    if (RTC->MODE2.INTFLAG.bit.ALARM0) {
+        rtc_callback.cb(rtc_callback.arg);
+        /* clear flag */
+        RTC->MODE2.INTFLAG.reg |= RTC_MODE2_INTFLAG_ALARM0;
+    }
+    if (RTC->MODE2.INTFLAG.bit.OVF) {
+        /* clear flag */
+        RTC->MODE2.INTFLAG.reg |= RTC_MODE2_INTFLAG_OVF;
+        /* At 1Hz, RTC goes till 63 years (2^5, see 17.8.22 in datasheet)
+        * Start RTC again with reference_year 64 years more (Be careful with alarm set) */
+        reference_year += 64;
+    }
+    cortexm_isr_end();
+}

--- a/cpu/saml1x/periph/rtt.c
+++ b/cpu/saml1x/periph/rtt.c
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ *               2015 FreshTemp, LLC.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_saml21
+ * @ingroup     drivers_periph_rtt
+ * @{
+ *
+ * @file        rtt.c
+ * @brief       Low-level RTT driver implementation
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * @}
+ */
+
+#include <stdint.h>
+#include "periph/rtt.h"
+#include "board.h"
+
+#define ENABLE_DEBUG 0
+#include "debug.h"
+
+static rtt_cb_t _overflow_cb;
+static void* _overflow_arg;
+
+static rtt_cb_t _cmp0_cb;
+static void* _cmp0_arg;
+
+void rtt_init(void)
+{
+    DEBUG("%s:%d\n", __func__, __LINE__);
+    /* Turn on power manager for RTC */
+    MCLK->APBAMASK.reg |= MCLK_APBAMASK_RTC | MCLK_APBAMASK_OSC32KCTRL;
+    rtt_poweron();
+
+    /* reset */
+    RTC->MODE0.CTRLA.bit.SWRST = 1;
+    while(RTC->MODE0.CTRLA.bit.SWRST) {}
+
+    /* set 32bit counting mode */
+    RTC->MODE0.CTRLA.bit.MODE = 0;
+
+    /* set clock source */
+    OSC32KCTRL->RTCCTRL.reg = OSC32KCTRL_RTCCTRL_RTCSEL_ULP32K;
+
+    /* enable */
+    RTC->MODE0.CTRLA.bit.ENABLE = 1;
+    while(RTC->MODE0.SYNCBUSY.bit.ENABLE) {}
+
+    /* initially clear flag */
+    RTC->MODE0.INTFLAG.reg |= RTC_MODE1_INTFLAG_CMP(1 << 0);
+
+    /* enable RTT IRQ */
+    NVIC_EnableIRQ(RTC_IRQn);
+
+    DEBUG("%s:%d %u\n", __func__, __LINE__, (unsigned)rtt_get_counter());
+}
+
+void rtt_set_overflow_cb(rtt_cb_t cb, void *arg)
+{
+    DEBUG("%s:%d\n", __func__, __LINE__);
+    /* clear overflow cb to avoid race while assigning */
+    rtt_clear_overflow_cb();
+
+    /* set callback variables */
+    _overflow_cb = cb;
+    _overflow_arg = arg;
+
+    /* enable overflow interrupt */
+    RTC->MODE0.INTENSET.bit.OVF = 1;
+}
+void rtt_clear_overflow_cb(void)
+{
+    DEBUG("%s:%d\n", __func__, __LINE__);
+    /* disable overflow interrupt */
+    RTC->MODE0.INTENCLR.bit.OVF = 1;
+}
+
+uint32_t rtt_get_counter(void)
+{
+    DEBUG("%s:%d\n", __func__, __LINE__);
+    while (RTC->MODE0.SYNCBUSY.bit.COUNT) {}
+    return RTC->MODE0.COUNT.reg;
+}
+
+void rtt_set_alarm(uint32_t alarm, rtt_cb_t cb, void *arg)
+{
+    DEBUG("%s:%d alarm=%u\n", __func__, __LINE__, (unsigned)alarm);
+
+    /* disable interrupt to avoid race */
+    rtt_clear_alarm();
+
+    /* set COM register */
+    while (RTC->MODE0.SYNCBUSY.bit.COMP0) {}
+    RTC->MODE0.COMP[0].reg = alarm;
+
+    /* setup callback */
+    _cmp0_cb = cb;
+    _cmp0_arg = arg;
+
+    /* enable compare interrupt */
+    RTC->MODE0.INTENSET.bit.CMP0 = 1;
+}
+
+void rtt_clear_alarm(void)
+{
+    DEBUG("%s:%d\n", __func__, __LINE__);
+    /* clear compare interrupt */
+    RTC->MODE0.INTENCLR.bit.CMP0 = 1;
+}
+
+void rtt_poweron(void)
+{
+    DEBUG("%s:%d\n", __func__, __LINE__);
+    MCLK->APBAMASK.reg |= MCLK_APBAMASK_RTC;
+}
+
+void rtt_poweroff(void)
+{
+    DEBUG("%s:%d\n", __func__, __LINE__);
+    MCLK->APBAMASK.reg &= ~MCLK_APBAMASK_RTC;
+}
+
+void isr_rtc(void)
+{
+    if (RTC->MODE0.INTFLAG.bit.OVF) {
+        RTC->MODE0.INTFLAG.reg |= RTC_MODE0_INTFLAG_OVF;
+        if (_overflow_cb) {
+            _overflow_cb(_overflow_arg);
+        }
+    }
+    if (RTC->MODE0.INTFLAG.bit.CMP0) {
+        /* clear flag */
+        RTC->MODE0.INTFLAG.reg |= RTC_MODE1_INTFLAG_CMP(1 << 0);
+        /* disable interrupt */
+        RTC->MODE0.INTENCLR.bit.CMP0 = 1;
+        if (_cmp0_cb) {
+            _cmp0_cb(_cmp0_arg);
+        }
+    }
+    cortexm_isr_end();
+}

--- a/cpu/saml1x/periph/timer.c
+++ b/cpu/saml1x/periph/timer.c
@@ -1,0 +1,231 @@
+/*
+ * Copyright (C) 2018 Mesotic SAS
+ *
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_saml1x
+ * @ingroup     drivers_periph_timer
+ * @{
+ *
+ * @file        timer.c
+ * @brief       Low-level timer driver implementation
+ *
+ * @author      Dylan Laduranty <dylan.laduranty@mesotic.com>
+ *
+ * @}
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "board.h"
+#include "cpu.h"
+
+#include "periph/timer.h"
+#include "periph_conf.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+/**
+ * @brief Timer state memory
+ */
+static timer_isr_ctx_t config[TIMER_NUMOF];
+
+/* enable timer interrupts */
+static inline void _irq_enable(tim_t dev);
+
+
+/**
+ * @brief Setup the given timer
+ */
+int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
+{
+    /* at the moment, the timer can only run at 1MHz */
+    if (freq != 1000000ul) {
+        return -1;
+    }
+    /* configure GCLK0 to feed TC0 & TC1*/
+    GCLK->PCHCTRL[TC0_GCLK_ID].reg |= GCLK_PCHCTRL_CHEN | GCLK_PCHCTRL_GEN_GCLK0;
+    while (!(GCLK->PCHCTRL[TC0_GCLK_ID].reg & GCLK_PCHCTRL_CHEN)) {}
+
+    /* select the timer and enable the timer specific peripheral clocks */
+    switch (dev) {
+#if TIMER_0_EN
+    case TIMER_0:
+        if (TIMER_0_DEV.CTRLA.bit.ENABLE) {
+            return 0;
+        }
+        MCLK->APBCMASK.reg |= MCLK_APBCMASK_TC0;
+        /* reset timer */
+        TIMER_0_DEV.CTRLA.bit.SWRST = 1;
+        while (TIMER_0_DEV.SYNCBUSY.bit.SWRST) {}
+        TIMER_0_DEV.CTRLA.reg |= TC_CTRLA_MODE_COUNT32 |    /* choosing 32 bit mode */
+                                 TC_CTRLA_PRESCALER(4) |    /* sourced by 4MHz with Presc 4 results in 1MHz*/
+                                 TC_CTRLA_PRESCSYNC_RESYNC; /* initial prescaler resync */
+        break;
+#endif
+    case TIMER_UNDEFINED:
+    default:
+        return -1;
+    }
+
+    /* save callback */
+    config[dev].cb = cb;
+    config[dev].arg = arg;
+
+    /* enable interrupts for given timer */
+    _irq_enable(dev);
+
+    timer_start(dev);
+
+    return 0;
+}
+
+int timer_set_absolute(tim_t dev, int channel, unsigned int value)
+{
+    DEBUG("Setting timer %i channel %i to %i\n", dev, channel, value);
+
+    /* get timer base register address */
+    switch (dev) {
+#if TIMER_0_EN
+    case TIMER_0:
+        /* set timeout value */
+        switch (channel) {
+        case 0:
+            TIMER_0_DEV.INTFLAG.reg |= TC_INTFLAG_MC0;
+            TIMER_0_DEV.CC[0].reg = value;
+            TIMER_0_DEV.INTENSET.bit.MC0 = 1;
+            break;
+        case 1:
+            TIMER_0_DEV.INTFLAG.reg |= TC_INTFLAG_MC1;
+            TIMER_0_DEV.CC[1].reg = value;
+            TIMER_0_DEV.INTENSET.bit.MC1 = 1;
+            break;
+        default:
+            return -1;
+        }
+        break;
+#endif
+    case TIMER_UNDEFINED:
+    default:
+        return -1;
+    }
+
+    return 1;
+}
+
+int timer_clear(tim_t dev, int channel)
+{
+    /* get timer base register address */
+    switch (dev) {
+#if TIMER_0_EN
+    case TIMER_0:
+        switch (channel) {
+        case 0:
+            TIMER_0_DEV.INTFLAG.reg |= TC_INTFLAG_MC0;
+            TIMER_0_DEV.INTENCLR.bit.MC0 = 1;
+            break;
+        case 1:
+            TIMER_0_DEV.INTFLAG.reg |= TC_INTFLAG_MC1;
+            TIMER_0_DEV.INTENCLR.bit.MC1 = 1;
+            break;
+        default:
+            return -1;
+        }
+        break;
+#endif
+    case TIMER_UNDEFINED:
+    default:
+        return -1;
+    }
+
+    return 1;
+}
+
+unsigned int timer_read(tim_t dev)
+{
+    switch (dev) {
+#if TIMER_0_EN
+    case TIMER_0:
+        /* request syncronisation */
+        TIMER_0_DEV.CTRLBSET.bit.CMD = TC_CTRLBSET_CMD_READSYNC_Val;
+        while (TIMER_0_DEV.SYNCBUSY.bit.CTRLB) {
+            /* WORKAROUND to prevent being stuck there if timer not init */
+            if(!TIMER_0_DEV.CTRLA.bit.ENABLE) {
+                return 0;
+            }
+        }
+        return TIMER_0_DEV.COUNT.reg;
+#endif
+    default:
+        return 0;
+    }
+
+
+}
+
+void timer_stop(tim_t dev)
+{
+    switch (dev) {
+#if TIMER_0_EN
+        case TIMER_0:
+            TIMER_0_DEV.CTRLA.bit.ENABLE = 0;
+            break;
+#endif
+        case TIMER_UNDEFINED:
+            break;
+    }
+}
+
+void timer_start(tim_t dev)
+{
+    switch (dev) {
+#if TIMER_0_EN
+        case TIMER_0:
+            TIMER_0_DEV.CTRLA.bit.ENABLE = 1;
+            break;
+#endif
+        case TIMER_UNDEFINED:
+            break;
+    }
+}
+
+static inline void _irq_enable(tim_t dev)
+{
+    switch (dev) {
+#if TIMER_0_EN
+        case TIMER_0:
+            NVIC_EnableIRQ(TC0_IRQn);
+            break;
+#endif
+        case TIMER_UNDEFINED:
+            break;
+    }
+}
+
+#if TIMER_0_EN
+void TIMER_0_ISR(void)
+{
+    if (TIMER_0_DEV.INTFLAG.bit.MC0 && TIMER_0_DEV.INTENSET.bit.MC0) {
+        if(config[TIMER_0].cb) {
+            TIMER_0_DEV.INTFLAG.reg |= TC_INTFLAG_MC0;
+            TIMER_0_DEV.INTENCLR.reg = TC_INTENCLR_MC0;
+            config[TIMER_0].cb(config[TIMER_0].arg, 0);
+        }
+    }
+    else if (TIMER_0_DEV.INTFLAG.bit.MC1 && TIMER_0_DEV.INTENSET.bit.MC1) {
+        if(config[TIMER_0].cb) {
+            TIMER_0_DEV.INTFLAG.reg |= TC_INTFLAG_MC1;
+            TIMER_0_DEV.INTENCLR.reg = TC_INTENCLR_MC1;
+            config[TIMER_0].cb(config[TIMER_0].arg, 1);
+        }
+    }
+    cortexm_isr_end();
+}
+#endif /* TIMER_0_EN */

--- a/cpu/saml1x/vectors.c
+++ b/cpu/saml1x/vectors.c
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2018 Mesotic SAS
+ *
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_saml1x
+ * @{
+ *
+ * @file        vectors.c
+ * @brief       Startup code and interrupt vector definition
+ *
+ * @author      Dylan Laduranty <dylan.laduranty@mesotic.com>
+ *
+ * @}
+ */
+
+#include <stdint.h>
+#include "vectors_cortexm.h"
+
+/* define a local dummy handler as it needs to be in the same compilation unit
+ * as the alias definition */
+void dummy_handler(void) {
+    dummy_handler_default();
+}
+
+/* SAML1x specific interrupt vector */
+WEAK_DEFAULT void isr_system(void);
+WEAK_DEFAULT void isr_wdt(void);
+WEAK_DEFAULT void isr_rtc(void);
+WEAK_DEFAULT void isr_eic0(void);
+WEAK_DEFAULT void isr_eic1(void);
+WEAK_DEFAULT void isr_eic2(void);
+WEAK_DEFAULT void isr_eic3(void);
+WEAK_DEFAULT void isr_eic_other(void);
+WEAK_DEFAULT void isr_freqm(void);
+WEAK_DEFAULT void isr_nvmctrl(void);
+WEAK_DEFAULT void isr_port(void);
+WEAK_DEFAULT void isr_dmac0(void);
+WEAK_DEFAULT void isr_dmac1(void);
+WEAK_DEFAULT void isr_dmac2(void);
+WEAK_DEFAULT void isr_dmac3(void);
+WEAK_DEFAULT void isr_dmac_other(void);
+WEAK_DEFAULT void isr_evsys0(void);
+WEAK_DEFAULT void isr_evsys1(void);
+WEAK_DEFAULT void isr_evsys2(void);
+WEAK_DEFAULT void isr_evsys3(void);
+WEAK_DEFAULT void isr_evsys_nschk(void);
+WEAK_DEFAULT void isr_pac(void);
+WEAK_DEFAULT void isr_sercom0_0(void);
+WEAK_DEFAULT void isr_sercom0_1(void);
+WEAK_DEFAULT void isr_sercom0_2(void);
+WEAK_DEFAULT void isr_sercom0_other(void);
+WEAK_DEFAULT void isr_sercom1_0(void);
+WEAK_DEFAULT void isr_sercom1_1(void);
+WEAK_DEFAULT void isr_sercom1_2(void);
+WEAK_DEFAULT void isr_sercom1_other(void);
+WEAK_DEFAULT void isr_sercom2_0(void);
+WEAK_DEFAULT void isr_sercom2_1(void);
+WEAK_DEFAULT void isr_sercom2_2(void);
+WEAK_DEFAULT void isr_sercom2_other(void);
+WEAK_DEFAULT void isr_tc0(void);
+WEAK_DEFAULT void isr_tc1(void);
+WEAK_DEFAULT void isr_tc2(void);
+WEAK_DEFAULT void isr_adc_other(void);
+WEAK_DEFAULT void isr_adc_resrdy(void);
+WEAK_DEFAULT void isr_ac(void);
+WEAK_DEFAULT void isr_dac_underrun_a(void);
+WEAK_DEFAULT void isr_dac_empty(void);
+WEAK_DEFAULT void isr_ptc(void);
+WEAK_DEFAULT void isr_trng(void);
+WEAK_DEFAULT void isr_tram(void);
+
+/* CPU specific interrupt vector table */
+ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
+    (void*) isr_system,             /*  0 Main Clock */
+    (void*) isr_wdt,                /*  1 Watchdog Timer */
+    (void*) isr_rtc,                /*  2 Real-Time Counter */
+    (void*) isr_eic0,               /*  3 External Interrupt Controller */
+    (void*) isr_eic1,               /*  4 External Interrupt Controller */
+    (void*) isr_eic2,               /*  5 External Interrupt Controller */
+    (void*) isr_eic3,               /*  6 External Interrupt Controller */
+    (void*) isr_eic_other,          /*  7 External Interrupt Controller */
+    (void*) isr_freqm,              /*  8 Frequency Meter */
+    (void*) isr_nvmctrl,            /*  9 Non-Volatile Memory Controller */
+    (void*) isr_port,               /*  10 Port Module */
+    (void*) isr_dmac0,              /*  11 Direct Memory Access Controller */
+    (void*) isr_dmac1,              /*  12 Direct Memory Access Controller */
+    (void*) isr_dmac2,              /*  13 Direct Memory Access Controller */
+    (void*) isr_dmac3,              /*  14 Direct Memory Access Controller */
+    (void*) isr_dmac_other,         /*  15 Direct Memory Access Controller */
+    (void*) isr_evsys0,             /*  16 Event System Interface */
+    (void*) isr_evsys1,             /*  17 Event System Interface */
+    (void*) isr_evsys2,             /*  18 Event System Interface */
+    (void*) isr_evsys3,             /*  19 Event System Interface */
+    (void*) isr_evsys_nschk,        /*  20 Event System Interface */
+    (void*) isr_pac,                /*  21 Peripheral Access Controller */
+    (void*) isr_sercom0_0,          /*  22 Serial Communication Interface */
+    (void*) isr_sercom0_1,          /*  23 Serial Communication Interface */
+    (void*) isr_sercom0_2,          /*  24 Serial Communication Interface */
+    (void*) isr_sercom0_other,      /*  25 Serial Communication Interface */
+    (void*) isr_sercom1_0,          /*  26 Serial Communication Interface */
+    (void*) isr_sercom1_1,          /*  27 Serial Communication Interface */
+    (void*) isr_sercom1_2,          /*  28 Serial Communication Interface */
+    (void*) isr_sercom1_other,      /*  29 Serial Communication Interface */
+    (void*) isr_sercom2_0,          /*  30 Serial Communication Interface */
+    (void*) isr_sercom2_1,          /*  31 Serial Communication Interface */
+    (void*) isr_sercom2_2,          /*  32 Serial Communication Interface */
+    (void*) isr_sercom2_other,      /*  33 Serial Communication Interface */
+    (void*) isr_tc0,                /*  34 Basic Timer Counter  */
+    (void*) isr_tc1,                /*  35 Basic Timer Counter  */
+    (void*) isr_tc2,                /*  36 Basic Timer Counter  */
+    (void*) isr_adc_other,          /*  37 Analog Digital Converter */
+    (void*) isr_adc_resrdy,         /*  38 Analog Digital Converter */
+    (void*) isr_ac,                 /*  39 Analog Comparators */
+    (void*) isr_dac_underrun_a,     /*  40 Digital Analog Converter */
+    (void*) isr_dac_empty,          /*  41 Analog Digital Converter */
+    (void*) isr_ptc,                /*  42 Peripheral Touch Controller */
+    (void*) isr_trng,               /*  43 True Random Number Generator */
+    (void*) isr_tram,               /*  44 Trust RAM */
+};

--- a/examples/asymcute_mqttsn/Makefile
+++ b/examples/asymcute_mqttsn/Makefile
@@ -15,6 +15,7 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon arduino-duemilanove arduino-mega2560 \
                              nucleo-f030r8 nucleo-f031k6 nucleo-f042k6 \
                              nucleo-f070rb nucleo-f072rb nucleo-f303k8 \
                              nucleo-f334r8 nucleo-l031k6 nucleo-l053r8 \
+                             saml10-xpro saml11-xpro  \
                              stm32f0discovery telosb waspmote-pro \
                              wsn430-v1_3b wsn430-v1_4 yunjia-nrf51822 z1
 

--- a/examples/dtls-echo/Makefile
+++ b/examples/dtls-echo/Makefile
@@ -17,8 +17,8 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 blackpill bluepill call
                              microbit nrf51dk nrf51dongle nrf6310 nucleo-f031k6 \
                              nucleo-f042k6 nucleo-f303k8 nucleo-l031k6 nucleo-f030r8 \
                              nucleo-f070rb nucleo-f072rb nucleo-f103rb nucleo-f302r8 nucleo-f334r8 \
-                             nucleo-l053r8 nucleo-l073rz opencm904 \
-                             spark-core stm32f0discovery yunjia-nrf51822
+                             nucleo-l053r8 nucleo-l073rz opencm904 saml10-xpro \
+                             saml11-xpro spark-core stm32f0discovery yunjia-nrf51822
 
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present

--- a/examples/gnrc_border_router/Makefile
+++ b/examples/gnrc_border_router/Makefile
@@ -15,8 +15,8 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon arduino-duemilanove arduino-mega2560 \
                              nucleo-f303k8 nucleo-l031k6 nucleo-f030r8 \
                              nucleo-f070rb nucleo-f072rb nucleo-f103rb \
                              nucleo-f302r8 nucleo-f334r8 nucleo-l053r8 \
-                             nucleo-l073rz opencm904 spark-core \
-                             stm32f0discovery telosb waspmote-pro \
+                             nucleo-l073rz opencm904 saml10-xpro saml11-xpro \
+                             spark-core stm32f0discovery telosb waspmote-pro \
                              weio wsn430-v1_3b wsn430-v1_4 yunjia-nrf51822 z1
 
 # The following boards do not have an available UART

--- a/examples/gnrc_networking/Makefile
+++ b/examples/gnrc_networking/Makefile
@@ -13,7 +13,8 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-uno \
                              nucleo-f042k6 nucleo-f303k8 nucleo-l031k6 \
                              nucleo-f030r8 nucleo-f070rb nucleo-f072rb \
                              nucleo-f103rb nucleo-f302r8 nucleo-f334r8 \
-                             nucleo-l053r8 spark-core stm32f0discovery telosb \
+                             nucleo-l053r8 saml10-xpro saml11-xpro \
+                             spark-core stm32f0discovery telosb \
                              waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
 
 # Include packages that pull up and auto-init the link layer.

--- a/examples/gnrc_tftp/Makefile
+++ b/examples/gnrc_tftp/Makefile
@@ -14,9 +14,9 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon arduino-duemilanove arduino-mega2560 \
                              nucleo-f042k6 nucleo-f303k8 nucleo-l031k6 \
                              nucleo-f030r8 nucleo-f070rb nucleo-f072rb \
                              nucleo-f103rb nucleo-f302r8 nucleo-f334r8 \
-                             nucleo-l053r8 spark-core stm32f0discovery \
-                             telosb waspmote-pro wsn430-v1_3b wsn430-v1_4 \
-                             yunjia-nrf51822 z1
+                             nucleo-l053r8 saml10-xpro saml11-xpro spark-core \
+                             stm32f0discovery telosb waspmote-pro wsn430-v1_3b \
+                             wsn430-v1_4 yunjia-nrf51822 z1
 
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present

--- a/examples/javascript/Makefile
+++ b/examples/javascript/Makefile
@@ -14,8 +14,8 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 blackpill bluepill call
                              nucleo-f103rb nucleo-f302r8 nucleo-f334r8 \
                              nucleo-f410rb nucleo-l053r8 nucleo-l073rz \
                              nucleo-f031k6 nucleo-f042k6 nucleo-f303k8 \
-                             nucleo-l031k6 opencm904 spark-core stm32f0discovery \
-                             yunjia-nrf51822
+                             nucleo-l031k6 opencm904 saml10-xpro saml11-xpro \
+                             spark-core stm32f0discovery yunjia-nrf51822
 
 BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-uno chronos \
                    msb-430 msb-430h telosb waspmote-pro wsn430-v1_3b \

--- a/examples/lua_REPL/Makefile
+++ b/examples/lua_REPL/Makefile
@@ -20,8 +20,8 @@ BOARD_INSUFFICIENT_MEMORY := blackpill bluepill calliope-mini cc2650-launchpad \
                              mbed_lpc1768  nrf6310 nucleo-f091rc  nucleo-l073rz \
                              nz32-sc151 openmote-cc2538 openmote-b pba-d-01-kw2x \
                              remote-pa remote-reva remote-revb samd21-xpro \
-                             saml21-xpro samr21-xpro samr30-xpro \
-                             seeeduino_arch-pro sensebox_samd21 slstk3401a \
+                             saml10-xpro saml11-xpro saml21-xpro samr21-xpro \
+                             samr30-xpro seeeduino_arch-pro sensebox_samd21 slstk3401a \
                              sltb001a slwstk6220a sodaq-autonomo sodaq-explorer \
                              sodaq-one sodaq-sara-aff stk3600 stm32f3discovery \
                              yunjia-nrf51822 esp8266-esp-12x esp8266-olimex-mod \

--- a/examples/lua_basic/Makefile
+++ b/examples/lua_basic/Makefile
@@ -12,7 +12,8 @@ BOARD_INSUFFICIENT_MEMORY := blackpill bluepill calliope-mini cc2650-launchpad \
                              nucleo-f042k6 nucleo-f070rb nucleo-f072rb \
                              nucleo-f103rb nucleo-f302r8 nucleo-f303k8 \
                              nucleo-f334r8 nucleo-f410rb nucleo-l031k6 \
-                             nucleo-l053r8 opencm904 spark-core stm32f0discovery
+                             nucleo-l053r8 opencm904 saml10-xpro saml11-xpro \
+                             spark-core stm32f0discovery
 
 BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-uno \
                    chronos hifive1 jiminy-mega256rfr2 mega-xplained mips-malta \

--- a/makefiles/arch/cortexm.inc.mk
+++ b/makefiles/arch/cortexm.inc.mk
@@ -128,6 +128,8 @@ else ifeq ($(CPU_ARCH),cortex-m4f)
 export CFLAGS += -DARM_MATH_CM4
 else ifeq ($(CPU_ARCH),cortex-m7)
 export CFLAGS += -DARM_MATH_CM7
+else ifeq ($(CPU_ARCH),cortex-m23)
+export CFLAGS += -DARM_MATH_CM23
 endif
 endif
 

--- a/pkg/qDSA/Makefile.dep
+++ b/pkg/qDSA/Makefile.dep
@@ -1,4 +1,4 @@
-ifneq (,$(filter cortex-m0%,$(CPU_ARCH)))
+ifneq (,$(filter cortex-m23 cortex-m0%,$(CPU_ARCH)))
   USEMODULE += qDSA_asm
 endif
 

--- a/pkg/qDSA/Makefile.include
+++ b/pkg/qDSA/Makefile.include
@@ -1,4 +1,4 @@
-ifneq (,$(filter cortex-m0%,$(CPU_ARCH)))
+ifneq (,$(filter cortex-m23 cortex-m0%,$(CPU_ARCH)))
   QDSA_IMPL ?= arm
 else
 ifneq (,$(filter atmega_common,$(USEMODULE)))

--- a/tests/conn_can/Makefile
+++ b/tests/conn_can/Makefile
@@ -5,8 +5,9 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-uno \
                              nucleo-f042k6 nucleo-f303k8 nucleo-l031k6 \
                              nucleo-f030r8 nucleo-f070rb nucleo-f072rb \
                              nucleo-f302r8 nucleo-f303re nucleo-f334r8 \
-                             nucleo-l053r8 stm32f0discovery telosb \
-                             waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
+                             nucleo-l053r8 saml10-xpro saml11-xpro \
+                             stm32f0discovery telosb waspmote-pro wsn430-v1_3b \
+                             wsn430-v1_4 z1
 
 CFLAGS += -DLOG_LEVEL=LOG_ALL
 

--- a/tests/gnrc_netif/Makefile
+++ b/tests/gnrc_netif/Makefile
@@ -9,8 +9,8 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon arduino-duemilanove arduino-mega2560 \
                              nucleo-f103rb nucleo-f302r8 nucleo-f334r8 \
                              nucleo-l053r8 nucleo-l073rz nucleo-f031k6 \
                              nucleo-f042k6 nucleo-f303k8 nucleo-l031k6 \
-                             opencm904 spark-core stm32f0discovery \
-                             telosb waspmote-pro \
+                             opencm904 saml10-xpro saml11-xpro spark-core \
+                             stm32f0discovery telosb waspmote-pro \
                              wsn430-v1_3b wsn430-v1_4 yunjia-nrf51822 z1
 
 USEMODULE += embunit

--- a/tests/gnrc_rpl_srh/Makefile
+++ b/tests/gnrc_rpl_srh/Makefile
@@ -7,8 +7,8 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-uno \
                              nucleo-f030r8 nucleo-f031k6 nucleo-f042k6 \
                              nucleo-f070rb nucleo-f072rb nucleo-f303k8 \
                              nucleo-f334r8 nucleo-l031k6 nucleo-l053r8 \
-                             stm32f0discovery telosb thingy52 waspmote-pro \
-                             wsn430-v1_3b wsn430-v1_4 z1
+                             saml10-xpro saml11-xpro stm32f0discovery telosb \
+                             thingy52 waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
 # chronos, mips-malta, and ruuvitag boards don't support ethos
 BOARD_BLACKLIST := chronos mips-malta ruuvitag
 

--- a/tests/gnrc_sixlowpan/Makefile
+++ b/tests/gnrc_sixlowpan/Makefile
@@ -6,8 +6,8 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-uno \
                              nucleo-f031k6 nucleo-f042k6 nucleo-f070rb \
                              nucleo-f070rb nucleo-f072rb nucleo-f303k8 \
                              nucleo-f334r8 nucleo-l031k6 nucleo-l053r8 \
-                             stm32f0discovery telosb waspmote-pro \
-                             wsn430-v1_3b wsn430-v1_4 z1
+                             saml10-xpro saml11-xpro stm32f0discovery telosb \
+                             waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
 
 # use IEEE 802.15.4 as link-layer protocol
 USEMODULE += netdev_ieee802154

--- a/tests/gnrc_tcp_client/Makefile
+++ b/tests/gnrc_tcp_client/Makefile
@@ -14,7 +14,7 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon arduino-duemilanove arduino-mega2560 \
                              msb-430 msb-430h nrf51dk nrf51dongle nrf6310 nucleo-f031k6 \
                              nucleo-f042k6 nucleo-f303k8 nucleo-l031k6 nucleo-f030r8 \
                              nucleo-f070rb nucleo-f072rb nucleo-f302r8 nucleo-f334r8 nucleo-l053r8 \
-                             sb-430 sb-430h stm32f0discovery telosb \
+                             saml10-xpro saml11-xpro sb-430 sb-430h stm32f0discovery telosb \
                              waspmote-pro wsn430-v1_3b wsn430-v1_4 yunjia-nrf51822 z1
 
 # Target Address, Target Port and number of Test Cycles

--- a/tests/gnrc_tcp_server/Makefile
+++ b/tests/gnrc_tcp_server/Makefile
@@ -14,7 +14,7 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon arduino-duemilanove arduino-mega2560 \
                              microbit msb-430 msb-430h nrf51dk nrf51dongle nrf6310 nucleo-f031k6 \
                              nucleo-f042k6 nucleo-f303k8 nucleo-l031k6 nucleo-f030r8 \
                              nucleo-f070rb nucleo-f072rb nucleo-f302r8 nucleo-f334r8 nucleo-l053r8 \
-                             sb-430 sb-430h stm32f0discovery telosb \
+                             saml10-xpro saml11-xpro sb-430 sb-430h stm32f0discovery telosb \
                              waspmote-pro wsn430-v1_3b wsn430-v1_4 yunjia-nrf51822 z1
 
 # This has to be the absolute path to the RIOT base directory:

--- a/tests/lwip_sock_tcp/Makefile
+++ b/tests/lwip_sock_tcp/Makefile
@@ -8,7 +8,7 @@ BOARD_BLACKLIST := arduino-uno arduino-duemilanove arduino-mega2560 chronos \
 BOARD_INSUFFICIENT_MEMORY = blackpill bluepill nucleo-f031k6 nucleo-f042k6 \
                             nucleo-l031k6 nucleo-f030r8 nucleo-f302r8 \
                             nucleo-f303k8 nucleo-f334r8 nucleo-l053r8 \
-                            stm32f0discovery
+                            saml10-xpro saml11-xpro stm32f0discovery
 
 LWIP_IPV4 ?= 0
 

--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -58,6 +58,8 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon \
                              remote-pa \
                              remote-reva \
                              remote-revb \
+                             saml10-xpro \
+                             saml11-xpro \
                              saml21-xpro \
                              samd21-xpro \
                              samr21-xpro \
@@ -170,6 +172,8 @@ ARM_CORTEX_M_BOARDS := airfy-beacon \
                        remote-pa \
                        remote-reva \
                        remote-revb \
+                       saml10-xpro \
+                       saml11-xpro \
                        samd21-xpro \
                        saml21-xpro \
                        samr21-xpro \

--- a/tests/unittests/tests-core/tests-core-atomic.c
+++ b/tests/unittests/tests-core/tests-core-atomic.c
@@ -51,7 +51,11 @@ static void test_atomic_inc_negative(void)
         TEST_ASSERT_EQUAL_INT(i + 1, atomic_load(&res));
     }
 }
-
+/* Prevent compiler optimization for SAML1X because of gcc internal bug */
+#ifdef CPU_SAML1X
+#pragma GCC push_options
+#pragma GCC optimize ("O0")
+#endif
 static void test_atomic_inc_rollover(void)
 {
     atomic_int res = ATOMIC_VAR_INIT(INT_MAX - 30);
@@ -67,7 +71,9 @@ static void test_atomic_inc_rollover(void)
     TEST_ASSERT_EQUAL_INT(INT_MIN + 1, atomic_fetch_add(&res, 1));
     TEST_ASSERT_EQUAL_INT(INT_MIN + 2, atomic_load(&res));
 }
-
+#ifdef CPU_SAML1X
+#pragma GCC pop_options
+#endif
 /* Test atomic_fetch_sub */
 static void test_atomic_dec_negative(void)
 {


### PR DESCRIPTION
### Contribution description

This PR adds a very basic support for our first Cortex-M23 MCUs, SAML10 and SAML11 so people can start to play with it. These chips are the same except that SAML11 add security stuff (ARM TrustZone, non-secure+secure registers,...)

~~In the current state, only GPIOs, timer and UART work.~~

SAML10/SAML11 IP peripherals are really close to SAML21. But I don't know if these MCUs should re-use stuff within sam0_common since they are cortex-m23 based...So right now, I copied GPIOs, timer , uart SAML21 drivers and make the required changes to use them but this can be optimized. (now or later). In fact, we can re-use all sam0 drivers with these MCUs but it will take much more time to fully test it. We can stay as it now and optimize later or we can do it now but I was hoping to see this PR merged for the incoming release.

Regarding MPU support, I intentionally prevent from using this feature on Cortex-M23 because armv8 introduces several changes and I need more time to rework and test this feature. I (or someone with more MPU knowledge) will do it later.


### Testing procedure

run make BOARD=saml10-xpro -C [test_you_want]
or  make BOARD=saml11-xpro -C [test_you_want]

EDBG will be used to flash the board.


### Issues/PRs references
This PR is based on top of #10558
see also #10570 for EDBG update which supports these MCUs.

