### PR TITLE
loramac: change rxdelay1 to millisec, was seconds

### DIFF
--- a/sys/include/net/loramac.h
+++ b/sys/include/net/loramac.h
@@ -181,16 +181,16 @@ extern "C" {
 #endif
 
 /**
- * @brief   Default first RX window delay (in s)
+ * @brief   Default first RX window delay (in ms)
  */
 #ifndef LORAMAC_DEFAULT_RX1_DELAY
-#define LORAMAC_DEFAULT_RX1_DELAY      (1U)
+#define LORAMAC_DEFAULT_RX1_DELAY      (1000U)
 #endif
 
 /**
- * @brief   Default first RX window delay (in s)
+ * @brief   Default second RX window delay (in ms)
  */
-#define LORAMAC_DEFAULT_RX2_DELAY      (1U + LORAMAC_DEFAULT_RX1_DELAY)
+#define LORAMAC_DEFAULT_RX2_DELAY      (1000U + LORAMAC_DEFAULT_RX1_DELAY)
 
 /**
  * @brief   Default automatic reply status


### PR DESCRIPTION
The RN2xx3 device has this parameter in milliseconds. So far, there is no
other device driver using loramac.h

Notice that RN2xx3 only has a get command for rxdelay2, not a set command.
Nevertheless, that parameter was changed to milliseconds as well.