### PR TITLE
cpu/esp8266: added/changed helper functions

### DIFF
--- a/cpu/esp8266/exceptions.c
+++ b/cpu/esp8266/exceptions.c
@@ -20,7 +20,6 @@
 #define ENABLE_DEBUG  0
 #include "debug.h"
 
-#include <malloc.h>
 #include <string.h>
 #include <stdlib.h>
 
@@ -32,13 +31,9 @@
 #include "esp/common_macros.h"
 #include "esp/xtensa_ops.h"
 #include "sdk/ets.h"
+#include "tools.h"
 #include "xtensa/corebits.h"
 #include "xtensa/xtensa_api.h"
-
-extern void malloc_stats (void);
-extern unsigned int get_free_heap_size (void);
-extern uint8_t _eheap;  /* end of heap (defined in esp8266.riot-os.app.ld) */
-extern uint8_t _sheap;  /* start of heap (defined in esp8266.riot-os.app.ld) */
 
 static const char* exception_names [] =
 {
@@ -96,9 +91,7 @@ void IRAM NORETURN exception_handler (XtExcFrame *frame)
     #if defined(MODULE_PS)
     ps();
     #endif
-    struct mallinfo minfo = mallinfo();
-    ets_printf("heap: %lu (free %lu) byte\n", &_eheap - &_sheap, get_free_heap_size());
-    ets_printf("sysmem: %d (used %d, free %d)\n", minfo.arena, minfo.uordblks, minfo.fordblks);
+    print_meminfo();
     #endif
     /* flushing the buffer */
     ets_printf("                                                          \n");
@@ -125,9 +118,7 @@ void init_exceptions (void)
 void IRAM NORETURN panic_arch(void)
 {
     #if defined(DEVELHELP)
-    struct mallinfo minfo = mallinfo();
-    ets_printf("heap: %lu (free %lu) byte\n", &_eheap - &_sheap, get_free_heap_size());
-    ets_printf("sysmem: %d (used %d, free %d)\n", minfo.arena, minfo.uordblks, minfo.fordblks);
+    print_meminfo();
     ets_printf("                                                          \n");
     ets_printf("                                                          \n");
     #endif

--- a/cpu/esp8266/include/sys/_intsup.h
+++ b/cpu/esp8266/include/sys/_intsup.h
@@ -92,9 +92,9 @@ extern "C" {
 #endif
 
 #if (__INT8_TYPE__ == 0)
-#define __INT8 "hh"
+#define __INT8 /* "hh" */ /* ets_printf doesn't support "h" */
 #elif (__INT8_TYPE__ == 1 || __INT8_TYPE__ == 3)
-#define __INT8 "h"
+#define __INT8 /* "h" */ /* ets_printf doesn't support "h" */
 #elif (__INT8_TYPE__ == 2)
 #define __INT8
 #elif (__INT8_TYPE__ == 4 || __INT8_TYPE__ == 6)
@@ -103,7 +103,7 @@ extern "C" {
 #define __INT8 "ll"
 #endif
 #if (__INT16_TYPE__ == 1 || __INT16_TYPE__ == 3)
-#define __INT16 "h"
+#define __INT16 /* "h" */ /* ets_printf doesn't support "h" */
 #elif (__INT16_TYPE__ == 2)
 #define __INT16
 #elif (__INT16_TYPE__ == 4 || __INT16_TYPE__ == 6)
@@ -136,9 +136,9 @@ extern "C" {
 #define __INT64 "ll"
 #endif
 #if (__INT_FAST8_TYPE__ == 0)
-#define __FAST8 "hh"
+#define __FAST8 /* "hh" */ /* ets_printf doesn't support "h" */
 #elif (__INT_FAST8_TYPE__ == 1 || __INT_FAST8_TYPE__ == 3)
-#define __FAST8 "h"
+#define __FAST8 /* "h" */ /* ets_printf doesn't support "h" */
 #elif (__INT_FAST8_TYPE__ == 2)
 #define __FAST8
 #elif (__INT_FAST8_TYPE__ == 4 || __INT_FAST8_TYPE__ == 6)
@@ -147,7 +147,7 @@ extern "C" {
 #define __FAST8 "ll"
 #endif
 #if (__INT_FAST16_TYPE__ == 1 || __INT_FAST16_TYPE__ == 3)
-#define __FAST16 "h"
+#define __FAST16 /* "h" */ /* ets_printf doesn't support "h" */
 #elif (__INT_FAST16_TYPE__ == 2)
 #define __FAST16
 #elif (__INT_FAST16_TYPE__ == 4 || __INT_FAST16_TYPE__ == 6)
@@ -171,9 +171,9 @@ extern "C" {
 #endif
 
 #if (__INT_LEAST8_TYPE__ == 0)
-#define __LEAST8 "hh"
+#define __LEAST8 /* "hh" */ /* ets_printf doesn't support "h" */
 #elif (__INT_LEAST8_TYPE__ == 1 || __INT_LEAST8_TYPE__ == 3)
-#define __LEAST8 "h"
+#define __LEAST8 /* "h" */ /* ets_printf doesn't support "h" */
 #elif (__INT_LEAST8_TYPE__ == 2)
 #define __LEAST8
 #elif (__INT_LEAST8_TYPE__ == 4 || __INT_LEAST8_TYPE__ == 6)
@@ -182,7 +182,7 @@ extern "C" {
 #define __LEAST8 "ll"
 #endif
 #if (__INT_LEAST16_TYPE__ == 1 || __INT_LEAST16_TYPE__ == 3)
-#define __LEAST16 "h"
+#define __LEAST16 /* "h" */ /* ets_printf doesn't support "h" */
 #elif (__INT_LEAST16_TYPE__ == 2)
 #define __LEAST16
 #elif (__INT_LEAST16_TYPE__ == 4 || __INT_LEAST16_TYPE__ == 6)

--- a/cpu/esp8266/include/tools.h
+++ b/cpu/esp8266/include/tools.h
@@ -34,7 +34,12 @@ extern "C" {
  * @param[in]  width     format of the items
  * @param[in]  per_line  number of items per line
  */
-extern void esp_hexdump (const void* addr, uint32_t num, char width, uint8_t per_line);
+void esp_hexdump (const void* addr, uint32_t num, char width, uint8_t per_line);
+
+/**
+ * @brief  Print heap and system memory information
+ */
+void print_meminfo (void);
 
 #ifdef __cplusplus
 }

--- a/cpu/esp8266/startup.c
+++ b/cpu/esp8266/startup.c
@@ -165,6 +165,9 @@ void system_init(void)
     /* trigger board initialization */
     board_init();
 
+    /* print memory info */
+    print_meminfo();
+
     /* print the board config */
     board_print_config();
 }
@@ -695,6 +698,9 @@ void __attribute__((noreturn)) IRAM cpu_user_start (void)
 
     /* initialize the board and startup the kernel */
     board_init();
+
+    /* print memory info */
+    print_meminfo();
 
     /* print the board config */
     board_print_config();

--- a/cpu/esp8266/tools.c
+++ b/cpu/esp8266/tools.c
@@ -47,10 +47,10 @@ void esp_hexdump (const void* addr, uint32_t num, char width, uint8_t per_line)
             printf ("%08x: ", (uint32_t)((uint8_t*)addr+count*size));
         }
         switch (width) {
-            case 'b': printf("%02" PRIx8, addr8[count++]); break;
-            case 'h': printf("%04" PRIx16, addr16[count++]); break;
-            case 'w': printf("%08" PRIx32, addr32[count++]); break;
-            case 'g': printf("%016" PRIx64, addr64[count++]); break;
+            case 'b': printf("%02" PRIx8 " ", addr8[count++]); break;
+            case 'h': printf("%04" PRIx16 " ", addr16[count++]); break;
+            case 'w': printf("%08" PRIx32 " ", addr32[count++]); break;
+            case 'g': printf("%016" PRIx64 " ", addr64[count++]); break;
 
             default : printf("."); count++; break;
         }

--- a/cpu/esp8266/tools.c
+++ b/cpu/esp8266/tools.c
@@ -20,9 +20,23 @@
 
 #include <stdio.h>
 #include <inttypes.h>
+#include <malloc.h>
 
 #include "esp/common_macros.h"
+#include "sdk/ets.h"
 #include "tools.h"
+
+extern void malloc_stats (void);
+extern unsigned int get_free_heap_size (void);
+extern uint8_t _eheap;  /* end of heap (defined in esp8266.riot-os.app.ld) */
+extern uint8_t _sheap;  /* start of heap (defined in esp8266.riot-os.app.ld) */
+
+void print_meminfo (void)
+{
+    struct mallinfo minfo = mallinfo();
+    ets_printf("heap: %lu (free %lu) byte\n", &_eheap - &_sheap, get_free_heap_size());
+    ets_printf("sysmem: %d (used %d, free %d)\n", minfo.arena, minfo.uordblks, minfo.fordblks);
+}
 
 void esp_hexdump (const void* addr, uint32_t num, char width, uint8_t per_line)
 {


### PR DESCRIPTION
### Contribution description

This PR contains

- a new helper function `print_meminfo` that can be used for debugging memory usage in ESP8266. Before, there were several modules with the same code for printing the memory usage. To avoid further code duplication, the new function `printf_meminfo` was introduced.
- a change of `printf` format identifiers since the `ets_printf` ROM function does not support `h` format identifier.
- a fix of missing spaces in `esp_hexdump` helper function

### Testing procedure

Since the PR does not contain changes of functionality, successful compilation is the test.

### Issues/PRs references

This PR is prerequisite for further upcoming PRs. The references to this PRs will be updated.