### PR TITLE
netdev_driver_t::recv(): Clarified documentation

### DIFF
--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -318,8 +318,8 @@ typedef struct netdev_driver {
      * Supposed to be called from
      * @ref netdev_t::event_callback "netdev->event_callback()"
      *
-     * If @p buf == NULL and @p len == 0, returns the packet size without
-     * dropping it.
+     * If @p buf == NULL and @p len == 0, returns the packet size -- or an upper
+     * bound estimation of the size -- without dropping the packet.
      * If @p buf == NULL and @p len > 0, drops the packet and returns the packet
      * size.
      *
@@ -342,7 +342,7 @@ typedef struct netdev_driver {
      *
      * @return `-ENOBUFS` if supplied buffer is too small
      * @return number of bytes read if buf != NULL
-     * @return packet size if buf == NULL
+     * @return packet size (or upper bound estimation) if buf == NULL
      */
     int (*recv)(netdev_t *dev, void *buf, size_t len, void *info);
 

--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -323,6 +323,13 @@ typedef struct netdev_driver {
      * If @p buf == NULL and @p len > 0, drops the packet and returns the packet
      * size.
      *
+     * If called with @p buf != NULL and @p len is smaller than the received
+     * packet:
+     *  - The received packet is dropped
+     *  - The content in @p buf becomes invalid. (The driver may use the memory
+     *    to implement the dropping - or may not change it.)
+     *  - `-ENOBUFS` is returned
+     *
      * @param[in]   dev     network device descriptor. Must not be NULL.
      * @param[out]  buf     buffer to write into or NULL to return the packet
      *                      size.

--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -313,7 +313,6 @@ typedef struct netdev_driver {
      * @brief Get a received frame
      *
      * @pre `(dev != NULL)`
-     * @pre `(buf != NULL) && (len > 0)`
      *
      * Supposed to be called from
      * @ref netdev_t::event_callback "netdev->event_callback()"

--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -310,7 +310,8 @@ typedef struct netdev_driver {
     int (*send)(netdev_t *dev, const iolist_t *iolist);
 
     /**
-     * @brief Get a received frame
+     * @brief Drop a received frame, **OR** get the length of a received frame,
+     *        **OR** get a received frame.
      *
      * @pre `(dev != NULL)`
      *


### PR DESCRIPTION
### Contribution description
This PR clarifies the documentation in `netdev_driver_t::recv()` a bit and brings it back in sync with the code.

Changes in detail:

 - Precondition `(buf != NULL) && (len > 0)` removed, because it is strictly incorrect
 - Changed `@brief` text to reflect the the three different features of `netdev_driver_t::recv()`. (Leading with the least obvious one, to attract more attention to it.)
 - Clarified how to behave correctly when receiving a frame larger than the supplied buffer
 - Clarified that `recv()` with `(buf == NULL) && (len == 0)` may also return an upper bound estimation of the frame size, instead of the actual frame size.

### Testing procedure
Doesn't apply.

### Issues/PRs references
- Resolves https://github.com/RIOT-OS/RIOT/issues/10413
- May also help to keep bugs like in https://github.com/RIOT-OS/RIOT/issues/10410 from re-appearing