### PR TITLE
gnrc_sixlowpan: amend gnrc_netapi introduction

### DIFF
--- a/sys/include/net/gnrc/sixlowpan.h
+++ b/sys/include/net/gnrc/sixlowpan.h
@@ -15,6 +15,8 @@
  *
  * # NETAPI command documentation
  *
+ * This module handles the following @ref net_gnrc_netapi message types:
+ *
  * ## `GNRC_NETAPI_MSG_TYPE_RCV`
  *
  * @ref GNRC_NETAPI_MSG_TYPE_RCV expects a @ref net_gnrc_pkt (referred to as "packet" in the


### PR DESCRIPTION
### Contribution description
Backports a request by @Lotterleben for `gnrc_ipv6` in #10583.

### Testing procedure
Should be fine, but try compiling with `make doc`.


### Issues/PRs references
See https://github.com/RIOT-OS/RIOT/pull/10583#discussion_r243826719