### PR TITLE
boards/nucleo-l496zg: use lpuart1 as stdio interface

### DIFF
--- a/boards/nucleo-l496zg/Makefile.dep
+++ b/boards/nucleo-l496zg/Makefile.dep
@@ -1,1 +1,3 @@
+FEATURES_REQUIRED += periph_lpuart
+
 include $(RIOTBOARD)/common/nucleo/Makefile.dep

--- a/boards/nucleo-l496zg/Makefile.features
+++ b/boards/nucleo-l496zg/Makefile.features
@@ -4,7 +4,7 @@ FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
-FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_uart periph_lpuart
 
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo144/Makefile.features

--- a/boards/nucleo-l496zg/Makefile.include
+++ b/boards/nucleo-l496zg/Makefile.include
@@ -4,7 +4,7 @@ export CPU_MODEL = stm32l496zg
 
 # stdio is not available over st-link but on the Arduino TX/RX pins
 # A serial to USB converter plugged to the host is required
-PORT_LINUX ?= /dev/ttyUSB0
+PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
 # load the common Makefile.include for Nucleo boards

--- a/boards/nucleo-l496zg/include/periph_conf.h
+++ b/boards/nucleo-l496zg/include/periph_conf.h
@@ -113,6 +113,18 @@ static const timer_conf_t timer_config[] = {
  */
 static const uart_conf_t uart_config[] = {
     {
+        .dev        = LPUART1,
+        .rcc_mask   = RCC_APB1ENR2_LPUART1EN,
+        .rx_pin     = GPIO_PIN(PORT_G, 8),
+        .tx_pin     = GPIO_PIN(PORT_G, 7),
+        .rx_af      = GPIO_AF8,
+        .tx_af      = GPIO_AF8,
+        .bus        = APB12,
+        .irqn       = LPUART1_IRQn,
+        .type       = STM32_LPUART,
+        .clk_src    = 0,
+    },
+    {
         .dev        = USART3,
         .rcc_mask   = RCC_APB1ENR1_USART3EN,
         .rx_pin     = GPIO_PIN(PORT_D, 9),
@@ -130,8 +142,9 @@ static const uart_conf_t uart_config[] = {
     }
 };
 
-#define UART_0_ISR          (isr_usart3)
-#define UART_0_DMA_ISR      (isr_dma1_stream5)
+#define UART_0_ISR          (isr_lpuart1)
+#define UART_1_ISR          (isr_usart3)
+#define UART_1_DMA_ISR      (isr_dma1_stream5)
 
 #define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
 /** @} */

--- a/cpu/stm32_common/periph/gpio.c
+++ b/cpu/stm32_common/periph/gpio.c
@@ -85,6 +85,13 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     periph_clk_en(IOP, (RCC_IOPENR_GPIOAEN << _port_num(pin)));
 #elif defined (CPU_FAM_STM32L4)
     periph_clk_en(AHB2, (RCC_AHB2ENR_GPIOAEN << _port_num(pin)));
+#ifdef PWR_CR2_IOSV
+    if (port == GPIOG) {
+        /* Port G requires external power supply */
+        periph_clk_en(APB1, RCC_APB1ENR1_PWREN);
+        PWR->CR2 |= PWR_CR2_IOSV;
+    }
+#endif /* PWR_CR2_IOSV */
 #else
     periph_clk_en(AHB1, (RCC_AHB1ENR_GPIOAEN << _port_num(pin)));
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR modifies the default stdio interface used for the nucleo-l496zg board: it allows to use the LPUART connected to the ST-Link programmer.
So with this is PR, there's no need anymore for an external USB to UART converter.

To make LPUART1 works with this board, a trick is required in `gpio_init` to enable Port G, which is used by the LPUART on this board. This is explained in the reference manual (RM0351), section 5.1.2.

Thanks also to @vincent-d for this help on this one :)

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Build and flash any application that required stdio, preferably an application with the shell, `examples/default` is a good candidate.
- Verify that the shell is working

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
