### PR TITLE
 gnrc_netif_hdr: add setter for netif

### DIFF
--- a/cpu/esp_common/esp-now/esp_now_gnrc.c
+++ b/cpu/esp_common/esp-now/esp_now_gnrc.c
@@ -173,7 +173,7 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
         goto err;
     }
 
-    ((gnrc_netif_hdr_t *)netif_hdr->data)->if_pid = netif->pid;
+    gnrc_netif_hdr_set_netif((gnrc_netif_hdr_t *)netif_hdr->data, netif);
 
     uint8_t *mac = mac_hdr->data;
     DEBUG("gnrc_esp_now: received packet from %02x:%02x:%02x:%02x:%02x:%02x of length %u\n",

--- a/cpu/nrf5x_common/radio/nrfmin/nrfmin_gnrc.c
+++ b/cpu/nrf5x_common/radio/nrfmin/nrfmin_gnrc.c
@@ -162,7 +162,7 @@ static gnrc_pktsnip_t *gnrc_nrfmin_recv(gnrc_netif_t *dev)
     }
     netif->lqi = 0;
     netif->rssi = 0;
-    netif->if_pid = dev->pid;
+    gnrc_netif_hdr_set_netif(netif, dev);
     pkt_snip->type = nrfmin->proto;
 
     /* finally: remove the nrfmin header and append the netif header */

--- a/drivers/xbee/gnrc_xbee.c
+++ b/drivers/xbee/gnrc_xbee.c
@@ -86,7 +86,7 @@ static gnrc_pktsnip_t *xbee_adpt_recv(gnrc_netif_t *netif)
         return NULL;
     }
     netif_hdr = (gnrc_netif_hdr_t *)netif_snip->data;
-    netif_hdr->if_pid = netif->pid;
+    gnrc_netif_hdr_set_netif(netif_hdr, netif);
     netif_hdr->rssi = l2hdr.rssi;
     if (l2hdr.bcast) {
         netif_hdr->flags = GNRC_NETIF_HDR_FLAGS_BROADCAST;

--- a/examples/gnrc_networking_mac/udp.c
+++ b/examples/gnrc_networking_mac/udp.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
+ * Copyright (C) 2015-17 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -14,6 +14,7 @@
  * @brief       Demonstrating the sending and receiving of UDP data
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Martine Lenders <m.lenders@fu-berlin.de>
  *
  * @}
  */
@@ -57,7 +58,7 @@ static void send(char *addr_str, char *port_str, char *data, unsigned int num,
         return;
     }
     /* parse port */
-    port = (uint16_t)atoi(port_str);
+    port = atoi(port_str);
     if (port == 0) {
         puts("Error: unable to parse destination port");
         return;
@@ -120,7 +121,7 @@ static void start_server(char *port_str)
         return;
     }
     /* parse port */
-    port = (uint16_t)atoi(port_str);
+    port = atoi(port_str);
     if (port == 0) {
         puts("Error: invalid port specified");
         return;
@@ -161,10 +162,10 @@ int udp_cmd(int argc, char **argv)
             return 1;
         }
         if (argc > 5) {
-            num = (uint32_t)atoi(argv[5]);
+            num = atoi(argv[5]);
         }
         if (argc > 6) {
-            delay = (uint32_t)atoi(argv[6]);
+            delay = atoi(argv[6]);
         }
         send(argv[2], argv[3], argv[4], num, delay);
     }

--- a/examples/gnrc_networking_mac/udp.c
+++ b/examples/gnrc_networking_mac/udp.c
@@ -38,6 +38,7 @@ static gnrc_netreg_entry_t server = GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX
 static void send(char *addr_str, char *port_str, char *data, unsigned int num,
                  unsigned int delay)
 {
+    gnrc_netif_t *netif;
     int iface;
     uint16_t port;
     ipv6_addr_t addr;
@@ -45,7 +46,10 @@ static void send(char *addr_str, char *port_str, char *data, unsigned int num,
     /* get interface, if available */
     iface = ipv6_addr_split_iface(addr_str);
     if ((iface < 0) && (gnrc_netif_numof() == 1)) {
-        iface = gnrc_netif_iter(NULL)->pid;
+        netif = gnrc_netif_iter(NULL);
+    }
+    else {
+        netif = gnrc_netif_get_by_pid(iface);
     }
     /* parse destination address */
     if (ipv6_addr_from_str(&addr, addr_str) == NULL) {
@@ -85,11 +89,11 @@ static void send(char *addr_str, char *port_str, char *data, unsigned int num,
             return;
         }
         /* add netif header, if interface was given */
-        if (iface > 0) {
-            gnrc_pktsnip_t *netif = gnrc_netif_hdr_build(NULL, 0, NULL, 0);
+        if (netif != NULL) {
+            gnrc_pktsnip_t *netif_hdr = gnrc_netif_hdr_build(NULL, 0, NULL, 0);
 
-            ((gnrc_netif_hdr_t *)netif->data)->if_pid = (kernel_pid_t)iface;
-            LL_PREPEND(ip, netif);
+            gnrc_netif_hdr_set_netif(netif_hdr->data, netif);
+            LL_PREPEND(ip, netif_hdr);
         }
         /* send packet */
         if (!gnrc_netapi_dispatch_send(GNRC_NETTYPE_UDP, GNRC_NETREG_DEMUX_CTX_ALL, ip)) {

--- a/pkg/nordic_softdevice_ble/src/gnrc_nordic_ble_6lowpan.c
+++ b/pkg/nordic_softdevice_ble/src/gnrc_nordic_ble_6lowpan.c
@@ -108,7 +108,7 @@ static void _handle_raw_sixlowpan(ble_mac_inbuf_t *inbuf)
     gnrc_netif_hdr_init(netif_hdr->data, BLE_L2_ADDR_LEN, BLE_L2_ADDR_LEN);
     gnrc_netif_hdr_set_src_addr(netif_hdr->data, inbuf->src, BLE_L2_ADDR_LEN);
     gnrc_netif_hdr_set_dst_addr(netif_hdr->data, _ble_netif->l2addr, BLE_L2_ADDR_LEN);
-    ((gnrc_netif_hdr_t *)netif_hdr->data)->if_pid = _ble_netif->pid;
+    gnrc_netif_hdr_set_netif(netif_hdr->data, _ble_netif);
 
     DEBUG("_handle_raw_sixlowpan(): received packet from %02x:%02x:%02x:%02x:%02x:%02x "
             "of length %d\n",

--- a/sys/net/gnrc/application_layer/tftp/gnrc_tftp.c
+++ b/sys/net/gnrc/application_layer/tftp/gnrc_tftp.c
@@ -1019,7 +1019,7 @@ tftp_state _tftp_send(gnrc_pktsnip_t *buf, tftp_context_t *ctxt, size_t len)
 
             return TS_FAILED;
         }
-        ((gnrc_netif_hdr_t *)netif_hdr->data)->if_pid = gnrc_netif_iter(NULL)->pid;
+        gnrc_netif_hdr_set_netif(netif_hdr->data, gnrc_netif_iter(NULL));
         LL_PREPEND(ip, netif_hdr);
     }
 

--- a/sys/net/gnrc/link_layer/gomach/gomach_internal.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach_internal.c
@@ -172,7 +172,7 @@ static int _parse_packet(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt,
     gnrc_netif_hdr_t *netif_hdr = netif_snip->data;
     netif_hdr->lqi = netif->mac.prot.gomach.rx_pkt_lqi;
     netif_hdr->rssi = netif->mac.prot.gomach.rx_pkt_rssi;
-    netif_hdr->if_pid = netif->pid;
+    gnrc_netif_hdr_set_netif(netif_hdr, netif);
     pkt->type = state->proto;
     gnrc_pktbuf_remove_snip(pkt, pkt->next);
     LL_APPEND(pkt, netif_snip);

--- a/sys/net/gnrc/link_layer/lwmac/lwmac.c
+++ b/sys/net/gnrc/link_layer/lwmac/lwmac.c
@@ -174,7 +174,7 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
 
             hdr->lqi = rx_info.lqi;
             hdr->rssi = rx_info.rssi;
-            hdr->if_pid = thread_getpid();
+            gnrc_netif_hdr_set_netif(hdr, netif);
             pkt->type = state->proto;
 #if ENABLE_DEBUG
             DEBUG("_recv_ieee802154: received packet from %s of length %u\n",

--- a/sys/net/gnrc/network_layer/icmpv6/echo/gnrc_icmpv6_echo.c
+++ b/sys/net/gnrc/network_layer/icmpv6/echo/gnrc_icmpv6_echo.c
@@ -98,14 +98,8 @@ void gnrc_icmpv6_echo_req_handle(gnrc_netif_t *netif, ipv6_hdr_t *ipv6_hdr,
         gnrc_pktbuf_release(pkt);
         return;
     }
-
-    if (netif != NULL) {
-        gnrc_netif_hdr_set_netif(hdr->data, netif);
-    }
-    else {
-        /* ipv6_hdr->dst is loopback address */
-        ((gnrc_netif_hdr_t *)hdr->data)->if_pid = KERNEL_PID_UNDEF;
-    }
+    /* (netif == NULL) => ipv6_hdr->dst is loopback address */
+    gnrc_netif_hdr_set_netif(hdr->data, netif);
 
     LL_PREPEND(pkt, hdr);
 

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
@@ -189,7 +189,6 @@ void gnrc_rpl_send(gnrc_pktsnip_t *pkt, kernel_pid_t iface, ipv6_addr_t *src, ip
             gnrc_pktbuf_release(pkt);
             return;
         }
-        iface = netif->pid;
     }
     else {
         netif = gnrc_netif_get_by_pid(iface);
@@ -225,7 +224,7 @@ void gnrc_rpl_send(gnrc_pktsnip_t *pkt, kernel_pid_t iface, ipv6_addr_t *src, ip
         gnrc_pktbuf_release(pkt);
         return;
     }
-    ((gnrc_netif_hdr_t *)hdr->data)->if_pid = iface;
+    gnrc_netif_hdr_set_netif(hdr->data, netif);
     LL_PREPEND(pkt, hdr);
 
     if (!gnrc_netapi_dispatch_send(GNRC_NETTYPE_IPV6, GNRC_NETREG_DEMUX_CTX_ALL, pkt)) {

--- a/tests/gnrc_ipv6_fwd_w_sub/main.c
+++ b/tests/gnrc_ipv6_fwd_w_sub/main.c
@@ -131,12 +131,10 @@ static gnrc_pktsnip_t *_build_recvd_pkt(void)
 {
     gnrc_pktsnip_t *netif;
     gnrc_pktsnip_t *pkt;
-    gnrc_netif_hdr_t *netif_hdr;
 
     netif = gnrc_netif_hdr_build(NULL, 0, NULL, 0);
     assert(netif);
-    netif_hdr = netif->data;
-    netif_hdr->if_pid = _mock_netif->pid;
+    gnrc_netif_hdr_set_netif(netif->data, _mock_netif);
     pkt = gnrc_pktbuf_add(netif, _l2_payload, sizeof(_l2_payload),
                           GNRC_NETTYPE_IPV6);
     assert(pkt);

--- a/tests/gnrc_sixlowpan/main.c
+++ b/tests/gnrc_sixlowpan/main.c
@@ -141,7 +141,7 @@ static void _send_packet(void)
 
     gnrc_netif_hdr_init(&(netif_hdr.netif_hdr), 8, 8);
 
-    netif_hdr.netif_hdr.if_pid = netif->pid;
+    gnrc_netif_hdr_set_netif(&netif_hdr.netif_hdr, netif);
 
     uint8_t data1[] = {
         /* 6LoWPAN Header */

--- a/tests/gnrc_udp/udp.c
+++ b/tests/gnrc_udp/udp.c
@@ -82,6 +82,7 @@ static void *_eventloop(void *arg)
 static void send(char *addr_str, char *port_str, char *data_len_str, unsigned int num,
                  unsigned int delay)
 {
+    gnrc_netif_t *netif;
     int iface;
     char *conversion_end;
     uint16_t port;
@@ -91,7 +92,10 @@ static void send(char *addr_str, char *port_str, char *data_len_str, unsigned in
     /* get interface, if available */
     iface = ipv6_addr_split_iface(addr_str);
     if ((iface < 0) && (gnrc_netif_numof() == 1)) {
-        iface = gnrc_netif_iter(NULL)->pid;
+        netif = gnrc_netif_iter(NULL);
+    }
+    else {
+        netif = gnrc_netif_get_by_pid(iface);
     }
     /* parse destination address */
     if (ipv6_addr_from_str(&addr, addr_str) == NULL) {
@@ -135,16 +139,16 @@ static void send(char *addr_str, char *port_str, char *data_len_str, unsigned in
             return;
         }
         /* add netif header, if interface was given */
-        if (iface > 0) {
-            gnrc_pktsnip_t *netif = gnrc_netif_hdr_build(NULL, 0, NULL, 0);
+        if (netif != NULL) {
+            gnrc_pktsnip_t *netif_hdr = gnrc_netif_hdr_build(NULL, 0, NULL, 0);
 
             if(netif == NULL) {
                 puts("Error: unable to allocate NETIF header");
                 gnrc_pktbuf_release(ip);
                 return;
             }
-            ((gnrc_netif_hdr_t *)netif->data)->if_pid = (kernel_pid_t)iface;
-            LL_PREPEND(ip, netif);
+            gnrc_netif_hdr_set_netif(netif_hdr->data, netif);
+            LL_PREPEND(ip, netif_hdr);
         }
         /* send packet */
         if (!gnrc_netapi_dispatch_send(GNRC_NETTYPE_UDP, GNRC_NETREG_DEMUX_CTX_ALL, ip)) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This eases the refactoring to a pointer-based approach for network
interfaces.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
The following modules should still work:

- [ ] `nrfmin` (test if `ping6` command still works in `gnrc_networking` e.g. on `nrf51dk`)
- [x] `cc110x` (test if `ping6` command still works in `gnrc_networking` e.g. on `msba2`) 
- [ ] `xbee` (test if `ping6` command still works in `gnrc_networking` e.g. on `arduino-zero` + `xbee` module)
- [ ] `nordic_softdevice_ble` (test if `ping6` command still works in `gnrc_networking` e.g. on `nrf52dk` to a controlling PC)
- [ ] `gnrc_gomac` (test if `ping6` still works in `gnrc_networking_mac` on e.g. `iotlab-m3`)
- [ ] `gnrc_lwmac` (test if reception of `txtsnd` still works in `tests/gnrc_lwmac` on e.g. `iotlab-m3`)
- [x] Ethernet via GNRC (test if `ping6` command still works in `gnrc_networking` e.g. on `native`)
- [x] IEEE 802.15.4 via GNRC (test if `ping6` command still works in `gnrc_networking` e.g. on `samr21-xpro`)
- [x] `gnrc_icmpv6_echo` (comes for free with one of the tests involving the `ping6` command above ;-))
- [ ] `gnrc_ipv6` (comes for free with one of the tests involving IPv6 exchange [e.g. using the `ping6` command] above)
- [ ] `gnrc_ndp` (comes for free with one of the tests involving IPv6 exchange [e.g. using the `ping6` command] above)
- [ ] `gnrc_rpl` (try and see if a DODAG is still build when using `gnrc_networking`)
- [ ] `gnrc_sock` (try and see if the `gcoap` example still works)
- [x] `sc_icmpv6_echo` (comes for free with one of the tests involving the `ping6` command above ;-))

Also retest the applications changed:

- [x] `examples/gnrc_networking` (exchange some UDP packets between two compatible nodes)
- [ ] `examples/gnrc_networking_mac` (exchange some UDP packets between two compatible nodes)
- [ ] `tests/gnrc_ipv6_ext` (just run with `make test`)
- [ ] `tests/gnrc_sixlowpan` (just run with `make test`)
- [ ] `tests/gnrc_udp` (exchange some UDP packets between two compatible nodes)


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Compare #10500 for corresponding getter.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
