### PR TITLE
cpu/esp32: GPIO macro cleanup in periph_cpu.h

### DIFF
--- a/cpu/esp32/include/periph_cpu.h
+++ b/cpu/esp32/include/periph_cpu.h
@@ -47,16 +47,6 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Definition of a fitting UNDEF value
- */
-#define GPIO_UNDEF (0xff)
-
-/**
- * @brief   Define CPU specific GPIO pin generator macro
- */
-#define GPIO_PIN(x, y)  ((x << 4) | y)
-
-/**
  * @brief   Define CPU specific number of GPIO pins
  * @{
  */


### PR DESCRIPTION
### Contribution description

The default macros GPIO_PIN and GPIO_UNDEF do not have to be overridden. The GPIO_PIN macro definition was even wrong for 40 GPIOs without splitting into ports, even if that did not lead to erroneous behavior.

### Testing procedure

Compile and flash `tests/periph_gpio` to an ESP32 board, e.g.,
```
make -C tests/periph_gpio BOARD=esp32-wroom-32 flash test
```