### PR TITLE
 gnrc_sixloenc: introduce pseudo-module to send 6Lo frames over Ethernet

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -154,7 +154,7 @@ ifneq (,$(filter gnrc_netif,$(USEMODULE)))
   endif
 endif
 
-ifneq (,$(filter ieee802154 nrfmin esp_now,$(USEMODULE)))
+ifneq (,$(filter ieee802154 nrfmin esp_now gnrc_sixloenc,$(USEMODULE)))
   ifneq (,$(filter gnrc_ipv6, $(USEMODULE)))
     USEMODULE += gnrc_sixlowpan
   endif

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -25,6 +25,7 @@ PSEUDOMODULES += gnrc_neterr
 PSEUDOMODULES += gnrc_netapi_callbacks
 PSEUDOMODULES += gnrc_netapi_mbox
 PSEUDOMODULES += gnrc_pktbuf_cmd
+PSEUDOMODULES += gnrc_sixloenc
 PSEUDOMODULES += gnrc_sixlowpan_border_router_default
 PSEUDOMODULES += gnrc_sixlowpan_default
 PSEUDOMODULES += gnrc_sixlowpan_iphc_nhc

--- a/sys/include/net/ethertype.h
+++ b/sys/include/net/ethertype.h
@@ -37,6 +37,7 @@ extern "C" {
 #define ETHERTYPE_CCNX          (0x0801)    /**< Parc CCNX */
 #define ETHERTYPE_NDN           (0x8624)    /**< NDN Protocol (http://named-data.net/) */
 #define ETHERTYPE_IPV6          (0x86dd)    /**< Internet protocol version 6 */
+#define ETHERTYPE_6LOENC        (0xa0ed)    /**< 6LoWPAN encapsulation */
 #define ETHERTYPE_UNKNOWN       (0xffff)    /**< Reserved (no protocol specified) */
 
 #ifdef __cplusplus

--- a/sys/include/net/gnrc/nettype.h
+++ b/sys/include/net/gnrc/nettype.h
@@ -159,6 +159,10 @@ static inline gnrc_nettype_t gnrc_nettype_from_ethertype(uint16_t type)
             return GNRC_NETTYPE_NDN;
 #endif
 #endif
+#ifdef MODULE_GNRC_SIXLOENC
+        case ETHERTYPE_6LOENC:
+            return GNRC_NETTYPE_SIXLOWPAN;
+#endif
         default:
             return GNRC_NETTYPE_UNDEF;
     }
@@ -178,6 +182,10 @@ static inline gnrc_nettype_t gnrc_nettype_from_ethertype(uint16_t type)
 static inline uint16_t gnrc_nettype_to_ethertype(gnrc_nettype_t type)
 {
     switch (type) {
+#ifdef MODULE_GNRC_SIXLOENC
+        case GNRC_NETTYPE_SIXLOWPAN:
+            return ETHERTYPE_6LOENC;
+#endif
 #ifdef MODULE_GNRC_IPV6
         case GNRC_NETTYPE_IPV6:
             return ETHERTYPE_IPV6;

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1114,6 +1114,9 @@ static ipv6_addr_t *_src_addr_selection(gnrc_netif_t *netif,
 bool gnrc_netif_is_6ln(const gnrc_netif_t *netif)
 {
     switch (netif->device_type) {
+#ifdef MODULE_GNRC_SIXLOENC
+        case NETDEV_TYPE_ETHERNET:
+#endif
         case NETDEV_TYPE_IEEE802154:
         case NETDEV_TYPE_CC110X:
         case NETDEV_TYPE_BLE:
@@ -1177,7 +1180,9 @@ static void _init_from_device(gnrc_netif_t *netif)
     assert(res == sizeof(tmp));
     netif->device_type = (uint8_t)tmp;
     switch (netif->device_type) {
-#if defined(MODULE_NETDEV_IEEE802154) || defined(MODULE_NRFMIN) || defined(MODULE_XBEE) || defined(MODULE_ESP_NOW)
+#if defined(MODULE_NETDEV_IEEE802154) || defined(MODULE_NRFMIN) || \
+    defined(MODULE_XBEE) || defined(MODULE_ESP_NOW) || \
+    defined(MODULE_GNRC_SIXLOENC)
         case NETDEV_TYPE_IEEE802154:
         case NETDEV_TYPE_NRFMIN:
 #ifdef MODULE_GNRC_SIXLOWPAN_IPHC
@@ -1201,6 +1206,9 @@ static void _init_from_device(gnrc_netif_t *netif)
         case NETDEV_TYPE_ETHERNET:
 #ifdef MODULE_GNRC_IPV6
             netif->ipv6.mtu = ETHERNET_DATA_LEN;
+#endif
+#if defined(MODULE_GNRC_SIXLOWPAN_IPHC) && defined(MODULE_GNRC_SIXLOENC)
+            netif->flags |= GNRC_NETIF_FLAGS_6LO_HC;
 #endif
             break;
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
See title (it implements [RFC 7973](https://tools.ietf.org/html/rfc7973)). Also activates capabilities, once this module is compiled in. I will add a way to configure the 6Lo capabilities of an Ethernet interface dynamically.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
- Compile `gnrc_networking` for `native` with `USEMODULE += gnrc_sixloenc`,
- use `dist/tools/tapsetup/tapsetup` to create two bridged TAP interfaces,
- start a wireshark sniffing the bridge and two native instances, and
- try to ping one of the native instances from the other.

Wireshark should show a 6Lo dispatch within the Ethernet frame (not sure why it is showing "wrong checksum", RIOT is happy with it):

![image](https://user-images.githubusercontent.com/675644/50495091-59511880-0a27-11e9-889a-cb4507c16ffd.png)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Redoing #4861.

Resolves #4857.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
