### PR TITLE
gnrc_netif: make 6LoENC dynamically configurable

### DIFF
--- a/sys/include/net/gnrc/netif/flags.h
+++ b/sys/include/net/gnrc/netif/flags.h
@@ -126,6 +126,16 @@ enum {
 #define GNRC_NETIF_FLAGS_6LN                       (0x00001000U)
 
 /**
+ * @brief   6Lo is activated for this interface
+ *
+ * @note    Most devices supporting 6Lo actually *require* 6Lo so this flag
+ *          should not be configurable for them. As a consequence, this flag
+ *          **must** only be changed by a @ref NETOPT_6LO message to the
+ *          interface.
+ */
+#define GNRC_NETIF_FLAGS_6LO                       (0x00002000U)
+
+/**
  * @brief   Network interface is configured in raw mode
  */
 #define GNRC_NETIF_FLAGS_RAWMODE                   (0x00010000U)

--- a/sys/include/net/gnrc/netif/internal.h
+++ b/sys/include/net/gnrc/netif/internal.h
@@ -337,13 +337,17 @@ static inline bool gnrc_netif_is_rtr_adv(const gnrc_netif_t *netif)
  *              @ref net_gnrc_sixlowpan module is included. When the
  *              @ref net_gnrc_sixlowpan module is not included, it is assumed
  *              to be false.
+ *              Since `gnrc_sixloenc` makes the interface's 6Lo capabilities
+ *              configurable for an Ethernet interface, this does not apply,
+ *              when that module is compiled in.
  *
  * @param[in] netif the network interface
  *
  * @return  true, if the interface represents a 6LN
  * @return  false, if the interface does not represent a 6LN
  */
-#if ((GNRC_NETIF_NUMOF > 1) && defined(MODULE_GNRC_SIXLOWPAN)) || defined(DOXYGEN)
+#if ((GNRC_NETIF_NUMOF > 1) && defined(MODULE_GNRC_SIXLOWPAN)) || \
+    defined(MODULE_GNRC_SIXLOENC) || defined(DOXYGEN)
 bool gnrc_netif_is_6lo(const gnrc_netif_t *netif);
 #elif (GNRC_NETIF_NUMOF == 1) && defined(MODULE_GNRC_SIXLOWPAN)
 #define gnrc_netif_is_6lo(netif)                (true)

--- a/sys/net/gnrc/netif/ethernet/gnrc_netif_ethernet.c
+++ b/sys/net/gnrc/netif/ethernet/gnrc_netif_ethernet.c
@@ -33,6 +33,11 @@
 
 static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt);
 static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif);
+#ifdef MODULE_GNRC_SIXLOENC
+static int _set(gnrc_netif_t *netif, const gnrc_netapi_opt_t *opt);
+#else
+#define _set    gnrc_netif_set_from_netdev
+#endif /* MODULE_GNRC_SIXLOENC */
 
 static char addr_str[ETHERNET_ADDR_LEN * 3];
 
@@ -40,7 +45,7 @@ static const gnrc_netif_ops_t ethernet_ops = {
     .send = _send,
     .recv = _recv,
     .get = gnrc_netif_get_from_netdev,
-    .set = gnrc_netif_set_from_netdev,
+    .set = _set,
 };
 
 gnrc_netif_t *gnrc_netif_ethernet_create(char *stack, int stacksize,
@@ -252,4 +257,22 @@ safe_out:
     return NULL;
 }
 
+#ifdef MODULE_GNRC_SIXLOENC
+static int _set(gnrc_netif_t *netif, const gnrc_netapi_opt_t *opt)
+{
+    if (opt->opt == NETOPT_6LO) {
+        assert(opt->data_len == sizeof(netopt_enable_t));
+        if (*((netopt_enable_t *)opt->data) == NETOPT_ENABLE) {
+            netif->flags |= (GNRC_NETIF_FLAGS_6LO | GNRC_NETIF_FLAGS_6LO_HC |
+                             GNRC_NETIF_FLAGS_6LN);
+        }
+        else {
+            netif->flags &= ~(GNRC_NETIF_FLAGS_6LO | GNRC_NETIF_FLAGS_6LO_HC |
+                              GNRC_NETIF_FLAGS_6LN);
+        }
+        return sizeof(netopt_enable_t);
+    }
+    return gnrc_netif_set_from_netdev(netif, opt);
+}
+#endif /* MODULE_GNRC_SIXLOENC */
 /** @} */

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1142,12 +1142,14 @@ static ipv6_addr_t *_src_addr_selection(gnrc_netif_t *netif,
 }
 #endif  /* MODULE_GNRC_IPV6 */
 
-#if (GNRC_NETIF_NUMOF > 1) && defined(MODULE_GNRC_SIXLOWPAN)
+#if ((GNRC_NETIF_NUMOF > 1) && defined(MODULE_GNRC_SIXLOWPAN)) || \
+    defined(MODULE_GNRC_SIXLOENC)
 bool gnrc_netif_is_6lo(const gnrc_netif_t *netif)
 {
     switch (netif->device_type) {
 #ifdef MODULE_GNRC_SIXLOENC
         case NETDEV_TYPE_ETHERNET:
+            return (netif->flags & GNRC_NETIF_FLAGS_6LO);
 #endif
         case NETDEV_TYPE_IEEE802154:
         case NETDEV_TYPE_CC110X:
@@ -1159,7 +1161,8 @@ bool gnrc_netif_is_6lo(const gnrc_netif_t *netif)
             return false;
     }
 }
-#endif  /* (GNRC_NETIF_NUMOF > 1) && defined(MODULE_GNRC_SIXLOWPAN) */
+#endif  /* ((GNRC_NETIF_NUMOF > 1) && defined(MODULE_GNRC_SIXLOWPAN)) || \
+         * defined(MODULE_GNRC_SIXLOENC)*/
 
 static void _update_l2addr_from_dev(gnrc_netif_t *netif)
 {

--- a/sys/net/gnrc/netif/gnrc_netif_device_type.c
+++ b/sys/net/gnrc/netif/gnrc_netif_device_type.c
@@ -149,8 +149,11 @@ void gnrc_netif_ipv6_init_mtu(gnrc_netif_t *netif)
 #ifdef MODULE_GNRC_IPV6
             netif->ipv6.mtu = ETHERNET_DATA_LEN;
 #endif
-#if defined(MODULE_GNRC_SIXLOWPAN_IPHC) && defined(MODULE_GNRC_SIXLOENC)
+#ifdef MODULE_GNRC_SIXLOENC
+            netif->flags |= GNRC_NETIF_FLAGS_6LO;
+#ifdef MODULE_GNRC_SIXLOWPAN_IPHC
             netif->flags |= GNRC_NETIF_FLAGS_6LO_HC;
+#endif
 #endif
             break;
 #endif

--- a/sys/shell/commands/sc_gnrc_netif.c
+++ b/sys/shell/commands/sc_gnrc_netif.c
@@ -53,6 +53,7 @@ static const struct {
     char *name;
     netopt_t opt;
 } flag_cmds[] = {
+    { "6lo", NETOPT_6LO },
     { "ack_req", NETOPT_ACK_REQ },
     { "autoack", NETOPT_AUTOACK },
     { "autocca", NETOPT_AUTOCCA },


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Reworks `gnrc_netif` so that for "devices" like 6LoEnc where 6Lo-behaviour is configurable, it is
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Repeat testing procedures for #10665. They should still work. Now set `ifconfig 7 -6lo` on both nodes. The nodes should now exchange normal Ethernet frames. Also try what happens if you activate `6lo` again.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Depends on ~~#10499~~ (merged), ~~#10665~~ (merged), and ~~#10666~~ (merged).
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
