### PR TITLE
net/nanocoap: fix confirmable retry countdown

### DIFF
--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -52,7 +52,7 @@ ssize_t nanocoap_request(coap_pkt_t *pkt, sock_udp_ep_t *local, sock_udp_ep_t *r
 
         res = sock_udp_send(&sock, buf, pdu_len, NULL);
         if (res <= 0) {
-            DEBUG("nanocoap: error sending coap request\n");
+            DEBUG("nanocoap: error sending coap request, %d\n", (int)res);
             break;
         }
 
@@ -68,7 +68,7 @@ ssize_t nanocoap_request(coap_pkt_t *pkt, sock_udp_ep_t *local, sock_udp_ep_t *r
                 }
                 continue;
             }
-            DEBUG("nanocoap: error receiving coap request\n");
+            DEBUG("nanocoap: error receiving coap response, %d\n", (int)res);
             break;
         }
         else {

--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -46,19 +46,14 @@ ssize_t nanocoap_request(coap_pkt_t *pkt, sock_udp_ep_t *local, sock_udp_ep_t *r
 
     /* TODO: timeout random between between ACK_TIMEOUT and (ACK_TIMEOUT *
      * ACK_RANDOM_FACTOR) */
-    uint32_t timeout = COAP_ACK_TIMEOUT * (1000000U);
-    int tries = 0;
-    while (tries++ < COAP_MAX_RETRANSMIT) {
-        if (!tries) {
-            DEBUG("nanocoap: maximum retries reached.\n");
-            res = -ETIMEDOUT;
-            goto out;
-        }
+    uint32_t timeout = COAP_ACK_TIMEOUT * US_PER_SEC;
+    unsigned tries_left = COAP_MAX_RETRANSMIT + 1;  /* add 1 for initial transmit */
+    while (tries_left) {
 
         res = sock_udp_send(&sock, buf, pdu_len, NULL);
         if (res <= 0) {
             DEBUG("nanocoap: error sending coap request\n");
-            goto out;
+            break;
         }
 
         res = sock_udp_recv(&sock, buf, len, timeout, NULL);
@@ -67,6 +62,10 @@ ssize_t nanocoap_request(coap_pkt_t *pkt, sock_udp_ep_t *local, sock_udp_ep_t *r
                 DEBUG("nanocoap: timeout\n");
 
                 timeout *= 2;
+                tries_left--;
+                if (!tries_left) {
+                    DEBUG("nanocoap: maximum retries reached\n");
+                }
                 continue;
             }
             DEBUG("nanocoap: error receiving coap request\n");
@@ -81,7 +80,6 @@ ssize_t nanocoap_request(coap_pkt_t *pkt, sock_udp_ep_t *local, sock_udp_ep_t *r
         }
     }
 
-out:
     sock_udp_close(&sock);
 
     return res;

--- a/tests/nanocoap_cli/nanocli_server.c
+++ b/tests/nanocoap_cli/nanocli_server.c
@@ -27,38 +27,104 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-static void _start_server(uint16_t port)
+/*
+ * Customized implementation of nanocoap_server() to ignore a count of
+ * requests. Allows testing confirmable messaging.
+ */
+static int _nanocoap_server(sock_udp_ep_t *local, uint8_t *buf, size_t bufsize,
+                            int ignore_count)
+{
+    sock_udp_t sock;
+    sock_udp_ep_t remote;
+
+    if (!local->port) {
+        local->port = COAP_PORT;
+    }
+
+    ssize_t res = sock_udp_create(&sock, local, NULL, 0);
+    if (res == -1) {
+        return -1;
+    }
+
+    int recv_count = 0;
+    while (1) {
+        res = sock_udp_recv(&sock, buf, bufsize, -1, &remote);
+        if (++recv_count <= ignore_count) {
+            DEBUG("ignoring request\n");
+            continue;
+        }
+        if (res == -1) {
+            DEBUG("nanocoap: error receiving coap request, \n");
+            return -1;
+        }
+        else {
+            coap_pkt_t pkt;
+            if (coap_parse(&pkt, (uint8_t *)buf, res) < 0) {
+                DEBUG("nanocoap: error parsing packet\n");
+                continue;
+            }
+            if ((res = coap_handle_req(&pkt, buf, bufsize)) > 0) {
+                res = sock_udp_send(&sock, buf, res, &remote);
+            }
+        }
+    }
+
+    return 0;
+}
+
+static void _start_server(uint16_t port, int ignore_count)
 {
     uint8_t buf[128];
     sock_udp_ep_t local = { .port=port, .family=AF_INET6 };
-    nanocoap_server(&local, buf, sizeof(buf));
+    _nanocoap_server(&local, buf, sizeof(buf), ignore_count);
 }
 
 int nanotest_server_cmd(int argc, char **argv)
 {
-    uint16_t port = COAP_PORT;
-    if (argc >= 2) {
-        if (strncmp("start", argv[1], 5) != 0) {
-            goto end;
-        }
-
-        if (argc == 3) {
-            port = atoi(argv[2]);
-            if (port == 0) {
-                puts("nanocli: unable to parse port");
-                return 1;
-            }
-        }
-
-        puts("starting server\n");
-        _start_server(port);
-
-        /* server executes run loop; never reaches this point*/
-        return 0;
+    if (argc < 2) {
+        goto error;
     }
 
-    end:
-    printf("usage: %s start [port]\n", argv[0]);
-    printf("       Port defaults to %u\n", COAP_PORT);
+    if (strncmp("start", argv[1], 5) != 0) {
+        goto error;
+    }
+
+    int arg_pos = 2;
+    int ignore_count = 0;
+    if ((argc >= (arg_pos+1)) && (strcmp(argv[arg_pos], "-i") == 0)) {
+        /* need count of requests to ignore*/
+        if (argc == 3) {
+            goto error;
+        }
+        arg_pos++;
+
+        ignore_count = atoi(argv[arg_pos]);
+        if (ignore_count <= 0) {
+            puts("nanocli: unable to parse ignore_count");
+            goto error;
+        }
+        arg_pos++;
+    }
+
+    uint16_t port = COAP_PORT;
+    if (argc == (arg_pos+1)) {
+        port = atoi(argv[arg_pos]);
+        if (port == 0) {
+            puts("nanocli: unable to parse port");
+            goto error;
+        }
+    }
+
+    printf("starting server on port %u\n", port);
+    _start_server(port, ignore_count);
+
+    /* server executes run loop; never reaches this point*/
+    return 0;
+
+    error:
+    printf("usage: %s start [-i ignore_count] [port]\n", argv[0]);
+    printf("Options\n");
+    printf("    -i  ignore a number of requests\n");
+    printf("  port  defaults to %u\n", COAP_PORT);
     return 1;
 }


### PR DESCRIPTION
### Contribution description
The nanocoap sock module includes a `nanocoap_request()` function, which sends the request confirmably. As described in #9191, the function does not perform the expected count of retries when a send fails. This PR fixes the problem with a rework of the countdown logic.

### Testing procedure
This PR extends the `nanocoap_cli` test in #10640 with a server that provides an option (-i) to ignore a count of requests. So, you can setup a tap bridge with both endpoints running this test. One of them runs as a server and the other as a client.

Try setting up the server to ignore 4 requests. The client will timeout on the RIOT master branch, but this PR should succeed on the final retry. When the server is set up to ignore 5 requests, the client should timeout on this PR, as expected. I created an unofficial [automated test](https://github.com/kb2ma/riot-coap-pytest/commits/nanocoap_retries) that uses a similar approach.

### Issues/PRs references
Fixes #9191. Depends on #10640.