### PR TITLE
net/coap: allow user to configure message retry macros

### DIFF
--- a/sys/include/net/coap.h
+++ b/sys/include/net/coap.h
@@ -164,6 +164,9 @@ extern "C" {
  */
 /**
  * @name    Timing parameters
+ *
+ * These parameters are defined as configurable in [RFC 7252, section 4.8.1]
+ * (https://tools.ietf.org/html/rfc7252#section-4.8.1).
  * @{
  */
 /**
@@ -192,6 +195,8 @@ extern "C" {
  *
  * Like @ref COAP_ACK_TIMEOUT, this value is valid for the initial confirmable
  * message, and doubles for subsequent retries.
+ *
+ * This parameter is nanocoap-specific, and is not defined in RFC 7252.
  */
 #ifndef COAP_ACK_VARIANCE
 #define COAP_ACK_VARIANCE       (1U)

--- a/sys/include/net/coap.h
+++ b/sys/include/net/coap.h
@@ -157,20 +157,52 @@ extern "C" {
 /** @} */
 
 /**
- * @name    Timing parameters
+ * @defgroup net_coap_conf    CoAP compile configurations
+ * @ingroup  net_coap
+ * @ingroup  config
  * @{
  */
-#define COAP_ACK_TIMEOUT        (2U)
-#define COAP_RANDOM_FACTOR      (1.5)
 /**
- * @brief   Maximum variation for confirmable timeout.
+ * @brief    Timeout in seconds for a response to a confirmable request
+ *
+ * This value is for the response to the *initial* confirmable message. The
+ * timeout doubles for subsequent retries. To avoid synchronization of resends
+ * across hosts, the actual timeout is chosen randomly between
+ * @ref COAP_ACK_TIMEOUT and (@ref COAP_ACK_TIMEOUT * @ref COAP_RANDOM_FACTOR).
+ */
+#ifndef COAP_ACK_TIMEOUT
+#define COAP_ACK_TIMEOUT        (2U)
+#endif
+
+/** @brief   Used to calculate upper bound for timeout; see @ref COAP_ACK_TIMEOUT */
+#ifndef COAP_RANDOM_FACTOR
+#define COAP_RANDOM_FACTOR      (1.5)
+#endif
+
+/**
+ * @brief   Approximation for maximum variation for confirmable timeout
  *
  * Must be an integer, defined as:
  *
  *     (COAP_ACK_TIMEOUT * COAP_RANDOM_FACTOR) - COAP_ACK_TIMEOUT
+ *
+ * Like @ref COAP_ACK_TIMEOUT, this value is valid for the initial confirmable
+ * message, and doubles for subsequent retries.
  */
+#ifndef COAP_ACK_VARIANCE
 #define COAP_ACK_VARIANCE       (1U)
+#endif
+
+/** @brief   Maximum number of retransmissions for a confirmable request */
+#ifndef COAP_MAX_RETRANSMIT
 #define COAP_MAX_RETRANSMIT     (4)
+#endif
+/** @} */
+
+/**
+ * @name    Timing parameters
+ * @{
+ */
 #define COAP_NSTART             (1)
 #define COAP_DEFAULT_LEISURE    (5)
 /** @} */

--- a/sys/include/net/coap.h
+++ b/sys/include/net/coap.h
@@ -163,6 +163,10 @@ extern "C" {
  * @{
  */
 /**
+ * @name    Timing parameters
+ * @{
+ */
+/**
  * @brief    Timeout in seconds for a response to a confirmable request
  *
  * This value is for the response to the *initial* confirmable message. The
@@ -198,9 +202,10 @@ extern "C" {
 #define COAP_MAX_RETRANSMIT     (4)
 #endif
 /** @} */
+/** @} */
 
 /**
- * @name    Timing parameters
+ * @name    Fixed timing parameters
  * @{
  */
 #define COAP_NSTART             (1)


### PR DESCRIPTION
### Contribution description
Allows the user to externally specify a value for several macros used for CoAP confirmable messaging. Also adds a documentation group for these user configurable macros, per #10566. 

Most of these macros are defined in RFC 7252, but I also added documentation here to make their purpose clear.

### Testing procedure
Compile the documentation. You should see:

- a new configuration group titled, "CoAP compile configurations"
- a new module within "CoAP defines", also titled "CoAP compile configurations"

### Issues/PRs references
Partially implements #10566 