### PR TITLE
pkg: gecko_sdk: bump version + vendor headers

### DIFF
--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg990f1024.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg990f1024.h
@@ -1,35 +1,34 @@
-/**************************************************************************//**
- * @file efm32gg990f1024.h
+/***************************************************************************//**
+ * @file
  * @brief CMSIS Cortex-M Peripheral Access Layer Header File
  *        for EFM32GG990F1024
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #if defined(__ICCARM__)
 #pragma system_include       /* Treat file as system include file. */
@@ -44,15 +43,15 @@
 extern "C" {
 #endif
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup Parts
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32GG990F1024 EFM32GG990F1024
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /** Interrupt Number Definition */
 typedef enum IRQn{
@@ -109,22 +108,22 @@ typedef enum IRQn{
   EMU_IRQn              = 38, /*!< 38 EFM32 EMU Interrupt */
 } IRQn_Type;
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32GG990F1024_Core EFM32GG990F1024 Core
  * @{
  * @brief Processor and Core Peripheral Section
- *****************************************************************************/
-#define __MPU_PRESENT             1 /**< Presence of MPU  */
-#define __VTOR_PRESENT            1 /**< Presence of VTOR register in SCB */
-#define __NVIC_PRIO_BITS          3 /**< NVIC interrupt priority bits */
-#define __Vendor_SysTickConfig    0 /**< Is 1 if different SysTick counter is used */
+ ******************************************************************************/
+#define __MPU_PRESENT             1U /**< Presence of MPU  */
+#define __VTOR_PRESENT            1U /**< Presence of VTOR register in SCB */
+#define __NVIC_PRIO_BITS          3U /**< NVIC interrupt priority bits */
+#define __Vendor_SysTickConfig    0U /**< Is 1 if different SysTick counter is used */
 
 /** @} End of group EFM32GG990F1024_Core */
 
-/**************************************************************************//**
-* @defgroup EFM32GG990F1024_Part EFM32GG990F1024 Part
-* @{
-******************************************************************************/
+/***************************************************************************//**
+ * @defgroup EFM32GG990F1024_Part EFM32GG990F1024 Part
+ * @{
+ ******************************************************************************/
 
 /** Part family */
 #define _EFM32_GIANT_FAMILY                     1  /**< Giant/Leopard Gecko EFM32LG/GG MCU Family */
@@ -188,7 +187,7 @@ typedef enum IRQn{
 #define FLASH_PAGE_SIZE      4096U          /**< Flash Memory page size */
 #define SRAM_BASE            (0x20000000UL) /**< SRAM Base Address */
 #define SRAM_SIZE            (0x00020000UL) /**< Available SRAM Memory */
-#define __CM3_REV            0x201          /**< Cortex-M3 Core revision r2p1 */
+#define __CM3_REV            0x0201U        /**< Cortex-M3 Core revision r2p1 */
 #define PRS_CHAN_COUNT       12             /**< Number of PRS channels */
 #define DMA_CHAN_COUNT       12             /**< Number of DMA channels */
 #define EXT_IRQ_COUNT        39             /**< Number of External (NVIC) interrupts */
@@ -279,11 +278,11 @@ typedef enum IRQn{
 
 /** @} End of group EFM32GG990F1024_Part */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32GG990F1024_Peripheral_TypeDefs EFM32GG990F1024 Peripheral TypeDefs
  * @{
  * @brief Device Specific Peripheral Register Structures
- *****************************************************************************/
+ ******************************************************************************/
 
 #include "efm32gg_dma_ch.h"
 #include "efm32gg_dma.h"
@@ -329,10 +328,10 @@ typedef enum IRQn{
 
 /** @} End of group EFM32GG990F1024_Peripheral_TypeDefs */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32GG990F1024_Peripheral_Base EFM32GG990F1024 Peripheral Memory Map
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 #define DMA_BASE          (0x400C2000UL) /**< DMA base address  */
 #define AES_BASE          (0x400E0000UL) /**< AES base address  */
@@ -380,10 +379,10 @@ typedef enum IRQn{
 
 /** @} End of group EFM32GG990F1024_Peripheral_Base */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32GG990F1024_Peripheral_Declaration  EFM32GG990F1024 Peripheral Declarations
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 #define DMA          ((DMA_TypeDef *) DMA_BASE)             /**< DMA base pointer */
 #define AES          ((AES_TypeDef *) AES_BASE)             /**< AES base pointer */
@@ -429,20 +428,20 @@ typedef enum IRQn{
 
 /** @} End of group EFM32GG990F1024_Peripheral_Declaration */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32GG990F1024_BitFields EFM32GG990F1024 Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 #include "efm32gg_prs_signals.h"
 #include "efm32gg_dmareq.h"
 #include "efm32gg_dmactrl.h"
 #include "efm32gg_uart.h"
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32GG990F1024_UNLOCK EFM32GG990F1024 Unlock Codes
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 #define MSC_UNLOCK_CODE      0x1B71 /**< MSC unlock code */
 #define EMU_UNLOCK_CODE      0xADE8 /**< EMU unlock code */
 #define CMU_UNLOCK_CODE      0x580E /**< CMU unlock code */
@@ -454,17 +453,17 @@ typedef enum IRQn{
 
 /** @} End of group EFM32GG990F1024_BitFields */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32GG990F1024_Alternate_Function EFM32GG990F1024 Alternate Function
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 #include "efm32gg_af_ports.h"
 #include "efm32gg_af_pins.h"
 
 /** @} End of group EFM32GG990F1024_Alternate_Function */
 
-/**************************************************************************//**
+/***************************************************************************//**
  *  @brief Set the value of a bit field within a register.
  *
  *  @param REG
@@ -476,7 +475,7 @@ typedef enum IRQn{
  *  @param OFFSET
  *       The number of bits that the field is offset within the register.
  *       0 (zero) means LSB.
- *****************************************************************************/
+ ******************************************************************************/
 #define SET_BIT_FIELD(REG, MASK, VALUE, OFFSET) \
   REG = ((REG) &~(MASK)) | (((VALUE) << (OFFSET)) & (MASK));
 

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_acmp.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_acmp.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32gg_acmp.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32GG_ACMP register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32GG_ACMP
  * @{
  * @brief EFM32GG_ACMP Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t CTRL;     /**< Control Register  */
   __IOM uint32_t INPUTSEL; /**< Input Selection Register  */
@@ -61,10 +60,10 @@ typedef struct {
   __IOM uint32_t ROUTE;    /**< I/O Routing Register  */
 } ACMP_TypeDef;            /**< ACMP Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32GG_ACMP_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for ACMP CTRL */
 #define _ACMP_CTRL_RESETVALUE              0x47000000UL                         /**< Default value for ACMP_CTRL */

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_adc.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_adc.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32gg_adc.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32GG_ADC register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,39 +40,39 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32GG_ADC
  * @{
  * @brief EFM32GG_ADC Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IOM uint32_t CTRL;         /**< Control Register  */
-  __IOM uint32_t CMD;          /**< Command Register  */
-  __IM uint32_t  STATUS;       /**< Status Register  */
-  __IOM uint32_t SINGLECTRL;   /**< Single Sample Control Register  */
-  __IOM uint32_t SCANCTRL;     /**< Scan Control Register  */
-  __IOM uint32_t IEN;          /**< Interrupt Enable Register  */
-  __IM uint32_t  IF;           /**< Interrupt Flag Register  */
-  __IOM uint32_t IFS;          /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;          /**< Interrupt Flag Clear Register  */
-  __IM uint32_t  SINGLEDATA;   /**< Single Conversion Result Data  */
-  __IM uint32_t  SCANDATA;     /**< Scan Conversion Result Data  */
-  __IM uint32_t  SINGLEDATAP;  /**< Single Conversion Result Data Peek Register  */
-  __IM uint32_t  SCANDATAP;    /**< Scan Sequence Result Data Peek Register  */
-  __IOM uint32_t CAL;          /**< Calibration Register  */
+  __IOM uint32_t CTRL;          /**< Control Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IOM uint32_t SINGLECTRL;    /**< Single Sample Control Register  */
+  __IOM uint32_t SCANCTRL;      /**< Scan Control Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IM uint32_t  SINGLEDATA;    /**< Single Conversion Result Data  */
+  __IM uint32_t  SCANDATA;      /**< Scan Conversion Result Data  */
+  __IM uint32_t  SINGLEDATAP;   /**< Single Conversion Result Data Peek Register  */
+  __IM uint32_t  SCANDATAP;     /**< Scan Sequence Result Data Peek Register  */
+  __IOM uint32_t CAL;           /**< Calibration Register  */
 
-  uint32_t       RESERVED0[1]; /**< Reserved for future use **/
-  __IOM uint32_t BIASPROG;     /**< Bias Programming Register  */
-} ADC_TypeDef;                 /**< ADC Register Declaration *//** @} */
+  uint32_t       RESERVED0[1U]; /**< Reserved for future use **/
+  __IOM uint32_t BIASPROG;      /**< Bias Programming Register  */
+} ADC_TypeDef;                  /**< ADC Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32GG_ADC_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for ADC CTRL */
 #define _ADC_CTRL_RESETVALUE                    0x001F0000UL                                /**< Default value for ADC_CTRL */

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_aes.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_aes.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32gg_aes.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32GG_AES register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,40 +40,40 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32GG_AES
  * @{
  * @brief EFM32GG_AES Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IOM uint32_t CTRL;         /**< Control Register  */
-  __IOM uint32_t CMD;          /**< Command Register  */
-  __IM uint32_t  STATUS;       /**< Status Register  */
-  __IOM uint32_t IEN;          /**< Interrupt Enable Register  */
-  __IM uint32_t  IF;           /**< Interrupt Flag Register  */
-  __IOM uint32_t IFS;          /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;          /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t DATA;         /**< DATA Register  */
-  __IOM uint32_t XORDATA;      /**< XORDATA Register  */
-  uint32_t       RESERVED0[3]; /**< Reserved for future use **/
-  __IOM uint32_t KEYLA;        /**< KEY Low Register  */
-  __IOM uint32_t KEYLB;        /**< KEY Low Register  */
-  __IOM uint32_t KEYLC;        /**< KEY Low Register  */
-  __IOM uint32_t KEYLD;        /**< KEY Low Register  */
-  __IOM uint32_t KEYHA;        /**< KEY High Register  */
-  __IOM uint32_t KEYHB;        /**< KEY High Register  */
-  __IOM uint32_t KEYHC;        /**< KEY High Register  */
-  __IOM uint32_t KEYHD;        /**< KEY High Register  */
-} AES_TypeDef;                 /**< AES Register Declaration *//** @} */
+  __IOM uint32_t CTRL;          /**< Control Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t DATA;          /**< DATA Register  */
+  __IOM uint32_t XORDATA;       /**< XORDATA Register  */
+  uint32_t       RESERVED0[3U]; /**< Reserved for future use **/
+  __IOM uint32_t KEYLA;         /**< KEY Low Register  */
+  __IOM uint32_t KEYLB;         /**< KEY Low Register  */
+  __IOM uint32_t KEYLC;         /**< KEY Low Register  */
+  __IOM uint32_t KEYLD;         /**< KEY Low Register  */
+  __IOM uint32_t KEYHA;         /**< KEY High Register  */
+  __IOM uint32_t KEYHB;         /**< KEY High Register  */
+  __IOM uint32_t KEYHC;         /**< KEY High Register  */
+  __IOM uint32_t KEYHD;         /**< KEY High Register  */
+} AES_TypeDef;                  /**< AES Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32GG_AES_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for AES CTRL */
 #define _AES_CTRL_RESETVALUE            0x00000000UL                       /**< Default value for AES_CTRL */

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_af_pins.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_af_pins.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32gg_af_pins.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32GG_AF_PINS register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,14 +40,14 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32GG_AF_Pins
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 #define AF_USB_VBUSEN_PIN(i)        ((i) == 0 ? 5 :  -1)                                                                                             /**< Pin number for AF_USB_VBUSEN location number i */
 #define AF_USB_DMPU_PIN(i)          ((i) == 0 ? 2 :  -1)                                                                                             /**< Pin number for AF_USB_DMPU location number i */

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_af_ports.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_af_ports.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32gg_af_ports.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32GG_AF_PORTS register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,14 +40,14 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32GG_AF_Ports
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 #define AF_USB_VBUSEN_PORT(i)        ((i) == 0 ? 5 :  -1)                                                                                           /**< Port number for AF_USB_VBUSEN location number i */
 #define AF_USB_DMPU_PORT(i)          ((i) == 0 ? 3 :  -1)                                                                                           /**< Port number for AF_USB_DMPU location number i */

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_burtc.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_burtc.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32gg_burtc.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32GG_BURTC register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,42 +40,42 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32GG_BURTC
  * @{
  * @brief EFM32GG_BURTC Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IOM uint32_t    CTRL;          /**< Control Register  */
-  __IOM uint32_t    LPMODE;        /**< Low power mode configuration  */
-  __IM uint32_t     CNT;           /**< Counter Value Register  */
-  __IOM uint32_t    COMP0;         /**< Counter Compare Value  */
-  __IM uint32_t     TIMESTAMP;     /**< Backup mode timestamp  */
-  __IOM uint32_t    LFXOFDET;      /**< LFXO   */
-  __IM uint32_t     STATUS;        /**< Status Register  */
-  __IOM uint32_t    CMD;           /**< Command Register  */
-  __IOM uint32_t    POWERDOWN;     /**< Retention RAM power-down Register  */
-  __IOM uint32_t    LOCK;          /**< Configuration Lock Register  */
-  __IM uint32_t     IF;            /**< Interrupt Flag Register  */
-  __IOM uint32_t    IFS;           /**< Interrupt Flag Set Register  */
-  __IOM uint32_t    IFC;           /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t    IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t    CTRL;           /**< Control Register  */
+  __IOM uint32_t    LPMODE;         /**< Low power mode configuration  */
+  __IM uint32_t     CNT;            /**< Counter Value Register  */
+  __IOM uint32_t    COMP0;          /**< Counter Compare Value  */
+  __IM uint32_t     TIMESTAMP;      /**< Backup mode timestamp  */
+  __IOM uint32_t    LFXOFDET;       /**< LFXO   */
+  __IM uint32_t     STATUS;         /**< Status Register  */
+  __IOM uint32_t    CMD;            /**< Command Register  */
+  __IOM uint32_t    POWERDOWN;      /**< Retention RAM power-down Register  */
+  __IOM uint32_t    LOCK;           /**< Configuration Lock Register  */
+  __IM uint32_t     IF;             /**< Interrupt Flag Register  */
+  __IOM uint32_t    IFS;            /**< Interrupt Flag Set Register  */
+  __IOM uint32_t    IFC;            /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t    IEN;            /**< Interrupt Enable Register  */
 
-  __IOM uint32_t    FREEZE;        /**< Freeze Register  */
-  __IM uint32_t     SYNCBUSY;      /**< Synchronization Busy Register  */
+  __IOM uint32_t    FREEZE;         /**< Freeze Register  */
+  __IM uint32_t     SYNCBUSY;       /**< Synchronization Busy Register  */
 
-  uint32_t          RESERVED0[48]; /**< Reserved registers */
-  BURTC_RET_TypeDef RET[128];      /**< RetentionReg */
-} BURTC_TypeDef;                   /**< BURTC Register Declaration *//** @} */
+  uint32_t          RESERVED0[48U]; /**< Reserved registers */
+  BURTC_RET_TypeDef RET[128U];      /**< RetentionReg */
+} BURTC_TypeDef;                    /**< BURTC Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32GG_BURTC_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for BURTC CTRL */
 #define _BURTC_CTRL_RESETVALUE                0x00000008UL                           /**< Default value for BURTC_CTRL */

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_burtc_ret.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_burtc_ret.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32gg_burtc_ret.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32GG_BURTC_RET register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,13 +40,13 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief BURTC_RET EFM32GG BURTC RET
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t REG; /**< Retention Register  */
 } BURTC_RET_TypeDef;

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_calibrate.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_calibrate.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32gg_calibrate.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32GG_CALIBRATE register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,14 +40,14 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32GG_CALIBRATE
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 #define CALIBRATE_MAX_REGISTERS    50 /**< Max number of address/value pairs for calibration */
 
 typedef struct {

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_cmu.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_cmu.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32gg_cmu.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32GG_CMU register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,56 +40,56 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32GG_CMU
  * @{
  * @brief EFM32GG_CMU Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IOM uint32_t CTRL;         /**< CMU Control Register  */
-  __IOM uint32_t HFCORECLKDIV; /**< High Frequency Core Clock Division Register  */
-  __IOM uint32_t HFPERCLKDIV;  /**< High Frequency Peripheral Clock Division Register  */
-  __IOM uint32_t HFRCOCTRL;    /**< HFRCO Control Register  */
-  __IOM uint32_t LFRCOCTRL;    /**< LFRCO Control Register  */
-  __IOM uint32_t AUXHFRCOCTRL; /**< AUXHFRCO Control Register  */
-  __IOM uint32_t CALCTRL;      /**< Calibration Control Register  */
-  __IOM uint32_t CALCNT;       /**< Calibration Counter Register  */
-  __IOM uint32_t OSCENCMD;     /**< Oscillator Enable/Disable Command Register  */
-  __IOM uint32_t CMD;          /**< Command Register  */
-  __IOM uint32_t LFCLKSEL;     /**< Low Frequency Clock Select Register  */
-  __IM uint32_t  STATUS;       /**< Status Register  */
-  __IM uint32_t  IF;           /**< Interrupt Flag Register  */
-  __IOM uint32_t IFS;          /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;          /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t IEN;          /**< Interrupt Enable Register  */
-  __IOM uint32_t HFCORECLKEN0; /**< High Frequency Core Clock Enable Register 0  */
-  __IOM uint32_t HFPERCLKEN0;  /**< High Frequency Peripheral Clock Enable Register 0  */
-  uint32_t       RESERVED0[2]; /**< Reserved for future use **/
-  __IM uint32_t  SYNCBUSY;     /**< Synchronization Busy Register  */
-  __IOM uint32_t FREEZE;       /**< Freeze Register  */
-  __IOM uint32_t LFACLKEN0;    /**< Low Frequency A Clock Enable Register 0  (Async Reg)  */
-  uint32_t       RESERVED1[1]; /**< Reserved for future use **/
-  __IOM uint32_t LFBCLKEN0;    /**< Low Frequency B Clock Enable Register 0 (Async Reg)  */
+  __IOM uint32_t CTRL;          /**< CMU Control Register  */
+  __IOM uint32_t HFCORECLKDIV;  /**< High Frequency Core Clock Division Register  */
+  __IOM uint32_t HFPERCLKDIV;   /**< High Frequency Peripheral Clock Division Register  */
+  __IOM uint32_t HFRCOCTRL;     /**< HFRCO Control Register  */
+  __IOM uint32_t LFRCOCTRL;     /**< LFRCO Control Register  */
+  __IOM uint32_t AUXHFRCOCTRL;  /**< AUXHFRCO Control Register  */
+  __IOM uint32_t CALCTRL;       /**< Calibration Control Register  */
+  __IOM uint32_t CALCNT;        /**< Calibration Counter Register  */
+  __IOM uint32_t OSCENCMD;      /**< Oscillator Enable/Disable Command Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IOM uint32_t LFCLKSEL;      /**< Low Frequency Clock Select Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t HFCORECLKEN0;  /**< High Frequency Core Clock Enable Register 0  */
+  __IOM uint32_t HFPERCLKEN0;   /**< High Frequency Peripheral Clock Enable Register 0  */
+  uint32_t       RESERVED0[2U]; /**< Reserved for future use **/
+  __IM uint32_t  SYNCBUSY;      /**< Synchronization Busy Register  */
+  __IOM uint32_t FREEZE;        /**< Freeze Register  */
+  __IOM uint32_t LFACLKEN0;     /**< Low Frequency A Clock Enable Register 0  (Async Reg)  */
+  uint32_t       RESERVED1[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBCLKEN0;     /**< Low Frequency B Clock Enable Register 0 (Async Reg)  */
 
-  uint32_t       RESERVED2[1]; /**< Reserved for future use **/
-  __IOM uint32_t LFAPRESC0;    /**< Low Frequency A Prescaler Register 0 (Async Reg)  */
-  uint32_t       RESERVED3[1]; /**< Reserved for future use **/
-  __IOM uint32_t LFBPRESC0;    /**< Low Frequency B Prescaler Register 0  (Async Reg)  */
-  uint32_t       RESERVED4[1]; /**< Reserved for future use **/
-  __IOM uint32_t PCNTCTRL;     /**< PCNT Control Register  */
-  __IOM uint32_t LCDCTRL;      /**< LCD Control Register  */
-  __IOM uint32_t ROUTE;        /**< I/O Routing Register  */
-  __IOM uint32_t LOCK;         /**< Configuration Lock Register  */
-} CMU_TypeDef;                 /**< CMU Register Declaration *//** @} */
+  uint32_t       RESERVED2[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFAPRESC0;     /**< Low Frequency A Prescaler Register 0 (Async Reg)  */
+  uint32_t       RESERVED3[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBPRESC0;     /**< Low Frequency B Prescaler Register 0  (Async Reg)  */
+  uint32_t       RESERVED4[1U]; /**< Reserved for future use **/
+  __IOM uint32_t PCNTCTRL;      /**< PCNT Control Register  */
+  __IOM uint32_t LCDCTRL;       /**< LCD Control Register  */
+  __IOM uint32_t ROUTE;         /**< I/O Routing Register  */
+  __IOM uint32_t LOCK;          /**< Configuration Lock Register  */
+} CMU_TypeDef;                  /**< CMU Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32GG_CMU_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for CMU CTRL */
 #define _CMU_CTRL_RESETVALUE                        0x000C062CUL                                /**< Default value for CMU_CTRL */

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_dac.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_dac.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32gg_dac.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32GG_DAC register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,41 +40,41 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32GG_DAC
  * @{
  * @brief EFM32GG_DAC Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IOM uint32_t CTRL;         /**< Control Register  */
-  __IM uint32_t  STATUS;       /**< Status Register  */
-  __IOM uint32_t CH0CTRL;      /**< Channel 0 Control Register  */
-  __IOM uint32_t CH1CTRL;      /**< Channel 1 Control Register  */
-  __IOM uint32_t IEN;          /**< Interrupt Enable Register  */
-  __IM uint32_t  IF;           /**< Interrupt Flag Register  */
-  __IOM uint32_t IFS;          /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;          /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t CH0DATA;      /**< Channel 0 Data Register  */
-  __IOM uint32_t CH1DATA;      /**< Channel 1 Data Register  */
-  __IOM uint32_t COMBDATA;     /**< Combined Data Register  */
-  __IOM uint32_t CAL;          /**< Calibration Register  */
-  __IOM uint32_t BIASPROG;     /**< Bias Programming Register  */
-  uint32_t       RESERVED0[8]; /**< Reserved for future use **/
-  __IOM uint32_t OPACTRL;      /**< Operational Amplifier Control Register  */
-  __IOM uint32_t OPAOFFSET;    /**< Operational Amplifier Offset Register  */
-  __IOM uint32_t OPA0MUX;      /**< Operational Amplifier Mux Configuration Register  */
-  __IOM uint32_t OPA1MUX;      /**< Operational Amplifier Mux Configuration Register  */
-  __IOM uint32_t OPA2MUX;      /**< Operational Amplifier Mux Configuration Register  */
-} DAC_TypeDef;                 /**< DAC Register Declaration *//** @} */
+  __IOM uint32_t CTRL;          /**< Control Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IOM uint32_t CH0CTRL;       /**< Channel 0 Control Register  */
+  __IOM uint32_t CH1CTRL;       /**< Channel 1 Control Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t CH0DATA;       /**< Channel 0 Data Register  */
+  __IOM uint32_t CH1DATA;       /**< Channel 1 Data Register  */
+  __IOM uint32_t COMBDATA;      /**< Combined Data Register  */
+  __IOM uint32_t CAL;           /**< Calibration Register  */
+  __IOM uint32_t BIASPROG;      /**< Bias Programming Register  */
+  uint32_t       RESERVED0[8U]; /**< Reserved for future use **/
+  __IOM uint32_t OPACTRL;       /**< Operational Amplifier Control Register  */
+  __IOM uint32_t OPAOFFSET;     /**< Operational Amplifier Offset Register  */
+  __IOM uint32_t OPA0MUX;       /**< Operational Amplifier Mux Configuration Register  */
+  __IOM uint32_t OPA1MUX;       /**< Operational Amplifier Mux Configuration Register  */
+  __IOM uint32_t OPA2MUX;       /**< Operational Amplifier Mux Configuration Register  */
+} DAC_TypeDef;                  /**< DAC Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32GG_DAC_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for DAC CTRL */
 #define _DAC_CTRL_RESETVALUE                  0x00000010UL                         /**< Default value for DAC_CTRL */

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_devinfo.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_devinfo.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32gg_devinfo.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32GG_DEVINFO register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,39 +40,39 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32GG_DEVINFO
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IM uint32_t CAL;          /**< Calibration temperature and checksum */
-  __IM uint32_t ADC0CAL0;     /**< ADC0 Calibration register 0 */
-  __IM uint32_t ADC0CAL1;     /**< ADC0 Calibration register 1 */
-  __IM uint32_t ADC0CAL2;     /**< ADC0 Calibration register 2 */
-  uint32_t      RESERVED0[2]; /**< Reserved */
-  __IM uint32_t DAC0CAL0;     /**< DAC calibrartion register 0 */
-  __IM uint32_t DAC0CAL1;     /**< DAC calibrartion register 1 */
-  __IM uint32_t DAC0CAL2;     /**< DAC calibrartion register 2 */
-  __IM uint32_t AUXHFRCOCAL0; /**< AUXHFRCO calibration register 0 */
-  __IM uint32_t AUXHFRCOCAL1; /**< AUXHFRCO calibration register 1 */
-  __IM uint32_t HFRCOCAL0;    /**< HFRCO calibration register 0 */
-  __IM uint32_t HFRCOCAL1;    /**< HFRCO calibration register 1 */
-  __IM uint32_t MEMINFO;      /**< Memory information */
-  uint32_t      RESERVED2[2]; /**< Reserved */
-  __IM uint32_t UNIQUEL;      /**< Low 32 bits of device unique number */
-  __IM uint32_t UNIQUEH;      /**< High 32 bits of device unique number */
-  __IM uint32_t MSIZE;        /**< Flash and SRAM Memory size in KiloBytes */
-  __IM uint32_t PART;         /**< Part description */
-} DEVINFO_TypeDef;            /** @} */
+  __IM uint32_t CAL;           /**< Calibration temperature and checksum */
+  __IM uint32_t ADC0CAL0;      /**< ADC0 Calibration register 0 */
+  __IM uint32_t ADC0CAL1;      /**< ADC0 Calibration register 1 */
+  __IM uint32_t ADC0CAL2;      /**< ADC0 Calibration register 2 */
+  uint32_t      RESERVED0[2U]; /**< Reserved */
+  __IM uint32_t DAC0CAL0;      /**< DAC calibrartion register 0 */
+  __IM uint32_t DAC0CAL1;      /**< DAC calibrartion register 1 */
+  __IM uint32_t DAC0CAL2;      /**< DAC calibrartion register 2 */
+  __IM uint32_t AUXHFRCOCAL0;  /**< AUXHFRCO calibration register 0 */
+  __IM uint32_t AUXHFRCOCAL1;  /**< AUXHFRCO calibration register 1 */
+  __IM uint32_t HFRCOCAL0;     /**< HFRCO calibration register 0 */
+  __IM uint32_t HFRCOCAL1;     /**< HFRCO calibration register 1 */
+  __IM uint32_t MEMINFO;       /**< Memory information */
+  uint32_t      RESERVED2[2U]; /**< Reserved */
+  __IM uint32_t UNIQUEL;       /**< Low 32 bits of device unique number */
+  __IM uint32_t UNIQUEH;       /**< High 32 bits of device unique number */
+  __IM uint32_t MSIZE;         /**< Flash and SRAM Memory size in KiloBytes */
+  __IM uint32_t PART;          /**< Part description */
+} DEVINFO_TypeDef;             /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32GG_DEVINFO_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 /* Bit fields for EFM32GG_DEVINFO */
 #define _DEVINFO_CAL_CRC_MASK                      0x0000FFFFUL /**< Integrity CRC checksum mask */
 #define _DEVINFO_CAL_CRC_SHIFT                     0            /**< Integrity CRC checksum shift */

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_dma.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_dma.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32gg_dma.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32GG_DMA register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,62 +40,62 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32GG_DMA
  * @{
  * @brief EFM32GG_DMA Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IM uint32_t  STATUS;         /**< DMA Status Registers  */
-  __OM uint32_t  CONFIG;         /**< DMA Configuration Register  */
-  __IOM uint32_t CTRLBASE;       /**< Channel Control Data Base Pointer Register  */
-  __IM uint32_t  ALTCTRLBASE;    /**< Channel Alternate Control Data Base Pointer Register  */
-  __IM uint32_t  CHWAITSTATUS;   /**< Channel Wait on Request Status Register  */
-  __OM uint32_t  CHSWREQ;        /**< Channel Software Request Register  */
-  __IOM uint32_t CHUSEBURSTS;    /**< Channel Useburst Set Register  */
-  __OM uint32_t  CHUSEBURSTC;    /**< Channel Useburst Clear Register  */
-  __IOM uint32_t CHREQMASKS;     /**< Channel Request Mask Set Register  */
-  __OM uint32_t  CHREQMASKC;     /**< Channel Request Mask Clear Register  */
-  __IOM uint32_t CHENS;          /**< Channel Enable Set Register  */
-  __OM uint32_t  CHENC;          /**< Channel Enable Clear Register  */
-  __IOM uint32_t CHALTS;         /**< Channel Alternate Set Register  */
-  __OM uint32_t  CHALTC;         /**< Channel Alternate Clear Register  */
-  __IOM uint32_t CHPRIS;         /**< Channel Priority Set Register  */
-  __OM uint32_t  CHPRIC;         /**< Channel Priority Clear Register  */
-  uint32_t       RESERVED0[3];   /**< Reserved for future use **/
-  __IOM uint32_t ERRORC;         /**< Bus Error Clear Register  */
+  __IM uint32_t  STATUS;          /**< DMA Status Registers  */
+  __OM uint32_t  CONFIG;          /**< DMA Configuration Register  */
+  __IOM uint32_t CTRLBASE;        /**< Channel Control Data Base Pointer Register  */
+  __IM uint32_t  ALTCTRLBASE;     /**< Channel Alternate Control Data Base Pointer Register  */
+  __IM uint32_t  CHWAITSTATUS;    /**< Channel Wait on Request Status Register  */
+  __OM uint32_t  CHSWREQ;         /**< Channel Software Request Register  */
+  __IOM uint32_t CHUSEBURSTS;     /**< Channel Useburst Set Register  */
+  __OM uint32_t  CHUSEBURSTC;     /**< Channel Useburst Clear Register  */
+  __IOM uint32_t CHREQMASKS;      /**< Channel Request Mask Set Register  */
+  __OM uint32_t  CHREQMASKC;      /**< Channel Request Mask Clear Register  */
+  __IOM uint32_t CHENS;           /**< Channel Enable Set Register  */
+  __OM uint32_t  CHENC;           /**< Channel Enable Clear Register  */
+  __IOM uint32_t CHALTS;          /**< Channel Alternate Set Register  */
+  __OM uint32_t  CHALTC;          /**< Channel Alternate Clear Register  */
+  __IOM uint32_t CHPRIS;          /**< Channel Priority Set Register  */
+  __OM uint32_t  CHPRIC;          /**< Channel Priority Clear Register  */
+  uint32_t       RESERVED0[3U];   /**< Reserved for future use **/
+  __IOM uint32_t ERRORC;          /**< Bus Error Clear Register  */
 
-  uint32_t       RESERVED1[880]; /**< Reserved for future use **/
-  __IM uint32_t  CHREQSTATUS;    /**< Channel Request Status  */
-  uint32_t       RESERVED2[1];   /**< Reserved for future use **/
-  __IM uint32_t  CHSREQSTATUS;   /**< Channel Single Request Status  */
+  uint32_t       RESERVED1[880U]; /**< Reserved for future use **/
+  __IM uint32_t  CHREQSTATUS;     /**< Channel Request Status  */
+  uint32_t       RESERVED2[1U];   /**< Reserved for future use **/
+  __IM uint32_t  CHSREQSTATUS;    /**< Channel Single Request Status  */
 
-  uint32_t       RESERVED3[121]; /**< Reserved for future use **/
-  __IM uint32_t  IF;             /**< Interrupt Flag Register  */
-  __IOM uint32_t IFS;            /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;            /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t IEN;            /**< Interrupt Enable register  */
-  __IOM uint32_t CTRL;           /**< DMA Control Register  */
-  __IOM uint32_t RDS;            /**< DMA Retain Descriptor State  */
+  uint32_t       RESERVED3[121U]; /**< Reserved for future use **/
+  __IM uint32_t  IF;              /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;             /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;             /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;             /**< Interrupt Enable register  */
+  __IOM uint32_t CTRL;            /**< DMA Control Register  */
+  __IOM uint32_t RDS;             /**< DMA Retain Descriptor State  */
 
-  uint32_t       RESERVED4[2];   /**< Reserved for future use **/
-  __IOM uint32_t LOOP0;          /**< Channel 0 Loop Register  */
-  __IOM uint32_t LOOP1;          /**< Channel 1 Loop Register  */
-  uint32_t       RESERVED5[14];  /**< Reserved for future use **/
-  __IOM uint32_t RECT0;          /**< Channel 0 Rectangle Register  */
+  uint32_t       RESERVED4[2U];   /**< Reserved for future use **/
+  __IOM uint32_t LOOP0;           /**< Channel 0 Loop Register  */
+  __IOM uint32_t LOOP1;           /**< Channel 1 Loop Register  */
+  uint32_t       RESERVED5[14U];  /**< Reserved for future use **/
+  __IOM uint32_t RECT0;           /**< Channel 0 Rectangle Register  */
 
-  uint32_t       RESERVED6[39];  /**< Reserved registers */
-  DMA_CH_TypeDef CH[12];         /**< Channel registers */
-} DMA_TypeDef;                   /**< DMA Register Declaration *//** @} */
+  uint32_t       RESERVED6[39U];  /**< Reserved registers */
+  DMA_CH_TypeDef CH[12U];         /**< Channel registers */
+} DMA_TypeDef;                    /**< DMA Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32GG_DMA_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for DMA STATUS */
 #define _DMA_STATUS_RESETVALUE                          0x100B0000UL                          /**< Default value for DMA_STATUS */

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_dma_ch.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_dma_ch.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32gg_dma_ch.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32GG_DMA_CH register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,13 +40,13 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief DMA_CH EFM32GG DMA CH
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t CTRL; /**< Channel Control Register  */
 } DMA_CH_TypeDef;

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_dma_descriptor.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_dma_descriptor.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32gg_dma_descriptor.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32GG_DMA_DESCRIPTOR register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,14 +40,14 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32GG_DMA_DESCRIPTOR
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   /* Note! Use of double __IOM (volatile) qualifier to ensure that both */
   /* pointer and referenced memory are declared volatile. */

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_dmactrl.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_dmactrl.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32gg_dmactrl.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32GG_DMACTRL register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32GG_DMACTRL_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 #define _DMA_CTRL_DST_INC_MASK                         0xC0000000UL  /**< Data increment for destination, bit mask */
 #define _DMA_CTRL_DST_INC_SHIFT                        30            /**< Data increment for destination, shift value */
 #define _DMA_CTRL_DST_INC_BYTE                         0x00          /**< Byte/8-bit increment */

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_dmareq.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_dmareq.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32gg_dmareq.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32GG_DMAREQ register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32GG_DMAREQ_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 #define DMAREQ_ADC0_SINGLE            ((8 << 16) + 0)  /**< DMA channel select for ADC0_SINGLE */
 #define DMAREQ_ADC0_SCAN              ((8 << 16) + 1)  /**< DMA channel select for ADC0_SCAN */
 #define DMAREQ_DAC0_CH0               ((10 << 16) + 0) /**< DMA channel select for DAC0_CH0 */

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_ebi.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_ebi.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32gg_ebi.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32GG_EBI register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32GG_EBI
  * @{
  * @brief EFM32GG_EBI Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t CTRL;         /**< Control Register  */
   __IOM uint32_t ADDRTIMING;   /**< Address Timing Register  */
@@ -95,10 +94,10 @@ typedef struct {
   __IOM uint32_t IEN;          /**< Interrupt Enable Register  */
 } EBI_TypeDef;                 /**< EBI Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32GG_EBI_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for EBI CTRL */
 #define _EBI_CTRL_RESETVALUE                      0x00000000UL                         /**< Default value for EBI_CTRL */

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_emu.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_emu.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32gg_emu.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32GG_EMU register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,24 +40,24 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32GG_EMU
  * @{
  * @brief EFM32GG_EMU Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t CTRL;          /**< Control Register  */
   __IOM uint32_t MEMCTRL;       /**< Memory Control Register  */
   __IOM uint32_t LOCK;          /**< Configuration Lock Register  */
 
-  uint32_t       RESERVED0[6];  /**< Reserved for future use **/
+  uint32_t       RESERVED0[6U]; /**< Reserved for future use **/
   __IOM uint32_t AUXCTRL;       /**< Auxiliary Control Register  */
 
-  uint32_t       RESERVED1[1];  /**< Reserved for future use **/
+  uint32_t       RESERVED1[1U]; /**< Reserved for future use **/
   __IOM uint32_t EM4CONF;       /**< Energy mode 4 configuration register  */
   __IOM uint32_t BUCTRL;        /**< Backup Power configuration register  */
   __IOM uint32_t PWRCONF;       /**< Power connection configuration register  */
@@ -74,10 +73,10 @@ typedef struct {
   __IOM uint32_t BUBODUNREGCAL; /**< Unregulated power Backup BOD calibration  */
 } EMU_TypeDef;                  /**< EMU Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32GG_EMU_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for EMU CTRL */
 #define _EMU_CTRL_RESETVALUE                 0x00000000UL                      /**< Default value for EMU_CTRL */

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_etm.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_etm.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32gg_etm.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32GG_ETM register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,80 +40,80 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32GG_ETM
  * @{
  * @brief EFM32GG_ETM Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IOM uint32_t ETMCR;           /**< Main Control Register  */
-  __IM uint32_t  ETMCCR;          /**< Configuration Code Register  */
-  __IOM uint32_t ETMTRIGGER;      /**< ETM Trigger Event Register  */
-  uint32_t       RESERVED0[1];    /**< Reserved for future use **/
-  __IOM uint32_t ETMSR;           /**< ETM Status Register  */
-  __IM uint32_t  ETMSCR;          /**< ETM System Configuration Register  */
-  uint32_t       RESERVED1[2];    /**< Reserved for future use **/
-  __IOM uint32_t ETMTEEVR;        /**< ETM TraceEnable Event Register  */
-  __IOM uint32_t ETMTECR1;        /**< ETM Trace control Register  */
-  uint32_t       RESERVED2[1];    /**< Reserved for future use **/
-  __IOM uint32_t ETMFFLR;         /**< ETM Fifo Full Level Register  */
-  uint32_t       RESERVED3[68];   /**< Reserved for future use **/
-  __IOM uint32_t ETMCNTRLDVR1;    /**< Counter Reload Value  */
-  uint32_t       RESERVED4[39];   /**< Reserved for future use **/
-  __IOM uint32_t ETMSYNCFR;       /**< Synchronisation Frequency Register  */
-  __IM uint32_t  ETMIDR;          /**< ID Register  */
-  __IM uint32_t  ETMCCER;         /**< Configuration Code Extension Register  */
-  uint32_t       RESERVED5[1];    /**< Reserved for future use **/
-  __IOM uint32_t ETMTESSEICR;     /**< TraceEnable Start/Stop EmbeddedICE Control Register  */
-  uint32_t       RESERVED6[1];    /**< Reserved for future use **/
-  __IOM uint32_t ETMTSEVR;        /**< Timestamp Event Register  */
-  uint32_t       RESERVED7[1];    /**< Reserved for future use **/
-  __IOM uint32_t ETMTRACEIDR;     /**< CoreSight Trace ID Register  */
-  uint32_t       RESERVED8[1];    /**< Reserved for future use **/
-  __IM uint32_t  ETMIDR2;         /**< ETM ID Register 2  */
-  uint32_t       RESERVED9[66];   /**< Reserved for future use **/
-  __IM uint32_t  ETMPDSR;         /**< Device Power-down Status Register  */
-  uint32_t       RESERVED10[754]; /**< Reserved for future use **/
-  __IOM uint32_t ETMISCIN;        /**< Integration Test Miscellaneous Inputs Register  */
-  uint32_t       RESERVED11[1];   /**< Reserved for future use **/
-  __OM uint32_t  ITTRIGOUT;       /**< Integration Test Trigger Out Register  */
-  uint32_t       RESERVED12[1];   /**< Reserved for future use **/
-  __IM uint32_t  ETMITATBCTR2;    /**< ETM Integration Test ATB Control 2 Register  */
-  uint32_t       RESERVED13[1];   /**< Reserved for future use **/
-  __OM uint32_t  ETMITATBCTR0;    /**< ETM Integration Test ATB Control 0 Register  */
-  uint32_t       RESERVED14[1];   /**< Reserved for future use **/
-  __IOM uint32_t ETMITCTRL;       /**< ETM Integration Control Register  */
-  uint32_t       RESERVED15[39];  /**< Reserved for future use **/
-  __IOM uint32_t ETMCLAIMSET;     /**< ETM Claim Tag Set Register  */
-  __IOM uint32_t ETMCLAIMCLR;     /**< ETM Claim Tag Clear Register  */
-  uint32_t       RESERVED16[2];   /**< Reserved for future use **/
-  __IOM uint32_t ETMLAR;          /**< ETM Lock Access Register  */
-  __IM uint32_t  ETMLSR;          /**< Lock Status Register  */
-  __IM uint32_t  ETMAUTHSTATUS;   /**< ETM Authentication Status Register  */
-  uint32_t       RESERVED17[4];   /**< Reserved for future use **/
-  __IM uint32_t  ETMDEVTYPE;      /**< CoreSight Device Type Register  */
-  __IM uint32_t  ETMPIDR4;        /**< Peripheral ID4 Register  */
-  __OM uint32_t  ETMPIDR5;        /**< Peripheral ID5 Register  */
-  __OM uint32_t  ETMPIDR6;        /**< Peripheral ID6 Register  */
-  __OM uint32_t  ETMPIDR7;        /**< Peripheral ID7 Register  */
-  __IM uint32_t  ETMPIDR0;        /**< Peripheral ID0 Register  */
-  __IM uint32_t  ETMPIDR1;        /**< Peripheral ID1 Register  */
-  __IM uint32_t  ETMPIDR2;        /**< Peripheral ID2 Register  */
-  __IM uint32_t  ETMPIDR3;        /**< Peripheral ID3 Register  */
-  __IM uint32_t  ETMCIDR0;        /**< Component ID0 Register  */
-  __IM uint32_t  ETMCIDR1;        /**< Component ID1 Register  */
-  __IM uint32_t  ETMCIDR2;        /**< Component ID2 Register  */
-  __IM uint32_t  ETMCIDR3;        /**< Component ID3 Register  */
-} ETM_TypeDef;                    /**< ETM Register Declaration *//** @} */
+  __IOM uint32_t ETMCR;            /**< Main Control Register  */
+  __IM uint32_t  ETMCCR;           /**< Configuration Code Register  */
+  __IOM uint32_t ETMTRIGGER;       /**< ETM Trigger Event Register  */
+  uint32_t       RESERVED0[1U];    /**< Reserved for future use **/
+  __IOM uint32_t ETMSR;            /**< ETM Status Register  */
+  __IM uint32_t  ETMSCR;           /**< ETM System Configuration Register  */
+  uint32_t       RESERVED1[2U];    /**< Reserved for future use **/
+  __IOM uint32_t ETMTEEVR;         /**< ETM TraceEnable Event Register  */
+  __IOM uint32_t ETMTECR1;         /**< ETM Trace control Register  */
+  uint32_t       RESERVED2[1U];    /**< Reserved for future use **/
+  __IOM uint32_t ETMFFLR;          /**< ETM Fifo Full Level Register  */
+  uint32_t       RESERVED3[68U];   /**< Reserved for future use **/
+  __IOM uint32_t ETMCNTRLDVR1;     /**< Counter Reload Value  */
+  uint32_t       RESERVED4[39U];   /**< Reserved for future use **/
+  __IOM uint32_t ETMSYNCFR;        /**< Synchronisation Frequency Register  */
+  __IM uint32_t  ETMIDR;           /**< ID Register  */
+  __IM uint32_t  ETMCCER;          /**< Configuration Code Extension Register  */
+  uint32_t       RESERVED5[1U];    /**< Reserved for future use **/
+  __IOM uint32_t ETMTESSEICR;      /**< TraceEnable Start/Stop EmbeddedICE Control Register  */
+  uint32_t       RESERVED6[1U];    /**< Reserved for future use **/
+  __IOM uint32_t ETMTSEVR;         /**< Timestamp Event Register  */
+  uint32_t       RESERVED7[1U];    /**< Reserved for future use **/
+  __IOM uint32_t ETMTRACEIDR;      /**< CoreSight Trace ID Register  */
+  uint32_t       RESERVED8[1U];    /**< Reserved for future use **/
+  __IM uint32_t  ETMIDR2;          /**< ETM ID Register 2  */
+  uint32_t       RESERVED9[66U];   /**< Reserved for future use **/
+  __IM uint32_t  ETMPDSR;          /**< Device Power-down Status Register  */
+  uint32_t       RESERVED10[754U]; /**< Reserved for future use **/
+  __IOM uint32_t ETMISCIN;         /**< Integration Test Miscellaneous Inputs Register  */
+  uint32_t       RESERVED11[1U];   /**< Reserved for future use **/
+  __OM uint32_t  ITTRIGOUT;        /**< Integration Test Trigger Out Register  */
+  uint32_t       RESERVED12[1U];   /**< Reserved for future use **/
+  __IM uint32_t  ETMITATBCTR2;     /**< ETM Integration Test ATB Control 2 Register  */
+  uint32_t       RESERVED13[1U];   /**< Reserved for future use **/
+  __OM uint32_t  ETMITATBCTR0;     /**< ETM Integration Test ATB Control 0 Register  */
+  uint32_t       RESERVED14[1U];   /**< Reserved for future use **/
+  __IOM uint32_t ETMITCTRL;        /**< ETM Integration Control Register  */
+  uint32_t       RESERVED15[39U];  /**< Reserved for future use **/
+  __IOM uint32_t ETMCLAIMSET;      /**< ETM Claim Tag Set Register  */
+  __IOM uint32_t ETMCLAIMCLR;      /**< ETM Claim Tag Clear Register  */
+  uint32_t       RESERVED16[2U];   /**< Reserved for future use **/
+  __IOM uint32_t ETMLAR;           /**< ETM Lock Access Register  */
+  __IM uint32_t  ETMLSR;           /**< Lock Status Register  */
+  __IM uint32_t  ETMAUTHSTATUS;    /**< ETM Authentication Status Register  */
+  uint32_t       RESERVED17[4U];   /**< Reserved for future use **/
+  __IM uint32_t  ETMDEVTYPE;       /**< CoreSight Device Type Register  */
+  __IM uint32_t  ETMPIDR4;         /**< Peripheral ID4 Register  */
+  __OM uint32_t  ETMPIDR5;         /**< Peripheral ID5 Register  */
+  __OM uint32_t  ETMPIDR6;         /**< Peripheral ID6 Register  */
+  __OM uint32_t  ETMPIDR7;         /**< Peripheral ID7 Register  */
+  __IM uint32_t  ETMPIDR0;         /**< Peripheral ID0 Register  */
+  __IM uint32_t  ETMPIDR1;         /**< Peripheral ID1 Register  */
+  __IM uint32_t  ETMPIDR2;         /**< Peripheral ID2 Register  */
+  __IM uint32_t  ETMPIDR3;         /**< Peripheral ID3 Register  */
+  __IM uint32_t  ETMCIDR0;         /**< Component ID0 Register  */
+  __IM uint32_t  ETMCIDR1;         /**< Component ID1 Register  */
+  __IM uint32_t  ETMCIDR2;         /**< Component ID2 Register  */
+  __IM uint32_t  ETMCIDR3;         /**< Component ID3 Register  */
+} ETM_TypeDef;                     /**< ETM Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32GG_ETM_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for ETM ETMCR */
 #define _ETM_ETMCR_RESETVALUE                         0x00000411UL                           /**< Default value for ETM_ETMCR */

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_gpio.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_gpio.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32gg_gpio.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32GG_GPIO register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,42 +40,42 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32GG_GPIO
  * @{
  * @brief EFM32GG_GPIO Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  GPIO_P_TypeDef P[6];          /**< Port configuration bits */
+  GPIO_P_TypeDef P[6U];          /**< Port configuration bits */
 
-  uint32_t       RESERVED0[10]; /**< Reserved for future use **/
-  __IOM uint32_t EXTIPSELL;     /**< External Interrupt Port Select Low Register  */
-  __IOM uint32_t EXTIPSELH;     /**< External Interrupt Port Select High Register  */
-  __IOM uint32_t EXTIRISE;      /**< External Interrupt Rising Edge Trigger Register  */
-  __IOM uint32_t EXTIFALL;      /**< External Interrupt Falling Edge Trigger Register  */
-  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
-  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
-  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  uint32_t       RESERVED0[10U]; /**< Reserved for future use **/
+  __IOM uint32_t EXTIPSELL;      /**< External Interrupt Port Select Low Register  */
+  __IOM uint32_t EXTIPSELH;      /**< External Interrupt Port Select High Register  */
+  __IOM uint32_t EXTIRISE;       /**< External Interrupt Rising Edge Trigger Register  */
+  __IOM uint32_t EXTIFALL;       /**< External Interrupt Falling Edge Trigger Register  */
+  __IOM uint32_t IEN;            /**< Interrupt Enable Register  */
+  __IM uint32_t  IF;             /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;            /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;            /**< Interrupt Flag Clear Register  */
 
-  __IOM uint32_t ROUTE;         /**< I/O Routing Register  */
-  __IOM uint32_t INSENSE;       /**< Input Sense Register  */
-  __IOM uint32_t LOCK;          /**< Configuration Lock Register  */
-  __IOM uint32_t CTRL;          /**< GPIO Control Register  */
-  __IOM uint32_t CMD;           /**< GPIO Command Register  */
-  __IOM uint32_t EM4WUEN;       /**< EM4 Wake-up Enable Register  */
-  __IOM uint32_t EM4WUPOL;      /**< EM4 Wake-up Polarity Register  */
-  __IM uint32_t  EM4WUCAUSE;    /**< EM4 Wake-up Cause Register  */
-} GPIO_TypeDef;                 /**< GPIO Register Declaration *//** @} */
+  __IOM uint32_t ROUTE;          /**< I/O Routing Register  */
+  __IOM uint32_t INSENSE;        /**< Input Sense Register  */
+  __IOM uint32_t LOCK;           /**< Configuration Lock Register  */
+  __IOM uint32_t CTRL;           /**< GPIO Control Register  */
+  __IOM uint32_t CMD;            /**< GPIO Command Register  */
+  __IOM uint32_t EM4WUEN;        /**< EM4 Wake-up Enable Register  */
+  __IOM uint32_t EM4WUPOL;       /**< EM4 Wake-up Polarity Register  */
+  __IM uint32_t  EM4WUCAUSE;     /**< EM4 Wake-up Cause Register  */
+} GPIO_TypeDef;                  /**< GPIO Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32GG_GPIO_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for GPIO P_CTRL */
 #define _GPIO_P_CTRL_RESETVALUE                           0x00000000UL                           /**< Default value for GPIO_P_CTRL */

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_gpio_p.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_gpio_p.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32gg_gpio_p.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32GG_GPIO_P register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,13 +40,13 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief GPIO_P EFM32GG GPIO P
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t CTRL;     /**< Port Control Register  */
   __IOM uint32_t MODEL;    /**< Port Pin Mode Low Register  */

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_i2c.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_i2c.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32gg_i2c.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32GG_I2C register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32GG_I2C
  * @{
  * @brief EFM32GG_I2C Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t CTRL;      /**< Control Register  */
   __IOM uint32_t CMD;       /**< Command Register  */
@@ -68,10 +67,10 @@ typedef struct {
   __IOM uint32_t ROUTE;     /**< I/O Routing Register  */
 } I2C_TypeDef;              /**< I2C Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32GG_I2C_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for I2C CTRL */
 #define _I2C_CTRL_RESETVALUE              0x00000000UL                     /**< Default value for I2C_CTRL */

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_lcd.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_lcd.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32gg_lcd.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32GG_LCD register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,57 +40,57 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32GG_LCD
  * @{
  * @brief EFM32GG_LCD Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IOM uint32_t CTRL;          /**< Control Register  */
-  __IOM uint32_t DISPCTRL;      /**< Display Control Register  */
-  __IOM uint32_t SEGEN;         /**< Segment Enable Register  */
-  __IOM uint32_t BACTRL;        /**< Blink and Animation Control Register  */
-  __IM uint32_t  STATUS;        /**< Status Register  */
-  __IOM uint32_t AREGA;         /**< Animation Register A  */
-  __IOM uint32_t AREGB;         /**< Animation Register B  */
-  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
-  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t CTRL;           /**< Control Register  */
+  __IOM uint32_t DISPCTRL;       /**< Display Control Register  */
+  __IOM uint32_t SEGEN;          /**< Segment Enable Register  */
+  __IOM uint32_t BACTRL;         /**< Blink and Animation Control Register  */
+  __IM uint32_t  STATUS;         /**< Status Register  */
+  __IOM uint32_t AREGA;          /**< Animation Register A  */
+  __IOM uint32_t AREGB;          /**< Animation Register B  */
+  __IM uint32_t  IF;             /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;            /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;            /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;            /**< Interrupt Enable Register  */
 
-  uint32_t       RESERVED0[5];  /**< Reserved for future use **/
-  __IOM uint32_t SEGD0L;        /**< Segment Data Low Register 0  */
-  __IOM uint32_t SEGD1L;        /**< Segment Data Low Register 1  */
-  __IOM uint32_t SEGD2L;        /**< Segment Data Low Register 2  */
-  __IOM uint32_t SEGD3L;        /**< Segment Data Low Register 3  */
-  __IOM uint32_t SEGD0H;        /**< Segment Data High Register 0  */
-  __IOM uint32_t SEGD1H;        /**< Segment Data High Register 1  */
-  __IOM uint32_t SEGD2H;        /**< Segment Data High Register 2  */
-  __IOM uint32_t SEGD3H;        /**< Segment Data High Register 3  */
+  uint32_t       RESERVED0[5U];  /**< Reserved for future use **/
+  __IOM uint32_t SEGD0L;         /**< Segment Data Low Register 0  */
+  __IOM uint32_t SEGD1L;         /**< Segment Data Low Register 1  */
+  __IOM uint32_t SEGD2L;         /**< Segment Data Low Register 2  */
+  __IOM uint32_t SEGD3L;         /**< Segment Data Low Register 3  */
+  __IOM uint32_t SEGD0H;         /**< Segment Data High Register 0  */
+  __IOM uint32_t SEGD1H;         /**< Segment Data High Register 1  */
+  __IOM uint32_t SEGD2H;         /**< Segment Data High Register 2  */
+  __IOM uint32_t SEGD3H;         /**< Segment Data High Register 3  */
 
-  __IOM uint32_t FREEZE;        /**< Freeze Register  */
-  __IM uint32_t  SYNCBUSY;      /**< Synchronization Busy Register  */
+  __IOM uint32_t FREEZE;         /**< Freeze Register  */
+  __IM uint32_t  SYNCBUSY;       /**< Synchronization Busy Register  */
 
-  uint32_t       RESERVED1[19]; /**< Reserved for future use **/
-  __IOM uint32_t SEGD4H;        /**< Segment Data High Register 4  */
-  __IOM uint32_t SEGD5H;        /**< Segment Data High Register 5  */
-  __IOM uint32_t SEGD6H;        /**< Segment Data High Register 6  */
-  __IOM uint32_t SEGD7H;        /**< Segment Data High Register 7  */
-  uint32_t       RESERVED2[2];  /**< Reserved for future use **/
-  __IOM uint32_t SEGD4L;        /**< Segment Data Low Register 4  */
-  __IOM uint32_t SEGD5L;        /**< Segment Data Low Register 5  */
-  __IOM uint32_t SEGD6L;        /**< Segment Data Low Register 6  */
-  __IOM uint32_t SEGD7L;        /**< Segment Data Low Register 7  */
-} LCD_TypeDef;                  /**< LCD Register Declaration *//** @} */
+  uint32_t       RESERVED1[19U]; /**< Reserved for future use **/
+  __IOM uint32_t SEGD4H;         /**< Segment Data High Register 4  */
+  __IOM uint32_t SEGD5H;         /**< Segment Data High Register 5  */
+  __IOM uint32_t SEGD6H;         /**< Segment Data High Register 6  */
+  __IOM uint32_t SEGD7H;         /**< Segment Data High Register 7  */
+  uint32_t       RESERVED2[2U];  /**< Reserved for future use **/
+  __IOM uint32_t SEGD4L;         /**< Segment Data Low Register 4  */
+  __IOM uint32_t SEGD5L;         /**< Segment Data Low Register 5  */
+  __IOM uint32_t SEGD6L;         /**< Segment Data Low Register 6  */
+  __IOM uint32_t SEGD7L;         /**< Segment Data Low Register 7  */
+} LCD_TypeDef;                   /**< LCD Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32GG_LCD_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for LCD CTRL */
 #define _LCD_CTRL_RESETVALUE               0x00000000UL                       /**< Default value for LCD_CTRL */

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_lesense.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_lesense.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32gg_lesense.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32GG_LESENSE register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,52 +40,52 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32GG_LESENSE
  * @{
  * @brief EFM32GG_LESENSE Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IOM uint32_t      CTRL;           /**< Control Register  */
-  __IOM uint32_t      TIMCTRL;        /**< Timing Control Register  */
-  __IOM uint32_t      PERCTRL;        /**< Peripheral Control Register  */
-  __IOM uint32_t      DECCTRL;        /**< Decoder control Register  */
-  __IOM uint32_t      BIASCTRL;       /**< Bias Control Register  */
-  __IOM uint32_t      CMD;            /**< Command Register  */
-  __IOM uint32_t      CHEN;           /**< Channel enable Register  */
-  __IM uint32_t       SCANRES;        /**< Scan result register  */
-  __IM uint32_t       STATUS;         /**< Status Register  */
-  __IM uint32_t       PTR;            /**< Result buffer pointers  */
-  __IM uint32_t       BUFDATA;        /**< Result buffer data register  */
-  __IM uint32_t       CURCH;          /**< Current channel index  */
-  __IOM uint32_t      DECSTATE;       /**< Current decoder state  */
-  __IOM uint32_t      SENSORSTATE;    /**< Decoder input register  */
-  __IOM uint32_t      IDLECONF;       /**< GPIO Idle phase configuration  */
-  __IOM uint32_t      ALTEXCONF;      /**< Alternative excite pin configuration  */
-  __IM uint32_t       IF;             /**< Interrupt Flag Register  */
-  __IOM uint32_t      IFC;            /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t      IFS;            /**< Interrupt Flag Set Register  */
-  __IOM uint32_t      IEN;            /**< Interrupt Enable Register  */
-  __IM uint32_t       SYNCBUSY;       /**< Synchronization Busy Register  */
-  __IOM uint32_t      ROUTE;          /**< I/O Routing Register  */
-  __IOM uint32_t      POWERDOWN;      /**< LESENSE RAM power-down register  */
+  __IOM uint32_t      CTRL;            /**< Control Register  */
+  __IOM uint32_t      TIMCTRL;         /**< Timing Control Register  */
+  __IOM uint32_t      PERCTRL;         /**< Peripheral Control Register  */
+  __IOM uint32_t      DECCTRL;         /**< Decoder control Register  */
+  __IOM uint32_t      BIASCTRL;        /**< Bias Control Register  */
+  __IOM uint32_t      CMD;             /**< Command Register  */
+  __IOM uint32_t      CHEN;            /**< Channel enable Register  */
+  __IM uint32_t       SCANRES;         /**< Scan result register  */
+  __IM uint32_t       STATUS;          /**< Status Register  */
+  __IM uint32_t       PTR;             /**< Result buffer pointers  */
+  __IM uint32_t       BUFDATA;         /**< Result buffer data register  */
+  __IM uint32_t       CURCH;           /**< Current channel index  */
+  __IOM uint32_t      DECSTATE;        /**< Current decoder state  */
+  __IOM uint32_t      SENSORSTATE;     /**< Decoder input register  */
+  __IOM uint32_t      IDLECONF;        /**< GPIO Idle phase configuration  */
+  __IOM uint32_t      ALTEXCONF;       /**< Alternative excite pin configuration  */
+  __IM uint32_t       IF;              /**< Interrupt Flag Register  */
+  __IOM uint32_t      IFC;             /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t      IFS;             /**< Interrupt Flag Set Register  */
+  __IOM uint32_t      IEN;             /**< Interrupt Enable Register  */
+  __IM uint32_t       SYNCBUSY;        /**< Synchronization Busy Register  */
+  __IOM uint32_t      ROUTE;           /**< I/O Routing Register  */
+  __IOM uint32_t      POWERDOWN;       /**< LESENSE RAM power-down register  */
 
-  uint32_t            RESERVED0[105]; /**< Reserved registers */
-  LESENSE_ST_TypeDef  ST[16];         /**< Decoding states */
+  uint32_t            RESERVED0[105U]; /**< Reserved registers */
+  LESENSE_ST_TypeDef  ST[16U];         /**< Decoding states */
 
-  LESENSE_BUF_TypeDef BUF[16];        /**< Scanresult */
+  LESENSE_BUF_TypeDef BUF[16U];        /**< Scanresult */
 
-  LESENSE_CH_TypeDef  CH[16];         /**< Scanconfig */
-} LESENSE_TypeDef;                    /**< LESENSE Register Declaration *//** @} */
+  LESENSE_CH_TypeDef  CH[16U];         /**< Scanconfig */
+} LESENSE_TypeDef;                     /**< LESENSE Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32GG_LESENSE_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for LESENSE CTRL */
 #define _LESENSE_CTRL_RESETVALUE                       0x00000000UL                             /**< Default value for LESENSE_CTRL */

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_lesense_buf.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_lesense_buf.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32gg_lesense_buf.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32GG_LESENSE_BUF register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,13 +40,13 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief LESENSE_BUF EFM32GG LESENSE BUF
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t DATA; /**< Scan results  */
 } LESENSE_BUF_TypeDef;

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_lesense_ch.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_lesense_ch.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32gg_lesense_ch.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32GG_LESENSE_CH register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,18 +40,18 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief LESENSE_CH EFM32GG LESENSE CH
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IOM uint32_t TIMING;       /**< Scan configuration  */
-  __IOM uint32_t INTERACT;     /**< Scan configuration  */
-  __IOM uint32_t EVAL;         /**< Scan configuration  */
-  uint32_t       RESERVED0[1]; /**< Reserved future */
+  __IOM uint32_t TIMING;        /**< Scan configuration  */
+  __IOM uint32_t INTERACT;      /**< Scan configuration  */
+  __IOM uint32_t EVAL;          /**< Scan configuration  */
+  uint32_t       RESERVED0[1U]; /**< Reserved future */
 } LESENSE_CH_TypeDef;
 
 /** @} End of group Parts */

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_lesense_st.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_lesense_st.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32gg_lesense_st.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32GG_LESENSE_ST register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,13 +40,13 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief LESENSE_ST EFM32GG LESENSE ST
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t TCONFA; /**< State transition configuration A  */
   __IOM uint32_t TCONFB; /**< State transition configuration B  */

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_letimer.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_letimer.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32gg_letimer.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32GG_LETIMER register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,40 +40,40 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32GG_LETIMER
  * @{
  * @brief EFM32GG_LETIMER Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IOM uint32_t CTRL;         /**< Control Register  */
-  __IOM uint32_t CMD;          /**< Command Register  */
-  __IM uint32_t  STATUS;       /**< Status Register  */
-  __IOM uint32_t CNT;          /**< Counter Value Register  */
-  __IOM uint32_t COMP0;        /**< Compare Value Register 0  */
-  __IOM uint32_t COMP1;        /**< Compare Value Register 1  */
-  __IOM uint32_t REP0;         /**< Repeat Counter Register 0  */
-  __IOM uint32_t REP1;         /**< Repeat Counter Register 1  */
-  __IM uint32_t  IF;           /**< Interrupt Flag Register  */
-  __IOM uint32_t IFS;          /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;          /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t IEN;          /**< Interrupt Enable Register  */
+  __IOM uint32_t CTRL;          /**< Control Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IOM uint32_t CNT;           /**< Counter Value Register  */
+  __IOM uint32_t COMP0;         /**< Compare Value Register 0  */
+  __IOM uint32_t COMP1;         /**< Compare Value Register 1  */
+  __IOM uint32_t REP0;          /**< Repeat Counter Register 0  */
+  __IOM uint32_t REP1;          /**< Repeat Counter Register 1  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
 
-  __IOM uint32_t FREEZE;       /**< Freeze Register  */
-  __IM uint32_t  SYNCBUSY;     /**< Synchronization Busy Register  */
+  __IOM uint32_t FREEZE;        /**< Freeze Register  */
+  __IM uint32_t  SYNCBUSY;      /**< Synchronization Busy Register  */
 
-  uint32_t       RESERVED0[2]; /**< Reserved for future use **/
-  __IOM uint32_t ROUTE;        /**< I/O Routing Register  */
-} LETIMER_TypeDef;             /**< LETIMER Register Declaration *//** @} */
+  uint32_t       RESERVED0[2U]; /**< Reserved for future use **/
+  __IOM uint32_t ROUTE;         /**< I/O Routing Register  */
+} LETIMER_TypeDef;              /**< LETIMER Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32GG_LETIMER_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for LETIMER CTRL */
 #define _LETIMER_CTRL_RESETVALUE             0x00000000UL                           /**< Default value for LETIMER_CTRL */

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_leuart.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_leuart.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32gg_leuart.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32GG_LEUART register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,46 +40,46 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32GG_LEUART
  * @{
  * @brief EFM32GG_LEUART Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IOM uint32_t CTRL;          /**< Control Register  */
-  __IOM uint32_t CMD;           /**< Command Register  */
-  __IM uint32_t  STATUS;        /**< Status Register  */
-  __IOM uint32_t CLKDIV;        /**< Clock Control Register  */
-  __IOM uint32_t STARTFRAME;    /**< Start Frame Register  */
-  __IOM uint32_t SIGFRAME;      /**< Signal Frame Register  */
-  __IM uint32_t  RXDATAX;       /**< Receive Buffer Data Extended Register  */
-  __IM uint32_t  RXDATA;        /**< Receive Buffer Data Register  */
-  __IM uint32_t  RXDATAXP;      /**< Receive Buffer Data Extended Peek Register  */
-  __IOM uint32_t TXDATAX;       /**< Transmit Buffer Data Extended Register  */
-  __IOM uint32_t TXDATA;        /**< Transmit Buffer Data Register  */
-  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
-  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
-  __IOM uint32_t PULSECTRL;     /**< Pulse Control Register  */
+  __IOM uint32_t CTRL;           /**< Control Register  */
+  __IOM uint32_t CMD;            /**< Command Register  */
+  __IM uint32_t  STATUS;         /**< Status Register  */
+  __IOM uint32_t CLKDIV;         /**< Clock Control Register  */
+  __IOM uint32_t STARTFRAME;     /**< Start Frame Register  */
+  __IOM uint32_t SIGFRAME;       /**< Signal Frame Register  */
+  __IM uint32_t  RXDATAX;        /**< Receive Buffer Data Extended Register  */
+  __IM uint32_t  RXDATA;         /**< Receive Buffer Data Register  */
+  __IM uint32_t  RXDATAXP;       /**< Receive Buffer Data Extended Peek Register  */
+  __IOM uint32_t TXDATAX;        /**< Transmit Buffer Data Extended Register  */
+  __IOM uint32_t TXDATA;         /**< Transmit Buffer Data Register  */
+  __IM uint32_t  IF;             /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;            /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;            /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;            /**< Interrupt Enable Register  */
+  __IOM uint32_t PULSECTRL;      /**< Pulse Control Register  */
 
-  __IOM uint32_t FREEZE;        /**< Freeze Register  */
-  __IM uint32_t  SYNCBUSY;      /**< Synchronization Busy Register  */
+  __IOM uint32_t FREEZE;         /**< Freeze Register  */
+  __IM uint32_t  SYNCBUSY;       /**< Synchronization Busy Register  */
 
-  uint32_t       RESERVED0[3];  /**< Reserved for future use **/
-  __IOM uint32_t ROUTE;         /**< I/O Routing Register  */
-  uint32_t       RESERVED1[21]; /**< Reserved for future use **/
-  __IOM uint32_t INPUT;         /**< LEUART Input Register  */
-} LEUART_TypeDef;               /**< LEUART Register Declaration *//** @} */
+  uint32_t       RESERVED0[3U];  /**< Reserved for future use **/
+  __IOM uint32_t ROUTE;          /**< I/O Routing Register  */
+  uint32_t       RESERVED1[21U]; /**< Reserved for future use **/
+  __IOM uint32_t INPUT;          /**< LEUART Input Register  */
+} LEUART_TypeDef;                /**< LEUART Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32GG_LEUART_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for LEUART CTRL */
 #define _LEUART_CTRL_RESETVALUE                  0x00000000UL                         /**< Default value for LEUART_CTRL */

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_msc.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_msc.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32gg_msc.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32GG_MSC register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,44 +40,44 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32GG_MSC
  * @{
  * @brief EFM32GG_MSC Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IOM uint32_t CTRL;         /**< Memory System Control Register  */
-  __IOM uint32_t READCTRL;     /**< Read Control Register  */
-  __IOM uint32_t WRITECTRL;    /**< Write Control Register  */
-  __IOM uint32_t WRITECMD;     /**< Write Command Register  */
-  __IOM uint32_t ADDRB;        /**< Page Erase/Write Address Buffer  */
+  __IOM uint32_t CTRL;          /**< Memory System Control Register  */
+  __IOM uint32_t READCTRL;      /**< Read Control Register  */
+  __IOM uint32_t WRITECTRL;     /**< Write Control Register  */
+  __IOM uint32_t WRITECMD;      /**< Write Command Register  */
+  __IOM uint32_t ADDRB;         /**< Page Erase/Write Address Buffer  */
 
-  uint32_t       RESERVED0[1]; /**< Reserved for future use **/
-  __IOM uint32_t WDATA;        /**< Write Data Register  */
-  __IM uint32_t  STATUS;       /**< Status Register  */
+  uint32_t       RESERVED0[1U]; /**< Reserved for future use **/
+  __IOM uint32_t WDATA;         /**< Write Data Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
 
-  uint32_t       RESERVED1[3]; /**< Reserved for future use **/
-  __IM uint32_t  IF;           /**< Interrupt Flag Register  */
-  __IOM uint32_t IFS;          /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;          /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t IEN;          /**< Interrupt Enable Register  */
-  __IOM uint32_t LOCK;         /**< Configuration Lock Register  */
-  __IOM uint32_t CMD;          /**< Command Register  */
-  __IM uint32_t  CACHEHITS;    /**< Cache Hits Performance Counter  */
-  __IM uint32_t  CACHEMISSES;  /**< Cache Misses Performance Counter  */
-  uint32_t       RESERVED2[1]; /**< Reserved for future use **/
-  __IOM uint32_t TIMEBASE;     /**< Flash Write and Erase Timebase  */
-  __IOM uint32_t MASSLOCK;     /**< Mass Erase Lock Register  */
-} MSC_TypeDef;                 /**< MSC Register Declaration *//** @} */
+  uint32_t       RESERVED1[3U]; /**< Reserved for future use **/
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t LOCK;          /**< Configuration Lock Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IM uint32_t  CACHEHITS;     /**< Cache Hits Performance Counter  */
+  __IM uint32_t  CACHEMISSES;   /**< Cache Misses Performance Counter  */
+  uint32_t       RESERVED2[1U]; /**< Reserved for future use **/
+  __IOM uint32_t TIMEBASE;      /**< Flash Write and Erase Timebase  */
+  __IOM uint32_t MASSLOCK;      /**< Mass Erase Lock Register  */
+} MSC_TypeDef;                  /**< MSC Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32GG_MSC_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for MSC CTRL */
 #define _MSC_CTRL_RESETVALUE                    0x00000001UL                       /**< Default value for MSC_CTRL */

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_pcnt.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_pcnt.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32gg_pcnt.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32GG_PCNT register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,40 +40,40 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32GG_PCNT
  * @{
  * @brief EFM32GG_PCNT Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IOM uint32_t CTRL;         /**< Control Register  */
-  __IOM uint32_t CMD;          /**< Command Register  */
-  __IM uint32_t  STATUS;       /**< Status Register  */
-  __IM uint32_t  CNT;          /**< Counter Value Register  */
-  __IM uint32_t  TOP;          /**< Top Value Register  */
-  __IOM uint32_t TOPB;         /**< Top Value Buffer Register  */
-  __IM uint32_t  IF;           /**< Interrupt Flag Register  */
-  __IOM uint32_t IFS;          /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;          /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t IEN;          /**< Interrupt Enable Register  */
-  __IOM uint32_t ROUTE;        /**< I/O Routing Register  */
+  __IOM uint32_t CTRL;          /**< Control Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IM uint32_t  CNT;           /**< Counter Value Register  */
+  __IM uint32_t  TOP;           /**< Top Value Register  */
+  __IOM uint32_t TOPB;          /**< Top Value Buffer Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t ROUTE;         /**< I/O Routing Register  */
 
-  __IOM uint32_t FREEZE;       /**< Freeze Register  */
-  __IM uint32_t  SYNCBUSY;     /**< Synchronization Busy Register  */
+  __IOM uint32_t FREEZE;        /**< Freeze Register  */
+  __IM uint32_t  SYNCBUSY;      /**< Synchronization Busy Register  */
 
-  uint32_t       RESERVED0[1]; /**< Reserved for future use **/
-  __IOM uint32_t AUXCNT;       /**< Auxiliary Counter Value Register  */
-  __IOM uint32_t INPUT;        /**< PCNT Input Register  */
-} PCNT_TypeDef;                /**< PCNT Register Declaration *//** @} */
+  uint32_t       RESERVED0[1U]; /**< Reserved for future use **/
+  __IOM uint32_t AUXCNT;        /**< Auxiliary Counter Value Register  */
+  __IOM uint32_t INPUT;         /**< PCNT Input Register  */
+} PCNT_TypeDef;                 /**< PCNT Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32GG_PCNT_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for PCNT CTRL */
 #define _PCNT_CTRL_RESETVALUE             0x00000000UL                        /**< Default value for PCNT_CTRL */

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_prs.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_prs.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32gg_prs.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32GG_PRS register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,28 +40,28 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32GG_PRS
  * @{
  * @brief EFM32GG_PRS Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IOM uint32_t SWPULSE;      /**< Software Pulse Register  */
-  __IOM uint32_t SWLEVEL;      /**< Software Level Register  */
-  __IOM uint32_t ROUTE;        /**< I/O Routing Register  */
+  __IOM uint32_t SWPULSE;       /**< Software Pulse Register  */
+  __IOM uint32_t SWLEVEL;       /**< Software Level Register  */
+  __IOM uint32_t ROUTE;         /**< I/O Routing Register  */
 
-  uint32_t       RESERVED0[1]; /**< Reserved registers */
-  PRS_CH_TypeDef CH[12];       /**< Channel registers */
-} PRS_TypeDef;                 /**< PRS Register Declaration *//** @} */
+  uint32_t       RESERVED0[1U]; /**< Reserved registers */
+  PRS_CH_TypeDef CH[12U];       /**< Channel registers */
+} PRS_TypeDef;                  /**< PRS Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32GG_PRS_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for PRS SWPULSE */
 #define _PRS_SWPULSE_RESETVALUE                 0x00000000UL                           /**< Default value for PRS_SWPULSE */

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_prs_ch.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_prs_ch.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32gg_prs_ch.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32GG_PRS_CH register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,13 +40,13 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief PRS_CH EFM32GG PRS CH
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t CTRL; /**< Channel Control Register  */
 } PRS_CH_TypeDef;

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_prs_signals.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_prs_signals.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32gg_prs_signals.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32GG_PRS_SIGNALS register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @addtogroup EFM32GG_PRS_Signals
  * @{
  * @brief PRS Signal names
- *****************************************************************************/
+ ******************************************************************************/
 #define PRS_VCMP_OUT             ((1 << 16) + 0)  /**< PRS Voltage comparator output */
 #define PRS_ACMP0_OUT            ((2 << 16) + 0)  /**< PRS Analog comparator output */
 #define PRS_ACMP1_OUT            ((3 << 16) + 0)  /**< PRS Analog comparator output */

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_rmu.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_rmu.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32gg_rmu.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32GG_RMU register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,25 +40,25 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32GG_RMU
  * @{
  * @brief EFM32GG_RMU Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t CTRL;     /**< Control Register  */
   __IM uint32_t  RSTCAUSE; /**< Reset Cause Register  */
   __OM uint32_t  CMD;      /**< Command Register  */
 } RMU_TypeDef;             /**< RMU Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32GG_RMU_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for RMU CTRL */
 #define _RMU_CTRL_RESETVALUE                  0x00000002UL                        /**< Default value for RMU_CTRL */

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_romtable.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_romtable.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32gg_romtable.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32GG_ROMTABLE register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32GG_ROMTABLE
  * @{
  * @brief Chip Information, Revision numbers
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IM uint32_t PID4; /**< JEP_106_BANK */
   __IM uint32_t PID5; /**< Unused */
@@ -62,10 +61,10 @@ typedef struct {
   __IM uint32_t CID0; /**< Unused */
 } ROMTABLE_TypeDef;   /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32GG_ROMTABLE_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 /* Bit fields for EFM32GG_ROMTABLE */
 #define _ROMTABLE_PID0_FAMILYLSB_MASK       0x000000C0UL /**< Least Significant Bits [1:0] of CHIP FAMILY, mask */
 #define _ROMTABLE_PID0_FAMILYLSB_SHIFT      6            /**< Least Significant Bits [1:0] of CHIP FAMILY, shift */

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_rtc.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_rtc.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32gg_rtc.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32GG_RTC register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32GG_RTC
  * @{
  * @brief EFM32GG_RTC Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t CTRL;     /**< Control Register  */
   __IOM uint32_t CNT;      /**< Counter Value Register  */
@@ -64,10 +63,10 @@ typedef struct {
   __IM uint32_t  SYNCBUSY; /**< Synchronization Busy Register  */
 } RTC_TypeDef;             /**< RTC Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32GG_RTC_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for RTC CTRL */
 #define _RTC_CTRL_RESETVALUE             0x00000000UL                      /**< Default value for RTC_CTRL */

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_timer.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_timer.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32gg_timer.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32GG_TIMER register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,45 +40,45 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32GG_TIMER
  * @{
  * @brief EFM32GG_TIMER Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IOM uint32_t   CTRL;         /**< Control Register  */
-  __IOM uint32_t   CMD;          /**< Command Register  */
-  __IM uint32_t    STATUS;       /**< Status Register  */
-  __IOM uint32_t   IEN;          /**< Interrupt Enable Register  */
-  __IM uint32_t    IF;           /**< Interrupt Flag Register  */
-  __IOM uint32_t   IFS;          /**< Interrupt Flag Set Register  */
-  __IOM uint32_t   IFC;          /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t   TOP;          /**< Counter Top Value Register  */
-  __IOM uint32_t   TOPB;         /**< Counter Top Value Buffer Register  */
-  __IOM uint32_t   CNT;          /**< Counter Value Register  */
-  __IOM uint32_t   ROUTE;        /**< I/O Routing Register  */
+  __IOM uint32_t   CTRL;          /**< Control Register  */
+  __IOM uint32_t   CMD;           /**< Command Register  */
+  __IM uint32_t    STATUS;        /**< Status Register  */
+  __IOM uint32_t   IEN;           /**< Interrupt Enable Register  */
+  __IM uint32_t    IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t   IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t   IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t   TOP;           /**< Counter Top Value Register  */
+  __IOM uint32_t   TOPB;          /**< Counter Top Value Buffer Register  */
+  __IOM uint32_t   CNT;           /**< Counter Value Register  */
+  __IOM uint32_t   ROUTE;         /**< I/O Routing Register  */
 
-  uint32_t         RESERVED0[1]; /**< Reserved registers */
-  TIMER_CC_TypeDef CC[3];        /**< Compare/Capture Channel */
+  uint32_t         RESERVED0[1U]; /**< Reserved registers */
+  TIMER_CC_TypeDef CC[3U];        /**< Compare/Capture Channel */
 
-  uint32_t         RESERVED1[4]; /**< Reserved for future use **/
-  __IOM uint32_t   DTCTRL;       /**< DTI Control Register  */
-  __IOM uint32_t   DTTIME;       /**< DTI Time Control Register  */
-  __IOM uint32_t   DTFC;         /**< DTI Fault Configuration Register  */
-  __IOM uint32_t   DTOGEN;       /**< DTI Output Generation Enable Register  */
-  __IM uint32_t    DTFAULT;      /**< DTI Fault Register  */
-  __OM uint32_t    DTFAULTC;     /**< DTI Fault Clear Register  */
-  __IOM uint32_t   DTLOCK;       /**< DTI Configuration Lock Register  */
-} TIMER_TypeDef;                 /**< TIMER Register Declaration *//** @} */
+  uint32_t         RESERVED1[4U]; /**< Reserved for future use **/
+  __IOM uint32_t   DTCTRL;        /**< DTI Control Register  */
+  __IOM uint32_t   DTTIME;        /**< DTI Time Control Register  */
+  __IOM uint32_t   DTFC;          /**< DTI Fault Configuration Register  */
+  __IOM uint32_t   DTOGEN;        /**< DTI Output Generation Enable Register  */
+  __IM uint32_t    DTFAULT;       /**< DTI Fault Register  */
+  __OM uint32_t    DTFAULTC;      /**< DTI Fault Clear Register  */
+  __IOM uint32_t   DTLOCK;        /**< DTI Configuration Lock Register  */
+} TIMER_TypeDef;                  /**< TIMER Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32GG_TIMER_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for TIMER CTRL */
 #define _TIMER_CTRL_RESETVALUE                     0x00000000UL                             /**< Default value for TIMER_CTRL */

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_timer_cc.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_timer_cc.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32gg_timer_cc.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32GG_TIMER_CC register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,13 +40,13 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief TIMER_CC EFM32GG TIMER CC
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t CTRL; /**< CC Channel Control Register  */
   __IOM uint32_t CCV;  /**< CC Channel Value Register  */

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_uart.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_uart.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32gg_uart.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32GG_UART register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32GG_UART_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for UART CTRL */
 #define _UART_CTRL_RESETVALUE                0x00000000UL                            /**< Default value for UART_CTRL */

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_usart.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_usart.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32gg_usart.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32GG_USART register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32GG_USART
  * @{
  * @brief EFM32GG_USART Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t CTRL;       /**< Control Register  */
   __IOM uint32_t FRAME;      /**< USART Frame Format Register  */
@@ -77,10 +76,10 @@ typedef struct {
   __IOM uint32_t I2SCTRL;    /**< I2S Control Register  */
 } USART_TypeDef;             /**< USART Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32GG_USART_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for USART CTRL */
 #define _USART_CTRL_RESETVALUE                0x00000000UL                             /**< Default value for USART_CTRL */

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_usb.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_usb.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32gg_usb.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32GG_USB register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,155 +40,155 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32GG_USB
  * @{
  * @brief EFM32GG_USB Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IOM uint32_t   CTRL;              /**< System Control Register  */
-  __IM uint32_t    STATUS;            /**< System Status Register  */
-  __IM uint32_t    IF;                /**< Interrupt Flag Register  */
-  __IOM uint32_t   IFS;               /**< Interrupt Flag Set Register  */
-  __IOM uint32_t   IFC;               /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t   IEN;               /**< Interrupt Enable Register  */
-  __IOM uint32_t   ROUTE;             /**< I/O Routing Register  */
+  __IOM uint32_t   CTRL;               /**< System Control Register  */
+  __IM uint32_t    STATUS;             /**< System Status Register  */
+  __IM uint32_t    IF;                 /**< Interrupt Flag Register  */
+  __IOM uint32_t   IFS;                /**< Interrupt Flag Set Register  */
+  __IOM uint32_t   IFC;                /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t   IEN;                /**< Interrupt Enable Register  */
+  __IOM uint32_t   ROUTE;              /**< I/O Routing Register  */
 
-  uint32_t         RESERVED0[61433];  /**< Reserved for future use **/
-  __IOM uint32_t   GOTGCTL;           /**< OTG Control and Status Register  */
-  __IOM uint32_t   GOTGINT;           /**< OTG Interrupt Register  */
-  __IOM uint32_t   GAHBCFG;           /**< AHB Configuration Register  */
-  __IOM uint32_t   GUSBCFG;           /**< USB Configuration Register  */
-  __IOM uint32_t   GRSTCTL;           /**< Reset Register  */
-  __IOM uint32_t   GINTSTS;           /**< Interrupt Register  */
-  __IOM uint32_t   GINTMSK;           /**< Interrupt Mask Register  */
-  __IM uint32_t    GRXSTSR;           /**< Receive Status Debug Read Register  */
-  __IM uint32_t    GRXSTSP;           /**< Receive Status Read and Pop Register  */
-  __IOM uint32_t   GRXFSIZ;           /**< Receive FIFO Size Register  */
-  __IOM uint32_t   GNPTXFSIZ;         /**< Non-periodic Transmit FIFO Size Register  */
-  __IM uint32_t    GNPTXSTS;          /**< Non-periodic Transmit FIFO/Queue Status Register  */
-  uint32_t         RESERVED1[11];     /**< Reserved for future use **/
-  __IOM uint32_t   GDFIFOCFG;         /**< Global DFIFO Configuration Register  */
+  uint32_t         RESERVED0[61433U];  /**< Reserved for future use **/
+  __IOM uint32_t   GOTGCTL;            /**< OTG Control and Status Register  */
+  __IOM uint32_t   GOTGINT;            /**< OTG Interrupt Register  */
+  __IOM uint32_t   GAHBCFG;            /**< AHB Configuration Register  */
+  __IOM uint32_t   GUSBCFG;            /**< USB Configuration Register  */
+  __IOM uint32_t   GRSTCTL;            /**< Reset Register  */
+  __IOM uint32_t   GINTSTS;            /**< Interrupt Register  */
+  __IOM uint32_t   GINTMSK;            /**< Interrupt Mask Register  */
+  __IM uint32_t    GRXSTSR;            /**< Receive Status Debug Read Register  */
+  __IM uint32_t    GRXSTSP;            /**< Receive Status Read and Pop Register  */
+  __IOM uint32_t   GRXFSIZ;            /**< Receive FIFO Size Register  */
+  __IOM uint32_t   GNPTXFSIZ;          /**< Non-periodic Transmit FIFO Size Register  */
+  __IM uint32_t    GNPTXSTS;           /**< Non-periodic Transmit FIFO/Queue Status Register  */
+  uint32_t         RESERVED1[11U];     /**< Reserved for future use **/
+  __IOM uint32_t   GDFIFOCFG;          /**< Global DFIFO Configuration Register  */
 
-  uint32_t         RESERVED2[40];     /**< Reserved for future use **/
-  __IOM uint32_t   HPTXFSIZ;          /**< Host Periodic Transmit FIFO Size Register  */
-  __IOM uint32_t   DIEPTXF1;          /**< Device IN Endpoint Transmit FIFO 1 Size Register  */
-  __IOM uint32_t   DIEPTXF2;          /**< Device IN Endpoint Transmit FIFO 2 Size Register  */
-  __IOM uint32_t   DIEPTXF3;          /**< Device IN Endpoint Transmit FIFO 3 Size Register  */
-  __IOM uint32_t   DIEPTXF4;          /**< Device IN Endpoint Transmit FIFO 4 Size Register  */
-  __IOM uint32_t   DIEPTXF5;          /**< Device IN Endpoint Transmit FIFO 5 Size Register  */
-  __IOM uint32_t   DIEPTXF6;          /**< Device IN Endpoint Transmit FIFO 6 Size Register  */
+  uint32_t         RESERVED2[40U];     /**< Reserved for future use **/
+  __IOM uint32_t   HPTXFSIZ;           /**< Host Periodic Transmit FIFO Size Register  */
+  __IOM uint32_t   DIEPTXF1;           /**< Device IN Endpoint Transmit FIFO 1 Size Register  */
+  __IOM uint32_t   DIEPTXF2;           /**< Device IN Endpoint Transmit FIFO 2 Size Register  */
+  __IOM uint32_t   DIEPTXF3;           /**< Device IN Endpoint Transmit FIFO 3 Size Register  */
+  __IOM uint32_t   DIEPTXF4;           /**< Device IN Endpoint Transmit FIFO 4 Size Register  */
+  __IOM uint32_t   DIEPTXF5;           /**< Device IN Endpoint Transmit FIFO 5 Size Register  */
+  __IOM uint32_t   DIEPTXF6;           /**< Device IN Endpoint Transmit FIFO 6 Size Register  */
 
-  uint32_t         RESERVED3[185];    /**< Reserved for future use **/
-  __IOM uint32_t   HCFG;              /**< Host Configuration Register  */
-  __IOM uint32_t   HFIR;              /**< Host Frame Interval Register  */
-  __IM uint32_t    HFNUM;             /**< Host Frame Number/Frame Time Remaining Register  */
-  uint32_t         RESERVED4[1];      /**< Reserved for future use **/
-  __IM uint32_t    HPTXSTS;           /**< Host Periodic Transmit FIFO/Queue Status Register  */
-  __IM uint32_t    HAINT;             /**< Host All Channels Interrupt Register  */
-  __IOM uint32_t   HAINTMSK;          /**< Host All Channels Interrupt Mask Register  */
-  uint32_t         RESERVED5[9];      /**< Reserved for future use **/
-  __IOM uint32_t   HPRT;              /**< Host Port Control and Status Register  */
+  uint32_t         RESERVED3[185U];    /**< Reserved for future use **/
+  __IOM uint32_t   HCFG;               /**< Host Configuration Register  */
+  __IOM uint32_t   HFIR;               /**< Host Frame Interval Register  */
+  __IM uint32_t    HFNUM;              /**< Host Frame Number/Frame Time Remaining Register  */
+  uint32_t         RESERVED4[1U];      /**< Reserved for future use **/
+  __IM uint32_t    HPTXSTS;            /**< Host Periodic Transmit FIFO/Queue Status Register  */
+  __IM uint32_t    HAINT;              /**< Host All Channels Interrupt Register  */
+  __IOM uint32_t   HAINTMSK;           /**< Host All Channels Interrupt Mask Register  */
+  uint32_t         RESERVED5[9U];      /**< Reserved for future use **/
+  __IOM uint32_t   HPRT;               /**< Host Port Control and Status Register  */
 
-  uint32_t         RESERVED6[47];     /**< Reserved registers */
-  USB_HC_TypeDef   HC[14];            /**< Host Channel Registers */
+  uint32_t         RESERVED6[47U];     /**< Reserved registers */
+  USB_HC_TypeDef   HC[14U];            /**< Host Channel Registers */
 
-  uint32_t         RESERVED7[80];     /**< Reserved for future use **/
-  __IOM uint32_t   DCFG;              /**< Device Configuration Register  */
-  __IOM uint32_t   DCTL;              /**< Device Control Register  */
-  __IM uint32_t    DSTS;              /**< Device Status Register  */
-  uint32_t         RESERVED8[1];      /**< Reserved for future use **/
-  __IOM uint32_t   DIEPMSK;           /**< Device IN Endpoint Common Interrupt Mask Register  */
-  __IOM uint32_t   DOEPMSK;           /**< Device OUT Endpoint Common Interrupt Mask Register  */
-  __IM uint32_t    DAINT;             /**< Device All Endpoints Interrupt Register  */
-  __IOM uint32_t   DAINTMSK;          /**< Device All Endpoints Interrupt Mask Register  */
-  uint32_t         RESERVED9[2];      /**< Reserved for future use **/
-  __IOM uint32_t   DVBUSDIS;          /**< Device VBUS Discharge Time Register  */
-  __IOM uint32_t   DVBUSPULSE;        /**< Device VBUS Pulsing Time Register  */
+  uint32_t         RESERVED7[80U];     /**< Reserved for future use **/
+  __IOM uint32_t   DCFG;               /**< Device Configuration Register  */
+  __IOM uint32_t   DCTL;               /**< Device Control Register  */
+  __IM uint32_t    DSTS;               /**< Device Status Register  */
+  uint32_t         RESERVED8[1U];      /**< Reserved for future use **/
+  __IOM uint32_t   DIEPMSK;            /**< Device IN Endpoint Common Interrupt Mask Register  */
+  __IOM uint32_t   DOEPMSK;            /**< Device OUT Endpoint Common Interrupt Mask Register  */
+  __IM uint32_t    DAINT;              /**< Device All Endpoints Interrupt Register  */
+  __IOM uint32_t   DAINTMSK;           /**< Device All Endpoints Interrupt Mask Register  */
+  uint32_t         RESERVED9[2U];      /**< Reserved for future use **/
+  __IOM uint32_t   DVBUSDIS;           /**< Device VBUS Discharge Time Register  */
+  __IOM uint32_t   DVBUSPULSE;         /**< Device VBUS Pulsing Time Register  */
 
-  uint32_t         RESERVED10[1];     /**< Reserved for future use **/
-  __IOM uint32_t   DIEPEMPMSK;        /**< Device IN Endpoint FIFO Empty Interrupt Mask Register  */
+  uint32_t         RESERVED10[1U];     /**< Reserved for future use **/
+  __IOM uint32_t   DIEPEMPMSK;         /**< Device IN Endpoint FIFO Empty Interrupt Mask Register  */
 
-  uint32_t         RESERVED11[50];    /**< Reserved for future use **/
-  __IOM uint32_t   DIEP0CTL;          /**< Device IN Endpoint 0 Control Register  */
-  uint32_t         RESERVED12[1];     /**< Reserved for future use **/
-  __IOM uint32_t   DIEP0INT;          /**< Device IN Endpoint 0 Interrupt Register  */
-  uint32_t         RESERVED13[1];     /**< Reserved for future use **/
-  __IOM uint32_t   DIEP0TSIZ;         /**< Device IN Endpoint 0 Transfer Size Register  */
-  __IOM uint32_t   DIEP0DMAADDR;      /**< Device IN Endpoint 0 DMA Address Register  */
-  __IM uint32_t    DIEP0TXFSTS;       /**< Device IN Endpoint 0 Transmit FIFO Status Register  */
+  uint32_t         RESERVED11[50U];    /**< Reserved for future use **/
+  __IOM uint32_t   DIEP0CTL;           /**< Device IN Endpoint 0 Control Register  */
+  uint32_t         RESERVED12[1U];     /**< Reserved for future use **/
+  __IOM uint32_t   DIEP0INT;           /**< Device IN Endpoint 0 Interrupt Register  */
+  uint32_t         RESERVED13[1U];     /**< Reserved for future use **/
+  __IOM uint32_t   DIEP0TSIZ;          /**< Device IN Endpoint 0 Transfer Size Register  */
+  __IOM uint32_t   DIEP0DMAADDR;       /**< Device IN Endpoint 0 DMA Address Register  */
+  __IM uint32_t    DIEP0TXFSTS;        /**< Device IN Endpoint 0 Transmit FIFO Status Register  */
 
-  uint32_t         RESERVED14[1];     /**< Reserved registers */
-  USB_DIEP_TypeDef DIEP[6];           /**< Device IN Endpoint x+1 Registers */
+  uint32_t         RESERVED14[1U];     /**< Reserved registers */
+  USB_DIEP_TypeDef DIEP[6U];           /**< Device IN Endpoint x+1 Registers */
 
-  uint32_t         RESERVED15[72];    /**< Reserved for future use **/
-  __IOM uint32_t   DOEP0CTL;          /**< Device OUT Endpoint 0 Control Register  */
-  uint32_t         RESERVED16[1];     /**< Reserved for future use **/
-  __IOM uint32_t   DOEP0INT;          /**< Device OUT Endpoint 0 Interrupt Register  */
-  uint32_t         RESERVED17[1];     /**< Reserved for future use **/
-  __IOM uint32_t   DOEP0TSIZ;         /**< Device OUT Endpoint 0 Transfer Size Register  */
-  __IOM uint32_t   DOEP0DMAADDR;      /**< Device OUT Endpoint 0 DMA Address Register  */
+  uint32_t         RESERVED15[72U];    /**< Reserved for future use **/
+  __IOM uint32_t   DOEP0CTL;           /**< Device OUT Endpoint 0 Control Register  */
+  uint32_t         RESERVED16[1U];     /**< Reserved for future use **/
+  __IOM uint32_t   DOEP0INT;           /**< Device OUT Endpoint 0 Interrupt Register  */
+  uint32_t         RESERVED17[1U];     /**< Reserved for future use **/
+  __IOM uint32_t   DOEP0TSIZ;          /**< Device OUT Endpoint 0 Transfer Size Register  */
+  __IOM uint32_t   DOEP0DMAADDR;       /**< Device OUT Endpoint 0 DMA Address Register  */
 
-  uint32_t         RESERVED18[2];     /**< Reserved registers */
-  USB_DOEP_TypeDef DOEP[6];           /**< Device OUT Endpoint x+1 Registers */
+  uint32_t         RESERVED18[2U];     /**< Reserved registers */
+  USB_DOEP_TypeDef DOEP[6U];           /**< Device OUT Endpoint x+1 Registers */
 
-  uint32_t         RESERVED19[136];   /**< Reserved for future use **/
-  __IOM uint32_t   PCGCCTL;           /**< Power and Clock Gating Control Register  */
+  uint32_t         RESERVED19[136U];   /**< Reserved for future use **/
+  __IOM uint32_t   PCGCCTL;            /**< Power and Clock Gating Control Register  */
 
-  uint32_t         RESERVED20[127];   /**< Reserved registers */
-  __IOM uint32_t   FIFO0D[512];       /**< Device EP 0/Host Channel 0 FIFO  */
+  uint32_t         RESERVED20[127U];   /**< Reserved registers */
+  __IOM uint32_t   FIFO0D[512U];       /**< Device EP 0/Host Channel 0 FIFO  */
 
-  uint32_t         RESERVED21[512];   /**< Reserved registers */
-  __IOM uint32_t   FIFO1D[512];       /**< Device EP 1/Host Channel 1 FIFO  */
+  uint32_t         RESERVED21[512U];   /**< Reserved registers */
+  __IOM uint32_t   FIFO1D[512U];       /**< Device EP 1/Host Channel 1 FIFO  */
 
-  uint32_t         RESERVED22[512];   /**< Reserved registers */
-  __IOM uint32_t   FIFO2D[512];       /**< Device EP 2/Host Channel 2 FIFO  */
+  uint32_t         RESERVED22[512U];   /**< Reserved registers */
+  __IOM uint32_t   FIFO2D[512U];       /**< Device EP 2/Host Channel 2 FIFO  */
 
-  uint32_t         RESERVED23[512];   /**< Reserved registers */
-  __IOM uint32_t   FIFO3D[512];       /**< Device EP 3/Host Channel 3 FIFO  */
+  uint32_t         RESERVED23[512U];   /**< Reserved registers */
+  __IOM uint32_t   FIFO3D[512U];       /**< Device EP 3/Host Channel 3 FIFO  */
 
-  uint32_t         RESERVED24[512];   /**< Reserved registers */
-  __IOM uint32_t   FIFO4D[512];       /**< Device EP 4/Host Channel 4 FIFO  */
+  uint32_t         RESERVED24[512U];   /**< Reserved registers */
+  __IOM uint32_t   FIFO4D[512U];       /**< Device EP 4/Host Channel 4 FIFO  */
 
-  uint32_t         RESERVED25[512];   /**< Reserved registers */
-  __IOM uint32_t   FIFO5D[512];       /**< Device EP 5/Host Channel 5 FIFO  */
+  uint32_t         RESERVED25[512U];   /**< Reserved registers */
+  __IOM uint32_t   FIFO5D[512U];       /**< Device EP 5/Host Channel 5 FIFO  */
 
-  uint32_t         RESERVED26[512];   /**< Reserved registers */
-  __IOM uint32_t   FIFO6D[512];       /**< Device EP 6/Host Channel 6 FIFO  */
+  uint32_t         RESERVED26[512U];   /**< Reserved registers */
+  __IOM uint32_t   FIFO6D[512U];       /**< Device EP 6/Host Channel 6 FIFO  */
 
-  uint32_t         RESERVED27[512];   /**< Reserved registers */
-  __IOM uint32_t   FIFO7D[512];       /**< Host Channel 7 FIFO  */
+  uint32_t         RESERVED27[512U];   /**< Reserved registers */
+  __IOM uint32_t   FIFO7D[512U];       /**< Host Channel 7 FIFO  */
 
-  uint32_t         RESERVED28[512];   /**< Reserved registers */
-  __IOM uint32_t   FIFO8D[512];       /**< Host Channel 8 FIFO  */
+  uint32_t         RESERVED28[512U];   /**< Reserved registers */
+  __IOM uint32_t   FIFO8D[512U];       /**< Host Channel 8 FIFO  */
 
-  uint32_t         RESERVED29[512];   /**< Reserved registers */
-  __IOM uint32_t   FIFO9D[512];       /**< Host Channel 9 FIFO  */
+  uint32_t         RESERVED29[512U];   /**< Reserved registers */
+  __IOM uint32_t   FIFO9D[512U];       /**< Host Channel 9 FIFO  */
 
-  uint32_t         RESERVED30[512];   /**< Reserved registers */
-  __IOM uint32_t   FIFO10D[512];      /**< Host Channel 10 FIFO  */
+  uint32_t         RESERVED30[512U];   /**< Reserved registers */
+  __IOM uint32_t   FIFO10D[512U];      /**< Host Channel 10 FIFO  */
 
-  uint32_t         RESERVED31[512];   /**< Reserved registers */
-  __IOM uint32_t   FIFO11D[512];      /**< Host Channel 11 FIFO  */
+  uint32_t         RESERVED31[512U];   /**< Reserved registers */
+  __IOM uint32_t   FIFO11D[512U];      /**< Host Channel 11 FIFO  */
 
-  uint32_t         RESERVED32[512];   /**< Reserved registers */
-  __IOM uint32_t   FIFO12D[512];      /**< Host Channel 12 FIFO  */
+  uint32_t         RESERVED32[512U];   /**< Reserved registers */
+  __IOM uint32_t   FIFO12D[512U];      /**< Host Channel 12 FIFO  */
 
-  uint32_t         RESERVED33[512];   /**< Reserved registers */
-  __IOM uint32_t   FIFO13D[512];      /**< Host Channel 13 FIFO  */
+  uint32_t         RESERVED33[512U];   /**< Reserved registers */
+  __IOM uint32_t   FIFO13D[512U];      /**< Host Channel 13 FIFO  */
 
-  uint32_t         RESERVED34[17920]; /**< Reserved registers */
-  __IOM uint32_t   FIFORAM[512];      /**< Direct Access to Data FIFO RAM for Debugging (2 KB)  */
-} USB_TypeDef;                        /**< USB Register Declaration *//** @} */
+  uint32_t         RESERVED34[17920U]; /**< Reserved registers */
+  __IOM uint32_t   FIFORAM[512U];      /**< Direct Access to Data FIFO RAM for Debugging (2 KB)  */
+} USB_TypeDef;                         /**< USB Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32GG_USB_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for USB CTRL */
 #define _USB_CTRL_RESETVALUE                       0x00000000UL                           /**< Default value for USB_CTRL */

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_usb_diep.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_usb_diep.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32gg_usb_diep.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32GG_USB_DIEP register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,22 +40,22 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief USB_DIEP EFM32GG USB DIEP
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IOM uint32_t CTL;          /**< Device IN Endpoint x+1 Control Register  */
-  uint32_t       RESERVED0[1]; /**< Reserved for future use **/
-  __IOM uint32_t INT;          /**< Device IN Endpoint x+1 Interrupt Register  */
-  uint32_t       RESERVED1[1]; /**< Reserved for future use **/
-  __IOM uint32_t TSIZ;         /**< Device IN Endpoint x+1 Transfer Size Register  */
-  __IOM uint32_t DMAADDR;      /**< Device IN Endpoint x+1 DMA Address Register  */
-  __IM uint32_t  TXFSTS;       /**< Device IN Endpoint x+1 Transmit FIFO Status Register  */
-  uint32_t       RESERVED2[1]; /**< Reserved future */
+  __IOM uint32_t CTL;           /**< Device IN Endpoint x+1 Control Register  */
+  uint32_t       RESERVED0[1U]; /**< Reserved for future use **/
+  __IOM uint32_t INT;           /**< Device IN Endpoint x+1 Interrupt Register  */
+  uint32_t       RESERVED1[1U]; /**< Reserved for future use **/
+  __IOM uint32_t TSIZ;          /**< Device IN Endpoint x+1 Transfer Size Register  */
+  __IOM uint32_t DMAADDR;       /**< Device IN Endpoint x+1 DMA Address Register  */
+  __IM uint32_t  TXFSTS;        /**< Device IN Endpoint x+1 Transmit FIFO Status Register  */
+  uint32_t       RESERVED2[1U]; /**< Reserved future */
 } USB_DIEP_TypeDef;
 
 /** @} End of group Parts */

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_usb_doep.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_usb_doep.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32gg_usb_doep.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32GG_USB_DOEP register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,21 +40,21 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief USB_DOEP EFM32GG USB DOEP
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IOM uint32_t CTL;          /**< Device OUT Endpoint x+1 Control Register  */
-  uint32_t       RESERVED0[1]; /**< Reserved for future use **/
-  __IOM uint32_t INT;          /**< Device OUT Endpoint x+1 Interrupt Register  */
-  uint32_t       RESERVED1[1]; /**< Reserved for future use **/
-  __IOM uint32_t TSIZ;         /**< Device OUT Endpoint x+1 Transfer Size Register  */
-  __IOM uint32_t DMAADDR;      /**< Device OUT Endpoint x+1 DMA Address Register  */
-  uint32_t       RESERVED2[2]; /**< Reserved future */
+  __IOM uint32_t CTL;           /**< Device OUT Endpoint x+1 Control Register  */
+  uint32_t       RESERVED0[1U]; /**< Reserved for future use **/
+  __IOM uint32_t INT;           /**< Device OUT Endpoint x+1 Interrupt Register  */
+  uint32_t       RESERVED1[1U]; /**< Reserved for future use **/
+  __IOM uint32_t TSIZ;          /**< Device OUT Endpoint x+1 Transfer Size Register  */
+  __IOM uint32_t DMAADDR;       /**< Device OUT Endpoint x+1 DMA Address Register  */
+  uint32_t       RESERVED2[2U]; /**< Reserved future */
 } USB_DOEP_TypeDef;
 
 /** @} End of group Parts */

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_usb_hc.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_usb_hc.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32gg_usb_hc.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32GG_USB_HC register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,21 +40,21 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief USB_HC EFM32GG USB HC
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IOM uint32_t CHAR;         /**< Host Channel x Characteristics Register  */
-  uint32_t       RESERVED0[1]; /**< Reserved for future use **/
-  __IOM uint32_t INT;          /**< Host Channel x Interrupt Register  */
-  __IOM uint32_t INTMSK;       /**< Host Channel x Interrupt Mask Register  */
-  __IOM uint32_t TSIZ;         /**< Host Channel x Transfer Size Register  */
-  __IOM uint32_t DMAADDR;      /**< Host Channel x DMA Address Register  */
-  uint32_t       RESERVED1[2]; /**< Reserved future */
+  __IOM uint32_t CHAR;          /**< Host Channel x Characteristics Register  */
+  uint32_t       RESERVED0[1U]; /**< Reserved for future use **/
+  __IOM uint32_t INT;           /**< Host Channel x Interrupt Register  */
+  __IOM uint32_t INTMSK;        /**< Host Channel x Interrupt Mask Register  */
+  __IOM uint32_t TSIZ;          /**< Host Channel x Transfer Size Register  */
+  __IOM uint32_t DMAADDR;       /**< Host Channel x DMA Address Register  */
+  uint32_t       RESERVED1[2U]; /**< Reserved future */
 } USB_HC_TypeDef;
 
 /** @} End of group Parts */

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_vcmp.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_vcmp.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32gg_vcmp.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32GG_VCMP register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32GG_VCMP
  * @{
  * @brief EFM32GG_VCMP Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t CTRL;     /**< Control Register  */
   __IOM uint32_t INPUTSEL; /**< Input Selection Register  */
@@ -60,10 +59,10 @@ typedef struct {
   __IOM uint32_t IFC;      /**< Interrupt Flag Clear Register  */
 } VCMP_TypeDef;            /**< VCMP Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32GG_VCMP_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for VCMP CTRL */
 #define _VCMP_CTRL_RESETVALUE               0x47000000UL                         /**< Default value for VCMP_CTRL */

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_wdog.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_wdog.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32gg_wdog.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32GG_WDOG register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32GG_WDOG
  * @{
  * @brief EFM32GG_WDOG Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t CTRL;     /**< Control Register  */
   __IOM uint32_t CMD;      /**< Command Register  */
@@ -57,10 +56,10 @@ typedef struct {
   __IM uint32_t  SYNCBUSY; /**< Synchronization Busy Register  */
 } WDOG_TypeDef;            /**< WDOG Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32GG_WDOG_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for WDOG CTRL */
 #define _WDOG_CTRL_RESETVALUE            0x00000F00UL                         /**< Default value for WDOG_CTRL */

--- a/cpu/efm32/families/efm32gg/include/vendor/em_device.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/em_device.h
@@ -1,5 +1,5 @@
-/**************************************************************************//**
- * @file em_device.h
+/***************************************************************************//**
+ * @file
  * @brief CMSIS Cortex-M Peripheral Access Layer for Silicon Laboratories
  *        microcontroller devices
  *
@@ -9,37 +9,35 @@
  * @verbatim
  * Example: Add "-DEFM32G890F128" to your build options, to define part
  *          Add "#include "em_device.h" to your source files
-
- *
  * @endverbatim
- * @version 5.4.0
- ******************************************************************************
+ *
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {

--- a/cpu/efm32/families/efm32gg/include/vendor/system_efm32gg.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/system_efm32gg.h
@@ -1,34 +1,33 @@
 /***************************************************************************//**
- * @file system_efm32gg.h
+ * @file
  * @brief CMSIS Cortex-M3 System Layer for EFM32GG devices.
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifndef SYSTEM_EFM32GG_H
 #define SYSTEM_EFM32GG_H
@@ -39,14 +38,14 @@ extern "C" {
 
 #include <stdint.h>
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup Parts
  * @{
- *****************************************************************************/
-/**************************************************************************//**
+ ******************************************************************************/
+/***************************************************************************//**
  * @addtogroup EFM32GG EFM32GG
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /*******************************************************************************
  **************************   GLOBAL VARIABLES   *******************************
@@ -113,7 +112,7 @@ void EMU_IRQHandler(void);          /**< EMU IRQ Handler */
 uint32_t SystemCoreClockGet(void);
 uint32_t SystemMaxCoreClockGet(void);
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @brief
  *   Update CMSIS SystemCoreClock variable.
  *
@@ -126,7 +125,7 @@ uint32_t SystemMaxCoreClockGet(void);
  *   API, this variable will be kept updated. This function is only provided
  *   for CMSIS compliance and if a user modifies the the core clock outside
  *   the CMU API.
- *****************************************************************************/
+ ******************************************************************************/
 static __INLINE void SystemCoreClockUpdate(void)
 {
   (void)SystemCoreClockGet();

--- a/cpu/efm32/families/efm32gg/system.c
+++ b/cpu/efm32/families/efm32gg/system.c
@@ -1,34 +1,33 @@
 /***************************************************************************//**
- * @file system_efm32gg.c
+ * @file
  * @brief CMSIS Cortex-M3 System Layer for EFM32GG devices.
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #include <stdint.h>
 #include "em_device.h"
@@ -63,7 +62,7 @@
 #define EFM32_HFRCO_MAX_FREQ (28000000UL)
 
 /* Do not define variable if HF crystal oscillator not present */
-#if (EFM32_HFXO_FREQ > 0)
+#if (EFM32_HFXO_FREQ > 0U)
 /** @cond DO_NOT_INCLUDE_WITH_DOXYGEN */
 /** System HFXO clock. */
 static uint32_t SystemHFXOClock = EFM32_HFXO_FREQ;
@@ -76,7 +75,7 @@ static uint32_t SystemHFXOClock = EFM32_HFXO_FREQ;
 #endif
 
 /* Do not define variable if LF crystal oscillator not present */
-#if (EFM32_LFXO_FREQ > 0)
+#if (EFM32_LFXO_FREQ > 0U)
 /** @cond DO_NOT_INCLUDE_WITH_DOXYGEN */
 /** System LFXO clock. */
 static uint32_t SystemLFXOClock = EFM32_LFXO_FREQ;
@@ -106,6 +105,13 @@ uint32_t SystemCoreClock = 14000000UL;
 /*******************************************************************************
  **************************   GLOBAL FUNCTIONS   *******************************
  ******************************************************************************/
+
+#if defined(__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+#if defined(__ICCARM__)    /* IAR requires the __vector_table symbol */
+#define __Vectors    __vector_table
+#endif
+extern uint32_t __Vectors;
+#endif
 
 /***************************************************************************//**
  * @brief
@@ -174,12 +180,12 @@ uint32_t SystemHFClockGet(void)
   switch (CMU->STATUS & (CMU_STATUS_HFRCOSEL | CMU_STATUS_HFXOSEL
                          | CMU_STATUS_LFRCOSEL | CMU_STATUS_LFXOSEL)) {
     case CMU_STATUS_LFXOSEL:
-#if (EFM32_LFXO_FREQ > 0)
+#if (EFM32_LFXO_FREQ > 0U)
       ret = SystemLFXOClock;
 #else
       /* We should not get here, since core should not be clocked. May */
       /* be caused by a misconfiguration though. */
-      ret = 0;
+      ret = 0U;
 #endif
       break;
 
@@ -188,12 +194,12 @@ uint32_t SystemHFClockGet(void)
       break;
 
     case CMU_STATUS_HFXOSEL:
-#if (EFM32_HFXO_FREQ > 0)
+#if (EFM32_HFXO_FREQ > 0U)
       ret = SystemHFXOClock;
 #else
       /* We should not get here, since core should not be clocked. May */
       /* be caused by a misconfiguration though. */
-      ret = 0;
+      ret = 0U;
 #endif
       break;
 
@@ -232,7 +238,7 @@ uint32_t SystemHFClockGet(void)
           break;
 
         default:
-          ret = 0;
+          ret = 0U;
           break;
       }
       break;
@@ -242,7 +248,7 @@ uint32_t SystemHFClockGet(void)
                       >> _CMU_CTRL_HFCLKDIV_SHIFT));
 }
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @brief
  *   Get high frequency crystal oscillator clock frequency for target system.
  *
@@ -251,18 +257,18 @@ uint32_t SystemHFClockGet(void)
  *
  * @return
  *   HFXO frequency in Hz.
- *****************************************************************************/
+ ******************************************************************************/
 uint32_t SystemHFXOClockGet(void)
 {
   /* External crystal oscillator present? */
-#if (EFM32_HFXO_FREQ > 0)
+#if (EFM32_HFXO_FREQ > 0U)
   return SystemHFXOClock;
 #else
-  return 0;
+  return 0U;
 #endif
 }
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @brief
  *   Set high frequency crystal oscillator clock frequency for target system.
  *
@@ -276,11 +282,11 @@ uint32_t SystemHFXOClockGet(void)
  *
  * @param[in] freq
  *   HFXO frequency in Hz used for target.
- *****************************************************************************/
+ ******************************************************************************/
 void SystemHFXOClockSet(uint32_t freq)
 {
   /* External crystal oscillator present? */
-#if (EFM32_HFXO_FREQ > 0)
+#if (EFM32_HFXO_FREQ > 0U)
   SystemHFXOClock = freq;
 
   /* Update core clock frequency if HFXO is used to clock core */
@@ -293,7 +299,7 @@ void SystemHFXOClockSet(uint32_t freq)
 #endif
 }
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @brief
  *   Initialize the system.
  *
@@ -304,12 +310,19 @@ void SystemHFXOClockSet(uint32_t freq)
  *   This function is invoked during system init, before the main() routine
  *   and any data has been initialized. For this reason, it cannot do any
  *   initialization of variables etc.
- *****************************************************************************/
+ ******************************************************************************/
 void SystemInit(void)
 {
+#if defined(__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  SCB->VTOR = (uint32_t)&__Vectors;
+#endif
+
+#if defined(UNALIGNED_SUPPORT_DISABLE)
+  SCB->CCR |= SCB_CCR_UNALIGN_TRP_Msk;
+#endif
 }
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @brief
  *   Get low frequency RC oscillator clock frequency for target system.
  *
@@ -318,7 +331,7 @@ void SystemInit(void)
  *
  * @return
  *   LFRCO frequency in Hz.
- *****************************************************************************/
+ ******************************************************************************/
 uint32_t SystemLFRCOClockGet(void)
 {
   /* Currently we assume that this frequency is properly tuned during */
@@ -327,7 +340,7 @@ uint32_t SystemLFRCOClockGet(void)
   return EFM32_LFRCO_FREQ;
 }
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @brief
  *   Get ultra low frequency RC oscillator clock frequency for target system.
  *
@@ -336,14 +349,14 @@ uint32_t SystemLFRCOClockGet(void)
  *
  * @return
  *   ULFRCO frequency in Hz.
- *****************************************************************************/
+ ******************************************************************************/
 uint32_t SystemULFRCOClockGet(void)
 {
   /* The ULFRCO frequency is not tuned, and can be very inaccurate */
   return EFM32_ULFRCO_FREQ;
 }
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @brief
  *   Get low frequency crystal oscillator clock frequency for target system.
  *
@@ -352,18 +365,18 @@ uint32_t SystemULFRCOClockGet(void)
  *
  * @return
  *   LFXO frequency in Hz.
- *****************************************************************************/
+ ******************************************************************************/
 uint32_t SystemLFXOClockGet(void)
 {
   /* External crystal oscillator present? */
-#if (EFM32_LFXO_FREQ > 0)
+#if (EFM32_LFXO_FREQ > 0U)
   return SystemLFXOClock;
 #else
-  return 0;
+  return 0U;
 #endif
 }
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @brief
  *   Set low frequency crystal oscillator clock frequency for target system.
  *
@@ -377,11 +390,11 @@ uint32_t SystemLFXOClockGet(void)
  *
  * @param[in] freq
  *   LFXO frequency in Hz used for target.
- *****************************************************************************/
+ ******************************************************************************/
 void SystemLFXOClockSet(uint32_t freq)
 {
   /* External crystal oscillator present? */
-#if (EFM32_LFXO_FREQ > 0)
+#if (EFM32_LFXO_FREQ > 0U)
   SystemLFXOClock = freq;
 
   /* Update core clock frequency if LFXO is used to clock core */

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg990f256.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg990f256.h
@@ -1,35 +1,34 @@
-/**************************************************************************//**
- * @file efm32lg990f256.h
+/***************************************************************************//**
+ * @file
  * @brief CMSIS Cortex-M Peripheral Access Layer Header File
  *        for EFM32LG990F256
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #if defined(__ICCARM__)
 #pragma system_include       /* Treat file as system include file. */
@@ -44,15 +43,15 @@
 extern "C" {
 #endif
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup Parts
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32LG990F256 EFM32LG990F256
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /** Interrupt Number Definition */
 typedef enum IRQn{
@@ -110,22 +109,22 @@ typedef enum IRQn{
   EMU_IRQn              = 38, /*!< 38 EFM32 EMU Interrupt */
 } IRQn_Type;
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32LG990F256_Core EFM32LG990F256 Core
  * @{
  * @brief Processor and Core Peripheral Section
- *****************************************************************************/
-#define __MPU_PRESENT             1 /**< Presence of MPU  */
-#define __VTOR_PRESENT            1 /**< Presence of VTOR register in SCB */
-#define __NVIC_PRIO_BITS          3 /**< NVIC interrupt priority bits */
-#define __Vendor_SysTickConfig    0 /**< Is 1 if different SysTick counter is used */
+ ******************************************************************************/
+#define __MPU_PRESENT             1U /**< Presence of MPU  */
+#define __VTOR_PRESENT            1U /**< Presence of VTOR register in SCB */
+#define __NVIC_PRIO_BITS          3U /**< NVIC interrupt priority bits */
+#define __Vendor_SysTickConfig    0U /**< Is 1 if different SysTick counter is used */
 
 /** @} End of group EFM32LG990F256_Core */
 
-/**************************************************************************//**
-* @defgroup EFM32LG990F256_Part EFM32LG990F256 Part
-* @{
-******************************************************************************/
+/***************************************************************************//**
+ * @defgroup EFM32LG990F256_Part EFM32LG990F256 Part
+ * @{
+ ******************************************************************************/
 
 /** Part family */
 #define _EFM32_GIANT_FAMILY                     1  /**< Giant/Leopard Gecko EFM32LG/GG MCU Family */
@@ -189,7 +188,7 @@ typedef enum IRQn{
 #define FLASH_PAGE_SIZE      2048U          /**< Flash Memory page size */
 #define SRAM_BASE            (0x20000000UL) /**< SRAM Base Address */
 #define SRAM_SIZE            (0x00008000UL) /**< Available SRAM Memory */
-#define __CM3_REV            0x201          /**< Cortex-M3 Core revision r2p1 */
+#define __CM3_REV            0x0201U        /**< Cortex-M3 Core revision r2p1 */
 #define PRS_CHAN_COUNT       12             /**< Number of PRS channels */
 #define DMA_CHAN_COUNT       12             /**< Number of DMA channels */
 #define EXT_IRQ_COUNT        40             /**< Number of External (NVIC) interrupts */
@@ -280,11 +279,11 @@ typedef enum IRQn{
 
 /** @} End of group EFM32LG990F256_Part */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32LG990F256_Peripheral_TypeDefs EFM32LG990F256 Peripheral TypeDefs
  * @{
  * @brief Device Specific Peripheral Register Structures
- *****************************************************************************/
+ ******************************************************************************/
 
 #include "efm32lg_dma_ch.h"
 #include "efm32lg_dma.h"
@@ -330,10 +329,10 @@ typedef enum IRQn{
 
 /** @} End of group EFM32LG990F256_Peripheral_TypeDefs */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32LG990F256_Peripheral_Base EFM32LG990F256 Peripheral Memory Map
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 #define DMA_BASE          (0x400C2000UL) /**< DMA base address  */
 #define AES_BASE          (0x400E0000UL) /**< AES base address  */
@@ -381,10 +380,10 @@ typedef enum IRQn{
 
 /** @} End of group EFM32LG990F256_Peripheral_Base */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32LG990F256_Peripheral_Declaration  EFM32LG990F256 Peripheral Declarations
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 #define DMA          ((DMA_TypeDef *) DMA_BASE)             /**< DMA base pointer */
 #define AES          ((AES_TypeDef *) AES_BASE)             /**< AES base pointer */
@@ -430,20 +429,20 @@ typedef enum IRQn{
 
 /** @} End of group EFM32LG990F256_Peripheral_Declaration */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32LG990F256_BitFields EFM32LG990F256 Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 #include "efm32lg_prs_signals.h"
 #include "efm32lg_dmareq.h"
 #include "efm32lg_dmactrl.h"
 #include "efm32lg_uart.h"
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32LG990F256_UNLOCK EFM32LG990F256 Unlock Codes
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 #define MSC_UNLOCK_CODE      0x1B71 /**< MSC unlock code */
 #define EMU_UNLOCK_CODE      0xADE8 /**< EMU unlock code */
 #define CMU_UNLOCK_CODE      0x580E /**< CMU unlock code */
@@ -455,17 +454,17 @@ typedef enum IRQn{
 
 /** @} End of group EFM32LG990F256_BitFields */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32LG990F256_Alternate_Function EFM32LG990F256 Alternate Function
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 #include "efm32lg_af_ports.h"
 #include "efm32lg_af_pins.h"
 
 /** @} End of group EFM32LG990F256_Alternate_Function */
 
-/**************************************************************************//**
+/***************************************************************************//**
  *  @brief Set the value of a bit field within a register.
  *
  *  @param REG
@@ -477,7 +476,7 @@ typedef enum IRQn{
  *  @param OFFSET
  *       The number of bits that the field is offset within the register.
  *       0 (zero) means LSB.
- *****************************************************************************/
+ ******************************************************************************/
 #define SET_BIT_FIELD(REG, MASK, VALUE, OFFSET) \
   REG = ((REG) &~(MASK)) | (((VALUE) << (OFFSET)) & (MASK));
 

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_acmp.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_acmp.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32lg_acmp.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32LG_ACMP register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32LG_ACMP
  * @{
  * @brief EFM32LG_ACMP Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t CTRL;     /**< Control Register  */
   __IOM uint32_t INPUTSEL; /**< Input Selection Register  */
@@ -61,10 +60,10 @@ typedef struct {
   __IOM uint32_t ROUTE;    /**< I/O Routing Register  */
 } ACMP_TypeDef;            /**< ACMP Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32LG_ACMP_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for ACMP CTRL */
 #define _ACMP_CTRL_RESETVALUE              0x47000000UL                         /**< Default value for ACMP_CTRL */

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_adc.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_adc.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32lg_adc.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32LG_ADC register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,39 +40,39 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32LG_ADC
  * @{
  * @brief EFM32LG_ADC Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IOM uint32_t CTRL;         /**< Control Register  */
-  __IOM uint32_t CMD;          /**< Command Register  */
-  __IM uint32_t  STATUS;       /**< Status Register  */
-  __IOM uint32_t SINGLECTRL;   /**< Single Sample Control Register  */
-  __IOM uint32_t SCANCTRL;     /**< Scan Control Register  */
-  __IOM uint32_t IEN;          /**< Interrupt Enable Register  */
-  __IM uint32_t  IF;           /**< Interrupt Flag Register  */
-  __IOM uint32_t IFS;          /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;          /**< Interrupt Flag Clear Register  */
-  __IM uint32_t  SINGLEDATA;   /**< Single Conversion Result Data  */
-  __IM uint32_t  SCANDATA;     /**< Scan Conversion Result Data  */
-  __IM uint32_t  SINGLEDATAP;  /**< Single Conversion Result Data Peek Register  */
-  __IM uint32_t  SCANDATAP;    /**< Scan Sequence Result Data Peek Register  */
-  __IOM uint32_t CAL;          /**< Calibration Register  */
+  __IOM uint32_t CTRL;          /**< Control Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IOM uint32_t SINGLECTRL;    /**< Single Sample Control Register  */
+  __IOM uint32_t SCANCTRL;      /**< Scan Control Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IM uint32_t  SINGLEDATA;    /**< Single Conversion Result Data  */
+  __IM uint32_t  SCANDATA;      /**< Scan Conversion Result Data  */
+  __IM uint32_t  SINGLEDATAP;   /**< Single Conversion Result Data Peek Register  */
+  __IM uint32_t  SCANDATAP;     /**< Scan Sequence Result Data Peek Register  */
+  __IOM uint32_t CAL;           /**< Calibration Register  */
 
-  uint32_t       RESERVED0[1]; /**< Reserved for future use **/
-  __IOM uint32_t BIASPROG;     /**< Bias Programming Register  */
-} ADC_TypeDef;                 /**< ADC Register Declaration *//** @} */
+  uint32_t       RESERVED0[1U]; /**< Reserved for future use **/
+  __IOM uint32_t BIASPROG;      /**< Bias Programming Register  */
+} ADC_TypeDef;                  /**< ADC Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32LG_ADC_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for ADC CTRL */
 #define _ADC_CTRL_RESETVALUE                    0x001F0000UL                                /**< Default value for ADC_CTRL */

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_aes.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_aes.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32lg_aes.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32LG_AES register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,40 +40,40 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32LG_AES
  * @{
  * @brief EFM32LG_AES Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IOM uint32_t CTRL;         /**< Control Register  */
-  __IOM uint32_t CMD;          /**< Command Register  */
-  __IM uint32_t  STATUS;       /**< Status Register  */
-  __IOM uint32_t IEN;          /**< Interrupt Enable Register  */
-  __IM uint32_t  IF;           /**< Interrupt Flag Register  */
-  __IOM uint32_t IFS;          /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;          /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t DATA;         /**< DATA Register  */
-  __IOM uint32_t XORDATA;      /**< XORDATA Register  */
-  uint32_t       RESERVED0[3]; /**< Reserved for future use **/
-  __IOM uint32_t KEYLA;        /**< KEY Low Register  */
-  __IOM uint32_t KEYLB;        /**< KEY Low Register  */
-  __IOM uint32_t KEYLC;        /**< KEY Low Register  */
-  __IOM uint32_t KEYLD;        /**< KEY Low Register  */
-  __IOM uint32_t KEYHA;        /**< KEY High Register  */
-  __IOM uint32_t KEYHB;        /**< KEY High Register  */
-  __IOM uint32_t KEYHC;        /**< KEY High Register  */
-  __IOM uint32_t KEYHD;        /**< KEY High Register  */
-} AES_TypeDef;                 /**< AES Register Declaration *//** @} */
+  __IOM uint32_t CTRL;          /**< Control Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t DATA;          /**< DATA Register  */
+  __IOM uint32_t XORDATA;       /**< XORDATA Register  */
+  uint32_t       RESERVED0[3U]; /**< Reserved for future use **/
+  __IOM uint32_t KEYLA;         /**< KEY Low Register  */
+  __IOM uint32_t KEYLB;         /**< KEY Low Register  */
+  __IOM uint32_t KEYLC;         /**< KEY Low Register  */
+  __IOM uint32_t KEYLD;         /**< KEY Low Register  */
+  __IOM uint32_t KEYHA;         /**< KEY High Register  */
+  __IOM uint32_t KEYHB;         /**< KEY High Register  */
+  __IOM uint32_t KEYHC;         /**< KEY High Register  */
+  __IOM uint32_t KEYHD;         /**< KEY High Register  */
+} AES_TypeDef;                  /**< AES Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32LG_AES_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for AES CTRL */
 #define _AES_CTRL_RESETVALUE            0x00000000UL                       /**< Default value for AES_CTRL */

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_af_pins.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_af_pins.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32lg_af_pins.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32LG_AF_PINS register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,14 +40,14 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32LG_AF_Pins
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 #define AF_USB_VBUSEN_PIN(i)        ((i) == 0 ? 5 :  -1)                                                                                             /**< Pin number for AF_USB_VBUSEN location number i */
 #define AF_USB_DMPU_PIN(i)          ((i) == 0 ? 2 :  -1)                                                                                             /**< Pin number for AF_USB_DMPU location number i */

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_af_ports.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_af_ports.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32lg_af_ports.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32LG_AF_PORTS register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,14 +40,14 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32LG_AF_Ports
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 #define AF_USB_VBUSEN_PORT(i)        ((i) == 0 ? 5 :  -1)                                                                                           /**< Port number for AF_USB_VBUSEN location number i */
 #define AF_USB_DMPU_PORT(i)          ((i) == 0 ? 3 :  -1)                                                                                           /**< Port number for AF_USB_DMPU location number i */

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_burtc.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_burtc.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32lg_burtc.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32LG_BURTC register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,42 +40,42 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32LG_BURTC
  * @{
  * @brief EFM32LG_BURTC Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IOM uint32_t    CTRL;          /**< Control Register  */
-  __IOM uint32_t    LPMODE;        /**< Low power mode configuration  */
-  __IM uint32_t     CNT;           /**< Counter Value Register  */
-  __IOM uint32_t    COMP0;         /**< Counter Compare Value  */
-  __IM uint32_t     TIMESTAMP;     /**< Backup mode timestamp  */
-  __IOM uint32_t    LFXOFDET;      /**< LFXO   */
-  __IM uint32_t     STATUS;        /**< Status Register  */
-  __IOM uint32_t    CMD;           /**< Command Register  */
-  __IOM uint32_t    POWERDOWN;     /**< Retention RAM power-down Register  */
-  __IOM uint32_t    LOCK;          /**< Configuration Lock Register  */
-  __IM uint32_t     IF;            /**< Interrupt Flag Register  */
-  __IOM uint32_t    IFS;           /**< Interrupt Flag Set Register  */
-  __IOM uint32_t    IFC;           /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t    IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t    CTRL;           /**< Control Register  */
+  __IOM uint32_t    LPMODE;         /**< Low power mode configuration  */
+  __IM uint32_t     CNT;            /**< Counter Value Register  */
+  __IOM uint32_t    COMP0;          /**< Counter Compare Value  */
+  __IM uint32_t     TIMESTAMP;      /**< Backup mode timestamp  */
+  __IOM uint32_t    LFXOFDET;       /**< LFXO   */
+  __IM uint32_t     STATUS;         /**< Status Register  */
+  __IOM uint32_t    CMD;            /**< Command Register  */
+  __IOM uint32_t    POWERDOWN;      /**< Retention RAM power-down Register  */
+  __IOM uint32_t    LOCK;           /**< Configuration Lock Register  */
+  __IM uint32_t     IF;             /**< Interrupt Flag Register  */
+  __IOM uint32_t    IFS;            /**< Interrupt Flag Set Register  */
+  __IOM uint32_t    IFC;            /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t    IEN;            /**< Interrupt Enable Register  */
 
-  __IOM uint32_t    FREEZE;        /**< Freeze Register  */
-  __IM uint32_t     SYNCBUSY;      /**< Synchronization Busy Register  */
+  __IOM uint32_t    FREEZE;         /**< Freeze Register  */
+  __IM uint32_t     SYNCBUSY;       /**< Synchronization Busy Register  */
 
-  uint32_t          RESERVED0[48]; /**< Reserved registers */
-  BURTC_RET_TypeDef RET[128];      /**< RetentionReg */
-} BURTC_TypeDef;                   /**< BURTC Register Declaration *//** @} */
+  uint32_t          RESERVED0[48U]; /**< Reserved registers */
+  BURTC_RET_TypeDef RET[128U];      /**< RetentionReg */
+} BURTC_TypeDef;                    /**< BURTC Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32LG_BURTC_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for BURTC CTRL */
 #define _BURTC_CTRL_RESETVALUE                0x00000008UL                           /**< Default value for BURTC_CTRL */

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_burtc_ret.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_burtc_ret.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32lg_burtc_ret.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32LG_BURTC_RET register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,13 +40,13 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief BURTC_RET EFM32LG BURTC RET
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t REG; /**< Retention Register  */
 } BURTC_RET_TypeDef;

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_calibrate.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_calibrate.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32lg_calibrate.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32LG_CALIBRATE register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,14 +40,14 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32LG_CALIBRATE
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 #define CALIBRATE_MAX_REGISTERS    50 /**< Max number of address/value pairs for calibration */
 
 typedef struct {

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_cmu.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_cmu.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32lg_cmu.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32LG_CMU register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,56 +40,56 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32LG_CMU
  * @{
  * @brief EFM32LG_CMU Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IOM uint32_t CTRL;         /**< CMU Control Register  */
-  __IOM uint32_t HFCORECLKDIV; /**< High Frequency Core Clock Division Register  */
-  __IOM uint32_t HFPERCLKDIV;  /**< High Frequency Peripheral Clock Division Register  */
-  __IOM uint32_t HFRCOCTRL;    /**< HFRCO Control Register  */
-  __IOM uint32_t LFRCOCTRL;    /**< LFRCO Control Register  */
-  __IOM uint32_t AUXHFRCOCTRL; /**< AUXHFRCO Control Register  */
-  __IOM uint32_t CALCTRL;      /**< Calibration Control Register  */
-  __IOM uint32_t CALCNT;       /**< Calibration Counter Register  */
-  __IOM uint32_t OSCENCMD;     /**< Oscillator Enable/Disable Command Register  */
-  __IOM uint32_t CMD;          /**< Command Register  */
-  __IOM uint32_t LFCLKSEL;     /**< Low Frequency Clock Select Register  */
-  __IM uint32_t  STATUS;       /**< Status Register  */
-  __IM uint32_t  IF;           /**< Interrupt Flag Register  */
-  __IOM uint32_t IFS;          /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;          /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t IEN;          /**< Interrupt Enable Register  */
-  __IOM uint32_t HFCORECLKEN0; /**< High Frequency Core Clock Enable Register 0  */
-  __IOM uint32_t HFPERCLKEN0;  /**< High Frequency Peripheral Clock Enable Register 0  */
-  uint32_t       RESERVED0[2]; /**< Reserved for future use **/
-  __IM uint32_t  SYNCBUSY;     /**< Synchronization Busy Register  */
-  __IOM uint32_t FREEZE;       /**< Freeze Register  */
-  __IOM uint32_t LFACLKEN0;    /**< Low Frequency A Clock Enable Register 0  (Async Reg)  */
-  uint32_t       RESERVED1[1]; /**< Reserved for future use **/
-  __IOM uint32_t LFBCLKEN0;    /**< Low Frequency B Clock Enable Register 0 (Async Reg)  */
+  __IOM uint32_t CTRL;          /**< CMU Control Register  */
+  __IOM uint32_t HFCORECLKDIV;  /**< High Frequency Core Clock Division Register  */
+  __IOM uint32_t HFPERCLKDIV;   /**< High Frequency Peripheral Clock Division Register  */
+  __IOM uint32_t HFRCOCTRL;     /**< HFRCO Control Register  */
+  __IOM uint32_t LFRCOCTRL;     /**< LFRCO Control Register  */
+  __IOM uint32_t AUXHFRCOCTRL;  /**< AUXHFRCO Control Register  */
+  __IOM uint32_t CALCTRL;       /**< Calibration Control Register  */
+  __IOM uint32_t CALCNT;        /**< Calibration Counter Register  */
+  __IOM uint32_t OSCENCMD;      /**< Oscillator Enable/Disable Command Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IOM uint32_t LFCLKSEL;      /**< Low Frequency Clock Select Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t HFCORECLKEN0;  /**< High Frequency Core Clock Enable Register 0  */
+  __IOM uint32_t HFPERCLKEN0;   /**< High Frequency Peripheral Clock Enable Register 0  */
+  uint32_t       RESERVED0[2U]; /**< Reserved for future use **/
+  __IM uint32_t  SYNCBUSY;      /**< Synchronization Busy Register  */
+  __IOM uint32_t FREEZE;        /**< Freeze Register  */
+  __IOM uint32_t LFACLKEN0;     /**< Low Frequency A Clock Enable Register 0  (Async Reg)  */
+  uint32_t       RESERVED1[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBCLKEN0;     /**< Low Frequency B Clock Enable Register 0 (Async Reg)  */
 
-  uint32_t       RESERVED2[1]; /**< Reserved for future use **/
-  __IOM uint32_t LFAPRESC0;    /**< Low Frequency A Prescaler Register 0 (Async Reg)  */
-  uint32_t       RESERVED3[1]; /**< Reserved for future use **/
-  __IOM uint32_t LFBPRESC0;    /**< Low Frequency B Prescaler Register 0  (Async Reg)  */
-  uint32_t       RESERVED4[1]; /**< Reserved for future use **/
-  __IOM uint32_t PCNTCTRL;     /**< PCNT Control Register  */
-  __IOM uint32_t LCDCTRL;      /**< LCD Control Register  */
-  __IOM uint32_t ROUTE;        /**< I/O Routing Register  */
-  __IOM uint32_t LOCK;         /**< Configuration Lock Register  */
-} CMU_TypeDef;                 /**< CMU Register Declaration *//** @} */
+  uint32_t       RESERVED2[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFAPRESC0;     /**< Low Frequency A Prescaler Register 0 (Async Reg)  */
+  uint32_t       RESERVED3[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBPRESC0;     /**< Low Frequency B Prescaler Register 0  (Async Reg)  */
+  uint32_t       RESERVED4[1U]; /**< Reserved for future use **/
+  __IOM uint32_t PCNTCTRL;      /**< PCNT Control Register  */
+  __IOM uint32_t LCDCTRL;       /**< LCD Control Register  */
+  __IOM uint32_t ROUTE;         /**< I/O Routing Register  */
+  __IOM uint32_t LOCK;          /**< Configuration Lock Register  */
+} CMU_TypeDef;                  /**< CMU Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32LG_CMU_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for CMU CTRL */
 #define _CMU_CTRL_RESETVALUE                        0x000C262CUL                                /**< Default value for CMU_CTRL */

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_dac.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_dac.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32lg_dac.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32LG_DAC register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,41 +40,41 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32LG_DAC
  * @{
  * @brief EFM32LG_DAC Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IOM uint32_t CTRL;         /**< Control Register  */
-  __IM uint32_t  STATUS;       /**< Status Register  */
-  __IOM uint32_t CH0CTRL;      /**< Channel 0 Control Register  */
-  __IOM uint32_t CH1CTRL;      /**< Channel 1 Control Register  */
-  __IOM uint32_t IEN;          /**< Interrupt Enable Register  */
-  __IM uint32_t  IF;           /**< Interrupt Flag Register  */
-  __IOM uint32_t IFS;          /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;          /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t CH0DATA;      /**< Channel 0 Data Register  */
-  __IOM uint32_t CH1DATA;      /**< Channel 1 Data Register  */
-  __IOM uint32_t COMBDATA;     /**< Combined Data Register  */
-  __IOM uint32_t CAL;          /**< Calibration Register  */
-  __IOM uint32_t BIASPROG;     /**< Bias Programming Register  */
-  uint32_t       RESERVED0[8]; /**< Reserved for future use **/
-  __IOM uint32_t OPACTRL;      /**< Operational Amplifier Control Register  */
-  __IOM uint32_t OPAOFFSET;    /**< Operational Amplifier Offset Register  */
-  __IOM uint32_t OPA0MUX;      /**< Operational Amplifier Mux Configuration Register  */
-  __IOM uint32_t OPA1MUX;      /**< Operational Amplifier Mux Configuration Register  */
-  __IOM uint32_t OPA2MUX;      /**< Operational Amplifier Mux Configuration Register  */
-} DAC_TypeDef;                 /**< DAC Register Declaration *//** @} */
+  __IOM uint32_t CTRL;          /**< Control Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IOM uint32_t CH0CTRL;       /**< Channel 0 Control Register  */
+  __IOM uint32_t CH1CTRL;       /**< Channel 1 Control Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t CH0DATA;       /**< Channel 0 Data Register  */
+  __IOM uint32_t CH1DATA;       /**< Channel 1 Data Register  */
+  __IOM uint32_t COMBDATA;      /**< Combined Data Register  */
+  __IOM uint32_t CAL;           /**< Calibration Register  */
+  __IOM uint32_t BIASPROG;      /**< Bias Programming Register  */
+  uint32_t       RESERVED0[8U]; /**< Reserved for future use **/
+  __IOM uint32_t OPACTRL;       /**< Operational Amplifier Control Register  */
+  __IOM uint32_t OPAOFFSET;     /**< Operational Amplifier Offset Register  */
+  __IOM uint32_t OPA0MUX;       /**< Operational Amplifier Mux Configuration Register  */
+  __IOM uint32_t OPA1MUX;       /**< Operational Amplifier Mux Configuration Register  */
+  __IOM uint32_t OPA2MUX;       /**< Operational Amplifier Mux Configuration Register  */
+} DAC_TypeDef;                  /**< DAC Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32LG_DAC_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for DAC CTRL */
 #define _DAC_CTRL_RESETVALUE                  0x00000010UL                         /**< Default value for DAC_CTRL */

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_devinfo.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_devinfo.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32lg_devinfo.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32LG_DEVINFO register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,39 +40,39 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32LG_DEVINFO
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IM uint32_t CAL;          /**< Calibration temperature and checksum */
-  __IM uint32_t ADC0CAL0;     /**< ADC0 Calibration register 0 */
-  __IM uint32_t ADC0CAL1;     /**< ADC0 Calibration register 1 */
-  __IM uint32_t ADC0CAL2;     /**< ADC0 Calibration register 2 */
-  uint32_t      RESERVED0[2]; /**< Reserved */
-  __IM uint32_t DAC0CAL0;     /**< DAC calibrartion register 0 */
-  __IM uint32_t DAC0CAL1;     /**< DAC calibrartion register 1 */
-  __IM uint32_t DAC0CAL2;     /**< DAC calibrartion register 2 */
-  __IM uint32_t AUXHFRCOCAL0; /**< AUXHFRCO calibration register 0 */
-  __IM uint32_t AUXHFRCOCAL1; /**< AUXHFRCO calibration register 1 */
-  __IM uint32_t HFRCOCAL0;    /**< HFRCO calibration register 0 */
-  __IM uint32_t HFRCOCAL1;    /**< HFRCO calibration register 1 */
-  __IM uint32_t MEMINFO;      /**< Memory information */
-  uint32_t      RESERVED2[2]; /**< Reserved */
-  __IM uint32_t UNIQUEL;      /**< Low 32 bits of device unique number */
-  __IM uint32_t UNIQUEH;      /**< High 32 bits of device unique number */
-  __IM uint32_t MSIZE;        /**< Flash and SRAM Memory size in KiloBytes */
-  __IM uint32_t PART;         /**< Part description */
-} DEVINFO_TypeDef;            /** @} */
+  __IM uint32_t CAL;           /**< Calibration temperature and checksum */
+  __IM uint32_t ADC0CAL0;      /**< ADC0 Calibration register 0 */
+  __IM uint32_t ADC0CAL1;      /**< ADC0 Calibration register 1 */
+  __IM uint32_t ADC0CAL2;      /**< ADC0 Calibration register 2 */
+  uint32_t      RESERVED0[2U]; /**< Reserved */
+  __IM uint32_t DAC0CAL0;      /**< DAC calibrartion register 0 */
+  __IM uint32_t DAC0CAL1;      /**< DAC calibrartion register 1 */
+  __IM uint32_t DAC0CAL2;      /**< DAC calibrartion register 2 */
+  __IM uint32_t AUXHFRCOCAL0;  /**< AUXHFRCO calibration register 0 */
+  __IM uint32_t AUXHFRCOCAL1;  /**< AUXHFRCO calibration register 1 */
+  __IM uint32_t HFRCOCAL0;     /**< HFRCO calibration register 0 */
+  __IM uint32_t HFRCOCAL1;     /**< HFRCO calibration register 1 */
+  __IM uint32_t MEMINFO;       /**< Memory information */
+  uint32_t      RESERVED2[2U]; /**< Reserved */
+  __IM uint32_t UNIQUEL;       /**< Low 32 bits of device unique number */
+  __IM uint32_t UNIQUEH;       /**< High 32 bits of device unique number */
+  __IM uint32_t MSIZE;         /**< Flash and SRAM Memory size in KiloBytes */
+  __IM uint32_t PART;          /**< Part description */
+} DEVINFO_TypeDef;             /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32LG_DEVINFO_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 /* Bit fields for EFM32LG_DEVINFO */
 #define _DEVINFO_CAL_CRC_MASK                      0x0000FFFFUL /**< Integrity CRC checksum mask */
 #define _DEVINFO_CAL_CRC_SHIFT                     0            /**< Integrity CRC checksum shift */

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_dma.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_dma.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32lg_dma.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32LG_DMA register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,62 +40,62 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32LG_DMA
  * @{
  * @brief EFM32LG_DMA Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IM uint32_t  STATUS;         /**< DMA Status Registers  */
-  __OM uint32_t  CONFIG;         /**< DMA Configuration Register  */
-  __IOM uint32_t CTRLBASE;       /**< Channel Control Data Base Pointer Register  */
-  __IM uint32_t  ALTCTRLBASE;    /**< Channel Alternate Control Data Base Pointer Register  */
-  __IM uint32_t  CHWAITSTATUS;   /**< Channel Wait on Request Status Register  */
-  __OM uint32_t  CHSWREQ;        /**< Channel Software Request Register  */
-  __IOM uint32_t CHUSEBURSTS;    /**< Channel Useburst Set Register  */
-  __OM uint32_t  CHUSEBURSTC;    /**< Channel Useburst Clear Register  */
-  __IOM uint32_t CHREQMASKS;     /**< Channel Request Mask Set Register  */
-  __OM uint32_t  CHREQMASKC;     /**< Channel Request Mask Clear Register  */
-  __IOM uint32_t CHENS;          /**< Channel Enable Set Register  */
-  __OM uint32_t  CHENC;          /**< Channel Enable Clear Register  */
-  __IOM uint32_t CHALTS;         /**< Channel Alternate Set Register  */
-  __OM uint32_t  CHALTC;         /**< Channel Alternate Clear Register  */
-  __IOM uint32_t CHPRIS;         /**< Channel Priority Set Register  */
-  __OM uint32_t  CHPRIC;         /**< Channel Priority Clear Register  */
-  uint32_t       RESERVED0[3];   /**< Reserved for future use **/
-  __IOM uint32_t ERRORC;         /**< Bus Error Clear Register  */
+  __IM uint32_t  STATUS;          /**< DMA Status Registers  */
+  __OM uint32_t  CONFIG;          /**< DMA Configuration Register  */
+  __IOM uint32_t CTRLBASE;        /**< Channel Control Data Base Pointer Register  */
+  __IM uint32_t  ALTCTRLBASE;     /**< Channel Alternate Control Data Base Pointer Register  */
+  __IM uint32_t  CHWAITSTATUS;    /**< Channel Wait on Request Status Register  */
+  __OM uint32_t  CHSWREQ;         /**< Channel Software Request Register  */
+  __IOM uint32_t CHUSEBURSTS;     /**< Channel Useburst Set Register  */
+  __OM uint32_t  CHUSEBURSTC;     /**< Channel Useburst Clear Register  */
+  __IOM uint32_t CHREQMASKS;      /**< Channel Request Mask Set Register  */
+  __OM uint32_t  CHREQMASKC;      /**< Channel Request Mask Clear Register  */
+  __IOM uint32_t CHENS;           /**< Channel Enable Set Register  */
+  __OM uint32_t  CHENC;           /**< Channel Enable Clear Register  */
+  __IOM uint32_t CHALTS;          /**< Channel Alternate Set Register  */
+  __OM uint32_t  CHALTC;          /**< Channel Alternate Clear Register  */
+  __IOM uint32_t CHPRIS;          /**< Channel Priority Set Register  */
+  __OM uint32_t  CHPRIC;          /**< Channel Priority Clear Register  */
+  uint32_t       RESERVED0[3U];   /**< Reserved for future use **/
+  __IOM uint32_t ERRORC;          /**< Bus Error Clear Register  */
 
-  uint32_t       RESERVED1[880]; /**< Reserved for future use **/
-  __IM uint32_t  CHREQSTATUS;    /**< Channel Request Status  */
-  uint32_t       RESERVED2[1];   /**< Reserved for future use **/
-  __IM uint32_t  CHSREQSTATUS;   /**< Channel Single Request Status  */
+  uint32_t       RESERVED1[880U]; /**< Reserved for future use **/
+  __IM uint32_t  CHREQSTATUS;     /**< Channel Request Status  */
+  uint32_t       RESERVED2[1U];   /**< Reserved for future use **/
+  __IM uint32_t  CHSREQSTATUS;    /**< Channel Single Request Status  */
 
-  uint32_t       RESERVED3[121]; /**< Reserved for future use **/
-  __IM uint32_t  IF;             /**< Interrupt Flag Register  */
-  __IOM uint32_t IFS;            /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;            /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t IEN;            /**< Interrupt Enable register  */
-  __IOM uint32_t CTRL;           /**< DMA Control Register  */
-  __IOM uint32_t RDS;            /**< DMA Retain Descriptor State  */
+  uint32_t       RESERVED3[121U]; /**< Reserved for future use **/
+  __IM uint32_t  IF;              /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;             /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;             /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;             /**< Interrupt Enable register  */
+  __IOM uint32_t CTRL;            /**< DMA Control Register  */
+  __IOM uint32_t RDS;             /**< DMA Retain Descriptor State  */
 
-  uint32_t       RESERVED4[2];   /**< Reserved for future use **/
-  __IOM uint32_t LOOP0;          /**< Channel 0 Loop Register  */
-  __IOM uint32_t LOOP1;          /**< Channel 1 Loop Register  */
-  uint32_t       RESERVED5[14];  /**< Reserved for future use **/
-  __IOM uint32_t RECT0;          /**< Channel 0 Rectangle Register  */
+  uint32_t       RESERVED4[2U];   /**< Reserved for future use **/
+  __IOM uint32_t LOOP0;           /**< Channel 0 Loop Register  */
+  __IOM uint32_t LOOP1;           /**< Channel 1 Loop Register  */
+  uint32_t       RESERVED5[14U];  /**< Reserved for future use **/
+  __IOM uint32_t RECT0;           /**< Channel 0 Rectangle Register  */
 
-  uint32_t       RESERVED6[39];  /**< Reserved registers */
-  DMA_CH_TypeDef CH[12];         /**< Channel registers */
-} DMA_TypeDef;                   /**< DMA Register Declaration *//** @} */
+  uint32_t       RESERVED6[39U];  /**< Reserved registers */
+  DMA_CH_TypeDef CH[12U];         /**< Channel registers */
+} DMA_TypeDef;                    /**< DMA Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32LG_DMA_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for DMA STATUS */
 #define _DMA_STATUS_RESETVALUE                          0x100B0000UL                          /**< Default value for DMA_STATUS */

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_dma_ch.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_dma_ch.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32lg_dma_ch.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32LG_DMA_CH register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,13 +40,13 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief DMA_CH EFM32LG DMA CH
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t CTRL; /**< Channel Control Register  */
 } DMA_CH_TypeDef;

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_dma_descriptor.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_dma_descriptor.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32lg_dma_descriptor.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32LG_DMA_DESCRIPTOR register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,14 +40,14 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32LG_DMA_DESCRIPTOR
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   /* Note! Use of double __IOM (volatile) qualifier to ensure that both */
   /* pointer and referenced memory are declared volatile. */

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_dmactrl.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_dmactrl.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32lg_dmactrl.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32LG_DMACTRL register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32LG_DMACTRL_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 #define _DMA_CTRL_DST_INC_MASK                         0xC0000000UL  /**< Data increment for destination, bit mask */
 #define _DMA_CTRL_DST_INC_SHIFT                        30            /**< Data increment for destination, shift value */
 #define _DMA_CTRL_DST_INC_BYTE                         0x00          /**< Byte/8-bit increment */

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_dmareq.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_dmareq.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32lg_dmareq.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32LG_DMAREQ register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32LG_DMAREQ_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 #define DMAREQ_ADC0_SINGLE            ((8 << 16) + 0)  /**< DMA channel select for ADC0_SINGLE */
 #define DMAREQ_ADC0_SCAN              ((8 << 16) + 1)  /**< DMA channel select for ADC0_SCAN */
 #define DMAREQ_DAC0_CH0               ((10 << 16) + 0) /**< DMA channel select for DAC0_CH0 */

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_ebi.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_ebi.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32lg_ebi.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32LG_EBI register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32LG_EBI
  * @{
  * @brief EFM32LG_EBI Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t CTRL;         /**< Control Register  */
   __IOM uint32_t ADDRTIMING;   /**< Address Timing Register  */
@@ -95,10 +94,10 @@ typedef struct {
   __IOM uint32_t IEN;          /**< Interrupt Enable Register  */
 } EBI_TypeDef;                 /**< EBI Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32LG_EBI_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for EBI CTRL */
 #define _EBI_CTRL_RESETVALUE                      0x00000000UL                         /**< Default value for EBI_CTRL */

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_emu.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_emu.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32lg_emu.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32LG_EMU register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,25 +40,25 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32LG_EMU
  * @{
  * @brief EFM32LG_EMU Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t CTRL;          /**< Control Register  */
 
-  uint32_t       RESERVED0[1];  /**< Reserved for future use **/
+  uint32_t       RESERVED0[1U]; /**< Reserved for future use **/
   __IOM uint32_t LOCK;          /**< Configuration Lock Register  */
 
-  uint32_t       RESERVED1[6];  /**< Reserved for future use **/
+  uint32_t       RESERVED1[6U]; /**< Reserved for future use **/
   __IOM uint32_t AUXCTRL;       /**< Auxiliary Control Register  */
 
-  uint32_t       RESERVED2[1];  /**< Reserved for future use **/
+  uint32_t       RESERVED2[1U]; /**< Reserved for future use **/
   __IOM uint32_t EM4CONF;       /**< Energy mode 4 configuration register  */
   __IOM uint32_t BUCTRL;        /**< Backup Power configuration register  */
   __IOM uint32_t PWRCONF;       /**< Power connection configuration register  */
@@ -75,10 +74,10 @@ typedef struct {
   __IOM uint32_t BUBODUNREGCAL; /**< Unregulated power Backup BOD calibration  */
 } EMU_TypeDef;                  /**< EMU Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32LG_EMU_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for EMU CTRL */
 #define _EMU_CTRL_RESETVALUE                0x00000000UL                      /**< Default value for EMU_CTRL */

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_etm.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_etm.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32lg_etm.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32LG_ETM register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,80 +40,80 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32LG_ETM
  * @{
  * @brief EFM32LG_ETM Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IOM uint32_t ETMCR;           /**< Main Control Register  */
-  __IM uint32_t  ETMCCR;          /**< Configuration Code Register  */
-  __IOM uint32_t ETMTRIGGER;      /**< ETM Trigger Event Register  */
-  uint32_t       RESERVED0[1];    /**< Reserved for future use **/
-  __IOM uint32_t ETMSR;           /**< ETM Status Register  */
-  __IM uint32_t  ETMSCR;          /**< ETM System Configuration Register  */
-  uint32_t       RESERVED1[2];    /**< Reserved for future use **/
-  __IOM uint32_t ETMTEEVR;        /**< ETM TraceEnable Event Register  */
-  __IOM uint32_t ETMTECR1;        /**< ETM Trace control Register  */
-  uint32_t       RESERVED2[1];    /**< Reserved for future use **/
-  __IOM uint32_t ETMFFLR;         /**< ETM Fifo Full Level Register  */
-  uint32_t       RESERVED3[68];   /**< Reserved for future use **/
-  __IOM uint32_t ETMCNTRLDVR1;    /**< Counter Reload Value  */
-  uint32_t       RESERVED4[39];   /**< Reserved for future use **/
-  __IOM uint32_t ETMSYNCFR;       /**< Synchronisation Frequency Register  */
-  __IM uint32_t  ETMIDR;          /**< ID Register  */
-  __IM uint32_t  ETMCCER;         /**< Configuration Code Extension Register  */
-  uint32_t       RESERVED5[1];    /**< Reserved for future use **/
-  __IOM uint32_t ETMTESSEICR;     /**< TraceEnable Start/Stop EmbeddedICE Control Register  */
-  uint32_t       RESERVED6[1];    /**< Reserved for future use **/
-  __IOM uint32_t ETMTSEVR;        /**< Timestamp Event Register  */
-  uint32_t       RESERVED7[1];    /**< Reserved for future use **/
-  __IOM uint32_t ETMTRACEIDR;     /**< CoreSight Trace ID Register  */
-  uint32_t       RESERVED8[1];    /**< Reserved for future use **/
-  __IM uint32_t  ETMIDR2;         /**< ETM ID Register 2  */
-  uint32_t       RESERVED9[66];   /**< Reserved for future use **/
-  __IM uint32_t  ETMPDSR;         /**< Device Power-down Status Register  */
-  uint32_t       RESERVED10[754]; /**< Reserved for future use **/
-  __IOM uint32_t ETMISCIN;        /**< Integration Test Miscellaneous Inputs Register  */
-  uint32_t       RESERVED11[1];   /**< Reserved for future use **/
-  __OM uint32_t  ITTRIGOUT;       /**< Integration Test Trigger Out Register  */
-  uint32_t       RESERVED12[1];   /**< Reserved for future use **/
-  __IM uint32_t  ETMITATBCTR2;    /**< ETM Integration Test ATB Control 2 Register  */
-  uint32_t       RESERVED13[1];   /**< Reserved for future use **/
-  __OM uint32_t  ETMITATBCTR0;    /**< ETM Integration Test ATB Control 0 Register  */
-  uint32_t       RESERVED14[1];   /**< Reserved for future use **/
-  __IOM uint32_t ETMITCTRL;       /**< ETM Integration Control Register  */
-  uint32_t       RESERVED15[39];  /**< Reserved for future use **/
-  __IOM uint32_t ETMCLAIMSET;     /**< ETM Claim Tag Set Register  */
-  __IOM uint32_t ETMCLAIMCLR;     /**< ETM Claim Tag Clear Register  */
-  uint32_t       RESERVED16[2];   /**< Reserved for future use **/
-  __IOM uint32_t ETMLAR;          /**< ETM Lock Access Register  */
-  __IM uint32_t  ETMLSR;          /**< Lock Status Register  */
-  __IM uint32_t  ETMAUTHSTATUS;   /**< ETM Authentication Status Register  */
-  uint32_t       RESERVED17[4];   /**< Reserved for future use **/
-  __IM uint32_t  ETMDEVTYPE;      /**< CoreSight Device Type Register  */
-  __IM uint32_t  ETMPIDR4;        /**< Peripheral ID4 Register  */
-  __OM uint32_t  ETMPIDR5;        /**< Peripheral ID5 Register  */
-  __OM uint32_t  ETMPIDR6;        /**< Peripheral ID6 Register  */
-  __OM uint32_t  ETMPIDR7;        /**< Peripheral ID7 Register  */
-  __IM uint32_t  ETMPIDR0;        /**< Peripheral ID0 Register  */
-  __IM uint32_t  ETMPIDR1;        /**< Peripheral ID1 Register  */
-  __IM uint32_t  ETMPIDR2;        /**< Peripheral ID2 Register  */
-  __IM uint32_t  ETMPIDR3;        /**< Peripheral ID3 Register  */
-  __IM uint32_t  ETMCIDR0;        /**< Component ID0 Register  */
-  __IM uint32_t  ETMCIDR1;        /**< Component ID1 Register  */
-  __IM uint32_t  ETMCIDR2;        /**< Component ID2 Register  */
-  __IM uint32_t  ETMCIDR3;        /**< Component ID3 Register  */
-} ETM_TypeDef;                    /**< ETM Register Declaration *//** @} */
+  __IOM uint32_t ETMCR;            /**< Main Control Register  */
+  __IM uint32_t  ETMCCR;           /**< Configuration Code Register  */
+  __IOM uint32_t ETMTRIGGER;       /**< ETM Trigger Event Register  */
+  uint32_t       RESERVED0[1U];    /**< Reserved for future use **/
+  __IOM uint32_t ETMSR;            /**< ETM Status Register  */
+  __IM uint32_t  ETMSCR;           /**< ETM System Configuration Register  */
+  uint32_t       RESERVED1[2U];    /**< Reserved for future use **/
+  __IOM uint32_t ETMTEEVR;         /**< ETM TraceEnable Event Register  */
+  __IOM uint32_t ETMTECR1;         /**< ETM Trace control Register  */
+  uint32_t       RESERVED2[1U];    /**< Reserved for future use **/
+  __IOM uint32_t ETMFFLR;          /**< ETM Fifo Full Level Register  */
+  uint32_t       RESERVED3[68U];   /**< Reserved for future use **/
+  __IOM uint32_t ETMCNTRLDVR1;     /**< Counter Reload Value  */
+  uint32_t       RESERVED4[39U];   /**< Reserved for future use **/
+  __IOM uint32_t ETMSYNCFR;        /**< Synchronisation Frequency Register  */
+  __IM uint32_t  ETMIDR;           /**< ID Register  */
+  __IM uint32_t  ETMCCER;          /**< Configuration Code Extension Register  */
+  uint32_t       RESERVED5[1U];    /**< Reserved for future use **/
+  __IOM uint32_t ETMTESSEICR;      /**< TraceEnable Start/Stop EmbeddedICE Control Register  */
+  uint32_t       RESERVED6[1U];    /**< Reserved for future use **/
+  __IOM uint32_t ETMTSEVR;         /**< Timestamp Event Register  */
+  uint32_t       RESERVED7[1U];    /**< Reserved for future use **/
+  __IOM uint32_t ETMTRACEIDR;      /**< CoreSight Trace ID Register  */
+  uint32_t       RESERVED8[1U];    /**< Reserved for future use **/
+  __IM uint32_t  ETMIDR2;          /**< ETM ID Register 2  */
+  uint32_t       RESERVED9[66U];   /**< Reserved for future use **/
+  __IM uint32_t  ETMPDSR;          /**< Device Power-down Status Register  */
+  uint32_t       RESERVED10[754U]; /**< Reserved for future use **/
+  __IOM uint32_t ETMISCIN;         /**< Integration Test Miscellaneous Inputs Register  */
+  uint32_t       RESERVED11[1U];   /**< Reserved for future use **/
+  __OM uint32_t  ITTRIGOUT;        /**< Integration Test Trigger Out Register  */
+  uint32_t       RESERVED12[1U];   /**< Reserved for future use **/
+  __IM uint32_t  ETMITATBCTR2;     /**< ETM Integration Test ATB Control 2 Register  */
+  uint32_t       RESERVED13[1U];   /**< Reserved for future use **/
+  __OM uint32_t  ETMITATBCTR0;     /**< ETM Integration Test ATB Control 0 Register  */
+  uint32_t       RESERVED14[1U];   /**< Reserved for future use **/
+  __IOM uint32_t ETMITCTRL;        /**< ETM Integration Control Register  */
+  uint32_t       RESERVED15[39U];  /**< Reserved for future use **/
+  __IOM uint32_t ETMCLAIMSET;      /**< ETM Claim Tag Set Register  */
+  __IOM uint32_t ETMCLAIMCLR;      /**< ETM Claim Tag Clear Register  */
+  uint32_t       RESERVED16[2U];   /**< Reserved for future use **/
+  __IOM uint32_t ETMLAR;           /**< ETM Lock Access Register  */
+  __IM uint32_t  ETMLSR;           /**< Lock Status Register  */
+  __IM uint32_t  ETMAUTHSTATUS;    /**< ETM Authentication Status Register  */
+  uint32_t       RESERVED17[4U];   /**< Reserved for future use **/
+  __IM uint32_t  ETMDEVTYPE;       /**< CoreSight Device Type Register  */
+  __IM uint32_t  ETMPIDR4;         /**< Peripheral ID4 Register  */
+  __OM uint32_t  ETMPIDR5;         /**< Peripheral ID5 Register  */
+  __OM uint32_t  ETMPIDR6;         /**< Peripheral ID6 Register  */
+  __OM uint32_t  ETMPIDR7;         /**< Peripheral ID7 Register  */
+  __IM uint32_t  ETMPIDR0;         /**< Peripheral ID0 Register  */
+  __IM uint32_t  ETMPIDR1;         /**< Peripheral ID1 Register  */
+  __IM uint32_t  ETMPIDR2;         /**< Peripheral ID2 Register  */
+  __IM uint32_t  ETMPIDR3;         /**< Peripheral ID3 Register  */
+  __IM uint32_t  ETMCIDR0;         /**< Component ID0 Register  */
+  __IM uint32_t  ETMCIDR1;         /**< Component ID1 Register  */
+  __IM uint32_t  ETMCIDR2;         /**< Component ID2 Register  */
+  __IM uint32_t  ETMCIDR3;         /**< Component ID3 Register  */
+} ETM_TypeDef;                     /**< ETM Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32LG_ETM_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for ETM ETMCR */
 #define _ETM_ETMCR_RESETVALUE                         0x00000411UL                           /**< Default value for ETM_ETMCR */

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_gpio.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_gpio.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32lg_gpio.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32LG_GPIO register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,42 +40,42 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32LG_GPIO
  * @{
  * @brief EFM32LG_GPIO Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  GPIO_P_TypeDef P[6];          /**< Port configuration bits */
+  GPIO_P_TypeDef P[6U];          /**< Port configuration bits */
 
-  uint32_t       RESERVED0[10]; /**< Reserved for future use **/
-  __IOM uint32_t EXTIPSELL;     /**< External Interrupt Port Select Low Register  */
-  __IOM uint32_t EXTIPSELH;     /**< External Interrupt Port Select High Register  */
-  __IOM uint32_t EXTIRISE;      /**< External Interrupt Rising Edge Trigger Register  */
-  __IOM uint32_t EXTIFALL;      /**< External Interrupt Falling Edge Trigger Register  */
-  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
-  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
-  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  uint32_t       RESERVED0[10U]; /**< Reserved for future use **/
+  __IOM uint32_t EXTIPSELL;      /**< External Interrupt Port Select Low Register  */
+  __IOM uint32_t EXTIPSELH;      /**< External Interrupt Port Select High Register  */
+  __IOM uint32_t EXTIRISE;       /**< External Interrupt Rising Edge Trigger Register  */
+  __IOM uint32_t EXTIFALL;       /**< External Interrupt Falling Edge Trigger Register  */
+  __IOM uint32_t IEN;            /**< Interrupt Enable Register  */
+  __IM uint32_t  IF;             /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;            /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;            /**< Interrupt Flag Clear Register  */
 
-  __IOM uint32_t ROUTE;         /**< I/O Routing Register  */
-  __IOM uint32_t INSENSE;       /**< Input Sense Register  */
-  __IOM uint32_t LOCK;          /**< Configuration Lock Register  */
-  __IOM uint32_t CTRL;          /**< GPIO Control Register  */
-  __IOM uint32_t CMD;           /**< GPIO Command Register  */
-  __IOM uint32_t EM4WUEN;       /**< EM4 Wake-up Enable Register  */
-  __IOM uint32_t EM4WUPOL;      /**< EM4 Wake-up Polarity Register  */
-  __IM uint32_t  EM4WUCAUSE;    /**< EM4 Wake-up Cause Register  */
-} GPIO_TypeDef;                 /**< GPIO Register Declaration *//** @} */
+  __IOM uint32_t ROUTE;          /**< I/O Routing Register  */
+  __IOM uint32_t INSENSE;        /**< Input Sense Register  */
+  __IOM uint32_t LOCK;           /**< Configuration Lock Register  */
+  __IOM uint32_t CTRL;           /**< GPIO Control Register  */
+  __IOM uint32_t CMD;            /**< GPIO Command Register  */
+  __IOM uint32_t EM4WUEN;        /**< EM4 Wake-up Enable Register  */
+  __IOM uint32_t EM4WUPOL;       /**< EM4 Wake-up Polarity Register  */
+  __IM uint32_t  EM4WUCAUSE;     /**< EM4 Wake-up Cause Register  */
+} GPIO_TypeDef;                  /**< GPIO Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32LG_GPIO_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for GPIO P_CTRL */
 #define _GPIO_P_CTRL_RESETVALUE                           0x00000000UL                           /**< Default value for GPIO_P_CTRL */

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_gpio_p.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_gpio_p.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32lg_gpio_p.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32LG_GPIO_P register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,13 +40,13 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief GPIO_P EFM32LG GPIO P
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t CTRL;     /**< Port Control Register  */
   __IOM uint32_t MODEL;    /**< Port Pin Mode Low Register  */

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_i2c.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_i2c.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32lg_i2c.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32LG_I2C register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32LG_I2C
  * @{
  * @brief EFM32LG_I2C Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t CTRL;      /**< Control Register  */
   __IOM uint32_t CMD;       /**< Command Register  */
@@ -68,10 +67,10 @@ typedef struct {
   __IOM uint32_t ROUTE;     /**< I/O Routing Register  */
 } I2C_TypeDef;              /**< I2C Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32LG_I2C_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for I2C CTRL */
 #define _I2C_CTRL_RESETVALUE              0x00000000UL                     /**< Default value for I2C_CTRL */

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_lcd.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_lcd.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32lg_lcd.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32LG_LCD register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,57 +40,57 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32LG_LCD
  * @{
  * @brief EFM32LG_LCD Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IOM uint32_t CTRL;          /**< Control Register  */
-  __IOM uint32_t DISPCTRL;      /**< Display Control Register  */
-  __IOM uint32_t SEGEN;         /**< Segment Enable Register  */
-  __IOM uint32_t BACTRL;        /**< Blink and Animation Control Register  */
-  __IM uint32_t  STATUS;        /**< Status Register  */
-  __IOM uint32_t AREGA;         /**< Animation Register A  */
-  __IOM uint32_t AREGB;         /**< Animation Register B  */
-  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
-  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t CTRL;           /**< Control Register  */
+  __IOM uint32_t DISPCTRL;       /**< Display Control Register  */
+  __IOM uint32_t SEGEN;          /**< Segment Enable Register  */
+  __IOM uint32_t BACTRL;         /**< Blink and Animation Control Register  */
+  __IM uint32_t  STATUS;         /**< Status Register  */
+  __IOM uint32_t AREGA;          /**< Animation Register A  */
+  __IOM uint32_t AREGB;          /**< Animation Register B  */
+  __IM uint32_t  IF;             /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;            /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;            /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;            /**< Interrupt Enable Register  */
 
-  uint32_t       RESERVED0[5];  /**< Reserved for future use **/
-  __IOM uint32_t SEGD0L;        /**< Segment Data Low Register 0  */
-  __IOM uint32_t SEGD1L;        /**< Segment Data Low Register 1  */
-  __IOM uint32_t SEGD2L;        /**< Segment Data Low Register 2  */
-  __IOM uint32_t SEGD3L;        /**< Segment Data Low Register 3  */
-  __IOM uint32_t SEGD0H;        /**< Segment Data High Register 0  */
-  __IOM uint32_t SEGD1H;        /**< Segment Data High Register 1  */
-  __IOM uint32_t SEGD2H;        /**< Segment Data High Register 2  */
-  __IOM uint32_t SEGD3H;        /**< Segment Data High Register 3  */
+  uint32_t       RESERVED0[5U];  /**< Reserved for future use **/
+  __IOM uint32_t SEGD0L;         /**< Segment Data Low Register 0  */
+  __IOM uint32_t SEGD1L;         /**< Segment Data Low Register 1  */
+  __IOM uint32_t SEGD2L;         /**< Segment Data Low Register 2  */
+  __IOM uint32_t SEGD3L;         /**< Segment Data Low Register 3  */
+  __IOM uint32_t SEGD0H;         /**< Segment Data High Register 0  */
+  __IOM uint32_t SEGD1H;         /**< Segment Data High Register 1  */
+  __IOM uint32_t SEGD2H;         /**< Segment Data High Register 2  */
+  __IOM uint32_t SEGD3H;         /**< Segment Data High Register 3  */
 
-  __IOM uint32_t FREEZE;        /**< Freeze Register  */
-  __IM uint32_t  SYNCBUSY;      /**< Synchronization Busy Register  */
+  __IOM uint32_t FREEZE;         /**< Freeze Register  */
+  __IM uint32_t  SYNCBUSY;       /**< Synchronization Busy Register  */
 
-  uint32_t       RESERVED1[19]; /**< Reserved for future use **/
-  __IOM uint32_t SEGD4H;        /**< Segment Data High Register 4  */
-  __IOM uint32_t SEGD5H;        /**< Segment Data High Register 5  */
-  __IOM uint32_t SEGD6H;        /**< Segment Data High Register 6  */
-  __IOM uint32_t SEGD7H;        /**< Segment Data High Register 7  */
-  uint32_t       RESERVED2[2];  /**< Reserved for future use **/
-  __IOM uint32_t SEGD4L;        /**< Segment Data Low Register 4  */
-  __IOM uint32_t SEGD5L;        /**< Segment Data Low Register 5  */
-  __IOM uint32_t SEGD6L;        /**< Segment Data Low Register 6  */
-  __IOM uint32_t SEGD7L;        /**< Segment Data Low Register 7  */
-} LCD_TypeDef;                  /**< LCD Register Declaration *//** @} */
+  uint32_t       RESERVED1[19U]; /**< Reserved for future use **/
+  __IOM uint32_t SEGD4H;         /**< Segment Data High Register 4  */
+  __IOM uint32_t SEGD5H;         /**< Segment Data High Register 5  */
+  __IOM uint32_t SEGD6H;         /**< Segment Data High Register 6  */
+  __IOM uint32_t SEGD7H;         /**< Segment Data High Register 7  */
+  uint32_t       RESERVED2[2U];  /**< Reserved for future use **/
+  __IOM uint32_t SEGD4L;         /**< Segment Data Low Register 4  */
+  __IOM uint32_t SEGD5L;         /**< Segment Data Low Register 5  */
+  __IOM uint32_t SEGD6L;         /**< Segment Data Low Register 6  */
+  __IOM uint32_t SEGD7L;         /**< Segment Data Low Register 7  */
+} LCD_TypeDef;                   /**< LCD Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32LG_LCD_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for LCD CTRL */
 #define _LCD_CTRL_RESETVALUE               0x00000000UL                       /**< Default value for LCD_CTRL */

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_lesense.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_lesense.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32lg_lesense.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32LG_LESENSE register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,52 +40,52 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32LG_LESENSE
  * @{
  * @brief EFM32LG_LESENSE Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IOM uint32_t      CTRL;           /**< Control Register  */
-  __IOM uint32_t      TIMCTRL;        /**< Timing Control Register  */
-  __IOM uint32_t      PERCTRL;        /**< Peripheral Control Register  */
-  __IOM uint32_t      DECCTRL;        /**< Decoder control Register  */
-  __IOM uint32_t      BIASCTRL;       /**< Bias Control Register  */
-  __IOM uint32_t      CMD;            /**< Command Register  */
-  __IOM uint32_t      CHEN;           /**< Channel enable Register  */
-  __IM uint32_t       SCANRES;        /**< Scan result register  */
-  __IM uint32_t       STATUS;         /**< Status Register  */
-  __IM uint32_t       PTR;            /**< Result buffer pointers  */
-  __IM uint32_t       BUFDATA;        /**< Result buffer data register  */
-  __IM uint32_t       CURCH;          /**< Current channel index  */
-  __IOM uint32_t      DECSTATE;       /**< Current decoder state  */
-  __IOM uint32_t      SENSORSTATE;    /**< Decoder input register  */
-  __IOM uint32_t      IDLECONF;       /**< GPIO Idle phase configuration  */
-  __IOM uint32_t      ALTEXCONF;      /**< Alternative excite pin configuration  */
-  __IM uint32_t       IF;             /**< Interrupt Flag Register  */
-  __IOM uint32_t      IFC;            /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t      IFS;            /**< Interrupt Flag Set Register  */
-  __IOM uint32_t      IEN;            /**< Interrupt Enable Register  */
-  __IM uint32_t       SYNCBUSY;       /**< Synchronization Busy Register  */
-  __IOM uint32_t      ROUTE;          /**< I/O Routing Register  */
-  __IOM uint32_t      POWERDOWN;      /**< LESENSE RAM power-down register  */
+  __IOM uint32_t      CTRL;            /**< Control Register  */
+  __IOM uint32_t      TIMCTRL;         /**< Timing Control Register  */
+  __IOM uint32_t      PERCTRL;         /**< Peripheral Control Register  */
+  __IOM uint32_t      DECCTRL;         /**< Decoder control Register  */
+  __IOM uint32_t      BIASCTRL;        /**< Bias Control Register  */
+  __IOM uint32_t      CMD;             /**< Command Register  */
+  __IOM uint32_t      CHEN;            /**< Channel enable Register  */
+  __IM uint32_t       SCANRES;         /**< Scan result register  */
+  __IM uint32_t       STATUS;          /**< Status Register  */
+  __IM uint32_t       PTR;             /**< Result buffer pointers  */
+  __IM uint32_t       BUFDATA;         /**< Result buffer data register  */
+  __IM uint32_t       CURCH;           /**< Current channel index  */
+  __IOM uint32_t      DECSTATE;        /**< Current decoder state  */
+  __IOM uint32_t      SENSORSTATE;     /**< Decoder input register  */
+  __IOM uint32_t      IDLECONF;        /**< GPIO Idle phase configuration  */
+  __IOM uint32_t      ALTEXCONF;       /**< Alternative excite pin configuration  */
+  __IM uint32_t       IF;              /**< Interrupt Flag Register  */
+  __IOM uint32_t      IFC;             /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t      IFS;             /**< Interrupt Flag Set Register  */
+  __IOM uint32_t      IEN;             /**< Interrupt Enable Register  */
+  __IM uint32_t       SYNCBUSY;        /**< Synchronization Busy Register  */
+  __IOM uint32_t      ROUTE;           /**< I/O Routing Register  */
+  __IOM uint32_t      POWERDOWN;       /**< LESENSE RAM power-down register  */
 
-  uint32_t            RESERVED0[105]; /**< Reserved registers */
-  LESENSE_ST_TypeDef  ST[16];         /**< Decoding states */
+  uint32_t            RESERVED0[105U]; /**< Reserved registers */
+  LESENSE_ST_TypeDef  ST[16U];         /**< Decoding states */
 
-  LESENSE_BUF_TypeDef BUF[16];        /**< Scanresult */
+  LESENSE_BUF_TypeDef BUF[16U];        /**< Scanresult */
 
-  LESENSE_CH_TypeDef  CH[16];         /**< Scanconfig */
-} LESENSE_TypeDef;                    /**< LESENSE Register Declaration *//** @} */
+  LESENSE_CH_TypeDef  CH[16U];         /**< Scanconfig */
+} LESENSE_TypeDef;                     /**< LESENSE Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32LG_LESENSE_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for LESENSE CTRL */
 #define _LESENSE_CTRL_RESETVALUE                       0x00000000UL                             /**< Default value for LESENSE_CTRL */

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_lesense_buf.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_lesense_buf.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32lg_lesense_buf.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32LG_LESENSE_BUF register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,13 +40,13 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief LESENSE_BUF EFM32LG LESENSE BUF
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t DATA; /**< Scan results  */
 } LESENSE_BUF_TypeDef;

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_lesense_ch.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_lesense_ch.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32lg_lesense_ch.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32LG_LESENSE_CH register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,18 +40,18 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief LESENSE_CH EFM32LG LESENSE CH
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IOM uint32_t TIMING;       /**< Scan configuration  */
-  __IOM uint32_t INTERACT;     /**< Scan configuration  */
-  __IOM uint32_t EVAL;         /**< Scan configuration  */
-  uint32_t       RESERVED0[1]; /**< Reserved future */
+  __IOM uint32_t TIMING;        /**< Scan configuration  */
+  __IOM uint32_t INTERACT;      /**< Scan configuration  */
+  __IOM uint32_t EVAL;          /**< Scan configuration  */
+  uint32_t       RESERVED0[1U]; /**< Reserved future */
 } LESENSE_CH_TypeDef;
 
 /** @} End of group Parts */

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_lesense_st.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_lesense_st.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32lg_lesense_st.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32LG_LESENSE_ST register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,13 +40,13 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief LESENSE_ST EFM32LG LESENSE ST
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t TCONFA; /**< State transition configuration A  */
   __IOM uint32_t TCONFB; /**< State transition configuration B  */

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_letimer.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_letimer.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32lg_letimer.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32LG_LETIMER register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,40 +40,40 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32LG_LETIMER
  * @{
  * @brief EFM32LG_LETIMER Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IOM uint32_t CTRL;         /**< Control Register  */
-  __IOM uint32_t CMD;          /**< Command Register  */
-  __IM uint32_t  STATUS;       /**< Status Register  */
-  __IOM uint32_t CNT;          /**< Counter Value Register  */
-  __IOM uint32_t COMP0;        /**< Compare Value Register 0  */
-  __IOM uint32_t COMP1;        /**< Compare Value Register 1  */
-  __IOM uint32_t REP0;         /**< Repeat Counter Register 0  */
-  __IOM uint32_t REP1;         /**< Repeat Counter Register 1  */
-  __IM uint32_t  IF;           /**< Interrupt Flag Register  */
-  __IOM uint32_t IFS;          /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;          /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t IEN;          /**< Interrupt Enable Register  */
+  __IOM uint32_t CTRL;          /**< Control Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IOM uint32_t CNT;           /**< Counter Value Register  */
+  __IOM uint32_t COMP0;         /**< Compare Value Register 0  */
+  __IOM uint32_t COMP1;         /**< Compare Value Register 1  */
+  __IOM uint32_t REP0;          /**< Repeat Counter Register 0  */
+  __IOM uint32_t REP1;          /**< Repeat Counter Register 1  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
 
-  __IOM uint32_t FREEZE;       /**< Freeze Register  */
-  __IM uint32_t  SYNCBUSY;     /**< Synchronization Busy Register  */
+  __IOM uint32_t FREEZE;        /**< Freeze Register  */
+  __IM uint32_t  SYNCBUSY;      /**< Synchronization Busy Register  */
 
-  uint32_t       RESERVED0[2]; /**< Reserved for future use **/
-  __IOM uint32_t ROUTE;        /**< I/O Routing Register  */
-} LETIMER_TypeDef;             /**< LETIMER Register Declaration *//** @} */
+  uint32_t       RESERVED0[2U]; /**< Reserved for future use **/
+  __IOM uint32_t ROUTE;         /**< I/O Routing Register  */
+} LETIMER_TypeDef;              /**< LETIMER Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32LG_LETIMER_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for LETIMER CTRL */
 #define _LETIMER_CTRL_RESETVALUE             0x00000000UL                           /**< Default value for LETIMER_CTRL */

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_leuart.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_leuart.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32lg_leuart.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32LG_LEUART register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,46 +40,46 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32LG_LEUART
  * @{
  * @brief EFM32LG_LEUART Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IOM uint32_t CTRL;          /**< Control Register  */
-  __IOM uint32_t CMD;           /**< Command Register  */
-  __IM uint32_t  STATUS;        /**< Status Register  */
-  __IOM uint32_t CLKDIV;        /**< Clock Control Register  */
-  __IOM uint32_t STARTFRAME;    /**< Start Frame Register  */
-  __IOM uint32_t SIGFRAME;      /**< Signal Frame Register  */
-  __IM uint32_t  RXDATAX;       /**< Receive Buffer Data Extended Register  */
-  __IM uint32_t  RXDATA;        /**< Receive Buffer Data Register  */
-  __IM uint32_t  RXDATAXP;      /**< Receive Buffer Data Extended Peek Register  */
-  __IOM uint32_t TXDATAX;       /**< Transmit Buffer Data Extended Register  */
-  __IOM uint32_t TXDATA;        /**< Transmit Buffer Data Register  */
-  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
-  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
-  __IOM uint32_t PULSECTRL;     /**< Pulse Control Register  */
+  __IOM uint32_t CTRL;           /**< Control Register  */
+  __IOM uint32_t CMD;            /**< Command Register  */
+  __IM uint32_t  STATUS;         /**< Status Register  */
+  __IOM uint32_t CLKDIV;         /**< Clock Control Register  */
+  __IOM uint32_t STARTFRAME;     /**< Start Frame Register  */
+  __IOM uint32_t SIGFRAME;       /**< Signal Frame Register  */
+  __IM uint32_t  RXDATAX;        /**< Receive Buffer Data Extended Register  */
+  __IM uint32_t  RXDATA;         /**< Receive Buffer Data Register  */
+  __IM uint32_t  RXDATAXP;       /**< Receive Buffer Data Extended Peek Register  */
+  __IOM uint32_t TXDATAX;        /**< Transmit Buffer Data Extended Register  */
+  __IOM uint32_t TXDATA;         /**< Transmit Buffer Data Register  */
+  __IM uint32_t  IF;             /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;            /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;            /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;            /**< Interrupt Enable Register  */
+  __IOM uint32_t PULSECTRL;      /**< Pulse Control Register  */
 
-  __IOM uint32_t FREEZE;        /**< Freeze Register  */
-  __IM uint32_t  SYNCBUSY;      /**< Synchronization Busy Register  */
+  __IOM uint32_t FREEZE;         /**< Freeze Register  */
+  __IM uint32_t  SYNCBUSY;       /**< Synchronization Busy Register  */
 
-  uint32_t       RESERVED0[3];  /**< Reserved for future use **/
-  __IOM uint32_t ROUTE;         /**< I/O Routing Register  */
-  uint32_t       RESERVED1[21]; /**< Reserved for future use **/
-  __IOM uint32_t INPUT;         /**< LEUART Input Register  */
-} LEUART_TypeDef;               /**< LEUART Register Declaration *//** @} */
+  uint32_t       RESERVED0[3U];  /**< Reserved for future use **/
+  __IOM uint32_t ROUTE;          /**< I/O Routing Register  */
+  uint32_t       RESERVED1[21U]; /**< Reserved for future use **/
+  __IOM uint32_t INPUT;          /**< LEUART Input Register  */
+} LEUART_TypeDef;                /**< LEUART Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32LG_LEUART_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for LEUART CTRL */
 #define _LEUART_CTRL_RESETVALUE                  0x00000000UL                         /**< Default value for LEUART_CTRL */

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_msc.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_msc.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32lg_msc.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32LG_MSC register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,44 +40,44 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32LG_MSC
  * @{
  * @brief EFM32LG_MSC Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IOM uint32_t CTRL;         /**< Memory System Control Register  */
-  __IOM uint32_t READCTRL;     /**< Read Control Register  */
-  __IOM uint32_t WRITECTRL;    /**< Write Control Register  */
-  __IOM uint32_t WRITECMD;     /**< Write Command Register  */
-  __IOM uint32_t ADDRB;        /**< Page Erase/Write Address Buffer  */
+  __IOM uint32_t CTRL;          /**< Memory System Control Register  */
+  __IOM uint32_t READCTRL;      /**< Read Control Register  */
+  __IOM uint32_t WRITECTRL;     /**< Write Control Register  */
+  __IOM uint32_t WRITECMD;      /**< Write Command Register  */
+  __IOM uint32_t ADDRB;         /**< Page Erase/Write Address Buffer  */
 
-  uint32_t       RESERVED0[1]; /**< Reserved for future use **/
-  __IOM uint32_t WDATA;        /**< Write Data Register  */
-  __IM uint32_t  STATUS;       /**< Status Register  */
+  uint32_t       RESERVED0[1U]; /**< Reserved for future use **/
+  __IOM uint32_t WDATA;         /**< Write Data Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
 
-  uint32_t       RESERVED1[3]; /**< Reserved for future use **/
-  __IM uint32_t  IF;           /**< Interrupt Flag Register  */
-  __IOM uint32_t IFS;          /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;          /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t IEN;          /**< Interrupt Enable Register  */
-  __IOM uint32_t LOCK;         /**< Configuration Lock Register  */
-  __IOM uint32_t CMD;          /**< Command Register  */
-  __IM uint32_t  CACHEHITS;    /**< Cache Hits Performance Counter  */
-  __IM uint32_t  CACHEMISSES;  /**< Cache Misses Performance Counter  */
-  uint32_t       RESERVED2[1]; /**< Reserved for future use **/
-  __IOM uint32_t TIMEBASE;     /**< Flash Write and Erase Timebase  */
-  __IOM uint32_t MASSLOCK;     /**< Mass Erase Lock Register  */
-} MSC_TypeDef;                 /**< MSC Register Declaration *//** @} */
+  uint32_t       RESERVED1[3U]; /**< Reserved for future use **/
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t LOCK;          /**< Configuration Lock Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IM uint32_t  CACHEHITS;     /**< Cache Hits Performance Counter  */
+  __IM uint32_t  CACHEMISSES;   /**< Cache Misses Performance Counter  */
+  uint32_t       RESERVED2[1U]; /**< Reserved for future use **/
+  __IOM uint32_t TIMEBASE;      /**< Flash Write and Erase Timebase  */
+  __IOM uint32_t MASSLOCK;      /**< Mass Erase Lock Register  */
+} MSC_TypeDef;                  /**< MSC Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32LG_MSC_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for MSC CTRL */
 #define _MSC_CTRL_RESETVALUE                    0x00000001UL                       /**< Default value for MSC_CTRL */

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_pcnt.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_pcnt.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32lg_pcnt.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32LG_PCNT register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,40 +40,40 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32LG_PCNT
  * @{
  * @brief EFM32LG_PCNT Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IOM uint32_t CTRL;         /**< Control Register  */
-  __IOM uint32_t CMD;          /**< Command Register  */
-  __IM uint32_t  STATUS;       /**< Status Register  */
-  __IM uint32_t  CNT;          /**< Counter Value Register  */
-  __IM uint32_t  TOP;          /**< Top Value Register  */
-  __IOM uint32_t TOPB;         /**< Top Value Buffer Register  */
-  __IM uint32_t  IF;           /**< Interrupt Flag Register  */
-  __IOM uint32_t IFS;          /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;          /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t IEN;          /**< Interrupt Enable Register  */
-  __IOM uint32_t ROUTE;        /**< I/O Routing Register  */
+  __IOM uint32_t CTRL;          /**< Control Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IM uint32_t  CNT;           /**< Counter Value Register  */
+  __IM uint32_t  TOP;           /**< Top Value Register  */
+  __IOM uint32_t TOPB;          /**< Top Value Buffer Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t ROUTE;         /**< I/O Routing Register  */
 
-  __IOM uint32_t FREEZE;       /**< Freeze Register  */
-  __IM uint32_t  SYNCBUSY;     /**< Synchronization Busy Register  */
+  __IOM uint32_t FREEZE;        /**< Freeze Register  */
+  __IM uint32_t  SYNCBUSY;      /**< Synchronization Busy Register  */
 
-  uint32_t       RESERVED0[1]; /**< Reserved for future use **/
-  __IOM uint32_t AUXCNT;       /**< Auxiliary Counter Value Register  */
-  __IOM uint32_t INPUT;        /**< PCNT Input Register  */
-} PCNT_TypeDef;                /**< PCNT Register Declaration *//** @} */
+  uint32_t       RESERVED0[1U]; /**< Reserved for future use **/
+  __IOM uint32_t AUXCNT;        /**< Auxiliary Counter Value Register  */
+  __IOM uint32_t INPUT;         /**< PCNT Input Register  */
+} PCNT_TypeDef;                 /**< PCNT Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32LG_PCNT_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for PCNT CTRL */
 #define _PCNT_CTRL_RESETVALUE             0x00000000UL                        /**< Default value for PCNT_CTRL */

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_prs.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_prs.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32lg_prs.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32LG_PRS register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,28 +40,28 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32LG_PRS
  * @{
  * @brief EFM32LG_PRS Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IOM uint32_t SWPULSE;      /**< Software Pulse Register  */
-  __IOM uint32_t SWLEVEL;      /**< Software Level Register  */
-  __IOM uint32_t ROUTE;        /**< I/O Routing Register  */
+  __IOM uint32_t SWPULSE;       /**< Software Pulse Register  */
+  __IOM uint32_t SWLEVEL;       /**< Software Level Register  */
+  __IOM uint32_t ROUTE;         /**< I/O Routing Register  */
 
-  uint32_t       RESERVED0[1]; /**< Reserved registers */
-  PRS_CH_TypeDef CH[12];       /**< Channel registers */
-} PRS_TypeDef;                 /**< PRS Register Declaration *//** @} */
+  uint32_t       RESERVED0[1U]; /**< Reserved registers */
+  PRS_CH_TypeDef CH[12U];       /**< Channel registers */
+} PRS_TypeDef;                  /**< PRS Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32LG_PRS_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for PRS SWPULSE */
 #define _PRS_SWPULSE_RESETVALUE                 0x00000000UL                           /**< Default value for PRS_SWPULSE */

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_prs_ch.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_prs_ch.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32lg_prs_ch.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32LG_PRS_CH register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,13 +40,13 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief PRS_CH EFM32LG PRS CH
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t CTRL; /**< Channel Control Register  */
 } PRS_CH_TypeDef;

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_prs_signals.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_prs_signals.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32lg_prs_signals.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32LG_PRS_SIGNALS register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @addtogroup EFM32LG_PRS_Signals
  * @{
  * @brief PRS Signal names
- *****************************************************************************/
+ ******************************************************************************/
 #define PRS_VCMP_OUT             ((1 << 16) + 0)  /**< PRS Voltage comparator output */
 #define PRS_ACMP0_OUT            ((2 << 16) + 0)  /**< PRS Analog comparator output */
 #define PRS_ACMP1_OUT            ((3 << 16) + 0)  /**< PRS Analog comparator output */

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_rmu.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_rmu.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32lg_rmu.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32LG_RMU register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,25 +40,25 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32LG_RMU
  * @{
  * @brief EFM32LG_RMU Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t CTRL;     /**< Control Register  */
   __IM uint32_t  RSTCAUSE; /**< Reset Cause Register  */
   __OM uint32_t  CMD;      /**< Command Register  */
 } RMU_TypeDef;             /**< RMU Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32LG_RMU_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for RMU CTRL */
 #define _RMU_CTRL_RESETVALUE                  0x00000002UL                        /**< Default value for RMU_CTRL */

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_romtable.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_romtable.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32lg_romtable.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32LG_ROMTABLE register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32LG_ROMTABLE
  * @{
  * @brief Chip Information, Revision numbers
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IM uint32_t PID4; /**< JEP_106_BANK */
   __IM uint32_t PID5; /**< Unused */
@@ -62,10 +61,10 @@ typedef struct {
   __IM uint32_t CID0; /**< Unused */
 } ROMTABLE_TypeDef;   /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32LG_ROMTABLE_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 /* Bit fields for EFM32LG_ROMTABLE */
 #define _ROMTABLE_PID0_FAMILYLSB_MASK       0x000000C0UL /**< Least Significant Bits [1:0] of CHIP FAMILY, mask */
 #define _ROMTABLE_PID0_FAMILYLSB_SHIFT      6            /**< Least Significant Bits [1:0] of CHIP FAMILY, shift */

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_rtc.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_rtc.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32lg_rtc.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32LG_RTC register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32LG_RTC
  * @{
  * @brief EFM32LG_RTC Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t CTRL;     /**< Control Register  */
   __IOM uint32_t CNT;      /**< Counter Value Register  */
@@ -64,10 +63,10 @@ typedef struct {
   __IM uint32_t  SYNCBUSY; /**< Synchronization Busy Register  */
 } RTC_TypeDef;             /**< RTC Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32LG_RTC_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for RTC CTRL */
 #define _RTC_CTRL_RESETVALUE             0x00000000UL                      /**< Default value for RTC_CTRL */

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_timer.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_timer.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32lg_timer.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32LG_TIMER register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,45 +40,45 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32LG_TIMER
  * @{
  * @brief EFM32LG_TIMER Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IOM uint32_t   CTRL;         /**< Control Register  */
-  __IOM uint32_t   CMD;          /**< Command Register  */
-  __IM uint32_t    STATUS;       /**< Status Register  */
-  __IOM uint32_t   IEN;          /**< Interrupt Enable Register  */
-  __IM uint32_t    IF;           /**< Interrupt Flag Register  */
-  __IOM uint32_t   IFS;          /**< Interrupt Flag Set Register  */
-  __IOM uint32_t   IFC;          /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t   TOP;          /**< Counter Top Value Register  */
-  __IOM uint32_t   TOPB;         /**< Counter Top Value Buffer Register  */
-  __IOM uint32_t   CNT;          /**< Counter Value Register  */
-  __IOM uint32_t   ROUTE;        /**< I/O Routing Register  */
+  __IOM uint32_t   CTRL;          /**< Control Register  */
+  __IOM uint32_t   CMD;           /**< Command Register  */
+  __IM uint32_t    STATUS;        /**< Status Register  */
+  __IOM uint32_t   IEN;           /**< Interrupt Enable Register  */
+  __IM uint32_t    IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t   IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t   IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t   TOP;           /**< Counter Top Value Register  */
+  __IOM uint32_t   TOPB;          /**< Counter Top Value Buffer Register  */
+  __IOM uint32_t   CNT;           /**< Counter Value Register  */
+  __IOM uint32_t   ROUTE;         /**< I/O Routing Register  */
 
-  uint32_t         RESERVED0[1]; /**< Reserved registers */
-  TIMER_CC_TypeDef CC[3];        /**< Compare/Capture Channel */
+  uint32_t         RESERVED0[1U]; /**< Reserved registers */
+  TIMER_CC_TypeDef CC[3U];        /**< Compare/Capture Channel */
 
-  uint32_t         RESERVED1[4]; /**< Reserved for future use **/
-  __IOM uint32_t   DTCTRL;       /**< DTI Control Register  */
-  __IOM uint32_t   DTTIME;       /**< DTI Time Control Register  */
-  __IOM uint32_t   DTFC;         /**< DTI Fault Configuration Register  */
-  __IOM uint32_t   DTOGEN;       /**< DTI Output Generation Enable Register  */
-  __IM uint32_t    DTFAULT;      /**< DTI Fault Register  */
-  __OM uint32_t    DTFAULTC;     /**< DTI Fault Clear Register  */
-  __IOM uint32_t   DTLOCK;       /**< DTI Configuration Lock Register  */
-} TIMER_TypeDef;                 /**< TIMER Register Declaration *//** @} */
+  uint32_t         RESERVED1[4U]; /**< Reserved for future use **/
+  __IOM uint32_t   DTCTRL;        /**< DTI Control Register  */
+  __IOM uint32_t   DTTIME;        /**< DTI Time Control Register  */
+  __IOM uint32_t   DTFC;          /**< DTI Fault Configuration Register  */
+  __IOM uint32_t   DTOGEN;        /**< DTI Output Generation Enable Register  */
+  __IM uint32_t    DTFAULT;       /**< DTI Fault Register  */
+  __OM uint32_t    DTFAULTC;      /**< DTI Fault Clear Register  */
+  __IOM uint32_t   DTLOCK;        /**< DTI Configuration Lock Register  */
+} TIMER_TypeDef;                  /**< TIMER Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32LG_TIMER_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for TIMER CTRL */
 #define _TIMER_CTRL_RESETVALUE                     0x00000000UL                             /**< Default value for TIMER_CTRL */

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_timer_cc.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_timer_cc.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32lg_timer_cc.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32LG_TIMER_CC register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,13 +40,13 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief TIMER_CC EFM32LG TIMER CC
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t CTRL; /**< CC Channel Control Register  */
   __IOM uint32_t CCV;  /**< CC Channel Value Register  */

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_uart.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_uart.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32lg_uart.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32LG_UART register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32LG_UART_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for UART CTRL */
 #define _UART_CTRL_RESETVALUE                0x00000000UL                            /**< Default value for UART_CTRL */

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_usart.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_usart.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32lg_usart.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32LG_USART register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32LG_USART
  * @{
  * @brief EFM32LG_USART Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t CTRL;       /**< Control Register  */
   __IOM uint32_t FRAME;      /**< USART Frame Format Register  */
@@ -77,10 +76,10 @@ typedef struct {
   __IOM uint32_t I2SCTRL;    /**< I2S Control Register  */
 } USART_TypeDef;             /**< USART Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32LG_USART_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for USART CTRL */
 #define _USART_CTRL_RESETVALUE                0x00000000UL                             /**< Default value for USART_CTRL */

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_usb.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_usb.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32lg_usb.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32LG_USB register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,155 +40,155 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32LG_USB
  * @{
  * @brief EFM32LG_USB Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IOM uint32_t   CTRL;              /**< System Control Register  */
-  __IM uint32_t    STATUS;            /**< System Status Register  */
-  __IM uint32_t    IF;                /**< Interrupt Flag Register  */
-  __IOM uint32_t   IFS;               /**< Interrupt Flag Set Register  */
-  __IOM uint32_t   IFC;               /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t   IEN;               /**< Interrupt Enable Register  */
-  __IOM uint32_t   ROUTE;             /**< I/O Routing Register  */
+  __IOM uint32_t   CTRL;               /**< System Control Register  */
+  __IM uint32_t    STATUS;             /**< System Status Register  */
+  __IM uint32_t    IF;                 /**< Interrupt Flag Register  */
+  __IOM uint32_t   IFS;                /**< Interrupt Flag Set Register  */
+  __IOM uint32_t   IFC;                /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t   IEN;                /**< Interrupt Enable Register  */
+  __IOM uint32_t   ROUTE;              /**< I/O Routing Register  */
 
-  uint32_t         RESERVED0[61433];  /**< Reserved for future use **/
-  __IOM uint32_t   GOTGCTL;           /**< OTG Control and Status Register  */
-  __IOM uint32_t   GOTGINT;           /**< OTG Interrupt Register  */
-  __IOM uint32_t   GAHBCFG;           /**< AHB Configuration Register  */
-  __IOM uint32_t   GUSBCFG;           /**< USB Configuration Register  */
-  __IOM uint32_t   GRSTCTL;           /**< Reset Register  */
-  __IOM uint32_t   GINTSTS;           /**< Interrupt Register  */
-  __IOM uint32_t   GINTMSK;           /**< Interrupt Mask Register  */
-  __IM uint32_t    GRXSTSR;           /**< Receive Status Debug Read Register  */
-  __IM uint32_t    GRXSTSP;           /**< Receive Status Read and Pop Register  */
-  __IOM uint32_t   GRXFSIZ;           /**< Receive FIFO Size Register  */
-  __IOM uint32_t   GNPTXFSIZ;         /**< Non-periodic Transmit FIFO Size Register  */
-  __IM uint32_t    GNPTXSTS;          /**< Non-periodic Transmit FIFO/Queue Status Register  */
-  uint32_t         RESERVED1[11];     /**< Reserved for future use **/
-  __IOM uint32_t   GDFIFOCFG;         /**< Global DFIFO Configuration Register  */
+  uint32_t         RESERVED0[61433U];  /**< Reserved for future use **/
+  __IOM uint32_t   GOTGCTL;            /**< OTG Control and Status Register  */
+  __IOM uint32_t   GOTGINT;            /**< OTG Interrupt Register  */
+  __IOM uint32_t   GAHBCFG;            /**< AHB Configuration Register  */
+  __IOM uint32_t   GUSBCFG;            /**< USB Configuration Register  */
+  __IOM uint32_t   GRSTCTL;            /**< Reset Register  */
+  __IOM uint32_t   GINTSTS;            /**< Interrupt Register  */
+  __IOM uint32_t   GINTMSK;            /**< Interrupt Mask Register  */
+  __IM uint32_t    GRXSTSR;            /**< Receive Status Debug Read Register  */
+  __IM uint32_t    GRXSTSP;            /**< Receive Status Read and Pop Register  */
+  __IOM uint32_t   GRXFSIZ;            /**< Receive FIFO Size Register  */
+  __IOM uint32_t   GNPTXFSIZ;          /**< Non-periodic Transmit FIFO Size Register  */
+  __IM uint32_t    GNPTXSTS;           /**< Non-periodic Transmit FIFO/Queue Status Register  */
+  uint32_t         RESERVED1[11U];     /**< Reserved for future use **/
+  __IOM uint32_t   GDFIFOCFG;          /**< Global DFIFO Configuration Register  */
 
-  uint32_t         RESERVED2[40];     /**< Reserved for future use **/
-  __IOM uint32_t   HPTXFSIZ;          /**< Host Periodic Transmit FIFO Size Register  */
-  __IOM uint32_t   DIEPTXF1;          /**< Device IN Endpoint Transmit FIFO 1 Size Register  */
-  __IOM uint32_t   DIEPTXF2;          /**< Device IN Endpoint Transmit FIFO 2 Size Register  */
-  __IOM uint32_t   DIEPTXF3;          /**< Device IN Endpoint Transmit FIFO 3 Size Register  */
-  __IOM uint32_t   DIEPTXF4;          /**< Device IN Endpoint Transmit FIFO 4 Size Register  */
-  __IOM uint32_t   DIEPTXF5;          /**< Device IN Endpoint Transmit FIFO 5 Size Register  */
-  __IOM uint32_t   DIEPTXF6;          /**< Device IN Endpoint Transmit FIFO 6 Size Register  */
+  uint32_t         RESERVED2[40U];     /**< Reserved for future use **/
+  __IOM uint32_t   HPTXFSIZ;           /**< Host Periodic Transmit FIFO Size Register  */
+  __IOM uint32_t   DIEPTXF1;           /**< Device IN Endpoint Transmit FIFO 1 Size Register  */
+  __IOM uint32_t   DIEPTXF2;           /**< Device IN Endpoint Transmit FIFO 2 Size Register  */
+  __IOM uint32_t   DIEPTXF3;           /**< Device IN Endpoint Transmit FIFO 3 Size Register  */
+  __IOM uint32_t   DIEPTXF4;           /**< Device IN Endpoint Transmit FIFO 4 Size Register  */
+  __IOM uint32_t   DIEPTXF5;           /**< Device IN Endpoint Transmit FIFO 5 Size Register  */
+  __IOM uint32_t   DIEPTXF6;           /**< Device IN Endpoint Transmit FIFO 6 Size Register  */
 
-  uint32_t         RESERVED3[185];    /**< Reserved for future use **/
-  __IOM uint32_t   HCFG;              /**< Host Configuration Register  */
-  __IOM uint32_t   HFIR;              /**< Host Frame Interval Register  */
-  __IM uint32_t    HFNUM;             /**< Host Frame Number/Frame Time Remaining Register  */
-  uint32_t         RESERVED4[1];      /**< Reserved for future use **/
-  __IM uint32_t    HPTXSTS;           /**< Host Periodic Transmit FIFO/Queue Status Register  */
-  __IM uint32_t    HAINT;             /**< Host All Channels Interrupt Register  */
-  __IOM uint32_t   HAINTMSK;          /**< Host All Channels Interrupt Mask Register  */
-  uint32_t         RESERVED5[9];      /**< Reserved for future use **/
-  __IOM uint32_t   HPRT;              /**< Host Port Control and Status Register  */
+  uint32_t         RESERVED3[185U];    /**< Reserved for future use **/
+  __IOM uint32_t   HCFG;               /**< Host Configuration Register  */
+  __IOM uint32_t   HFIR;               /**< Host Frame Interval Register  */
+  __IM uint32_t    HFNUM;              /**< Host Frame Number/Frame Time Remaining Register  */
+  uint32_t         RESERVED4[1U];      /**< Reserved for future use **/
+  __IM uint32_t    HPTXSTS;            /**< Host Periodic Transmit FIFO/Queue Status Register  */
+  __IM uint32_t    HAINT;              /**< Host All Channels Interrupt Register  */
+  __IOM uint32_t   HAINTMSK;           /**< Host All Channels Interrupt Mask Register  */
+  uint32_t         RESERVED5[9U];      /**< Reserved for future use **/
+  __IOM uint32_t   HPRT;               /**< Host Port Control and Status Register  */
 
-  uint32_t         RESERVED6[47];     /**< Reserved registers */
-  USB_HC_TypeDef   HC[14];            /**< Host Channel Registers */
+  uint32_t         RESERVED6[47U];     /**< Reserved registers */
+  USB_HC_TypeDef   HC[14U];            /**< Host Channel Registers */
 
-  uint32_t         RESERVED7[80];     /**< Reserved for future use **/
-  __IOM uint32_t   DCFG;              /**< Device Configuration Register  */
-  __IOM uint32_t   DCTL;              /**< Device Control Register  */
-  __IM uint32_t    DSTS;              /**< Device Status Register  */
-  uint32_t         RESERVED8[1];      /**< Reserved for future use **/
-  __IOM uint32_t   DIEPMSK;           /**< Device IN Endpoint Common Interrupt Mask Register  */
-  __IOM uint32_t   DOEPMSK;           /**< Device OUT Endpoint Common Interrupt Mask Register  */
-  __IM uint32_t    DAINT;             /**< Device All Endpoints Interrupt Register  */
-  __IOM uint32_t   DAINTMSK;          /**< Device All Endpoints Interrupt Mask Register  */
-  uint32_t         RESERVED9[2];      /**< Reserved for future use **/
-  __IOM uint32_t   DVBUSDIS;          /**< Device VBUS Discharge Time Register  */
-  __IOM uint32_t   DVBUSPULSE;        /**< Device VBUS Pulsing Time Register  */
+  uint32_t         RESERVED7[80U];     /**< Reserved for future use **/
+  __IOM uint32_t   DCFG;               /**< Device Configuration Register  */
+  __IOM uint32_t   DCTL;               /**< Device Control Register  */
+  __IM uint32_t    DSTS;               /**< Device Status Register  */
+  uint32_t         RESERVED8[1U];      /**< Reserved for future use **/
+  __IOM uint32_t   DIEPMSK;            /**< Device IN Endpoint Common Interrupt Mask Register  */
+  __IOM uint32_t   DOEPMSK;            /**< Device OUT Endpoint Common Interrupt Mask Register  */
+  __IM uint32_t    DAINT;              /**< Device All Endpoints Interrupt Register  */
+  __IOM uint32_t   DAINTMSK;           /**< Device All Endpoints Interrupt Mask Register  */
+  uint32_t         RESERVED9[2U];      /**< Reserved for future use **/
+  __IOM uint32_t   DVBUSDIS;           /**< Device VBUS Discharge Time Register  */
+  __IOM uint32_t   DVBUSPULSE;         /**< Device VBUS Pulsing Time Register  */
 
-  uint32_t         RESERVED10[1];     /**< Reserved for future use **/
-  __IOM uint32_t   DIEPEMPMSK;        /**< Device IN Endpoint FIFO Empty Interrupt Mask Register  */
+  uint32_t         RESERVED10[1U];     /**< Reserved for future use **/
+  __IOM uint32_t   DIEPEMPMSK;         /**< Device IN Endpoint FIFO Empty Interrupt Mask Register  */
 
-  uint32_t         RESERVED11[50];    /**< Reserved for future use **/
-  __IOM uint32_t   DIEP0CTL;          /**< Device IN Endpoint 0 Control Register  */
-  uint32_t         RESERVED12[1];     /**< Reserved for future use **/
-  __IOM uint32_t   DIEP0INT;          /**< Device IN Endpoint 0 Interrupt Register  */
-  uint32_t         RESERVED13[1];     /**< Reserved for future use **/
-  __IOM uint32_t   DIEP0TSIZ;         /**< Device IN Endpoint 0 Transfer Size Register  */
-  __IOM uint32_t   DIEP0DMAADDR;      /**< Device IN Endpoint 0 DMA Address Register  */
-  __IM uint32_t    DIEP0TXFSTS;       /**< Device IN Endpoint 0 Transmit FIFO Status Register  */
+  uint32_t         RESERVED11[50U];    /**< Reserved for future use **/
+  __IOM uint32_t   DIEP0CTL;           /**< Device IN Endpoint 0 Control Register  */
+  uint32_t         RESERVED12[1U];     /**< Reserved for future use **/
+  __IOM uint32_t   DIEP0INT;           /**< Device IN Endpoint 0 Interrupt Register  */
+  uint32_t         RESERVED13[1U];     /**< Reserved for future use **/
+  __IOM uint32_t   DIEP0TSIZ;          /**< Device IN Endpoint 0 Transfer Size Register  */
+  __IOM uint32_t   DIEP0DMAADDR;       /**< Device IN Endpoint 0 DMA Address Register  */
+  __IM uint32_t    DIEP0TXFSTS;        /**< Device IN Endpoint 0 Transmit FIFO Status Register  */
 
-  uint32_t         RESERVED14[1];     /**< Reserved registers */
-  USB_DIEP_TypeDef DIEP[6];           /**< Device IN Endpoint x+1 Registers */
+  uint32_t         RESERVED14[1U];     /**< Reserved registers */
+  USB_DIEP_TypeDef DIEP[6U];           /**< Device IN Endpoint x+1 Registers */
 
-  uint32_t         RESERVED15[72];    /**< Reserved for future use **/
-  __IOM uint32_t   DOEP0CTL;          /**< Device OUT Endpoint 0 Control Register  */
-  uint32_t         RESERVED16[1];     /**< Reserved for future use **/
-  __IOM uint32_t   DOEP0INT;          /**< Device OUT Endpoint 0 Interrupt Register  */
-  uint32_t         RESERVED17[1];     /**< Reserved for future use **/
-  __IOM uint32_t   DOEP0TSIZ;         /**< Device OUT Endpoint 0 Transfer Size Register  */
-  __IOM uint32_t   DOEP0DMAADDR;      /**< Device OUT Endpoint 0 DMA Address Register  */
+  uint32_t         RESERVED15[72U];    /**< Reserved for future use **/
+  __IOM uint32_t   DOEP0CTL;           /**< Device OUT Endpoint 0 Control Register  */
+  uint32_t         RESERVED16[1U];     /**< Reserved for future use **/
+  __IOM uint32_t   DOEP0INT;           /**< Device OUT Endpoint 0 Interrupt Register  */
+  uint32_t         RESERVED17[1U];     /**< Reserved for future use **/
+  __IOM uint32_t   DOEP0TSIZ;          /**< Device OUT Endpoint 0 Transfer Size Register  */
+  __IOM uint32_t   DOEP0DMAADDR;       /**< Device OUT Endpoint 0 DMA Address Register  */
 
-  uint32_t         RESERVED18[2];     /**< Reserved registers */
-  USB_DOEP_TypeDef DOEP[6];           /**< Device OUT Endpoint x+1 Registers */
+  uint32_t         RESERVED18[2U];     /**< Reserved registers */
+  USB_DOEP_TypeDef DOEP[6U];           /**< Device OUT Endpoint x+1 Registers */
 
-  uint32_t         RESERVED19[136];   /**< Reserved for future use **/
-  __IOM uint32_t   PCGCCTL;           /**< Power and Clock Gating Control Register  */
+  uint32_t         RESERVED19[136U];   /**< Reserved for future use **/
+  __IOM uint32_t   PCGCCTL;            /**< Power and Clock Gating Control Register  */
 
-  uint32_t         RESERVED20[127];   /**< Reserved registers */
-  __IOM uint32_t   FIFO0D[512];       /**< Device EP 0/Host Channel 0 FIFO  */
+  uint32_t         RESERVED20[127U];   /**< Reserved registers */
+  __IOM uint32_t   FIFO0D[512U];       /**< Device EP 0/Host Channel 0 FIFO  */
 
-  uint32_t         RESERVED21[512];   /**< Reserved registers */
-  __IOM uint32_t   FIFO1D[512];       /**< Device EP 1/Host Channel 1 FIFO  */
+  uint32_t         RESERVED21[512U];   /**< Reserved registers */
+  __IOM uint32_t   FIFO1D[512U];       /**< Device EP 1/Host Channel 1 FIFO  */
 
-  uint32_t         RESERVED22[512];   /**< Reserved registers */
-  __IOM uint32_t   FIFO2D[512];       /**< Device EP 2/Host Channel 2 FIFO  */
+  uint32_t         RESERVED22[512U];   /**< Reserved registers */
+  __IOM uint32_t   FIFO2D[512U];       /**< Device EP 2/Host Channel 2 FIFO  */
 
-  uint32_t         RESERVED23[512];   /**< Reserved registers */
-  __IOM uint32_t   FIFO3D[512];       /**< Device EP 3/Host Channel 3 FIFO  */
+  uint32_t         RESERVED23[512U];   /**< Reserved registers */
+  __IOM uint32_t   FIFO3D[512U];       /**< Device EP 3/Host Channel 3 FIFO  */
 
-  uint32_t         RESERVED24[512];   /**< Reserved registers */
-  __IOM uint32_t   FIFO4D[512];       /**< Device EP 4/Host Channel 4 FIFO  */
+  uint32_t         RESERVED24[512U];   /**< Reserved registers */
+  __IOM uint32_t   FIFO4D[512U];       /**< Device EP 4/Host Channel 4 FIFO  */
 
-  uint32_t         RESERVED25[512];   /**< Reserved registers */
-  __IOM uint32_t   FIFO5D[512];       /**< Device EP 5/Host Channel 5 FIFO  */
+  uint32_t         RESERVED25[512U];   /**< Reserved registers */
+  __IOM uint32_t   FIFO5D[512U];       /**< Device EP 5/Host Channel 5 FIFO  */
 
-  uint32_t         RESERVED26[512];   /**< Reserved registers */
-  __IOM uint32_t   FIFO6D[512];       /**< Device EP 6/Host Channel 6 FIFO  */
+  uint32_t         RESERVED26[512U];   /**< Reserved registers */
+  __IOM uint32_t   FIFO6D[512U];       /**< Device EP 6/Host Channel 6 FIFO  */
 
-  uint32_t         RESERVED27[512];   /**< Reserved registers */
-  __IOM uint32_t   FIFO7D[512];       /**< Host Channel 7 FIFO  */
+  uint32_t         RESERVED27[512U];   /**< Reserved registers */
+  __IOM uint32_t   FIFO7D[512U];       /**< Host Channel 7 FIFO  */
 
-  uint32_t         RESERVED28[512];   /**< Reserved registers */
-  __IOM uint32_t   FIFO8D[512];       /**< Host Channel 8 FIFO  */
+  uint32_t         RESERVED28[512U];   /**< Reserved registers */
+  __IOM uint32_t   FIFO8D[512U];       /**< Host Channel 8 FIFO  */
 
-  uint32_t         RESERVED29[512];   /**< Reserved registers */
-  __IOM uint32_t   FIFO9D[512];       /**< Host Channel 9 FIFO  */
+  uint32_t         RESERVED29[512U];   /**< Reserved registers */
+  __IOM uint32_t   FIFO9D[512U];       /**< Host Channel 9 FIFO  */
 
-  uint32_t         RESERVED30[512];   /**< Reserved registers */
-  __IOM uint32_t   FIFO10D[512];      /**< Host Channel 10 FIFO  */
+  uint32_t         RESERVED30[512U];   /**< Reserved registers */
+  __IOM uint32_t   FIFO10D[512U];      /**< Host Channel 10 FIFO  */
 
-  uint32_t         RESERVED31[512];   /**< Reserved registers */
-  __IOM uint32_t   FIFO11D[512];      /**< Host Channel 11 FIFO  */
+  uint32_t         RESERVED31[512U];   /**< Reserved registers */
+  __IOM uint32_t   FIFO11D[512U];      /**< Host Channel 11 FIFO  */
 
-  uint32_t         RESERVED32[512];   /**< Reserved registers */
-  __IOM uint32_t   FIFO12D[512];      /**< Host Channel 12 FIFO  */
+  uint32_t         RESERVED32[512U];   /**< Reserved registers */
+  __IOM uint32_t   FIFO12D[512U];      /**< Host Channel 12 FIFO  */
 
-  uint32_t         RESERVED33[512];   /**< Reserved registers */
-  __IOM uint32_t   FIFO13D[512];      /**< Host Channel 13 FIFO  */
+  uint32_t         RESERVED33[512U];   /**< Reserved registers */
+  __IOM uint32_t   FIFO13D[512U];      /**< Host Channel 13 FIFO  */
 
-  uint32_t         RESERVED34[17920]; /**< Reserved registers */
-  __IOM uint32_t   FIFORAM[512];      /**< Direct Access to Data FIFO RAM for Debugging (2 KB)  */
-} USB_TypeDef;                        /**< USB Register Declaration *//** @} */
+  uint32_t         RESERVED34[17920U]; /**< Reserved registers */
+  __IOM uint32_t   FIFORAM[512U];      /**< Direct Access to Data FIFO RAM for Debugging (2 KB)  */
+} USB_TypeDef;                         /**< USB Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32LG_USB_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for USB CTRL */
 #define _USB_CTRL_RESETVALUE                       0x00000000UL                           /**< Default value for USB_CTRL */

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_usb_diep.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_usb_diep.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32lg_usb_diep.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32LG_USB_DIEP register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,22 +40,22 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief USB_DIEP EFM32LG USB DIEP
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IOM uint32_t CTL;          /**< Device IN Endpoint x+1 Control Register  */
-  uint32_t       RESERVED0[1]; /**< Reserved for future use **/
-  __IOM uint32_t INT;          /**< Device IN Endpoint x+1 Interrupt Register  */
-  uint32_t       RESERVED1[1]; /**< Reserved for future use **/
-  __IOM uint32_t TSIZ;         /**< Device IN Endpoint x+1 Transfer Size Register  */
-  __IOM uint32_t DMAADDR;      /**< Device IN Endpoint x+1 DMA Address Register  */
-  __IM uint32_t  TXFSTS;       /**< Device IN Endpoint x+1 Transmit FIFO Status Register  */
-  uint32_t       RESERVED2[1]; /**< Reserved future */
+  __IOM uint32_t CTL;           /**< Device IN Endpoint x+1 Control Register  */
+  uint32_t       RESERVED0[1U]; /**< Reserved for future use **/
+  __IOM uint32_t INT;           /**< Device IN Endpoint x+1 Interrupt Register  */
+  uint32_t       RESERVED1[1U]; /**< Reserved for future use **/
+  __IOM uint32_t TSIZ;          /**< Device IN Endpoint x+1 Transfer Size Register  */
+  __IOM uint32_t DMAADDR;       /**< Device IN Endpoint x+1 DMA Address Register  */
+  __IM uint32_t  TXFSTS;        /**< Device IN Endpoint x+1 Transmit FIFO Status Register  */
+  uint32_t       RESERVED2[1U]; /**< Reserved future */
 } USB_DIEP_TypeDef;
 
 /** @} End of group Parts */

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_usb_doep.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_usb_doep.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32lg_usb_doep.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32LG_USB_DOEP register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,21 +40,21 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief USB_DOEP EFM32LG USB DOEP
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IOM uint32_t CTL;          /**< Device OUT Endpoint x+1 Control Register  */
-  uint32_t       RESERVED0[1]; /**< Reserved for future use **/
-  __IOM uint32_t INT;          /**< Device OUT Endpoint x+1 Interrupt Register  */
-  uint32_t       RESERVED1[1]; /**< Reserved for future use **/
-  __IOM uint32_t TSIZ;         /**< Device OUT Endpoint x+1 Transfer Size Register  */
-  __IOM uint32_t DMAADDR;      /**< Device OUT Endpoint x+1 DMA Address Register  */
-  uint32_t       RESERVED2[2]; /**< Reserved future */
+  __IOM uint32_t CTL;           /**< Device OUT Endpoint x+1 Control Register  */
+  uint32_t       RESERVED0[1U]; /**< Reserved for future use **/
+  __IOM uint32_t INT;           /**< Device OUT Endpoint x+1 Interrupt Register  */
+  uint32_t       RESERVED1[1U]; /**< Reserved for future use **/
+  __IOM uint32_t TSIZ;          /**< Device OUT Endpoint x+1 Transfer Size Register  */
+  __IOM uint32_t DMAADDR;       /**< Device OUT Endpoint x+1 DMA Address Register  */
+  uint32_t       RESERVED2[2U]; /**< Reserved future */
 } USB_DOEP_TypeDef;
 
 /** @} End of group Parts */

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_usb_hc.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_usb_hc.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32lg_usb_hc.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32LG_USB_HC register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,21 +40,21 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief USB_HC EFM32LG USB HC
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IOM uint32_t CHAR;         /**< Host Channel x Characteristics Register  */
-  uint32_t       RESERVED0[1]; /**< Reserved for future use **/
-  __IOM uint32_t INT;          /**< Host Channel x Interrupt Register  */
-  __IOM uint32_t INTMSK;       /**< Host Channel x Interrupt Mask Register  */
-  __IOM uint32_t TSIZ;         /**< Host Channel x Transfer Size Register  */
-  __IOM uint32_t DMAADDR;      /**< Host Channel x DMA Address Register  */
-  uint32_t       RESERVED1[2]; /**< Reserved future */
+  __IOM uint32_t CHAR;          /**< Host Channel x Characteristics Register  */
+  uint32_t       RESERVED0[1U]; /**< Reserved for future use **/
+  __IOM uint32_t INT;           /**< Host Channel x Interrupt Register  */
+  __IOM uint32_t INTMSK;        /**< Host Channel x Interrupt Mask Register  */
+  __IOM uint32_t TSIZ;          /**< Host Channel x Transfer Size Register  */
+  __IOM uint32_t DMAADDR;       /**< Host Channel x DMA Address Register  */
+  uint32_t       RESERVED1[2U]; /**< Reserved future */
 } USB_HC_TypeDef;
 
 /** @} End of group Parts */

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_vcmp.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_vcmp.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32lg_vcmp.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32LG_VCMP register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32LG_VCMP
  * @{
  * @brief EFM32LG_VCMP Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t CTRL;     /**< Control Register  */
   __IOM uint32_t INPUTSEL; /**< Input Selection Register  */
@@ -60,10 +59,10 @@ typedef struct {
   __IOM uint32_t IFC;      /**< Interrupt Flag Clear Register  */
 } VCMP_TypeDef;            /**< VCMP Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32LG_VCMP_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for VCMP CTRL */
 #define _VCMP_CTRL_RESETVALUE               0x47000000UL                         /**< Default value for VCMP_CTRL */

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_wdog.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_wdog.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32lg_wdog.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32LG_WDOG register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32LG_WDOG
  * @{
  * @brief EFM32LG_WDOG Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t CTRL;     /**< Control Register  */
   __IOM uint32_t CMD;      /**< Command Register  */
@@ -57,10 +56,10 @@ typedef struct {
   __IM uint32_t  SYNCBUSY; /**< Synchronization Busy Register  */
 } WDOG_TypeDef;            /**< WDOG Register Declaration *//** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32LG_WDOG_BitFields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for WDOG CTRL */
 #define _WDOG_CTRL_RESETVALUE            0x00000F00UL                         /**< Default value for WDOG_CTRL */

--- a/cpu/efm32/families/efm32lg/include/vendor/em_device.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/em_device.h
@@ -1,5 +1,5 @@
-/**************************************************************************//**
- * @file em_device.h
+/***************************************************************************//**
+ * @file
  * @brief CMSIS Cortex-M Peripheral Access Layer for Silicon Laboratories
  *        microcontroller devices
  *
@@ -9,37 +9,35 @@
  * @verbatim
  * Example: Add "-DEFM32G890F128" to your build options, to define part
  *          Add "#include "em_device.h" to your source files
-
- *
  * @endverbatim
- * @version 5.4.0
- ******************************************************************************
+ *
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {

--- a/cpu/efm32/families/efm32lg/include/vendor/system_efm32lg.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/system_efm32lg.h
@@ -1,34 +1,33 @@
 /***************************************************************************//**
- * @file system_efm32lg.h
+ * @file
  * @brief CMSIS Cortex-M3 System Layer for EFM32LG devices.
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifndef SYSTEM_EFM32LG_H
 #define SYSTEM_EFM32LG_H
@@ -39,14 +38,14 @@ extern "C" {
 
 #include <stdint.h>
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup Parts
  * @{
- *****************************************************************************/
-/**************************************************************************//**
+ ******************************************************************************/
+/***************************************************************************//**
  * @addtogroup EFM32LG EFM32LG
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /*******************************************************************************
  **************************   GLOBAL VARIABLES   *******************************
@@ -113,7 +112,7 @@ void EMU_IRQHandler(void);          /**< EMU IRQ Handler */
 uint32_t SystemCoreClockGet(void);
 uint32_t SystemMaxCoreClockGet(void);
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @brief
  *   Update CMSIS SystemCoreClock variable.
  *
@@ -126,7 +125,7 @@ uint32_t SystemMaxCoreClockGet(void);
  *   API, this variable will be kept updated. This function is only provided
  *   for CMSIS compliance and if a user modifies the the core clock outside
  *   the CMU API.
- *****************************************************************************/
+ ******************************************************************************/
 static __INLINE void SystemCoreClockUpdate(void)
 {
   (void)SystemCoreClockGet();

--- a/cpu/efm32/families/efm32lg/system.c
+++ b/cpu/efm32/families/efm32lg/system.c
@@ -1,34 +1,33 @@
 /***************************************************************************//**
- * @file system_efm32lg.c
+ * @file
  * @brief CMSIS Cortex-M3 System Layer for EFM32LG devices.
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #include <stdint.h>
 #include "em_device.h"
@@ -63,7 +62,7 @@
 #define EFM32_HFRCO_MAX_FREQ (28000000UL)
 
 /* Do not define variable if HF crystal oscillator not present */
-#if (EFM32_HFXO_FREQ > 0)
+#if (EFM32_HFXO_FREQ > 0U)
 /** @cond DO_NOT_INCLUDE_WITH_DOXYGEN */
 /** System HFXO clock. */
 static uint32_t SystemHFXOClock = EFM32_HFXO_FREQ;
@@ -76,7 +75,7 @@ static uint32_t SystemHFXOClock = EFM32_HFXO_FREQ;
 #endif
 
 /* Do not define variable if LF crystal oscillator not present */
-#if (EFM32_LFXO_FREQ > 0)
+#if (EFM32_LFXO_FREQ > 0U)
 /** @cond DO_NOT_INCLUDE_WITH_DOXYGEN */
 /** System LFXO clock. */
 static uint32_t SystemLFXOClock = EFM32_LFXO_FREQ;
@@ -106,6 +105,13 @@ uint32_t SystemCoreClock = 14000000UL;
 /*******************************************************************************
  **************************   GLOBAL FUNCTIONS   *******************************
  ******************************************************************************/
+
+#if defined(__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+#if defined(__ICCARM__)    /* IAR requires the __vector_table symbol */
+#define __Vectors    __vector_table
+#endif
+extern uint32_t __Vectors;
+#endif
 
 /***************************************************************************//**
  * @brief
@@ -174,12 +180,12 @@ uint32_t SystemHFClockGet(void)
   switch (CMU->STATUS & (CMU_STATUS_HFRCOSEL | CMU_STATUS_HFXOSEL
                          | CMU_STATUS_LFRCOSEL | CMU_STATUS_LFXOSEL)) {
     case CMU_STATUS_LFXOSEL:
-#if (EFM32_LFXO_FREQ > 0)
+#if (EFM32_LFXO_FREQ > 0U)
       ret = SystemLFXOClock;
 #else
       /* We should not get here, since core should not be clocked. May */
       /* be caused by a misconfiguration though. */
-      ret = 0;
+      ret = 0U;
 #endif
       break;
 
@@ -188,12 +194,12 @@ uint32_t SystemHFClockGet(void)
       break;
 
     case CMU_STATUS_HFXOSEL:
-#if (EFM32_HFXO_FREQ > 0)
+#if (EFM32_HFXO_FREQ > 0U)
       ret = SystemHFXOClock;
 #else
       /* We should not get here, since core should not be clocked. May */
       /* be caused by a misconfiguration though. */
-      ret = 0;
+      ret = 0U;
 #endif
       break;
 
@@ -232,7 +238,7 @@ uint32_t SystemHFClockGet(void)
           break;
 
         default:
-          ret = 0;
+          ret = 0U;
           break;
       }
       break;
@@ -242,7 +248,7 @@ uint32_t SystemHFClockGet(void)
                       >> _CMU_CTRL_HFCLKDIV_SHIFT));
 }
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @brief
  *   Get high frequency crystal oscillator clock frequency for target system.
  *
@@ -251,18 +257,18 @@ uint32_t SystemHFClockGet(void)
  *
  * @return
  *   HFXO frequency in Hz.
- *****************************************************************************/
+ ******************************************************************************/
 uint32_t SystemHFXOClockGet(void)
 {
   /* External crystal oscillator present? */
-#if (EFM32_HFXO_FREQ > 0)
+#if (EFM32_HFXO_FREQ > 0U)
   return SystemHFXOClock;
 #else
-  return 0;
+  return 0U;
 #endif
 }
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @brief
  *   Set high frequency crystal oscillator clock frequency for target system.
  *
@@ -276,11 +282,11 @@ uint32_t SystemHFXOClockGet(void)
  *
  * @param[in] freq
  *   HFXO frequency in Hz used for target.
- *****************************************************************************/
+ ******************************************************************************/
 void SystemHFXOClockSet(uint32_t freq)
 {
   /* External crystal oscillator present? */
-#if (EFM32_HFXO_FREQ > 0)
+#if (EFM32_HFXO_FREQ > 0U)
   SystemHFXOClock = freq;
 
   /* Update core clock frequency if HFXO is used to clock core */
@@ -293,7 +299,7 @@ void SystemHFXOClockSet(uint32_t freq)
 #endif
 }
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @brief
  *   Initialize the system.
  *
@@ -304,12 +310,19 @@ void SystemHFXOClockSet(uint32_t freq)
  *   This function is invoked during system init, before the main() routine
  *   and any data has been initialized. For this reason, it cannot do any
  *   initialization of variables etc.
- *****************************************************************************/
+ ******************************************************************************/
 void SystemInit(void)
 {
+#if defined(__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  SCB->VTOR = (uint32_t)&__Vectors;
+#endif
+
+#if defined(UNALIGNED_SUPPORT_DISABLE)
+  SCB->CCR |= SCB_CCR_UNALIGN_TRP_Msk;
+#endif
 }
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @brief
  *   Get low frequency RC oscillator clock frequency for target system.
  *
@@ -318,7 +331,7 @@ void SystemInit(void)
  *
  * @return
  *   LFRCO frequency in Hz.
- *****************************************************************************/
+ ******************************************************************************/
 uint32_t SystemLFRCOClockGet(void)
 {
   /* Currently we assume that this frequency is properly tuned during */
@@ -327,7 +340,7 @@ uint32_t SystemLFRCOClockGet(void)
   return EFM32_LFRCO_FREQ;
 }
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @brief
  *   Get ultra low frequency RC oscillator clock frequency for target system.
  *
@@ -336,14 +349,14 @@ uint32_t SystemLFRCOClockGet(void)
  *
  * @return
  *   ULFRCO frequency in Hz.
- *****************************************************************************/
+ ******************************************************************************/
 uint32_t SystemULFRCOClockGet(void)
 {
   /* The ULFRCO frequency is not tuned, and can be very inaccurate */
   return EFM32_ULFRCO_FREQ;
 }
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @brief
  *   Get low frequency crystal oscillator clock frequency for target system.
  *
@@ -352,18 +365,18 @@ uint32_t SystemULFRCOClockGet(void)
  *
  * @return
  *   LFXO frequency in Hz.
- *****************************************************************************/
+ ******************************************************************************/
 uint32_t SystemLFXOClockGet(void)
 {
   /* External crystal oscillator present? */
-#if (EFM32_LFXO_FREQ > 0)
+#if (EFM32_LFXO_FREQ > 0U)
   return SystemLFXOClock;
 #else
-  return 0;
+  return 0U;
 #endif
 }
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @brief
  *   Set low frequency crystal oscillator clock frequency for target system.
  *
@@ -377,11 +390,11 @@ uint32_t SystemLFXOClockGet(void)
  *
  * @param[in] freq
  *   LFXO frequency in Hz used for target.
- *****************************************************************************/
+ ******************************************************************************/
 void SystemLFXOClockSet(uint32_t freq)
 {
   /* External crystal oscillator present? */
-#if (EFM32_LFXO_FREQ > 0)
+#if (EFM32_LFXO_FREQ > 0U)
   SystemLFXOClock = freq;
 
   /* Update core clock frequency if LFXO is used to clock core */

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b500f1024gl125.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b500f1024gl125.h
@@ -1,35 +1,34 @@
-/**************************************************************************//**
- * @file efm32pg12b500f1024gl125.h
+/***************************************************************************//**
+ * @file
  * @brief CMSIS Cortex-M Peripheral Access Layer Header File
  *        for EFM32PG12B500F1024GL125
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #if defined(__ICCARM__)
 #pragma system_include       /* Treat file as system include file. */
@@ -44,15 +43,15 @@
 extern "C" {
 #endif
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup Parts
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32PG12B500F1024GL125 EFM32PG12B500F1024GL125
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /** Interrupt Number Definition */
 typedef enum IRQn{
@@ -113,23 +112,23 @@ typedef enum IRQn{
 
 #define CRYPTO_IRQn               CRYPTO0_IRQn /*!< Alias for CRYPTO0_IRQn */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32PG12B500F1024GL125_Core Core
  * @{
  * @brief Processor and Core Peripheral Section
- *****************************************************************************/
-#define __MPU_PRESENT             1 /**< Presence of MPU  */
-#define __FPU_PRESENT             1 /**< Presence of FPU  */
-#define __VTOR_PRESENT            1 /**< Presence of VTOR register in SCB */
-#define __NVIC_PRIO_BITS          3 /**< NVIC interrupt priority bits */
-#define __Vendor_SysTickConfig    0 /**< Is 1 if different SysTick counter is used */
+ ******************************************************************************/
+#define __MPU_PRESENT             1U /**< Presence of MPU  */
+#define __FPU_PRESENT             1U /**< Presence of FPU  */
+#define __VTOR_PRESENT            1U /**< Presence of VTOR register in SCB */
+#define __NVIC_PRIO_BITS          3U /**< NVIC interrupt priority bits */
+#define __Vendor_SysTickConfig    0U /**< Is 1 if different SysTick counter is used */
 
 /** @} End of group EFM32PG12B500F1024GL125_Core */
 
-/**************************************************************************//**
-* @defgroup EFM32PG12B500F1024GL125_Part Part
-* @{
-******************************************************************************/
+/***************************************************************************//**
+ * @defgroup EFM32PG12B500F1024GL125_Part Part
+ * @{
+ ******************************************************************************/
 
 /** Part family */
 #define _EFM32_PEARL_FAMILY                     1  /**< PEARL Gecko MCU Family  */
@@ -241,7 +240,7 @@ typedef enum IRQn{
 #define FLASH_PAGE_SIZE            2048U          /**< Flash Memory page size (interleaving off) */
 #define SRAM_BASE                  (0x20000000UL) /**< SRAM Base Address */
 #define SRAM_SIZE                  (0x00040000UL) /**< Available SRAM Memory */
-#define __CM4_REV                  0x001          /**< Cortex-M4 Core revision r0p1 */
+#define __CM4_REV                  0x0001U        /**< Cortex-M4 Core revision r0p1 */
 #define PRS_CHAN_COUNT             12             /**< Number of PRS channels */
 #define DMA_CHAN_COUNT             8              /**< Number of DMA channels */
 #define EXT_IRQ_COUNT              51             /**< Number of External (NVIC) interrupts */
@@ -323,11 +322,11 @@ typedef enum IRQn{
 
 /** @} End of group EFM32PG12B500F1024GL125_Part */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32PG12B500F1024GL125_Peripheral_TypeDefs Peripheral TypeDefs
  * @{
  * @brief Device Specific Peripheral Register Structures
- *****************************************************************************/
+ ******************************************************************************/
 
 #include "efm32pg12b_msc.h"
 #include "efm32pg12b_emu.h"
@@ -374,10 +373,10 @@ typedef enum IRQn{
 
 /** @} End of group EFM32PG12B500F1024GL125_Peripheral_TypeDefs  */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32PG12B500F1024GL125_Peripheral_Base Peripheral Memory Map
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 #define MSC_BASE          (0x400E0000UL) /**< MSC base address  */
 #define EMU_BASE          (0x400E3000UL) /**< EMU base address  */
@@ -427,10 +426,10 @@ typedef enum IRQn{
 
 /** @} End of group EFM32PG12B500F1024GL125_Peripheral_Base */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32PG12B500F1024GL125_Peripheral_Declaration Peripheral Declarations
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 #define MSC          ((MSC_TypeDef *) MSC_BASE)             /**< MSC base pointer */
 #define EMU          ((EMU_TypeDef *) EMU_BASE)             /**< EMU base pointer */
@@ -478,10 +477,10 @@ typedef enum IRQn{
 
 /** @} End of group EFM32PG12B500F1024GL125_Peripheral_Declaration */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32PG12B500F1024GL125_Peripheral_Offsets Peripheral Offsets
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 #define CRYPTO_OFFSET     0x400 /**< Offset in bytes between CRYPTO instances */
 #define TIMER_OFFSET      0x400 /**< Offset in bytes between TIMER instances */
@@ -500,20 +499,20 @@ typedef enum IRQn{
 
 /** @} End of group EFM32PG12B500F1024GL125_Peripheral_Offsets */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32PG12B500F1024GL125_BitFields Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 #include "efm32pg12b_prs_signals.h"
 #include "efm32pg12b_dmareq.h"
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG12B500F1024GL125_WTIMER
  * @{
  * @defgroup EFM32PG12B500F1024GL125_WTIMER_BitFields  WTIMER Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for WTIMER CTRL */
 #define _WTIMER_CTRL_RESETVALUE                     0x00000000UL                              /**< Default value for WTIMER_CTRL */
@@ -2014,10 +2013,10 @@ typedef enum IRQn{
 /** @} */
 /** @} End of group EFM32PG12B500F1024GL125_WTIMER */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32PG12B500F1024GL125_UNLOCK Unlock Codes
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 #define MSC_UNLOCK_CODE      0x1B71 /**< MSC unlock code */
 #define EMU_UNLOCK_CODE      0xADE8 /**< EMU unlock code */
 #define RMU_UNLOCK_CODE      0xE084 /**< RMU unlock code */

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_acmp.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_acmp.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg12b_acmp.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG12B_ACMP register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG12B_ACMP ACMP
  * @{
  * @brief EFM32PG12B_ACMP Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** ACMP Register Declaration */
 typedef struct {
   __IOM uint32_t CTRL;          /**< Control Register  */
@@ -59,24 +58,24 @@ typedef struct {
   __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
   __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
   __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
-  uint32_t       RESERVED0[1];  /**< Reserved for future use **/
+  uint32_t       RESERVED0[1U]; /**< Reserved for future use **/
   __IM uint32_t  APORTREQ;      /**< APORT Request Status Register  */
   __IM uint32_t  APORTCONFLICT; /**< APORT Conflict Status Register  */
   __IOM uint32_t HYSTERESIS0;   /**< Hysteresis 0 Register  */
   __IOM uint32_t HYSTERESIS1;   /**< Hysteresis 1 Register  */
 
-  uint32_t       RESERVED1[4];  /**< Reserved for future use **/
+  uint32_t       RESERVED1[4U]; /**< Reserved for future use **/
   __IOM uint32_t ROUTEPEN;      /**< I/O Routing Pine Enable Register  */
   __IOM uint32_t ROUTELOC0;     /**< I/O Routing Location Register  */
   __IOM uint32_t EXTIFCTRL;     /**< External Override Interface Control  */
 } ACMP_TypeDef;                 /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG12B_ACMP
  * @{
  * @defgroup EFM32PG12B_ACMP_BitFields  ACMP Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for ACMP CTRL */
 #define _ACMP_CTRL_RESETVALUE                          0x07000000UL                               /**< Default value for ACMP_CTRL */

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_adc.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_adc.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg12b_adc.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG12B_ADC register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,19 +40,19 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG12B_ADC ADC
  * @{
  * @brief EFM32PG12B_ADC Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** ADC Register Declaration */
 typedef struct {
   __IOM uint32_t CTRL;            /**< Control Register  */
-  uint32_t       RESERVED0[1];    /**< Reserved for future use **/
+  uint32_t       RESERVED0[1U];   /**< Reserved for future use **/
   __IOM uint32_t CMD;             /**< Command Register  */
   __IM uint32_t  STATUS;          /**< Status Register  */
   __IOM uint32_t SINGLECTRL;      /**< Single Channel Control Register  */
@@ -74,11 +73,11 @@ typedef struct {
   __IM uint32_t  SCANDATA;        /**< Scan Conversion Result Data  */
   __IM uint32_t  SINGLEDATAP;     /**< Single Conversion Result Data Peek Register  */
   __IM uint32_t  SCANDATAP;       /**< Scan Sequence Result Data Peek Register  */
-  uint32_t       RESERVED1[4];    /**< Reserved for future use **/
+  uint32_t       RESERVED1[4U];   /**< Reserved for future use **/
   __IM uint32_t  SCANDATAX;       /**< Scan Sequence Result Data + Data Source Register  */
   __IM uint32_t  SCANDATAXP;      /**< Scan Sequence Result Data + Data Source Peek Register  */
 
-  uint32_t       RESERVED2[3];    /**< Reserved for future use **/
+  uint32_t       RESERVED2[3U];   /**< Reserved for future use **/
   __IM uint32_t  APORTREQ;        /**< APORT Request Status Register  */
   __IM uint32_t  APORTCONFLICT;   /**< APORT Conflict Status Register  */
   __IM uint32_t  SINGLEFIFOCOUNT; /**< Single FIFO Count Register  */
@@ -88,12 +87,12 @@ typedef struct {
   __IOM uint32_t APORTMASTERDIS;  /**< APORT Bus Master Disable Register  */
 } ADC_TypeDef;                    /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG12B_ADC
  * @{
  * @defgroup EFM32PG12B_ADC_BitFields  ADC Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for ADC CTRL */
 #define _ADC_CTRL_RESETVALUE                               0x001F0000UL                                  /**< Default value for ADC_CTRL */
@@ -499,12 +498,12 @@ typedef struct {
 #define _ADC_SINGLECTRL_POSSEL_APORT4YCH30                 0x0000009EUL                               /**< Mode APORT4YCH30 for ADC_SINGLECTRL */
 #define _ADC_SINGLECTRL_POSSEL_APORT4XCH31                 0x0000009FUL                               /**< Mode APORT4XCH31 for ADC_SINGLECTRL */
 #define _ADC_SINGLECTRL_POSSEL_AVDD                        0x000000E0UL                               /**< Mode AVDD for ADC_SINGLECTRL */
-#define _ADC_SINGLECTRL_POSSEL_BU                          0x000000E1UL                               /**< Mode BU for ADC_SINGLECTRL */
-#define _ADC_SINGLECTRL_POSSEL_AREG                        0x000000E2UL                               /**< Mode AREG for ADC_SINGLECTRL */
-#define _ADC_SINGLECTRL_POSSEL_VREGOUTPA                   0x000000E3UL                               /**< Mode VREGOUTPA for ADC_SINGLECTRL */
-#define _ADC_SINGLECTRL_POSSEL_PDBU                        0x000000E4UL                               /**< Mode PDBU for ADC_SINGLECTRL */
-#define _ADC_SINGLECTRL_POSSEL_IO0                         0x000000E5UL                               /**< Mode IO0 for ADC_SINGLECTRL */
-#define _ADC_SINGLECTRL_POSSEL_IO1                         0x000000E6UL                               /**< Mode IO1 for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_POSSEL_BUVDD                       0x000000E1UL                               /**< Mode BUVDD for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_POSSEL_DVDD                        0x000000E2UL                               /**< Mode DVDD for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_POSSEL_PAVDD                       0x000000E3UL                               /**< Mode PAVDD for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_POSSEL_DECOUPLE                    0x000000E4UL                               /**< Mode DECOUPLE for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_POSSEL_IOVDD                       0x000000E5UL                               /**< Mode IOVDD for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_POSSEL_IOVDD1                      0x000000E6UL                               /**< Mode IOVDD1 for ADC_SINGLECTRL */
 #define _ADC_SINGLECTRL_POSSEL_VSP                         0x000000E7UL                               /**< Mode VSP for ADC_SINGLECTRL */
 #define _ADC_SINGLECTRL_POSSEL_OPA2                        0x000000F2UL                               /**< Mode OPA2 for ADC_SINGLECTRL */
 #define _ADC_SINGLECTRL_POSSEL_TEMP                        0x000000F3UL                               /**< Mode TEMP for ADC_SINGLECTRL */
@@ -678,12 +677,12 @@ typedef struct {
 #define ADC_SINGLECTRL_POSSEL_APORT4YCH30                  (_ADC_SINGLECTRL_POSSEL_APORT4YCH30 << 8)  /**< Shifted mode APORT4YCH30 for ADC_SINGLECTRL */
 #define ADC_SINGLECTRL_POSSEL_APORT4XCH31                  (_ADC_SINGLECTRL_POSSEL_APORT4XCH31 << 8)  /**< Shifted mode APORT4XCH31 for ADC_SINGLECTRL */
 #define ADC_SINGLECTRL_POSSEL_AVDD                         (_ADC_SINGLECTRL_POSSEL_AVDD << 8)         /**< Shifted mode AVDD for ADC_SINGLECTRL */
-#define ADC_SINGLECTRL_POSSEL_BU                           (_ADC_SINGLECTRL_POSSEL_BU << 8)           /**< Shifted mode BU for ADC_SINGLECTRL */
-#define ADC_SINGLECTRL_POSSEL_AREG                         (_ADC_SINGLECTRL_POSSEL_AREG << 8)         /**< Shifted mode AREG for ADC_SINGLECTRL */
-#define ADC_SINGLECTRL_POSSEL_VREGOUTPA                    (_ADC_SINGLECTRL_POSSEL_VREGOUTPA << 8)    /**< Shifted mode VREGOUTPA for ADC_SINGLECTRL */
-#define ADC_SINGLECTRL_POSSEL_PDBU                         (_ADC_SINGLECTRL_POSSEL_PDBU << 8)         /**< Shifted mode PDBU for ADC_SINGLECTRL */
-#define ADC_SINGLECTRL_POSSEL_IO0                          (_ADC_SINGLECTRL_POSSEL_IO0 << 8)          /**< Shifted mode IO0 for ADC_SINGLECTRL */
-#define ADC_SINGLECTRL_POSSEL_IO1                          (_ADC_SINGLECTRL_POSSEL_IO1 << 8)          /**< Shifted mode IO1 for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_POSSEL_BUVDD                        (_ADC_SINGLECTRL_POSSEL_BUVDD << 8)        /**< Shifted mode BUVDD for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_POSSEL_DVDD                         (_ADC_SINGLECTRL_POSSEL_DVDD << 8)         /**< Shifted mode DVDD for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_POSSEL_PAVDD                        (_ADC_SINGLECTRL_POSSEL_PAVDD << 8)        /**< Shifted mode PAVDD for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_POSSEL_DECOUPLE                     (_ADC_SINGLECTRL_POSSEL_DECOUPLE << 8)     /**< Shifted mode DECOUPLE for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_POSSEL_IOVDD                        (_ADC_SINGLECTRL_POSSEL_IOVDD << 8)        /**< Shifted mode IOVDD for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_POSSEL_IOVDD1                       (_ADC_SINGLECTRL_POSSEL_IOVDD1 << 8)       /**< Shifted mode IOVDD1 for ADC_SINGLECTRL */
 #define ADC_SINGLECTRL_POSSEL_VSP                          (_ADC_SINGLECTRL_POSSEL_VSP << 8)          /**< Shifted mode VSP for ADC_SINGLECTRL */
 #define ADC_SINGLECTRL_POSSEL_OPA2                         (_ADC_SINGLECTRL_POSSEL_OPA2 << 8)         /**< Shifted mode OPA2 for ADC_SINGLECTRL */
 #define ADC_SINGLECTRL_POSSEL_TEMP                         (_ADC_SINGLECTRL_POSSEL_TEMP << 8)         /**< Shifted mode TEMP for ADC_SINGLECTRL */

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_af_pins.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_af_pins.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg12b_af_pins.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG12B_AF_PINS register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,16 +40,16 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @addtogroup EFM32PG12B_Alternate_Function Alternate Function
  * @{
  * @defgroup EFM32PG12B_AF_Pins  Alternate Function Pins
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 #define AF_CMU_CLK0_PIN(i)          ((i) == 0 ? 1 : (i) == 1 ? 15 : (i) == 2 ? 6 : (i) == 3 ? 11 : (i) == 4 ? 9 : (i) == 5 ? 14 : (i) == 6 ? 2 : (i) == 7 ? 7 :  -1)                                                                                                                                                                                                                                                                                                                                                                                                           /**< Pin number for AF_CMU_CLK0 location number i */
 #define AF_CMU_CLK1_PIN(i)          ((i) == 0 ? 0 : (i) == 1 ? 14 : (i) == 2 ? 7 : (i) == 3 ? 10 : (i) == 4 ? 10 : (i) == 5 ? 15 : (i) == 6 ? 3 : (i) == 7 ? 6 :  -1)                                                                                                                                                                                                                                                                                                                                                                                                          /**< Pin number for AF_CMU_CLK1 location number i */

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_af_ports.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_af_ports.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg12b_af_ports.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG12B_AF_PORTS register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,16 +40,16 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @addtogroup EFM32PG12B_Alternate_Function Alternate Function
  * @{
  * @defgroup EFM32PG12B_AF_Ports Alternate Function Ports
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 #define AF_CMU_CLK0_PORT(i)          ((i) == 0 ? 0 : (i) == 1 ? 1 : (i) == 2 ? 2 : (i) == 3 ? 2 : (i) == 4 ? 3 : (i) == 5 ? 3 : (i) == 6 ? 5 : (i) == 7 ? 5 :  -1)                                                                                                                                                                                                                                                                                                                                                                                                  /**< Port number for AF_CMU_CLK0 location number i */
 #define AF_CMU_CLK1_PORT(i)          ((i) == 0 ? 0 : (i) == 1 ? 1 : (i) == 2 ? 2 : (i) == 3 ? 2 : (i) == 4 ? 3 : (i) == 5 ? 3 : (i) == 6 ? 5 : (i) == 7 ? 5 :  -1)                                                                                                                                                                                                                                                                                                                                                                                                  /**< Port number for AF_CMU_CLK1 location number i */

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_cmu.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_cmu.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg12b_cmu.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG12B_CMU register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,56 +40,56 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG12B_CMU CMU
  * @{
  * @brief EFM32PG12B_CMU Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** CMU Register Declaration */
 typedef struct {
   __IOM uint32_t CTRL;                /**< CMU Control Register  */
 
-  uint32_t       RESERVED0[3];        /**< Reserved for future use **/
+  uint32_t       RESERVED0[3U];       /**< Reserved for future use **/
   __IOM uint32_t HFRCOCTRL;           /**< HFRCO Control Register  */
 
-  uint32_t       RESERVED1[1];        /**< Reserved for future use **/
+  uint32_t       RESERVED1[1U];       /**< Reserved for future use **/
   __IOM uint32_t AUXHFRCOCTRL;        /**< AUXHFRCO Control Register  */
 
-  uint32_t       RESERVED2[1];        /**< Reserved for future use **/
+  uint32_t       RESERVED2[1U];       /**< Reserved for future use **/
   __IOM uint32_t LFRCOCTRL;           /**< LFRCO Control Register  */
   __IOM uint32_t HFXOCTRL;            /**< HFXO Control Register  */
 
-  uint32_t       RESERVED3[1];        /**< Reserved for future use **/
+  uint32_t       RESERVED3[1U];       /**< Reserved for future use **/
   __IOM uint32_t HFXOSTARTUPCTRL;     /**< HFXO Startup Control  */
   __IOM uint32_t HFXOSTEADYSTATECTRL; /**< HFXO Steady State Control  */
   __IOM uint32_t HFXOTIMEOUTCTRL;     /**< HFXO Timeout Control  */
   __IOM uint32_t LFXOCTRL;            /**< LFXO Control Register  */
 
-  uint32_t       RESERVED4[1];        /**< Reserved for future use **/
+  uint32_t       RESERVED4[1U];       /**< Reserved for future use **/
   __IOM uint32_t DPLLCTRL;            /**< DPLL Control Register  */
   __IOM uint32_t DPLLCTRL1;           /**< DPLL Control Register  */
-  uint32_t       RESERVED5[2];        /**< Reserved for future use **/
+  uint32_t       RESERVED5[2U];       /**< Reserved for future use **/
   __IOM uint32_t CALCTRL;             /**< Calibration Control Register  */
   __IOM uint32_t CALCNT;              /**< Calibration Counter Register  */
-  uint32_t       RESERVED6[2];        /**< Reserved for future use **/
+  uint32_t       RESERVED6[2U];       /**< Reserved for future use **/
   __IOM uint32_t OSCENCMD;            /**< Oscillator Enable/Disable Command Register  */
   __IOM uint32_t CMD;                 /**< Command Register  */
-  uint32_t       RESERVED7[2];        /**< Reserved for future use **/
+  uint32_t       RESERVED7[2U];       /**< Reserved for future use **/
   __IOM uint32_t DBGCLKSEL;           /**< Debug Trace Clock Select  */
   __IOM uint32_t HFCLKSEL;            /**< High Frequency Clock Select Command Register  */
-  uint32_t       RESERVED8[2];        /**< Reserved for future use **/
+  uint32_t       RESERVED8[2U];       /**< Reserved for future use **/
   __IOM uint32_t LFACLKSEL;           /**< Low Frequency A Clock Select Register  */
   __IOM uint32_t LFBCLKSEL;           /**< Low Frequency B Clock Select Register  */
   __IOM uint32_t LFECLKSEL;           /**< Low Frequency E Clock Select Register  */
 
-  uint32_t       RESERVED9[1];        /**< Reserved for future use **/
+  uint32_t       RESERVED9[1U];       /**< Reserved for future use **/
   __IM uint32_t  STATUS;              /**< Status Register  */
   __IM uint32_t  HFCLKSTATUS;         /**< HFCLK Status Register  */
-  uint32_t       RESERVED10[1];       /**< Reserved for future use **/
+  uint32_t       RESERVED10[1U];      /**< Reserved for future use **/
   __IM uint32_t  HFXOTRIMSTATUS;      /**< HFXO Trim Status  */
   __IM uint32_t  IF;                  /**< Interrupt Flag Register  */
   __IOM uint32_t IFS;                 /**< Interrupt Flag Set Register  */
@@ -98,57 +97,57 @@ typedef struct {
   __IOM uint32_t IEN;                 /**< Interrupt Enable Register  */
   __IOM uint32_t HFBUSCLKEN0;         /**< High Frequency Bus Clock Enable Register 0  */
 
-  uint32_t       RESERVED11[3];       /**< Reserved for future use **/
+  uint32_t       RESERVED11[3U];      /**< Reserved for future use **/
   __IOM uint32_t HFPERCLKEN0;         /**< High Frequency Peripheral Clock Enable Register 0  */
 
-  uint32_t       RESERVED12[7];       /**< Reserved for future use **/
+  uint32_t       RESERVED12[7U];      /**< Reserved for future use **/
   __IOM uint32_t LFACLKEN0;           /**< Low Frequency a Clock Enable Register 0  (Async Reg)  */
-  uint32_t       RESERVED13[1];       /**< Reserved for future use **/
+  uint32_t       RESERVED13[1U];      /**< Reserved for future use **/
   __IOM uint32_t LFBCLKEN0;           /**< Low Frequency B Clock Enable Register 0 (Async Reg)  */
 
-  uint32_t       RESERVED14[1];       /**< Reserved for future use **/
+  uint32_t       RESERVED14[1U];      /**< Reserved for future use **/
   __IOM uint32_t LFECLKEN0;           /**< Low Frequency E Clock Enable Register 0 (Async Reg)  */
-  uint32_t       RESERVED15[3];       /**< Reserved for future use **/
+  uint32_t       RESERVED15[3U];      /**< Reserved for future use **/
   __IOM uint32_t HFPRESC;             /**< High Frequency Clock Prescaler Register  */
 
-  uint32_t       RESERVED16[1];       /**< Reserved for future use **/
+  uint32_t       RESERVED16[1U];      /**< Reserved for future use **/
   __IOM uint32_t HFCOREPRESC;         /**< High Frequency Core Clock Prescaler Register  */
   __IOM uint32_t HFPERPRESC;          /**< High Frequency Peripheral Clock Prescaler Register  */
 
-  uint32_t       RESERVED17[1];       /**< Reserved for future use **/
+  uint32_t       RESERVED17[1U];      /**< Reserved for future use **/
   __IOM uint32_t HFEXPPRESC;          /**< High Frequency Export Clock Prescaler Register  */
 
-  uint32_t       RESERVED18[2];       /**< Reserved for future use **/
+  uint32_t       RESERVED18[2U];      /**< Reserved for future use **/
   __IOM uint32_t LFAPRESC0;           /**< Low Frequency a Prescaler Register 0 (Async Reg)  */
-  uint32_t       RESERVED19[1];       /**< Reserved for future use **/
+  uint32_t       RESERVED19[1U];      /**< Reserved for future use **/
   __IOM uint32_t LFBPRESC0;           /**< Low Frequency B Prescaler Register 0  (Async Reg)  */
-  uint32_t       RESERVED20[1];       /**< Reserved for future use **/
+  uint32_t       RESERVED20[1U];      /**< Reserved for future use **/
   __IOM uint32_t LFEPRESC0;           /**< Low Frequency E Prescaler Register 0  (Async Reg)  */
 
-  uint32_t       RESERVED21[3];       /**< Reserved for future use **/
+  uint32_t       RESERVED21[3U];      /**< Reserved for future use **/
   __IM uint32_t  SYNCBUSY;            /**< Synchronization Busy Register  */
   __IOM uint32_t FREEZE;              /**< Freeze Register  */
-  uint32_t       RESERVED22[2];       /**< Reserved for future use **/
+  uint32_t       RESERVED22[2U];      /**< Reserved for future use **/
   __IOM uint32_t PCNTCTRL;            /**< PCNT Control Register  */
 
-  uint32_t       RESERVED23[2];       /**< Reserved for future use **/
+  uint32_t       RESERVED23[2U];      /**< Reserved for future use **/
   __IOM uint32_t ADCCTRL;             /**< ADC Control Register  */
 
-  uint32_t       RESERVED24[4];       /**< Reserved for future use **/
+  uint32_t       RESERVED24[4U];      /**< Reserved for future use **/
   __IOM uint32_t ROUTEPEN;            /**< I/O Routing Pin Enable Register  */
   __IOM uint32_t ROUTELOC0;           /**< I/O Routing Location Register  */
   __IOM uint32_t ROUTELOC1;           /**< I/O Routing Location Register  */
-  uint32_t       RESERVED25[1];       /**< Reserved for future use **/
+  uint32_t       RESERVED25[1U];      /**< Reserved for future use **/
   __IOM uint32_t LOCK;                /**< Configuration Lock Register  */
   __IOM uint32_t HFRCOSS;             /**< HFRCO Spread Spectrum Register  */
 } CMU_TypeDef;                        /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG12B_CMU
  * @{
  * @defgroup EFM32PG12B_CMU_BitFields  CMU Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for CMU CTRL */
 #define _CMU_CTRL_RESETVALUE                              0x00300000UL                          /**< Default value for CMU_CTRL */

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_cryotimer.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_cryotimer.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg12b_cryotimer.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG12B_CRYOTIMER register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG12B_CRYOTIMER CRYOTIMER
  * @{
  * @brief EFM32PG12B_CRYOTIMER Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** CRYOTIMER Register Declaration */
 typedef struct {
   __IOM uint32_t CTRL;      /**< Control Register  */
@@ -62,12 +61,12 @@ typedef struct {
   __IOM uint32_t IEN;       /**< Interrupt Enable Register  */
 } CRYOTIMER_TypeDef;        /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG12B_CRYOTIMER
  * @{
  * @defgroup EFM32PG12B_CRYOTIMER_BitFields  CRYOTIMER Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for CRYOTIMER CTRL */
 #define _CRYOTIMER_CTRL_RESETVALUE                0x00000000UL                            /**< Default value for CRYOTIMER_CTRL */

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_crypto.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_crypto.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg12b_crypto.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG12B_CRYPTO register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,84 +40,84 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG12B_CRYPTO CRYPTO
  * @{
  * @brief EFM32PG12B_CRYPTO Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** CRYPTO Register Declaration */
 typedef struct {
-  __IOM uint32_t CTRL;           /**< Control Register  */
-  __IOM uint32_t WAC;            /**< Wide Arithmetic Configuration  */
-  __IOM uint32_t CMD;            /**< Command Register  */
-  uint32_t       RESERVED0[1];   /**< Reserved for future use **/
-  __IM uint32_t  STATUS;         /**< Status Register  */
-  __IM uint32_t  DSTATUS;        /**< Data Status Register  */
-  __IM uint32_t  CSTATUS;        /**< Control Status Register  */
-  uint32_t       RESERVED1[1];   /**< Reserved for future use **/
-  __IOM uint32_t KEY;            /**< KEY Register Access  */
-  __IOM uint32_t KEYBUF;         /**< KEY Buffer Register Access  */
-  uint32_t       RESERVED2[2];   /**< Reserved for future use **/
-  __IOM uint32_t SEQCTRL;        /**< Sequence Control  */
-  __IOM uint32_t SEQCTRLB;       /**< Sequence Control B  */
-  uint32_t       RESERVED3[2];   /**< Reserved for future use **/
-  __IM uint32_t  IF;             /**< AES Interrupt Flags  */
-  __IOM uint32_t IFS;            /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;            /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t IEN;            /**< Interrupt Enable Register  */
-  __IOM uint32_t SEQ0;           /**< Sequence Register 0  */
-  __IOM uint32_t SEQ1;           /**< Sequence Register 1  */
-  __IOM uint32_t SEQ2;           /**< Sequence Register 2  */
-  __IOM uint32_t SEQ3;           /**< Sequence Register 3  */
-  __IOM uint32_t SEQ4;           /**< Sequence Register 4  */
-  uint32_t       RESERVED4[7];   /**< Reserved for future use **/
-  __IOM uint32_t DATA0;          /**< DATA0 Register Access  */
-  __IOM uint32_t DATA1;          /**< DATA1 Register Access  */
-  __IOM uint32_t DATA2;          /**< DATA2 Register Access  */
-  __IOM uint32_t DATA3;          /**< DATA3 Register Access  */
-  uint32_t       RESERVED5[4];   /**< Reserved for future use **/
-  __IOM uint32_t DATA0XOR;       /**< DATA0XOR Register Access  */
-  uint32_t       RESERVED6[3];   /**< Reserved for future use **/
-  __IOM uint32_t DATA0BYTE;      /**< DATA0 Register Byte Access  */
-  __IOM uint32_t DATA1BYTE;      /**< DATA1 Register Byte Access  */
-  uint32_t       RESERVED7[1];   /**< Reserved for future use **/
-  __IOM uint32_t DATA0XORBYTE;   /**< DATA0 Register Byte XOR Access  */
-  __IOM uint32_t DATA0BYTE12;    /**< DATA0 Register Byte 12 Access  */
-  __IOM uint32_t DATA0BYTE13;    /**< DATA0 Register Byte 13 Access  */
-  __IOM uint32_t DATA0BYTE14;    /**< DATA0 Register Byte 14 Access  */
-  __IOM uint32_t DATA0BYTE15;    /**< DATA0 Register Byte 15 Access  */
-  uint32_t       RESERVED8[12];  /**< Reserved for future use **/
-  __IOM uint32_t DDATA0;         /**< DDATA0 Register Access  */
-  __IOM uint32_t DDATA1;         /**< DDATA1 Register Access  */
-  __IOM uint32_t DDATA2;         /**< DDATA2 Register Access  */
-  __IOM uint32_t DDATA3;         /**< DDATA3 Register Access  */
-  __IOM uint32_t DDATA4;         /**< DDATA4 Register Access  */
-  uint32_t       RESERVED9[7];   /**< Reserved for future use **/
-  __IOM uint32_t DDATA0BIG;      /**< DDATA0 Register Big Endian Access  */
-  uint32_t       RESERVED10[3];  /**< Reserved for future use **/
-  __IOM uint32_t DDATA0BYTE;     /**< DDATA0 Register Byte Access  */
-  __IOM uint32_t DDATA1BYTE;     /**< DDATA1 Register Byte Access  */
-  __IOM uint32_t DDATA0BYTE32;   /**< DDATA0 Register Byte 32 Access  */
-  uint32_t       RESERVED11[13]; /**< Reserved for future use **/
-  __IOM uint32_t QDATA0;         /**< QDATA0 Register Access  */
-  __IOM uint32_t QDATA1;         /**< QDATA1 Register Access  */
-  uint32_t       RESERVED12[7];  /**< Reserved for future use **/
-  __IOM uint32_t QDATA1BIG;      /**< QDATA1 Register Big Endian Access  */
-  uint32_t       RESERVED13[6];  /**< Reserved for future use **/
-  __IOM uint32_t QDATA0BYTE;     /**< QDATA0 Register Byte Access  */
-  __IOM uint32_t QDATA1BYTE;     /**< QDATA1 Register Byte Access  */
-} CRYPTO_TypeDef;                /** @} */
+  __IOM uint32_t CTRL;            /**< Control Register  */
+  __IOM uint32_t WAC;             /**< Wide Arithmetic Configuration  */
+  __IOM uint32_t CMD;             /**< Command Register  */
+  uint32_t       RESERVED0[1U];   /**< Reserved for future use **/
+  __IM uint32_t  STATUS;          /**< Status Register  */
+  __IM uint32_t  DSTATUS;         /**< Data Status Register  */
+  __IM uint32_t  CSTATUS;         /**< Control Status Register  */
+  uint32_t       RESERVED1[1U];   /**< Reserved for future use **/
+  __IOM uint32_t KEY;             /**< KEY Register Access  */
+  __IOM uint32_t KEYBUF;          /**< KEY Buffer Register Access  */
+  uint32_t       RESERVED2[2U];   /**< Reserved for future use **/
+  __IOM uint32_t SEQCTRL;         /**< Sequence Control  */
+  __IOM uint32_t SEQCTRLB;        /**< Sequence Control B  */
+  uint32_t       RESERVED3[2U];   /**< Reserved for future use **/
+  __IM uint32_t  IF;              /**< AES Interrupt Flags  */
+  __IOM uint32_t IFS;             /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;             /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;             /**< Interrupt Enable Register  */
+  __IOM uint32_t SEQ0;            /**< Sequence Register 0  */
+  __IOM uint32_t SEQ1;            /**< Sequence Register 1  */
+  __IOM uint32_t SEQ2;            /**< Sequence Register 2  */
+  __IOM uint32_t SEQ3;            /**< Sequence Register 3  */
+  __IOM uint32_t SEQ4;            /**< Sequence Register 4  */
+  uint32_t       RESERVED4[7U];   /**< Reserved for future use **/
+  __IOM uint32_t DATA0;           /**< DATA0 Register Access  */
+  __IOM uint32_t DATA1;           /**< DATA1 Register Access  */
+  __IOM uint32_t DATA2;           /**< DATA2 Register Access  */
+  __IOM uint32_t DATA3;           /**< DATA3 Register Access  */
+  uint32_t       RESERVED5[4U];   /**< Reserved for future use **/
+  __IOM uint32_t DATA0XOR;        /**< DATA0XOR Register Access  */
+  uint32_t       RESERVED6[3U];   /**< Reserved for future use **/
+  __IOM uint32_t DATA0BYTE;       /**< DATA0 Register Byte Access  */
+  __IOM uint32_t DATA1BYTE;       /**< DATA1 Register Byte Access  */
+  uint32_t       RESERVED7[1U];   /**< Reserved for future use **/
+  __IOM uint32_t DATA0XORBYTE;    /**< DATA0 Register Byte XOR Access  */
+  __IOM uint32_t DATA0BYTE12;     /**< DATA0 Register Byte 12 Access  */
+  __IOM uint32_t DATA0BYTE13;     /**< DATA0 Register Byte 13 Access  */
+  __IOM uint32_t DATA0BYTE14;     /**< DATA0 Register Byte 14 Access  */
+  __IOM uint32_t DATA0BYTE15;     /**< DATA0 Register Byte 15 Access  */
+  uint32_t       RESERVED8[12U];  /**< Reserved for future use **/
+  __IOM uint32_t DDATA0;          /**< DDATA0 Register Access  */
+  __IOM uint32_t DDATA1;          /**< DDATA1 Register Access  */
+  __IOM uint32_t DDATA2;          /**< DDATA2 Register Access  */
+  __IOM uint32_t DDATA3;          /**< DDATA3 Register Access  */
+  __IOM uint32_t DDATA4;          /**< DDATA4 Register Access  */
+  uint32_t       RESERVED9[7U];   /**< Reserved for future use **/
+  __IOM uint32_t DDATA0BIG;       /**< DDATA0 Register Big Endian Access  */
+  uint32_t       RESERVED10[3U];  /**< Reserved for future use **/
+  __IOM uint32_t DDATA0BYTE;      /**< DDATA0 Register Byte Access  */
+  __IOM uint32_t DDATA1BYTE;      /**< DDATA1 Register Byte Access  */
+  __IOM uint32_t DDATA0BYTE32;    /**< DDATA0 Register Byte 32 Access  */
+  uint32_t       RESERVED11[13U]; /**< Reserved for future use **/
+  __IOM uint32_t QDATA0;          /**< QDATA0 Register Access  */
+  __IOM uint32_t QDATA1;          /**< QDATA1 Register Access  */
+  uint32_t       RESERVED12[7U];  /**< Reserved for future use **/
+  __IOM uint32_t QDATA1BIG;       /**< QDATA1 Register Big Endian Access  */
+  uint32_t       RESERVED13[6U];  /**< Reserved for future use **/
+  __IOM uint32_t QDATA0BYTE;      /**< QDATA0 Register Byte Access  */
+  __IOM uint32_t QDATA1BYTE;      /**< QDATA1 Register Byte Access  */
+} CRYPTO_TypeDef;                 /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG12B_CRYPTO
  * @{
  * @defgroup EFM32PG12B_CRYPTO_BitFields  CRYPTO Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for CRYPTO CTRL */
 #define _CRYPTO_CTRL_RESETVALUE                      0x00000000UL                               /**< Default value for CRYPTO_CTRL */

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_csen.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_csen.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg12b_csen.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG12B_CSEN register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG12B_CSEN CSEN
  * @{
  * @brief EFM32PG12B_CSEN Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** CSEN Register Declaration */
 typedef struct {
   __IOM uint32_t CTRL;          /**< Control  */
@@ -72,19 +71,19 @@ typedef struct {
   __IOM uint32_t DMCFG;         /**< Delta Modulation Configuration  */
   __IOM uint32_t ANACTRL;       /**< Analog Control  */
 
-  uint32_t       RESERVED0[2];  /**< Reserved for future use **/
+  uint32_t       RESERVED0[2U]; /**< Reserved for future use **/
   __IM uint32_t  IF;            /**< Interrupt Flag  */
   __IOM uint32_t IFS;           /**< Interrupt Flag Set  */
   __IOM uint32_t IFC;           /**< Interrupt Flag Clear  */
   __IOM uint32_t IEN;           /**< Interrupt Enable  */
 } CSEN_TypeDef;                 /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG12B_CSEN
  * @{
  * @defgroup EFM32PG12B_CSEN_BitFields  CSEN Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for CSEN CTRL */
 #define _CSEN_CTRL_RESETVALUE                                0x00030000UL                               /**< Default value for CSEN_CTRL */

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_devinfo.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_devinfo.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg12b_devinfo.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG12B_DEVINFO register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,67 +40,67 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG12B_DEVINFO Device Information and Calibration
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /** DEVINFO Register Declaration */
 typedef struct {
   __IM uint32_t CAL;              /**< CRC of DI-page and calibration temperature  */
-  uint32_t      RESERVED0[9];     /**< Reserved for future use **/
+  uint32_t      RESERVED0[9U];    /**< Reserved for future use **/
   __IM uint32_t EUI48L;           /**< EUI48 OUI and Unique identifier  */
   __IM uint32_t EUI48H;           /**< OUI  */
   __IM uint32_t CUSTOMINFO;       /**< Custom information  */
   __IM uint32_t MEMINFO;          /**< Flash page size and misc. chip information  */
-  uint32_t      RESERVED1[2];     /**< Reserved for future use **/
+  uint32_t      RESERVED1[2U];    /**< Reserved for future use **/
   __IM uint32_t UNIQUEL;          /**< Low 32 bits of device unique number  */
   __IM uint32_t UNIQUEH;          /**< High 32 bits of device unique number  */
   __IM uint32_t MSIZE;            /**< Flash and SRAM Memory size in kB  */
   __IM uint32_t PART;             /**< Part description  */
   __IM uint32_t DEVINFOREV;       /**< Device information page revision  */
   __IM uint32_t EMUTEMP;          /**< EMU Temperature Calibration Information  */
-  uint32_t      RESERVED2[2];     /**< Reserved for future use **/
+  uint32_t      RESERVED2[2U];    /**< Reserved for future use **/
   __IM uint32_t ADC0CAL0;         /**< ADC0 calibration register 0  */
   __IM uint32_t ADC0CAL1;         /**< ADC0 calibration register 1  */
   __IM uint32_t ADC0CAL2;         /**< ADC0 calibration register 2  */
   __IM uint32_t ADC0CAL3;         /**< ADC0 calibration register 3  */
-  uint32_t      RESERVED3[4];     /**< Reserved for future use **/
+  uint32_t      RESERVED3[4U];    /**< Reserved for future use **/
   __IM uint32_t HFRCOCAL0;        /**< HFRCO Calibration Register (4 MHz)  */
-  uint32_t      RESERVED4[2];     /**< Reserved for future use **/
+  uint32_t      RESERVED4[2U];    /**< Reserved for future use **/
   __IM uint32_t HFRCOCAL3;        /**< HFRCO Calibration Register (7 MHz)  */
-  uint32_t      RESERVED5[2];     /**< Reserved for future use **/
+  uint32_t      RESERVED5[2U];    /**< Reserved for future use **/
   __IM uint32_t HFRCOCAL6;        /**< HFRCO Calibration Register (13 MHz)  */
   __IM uint32_t HFRCOCAL7;        /**< HFRCO Calibration Register (16 MHz)  */
   __IM uint32_t HFRCOCAL8;        /**< HFRCO Calibration Register (19 MHz)  */
-  uint32_t      RESERVED6[1];     /**< Reserved for future use **/
+  uint32_t      RESERVED6[1U];    /**< Reserved for future use **/
   __IM uint32_t HFRCOCAL10;       /**< HFRCO Calibration Register (26 MHz)  */
   __IM uint32_t HFRCOCAL11;       /**< HFRCO Calibration Register (32 MHz)  */
   __IM uint32_t HFRCOCAL12;       /**< HFRCO Calibration Register (38 MHz)  */
-  uint32_t      RESERVED7[11];    /**< Reserved for future use **/
+  uint32_t      RESERVED7[11U];   /**< Reserved for future use **/
   __IM uint32_t AUXHFRCOCAL0;     /**< AUXHFRCO Calibration Register (4 MHz)  */
-  uint32_t      RESERVED8[2];     /**< Reserved for future use **/
+  uint32_t      RESERVED8[2U];    /**< Reserved for future use **/
   __IM uint32_t AUXHFRCOCAL3;     /**< AUXHFRCO Calibration Register (7 MHz)  */
-  uint32_t      RESERVED9[2];     /**< Reserved for future use **/
+  uint32_t      RESERVED9[2U];    /**< Reserved for future use **/
   __IM uint32_t AUXHFRCOCAL6;     /**< AUXHFRCO Calibration Register (13 MHz)  */
   __IM uint32_t AUXHFRCOCAL7;     /**< AUXHFRCO Calibration Register (16 MHz)  */
   __IM uint32_t AUXHFRCOCAL8;     /**< AUXHFRCO Calibration Register (19 MHz)  */
-  uint32_t      RESERVED10[1];    /**< Reserved for future use **/
+  uint32_t      RESERVED10[1U];   /**< Reserved for future use **/
   __IM uint32_t AUXHFRCOCAL10;    /**< AUXHFRCO Calibration Register (26 MHz)  */
   __IM uint32_t AUXHFRCOCAL11;    /**< AUXHFRCO Calibration Register (32 MHz)  */
   __IM uint32_t AUXHFRCOCAL12;    /**< AUXHFRCO Calibration Register (38 MHz)  */
-  uint32_t      RESERVED11[11];   /**< Reserved for future use **/
+  uint32_t      RESERVED11[11U];  /**< Reserved for future use **/
   __IM uint32_t VMONCAL0;         /**< VMON Calibration Register 0  */
   __IM uint32_t VMONCAL1;         /**< VMON Calibration Register 1  */
   __IM uint32_t VMONCAL2;         /**< VMON Calibration Register 2  */
-  uint32_t      RESERVED12[3];    /**< Reserved for future use **/
+  uint32_t      RESERVED12[3U];   /**< Reserved for future use **/
   __IM uint32_t IDAC0CAL0;        /**< IDAC0 Calibration Register 0  */
   __IM uint32_t IDAC0CAL1;        /**< IDAC0 Calibration Register 1  */
-  uint32_t      RESERVED13[2];    /**< Reserved for future use **/
+  uint32_t      RESERVED13[2U];   /**< Reserved for future use **/
   __IM uint32_t DCDCLNVCTRL0;     /**< DCDC Low-noise VREF Trim Register 0  */
   __IM uint32_t DCDCLPVCTRL0;     /**< DCDC Low-power VREF Trim Register 0  */
   __IM uint32_t DCDCLPVCTRL1;     /**< DCDC Low-power VREF Trim Register 1  */
@@ -125,7 +124,7 @@ typedef struct {
   __IM uint32_t OPA2CAL2;         /**< OPA2 Calibration Register for DRIVESTRENGTH 2, INCBW=1  */
   __IM uint32_t OPA2CAL3;         /**< OPA2 Calibration Register for DRIVESTRENGTH 3, INCBW=1  */
   __IM uint32_t CSENGAINCAL;      /**< Cap Sense Gain Adjustment  */
-  uint32_t      RESERVED14[3];    /**< Reserved for future use **/
+  uint32_t      RESERVED14[3U];   /**< Reserved for future use **/
   __IM uint32_t OPA0CAL4;         /**< OPA0 Calibration Register for DRIVESTRENGTH 0, INCBW=0  */
   __IM uint32_t OPA0CAL5;         /**< OPA0 Calibration Register for DRIVESTRENGTH 1, INCBW=0  */
   __IM uint32_t OPA0CAL6;         /**< OPA0 Calibration Register for DRIVESTRENGTH 2, INCBW=0  */
@@ -140,12 +139,12 @@ typedef struct {
   __IM uint32_t OPA2CAL7;         /**< OPA2 Calibration Register for DRIVESTRENGTH 3, INCBW=0  */
 } DEVINFO_TypeDef;                /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG12B_DEVINFO
  * @{
  * @defgroup EFM32PG12B_DEVINFO_BitFields DEVINFO Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for DEVINFO CAL */
 #define _DEVINFO_CAL_MASK                                        0x00FFFFFFUL /**< Mask for DEVINFO_CAL */
@@ -245,6 +244,7 @@ typedef struct {
 #define _DEVINFO_PART_DEVICE_FAMILY_EFR32BG13P                   0x0000002BUL                                   /**< Mode EFR32BG13P for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFR32BG13B                   0x0000002CUL                                   /**< Mode EFR32BG13B for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFR32BG13V                   0x0000002DUL                                   /**< Mode EFR32BG13V for DEVINFO_PART */
+#define _DEVINFO_PART_DEVICE_FAMILY_EFR32ZG13P                   0x0000002EUL                                   /**< Mode EFR32ZG13P for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFR32FG13P                   0x00000031UL                                   /**< Mode EFR32FG13P for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFR32FG13B                   0x00000032UL                                   /**< Mode EFR32FG13B for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFR32FG13V                   0x00000033UL                                   /**< Mode EFR32FG13V for DEVINFO_PART */
@@ -254,6 +254,7 @@ typedef struct {
 #define _DEVINFO_PART_DEVICE_FAMILY_EFR32BG14P                   0x00000037UL                                   /**< Mode EFR32BG14P for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFR32BG14B                   0x00000038UL                                   /**< Mode EFR32BG14B for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFR32BG14V                   0x00000039UL                                   /**< Mode EFR32BG14V for DEVINFO_PART */
+#define _DEVINFO_PART_DEVICE_FAMILY_EFR32ZG14P                   0x0000003AUL                                   /**< Mode EFR32ZG14P for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFR32FG14P                   0x0000003DUL                                   /**< Mode EFR32FG14P for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFR32FG14B                   0x0000003EUL                                   /**< Mode EFR32FG14B for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFR32FG14V                   0x0000003FUL                                   /**< Mode EFR32FG14V for DEVINFO_PART */
@@ -277,6 +278,7 @@ typedef struct {
 #define _DEVINFO_PART_DEVICE_FAMILY_EFM32JG12B                   0x00000057UL                                   /**< Mode EFM32JG12B for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFM32GG11B                   0x00000064UL                                   /**< Mode EFM32GG11B for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFM32TG11B                   0x00000067UL                                   /**< Mode EFM32TG11B for DEVINFO_PART */
+#define _DEVINFO_PART_DEVICE_FAMILY_EFM32GG12B                   0x0000006AUL                                   /**< Mode EFM32GG12B for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EZR32LG                      0x00000078UL                                   /**< Mode EZR32LG for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EZR32WG                      0x00000079UL                                   /**< Mode EZR32WG for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EZR32HG                      0x0000007AUL                                   /**< Mode EZR32HG for DEVINFO_PART */
@@ -304,6 +306,7 @@ typedef struct {
 #define DEVINFO_PART_DEVICE_FAMILY_EFR32BG13P                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32BG13P << 16) /**< Shifted mode EFR32BG13P for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFR32BG13B                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32BG13B << 16) /**< Shifted mode EFR32BG13B for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFR32BG13V                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32BG13V << 16) /**< Shifted mode EFR32BG13V for DEVINFO_PART */
+#define DEVINFO_PART_DEVICE_FAMILY_EFR32ZG13P                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32ZG13P << 16) /**< Shifted mode EFR32ZG13P for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFR32FG13P                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32FG13P << 16) /**< Shifted mode EFR32FG13P for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFR32FG13B                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32FG13B << 16) /**< Shifted mode EFR32FG13B for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFR32FG13V                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32FG13V << 16) /**< Shifted mode EFR32FG13V for DEVINFO_PART */
@@ -313,6 +316,7 @@ typedef struct {
 #define DEVINFO_PART_DEVICE_FAMILY_EFR32BG14P                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32BG14P << 16) /**< Shifted mode EFR32BG14P for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFR32BG14B                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32BG14B << 16) /**< Shifted mode EFR32BG14B for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFR32BG14V                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32BG14V << 16) /**< Shifted mode EFR32BG14V for DEVINFO_PART */
+#define DEVINFO_PART_DEVICE_FAMILY_EFR32ZG14P                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32ZG14P << 16) /**< Shifted mode EFR32ZG14P for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFR32FG14P                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32FG14P << 16) /**< Shifted mode EFR32FG14P for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFR32FG14B                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32FG14B << 16) /**< Shifted mode EFR32FG14B for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFR32FG14V                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32FG14V << 16) /**< Shifted mode EFR32FG14V for DEVINFO_PART */
@@ -336,6 +340,7 @@ typedef struct {
 #define DEVINFO_PART_DEVICE_FAMILY_EFM32JG12B                    (_DEVINFO_PART_DEVICE_FAMILY_EFM32JG12B << 16) /**< Shifted mode EFM32JG12B for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFM32GG11B                    (_DEVINFO_PART_DEVICE_FAMILY_EFM32GG11B << 16) /**< Shifted mode EFM32GG11B for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFM32TG11B                    (_DEVINFO_PART_DEVICE_FAMILY_EFM32TG11B << 16) /**< Shifted mode EFM32TG11B for DEVINFO_PART */
+#define DEVINFO_PART_DEVICE_FAMILY_EFM32GG12B                    (_DEVINFO_PART_DEVICE_FAMILY_EFM32GG12B << 16) /**< Shifted mode EFM32GG12B for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EZR32LG                       (_DEVINFO_PART_DEVICE_FAMILY_EZR32LG << 16)    /**< Shifted mode EZR32LG for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EZR32WG                       (_DEVINFO_PART_DEVICE_FAMILY_EZR32WG << 16)    /**< Shifted mode EZR32WG for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EZR32HG                       (_DEVINFO_PART_DEVICE_FAMILY_EZR32HG << 16)    /**< Shifted mode EZR32HG for DEVINFO_PART */

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_dma_descriptor.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_dma_descriptor.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg12b_dma_descriptor.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG12B_DMA_DESCRIPTOR register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,14 +40,14 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG12B_DMA_DESCRIPTOR DMA Descriptor
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 /** DMA_DESCRIPTOR Register Declaration */
 typedef struct {
   /* Note! Use of double __IOM (volatile) qualifier to ensure that both */

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_dmareq.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_dmareq.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg12b_dmareq.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG12B_DMAREQ register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,17 +40,17 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG12B_DMAREQ DMAREQ
  * @{
  * @defgroup EFM32PG12B_DMAREQ_BitFields DMAREQ Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 #define DMAREQ_PRS_REQ0               ((1 << 16) + 0)         /**< DMA channel select for PRS_REQ0 */
 #define DMAREQ_PRS_REQ1               ((1 << 16) + 1)         /**< DMA channel select for PRS_REQ1 */
 #define DMAREQ_ADC0_SINGLE            ((8 << 16) + 0)         /**< DMA channel select for ADC0_SINGLE */

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_emu.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_emu.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg12b_emu.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG12B_EMU register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG12B_EMU EMU
  * @{
  * @brief EFM32PG12B_EMU Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** EMU Register Declaration */
 typedef struct {
   __IOM uint32_t CTRL;                  /**< Control Register  */
@@ -58,7 +57,7 @@ typedef struct {
   __IOM uint32_t RAM0CTRL;              /**< Memory Control Register  */
   __IOM uint32_t CMD;                   /**< Command Register  */
 
-  uint32_t       RESERVED0[1];          /**< Reserved for future use **/
+  uint32_t       RESERVED0[1U];         /**< Reserved for future use **/
   __IOM uint32_t EM4CTRL;               /**< EM4 Control Register  */
   __IOM uint32_t TEMPLIMITS;            /**< Temperature Limits for Interrupt Generation  */
   __IM uint32_t  TEMP;                  /**< Value of Last Temperature Measurement  */
@@ -71,48 +70,48 @@ typedef struct {
   __IOM uint32_t PWRCTRL;               /**< Power Control Register  */
   __IOM uint32_t DCDCCTRL;              /**< DCDC Control  */
 
-  uint32_t       RESERVED1[2];          /**< Reserved for future use **/
+  uint32_t       RESERVED1[2U];         /**< Reserved for future use **/
   __IOM uint32_t DCDCMISCCTRL;          /**< DCDC Miscellaneous Control Register  */
   __IOM uint32_t DCDCZDETCTRL;          /**< DCDC Power Train NFET Zero Current Detector Control Register  */
   __IOM uint32_t DCDCCLIMCTRL;          /**< DCDC Power Train PFET Current Limiter Control Register  */
   __IOM uint32_t DCDCLNCOMPCTRL;        /**< DCDC Low Noise Compensator Control Register  */
   __IOM uint32_t DCDCLNVCTRL;           /**< DCDC Low Noise Voltage Register  */
 
-  uint32_t       RESERVED2[1];          /**< Reserved for future use **/
+  uint32_t       RESERVED2[1U];         /**< Reserved for future use **/
   __IOM uint32_t DCDCLPVCTRL;           /**< DCDC Low Power Voltage Register  */
 
-  uint32_t       RESERVED3[1];          /**< Reserved for future use **/
+  uint32_t       RESERVED3[1U];         /**< Reserved for future use **/
   __IOM uint32_t DCDCLPCTRL;            /**< DCDC Low Power Control Register  */
   __IOM uint32_t DCDCLNFREQCTRL;        /**< DCDC Low Noise Controller Frequency Control  */
 
-  uint32_t       RESERVED4[1];          /**< Reserved for future use **/
+  uint32_t       RESERVED4[1U];         /**< Reserved for future use **/
   __IM uint32_t  DCDCSYNC;              /**< DCDC Read Status Register  */
 
-  uint32_t       RESERVED5[5];          /**< Reserved for future use **/
+  uint32_t       RESERVED5[5U];         /**< Reserved for future use **/
   __IOM uint32_t VMONAVDDCTRL;          /**< VMON AVDD Channel Control  */
   __IOM uint32_t VMONALTAVDDCTRL;       /**< Alternate VMON AVDD Channel Control  */
   __IOM uint32_t VMONDVDDCTRL;          /**< VMON DVDD Channel Control  */
   __IOM uint32_t VMONIO0CTRL;           /**< VMON IOVDD0 Channel Control  */
 
-  uint32_t       RESERVED6[5];          /**< Reserved for future use **/
+  uint32_t       RESERVED6[5U];         /**< Reserved for future use **/
   __IOM uint32_t RAM1CTRL;              /**< Memory Control Register  */
   __IOM uint32_t RAM2CTRL;              /**< Memory Control Register  */
 
-  uint32_t       RESERVED7[12];         /**< Reserved for future use **/
+  uint32_t       RESERVED7[12U];        /**< Reserved for future use **/
   __IOM uint32_t DCDCLPEM01CFG;         /**< Configuration Bits for Low Power Mode to Be Applied During EM01, This Field is Only Relevant If LP Mode is Used in EM01  */
 
-  uint32_t       RESERVED8[4];          /**< Reserved for future use **/
+  uint32_t       RESERVED8[4U];         /**< Reserved for future use **/
   __IOM uint32_t EM23PERNORETAINCMD;    /**< Clears Corresponding Bits in EM23PERNORETAINSTATUS Unlocking Access to Peripheral  */
   __IM uint32_t  EM23PERNORETAINSTATUS; /**< Status Indicating If Peripherals Were Powered Down in EM23, Subsequently Locking Access to It  */
   __IOM uint32_t EM23PERNORETAINCTRL;   /**< When Set Corresponding Peripherals May Get Powered Down in EM23  */
 } EMU_TypeDef;                          /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG12B_EMU
  * @{
  * @defgroup EFM32PG12B_EMU_BitFields  EMU Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for EMU CTRL */
 #define _EMU_CTRL_RESETVALUE                                 0x00000000UL                                /**< Default value for EMU_CTRL */
@@ -132,7 +131,7 @@ typedef struct {
 #define _EMU_CTRL_EM01LD_MASK                                0x8UL                                       /**< Bit mask for EMU_EM01LD */
 #define _EMU_CTRL_EM01LD_DEFAULT                             0x00000000UL                                /**< Mode DEFAULT for EMU_CTRL */
 #define EMU_CTRL_EM01LD_DEFAULT                              (_EMU_CTRL_EM01LD_DEFAULT << 3)             /**< Shifted mode DEFAULT for EMU_CTRL */
-#define EMU_CTRL_EM23VSCALEAUTOWSEN                          (0x1UL << 4)                                /**< Automatically Configures Flash, Ram and Frequency to Wakeup From EM2 or EM3 at Low Voltage */
+#define EMU_CTRL_EM23VSCALEAUTOWSEN                          (0x1UL << 4)                                /**< Automatically Configures Flash and Frequency to Wakeup From EM2 or EM3 at Low Voltage */
 #define _EMU_CTRL_EM23VSCALEAUTOWSEN_SHIFT                   4                                           /**< Shift value for EMU_EM23VSCALEAUTOWSEN */
 #define _EMU_CTRL_EM23VSCALEAUTOWSEN_MASK                    0x10UL                                      /**< Bit mask for EMU_EM23VSCALEAUTOWSEN */
 #define _EMU_CTRL_EM23VSCALEAUTOWSEN_DEFAULT                 0x00000000UL                                /**< Mode DEFAULT for EMU_CTRL */
@@ -1400,11 +1399,11 @@ typedef struct {
 #define _EMU_EM23PERNORETAINCTRL_I2C1DIS_MASK                0x40UL                                               /**< Bit mask for EMU_I2C1DIS */
 #define _EMU_EM23PERNORETAINCTRL_I2C1DIS_DEFAULT             0x00000000UL                                         /**< Mode DEFAULT for EMU_EM23PERNORETAINCTRL */
 #define EMU_EM23PERNORETAINCTRL_I2C1DIS_DEFAULT              (_EMU_EM23PERNORETAINCTRL_I2C1DIS_DEFAULT << 6)      /**< Shifted mode DEFAULT for EMU_EM23PERNORETAINCTRL */
-#define EMU_EM23PERNORETAINCTRL_DAC0DIS                      (0x1UL << 7)                                         /**< Allow Power Down of DAC0 During EM23 */
-#define _EMU_EM23PERNORETAINCTRL_DAC0DIS_SHIFT               7                                                    /**< Shift value for EMU_DAC0DIS */
-#define _EMU_EM23PERNORETAINCTRL_DAC0DIS_MASK                0x80UL                                               /**< Bit mask for EMU_DAC0DIS */
-#define _EMU_EM23PERNORETAINCTRL_DAC0DIS_DEFAULT             0x00000000UL                                         /**< Mode DEFAULT for EMU_EM23PERNORETAINCTRL */
-#define EMU_EM23PERNORETAINCTRL_DAC0DIS_DEFAULT              (_EMU_EM23PERNORETAINCTRL_DAC0DIS_DEFAULT << 7)      /**< Shifted mode DEFAULT for EMU_EM23PERNORETAINCTRL */
+#define EMU_EM23PERNORETAINCTRL_VDAC0DIS                     (0x1UL << 7)                                         /**< Allow Power Down of DAC0 During EM23 */
+#define _EMU_EM23PERNORETAINCTRL_VDAC0DIS_SHIFT              7                                                    /**< Shift value for EMU_VDAC0DIS */
+#define _EMU_EM23PERNORETAINCTRL_VDAC0DIS_MASK               0x80UL                                               /**< Bit mask for EMU_VDAC0DIS */
+#define _EMU_EM23PERNORETAINCTRL_VDAC0DIS_DEFAULT            0x00000000UL                                         /**< Mode DEFAULT for EMU_EM23PERNORETAINCTRL */
+#define EMU_EM23PERNORETAINCTRL_VDAC0DIS_DEFAULT             (_EMU_EM23PERNORETAINCTRL_VDAC0DIS_DEFAULT << 7)     /**< Shifted mode DEFAULT for EMU_EM23PERNORETAINCTRL */
 #define EMU_EM23PERNORETAINCTRL_IDAC0DIS                     (0x1UL << 8)                                         /**< Allow Power Down of IDAC0 During EM23 */
 #define _EMU_EM23PERNORETAINCTRL_IDAC0DIS_SHIFT              8                                                    /**< Shift value for EMU_IDAC0DIS */
 #define _EMU_EM23PERNORETAINCTRL_IDAC0DIS_MASK               0x100UL                                              /**< Bit mask for EMU_IDAC0DIS */

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_etm.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_etm.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg12b_etm.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG12B_ETM register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,83 +40,83 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG12B_ETM ETM
  * @{
  * @brief EFM32PG12B_ETM Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** ETM Register Declaration */
 typedef struct {
-  __IOM uint32_t ETMCR;           /**< Main Control Register  */
-  __IM uint32_t  ETMCCR;          /**< Configuration Code Register  */
-  __IOM uint32_t ETMTRIGGER;      /**< ETM Trigger Event Register  */
-  uint32_t       RESERVED0[1];    /**< Reserved for future use **/
-  __IOM uint32_t ETMSR;           /**< ETM Status Register  */
-  __IM uint32_t  ETMSCR;          /**< ETM System Configuration Register  */
-  uint32_t       RESERVED1[2];    /**< Reserved for future use **/
-  __IOM uint32_t ETMTEEVR;        /**< ETM TraceEnable Event Register  */
-  __IOM uint32_t ETMTECR1;        /**< ETM Trace control Register  */
-  uint32_t       RESERVED2[1];    /**< Reserved for future use **/
-  __IOM uint32_t ETMFFLR;         /**< ETM Fifo Full Level Register  */
-  uint32_t       RESERVED3[68];   /**< Reserved for future use **/
-  __IOM uint32_t ETMCNTRLDVR1;    /**< Counter Reload Value  */
-  uint32_t       RESERVED4[39];   /**< Reserved for future use **/
-  __IOM uint32_t ETMSYNCFR;       /**< Synchronisation Frequency Register  */
-  __IM uint32_t  ETMIDR;          /**< ID Register  */
-  __IM uint32_t  ETMCCER;         /**< Configuration Code Extension Register  */
-  uint32_t       RESERVED5[1];    /**< Reserved for future use **/
-  __IOM uint32_t ETMTESSEICR;     /**< TraceEnable Start/Stop EmbeddedICE Control Register  */
-  uint32_t       RESERVED6[1];    /**< Reserved for future use **/
-  __IOM uint32_t ETMTSEVR;        /**< Timestamp Event Register  */
-  uint32_t       RESERVED7[1];    /**< Reserved for future use **/
-  __IOM uint32_t ETMTRACEIDR;     /**< CoreSight Trace ID Register  */
-  uint32_t       RESERVED8[1];    /**< Reserved for future use **/
-  __IM uint32_t  ETMIDR2;         /**< ETM ID Register 2  */
-  uint32_t       RESERVED9[66];   /**< Reserved for future use **/
-  __IM uint32_t  ETMPDSR;         /**< Device Power-down Status Register  */
-  uint32_t       RESERVED10[754]; /**< Reserved for future use **/
-  __IOM uint32_t ETMISCIN;        /**< Integration Test Miscellaneous Inputs Register  */
-  uint32_t       RESERVED11[1];   /**< Reserved for future use **/
-  __IOM uint32_t ITTRIGOUT;       /**< Integration Test Trigger Out Register  */
-  uint32_t       RESERVED12[1];   /**< Reserved for future use **/
-  __IM uint32_t  ETMITATBCTR2;    /**< ETM Integration Test ATB Control 2 Register  */
-  uint32_t       RESERVED13[1];   /**< Reserved for future use **/
-  __IOM uint32_t ETMITATBCTR0;    /**< ETM Integration Test ATB Control 0 Register  */
-  uint32_t       RESERVED14[1];   /**< Reserved for future use **/
-  __IOM uint32_t ETMITCTRL;       /**< ETM Integration Control Register  */
-  uint32_t       RESERVED15[39];  /**< Reserved for future use **/
-  __IOM uint32_t ETMCLAIMSET;     /**< ETM Claim Tag Set Register  */
-  __IOM uint32_t ETMCLAIMCLR;     /**< ETM Claim Tag Clear Register  */
-  uint32_t       RESERVED16[2];   /**< Reserved for future use **/
-  __IOM uint32_t ETMLAR;          /**< ETM Lock Access Register  */
-  __IM uint32_t  ETMLSR;          /**< Lock Status Register  */
-  __IM uint32_t  ETMAUTHSTATUS;   /**< ETM Authentication Status Register  */
-  uint32_t       RESERVED17[4];   /**< Reserved for future use **/
-  __IM uint32_t  ETMDEVTYPE;      /**< CoreSight Device Type Register  */
-  __IM uint32_t  ETMPIDR4;        /**< Peripheral ID4 Register  */
-  __OM uint32_t  ETMPIDR5;        /**< Peripheral ID5 Register  */
-  __OM uint32_t  ETMPIDR6;        /**< Peripheral ID6 Register  */
-  __OM uint32_t  ETMPIDR7;        /**< Peripheral ID7 Register  */
-  __IM uint32_t  ETMPIDR0;        /**< Peripheral ID0 Register  */
-  __IM uint32_t  ETMPIDR1;        /**< Peripheral ID1 Register  */
-  __IM uint32_t  ETMPIDR2;        /**< Peripheral ID2 Register  */
-  __IM uint32_t  ETMPIDR3;        /**< Peripheral ID3 Register  */
-  __IM uint32_t  ETMCIDR0;        /**< Component ID0 Register  */
-  __IM uint32_t  ETMCIDR1;        /**< Component ID1 Register  */
-  __IM uint32_t  ETMCIDR2;        /**< Component ID2 Register  */
-  __IM uint32_t  ETMCIDR3;        /**< Component ID3 Register  */
-} ETM_TypeDef;                    /** @} */
+  __IOM uint32_t ETMCR;            /**< Main Control Register  */
+  __IM uint32_t  ETMCCR;           /**< Configuration Code Register  */
+  __IOM uint32_t ETMTRIGGER;       /**< ETM Trigger Event Register  */
+  uint32_t       RESERVED0[1U];    /**< Reserved for future use **/
+  __IOM uint32_t ETMSR;            /**< ETM Status Register  */
+  __IM uint32_t  ETMSCR;           /**< ETM System Configuration Register  */
+  uint32_t       RESERVED1[2U];    /**< Reserved for future use **/
+  __IOM uint32_t ETMTEEVR;         /**< ETM TraceEnable Event Register  */
+  __IOM uint32_t ETMTECR1;         /**< ETM Trace control Register  */
+  uint32_t       RESERVED2[1U];    /**< Reserved for future use **/
+  __IOM uint32_t ETMFFLR;          /**< ETM Fifo Full Level Register  */
+  uint32_t       RESERVED3[68U];   /**< Reserved for future use **/
+  __IOM uint32_t ETMCNTRLDVR1;     /**< Counter Reload Value  */
+  uint32_t       RESERVED4[39U];   /**< Reserved for future use **/
+  __IOM uint32_t ETMSYNCFR;        /**< Synchronisation Frequency Register  */
+  __IM uint32_t  ETMIDR;           /**< ID Register  */
+  __IM uint32_t  ETMCCER;          /**< Configuration Code Extension Register  */
+  uint32_t       RESERVED5[1U];    /**< Reserved for future use **/
+  __IOM uint32_t ETMTESSEICR;      /**< TraceEnable Start/Stop EmbeddedICE Control Register  */
+  uint32_t       RESERVED6[1U];    /**< Reserved for future use **/
+  __IOM uint32_t ETMTSEVR;         /**< Timestamp Event Register  */
+  uint32_t       RESERVED7[1U];    /**< Reserved for future use **/
+  __IOM uint32_t ETMTRACEIDR;      /**< CoreSight Trace ID Register  */
+  uint32_t       RESERVED8[1U];    /**< Reserved for future use **/
+  __IM uint32_t  ETMIDR2;          /**< ETM ID Register 2  */
+  uint32_t       RESERVED9[66U];   /**< Reserved for future use **/
+  __IM uint32_t  ETMPDSR;          /**< Device Power-down Status Register  */
+  uint32_t       RESERVED10[754U]; /**< Reserved for future use **/
+  __IOM uint32_t ETMISCIN;         /**< Integration Test Miscellaneous Inputs Register  */
+  uint32_t       RESERVED11[1U];   /**< Reserved for future use **/
+  __IOM uint32_t ITTRIGOUT;        /**< Integration Test Trigger Out Register  */
+  uint32_t       RESERVED12[1U];   /**< Reserved for future use **/
+  __IM uint32_t  ETMITATBCTR2;     /**< ETM Integration Test ATB Control 2 Register  */
+  uint32_t       RESERVED13[1U];   /**< Reserved for future use **/
+  __IOM uint32_t ETMITATBCTR0;     /**< ETM Integration Test ATB Control 0 Register  */
+  uint32_t       RESERVED14[1U];   /**< Reserved for future use **/
+  __IOM uint32_t ETMITCTRL;        /**< ETM Integration Control Register  */
+  uint32_t       RESERVED15[39U];  /**< Reserved for future use **/
+  __IOM uint32_t ETMCLAIMSET;      /**< ETM Claim Tag Set Register  */
+  __IOM uint32_t ETMCLAIMCLR;      /**< ETM Claim Tag Clear Register  */
+  uint32_t       RESERVED16[2U];   /**< Reserved for future use **/
+  __IOM uint32_t ETMLAR;           /**< ETM Lock Access Register  */
+  __IM uint32_t  ETMLSR;           /**< Lock Status Register  */
+  __IM uint32_t  ETMAUTHSTATUS;    /**< ETM Authentication Status Register  */
+  uint32_t       RESERVED17[4U];   /**< Reserved for future use **/
+  __IM uint32_t  ETMDEVTYPE;       /**< CoreSight Device Type Register  */
+  __IM uint32_t  ETMPIDR4;         /**< Peripheral ID4 Register  */
+  __OM uint32_t  ETMPIDR5;         /**< Peripheral ID5 Register  */
+  __OM uint32_t  ETMPIDR6;         /**< Peripheral ID6 Register  */
+  __OM uint32_t  ETMPIDR7;         /**< Peripheral ID7 Register  */
+  __IM uint32_t  ETMPIDR0;         /**< Peripheral ID0 Register  */
+  __IM uint32_t  ETMPIDR1;         /**< Peripheral ID1 Register  */
+  __IM uint32_t  ETMPIDR2;         /**< Peripheral ID2 Register  */
+  __IM uint32_t  ETMPIDR3;         /**< Peripheral ID3 Register  */
+  __IM uint32_t  ETMCIDR0;         /**< Component ID0 Register  */
+  __IM uint32_t  ETMCIDR1;         /**< Component ID1 Register  */
+  __IM uint32_t  ETMCIDR2;         /**< Component ID2 Register  */
+  __IM uint32_t  ETMCIDR3;         /**< Component ID3 Register  */
+} ETM_TypeDef;                     /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG12B_ETM
  * @{
  * @defgroup EFM32PG12B_ETM_BitFields  ETM Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for ETM ETMCR */
 #define _ETM_ETMCR_RESETVALUE                         0x00000411UL                           /**< Default value for ETM_ETMCR */

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_fpueh.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_fpueh.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg12b_fpueh.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG12B_FPUEH register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG12B_FPUEH FPUEH
  * @{
  * @brief EFM32PG12B_FPUEH Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** FPUEH Register Declaration */
 typedef struct {
   __IM uint32_t  IF;  /**< Interrupt Flag Register  */
@@ -58,12 +57,12 @@ typedef struct {
   __IOM uint32_t IEN; /**< Interrupt Enable Register  */
 } FPUEH_TypeDef;      /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG12B_FPUEH
  * @{
  * @defgroup EFM32PG12B_FPUEH_BitFields  FPUEH Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for FPUEH IF */
 #define _FPUEH_IF_RESETVALUE        0x00000000UL                   /**< Default value for FPUEH_IF */

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_gpcrc.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_gpcrc.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg12b_gpcrc.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG12B_GPCRC register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG12B_GPCRC GPCRC
  * @{
  * @brief EFM32PG12B_GPCRC Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** GPCRC Register Declaration */
 typedef struct {
   __IOM uint32_t CTRL;           /**< Control Register  */
@@ -64,12 +63,12 @@ typedef struct {
   __IM uint32_t  DATABYTEREV;    /**< CRC Data Byte Reverse Register  */
 } GPCRC_TypeDef;                 /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG12B_GPCRC
  * @{
  * @defgroup EFM32PG12B_GPCRC_BitFields  GPCRC Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for GPCRC CTRL */
 #define _GPCRC_CTRL_RESETVALUE                          0x00000000UL                             /**< Default value for GPCRC_CTRL */

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_gpio.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_gpio.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg12b_gpio.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG12B_GPIO register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,49 +40,49 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG12B_GPIO GPIO
  * @{
  * @brief EFM32PG12B_GPIO Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** GPIO Register Declaration */
 typedef struct {
-  GPIO_P_TypeDef P[12];          /**< Port configuration bits */
+  GPIO_P_TypeDef P[12U];          /**< Port configuration bits */
 
-  uint32_t       RESERVED0[112]; /**< Reserved for future use **/
-  __IOM uint32_t EXTIPSELL;      /**< External Interrupt Port Select Low Register  */
-  __IOM uint32_t EXTIPSELH;      /**< External Interrupt Port Select High Register  */
-  __IOM uint32_t EXTIPINSELL;    /**< External Interrupt Pin Select Low Register  */
-  __IOM uint32_t EXTIPINSELH;    /**< External Interrupt Pin Select High Register  */
-  __IOM uint32_t EXTIRISE;       /**< External Interrupt Rising Edge Trigger Register  */
-  __IOM uint32_t EXTIFALL;       /**< External Interrupt Falling Edge Trigger Register  */
-  __IOM uint32_t EXTILEVEL;      /**< External Interrupt Level Register  */
-  __IM uint32_t  IF;             /**< Interrupt Flag Register  */
-  __IOM uint32_t IFS;            /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;            /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t IEN;            /**< Interrupt Enable Register  */
-  __IOM uint32_t EM4WUEN;        /**< EM4 Wake Up Enable Register  */
+  uint32_t       RESERVED0[112U]; /**< Reserved for future use **/
+  __IOM uint32_t EXTIPSELL;       /**< External Interrupt Port Select Low Register  */
+  __IOM uint32_t EXTIPSELH;       /**< External Interrupt Port Select High Register  */
+  __IOM uint32_t EXTIPINSELL;     /**< External Interrupt Pin Select Low Register  */
+  __IOM uint32_t EXTIPINSELH;     /**< External Interrupt Pin Select High Register  */
+  __IOM uint32_t EXTIRISE;        /**< External Interrupt Rising Edge Trigger Register  */
+  __IOM uint32_t EXTIFALL;        /**< External Interrupt Falling Edge Trigger Register  */
+  __IOM uint32_t EXTILEVEL;       /**< External Interrupt Level Register  */
+  __IM uint32_t  IF;              /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;             /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;             /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;             /**< Interrupt Enable Register  */
+  __IOM uint32_t EM4WUEN;         /**< EM4 Wake Up Enable Register  */
 
-  uint32_t       RESERVED1[4];   /**< Reserved for future use **/
-  __IOM uint32_t ROUTEPEN;       /**< I/O Routing Pin Enable Register  */
-  __IOM uint32_t ROUTELOC0;      /**< I/O Routing Location Register  */
-  __IOM uint32_t ROUTELOC1;      /**< I/O Routing Location Register 1  */
+  uint32_t       RESERVED1[4U];   /**< Reserved for future use **/
+  __IOM uint32_t ROUTEPEN;        /**< I/O Routing Pin Enable Register  */
+  __IOM uint32_t ROUTELOC0;       /**< I/O Routing Location Register  */
+  __IOM uint32_t ROUTELOC1;       /**< I/O Routing Location Register 1  */
 
-  uint32_t       RESERVED2[1];   /**< Reserved for future use **/
-  __IOM uint32_t INSENSE;        /**< Input Sense Register  */
-  __IOM uint32_t LOCK;           /**< Configuration Lock Register  */
-} GPIO_TypeDef;                  /** @} */
+  uint32_t       RESERVED2[1U];   /**< Reserved for future use **/
+  __IOM uint32_t INSENSE;         /**< Input Sense Register  */
+  __IOM uint32_t LOCK;            /**< Configuration Lock Register  */
+} GPIO_TypeDef;                   /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG12B_GPIO
  * @{
  * @defgroup EFM32PG12B_GPIO_BitFields  GPIO Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for GPIO P_CTRL */
 #define _GPIO_P_CTRL_RESETVALUE                         0x00500050UL                                  /**< Default value for GPIO_P_CTRL */

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_gpio_p.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_gpio_p.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg12b_gpio_p.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG12B_GPIO_P register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,26 +40,26 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief GPIO_P GPIO P Register
  * @ingroup EFM32PG12B_GPIO
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IOM uint32_t CTRL;         /**< Port Control Register  */
-  __IOM uint32_t MODEL;        /**< Port Pin Mode Low Register  */
-  __IOM uint32_t MODEH;        /**< Port Pin Mode High Register  */
-  __IOM uint32_t DOUT;         /**< Port Data Out Register  */
-  uint32_t       RESERVED0[2]; /**< Reserved for future use **/
-  __IOM uint32_t DOUTTGL;      /**< Port Data Out Toggle Register  */
-  __IM uint32_t  DIN;          /**< Port Data in Register  */
-  __IOM uint32_t PINLOCKN;     /**< Port Unlocked Pins Register  */
-  uint32_t       RESERVED1[1]; /**< Reserved for future use **/
-  __IOM uint32_t OVTDIS;       /**< Over Voltage Disable for All Modes  */
-  uint32_t       RESERVED2[1]; /**< Reserved future */
+  __IOM uint32_t CTRL;          /**< Port Control Register  */
+  __IOM uint32_t MODEL;         /**< Port Pin Mode Low Register  */
+  __IOM uint32_t MODEH;         /**< Port Pin Mode High Register  */
+  __IOM uint32_t DOUT;          /**< Port Data Out Register  */
+  uint32_t       RESERVED0[2U]; /**< Reserved for future use **/
+  __IOM uint32_t DOUTTGL;       /**< Port Data Out Toggle Register  */
+  __IM uint32_t  DIN;           /**< Port Data in Register  */
+  __IOM uint32_t PINLOCKN;      /**< Port Unlocked Pins Register  */
+  uint32_t       RESERVED1[1U]; /**< Reserved for future use **/
+  __IOM uint32_t OVTDIS;        /**< Over Voltage Disable for All Modes  */
+  uint32_t       RESERVED2[1U]; /**< Reserved future */
 } GPIO_P_TypeDef;
 
 /** @} End of group Parts */

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_i2c.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_i2c.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg12b_i2c.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG12B_I2C register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG12B_I2C I2C
  * @{
  * @brief EFM32PG12B_I2C Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** I2C Register Declaration */
 typedef struct {
   __IOM uint32_t CTRL;      /**< Control Register  */
@@ -73,12 +72,12 @@ typedef struct {
   __IOM uint32_t ROUTELOC0; /**< I/O Routing Location Register  */
 } I2C_TypeDef;              /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG12B_I2C
  * @{
  * @defgroup EFM32PG12B_I2C_BitFields  I2C Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for I2C CTRL */
 #define _I2C_CTRL_RESETVALUE               0x00000000UL                     /**< Default value for I2C_CTRL */
@@ -426,7 +425,7 @@ typedef struct {
 #define I2C_IF_TXBL                        (0x1UL << 4)                    /**< Transmit Buffer Level Interrupt Flag */
 #define _I2C_IF_TXBL_SHIFT                 4                               /**< Shift value for I2C_TXBL */
 #define _I2C_IF_TXBL_MASK                  0x10UL                          /**< Bit mask for I2C_TXBL */
-#define _I2C_IF_TXBL_DEFAULT               0x00000000UL                    /**< Mode DEFAULT for I2C_IF */
+#define _I2C_IF_TXBL_DEFAULT               0x00000001UL                    /**< Mode DEFAULT for I2C_IF */
 #define I2C_IF_TXBL_DEFAULT                (_I2C_IF_TXBL_DEFAULT << 4)     /**< Shifted mode DEFAULT for I2C_IF */
 #define I2C_IF_RXDATAV                     (0x1UL << 5)                    /**< Receive Data Valid Interrupt Flag */
 #define _I2C_IF_RXDATAV_SHIFT              5                               /**< Shift value for I2C_RXDATAV */

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_idac.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_idac.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg12b_idac.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG12B_IDAC register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,40 +40,40 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG12B_IDAC IDAC
  * @{
  * @brief EFM32PG12B_IDAC Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** IDAC Register Declaration */
 typedef struct {
   __IOM uint32_t CTRL;          /**< Control Register  */
   __IOM uint32_t CURPROG;       /**< Current Programming Register  */
-  uint32_t       RESERVED0[1];  /**< Reserved for future use **/
+  uint32_t       RESERVED0[1U]; /**< Reserved for future use **/
   __IOM uint32_t DUTYCONFIG;    /**< Duty Cycle Configuration Register  */
 
-  uint32_t       RESERVED1[2];  /**< Reserved for future use **/
+  uint32_t       RESERVED1[2U]; /**< Reserved for future use **/
   __IM uint32_t  STATUS;        /**< Status Register  */
-  uint32_t       RESERVED2[1];  /**< Reserved for future use **/
+  uint32_t       RESERVED2[1U]; /**< Reserved for future use **/
   __IM uint32_t  IF;            /**< Interrupt Flag Register  */
   __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
   __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
   __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
-  uint32_t       RESERVED3[1];  /**< Reserved for future use **/
+  uint32_t       RESERVED3[1U]; /**< Reserved for future use **/
   __IM uint32_t  APORTREQ;      /**< APORT Request Status Register  */
   __IM uint32_t  APORTCONFLICT; /**< APORT Request Status Register  */
 } IDAC_TypeDef;                 /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG12B_IDAC
  * @{
  * @defgroup EFM32PG12B_IDAC_BitFields  IDAC Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for IDAC CTRL */
 #define _IDAC_CTRL_RESETVALUE                          0x00000000UL                              /**< Default value for IDAC_CTRL */

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_ldma.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_ldma.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg12b_ldma.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG12B_LDMA register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,46 +40,46 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG12B_LDMA LDMA
  * @{
  * @brief EFM32PG12B_LDMA Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** LDMA Register Declaration */
 typedef struct {
-  __IOM uint32_t  CTRL;         /**< DMA Control Register  */
-  __IM uint32_t   STATUS;       /**< DMA Status Register  */
-  __IOM uint32_t  SYNC;         /**< DMA Synchronization Trigger Register (Single-Cycle RMW)  */
-  uint32_t        RESERVED0[5]; /**< Reserved for future use **/
-  __IOM uint32_t  CHEN;         /**< DMA Channel Enable Register (Single-Cycle RMW)  */
-  __IM uint32_t   CHBUSY;       /**< DMA Channel Busy Register  */
-  __IOM uint32_t  CHDONE;       /**< DMA Channel Linking Done Register (Single-Cycle RMW)  */
-  __IOM uint32_t  DBGHALT;      /**< DMA Channel Debug Halt Register  */
-  __IOM uint32_t  SWREQ;        /**< DMA Channel Software Transfer Request Register  */
-  __IOM uint32_t  REQDIS;       /**< DMA Channel Request Disable Register  */
-  __IM uint32_t   REQPEND;      /**< DMA Channel Requests Pending Register  */
-  __IOM uint32_t  LINKLOAD;     /**< DMA Channel Link Load Register  */
-  __IOM uint32_t  REQCLEAR;     /**< DMA Channel Request Clear Register  */
-  uint32_t        RESERVED1[7]; /**< Reserved for future use **/
-  __IM uint32_t   IF;           /**< Interrupt Flag Register  */
-  __IOM uint32_t  IFS;          /**< Interrupt Flag Set Register  */
-  __IOM uint32_t  IFC;          /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t  IEN;          /**< Interrupt Enable Register  */
+  __IOM uint32_t  CTRL;          /**< DMA Control Register  */
+  __IM uint32_t   STATUS;        /**< DMA Status Register  */
+  __IOM uint32_t  SYNC;          /**< DMA Synchronization Trigger Register (Single-Cycle RMW)  */
+  uint32_t        RESERVED0[5U]; /**< Reserved for future use **/
+  __IOM uint32_t  CHEN;          /**< DMA Channel Enable Register (Single-Cycle RMW)  */
+  __IM uint32_t   CHBUSY;        /**< DMA Channel Busy Register  */
+  __IOM uint32_t  CHDONE;        /**< DMA Channel Linking Done Register (Single-Cycle RMW)  */
+  __IOM uint32_t  DBGHALT;       /**< DMA Channel Debug Halt Register  */
+  __IOM uint32_t  SWREQ;         /**< DMA Channel Software Transfer Request Register  */
+  __IOM uint32_t  REQDIS;        /**< DMA Channel Request Disable Register  */
+  __IM uint32_t   REQPEND;       /**< DMA Channel Requests Pending Register  */
+  __IOM uint32_t  LINKLOAD;      /**< DMA Channel Link Load Register  */
+  __IOM uint32_t  REQCLEAR;      /**< DMA Channel Request Clear Register  */
+  uint32_t        RESERVED1[7U]; /**< Reserved for future use **/
+  __IM uint32_t   IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t  IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t  IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t  IEN;           /**< Interrupt Enable Register  */
 
-  uint32_t        RESERVED2[4]; /**< Reserved registers */
-  LDMA_CH_TypeDef CH[8];        /**< DMA Channel Registers */
-} LDMA_TypeDef;                 /** @} */
+  uint32_t        RESERVED2[4U]; /**< Reserved registers */
+  LDMA_CH_TypeDef CH[8U];        /**< DMA Channel Registers */
+} LDMA_TypeDef;                  /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG12B_LDMA
  * @{
  * @defgroup EFM32PG12B_LDMA_BitFields  LDMA Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for LDMA CTRL */
 #define _LDMA_CTRL_RESETVALUE                        0x07000000UL                           /**< Default value for LDMA_CTRL */

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_ldma_ch.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_ldma_ch.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg12b_ldma_ch.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG12B_LDMA_CH register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,23 +40,23 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief LDMA_CH LDMA CH Register
  * @ingroup EFM32PG12B_LDMA
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IOM uint32_t REQSEL;       /**< Channel Peripheral Request Select Register  */
-  __IOM uint32_t CFG;          /**< Channel Configuration Register  */
-  __IOM uint32_t LOOP;         /**< Channel Loop Counter Register  */
-  __IOM uint32_t CTRL;         /**< Channel Descriptor Control Word Register  */
-  __IOM uint32_t SRC;          /**< Channel Descriptor Source Data Address Register  */
-  __IOM uint32_t DST;          /**< Channel Descriptor Destination Data Address Register  */
-  __IOM uint32_t LINK;         /**< Channel Descriptor Link Structure Address Register  */
-  uint32_t       RESERVED0[5]; /**< Reserved future */
+  __IOM uint32_t REQSEL;        /**< Channel Peripheral Request Select Register  */
+  __IOM uint32_t CFG;           /**< Channel Configuration Register  */
+  __IOM uint32_t LOOP;          /**< Channel Loop Counter Register  */
+  __IOM uint32_t CTRL;          /**< Channel Descriptor Control Word Register  */
+  __IOM uint32_t SRC;           /**< Channel Descriptor Source Data Address Register  */
+  __IOM uint32_t DST;           /**< Channel Descriptor Destination Data Address Register  */
+  __IOM uint32_t LINK;          /**< Channel Descriptor Link Structure Address Register  */
+  uint32_t       RESERVED0[5U]; /**< Reserved future */
 } LDMA_CH_TypeDef;
 
 /** @} End of group Parts */

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_lesense.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_lesense.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg12b_lesense.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG12B_LESENSE register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,57 +40,57 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG12B_LESENSE LESENSE
  * @{
  * @brief EFM32PG12B_LESENSE Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** LESENSE Register Declaration */
 typedef struct {
-  __IOM uint32_t      CTRL;          /**< Control Register  */
-  __IOM uint32_t      TIMCTRL;       /**< Timing Control Register  */
-  __IOM uint32_t      PERCTRL;       /**< Peripheral Control Register  */
-  __IOM uint32_t      DECCTRL;       /**< Decoder Control Register  */
-  __IOM uint32_t      BIASCTRL;      /**< Bias Control Register  */
-  __IOM uint32_t      EVALCTRL;      /**< LESENSE Evaluation Control  */
-  __IOM uint32_t      PRSCTRL;       /**< PRS Control Register  */
-  __IOM uint32_t      CMD;           /**< Command Register  */
-  __IOM uint32_t      CHEN;          /**< Channel Enable Register  */
-  __IOM uint32_t      SCANRES;       /**< Scan Result Register  */
-  __IM uint32_t       STATUS;        /**< Status Register  */
-  __IM uint32_t       PTR;           /**< Result Buffer Pointers  */
-  __IM uint32_t       BUFDATA;       /**< Result Buffer Data Register  */
-  __IM uint32_t       CURCH;         /**< Current Channel Index  */
-  __IOM uint32_t      DECSTATE;      /**< Current Decoder State  */
-  __IOM uint32_t      SENSORSTATE;   /**< Decoder Input Register  */
-  __IOM uint32_t      IDLECONF;      /**< GPIO Idle Phase Configuration  */
-  __IOM uint32_t      ALTEXCONF;     /**< Alternative Excite Pin Configuration  */
-  uint32_t            RESERVED0[2];  /**< Reserved for future use **/
-  __IM uint32_t       IF;            /**< Interrupt Flag Register  */
-  __IOM uint32_t      IFS;           /**< Interrupt Flag Set Register  */
-  __IOM uint32_t      IFC;           /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t      IEN;           /**< Interrupt Enable Register  */
-  __IM uint32_t       SYNCBUSY;      /**< Synchronization Busy Register  */
-  __IOM uint32_t      ROUTEPEN;      /**< I/O Routing Register  */
+  __IOM uint32_t      CTRL;           /**< Control Register  */
+  __IOM uint32_t      TIMCTRL;        /**< Timing Control Register  */
+  __IOM uint32_t      PERCTRL;        /**< Peripheral Control Register  */
+  __IOM uint32_t      DECCTRL;        /**< Decoder Control Register  */
+  __IOM uint32_t      BIASCTRL;       /**< Bias Control Register  */
+  __IOM uint32_t      EVALCTRL;       /**< LESENSE Evaluation Control  */
+  __IOM uint32_t      PRSCTRL;        /**< PRS Control Register  */
+  __IOM uint32_t      CMD;            /**< Command Register  */
+  __IOM uint32_t      CHEN;           /**< Channel Enable Register  */
+  __IOM uint32_t      SCANRES;        /**< Scan Result Register  */
+  __IM uint32_t       STATUS;         /**< Status Register  */
+  __IM uint32_t       PTR;            /**< Result Buffer Pointers  */
+  __IM uint32_t       BUFDATA;        /**< Result Buffer Data Register  */
+  __IM uint32_t       CURCH;          /**< Current Channel Index  */
+  __IOM uint32_t      DECSTATE;       /**< Current Decoder State  */
+  __IOM uint32_t      SENSORSTATE;    /**< Decoder Input Register  */
+  __IOM uint32_t      IDLECONF;       /**< GPIO Idle Phase Configuration  */
+  __IOM uint32_t      ALTEXCONF;      /**< Alternative Excite Pin Configuration  */
+  uint32_t            RESERVED0[2U];  /**< Reserved for future use **/
+  __IM uint32_t       IF;             /**< Interrupt Flag Register  */
+  __IOM uint32_t      IFS;            /**< Interrupt Flag Set Register  */
+  __IOM uint32_t      IFC;            /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t      IEN;            /**< Interrupt Enable Register  */
+  __IM uint32_t       SYNCBUSY;       /**< Synchronization Busy Register  */
+  __IOM uint32_t      ROUTEPEN;       /**< I/O Routing Register  */
 
-  uint32_t            RESERVED1[38]; /**< Reserved registers */
-  LESENSE_ST_TypeDef  ST[32];        /**< Decoding states */
+  uint32_t            RESERVED1[38U]; /**< Reserved registers */
+  LESENSE_ST_TypeDef  ST[32U];        /**< Decoding states */
 
-  LESENSE_BUF_TypeDef BUF[16];       /**< Scanresult */
+  LESENSE_BUF_TypeDef BUF[16U];       /**< Scanresult */
 
-  LESENSE_CH_TypeDef  CH[16];        /**< Scanconfig */
-} LESENSE_TypeDef;                   /** @} */
+  LESENSE_CH_TypeDef  CH[16U];        /**< Scanconfig */
+} LESENSE_TypeDef;                    /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG12B_LESENSE
  * @{
  * @defgroup EFM32PG12B_LESENSE_BitFields  LESENSE Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for LESENSE CTRL */
 #define _LESENSE_CTRL_RESETVALUE                       0x00000000UL                             /**< Default value for LESENSE_CTRL */

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_lesense_buf.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_lesense_buf.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg12b_lesense_buf.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG12B_LESENSE_BUF register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,14 +40,14 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief LESENSE_BUF LESENSE BUF Register
  * @ingroup EFM32PG12B_LESENSE
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t DATA; /**< Scan Results  */
 } LESENSE_BUF_TypeDef;

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_lesense_ch.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_lesense_ch.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg12b_lesense_ch.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG12B_LESENSE_CH register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,19 +40,19 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief LESENSE_CH LESENSE CH Register
  * @ingroup EFM32PG12B_LESENSE
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IOM uint32_t TIMING;       /**< Scan Configuration  */
-  __IOM uint32_t INTERACT;     /**< Scan Configuration  */
-  __IOM uint32_t EVAL;         /**< Scan Configuration  */
-  uint32_t       RESERVED0[1]; /**< Reserved future */
+  __IOM uint32_t TIMING;        /**< Scan Configuration  */
+  __IOM uint32_t INTERACT;      /**< Scan Configuration  */
+  __IOM uint32_t EVAL;          /**< Scan Configuration  */
+  uint32_t       RESERVED0[1U]; /**< Reserved future */
 } LESENSE_CH_TypeDef;
 
 /** @} End of group Parts */

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_lesense_st.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_lesense_st.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg12b_lesense_st.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG12B_LESENSE_ST register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,14 +40,14 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief LESENSE_ST LESENSE ST Register
  * @ingroup EFM32PG12B_LESENSE
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t TCONFA; /**< State Transition Configuration a  */
   __IOM uint32_t TCONFB; /**< State Transition Configuration B  */

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_letimer.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_letimer.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg12b_letimer.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG12B_LETIMER register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,47 +40,47 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG12B_LETIMER LETIMER
  * @{
  * @brief EFM32PG12B_LETIMER Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** LETIMER Register Declaration */
 typedef struct {
-  __IOM uint32_t CTRL;         /**< Control Register  */
-  __IOM uint32_t CMD;          /**< Command Register  */
-  __IM uint32_t  STATUS;       /**< Status Register  */
-  __IOM uint32_t CNT;          /**< Counter Value Register  */
-  __IOM uint32_t COMP0;        /**< Compare Value Register 0  */
-  __IOM uint32_t COMP1;        /**< Compare Value Register 1  */
-  __IOM uint32_t REP0;         /**< Repeat Counter Register 0  */
-  __IOM uint32_t REP1;         /**< Repeat Counter Register 1  */
-  __IM uint32_t  IF;           /**< Interrupt Flag Register  */
-  __IOM uint32_t IFS;          /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;          /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t IEN;          /**< Interrupt Enable Register  */
+  __IOM uint32_t CTRL;          /**< Control Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IOM uint32_t CNT;           /**< Counter Value Register  */
+  __IOM uint32_t COMP0;         /**< Compare Value Register 0  */
+  __IOM uint32_t COMP1;         /**< Compare Value Register 1  */
+  __IOM uint32_t REP0;          /**< Repeat Counter Register 0  */
+  __IOM uint32_t REP1;          /**< Repeat Counter Register 1  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
 
-  uint32_t       RESERVED0[1]; /**< Reserved for future use **/
-  __IM uint32_t  SYNCBUSY;     /**< Synchronization Busy Register  */
+  uint32_t       RESERVED0[1U]; /**< Reserved for future use **/
+  __IM uint32_t  SYNCBUSY;      /**< Synchronization Busy Register  */
 
-  uint32_t       RESERVED1[2]; /**< Reserved for future use **/
-  __IOM uint32_t ROUTEPEN;     /**< I/O Routing Pin Enable Register  */
-  __IOM uint32_t ROUTELOC0;    /**< I/O Routing Location Register  */
+  uint32_t       RESERVED1[2U]; /**< Reserved for future use **/
+  __IOM uint32_t ROUTEPEN;      /**< I/O Routing Pin Enable Register  */
+  __IOM uint32_t ROUTELOC0;     /**< I/O Routing Location Register  */
 
-  uint32_t       RESERVED2[2]; /**< Reserved for future use **/
-  __IOM uint32_t PRSSEL;       /**< PRS Input Select Register  */
-} LETIMER_TypeDef;             /** @} */
+  uint32_t       RESERVED2[2U]; /**< Reserved for future use **/
+  __IOM uint32_t PRSSEL;        /**< PRS Input Select Register  */
+} LETIMER_TypeDef;              /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG12B_LETIMER
  * @{
  * @defgroup EFM32PG12B_LETIMER_BitFields  LETIMER Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for LETIMER CTRL */
 #define _LETIMER_CTRL_RESETVALUE                0x00000000UL                           /**< Default value for LETIMER_CTRL */

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_leuart.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_leuart.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg12b_leuart.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG12B_LEUART register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,50 +40,50 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG12B_LEUART LEUART
  * @{
  * @brief EFM32PG12B_LEUART Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** LEUART Register Declaration */
 typedef struct {
-  __IOM uint32_t CTRL;         /**< Control Register  */
-  __IOM uint32_t CMD;          /**< Command Register  */
-  __IM uint32_t  STATUS;       /**< Status Register  */
-  __IOM uint32_t CLKDIV;       /**< Clock Control Register  */
-  __IOM uint32_t STARTFRAME;   /**< Start Frame Register  */
-  __IOM uint32_t SIGFRAME;     /**< Signal Frame Register  */
-  __IM uint32_t  RXDATAX;      /**< Receive Buffer Data Extended Register  */
-  __IM uint32_t  RXDATA;       /**< Receive Buffer Data Register  */
-  __IM uint32_t  RXDATAXP;     /**< Receive Buffer Data Extended Peek Register  */
-  __IOM uint32_t TXDATAX;      /**< Transmit Buffer Data Extended Register  */
-  __IOM uint32_t TXDATA;       /**< Transmit Buffer Data Register  */
-  __IM uint32_t  IF;           /**< Interrupt Flag Register  */
-  __IOM uint32_t IFS;          /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;          /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t IEN;          /**< Interrupt Enable Register  */
-  __IOM uint32_t PULSECTRL;    /**< Pulse Control Register  */
+  __IOM uint32_t CTRL;          /**< Control Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IOM uint32_t CLKDIV;        /**< Clock Control Register  */
+  __IOM uint32_t STARTFRAME;    /**< Start Frame Register  */
+  __IOM uint32_t SIGFRAME;      /**< Signal Frame Register  */
+  __IM uint32_t  RXDATAX;       /**< Receive Buffer Data Extended Register  */
+  __IM uint32_t  RXDATA;        /**< Receive Buffer Data Register  */
+  __IM uint32_t  RXDATAXP;      /**< Receive Buffer Data Extended Peek Register  */
+  __IOM uint32_t TXDATAX;       /**< Transmit Buffer Data Extended Register  */
+  __IOM uint32_t TXDATA;        /**< Transmit Buffer Data Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t PULSECTRL;     /**< Pulse Control Register  */
 
-  __IOM uint32_t FREEZE;       /**< Freeze Register  */
-  __IM uint32_t  SYNCBUSY;     /**< Synchronization Busy Register  */
+  __IOM uint32_t FREEZE;        /**< Freeze Register  */
+  __IM uint32_t  SYNCBUSY;      /**< Synchronization Busy Register  */
 
-  uint32_t       RESERVED0[3]; /**< Reserved for future use **/
-  __IOM uint32_t ROUTEPEN;     /**< I/O Routing Pin Enable Register  */
-  __IOM uint32_t ROUTELOC0;    /**< I/O Routing Location Register  */
-  uint32_t       RESERVED1[2]; /**< Reserved for future use **/
-  __IOM uint32_t INPUT;        /**< LEUART Input Register  */
-} LEUART_TypeDef;              /** @} */
+  uint32_t       RESERVED0[3U]; /**< Reserved for future use **/
+  __IOM uint32_t ROUTEPEN;      /**< I/O Routing Pin Enable Register  */
+  __IOM uint32_t ROUTELOC0;     /**< I/O Routing Location Register  */
+  uint32_t       RESERVED1[2U]; /**< Reserved for future use **/
+  __IOM uint32_t INPUT;         /**< LEUART Input Register  */
+} LEUART_TypeDef;               /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG12B_LEUART
  * @{
  * @defgroup EFM32PG12B_LEUART_BitFields  LEUART Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for LEUART CTRL */
 #define _LEUART_CTRL_RESETVALUE                  0x00000000UL                         /**< Default value for LEUART_CTRL */

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_msc.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_msc.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg12b_msc.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG12B_MSC register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG12B_MSC MSC
  * @{
  * @brief EFM32PG12B_MSC Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** MSC Register Declaration */
 typedef struct {
   __IOM uint32_t CTRL;           /**< Memory System Control Register  */
@@ -57,11 +56,11 @@ typedef struct {
   __IOM uint32_t WRITECTRL;      /**< Write Control Register  */
   __IOM uint32_t WRITECMD;       /**< Write Command Register  */
   __IOM uint32_t ADDRB;          /**< Page Erase/Write Address Buffer  */
-  uint32_t       RESERVED0[1];   /**< Reserved for future use **/
+  uint32_t       RESERVED0[1U];  /**< Reserved for future use **/
   __IOM uint32_t WDATA;          /**< Write Data Register  */
   __IM uint32_t  STATUS;         /**< Status Register  */
 
-  uint32_t       RESERVED1[4];   /**< Reserved for future use **/
+  uint32_t       RESERVED1[4U];  /**< Reserved for future use **/
   __IM uint32_t  IF;             /**< Interrupt Flag Register  */
   __IOM uint32_t IFS;            /**< Interrupt Flag Set Register  */
   __IOM uint32_t IFC;            /**< Interrupt Flag Clear Register  */
@@ -71,31 +70,31 @@ typedef struct {
   __IM uint32_t  CACHEHITS;      /**< Cache Hits Performance Counter  */
   __IM uint32_t  CACHEMISSES;    /**< Cache Misses Performance Counter  */
 
-  uint32_t       RESERVED2[1];   /**< Reserved for future use **/
+  uint32_t       RESERVED2[1U];  /**< Reserved for future use **/
   __IOM uint32_t MASSLOCK;       /**< Mass Erase Lock Register  */
 
-  uint32_t       RESERVED3[1];   /**< Reserved for future use **/
+  uint32_t       RESERVED3[1U];  /**< Reserved for future use **/
   __IOM uint32_t STARTUP;        /**< Startup Control  */
 
-  uint32_t       RESERVED4[4];   /**< Reserved for future use **/
+  uint32_t       RESERVED4[4U];  /**< Reserved for future use **/
   __IOM uint32_t BANKSWITCHLOCK; /**< Bank Switching Lock Register  */
   __IOM uint32_t CMD;            /**< Command Register  */
 
-  uint32_t       RESERVED5[6];   /**< Reserved for future use **/
+  uint32_t       RESERVED5[6U];  /**< Reserved for future use **/
   __IOM uint32_t BOOTLOADERCTRL; /**< Bootloader Read and Write Enable, Write Once Register  */
   __IOM uint32_t AAPUNLOCKCMD;   /**< Software Unlock AAP Command Register  */
   __IOM uint32_t CACHECONFIG0;   /**< Cache Configuration Register 0  */
 
-  uint32_t       RESERVED6[25];  /**< Reserved for future use **/
+  uint32_t       RESERVED6[25U]; /**< Reserved for future use **/
   __IOM uint32_t RAMCTRL;        /**< RAM Control Enable Register  */
 } MSC_TypeDef;                   /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG12B_MSC
  * @{
  * @defgroup EFM32PG12B_MSC_BitFields  MSC Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for MSC CTRL */
 #define _MSC_CTRL_RESETVALUE                              0x00000001UL                            /**< Default value for MSC_CTRL */
@@ -650,28 +649,18 @@ typedef struct {
 #define MSC_CACHECONFIG0_CACHELPLEVEL_MINACTIVITY         (_MSC_CACHECONFIG0_CACHELPLEVEL_MINACTIVITY << 0) /**< Shifted mode MINACTIVITY for MSC_CACHECONFIG0 */
 
 /* Bit fields for MSC RAMCTRL */
-#define _MSC_RAMCTRL_RESETVALUE                           0x00000000UL                               /**< Default value for MSC_RAMCTRL */
-#define _MSC_RAMCTRL_MASK                                 0x00090101UL                               /**< Mask for MSC_RAMCTRL */
-#define MSC_RAMCTRL_RAMCACHEEN                            (0x1UL << 0)                               /**< RAM CACHE Enable */
-#define _MSC_RAMCTRL_RAMCACHEEN_SHIFT                     0                                          /**< Shift value for MSC_RAMCACHEEN */
-#define _MSC_RAMCTRL_RAMCACHEEN_MASK                      0x1UL                                      /**< Bit mask for MSC_RAMCACHEEN */
-#define _MSC_RAMCTRL_RAMCACHEEN_DEFAULT                   0x00000000UL                               /**< Mode DEFAULT for MSC_RAMCTRL */
-#define MSC_RAMCTRL_RAMCACHEEN_DEFAULT                    (_MSC_RAMCTRL_RAMCACHEEN_DEFAULT << 0)     /**< Shifted mode DEFAULT for MSC_RAMCTRL */
-#define MSC_RAMCTRL_RAM1CACHEEN                           (0x1UL << 8)                               /**< RAM1 CACHE Enable */
-#define _MSC_RAMCTRL_RAM1CACHEEN_SHIFT                    8                                          /**< Shift value for MSC_RAM1CACHEEN */
-#define _MSC_RAMCTRL_RAM1CACHEEN_MASK                     0x100UL                                    /**< Bit mask for MSC_RAM1CACHEEN */
-#define _MSC_RAMCTRL_RAM1CACHEEN_DEFAULT                  0x00000000UL                               /**< Mode DEFAULT for MSC_RAMCTRL */
-#define MSC_RAMCTRL_RAM1CACHEEN_DEFAULT                   (_MSC_RAMCTRL_RAM1CACHEEN_DEFAULT << 8)    /**< Shifted mode DEFAULT for MSC_RAMCTRL */
-#define MSC_RAMCTRL_RAM2CACHEEN                           (0x1UL << 16)                              /**< RAM2 CACHE Enable */
-#define _MSC_RAMCTRL_RAM2CACHEEN_SHIFT                    16                                         /**< Shift value for MSC_RAM2CACHEEN */
-#define _MSC_RAMCTRL_RAM2CACHEEN_MASK                     0x10000UL                                  /**< Bit mask for MSC_RAM2CACHEEN */
-#define _MSC_RAMCTRL_RAM2CACHEEN_DEFAULT                  0x00000000UL                               /**< Mode DEFAULT for MSC_RAMCTRL */
-#define MSC_RAMCTRL_RAM2CACHEEN_DEFAULT                   (_MSC_RAMCTRL_RAM2CACHEEN_DEFAULT << 16)   /**< Shifted mode DEFAULT for MSC_RAMCTRL */
-#define MSC_RAMCTRL_RAMSEQCACHEEN                         (0x1UL << 19)                              /**< RAMSEQ CACHE Enable */
-#define _MSC_RAMCTRL_RAMSEQCACHEEN_SHIFT                  19                                         /**< Shift value for MSC_RAMSEQCACHEEN */
-#define _MSC_RAMCTRL_RAMSEQCACHEEN_MASK                   0x80000UL                                  /**< Bit mask for MSC_RAMSEQCACHEEN */
-#define _MSC_RAMCTRL_RAMSEQCACHEEN_DEFAULT                0x00000000UL                               /**< Mode DEFAULT for MSC_RAMCTRL */
-#define MSC_RAMCTRL_RAMSEQCACHEEN_DEFAULT                 (_MSC_RAMCTRL_RAMSEQCACHEEN_DEFAULT << 19) /**< Shifted mode DEFAULT for MSC_RAMCTRL */
+#define _MSC_RAMCTRL_RESETVALUE                           0x00000000UL                            /**< Default value for MSC_RAMCTRL */
+#define _MSC_RAMCTRL_MASK                                 0x00000101UL                            /**< Mask for MSC_RAMCTRL */
+#define MSC_RAMCTRL_RAMCACHEEN                            (0x1UL << 0)                            /**< RAM CACHE Enable */
+#define _MSC_RAMCTRL_RAMCACHEEN_SHIFT                     0                                       /**< Shift value for MSC_RAMCACHEEN */
+#define _MSC_RAMCTRL_RAMCACHEEN_MASK                      0x1UL                                   /**< Bit mask for MSC_RAMCACHEEN */
+#define _MSC_RAMCTRL_RAMCACHEEN_DEFAULT                   0x00000000UL                            /**< Mode DEFAULT for MSC_RAMCTRL */
+#define MSC_RAMCTRL_RAMCACHEEN_DEFAULT                    (_MSC_RAMCTRL_RAMCACHEEN_DEFAULT << 0)  /**< Shifted mode DEFAULT for MSC_RAMCTRL */
+#define MSC_RAMCTRL_RAM1CACHEEN                           (0x1UL << 8)                            /**< RAM1 CACHE Enable */
+#define _MSC_RAMCTRL_RAM1CACHEEN_SHIFT                    8                                       /**< Shift value for MSC_RAM1CACHEEN */
+#define _MSC_RAMCTRL_RAM1CACHEEN_MASK                     0x100UL                                 /**< Bit mask for MSC_RAM1CACHEEN */
+#define _MSC_RAMCTRL_RAM1CACHEEN_DEFAULT                  0x00000000UL                            /**< Mode DEFAULT for MSC_RAMCTRL */
+#define MSC_RAMCTRL_RAM1CACHEEN_DEFAULT                   (_MSC_RAMCTRL_RAM1CACHEEN_DEFAULT << 8) /**< Shifted mode DEFAULT for MSC_RAMCTRL */
 
 /** @} */
 /** @} End of group EFM32PG12B_MSC */

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_pcnt.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_pcnt.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg12b_pcnt.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG12B_PCNT register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,46 +40,46 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG12B_PCNT PCNT
  * @{
  * @brief EFM32PG12B_PCNT Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** PCNT Register Declaration */
 typedef struct {
-  __IOM uint32_t CTRL;         /**< Control Register  */
-  __IOM uint32_t CMD;          /**< Command Register  */
-  __IM uint32_t  STATUS;       /**< Status Register  */
-  __IM uint32_t  CNT;          /**< Counter Value Register  */
-  __IM uint32_t  TOP;          /**< Top Value Register  */
-  __IOM uint32_t TOPB;         /**< Top Value Buffer Register  */
-  __IM uint32_t  IF;           /**< Interrupt Flag Register  */
-  __IOM uint32_t IFS;          /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;          /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t IEN;          /**< Interrupt Enable Register  */
-  uint32_t       RESERVED0[1]; /**< Reserved for future use **/
-  __IOM uint32_t ROUTELOC0;    /**< I/O Routing Location Register  */
+  __IOM uint32_t CTRL;          /**< Control Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IM uint32_t  CNT;           /**< Counter Value Register  */
+  __IM uint32_t  TOP;           /**< Top Value Register  */
+  __IOM uint32_t TOPB;          /**< Top Value Buffer Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  uint32_t       RESERVED0[1U]; /**< Reserved for future use **/
+  __IOM uint32_t ROUTELOC0;     /**< I/O Routing Location Register  */
 
-  uint32_t       RESERVED1[4]; /**< Reserved for future use **/
-  __IOM uint32_t FREEZE;       /**< Freeze Register  */
-  __IM uint32_t  SYNCBUSY;     /**< Synchronization Busy Register  */
+  uint32_t       RESERVED1[4U]; /**< Reserved for future use **/
+  __IOM uint32_t FREEZE;        /**< Freeze Register  */
+  __IM uint32_t  SYNCBUSY;      /**< Synchronization Busy Register  */
 
-  uint32_t       RESERVED2[7]; /**< Reserved for future use **/
-  __IM uint32_t  AUXCNT;       /**< Auxiliary Counter Value Register  */
-  __IOM uint32_t INPUT;        /**< PCNT Input Register  */
-  __IOM uint32_t OVSCFG;       /**< Oversampling Config Register  */
-} PCNT_TypeDef;                /** @} */
+  uint32_t       RESERVED2[7U]; /**< Reserved for future use **/
+  __IM uint32_t  AUXCNT;        /**< Auxiliary Counter Value Register  */
+  __IOM uint32_t INPUT;         /**< PCNT Input Register  */
+  __IOM uint32_t OVSCFG;        /**< Oversampling Config Register  */
+} PCNT_TypeDef;                 /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG12B_PCNT
  * @{
  * @defgroup EFM32PG12B_PCNT_BitFields  PCNT Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for PCNT CTRL */
 #define _PCNT_CTRL_RESETVALUE              0x00000000UL                          /**< Default value for PCNT_CTRL */

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_prs.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_prs.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg12b_prs.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG12B_PRS register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,42 +40,42 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG12B_PRS PRS
  * @{
  * @brief EFM32PG12B_PRS Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** PRS Register Declaration */
 typedef struct {
-  __IOM uint32_t SWPULSE;      /**< Software Pulse Register  */
-  __IOM uint32_t SWLEVEL;      /**< Software Level Register  */
-  __IOM uint32_t ROUTEPEN;     /**< I/O Routing Pin Enable Register  */
-  uint32_t       RESERVED0[1]; /**< Reserved for future use **/
-  __IOM uint32_t ROUTELOC0;    /**< I/O Routing Location Register  */
-  __IOM uint32_t ROUTELOC1;    /**< I/O Routing Location Register  */
-  __IOM uint32_t ROUTELOC2;    /**< I/O Routing Location Register  */
+  __IOM uint32_t SWPULSE;       /**< Software Pulse Register  */
+  __IOM uint32_t SWLEVEL;       /**< Software Level Register  */
+  __IOM uint32_t ROUTEPEN;      /**< I/O Routing Pin Enable Register  */
+  uint32_t       RESERVED0[1U]; /**< Reserved for future use **/
+  __IOM uint32_t ROUTELOC0;     /**< I/O Routing Location Register  */
+  __IOM uint32_t ROUTELOC1;     /**< I/O Routing Location Register  */
+  __IOM uint32_t ROUTELOC2;     /**< I/O Routing Location Register  */
 
-  uint32_t       RESERVED1[5]; /**< Reserved for future use **/
-  __IOM uint32_t CTRL;         /**< Control Register  */
-  __IOM uint32_t DMAREQ0;      /**< DMA Request 0 Register  */
-  __IOM uint32_t DMAREQ1;      /**< DMA Request 1 Register  */
-  uint32_t       RESERVED2[1]; /**< Reserved for future use **/
-  __IM uint32_t  PEEK;         /**< PRS Channel Values  */
+  uint32_t       RESERVED1[5U]; /**< Reserved for future use **/
+  __IOM uint32_t CTRL;          /**< Control Register  */
+  __IOM uint32_t DMAREQ0;       /**< DMA Request 0 Register  */
+  __IOM uint32_t DMAREQ1;       /**< DMA Request 1 Register  */
+  uint32_t       RESERVED2[1U]; /**< Reserved for future use **/
+  __IM uint32_t  PEEK;          /**< PRS Channel Values  */
 
-  uint32_t       RESERVED3[3]; /**< Reserved registers */
-  PRS_CH_TypeDef CH[12];       /**< Channel registers */
-} PRS_TypeDef;                 /** @} */
+  uint32_t       RESERVED3[3U]; /**< Reserved registers */
+  PRS_CH_TypeDef CH[12U];       /**< Channel registers */
+} PRS_TypeDef;                  /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG12B_PRS
  * @{
  * @defgroup EFM32PG12B_PRS_BitFields  PRS Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for PRS SWPULSE */
 #define _PRS_SWPULSE_RESETVALUE                    0x00000000UL                           /**< Default value for PRS_SWPULSE */

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_prs_ch.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_prs_ch.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg12b_prs_ch.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG12B_PRS_CH register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,14 +40,14 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief PRS_CH PRS CH Register
  * @ingroup EFM32PG12B_PRS
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t CTRL; /**< Channel Control Register  */
 } PRS_CH_TypeDef;

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_prs_signals.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_prs_signals.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg12b_prs_signals.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG12B_PRS_SIGNALS register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,17 +40,17 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @addtogroup EFM32PG12B_PRS
  * @{
  * @addtogroup EFM32PG12B_PRS_Signals PRS Signals
  * @{
  * @brief PRS Signal names
- *****************************************************************************/
+ ******************************************************************************/
 #define PRS_PRS_CH0                 ((1 << 8) + 0)  /**< PRS PRS channel 0 */
 #define PRS_PRS_CH1                 ((1 << 8) + 1)  /**< PRS PRS channel 1 */
 #define PRS_PRS_CH2                 ((1 << 8) + 2)  /**< PRS PRS channel 2 */
@@ -189,6 +188,8 @@ extern "C" {
 #define PRS_MODEM_FRAMESENT         ((86 << 8) + 3) /**< PRS Entire frame transmitted */
 #define PRS_MODEM_SYNCSENT          ((86 << 8) + 4) /**< PRS Syncword transmitted */
 #define PRS_MODEM_PRESENT           ((86 << 8) + 5) /**< PRS Preamble transmitted */
+#define PRS_MODEM_ANT0              ((87 << 8) + 5) /**< PRS Antenna 0 select */
+#define PRS_MODEM_ANT1              ((87 << 8) + 6) /**< PRS Antenna 1 select */
 
 /** @} */
 /** @} End of group EFM32PG12B_PRS */

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_rmu.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_rmu.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg12b_rmu.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG12B_RMU register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG12B_RMU RMU
  * @{
  * @brief EFM32PG12B_RMU Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** RMU Register Declaration */
 typedef struct {
   __IOM uint32_t CTRL;     /**< Control Register  */
@@ -59,12 +58,12 @@ typedef struct {
   __IOM uint32_t LOCK;     /**< Configuration Lock Register  */
 } RMU_TypeDef;             /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG12B_RMU
  * @{
  * @defgroup EFM32PG12B_RMU_BitFields  RMU Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for RMU CTRL */
 #define _RMU_CTRL_RESETVALUE               0x00004204UL                          /**< Default value for RMU_CTRL */

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_romtable.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_romtable.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg12b_romtable.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG12B_ROMTABLE register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG12B_ROMTABLE ROM Table, Chip Revision Information
  * @{
  * @brief Chip Information, Revision numbers
- *****************************************************************************/
+ ******************************************************************************/
 /** ROMTABLE Register Declaration */
 typedef struct {
   __IM uint32_t PID4; /**< JEP_106_BANK */
@@ -63,12 +62,12 @@ typedef struct {
   __IM uint32_t CID0; /**< Unused */
 } ROMTABLE_TypeDef;   /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG12B_ROMTABLE
  * @{
  * @defgroup EFM32PG12B_ROMTABLE_BitFields ROM Table Bit Field definitions
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 /* Bit fields for EFM32PG12B_ROMTABLE */
 #define _ROMTABLE_PID0_FAMILYLSB_MASK       0x000000C0UL /**< Least Significant Bits [1:0] of CHIP FAMILY, mask */
 #define _ROMTABLE_PID0_FAMILYLSB_SHIFT      6            /**< Least Significant Bits [1:0] of CHIP FAMILY, shift */

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_rtcc.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_rtcc.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg12b_rtcc.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG12B_RTCC register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,46 +40,46 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG12B_RTCC RTCC
  * @{
  * @brief EFM32PG12B_RTCC Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** RTCC Register Declaration */
 typedef struct {
-  __IOM uint32_t   CTRL;          /**< Control Register  */
-  __IOM uint32_t   PRECNT;        /**< Pre-Counter Value Register  */
-  __IOM uint32_t   CNT;           /**< Counter Value Register  */
-  __IM uint32_t    COMBCNT;       /**< Combined Pre-Counter and Counter Value Register  */
-  __IOM uint32_t   TIME;          /**< Time of Day Register  */
-  __IOM uint32_t   DATE;          /**< Date Register  */
-  __IM uint32_t    IF;            /**< RTCC Interrupt Flags  */
-  __IOM uint32_t   IFS;           /**< Interrupt Flag Set Register  */
-  __IOM uint32_t   IFC;           /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t   IEN;           /**< Interrupt Enable Register  */
-  __IM uint32_t    STATUS;        /**< Status Register  */
-  __IOM uint32_t   CMD;           /**< Command Register  */
-  __IM uint32_t    SYNCBUSY;      /**< Synchronization Busy Register  */
-  __IOM uint32_t   POWERDOWN;     /**< Retention RAM Power-down Register  */
-  __IOM uint32_t   LOCK;          /**< Configuration Lock Register  */
-  __IOM uint32_t   EM4WUEN;       /**< Wake Up Enable  */
+  __IOM uint32_t   CTRL;           /**< Control Register  */
+  __IOM uint32_t   PRECNT;         /**< Pre-Counter Value Register  */
+  __IOM uint32_t   CNT;            /**< Counter Value Register  */
+  __IM uint32_t    COMBCNT;        /**< Combined Pre-Counter and Counter Value Register  */
+  __IOM uint32_t   TIME;           /**< Time of Day Register  */
+  __IOM uint32_t   DATE;           /**< Date Register  */
+  __IM uint32_t    IF;             /**< RTCC Interrupt Flags  */
+  __IOM uint32_t   IFS;            /**< Interrupt Flag Set Register  */
+  __IOM uint32_t   IFC;            /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t   IEN;            /**< Interrupt Enable Register  */
+  __IM uint32_t    STATUS;         /**< Status Register  */
+  __IOM uint32_t   CMD;            /**< Command Register  */
+  __IM uint32_t    SYNCBUSY;       /**< Synchronization Busy Register  */
+  __IOM uint32_t   POWERDOWN;      /**< Retention RAM Power-down Register  */
+  __IOM uint32_t   LOCK;           /**< Configuration Lock Register  */
+  __IOM uint32_t   EM4WUEN;        /**< Wake Up Enable  */
 
-  RTCC_CC_TypeDef  CC[3];         /**< Capture/Compare Channel */
+  RTCC_CC_TypeDef  CC[3U];         /**< Capture/Compare Channel */
 
-  uint32_t         RESERVED0[37]; /**< Reserved registers */
-  RTCC_RET_TypeDef RET[32];       /**< RetentionReg */
-} RTCC_TypeDef;                   /** @} */
+  uint32_t         RESERVED0[37U]; /**< Reserved registers */
+  RTCC_RET_TypeDef RET[32U];       /**< RetentionReg */
+} RTCC_TypeDef;                    /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG12B_RTCC
  * @{
  * @defgroup EFM32PG12B_RTCC_BitFields  RTCC Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for RTCC CTRL */
 #define _RTCC_CTRL_RESETVALUE               0x00000000UL                            /**< Default value for RTCC_CTRL */

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_rtcc_cc.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_rtcc_cc.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg12b_rtcc_cc.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG12B_RTCC_CC register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,14 +40,14 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief RTCC_CC RTCC CC Register
  * @ingroup EFM32PG12B_RTCC
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t CTRL; /**< CC Channel Control Register  */
   __IOM uint32_t CCV;  /**< Capture/Compare Value Register  */

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_rtcc_ret.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_rtcc_ret.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg12b_rtcc_ret.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG12B_RTCC_RET register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,14 +40,14 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief RTCC_RET RTCC RET Register
  * @ingroup EFM32PG12B_RTCC
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t REG; /**< Retention Register  */
 } RTCC_RET_TypeDef;

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_smu.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_smu.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg12b_smu.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG12B_SMU register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,39 +40,39 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG12B_SMU SMU
  * @{
  * @brief EFM32PG12B_SMU Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** SMU Register Declaration */
 typedef struct {
-  uint32_t       RESERVED0[3];  /**< Reserved for future use **/
-  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
-  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  uint32_t       RESERVED0[3U];  /**< Reserved for future use **/
+  __IM uint32_t  IF;             /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;            /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;            /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;            /**< Interrupt Enable Register  */
 
-  uint32_t       RESERVED1[9];  /**< Reserved for future use **/
-  __IOM uint32_t PPUCTRL;       /**< PPU Control Register  */
-  uint32_t       RESERVED2[3];  /**< Reserved for future use **/
-  __IOM uint32_t PPUPATD0;      /**< PPU Privilege Access Type Descriptor 0  */
-  __IOM uint32_t PPUPATD1;      /**< PPU Privilege Access Type Descriptor 1  */
+  uint32_t       RESERVED1[9U];  /**< Reserved for future use **/
+  __IOM uint32_t PPUCTRL;        /**< PPU Control Register  */
+  uint32_t       RESERVED2[3U];  /**< Reserved for future use **/
+  __IOM uint32_t PPUPATD0;       /**< PPU Privilege Access Type Descriptor 0  */
+  __IOM uint32_t PPUPATD1;       /**< PPU Privilege Access Type Descriptor 1  */
 
-  uint32_t       RESERVED3[14]; /**< Reserved for future use **/
-  __IM uint32_t  PPUFS;         /**< PPU Fault Status  */
-} SMU_TypeDef;                  /** @} */
+  uint32_t       RESERVED3[14U]; /**< Reserved for future use **/
+  __IM uint32_t  PPUFS;          /**< PPU Fault Status  */
+} SMU_TypeDef;                   /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG12B_SMU
  * @{
  * @defgroup EFM32PG12B_SMU_BitFields  SMU Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for SMU IF */
 #define _SMU_IF_RESETVALUE                 0x00000000UL                   /**< Default value for SMU_IF */

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_timer.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_timer.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg12b_timer.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG12B_TIMER register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,52 +40,52 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG12B_TIMER TIMER
  * @{
  * @brief EFM32PG12B_TIMER Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** TIMER Register Declaration */
 typedef struct {
-  __IOM uint32_t   CTRL;         /**< Control Register  */
-  __IOM uint32_t   CMD;          /**< Command Register  */
-  __IM uint32_t    STATUS;       /**< Status Register  */
-  __IM uint32_t    IF;           /**< Interrupt Flag Register  */
-  __IOM uint32_t   IFS;          /**< Interrupt Flag Set Register  */
-  __IOM uint32_t   IFC;          /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t   IEN;          /**< Interrupt Enable Register  */
-  __IOM uint32_t   TOP;          /**< Counter Top Value Register  */
-  __IOM uint32_t   TOPB;         /**< Counter Top Value Buffer Register  */
-  __IOM uint32_t   CNT;          /**< Counter Value Register  */
-  uint32_t         RESERVED0[1]; /**< Reserved for future use **/
-  __IOM uint32_t   LOCK;         /**< TIMER Configuration Lock Register  */
-  __IOM uint32_t   ROUTEPEN;     /**< I/O Routing Pin Enable Register  */
-  __IOM uint32_t   ROUTELOC0;    /**< I/O Routing Location Register  */
-  uint32_t         RESERVED1[1]; /**< Reserved for future use **/
-  __IOM uint32_t   ROUTELOC2;    /**< I/O Routing Location Register  */
+  __IOM uint32_t   CTRL;          /**< Control Register  */
+  __IOM uint32_t   CMD;           /**< Command Register  */
+  __IM uint32_t    STATUS;        /**< Status Register  */
+  __IM uint32_t    IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t   IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t   IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t   IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t   TOP;           /**< Counter Top Value Register  */
+  __IOM uint32_t   TOPB;          /**< Counter Top Value Buffer Register  */
+  __IOM uint32_t   CNT;           /**< Counter Value Register  */
+  uint32_t         RESERVED0[1U]; /**< Reserved for future use **/
+  __IOM uint32_t   LOCK;          /**< TIMER Configuration Lock Register  */
+  __IOM uint32_t   ROUTEPEN;      /**< I/O Routing Pin Enable Register  */
+  __IOM uint32_t   ROUTELOC0;     /**< I/O Routing Location Register  */
+  uint32_t         RESERVED1[1U]; /**< Reserved for future use **/
+  __IOM uint32_t   ROUTELOC2;     /**< I/O Routing Location Register  */
 
-  uint32_t         RESERVED2[8]; /**< Reserved registers */
-  TIMER_CC_TypeDef CC[4];        /**< Compare/Capture Channel */
+  uint32_t         RESERVED2[8U]; /**< Reserved registers */
+  TIMER_CC_TypeDef CC[4U];        /**< Compare/Capture Channel */
 
-  __IOM uint32_t   DTCTRL;       /**< DTI Control Register  */
-  __IOM uint32_t   DTTIME;       /**< DTI Time Control Register  */
-  __IOM uint32_t   DTFC;         /**< DTI Fault Configuration Register  */
-  __IOM uint32_t   DTOGEN;       /**< DTI Output Generation Enable Register  */
-  __IM uint32_t    DTFAULT;      /**< DTI Fault Register  */
-  __IOM uint32_t   DTFAULTC;     /**< DTI Fault Clear Register  */
-  __IOM uint32_t   DTLOCK;       /**< DTI Configuration Lock Register  */
-} TIMER_TypeDef;                 /** @} */
+  __IOM uint32_t   DTCTRL;        /**< DTI Control Register  */
+  __IOM uint32_t   DTTIME;        /**< DTI Time Control Register  */
+  __IOM uint32_t   DTFC;          /**< DTI Fault Configuration Register  */
+  __IOM uint32_t   DTOGEN;        /**< DTI Output Generation Enable Register  */
+  __IM uint32_t    DTFAULT;       /**< DTI Fault Register  */
+  __IOM uint32_t   DTFAULTC;      /**< DTI Fault Clear Register  */
+  __IOM uint32_t   DTLOCK;        /**< DTI Configuration Lock Register  */
+} TIMER_TypeDef;                  /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG12B_TIMER
  * @{
  * @defgroup EFM32PG12B_TIMER_BitFields  TIMER Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for TIMER CTRL */
 #define _TIMER_CTRL_RESETVALUE                     0x00000000UL                             /**< Default value for TIMER_CTRL */

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_timer_cc.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_timer_cc.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg12b_timer_cc.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG12B_TIMER_CC register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,14 +40,14 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief TIMER_CC TIMER CC Register
  * @ingroup EFM32PG12B_TIMER
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t CTRL; /**< CC Channel Control Register  */
   __IOM uint32_t CCV;  /**< CC Channel Value Register  */

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_trng.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_trng.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg12b_trng.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG12B_TRNG register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,40 +40,40 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG12B_TRNG TRNG
  * @{
  * @brief EFM32PG12B_TRNG Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** TRNG Register Declaration */
 typedef struct {
-  __IOM uint32_t CONTROL;       /**< Main Control Register  */
-  __IM uint32_t  FIFOLEVEL;     /**< FIFO Level Register  */
-  uint32_t       RESERVED0[1];  /**< Reserved for future use **/
-  __IM uint32_t  FIFODEPTH;     /**< FIFO Depth Register  */
-  __IOM uint32_t KEY0;          /**< Key Register 0  */
-  __IOM uint32_t KEY1;          /**< Key Register 1  */
-  __IOM uint32_t KEY2;          /**< Key Register 2  */
-  __IOM uint32_t KEY3;          /**< Key Register 3  */
-  __IOM uint32_t TESTDATA;      /**< Test Data Register  */
+  __IOM uint32_t CONTROL;        /**< Main Control Register  */
+  __IM uint32_t  FIFOLEVEL;      /**< FIFO Level Register  */
+  uint32_t       RESERVED0[1U];  /**< Reserved for future use **/
+  __IM uint32_t  FIFODEPTH;      /**< FIFO Depth Register  */
+  __IOM uint32_t KEY0;           /**< Key Register 0  */
+  __IOM uint32_t KEY1;           /**< Key Register 1  */
+  __IOM uint32_t KEY2;           /**< Key Register 2  */
+  __IOM uint32_t KEY3;           /**< Key Register 3  */
+  __IOM uint32_t TESTDATA;       /**< Test Data Register  */
 
-  uint32_t       RESERVED1[3];  /**< Reserved for future use **/
-  __IOM uint32_t STATUS;        /**< Status Register  */
-  __IOM uint32_t INITWAITVAL;   /**< Initial Wait Counter  */
-  uint32_t       RESERVED2[50]; /**< Reserved for future use **/
-  __IM uint32_t  FIFO;          /**< FIFO Data  */
-} TRNG_TypeDef;                 /** @} */
+  uint32_t       RESERVED1[3U];  /**< Reserved for future use **/
+  __IOM uint32_t STATUS;         /**< Status Register  */
+  __IOM uint32_t INITWAITVAL;    /**< Initial Wait Counter  */
+  uint32_t       RESERVED2[50U]; /**< Reserved for future use **/
+  __IM uint32_t  FIFO;           /**< FIFO Data  */
+} TRNG_TypeDef;                  /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG12B_TRNG
  * @{
  * @defgroup EFM32PG12B_TRNG_BitFields  TRNG Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for TRNG CONTROL */
 #define _TRNG_CONTROL_RESETVALUE             0x00000000UL                             /**< Default value for TRNG_CONTROL */

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_usart.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_usart.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg12b_usart.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG12B_USART register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,57 +40,57 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG12B_USART USART
  * @{
  * @brief EFM32PG12B_USART Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** USART Register Declaration */
 typedef struct {
-  __IOM uint32_t CTRL;         /**< Control Register  */
-  __IOM uint32_t FRAME;        /**< USART Frame Format Register  */
-  __IOM uint32_t TRIGCTRL;     /**< USART Trigger Control Register  */
-  __IOM uint32_t CMD;          /**< Command Register  */
-  __IM uint32_t  STATUS;       /**< USART Status Register  */
-  __IOM uint32_t CLKDIV;       /**< Clock Control Register  */
-  __IM uint32_t  RXDATAX;      /**< RX Buffer Data Extended Register  */
-  __IM uint32_t  RXDATA;       /**< RX Buffer Data Register  */
-  __IM uint32_t  RXDOUBLEX;    /**< RX Buffer Double Data Extended Register  */
-  __IM uint32_t  RXDOUBLE;     /**< RX FIFO Double Data Register  */
-  __IM uint32_t  RXDATAXP;     /**< RX Buffer Data Extended Peek Register  */
-  __IM uint32_t  RXDOUBLEXP;   /**< RX Buffer Double Data Extended Peek Register  */
-  __IOM uint32_t TXDATAX;      /**< TX Buffer Data Extended Register  */
-  __IOM uint32_t TXDATA;       /**< TX Buffer Data Register  */
-  __IOM uint32_t TXDOUBLEX;    /**< TX Buffer Double Data Extended Register  */
-  __IOM uint32_t TXDOUBLE;     /**< TX Buffer Double Data Register  */
-  __IM uint32_t  IF;           /**< Interrupt Flag Register  */
-  __IOM uint32_t IFS;          /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;          /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t IEN;          /**< Interrupt Enable Register  */
-  __IOM uint32_t IRCTRL;       /**< IrDA Control Register  */
-  uint32_t       RESERVED0[1]; /**< Reserved for future use **/
-  __IOM uint32_t INPUT;        /**< USART Input Register  */
-  __IOM uint32_t I2SCTRL;      /**< I2S Control Register  */
-  __IOM uint32_t TIMING;       /**< Timing Register  */
-  __IOM uint32_t CTRLX;        /**< Control Register Extended  */
-  __IOM uint32_t TIMECMP0;     /**< Used to Generate Interrupts and Various Delays  */
-  __IOM uint32_t TIMECMP1;     /**< Used to Generate Interrupts and Various Delays  */
-  __IOM uint32_t TIMECMP2;     /**< Used to Generate Interrupts and Various Delays  */
-  __IOM uint32_t ROUTEPEN;     /**< I/O Routing Pin Enable Register  */
-  __IOM uint32_t ROUTELOC0;    /**< I/O Routing Location Register  */
-  __IOM uint32_t ROUTELOC1;    /**< I/O Routing Location Register  */
-} USART_TypeDef;               /** @} */
+  __IOM uint32_t CTRL;          /**< Control Register  */
+  __IOM uint32_t FRAME;         /**< USART Frame Format Register  */
+  __IOM uint32_t TRIGCTRL;      /**< USART Trigger Control Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IM uint32_t  STATUS;        /**< USART Status Register  */
+  __IOM uint32_t CLKDIV;        /**< Clock Control Register  */
+  __IM uint32_t  RXDATAX;       /**< RX Buffer Data Extended Register  */
+  __IM uint32_t  RXDATA;        /**< RX Buffer Data Register  */
+  __IM uint32_t  RXDOUBLEX;     /**< RX Buffer Double Data Extended Register  */
+  __IM uint32_t  RXDOUBLE;      /**< RX FIFO Double Data Register  */
+  __IM uint32_t  RXDATAXP;      /**< RX Buffer Data Extended Peek Register  */
+  __IM uint32_t  RXDOUBLEXP;    /**< RX Buffer Double Data Extended Peek Register  */
+  __IOM uint32_t TXDATAX;       /**< TX Buffer Data Extended Register  */
+  __IOM uint32_t TXDATA;        /**< TX Buffer Data Register  */
+  __IOM uint32_t TXDOUBLEX;     /**< TX Buffer Double Data Extended Register  */
+  __IOM uint32_t TXDOUBLE;      /**< TX Buffer Double Data Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t IRCTRL;        /**< IrDA Control Register  */
+  uint32_t       RESERVED0[1U]; /**< Reserved for future use **/
+  __IOM uint32_t INPUT;         /**< USART Input Register  */
+  __IOM uint32_t I2SCTRL;       /**< I2S Control Register  */
+  __IOM uint32_t TIMING;        /**< Timing Register  */
+  __IOM uint32_t CTRLX;         /**< Control Register Extended  */
+  __IOM uint32_t TIMECMP0;      /**< Used to Generate Interrupts and Various Delays  */
+  __IOM uint32_t TIMECMP1;      /**< Used to Generate Interrupts and Various Delays  */
+  __IOM uint32_t TIMECMP2;      /**< Used to Generate Interrupts and Various Delays  */
+  __IOM uint32_t ROUTEPEN;      /**< I/O Routing Pin Enable Register  */
+  __IOM uint32_t ROUTELOC0;     /**< I/O Routing Location Register  */
+  __IOM uint32_t ROUTELOC1;     /**< I/O Routing Location Register  */
+} USART_TypeDef;                /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG12B_USART
  * @{
  * @defgroup EFM32PG12B_USART_BitFields  USART Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for USART CTRL */
 #define _USART_CTRL_RESETVALUE                  0x00000000UL                             /**< Default value for USART_CTRL */

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_vdac.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_vdac.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg12b_vdac.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG12B_VDAC register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,41 +40,41 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG12B_VDAC VDAC
  * @{
  * @brief EFM32PG12B_VDAC Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** VDAC Register Declaration */
 typedef struct {
-  __IOM uint32_t   CTRL;          /**< Control Register  */
-  __IM uint32_t    STATUS;        /**< Status Register  */
-  __IOM uint32_t   CH0CTRL;       /**< Channel 0 Control Register  */
-  __IOM uint32_t   CH1CTRL;       /**< Channel 1 Control Register  */
-  __IOM uint32_t   CMD;           /**< Command Register  */
-  __IM uint32_t    IF;            /**< Interrupt Flag Register  */
-  __IOM uint32_t   IFS;           /**< Interrupt Flag Set Register  */
-  __IOM uint32_t   IFC;           /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t   IEN;           /**< Interrupt Enable Register  */
-  __IOM uint32_t   CH0DATA;       /**< Channel 0 Data Register  */
-  __IOM uint32_t   CH1DATA;       /**< Channel 1 Data Register  */
-  __IOM uint32_t   COMBDATA;      /**< Combined Data Register  */
-  __IOM uint32_t   CAL;           /**< Calibration Register  */
+  __IOM uint32_t   CTRL;           /**< Control Register  */
+  __IM uint32_t    STATUS;         /**< Status Register  */
+  __IOM uint32_t   CH0CTRL;        /**< Channel 0 Control Register  */
+  __IOM uint32_t   CH1CTRL;        /**< Channel 1 Control Register  */
+  __IOM uint32_t   CMD;            /**< Command Register  */
+  __IM uint32_t    IF;             /**< Interrupt Flag Register  */
+  __IOM uint32_t   IFS;            /**< Interrupt Flag Set Register  */
+  __IOM uint32_t   IFC;            /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t   IEN;            /**< Interrupt Enable Register  */
+  __IOM uint32_t   CH0DATA;        /**< Channel 0 Data Register  */
+  __IOM uint32_t   CH1DATA;        /**< Channel 1 Data Register  */
+  __IOM uint32_t   COMBDATA;       /**< Combined Data Register  */
+  __IOM uint32_t   CAL;            /**< Calibration Register  */
 
-  uint32_t         RESERVED0[27]; /**< Reserved registers */
-  VDAC_OPA_TypeDef OPA[3];        /**< OPA Registers */
-} VDAC_TypeDef;                   /** @} */
+  uint32_t         RESERVED0[27U]; /**< Reserved registers */
+  VDAC_OPA_TypeDef OPA[3U];        /**< OPA Registers */
+} VDAC_TypeDef;                    /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG12B_VDAC
  * @{
  * @defgroup EFM32PG12B_VDAC_BitFields  VDAC Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for VDAC CTRL */
 #define _VDAC_CTRL_RESETVALUE                              0x00000000UL                                /**< Default value for VDAC_CTRL */

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_vdac_opa.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_vdac_opa.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg12b_vdac_opa.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG12B_VDAC_OPA register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,14 +40,14 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief VDAC_OPA VDAC OPA Register
  * @ingroup EFM32PG12B_VDAC
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IM uint32_t  APORTREQ;      /**< Operational Amplifier APORT Request Status Register  */
   __IM uint32_t  APORTCONFLICT; /**< Operational Amplifier APORT Conflict Status Register  */
@@ -57,7 +56,7 @@ typedef struct {
   __IOM uint32_t MUX;           /**< Operational Amplifier Mux Configuration Register  */
   __IOM uint32_t OUT;           /**< Operational Amplifier Output Configuration Register  */
   __IOM uint32_t CAL;           /**< Operational Amplifier Calibration Register  */
-  uint32_t       RESERVED0[1];  /**< Reserved future */
+  uint32_t       RESERVED0[1U]; /**< Reserved future */
 } VDAC_OPA_TypeDef;
 
 /** @} End of group Parts */

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_wdog.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_wdog.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg12b_wdog.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG12B_WDOG register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,37 +40,37 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG12B_WDOG WDOG
  * @{
  * @brief EFM32PG12B_WDOG Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** WDOG Register Declaration */
 typedef struct {
-  __IOM uint32_t   CTRL;         /**< Control Register  */
-  __IOM uint32_t   CMD;          /**< Command Register  */
+  __IOM uint32_t   CTRL;          /**< Control Register  */
+  __IOM uint32_t   CMD;           /**< Command Register  */
 
-  __IM uint32_t    SYNCBUSY;     /**< Synchronization Busy Register  */
+  __IM uint32_t    SYNCBUSY;      /**< Synchronization Busy Register  */
 
-  WDOG_PCH_TypeDef PCH[2];       /**< PCH */
+  WDOG_PCH_TypeDef PCH[2U];       /**< PCH */
 
-  uint32_t         RESERVED0[2]; /**< Reserved for future use **/
-  __IM uint32_t    IF;           /**< Watchdog Interrupt Flags  */
-  __IOM uint32_t   IFS;          /**< Interrupt Flag Set Register  */
-  __IOM uint32_t   IFC;          /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t   IEN;          /**< Interrupt Enable Register  */
-} WDOG_TypeDef;                  /** @} */
+  uint32_t         RESERVED0[2U]; /**< Reserved for future use **/
+  __IM uint32_t    IF;            /**< Watchdog Interrupt Flags  */
+  __IOM uint32_t   IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t   IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t   IEN;           /**< Interrupt Enable Register  */
+} WDOG_TypeDef;                   /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG12B_WDOG
  * @{
  * @defgroup EFM32PG12B_WDOG_BitFields  WDOG Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for WDOG CTRL */
 #define _WDOG_CTRL_RESETVALUE                     0x00000F00UL                          /**< Default value for WDOG_CTRL */

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_wdog_pch.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_wdog_pch.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg12b_wdog_pch.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG12B_WDOG_PCH register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,14 +40,14 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief WDOG_PCH WDOG PCH Register
  * @ingroup EFM32PG12B_WDOG
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t PRSCTRL; /**< PRS Control Register  */
 } WDOG_PCH_TypeDef;

--- a/cpu/efm32/families/efm32pg12b/include/vendor/em_device.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/em_device.h
@@ -1,5 +1,5 @@
-/**************************************************************************//**
- * @file em_device.h
+/***************************************************************************//**
+ * @file
  * @brief CMSIS Cortex-M Peripheral Access Layer for Silicon Laboratories
  *        microcontroller devices
  *
@@ -9,37 +9,35 @@
  * @verbatim
  * Example: Add "-DEFM32G890F128" to your build options, to define part
  *          Add "#include "em_device.h" to your source files
-
- *
  * @endverbatim
- * @version 5.4.0
- ******************************************************************************
+ *
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {

--- a/cpu/efm32/families/efm32pg12b/include/vendor/system_efm32pg12b.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/system_efm32pg12b.h
@@ -1,34 +1,33 @@
 /***************************************************************************//**
- * @file system_efm32pg12b.h
+ * @file
  * @brief CMSIS Cortex-M3/M4 System Layer for EFM32 devices.
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifndef SYSTEM_EFM32_H
 #define SYSTEM_EFM32_H
@@ -39,14 +38,14 @@ extern "C" {
 
 #include <stdint.h>
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup Parts
  * @{
- *****************************************************************************/
-/**************************************************************************//**
+ ******************************************************************************/
+/***************************************************************************//**
  * @addtogroup EFM32 EFM32
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /*******************************************************************************
  **************************   GLOBAL VARIABLES   *******************************
@@ -116,7 +115,7 @@ void FPUEH_IRQHandler(void);        /**< FPUEH IRQ Handler */
 
 uint32_t SystemCoreClockGet(void);
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @brief
  *   Update CMSIS SystemCoreClock variable.
  *
@@ -129,7 +128,7 @@ uint32_t SystemCoreClockGet(void);
  *   API, this variable will be kept updated. This function is only provided
  *   for CMSIS compliance and if a user modifies the the core clock outside
  *   the CMU API.
- *****************************************************************************/
+ ******************************************************************************/
 static __INLINE void SystemCoreClockUpdate(void)
 {
   (void)SystemCoreClockGet();

--- a/cpu/efm32/families/efm32pg12b/system.c
+++ b/cpu/efm32/families/efm32pg12b/system.c
@@ -1,34 +1,33 @@
 /***************************************************************************//**
- * @file system_efm32pg12b.c
+ * @file
  * @brief CMSIS Cortex-M3/M4 System Layer for EFM32 devices.
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #include <stdint.h>
 #include "em_device.h"
@@ -70,7 +69,7 @@
 #endif
 
 /* Do not define variable if HF crystal oscillator not present */
-#if (EFM32_HFXO_FREQ > 0UL)
+#if (EFM32_HFXO_FREQ > 0U)
 /** @cond DO_NOT_INCLUDE_WITH_DOXYGEN */
 /** System HFXO clock. */
 static uint32_t SystemHFXOClock = EFM32_HFXO_FREQ;
@@ -82,7 +81,7 @@ static uint32_t SystemHFXOClock = EFM32_HFXO_FREQ;
 #define EFM32_LFXO_FREQ (EFM32_LFRCO_FREQ)
 #endif
 /* Do not define variable if LF crystal oscillator not present */
-#if (EFM32_LFXO_FREQ > 0UL)
+#if (EFM32_LFXO_FREQ > 0U)
 /** @cond DO_NOT_INCLUDE_WITH_DOXYGEN */
 /** System LFXO clock. */
 static uint32_t SystemLFXOClock = EFM32_LFXO_FREQ;
@@ -117,6 +116,13 @@ uint32_t SystemHfrcoFreq = EFM32_HFRCO_STARTUP_FREQ;
 /*******************************************************************************
  **************************   GLOBAL FUNCTIONS   *******************************
  ******************************************************************************/
+
+#if defined(__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+#if defined(__ICCARM__)    /* IAR requires the __vector_table symbol */
+#define __Vectors    __vector_table
+#endif
+extern uint32_t __Vectors;
+#endif
 
 /***************************************************************************//**
  * @brief
@@ -186,12 +192,12 @@ uint32_t SystemHFClockGet(void)
 
   switch (CMU->HFCLKSTATUS & _CMU_HFCLKSTATUS_SELECTED_MASK) {
     case CMU_HFCLKSTATUS_SELECTED_LFXO:
-#if (EFM32_LFXO_FREQ > 0)
+#if (EFM32_LFXO_FREQ > 0U)
       ret = SystemLFXOClock;
 #else
       /* We should not get here, since core should not be clocked. May */
       /* be caused by a misconfiguration though. */
-      ret = 0;
+      ret = 0U;
 #endif
       break;
 
@@ -200,12 +206,12 @@ uint32_t SystemHFClockGet(void)
       break;
 
     case CMU_HFCLKSTATUS_SELECTED_HFXO:
-#if (EFM32_HFXO_FREQ > 0)
+#if (EFM32_HFXO_FREQ > 0U)
       ret = SystemHFXOClock;
 #else
       /* We should not get here, since core should not be clocked. May */
       /* be caused by a misconfiguration though. */
-      ret = 0;
+      ret = 0U;
 #endif
       break;
 
@@ -218,7 +224,7 @@ uint32_t SystemHFClockGet(void)
                       >> _CMU_HFPRESC_PRESC_SHIFT));
 }
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @brief
  *   Get high frequency crystal oscillator clock frequency for target system.
  *
@@ -227,18 +233,18 @@ uint32_t SystemHFClockGet(void)
  *
  * @return
  *   HFXO frequency in Hz.
- *****************************************************************************/
+ ******************************************************************************/
 uint32_t SystemHFXOClockGet(void)
 {
   /* External crystal oscillator present? */
-#if (EFM32_HFXO_FREQ > 0)
+#if (EFM32_HFXO_FREQ > 0U)
   return SystemHFXOClock;
 #else
-  return 0;
+  return 0U;
 #endif
 }
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @brief
  *   Set high frequency crystal oscillator clock frequency for target system.
  *
@@ -252,11 +258,11 @@ uint32_t SystemHFXOClockGet(void)
  *
  * @param[in] freq
  *   HFXO frequency in Hz used for target.
- *****************************************************************************/
+ ******************************************************************************/
 void SystemHFXOClockSet(uint32_t freq)
 {
   /* External crystal oscillator present? */
-#if (EFM32_HFXO_FREQ > 0)
+#if (EFM32_HFXO_FREQ > 0U)
   SystemHFXOClock = freq;
 
   /* Update core clock frequency if HFXO is used to clock core */
@@ -270,7 +276,7 @@ void SystemHFXOClockSet(uint32_t freq)
 #endif
 }
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @brief
  *   Initialize the system.
  *
@@ -281,17 +287,25 @@ void SystemHFXOClockSet(uint32_t freq)
  *   This function is invoked during system init, before the main() routine
  *   and any data has been initialized. For this reason, it cannot do any
  *   initialization of variables etc.
- *****************************************************************************/
+ ******************************************************************************/
 void SystemInit(void)
 {
-#if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
+#if defined(__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  SCB->VTOR = (uint32_t)&__Vectors;
+#endif
+
+#if (__FPU_PRESENT == 1U) && (__FPU_USED == 1U)
   /* Set floating point coprosessor access mode. */
-  SCB->CPACR |= ((3UL << 10 * 2)                      /* set CP10 Full Access */
-                 | (3UL << 11 * 2));                  /* set CP11 Full Access */
+  SCB->CPACR |= ((3UL << 10 * 2)                    /* set CP10 Full Access */
+                 | (3UL << 11 * 2));                /* set CP11 Full Access */
+#endif
+
+#if defined(UNALIGNED_SUPPORT_DISABLE)
+  SCB->CCR |= SCB_CCR_UNALIGN_TRP_Msk;
 #endif
 }
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @brief
  *   Get low frequency RC oscillator clock frequency for target system.
  *
@@ -300,7 +314,7 @@ void SystemInit(void)
  *
  * @return
  *   LFRCO frequency in Hz.
- *****************************************************************************/
+ ******************************************************************************/
 uint32_t SystemLFRCOClockGet(void)
 {
   /* Currently we assume that this frequency is properly tuned during */
@@ -309,7 +323,7 @@ uint32_t SystemLFRCOClockGet(void)
   return EFM32_LFRCO_FREQ;
 }
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @brief
  *   Get ultra low frequency RC oscillator clock frequency for target system.
  *
@@ -318,14 +332,14 @@ uint32_t SystemLFRCOClockGet(void)
  *
  * @return
  *   ULFRCO frequency in Hz.
- *****************************************************************************/
+ ******************************************************************************/
 uint32_t SystemULFRCOClockGet(void)
 {
   /* The ULFRCO frequency is not tuned, and can be very inaccurate */
   return EFM32_ULFRCO_FREQ;
 }
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @brief
  *   Get low frequency crystal oscillator clock frequency for target system.
  *
@@ -334,18 +348,18 @@ uint32_t SystemULFRCOClockGet(void)
  *
  * @return
  *   LFXO frequency in Hz.
- *****************************************************************************/
+ ******************************************************************************/
 uint32_t SystemLFXOClockGet(void)
 {
   /* External crystal oscillator present? */
-#if (EFM32_LFXO_FREQ > 0)
+#if (EFM32_LFXO_FREQ > 0U)
   return SystemLFXOClock;
 #else
-  return 0;
+  return 0U;
 #endif
 }
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @brief
  *   Set low frequency crystal oscillator clock frequency for target system.
  *
@@ -359,11 +373,11 @@ uint32_t SystemLFXOClockGet(void)
  *
  * @param[in] freq
  *   LFXO frequency in Hz used for target.
- *****************************************************************************/
+ ******************************************************************************/
 void SystemLFXOClockSet(uint32_t freq)
 {
   /* External crystal oscillator present? */
-#if (EFM32_LFXO_FREQ > 0)
+#if (EFM32_LFXO_FREQ > 0U)
   SystemLFXOClock = freq;
 
   /* Update core clock frequency if LFXO is used to clock core */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b200f256gm48.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b200f256gm48.h
@@ -1,35 +1,34 @@
-/**************************************************************************//**
- * @file efm32pg1b200f256gm48.h
+/***************************************************************************//**
+ * @file
  * @brief CMSIS Cortex-M Peripheral Access Layer Header File
  *        for EFM32PG1B200F256GM48
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #if defined(__ICCARM__)
 #pragma system_include       /* Treat file as system include file. */
@@ -44,15 +43,15 @@
 extern "C" {
 #endif
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup Parts
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32PG1B200F256GM48 EFM32PG1B200F256GM48
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /** Interrupt Number Definition */
 typedef enum IRQn{
@@ -95,23 +94,23 @@ typedef enum IRQn{
   FPUEH_IRQn            = 33, /*!< 16+33 EFM32 FPUEH Interrupt */
 } IRQn_Type;
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32PG1B200F256GM48_Core Core
  * @{
  * @brief Processor and Core Peripheral Section
- *****************************************************************************/
-#define __MPU_PRESENT             1 /**< Presence of MPU  */
-#define __FPU_PRESENT             1 /**< Presence of FPU  */
-#define __VTOR_PRESENT            1 /**< Presence of VTOR register in SCB */
-#define __NVIC_PRIO_BITS          3 /**< NVIC interrupt priority bits */
-#define __Vendor_SysTickConfig    0 /**< Is 1 if different SysTick counter is used */
+ ******************************************************************************/
+#define __MPU_PRESENT             1U /**< Presence of MPU  */
+#define __FPU_PRESENT             1U /**< Presence of FPU  */
+#define __VTOR_PRESENT            1U /**< Presence of VTOR register in SCB */
+#define __NVIC_PRIO_BITS          3U /**< NVIC interrupt priority bits */
+#define __Vendor_SysTickConfig    0U /**< Is 1 if different SysTick counter is used */
 
 /** @} End of group EFM32PG1B200F256GM48_Core */
 
-/**************************************************************************//**
-* @defgroup EFM32PG1B200F256GM48_Part Part
-* @{
-******************************************************************************/
+/***************************************************************************//**
+ * @defgroup EFM32PG1B200F256GM48_Part Part
+ * @{
+ ******************************************************************************/
 
 /** Part family */
 #define _EFM32_PEARL_FAMILY                     1  /**< PEARL Gecko MCU Family  */
@@ -183,7 +182,7 @@ typedef enum IRQn{
 #define FLASH_PAGE_SIZE           2048U          /**< Flash Memory page size */
 #define SRAM_BASE                 (0x20000000UL) /**< SRAM Base Address */
 #define SRAM_SIZE                 (0x00008000UL) /**< Available SRAM Memory */
-#define __CM4_REV                 0x001          /**< Cortex-M4 Core revision r0p1 */
+#define __CM4_REV                 0x0001U        /**< Cortex-M4 Core revision r0p1 */
 #define PRS_CHAN_COUNT            12             /**< Number of PRS channels */
 #define DMA_CHAN_COUNT            8              /**< Number of DMA channels */
 #define EXT_IRQ_COUNT             34             /**< Number of External (NVIC) interrupts */
@@ -251,11 +250,11 @@ typedef enum IRQn{
 
 /** @} End of group EFM32PG1B200F256GM48_Part */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32PG1B200F256GM48_Peripheral_TypeDefs Peripheral TypeDefs
  * @{
  * @brief Device Specific Peripheral Register Structures
- *****************************************************************************/
+ ******************************************************************************/
 
 #include "efm32pg1b_msc.h"
 #include "efm32pg1b_emu.h"
@@ -292,10 +291,10 @@ typedef enum IRQn{
 
 /** @} End of group EFM32PG1B200F256GM48_Peripheral_TypeDefs  */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32PG1B200F256GM48_Peripheral_Base Peripheral Memory Map
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 #define MSC_BASE          (0x400E0000UL) /**< MSC base address  */
 #define EMU_BASE          (0x400E3000UL) /**< EMU base address  */
@@ -329,10 +328,10 @@ typedef enum IRQn{
 
 /** @} End of group EFM32PG1B200F256GM48_Peripheral_Base */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32PG1B200F256GM48_Peripheral_Declaration Peripheral Declarations
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 #define MSC          ((MSC_TypeDef *) MSC_BASE)             /**< MSC base pointer */
 #define EMU          ((EMU_TypeDef *) EMU_BASE)             /**< EMU base pointer */
@@ -364,10 +363,10 @@ typedef enum IRQn{
 
 /** @} End of group EFM32PG1B200F256GM48_Peripheral_Declaration */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32PG1B200F256GM48_Peripheral_Offsets Peripheral Offsets
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 #define TIMER_OFFSET      0x400 /**< Offset in bytes between TIMER instances */
 #define USART_OFFSET      0x400 /**< Offset in bytes between USART instances */
@@ -382,18 +381,18 @@ typedef enum IRQn{
 
 /** @} End of group EFM32PG1B200F256GM48_Peripheral_Offsets */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32PG1B200F256GM48_BitFields Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 #include "efm32pg1b_prs_signals.h"
 #include "efm32pg1b_dmareq.h"
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFM32PG1B200F256GM48_UNLOCK Unlock Codes
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 #define MSC_UNLOCK_CODE      0x1B71 /**< MSC unlock code */
 #define EMU_UNLOCK_CODE      0xADE8 /**< EMU unlock code */
 #define RMU_UNLOCK_CODE      0xE084 /**< RMU unlock code */
@@ -409,7 +408,7 @@ typedef enum IRQn{
 #include "efm32pg1b_af_ports.h"
 #include "efm32pg1b_af_pins.h"
 
-/**************************************************************************//**
+/***************************************************************************//**
  *  @brief Set the value of a bit field within a register.
  *
  *  @param REG
@@ -421,7 +420,7 @@ typedef enum IRQn{
  *  @param OFFSET
  *       The number of bits that the field is offset within the register.
  *       0 (zero) means LSB.
- *****************************************************************************/
+ ******************************************************************************/
 #define SET_BIT_FIELD(REG, MASK, VALUE, OFFSET) \
   REG = ((REG) &~(MASK)) | (((VALUE) << (OFFSET)) & (MASK));
 

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_acmp.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_acmp.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg1b_acmp.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG1B_ACMP register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG1B_ACMP ACMP
  * @{
  * @brief EFM32PG1B_ACMP Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** ACMP Register Declaration */
 typedef struct {
   __IOM uint32_t CTRL;          /**< Control Register  */
@@ -59,23 +58,23 @@ typedef struct {
   __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
   __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
   __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
-  uint32_t       RESERVED0[1];  /**< Reserved for future use **/
+  uint32_t       RESERVED0[1U]; /**< Reserved for future use **/
   __IM uint32_t  APORTREQ;      /**< APORT Request Status Register  */
   __IM uint32_t  APORTCONFLICT; /**< APORT Conflict Status Register  */
   __IOM uint32_t HYSTERESIS0;   /**< Hysteresis 0 Register  */
   __IOM uint32_t HYSTERESIS1;   /**< Hysteresis 1 Register  */
 
-  uint32_t       RESERVED1[4];  /**< Reserved for future use **/
+  uint32_t       RESERVED1[4U]; /**< Reserved for future use **/
   __IOM uint32_t ROUTEPEN;      /**< I/O Routing Pine Enable Register  */
   __IOM uint32_t ROUTELOC0;     /**< I/O Routing Location Register  */
 } ACMP_TypeDef;                 /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG1B_ACMP
  * @{
  * @defgroup EFM32PG1B_ACMP_BitFields  ACMP Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for ACMP CTRL */
 #define _ACMP_CTRL_RESETVALUE                          0x07000000UL                               /**< Default value for ACMP_CTRL */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_adc.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_adc.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg1b_adc.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG1B_ADC register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,19 +40,19 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG1B_ADC ADC
  * @{
  * @brief EFM32PG1B_ADC Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** ADC Register Declaration */
 typedef struct {
   __IOM uint32_t CTRL;            /**< Control Register  */
-  uint32_t       RESERVED0[1];    /**< Reserved for future use **/
+  uint32_t       RESERVED0[1U];   /**< Reserved for future use **/
   __IOM uint32_t CMD;             /**< Command Register  */
   __IM uint32_t  STATUS;          /**< Status Register  */
   __IOM uint32_t SINGLECTRL;      /**< Single Channel Control Register  */
@@ -74,11 +73,11 @@ typedef struct {
   __IM uint32_t  SCANDATA;        /**< Scan Conversion Result Data  */
   __IM uint32_t  SINGLEDATAP;     /**< Single Conversion Result Data Peek Register  */
   __IM uint32_t  SCANDATAP;       /**< Scan Sequence Result Data Peek Register  */
-  uint32_t       RESERVED1[4];    /**< Reserved for future use **/
+  uint32_t       RESERVED1[4U];   /**< Reserved for future use **/
   __IM uint32_t  SCANDATAX;       /**< Scan Sequence Result Data + Data Source Register  */
   __IM uint32_t  SCANDATAXP;      /**< Scan Sequence Result Data + Data Source Peek Register  */
 
-  uint32_t       RESERVED2[3];    /**< Reserved for future use **/
+  uint32_t       RESERVED2[3U];   /**< Reserved for future use **/
   __IM uint32_t  APORTREQ;        /**< APORT Request Status Register  */
   __IM uint32_t  APORTCONFLICT;   /**< APORT Conflict Status Register  */
   __IM uint32_t  SINGLEFIFOCOUNT; /**< Single FIFO Count Register  */
@@ -88,12 +87,12 @@ typedef struct {
   __IOM uint32_t APORTMASTERDIS;  /**< APORT Bus Master Disable Register  */
 } ADC_TypeDef;                    /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG1B_ADC
  * @{
  * @defgroup EFM32PG1B_ADC_BitFields  ADC Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for ADC CTRL */
 #define _ADC_CTRL_RESETVALUE                               0x001F0000UL                              /**< Default value for ADC_CTRL */
@@ -479,12 +478,12 @@ typedef struct {
 #define _ADC_SINGLECTRL_POSSEL_APORT4YCH30                 0x0000009EUL                               /**< Mode APORT4YCH30 for ADC_SINGLECTRL */
 #define _ADC_SINGLECTRL_POSSEL_APORT4XCH31                 0x0000009FUL                               /**< Mode APORT4XCH31 for ADC_SINGLECTRL */
 #define _ADC_SINGLECTRL_POSSEL_AVDD                        0x000000E0UL                               /**< Mode AVDD for ADC_SINGLECTRL */
-#define _ADC_SINGLECTRL_POSSEL_BU                          0x000000E1UL                               /**< Mode BU for ADC_SINGLECTRL */
-#define _ADC_SINGLECTRL_POSSEL_AREG                        0x000000E2UL                               /**< Mode AREG for ADC_SINGLECTRL */
-#define _ADC_SINGLECTRL_POSSEL_VREGOUTPA                   0x000000E3UL                               /**< Mode VREGOUTPA for ADC_SINGLECTRL */
-#define _ADC_SINGLECTRL_POSSEL_PDBU                        0x000000E4UL                               /**< Mode PDBU for ADC_SINGLECTRL */
-#define _ADC_SINGLECTRL_POSSEL_IO0                         0x000000E5UL                               /**< Mode IO0 for ADC_SINGLECTRL */
-#define _ADC_SINGLECTRL_POSSEL_IO1                         0x000000E6UL                               /**< Mode IO1 for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_POSSEL_BUVDD                       0x000000E1UL                               /**< Mode BUVDD for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_POSSEL_DVDD                        0x000000E2UL                               /**< Mode DVDD for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_POSSEL_PAVDD                       0x000000E3UL                               /**< Mode PAVDD for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_POSSEL_DECOUPLE                    0x000000E4UL                               /**< Mode DECOUPLE for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_POSSEL_IOVDD                       0x000000E5UL                               /**< Mode IOVDD for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_POSSEL_IOVDD1                      0x000000E6UL                               /**< Mode IOVDD1 for ADC_SINGLECTRL */
 #define _ADC_SINGLECTRL_POSSEL_VSP                         0x000000E7UL                               /**< Mode VSP for ADC_SINGLECTRL */
 #define _ADC_SINGLECTRL_POSSEL_OPA2                        0x000000F2UL                               /**< Mode OPA2 for ADC_SINGLECTRL */
 #define _ADC_SINGLECTRL_POSSEL_TEMP                        0x000000F3UL                               /**< Mode TEMP for ADC_SINGLECTRL */
@@ -658,12 +657,12 @@ typedef struct {
 #define ADC_SINGLECTRL_POSSEL_APORT4YCH30                  (_ADC_SINGLECTRL_POSSEL_APORT4YCH30 << 8)  /**< Shifted mode APORT4YCH30 for ADC_SINGLECTRL */
 #define ADC_SINGLECTRL_POSSEL_APORT4XCH31                  (_ADC_SINGLECTRL_POSSEL_APORT4XCH31 << 8)  /**< Shifted mode APORT4XCH31 for ADC_SINGLECTRL */
 #define ADC_SINGLECTRL_POSSEL_AVDD                         (_ADC_SINGLECTRL_POSSEL_AVDD << 8)         /**< Shifted mode AVDD for ADC_SINGLECTRL */
-#define ADC_SINGLECTRL_POSSEL_BU                           (_ADC_SINGLECTRL_POSSEL_BU << 8)           /**< Shifted mode BU for ADC_SINGLECTRL */
-#define ADC_SINGLECTRL_POSSEL_AREG                         (_ADC_SINGLECTRL_POSSEL_AREG << 8)         /**< Shifted mode AREG for ADC_SINGLECTRL */
-#define ADC_SINGLECTRL_POSSEL_VREGOUTPA                    (_ADC_SINGLECTRL_POSSEL_VREGOUTPA << 8)    /**< Shifted mode VREGOUTPA for ADC_SINGLECTRL */
-#define ADC_SINGLECTRL_POSSEL_PDBU                         (_ADC_SINGLECTRL_POSSEL_PDBU << 8)         /**< Shifted mode PDBU for ADC_SINGLECTRL */
-#define ADC_SINGLECTRL_POSSEL_IO0                          (_ADC_SINGLECTRL_POSSEL_IO0 << 8)          /**< Shifted mode IO0 for ADC_SINGLECTRL */
-#define ADC_SINGLECTRL_POSSEL_IO1                          (_ADC_SINGLECTRL_POSSEL_IO1 << 8)          /**< Shifted mode IO1 for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_POSSEL_BUVDD                        (_ADC_SINGLECTRL_POSSEL_BUVDD << 8)        /**< Shifted mode BUVDD for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_POSSEL_DVDD                         (_ADC_SINGLECTRL_POSSEL_DVDD << 8)         /**< Shifted mode DVDD for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_POSSEL_PAVDD                        (_ADC_SINGLECTRL_POSSEL_PAVDD << 8)        /**< Shifted mode PAVDD for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_POSSEL_DECOUPLE                     (_ADC_SINGLECTRL_POSSEL_DECOUPLE << 8)     /**< Shifted mode DECOUPLE for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_POSSEL_IOVDD                        (_ADC_SINGLECTRL_POSSEL_IOVDD << 8)        /**< Shifted mode IOVDD for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_POSSEL_IOVDD1                       (_ADC_SINGLECTRL_POSSEL_IOVDD1 << 8)       /**< Shifted mode IOVDD1 for ADC_SINGLECTRL */
 #define ADC_SINGLECTRL_POSSEL_VSP                          (_ADC_SINGLECTRL_POSSEL_VSP << 8)          /**< Shifted mode VSP for ADC_SINGLECTRL */
 #define ADC_SINGLECTRL_POSSEL_OPA2                         (_ADC_SINGLECTRL_POSSEL_OPA2 << 8)         /**< Shifted mode OPA2 for ADC_SINGLECTRL */
 #define ADC_SINGLECTRL_POSSEL_TEMP                         (_ADC_SINGLECTRL_POSSEL_TEMP << 8)         /**< Shifted mode TEMP for ADC_SINGLECTRL */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_af_pins.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_af_pins.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg1b_af_pins.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG1B_AF_PINS register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,16 +40,16 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @addtogroup EFM32PG1B_Alternate_Function Alternate Function
  * @{
  * @defgroup EFM32PG1B_AF_Pins Alternate Function Pins
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 #define AF_CMU_CLK0_PIN(i)         ((i) == 0 ? 1 : (i) == 1 ? 15 : (i) == 2 ? 6 : (i) == 3 ? 11 : (i) == 4 ? 9 : (i) == 5 ? 14 : (i) == 6 ? 2 : (i) == 7 ? 7 :  -1)                                                                                                                                                                                                                                                                                                                                                                                                         /**< Pin number for AF_CMU_CLK0 location number i */
 #define AF_CMU_CLK1_PIN(i)         ((i) == 0 ? 0 : (i) == 1 ? 14 : (i) == 2 ? 7 : (i) == 3 ? 10 : (i) == 4 ? 10 : (i) == 5 ? 15 : (i) == 6 ? 3 : (i) == 7 ? 6 :  -1)                                                                                                                                                                                                                                                                                                                                                                                                        /**< Pin number for AF_CMU_CLK1 location number i */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_af_ports.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_af_ports.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg1b_af_ports.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG1B_AF_PORTS register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,16 +40,16 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @addtogroup EFM32PG1B_Alternate_Function Alternate Function
  * @{
  * @defgroup EFM32PG1B_AF_Ports Alternate Function Ports
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 #define AF_CMU_CLK0_PORT(i)         ((i) == 0 ? 0 : (i) == 1 ? 1 : (i) == 2 ? 2 : (i) == 3 ? 2 : (i) == 4 ? 3 : (i) == 5 ? 3 : (i) == 6 ? 5 : (i) == 7 ? 5 :  -1)                                                                                                                                                                                                                                                                                                                                                                                               /**< Port number for AF_CMU_CLK0 location number i */
 #define AF_CMU_CLK1_PORT(i)         ((i) == 0 ? 0 : (i) == 1 ? 1 : (i) == 2 ? 2 : (i) == 3 ? 2 : (i) == 4 ? 3 : (i) == 5 ? 3 : (i) == 6 ? 5 : (i) == 7 ? 5 :  -1)                                                                                                                                                                                                                                                                                                                                                                                               /**< Port number for AF_CMU_CLK1 location number i */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_cmu.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_cmu.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg1b_cmu.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG1B_CMU register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,26 +40,26 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG1B_CMU CMU
  * @{
  * @brief EFM32PG1B_CMU Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** CMU Register Declaration */
 typedef struct {
   __IOM uint32_t CTRL;                /**< CMU Control Register  */
 
-  uint32_t       RESERVED0[3];        /**< Reserved for future use **/
+  uint32_t       RESERVED0[3U];       /**< Reserved for future use **/
   __IOM uint32_t HFRCOCTRL;           /**< HFRCO Control Register  */
 
-  uint32_t       RESERVED1[1];        /**< Reserved for future use **/
+  uint32_t       RESERVED1[1U];       /**< Reserved for future use **/
   __IOM uint32_t AUXHFRCOCTRL;        /**< AUXHFRCO Control Register  */
 
-  uint32_t       RESERVED2[1];        /**< Reserved for future use **/
+  uint32_t       RESERVED2[1U];       /**< Reserved for future use **/
   __IOM uint32_t LFRCOCTRL;           /**< LFRCO Control Register  */
   __IOM uint32_t HFXOCTRL;            /**< HFXO Control Register  */
   __IOM uint32_t HFXOCTRL1;           /**< HFXO Control 1  */
@@ -70,24 +69,24 @@ typedef struct {
   __IOM uint32_t LFXOCTRL;            /**< LFXO Control Register  */
   __IOM uint32_t ULFRCOCTRL;          /**< ULFRCO Control Register  */
 
-  uint32_t       RESERVED3[4];        /**< Reserved for future use **/
+  uint32_t       RESERVED3[4U];       /**< Reserved for future use **/
   __IOM uint32_t CALCTRL;             /**< Calibration Control Register  */
   __IOM uint32_t CALCNT;              /**< Calibration Counter Register  */
-  uint32_t       RESERVED4[2];        /**< Reserved for future use **/
+  uint32_t       RESERVED4[2U];       /**< Reserved for future use **/
   __IOM uint32_t OSCENCMD;            /**< Oscillator Enable/Disable Command Register  */
   __IOM uint32_t CMD;                 /**< Command Register  */
-  uint32_t       RESERVED5[2];        /**< Reserved for future use **/
+  uint32_t       RESERVED5[2U];       /**< Reserved for future use **/
   __IOM uint32_t DBGCLKSEL;           /**< Debug Trace Clock Select  */
   __IOM uint32_t HFCLKSEL;            /**< High Frequency Clock Select Command Register  */
-  uint32_t       RESERVED6[2];        /**< Reserved for future use **/
+  uint32_t       RESERVED6[2U];       /**< Reserved for future use **/
   __IOM uint32_t LFACLKSEL;           /**< Low Frequency A Clock Select Register  */
   __IOM uint32_t LFBCLKSEL;           /**< Low Frequency B Clock Select Register  */
   __IOM uint32_t LFECLKSEL;           /**< Low Frequency E Clock Select Register  */
 
-  uint32_t       RESERVED7[1];        /**< Reserved for future use **/
+  uint32_t       RESERVED7[1U];       /**< Reserved for future use **/
   __IM uint32_t  STATUS;              /**< Status Register  */
   __IM uint32_t  HFCLKSTATUS;         /**< HFCLK Status Register  */
-  uint32_t       RESERVED8[1];        /**< Reserved for future use **/
+  uint32_t       RESERVED8[1U];       /**< Reserved for future use **/
   __IM uint32_t  HFXOTRIMSTATUS;      /**< HFXO Trim Status  */
   __IM uint32_t  IF;                  /**< Interrupt Flag Register  */
   __IOM uint32_t IFS;                 /**< Interrupt Flag Set Register  */
@@ -95,56 +94,56 @@ typedef struct {
   __IOM uint32_t IEN;                 /**< Interrupt Enable Register  */
   __IOM uint32_t HFBUSCLKEN0;         /**< High Frequency Bus Clock Enable Register 0  */
 
-  uint32_t       RESERVED9[3];        /**< Reserved for future use **/
+  uint32_t       RESERVED9[3U];       /**< Reserved for future use **/
   __IOM uint32_t HFPERCLKEN0;         /**< High Frequency Peripheral Clock Enable Register 0  */
 
-  uint32_t       RESERVED10[7];       /**< Reserved for future use **/
+  uint32_t       RESERVED10[7U];      /**< Reserved for future use **/
   __IOM uint32_t LFACLKEN0;           /**< Low Frequency a Clock Enable Register 0  (Async Reg)  */
-  uint32_t       RESERVED11[1];       /**< Reserved for future use **/
+  uint32_t       RESERVED11[1U];      /**< Reserved for future use **/
   __IOM uint32_t LFBCLKEN0;           /**< Low Frequency B Clock Enable Register 0 (Async Reg)  */
 
-  uint32_t       RESERVED12[1];       /**< Reserved for future use **/
+  uint32_t       RESERVED12[1U];      /**< Reserved for future use **/
   __IOM uint32_t LFECLKEN0;           /**< Low Frequency E Clock Enable Register 0 (Async Reg)  */
-  uint32_t       RESERVED13[3];       /**< Reserved for future use **/
+  uint32_t       RESERVED13[3U];      /**< Reserved for future use **/
   __IOM uint32_t HFPRESC;             /**< High Frequency Clock Prescaler Register  */
 
-  uint32_t       RESERVED14[1];       /**< Reserved for future use **/
+  uint32_t       RESERVED14[1U];      /**< Reserved for future use **/
   __IOM uint32_t HFCOREPRESC;         /**< High Frequency Core Clock Prescaler Register  */
   __IOM uint32_t HFPERPRESC;          /**< High Frequency Peripheral Clock Prescaler Register  */
 
-  uint32_t       RESERVED15[1];       /**< Reserved for future use **/
+  uint32_t       RESERVED15[1U];      /**< Reserved for future use **/
   __IOM uint32_t HFEXPPRESC;          /**< High Frequency Export Clock Prescaler Register  */
 
-  uint32_t       RESERVED16[2];       /**< Reserved for future use **/
+  uint32_t       RESERVED16[2U];      /**< Reserved for future use **/
   __IOM uint32_t LFAPRESC0;           /**< Low Frequency a Prescaler Register 0 (Async Reg)  */
-  uint32_t       RESERVED17[1];       /**< Reserved for future use **/
+  uint32_t       RESERVED17[1U];      /**< Reserved for future use **/
   __IOM uint32_t LFBPRESC0;           /**< Low Frequency B Prescaler Register 0  (Async Reg)  */
-  uint32_t       RESERVED18[1];       /**< Reserved for future use **/
+  uint32_t       RESERVED18[1U];      /**< Reserved for future use **/
   __IOM uint32_t LFEPRESC0;           /**< Low Frequency E Prescaler Register 0  (Async Reg)  */
 
-  uint32_t       RESERVED19[3];       /**< Reserved for future use **/
+  uint32_t       RESERVED19[3U];      /**< Reserved for future use **/
   __IM uint32_t  SYNCBUSY;            /**< Synchronization Busy Register  */
   __IOM uint32_t FREEZE;              /**< Freeze Register  */
-  uint32_t       RESERVED20[2];       /**< Reserved for future use **/
+  uint32_t       RESERVED20[2U];      /**< Reserved for future use **/
   __IOM uint32_t PCNTCTRL;            /**< PCNT Control Register  */
 
-  uint32_t       RESERVED21[2];       /**< Reserved for future use **/
+  uint32_t       RESERVED21[2U];      /**< Reserved for future use **/
   __IOM uint32_t ADCCTRL;             /**< ADC Control Register  */
 
-  uint32_t       RESERVED22[4];       /**< Reserved for future use **/
+  uint32_t       RESERVED22[4U];      /**< Reserved for future use **/
   __IOM uint32_t ROUTEPEN;            /**< I/O Routing Pin Enable Register  */
   __IOM uint32_t ROUTELOC0;           /**< I/O Routing Location Register  */
 
-  uint32_t       RESERVED23[2];       /**< Reserved for future use **/
+  uint32_t       RESERVED23[2U];      /**< Reserved for future use **/
   __IOM uint32_t LOCK;                /**< Configuration Lock Register  */
 } CMU_TypeDef;                        /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG1B_CMU
  * @{
  * @defgroup EFM32PG1B_CMU_BitFields  CMU Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for CMU CTRL */
 #define _CMU_CTRL_RESETVALUE                              0x00300000UL                          /**< Default value for CMU_CTRL */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_cryotimer.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_cryotimer.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg1b_cryotimer.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG1B_CRYOTIMER register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG1B_CRYOTIMER CRYOTIMER
  * @{
  * @brief EFM32PG1B_CRYOTIMER Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** CRYOTIMER Register Declaration */
 typedef struct {
   __IOM uint32_t CTRL;      /**< Control Register  */
@@ -62,12 +61,12 @@ typedef struct {
   __IOM uint32_t IEN;       /**< Interrupt Enable Register  */
 } CRYOTIMER_TypeDef;        /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG1B_CRYOTIMER
  * @{
  * @defgroup EFM32PG1B_CRYOTIMER_BitFields  CRYOTIMER Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for CRYOTIMER CTRL */
 #define _CRYOTIMER_CTRL_RESETVALUE                0x00000000UL                            /**< Default value for CRYOTIMER_CTRL */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_crypto.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_crypto.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg1b_crypto.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG1B_CRYPTO register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,84 +40,84 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG1B_CRYPTO CRYPTO
  * @{
  * @brief EFM32PG1B_CRYPTO Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** CRYPTO Register Declaration */
 typedef struct {
-  __IOM uint32_t CTRL;           /**< Control Register  */
-  __IOM uint32_t WAC;            /**< Wide Arithmetic Configuration  */
-  __IOM uint32_t CMD;            /**< Command Register  */
-  uint32_t       RESERVED0[1];   /**< Reserved for future use **/
-  __IM uint32_t  STATUS;         /**< Status Register  */
-  __IM uint32_t  DSTATUS;        /**< Data Status Register  */
-  __IM uint32_t  CSTATUS;        /**< Control Status Register  */
-  uint32_t       RESERVED1[1];   /**< Reserved for future use **/
-  __IOM uint32_t KEY;            /**< KEY Register Access  */
-  __IOM uint32_t KEYBUF;         /**< KEY Buffer Register Access  */
-  uint32_t       RESERVED2[2];   /**< Reserved for future use **/
-  __IOM uint32_t SEQCTRL;        /**< Sequence Control  */
-  __IOM uint32_t SEQCTRLB;       /**< Sequence Control B  */
-  uint32_t       RESERVED3[2];   /**< Reserved for future use **/
-  __IM uint32_t  IF;             /**< AES Interrupt Flags  */
-  __IOM uint32_t IFS;            /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;            /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t IEN;            /**< Interrupt Enable Register  */
-  __IOM uint32_t SEQ0;           /**< Sequence Register 0  */
-  __IOM uint32_t SEQ1;           /**< Sequence Register 1  */
-  __IOM uint32_t SEQ2;           /**< Sequence Register 2  */
-  __IOM uint32_t SEQ3;           /**< Sequence Register 3  */
-  __IOM uint32_t SEQ4;           /**< Sequence Register 4  */
-  uint32_t       RESERVED4[7];   /**< Reserved for future use **/
-  __IOM uint32_t DATA0;          /**< DATA0 Register Access  */
-  __IOM uint32_t DATA1;          /**< DATA1 Register Access  */
-  __IOM uint32_t DATA2;          /**< DATA2 Register Access  */
-  __IOM uint32_t DATA3;          /**< DATA3 Register Access  */
-  uint32_t       RESERVED5[4];   /**< Reserved for future use **/
-  __IOM uint32_t DATA0XOR;       /**< DATA0XOR Register Access  */
-  uint32_t       RESERVED6[3];   /**< Reserved for future use **/
-  __IOM uint32_t DATA0BYTE;      /**< DATA0 Register Byte Access  */
-  __IOM uint32_t DATA1BYTE;      /**< DATA1 Register Byte Access  */
-  uint32_t       RESERVED7[1];   /**< Reserved for future use **/
-  __IOM uint32_t DATA0XORBYTE;   /**< DATA0 Register Byte XOR Access  */
-  __IOM uint32_t DATA0BYTE12;    /**< DATA0 Register Byte 12 Access  */
-  __IOM uint32_t DATA0BYTE13;    /**< DATA0 Register Byte 13 Access  */
-  __IOM uint32_t DATA0BYTE14;    /**< DATA0 Register Byte 14 Access  */
-  __IOM uint32_t DATA0BYTE15;    /**< DATA0 Register Byte 15 Access  */
-  uint32_t       RESERVED8[12];  /**< Reserved for future use **/
-  __IOM uint32_t DDATA0;         /**< DDATA0 Register Access  */
-  __IOM uint32_t DDATA1;         /**< DDATA1 Register Access  */
-  __IOM uint32_t DDATA2;         /**< DDATA2 Register Access  */
-  __IOM uint32_t DDATA3;         /**< DDATA3 Register Access  */
-  __IOM uint32_t DDATA4;         /**< DDATA4 Register Access  */
-  uint32_t       RESERVED9[7];   /**< Reserved for future use **/
-  __IOM uint32_t DDATA0BIG;      /**< DDATA0 Register Big Endian Access  */
-  uint32_t       RESERVED10[3];  /**< Reserved for future use **/
-  __IOM uint32_t DDATA0BYTE;     /**< DDATA0 Register Byte Access  */
-  __IOM uint32_t DDATA1BYTE;     /**< DDATA1 Register Byte Access  */
-  __IOM uint32_t DDATA0BYTE32;   /**< DDATA0 Register Byte 32 Access  */
-  uint32_t       RESERVED11[13]; /**< Reserved for future use **/
-  __IOM uint32_t QDATA0;         /**< QDATA0 Register Access  */
-  __IOM uint32_t QDATA1;         /**< QDATA1 Register Access  */
-  uint32_t       RESERVED12[7];  /**< Reserved for future use **/
-  __IOM uint32_t QDATA1BIG;      /**< QDATA1 Register Big Endian Access  */
-  uint32_t       RESERVED13[6];  /**< Reserved for future use **/
-  __IOM uint32_t QDATA0BYTE;     /**< QDATA0 Register Byte Access  */
-  __IOM uint32_t QDATA1BYTE;     /**< QDATA1 Register Byte Access  */
-} CRYPTO_TypeDef;                /** @} */
+  __IOM uint32_t CTRL;            /**< Control Register  */
+  __IOM uint32_t WAC;             /**< Wide Arithmetic Configuration  */
+  __IOM uint32_t CMD;             /**< Command Register  */
+  uint32_t       RESERVED0[1U];   /**< Reserved for future use **/
+  __IM uint32_t  STATUS;          /**< Status Register  */
+  __IM uint32_t  DSTATUS;         /**< Data Status Register  */
+  __IM uint32_t  CSTATUS;         /**< Control Status Register  */
+  uint32_t       RESERVED1[1U];   /**< Reserved for future use **/
+  __IOM uint32_t KEY;             /**< KEY Register Access  */
+  __IOM uint32_t KEYBUF;          /**< KEY Buffer Register Access  */
+  uint32_t       RESERVED2[2U];   /**< Reserved for future use **/
+  __IOM uint32_t SEQCTRL;         /**< Sequence Control  */
+  __IOM uint32_t SEQCTRLB;        /**< Sequence Control B  */
+  uint32_t       RESERVED3[2U];   /**< Reserved for future use **/
+  __IM uint32_t  IF;              /**< AES Interrupt Flags  */
+  __IOM uint32_t IFS;             /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;             /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;             /**< Interrupt Enable Register  */
+  __IOM uint32_t SEQ0;            /**< Sequence Register 0  */
+  __IOM uint32_t SEQ1;            /**< Sequence Register 1  */
+  __IOM uint32_t SEQ2;            /**< Sequence Register 2  */
+  __IOM uint32_t SEQ3;            /**< Sequence Register 3  */
+  __IOM uint32_t SEQ4;            /**< Sequence Register 4  */
+  uint32_t       RESERVED4[7U];   /**< Reserved for future use **/
+  __IOM uint32_t DATA0;           /**< DATA0 Register Access  */
+  __IOM uint32_t DATA1;           /**< DATA1 Register Access  */
+  __IOM uint32_t DATA2;           /**< DATA2 Register Access  */
+  __IOM uint32_t DATA3;           /**< DATA3 Register Access  */
+  uint32_t       RESERVED5[4U];   /**< Reserved for future use **/
+  __IOM uint32_t DATA0XOR;        /**< DATA0XOR Register Access  */
+  uint32_t       RESERVED6[3U];   /**< Reserved for future use **/
+  __IOM uint32_t DATA0BYTE;       /**< DATA0 Register Byte Access  */
+  __IOM uint32_t DATA1BYTE;       /**< DATA1 Register Byte Access  */
+  uint32_t       RESERVED7[1U];   /**< Reserved for future use **/
+  __IOM uint32_t DATA0XORBYTE;    /**< DATA0 Register Byte XOR Access  */
+  __IOM uint32_t DATA0BYTE12;     /**< DATA0 Register Byte 12 Access  */
+  __IOM uint32_t DATA0BYTE13;     /**< DATA0 Register Byte 13 Access  */
+  __IOM uint32_t DATA0BYTE14;     /**< DATA0 Register Byte 14 Access  */
+  __IOM uint32_t DATA0BYTE15;     /**< DATA0 Register Byte 15 Access  */
+  uint32_t       RESERVED8[12U];  /**< Reserved for future use **/
+  __IOM uint32_t DDATA0;          /**< DDATA0 Register Access  */
+  __IOM uint32_t DDATA1;          /**< DDATA1 Register Access  */
+  __IOM uint32_t DDATA2;          /**< DDATA2 Register Access  */
+  __IOM uint32_t DDATA3;          /**< DDATA3 Register Access  */
+  __IOM uint32_t DDATA4;          /**< DDATA4 Register Access  */
+  uint32_t       RESERVED9[7U];   /**< Reserved for future use **/
+  __IOM uint32_t DDATA0BIG;       /**< DDATA0 Register Big Endian Access  */
+  uint32_t       RESERVED10[3U];  /**< Reserved for future use **/
+  __IOM uint32_t DDATA0BYTE;      /**< DDATA0 Register Byte Access  */
+  __IOM uint32_t DDATA1BYTE;      /**< DDATA1 Register Byte Access  */
+  __IOM uint32_t DDATA0BYTE32;    /**< DDATA0 Register Byte 32 Access  */
+  uint32_t       RESERVED11[13U]; /**< Reserved for future use **/
+  __IOM uint32_t QDATA0;          /**< QDATA0 Register Access  */
+  __IOM uint32_t QDATA1;          /**< QDATA1 Register Access  */
+  uint32_t       RESERVED12[7U];  /**< Reserved for future use **/
+  __IOM uint32_t QDATA1BIG;       /**< QDATA1 Register Big Endian Access  */
+  uint32_t       RESERVED13[6U];  /**< Reserved for future use **/
+  __IOM uint32_t QDATA0BYTE;      /**< QDATA0 Register Byte Access  */
+  __IOM uint32_t QDATA1BYTE;      /**< QDATA1 Register Byte Access  */
+} CRYPTO_TypeDef;                 /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG1B_CRYPTO
  * @{
  * @defgroup EFM32PG1B_CRYPTO_BitFields  CRYPTO Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for CRYPTO CTRL */
 #define _CRYPTO_CTRL_RESETVALUE                      0x00000000UL                               /**< Default value for CRYPTO_CTRL */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_devinfo.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_devinfo.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg1b_devinfo.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG1B_DEVINFO register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,67 +40,67 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG1B_DEVINFO Device Information and Calibration
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /** DEVINFO Register Declaration */
 typedef struct {
   __IM uint32_t CAL;              /**< CRC of DI-page and calibration temperature  */
-  uint32_t      RESERVED0[9];     /**< Reserved for future use **/
+  uint32_t      RESERVED0[9U];    /**< Reserved for future use **/
   __IM uint32_t EUI48L;           /**< EUI48 OUI and Unique identifier  */
   __IM uint32_t EUI48H;           /**< OUI  */
   __IM uint32_t CUSTOMINFO;       /**< Custom information  */
   __IM uint32_t MEMINFO;          /**< Flash page size and misc. chip information  */
-  uint32_t      RESERVED1[2];     /**< Reserved for future use **/
+  uint32_t      RESERVED1[2U];    /**< Reserved for future use **/
   __IM uint32_t UNIQUEL;          /**< Low 32 bits of device unique number  */
   __IM uint32_t UNIQUEH;          /**< High 32 bits of device unique number  */
   __IM uint32_t MSIZE;            /**< Flash and SRAM Memory size in kB  */
   __IM uint32_t PART;             /**< Part description  */
   __IM uint32_t DEVINFOREV;       /**< Device information page revision  */
   __IM uint32_t EMUTEMP;          /**< EMU Temperature Calibration Information  */
-  uint32_t      RESERVED2[2];     /**< Reserved for future use **/
+  uint32_t      RESERVED2[2U];    /**< Reserved for future use **/
   __IM uint32_t ADC0CAL0;         /**< ADC0 calibration register 0  */
   __IM uint32_t ADC0CAL1;         /**< ADC0 calibration register 1  */
   __IM uint32_t ADC0CAL2;         /**< ADC0 calibration register 2  */
   __IM uint32_t ADC0CAL3;         /**< ADC0 calibration register 3  */
-  uint32_t      RESERVED3[4];     /**< Reserved for future use **/
+  uint32_t      RESERVED3[4U];    /**< Reserved for future use **/
   __IM uint32_t HFRCOCAL0;        /**< HFRCO Calibration Register (4 MHz)  */
-  uint32_t      RESERVED4[2];     /**< Reserved for future use **/
+  uint32_t      RESERVED4[2U];    /**< Reserved for future use **/
   __IM uint32_t HFRCOCAL3;        /**< HFRCO Calibration Register (7 MHz)  */
-  uint32_t      RESERVED5[2];     /**< Reserved for future use **/
+  uint32_t      RESERVED5[2U];    /**< Reserved for future use **/
   __IM uint32_t HFRCOCAL6;        /**< HFRCO Calibration Register (13 MHz)  */
   __IM uint32_t HFRCOCAL7;        /**< HFRCO Calibration Register (16 MHz)  */
   __IM uint32_t HFRCOCAL8;        /**< HFRCO Calibration Register (19 MHz)  */
-  uint32_t      RESERVED6[1];     /**< Reserved for future use **/
+  uint32_t      RESERVED6[1U];    /**< Reserved for future use **/
   __IM uint32_t HFRCOCAL10;       /**< HFRCO Calibration Register (26 MHz)  */
   __IM uint32_t HFRCOCAL11;       /**< HFRCO Calibration Register (32 MHz)  */
   __IM uint32_t HFRCOCAL12;       /**< HFRCO Calibration Register (38 MHz)  */
-  uint32_t      RESERVED7[11];    /**< Reserved for future use **/
+  uint32_t      RESERVED7[11U];   /**< Reserved for future use **/
   __IM uint32_t AUXHFRCOCAL0;     /**< AUXHFRCO Calibration Register (4 MHz)  */
-  uint32_t      RESERVED8[2];     /**< Reserved for future use **/
+  uint32_t      RESERVED8[2U];    /**< Reserved for future use **/
   __IM uint32_t AUXHFRCOCAL3;     /**< AUXHFRCO Calibration Register (7 MHz)  */
-  uint32_t      RESERVED9[2];     /**< Reserved for future use **/
+  uint32_t      RESERVED9[2U];    /**< Reserved for future use **/
   __IM uint32_t AUXHFRCOCAL6;     /**< AUXHFRCO Calibration Register (13 MHz)  */
   __IM uint32_t AUXHFRCOCAL7;     /**< AUXHFRCO Calibration Register (16 MHz)  */
   __IM uint32_t AUXHFRCOCAL8;     /**< AUXHFRCO Calibration Register (19 MHz)  */
-  uint32_t      RESERVED10[1];    /**< Reserved for future use **/
+  uint32_t      RESERVED10[1U];   /**< Reserved for future use **/
   __IM uint32_t AUXHFRCOCAL10;    /**< AUXHFRCO Calibration Register (26 MHz)  */
   __IM uint32_t AUXHFRCOCAL11;    /**< AUXHFRCO Calibration Register (32 MHz)  */
   __IM uint32_t AUXHFRCOCAL12;    /**< AUXHFRCO Calibration Register (38 MHz)  */
-  uint32_t      RESERVED11[11];   /**< Reserved for future use **/
+  uint32_t      RESERVED11[11U];  /**< Reserved for future use **/
   __IM uint32_t VMONCAL0;         /**< VMON Calibration Register 0  */
   __IM uint32_t VMONCAL1;         /**< VMON Calibration Register 1  */
   __IM uint32_t VMONCAL2;         /**< VMON Calibration Register 2  */
-  uint32_t      RESERVED12[3];    /**< Reserved for future use **/
+  uint32_t      RESERVED12[3U];   /**< Reserved for future use **/
   __IM uint32_t IDAC0CAL0;        /**< IDAC0 Calibration Register 0  */
   __IM uint32_t IDAC0CAL1;        /**< IDAC0 Calibration Register 1  */
-  uint32_t      RESERVED13[2];    /**< Reserved for future use **/
+  uint32_t      RESERVED13[2U];   /**< Reserved for future use **/
   __IM uint32_t DCDCLNVCTRL0;     /**< DCDC Low-noise VREF Trim Register 0  */
   __IM uint32_t DCDCLPVCTRL0;     /**< DCDC Low-power VREF Trim Register 0  */
   __IM uint32_t DCDCLPVCTRL1;     /**< DCDC Low-power VREF Trim Register 1  */
@@ -111,12 +110,12 @@ typedef struct {
   __IM uint32_t DCDCLPCMPHYSSEL1; /**< DCDC LPCMPHYSSEL Trim Register 1  */
 } DEVINFO_TypeDef;                /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG1B_DEVINFO
  * @{
  * @defgroup EFM32PG1B_DEVINFO_BitFields DEVINFO Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for DEVINFO CAL */
 #define _DEVINFO_CAL_MASK                                        0x00FFFFFFUL /**< Mask for DEVINFO_CAL */
@@ -214,6 +213,7 @@ typedef struct {
 #define _DEVINFO_PART_DEVICE_FAMILY_EFR32BG13P                   0x0000002BUL                                   /**< Mode EFR32BG13P for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFR32BG13B                   0x0000002CUL                                   /**< Mode EFR32BG13B for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFR32BG13V                   0x0000002DUL                                   /**< Mode EFR32BG13V for DEVINFO_PART */
+#define _DEVINFO_PART_DEVICE_FAMILY_EFR32ZG13P                   0x0000002EUL                                   /**< Mode EFR32ZG13P for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFR32FG13P                   0x00000031UL                                   /**< Mode EFR32FG13P for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFR32FG13B                   0x00000032UL                                   /**< Mode EFR32FG13B for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFR32FG13V                   0x00000033UL                                   /**< Mode EFR32FG13V for DEVINFO_PART */
@@ -223,6 +223,7 @@ typedef struct {
 #define _DEVINFO_PART_DEVICE_FAMILY_EFR32BG14P                   0x00000037UL                                   /**< Mode EFR32BG14P for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFR32BG14B                   0x00000038UL                                   /**< Mode EFR32BG14B for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFR32BG14V                   0x00000039UL                                   /**< Mode EFR32BG14V for DEVINFO_PART */
+#define _DEVINFO_PART_DEVICE_FAMILY_EFR32ZG14P                   0x0000003AUL                                   /**< Mode EFR32ZG14P for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFR32FG14P                   0x0000003DUL                                   /**< Mode EFR32FG14P for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFR32FG14B                   0x0000003EUL                                   /**< Mode EFR32FG14B for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFR32FG14V                   0x0000003FUL                                   /**< Mode EFR32FG14V for DEVINFO_PART */
@@ -246,6 +247,7 @@ typedef struct {
 #define _DEVINFO_PART_DEVICE_FAMILY_EFM32JG12B                   0x00000057UL                                   /**< Mode EFM32JG12B for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFM32GG11B                   0x00000064UL                                   /**< Mode EFM32GG11B for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFM32TG11B                   0x00000067UL                                   /**< Mode EFM32TG11B for DEVINFO_PART */
+#define _DEVINFO_PART_DEVICE_FAMILY_EFM32GG12B                   0x0000006AUL                                   /**< Mode EFM32GG12B for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EZR32LG                      0x00000078UL                                   /**< Mode EZR32LG for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EZR32WG                      0x00000079UL                                   /**< Mode EZR32WG for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EZR32HG                      0x0000007AUL                                   /**< Mode EZR32HG for DEVINFO_PART */
@@ -273,6 +275,7 @@ typedef struct {
 #define DEVINFO_PART_DEVICE_FAMILY_EFR32BG13P                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32BG13P << 16) /**< Shifted mode EFR32BG13P for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFR32BG13B                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32BG13B << 16) /**< Shifted mode EFR32BG13B for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFR32BG13V                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32BG13V << 16) /**< Shifted mode EFR32BG13V for DEVINFO_PART */
+#define DEVINFO_PART_DEVICE_FAMILY_EFR32ZG13P                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32ZG13P << 16) /**< Shifted mode EFR32ZG13P for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFR32FG13P                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32FG13P << 16) /**< Shifted mode EFR32FG13P for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFR32FG13B                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32FG13B << 16) /**< Shifted mode EFR32FG13B for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFR32FG13V                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32FG13V << 16) /**< Shifted mode EFR32FG13V for DEVINFO_PART */
@@ -282,6 +285,7 @@ typedef struct {
 #define DEVINFO_PART_DEVICE_FAMILY_EFR32BG14P                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32BG14P << 16) /**< Shifted mode EFR32BG14P for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFR32BG14B                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32BG14B << 16) /**< Shifted mode EFR32BG14B for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFR32BG14V                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32BG14V << 16) /**< Shifted mode EFR32BG14V for DEVINFO_PART */
+#define DEVINFO_PART_DEVICE_FAMILY_EFR32ZG14P                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32ZG14P << 16) /**< Shifted mode EFR32ZG14P for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFR32FG14P                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32FG14P << 16) /**< Shifted mode EFR32FG14P for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFR32FG14B                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32FG14B << 16) /**< Shifted mode EFR32FG14B for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFR32FG14V                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32FG14V << 16) /**< Shifted mode EFR32FG14V for DEVINFO_PART */
@@ -305,6 +309,7 @@ typedef struct {
 #define DEVINFO_PART_DEVICE_FAMILY_EFM32JG12B                    (_DEVINFO_PART_DEVICE_FAMILY_EFM32JG12B << 16) /**< Shifted mode EFM32JG12B for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFM32GG11B                    (_DEVINFO_PART_DEVICE_FAMILY_EFM32GG11B << 16) /**< Shifted mode EFM32GG11B for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFM32TG11B                    (_DEVINFO_PART_DEVICE_FAMILY_EFM32TG11B << 16) /**< Shifted mode EFM32TG11B for DEVINFO_PART */
+#define DEVINFO_PART_DEVICE_FAMILY_EFM32GG12B                    (_DEVINFO_PART_DEVICE_FAMILY_EFM32GG12B << 16) /**< Shifted mode EFM32GG12B for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EZR32LG                       (_DEVINFO_PART_DEVICE_FAMILY_EZR32LG << 16)    /**< Shifted mode EZR32LG for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EZR32WG                       (_DEVINFO_PART_DEVICE_FAMILY_EZR32WG << 16)    /**< Shifted mode EZR32WG for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EZR32HG                       (_DEVINFO_PART_DEVICE_FAMILY_EZR32HG << 16)    /**< Shifted mode EZR32HG for DEVINFO_PART */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_dma_descriptor.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_dma_descriptor.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg1b_dma_descriptor.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG1B_DMA_DESCRIPTOR register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,14 +40,14 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG1B_DMA_DESCRIPTOR DMA Descriptor
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 /** DMA_DESCRIPTOR Register Declaration */
 typedef struct {
   /* Note! Use of double __IOM (volatile) qualifier to ensure that both */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_dmareq.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_dmareq.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg1b_dmareq.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG1B_DMAREQ register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,17 +40,17 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG1B_DMAREQ DMAREQ
  * @{
  * @defgroup EFM32PG1B_DMAREQ_BitFields DMAREQ Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 #define DMAREQ_PRS_REQ0               ((1 << 16) + 0)  /**< DMA channel select for PRS_REQ0 */
 #define DMAREQ_PRS_REQ1               ((1 << 16) + 1)  /**< DMA channel select for PRS_REQ1 */
 #define DMAREQ_ADC0_SINGLE            ((8 << 16) + 0)  /**< DMA channel select for ADC0_SINGLE */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_emu.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_emu.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg1b_emu.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG1B_EMU register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG1B_EMU EMU
  * @{
  * @brief EFM32PG1B_EMU Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** EMU Register Declaration */
 typedef struct {
   __IOM uint32_t CTRL;            /**< Control Register  */
@@ -58,7 +57,7 @@ typedef struct {
   __IOM uint32_t RAM0CTRL;        /**< Memory Control Register  */
   __IOM uint32_t CMD;             /**< Command Register  */
 
-  uint32_t       RESERVED0[1];    /**< Reserved for future use **/
+  uint32_t       RESERVED0[1U];   /**< Reserved for future use **/
   __IOM uint32_t EM4CTRL;         /**< EM4 Control Register  */
   __IOM uint32_t TEMPLIMITS;      /**< Temperature Limits for Interrupt Generation  */
   __IM uint32_t  TEMP;            /**< Value of Last Temperature Measurement  */
@@ -71,7 +70,7 @@ typedef struct {
   __IOM uint32_t PWRCTRL;         /**< Power Control Register  */
   __IOM uint32_t DCDCCTRL;        /**< DCDC Control  */
 
-  uint32_t       RESERVED1[2];    /**< Reserved for future use **/
+  uint32_t       RESERVED1[2U];   /**< Reserved for future use **/
   __IOM uint32_t DCDCMISCCTRL;    /**< DCDC Miscellaneous Control Register  */
   __IOM uint32_t DCDCZDETCTRL;    /**< DCDC Power Train NFET Zero Current Detector Control Register  */
   __IOM uint32_t DCDCCLIMCTRL;    /**< DCDC Power Train PFET Current Limiter Control Register  */
@@ -80,35 +79,35 @@ typedef struct {
   __IOM uint32_t DCDCTIMING;      /**< DCDC Controller Timing Value Register  */
   __IOM uint32_t DCDCLPVCTRL;     /**< DCDC Low Power Voltage Register  */
 
-  uint32_t       RESERVED2[1];    /**< Reserved for future use **/
+  uint32_t       RESERVED2[1U];   /**< Reserved for future use **/
   __IOM uint32_t DCDCLPCTRL;      /**< DCDC Low Power Control Register  */
   __IOM uint32_t DCDCLNFREQCTRL;  /**< DCDC Low Noise Controller Frequency Control  */
 
-  uint32_t       RESERVED3[1];    /**< Reserved for future use **/
+  uint32_t       RESERVED3[1U];   /**< Reserved for future use **/
   __IM uint32_t  DCDCSYNC;        /**< DCDC Read Status Register  */
 
-  uint32_t       RESERVED4[5];    /**< Reserved for future use **/
+  uint32_t       RESERVED4[5U];   /**< Reserved for future use **/
   __IOM uint32_t VMONAVDDCTRL;    /**< VMON AVDD Channel Control  */
   __IOM uint32_t VMONALTAVDDCTRL; /**< Alternate VMON AVDD Channel Control  */
   __IOM uint32_t VMONDVDDCTRL;    /**< VMON DVDD Channel Control  */
   __IOM uint32_t VMONIO0CTRL;     /**< VMON IOVDD0 Channel Control  */
 
-  uint32_t       RESERVED5[49];   /**< Reserved for future use **/
+  uint32_t       RESERVED5[49U];  /**< Reserved for future use **/
   __IOM uint32_t BIASCONF;        /**< Configurations Related to the Bias  */
 
-  uint32_t       RESERVED6[10];   /**< Reserved for future use **/
+  uint32_t       RESERVED6[10U];  /**< Reserved for future use **/
   __IOM uint32_t TESTLOCK;        /**< Test Lock Register  */
 
-  uint32_t       RESERVED7[2];    /**< Reserved for future use **/
+  uint32_t       RESERVED7[2U];   /**< Reserved for future use **/
   __IOM uint32_t BIASTESTCTRL;    /**< Test Control Register for Regulator and BIAS  */
 } EMU_TypeDef;                    /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG1B_EMU
  * @{
  * @defgroup EFM32PG1B_EMU_BitFields  EMU Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for EMU CTRL */
 #define _EMU_CTRL_RESETVALUE                         0x00000000UL                      /**< Default value for EMU_CTRL */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_fpueh.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_fpueh.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg1b_fpueh.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG1B_FPUEH register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG1B_FPUEH FPUEH
  * @{
  * @brief EFM32PG1B_FPUEH Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** FPUEH Register Declaration */
 typedef struct {
   __IM uint32_t  IF;  /**< Interrupt Flag Register  */
@@ -58,12 +57,12 @@ typedef struct {
   __IOM uint32_t IEN; /**< Interrupt Enable Register  */
 } FPUEH_TypeDef;      /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG1B_FPUEH
  * @{
  * @defgroup EFM32PG1B_FPUEH_BitFields  FPUEH Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for FPUEH IF */
 #define _FPUEH_IF_RESETVALUE        0x00000000UL                   /**< Default value for FPUEH_IF */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_gpcrc.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_gpcrc.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg1b_gpcrc.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG1B_GPCRC register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG1B_GPCRC GPCRC
  * @{
  * @brief EFM32PG1B_GPCRC Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** GPCRC Register Declaration */
 typedef struct {
   __IOM uint32_t CTRL;           /**< Control Register  */
@@ -64,12 +63,12 @@ typedef struct {
   __IM uint32_t  DATABYTEREV;    /**< CRC Data Byte Reverse Register  */
 } GPCRC_TypeDef;                 /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG1B_GPCRC
  * @{
  * @defgroup EFM32PG1B_GPCRC_BitFields  GPCRC Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for GPCRC CTRL */
 #define _GPCRC_CTRL_RESETVALUE                          0x00000000UL                             /**< Default value for GPCRC_CTRL */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_gpio.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_gpio.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg1b_gpio.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG1B_GPIO register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,48 +40,48 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG1B_GPIO GPIO
  * @{
  * @brief EFM32PG1B_GPIO Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** GPIO Register Declaration */
 typedef struct {
-  GPIO_P_TypeDef P[6];           /**< Port configuration bits */
+  GPIO_P_TypeDef P[6U];           /**< Port configuration bits */
 
-  uint32_t       RESERVED0[184]; /**< Reserved for future use **/
-  __IOM uint32_t EXTIPSELL;      /**< External Interrupt Port Select Low Register  */
-  __IOM uint32_t EXTIPSELH;      /**< External Interrupt Port Select High Register  */
-  __IOM uint32_t EXTIPINSELL;    /**< External Interrupt Pin Select Low Register  */
-  __IOM uint32_t EXTIPINSELH;    /**< External Interrupt Pin Select High Register  */
-  __IOM uint32_t EXTIRISE;       /**< External Interrupt Rising Edge Trigger Register  */
-  __IOM uint32_t EXTIFALL;       /**< External Interrupt Falling Edge Trigger Register  */
-  __IOM uint32_t EXTILEVEL;      /**< External Interrupt Level Register  */
-  __IM uint32_t  IF;             /**< Interrupt Flag Register  */
-  __IOM uint32_t IFS;            /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;            /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t IEN;            /**< Interrupt Enable Register  */
-  __IOM uint32_t EM4WUEN;        /**< EM4 Wake Up Enable Register  */
+  uint32_t       RESERVED0[184U]; /**< Reserved for future use **/
+  __IOM uint32_t EXTIPSELL;       /**< External Interrupt Port Select Low Register  */
+  __IOM uint32_t EXTIPSELH;       /**< External Interrupt Port Select High Register  */
+  __IOM uint32_t EXTIPINSELL;     /**< External Interrupt Pin Select Low Register  */
+  __IOM uint32_t EXTIPINSELH;     /**< External Interrupt Pin Select High Register  */
+  __IOM uint32_t EXTIRISE;        /**< External Interrupt Rising Edge Trigger Register  */
+  __IOM uint32_t EXTIFALL;        /**< External Interrupt Falling Edge Trigger Register  */
+  __IOM uint32_t EXTILEVEL;       /**< External Interrupt Level Register  */
+  __IM uint32_t  IF;              /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;             /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;             /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;             /**< Interrupt Enable Register  */
+  __IOM uint32_t EM4WUEN;         /**< EM4 Wake Up Enable Register  */
 
-  uint32_t       RESERVED1[4];   /**< Reserved for future use **/
-  __IOM uint32_t ROUTEPEN;       /**< I/O Routing Pin Enable Register  */
-  __IOM uint32_t ROUTELOC0;      /**< I/O Routing Location Register  */
+  uint32_t       RESERVED1[4U];   /**< Reserved for future use **/
+  __IOM uint32_t ROUTEPEN;        /**< I/O Routing Pin Enable Register  */
+  __IOM uint32_t ROUTELOC0;       /**< I/O Routing Location Register  */
 
-  uint32_t       RESERVED2[2];   /**< Reserved for future use **/
-  __IOM uint32_t INSENSE;        /**< Input Sense Register  */
-  __IOM uint32_t LOCK;           /**< Configuration Lock Register  */
-} GPIO_TypeDef;                  /** @} */
+  uint32_t       RESERVED2[2U];   /**< Reserved for future use **/
+  __IOM uint32_t INSENSE;         /**< Input Sense Register  */
+  __IOM uint32_t LOCK;            /**< Configuration Lock Register  */
+} GPIO_TypeDef;                   /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG1B_GPIO
  * @{
  * @defgroup EFM32PG1B_GPIO_BitFields  GPIO Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for GPIO P_CTRL */
 #define _GPIO_P_CTRL_RESETVALUE                         0x00500050UL                                  /**< Default value for GPIO_P_CTRL */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_gpio_p.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_gpio_p.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg1b_gpio_p.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG1B_GPIO_P register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,26 +40,26 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief GPIO_P GPIO P Register
  * @ingroup EFM32PG1B_GPIO
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IOM uint32_t CTRL;         /**< Port Control Register  */
-  __IOM uint32_t MODEL;        /**< Port Pin Mode Low Register  */
-  __IOM uint32_t MODEH;        /**< Port Pin Mode High Register  */
-  __IOM uint32_t DOUT;         /**< Port Data Out Register  */
-  uint32_t       RESERVED0[2]; /**< Reserved for future use **/
-  __IOM uint32_t DOUTTGL;      /**< Port Data Out Toggle Register  */
-  __IM uint32_t  DIN;          /**< Port Data in Register  */
-  __IOM uint32_t PINLOCKN;     /**< Port Unlocked Pins Register  */
-  uint32_t       RESERVED1[1]; /**< Reserved for future use **/
-  __IOM uint32_t OVTDIS;       /**< Over Voltage Disable for All Modes  */
-  uint32_t       RESERVED2[1]; /**< Reserved future */
+  __IOM uint32_t CTRL;          /**< Port Control Register  */
+  __IOM uint32_t MODEL;         /**< Port Pin Mode Low Register  */
+  __IOM uint32_t MODEH;         /**< Port Pin Mode High Register  */
+  __IOM uint32_t DOUT;          /**< Port Data Out Register  */
+  uint32_t       RESERVED0[2U]; /**< Reserved for future use **/
+  __IOM uint32_t DOUTTGL;       /**< Port Data Out Toggle Register  */
+  __IM uint32_t  DIN;           /**< Port Data in Register  */
+  __IOM uint32_t PINLOCKN;      /**< Port Unlocked Pins Register  */
+  uint32_t       RESERVED1[1U]; /**< Reserved for future use **/
+  __IOM uint32_t OVTDIS;        /**< Over Voltage Disable for All Modes  */
+  uint32_t       RESERVED2[1U]; /**< Reserved future */
 } GPIO_P_TypeDef;
 
 /** @} End of group Parts */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_i2c.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_i2c.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg1b_i2c.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG1B_I2C register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG1B_I2C I2C
  * @{
  * @brief EFM32PG1B_I2C Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** I2C Register Declaration */
 typedef struct {
   __IOM uint32_t CTRL;      /**< Control Register  */
@@ -73,12 +72,12 @@ typedef struct {
   __IOM uint32_t ROUTELOC0; /**< I/O Routing Location Register  */
 } I2C_TypeDef;              /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG1B_I2C
  * @{
  * @defgroup EFM32PG1B_I2C_BitFields  I2C Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for I2C CTRL */
 #define _I2C_CTRL_RESETVALUE               0x00000000UL                     /**< Default value for I2C_CTRL */
@@ -426,7 +425,7 @@ typedef struct {
 #define I2C_IF_TXBL                        (0x1UL << 4)                    /**< Transmit Buffer Level Interrupt Flag */
 #define _I2C_IF_TXBL_SHIFT                 4                               /**< Shift value for I2C_TXBL */
 #define _I2C_IF_TXBL_MASK                  0x10UL                          /**< Bit mask for I2C_TXBL */
-#define _I2C_IF_TXBL_DEFAULT               0x00000000UL                    /**< Mode DEFAULT for I2C_IF */
+#define _I2C_IF_TXBL_DEFAULT               0x00000001UL                    /**< Mode DEFAULT for I2C_IF */
 #define I2C_IF_TXBL_DEFAULT                (_I2C_IF_TXBL_DEFAULT << 4)     /**< Shifted mode DEFAULT for I2C_IF */
 #define I2C_IF_RXDATAV                     (0x1UL << 5)                    /**< Receive Data Valid Interrupt Flag */
 #define _I2C_IF_RXDATAV_SHIFT              5                               /**< Shift value for I2C_RXDATAV */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_idac.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_idac.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg1b_idac.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG1B_IDAC register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,40 +40,40 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG1B_IDAC IDAC
  * @{
  * @brief EFM32PG1B_IDAC Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** IDAC Register Declaration */
 typedef struct {
   __IOM uint32_t CTRL;          /**< Control Register  */
   __IOM uint32_t CURPROG;       /**< Current Programming Register  */
-  uint32_t       RESERVED0[1];  /**< Reserved for future use **/
+  uint32_t       RESERVED0[1U]; /**< Reserved for future use **/
   __IOM uint32_t DUTYCONFIG;    /**< Duty Cycle Configuration Register  */
 
-  uint32_t       RESERVED1[2];  /**< Reserved for future use **/
+  uint32_t       RESERVED1[2U]; /**< Reserved for future use **/
   __IM uint32_t  STATUS;        /**< Status Register  */
-  uint32_t       RESERVED2[1];  /**< Reserved for future use **/
+  uint32_t       RESERVED2[1U]; /**< Reserved for future use **/
   __IM uint32_t  IF;            /**< Interrupt Flag Register  */
   __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
   __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
   __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
-  uint32_t       RESERVED3[1];  /**< Reserved for future use **/
+  uint32_t       RESERVED3[1U]; /**< Reserved for future use **/
   __IM uint32_t  APORTREQ;      /**< APORT Request Status Register  */
   __IM uint32_t  APORTCONFLICT; /**< APORT Request Status Register  */
 } IDAC_TypeDef;                 /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG1B_IDAC
  * @{
  * @defgroup EFM32PG1B_IDAC_BitFields  IDAC Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for IDAC CTRL */
 #define _IDAC_CTRL_RESETVALUE                          0x00000000UL                              /**< Default value for IDAC_CTRL */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_ldma.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_ldma.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg1b_ldma.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG1B_LDMA register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,46 +40,46 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG1B_LDMA LDMA
  * @{
  * @brief EFM32PG1B_LDMA Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** LDMA Register Declaration */
 typedef struct {
-  __IOM uint32_t  CTRL;         /**< DMA Control Register  */
-  __IM uint32_t   STATUS;       /**< DMA Status Register  */
-  __IOM uint32_t  SYNC;         /**< DMA Synchronization Trigger Register (Single-Cycle RMW)  */
-  uint32_t        RESERVED0[5]; /**< Reserved for future use **/
-  __IOM uint32_t  CHEN;         /**< DMA Channel Enable Register (Single-Cycle RMW)  */
-  __IM uint32_t   CHBUSY;       /**< DMA Channel Busy Register  */
-  __IOM uint32_t  CHDONE;       /**< DMA Channel Linking Done Register (Single-Cycle RMW)  */
-  __IOM uint32_t  DBGHALT;      /**< DMA Channel Debug Halt Register  */
-  __IOM uint32_t  SWREQ;        /**< DMA Channel Software Transfer Request Register  */
-  __IOM uint32_t  REQDIS;       /**< DMA Channel Request Disable Register  */
-  __IM uint32_t   REQPEND;      /**< DMA Channel Requests Pending Register  */
-  __IOM uint32_t  LINKLOAD;     /**< DMA Channel Link Load Register  */
-  __IOM uint32_t  REQCLEAR;     /**< DMA Channel Request Clear Register  */
-  uint32_t        RESERVED1[7]; /**< Reserved for future use **/
-  __IM uint32_t   IF;           /**< Interrupt Flag Register  */
-  __IOM uint32_t  IFS;          /**< Interrupt Flag Set Register  */
-  __IOM uint32_t  IFC;          /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t  IEN;          /**< Interrupt Enable Register  */
+  __IOM uint32_t  CTRL;          /**< DMA Control Register  */
+  __IM uint32_t   STATUS;        /**< DMA Status Register  */
+  __IOM uint32_t  SYNC;          /**< DMA Synchronization Trigger Register (Single-Cycle RMW)  */
+  uint32_t        RESERVED0[5U]; /**< Reserved for future use **/
+  __IOM uint32_t  CHEN;          /**< DMA Channel Enable Register (Single-Cycle RMW)  */
+  __IM uint32_t   CHBUSY;        /**< DMA Channel Busy Register  */
+  __IOM uint32_t  CHDONE;        /**< DMA Channel Linking Done Register (Single-Cycle RMW)  */
+  __IOM uint32_t  DBGHALT;       /**< DMA Channel Debug Halt Register  */
+  __IOM uint32_t  SWREQ;         /**< DMA Channel Software Transfer Request Register  */
+  __IOM uint32_t  REQDIS;        /**< DMA Channel Request Disable Register  */
+  __IM uint32_t   REQPEND;       /**< DMA Channel Requests Pending Register  */
+  __IOM uint32_t  LINKLOAD;      /**< DMA Channel Link Load Register  */
+  __IOM uint32_t  REQCLEAR;      /**< DMA Channel Request Clear Register  */
+  uint32_t        RESERVED1[7U]; /**< Reserved for future use **/
+  __IM uint32_t   IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t  IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t  IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t  IEN;           /**< Interrupt Enable Register  */
 
-  uint32_t        RESERVED2[4]; /**< Reserved registers */
-  LDMA_CH_TypeDef CH[8];        /**< DMA Channel Registers */
-} LDMA_TypeDef;                 /** @} */
+  uint32_t        RESERVED2[4U]; /**< Reserved registers */
+  LDMA_CH_TypeDef CH[8U];        /**< DMA Channel Registers */
+} LDMA_TypeDef;                  /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG1B_LDMA
  * @{
  * @defgroup EFM32PG1B_LDMA_BitFields  LDMA Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for LDMA CTRL */
 #define _LDMA_CTRL_RESETVALUE                        0x07000000UL                           /**< Default value for LDMA_CTRL */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_ldma_ch.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_ldma_ch.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg1b_ldma_ch.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG1B_LDMA_CH register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,23 +40,23 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief LDMA_CH LDMA CH Register
  * @ingroup EFM32PG1B_LDMA
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IOM uint32_t REQSEL;       /**< Channel Peripheral Request Select Register  */
-  __IOM uint32_t CFG;          /**< Channel Configuration Register  */
-  __IOM uint32_t LOOP;         /**< Channel Loop Counter Register  */
-  __IOM uint32_t CTRL;         /**< Channel Descriptor Control Word Register  */
-  __IOM uint32_t SRC;          /**< Channel Descriptor Source Data Address Register  */
-  __IOM uint32_t DST;          /**< Channel Descriptor Destination Data Address Register  */
-  __IOM uint32_t LINK;         /**< Channel Descriptor Link Structure Address Register  */
-  uint32_t       RESERVED0[5]; /**< Reserved future */
+  __IOM uint32_t REQSEL;        /**< Channel Peripheral Request Select Register  */
+  __IOM uint32_t CFG;           /**< Channel Configuration Register  */
+  __IOM uint32_t LOOP;          /**< Channel Loop Counter Register  */
+  __IOM uint32_t CTRL;          /**< Channel Descriptor Control Word Register  */
+  __IOM uint32_t SRC;           /**< Channel Descriptor Source Data Address Register  */
+  __IOM uint32_t DST;           /**< Channel Descriptor Destination Data Address Register  */
+  __IOM uint32_t LINK;          /**< Channel Descriptor Link Structure Address Register  */
+  uint32_t       RESERVED0[5U]; /**< Reserved future */
 } LDMA_CH_TypeDef;
 
 /** @} End of group Parts */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_letimer.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_letimer.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg1b_letimer.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG1B_LETIMER register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,47 +40,47 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG1B_LETIMER LETIMER
  * @{
  * @brief EFM32PG1B_LETIMER Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** LETIMER Register Declaration */
 typedef struct {
-  __IOM uint32_t CTRL;         /**< Control Register  */
-  __IOM uint32_t CMD;          /**< Command Register  */
-  __IM uint32_t  STATUS;       /**< Status Register  */
-  __IOM uint32_t CNT;          /**< Counter Value Register  */
-  __IOM uint32_t COMP0;        /**< Compare Value Register 0  */
-  __IOM uint32_t COMP1;        /**< Compare Value Register 1  */
-  __IOM uint32_t REP0;         /**< Repeat Counter Register 0  */
-  __IOM uint32_t REP1;         /**< Repeat Counter Register 1  */
-  __IM uint32_t  IF;           /**< Interrupt Flag Register  */
-  __IOM uint32_t IFS;          /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;          /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t IEN;          /**< Interrupt Enable Register  */
+  __IOM uint32_t CTRL;          /**< Control Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IOM uint32_t CNT;           /**< Counter Value Register  */
+  __IOM uint32_t COMP0;         /**< Compare Value Register 0  */
+  __IOM uint32_t COMP1;         /**< Compare Value Register 1  */
+  __IOM uint32_t REP0;          /**< Repeat Counter Register 0  */
+  __IOM uint32_t REP1;          /**< Repeat Counter Register 1  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
 
-  uint32_t       RESERVED0[1]; /**< Reserved for future use **/
-  __IM uint32_t  SYNCBUSY;     /**< Synchronization Busy Register  */
+  uint32_t       RESERVED0[1U]; /**< Reserved for future use **/
+  __IM uint32_t  SYNCBUSY;      /**< Synchronization Busy Register  */
 
-  uint32_t       RESERVED1[2]; /**< Reserved for future use **/
-  __IOM uint32_t ROUTEPEN;     /**< I/O Routing Pin Enable Register  */
-  __IOM uint32_t ROUTELOC0;    /**< I/O Routing Location Register  */
+  uint32_t       RESERVED1[2U]; /**< Reserved for future use **/
+  __IOM uint32_t ROUTEPEN;      /**< I/O Routing Pin Enable Register  */
+  __IOM uint32_t ROUTELOC0;     /**< I/O Routing Location Register  */
 
-  uint32_t       RESERVED2[2]; /**< Reserved for future use **/
-  __IOM uint32_t PRSSEL;       /**< PRS Input Select Register  */
-} LETIMER_TypeDef;             /** @} */
+  uint32_t       RESERVED2[2U]; /**< Reserved for future use **/
+  __IOM uint32_t PRSSEL;        /**< PRS Input Select Register  */
+} LETIMER_TypeDef;              /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG1B_LETIMER
  * @{
  * @defgroup EFM32PG1B_LETIMER_BitFields  LETIMER Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for LETIMER CTRL */
 #define _LETIMER_CTRL_RESETVALUE                0x00000000UL                           /**< Default value for LETIMER_CTRL */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_leuart.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_leuart.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg1b_leuart.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG1B_LEUART register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,50 +40,50 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG1B_LEUART LEUART
  * @{
  * @brief EFM32PG1B_LEUART Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** LEUART Register Declaration */
 typedef struct {
-  __IOM uint32_t CTRL;         /**< Control Register  */
-  __IOM uint32_t CMD;          /**< Command Register  */
-  __IM uint32_t  STATUS;       /**< Status Register  */
-  __IOM uint32_t CLKDIV;       /**< Clock Control Register  */
-  __IOM uint32_t STARTFRAME;   /**< Start Frame Register  */
-  __IOM uint32_t SIGFRAME;     /**< Signal Frame Register  */
-  __IM uint32_t  RXDATAX;      /**< Receive Buffer Data Extended Register  */
-  __IM uint32_t  RXDATA;       /**< Receive Buffer Data Register  */
-  __IM uint32_t  RXDATAXP;     /**< Receive Buffer Data Extended Peek Register  */
-  __IOM uint32_t TXDATAX;      /**< Transmit Buffer Data Extended Register  */
-  __IOM uint32_t TXDATA;       /**< Transmit Buffer Data Register  */
-  __IM uint32_t  IF;           /**< Interrupt Flag Register  */
-  __IOM uint32_t IFS;          /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;          /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t IEN;          /**< Interrupt Enable Register  */
-  __IOM uint32_t PULSECTRL;    /**< Pulse Control Register  */
+  __IOM uint32_t CTRL;          /**< Control Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IOM uint32_t CLKDIV;        /**< Clock Control Register  */
+  __IOM uint32_t STARTFRAME;    /**< Start Frame Register  */
+  __IOM uint32_t SIGFRAME;      /**< Signal Frame Register  */
+  __IM uint32_t  RXDATAX;       /**< Receive Buffer Data Extended Register  */
+  __IM uint32_t  RXDATA;        /**< Receive Buffer Data Register  */
+  __IM uint32_t  RXDATAXP;      /**< Receive Buffer Data Extended Peek Register  */
+  __IOM uint32_t TXDATAX;       /**< Transmit Buffer Data Extended Register  */
+  __IOM uint32_t TXDATA;        /**< Transmit Buffer Data Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t PULSECTRL;     /**< Pulse Control Register  */
 
-  __IOM uint32_t FREEZE;       /**< Freeze Register  */
-  __IM uint32_t  SYNCBUSY;     /**< Synchronization Busy Register  */
+  __IOM uint32_t FREEZE;        /**< Freeze Register  */
+  __IM uint32_t  SYNCBUSY;      /**< Synchronization Busy Register  */
 
-  uint32_t       RESERVED0[3]; /**< Reserved for future use **/
-  __IOM uint32_t ROUTEPEN;     /**< I/O Routing Pin Enable Register  */
-  __IOM uint32_t ROUTELOC0;    /**< I/O Routing Location Register  */
-  uint32_t       RESERVED1[2]; /**< Reserved for future use **/
-  __IOM uint32_t INPUT;        /**< LEUART Input Register  */
-} LEUART_TypeDef;              /** @} */
+  uint32_t       RESERVED0[3U]; /**< Reserved for future use **/
+  __IOM uint32_t ROUTEPEN;      /**< I/O Routing Pin Enable Register  */
+  __IOM uint32_t ROUTELOC0;     /**< I/O Routing Location Register  */
+  uint32_t       RESERVED1[2U]; /**< Reserved for future use **/
+  __IOM uint32_t INPUT;         /**< LEUART Input Register  */
+} LEUART_TypeDef;               /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG1B_LEUART
  * @{
  * @defgroup EFM32PG1B_LEUART_BitFields  LEUART Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for LEUART CTRL */
 #define _LEUART_CTRL_RESETVALUE                  0x00000000UL                         /**< Default value for LEUART_CTRL */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_msc.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_msc.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg1b_msc.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG1B_MSC register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,52 +40,52 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG1B_MSC MSC
  * @{
  * @brief EFM32PG1B_MSC Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** MSC Register Declaration */
 typedef struct {
-  __IOM uint32_t CTRL;         /**< Memory System Control Register  */
-  __IOM uint32_t READCTRL;     /**< Read Control Register  */
-  __IOM uint32_t WRITECTRL;    /**< Write Control Register  */
-  __IOM uint32_t WRITECMD;     /**< Write Command Register  */
-  __IOM uint32_t ADDRB;        /**< Page Erase/Write Address Buffer  */
-  uint32_t       RESERVED0[1]; /**< Reserved for future use **/
-  __IOM uint32_t WDATA;        /**< Write Data Register  */
-  __IM uint32_t  STATUS;       /**< Status Register  */
+  __IOM uint32_t CTRL;          /**< Memory System Control Register  */
+  __IOM uint32_t READCTRL;      /**< Read Control Register  */
+  __IOM uint32_t WRITECTRL;     /**< Write Control Register  */
+  __IOM uint32_t WRITECMD;      /**< Write Command Register  */
+  __IOM uint32_t ADDRB;         /**< Page Erase/Write Address Buffer  */
+  uint32_t       RESERVED0[1U]; /**< Reserved for future use **/
+  __IOM uint32_t WDATA;         /**< Write Data Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
 
-  uint32_t       RESERVED1[4]; /**< Reserved for future use **/
-  __IM uint32_t  IF;           /**< Interrupt Flag Register  */
-  __IOM uint32_t IFS;          /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;          /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t IEN;          /**< Interrupt Enable Register  */
-  __IOM uint32_t LOCK;         /**< Configuration Lock Register  */
-  __IOM uint32_t CACHECMD;     /**< Flash Cache Command Register  */
-  __IM uint32_t  CACHEHITS;    /**< Cache Hits Performance Counter  */
-  __IM uint32_t  CACHEMISSES;  /**< Cache Misses Performance Counter  */
+  uint32_t       RESERVED1[4U]; /**< Reserved for future use **/
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t LOCK;          /**< Configuration Lock Register  */
+  __IOM uint32_t CACHECMD;      /**< Flash Cache Command Register  */
+  __IM uint32_t  CACHEHITS;     /**< Cache Hits Performance Counter  */
+  __IM uint32_t  CACHEMISSES;   /**< Cache Misses Performance Counter  */
 
-  uint32_t       RESERVED2[1]; /**< Reserved for future use **/
-  __IOM uint32_t MASSLOCK;     /**< Mass Erase Lock Register  */
+  uint32_t       RESERVED2[1U]; /**< Reserved for future use **/
+  __IOM uint32_t MASSLOCK;      /**< Mass Erase Lock Register  */
 
-  uint32_t       RESERVED3[1]; /**< Reserved for future use **/
-  __IOM uint32_t STARTUP;      /**< Startup Control  */
+  uint32_t       RESERVED3[1U]; /**< Reserved for future use **/
+  __IOM uint32_t STARTUP;       /**< Startup Control  */
 
-  uint32_t       RESERVED4[5]; /**< Reserved for future use **/
-  __IOM uint32_t CMD;          /**< Command Register  */
-} MSC_TypeDef;                 /** @} */
+  uint32_t       RESERVED4[5U]; /**< Reserved for future use **/
+  __IOM uint32_t CMD;           /**< Command Register  */
+} MSC_TypeDef;                  /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG1B_MSC
  * @{
  * @defgroup EFM32PG1B_MSC_BitFields  MSC Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for MSC CTRL */
 #define _MSC_CTRL_RESETVALUE                    0x00000001UL                           /**< Default value for MSC_CTRL */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_pcnt.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_pcnt.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg1b_pcnt.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG1B_PCNT register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,46 +40,46 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG1B_PCNT PCNT
  * @{
  * @brief EFM32PG1B_PCNT Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** PCNT Register Declaration */
 typedef struct {
-  __IOM uint32_t CTRL;         /**< Control Register  */
-  __IOM uint32_t CMD;          /**< Command Register  */
-  __IM uint32_t  STATUS;       /**< Status Register  */
-  __IM uint32_t  CNT;          /**< Counter Value Register  */
-  __IM uint32_t  TOP;          /**< Top Value Register  */
-  __IOM uint32_t TOPB;         /**< Top Value Buffer Register  */
-  __IM uint32_t  IF;           /**< Interrupt Flag Register  */
-  __IOM uint32_t IFS;          /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;          /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t IEN;          /**< Interrupt Enable Register  */
-  uint32_t       RESERVED0[1]; /**< Reserved for future use **/
-  __IOM uint32_t ROUTELOC0;    /**< I/O Routing Location Register  */
+  __IOM uint32_t CTRL;          /**< Control Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IM uint32_t  CNT;           /**< Counter Value Register  */
+  __IM uint32_t  TOP;           /**< Top Value Register  */
+  __IOM uint32_t TOPB;          /**< Top Value Buffer Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  uint32_t       RESERVED0[1U]; /**< Reserved for future use **/
+  __IOM uint32_t ROUTELOC0;     /**< I/O Routing Location Register  */
 
-  uint32_t       RESERVED1[4]; /**< Reserved for future use **/
-  __IOM uint32_t FREEZE;       /**< Freeze Register  */
-  __IM uint32_t  SYNCBUSY;     /**< Synchronization Busy Register  */
+  uint32_t       RESERVED1[4U]; /**< Reserved for future use **/
+  __IOM uint32_t FREEZE;        /**< Freeze Register  */
+  __IM uint32_t  SYNCBUSY;      /**< Synchronization Busy Register  */
 
-  uint32_t       RESERVED2[7]; /**< Reserved for future use **/
-  __IM uint32_t  AUXCNT;       /**< Auxiliary Counter Value Register  */
-  __IOM uint32_t INPUT;        /**< PCNT Input Register  */
-  __IOM uint32_t OVSCFG;       /**< Oversampling Config Register  */
-} PCNT_TypeDef;                /** @} */
+  uint32_t       RESERVED2[7U]; /**< Reserved for future use **/
+  __IM uint32_t  AUXCNT;        /**< Auxiliary Counter Value Register  */
+  __IOM uint32_t INPUT;         /**< PCNT Input Register  */
+  __IOM uint32_t OVSCFG;        /**< Oversampling Config Register  */
+} PCNT_TypeDef;                 /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG1B_PCNT
  * @{
  * @defgroup EFM32PG1B_PCNT_BitFields  PCNT Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for PCNT CTRL */
 #define _PCNT_CTRL_RESETVALUE              0x00000000UL                          /**< Default value for PCNT_CTRL */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_prs.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_prs.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg1b_prs.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG1B_PRS register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,42 +40,42 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG1B_PRS PRS
  * @{
  * @brief EFM32PG1B_PRS Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** PRS Register Declaration */
 typedef struct {
-  __IOM uint32_t SWPULSE;      /**< Software Pulse Register  */
-  __IOM uint32_t SWLEVEL;      /**< Software Level Register  */
-  __IOM uint32_t ROUTEPEN;     /**< I/O Routing Pin Enable Register  */
-  uint32_t       RESERVED0[1]; /**< Reserved for future use **/
-  __IOM uint32_t ROUTELOC0;    /**< I/O Routing Location Register  */
-  __IOM uint32_t ROUTELOC1;    /**< I/O Routing Location Register  */
-  __IOM uint32_t ROUTELOC2;    /**< I/O Routing Location Register  */
+  __IOM uint32_t SWPULSE;       /**< Software Pulse Register  */
+  __IOM uint32_t SWLEVEL;       /**< Software Level Register  */
+  __IOM uint32_t ROUTEPEN;      /**< I/O Routing Pin Enable Register  */
+  uint32_t       RESERVED0[1U]; /**< Reserved for future use **/
+  __IOM uint32_t ROUTELOC0;     /**< I/O Routing Location Register  */
+  __IOM uint32_t ROUTELOC1;     /**< I/O Routing Location Register  */
+  __IOM uint32_t ROUTELOC2;     /**< I/O Routing Location Register  */
 
-  uint32_t       RESERVED1[1]; /**< Reserved for future use **/
-  __IOM uint32_t CTRL;         /**< Control Register  */
-  __IOM uint32_t DMAREQ0;      /**< DMA Request 0 Register  */
-  __IOM uint32_t DMAREQ1;      /**< DMA Request 1 Register  */
-  uint32_t       RESERVED2[1]; /**< Reserved for future use **/
-  __IM uint32_t  PEEK;         /**< PRS Channel Values  */
+  uint32_t       RESERVED1[1U]; /**< Reserved for future use **/
+  __IOM uint32_t CTRL;          /**< Control Register  */
+  __IOM uint32_t DMAREQ0;       /**< DMA Request 0 Register  */
+  __IOM uint32_t DMAREQ1;       /**< DMA Request 1 Register  */
+  uint32_t       RESERVED2[1U]; /**< Reserved for future use **/
+  __IM uint32_t  PEEK;          /**< PRS Channel Values  */
 
-  uint32_t       RESERVED3[3]; /**< Reserved registers */
-  PRS_CH_TypeDef CH[12];       /**< Channel registers */
-} PRS_TypeDef;                 /** @} */
+  uint32_t       RESERVED3[3U]; /**< Reserved registers */
+  PRS_CH_TypeDef CH[12U];       /**< Channel registers */
+} PRS_TypeDef;                  /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG1B_PRS
  * @{
  * @defgroup EFM32PG1B_PRS_BitFields  PRS Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for PRS SWPULSE */
 #define _PRS_SWPULSE_RESETVALUE                0x00000000UL                           /**< Default value for PRS_SWPULSE */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_prs_ch.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_prs_ch.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg1b_prs_ch.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG1B_PRS_CH register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,14 +40,14 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief PRS_CH PRS CH Register
  * @ingroup EFM32PG1B_PRS
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t CTRL; /**< Channel Control Register  */
 } PRS_CH_TypeDef;

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_prs_signals.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_prs_signals.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg1b_prs_signals.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG1B_PRS_SIGNALS register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,17 +40,17 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @addtogroup EFM32PG1B_PRS
  * @{
  * @addtogroup EFM32PG1B_PRS_Signals PRS Signals
  * @{
  * @brief PRS Signal names
- *****************************************************************************/
+ ******************************************************************************/
 #define PRS_PRS_CH0             ((1 << 8) + 0)  /**< PRS PRS channel 0 */
 #define PRS_PRS_CH1             ((1 << 8) + 1)  /**< PRS PRS channel 1 */
 #define PRS_PRS_CH2             ((1 << 8) + 2)  /**< PRS PRS channel 2 */
@@ -104,6 +103,8 @@ extern "C" {
 #define PRS_MODEM_FRAMESENT     ((38 << 8) + 3) /**< PRS Entire frame transmitted */
 #define PRS_MODEM_SYNCSENT      ((38 << 8) + 4) /**< PRS Syncword transmitted */
 #define PRS_MODEM_PRESENT       ((38 << 8) + 5) /**< PRS Preamble transmitted */
+#define PRS_MODEM_ANT0          ((39 << 8) + 5) /**< PRS Antenna 0 select */
+#define PRS_MODEM_ANT1          ((39 << 8) + 6) /**< PRS Antenna 1 select */
 #define PRS_RTCC_CCV0           ((41 << 8) + 1) /**< PRS RTCC Compare 0 */
 #define PRS_RTCC_CCV1           ((41 << 8) + 2) /**< PRS RTCC Compare 1 */
 #define PRS_RTCC_CCV2           ((41 << 8) + 3) /**< PRS RTCC Compare 2 */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_rmu.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_rmu.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg1b_rmu.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG1B_RMU register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG1B_RMU RMU
  * @{
  * @brief EFM32PG1B_RMU Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** RMU Register Declaration */
 typedef struct {
   __IOM uint32_t CTRL;     /**< Control Register  */
@@ -59,12 +58,12 @@ typedef struct {
   __IOM uint32_t LOCK;     /**< Configuration Lock Register  */
 } RMU_TypeDef;             /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG1B_RMU
  * @{
  * @defgroup EFM32PG1B_RMU_BitFields  RMU Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for RMU CTRL */
 #define _RMU_CTRL_RESETVALUE               0x00004224UL                          /**< Default value for RMU_CTRL */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_romtable.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_romtable.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg1b_romtable.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG1B_ROMTABLE register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG1B_ROMTABLE ROM Table, Chip Revision Information
  * @{
  * @brief Chip Information, Revision numbers
- *****************************************************************************/
+ ******************************************************************************/
 /** ROMTABLE Register Declaration */
 typedef struct {
   __IM uint32_t PID4; /**< JEP_106_BANK */
@@ -63,12 +62,12 @@ typedef struct {
   __IM uint32_t CID0; /**< Unused */
 } ROMTABLE_TypeDef;   /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG1B_ROMTABLE
  * @{
  * @defgroup EFM32PG1B_ROMTABLE_BitFields ROM Table Bit Field definitions
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 /* Bit fields for EFM32PG1B_ROMTABLE */
 #define _ROMTABLE_PID0_FAMILYLSB_MASK       0x000000C0UL /**< Least Significant Bits [1:0] of CHIP FAMILY, mask */
 #define _ROMTABLE_PID0_FAMILYLSB_SHIFT      6            /**< Least Significant Bits [1:0] of CHIP FAMILY, shift */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_rtcc.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_rtcc.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg1b_rtcc.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG1B_RTCC register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,46 +40,46 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG1B_RTCC RTCC
  * @{
  * @brief EFM32PG1B_RTCC Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** RTCC Register Declaration */
 typedef struct {
-  __IOM uint32_t   CTRL;          /**< Control Register  */
-  __IOM uint32_t   PRECNT;        /**< Pre-Counter Value Register  */
-  __IOM uint32_t   CNT;           /**< Counter Value Register  */
-  __IM uint32_t    COMBCNT;       /**< Combined Pre-Counter and Counter Value Register  */
-  __IOM uint32_t   TIME;          /**< Time of Day Register  */
-  __IOM uint32_t   DATE;          /**< Date Register  */
-  __IM uint32_t    IF;            /**< RTCC Interrupt Flags  */
-  __IOM uint32_t   IFS;           /**< Interrupt Flag Set Register  */
-  __IOM uint32_t   IFC;           /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t   IEN;           /**< Interrupt Enable Register  */
-  __IM uint32_t    STATUS;        /**< Status Register  */
-  __IOM uint32_t   CMD;           /**< Command Register  */
-  __IM uint32_t    SYNCBUSY;      /**< Synchronization Busy Register  */
-  __IOM uint32_t   POWERDOWN;     /**< Retention RAM Power-down Register  */
-  __IOM uint32_t   LOCK;          /**< Configuration Lock Register  */
-  __IOM uint32_t   EM4WUEN;       /**< Wake Up Enable  */
+  __IOM uint32_t   CTRL;           /**< Control Register  */
+  __IOM uint32_t   PRECNT;         /**< Pre-Counter Value Register  */
+  __IOM uint32_t   CNT;            /**< Counter Value Register  */
+  __IM uint32_t    COMBCNT;        /**< Combined Pre-Counter and Counter Value Register  */
+  __IOM uint32_t   TIME;           /**< Time of Day Register  */
+  __IOM uint32_t   DATE;           /**< Date Register  */
+  __IM uint32_t    IF;             /**< RTCC Interrupt Flags  */
+  __IOM uint32_t   IFS;            /**< Interrupt Flag Set Register  */
+  __IOM uint32_t   IFC;            /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t   IEN;            /**< Interrupt Enable Register  */
+  __IM uint32_t    STATUS;         /**< Status Register  */
+  __IOM uint32_t   CMD;            /**< Command Register  */
+  __IM uint32_t    SYNCBUSY;       /**< Synchronization Busy Register  */
+  __IOM uint32_t   POWERDOWN;      /**< Retention RAM Power-down Register  */
+  __IOM uint32_t   LOCK;           /**< Configuration Lock Register  */
+  __IOM uint32_t   EM4WUEN;        /**< Wake Up Enable  */
 
-  RTCC_CC_TypeDef  CC[3];         /**< Capture/Compare Channel */
+  RTCC_CC_TypeDef  CC[3U];         /**< Capture/Compare Channel */
 
-  uint32_t         RESERVED0[37]; /**< Reserved registers */
-  RTCC_RET_TypeDef RET[32];       /**< RetentionReg */
-} RTCC_TypeDef;                   /** @} */
+  uint32_t         RESERVED0[37U]; /**< Reserved registers */
+  RTCC_RET_TypeDef RET[32U];       /**< RetentionReg */
+} RTCC_TypeDef;                    /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG1B_RTCC
  * @{
  * @defgroup EFM32PG1B_RTCC_BitFields  RTCC Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for RTCC CTRL */
 #define _RTCC_CTRL_RESETVALUE               0x00000000UL                            /**< Default value for RTCC_CTRL */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_rtcc_cc.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_rtcc_cc.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg1b_rtcc_cc.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG1B_RTCC_CC register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,14 +40,14 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief RTCC_CC RTCC CC Register
  * @ingroup EFM32PG1B_RTCC
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t CTRL; /**< CC Channel Control Register  */
   __IOM uint32_t CCV;  /**< Capture/Compare Value Register  */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_rtcc_ret.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_rtcc_ret.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg1b_rtcc_ret.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG1B_RTCC_RET register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,14 +40,14 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief RTCC_RET RTCC RET Register
  * @ingroup EFM32PG1B_RTCC
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t REG; /**< Retention Register  */
 } RTCC_RET_TypeDef;

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_timer.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_timer.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg1b_timer.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG1B_TIMER register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,52 +40,52 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG1B_TIMER TIMER
  * @{
  * @brief EFM32PG1B_TIMER Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** TIMER Register Declaration */
 typedef struct {
-  __IOM uint32_t   CTRL;         /**< Control Register  */
-  __IOM uint32_t   CMD;          /**< Command Register  */
-  __IM uint32_t    STATUS;       /**< Status Register  */
-  __IM uint32_t    IF;           /**< Interrupt Flag Register  */
-  __IOM uint32_t   IFS;          /**< Interrupt Flag Set Register  */
-  __IOM uint32_t   IFC;          /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t   IEN;          /**< Interrupt Enable Register  */
-  __IOM uint32_t   TOP;          /**< Counter Top Value Register  */
-  __IOM uint32_t   TOPB;         /**< Counter Top Value Buffer Register  */
-  __IOM uint32_t   CNT;          /**< Counter Value Register  */
-  uint32_t         RESERVED0[1]; /**< Reserved for future use **/
-  __IOM uint32_t   LOCK;         /**< TIMER Configuration Lock Register  */
-  __IOM uint32_t   ROUTEPEN;     /**< I/O Routing Pin Enable Register  */
-  __IOM uint32_t   ROUTELOC0;    /**< I/O Routing Location Register  */
-  uint32_t         RESERVED1[1]; /**< Reserved for future use **/
-  __IOM uint32_t   ROUTELOC2;    /**< I/O Routing Location Register  */
+  __IOM uint32_t   CTRL;          /**< Control Register  */
+  __IOM uint32_t   CMD;           /**< Command Register  */
+  __IM uint32_t    STATUS;        /**< Status Register  */
+  __IM uint32_t    IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t   IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t   IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t   IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t   TOP;           /**< Counter Top Value Register  */
+  __IOM uint32_t   TOPB;          /**< Counter Top Value Buffer Register  */
+  __IOM uint32_t   CNT;           /**< Counter Value Register  */
+  uint32_t         RESERVED0[1U]; /**< Reserved for future use **/
+  __IOM uint32_t   LOCK;          /**< TIMER Configuration Lock Register  */
+  __IOM uint32_t   ROUTEPEN;      /**< I/O Routing Pin Enable Register  */
+  __IOM uint32_t   ROUTELOC0;     /**< I/O Routing Location Register  */
+  uint32_t         RESERVED1[1U]; /**< Reserved for future use **/
+  __IOM uint32_t   ROUTELOC2;     /**< I/O Routing Location Register  */
 
-  uint32_t         RESERVED2[8]; /**< Reserved registers */
-  TIMER_CC_TypeDef CC[4];        /**< Compare/Capture Channel */
+  uint32_t         RESERVED2[8U]; /**< Reserved registers */
+  TIMER_CC_TypeDef CC[4U];        /**< Compare/Capture Channel */
 
-  __IOM uint32_t   DTCTRL;       /**< DTI Control Register  */
-  __IOM uint32_t   DTTIME;       /**< DTI Time Control Register  */
-  __IOM uint32_t   DTFC;         /**< DTI Fault Configuration Register  */
-  __IOM uint32_t   DTOGEN;       /**< DTI Output Generation Enable Register  */
-  __IM uint32_t    DTFAULT;      /**< DTI Fault Register  */
-  __IOM uint32_t   DTFAULTC;     /**< DTI Fault Clear Register  */
-  __IOM uint32_t   DTLOCK;       /**< DTI Configuration Lock Register  */
-} TIMER_TypeDef;                 /** @} */
+  __IOM uint32_t   DTCTRL;        /**< DTI Control Register  */
+  __IOM uint32_t   DTTIME;        /**< DTI Time Control Register  */
+  __IOM uint32_t   DTFC;          /**< DTI Fault Configuration Register  */
+  __IOM uint32_t   DTOGEN;        /**< DTI Output Generation Enable Register  */
+  __IM uint32_t    DTFAULT;       /**< DTI Fault Register  */
+  __IOM uint32_t   DTFAULTC;      /**< DTI Fault Clear Register  */
+  __IOM uint32_t   DTLOCK;        /**< DTI Configuration Lock Register  */
+} TIMER_TypeDef;                  /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG1B_TIMER
  * @{
  * @defgroup EFM32PG1B_TIMER_BitFields  TIMER Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for TIMER CTRL */
 #define _TIMER_CTRL_RESETVALUE                     0x00000000UL                             /**< Default value for TIMER_CTRL */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_timer_cc.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_timer_cc.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg1b_timer_cc.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG1B_TIMER_CC register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,14 +40,14 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief TIMER_CC TIMER CC Register
  * @ingroup EFM32PG1B_TIMER
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t CTRL; /**< CC Channel Control Register  */
   __IOM uint32_t CCV;  /**< CC Channel Value Register  */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_usart.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_usart.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg1b_usart.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG1B_USART register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,57 +40,57 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG1B_USART USART
  * @{
  * @brief EFM32PG1B_USART Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** USART Register Declaration */
 typedef struct {
-  __IOM uint32_t CTRL;         /**< Control Register  */
-  __IOM uint32_t FRAME;        /**< USART Frame Format Register  */
-  __IOM uint32_t TRIGCTRL;     /**< USART Trigger Control Register  */
-  __IOM uint32_t CMD;          /**< Command Register  */
-  __IM uint32_t  STATUS;       /**< USART Status Register  */
-  __IOM uint32_t CLKDIV;       /**< Clock Control Register  */
-  __IM uint32_t  RXDATAX;      /**< RX Buffer Data Extended Register  */
-  __IM uint32_t  RXDATA;       /**< RX Buffer Data Register  */
-  __IM uint32_t  RXDOUBLEX;    /**< RX Buffer Double Data Extended Register  */
-  __IM uint32_t  RXDOUBLE;     /**< RX FIFO Double Data Register  */
-  __IM uint32_t  RXDATAXP;     /**< RX Buffer Data Extended Peek Register  */
-  __IM uint32_t  RXDOUBLEXP;   /**< RX Buffer Double Data Extended Peek Register  */
-  __IOM uint32_t TXDATAX;      /**< TX Buffer Data Extended Register  */
-  __IOM uint32_t TXDATA;       /**< TX Buffer Data Register  */
-  __IOM uint32_t TXDOUBLEX;    /**< TX Buffer Double Data Extended Register  */
-  __IOM uint32_t TXDOUBLE;     /**< TX Buffer Double Data Register  */
-  __IM uint32_t  IF;           /**< Interrupt Flag Register  */
-  __IOM uint32_t IFS;          /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;          /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t IEN;          /**< Interrupt Enable Register  */
-  __IOM uint32_t IRCTRL;       /**< IrDA Control Register  */
-  uint32_t       RESERVED0[1]; /**< Reserved for future use **/
-  __IOM uint32_t INPUT;        /**< USART Input Register  */
-  __IOM uint32_t I2SCTRL;      /**< I2S Control Register  */
-  __IOM uint32_t TIMING;       /**< Timing Register  */
-  __IOM uint32_t CTRLX;        /**< Control Register Extended  */
-  __IOM uint32_t TIMECMP0;     /**< Used to Generate Interrupts and Various Delays  */
-  __IOM uint32_t TIMECMP1;     /**< Used to Generate Interrupts and Various Delays  */
-  __IOM uint32_t TIMECMP2;     /**< Used to Generate Interrupts and Various Delays  */
-  __IOM uint32_t ROUTEPEN;     /**< I/O Routing Pin Enable Register  */
-  __IOM uint32_t ROUTELOC0;    /**< I/O Routing Location Register  */
-  __IOM uint32_t ROUTELOC1;    /**< I/O Routing Location Register  */
-} USART_TypeDef;               /** @} */
+  __IOM uint32_t CTRL;          /**< Control Register  */
+  __IOM uint32_t FRAME;         /**< USART Frame Format Register  */
+  __IOM uint32_t TRIGCTRL;      /**< USART Trigger Control Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IM uint32_t  STATUS;        /**< USART Status Register  */
+  __IOM uint32_t CLKDIV;        /**< Clock Control Register  */
+  __IM uint32_t  RXDATAX;       /**< RX Buffer Data Extended Register  */
+  __IM uint32_t  RXDATA;        /**< RX Buffer Data Register  */
+  __IM uint32_t  RXDOUBLEX;     /**< RX Buffer Double Data Extended Register  */
+  __IM uint32_t  RXDOUBLE;      /**< RX FIFO Double Data Register  */
+  __IM uint32_t  RXDATAXP;      /**< RX Buffer Data Extended Peek Register  */
+  __IM uint32_t  RXDOUBLEXP;    /**< RX Buffer Double Data Extended Peek Register  */
+  __IOM uint32_t TXDATAX;       /**< TX Buffer Data Extended Register  */
+  __IOM uint32_t TXDATA;        /**< TX Buffer Data Register  */
+  __IOM uint32_t TXDOUBLEX;     /**< TX Buffer Double Data Extended Register  */
+  __IOM uint32_t TXDOUBLE;      /**< TX Buffer Double Data Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t IRCTRL;        /**< IrDA Control Register  */
+  uint32_t       RESERVED0[1U]; /**< Reserved for future use **/
+  __IOM uint32_t INPUT;         /**< USART Input Register  */
+  __IOM uint32_t I2SCTRL;       /**< I2S Control Register  */
+  __IOM uint32_t TIMING;        /**< Timing Register  */
+  __IOM uint32_t CTRLX;         /**< Control Register Extended  */
+  __IOM uint32_t TIMECMP0;      /**< Used to Generate Interrupts and Various Delays  */
+  __IOM uint32_t TIMECMP1;      /**< Used to Generate Interrupts and Various Delays  */
+  __IOM uint32_t TIMECMP2;      /**< Used to Generate Interrupts and Various Delays  */
+  __IOM uint32_t ROUTEPEN;      /**< I/O Routing Pin Enable Register  */
+  __IOM uint32_t ROUTELOC0;     /**< I/O Routing Location Register  */
+  __IOM uint32_t ROUTELOC1;     /**< I/O Routing Location Register  */
+} USART_TypeDef;                /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG1B_USART
  * @{
  * @defgroup EFM32PG1B_USART_BitFields  USART Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for USART CTRL */
 #define _USART_CTRL_RESETVALUE                  0x00000000UL                             /**< Default value for USART_CTRL */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_wdog.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_wdog.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg1b_wdog.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG1B_WDOG register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,37 +40,37 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFM32PG1B_WDOG WDOG
  * @{
  * @brief EFM32PG1B_WDOG Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** WDOG Register Declaration */
 typedef struct {
-  __IOM uint32_t   CTRL;         /**< Control Register  */
-  __IOM uint32_t   CMD;          /**< Command Register  */
+  __IOM uint32_t   CTRL;          /**< Control Register  */
+  __IOM uint32_t   CMD;           /**< Command Register  */
 
-  __IM uint32_t    SYNCBUSY;     /**< Synchronization Busy Register  */
+  __IM uint32_t    SYNCBUSY;      /**< Synchronization Busy Register  */
 
-  WDOG_PCH_TypeDef PCH[2];       /**< PCH */
+  WDOG_PCH_TypeDef PCH[2U];       /**< PCH */
 
-  uint32_t         RESERVED0[2]; /**< Reserved for future use **/
-  __IM uint32_t    IF;           /**< Watchdog Interrupt Flags  */
-  __IOM uint32_t   IFS;          /**< Interrupt Flag Set Register  */
-  __IOM uint32_t   IFC;          /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t   IEN;          /**< Interrupt Enable Register  */
-} WDOG_TypeDef;                  /** @} */
+  uint32_t         RESERVED0[2U]; /**< Reserved for future use **/
+  __IM uint32_t    IF;            /**< Watchdog Interrupt Flags  */
+  __IOM uint32_t   IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t   IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t   IEN;           /**< Interrupt Enable Register  */
+} WDOG_TypeDef;                   /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFM32PG1B_WDOG
  * @{
  * @defgroup EFM32PG1B_WDOG_BitFields  WDOG Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for WDOG CTRL */
 #define _WDOG_CTRL_RESETVALUE                     0x00000F00UL                          /**< Default value for WDOG_CTRL */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_wdog_pch.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_wdog_pch.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efm32pg1b_wdog_pch.h
+/***************************************************************************//**
+ * @file
  * @brief EFM32PG1B_WDOG_PCH register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,14 +40,14 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief WDOG_PCH WDOG PCH Register
  * @ingroup EFM32PG1B_WDOG
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t PRSCTRL; /**< PRS Control Register  */
 } WDOG_PCH_TypeDef;

--- a/cpu/efm32/families/efm32pg1b/include/vendor/em_device.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/em_device.h
@@ -1,5 +1,5 @@
-/**************************************************************************//**
- * @file em_device.h
+/***************************************************************************//**
+ * @file
  * @brief CMSIS Cortex-M Peripheral Access Layer for Silicon Laboratories
  *        microcontroller devices
  *
@@ -9,37 +9,35 @@
  * @verbatim
  * Example: Add "-DEFM32G890F128" to your build options, to define part
  *          Add "#include "em_device.h" to your source files
-
- *
  * @endverbatim
- * @version 5.4.0
- ******************************************************************************
+ *
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {

--- a/cpu/efm32/families/efm32pg1b/include/vendor/system_efm32pg1b.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/system_efm32pg1b.h
@@ -1,34 +1,33 @@
 /***************************************************************************//**
- * @file system_efm32pg1b.h
+ * @file
  * @brief CMSIS Cortex-M3/M4 System Layer for EFM32 devices.
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifndef SYSTEM_EFM32_H
 #define SYSTEM_EFM32_H
@@ -39,14 +38,14 @@ extern "C" {
 
 #include <stdint.h>
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup Parts
  * @{
- *****************************************************************************/
-/**************************************************************************//**
+ ******************************************************************************/
+/***************************************************************************//**
  * @addtogroup EFM32 EFM32
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /*******************************************************************************
  **************************   GLOBAL VARIABLES   *******************************
@@ -100,7 +99,7 @@ void FPUEH_IRQHandler(void);        /**< FPUEH IRQ Handler */
 
 uint32_t SystemCoreClockGet(void);
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @brief
  *   Update CMSIS SystemCoreClock variable.
  *
@@ -113,7 +112,7 @@ uint32_t SystemCoreClockGet(void);
  *   API, this variable will be kept updated. This function is only provided
  *   for CMSIS compliance and if a user modifies the the core clock outside
  *   the CMU API.
- *****************************************************************************/
+ ******************************************************************************/
 static __INLINE void SystemCoreClockUpdate(void)
 {
   (void)SystemCoreClockGet();

--- a/cpu/efm32/families/efm32pg1b/system.c
+++ b/cpu/efm32/families/efm32pg1b/system.c
@@ -1,34 +1,33 @@
 /***************************************************************************//**
- * @file system_efm32pg1b.c
+ * @file
  * @brief CMSIS Cortex-M3/M4 System Layer for EFM32 devices.
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #include <stdint.h>
 #include "em_device.h"
@@ -70,7 +69,7 @@
 #endif
 
 /* Do not define variable if HF crystal oscillator not present */
-#if (EFM32_HFXO_FREQ > 0UL)
+#if (EFM32_HFXO_FREQ > 0U)
 /** @cond DO_NOT_INCLUDE_WITH_DOXYGEN */
 /** System HFXO clock. */
 static uint32_t SystemHFXOClock = EFM32_HFXO_FREQ;
@@ -82,7 +81,7 @@ static uint32_t SystemHFXOClock = EFM32_HFXO_FREQ;
 #define EFM32_LFXO_FREQ (EFM32_LFRCO_FREQ)
 #endif
 /* Do not define variable if LF crystal oscillator not present */
-#if (EFM32_LFXO_FREQ > 0UL)
+#if (EFM32_LFXO_FREQ > 0U)
 /** @cond DO_NOT_INCLUDE_WITH_DOXYGEN */
 /** System LFXO clock. */
 static uint32_t SystemLFXOClock = EFM32_LFXO_FREQ;
@@ -117,6 +116,13 @@ uint32_t SystemHfrcoFreq = EFM32_HFRCO_STARTUP_FREQ;
 /*******************************************************************************
  **************************   GLOBAL FUNCTIONS   *******************************
  ******************************************************************************/
+
+#if defined(__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+#if defined(__ICCARM__)    /* IAR requires the __vector_table symbol */
+#define __Vectors    __vector_table
+#endif
+extern uint32_t __Vectors;
+#endif
 
 /***************************************************************************//**
  * @brief
@@ -186,12 +192,12 @@ uint32_t SystemHFClockGet(void)
 
   switch (CMU->HFCLKSTATUS & _CMU_HFCLKSTATUS_SELECTED_MASK) {
     case CMU_HFCLKSTATUS_SELECTED_LFXO:
-#if (EFM32_LFXO_FREQ > 0)
+#if (EFM32_LFXO_FREQ > 0U)
       ret = SystemLFXOClock;
 #else
       /* We should not get here, since core should not be clocked. May */
       /* be caused by a misconfiguration though. */
-      ret = 0;
+      ret = 0U;
 #endif
       break;
 
@@ -200,12 +206,12 @@ uint32_t SystemHFClockGet(void)
       break;
 
     case CMU_HFCLKSTATUS_SELECTED_HFXO:
-#if (EFM32_HFXO_FREQ > 0)
+#if (EFM32_HFXO_FREQ > 0U)
       ret = SystemHFXOClock;
 #else
       /* We should not get here, since core should not be clocked. May */
       /* be caused by a misconfiguration though. */
-      ret = 0;
+      ret = 0U;
 #endif
       break;
 
@@ -218,7 +224,7 @@ uint32_t SystemHFClockGet(void)
                       >> _CMU_HFPRESC_PRESC_SHIFT));
 }
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @brief
  *   Get high frequency crystal oscillator clock frequency for target system.
  *
@@ -227,18 +233,18 @@ uint32_t SystemHFClockGet(void)
  *
  * @return
  *   HFXO frequency in Hz.
- *****************************************************************************/
+ ******************************************************************************/
 uint32_t SystemHFXOClockGet(void)
 {
   /* External crystal oscillator present? */
-#if (EFM32_HFXO_FREQ > 0)
+#if (EFM32_HFXO_FREQ > 0U)
   return SystemHFXOClock;
 #else
-  return 0;
+  return 0U;
 #endif
 }
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @brief
  *   Set high frequency crystal oscillator clock frequency for target system.
  *
@@ -252,11 +258,11 @@ uint32_t SystemHFXOClockGet(void)
  *
  * @param[in] freq
  *   HFXO frequency in Hz used for target.
- *****************************************************************************/
+ ******************************************************************************/
 void SystemHFXOClockSet(uint32_t freq)
 {
   /* External crystal oscillator present? */
-#if (EFM32_HFXO_FREQ > 0)
+#if (EFM32_HFXO_FREQ > 0U)
   SystemHFXOClock = freq;
 
   /* Update core clock frequency if HFXO is used to clock core */
@@ -270,7 +276,7 @@ void SystemHFXOClockSet(uint32_t freq)
 #endif
 }
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @brief
  *   Initialize the system.
  *
@@ -281,17 +287,25 @@ void SystemHFXOClockSet(uint32_t freq)
  *   This function is invoked during system init, before the main() routine
  *   and any data has been initialized. For this reason, it cannot do any
  *   initialization of variables etc.
- *****************************************************************************/
+ ******************************************************************************/
 void SystemInit(void)
 {
-#if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
+#if defined(__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  SCB->VTOR = (uint32_t)&__Vectors;
+#endif
+
+#if (__FPU_PRESENT == 1U) && (__FPU_USED == 1U)
   /* Set floating point coprosessor access mode. */
-  SCB->CPACR |= ((3UL << 10 * 2)                      /* set CP10 Full Access */
-                 | (3UL << 11 * 2));                  /* set CP11 Full Access */
+  SCB->CPACR |= ((3UL << 10 * 2)                    /* set CP10 Full Access */
+                 | (3UL << 11 * 2));                /* set CP11 Full Access */
+#endif
+
+#if defined(UNALIGNED_SUPPORT_DISABLE)
+  SCB->CCR |= SCB_CCR_UNALIGN_TRP_Msk;
 #endif
 }
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @brief
  *   Get low frequency RC oscillator clock frequency for target system.
  *
@@ -300,7 +314,7 @@ void SystemInit(void)
  *
  * @return
  *   LFRCO frequency in Hz.
- *****************************************************************************/
+ ******************************************************************************/
 uint32_t SystemLFRCOClockGet(void)
 {
   /* Currently we assume that this frequency is properly tuned during */
@@ -309,7 +323,7 @@ uint32_t SystemLFRCOClockGet(void)
   return EFM32_LFRCO_FREQ;
 }
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @brief
  *   Get ultra low frequency RC oscillator clock frequency for target system.
  *
@@ -318,14 +332,14 @@ uint32_t SystemLFRCOClockGet(void)
  *
  * @return
  *   ULFRCO frequency in Hz.
- *****************************************************************************/
+ ******************************************************************************/
 uint32_t SystemULFRCOClockGet(void)
 {
   /* The ULFRCO frequency is not tuned, and can be very inaccurate */
   return EFM32_ULFRCO_FREQ;
 }
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @brief
  *   Get low frequency crystal oscillator clock frequency for target system.
  *
@@ -334,18 +348,18 @@ uint32_t SystemULFRCOClockGet(void)
  *
  * @return
  *   LFXO frequency in Hz.
- *****************************************************************************/
+ ******************************************************************************/
 uint32_t SystemLFXOClockGet(void)
 {
   /* External crystal oscillator present? */
-#if (EFM32_LFXO_FREQ > 0)
+#if (EFM32_LFXO_FREQ > 0U)
   return SystemLFXOClock;
 #else
-  return 0;
+  return 0U;
 #endif
 }
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @brief
  *   Set low frequency crystal oscillator clock frequency for target system.
  *
@@ -359,11 +373,11 @@ uint32_t SystemLFXOClockGet(void)
  *
  * @param[in] freq
  *   LFXO frequency in Hz used for target.
- *****************************************************************************/
+ ******************************************************************************/
 void SystemLFXOClockSet(uint32_t freq)
 {
   /* External crystal oscillator present? */
-#if (EFM32_LFXO_FREQ > 0)
+#if (EFM32_LFXO_FREQ > 0U)
   SystemLFXOClock = freq;
 
   /* Update core clock frequency if LFXO is used to clock core */

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p332f1024gl125.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p332f1024gl125.h
@@ -1,35 +1,34 @@
-/**************************************************************************//**
- * @file efr32mg12p332f1024gl125.h
+/***************************************************************************//**
+ * @file
  * @brief CMSIS Cortex-M Peripheral Access Layer Header File
  *        for EFR32MG12P332F1024GL125
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #if defined(__ICCARM__)
 #pragma system_include       /* Treat file as system include file. */
@@ -44,15 +43,15 @@
 extern "C" {
 #endif
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup Parts
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFR32MG12P332F1024GL125 EFR32MG12P332F1024GL125
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /** Interrupt Number Definition */
 typedef enum IRQn{
@@ -70,8 +69,14 @@ typedef enum IRQn{
 /******  EFR32MG12P Peripheral Interrupt Numbers ********************************************/
 
   EMU_IRQn              = 0,  /*!< 16+0 EFR32 EMU Interrupt */
+  FRC_PRI_IRQn          = 1,  /*!< 16+1 EFR32 FRC_PRI Interrupt */
   WDOG0_IRQn            = 2,  /*!< 16+2 EFR32 WDOG0 Interrupt */
   WDOG1_IRQn            = 3,  /*!< 16+3 EFR32 WDOG1 Interrupt */
+  FRC_IRQn              = 4,  /*!< 16+4 EFR32 FRC Interrupt */
+  MODEM_IRQn            = 5,  /*!< 16+5 EFR32 MODEM Interrupt */
+  RAC_SEQ_IRQn          = 6,  /*!< 16+6 EFR32 RAC_SEQ Interrupt */
+  RAC_RSM_IRQn          = 7,  /*!< 16+7 EFR32 RAC_RSM Interrupt */
+  BUFC_IRQn             = 8,  /*!< 16+8 EFR32 BUFC Interrupt */
   LDMA_IRQn             = 9,  /*!< 16+9 EFR32 LDMA Interrupt */
   GPIO_EVEN_IRQn        = 10, /*!< 16+10 EFR32 GPIO_EVEN Interrupt */
   TIMER0_IRQn           = 11, /*!< 16+11 EFR32 TIMER0 Interrupt */
@@ -91,8 +96,12 @@ typedef enum IRQn{
   MSC_IRQn              = 25, /*!< 16+25 EFR32 MSC Interrupt */
   CRYPTO0_IRQn          = 26, /*!< 16+26 EFR32 CRYPTO0 Interrupt */
   LETIMER0_IRQn         = 27, /*!< 16+27 EFR32 LETIMER0 Interrupt */
+  AGC_IRQn              = 28, /*!< 16+28 EFR32 AGC Interrupt */
+  PROTIMER_IRQn         = 29, /*!< 16+29 EFR32 PROTIMER Interrupt */
   RTCC_IRQn             = 30, /*!< 16+30 EFR32 RTCC Interrupt */
+  SYNTH_IRQn            = 31, /*!< 16+31 EFR32 SYNTH Interrupt */
   CRYOTIMER_IRQn        = 32, /*!< 16+32 EFR32 CRYOTIMER Interrupt */
+  RFSENSE_IRQn          = 33, /*!< 16+33 EFR32 RFSENSE Interrupt */
   FPUEH_IRQn            = 34, /*!< 16+34 EFR32 FPUEH Interrupt */
   SMU_IRQn              = 35, /*!< 16+35 EFR32 SMU Interrupt */
   WTIMER0_IRQn          = 36, /*!< 16+36 EFR32 WTIMER0 Interrupt */
@@ -113,23 +122,23 @@ typedef enum IRQn{
 
 #define CRYPTO_IRQn               CRYPTO0_IRQn /*!< Alias for CRYPTO0_IRQn */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFR32MG12P332F1024GL125_Core Core
  * @{
  * @brief Processor and Core Peripheral Section
- *****************************************************************************/
-#define __MPU_PRESENT             1 /**< Presence of MPU  */
-#define __FPU_PRESENT             1 /**< Presence of FPU  */
-#define __VTOR_PRESENT            1 /**< Presence of VTOR register in SCB */
-#define __NVIC_PRIO_BITS          3 /**< NVIC interrupt priority bits */
-#define __Vendor_SysTickConfig    0 /**< Is 1 if different SysTick counter is used */
+ ******************************************************************************/
+#define __MPU_PRESENT             1U /**< Presence of MPU  */
+#define __FPU_PRESENT             1U /**< Presence of FPU  */
+#define __VTOR_PRESENT            1U /**< Presence of VTOR register in SCB */
+#define __NVIC_PRIO_BITS          3U /**< NVIC interrupt priority bits */
+#define __Vendor_SysTickConfig    0U /**< Is 1 if different SysTick counter is used */
 
 /** @} End of group EFR32MG12P332F1024GL125_Core */
 
-/**************************************************************************//**
-* @defgroup EFR32MG12P332F1024GL125_Part Part
-* @{
-******************************************************************************/
+/***************************************************************************//**
+ * @defgroup EFR32MG12P332F1024GL125_Part Part
+ * @{
+ ******************************************************************************/
 
 /** Part family */
 #define _EFR32_MIGHTY_FAMILY                    1                               /**< MIGHTY Gecko RF SoC Family  */
@@ -245,7 +254,7 @@ typedef enum IRQn{
 #define FLASH_PAGE_SIZE            2048U          /**< Flash Memory page size (interleaving off) */
 #define SRAM_BASE                  (0x20000000UL) /**< SRAM Base Address */
 #define SRAM_SIZE                  (0x00040000UL) /**< Available SRAM Memory */
-#define __CM4_REV                  0x001          /**< Cortex-M4 Core revision r0p1 */
+#define __CM4_REV                  0x0001U        /**< Cortex-M4 Core revision r0p1 */
 #define PRS_CHAN_COUNT             12             /**< Number of PRS channels */
 #define DMA_CHAN_COUNT             8              /**< Number of DMA channels */
 #define EXT_IRQ_COUNT              51             /**< Number of External (NVIC) interrupts */
@@ -327,11 +336,11 @@ typedef enum IRQn{
 
 /** @} End of group EFR32MG12P332F1024GL125_Part */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFR32MG12P332F1024GL125_Peripheral_TypeDefs Peripheral TypeDefs
  * @{
  * @brief Device Specific Peripheral Register Structures
- *****************************************************************************/
+ ******************************************************************************/
 
 #include "efr32mg12p_msc.h"
 #include "efr32mg12p_emu.h"
@@ -378,10 +387,10 @@ typedef enum IRQn{
 
 /** @} End of group EFR32MG12P332F1024GL125_Peripheral_TypeDefs  */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFR32MG12P332F1024GL125_Peripheral_Base Peripheral Memory Map
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 #define MSC_BASE          (0x400E0000UL) /**< MSC base address  */
 #define EMU_BASE          (0x400E3000UL) /**< EMU base address  */
@@ -431,10 +440,10 @@ typedef enum IRQn{
 
 /** @} End of group EFR32MG12P332F1024GL125_Peripheral_Base */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFR32MG12P332F1024GL125_Peripheral_Declaration Peripheral Declarations
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 #define MSC          ((MSC_TypeDef *) MSC_BASE)             /**< MSC base pointer */
 #define EMU          ((EMU_TypeDef *) EMU_BASE)             /**< EMU base pointer */
@@ -482,10 +491,10 @@ typedef enum IRQn{
 
 /** @} End of group EFR32MG12P332F1024GL125_Peripheral_Declaration */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFR32MG12P332F1024GL125_Peripheral_Offsets Peripheral Offsets
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 #define CRYPTO_OFFSET     0x400 /**< Offset in bytes between CRYPTO instances */
 #define TIMER_OFFSET      0x400 /**< Offset in bytes between TIMER instances */
@@ -504,20 +513,20 @@ typedef enum IRQn{
 
 /** @} End of group EFR32MG12P332F1024GL125_Peripheral_Offsets */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFR32MG12P332F1024GL125_BitFields Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 #include "efr32mg12p_prs_signals.h"
 #include "efr32mg12p_dmareq.h"
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG12P332F1024GL125_WTIMER
  * @{
  * @defgroup EFR32MG12P332F1024GL125_WTIMER_BitFields  WTIMER Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for WTIMER CTRL */
 #define _WTIMER_CTRL_RESETVALUE                     0x00000000UL                              /**< Default value for WTIMER_CTRL */
@@ -2018,10 +2027,10 @@ typedef enum IRQn{
 /** @} */
 /** @} End of group EFR32MG12P332F1024GL125_WTIMER */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFR32MG12P332F1024GL125_UNLOCK Unlock Codes
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 #define MSC_UNLOCK_CODE      0x1B71 /**< MSC unlock code */
 #define EMU_UNLOCK_CODE      0xADE8 /**< EMU unlock code */
 #define RMU_UNLOCK_CODE      0xE084 /**< RMU unlock code */

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_acmp.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_acmp.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg12p_acmp.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG12P_ACMP register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG12P_ACMP ACMP
  * @{
  * @brief EFR32MG12P_ACMP Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** ACMP Register Declaration */
 typedef struct {
   __IOM uint32_t CTRL;          /**< Control Register  */
@@ -59,24 +58,24 @@ typedef struct {
   __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
   __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
   __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
-  uint32_t       RESERVED0[1];  /**< Reserved for future use **/
+  uint32_t       RESERVED0[1U]; /**< Reserved for future use **/
   __IM uint32_t  APORTREQ;      /**< APORT Request Status Register  */
   __IM uint32_t  APORTCONFLICT; /**< APORT Conflict Status Register  */
   __IOM uint32_t HYSTERESIS0;   /**< Hysteresis 0 Register  */
   __IOM uint32_t HYSTERESIS1;   /**< Hysteresis 1 Register  */
 
-  uint32_t       RESERVED1[4];  /**< Reserved for future use **/
+  uint32_t       RESERVED1[4U]; /**< Reserved for future use **/
   __IOM uint32_t ROUTEPEN;      /**< I/O Routing Pine Enable Register  */
   __IOM uint32_t ROUTELOC0;     /**< I/O Routing Location Register  */
   __IOM uint32_t EXTIFCTRL;     /**< External Override Interface Control  */
 } ACMP_TypeDef;                 /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG12P_ACMP
  * @{
  * @defgroup EFR32MG12P_ACMP_BitFields  ACMP Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for ACMP CTRL */
 #define _ACMP_CTRL_RESETVALUE                          0x07000000UL                               /**< Default value for ACMP_CTRL */

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_adc.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_adc.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg12p_adc.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG12P_ADC register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,19 +40,19 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG12P_ADC ADC
  * @{
  * @brief EFR32MG12P_ADC Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** ADC Register Declaration */
 typedef struct {
   __IOM uint32_t CTRL;            /**< Control Register  */
-  uint32_t       RESERVED0[1];    /**< Reserved for future use **/
+  uint32_t       RESERVED0[1U];   /**< Reserved for future use **/
   __IOM uint32_t CMD;             /**< Command Register  */
   __IM uint32_t  STATUS;          /**< Status Register  */
   __IOM uint32_t SINGLECTRL;      /**< Single Channel Control Register  */
@@ -74,11 +73,11 @@ typedef struct {
   __IM uint32_t  SCANDATA;        /**< Scan Conversion Result Data  */
   __IM uint32_t  SINGLEDATAP;     /**< Single Conversion Result Data Peek Register  */
   __IM uint32_t  SCANDATAP;       /**< Scan Sequence Result Data Peek Register  */
-  uint32_t       RESERVED1[4];    /**< Reserved for future use **/
+  uint32_t       RESERVED1[4U];   /**< Reserved for future use **/
   __IM uint32_t  SCANDATAX;       /**< Scan Sequence Result Data + Data Source Register  */
   __IM uint32_t  SCANDATAXP;      /**< Scan Sequence Result Data + Data Source Peek Register  */
 
-  uint32_t       RESERVED2[3];    /**< Reserved for future use **/
+  uint32_t       RESERVED2[3U];   /**< Reserved for future use **/
   __IM uint32_t  APORTREQ;        /**< APORT Request Status Register  */
   __IM uint32_t  APORTCONFLICT;   /**< APORT Conflict Status Register  */
   __IM uint32_t  SINGLEFIFOCOUNT; /**< Single FIFO Count Register  */
@@ -88,12 +87,12 @@ typedef struct {
   __IOM uint32_t APORTMASTERDIS;  /**< APORT Bus Master Disable Register  */
 } ADC_TypeDef;                    /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG12P_ADC
  * @{
  * @defgroup EFR32MG12P_ADC_BitFields  ADC Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for ADC CTRL */
 #define _ADC_CTRL_RESETVALUE                               0x001F0000UL                                  /**< Default value for ADC_CTRL */
@@ -499,12 +498,12 @@ typedef struct {
 #define _ADC_SINGLECTRL_POSSEL_APORT4YCH30                 0x0000009EUL                               /**< Mode APORT4YCH30 for ADC_SINGLECTRL */
 #define _ADC_SINGLECTRL_POSSEL_APORT4XCH31                 0x0000009FUL                               /**< Mode APORT4XCH31 for ADC_SINGLECTRL */
 #define _ADC_SINGLECTRL_POSSEL_AVDD                        0x000000E0UL                               /**< Mode AVDD for ADC_SINGLECTRL */
-#define _ADC_SINGLECTRL_POSSEL_BU                          0x000000E1UL                               /**< Mode BU for ADC_SINGLECTRL */
-#define _ADC_SINGLECTRL_POSSEL_AREG                        0x000000E2UL                               /**< Mode AREG for ADC_SINGLECTRL */
-#define _ADC_SINGLECTRL_POSSEL_VREGOUTPA                   0x000000E3UL                               /**< Mode VREGOUTPA for ADC_SINGLECTRL */
-#define _ADC_SINGLECTRL_POSSEL_PDBU                        0x000000E4UL                               /**< Mode PDBU for ADC_SINGLECTRL */
-#define _ADC_SINGLECTRL_POSSEL_IO0                         0x000000E5UL                               /**< Mode IO0 for ADC_SINGLECTRL */
-#define _ADC_SINGLECTRL_POSSEL_IO1                         0x000000E6UL                               /**< Mode IO1 for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_POSSEL_BUVDD                       0x000000E1UL                               /**< Mode BUVDD for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_POSSEL_DVDD                        0x000000E2UL                               /**< Mode DVDD for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_POSSEL_PAVDD                       0x000000E3UL                               /**< Mode PAVDD for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_POSSEL_DECOUPLE                    0x000000E4UL                               /**< Mode DECOUPLE for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_POSSEL_IOVDD                       0x000000E5UL                               /**< Mode IOVDD for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_POSSEL_IOVDD1                      0x000000E6UL                               /**< Mode IOVDD1 for ADC_SINGLECTRL */
 #define _ADC_SINGLECTRL_POSSEL_VSP                         0x000000E7UL                               /**< Mode VSP for ADC_SINGLECTRL */
 #define _ADC_SINGLECTRL_POSSEL_OPA2                        0x000000F2UL                               /**< Mode OPA2 for ADC_SINGLECTRL */
 #define _ADC_SINGLECTRL_POSSEL_TEMP                        0x000000F3UL                               /**< Mode TEMP for ADC_SINGLECTRL */
@@ -678,12 +677,12 @@ typedef struct {
 #define ADC_SINGLECTRL_POSSEL_APORT4YCH30                  (_ADC_SINGLECTRL_POSSEL_APORT4YCH30 << 8)  /**< Shifted mode APORT4YCH30 for ADC_SINGLECTRL */
 #define ADC_SINGLECTRL_POSSEL_APORT4XCH31                  (_ADC_SINGLECTRL_POSSEL_APORT4XCH31 << 8)  /**< Shifted mode APORT4XCH31 for ADC_SINGLECTRL */
 #define ADC_SINGLECTRL_POSSEL_AVDD                         (_ADC_SINGLECTRL_POSSEL_AVDD << 8)         /**< Shifted mode AVDD for ADC_SINGLECTRL */
-#define ADC_SINGLECTRL_POSSEL_BU                           (_ADC_SINGLECTRL_POSSEL_BU << 8)           /**< Shifted mode BU for ADC_SINGLECTRL */
-#define ADC_SINGLECTRL_POSSEL_AREG                         (_ADC_SINGLECTRL_POSSEL_AREG << 8)         /**< Shifted mode AREG for ADC_SINGLECTRL */
-#define ADC_SINGLECTRL_POSSEL_VREGOUTPA                    (_ADC_SINGLECTRL_POSSEL_VREGOUTPA << 8)    /**< Shifted mode VREGOUTPA for ADC_SINGLECTRL */
-#define ADC_SINGLECTRL_POSSEL_PDBU                         (_ADC_SINGLECTRL_POSSEL_PDBU << 8)         /**< Shifted mode PDBU for ADC_SINGLECTRL */
-#define ADC_SINGLECTRL_POSSEL_IO0                          (_ADC_SINGLECTRL_POSSEL_IO0 << 8)          /**< Shifted mode IO0 for ADC_SINGLECTRL */
-#define ADC_SINGLECTRL_POSSEL_IO1                          (_ADC_SINGLECTRL_POSSEL_IO1 << 8)          /**< Shifted mode IO1 for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_POSSEL_BUVDD                        (_ADC_SINGLECTRL_POSSEL_BUVDD << 8)        /**< Shifted mode BUVDD for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_POSSEL_DVDD                         (_ADC_SINGLECTRL_POSSEL_DVDD << 8)         /**< Shifted mode DVDD for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_POSSEL_PAVDD                        (_ADC_SINGLECTRL_POSSEL_PAVDD << 8)        /**< Shifted mode PAVDD for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_POSSEL_DECOUPLE                     (_ADC_SINGLECTRL_POSSEL_DECOUPLE << 8)     /**< Shifted mode DECOUPLE for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_POSSEL_IOVDD                        (_ADC_SINGLECTRL_POSSEL_IOVDD << 8)        /**< Shifted mode IOVDD for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_POSSEL_IOVDD1                       (_ADC_SINGLECTRL_POSSEL_IOVDD1 << 8)       /**< Shifted mode IOVDD1 for ADC_SINGLECTRL */
 #define ADC_SINGLECTRL_POSSEL_VSP                          (_ADC_SINGLECTRL_POSSEL_VSP << 8)          /**< Shifted mode VSP for ADC_SINGLECTRL */
 #define ADC_SINGLECTRL_POSSEL_OPA2                         (_ADC_SINGLECTRL_POSSEL_OPA2 << 8)         /**< Shifted mode OPA2 for ADC_SINGLECTRL */
 #define ADC_SINGLECTRL_POSSEL_TEMP                         (_ADC_SINGLECTRL_POSSEL_TEMP << 8)         /**< Shifted mode TEMP for ADC_SINGLECTRL */

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_af_pins.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_af_pins.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg12p_af_pins.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG12P_AF_PINS register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,16 +40,16 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @addtogroup EFR32MG12P_Alternate_Function Alternate Function
  * @{
  * @defgroup EFR32MG12P_AF_Pins  Alternate Function Pins
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 #define AF_CMU_CLK0_PIN(i)          ((i) == 0 ? 1 : (i) == 1 ? 15 : (i) == 2 ? 6 : (i) == 3 ? 11 : (i) == 4 ? 9 : (i) == 5 ? 14 : (i) == 6 ? 2 : (i) == 7 ? 7 :  -1)                                                                                                                                                                                                                                                                                                                                                                                                           /**< Pin number for AF_CMU_CLK0 location number i */
 #define AF_CMU_CLK1_PIN(i)          ((i) == 0 ? 0 : (i) == 1 ? 14 : (i) == 2 ? 7 : (i) == 3 ? 10 : (i) == 4 ? 10 : (i) == 5 ? 15 : (i) == 6 ? 3 : (i) == 7 ? 6 :  -1)                                                                                                                                                                                                                                                                                                                                                                                                          /**< Pin number for AF_CMU_CLK1 location number i */

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_af_ports.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_af_ports.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg12p_af_ports.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG12P_AF_PORTS register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,16 +40,16 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @addtogroup EFR32MG12P_Alternate_Function Alternate Function
  * @{
  * @defgroup EFR32MG12P_AF_Ports Alternate Function Ports
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 #define AF_CMU_CLK0_PORT(i)          ((i) == 0 ? 0 : (i) == 1 ? 1 : (i) == 2 ? 2 : (i) == 3 ? 2 : (i) == 4 ? 3 : (i) == 5 ? 3 : (i) == 6 ? 5 : (i) == 7 ? 5 :  -1)                                                                                                                                                                                                                                                                                                                                                                                                  /**< Port number for AF_CMU_CLK0 location number i */
 #define AF_CMU_CLK1_PORT(i)          ((i) == 0 ? 0 : (i) == 1 ? 1 : (i) == 2 ? 2 : (i) == 3 ? 2 : (i) == 4 ? 3 : (i) == 5 ? 3 : (i) == 6 ? 5 : (i) == 7 ? 5 :  -1)                                                                                                                                                                                                                                                                                                                                                                                                  /**< Port number for AF_CMU_CLK1 location number i */

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_cmu.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_cmu.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg12p_cmu.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG12P_CMU register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,56 +40,56 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG12P_CMU CMU
  * @{
  * @brief EFR32MG12P_CMU Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** CMU Register Declaration */
 typedef struct {
   __IOM uint32_t CTRL;                /**< CMU Control Register  */
 
-  uint32_t       RESERVED0[3];        /**< Reserved for future use **/
+  uint32_t       RESERVED0[3U];       /**< Reserved for future use **/
   __IOM uint32_t HFRCOCTRL;           /**< HFRCO Control Register  */
 
-  uint32_t       RESERVED1[1];        /**< Reserved for future use **/
+  uint32_t       RESERVED1[1U];       /**< Reserved for future use **/
   __IOM uint32_t AUXHFRCOCTRL;        /**< AUXHFRCO Control Register  */
 
-  uint32_t       RESERVED2[1];        /**< Reserved for future use **/
+  uint32_t       RESERVED2[1U];       /**< Reserved for future use **/
   __IOM uint32_t LFRCOCTRL;           /**< LFRCO Control Register  */
   __IOM uint32_t HFXOCTRL;            /**< HFXO Control Register  */
 
-  uint32_t       RESERVED3[1];        /**< Reserved for future use **/
+  uint32_t       RESERVED3[1U];       /**< Reserved for future use **/
   __IOM uint32_t HFXOSTARTUPCTRL;     /**< HFXO Startup Control  */
   __IOM uint32_t HFXOSTEADYSTATECTRL; /**< HFXO Steady State Control  */
   __IOM uint32_t HFXOTIMEOUTCTRL;     /**< HFXO Timeout Control  */
   __IOM uint32_t LFXOCTRL;            /**< LFXO Control Register  */
 
-  uint32_t       RESERVED4[1];        /**< Reserved for future use **/
+  uint32_t       RESERVED4[1U];       /**< Reserved for future use **/
   __IOM uint32_t DPLLCTRL;            /**< DPLL Control Register  */
   __IOM uint32_t DPLLCTRL1;           /**< DPLL Control Register  */
-  uint32_t       RESERVED5[2];        /**< Reserved for future use **/
+  uint32_t       RESERVED5[2U];       /**< Reserved for future use **/
   __IOM uint32_t CALCTRL;             /**< Calibration Control Register  */
   __IOM uint32_t CALCNT;              /**< Calibration Counter Register  */
-  uint32_t       RESERVED6[2];        /**< Reserved for future use **/
+  uint32_t       RESERVED6[2U];       /**< Reserved for future use **/
   __IOM uint32_t OSCENCMD;            /**< Oscillator Enable/Disable Command Register  */
   __IOM uint32_t CMD;                 /**< Command Register  */
-  uint32_t       RESERVED7[2];        /**< Reserved for future use **/
+  uint32_t       RESERVED7[2U];       /**< Reserved for future use **/
   __IOM uint32_t DBGCLKSEL;           /**< Debug Trace Clock Select  */
   __IOM uint32_t HFCLKSEL;            /**< High Frequency Clock Select Command Register  */
-  uint32_t       RESERVED8[2];        /**< Reserved for future use **/
+  uint32_t       RESERVED8[2U];       /**< Reserved for future use **/
   __IOM uint32_t LFACLKSEL;           /**< Low Frequency A Clock Select Register  */
   __IOM uint32_t LFBCLKSEL;           /**< Low Frequency B Clock Select Register  */
   __IOM uint32_t LFECLKSEL;           /**< Low Frequency E Clock Select Register  */
 
-  uint32_t       RESERVED9[1];        /**< Reserved for future use **/
+  uint32_t       RESERVED9[1U];       /**< Reserved for future use **/
   __IM uint32_t  STATUS;              /**< Status Register  */
   __IM uint32_t  HFCLKSTATUS;         /**< HFCLK Status Register  */
-  uint32_t       RESERVED10[1];       /**< Reserved for future use **/
+  uint32_t       RESERVED10[1U];      /**< Reserved for future use **/
   __IM uint32_t  HFXOTRIMSTATUS;      /**< HFXO Trim Status  */
   __IM uint32_t  IF;                  /**< Interrupt Flag Register  */
   __IOM uint32_t IFS;                 /**< Interrupt Flag Set Register  */
@@ -98,57 +97,57 @@ typedef struct {
   __IOM uint32_t IEN;                 /**< Interrupt Enable Register  */
   __IOM uint32_t HFBUSCLKEN0;         /**< High Frequency Bus Clock Enable Register 0  */
 
-  uint32_t       RESERVED11[3];       /**< Reserved for future use **/
+  uint32_t       RESERVED11[3U];      /**< Reserved for future use **/
   __IOM uint32_t HFPERCLKEN0;         /**< High Frequency Peripheral Clock Enable Register 0  */
 
-  uint32_t       RESERVED12[7];       /**< Reserved for future use **/
+  uint32_t       RESERVED12[7U];      /**< Reserved for future use **/
   __IOM uint32_t LFACLKEN0;           /**< Low Frequency a Clock Enable Register 0  (Async Reg)  */
-  uint32_t       RESERVED13[1];       /**< Reserved for future use **/
+  uint32_t       RESERVED13[1U];      /**< Reserved for future use **/
   __IOM uint32_t LFBCLKEN0;           /**< Low Frequency B Clock Enable Register 0 (Async Reg)  */
 
-  uint32_t       RESERVED14[1];       /**< Reserved for future use **/
+  uint32_t       RESERVED14[1U];      /**< Reserved for future use **/
   __IOM uint32_t LFECLKEN0;           /**< Low Frequency E Clock Enable Register 0 (Async Reg)  */
-  uint32_t       RESERVED15[3];       /**< Reserved for future use **/
+  uint32_t       RESERVED15[3U];      /**< Reserved for future use **/
   __IOM uint32_t HFPRESC;             /**< High Frequency Clock Prescaler Register  */
 
-  uint32_t       RESERVED16[1];       /**< Reserved for future use **/
+  uint32_t       RESERVED16[1U];      /**< Reserved for future use **/
   __IOM uint32_t HFCOREPRESC;         /**< High Frequency Core Clock Prescaler Register  */
   __IOM uint32_t HFPERPRESC;          /**< High Frequency Peripheral Clock Prescaler Register  */
 
-  uint32_t       RESERVED17[1];       /**< Reserved for future use **/
+  uint32_t       RESERVED17[1U];      /**< Reserved for future use **/
   __IOM uint32_t HFEXPPRESC;          /**< High Frequency Export Clock Prescaler Register  */
 
-  uint32_t       RESERVED18[2];       /**< Reserved for future use **/
+  uint32_t       RESERVED18[2U];      /**< Reserved for future use **/
   __IOM uint32_t LFAPRESC0;           /**< Low Frequency a Prescaler Register 0 (Async Reg)  */
-  uint32_t       RESERVED19[1];       /**< Reserved for future use **/
+  uint32_t       RESERVED19[1U];      /**< Reserved for future use **/
   __IOM uint32_t LFBPRESC0;           /**< Low Frequency B Prescaler Register 0  (Async Reg)  */
-  uint32_t       RESERVED20[1];       /**< Reserved for future use **/
+  uint32_t       RESERVED20[1U];      /**< Reserved for future use **/
   __IOM uint32_t LFEPRESC0;           /**< Low Frequency E Prescaler Register 0  (Async Reg)  */
 
-  uint32_t       RESERVED21[3];       /**< Reserved for future use **/
+  uint32_t       RESERVED21[3U];      /**< Reserved for future use **/
   __IM uint32_t  SYNCBUSY;            /**< Synchronization Busy Register  */
   __IOM uint32_t FREEZE;              /**< Freeze Register  */
-  uint32_t       RESERVED22[2];       /**< Reserved for future use **/
+  uint32_t       RESERVED22[2U];      /**< Reserved for future use **/
   __IOM uint32_t PCNTCTRL;            /**< PCNT Control Register  */
 
-  uint32_t       RESERVED23[2];       /**< Reserved for future use **/
+  uint32_t       RESERVED23[2U];      /**< Reserved for future use **/
   __IOM uint32_t ADCCTRL;             /**< ADC Control Register  */
 
-  uint32_t       RESERVED24[4];       /**< Reserved for future use **/
+  uint32_t       RESERVED24[4U];      /**< Reserved for future use **/
   __IOM uint32_t ROUTEPEN;            /**< I/O Routing Pin Enable Register  */
   __IOM uint32_t ROUTELOC0;           /**< I/O Routing Location Register  */
   __IOM uint32_t ROUTELOC1;           /**< I/O Routing Location Register  */
-  uint32_t       RESERVED25[1];       /**< Reserved for future use **/
+  uint32_t       RESERVED25[1U];      /**< Reserved for future use **/
   __IOM uint32_t LOCK;                /**< Configuration Lock Register  */
   __IOM uint32_t HFRCOSS;             /**< HFRCO Spread Spectrum Register  */
 } CMU_TypeDef;                        /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG12P_CMU
  * @{
  * @defgroup EFR32MG12P_CMU_BitFields  CMU Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for CMU CTRL */
 #define _CMU_CTRL_RESETVALUE                              0x00300000UL                          /**< Default value for CMU_CTRL */

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_cryotimer.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_cryotimer.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg12p_cryotimer.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG12P_CRYOTIMER register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG12P_CRYOTIMER CRYOTIMER
  * @{
  * @brief EFR32MG12P_CRYOTIMER Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** CRYOTIMER Register Declaration */
 typedef struct {
   __IOM uint32_t CTRL;      /**< Control Register  */
@@ -62,12 +61,12 @@ typedef struct {
   __IOM uint32_t IEN;       /**< Interrupt Enable Register  */
 } CRYOTIMER_TypeDef;        /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG12P_CRYOTIMER
  * @{
  * @defgroup EFR32MG12P_CRYOTIMER_BitFields  CRYOTIMER Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for CRYOTIMER CTRL */
 #define _CRYOTIMER_CTRL_RESETVALUE                0x00000000UL                            /**< Default value for CRYOTIMER_CTRL */

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_crypto.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_crypto.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg12p_crypto.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG12P_CRYPTO register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,84 +40,84 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG12P_CRYPTO CRYPTO
  * @{
  * @brief EFR32MG12P_CRYPTO Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** CRYPTO Register Declaration */
 typedef struct {
-  __IOM uint32_t CTRL;           /**< Control Register  */
-  __IOM uint32_t WAC;            /**< Wide Arithmetic Configuration  */
-  __IOM uint32_t CMD;            /**< Command Register  */
-  uint32_t       RESERVED0[1];   /**< Reserved for future use **/
-  __IM uint32_t  STATUS;         /**< Status Register  */
-  __IM uint32_t  DSTATUS;        /**< Data Status Register  */
-  __IM uint32_t  CSTATUS;        /**< Control Status Register  */
-  uint32_t       RESERVED1[1];   /**< Reserved for future use **/
-  __IOM uint32_t KEY;            /**< KEY Register Access  */
-  __IOM uint32_t KEYBUF;         /**< KEY Buffer Register Access  */
-  uint32_t       RESERVED2[2];   /**< Reserved for future use **/
-  __IOM uint32_t SEQCTRL;        /**< Sequence Control  */
-  __IOM uint32_t SEQCTRLB;       /**< Sequence Control B  */
-  uint32_t       RESERVED3[2];   /**< Reserved for future use **/
-  __IM uint32_t  IF;             /**< AES Interrupt Flags  */
-  __IOM uint32_t IFS;            /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;            /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t IEN;            /**< Interrupt Enable Register  */
-  __IOM uint32_t SEQ0;           /**< Sequence Register 0  */
-  __IOM uint32_t SEQ1;           /**< Sequence Register 1  */
-  __IOM uint32_t SEQ2;           /**< Sequence Register 2  */
-  __IOM uint32_t SEQ3;           /**< Sequence Register 3  */
-  __IOM uint32_t SEQ4;           /**< Sequence Register 4  */
-  uint32_t       RESERVED4[7];   /**< Reserved for future use **/
-  __IOM uint32_t DATA0;          /**< DATA0 Register Access  */
-  __IOM uint32_t DATA1;          /**< DATA1 Register Access  */
-  __IOM uint32_t DATA2;          /**< DATA2 Register Access  */
-  __IOM uint32_t DATA3;          /**< DATA3 Register Access  */
-  uint32_t       RESERVED5[4];   /**< Reserved for future use **/
-  __IOM uint32_t DATA0XOR;       /**< DATA0XOR Register Access  */
-  uint32_t       RESERVED6[3];   /**< Reserved for future use **/
-  __IOM uint32_t DATA0BYTE;      /**< DATA0 Register Byte Access  */
-  __IOM uint32_t DATA1BYTE;      /**< DATA1 Register Byte Access  */
-  uint32_t       RESERVED7[1];   /**< Reserved for future use **/
-  __IOM uint32_t DATA0XORBYTE;   /**< DATA0 Register Byte XOR Access  */
-  __IOM uint32_t DATA0BYTE12;    /**< DATA0 Register Byte 12 Access  */
-  __IOM uint32_t DATA0BYTE13;    /**< DATA0 Register Byte 13 Access  */
-  __IOM uint32_t DATA0BYTE14;    /**< DATA0 Register Byte 14 Access  */
-  __IOM uint32_t DATA0BYTE15;    /**< DATA0 Register Byte 15 Access  */
-  uint32_t       RESERVED8[12];  /**< Reserved for future use **/
-  __IOM uint32_t DDATA0;         /**< DDATA0 Register Access  */
-  __IOM uint32_t DDATA1;         /**< DDATA1 Register Access  */
-  __IOM uint32_t DDATA2;         /**< DDATA2 Register Access  */
-  __IOM uint32_t DDATA3;         /**< DDATA3 Register Access  */
-  __IOM uint32_t DDATA4;         /**< DDATA4 Register Access  */
-  uint32_t       RESERVED9[7];   /**< Reserved for future use **/
-  __IOM uint32_t DDATA0BIG;      /**< DDATA0 Register Big Endian Access  */
-  uint32_t       RESERVED10[3];  /**< Reserved for future use **/
-  __IOM uint32_t DDATA0BYTE;     /**< DDATA0 Register Byte Access  */
-  __IOM uint32_t DDATA1BYTE;     /**< DDATA1 Register Byte Access  */
-  __IOM uint32_t DDATA0BYTE32;   /**< DDATA0 Register Byte 32 Access  */
-  uint32_t       RESERVED11[13]; /**< Reserved for future use **/
-  __IOM uint32_t QDATA0;         /**< QDATA0 Register Access  */
-  __IOM uint32_t QDATA1;         /**< QDATA1 Register Access  */
-  uint32_t       RESERVED12[7];  /**< Reserved for future use **/
-  __IOM uint32_t QDATA1BIG;      /**< QDATA1 Register Big Endian Access  */
-  uint32_t       RESERVED13[6];  /**< Reserved for future use **/
-  __IOM uint32_t QDATA0BYTE;     /**< QDATA0 Register Byte Access  */
-  __IOM uint32_t QDATA1BYTE;     /**< QDATA1 Register Byte Access  */
-} CRYPTO_TypeDef;                /** @} */
+  __IOM uint32_t CTRL;            /**< Control Register  */
+  __IOM uint32_t WAC;             /**< Wide Arithmetic Configuration  */
+  __IOM uint32_t CMD;             /**< Command Register  */
+  uint32_t       RESERVED0[1U];   /**< Reserved for future use **/
+  __IM uint32_t  STATUS;          /**< Status Register  */
+  __IM uint32_t  DSTATUS;         /**< Data Status Register  */
+  __IM uint32_t  CSTATUS;         /**< Control Status Register  */
+  uint32_t       RESERVED1[1U];   /**< Reserved for future use **/
+  __IOM uint32_t KEY;             /**< KEY Register Access  */
+  __IOM uint32_t KEYBUF;          /**< KEY Buffer Register Access  */
+  uint32_t       RESERVED2[2U];   /**< Reserved for future use **/
+  __IOM uint32_t SEQCTRL;         /**< Sequence Control  */
+  __IOM uint32_t SEQCTRLB;        /**< Sequence Control B  */
+  uint32_t       RESERVED3[2U];   /**< Reserved for future use **/
+  __IM uint32_t  IF;              /**< AES Interrupt Flags  */
+  __IOM uint32_t IFS;             /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;             /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;             /**< Interrupt Enable Register  */
+  __IOM uint32_t SEQ0;            /**< Sequence Register 0  */
+  __IOM uint32_t SEQ1;            /**< Sequence Register 1  */
+  __IOM uint32_t SEQ2;            /**< Sequence Register 2  */
+  __IOM uint32_t SEQ3;            /**< Sequence Register 3  */
+  __IOM uint32_t SEQ4;            /**< Sequence Register 4  */
+  uint32_t       RESERVED4[7U];   /**< Reserved for future use **/
+  __IOM uint32_t DATA0;           /**< DATA0 Register Access  */
+  __IOM uint32_t DATA1;           /**< DATA1 Register Access  */
+  __IOM uint32_t DATA2;           /**< DATA2 Register Access  */
+  __IOM uint32_t DATA3;           /**< DATA3 Register Access  */
+  uint32_t       RESERVED5[4U];   /**< Reserved for future use **/
+  __IOM uint32_t DATA0XOR;        /**< DATA0XOR Register Access  */
+  uint32_t       RESERVED6[3U];   /**< Reserved for future use **/
+  __IOM uint32_t DATA0BYTE;       /**< DATA0 Register Byte Access  */
+  __IOM uint32_t DATA1BYTE;       /**< DATA1 Register Byte Access  */
+  uint32_t       RESERVED7[1U];   /**< Reserved for future use **/
+  __IOM uint32_t DATA0XORBYTE;    /**< DATA0 Register Byte XOR Access  */
+  __IOM uint32_t DATA0BYTE12;     /**< DATA0 Register Byte 12 Access  */
+  __IOM uint32_t DATA0BYTE13;     /**< DATA0 Register Byte 13 Access  */
+  __IOM uint32_t DATA0BYTE14;     /**< DATA0 Register Byte 14 Access  */
+  __IOM uint32_t DATA0BYTE15;     /**< DATA0 Register Byte 15 Access  */
+  uint32_t       RESERVED8[12U];  /**< Reserved for future use **/
+  __IOM uint32_t DDATA0;          /**< DDATA0 Register Access  */
+  __IOM uint32_t DDATA1;          /**< DDATA1 Register Access  */
+  __IOM uint32_t DDATA2;          /**< DDATA2 Register Access  */
+  __IOM uint32_t DDATA3;          /**< DDATA3 Register Access  */
+  __IOM uint32_t DDATA4;          /**< DDATA4 Register Access  */
+  uint32_t       RESERVED9[7U];   /**< Reserved for future use **/
+  __IOM uint32_t DDATA0BIG;       /**< DDATA0 Register Big Endian Access  */
+  uint32_t       RESERVED10[3U];  /**< Reserved for future use **/
+  __IOM uint32_t DDATA0BYTE;      /**< DDATA0 Register Byte Access  */
+  __IOM uint32_t DDATA1BYTE;      /**< DDATA1 Register Byte Access  */
+  __IOM uint32_t DDATA0BYTE32;    /**< DDATA0 Register Byte 32 Access  */
+  uint32_t       RESERVED11[13U]; /**< Reserved for future use **/
+  __IOM uint32_t QDATA0;          /**< QDATA0 Register Access  */
+  __IOM uint32_t QDATA1;          /**< QDATA1 Register Access  */
+  uint32_t       RESERVED12[7U];  /**< Reserved for future use **/
+  __IOM uint32_t QDATA1BIG;       /**< QDATA1 Register Big Endian Access  */
+  uint32_t       RESERVED13[6U];  /**< Reserved for future use **/
+  __IOM uint32_t QDATA0BYTE;      /**< QDATA0 Register Byte Access  */
+  __IOM uint32_t QDATA1BYTE;      /**< QDATA1 Register Byte Access  */
+} CRYPTO_TypeDef;                 /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG12P_CRYPTO
  * @{
  * @defgroup EFR32MG12P_CRYPTO_BitFields  CRYPTO Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for CRYPTO CTRL */
 #define _CRYPTO_CTRL_RESETVALUE                      0x00000000UL                               /**< Default value for CRYPTO_CTRL */

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_csen.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_csen.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg12p_csen.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG12P_CSEN register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG12P_CSEN CSEN
  * @{
  * @brief EFR32MG12P_CSEN Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** CSEN Register Declaration */
 typedef struct {
   __IOM uint32_t CTRL;          /**< Control  */
@@ -72,19 +71,19 @@ typedef struct {
   __IOM uint32_t DMCFG;         /**< Delta Modulation Configuration  */
   __IOM uint32_t ANACTRL;       /**< Analog Control  */
 
-  uint32_t       RESERVED0[2];  /**< Reserved for future use **/
+  uint32_t       RESERVED0[2U]; /**< Reserved for future use **/
   __IM uint32_t  IF;            /**< Interrupt Flag  */
   __IOM uint32_t IFS;           /**< Interrupt Flag Set  */
   __IOM uint32_t IFC;           /**< Interrupt Flag Clear  */
   __IOM uint32_t IEN;           /**< Interrupt Enable  */
 } CSEN_TypeDef;                 /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG12P_CSEN
  * @{
  * @defgroup EFR32MG12P_CSEN_BitFields  CSEN Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for CSEN CTRL */
 #define _CSEN_CTRL_RESETVALUE                                0x00030000UL                               /**< Default value for CSEN_CTRL */

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_devinfo.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_devinfo.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg12p_devinfo.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG12P_DEVINFO register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,69 +40,71 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG12P_DEVINFO Device Information and Calibration
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /** DEVINFO Register Declaration */
 typedef struct {
   __IM uint32_t CAL;              /**< CRC of DI-page and calibration temperature  */
-  uint32_t      RESERVED0[7];     /**< Reserved for future use **/
+  __IM uint32_t MODULEINFO;       /**< Module trace information  */
+  __IM uint32_t MODXOCAL;         /**< Module Crystal Oscillator Calibration  */
+  uint32_t      RESERVED0[5U];    /**< Reserved for future use **/
   __IM uint32_t EXTINFO;          /**< External Component description  */
-  uint32_t      RESERVED1[1];     /**< Reserved for future use **/
+  uint32_t      RESERVED1[1U];    /**< Reserved for future use **/
   __IM uint32_t EUI48L;           /**< EUI48 OUI and Unique identifier  */
   __IM uint32_t EUI48H;           /**< OUI  */
   __IM uint32_t CUSTOMINFO;       /**< Custom information  */
   __IM uint32_t MEMINFO;          /**< Flash page size and misc. chip information  */
-  uint32_t      RESERVED2[2];     /**< Reserved for future use **/
+  uint32_t      RESERVED2[2U];    /**< Reserved for future use **/
   __IM uint32_t UNIQUEL;          /**< Low 32 bits of device unique number  */
   __IM uint32_t UNIQUEH;          /**< High 32 bits of device unique number  */
   __IM uint32_t MSIZE;            /**< Flash and SRAM Memory size in kB  */
   __IM uint32_t PART;             /**< Part description  */
   __IM uint32_t DEVINFOREV;       /**< Device information page revision  */
   __IM uint32_t EMUTEMP;          /**< EMU Temperature Calibration Information  */
-  uint32_t      RESERVED3[2];     /**< Reserved for future use **/
+  uint32_t      RESERVED3[2U];    /**< Reserved for future use **/
   __IM uint32_t ADC0CAL0;         /**< ADC0 calibration register 0  */
   __IM uint32_t ADC0CAL1;         /**< ADC0 calibration register 1  */
   __IM uint32_t ADC0CAL2;         /**< ADC0 calibration register 2  */
   __IM uint32_t ADC0CAL3;         /**< ADC0 calibration register 3  */
-  uint32_t      RESERVED4[4];     /**< Reserved for future use **/
+  uint32_t      RESERVED4[4U];    /**< Reserved for future use **/
   __IM uint32_t HFRCOCAL0;        /**< HFRCO Calibration Register (4 MHz)  */
-  uint32_t      RESERVED5[2];     /**< Reserved for future use **/
+  uint32_t      RESERVED5[2U];    /**< Reserved for future use **/
   __IM uint32_t HFRCOCAL3;        /**< HFRCO Calibration Register (7 MHz)  */
-  uint32_t      RESERVED6[2];     /**< Reserved for future use **/
+  uint32_t      RESERVED6[2U];    /**< Reserved for future use **/
   __IM uint32_t HFRCOCAL6;        /**< HFRCO Calibration Register (13 MHz)  */
   __IM uint32_t HFRCOCAL7;        /**< HFRCO Calibration Register (16 MHz)  */
   __IM uint32_t HFRCOCAL8;        /**< HFRCO Calibration Register (19 MHz)  */
-  uint32_t      RESERVED7[1];     /**< Reserved for future use **/
+  uint32_t      RESERVED7[1U];    /**< Reserved for future use **/
   __IM uint32_t HFRCOCAL10;       /**< HFRCO Calibration Register (26 MHz)  */
   __IM uint32_t HFRCOCAL11;       /**< HFRCO Calibration Register (32 MHz)  */
   __IM uint32_t HFRCOCAL12;       /**< HFRCO Calibration Register (38 MHz)  */
-  uint32_t      RESERVED8[11];    /**< Reserved for future use **/
+  uint32_t      RESERVED8[11U];   /**< Reserved for future use **/
   __IM uint32_t AUXHFRCOCAL0;     /**< AUXHFRCO Calibration Register (4 MHz)  */
-  uint32_t      RESERVED9[2];     /**< Reserved for future use **/
+  uint32_t      RESERVED9[2U];    /**< Reserved for future use **/
   __IM uint32_t AUXHFRCOCAL3;     /**< AUXHFRCO Calibration Register (7 MHz)  */
-  uint32_t      RESERVED10[2];    /**< Reserved for future use **/
+  uint32_t      RESERVED10[2U];   /**< Reserved for future use **/
   __IM uint32_t AUXHFRCOCAL6;     /**< AUXHFRCO Calibration Register (13 MHz)  */
   __IM uint32_t AUXHFRCOCAL7;     /**< AUXHFRCO Calibration Register (16 MHz)  */
   __IM uint32_t AUXHFRCOCAL8;     /**< AUXHFRCO Calibration Register (19 MHz)  */
-  uint32_t      RESERVED11[1];    /**< Reserved for future use **/
+  uint32_t      RESERVED11[1U];   /**< Reserved for future use **/
   __IM uint32_t AUXHFRCOCAL10;    /**< AUXHFRCO Calibration Register (26 MHz)  */
   __IM uint32_t AUXHFRCOCAL11;    /**< AUXHFRCO Calibration Register (32 MHz)  */
   __IM uint32_t AUXHFRCOCAL12;    /**< AUXHFRCO Calibration Register (38 MHz)  */
-  uint32_t      RESERVED12[11];   /**< Reserved for future use **/
+  uint32_t      RESERVED12[11U];  /**< Reserved for future use **/
   __IM uint32_t VMONCAL0;         /**< VMON Calibration Register 0  */
   __IM uint32_t VMONCAL1;         /**< VMON Calibration Register 1  */
   __IM uint32_t VMONCAL2;         /**< VMON Calibration Register 2  */
-  uint32_t      RESERVED13[3];    /**< Reserved for future use **/
+  uint32_t      RESERVED13[3U];   /**< Reserved for future use **/
   __IM uint32_t IDAC0CAL0;        /**< IDAC0 Calibration Register 0  */
   __IM uint32_t IDAC0CAL1;        /**< IDAC0 Calibration Register 1  */
-  uint32_t      RESERVED14[2];    /**< Reserved for future use **/
+  uint32_t      RESERVED14[2U];   /**< Reserved for future use **/
   __IM uint32_t DCDCLNVCTRL0;     /**< DCDC Low-noise VREF Trim Register 0  */
   __IM uint32_t DCDCLPVCTRL0;     /**< DCDC Low-power VREF Trim Register 0  */
   __IM uint32_t DCDCLPVCTRL1;     /**< DCDC Low-power VREF Trim Register 1  */
@@ -127,7 +128,7 @@ typedef struct {
   __IM uint32_t OPA2CAL2;         /**< OPA2 Calibration Register for DRIVESTRENGTH 2, INCBW=1  */
   __IM uint32_t OPA2CAL3;         /**< OPA2 Calibration Register for DRIVESTRENGTH 3, INCBW=1  */
   __IM uint32_t CSENGAINCAL;      /**< Cap Sense Gain Adjustment  */
-  uint32_t      RESERVED15[3];    /**< Reserved for future use **/
+  uint32_t      RESERVED15[3U];   /**< Reserved for future use **/
   __IM uint32_t OPA0CAL4;         /**< OPA0 Calibration Register for DRIVESTRENGTH 0, INCBW=0  */
   __IM uint32_t OPA0CAL5;         /**< OPA0 Calibration Register for DRIVESTRENGTH 1, INCBW=0  */
   __IM uint32_t OPA0CAL6;         /**< OPA0 Calibration Register for DRIVESTRENGTH 2, INCBW=0  */
@@ -142,12 +143,12 @@ typedef struct {
   __IM uint32_t OPA2CAL7;         /**< OPA2 Calibration Register for DRIVESTRENGTH 3, INCBW=0  */
 } DEVINFO_TypeDef;                /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG12P_DEVINFO
  * @{
  * @defgroup EFR32MG12P_DEVINFO_BitFields DEVINFO Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for DEVINFO CAL */
 #define _DEVINFO_CAL_MASK                                        0x00FFFFFFUL /**< Mask for DEVINFO_CAL */
@@ -156,21 +157,79 @@ typedef struct {
 #define _DEVINFO_CAL_TEMP_SHIFT                                  16           /**< Shift value for TEMP */
 #define _DEVINFO_CAL_TEMP_MASK                                   0xFF0000UL   /**< Bit mask for TEMP */
 
+/* Bit fields for DEVINFO MODULEINFO */
+#define _DEVINFO_MODULEINFO_MASK                                 0xFFFFFFFFUL                                    /**< Mask for DEVINFO_MODULEINFO */
+#define _DEVINFO_MODULEINFO_HWREV_SHIFT                          0                                               /**< Shift value for HWREV */
+#define _DEVINFO_MODULEINFO_HWREV_MASK                           0x1FUL                                          /**< Bit mask for HWREV */
+#define _DEVINFO_MODULEINFO_ANTENNA_SHIFT                        5                                               /**< Shift value for ANTENNA */
+#define _DEVINFO_MODULEINFO_ANTENNA_MASK                         0xE0UL                                          /**< Bit mask for ANTENNA */
+#define _DEVINFO_MODULEINFO_ANTENNA_BUILTIN                      0x00000000UL                                    /**< Mode BUILTIN for DEVINFO_MODULEINFO */
+#define _DEVINFO_MODULEINFO_ANTENNA_CONNECTOR                    0x00000001UL                                    /**< Mode CONNECTOR for DEVINFO_MODULEINFO */
+#define _DEVINFO_MODULEINFO_ANTENNA_RFPAD                        0x00000002UL                                    /**< Mode RFPAD for DEVINFO_MODULEINFO */
+#define DEVINFO_MODULEINFO_ANTENNA_BUILTIN                       (_DEVINFO_MODULEINFO_ANTENNA_BUILTIN << 5)      /**< Shifted mode BUILTIN for DEVINFO_MODULEINFO */
+#define DEVINFO_MODULEINFO_ANTENNA_CONNECTOR                     (_DEVINFO_MODULEINFO_ANTENNA_CONNECTOR << 5)    /**< Shifted mode CONNECTOR for DEVINFO_MODULEINFO */
+#define DEVINFO_MODULEINFO_ANTENNA_RFPAD                         (_DEVINFO_MODULEINFO_ANTENNA_RFPAD << 5)        /**< Shifted mode RFPAD for DEVINFO_MODULEINFO */
+#define _DEVINFO_MODULEINFO_MODNUMBER_SHIFT                      8                                               /**< Shift value for MODNUMBER */
+#define _DEVINFO_MODULEINFO_MODNUMBER_MASK                       0x7F00UL                                        /**< Bit mask for MODNUMBER */
+#define _DEVINFO_MODULEINFO_TYPE_SHIFT                           15                                              /**< Shift value for TYPE */
+#define _DEVINFO_MODULEINFO_TYPE_MASK                            0x8000UL                                        /**< Bit mask for TYPE */
+#define _DEVINFO_MODULEINFO_TYPE_PCB                             0x00000000UL                                    /**< Mode PCB for DEVINFO_MODULEINFO */
+#define _DEVINFO_MODULEINFO_TYPE_SIP                             0x00000001UL                                    /**< Mode SIP for DEVINFO_MODULEINFO */
+#define DEVINFO_MODULEINFO_TYPE_PCB                              (_DEVINFO_MODULEINFO_TYPE_PCB << 15)            /**< Shifted mode PCB for DEVINFO_MODULEINFO */
+#define DEVINFO_MODULEINFO_TYPE_SIP                              (_DEVINFO_MODULEINFO_TYPE_SIP << 15)            /**< Shifted mode SIP for DEVINFO_MODULEINFO */
+#define _DEVINFO_MODULEINFO_LFXO_SHIFT                           16                                              /**< Shift value for LFXO */
+#define _DEVINFO_MODULEINFO_LFXO_MASK                            0x10000UL                                       /**< Bit mask for LFXO */
+#define _DEVINFO_MODULEINFO_LFXO_NONE                            0x00000000UL                                    /**< Mode NONE for DEVINFO_MODULEINFO */
+#define _DEVINFO_MODULEINFO_LFXO_PRESENT                         0x00000001UL                                    /**< Mode PRESENT for DEVINFO_MODULEINFO */
+#define DEVINFO_MODULEINFO_LFXO_NONE                             (_DEVINFO_MODULEINFO_LFXO_NONE << 16)           /**< Shifted mode NONE for DEVINFO_MODULEINFO */
+#define DEVINFO_MODULEINFO_LFXO_PRESENT                          (_DEVINFO_MODULEINFO_LFXO_PRESENT << 16)        /**< Shifted mode PRESENT for DEVINFO_MODULEINFO */
+#define _DEVINFO_MODULEINFO_EXPRESS_SHIFT                        17                                              /**< Shift value for EXPRESS */
+#define _DEVINFO_MODULEINFO_EXPRESS_MASK                         0x20000UL                                       /**< Bit mask for EXPRESS */
+#define _DEVINFO_MODULEINFO_EXPRESS_SUPPORTED                    0x00000000UL                                    /**< Mode SUPPORTED for DEVINFO_MODULEINFO */
+#define _DEVINFO_MODULEINFO_EXPRESS_NONE                         0x00000001UL                                    /**< Mode NONE for DEVINFO_MODULEINFO */
+#define DEVINFO_MODULEINFO_EXPRESS_SUPPORTED                     (_DEVINFO_MODULEINFO_EXPRESS_SUPPORTED << 17)   /**< Shifted mode SUPPORTED for DEVINFO_MODULEINFO */
+#define DEVINFO_MODULEINFO_EXPRESS_NONE                          (_DEVINFO_MODULEINFO_EXPRESS_NONE << 17)        /**< Shifted mode NONE for DEVINFO_MODULEINFO */
+#define _DEVINFO_MODULEINFO_LFXOCALVAL_SHIFT                     18                                              /**< Shift value for LFXOCALVAL */
+#define _DEVINFO_MODULEINFO_LFXOCALVAL_MASK                      0x40000UL                                       /**< Bit mask for LFXOCALVAL */
+#define _DEVINFO_MODULEINFO_LFXOCALVAL_VALID                     0x00000000UL                                    /**< Mode VALID for DEVINFO_MODULEINFO */
+#define _DEVINFO_MODULEINFO_LFXOCALVAL_NOTVALID                  0x00000001UL                                    /**< Mode NOTVALID for DEVINFO_MODULEINFO */
+#define DEVINFO_MODULEINFO_LFXOCALVAL_VALID                      (_DEVINFO_MODULEINFO_LFXOCALVAL_VALID << 18)    /**< Shifted mode VALID for DEVINFO_MODULEINFO */
+#define DEVINFO_MODULEINFO_LFXOCALVAL_NOTVALID                   (_DEVINFO_MODULEINFO_LFXOCALVAL_NOTVALID << 18) /**< Shifted mode NOTVALID for DEVINFO_MODULEINFO */
+#define _DEVINFO_MODULEINFO_HFXOCALVAL_SHIFT                     19                                              /**< Shift value for HFXOCALVAL */
+#define _DEVINFO_MODULEINFO_HFXOCALVAL_MASK                      0x80000UL                                       /**< Bit mask for HFXOCALVAL */
+#define _DEVINFO_MODULEINFO_HFXOCALVAL_VALID                     0x00000000UL                                    /**< Mode VALID for DEVINFO_MODULEINFO */
+#define _DEVINFO_MODULEINFO_HFXOCALVAL_NOTVALID                  0x00000001UL                                    /**< Mode NOTVALID for DEVINFO_MODULEINFO */
+#define DEVINFO_MODULEINFO_HFXOCALVAL_VALID                      (_DEVINFO_MODULEINFO_HFXOCALVAL_VALID << 19)    /**< Shifted mode VALID for DEVINFO_MODULEINFO */
+#define DEVINFO_MODULEINFO_HFXOCALVAL_NOTVALID                   (_DEVINFO_MODULEINFO_HFXOCALVAL_NOTVALID << 19) /**< Shifted mode NOTVALID for DEVINFO_MODULEINFO */
+#define _DEVINFO_MODULEINFO_RESERVED1_SHIFT                      20                                              /**< Shift value for RESERVED1 */
+#define _DEVINFO_MODULEINFO_RESERVED1_MASK                       0xFFF00000UL                                    /**< Bit mask for RESERVED1 */
+
+/* Bit fields for DEVINFO MODXOCAL */
+#define _DEVINFO_MODXOCAL_MASK                                   0x0000FFFFUL /**< Mask for DEVINFO_MODXOCAL */
+#define _DEVINFO_MODXOCAL_HFXOCTUNE_SHIFT                        0            /**< Shift value for HFXOCTUNE */
+#define _DEVINFO_MODXOCAL_HFXOCTUNE_MASK                         0x1FFUL      /**< Bit mask for HFXOCTUNE */
+#define _DEVINFO_MODXOCAL_LFXOTUNING_SHIFT                       9            /**< Shift value for LFXOTUNING */
+#define _DEVINFO_MODXOCAL_LFXOTUNING_MASK                        0xFE00UL     /**< Bit mask for LFXOTUNING */
+
 /* Bit fields for DEVINFO EXTINFO */
 #define _DEVINFO_EXTINFO_MASK                                    0x00FFFFFFUL                            /**< Mask for DEVINFO_EXTINFO */
 #define _DEVINFO_EXTINFO_TYPE_SHIFT                              0                                       /**< Shift value for TYPE */
 #define _DEVINFO_EXTINFO_TYPE_MASK                               0xFFUL                                  /**< Bit mask for TYPE */
 #define _DEVINFO_EXTINFO_TYPE_IS25LQ040B                         0x00000001UL                            /**< Mode IS25LQ040B for DEVINFO_EXTINFO */
 #define _DEVINFO_EXTINFO_TYPE_AT25S041                           0x00000002UL                            /**< Mode AT25S041 for DEVINFO_EXTINFO */
+#define _DEVINFO_EXTINFO_TYPE_WF200                              0x00000003UL                            /**< Mode WF200 for DEVINFO_EXTINFO */
 #define _DEVINFO_EXTINFO_TYPE_NONE                               0x000000FFUL                            /**< Mode NONE for DEVINFO_EXTINFO */
 #define DEVINFO_EXTINFO_TYPE_IS25LQ040B                          (_DEVINFO_EXTINFO_TYPE_IS25LQ040B << 0) /**< Shifted mode IS25LQ040B for DEVINFO_EXTINFO */
 #define DEVINFO_EXTINFO_TYPE_AT25S041                            (_DEVINFO_EXTINFO_TYPE_AT25S041 << 0)   /**< Shifted mode AT25S041 for DEVINFO_EXTINFO */
+#define DEVINFO_EXTINFO_TYPE_WF200                               (_DEVINFO_EXTINFO_TYPE_WF200 << 0)      /**< Shifted mode WF200 for DEVINFO_EXTINFO */
 #define DEVINFO_EXTINFO_TYPE_NONE                                (_DEVINFO_EXTINFO_TYPE_NONE << 0)       /**< Shifted mode NONE for DEVINFO_EXTINFO */
 #define _DEVINFO_EXTINFO_CONNECTION_SHIFT                        8                                       /**< Shift value for CONNECTION */
 #define _DEVINFO_EXTINFO_CONNECTION_MASK                         0xFF00UL                                /**< Bit mask for CONNECTION */
 #define _DEVINFO_EXTINFO_CONNECTION_SPI                          0x00000001UL                            /**< Mode SPI for DEVINFO_EXTINFO */
+#define _DEVINFO_EXTINFO_CONNECTION_SDIO                         0x00000002UL                            /**< Mode SDIO for DEVINFO_EXTINFO */
 #define _DEVINFO_EXTINFO_CONNECTION_NONE                         0x000000FFUL                            /**< Mode NONE for DEVINFO_EXTINFO */
 #define DEVINFO_EXTINFO_CONNECTION_SPI                           (_DEVINFO_EXTINFO_CONNECTION_SPI << 8)  /**< Shifted mode SPI for DEVINFO_EXTINFO */
+#define DEVINFO_EXTINFO_CONNECTION_SDIO                          (_DEVINFO_EXTINFO_CONNECTION_SDIO << 8) /**< Shifted mode SDIO for DEVINFO_EXTINFO */
 #define DEVINFO_EXTINFO_CONNECTION_NONE                          (_DEVINFO_EXTINFO_CONNECTION_NONE << 8) /**< Shifted mode NONE for DEVINFO_EXTINFO */
 #define _DEVINFO_EXTINFO_REV_SHIFT                               16                                      /**< Shift value for REV */
 #define _DEVINFO_EXTINFO_REV_MASK                                0xFF0000UL                              /**< Bit mask for REV */
@@ -270,6 +329,7 @@ typedef struct {
 #define _DEVINFO_PART_DEVICE_FAMILY_EFR32BG13P                   0x0000002BUL                                   /**< Mode EFR32BG13P for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFR32BG13B                   0x0000002CUL                                   /**< Mode EFR32BG13B for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFR32BG13V                   0x0000002DUL                                   /**< Mode EFR32BG13V for DEVINFO_PART */
+#define _DEVINFO_PART_DEVICE_FAMILY_EFR32ZG13P                   0x0000002EUL                                   /**< Mode EFR32ZG13P for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFR32FG13P                   0x00000031UL                                   /**< Mode EFR32FG13P for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFR32FG13B                   0x00000032UL                                   /**< Mode EFR32FG13B for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFR32FG13V                   0x00000033UL                                   /**< Mode EFR32FG13V for DEVINFO_PART */
@@ -279,6 +339,7 @@ typedef struct {
 #define _DEVINFO_PART_DEVICE_FAMILY_EFR32BG14P                   0x00000037UL                                   /**< Mode EFR32BG14P for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFR32BG14B                   0x00000038UL                                   /**< Mode EFR32BG14B for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFR32BG14V                   0x00000039UL                                   /**< Mode EFR32BG14V for DEVINFO_PART */
+#define _DEVINFO_PART_DEVICE_FAMILY_EFR32ZG14P                   0x0000003AUL                                   /**< Mode EFR32ZG14P for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFR32FG14P                   0x0000003DUL                                   /**< Mode EFR32FG14P for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFR32FG14B                   0x0000003EUL                                   /**< Mode EFR32FG14B for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFR32FG14V                   0x0000003FUL                                   /**< Mode EFR32FG14V for DEVINFO_PART */
@@ -302,6 +363,7 @@ typedef struct {
 #define _DEVINFO_PART_DEVICE_FAMILY_EFM32JG12B                   0x00000057UL                                   /**< Mode EFM32JG12B for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFM32GG11B                   0x00000064UL                                   /**< Mode EFM32GG11B for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFM32TG11B                   0x00000067UL                                   /**< Mode EFM32TG11B for DEVINFO_PART */
+#define _DEVINFO_PART_DEVICE_FAMILY_EFM32GG12B                   0x0000006AUL                                   /**< Mode EFM32GG12B for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EZR32LG                      0x00000078UL                                   /**< Mode EZR32LG for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EZR32WG                      0x00000079UL                                   /**< Mode EZR32WG for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EZR32HG                      0x0000007AUL                                   /**< Mode EZR32HG for DEVINFO_PART */
@@ -329,6 +391,7 @@ typedef struct {
 #define DEVINFO_PART_DEVICE_FAMILY_EFR32BG13P                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32BG13P << 16) /**< Shifted mode EFR32BG13P for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFR32BG13B                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32BG13B << 16) /**< Shifted mode EFR32BG13B for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFR32BG13V                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32BG13V << 16) /**< Shifted mode EFR32BG13V for DEVINFO_PART */
+#define DEVINFO_PART_DEVICE_FAMILY_EFR32ZG13P                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32ZG13P << 16) /**< Shifted mode EFR32ZG13P for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFR32FG13P                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32FG13P << 16) /**< Shifted mode EFR32FG13P for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFR32FG13B                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32FG13B << 16) /**< Shifted mode EFR32FG13B for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFR32FG13V                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32FG13V << 16) /**< Shifted mode EFR32FG13V for DEVINFO_PART */
@@ -338,6 +401,7 @@ typedef struct {
 #define DEVINFO_PART_DEVICE_FAMILY_EFR32BG14P                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32BG14P << 16) /**< Shifted mode EFR32BG14P for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFR32BG14B                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32BG14B << 16) /**< Shifted mode EFR32BG14B for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFR32BG14V                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32BG14V << 16) /**< Shifted mode EFR32BG14V for DEVINFO_PART */
+#define DEVINFO_PART_DEVICE_FAMILY_EFR32ZG14P                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32ZG14P << 16) /**< Shifted mode EFR32ZG14P for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFR32FG14P                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32FG14P << 16) /**< Shifted mode EFR32FG14P for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFR32FG14B                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32FG14B << 16) /**< Shifted mode EFR32FG14B for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFR32FG14V                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32FG14V << 16) /**< Shifted mode EFR32FG14V for DEVINFO_PART */
@@ -361,6 +425,7 @@ typedef struct {
 #define DEVINFO_PART_DEVICE_FAMILY_EFM32JG12B                    (_DEVINFO_PART_DEVICE_FAMILY_EFM32JG12B << 16) /**< Shifted mode EFM32JG12B for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFM32GG11B                    (_DEVINFO_PART_DEVICE_FAMILY_EFM32GG11B << 16) /**< Shifted mode EFM32GG11B for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFM32TG11B                    (_DEVINFO_PART_DEVICE_FAMILY_EFM32TG11B << 16) /**< Shifted mode EFM32TG11B for DEVINFO_PART */
+#define DEVINFO_PART_DEVICE_FAMILY_EFM32GG12B                    (_DEVINFO_PART_DEVICE_FAMILY_EFM32GG12B << 16) /**< Shifted mode EFM32GG12B for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EZR32LG                       (_DEVINFO_PART_DEVICE_FAMILY_EZR32LG << 16)    /**< Shifted mode EZR32LG for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EZR32WG                       (_DEVINFO_PART_DEVICE_FAMILY_EZR32WG << 16)    /**< Shifted mode EZR32WG for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EZR32HG                       (_DEVINFO_PART_DEVICE_FAMILY_EZR32HG << 16)    /**< Shifted mode EZR32HG for DEVINFO_PART */

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_dma_descriptor.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_dma_descriptor.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg12p_dma_descriptor.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG12P_DMA_DESCRIPTOR register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,14 +40,14 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG12P_DMA_DESCRIPTOR DMA Descriptor
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 /** DMA_DESCRIPTOR Register Declaration */
 typedef struct {
   /* Note! Use of double __IOM (volatile) qualifier to ensure that both */

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_dmareq.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_dmareq.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg12p_dmareq.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG12P_DMAREQ register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,17 +40,17 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG12P_DMAREQ DMAREQ
  * @{
  * @defgroup EFR32MG12P_DMAREQ_BitFields DMAREQ Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 #define DMAREQ_PRS_REQ0               ((1 << 16) + 0)         /**< DMA channel select for PRS_REQ0 */
 #define DMAREQ_PRS_REQ1               ((1 << 16) + 1)         /**< DMA channel select for PRS_REQ1 */
 #define DMAREQ_ADC0_SINGLE            ((8 << 16) + 0)         /**< DMA channel select for ADC0_SINGLE */

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_emu.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_emu.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg12p_emu.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG12P_EMU register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG12P_EMU EMU
  * @{
  * @brief EFR32MG12P_EMU Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** EMU Register Declaration */
 typedef struct {
   __IOM uint32_t CTRL;                  /**< Control Register  */
@@ -58,7 +57,7 @@ typedef struct {
   __IOM uint32_t RAM0CTRL;              /**< Memory Control Register  */
   __IOM uint32_t CMD;                   /**< Command Register  */
 
-  uint32_t       RESERVED0[1];          /**< Reserved for future use **/
+  uint32_t       RESERVED0[1U];         /**< Reserved for future use **/
   __IOM uint32_t EM4CTRL;               /**< EM4 Control Register  */
   __IOM uint32_t TEMPLIMITS;            /**< Temperature Limits for Interrupt Generation  */
   __IM uint32_t  TEMP;                  /**< Value of Last Temperature Measurement  */
@@ -71,48 +70,48 @@ typedef struct {
   __IOM uint32_t PWRCTRL;               /**< Power Control Register  */
   __IOM uint32_t DCDCCTRL;              /**< DCDC Control  */
 
-  uint32_t       RESERVED1[2];          /**< Reserved for future use **/
+  uint32_t       RESERVED1[2U];         /**< Reserved for future use **/
   __IOM uint32_t DCDCMISCCTRL;          /**< DCDC Miscellaneous Control Register  */
   __IOM uint32_t DCDCZDETCTRL;          /**< DCDC Power Train NFET Zero Current Detector Control Register  */
   __IOM uint32_t DCDCCLIMCTRL;          /**< DCDC Power Train PFET Current Limiter Control Register  */
   __IOM uint32_t DCDCLNCOMPCTRL;        /**< DCDC Low Noise Compensator Control Register  */
   __IOM uint32_t DCDCLNVCTRL;           /**< DCDC Low Noise Voltage Register  */
 
-  uint32_t       RESERVED2[1];          /**< Reserved for future use **/
+  uint32_t       RESERVED2[1U];         /**< Reserved for future use **/
   __IOM uint32_t DCDCLPVCTRL;           /**< DCDC Low Power Voltage Register  */
 
-  uint32_t       RESERVED3[1];          /**< Reserved for future use **/
+  uint32_t       RESERVED3[1U];         /**< Reserved for future use **/
   __IOM uint32_t DCDCLPCTRL;            /**< DCDC Low Power Control Register  */
   __IOM uint32_t DCDCLNFREQCTRL;        /**< DCDC Low Noise Controller Frequency Control  */
 
-  uint32_t       RESERVED4[1];          /**< Reserved for future use **/
+  uint32_t       RESERVED4[1U];         /**< Reserved for future use **/
   __IM uint32_t  DCDCSYNC;              /**< DCDC Read Status Register  */
 
-  uint32_t       RESERVED5[5];          /**< Reserved for future use **/
+  uint32_t       RESERVED5[5U];         /**< Reserved for future use **/
   __IOM uint32_t VMONAVDDCTRL;          /**< VMON AVDD Channel Control  */
   __IOM uint32_t VMONALTAVDDCTRL;       /**< Alternate VMON AVDD Channel Control  */
   __IOM uint32_t VMONDVDDCTRL;          /**< VMON DVDD Channel Control  */
   __IOM uint32_t VMONIO0CTRL;           /**< VMON IOVDD0 Channel Control  */
 
-  uint32_t       RESERVED6[5];          /**< Reserved for future use **/
+  uint32_t       RESERVED6[5U];         /**< Reserved for future use **/
   __IOM uint32_t RAM1CTRL;              /**< Memory Control Register  */
   __IOM uint32_t RAM2CTRL;              /**< Memory Control Register  */
 
-  uint32_t       RESERVED7[12];         /**< Reserved for future use **/
+  uint32_t       RESERVED7[12U];        /**< Reserved for future use **/
   __IOM uint32_t DCDCLPEM01CFG;         /**< Configuration Bits for Low Power Mode to Be Applied During EM01, This Field is Only Relevant If LP Mode is Used in EM01  */
 
-  uint32_t       RESERVED8[4];          /**< Reserved for future use **/
+  uint32_t       RESERVED8[4U];         /**< Reserved for future use **/
   __IOM uint32_t EM23PERNORETAINCMD;    /**< Clears Corresponding Bits in EM23PERNORETAINSTATUS Unlocking Access to Peripheral  */
   __IM uint32_t  EM23PERNORETAINSTATUS; /**< Status Indicating If Peripherals Were Powered Down in EM23, Subsequently Locking Access to It  */
   __IOM uint32_t EM23PERNORETAINCTRL;   /**< When Set Corresponding Peripherals May Get Powered Down in EM23  */
 } EMU_TypeDef;                          /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG12P_EMU
  * @{
  * @defgroup EFR32MG12P_EMU_BitFields  EMU Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for EMU CTRL */
 #define _EMU_CTRL_RESETVALUE                                 0x00000000UL                                /**< Default value for EMU_CTRL */
@@ -132,7 +131,7 @@ typedef struct {
 #define _EMU_CTRL_EM01LD_MASK                                0x8UL                                       /**< Bit mask for EMU_EM01LD */
 #define _EMU_CTRL_EM01LD_DEFAULT                             0x00000000UL                                /**< Mode DEFAULT for EMU_CTRL */
 #define EMU_CTRL_EM01LD_DEFAULT                              (_EMU_CTRL_EM01LD_DEFAULT << 3)             /**< Shifted mode DEFAULT for EMU_CTRL */
-#define EMU_CTRL_EM23VSCALEAUTOWSEN                          (0x1UL << 4)                                /**< Automatically Configures Flash, Ram and Frequency to Wakeup From EM2 or EM3 at Low Voltage */
+#define EMU_CTRL_EM23VSCALEAUTOWSEN                          (0x1UL << 4)                                /**< Automatically Configures Flash and Frequency to Wakeup From EM2 or EM3 at Low Voltage */
 #define _EMU_CTRL_EM23VSCALEAUTOWSEN_SHIFT                   4                                           /**< Shift value for EMU_EM23VSCALEAUTOWSEN */
 #define _EMU_CTRL_EM23VSCALEAUTOWSEN_MASK                    0x10UL                                      /**< Bit mask for EMU_EM23VSCALEAUTOWSEN */
 #define _EMU_CTRL_EM23VSCALEAUTOWSEN_DEFAULT                 0x00000000UL                                /**< Mode DEFAULT for EMU_CTRL */
@@ -1400,11 +1399,11 @@ typedef struct {
 #define _EMU_EM23PERNORETAINCTRL_I2C1DIS_MASK                0x40UL                                               /**< Bit mask for EMU_I2C1DIS */
 #define _EMU_EM23PERNORETAINCTRL_I2C1DIS_DEFAULT             0x00000000UL                                         /**< Mode DEFAULT for EMU_EM23PERNORETAINCTRL */
 #define EMU_EM23PERNORETAINCTRL_I2C1DIS_DEFAULT              (_EMU_EM23PERNORETAINCTRL_I2C1DIS_DEFAULT << 6)      /**< Shifted mode DEFAULT for EMU_EM23PERNORETAINCTRL */
-#define EMU_EM23PERNORETAINCTRL_DAC0DIS                      (0x1UL << 7)                                         /**< Allow Power Down of DAC0 During EM23 */
-#define _EMU_EM23PERNORETAINCTRL_DAC0DIS_SHIFT               7                                                    /**< Shift value for EMU_DAC0DIS */
-#define _EMU_EM23PERNORETAINCTRL_DAC0DIS_MASK                0x80UL                                               /**< Bit mask for EMU_DAC0DIS */
-#define _EMU_EM23PERNORETAINCTRL_DAC0DIS_DEFAULT             0x00000000UL                                         /**< Mode DEFAULT for EMU_EM23PERNORETAINCTRL */
-#define EMU_EM23PERNORETAINCTRL_DAC0DIS_DEFAULT              (_EMU_EM23PERNORETAINCTRL_DAC0DIS_DEFAULT << 7)      /**< Shifted mode DEFAULT for EMU_EM23PERNORETAINCTRL */
+#define EMU_EM23PERNORETAINCTRL_VDAC0DIS                     (0x1UL << 7)                                         /**< Allow Power Down of DAC0 During EM23 */
+#define _EMU_EM23PERNORETAINCTRL_VDAC0DIS_SHIFT              7                                                    /**< Shift value for EMU_VDAC0DIS */
+#define _EMU_EM23PERNORETAINCTRL_VDAC0DIS_MASK               0x80UL                                               /**< Bit mask for EMU_VDAC0DIS */
+#define _EMU_EM23PERNORETAINCTRL_VDAC0DIS_DEFAULT            0x00000000UL                                         /**< Mode DEFAULT for EMU_EM23PERNORETAINCTRL */
+#define EMU_EM23PERNORETAINCTRL_VDAC0DIS_DEFAULT             (_EMU_EM23PERNORETAINCTRL_VDAC0DIS_DEFAULT << 7)     /**< Shifted mode DEFAULT for EMU_EM23PERNORETAINCTRL */
 #define EMU_EM23PERNORETAINCTRL_IDAC0DIS                     (0x1UL << 8)                                         /**< Allow Power Down of IDAC0 During EM23 */
 #define _EMU_EM23PERNORETAINCTRL_IDAC0DIS_SHIFT              8                                                    /**< Shift value for EMU_IDAC0DIS */
 #define _EMU_EM23PERNORETAINCTRL_IDAC0DIS_MASK               0x100UL                                              /**< Bit mask for EMU_IDAC0DIS */

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_etm.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_etm.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg12p_etm.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG12P_ETM register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,83 +40,83 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG12P_ETM ETM
  * @{
  * @brief EFR32MG12P_ETM Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** ETM Register Declaration */
 typedef struct {
-  __IOM uint32_t ETMCR;           /**< Main Control Register  */
-  __IM uint32_t  ETMCCR;          /**< Configuration Code Register  */
-  __IOM uint32_t ETMTRIGGER;      /**< ETM Trigger Event Register  */
-  uint32_t       RESERVED0[1];    /**< Reserved for future use **/
-  __IOM uint32_t ETMSR;           /**< ETM Status Register  */
-  __IM uint32_t  ETMSCR;          /**< ETM System Configuration Register  */
-  uint32_t       RESERVED1[2];    /**< Reserved for future use **/
-  __IOM uint32_t ETMTEEVR;        /**< ETM TraceEnable Event Register  */
-  __IOM uint32_t ETMTECR1;        /**< ETM Trace control Register  */
-  uint32_t       RESERVED2[1];    /**< Reserved for future use **/
-  __IOM uint32_t ETMFFLR;         /**< ETM Fifo Full Level Register  */
-  uint32_t       RESERVED3[68];   /**< Reserved for future use **/
-  __IOM uint32_t ETMCNTRLDVR1;    /**< Counter Reload Value  */
-  uint32_t       RESERVED4[39];   /**< Reserved for future use **/
-  __IOM uint32_t ETMSYNCFR;       /**< Synchronisation Frequency Register  */
-  __IM uint32_t  ETMIDR;          /**< ID Register  */
-  __IM uint32_t  ETMCCER;         /**< Configuration Code Extension Register  */
-  uint32_t       RESERVED5[1];    /**< Reserved for future use **/
-  __IOM uint32_t ETMTESSEICR;     /**< TraceEnable Start/Stop EmbeddedICE Control Register  */
-  uint32_t       RESERVED6[1];    /**< Reserved for future use **/
-  __IOM uint32_t ETMTSEVR;        /**< Timestamp Event Register  */
-  uint32_t       RESERVED7[1];    /**< Reserved for future use **/
-  __IOM uint32_t ETMTRACEIDR;     /**< CoreSight Trace ID Register  */
-  uint32_t       RESERVED8[1];    /**< Reserved for future use **/
-  __IM uint32_t  ETMIDR2;         /**< ETM ID Register 2  */
-  uint32_t       RESERVED9[66];   /**< Reserved for future use **/
-  __IM uint32_t  ETMPDSR;         /**< Device Power-down Status Register  */
-  uint32_t       RESERVED10[754]; /**< Reserved for future use **/
-  __IOM uint32_t ETMISCIN;        /**< Integration Test Miscellaneous Inputs Register  */
-  uint32_t       RESERVED11[1];   /**< Reserved for future use **/
-  __IOM uint32_t ITTRIGOUT;       /**< Integration Test Trigger Out Register  */
-  uint32_t       RESERVED12[1];   /**< Reserved for future use **/
-  __IM uint32_t  ETMITATBCTR2;    /**< ETM Integration Test ATB Control 2 Register  */
-  uint32_t       RESERVED13[1];   /**< Reserved for future use **/
-  __IOM uint32_t ETMITATBCTR0;    /**< ETM Integration Test ATB Control 0 Register  */
-  uint32_t       RESERVED14[1];   /**< Reserved for future use **/
-  __IOM uint32_t ETMITCTRL;       /**< ETM Integration Control Register  */
-  uint32_t       RESERVED15[39];  /**< Reserved for future use **/
-  __IOM uint32_t ETMCLAIMSET;     /**< ETM Claim Tag Set Register  */
-  __IOM uint32_t ETMCLAIMCLR;     /**< ETM Claim Tag Clear Register  */
-  uint32_t       RESERVED16[2];   /**< Reserved for future use **/
-  __IOM uint32_t ETMLAR;          /**< ETM Lock Access Register  */
-  __IM uint32_t  ETMLSR;          /**< Lock Status Register  */
-  __IM uint32_t  ETMAUTHSTATUS;   /**< ETM Authentication Status Register  */
-  uint32_t       RESERVED17[4];   /**< Reserved for future use **/
-  __IM uint32_t  ETMDEVTYPE;      /**< CoreSight Device Type Register  */
-  __IM uint32_t  ETMPIDR4;        /**< Peripheral ID4 Register  */
-  __OM uint32_t  ETMPIDR5;        /**< Peripheral ID5 Register  */
-  __OM uint32_t  ETMPIDR6;        /**< Peripheral ID6 Register  */
-  __OM uint32_t  ETMPIDR7;        /**< Peripheral ID7 Register  */
-  __IM uint32_t  ETMPIDR0;        /**< Peripheral ID0 Register  */
-  __IM uint32_t  ETMPIDR1;        /**< Peripheral ID1 Register  */
-  __IM uint32_t  ETMPIDR2;        /**< Peripheral ID2 Register  */
-  __IM uint32_t  ETMPIDR3;        /**< Peripheral ID3 Register  */
-  __IM uint32_t  ETMCIDR0;        /**< Component ID0 Register  */
-  __IM uint32_t  ETMCIDR1;        /**< Component ID1 Register  */
-  __IM uint32_t  ETMCIDR2;        /**< Component ID2 Register  */
-  __IM uint32_t  ETMCIDR3;        /**< Component ID3 Register  */
-} ETM_TypeDef;                    /** @} */
+  __IOM uint32_t ETMCR;            /**< Main Control Register  */
+  __IM uint32_t  ETMCCR;           /**< Configuration Code Register  */
+  __IOM uint32_t ETMTRIGGER;       /**< ETM Trigger Event Register  */
+  uint32_t       RESERVED0[1U];    /**< Reserved for future use **/
+  __IOM uint32_t ETMSR;            /**< ETM Status Register  */
+  __IM uint32_t  ETMSCR;           /**< ETM System Configuration Register  */
+  uint32_t       RESERVED1[2U];    /**< Reserved for future use **/
+  __IOM uint32_t ETMTEEVR;         /**< ETM TraceEnable Event Register  */
+  __IOM uint32_t ETMTECR1;         /**< ETM Trace control Register  */
+  uint32_t       RESERVED2[1U];    /**< Reserved for future use **/
+  __IOM uint32_t ETMFFLR;          /**< ETM Fifo Full Level Register  */
+  uint32_t       RESERVED3[68U];   /**< Reserved for future use **/
+  __IOM uint32_t ETMCNTRLDVR1;     /**< Counter Reload Value  */
+  uint32_t       RESERVED4[39U];   /**< Reserved for future use **/
+  __IOM uint32_t ETMSYNCFR;        /**< Synchronisation Frequency Register  */
+  __IM uint32_t  ETMIDR;           /**< ID Register  */
+  __IM uint32_t  ETMCCER;          /**< Configuration Code Extension Register  */
+  uint32_t       RESERVED5[1U];    /**< Reserved for future use **/
+  __IOM uint32_t ETMTESSEICR;      /**< TraceEnable Start/Stop EmbeddedICE Control Register  */
+  uint32_t       RESERVED6[1U];    /**< Reserved for future use **/
+  __IOM uint32_t ETMTSEVR;         /**< Timestamp Event Register  */
+  uint32_t       RESERVED7[1U];    /**< Reserved for future use **/
+  __IOM uint32_t ETMTRACEIDR;      /**< CoreSight Trace ID Register  */
+  uint32_t       RESERVED8[1U];    /**< Reserved for future use **/
+  __IM uint32_t  ETMIDR2;          /**< ETM ID Register 2  */
+  uint32_t       RESERVED9[66U];   /**< Reserved for future use **/
+  __IM uint32_t  ETMPDSR;          /**< Device Power-down Status Register  */
+  uint32_t       RESERVED10[754U]; /**< Reserved for future use **/
+  __IOM uint32_t ETMISCIN;         /**< Integration Test Miscellaneous Inputs Register  */
+  uint32_t       RESERVED11[1U];   /**< Reserved for future use **/
+  __IOM uint32_t ITTRIGOUT;        /**< Integration Test Trigger Out Register  */
+  uint32_t       RESERVED12[1U];   /**< Reserved for future use **/
+  __IM uint32_t  ETMITATBCTR2;     /**< ETM Integration Test ATB Control 2 Register  */
+  uint32_t       RESERVED13[1U];   /**< Reserved for future use **/
+  __IOM uint32_t ETMITATBCTR0;     /**< ETM Integration Test ATB Control 0 Register  */
+  uint32_t       RESERVED14[1U];   /**< Reserved for future use **/
+  __IOM uint32_t ETMITCTRL;        /**< ETM Integration Control Register  */
+  uint32_t       RESERVED15[39U];  /**< Reserved for future use **/
+  __IOM uint32_t ETMCLAIMSET;      /**< ETM Claim Tag Set Register  */
+  __IOM uint32_t ETMCLAIMCLR;      /**< ETM Claim Tag Clear Register  */
+  uint32_t       RESERVED16[2U];   /**< Reserved for future use **/
+  __IOM uint32_t ETMLAR;           /**< ETM Lock Access Register  */
+  __IM uint32_t  ETMLSR;           /**< Lock Status Register  */
+  __IM uint32_t  ETMAUTHSTATUS;    /**< ETM Authentication Status Register  */
+  uint32_t       RESERVED17[4U];   /**< Reserved for future use **/
+  __IM uint32_t  ETMDEVTYPE;       /**< CoreSight Device Type Register  */
+  __IM uint32_t  ETMPIDR4;         /**< Peripheral ID4 Register  */
+  __OM uint32_t  ETMPIDR5;         /**< Peripheral ID5 Register  */
+  __OM uint32_t  ETMPIDR6;         /**< Peripheral ID6 Register  */
+  __OM uint32_t  ETMPIDR7;         /**< Peripheral ID7 Register  */
+  __IM uint32_t  ETMPIDR0;         /**< Peripheral ID0 Register  */
+  __IM uint32_t  ETMPIDR1;         /**< Peripheral ID1 Register  */
+  __IM uint32_t  ETMPIDR2;         /**< Peripheral ID2 Register  */
+  __IM uint32_t  ETMPIDR3;         /**< Peripheral ID3 Register  */
+  __IM uint32_t  ETMCIDR0;         /**< Component ID0 Register  */
+  __IM uint32_t  ETMCIDR1;         /**< Component ID1 Register  */
+  __IM uint32_t  ETMCIDR2;         /**< Component ID2 Register  */
+  __IM uint32_t  ETMCIDR3;         /**< Component ID3 Register  */
+} ETM_TypeDef;                     /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG12P_ETM
  * @{
  * @defgroup EFR32MG12P_ETM_BitFields  ETM Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for ETM ETMCR */
 #define _ETM_ETMCR_RESETVALUE                         0x00000411UL                           /**< Default value for ETM_ETMCR */

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_fpueh.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_fpueh.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg12p_fpueh.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG12P_FPUEH register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG12P_FPUEH FPUEH
  * @{
  * @brief EFR32MG12P_FPUEH Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** FPUEH Register Declaration */
 typedef struct {
   __IM uint32_t  IF;  /**< Interrupt Flag Register  */
@@ -58,12 +57,12 @@ typedef struct {
   __IOM uint32_t IEN; /**< Interrupt Enable Register  */
 } FPUEH_TypeDef;      /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG12P_FPUEH
  * @{
  * @defgroup EFR32MG12P_FPUEH_BitFields  FPUEH Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for FPUEH IF */
 #define _FPUEH_IF_RESETVALUE        0x00000000UL                   /**< Default value for FPUEH_IF */

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_gpcrc.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_gpcrc.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg12p_gpcrc.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG12P_GPCRC register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG12P_GPCRC GPCRC
  * @{
  * @brief EFR32MG12P_GPCRC Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** GPCRC Register Declaration */
 typedef struct {
   __IOM uint32_t CTRL;           /**< Control Register  */
@@ -64,12 +63,12 @@ typedef struct {
   __IM uint32_t  DATABYTEREV;    /**< CRC Data Byte Reverse Register  */
 } GPCRC_TypeDef;                 /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG12P_GPCRC
  * @{
  * @defgroup EFR32MG12P_GPCRC_BitFields  GPCRC Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for GPCRC CTRL */
 #define _GPCRC_CTRL_RESETVALUE                          0x00000000UL                             /**< Default value for GPCRC_CTRL */

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_gpio.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_gpio.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg12p_gpio.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG12P_GPIO register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,49 +40,49 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG12P_GPIO GPIO
  * @{
  * @brief EFR32MG12P_GPIO Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** GPIO Register Declaration */
 typedef struct {
-  GPIO_P_TypeDef P[12];          /**< Port configuration bits */
+  GPIO_P_TypeDef P[12U];          /**< Port configuration bits */
 
-  uint32_t       RESERVED0[112]; /**< Reserved for future use **/
-  __IOM uint32_t EXTIPSELL;      /**< External Interrupt Port Select Low Register  */
-  __IOM uint32_t EXTIPSELH;      /**< External Interrupt Port Select High Register  */
-  __IOM uint32_t EXTIPINSELL;    /**< External Interrupt Pin Select Low Register  */
-  __IOM uint32_t EXTIPINSELH;    /**< External Interrupt Pin Select High Register  */
-  __IOM uint32_t EXTIRISE;       /**< External Interrupt Rising Edge Trigger Register  */
-  __IOM uint32_t EXTIFALL;       /**< External Interrupt Falling Edge Trigger Register  */
-  __IOM uint32_t EXTILEVEL;      /**< External Interrupt Level Register  */
-  __IM uint32_t  IF;             /**< Interrupt Flag Register  */
-  __IOM uint32_t IFS;            /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;            /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t IEN;            /**< Interrupt Enable Register  */
-  __IOM uint32_t EM4WUEN;        /**< EM4 Wake Up Enable Register  */
+  uint32_t       RESERVED0[112U]; /**< Reserved for future use **/
+  __IOM uint32_t EXTIPSELL;       /**< External Interrupt Port Select Low Register  */
+  __IOM uint32_t EXTIPSELH;       /**< External Interrupt Port Select High Register  */
+  __IOM uint32_t EXTIPINSELL;     /**< External Interrupt Pin Select Low Register  */
+  __IOM uint32_t EXTIPINSELH;     /**< External Interrupt Pin Select High Register  */
+  __IOM uint32_t EXTIRISE;        /**< External Interrupt Rising Edge Trigger Register  */
+  __IOM uint32_t EXTIFALL;        /**< External Interrupt Falling Edge Trigger Register  */
+  __IOM uint32_t EXTILEVEL;       /**< External Interrupt Level Register  */
+  __IM uint32_t  IF;              /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;             /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;             /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;             /**< Interrupt Enable Register  */
+  __IOM uint32_t EM4WUEN;         /**< EM4 Wake Up Enable Register  */
 
-  uint32_t       RESERVED1[4];   /**< Reserved for future use **/
-  __IOM uint32_t ROUTEPEN;       /**< I/O Routing Pin Enable Register  */
-  __IOM uint32_t ROUTELOC0;      /**< I/O Routing Location Register  */
-  __IOM uint32_t ROUTELOC1;      /**< I/O Routing Location Register 1  */
+  uint32_t       RESERVED1[4U];   /**< Reserved for future use **/
+  __IOM uint32_t ROUTEPEN;        /**< I/O Routing Pin Enable Register  */
+  __IOM uint32_t ROUTELOC0;       /**< I/O Routing Location Register  */
+  __IOM uint32_t ROUTELOC1;       /**< I/O Routing Location Register 1  */
 
-  uint32_t       RESERVED2[1];   /**< Reserved for future use **/
-  __IOM uint32_t INSENSE;        /**< Input Sense Register  */
-  __IOM uint32_t LOCK;           /**< Configuration Lock Register  */
-} GPIO_TypeDef;                  /** @} */
+  uint32_t       RESERVED2[1U];   /**< Reserved for future use **/
+  __IOM uint32_t INSENSE;         /**< Input Sense Register  */
+  __IOM uint32_t LOCK;            /**< Configuration Lock Register  */
+} GPIO_TypeDef;                   /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG12P_GPIO
  * @{
  * @defgroup EFR32MG12P_GPIO_BitFields  GPIO Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for GPIO P_CTRL */
 #define _GPIO_P_CTRL_RESETVALUE                         0x00500050UL                                  /**< Default value for GPIO_P_CTRL */

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_gpio_p.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_gpio_p.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg12p_gpio_p.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG12P_GPIO_P register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,26 +40,26 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief GPIO_P GPIO P Register
  * @ingroup EFR32MG12P_GPIO
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IOM uint32_t CTRL;         /**< Port Control Register  */
-  __IOM uint32_t MODEL;        /**< Port Pin Mode Low Register  */
-  __IOM uint32_t MODEH;        /**< Port Pin Mode High Register  */
-  __IOM uint32_t DOUT;         /**< Port Data Out Register  */
-  uint32_t       RESERVED0[2]; /**< Reserved for future use **/
-  __IOM uint32_t DOUTTGL;      /**< Port Data Out Toggle Register  */
-  __IM uint32_t  DIN;          /**< Port Data in Register  */
-  __IOM uint32_t PINLOCKN;     /**< Port Unlocked Pins Register  */
-  uint32_t       RESERVED1[1]; /**< Reserved for future use **/
-  __IOM uint32_t OVTDIS;       /**< Over Voltage Disable for All Modes  */
-  uint32_t       RESERVED2[1]; /**< Reserved future */
+  __IOM uint32_t CTRL;          /**< Port Control Register  */
+  __IOM uint32_t MODEL;         /**< Port Pin Mode Low Register  */
+  __IOM uint32_t MODEH;         /**< Port Pin Mode High Register  */
+  __IOM uint32_t DOUT;          /**< Port Data Out Register  */
+  uint32_t       RESERVED0[2U]; /**< Reserved for future use **/
+  __IOM uint32_t DOUTTGL;       /**< Port Data Out Toggle Register  */
+  __IM uint32_t  DIN;           /**< Port Data in Register  */
+  __IOM uint32_t PINLOCKN;      /**< Port Unlocked Pins Register  */
+  uint32_t       RESERVED1[1U]; /**< Reserved for future use **/
+  __IOM uint32_t OVTDIS;        /**< Over Voltage Disable for All Modes  */
+  uint32_t       RESERVED2[1U]; /**< Reserved future */
 } GPIO_P_TypeDef;
 
 /** @} End of group Parts */

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_i2c.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_i2c.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg12p_i2c.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG12P_I2C register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG12P_I2C I2C
  * @{
  * @brief EFR32MG12P_I2C Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** I2C Register Declaration */
 typedef struct {
   __IOM uint32_t CTRL;      /**< Control Register  */
@@ -73,12 +72,12 @@ typedef struct {
   __IOM uint32_t ROUTELOC0; /**< I/O Routing Location Register  */
 } I2C_TypeDef;              /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG12P_I2C
  * @{
  * @defgroup EFR32MG12P_I2C_BitFields  I2C Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for I2C CTRL */
 #define _I2C_CTRL_RESETVALUE               0x00000000UL                     /**< Default value for I2C_CTRL */
@@ -426,7 +425,7 @@ typedef struct {
 #define I2C_IF_TXBL                        (0x1UL << 4)                    /**< Transmit Buffer Level Interrupt Flag */
 #define _I2C_IF_TXBL_SHIFT                 4                               /**< Shift value for I2C_TXBL */
 #define _I2C_IF_TXBL_MASK                  0x10UL                          /**< Bit mask for I2C_TXBL */
-#define _I2C_IF_TXBL_DEFAULT               0x00000000UL                    /**< Mode DEFAULT for I2C_IF */
+#define _I2C_IF_TXBL_DEFAULT               0x00000001UL                    /**< Mode DEFAULT for I2C_IF */
 #define I2C_IF_TXBL_DEFAULT                (_I2C_IF_TXBL_DEFAULT << 4)     /**< Shifted mode DEFAULT for I2C_IF */
 #define I2C_IF_RXDATAV                     (0x1UL << 5)                    /**< Receive Data Valid Interrupt Flag */
 #define _I2C_IF_RXDATAV_SHIFT              5                               /**< Shift value for I2C_RXDATAV */

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_idac.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_idac.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg12p_idac.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG12P_IDAC register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,40 +40,40 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG12P_IDAC IDAC
  * @{
  * @brief EFR32MG12P_IDAC Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** IDAC Register Declaration */
 typedef struct {
   __IOM uint32_t CTRL;          /**< Control Register  */
   __IOM uint32_t CURPROG;       /**< Current Programming Register  */
-  uint32_t       RESERVED0[1];  /**< Reserved for future use **/
+  uint32_t       RESERVED0[1U]; /**< Reserved for future use **/
   __IOM uint32_t DUTYCONFIG;    /**< Duty Cycle Configuration Register  */
 
-  uint32_t       RESERVED1[2];  /**< Reserved for future use **/
+  uint32_t       RESERVED1[2U]; /**< Reserved for future use **/
   __IM uint32_t  STATUS;        /**< Status Register  */
-  uint32_t       RESERVED2[1];  /**< Reserved for future use **/
+  uint32_t       RESERVED2[1U]; /**< Reserved for future use **/
   __IM uint32_t  IF;            /**< Interrupt Flag Register  */
   __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
   __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
   __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
-  uint32_t       RESERVED3[1];  /**< Reserved for future use **/
+  uint32_t       RESERVED3[1U]; /**< Reserved for future use **/
   __IM uint32_t  APORTREQ;      /**< APORT Request Status Register  */
   __IM uint32_t  APORTCONFLICT; /**< APORT Request Status Register  */
 } IDAC_TypeDef;                 /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG12P_IDAC
  * @{
  * @defgroup EFR32MG12P_IDAC_BitFields  IDAC Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for IDAC CTRL */
 #define _IDAC_CTRL_RESETVALUE                          0x00000000UL                              /**< Default value for IDAC_CTRL */

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_ldma.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_ldma.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg12p_ldma.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG12P_LDMA register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,46 +40,46 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG12P_LDMA LDMA
  * @{
  * @brief EFR32MG12P_LDMA Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** LDMA Register Declaration */
 typedef struct {
-  __IOM uint32_t  CTRL;         /**< DMA Control Register  */
-  __IM uint32_t   STATUS;       /**< DMA Status Register  */
-  __IOM uint32_t  SYNC;         /**< DMA Synchronization Trigger Register (Single-Cycle RMW)  */
-  uint32_t        RESERVED0[5]; /**< Reserved for future use **/
-  __IOM uint32_t  CHEN;         /**< DMA Channel Enable Register (Single-Cycle RMW)  */
-  __IM uint32_t   CHBUSY;       /**< DMA Channel Busy Register  */
-  __IOM uint32_t  CHDONE;       /**< DMA Channel Linking Done Register (Single-Cycle RMW)  */
-  __IOM uint32_t  DBGHALT;      /**< DMA Channel Debug Halt Register  */
-  __IOM uint32_t  SWREQ;        /**< DMA Channel Software Transfer Request Register  */
-  __IOM uint32_t  REQDIS;       /**< DMA Channel Request Disable Register  */
-  __IM uint32_t   REQPEND;      /**< DMA Channel Requests Pending Register  */
-  __IOM uint32_t  LINKLOAD;     /**< DMA Channel Link Load Register  */
-  __IOM uint32_t  REQCLEAR;     /**< DMA Channel Request Clear Register  */
-  uint32_t        RESERVED1[7]; /**< Reserved for future use **/
-  __IM uint32_t   IF;           /**< Interrupt Flag Register  */
-  __IOM uint32_t  IFS;          /**< Interrupt Flag Set Register  */
-  __IOM uint32_t  IFC;          /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t  IEN;          /**< Interrupt Enable Register  */
+  __IOM uint32_t  CTRL;          /**< DMA Control Register  */
+  __IM uint32_t   STATUS;        /**< DMA Status Register  */
+  __IOM uint32_t  SYNC;          /**< DMA Synchronization Trigger Register (Single-Cycle RMW)  */
+  uint32_t        RESERVED0[5U]; /**< Reserved for future use **/
+  __IOM uint32_t  CHEN;          /**< DMA Channel Enable Register (Single-Cycle RMW)  */
+  __IM uint32_t   CHBUSY;        /**< DMA Channel Busy Register  */
+  __IOM uint32_t  CHDONE;        /**< DMA Channel Linking Done Register (Single-Cycle RMW)  */
+  __IOM uint32_t  DBGHALT;       /**< DMA Channel Debug Halt Register  */
+  __IOM uint32_t  SWREQ;         /**< DMA Channel Software Transfer Request Register  */
+  __IOM uint32_t  REQDIS;        /**< DMA Channel Request Disable Register  */
+  __IM uint32_t   REQPEND;       /**< DMA Channel Requests Pending Register  */
+  __IOM uint32_t  LINKLOAD;      /**< DMA Channel Link Load Register  */
+  __IOM uint32_t  REQCLEAR;      /**< DMA Channel Request Clear Register  */
+  uint32_t        RESERVED1[7U]; /**< Reserved for future use **/
+  __IM uint32_t   IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t  IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t  IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t  IEN;           /**< Interrupt Enable Register  */
 
-  uint32_t        RESERVED2[4]; /**< Reserved registers */
-  LDMA_CH_TypeDef CH[8];        /**< DMA Channel Registers */
-} LDMA_TypeDef;                 /** @} */
+  uint32_t        RESERVED2[4U]; /**< Reserved registers */
+  LDMA_CH_TypeDef CH[8U];        /**< DMA Channel Registers */
+} LDMA_TypeDef;                  /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG12P_LDMA
  * @{
  * @defgroup EFR32MG12P_LDMA_BitFields  LDMA Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for LDMA CTRL */
 #define _LDMA_CTRL_RESETVALUE                        0x07000000UL                           /**< Default value for LDMA_CTRL */

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_ldma_ch.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_ldma_ch.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg12p_ldma_ch.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG12P_LDMA_CH register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,23 +40,23 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief LDMA_CH LDMA CH Register
  * @ingroup EFR32MG12P_LDMA
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IOM uint32_t REQSEL;       /**< Channel Peripheral Request Select Register  */
-  __IOM uint32_t CFG;          /**< Channel Configuration Register  */
-  __IOM uint32_t LOOP;         /**< Channel Loop Counter Register  */
-  __IOM uint32_t CTRL;         /**< Channel Descriptor Control Word Register  */
-  __IOM uint32_t SRC;          /**< Channel Descriptor Source Data Address Register  */
-  __IOM uint32_t DST;          /**< Channel Descriptor Destination Data Address Register  */
-  __IOM uint32_t LINK;         /**< Channel Descriptor Link Structure Address Register  */
-  uint32_t       RESERVED0[5]; /**< Reserved future */
+  __IOM uint32_t REQSEL;        /**< Channel Peripheral Request Select Register  */
+  __IOM uint32_t CFG;           /**< Channel Configuration Register  */
+  __IOM uint32_t LOOP;          /**< Channel Loop Counter Register  */
+  __IOM uint32_t CTRL;          /**< Channel Descriptor Control Word Register  */
+  __IOM uint32_t SRC;           /**< Channel Descriptor Source Data Address Register  */
+  __IOM uint32_t DST;           /**< Channel Descriptor Destination Data Address Register  */
+  __IOM uint32_t LINK;          /**< Channel Descriptor Link Structure Address Register  */
+  uint32_t       RESERVED0[5U]; /**< Reserved future */
 } LDMA_CH_TypeDef;
 
 /** @} End of group Parts */

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_lesense.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_lesense.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg12p_lesense.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG12P_LESENSE register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,57 +40,57 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG12P_LESENSE LESENSE
  * @{
  * @brief EFR32MG12P_LESENSE Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** LESENSE Register Declaration */
 typedef struct {
-  __IOM uint32_t      CTRL;          /**< Control Register  */
-  __IOM uint32_t      TIMCTRL;       /**< Timing Control Register  */
-  __IOM uint32_t      PERCTRL;       /**< Peripheral Control Register  */
-  __IOM uint32_t      DECCTRL;       /**< Decoder Control Register  */
-  __IOM uint32_t      BIASCTRL;      /**< Bias Control Register  */
-  __IOM uint32_t      EVALCTRL;      /**< LESENSE Evaluation Control  */
-  __IOM uint32_t      PRSCTRL;       /**< PRS Control Register  */
-  __IOM uint32_t      CMD;           /**< Command Register  */
-  __IOM uint32_t      CHEN;          /**< Channel Enable Register  */
-  __IOM uint32_t      SCANRES;       /**< Scan Result Register  */
-  __IM uint32_t       STATUS;        /**< Status Register  */
-  __IM uint32_t       PTR;           /**< Result Buffer Pointers  */
-  __IM uint32_t       BUFDATA;       /**< Result Buffer Data Register  */
-  __IM uint32_t       CURCH;         /**< Current Channel Index  */
-  __IOM uint32_t      DECSTATE;      /**< Current Decoder State  */
-  __IOM uint32_t      SENSORSTATE;   /**< Decoder Input Register  */
-  __IOM uint32_t      IDLECONF;      /**< GPIO Idle Phase Configuration  */
-  __IOM uint32_t      ALTEXCONF;     /**< Alternative Excite Pin Configuration  */
-  uint32_t            RESERVED0[2];  /**< Reserved for future use **/
-  __IM uint32_t       IF;            /**< Interrupt Flag Register  */
-  __IOM uint32_t      IFS;           /**< Interrupt Flag Set Register  */
-  __IOM uint32_t      IFC;           /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t      IEN;           /**< Interrupt Enable Register  */
-  __IM uint32_t       SYNCBUSY;      /**< Synchronization Busy Register  */
-  __IOM uint32_t      ROUTEPEN;      /**< I/O Routing Register  */
+  __IOM uint32_t      CTRL;           /**< Control Register  */
+  __IOM uint32_t      TIMCTRL;        /**< Timing Control Register  */
+  __IOM uint32_t      PERCTRL;        /**< Peripheral Control Register  */
+  __IOM uint32_t      DECCTRL;        /**< Decoder Control Register  */
+  __IOM uint32_t      BIASCTRL;       /**< Bias Control Register  */
+  __IOM uint32_t      EVALCTRL;       /**< LESENSE Evaluation Control  */
+  __IOM uint32_t      PRSCTRL;        /**< PRS Control Register  */
+  __IOM uint32_t      CMD;            /**< Command Register  */
+  __IOM uint32_t      CHEN;           /**< Channel Enable Register  */
+  __IOM uint32_t      SCANRES;        /**< Scan Result Register  */
+  __IM uint32_t       STATUS;         /**< Status Register  */
+  __IM uint32_t       PTR;            /**< Result Buffer Pointers  */
+  __IM uint32_t       BUFDATA;        /**< Result Buffer Data Register  */
+  __IM uint32_t       CURCH;          /**< Current Channel Index  */
+  __IOM uint32_t      DECSTATE;       /**< Current Decoder State  */
+  __IOM uint32_t      SENSORSTATE;    /**< Decoder Input Register  */
+  __IOM uint32_t      IDLECONF;       /**< GPIO Idle Phase Configuration  */
+  __IOM uint32_t      ALTEXCONF;      /**< Alternative Excite Pin Configuration  */
+  uint32_t            RESERVED0[2U];  /**< Reserved for future use **/
+  __IM uint32_t       IF;             /**< Interrupt Flag Register  */
+  __IOM uint32_t      IFS;            /**< Interrupt Flag Set Register  */
+  __IOM uint32_t      IFC;            /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t      IEN;            /**< Interrupt Enable Register  */
+  __IM uint32_t       SYNCBUSY;       /**< Synchronization Busy Register  */
+  __IOM uint32_t      ROUTEPEN;       /**< I/O Routing Register  */
 
-  uint32_t            RESERVED1[38]; /**< Reserved registers */
-  LESENSE_ST_TypeDef  ST[32];        /**< Decoding states */
+  uint32_t            RESERVED1[38U]; /**< Reserved registers */
+  LESENSE_ST_TypeDef  ST[32U];        /**< Decoding states */
 
-  LESENSE_BUF_TypeDef BUF[16];       /**< Scanresult */
+  LESENSE_BUF_TypeDef BUF[16U];       /**< Scanresult */
 
-  LESENSE_CH_TypeDef  CH[16];        /**< Scanconfig */
-} LESENSE_TypeDef;                   /** @} */
+  LESENSE_CH_TypeDef  CH[16U];        /**< Scanconfig */
+} LESENSE_TypeDef;                    /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG12P_LESENSE
  * @{
  * @defgroup EFR32MG12P_LESENSE_BitFields  LESENSE Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for LESENSE CTRL */
 #define _LESENSE_CTRL_RESETVALUE                       0x00000000UL                             /**< Default value for LESENSE_CTRL */

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_lesense_buf.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_lesense_buf.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg12p_lesense_buf.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG12P_LESENSE_BUF register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,14 +40,14 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief LESENSE_BUF LESENSE BUF Register
  * @ingroup EFR32MG12P_LESENSE
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t DATA; /**< Scan Results  */
 } LESENSE_BUF_TypeDef;

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_lesense_ch.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_lesense_ch.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg12p_lesense_ch.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG12P_LESENSE_CH register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,19 +40,19 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief LESENSE_CH LESENSE CH Register
  * @ingroup EFR32MG12P_LESENSE
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IOM uint32_t TIMING;       /**< Scan Configuration  */
-  __IOM uint32_t INTERACT;     /**< Scan Configuration  */
-  __IOM uint32_t EVAL;         /**< Scan Configuration  */
-  uint32_t       RESERVED0[1]; /**< Reserved future */
+  __IOM uint32_t TIMING;        /**< Scan Configuration  */
+  __IOM uint32_t INTERACT;      /**< Scan Configuration  */
+  __IOM uint32_t EVAL;          /**< Scan Configuration  */
+  uint32_t       RESERVED0[1U]; /**< Reserved future */
 } LESENSE_CH_TypeDef;
 
 /** @} End of group Parts */

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_lesense_st.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_lesense_st.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg12p_lesense_st.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG12P_LESENSE_ST register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,14 +40,14 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief LESENSE_ST LESENSE ST Register
  * @ingroup EFR32MG12P_LESENSE
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t TCONFA; /**< State Transition Configuration a  */
   __IOM uint32_t TCONFB; /**< State Transition Configuration B  */

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_letimer.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_letimer.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg12p_letimer.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG12P_LETIMER register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,47 +40,47 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG12P_LETIMER LETIMER
  * @{
  * @brief EFR32MG12P_LETIMER Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** LETIMER Register Declaration */
 typedef struct {
-  __IOM uint32_t CTRL;         /**< Control Register  */
-  __IOM uint32_t CMD;          /**< Command Register  */
-  __IM uint32_t  STATUS;       /**< Status Register  */
-  __IOM uint32_t CNT;          /**< Counter Value Register  */
-  __IOM uint32_t COMP0;        /**< Compare Value Register 0  */
-  __IOM uint32_t COMP1;        /**< Compare Value Register 1  */
-  __IOM uint32_t REP0;         /**< Repeat Counter Register 0  */
-  __IOM uint32_t REP1;         /**< Repeat Counter Register 1  */
-  __IM uint32_t  IF;           /**< Interrupt Flag Register  */
-  __IOM uint32_t IFS;          /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;          /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t IEN;          /**< Interrupt Enable Register  */
+  __IOM uint32_t CTRL;          /**< Control Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IOM uint32_t CNT;           /**< Counter Value Register  */
+  __IOM uint32_t COMP0;         /**< Compare Value Register 0  */
+  __IOM uint32_t COMP1;         /**< Compare Value Register 1  */
+  __IOM uint32_t REP0;          /**< Repeat Counter Register 0  */
+  __IOM uint32_t REP1;          /**< Repeat Counter Register 1  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
 
-  uint32_t       RESERVED0[1]; /**< Reserved for future use **/
-  __IM uint32_t  SYNCBUSY;     /**< Synchronization Busy Register  */
+  uint32_t       RESERVED0[1U]; /**< Reserved for future use **/
+  __IM uint32_t  SYNCBUSY;      /**< Synchronization Busy Register  */
 
-  uint32_t       RESERVED1[2]; /**< Reserved for future use **/
-  __IOM uint32_t ROUTEPEN;     /**< I/O Routing Pin Enable Register  */
-  __IOM uint32_t ROUTELOC0;    /**< I/O Routing Location Register  */
+  uint32_t       RESERVED1[2U]; /**< Reserved for future use **/
+  __IOM uint32_t ROUTEPEN;      /**< I/O Routing Pin Enable Register  */
+  __IOM uint32_t ROUTELOC0;     /**< I/O Routing Location Register  */
 
-  uint32_t       RESERVED2[2]; /**< Reserved for future use **/
-  __IOM uint32_t PRSSEL;       /**< PRS Input Select Register  */
-} LETIMER_TypeDef;             /** @} */
+  uint32_t       RESERVED2[2U]; /**< Reserved for future use **/
+  __IOM uint32_t PRSSEL;        /**< PRS Input Select Register  */
+} LETIMER_TypeDef;              /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG12P_LETIMER
  * @{
  * @defgroup EFR32MG12P_LETIMER_BitFields  LETIMER Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for LETIMER CTRL */
 #define _LETIMER_CTRL_RESETVALUE                0x00000000UL                           /**< Default value for LETIMER_CTRL */

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_leuart.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_leuart.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg12p_leuart.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG12P_LEUART register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,50 +40,50 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG12P_LEUART LEUART
  * @{
  * @brief EFR32MG12P_LEUART Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** LEUART Register Declaration */
 typedef struct {
-  __IOM uint32_t CTRL;         /**< Control Register  */
-  __IOM uint32_t CMD;          /**< Command Register  */
-  __IM uint32_t  STATUS;       /**< Status Register  */
-  __IOM uint32_t CLKDIV;       /**< Clock Control Register  */
-  __IOM uint32_t STARTFRAME;   /**< Start Frame Register  */
-  __IOM uint32_t SIGFRAME;     /**< Signal Frame Register  */
-  __IM uint32_t  RXDATAX;      /**< Receive Buffer Data Extended Register  */
-  __IM uint32_t  RXDATA;       /**< Receive Buffer Data Register  */
-  __IM uint32_t  RXDATAXP;     /**< Receive Buffer Data Extended Peek Register  */
-  __IOM uint32_t TXDATAX;      /**< Transmit Buffer Data Extended Register  */
-  __IOM uint32_t TXDATA;       /**< Transmit Buffer Data Register  */
-  __IM uint32_t  IF;           /**< Interrupt Flag Register  */
-  __IOM uint32_t IFS;          /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;          /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t IEN;          /**< Interrupt Enable Register  */
-  __IOM uint32_t PULSECTRL;    /**< Pulse Control Register  */
+  __IOM uint32_t CTRL;          /**< Control Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IOM uint32_t CLKDIV;        /**< Clock Control Register  */
+  __IOM uint32_t STARTFRAME;    /**< Start Frame Register  */
+  __IOM uint32_t SIGFRAME;      /**< Signal Frame Register  */
+  __IM uint32_t  RXDATAX;       /**< Receive Buffer Data Extended Register  */
+  __IM uint32_t  RXDATA;        /**< Receive Buffer Data Register  */
+  __IM uint32_t  RXDATAXP;      /**< Receive Buffer Data Extended Peek Register  */
+  __IOM uint32_t TXDATAX;       /**< Transmit Buffer Data Extended Register  */
+  __IOM uint32_t TXDATA;        /**< Transmit Buffer Data Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t PULSECTRL;     /**< Pulse Control Register  */
 
-  __IOM uint32_t FREEZE;       /**< Freeze Register  */
-  __IM uint32_t  SYNCBUSY;     /**< Synchronization Busy Register  */
+  __IOM uint32_t FREEZE;        /**< Freeze Register  */
+  __IM uint32_t  SYNCBUSY;      /**< Synchronization Busy Register  */
 
-  uint32_t       RESERVED0[3]; /**< Reserved for future use **/
-  __IOM uint32_t ROUTEPEN;     /**< I/O Routing Pin Enable Register  */
-  __IOM uint32_t ROUTELOC0;    /**< I/O Routing Location Register  */
-  uint32_t       RESERVED1[2]; /**< Reserved for future use **/
-  __IOM uint32_t INPUT;        /**< LEUART Input Register  */
-} LEUART_TypeDef;              /** @} */
+  uint32_t       RESERVED0[3U]; /**< Reserved for future use **/
+  __IOM uint32_t ROUTEPEN;      /**< I/O Routing Pin Enable Register  */
+  __IOM uint32_t ROUTELOC0;     /**< I/O Routing Location Register  */
+  uint32_t       RESERVED1[2U]; /**< Reserved for future use **/
+  __IOM uint32_t INPUT;         /**< LEUART Input Register  */
+} LEUART_TypeDef;               /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG12P_LEUART
  * @{
  * @defgroup EFR32MG12P_LEUART_BitFields  LEUART Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for LEUART CTRL */
 #define _LEUART_CTRL_RESETVALUE                  0x00000000UL                         /**< Default value for LEUART_CTRL */

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_msc.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_msc.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg12p_msc.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG12P_MSC register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG12P_MSC MSC
  * @{
  * @brief EFR32MG12P_MSC Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** MSC Register Declaration */
 typedef struct {
   __IOM uint32_t CTRL;           /**< Memory System Control Register  */
@@ -57,11 +56,11 @@ typedef struct {
   __IOM uint32_t WRITECTRL;      /**< Write Control Register  */
   __IOM uint32_t WRITECMD;       /**< Write Command Register  */
   __IOM uint32_t ADDRB;          /**< Page Erase/Write Address Buffer  */
-  uint32_t       RESERVED0[1];   /**< Reserved for future use **/
+  uint32_t       RESERVED0[1U];  /**< Reserved for future use **/
   __IOM uint32_t WDATA;          /**< Write Data Register  */
   __IM uint32_t  STATUS;         /**< Status Register  */
 
-  uint32_t       RESERVED1[4];   /**< Reserved for future use **/
+  uint32_t       RESERVED1[4U];  /**< Reserved for future use **/
   __IM uint32_t  IF;             /**< Interrupt Flag Register  */
   __IOM uint32_t IFS;            /**< Interrupt Flag Set Register  */
   __IOM uint32_t IFC;            /**< Interrupt Flag Clear Register  */
@@ -71,31 +70,31 @@ typedef struct {
   __IM uint32_t  CACHEHITS;      /**< Cache Hits Performance Counter  */
   __IM uint32_t  CACHEMISSES;    /**< Cache Misses Performance Counter  */
 
-  uint32_t       RESERVED2[1];   /**< Reserved for future use **/
+  uint32_t       RESERVED2[1U];  /**< Reserved for future use **/
   __IOM uint32_t MASSLOCK;       /**< Mass Erase Lock Register  */
 
-  uint32_t       RESERVED3[1];   /**< Reserved for future use **/
+  uint32_t       RESERVED3[1U];  /**< Reserved for future use **/
   __IOM uint32_t STARTUP;        /**< Startup Control  */
 
-  uint32_t       RESERVED4[4];   /**< Reserved for future use **/
+  uint32_t       RESERVED4[4U];  /**< Reserved for future use **/
   __IOM uint32_t BANKSWITCHLOCK; /**< Bank Switching Lock Register  */
   __IOM uint32_t CMD;            /**< Command Register  */
 
-  uint32_t       RESERVED5[6];   /**< Reserved for future use **/
+  uint32_t       RESERVED5[6U];  /**< Reserved for future use **/
   __IOM uint32_t BOOTLOADERCTRL; /**< Bootloader Read and Write Enable, Write Once Register  */
   __IOM uint32_t AAPUNLOCKCMD;   /**< Software Unlock AAP Command Register  */
   __IOM uint32_t CACHECONFIG0;   /**< Cache Configuration Register 0  */
 
-  uint32_t       RESERVED6[25];  /**< Reserved for future use **/
+  uint32_t       RESERVED6[25U]; /**< Reserved for future use **/
   __IOM uint32_t RAMCTRL;        /**< RAM Control Enable Register  */
 } MSC_TypeDef;                   /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG12P_MSC
  * @{
  * @defgroup EFR32MG12P_MSC_BitFields  MSC Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for MSC CTRL */
 #define _MSC_CTRL_RESETVALUE                              0x00000001UL                            /**< Default value for MSC_CTRL */
@@ -650,28 +649,18 @@ typedef struct {
 #define MSC_CACHECONFIG0_CACHELPLEVEL_MINACTIVITY         (_MSC_CACHECONFIG0_CACHELPLEVEL_MINACTIVITY << 0) /**< Shifted mode MINACTIVITY for MSC_CACHECONFIG0 */
 
 /* Bit fields for MSC RAMCTRL */
-#define _MSC_RAMCTRL_RESETVALUE                           0x00000000UL                               /**< Default value for MSC_RAMCTRL */
-#define _MSC_RAMCTRL_MASK                                 0x00090101UL                               /**< Mask for MSC_RAMCTRL */
-#define MSC_RAMCTRL_RAMCACHEEN                            (0x1UL << 0)                               /**< RAM CACHE Enable */
-#define _MSC_RAMCTRL_RAMCACHEEN_SHIFT                     0                                          /**< Shift value for MSC_RAMCACHEEN */
-#define _MSC_RAMCTRL_RAMCACHEEN_MASK                      0x1UL                                      /**< Bit mask for MSC_RAMCACHEEN */
-#define _MSC_RAMCTRL_RAMCACHEEN_DEFAULT                   0x00000000UL                               /**< Mode DEFAULT for MSC_RAMCTRL */
-#define MSC_RAMCTRL_RAMCACHEEN_DEFAULT                    (_MSC_RAMCTRL_RAMCACHEEN_DEFAULT << 0)     /**< Shifted mode DEFAULT for MSC_RAMCTRL */
-#define MSC_RAMCTRL_RAM1CACHEEN                           (0x1UL << 8)                               /**< RAM1 CACHE Enable */
-#define _MSC_RAMCTRL_RAM1CACHEEN_SHIFT                    8                                          /**< Shift value for MSC_RAM1CACHEEN */
-#define _MSC_RAMCTRL_RAM1CACHEEN_MASK                     0x100UL                                    /**< Bit mask for MSC_RAM1CACHEEN */
-#define _MSC_RAMCTRL_RAM1CACHEEN_DEFAULT                  0x00000000UL                               /**< Mode DEFAULT for MSC_RAMCTRL */
-#define MSC_RAMCTRL_RAM1CACHEEN_DEFAULT                   (_MSC_RAMCTRL_RAM1CACHEEN_DEFAULT << 8)    /**< Shifted mode DEFAULT for MSC_RAMCTRL */
-#define MSC_RAMCTRL_RAM2CACHEEN                           (0x1UL << 16)                              /**< RAM2 CACHE Enable */
-#define _MSC_RAMCTRL_RAM2CACHEEN_SHIFT                    16                                         /**< Shift value for MSC_RAM2CACHEEN */
-#define _MSC_RAMCTRL_RAM2CACHEEN_MASK                     0x10000UL                                  /**< Bit mask for MSC_RAM2CACHEEN */
-#define _MSC_RAMCTRL_RAM2CACHEEN_DEFAULT                  0x00000000UL                               /**< Mode DEFAULT for MSC_RAMCTRL */
-#define MSC_RAMCTRL_RAM2CACHEEN_DEFAULT                   (_MSC_RAMCTRL_RAM2CACHEEN_DEFAULT << 16)   /**< Shifted mode DEFAULT for MSC_RAMCTRL */
-#define MSC_RAMCTRL_RAMSEQCACHEEN                         (0x1UL << 19)                              /**< RAMSEQ CACHE Enable */
-#define _MSC_RAMCTRL_RAMSEQCACHEEN_SHIFT                  19                                         /**< Shift value for MSC_RAMSEQCACHEEN */
-#define _MSC_RAMCTRL_RAMSEQCACHEEN_MASK                   0x80000UL                                  /**< Bit mask for MSC_RAMSEQCACHEEN */
-#define _MSC_RAMCTRL_RAMSEQCACHEEN_DEFAULT                0x00000000UL                               /**< Mode DEFAULT for MSC_RAMCTRL */
-#define MSC_RAMCTRL_RAMSEQCACHEEN_DEFAULT                 (_MSC_RAMCTRL_RAMSEQCACHEEN_DEFAULT << 19) /**< Shifted mode DEFAULT for MSC_RAMCTRL */
+#define _MSC_RAMCTRL_RESETVALUE                           0x00000000UL                            /**< Default value for MSC_RAMCTRL */
+#define _MSC_RAMCTRL_MASK                                 0x00000101UL                            /**< Mask for MSC_RAMCTRL */
+#define MSC_RAMCTRL_RAMCACHEEN                            (0x1UL << 0)                            /**< RAM CACHE Enable */
+#define _MSC_RAMCTRL_RAMCACHEEN_SHIFT                     0                                       /**< Shift value for MSC_RAMCACHEEN */
+#define _MSC_RAMCTRL_RAMCACHEEN_MASK                      0x1UL                                   /**< Bit mask for MSC_RAMCACHEEN */
+#define _MSC_RAMCTRL_RAMCACHEEN_DEFAULT                   0x00000000UL                            /**< Mode DEFAULT for MSC_RAMCTRL */
+#define MSC_RAMCTRL_RAMCACHEEN_DEFAULT                    (_MSC_RAMCTRL_RAMCACHEEN_DEFAULT << 0)  /**< Shifted mode DEFAULT for MSC_RAMCTRL */
+#define MSC_RAMCTRL_RAM1CACHEEN                           (0x1UL << 8)                            /**< RAM1 CACHE Enable */
+#define _MSC_RAMCTRL_RAM1CACHEEN_SHIFT                    8                                       /**< Shift value for MSC_RAM1CACHEEN */
+#define _MSC_RAMCTRL_RAM1CACHEEN_MASK                     0x100UL                                 /**< Bit mask for MSC_RAM1CACHEEN */
+#define _MSC_RAMCTRL_RAM1CACHEEN_DEFAULT                  0x00000000UL                            /**< Mode DEFAULT for MSC_RAMCTRL */
+#define MSC_RAMCTRL_RAM1CACHEEN_DEFAULT                   (_MSC_RAMCTRL_RAM1CACHEEN_DEFAULT << 8) /**< Shifted mode DEFAULT for MSC_RAMCTRL */
 
 /** @} */
 /** @} End of group EFR32MG12P_MSC */

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_pcnt.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_pcnt.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg12p_pcnt.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG12P_PCNT register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,46 +40,46 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG12P_PCNT PCNT
  * @{
  * @brief EFR32MG12P_PCNT Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** PCNT Register Declaration */
 typedef struct {
-  __IOM uint32_t CTRL;         /**< Control Register  */
-  __IOM uint32_t CMD;          /**< Command Register  */
-  __IM uint32_t  STATUS;       /**< Status Register  */
-  __IM uint32_t  CNT;          /**< Counter Value Register  */
-  __IM uint32_t  TOP;          /**< Top Value Register  */
-  __IOM uint32_t TOPB;         /**< Top Value Buffer Register  */
-  __IM uint32_t  IF;           /**< Interrupt Flag Register  */
-  __IOM uint32_t IFS;          /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;          /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t IEN;          /**< Interrupt Enable Register  */
-  uint32_t       RESERVED0[1]; /**< Reserved for future use **/
-  __IOM uint32_t ROUTELOC0;    /**< I/O Routing Location Register  */
+  __IOM uint32_t CTRL;          /**< Control Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IM uint32_t  CNT;           /**< Counter Value Register  */
+  __IM uint32_t  TOP;           /**< Top Value Register  */
+  __IOM uint32_t TOPB;          /**< Top Value Buffer Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  uint32_t       RESERVED0[1U]; /**< Reserved for future use **/
+  __IOM uint32_t ROUTELOC0;     /**< I/O Routing Location Register  */
 
-  uint32_t       RESERVED1[4]; /**< Reserved for future use **/
-  __IOM uint32_t FREEZE;       /**< Freeze Register  */
-  __IM uint32_t  SYNCBUSY;     /**< Synchronization Busy Register  */
+  uint32_t       RESERVED1[4U]; /**< Reserved for future use **/
+  __IOM uint32_t FREEZE;        /**< Freeze Register  */
+  __IM uint32_t  SYNCBUSY;      /**< Synchronization Busy Register  */
 
-  uint32_t       RESERVED2[7]; /**< Reserved for future use **/
-  __IM uint32_t  AUXCNT;       /**< Auxiliary Counter Value Register  */
-  __IOM uint32_t INPUT;        /**< PCNT Input Register  */
-  __IOM uint32_t OVSCFG;       /**< Oversampling Config Register  */
-} PCNT_TypeDef;                /** @} */
+  uint32_t       RESERVED2[7U]; /**< Reserved for future use **/
+  __IM uint32_t  AUXCNT;        /**< Auxiliary Counter Value Register  */
+  __IOM uint32_t INPUT;         /**< PCNT Input Register  */
+  __IOM uint32_t OVSCFG;        /**< Oversampling Config Register  */
+} PCNT_TypeDef;                 /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG12P_PCNT
  * @{
  * @defgroup EFR32MG12P_PCNT_BitFields  PCNT Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for PCNT CTRL */
 #define _PCNT_CTRL_RESETVALUE              0x00000000UL                          /**< Default value for PCNT_CTRL */

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_prs.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_prs.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg12p_prs.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG12P_PRS register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,42 +40,42 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG12P_PRS PRS
  * @{
  * @brief EFR32MG12P_PRS Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** PRS Register Declaration */
 typedef struct {
-  __IOM uint32_t SWPULSE;      /**< Software Pulse Register  */
-  __IOM uint32_t SWLEVEL;      /**< Software Level Register  */
-  __IOM uint32_t ROUTEPEN;     /**< I/O Routing Pin Enable Register  */
-  uint32_t       RESERVED0[1]; /**< Reserved for future use **/
-  __IOM uint32_t ROUTELOC0;    /**< I/O Routing Location Register  */
-  __IOM uint32_t ROUTELOC1;    /**< I/O Routing Location Register  */
-  __IOM uint32_t ROUTELOC2;    /**< I/O Routing Location Register  */
+  __IOM uint32_t SWPULSE;       /**< Software Pulse Register  */
+  __IOM uint32_t SWLEVEL;       /**< Software Level Register  */
+  __IOM uint32_t ROUTEPEN;      /**< I/O Routing Pin Enable Register  */
+  uint32_t       RESERVED0[1U]; /**< Reserved for future use **/
+  __IOM uint32_t ROUTELOC0;     /**< I/O Routing Location Register  */
+  __IOM uint32_t ROUTELOC1;     /**< I/O Routing Location Register  */
+  __IOM uint32_t ROUTELOC2;     /**< I/O Routing Location Register  */
 
-  uint32_t       RESERVED1[5]; /**< Reserved for future use **/
-  __IOM uint32_t CTRL;         /**< Control Register  */
-  __IOM uint32_t DMAREQ0;      /**< DMA Request 0 Register  */
-  __IOM uint32_t DMAREQ1;      /**< DMA Request 1 Register  */
-  uint32_t       RESERVED2[1]; /**< Reserved for future use **/
-  __IM uint32_t  PEEK;         /**< PRS Channel Values  */
+  uint32_t       RESERVED1[5U]; /**< Reserved for future use **/
+  __IOM uint32_t CTRL;          /**< Control Register  */
+  __IOM uint32_t DMAREQ0;       /**< DMA Request 0 Register  */
+  __IOM uint32_t DMAREQ1;       /**< DMA Request 1 Register  */
+  uint32_t       RESERVED2[1U]; /**< Reserved for future use **/
+  __IM uint32_t  PEEK;          /**< PRS Channel Values  */
 
-  uint32_t       RESERVED3[3]; /**< Reserved registers */
-  PRS_CH_TypeDef CH[12];       /**< Channel registers */
-} PRS_TypeDef;                 /** @} */
+  uint32_t       RESERVED3[3U]; /**< Reserved registers */
+  PRS_CH_TypeDef CH[12U];       /**< Channel registers */
+} PRS_TypeDef;                  /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG12P_PRS
  * @{
  * @defgroup EFR32MG12P_PRS_BitFields  PRS Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for PRS SWPULSE */
 #define _PRS_SWPULSE_RESETVALUE                    0x00000000UL                           /**< Default value for PRS_SWPULSE */

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_prs_ch.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_prs_ch.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg12p_prs_ch.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG12P_PRS_CH register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,14 +40,14 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief PRS_CH PRS CH Register
  * @ingroup EFR32MG12P_PRS
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t CTRL; /**< Channel Control Register  */
 } PRS_CH_TypeDef;

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_prs_signals.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_prs_signals.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg12p_prs_signals.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG12P_PRS_SIGNALS register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,17 +40,17 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @addtogroup EFR32MG12P_PRS
  * @{
  * @addtogroup EFR32MG12P_PRS_Signals PRS Signals
  * @{
  * @brief PRS Signal names
- *****************************************************************************/
+ ******************************************************************************/
 #define PRS_PRS_CH0                 ((1 << 8) + 0)  /**< PRS PRS channel 0 */
 #define PRS_PRS_CH1                 ((1 << 8) + 1)  /**< PRS PRS channel 1 */
 #define PRS_PRS_CH2                 ((1 << 8) + 2)  /**< PRS PRS channel 2 */
@@ -189,6 +188,8 @@ extern "C" {
 #define PRS_MODEM_FRAMESENT         ((86 << 8) + 3) /**< PRS Entire frame transmitted */
 #define PRS_MODEM_SYNCSENT          ((86 << 8) + 4) /**< PRS Syncword transmitted */
 #define PRS_MODEM_PRESENT           ((86 << 8) + 5) /**< PRS Preamble transmitted */
+#define PRS_MODEM_ANT0              ((87 << 8) + 5) /**< PRS Antenna 0 select */
+#define PRS_MODEM_ANT1              ((87 << 8) + 6) /**< PRS Antenna 1 select */
 
 /** @} */
 /** @} End of group EFR32MG12P_PRS */

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_rmu.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_rmu.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg12p_rmu.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG12P_RMU register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG12P_RMU RMU
  * @{
  * @brief EFR32MG12P_RMU Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** RMU Register Declaration */
 typedef struct {
   __IOM uint32_t CTRL;     /**< Control Register  */
@@ -59,12 +58,12 @@ typedef struct {
   __IOM uint32_t LOCK;     /**< Configuration Lock Register  */
 } RMU_TypeDef;             /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG12P_RMU
  * @{
  * @defgroup EFR32MG12P_RMU_BitFields  RMU Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for RMU CTRL */
 #define _RMU_CTRL_RESETVALUE               0x00004204UL                          /**< Default value for RMU_CTRL */

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_romtable.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_romtable.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg12p_romtable.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG12P_ROMTABLE register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG12P_ROMTABLE ROM Table, Chip Revision Information
  * @{
  * @brief Chip Information, Revision numbers
- *****************************************************************************/
+ ******************************************************************************/
 /** ROMTABLE Register Declaration */
 typedef struct {
   __IM uint32_t PID4; /**< JEP_106_BANK */
@@ -63,12 +62,12 @@ typedef struct {
   __IM uint32_t CID0; /**< Unused */
 } ROMTABLE_TypeDef;   /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG12P_ROMTABLE
  * @{
  * @defgroup EFR32MG12P_ROMTABLE_BitFields ROM Table Bit Field definitions
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 /* Bit fields for EFR32MG12P_ROMTABLE */
 #define _ROMTABLE_PID0_FAMILYLSB_MASK       0x000000C0UL /**< Least Significant Bits [1:0] of CHIP FAMILY, mask */
 #define _ROMTABLE_PID0_FAMILYLSB_SHIFT      6            /**< Least Significant Bits [1:0] of CHIP FAMILY, shift */

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_rtcc.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_rtcc.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg12p_rtcc.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG12P_RTCC register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,46 +40,46 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG12P_RTCC RTCC
  * @{
  * @brief EFR32MG12P_RTCC Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** RTCC Register Declaration */
 typedef struct {
-  __IOM uint32_t   CTRL;          /**< Control Register  */
-  __IOM uint32_t   PRECNT;        /**< Pre-Counter Value Register  */
-  __IOM uint32_t   CNT;           /**< Counter Value Register  */
-  __IM uint32_t    COMBCNT;       /**< Combined Pre-Counter and Counter Value Register  */
-  __IOM uint32_t   TIME;          /**< Time of Day Register  */
-  __IOM uint32_t   DATE;          /**< Date Register  */
-  __IM uint32_t    IF;            /**< RTCC Interrupt Flags  */
-  __IOM uint32_t   IFS;           /**< Interrupt Flag Set Register  */
-  __IOM uint32_t   IFC;           /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t   IEN;           /**< Interrupt Enable Register  */
-  __IM uint32_t    STATUS;        /**< Status Register  */
-  __IOM uint32_t   CMD;           /**< Command Register  */
-  __IM uint32_t    SYNCBUSY;      /**< Synchronization Busy Register  */
-  __IOM uint32_t   POWERDOWN;     /**< Retention RAM Power-down Register  */
-  __IOM uint32_t   LOCK;          /**< Configuration Lock Register  */
-  __IOM uint32_t   EM4WUEN;       /**< Wake Up Enable  */
+  __IOM uint32_t   CTRL;           /**< Control Register  */
+  __IOM uint32_t   PRECNT;         /**< Pre-Counter Value Register  */
+  __IOM uint32_t   CNT;            /**< Counter Value Register  */
+  __IM uint32_t    COMBCNT;        /**< Combined Pre-Counter and Counter Value Register  */
+  __IOM uint32_t   TIME;           /**< Time of Day Register  */
+  __IOM uint32_t   DATE;           /**< Date Register  */
+  __IM uint32_t    IF;             /**< RTCC Interrupt Flags  */
+  __IOM uint32_t   IFS;            /**< Interrupt Flag Set Register  */
+  __IOM uint32_t   IFC;            /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t   IEN;            /**< Interrupt Enable Register  */
+  __IM uint32_t    STATUS;         /**< Status Register  */
+  __IOM uint32_t   CMD;            /**< Command Register  */
+  __IM uint32_t    SYNCBUSY;       /**< Synchronization Busy Register  */
+  __IOM uint32_t   POWERDOWN;      /**< Retention RAM Power-down Register  */
+  __IOM uint32_t   LOCK;           /**< Configuration Lock Register  */
+  __IOM uint32_t   EM4WUEN;        /**< Wake Up Enable  */
 
-  RTCC_CC_TypeDef  CC[3];         /**< Capture/Compare Channel */
+  RTCC_CC_TypeDef  CC[3U];         /**< Capture/Compare Channel */
 
-  uint32_t         RESERVED0[37]; /**< Reserved registers */
-  RTCC_RET_TypeDef RET[32];       /**< RetentionReg */
-} RTCC_TypeDef;                   /** @} */
+  uint32_t         RESERVED0[37U]; /**< Reserved registers */
+  RTCC_RET_TypeDef RET[32U];       /**< RetentionReg */
+} RTCC_TypeDef;                    /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG12P_RTCC
  * @{
  * @defgroup EFR32MG12P_RTCC_BitFields  RTCC Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for RTCC CTRL */
 #define _RTCC_CTRL_RESETVALUE               0x00000000UL                            /**< Default value for RTCC_CTRL */

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_rtcc_cc.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_rtcc_cc.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg12p_rtcc_cc.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG12P_RTCC_CC register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,14 +40,14 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief RTCC_CC RTCC CC Register
  * @ingroup EFR32MG12P_RTCC
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t CTRL; /**< CC Channel Control Register  */
   __IOM uint32_t CCV;  /**< Capture/Compare Value Register  */

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_rtcc_ret.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_rtcc_ret.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg12p_rtcc_ret.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG12P_RTCC_RET register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,14 +40,14 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief RTCC_RET RTCC RET Register
  * @ingroup EFR32MG12P_RTCC
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t REG; /**< Retention Register  */
 } RTCC_RET_TypeDef;

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_smu.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_smu.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg12p_smu.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG12P_SMU register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,39 +40,39 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG12P_SMU SMU
  * @{
  * @brief EFR32MG12P_SMU Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** SMU Register Declaration */
 typedef struct {
-  uint32_t       RESERVED0[3];  /**< Reserved for future use **/
-  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
-  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  uint32_t       RESERVED0[3U];  /**< Reserved for future use **/
+  __IM uint32_t  IF;             /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;            /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;            /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;            /**< Interrupt Enable Register  */
 
-  uint32_t       RESERVED1[9];  /**< Reserved for future use **/
-  __IOM uint32_t PPUCTRL;       /**< PPU Control Register  */
-  uint32_t       RESERVED2[3];  /**< Reserved for future use **/
-  __IOM uint32_t PPUPATD0;      /**< PPU Privilege Access Type Descriptor 0  */
-  __IOM uint32_t PPUPATD1;      /**< PPU Privilege Access Type Descriptor 1  */
+  uint32_t       RESERVED1[9U];  /**< Reserved for future use **/
+  __IOM uint32_t PPUCTRL;        /**< PPU Control Register  */
+  uint32_t       RESERVED2[3U];  /**< Reserved for future use **/
+  __IOM uint32_t PPUPATD0;       /**< PPU Privilege Access Type Descriptor 0  */
+  __IOM uint32_t PPUPATD1;       /**< PPU Privilege Access Type Descriptor 1  */
 
-  uint32_t       RESERVED3[14]; /**< Reserved for future use **/
-  __IM uint32_t  PPUFS;         /**< PPU Fault Status  */
-} SMU_TypeDef;                  /** @} */
+  uint32_t       RESERVED3[14U]; /**< Reserved for future use **/
+  __IM uint32_t  PPUFS;          /**< PPU Fault Status  */
+} SMU_TypeDef;                   /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG12P_SMU
  * @{
  * @defgroup EFR32MG12P_SMU_BitFields  SMU Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for SMU IF */
 #define _SMU_IF_RESETVALUE                 0x00000000UL                   /**< Default value for SMU_IF */

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_timer.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_timer.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg12p_timer.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG12P_TIMER register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,52 +40,52 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG12P_TIMER TIMER
  * @{
  * @brief EFR32MG12P_TIMER Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** TIMER Register Declaration */
 typedef struct {
-  __IOM uint32_t   CTRL;         /**< Control Register  */
-  __IOM uint32_t   CMD;          /**< Command Register  */
-  __IM uint32_t    STATUS;       /**< Status Register  */
-  __IM uint32_t    IF;           /**< Interrupt Flag Register  */
-  __IOM uint32_t   IFS;          /**< Interrupt Flag Set Register  */
-  __IOM uint32_t   IFC;          /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t   IEN;          /**< Interrupt Enable Register  */
-  __IOM uint32_t   TOP;          /**< Counter Top Value Register  */
-  __IOM uint32_t   TOPB;         /**< Counter Top Value Buffer Register  */
-  __IOM uint32_t   CNT;          /**< Counter Value Register  */
-  uint32_t         RESERVED0[1]; /**< Reserved for future use **/
-  __IOM uint32_t   LOCK;         /**< TIMER Configuration Lock Register  */
-  __IOM uint32_t   ROUTEPEN;     /**< I/O Routing Pin Enable Register  */
-  __IOM uint32_t   ROUTELOC0;    /**< I/O Routing Location Register  */
-  uint32_t         RESERVED1[1]; /**< Reserved for future use **/
-  __IOM uint32_t   ROUTELOC2;    /**< I/O Routing Location Register  */
+  __IOM uint32_t   CTRL;          /**< Control Register  */
+  __IOM uint32_t   CMD;           /**< Command Register  */
+  __IM uint32_t    STATUS;        /**< Status Register  */
+  __IM uint32_t    IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t   IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t   IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t   IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t   TOP;           /**< Counter Top Value Register  */
+  __IOM uint32_t   TOPB;          /**< Counter Top Value Buffer Register  */
+  __IOM uint32_t   CNT;           /**< Counter Value Register  */
+  uint32_t         RESERVED0[1U]; /**< Reserved for future use **/
+  __IOM uint32_t   LOCK;          /**< TIMER Configuration Lock Register  */
+  __IOM uint32_t   ROUTEPEN;      /**< I/O Routing Pin Enable Register  */
+  __IOM uint32_t   ROUTELOC0;     /**< I/O Routing Location Register  */
+  uint32_t         RESERVED1[1U]; /**< Reserved for future use **/
+  __IOM uint32_t   ROUTELOC2;     /**< I/O Routing Location Register  */
 
-  uint32_t         RESERVED2[8]; /**< Reserved registers */
-  TIMER_CC_TypeDef CC[4];        /**< Compare/Capture Channel */
+  uint32_t         RESERVED2[8U]; /**< Reserved registers */
+  TIMER_CC_TypeDef CC[4U];        /**< Compare/Capture Channel */
 
-  __IOM uint32_t   DTCTRL;       /**< DTI Control Register  */
-  __IOM uint32_t   DTTIME;       /**< DTI Time Control Register  */
-  __IOM uint32_t   DTFC;         /**< DTI Fault Configuration Register  */
-  __IOM uint32_t   DTOGEN;       /**< DTI Output Generation Enable Register  */
-  __IM uint32_t    DTFAULT;      /**< DTI Fault Register  */
-  __IOM uint32_t   DTFAULTC;     /**< DTI Fault Clear Register  */
-  __IOM uint32_t   DTLOCK;       /**< DTI Configuration Lock Register  */
-} TIMER_TypeDef;                 /** @} */
+  __IOM uint32_t   DTCTRL;        /**< DTI Control Register  */
+  __IOM uint32_t   DTTIME;        /**< DTI Time Control Register  */
+  __IOM uint32_t   DTFC;          /**< DTI Fault Configuration Register  */
+  __IOM uint32_t   DTOGEN;        /**< DTI Output Generation Enable Register  */
+  __IM uint32_t    DTFAULT;       /**< DTI Fault Register  */
+  __IOM uint32_t   DTFAULTC;      /**< DTI Fault Clear Register  */
+  __IOM uint32_t   DTLOCK;        /**< DTI Configuration Lock Register  */
+} TIMER_TypeDef;                  /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG12P_TIMER
  * @{
  * @defgroup EFR32MG12P_TIMER_BitFields  TIMER Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for TIMER CTRL */
 #define _TIMER_CTRL_RESETVALUE                     0x00000000UL                             /**< Default value for TIMER_CTRL */

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_timer_cc.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_timer_cc.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg12p_timer_cc.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG12P_TIMER_CC register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,14 +40,14 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief TIMER_CC TIMER CC Register
  * @ingroup EFR32MG12P_TIMER
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t CTRL; /**< CC Channel Control Register  */
   __IOM uint32_t CCV;  /**< CC Channel Value Register  */

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_trng.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_trng.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg12p_trng.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG12P_TRNG register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,40 +40,40 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG12P_TRNG TRNG
  * @{
  * @brief EFR32MG12P_TRNG Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** TRNG Register Declaration */
 typedef struct {
-  __IOM uint32_t CONTROL;       /**< Main Control Register  */
-  __IM uint32_t  FIFOLEVEL;     /**< FIFO Level Register  */
-  uint32_t       RESERVED0[1];  /**< Reserved for future use **/
-  __IM uint32_t  FIFODEPTH;     /**< FIFO Depth Register  */
-  __IOM uint32_t KEY0;          /**< Key Register 0  */
-  __IOM uint32_t KEY1;          /**< Key Register 1  */
-  __IOM uint32_t KEY2;          /**< Key Register 2  */
-  __IOM uint32_t KEY3;          /**< Key Register 3  */
-  __IOM uint32_t TESTDATA;      /**< Test Data Register  */
+  __IOM uint32_t CONTROL;        /**< Main Control Register  */
+  __IM uint32_t  FIFOLEVEL;      /**< FIFO Level Register  */
+  uint32_t       RESERVED0[1U];  /**< Reserved for future use **/
+  __IM uint32_t  FIFODEPTH;      /**< FIFO Depth Register  */
+  __IOM uint32_t KEY0;           /**< Key Register 0  */
+  __IOM uint32_t KEY1;           /**< Key Register 1  */
+  __IOM uint32_t KEY2;           /**< Key Register 2  */
+  __IOM uint32_t KEY3;           /**< Key Register 3  */
+  __IOM uint32_t TESTDATA;       /**< Test Data Register  */
 
-  uint32_t       RESERVED1[3];  /**< Reserved for future use **/
-  __IOM uint32_t STATUS;        /**< Status Register  */
-  __IOM uint32_t INITWAITVAL;   /**< Initial Wait Counter  */
-  uint32_t       RESERVED2[50]; /**< Reserved for future use **/
-  __IM uint32_t  FIFO;          /**< FIFO Data  */
-} TRNG_TypeDef;                 /** @} */
+  uint32_t       RESERVED1[3U];  /**< Reserved for future use **/
+  __IOM uint32_t STATUS;         /**< Status Register  */
+  __IOM uint32_t INITWAITVAL;    /**< Initial Wait Counter  */
+  uint32_t       RESERVED2[50U]; /**< Reserved for future use **/
+  __IM uint32_t  FIFO;           /**< FIFO Data  */
+} TRNG_TypeDef;                  /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG12P_TRNG
  * @{
  * @defgroup EFR32MG12P_TRNG_BitFields  TRNG Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for TRNG CONTROL */
 #define _TRNG_CONTROL_RESETVALUE             0x00000000UL                             /**< Default value for TRNG_CONTROL */

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_usart.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_usart.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg12p_usart.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG12P_USART register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,57 +40,57 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG12P_USART USART
  * @{
  * @brief EFR32MG12P_USART Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** USART Register Declaration */
 typedef struct {
-  __IOM uint32_t CTRL;         /**< Control Register  */
-  __IOM uint32_t FRAME;        /**< USART Frame Format Register  */
-  __IOM uint32_t TRIGCTRL;     /**< USART Trigger Control Register  */
-  __IOM uint32_t CMD;          /**< Command Register  */
-  __IM uint32_t  STATUS;       /**< USART Status Register  */
-  __IOM uint32_t CLKDIV;       /**< Clock Control Register  */
-  __IM uint32_t  RXDATAX;      /**< RX Buffer Data Extended Register  */
-  __IM uint32_t  RXDATA;       /**< RX Buffer Data Register  */
-  __IM uint32_t  RXDOUBLEX;    /**< RX Buffer Double Data Extended Register  */
-  __IM uint32_t  RXDOUBLE;     /**< RX FIFO Double Data Register  */
-  __IM uint32_t  RXDATAXP;     /**< RX Buffer Data Extended Peek Register  */
-  __IM uint32_t  RXDOUBLEXP;   /**< RX Buffer Double Data Extended Peek Register  */
-  __IOM uint32_t TXDATAX;      /**< TX Buffer Data Extended Register  */
-  __IOM uint32_t TXDATA;       /**< TX Buffer Data Register  */
-  __IOM uint32_t TXDOUBLEX;    /**< TX Buffer Double Data Extended Register  */
-  __IOM uint32_t TXDOUBLE;     /**< TX Buffer Double Data Register  */
-  __IM uint32_t  IF;           /**< Interrupt Flag Register  */
-  __IOM uint32_t IFS;          /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;          /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t IEN;          /**< Interrupt Enable Register  */
-  __IOM uint32_t IRCTRL;       /**< IrDA Control Register  */
-  uint32_t       RESERVED0[1]; /**< Reserved for future use **/
-  __IOM uint32_t INPUT;        /**< USART Input Register  */
-  __IOM uint32_t I2SCTRL;      /**< I2S Control Register  */
-  __IOM uint32_t TIMING;       /**< Timing Register  */
-  __IOM uint32_t CTRLX;        /**< Control Register Extended  */
-  __IOM uint32_t TIMECMP0;     /**< Used to Generate Interrupts and Various Delays  */
-  __IOM uint32_t TIMECMP1;     /**< Used to Generate Interrupts and Various Delays  */
-  __IOM uint32_t TIMECMP2;     /**< Used to Generate Interrupts and Various Delays  */
-  __IOM uint32_t ROUTEPEN;     /**< I/O Routing Pin Enable Register  */
-  __IOM uint32_t ROUTELOC0;    /**< I/O Routing Location Register  */
-  __IOM uint32_t ROUTELOC1;    /**< I/O Routing Location Register  */
-} USART_TypeDef;               /** @} */
+  __IOM uint32_t CTRL;          /**< Control Register  */
+  __IOM uint32_t FRAME;         /**< USART Frame Format Register  */
+  __IOM uint32_t TRIGCTRL;      /**< USART Trigger Control Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IM uint32_t  STATUS;        /**< USART Status Register  */
+  __IOM uint32_t CLKDIV;        /**< Clock Control Register  */
+  __IM uint32_t  RXDATAX;       /**< RX Buffer Data Extended Register  */
+  __IM uint32_t  RXDATA;        /**< RX Buffer Data Register  */
+  __IM uint32_t  RXDOUBLEX;     /**< RX Buffer Double Data Extended Register  */
+  __IM uint32_t  RXDOUBLE;      /**< RX FIFO Double Data Register  */
+  __IM uint32_t  RXDATAXP;      /**< RX Buffer Data Extended Peek Register  */
+  __IM uint32_t  RXDOUBLEXP;    /**< RX Buffer Double Data Extended Peek Register  */
+  __IOM uint32_t TXDATAX;       /**< TX Buffer Data Extended Register  */
+  __IOM uint32_t TXDATA;        /**< TX Buffer Data Register  */
+  __IOM uint32_t TXDOUBLEX;     /**< TX Buffer Double Data Extended Register  */
+  __IOM uint32_t TXDOUBLE;      /**< TX Buffer Double Data Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t IRCTRL;        /**< IrDA Control Register  */
+  uint32_t       RESERVED0[1U]; /**< Reserved for future use **/
+  __IOM uint32_t INPUT;         /**< USART Input Register  */
+  __IOM uint32_t I2SCTRL;       /**< I2S Control Register  */
+  __IOM uint32_t TIMING;        /**< Timing Register  */
+  __IOM uint32_t CTRLX;         /**< Control Register Extended  */
+  __IOM uint32_t TIMECMP0;      /**< Used to Generate Interrupts and Various Delays  */
+  __IOM uint32_t TIMECMP1;      /**< Used to Generate Interrupts and Various Delays  */
+  __IOM uint32_t TIMECMP2;      /**< Used to Generate Interrupts and Various Delays  */
+  __IOM uint32_t ROUTEPEN;      /**< I/O Routing Pin Enable Register  */
+  __IOM uint32_t ROUTELOC0;     /**< I/O Routing Location Register  */
+  __IOM uint32_t ROUTELOC1;     /**< I/O Routing Location Register  */
+} USART_TypeDef;                /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG12P_USART
  * @{
  * @defgroup EFR32MG12P_USART_BitFields  USART Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for USART CTRL */
 #define _USART_CTRL_RESETVALUE                  0x00000000UL                             /**< Default value for USART_CTRL */

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_vdac.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_vdac.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg12p_vdac.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG12P_VDAC register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,41 +40,41 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG12P_VDAC VDAC
  * @{
  * @brief EFR32MG12P_VDAC Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** VDAC Register Declaration */
 typedef struct {
-  __IOM uint32_t   CTRL;          /**< Control Register  */
-  __IM uint32_t    STATUS;        /**< Status Register  */
-  __IOM uint32_t   CH0CTRL;       /**< Channel 0 Control Register  */
-  __IOM uint32_t   CH1CTRL;       /**< Channel 1 Control Register  */
-  __IOM uint32_t   CMD;           /**< Command Register  */
-  __IM uint32_t    IF;            /**< Interrupt Flag Register  */
-  __IOM uint32_t   IFS;           /**< Interrupt Flag Set Register  */
-  __IOM uint32_t   IFC;           /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t   IEN;           /**< Interrupt Enable Register  */
-  __IOM uint32_t   CH0DATA;       /**< Channel 0 Data Register  */
-  __IOM uint32_t   CH1DATA;       /**< Channel 1 Data Register  */
-  __IOM uint32_t   COMBDATA;      /**< Combined Data Register  */
-  __IOM uint32_t   CAL;           /**< Calibration Register  */
+  __IOM uint32_t   CTRL;           /**< Control Register  */
+  __IM uint32_t    STATUS;         /**< Status Register  */
+  __IOM uint32_t   CH0CTRL;        /**< Channel 0 Control Register  */
+  __IOM uint32_t   CH1CTRL;        /**< Channel 1 Control Register  */
+  __IOM uint32_t   CMD;            /**< Command Register  */
+  __IM uint32_t    IF;             /**< Interrupt Flag Register  */
+  __IOM uint32_t   IFS;            /**< Interrupt Flag Set Register  */
+  __IOM uint32_t   IFC;            /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t   IEN;            /**< Interrupt Enable Register  */
+  __IOM uint32_t   CH0DATA;        /**< Channel 0 Data Register  */
+  __IOM uint32_t   CH1DATA;        /**< Channel 1 Data Register  */
+  __IOM uint32_t   COMBDATA;       /**< Combined Data Register  */
+  __IOM uint32_t   CAL;            /**< Calibration Register  */
 
-  uint32_t         RESERVED0[27]; /**< Reserved registers */
-  VDAC_OPA_TypeDef OPA[3];        /**< OPA Registers */
-} VDAC_TypeDef;                   /** @} */
+  uint32_t         RESERVED0[27U]; /**< Reserved registers */
+  VDAC_OPA_TypeDef OPA[3U];        /**< OPA Registers */
+} VDAC_TypeDef;                    /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG12P_VDAC
  * @{
  * @defgroup EFR32MG12P_VDAC_BitFields  VDAC Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for VDAC CTRL */
 #define _VDAC_CTRL_RESETVALUE                              0x00000000UL                                /**< Default value for VDAC_CTRL */

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_vdac_opa.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_vdac_opa.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg12p_vdac_opa.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG12P_VDAC_OPA register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,14 +40,14 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief VDAC_OPA VDAC OPA Register
  * @ingroup EFR32MG12P_VDAC
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IM uint32_t  APORTREQ;      /**< Operational Amplifier APORT Request Status Register  */
   __IM uint32_t  APORTCONFLICT; /**< Operational Amplifier APORT Conflict Status Register  */
@@ -57,7 +56,7 @@ typedef struct {
   __IOM uint32_t MUX;           /**< Operational Amplifier Mux Configuration Register  */
   __IOM uint32_t OUT;           /**< Operational Amplifier Output Configuration Register  */
   __IOM uint32_t CAL;           /**< Operational Amplifier Calibration Register  */
-  uint32_t       RESERVED0[1];  /**< Reserved future */
+  uint32_t       RESERVED0[1U]; /**< Reserved future */
 } VDAC_OPA_TypeDef;
 
 /** @} End of group Parts */

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_wdog.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_wdog.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg12p_wdog.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG12P_WDOG register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,37 +40,37 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG12P_WDOG WDOG
  * @{
  * @brief EFR32MG12P_WDOG Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** WDOG Register Declaration */
 typedef struct {
-  __IOM uint32_t   CTRL;         /**< Control Register  */
-  __IOM uint32_t   CMD;          /**< Command Register  */
+  __IOM uint32_t   CTRL;          /**< Control Register  */
+  __IOM uint32_t   CMD;           /**< Command Register  */
 
-  __IM uint32_t    SYNCBUSY;     /**< Synchronization Busy Register  */
+  __IM uint32_t    SYNCBUSY;      /**< Synchronization Busy Register  */
 
-  WDOG_PCH_TypeDef PCH[2];       /**< PCH */
+  WDOG_PCH_TypeDef PCH[2U];       /**< PCH */
 
-  uint32_t         RESERVED0[2]; /**< Reserved for future use **/
-  __IM uint32_t    IF;           /**< Watchdog Interrupt Flags  */
-  __IOM uint32_t   IFS;          /**< Interrupt Flag Set Register  */
-  __IOM uint32_t   IFC;          /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t   IEN;          /**< Interrupt Enable Register  */
-} WDOG_TypeDef;                  /** @} */
+  uint32_t         RESERVED0[2U]; /**< Reserved for future use **/
+  __IM uint32_t    IF;            /**< Watchdog Interrupt Flags  */
+  __IOM uint32_t   IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t   IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t   IEN;           /**< Interrupt Enable Register  */
+} WDOG_TypeDef;                   /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG12P_WDOG
  * @{
  * @defgroup EFR32MG12P_WDOG_BitFields  WDOG Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for WDOG CTRL */
 #define _WDOG_CTRL_RESETVALUE                     0x00000F00UL                          /**< Default value for WDOG_CTRL */

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_wdog_pch.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_wdog_pch.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg12p_wdog_pch.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG12P_WDOG_PCH register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,14 +40,14 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief WDOG_PCH WDOG PCH Register
  * @ingroup EFR32MG12P_WDOG
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t PRSCTRL; /**< PRS Control Register  */
 } WDOG_PCH_TypeDef;

--- a/cpu/efm32/families/efr32mg12p/include/vendor/em_device.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/em_device.h
@@ -1,5 +1,5 @@
-/**************************************************************************//**
- * @file em_device.h
+/***************************************************************************//**
+ * @file
  * @brief CMSIS Cortex-M Peripheral Access Layer for Silicon Laboratories
  *        microcontroller devices
  *
@@ -9,37 +9,35 @@
  * @verbatim
  * Example: Add "-DEFM32G890F128" to your build options, to define part
  *          Add "#include "em_device.h" to your source files
-
- *
  * @endverbatim
- * @version 5.4.0
- ******************************************************************************
+ *
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {

--- a/cpu/efm32/families/efr32mg12p/include/vendor/system_efr32mg12p.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/system_efr32mg12p.h
@@ -1,34 +1,33 @@
 /***************************************************************************//**
- * @file system_efr32mg12p.h
+ * @file
  * @brief CMSIS Cortex-M3/M4 System Layer for EFR32 devices.
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifndef SYSTEM_EFR32_H
 #define SYSTEM_EFR32_H
@@ -39,14 +38,14 @@ extern "C" {
 
 #include <stdint.h>
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup Parts
  * @{
- *****************************************************************************/
-/**************************************************************************//**
+ ******************************************************************************/
+/***************************************************************************//**
  * @addtogroup EFR32 EFR32
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /*******************************************************************************
  **************************   GLOBAL VARIABLES   *******************************
@@ -124,7 +123,7 @@ void SYSCFG_IRQHandler(void);       /**< SYSCFG IRQ Handler */
 
 uint32_t SystemCoreClockGet(void);
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @brief
  *   Update CMSIS SystemCoreClock variable.
  *
@@ -137,7 +136,7 @@ uint32_t SystemCoreClockGet(void);
  *   API, this variable will be kept updated. This function is only provided
  *   for CMSIS compliance and if a user modifies the the core clock outside
  *   the CMU API.
- *****************************************************************************/
+ ******************************************************************************/
 static __INLINE void SystemCoreClockUpdate(void)
 {
   (void)SystemCoreClockGet();

--- a/cpu/efm32/families/efr32mg12p/system.c
+++ b/cpu/efm32/families/efr32mg12p/system.c
@@ -1,34 +1,33 @@
 /***************************************************************************//**
- * @file system_efr32mg12p.c
+ * @file
  * @brief CMSIS Cortex-M3/M4 System Layer for EFR32 devices.
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #include <stdint.h>
 #include "em_device.h"
@@ -70,7 +69,7 @@
 #endif
 
 /* Do not define variable if HF crystal oscillator not present */
-#if (EFR32_HFXO_FREQ > 0UL)
+#if (EFR32_HFXO_FREQ > 0U)
 /** @cond DO_NOT_INCLUDE_WITH_DOXYGEN */
 /** System HFXO clock. */
 static uint32_t SystemHFXOClock = EFR32_HFXO_FREQ;
@@ -82,7 +81,7 @@ static uint32_t SystemHFXOClock = EFR32_HFXO_FREQ;
 #define EFR32_LFXO_FREQ (EFR32_LFRCO_FREQ)
 #endif
 /* Do not define variable if LF crystal oscillator not present */
-#if (EFR32_LFXO_FREQ > 0UL)
+#if (EFR32_LFXO_FREQ > 0U)
 /** @cond DO_NOT_INCLUDE_WITH_DOXYGEN */
 /** System LFXO clock. */
 static uint32_t SystemLFXOClock = EFR32_LFXO_FREQ;
@@ -117,6 +116,13 @@ uint32_t SystemHfrcoFreq = EFR32_HFRCO_STARTUP_FREQ;
 /*******************************************************************************
  **************************   GLOBAL FUNCTIONS   *******************************
  ******************************************************************************/
+
+#if defined(__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+#if defined(__ICCARM__)    /* IAR requires the __vector_table symbol */
+#define __Vectors    __vector_table
+#endif
+extern uint32_t __Vectors;
+#endif
 
 /***************************************************************************//**
  * @brief
@@ -186,12 +192,12 @@ uint32_t SystemHFClockGet(void)
 
   switch (CMU->HFCLKSTATUS & _CMU_HFCLKSTATUS_SELECTED_MASK) {
     case CMU_HFCLKSTATUS_SELECTED_LFXO:
-#if (EFR32_LFXO_FREQ > 0)
+#if (EFR32_LFXO_FREQ > 0U)
       ret = SystemLFXOClock;
 #else
       /* We should not get here, since core should not be clocked. May */
       /* be caused by a misconfiguration though. */
-      ret = 0;
+      ret = 0U;
 #endif
       break;
 
@@ -200,12 +206,12 @@ uint32_t SystemHFClockGet(void)
       break;
 
     case CMU_HFCLKSTATUS_SELECTED_HFXO:
-#if (EFR32_HFXO_FREQ > 0)
+#if (EFR32_HFXO_FREQ > 0U)
       ret = SystemHFXOClock;
 #else
       /* We should not get here, since core should not be clocked. May */
       /* be caused by a misconfiguration though. */
-      ret = 0;
+      ret = 0U;
 #endif
       break;
 
@@ -218,7 +224,7 @@ uint32_t SystemHFClockGet(void)
                       >> _CMU_HFPRESC_PRESC_SHIFT));
 }
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @brief
  *   Get high frequency crystal oscillator clock frequency for target system.
  *
@@ -227,18 +233,18 @@ uint32_t SystemHFClockGet(void)
  *
  * @return
  *   HFXO frequency in Hz.
- *****************************************************************************/
+ ******************************************************************************/
 uint32_t SystemHFXOClockGet(void)
 {
   /* External crystal oscillator present? */
-#if (EFR32_HFXO_FREQ > 0)
+#if (EFR32_HFXO_FREQ > 0U)
   return SystemHFXOClock;
 #else
-  return 0;
+  return 0U;
 #endif
 }
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @brief
  *   Set high frequency crystal oscillator clock frequency for target system.
  *
@@ -252,11 +258,11 @@ uint32_t SystemHFXOClockGet(void)
  *
  * @param[in] freq
  *   HFXO frequency in Hz used for target.
- *****************************************************************************/
+ ******************************************************************************/
 void SystemHFXOClockSet(uint32_t freq)
 {
   /* External crystal oscillator present? */
-#if (EFR32_HFXO_FREQ > 0)
+#if (EFR32_HFXO_FREQ > 0U)
   SystemHFXOClock = freq;
 
   /* Update core clock frequency if HFXO is used to clock core */
@@ -270,7 +276,7 @@ void SystemHFXOClockSet(uint32_t freq)
 #endif
 }
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @brief
  *   Initialize the system.
  *
@@ -281,17 +287,25 @@ void SystemHFXOClockSet(uint32_t freq)
  *   This function is invoked during system init, before the main() routine
  *   and any data has been initialized. For this reason, it cannot do any
  *   initialization of variables etc.
- *****************************************************************************/
+ ******************************************************************************/
 void SystemInit(void)
 {
-#if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
+#if defined(__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  SCB->VTOR = (uint32_t)&__Vectors;
+#endif
+
+#if (__FPU_PRESENT == 1U) && (__FPU_USED == 1U)
   /* Set floating point coprosessor access mode. */
-  SCB->CPACR |= ((3UL << 10 * 2)                      /* set CP10 Full Access */
-                 | (3UL << 11 * 2));                  /* set CP11 Full Access */
+  SCB->CPACR |= ((3UL << 10 * 2)                    /* set CP10 Full Access */
+                 | (3UL << 11 * 2));                /* set CP11 Full Access */
+#endif
+
+#if defined(UNALIGNED_SUPPORT_DISABLE)
+  SCB->CCR |= SCB_CCR_UNALIGN_TRP_Msk;
 #endif
 }
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @brief
  *   Get low frequency RC oscillator clock frequency for target system.
  *
@@ -300,7 +314,7 @@ void SystemInit(void)
  *
  * @return
  *   LFRCO frequency in Hz.
- *****************************************************************************/
+ ******************************************************************************/
 uint32_t SystemLFRCOClockGet(void)
 {
   /* Currently we assume that this frequency is properly tuned during */
@@ -309,7 +323,7 @@ uint32_t SystemLFRCOClockGet(void)
   return EFR32_LFRCO_FREQ;
 }
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @brief
  *   Get ultra low frequency RC oscillator clock frequency for target system.
  *
@@ -318,14 +332,14 @@ uint32_t SystemLFRCOClockGet(void)
  *
  * @return
  *   ULFRCO frequency in Hz.
- *****************************************************************************/
+ ******************************************************************************/
 uint32_t SystemULFRCOClockGet(void)
 {
   /* The ULFRCO frequency is not tuned, and can be very inaccurate */
   return EFR32_ULFRCO_FREQ;
 }
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @brief
  *   Get low frequency crystal oscillator clock frequency for target system.
  *
@@ -334,18 +348,18 @@ uint32_t SystemULFRCOClockGet(void)
  *
  * @return
  *   LFXO frequency in Hz.
- *****************************************************************************/
+ ******************************************************************************/
 uint32_t SystemLFXOClockGet(void)
 {
   /* External crystal oscillator present? */
-#if (EFR32_LFXO_FREQ > 0)
+#if (EFR32_LFXO_FREQ > 0U)
   return SystemLFXOClock;
 #else
-  return 0;
+  return 0U;
 #endif
 }
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @brief
  *   Set low frequency crystal oscillator clock frequency for target system.
  *
@@ -359,11 +373,11 @@ uint32_t SystemLFXOClockGet(void)
  *
  * @param[in] freq
  *   LFXO frequency in Hz used for target.
- *****************************************************************************/
+ ******************************************************************************/
 void SystemLFXOClockSet(uint32_t freq)
 {
   /* External crystal oscillator present? */
-#if (EFR32_LFXO_FREQ > 0)
+#if (EFR32_LFXO_FREQ > 0U)
   SystemLFXOClock = freq;
 
   /* Update core clock frequency if LFXO is used to clock core */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p132f256gm32.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p132f256gm32.h
@@ -1,35 +1,34 @@
-/**************************************************************************//**
- * @file efr32mg1p132f256gm32.h
+/***************************************************************************//**
+ * @file
  * @brief CMSIS Cortex-M Peripheral Access Layer Header File
  *        for EFR32MG1P132F256GM32
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #if defined(__ICCARM__)
 #pragma system_include       /* Treat file as system include file. */
@@ -44,15 +43,15 @@
 extern "C" {
 #endif
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup Parts
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFR32MG1P132F256GM32 EFR32MG1P132F256GM32
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /** Interrupt Number Definition */
 typedef enum IRQn{
@@ -70,7 +69,13 @@ typedef enum IRQn{
 /******  EFR32MG1P Peripheral Interrupt Numbers ********************************************/
 
   EMU_IRQn              = 0,  /*!< 16+0 EFR32 EMU Interrupt */
+  FRC_PRI_IRQn          = 1,  /*!< 16+1 EFR32 FRC_PRI Interrupt */
   WDOG0_IRQn            = 2,  /*!< 16+2 EFR32 WDOG0 Interrupt */
+  FRC_IRQn              = 3,  /*!< 16+3 EFR32 FRC Interrupt */
+  MODEM_IRQn            = 4,  /*!< 16+4 EFR32 MODEM Interrupt */
+  RAC_SEQ_IRQn          = 5,  /*!< 16+5 EFR32 RAC_SEQ Interrupt */
+  RAC_RSM_IRQn          = 6,  /*!< 16+6 EFR32 RAC_RSM Interrupt */
+  BUFC_IRQn             = 7,  /*!< 16+7 EFR32 BUFC Interrupt */
   LDMA_IRQn             = 8,  /*!< 16+8 EFR32 LDMA Interrupt */
   GPIO_EVEN_IRQn        = 9,  /*!< 16+9 EFR32 GPIO_EVEN Interrupt */
   TIMER0_IRQn           = 10, /*!< 16+10 EFR32 TIMER0 Interrupt */
@@ -90,28 +95,32 @@ typedef enum IRQn{
   MSC_IRQn              = 24, /*!< 16+24 EFR32 MSC Interrupt */
   CRYPTO_IRQn           = 25, /*!< 16+25 EFR32 CRYPTO Interrupt */
   LETIMER0_IRQn         = 26, /*!< 16+26 EFR32 LETIMER0 Interrupt */
+  AGC_IRQn              = 27, /*!< 16+27 EFR32 AGC Interrupt */
+  PROTIMER_IRQn         = 28, /*!< 16+28 EFR32 PROTIMER Interrupt */
   RTCC_IRQn             = 29, /*!< 16+29 EFR32 RTCC Interrupt */
+  SYNTH_IRQn            = 30, /*!< 16+30 EFR32 SYNTH Interrupt */
   CRYOTIMER_IRQn        = 31, /*!< 16+31 EFR32 CRYOTIMER Interrupt */
+  RFSENSE_IRQn          = 32, /*!< 16+32 EFR32 RFSENSE Interrupt */
   FPUEH_IRQn            = 33, /*!< 16+33 EFR32 FPUEH Interrupt */
 } IRQn_Type;
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFR32MG1P132F256GM32_Core Core
  * @{
  * @brief Processor and Core Peripheral Section
- *****************************************************************************/
-#define __MPU_PRESENT             1 /**< Presence of MPU  */
-#define __FPU_PRESENT             1 /**< Presence of FPU  */
-#define __VTOR_PRESENT            1 /**< Presence of VTOR register in SCB */
-#define __NVIC_PRIO_BITS          3 /**< NVIC interrupt priority bits */
-#define __Vendor_SysTickConfig    0 /**< Is 1 if different SysTick counter is used */
+ ******************************************************************************/
+#define __MPU_PRESENT             1U /**< Presence of MPU  */
+#define __FPU_PRESENT             1U /**< Presence of FPU  */
+#define __VTOR_PRESENT            1U /**< Presence of VTOR register in SCB */
+#define __NVIC_PRIO_BITS          3U /**< NVIC interrupt priority bits */
+#define __Vendor_SysTickConfig    0U /**< Is 1 if different SysTick counter is used */
 
 /** @} End of group EFR32MG1P132F256GM32_Core */
 
-/**************************************************************************//**
-* @defgroup EFR32MG1P132F256GM32_Part Part
-* @{
-******************************************************************************/
+/***************************************************************************//**
+ * @defgroup EFR32MG1P132F256GM32_Part Part
+ * @{
+ ******************************************************************************/
 
 /** Part family */
 #define _EFR32_MIGHTY_FAMILY                    1                               /**< MIGHTY Gecko RF SoC Family  */
@@ -187,7 +196,7 @@ typedef enum IRQn{
 #define FLASH_PAGE_SIZE           2048U          /**< Flash Memory page size */
 #define SRAM_BASE                 (0x20000000UL) /**< SRAM Base Address */
 #define SRAM_SIZE                 (0x00007C00UL) /**< Available SRAM Memory */
-#define __CM4_REV                 0x001          /**< Cortex-M4 Core revision r0p1 */
+#define __CM4_REV                 0x0001U        /**< Cortex-M4 Core revision r0p1 */
 #define PRS_CHAN_COUNT            12             /**< Number of PRS channels */
 #define DMA_CHAN_COUNT            8              /**< Number of DMA channels */
 #define EXT_IRQ_COUNT             34             /**< Number of External (NVIC) interrupts */
@@ -255,11 +264,11 @@ typedef enum IRQn{
 
 /** @} End of group EFR32MG1P132F256GM32_Part */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFR32MG1P132F256GM32_Peripheral_TypeDefs Peripheral TypeDefs
  * @{
  * @brief Device Specific Peripheral Register Structures
- *****************************************************************************/
+ ******************************************************************************/
 
 #include "efr32mg1p_msc.h"
 #include "efr32mg1p_emu.h"
@@ -296,10 +305,10 @@ typedef enum IRQn{
 
 /** @} End of group EFR32MG1P132F256GM32_Peripheral_TypeDefs  */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFR32MG1P132F256GM32_Peripheral_Base Peripheral Memory Map
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 #define MSC_BASE          (0x400E0000UL) /**< MSC base address  */
 #define EMU_BASE          (0x400E3000UL) /**< EMU base address  */
@@ -333,10 +342,10 @@ typedef enum IRQn{
 
 /** @} End of group EFR32MG1P132F256GM32_Peripheral_Base */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFR32MG1P132F256GM32_Peripheral_Declaration Peripheral Declarations
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 #define MSC          ((MSC_TypeDef *) MSC_BASE)             /**< MSC base pointer */
 #define EMU          ((EMU_TypeDef *) EMU_BASE)             /**< EMU base pointer */
@@ -368,10 +377,10 @@ typedef enum IRQn{
 
 /** @} End of group EFR32MG1P132F256GM32_Peripheral_Declaration */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFR32MG1P132F256GM32_Peripheral_Offsets Peripheral Offsets
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 #define TIMER_OFFSET      0x400 /**< Offset in bytes between TIMER instances */
 #define USART_OFFSET      0x400 /**< Offset in bytes between USART instances */
@@ -386,18 +395,18 @@ typedef enum IRQn{
 
 /** @} End of group EFR32MG1P132F256GM32_Peripheral_Offsets */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFR32MG1P132F256GM32_BitFields Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 #include "efr32mg1p_prs_signals.h"
 #include "efr32mg1p_dmareq.h"
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFR32MG1P132F256GM32_UNLOCK Unlock Codes
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 #define MSC_UNLOCK_CODE      0x1B71 /**< MSC unlock code */
 #define EMU_UNLOCK_CODE      0xADE8 /**< EMU unlock code */
 #define RMU_UNLOCK_CODE      0xE084 /**< RMU unlock code */
@@ -413,7 +422,7 @@ typedef enum IRQn{
 #include "efr32mg1p_af_ports.h"
 #include "efr32mg1p_af_pins.h"
 
-/**************************************************************************//**
+/***************************************************************************//**
  *  @brief Set the value of a bit field within a register.
  *
  *  @param REG
@@ -425,7 +434,7 @@ typedef enum IRQn{
  *  @param OFFSET
  *       The number of bits that the field is offset within the register.
  *       0 (zero) means LSB.
- *****************************************************************************/
+ ******************************************************************************/
 #define SET_BIT_FIELD(REG, MASK, VALUE, OFFSET) \
   REG = ((REG) &~(MASK)) | (((VALUE) << (OFFSET)) & (MASK));
 

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p132f256gm48.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p132f256gm48.h
@@ -1,35 +1,34 @@
-/**************************************************************************//**
- * @file efr32mg1p132f256gm48.h
+/***************************************************************************//**
+ * @file
  * @brief CMSIS Cortex-M Peripheral Access Layer Header File
  *        for EFR32MG1P132F256GM48
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #if defined(__ICCARM__)
 #pragma system_include       /* Treat file as system include file. */
@@ -44,15 +43,15 @@
 extern "C" {
 #endif
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup Parts
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFR32MG1P132F256GM48 EFR32MG1P132F256GM48
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /** Interrupt Number Definition */
 typedef enum IRQn{
@@ -70,7 +69,13 @@ typedef enum IRQn{
 /******  EFR32MG1P Peripheral Interrupt Numbers ********************************************/
 
   EMU_IRQn              = 0,  /*!< 16+0 EFR32 EMU Interrupt */
+  FRC_PRI_IRQn          = 1,  /*!< 16+1 EFR32 FRC_PRI Interrupt */
   WDOG0_IRQn            = 2,  /*!< 16+2 EFR32 WDOG0 Interrupt */
+  FRC_IRQn              = 3,  /*!< 16+3 EFR32 FRC Interrupt */
+  MODEM_IRQn            = 4,  /*!< 16+4 EFR32 MODEM Interrupt */
+  RAC_SEQ_IRQn          = 5,  /*!< 16+5 EFR32 RAC_SEQ Interrupt */
+  RAC_RSM_IRQn          = 6,  /*!< 16+6 EFR32 RAC_RSM Interrupt */
+  BUFC_IRQn             = 7,  /*!< 16+7 EFR32 BUFC Interrupt */
   LDMA_IRQn             = 8,  /*!< 16+8 EFR32 LDMA Interrupt */
   GPIO_EVEN_IRQn        = 9,  /*!< 16+9 EFR32 GPIO_EVEN Interrupt */
   TIMER0_IRQn           = 10, /*!< 16+10 EFR32 TIMER0 Interrupt */
@@ -90,28 +95,32 @@ typedef enum IRQn{
   MSC_IRQn              = 24, /*!< 16+24 EFR32 MSC Interrupt */
   CRYPTO_IRQn           = 25, /*!< 16+25 EFR32 CRYPTO Interrupt */
   LETIMER0_IRQn         = 26, /*!< 16+26 EFR32 LETIMER0 Interrupt */
+  AGC_IRQn              = 27, /*!< 16+27 EFR32 AGC Interrupt */
+  PROTIMER_IRQn         = 28, /*!< 16+28 EFR32 PROTIMER Interrupt */
   RTCC_IRQn             = 29, /*!< 16+29 EFR32 RTCC Interrupt */
+  SYNTH_IRQn            = 30, /*!< 16+30 EFR32 SYNTH Interrupt */
   CRYOTIMER_IRQn        = 31, /*!< 16+31 EFR32 CRYOTIMER Interrupt */
+  RFSENSE_IRQn          = 32, /*!< 16+32 EFR32 RFSENSE Interrupt */
   FPUEH_IRQn            = 33, /*!< 16+33 EFR32 FPUEH Interrupt */
 } IRQn_Type;
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFR32MG1P132F256GM48_Core Core
  * @{
  * @brief Processor and Core Peripheral Section
- *****************************************************************************/
-#define __MPU_PRESENT             1 /**< Presence of MPU  */
-#define __FPU_PRESENT             1 /**< Presence of FPU  */
-#define __VTOR_PRESENT            1 /**< Presence of VTOR register in SCB */
-#define __NVIC_PRIO_BITS          3 /**< NVIC interrupt priority bits */
-#define __Vendor_SysTickConfig    0 /**< Is 1 if different SysTick counter is used */
+ ******************************************************************************/
+#define __MPU_PRESENT             1U /**< Presence of MPU  */
+#define __FPU_PRESENT             1U /**< Presence of FPU  */
+#define __VTOR_PRESENT            1U /**< Presence of VTOR register in SCB */
+#define __NVIC_PRIO_BITS          3U /**< NVIC interrupt priority bits */
+#define __Vendor_SysTickConfig    0U /**< Is 1 if different SysTick counter is used */
 
 /** @} End of group EFR32MG1P132F256GM48_Core */
 
-/**************************************************************************//**
-* @defgroup EFR32MG1P132F256GM48_Part Part
-* @{
-******************************************************************************/
+/***************************************************************************//**
+ * @defgroup EFR32MG1P132F256GM48_Part Part
+ * @{
+ ******************************************************************************/
 
 /** Part family */
 #define _EFR32_MIGHTY_FAMILY                    1                               /**< MIGHTY Gecko RF SoC Family  */
@@ -187,7 +196,7 @@ typedef enum IRQn{
 #define FLASH_PAGE_SIZE           2048U          /**< Flash Memory page size */
 #define SRAM_BASE                 (0x20000000UL) /**< SRAM Base Address */
 #define SRAM_SIZE                 (0x00007C00UL) /**< Available SRAM Memory */
-#define __CM4_REV                 0x001          /**< Cortex-M4 Core revision r0p1 */
+#define __CM4_REV                 0x0001U        /**< Cortex-M4 Core revision r0p1 */
 #define PRS_CHAN_COUNT            12             /**< Number of PRS channels */
 #define DMA_CHAN_COUNT            8              /**< Number of DMA channels */
 #define EXT_IRQ_COUNT             34             /**< Number of External (NVIC) interrupts */
@@ -255,11 +264,11 @@ typedef enum IRQn{
 
 /** @} End of group EFR32MG1P132F256GM48_Part */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFR32MG1P132F256GM48_Peripheral_TypeDefs Peripheral TypeDefs
  * @{
  * @brief Device Specific Peripheral Register Structures
- *****************************************************************************/
+ ******************************************************************************/
 
 #include "efr32mg1p_msc.h"
 #include "efr32mg1p_emu.h"
@@ -296,10 +305,10 @@ typedef enum IRQn{
 
 /** @} End of group EFR32MG1P132F256GM48_Peripheral_TypeDefs  */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFR32MG1P132F256GM48_Peripheral_Base Peripheral Memory Map
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 #define MSC_BASE          (0x400E0000UL) /**< MSC base address  */
 #define EMU_BASE          (0x400E3000UL) /**< EMU base address  */
@@ -333,10 +342,10 @@ typedef enum IRQn{
 
 /** @} End of group EFR32MG1P132F256GM48_Peripheral_Base */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFR32MG1P132F256GM48_Peripheral_Declaration Peripheral Declarations
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 #define MSC          ((MSC_TypeDef *) MSC_BASE)             /**< MSC base pointer */
 #define EMU          ((EMU_TypeDef *) EMU_BASE)             /**< EMU base pointer */
@@ -368,10 +377,10 @@ typedef enum IRQn{
 
 /** @} End of group EFR32MG1P132F256GM48_Peripheral_Declaration */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFR32MG1P132F256GM48_Peripheral_Offsets Peripheral Offsets
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 #define TIMER_OFFSET      0x400 /**< Offset in bytes between TIMER instances */
 #define USART_OFFSET      0x400 /**< Offset in bytes between USART instances */
@@ -386,18 +395,18 @@ typedef enum IRQn{
 
 /** @} End of group EFR32MG1P132F256GM48_Peripheral_Offsets */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFR32MG1P132F256GM48_BitFields Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 #include "efr32mg1p_prs_signals.h"
 #include "efr32mg1p_dmareq.h"
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFR32MG1P132F256GM48_UNLOCK Unlock Codes
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 #define MSC_UNLOCK_CODE      0x1B71 /**< MSC unlock code */
 #define EMU_UNLOCK_CODE      0xADE8 /**< EMU unlock code */
 #define RMU_UNLOCK_CODE      0xE084 /**< RMU unlock code */
@@ -413,7 +422,7 @@ typedef enum IRQn{
 #include "efr32mg1p_af_ports.h"
 #include "efr32mg1p_af_pins.h"
 
-/**************************************************************************//**
+/***************************************************************************//**
  *  @brief Set the value of a bit field within a register.
  *
  *  @param REG
@@ -425,7 +434,7 @@ typedef enum IRQn{
  *  @param OFFSET
  *       The number of bits that the field is offset within the register.
  *       0 (zero) means LSB.
- *****************************************************************************/
+ ******************************************************************************/
 #define SET_BIT_FIELD(REG, MASK, VALUE, OFFSET) \
   REG = ((REG) &~(MASK)) | (((VALUE) << (OFFSET)) & (MASK));
 

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p233f256gm48.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p233f256gm48.h
@@ -1,35 +1,34 @@
-/**************************************************************************//**
- * @file efr32mg1p233f256gm48.h
+/***************************************************************************//**
+ * @file
  * @brief CMSIS Cortex-M Peripheral Access Layer Header File
  *        for EFR32MG1P233F256GM48
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #if defined(__ICCARM__)
 #pragma system_include       /* Treat file as system include file. */
@@ -44,15 +43,15 @@
 extern "C" {
 #endif
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup Parts
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFR32MG1P233F256GM48 EFR32MG1P233F256GM48
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /** Interrupt Number Definition */
 typedef enum IRQn{
@@ -70,7 +69,13 @@ typedef enum IRQn{
 /******  EFR32MG1P Peripheral Interrupt Numbers ********************************************/
 
   EMU_IRQn              = 0,  /*!< 16+0 EFR32 EMU Interrupt */
+  FRC_PRI_IRQn          = 1,  /*!< 16+1 EFR32 FRC_PRI Interrupt */
   WDOG0_IRQn            = 2,  /*!< 16+2 EFR32 WDOG0 Interrupt */
+  FRC_IRQn              = 3,  /*!< 16+3 EFR32 FRC Interrupt */
+  MODEM_IRQn            = 4,  /*!< 16+4 EFR32 MODEM Interrupt */
+  RAC_SEQ_IRQn          = 5,  /*!< 16+5 EFR32 RAC_SEQ Interrupt */
+  RAC_RSM_IRQn          = 6,  /*!< 16+6 EFR32 RAC_RSM Interrupt */
+  BUFC_IRQn             = 7,  /*!< 16+7 EFR32 BUFC Interrupt */
   LDMA_IRQn             = 8,  /*!< 16+8 EFR32 LDMA Interrupt */
   GPIO_EVEN_IRQn        = 9,  /*!< 16+9 EFR32 GPIO_EVEN Interrupt */
   TIMER0_IRQn           = 10, /*!< 16+10 EFR32 TIMER0 Interrupt */
@@ -90,28 +95,32 @@ typedef enum IRQn{
   MSC_IRQn              = 24, /*!< 16+24 EFR32 MSC Interrupt */
   CRYPTO_IRQn           = 25, /*!< 16+25 EFR32 CRYPTO Interrupt */
   LETIMER0_IRQn         = 26, /*!< 16+26 EFR32 LETIMER0 Interrupt */
+  AGC_IRQn              = 27, /*!< 16+27 EFR32 AGC Interrupt */
+  PROTIMER_IRQn         = 28, /*!< 16+28 EFR32 PROTIMER Interrupt */
   RTCC_IRQn             = 29, /*!< 16+29 EFR32 RTCC Interrupt */
+  SYNTH_IRQn            = 30, /*!< 16+30 EFR32 SYNTH Interrupt */
   CRYOTIMER_IRQn        = 31, /*!< 16+31 EFR32 CRYOTIMER Interrupt */
+  RFSENSE_IRQn          = 32, /*!< 16+32 EFR32 RFSENSE Interrupt */
   FPUEH_IRQn            = 33, /*!< 16+33 EFR32 FPUEH Interrupt */
 } IRQn_Type;
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFR32MG1P233F256GM48_Core Core
  * @{
  * @brief Processor and Core Peripheral Section
- *****************************************************************************/
-#define __MPU_PRESENT             1 /**< Presence of MPU  */
-#define __FPU_PRESENT             1 /**< Presence of FPU  */
-#define __VTOR_PRESENT            1 /**< Presence of VTOR register in SCB */
-#define __NVIC_PRIO_BITS          3 /**< NVIC interrupt priority bits */
-#define __Vendor_SysTickConfig    0 /**< Is 1 if different SysTick counter is used */
+ ******************************************************************************/
+#define __MPU_PRESENT             1U /**< Presence of MPU  */
+#define __FPU_PRESENT             1U /**< Presence of FPU  */
+#define __VTOR_PRESENT            1U /**< Presence of VTOR register in SCB */
+#define __NVIC_PRIO_BITS          3U /**< NVIC interrupt priority bits */
+#define __Vendor_SysTickConfig    0U /**< Is 1 if different SysTick counter is used */
 
 /** @} End of group EFR32MG1P233F256GM48_Core */
 
-/**************************************************************************//**
-* @defgroup EFR32MG1P233F256GM48_Part Part
-* @{
-******************************************************************************/
+/***************************************************************************//**
+ * @defgroup EFR32MG1P233F256GM48_Part Part
+ * @{
+ ******************************************************************************/
 
 /** Part family */
 #define _EFR32_MIGHTY_FAMILY                    1                                  /**< MIGHTY Gecko RF SoC Family  */
@@ -187,7 +196,7 @@ typedef enum IRQn{
 #define FLASH_PAGE_SIZE           2048U          /**< Flash Memory page size */
 #define SRAM_BASE                 (0x20000000UL) /**< SRAM Base Address */
 #define SRAM_SIZE                 (0x00007C00UL) /**< Available SRAM Memory */
-#define __CM4_REV                 0x001          /**< Cortex-M4 Core revision r0p1 */
+#define __CM4_REV                 0x0001U        /**< Cortex-M4 Core revision r0p1 */
 #define PRS_CHAN_COUNT            12             /**< Number of PRS channels */
 #define DMA_CHAN_COUNT            8              /**< Number of DMA channels */
 #define EXT_IRQ_COUNT             34             /**< Number of External (NVIC) interrupts */
@@ -255,11 +264,11 @@ typedef enum IRQn{
 
 /** @} End of group EFR32MG1P233F256GM48_Part */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFR32MG1P233F256GM48_Peripheral_TypeDefs Peripheral TypeDefs
  * @{
  * @brief Device Specific Peripheral Register Structures
- *****************************************************************************/
+ ******************************************************************************/
 
 #include "efr32mg1p_msc.h"
 #include "efr32mg1p_emu.h"
@@ -296,10 +305,10 @@ typedef enum IRQn{
 
 /** @} End of group EFR32MG1P233F256GM48_Peripheral_TypeDefs  */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFR32MG1P233F256GM48_Peripheral_Base Peripheral Memory Map
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 #define MSC_BASE          (0x400E0000UL) /**< MSC base address  */
 #define EMU_BASE          (0x400E3000UL) /**< EMU base address  */
@@ -333,10 +342,10 @@ typedef enum IRQn{
 
 /** @} End of group EFR32MG1P233F256GM48_Peripheral_Base */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFR32MG1P233F256GM48_Peripheral_Declaration Peripheral Declarations
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 #define MSC          ((MSC_TypeDef *) MSC_BASE)             /**< MSC base pointer */
 #define EMU          ((EMU_TypeDef *) EMU_BASE)             /**< EMU base pointer */
@@ -368,10 +377,10 @@ typedef enum IRQn{
 
 /** @} End of group EFR32MG1P233F256GM48_Peripheral_Declaration */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFR32MG1P233F256GM48_Peripheral_Offsets Peripheral Offsets
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 #define TIMER_OFFSET      0x400 /**< Offset in bytes between TIMER instances */
 #define USART_OFFSET      0x400 /**< Offset in bytes between USART instances */
@@ -386,18 +395,18 @@ typedef enum IRQn{
 
 /** @} End of group EFR32MG1P233F256GM48_Peripheral_Offsets */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFR32MG1P233F256GM48_BitFields Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 #include "efr32mg1p_prs_signals.h"
 #include "efr32mg1p_dmareq.h"
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @defgroup EFR32MG1P233F256GM48_UNLOCK Unlock Codes
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 #define MSC_UNLOCK_CODE      0x1B71 /**< MSC unlock code */
 #define EMU_UNLOCK_CODE      0xADE8 /**< EMU unlock code */
 #define RMU_UNLOCK_CODE      0xE084 /**< RMU unlock code */
@@ -413,7 +422,7 @@ typedef enum IRQn{
 #include "efr32mg1p_af_ports.h"
 #include "efr32mg1p_af_pins.h"
 
-/**************************************************************************//**
+/***************************************************************************//**
  *  @brief Set the value of a bit field within a register.
  *
  *  @param REG
@@ -425,7 +434,7 @@ typedef enum IRQn{
  *  @param OFFSET
  *       The number of bits that the field is offset within the register.
  *       0 (zero) means LSB.
- *****************************************************************************/
+ ******************************************************************************/
 #define SET_BIT_FIELD(REG, MASK, VALUE, OFFSET) \
   REG = ((REG) &~(MASK)) | (((VALUE) << (OFFSET)) & (MASK));
 

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_acmp.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_acmp.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg1p_acmp.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG1P_ACMP register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG1P_ACMP ACMP
  * @{
  * @brief EFR32MG1P_ACMP Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** ACMP Register Declaration */
 typedef struct {
   __IOM uint32_t CTRL;          /**< Control Register  */
@@ -59,23 +58,23 @@ typedef struct {
   __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
   __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
   __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
-  uint32_t       RESERVED0[1];  /**< Reserved for future use **/
+  uint32_t       RESERVED0[1U]; /**< Reserved for future use **/
   __IM uint32_t  APORTREQ;      /**< APORT Request Status Register  */
   __IM uint32_t  APORTCONFLICT; /**< APORT Conflict Status Register  */
   __IOM uint32_t HYSTERESIS0;   /**< Hysteresis 0 Register  */
   __IOM uint32_t HYSTERESIS1;   /**< Hysteresis 1 Register  */
 
-  uint32_t       RESERVED1[4];  /**< Reserved for future use **/
+  uint32_t       RESERVED1[4U]; /**< Reserved for future use **/
   __IOM uint32_t ROUTEPEN;      /**< I/O Routing Pine Enable Register  */
   __IOM uint32_t ROUTELOC0;     /**< I/O Routing Location Register  */
 } ACMP_TypeDef;                 /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG1P_ACMP
  * @{
  * @defgroup EFR32MG1P_ACMP_BitFields  ACMP Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for ACMP CTRL */
 #define _ACMP_CTRL_RESETVALUE                          0x07000000UL                               /**< Default value for ACMP_CTRL */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_adc.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_adc.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg1p_adc.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG1P_ADC register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,19 +40,19 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG1P_ADC ADC
  * @{
  * @brief EFR32MG1P_ADC Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** ADC Register Declaration */
 typedef struct {
   __IOM uint32_t CTRL;            /**< Control Register  */
-  uint32_t       RESERVED0[1];    /**< Reserved for future use **/
+  uint32_t       RESERVED0[1U];   /**< Reserved for future use **/
   __IOM uint32_t CMD;             /**< Command Register  */
   __IM uint32_t  STATUS;          /**< Status Register  */
   __IOM uint32_t SINGLECTRL;      /**< Single Channel Control Register  */
@@ -74,11 +73,11 @@ typedef struct {
   __IM uint32_t  SCANDATA;        /**< Scan Conversion Result Data  */
   __IM uint32_t  SINGLEDATAP;     /**< Single Conversion Result Data Peek Register  */
   __IM uint32_t  SCANDATAP;       /**< Scan Sequence Result Data Peek Register  */
-  uint32_t       RESERVED1[4];    /**< Reserved for future use **/
+  uint32_t       RESERVED1[4U];   /**< Reserved for future use **/
   __IM uint32_t  SCANDATAX;       /**< Scan Sequence Result Data + Data Source Register  */
   __IM uint32_t  SCANDATAXP;      /**< Scan Sequence Result Data + Data Source Peek Register  */
 
-  uint32_t       RESERVED2[3];    /**< Reserved for future use **/
+  uint32_t       RESERVED2[3U];   /**< Reserved for future use **/
   __IM uint32_t  APORTREQ;        /**< APORT Request Status Register  */
   __IM uint32_t  APORTCONFLICT;   /**< APORT Conflict Status Register  */
   __IM uint32_t  SINGLEFIFOCOUNT; /**< Single FIFO Count Register  */
@@ -88,12 +87,12 @@ typedef struct {
   __IOM uint32_t APORTMASTERDIS;  /**< APORT Bus Master Disable Register  */
 } ADC_TypeDef;                    /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG1P_ADC
  * @{
  * @defgroup EFR32MG1P_ADC_BitFields  ADC Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for ADC CTRL */
 #define _ADC_CTRL_RESETVALUE                               0x001F0000UL                              /**< Default value for ADC_CTRL */
@@ -479,12 +478,12 @@ typedef struct {
 #define _ADC_SINGLECTRL_POSSEL_APORT4YCH30                 0x0000009EUL                               /**< Mode APORT4YCH30 for ADC_SINGLECTRL */
 #define _ADC_SINGLECTRL_POSSEL_APORT4XCH31                 0x0000009FUL                               /**< Mode APORT4XCH31 for ADC_SINGLECTRL */
 #define _ADC_SINGLECTRL_POSSEL_AVDD                        0x000000E0UL                               /**< Mode AVDD for ADC_SINGLECTRL */
-#define _ADC_SINGLECTRL_POSSEL_BU                          0x000000E1UL                               /**< Mode BU for ADC_SINGLECTRL */
-#define _ADC_SINGLECTRL_POSSEL_AREG                        0x000000E2UL                               /**< Mode AREG for ADC_SINGLECTRL */
-#define _ADC_SINGLECTRL_POSSEL_VREGOUTPA                   0x000000E3UL                               /**< Mode VREGOUTPA for ADC_SINGLECTRL */
-#define _ADC_SINGLECTRL_POSSEL_PDBU                        0x000000E4UL                               /**< Mode PDBU for ADC_SINGLECTRL */
-#define _ADC_SINGLECTRL_POSSEL_IO0                         0x000000E5UL                               /**< Mode IO0 for ADC_SINGLECTRL */
-#define _ADC_SINGLECTRL_POSSEL_IO1                         0x000000E6UL                               /**< Mode IO1 for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_POSSEL_BUVDD                       0x000000E1UL                               /**< Mode BUVDD for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_POSSEL_DVDD                        0x000000E2UL                               /**< Mode DVDD for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_POSSEL_PAVDD                       0x000000E3UL                               /**< Mode PAVDD for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_POSSEL_DECOUPLE                    0x000000E4UL                               /**< Mode DECOUPLE for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_POSSEL_IOVDD                       0x000000E5UL                               /**< Mode IOVDD for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_POSSEL_IOVDD1                      0x000000E6UL                               /**< Mode IOVDD1 for ADC_SINGLECTRL */
 #define _ADC_SINGLECTRL_POSSEL_VSP                         0x000000E7UL                               /**< Mode VSP for ADC_SINGLECTRL */
 #define _ADC_SINGLECTRL_POSSEL_OPA2                        0x000000F2UL                               /**< Mode OPA2 for ADC_SINGLECTRL */
 #define _ADC_SINGLECTRL_POSSEL_TEMP                        0x000000F3UL                               /**< Mode TEMP for ADC_SINGLECTRL */
@@ -658,12 +657,12 @@ typedef struct {
 #define ADC_SINGLECTRL_POSSEL_APORT4YCH30                  (_ADC_SINGLECTRL_POSSEL_APORT4YCH30 << 8)  /**< Shifted mode APORT4YCH30 for ADC_SINGLECTRL */
 #define ADC_SINGLECTRL_POSSEL_APORT4XCH31                  (_ADC_SINGLECTRL_POSSEL_APORT4XCH31 << 8)  /**< Shifted mode APORT4XCH31 for ADC_SINGLECTRL */
 #define ADC_SINGLECTRL_POSSEL_AVDD                         (_ADC_SINGLECTRL_POSSEL_AVDD << 8)         /**< Shifted mode AVDD for ADC_SINGLECTRL */
-#define ADC_SINGLECTRL_POSSEL_BU                           (_ADC_SINGLECTRL_POSSEL_BU << 8)           /**< Shifted mode BU for ADC_SINGLECTRL */
-#define ADC_SINGLECTRL_POSSEL_AREG                         (_ADC_SINGLECTRL_POSSEL_AREG << 8)         /**< Shifted mode AREG for ADC_SINGLECTRL */
-#define ADC_SINGLECTRL_POSSEL_VREGOUTPA                    (_ADC_SINGLECTRL_POSSEL_VREGOUTPA << 8)    /**< Shifted mode VREGOUTPA for ADC_SINGLECTRL */
-#define ADC_SINGLECTRL_POSSEL_PDBU                         (_ADC_SINGLECTRL_POSSEL_PDBU << 8)         /**< Shifted mode PDBU for ADC_SINGLECTRL */
-#define ADC_SINGLECTRL_POSSEL_IO0                          (_ADC_SINGLECTRL_POSSEL_IO0 << 8)          /**< Shifted mode IO0 for ADC_SINGLECTRL */
-#define ADC_SINGLECTRL_POSSEL_IO1                          (_ADC_SINGLECTRL_POSSEL_IO1 << 8)          /**< Shifted mode IO1 for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_POSSEL_BUVDD                        (_ADC_SINGLECTRL_POSSEL_BUVDD << 8)        /**< Shifted mode BUVDD for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_POSSEL_DVDD                         (_ADC_SINGLECTRL_POSSEL_DVDD << 8)         /**< Shifted mode DVDD for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_POSSEL_PAVDD                        (_ADC_SINGLECTRL_POSSEL_PAVDD << 8)        /**< Shifted mode PAVDD for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_POSSEL_DECOUPLE                     (_ADC_SINGLECTRL_POSSEL_DECOUPLE << 8)     /**< Shifted mode DECOUPLE for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_POSSEL_IOVDD                        (_ADC_SINGLECTRL_POSSEL_IOVDD << 8)        /**< Shifted mode IOVDD for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_POSSEL_IOVDD1                       (_ADC_SINGLECTRL_POSSEL_IOVDD1 << 8)       /**< Shifted mode IOVDD1 for ADC_SINGLECTRL */
 #define ADC_SINGLECTRL_POSSEL_VSP                          (_ADC_SINGLECTRL_POSSEL_VSP << 8)          /**< Shifted mode VSP for ADC_SINGLECTRL */
 #define ADC_SINGLECTRL_POSSEL_OPA2                         (_ADC_SINGLECTRL_POSSEL_OPA2 << 8)         /**< Shifted mode OPA2 for ADC_SINGLECTRL */
 #define ADC_SINGLECTRL_POSSEL_TEMP                         (_ADC_SINGLECTRL_POSSEL_TEMP << 8)         /**< Shifted mode TEMP for ADC_SINGLECTRL */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_af_pins.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_af_pins.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg1p_af_pins.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG1P_AF_PINS register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,16 +40,16 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @addtogroup EFR32MG1P_Alternate_Function Alternate Function
  * @{
  * @defgroup EFR32MG1P_AF_Pins Alternate Function Pins
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 #define AF_CMU_CLK0_PIN(i)         ((i) == 0 ? 1 : (i) == 1 ? 15 : (i) == 2 ? 6 : (i) == 3 ? 11 : (i) == 4 ? 9 : (i) == 5 ? 14 : (i) == 6 ? 2 : (i) == 7 ? 7 :  -1)                                                                                                                                                                                                                                                                                                                                                                                                         /**< Pin number for AF_CMU_CLK0 location number i */
 #define AF_CMU_CLK1_PIN(i)         ((i) == 0 ? 0 : (i) == 1 ? 14 : (i) == 2 ? 7 : (i) == 3 ? 10 : (i) == 4 ? 10 : (i) == 5 ? 15 : (i) == 6 ? 3 : (i) == 7 ? 6 :  -1)                                                                                                                                                                                                                                                                                                                                                                                                        /**< Pin number for AF_CMU_CLK1 location number i */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_af_ports.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_af_ports.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg1p_af_ports.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG1P_AF_PORTS register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,16 +40,16 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @addtogroup EFR32MG1P_Alternate_Function Alternate Function
  * @{
  * @defgroup EFR32MG1P_AF_Ports Alternate Function Ports
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 #define AF_CMU_CLK0_PORT(i)         ((i) == 0 ? 0 : (i) == 1 ? 1 : (i) == 2 ? 2 : (i) == 3 ? 2 : (i) == 4 ? 3 : (i) == 5 ? 3 : (i) == 6 ? 5 : (i) == 7 ? 5 :  -1)                                                                                                                                                                                                                                                                                                                                                                                               /**< Port number for AF_CMU_CLK0 location number i */
 #define AF_CMU_CLK1_PORT(i)         ((i) == 0 ? 0 : (i) == 1 ? 1 : (i) == 2 ? 2 : (i) == 3 ? 2 : (i) == 4 ? 3 : (i) == 5 ? 3 : (i) == 6 ? 5 : (i) == 7 ? 5 :  -1)                                                                                                                                                                                                                                                                                                                                                                                               /**< Port number for AF_CMU_CLK1 location number i */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_cmu.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_cmu.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg1p_cmu.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG1P_CMU register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,26 +40,26 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG1P_CMU CMU
  * @{
  * @brief EFR32MG1P_CMU Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** CMU Register Declaration */
 typedef struct {
   __IOM uint32_t CTRL;                /**< CMU Control Register  */
 
-  uint32_t       RESERVED0[3];        /**< Reserved for future use **/
+  uint32_t       RESERVED0[3U];       /**< Reserved for future use **/
   __IOM uint32_t HFRCOCTRL;           /**< HFRCO Control Register  */
 
-  uint32_t       RESERVED1[1];        /**< Reserved for future use **/
+  uint32_t       RESERVED1[1U];       /**< Reserved for future use **/
   __IOM uint32_t AUXHFRCOCTRL;        /**< AUXHFRCO Control Register  */
 
-  uint32_t       RESERVED2[1];        /**< Reserved for future use **/
+  uint32_t       RESERVED2[1U];       /**< Reserved for future use **/
   __IOM uint32_t LFRCOCTRL;           /**< LFRCO Control Register  */
   __IOM uint32_t HFXOCTRL;            /**< HFXO Control Register  */
   __IOM uint32_t HFXOCTRL1;           /**< HFXO Control 1  */
@@ -70,24 +69,24 @@ typedef struct {
   __IOM uint32_t LFXOCTRL;            /**< LFXO Control Register  */
   __IOM uint32_t ULFRCOCTRL;          /**< ULFRCO Control Register  */
 
-  uint32_t       RESERVED3[4];        /**< Reserved for future use **/
+  uint32_t       RESERVED3[4U];       /**< Reserved for future use **/
   __IOM uint32_t CALCTRL;             /**< Calibration Control Register  */
   __IOM uint32_t CALCNT;              /**< Calibration Counter Register  */
-  uint32_t       RESERVED4[2];        /**< Reserved for future use **/
+  uint32_t       RESERVED4[2U];       /**< Reserved for future use **/
   __IOM uint32_t OSCENCMD;            /**< Oscillator Enable/Disable Command Register  */
   __IOM uint32_t CMD;                 /**< Command Register  */
-  uint32_t       RESERVED5[2];        /**< Reserved for future use **/
+  uint32_t       RESERVED5[2U];       /**< Reserved for future use **/
   __IOM uint32_t DBGCLKSEL;           /**< Debug Trace Clock Select  */
   __IOM uint32_t HFCLKSEL;            /**< High Frequency Clock Select Command Register  */
-  uint32_t       RESERVED6[2];        /**< Reserved for future use **/
+  uint32_t       RESERVED6[2U];       /**< Reserved for future use **/
   __IOM uint32_t LFACLKSEL;           /**< Low Frequency A Clock Select Register  */
   __IOM uint32_t LFBCLKSEL;           /**< Low Frequency B Clock Select Register  */
   __IOM uint32_t LFECLKSEL;           /**< Low Frequency E Clock Select Register  */
 
-  uint32_t       RESERVED7[1];        /**< Reserved for future use **/
+  uint32_t       RESERVED7[1U];       /**< Reserved for future use **/
   __IM uint32_t  STATUS;              /**< Status Register  */
   __IM uint32_t  HFCLKSTATUS;         /**< HFCLK Status Register  */
-  uint32_t       RESERVED8[1];        /**< Reserved for future use **/
+  uint32_t       RESERVED8[1U];       /**< Reserved for future use **/
   __IM uint32_t  HFXOTRIMSTATUS;      /**< HFXO Trim Status  */
   __IM uint32_t  IF;                  /**< Interrupt Flag Register  */
   __IOM uint32_t IFS;                 /**< Interrupt Flag Set Register  */
@@ -95,56 +94,56 @@ typedef struct {
   __IOM uint32_t IEN;                 /**< Interrupt Enable Register  */
   __IOM uint32_t HFBUSCLKEN0;         /**< High Frequency Bus Clock Enable Register 0  */
 
-  uint32_t       RESERVED9[3];        /**< Reserved for future use **/
+  uint32_t       RESERVED9[3U];       /**< Reserved for future use **/
   __IOM uint32_t HFPERCLKEN0;         /**< High Frequency Peripheral Clock Enable Register 0  */
 
-  uint32_t       RESERVED10[7];       /**< Reserved for future use **/
+  uint32_t       RESERVED10[7U];      /**< Reserved for future use **/
   __IOM uint32_t LFACLKEN0;           /**< Low Frequency a Clock Enable Register 0  (Async Reg)  */
-  uint32_t       RESERVED11[1];       /**< Reserved for future use **/
+  uint32_t       RESERVED11[1U];      /**< Reserved for future use **/
   __IOM uint32_t LFBCLKEN0;           /**< Low Frequency B Clock Enable Register 0 (Async Reg)  */
 
-  uint32_t       RESERVED12[1];       /**< Reserved for future use **/
+  uint32_t       RESERVED12[1U];      /**< Reserved for future use **/
   __IOM uint32_t LFECLKEN0;           /**< Low Frequency E Clock Enable Register 0 (Async Reg)  */
-  uint32_t       RESERVED13[3];       /**< Reserved for future use **/
+  uint32_t       RESERVED13[3U];      /**< Reserved for future use **/
   __IOM uint32_t HFPRESC;             /**< High Frequency Clock Prescaler Register  */
 
-  uint32_t       RESERVED14[1];       /**< Reserved for future use **/
+  uint32_t       RESERVED14[1U];      /**< Reserved for future use **/
   __IOM uint32_t HFCOREPRESC;         /**< High Frequency Core Clock Prescaler Register  */
   __IOM uint32_t HFPERPRESC;          /**< High Frequency Peripheral Clock Prescaler Register  */
 
-  uint32_t       RESERVED15[1];       /**< Reserved for future use **/
+  uint32_t       RESERVED15[1U];      /**< Reserved for future use **/
   __IOM uint32_t HFEXPPRESC;          /**< High Frequency Export Clock Prescaler Register  */
 
-  uint32_t       RESERVED16[2];       /**< Reserved for future use **/
+  uint32_t       RESERVED16[2U];      /**< Reserved for future use **/
   __IOM uint32_t LFAPRESC0;           /**< Low Frequency a Prescaler Register 0 (Async Reg)  */
-  uint32_t       RESERVED17[1];       /**< Reserved for future use **/
+  uint32_t       RESERVED17[1U];      /**< Reserved for future use **/
   __IOM uint32_t LFBPRESC0;           /**< Low Frequency B Prescaler Register 0  (Async Reg)  */
-  uint32_t       RESERVED18[1];       /**< Reserved for future use **/
+  uint32_t       RESERVED18[1U];      /**< Reserved for future use **/
   __IOM uint32_t LFEPRESC0;           /**< Low Frequency E Prescaler Register 0  (Async Reg)  */
 
-  uint32_t       RESERVED19[3];       /**< Reserved for future use **/
+  uint32_t       RESERVED19[3U];      /**< Reserved for future use **/
   __IM uint32_t  SYNCBUSY;            /**< Synchronization Busy Register  */
   __IOM uint32_t FREEZE;              /**< Freeze Register  */
-  uint32_t       RESERVED20[2];       /**< Reserved for future use **/
+  uint32_t       RESERVED20[2U];      /**< Reserved for future use **/
   __IOM uint32_t PCNTCTRL;            /**< PCNT Control Register  */
 
-  uint32_t       RESERVED21[2];       /**< Reserved for future use **/
+  uint32_t       RESERVED21[2U];      /**< Reserved for future use **/
   __IOM uint32_t ADCCTRL;             /**< ADC Control Register  */
 
-  uint32_t       RESERVED22[4];       /**< Reserved for future use **/
+  uint32_t       RESERVED22[4U];      /**< Reserved for future use **/
   __IOM uint32_t ROUTEPEN;            /**< I/O Routing Pin Enable Register  */
   __IOM uint32_t ROUTELOC0;           /**< I/O Routing Location Register  */
 
-  uint32_t       RESERVED23[2];       /**< Reserved for future use **/
+  uint32_t       RESERVED23[2U];      /**< Reserved for future use **/
   __IOM uint32_t LOCK;                /**< Configuration Lock Register  */
 } CMU_TypeDef;                        /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG1P_CMU
  * @{
  * @defgroup EFR32MG1P_CMU_BitFields  CMU Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for CMU CTRL */
 #define _CMU_CTRL_RESETVALUE                              0x00300000UL                          /**< Default value for CMU_CTRL */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_cryotimer.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_cryotimer.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg1p_cryotimer.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG1P_CRYOTIMER register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG1P_CRYOTIMER CRYOTIMER
  * @{
  * @brief EFR32MG1P_CRYOTIMER Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** CRYOTIMER Register Declaration */
 typedef struct {
   __IOM uint32_t CTRL;      /**< Control Register  */
@@ -62,12 +61,12 @@ typedef struct {
   __IOM uint32_t IEN;       /**< Interrupt Enable Register  */
 } CRYOTIMER_TypeDef;        /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG1P_CRYOTIMER
  * @{
  * @defgroup EFR32MG1P_CRYOTIMER_BitFields  CRYOTIMER Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for CRYOTIMER CTRL */
 #define _CRYOTIMER_CTRL_RESETVALUE                0x00000000UL                            /**< Default value for CRYOTIMER_CTRL */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_crypto.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_crypto.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg1p_crypto.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG1P_CRYPTO register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,84 +40,84 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG1P_CRYPTO CRYPTO
  * @{
  * @brief EFR32MG1P_CRYPTO Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** CRYPTO Register Declaration */
 typedef struct {
-  __IOM uint32_t CTRL;           /**< Control Register  */
-  __IOM uint32_t WAC;            /**< Wide Arithmetic Configuration  */
-  __IOM uint32_t CMD;            /**< Command Register  */
-  uint32_t       RESERVED0[1];   /**< Reserved for future use **/
-  __IM uint32_t  STATUS;         /**< Status Register  */
-  __IM uint32_t  DSTATUS;        /**< Data Status Register  */
-  __IM uint32_t  CSTATUS;        /**< Control Status Register  */
-  uint32_t       RESERVED1[1];   /**< Reserved for future use **/
-  __IOM uint32_t KEY;            /**< KEY Register Access  */
-  __IOM uint32_t KEYBUF;         /**< KEY Buffer Register Access  */
-  uint32_t       RESERVED2[2];   /**< Reserved for future use **/
-  __IOM uint32_t SEQCTRL;        /**< Sequence Control  */
-  __IOM uint32_t SEQCTRLB;       /**< Sequence Control B  */
-  uint32_t       RESERVED3[2];   /**< Reserved for future use **/
-  __IM uint32_t  IF;             /**< AES Interrupt Flags  */
-  __IOM uint32_t IFS;            /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;            /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t IEN;            /**< Interrupt Enable Register  */
-  __IOM uint32_t SEQ0;           /**< Sequence Register 0  */
-  __IOM uint32_t SEQ1;           /**< Sequence Register 1  */
-  __IOM uint32_t SEQ2;           /**< Sequence Register 2  */
-  __IOM uint32_t SEQ3;           /**< Sequence Register 3  */
-  __IOM uint32_t SEQ4;           /**< Sequence Register 4  */
-  uint32_t       RESERVED4[7];   /**< Reserved for future use **/
-  __IOM uint32_t DATA0;          /**< DATA0 Register Access  */
-  __IOM uint32_t DATA1;          /**< DATA1 Register Access  */
-  __IOM uint32_t DATA2;          /**< DATA2 Register Access  */
-  __IOM uint32_t DATA3;          /**< DATA3 Register Access  */
-  uint32_t       RESERVED5[4];   /**< Reserved for future use **/
-  __IOM uint32_t DATA0XOR;       /**< DATA0XOR Register Access  */
-  uint32_t       RESERVED6[3];   /**< Reserved for future use **/
-  __IOM uint32_t DATA0BYTE;      /**< DATA0 Register Byte Access  */
-  __IOM uint32_t DATA1BYTE;      /**< DATA1 Register Byte Access  */
-  uint32_t       RESERVED7[1];   /**< Reserved for future use **/
-  __IOM uint32_t DATA0XORBYTE;   /**< DATA0 Register Byte XOR Access  */
-  __IOM uint32_t DATA0BYTE12;    /**< DATA0 Register Byte 12 Access  */
-  __IOM uint32_t DATA0BYTE13;    /**< DATA0 Register Byte 13 Access  */
-  __IOM uint32_t DATA0BYTE14;    /**< DATA0 Register Byte 14 Access  */
-  __IOM uint32_t DATA0BYTE15;    /**< DATA0 Register Byte 15 Access  */
-  uint32_t       RESERVED8[12];  /**< Reserved for future use **/
-  __IOM uint32_t DDATA0;         /**< DDATA0 Register Access  */
-  __IOM uint32_t DDATA1;         /**< DDATA1 Register Access  */
-  __IOM uint32_t DDATA2;         /**< DDATA2 Register Access  */
-  __IOM uint32_t DDATA3;         /**< DDATA3 Register Access  */
-  __IOM uint32_t DDATA4;         /**< DDATA4 Register Access  */
-  uint32_t       RESERVED9[7];   /**< Reserved for future use **/
-  __IOM uint32_t DDATA0BIG;      /**< DDATA0 Register Big Endian Access  */
-  uint32_t       RESERVED10[3];  /**< Reserved for future use **/
-  __IOM uint32_t DDATA0BYTE;     /**< DDATA0 Register Byte Access  */
-  __IOM uint32_t DDATA1BYTE;     /**< DDATA1 Register Byte Access  */
-  __IOM uint32_t DDATA0BYTE32;   /**< DDATA0 Register Byte 32 Access  */
-  uint32_t       RESERVED11[13]; /**< Reserved for future use **/
-  __IOM uint32_t QDATA0;         /**< QDATA0 Register Access  */
-  __IOM uint32_t QDATA1;         /**< QDATA1 Register Access  */
-  uint32_t       RESERVED12[7];  /**< Reserved for future use **/
-  __IOM uint32_t QDATA1BIG;      /**< QDATA1 Register Big Endian Access  */
-  uint32_t       RESERVED13[6];  /**< Reserved for future use **/
-  __IOM uint32_t QDATA0BYTE;     /**< QDATA0 Register Byte Access  */
-  __IOM uint32_t QDATA1BYTE;     /**< QDATA1 Register Byte Access  */
-} CRYPTO_TypeDef;                /** @} */
+  __IOM uint32_t CTRL;            /**< Control Register  */
+  __IOM uint32_t WAC;             /**< Wide Arithmetic Configuration  */
+  __IOM uint32_t CMD;             /**< Command Register  */
+  uint32_t       RESERVED0[1U];   /**< Reserved for future use **/
+  __IM uint32_t  STATUS;          /**< Status Register  */
+  __IM uint32_t  DSTATUS;         /**< Data Status Register  */
+  __IM uint32_t  CSTATUS;         /**< Control Status Register  */
+  uint32_t       RESERVED1[1U];   /**< Reserved for future use **/
+  __IOM uint32_t KEY;             /**< KEY Register Access  */
+  __IOM uint32_t KEYBUF;          /**< KEY Buffer Register Access  */
+  uint32_t       RESERVED2[2U];   /**< Reserved for future use **/
+  __IOM uint32_t SEQCTRL;         /**< Sequence Control  */
+  __IOM uint32_t SEQCTRLB;        /**< Sequence Control B  */
+  uint32_t       RESERVED3[2U];   /**< Reserved for future use **/
+  __IM uint32_t  IF;              /**< AES Interrupt Flags  */
+  __IOM uint32_t IFS;             /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;             /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;             /**< Interrupt Enable Register  */
+  __IOM uint32_t SEQ0;            /**< Sequence Register 0  */
+  __IOM uint32_t SEQ1;            /**< Sequence Register 1  */
+  __IOM uint32_t SEQ2;            /**< Sequence Register 2  */
+  __IOM uint32_t SEQ3;            /**< Sequence Register 3  */
+  __IOM uint32_t SEQ4;            /**< Sequence Register 4  */
+  uint32_t       RESERVED4[7U];   /**< Reserved for future use **/
+  __IOM uint32_t DATA0;           /**< DATA0 Register Access  */
+  __IOM uint32_t DATA1;           /**< DATA1 Register Access  */
+  __IOM uint32_t DATA2;           /**< DATA2 Register Access  */
+  __IOM uint32_t DATA3;           /**< DATA3 Register Access  */
+  uint32_t       RESERVED5[4U];   /**< Reserved for future use **/
+  __IOM uint32_t DATA0XOR;        /**< DATA0XOR Register Access  */
+  uint32_t       RESERVED6[3U];   /**< Reserved for future use **/
+  __IOM uint32_t DATA0BYTE;       /**< DATA0 Register Byte Access  */
+  __IOM uint32_t DATA1BYTE;       /**< DATA1 Register Byte Access  */
+  uint32_t       RESERVED7[1U];   /**< Reserved for future use **/
+  __IOM uint32_t DATA0XORBYTE;    /**< DATA0 Register Byte XOR Access  */
+  __IOM uint32_t DATA0BYTE12;     /**< DATA0 Register Byte 12 Access  */
+  __IOM uint32_t DATA0BYTE13;     /**< DATA0 Register Byte 13 Access  */
+  __IOM uint32_t DATA0BYTE14;     /**< DATA0 Register Byte 14 Access  */
+  __IOM uint32_t DATA0BYTE15;     /**< DATA0 Register Byte 15 Access  */
+  uint32_t       RESERVED8[12U];  /**< Reserved for future use **/
+  __IOM uint32_t DDATA0;          /**< DDATA0 Register Access  */
+  __IOM uint32_t DDATA1;          /**< DDATA1 Register Access  */
+  __IOM uint32_t DDATA2;          /**< DDATA2 Register Access  */
+  __IOM uint32_t DDATA3;          /**< DDATA3 Register Access  */
+  __IOM uint32_t DDATA4;          /**< DDATA4 Register Access  */
+  uint32_t       RESERVED9[7U];   /**< Reserved for future use **/
+  __IOM uint32_t DDATA0BIG;       /**< DDATA0 Register Big Endian Access  */
+  uint32_t       RESERVED10[3U];  /**< Reserved for future use **/
+  __IOM uint32_t DDATA0BYTE;      /**< DDATA0 Register Byte Access  */
+  __IOM uint32_t DDATA1BYTE;      /**< DDATA1 Register Byte Access  */
+  __IOM uint32_t DDATA0BYTE32;    /**< DDATA0 Register Byte 32 Access  */
+  uint32_t       RESERVED11[13U]; /**< Reserved for future use **/
+  __IOM uint32_t QDATA0;          /**< QDATA0 Register Access  */
+  __IOM uint32_t QDATA1;          /**< QDATA1 Register Access  */
+  uint32_t       RESERVED12[7U];  /**< Reserved for future use **/
+  __IOM uint32_t QDATA1BIG;       /**< QDATA1 Register Big Endian Access  */
+  uint32_t       RESERVED13[6U];  /**< Reserved for future use **/
+  __IOM uint32_t QDATA0BYTE;      /**< QDATA0 Register Byte Access  */
+  __IOM uint32_t QDATA1BYTE;      /**< QDATA1 Register Byte Access  */
+} CRYPTO_TypeDef;                 /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG1P_CRYPTO
  * @{
  * @defgroup EFR32MG1P_CRYPTO_BitFields  CRYPTO Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for CRYPTO CTRL */
 #define _CRYPTO_CTRL_RESETVALUE                      0x00000000UL                               /**< Default value for CRYPTO_CTRL */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_devinfo.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_devinfo.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg1p_devinfo.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG1P_DEVINFO register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,69 +40,71 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG1P_DEVINFO Device Information and Calibration
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /** DEVINFO Register Declaration */
 typedef struct {
   __IM uint32_t CAL;              /**< CRC of DI-page and calibration temperature  */
-  uint32_t      RESERVED0[7];     /**< Reserved for future use **/
+  __IM uint32_t MODULEINFO;       /**< Module trace information  */
+  __IM uint32_t MODXOCAL;         /**< Module Crystal Oscillator Calibration  */
+  uint32_t      RESERVED0[5U];    /**< Reserved for future use **/
   __IM uint32_t EXTINFO;          /**< External Component description  */
-  uint32_t      RESERVED1[1];     /**< Reserved for future use **/
+  uint32_t      RESERVED1[1U];    /**< Reserved for future use **/
   __IM uint32_t EUI48L;           /**< EUI48 OUI and Unique identifier  */
   __IM uint32_t EUI48H;           /**< OUI  */
   __IM uint32_t CUSTOMINFO;       /**< Custom information  */
   __IM uint32_t MEMINFO;          /**< Flash page size and misc. chip information  */
-  uint32_t      RESERVED2[2];     /**< Reserved for future use **/
+  uint32_t      RESERVED2[2U];    /**< Reserved for future use **/
   __IM uint32_t UNIQUEL;          /**< Low 32 bits of device unique number  */
   __IM uint32_t UNIQUEH;          /**< High 32 bits of device unique number  */
   __IM uint32_t MSIZE;            /**< Flash and SRAM Memory size in kB  */
   __IM uint32_t PART;             /**< Part description  */
   __IM uint32_t DEVINFOREV;       /**< Device information page revision  */
   __IM uint32_t EMUTEMP;          /**< EMU Temperature Calibration Information  */
-  uint32_t      RESERVED3[2];     /**< Reserved for future use **/
+  uint32_t      RESERVED3[2U];    /**< Reserved for future use **/
   __IM uint32_t ADC0CAL0;         /**< ADC0 calibration register 0  */
   __IM uint32_t ADC0CAL1;         /**< ADC0 calibration register 1  */
   __IM uint32_t ADC0CAL2;         /**< ADC0 calibration register 2  */
   __IM uint32_t ADC0CAL3;         /**< ADC0 calibration register 3  */
-  uint32_t      RESERVED4[4];     /**< Reserved for future use **/
+  uint32_t      RESERVED4[4U];    /**< Reserved for future use **/
   __IM uint32_t HFRCOCAL0;        /**< HFRCO Calibration Register (4 MHz)  */
-  uint32_t      RESERVED5[2];     /**< Reserved for future use **/
+  uint32_t      RESERVED5[2U];    /**< Reserved for future use **/
   __IM uint32_t HFRCOCAL3;        /**< HFRCO Calibration Register (7 MHz)  */
-  uint32_t      RESERVED6[2];     /**< Reserved for future use **/
+  uint32_t      RESERVED6[2U];    /**< Reserved for future use **/
   __IM uint32_t HFRCOCAL6;        /**< HFRCO Calibration Register (13 MHz)  */
   __IM uint32_t HFRCOCAL7;        /**< HFRCO Calibration Register (16 MHz)  */
   __IM uint32_t HFRCOCAL8;        /**< HFRCO Calibration Register (19 MHz)  */
-  uint32_t      RESERVED7[1];     /**< Reserved for future use **/
+  uint32_t      RESERVED7[1U];    /**< Reserved for future use **/
   __IM uint32_t HFRCOCAL10;       /**< HFRCO Calibration Register (26 MHz)  */
   __IM uint32_t HFRCOCAL11;       /**< HFRCO Calibration Register (32 MHz)  */
   __IM uint32_t HFRCOCAL12;       /**< HFRCO Calibration Register (38 MHz)  */
-  uint32_t      RESERVED8[11];    /**< Reserved for future use **/
+  uint32_t      RESERVED8[11U];   /**< Reserved for future use **/
   __IM uint32_t AUXHFRCOCAL0;     /**< AUXHFRCO Calibration Register (4 MHz)  */
-  uint32_t      RESERVED9[2];     /**< Reserved for future use **/
+  uint32_t      RESERVED9[2U];    /**< Reserved for future use **/
   __IM uint32_t AUXHFRCOCAL3;     /**< AUXHFRCO Calibration Register (7 MHz)  */
-  uint32_t      RESERVED10[2];    /**< Reserved for future use **/
+  uint32_t      RESERVED10[2U];   /**< Reserved for future use **/
   __IM uint32_t AUXHFRCOCAL6;     /**< AUXHFRCO Calibration Register (13 MHz)  */
   __IM uint32_t AUXHFRCOCAL7;     /**< AUXHFRCO Calibration Register (16 MHz)  */
   __IM uint32_t AUXHFRCOCAL8;     /**< AUXHFRCO Calibration Register (19 MHz)  */
-  uint32_t      RESERVED11[1];    /**< Reserved for future use **/
+  uint32_t      RESERVED11[1U];   /**< Reserved for future use **/
   __IM uint32_t AUXHFRCOCAL10;    /**< AUXHFRCO Calibration Register (26 MHz)  */
   __IM uint32_t AUXHFRCOCAL11;    /**< AUXHFRCO Calibration Register (32 MHz)  */
   __IM uint32_t AUXHFRCOCAL12;    /**< AUXHFRCO Calibration Register (38 MHz)  */
-  uint32_t      RESERVED12[11];   /**< Reserved for future use **/
+  uint32_t      RESERVED12[11U];  /**< Reserved for future use **/
   __IM uint32_t VMONCAL0;         /**< VMON Calibration Register 0  */
   __IM uint32_t VMONCAL1;         /**< VMON Calibration Register 1  */
   __IM uint32_t VMONCAL2;         /**< VMON Calibration Register 2  */
-  uint32_t      RESERVED13[3];    /**< Reserved for future use **/
+  uint32_t      RESERVED13[3U];   /**< Reserved for future use **/
   __IM uint32_t IDAC0CAL0;        /**< IDAC0 Calibration Register 0  */
   __IM uint32_t IDAC0CAL1;        /**< IDAC0 Calibration Register 1  */
-  uint32_t      RESERVED14[2];    /**< Reserved for future use **/
+  uint32_t      RESERVED14[2U];   /**< Reserved for future use **/
   __IM uint32_t DCDCLNVCTRL0;     /**< DCDC Low-noise VREF Trim Register 0  */
   __IM uint32_t DCDCLPVCTRL0;     /**< DCDC Low-power VREF Trim Register 0  */
   __IM uint32_t DCDCLPVCTRL1;     /**< DCDC Low-power VREF Trim Register 1  */
@@ -113,12 +114,12 @@ typedef struct {
   __IM uint32_t DCDCLPCMPHYSSEL1; /**< DCDC LPCMPHYSSEL Trim Register 1  */
 } DEVINFO_TypeDef;                /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG1P_DEVINFO
  * @{
  * @defgroup EFR32MG1P_DEVINFO_BitFields DEVINFO Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for DEVINFO CAL */
 #define _DEVINFO_CAL_MASK                                        0x00FFFFFFUL /**< Mask for DEVINFO_CAL */
@@ -126,6 +127,60 @@ typedef struct {
 #define _DEVINFO_CAL_CRC_MASK                                    0xFFFFUL     /**< Bit mask for CRC */
 #define _DEVINFO_CAL_TEMP_SHIFT                                  16           /**< Shift value for TEMP */
 #define _DEVINFO_CAL_TEMP_MASK                                   0xFF0000UL   /**< Bit mask for TEMP */
+
+/* Bit fields for DEVINFO MODULEINFO */
+#define _DEVINFO_MODULEINFO_MASK                                 0xFFFFFFFFUL                                    /**< Mask for DEVINFO_MODULEINFO */
+#define _DEVINFO_MODULEINFO_HWREV_SHIFT                          0                                               /**< Shift value for HWREV */
+#define _DEVINFO_MODULEINFO_HWREV_MASK                           0x1FUL                                          /**< Bit mask for HWREV */
+#define _DEVINFO_MODULEINFO_ANTENNA_SHIFT                        5                                               /**< Shift value for ANTENNA */
+#define _DEVINFO_MODULEINFO_ANTENNA_MASK                         0xE0UL                                          /**< Bit mask for ANTENNA */
+#define _DEVINFO_MODULEINFO_ANTENNA_BUILTIN                      0x00000000UL                                    /**< Mode BUILTIN for DEVINFO_MODULEINFO */
+#define _DEVINFO_MODULEINFO_ANTENNA_CONNECTOR                    0x00000001UL                                    /**< Mode CONNECTOR for DEVINFO_MODULEINFO */
+#define _DEVINFO_MODULEINFO_ANTENNA_RFPAD                        0x00000002UL                                    /**< Mode RFPAD for DEVINFO_MODULEINFO */
+#define DEVINFO_MODULEINFO_ANTENNA_BUILTIN                       (_DEVINFO_MODULEINFO_ANTENNA_BUILTIN << 5)      /**< Shifted mode BUILTIN for DEVINFO_MODULEINFO */
+#define DEVINFO_MODULEINFO_ANTENNA_CONNECTOR                     (_DEVINFO_MODULEINFO_ANTENNA_CONNECTOR << 5)    /**< Shifted mode CONNECTOR for DEVINFO_MODULEINFO */
+#define DEVINFO_MODULEINFO_ANTENNA_RFPAD                         (_DEVINFO_MODULEINFO_ANTENNA_RFPAD << 5)        /**< Shifted mode RFPAD for DEVINFO_MODULEINFO */
+#define _DEVINFO_MODULEINFO_MODNUMBER_SHIFT                      8                                               /**< Shift value for MODNUMBER */
+#define _DEVINFO_MODULEINFO_MODNUMBER_MASK                       0x7F00UL                                        /**< Bit mask for MODNUMBER */
+#define _DEVINFO_MODULEINFO_TYPE_SHIFT                           15                                              /**< Shift value for TYPE */
+#define _DEVINFO_MODULEINFO_TYPE_MASK                            0x8000UL                                        /**< Bit mask for TYPE */
+#define _DEVINFO_MODULEINFO_TYPE_PCB                             0x00000000UL                                    /**< Mode PCB for DEVINFO_MODULEINFO */
+#define _DEVINFO_MODULEINFO_TYPE_SIP                             0x00000001UL                                    /**< Mode SIP for DEVINFO_MODULEINFO */
+#define DEVINFO_MODULEINFO_TYPE_PCB                              (_DEVINFO_MODULEINFO_TYPE_PCB << 15)            /**< Shifted mode PCB for DEVINFO_MODULEINFO */
+#define DEVINFO_MODULEINFO_TYPE_SIP                              (_DEVINFO_MODULEINFO_TYPE_SIP << 15)            /**< Shifted mode SIP for DEVINFO_MODULEINFO */
+#define _DEVINFO_MODULEINFO_LFXO_SHIFT                           16                                              /**< Shift value for LFXO */
+#define _DEVINFO_MODULEINFO_LFXO_MASK                            0x10000UL                                       /**< Bit mask for LFXO */
+#define _DEVINFO_MODULEINFO_LFXO_NONE                            0x00000000UL                                    /**< Mode NONE for DEVINFO_MODULEINFO */
+#define _DEVINFO_MODULEINFO_LFXO_PRESENT                         0x00000001UL                                    /**< Mode PRESENT for DEVINFO_MODULEINFO */
+#define DEVINFO_MODULEINFO_LFXO_NONE                             (_DEVINFO_MODULEINFO_LFXO_NONE << 16)           /**< Shifted mode NONE for DEVINFO_MODULEINFO */
+#define DEVINFO_MODULEINFO_LFXO_PRESENT                          (_DEVINFO_MODULEINFO_LFXO_PRESENT << 16)        /**< Shifted mode PRESENT for DEVINFO_MODULEINFO */
+#define _DEVINFO_MODULEINFO_EXPRESS_SHIFT                        17                                              /**< Shift value for EXPRESS */
+#define _DEVINFO_MODULEINFO_EXPRESS_MASK                         0x20000UL                                       /**< Bit mask for EXPRESS */
+#define _DEVINFO_MODULEINFO_EXPRESS_SUPPORTED                    0x00000000UL                                    /**< Mode SUPPORTED for DEVINFO_MODULEINFO */
+#define _DEVINFO_MODULEINFO_EXPRESS_NONE                         0x00000001UL                                    /**< Mode NONE for DEVINFO_MODULEINFO */
+#define DEVINFO_MODULEINFO_EXPRESS_SUPPORTED                     (_DEVINFO_MODULEINFO_EXPRESS_SUPPORTED << 17)   /**< Shifted mode SUPPORTED for DEVINFO_MODULEINFO */
+#define DEVINFO_MODULEINFO_EXPRESS_NONE                          (_DEVINFO_MODULEINFO_EXPRESS_NONE << 17)        /**< Shifted mode NONE for DEVINFO_MODULEINFO */
+#define _DEVINFO_MODULEINFO_LFXOCALVAL_SHIFT                     18                                              /**< Shift value for LFXOCALVAL */
+#define _DEVINFO_MODULEINFO_LFXOCALVAL_MASK                      0x40000UL                                       /**< Bit mask for LFXOCALVAL */
+#define _DEVINFO_MODULEINFO_LFXOCALVAL_VALID                     0x00000000UL                                    /**< Mode VALID for DEVINFO_MODULEINFO */
+#define _DEVINFO_MODULEINFO_LFXOCALVAL_NOTVALID                  0x00000001UL                                    /**< Mode NOTVALID for DEVINFO_MODULEINFO */
+#define DEVINFO_MODULEINFO_LFXOCALVAL_VALID                      (_DEVINFO_MODULEINFO_LFXOCALVAL_VALID << 18)    /**< Shifted mode VALID for DEVINFO_MODULEINFO */
+#define DEVINFO_MODULEINFO_LFXOCALVAL_NOTVALID                   (_DEVINFO_MODULEINFO_LFXOCALVAL_NOTVALID << 18) /**< Shifted mode NOTVALID for DEVINFO_MODULEINFO */
+#define _DEVINFO_MODULEINFO_HFXOCALVAL_SHIFT                     19                                              /**< Shift value for HFXOCALVAL */
+#define _DEVINFO_MODULEINFO_HFXOCALVAL_MASK                      0x80000UL                                       /**< Bit mask for HFXOCALVAL */
+#define _DEVINFO_MODULEINFO_HFXOCALVAL_VALID                     0x00000000UL                                    /**< Mode VALID for DEVINFO_MODULEINFO */
+#define _DEVINFO_MODULEINFO_HFXOCALVAL_NOTVALID                  0x00000001UL                                    /**< Mode NOTVALID for DEVINFO_MODULEINFO */
+#define DEVINFO_MODULEINFO_HFXOCALVAL_VALID                      (_DEVINFO_MODULEINFO_HFXOCALVAL_VALID << 19)    /**< Shifted mode VALID for DEVINFO_MODULEINFO */
+#define DEVINFO_MODULEINFO_HFXOCALVAL_NOTVALID                   (_DEVINFO_MODULEINFO_HFXOCALVAL_NOTVALID << 19) /**< Shifted mode NOTVALID for DEVINFO_MODULEINFO */
+#define _DEVINFO_MODULEINFO_RESERVED1_SHIFT                      20                                              /**< Shift value for RESERVED1 */
+#define _DEVINFO_MODULEINFO_RESERVED1_MASK                       0xFFF00000UL                                    /**< Bit mask for RESERVED1 */
+
+/* Bit fields for DEVINFO MODXOCAL */
+#define _DEVINFO_MODXOCAL_MASK                                   0x0000FFFFUL /**< Mask for DEVINFO_MODXOCAL */
+#define _DEVINFO_MODXOCAL_HFXOCTUNE_SHIFT                        0            /**< Shift value for HFXOCTUNE */
+#define _DEVINFO_MODXOCAL_HFXOCTUNE_MASK                         0x1FFUL      /**< Bit mask for HFXOCTUNE */
+#define _DEVINFO_MODXOCAL_LFXOTUNING_SHIFT                       9            /**< Shift value for LFXOTUNING */
+#define _DEVINFO_MODXOCAL_LFXOTUNING_MASK                        0xFE00UL     /**< Bit mask for LFXOTUNING */
 
 /* Bit fields for DEVINFO EXTINFO */
 #define _DEVINFO_EXTINFO_MASK                                    0x00FFFFFFUL                            /**< Mask for DEVINFO_EXTINFO */
@@ -241,6 +296,7 @@ typedef struct {
 #define _DEVINFO_PART_DEVICE_FAMILY_EFR32BG13P                   0x0000002BUL                                   /**< Mode EFR32BG13P for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFR32BG13B                   0x0000002CUL                                   /**< Mode EFR32BG13B for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFR32BG13V                   0x0000002DUL                                   /**< Mode EFR32BG13V for DEVINFO_PART */
+#define _DEVINFO_PART_DEVICE_FAMILY_EFR32ZG13P                   0x0000002EUL                                   /**< Mode EFR32ZG13P for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFR32FG13P                   0x00000031UL                                   /**< Mode EFR32FG13P for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFR32FG13B                   0x00000032UL                                   /**< Mode EFR32FG13B for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFR32FG13V                   0x00000033UL                                   /**< Mode EFR32FG13V for DEVINFO_PART */
@@ -250,6 +306,7 @@ typedef struct {
 #define _DEVINFO_PART_DEVICE_FAMILY_EFR32BG14P                   0x00000037UL                                   /**< Mode EFR32BG14P for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFR32BG14B                   0x00000038UL                                   /**< Mode EFR32BG14B for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFR32BG14V                   0x00000039UL                                   /**< Mode EFR32BG14V for DEVINFO_PART */
+#define _DEVINFO_PART_DEVICE_FAMILY_EFR32ZG14P                   0x0000003AUL                                   /**< Mode EFR32ZG14P for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFR32FG14P                   0x0000003DUL                                   /**< Mode EFR32FG14P for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFR32FG14B                   0x0000003EUL                                   /**< Mode EFR32FG14B for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFR32FG14V                   0x0000003FUL                                   /**< Mode EFR32FG14V for DEVINFO_PART */
@@ -273,6 +330,7 @@ typedef struct {
 #define _DEVINFO_PART_DEVICE_FAMILY_EFM32JG12B                   0x00000057UL                                   /**< Mode EFM32JG12B for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFM32GG11B                   0x00000064UL                                   /**< Mode EFM32GG11B for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFM32TG11B                   0x00000067UL                                   /**< Mode EFM32TG11B for DEVINFO_PART */
+#define _DEVINFO_PART_DEVICE_FAMILY_EFM32GG12B                   0x0000006AUL                                   /**< Mode EFM32GG12B for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EZR32LG                      0x00000078UL                                   /**< Mode EZR32LG for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EZR32WG                      0x00000079UL                                   /**< Mode EZR32WG for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EZR32HG                      0x0000007AUL                                   /**< Mode EZR32HG for DEVINFO_PART */
@@ -300,6 +358,7 @@ typedef struct {
 #define DEVINFO_PART_DEVICE_FAMILY_EFR32BG13P                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32BG13P << 16) /**< Shifted mode EFR32BG13P for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFR32BG13B                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32BG13B << 16) /**< Shifted mode EFR32BG13B for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFR32BG13V                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32BG13V << 16) /**< Shifted mode EFR32BG13V for DEVINFO_PART */
+#define DEVINFO_PART_DEVICE_FAMILY_EFR32ZG13P                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32ZG13P << 16) /**< Shifted mode EFR32ZG13P for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFR32FG13P                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32FG13P << 16) /**< Shifted mode EFR32FG13P for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFR32FG13B                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32FG13B << 16) /**< Shifted mode EFR32FG13B for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFR32FG13V                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32FG13V << 16) /**< Shifted mode EFR32FG13V for DEVINFO_PART */
@@ -309,6 +368,7 @@ typedef struct {
 #define DEVINFO_PART_DEVICE_FAMILY_EFR32BG14P                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32BG14P << 16) /**< Shifted mode EFR32BG14P for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFR32BG14B                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32BG14B << 16) /**< Shifted mode EFR32BG14B for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFR32BG14V                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32BG14V << 16) /**< Shifted mode EFR32BG14V for DEVINFO_PART */
+#define DEVINFO_PART_DEVICE_FAMILY_EFR32ZG14P                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32ZG14P << 16) /**< Shifted mode EFR32ZG14P for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFR32FG14P                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32FG14P << 16) /**< Shifted mode EFR32FG14P for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFR32FG14B                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32FG14B << 16) /**< Shifted mode EFR32FG14B for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFR32FG14V                    (_DEVINFO_PART_DEVICE_FAMILY_EFR32FG14V << 16) /**< Shifted mode EFR32FG14V for DEVINFO_PART */
@@ -332,6 +392,7 @@ typedef struct {
 #define DEVINFO_PART_DEVICE_FAMILY_EFM32JG12B                    (_DEVINFO_PART_DEVICE_FAMILY_EFM32JG12B << 16) /**< Shifted mode EFM32JG12B for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFM32GG11B                    (_DEVINFO_PART_DEVICE_FAMILY_EFM32GG11B << 16) /**< Shifted mode EFM32GG11B for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFM32TG11B                    (_DEVINFO_PART_DEVICE_FAMILY_EFM32TG11B << 16) /**< Shifted mode EFM32TG11B for DEVINFO_PART */
+#define DEVINFO_PART_DEVICE_FAMILY_EFM32GG12B                    (_DEVINFO_PART_DEVICE_FAMILY_EFM32GG12B << 16) /**< Shifted mode EFM32GG12B for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EZR32LG                       (_DEVINFO_PART_DEVICE_FAMILY_EZR32LG << 16)    /**< Shifted mode EZR32LG for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EZR32WG                       (_DEVINFO_PART_DEVICE_FAMILY_EZR32WG << 16)    /**< Shifted mode EZR32WG for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EZR32HG                       (_DEVINFO_PART_DEVICE_FAMILY_EZR32HG << 16)    /**< Shifted mode EZR32HG for DEVINFO_PART */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_dma_descriptor.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_dma_descriptor.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg1p_dma_descriptor.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG1P_DMA_DESCRIPTOR register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,14 +40,14 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG1P_DMA_DESCRIPTOR DMA Descriptor
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 /** DMA_DESCRIPTOR Register Declaration */
 typedef struct {
   /* Note! Use of double __IOM (volatile) qualifier to ensure that both */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_dmareq.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_dmareq.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg1p_dmareq.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG1P_DMAREQ register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,17 +40,17 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG1P_DMAREQ DMAREQ
  * @{
  * @defgroup EFR32MG1P_DMAREQ_BitFields DMAREQ Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 #define DMAREQ_PRS_REQ0               ((1 << 16) + 0)  /**< DMA channel select for PRS_REQ0 */
 #define DMAREQ_PRS_REQ1               ((1 << 16) + 1)  /**< DMA channel select for PRS_REQ1 */
 #define DMAREQ_ADC0_SINGLE            ((8 << 16) + 0)  /**< DMA channel select for ADC0_SINGLE */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_emu.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_emu.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg1p_emu.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG1P_EMU register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG1P_EMU EMU
  * @{
  * @brief EFR32MG1P_EMU Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** EMU Register Declaration */
 typedef struct {
   __IOM uint32_t CTRL;            /**< Control Register  */
@@ -58,7 +57,7 @@ typedef struct {
   __IOM uint32_t RAM0CTRL;        /**< Memory Control Register  */
   __IOM uint32_t CMD;             /**< Command Register  */
 
-  uint32_t       RESERVED0[1];    /**< Reserved for future use **/
+  uint32_t       RESERVED0[1U];   /**< Reserved for future use **/
   __IOM uint32_t EM4CTRL;         /**< EM4 Control Register  */
   __IOM uint32_t TEMPLIMITS;      /**< Temperature Limits for Interrupt Generation  */
   __IM uint32_t  TEMP;            /**< Value of Last Temperature Measurement  */
@@ -71,7 +70,7 @@ typedef struct {
   __IOM uint32_t PWRCTRL;         /**< Power Control Register  */
   __IOM uint32_t DCDCCTRL;        /**< DCDC Control  */
 
-  uint32_t       RESERVED1[2];    /**< Reserved for future use **/
+  uint32_t       RESERVED1[2U];   /**< Reserved for future use **/
   __IOM uint32_t DCDCMISCCTRL;    /**< DCDC Miscellaneous Control Register  */
   __IOM uint32_t DCDCZDETCTRL;    /**< DCDC Power Train NFET Zero Current Detector Control Register  */
   __IOM uint32_t DCDCCLIMCTRL;    /**< DCDC Power Train PFET Current Limiter Control Register  */
@@ -80,35 +79,35 @@ typedef struct {
   __IOM uint32_t DCDCTIMING;      /**< DCDC Controller Timing Value Register  */
   __IOM uint32_t DCDCLPVCTRL;     /**< DCDC Low Power Voltage Register  */
 
-  uint32_t       RESERVED2[1];    /**< Reserved for future use **/
+  uint32_t       RESERVED2[1U];   /**< Reserved for future use **/
   __IOM uint32_t DCDCLPCTRL;      /**< DCDC Low Power Control Register  */
   __IOM uint32_t DCDCLNFREQCTRL;  /**< DCDC Low Noise Controller Frequency Control  */
 
-  uint32_t       RESERVED3[1];    /**< Reserved for future use **/
+  uint32_t       RESERVED3[1U];   /**< Reserved for future use **/
   __IM uint32_t  DCDCSYNC;        /**< DCDC Read Status Register  */
 
-  uint32_t       RESERVED4[5];    /**< Reserved for future use **/
+  uint32_t       RESERVED4[5U];   /**< Reserved for future use **/
   __IOM uint32_t VMONAVDDCTRL;    /**< VMON AVDD Channel Control  */
   __IOM uint32_t VMONALTAVDDCTRL; /**< Alternate VMON AVDD Channel Control  */
   __IOM uint32_t VMONDVDDCTRL;    /**< VMON DVDD Channel Control  */
   __IOM uint32_t VMONIO0CTRL;     /**< VMON IOVDD0 Channel Control  */
 
-  uint32_t       RESERVED5[49];   /**< Reserved for future use **/
+  uint32_t       RESERVED5[49U];  /**< Reserved for future use **/
   __IOM uint32_t BIASCONF;        /**< Configurations Related to the Bias  */
 
-  uint32_t       RESERVED6[10];   /**< Reserved for future use **/
+  uint32_t       RESERVED6[10U];  /**< Reserved for future use **/
   __IOM uint32_t TESTLOCK;        /**< Test Lock Register  */
 
-  uint32_t       RESERVED7[2];    /**< Reserved for future use **/
+  uint32_t       RESERVED7[2U];   /**< Reserved for future use **/
   __IOM uint32_t BIASTESTCTRL;    /**< Test Control Register for Regulator and BIAS  */
 } EMU_TypeDef;                    /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG1P_EMU
  * @{
  * @defgroup EFR32MG1P_EMU_BitFields  EMU Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for EMU CTRL */
 #define _EMU_CTRL_RESETVALUE                         0x00000000UL                      /**< Default value for EMU_CTRL */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_fpueh.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_fpueh.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg1p_fpueh.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG1P_FPUEH register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG1P_FPUEH FPUEH
  * @{
  * @brief EFR32MG1P_FPUEH Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** FPUEH Register Declaration */
 typedef struct {
   __IM uint32_t  IF;  /**< Interrupt Flag Register  */
@@ -58,12 +57,12 @@ typedef struct {
   __IOM uint32_t IEN; /**< Interrupt Enable Register  */
 } FPUEH_TypeDef;      /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG1P_FPUEH
  * @{
  * @defgroup EFR32MG1P_FPUEH_BitFields  FPUEH Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for FPUEH IF */
 #define _FPUEH_IF_RESETVALUE        0x00000000UL                   /**< Default value for FPUEH_IF */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_gpcrc.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_gpcrc.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg1p_gpcrc.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG1P_GPCRC register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG1P_GPCRC GPCRC
  * @{
  * @brief EFR32MG1P_GPCRC Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** GPCRC Register Declaration */
 typedef struct {
   __IOM uint32_t CTRL;           /**< Control Register  */
@@ -64,12 +63,12 @@ typedef struct {
   __IM uint32_t  DATABYTEREV;    /**< CRC Data Byte Reverse Register  */
 } GPCRC_TypeDef;                 /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG1P_GPCRC
  * @{
  * @defgroup EFR32MG1P_GPCRC_BitFields  GPCRC Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for GPCRC CTRL */
 #define _GPCRC_CTRL_RESETVALUE                          0x00000000UL                             /**< Default value for GPCRC_CTRL */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_gpio.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_gpio.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg1p_gpio.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG1P_GPIO register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,48 +40,48 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG1P_GPIO GPIO
  * @{
  * @brief EFR32MG1P_GPIO Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** GPIO Register Declaration */
 typedef struct {
-  GPIO_P_TypeDef P[6];           /**< Port configuration bits */
+  GPIO_P_TypeDef P[6U];           /**< Port configuration bits */
 
-  uint32_t       RESERVED0[184]; /**< Reserved for future use **/
-  __IOM uint32_t EXTIPSELL;      /**< External Interrupt Port Select Low Register  */
-  __IOM uint32_t EXTIPSELH;      /**< External Interrupt Port Select High Register  */
-  __IOM uint32_t EXTIPINSELL;    /**< External Interrupt Pin Select Low Register  */
-  __IOM uint32_t EXTIPINSELH;    /**< External Interrupt Pin Select High Register  */
-  __IOM uint32_t EXTIRISE;       /**< External Interrupt Rising Edge Trigger Register  */
-  __IOM uint32_t EXTIFALL;       /**< External Interrupt Falling Edge Trigger Register  */
-  __IOM uint32_t EXTILEVEL;      /**< External Interrupt Level Register  */
-  __IM uint32_t  IF;             /**< Interrupt Flag Register  */
-  __IOM uint32_t IFS;            /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;            /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t IEN;            /**< Interrupt Enable Register  */
-  __IOM uint32_t EM4WUEN;        /**< EM4 Wake Up Enable Register  */
+  uint32_t       RESERVED0[184U]; /**< Reserved for future use **/
+  __IOM uint32_t EXTIPSELL;       /**< External Interrupt Port Select Low Register  */
+  __IOM uint32_t EXTIPSELH;       /**< External Interrupt Port Select High Register  */
+  __IOM uint32_t EXTIPINSELL;     /**< External Interrupt Pin Select Low Register  */
+  __IOM uint32_t EXTIPINSELH;     /**< External Interrupt Pin Select High Register  */
+  __IOM uint32_t EXTIRISE;        /**< External Interrupt Rising Edge Trigger Register  */
+  __IOM uint32_t EXTIFALL;        /**< External Interrupt Falling Edge Trigger Register  */
+  __IOM uint32_t EXTILEVEL;       /**< External Interrupt Level Register  */
+  __IM uint32_t  IF;              /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;             /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;             /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;             /**< Interrupt Enable Register  */
+  __IOM uint32_t EM4WUEN;         /**< EM4 Wake Up Enable Register  */
 
-  uint32_t       RESERVED1[4];   /**< Reserved for future use **/
-  __IOM uint32_t ROUTEPEN;       /**< I/O Routing Pin Enable Register  */
-  __IOM uint32_t ROUTELOC0;      /**< I/O Routing Location Register  */
+  uint32_t       RESERVED1[4U];   /**< Reserved for future use **/
+  __IOM uint32_t ROUTEPEN;        /**< I/O Routing Pin Enable Register  */
+  __IOM uint32_t ROUTELOC0;       /**< I/O Routing Location Register  */
 
-  uint32_t       RESERVED2[2];   /**< Reserved for future use **/
-  __IOM uint32_t INSENSE;        /**< Input Sense Register  */
-  __IOM uint32_t LOCK;           /**< Configuration Lock Register  */
-} GPIO_TypeDef;                  /** @} */
+  uint32_t       RESERVED2[2U];   /**< Reserved for future use **/
+  __IOM uint32_t INSENSE;         /**< Input Sense Register  */
+  __IOM uint32_t LOCK;            /**< Configuration Lock Register  */
+} GPIO_TypeDef;                   /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG1P_GPIO
  * @{
  * @defgroup EFR32MG1P_GPIO_BitFields  GPIO Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for GPIO P_CTRL */
 #define _GPIO_P_CTRL_RESETVALUE                         0x00500050UL                                  /**< Default value for GPIO_P_CTRL */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_gpio_p.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_gpio_p.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg1p_gpio_p.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG1P_GPIO_P register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,26 +40,26 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief GPIO_P GPIO P Register
  * @ingroup EFR32MG1P_GPIO
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IOM uint32_t CTRL;         /**< Port Control Register  */
-  __IOM uint32_t MODEL;        /**< Port Pin Mode Low Register  */
-  __IOM uint32_t MODEH;        /**< Port Pin Mode High Register  */
-  __IOM uint32_t DOUT;         /**< Port Data Out Register  */
-  uint32_t       RESERVED0[2]; /**< Reserved for future use **/
-  __IOM uint32_t DOUTTGL;      /**< Port Data Out Toggle Register  */
-  __IM uint32_t  DIN;          /**< Port Data in Register  */
-  __IOM uint32_t PINLOCKN;     /**< Port Unlocked Pins Register  */
-  uint32_t       RESERVED1[1]; /**< Reserved for future use **/
-  __IOM uint32_t OVTDIS;       /**< Over Voltage Disable for All Modes  */
-  uint32_t       RESERVED2[1]; /**< Reserved future */
+  __IOM uint32_t CTRL;          /**< Port Control Register  */
+  __IOM uint32_t MODEL;         /**< Port Pin Mode Low Register  */
+  __IOM uint32_t MODEH;         /**< Port Pin Mode High Register  */
+  __IOM uint32_t DOUT;          /**< Port Data Out Register  */
+  uint32_t       RESERVED0[2U]; /**< Reserved for future use **/
+  __IOM uint32_t DOUTTGL;       /**< Port Data Out Toggle Register  */
+  __IM uint32_t  DIN;           /**< Port Data in Register  */
+  __IOM uint32_t PINLOCKN;      /**< Port Unlocked Pins Register  */
+  uint32_t       RESERVED1[1U]; /**< Reserved for future use **/
+  __IOM uint32_t OVTDIS;        /**< Over Voltage Disable for All Modes  */
+  uint32_t       RESERVED2[1U]; /**< Reserved future */
 } GPIO_P_TypeDef;
 
 /** @} End of group Parts */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_i2c.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_i2c.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg1p_i2c.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG1P_I2C register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG1P_I2C I2C
  * @{
  * @brief EFR32MG1P_I2C Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** I2C Register Declaration */
 typedef struct {
   __IOM uint32_t CTRL;      /**< Control Register  */
@@ -73,12 +72,12 @@ typedef struct {
   __IOM uint32_t ROUTELOC0; /**< I/O Routing Location Register  */
 } I2C_TypeDef;              /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG1P_I2C
  * @{
  * @defgroup EFR32MG1P_I2C_BitFields  I2C Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for I2C CTRL */
 #define _I2C_CTRL_RESETVALUE               0x00000000UL                     /**< Default value for I2C_CTRL */
@@ -426,7 +425,7 @@ typedef struct {
 #define I2C_IF_TXBL                        (0x1UL << 4)                    /**< Transmit Buffer Level Interrupt Flag */
 #define _I2C_IF_TXBL_SHIFT                 4                               /**< Shift value for I2C_TXBL */
 #define _I2C_IF_TXBL_MASK                  0x10UL                          /**< Bit mask for I2C_TXBL */
-#define _I2C_IF_TXBL_DEFAULT               0x00000000UL                    /**< Mode DEFAULT for I2C_IF */
+#define _I2C_IF_TXBL_DEFAULT               0x00000001UL                    /**< Mode DEFAULT for I2C_IF */
 #define I2C_IF_TXBL_DEFAULT                (_I2C_IF_TXBL_DEFAULT << 4)     /**< Shifted mode DEFAULT for I2C_IF */
 #define I2C_IF_RXDATAV                     (0x1UL << 5)                    /**< Receive Data Valid Interrupt Flag */
 #define _I2C_IF_RXDATAV_SHIFT              5                               /**< Shift value for I2C_RXDATAV */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_idac.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_idac.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg1p_idac.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG1P_IDAC register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,40 +40,40 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG1P_IDAC IDAC
  * @{
  * @brief EFR32MG1P_IDAC Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** IDAC Register Declaration */
 typedef struct {
   __IOM uint32_t CTRL;          /**< Control Register  */
   __IOM uint32_t CURPROG;       /**< Current Programming Register  */
-  uint32_t       RESERVED0[1];  /**< Reserved for future use **/
+  uint32_t       RESERVED0[1U]; /**< Reserved for future use **/
   __IOM uint32_t DUTYCONFIG;    /**< Duty Cycle Configuration Register  */
 
-  uint32_t       RESERVED1[2];  /**< Reserved for future use **/
+  uint32_t       RESERVED1[2U]; /**< Reserved for future use **/
   __IM uint32_t  STATUS;        /**< Status Register  */
-  uint32_t       RESERVED2[1];  /**< Reserved for future use **/
+  uint32_t       RESERVED2[1U]; /**< Reserved for future use **/
   __IM uint32_t  IF;            /**< Interrupt Flag Register  */
   __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
   __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
   __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
-  uint32_t       RESERVED3[1];  /**< Reserved for future use **/
+  uint32_t       RESERVED3[1U]; /**< Reserved for future use **/
   __IM uint32_t  APORTREQ;      /**< APORT Request Status Register  */
   __IM uint32_t  APORTCONFLICT; /**< APORT Request Status Register  */
 } IDAC_TypeDef;                 /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG1P_IDAC
  * @{
  * @defgroup EFR32MG1P_IDAC_BitFields  IDAC Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for IDAC CTRL */
 #define _IDAC_CTRL_RESETVALUE                          0x00000000UL                              /**< Default value for IDAC_CTRL */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_ldma.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_ldma.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg1p_ldma.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG1P_LDMA register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,46 +40,46 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG1P_LDMA LDMA
  * @{
  * @brief EFR32MG1P_LDMA Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** LDMA Register Declaration */
 typedef struct {
-  __IOM uint32_t  CTRL;         /**< DMA Control Register  */
-  __IM uint32_t   STATUS;       /**< DMA Status Register  */
-  __IOM uint32_t  SYNC;         /**< DMA Synchronization Trigger Register (Single-Cycle RMW)  */
-  uint32_t        RESERVED0[5]; /**< Reserved for future use **/
-  __IOM uint32_t  CHEN;         /**< DMA Channel Enable Register (Single-Cycle RMW)  */
-  __IM uint32_t   CHBUSY;       /**< DMA Channel Busy Register  */
-  __IOM uint32_t  CHDONE;       /**< DMA Channel Linking Done Register (Single-Cycle RMW)  */
-  __IOM uint32_t  DBGHALT;      /**< DMA Channel Debug Halt Register  */
-  __IOM uint32_t  SWREQ;        /**< DMA Channel Software Transfer Request Register  */
-  __IOM uint32_t  REQDIS;       /**< DMA Channel Request Disable Register  */
-  __IM uint32_t   REQPEND;      /**< DMA Channel Requests Pending Register  */
-  __IOM uint32_t  LINKLOAD;     /**< DMA Channel Link Load Register  */
-  __IOM uint32_t  REQCLEAR;     /**< DMA Channel Request Clear Register  */
-  uint32_t        RESERVED1[7]; /**< Reserved for future use **/
-  __IM uint32_t   IF;           /**< Interrupt Flag Register  */
-  __IOM uint32_t  IFS;          /**< Interrupt Flag Set Register  */
-  __IOM uint32_t  IFC;          /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t  IEN;          /**< Interrupt Enable Register  */
+  __IOM uint32_t  CTRL;          /**< DMA Control Register  */
+  __IM uint32_t   STATUS;        /**< DMA Status Register  */
+  __IOM uint32_t  SYNC;          /**< DMA Synchronization Trigger Register (Single-Cycle RMW)  */
+  uint32_t        RESERVED0[5U]; /**< Reserved for future use **/
+  __IOM uint32_t  CHEN;          /**< DMA Channel Enable Register (Single-Cycle RMW)  */
+  __IM uint32_t   CHBUSY;        /**< DMA Channel Busy Register  */
+  __IOM uint32_t  CHDONE;        /**< DMA Channel Linking Done Register (Single-Cycle RMW)  */
+  __IOM uint32_t  DBGHALT;       /**< DMA Channel Debug Halt Register  */
+  __IOM uint32_t  SWREQ;         /**< DMA Channel Software Transfer Request Register  */
+  __IOM uint32_t  REQDIS;        /**< DMA Channel Request Disable Register  */
+  __IM uint32_t   REQPEND;       /**< DMA Channel Requests Pending Register  */
+  __IOM uint32_t  LINKLOAD;      /**< DMA Channel Link Load Register  */
+  __IOM uint32_t  REQCLEAR;      /**< DMA Channel Request Clear Register  */
+  uint32_t        RESERVED1[7U]; /**< Reserved for future use **/
+  __IM uint32_t   IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t  IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t  IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t  IEN;           /**< Interrupt Enable Register  */
 
-  uint32_t        RESERVED2[4]; /**< Reserved registers */
-  LDMA_CH_TypeDef CH[8];        /**< DMA Channel Registers */
-} LDMA_TypeDef;                 /** @} */
+  uint32_t        RESERVED2[4U]; /**< Reserved registers */
+  LDMA_CH_TypeDef CH[8U];        /**< DMA Channel Registers */
+} LDMA_TypeDef;                  /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG1P_LDMA
  * @{
  * @defgroup EFR32MG1P_LDMA_BitFields  LDMA Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for LDMA CTRL */
 #define _LDMA_CTRL_RESETVALUE                        0x07000000UL                           /**< Default value for LDMA_CTRL */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_ldma_ch.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_ldma_ch.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg1p_ldma_ch.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG1P_LDMA_CH register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,23 +40,23 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief LDMA_CH LDMA CH Register
  * @ingroup EFR32MG1P_LDMA
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
-  __IOM uint32_t REQSEL;       /**< Channel Peripheral Request Select Register  */
-  __IOM uint32_t CFG;          /**< Channel Configuration Register  */
-  __IOM uint32_t LOOP;         /**< Channel Loop Counter Register  */
-  __IOM uint32_t CTRL;         /**< Channel Descriptor Control Word Register  */
-  __IOM uint32_t SRC;          /**< Channel Descriptor Source Data Address Register  */
-  __IOM uint32_t DST;          /**< Channel Descriptor Destination Data Address Register  */
-  __IOM uint32_t LINK;         /**< Channel Descriptor Link Structure Address Register  */
-  uint32_t       RESERVED0[5]; /**< Reserved future */
+  __IOM uint32_t REQSEL;        /**< Channel Peripheral Request Select Register  */
+  __IOM uint32_t CFG;           /**< Channel Configuration Register  */
+  __IOM uint32_t LOOP;          /**< Channel Loop Counter Register  */
+  __IOM uint32_t CTRL;          /**< Channel Descriptor Control Word Register  */
+  __IOM uint32_t SRC;           /**< Channel Descriptor Source Data Address Register  */
+  __IOM uint32_t DST;           /**< Channel Descriptor Destination Data Address Register  */
+  __IOM uint32_t LINK;          /**< Channel Descriptor Link Structure Address Register  */
+  uint32_t       RESERVED0[5U]; /**< Reserved future */
 } LDMA_CH_TypeDef;
 
 /** @} End of group Parts */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_letimer.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_letimer.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg1p_letimer.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG1P_LETIMER register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,47 +40,47 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG1P_LETIMER LETIMER
  * @{
  * @brief EFR32MG1P_LETIMER Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** LETIMER Register Declaration */
 typedef struct {
-  __IOM uint32_t CTRL;         /**< Control Register  */
-  __IOM uint32_t CMD;          /**< Command Register  */
-  __IM uint32_t  STATUS;       /**< Status Register  */
-  __IOM uint32_t CNT;          /**< Counter Value Register  */
-  __IOM uint32_t COMP0;        /**< Compare Value Register 0  */
-  __IOM uint32_t COMP1;        /**< Compare Value Register 1  */
-  __IOM uint32_t REP0;         /**< Repeat Counter Register 0  */
-  __IOM uint32_t REP1;         /**< Repeat Counter Register 1  */
-  __IM uint32_t  IF;           /**< Interrupt Flag Register  */
-  __IOM uint32_t IFS;          /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;          /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t IEN;          /**< Interrupt Enable Register  */
+  __IOM uint32_t CTRL;          /**< Control Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IOM uint32_t CNT;           /**< Counter Value Register  */
+  __IOM uint32_t COMP0;         /**< Compare Value Register 0  */
+  __IOM uint32_t COMP1;         /**< Compare Value Register 1  */
+  __IOM uint32_t REP0;          /**< Repeat Counter Register 0  */
+  __IOM uint32_t REP1;          /**< Repeat Counter Register 1  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
 
-  uint32_t       RESERVED0[1]; /**< Reserved for future use **/
-  __IM uint32_t  SYNCBUSY;     /**< Synchronization Busy Register  */
+  uint32_t       RESERVED0[1U]; /**< Reserved for future use **/
+  __IM uint32_t  SYNCBUSY;      /**< Synchronization Busy Register  */
 
-  uint32_t       RESERVED1[2]; /**< Reserved for future use **/
-  __IOM uint32_t ROUTEPEN;     /**< I/O Routing Pin Enable Register  */
-  __IOM uint32_t ROUTELOC0;    /**< I/O Routing Location Register  */
+  uint32_t       RESERVED1[2U]; /**< Reserved for future use **/
+  __IOM uint32_t ROUTEPEN;      /**< I/O Routing Pin Enable Register  */
+  __IOM uint32_t ROUTELOC0;     /**< I/O Routing Location Register  */
 
-  uint32_t       RESERVED2[2]; /**< Reserved for future use **/
-  __IOM uint32_t PRSSEL;       /**< PRS Input Select Register  */
-} LETIMER_TypeDef;             /** @} */
+  uint32_t       RESERVED2[2U]; /**< Reserved for future use **/
+  __IOM uint32_t PRSSEL;        /**< PRS Input Select Register  */
+} LETIMER_TypeDef;              /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG1P_LETIMER
  * @{
  * @defgroup EFR32MG1P_LETIMER_BitFields  LETIMER Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for LETIMER CTRL */
 #define _LETIMER_CTRL_RESETVALUE                0x00000000UL                           /**< Default value for LETIMER_CTRL */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_leuart.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_leuart.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg1p_leuart.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG1P_LEUART register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,50 +40,50 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG1P_LEUART LEUART
  * @{
  * @brief EFR32MG1P_LEUART Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** LEUART Register Declaration */
 typedef struct {
-  __IOM uint32_t CTRL;         /**< Control Register  */
-  __IOM uint32_t CMD;          /**< Command Register  */
-  __IM uint32_t  STATUS;       /**< Status Register  */
-  __IOM uint32_t CLKDIV;       /**< Clock Control Register  */
-  __IOM uint32_t STARTFRAME;   /**< Start Frame Register  */
-  __IOM uint32_t SIGFRAME;     /**< Signal Frame Register  */
-  __IM uint32_t  RXDATAX;      /**< Receive Buffer Data Extended Register  */
-  __IM uint32_t  RXDATA;       /**< Receive Buffer Data Register  */
-  __IM uint32_t  RXDATAXP;     /**< Receive Buffer Data Extended Peek Register  */
-  __IOM uint32_t TXDATAX;      /**< Transmit Buffer Data Extended Register  */
-  __IOM uint32_t TXDATA;       /**< Transmit Buffer Data Register  */
-  __IM uint32_t  IF;           /**< Interrupt Flag Register  */
-  __IOM uint32_t IFS;          /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;          /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t IEN;          /**< Interrupt Enable Register  */
-  __IOM uint32_t PULSECTRL;    /**< Pulse Control Register  */
+  __IOM uint32_t CTRL;          /**< Control Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IOM uint32_t CLKDIV;        /**< Clock Control Register  */
+  __IOM uint32_t STARTFRAME;    /**< Start Frame Register  */
+  __IOM uint32_t SIGFRAME;      /**< Signal Frame Register  */
+  __IM uint32_t  RXDATAX;       /**< Receive Buffer Data Extended Register  */
+  __IM uint32_t  RXDATA;        /**< Receive Buffer Data Register  */
+  __IM uint32_t  RXDATAXP;      /**< Receive Buffer Data Extended Peek Register  */
+  __IOM uint32_t TXDATAX;       /**< Transmit Buffer Data Extended Register  */
+  __IOM uint32_t TXDATA;        /**< Transmit Buffer Data Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t PULSECTRL;     /**< Pulse Control Register  */
 
-  __IOM uint32_t FREEZE;       /**< Freeze Register  */
-  __IM uint32_t  SYNCBUSY;     /**< Synchronization Busy Register  */
+  __IOM uint32_t FREEZE;        /**< Freeze Register  */
+  __IM uint32_t  SYNCBUSY;      /**< Synchronization Busy Register  */
 
-  uint32_t       RESERVED0[3]; /**< Reserved for future use **/
-  __IOM uint32_t ROUTEPEN;     /**< I/O Routing Pin Enable Register  */
-  __IOM uint32_t ROUTELOC0;    /**< I/O Routing Location Register  */
-  uint32_t       RESERVED1[2]; /**< Reserved for future use **/
-  __IOM uint32_t INPUT;        /**< LEUART Input Register  */
-} LEUART_TypeDef;              /** @} */
+  uint32_t       RESERVED0[3U]; /**< Reserved for future use **/
+  __IOM uint32_t ROUTEPEN;      /**< I/O Routing Pin Enable Register  */
+  __IOM uint32_t ROUTELOC0;     /**< I/O Routing Location Register  */
+  uint32_t       RESERVED1[2U]; /**< Reserved for future use **/
+  __IOM uint32_t INPUT;         /**< LEUART Input Register  */
+} LEUART_TypeDef;               /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG1P_LEUART
  * @{
  * @defgroup EFR32MG1P_LEUART_BitFields  LEUART Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for LEUART CTRL */
 #define _LEUART_CTRL_RESETVALUE                  0x00000000UL                         /**< Default value for LEUART_CTRL */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_msc.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_msc.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg1p_msc.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG1P_MSC register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,52 +40,52 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG1P_MSC MSC
  * @{
  * @brief EFR32MG1P_MSC Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** MSC Register Declaration */
 typedef struct {
-  __IOM uint32_t CTRL;         /**< Memory System Control Register  */
-  __IOM uint32_t READCTRL;     /**< Read Control Register  */
-  __IOM uint32_t WRITECTRL;    /**< Write Control Register  */
-  __IOM uint32_t WRITECMD;     /**< Write Command Register  */
-  __IOM uint32_t ADDRB;        /**< Page Erase/Write Address Buffer  */
-  uint32_t       RESERVED0[1]; /**< Reserved for future use **/
-  __IOM uint32_t WDATA;        /**< Write Data Register  */
-  __IM uint32_t  STATUS;       /**< Status Register  */
+  __IOM uint32_t CTRL;          /**< Memory System Control Register  */
+  __IOM uint32_t READCTRL;      /**< Read Control Register  */
+  __IOM uint32_t WRITECTRL;     /**< Write Control Register  */
+  __IOM uint32_t WRITECMD;      /**< Write Command Register  */
+  __IOM uint32_t ADDRB;         /**< Page Erase/Write Address Buffer  */
+  uint32_t       RESERVED0[1U]; /**< Reserved for future use **/
+  __IOM uint32_t WDATA;         /**< Write Data Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
 
-  uint32_t       RESERVED1[4]; /**< Reserved for future use **/
-  __IM uint32_t  IF;           /**< Interrupt Flag Register  */
-  __IOM uint32_t IFS;          /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;          /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t IEN;          /**< Interrupt Enable Register  */
-  __IOM uint32_t LOCK;         /**< Configuration Lock Register  */
-  __IOM uint32_t CACHECMD;     /**< Flash Cache Command Register  */
-  __IM uint32_t  CACHEHITS;    /**< Cache Hits Performance Counter  */
-  __IM uint32_t  CACHEMISSES;  /**< Cache Misses Performance Counter  */
+  uint32_t       RESERVED1[4U]; /**< Reserved for future use **/
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t LOCK;          /**< Configuration Lock Register  */
+  __IOM uint32_t CACHECMD;      /**< Flash Cache Command Register  */
+  __IM uint32_t  CACHEHITS;     /**< Cache Hits Performance Counter  */
+  __IM uint32_t  CACHEMISSES;   /**< Cache Misses Performance Counter  */
 
-  uint32_t       RESERVED2[1]; /**< Reserved for future use **/
-  __IOM uint32_t MASSLOCK;     /**< Mass Erase Lock Register  */
+  uint32_t       RESERVED2[1U]; /**< Reserved for future use **/
+  __IOM uint32_t MASSLOCK;      /**< Mass Erase Lock Register  */
 
-  uint32_t       RESERVED3[1]; /**< Reserved for future use **/
-  __IOM uint32_t STARTUP;      /**< Startup Control  */
+  uint32_t       RESERVED3[1U]; /**< Reserved for future use **/
+  __IOM uint32_t STARTUP;       /**< Startup Control  */
 
-  uint32_t       RESERVED4[5]; /**< Reserved for future use **/
-  __IOM uint32_t CMD;          /**< Command Register  */
-} MSC_TypeDef;                 /** @} */
+  uint32_t       RESERVED4[5U]; /**< Reserved for future use **/
+  __IOM uint32_t CMD;           /**< Command Register  */
+} MSC_TypeDef;                  /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG1P_MSC
  * @{
  * @defgroup EFR32MG1P_MSC_BitFields  MSC Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for MSC CTRL */
 #define _MSC_CTRL_RESETVALUE                    0x00000001UL                           /**< Default value for MSC_CTRL */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_pcnt.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_pcnt.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg1p_pcnt.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG1P_PCNT register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,46 +40,46 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG1P_PCNT PCNT
  * @{
  * @brief EFR32MG1P_PCNT Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** PCNT Register Declaration */
 typedef struct {
-  __IOM uint32_t CTRL;         /**< Control Register  */
-  __IOM uint32_t CMD;          /**< Command Register  */
-  __IM uint32_t  STATUS;       /**< Status Register  */
-  __IM uint32_t  CNT;          /**< Counter Value Register  */
-  __IM uint32_t  TOP;          /**< Top Value Register  */
-  __IOM uint32_t TOPB;         /**< Top Value Buffer Register  */
-  __IM uint32_t  IF;           /**< Interrupt Flag Register  */
-  __IOM uint32_t IFS;          /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;          /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t IEN;          /**< Interrupt Enable Register  */
-  uint32_t       RESERVED0[1]; /**< Reserved for future use **/
-  __IOM uint32_t ROUTELOC0;    /**< I/O Routing Location Register  */
+  __IOM uint32_t CTRL;          /**< Control Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IM uint32_t  CNT;           /**< Counter Value Register  */
+  __IM uint32_t  TOP;           /**< Top Value Register  */
+  __IOM uint32_t TOPB;          /**< Top Value Buffer Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  uint32_t       RESERVED0[1U]; /**< Reserved for future use **/
+  __IOM uint32_t ROUTELOC0;     /**< I/O Routing Location Register  */
 
-  uint32_t       RESERVED1[4]; /**< Reserved for future use **/
-  __IOM uint32_t FREEZE;       /**< Freeze Register  */
-  __IM uint32_t  SYNCBUSY;     /**< Synchronization Busy Register  */
+  uint32_t       RESERVED1[4U]; /**< Reserved for future use **/
+  __IOM uint32_t FREEZE;        /**< Freeze Register  */
+  __IM uint32_t  SYNCBUSY;      /**< Synchronization Busy Register  */
 
-  uint32_t       RESERVED2[7]; /**< Reserved for future use **/
-  __IM uint32_t  AUXCNT;       /**< Auxiliary Counter Value Register  */
-  __IOM uint32_t INPUT;        /**< PCNT Input Register  */
-  __IOM uint32_t OVSCFG;       /**< Oversampling Config Register  */
-} PCNT_TypeDef;                /** @} */
+  uint32_t       RESERVED2[7U]; /**< Reserved for future use **/
+  __IM uint32_t  AUXCNT;        /**< Auxiliary Counter Value Register  */
+  __IOM uint32_t INPUT;         /**< PCNT Input Register  */
+  __IOM uint32_t OVSCFG;        /**< Oversampling Config Register  */
+} PCNT_TypeDef;                 /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG1P_PCNT
  * @{
  * @defgroup EFR32MG1P_PCNT_BitFields  PCNT Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for PCNT CTRL */
 #define _PCNT_CTRL_RESETVALUE              0x00000000UL                          /**< Default value for PCNT_CTRL */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_prs.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_prs.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg1p_prs.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG1P_PRS register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,42 +40,42 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG1P_PRS PRS
  * @{
  * @brief EFR32MG1P_PRS Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** PRS Register Declaration */
 typedef struct {
-  __IOM uint32_t SWPULSE;      /**< Software Pulse Register  */
-  __IOM uint32_t SWLEVEL;      /**< Software Level Register  */
-  __IOM uint32_t ROUTEPEN;     /**< I/O Routing Pin Enable Register  */
-  uint32_t       RESERVED0[1]; /**< Reserved for future use **/
-  __IOM uint32_t ROUTELOC0;    /**< I/O Routing Location Register  */
-  __IOM uint32_t ROUTELOC1;    /**< I/O Routing Location Register  */
-  __IOM uint32_t ROUTELOC2;    /**< I/O Routing Location Register  */
+  __IOM uint32_t SWPULSE;       /**< Software Pulse Register  */
+  __IOM uint32_t SWLEVEL;       /**< Software Level Register  */
+  __IOM uint32_t ROUTEPEN;      /**< I/O Routing Pin Enable Register  */
+  uint32_t       RESERVED0[1U]; /**< Reserved for future use **/
+  __IOM uint32_t ROUTELOC0;     /**< I/O Routing Location Register  */
+  __IOM uint32_t ROUTELOC1;     /**< I/O Routing Location Register  */
+  __IOM uint32_t ROUTELOC2;     /**< I/O Routing Location Register  */
 
-  uint32_t       RESERVED1[1]; /**< Reserved for future use **/
-  __IOM uint32_t CTRL;         /**< Control Register  */
-  __IOM uint32_t DMAREQ0;      /**< DMA Request 0 Register  */
-  __IOM uint32_t DMAREQ1;      /**< DMA Request 1 Register  */
-  uint32_t       RESERVED2[1]; /**< Reserved for future use **/
-  __IM uint32_t  PEEK;         /**< PRS Channel Values  */
+  uint32_t       RESERVED1[1U]; /**< Reserved for future use **/
+  __IOM uint32_t CTRL;          /**< Control Register  */
+  __IOM uint32_t DMAREQ0;       /**< DMA Request 0 Register  */
+  __IOM uint32_t DMAREQ1;       /**< DMA Request 1 Register  */
+  uint32_t       RESERVED2[1U]; /**< Reserved for future use **/
+  __IM uint32_t  PEEK;          /**< PRS Channel Values  */
 
-  uint32_t       RESERVED3[3]; /**< Reserved registers */
-  PRS_CH_TypeDef CH[12];       /**< Channel registers */
-} PRS_TypeDef;                 /** @} */
+  uint32_t       RESERVED3[3U]; /**< Reserved registers */
+  PRS_CH_TypeDef CH[12U];       /**< Channel registers */
+} PRS_TypeDef;                  /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG1P_PRS
  * @{
  * @defgroup EFR32MG1P_PRS_BitFields  PRS Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for PRS SWPULSE */
 #define _PRS_SWPULSE_RESETVALUE                0x00000000UL                           /**< Default value for PRS_SWPULSE */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_prs_ch.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_prs_ch.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg1p_prs_ch.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG1P_PRS_CH register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,14 +40,14 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief PRS_CH PRS CH Register
  * @ingroup EFR32MG1P_PRS
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t CTRL; /**< Channel Control Register  */
 } PRS_CH_TypeDef;

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_prs_signals.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_prs_signals.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg1p_prs_signals.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG1P_PRS_SIGNALS register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,17 +40,17 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @addtogroup EFR32MG1P_PRS
  * @{
  * @addtogroup EFR32MG1P_PRS_Signals PRS Signals
  * @{
  * @brief PRS Signal names
- *****************************************************************************/
+ ******************************************************************************/
 #define PRS_PRS_CH0             ((1 << 8) + 0)  /**< PRS PRS channel 0 */
 #define PRS_PRS_CH1             ((1 << 8) + 1)  /**< PRS PRS channel 1 */
 #define PRS_PRS_CH2             ((1 << 8) + 2)  /**< PRS PRS channel 2 */
@@ -104,6 +103,8 @@ extern "C" {
 #define PRS_MODEM_FRAMESENT     ((38 << 8) + 3) /**< PRS Entire frame transmitted */
 #define PRS_MODEM_SYNCSENT      ((38 << 8) + 4) /**< PRS Syncword transmitted */
 #define PRS_MODEM_PRESENT       ((38 << 8) + 5) /**< PRS Preamble transmitted */
+#define PRS_MODEM_ANT0          ((39 << 8) + 5) /**< PRS Antenna 0 select */
+#define PRS_MODEM_ANT1          ((39 << 8) + 6) /**< PRS Antenna 1 select */
 #define PRS_RTCC_CCV0           ((41 << 8) + 1) /**< PRS RTCC Compare 0 */
 #define PRS_RTCC_CCV1           ((41 << 8) + 2) /**< PRS RTCC Compare 1 */
 #define PRS_RTCC_CCV2           ((41 << 8) + 3) /**< PRS RTCC Compare 2 */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_rmu.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_rmu.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg1p_rmu.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG1P_RMU register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG1P_RMU RMU
  * @{
  * @brief EFR32MG1P_RMU Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** RMU Register Declaration */
 typedef struct {
   __IOM uint32_t CTRL;     /**< Control Register  */
@@ -59,12 +58,12 @@ typedef struct {
   __IOM uint32_t LOCK;     /**< Configuration Lock Register  */
 } RMU_TypeDef;             /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG1P_RMU
  * @{
  * @defgroup EFR32MG1P_RMU_BitFields  RMU Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for RMU CTRL */
 #define _RMU_CTRL_RESETVALUE               0x00004224UL                          /**< Default value for RMU_CTRL */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_romtable.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_romtable.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg1p_romtable.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG1P_ROMTABLE register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +40,15 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG1P_ROMTABLE ROM Table, Chip Revision Information
  * @{
  * @brief Chip Information, Revision numbers
- *****************************************************************************/
+ ******************************************************************************/
 /** ROMTABLE Register Declaration */
 typedef struct {
   __IM uint32_t PID4; /**< JEP_106_BANK */
@@ -63,12 +62,12 @@ typedef struct {
   __IM uint32_t CID0; /**< Unused */
 } ROMTABLE_TypeDef;   /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG1P_ROMTABLE
  * @{
  * @defgroup EFR32MG1P_ROMTABLE_BitFields ROM Table Bit Field definitions
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 /* Bit fields for EFR32MG1P_ROMTABLE */
 #define _ROMTABLE_PID0_FAMILYLSB_MASK       0x000000C0UL /**< Least Significant Bits [1:0] of CHIP FAMILY, mask */
 #define _ROMTABLE_PID0_FAMILYLSB_SHIFT      6            /**< Least Significant Bits [1:0] of CHIP FAMILY, shift */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_rtcc.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_rtcc.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg1p_rtcc.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG1P_RTCC register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,46 +40,46 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG1P_RTCC RTCC
  * @{
  * @brief EFR32MG1P_RTCC Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** RTCC Register Declaration */
 typedef struct {
-  __IOM uint32_t   CTRL;          /**< Control Register  */
-  __IOM uint32_t   PRECNT;        /**< Pre-Counter Value Register  */
-  __IOM uint32_t   CNT;           /**< Counter Value Register  */
-  __IM uint32_t    COMBCNT;       /**< Combined Pre-Counter and Counter Value Register  */
-  __IOM uint32_t   TIME;          /**< Time of Day Register  */
-  __IOM uint32_t   DATE;          /**< Date Register  */
-  __IM uint32_t    IF;            /**< RTCC Interrupt Flags  */
-  __IOM uint32_t   IFS;           /**< Interrupt Flag Set Register  */
-  __IOM uint32_t   IFC;           /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t   IEN;           /**< Interrupt Enable Register  */
-  __IM uint32_t    STATUS;        /**< Status Register  */
-  __IOM uint32_t   CMD;           /**< Command Register  */
-  __IM uint32_t    SYNCBUSY;      /**< Synchronization Busy Register  */
-  __IOM uint32_t   POWERDOWN;     /**< Retention RAM Power-down Register  */
-  __IOM uint32_t   LOCK;          /**< Configuration Lock Register  */
-  __IOM uint32_t   EM4WUEN;       /**< Wake Up Enable  */
+  __IOM uint32_t   CTRL;           /**< Control Register  */
+  __IOM uint32_t   PRECNT;         /**< Pre-Counter Value Register  */
+  __IOM uint32_t   CNT;            /**< Counter Value Register  */
+  __IM uint32_t    COMBCNT;        /**< Combined Pre-Counter and Counter Value Register  */
+  __IOM uint32_t   TIME;           /**< Time of Day Register  */
+  __IOM uint32_t   DATE;           /**< Date Register  */
+  __IM uint32_t    IF;             /**< RTCC Interrupt Flags  */
+  __IOM uint32_t   IFS;            /**< Interrupt Flag Set Register  */
+  __IOM uint32_t   IFC;            /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t   IEN;            /**< Interrupt Enable Register  */
+  __IM uint32_t    STATUS;         /**< Status Register  */
+  __IOM uint32_t   CMD;            /**< Command Register  */
+  __IM uint32_t    SYNCBUSY;       /**< Synchronization Busy Register  */
+  __IOM uint32_t   POWERDOWN;      /**< Retention RAM Power-down Register  */
+  __IOM uint32_t   LOCK;           /**< Configuration Lock Register  */
+  __IOM uint32_t   EM4WUEN;        /**< Wake Up Enable  */
 
-  RTCC_CC_TypeDef  CC[3];         /**< Capture/Compare Channel */
+  RTCC_CC_TypeDef  CC[3U];         /**< Capture/Compare Channel */
 
-  uint32_t         RESERVED0[37]; /**< Reserved registers */
-  RTCC_RET_TypeDef RET[32];       /**< RetentionReg */
-} RTCC_TypeDef;                   /** @} */
+  uint32_t         RESERVED0[37U]; /**< Reserved registers */
+  RTCC_RET_TypeDef RET[32U];       /**< RetentionReg */
+} RTCC_TypeDef;                    /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG1P_RTCC
  * @{
  * @defgroup EFR32MG1P_RTCC_BitFields  RTCC Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for RTCC CTRL */
 #define _RTCC_CTRL_RESETVALUE               0x00000000UL                            /**< Default value for RTCC_CTRL */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_rtcc_cc.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_rtcc_cc.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg1p_rtcc_cc.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG1P_RTCC_CC register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,14 +40,14 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief RTCC_CC RTCC CC Register
  * @ingroup EFR32MG1P_RTCC
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t CTRL; /**< CC Channel Control Register  */
   __IOM uint32_t CCV;  /**< Capture/Compare Value Register  */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_rtcc_ret.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_rtcc_ret.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg1p_rtcc_ret.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG1P_RTCC_RET register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,14 +40,14 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief RTCC_RET RTCC RET Register
  * @ingroup EFR32MG1P_RTCC
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t REG; /**< Retention Register  */
 } RTCC_RET_TypeDef;

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_timer.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_timer.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg1p_timer.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG1P_TIMER register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,52 +40,52 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG1P_TIMER TIMER
  * @{
  * @brief EFR32MG1P_TIMER Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** TIMER Register Declaration */
 typedef struct {
-  __IOM uint32_t   CTRL;         /**< Control Register  */
-  __IOM uint32_t   CMD;          /**< Command Register  */
-  __IM uint32_t    STATUS;       /**< Status Register  */
-  __IM uint32_t    IF;           /**< Interrupt Flag Register  */
-  __IOM uint32_t   IFS;          /**< Interrupt Flag Set Register  */
-  __IOM uint32_t   IFC;          /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t   IEN;          /**< Interrupt Enable Register  */
-  __IOM uint32_t   TOP;          /**< Counter Top Value Register  */
-  __IOM uint32_t   TOPB;         /**< Counter Top Value Buffer Register  */
-  __IOM uint32_t   CNT;          /**< Counter Value Register  */
-  uint32_t         RESERVED0[1]; /**< Reserved for future use **/
-  __IOM uint32_t   LOCK;         /**< TIMER Configuration Lock Register  */
-  __IOM uint32_t   ROUTEPEN;     /**< I/O Routing Pin Enable Register  */
-  __IOM uint32_t   ROUTELOC0;    /**< I/O Routing Location Register  */
-  uint32_t         RESERVED1[1]; /**< Reserved for future use **/
-  __IOM uint32_t   ROUTELOC2;    /**< I/O Routing Location Register  */
+  __IOM uint32_t   CTRL;          /**< Control Register  */
+  __IOM uint32_t   CMD;           /**< Command Register  */
+  __IM uint32_t    STATUS;        /**< Status Register  */
+  __IM uint32_t    IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t   IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t   IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t   IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t   TOP;           /**< Counter Top Value Register  */
+  __IOM uint32_t   TOPB;          /**< Counter Top Value Buffer Register  */
+  __IOM uint32_t   CNT;           /**< Counter Value Register  */
+  uint32_t         RESERVED0[1U]; /**< Reserved for future use **/
+  __IOM uint32_t   LOCK;          /**< TIMER Configuration Lock Register  */
+  __IOM uint32_t   ROUTEPEN;      /**< I/O Routing Pin Enable Register  */
+  __IOM uint32_t   ROUTELOC0;     /**< I/O Routing Location Register  */
+  uint32_t         RESERVED1[1U]; /**< Reserved for future use **/
+  __IOM uint32_t   ROUTELOC2;     /**< I/O Routing Location Register  */
 
-  uint32_t         RESERVED2[8]; /**< Reserved registers */
-  TIMER_CC_TypeDef CC[4];        /**< Compare/Capture Channel */
+  uint32_t         RESERVED2[8U]; /**< Reserved registers */
+  TIMER_CC_TypeDef CC[4U];        /**< Compare/Capture Channel */
 
-  __IOM uint32_t   DTCTRL;       /**< DTI Control Register  */
-  __IOM uint32_t   DTTIME;       /**< DTI Time Control Register  */
-  __IOM uint32_t   DTFC;         /**< DTI Fault Configuration Register  */
-  __IOM uint32_t   DTOGEN;       /**< DTI Output Generation Enable Register  */
-  __IM uint32_t    DTFAULT;      /**< DTI Fault Register  */
-  __IOM uint32_t   DTFAULTC;     /**< DTI Fault Clear Register  */
-  __IOM uint32_t   DTLOCK;       /**< DTI Configuration Lock Register  */
-} TIMER_TypeDef;                 /** @} */
+  __IOM uint32_t   DTCTRL;        /**< DTI Control Register  */
+  __IOM uint32_t   DTTIME;        /**< DTI Time Control Register  */
+  __IOM uint32_t   DTFC;          /**< DTI Fault Configuration Register  */
+  __IOM uint32_t   DTOGEN;        /**< DTI Output Generation Enable Register  */
+  __IM uint32_t    DTFAULT;       /**< DTI Fault Register  */
+  __IOM uint32_t   DTFAULTC;      /**< DTI Fault Clear Register  */
+  __IOM uint32_t   DTLOCK;        /**< DTI Configuration Lock Register  */
+} TIMER_TypeDef;                  /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG1P_TIMER
  * @{
  * @defgroup EFR32MG1P_TIMER_BitFields  TIMER Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for TIMER CTRL */
 #define _TIMER_CTRL_RESETVALUE                     0x00000000UL                             /**< Default value for TIMER_CTRL */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_timer_cc.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_timer_cc.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg1p_timer_cc.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG1P_TIMER_CC register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,14 +40,14 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief TIMER_CC TIMER CC Register
  * @ingroup EFR32MG1P_TIMER
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t CTRL; /**< CC Channel Control Register  */
   __IOM uint32_t CCV;  /**< CC Channel Value Register  */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_usart.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_usart.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg1p_usart.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG1P_USART register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,57 +40,57 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG1P_USART USART
  * @{
  * @brief EFR32MG1P_USART Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** USART Register Declaration */
 typedef struct {
-  __IOM uint32_t CTRL;         /**< Control Register  */
-  __IOM uint32_t FRAME;        /**< USART Frame Format Register  */
-  __IOM uint32_t TRIGCTRL;     /**< USART Trigger Control Register  */
-  __IOM uint32_t CMD;          /**< Command Register  */
-  __IM uint32_t  STATUS;       /**< USART Status Register  */
-  __IOM uint32_t CLKDIV;       /**< Clock Control Register  */
-  __IM uint32_t  RXDATAX;      /**< RX Buffer Data Extended Register  */
-  __IM uint32_t  RXDATA;       /**< RX Buffer Data Register  */
-  __IM uint32_t  RXDOUBLEX;    /**< RX Buffer Double Data Extended Register  */
-  __IM uint32_t  RXDOUBLE;     /**< RX FIFO Double Data Register  */
-  __IM uint32_t  RXDATAXP;     /**< RX Buffer Data Extended Peek Register  */
-  __IM uint32_t  RXDOUBLEXP;   /**< RX Buffer Double Data Extended Peek Register  */
-  __IOM uint32_t TXDATAX;      /**< TX Buffer Data Extended Register  */
-  __IOM uint32_t TXDATA;       /**< TX Buffer Data Register  */
-  __IOM uint32_t TXDOUBLEX;    /**< TX Buffer Double Data Extended Register  */
-  __IOM uint32_t TXDOUBLE;     /**< TX Buffer Double Data Register  */
-  __IM uint32_t  IF;           /**< Interrupt Flag Register  */
-  __IOM uint32_t IFS;          /**< Interrupt Flag Set Register  */
-  __IOM uint32_t IFC;          /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t IEN;          /**< Interrupt Enable Register  */
-  __IOM uint32_t IRCTRL;       /**< IrDA Control Register  */
-  uint32_t       RESERVED0[1]; /**< Reserved for future use **/
-  __IOM uint32_t INPUT;        /**< USART Input Register  */
-  __IOM uint32_t I2SCTRL;      /**< I2S Control Register  */
-  __IOM uint32_t TIMING;       /**< Timing Register  */
-  __IOM uint32_t CTRLX;        /**< Control Register Extended  */
-  __IOM uint32_t TIMECMP0;     /**< Used to Generate Interrupts and Various Delays  */
-  __IOM uint32_t TIMECMP1;     /**< Used to Generate Interrupts and Various Delays  */
-  __IOM uint32_t TIMECMP2;     /**< Used to Generate Interrupts and Various Delays  */
-  __IOM uint32_t ROUTEPEN;     /**< I/O Routing Pin Enable Register  */
-  __IOM uint32_t ROUTELOC0;    /**< I/O Routing Location Register  */
-  __IOM uint32_t ROUTELOC1;    /**< I/O Routing Location Register  */
-} USART_TypeDef;               /** @} */
+  __IOM uint32_t CTRL;          /**< Control Register  */
+  __IOM uint32_t FRAME;         /**< USART Frame Format Register  */
+  __IOM uint32_t TRIGCTRL;      /**< USART Trigger Control Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IM uint32_t  STATUS;        /**< USART Status Register  */
+  __IOM uint32_t CLKDIV;        /**< Clock Control Register  */
+  __IM uint32_t  RXDATAX;       /**< RX Buffer Data Extended Register  */
+  __IM uint32_t  RXDATA;        /**< RX Buffer Data Register  */
+  __IM uint32_t  RXDOUBLEX;     /**< RX Buffer Double Data Extended Register  */
+  __IM uint32_t  RXDOUBLE;      /**< RX FIFO Double Data Register  */
+  __IM uint32_t  RXDATAXP;      /**< RX Buffer Data Extended Peek Register  */
+  __IM uint32_t  RXDOUBLEXP;    /**< RX Buffer Double Data Extended Peek Register  */
+  __IOM uint32_t TXDATAX;       /**< TX Buffer Data Extended Register  */
+  __IOM uint32_t TXDATA;        /**< TX Buffer Data Register  */
+  __IOM uint32_t TXDOUBLEX;     /**< TX Buffer Double Data Extended Register  */
+  __IOM uint32_t TXDOUBLE;      /**< TX Buffer Double Data Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t IRCTRL;        /**< IrDA Control Register  */
+  uint32_t       RESERVED0[1U]; /**< Reserved for future use **/
+  __IOM uint32_t INPUT;         /**< USART Input Register  */
+  __IOM uint32_t I2SCTRL;       /**< I2S Control Register  */
+  __IOM uint32_t TIMING;        /**< Timing Register  */
+  __IOM uint32_t CTRLX;         /**< Control Register Extended  */
+  __IOM uint32_t TIMECMP0;      /**< Used to Generate Interrupts and Various Delays  */
+  __IOM uint32_t TIMECMP1;      /**< Used to Generate Interrupts and Various Delays  */
+  __IOM uint32_t TIMECMP2;      /**< Used to Generate Interrupts and Various Delays  */
+  __IOM uint32_t ROUTEPEN;      /**< I/O Routing Pin Enable Register  */
+  __IOM uint32_t ROUTELOC0;     /**< I/O Routing Location Register  */
+  __IOM uint32_t ROUTELOC1;     /**< I/O Routing Location Register  */
+} USART_TypeDef;                /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG1P_USART
  * @{
  * @defgroup EFR32MG1P_USART_BitFields  USART Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for USART CTRL */
 #define _USART_CTRL_RESETVALUE                  0x00000000UL                             /**< Default value for USART_CTRL */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_wdog.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_wdog.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg1p_wdog.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG1P_WDOG register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,37 +40,37 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @defgroup EFR32MG1P_WDOG WDOG
  * @{
  * @brief EFR32MG1P_WDOG Register Declaration
- *****************************************************************************/
+ ******************************************************************************/
 /** WDOG Register Declaration */
 typedef struct {
-  __IOM uint32_t   CTRL;         /**< Control Register  */
-  __IOM uint32_t   CMD;          /**< Command Register  */
+  __IOM uint32_t   CTRL;          /**< Control Register  */
+  __IOM uint32_t   CMD;           /**< Command Register  */
 
-  __IM uint32_t    SYNCBUSY;     /**< Synchronization Busy Register  */
+  __IM uint32_t    SYNCBUSY;      /**< Synchronization Busy Register  */
 
-  WDOG_PCH_TypeDef PCH[2];       /**< PCH */
+  WDOG_PCH_TypeDef PCH[2U];       /**< PCH */
 
-  uint32_t         RESERVED0[2]; /**< Reserved for future use **/
-  __IM uint32_t    IF;           /**< Watchdog Interrupt Flags  */
-  __IOM uint32_t   IFS;          /**< Interrupt Flag Set Register  */
-  __IOM uint32_t   IFC;          /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t   IEN;          /**< Interrupt Enable Register  */
-} WDOG_TypeDef;                  /** @} */
+  uint32_t         RESERVED0[2U]; /**< Reserved for future use **/
+  __IM uint32_t    IF;            /**< Watchdog Interrupt Flags  */
+  __IOM uint32_t   IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t   IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t   IEN;           /**< Interrupt Enable Register  */
+} WDOG_TypeDef;                   /** @} */
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup EFR32MG1P_WDOG
  * @{
  * @defgroup EFR32MG1P_WDOG_BitFields  WDOG Bit Fields
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /* Bit fields for WDOG CTRL */
 #define _WDOG_CTRL_RESETVALUE                     0x00000F00UL                          /**< Default value for WDOG_CTRL */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_wdog_pch.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_wdog_pch.h
@@ -1,34 +1,33 @@
-/**************************************************************************//**
- * @file efr32mg1p_wdog_pch.h
+/***************************************************************************//**
+ * @file
  * @brief EFR32MG1P_WDOG_PCH register and bit field definitions
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,14 +40,14 @@ extern "C" {
 #pragma clang system_header  /* Treat file as system include file. */
 #endif
 
-/**************************************************************************//**
-* @addtogroup Parts
-* @{
-******************************************************************************/
-/**************************************************************************//**
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
  * @brief WDOG_PCH WDOG PCH Register
  * @ingroup EFR32MG1P_WDOG
- *****************************************************************************/
+ ******************************************************************************/
 typedef struct {
   __IOM uint32_t PRSCTRL; /**< PRS Control Register  */
 } WDOG_PCH_TypeDef;

--- a/cpu/efm32/families/efr32mg1p/include/vendor/em_device.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/em_device.h
@@ -1,5 +1,5 @@
-/**************************************************************************//**
- * @file em_device.h
+/***************************************************************************//**
+ * @file
  * @brief CMSIS Cortex-M Peripheral Access Layer for Silicon Laboratories
  *        microcontroller devices
  *
@@ -9,37 +9,35 @@
  * @verbatim
  * Example: Add "-DEFM32G890F128" to your build options, to define part
  *          Add "#include "em_device.h" to your source files
-
- *
  * @endverbatim
- * @version 5.4.0
- ******************************************************************************
+ *
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifdef __cplusplus
 extern "C" {

--- a/cpu/efm32/families/efr32mg1p/include/vendor/system_efr32mg1p.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/system_efr32mg1p.h
@@ -1,34 +1,33 @@
 /***************************************************************************//**
- * @file system_efr32mg1p.h
+ * @file
  * @brief CMSIS Cortex-M3/M4 System Layer for EFR32 devices.
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #ifndef SYSTEM_EFR32_H
 #define SYSTEM_EFR32_H
@@ -39,14 +38,14 @@ extern "C" {
 
 #include <stdint.h>
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @addtogroup Parts
  * @{
- *****************************************************************************/
-/**************************************************************************//**
+ ******************************************************************************/
+/***************************************************************************//**
  * @addtogroup EFR32 EFR32
  * @{
- *****************************************************************************/
+ ******************************************************************************/
 
 /*******************************************************************************
  **************************   GLOBAL VARIABLES   *******************************
@@ -110,7 +109,7 @@ void FPUEH_IRQHandler(void);        /**< FPUEH IRQ Handler */
 
 uint32_t SystemCoreClockGet(void);
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @brief
  *   Update CMSIS SystemCoreClock variable.
  *
@@ -123,7 +122,7 @@ uint32_t SystemCoreClockGet(void);
  *   API, this variable will be kept updated. This function is only provided
  *   for CMSIS compliance and if a user modifies the the core clock outside
  *   the CMU API.
- *****************************************************************************/
+ ******************************************************************************/
 static __INLINE void SystemCoreClockUpdate(void)
 {
   (void)SystemCoreClockGet();

--- a/cpu/efm32/families/efr32mg1p/system.c
+++ b/cpu/efm32/families/efr32mg1p/system.c
@@ -1,34 +1,33 @@
 /***************************************************************************//**
- * @file system_efr32mg1p.c
+ * @file
  * @brief CMSIS Cortex-M3/M4 System Layer for EFR32 devices.
- * @version 5.4.0
- ******************************************************************************
+ * @version 5.7.0
+ *******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
- ******************************************************************************
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
  *
  * 1. The origin of this software must not be misrepresented; you must not
- *    claim that you wrote the original software.@n
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- *    misrepresented as being the original software.@n
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  *
- * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
- * has no obligation to support this Software. Silicon Laboratories, Inc. is
- * providing the Software "AS IS", with no express or implied warranties of any
- * kind, including, but not limited to, any implied warranties of
- * merchantability or fitness for any particular purpose or warranties against
- * infringement of any proprietary rights of a third party.
- *
- * Silicon Laboratories, Inc. will not be liable for any consequential,
- * incidental, or special damages, or any other relief, or for any claim by
- * any third party, arising from your use of this Software.
- *
- *****************************************************************************/
+ ******************************************************************************/
 
 #include <stdint.h>
 #include "em_device.h"
@@ -70,7 +69,7 @@
 #endif
 
 /* Do not define variable if HF crystal oscillator not present */
-#if (EFR32_HFXO_FREQ > 0UL)
+#if (EFR32_HFXO_FREQ > 0U)
 /** @cond DO_NOT_INCLUDE_WITH_DOXYGEN */
 /** System HFXO clock. */
 static uint32_t SystemHFXOClock = EFR32_HFXO_FREQ;
@@ -82,7 +81,7 @@ static uint32_t SystemHFXOClock = EFR32_HFXO_FREQ;
 #define EFR32_LFXO_FREQ (EFR32_LFRCO_FREQ)
 #endif
 /* Do not define variable if LF crystal oscillator not present */
-#if (EFR32_LFXO_FREQ > 0UL)
+#if (EFR32_LFXO_FREQ > 0U)
 /** @cond DO_NOT_INCLUDE_WITH_DOXYGEN */
 /** System LFXO clock. */
 static uint32_t SystemLFXOClock = EFR32_LFXO_FREQ;
@@ -117,6 +116,13 @@ uint32_t SystemHfrcoFreq = EFR32_HFRCO_STARTUP_FREQ;
 /*******************************************************************************
  **************************   GLOBAL FUNCTIONS   *******************************
  ******************************************************************************/
+
+#if defined(__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+#if defined(__ICCARM__)    /* IAR requires the __vector_table symbol */
+#define __Vectors    __vector_table
+#endif
+extern uint32_t __Vectors;
+#endif
 
 /***************************************************************************//**
  * @brief
@@ -186,12 +192,12 @@ uint32_t SystemHFClockGet(void)
 
   switch (CMU->HFCLKSTATUS & _CMU_HFCLKSTATUS_SELECTED_MASK) {
     case CMU_HFCLKSTATUS_SELECTED_LFXO:
-#if (EFR32_LFXO_FREQ > 0)
+#if (EFR32_LFXO_FREQ > 0U)
       ret = SystemLFXOClock;
 #else
       /* We should not get here, since core should not be clocked. May */
       /* be caused by a misconfiguration though. */
-      ret = 0;
+      ret = 0U;
 #endif
       break;
 
@@ -200,12 +206,12 @@ uint32_t SystemHFClockGet(void)
       break;
 
     case CMU_HFCLKSTATUS_SELECTED_HFXO:
-#if (EFR32_HFXO_FREQ > 0)
+#if (EFR32_HFXO_FREQ > 0U)
       ret = SystemHFXOClock;
 #else
       /* We should not get here, since core should not be clocked. May */
       /* be caused by a misconfiguration though. */
-      ret = 0;
+      ret = 0U;
 #endif
       break;
 
@@ -218,7 +224,7 @@ uint32_t SystemHFClockGet(void)
                       >> _CMU_HFPRESC_PRESC_SHIFT));
 }
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @brief
  *   Get high frequency crystal oscillator clock frequency for target system.
  *
@@ -227,18 +233,18 @@ uint32_t SystemHFClockGet(void)
  *
  * @return
  *   HFXO frequency in Hz.
- *****************************************************************************/
+ ******************************************************************************/
 uint32_t SystemHFXOClockGet(void)
 {
   /* External crystal oscillator present? */
-#if (EFR32_HFXO_FREQ > 0)
+#if (EFR32_HFXO_FREQ > 0U)
   return SystemHFXOClock;
 #else
-  return 0;
+  return 0U;
 #endif
 }
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @brief
  *   Set high frequency crystal oscillator clock frequency for target system.
  *
@@ -252,11 +258,11 @@ uint32_t SystemHFXOClockGet(void)
  *
  * @param[in] freq
  *   HFXO frequency in Hz used for target.
- *****************************************************************************/
+ ******************************************************************************/
 void SystemHFXOClockSet(uint32_t freq)
 {
   /* External crystal oscillator present? */
-#if (EFR32_HFXO_FREQ > 0)
+#if (EFR32_HFXO_FREQ > 0U)
   SystemHFXOClock = freq;
 
   /* Update core clock frequency if HFXO is used to clock core */
@@ -270,7 +276,7 @@ void SystemHFXOClockSet(uint32_t freq)
 #endif
 }
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @brief
  *   Initialize the system.
  *
@@ -281,13 +287,21 @@ void SystemHFXOClockSet(uint32_t freq)
  *   This function is invoked during system init, before the main() routine
  *   and any data has been initialized. For this reason, it cannot do any
  *   initialization of variables etc.
- *****************************************************************************/
+ ******************************************************************************/
 void SystemInit(void)
 {
-#if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
+#if defined(__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  SCB->VTOR = (uint32_t)&__Vectors;
+#endif
+
+#if (__FPU_PRESENT == 1U) && (__FPU_USED == 1U)
   /* Set floating point coprosessor access mode. */
-  SCB->CPACR |= ((3UL << 10 * 2)                      /* set CP10 Full Access */
-                 | (3UL << 11 * 2));                  /* set CP11 Full Access */
+  SCB->CPACR |= ((3UL << 10 * 2)                    /* set CP10 Full Access */
+                 | (3UL << 11 * 2));                /* set CP11 Full Access */
+#endif
+
+#if defined(UNALIGNED_SUPPORT_DISABLE)
+  SCB->CCR |= SCB_CCR_UNALIGN_TRP_Msk;
 #endif
 
   /****************************
@@ -302,7 +316,7 @@ void SystemInit(void)
   *(volatile uint32_t *)(0x400E3060) &= ~(0x1UL << 28);
 }
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @brief
  *   Get low frequency RC oscillator clock frequency for target system.
  *
@@ -311,7 +325,7 @@ void SystemInit(void)
  *
  * @return
  *   LFRCO frequency in Hz.
- *****************************************************************************/
+ ******************************************************************************/
 uint32_t SystemLFRCOClockGet(void)
 {
   /* Currently we assume that this frequency is properly tuned during */
@@ -320,7 +334,7 @@ uint32_t SystemLFRCOClockGet(void)
   return EFR32_LFRCO_FREQ;
 }
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @brief
  *   Get ultra low frequency RC oscillator clock frequency for target system.
  *
@@ -329,14 +343,14 @@ uint32_t SystemLFRCOClockGet(void)
  *
  * @return
  *   ULFRCO frequency in Hz.
- *****************************************************************************/
+ ******************************************************************************/
 uint32_t SystemULFRCOClockGet(void)
 {
   /* The ULFRCO frequency is not tuned, and can be very inaccurate */
   return EFR32_ULFRCO_FREQ;
 }
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @brief
  *   Get low frequency crystal oscillator clock frequency for target system.
  *
@@ -345,18 +359,18 @@ uint32_t SystemULFRCOClockGet(void)
  *
  * @return
  *   LFXO frequency in Hz.
- *****************************************************************************/
+ ******************************************************************************/
 uint32_t SystemLFXOClockGet(void)
 {
   /* External crystal oscillator present? */
-#if (EFR32_LFXO_FREQ > 0)
+#if (EFR32_LFXO_FREQ > 0U)
   return SystemLFXOClock;
 #else
-  return 0;
+  return 0U;
 #endif
 }
 
-/**************************************************************************//**
+/***************************************************************************//**
  * @brief
  *   Set low frequency crystal oscillator clock frequency for target system.
  *
@@ -370,11 +384,11 @@ uint32_t SystemLFXOClockGet(void)
  *
  * @param[in] freq
  *   LFXO frequency in Hz used for target.
- *****************************************************************************/
+ ******************************************************************************/
 void SystemLFXOClockSet(uint32_t freq)
 {
   /* External crystal oscillator present? */
-#if (EFR32_LFXO_FREQ > 0)
+#if (EFR32_LFXO_FREQ > 0U)
   SystemLFXOClock = freq;
 
   /* Update core clock frequency if LFXO is used to clock core */

--- a/pkg/gecko_sdk/Makefile
+++ b/pkg/gecko_sdk/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=gecko_sdk
 PKG_URL=https://github.com/basilfx/RIOT-gecko-sdk
-PKG_VERSION=6f076bc0557e6f9a44a9d08e0a734f0d24d7c97c
+PKG_VERSION=50996be7377cec885954312b7d4caf61788aaa40
 PKG_LICENSE=Zlib
 
 ifneq ($(CPU),efm32)


### PR DESCRIPTION
### Contribution description
This PR will update Gecko SDK to version 2.5. The main reason for this update, is to support #9212.

Since Gecko SDK uses the vendor headers, which have changed as well, this PR also updates the vendor headers. It needs to be in one PR to satisfy Murdock.

### Testing procedure
All EFM32-based boards (IKEA Tradfri, STK3600, STK3700, SLSTK3401a, SLSTK3402a and SLWSTK6000B) compile as before, and run the examples and tests.

### Issues/PRs references
#9212
