### PR TITLE
net/nanocoap: remove obsolete macro

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -188,7 +188,6 @@ extern "C" {
 /** @} */
 
 #ifdef MODULE_GCOAP
-#define NANOCOAP_URL_MAX        NANOCOAP_URI_MAX
 #define NANOCOAP_QS_MAX         (64)
 #endif
 


### PR DESCRIPTION
### Contribution description
Removes definition of NANOCOAP_URL_MAX macro. This macro was useful prior to #9156, when the resource path for a gcoap message was stored in a coap_pkt_t struct.

### Testing procedure
Do a text search for the macro to confirm it is unused.

### Issues/PRs references
-none-