### PR TITLE
boards/stm32: remove unnecessary ADC defines in board config

### DIFF
--- a/boards/b-l072z-lrwan1/include/periph_conf.h
+++ b/boards/b-l072z-lrwan1/include/periph_conf.h
@@ -179,13 +179,6 @@ static const i2c_conf_t i2c_config[] = {
 /** @} */
 
 /**
- * @name    ADC configuration
- * @{
- */
-#define ADC_NUMOF           (0)
-/** @} */
-
-/**
  * @name    RTC configuration
  * @{
  */

--- a/boards/b-l475e-iot01a/include/periph_conf.h
+++ b/boards/b-l475e-iot01a/include/periph_conf.h
@@ -229,13 +229,6 @@ static const i2c_conf_t i2c_config[] = {
 /** @} */
 
 /**
- * @name    ADC configuration
- * @{
- */
-#define ADC_NUMOF           (0)
-/** @} */
-
-/**
  * @name    RTT configuration
  *
  * On the STM32Lx platforms, we always utilize the LPTIM1.

--- a/boards/f4vi1/include/periph_conf.h
+++ b/boards/f4vi1/include/periph_conf.h
@@ -82,13 +82,6 @@ static const uart_conf_t uart_config[] = {
 #define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
 /** @} */
 
-/**
- * @name    ADC configuration
- * @{
- */
-#define ADC_NUMOF           (0)
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/fox/include/periph_conf.h
+++ b/boards/fox/include/periph_conf.h
@@ -60,13 +60,6 @@ extern "C" {
 /** @} */
 
 /**
- * @name    ADC configuration
- * @{
- */
-#define ADC_NUMOF           (0)
-/** @} */
-
-/**
  * @name    Timer configuration
  * @{
  */

--- a/boards/maple-mini/include/periph_conf.h
+++ b/boards/maple-mini/include/periph_conf.h
@@ -60,13 +60,6 @@ extern "C" {
 /** @} */
 
 /**
- * @name ADC configuration
- * @{
- */
-#define ADC_NUMOF           (0)
-/** @} */
-
-/**
  * @name   Timer configuration
  * @{
  */

--- a/boards/nucleo-f103rb/include/periph_conf.h
+++ b/boards/nucleo-f103rb/include/periph_conf.h
@@ -57,13 +57,6 @@ extern "C" {
 /** @} */
 
 /**
- * @name ADC configuration
- * @{
- */
-#define ADC_NUMOF           (0)
-/** @} */
-
-/**
  * @name   Timer configuration
  * @{
  */

--- a/boards/nucleo-f302r8/include/periph_conf.h
+++ b/boards/nucleo-f302r8/include/periph_conf.h
@@ -61,13 +61,6 @@ extern "C" {
 /** @} */
 
 /**
- * @name ADC configuration
- * @{
- */
-#define ADC_NUMOF           (0)
-/** @} */
-
-/**
  * @name   Timer configuration
  * @{
  */

--- a/boards/nucleo-f722ze/include/periph_conf.h
+++ b/boards/nucleo-f722ze/include/periph_conf.h
@@ -159,13 +159,6 @@ static const i2c_conf_t i2c_config[] = {
 #define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
 /** @} */
 
-/**
- * @name    ADC configuration
- * @{
- */
-#define ADC_NUMOF           (0)
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/nucleo-f746zg/include/periph_conf.h
+++ b/boards/nucleo-f746zg/include/periph_conf.h
@@ -136,13 +136,6 @@ static const uart_conf_t uart_config[] = {
 #define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
 /** @} */
 
-/**
- * @name    ADC configuration
- * @{
- */
-#define ADC_NUMOF           (0)
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/nucleo-f767zi/include/periph_conf.h
+++ b/boards/nucleo-f767zi/include/periph_conf.h
@@ -136,13 +136,6 @@ static const uart_conf_t uart_config[] = {
 #define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
 /** @} */
 
-/**
- * @name    ADC configuration
- * @{
- */
-#define ADC_NUMOF           (0)
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/nucleo-l053r8/include/periph_conf.h
+++ b/boards/nucleo-l053r8/include/periph_conf.h
@@ -170,13 +170,6 @@ static const spi_conf_t spi_config[] = {
 /** @} */
 
 /**
- * @name    ADC configuration
- * @{
- */
-#define ADC_NUMOF           (0)
-/** @} */
-
-/**
  * @name    RTC configuration
  * @{
  */

--- a/boards/nucleo-l433rc/include/periph_conf.h
+++ b/boards/nucleo-l433rc/include/periph_conf.h
@@ -203,13 +203,6 @@ static const spi_conf_t spi_config[] = {
 /** @} */
 
 /**
- * @name    ADC configuration
- * @{
- */
-#define ADC_NUMOF           (0)
-/** @} */
-
-/**
  * @name    RTT configuration
  *
  * On the STM32Lx platforms, we always utilize the LPTIM1.

--- a/boards/nucleo-l452re/include/periph_conf.h
+++ b/boards/nucleo-l452re/include/periph_conf.h
@@ -202,13 +202,6 @@ static const spi_conf_t spi_config[] = {
 /** @} */
 
 /**
- * @name    ADC configuration
- * @{
- */
-#define ADC_NUMOF           (0)
-/** @} */
-
-/**
  * @name    RTT configuration
  *
  * On the STM32Lx platforms, we always utilize the LPTIM1.

--- a/boards/opencm904/include/periph_conf.h
+++ b/boards/opencm904/include/periph_conf.h
@@ -60,13 +60,6 @@ extern "C" {
 /** @} */
 
 /**
- * @name ADC configuration
- * @{
- */
-#define ADC_NUMOF           (0)
-/** @} */
-
-/**
  * @name   Timer configuration
  * @{
  */

--- a/boards/spark-core/include/periph_conf.h
+++ b/boards/spark-core/include/periph_conf.h
@@ -60,13 +60,6 @@ extern "C" {
 /** @} */
 
 /**
- * @name ADC configuration
- * @{
- */
-#define ADC_NUMOF           (0)
-/** @} */
-
-/**
  * @name   Timer configuration
  * @{
  */

--- a/boards/stm32f769i-disco/include/periph_conf.h
+++ b/boards/stm32f769i-disco/include/periph_conf.h
@@ -103,13 +103,6 @@ static const uart_conf_t uart_config[] = {
 /** @} */
 
 /**
- * @name    ADC configuration
- * @{
- */
-#define ADC_NUMOF           (0)
-/** @} */
-
-/**
  * @name    RTC configuration
  * @{
  */

--- a/boards/stm32l476g-disco/include/periph_conf.h
+++ b/boards/stm32l476g-disco/include/periph_conf.h
@@ -117,13 +117,6 @@ static const uart_conf_t uart_config[] = {
 /** @} */
 
 /**
- * @name    ADC configuration
- * @{
- */
-#define ADC_NUMOF           (0)
-/** @} */
-
-/**
  * @name    RTT configuration
  *
  * On the STM32Lx platforms, we always utilize the LPTIM1.


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR cleans up the ST based boards configuration. While having another look at #8939, I found that there were still a lot of them used while this is not necessary since the features is already not provided by the board.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

If Murdock is green, all should be ok.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
