### PR TITLE
boards/stm32: factorize i2c configuration on stm32f0 and stm32f2 based nucleo boards

### DIFF
--- a/boards/common/stm32/include/cfg_i2c1_pb8_pb9.h
+++ b/boards/common/stm32/include/cfg_i2c1_pb8_pb9.h
@@ -35,10 +35,15 @@ static const i2c_conf_t i2c_config[] = {
         .speed          = I2C_SPEED_NORMAL,
         .scl_pin        = GPIO_PIN(PORT_B, 8),
         .sda_pin        = GPIO_PIN(PORT_B, 9),
+#if CPU_FAM_STM32F0
+        .scl_af         = GPIO_AF1,
+        .sda_af         = GPIO_AF1,
+#else
         .scl_af         = GPIO_AF4,
         .sda_af         = GPIO_AF4,
+#endif
         .bus            = APB1,
-#if CPU_FAM_STM32F4
+#if CPU_FAM_STM32F4 || CPU_FAM_STM32F2
         .rcc_mask       = RCC_APB1ENR_I2C1EN,
         .clk            = CLOCK_APB1,
         .irqn           = I2C1_EV_IRQn,
@@ -48,14 +53,20 @@ static const i2c_conf_t i2c_config[] = {
 #elif CPU_FAM_STM32F7
         .rcc_mask       = RCC_APB1ENR_I2C1EN,
         .irqn           = I2C1_ER_IRQn,
+#elif CPU_FAM_STM32F0
+        .rcc_mask       = RCC_APB1ENR_I2C1EN,
+        .rcc_sw_mask    = RCC_CFGR3_I2C1SW,
+        .irqn           = I2C1_IRQn,
 #endif
     }
 };
 
-#if CPU_FAM_STM32F4
+#if CPU_FAM_STM32F4 || CPU_FAM_STM32F2
 #define I2C_0_ISR           isr_i2c1_ev
 #elif CPU_FAM_STM32L4 || CPU_FAM_STM32F7
 #define I2C_0_ISR           isr_i2c1_er
+#elif CPU_FAM_STM32F0
+#define I2C_0_ISR           isr_i2c1
 #endif
 
 #define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))

--- a/boards/common/stm32/include/f2/cfg_clock_120_8_1.h
+++ b/boards/common/stm32/include/f2/cfg_clock_120_8_1.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2016-2017  OTA keys S.A.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_common_stm32
+ * @{
+ *
+ * @file
+ * @brief       Configure STM32F2 clock to 120MHz using PLL
+ *
+ * @author      Vincent Dupont <vincent@otakeys.com>
+ * @author      Aurelien Gonce <aurelien.gonce@altran.fr>
+ * @author      Toon Stegen <toon.stegen@altran.com>
+ */
+
+#ifndef F2_CFG_CLOCK_120_8_1_H
+#define F2_CFG_CLOCK_120_8_1_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Clock settings
+ *
+ * @note    This is auto-generated from
+ *          `cpu/stm32_common/dist/clk_conf/clk_conf.c`
+ * @{
+ */
+/* give the target core clock (HCLK) frequency [in Hz],
+ * maximum: 120MHz */
+#define CLOCK_CORECLOCK     (120000000U)
+/* 0: no external high speed crystal available
+ * else: actual crystal frequency [in Hz] */
+#define CLOCK_HSE           (8000000U)
+/* 0: no external low speed crystal available,
+ * 1: external crystal available (always 32.768kHz) */
+#define CLOCK_LSE           (1)
+/* peripheral clock setup */
+#define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1
+#define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
+#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV4     /* max 30MHz */
+#define CLOCK_APB1          (CLOCK_CORECLOCK / 4)
+#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV2     /* max 60MHz */
+#define CLOCK_APB2          (CLOCK_CORECLOCK / 2)
+
+/* Main PLL factors */
+#define CLOCK_PLL_M          (4)
+#define CLOCK_PLL_N          (120)
+#define CLOCK_PLL_P          (2)
+#define CLOCK_PLL_Q          (5)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* F2_CFG_CLOCK_120_8_1_H */
+/** @} */

--- a/boards/nucleo-f070rb/include/periph_conf.h
+++ b/boards/nucleo-f070rb/include/periph_conf.h
@@ -24,6 +24,7 @@
 #define PERIPH_CONF_H
 
 #include "periph_cpu.h"
+#include "cfg_i2c1_pb8_pb9.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -149,30 +150,6 @@ static const pwm_conf_t pwm_config[] = {
 };
 
 #define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
-/** @} */
-
-/**
- * @name I2C configuration
- * @{
- */
-static const i2c_conf_t i2c_config[] = {
-    {
-        .dev            = I2C1,
-        .speed          = I2C_SPEED_NORMAL,
-        .scl_pin        = GPIO_PIN(PORT_B, 8),
-        .sda_pin        = GPIO_PIN(PORT_B, 9),
-        .scl_af         = GPIO_AF1,
-        .sda_af         = GPIO_AF1,
-        .bus            = APB1,
-        .rcc_mask       = RCC_APB1ENR_I2C1EN,
-        .rcc_sw_mask    = RCC_CFGR3_I2C1SW,
-        .irqn           = I2C1_IRQn,
-    }
-};
-
-#define I2C_0_ISR           isr_i2c1
-
-#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
 /** @} */
 
 /**

--- a/boards/nucleo-f091rc/include/periph_conf.h
+++ b/boards/nucleo-f091rc/include/periph_conf.h
@@ -22,6 +22,7 @@
 #define PERIPH_CONF_H
 
 #include "periph_cpu.h"
+#include "cfg_i2c1_pb8_pb9.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -157,30 +158,6 @@ static const spi_conf_t spi_config[] = {
 };
 
 #define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
-/** @} */
-
-/**
- * @name    I2C configuration
- * @{
- */
-static const i2c_conf_t i2c_config[] = {
-    {
-        .dev            = I2C1,
-        .speed          = I2C_SPEED_NORMAL,
-        .scl_pin        = GPIO_PIN(PORT_B, 8),
-        .sda_pin        = GPIO_PIN(PORT_B, 9),
-        .scl_af         = GPIO_AF1,
-        .sda_af         = GPIO_AF1,
-        .bus            = APB1,
-        .rcc_mask       = RCC_APB1ENR_I2C1EN,
-        .rcc_sw_mask    = RCC_CFGR3_I2C1SW,
-        .irqn           = I2C1_IRQn,
-    }
-};
-
-#define I2C_0_ISR           isr_i2c1
-
-#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
 /** @} */
 
 /**

--- a/boards/nucleo-f207zg/include/periph_conf.h
+++ b/boards/nucleo-f207zg/include/periph_conf.h
@@ -22,41 +22,12 @@
 #define PERIPH_CONF_H
 
 #include "periph_cpu.h"
+#include "f2/cfg_clock_120_8_1.h"
+#include "cfg_i2c1_pb8_pb9.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @name    Clock settings
- *
- * @note    This is auto-generated from
- *          `cpu/stm32_common/dist/clk_conf/clk_conf.c`
- * @{
- */
-/* give the target core clock (HCLK) frequency [in Hz],
- * maximum: 120MHz */
-#define CLOCK_CORECLOCK     (120000000U)
-/* 0: no external high speed crystal available
- * else: actual crystal frequency [in Hz] */
-#define CLOCK_HSE           (8000000U)
-/* 0: no external low speed crystal available,
- * 1: external crystal available (always 32.768kHz) */
-#define CLOCK_LSE           (1)
-/* peripheral clock setup */
-#define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1
-#define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV4     /* max 30MHz */
-#define CLOCK_APB1          (CLOCK_CORECLOCK / 4)
-#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV2     /* max 60MHz */
-#define CLOCK_APB2          (CLOCK_CORECLOCK / 2)
-
-/* Main PLL factors */
-#define CLOCK_PLL_M          (4)
-#define CLOCK_PLL_N          (120)
-#define CLOCK_PLL_P          (2)
-#define CLOCK_PLL_Q          (5)
-/** @} */
 
 /**
  * @name    PWM configuration
@@ -224,30 +195,6 @@ static const spi_conf_t spi_config[] = {
 };
 
 #define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
-/** @} */
-
-/**
- * @name    I2C configuration
- * @{
- */
-static const i2c_conf_t i2c_config[] = {
-    {
-        .dev            = I2C1,
-        .speed          = I2C_SPEED_NORMAL,
-        .scl_pin        = GPIO_PIN(PORT_B, 8),
-        .sda_pin        = GPIO_PIN(PORT_B, 9),
-        .scl_af         = GPIO_AF4,
-        .sda_af         = GPIO_AF4,
-        .bus            = APB1,
-        .rcc_mask       = RCC_APB1ENR_I2C1EN,
-        .clk            = CLOCK_APB1,
-        .irqn           = I2C1_EV_IRQn
-    }
-};
-
-#define I2C_0_ISR           isr_i2c1_ev
-
-#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
 /** @} */
 
 /**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is following #9728 and applies the same strategy to f0 and f2 based nucleo boards.

Tested on nucleo-f070rb/f091rc and f207zg

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Test I2C (using Arduino pinout) on the modified boards.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Follows #9728 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
