### PR TITLE
boards/stm32: remove useless empty conf defines

### DIFF
--- a/boards/lobaro-lorabox/include/periph_conf.h
+++ b/boards/lobaro-lorabox/include/periph_conf.h
@@ -210,20 +210,6 @@ static const i2c_conf_t i2c_config[] = {
 #define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
 /** @} */
 
-/**
- * @name   ADC configuration
- * @{
- */
-#define ADC_NUMOF           (0U)
-/** @} */
-
-/**
- * @name   DAC configuration
- * @{
- */
-#define DAC_NUMOF           0
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/nucleo-f031k6/include/periph_conf.h
+++ b/boards/nucleo-f031k6/include/periph_conf.h
@@ -176,17 +176,6 @@ static const spi_conf_t spi_config[] = {
 /** @} */
 
 /**
- * @name RTC configuration
- * @{
- */
-/**
- * Nucleo-f031 does not have any LSE, current RTC driver does not support LSI as
- * clock source, so disabling RTC.
- */
-#define RTC_NUMOF           (0U)
-/** @} */
-
-/**
  * @name   ADC configuration
  * @{
  */

--- a/boards/nucleo-f042k6/include/periph_conf.h
+++ b/boards/nucleo-f042k6/include/periph_conf.h
@@ -187,17 +187,6 @@ static const spi_conf_t spi_config[] = {
 /** @} */
 
 /**
- * @name RTC configuration
- * @{
- */
-/**
- * Nucleo-f042 does not have any LSE, current RTC driver does not support LSI as
- * clock source, so disabling RTC.
- */
-#define RTC_NUMOF           (0U)
-/** @} */
-
-/**
  * @name   ADC configuration
  * @{
  */

--- a/boards/nucleo-f303k8/include/periph_conf.h
+++ b/boards/nucleo-f303k8/include/periph_conf.h
@@ -178,20 +178,6 @@ static const spi_conf_t spi_config[] = {
 #define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
 /** @} */
 
-/**
- * @name RTC configuration
- * @{
- */
-#define RTC_NUMOF           (0U)
-/** @} */
-
-/**
- * @name   ADC configuration
- * @{
- */
-#define ADC_NUMOF (0)
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/nucleo-f303ze/include/periph_conf.h
+++ b/boards/nucleo-f303ze/include/periph_conf.h
@@ -204,13 +204,6 @@ static const spi_conf_t spi_config[] = {
 #define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
 /** @} */
 
-/**
- * @name   ADC configuration
- * @{
- */
-#define ADC_NUMOF          (0)
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/nucleo-f446ze/include/periph_conf.h
+++ b/boards/nucleo-f446ze/include/periph_conf.h
@@ -158,13 +158,6 @@ static const spi_conf_t spi_config[] = {
 #define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
 /** @} */
 
-/**
- * @name    ADC configuration
- * @{
- */
-#define ADC_NUMOF          (0)
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/nucleo-l432kc/include/periph_conf.h
+++ b/boards/nucleo-l432kc/include/periph_conf.h
@@ -189,20 +189,6 @@ static const spi_conf_t spi_config[] = {
 #define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
 /** @} */
 
-/**
- * @name RTC configuration
- * @{
- */
-#define RTC_NUMOF           (0U)
-/** @} */
-
-/**
- * @name   ADC configuration
- * @{
- */
-#define ADC_NUMOF           (0U)
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/nucleo-l496zg/include/periph_conf.h
+++ b/boards/nucleo-l496zg/include/periph_conf.h
@@ -221,13 +221,6 @@ static const spi_conf_t spi_config[] = {
 /** @} */
 
 /**
- * @name    ADC configuration
- * @{
- */
-#define ADC_NUMOF           (0)
-/** @} */
-
-/**
  * @name    RTT configuration
  *
  * On the STM32Lx platforms, we always utilize the LPTIM1.

--- a/boards/opencm904/include/periph_conf.h
+++ b/boards/opencm904/include/periph_conf.h
@@ -124,13 +124,6 @@ static const uart_conf_t uart_config[] = {
 #define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
 /** @} */
 
-/**
- * @name I2C configuration
- * @{
- */
-#define I2C_NUMOF           (0)
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Another cleanup of useless defines in STM32 based boards configuration files. Those ones are leftover from #10689 but also applied to RTC, DAC, etc. Found while working on the different factorizations of I2C config.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

### Testing procedure

Murdock's happiness should be enough.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Follow-up of #10689 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
