### PR TITLE
drivers/bh1750: Fix mislabeled i2c address

### DIFF
--- a/drivers/include/bh1750fvi.h
+++ b/drivers/include/bh1750fvi.h
@@ -33,14 +33,14 @@ extern "C" {
  * The actual address of the device depends on the state of the ADDR pin.
  * @{
  */
-#define BH1750FVI_ADDR_PIN_LOW          (0x5c)      /**< ADDR pin := 0 */
-#define BH1750FVI_ADDR_PIN_HIGH         (0x23)      /**< ADDR pin := 1 */
+#define BH1750FVI_ADDR_PIN_LOW          (0x23)      /**< ADDR pin := 0 */
+#define BH1750FVI_ADDR_PIN_HIGH         (0x5c)      /**< ADDR pin := 1 */
 /** @} */
 
 /**
  * @brief   Default address of BH1750FVI sensors
  */
-#define BH1750FVI_DEFAULT_ADDR          BH1750FVI_ADDR_PIN_HIGH
+#define BH1750FVI_DEFAULT_ADDR          BH1750FVI_ADDR_PIN_LOW
 
 /**
  * @brief   Maximum I2C bus speed to use with the device


### PR DESCRIPTION
### Contribution description

The i2c address when the pin is high/low are swapped.
This swaps them to match the datasheet and changes the default to low.

### Testing procedure

Connect a board and run the tests/driver_bh1750 with the addr pin low, it should work by default.  Pull it high and set the pin high.

Or just read the [datasheet](https://www.mouser.com/ds/2/348/bh1750fvi-e-186247.pdf) page 7/17, only macro names were swapped no actual values.


### Issues/PRs references
Fixes #10628