### PR TITLE
board/z1: Fix BTN0_PIN

### DIFF
--- a/boards/z1/include/board.h
+++ b/boards/z1/include/board.h
@@ -94,7 +94,7 @@ extern "C" {
  * @name    User button configuration
  * @{
  */
-#define BTN0_PIN            P2IN
+#define BTN0_PIN            GPIO_PIN(2, 5)
 #define BTN0_MASK           (0x20)
 #define BTN0_MODE           GPIO_IN
 


### PR DESCRIPTION
Set BTN0_PIN to GPIO_PIN(2, 5) in board.h

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
The BTN0_PIN was not defined for the Zolertia Z1 board in `boards/z1/include/board.h`.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->



### Issues/PRs references
Fixes #10611 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
