### PR TITLE
tests/driver_ds1307: Blacklist iotlab boards

### DIFF
--- a/tests/driver_ds1307/Makefile
+++ b/tests/driver_ds1307/Makefile
@@ -1,5 +1,9 @@
 include ../Makefile.tests_common
 
+# Blacklist iotlab boards since a different device has the same i2c address
+BOARD_BLACKLIST := iotlab-a8-m3 \
+                   iotlab-m3
+
 USEMODULE += ds1307
 USEMODULE += embunit
 USEMODULE += xtimer


### PR DESCRIPTION
### Contribution description

This states iotlab boards shouldn't run these tests.
This is because the i2c address of L3G4200 is the same ad the ds1307.
This causes an error that thinks the test is valid when it is not.

### Testing procedure

The iotlab-m3 and iotlab-a8-m3 board should now state to expect errors for the test.

### Issues/PRs references
Fixes #10335
