### PR TITLE
tests/periph_uart: fix baudrate truncation

### DIFF
--- a/tests/periph_uart/main.c
+++ b/tests/periph_uart/main.c
@@ -133,7 +133,7 @@ static int cmd_init(int argc, char **argv)
     if (dev < 0) {
         return 1;
     }
-    baud = atoi(argv[2]);
+    baud = strtol(argv[2], NULL, 0);
 
     /* initialize UART */
     res = uart_init(UART_DEV(dev), baud, rx_cb, (void *)dev);
@@ -145,7 +145,7 @@ static int cmd_init(int argc, char **argv)
         puts("Error: Unable to initialize UART device\n");
         return 1;
     }
-    printf("Success: Successfully initialized UART_DEV(%i)\n", dev);
+    printf("Success: Initialized UART_DEV(%i) at BAUD %"PRIu32"\n", dev, baud);
 
     /* also test if poweron() and poweroff() work (or at least don't break
      * anything) */


### PR DESCRIPTION

### Contribution description
Since some boards an int is 16 bits the atoi truncates values.
This commit using a long instead of an int.


### Testing procedure
On any board where an int is 16 bits (such as the arduino-mega2560
run `BOARD=arduino-mega2560 make flash term -C tests/periph_uart/`
initialize with 115200 and try sending to something else with that same baudrate (loopback shouldn't work) or scoping it.

### Issues/PRs references
Fixes #10517
