### PR TITLE
cpu/atmega_common/uart: Comment why brr calc is different from datasheet

### DIFF
--- a/cpu/atmega_common/periph/uart.c
+++ b/cpu/atmega_common/periph/uart.c
@@ -97,6 +97,7 @@ static void _set_brr(uart_t uart, uint32_t baudrate)
         return;
     }
 #endif
+/* brr calculation is different from the datasheet to provide better rounding */
 #if defined(UART_DOUBLE_SPEED)
     brr = (CLOCK_CORECLOCK + 4UL * baudrate) / (8UL * baudrate) - 1UL;
     _update_brr(uart, brr, true);


### PR DESCRIPTION
### Contribution description
The brr calculation on the datasheet is different than what is implemented.
This is intentional since it provides better rounding due to truncation.
There was no comment explaining that so this comment should prevent confusion.

### Testing procedure
No test needed, look at related PRs and comments

### Issues/PRs references
Mentioned in #10517
Original reasoning  #5617