### PR TITLE
cpu/esp: esp_now_netdev fixes and optimizations

### DIFF
--- a/cpu/esp_common/esp-now/esp_now_netdev.c
+++ b/cpu/esp_common/esp-now/esp_now_netdev.c
@@ -213,11 +213,7 @@ static IRAM_ATTR void esp_now_recv_cb(const uint8_t *mac, const uint8_t *data, i
      * `esp_now_recv_cb`. To avoid inconsistencies this is checked by an
      * additional boolean variable . This can not be realized by a mutex
      * because `esp_now_recv_cb` would be reentered from same thread context.
-     * If the NDEBUG macro is undefined, an assertion is used instead for
-     * debugging purposes.
      */
-    assert(!_in_recv_cb);
-
     if (_in_recv_cb) {
         return;
     }

--- a/cpu/esp_common/esp-now/esp_now_netdev.c
+++ b/cpu/esp_common/esp-now/esp_now_netdev.c
@@ -160,9 +160,6 @@ static void IRAM_ATTR esp_now_scan_peers_done(void)
 
     _esp_now_scan_peers_done = true;
 
-    /* set the time for next scan */
-    xtimer_set(&_esp_now_scan_peers_timer, esp_now_params.scan_period);
-
     mutex_unlock(&_esp_now_dev.dev_lock);
 }
 
@@ -170,7 +167,10 @@ static void esp_now_scan_peers_start(void)
 {
     DEBUG("%s\n", __func__);
 
+    /* start the scan */
     esp_wifi_scan_start(&scan_cfg, false);
+    /* set the time for next scan */
+    xtimer_set(&_esp_now_scan_peers_timer, esp_now_params.scan_period);
 }
 
 static void IRAM_ATTR esp_now_scan_peers_timer_cb(void* arg)

--- a/cpu/esp_common/esp-now/esp_now_netdev.c
+++ b/cpu/esp_common/esp-now/esp_now_netdev.c
@@ -577,6 +577,8 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
     if (len < size) {
         /* buffer is smaller than the number of received bytes */
         DEBUG("[esp_now] No space in receive buffers\n");
+        /* newest API requires to drop the frame in that case */
+        ringbuffer_remove(&dev->rx_buf, 1 + size);
         mutex_unlock(&dev->dev_lock);
         return -ENOBUFS;
     }

--- a/cpu/esp_common/esp-now/esp_now_netdev.c
+++ b/cpu/esp_common/esp-now/esp_now_netdev.c
@@ -622,24 +622,6 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
     return size;
 }
 
-static inline int _get_iid(esp_now_netdev_t *dev, eui64_t *value, size_t max_len)
-{
-    CHECK_PARAM_RET(max_len >= sizeof(eui64_t), -EOVERFLOW);
-
-    /* interface id according to */
-    /* https://tools.ietf.org/html/rfc4291#section-2.5.1 */
-    value->uint8[0] = dev->addr[0] ^ 0x02; /* invert bit1 */
-    value->uint8[1] = dev->addr[1];
-    value->uint8[2] = dev->addr[2];
-    value->uint8[3] = 0xff;
-    value->uint8[4] = 0xfe;
-    value->uint8[5] = dev->addr[3];
-    value->uint8[6] = dev->addr[4];
-    value->uint8[7] = dev->addr[5];
-
-    return sizeof(eui64_t);
-}
-
 static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
 {
     DEBUG("%s: %s %p %p %u\n", __func__, netopt2str(opt), netdev, val, max_len);
@@ -683,10 +665,6 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
             CHECK_PARAM_RET(max_len >= sizeof(dev->addr), -EOVERFLOW);
             memcpy(val, dev->addr, sizeof(dev->addr));
             res = sizeof(dev->addr);
-            break;
-
-        case NETOPT_IPV6_IID:
-            res = _get_iid(dev, val, max_len);
             break;
 
 #ifdef MODULE_NETSTATS_L2

--- a/cpu/esp_common/esp-now/esp_now_netdev.c
+++ b/cpu/esp_common/esp-now/esp_now_netdev.c
@@ -240,7 +240,6 @@ static IRAM_ATTR void esp_now_recv_cb(const uint8_t *mac, const uint8_t *data, i
     /*
      * Since we are not in the interrupt context, we do not have to pass
      * `NETDEV_EVENT_ISR` first. We can call the receive function directly.
-     * But we have to unlock the mutex and enable interrupts before.
      */
     if (_esp_now_dev.netdev.event_callback) {
         _esp_now_dev.netdev.event_callback((netdev_t*)&_esp_now_dev,

--- a/cpu/esp_common/esp-now/esp_now_netdev.c
+++ b/cpu/esp_common/esp-now/esp_now_netdev.c
@@ -180,7 +180,7 @@ static void IRAM_ATTR esp_now_scan_peers_timer_cb(void* arg)
     esp_now_netdev_t* dev = (esp_now_netdev_t*)arg;
 
     if (dev->netdev.event_callback) {
-        dev->scan_event = true;
+        dev->scan_event++;
         dev->netdev.event_callback((netdev_t*)dev, NETDEV_EVENT_ISR);
     }
 }
@@ -228,7 +228,7 @@ static IRAM_ATTR void esp_now_recv_cb(const uint8_t *mac, const uint8_t *data, i
     ringbuffer_add(&_esp_now_dev.rx_buf, (char*)data, len);
 
     if (_esp_now_dev.netdev.event_callback) {
-        _esp_now_dev.recv_event = true;
+        _esp_now_dev.recv_event++;
         _esp_now_dev.netdev.event_callback((netdev_t*)&_esp_now_dev, NETDEV_EVENT_ISR);
     }
 
@@ -416,8 +416,8 @@ esp_now_netdev_t *netdev_esp_now_setup(void)
     dev->netdev.driver = &_esp_now_driver;
 
     /* initialize netdev data structure */
-    dev->recv_event = false;
-    dev->scan_event = false;
+    dev->recv_event = 0;
+    dev->scan_event = 0;
 
     mutex_init(&dev->dev_lock);
     mutex_init(&dev->rx_lock);
@@ -733,12 +733,16 @@ static void _isr(netdev_t *netdev)
 
     esp_now_netdev_t *dev = (esp_now_netdev_t*)netdev;
 
+    critical_enter();
+
     if (dev->recv_event) {
-        dev->recv_event = false;
+        dev->recv_event--;
+        critical_exit();
         dev->netdev.event_callback(netdev, NETDEV_EVENT_RX_COMPLETE);
     }
     else if (dev->scan_event) {
-        dev->scan_event = false;
+        dev->scan_event--;
+        critical_exit();
         esp_now_scan_peers_start();
     }
     return;

--- a/cpu/esp_common/esp-now/esp_now_netdev.h
+++ b/cpu/esp_common/esp-now/esp_now_netdev.h
@@ -82,8 +82,9 @@ typedef struct
 
     uint8_t addr[ESP_NOW_ADDR_LEN];  /**< device addr (MAC address) */
 
-    uint8_t rx_mem_len;              /**< number of bytes in buffer */
-    uint8_t rx_mem[ESP_NOW_BUFSIZE]; /**< memory holding one incoming frame */
+    uint8_t rx_len;                  /**< number of bytes received */
+    uint8_t* rx_mac;                 /**< source mac of received data */
+    uint8_t* rx_data;                /**< received */
 
     uint8_t tx_mem[ESP_NOW_MAX_SIZE_RAW]; /**< memory holding outgoing package */
 

--- a/cpu/esp_common/esp-now/esp_now_netdev.h
+++ b/cpu/esp_common/esp-now/esp_now_netdev.h
@@ -96,7 +96,6 @@ typedef struct
     mutex_t dev_lock;                /**< device is already in use */
     mutex_t rx_lock;                 /**< rx_buf handling in progress */
 
-    uint8_t recv_event;              /**< ESP-NOW frame received */
     uint8_t scan_event;              /**< ESP-NOW peers have to be scannged */
 
 } esp_now_netdev_t;

--- a/cpu/esp_common/esp-now/esp_now_netdev.h
+++ b/cpu/esp_common/esp-now/esp_now_netdev.h
@@ -96,8 +96,8 @@ typedef struct
     mutex_t dev_lock;                /**< device is already in use */
     mutex_t rx_lock;                 /**< rx_buf handling in progress */
 
-    bool recv_event;                 /**< ESP-NOW frame received */
-    bool scan_event;                 /**< ESP-NOW peers have to be scannged */
+    uint8_t recv_event;              /**< ESP-NOW frame received */
+    uint8_t scan_event;              /**< ESP-NOW peers have to be scannged */
 
 } esp_now_netdev_t;
 

--- a/cpu/esp_common/esp-now/esp_now_netdev.h
+++ b/cpu/esp_common/esp-now/esp_now_netdev.h
@@ -21,7 +21,6 @@
 #define ESP_NOW_NETDEV_H
 
 #include "net/netdev.h"
-#include "ringbuffer.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -50,11 +49,10 @@ extern "C" {
 /**
  * @brief   buffer size used for RX buffering
  *
- * Reduce this value if your expected traffic does not include full IPv6 MTU
- * sized packets.
+ * The buffer is use to store a ESP-NOW packet and the source MAC address.
  */
 #ifndef ESP_NOW_BUFSIZE
-#define ESP_NOW_BUFSIZE (1500)
+#define ESP_NOW_BUFSIZE (ESP_NOW_MAX_SIZE_RAW + ESP_NOW_ADDR_LEN)
 #endif
 
 /**
@@ -84,8 +82,8 @@ typedef struct
 
     uint8_t addr[ESP_NOW_ADDR_LEN];  /**< device addr (MAC address) */
 
-    uint8_t rx_mem[ESP_NOW_BUFSIZE]; /**< memory holding incoming packages */
-    ringbuffer_t rx_buf;             /**< ringbuffer for incoming packages */
+    uint8_t rx_mem_len;              /**< number of bytes in buffer */
+    uint8_t rx_mem[ESP_NOW_BUFSIZE]; /**< memory holding one incoming frame */
 
     uint8_t tx_mem[ESP_NOW_MAX_SIZE_RAW]; /**< memory holding outgoing package */
 

--- a/cpu/esp_common/esp-now/esp_now_netdev.h
+++ b/cpu/esp_common/esp-now/esp_now_netdev.h
@@ -94,7 +94,6 @@ typedef struct
 #endif
 
     mutex_t dev_lock;                /**< device is already in use */
-    mutex_t rx_lock;                 /**< rx_buf handling in progress */
 
     uint8_t scan_event;              /**< ESP-NOW peers have to be scannged */
 


### PR DESCRIPTION
### Contribution description

This PR provides a fix of problem 2 in issue #10682.

As described in #10682, a single ping without data was not possible anymore after heavy load with ping timeouts. The reason was that ISR events got lost and messed up the ringbuffer used in `esp_now_netdev`.

This PR is rather an evolution than only a fix. All different steps are realized as separate commits which contain the following changes:

1. `_recv` function of `esp_now_netdev` simplified according to the possible parameter values.
2. `_recv` function of `esp_now_netdev` updated to drop the frame as documented in new API if the parameter `len` is smaller than the received frame.
3. Lost of `NETDEV_EVENT_ISR` events in `esp_now_netdev` fixed.

In further extensive stress tests the following could be figured out:

- Function `esp_now_recv_cb` is executed in the context of the `wifi` thread (this was already known).
- The ISRs which handle the hardware interrupts from the WiFi interface only pass events to a message queue of the `wifi` thread.
- The `wifi` thread then processes the events sequentially and executes registered callback functions like `esp_now_recv_cb` asynchronously.
- This corresponds to the `NETDEV_EVENT_ISR` approach in GNRC.

This results in the following facts:

- Function `esp_now_recv_cb` will not be reentered.
- Execution of function `esp_now_recv_cb` is executed in the context of the highest priority thread and is therefore not interrupted or superseded by other threads.

These facts allow the following optimizations which are provided step by step as separate commits.

1. `NETDEV_EVENT_ISR` events are not needed. The execution of `netif::_recv` and thus `esp_now_netdev::_recv` can be triggered directly with `NETDEV_EVENT_RX_COMPLETE` on the receiption of a frame in `esp_now_recv_cb`.
2. Mutual exclusion is not required anymore since `esp_now_recv_cb` and `esp_now_netdev::_recv` are executed sequentially in same thread context.
3. Handling of critical section by disabling/enabling interrupts is not needed.
4. If `esp_now_netdev::_recv` is executed immediately in `esp_now_recv_cb` and in same thread context, there is no need for a ring buffer anymore.
5. There is even no buffer required. Received data can be copied directly from the buffer of the `wifi` thread.

Although function `esp_now_recv_cb` will not be reentered, it is secured by an additional boolean variable to avoid potential data inconsistencies. If the NDEBUG macro is undefined, an assertion is used instead for debugging purposes.

### Testing procedure

Use at least two or more ESP32 nodes and flash them with `examples/gnrc_networking`, e.g.:
```
USEMODULE=esp_now make -C examples/gnrc_networking BOARD=esp32-wroom-32 flash
```
Use the `ping` command to ping from each node another node to produce heavy load, either with two nodes
```
node1> ping6 10000 <node2_addr> 1232 0
node2> ping6 10000 <node1_addr> 1232 0
```
or with three nodes
```
node1> ping6 10000 <node2_addr> 1232 0
node2> ping6 10000 <node3_addr> 1232 0
node3> ping6 10000 <node1_addr> 1232 0
```
A further test is bombarding one node from two other nodes:
```
node1> ping6 10000 <node3_addr> 1232 0
node2> ping6 10000 <node3_addr> 1232 0
node3> 
```

### Issues/PRs references

This PR fixes #10682 problem 2, the stucked gnrc buffer problem remains.
This PR is a follow-on PR of #10581, #10679, #10680.