### PR TITLE
net/nanocoap: write struct-based block1 option

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -645,6 +645,20 @@ ssize_t coap_opt_finish(coap_pkt_t *pkt, uint16_t flags);
 size_t coap_opt_put_block2(uint8_t *buf, uint16_t lastonum, coap_block_slicer_t *slicer, bool more);
 
 /**
+ * @brief   Add the given block1 option into pkt
+ *
+ * @post pkt.payload advanced to first byte after option
+ * @post pkt.payload_len reduced by option length
+ *
+ * @param[in,out] pkt         pkt referencing target buffer
+ * @param[in]     block1      struct with block values
+ *
+ * @return        number of bytes written to buffer
+ * @return        <0 reserved for error but not implemented yet
+ */
+size_t coap_opt_add_block1(coap_pkt_t *pkt, coap_block1_t *block1);
+
+/**
  * @brief   Get content type from packet
  *
  * @param[in]   pkt     packet to work on

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -632,6 +632,14 @@ size_t coap_opt_put_block2(uint8_t *buf, uint16_t lastonum, coap_block_slicer_t 
     return coap_put_option_block(buf, lastonum, blknum, szx, more, COAP_OPT_BLOCK2);
 }
 
+size_t coap_opt_add_block1(coap_pkt_t *pkt, coap_block1_t *block1)
+{
+    uint32_t val = (block1->blknum << 4) | block1->szx | (block1->more ? 0x8 : 0);
+    _encode_uint(&val);
+
+    return coap_opt_add_uint(pkt, COAP_OPT_BLOCK1, val);
+}
+
 size_t coap_opt_put_string(uint8_t *buf, uint16_t lastonum, uint16_t optnum,
                            const char *string, char separator)
 {


### PR DESCRIPTION
### Contribution description
Adds a function to write a block1 option using the struct-based nanocoap API.

### Testing procedure
See the [gcoap-block](https://github.com/kb2ma/applications/tree/kb2ma-master/gcoap-block) server app. It is equivalent to the nanocoap_server example, and includes an `/sha256` resource. The handler writes a block1 option in the responses. Note that the RIOTBASE variable in `Makefile` does not use the RIOT submodule.

For a more complete test, see pytest-based [block1_test](https://github.com/kb2ma/riot-coap-pytest/blob/master/block1_test.py).

### Issues/PRs references
Part of the implementation of #9309.