### PR TITLE
net/coap: improve message code macros

### DIFF
--- a/examples/nanocoap_server/coap_handler.c
+++ b/examples/nanocoap_server/coap_handler.c
@@ -121,7 +121,7 @@ ssize_t _sha256_handler(coap_pkt_t* pkt, uint8_t *buf, size_t len, void *context
     sha256_update(&sha256, pkt->payload, pkt->payload_len);
 
     if (block1.more == 1) {
-        result = COAP_CODE_231;
+        result = COAP_CODE_CONTINUE;
     }
 
     size_t result_len = 0;

--- a/sys/include/net/coap.h
+++ b/sys/include/net/coap.h
@@ -86,6 +86,7 @@ extern "C" {
 #define COAP_CODE_204          ((2 << 5) | 4)
 #define COAP_CODE_CONTENT      ((2 << 5) | 5)
 #define COAP_CODE_205          ((2 << 5) | 5)
+#define COAP_CODE_CONTINUE     ((2 << 5) | 31)
 #define COAP_CODE_231          ((2 << 5) | 31)
 /** @} */
 
@@ -103,9 +104,9 @@ extern "C" {
 #define COAP_CODE_METHOD_NOT_ALLOWED         ((4 << 5) | 5)
 #define COAP_CODE_NOT_ACCEPTABLE             ((4 << 5) | 6)
 #define COAP_CODE_REQUEST_ENTITY_INCOMPLETE  ((4 << 5) | 8)
-#define COAP_CODE_PRECONDITION_FAILED        ((4 << 5) | 0xC)
-#define COAP_CODE_REQUEST_ENTITY_TOO_LARGE   ((4 << 5) | 0xD)
-#define COAP_CODE_UNSUPPORTED_CONTENT_FORMAT ((4 << 5) | 0xF)
+#define COAP_CODE_PRECONDITION_FAILED        ((4 << 5) | 12)
+#define COAP_CODE_REQUEST_ENTITY_TOO_LARGE   ((4 << 5) | 13)
+#define COAP_CODE_UNSUPPORTED_CONTENT_FORMAT ((4 << 5) | 15)
 /** @} */
 
 /**


### PR DESCRIPTION
### Contribution description
Adds a more descriptive name for the 2.31 Continue message code. Also, always use base 10 for the definition of other code macros.

Also updated the nanocoap_server example to use the new Continue macro.

### Testing procedure
The `/sha256` resource for nanocoap_server should still work. See pytest-based [block1_test](https://github.com/kb2ma/riot-coap-pytest/blob/master/block1_test.py) for a test against this resource.

### Issues/PRs references
-none-