### PR TITLE
drivers/bmx055: eliminate some casts

### DIFF
--- a/drivers/bmx055/bmx055_saul.c
+++ b/drivers/bmx055/bmx055_saul.c
@@ -24,7 +24,9 @@
 
 static int read_mag(const void *dev, phydat_t *res)
 {
-    if (bmx055_mag_read((bmx055_t *)dev, (int16_t *)res) != BMX055_OK) {
+    const bmx055_t *mydev = (const bmx055_t *)dev;
+
+    if (bmx055_mag_read(mydev, res->val) != BMX055_OK) {
         return 0;
     }
     res->unit = UNIT_GS;
@@ -34,7 +36,9 @@ static int read_mag(const void *dev, phydat_t *res)
 
 static int read_acc(const void *dev, phydat_t *res)
 {
-    if (bmx055_acc_read((bmx055_t *)dev, (int16_t *)res) != BMX055_OK) {
+    const bmx055_t *mydev = (const bmx055_t *)dev;
+
+    if (bmx055_acc_read(mydev, res->val) != BMX055_OK) {
         return 0;
     }
     res->unit = UNIT_G;
@@ -44,7 +48,9 @@ static int read_acc(const void *dev, phydat_t *res)
 
 static int read_gyro(const void *dev, phydat_t *res)
 {
-    if (bmx055_gyro_read((bmx055_t *)dev, (int16_t *)res) != BMX055_OK) {
+    const bmx055_t *mydev = (const bmx055_t *)dev;
+
+    if (bmx055_gyro_read(mydev, res->val) != BMX055_OK) {
         return 0;
     }
     res->unit = UNIT_DPS;


### PR DESCRIPTION
First, every read function converts the void pointer into a const bmx055_t

Second, it is cleaner (more obvious) to pass phydat_t.val[3] instead of
type casting to int16_t* and relying that .val[3] is the first struct
member of phydat_t.

Notice that it wasn't tested but I'm fairly sure that the code behavior hasn't changed.