### PR TITLE
drivers/bh1750fvi: change prototype of bh1750fvi_init

### DIFF
--- a/drivers/bh1750fvi/bh1750fvi.c
+++ b/drivers/bh1750fvi/bh1750fvi.c
@@ -28,7 +28,7 @@
 #define ENABLE_DEBUG        (0)
 #include "debug.h"
 
-int bh1750fvi_init(bh1750fvi_t *dev, bh1750fvi_params_t *params)
+int bh1750fvi_init(bh1750fvi_t *dev, const bh1750fvi_params_t *params)
 {
     int res;
 

--- a/drivers/include/bh1750fvi.h
+++ b/drivers/include/bh1750fvi.h
@@ -80,7 +80,7 @@ typedef struct {
  * @return      0 on success
  * @return      -1 if unable to speak to the device
  */
-int bh1750fvi_init(bh1750fvi_t *dev, bh1750fvi_params_t *params);
+int bh1750fvi_init(bh1750fvi_t *dev, const bh1750fvi_params_t *params);
 
 /**
  * @brief   Read a ambient light value from the given device [in LUX]

--- a/tests/driver_bh1750/main.c
+++ b/tests/driver_bh1750/main.c
@@ -35,7 +35,7 @@ int main(void)
     puts("BH1750FVI ambient light sensor test\n");
 
     /* initialize the device */
-    res = bh1750fvi_init(&dev, (bh1750fvi_params_t *)(&bh1750fvi_params));
+    res = bh1750fvi_init(&dev, &bh1750fvi_params[0]);
     if (res != BH1750FVI_OK) {
         puts("error: unable to initialize sensor [I2C initialization error]");
         return 1;


### PR DESCRIPTION
The params argument is now a const pointer. This eliminates the need for
a type cast that converts a const to a non-const.

Notice that it wasn't tested but I'm fairly sure that the code behavior hasn't changed.