### PR TITLE
tests/driver_at86rf2xx: eliminate cast

### DIFF
--- a/tests/driver_at86rf2xx/main.c
+++ b/tests/driver_at86rf2xx/main.c
@@ -95,7 +95,7 @@ int main(void)
         netdev_t *dev = (netdev_t *)(&devs[i]);
 
         printf("Initializing AT86RF2xx radio at SPI_%d\n", p->spi);
-        at86rf2xx_setup(&devs[i], (at86rf2xx_params_t*) p);
+        at86rf2xx_setup(&devs[i], p);
         dev->event_callback = _event_cb;
         dev->driver->init(dev);
     }


### PR DESCRIPTION
Not much to add. The function at86rf2xx_setup wants a const pointer, so it is silly to cast a const
pointer to a non-const of the same type.