### PR TITLE
drivers/ds18: refactor functions with const dev pointer

### DIFF
--- a/drivers/ds18/ds18_saul.c
+++ b/drivers/ds18/ds18_saul.c
@@ -26,7 +26,7 @@
 
 static int read_temperature(const void *dev, phydat_t *res)
 {
-    if (ds18_get_temperature((ds18_t *)dev, &res->val[0]) == DS18_ERROR) {
+    if (ds18_get_temperature(dev, &res->val[0]) == DS18_ERROR) {
         return -ECANCELED;
     }
 

--- a/drivers/include/ds18.h
+++ b/drivers/include/ds18.h
@@ -54,21 +54,20 @@ extern "C" {
 
 
 /**
- * @brief   Device descriptor for a ds18 device
- */
-typedef struct {
-    gpio_t pin;             /**< Pin the sensor is connected to */
-    gpio_mode_t out_mode;  /**< Pin output mode */
-    gpio_mode_t in_mode;    /**< Pin input mode */
-} ds18_t;
-
-/**
  * @brief Device initialization parameters
  */
 typedef struct {
     gpio_t pin;             /**< Pin the sensor is connected to */
-    gpio_mode_t out_mode;    /**< Pin output mode */
+    gpio_mode_t out_mode;   /**< Pin output mode */
+    gpio_mode_t in_mode;    /**< Pin input mode (usually deduced from output mode) */
 } ds18_params_t;
+
+/**
+ * @brief   Device descriptor for a ds18 device
+ */
+typedef struct {
+    ds18_params_t params;   /**< Device Parameters */
+} ds18_t;
 
 /**
  * @brief   Initialize a ds18 device
@@ -91,7 +90,7 @@ int ds18_init(ds18_t *dev, const ds18_params_t *params);
  * @return                  0 on success
  * @return                 -1 on error
  */
-int ds18_trigger(ds18_t *dev);
+int ds18_trigger(const ds18_t *dev);
 
 /**
  * @brief Reads the scratchpad for the last conversion
@@ -102,7 +101,7 @@ int ds18_trigger(ds18_t *dev);
  * @return                  0 on success
  * @return                 -1 on error
  */
-int ds18_read(ds18_t *dev, int16_t *temperature);
+int ds18_read(const ds18_t *dev, int16_t *temperature);
 
 /**
  * @brief   convenience fuction for triggering a conversion and reading the
@@ -117,7 +116,7 @@ int ds18_read(ds18_t *dev, int16_t *temperature);
  * @return                   0 on success
  * @return                  -1 on error
  */
-int ds18_get_temperature(ds18_t *dev, int16_t *temperature);
+int ds18_get_temperature(const ds18_t *dev, int16_t *temperature);
 
 #ifdef __cplusplus
 }

--- a/sys/auto_init/saul/auto_init_ds18.c
+++ b/sys/auto_init/saul/auto_init_ds18.c
@@ -55,7 +55,7 @@ void auto_init_ds18(void)
 
         LOG_DEBUG("[auto_init_saul] initializing ds18 #%u\n", i);
 
-        if (ds18_init(&ds18_devs[i], (ds18_params_t *) p) < 0) {
+        if (ds18_init(&ds18_devs[i], p) < 0) {
             LOG_ERROR("[auto_init_saul] error initializing ds18 #%u\n", i);
             return;
         }


### PR DESCRIPTION
All DS18 functions have a dev argument. All except the init function use
it as an IN parameter, so we can prototype it as const ds18_t*.

As a consequence we can drop the cast in read_temperature() in ds18_saul.c
which was the primary trigger for the changes.

The commit also follows the preferred convention that "params" is a field
in the device struct. Only the init function needs to write it.

Notice, this has not been tested because of lack of hardware for it. Also the SAUL
part needs to be tested.