### PR TITLE
drivers/lsm6dsl: eliminate and correct casts

### DIFF
--- a/drivers/lsm6dsl/lsm6dsl_saul.c
+++ b/drivers/lsm6dsl/lsm6dsl_saul.c
@@ -25,7 +25,7 @@
 
 static int read_acc(const void *dev, phydat_t *res)
 {
-    int ret = lsm6dsl_read_acc((const lsm6dsl_t *)dev, (lsm6dsl_3d_data_t *)res);
+    int ret = lsm6dsl_read_acc((const lsm6dsl_t *)dev, (lsm6dsl_3d_data_t *)res->val);
     if (ret < 0) {
         return -ECANCELED;
     }
@@ -38,7 +38,7 @@ static int read_acc(const void *dev, phydat_t *res)
 
 static int read_gyro(const void *dev, phydat_t *res)
 {
-    int ret = lsm6dsl_read_gyro((const lsm6dsl_t *)dev, (lsm6dsl_3d_data_t *)res);
+    int ret = lsm6dsl_read_gyro((const lsm6dsl_t *)dev, (lsm6dsl_3d_data_t *)res->val);
     if (ret < 0) {
         return -ECANCELED;
     }
@@ -51,7 +51,7 @@ static int read_gyro(const void *dev, phydat_t *res)
 
 static int read_temp(const void *dev, phydat_t *res)
 {
-    if (lsm6dsl_read_temp((const lsm6dsl_t *)dev, (int16_t *)&res[0]) < 0) {
+    if (lsm6dsl_read_temp((const lsm6dsl_t *)dev, &res->val[0]) < 0) {
         return -ECANCELED;
     }
     res->scale = -2;


### PR DESCRIPTION
Converting phydat_t* to lsm6dsl_3d_data_t* is not correct, but it happened
to just work because the first struct member of phydat_t will be used.

Furthermore, casting &res[0] to int16_t* is wrong. Again, it just happened
to work. Unfortunately, I want to add.