### PR TITLE
drivers/lsm303dlhc: correct cast of phydat_t*

### DIFF
--- a/drivers/lsm303dlhc/lsm303dlhc_saul.c
+++ b/drivers/lsm303dlhc/lsm303dlhc_saul.c
@@ -26,7 +26,7 @@
 static int read_acc(const void *dev, phydat_t *res)
 {
     const lsm303dlhc_t *d = (const lsm303dlhc_t *)dev;
-    lsm303dlhc_read_acc(d, (lsm303dlhc_3d_data_t *)res);
+    lsm303dlhc_read_acc(d, (lsm303dlhc_3d_data_t *)res->val);
 
     /* normalize result */
     int fac = (1 << (d->params.acc_scale >> 4));
@@ -43,7 +43,7 @@ static int read_mag(const void *dev, phydat_t *res)
 {
     const lsm303dlhc_t *d = (const lsm303dlhc_t *)dev;
 
-    lsm303dlhc_read_mag(d, (lsm303dlhc_3d_data_t *)res);
+    lsm303dlhc_read_mag(d, (lsm303dlhc_3d_data_t *)res->val);
 
     /* normalize results */
     int gain;

--- a/drivers/mag3110/mag3110_saul.c
+++ b/drivers/mag3110/mag3110_saul.c
@@ -26,7 +26,7 @@
 
 static int read_mag(const void *dev, phydat_t *res)
 {
-    mag3110_read((const mag3110_t *)dev, (mag3110_data_t *)res);
+    mag3110_read((const mag3110_t *)dev, (mag3110_data_t *)res->val);
 
     res->unit = UNIT_GS;
     res->scale = 2;

--- a/drivers/mma7660/mma7660_saul.c
+++ b/drivers/mma7660/mma7660_saul.c
@@ -26,7 +26,7 @@
 
 static int read_acc(const void *dev, phydat_t *res)
 {
-    mma7660_read((const mma7660_t *)dev, (mma7660_data_t *)res);
+    mma7660_read((const mma7660_t *)dev, (mma7660_data_t *)res->val);
 
     res->unit = UNIT_G;
     res->scale = -3;

--- a/drivers/mma8x5x/mma8x5x_saul.c
+++ b/drivers/mma8x5x/mma8x5x_saul.c
@@ -27,7 +27,7 @@
 
 static int read_acc(const void *dev, phydat_t *res)
 {
-    mma8x5x_read((const mma8x5x_t *)dev, (mma8x5x_data_t *)res);
+    mma8x5x_read((const mma8x5x_t *)dev, (mma8x5x_data_t *)res->val);
 
     res->unit = UNIT_G;
     res->scale = -3;

--- a/drivers/mpu9150/mpu9150_saul.c
+++ b/drivers/mpu9150/mpu9150_saul.c
@@ -25,7 +25,7 @@
 
 static int read_acc(const void *dev, phydat_t *res)
 {
-    int ret = mpu9150_read_accel((const mpu9150_t *)dev, (mpu9150_results_t *)res);
+    int ret = mpu9150_read_accel((const mpu9150_t *)dev, (mpu9150_results_t *)res->val);
     if (ret < 0) {
         return -ECANCELED;
     }
@@ -38,7 +38,7 @@ static int read_acc(const void *dev, phydat_t *res)
 
 static int read_gyro(const void *dev, phydat_t *res)
 {
-    int ret = mpu9150_read_gyro((const mpu9150_t *)dev, (mpu9150_results_t *)res);
+    int ret = mpu9150_read_gyro((const mpu9150_t *)dev, (mpu9150_results_t *)res->val);
     if (ret < 0) {
         return -ECANCELED;
     }
@@ -51,7 +51,7 @@ static int read_gyro(const void *dev, phydat_t *res)
 
 static int read_mag(const void *dev, phydat_t *res)
 {
-    int ret = mpu9150_read_compass((const mpu9150_t *)dev, (mpu9150_results_t *)res);
+    int ret = mpu9150_read_compass((const mpu9150_t *)dev, (mpu9150_results_t *)res->val);
     if (ret < 0) {
         return -ECANCELED;
     }


### PR DESCRIPTION
The read functions have a lsm303dlhc_3d_data_t* argument which is a
struct with 3 int16_t members. Thus we should cast res->val instead of
just res.