### PR TITLE
drivers/pulse_counter: refactor the prototypes of read funcs

### DIFF
--- a/drivers/include/pulse_counter.h
+++ b/drivers/include/pulse_counter.h
@@ -61,11 +61,11 @@ int pulse_counter_init(pulse_counter_t *dev, const pulse_counter_params_t *param
 /**
  * @brief   Read and reset pulse counter value
  *
- * @param[in]  dev          device descriptor of sensor
+ * @param[out] dev          device descriptor of sensor
  *
  * @return                  Accumulated pulse counts
  */
-int16_t pulse_counter_read_with_reset(const void *dev);
+int16_t pulse_counter_read_with_reset(pulse_counter_t *dev);
 
 /**
  * @brief   Read pulse counter value
@@ -74,14 +74,14 @@ int16_t pulse_counter_read_with_reset(const void *dev);
  *
  * @return                  Accumulated pulse counts
  */
-int16_t pulse_counter_read_without_reset(const void *dev);
+int16_t pulse_counter_read_without_reset(const pulse_counter_t *dev);
 
 /**
  * @brief   Reset pulse counter value
  *
- * @param[in]  dev          device descriptor of sensor
+ * @param[out] dev         device descriptor of sensor
  */
-void pulse_counter_reset(const void *dev);
+void pulse_counter_reset(pulse_counter_t *dev);
 
 #ifdef __cplusplus
 }

--- a/drivers/pulse_counter/pulse_counter.c
+++ b/drivers/pulse_counter/pulse_counter.c
@@ -55,24 +55,24 @@ int pulse_counter_init(pulse_counter_t *dev, const pulse_counter_params_t *param
 }
 
 /* Return the accumulated pulse counts and reset the count to zero */
-int16_t pulse_counter_read_with_reset(const void *dev)
+int16_t pulse_counter_read_with_reset(pulse_counter_t *dev)
 {
     int16_t pulse_count_output = 0;
     int16_t reset_value = 0;
 
     /* Use atomic operations to avoid messing with IRQ flags */
-    __atomic_exchange(&(((pulse_counter_t *)dev)->pulse_count), &reset_value, &pulse_count_output, __ATOMIC_SEQ_CST);
+    __atomic_exchange(&(dev->pulse_count), &reset_value, &pulse_count_output, __ATOMIC_SEQ_CST);
     return pulse_count_output;
 }
 
 /* Return the accumulated pulse counts */
-int16_t pulse_counter_read_without_reset(const void *dev)
+int16_t pulse_counter_read_without_reset(const pulse_counter_t *dev)
 {
-    return ((pulse_counter_t *)dev)->pulse_count;
+    return dev->pulse_count;
 }
 
 /* Reset the pulse count value to zero */
-void pulse_counter_reset(const void *dev)
+void pulse_counter_reset(pulse_counter_t *dev)
 {
-    ((pulse_counter_t *)dev)->pulse_count = 0;
+    dev->pulse_count = 0;
 }

--- a/drivers/pulse_counter/pulse_counter_saul.c
+++ b/drivers/pulse_counter/pulse_counter_saul.c
@@ -25,7 +25,9 @@
 
 static int read_pulse_counter(const void *dev, phydat_t *res)
 {
-    res->val[0] = pulse_counter_read_with_reset(dev);
+    /* Using non-const dev !! */
+    pulse_counter_t *mydev = (pulse_counter_t *)dev;
+    res->val[0] = pulse_counter_read_with_reset(mydev);
     res->unit  = UNIT_NONE;
     res->scale = 0;
     return 1;
@@ -33,7 +35,9 @@ static int read_pulse_counter(const void *dev, phydat_t *res)
 
 static int write_pulse_counter(const void *dev, phydat_t *data)
 {
-    pulse_counter_reset(dev);
+    /* Using non-const dev !! */
+    pulse_counter_t *mydev = (pulse_counter_t *)dev;
+    pulse_counter_reset(mydev);
     (void) data;
     return 1;
 }


### PR DESCRIPTION
This change makes it more clear that the dev is modified in some of the
read functions. Only `pulse_counter_read_without_reset` gets a const
pointer argument.

Also, use `pulse_counter_t` pointers instead of `void` pointers where
possible.

In two places a const `void` pointer is casted to a non-const `pulse_counter_t` pointer.

This has not been tested with hardware, so please test before merging.