### PR TITLE
doxygen: refine grouping of kernel docs

### DIFF
--- a/core/doc.txt
+++ b/core/doc.txt
@@ -15,7 +15,7 @@
  */
 
 /**
- * @defgroup    core_util Kernel utilities
+ * @defgroup    core_util Kernel Utilities
  * @ingroup     core
  * @brief       Utilities and data structures used by the kernel
  */

--- a/core/doc.txt
+++ b/core/doc.txt
@@ -25,3 +25,9 @@
  * @ingroup     core
  * @brief       Configuration data and startup code for the kernel
  */
+
+ /**
+  * @defgroup    core_sync Thread Synchronization
+  * @ingroup     core
+  * @brief       Thread synchronization mechanisms of the kernel
+  */

--- a/core/include/assert.h
+++ b/core/include/assert.h
@@ -8,7 +8,7 @@
  */
 
 /**
- * @addtogroup  core_util
+ * @ingroup     core_util
  *
  * @{
  * @file

--- a/core/include/bitarithm.h
+++ b/core/include/bitarithm.h
@@ -8,7 +8,7 @@
  */
 
 /**
- * @addtogroup  core_util
+ * @ingroup     core_util
  * @{
  *
  * @file

--- a/core/include/byteorder.h
+++ b/core/include/byteorder.h
@@ -7,13 +7,13 @@
  */
 
 /**
- * @addtogroup     core_util
+ * @ingroup     core_util
  * @{
  *
  * @file
- * @brief          Functions to work with different byte orders.
+ * @brief       Functions to work with different byte orders.
  *
- * @author         René Kijewski <rene.kijewski@fu-berlin.de>
+ * @author      René Kijewski <rene.kijewski@fu-berlin.de>
  */
 
 #ifndef BYTEORDER_H

--- a/core/include/cib.h
+++ b/core/include/cib.h
@@ -8,7 +8,7 @@
  */
 
  /**
- * @addtogroup  core_util
+ * @ingroup     core_util
  * @{
  *
  * @file

--- a/core/include/clist.h
+++ b/core/include/clist.h
@@ -8,7 +8,7 @@
  */
 
 /**
- * @addtogroup  core_util
+ * @ingroup     core_util
  * @{
  *
  * @file

--- a/core/include/cond.h
+++ b/core/include/cond.h
@@ -5,12 +5,9 @@
  */
 
 /**
+ * @defgroup    core_sync_cond Condition Variable
+ * @ingroup     core_sync
  * @brief       Condition variable for thread synchronization
- * @ingroup     core, core_sync
- * @{
- *
- * @file
- * @brief       RIOT synchronization API
  *
  * This file contains a condition variable with Mesa-style semantics.
  *
@@ -128,6 +125,11 @@
  *
  * Note that this could actually be written with a single condition variable.
  * However, the example includes two for didactic reasons.
+ *
+ * @{
+ *
+ * @file
+ * @brief       Condition variable for thread synchronization
  *
  * @author      Sam Kumar <samkumar@berkeley.edu>
  */

--- a/core/include/debug.h
+++ b/core/include/debug.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @addtogroup  core_util
+ * @ingroup     core_util
  * @{
  *
  * @file

--- a/core/include/kernel_defines.h
+++ b/core/include/kernel_defines.h
@@ -8,7 +8,7 @@
  */
 
 /**
- * @addtogroup  core_internal
+ * @ingroup     core_internal
  * @{
  *
  * @file

--- a/core/include/kernel_init.h
+++ b/core/include/kernel_init.h
@@ -8,7 +8,7 @@
  */
 
 /**
- * @addtogroup  core_internal
+ * @ingroup     core_internal
  * @{
  *
  * @file

--- a/core/include/kernel_types.h
+++ b/core/include/kernel_types.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @addtogroup  core_util
+ * @ingroup     core_util
  * @{
  *
  * @file

--- a/core/include/lifo.h
+++ b/core/include/lifo.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @addtogroup  core_util
+ * @ingroup     core_util
  * @{
  *
  * @file

--- a/core/include/list.h
+++ b/core/include/list.h
@@ -8,7 +8,7 @@
  */
 
 /**
- * @addtogroup  core_util
+ * @ingroup     core_util
  * @{
  *
  * @file

--- a/core/include/log.h
+++ b/core/include/log.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @addtogroup  core_util
+ * @ingroup     core_util
  * @{
  *
  * @file

--- a/core/include/mutex.h
+++ b/core/include/mutex.h
@@ -8,13 +8,13 @@
  */
 
 /**
- * @defgroup    core_sync Synchronization
+ * @defgroup    core_sync_mutex Mutex
+ * @ingroup     core_sync
  * @brief       Mutex for thread synchronization
- * @ingroup     core
  * @{
  *
  * @file
- * @brief       RIOT synchronization API
+ * @brief       Mutex for thread synchronization
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */

--- a/core/include/panic.h
+++ b/core/include/panic.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @addtogroup  core_util
+ * @ingroup     core_util
  * @{
  *
  * @file

--- a/core/include/priority_queue.h
+++ b/core/include/priority_queue.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @addtogroup  core_util
+ * @ingroup     core_util
  * @{
  *
  * @file

--- a/core/include/ringbuffer.h
+++ b/core/include/ringbuffer.h
@@ -8,7 +8,7 @@
  */
 
 /**
- * @ingroup  core_util
+ * @ingroup     core_util
  * @{
  * @file
  * @author Kaspar Schleiser <kaspar@schleiser.de>

--- a/core/include/rmutex.h
+++ b/core/include/rmutex.h
@@ -7,12 +7,14 @@
  */
 
 /**
+ * @defgroup    core_sync_rmutex Recursive Mutex
  * @ingroup     core_sync
  * @brief       Recursive Mutex for thread synchronization
+ *
  * @{
  *
  * @file
- * @brief       RIOT synchronization API
+ * @brief       Recursive Mutex for thread synchronization
  *
  * @author      Martin Elshuber <martin.elshuber@theobroma-systems.com>
  *


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Some refinement and restructuring the doxygen documentation of the kernel.

1. fix grouping of sync mechanisms
2. adapt using `@ingroup` instead of `@addtogroup`


### Testing procedure

build the docs and check the grouping in `Modules->Kernel` specifically look into the sync branch.


### Issues/PRs references

None