### PR TITLE
asymcute: check for minimum packet length early

### DIFF
--- a/sys/net/application_layer/asymcute/asymcute.c
+++ b/sys/net/application_layer/asymcute/asymcute.c
@@ -516,6 +516,10 @@ static void _on_unsuback(asymcute_con_t *con, const uint8_t *data, size_t len)
 
 static void _on_data(asymcute_con_t *con, size_t pkt_len, sock_udp_ep_t *remote)
 {
+    if (pkt_len < 2) {
+        return;
+    }
+
     size_t len;
     size_t pos = _len_get(con->rxbuf, &len);
 
@@ -524,8 +528,7 @@ static void _on_data(asymcute_con_t *con, size_t pkt_len, sock_udp_ep_t *remote)
         return;
     }
     /* validate incoming data: verify message length */
-    if ((pkt_len < 2) ||
-        (pkt_len <= pos) || (pkt_len < len)) {
+    if ((pkt_len <= pos) || (pkt_len < len)) {
         /* length field of MQTT-SN packet seems to be invalid -> drop the pkt */
         return;
     }


### PR DESCRIPTION
### Contribution description

Without this patch `_len_get` reads one byte beyond `con->rxbuf` if the incoming packet consists only of the byte `0x01`. Fortunately, the `rxbuf` is initialized with zeros in `asymcute_listener_run` so this doesn't access uninitialized memory. I would still consider this an error though.

### Testing procedure

1. Start the application `examples/asymcute_mqttsn`
2. Send a packet containing only the byte `0x01` to the sock ephemeral port.

Step 2. can be performed using netcat, e.g.:

```
printf '\x01' | nc -u '[link-local-addr%tap0]' 49152
```

### Issues/PRs references

None.