### PR TITLE
drivers/cc2420: move flush sequence to inline function 

### DIFF
--- a/drivers/cc2420/cc2420.c
+++ b/drivers/cc2420/cc2420.c
@@ -158,6 +158,12 @@ void cc2420_tx_exec(cc2420_t *dev)
     }
 }
 
+static inline void _flush_rx_fifo(cc2420_t *dev)
+{
+    cc2420_strobe(dev, CC2420_STROBE_FLUSHRX);
+    cc2420_strobe(dev, CC2420_STROBE_FLUSHRX);
+}
+
 int cc2420_rx(cc2420_t *dev, uint8_t *buf, size_t max_len, void *info)
 {
     (void)info;
@@ -202,8 +208,7 @@ int cc2420_rx(cc2420_t *dev, uint8_t *buf, size_t max_len, void *info)
         }
 
         /* finally flush the FIFO */
-        cc2420_strobe(dev, CC2420_STROBE_FLUSHRX);
-        cc2420_strobe(dev, CC2420_STROBE_FLUSHRX);
+        _flush_rx_fifo(dev);
     }
 
     return (int)len;

--- a/drivers/cc2420/cc2420.c
+++ b/drivers/cc2420/cc2420.c
@@ -160,6 +160,9 @@ void cc2420_tx_exec(cc2420_t *dev)
 
 static inline void _flush_rx_fifo(cc2420_t *dev)
 {
+    /* as stated in the CC2420 datasheet (section 14.3), the SFLUSHRX command
+     * strobe should be issued twice to ensure that the SFD pin goes back to its
+     * idle state */
     cc2420_strobe(dev, CC2420_STROBE_FLUSHRX);
     cc2420_strobe(dev, CC2420_STROBE_FLUSHRX);
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
See https://github.com/RIOT-OS/RIOT/pull/10416#issuecomment-451980544

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Check it compiles properly. Try to receive packets and check they are received correctly (if FIFO is not flushed, new packets won't be received)
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
#10416 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
