### PR TITLE
nanocoap: fix sock_udp return value checks

### DIFF
--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -128,17 +128,17 @@ int nanocoap_server(sock_udp_ep_t *local, uint8_t *buf, size_t bufsize)
     }
 
     ssize_t res = sock_udp_create(&sock, local, NULL, 0);
-    if (res == -1) {
+    if (res != 0) {
         return -1;
     }
 
     while (1) {
         res = sock_udp_recv(&sock, buf, bufsize, -1, &remote);
-        if (res == -1) {
+        if (res < 0) {
             DEBUG("error receiving UDP packet\n");
             return -1;
         }
-        else {
+        else if (res > 0) {
             coap_pkt_t pkt;
             if (coap_parse(&pkt, (uint8_t *)buf, res) < 0) {
                 DEBUG("error parsing packet\n");


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Both `sock_udp_create` and `sock_udp_recv` return negative `errno(3)` values on error.  Thus errors weren't detected properly.

### Testing procedure

Read the doxygen documentation of `sock_udp_create` and `sock_udp_recv`.

### Issues/PRs references

None.