### PR TITLE
Do normal assignment instead of memcpy

### DIFF
--- a/cpu/cc430/periph/rtc.c
+++ b/cpu/cc430/periph/rtc.c
@@ -60,7 +60,7 @@ int rtc_set_time(struct tm *localt)
     }
 
     /* copy time to be set */
-    memcpy(&time_to_set, localt, sizeof(struct tm));
+    time_to_set = *localt;
     set_time = 1;
     return 0;
 }

--- a/cpu/native/periph/rtc.c
+++ b/cpu/native/periph/rtc.c
@@ -142,7 +142,7 @@ int rtc_set_alarm(struct tm *time, rtc_alarm_cb_t cb, void *arg)
         return -1;
     }
 
-    memcpy(&_native_rtc_alarm, time, sizeof(_native_rtc_alarm));
+    _native_rtc_alarm = *time;
 
     warnx("rtc_set_alarm: not implemented");
 
@@ -162,7 +162,7 @@ int rtc_get_alarm(struct tm *time)
         return -1;
     }
 
-    memcpy(time, &_native_rtc_alarm, sizeof(_native_rtc_alarm));
+    *time = _native_rtc_alarm;
 
     return 0;
 }

--- a/drivers/apa102/apa102.c
+++ b/drivers/apa102/apa102.c
@@ -49,7 +49,7 @@ void apa102_init(apa102_t *dev, const apa102_params_t *params)
 {
     assert(dev && params);
 
-    memcpy(dev, params, sizeof(apa102_params_t));
+    *dev = *params;
 
     gpio_init(dev->data_pin, GPIO_OUT);
     gpio_init(dev->clk_pin, GPIO_OUT);

--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -43,7 +43,7 @@ void at86rf2xx_setup(at86rf2xx_t *dev, const at86rf2xx_params_t *params)
 
     netdev->driver = &at86rf2xx_driver;
     /* initialize device descriptor */
-    memcpy(&dev->params, params, sizeof(at86rf2xx_params_t));
+    dev->params = *params;
     /* State to return after receiving or transmitting */
     dev->idle_state = AT86RF2XX_STATE_TRX_OFF;
     /* radio state is P_ON when first powered-on */

--- a/drivers/ata8520e/ata8520e.c
+++ b/drivers/ata8520e/ata8520e.c
@@ -239,7 +239,7 @@ static void _poweroff(const ata8520e_t *dev)
 int ata8520e_init(ata8520e_t *dev, const ata8520e_params_t *params)
 {
     /* write config params to device descriptor */
-    memcpy(&dev->params, params, sizeof(ata8520e_params_t));
+    dev->params = *params;
 
     /* Initialize pins*/
     if (gpio_init_int(INTPIN, GPIO_IN_PD,

--- a/drivers/bmx055/bmx055.c
+++ b/drivers/bmx055/bmx055.c
@@ -54,7 +54,7 @@ int bmx055_init(bmx055_t *dev, const bmx055_params_t *params)
 
     uint8_t tmp;
 
-    memcpy(&dev->p, params, sizeof(bmx055_params_t));
+    dev->p = *params;
 
     /* bring magnetometer from suspend mode to sleep mode just in case
      * and try to read magnetometer id

--- a/drivers/cc2420/cc2420.c
+++ b/drivers/cc2420/cc2420.c
@@ -38,7 +38,7 @@ void cc2420_setup(cc2420_t * dev, const cc2420_params_t *params)
     /* set pointer to the devices netdev functions */
     dev->netdev.netdev.driver = &cc2420_driver;
     /* pull in device configuration parameters */
-    memcpy(&dev->params, params, sizeof(cc2420_params_t));
+    dev->params = *params;
     dev->state = CC2420_STATE_IDLE;
     /* reset device descriptor fields */
     dev->options = 0;

--- a/drivers/dht/dht.c
+++ b/drivers/dht/dht.c
@@ -69,7 +69,7 @@ int dht_init(dht_t *dev, const dht_params_t *params)
     assert(dev && params &&
            ((dev->type == DHT11) || (dev->type == DHT22) || (dev->type == DHT21)));
 
-    memcpy(dev, params, sizeof(dht_t));
+    *dev = *params;
 
     gpio_init(dev->pin, GPIO_OUT);
     gpio_set(dev->pin);

--- a/drivers/hd44780/hd44780.c
+++ b/drivers/hd44780/hd44780.c
@@ -101,7 +101,7 @@ static void _write_bits(const hd44780_t *dev, uint8_t bits, uint8_t value)
 int hd44780_init(hd44780_t *dev, const hd44780_params_t *params)
 {
     /* write config params to device descriptor */
-    memcpy(&dev->p, params, sizeof(hd44780_params_t));
+    dev->p = *params;
     /* verify cols and rows */
     if ((dev->p.cols > HD44780_MAX_COLS) || (dev->p.rows > HD44780_MAX_ROWS)
                                          || (dev->p.rows * dev->p.cols > 80)) {

--- a/drivers/hdc1000/hdc1000.c
+++ b/drivers/hdc1000/hdc1000.c
@@ -40,7 +40,7 @@ int hdc1000_init(hdc1000_t *dev, const hdc1000_params_t *params)
     uint16_t tmp;
 
     /* write device descriptor */
-    memcpy(&dev->p, params, sizeof(hdc1000_params_t));
+    dev->p = *params;
 
     /* try if we can interact with the device by reading its manufacturer ID */
     i2c_acquire(dev->p.i2c);

--- a/drivers/hts221/hts221.c
+++ b/drivers/hts221/hts221.c
@@ -147,7 +147,7 @@ int hts221_init(hts221_t *dev, const hts221_params_t *params)
 {
     uint8_t reg;
 
-    memcpy(&dev->p, params, sizeof(hts221_params_t));
+    dev->p = *params;
 
     i2c_acquire(BUS);
     /* try if we can interact with the device by reading its manufacturer ID */

--- a/drivers/kw2xrf/kw2xrf.c
+++ b/drivers/kw2xrf/kw2xrf.c
@@ -60,7 +60,7 @@ void kw2xrf_setup(kw2xrf_t *dev, const kw2xrf_params_t *params)
 
     netdev->driver = &kw2xrf_driver;
     /* initialize device descriptor */
-    memcpy(&dev->params, params, sizeof(kw2xrf_params_t));
+    dev->params = *params;
     dev->idle_state = XCVSEQ_RECEIVE;
     dev->state = 0;
     dev->pending_tx = 0;

--- a/drivers/lpd8808/lpd8808.c
+++ b/drivers/lpd8808/lpd8808.c
@@ -56,7 +56,7 @@ static void flush(const lpd8808_t *dev)
 
 int lpd8808_init(lpd8808_t *dev, const lpd8808_params_t *params)
 {
-    memcpy(dev, params, sizeof(lpd8808_params_t));
+    *dev = *params;
 
     /* initialize pins */
     gpio_init(dev->pin_dat, GPIO_OUT);

--- a/drivers/mag3110/mag3110.c
+++ b/drivers/mag3110/mag3110.c
@@ -46,7 +46,7 @@ int mag3110_init(mag3110_t *dev, const mag3110_params_t *params)
     assert(params);
 
     /* write device descriptor */
-    memcpy(dev, params, sizeof(mag3110_params_t));
+    dev->params = *params;
 
     i2c_acquire(BUS);
     /* test device */

--- a/drivers/mma7660/mma7660.c
+++ b/drivers/mma7660/mma7660.c
@@ -48,7 +48,7 @@
 int mma7660_init(mma7660_t *dev, const mma7660_params_t *params)
 {
     /* write device descriptor */
-    memcpy(&dev->params, params, sizeof(mma7660_params_t));
+    dev->params = *params;
 
     if (mma7660_set_mode(dev, 0, 0, 0, 0) != MMA7660_OK) {
         DEBUG("mma7660_set_mode failed!\n");

--- a/drivers/mma8x5x/mma8x5x.c
+++ b/drivers/mma8x5x/mma8x5x.c
@@ -44,7 +44,7 @@ int mma8x5x_init(mma8x5x_t *dev, const mma8x5x_params_t *params)
     assert(dev && params);
 
     /* write device descriptor */
-    memcpy(dev, params, sizeof(mma8x5x_params_t));
+    dev->params = *params;
 
     /* acquire the I2C bus */
     i2c_acquire(BUS);

--- a/drivers/mpl3115a2/mpl3115a2.c
+++ b/drivers/mpl3115a2/mpl3115a2.c
@@ -46,7 +46,7 @@ int mpl3115a2_init(mpl3115a2_t *dev, const mpl3115a2_params_t *params)
     assert(params);
 
     /* write device descriptor */
-    memcpy(dev, params, sizeof(mpl3115a2_params_t));
+    dev->params = *params;
 
     i2c_acquire(BUS);
     /* test device */

--- a/drivers/mrf24j40/mrf24j40.c
+++ b/drivers/mrf24j40/mrf24j40.c
@@ -37,7 +37,7 @@ void mrf24j40_setup(mrf24j40_t *dev, const mrf24j40_params_t *params)
 
     netdev->driver = &mrf24j40_driver;
     /* initialize device descriptor */
-    memcpy(&dev->params, params, sizeof(mrf24j40_params_t));
+    dev->params = *params;
 }
 
 void mrf24j40_reset(mrf24j40_t *dev)

--- a/drivers/my9221/my9221.c
+++ b/drivers/my9221/my9221.c
@@ -96,7 +96,7 @@ int my9221_init(my9221_t *dev, const my9221_params_t *params)
     assert(dev);
     assert(params);
     /* write config params to device descriptor */
-    memcpy(&dev->params, params, sizeof(my9221_params_t));
+    dev->params = *params;
     /* init clock and data pins as output */
     gpio_init(PIN_CLK, GPIO_OUT);
     gpio_init(PIN_DAT, GPIO_OUT);

--- a/drivers/rn2xx3/rn2xx3.c
+++ b/drivers/rn2xx3/rn2xx3.c
@@ -141,7 +141,7 @@ void rn2xx3_setup(rn2xx3_t *dev, const rn2xx3_params_t *params)
     assert(dev && (params->uart < UART_NUMOF));
 
     /* initialize device parameters */
-    memcpy(&dev->p, params, sizeof(rn2xx3_params_t));
+    dev->p = *params;
 
     /* initialize pins and perform hardware reset */
     if (dev->p.pin_reset != GPIO_UNDEF) {

--- a/drivers/sdcard_spi/sdcard_spi.c
+++ b/drivers/sdcard_spi/sdcard_spi.c
@@ -62,7 +62,7 @@ static int (*_dyn_spi_rxtx_byte)(sdcard_spi_t *card, char out, char *in);
 int sdcard_spi_init(sdcard_spi_t *card, const sdcard_spi_params_t *params)
 {
     sd_init_fsm_state_t state = SD_INIT_START;
-    memcpy(&card->params, params, sizeof(sdcard_spi_params_t));
+    card->params = *params;
     card->spi_clk = SD_CARD_SPI_SPEED_PREINIT;
 
     do {

--- a/drivers/si70xx/si70xx.c
+++ b/drivers/si70xx/si70xx.c
@@ -148,7 +148,7 @@ static int _test_device(const si70xx_t *dev)
 int si70xx_init(si70xx_t *dev, const si70xx_params_t *params)
 {
     /* initialize the device descriptor */
-    memcpy(&dev->params, params, sizeof(si70xx_params_t));
+    dev->params = *params;
 
     /* setup the i2c bus */
     i2c_acquire(SI70XX_I2C);

--- a/drivers/slipdev/slipdev.c
+++ b/drivers/slipdev/slipdev.c
@@ -200,7 +200,7 @@ static const netdev_driver_t slip_driver = {
 void slipdev_setup(slipdev_t *dev, const slipdev_params_t *params)
 {
     /* set device descriptor fields */
-    memcpy(&dev->config, params, sizeof(dev->config));
+    dev->config = *params;
     dev->inesc = 0U;
     dev->netdev.driver = &slip_driver;
 }

--- a/drivers/sx127x/sx127x.c
+++ b/drivers/sx127x/sx127x.c
@@ -61,7 +61,7 @@ void sx127x_setup(sx127x_t *dev, const sx127x_params_t *params)
 {
     netdev_t *netdev = (netdev_t*) dev;
     netdev->driver = &sx127x_driver;
-    memcpy(&dev->params, params, sizeof(sx127x_params_t));
+    dev->params = *params;
 }
 
 int sx127x_reset(const sx127x_t *dev)

--- a/drivers/tcs37727/tcs37727.c
+++ b/drivers/tcs37727/tcs37727.c
@@ -44,7 +44,7 @@ int tcs37727_init(tcs37727_t *dev, const tcs37727_params_t *params)
     assert(dev && params);
 
     /* initialize the device descriptor */
-    memcpy(&dev->p, params, sizeof(tcs37727_params_t));
+    dev->p = *params;
 
     /* setup the I2C bus */
     i2c_acquire(BUS);

--- a/drivers/tmp006/tmp006.c
+++ b/drivers/tmp006/tmp006.c
@@ -70,7 +70,7 @@ int tmp006_init(tmp006_t *dev, const tmp006_params_t *params)
     uint16_t tmp;
 
     /* initialize the device descriptor */
-    memcpy(&dev->p, params, sizeof(tmp006_params_t));
+    dev->p = *params;
 
     if (dev->p.rate > TMP006_CONFIG_CR_AS16) {
         LOG_ERROR("tmp006_init: invalid conversion rate!\n");

--- a/drivers/w5100/w5100.c
+++ b/drivers/w5100/w5100.c
@@ -118,7 +118,7 @@ void w5100_setup(w5100_t *dev, const w5100_params_t *params)
     dev->nd.context = dev;
 
     /* initialize the device descriptor */
-    memcpy(&dev->p, params, sizeof(w5100_params_t));
+    dev->p = *params;
 
     /* initialize the chip select pin and the external interrupt pin */
     spi_init_cs(dev->p.spi, dev->p.cs);

--- a/drivers/xbee/xbee.c
+++ b/drivers/xbee/xbee.c
@@ -483,7 +483,7 @@ void xbee_setup(xbee_t *dev, const xbee_params_t *params)
     dev->context = dev;
 
     /* set peripherals to use */
-    memcpy(&dev->p, params, sizeof(xbee_params_t));
+    dev->p = *params;
 
     /* initialize pins */
     if (dev->p.pin_reset != GPIO_UNDEF) {

--- a/examples/asymcute_mqttsn/main.c
+++ b/examples/asymcute_mqttsn/main.c
@@ -128,7 +128,7 @@ static int _topic_find(asymcute_topic_t *t, const char *name)
         if (asymcute_topic_is_reg(&_topics[i]) &&
             (strncmp(name, _topics[i].name, sizeof(_topics[i].name)) == 0)) {
             if (t) {
-                memcpy(t, &_topics[i], sizeof(asymcute_topic_t));
+                *t = _topics[i];
             }
             return 0;
         }

--- a/tests/driver_sx127x/main.c
+++ b/tests/driver_sx127x/main.c
@@ -376,7 +376,7 @@ void *_recv_thread(void *arg)
 
 int main(void)
 {
-    memcpy(&sx127x.params, sx127x_params, sizeof(sx127x_params));
+    sx127x.params = sx127x_params[0];
     netdev_t *netdev = (netdev_t*) &sx127x;
     netdev->driver = &sx127x_driver;
 


### PR DESCRIPTION
This commit is a collection of changes like this:
    memcpy(&dev->p, params, sizeof(hd44780_params_t));
into
    dev->p = *params;

In all these cases there is no good reason to use memcpy. The memcpy takes away
an opportunity for the compiler to check things. And the simple assignment is much
more readable.

Sorry for the long list, but I think it makes sense to do them all in one commit.