### PR TITLE
drivers: replace memset by simple assignments

### DIFF
--- a/drivers/dht/dht_saul.c
+++ b/drivers/dht/dht_saul.c
@@ -47,7 +47,8 @@ static int check_and_read(const void *dev, phydat_t *res, int16_t *val, uint8_t 
     }
 
     res->val[0] = *val;
-    memset(&res->val[1], 0, 2 * sizeof(int16_t));
+    res->val[1] = 0;
+    res->val[2] = 0;
     res->unit = unit;
     res->scale = -1;
     return 1;

--- a/drivers/hdc1000/hdc1000_saul.c
+++ b/drivers/hdc1000/hdc1000_saul.c
@@ -28,7 +28,8 @@ static int read_temp(const void *dev, phydat_t *res)
     if (hdc1000_read_cached((const hdc1000_t *)dev, &(res->val[0]), NULL) != HDC1000_OK) {
         return -ECANCELED;
     }
-    memset(&(res->val[1]), 0, 2 * sizeof(int16_t));
+    res->val[1] = 0;
+    res->val[2] = 0;
     res->unit = UNIT_TEMP_C;
     res->scale = -2;
 
@@ -40,7 +41,8 @@ static int read_hum(const void *dev, phydat_t *res)
     if (hdc1000_read_cached((const hdc1000_t *)dev, NULL, &(res->val[0])) != HDC1000_OK) {
         return -ECANCELED;
     }
-    memset(&(res->val[1]), 0, 2 * sizeof(int16_t));
+    res->val[1] = 0;
+    res->val[2] = 0;
     res->unit = UNIT_PERCENT;
     res->scale = -2;
 

--- a/drivers/isl29020/isl29020_saul.c
+++ b/drivers/isl29020/isl29020_saul.c
@@ -26,7 +26,8 @@
 static int read(const void *dev, phydat_t *res)
 {
     res->val[0] = (int16_t)isl29020_read((const isl29020_t *)dev);
-    memset(&(res->val[1]), 0, 2 * sizeof(int16_t));
+    res->val[1] = 0;
+    res->val[2] = 0;
     res->unit = UNIT_CD;
     res->scale = 0;
     return 1;

--- a/drivers/pir/pir_saul.c
+++ b/drivers/pir/pir_saul.c
@@ -29,7 +29,8 @@ static int read_occup(const void *dev, phydat_t *res) {
         /* Read failure */
         return -ECANCELED;
     }
-    memset(&(res->val[1]), 0, 2 * sizeof(int16_t));
+    res->val[1] = 0;
+    res->val[2] = 0;
     res->unit = UNIT_PERCENT;
     res->scale = -2;
     return 1;

--- a/drivers/saul/adc_saul.c
+++ b/drivers/saul/adc_saul.c
@@ -30,7 +30,8 @@ static int read_adc(const void *dev, phydat_t *res)
 {
     const saul_adc_params_t *params = *((const saul_adc_params_t **)dev);
     res->val[0] = adc_sample(params->line, params->res);
-    memset(&(res->val[1]), 0, 2 * sizeof(res->val[1]));
+    res->val[1] = 0;
+    res->val[2] = 0;
     /* Raw ADC reading has no unit */
     res->unit = UNIT_NONE;
     res->scale = 0;

--- a/drivers/saul/gpio_saul.c
+++ b/drivers/saul/gpio_saul.c
@@ -33,7 +33,8 @@ static int read(const void *dev, phydat_t *res)
 
     res->val[0] = (gpio_read(p->pin)) ? !inverted : inverted;
 
-    memset(&(res->val[1]), 0, 2 * sizeof(int16_t));
+    res->val[1] = 0;
+    res->val[2] = 0;
     res->unit = UNIT_BOOL;
     res->scale = 0;
     return 1;


### PR DESCRIPTION
A memset was used to clear two of the SAUL values in phydat_t::val
The change is to replace that by the following
    res->val[1] = 0;
    res->val[2] = 0;
which makes the code more obvious.