### PR TITLE
core/irq: fix 2 missing words in documentation

### DIFF
--- a/core/include/irq.h
+++ b/core/include/irq.h
@@ -30,7 +30,7 @@
 /**
  * @brief   This function sets the IRQ disable bit in the status register
  *
- * @return  Previous value of status register. The return value should not
+ * @return  Previous value of status register. The return value should not be
  *          interpreted as a boolean value. The actual value is only
  *          significant for irq_restore().
  *
@@ -41,7 +41,7 @@ unsigned irq_disable(void);
 /**
  * @brief   This function clears the IRQ disable bit in the status register
  *
- * @return  Previous value of status register. The return value should not
+ * @return  Previous value of status register. The return value should not be
  *          interpreted as a boolean value. The actual value is only
  *          significant for irq_restore().
  *


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

While reviewing #10720, I built and read a bit the Core documentation, and found that these typos return value if `irq_disable`/`irq_restore` functions.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Just build the documentation, e.g `make doc` and check the result.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Found while reviewing #10720

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
