### PR TITLE
boards/esp32-wroom-32: configure saul button as inverted

### DIFF
--- a/boards/esp32-olimex-evb/include/gpio_params.h
+++ b/boards/esp32-olimex-evb/include/gpio_params.h
@@ -41,7 +41,7 @@ static const  saul_gpio_params_t saul_gpio_params[] =
         .name = "BUT1",
         .pin = BUTTON0_PIN,
         .mode = GPIO_IN,
-        .flags = 0
+        .flags = SAUL_GPIO_INVERTED
     },
 };
 

--- a/boards/esp32-wroom-32/include/gpio_params.h
+++ b/boards/esp32-wroom-32/include/gpio_params.h
@@ -33,7 +33,7 @@ static const  saul_gpio_params_t saul_gpio_params[] =
         .name = "BOOT",
         .pin = BUTTON0_PIN,
         .mode = GPIO_IN,
-        .flags = 0
+        .flags = SAUL_GPIO_INVERTED
     },
 };
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR configures the saul gpio BOOT button of the esp32-wroom-32 board with the inverted flag.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

1. Build and flash the `examples/default` on the board:
```
$ make BOARD=esp32-wroom-32 -C examples/default flash term
```
2. Check the value returned by saul read is correct:
```
> saul read 0  (BOOT not pressed)
Reading from #0 (BOOT|SENSE_BTN)
Data:	          0
> saul read 0  (BOOT pressed)
Reading from #0 (BOOT|SENSE_BTN)
Data:	          1
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
