### PR TITLE
sock_dns: fix out-of-bound errors

### DIFF
--- a/sys/include/net/sock/dns.h
+++ b/sys/include/net/sock/dns.h
@@ -57,7 +57,14 @@ typedef struct {
 #define SOCK_DNS_PORT           (53)
 #define SOCK_DNS_RETRIES        (2)
 
-#define SOCK_DNS_MAX_NAME_LEN   (64U)       /* we're in embedded context. */
+/**
+ * @brief   Maximum expected address length
+ *
+ * @note    Derived from the length of an IPv6 address
+ */
+#define SOCK_DNS_MAX_ADDR_LEN   (16U)
+
+#define SOCK_DNS_MAX_NAME_LEN   (64U)   /* we're in embedded context. */
 #define SOCK_DNS_QUERYBUF_LEN   (sizeof(sock_dns_hdr_t) + 4 + SOCK_DNS_MAX_NAME_LEN)
 /** @} */
 
@@ -73,8 +80,8 @@ typedef struct {
  * This function will return the first DNS record it receives. IF both A and
  * AAAA are requested, AAAA will be preferred.
  *
- * @note @p addr_out needs to provide space for any possible result!
- *       (4byte when family==AF_INET, 16byte otherwise)
+ * @note @p addr_out needs to provide space for at least
+ *       @ref SOCK_DNS_ADDR_LEN_MAX byets
  *
  * @param[in]   domain_name     DNS name to resolve into address
  * @param[out]  addr_out        buffer to write result into


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Fixes #10739

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I compiled `tests/gnrc_sock_dns` with the following patch:

```diff
diff --git a/tests/gnrc_sock_dns/Makefile b/tests/gnrc_sock_dns/Makefile
index 4ef2c75..0b3824e 100644
--- a/tests/gnrc_sock_dns/Makefile
+++ b/tests/gnrc_sock_dns/Makefile
@@ -11,7 +11,11 @@ USEMODULE += sock_dns
 USEMODULE += gnrc_sock_udp
 USEMODULE += gnrc_ipv6_default
 USEMODULE += gnrc_ipv6_nib_dns
-USEMODULE += gnrc_netdev_default
+USEMODULE += ethos
+
+# ethos baudrate can be configured from make command
+ETHOS_BAUDRATE ?= 115200
+CFLAGS += -DETHOS_BAUDRATE=$(ETHOS_BAUDRATE) -DUSE_ETHOS_FOR_STDIO
 USEMODULE += auto_init_gnrc_netif
 
 USEMODULE += shell_commands
diff --git a/tests/gnrc_sock_dns/main.c b/tests/gnrc_sock_dns/main.c
index 52700fe..b8c2ad5 100644
--- a/tests/gnrc_sock_dns/main.c
+++ b/tests/gnrc_sock_dns/main.c
@@ -40,7 +40,7 @@ int main(void)
     uint8_t addr[16] = {0};
 
     puts("waiting for router advertisement...");
-    xtimer_usleep(1U*1000000);
+    xtimer_usleep(5U*1000000);
 
     /* print network addresses */
     puts("Configured network interfaces:");
```

flashed a `samr21-xpro` (alternatively `pba-d-01-kw2x` as described in #10739 is also possible), and connected an ethos terminal to the node

```
sudo ./dist/tools/ethos/start_network.sh /dev/ttyACM0 tap0 affe:abe::/48
```

I reset the node to get its link-local address for later.

Then I started a RADVD with the following config:

```
interface tap0 {
        AdvSendAdvert on;
        MinRtrAdvInterval 3;
        MaxRtrAdvInterval 10;
        prefix affe:abe::/64 {
                AdvOnLink off;
                AdvAutonomous on;
                AdvRouterAddr on;
        };
        RDNSS <a global address on your host> {
            AdvRDNSSLifetime 60;
        };
};
```

and reconfigured the correct route to the host (the preconfigured route by `start_network.sh` does not work, since uhcpc is not available on the node):

```sh
sudo ip route del affe:abe::/64
sudo ip route add affe:abe::/64 via "<link-local address of node>" dev tap0
```

Then I start the exploit script described in #10739 (or provided by https://github.com/beduino-project/exploit-riot-dns) and reset the node again to start the test. Without this PR the node will crash (note that the exploit described in #10739 does not work but only crashes the node since due to the usage of `ethos` the binary is different), withit it will just report `error resolving example.org`.

I also tested expected operation as described in the application's README.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Fixes #10739.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
