### PR TITLE
sys: stdio_null: add null driver

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -403,7 +403,7 @@ ifneq (,$(filter newlib,$(USEMODULE)))
   ifeq (,$(filter newlib_syscalls_%,$(USEMODULE)))
     USEMODULE += newlib_syscalls_default
   endif
-  ifeq (,$(filter stdio_rtt stdio_cdc_acm,$(USEMODULE)))
+  ifeq (,$(filter stdio_cdc_acm stdio_null stdio_rtt,$(USEMODULE)))
     USEMODULE += stdio_uart
   endif
 endif

--- a/sys/stdio_null/Makefile
+++ b/sys/stdio_null/Makefile
@@ -1,0 +1,5 @@
+ifeq ($(DEVELHELP),1)
+  $(warning STDIO disabled via stdio_null, but DEVELHELP enabled)
+endif
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/stdio_null/stdio_null.c
+++ b/sys/stdio_null/stdio_null.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2019 Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys
+ * @{
+ *
+ * @file
+ * @brief       STDIO null driver
+ *
+ * This file provides a null driver for STDIO that does not depend on anything.
+ *
+ * @author      Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * @}
+ */
+
+#include "stdio_base.h"
+
+#if MODULE_VFS
+#include "vfs.h"
+#endif
+
+#define ENABLE_DEBUG 0
+#include "debug.h"
+
+void stdio_init(void)
+{
+#if MODULE_VFS
+    vfs_bind_stdio();
+#endif
+}
+
+ssize_t stdio_read(void* buffer, size_t count)
+{
+    (void) buffer;
+    (void) count;
+
+    return 0;
+}
+
+ssize_t stdio_write(const void* buffer, size_t len)
+{
+    (void) buffer;
+    (void) len;
+
+    return 0;
+}

--- a/tests/minimal/Makefile
+++ b/tests/minimal/Makefile
@@ -5,4 +5,6 @@ CFLAGS += -DNDEBUG -DLOG_LEVEL=LOG_NONE
 
 DISABLE_MODULE += auto_init
 
+USEMODULE += stdio_null
+
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
### Contribution description
This PR provides a null driver for STDIO, so that it doesn't depend on UART or RTT. 

I created this to test #10215, where the bootloader easily exceeds the default 4KiB on EFM32 targets, because due to `periph_uart` still being included (which includes other big stuff). With this null driver, I could save an additional 2KiB. This makes sense for something like a bootloader, but anything that depends on reading from UART will break.

I've added a warning with `DEVELHELP=1`, because I assume you enabled it to show some output.

It took me five minutes to create, so if this doesn't make any sense, that I don't feel bad ;-)

### Testing procedure
Add `USEMODULE=stdio_null` to any application to see what it saves. In particular, add this to `bootloaders/riotboot/Makefile` and observe that `tests/riotboot` still works.

Here is an example for `tests/minimal`.

As usual:

```shell
basilfx:minimal/ (feature/stdio_null) $ BOARD=samr21-xpro make -j8
Building application "tests_minimal" for "samr21-xpro" with MCU "samd21".

"make" -C boards/samr21-xpro
"make" -C core
"make" -C cpu/samd21
"make" -C drivers
"make" -C sys
"make" -C cpu/cortexm_common
"make" -C cpu/sam0_common
"make" -C cpu/samd21/periph
"make" -C sys/isrpipe
"make" -C drivers/periph_common
"make" -C sys/newlib_syscalls_default
"make" -C cpu/sam0_common/periph
"make" -C cpu/cortexm_common/periph
"make" -C sys/pm_layered
"make" -C sys/stdio_uart
"make" -C sys/tsrb
   text	   data	    bss	    dec	    hex	filename
   3260	     36	   2604	   5900	   170c	tests/minimal/bin/samr21-xpro/tests_minimal.elf
```

With `USEMODULE=stdio_null`:

```shell
basilfx:minimal/ (feature/stdio_null) $ USEMODULE=stdio_null BOARD=samr21-xpro make -j8
Building application "tests_minimal" for "samr21-xpro" with MCU "samd21".

"make" -C boards/samr21-xpro
"make" -C core
"make" -C cpu/samd21
"make" -C drivers
"make" -C sys
"make" -C cpu/cortexm_common
"make" -C drivers/periph_common
"make" -C sys/isrpipe
"make" -C cpu/sam0_common
"make" -C cpu/sam0_common/periph
"make" -C sys/newlib_syscalls_default
"make" -C sys/pm_layered
"make" -C cpu/samd21/periph
"make" -C sys/stdio_null
"make" -C sys/stdio_uart
"make" -C sys/tsrb
"make" -C cpu/cortexm_common/periph
   text	   data	    bss	    dec	    hex	filename
   2232	     16	   2524	   4772	   12a4	tests/minimal/bin/samr21-xpro/tests_minimal.elf
```

With `DEVELHELP=1 USEMODULE=stdio_null`:

```shell
basilfx:minimal/ (feature/stdio_null) $ DEVELHELP=1 USEMODULE=stdio_null BOARD=samr21-xpro make -j8
Building application "tests_minimal" for "samr21-xpro" with MCU "samd21".

"make" -C boards/samr21-xpro
"make" -C core
"make" -C cpu/samd21
"make" -C drivers
"make" -C sys
"make" -C cpu/cortexm_common
"make" -C cpu/sam0_common
"make" -C cpu/sam0_common/periph
"make" -C sys/newlib_syscalls_default
"make" -C drivers/periph_common
"make" -C cpu/samd21/periph
"make" -C sys/pm_layered
"make" -C cpu/cortexm_common/periph
"make" -C sys/stdio_null
Makefile:2: STDIO disabled via stdio_null, but DEVELHELP enabled
   text    data     bss     dec     hex filename
  10088     120    2532   12740    31c4 tests/minimal/bin/samr21-xpro/tests_minimal.elf
```

### Issues/PRs references

#9503
#10215