### PR TITLE
gnrc_netif_*: use the `gnrc_netif_t::pid` member instead of the pid of the current thread in netif header

### DIFF
--- a/sys/net/gnrc/netif/ethernet/gnrc_netif_ethernet.c
+++ b/sys/net/gnrc/netif/ethernet/gnrc_netif_ethernet.c
@@ -226,7 +226,7 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
         gnrc_netif_hdr_init(netif_hdr->data, ETHERNET_ADDR_LEN, ETHERNET_ADDR_LEN);
         gnrc_netif_hdr_set_src_addr(netif_hdr->data, hdr->src, ETHERNET_ADDR_LEN);
         gnrc_netif_hdr_set_dst_addr(netif_hdr->data, hdr->dst, ETHERNET_ADDR_LEN);
-        ((gnrc_netif_hdr_t *)netif_hdr->data)->if_pid = thread_getpid();
+        ((gnrc_netif_hdr_t *)netif_hdr->data)->if_pid = netif->pid;
 
         DEBUG("gnrc_netif_ethernet: received packet from %02x:%02x:%02x:%02x:%02x:%02x "
               "of length %d\n",

--- a/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c
+++ b/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c
@@ -107,7 +107,7 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
             gnrc_netif_hdr_t *hdr = netif_snip->data;
             hdr->lqi = rx_info.lqi;
             hdr->rssi = rx_info.rssi;
-            hdr->if_pid = thread_getpid();
+            hdr->if_pid = netif->pid;
             LL_APPEND(pkt, netif_snip);
         }
         else {


### PR DESCRIPTION
### Contribution description

Due to the interrupt context problem, the receive sequence of defined as follows.

![gnrc_netif_1](https://user-images.githubusercontent.com/31932013/50937496-3cc7ce00-1474-11e9-97e0-517d56419ca2.png)

It is not an UML compliant message sequence chart by intention. Activities show the active context.

In `netif::_recv`, the `thread_getpid` function is used to set the `netif` pid in `gnrc_netif_hdr`. This works since `_recv` is executed in the `netif` thread context.

However, if the `netdev` polls for new data using its own thread context, data are not fetched in interrupt context and there is no necessity to send an `NETDEV_EVENT_ISR` event to the `netif` first. Rather, `netdev` can call the event callback of `netif` with NETDEV_EVENT_RX_COMPLETE directly.

![gnrc_netif_2](https://user-images.githubusercontent.com/31932013/50938192-63d3cf00-1477-11e9-9707-00380e318b3f.png)

This has two advantages:
- it is faster
- there is no need for an additional buffer in `netdev`, data can be copied directly from hardware to the `netif` buffer.

However, since `netif::_recv` is executed in the `netdev` thread context, the `thread_getpid` function returns the wrong pid.

Since the `netif` has a member `pid` it should be used here.  Both approaches are possible with the change in this PR

### Testing procedure

Use any board with Ethernet interface or IEEE802.15.4 interfaces and use `example/gnrc_networking` to ping them.