### PR TITLE
make: handle disabled default modules before dependencies

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -286,10 +286,11 @@ ifneq ($(GNRC_NETIF_NUMOF),1)
   CFLAGS += -DGNRC_NETIF_NUMOF=$(GNRC_NETIF_NUMOF)
 endif
 
+# handle removal of default modules
+USEMODULE += $(filter-out $(DISABLE_MODULE), $(DEFAULT_MODULE))
+
 # process dependencies
 include $(RIOTBASE)/Makefile.dep
-
-USEMODULE += $(filter-out $(DISABLE_MODULE), $(DEFAULT_MODULE))
 
 ifeq ($(strip $(MCU)),)
 	MCU = $(CPU)


### PR DESCRIPTION
### Contribution description

Currently, default modules can be disabled by adding the name to ```DISABLE_MODULE```.
Unfortunately, this gets parsed *after* resolving the dependencies.

This makes it impossible to disable e.g., stdio_uart and implicitly periph/uart. The dependency parsing would select periph/uart (as it is dependend on stdio_uart), but later stdio_uart would be dropped, leaking the dependency.

This PR moves ```DISABLE_MODULE``` before dependency resolution.

### Testing procedure

Correct compilation of all applications should suffice.

### Issues/PRs references

#10741