### PR TITLE
cpu: make default idle/main stacksizes configurable on all archs

### DIFF
--- a/cpu/atmega32u4/include/cpu_conf.h
+++ b/cpu/atmega32u4/include/cpu_conf.h
@@ -39,7 +39,9 @@ extern "C" {
 #define THREAD_STACKSIZE_DEFAULT   (256)
 #endif
 
+#ifndef THREAD_STACKSIZE_IDLE
 #define THREAD_STACKSIZE_IDLE      (128)
+#endif
 /** @} */
 
 #ifdef __cplusplus

--- a/cpu/atmega_common/include/cpu_conf.h
+++ b/cpu/atmega_common/include/cpu_conf.h
@@ -48,7 +48,9 @@ extern "C" {
 /* keep THREAD_STACKSIZE_IDLE > THREAD_EXTRA_STACKSIZE_PRINTF
  * to avoid not printing of debug in interrupts
  */
+#ifndef THREAD_STACKSIZE_IDLE
 #define THREAD_STACKSIZE_IDLE      (128)
+#endif
 /** @} */
 
 /**

--- a/cpu/esp32/include/cpu_conf.h
+++ b/cpu/esp32/include/cpu_conf.h
@@ -38,8 +38,12 @@ extern "C" {
  * @{
  */
 #define THREAD_EXTRA_STACKSIZE_PRINTF (1024)
+#ifndef THREAD_STACKSIZE_DEFAULT
 #define THREAD_STACKSIZE_DEFAULT      (2048)
+#endif
+#ifndef THREAD_STACKSIZE_IDLE
 #define THREAD_STACKSIZE_IDLE         (2048)
+#endif
 /** @} */
 
 /**

--- a/cpu/lpc2387/include/cpu_conf.h
+++ b/cpu/lpc2387/include/cpu_conf.h
@@ -48,7 +48,9 @@ extern "C" {
 #define THREAD_STACKSIZE_DEFAULT   (1024)
 #endif
 
+#ifndef THREAD_STACKSIZE_IDLE
 #define THREAD_STACKSIZE_IDLE      (160)
+#endif
 /** @} */
 
 /**
@@ -93,7 +95,9 @@ extern "C" {
  * @brief   Stack size used for the interrupt (ISR) stack
  * @{
  */
+#ifndef ISR_STACKSIZE
 #define ISR_STACKSIZE                   (400)
+#endif
 /** @} */
 
 /**

--- a/sys/ps/ps.c
+++ b/sys/ps/ps.c
@@ -75,7 +75,7 @@ void ps(void)
 #endif
            "state");
 
-#if defined(DEVELHELP) && defined(ISR_STACKSIZE)
+#if defined(DEVELHELP) && ISR_STACKSIZE
     int isr_usage = thread_isr_stack_usage();
     void *isr_start = thread_isr_stack_start();
     void *isr_sp = thread_isr_stack_pointer();

--- a/tests/minimal/Makefile
+++ b/tests/minimal/Makefile
@@ -8,4 +8,9 @@ DISABLE_MODULE += test_utils_interactive_sync
 
 USEMODULE += stdio_null
 
+# adjust stack sizes to very small values
+ifneq (native,$(BOARD))
+  CFLAGS += -DTHREAD_STACKSIZE_MAIN=256 -DTHREAD_STACKSIZE_IDLE=128
+endif
+
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
### Contribution description

Most platforms allow overriding the default idle/main stacksizes. This PR adds that functionality to the missing ones.

In addition, a commit makes use of this functionality to reduce tests/minimal RAM usage.

### Testing procedure

Successful compilation should suffice.