### PR TITLE
cpu/lpc2387: remove newlib dependencies

### DIFF
--- a/cpu/arm7_common/bootloader.c
+++ b/cpu/arm7_common/bootloader.c
@@ -28,34 +28,36 @@
 #include <stdlib.h>
 #include "thread.h"
 
+#include "log.h"
+
 void FIQ_Routine(void)   __attribute__((interrupt("FIQ")));
 //void SWI_Routine (void)   __attribute__((interrupt("SWI")));
 void UNDEF_Routine(void) __attribute__((interrupt("UNDEF")));
 
 void IRQ_Routine(void)
 {
-    printf("Kernel Panic,\nEarly IRQ call\n");
+    LOG_ERROR("Kernel Panic,\nEarly IRQ call\n");
 
     while (1) {};
 }
 /*-----------------------------------------------------------------------------------*/
 void FIQ_Routine(void)
 {
-    printf("Kernel Panic,\nEarly FIQ call\n");
+    LOG_ERROR("Kernel Panic,\nEarly FIQ call\n");
 
     while (1) {};
 }
 /*-----------------------------------------------------------------------------------*/
 void SWI_Routine(void)
 {
-    printf("Kernel Panic,\nEarly SWI call\n");
+    LOG_ERROR("Kernel Panic,\nEarly SWI call\n");
 
     while (1) {};
 }
 /*-----------------------------------------------------------------------------------*/
 void DEBUG_Routine(void)
 {
-    printf("DEBUG hit.");
+    LOG_ERROR("DEBUG hit.");
 
     while (1) {};
 }
@@ -75,7 +77,7 @@ void abtorigin(const char *vector, unsigned long *lnk_ptr1)
     __asm__ __volatile__("mov %0, sp" : "=r"(sp));              // copy sp
     __asm__ __volatile__("msr cpsr_c, %0" :: "r"(cpsr));        // switch back to abt mode
 
-    printf("#!%s abort at %p (0x%08lX) originating from %p (0x%08lX) in mode 0x%X\n",
+    LOG_ERROR("#!%s abort at %p (0x%08lX) originating from %p (0x%08lX) in mode 0x%X\n",
            vector, (void *)lnk_ptr1, *(lnk_ptr1), (void *)lnk_ptr2, *(lnk_ptr2), spsr
           );
 

--- a/cpu/arm7_common/bootloader.c
+++ b/cpu/arm7_common/bootloader.c
@@ -81,7 +81,7 @@ void abtorigin(const char *vector, unsigned long *lnk_ptr1)
            vector, (void *)lnk_ptr1, *(lnk_ptr1), (void *)lnk_ptr2, *(lnk_ptr2), spsr
           );
 
-    exit(1);
+    while (1) {};
 }
 /*-----------------------------------------------------------------------------------*/
 void UNDEF_Routine(void)
@@ -96,7 +96,7 @@ void UNDEF_Routine(void)
         abtorigin("undef", lnk_ptr);
     }
 
-    exit(1);
+    while (1) {};
 }
 /*-----------------------------------------------------------------------------------*/
 void PABT_Routine(void)
@@ -111,7 +111,7 @@ void PABT_Routine(void)
         abtorigin("pabt", lnk_ptr);
     }
 
-    exit(1);
+    while (1) {};
 }
 /*-----------------------------------------------------------------------------------*/
 void DABT_Routine(void)
@@ -126,7 +126,7 @@ void DABT_Routine(void)
         abtorigin("data", lnk_ptr);
     }
 
-    exit(1);
+    while (1) {};
 }
 /*-----------------------------------------------------------------------------------*/
 static inline void


### PR DESCRIPTION
### Contribution description

Currently, the boot code on lpc2387 hard-codes the use of ```printf()``` and uses ```exit()```, both inducing a dependency to libc.

This PR replaces ```printf()``` with ```LOG_ERROR()``` and ```exit(1)``` with an endless loop.

### Testing procedure

Run basic tests on lpc2387.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
