### PR TITLE
tests/gnrc_udp: Fixed typo in Makefile

### DIFF
--- a/examples/gnrc_networking/Makefile
+++ b/examples/gnrc_networking/Makefile
@@ -67,7 +67,7 @@ ifneq (,$(filter cc110x,$(USEMODULE)))          # radio is cc110x sub-GHz
 else
   ifneq (,$(filter at86rf212b,$(USEMODULE)))    # radio is IEEE 802.15.4 sub-GHz
     DEFAULT_CHANNEL ?= 5
-    FLAGS += -DIEEE802154_DEFAULT_SUBGHZ_CHANNEL=$(DEFAULT_CHANNEL)
+    CFLAGS += -DIEEE802154_DEFAULT_SUBGHZ_CHANNEL=$(DEFAULT_CHANNEL)
   else                                          # radio is IEEE 802.15.4 2.4 GHz
     DEFAULT_CHANNEL ?= 26
     CFLAGS += -DIEEE802154_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)

--- a/tests/gnrc_udp/Makefile
+++ b/tests/gnrc_udp/Makefile
@@ -31,7 +31,7 @@ ifneq (,$(filter cc110x,$(USEMODULE)))          # radio is cc110x sub-GHz
 else
   ifneq (,$(filter at86rf212b,$(USEMODULE)))    # radio is IEEE 802.15.4 sub-GHz
     DEFAULT_CHANNEL ?= 5
-    FLAGS += -DIEEE802154_DEFAULT_SUBGHZ_CHANNEL=$(DEFAULT_CHANNEL)
+    CFLAGS += -DIEEE802154_DEFAULT_SUBGHZ_CHANNEL=$(DEFAULT_CHANNEL)
   else                                          # radio is IEEE 802.15.4 2.4 GHz
     DEFAULT_CHANNEL ?= 26
     CFLAGS += -DIEEE802154_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)


### PR DESCRIPTION
### Contribution description

As little as the title suggests

### Testing procedure

Check if the correct default channel is applied on `at86rf212b`.

### Issues/PRs references

None