### PR TITLE
nanocoap: fix server-side option_count overflow

### DIFF
--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -111,6 +111,9 @@ int coap_parse(coap_pkt_t *pkt, uint8_t *buf, size_t len)
                 DEBUG("optpos option_nr=%u %u\n", (unsigned)option_nr, (unsigned)optpos->offset);
                 optpos++;
                 option_count++;
+                if (option_count >= NANOCOAP_NOPTS_MAX) {
+                    return -ENOMEM;
+                }
             }
 
             pkt_pos += option_len;


### PR DESCRIPTION
### Contribution description

nanocoap limits the number of options it parses, but didn't check if that limit was reached when parsing a packet. (See report in #10753).

This PR provides a fix. It also adds a unittest that exposes the flaw.

Fixes #10753.

### Testing procedure

Run unittests without uppermost commit. The nanocoap test should crash on native. Run again with topmost commit. Tests should succeed.

### Issues/PRs references

See #10753.