### PR TITLE
drivers/ltc4150: (Re-)implemented driver for the LTC4150 coulomb counter

### DIFF
--- a/boards/msba2/Makefile.dep
+++ b/boards/msba2/Makefile.dep
@@ -5,5 +5,6 @@ ifneq (,$(filter netdev_default gnrc_netdev_default,$(USEMODULE)))
 endif
 
 ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += ltc4150
   USEMODULE += sht11
 endif

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -273,6 +273,16 @@ ifneq (,$(filter lsm6dsl,$(USEMODULE)))
   USEMODULE += xtimer
 endif
 
+ifneq (,$(filter ltc4150_bidirectional,$(USEMODULE)))
+  USEMODULE += ltc4150
+endif
+
+ifneq (,$(filter ltc4150,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_gpio
+  FEATURES_REQUIRED += periph_gpio_irq
+  USEMODULE += xtimer
+endif
+
 ifneq (,$(filter mag3110,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
 endif

--- a/drivers/Makefile.include
+++ b/drivers/Makefile.include
@@ -162,6 +162,10 @@ ifneq (,$(filter lsm6dsl,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/lsm6dsl/include
 endif
 
+ifneq (,$(filter ltc4150,$(USEMODULE)))
+  USEMODULE_INCLUDES += $(RIOTBASE)/drivers/ltc4150/include
+endif
+
 ifneq (,$(filter mag3110,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/mag3110/include
 endif

--- a/drivers/include/ltc4150.h
+++ b/drivers/include/ltc4150.h
@@ -1,0 +1,283 @@
+/*
+ * Copyright 2019 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_ltc4150 LTC4150 coulomb counter
+ * @ingroup     drivers_sensors
+ * @brief       Driver for the Linear Tech LTC4150 Coulomb Counter
+ *              (a.k.a. battery gauge sensor or power consumption sensor)
+ *
+ * # Wiring the LTC4150
+ * Hint: M Grusin thankfully created an
+ * [open hardware breakout board](https://cdn.sparkfun.com/datasheets/BreakoutBoards/LTC4150_BOB_v10.pdf).
+ * As a result, virtually all LTC4150 breakout boards are using this schematic.
+ * Whenever this documentation refers to a breakout board, this open hardware
+ * board is meant. Of course, this driver works with the "bare" LTC4150 as well.
+ *
+ * Please note that this driver works interrupt driven and does not clear the
+ * signal. Thus, the /CLR and /INT pins on the LTC4150 need to be connected
+ * (in case of the breakout board: close solder jumper SJ1), so that the signal
+ * is automatically cleared.
+ *
+ * Hint: The breakout board uses external pull up resistors on /INT, POL and
+ * /SHDN. Therefore /SHDN can be left unconnected and no internal pull ups are
+ * required for /INT and POL. In case your board uses 3.3V logic the solder
+ * jumpers SJ2 and SJ3 have to be closed, in case of 5V they have to remain
+ * open. Connect the VIO pin to the logic level, GND to ground, IN+ and IN- to
+ * the power supply and use OUT+ and OUT- to power your board.
+ *
+ * In the easiest case only the /INT pin needs to be connected to a GPIO,
+ * and (in case of external pull ups) /SHDN and POL can be left unconnected.
+ * The GPIO /INT is connected to support for interrupts, /SHDN and POL
+ * (if connected) do not require interrupt support.
+ *
+ * In case a battery is used the POL pin connected to another GPIO. This allows
+ * to distinguish between charge drawn from the battery and charge transferred
+ * into the battery (used to load it).
+ *
+ * In case support to power off the LTC4150 is desired, the /SHDN pin needs to
+ * be connected to a third GPIO.
+ *
+ * # Things to keep in mind
+ * The LTC4150 creates pulses with a frequency depending on the current drawn.
+ * Thus, more interrupts need to be handled when more current is drawn, which
+ * in turn increases system load (and power consumption). The interrupt service
+ * routing is quite short and even when used outside of specification less than
+ * 20 ticks per second will occur. Hence, this effect should hopefully be
+ * negligible.
+ *
+ * @{
+ *
+ * @file
+ * @brief       LTC4150 coulomb counter
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ */
+
+#ifndef LTC4150_H
+#define LTC4150_H
+
+#include <stdint.h>
+
+#include "mutex.h"
+#include "periph/gpio.h"
+#include "xtimer.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Configuration flags of the LTC4150 coulomb counter
+ */
+enum {
+    /**
+     * @brief External pull on the /INT pin is present
+     */
+    LTC4150_INT_EXT_PULL_UP = 0x01,
+    /**
+     * @brief External pull on the /POL pin is present
+     */
+    LTC4150_POL_EXT_PULL_UP = 0x02,
+    /**
+     * @brief External pull on the /INT *and* the /POL pin is present
+     */
+    LTC4150_EXT_PULL_UP = LTC4150_INT_EXT_PULL_UP | LTC4150_POL_EXT_PULL_UP,
+};
+
+/**
+ * @brief Enumeration of directions in which the charge can be transferred
+ */
+typedef enum {
+    LTC4150_CHARGE,             /**< The battery is charged */
+    LTC4150_DISCHARGE,          /**< Charge is drawn from the battery */
+} ltc4150_dir_t;
+
+/**
+ * @brief LTC4150 coulomb counter
+ */
+typedef struct ltc4150_dev ltc4150_dev_t;
+
+/**
+ * @brief Interface to allow recording of the drawn current in a user defined
+ *        resolution
+ *
+ * @note  Keep in mind that the data recording may be performed by the CPU of
+ *        the system to monitor - thus keep power consumption for the recording
+ *        low!
+ *
+ * The LTC4150 driver will only track total charge transferred (separately for
+ * charging in discharging direction). However, there are use cases that
+ * required more precise data recording, e.g. a rolling average of the last
+ * minute. This interface allows application developers to implement the ideal
+ * trade-off between RAM, ROM and runtime overhead for the data recording and
+ * the level of information they require.
+ */
+typedef struct {
+    /**
+     * @brief   Function to call on every pulse received from the LTC4150
+     * @warning This function is called in interrupt context
+     *
+     * @param[in] dev       The device the pulse was received from
+     * @param[in] dir       Direction in which the charge is transferred
+     * @param[in] now_usec  The system time the pulse was received in µs
+     * @param[in] arg       (Optional) argument for this callback
+     */
+    void (*pulse)(ltc4150_dev_t *dev, ltc4150_dir_t dir, uint64_t now_usec, void *arg);
+    /**
+     * @brief   Function to call upon driver initialization or reset
+     *
+     * @see ltc4150_init
+     * @see ltc4150_reset_counters
+     *
+     * @param[in] dev       The LTC4150 device to monitor
+     * @param[in] now_usec  The system time the pulse was received in µs
+     * @param[in] arg       (Optional) argument for this callback
+     */
+    void (*reset)(ltc4150_dev_t *dev, uint64_t now_usec, void *arg);
+} ltc4150_recorder_t;
+
+/**
+ * @brief Parameters required to set up the LTC4150 coulomb counter
+ */
+typedef struct {
+    /**
+     * @brief Pin going LOW every time a specific charge is drawn, labeled INT
+     */
+    gpio_t interrupt;
+    /**
+     * @brief Pin indicating (dis-)charging, labeled POL
+     *
+     * Set this pin to `GPIO_UNDEF` to tread every pulse as discharging. This
+     * pin is pulled low by the LTC4150 in case the battery is discharging.
+     */
+    gpio_t polarity;
+    /**
+     * @brief Pin to power off the LTC4150 coulomb counter, labeled SHDN
+     *
+     * Set this pin to `GPIO_UNDEF` if the SHDN pin is not connected to the MCU
+     */
+    gpio_t shutdown;
+    /**
+     * @brief Pulse per ampere hour of charge
+     *
+     * pulses = 3600 * 32.55 * R
+     *
+     * Where R is the resistance (in Ohm) between the SENSE+ and SENSE- pins.
+     * E.g. the MSBA2 has 0.390 Ohm (==> 45700 pulses), while most breakout
+     * boards for the LTC4150 have 0.050 Ohm (==> 5859 pulses).
+     */
+    uint16_t pulses_per_ah;
+    /**
+     * @brief Configuration flags controlling if inter pull ups are required
+     *
+     * Most [breakout boards](https://cdn.sparkfun.com/datasheets/BreakoutBoards/LTC4150_BOB_v10.pdf)
+     * and the MSBA2 board use external pull up resistors, so no internal pull
+     * ups are required. Clear the flags to use internal pull ups instead.
+     */
+    uint16_t flags;
+    /**
+     * @brief `NULL` or a `NULL`-terminated array of data recorders
+     * @pre   If not `NULL`, the last element of the array must be `NULL`
+     */
+    ltc4150_recorder_t **recorders;
+    /**
+     * @brief `NULL` or an array of the user defined data for each recorder
+     * @pre   If @see ltc4150_params_t::recorders is not `NULL`, this must point
+     *        to an array of `void`-Pointers of the same length.
+     * @note  Unlike @see ltc4150_param_t::callback, this array does not need to
+     *        be `NULL`-terminated
+     */
+    void **recorder_data;
+} ltc4150_params_t;
+
+/**
+ * @brief LTC4150 coulomb counter
+ */
+struct ltc4150_dev {
+    ltc4150_params_t params;    /**< Parameter of the LTC4150 coulomb counter */
+    uint32_t start_sec;         /**< Time stamp when started counting */
+    uint32_t last_update_sec;   /**< Time stamp of last pulse */
+    uint32_t charged;           /**< # of pulses for charging (POL=high) */
+    uint32_t discharged;        /**< # of pulses for discharging (POL=low) */
+};
+
+/**
+ * @brief             Initialize the LTC4150 driver
+ *
+ * @param  dev        Device to initialize
+ * @param  params     Information on how the LTC4150 is conntected
+ *
+ * @retval  0         Success
+ * @retval -EINVAL    Called with invalid argument(s)
+ * @retval -EIO       IO failure (`gpio_init()`/`gpio_init_int()` failed)
+ */
+int ltc4150_init(ltc4150_dev_t *dev, const ltc4150_params_t *params);
+
+/**
+ * @brief             Clear current counters of the given LTC4150 device
+ * @param dev         The LTC4150 device to clear current counters from
+ *
+ * @retval 0          Success
+ * @retval -EINVAL    Called with an invalid argument
+ */
+int ltc4150_reset_counters(ltc4150_dev_t *dev);
+
+/**
+ * @brief             Disable the interrupt handler and turn the chip off
+ *
+ * @param  dev        Previously initialized device to power off
+ *
+ * @retval  0         Success
+ * @retval -EINVAL    Called with invalid argument(s)
+ *
+ * The driver can be reinitialized to power on the LTC4150 chip again
+ */
+int ltc4150_shutdown(ltc4150_dev_t *dev);
+
+/**
+ * @brief                  Get the measured charge since boot or last reset in
+ *                         millicoulomb
+ *
+ * @param dev              The LTC4150 device to read data from
+ * @param[out] charged     The charge transferred in charging direction
+ * @param[out] discharged  The charge transferred in discharging direction
+ *
+ * @retval 0                Success
+ * @retval -EINVAL          Called with an invalid argument
+ *
+ * Passing `NULL` for `charged` or `discharged` is allowed, if only one
+ * information is of interest.
+ */
+int ltc4150_charge(ltc4150_dev_t *dev, uint32_t *charged, uint32_t *discharged);
+
+/**
+ * @brief             Get the average current drawn in E-01 milliampere
+ *
+ * This will return the average current drawn since boot or last reset until the
+ * last pulse from the LTC4150 was received. The value might thus be a bit
+ * outdated (0.8 seconds for the breakout board and a current of 100mA, 79
+ * seconds for a current of 1mA).
+ *
+ * @param dev         The LTC4150 device to read data from
+ * @param[out] dest   Store the average current drawn in E-01 milliampere here
+ *
+ * @retval 0          Success
+ * @retval -EINVAL    Called with an invalid argument
+ * @retval -EAGAIN    Called before enough data samples have been acquired.
+ *                    (Wait for at least one second or one pulse from the
+                      LTC4150, whichever takes longer.)
+ */
+int ltc4150_avg_current(ltc4150_dev_t *dev, int16_t *dest);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LTC4150_H */
+/** @} */

--- a/drivers/include/saul.h
+++ b/drivers/include/saul.h
@@ -99,6 +99,8 @@ enum {
     SAUL_SENSE_OCCUP    = 0x91,     /**< sensor: occupancy */
     SAUL_SENSE_PROXIMITY= 0x92,     /**< sensor: proximity */
     SAUL_SENSE_RSSI     = 0x93,     /**< sensor: RSSI */
+    SAUL_SENSE_CHARGE   = 0x94,     /**< sensor: coulomb counter */
+    SAUL_SENSE_CURRENT  = 0x95,     /**< sensor: ammeter */
     SAUL_CLASS_ANY      = 0xff      /**< any device - wildcard */
     /* extend this list as needed... */
 };

--- a/drivers/ltc4150/Makefile
+++ b/drivers/ltc4150/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/ltc4150/include/ltc4150_params.h
+++ b/drivers/ltc4150/include/ltc4150_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "ltc4150.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -61,11 +62,30 @@ extern "C" {
 /**@}*/
 
 /**
+ * @name    Set default SAUL info text for the LTC4150
+ * @{
+ */
+#ifndef LTC4150_SAULINFO
+#define LTC4150_SAULINFO              { .name = "LTC4150 charge" }, \
+                                      { .name = "LTC4150 average current" }
+#endif
+
+/**@}*/
+
+/**
  * @brief   Configure LTC4150 devices
  */
 static const ltc4150_params_t ltc4150_params[] =
 {
     LTC4150_PARAMS
+};
+
+/**
+ * @brief   Allocate and configure entries to the SAUL registry
+ */
+static const saul_reg_info_t ltc4150_saul_info[] =
+{
+    LTC4150_SAULINFO
 };
 
 #ifdef __cplusplus

--- a/drivers/ltc4150/include/ltc4150_params.h
+++ b/drivers/ltc4150/include/ltc4150_params.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2019 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_ltc4150
+ *
+ * @{
+ * @file
+ * @brief       Default configuration for LTC4150 coulomb counters
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ */
+
+#ifndef LTC4150_PARAMS_H
+#define LTC4150_PARAMS_H
+
+#include "board.h"
+#include "ltc4150.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Set default configuration parameters for the LTC4150
+ * @{
+ */
+#ifndef LTC4150_PARAM_INT
+#define LTC4150_PARAM_INT             (GPIO_PIN(0, 4))
+#endif
+#ifndef LTC4150_PARAM_POL
+#define LTC4150_PARAM_POL             (GPIO_UNDEF)
+#endif
+#ifndef LTC4150_PARAM_SHUTDOWN
+#define LTC4150_PARAM_SHUTDOWN        (GPIO_PIN(0, 5))
+#endif
+#ifndef LTC4150_PARAM_PULSES
+#define LTC4150_PARAM_PULSES          (45700U)
+#endif
+#ifndef LTC4150_PARAM_FLAGS
+#define LTC4150_PARAM_FLAGS           LTC4150_EXT_PULL_UP
+#endif
+#ifndef LTC4150_PARAM_RECS
+#define LTC4150_PARAM_RECS            NULL
+#define LTC4150_PARAM_RECDATA         NULL
+#endif
+#ifndef LTC4150_PARAMS
+#define LTC4150_PARAMS                { .interrupt = LTC4150_PARAM_INT,  \
+                                        .polarity = LTC4150_PARAM_POL, \
+                                        .shutdown = LTC4150_PARAM_SHUTDOWN, \
+                                        .pulses_per_ah = LTC4150_PARAM_PULSES, \
+                                        .flags = LTC4150_PARAM_FLAGS, \
+                                        .recorders = LTC4150_PARAM_RECS, \
+                                        .recorder_data = LTC4150_PARAM_RECDATA }
+#endif
+/**@}*/
+
+/**
+ * @brief   Configure LTC4150 devices
+ */
+static const ltc4150_params_t ltc4150_params[] =
+{
+    LTC4150_PARAMS
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LTC4150_PARAMS_H */
+/** @} */

--- a/drivers/ltc4150/ltc4150.c
+++ b/drivers/ltc4150/ltc4150.c
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2019 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_ltc4150
+ * @{
+ *
+ * @file
+ * @brief       LTC4150 Device Driver
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ *
+ * @}
+ */
+#include <assert.h>
+#include <errno.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "ltc4150.h"
+#include "xtimer.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+static void pulse_cb(void *_dev)
+{
+    uint64_t now;
+    ltc4150_dir_t dir;
+    ltc4150_dev_t *dev = _dev;
+
+    if ((dev->params.polarity == GPIO_UNDEF) ||
+        (!gpio_read(dev->params.polarity))
+        ) {
+        dev->discharged++;
+        dir = LTC4150_DISCHARGE;
+    }
+    else {
+        dev->charged++;
+        dir = LTC4150_CHARGE;
+    }
+
+    now = xtimer_now_usec64();
+
+    if (dev->params.recorders) {
+        assert(dev->params.recorder_data);
+        for (unsigned i = 0; dev->params.recorders[i] != NULL; i++) {
+            dev->params.recorders[i]->pulse(dev, dir, now,
+                                            dev->params.recorder_data[i]);
+        }
+    }
+
+    dev->last_update_sec = now / US_PER_SEC;
+}
+
+int ltc4150_init(ltc4150_dev_t *dev, const ltc4150_params_t *params)
+{
+    if (!dev || !params) {
+        return -EINVAL;
+    }
+
+    memset(dev, 0, sizeof(ltc4150_dev_t));
+    dev->params = *params;
+
+    if (dev->params.shutdown != GPIO_UNDEF) {
+        /* Activate LTC4150 */
+        if (gpio_init(dev->params.shutdown, GPIO_OUT)) {
+            DEBUG("[ltc4150] Failed to initialize shutdown pin");
+            return -EIO;
+        }
+        gpio_set(dev->params.shutdown);
+    }
+
+    if (dev->params.polarity != GPIO_UNDEF) {
+        gpio_mode_t mode = (dev->params.flags & LTC4150_POL_EXT_PULL_UP) ?
+                           GPIO_IN : GPIO_IN_PU;
+        if (gpio_init(dev->params.polarity, mode)) {
+            DEBUG("[ltc4150] Failed to initialize polarity pin");
+            return -EIO;
+        }
+    }
+
+    gpio_mode_t mode = (dev->params.flags & LTC4150_INT_EXT_PULL_UP) ?
+                       GPIO_IN : GPIO_IN_PU;
+    if (gpio_init_int(dev->params.interrupt, mode, GPIO_FALLING,
+                      pulse_cb, dev)
+        ) {
+        DEBUG("[ltc4150] Failed to initialize interrupt pin");
+        return -EIO;
+    }
+
+    ltc4150_reset_counters(dev);
+
+    DEBUG("[ltc4150] Initialized successfully");
+    return 0;
+}
+
+int ltc4150_reset_counters(ltc4150_dev_t *dev)
+{
+    uint64_t now = xtimer_now_usec64();
+
+    if (!dev) {
+        return -EINVAL;
+    }
+
+    gpio_irq_disable(dev->params.interrupt);
+
+    dev->charged = 0;
+    dev->discharged = 0;
+    dev->last_update_sec = dev->start_sec = now / US_PER_SEC;
+
+    if (dev->params.recorders) {
+        assert(dev->params.recorder_data);
+        for (unsigned i = 0; dev->params.recorders[i] != NULL; i++) {
+            dev->params.recorders[i]->reset(dev, now, dev->params.recorder_data[i]);
+        }
+    }
+
+    gpio_irq_enable(dev->params.interrupt);
+    return 0;
+}
+
+int ltc4150_shutdown(ltc4150_dev_t *dev)
+{
+    if (!dev) {
+        return -EINVAL;
+    }
+
+    gpio_irq_disable(dev->params.interrupt);
+
+    if (dev->params.shutdown != GPIO_UNDEF) {
+        gpio_clear(dev->params.shutdown);
+    }
+
+    return 0;
+}
+
+/**
+ * @brief Convert the raw data (# pulses) acquired by the LTC4150 device to
+ *        charge information in millicoulomb
+ *
+ * @param dev                 LTC4150 device the data was received from
+ * @param[out] charged        Charge in charging direction is stored here
+ * @param[out] discharged     Charge in discharging direction is stored here
+ * @param[in] raw_charged     Number of pulses in charging direction
+ * @param[in] raw_discharged  Number of pulses in discharging direction
+ */
+static void get_coulomb(const ltc4150_dev_t *dev,
+                        uint32_t *charged, uint32_t *discharged,
+                        uint32_t raw_charged,
+                        uint32_t raw_discharged)
+{
+    uint64_t tmp;
+
+    if (charged) {
+        tmp = raw_charged;
+        tmp *= 3600000;
+        tmp += dev->params.pulses_per_ah >> 1;
+        tmp /= dev->params.pulses_per_ah;
+        *charged = tmp;
+    }
+
+    if (discharged) {
+        tmp = raw_discharged;
+        tmp *= 3600000;
+        tmp += dev->params.pulses_per_ah >> 1;
+        tmp /= dev->params.pulses_per_ah;
+        *discharged = tmp;
+    }
+}
+
+int ltc4150_charge(ltc4150_dev_t *dev, uint32_t *charged, uint32_t *discharged)
+{
+    if (!dev) {
+        return -EINVAL;
+    }
+
+    gpio_irq_disable(dev->params.interrupt);
+    get_coulomb(dev, charged, discharged, dev->charged, dev->discharged);
+    gpio_irq_enable(dev->params.interrupt);
+    return 0;
+}
+
+int ltc4150_avg_current(ltc4150_dev_t *dev, int16_t *dest)
+{
+    int32_t duration, charged, discharged;;
+    int retval;
+
+    retval = ltc4150_charge(dev, (uint32_t *)&charged, (uint32_t *)&discharged);
+    if (retval) {
+        return retval;
+    }
+
+    duration = dev->last_update_sec - dev->start_sec;
+    if (!duration) {
+        /* Called before one second of date or one pulse acquired. Prevent
+         * division by zero by returning -EAGAIN.
+         */
+        return -EAGAIN;
+    }
+
+    /* From millicoloumb (=mAs) to E-01 mA */
+    *dest = ((discharged - charged) * 10) / duration;
+
+    return 0;
+}

--- a/drivers/ltc4150/ltc4150.c
+++ b/drivers/ltc4150/ltc4150.c
@@ -139,20 +139,10 @@ int ltc4150_shutdown(ltc4150_dev_t *dev)
     return 0;
 }
 
-/**
- * @brief Convert the raw data (# pulses) acquired by the LTC4150 device to
- *        charge information in millicoulomb
- *
- * @param dev                 LTC4150 device the data was received from
- * @param[out] charged        Charge in charging direction is stored here
- * @param[out] discharged     Charge in discharging direction is stored here
- * @param[in] raw_charged     Number of pulses in charging direction
- * @param[in] raw_discharged  Number of pulses in discharging direction
- */
-static void get_coulomb(const ltc4150_dev_t *dev,
-                        uint32_t *charged, uint32_t *discharged,
-                        uint32_t raw_charged,
-                        uint32_t raw_discharged)
+void ltc4150_pulses2c(const ltc4150_dev_t *dev,
+                      uint32_t *charged, uint32_t *discharged,
+                      uint32_t raw_charged,
+                      uint32_t raw_discharged)
 {
     uint64_t tmp;
 
@@ -180,7 +170,7 @@ int ltc4150_charge(ltc4150_dev_t *dev, uint32_t *charged, uint32_t *discharged)
     }
 
     gpio_irq_disable(dev->params.interrupt);
-    get_coulomb(dev, charged, discharged, dev->charged, dev->discharged);
+    ltc4150_pulses2c(dev, charged, discharged, dev->charged, dev->discharged);
     gpio_irq_enable(dev->params.interrupt);
     return 0;
 }

--- a/drivers/ltc4150/ltc4150_last_minute.c
+++ b/drivers/ltc4150/ltc4150_last_minute.c
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2019 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_ltc4150
+ * @{
+ *
+ * @file
+ * @brief       Track the drawn charged of the last minute
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ * @}
+ */
+
+#include <errno.h>
+#include <string.h>
+
+#include "ltc4150.h"
+#include "xtimer.h"
+
+static void init_or_reset(ltc4150_dev_t *dev, uint64_t now_usec, void *arg);
+static void pulse(ltc4150_dev_t *dev, ltc4150_dir_t dir, uint64_t now_usec,
+                  void *arg);
+
+const ltc4150_recorder_t ltc4150_last_minute = {
+    .reset = init_or_reset,
+    .pulse = pulse,
+};
+
+static void init_or_reset(ltc4150_dev_t *dev, uint64_t now_usec, void *arg)
+{
+    (void)dev;
+    ltc4150_last_minute_data_t *data = arg;
+
+    memset(data, 0, sizeof(ltc4150_last_minute_data_t));
+    data->last_rotate_sec = now_usec / US_PER_SEC;
+}
+
+static void update_ringbuffer(ltc4150_last_minute_data_t *data,
+                              uint64_t now_usec)
+{
+    uint32_t now_sec = (now_usec / US_PER_SEC);
+
+    /* Note: This expression should be correct even when time overflows */
+    while (now_sec - data->last_rotate_sec > 10) {
+        data->last_rotate_sec += 10;
+        data->charged += data->buf_charged[data->ring_pos];
+        data->discharged += data->buf_discharged[data->ring_pos];
+        if (++data->ring_pos >= sizeof(data->buf_charged)/sizeof(data->buf_charged[0])) {
+            data->ring_pos = 0;
+        }
+        data->charged -= data->buf_charged[data->ring_pos];
+        data->discharged -= data->buf_discharged[data->ring_pos];
+        data->buf_charged[data->ring_pos] = 0;
+        data->buf_discharged[data->ring_pos] = 0;
+    }
+}
+
+static void pulse(ltc4150_dev_t *dev, ltc4150_dir_t dir, uint64_t now_usec,
+                  void *arg)
+{
+    (void)dev;
+    ltc4150_last_minute_data_t *data = arg;
+    update_ringbuffer(data, now_usec);
+
+    switch (dir) {
+        case LTC4150_CHARGE:
+            data->buf_charged[data->ring_pos]++;
+            break;
+        default:
+        case LTC4150_DISCHARGE:
+            data->buf_discharged[data->ring_pos]++;
+            break;
+    }
+}
+
+int ltc4150_last_minute_charge(ltc4150_dev_t *dev,
+                               ltc4150_last_minute_data_t *d,
+                               uint32_t *charged, uint32_t *discharged)
+{
+    if (!dev || !d) {
+        return -EINVAL;
+    }
+
+    gpio_irq_disable(dev->params.interrupt);
+    update_ringbuffer(d, xtimer_now_usec64());
+    ltc4150_pulses2c(dev, charged, discharged, d->charged, d->discharged);
+    gpio_irq_enable(dev->params.interrupt);
+
+    return 0;
+}

--- a/drivers/ltc4150/ltc4150_saul.c
+++ b/drivers/ltc4150/ltc4150_saul.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_ltc4150
+ * @{
+ *
+ * @file
+ * @brief       SAUL adaption for LTC4150 devices
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ *
+ * @}
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "phydat.h"
+#include "saul.h"
+#include "ltc4150.h"
+
+static int read_charge(const void *_dev, phydat_t *res)
+{
+    ltc4150_dev_t *dev = (ltc4150_dev_t *)_dev;
+    int32_t temp[3];
+
+    if (ltc4150_charge(dev, (uint32_t *)&temp[1], (uint32_t *)&temp[2]) == 0) {
+        res->scale = -3;
+        res->unit = UNIT_COULOMB;
+        temp[0] = temp[2] - temp[1];
+        int dim = (dev->params.polarity != GPIO_UNDEF) ? 3 : 1;
+        phydat_fit(res, temp, (unsigned)dim);
+        return dim;
+    }
+
+    return -ECANCELED;
+}
+
+static int read_current(const void *dev, phydat_t *res)
+{
+    if (ltc4150_avg_current((ltc4150_dev_t *)dev, res->val) == 0) {
+        res->unit = UNIT_A;
+        res->scale = -4;
+        return 1;
+    }
+
+    return -ECANCELED;
+}
+
+const saul_driver_t ltc4150_saul_charge_driver = {
+    .read = read_charge,
+    .write = saul_notsup,
+    .type = SAUL_SENSE_CHARGE
+};
+
+const saul_driver_t ltc4150_saul_current_driver = {
+    .read = read_current,
+    .write = saul_notsup,
+    .type = SAUL_SENSE_CURRENT
+};

--- a/drivers/saul/saul_str.c
+++ b/drivers/saul/saul_str.c
@@ -55,6 +55,8 @@ const char *saul_class_to_str(const uint8_t class_id)
         case SAUL_SENSE_TVOC:      return "SENSE_TVOC";
         case SAUL_SENSE_PROXIMITY: return "SENSE_PROXIMITY";
         case SAUL_SENSE_RSSI:      return "SENSE_RSSI";
+        case SAUL_SENSE_CHARGE:    return "SENSE_CHARGE";
+        case SAUL_SENSE_CURRENT:   return "SENSE_CURRENT";
         case SAUL_CLASS_ANY:       return "CLASS_ANY";
         case SAUL_SENSE_OCCUP:     return "SENSE_OCCUP";
         default:                   return "CLASS_UNKNOWN";

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -413,6 +413,10 @@ void auto_init(void)
     extern void auto_init_lsm6dsl(void);
     auto_init_lsm6dsl();
 #endif
+#ifdef MODULE_LTC4150
+    extern void auto_init_ltc4150(void);
+    auto_init_ltc4150();
+ #endif
 #ifdef MODULE_MAG3110
     extern void auto_init_mag3110(void);
     auto_init_mag3110();

--- a/sys/auto_init/saul/auto_init_ltc4150.c
+++ b/sys/auto_init/saul/auto_init_ltc4150.c
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2018 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
+
+/*
+ * @ingroup     sys_auto_init_saul
+ * @{
+ *
+ * @file
+ * @brief       Auto initialization for LTC4150 coulomb counter
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ *
+ * @}
+ */
+
+#ifdef MODULE_LTC4150
+
+#include "assert.h"
+#include "log.h"
+#include "saul_reg.h"
+#include "ltc4150_params.h"
+#include "ltc4150.h"
+
+/**
+ * @brief   Define the number of configured sensors
+ */
+#define LTC4150_NUM     (sizeof(ltc4150_params) / sizeof(ltc4150_params[0]))
+
+/**
+ * @brief   Allocate memory for the device descriptors
+ */
+static ltc4150_dev_t ltc4150_devs[LTC4150_NUM];
+
+/**
+ * @brief   Memory for the SAUL registry entries
+ */
+static saul_reg_t saul_entries[LTC4150_NUM * 2];
+
+/**
+ * @brief   Define the number of saul info
+ */
+#define LTC4150_INFO_NUM (sizeof(ltc4150_saul_info) / sizeof(ltc4150_saul_info[0]))
+
+/**
+ * @name    Import SAUL endpoints
+ * @{
+ */
+extern const saul_driver_t ltc4150_saul_charge_driver;
+extern const saul_driver_t ltc4150_saul_current_driver;
+/** @} */
+
+void auto_init_ltc4150(void)
+{
+    assert(LTC4150_INFO_NUM == 2 * LTC4150_NUM);
+
+    for (unsigned int i = 0; i < LTC4150_NUM; i++) {
+        LOG_DEBUG("[auto_init_saul] initializing ltc4150 #%u\n", i);
+
+        if (ltc4150_init(&ltc4150_devs[i], &ltc4150_params[i])) {
+            LOG_ERROR("[auto_init_saul] error initializing ltc4150 #%u\n", i);
+            continue;
+        }
+
+        saul_entries[i * 2    ].dev = &(ltc4150_devs[i]);
+        saul_entries[i * 2    ].name = ltc4150_saul_info[2 * i    ].name;
+        saul_entries[i * 2    ].driver = &ltc4150_saul_charge_driver;
+        saul_entries[i * 2 + 1].dev = &(ltc4150_devs[i]);
+        saul_entries[i * 2 + 1].name = ltc4150_saul_info[2 * i + 1].name;
+        saul_entries[i * 2 + 1].driver = &ltc4150_saul_current_driver;
+        saul_reg_add(&(saul_entries[i * 2    ]));
+        saul_reg_add(&(saul_entries[i * 2 + 1]));
+    }
+}
+
+#else
+typedef int dont_be_pedantic;
+#endif /* MODULE_LTC4150 */

--- a/sys/include/phydat.h
+++ b/sys/include/phydat.h
@@ -95,6 +95,7 @@ enum {
     UNIT_V,         /**< Volts */
     UNIT_GS,        /**< gauss */
     UNIT_DBM,       /**< decibel-milliwatts */
+    UNIT_COULOMB,   /**< coulomb */
     /* pressure */
     UNIT_BAR,       /**< Beer? */
     UNIT_PA,        /**< Pascal */

--- a/sys/phydat/phydat_str.c
+++ b/sys/phydat/phydat_str.c
@@ -101,6 +101,7 @@ const char *phydat_unit_to_str(uint8_t unit)
         case UNIT_CD:       return "cd";
         case UNIT_PERCENT:  return "%";
         case UNIT_CTS:      return "cts";
+        case UNIT_COULOMB:  return "C";
         default:            return "";
     }
 }

--- a/sys/shell/commands/shell_commands.c
+++ b/sys/shell/commands/shell_commands.c
@@ -44,11 +44,6 @@ extern int _get_weather_handler(int argc, char **argv);
 extern int _sht_config_handler(int argc, char **argv);
 #endif
 
-#ifdef MODULE_LTC4150
-extern int _get_current_handler(int argc, char **argv);
-extern int _reset_current_handler(int argc, char **argv);
-#endif
-
 #ifdef MODULE_AT30TSE75X
 extern int _at30tse75x_handler(int argc, char **argv);
 #endif
@@ -162,10 +157,6 @@ const shell_command_t _shell_command_list[] = {
     {"hum", "Prints measured humidity.", _get_humidity_handler},
     {"weather", "Prints measured humidity and temperature.", _get_weather_handler},
     {"sht-config", "Get/set SHT10/11/15 sensor configuration.", _sht_config_handler},
-#endif
-#ifdef MODULE_LTC4150
-    {"cur", "Prints current and average power consumption.", _get_current_handler},
-    {"rstcur", "Resets coulomb counter.", _reset_current_handler},
 #endif
 #ifdef MODULE_AT30TSE75X
     {"at30tse75x", "Test AT30TSE75X temperature sensor", _at30tse75x_handler},

--- a/tests/driver_ltc4150/Makefile
+++ b/tests/driver_ltc4150/Makefile
@@ -6,3 +6,7 @@ USEMODULE += fmt
 USEMODULE += ltc4150
 
 include $(RIOTBASE)/Makefile.include
+
+ifneq (,$(filter $(BOARD),msb-430 msb-430h telosb wsn430-v1_3b wsn430-v1_4 z1))
+  CFLAGS += -DNO_FPUTS
+endif

--- a/tests/driver_ltc4150/Makefile
+++ b/tests/driver_ltc4150/Makefile
@@ -1,5 +1,7 @@
 include ../Makefile.tests_common
 
+BOARD_INSUFFICIENT_MEMORY += arduino-uno arduino-duemilanove
+
 BOARD ?= msba2
 
 USEMODULE += fmt

--- a/tests/driver_ltc4150/Makefile
+++ b/tests/driver_ltc4150/Makefile
@@ -1,0 +1,8 @@
+include ../Makefile.tests_common
+
+BOARD ?= msba2
+
+USEMODULE += fmt
+USEMODULE += ltc4150
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/driver_ltc4150/main.c
+++ b/tests/driver_ltc4150/main.c
@@ -1,0 +1,331 @@
+/*
+ * Copyright (C) 2019 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for the LTC4150 coulomb counter driver
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ *
+ * @}
+ */
+
+#include <errno.h>
+#include <stdio.h>
+
+#include "fmt.h"
+#include "led.h"
+#include "ltc4150.h"
+#include "thread.h"
+#include "xtimer.h"
+
+typedef struct {
+    uint64_t last_usec;
+    uint64_t now_usec;
+    ltc4150_dir_t dir;
+} test_recorder_data_t;
+
+static void pulse_cb(ltc4150_dev_t *, ltc4150_dir_t, uint64_t, void *);
+static void reset_cb(ltc4150_dev_t *, uint64_t, void *);
+
+static ltc4150_last_minute_data_t last_minute_data;
+static test_recorder_data_t test_data;
+static const ltc4150_recorder_t test_recorder = {
+    .pulse = pulse_cb,
+    .reset = reset_cb,
+};
+static kernel_pid_t target_pid;
+static char busy_thread_stack[THREAD_STACKSIZE_DEFAULT];
+static ltc4150_dev_t ltc4150;
+static int change_of_load_level = 0;
+
+static const ltc4150_recorder_t *recorders[] = {
+    &ltc4150_last_minute,
+    &test_recorder,
+    NULL
+};
+static void *recorder_data[] = {
+    &last_minute_data,
+    &test_data,
+};
+
+#define LTC4150_PARAM_RECS            (recorders)
+#define LTC4150_PARAM_RECDATA         (recorder_data)
+
+#include "ltc4150_params.h"
+
+/**
+ * @brief Callback function to reset/initialize the recorder data
+ */
+static void reset_cb(ltc4150_dev_t *dev, uint64_t now_usec, void *_data)
+{
+    (void)dev;
+    test_recorder_data_t *data = _data;
+    data->last_usec = data->now_usec = now_usec;
+    data->dir = LTC4150_DISCHARGE;
+}
+
+/**
+ * @brief Callback function to record the current pulse
+ */
+static void pulse_cb(ltc4150_dev_t *dev, ltc4150_dir_t dir, uint64_t now_usec,
+                     void *_data)
+{
+    (void)dev;
+    static msg_t m = { .content = { .value = 0} };
+
+    test_recorder_data_t *data = _data;
+    data->last_usec = data->now_usec;
+    data->now_usec = now_usec;
+    data->dir = dir;
+
+    msg_send(&m, target_pid);
+}
+
+/**
+ * @brief Busy waits for the given amount of seconds
+ * @param seconds    Number of seconds to roast the CPU
+ */
+static void spin(uint32_t seconds)
+{
+    uint32_t till = xtimer_now_usec() + US_PER_SEC * seconds;
+    while (xtimer_now_usec() < till) { }
+}
+
+/**
+ * @brief Thread that will put three levels of CPU load on the MCU
+ */
+static void *busy_thread(void *arg)
+{
+    (void)arg;
+    while (1) {
+        /* one minute of ~0% CPU usage */
+        LED0_OFF;
+        LED1_OFF;
+        xtimer_sleep(60);
+        change_of_load_level = 1;
+
+        /* one minute of ~50% CPU usage */
+        for (unsigned i = 0; i < 30; i++) {
+            LED0_OFF;
+            LED1_OFF;
+            xtimer_sleep(1);
+            LED0_ON;
+            LED1_ON;
+            spin(1);
+        }
+        change_of_load_level = 1;
+
+        /* one minute of 100% CPU usage */
+        LED0_ON;
+        LED1_ON;
+        spin(60);
+        change_of_load_level = 1;
+    }
+
+    /* unreachable */
+    return NULL;
+}
+
+/**
+ * @brief Print the given number of spaces
+ */
+static void print_spaces(size_t number)
+{
+    static const char *spaces = "                ";
+    while (number > 16) {
+        fputs(spaces, stdout);
+        number -= 16;
+    }
+
+    fputs(spaces + 16 - number, stdout);
+}
+
+/**
+ * @brief Print a table column with the given number as decimal
+ * @param number    Number to print in the column
+ * @param width     Width of the column
+ */
+static void print_col_u32(uint32_t number, size_t width)
+{
+    char sbuf[32];
+    size_t slen;
+
+    slen = fmt_u32_dec(sbuf, number);
+    sbuf[slen] = '\0';
+    if (width > slen) {
+        print_spaces(width - slen);
+    }
+    fputs(sbuf, stdout);
+}
+
+/**
+ * @brief Print a table column with the given number as decimal
+ * @param number    Number to print in the column
+ * @param width     Width of the column
+ */
+static void print_col_i32(int32_t number, size_t width)
+{
+    char sbuf[32];
+    size_t slen;
+    char *pos = sbuf;
+
+    if (number < 0) {
+        *pos++ = '-';
+        number = -number;
+        width--;
+    }
+    slen = fmt_u32_dec(sbuf, (uint32_t)number);
+    sbuf[slen] = '\0';
+    if (width > slen) {
+        print_spaces(width - slen);
+    }
+    fputs(sbuf, stdout);
+}
+
+/**
+ * @brief Print a table column with the given current as E-01
+ * @param current   Value to print in the column (as E-01)
+ * @param width     Width of the column
+ */
+static void print_current(int32_t current, size_t width)
+{
+    char sbuf[3];
+
+    print_col_i32(current/10, width - 2);
+    sbuf[0] = '.';
+    sbuf[1] = '0' + current % 10;
+    sbuf[2] = '\0';
+    fputs(sbuf, stdout);
+}
+
+int main(void)
+{
+    target_pid = thread_getpid();
+    uint32_t ten_uc_per_pulse;
+    msg_t m;
+    int retval;
+
+    retval = ltc4150_init(&ltc4150, &ltc4150_params[0]);
+
+    /* Pre-compute the charge corresponding to one pulse */
+    ltc4150_pulses2c(&ltc4150, &ten_uc_per_pulse, NULL, 10000, 0);
+
+    if (retval) {
+        fputs("Failed to initialize LTC4150 driver:", stdout);
+        switch (retval) {
+            case -EINVAL:
+                puts("Invalid parameter");
+                break;
+            case -EIO:
+                puts("GPIO or interrupt configuration failed");
+                break;
+            default:
+                puts("Unknown (should no happen, file a bug)");
+                break;
+        }
+        return -1;
+    }
+
+    /* Start the thread that will keep the MCU busy */
+    thread_create(busy_thread_stack, sizeof(busy_thread_stack),
+                  THREAD_PRIORITY_MAIN + 1, THREAD_CREATE_STACKTEST,
+                  busy_thread, NULL, "busy_thread");
+
+    puts("This test will put three levels of load on the MCU:\n"
+         " 1. One minute of little to no load (LEDs(*) off)\n"
+         " 2. One minute of about 50% CPU load (LEDs(*) blinking)\n"
+         " 3. One minute of 100% CPU load (LEDs(*) constantly on)\n"
+         "\n"
+         "    (*) LED0 and LED1, if present on your board\n"
+         "\n"
+         "During this time the charge drawn is measured and printed on every\n"
+         "pulse the LTC4150 generates. A horizontal line in the table\n"
+         "separates values of different load levels. On the MSB-A2 the\n"
+         "expected result per column is:\n"
+         "\n"
+         "  Charging:     Should remain zero\n"
+         "  Discharging:  Should increase for every pulse\n"
+         "  Average:      Should be something between 60mA to 80mA\n"
+         "  Last Minute:  Starts with 0 at boot up and is updated every 10s.\n"
+         "                Should be higher for higher system load when looking\n"
+         "                at the last update for each load level.\n"
+         "                (Note: Not synchronized with load levels!)\n"
+         "  Currently:    Should be higher for higher system load. Might be\n"
+         "                \"jumpy\" on 50% load, as this implemented by having\n"
+         "                one second of 100% load and one second of ~0% load\n"
+         "                in turns.\n"
+         "\n"
+         "Hint: You'll want to look mostly at the rightmost column.\n"
+         "Note: The test will repeat endlessly.");
+
+    LED0_OFF;
+
+    puts("+-------------------------------+-----------------------------------+\n"
+         "| Total Transferred Charge [mC] |   Current from Power Supply [mA]  |\n"
+         "| Charging      | Discharging   | Average | Last Minute | Currently |\n"
+         "+---------------+---------------+---------+-------------+-----------+");
+
+    while (1) {
+        /* Wait for the next pulse of the LTC4150 */
+        msg_receive(&m);
+        uint32_t charged, discharged;
+        int16_t avg_current;
+        int32_t current;
+
+        if (change_of_load_level) {
+            puts("+---------------+---------------+---------+-------------+-----------+");
+            change_of_load_level = 0;
+        }
+
+        /* Get & print total charge transferred */
+        if (ltc4150_charge(&ltc4150, &charged, &discharged)) {
+            puts("ltc4150_charge() failed!");
+            return -1;
+        }
+        fputs("| ", stdout);
+        print_col_u32(charged, 13);
+        fputs(" | ", stdout);
+        print_col_u32(discharged, 13);
+        fputs(" | ", stdout);
+
+        /* Get & print avg current */
+        if (ltc4150_avg_current(&ltc4150, &avg_current)) {
+            puts("ltc4150_avg_current() failed!");
+            return -1;
+        }
+        print_current(avg_current, 7);
+        fputs(" | ", stdout);
+
+        /* Get & print last minute current */
+        if (ltc4150_last_minute_charge(&ltc4150, &last_minute_data,
+                                       &charged, &discharged)
+            ) {
+            puts("ltc4150_last_minute_charge() failed!");
+            return -1;
+        }
+        current = (int32_t)discharged - (int32_t)charged;
+        current /= 60;
+        print_col_i32(current, 11);
+        fputs(" | ", stdout);
+
+        /* Calculate & print the current between the last two pulses */
+        current = (int32_t)((test_data.now_usec - test_data.last_usec) / MS_PER_SEC);
+        current = ten_uc_per_pulse / current;
+        if (test_data.dir == LTC4150_CHARGE) {
+            current = -current;
+        }
+        print_current(current, 9);
+        puts(" |");
+    }
+
+    return 0;
+}

--- a/tests/saul/Makefile
+++ b/tests/saul/Makefile
@@ -5,4 +5,7 @@ USEMODULE += saul_default
 
 USEMODULE += xtimer
 
+# Too little flash:
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
+
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
### Contribution description

This PR implements a driver for the LTC4150 coulomb counter. A driver for that device was previously part for RIOT, but was dropped because of quality shortcomings. This driver is written from scratch.


### Testing procedure

The LTC4150 is integrated in the MSB-A2 board, thus using that board will be most convenient to use for testing. However, this chip is also cheaply available as breakout board from various vendors, which all seem to be based on the same open hardware PCB.

Testing:

1. Build, flash & run `tests/driver_ltc4150` on the MSB-A2. I intended the program to be self-explaining - so I will not provide more information here to see if I indeed reached that goal
2. Build, flash & run `example/default`. Try to read the data using the `saul` shell command

### Issues/PRs references

This PR competes with PR https://github.com/RIOT-OS/RIOT/pull/9653 also opened by me. I personally favor this PR strongly over the old approach.