### PR TITLE
.github: add big warning signs about security bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -5,10 +5,13 @@ about: Create a report to help us improve
 ---
 
 <!--
+====================================
+IF YOUR ISSUE IS RELATED TO SECURITY
+====================================
+please submit it to the security mailing-list security@riot-os.org.
+
 If your issue is a usage question, please submit it to the user mailing-list
 users@riot-os.org or to the developer mailing-list devel@riot-os.org.
-If your issue is related to security, please submit it to the security
-mailing-list security@riot-os.org.
 -->
 
 #### Description

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,8 +10,9 @@ IF YOUR ISSUE IS RELATED TO SECURITY
 ====================================
 please submit it to the security mailing-list security@riot-os.org.
 
-If your issue is a usage question, please submit it to the user mailing-list
-users@riot-os.org or to the developer mailing-list devel@riot-os.org.
+If your issue is a question related to the usage of RIOT, please submit it to
+the user mailing-list users@riot-os.org or to the developer mailing-list
+devel@riot-os.org.
 -->
 
 #### Description

--- a/.github/ISSUE_TEMPLATE/security_bug.md
+++ b/.github/ISSUE_TEMPLATE/security_bug.md
@@ -1,0 +1,12 @@
+---
+title: 'Security Bug report'
+about: |
+    Don't use the issue tracker for this! Please write an e-mail to
+    security@riot-os.org. The button was just added to advertise this message.
+---
+
+# DON'T USE THE ISSUE TRACKER FOR THIS!
+<!--
+Please write an e-mail to security@riot-os.org. The button was just added to
+advertise this message!
+-->


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This makes

1. The hint about security@riot-os.org in the bug report issue much clearer (hopefully).
2. Adds a new issue template "Security bug" that mainly aims to advertise the security@riot-os.org mailing list even more (thanks @jcarrano for the idea).
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
None
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Addresses #10752.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
