### PR TITLE
sock_dns: fix out-of-bound errors [backport 2018.10]

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -683,6 +683,7 @@ endif
 
 ifneq (,$(filter sock_dns,$(USEMODULE)))
   USEMODULE += sock_util
+  USEMODULE += posix
 endif
 
 ifneq (,$(filter sock_util,$(USEMODULE)))

--- a/sys/include/net/dns.h
+++ b/sys/include/net/dns.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2019 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    net_dns DNS defines
+ * @ingroup     net
+ * @brief       Generic DNS values
+ * @{
+ *
+ * @file
+ * @brief   Generic DNS values
+ *
+ * @author  Martine Lenders <m.lenders@fu-berlin.de>
+ */
+#ifndef NET_DNS_H
+#define NET_DNS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Field lengths
+ * @{
+ */
+#define RR_TYPE_LENGTH      (2U)
+#define RR_CLASS_LENGTH     (2U)
+#define RR_TTL_LENGTH       (4U)
+#define RR_RDLENGTH_LENGTH  (2U)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NET_DNS_H */
+/** @} */

--- a/sys/net/application_layer/dns/dns.c
+++ b/sys/net/application_layer/dns/dns.c
@@ -212,7 +212,6 @@ int sock_dns_query(const char *domain_name, void *addr_out, int family)
 
     ssize_t res = sock_udp_create(&sock_dns, NULL, &sock_dns_server, 0);
     if (res) {
-            puts("a");
         goto out;
     }
 

--- a/sys/net/application_layer/dns/dns.c
+++ b/sys/net/application_layer/dns/dns.c
@@ -15,6 +15,7 @@
  * @}
  */
 
+#include <arpa/inet.h>
 #include <string.h>
 #include <stdio.h>
 
@@ -73,34 +74,58 @@ static unsigned _get_short(uint8_t *buf)
     return _tmp;
 }
 
-static size_t _skip_hostname(uint8_t *buf)
+static ssize_t _skip_hostname(const uint8_t *buf, size_t len, uint8_t *bufpos)
 {
-    uint8_t *bufpos = buf;
+    const uint8_t *buflim = buf + len;
+    unsigned res = 0;
 
+    if (bufpos >= buflim) {
+        /* out-of-bound */
+        return -EBADMSG;
+    }
     /* handle DNS Message Compression */
     if (*bufpos >= 192) {
+        if ((bufpos + 2) >= buflim) {
+            return -EBADMSG;
+        }
         return 2;
     }
 
-    while(*bufpos) {
-        bufpos += *bufpos + 1;
+    while (bufpos[res]) {
+        res += bufpos[res] + 1;
+        if ((&bufpos[res]) >= buflim) {
+            /* out-of-bound */
+            return -EBADMSG;
+        }
     }
-    return (bufpos - buf + 1);
+    return res + 1;
 }
 
 static int _parse_dns_reply(uint8_t *buf, size_t len, void* addr_out, int family)
 {
+    const uint8_t *buflim = buf + len;
     sock_dns_hdr_t *hdr = (sock_dns_hdr_t*) buf;
     uint8_t *bufpos = buf + sizeof(*hdr);
 
     /* skip all queries that are part of the reply */
     for (unsigned n = 0; n < ntohs(hdr->qdcount); n++) {
-        bufpos += _skip_hostname(bufpos);
+        ssize_t tmp = _skip_hostname(buf, len, bufpos);
+        if (tmp < 0) {
+            return tmp;
+        }
+        bufpos += tmp;
         bufpos += 4;    /* skip type and class of query */
     }
 
     for (unsigned n = 0; n < ntohs(hdr->ancount); n++) {
-        bufpos += _skip_hostname(bufpos);
+        ssize_t tmp = _skip_hostname(buf, len, bufpos);
+        if (tmp < 0) {
+            return tmp;
+        }
+        bufpos += tmp;
+        if ((bufpos + 2 + 2 + 4) >= buflim) {
+            return -EBADMSG;
+        }
         uint16_t _type = ntohs(_get_short(bufpos));
         bufpos += 2;
         uint16_t class = ntohs(_get_short(bufpos));
@@ -108,19 +133,30 @@ static int _parse_dns_reply(uint8_t *buf, size_t len, void* addr_out, int family
         bufpos += 4; /* skip ttl */
 
         unsigned addrlen = ntohs(_get_short(bufpos));
-        bufpos += 2;
-        if ((bufpos + addrlen) > (buf + len)) {
-            return -EBADMSG;
-        }
-
         /* skip unwanted answers */
         if ((class != DNS_CLASS_IN) ||
                 ((_type == DNS_TYPE_A) && (family == AF_INET6)) ||
                 ((_type == DNS_TYPE_AAAA) && (family == AF_INET)) ||
                 ! ((_type == DNS_TYPE_A) || ((_type == DNS_TYPE_AAAA))
                     )) {
+            if (addrlen > len) {
+                /* buffer wraps around memory space */
+                return -EBADMSG;
+            }
             bufpos += addrlen;
+            /* other out-of-bound is checked in `_skip_hostname()` at start of
+             * loop */
             continue;
+        }
+        if (((addrlen != INADDRSZ) && (family == AF_INET)) ||
+            ((addrlen != IN6ADDRSZ) && (family == AF_INET6)) ||
+            ((addrlen != IN6ADDRSZ) && (addrlen != INADDRSZ) &&
+             (family == AF_UNSPEC))) {
+            return -EBADMSG;
+        }
+        bufpos += 2;
+        if ((bufpos + addrlen) >= buflim) {
+            return -EBADMSG;
         }
 
         memcpy(addr_out, bufpos, addrlen);

--- a/sys/net/application_layer/dns/dns.c
+++ b/sys/net/application_layer/dns/dns.c
@@ -19,6 +19,7 @@
 #include <string.h>
 #include <stdio.h>
 
+#include "net/dns.h"
 #include "net/sock/udp.h"
 #include "net/sock/dns.h"
 
@@ -114,7 +115,8 @@ static int _parse_dns_reply(uint8_t *buf, size_t len, void* addr_out, int family
             return tmp;
         }
         bufpos += tmp;
-        bufpos += 4;    /* skip type and class of query */
+        /* skip type and class of query */
+        bufpos += (RR_TYPE_LENGTH + RR_CLASS_LENGTH);
     }
 
     for (unsigned n = 0; n < ntohs(hdr->ancount); n++) {
@@ -123,14 +125,14 @@ static int _parse_dns_reply(uint8_t *buf, size_t len, void* addr_out, int family
             return tmp;
         }
         bufpos += tmp;
-        if ((bufpos + 2 + 2 + 4) >= buflim) {
+        if ((bufpos + RR_TYPE_LENGTH + RR_CLASS_LENGTH + RR_TTL_LENGTH) >= buflim) {
             return -EBADMSG;
         }
         uint16_t _type = ntohs(_get_short(bufpos));
-        bufpos += 2;
+        bufpos += RR_TYPE_LENGTH;
         uint16_t class = ntohs(_get_short(bufpos));
-        bufpos += 2;
-        bufpos += 4; /* skip ttl */
+        bufpos += RR_CLASS_LENGTH;
+        bufpos += RR_TTL_LENGTH; /* skip ttl */
 
         unsigned addrlen = ntohs(_get_short(bufpos));
         /* skip unwanted answers */
@@ -154,7 +156,7 @@ static int _parse_dns_reply(uint8_t *buf, size_t len, void* addr_out, int family
              (family == AF_UNSPEC))) {
             return -EBADMSG;
         }
-        bufpos += 2;
+        bufpos += RR_RDLENGTH_LENGTH;
         if ((bufpos + addrlen) >= buflim) {
             return -EBADMSG;
         }


### PR DESCRIPTION
# Backport of #10740


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Fixes #10739

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I compiled `tests/gnrc_sock_dns` with the following patch:

```diff
diff --git a/tests/gnrc_sock_dns/Makefile b/tests/gnrc_sock_dns/Makefile
index 4ef2c75..0b3824e 100644
--- a/tests/gnrc_sock_dns/Makefile
+++ b/tests/gnrc_sock_dns/Makefile
@@ -11,7 +11,11 @@ USEMODULE += sock_dns
 USEMODULE += gnrc_sock_udp
 USEMODULE += gnrc_ipv6_default
 USEMODULE += gnrc_ipv6_nib_dns
-USEMODULE += gnrc_netdev_default
+USEMODULE += ethos
+
+# ethos baudrate can be configured from make command
+ETHOS_BAUDRATE ?= 115200
+CFLAGS += -DETHOS_BAUDRATE=$(ETHOS_BAUDRATE) -DUSE_ETHOS_FOR_STDIO
 USEMODULE += auto_init_gnrc_netif
 
 USEMODULE += shell_commands
diff --git a/tests/gnrc_sock_dns/main.c b/tests/gnrc_sock_dns/main.c
index 52700fe..b8c2ad5 100644
--- a/tests/gnrc_sock_dns/main.c
+++ b/tests/gnrc_sock_dns/main.c
@@ -40,7 +40,7 @@ int main(void)
     uint8_t addr[16] = {0};
 
     puts("waiting for router advertisement...");
-    xtimer_usleep(1U*1000000);
+    xtimer_usleep(5U*1000000);
 
     /* print network addresses */
     puts("Configured network interfaces:");
```

flashed a `samr21-xpro` (alternatively `pba-d-01-kw2x` as described in #10739 is also possible), and connected an ethos terminal to the node

```
sudo ./dist/tools/ethos/start_network.sh /dev/ttyACM0 tap0 affe:abe::/48
```

I reset the node to get its link-local address for later.

Then I started a RADVD with the following config:

```
interface tap0 {
        AdvSendAdvert on;
        MinRtrAdvInterval 3;
        MaxRtrAdvInterval 10;
        prefix affe:abe::/64 {
                AdvOnLink off;
                AdvAutonomous on;
                AdvRouterAddr on;
        };
        RDNSS <a global address on your host> {
            AdvRDNSSLifetime 60;
        };
};
```

and reconfigured the correct route to the host (the preconfigured route by `start_network.sh` does not work, since uhcpc is not available on the node):

```sh
sudo ip route del affe:abe::/64
sudo ip route add affe:abe::/64 via "<link-local address of node>" dev tap0
```

Then I start the exploit script described in #10739 (or provided by https://github.com/beduino-project/exploit-riot-dns) and reset the node again to start the test. Without this PR the node will crash (note that the exploit described in #10739 does not work but only crashes the node since due to the usage of `ethos` the binary is different), withit it will just report `error resolving example.org`.

I also tested expected operation as described in the application's README.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Fixes #10739.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
