### PR TITLE
backport: 2018.10 compile fixes

### DIFF
--- a/pkg/jerryscript/Makefile.jerryscript
+++ b/pkg/jerryscript/Makefile.jerryscript
@@ -4,6 +4,10 @@ JERRYHEAP  ?= 16
 
 EXT_CFLAGS :=-D__TARGET_RIOT
 
+ifeq ($(TOOLCHAIN)_$(BOARD),llvm_native)
+  EXT_CFLAGS :=-D__TARGET_RIOT -Wno-conversion
+endif
+
 .PHONY: libjerry riot-jerry flash clean
 
 # all: libjerry riot-jerry

--- a/pkg/nimble/Makefile
+++ b/pkg/nimble/Makefile
@@ -14,6 +14,7 @@ CFLAGS += -Wno-extra
 # tell LLVM/clang not to be so pedantic with this.
 ifeq (llvm,$(TOOLCHAIN))
   CFLAGS += -Wno-unused-function
+  CFLAGS += -Wno-address-of-packed-member
 endif
 
 .PHONY: all

--- a/pkg/tinycrypt/Makefile
+++ b/pkg/tinycrypt/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=tinycrypt
 PKG_URL=https://github.com/01org/tinycrypt
-PKG_VERSION=3ea1a609e7aff9f2d8d13803e1076b7a8e551804
+PKG_VERSION=6a22712bebbf2fc60d9fc6192dddefd5ad1933e3
 PKG_LICENSE=BSD-3-Clause
 
 .PHONY: all


### PR DESCRIPTION
# Contribution description

Backport of some compile fixes from master.

- https://github.com/RIOT-OS/RIOT/pull/10503
    - jerryscript warning disable for llvm
    - nimble warning disable for llvm
- https://github.com/RIOT-OS/RIOT/pull/10470
    - tinycrypt commit hash update

# Testing procedure

Compilation by CI should be sufficient.

# Issues/PRs references

Needed to make #10757 pass CI.