### PR TITLE
cpu/esp32: support of NETOPT_LINK_CONNECTED in esp_eth_netdev

### DIFF
--- a/cpu/esp32/esp-eth/esp_eth_netdev.c
+++ b/cpu/esp32/esp-eth/esp_eth_netdev.c
@@ -288,11 +288,18 @@ static int _esp_eth_get(netdev_t *netdev, netopt_t opt, void *val, size_t max_le
     CHECK_PARAM_RET (netdev != NULL, -ENODEV);
     CHECK_PARAM_RET (val != NULL, -EINVAL);
 
+    esp_eth_netdev_t* dev = (esp_eth_netdev_t*)netdev;
+
     switch (opt) {
         case NETOPT_ADDRESS:
             assert(max_len == ETHERNET_ADDR_LEN);
             esp_eth_get_mac((uint8_t *)val);
             return ETHERNET_ADDR_LEN;
+        case NETOPT_LINK_CONNECTED:
+            assert(max_len == 1);
+            *((netopt_enable_t *)val) = (dev->link_up) ? NETOPT_ENABLE
+                                                       : NETOPT_DISABLE;
+            return sizeof(netopt_enable_t);
         default:
             return netdev_eth_get(netdev, opt, val, max_len);
     }


### PR DESCRIPTION
### Contribution description

Support for option `NETOPT_LINK_CONNECTED` added to `esp_eth_netdev::_get`.

### Testing procedure

Compile and flash `examples/gnrc_networking` to an ESP32 board with Ethernet interface, e.g.,

```
USEMODULE="esp_eth" make BOARD=esp32-olimex-evb -C examples/gnrc_networking flash
```
Use the `ifconfig` command before connecting the cable. In this state you should see something like:
```
Iface  7  HWaddr: 30:AE:A4:47:4C:CF  Link: down 
```
After you have connected the cable and the link is up, this output should change to:
```
Iface  7  HWaddr: 30:AE:A4:47:4C:CF  Link: up 
```