### PR TITLE
cpu/kinetis/rtt: clear TPR when writing TSR

### DIFF
--- a/cpu/kinetis/periph/rtt.c
+++ b/cpu/kinetis/periph/rtt.c
@@ -110,6 +110,8 @@ void rtt_set_counter(uint32_t counter)
 {
     /* Disable time counter before writing to the timestamp register */
     bit_clear32(&RTC->SR, RTC_SR_TCE_SHIFT);
+    RTC->TPR = 0;
+    /* write TSR after TPR, as clearing TPR bit 14 will increment TSR */
     RTC->TSR = counter;
     /* Enable when done */
     bit_set32(&RTC->SR, RTC_SR_TCE_SHIFT);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Currently the `periph_rtt` implementation for `kinetis` ignores the subsecond RTC register (`RTC->TPR`). As a result, when `rtc_set_time()` is called, the RTC is left with a known second count but an unknown subsecond count.

This means that setting the RTC incurs an error of +/-1 second.

This PR clears the subsecond register `RTC->TPR` while setting the second register `RTC->TSR` to the requested value so that the RTC is left unambiguously set to the requested time.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

### Testing procedure
Using #10763, run `tests/periph_rtc` with and without this PR on a `kw41z` or other `kinetis` platform.

The RTC alarm error output from the test should be always minimal (<100us) with this PR. Without it, the error will vary +/-1 second and will depend on how and when the last reset occurred. In particular, a power-on reset will synchronize the RTC clock domain and cause good error offsets even without this PR until the next non-POR reset.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
