### PR TITLE
.travis.yml: provide base branch to static tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,6 @@ before_script:
 
 script:
   - docker run -a STDIN -a STDOUT -a STDERR --rm -u "$(id -u)"
+      -e CI_BASE_BRANCH="${TRAVIS_BRANCH}"
       -v "${PWD}:/data/riotbuild" -v /etc/localtime:/etc/localtime:ro
       riot/riotbuild make static-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ services:
 before_install:
   - docker pull riot/riotbuild
 
+before_script:
+  # Fetch the base branch when it is not `master`
+  - git fetch origin "${TRAVIS_BRANCH}:${TRAVIS_BRANCH}"
+
 script:
   - docker run -a STDIN -a STDOUT -a STDERR --rm -u "$(id -u)"
       -v "${PWD}:/data/riotbuild" -v /etc/localtime:/etc/localtime:ro


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
In #10759 we noticed that Travis was trying to rebase to `master`, though the PR was against `2018.10-branch`. I suspect the environment was not set properly in #10251. According to [the Travis documentation](https://docs.travis-ci.com/user/environment-variables/#default-environment-variables) this should be fixed the way I did here.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Run Travis against master and another base branch.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Discovered in #10759, but unrelated.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
