### PR TITLE
cpu/esp*: compile time configurations for ESP MCUs

### DIFF
--- a/cpu/esp32/include/cpu_conf.h
+++ b/cpu/esp32/include/cpu_conf.h
@@ -7,7 +7,10 @@
  */
 
 /**
+ * @defgroup    cpu_esp32_conf ESP32 compile configurations
  * @ingroup     cpu_esp32
+ * @ingroup     config
+ * @brief       Compile-time configuration macros for ESP32 modules
  * @{
  *
  * @file
@@ -29,7 +32,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   Stack size configuration
+ * @name   Stack size configuration
  * @{
  */
 #define THREAD_EXTRA_STACKSIZE_PRINTF (1024)

--- a/cpu/esp8266/include/cpu_conf.h
+++ b/cpu/esp8266/include/cpu_conf.h
@@ -7,7 +7,10 @@
  */
 
 /**
+ * @defgroup    cpu_esp8266_conf ESP8266 compile configurations
  * @ingroup     cpu_esp8266
+ * @ingroup     config
+ * @brief       Compile-time configuration macros for ESP8266 modules
  * @{
  *
  * @file


### PR DESCRIPTION
### Contribution description

This PR adds the groups for ESP MCUs to the `config` group and adds first compile-time configuration macros to these groups.

### Testing procedure

Generate the documentation with `make doc` and check `Modules / Compile time configurations` page for the modules `ESP8266 compile configurations` and `ESP32 compile configurations`.

### Issues/PRs references

This PR is prerequisite for PR #10762 and further upcoming PRs.