### PR TITLE
cpu: cortexm: make newlib a default module

### DIFF
--- a/bootloaders/riotboot/Makefile
+++ b/bootloaders/riotboot/Makefile
@@ -10,6 +10,7 @@ FEATURES_REQUIRED += riotboot
 # Disable unused modules
 CFLAGS += -DNDEBUG -DLOG_LEVEL=LOG_NONE
 DISABLE_MODULE += auto_init
+DISABLE_MODULE += newlib newlib_nano
 
 # Include riotboot flash partition functionality
 USEMODULE += riotboot_slot

--- a/makefiles/arch/cortexm.inc.mk
+++ b/makefiles/arch/cortexm.inc.mk
@@ -37,7 +37,7 @@ export USEMODULE += periph
 export USEMODULE += cortexm_common_periph
 
 # all cortex MCU's use newlib as libc
-export USEMODULE += newlib
+DEFAULT_MODULE += newlib
 
 # set default for CPU_MODEL
 export CPU_MODEL ?= $(CPU)
@@ -143,7 +143,8 @@ endif
 include $(RIOTCPU)/cortexm_common/Makefile.include
 
 # use the nano-specs of Newlib when available
-USEMODULE += newlib_nano
+DEFAULT_MODULE += newlib_nano
+
 # Avoid overriding the default rule:
 all:
 

--- a/tests/minimal/Makefile
+++ b/tests/minimal/Makefile
@@ -5,4 +5,7 @@ CFLAGS += -DNDEBUG -DLOG_LEVEL=LOG_NONE
 
 DISABLE_MODULE += auto_init
 
+# disable newlib. safe to do on non-newlib platforms.
+DISABLE_MODULE += newlib newlib_nano
+
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
### Contribution description

Currently, newlib is always selected using ```USEMODULE``` for all Cortex-M.
This PR turns it into ```DEFAULT_MODULE```. The advantage is that now it can be disabled on-demand using ```DISABLE_MODULE```.

### Testing procedure

CI compiling successfully should be fine.

### Issues/PRs references

With #10744, this allows deployments without newlib altogether in some cases.