### PR TITLE
tools/print_toolchain_versions.sh: use lsb_release.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ services:
   - docker
 
 before_install:
-  - docker pull riot/riotbuild
+  - docker pull jcarrano/riotdocker
 
 script:
   - docker run -a STDIN -a STDOUT -a STDERR --rm -u "$(id -u)"
       -v "${PWD}:/data/riotbuild" -v /etc/localtime:/etc/localtime:ro
-      riot/riotbuild make static-test
+      jcarrano/riotdocker make static-test

--- a/dist/tools/ci/print_toolchain_versions.sh
+++ b/dist/tools/ci/print_toolchain_versions.sh
@@ -38,13 +38,27 @@ get_kernel_info() {
     uname -mprs
 }
 
+have_lsb_release() {
+    lsb_release >/dev/null 2>&1
+    if [ $? == 127 ] ; then
+        return 1
+    else
+        return 0
+    fi
+}
+
 get_os_info() {
     local os="$(uname -s)"
     local osname="unknown"
     local osvers="unknown"
     if [ "$os" = "Linux" ]; then
-        osname="$(cat /etc/os-release | grep ^NAME= | awk -F'=' '{print $2}')"
-        osvers="$(cat /etc/os-release | grep ^VERSION= | awk -F'=' '{print $2}')"
+        if have_lsb_release ; then
+            osname="$(lsb_release -si)"
+            osvers="$(lsb_release -src)"
+        else
+            osname="Unknown Linux"
+            osvers="(please install lsb_release)"
+        fi
     elif [ "$os" = "Darwin" ]; then
         osname="$(sw_vers -productName)"
         osvers="$(sw_vers -productVersion)"

--- a/dist/tools/ci/print_toolchain_versions.sh
+++ b/dist/tools/ci/print_toolchain_versions.sh
@@ -63,7 +63,7 @@ get_os_info() {
         osname="$(sw_vers -productName)"
         osvers="$(sw_vers -productVersion)"
     fi
-    printf "%s %s" "$osname" "$osvers"
+    printf "%s %s" "$osname" "$osvers" | tr [:space:] " "
 }
 
 newlib_version() {

--- a/dist/tools/ci/print_toolchain_versions.sh
+++ b/dist/tools/ci/print_toolchain_versions.sh
@@ -40,7 +40,7 @@ get_kernel_info() {
 
 have_lsb_release() {
     lsb_release >/dev/null 2>&1
-    if [ $? == 127 ] ; then
+    if [ $? -eq 127 ] ; then
         return 1
     else
         return 0


### PR DESCRIPTION
### Contribution description

When trying to run  `./dist/tools/ci/print_toolchain_versions.sh` on my personal machine (Artix linux, that is Arch exorcised of systemd) I found out that the script relies on `/etc/os-release` and that that file is not universally available.

/etc/os-release is only guaranteed to be available on systems using systemd. The lsb_release, on the other hand, should be avaiable on any platform complying to the LSB specification (maybe not by default, but it can be installed from the package manager.)

### Testing procedure

Run `./dist/tools/ci/print_toolchain_versions.sh` on linux, it should correctly report your OS version. Try it on a machine without the lsb_release tool. It should report:

```
Operating System: Unknown Linux (please install lsb_release)
```

## Related PRs

Depends on https://github.com/RIOT-OS/riotdocker/pull/63.