### PR TITLE
drivers/mrf24j40 : support of NETOPT_LAST_ED_LEVEL

### DIFF
--- a/drivers/include/mrf24j40.h
+++ b/drivers/include/mrf24j40.h
@@ -169,14 +169,15 @@ void mrf24j40_setup(mrf24j40_t *dev, const mrf24j40_params_t *params);
 void mrf24j40_reset(mrf24j40_t *dev);
 
 /**
- * @brief   Trigger a clear channel assessment
+ * @brief   Trigger a clear channel assessment & retrieve RSSI
  *
  * @param[in] dev           device to use
+ * @param[in] rssi          RSSI value from register in dBm
  *
  * @return                  true if channel is clear
  * @return                  false if channel is busy
  */
-bool mrf24j40_cca(mrf24j40_t *dev);
+bool mrf24j40_cca(mrf24j40_t *dev, int8_t *rssi);
 
 /**
  * @brief   Get the short address of the given device

--- a/drivers/mrf24j40/include/mrf24j40_registers.h
+++ b/drivers/mrf24j40/include/mrf24j40_registers.h
@@ -336,6 +336,17 @@ extern "C" {
 #define MRF24J40_GPIO_3                 (0x08)
 #define MRF24J40_GPIO_4                 (0x10)
 #define MRF24J40_GPIO_5                 (0x20)
+
+/**
+ * @name    Bitfield definitions for the TRISGPIO register (0x34)
+ * @{
+ */
+#define MRF24J40_TRISGPIO_TRISGP5       (0x20)
+#define MRF24J40_TRISGPIO_TRISGP4       (0x10)
+#define MRF24J40_TRISGPIO_TRISGP3       (0x08)
+#define MRF24J40_TRISGPIO_TRISGP2       (0x04)
+#define MRF24J40_TRISGPIO_TRISGP1       (0x02)
+#define MRF24J40_TRISGPIO_TRISGP0       (0x01)
 /** @} */
 
 /**

--- a/drivers/mrf24j40/mrf24j40.c
+++ b/drivers/mrf24j40/mrf24j40.c
@@ -74,7 +74,7 @@ void mrf24j40_reset(mrf24j40_t *dev)
     DEBUG("mrf24j40_reset(): reset complete.\n");
 }
 
-bool mrf24j40_cca(mrf24j40_t *dev)
+bool mrf24j40_cca(mrf24j40_t *dev, int8_t *rssi)
 {
     uint8_t tmp_ccaedth;
     uint8_t status;
@@ -94,6 +94,9 @@ bool mrf24j40_cca(mrf24j40_t *dev)
     /* return according to measurement */
     tmp_ccaedth = mrf24j40_reg_read_short(dev, MRF24J40_REG_CCAEDTH);       /* Energy detection threshold */
     tmp_rssi = mrf24j40_reg_read_long(dev, MRF24J40_REG_RSSI);
+    if (rssi != NULL) {
+        *rssi = mrf24j40_dbm_from_reg(tmp_rssi);
+    }
 
     mrf24j40_enable_auto_pa_lna(dev);
 

--- a/drivers/mrf24j40/mrf24j40_getset.c
+++ b/drivers/mrf24j40/mrf24j40_getset.c
@@ -407,7 +407,6 @@ void mrf24j40_set_option(mrf24j40_t *dev, uint16_t option, bool state)
     }
 }
 
-
 void mrf24j40_set_state(mrf24j40_t *dev, uint8_t state)
 {
     uint8_t old_state;

--- a/drivers/mrf24j40/mrf24j40_netdev.c
+++ b/drivers/mrf24j40/mrf24j40_netdev.c
@@ -279,13 +279,23 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
             break;
 
         case NETOPT_IS_CHANNEL_CLR:
-            if (mrf24j40_cca(dev)) {
+            if (mrf24j40_cca(dev, NULL)) {
                 *((netopt_enable_t *)val) = NETOPT_ENABLE;
             }
             else {
                 *((netopt_enable_t *)val) = NETOPT_DISABLE;
             }
             res = sizeof(netopt_enable_t);
+            break;
+
+        case NETOPT_LAST_ED_LEVEL:
+            if (max_len < sizeof(int8_t)) {
+                res = -EOVERFLOW;
+            }
+            else {
+                mrf24j40_cca(dev, (int8_t *)val);
+                res = sizeof(int8_t);
+            }
             break;
 
         case NETOPT_CSMA_RETRIES:
@@ -307,6 +317,7 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
                 res = sizeof(int8_t);
             }
             break;
+
         case NETOPT_TX_RETRIES_NEEDED:
             if (max_len < sizeof(uint8_t)) {
                 res = -EOVERFLOW;


### PR DESCRIPTION
### Contribution description

This commit adds the NETOPT "NETOPT_LAST_ED_LEVEL" for the MRF24J40 driver. I needed this for my personal project and it may be useful for the community.

### Testing procedure

I tested my modifications by using the [spectrum-scanner](https://github.com/RIOT-OS/applications/tree/master/spectrum-scanner) application found in RIOT applications page and, mainly, with a custom application based on same principle.

### Issues/PRs references

None

**EDIT** (22.05.2019): I edited this PR to better match the datasheet of MRF24J40MC/MD/ME. It uses macro MRF24J40_USE_EXT_PA_LNA of PR #11410
