### PR TITLE
cpu/stm_common/i2c: set fast mode flag

### DIFF
--- a/cpu/stm32_common/periph/i2c_2.c
+++ b/cpu/stm32_common/periph/i2c_2.c
@@ -92,10 +92,12 @@ void i2c_init(i2c_t dev)
         case I2C_SPEED_NORMAL:
             /* 100Kbit/s */
             ccr = i2c_config[dev].clk / 200000;
+            ccr &= ~I2C_CCR_FS;
             break;
 
         case I2C_SPEED_FAST:
             ccr = i2c_config[dev].clk / 800000;
+            ccr |= I2C_CCR_FS;
             break;
 
         default:


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
Set fast mode flag in CCR register. At the moment fast mode seems to be working fine even though it is not set, but it's cleaner to follow the datasheet.

### Testing procedure
Use I2C in fast mode.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
