### PR TITLE
boards/iotlab-m3: disable DMA with SPI

### DIFF
--- a/boards/common/iotlab/include/periph_conf_common.h
+++ b/boards/common/iotlab/include/periph_conf_common.h
@@ -74,16 +74,12 @@ extern "C" {
  */
 #ifdef MODULE_PERIPH_DMA
 static const dma_conf_t dma_config[] = {
-    { .stream = 1 },    /* DMA1 Channel 2 - SPI1_RX */
-    { .stream = 2 },    /* DMA1 Channel 3 - SPI1_TX */
     { .stream = 3 },    /* DMA1 Channel 4 - USART1_TX */
     { .stream = 5 },    /* DMA1 Channel 6 - USART2_TX */
 };
 
-#define DMA_0_ISR  isr_dma1_channel2
-#define DMA_1_ISR  isr_dma1_channel3
-#define DMA_2_ISR  isr_dma1_channel4
-#define DMA_3_ISR  isr_dma1_channel6
+#define DMA_0_ISR  isr_dma1_channel4
+#define DMA_1_ISR  isr_dma1_channel6
 
 #define DMA_NUMOF           (sizeof(dma_config) / sizeof(dma_config[0]))
 #endif
@@ -129,7 +125,7 @@ static const uart_conf_t uart_config[] = {
         .bus      = APB2,
         .irqn     = USART1_IRQn,
 #ifdef MODULE_PERIPH_DMA
-        .dma        = 2,
+        .dma        = 0,
         .dma_chan   = 2
 #endif
     },
@@ -141,7 +137,7 @@ static const uart_conf_t uart_config[] = {
         .bus      = APB1,
         .irqn     = USART2_IRQn,
 #ifdef MODULE_PERIPH_DMA
-        .dma        = 3,
+        .dma        = 1,
         .dma_chan   = 2
 #endif
     }

--- a/boards/iotlab-m3/include/periph_conf.h
+++ b/boards/iotlab-m3/include/periph_conf.h
@@ -41,9 +41,9 @@ static const spi_conf_t spi_config[] = {
         .rccmask  = RCC_APB2ENR_SPI1EN,
         .apbbus   = APB2,
 #ifdef MODULE_PERIPH_DMA
-        .tx_dma   = 1,
+        .tx_dma   = DMA_STREAM_UNDEF,
         .tx_dma_chan = 1,
-        .rx_dma   = 0,
+        .rx_dma   = DMA_STREAM_UNDEF,
         .rx_dma_chan = 1,
 #endif
     }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is an attempt to improve the situation with #10761. The idea is just to disable the use of DMA on the SPI interface used by the radio on iotlab-m3.

Even if it needs further investigation with the DMA implementation with stm32f1, for the moment this should make networking usable again.

Not tested.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

See #10761 

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

fixes #10761, fixes regression introduced in #9171 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
