### PR TITLE
gnrc_sixlowpan_frag: drop received duplicates

### DIFF
--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.c
@@ -139,7 +139,12 @@ static int _rbuf_add(gnrc_netif_hdr_t *netif_hdr, gnrc_pktsnip_t *pkt,
              * https://tools.ietf.org/html/rfc4944#section-5.3 */
             return RBUF_ADD_REPEAT;
         }
-
+        /* End was already checked in overlap check */
+        if (ptr->start == offset) {
+            DEBUG("6lo rbuf: fragment already in reassembly buffer");
+            gnrc_pktbuf_release(pkt);
+            return RBUF_ADD_SUCCESS;
+        }
         ptr = ptr->next;
     }
 


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Otherwise duplicate fragments are added to the number of already
received datagram bytes in L153 leading to possible race-conditions.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Ping should still work for large packets. Also the expected results from #10701 should be the outcome.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Fixes #10701 (hopefully).
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
