### PR TITLE
tests/periph_flashpage: improve flashpage tests

### DIFF
--- a/tests/periph_flashpage/main.c
+++ b/tests/periph_flashpage/main.c
@@ -310,7 +310,7 @@ static int cmd_test_last(int argc, char **argv)
         }
     }
 
-    if (flashpage_write_and_verify((int)FLASHPAGE_NUMOF - 2, page_mem) != FLASHPAGE_OK) {
+    if (flashpage_write_and_verify((int)FLASHPAGE_NUMOF - 1, page_mem) != FLASHPAGE_OK) {
         puts("error verifying the content of last page");
         return 1;
     }
@@ -336,9 +336,15 @@ static int cmd_test_last_raw(int argc, char **argv)
     memcpy(raw_buf, "test12344321tset", 16);
 
     /* erase the page first */
-    flashpage_write(((int)FLASHPAGE_NUMOF - 2), NULL);
+    flashpage_write(((int)FLASHPAGE_NUMOF - 1), NULL);
 
-    flashpage_write_raw((void*) ((int)CPU_FLASH_BASE + (int)FLASHPAGE_SIZE * ((int)FLASHPAGE_NUMOF - 2)), raw_buf, strlen(raw_buf));
+    flashpage_write_raw(flashpage_addr((int)FLASHPAGE_NUMOF - 1), raw_buf, strlen(raw_buf));
+
+    /* verify that previous write_raw effectively wrote the desired data */
+    if (memcmp(flashpage_addr((int)FLASHPAGE_NUMOF - 1), raw_buf, strlen(raw_buf)) != 0) {
+        puts("error verifying the content of last page");
+        return 1;
+    }
 
     puts("wrote raw short buffer to last flash page");
     return 0;


### PR DESCRIPTION
### Contribution description
Improvements of automatic tests in peripherals flashpage:
-) verify correctness of data written by raw write test (before no actual verification that data was correctly written was done)
-) write to really last flash page and not last - 1 (so name/doc is aligned with functionality and we are testing a more edge case, that is the real last page, than before)
-) use flashpage_addr instead of manual calculation of flash address (code cleanup)

The first two points came out while working on #10069 (the assert error in b8b8ffd16304c2501f7a78d5866b29ce37c48063 would have been spotted before) but had time to go through the test just now.

### Testing procedure
Just build and execute the test in periph_flashpage


