### PR TITLE
examples/gcoap: verify buffer size

### DIFF
--- a/examples/gcoap/gcoap_cli.c
+++ b/examples/gcoap/gcoap_cli.c
@@ -243,7 +243,14 @@ int gcoap_cli_cmd(int argc, char **argv)
         ((argc == apos + 4) && (code_pos != 0))) {
         gcoap_req_init(&pdu, &buf[0], GCOAP_PDU_BUF_SIZE, code_pos+1, argv[apos+2]);
         if (argc == apos + 4) {
-            memcpy(pdu.payload, argv[apos+3], strlen(argv[apos+3]));
+            /* must be 'greater than' to account for payload marker byte */
+            if (pdu.payload_len > strlen(argv[apos+3])) {
+                memcpy(pdu.payload, argv[apos+3], strlen(argv[apos+3]));
+            }
+            else {
+                puts("gcoap_cli: msg buffer too small");
+                return 1;
+            }
         }
         coap_hdr_set_type(pdu.hdr, msg_type);
 

--- a/examples/gcoap/gcoap_cli.c
+++ b/examples/gcoap/gcoap_cli.c
@@ -137,8 +137,15 @@ static ssize_t _riot_board_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, vo
     (void)ctx;
     gcoap_resp_init(pdu, buf, len, COAP_CODE_CONTENT);
     /* write the RIOT board name in the response buffer */
-    memcpy(pdu->payload, RIOT_BOARD, strlen(RIOT_BOARD));
-    return gcoap_finish(pdu, strlen(RIOT_BOARD), COAP_FORMAT_TEXT);
+    /* must be 'greater than' to account for payload marker byte */
+    if (pdu->payload_len > strlen(RIOT_BOARD)) {
+        memcpy(pdu->payload, RIOT_BOARD, strlen(RIOT_BOARD));
+        return gcoap_finish(pdu, strlen(RIOT_BOARD), COAP_FORMAT_TEXT);
+    }
+    else {
+        puts("gcoap_cli: msg buffer too small");
+        return gcoap_response(pdu, buf, len, COAP_CODE_INTERNAL_SERVER_ERROR);
+    }
 }
 
 static size_t _send(uint8_t *buf, size_t len, char *addr_str, char *port_str)


### PR DESCRIPTION
### Contribution description
Verifies the message buffer used in the  gcoap CLI examples are large enough. The buffer is sized by the GCOAP_PDU_BUF_SIZE macro. This macro is user configurable, and this PR verifies that the user has not reduced it too much. This update also illustrates how to perform this check for a user's own applications.

There are two issues in the example: the size of the buffer to write a POST/PUT request, and the size of the buffer to write a response for /riot/board.

### Testing procedure
To test a POST request: 

- compile the gcoap example with `CFLAGS="-DGCOAP_PDU_BUF_SIZE=24"`
- create a tap bridge with `tapsetup -c 2` and start two gcoap example instances

Send the commands below to see success and failure. Disregard the error response in the first example. For this test we care only that the request was sent:
```
coap put fd00:bbbb::1 5683 /riot/board 01
gcoap_cli: sending msg ID 36925, 21 bytes
> gcoap: response Error, code 4.05, empty payload

> coap put fd00:bbbb::1 5683 /riot/board 012
gcoap_cli: msg buffer too small
```

To test /riot/board server response is more complicated:

First modify _riot_board_handler() to use "arduino-duemilanove" as the name of the board, rather than the definition of RIOT_BOARD, which is "native".

- compile the gcoap example with `CFLAGS="-DGCOAP_PDU_BUF_SIZE=30"`
- create a tap bridge with `tapsetup -c 2` and start two gcoap example instances

From the client send,
```
> coap get fd00:bbbb::1 5683 /riot/board
coap get fd00:bbbb::1 5683 /riot/board
gcoap_cli: sending msg ID 46325, 17 bytes
> gcoap: response Success, code 2.05, 19 bytes
arduino-duemilanove
```

Now recompile the example with GCOAP_PDU_BUF_SIZE=29, and run the test again. In this case, the response is a code 5.00 Error. On the server terminal, you will see `gcoap_cli: msg buffer too small`

### Issues/PRs references
-none-