### PR TITLE
cpu/stm32f0: add missing definition for M1 bit

### DIFF
--- a/cpu/stm32f0/include/vendor/stm32f030x8.h
+++ b/cpu/stm32f0/include/vendor/stm32f030x8.h
@@ -4757,7 +4757,7 @@ typedef struct
 #define USART_CR1_WAKE                USART_CR1_WAKE_Msk                       /*!< Receiver Wakeup method */
 #define USART_CR1_M_Pos               (12U)
 #define USART_CR1_M_Msk               (0x1U << USART_CR1_M_Pos)                /*!< 0x00001000 */
-#define USART_CR1_M                   USART_CR1_M_Msk                          /*!< Word Length */
+#define USART_CR1_M                   USART_CR1_M_Msk                          /*!< Word Length - Bit 0 */
 #define USART_CR1_MME_Pos             (13U)
 #define USART_CR1_MME_Msk             (0x1U << USART_CR1_MME_Pos)              /*!< 0x00002000 */
 #define USART_CR1_MME                 USART_CR1_MME_Msk                        /*!< Mute Mode Enable */
@@ -4789,6 +4789,9 @@ typedef struct
 #define USART_CR1_EOBIE_Pos           (27U)
 #define USART_CR1_EOBIE_Msk           (0x1U << USART_CR1_EOBIE_Pos)            /*!< 0x08000000 */
 #define USART_CR1_EOBIE               USART_CR1_EOBIE_Msk                      /*!< End of Block interrupt enable */
+#define USART_CR1_M1_Pos              (28U)
+#define USART_CR1_M1_Msk              (0x1U << USART_CR1_M1_Pos)               /*!< 0x10000000 */
+#define USART_CR1_M1                  USART_CR1_M1_Msk                         /*!< Word length - Bit 1 */
 
 /******************  Bit definition for USART_CR2 register  *******************/
 #define USART_CR2_ADDM7_Pos           (4U)

--- a/cpu/stm32f0/include/vendor/stm32f031x6.h
+++ b/cpu/stm32f0/include/vendor/stm32f031x6.h
@@ -4935,7 +4935,7 @@ typedef struct
 #define USART_CR1_WAKE                USART_CR1_WAKE_Msk                       /*!< Receiver Wakeup method */
 #define USART_CR1_M_Pos               (12U)
 #define USART_CR1_M_Msk               (0x1U << USART_CR1_M_Pos)                /*!< 0x00001000 */
-#define USART_CR1_M                   USART_CR1_M_Msk                          /*!< Word Length */
+#define USART_CR1_M                   USART_CR1_M_Msk                          /*!< Word Length - Bit 0 */
 #define USART_CR1_MME_Pos             (13U)
 #define USART_CR1_MME_Msk             (0x1U << USART_CR1_MME_Pos)              /*!< 0x00002000 */
 #define USART_CR1_MME                 USART_CR1_MME_Msk                        /*!< Mute Mode Enable */
@@ -4967,6 +4967,9 @@ typedef struct
 #define USART_CR1_EOBIE_Pos           (27U)
 #define USART_CR1_EOBIE_Msk           (0x1U << USART_CR1_EOBIE_Pos)            /*!< 0x08000000 */
 #define USART_CR1_EOBIE               USART_CR1_EOBIE_Msk                      /*!< End of Block interrupt enable */
+#define USART_CR1_M1_Pos              (28U)
+#define USART_CR1_M1_Msk              (0x1U << USART_CR1_M1_Pos)               /*!< 0x10000000 */
+#define USART_CR1_M1                  USART_CR1_M1_Msk                         /*!< Word length - Bit 1 */
 
 /******************  Bit definition for USART_CR2 register  *******************/
 #define USART_CR2_ADDM7_Pos           (4U)

--- a/cpu/stm32f0/include/vendor/stm32f051x8.h
+++ b/cpu/stm32f0/include/vendor/stm32f051x8.h
@@ -3259,7 +3259,7 @@ typedef struct
 #define  USART_CR1_PS                        ((uint32_t)0x00000200)            /*!< Parity Selection */
 #define  USART_CR1_PCE                       ((uint32_t)0x00000400)            /*!< Parity Control Enable */
 #define  USART_CR1_WAKE                      ((uint32_t)0x00000800)            /*!< Receiver Wakeup method */
-#define  USART_CR1_M0                        ((uint32_t)0x00001000)            /*!< Word length bit 0 */
+#define  USART_CR1_M0                        ((uint32_t)0x00001000)            /*!< Word length - Bit 0 */
 #define  USART_CR1_M                         ((uint32_t)0x00001000)            /*!< SmartCard Length */
 #define  USART_CR1_MME                       ((uint32_t)0x00002000)            /*!< Mute Mode Enable */
 #define  USART_CR1_CMIE                      ((uint32_t)0x00004000)            /*!< Character match interrupt enable */
@@ -3278,6 +3278,7 @@ typedef struct
 #define  USART_CR1_DEAT_4                    ((uint32_t)0x02000000)            /*!< Bit 4 */
 #define  USART_CR1_RTOIE                     ((uint32_t)0x04000000)            /*!< Receive Time Out interrupt enable */
 #define  USART_CR1_EOBIE                     ((uint32_t)0x08000000)            /*!< End of Block interrupt enable */
+#define  USART_CR1_M1                        ((uint32_t)0x10000000)            /*!< Word length - Bit 1 */
 
 /******************  Bit definition for USART_CR2 register  *******************/
 #define  USART_CR2_ADDM7                     ((uint32_t)0x00000010)            /*!< 7-bit or 4-bit Address Detection */


### PR DESCRIPTION
### Contribution description

USART_CR1_M1 bit enables 7-bit mode for stm32f0x0 UARTs. All other headers for this device family already provide this definition. So this PR just adds missing ones.

### Issues/PRs references

PR #10743 depends on it.