### PR TITLE
nrfmin: remove long address support

### DIFF
--- a/cpu/nrf5x_common/include/nrfmin.h
+++ b/cpu/nrf5x_common/include/nrfmin.h
@@ -163,16 +163,6 @@ uint16_t nrfmin_get_addr(void);
 void nrfmin_set_addr(uint16_t addr);
 
 /**
- * @brief   Get a pseudo 64-bit long address (needed by IPv6 and 6LoWPAN)
- *
- * As we do not support 64-bit addresses, we just make one up, for this we
- * simply return 4 times concatenated the 16-bit address.
- *
- * @param[out] addr     64-bit pseudo long address, as array of 4 * 16-bit
- */
-void nrfmin_get_pseudo_long_addr(uint16_t *addr);
-
-/**
  * @brief   Get the IID build from the 16-bit node address
  *
  * @param[out] iid      the 64-bit IID, as array of 4 * 16-bit

--- a/cpu/nrf5x_common/radio/nrfmin/nrfmin.c
+++ b/cpu/nrf5x_common/radio/nrfmin/nrfmin.c
@@ -188,13 +188,6 @@ uint16_t nrfmin_get_addr(void)
     return my_addr;
 }
 
-void nrfmin_get_pseudo_long_addr(uint16_t *addr)
-{
-    for (int i = 0; i < 4; i++) {
-        addr[i] = my_addr;
-    }
-}
-
 void nrfmin_get_iid(uint16_t *iid)
 {
     iid[0] = 0;
@@ -487,10 +480,6 @@ static int nrfmin_get(netdev_t *dev, netopt_t opt, void *val, size_t max_len)
             assert(max_len >= sizeof(uint16_t));
             *((uint16_t *)val) = NRFMIN_PAYLOAD_MAX;
             return sizeof(uint16_t);
-        case NETOPT_ADDRESS_LONG:
-            assert(max_len >= sizeof(uint64_t));
-            nrfmin_get_pseudo_long_addr((uint16_t *)val);
-            return sizeof(uint64_t);
         case NETOPT_ADDR_LEN:
             assert(max_len >= sizeof(uint16_t));
             *((uint16_t *)val) = 2;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
The driver is claiming it is needed for IPv6 / 6LoWPAN support, which
is not true (the long address is never used for NRFMIN in fact) and
this assumption actually leads to an assertion when compiled as with
the `gnrc_border_router` example.

 I talked to @haukepetersen about this and he agrees that this address type is not at all required.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Compile `gnrc_border_router` for an `nrfmin` supporting board. If you type `ifconfig` it should not run into an assertion anymore. Ping between two boards should still work.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
