### PR TITLE
make: add ubsan support

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -269,6 +269,9 @@ TOOLCHAINS_SUPPORTED ?= gnu
 # Import all toolchain settings
 include $(RIOTMAKE)/toolchain/$(TOOLCHAIN).inc.mk
 
+# include undefined behaviour sanitizer (UBSAN) support
+include $(RIOTMAKE)/ubsan.inc.mk
+
 # Tell ccache to pass the original file to the compiler, instead of passing the
 # preprocessed code. Without this setting, the compilation will fail with
 # -Wimplicit-fallthrough warnings even when the fall through case is properly

--- a/makefiles/ubsan.inc.mk
+++ b/makefiles/ubsan.inc.mk
@@ -1,0 +1,62 @@
+# Copyright (C) 2019 Kaspar Schleiser <kaspar@schleiser.de>
+#
+# # Introduction
+#
+# This file contains makefile convenience support for gcc/clang's undefined
+# behaviour sanitizer.
+#
+# # Overview
+#
+# Both gcc and clang allow generation on code that does runtime checks for
+# undefined behavior (UB).
+#
+# E.g., the following code might trigger UB for some parameters:
+#
+#   void test(int foo) {
+#     return (foo << 24);
+#   }
+#
+#  In this case, the signed shift would be alright unless it would "push out"
+#  bits to the left, with undefined runtime result. Using ubsan, this can be
+#  caught.
+#
+# # How to use
+#
+# 1. build with "UBSAN_ENABLE=1". This will cause a trap on undefined
+# behaviour.
+#
+# 2. build with "UBSAN_ENABLE=1 UBSAN_MODE=msg_exit" will print where and how
+# the undefined behaviour occured, then exit with error code.  This is only
+# available on native built with gcc.
+#
+
+# use this to switch on ubsan
+UBSAN_ENABLE ?= 0
+
+# trap, msg_exit, msg_recover
+UBSAN_MODE ?= trap
+
+ifeq (1,$(UBSAN_ENABLE))
+  CFLAGS += -fsanitize=undefined
+
+  ifeq (gnu,$(TOOLCHAIN))
+    ifeq (native,$(BOARD))
+      ifneq (,$(filter msg_%,$(UBSAN_MODE)))
+        LINKFLAGS += -lubsan
+        ifneq (msg_recover,$(UBSAN_MODE))
+          CFLAGS += -fno-sanitize-recover=undefined
+        endif
+      else
+        CFLAGS += -fsanitize-undefined-trap-on-error
+      endif
+    else
+      # on real hardware, there's currently no runtime support.
+      # so just crash when undefined behaviour is triggered.
+      CFLAGS += -fsanitize-undefined-trap-on-error
+    endif
+  else
+    # libubsan doesn't link properly when using clang.
+    # thus when using llvm as toolchain, always generate traps.
+    CFLAGS += -fsanitize-trap=undefined
+  endif
+endif

--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -1,6 +1,9 @@
 DEVELHELP ?= 0
 include ../Makefile.tests_common
 
+# enable trap on undefined behaviour
+UBSAN_ENABLE ?= 1
+
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon \
                              arduino-duemilanove \
                              arduino-mega2560 \

--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -1,8 +1,14 @@
 DEVELHELP ?= 0
 include ../Makefile.tests_common
 
-# enable trap on undefined behaviour
-UBSAN_ENABLE ?= 1
+ifeq (native, $(BOARD))
+  # enable undefined behaviour runtime detection
+  UBSAN_ENABLE ?= 1
+  # if UB is detected, print error, then exit
+  UBSAN_MODE ?= msg_exit
+  # In order to locate the location where the undefined behaviour was
+  # triggered, recompile with UBSAN_MODE=trap and run in gdb.
+endif
 
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon \
                              arduino-duemilanove \


### PR DESCRIPTION
### Contribution description

Both gcc and clang allow generation of code to check for undefined behaviour at runtime, called the "undefined behaviour sanitizer" (ubsan).
This PR adds some Makefile logic to enable it.

It also includes a commit that enables ubsan for the unittests.

Marked WIP as there are currently quite some hits for the unittests.

### Testing procedure

Run unittests on native and hardware.

### Issues/PRs references

-