### PR TITLE
cpu/native/periph/timer: fix type conversion

### DIFF
--- a/cpu/native/periph/timer.c
+++ b/cpu/native/periph/timer.c
@@ -66,7 +66,7 @@ static struct itimerval itv;
 static unsigned long ts2ticks(struct timespec *tp)
 {
     /* TODO: check for overflow */
-    return((tp->tv_sec * NATIVE_TIMER_SPEED) + (tp->tv_nsec / 1000));
+    return(((unsigned long)tp->tv_sec * NATIVE_TIMER_SPEED) + (tp->tv_nsec / 1000));
 }
 
 /**


### PR DESCRIPTION
### Contribution description

Depending on the definition of time_t, a calculation returning unsigned long would use signed long as intermediary type, causing undefined behaviour for some inputs.

This PR helps by explicitly casting.

### Testing procedure

Previous behaviour relied on two's compliment wrap, which apparently worked by chance. Anyhow, running the CI tests on native should be sufficient.

### Issues/PRs references

Found using #10782.