### PR TITLE
fmt: fix fmt_s32_dec() and fmt_s64_dec() sign bit handling

### DIFF
--- a/sys/fmt/fmt.c
+++ b/sys/fmt/fmt.c
@@ -265,25 +265,33 @@ size_t fmt_u16_dec(char *out, uint16_t val)
 size_t fmt_s64_dec(char *out, int64_t val)
 {
     unsigned negative = (val < 0);
+    uint64_t sval;
     if (negative) {
         if (out) {
             *out++ = '-';
         }
-        val = -val;
+        sval = -(uint64_t)(val);
     }
-    return fmt_u64_dec(out, val) + negative;
+    else {
+        sval = +(uint64_t)(val);
+    }
+    return fmt_u64_dec(out, sval) + negative;
 }
 
 size_t fmt_s32_dec(char *out, int32_t val)
 {
     unsigned negative = (val < 0);
+    uint32_t sval;
     if (negative) {
         if (out) {
             *out++ = '-';
         }
-        val = -val;
+        sval = -((uint32_t)(val));
     }
-    return fmt_u32_dec(out, val) + negative;
+    else {
+        sval = +((uint32_t)(val));
+    }
+    return fmt_u32_dec(out, sval) + negative;
 }
 
 size_t fmt_s16_dec(char *out, int16_t val)


### PR DESCRIPTION
### Contribution description
```val = -val``` causes undefined behaviour for INTMIN.

E.g., because int32_t can hold values from -2,147,483,648 to 2,147,483,647, thus 2,147,483,648 cannot be represented.

This PR makes the conversion explicit through casting.

### Testing procedure

The generated binary should be identical.

### Issues/PRs references

Found using #10782.