### PR TITLE
gnrc/pktbuf: avoid memcpy if size <= 0

### DIFF
--- a/sys/net/gnrc/pktbuf_static/gnrc_pktbuf_static.c
+++ b/sys/net/gnrc/pktbuf_static/gnrc_pktbuf_static.c
@@ -380,11 +380,11 @@ static gnrc_pktsnip_t *_create_snip(gnrc_pktsnip_t *next, const void *data, size
             _pktbuf_free(pkt, sizeof(gnrc_pktsnip_t));
             return NULL;
         }
+        if (data != NULL) {
+            memcpy(_data, data, size);
+        }
     }
     _set_pktsnip(pkt, next, _data, size, type);
-    if (data != NULL) {
-        memcpy(_data, data, size);
-    }
     return pkt;
 }
 


### PR DESCRIPTION
### Contribution description

ubsan complains about memcpy called with a NULL pointer. Though this only happens if the size parameter is 0, it should be avoided.

This PR solves this by moving the memcpy into the ```size > 0``` block.

### Testing procedure

No idea. Unittests should be enough?

### Issues/PRs references

Found via #10782.