### PR TITLE
sys/shell: Exit the shell on ctrl-D

### DIFF
--- a/sys/shell/shell.c
+++ b/sys/shell/shell.c
@@ -33,6 +33,8 @@
 #include "shell_commands.h"
 
 #define ETX '\x03'  /** ASCII "End-of-Text", or ctrl-C */
+#define EOT '\x04'  /** ASCII "End-of-Transmission", or ctrl-D */
+
 #if !defined(SHELL_NO_ECHO) || !defined(SHELL_NO_PROMPT)
 #ifdef MODULE_NEWLIB
 /* use local copy of putchar, as it seems to be inlined,
@@ -237,7 +239,7 @@ static int readline(char *buf, size_t size)
         }
 
         int c = getchar();
-        if (c < 0) {
+        if (c < 0 || c == EOT) {
             return EOF;
         }
 

--- a/tests/shell/main.c
+++ b/tests/shell/main.c
@@ -78,6 +78,14 @@ int main(void)
     /* define own shell commands */
     shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
 
+    puts("shell exited (1)");
+
+    /* Restart the shell after the previous one exits, so that we can test
+     * ctrl-D exit */
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    puts("shell exited (2)");
+
     /* or use only system shell commands */
     /*
     shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);

--- a/tests/shell/tests/01-run.py
+++ b/tests/shell/tests/01-run.py
@@ -50,6 +50,8 @@ CMDS = (
     ('help', EXPECTED_HELP),
     ('echo a string', ('\"echo\"\"a\"\"string\"')),
     ('ps', EXPECTED_PS),
+    ('reboot', ('test_shell.')),
+    (CONTROL_D, ('shell exited (1)')),
     ('garbage1234'+CONTROL_C, ('>')),  # test cancelling a line
     ('help', EXPECTED_HELP),
     ('reboot', ('test_shell.'))


### PR DESCRIPTION
### Contribution description

**Note** the control-C part of this PR was split to #11004 .

Right now the only way to exit the shell is if stdin is closed. This works on native, but on an embedded platform stdin is the uart and thus is never closed.

This patch causes the shell loop to exit on EOT (ASCII 0x04 / ctrl-D a.k.a. "End-of-Transmission".)

### Testing procedure

Run the test in `tests/shell` with `native` _and_ with a board.

```
$ cd tests/shell
$ BOARD=samr21-xpro make all
$ BOARD=samr21-xpro make flash
$ BOARD=samr21-xpro make test
```

To test it by hand with a board, use a terminal program that passes ctrl-D to the tty. In native, use Ctrl-V ctrl-D to insert a literal EOT.

### Related PRs

Depends on #11003 , #11004.
