### PR TITLE
pkg/jerryscript: namespace BUILD_DIR variable

### DIFF
--- a/pkg/jerryscript/Makefile.jerryscript
+++ b/pkg/jerryscript/Makefile.jerryscript
@@ -1,4 +1,4 @@
-BUILD_DIR  ?= $(BINDIR)/jerryscript
+JERRYSCRIPT_BUILD_DIR  ?= $(BINDIR)/jerryscript
 
 JERRYHEAP  ?= 16
 
@@ -27,7 +27,7 @@ endif
 all: libjerry
 
 libjerry:
-	cmake -B$(BUILD_DIR) -H./ \
+	cmake -B$(JERRYSCRIPT_BUILD_DIR) -H./ \
 	 -DCMAKE_SYSTEM_NAME=RIOT \
 	 -DCMAKE_SYSTEM_PROCESSOR="$(MCPU)" \
 	 -DCMAKE_C_COMPILER=$(CC) \
@@ -42,7 +42,7 @@ libjerry:
 	 -DEXTERNAL_COMPILE_FLAGS="$(INCLUDES) $(EXT_CFLAGS)" \
 	 -DMEM_HEAP_SIZE_KB=$(JERRYHEAP)
 
-	"$(MAKE)" -C $(BUILD_DIR) jerry-core jerry-ext jerry-port-default-minimal
-	cp $(BUILD_DIR)/lib/libjerry-core.a $(BINDIR)/jerryscript.a
-	cp $(BUILD_DIR)/lib/libjerry-ext.a $(BINDIR)/jerryscript-ext.a
-	cp $(BUILD_DIR)/lib/libjerry-port-default-minimal.a $(BINDIR)/jerryport-minimal.a
+	"$(MAKE)" -C $(JERRYSCRIPT_BUILD_DIR) jerry-core jerry-ext jerry-port-default-minimal
+	cp $(JERRYSCRIPT_BUILD_DIR)/lib/libjerry-core.a $(BINDIR)/jerryscript.a
+	cp $(JERRYSCRIPT_BUILD_DIR)/lib/libjerry-ext.a $(BINDIR)/jerryscript-ext.a
+	cp $(JERRYSCRIPT_BUILD_DIR)/lib/libjerry-port-default-minimal.a $(BINDIR)/jerryport-minimal.a


### PR DESCRIPTION
### Contribution description

I forgot to git grep when merging `BUILD_DIR` and I found issues about it.

BUILD_DIR was introduced but the variable was already used by
`pkg/jerryscript` so there is a name collision.
Namespace it to prevent issues.


### Testing procedure

Build `examples/javascript` and the `build` directory should not be created, and the archives will be generated in `examples/javascript/bin/native/jerryscript/lib/`
When building in docker, `build` will be created but empty.

There is no more other usages now in the repository:

```
git grep '(BUILD_DIR)'
Makefile.include:override BUILD_DIR      := $(abspath $(BUILD_DIR))
makefiles/docker.inc.mk:        $(Q)mkdir -p $(BUILD_DIR)
makefiles/docker.inc.mk:            -v '$(BUILD_DIR):$(DOCKER_BUILD_ROOT)/build' \
```

### Issues/PRs references

Original PR https://github.com/RIOT-OS/RIOT/pull/10038