### PR TITLE
tests/build_system_utils: fix TESTS name collision

### DIFF
--- a/tests/build_system_utils/Makefile
+++ b/tests/build_system_utils/Makefile
@@ -16,13 +16,13 @@ endef
 
 MAKEFILES_UTILS = $(RIOTMAKE)/utils
 
-TESTS = test-ensure_value test-ensure_value-negative
+COMPILE_TESTS = test-ensure_value test-ensure_value-negative
 
 # Tests will be run both in the host machine and in `docker`
 all: build-system-utils-tests
 
-build-system-utils-tests: $(TESTS)
-.PHONY: build-system-utils-tests $(TESTS)
+build-system-utils-tests: $(COMPILE_TESTS)
+.PHONY: build-system-utils-tests $(COMPILE_TESTS)
 
 
 # tests for 'ensure_value'


### PR DESCRIPTION
### Contribution description

TESTS is used to find the tests files for the application but was used
to list test targets. Rename to COMPILE_TESTS as already done in some of
my other applications.


### Testing procedure

With this PR:
```
make -C tests/build_system_utils/ test
make: Entering directory '/home/harter/work/git/worktree/riot_master/tests/build_system_utils'
make: Leaving directory '/home/harter/work/git/worktree/riot_master/tests/build_system_utils'
```

In master:

```make -C tests/build_system_utils/ test
make: Entering directory '/home/harter/work/git/worktree/riot_master/tests/build_system_utils'
/bin/sh: 2: test-ensure_value: not found
/home/harter/work/git/worktree/riot_master/tests/build_system_utils/../../Makefile.include:570: recipe for target 'test' failed
make: *** [test] Error 1
make: Leaving directory '/home/harter/work/git/worktree/riot_master/tests/build_system_utils'
```

### Issues/PRs references

Found while executing `Release-Specs/02-tests/compile_and_test.py`.