### PR TITLE
net/gcoap: make options buf macros configurable

### DIFF
--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -259,6 +259,36 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Reduce payload length by this value for a request
+ *
+ * Accommodates writing Content-Format option in gcoap_finish(). May set to
+ * zero if function not used.
+ */
+#ifndef GCOAP_REQ_OPTIONS_BUF
+#define GCOAP_REQ_OPTIONS_BUF   (4)
+#endif
+
+/**
+ * @brief   Reduce payload length by this value for a response
+ *
+ * Accommodates writing Content-Format option in gcoap_finish(). May set to
+ * zero if function not used.
+ */
+#ifndef GCOAP_RESP_OPTIONS_BUF
+#define GCOAP_RESP_OPTIONS_BUF  (4)
+#endif
+
+/**
+ * @brief   Reduce payload length by this value for an observe notification
+ *
+ * Accommodates writing Content-Format option in gcoap_finish(). May set to
+ * zero if function not used.
+ */
+#ifndef GCOAP_OBS_OPTIONS_BUF
+#define GCOAP_OBS_OPTIONS_BUF   (4)
+#endif
+
+/**
  * @brief   Maximum number of requests awaiting a response
  */
 #ifndef GCOAP_REQ_WAITING_MAX

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -38,15 +38,6 @@
 #define GCOAP_RESOURCE_WRONG_METHOD -1
 #define GCOAP_RESOURCE_NO_PATH -2
 
-/*
- * Reduce payload length by this value for a request created with
- * gcoap_req_init(), gcoap_resp_init(), and gcoap_obs_init(), respectively.
- * Accommodates writing Content-Format option in gcoap_finish().
- */
-#define GCOAP_REQ_OPTIONS_BUF   (4)
-#define GCOAP_RESP_OPTIONS_BUF  (4)
-#define GCOAP_OBS_OPTIONS_BUF   (4)
-
 /* Internal functions */
 static void *_event_loop(void *arg);
 static void _listen(sock_udp_t *sock);


### PR DESCRIPTION
### Contribution description
By default, the GCOAP_xxx_OPTIONS_BUF macros set aside four bytes in a message buffer to insert a Content-Format option during gcoap_finish(). However, the new Pkt Add API no longer uses gcoap_finish(). In this case, the user can save a little memory by zeroing these macros. This PR makes the macros externally configurable. After merging this PR, I will add them to the gcoap config doc group per #10566.

This PR undoes commit 034c78d in #9156 that moved the macros into gcoap.c. It is more important to include them in the new config doc group so the user is aware of them.

### Testing procedure
Just compiling the gcoap example ensures the macros still are defined. You also could try sending and receiving a message in the example.

### Issues/PRs references
-none-