### PR TITLE
esp8266: esp_wifi netdev driver

### DIFF
--- a/cpu/esp8266/Makefile
+++ b/cpu/esp8266/Makefile
@@ -7,4 +7,8 @@ DIRS += periph
 DIRS += sdk
 DIRS += vendor
 
+ifneq (, $(filter esp_wifi, $(USEMODULE)))
+    DIRS += esp-wifi
+endif
+
 include $(RIOTBASE)/Makefile.base

--- a/cpu/esp8266/Makefile.dep
+++ b/cpu/esp8266/Makefile.dep
@@ -12,6 +12,7 @@ endif
 
 ifneq (, $(filter esp_wifi, $(USEMODULE)))
     CFLAGS += -DLWIP_OPEN_SRC
+    INCLUDES += -I$(ESP8266_SDK_DIR)/third_party/include
     LINKFLAGS += -Wl,-wrap=ethernet_input
     USEMODULE += netdev_eth
 endif

--- a/cpu/esp8266/Makefile.dep
+++ b/cpu/esp8266/Makefile.dep
@@ -2,6 +2,14 @@
 
 ifneq (, $(filter esp_sdk, $(USEMODULE)))
     USEMODULE += core_thread_flags
+    LINKFLAGS += -Wl,-wrap=malloc
+    LINKFLAGS += -Wl,-wrap=free
+    LINKFLAGS += -Wl,-wrap=calloc
+    LINKFLAGS += -Wl,-wrap=realloc
+    LINKFLAGS += -Wl,-wrap=_malloc_r
+    LINKFLAGS += -Wl,-wrap=_free_r
+    LINKFLAGS += -Wl,-wrap=_realloc_r
+    LINKFLAGS += -Wl,-wrap=mallinfo
 endif
 
 ifneq (, $(filter esp_spiffs, $(USEMODULE)))

--- a/cpu/esp8266/Makefile.dep
+++ b/cpu/esp8266/Makefile.dep
@@ -10,6 +10,12 @@ ifneq (, $(filter esp_spiffs, $(USEMODULE)))
     USEMODULE += vfs
 endif
 
+ifneq (, $(filter esp_wifi, $(USEMODULE)))
+    CFLAGS += -DLWIP_OPEN_SRC
+    LINKFLAGS += -Wl,-wrap=ethernet_input
+    USEMODULE += netdev_eth
+endif
+
 ifneq (, $(filter lua, $(USEPKG)))
     USEMODULE += newlib_syscalls_default
     USEMODULE += xtimer

--- a/cpu/esp8266/Makefile.include
+++ b/cpu/esp8266/Makefile.include
@@ -33,6 +33,12 @@ ifneq (, $(filter esp_sw_timer, $(USEMODULE)))
     USEMODULE += esp_sdk
 endif
 
+ifneq (, $(filter esp_now esp_wifi, $(USEMODULE)))
+    $(eval GNRC_NETIF_NUMOF=$(shell echo $$(($(GNRC_NETIF_NUMOF)+1))))
+    USEMODULE += esp_sdk
+    USEMODULE += netopt
+endif
+
 ifneq (, $(filter esp_gdbstub, $(USEMODULE)))
     USEMODULE += esp_gdb
 endif

--- a/cpu/esp8266/doc.txt
+++ b/cpu/esp8266/doc.txt
@@ -27,14 +27,17 @@
     6. [Timers](#esp8266_timers)
     7. [SPIFFS Device](#esp8266_spiffs_device)
     8. [Other Peripherals](#esp8266_other_peripherals)
-6. [Preconfigured Devices](#esp8266_preconfigured_devices)
+6. [Network Interfaces](#esp8266_network_interfaces)
+    1. [WiFi Network Interface](#esp8266_wifi_network_interface)
+    2. [ESP-NOW Network Interface](#esp8266_esp_now_network_interface)
+7. [Preconfigured Devices](#esp8266_preconfigured_devices)
     1. [Network Devices](#esp8266_network_devices)
     2. [SD-Card Device](#esp8266_sd_card_device)
-7. [Application-Specific Configurations](#esp8266_application_specific_configurations)
+8. [Application-Specific Configurations](#esp8266_application_specific_configurations)
     1. [Application-Specific Board Configuration](#esp8266_application_specific_board_configuration)
     2. [Application-Specific Driver Configuration](#esp8266_application_specific_driver_configuration)
-8. [SDK Task Handling](#esp8266_sdk_task_handling)
-9. [QEMU Mode and GDB](#esp8266_qemu_mode_and_gdb)
+9. [SDK Task Handling](#esp8266_sdk_task_handling)
+10. [QEMU Mode and GDB](#esp8266_qemu_mode_and_gdb)
 
 # <a name="esp8266_overview"> Overview </a> &nbsp;&nbsp; [[TOC](#esp8266_toc)]
 
@@ -353,9 +356,11 @@ Optional features of ESP8266 can be enabled by ```USEMODULE``` definitions in th
 Module | Description
 -------|------------
 [esp_gdb](#esp8266_qemu_mode_and_gdb) | Enable the compilation with debug information, which is equivalent to using ```ENABLE_GDB=1```
+[esp_now](#esp8266_esp_now_network_interface) | Enable the built-in WiFi module with the ESP-NOW protocol as `netdev` network device
 [esp_sdk](#esp8266_sdk_task_handling) | Enable the SDK version, which is equivalent to using ```USE_SDK=1```
 [esp_spiffs](#esp8266_spiffs_device) | Enable the SPIFFS drive in on-board flash memory
 [esp_sw_timer](#esp8266_timers) | Enable software timer implementation, implies the setting ```USE_SDK=1``` (module ```esp_sdk```)
+[esp_wifi](#esp8266_wifi_network_interface) | Use the built-in WiFi module as `netdev` network device
 
 </center><br>
 
@@ -562,6 +567,104 @@ The ESP8266 port of RIOT also supports
 - power management functions.
 
 RTC is not yet implemented.
+
+# <a name="esp8266_network_interfaces"> Network Interfaces </a> &nbsp;[[TOC](#esp8266_toc)]
+
+ESP8266 provides different built-in possibilities to realize network devices:
+
+- <b>ESP WiFi</b>, usual AP-based wireless LAN (not yet supported)
+- <b>ESP-NOW</b>, a WiFi based AP-less and connectionless peer to peer communication protocol
+
+\anchor esp8266_wifi_network_interface
+## <a name="esp8266_wifi_network_interface"> WiFi Network Interface </a> &nbsp;[[TOC](#esp8266_toc)]
+
+The RIOT port for ESP8266 implements in module `esp_wifi` a `netdev` driver for
+the built-in WiFi interface.
+
+@note Due to symbol conflicts with the `crypto` and `hash` modules of RIOT
+in vendor library `libwpa.so`, which is required by module
+`esp_wifi`, `esp_wifi` cannot be used for applications that use these modules.
+Therefore, module `esp_wifi` is not automatically enabled when module
+`netdev_default` is used. Instead, if necessary, the application has to add
+the module `esp_wifi` in the Makefile.
+
+```
+USEMODULE += esp_wifi
+```
+
+Furthermore, the following configuration parameters have to be defined:
+
+<center>
+
+Parameter          | Default                   | Description
+:------------------|:--------------------------|:------------
+ESP_WIFI_SSID      | "RIOT_AP"                 | SSID of the AP to be used.
+ESP_WIFI_PASS      | "ThisistheRIOTporttoESP"  | Passphrase used for the AP as clear text (max. 64 chars).
+ESP_WIFI_STACKSIZE | #THREAD_STACKSIZE_DEFAULT |Stack size used for the WiFi netdev driver thread.
+
+</center>
+
+These configuration parameter definitions, as well as enabling the `esp_wifi`
+module, can be done either in the makefile of the project or at make command
+line, e.g.:
+
+```
+USEMODULE=esp_wifi \
+CFLAGS='-DESP_WIFI_SSID=\"MySSID\" -DESP_WIFI_PASS=\"MyPassphrase\"' \
+make -C examples/gnrc_networking BOARD=...
+```
+
+@note The Wifi network interface (module `esp_wifi`) and the
+[ESP-NOW network interface](#esp8266_esp_now_network_interface)
+(module `esp_now`) can be used simultaneously, for example, to realize a
+border router for a mesh network which uses ESP-NOW.
+
+\anchor esp8266_esp_now_network_interface
+## <a name="esp8266_esp_now_network_interface"> ESP-NOW Network Interface </a> &nbsp;[[TOC](#esp8266_toc)]
+
+With ESP-NOW, the ESP8266 provides a connectionless communication technology,
+featuring short packet transmission. It applies the IEEE802.11 Action Vendor
+frame technology, along with the IE function developed by Espressif, and CCMP
+encryption technology, realizing a secure, connectionless communication solution.
+
+The RIOT port for ESP8266 implements in module `esp_now` a `netdev` driver
+which uses ESP-NOW to provide a link layer interface to a meshed network of
+ESP8266 nodes. In this network, each node can send short packets with up to
+250 data bytes to all other nodes that are visible in its range.
+
+@note Due to symbol conflicts in vendor library `libwpa.so` used by the
+`esp_now` with RIOT's `crypto` and `hashes` modules, ESP-NOW cannot be used
+for application that use these modules. Therefore, the module `esp_now` is
+not enabled automatically if the `netdev_default` module is used. Instead,
+the application has to add the `esp_now` module in its makefile when needed.<br>
+```
+USEMODULE += esp_now
+```
+
+For ESP-NOW, ESP8266 nodes are used in WiFi SoftAP + Station mode to advertise
+their SSID and become visible to other ESP8266 nodes. The SSID of an ESP8266
+node is the concatenation of the prefix `RIOT_ESP_` with the MAC address of
+its SoftAP WiFi interface. The driver periodically scans all visible ESP8266
+nodes.
+
+The following parameters are defined for ESP-NOW nodes. These parameters can
+be overriden by [application-specific board configurations](#esp8266_application_specific_board_configuration).
+
+<center>
+
+Parameter | Default | Description
+:---------|:--------|:-----------
+ESP_NOW_SCAN_PERIOD | 10000000UL | Defines the period in us at which an node scans for other nodes in its range. The default period is 10 s.
+ESP_NOW_SOFT_AP_PASS | "ThisistheRIOTporttoESP" | Defines the passphrase as clear text (max. 64 chars) that is used for the SoftAP interface of ESP-NOW nodes. It has to be same for all nodes in one network.
+ESP_NOW_CHANNEL | 6 | Defines the channel that is used as the broadcast medium by all nodes together.
+ESP_NOW_KEY | NULL | Defines a key that is used for encrypted communication between nodes. If it is NULL, encryption is disabled. The key has to be of type ```uint8_t[16]``` and has to be exactly 16 bytes long.
+
+</center>
+
+@note The ESP-NOW network interface (module `esp_now`) and the
+[Wifi network interface](#esp8266_wifi_network_interface) (module `esp_wifi`)
+can be used simultaneously, for example, to realize a border router for
+a mesh network which uses ESP-NOW.
 
 # <a name="esp8266_preconfigured_devices"> Preconfigured Devices </a> &nbsp;[[TOC](#esp8266_toc)]
 

--- a/cpu/esp8266/esp-wifi/Makefile
+++ b/cpu/esp8266/esp-wifi/Makefile
@@ -1,0 +1,3 @@
+MODULE=esp_wifi
+
+include $(RIOTBASE)/Makefile.base

--- a/cpu/esp8266/esp-wifi/doc.txt
+++ b/cpu/esp8266/esp-wifi/doc.txt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2019 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    cpu_esp8266_esp_wifi ESP8266 WiFi netdev interface
+ * @ingroup     cpu_esp8266
+ * @brief       Network device driver for the ESP8266 WiFi interface
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+
+This module realizes a `netdev` interface for the built-in WiFi interface
+of ESP8266. To enable the WiFi interface, module `esp_wifi` has to be used.
+Furthermore, the following configuration parameters have to be defined:
+
+Configuration Parameter | Description
+------------------------|------------
+ESP_WIFI_SSID           | SSID of the AP to be used.
+ESP_WIFI_PASS           | Passphrase used for the AP as clear text (max. 64 chars).
+ESP_WIFI_STACKSIZE      | Stack size used for the WiFi netdev driver thread.
+
+These configuration parameter definitions, as well as enabling the `esp_wifi`
+module, can be done either in the makefile of the project or at make command
+line, e.g.:
+
+```
+USEMODULE=esp_wifi \
+CFLAGS='-DESP_WIFI_SSID=\"MySSID\" -DESP_WIFI_PASS=\"MyPassphrase\"' \
+make -C examples/gnrc_networking BOARD=...
+```
+
+@note The Wifi network interface (module `esp_wifi`) and the
+\ref esp32_esp_now_network_interface "ESP-NOW network interface" (module `esp_now`)
+can be used simultaneously, for example, to realize a border router for
+a mesh network which uses ESP-NOW.
+ */

--- a/cpu/esp8266/esp-wifi/esp_wifi_netdev.c
+++ b/cpu/esp8266/esp-wifi/esp_wifi_netdev.c
@@ -194,6 +194,20 @@ static void _esp_wifi_handle_event_cb(System_Event_t *evt)
                               evt->event_info.disconnected.ssid,
                               evt->event_info.disconnected.reason);
             _esp_wifi_dev.connected = false;
+
+            /* call disconnect to reset internal state */
+            if (!wifi_station_disconnect()) {
+                ESP_WIFI_LOG_ERROR("could not disconnect from to AP %s",
+                                   ESP_WIFI_SSID);
+                return;
+            }
+
+            /* try to reconnect */
+            if (!wifi_station_connect()) {
+                ESP_WIFI_LOG_ERROR("could not start connection to AP %s",
+                                   ESP_WIFI_SSID);
+                return;
+            }
             break;
 
         default:
@@ -523,7 +537,7 @@ static void _esp_wifi_setup(void)
 
     /* connect */
     if (!wifi_station_connect()) {
-        ESP_WIFI_DEBUG("could not start connection to AP %s", ESP_WIFI_SSID);
+        ESP_WIFI_LOG_ERROR("could not start connection to AP %s", ESP_WIFI_SSID);
         return;
     }
 

--- a/cpu/esp8266/esp-wifi/esp_wifi_netdev.c
+++ b/cpu/esp8266/esp-wifi/esp_wifi_netdev.c
@@ -41,7 +41,6 @@
 #include "lwip/igmp.h"
 #include "lwip/udp.h"
 
-#include "espconn.h"
 #include "esp_wifi_params.h"
 #include "esp_wifi_netdev.h"
 

--- a/cpu/esp8266/esp-wifi/esp_wifi_netdev.c
+++ b/cpu/esp8266/esp-wifi/esp_wifi_netdev.c
@@ -514,7 +514,12 @@ extern err_t __real_ethernet_input(struct pbuf *pb, struct netif* netif);
 err_t __wrap_ethernet_input(struct pbuf *pb, struct netif* netif)
 {
     ESP_WIFI_DEBUG("%p %p", pb, netif);
-    _esp_wifi_recv_cb(pb, netif);
+    if (_esp_wifi_dev.state == ESP_WIFI_CONNECTED) {
+        _esp_wifi_recv_cb(pb, netif);
+    }
+    else {
+        __real_ethernet_input(pb, netif);
+    }
     return ERR_OK;
 }
 

--- a/cpu/esp8266/esp-wifi/esp_wifi_netdev.c
+++ b/cpu/esp8266/esp-wifi/esp_wifi_netdev.c
@@ -50,6 +50,12 @@
 #define ESP_WIFI_DEBUG(f, ...) \
         DEBUG("[esp_wifi] %s: " f "\n", __func__, ## __VA_ARGS__)
 
+#define ESP_WIFI_LOG_INFO(f, ...) \
+        LOG_INFO("[esp_wifi] " f "\n", ## __VA_ARGS__)
+
+#define ESP_WIFI_LOG_ERROR(f, ...) \
+        LOG_ERROR("[esp_wifi] " f "\n", ## __VA_ARGS__)
+
 #define ESP_WIFI_STATION_MODE       (STATION_MODE)
 #define ESP_WIFI_AP_MODE            (SOFTAP_MODE)
 #define ESP_WIFI_STATION_AP_MODE    (STATIONAP_MODE)
@@ -102,7 +108,7 @@ void _esp_wifi_recv_cb(struct pbuf *pb, struct netif *netif)
      *
      * It should be therefore not possible to reenter function
      * `esp_wifi_recv_cb`. If it does occur inspite of that, we use a
-     * protection variable to avoid inconsistencies. This can not be realized
+     * guard variable to avoid inconsistencies. This can not be realized
      * by a mutex because `esp_wifi_recv_cb` would be reentered from same
      * thread context.
      */
@@ -177,16 +183,16 @@ static void _esp_wifi_handle_event_cb(System_Event_t *evt)
 
     switch (evt->event) {
         case EVENT_STAMODE_CONNECTED:
-            ESP_WIFI_DEBUG("connect to ssid %s, channel %d",
-                           evt->event_info.connected.ssid,
-                           evt->event_info.connected.channel);
+            ESP_WIFI_LOG_INFO("connected to ssid %s, channel %d",
+                              evt->event_info.connected.ssid,
+                              evt->event_info.connected.channel);
             _esp_wifi_dev.connected = true;
             break;
 
         case EVENT_STAMODE_DISCONNECTED:
-            ESP_WIFI_DEBUG("disconnect from ssid %s, reason %d",
-                           evt->event_info.disconnected.ssid,
-                           evt->event_info.disconnected.reason);
+            ESP_WIFI_LOG_INFO("disconnected from ssid %s, reason %d",
+                              evt->event_info.disconnected.ssid,
+                              evt->event_info.disconnected.reason);
             _esp_wifi_dev.connected = false;
             break;
 
@@ -495,19 +501,19 @@ static void _esp_wifi_setup(void)
 
     /* set the WiFi interface to Station mode without DHCP */
     if (!wifi_set_opmode_current(ESP_WIFI_STATION_MODE)) {
-        ESP_WIFI_DEBUG("could not set WiFi working mode");
+        ESP_WIFI_LOG_ERROR("could not set WiFi working mode");
         return;
     }
 
     /* set the WiFi configuration */
     if (!wifi_station_set_config_current((struct station_config *)&station_cfg)) {
-        ESP_WIFI_DEBUG("could not set WiFi configuration");
+        ESP_WIFI_LOG_ERROR("could not set WiFi configuration");
         return;
     }
 
     /* get station mac address and store it in device address */
     if (!wifi_get_macaddr(ESP_WIFI_STATION_IF, dev->mac)) {
-        ESP_WIFI_DEBUG("could not get MAC address of WiFi interface");
+        ESP_WIFI_LOG_ERROR("could not get MAC address of WiFi interface");
         return;
     }
     ESP_WIFI_DEBUG("own MAC addr is " MAC_STR, MAC_STR_ARG(dev->mac));

--- a/cpu/esp8266/esp-wifi/esp_wifi_netdev.c
+++ b/cpu/esp8266/esp-wifi/esp_wifi_netdev.c
@@ -141,6 +141,8 @@ static void IRAM _esp_wifi_reconnect_timer_cb(void* arg)
 
     if (dev->state == ESP_WIFI_DISCONNECTED ||
         dev->state == ESP_WIFI_CONNECTING) {
+        ESP_WIFI_LOG_INFO("trying to reconnect to ssid " ESP_WIFI_SSID);
+
         wifi_station_disconnect();
         wifi_station_connect();
         dev->state = ESP_WIFI_CONNECTING;

--- a/cpu/esp8266/esp-wifi/esp_wifi_netdev.c
+++ b/cpu/esp8266/esp-wifi/esp_wifi_netdev.c
@@ -97,7 +97,7 @@ static bool _in_esp_wifi_recv_cb = false;
 /**
  * @brief   Callback when ethernet frame is received. Has to run in IRAM.
  */
-void _esp_wifi_recv_cb(struct pbuf *pb, struct netif *netif)
+void IRAM _esp_wifi_recv_cb(struct pbuf *pb, struct netif *netif)
 {
     assert(pb != NULL);
     assert(netif != NULL);
@@ -244,8 +244,7 @@ uint8_t _send_pkt_buf[ETHERNET_MAX_LEN];
 /** function used to send an ethernet frame over WiFi */
 extern err_t ieee80211_output_pbuf(struct netif *netif, struct pbuf *p);
 
-/** guard variable to avoid reentrance to _send */
-static int _send(netdev_t *netdev, const iolist_t *iolist)
+static int IRAM _send(netdev_t *netdev, const iolist_t *iolist)
 {
     ESP_WIFI_DEBUG("%p %p", netdev, iolist);
 

--- a/cpu/esp8266/esp-wifi/esp_wifi_netdev.c
+++ b/cpu/esp8266/esp-wifi/esp_wifi_netdev.c
@@ -1,0 +1,510 @@
+/*
+ * Copyright (C) 2018 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_esp8266_esp_wifi
+ * @{
+ *
+ * @file
+ * @brief       Network device driver for the ESP8266 WiFi interface
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#include "log.h"
+#include "tools.h"
+
+#include <assert.h>
+#include <errno.h>
+#include <inttypes.h>
+#include <string.h>
+
+#include "net/ethernet.h"
+#include "net/ipv4/addr.h"
+#include "net/gnrc/netif/ethernet.h"
+#include "net/netdev/eth.h"
+#include "od.h"
+#include "xtimer.h"
+
+#include "common.h"
+#include "espressif/c_types.h"
+#include "espnow.h"
+#include "esp/common_macros.h"
+#include "irq_arch.h"
+#include "sdk/sdk.h"
+
+#include "lwip/igmp.h"
+#include "lwip/udp.h"
+
+#include "espconn.h"
+#include "esp_wifi_params.h"
+#include "esp_wifi_netdev.h"
+
+#define ENABLE_DEBUG                (0)
+#include "debug.h"
+
+#define ESP_WIFI_DEBUG(f, ...) \
+        DEBUG("[esp_wifi] %s: " f "\n", __func__, ## __VA_ARGS__)
+
+#define ESP_WIFI_STATION_MODE       (STATION_MODE)
+#define ESP_WIFI_AP_MODE            (SOFTAP_MODE)
+#define ESP_WIFI_STATION_AP_MODE    (STATIONAP_MODE)
+
+#define ESP_WIFI_STATION_IF         (STATION_IF)
+#define ESP_WIFI_SOFTAP_IF          (SOFTAP_IF)
+
+#define MAC_STR                     "%02x:%02x:%02x:%02x:%02x:%02x"
+#define MAC_STR_ARG(m)              m[0], m[1], m[2], m[3], m[4], m[5]
+/**
+ * There is only one ESP WIFI device. We define it as static device variable
+ * to have accesss to the device inside ESP WIFI interrupt routines which do
+ * not provide an argument that could be used as pointer to the ESP WIFI
+ * device which triggers the interrupt.
+ */
+static esp_wifi_netdev_t _esp_wifi_dev;
+
+/** forward declaration of the driver functions structure */
+static const netdev_driver_t _esp_wifi_driver;
+
+/** Stack for the netif thread */
+static char _esp_wifi_stack[ESP_WIFI_STACKSIZE];
+
+/** Static station configuration used for the WiFi interface */
+static const struct station_config station_cfg = {
+        .bssid_set = 0,             /* no check of MAC address of AP */
+        .ssid = ESP_WIFI_SSID,
+        .password = ESP_WIFI_PASS,
+};
+
+extern struct netif * eagle_lwip_getif(uint8 index);
+
+/** guard variable to avoid reentrance to _esp_wifi_recv_cb */
+static bool _in_esp_wifi_recv_cb = false;
+
+/**
+ * @brief   Callback when UDP packet is received
+ */
+void _esp_wifi_recv_cb(struct pbuf *pb, struct netif *netif)
+{
+    assert(pb != NULL);
+    assert(netif != NULL);
+
+    /*
+     * The function `esp_wifi_recv_cb` is executed in the context of the `wifi`
+     * thread. The ISRs handling the hardware interrupts from the WiFi
+     * interface pass events to a message queue of the `wifi` thread which is
+     * sequentially processed by the `wifi` thread to asynchronously execute
+     * callback functions such as `esp_wifi_recv_cb`.
+     *
+     * It should be therefore not possible to reenter function
+     * `esp_wifi_recv_cb`. To avoid inconsistencies this is checked by an
+     * additional boolean variable . This can not be realized by a mutex
+     * because `esp_wifi_recv_cb` would be reentered from same thread context.
+     */
+
+    if (_in_esp_wifi_recv_cb) {
+        return;
+    }
+    _in_esp_wifi_recv_cb = true;
+
+    /*
+     * Since it is not possible to reenter the function `esp_wifi_recv_cb`, and
+     * the functions netif::_ recv and esp_wifi_netdev::_ recv are called
+     * directly in the same thread context, neither a mutual exclusion has to
+     * be realized nor have the interrupts to be deactivated.
+     * Therefore we can read directly from the `data` and don't need a receive
+     * buffer.
+     */
+
+    /* check the first packet buffer for the minimum packet size */
+    if (pb->len < sizeof(ethernet_hdr_t)) {
+        ESP_WIFI_DEBUG("frame length is less than the size of an Ethernet"
+                       "header (%u < %u)", pb->len, sizeof(ethernet_hdr_t));
+        _in_esp_wifi_recv_cb = false;
+        pbuf_free(pb);
+        return;
+    }
+
+    if (_esp_wifi_dev.rx_pbuf) {
+        ESP_WIFI_DEBUG("buffer used, dropping incoming frame of %d bytes",
+                       pb->tot_len);
+        _in_esp_wifi_recv_cb = false;
+        pbuf_free(pb);
+        return;
+    }
+
+    _esp_wifi_dev.rx_pbuf = pb;
+
+    if (_esp_wifi_dev.netdev.event_callback) {
+        _esp_wifi_dev.netdev.event_callback(&_esp_wifi_dev.netdev,
+                                            NETDEV_EVENT_RX_COMPLETE);
+    }
+
+    _in_esp_wifi_recv_cb = false;
+}
+
+/**
+ * @brief   Event handler for esp system events.
+ */
+static void _esp_wifi_handle_event_cb(System_Event_t *evt)
+{
+    ESP_WIFI_DEBUG("event %d", evt->event);
+
+    switch (evt->event) {
+        case EVENT_STAMODE_CONNECTED:
+            ESP_WIFI_DEBUG("connect to ssid %s, channel %d",
+                           evt->event_info.connected.ssid,
+                           evt->event_info.connected.channel);
+            _esp_wifi_dev.connected = true;
+            break;
+
+        case EVENT_STAMODE_DISCONNECTED:
+            ESP_WIFI_DEBUG("disconnect from ssid %s, reason %d",
+                           evt->event_info.disconnected.ssid,
+                           evt->event_info.disconnected.reason);
+            _esp_wifi_dev.connected = false;
+            break;
+
+        default:
+            break;
+    }
+}
+
+static int _init(netdev_t *netdev)
+{
+    ESP_WIFI_DEBUG("%p", netdev);
+
+#ifdef MODULE_NETSTATS_L2
+    memset(&netdev->stats, 0x00, sizeof(netstats_t));
+#endif
+
+    return 0;
+}
+
+#if ENABLE_DEBUG
+/** buffer for sent packet dump */
+uint8_t _send_pkt_buf[ETHERNET_MAX_LEN];
+#endif
+
+/** function used to send an ethernet frame over WiFi */
+extern err_t ieee80211_output_pbuf(struct netif *netif, struct pbuf *p);
+
+/** guard variable to avoid reentrance to _send */
+static bool _in_send = false;
+
+static int _send(netdev_t *netdev, const iolist_t *iolist)
+{
+    ESP_WIFI_DEBUG("%p %p", netdev, iolist);
+
+    assert(netdev != NULL);
+    assert(iolist != NULL);
+
+    if (_in_send) {
+        return 0;
+    }
+    _in_send = true;
+
+    esp_wifi_netdev_t *dev = (esp_wifi_netdev_t*)netdev;
+
+    if (!dev->connected) {
+        ESP_WIFI_DEBUG("WiFi is still not connected to AP, cannot send");
+        _in_send = false;
+        return -EIO;
+    }
+
+    if (wifi_get_opmode() != ESP_WIFI_STATION_MODE) {
+        ESP_WIFI_DEBUG("WiFi is not in station mode, cannot send");
+        _in_send = false;
+        return -EIO;
+    }
+
+    const iolist_t *iol = iolist;
+    size_t iol_len = 0;
+
+    /* determine the frame size */
+    while (iol) {
+        iol_len += iol->iol_len;
+        iol = iol->iol_next;
+    }
+
+    /* limit checks */
+    if (iol_len > ETHERNET_MAX_LEN) {
+        ESP_WIFI_DEBUG("frame length exceeds maximum (%u > %u)",
+                       iol_len, ETHERNET_MAX_LEN);
+        _in_send = false;
+        return -EBADMSG;
+    }
+
+    if (iol_len < sizeof(ethernet_hdr_t)) {
+        ESP_WIFI_DEBUG("frame length is less than the size of an Ethernet"
+                       "header (%u < %u)", iol_len, sizeof(ethernet_hdr_t));
+        _in_send = false;
+        return -EBADMSG;
+    }
+
+    struct netif *sta_netif = (struct netif *)eagle_lwip_getif(ESP_WIFI_STATION_IF);
+    netif_set_default(sta_netif);
+
+    struct pbuf *pb = pbuf_alloc(PBUF_LINK, iol_len, PBUF_RAM);
+    if (pb == NULL || pb->tot_len < iol_len) {
+        ESP_WIFI_DEBUG("could not allocate buffer to send %d bytes ", iol_len);
+        _in_send = false;
+        return -EIO;
+    }
+
+    struct pbuf *pbi = pb;
+    uint8_t *pbi_payload = pb->payload;
+    size_t pbi_pos = 0;
+
+    /* prepare lwIP packet buffer direct from iolist without any buffer */
+    for (const iolist_t *iol = iolist; iol && pbi; iol = iol->iol_next) {
+        uint8_t *iol_base = iol->iol_base;
+        for (unsigned i = 0; i < iol->iol_len && pbi; i++) {
+            pbi_payload[pbi_pos++] = iol_base[i];
+            if (pbi_pos >= pbi->len) {
+                pbi = pbi->next;
+            }
+        }
+    }
+
+#if ENABLE_DEBUG
+    pbi = pb;
+    pbi_pos = 0;
+
+    for (; pbi; pbi = pbi->next) {
+        memcpy(_send_pkt_buf + pbi_pos, pbi->payload, pbi->len);
+        pbi_pos += pbi->len;
+    }
+
+    const ethernet_hdr_t* hdr = (const ethernet_hdr_t *)_send_pkt_buf;
+
+    ESP_WIFI_DEBUG("send %u byte to " MAC_STR,
+                   (unsigned)iol_len, MAC_STR_ARG(hdr->dst));
+#if MODULE_OD
+    od_hex_dump(_send_pkt_buf, iol_len, OD_WIDTH_DEFAULT);
+#endif /* MODULE_OD */
+#endif /* ENABLE_DEBUG */
+
+    int res = ieee80211_output_pbuf(sta_netif, pb);
+    pbuf_free(pb);
+
+    if (res == ERR_OK) {
+#ifdef MODULE_NETSTATS_L2
+        netdev->stats.tx_bytes += iol_len;
+        netdev->event_callback(netdev, NETDEV_EVENT_TX_COMPLETE);
+#endif
+        _in_send = false;
+        return iol_len;
+    }
+    else {
+#ifdef MODULE_NETSTATS_L2
+        netdev->stats.tx_failed++;
+#endif
+        _in_send = false;
+        return -EIO;
+    }
+}
+
+static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
+{
+    ESP_WIFI_DEBUG("%p %p %u %p", netdev, buf, len, info);
+
+    assert(netdev != NULL);
+
+    esp_wifi_netdev_t* dev = (esp_wifi_netdev_t*)netdev;
+
+    /* we store received data in `buf` */
+    uint16_t size = dev->rx_pbuf->tot_len ? dev->rx_pbuf->tot_len : 0;
+
+    if (!buf) {
+        /* get the size of the frame */
+        if (len > 0 && size) {
+            /* if len > 0, drop the frame */
+            pbuf_free(dev->rx_pbuf);
+            dev->rx_pbuf = NULL;
+        }
+        return size;
+    }
+
+    if (len < size) {
+        /* buffer is smaller than the number of received bytes */
+        ESP_WIFI_DEBUG("not enough space in receive buffer");
+        /* newest API requires to drop the frame in that case */
+        pbuf_free(dev->rx_pbuf);
+        dev->rx_pbuf = NULL;
+        return -ENOBUFS;
+    }
+
+    /* copy the buffer and free */
+    pbuf_copy_partial(dev->rx_pbuf, buf, dev->rx_pbuf->tot_len, 0);
+    pbuf_free(dev->rx_pbuf);
+    dev->rx_pbuf = NULL;
+
+#if ENABLE_DEBUG
+    ethernet_hdr_t *hdr = (ethernet_hdr_t *)buf;
+
+    ESP_WIFI_DEBUG("received %u byte from addr " MAC_STR,
+                   size, MAC_STR_ARG(hdr->src));
+#if MODULE_OD
+    od_hex_dump(buf, size, OD_WIDTH_DEFAULT);
+#endif /* MODULE_OD */
+#endif /* ENABLE_DEBUG */
+
+#if MODULE_NETSTATS_L2
+    netdev->stats.rx_count++;
+    netdev->stats.rx_bytes += size;
+#endif
+
+    return size;
+}
+
+static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
+{
+    ESP_WIFI_DEBUG("%s %p %p %u", netopt2str(opt), netdev, val, max_len);
+
+    assert(netdev != NULL);
+    assert(val != NULL);
+
+    esp_wifi_netdev_t *dev = (esp_wifi_netdev_t*)netdev;
+
+    switch (opt) {
+
+        case NETOPT_IS_WIRED:
+            return -ENOTSUP;
+
+        case NETOPT_LINK_CONNECTED:
+            assert(max_len == 1);
+            if (dev->connected) {
+                *((netopt_enable_t *)val) = NETOPT_ENABLE;
+            }
+            else {
+                *((netopt_enable_t *)val) = NETOPT_DISABLE;
+            }
+            return 1;
+
+        case NETOPT_ADDRESS:
+            assert(max_len >= sizeof(dev->mac));
+            memcpy(val, dev->mac, sizeof(dev->mac));
+            return sizeof(dev->mac);
+
+        default:
+            return netdev_eth_get(netdev, opt, val, max_len);
+
+    }
+}
+
+static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t max_len)
+{
+    ESP_WIFI_DEBUG("%s %p %p %u", netopt2str(opt), netdev, val, max_len);
+
+    assert(netdev != NULL);
+    assert(val != NULL);
+
+    esp_wifi_netdev_t *dev = (esp_wifi_netdev_t *) netdev;
+
+    switch (opt) {
+
+        case NETOPT_ADDRESS:
+            assert(max_len >= sizeof(dev->mac));
+            memcpy(dev->mac, val, sizeof(dev->mac));
+            return sizeof(dev->mac);
+
+        default:
+            return netdev_eth_set(netdev, opt, val, max_len);
+    }
+}
+
+static void _isr(netdev_t *netdev)
+{
+    ESP_WIFI_DEBUG("%p", netdev);
+
+    assert(netdev != NULL);
+}
+
+/** override lwIP ethernet_intput to get ethernet frames */
+extern err_t __real_ethernet_input(struct pbuf *pb, struct netif* netif);
+
+err_t __wrap_ethernet_input(struct pbuf *pb, struct netif* netif)
+{
+    ESP_WIFI_DEBUG("%p %p", pb, netif);
+    _esp_wifi_recv_cb(pb, netif);
+    return ERR_OK;
+}
+
+static const netdev_driver_t _esp_wifi_driver = {
+    .send = _send,
+    .recv = _recv,
+    .init = _init,
+    .isr = _isr,
+    .get = _get,
+    .set = _set,
+};
+
+static void _esp_wifi_setup(void)
+{
+    esp_wifi_netdev_t* dev = &_esp_wifi_dev;
+
+    ESP_WIFI_DEBUG("%p", dev);
+
+    if (dev->netdev.driver) {
+        ESP_WIFI_DEBUG("early returning previously initialized device");
+        return;
+    }
+
+    /* initialize netdev data structure */
+    dev->rx_pbuf = NULL;
+    dev->connected = false;
+
+    /* set the netdev driver */
+    dev->netdev.driver = &_esp_wifi_driver;
+
+    /* set the WiFi interface to Station mode without DHCP */
+    if (!wifi_set_opmode_current(ESP_WIFI_STATION_MODE)) {
+        ESP_WIFI_DEBUG("could not set WiFi working mode");
+        return;
+    }
+
+    /* set the WiFi configuration */
+    if (!wifi_station_set_config_current((struct station_config *)&station_cfg)) {
+        ESP_WIFI_DEBUG("could not set WiFi configuration");
+        return;
+    }
+
+    /* get station mac address and store it in device address */
+    if (!wifi_get_macaddr(ESP_WIFI_STATION_IF, dev->mac)) {
+        ESP_WIFI_DEBUG("could not get MAC address of WiFi interface");
+        return;
+    }
+    ESP_WIFI_DEBUG("own MAC addr is " MAC_STR, MAC_STR_ARG(dev->mac));
+
+    /* register callbacks */
+    wifi_set_event_handler_cb(_esp_wifi_handle_event_cb);
+
+    /* connect */
+    if (!wifi_station_connect()) {
+        ESP_WIFI_DEBUG("could not start connection to AP %s", ESP_WIFI_SSID);
+        return;
+    }
+
+    return;
+}
+
+void auto_init_esp_wifi(void)
+{
+    ESP_WIFI_DEBUG("auto initializing netdev\n");
+
+    /* setup netdev device */
+    _esp_wifi_setup();
+
+    /* create netif */
+    gnrc_netif_ethernet_create(_esp_wifi_stack, ESP_WIFI_STACKSIZE,
+                               ESP_WIFI_PRIO, "esp_wifi",
+                               (netdev_t *)&_esp_wifi_dev);
+}
+
+/** @} */

--- a/cpu/esp8266/esp-wifi/esp_wifi_netdev.c
+++ b/cpu/esp8266/esp-wifi/esp_wifi_netdev.c
@@ -68,6 +68,9 @@
 
 #define MAC_STR                     "%02x:%02x:%02x:%02x:%02x:%02x"
 #define MAC_STR_ARG(m)              m[0], m[1], m[2], m[3], m[4], m[5]
+
+#define PBUF_IEEE80211_HLEN         (36)
+
 /** Timer used to reconnect automatically after 20 seconds if not connected */
 static xtimer_t _esp_wifi_reconnect_timer;
 
@@ -328,7 +331,7 @@ static int IRAM _send(netdev_t *netdev, const iolist_t *iolist)
     struct netif *sta_netif = (struct netif *)eagle_lwip_getif(ESP_WIFI_STATION_IF);
     netif_set_default(sta_netif);
 
-    struct pbuf *pb = pbuf_alloc(PBUF_LINK, iol_len, PBUF_RAM);
+    struct pbuf *pb = pbuf_alloc(PBUF_LINK, iol_len + PBUF_IEEE80211_HLEN, PBUF_RAM);
     if (pb == NULL || pb->tot_len < iol_len) {
         ESP_WIFI_DEBUG("could not allocate buffer to send %d bytes ", iol_len);
         /*

--- a/cpu/esp8266/esp-wifi/esp_wifi_netdev.c
+++ b/cpu/esp8266/esp-wifi/esp_wifi_netdev.c
@@ -207,18 +207,14 @@ static void _esp_wifi_handle_event_cb(System_Event_t *evt)
             _esp_wifi_dev.state = ESP_WIFI_DISCONNECTED;
 
             /* call disconnect to reset internal state */
-            if (!wifi_station_disconnect()) {
-                ESP_WIFI_LOG_ERROR("could not disconnect from to AP %s",
-                                   ESP_WIFI_SSID);
-                return;
+            if (evt->event_info.disconnected.reason != REASON_ASSOC_LEAVE) {
+                wifi_station_disconnect();
             }
 
             /* try to reconnect */
-            if (!wifi_station_connect()) {
-                ESP_WIFI_LOG_ERROR("could not start connection to AP %s",
-                                   ESP_WIFI_SSID);
-                return;
-            }
+            wifi_station_connect();
+            _esp_wifi_dev.state = ESP_WIFI_CONNECTING;
+
             break;
 
         default:
@@ -574,10 +570,8 @@ static void _esp_wifi_setup(void)
     wifi_set_event_handler_cb(_esp_wifi_handle_event_cb);
 
     /* connect */
-    if (!wifi_station_connect()) {
-        ESP_WIFI_LOG_ERROR("could not start connection to AP %s", ESP_WIFI_SSID);
-        return;
-    }
+    wifi_station_connect();
+    _esp_wifi_dev.state = ESP_WIFI_CONNECTING;
 
     return;
 }

--- a/cpu/esp8266/esp-wifi/esp_wifi_netdev.c
+++ b/cpu/esp8266/esp-wifi/esp_wifi_netdev.c
@@ -98,7 +98,7 @@ static const struct station_config station_cfg = {
 
 #ifndef MODULE_ESP_NOW
 /**
- * Static const configuration for the SoftAP which is used to configure the 
+ * Static const configuration for the SoftAP which is used to configure the
  * SoftAP interface if ESP-NOW is not enabled.
  *
  * Since we need to use the WiFi interface in SoftAP + Station mode for
@@ -173,7 +173,7 @@ void IRAM _esp_wifi_recv_cb(struct pbuf *pb, struct netif *netif)
      * by a mutex because `esp_wifi_recv_cb` would be reentered from same
      * thread context.
      */
-    if (_in_esp_wifi_recv_cb || _in_send) {
+    if (_in_esp_wifi_recv_cb) {
         pbuf_free(pb);
         return;
     }

--- a/cpu/esp8266/esp-wifi/esp_wifi_netdev.c
+++ b/cpu/esp8266/esp-wifi/esp_wifi_netdev.c
@@ -185,9 +185,9 @@ void IRAM _esp_wifi_recv_cb(struct pbuf *pb, struct netif *netif)
     critical_enter();
 
     /* first, check packet buffer for the minimum packet size */
-    if (pb->len < sizeof(ethernet_hdr_t)) {
+    if (pb->tot_len < sizeof(ethernet_hdr_t)) {
         ESP_WIFI_DEBUG("frame length is less than the size of an Ethernet"
-                       "header (%u < %u)", pb->len, sizeof(ethernet_hdr_t));
+                       "header (%u < %u)", pb->tot_len, sizeof(ethernet_hdr_t));
         pbuf_free(pb);
         _in_esp_wifi_recv_cb = false;
         critical_exit();
@@ -207,9 +207,9 @@ void IRAM _esp_wifi_recv_cb(struct pbuf *pb, struct netif *netif)
     }
 
     /* check whether packet buffer fits into receive buffer */
-    if (pb->len > ETHERNET_MAX_LEN) {
+    if (pb->tot_len > ETHERNET_MAX_LEN) {
         ESP_WIFI_DEBUG("frame length is greater than the maximum size of an "
-                       "Ethernet frame (%u > %u)", pb->len, ETHERNET_MAX_LEN);
+                       "Ethernet frame (%u > %u)", pb->tot_len, ETHERNET_MAX_LEN);
         pbuf_free(pb);
         _in_esp_wifi_recv_cb = false;
         critical_exit();

--- a/cpu/esp8266/esp-wifi/esp_wifi_netdev.c
+++ b/cpu/esp8266/esp-wifi/esp_wifi_netdev.c
@@ -64,6 +64,8 @@
 #define ESP_WIFI_SOFTAP_IF          (SOFTAP_IF)
 
 #define ESP_WIFI_RECONNECT_TIME     (20 * US_PER_SEC)
+#define ESP_WIFI_SEND_TIMEOUT       (MS_PER_SEC)
+
 #define MAC_STR                     "%02x:%02x:%02x:%02x:%02x:%02x"
 #define MAC_STR_ARG(m)              m[0], m[1], m[2], m[3], m[4], m[5]
 /** Timer used to reconnect automatically after 20 seconds if not connected */
@@ -380,9 +382,22 @@ static int IRAM _send(netdev_t *netdev, const iolist_t *iolist)
 #endif /* ENABLE_DEBUG */
 
     int res = ieee80211_output_pbuf(sta_netif, pb);
+
+    /*
+     * Attempting to send the next frame before completing the transmission
+     * of the previous frame may result in a complete blockage of the send
+     * function. To avoid this blockage, we have to wait here until the frame
+     * has been sent. The frame has been sent when pb->ref becomes 1.
+     * We wait for a maximum time of ESP_WIFI_SEND_TIMEOUT milliseconds.
+     */
+    unsigned _timeout = ESP_WIFI_SEND_TIMEOUT;
+    while (pb->ref > 1 && --_timeout && dev->state == ESP_WIFI_CONNECTED) {
+        xtimer_usleep(US_PER_MS);
+    }
     pbuf_free(pb);
 
-    if (res == ERR_OK) {
+    if (res == ERR_OK && _timeout) {
+        /* There was no ieee80211_output_pbuf error and no send timeout. */
 #ifdef MODULE_NETSTATS_L2
         netdev->stats.tx_bytes += iol_len;
         netdev->event_callback(netdev, NETDEV_EVENT_TX_COMPLETE);
@@ -392,16 +407,17 @@ static int IRAM _send(netdev_t *netdev, const iolist_t *iolist)
         return iol_len;
     }
     else {
+        /* There was either a ieee80211_output_pbuf error or send timed out. */
 #ifdef MODULE_NETSTATS_L2
         netdev->stats.tx_failed++;
 #endif
         _in_send = false;
         critical_exit();
         /*
-         * This error usually happens because we run into out of memory. We have
-         * to wait until lwIP pbuf has been flushed. For that purpose, we
-         * have to disconnect from AP and wait for a short time. The node will
-         * then reconnect to AP automatically.
+         * ieee80211_output_pbuf usually happens because we run into out of
+         * memory. We have to wait until lwIP pbuf has been flushed. For that
+         * purpose, we have to disconnect from AP and wait for a short time.
+         * The node will then reconnect to AP automatically.
          */
         wifi_station_disconnect();
         return -EIO;

--- a/cpu/esp8266/esp-wifi/esp_wifi_netdev.h
+++ b/cpu/esp8266/esp-wifi/esp_wifi_netdev.h
@@ -36,7 +36,7 @@ typedef struct
     uint8_t mac[ETHERNET_ADDR_LEN];   /**< MAC address of the device */
     ip_addr_t ip;                     /**< IPv4 address of the device */
 
-    uint8_t rx_buf[ETHERNET_DATA_LEN];/**< receive buffer */
+    uint8_t rx_buf[ETHERNET_MAX_LEN]; /**< receive buffer */
     uint16_t rx_len;                  /**< number of bytes received from lwIP */
 
     bool connected;   /**< indicates the connection state to the AP */

--- a/cpu/esp8266/esp-wifi/esp_wifi_netdev.h
+++ b/cpu/esp8266/esp-wifi/esp_wifi_netdev.h
@@ -36,10 +36,12 @@ typedef struct
     uint8_t mac[ETHERNET_ADDR_LEN];   /**< MAC address of the device */
     ip_addr_t ip;                     /**< IPv4 address of the device */
 
-    struct pbuf *rx_pbuf;             /**< lwIP receive buffer reference */
+    uint8_t rx_buf[ETHERNET_DATA_LEN];/**< receive buffer */
     uint16_t rx_len;                  /**< number of bytes received from lwIP */
 
-    bool connected;        /**< indicates the connection state to the AP */
+    bool connected;   /**< indicates the connection state to the AP */
+
+    mutex_t dev_lock; /**< for exclusive access to buffer in receive functions */
 
 } esp_wifi_netdev_t;
 

--- a/cpu/esp8266/esp-wifi/esp_wifi_netdev.h
+++ b/cpu/esp8266/esp-wifi/esp_wifi_netdev.h
@@ -20,11 +20,21 @@
 #define ESP_WIFI_NETDEV_H
 
 #include "net/netdev.h"
-#include "lwip/udp.h"
+#include "ringbuffer.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * @brief   State of the WiFi interface
+ */
+typedef enum {
+    ESP_WIFI_NOT_WORKING,   /**< interface is not working correctly */
+    ESP_WIFI_DISCONNECTED,  /**< interface is not associated to the AP */
+    ESP_WIFI_CONNECTING,    /**< interface is trying an association to the AP */
+    ESP_WIFI_CONNECTED      /**< interface is not associated to the AP */
+} esp_wifi_state_t;
 
 /**
  * @brief   Device descriptor for ESP infrastructure mode WIFI device
@@ -34,15 +44,14 @@ typedef struct
     netdev_t netdev;                  /**< netdev parent struct */
 
     uint8_t mac[ETHERNET_ADDR_LEN];   /**< MAC address of the device */
-    ip_addr_t ip;                     /**< IPv4 address of the device */
 
     uint8_t rx_buf[ETHERNET_MAX_LEN]; /**< receive buffer */
     uint16_t rx_len;                  /**< number of bytes received from lwIP */
 
-    bool connected;   /**< indicates the connection state to the AP */
+    esp_wifi_state_t state;           /**< indicates the interface state */
 
-    mutex_t dev_lock; /**< for exclusive access to buffer in receive functions */
-
+    mutex_t dev_lock;                 /**< for exclusive access to buffer in
+                                           receive functions */
 } esp_wifi_netdev_t;
 
 #ifdef __cplusplus

--- a/cpu/esp8266/esp-wifi/esp_wifi_netdev.h
+++ b/cpu/esp8266/esp-wifi/esp_wifi_netdev.h
@@ -20,7 +20,6 @@
 #define ESP_WIFI_NETDEV_H
 
 #include "net/netdev.h"
-#include "ringbuffer.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/cpu/esp8266/esp-wifi/esp_wifi_netdev.h
+++ b/cpu/esp8266/esp-wifi/esp_wifi_netdev.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2019 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_esp8266_esp_wifi
+ * @{
+ *
+ * @file
+ * @brief       Network device driver for the ESP8266 WiFi interface
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef ESP_WIFI_NETDEV_H
+#define ESP_WIFI_NETDEV_H
+
+#include "net/netdev.h"
+#include "lwip/udp.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Device descriptor for ESP infrastructure mode WIFI device
+ */
+typedef struct
+{
+    netdev_t netdev;                  /**< netdev parent struct */
+
+    uint8_t mac[ETHERNET_ADDR_LEN];   /**< MAC address of the device */
+    ip_addr_t ip;                     /**< IPv4 address of the device */
+
+    struct pbuf *rx_pbuf;             /**< lwIP receive buffer reference */
+    uint16_t rx_len;                  /**< number of bytes received from lwIP */
+
+    bool connected;        /**< indicates the connection state to the AP */
+
+} esp_wifi_netdev_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ESP_WIFI_NETDEV_H */
+/** @} */

--- a/cpu/esp8266/esp-wifi/esp_wifi_params.h
+++ b/cpu/esp8266/esp-wifi/esp_wifi_params.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2019 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_esp8266_esp_wifi
+ * @ingroup     cpu_esp8266_conf
+ * @{
+ *
+ * @file
+ * @brief       Parameters for the ESP8266 WiFi netdev interface
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef ESP_WIFI_PARAMS_H
+#define ESP_WIFI_PARAMS_H
+
+#if MODULE_ESP_WIFI || DOXYGEN
+
+/**
+ * @name    Set default configuration parameters for the ESP WIFI netdev driver
+ * @{
+ */
+
+/**
+ * @brief   The size of the stack used for the ESP WIFI netdev driver thread.
+ */
+#ifndef ESP_WIFI_STACKSIZE
+#define ESP_WIFI_STACKSIZE       (1536)
+#endif
+
+/**
+ * @brief   The priority of the ESP WiFi netdev driver thread. Should not be changed.
+ */
+#ifndef ESP_WIFI_PRIO
+#define ESP_WIFI_PRIO            (GNRC_NETIF_PRIO)
+#endif
+
+/**
+ * @brief   SSID of the AP to be used.
+ */
+#ifndef ESP_WIFI_SSID
+#define ESP_WIFI_SSID           "RIOT_AP"
+#endif
+
+/**
+ * @brief   Passphrase used for the AP (max. 64 chars).
+ */
+#ifndef ESP_WIFI_PASS
+#define ESP_WIFI_PASS           "ThisistheRIOTporttoESP"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MODULE_ESP_WIFI || DOXYGEN */
+
+#endif /* ESP_WIFI_PARAMS_H */
+/**@}*/

--- a/cpu/esp8266/include/cpu_conf.h
+++ b/cpu/esp8266/include/cpu_conf.h
@@ -47,6 +47,9 @@ extern "C" {
 #define THREAD_STACKSIZE_MAIN         (3072)
 #endif
 
+#ifndef GNRC_IPV6_STACK_SIZE
+#define GNRC_IPV6_STACK_SIZE          (1536)
+#endif
 #ifndef GNRC_PKTDUMP_STACKSIZE
 #define GNRC_PKTDUMP_STACKSIZE        (THREAD_STACKSIZE_DEFAULT)
 #endif
@@ -74,6 +77,9 @@ extern "C" {
 #define THREAD_STACKSIZE_MAIN         (3072)
 #endif
 
+#ifndef GNRC_IPV6_STACK_SIZE
+#define GNRC_IPV6_STACK_SIZE          (1536)
+#endif
 #ifndef GNRC_PKTDUMP_STACKSIZE
 #define GNRC_PKTDUMP_STACKSIZE        (THREAD_STACKSIZE_DEFAULT)
 #endif

--- a/cpu/esp8266/vendor/espressif/lwipopts.h
+++ b/cpu/esp8266/vendor/espressif/lwipopts.h
@@ -1,0 +1,2067 @@
+/**
+ * @file
+ *
+ * lwIP Options Configuration
+ */
+
+/*
+ * Copyright (c) 2001-2004 Swedish Institute of Computer Science.
+ * All rights reserved. 
+ * 
+ * Redistribution and use in source and binary forms, with or without modification, 
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission. 
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED 
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT 
+ * SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, 
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT 
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+ * OF SUCH DAMAGE.
+ *
+ * This file is part of the lwIP TCP/IP stack.
+ * 
+ * Author: Adam Dunkels <adam@sics.se>
+ *
+ */
+#ifndef __LWIPOPTS_H__
+#define __LWIPOPTS_H__
+
+#define ESP_SYSTEM_APP 1
+/*
+   -----------------------------------------------
+   ---------- Platform specific locking ----------
+   -----------------------------------------------
+*/
+
+/**
+ * SYS_LIGHTWEIGHT_PROT==1: if you want inter-task protection for certain
+ * critical regions during buffer allocation, deallocation and memory
+ * allocation and deallocation.
+ */
+#ifndef SYS_LIGHTWEIGHT_PROT
+#define SYS_LIGHTWEIGHT_PROT            0
+#endif
+
+/** 
+ * NO_SYS==1: Provides VERY minimal functionality. Otherwise,
+ * use lwIP facilities.
+ */
+#ifndef NO_SYS
+#define NO_SYS                          1
+#endif
+
+/**
+ * NO_SYS_NO_TIMERS==1: Drop support for sys_timeout when NO_SYS==1
+ * Mainly for compatibility to old versions.
+ */
+#ifndef NO_SYS_NO_TIMERS
+#define NO_SYS_NO_TIMERS                0
+#endif
+
+/**
+ * MEMCPY: override this if you have a faster implementation at hand than the
+ * one included in your C library
+ */
+#ifndef MEMCPY
+#define MEMCPY(dst,src,len)             os_memcpy(dst,src,len)
+#endif
+
+/**
+ * SMEMCPY: override this with care! Some compilers (e.g. gcc) can inline a
+ * call to memcpy() if the length is known at compile time and is small.
+ */
+#ifndef SMEMCPY
+#define SMEMCPY(dst,src,len)            os_memcpy(dst,src,len)
+#endif
+
+/*
+   ------------------------------------
+   ---------- Memory options ----------
+   ------------------------------------
+*/
+/**
+ * MEM_LIBC_MALLOC==1: Use malloc/free/realloc provided by your C-library
+ * instead of the lwip internal allocator. Can save code size if you
+ * already use it.
+ */
+#ifndef MEM_LIBC_MALLOC
+#define MEM_LIBC_MALLOC                 1
+#endif
+
+/**
+* MEMP_MEM_MALLOC==1: Use mem_malloc/mem_free instead of the lwip pool allocator.
+* Especially useful with MEM_LIBC_MALLOC but handle with care regarding execution
+* speed and usage from interrupts!
+*/
+#ifndef MEMP_MEM_MALLOC
+#define MEMP_MEM_MALLOC                 1
+#endif
+
+/**
+ * MEM_ALIGNMENT: should be set to the alignment of the CPU
+ *    4 byte alignment -> #define MEM_ALIGNMENT 4
+ *    2 byte alignment -> #define MEM_ALIGNMENT 2
+ */
+#ifndef MEM_ALIGNMENT
+#define MEM_ALIGNMENT                   4
+#endif
+
+/**
+ * MEM_SIZE: the size of the heap memory. If the application will send
+ * a lot of data that needs to be copied, this should be set high.
+ */
+#ifndef MEM_SIZE
+#define MEM_SIZE                        16000
+#endif
+
+/**
+ * MEMP_SEPARATE_POOLS: if defined to 1, each pool is placed in its own array.
+ * This can be used to individually change the location of each pool.
+ * Default is one big array for all pools
+ */
+#ifndef MEMP_SEPARATE_POOLS
+#define MEMP_SEPARATE_POOLS             1
+#endif
+
+/**
+ * MEMP_OVERFLOW_CHECK: memp overflow protection reserves a configurable
+ * amount of bytes before and after each memp element in every pool and fills
+ * it with a prominent default value.
+ *    MEMP_OVERFLOW_CHECK == 0 no checking
+ *    MEMP_OVERFLOW_CHECK == 1 checks each element when it is freed
+ *    MEMP_OVERFLOW_CHECK >= 2 checks each element in every pool every time
+ *      memp_malloc() or memp_free() is called (useful but slow!)
+ */
+#ifndef MEMP_OVERFLOW_CHECK
+#define MEMP_OVERFLOW_CHECK             0
+#endif
+
+/**
+ * MEMP_SANITY_CHECK==1: run a sanity check after each memp_free() to make
+ * sure that there are no cycles in the linked lists.
+ */
+#ifndef MEMP_SANITY_CHECK
+#define MEMP_SANITY_CHECK               1
+#endif
+
+/**
+ * MEM_USE_POOLS==1: Use an alternative to malloc() by allocating from a set
+ * of memory pools of various sizes. When mem_malloc is called, an element of
+ * the smallest pool that can provide the length needed is returned.
+ * To use this, MEMP_USE_CUSTOM_POOLS also has to be enabled.
+ */
+#ifndef MEM_USE_POOLS
+#define MEM_USE_POOLS                   0
+#endif
+
+/**
+ * MEM_USE_POOLS_TRY_BIGGER_POOL==1: if one malloc-pool is empty, try the next
+ * bigger pool - WARNING: THIS MIGHT WASTE MEMORY but it can make a system more
+ * reliable. */
+#ifndef MEM_USE_POOLS_TRY_BIGGER_POOL
+#define MEM_USE_POOLS_TRY_BIGGER_POOL   0
+#endif
+
+/**
+ * MEMP_USE_CUSTOM_POOLS==1: whether to include a user file lwippools.h
+ * that defines additional pools beyond the "standard" ones required
+ * by lwIP. If you set this to 1, you must have lwippools.h in your 
+ * inlude path somewhere. 
+ */
+#ifndef MEMP_USE_CUSTOM_POOLS
+#define MEMP_USE_CUSTOM_POOLS           0
+#endif
+
+/**
+ * Set this to 1 if you want to free PBUF_RAM pbufs (or call mem_free()) from
+ * interrupt context (or another context that doesn't allow waiting for a
+ * semaphore).
+ * If set to 1, mem_malloc will be protected by a semaphore and SYS_ARCH_PROTECT,
+ * while mem_free will only use SYS_ARCH_PROTECT. mem_malloc SYS_ARCH_UNPROTECTs
+ * with each loop so that mem_free can run.
+ *
+ * ATTENTION: As you can see from the above description, this leads to dis-/
+ * enabling interrupts often, which can be slow! Also, on low memory, mem_malloc
+ * can need longer.
+ *
+ * If you don't want that, at least for NO_SYS=0, you can still use the following
+ * functions to enqueue a deallocation call which then runs in the tcpip_thread
+ * context:
+ * - pbuf_free_callback(p);
+ * - mem_free_callback(m);
+ */
+#ifndef LWIP_ALLOW_MEM_FREE_FROM_OTHER_CONTEXT
+#define LWIP_ALLOW_MEM_FREE_FROM_OTHER_CONTEXT 0
+#endif
+
+/*
+   ------------------------------------------------
+   ---------- Internal Memory Pool Sizes ----------
+   ------------------------------------------------
+*/
+/**
+ * MEMP_NUM_PBUF: the number of memp struct pbufs (used for PBUF_ROM and PBUF_REF).
+ * If the application sends a lot of data out of ROM (or other static memory),
+ * this should be set high.
+ */
+#ifndef MEMP_NUM_PBUF
+#define MEMP_NUM_PBUF                   10
+#endif
+
+/**
+ * MEMP_NUM_RAW_PCB: Number of raw connection PCBs
+ * (requires the LWIP_RAW option)
+ */
+#ifndef MEMP_NUM_RAW_PCB
+#define MEMP_NUM_RAW_PCB                4
+#endif
+
+/**
+ * MEMP_NUM_UDP_PCB: the number of UDP protocol control blocks. One
+ * per active UDP "connection".
+ * (requires the LWIP_UDP option)
+ */
+#ifndef MEMP_NUM_UDP_PCB
+#define MEMP_NUM_UDP_PCB                4
+#endif
+
+/**
+ * MEMP_NUM_TCP_PCB: the number of simulatenously active TCP connections.
+ * (requires the LWIP_TCP option)
+ */
+#ifndef MEMP_NUM_TCP_PCB
+#define MEMP_NUM_TCP_PCB                (*(volatile uint32*)0x600011FC)
+#endif
+
+/**
+ * MEMP_NUM_TCP_PCB_LISTEN: the number of listening TCP connections.
+ * (requires the LWIP_TCP option)
+ */
+#ifndef MEMP_NUM_TCP_PCB_LISTEN
+#define MEMP_NUM_TCP_PCB_LISTEN         2
+#endif
+
+/**
+ * MEMP_NUM_TCP_SEG: the number of simultaneously queued TCP segments.
+ * (requires the LWIP_TCP option)
+ */
+#ifndef MEMP_NUM_TCP_SEG
+#define MEMP_NUM_TCP_SEG                16
+#endif
+
+/**
+ * MEMP_NUM_REASSDATA: the number of simultaneously IP packets queued for
+ * reassembly (whole packets, not fragments!)
+ */
+#ifndef MEMP_NUM_REASSDATA
+#define MEMP_NUM_REASSDATA              0
+#endif
+
+/**
+ * MEMP_NUM_FRAG_PBUF: the number of IP fragments simultaneously sent
+ * (fragments, not whole packets!).
+ * This is only used with IP_FRAG_USES_STATIC_BUF==0 and
+ * LWIP_NETIF_TX_SINGLE_PBUF==0 and only has to be > 1 with DMA-enabled MACs
+ * where the packet is not yet sent when netif->output returns.
+ */
+#ifndef MEMP_NUM_FRAG_PBUF
+#define MEMP_NUM_FRAG_PBUF              0
+#endif
+
+/**
+ * MEMP_NUM_ARP_QUEUE: the number of simulateously queued outgoing
+ * packets (pbufs) that are waiting for an ARP request (to resolve
+ * their destination address) to finish.
+ * (requires the ARP_QUEUEING option)
+ */
+#ifndef MEMP_NUM_ARP_QUEUE
+#define MEMP_NUM_ARP_QUEUE              10
+#endif
+
+/**
+ * MEMP_NUM_IGMP_GROUP: The number of multicast groups whose network interfaces
+ * can be members et the same time (one per netif - allsystems group -, plus one
+ * per netif membership).
+ * (requires the LWIP_IGMP option)
+ */
+#ifndef MEMP_NUM_IGMP_GROUP
+#define MEMP_NUM_IGMP_GROUP             8
+#endif
+
+/**
+ * MEMP_NUM_SYS_TIMEOUT: the number of simulateously active timeouts.
+ * (requires NO_SYS==0)
+ */
+#ifndef MEMP_NUM_SYS_TIMEOUT
+#define MEMP_NUM_SYS_TIMEOUT            8
+#endif
+
+/**
+ * MEMP_NUM_NETBUF: the number of struct netbufs.
+ * (only needed if you use the sequential API, like api_lib.c)
+ */
+#ifndef MEMP_NUM_NETBUF
+#define MEMP_NUM_NETBUF                 0
+#endif
+
+/**
+ * MEMP_NUM_NETCONN: the number of struct netconns.
+ * (only needed if you use the sequential API, like api_lib.c)
+ */
+#ifndef MEMP_NUM_NETCONN
+#define MEMP_NUM_NETCONN                0
+#endif
+
+/**
+ * MEMP_NUM_TCPIP_MSG_API: the number of struct tcpip_msg, which are used
+ * for callback/timeout API communication. 
+ * (only needed if you use tcpip.c)
+ */
+#ifndef MEMP_NUM_TCPIP_MSG_API
+#define MEMP_NUM_TCPIP_MSG_API          4
+#endif
+
+/**
+ * MEMP_NUM_TCPIP_MSG_INPKT: the number of struct tcpip_msg, which are used
+ * for incoming packets. 
+ * (only needed if you use tcpip.c)
+ */
+#ifndef MEMP_NUM_TCPIP_MSG_INPKT
+#define MEMP_NUM_TCPIP_MSG_INPKT        4
+#endif
+
+/**
+ * MEMP_NUM_SNMP_NODE: the number of leafs in the SNMP tree.
+ */
+#ifndef MEMP_NUM_SNMP_NODE
+#define MEMP_NUM_SNMP_NODE              0
+#endif
+
+/**
+ * MEMP_NUM_SNMP_ROOTNODE: the number of branches in the SNMP tree.
+ * Every branch has one leaf (MEMP_NUM_SNMP_NODE) at least!
+ */
+#ifndef MEMP_NUM_SNMP_ROOTNODE
+#define MEMP_NUM_SNMP_ROOTNODE          0
+#endif
+
+/**
+ * MEMP_NUM_SNMP_VARBIND: the number of concurrent requests (does not have to
+ * be changed normally) - 2 of these are used per request (1 for input,
+ * 1 for output)
+ */
+#ifndef MEMP_NUM_SNMP_VARBIND
+#define MEMP_NUM_SNMP_VARBIND           0
+#endif
+
+/**
+ * MEMP_NUM_SNMP_VALUE: the number of OID or values concurrently used
+ * (does not have to be changed normally) - 3 of these are used per request
+ * (1 for the value read and 2 for OIDs - input and output)
+ */
+#ifndef MEMP_NUM_SNMP_VALUE
+#define MEMP_NUM_SNMP_VALUE             0
+#endif
+
+/**
+ * MEMP_NUM_NETDB: the number of concurrently running lwip_addrinfo() calls
+ * (before freeing the corresponding memory using lwip_freeaddrinfo()).
+ */
+#ifndef MEMP_NUM_NETDB
+#define MEMP_NUM_NETDB                  0
+#endif
+
+/**
+ * MEMP_NUM_LOCALHOSTLIST: the number of host entries in the local host list
+ * if DNS_LOCAL_HOSTLIST_IS_DYNAMIC==1.
+ */
+#ifndef MEMP_NUM_LOCALHOSTLIST
+#define MEMP_NUM_LOCALHOSTLIST          0
+#endif
+
+/**
+ * MEMP_NUM_PPPOE_INTERFACES: the number of concurrently active PPPoE
+ * interfaces (only used with PPPOE_SUPPORT==1)
+ */
+#ifndef MEMP_NUM_PPPOE_INTERFACES
+#define MEMP_NUM_PPPOE_INTERFACES       0
+#endif
+
+/**
+ * PBUF_POOL_SIZE: the number of buffers in the pbuf pool. 
+ */
+#ifndef PBUF_POOL_SIZE
+#define PBUF_POOL_SIZE                  10
+#endif
+
+/*
+   ---------------------------------
+   ---------- ARP options ----------
+   ---------------------------------
+*/
+/**
+ * LWIP_ARP==1: Enable ARP functionality.
+ */
+#ifndef LWIP_ARP
+#define LWIP_ARP                        1
+#endif
+
+/**
+ * ARP_TABLE_SIZE: Number of active MAC-IP address pairs cached.
+ */
+#ifndef ARP_TABLE_SIZE
+#define ARP_TABLE_SIZE                  10
+#endif
+
+/**
+ * ARP_QUEUEING==1: Multiple outgoing packets are queued during hardware address
+ * resolution. By default, only the most recent packet is queued per IP address.
+ * This is sufficient for most protocols and mainly reduces TCP connection
+ * startup time. Set this to 1 if you know your application sends more than one
+ * packet in a row to an IP address that is not in the ARP cache.
+ */
+#ifndef ARP_QUEUEING
+#define ARP_QUEUEING                    1
+#endif
+
+/**
+ * ETHARP_TRUST_IP_MAC==1: Incoming IP packets cause the ARP table to be
+ * updated with the source MAC and IP addresses supplied in the packet.
+ * You may want to disable this if you do not trust LAN peers to have the
+ * correct addresses, or as a limited approach to attempt to handle
+ * spoofing. If disabled, lwIP will need to make a new ARP request if
+ * the peer is not already in the ARP table, adding a little latency.
+ * The peer *is* in the ARP table if it requested our address before.
+ * Also notice that this slows down input processing of every IP packet!
+ */
+#ifndef ETHARP_TRUST_IP_MAC
+#define ETHARP_TRUST_IP_MAC             1
+#endif
+
+/**
+ * ETHARP_SUPPORT_VLAN==1: support receiving ethernet packets with VLAN header.
+ * Additionally, you can define ETHARP_VLAN_CHECK to an u16_t VLAN ID to check.
+ * If ETHARP_VLAN_CHECK is defined, only VLAN-traffic for this VLAN is accepted.
+ * If ETHARP_VLAN_CHECK is not defined, all traffic is accepted.
+ */
+#ifndef ETHARP_SUPPORT_VLAN
+#define ETHARP_SUPPORT_VLAN             0
+#endif
+
+/** LWIP_ETHERNET==1: enable ethernet support for PPPoE even though ARP
+ * might be disabled
+ */
+#ifndef LWIP_ETHERNET
+#define LWIP_ETHERNET                   (LWIP_ARP || PPPOE_SUPPORT)
+#endif
+
+/** ETH_PAD_SIZE: number of bytes added before the ethernet header to ensure
+ * alignment of payload after that header. Since the header is 14 bytes long,
+ * without this padding e.g. addresses in the IP header will not be aligned
+ * on a 32-bit boundary, so setting this to 2 can speed up 32-bit-platforms.
+ */
+#ifndef ETH_PAD_SIZE
+#define ETH_PAD_SIZE                    0
+#endif
+
+/** ETHARP_SUPPORT_STATIC_ENTRIES==1: enable code to support static ARP table
+ * entries (using etharp_add_static_entry/etharp_remove_static_entry).
+ */
+#ifndef ETHARP_SUPPORT_STATIC_ENTRIES
+#define ETHARP_SUPPORT_STATIC_ENTRIES   0
+#endif
+
+
+/*
+   --------------------------------
+   ---------- IP options ----------
+   --------------------------------
+*/
+/**
+ * IP_FORWARD==1: Enables the ability to forward IP packets across network
+ * interfaces. If you are going to run lwIP on a device with only one network
+ * interface, define this to 0.
+ */
+#ifndef IP_FORWARD
+#define IP_FORWARD                      0
+#endif
+
+/**
+ * IP_OPTIONS_ALLOWED: Defines the behavior for IP options.
+ *      IP_OPTIONS_ALLOWED==0: All packets with IP options are dropped.
+ *      IP_OPTIONS_ALLOWED==1: IP options are allowed (but not parsed).
+ */
+#ifndef IP_OPTIONS_ALLOWED
+#define IP_OPTIONS_ALLOWED              1
+#endif
+
+/**
+ * IP_REASSEMBLY==1: Reassemble incoming fragmented IP packets. Note that
+ * this option does not affect outgoing packet sizes, which can be controlled
+ * via IP_FRAG.
+ */
+#ifndef IP_REASSEMBLY
+#define IP_REASSEMBLY                   0
+#endif
+
+/**
+ * IP_FRAG==1: Fragment outgoing IP packets if their size exceeds MTU. Note
+ * that this option does not affect incoming packet sizes, which can be
+ * controlled via IP_REASSEMBLY.
+ */
+#ifndef IP_FRAG
+#define IP_FRAG                         0
+#endif
+
+/**
+ * IP_REASS_MAXAGE: Maximum time (in multiples of IP_TMR_INTERVAL - so seconds, normally)
+ * a fragmented IP packet waits for all fragments to arrive. If not all fragments arrived
+ * in this time, the whole packet is discarded.
+ */
+#ifndef IP_REASS_MAXAGE
+#define IP_REASS_MAXAGE                 3
+#endif
+
+/**
+ * IP_REASS_MAX_PBUFS: Total maximum amount of pbufs waiting to be reassembled.
+ * Since the received pbufs are enqueued, be sure to configure
+ * PBUF_POOL_SIZE > IP_REASS_MAX_PBUFS so that the stack is still able to receive
+ * packets even if the maximum amount of fragments is enqueued for reassembly!
+ */
+#ifndef IP_REASS_MAX_PBUFS
+#define IP_REASS_MAX_PBUFS              10
+#endif
+
+/**
+ * IP_FRAG_USES_STATIC_BUF==1: Use a static MTU-sized buffer for IP
+ * fragmentation. Otherwise pbufs are allocated and reference the original
+ * packet data to be fragmented (or with LWIP_NETIF_TX_SINGLE_PBUF==1,
+ * new PBUF_RAM pbufs are used for fragments).
+ * ATTENTION: IP_FRAG_USES_STATIC_BUF==1 may not be used for DMA-enabled MACs!
+ */
+#ifndef IP_FRAG_USES_STATIC_BUF
+#define IP_FRAG_USES_STATIC_BUF         1
+#endif
+
+/**
+ * IP_FRAG_MAX_MTU: Assumed max MTU on any interface for IP frag buffer
+ * (requires IP_FRAG_USES_STATIC_BUF==1)
+ */
+#if IP_FRAG_USES_STATIC_BUF && !defined(IP_FRAG_MAX_MTU)
+#define IP_FRAG_MAX_MTU                 1500
+#endif
+
+/**
+ * IP_DEFAULT_TTL: Default value for Time-To-Live used by transport layers.
+ */
+#ifndef IP_DEFAULT_TTL
+#define IP_DEFAULT_TTL                  128
+#endif
+
+/**
+ * IP_SOF_BROADCAST=1: Use the SOF_BROADCAST field to enable broadcast
+ * filter per pcb on udp and raw send operations. To enable broadcast filter
+ * on recv operations, you also have to set IP_SOF_BROADCAST_RECV=1.
+ */
+#ifndef IP_SOF_BROADCAST
+#define IP_SOF_BROADCAST                0
+#endif
+
+/**
+ * IP_SOF_BROADCAST_RECV (requires IP_SOF_BROADCAST=1) enable the broadcast
+ * filter on recv operations.
+ */
+#ifndef IP_SOF_BROADCAST_RECV
+#define IP_SOF_BROADCAST_RECV           0
+#endif
+
+/*
+   ----------------------------------
+   ---------- ICMP options ----------
+   ----------------------------------
+*/
+/**
+ * LWIP_ICMP==1: Enable ICMP module inside the IP stack.
+ * Be careful, disable that make your product non-compliant to RFC1122
+ */
+#ifndef LWIP_ICMP
+#define LWIP_ICMP                       1
+#endif
+
+/**
+ * ICMP_TTL: Default value for Time-To-Live used by ICMP packets.
+ */
+#ifndef ICMP_TTL
+#define ICMP_TTL                       (IP_DEFAULT_TTL)
+#endif
+
+/**
+ * LWIP_BROADCAST_PING==1: respond to broadcast pings (default is unicast only)
+ */
+#ifndef LWIP_BROADCAST_PING
+#define LWIP_BROADCAST_PING             0
+#endif
+
+/**
+ * LWIP_MULTICAST_PING==1: respond to multicast pings (default is unicast only)
+ */
+#ifndef LWIP_MULTICAST_PING
+#define LWIP_MULTICAST_PING             0
+#endif
+
+/*
+   ---------------------------------
+   ---------- RAW options ----------
+   ---------------------------------
+*/
+/**
+ * LWIP_RAW==1: Enable application layer to hook into the IP layer itself.
+ */
+#ifndef LWIP_RAW
+#define LWIP_RAW                        1
+#endif
+
+/**
+ * LWIP_RAW==1: Enable application layer to hook into the IP layer itself.
+ */
+#ifndef RAW_TTL
+#define RAW_TTL                        (IP_DEFAULT_TTL)
+#endif
+
+/*
+   ----------------------------------
+   ---------- DHCP options ----------
+   ----------------------------------
+*/
+/**
+ * LWIP_DHCP==1: Enable DHCP module.
+ */
+#ifndef LWIP_DHCP
+#define LWIP_DHCP                       1
+#endif
+
+/**
+ * DHCP_DOES_ARP_CHECK==1: Do an ARP check on the offered address.
+ */
+#ifndef DHCP_DOES_ARP_CHECK
+#define DHCP_DOES_ARP_CHECK             ((LWIP_DHCP) && (LWIP_ARP))
+#endif
+
+/**
+ * DHCP_MAXRTX: Maximum number of retries of current request.
+ */
+#ifndef DHCP_MAXRTX
+#define DHCP_MAXRTX						(*(volatile uint32*)0x600011E0)
+#endif
+
+/*
+   ------------------------------------
+   ---------- AUTOIP options ----------
+   ------------------------------------
+*/
+/**
+ * LWIP_AUTOIP==1: Enable AUTOIP module.
+ */
+#ifndef LWIP_AUTOIP
+#define LWIP_AUTOIP                     0
+#endif
+
+/**
+ * LWIP_DHCP_AUTOIP_COOP==1: Allow DHCP and AUTOIP to be both enabled on
+ * the same interface at the same time.
+ */
+#ifndef LWIP_DHCP_AUTOIP_COOP
+#define LWIP_DHCP_AUTOIP_COOP           0
+#endif
+
+/**
+ * LWIP_DHCP_AUTOIP_COOP_TRIES: Set to the number of DHCP DISCOVER probes
+ * that should be sent before falling back on AUTOIP. This can be set
+ * as low as 1 to get an AutoIP address very quickly, but you should
+ * be prepared to handle a changing IP address when DHCP overrides
+ * AutoIP.
+ */
+#ifndef LWIP_DHCP_AUTOIP_COOP_TRIES
+#define LWIP_DHCP_AUTOIP_COOP_TRIES     9
+#endif
+
+/*
+   ----------------------------------
+   ---------- SNMP options ----------
+   ----------------------------------
+*/
+/**
+ * LWIP_SNMP==1: Turn on SNMP module. UDP must be available for SNMP
+ * transport.
+ */
+#ifndef LWIP_SNMP
+#define LWIP_SNMP                       0
+#endif
+
+/**
+ * SNMP_CONCURRENT_REQUESTS: Number of concurrent requests the module will
+ * allow. At least one request buffer is required. 
+ */
+#ifndef SNMP_CONCURRENT_REQUESTS
+#define SNMP_CONCURRENT_REQUESTS        0
+#endif
+
+/**
+ * SNMP_TRAP_DESTINATIONS: Number of trap destinations. At least one trap
+ * destination is required
+ */
+#ifndef SNMP_TRAP_DESTINATIONS
+#define SNMP_TRAP_DESTINATIONS          0
+#endif
+
+/**
+ * SNMP_PRIVATE_MIB: 
+ */
+#ifndef SNMP_PRIVATE_MIB
+#define SNMP_PRIVATE_MIB                0
+#endif
+
+/**
+ * Only allow SNMP write actions that are 'safe' (e.g. disabeling netifs is not
+ * a safe action and disabled when SNMP_SAFE_REQUESTS = 1).
+ * Unsafe requests are disabled by default!
+ */
+#ifndef SNMP_SAFE_REQUESTS
+#define SNMP_SAFE_REQUESTS              0
+#endif
+
+/**
+ * The maximum length of strings used. This affects the size of
+ * MEMP_SNMP_VALUE elements.
+ */
+#ifndef SNMP_MAX_OCTET_STRING_LEN
+#define SNMP_MAX_OCTET_STRING_LEN       127
+#endif
+
+/**
+ * The maximum depth of the SNMP tree.
+ * With private MIBs enabled, this depends on your MIB!
+ * This affects the size of MEMP_SNMP_VALUE elements.
+ */
+#ifndef SNMP_MAX_TREE_DEPTH
+#define SNMP_MAX_TREE_DEPTH             15
+#endif
+
+/**
+ * The size of the MEMP_SNMP_VALUE elements, normally calculated from
+ * SNMP_MAX_OCTET_STRING_LEN and SNMP_MAX_TREE_DEPTH.
+ */
+#ifndef SNMP_MAX_VALUE_SIZE
+#define SNMP_MAX_VALUE_SIZE             LWIP_MAX((SNMP_MAX_OCTET_STRING_LEN)+1, sizeof(s32_t)*(SNMP_MAX_TREE_DEPTH))
+#endif
+
+/*
+   ----------------------------------
+   ---------- IGMP options ----------
+   ----------------------------------
+*/
+/**
+ * LWIP_IGMP==1: Turn on IGMP module. 
+ */
+#ifndef LWIP_IGMP
+#define LWIP_IGMP                       1
+#endif
+/*
+   ----------------------------------
+   ---------- MDNS options ----------
+   ----------------------------------
+*/
+/**
+ * LWIP_MDNS==1: Turn on MDNS module.
+ */
+#ifndef LWIP_MDNS
+#define LWIP_MDNS                      1
+#endif
+/*
+   ----------------------------------
+   ---------- DNS options -----------
+   ----------------------------------
+*/
+/**
+ * LWIP_DNS==1: Turn on DNS module. UDP must be available for DNS
+ * transport.
+ */
+#ifndef LWIP_DNS
+#define LWIP_DNS                        1
+#endif
+
+/** DNS maximum number of entries to maintain locally. */
+#ifndef DNS_TABLE_SIZE
+#define DNS_TABLE_SIZE                  4
+#endif
+
+/** DNS maximum host name length supported in the name table. */
+#ifndef DNS_MAX_NAME_LENGTH
+#define DNS_MAX_NAME_LENGTH             256
+#endif
+
+/** The maximum of DNS servers */
+#ifndef DNS_MAX_SERVERS
+#define DNS_MAX_SERVERS                 2
+#endif
+
+/** DNS do a name checking between the query and the response. */
+#ifndef DNS_DOES_NAME_CHECK
+#define DNS_DOES_NAME_CHECK             1
+#endif
+
+/** DNS message max. size. Default value is RFC compliant. */
+#ifndef DNS_MSG_SIZE
+#define DNS_MSG_SIZE                    512
+#endif
+
+/** DNS_LOCAL_HOSTLIST: Implements a local host-to-address list. If enabled,
+ *  you have to define
+ *    #define DNS_LOCAL_HOSTLIST_INIT {{"host1", 0x123}, {"host2", 0x234}}
+ *  (an array of structs name/address, where address is an u32_t in network
+ *  byte order).
+ *
+ *  Instead, you can also use an external function:
+ *  #define DNS_LOOKUP_LOCAL_EXTERN(x) extern u32_t my_lookup_function(const char *name)
+ *  that returns the IP address or INADDR_NONE if not found.
+ */
+#ifndef DNS_LOCAL_HOSTLIST
+#define DNS_LOCAL_HOSTLIST              0
+#endif /* DNS_LOCAL_HOSTLIST */
+
+/** If this is turned on, the local host-list can be dynamically changed
+ *  at runtime. */
+#ifndef DNS_LOCAL_HOSTLIST_IS_DYNAMIC
+#define DNS_LOCAL_HOSTLIST_IS_DYNAMIC   0
+#endif /* DNS_LOCAL_HOSTLIST_IS_DYNAMIC */
+
+/*
+   ---------------------------------
+   ---------- UDP options ----------
+   ---------------------------------
+*/
+/**
+ * LWIP_UDP==1: Turn on UDP.
+ */
+#ifndef LWIP_UDP
+#define LWIP_UDP                        1
+#endif
+
+/**
+ * LWIP_UDPLITE==1: Turn on UDP-Lite. (Requires LWIP_UDP)
+ */
+#ifndef LWIP_UDPLITE
+#define LWIP_UDPLITE                    0
+#endif
+
+/**
+ * UDP_TTL: Default Time-To-Live value.
+ */
+#ifndef UDP_TTL
+#define UDP_TTL                         (IP_DEFAULT_TTL)
+#endif
+
+/**
+ * LWIP_NETBUF_RECVINFO==1: append destination addr and port to every netbuf.
+ */
+#ifndef LWIP_NETBUF_RECVINFO
+#define LWIP_NETBUF_RECVINFO            0
+#endif
+
+/*
+   ---------------------------------
+   ---------- TCP options ----------
+   ---------------------------------
+*/
+/**
+ * LWIP_TCP==1: Turn on TCP.
+ */
+#ifndef LWIP_TCP
+#define LWIP_TCP                        1
+#endif
+
+/**
+ * TCP_TTL: Default Time-To-Live value.
+ */
+#ifndef TCP_TTL
+#define TCP_TTL                         (IP_DEFAULT_TTL)
+#endif
+
+/**
+ * TCP_MAXRTX: Maximum number of retransmissions of data segments.
+ */
+#ifndef TCP_MAXRTX
+#define TCP_MAXRTX                      (*(volatile uint32*)0x600011E8)
+#endif
+
+/**
+ * TCP_SYNMAXRTX: Maximum number of retransmissions of SYN segments.
+ */
+#ifndef TCP_SYNMAXRTX
+#define TCP_SYNMAXRTX                   (*(volatile uint32*)0x600011E4)
+#endif
+
+/**
+ * TCP_MAXRTO: Maximum retransmission timeout of data segments.
+ */
+#ifndef TCP_MAXRTO
+#define TCP_MAXRTO                      10
+#endif
+
+/**
+ * TCP_MINRTO: Minimum retransmission timeout of data segments.
+ */
+#ifndef TCP_MINRTO
+#define TCP_MINRTO                      2
+#endif
+
+/**
+ * TCP_QUEUE_OOSEQ==1: TCP will queue segments that arrive out of order.
+ * Define to 0 if your device is low on memory.
+ */
+#ifndef TCP_QUEUE_OOSEQ
+#define TCP_QUEUE_OOSEQ                 1
+#endif
+
+#if 1
+/**
+ * TCP_MSS: TCP Maximum segment size. (default is 536, a conservative default,
+ * you might want to increase this.)
+ * For the receive side, this MSS is advertised to the remote side
+ * when opening a connection. For the transmit size, this MSS sets
+ * an upper limit on the MSS advertised by the remote host.
+ */
+#ifndef TCP_MSS
+#define TCP_MSS                         1460
+#endif
+#endif
+
+/**
+ * TCP_WND: The size of a TCP window.  This must be at least 
+ * (2 * TCP_MSS) for things to work well
+ */
+#ifndef TCP_WND
+#define TCP_WND                         (*(volatile uint32*)0x600011F0)
+#endif 
+
+/**
+ * TCP_CALCULATE_EFF_SEND_MSS: "The maximum size of a segment that TCP really
+ * sends, the 'effective send MSS,' MUST be the smaller of the send MSS (which
+ * reflects the available reassembly buffer size at the remote host) and the
+ * largest size permitted by the IP layer" (RFC 1122)
+ * Setting this to 1 enables code that checks TCP_MSS against the MTU of the
+ * netif used for a connection and limits the MSS if it would be too big otherwise.
+ */
+#ifndef TCP_CALCULATE_EFF_SEND_MSS
+#define TCP_CALCULATE_EFF_SEND_MSS      1
+#endif
+
+
+/**
+ * TCP_SND_BUF: TCP sender buffer space (bytes). 
+ */
+#ifndef TCP_SND_BUF
+#define TCP_SND_BUF                     2 * TCP_MSS
+#endif
+
+/**
+ * TCP_SND_QUEUELEN: TCP sender buffer space (pbufs). This must be at least
+ * as much as (2 * TCP_SND_BUF/TCP_MSS) for things to work.
+ */
+#ifndef TCP_SND_QUEUELEN
+#define TCP_SND_QUEUELEN                ((4 * (TCP_SND_BUF) + (TCP_MSS - 1))/(TCP_MSS))
+#endif
+
+/**
+ * TCP_SNDLOWAT: TCP writable space (bytes). This must be less than
+ * TCP_SND_BUF. It is the amount of space which must be available in the
+ * TCP snd_buf for select to return writable (combined with TCP_SNDQUEUELOWAT).
+ */
+#ifndef TCP_SNDLOWAT
+#define TCP_SNDLOWAT                    ((TCP_SND_BUF)/2)
+#endif
+
+/**
+ * TCP_SNDQUEUELOWAT: TCP writable bufs (pbuf count). This must be grater
+ * than TCP_SND_QUEUELEN. If the number of pbufs queued on a pcb drops below
+ * this number, select returns writable (combined with TCP_SNDLOWAT).
+ */
+#ifndef TCP_SNDQUEUELOWAT
+#define TCP_SNDQUEUELOWAT               LWIP_MAX(((TCP_SND_QUEUELEN)/2), 5)
+#endif
+
+/**
+ * TCP_LISTEN_BACKLOG: Enable the backlog option for tcp listen pcb.
+ */
+#ifndef TCP_LISTEN_BACKLOG
+#define TCP_LISTEN_BACKLOG              0
+#endif
+
+/**
+ * The maximum allowed backlog for TCP listen netconns.
+ * This backlog is used unless another is explicitly specified.
+ * 0xff is the maximum (u8_t).
+ */
+#ifndef TCP_DEFAULT_LISTEN_BACKLOG
+#define TCP_DEFAULT_LISTEN_BACKLOG      0xff
+#endif
+
+/**
+ * TCP_OVERSIZE: The maximum number of bytes that tcp_write may
+ * allocate ahead of time in an attempt to create shorter pbuf chains
+ * for transmission. The meaningful range is 0 to TCP_MSS. Some
+ * suggested values are:
+ *
+ * 0:         Disable oversized allocation. Each tcp_write() allocates a new
+              pbuf (old behaviour).
+ * 1:         Allocate size-aligned pbufs with minimal excess. Use this if your
+ *            scatter-gather DMA requires aligned fragments.
+ * 128:       Limit the pbuf/memory overhead to 20%.
+ * TCP_MSS:   Try to create unfragmented TCP packets.
+ * TCP_MSS/4: Try to create 4 fragments or less per TCP packet.
+ */
+#ifndef TCP_OVERSIZE
+#define TCP_OVERSIZE                    TCP_MSS
+#endif
+
+/**
+ * LWIP_TCP_TIMESTAMPS==1: support the TCP timestamp option.
+ */
+#ifndef LWIP_TCP_TIMESTAMPS
+#define LWIP_TCP_TIMESTAMPS             0
+#endif
+
+/**
+ * TCP_WND_UPDATE_THRESHOLD: difference in window to trigger an
+ * explicit window update
+ */
+#ifndef TCP_WND_UPDATE_THRESHOLD
+#define TCP_WND_UPDATE_THRESHOLD   (TCP_WND / 4)
+#endif
+
+/**
+ * LWIP_EVENT_API and LWIP_CALLBACK_API: Only one of these should be set to 1.
+ *     LWIP_EVENT_API==1: The user defines lwip_tcp_event() to receive all
+ *         events (accept, sent, etc) that happen in the system.
+ *     LWIP_CALLBACK_API==1: The PCB callback function is called directly
+ *         for the event.
+ */
+#ifndef LWIP_EVENT_API
+#define LWIP_EVENT_API                  0
+#define LWIP_CALLBACK_API               1
+#else 
+#define LWIP_EVENT_API                  1
+#define LWIP_CALLBACK_API               0
+#endif
+
+
+/*
+   ----------------------------------
+   ---------- Pbuf options ----------
+   ----------------------------------
+*/
+/**
+ * PBUF_LINK_HLEN: the number of bytes that should be allocated for a
+ * link level header. The default is 14, the standard value for
+ * Ethernet.
+ */
+#ifndef PBUF_LINK_HLEN
+#define PBUF_LINK_HLEN                  (14 + ETH_PAD_SIZE)
+#endif
+
+/**
+ * PBUF_POOL_BUFSIZE: the size of each pbuf in the pbuf pool. The default is
+ * designed to accomodate single full size TCP frame in one pbuf, including
+ * TCP_MSS, IP header, and link header.
+ */
+#ifndef PBUF_POOL_BUFSIZE
+#define PBUF_POOL_BUFSIZE               LWIP_MEM_ALIGN_SIZE(TCP_MSS+40+PBUF_LINK_HLEN)
+#endif
+
+/*
+   ------------------------------------------------
+   ---------- Network Interfaces options ----------
+   ------------------------------------------------
+*/
+/**
+ * LWIP_NETIF_HOSTNAME==1: use DHCP_OPTION_HOSTNAME with netif's hostname
+ * field.
+ */
+#ifndef LWIP_NETIF_HOSTNAME
+#define LWIP_NETIF_HOSTNAME             1
+#endif
+
+/**
+ * LWIP_NETIF_API==1: Support netif api (in netifapi.c)
+ */
+#ifndef LWIP_NETIF_API
+#define LWIP_NETIF_API                  0
+#endif
+
+/**
+ * LWIP_NETIF_STATUS_CALLBACK==1: Support a callback function whenever an interface
+ * changes its up/down status (i.e., due to DHCP IP acquistion)
+ */
+#ifndef LWIP_NETIF_STATUS_CALLBACK
+#define LWIP_NETIF_STATUS_CALLBACK      0
+#endif
+
+/**
+ * LWIP_NETIF_LINK_CALLBACK==1: Support a callback function from an interface
+ * whenever the link changes (i.e., link down)
+ */
+#ifndef LWIP_NETIF_LINK_CALLBACK
+#define LWIP_NETIF_LINK_CALLBACK        0
+#endif
+
+/**
+ * LWIP_NETIF_HWADDRHINT==1: Cache link-layer-address hints (e.g. table
+ * indices) in struct netif. TCP and UDP can make use of this to prevent
+ * scanning the ARP table for every sent packet. While this is faster for big
+ * ARP tables or many concurrent connections, it might be counterproductive
+ * if you have a tiny ARP table or if there never are concurrent connections.
+ */
+#ifndef LWIP_NETIF_HWADDRHINT
+#define LWIP_NETIF_HWADDRHINT           0
+#endif
+
+/**
+ * LWIP_NETIF_LOOPBACK==1: Support sending packets with a destination IP
+ * address equal to the netif IP address, looping them back up the stack.
+ */
+#ifndef LWIP_NETIF_LOOPBACK
+#define LWIP_NETIF_LOOPBACK             0
+#endif
+
+/**
+ * LWIP_LOOPBACK_MAX_PBUFS: Maximum number of pbufs on queue for loopback
+ * sending for each netif (0 = disabled)
+ */
+#ifndef LWIP_LOOPBACK_MAX_PBUFS
+#define LWIP_LOOPBACK_MAX_PBUFS         0
+#endif
+
+/**
+ * LWIP_NETIF_LOOPBACK_MULTITHREADING: Indicates whether threading is enabled in
+ * the system, as netifs must change how they behave depending on this setting
+ * for the LWIP_NETIF_LOOPBACK option to work.
+ * Setting this is needed to avoid reentering non-reentrant functions like
+ * tcp_input().
+ *    LWIP_NETIF_LOOPBACK_MULTITHREADING==1: Indicates that the user is using a
+ *       multithreaded environment like tcpip.c. In this case, netif->input()
+ *       is called directly.
+ *    LWIP_NETIF_LOOPBACK_MULTITHREADING==0: Indicates a polling (or NO_SYS) setup.
+ *       The packets are put on a list and netif_poll() must be called in
+ *       the main application loop.
+ */
+#ifndef LWIP_NETIF_LOOPBACK_MULTITHREADING
+#define LWIP_NETIF_LOOPBACK_MULTITHREADING    (!NO_SYS)
+#endif
+
+/**
+ * LWIP_NETIF_TX_SINGLE_PBUF: if this is set to 1, lwIP tries to put all data
+ * to be sent into one single pbuf. This is for compatibility with DMA-enabled
+ * MACs that do not support scatter-gather.
+ * Beware that this might involve CPU-memcpy before transmitting that would not
+ * be needed without this flag! Use this only if you need to!
+ *
+ * @todo: TCP and IP-frag do not work with this, yet:
+ */
+#ifndef LWIP_NETIF_TX_SINGLE_PBUF
+#define LWIP_NETIF_TX_SINGLE_PBUF             1
+#endif /* LWIP_NETIF_TX_SINGLE_PBUF */
+
+/*
+   ------------------------------------
+   ---------- LOOPIF options ----------
+   ------------------------------------
+*/
+/**
+ * LWIP_HAVE_LOOPIF==1: Support loop interface (127.0.0.1) and loopif.c
+ */
+#ifndef LWIP_HAVE_LOOPIF
+#define LWIP_HAVE_LOOPIF                0
+#endif
+
+/*
+   ------------------------------------
+   ---------- SLIPIF options ----------
+   ------------------------------------
+*/
+/**
+ * LWIP_HAVE_SLIPIF==1: Support slip interface and slipif.c
+ */
+#ifndef LWIP_HAVE_SLIPIF
+#define LWIP_HAVE_SLIPIF                0
+#endif
+
+/*
+   ------------------------------------
+   ---------- Thread options ----------
+   ------------------------------------
+*/
+/**
+ * TCPIP_THREAD_NAME: The name assigned to the main tcpip thread.
+ */
+#ifndef TCPIP_THREAD_NAME
+#define TCPIP_THREAD_NAME              "tcpip_thread"
+#endif
+
+/**
+ * TCPIP_THREAD_STACKSIZE: The stack size used by the main tcpip thread.
+ * The stack size value itself is platform-dependent, but is passed to
+ * sys_thread_new() when the thread is created.
+ */
+#ifndef TCPIP_THREAD_STACKSIZE
+#define TCPIP_THREAD_STACKSIZE          0
+#endif
+
+/**
+ * TCPIP_THREAD_PRIO: The priority assigned to the main tcpip thread.
+ * The priority value itself is platform-dependent, but is passed to
+ * sys_thread_new() when the thread is created.
+ */
+#ifndef TCPIP_THREAD_PRIO
+#define TCPIP_THREAD_PRIO               1
+#endif
+
+/**
+ * TCPIP_MBOX_SIZE: The mailbox size for the tcpip thread messages
+ * The queue size value itself is platform-dependent, but is passed to
+ * sys_mbox_new() when tcpip_init is called.
+ */
+#ifndef TCPIP_MBOX_SIZE
+#define TCPIP_MBOX_SIZE                 0
+#endif
+
+/**
+ * SLIPIF_THREAD_NAME: The name assigned to the slipif_loop thread.
+ */
+#ifndef SLIPIF_THREAD_NAME
+#define SLIPIF_THREAD_NAME             "slipif_loop"
+#endif
+
+/**
+ * SLIP_THREAD_STACKSIZE: The stack size used by the slipif_loop thread.
+ * The stack size value itself is platform-dependent, but is passed to
+ * sys_thread_new() when the thread is created.
+ */
+#ifndef SLIPIF_THREAD_STACKSIZE
+#define SLIPIF_THREAD_STACKSIZE         0
+#endif
+
+/**
+ * SLIPIF_THREAD_PRIO: The priority assigned to the slipif_loop thread.
+ * The priority value itself is platform-dependent, but is passed to
+ * sys_thread_new() when the thread is created.
+ */
+#ifndef SLIPIF_THREAD_PRIO
+#define SLIPIF_THREAD_PRIO              1
+#endif
+
+/**
+ * PPP_THREAD_NAME: The name assigned to the pppInputThread.
+ */
+#ifndef PPP_THREAD_NAME
+#define PPP_THREAD_NAME                "pppInputThread"
+#endif
+
+/**
+ * PPP_THREAD_STACKSIZE: The stack size used by the pppInputThread.
+ * The stack size value itself is platform-dependent, but is passed to
+ * sys_thread_new() when the thread is created.
+ */
+#ifndef PPP_THREAD_STACKSIZE
+#define PPP_THREAD_STACKSIZE            0
+#endif
+
+/**
+ * PPP_THREAD_PRIO: The priority assigned to the pppInputThread.
+ * The priority value itself is platform-dependent, but is passed to
+ * sys_thread_new() when the thread is created.
+ */
+#ifndef PPP_THREAD_PRIO
+#define PPP_THREAD_PRIO                 1
+#endif
+
+/**
+ * DEFAULT_THREAD_NAME: The name assigned to any other lwIP thread.
+ */
+#ifndef DEFAULT_THREAD_NAME
+#define DEFAULT_THREAD_NAME            "lwIP"
+#endif
+
+/**
+ * DEFAULT_THREAD_STACKSIZE: The stack size used by any other lwIP thread.
+ * The stack size value itself is platform-dependent, but is passed to
+ * sys_thread_new() when the thread is created.
+ */
+#ifndef DEFAULT_THREAD_STACKSIZE
+#define DEFAULT_THREAD_STACKSIZE        0
+#endif
+
+/**
+ * DEFAULT_THREAD_PRIO: The priority assigned to any other lwIP thread.
+ * The priority value itself is platform-dependent, but is passed to
+ * sys_thread_new() when the thread is created.
+ */
+#ifndef DEFAULT_THREAD_PRIO
+#define DEFAULT_THREAD_PRIO             1
+#endif
+
+/**
+ * DEFAULT_RAW_RECVMBOX_SIZE: The mailbox size for the incoming packets on a
+ * NETCONN_RAW. The queue size value itself is platform-dependent, but is passed
+ * to sys_mbox_new() when the recvmbox is created.
+ */
+#ifndef DEFAULT_RAW_RECVMBOX_SIZE
+#define DEFAULT_RAW_RECVMBOX_SIZE       0
+#endif
+
+/**
+ * DEFAULT_UDP_RECVMBOX_SIZE: The mailbox size for the incoming packets on a
+ * NETCONN_UDP. The queue size value itself is platform-dependent, but is passed
+ * to sys_mbox_new() when the recvmbox is created.
+ */
+#ifndef DEFAULT_UDP_RECVMBOX_SIZE
+#define DEFAULT_UDP_RECVMBOX_SIZE       0
+#endif
+
+/**
+ * DEFAULT_TCP_RECVMBOX_SIZE: The mailbox size for the incoming packets on a
+ * NETCONN_TCP. The queue size value itself is platform-dependent, but is passed
+ * to sys_mbox_new() when the recvmbox is created.
+ */
+#ifndef DEFAULT_TCP_RECVMBOX_SIZE
+#define DEFAULT_TCP_RECVMBOX_SIZE       0
+#endif
+
+/**
+ * DEFAULT_ACCEPTMBOX_SIZE: The mailbox size for the incoming connections.
+ * The queue size value itself is platform-dependent, but is passed to
+ * sys_mbox_new() when the acceptmbox is created.
+ */
+#ifndef DEFAULT_ACCEPTMBOX_SIZE
+#define DEFAULT_ACCEPTMBOX_SIZE         0
+#endif
+
+/*
+   ----------------------------------------------
+   ---------- Sequential layer options ----------
+   ----------------------------------------------
+*/
+/**
+ * LWIP_TCPIP_CORE_LOCKING: (EXPERIMENTAL!)
+ * Don't use it if you're not an active lwIP project member
+ */
+#ifndef LWIP_TCPIP_CORE_LOCKING
+#define LWIP_TCPIP_CORE_LOCKING         0
+#endif
+
+/**
+ * LWIP_TCPIP_CORE_LOCKING_INPUT: (EXPERIMENTAL!)
+ * Don't use it if you're not an active lwIP project member
+ */
+#ifndef LWIP_TCPIP_CORE_LOCKING_INPUT
+#define LWIP_TCPIP_CORE_LOCKING_INPUT   0
+#endif
+
+/**
+ * LWIP_NETCONN==1: Enable Netconn API (require to use api_lib.c)
+ */
+#ifndef LWIP_NETCONN
+#define LWIP_NETCONN                    0
+#endif
+
+/** LWIP_TCPIP_TIMEOUT==1: Enable tcpip_timeout/tcpip_untimeout tod create
+ * timers running in tcpip_thread from another thread.
+ */
+#ifndef LWIP_TCPIP_TIMEOUT
+#define LWIP_TCPIP_TIMEOUT              1
+#endif
+
+/*
+   ------------------------------------
+   ---------- Socket options ----------
+   ------------------------------------
+*/
+/**
+ * LWIP_SOCKET==1: Enable Socket API (require to use sockets.c)
+ */
+#ifndef LWIP_SOCKET
+#define LWIP_SOCKET                     0
+#endif
+
+/**
+ * LWIP_COMPAT_SOCKETS==1: Enable BSD-style sockets functions names.
+ * (only used if you use sockets.c)
+ */
+#ifndef LWIP_COMPAT_SOCKETS
+#define LWIP_COMPAT_SOCKETS             0
+#endif
+
+/**
+ * LWIP_POSIX_SOCKETS_IO_NAMES==1: Enable POSIX-style sockets functions names.
+ * Disable this option if you use a POSIX operating system that uses the same
+ * names (read, write & close). (only used if you use sockets.c)
+ */
+#ifndef LWIP_POSIX_SOCKETS_IO_NAMES
+#define LWIP_POSIX_SOCKETS_IO_NAMES     0
+#endif
+
+/**
+ * LWIP_TCP_KEEPALIVE==1: Enable TCP_KEEPIDLE, TCP_KEEPINTVL and TCP_KEEPCNT
+ * options processing. Note that TCP_KEEPIDLE and TCP_KEEPINTVL have to be set
+ * in seconds. (does not require sockets.c, and will affect tcp.c)
+ */
+#ifndef LWIP_TCP_KEEPALIVE
+#define LWIP_TCP_KEEPALIVE              1
+#endif
+
+/**
+ * LWIP_SO_RCVTIMEO==1: Enable SO_RCVTIMEO processing.
+ */
+#ifndef LWIP_SO_RCVTIMEO
+#define LWIP_SO_RCVTIMEO                0
+#endif
+
+/**
+ * LWIP_SO_RCVBUF==1: Enable SO_RCVBUF processing.
+ */
+#ifndef LWIP_SO_RCVBUF
+#define LWIP_SO_RCVBUF                  0
+#endif
+
+/**
+ * If LWIP_SO_RCVBUF is used, this is the default value for recv_bufsize.
+ */
+#ifndef RECV_BUFSIZE_DEFAULT
+#define RECV_BUFSIZE_DEFAULT            INT_MAX
+#endif
+
+/**
+ * SO_REUSE==1: Enable SO_REUSEADDR option.
+ */
+#ifndef SO_REUSE
+#define SO_REUSE                        0
+#endif
+
+/**
+ * SO_REUSE_RXTOALL==1: Pass a copy of incoming broadcast/multicast packets
+ * to all local matches if SO_REUSEADDR is turned on.
+ * WARNING: Adds a memcpy for every packet if passing to more than one pcb!
+ */
+#ifndef SO_REUSE_RXTOALL
+#define SO_REUSE_RXTOALL                0
+#endif
+
+/*
+   ----------------------------------------
+   ---------- Statistics options ----------
+   ----------------------------------------
+*/
+/**
+ * LWIP_STATS==1: Enable statistics collection in lwip_stats.
+ */
+#ifndef LWIP_STATS
+#define LWIP_STATS                      0
+#endif
+
+#if LWIP_STATS
+
+/**
+ * LWIP_STATS_DISPLAY==1: Compile in the statistics output functions.
+ */
+#ifndef LWIP_STATS_DISPLAY
+#define LWIP_STATS_DISPLAY              0
+#endif
+
+/**
+ * LINK_STATS==1: Enable link stats.
+ */
+#ifndef LINK_STATS
+#define LINK_STATS                      1
+#endif
+
+/**
+ * ETHARP_STATS==1: Enable etharp stats.
+ */
+#ifndef ETHARP_STATS
+#define ETHARP_STATS                    (LWIP_ARP)
+#endif
+
+/**
+ * IP_STATS==1: Enable IP stats.
+ */
+#ifndef IP_STATS
+#define IP_STATS                        1
+#endif
+
+/**
+ * IPFRAG_STATS==1: Enable IP fragmentation stats. Default is
+ * on if using either frag or reass.
+ */
+#ifndef IPFRAG_STATS
+#define IPFRAG_STATS                    (IP_REASSEMBLY || IP_FRAG)
+#endif
+
+/**
+ * ICMP_STATS==1: Enable ICMP stats.
+ */
+#ifndef ICMP_STATS
+#define ICMP_STATS                      1
+#endif
+
+/**
+ * IGMP_STATS==1: Enable IGMP stats.
+ */
+#ifndef IGMP_STATS
+#define IGMP_STATS                      (LWIP_IGMP)
+#endif
+
+/**
+ * UDP_STATS==1: Enable UDP stats. Default is on if
+ * UDP enabled, otherwise off.
+ */
+#ifndef UDP_STATS
+#define UDP_STATS                       (LWIP_UDP)
+#endif
+
+/**
+ * TCP_STATS==1: Enable TCP stats. Default is on if TCP
+ * enabled, otherwise off.
+ */
+#ifndef TCP_STATS
+#define TCP_STATS                       (LWIP_TCP)
+#endif
+
+/**
+ * MEM_STATS==1: Enable mem.c stats.
+ */
+#ifndef MEM_STATS
+#define MEM_STATS                       ((MEM_LIBC_MALLOC == 0) && (MEM_USE_POOLS == 0))
+#endif
+
+/**
+ * MEMP_STATS==1: Enable memp.c pool stats.
+ */
+#ifndef MEMP_STATS
+#define MEMP_STATS                      (MEMP_MEM_MALLOC == 0)
+#endif
+
+/**
+ * SYS_STATS==1: Enable system stats (sem and mbox counts, etc).
+ */
+#ifndef SYS_STATS
+#define SYS_STATS                       (NO_SYS == 0)
+#endif
+
+#else
+#define ETHARP_STATS                    0
+#define LINK_STATS                      0
+#define IP_STATS                        0
+#define IPFRAG_STATS                    0
+#define ICMP_STATS                      0
+#define IGMP_STATS                      0
+#define UDP_STATS                       0
+#define TCP_STATS                       0
+#define MEM_STATS                       0
+#define MEMP_STATS                      0
+#define SYS_STATS                       0
+#define LWIP_STATS_DISPLAY              0
+
+#endif /* LWIP_STATS */
+
+/*
+   ---------------------------------
+   ---------- PPP options ----------
+   ---------------------------------
+*/
+/**
+ * PPP_SUPPORT==1: Enable PPP.
+ */
+#ifndef PPP_SUPPORT
+#define PPP_SUPPORT                     0
+#endif
+
+/**
+ * PPPOE_SUPPORT==1: Enable PPP Over Ethernet
+ */
+#ifndef PPPOE_SUPPORT
+#define PPPOE_SUPPORT                   0
+#endif
+
+/**
+ * PPPOS_SUPPORT==1: Enable PPP Over Serial
+ */
+#ifndef PPPOS_SUPPORT
+#define PPPOS_SUPPORT                   PPP_SUPPORT
+#endif
+
+#if PPP_SUPPORT
+
+/**
+ * NUM_PPP: Max PPP sessions.
+ */
+#ifndef NUM_PPP
+#define NUM_PPP                         1
+#endif
+
+/**
+ * PAP_SUPPORT==1: Support PAP.
+ */
+#ifndef PAP_SUPPORT
+#define PAP_SUPPORT                     0
+#endif
+
+/**
+ * CHAP_SUPPORT==1: Support CHAP.
+ */
+#ifndef CHAP_SUPPORT
+#define CHAP_SUPPORT                    0
+#endif
+
+/**
+ * MSCHAP_SUPPORT==1: Support MSCHAP. CURRENTLY NOT SUPPORTED! DO NOT SET!
+ */
+#ifndef MSCHAP_SUPPORT
+#define MSCHAP_SUPPORT                  0
+#endif
+
+/**
+ * CBCP_SUPPORT==1: Support CBCP. CURRENTLY NOT SUPPORTED! DO NOT SET!
+ */
+#ifndef CBCP_SUPPORT
+#define CBCP_SUPPORT                    0
+#endif
+
+/**
+ * CCP_SUPPORT==1: Support CCP. CURRENTLY NOT SUPPORTED! DO NOT SET!
+ */
+#ifndef CCP_SUPPORT
+#define CCP_SUPPORT                     0
+#endif
+
+/**
+ * VJ_SUPPORT==1: Support VJ header compression.
+ */
+#ifndef VJ_SUPPORT
+#define VJ_SUPPORT                      0
+#endif
+
+/**
+ * MD5_SUPPORT==1: Support MD5 (see also CHAP).
+ */
+#ifndef MD5_SUPPORT
+#define MD5_SUPPORT                     0
+#endif
+
+/*
+ * Timeouts
+ */
+#ifndef FSM_DEFTIMEOUT
+#define FSM_DEFTIMEOUT                  6       /* Timeout time in seconds */
+#endif
+
+#ifndef FSM_DEFMAXTERMREQS
+#define FSM_DEFMAXTERMREQS              2       /* Maximum Terminate-Request transmissions */
+#endif
+
+#ifndef FSM_DEFMAXCONFREQS
+#define FSM_DEFMAXCONFREQS              10      /* Maximum Configure-Request transmissions */
+#endif
+
+#ifndef FSM_DEFMAXNAKLOOPS
+#define FSM_DEFMAXNAKLOOPS              5       /* Maximum number of nak loops */
+#endif
+
+#ifndef UPAP_DEFTIMEOUT
+#define UPAP_DEFTIMEOUT                 6       /* Timeout (seconds) for retransmitting req */
+#endif
+
+#ifndef UPAP_DEFREQTIME
+#define UPAP_DEFREQTIME                 30      /* Time to wait for auth-req from peer */
+#endif
+
+#ifndef CHAP_DEFTIMEOUT
+#define CHAP_DEFTIMEOUT                 6       /* Timeout time in seconds */
+#endif
+
+#ifndef CHAP_DEFTRANSMITS
+#define CHAP_DEFTRANSMITS               10      /* max # times to send challenge */
+#endif
+
+/* Interval in seconds between keepalive echo requests, 0 to disable. */
+#ifndef LCP_ECHOINTERVAL
+#define LCP_ECHOINTERVAL                0
+#endif
+
+/* Number of unanswered echo requests before failure. */
+#ifndef LCP_MAXECHOFAILS
+#define LCP_MAXECHOFAILS                3
+#endif
+
+/* Max Xmit idle time (in jiffies) before resend flag char. */
+#ifndef PPP_MAXIDLEFLAG
+#define PPP_MAXIDLEFLAG                 100
+#endif
+
+/*
+ * Packet sizes
+ *
+ * Note - lcp shouldn't be allowed to negotiate stuff outside these
+ *    limits.  See lcp.h in the pppd directory.
+ * (XXX - these constants should simply be shared by lcp.c instead
+ *    of living in lcp.h)
+ */
+#define PPP_MTU                         1500     /* Default MTU (size of Info field) */
+#ifndef PPP_MAXMTU
+/* #define PPP_MAXMTU  65535 - (PPP_HDRLEN + PPP_FCSLEN) */
+#define PPP_MAXMTU                      1500 /* Largest MTU we allow */
+#endif
+#define PPP_MINMTU                      64
+#define PPP_MRU                         1500     /* default MRU = max length of info field */
+#define PPP_MAXMRU                      1500     /* Largest MRU we allow */
+#ifndef PPP_DEFMRU
+#define PPP_DEFMRU                      296             /* Try for this */
+#endif
+#define PPP_MINMRU                      128             /* No MRUs below this */
+
+#ifndef MAXNAMELEN
+#define MAXNAMELEN                      256     /* max length of hostname or name for auth */
+#endif
+#ifndef MAXSECRETLEN
+#define MAXSECRETLEN                    256     /* max length of password or secret */
+#endif
+
+#endif /* PPP_SUPPORT */
+
+/*
+   --------------------------------------
+   ---------- Checksum options ----------
+   --------------------------------------
+*/
+/**
+ * CHECKSUM_GEN_IP==1: Generate checksums in software for outgoing IP packets.
+ */
+#ifndef CHECKSUM_GEN_IP
+#define CHECKSUM_GEN_IP                 1
+#endif
+ 
+/**
+ * CHECKSUM_GEN_UDP==1: Generate checksums in software for outgoing UDP packets.
+ */
+#ifndef CHECKSUM_GEN_UDP
+#define CHECKSUM_GEN_UDP                1
+#endif
+ 
+/**
+ * CHECKSUM_GEN_TCP==1: Generate checksums in software for outgoing TCP packets.
+ */
+#ifndef CHECKSUM_GEN_TCP
+#define CHECKSUM_GEN_TCP                1
+#endif
+ 
+/**
+ * CHECKSUM_CHECK_IP==1: Check checksums in software for incoming IP packets.
+ */
+#ifndef CHECKSUM_CHECK_IP
+#define CHECKSUM_CHECK_IP               1
+#endif
+ 
+/**
+ * CHECKSUM_CHECK_UDP==1: Check checksums in software for incoming UDP packets.
+ */
+#ifndef CHECKSUM_CHECK_UDP
+#define CHECKSUM_CHECK_UDP              1
+#endif
+
+/**
+ * CHECKSUM_CHECK_TCP==1: Check checksums in software for incoming TCP packets.
+ */
+#ifndef CHECKSUM_CHECK_TCP
+#define CHECKSUM_CHECK_TCP              1
+#endif
+
+/**
+ * LWIP_CHECKSUM_ON_COPY==1: Calculate checksum when copying data from
+ * application buffers to pbufs.
+ */
+#ifndef LWIP_CHECKSUM_ON_COPY
+#define LWIP_CHECKSUM_ON_COPY           0
+#endif
+
+/*
+   ---------------------------------------
+   ---------- Debugging options ----------
+   ---------------------------------------
+*/
+/**
+ * LWIP_DBG_MIN_LEVEL: After masking, the value of the debug is
+ * compared against this value. If it is smaller, then debugging
+ * messages are written.
+ */
+#ifndef LWIP_DBG_MIN_LEVEL
+#define LWIP_DBG_MIN_LEVEL              LWIP_DBG_LEVEL_ALL
+#endif
+
+/**
+ * LWIP_DBG_TYPES_ON: A mask that can be used to globally enable/disable
+ * debug messages of certain types.
+ */
+#ifndef LWIP_DBG_TYPES_ON
+#define LWIP_DBG_TYPES_ON               LWIP_DBG_OFF
+#endif
+
+/**
+ * ETHARP_DEBUG: Enable debugging in etharp.c.
+ */
+#ifndef ETHARP_DEBUG
+#define ETHARP_DEBUG                    LWIP_DBG_OFF
+#endif
+
+/**
+ * NETIF_DEBUG: Enable debugging in netif.c.
+ */
+#ifndef NETIF_DEBUG
+#define NETIF_DEBUG                     LWIP_DBG_OFF
+#endif
+
+/**
+ * PBUF_DEBUG: Enable debugging in pbuf.c.
+ */
+#ifndef PBUF_DEBUG
+#define PBUF_DEBUG                      LWIP_DBG_OFF
+#endif
+
+/**
+ * API_LIB_DEBUG: Enable debugging in api_lib.c.
+ */
+#ifndef API_LIB_DEBUG
+#define API_LIB_DEBUG                   LWIP_DBG_OFF
+#endif
+
+/**
+ * API_MSG_DEBUG: Enable debugging in api_msg.c.
+ */
+#ifndef API_MSG_DEBUG
+#define API_MSG_DEBUG                   LWIP_DBG_OFF
+#endif
+
+/**
+ * SOCKETS_DEBUG: Enable debugging in sockets.c.
+ */
+#ifndef SOCKETS_DEBUG
+#define SOCKETS_DEBUG                   LWIP_DBG_OFF
+#endif
+
+/**
+ * ICMP_DEBUG: Enable debugging in icmp.c.
+ */
+#ifndef ICMP_DEBUG
+#define ICMP_DEBUG                      LWIP_DBG_OFF
+#endif
+
+/**
+ * IGMP_DEBUG: Enable debugging in igmp.c.
+ */
+#ifndef IGMP_DEBUG
+#define IGMP_DEBUG                      LWIP_DBG_OFF
+#endif
+
+/**
+ * INET_DEBUG: Enable debugging in inet.c.
+ */
+#ifndef INET_DEBUG
+#define INET_DEBUG                      LWIP_DBG_OFF
+#endif
+
+/**
+ * IP_DEBUG: Enable debugging for IP.
+ */
+#ifndef IP_DEBUG
+#define IP_DEBUG                        LWIP_DBG_OFF
+#endif
+
+/**
+ * IP_REASS_DEBUG: Enable debugging in ip_frag.c for both frag & reass.
+ */
+#ifndef IP_REASS_DEBUG
+#define IP_REASS_DEBUG                  LWIP_DBG_OFF
+#endif
+
+/**
+ * RAW_DEBUG: Enable debugging in raw.c.
+ */
+#ifndef RAW_DEBUG
+#define RAW_DEBUG                       LWIP_DBG_OFF
+#endif
+
+/**
+ * MEM_DEBUG: Enable debugging in mem.c.
+ */
+#ifndef MEM_DEBUG
+#define MEM_DEBUG                       LWIP_DBG_OFF
+#endif
+
+/**
+ * MEMP_DEBUG: Enable debugging in memp.c.
+ */
+#ifndef MEMP_DEBUG
+#define MEMP_DEBUG                      LWIP_DBG_OFF
+#endif
+
+/**
+ * SYS_DEBUG: Enable debugging in sys.c.
+ */
+#ifndef SYS_DEBUG
+#define SYS_DEBUG                       LWIP_DBG_OFF
+#endif
+
+/**
+ * TIMERS_DEBUG: Enable debugging in timers.c.
+ */
+#ifndef TIMERS_DEBUG
+#define TIMERS_DEBUG                    LWIP_DBG_OFF
+#endif
+
+/**
+ * TCP_DEBUG: Enable debugging for TCP.
+ */
+#ifndef TCP_DEBUG
+#define TCP_DEBUG                       LWIP_DBG_OFF
+#endif
+
+/**
+ * TCP_INPUT_DEBUG: Enable debugging in tcp_in.c for incoming debug.
+ */
+#ifndef TCP_INPUT_DEBUG
+#define TCP_INPUT_DEBUG                 LWIP_DBG_OFF
+#endif
+
+/**
+ * TCP_FR_DEBUG: Enable debugging in tcp_in.c for fast retransmit.
+ */
+#ifndef TCP_FR_DEBUG
+#define TCP_FR_DEBUG                    LWIP_DBG_OFF
+#endif
+
+/**
+ * TCP_RTO_DEBUG: Enable debugging in TCP for retransmit
+ * timeout.
+ */
+#ifndef TCP_RTO_DEBUG
+#define TCP_RTO_DEBUG                   LWIP_DBG_OFF
+#endif
+
+/**
+ * TCP_CWND_DEBUG: Enable debugging for TCP congestion window.
+ */
+#ifndef TCP_CWND_DEBUG
+#define TCP_CWND_DEBUG                  LWIP_DBG_OFF
+#endif
+
+/**
+ * TCP_WND_DEBUG: Enable debugging in tcp_in.c for window updating.
+ */
+#ifndef TCP_WND_DEBUG
+#define TCP_WND_DEBUG                   LWIP_DBG_OFF
+#endif
+
+/**
+ * TCP_OUTPUT_DEBUG: Enable debugging in tcp_out.c output functions.
+ */
+#ifndef TCP_OUTPUT_DEBUG
+#define TCP_OUTPUT_DEBUG                LWIP_DBG_OFF
+#endif
+
+/**
+ * TCP_RST_DEBUG: Enable debugging for TCP with the RST message.
+ */
+#ifndef TCP_RST_DEBUG
+#define TCP_RST_DEBUG                   LWIP_DBG_OFF
+#endif
+
+/**
+ * TCP_QLEN_DEBUG: Enable debugging for TCP queue lengths.
+ */
+#ifndef TCP_QLEN_DEBUG
+#define TCP_QLEN_DEBUG                  LWIP_DBG_OFF
+#endif
+
+/**
+ * UDP_DEBUG: Enable debugging in UDP.
+ */
+#ifndef UDP_DEBUG
+#define UDP_DEBUG                       LWIP_DBG_OFF
+#endif
+
+/**
+ * TCPIP_DEBUG: Enable debugging in tcpip.c.
+ */
+#ifndef TCPIP_DEBUG
+#define TCPIP_DEBUG                     LWIP_DBG_OFF
+#endif
+
+/**
+ * PPP_DEBUG: Enable debugging for PPP.
+ */
+#ifndef PPP_DEBUG
+#define PPP_DEBUG                       LWIP_DBG_OFF
+#endif
+
+/**
+ * SLIP_DEBUG: Enable debugging in slipif.c.
+ */
+#ifndef SLIP_DEBUG
+#define SLIP_DEBUG                      LWIP_DBG_OFF
+#endif
+
+/**
+ * DHCP_DEBUG: Enable debugging in dhcp.c.
+ */
+#ifndef DHCP_DEBUG
+#define DHCP_DEBUG                      LWIP_DBG_OFF
+#endif
+
+/**
+ * AUTOIP_DEBUG: Enable debugging in autoip.c.
+ */
+#ifndef AUTOIP_DEBUG
+#define AUTOIP_DEBUG                    LWIP_DBG_OFF
+#endif
+
+/**
+ * SNMP_MSG_DEBUG: Enable debugging for SNMP messages.
+ */
+#ifndef SNMP_MSG_DEBUG
+#define SNMP_MSG_DEBUG                  LWIP_DBG_OFF
+#endif
+
+/**
+ * SNMP_MIB_DEBUG: Enable debugging for SNMP MIBs.
+ */
+#ifndef SNMP_MIB_DEBUG
+#define SNMP_MIB_DEBUG                  LWIP_DBG_OFF
+#endif
+
+/**
+ * DNS_DEBUG: Enable debugging for DNS.
+ */
+#ifndef DNS_DEBUG
+#define DNS_DEBUG                       LWIP_DBG_OFF
+#endif
+
+#endif /* __LWIP_OPT_H__ */

--- a/tests/lwip/Makefile
+++ b/tests/lwip/Makefile
@@ -3,6 +3,7 @@ include ../Makefile.tests_common
 # lwIP's memory management doesn't seem to work on non 32-bit platforms at the
 # moment.
 BOARD_BLACKLIST := arduino-uno arduino-duemilanove arduino-mega2560 chronos \
+                   esp8266-esp-12x esp8266-olimex-mod esp8266-sparkfun-thing \
                    msb-430 msb-430h telosb waspmote-pro wsn430-v1_3b \
                    wsn430-v1_4 z1 jiminy-mega256rfr2 mega-xplained
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon hifive1 nrf6310 nucleo-f031k6 nucleo-f042k6 \

--- a/tests/lwip_sock_ip/Makefile
+++ b/tests/lwip_sock_ip/Makefile
@@ -3,6 +3,7 @@ include ../Makefile.tests_common
 # lwIP's memory management doesn't seem to work on non 32-bit platforms at the
 # moment.
 BOARD_BLACKLIST := arduino-uno arduino-duemilanove arduino-mega2560 chronos \
+                   esp8266-esp-12x esp8266-olimex-mod esp8266-sparkfun-thing \
                    msb-430 msb-430h telosb waspmote-pro wsn430-v1_3b \
                    wsn430-v1_4 z1 jiminy-mega256rfr2 mega-xplained
 BOARD_INSUFFICIENT_MEMORY = nucleo-f031k6 nucleo-f042k6 nucleo-l031k6 nucleo-f030r8 \

--- a/tests/lwip_sock_tcp/Makefile
+++ b/tests/lwip_sock_tcp/Makefile
@@ -3,6 +3,7 @@ include ../Makefile.tests_common
 # lwIP's memory management doesn't seem to work on non 32-bit platforms at the
 # moment.
 BOARD_BLACKLIST := arduino-uno arduino-duemilanove arduino-mega2560 chronos \
+                   esp8266-esp-12x esp8266-olimex-mod esp8266-sparkfun-thing \
                    msb-430 msb-430h telosb waspmote-pro wsn430-v1_3b \
                    wsn430-v1_4 z1 jiminy-mega256rfr2 mega-xplained
 BOARD_INSUFFICIENT_MEMORY = blackpill bluepill nucleo-f031k6 nucleo-f042k6 \

--- a/tests/lwip_sock_udp/Makefile
+++ b/tests/lwip_sock_udp/Makefile
@@ -3,6 +3,7 @@ include ../Makefile.tests_common
 # lwIP's memory management doesn't seem to work on non 32-bit platforms at the
 # moment.
 BOARD_BLACKLIST := arduino-uno arduino-duemilanove arduino-mega2560 chronos \
+                   esp8266-esp-12x esp8266-olimex-mod esp8266-sparkfun-thing \
                    msb-430 msb-430h telosb waspmote-pro wsn430-v1_3b \
                    wsn430-v1_4 z1 jiminy-mega256rfr2 mega-xplained
 BOARD_INSUFFICIENT_MEMORY = nucleo-f031k6 nucleo-f042k6 nucleo-l031k6 nucleo-f030r8 \


### PR DESCRIPTION
### Contribution description

This PR adds a `netdev` driver for infrastructure mode WiFi for ESP8266 using the built-in WiFi module. Using this `netdev` driver, ESP8266 can use an existing WiFi network to get connectivity. The `netdev` driver supports WPA authentication only.

The Wifi network interface (module `esp_wifi`) and the ESP-NOW network interface (module `esp_now` #9917)
can be used simultaneously, for example, to realize a border router for a mesh network which uses ESP-NOW.

### Testing procedure

- Compile and flash `example/gnrc_networking` to at least one ESP8266 node using your AP configuration, e.g.,
    ```
    CFLAGS='-DESP_WIFI_SSID=\"<your SSID>\" -DESP_WIFI_PASS=\"your passphrase\"' USEMODULE="esp_wifi" make BOARD=esp8266-esp-12x -C examples/gnrc_networking flash
    ```
- Once the application is flashed connect the ESP32 node with any terminal programm with a default baudrate of 115.200 bps.
- Use `ifconfig` command to check the existence of the network interface. You should be able to observe an output as follows:
   ```
   Iface  7  HWaddr: 5C:CF:7F:80:3F:08  Link: up 
          MTU:1500  HL:64  RTR  
          RTR_ADV  
          Source address length: 6
          Link type: wireless
          inet6 addr: fe80::5ecf:7fff:fe80:3f08  scope: local  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff80:3f08
          inet6 group: ff02::1a
          
          Statistics for Layer 2
            RX packets 12  bytes 2698
            TX packets 1 (Multicast: 1)  bytes 0
            TX succeeded 0 errors 0
          Statistics for IPv6
            RX packets 0  bytes 0
            TX packets 1 (Multicast: 1)  bytes 64
            TX succeeded 1 errors 0
    ```
- Ping any host in LAN.
- If the router provides a global routing prefix, check with `ifconfig` that the prefix is set.
   ```
   Iface  7  HWaddr: 5C:CF:7F:80:3F:08  Link: up 
          MTU:1440  HL:255  RTR  
          RTR_ADV  
          Source address length: 6
          Link type: wireless
          inet6 addr: fe80::5ecf:7fff:fe80:3f08  scope: local  VAL
          inet6 addr: 2003:c1:e72f:6c40:5ecf:7fff:fe80:3f08  scope: global  VAL
          ...
   ```
- Stress testing from LAN with `sudo ping6 fe80::<ESP_IID> -Ieth0 -s1392 -i 0.0001` should be stable over hours.
- It should also be possible to ping simultaneously
   - the ESP8266 node from the LAN with `sudo ping6 fe80::<ESP_IID> -Ieth0 -s1392 -i 0.0001`
   - the node in the LAN swith `ping6 1000 fe80::<LAN_IID> 1392 0` .

### Issues/PRs references

This PR depends on PRs #10656 and #10766 and is related to PR #9917.
