### PR TITLE
boards/thingy52: add dependency for on-board hts221/lps22hb sensors

### DIFF
--- a/boards/thingy52/Makefile.dep
+++ b/boards/thingy52/Makefile.dep
@@ -1,6 +1,7 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += lis2dh12
   USEMODULE += hts221
+  USEMODULE += lps22hb
 endif
 
 include $(RIOTBOARD)/common/nrf52/Makefile.dep

--- a/boards/thingy52/Makefile.dep
+++ b/boards/thingy52/Makefile.dep
@@ -1,5 +1,6 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += lis2dh12
+  USEMODULE += hts221
 endif
 
 include $(RIOTBOARD)/common/nrf52/Makefile.dep

--- a/boards/thingy52/board.c
+++ b/boards/thingy52/board.c
@@ -21,8 +21,19 @@
 #include "cpu.h"
 #include "board.h"
 
+#if defined(MODULE_LPS22HB) || defined(MODULE_HTS221)
+#include "periph/gpio.h"
+#endif
+
 void board_init(void)
 {
+    /* LP22HB and HTS221 can only be powered with VREG when VDD_PWR_CTRL_PIN
+       is set. */
+#if defined(MODULE_LPS22HB) || defined(MODULE_HTS221)
+    gpio_init(VDD_PWR_CTRL_PIN, GPIO_OUT);
+    gpio_set(VDD_PWR_CTRL_PIN);
+#endif
+
     /* initialize the CPU */
     cpu_init();
 }

--- a/boards/thingy52/include/board.h
+++ b/boards/thingy52/include/board.h
@@ -34,6 +34,14 @@ extern "C" {
 /** @} */
 
 /**
+ * @name    Power switch pins definitions
+ * @{
+ */
+#define SPK_PWR_CTRL_PIN    GPIO_PIN(0, 29) /**< Speaker power switch */
+#define VDD_PWR_CTRL_PIN    GPIO_PIN(0, 30) /**< VDD power switch */
+/** @} */
+
+/**
  * @name    LIS2DH12 low power accelerometer configuration
  * @{
  */

--- a/boards/thingy52/include/board.h
+++ b/boards/thingy52/include/board.h
@@ -40,6 +40,12 @@ extern "C" {
 #define LIS2DH12_PARAM_I2C  I2C_DEV(1)
 /** @} */
 
+/**
+ * @name    LPS22HB device address
+ * @{
+ */
+#define LPSXXX_PARAM_ADDR   (0x5c)
+/** @} */
 
 /**
  * @brief   Initialize board specific hardware


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR provides a default I2C configuration for the nrf52 Thingy52 and add hts221 sensor as dependency when saul is used. lps22hb could also be added when #10695 will be merged. ccs811 requires support for the GPIO expander SX1509.

This PR is untested, I don't have this hardware. Maybe @haukepetersen will be able to test this.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Build and flash `tests/driver_hts221` and verify the output is correct:
```
    $ make BOARD=thingy52 -C tests/driver_hts221 flash term
```
- Build and flash `examples/saul` and check the hts221 and lps22hb values:
```
    $ make BOARD=thingy52 -C examples/saul flash term
```



<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
