### PR TITLE
hashes/sha256: don't call memcpy if len==0

### DIFF
--- a/sys/hashes/sha256.c
+++ b/sys/hashes/sha256.c
@@ -223,7 +223,9 @@ void sha256_update(sha256_context_t *ctx, const void *data, size_t len)
 
     /* Handle the case where we don't need to perform any transforms */
     if (len < 64 - r) {
-        memcpy(&ctx->buf[r], data, len);
+        if (len > 0) {
+            memcpy(&ctx->buf[r], data, len);
+        }
         return;
     }
 


### PR DESCRIPTION
### Contribution description

If ```sha256_update()``` is called with a length of zero, memcpy is called with that same zero length.
ubsan complains about that (when running our unittests):

```sha256.c:231:9: runtime error: null pointer passed as argument 2, which is declared to never be null``` if compiled with ubsan enabled.

This PR adds a guard for the memcpy call.

### Testing procedure

Run sha256 unittests.

### Issues/PRs references

Found using #10782.