### PR TITLE
sys/base64: Add size estimation functions

### DIFF
--- a/sys/base64/base64.c
+++ b/sys/base64/base64.c
@@ -60,7 +60,7 @@ int base64_encode(const void *data_in, size_t data_in_size,
                   unsigned char *base64_out, size_t *base64_out_size)
 {
     const unsigned char *in = data_in;
-    size_t required_size = 4 * ((data_in_size + 2) / 3);
+    size_t required_size = base64_estimate_encode_size(data_in_size);
 
     if (data_in == NULL) {
         return BASE64_ERROR_DATA_IN;
@@ -164,7 +164,7 @@ int base64_decode(const unsigned char *base64_in, size_t base64_in_size,
                   void *data_out, size_t *data_out_size)
 {
     unsigned char *out = data_out;
-    size_t required_size = ((base64_in_size / 4) * 3);
+    size_t required_size = base64_estimate_decode_size(base64_in_size);
 
     if (base64_in == NULL) {
         return BASE64_ERROR_DATA_IN;

--- a/sys/include/base64.h
+++ b/sys/include/base64.h
@@ -33,6 +33,30 @@ extern "C" {
 #define BASE64_ERROR_DATA_IN_SIZE     (-4) /**< error value for invalid input buffer size      */
 
 /**
+ * @brief Estimates the amount of bytes needed for decoding @p base64_in_size
+ * characters from base64.
+ *
+ * @param[in] base64_in_size Size of the string to be decoded
+ * @return Amount of bytes estimated to be used after decoding
+ */
+static inline size_t base64_estimate_decode_size(size_t base64_in_size)
+{
+    return ((base64_in_size / 4) * 3);
+}
+
+/**
+ * @brief Estimates the length of the resulting string after encoding
+ * @p data_in_size bytes into base64.
+ *
+ * @param[in] data_in_size Amount of bytes to be encoded
+ * @return Amount of characters the output string is estimated to have
+ */
+static inline size_t base64_estimate_encode_size(size_t data_in_size)
+{
+    return (4 * ((data_in_size + 2) / 3));
+}
+
+/**
  * @brief           Encodes a given datum to base64 and save the result to the given destination.
  * @param[in]       data_in           pointer to the datum to encode
  * @param[in]       data_in_size      the size of `data_in`
@@ -48,7 +72,7 @@ extern "C" {
             BASE64_ERROR_BUFFER_OUT if `base64_out` equals NULL
                                     but the `base64_out_size` is sufficient,
             BASE64_ERROR_DATA_IN if `data_in` equals NULL,
-            BASE64_ERROR_DATA_IN_SIZE if `data_in_size` is less then 1.
+            BASE64_ERROR_DATA_IN_SIZE if `data_in_size` is less than 1.
  */
 int base64_encode(const void *data_in, size_t data_in_size,
                   unsigned char *base64_out, size_t *base64_out_size);
@@ -69,7 +93,7 @@ int base64_encode(const void *data_in, size_t data_in_size,
             BASE64_ERROR_BUFFER_OUT if `data_out` equals NULL
                                     but the size for `data_out_size` is sufficient,
             BASE64_ERROR_DATA_IN if `base64_in` equals NULL,
-            BASE64_ERROR_DATA_IN_SIZE if `base64_in_size` is less then 4.
+            BASE64_ERROR_DATA_IN_SIZE if `base64_in_size` is less than 4.
  */
 int base64_decode(const unsigned char *base64_in, size_t base64_in_size,
                   void *data_out, size_t *data_out_size);


### PR DESCRIPTION
### Contribution description
This moves the size estimation calculation of encoding and decoding to inline functions so it can be used by other modules that may need to estimate buffer sizes.

### Testing procedure
Run the base64 unit test:
```
cd tests/unittests
make tests-base64 test
```

### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
