### PR TITLE
sys: add unaligned.h (header for alignment safe value-from-pointer functions)

### DIFF
--- a/sys/checksum/fletcher32.c
+++ b/sys/checksum/fletcher32.c
@@ -18,6 +18,7 @@
  * @}
  */
 
+#include "unaligned.h"
 #include "checksum/fletcher32.h"
 
 uint32_t fletcher32(const uint16_t *data, size_t words)
@@ -28,7 +29,7 @@ uint32_t fletcher32(const uint16_t *data, size_t words)
         unsigned tlen = words > 359 ? 359 : words;
         words -= tlen;
         do {
-            sum2 += sum1 += *data++;
+            sum2 += sum1 += unaligned_get_u16(data++);
         } while (--tlen);
         sum1 = (sum1 & 0xffff) + (sum1 >> 16);
         sum2 = (sum2 & 0xffff) + (sum2 >> 16);

--- a/sys/include/unaligned.h
+++ b/sys/include/unaligned.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2019 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    sys_unaligned unaligned memory access methods
+ * @ingroup     sys
+ * @brief       Provides functions for safe unaligned memory accesses
+ *
+ * This header provides functions to read values from pointers that are not
+ * necessarily aligned to the type's alignment requirements.
+ *
+ * E.g.,
+ *
+ *     uint16_t *foo = 0x123;
+ *     printf("%u\n", *foo);
+ *
+ * ... might cause an unaligned access, if `uint16_t` is usually aligned at
+ * 2-byte-boundaries, as foo has an odd address.
+ *
+ * The current implementation casts a pointer to a packed struct, which forces
+ * the compiler to deal with possibly unalignedness.  Idea taken from linux
+ * kernel sources.
+ *
+ * @{
+ *
+ * @file
+ * @brief       Unaligned but safe memory access functions
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ */
+
+#ifndef UNALIGNED_H
+#define UNALIGNED_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @brief Unaligned access helper struct (uint16_t version) */
+typedef struct __attribute__((packed)) {
+    uint16_t val;       /**< value */
+} uint16_una_t;
+
+/**
+ * @brief    Get uint16_t from possibly unaligned pointer
+ *
+ * @param[in]   ptr pointer to read from
+ *
+ * @returns value read from @p ptr
+ */
+static inline uint16_t unaligned_get_u16(const void *ptr)
+{
+    const uint16_una_t *tmp = ptr;
+    return tmp->val;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+#endif /* UNALIGNED_H */


### PR DESCRIPTION
### Contribution description

This PR adds a header containing functions for reading values from a pointer in an alignment-safe manner.

Usually we'd use memcpy to copy a value bytewise, if pointer alignment cannot be guaranteed.
This PR uses a packed struct instead, which forces the compiler to deal with possibly off alignment.
In my tests it generates slightly smaller code. (Idea taken from Linux.)

AFAIK this trick makes gcc and clang generate optimal code for all platforms. Should platforms need different handling (e.g., use memcpy), the header can become the dispatch point.

For now, only unsigned 16bit reads are implemented. I'd propose to add different types and possibly write functions if needed as we go.

The PR contains a commit for fletcher32() making it use the new header. Without this commit, the fletcher32 unittest trigger unaligned access UB when compiled with ubsan.

### Testing procedure

With fletcher32 as the only user, make sure it's unit tests still work on all platforms.

### Issues/PRs references

#10782 for ubsan support.