### PR TITLE
cpu/esp32: fixes the memset optimization problem in esp_wifi/wpa_supplicant

### DIFF
--- a/cpu/esp32/include/syscalls.h
+++ b/cpu/esp32/include/syscalls.h
@@ -23,6 +23,7 @@
 
 #include <stdarg.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdlib.h>
 
 #include "esp_common.h"
@@ -60,6 +61,9 @@ void system_wdt_stop (void);
 
 /** reset the system watchdog timer */
 void system_wdt_feed (void);
+
+/** memset version that the compiler should not be allowed to optimize this */
+void *system_secure_memset(void *s, int c, size_t n);
 
 #ifdef __cplusplus
 }

--- a/cpu/esp32/syscalls.c
+++ b/cpu/esp32/syscalls.c
@@ -595,3 +595,18 @@ void system_wdt_start (void)
     TIMERG0.wdt_wprotect = 0;     /* enable write protection */
     xt_ints_on(BIT(CPU_INUM_WDT));
 }
+
+__attribute__((weak)) void
+_system_prevent_memset_lto(void *const  s, int c, const size_t n)
+{
+    (void) s;
+    (void) c;
+    (void) n;
+}
+
+void *system_secure_memset(void *s, int c, size_t n)
+{
+    memset(s, c, n);
+    _system_prevent_memset_lto(s, c, n);
+    return s;
+}

--- a/cpu/esp32/vendor/esp-idf/wpa_supplicant/port/include/os.h
+++ b/cpu/esp32/vendor/esp-idf/wpa_supplicant/port/include/os.h
@@ -19,6 +19,11 @@
 extern "C" {
 #endif
 
+#ifdef RIOT_VERSION
+#include "syscalls.h"
+#define os_memset   system_secure_memset
+#endif
+
 #include "esp_types.h"
 #include <string.h>
 #include <stdio.h>


### PR DESCRIPTION
### Contribution description

This PR adds a memset function `system_secure_memset` which cannot be optimized out by the compiler. It uses the libsodium approach of weak symbols. Function `system_secure_memset` calls the standard `memset` function. Calling an empty function declared with weak attribute after the `memset` call, prevents the compiler to optimize it out. The overhead is only one function call.

### Testing procedure

- For the time being only the successful compilation.
- Once PR #10762 is merged, `examples/gnrc_networking` with `esp_wif` netdev can be used to test.
   ```
   CFLAGS='-DESP_WIFI_SSID=\"<your SSID>\" -DESP_WIFI_PASS=\"your passphrase\"' USEMODULE="esp_wifi" make BOARD=esp32-wroom-32 -C examples/gnrc_networking flash
   ```

### Issues/PRs references

Fixes the problem described in #10751 for ESP32 vendor code.