### PR TITLE
boards/sensebox_samd21: Add MTD definition

### DIFF
--- a/boards/sensebox_samd21/board.c
+++ b/boards/sensebox_samd21/board.c
@@ -21,6 +21,27 @@
 #include "cpu.h"
 #include "board.h"
 #include "periph/gpio.h"
+#include "sdcard_spi_params.h"
+#include "mtd_sdcard.h"
+
+#if defined(MODULE_MTD_SDCARD) || defined(DOXYGEN)
+ /* this is provided by the sdcard_spi driver
+ * see sys/auto_init/storage/auto_init_sdcard_spi.c */
+extern sdcard_spi_t sdcard_spi_devs[sizeof(sdcard_spi_params) /
+                                    sizeof(sdcard_spi_params[0])];
+mtd_sdcard_t sensebox_sd_dev = {
+    .base = {
+        .driver = &mtd_sdcard_driver,
+        .page_size = MTD_SD_CARD_PAGE_SIZE,
+        .pages_per_sector = MTD_SD_CARD_PAGES_PER_SECTOR,
+        .sector_count = MTD_SD_CARD_SECTOR_COUNT
+    },
+    .sd_card = &sdcard_spi_devs[0],
+    .params = &sdcard_spi_params[0]
+};
+
+mtd_dev_t *mtd0 = (mtd_dev_t *)&sensebox_sd_dev;
+#endif /* MODULE_MTD_SDCARD || DOXYGEN */
 
 void board_init(void)
 {

--- a/boards/sensebox_samd21/include/board.h
+++ b/boards/sensebox_samd21/include/board.h
@@ -25,6 +25,7 @@
 #include "cpu.h"
 #include "periph_conf.h"
 #include "periph_cpu.h"
+#include "mtd_sdcard.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -161,6 +162,33 @@ extern "C" {
  * @brief    BMP280 Pressure and temperature sensor
  */
 #define BMX280_PARAM_I2C_ADDR        (0x76)
+
+#if defined(MODULE_MTD_SDCARD) || defined(DOXYGEN)
+/**
+ * @brief MTD device 0 (SD Card) definition. mtd0 is defined in board.c
+ * @{
+ */
+extern mtd_dev_t *mtd0;
+#define MTD_0 mtd0
+/** @} */
+
+/**
+ * @brief Attributes for the mtd_sdcard driver
+ * @{
+ */
+#ifndef MTD_SD_CARD_PAGE_SIZE
+#define MTD_SD_CARD_PAGE_SIZE           (512)
+#endif
+
+#ifndef MTD_SD_CARD_PAGES_PER_SECTOR
+#define MTD_SD_CARD_PAGES_PER_SECTOR    (128)
+#endif
+
+#ifndef MTD_SD_CARD_SECTOR_COUNT
+#define MTD_SD_CARD_SECTOR_COUNT        (3921920UL)
+#endif
+/** @} */
+#endif /* MODULE_MTD_SDCARD || DOXYGEN */
 
 /**
  * @brief   Initialize board specific hardware, including clock, LEDs and std-IO

--- a/tests/pkg_fatfs/Makefile
+++ b/tests/pkg_fatfs/Makefile
@@ -19,10 +19,11 @@ BOARD_WHITELIST := airfy-beacon arduino-due arduino-duemilanove arduino-mega2560
                    nucleo-f303re nucleo-f334r8 nucleo-f401re nucleo-f410rb nucleo-f411re \
                    nucleo-f446re nucleo-l053r8 nucleo-l073rz nucleo-l152re nucleo-l476rg \
                    nz32-sc151 openmote-cc2538 pba-d-01-kw2x remote-pa remote-reva \
-                   remote-revb samd21-xpro saml21-xpro samr21-xpro sltb001a \
-                   sodaq-autonomo sodaq-explorer spark-core stm32f0discovery \
-                   stm32f3discovery stm32f4discovery telosb udoo waspmote-pro \
-                   wsn430-v1_3b wsn430-v1_4 yunjia-nrf51822 z1 native
+                   remote-revb samd21-xpro saml21-xpro samr21-xpro \
+                   sensebox_samd21 sltb001a sodaq-autonomo \
+                   sodaq-explorer spark-core stm32f0discovery stm32f3discovery \
+                   stm32f4discovery telosb udoo waspmote-pro wsn430-v1_3b \
+                   wsn430-v1_4 yunjia-nrf51822 z1 native
 
 USEMODULE += shell
 USEMODULE += fatfs_diskio_mtd

--- a/tests/pkg_fatfs_vfs/Makefile
+++ b/tests/pkg_fatfs_vfs/Makefile
@@ -42,10 +42,10 @@ BOARD_WHITELIST := airfy-beacon arduino-due arduino-duemilanove arduino-mega2560
                    nucleo-f303re nucleo-f334r8 nucleo-f401re nucleo-f410rb nucleo-f411re \
                    nucleo-f446re nucleo-l053r8 nucleo-l073rz nucleo-l152re nucleo-l476rg \
                    nz32-sc151 openmote-cc2538 pba-d-01-kw2x remote-pa remote-reva \
-                   remote-revb samd21-xpro saml21-xpro samr21-xpro sltb001a \
-                   sodaq-autonomo sodaq-explorer spark-core stm32f0discovery \
-                   stm32f3discovery stm32f4discovery udoo waspmote-pro \
-                   yunjia-nrf51822 native
+                   remote-revb samd21-xpro saml21-xpro samr21-xpro \
+                   sensebox_samd21 sltb001a sodaq-autonomo sodaq-explorer \
+                   spark-core stm32f0discovery stm32f3discovery \
+                   stm32f4discovery udoo waspmote-pro yunjia-nrf51822 native
 
 TEST_DEPS += image
 


### PR DESCRIPTION
### Contribution description
This PR adds the needed MTD (Memory Technology Device) definition, using the SD card device that is already defined for the board (`mtd0`), to use it .

### Testing procedure
This can be tested using the `pkg_fatfs` test application. Check that the file system can be mounted and read and write operations are working.

### Issues/PRs references
None