### PR TITLE
boards/stm32: revert forced use of dma feature in STM32 boards

### DIFF
--- a/boards/b-l072z-lrwan1/Makefile.dep
+++ b/boards/b-l072z-lrwan1/Makefile.dep
@@ -1,5 +1,3 @@
-FEATURES_REQUIRED += periph_dma
-
 ifneq (,$(filter netdev_default,$(USEMODULE)))
   USEMODULE += sx1276
 endif

--- a/boards/b-l475e-iot01a/Makefile.dep
+++ b/boards/b-l475e-iot01a/Makefile.dep
@@ -1,5 +1,3 @@
-FEATURES_REQUIRED += periph_dma
-
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
   USEMODULE += hts221

--- a/boards/iotlab-m3/Makefile.dep
+++ b/boards/iotlab-m3/Makefile.dep
@@ -1,7 +1,5 @@
 include $(RIOTBOARD)/common/iotlab/Makefile.dep
 
-FEATURES_REQUIRED += periph_dma
-
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += isl29020
   USEMODULE += lps331ap

--- a/boards/nucleo-f091rc/Makefile.dep
+++ b/boards/nucleo-f091rc/Makefile.dep
@@ -1,3 +1,1 @@
-FEATURES_REQUIRED += periph_dma
-
 include $(RIOTBOARD)/common/nucleo/Makefile.dep

--- a/boards/nucleo-f207zg/Makefile.dep
+++ b/boards/nucleo-f207zg/Makefile.dep
@@ -1,3 +1,1 @@
-FEATURES_REQUIRED += periph_dma
-
 include $(RIOTBOARD)/common/nucleo/Makefile.dep

--- a/boards/nucleo-f767zi/Makefile.dep
+++ b/boards/nucleo-f767zi/Makefile.dep
@@ -1,3 +1,1 @@
-FEATURES_REQUIRED += periph_dma
-
 include $(RIOTBOARD)/common/nucleo/Makefile.dep

--- a/boards/nucleo-l152re/Makefile.dep
+++ b/boards/nucleo-l152re/Makefile.dep
@@ -1,3 +1,1 @@
-FEATURES_REQUIRED += periph_dma
-
 include $(RIOTBOARD)/common/nucleo/Makefile.dep


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR reverts parts of the changes introduced in #9171 to fix problems reported in #10800. See #10800 for details about the problems but the general idea is that some thread tests are not thread safe because multiple threads tries to write to stdio in parallel.

Since the UART DMA is still configured for the boards, I adapted the `tests/periph_dma` to check UART is working on hardware.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Build, flash, test `tests/periph_dma` on iotlab-m3, b-l072z-lrwan1, nucleo-l152re, etc (e.g all boards modified in #9171)
- Check the output is OK
- Play the shell using `examples/default` on those boards.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

related to #10800 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
