### PR TITLE
boards/hifive1: fix CLOCK_CORECLOCK

### DIFF
--- a/boards/hifive1/include/periph_conf.h
+++ b/boards/hifive1/include/periph_conf.h
@@ -27,12 +27,8 @@ extern "C" {
  * @name    Core Clock configuration
  * @{
  */
-#define CLOCK_CORECLOCK             (1600000ul)
-/*
- * #define CLOCK_CORECLOCK           (20000000ul)
- * #define CLOCK_CORECLOCK           (27000000ul)
- * #define CLOCK_CORECLOCK           (38400000ul)
- */
+/* As defined in boards/hifive1/board.c CPU_DESIRED_FREQ **/
+#define CLOCK_CORECLOCK             (200000000ul)
 /** @} */
 
 /**


### PR DESCRIPTION
### Contribution description

* The `CLOCK_CORECLOCK` was completely wrong; fixed it

### Testing procedure

    make BOARD=hifive1 -C tests/leds/
