### PR TITLE
toosl/print_toolchain_versions: report windows version

### DIFF
--- a/dist/tools/ci/print_toolchain_versions.sh
+++ b/dist/tools/ci/print_toolchain_versions.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 get_cmd_version() {
     if [ -z "$1" ]; then

--- a/dist/tools/ci/print_toolchain_versions.sh
+++ b/dist/tools/ci/print_toolchain_versions.sh
@@ -38,17 +38,33 @@ get_kernel_info() {
     uname -mprs
 }
 
+# On windows systems, return OS name and OS version, each in a separate line.
+get_windows_info() {
+    systeminfo | grep '\(^OS Name\)\|\(^OS Version\)' | cut -d: -f2 | sed 's/^[[:space:]]*//'
+}
+
 get_os_info() {
+    local osname
+    local osvers
+
     local os="$(uname -s)"
-    local osname="unknown"
-    local osvers="unknown"
-    if [ "$os" = "Linux" ]; then
-        osname="$(cat /etc/os-release | grep ^NAME= | awk -F'=' '{print $2}')"
-        osvers="$(cat /etc/os-release | grep ^VERSION= | awk -F'=' '{print $2}')"
-    elif [ "$os" = "Darwin" ]; then
-        osname="$(sw_vers -productName)"
-        osvers="$(sw_vers -productVersion)"
-    fi
+    case "$os" in
+        Linux)
+            osname="$(cat /etc/os-release | grep ^NAME= | awk -F'=' '{print $2}')"
+            osvers="$(cat /etc/os-release | grep ^VERSION= | awk -F'=' '{print $2}')"
+            ;;
+        Darwin)
+            osname="$(sw_vers -productName)"
+            osvers="$(sw_vers -productVersion)"
+            ;;
+        MINGW*)
+            read -r osname osvers <<<$(get_windows_info)
+            ;;
+        *)
+            osname="unknown"
+            osvers="unknown"
+            ;;
+    esac
     printf "%s %s" "$osname" "$osvers"
 }
 


### PR DESCRIPTION
### Contribution description

Due to by a recent bug report in the windows platform, I realized the `print_toolchain_versions.sh` script cannot detect the version of windows used. This patch fixes it.

**I'm also setting the interpreter to bash.** I think it should not be a problem since we already have bash in other scripts.

### Testing procedure

Get a machine with Windows, and run `./dist/tools/ci/print_toolchain_versions.sh`. In master you get an unknown os. With this patch I get:

```
Operating System Environment
-----------------------------
       Operating System: Microsoft Windows 10 Enterprise Evaluation 10.0.17134 N/A Build 17134
                 Kernel: MINGW32_NT-6.2 1.0.19(0.48/3/2) i686 unknown
```

That Linux still works will be tested by Travis, and Mac should not be a problem either, but mac users are welcome to test it.


