### PR TITLE
doc: include *_params.h files in documentation

### DIFF
--- a/doc/doxygen/riot.doxyfile
+++ b/doc/doxygen/riot.doxyfile
@@ -140,7 +140,7 @@ INLINE_INHERITED_MEMB  = NO
 # shortest path that makes the file name unique will be used
 # The default value is: YES.
 
-FULL_PATH_NAMES        = NO
+FULL_PATH_NAMES        = YES
 
 # The STRIP_FROM_PATH tag can be used to strip a user-defined part of the path.
 # Stripping is only done if one of the specified strings matches the left-hand

--- a/doc/doxygen/riot.doxyfile
+++ b/doc/doxygen/riot.doxyfile
@@ -161,7 +161,7 @@ STRIP_FROM_PATH        =
 # specify the list of include paths that are normally passed to the compiler
 # using the -I flag.
 
-STRIP_FROM_INC_PATH    = $(STRIP_FROM_INC_PATH_LIST) # Exported from Makefile.
+STRIP_FROM_INC_PATH    = # $(STRIP_FROM_INC_PATH_LIST) # Exported from Makefile.
 
 # If the SHORT_NAMES tag is set to YES, doxygen will generate much shorter (but
 # less readable) file names. This can be useful is your file systems doesn't

--- a/doc/doxygen/riot.doxyfile
+++ b/doc/doxygen/riot.doxyfile
@@ -152,7 +152,7 @@ FULL_PATH_NAMES        = YES
 # will be relative from the directory where doxygen is started.
 # This tag requires that the tag FULL_PATH_NAMES is set to YES.
 
-STRIP_FROM_PATH        =
+STRIP_FROM_PATH        = ../../
 
 # The STRIP_FROM_INC_PATH tag can be used to strip a user-defined part of the
 # path mentioned in the documentation of a class, which tells the reader which

--- a/doc/doxygen/riot.doxyfile
+++ b/doc/doxygen/riot.doxyfile
@@ -821,7 +821,6 @@ EXCLUDE_SYMLINKS       = NO
 # exclude all test directories for example use the pattern */test/*
 
 EXCLUDE_PATTERNS       = */board/*/tools/* \
-                         *_params.h \
                          */cpu/atmega_common/include/sys/*.h \
                          */cpu/msp430_common/include/stdatomic.h \
                          */cpu/msp430_common/include/sys/*.h \


### PR DESCRIPTION
### Contribution description

This PR tries to fix the problem described in issue #10427. Due to some warnings like
```
drivers/sdcard_spi/include/sdcard_spi_params.h:13: warning: the name 'drivers/sdcard_spi/include/sdcard_spi_params.h' supplied as the second argument in the \file statement matches the following input files:
   drivers/sdcard_spi/include/sdcard_spi_params.h
Please use a more specific name by including a (larger) part of the path!
```
`*_params.h` were excluded from documentation :worried:

After some investigations it became clear that `*_params.h` files can be included in the documentation without any warning if `STRIP_FROM_INC_PATH` variable is empty in `riot.doxyfile`. The generated documentation looks as before including the include paths of header files in documentation. The only differences are
- `*_params.h` files are now included in documentation as expected and
- dependency graphs include all files from which they depend and not only the direct includes.

This PR depends on PR #10810.

### Testing procedure

- Generate the docuementation with `make doc` in your RIOT directory
  ```
   cd <your_RIOT_dir>
   make doc
   ```
- Open the documentation in browser using URL `https:///<your_RIOT_dir>/doc/doxygen/html/index.html`.
- Open complex pages like
   - `Networking » Generic (GNRC) network stack » IPv6 » ICMPv6` and
   - `Networking » Generic (GNRC) network stack » IPv6 » ICMPv6 » gnrc/icmpv6.h`
- Check for
   - included header files
   - dependency graph
   - navigation tree
   ...
- Search for parameters, for example `sdcard_spi_params`
  - In the official docs the only thing that show up is `sdcard_spi_params_t ` (the definition of the structure).
  - With this PR the instantiations of `sdcard_spi_params` (define in "*_pararam.h" files) also appear.

### Issues/PRs references

Fixes #10427. Depends on PR #10810.