### PR TITLE
doc: fix warnings in *_params.h

### DIFF
--- a/cpu/native/include/socket_zep_params.h
+++ b/cpu/native/include/socket_zep_params.h
@@ -44,6 +44,9 @@ extern "C" {
  * @}
  */
 
+/**
+ * @brief   socket_zep configurations
+ */
 extern socket_zep_params_t socket_zep_params[SOCKET_ZEP_MAX];
 
 #ifdef __cplusplus

--- a/drivers/ads101x/include/ads101x_params.h
+++ b/drivers/ads101x/include/ads101x_params.h
@@ -79,6 +79,10 @@ static const ads101x_params_t ads101x_params[] =
 {
     ADS101X_PARAMS
 };
+
+/**
+ * @brief   ADS101X/111x alert defaults if not defined for a board or application
+ */
 static const ads101x_alert_params_t ads101x_alert_params[] =
 {
     ADS101X_ALERT_PARAMS

--- a/drivers/srf04/include/srf04_params.h
+++ b/drivers/srf04/include/srf04_params.h
@@ -52,6 +52,9 @@ static const srf04_params_t srf04_params[] = {
     SRF04_PARAMS
 };
 
+/**
+ * @brief   Number of SRF04 devices
+ */
 #define SRF04_NUMOF     (sizeof(srf04_params) / sizeof(srf04_params[0]))
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Contribution description

This PR fixes remaining warnings in some `*_params.h` files. It is prerequisite to get the documentation generated with PR #10808.

### Testing procedure

Successful generation of doc with `make doc`.

### Issues/PRs references

The PR is prerequisite for PR #10808.