### PR TITLE
tests/periph_rtc: fix alarm period in README

### DIFF
--- a/tests/periph_rtc/README.md
+++ b/tests/periph_rtc/README.md
@@ -1,6 +1,7 @@
 Expected result
 ===============
-When everything works as expected, you should see a alarm message after 10 seconds from start-up.
+When everything works as expected, after start-up, 4 alarm messages are
+displayed every 2 seconds.
 
 Background
 ==========


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This is fixing the period value mentioned in the tests/periph_rtc application README. The PR also contains a small reword.
In the code, alarms are fired every 2s but the README says 10s.

This was reported in https://github.com/RIOT-OS/RIOT/pull/10653#issuecomment-455400871

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Just compare the README and the [code](https://github.com/RIOT-OS/RIOT/blob/master/tests/periph_rtc/main.c#L31).

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Mentioned in #10653 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
