### PR TITLE
tests/periph_rtc: add automatic python test script

### DIFF
--- a/tests/periph_rtc/tests/01-run.py
+++ b/tests/periph_rtc/tests/01-run.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2019 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import os
+import sys
+from testrunner import run
+
+
+BOARD = os.getenv('BOARD', 'native')
+DATE_PATTERN = r'\d{4}\-\d{2}\-\d{2} \d{2}\:\d{2}\:\d{2}'
+
+
+def testfunc(child):
+    child.expect(r'This test will display \'Alarm\!\' every 2 seconds '
+                 r'for (\d{1}) times')
+    alarm_count = int(child.match.group(1))
+    child.expect(r'  Setting clock to   ({})'.format(DATE_PATTERN))
+    clock_set = child.match.group(1)
+    if BOARD == 'native':
+        child.expect(r'.*rtc_set_time: not implemented')
+    child.expect(r'Clock value is now   ({})'.format(DATE_PATTERN))
+    clock_value = child.match.group(1)
+    if BOARD != 'native':
+        # Set clock is not implemented for native board so no need to compare
+        # clock values
+        assert clock_set == clock_value
+
+    child.expect(r'  Setting alarm to   ({})'.format(DATE_PATTERN))
+    alarm_set = child.match.group(1)
+    if BOARD == 'native':
+        child.expect(r'.*rtc_set_alarm: not implemented')
+    child.expect(r'   Alarm is set to   ({})'.format(DATE_PATTERN))
+    alarm_value = child.match.group(1)
+    if BOARD != 'native':
+        # Set alarm is not implemented for native board so no need to compare
+        # alarm values
+        assert alarm_set == alarm_value
+
+    if BOARD != 'native':
+        for _ in range(alarm_count):
+            child.expect_exact('Alarm!')
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is just adding a test script for the `periph_rtc` application. There is some specific checks for the native plateform because some functions used in the application are not implemented.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

This PR can be tested on native and on a board providing the RTC feature. I tested with b-l072z-lrwan1 but others could be used.
- On native:
```
$ make -C tests/periph_rtc all test
```
- On b-l072z-lrwan1:
```
$ make BOARD=b-l072z-lrwan1 -C tests/periph_rtc flash test
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
