### PR TITLE
tests/pkg_{hacl,monocypher}: set custom timeout value

### DIFF
--- a/tests/pkg_hacl/tests/01-run.py
+++ b/tests/pkg_hacl/tests/01-run.py
@@ -10,8 +10,13 @@ import sys
 from testrunner import run
 
 
+# increase the default timeout to 30s, on samr30-xpro this test takes 20s to
+# complete.
+TIMEOUT = 30
+
+
 def testfunc(child):
-    child.expect('OK \(\d+ tests\)')
+    child.expect('OK \(\d+ tests\)', timeout=TIMEOUT)
 
 
 if __name__ == "__main__":

--- a/tests/pkg_monocypher/tests/01-run.py
+++ b/tests/pkg_monocypher/tests/01-run.py
@@ -11,8 +11,13 @@ import sys
 from testrunner import run
 
 
+# increase the default timeout to 20s, on samr30-xpro this test takes 14s to
+# complete.
+TIMEOUT = 20
+
+
 def testfunc(child):
-    child.expect(r"OK \(2 tests\)")
+    child.expect(r"OK \(2 tests\)", timeout=TIMEOUT)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is setting a custom timeout to hacl and monocypher packages test applications. 
On slow targets samr30-xpro or maybe also saml21-xpro (same coreclock value), these tests takes respectively 20 and 14 seconds to complete.

@dylad do you confirm that the test scripts for these applications are not working on saml21 ? If it's the case, I'll change the comment in the scripts and in the commit message to mention this target (since it's already in the codebase).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

This can be tested on IoT-LAB.

- Start an experiment on IoT-LAB:
```
$ iotlab-experiment submit -n test -d 60 -l saclay,samr30,2
```
- Build, flash and test `tests/pkg_hacl` and `tests/pkg_monocypher` on samr30-xpro:
```
$ make BOARD=samr30-xpro IOTLAB_NODE=auto-ssh -C tests/pkg_hacl flash test
$ make BOARD=samr30-xpro IOTLAB_NODE=auto-ssh -C tests/pkg_monocypher flash test
```
- The tests should complete without errors with this PR, on master they just fail.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Loosely required by #10653 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
