### PR TITLE
nordic_softdevice_ble: document working Linux versions

### DIFF
--- a/pkg/nordic_softdevice_ble/README-BLE-6LoWPAN.md
+++ b/pkg/nordic_softdevice_ble/README-BLE-6LoWPAN.md
@@ -6,13 +6,13 @@ Prerequisites
 In general, any device capable of running Linux operating system, can be used
 as a BLE router provided the following conditions are met:
 
-* Linux Kernel >3.18 is used
+* Linux Kernel >3.18 and <=4.12 is used
 * bluez, libcap-ng0, radvd tools are present.
 
 If a built-in Bluetooth device is not available then Bluetooth 4.0 compatible
 USB dongle can be used.
 
-The following procedures have been tested on Ubuntu 15.10.
+The following procedures have been tested on Ubuntu 15.10 and Ubuntu 16.04.
 
 Establishing an IPv6 connection
 ===============================


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
While testing #10514 we found that the `nordic_softdevice_ble` is not able to communicate with newer versions of Linux.

It is not 100% clear if 4.12 is the last version the softdevice is able to interact with, but newer kernel versions than 4.12 definitely don't work (we tried 4.15 on Ubuntu 18.04 and 4.20 on a quite recent Arch).

The reason I believe it's the 4.12 that last worked is that in the documentation of the nRF5 SDK it is mentioned for something called "legacy mode" [[1]]. However, we are using the nRF5 *IoT* SDK which doesn't mention this "legacy mode" at all in its documentation.

I don't know if we can update the `pkg` to the other SDK (and thus be able to deactivate "legacy mode"), so I just updated the documentation accordingly for now.

[1]: https://www.nordicsemi.com/DocLib/Content/SDK_Doc/nRF5_SDK/v15-2-0/group__ble__6lowpan__config?9932#ga5285fd3eaf403092286f607cd66850f3

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

### Testing procedure
RTFM
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
