### PR TITLE
gnrc_ipv6_nib: use generated EUI-64 for ARO build and check

### DIFF
--- a/sys/include/net/eui48.h
+++ b/sys/include/net/eui48.h
@@ -68,14 +68,8 @@ static inline void eui48_to_eui64(eui64_t *eui64, const eui48_t *addr)
  */
 static inline void eui48_to_ipv6_iid(eui64_t *iid, const eui48_t *addr)
 {
-    iid->uint8[0] = addr->uint8[0] ^ 0x02;
-    iid->uint8[1] = addr->uint8[1];
-    iid->uint8[2] = addr->uint8[2];
-    iid->uint8[3] = 0xff;
-    iid->uint8[4] = 0xfe;
-    iid->uint8[5] = addr->uint8[3];
-    iid->uint8[6] = addr->uint8[4];
-    iid->uint8[7] = addr->uint8[5];
+    eui48_to_eui64(iid, addr);
+    iid->uint8[0] ^= 0x02;
 }
 
 /**

--- a/sys/include/net/eui48.h
+++ b/sys/include/net/eui48.h
@@ -37,8 +37,29 @@ typedef struct {
 } eui48_t;
 
 /**
+ * @brief   Generates an EUI-64 from a 48-bit device address
+ *
+ * @see     [RFC 2464, section 4](https://tools.ietf.org/html/rfc2464#section-4)
+ *
+ * @param[out] eui64    the resulting EUI-64.
+ * @param[in]  addr     a 48-bit device address
+ */
+static inline void eui48_to_eui64(eui64_t *eui64, const eui48_t *addr)
+{
+    eui64->uint8[0] = addr->uint8[0];
+    eui64->uint8[1] = addr->uint8[1];
+    eui64->uint8[2] = addr->uint8[2];
+    eui64->uint8[3] = 0xff;
+    eui64->uint8[4] = 0xfe;
+    eui64->uint8[5] = addr->uint8[3];
+    eui64->uint8[6] = addr->uint8[4];
+    eui64->uint8[7] = addr->uint8[5];
+}
+
+/**
  * @brief   Generates an IPv6 interface identifier from a 48-bit device address
  *
+ * @note    The IPv6 IID is derived from the EUI-64 by flipping the U/L bit.
  * @see     [RFC 2464, section 4](https://tools.ietf.org/html/rfc2464#section-4)
  * @see     [RFC 4291, section 2.5.1](https://tools.ietf.org/html/rfc4291#section-2.5.1)
  *

--- a/sys/net/gnrc/netif/gnrc_netif_device_type.c
+++ b/sys/net/gnrc/netif/gnrc_netif_device_type.c
@@ -54,6 +54,81 @@ netopt_t gnrc_netif_get_l2addr_opt(const gnrc_netif_t *netif)
     return res;
 }
 
+#if defined(MODULE_CC110X) || defined(MODULE_NRFMIN)
+static void _create_eui64_from_short(const uint8_t *addr, size_t addr_len,
+                                     eui64_t *eui64)
+{
+    const unsigned offset = sizeof(eui64_t) - addr_len;
+
+    memset(eui64->uint8, 0, sizeof(eui64->uint8));
+    eui64->uint8[3] = 0xff;
+    eui64->uint8[4] = 0xfe;
+    memcpy(&eui64->uint8[offset], addr, addr_len);
+}
+#endif /* defined(MODULE_CC110X) || defined(MODULE_NRFMIN) */
+
+int gnrc_netif_eui64_from_addr(const gnrc_netif_t *netif,
+                               const uint8_t *addr, size_t addr_len,
+                               eui64_t *eui64)
+{
+#if GNRC_NETIF_L2ADDR_MAXLEN > 0
+    if (netif->flags & GNRC_NETIF_FLAGS_HAS_L2ADDR) {
+        switch (netif->device_type) {
+#if defined(MODULE_NETDEV_ETH) || defined(MODULE_ESP_NOW) || \
+    defined(MODULE_NORDIC_SOFTDEVICE_BLE)
+            case NETDEV_TYPE_ETHERNET:
+            case NETDEV_TYPE_ESP_NOW:
+            case NETDEV_TYPE_BLE:
+                if (addr_len == sizeof(eui48_t)) {
+                    eui48_to_eui64(eui64, (const eui48_t *)addr);
+                    return sizeof(eui64_t);
+                }
+                else {
+                    return -EINVAL;
+                }
+#endif  /* defined(MODULE_NETDEV_ETH) || defined(MODULE_ESP_NOW) */
+#if defined(MODULE_NETDEV_IEEE802154) || defined(MODULE_XBEE)
+            case NETDEV_TYPE_IEEE802154:
+                switch (addr_len) {
+                    case IEEE802154_SHORT_ADDRESS_LEN: {
+                        netdev_t *dev = netif->dev;
+                        return dev->driver->get(dev, NETOPT_ADDRESS_LONG, eui64,
+                                                sizeof(eui64_t));
+                    }
+                    case IEEE802154_LONG_ADDRESS_LEN:
+                        memcpy(eui64, addr, addr_len);
+                        return sizeof(eui64_t);
+                    default:
+                        return -EINVAL;
+                }
+#endif  /* defined(MODULE_NETDEV_IEEE802154) || defined(MODULE_XBEE) */
+#if defined(MODULE_CC110X) || defined(MODULE_NRFMIN)
+            case NETDEV_TYPE_CC110X:
+            case NETDEV_TYPE_NRFMIN:
+                if (addr_len <= 3) {
+                    _create_eui64_from_short(addr, addr_len, eui64);
+                    return sizeof(eui64_t);
+                }
+                else {
+                    return -EINVAL;
+                }
+#endif  /* defined(MODULE_CC110X) || defined(MODULE_NRFMIN) */
+            default:
+                (void)addr;
+                (void)addr_len;
+                (void)eui64;
+#ifdef DEVELHELP
+                LOG_ERROR("gnrc_netif: can't convert hardware address to EUI-64"
+                          " on interface %u\n", netif->pid);
+#endif  /* DEVELHELP */
+                assert(false);
+                break;
+        }
+    }
+#endif /* GNRC_NETIF_L2ADDR_MAXLEN > 0 */
+    return -ENOTSUP;
+}
+
 #ifdef MODULE_GNRC_IPV6
 void gnrc_netif_ipv6_init_mtu(gnrc_netif_t *netif)
 {
@@ -121,19 +196,6 @@ void gnrc_netif_ipv6_init_mtu(gnrc_netif_t *netif)
     }
 #endif
 }
-
-#if defined(MODULE_CC110X) || defined(MODULE_NRFMIN)
-static void _create_eui64_from_short(const uint8_t *addr, size_t addr_len,
-                                     eui64_t *eui64)
-{
-    const unsigned offset = sizeof(eui64_t) - addr_len;
-
-    memset(eui64->uint8, 0, sizeof(eui64->uint8));
-    eui64->uint8[3] = 0xff;
-    eui64->uint8[4] = 0xfe;
-    memcpy(&eui64->uint8[offset], addr, addr_len);
-}
-#endif /* defined(MODULE_CC110X) || defined(MODULE_NRFMIN) */
 
 int gnrc_netif_ipv6_iid_from_addr(const gnrc_netif_t *netif,
                                   const uint8_t *addr, size_t addr_len,

--- a/sys/net/gnrc/netif/gnrc_netif_device_type.c
+++ b/sys/net/gnrc/netif/gnrc_netif_device_type.c
@@ -123,15 +123,15 @@ void gnrc_netif_ipv6_init_mtu(gnrc_netif_t *netif)
 }
 
 #if defined(MODULE_CC110X) || defined(MODULE_NRFMIN)
-static void _create_iid_from_short(const uint8_t *addr, size_t addr_len,
-                                   eui64_t *iid)
+static void _create_eui64_from_short(const uint8_t *addr, size_t addr_len,
+                                     eui64_t *eui64)
 {
     const unsigned offset = sizeof(eui64_t) - addr_len;
 
-    memset(iid->uint8, 0, sizeof(iid->uint8));
-    iid->uint8[3] = 0xff;
-    iid->uint8[4] = 0xfe;
-    memcpy(&iid->uint8[offset], addr, addr_len);
+    memset(eui64->uint8, 0, sizeof(eui64->uint8));
+    eui64->uint8[3] = 0xff;
+    eui64->uint8[4] = 0xfe;
+    memcpy(&eui64->uint8[offset], addr, addr_len);
 }
 #endif /* defined(MODULE_CC110X) || defined(MODULE_NRFMIN) */
 
@@ -168,7 +168,7 @@ int gnrc_netif_ipv6_iid_from_addr(const gnrc_netif_t *netif,
             case NETDEV_TYPE_CC110X:
             case NETDEV_TYPE_NRFMIN:
                 if (addr_len <= 3) {
-                    _create_iid_from_short(addr, addr_len, iid);
+                    _create_eui64_from_short(addr, addr_len, iid);
                     return sizeof(eui64_t);
                 }
                 else {

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-6ln.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-6ln.c
@@ -29,11 +29,12 @@ static char addr_str[IPV6_ADDR_MAX_STR_LEN];
 
 extern void _handle_search_rtr(gnrc_netif_t *netif);
 
-static inline bool _is_iface_eui64(gnrc_netif_t *netif, const eui64_t *eui64)
+static bool _is_iface_eui64(gnrc_netif_t *netif, const eui64_t *eui64)
 {
-    /* TODO: adapt for short addresses */
-    return (netif->l2addr_len == sizeof(eui64_t)) &&
-           (memcmp(&netif->l2addr, eui64, netif->l2addr_len) == 0);
+    eui64_t iface_eui64;
+    int res = gnrc_netif_get_eui64(netif, &iface_eui64);
+    return (res == sizeof(eui64_t)) &&
+           (iface_eui64.uint64.u64 == eui64->uint64.u64);
 }
 
 bool _resolve_addr_from_ipv6(const ipv6_addr_t *dst, gnrc_netif_t *netif,

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.c
@@ -43,16 +43,15 @@ void _snd_ns(const ipv6_addr_t *tgt, gnrc_netif_t *netif,
     if ((src != NULL) && gnrc_netif_is_6ln(netif) &&
         (_nib_onl_get_if(dr->next_hop) == (unsigned)netif->pid) &&
         ipv6_addr_equal(&dr->next_hop->ipv6, dst)) {
-        netdev_t *dev = netif->dev;
-        uint8_t l2src[GNRC_NETIF_L2ADDR_MAXLEN];
-        size_t l2src_len = (uint16_t)dev->driver->get(dev, NETOPT_ADDRESS_LONG,
-                                                      l2src, sizeof(l2src));
-        if (l2src_len != sizeof(eui64_t)) {
+        eui64_t eui64;
+        int res = gnrc_netif_get_eui64(netif, &eui64);
+
+        if (res != sizeof(eui64_t)) {
             DEBUG("nib: can't get EUI-64 of the interface for ARO\n");
             return;
         }
         ext_opt = gnrc_sixlowpan_nd_opt_ar_build(0, GNRC_SIXLOWPAN_ND_AR_LTIME,
-                                                 (eui64_t *)l2src, NULL);
+                                                 &eui64, NULL);
         if (ext_opt == NULL) {
             DEBUG("nib: error allocating ARO.\n");
             return;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This fixes #10723 by providing a new getter for the (unconverted) EUI-64 in the interface layer. This getter then is used instead of the link-layer address to set the EUI-64 in the ARO and also check it.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Flash two 6Lo-capable boards with `gnrc_border_router` and `gnrc_networking`. The `gnrc_networking` should get a global address which will be marked as valid. Not just IEEE 802.15.4-capable boards should be able to do this now, but also BLE-based boards and more exotic candidates like `cc110x`, `nrfmin`, or `esp-now`.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Closes #10723.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

![gnrc_netif/gnrc_sixlowpan_iphc BLE capability](http://page.mi.fu-berlin.de/mlenders/netif_ble.svg)