### PR TITLE
eui48: fix type alignment

### DIFF
--- a/sys/include/net/eui48.h
+++ b/sys/include/net/eui48.h
@@ -32,9 +32,8 @@ extern "C" {
 /**
  * @brief   Data type to represent an EUI-48
  */
-typedef union {
+typedef struct {
     uint8_t uint8[6];            /**< split into 6 8-bit words. */
-    network_uint16_t uint16[3];  /**< split into 3 16-bit words. */
 } eui48_t;
 
 /**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This tries to fix the type alignment of the `eui48_t` type, as pointed out https://github.com/RIOT-OS/RIOT/pull/10817#discussion_r249081588. The `uint16` union member isn't used anywhere in the codebase and the module is quite new (it was introduced in #10567 so within this release cycle), so I think it's safe to be removed.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Ethernet-based boards like `native` should still be able to handle their addresses (check `ifconfig` in `gnrc_networking`, try pinging another node).
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Found in https://github.com/RIOT-OS/RIOT/pull/10817#discussion_r249081588.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
