### PR TITLE
Makefile.include: append the values to GLOBAL_GOALS

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -97,7 +97,7 @@ include $(RIOTMAKE)/color.inc.mk
 # include concurrency helpers
 include $(RIOTMAKE)/info-nproc.inc.mk
 
-GLOBAL_GOALS := buildtest info-boards-supported info-boards-features-missing info-buildsizes info-buildsizes-diff
+GLOBAL_GOALS += buildtest info-boards-supported info-boards-features-missing info-buildsizes info-buildsizes-diff
 ifneq (, $(filter $(GLOBAL_GOALS), $(MAKECMDGOALS)))
   BOARD=none
 endif


### PR DESCRIPTION
### Contribution description

This allows setting other GLOBAL_GOALS by setting it before.
This could be the case for the application `Makefile` or files parsed
from `RIOT_MAKEFILES_GLOBAL_PRE`.

#### Why needed

I wanted to run `make` from inside a target and failed because many variables are exported.
Using `env` to only select few exported variables mean maybe miss one.
By declaring it as a global goal, nothing is exported.

### Testing procedure

I build a simple example using what I needed. https://gist.githubusercontent.com/cladmi/8eae8ba332909e863b124c8a93cbe140/raw/63d1ee0449e6a332266f10b30982274556b9ebfc/make_in_make.inc.pre
In the base of the RIOT repository run the following commands:

```
wget https://gist.githubusercontent.com/cladmi/8eae8ba332909e863b124c8a93cbe140/raw/63d1ee0449e6a332266f10b30982274556b9ebfc/make_in_make.inc.pre -O make_in_make.inc.pre
BOARD=samr21-xpro RIOT_MAKEFILES_GLOBAL_PRE='${RIOTBASE}/make_in_make.inc.pre' make -C examples/hello-world/ time-make
```

In the PR it correctly compiles as it is considered as a global target so does not export all the variables. In master it fails:

```
wget https://gist.githubusercontent.com/cladmi/8eae8ba332909e863b124c8a93cbe140/raw/63d1ee0449e6a332266f10b30982274556b9ebfc/make_in_make.inc.pre -O make_in_make.inc.pre; BOARD=samr21-xpro RIOT_MAKEFILES_GLOBAL_PRE='${RIOTBASE}/make_in_make.inc.pre' make -C examples/hello-world/ time-make
--2019-01-18 17:03:27--  https://gist.githubusercontent.com/cladmi/8eae8ba332909e863b124c8a93cbe140/raw/63d1ee0449e6a332266f10b30982274556b9ebfc/make_in_make.inc.pre
Resolving gist.githubusercontent.com (gist.githubusercontent.com)... 151.101.112.133
Connecting to gist.githubusercontent.com (gist.githubusercontent.com)|151.101.112.133|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 308 [text/plain]
Saving to: ‘make_in_make.inc.pre’

make_in_make.inc.pre                                                   100%[==========================================================================================================================================================================>]     308  --.-KB/s    in 0s      

2019-01-18 17:03:28 (17.6 MB/s) - ‘make_in_make.inc.pre’ saved [308/308]

make: Entering directory '/home/harter/work/git/RIOT/examples/hello-world'
time-make: samr21-xpro
time make clean all
Building application "hello-world" for "samr21-xpro" with MCU "samd21".

"make" -C /home/harter/work/git/RIOT/boards/samr21-xpro
"make" -C /home/harter/work/git/RIOT/core
"make" -C /home/harter/work/git/RIOT/cpu/samd21
"make" -C /home/harter/work/git/RIOT/cpu/cortexm_common
"make" -C /home/harter/work/git/RIOT/cpu/cortexm_common/periph
"make" -C /home/harter/work/git/RIOT/cpu/sam0_common
"make" -C /home/harter/work/git/RIOT/cpu/sam0_common/periph
"make" -C /home/harter/work/git/RIOT/cpu/samd21/periph
"make" -C /home/harter/work/git/RIOT/drivers
"make" -C /home/harter/work/git/RIOT/drivers/periph_common
"make" -C /home/harter/work/git/RIOT/sys
"make" -C /home/harter/work/git/RIOT/sys/auto_init
"make" -C /home/harter/work/git/RIOT/sys/isrpipe
"make" -C /home/harter/work/git/RIOT/sys/newlib_syscalls_default
"make" -C /home/harter/work/git/RIOT/sys/pm_layered
"make" -C /home/harter/work/git/RIOT/sys/stdio_uart
"make" -C /home/harter/work/git/RIOT/sys/tsrb
arm-none-eabi-gcc: fatal error: /opt/gcc-arm-none-eabi-7-2018-q2-update/bin/../lib/gcc/arm-none-eabi/7.3.1/../../../../arm-none-eabi/lib/nano.specs: attempt to rename spec 'link' to already defined spec 'nano_link'
compilation terminated.
/home/harter/work/git/RIOT/Makefile.include:454: recipe for target '/home/harter/work/git/RIOT/examples/hello-world/bin/samr21-xpro/hello-world.elf' failed
make[1]: *** [/home/harter/work/git/RIOT/examples/hello-world/bin/samr21-xpro/hello-world.elf] Error 1
Command exited with non-zero status 2
4.44user 0.71system 0:05.14elapsed 100%CPU (0avgtext+0avgdata 33560maxresident)k
0inputs+188224outputs (0major+380065minor)pagefaults 0swaps
/home/harter/work/git/RIOT/examples/hello-world/../../make_in_make.inc.pre:9: recipe for target 'time-make' failed
make: *** [time-make] Error 2
make: Leaving directory '/home/harter/work/git/RIOT/examples/hello-world'
```

### Issues/PRs references

Was found while trying to write a wrapped target for testing.