### PR TITLE
nrfmin: fix type for NETOPT_PROTO

### DIFF
--- a/cpu/nrf5x_common/radio/nrfmin/nrfmin.c
+++ b/cpu/nrf5x_common/radio/nrfmin/nrfmin.c
@@ -490,9 +490,9 @@ static int nrfmin_get(netdev_t *dev, netopt_t opt, void *val, size_t max_len)
             return sizeof(uint16_t);
 #ifdef MODULE_GNRC_SIXLOWPAN
         case NETOPT_PROTO:
-            assert(max_len >= sizeof(uint16_t));
-            *((uint16_t *)val) = GNRC_NETTYPE_SIXLOWPAN;
-            return sizeof(uint16_t);
+            assert(max_len == sizeof(gnrc_nettype_t));
+            *((gnrc_nettype_t *)val) = GNRC_NETTYPE_SIXLOWPAN;
+            return sizeof(gnrc_nettype_t);
 #endif
         case NETOPT_DEVICE_TYPE:
             assert(max_len >= sizeof(uint16_t));


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
The type [is documented as `gnrc_nettype_t`][1] so it should by checked
as such.

[1]: https://github.com/RIOT-OS/RIOT/blob/f9a3bdf1a749f0e6a0d9e79eee652d8b31d4d9e0/sys/include/net/netopt.h#L210-L212
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`nrfmin` should still send 6Lo frames without running into an assertion.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Revealed in https://github.com/RIOT-OS/RIOT/pull/10532#issuecomment-455616387 and thus required for #10532.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
