### PR TITLE
net/nanocoap: validate option length

### DIFF
--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -717,8 +717,14 @@ static ssize_t _add_opt_pkt(coap_pkt_t *pkt, uint16_t optnum, uint8_t *val,
             ? pkt->options[pkt->options_len - 1].opt_num : 0;
     assert(optnum >= lastonum);
 
-    size_t optlen = coap_put_option(pkt->payload, lastonum, optnum, val, val_len);
-    assert(pkt->payload_len > optlen);
+    /* calculate option length */
+    uint8_t dummy[3];
+    size_t optlen = _put_delta_optlen(dummy, 1, 4, optnum - lastonum);
+    optlen += _put_delta_optlen(dummy, 0, 0, val_len);
+    optlen += val_len;
+    assert(pkt->payload_len >= optlen);
+
+    coap_put_option(pkt->payload, lastonum, optnum, val, val_len);
 
     pkt->options[pkt->options_len].opt_num = optnum;
     pkt->options[pkt->options_len].offset = pkt->payload - (uint8_t *)pkt->hdr;

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -499,7 +499,35 @@ static size_t _encode_uint(uint32_t *val)
     return size;
 }
 
-static unsigned _put_delta_optlen(uint8_t *buf, unsigned offset, unsigned shift, unsigned val)
+/*
+ * Writes CoAP Option header. Expected to be called twice to write an option:
+ *
+ * 1. write delta, using offset 1, shift 4
+ * 2. write length, using offset n, shift 0, where n is the return value from
+ *    the first invocation of this function
+ *
+ *     0   1   2   3   4   5   6   7
+ *   +---------------+---------------+
+ *   |  Option Delta | Option Length |   1 byte
+ *   +---------------+---------------+
+ *   /         Option Delta          /   0-2 bytes
+ *   \          (extended)           \
+ *   +-------------------------------+
+ *   /         Option Length         /   0-2 bytes
+ *   \          (extended)           \
+ *   +-------------------------------+
+ *
+ *   From RFC 7252, Figure 8
+ *
+ * param[out] buf       addr of byte 0 of header
+ * param[in]  offset    offset from buf to write any extended header
+ * param[in]  shift     bit shift for byte 0 value
+ * param[in]  value     delta/length value to write to header
+ *
+ * return     offset from byte 0 of next byte to write
+ */
+static unsigned _put_delta_optlen(uint8_t *buf, unsigned offset, unsigned shift,
+                                  unsigned val)
 {
     if (val < 13) {
         *buf |= (val << shift);

--- a/tests/unittests/tests-nanocoap/tests-nanocoap.c
+++ b/tests/unittests/tests-nanocoap/tests-nanocoap.c
@@ -331,6 +331,29 @@ static void test_nanocoap__get_multi_query(void)
 }
 
 /*
+ * Builds on get_req test, to test building a PDU that completely fills the
+ * buffer.
+ */
+static void test_nanocoap__option_add_buffer_max(void)
+{
+    uint8_t buf[70];    /* header 4, token 2, path 64 */
+    coap_pkt_t pkt;
+    uint16_t msgid = 0xABCD;
+    uint8_t token[2] = {0xDA, 0xEC};
+    char path[] = "/23456789012345678901234567890123456789012345678901234567890123";
+
+    size_t uri_opt_len = 64;    /* option hdr 2, option value 62 */
+
+    size_t len = coap_build_hdr((coap_hdr_t *)&buf[0], COAP_TYPE_NON,
+                                &token[0], 2, COAP_METHOD_GET, msgid);
+
+    coap_pkt_init(&pkt, &buf[0], sizeof(buf), len);
+
+    len = coap_opt_add_string(&pkt, COAP_OPT_URI_PATH, &path[0], '/');
+    TEST_ASSERT_EQUAL_INT(uri_opt_len, len);
+}
+
+/*
  * Helper for server_get tests below.
  * GET Request for nanocoap server example /riot/value resource.
  * Includes 2-byte token; non-confirmable.
@@ -531,6 +554,7 @@ Test *tests_nanocoap_tests(void)
         new_TestFixture(test_nanocoap__get_path_too_long),
         new_TestFixture(test_nanocoap__get_query),
         new_TestFixture(test_nanocoap__get_multi_query),
+        new_TestFixture(test_nanocoap__option_add_buffer_max),
         new_TestFixture(test_nanocoap__server_get_req),
         new_TestFixture(test_nanocoap__server_reply_simple),
         new_TestFixture(test_nanocoap__server_get_req_con),


### PR DESCRIPTION
### Contribution description
The Buffer Append API added in #9085 uses the coap_pkt_t struct to track to amount of buffer space remaining as the CoAP PDU is built. _add_opt_pkt() is the low level function in that API to add an option to the buffer. This function uses coap_put_option() to actually write to the buffer. However, that function is part of the minimal Buffer Put API, and does not check the length of the buffer before writing. This PR updates _add_opt_pkt() to test the available buffer space *before* writing the option.

The PR also adds function documentation for _put_delta_optlen(), which writes the option header, and a unit test for building a message that completely fills the buffer.

The use of an assert in _add_opt_pkt() when the buffer is too small is not ideal. We plan to create a follow-on PR that returns a negative value from the function so the caller can recover.

### Testing procedure
The 'tests-nanocoap' unit tests include a new test, test_nanocoap__option_add_buffer_max(), which completely fills the buffer used to write a request. Run 'tests-nanocoap' both without and with assertions enabled (compile with FORCE_ASSERTS=1). Both runs should pass.

Next, manually reduce the size of the buffer in the new test from 70 to 69 and rerun the tests. Without asserts, on native the test fails abruptly when the buffer overflows ("stack smashing detected"). With asserts enabled, the relevant assert in _add_opt_pkt() is tripped.

### Issues/PRs references
-none-
