### PR TITLE
cpu/fe310: Add call to periph_init()

### DIFF
--- a/cpu/fe310/Makefile.include
+++ b/cpu/fe310/Makefile.include
@@ -5,6 +5,7 @@ USEMODULE += newlib_syscalls_fe310
 USEMODULE += sifive_drivers_fe310
 
 USEMODULE += periph
+USEMODULE += periph_common
 USEMODULE += periph_pm
 
 CFLAGS += -Wno-pedantic

--- a/cpu/fe310/cpu.c
+++ b/cpu/fe310/cpu.c
@@ -28,6 +28,7 @@
 #include "cpu.h"
 #include "context_frame.h"
 #include "periph_cpu.h"
+#include "periph/init.h"
 #include "panic.h"
 #include "vendor/encoding.h"
 #include "vendor/platform.h"
@@ -88,6 +89,9 @@ void cpu_init(void)
 
     /*  Set default state of mstatus */
     set_csr(mstatus, MSTATUS_DEFAULT);
+
+    /* trigger static peripheral initialization */
+    periph_init();
 }
 
 /**


### PR DESCRIPTION
### Contribution description

Until now fe310's cpu_init() was missing a call to periph_init(). This commit adds this call.

### Testing procedure

Check if the HiFive1 board still boots as expected

### Issues/PRs references

Required for https://github.com/RIOT-OS/RIOT/pull/10806