### PR TITLE
drivers/at: make at_dev_init() return uart initialize status

### DIFF
--- a/drivers/at/at.c
+++ b/drivers/at/at.c
@@ -31,10 +31,9 @@ int at_dev_init(at_dev_t *dev, uart_t uart, uint32_t baudrate, char *buf, size_t
 {
     dev->uart = uart;
     isrpipe_init(&dev->isrpipe, buf, bufsize);
-    uart_init(uart, baudrate, _isrpipe_write_one_wrapper,
-              &dev->isrpipe);
 
-    return 0;
+    return uart_init(uart, baudrate, _isrpipe_write_one_wrapper,
+                     &dev->isrpipe);
 }
 
 int at_expect_bytes(at_dev_t *dev, const char *bytes, uint32_t timeout)

--- a/drivers/include/at.h
+++ b/drivers/include/at.h
@@ -124,8 +124,8 @@ typedef struct {
  * @param[in]   buf         input buffer
  * @param[in]   bufsize     size of @p buf
  *
- * @returns     0 on success
- * @returns     <0 otherwise
+ * @returns     success code UART_OK on success
+ * @returns     error code UART_NODEV or UART_NOBAUD otherwise
  */
 int at_dev_init(at_dev_t *dev, uart_t uart, uint32_t baudrate, char *buf, size_t bufsize);
 

--- a/tests/driver_at/main.c
+++ b/tests/driver_at/main.c
@@ -47,9 +47,19 @@ static int init(int argc, char **argv)
     uint8_t uart = atoi(argv[1]);
     uint32_t baudrate = atoi(argv[2]);
 
-    at_dev_init(&at_dev, UART_DEV(uart), baudrate, buf, sizeof(buf));
+    int res = at_dev_init(&at_dev, UART_DEV(uart), baudrate, buf, sizeof(buf));
 
-    return 0;
+    /* check the UART initialization return value and respond as needed */
+    if (res == UART_NODEV) {
+        puts("Invalid UART device given!");
+        return 1;
+    }
+    else if (res == UART_NOBAUD) {
+        puts("Baudrate is not applicable!");
+        return 1;
+    }
+
+    return res;
 }
 
 static int send(int argc, char **argv)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

at the file drivers/at.c there's the uart_init function which returns 0 no matter what, in case the function failed the user/tester won't know that it failed or why.
i changed the function uart_init to return the result of the uart_init which could be:
UART_OK
UART_NODEV
UART_NOBAUD

then in tests/driver_at/main in the init function, i checked if the result code is equal to one of the last two, if yes, i printed it and returned 1.


### Testing procedure

<!--
Details steps to test your contribution:
-you can compile driver_at test, for any of the at devices
-it was working, just not correctly, in my opinion.
- the expected success test output
in case of wrong uart:
"Invalid UART device given!"
or in case of wrong baudrate:
"Baudrate is not applicable!"
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
