### PR TITLE
boards/b-l475e-iot01a: provide already configured RTC and RTT features

### DIFF
--- a/boards/b-l475e-iot01a/Makefile.features
+++ b/boards/b-l475e-iot01a/Makefile.features
@@ -2,6 +2,8 @@
 FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The board b-l475e-iot01a provides a configuration for both RTC and RTT but the features are not exposed by the build system via the `FEATURES_PROVIDED` variable.

This PR is adding the missing features to this variable.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

This can be roughly tested on IoT-LAB:
- Start an experiment using the IoT-LAB cli tools:
```
$ iotlab-experiment submit -n test -d 60 -l 1,site=saclay+archi=st-iotnode:multi
$ iotlab-experiment wait
```
- Build/flash/run the `tests/periph_rtc` and `tests/periph_rtt` applications:
```
$ make BOARD=b-l475e-iot01a IOTLAB_NODE=auto-ssh -C tests/periph_rtc flash term (or test)
$ make BOARD=b-l475e-iot01a IOTLAB_NODE=auto-ssh -C tests/periph_rtt flash term
```
- Both application should work as expected (but difficult to check the timings on IoT-LAB), on master you get the red message "There are unsatisfied feature requirements" although the application works.


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
