### PR TITLE
testrunner: fix script when RIOTBASE is not defined

### DIFF
--- a/dist/pythonlibs/testrunner/__init__.py
+++ b/dist/pythonlibs/testrunner/__init__.py
@@ -16,8 +16,9 @@ from traceback import extract_tb, print_tb
 import pexpect
 
 PEXPECT_PATH = os.path.dirname(pexpect.__file__)
-RIOTBASE = os.environ['RIOTBASE'] or \
-    os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+RIOTBASE = (os.environ.get('RIOTBASE') or
+            os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                         "..", "..", "..")))
 
 # Setting an empty 'TESTRUNNER_START_DELAY' environment variable use the
 # default value (3)


### PR DESCRIPTION
### Contribution description

If not defined it was raising a KeyError. Use the 'get' function to
handle non defined value.

It did not put the value in the `default` case as it would have changed
the behavior when `RIOTBASE` is defined but empty.

### Testing procedure

Import `testrunner` when `RIOTBASE` is not defined

    PYTHONPATH='dist/pythonlibs/' python3 -c 'import testrunner'

It works with this PR and fails in master. I also did not changed the behavior of having `RIOTBASE` defined empty.

* PR:
    ```
    PYTHONPATH='dist/pythonlibs/' python3 -c 'import testrunner; print(testrunner.RIOTBASE)'
   /home/harter/work/git/RIOT
    ```

* master:
    ```
    PYTHONPATH='dist/pythonlibs/' python3 -c 'import testrunner; print(testrunner.RIOTBASE)'
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/home/harter/work/git/RIOT/dist/pythonlibs/testrunner/__init__.py", line 19, in <module>
        RIOTBASE = os.environ['RIOTBASE'] or \
      File "/usr/lib/python3.6/os.py", line 669, in __getitem__
        raise KeyError(key) from None
    KeyError: 'RIOTBASE'
    ```

And did not add regression on these ones for both master and the PR

    # No value in RIOTBASE
    RIOTBASE= PYTHONPATH='dist/pythonlibs/' python3 -c 'import testrunner; print(testrunner.RIOTBASE)'
    /home/harter/work/git/RIOT

    # And a value is used
    RIOTBASE=dummy PYTHONPATH='dist/pythonlibs/' python3 -c 'import testrunner; print(testrunner.RIOTBASE)'
    dummy


### Issues/PRs references

None just found it