### PR TITLE
tests/posix_semaphore: private sub functions for tests libs

### DIFF
--- a/tests/posix_semaphore/tests/01-run.py
+++ b/tests/posix_semaphore/tests/01-run.py
@@ -10,7 +10,7 @@ import sys
 from testrunner import run
 
 
-def test1(term):
+def _test1(term):
     term.expect_exact("######################### TEST1:")
     term.expect_exact("first: sem_init")
     term.expect_exact("first: thread create")
@@ -33,7 +33,7 @@ def test1(term):
     term.expect_exact("first: end")
 
 
-def test2(term):
+def _test2(term):
     term.expect_exact("######################### TEST2:")
     term.expect_exact("first: sem_init")
     term.expect_exact("first: thread create: 5")
@@ -64,7 +64,7 @@ def test2(term):
     term.expect_exact("Back in main thread.")
 
 
-def test3(term):
+def _test3(term):
     term.expect_exact("######################### TEST3:")
     term.expect_exact("first: sem_init s1")
     term.expect_exact("first: sem_init s2")
@@ -81,7 +81,7 @@ def test3(term):
     term.expect_exact("Thread 2 woke up after waiting for s1.")
 
 
-def test4(term):
+def _test4(term):
     term.expect_exact("######################### TEST4:")
     term.expect_exact("first: sem_init s1")
     term.expect_exact("first: wait 1 sec for s1")
@@ -90,10 +90,10 @@ def test4(term):
 
 
 def testfunc(child):
-    test1(child)
-    test2(child)
-    test3(child)
-    test4(child)
+    _test1(child)
+    _test2(child)
+    _test3(child)
+    _test4(child)
     child.expect("######################### DONE")
 
 


### PR DESCRIPTION
### Contribution description

While trying python test libraries, like pytest, the automatic test collection
detects the `testNUM` functions as tests but does not know the `term` argument
and fails.

This declares them as private to only find `testfunc(child)` entry point.

Another solution could have been to use `testNUM(child)` and rename
`testfunc` to `main` but would not match other tests.

It is required for the board tests on `iot-lab` CI.

### Testing procedure

The current tests should still work in master and have the same result.

    BOARD=samr21-xpro make -C tests/posix_semaphore/ all flash test

I tested and got `TEST1` to `TEST4` on both `native` and `samr21-xpro`.

#### Fixed bug

To test that it addresses the described issue, it can be used with https://github.com/cladmi/iotlab-os-ci/tree/master/tools/pytest

It works with the PR but not in master.

```
RIOT_MAKEFILES_GLOBAL_POST=iotlab-os-ci/tools/pytest/pytest.mk.post BOARD=samr21-xpro make -C tests/posix_semaphore/ all flash pytest
...
File /home/harter/work/git/RIOT/tests/posix_semaphore/tests/01-run.py, line 13
  def test1(term):
E       fixture 'term' not found
>       available fixtures: cache, capfd, capfdbinary, caplog, capsys, capsysbinary, child, doctest_namespace, metadata, monkeypatch, pytestconfig, record_property, record_xml_attribute, record_xml_property, recwarn, tmp_path, tmp_path_factory, tmpdir, tmpdir_factory
>       use 'pytest --fixtures [testpath]' for help on them.
```

A special handling could be done for this case but it is the only test where it happens.

### Issues/PRs references

Found while preparing release tests to run on IoT-LAB.