### PR TITLE
tests/periph_dma: add automatic testing of DMA over UART

### DIFF
--- a/tests/periph_dma/main.c
+++ b/tests/periph_dma/main.c
@@ -21,7 +21,12 @@
 
 int main(void)
 {
-    puts("DMA dummy test app");
+    /*
+    This test is checking that DMA on UART is not broken when stdio UART is
+    configured with DMA.
+    Note that this message is also printed on 'normal' stdio UART (without DMA).
+    */
+    puts("DMA is working");
 
     return 0;
 }

--- a/tests/periph_dma/tests/01-run.py
+++ b/tests/periph_dma/tests/01-run.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2019 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect_exact('DMA is working')
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is cut out from #10803 and provides a testing python script for the output of UART when periph_dma is loaded in a application and the UART is configured with DMA.

After #10803 is merged, this will be the case for some ST boards. Using this script, we have an automatic way of testing that stdio UART + DMA is working.

The main problem is the fact that this also tests 'normal' stdio UART, e.g an UART without DMA configured of a board that provide DMA (for SPI for example). In #10803, no ST boards are in this case, but that may happen.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Pick one ST board with `periph_dma` feature provided (iotlab-m3, b-l072z-lrwan1, b-l475e-iot01a, nucleo-l152re, nucleo-f207zg, nucleo-f413zh, nucleo-f767zi)
- Build/flash/test the `periph_dma` test application (some boards are provided in IoT-LAB):
```
$ make BOARD=<the board> -C tests/periph_dma flash test
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Cut out from #10803 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
