### PR TITLE
cpu/fe310, board/hifive1: SPI support

### DIFF
--- a/boards/hifive1/Makefile.features
+++ b/boards/hifive1/Makefile.features
@@ -3,7 +3,7 @@ FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 #FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt
-#FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 

--- a/boards/hifive1/include/periph_conf.h
+++ b/boards/hifive1/include/periph_conf.h
@@ -27,12 +27,8 @@ extern "C" {
  * @name    Core Clock configuration
  * @{
  */
-#define CLOCK_CORECLOCK             (1600000ul)
-/*
- * #define CLOCK_CORECLOCK           (20000000ul)
- * #define CLOCK_CORECLOCK           (27000000ul)
- * #define CLOCK_CORECLOCK           (38400000ul)
- */
+/* As defined in boards/hifive1/board.c CPU_DESIRED_FREQ **/
+#define CLOCK_CORECLOCK             (200000000ul)
 /** @} */
 
 /**

--- a/boards/hifive1/include/periph_conf.h
+++ b/boards/hifive1/include/periph_conf.h
@@ -19,6 +19,8 @@
 #ifndef PERIPH_CONF_H
 #define PERIPH_CONF_H
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -76,6 +78,24 @@ extern "C" {
  * @{
  */
 #define PWM_NUMOF                   (3)
+/** @} */
+
+/**
+ * @name    SPI device configuration
+ *
+ * @{
+ */
+/* DIV_UP is division which rounds up instead of down */
+#define DIV_UP(a,b) (((a) + ((b) - 1)) / (b))
+static const uint32_t spi_clk_config[] = {
+    DIV_UP(CLOCK_CORECLOCK, 2 *   100000) - 1,
+    DIV_UP(CLOCK_CORECLOCK, 2 *   400000) - 1,
+    DIV_UP(CLOCK_CORECLOCK, 2 *  1000000) - 1,
+    DIV_UP(CLOCK_CORECLOCK, 2 *  5000000) - 1,
+    DIV_UP(CLOCK_CORECLOCK, 2 * 10000000) - 1,
+};
+#undef DIV_UP
+#define SPI_NUMOF                   (1)
 /** @} */
 
 /**

--- a/cpu/fe310/Makefile.include
+++ b/cpu/fe310/Makefile.include
@@ -5,6 +5,7 @@ USEMODULE += newlib_syscalls_fe310
 USEMODULE += sifive_drivers_fe310
 
 USEMODULE += periph
+USEMODULE += periph_common
 USEMODULE += periph_pm
 
 CFLAGS += -Wno-pedantic

--- a/cpu/fe310/Makefile.include
+++ b/cpu/fe310/Makefile.include
@@ -8,6 +8,9 @@ USEMODULE += periph
 USEMODULE += periph_common
 USEMODULE += periph_pm
 
+# include common periph drivers
+USEMODULE += periph_common
+
 CFLAGS += -Wno-pedantic
 
 include $(RIOTMAKE)/arch/riscv.inc.mk

--- a/cpu/fe310/cpu.c
+++ b/cpu/fe310/cpu.c
@@ -28,6 +28,7 @@
 #include "cpu.h"
 #include "context_frame.h"
 #include "periph_cpu.h"
+#include "periph/init.h"
 #include "panic.h"
 #include "vendor/encoding.h"
 #include "vendor/platform.h"
@@ -88,6 +89,9 @@ void cpu_init(void)
 
     /*  Set default state of mstatus */
     set_csr(mstatus, MSTATUS_DEFAULT);
+
+    /* trigger static peripheral initialization */
+    periph_init();
 }
 
 /**

--- a/cpu/fe310/include/periph_cpu.h
+++ b/cpu/fe310/include/periph_cpu.h
@@ -29,6 +29,15 @@ extern "C" {
 #define CPUID_LEN           (12U)
 
 /**
+ * @name    This CPU makes use of the following shared SPI functions
+ * @{
+ */
+#define PERIPH_SPI_NEEDS_TRANSFER_BYTE  1
+#define PERIPH_SPI_NEEDS_TRANSFER_REG   1
+#define PERIPH_SPI_NEEDS_TRANSFER_REGS  1
+/** @} */
+
+/**
  * @brief   Prevent shared timer functions from being used
  */
 #define PERIPH_TIMER_PROVIDES_SET

--- a/cpu/fe310/periph/spi.c
+++ b/cpu/fe310/periph/spi.c
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2019 Tristan Bruns
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_fe310
+ * @ingroup     drivers_periph_spi
+ *
+ * @{
+ *
+ * @file        spi.c
+ * @brief       Low-level SPI driver implementation
+ *
+ * @author      Tristan Bruns
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "mutex.h"
+#include "assert.h"
+#include "periph/spi.h"
+#include "vendor/platform.h"
+
+#define ENABLE_DEBUG        (0)
+#include "debug.h"
+
+/**
+ * @brief   Allocation device locks
+ */
+static mutex_t lock;
+
+void spi_init(spi_t bus)
+{
+    /* make sure given bus device is valid */
+    assert(bus == 0);
+
+    /* initialize the buses lock */
+    mutex_init(&lock);
+
+    /* trigger pin initialization */
+    spi_init_pins(bus);
+
+    /* disable hardware chip select
+       (hardware chip select only supports one-byte transfers...) */
+    SPI1_REG(SPI_REG_CSMODE) = SPI_CSMODE_OFF;
+}
+
+void spi_init_pins(spi_t bus)
+{
+    assert(bus == 0);
+
+    const gpio_t spi1_pins =
+        (1 << IOF_SPI1_MOSI) |
+        (1 << IOF_SPI1_MISO) |
+        (1 << IOF_SPI1_SCK);
+
+    /* Enable I/O Function 0 */
+    GPIO_REG(GPIO_IOF_EN)  |=  spi1_pins;
+    GPIO_REG(GPIO_IOF_SEL) &= ~spi1_pins;
+}
+
+int spi_init_cs(spi_t bus, spi_cs_t cs)
+{
+    if (bus != 0) {
+        return SPI_NODEV;
+    }
+
+    /* setting the CS high before configuring it as an
+       output should be fine on FE310. */
+    gpio_set(cs);
+
+    if (gpio_init(cs, GPIO_OUT)) {
+        return SPI_NOCS;
+    }
+
+    return SPI_OK;
+}
+
+int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
+{
+    (void) bus;
+    (void) cs;
+
+    mutex_lock(&lock);
+
+    SPI1_REG(SPI_REG_SCKDIV)  = spi_clk_config[clk];
+    SPI1_REG(SPI_REG_SCKMODE) = mode;
+
+    return SPI_OK;
+}
+
+void spi_release(spi_t bus)
+{
+    (void) bus;
+
+    mutex_unlock(&lock);
+}
+
+void spi_transfer_bytes(spi_t bus, spi_cs_t cs, bool cont,
+                        const void *out_, void *in_, size_t len)
+{
+    (void) bus;
+
+    assert((out_ || in_) && len > 0);
+    assert(SPI1_REG(SPI_REG_RXFIFO) & SPI_RXFIFO_EMPTY);
+    assert(!(SPI1_REG(SPI_REG_TXFIFO) & SPI_TXFIFO_FULL));
+
+    const uint8_t *out = out_;
+    uint8_t *in = in_;
+
+    if (cs != SPI_CS_UNDEF) {
+        gpio_clear(cs);
+    }
+
+    for (size_t i = 0; i < len; i++) {
+        SPI1_REG(SPI_REG_TXFIFO) = out ? out[i] : 0;
+
+        uint32_t rxdata = SPI_RXFIFO_EMPTY;
+        while (rxdata & SPI_RXFIFO_EMPTY) {
+            rxdata = SPI1_REG(SPI_REG_RXFIFO);
+        }
+
+        if (in) {
+            in[i] = (uint8_t)rxdata;
+        }
+    }
+
+    if (cs != SPI_CS_UNDEF && !cont) {
+        gpio_set(cs);
+    }
+}

--- a/cpu/fe310/periph/spi.c
+++ b/cpu/fe310/periph/spi.c
@@ -52,6 +52,7 @@ void spi_init(spi_t bus)
 
 void spi_init_pins(spi_t bus)
 {
+    (void) bus;
     assert(bus == 0);
 
     const gpio_t spi1_pins =


### PR DESCRIPTION
**Please note: This is not tested as much as I would like. Please wait with merging until I had a look with an oscilloscope.**

### Contribution description

* This implements `periph/spi` on `cpu/fe310` and `board/hifive1`
* Hardware Chip Select lines were not implemented, since they don't offer any benefit for transfers larger than one byte in size, due to limitations of the hardware. This simplifies the code.

### Testing procedure

    make -C tests/periph_spi BOARD=hifive1

### Issues/PRs references

* ~~Depends on and includes PR #10825~~ (merged)
* ~~Depends on and includes PR #10805~~ (merged)
