### PR TITLE
cpu/esp32: fix of buffer sizes and length checking in esp_eth and esp_wifi

### DIFF
--- a/cpu/esp32/esp-eth/esp_eth_netdev.c
+++ b/cpu/esp32/esp-eth/esp_eth_netdev.c
@@ -95,7 +95,7 @@ static esp_err_t IRAM_ATTR _eth_input_callback(void *buffer, uint16_t len, void 
     DEBUG("%s: buf=%p len=%d eb=%p\n", __func__, buffer, len, eb);
 
     CHECK_PARAM_RET (buffer != NULL, -EINVAL);
-    CHECK_PARAM_RET (len <= ETHERNET_DATA_LEN, -EINVAL);
+    CHECK_PARAM_RET (len <= ETHERNET_MAX_LEN, -EINVAL);
 
     mutex_lock(&_esp_eth_dev.dev_lock);
 
@@ -198,7 +198,7 @@ static int _esp_eth_send(netdev_t *netdev, const iolist_t *iolist)
 
     /* load packet data into TX buffer */
     for (const iolist_t *iol = iolist; iol; iol = iol->iol_next) {
-        if (dev->tx_len + iol->iol_len > ETHERNET_DATA_LEN) {
+        if (dev->tx_len + iol->iol_len > ETHERNET_MAX_LEN) {
             mutex_unlock(&dev->dev_lock);
             return -EOVERFLOW;
         }

--- a/cpu/esp32/esp-eth/esp_eth_netdev.h
+++ b/cpu/esp32/esp-eth/esp_eth_netdev.h
@@ -40,8 +40,8 @@ typedef struct
     uint16_t rx_len;                     /**< number of bytes received */
     uint16_t tx_len;                     /**< number of bytes in transmit buffer */
 
-    uint8_t  rx_buf[ETHERNET_DATA_LEN];  /**< receive buffer */
-    uint8_t  tx_buf[ETHERNET_DATA_LEN];  /**< transmit buffer */
+    uint8_t  rx_buf[ETHERNET_MAX_LEN];  /**< receive buffer */
+    uint8_t  tx_buf[ETHERNET_MAX_LEN];  /**< transmit buffer */
 
     uint32_t event;                     /**< received event */
     bool     link_up;                   /**< indicates whether link is up */

--- a/cpu/esp32/esp-wifi/esp_wifi_netdev.c
+++ b/cpu/esp32/esp-wifi/esp_wifi_netdev.c
@@ -79,7 +79,7 @@ esp_err_t _esp_wifi_rx_cb(void *buffer, uint16_t len, void *eb)
 
     DEBUG("%s: buf=%p len=%d eb=%p\n", __func__, buffer, len, eb);
 
-    if ((buffer == NULL) || (len >= ETHERNET_DATA_LEN)) {
+    if ((buffer == NULL) || (len >= ETHERNET_MAX_LEN)) {
         if (eb != NULL) {
             esp_wifi_internal_free_rx_buffer(eb);
         }
@@ -298,7 +298,7 @@ static int _esp_wifi_send(netdev_t *netdev, const iolist_t *iolist)
 
     /* load packet data into TX buffer */
     for (const iolist_t *iol = iolist; iol; iol = iol->iol_next) {
-        if (dev->tx_len + iol->iol_len > ETHERNET_DATA_LEN) {
+        if (dev->tx_len + iol->iol_len > ETHERNET_MAX_LEN) {
             mutex_unlock(&dev->dev_lock);
             return -EOVERFLOW;
         }

--- a/cpu/esp32/esp-wifi/esp_wifi_netdev.h
+++ b/cpu/esp32/esp-wifi/esp_wifi_netdev.h
@@ -38,10 +38,10 @@ typedef struct
     netdev_t netdev;                   /**< netdev parent struct */
 
     uint16_t rx_len;                   /**< number of bytes received */
-    uint8_t rx_buf[ETHERNET_DATA_LEN]; /**< receive buffer */
+    uint8_t rx_buf[ETHERNET_MAX_LEN];  /**< receive buffer */
 
     uint16_t tx_len;                   /**< number of bytes in transmit buffer */
-    uint8_t tx_buf[ETHERNET_DATA_LEN]; /**< transmit buffer */
+    uint8_t tx_buf[ETHERNET_MAX_LEN];  /**< transmit buffer */
 
     uint32_t event;                    /**< received event */
     bool connected;                    /**< indicates whether connected to AP */


### PR DESCRIPTION
### Contribution description

This PR provides a fix of buffer sizes and length checks in `esp_wifi` and `esp_eth` netdev drivers. Since complete MAC frames are handled by these netdev drivers, `ETHERNET_MAX_LEN` has to be used instead of ETHERNET_DATA_LEN for buffer sizes and length checks.

### Testing procedure

Compile and flash `examples/gnrc_networking` for `esp_wifi`
```
CFLAGS='-DESP_WIFI_SSID=\"<your SSID>\" -DESP_WIFI_PASS=\"your passphrase\"' \
USEMODULE="esp_wifi" make BOARD=esp32-wroom-32 -C examples/gnrc_networking flash
```
or `esp_eth`
```
USEMODULE="esp_wifi" make BOARD=esp32-olimex-evb -C examples/gnrc_networking flash
```
and ping a machine in your LAN from the ESP32 node, e.g.,
```
ping6 fe80::5ecf:7fff:fe80:3f08 1392
```
It should at least work with a ICMPv6 data size of 1392 bytes.

### Issues/PRs references

See also discussion in PR #10792 

