### PR TITLE
examples/bindist: cleanup and fix formatting in README

### DIFF
--- a/examples/bindist/README.md
+++ b/examples/bindist/README.md
@@ -20,20 +20,20 @@ compiled and linked binary, bindist.a, abc.a and Makefiles.
 In order to recompile RIOT, adjust "RIOTBASE" in Makefile to point to a RIOT
 source checkout, then call "make check_bindist".
 
-RIOT will be build as usual, but just take the pre-compiled bindist.a and
-abc.a.  Their source is not necessary.  The resulting binary will then be
-compared with te precompiled  "bindist.elf" (using md5sum) and the result gets
-printed.  If the same RIOT source tree and build environment (compiler version,
+RIOT will be built as usual, but just take the pre-compiled bindist.a and
+abc.a. Their source is not necessary. The resulting binary will then be
+compared with the precompiled "bindist.elf" (using md5sum) and the result gets
+printed. If the same RIOT source tree and build environment (compiler version,
 etc.) was used, the binaries should match.
 
 Step-by-step:
 
-1. # cd <riot-checkout>/examples/bindist
-2. # make all
-3. # make bindist
-4. # cd bindist
-5. <adjust RIOTBASE variable (../.. -> ../../..)
-6. # make check_bindist
+    $ cd <riot-checkout>/examples/bindist
+    $ make all
+    $ make bindist
+    $ cd bindist
+    <adjust RIOTBASE variable (../.. -> ../../..)
+    $ make check_bindist
 
 ## Needed Makefile changes
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is fixing a couple of typo and a formatting issue in the `examples/bindist` README.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Compare the README between [master](https://github.com/RIOT-OS/RIOT/tree/master/examples/bindist) and [this PR](https://github.com/aabadie/RIOT/tree/pr/examples/bindist_cleanup/examples/bindist).

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Found while answering to #10835 (same question was also asked by the same person on the users ML)

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
