### PR TITLE
dist/tools/compile_and_test_for_board: add basic checks for script

### DIFF
--- a/dist/tools/compile_and_test_for_board/.gitignore
+++ b/dist/tools/compile_and_test_for_board/.gitignore
@@ -1,0 +1,2 @@
+# tox envs directory
+.tox

--- a/dist/tools/compile_and_test_for_board/README.md
+++ b/dist/tools/compile_and_test_for_board/README.md
@@ -20,6 +20,20 @@ They can be checked with:
     find results/ -name '*.failed'
     find results/ -name 'test.success'
 
+Script checks
+-------------
+
+Use [tox](https://tox.readthedocs.io/en/latest/) to run basic checks on the
+script:
+
+    $ tox
+
+This runs doctest (via pytest), pylint and flake8 checks in a row.
+Use `-e` to run each check independently:
+
+    $ tox -e test
+    $ tox -e lint
+    $ tox -e flake8
 
 Implementation TODO
 -------------------
@@ -31,6 +45,6 @@ simply adapt to be used from within RIOT.
 * Provide a RIOT/Makefile integration
 * Save output files into `${BUILD_DIR}/output/compile_and_test` directory by
   default
-* tox file to run `doctests/pylint/flake8`. Add tests.
+* Add tests.
 * Implement the `board_is_supported`/`board_has_enough_memory`/`has_tests` to
   make targets instead of fiddling to get the value

--- a/dist/tools/compile_and_test_for_board/compile_and_test_for_board.py
+++ b/dist/tools/compile_and_test_for_board/compile_and_test_for_board.py
@@ -79,7 +79,7 @@ LOG_HANDLER.setFormatter(logging.Formatter(logging.BASIC_FORMAT))
 LOG_LEVELS = ('debug', 'info', 'warning', 'error', 'fatal', 'critical')
 
 
-class TestError(Exception):
+class ErrorInTest(Exception):
     """Custom exception for a failed test.
 
     It contains the step that failed in 'message', the 'application' and the
@@ -264,7 +264,7 @@ class RIOTApplication():
         try:
             self.compilation_and_test(**test_kwargs)
             return None
-        except TestError as err:
+        except ErrorInTest as err:
             self.logger.error('Failed during: %s', err)
             return (str(err), err.application.appdir, err.errorfile)
 
@@ -283,7 +283,7 @@ class RIOTApplication():
         succeeds.
 
         :param incremental: Do not rerun successful compilation and tests
-        :raises TestError: on execution failed during one step
+        :raises ErrorInTest: on execution failed during one step
         """
 
         # Ignore incompatible APPS
@@ -301,7 +301,7 @@ class RIOTApplication():
         create_directory(self.resultdir, clean=not incremental)
 
         # Run compilation and flash+test
-        # It raises TestError on error which is handled outside
+        # It raises ErrorInTest on error which is handled outside
 
         compilation_cmd = list(self.COMPILE_TARGETS)
         if jobs is not None:
@@ -415,7 +415,7 @@ class RIOTApplication():
 
         self.logger.warning(output)
         self.logger.error('Error during %s, writing to %s', name, outfile)
-        raise TestError(name, self, outfile)
+        raise ErrorInTest(name, self, outfile)
 
     def _write_resultfile(self, name, status, body=''):
         """Write `body` to result file `name.status`.

--- a/dist/tools/compile_and_test_for_board/tox.ini
+++ b/dist/tools/compile_and_test_for_board/tox.ini
@@ -1,0 +1,27 @@
+[tox]
+envlist = test,lint,flake8
+skipsdist = True
+
+[testenv]
+basepython = python3
+setenv =
+    script = compile_and_test_for_board.py
+commands =
+    test:       {[testenv:test]commands}
+    lint:       {[testenv:lint]commands}
+    flake8:     {[testenv:flake8]commands}
+
+[testenv:test]
+deps = pytest
+commands =
+    pytest -v --doctest-modules {env:script}
+
+[testenv:lint]
+deps = pylint
+commands =
+    pylint {env:script}
+
+[testenv:flake8]
+deps = flake8
+commands =
+    flake8 {env:script}


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is adding basic Python checks for the `compile_and_test_for_board.py` script. The checks are run using [Tox](https://tox.readthedocs.io/en/latest/). Performed are:
- doctest (via pytest)
- pylint
- flake8

To avoid issues with pytest automatic parsing, I renamed the `TestError` exception to `ErrorInTest`.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Install tox:

    pip install tox --user

- Use it:

    cd dist/tools/compile_and_test_for_board
    tox compile_and_test_for_board.py

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Follow-up of #10818 and idea suggested by @cladmi 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
