### PR TITLE
tools/compile_and_test_for_board.py: allow use of wildcards for applications selection

### DIFF
--- a/dist/tools/compile_and_test_for_board/compile_and_test_for_board.py
+++ b/dist/tools/compile_and_test_for_board/compile_and_test_for_board.py
@@ -108,6 +108,33 @@ class ErrorInTest(Exception):
         self.errorfile = errorfile
 
 
+def _expand_apps_directories(apps_dirs, riotdir, skip=False):
+    """Expand the list of applications using wildcards."""
+    # Get the full list of RIOT applications in riotdir
+    _riot_applications = _riot_applications_dirs(riotdir)
+
+    if apps_dirs is None:
+        if skip is True:
+            return []
+        return _riot_applications
+
+    ret = []
+    for app_dir in apps_dirs:
+        if os.path.isdir(app_dir):
+            # Case where the application directory exists: don't use globbing.
+            # the application directory can also be outside of riotdir and
+            # relative to it.
+            ret += [app_dir]
+        else:
+            ret += [
+                os.path.relpath(el, riotdir)
+                for el in glob.glob(os.path.join(riotdir, app_dir))
+                if os.path.relpath(el, riotdir) in _riot_applications
+            ]
+
+    return ret
+
+
 def apps_directories(riotdir, apps_dirs=None, apps_dirs_skip=None):
     """Return sorted list of test directories relative to `riotdir`.
 
@@ -617,9 +644,14 @@ def main():
     board = check_is_board(args.riot_directory, args.board)
     logger.debug('board: %s', board)
 
-    app_dirs = apps_directories(args.riot_directory,
-                                apps_dirs=args.applications,
-                                apps_dirs_skip=args.applications_exclude)
+    # Expand application directories: allows use of glob in application names
+    apps_dirs = _expand_apps_directories(args.applications,
+                                         args.riot_directory)
+    apps_dirs_skip = _expand_apps_directories(args.applications_exclude,
+                                              args.riot_directory, skip=True)
+
+    app_dirs = apps_directories(args.riot_directory, apps_dirs=apps_dirs,
+                                apps_dirs_skip=apps_dirs_skip)
 
     logger.debug('app_dirs: %s', app_dirs)
     logger.debug('resultdir: %s', args.result_directory)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This is adding the possibility to use wildcard to select multiple applications easily with `compile_and_test_for_board.py`. This is used with `--applications` and `--application-exclude` parameters

For the moment, one can only explicitly select a list of applications with `--applications="tests/shell tests/buttons"` but one can't easily select all applications in `tests`.

With this PR, one can do:

    compile_and_test_for_board.py --applications="tests/*" --applications-exclude="tests/xtimer* tests/pkg*" <riotbase> <board>

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Only build examples applications for native:

      compile_and_test_for_board.py --jobs=4 --applications="examples/*" <riotbase> native

- Only build `tests/shell` with test xtimer tests but without xtimer_usleep*:

      compile_and_test_for_board.py --jobs=4 --applications="tests/shell tests/xtimer*" --applications-exclude="tests/xtimer_usleep*" <riotbase> native

- One can also test the corner cases with only '*", for example, the following does nothing:

      compile_and_test_for_board.py --jobs=4 --applications="*" --applications-exclude="*" <riotbase> native


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Follow-up of #10837 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
