### PR TITLE
cpu/sam0_common: remove unneeded GCLK_SLOW setup in i2c driver

### DIFF
--- a/cpu/sam0_common/periph/i2c.c
+++ b/cpu/sam0_common/periph/i2c.c
@@ -92,23 +92,6 @@ void i2c_init(i2c_t dev)
 
     /* I2C using CLK GEN 0 */
     sercom_set_gen(bus(dev),i2c_config[dev].gclk_src);
-#if defined(CPU_FAM_SAML21) || defined(CPU_FAM_SAMR30)
-    /* GCLK_ID_SLOW is shared for SERCOM[0..4] */
-    GCLK->PCHCTRL[(sercom_id(bus(dev)) < 5 ?
-                  SERCOM0_GCLK_ID_SLOW : SERCOM5_GCLK_ID_SLOW)].reg =
-    (GCLK_PCHCTRL_CHEN | i2c_config[dev].gclk_src  );
-    while (GCLK->SYNCBUSY.bit.GENCTRL) {}
-#elif defined (CPU_SAML1X)
-    GCLK->PCHCTRL[SERCOM0_GCLK_ID_SLOW].reg = (GCLK_PCHCTRL_CHEN |
-                                              i2c_config[dev].gclk_src  );
-     while (GCLK->SYNCBUSY.bit.GENCTRL0) {}
-#else
-    /* GCLK_SERCOMx_SLOW is shared for all sercom */
-    GCLK->CLKCTRL.reg = (GCLK_CLKCTRL_CLKEN |
-                         i2c_config[dev].gclk_src |
-                         SERCOM0_GCLK_ID_SLOW);
-    while (GCLK->STATUS.bit.SYNCBUSY) {}
-#endif
 
     /* Check if module is enabled. */
     if (bus(dev)->CTRLA.reg & SERCOM_I2CM_CTRLA_ENABLE) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR removes the SERCOMx_GLCK_SLOW clock setup from the I2C driver.
According to [SAML21](http://ww1.microchip.com/downloads/en/DeviceDoc/60001477A.pdf), [SAMD21](http://ww1.microchip.com/downloads/en/DeviceDoc/SAMD21-Family-DataSheet-DS40001882D.pdf) and [SAML10](http://ww1.microchip.com/downloads/en/DeviceDoc/SAM-L10L11%20Family-DataSheet%20-%20DS60001513B.pdf) datasheets, this clock is used for SMBus timeouts features but RIOT doesn't use them at all. 
Look for `GCLK_SERCOM_SLOW` within the datasheet for more information.
In addition, this clock should be feed with 32kHz clock source not xx MHz (which is the case now)
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Pick the SAM0 board you want, play with any I2C sensors.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Found this while adding I2C support for SAML10/SAML11 in #10653 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
