### PR TITLE
make: test SERIAL for sam0 boards only if required

### DIFF
--- a/makefiles/boards/sam0.inc.mk
+++ b/makefiles/boards/sam0.inc.mk
@@ -1,6 +1,11 @@
 # set default port depending on operating system
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
+
+# check and set flash and debug parameters if required, only
+FLASH_DEBUG_GOALS := flash flash-only debug debug-server
+ifneq (, $(filter $(FLASH_DEBUG_GOALS), $(MAKECMDGOALS)))
+
 # Use DEBUG_ADAPTER_ID to specify the programmer serial number to use:
 # export DEBUG_ADAPTER_ID="ATML..."
 
@@ -39,3 +44,5 @@ endif
 
 # this board uses openocd for debug and possibly flashing
 include $(RIOTMAKE)/tools/openocd.inc.mk
+
+endif # FLASH_DEBUG_GOALS


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

If SERIAL is given as environment variable to the build/make system only
test/check the SERIAL if needed for certain make goals, i.e., flash,
flash-only, debug and debug-server. Otherwise ignore it and simply build.




### Testing procedure

as described in #10367 run following command on master and with this PR

```
make -C examples/hello-world BOARD=samr21-xpro SERIAL=ATML211234567
```

on master this will not build but fail, with this PR it builds as expected as SERIAL is not required and can be safely ignored.


### Issues/PRs references

fixes #10367