### PR TITLE
net/nanocoap: add debug message for server

### DIFF
--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -145,6 +145,9 @@ int nanocoap_server(sock_udp_ep_t *local, uint8_t *buf, size_t bufsize)
             if ((res = coap_handle_req(&pkt, buf, bufsize)) > 0) {
                 res = sock_udp_send(&sock, buf, res, &remote);
             }
+            else {
+                DEBUG("error handling request %d\n", (int)res);
+            }
         }
     }
 


### PR DESCRIPTION
### Contribution description
Adds a debug message to the nanocoap_server() function when the result of generating the response indicates an error has occurred.

### Testing procedure
You can add a failing handler function to the nanocoap_server example's coap_handler.c. For example:
```
static ssize_t _fail(coap_pkt_t *pkt, uint8_t *buf, size_t len, void *context)
{
    (void)pkt;
    (void)buf;
    (void)len;
    (void)context;
    return -1;
}
```
Also add _fail to the coap_resources array at the bottom of the file, for example as the resource `/fail`. Of course, you'll also want to enable debugging in sock.c. :-) 

Finally, start a couple of native instances -- nanocoap_server and gcoap. Then have the gcoap instance request the /fail resource from the nanocoap_server instance. In the nanocoap terminal you should see:
```
error handling request -1
```

### Issues/PRs references
-none-