### PR TITLE
boards: add support for kw41z-mini

### DIFF
--- a/boards/openlabs-kw41z-mini/Makefile
+++ b/boards/openlabs-kw41z-mini/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/openlabs-kw41z-mini/Makefile.dep
+++ b/boards/openlabs-kw41z-mini/Makefile.dep
@@ -1,0 +1,9 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_adc
+  USEMODULE += saul_gpio
+endif
+
+# TODO uncomment after #12277 (add support for kw41zrf) is merged
+# ifneq (,$(filter netdev_default gnrc_netdev_default,$(USEMODULE)))
+#   USEMODULE += kw41zrf
+# endif

--- a/boards/openlabs-kw41z-mini/Makefile.features
+++ b/boards/openlabs-kw41z-mini/Makefile.features
@@ -1,0 +1,15 @@
+CPU = kinetis
+CPU_MODEL = mkw41z512vht4
+
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_dac
+FEATURES_PROVIDED += periph_i2c
+# TODO uncomment this after Kinetis PWM support is merged
+# FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_rtt
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += riotboot

--- a/boards/openlabs-kw41z-mini/Makefile.include
+++ b/boards/openlabs-kw41z-mini/Makefile.include
@@ -1,0 +1,17 @@
+# Configure riotboot bootloader and slot lengths.
+RIOTBOOT_LEN ?= 0x4000
+NUM_SLOTS ?= 2
+SLOT0_LEN ?= 0x3C000
+SLOT1_LEN ?= $(SLOT0_LEN)
+
+# support SWD and UART via Pi GPIO header
+PORT_LINUX ?= /dev/serial0
+# TODO change to bcm2835gpio after it's merged as it's faster
+# DEBUG_ADAPTER ?= bcm2835gpio
+DEBUG_ADAPTER ?= sysfs_gpio
+SRST_PIN ?= 16
+SWCLK_PIN ?= 20
+SWDIO_PIN ?= 21
+
+# Include default FRDM board config for openocd configuration
+include $(RIOTBOARD)/common/frdm/Makefile.include

--- a/boards/openlabs-kw41z-mini/board.c
+++ b/boards/openlabs-kw41z-mini/board.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2017 Thomas Stilwell <stilwellt@openlabs.co>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     boards_openlabs-kw41z-mini
+ * @{
+ *
+ * @file
+ * @brief       Board specific initialization for openlabs-kw41z-mini
+ *
+ * @author      Thomas Stilwell <stilwellt@openlabs.co>
+ *
+ * @}
+ */
+
+#include "board.h"
+#include "periph/rtc.h"
+#include "periph/gpio.h"
+
+void board_init(void)
+{
+    /* initialize the CPU core */
+    cpu_init();
+
+    /* initialize and turn off LEDs */
+    LED0_OFF;
+    gpio_init(LED0_PIN, GPIO_OUT);
+
+    /* enable OSCERCLK output on PTB3 */
+#if PTB3_OUTPUT_OSCERCLK
+    SIM->SOPT2 |= SIM_SOPT2_CLKOUTSEL(0b110);
+    gpio_init_port(GPIO_PIN(PORT_B,  3), PORT_PCR_MUX(4));
+
+    /* enable 32KHz oscillator output on PTB3 */
+#elif PTB3_OUTPUT_OSC32K
+    SIM->SOPT1 |= SIM_SOPT1_OSC32KOUT_MASK;
+#endif
+}

--- a/boards/openlabs-kw41z-mini/doc.txt
+++ b/boards/openlabs-kw41z-mini/doc.txt
@@ -1,0 +1,100 @@
+/**
+@defgroup    boards_openlabs-kw41z-mini openlabs.co kw41z-mini board
+@ingroup     boards
+@brief       Support for openlabs-kw41z-mini
+
+ ### General information
+
+This is an open-source development board shipped by openlabs.co with
+source files located at https://openlabs.co/OSHW/kw41z-mini
+
+A driver for the radio transceiver is available in #12277 (802.15.4 only).
+
+
+### Programming Pinout
+
+Programming and debugging can be done with a Raspberry Pi (or equivalent)
+running OpenOCD.
+
+
+    Pi GPIO Pins       kw41z-mini
+ ====================================
+                  ||
+    GPIO_19 ------||------- RST
+                  ||
+    GPIO_20 ------||------- SWDCLK
+                  ||
+    GPIO_21 ------||------- SWDIO
+                  ||
+      3.3V -------||------- 3.3V
+                  ||
+       GND -------||------- GND
+                  ||
+
+
+### Compiling and Flashing
+
+# install build deps for openocd
+apt install git build-essential libtool automake
+# fetch and build openocd with support for JTAG via RPi or generic GPIO
+git clone https://github.com/beduino-project/openocd.git
+cd openocd
+./bootstrap
+./configure --enable-bcm2835gpio --enable-sysfsgpio
+make -j4 && sudo make install
+
+# install arm toolchain
+apt install git gcc-arm-none-eabi gdb-arm-none-eabi
+# fetch Riot
+git clone https://github.com/RIOT-OS/RIOT.git
+# build and flash the gnrc_networking example
+cd RIOT/examples/gnrc_networking
+BOARD=openlabs-kw41z-mini CFLAGS+="-DKW41ZRF_ENABLE_LEDS=1" make -j4 flash
+
+
+### Debug Uart Pinout
+
+It is also possible to use the Pi for connecting to the debug uart.
+
+
+    Pi GPIO Pins     kw41z-mini
+ ==================================
+                 ||
+     UART TX ----||------ RXI
+                 ||
+     UART RX ----||------ TXO
+                 ||
+       GND ------||------ GND
+                 ||
+
+
+# enable the uart on the Pi
+echo "enable_uart=1" >> /boot/config.txt
+reboot
+# install serial terminal
+apt install picocom
+# run serial terminal to access debug uart
+picocom -b115200 /dev/serial0
+
+
+It is recommended (if possible) to switch the Pi to the better-clocked
+uart for higher baud rates:
+
+echo "dtoverlay=disable-bt" >> /boot/config.txt
+reboot
+
+
+### Notes
+
+To get a working radio, add #12277 and uncomment the lines in
+boards/openlabs-kw41z-mini/Makefile.dep
+
+The DAC output is on pin PTB18.
+
+ADC input A3 needs a hack applied to cpu/kinetis/periph/adc.c to remove
+ADC_CFG2_MUXSEL_MASK from CFG2 to switch to the correct mux setting.
+
+The PWM peripheral on this board isn't supported in the Kinetis PWM driver yet.
+
+Use external I2C pullup resistors if I2C is used.
+ */

--- a/boards/openlabs-kw41z-mini/include/adc_params.h
+++ b/boards/openlabs-kw41z-mini/include/adc_params.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2017 Thomas Stilwell <stilwellt@openlabs.co>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   boards_openlabs-kw41z-mini
+ * @{
+ *
+ * @file
+ * @brief     Board specific configuration of direct mapped ADC
+ *
+ * @author    Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ * @author    Thomas Stilwell <stilwellt@openlabs.co>
+ */
+
+#ifndef ADC_PARAMS_H
+#define ADC_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    ADC configuration
+ */
+static const saul_adc_params_t saul_adc_params[] =
+{
+    {
+        .name = "A0",
+        .line = ADC_LINE(0),
+        .res  = ADC_RES_16BIT,
+    },
+    {
+        .name = "A1",
+        .line = ADC_LINE(1),
+        .res  = ADC_RES_16BIT,
+    },
+        {
+        .name = "A2",
+        .line = ADC_LINE(2),
+        .res  = ADC_RES_16BIT,
+    },
+        {
+        .name = "A3",
+        .line = ADC_LINE(3),
+        .res  = ADC_RES_16BIT,
+    },
+    {
+        .name = "coretemp",
+        .line = ADC_LINE(4),
+        .res  = ADC_RES_16BIT,
+    },
+    {
+        .name = "corebandgap",
+        .line = ADC_LINE(5),
+        .res  = ADC_RES_16BIT,
+    },
+    {
+        .name = "dcdcvbat",
+        .line = ADC_LINE(6),
+        .res  = ADC_RES_16BIT,
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ADC_PARAMS_H */
+/** @} */

--- a/boards/openlabs-kw41z-mini/include/board.h
+++ b/boards/openlabs-kw41z-mini/include/board.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2017 Thomas Stilwell <stilwellt@openlabs.co>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     boards_openlabs-kw41z-mini
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for openlabs-kw41z-mini
+ *
+ * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ * @author      Thomas Stilwell <stilwellt@openlabs.co>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+#include "periph_conf.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*
+ * NMI shares a pin with DAC output and ADC input. Holding the pin low during
+ * reset will cause a hang unless NMI is disabled. It can be enabled in
+ * applications where the pin is not held low during reset.
+ */
+#define KINETIS_FOPT 0xFB /* disable NMI (0xFF to enable) */
+
+/**
+ * @name   LED pin definitions and handlers
+ * @{
+ */
+#define LED0_PIN           GPIO_PIN(PORT_B,  0)
+#define LED0_MASK          (1 << 0)
+#define LED0_ON            (GPIOB->PCOR = LED0_MASK)
+#define LED0_OFF           (GPIOB->PSOR = LED0_MASK)
+#define LED0_TOGGLE        (GPIOB->PTOR = LED0_MASK)
+/** @} */
+
+/**
+ * @name    xtimer configuration
+ * @{
+ */
+#if KINETIS_XTIMER_SOURCE_PIT
+/* PIT xtimer configuration */
+#define XTIMER_DEV                  (TIMER_PIT_DEV(0))
+#define XTIMER_CHAN                 (0)
+/* Default xtimer settings should work on the PIT */
+#else
+/* LPTMR xtimer configuration */
+#define XTIMER_DEV                  (TIMER_LPTMR_DEV(0))
+#define XTIMER_CHAN                 (0)
+/* LPTMR is 16 bits wide and runs at 32768 Hz (clocked by the RTC) */
+#define XTIMER_WIDTH                (16)
+#define XTIMER_BACKOFF              (16)
+#define XTIMER_ISR_BACKOFF          (5)
+#define XTIMER_HZ                   (32768ul)
+#endif
+/** @} */
+
+/**
+ * @def     PTB3_OUTPUT_OSC32K
+ *
+ * @brief   Enable LF oscillator output on PTB3 to aid debugging or calibration
+ */
+#ifndef PTB3_OUTPUT_OSC32K
+#define PTB3_OUTPUT_OSC32K          (0)
+#endif
+
+/**
+ * @def     PTB3_OUTPUT_OSCERCLK
+ *
+ * @brief   Enable HF oscillator output on PTB3 to aid debugging or calibration
+ */
+#ifndef PTB3_OUTPUT_OSCERCLK
+#define PTB3_OUTPUT_OSCERCLK        (0)
+#endif
+
+/**
+ * @brief Initialize board-specific hardware, including clock, LEDs, and stdio
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/openlabs-kw41z-mini/include/gpio_params.h
+++ b/boards/openlabs-kw41z-mini/include/gpio_params.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2017 Thomas Stilwell <stilwellt@openlabs.co>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   boards_openlabs-kw41z-mini
+ * @{
+ *
+ * @file
+ * @brief     Board specific configuration of direct mapped GPIOs
+ *
+ * @author    Thomas Stilwell <stilwellt@openlabs.co>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    SAUL configuration
+ */
+static const saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "LED",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/openlabs-kw41z-mini/include/periph_conf.h
+++ b/boards/openlabs-kw41z-mini/include/periph_conf.h
@@ -1,0 +1,363 @@
+/*
+ * Copyright (C) 2017 Thomas Stilwell <stilwellt@openlabs.co>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     boards_openlabs-kw41z-mini
+ * @{
+ *
+ * @file
+ * @name        Peripheral MCU configuration for openlabs-kw41z-mini
+ *
+ * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ * @author      Thomas Stilwell <stilwellt@openlabs.co>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/**
+ * @name Clock system configuration
+ * @{
+ */
+static const clock_config_t clock_config = {
+    /*
+     * This configuration results in the system running with the internal clock
+     * with the following clock frequencies:
+     * Core:  48 MHz
+     * Bus:   24 MHz
+     * Flash: 24 MHz
+     */
+
+    .clkdiv1            = SIM_CLKDIV1_OUTDIV1(0) | SIM_CLKDIV1_OUTDIV4(1),
+    .rtc_clc            = RTC_CR_SC16P_MASK | RTC_CR_SC4P_MASK | RTC_CR_SC2P_MASK,
+
+    /* Use the 32 kHz oscillator as ERCLK32K. Note that the values here have a
+     * different mapping for the KW41Z than the values used in the Kinetis
+     * K series */
+    .osc32ksel          = SIM_SOPT1_OSC32KSEL(0),
+
+    /* enable clocks */
+    .clock_flags =
+        KINETIS_CLOCK_OSC0_EN | /* Enable RSIM oscillator */
+        KINETIS_CLOCK_RTCOSC_EN |
+        KINETIS_CLOCK_USE_FAST_IRC |
+        KINETIS_CLOCK_MCGIRCLK_EN | /* Used for LPUART clocking */
+        KINETIS_CLOCK_MCGIRCLK_STOP_EN |
+        0,
+
+    /* Using FEI mode by default, the external crystal settings below are only
+     * used if mode is changed to an external mode (PEE, FBE, or FEE) */
+    .default_mode       = KINETIS_MCG_MODE_FEI,
+
+    /* The crystal connected to RSIM OSC is 32 MHz */
+    .erc_range          = KINETIS_MCG_ERC_RANGE_VERY_HIGH,
+
+    .osc_clc            = 0, /* not used by kw41z */
+    .oscsel             = MCG_C7_OSCSEL(0), /* Use RSIM for external clock */
+    .fcrdiv             = MCG_SC_FCRDIV(0), /* Fast IRC divide by 1 => 4 MHz */
+
+    .fll_frdiv          = MCG_C1_FRDIV(0b101), /* Divide by 1024 */
+    .fll_factor_fei     = KINETIS_MCG_FLL_FACTOR_1464, /* FEI FLL freq = 48 MHz */
+    .fll_factor_fee     = KINETIS_MCG_FLL_FACTOR_1280, /* FEE FLL freq = 40 MHz */
+};
+/* Radio xtal frequency, either 32 MHz or 26 MHz */
+#define CLOCK_RADIOXTAL              (32000000ul)
+/* CPU core clock, the MCG clock output frequency */
+#define CLOCK_CORECLOCK              (48000000ul)
+#define CLOCK_BUSCLOCK               (CLOCK_CORECLOCK / 2)
+#define CLOCK_MCGFLLCLK              (CLOCK_CORECLOCK)
+#define CLOCK_OSCERCLK               (CLOCK_RADIOXTAL)
+#define CLOCK_MCGIRCLK               (4000000ul)
+/** @} */
+
+/**
+ * @name Timer configuration
+ * @{
+ */
+#define PIT_NUMOF               (1U)
+#define PIT_CONFIG {                 \
+        {                            \
+            .prescaler_ch = 0,       \
+            .count_ch = 1,           \
+        },                           \
+    }
+#define LPTMR_NUMOF             (1U)
+#define LPTMR_CONFIG {               \
+        {                            \
+            .dev = LPTMR0,           \
+            .base_freq = 32768u,     \
+            .src = 2,                \
+            .irqn = LPTMR0_IRQn,     \
+        },                           \
+    }
+#define TIMER_NUMOF             ((PIT_NUMOF) + (LPTMR_NUMOF))
+#define PIT_BASECLOCK           (CLOCK_BUSCLOCK)
+#define LPTMR_ISR_0             isr_lptmr0
+/** @} */
+
+/**
+ * @name UART configuration
+ * @{
+ */
+#ifndef LPUART_0_SRC
+#define LPUART_0_SRC                1
+#endif
+
+#if (LPUART_0_SRC == 3)
+/* Use MCGIRCLK (4 MHz internal reference - not available in KINETIS_PM_LLS) */
+#define LPUART_0_CLOCK                  CLOCK_MCGIRCLK
+#define UART_CLOCK_PM_BLOCKER           KINETIS_PM_LLS
+#define UART_MAX_UNCLOCKED_BAUDRATE     19200ul
+#elif (LPUART_0_SRC == 2)
+#define LPUART_0_CLOCK                  CLOCK_OSCERCLK
+#elif (LPUART_0_SRC == 1)
+/* Use CLOCK_MCGFLLCLK (48 MHz FLL output - not available in KINETIS_PM_STOP) */
+#define LPUART_0_CLOCK                  CLOCK_MCGFLLCLK
+#define UART_CLOCK_PM_BLOCKER           KINETIS_PM_STOP
+#define UART_MAX_UNCLOCKED_BAUDRATE     57600ul
+#endif
+
+static const uart_conf_t uart_config[] = {
+    {
+        .dev    = LPUART0,
+        .freq   = LPUART_0_CLOCK,
+        .pin_rx = GPIO_PIN(PORT_C,  6),
+        .pin_tx = GPIO_PIN(PORT_C,  7),
+        .pcr_rx = PORT_PCR_MUX(4) | GPIO_IN_PU,
+        .pcr_tx = PORT_PCR_MUX(4),
+        .irqn   = LPUART0_IRQn,
+        .scgc_addr = &SIM->SCGC5,
+        .scgc_bit = SIM_SCGC5_LPUART0_SHIFT,
+        .mode   = UART_MODE_8N1,
+        .type   = KINETIS_LPUART,
+#ifdef MODULE_PERIPH_LLWU /* TODO remove ifdef after #11789 is merged */
+        .llwu_rx = LLWU_WAKEUP_PIN_PTC6,
+#endif
+    },
+};
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
+#define LPUART_0_ISR        isr_lpuart0
+/** @} */
+
+/**
+ * @name ADC configuration
+ * @{
+ */
+static const adc_conf_t adc_config[] = {
+    /* ADC0_SE1 A0 */
+    [0] = { .dev = ADC0, .pin = GPIO_PIN(PORT_B,  1),  .chan = 1, .avg = ADC_AVG_MAX },
+    /* ADC0_SE2 A1 */
+    [1] = { .dev = ADC0, .pin = GPIO_PIN(PORT_B,  2),  .chan = 3, .avg = ADC_AVG_MAX },
+    /* ADC0_SE3 A2 */
+    [2] = { .dev = ADC0, .pin = GPIO_PIN(PORT_B,  3),  .chan = 2, .avg = ADC_AVG_MAX },
+    /* ADC0_SE4 A3 */
+    [3] = { .dev = ADC0, .pin = GPIO_PIN(PORT_B,  18), .chan = 4, .avg = ADC_AVG_MAX },
+
+    /* internal: temperature sensor */
+    /* The temperature sensor has a very high output impedance, it must not be
+     * sampled using hardware averaging, or the sampled values will be garbage */
+    [4] = { .dev = ADC0, .pin = GPIO_UNDEF, .chan = 26, .avg = ADC_AVG_NONE },
+    /* internal: band gap */
+    /* Note: the band gap buffer uses a bit of current and is turned off
+     * by default,
+     * Set PMC->REGSC |= PMC_REGSC_BGBE_MASK before reading or the input will
+     * be floating */
+    [5] = { .dev = ADC0, .pin = GPIO_UNDEF, .chan = 27, .avg = ADC_AVG_MAX },
+    /* internal: DCDC divided battery level */
+    [6] = { .dev = ADC0, .pin = GPIO_UNDEF, .chan = 23, .avg = ADC_AVG_MAX },
+};
+
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
+/*
+ * KW41Z ADC reference settings:
+ * 0: VREFH external pin or VREF_OUT 1.2 V signal (if VREF module is enabled)
+ * 1: VDDA (analog supply input voltage)
+ * 2-3: reserved
+ */
+#define ADC_REF_SETTING     1
+#if ADC_REF_SETTING
+#define ADC_REF_VOLTAGE     (3.3f)
+#else
+#define ADC_REF_VOLTAGE     (1.2f)
+#endif
+
+#define ADC_TEMPERATURE_CHANNEL     (4)
+/** @} */
+
+/**
+ * @name   DAC configuration
+ * @{
+ */
+static const dac_conf_t dac_config[] = {
+    {
+        /* PTB18 | ADC0_SE4 | A3 */
+        .dev       = DAC0,
+        .scgc_addr = &SIM->SCGC6,
+        .scgc_bit  = SIM_SCGC6_DAC0_SHIFT,
+    },
+};
+
+#define DAC_NUMOF           ARRAY_SIZE(dac_config)
+/** @} */
+
+/**
+ * @name   PWM mode configuration
+ * @{
+ */
+#define HAVE_PWM_MODE_T
+typedef enum {
+    PWM_LEFT   = (TPM_CnSC_MSB_MASK | TPM_CnSC_ELSB_MASK),  /**< left aligned */
+    PWM_RIGHT  = (TPM_CnSC_MSB_MASK | TPM_CnSC_ELSA_MASK),  /**< right aligned */
+    PWM_CENTER = (TPM_CnSC_MSB_MASK)                        /**< center aligned */
+} pwm_mode_t;
+
+/**
+ * @brief   PWM configuration structure
+ */
+#define PWM_CHAN_MAX        (4U)
+typedef struct {
+    TPM_Type *tpm;          /**< used TPM */
+    struct {
+        gpio_t pin;         /**< GPIO pin used, set to GPIO_UNDEF */
+        uint8_t af;         /**< alternate function mapping */
+        uint8_t ftm_chan;   /**< the actual FTM channel used */
+    } chan[PWM_CHAN_MAX];   /**< logical channel configuration */
+    uint8_t chan_numof;     /**< number of actually configured channels */
+    uint8_t tpm_num;        /**< FTM number used */
+} pwm_conf_t;
+
+/**
+ * @name    PWM configuration
+ * @{
+ */
+static const pwm_conf_t pwm_config[] = {
+    {
+        .tpm        = TPM0,
+        .chan       = {
+            { .pin = GPIO_PIN(PORT_B, 0), .af = 5, .ftm_chan = 1 }
+        },
+        .chan_numof = 1,
+        .tpm_num    = 0
+    },
+    {
+        .tpm        = TPM1,
+        .chan       = {
+            { .pin = GPIO_PIN(PORT_C, 4), .af = 5, .ftm_chan = 0 }
+        },
+        .chan_numof = 1,
+        .tpm_num    = 1
+    }
+};
+
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
+/** @} */
+
+/**
+ * @name   SPI configuration
+ *
+ * Clock configuration values based on the configured 16Mhz module clock.
+ *
+ * Auto-generated by:
+ * cpu/kinetis/dist/calc_spi_scalers/calc_spi_scalers.c
+ *
+ * @{
+ */
+static const uint32_t spi_clk_config[] = {
+    (
+        SPI_CTAR_PBR(2) | SPI_CTAR_BR(5) |          /* -> 100000Hz */
+        SPI_CTAR_PCSSCK(2) | SPI_CTAR_CSSCK(4) |
+        SPI_CTAR_PASC(2) | SPI_CTAR_ASC(4) |
+        SPI_CTAR_PDT(2) | SPI_CTAR_DT(4)
+    ),
+    (
+        SPI_CTAR_PBR(2) | SPI_CTAR_BR(3) |          /* -> 400000Hz */
+        SPI_CTAR_PCSSCK(2) | SPI_CTAR_CSSCK(2) |
+        SPI_CTAR_PASC(2) | SPI_CTAR_ASC(2) |
+        SPI_CTAR_PDT(2) | SPI_CTAR_DT(2)
+    ),
+    (
+        SPI_CTAR_PBR(0) | SPI_CTAR_BR(3) |          /* -> 1000000Hz */
+        SPI_CTAR_PCSSCK(0) | SPI_CTAR_CSSCK(3) |
+        SPI_CTAR_PASC(0) | SPI_CTAR_ASC(3) |
+        SPI_CTAR_PDT(0) | SPI_CTAR_DT(3)
+    ),
+    (
+        SPI_CTAR_PBR(0) | SPI_CTAR_BR(0) |          /* -> 4000000Hz */
+        SPI_CTAR_PCSSCK(0) | SPI_CTAR_CSSCK(1) |
+        SPI_CTAR_PASC(0) | SPI_CTAR_ASC(1) |
+        SPI_CTAR_PDT(0) | SPI_CTAR_DT(1)
+    ),
+    (
+        SPI_CTAR_PBR(0) | SPI_CTAR_BR(0) |          /* -> 4000000Hz */
+        SPI_CTAR_PCSSCK(0) | SPI_CTAR_CSSCK(0) |
+        SPI_CTAR_PASC(0) | SPI_CTAR_ASC(0) |
+        SPI_CTAR_PDT(0) | SPI_CTAR_DT(0)
+    )
+};
+
+static const spi_conf_t spi_config[] = {
+    {
+        .dev      = SPI0,
+        .pin_miso = GPIO_PIN(PORT_C, 18),
+        .pin_mosi = GPIO_PIN(PORT_C, 17),
+        .pin_clk  = GPIO_PIN(PORT_C, 16),
+        .pin_cs   = {
+            GPIO_PIN(PORT_C, 19),
+            GPIO_UNDEF,
+            GPIO_UNDEF,
+            GPIO_UNDEF,
+            GPIO_UNDEF
+        },
+        .pcr      = (gpio_pcr_t)(GPIO_AF_2 | GPIO_IN_PU),
+        .simmask  = SIM_SCGC6_SPI0_MASK
+    },
+};
+
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
+/** @} */
+
+/**
+ * @name I2C configuration
+ * @{
+ */
+static const i2c_conf_t i2c_config[] = {
+    {
+        .i2c = I2C1,
+        .scl_pin = GPIO_PIN(PORT_C, 2),
+        .sda_pin = GPIO_PIN(PORT_C, 3),
+        .freq = CLOCK_CORECLOCK,
+        .speed = I2C_SPEED_FAST,
+        .irqn = I2C1_IRQn,
+        .scl_pcr = (PORT_PCR_MUX(3)),
+        .sda_pcr = (PORT_PCR_MUX(3)),
+    },
+};
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
+#define I2C_0_ISR           (isr_i2c1)
+/** @} */
+
+/**
+ * @name Random Number Generator configuration
+ * @{
+ */
+#define KINETIS_TRNG                TRNG
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/tests/periph_timer/Makefile
+++ b/tests/periph_timer/Makefile
@@ -16,6 +16,7 @@ BOARDS_TIMER_32kHz := \
     hifive1 \
     hifive1b \
     %-kw41z \
+    openlabs-kw41z-mini \
     frdm-k64f \
     frdm-k22f \
     #


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This adds support for [kw41z-mini](https://openlabs.co/OSHW/kw41z-mini). It's much the same as frdm-kw41z except it has half the memory and no dcdc. Also no load caps on the crystals. I plan to be making them regularly unless the stm32wb ends up being a much better chip.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

### Testing procedure
Radio support needs #7107 

Everything I've tested seems to be working. I haven't taken a close look at low power modes yet (with #7897) aside from getting down to about 5uA and being unable to wake afterwards. I didn't pursue it further but I plan to soonish.

I just realized I've never tested I2C and I don't have anything handy to test with, but if it works on frdm-kw41z then it must work on kw41z-mini because they use the same I2C pins and I copied and pasted the I2C configuration.

Tested:
- [x] ADC
- [x] DAC
- [x] GPIO
- [x] SPI
- [x] I2C
- [x] RTC
- [x] networking (with #7107)


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Continuing the discussion from #9934, I don't see much room for combining common kw41z files. The only things I see that could be picked out are timer and xtimer configurations and `spi_clk_config`, but I don't know that it's worth it for that and there can be valid reasons for a board to change the timer.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
