### PR TITLE
net/netreg: fix static netreg init macros

### DIFF
--- a/sys/include/net/gnrc/netreg.h
+++ b/sys/include/net/gnrc/netreg.h
@@ -107,15 +107,15 @@ typedef enum {
  *
  * @param[in] demux_ctx The @ref gnrc_netreg_entry_t::demux_ctx "demux context"
  *                      for the netreg entry
- * @param[in] mbox      Target @ref core_mbox "mailbox" for the registry entry
+ * @param[in] _mbox      Target @ref core_mbox "mailbox" for the registry entry
  *
  * @note    Only available with @ref net_gnrc_netapi_mbox.
  *
  * @return  An initialized netreg entry
  */
-#define GNRC_NETREG_ENTRY_INIT_MBOX(demux_ctx, mbox) { NULL, demux_ctx, \
+#define GNRC_NETREG_ENTRY_INIT_MBOX(demux_ctx, _mbox) { NULL, demux_ctx, \
                                                        GNRC_NETREG_TYPE_MBOX, \
-                                                       { .mbox = mbox } }
+                                                       { .mbox = _mbox } }
 #endif
 
 #if defined(MODULE_GNRC_NETAPI_CALLBACKS) || defined(DOXYGEN)
@@ -124,15 +124,15 @@ typedef enum {
  *
  * @param[in] demux_ctx The @ref gnrc_netreg_entry_t::demux_ctx "demux context"
  *                      for the netreg entry
- * @param[in] cbd       Target callback for the registry entry
+ * @param[in] _cbd       Target callback for the registry entry
  *
  * @note    Only available with @ref net_gnrc_netapi_callbacks.
  *
  * @return  An initialized netreg entry
  */
-#define GNRC_NETREG_ENTRY_INIT_CB(demux_ctx, cbd)   { NULL, demux_ctx, \
+#define GNRC_NETREG_ENTRY_INIT_CB(demux_ctx, _cbd)   { NULL, demux_ctx, \
                                                       GNRC_NETREG_TYPE_CB, \
-                                                      { .cbd = cbd } }
+                                                      { .cbd = _cbd } }
 /** @} */
 
 /**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR fixes GNRC_NETREG_ENTRY_INIT_MBOX and GNRC_NETREG_ENTRY_INIT_CB macros.

These were defined like this:
```c
#define GNRC_NETREG_ENTRY_INIT_MBOX(demux_ctx, mbox) { NULL, demux_ctx, \
                                                       GNRC_NETREG_TYPE_MBOX, \
                                                       { .mbox = mbox } }
/* ... */
#define GNRC_NETREG_ENTRY_INIT_CB(demux_ctx, cbd)   { NULL, demux_ctx, \
                                                      GNRC_NETREG_TYPE_CB, \
                                                      { .cbd = cbd } }
```

This means GNRC_NETREG_ENTRY_INIT_CB(demux_ctx, my_cbd) will resolve to:
```c
{ NULL, demux_ctx, \
                                                      GNRC_NETREG_TYPE_CB, \
                                                      { .my_cbd = my_cbd } }
```

This PR adds an underscore to `mbox` and `cbd` so the macro resolves correctly.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Try to create a static netreg entry with GNRC_NETREG_ENTRY_INIT_MBOX or GNRC_NETREG_ENTRY_INIT_CB avoiding `mbox` and `cbd` keywords in params (e.g use `test_mbox` or `test_cbd`)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None so far
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
