### PR TITLE
boards/phynode-kw41z:enable support for cc811 sensor

### DIFF
--- a/boards/phynode-kw41z/Makefile.dep
+++ b/boards/phynode-kw41z/Makefile.dep
@@ -1,6 +1,9 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
   USEMODULE += saul_adc
+  USEMODULE += ccs811
+  USEMODULE += mma8x5x
+  USEMODULE += tcs37727
 endif
 
 include $(RIOTCPU)/kinetis/Makefile.dep

--- a/boards/phynode-kw41z/board.c
+++ b/boards/phynode-kw41z/board.c
@@ -45,4 +45,11 @@ void board_init(void)
     gpio_init(LED3_PIN, GPIO_OUT);
     gpio_set(LED3_PIN);
 #endif
+/* If further modules are supported (e.g. HDC1010 sensor or the EPD) they have
+ * to be added here so V_PERIPH pin is set and the devices are powered */
+#if defined(MODULE_MMA8X5X) || defined(MODULE_TCS37727) || \
+    defined(MODULE_CCS811)
+    gpio_init(V_PERIPH_PIN, GPIO_OUT);
+    gpio_set(V_PERIPH_PIN);
+#endif
 }

--- a/boards/phynode-kw41z/doc.txt
+++ b/boards/phynode-kw41z/doc.txt
@@ -13,7 +13,8 @@ It provides a radio device with Bluetooth Low Energy and/or IEEE
 802.15.4.
 
 There's also available an HDL1010 High Accuracy Digital Humidity sensor, a
-CCS811 IAQ gas sensor and a TCS37727 RGB Light sensor.
+CCS811 IAQ gas sensor, a MMA8652FC accelerometer and a TCS37727 RGB Light
+sensor.
 
 There board also provides an SSD1673 Active Matrix EPD 150x200 Display Driver
  with Controller on board.
@@ -35,11 +36,10 @@ To flash the board using OpenOCD:
 
 ### Current support
 
-Only the TCS37727 RGB Light sensor is supported. There's ongoing work
-on [IEEE802.15.4 radio support for KW41Z][radio-support] and
-[CCS811 gas sensor][gas-sensor]
+The TCS37727 RGB Light sensor, the MMA8652FC accelerometer and the CCS811
+digital gas sensor are supported. There's ongoing work on
+[IEEE802.15.4 radio support for KW41Z][radio-support]
 
 [radio-support]: https://github.com/RIOT-OS/RIOT/pull/7107
-[gas-sensor]: https://github.com/RIOT-OS/RIOT/pull/10033
 
  */

--- a/boards/phynode-kw41z/include/board.h
+++ b/boards/phynode-kw41z/include/board.h
@@ -74,6 +74,16 @@ extern "C"
 /** @} */
 
 /**
+ * @name    Sensors voltage pin definitions (V_PERIPH)
+ * @{
+ */
+#define V_PERIPH_PIN        GPIO_PIN(PORT_C, 19)
+#define V_PERIPH_MASK       (1 << 19)
+#define V_PERIPH_ON         (GPIOC->PSOR = V_PERIPH_MASK)
+#define V_PERIPH_OFF        (GPIOC->PCOR = V_PERIPH_MASK)
+/** @} */
+
+/**
  * @name    xtimer configuration
  * @{
  */
@@ -93,6 +103,34 @@ extern "C"
 #define XTIMER_OVERHEAD             (4)
 #define XTIMER_HZ                   (32768ul)
 #endif
+/** @} */
+
+/**
+ * @name Define the interface for the CCS811 gas sensors
+ * @{
+ */
+#define CCS811_PARAM_I2C_DEV        (I2C_DEV(0))
+#define CCS811_PARAM_I2C_ADDR       (0x5A)
+#define CCS811_PARAM_RESET_PIN      (GPIO_UNDEF)
+#define CCS811_PARAM_WAKE_PIN       (GPIO_PIN(1, 2))
+#define CCS811_PARAM_INT_PIN        (GPIO_PIN(1, 3))
+#define CCS811_PARAM_INT_MODE       (CCS811_INT_NONE)
+/** @} */
+
+/**
+ * @name Define the interface for the TCS37727 RGB light sensor
+ * @{
+ */
+#define TCS37727_PARAM_I2C          (I2C_DEV(0))
+#define TCS37727_PARAM_ADDR         (0x29)
+/** @} */
+
+/**
+ * @name Define the interface for the MMA8X5X accelerometer
+ * @{
+ */
+#define MMA8X5X_PARAM_I2C           (I2C_DEV(0))
+#define MMA8X5X_PARAM_ADDR          (0x1D)
 /** @} */
 
 /**


### PR DESCRIPTION
### Contribution description

Since #10033 already got merged by the end of '18, I've added a configuration for this gas sensor to the recent PHYTEC node (`phynode-kw41z`). Schematics of that board can be found [here](https://www.phytec.eu/fileadmin/user_upload/images/content/1.Products/IoT/PN-02218-A-001.A0-1490-1-001.pdf). Additionally, I removed the WIP text in the boards documentation. 

Unfortunately I can not yet flash this device to run tests myself.

### Testing procedure
- Run *tests/driver_ccs811* on the respective board and see that it works as expected
- Run *examples/default* on the respective board and see that the CCS811 device appears and gives reasonable results.


### Issues/PRs references
 #10033,  #10600
