### PR TITLE
jlink.sh: wait for rtt server to start

### DIFF
--- a/dist/tools/jlink/jlink.sh
+++ b/dist/tools/jlink/jlink.sh
@@ -62,7 +62,8 @@ _JLINK_IF=SWD
 _JLINK_SPEED=2000
 # default terminal frontend
 _JLINK_TERMPROG=${RIOTTOOLS}/pyterm/pyterm
-_JLINK_TERMFLAGS="-ts 19021"
+_JLINK_TERMPORT=19021
+_JLINK_TERMFLAGS="-ts ${_JLINK_TERMPORT}"
 
 #
 # a couple of tests for certain configuration options


### PR DESCRIPTION
### Contribution description

On my machine I needed some delay between the server start and
connecting to prevent the port not being ready.

I based my code on [1]. I changed using a for loop to limit the number
of iterations.

1: https://stackoverflow.com/questions/27599839/how-to-wait-for-an-open-port-with-netcat

I also added a `timeout` around `nc` as when not doing `return` and calling
`nc -z` when it was already launched, it could get stuck.
I tried preventing that.

#### Issues found

When testing without the `return` after `nc` and connecting when the server was started, I could not talk to it. So cases that were working before should also be re-tested.

### Testing procedure

Using https://github.com/RIOT-OS/RIOT/pull/9013, if you had the issue before, you should now be able to do
```
BOARD=hamilton make -C examples/default/ flash term
```
and interact with the board.

I did not tested `ruuvitag` or `thingy52` as I do not have any.


I checked there are no newly introduced `shellcheck` errors.

### Issues/PRs references

I found the issue while testing https://github.com/RIOT-OS/RIOT/pull/9013
I needed to add a delay before starting the terminal https://github.com/RIOT-OS/RIOT/pull/9013#issuecomment-456818549