### PR TITLE
makefiles/vars.inc.mk: do not export LINKFLAGS

### DIFF
--- a/makefiles/vars.inc.mk
+++ b/makefiles/vars.inc.mk
@@ -56,7 +56,7 @@ export ARFLAGS               # Command-line options to pass to AR, default `rcs`
 export AS                    # The assembler.
 export ASFLAGS               # Flags for the assembler.
 export LINK                  # The command used to link the files. Must take the same parameters as GCC, i.e. "ld" won't work.
-export LINKFLAGS             # Flags to supply in the linking step.
+# LINKFLAGS                  # Flags to supply in the linking step.
 export LTOFLAGS              # extra CFLAGS for compiling with link time optimization
 export OBJCOPY               # The command used to create the HEXFILE.
 export OFLAGS                # The parameter for OBJCOPY, e.g. to strip the debug information.


### PR DESCRIPTION
### Contribution description

It is only used by `Makefile.include` and should not be used by sub-make
instances.

This is required to prevent evaluating `LINKFLAGS` when not needed and a
required step to not evaluate it on the host with for example `avr-ld`
when building in docker.

I checked usage with:

    git grep -e '(LINKFLAGS)' -e '{LINKFLAGS}'

Packages may be using it but `LINKFLAGS` is a RIOT way of naming
things and even if `generate-xcompile-toolchain` uses `LINK` it does not
use `LINKFLAGS`.

### Testing procedure

Look at the usages on `LINKFLAGS` with `git grep -e '(LINKFLAGS)' -e '{LINKFLAGS}'` and notice nothing is using it except `Makefile.include` and `makefiles/info.inc.mk`.

I did not look in the packages yet but will if the CI build fails.

### Issues/PRs references

Found while testing `arduino-mega2560` in docker on a machine without `avr` installed. `/bin/sh: 1: avr-ld: not found`. It needs another commit to be fixed though that will come in another PR.

Main reference on removing exports: https://github.com/RIOT-OS/RIOT/issues/10850
