### PR TITLE
cpu/atmega_common: do not export LINKFLAGS

### DIFF
--- a/cpu/atmega_common/Makefile.include
+++ b/cpu/atmega_common/Makefile.include
@@ -8,7 +8,7 @@ export CFLAGS_OPT  ?= -Os
 
 export CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)
 export ASFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG)
-export LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) -static -lgcc -e reset_handler -Wl,--gc-sections
+LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) -static -lgcc -e reset_handler -Wl,--gc-sections
 
 # export the peripheral drivers to be linked into the final binary
 export USEMODULE += atmega_common_periph
@@ -26,7 +26,7 @@ ifeq ($(LTO),1)
   # avr-gcc <4.8.3 has a bug when using LTO which causes a warning to be printed always:
   # '_vector_25' appears to be a misspelled signal handler [enabled by default]
   # See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=59396
-  export LINKFLAGS += -Wno-error
+  LINKFLAGS += -Wno-error
 endif
 
 # Use ROM_LEN and RAM_LEN during link

--- a/makefiles/vars.inc.mk
+++ b/makefiles/vars.inc.mk
@@ -56,7 +56,7 @@ export ARFLAGS               # Command-line options to pass to AR, default `rcs`
 export AS                    # The assembler.
 export ASFLAGS               # Flags for the assembler.
 export LINK                  # The command used to link the files. Must take the same parameters as GCC, i.e. "ld" won't work.
-export LINKFLAGS             # Flags to supply in the linking step.
+# LINKFLAGS                  # Flags to supply in the linking step.
 export LTOFLAGS              # extra CFLAGS for compiling with link time optimization
 export OBJCOPY               # The command used to create the HEXFILE.
 export OFLAGS                # The parameter for OBJCOPY, e.g. to strip the debug information.


### PR DESCRIPTION
### Contribution description

cpu/atmega_common: do not export LINKFLAGS

This prevent evaluating `LINKFLAGS` when not needed and when building
in docker so does not produce errors if `avr-ld` is not installed.

```
BUILD_IN_DOCKER=1 BOARD=arduino-mega2560  make --no-print-directory -C examples/hello-world/ clean
/srv/ilab-builds/workspace/git/riot_master/makefiles/toolchain/gnu.inc.mk:18: objcopy not found. Hex file will not be created.
/bin/sh: 1: avr-ld: not found
```

It removes the `/bin/sh: 1: avr-ld: not found`

### Testing procedure

On a machine without `avr` installed, try compiling in docker for any board using `atmega_common/Makefile.include` and notice the `/bin/sh: 1: avr-ld: not found` errors.

```
BUILD_IN_DOCKER=1 BOARD=arduino-mega2560  make --no-print-directory -C examples/hello-world/
/srv/ilab-builds/workspace/git/riot_test/makefiles/toolchain/gnu.inc.mk:18: objcopy not found. Hex file will not be created.
/bin/sh: 1: avr-ld: not found
Launching build container using image "riot/riotbuild:latest".
docker run --rm -t -u "$(id -u)" \
    -v '/srv/ilab-builds/workspace/git/riot_test:/data/riotbuild/riotbase' \
    -v '/srv/ilab-builds/workspace/git/riot_test/build:/data/riotbuild/build' \
    -v '/srv/ilab-builds/workspace/git/riot_test/cpu:/data/riotbuild/riotcpu' \
    -v '/srv/ilab-builds/workspace/git/riot_test/boards:/data/riotbuild/riotboard' \
    -v '/srv/ilab-builds/workspace/git/riot_test/makefiles:/data/riotbuild/riotmake' \
    -v '/srv/ilab-builds/workspace/git/riot_test:/data/riotbuild/riotproject' \
    -v '/usr/share/zoneinfo/Europe/Berlin:/etc/localtime:ro' \
    -e 'RIOTBASE=/data/riotbuild/riotbase' \
    -e 'BUILD_DIR=/data/riotbuild/build' \
    -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' \
    -e 'RIOTCPU=/data/riotbuild/riotcpu' \
    -e 'RIOTBOARD=/data/riotbuild/riotboard' \
    -e 'RIOTMAKE=/data/riotbuild/riotmake' \
    -e 'RIOTPROJECT=/data/riotbuild/riotproject' \
      -v /srv/ilab-builds/workspace/git/RIOT/.git:/srv/ilab-builds/workspace/git/RIOT/.git \
    -e 'BOARD=arduino-mega2560' \
    -w '/data/riotbuild/riotproject/examples/hello-world/' \
    'riot/riotbuild:latest' make  
Building application "hello-world" for "arduino-mega2560" with MCU "atmega2560".

"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/isrpipe
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
"make" -C /data/riotbuild/riotbase/sys/tsrb
"make" -C /data/riotbuild/riotboard/arduino-mega2560
"make" -C /data/riotbuild/riotboard/common/arduino-atmega
"make" -C /data/riotbuild/riotboard/common/atmega
"make" -C /data/riotbuild/riotcpu/atmega2560
"make" -C /data/riotbuild/riotcpu/atmega_common
"make" -C /data/riotbuild/riotcpu/atmega_common/avr_libc_extra
"make" -C /data/riotbuild/riotcpu/atmega_common/periph
   text    data     bss     dec     hex filename
   5726     324     969    7019    1b6b /data/riotbuild/riotproject/examples/hello-world/bin/arduino-mega2560/hello-world.elf
/bin/sh: 1: avr-ld: not found
```

A shorter output is simply calling `clean` as described in the commit message.
With this PR the `avr-ld: not found` should not be printed anymore.


### Issues/PRs references

Found while testing `arduino-mega2560` on a machine without `avr`.
Depends on https://github.com/RIOT-OS/RIOT/pull/10853
Tracking issue on removing exports and immediate evaluations https://github.com/RIOT-OS/RIOT/issues/10850
