### PR TITLE
net/nanocoap: verify simple reply buffer

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -322,8 +322,11 @@ int coap_parse(coap_pkt_t *pkt, uint8_t *buf, size_t len);
  *
  * This function can be used to create a reply to any CoAP request packet.  It
  * will create the reply packet header based on parameters from the request
- * (e.g., id, token).  Passing a non-zero @p payload_len will ensure the payload
- * fits into the buffer along with the header.
+ * (e.g., id, token).
+ *
+ * Passing a non-zero @p payload_len will ensure the payload fits into the
+ * buffer along with the header. For this validation, payload_len must include
+ * any options, the payload marker, as well as the payload proper.
  *
  * @param[in]   pkt         packet to reply to
  * @param[in]   code        reply code (e.g., COAP_CODE_204)
@@ -333,6 +336,7 @@ int coap_parse(coap_pkt_t *pkt, uint8_t *buf, size_t len);
  *
  * @returns     size of reply packet on success
  * @returns     <0 on error
+ * @returns     -ENOSPC if @p rbuf too small
  */
 ssize_t coap_build_reply(coap_pkt_t *pkt, unsigned code,
                          uint8_t *rbuf, unsigned rlen, unsigned payload_len);
@@ -343,7 +347,7 @@ ssize_t coap_build_reply(coap_pkt_t *pkt, unsigned code,
  * This is a simple wrapper that allows for building CoAP replies for simple
  * use-cases.
  *
- * The reply will be written to @p buf. Is @p payload and @p payload_len
+ * The reply will be written to @p buf. If @p payload and @p payload_len are
  * non-zero, the payload will be copied into the resulting reply packet.
  *
  * @param[in]   pkt         packet to reply to
@@ -356,6 +360,7 @@ ssize_t coap_build_reply(coap_pkt_t *pkt, unsigned code,
  *
  * @returns     size of reply packet on success
  * @returns     <0 on error
+ * @returns     -ENOSPC if @p buf too small
  */
 ssize_t coap_reply_simple(coap_pkt_t *pkt,
                           unsigned code,

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -364,7 +364,7 @@ ssize_t coap_build_reply(coap_pkt_t *pkt, unsigned code,
     unsigned tkl = coap_get_token_len(pkt);
     unsigned len = sizeof(coap_hdr_t) + tkl;
 
-    if ((len + payload_len + 1) > rlen) {
+    if ((len + payload_len) > rlen) {
         return -ENOSPC;
     }
 

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -350,12 +350,17 @@ ssize_t coap_reply_simple(coap_pkt_t *pkt,
     if (payload_len) {
         bufpos += coap_put_option_ct(bufpos, 0, ct);
         *bufpos++ = 0xff;
-
-        memcpy(bufpos, payload, payload_len);
-        bufpos += payload_len;
     }
 
-    return coap_build_reply(pkt, code, buf, len, bufpos - payload_start);
+    ssize_t res = coap_build_reply(pkt, code, buf, len,
+                                   bufpos - payload_start + payload_len);
+
+    if (payload_len && res > 0) {
+        assert(payload);
+        memcpy(bufpos, payload, payload_len);
+    }
+
+    return res;
 }
 
 ssize_t coap_build_reply(coap_pkt_t *pkt, unsigned code,


### PR DESCRIPTION
### Contribution description
coap_reply_simple() is a single function to write a reply, including a payload. However, it writes the payload before verifying the available buffer length. This PR refactors this function to verify first. This PR also updates the documentation for coap_build_reply(), on which coap_reply_simple() depends, to describe how to ensure the length comparison is accurate.

### Testing procedure
Test with /riot/board resource in the nanocoap_server example. 

- in coap_handler.c, modify _riot_board_handler() to use "arduino-duemilanove" as the name of the board, rather than the definition of RIOT_BOARD, which is "native"
- in main.c, modify COAP_INBUF_SIZE to 27
- in sock.c, enable debug
- also build gcoap
- create a tap bridge with `tapsetup -c 2`, start nanocoap_server for tap0 and gcoap for tap1

From the gcoap terminal,
```
> coap get <tap0-addr> 5683 /riot/board
coap get <tap0-addr> 5683 /riot/board
gcoap_cli: sending msg ID 46325, 17 bytes
> gcoap: response Success, code 2.05, 19 bytes
arduino-duemilanove
```

Now recompile main.c with COAP_INBUF_SIZE set to 26, and run the test again. In this case, the request times out. On the server terminal, you will see `error handling request -28`

### Issues/PRs references
-none-