### PR TITLE
cpu: fix returns of i2c_acquire and i2c_release

### DIFF
--- a/cpu/atmega_common/periph/i2c.c
+++ b/cpu/atmega_common/periph/i2c.c
@@ -220,18 +220,20 @@ int i2c_write_bytes(i2c_t dev, uint16_t addr, const void *data, size_t len,
 
 int i2c_acquire(i2c_t dev)
 {
-    assert(dev < I2C_NUMOF);
-
-    mutex_lock(&locks[dev]);
-    return 0;
+    if (dev < I2C_NUMOF) {
+        mutex_lock(&locks[dev]);
+        return 0;
+    }
+    return -1;
 }
 
 int i2c_release(i2c_t dev)
 {
-    assert(dev < I2C_NUMOF);
-
-    mutex_unlock(&locks[dev]);
-    return 0;
+    if (dev < I2C_NUMOF) {
+        mutex_unlock(&locks[dev]);
+        return 0;
+    }
+    return -1;
 }
 
 static void i2c_poweron(i2c_t dev)

--- a/cpu/efm32/periph/i2c.c
+++ b/cpu/efm32/periph/i2c.c
@@ -142,24 +142,25 @@ void i2c_init(i2c_t dev)
 
 int i2c_acquire(i2c_t dev)
 {
-    /* acquire lock */
-    mutex_lock(&i2c_lock[dev]);
-
-    /* power peripheral */
-    CMU_ClockEnable(i2c_config[dev].cmu, true);
-
-    return 0;
+    if (dev < I2C_NUMOF) {
+        mutex_lock(&i2c_lock[dev]);
+        /* power peripheral */
+        CMU_ClockEnable(i2c_config[dev].cmu, true);
+        return 0;
+    }
+    return -1;
 }
 
 int i2c_release(i2c_t dev)
 {
-    /* disable peripheral */
-    CMU_ClockEnable(i2c_config[dev].cmu, false);
+    if (dev < I2C_NUMOF) {
+        /* disable peripheral */
+        CMU_ClockEnable(i2c_config[dev].cmu, false);
 
-    /* release lock */
-    mutex_unlock(&i2c_lock[dev]);
-
-    return 0;
+        mutex_unlock(&i2c_lock[dev]);
+        return 0;
+    }
+    return -1;
 }
 
 int i2c_read_bytes(i2c_t dev, uint16_t address, void *data, size_t length, uint8_t flags)

--- a/cpu/nrf51/periph/i2c.c
+++ b/cpu/nrf51/periph/i2c.c
@@ -133,18 +133,20 @@ void i2c_init(i2c_t dev)
 
 int i2c_acquire(i2c_t dev)
 {
-    assert(dev < I2C_NUMOF);
-
-    mutex_lock(&locks[dev]);
-    return 0;
+    if (dev < I2C_NUMOF) {
+        mutex_lock(&locks[dev]);
+        return 0;
+    }
+    return -1;
 }
 
 int i2c_release(i2c_t dev)
 {
-    assert(dev < I2C_NUMOF);
-
-    mutex_unlock(&locks[dev]);
-    return 0;
+    if (dev < I2C_NUMOF) {
+        mutex_unlock(&locks[dev]);
+        return 0;
+    }
+    return -1;
 }
 
 int i2c_read_bytes(i2c_t dev, uint16_t address, void *data, size_t length,

--- a/cpu/nrf52/periph/i2c.c
+++ b/cpu/nrf52/periph/i2c.c
@@ -104,24 +104,27 @@ void i2c_init(i2c_t dev)
 
 int i2c_acquire(i2c_t dev)
 {
-    assert(dev < I2C_NUMOF);
+    if (dev < I2C_NUMOF) {
+        mutex_lock(&locks[dev]);
+        bus(dev)->ENABLE = TWIM_ENABLE_ENABLE_Enabled;
 
-    mutex_lock(&locks[dev]);
-    bus(dev)->ENABLE = TWIM_ENABLE_ENABLE_Enabled;
-
-    DEBUG("[i2c] acquired dev %i\n", (int)dev);
-    return 0;
+        DEBUG("[i2c] acquired dev %i\n", (int)dev);
+        return 0;
+    }
+    return -1;
 }
 
 int i2c_release(i2c_t dev)
 {
-    assert(dev < I2C_NUMOF);
+    if (dev < I2C_NUMOF) {
 
-    bus(dev)->ENABLE = TWIM_ENABLE_ENABLE_Disabled;
-    mutex_unlock(&locks[dev]);
+        bus(dev)->ENABLE = TWIM_ENABLE_ENABLE_Disabled;
+        mutex_unlock(&locks[dev]);
 
-    DEBUG("[i2c] released dev %i\n", (int)dev);
-    return 0;
+        DEBUG("[i2c] released dev %i\n", (int)dev);
+        return 0;
+    }
+    return -1;
 }
 
 int i2c_write_regs(i2c_t dev, uint16_t addr, uint16_t reg,

--- a/cpu/sam0_common/periph/i2c.c
+++ b/cpu/sam0_common/periph/i2c.c
@@ -176,16 +176,20 @@ void i2c_init(i2c_t dev)
 
 int i2c_acquire(i2c_t dev)
 {
-    assert(dev < I2C_NUMOF);
-    mutex_lock(&locks[dev]);
-    return 0;
+    if (dev < I2C_NUMOF) {
+        mutex_lock(&locks[dev]);
+        return 0;
+    }
+    return -1;
 }
 
 int i2c_release(i2c_t dev)
 {
-    assert(dev < I2C_NUMOF);
-    mutex_unlock(&locks[dev]);
-    return 0;
+    if (dev < I2C_NUMOF) {
+        mutex_unlock(&locks[dev]);
+        return 0;
+    }
+    return -1;
 }
 
 int i2c_read_bytes(i2c_t dev, uint16_t addr,

--- a/cpu/stm32_common/periph/i2c_1.c
+++ b/cpu/stm32_common/periph/i2c_1.c
@@ -135,23 +135,22 @@ static void _i2c_init(I2C_TypeDef *i2c, uint32_t timing)
 
 int i2c_acquire(i2c_t dev)
 {
-    assert(dev < I2C_NUMOF);
-
-    mutex_lock(&locks[dev]);
-
-    periph_clk_en(i2c_config[dev].bus, i2c_config[dev].rcc_mask);
-
-    return 0;
+    if (dev < I2C_NUMOF) {
+        mutex_lock(&locks[dev]);
+        periph_clk_en(i2c_config[dev].bus, i2c_config[dev].rcc_mask);
+        return 0;
+    }
+    return -1;
 }
 
 int i2c_release(i2c_t dev)
 {
-    assert(dev < I2C_NUMOF);
-
-    periph_clk_dis(i2c_config[dev].bus, i2c_config[dev].rcc_mask);
-
-    mutex_unlock(&locks[dev]);
-    return 0;
+    if (dev < I2C_NUMOF) {
+        periph_clk_dis(i2c_config[dev].bus, i2c_config[dev].rcc_mask);
+        mutex_unlock(&locks[dev]);
+        return 0;
+    }
+    return -1;
 }
 
 int i2c_write_regs(i2c_t dev, uint16_t addr, uint16_t reg,

--- a/cpu/stm32_common/periph/i2c_2.c
+++ b/cpu/stm32_common/periph/i2c_2.c
@@ -176,33 +176,30 @@ static void _i2c_init(I2C_TypeDef *i2c, uint32_t clk, uint32_t ccr)
 
 int i2c_acquire(i2c_t dev)
 {
-    assert(dev < I2C_NUMOF);
-
-    mutex_lock(&locks[dev]);
-
+    if (dev < I2C_NUMOF) {
+        mutex_lock(&locks[dev]);
 #ifdef STM32_PM_STOP
-    /* block STOP mode */
-    pm_block(STM32_PM_STOP);
+        /* block STOP mode */
+        pm_block(STM32_PM_STOP);
 #endif
-
-    periph_clk_en(i2c_config[dev].bus, i2c_config[dev].rcc_mask);
-
-    return 0;
+        periph_clk_en(i2c_config[dev].bus, i2c_config[dev].rcc_mask);
+        return 0;
+    }
+    return -1;
 }
 
 int i2c_release(i2c_t dev)
 {
-    assert(dev < I2C_NUMOF);
-
-    periph_clk_dis(i2c_config[dev].bus, i2c_config[dev].rcc_mask);
-
+    if (dev < I2C_NUMOF) {
+        periph_clk_dis(i2c_config[dev].bus, i2c_config[dev].rcc_mask);
 #ifdef STM32_PM_STOP
-    /* unblock STOP mode */
-    pm_unblock(STM32_PM_STOP);
+        /* unblock STOP mode */
+        pm_unblock(STM32_PM_STOP);
 #endif
-
-    mutex_unlock(&locks[dev]);
-    return 0;
+        mutex_unlock(&locks[dev]);
+        return 0;
+    }
+    return -1;
 }
 
 int i2c_read_bytes(i2c_t dev, uint16_t address, void *data, size_t length,


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR replaces `asserts` with `if` statements in `periph/i2c` for all CPUs to return proper error codes according to the API spec. The rational behind this is that (theoretically) one could write a driver and simply link against RIOT without recompiling the `periph/i2c`, hence `asserts` will not work but according to the API specs `acquire` and `release` should return `-1` on error, which in this case mostly means: wrong device

### Testing procedure

run `tests/periph_i2c` (or any drivers requiring I2C) for different boards to match all CPUs, it should still work.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->