### PR TITLE
gnrc_icmpv6: release in error cases of demux

### DIFF
--- a/sys/net/gnrc/network_layer/icmpv6/gnrc_icmpv6.c
+++ b/sys/net/gnrc/network_layer/icmpv6/gnrc_icmpv6.c
@@ -78,7 +78,7 @@ void gnrc_icmpv6_demux(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
 
     if (_calc_csum(icmpv6, ipv6, pkt)) {
         DEBUG("icmpv6: wrong checksum.\n");
-        /* don't release: IPv6 does this */
+        gnrc_pktbuf_release(pkt);
         return;
     }
 

--- a/sys/net/gnrc/network_layer/icmpv6/gnrc_icmpv6.c
+++ b/sys/net/gnrc/network_layer/icmpv6/gnrc_icmpv6.c
@@ -69,6 +69,7 @@ void gnrc_icmpv6_demux(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
 
     if (icmpv6->size < sizeof(icmpv6_hdr_t)) {
         DEBUG("icmpv6: packet too short.\n");
+        gnrc_pktbuf_release(pkt);
         return;
     }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
While hunting the bug fixed in https://github.com/RIOT-OS/RIOT/pull/10776 I never really questioned why the packet buffer was filling up when the a duplicate isn't dropped (because it was just incrementing a counter and the packet was released in any way). So I investigated further: Turns out I forgot yet another release. 
The comment suggests that I assumed in 591ef182 that `gnrc_ipv6.c:_demux` (or rather the equivalent version of it then) releases it, which might have been the case then, but isn't the case now. Doing the release in `gnrc_ipv6.c` would also lead to undefined behavior due to the *necessary* release within `gnrc_icmpv6_demux()` introduced in 891450d29d5f4c5f7f9e4eaf here:

https://github.com/RIOT-OS/RIOT/blob/06b5a58e6285a7f6f49cd1df0adae6be066921e1/sys/net/gnrc/network_layer/icmpv6/gnrc_icmpv6.c#L112-L117
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I applied the following patch to simulate the error behavior before #10776 (at least it worked on a `samr21-xpro` and on `native` with `socket_zep` ;-))  and to have the `pktbuf` command available.

```diff
diff --git a/examples/gnrc_networking/Makefile b/examples/gnrc_networking/Makefile
index 628b9c9..b0f401e 100644
--- a/examples/gnrc_networking/Makefile
+++ b/examples/gnrc_networking/Makefile
@@ -19,6 +19,7 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-uno \
 
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
+USEMODULE += gnrc_pktbuf_cmd
 USEMODULE += gnrc_netdev_default
 USEMODULE += auto_init_gnrc_netif
 # Activate ICMPv6 error messages
diff --git a/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.c b/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.c
index a7b9dd2..06fcdd9 100644
--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.c
@@ -151,6 +151,12 @@ static int _rbuf_add(gnrc_netif_hdr_t *netif_hdr, gnrc_pktsnip_t *pkt,
 
     if (_rbuf_update_ints(entry, offset, frag_size)) {
         DEBUG("6lo rbuf: add fragment data\n");
+        if (offset == 128) {
+            entry->super.current_size += (uint16_t)frag_size;
+            gnrc_sixlowpan_frag_rbuf_dispatch_when_complete(&entry->super, netif_hdr);
+            gnrc_pktbuf_release(pkt);
+            return RBUF_ADD_SUCCESS;
+        }
         entry->super.current_size += (uint16_t)frag_size;
         if (offset == 0) {
 #ifdef MODULE_GNRC_SIXLOWPAN_IPHC
```

This is how I hunted the bug

#### Alternatively

One can just compile `gnrc_networking` for `native` with the `gnrc_pktbuf_cmd`, run it with `dist/tools/tapsetup/tapsetup` generated TAPs, and inject a bogus ICMPv6 packet using `sudo scapy`:

```py
sendp(Ether() / IPv6(dst="<lladdr of native node>") / ICMPv6EchoRequest(cksum=0x01), iface="tapbr0")
```

Without this PR the packet will show up in the output of `pktbuf` and remain there.

E.g.
```
> pktbuf
pktbuf
packet buffer: first byte: 0x808ad60, last byte: 0x808c560 (size: 6144)
  position of last byte used: 1776
=========== chunk   0 (0x808ad60  size:   96) ===========
00000000  A8  AD  08  08  08  AE  08  08  08  00  00  00  01  00  00  00
00000010  02  00  00  00  00  00  00  00  00  00  00  00  90  AD  08  08
00000020  14  00  00  00  01  00  00  00  FF  FF  FF  FF  3A  40  FE  80
00000030  06  06  06  00  00  00  00  00  98  90  96  9A  33  5D  FF  FF
00000040  FF  FF  FF  FF  00  00  B4  1F  78  AD  08  08  E0  AD  08  08
00000050  28  00  00  00  01  00  00  00  01  00  00  00  18  00  00  00
~ unused: 0x808adc0 (next: 0x808ae10, size:   32) ~
=========== chunk   1 (0x808ade0  size:   48) ===========
00000000  60  00  00  00  00  08  3A  40  FE  80  00  00  00  00  00  00
00000010  4B  4F  18  4B  5B  85  68  96  FE  80  00  00  00  00  00  00
00000020  B4  1F  CE  FF  FE  BE  78  D3  80  00  00  01  00  00  00  00
~ unused: 0x808ae10 (next: (nil), size: 5968) ~
```

with this PR the packet buffer is clear:
```
> pktbuf
pktbuf
packet buffer: first byte: 0x808ad60, last byte: 0x808c560 (size: 6144)
  position of last byte used: 1544
~ unused: 0x808ad60 (next: (nil), size: 6144) ~
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up to #10776.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
