### PR TITLE
gnrc_ipv6_nib: release when not queuable on AR

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -1171,6 +1171,12 @@ static bool _resolve_addr(const ipv6_addr_t *dst, gnrc_netif_t *netif,
                     }
                     gnrc_pktqueue_add(&entry->pktqueue, queue_entry);
                 }
+                else {
+                    DEBUG("nib: can't allocate entry for packet queue "
+                          "dropping packet\n");
+                    gnrc_pktbuf_release(pkt);
+                    return false;
+                }
             }
             else {
                 gnrc_icmpv6_error_dst_unr_send(ICMPV6_ERROR_DST_UNR_ADDR,


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
As mentioned in https://github.com/RIOT-OS/RIOT/pull/10859#issuecomment-457228518 I was still able to cause leaks in the packet buffer. This was because when a new queue entry is tried to be allocated for a neighbor who's address is currently tried to be resolved there was no error case before. The packet that was tried to be  put in the queue was thus not released and stayed in the packet buffer for ever.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I started a native instance with `gnrc_pktbuf_cmd` compiled in. I then used `scapy` to spam the node with ICMPv6 echo requests with non-existent source addresses:

```py
sendp(Ether(dst="<native l2addr>") / IPv6(src="fe80::1", dst="<native lladdr>") /
    ICMPv6EchoRequest(), iface="tapbr0", count=100)
```

Without this PR the *replies* stick in the packet buffer. With it the packet buffer stays empty (leave the neighbor cache entry a little time to timeout so the packets actually being in the queue got deleted).
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
See https://github.com/RIOT-OS/RIOT/pull/10859#issuecomment-457228518
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
