### PR TITLE
cpu/esp8266: Fixes and improvements of esp_wifi netdev driver

### DIFF
--- a/cpu/esp8266/Makefile.dep
+++ b/cpu/esp8266/Makefile.dep
@@ -2,6 +2,7 @@
 
 ifneq (, $(filter esp_sdk, $(USEMODULE)))
     USEMODULE += core_thread_flags
+    INCLUDES += -I$(ESP8266_SDK_DIR)/third_party/include
     LINKFLAGS += -Wl,-wrap=malloc
     LINKFLAGS += -Wl,-wrap=free
     LINKFLAGS += -Wl,-wrap=calloc
@@ -20,7 +21,6 @@ endif
 
 ifneq (, $(filter esp_wifi, $(USEMODULE)))
     CFLAGS += -DLWIP_OPEN_SRC
-    INCLUDES += -I$(ESP8266_SDK_DIR)/third_party/include
     LINKFLAGS += -Wl,-wrap=ethernet_input
     USEMODULE += netdev_eth
 endif

--- a/cpu/esp8266/esp-wifi/esp_wifi_netdev.c
+++ b/cpu/esp8266/esp-wifi/esp_wifi_netdev.c
@@ -394,7 +394,7 @@ static int IRAM _send(netdev_t *netdev, const iolist_t *iolist)
 
     struct pbuf *pb = pbuf_alloc(PBUF_LINK, iol_len + PBUF_IEEE80211_HLEN, PBUF_RAM);
     if (pb == NULL || pb->tot_len < iol_len) {
-        ESP_WIFI_DEBUG("could not allocate buffer to send %d bytes ", iol_len);
+        ESP_WIFI_LOG_ERROR("could not allocate buffer to send %d bytes ", iol_len);
         /*
          * The memory of EPS8266 is quite small. Therefore, it may happen on
          * heavy network load that we run into out of memory and we have

--- a/cpu/esp8266/esp-wifi/esp_wifi_netdev.c
+++ b/cpu/esp8266/esp-wifi/esp_wifi_netdev.c
@@ -350,13 +350,9 @@ static int IRAM _send(netdev_t *netdev, const iolist_t *iolist)
         /*
          * The memory of EPS8266 is quite small. Therefore, it may happen on
          * heavy network load that we run into out of memory and we have
-         * to wait until lwIP pbuf has been flushed. For that purpose, we
-         * have to disconnect from AP and slow down sending. The node will
-         * then reconnect to AP automatically.
+         * to wait until lwIP pbuf has been flushed. We slow down sending a bit.
          */
         critical_exit();
-        /* disconnect from AP */
-        wifi_station_disconnect();
         /* wait 20 ms */
         xtimer_usleep(20 * US_PER_MS);
 

--- a/cpu/esp8266/esp-wifi/esp_wifi_netdev.c
+++ b/cpu/esp8266/esp-wifi/esp_wifi_netdev.c
@@ -684,6 +684,9 @@ static void _esp_wifi_setup(void)
     /* set the the reconnect timer */
     xtimer_set(&_esp_wifi_reconnect_timer, ESP_WIFI_RECONNECT_TIME);
 
+    /* avoid the WiFi modem going into sleep mode */
+    wifi_set_sleep_type(NONE_SLEEP_T);
+
     /* connect */
     wifi_station_connect();
     _esp_wifi_dev.state = ESP_WIFI_CONNECTING;

--- a/cpu/esp8266/esp-wifi/esp_wifi_netdev.c
+++ b/cpu/esp8266/esp-wifi/esp_wifi_netdev.c
@@ -254,16 +254,6 @@ static void _esp_wifi_handle_event_cb(System_Event_t *evt)
                               evt->event_info.disconnected.ssid,
                               evt->event_info.disconnected.reason);
             _esp_wifi_dev.state = ESP_WIFI_DISCONNECTED;
-
-            /* call disconnect to reset internal state */
-            if (evt->event_info.disconnected.reason != REASON_ASSOC_LEAVE) {
-                wifi_station_disconnect();
-            }
-
-            /* try to reconnect */
-            wifi_station_connect();
-            _esp_wifi_dev.state = ESP_WIFI_CONNECTING;
-
             break;
 
         case EVENT_SOFTAPMODE_STACONNECTED:
@@ -630,6 +620,10 @@ static void _esp_wifi_setup(void)
         return;
     }
     ESP_WIFI_DEBUG("own MAC addr is " MAC_STR, MAC_STR_ARG(dev->mac));
+
+    /* set auto reconnect policy */
+    wifi_station_set_reconnect_policy(true);
+    wifi_station_set_auto_connect(true);
 
     /* register callbacks */
     wifi_set_event_handler_cb(_esp_wifi_handle_event_cb);

--- a/cpu/esp8266/esp-wifi/esp_wifi_netdev.c
+++ b/cpu/esp8266/esp-wifi/esp_wifi_netdev.c
@@ -574,6 +574,22 @@ static void _isr(netdev_t *netdev)
     ESP_WIFI_DEBUG("%p", netdev);
 
     assert(netdev != NULL);
+
+    esp_wifi_netdev_t *dev = (esp_wifi_netdev_t *) netdev;
+
+    switch (dev->event) {
+        case EVENT_STAMODE_CONNECTED:
+            dev->netdev.event_callback(netdev, NETDEV_EVENT_LINK_UP);
+            break;
+        case EVENT_STAMODE_DISCONNECTED:
+            dev->netdev.event_callback(netdev, NETDEV_EVENT_LINK_DOWN);
+            break;
+        default:
+            break;
+    }
+    _esp_wifi_dev.event = EVENT_MAX; /* no event */
+
+    return;
 }
 
 /** override lwIP ethernet_intput to get ethernet frames */
@@ -614,6 +630,7 @@ static void _esp_wifi_setup(void)
     /* initialize netdev data structure */
     dev->rx_len = 0;
     dev->state = ESP_WIFI_DISCONNECTED;
+    dev->event = EVENT_MAX;
 
     /* set the netdev driver */
     dev->netdev.driver = &_esp_wifi_driver;

--- a/cpu/esp8266/esp-wifi/esp_wifi_netdev.h
+++ b/cpu/esp8266/esp-wifi/esp_wifi_netdev.h
@@ -48,6 +48,7 @@ typedef struct
     uint16_t rx_len;                  /**< number of bytes received from lwIP */
 
     esp_wifi_state_t state;           /**< indicates the interface state */
+    uint32_t event;                   /**< received event */
 
 } esp_wifi_netdev_t;
 

--- a/cpu/esp8266/esp-wifi/esp_wifi_netdev.h
+++ b/cpu/esp8266/esp-wifi/esp_wifi_netdev.h
@@ -49,8 +49,6 @@ typedef struct
 
     esp_wifi_state_t state;           /**< indicates the interface state */
 
-    mutex_t dev_lock;                 /**< for exclusive access to buffer in
-                                           receive functions */
 } esp_wifi_netdev_t;
 
 #ifdef __cplusplus

--- a/cpu/esp8266/sdk/lwip.c
+++ b/cpu/esp8266/sdk/lwip.c
@@ -1,0 +1,209 @@
+/*
+ * Copyright (C) 2018 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_esp8266
+ * @{
+ *
+ * @file
+ * @brief       lwIP functions required as symbols by the SDK
+ *
+ * This file defines a number of lwIP functions that are required as symbols by
+ * Espressif's SDK libraries. Since RIOT doesn't need lwIP, these functions are
+ * only dummies without real functionality. Using these functions instead of
+ * the lwIP functions as provided with the SDK saves arround 4 kBytes of RAM.
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @}
+ */
+
+#include "lwip/err.h"
+#include "lwip/ip_addr.h"
+#include "lwip/netif.h"
+#include "lwip/pbuf.h"
+#include "lwip/tcp_impl.h"
+#include "netif/etharp.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+#include "log.h"
+
+#ifndef ERR_OK
+#define ERR_OK 0
+#endif
+
+const struct eth_addr ethbroadcast = {{0xff,0xff,0xff,0xff,0xff,0xff}};
+
+err_t ethernet_input(struct pbuf *pb, struct netif* netif)
+{
+    DEBUG("%s\n", __func__);
+    (void)pb;
+    (void)netif;
+    return ERR_OK;
+}
+
+err_t etharp_output(struct netif *netif, struct pbuf *q, ip_addr_t *ipaddr)
+{
+    DEBUG("%s\n", __func__);
+    (void)netif;
+    (void)q;
+    (void)ipaddr;
+    return ERR_OK;
+}
+
+err_t etharp_request(struct netif *netif, ip_addr_t *ipaddr)
+{
+    DEBUG("%s\n", __func__);
+    (void)netif;
+    (void)ipaddr;
+    return ERR_OK;
+}
+
+void etharp_tmr(void)
+{
+    DEBUG("%s\n", __func__);
+}
+
+void etharp_cleanup_netif(struct netif *netif)
+{
+    DEBUG("%s\n", __func__);
+    (void)netif;
+}
+
+void dhcp_cleanup(struct netif *netif)
+{
+    DEBUG("%s\n", __func__);
+    (void)netif;
+}
+
+err_t dhcp_start(struct netif *netif)
+{
+    DEBUG("%s\n", __func__);
+    (void)netif;
+    return ERR_OK;
+}
+
+err_t dhcp_renew(struct netif *netif)
+{
+    DEBUG("%s\n", __func__);
+    (void)netif;
+    return ERR_OK;
+}
+
+err_t dhcp_release(struct netif *netif)
+{
+    DEBUG("%s\n", __func__);
+    (void)netif;
+    return ERR_OK;
+}
+
+void dhcp_stop(struct netif *netif)
+{
+    DEBUG("%s\n", __func__);
+    (void)netif;
+}
+
+void dhcp_network_changed(struct netif *netif)
+{
+    DEBUG("%s\n", __func__);
+    (void)netif;
+}
+
+void dhcp_coarse_tmr(void)
+{
+    DEBUG("%s\n", __func__);
+}
+
+void dhcp_fine_tmr(void)
+{
+    DEBUG("%s\n", __func__);
+}
+
+void dhcps_start(struct ip_info *info)
+{
+    DEBUG("%s\n", __func__);
+    (void)info;
+}
+
+void dhcps_stop(void)
+{
+    DEBUG("%s\n", __func__);
+}
+
+void dhcps_coarse_tmr(void)
+{
+    DEBUG("%s\n", __func__);
+}
+
+union tcp_listen_pcbs_t tcp_listen_pcbs;
+struct tcp_pcb *tcp_active_pcbs;
+struct tcp_pcb *tcp_tw_pcbs;
+
+void tcp_seg_free(struct tcp_seg *seg)
+{
+    DEBUG("%s\n", __func__);
+    (void)seg;
+}
+
+void tcp_abort (struct tcp_pcb *pcb)
+{
+    DEBUG("%s\n", __func__);
+    (void)pcb;
+}
+
+void tcp_tmr(void)
+{
+    DEBUG("%s\n", __func__);
+}
+
+void igmp_init(void)
+{
+    DEBUG("%s\n", __func__);
+}
+
+err_t igmp_start(struct netif *netif)
+{
+    DEBUG("%s\n", __func__);
+    (void)netif;
+    return ERR_OK;
+}
+
+err_t igmp_stop(struct netif *netif)
+{
+    DEBUG("%s\n", __func__);
+    (void)netif;
+    return ERR_OK;
+}
+
+void igmp_report_groups(struct netif *netif)
+{
+    DEBUG("%s\n", __func__);
+    (void)netif;
+}
+
+void igmp_tmr(void)
+{
+    DEBUG("%s\n", __func__);
+}
+
+void dns_init(void)
+{
+    DEBUG("%s\n", __func__);
+}
+
+void dns_tmr(void)
+{
+    DEBUG("%s\n", __func__);
+}
+
+uint32_t espconn_init(uint32 arg)
+{
+    DEBUG("%s\n", __func__);
+    (void)arg;
+    return 1;
+}

--- a/cpu/esp8266/sdk/lwip.c
+++ b/cpu/esp8266/sdk/lwip.c
@@ -22,6 +22,8 @@
  * @}
  */
 
+#ifdef MODULE_ESP_SDK
+
 #include "lwip/err.h"
 #include "lwip/ip_addr.h"
 #include "lwip/netif.h"
@@ -207,3 +209,5 @@ uint32_t espconn_init(uint32 arg)
     (void)arg;
     return 1;
 }
+
+#endif /* MODULE_ESP_SDK */


### PR DESCRIPTION
### Contribution description

This PR increases the performance and the stability of the `esp_wifi` netdev driver. These are in detail:

- Since the `_esp_wifi_recv_cb` callback on frame receiption is not executed in interrupt context but in the context of the `ets` thread, it is not necessary to pass the`NETDEV_EVENT_ISR` event first. Instead, the receive function `_recv` can be called directly which leads to a much faster handling, a lower frame lost rate and more robustness.

- Since `_recv` function and `_esp_wifi_recv_cb` are called in a deterministic order, there is no need for a mutex anymore to synchronize the access to the receive buffer between the `_esp_wifi_recv_cb` and the `recv` function.

- The Espressif SDK includes its own `lwIP` version. Since `lwIP` is not required for RIOT, the `lwIP` library from Espressif SDK is not used anymore. To satisfy symbol dependencies of the SDK libraries to the `lwIP` library, a number of dummy functions are defined without real functionality. Using these dummy functions instead of real `lwIP` functions saves about 4 kbytes of RAM.

- The auto reconnect mechanism from SDK is used now since it seems to be more stable and less memory consuming.

- Removes timeout handling and disconnecting in send function when the lwIP buffer is exhausted. This PR solves problems 2 and 4 in issue #10861. Waiting that the frame allocated in lwIP packet buffer is freed by MAC layer led to the complete blockage of send function on heavy network load. Disconnecting from AP is counterproductive since reconnecting usually fails on heavy network load.

- Human readable disconnect reasons.

- Generation of `NETDEV_EVENT_LINK_DOWN` and `NETDEV_EVENT_LINK_DOWN` on disconnect and connect to the AP.

### Testing procedure

With this PR, the performance of pinging an esp8266 node should be noticeably better than before.

- Compile and flash `example/gnrc_networking` to at least one ESP8266 node using your AP configuration, e.g.,
    ```
    CFLAGS='-DESP_WIFI_SSID=\"<your SSID>\" -DESP_WIFI_PASS=\"your passphrase\"' USEMODULE="esp_wifi" make BOARD=esp8266-esp-12x -C examples/gnrc_networking flash
    ```
- Stress test from LAN with `sudo ping6 fe80::<ESP_IID> -Ieth0 -s1392 -i 0` should be stable. The packet loss rate should be 0. This should be also the case, if ping is executed on two nodes or in both directions.

### Issues/PRs references

This PR solves the problems 2 and 4 as described in #10861. It improves the stability and the performance a lot.