### PR TITLE
.gitignore: exclude results directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ Makefile.local
 
 # scan-build artifacts
 scan-build/
+
+# compile_and_test_for_boards default "results" directory
+results/


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The `results` directory is created by the `compile_and_test_for_board.py` script when ran from RIOTBASE and no custom value is specified using the `--results` option.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Go to your riotbase directory and run:

    ./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py --applications="tests/shell tests/leds" . native

Then run `git status`

With master, there's an untracked `results` directory, with this PR it's ignored.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
