### PR TITLE
uncrustify: add "sp_after_cast = remove"

### DIFF
--- a/uncrustify-riot.cfg
+++ b/uncrustify-riot.cfg
@@ -54,6 +54,7 @@ sp_bool                 = add      #
 sp_compare              = add      #
 sp_assign               = add      #
 sp_after_comma          = add      #
+sp_after_cast           = remove   # "(int) foo vs (int)foo
 sp_func_def_paren       = remove   # "int foo (){" vs "int foo(){"
 sp_func_call_paren      = remove   # "foo (" vs "foo("
 sp_func_proto_paren     = remove   # "int foo ();" vs "int foo();"


### PR DESCRIPTION
### Contribution description

Our current uncrustify config fixes e.g., ```(type_t*) foo``` to ```(type_t *) foo```, keeping the extra space.

This PR adds the uncrustify option to remove the space between cast and castee so above example becomes ```(type_t *)foo```.

AFAIK this was convention for a while, but I can't find a reference.

### Testing procedure

Run uncrustify on core/msg.c, see changes with and without this PR.

### Issues/PRs references

None.