### PR TITLE
uncrustify: change en/disable markers

### DIFF
--- a/boards/hifive1/board.c
+++ b/boards/hifive1/board.c
@@ -96,7 +96,7 @@ void board_init_clock(void)
      /* Note: The range is limited to ~100MHz and depends on PLL settings */
     PRCI_set_hfrosctrim_for_f_cpu(CPU_DESIRED_FREQ, PRCI_FREQ_UNDERSHOOT);
 
-     /* disable uncrustify *INDENT-OFF* */
+     /* begin{code-style-ignore} */
     SPI0_REG(SPI_REG_FFMT) =               /* setup "Fast Read Dual I/O" 1-1-2              */
         SPI_INSN_CMD_EN         |          /* Enable memory-mapped flash                    */
         SPI_INSN_ADDR_LEN(3)    |          /* 25LP128 read commands have 3 address bytes    */
@@ -106,7 +106,7 @@ void board_init_clock(void)
         SPI_INSN_DATA_PROTO(SPI_PROTO_D) | /*  data protocol for given instruction          */
         SPI_INSN_CMD_CODE(0xbb) |          /* Set the instruction to "Fast Read Dual I/O"   */
         SPI_INSN_PAD_CODE(0x00);           /* Dummy cycle sends 0 value bits                */
-    /* *INDENT-ON* */
+    /* end{code-style-ignore} */
 
     SPI0_REG(SPI_REG_SCKDIV) = SCKDIV;
 }

--- a/uncrustify-riot.cfg
+++ b/uncrustify-riot.cfg
@@ -1,3 +1,7 @@
+#
+# indentation
+#
+
 indent_with_tabs        = 0                 # 1=indent to level only, 2=indent with tabs
 input_tab_size          = 4                 # original tab size
 output_tab_size         = 4                 # new tab size

--- a/uncrustify-riot.cfg
+++ b/uncrustify-riot.cfg
@@ -85,3 +85,10 @@ align_right_cmt_span   = 3         #
 #
 
 set PROTO_WRAP ISR   # Wrap ISR macros like functions
+
+#
+# enable / disable marker config
+#
+
+disable_processing_cmt          = " begin{code-style-ignore}"
+enable_processing_cmt           = " end{code-style-ignore}"


### PR DESCRIPTION
### Contribution description

Default uncrustify uses ```*INDENT-OFF*``` as marker for disabling all formatting processing.
As a lot more than indenting is disabled, I find that misleading. Also it kinda screams at me using all-caps.

```boards/hifive1/board.c``` is currently the only non-vendor file in the repository that made use of the markers. Previously, it used a speaking comment à la ```/* disable uncrustify *INDENT-OFF* */ ```.

I'd like to change the marker to speak for itself, but allows changing of the used tool.

This PR changes uncrustify's markers to ```*auto-format-off*``` and ```auto-format-on```.

What do you think?

### Testing procedure

See uncrustify output for ```boards/hifive1/board.c``` with / without PR.

### Issues/PRs references

none