### PR TITLE
gnrc_sixlowpan: stop type-finding loop when type is found

### DIFF
--- a/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
@@ -73,6 +73,7 @@ void gnrc_sixlowpan_dispatch_recv(gnrc_pktsnip_t *pkt, void *context,
          ptr = ptr->next) {
         if ((ptr->next) && (ptr->next->type == GNRC_NETTYPE_NETIF)) {
             type = ptr->type;
+            break;
         }
     }
 #else   /* MODULE_GNRC_IPV6 */


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Currently the loop just continues to run after a viable type is found.

In #10851 this lead to a crash of the tests, when the dependency of `gnrc_sixlowpan` to `gnrc_ipv6` was removed.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Merge #10851 and remove the `gnrc_ipv6` dependency of `gnrc_sixlowpan`:

```diff
diff --git a/Makefile.dep b/Makefile.dep
index 5b5664a27..a9bd33c10 100644
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -213,7 +213,6 @@ ifneq (,$(filter gnrc_sixlowpan_iphc,$(USEMODULE)))
 endif
 
 ifneq (,$(filter gnrc_sixlowpan,$(USEMODULE)))
-  USEMODULE += gnrc_ipv6
   USEMODULE += sixlowpan
 endif
```

Then compile and run `tests/gnrc_sixlowpan_frag` on a board of your choice (I tested with `native`). Without this PR the test will crash. Without it it will continue to run.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Found with #10851.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
