### PR TITLE
core: uncrustify

### DIFF
--- a/core/atomic_c11.c
+++ b/core/atomic_c11.c
@@ -41,6 +41,11 @@
 #include <string.h>
 #include "irq.h"
 
+/*
+ * uncrustify mis-formats the macros in this file, so disable it for them.
+ * begin{code-style-ignore}
+ */
+
 /* GCC documentation refers to the types as I1, I2, I4, I8, I16 */
 typedef uint8_t  I1;
 typedef uint16_t I2;
@@ -244,6 +249,8 @@ TEMPLATE_ATOMIC_OP_FETCH_N(nand, &, 1, ~) /* __atomic_nand_fetch_1 */
 TEMPLATE_ATOMIC_OP_FETCH_N(nand, &, 2, ~) /* __atomic_nand_fetch_2 */
 TEMPLATE_ATOMIC_OP_FETCH_N(nand, &, 4, ~) /* __atomic_nand_fetch_4 */
 TEMPLATE_ATOMIC_OP_FETCH_N(nand, &, 8, ~) /* __atomic_nand_fetch_8 */
+
+/* end{code-style-ignore} */
 
 /* ***** Generic versions below ***** */
 

--- a/core/atomic_c11.c
+++ b/core/atomic_c11.c
@@ -272,7 +272,7 @@ TEMPLATE_ATOMIC_OP_FETCH_N(nand, &, 8, ~) /* __atomic_nand_fetch_8 */
  */
 void __atomic_load_c(size_t size, const void *src, void *dest, int memorder)
 {
-    (void) memorder;
+    (void)memorder;
     unsigned int mask = irq_disable();
     memcpy(dest, src, size);
     irq_restore(mask);
@@ -288,7 +288,7 @@ void __atomic_load_c(size_t size, const void *src, void *dest, int memorder)
  */
 void __atomic_store_c(size_t size, void *dest, const void *src, int memorder)
 {
-    (void) memorder;
+    (void)memorder;
     unsigned int mask = irq_disable();
     memcpy(dest, src, size);
     irq_restore(mask);
@@ -303,9 +303,10 @@ void __atomic_store_c(size_t size, void *dest, const void *src, int memorder)
  * @param[in]  ret        put the old value from @p ptr in @p ret
  * @param[in]  memorder   memory ordering, ignored in this implementation
  */
-void __atomic_exchange_c(size_t size, void *ptr, void *val, void *ret, int memorder)
+void __atomic_exchange_c(size_t size, void *ptr, void *val, void *ret,
+                         int memorder)
 {
-    (void) memorder;
+    (void)memorder;
     unsigned int mask = irq_disable();
     memcpy(ret, ptr, size);
     memcpy(ptr, val, size);
@@ -345,7 +346,8 @@ void __atomic_exchange_c(size_t size, void *ptr, void *val, void *ret, int memor
  * @return false otherwise
  */
 bool __atomic_compare_exchange_c(size_t len, void *ptr, void *expected,
-    void *desired, bool weak, int success_memorder, int failure_memorder)
+                                 void *desired, bool weak, int success_memorder,
+                                 int failure_memorder)
 {
     (void)weak;
     (void)success_memorder;
@@ -366,7 +368,8 @@ bool __atomic_compare_exchange_c(size_t len, void *ptr, void *expected,
 #if !defined(__llvm__) && !defined(__clang__)
 /* Memory barrier helper function, for platforms without barrier instructions */
 void __sync_synchronize(void) __attribute__((__weak__));
-void __sync_synchronize(void) {
+void __sync_synchronize(void)
+{
     /* ARMv4, ARMv5 do not have any hardware support for memory barriers,
      * This is a software only barrier and a no-op, and will likely break on SMP
      * systems, but we don't support any multi-CPU ARMv5 or ARMv4 boards in RIOT

--- a/core/atomic_sync.c
+++ b/core/atomic_sync.c
@@ -29,6 +29,11 @@
 #include <string.h>
 #include "irq.h"
 
+/*
+ * uncrustify mis-formats the macros in this file, so disable it globally.
+ * begin{code-style-ignore}
+ */
+
 /* use gcc/clang implementation if available */
 #if defined(__GNUC__) \
     && (__GNUC__ > 4 || \
@@ -234,4 +239,5 @@ TEMPLATE_SYNC_OP_AND_FETCH_N(nand, &, 2, ~) /* __sync_nand_and_fetch_2 */
 TEMPLATE_SYNC_OP_AND_FETCH_N(nand, &, 4, ~) /* __sync_nand_and_fetch_4 */
 TEMPLATE_SYNC_OP_AND_FETCH_N(nand, &, 8, ~) /* __sync_nand_and_fetch_8 */
 #endif
+/* end{code-style-ignore} */
 /** @} */

--- a/core/bitarithm.c
+++ b/core/bitarithm.c
@@ -30,11 +30,13 @@ unsigned bitarithm_msb(unsigned v)
 #if ARCH_32_BIT
     register unsigned shift;
 
+    /* begin{code-style-ignore} */
     r =     (v > 0xFFFF) << 4; v >>= r;
     shift = (v > 0xFF  ) << 3; v >>= shift; r |= shift;
     shift = (v > 0xF   ) << 2; v >>= shift; r |= shift;
     shift = (v > 0x3   ) << 1; v >>= shift; r |= shift;
                                             r |= (v >> 1);
+    /* end{code-style-ignore} */
 #else
     r = 0;
     while (v >>= 1) { /* unroll for more speed... */

--- a/core/bitarithm.c
+++ b/core/bitarithm.c
@@ -63,6 +63,7 @@ unsigned bitarithm_bits_set(unsigned v)
 uint8_t bitarithm_bits_set_u32(uint32_t v)
 {
     uint8_t c;
+
     for (c = 0; v; c++) {
         v &= v - 1; /* clear the least significant bit set */
     }

--- a/core/cond.c
+++ b/core/cond.c
@@ -58,7 +58,8 @@ static void _cond_signal(cond_t *cond, bool broadcast)
     uint16_t min_prio = THREAD_PRIORITY_MIN + 1;
 
     while ((next = list_remove_head(&cond->queue)) != NULL) {
-        thread_t *process = container_of((clist_node_t *)next, thread_t, rq_entry);
+        thread_t *process = container_of((clist_node_t *)next, thread_t,
+                                         rq_entry);
         sched_set_status(process, STATUS_PENDING);
         uint16_t process_priority = process->priority;
         if (process_priority < min_prio) {

--- a/core/include/assert.h
+++ b/core/include/assert.h
@@ -56,7 +56,7 @@ extern "C" {
 extern const char assert_crash_message[];
 
 #ifdef NDEBUG
-#define assert(ignore)((void) 0)
+#define assert(ignore)((void)0)
 #elif defined(DEBUG_ASSERT_VERBOSE)
 /**
  * @brief   Function to handle failed assertion
@@ -101,9 +101,11 @@ NORETURN void _assert_failure(const char *file, unsigned line);
  *
  * @see http://pubs.opengroup.org/onlinepubs/9699919799/functions/assert.html
  */
-#define assert(cond) ((cond) ? (void)0 :  _assert_failure(RIOT_FILE_RELATIVE, __LINE__))
+#define assert(cond) ((cond) ? (void)0 :  _assert_failure(RIOT_FILE_RELATIVE, \
+                                                          __LINE__))
 #else
-#define assert(cond) ((cond) ? (void)0 : core_panic(PANIC_ASSERT_FAIL, assert_crash_message))
+#define assert(cond) ((cond) ? (void)0 : core_panic(PANIC_ASSERT_FAIL, \
+                                                    assert_crash_message))
 #endif
 
 #if !defined __cplusplus

--- a/core/include/bitarithm.h
+++ b/core/include/bitarithm.h
@@ -26,7 +26,7 @@
 #include "cpu_conf.h"
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /**
@@ -147,7 +147,8 @@ static inline unsigned bitarithm_lsb(unsigned v)
 {
 /* Source: http://graphics.stanford.edu/~seander/bithacks.html#ZerosOnRightMultLookup */
     extern const uint8_t MultiplyDeBruijnBitPosition[32];
-    return MultiplyDeBruijnBitPosition[((uint32_t)((v & -v) * 0x077CB531U)) >> 27];
+    return MultiplyDeBruijnBitPosition[((uint32_t)((v & -v) * 0x077CB531U)) >>
+                                       27];
 }
 #else
 {
@@ -157,7 +158,7 @@ static inline unsigned bitarithm_lsb(unsigned v)
     while ((v & 0x01) == 0) {
         v >>= 1;
         r++;
-    };
+    }
 
     return r;
 }

--- a/core/include/byteorder.h
+++ b/core/include/byteorder.h
@@ -38,8 +38,8 @@ extern "C" {
  *                 between different byte orders at compile time.
  */
 typedef union __attribute__((packed)) {
-    uint16_t    u16;    /**< 16 bit representation */
-    uint8_t      u8[2]; /**< 8 bit representation */
+    uint16_t u16;       /**< 16 bit representation */
+    uint8_t u8[2];      /**< 8 bit representation */
 } le_uint16_t;
 
 /**
@@ -48,9 +48,9 @@ typedef union __attribute__((packed)) {
  *                 between different byte orders at compile time.
  */
 typedef union __attribute__((packed)) {
-    uint32_t    u32;    /**< 32 bit representation */
-    uint8_t      u8[4]; /**< 8 bit representation */
-    uint16_t    u16[2]; /**< 16 bit representation */
+    uint32_t u32;       /**< 32 bit representation */
+    uint8_t u8[4];      /**< 8 bit representation */
+    uint16_t u16[2];    /**< 16 bit representation */
     le_uint16_t l16[2]; /**< little endian 16 bit representation */
 } le_uint32_t;
 
@@ -60,10 +60,10 @@ typedef union __attribute__((packed)) {
  *                 between different byte orders at compile time.
  */
 typedef union __attribute__((packed)) {
-    uint64_t    u64;    /**< 64 bit representation */
-    uint8_t      u8[8]; /**< 8 bit representation */
-    uint16_t    u16[4]; /**< 16 bit representation */
-    uint32_t    u32[2]; /**< 32 bit representation */
+    uint64_t u64;       /**< 64 bit representation */
+    uint8_t u8[8];      /**< 8 bit representation */
+    uint16_t u16[4];    /**< 16 bit representation */
+    uint32_t u32[2];    /**< 32 bit representation */
     le_uint16_t l16[4]; /**< little endian 16 bit representation */
     le_uint32_t l32[2]; /**< little endian 32 bit representation */
 } le_uint64_t;
@@ -74,8 +74,8 @@ typedef union __attribute__((packed)) {
  *                 between different byte orders at compile time.
  */
 typedef union __attribute__((packed)) {
-    uint16_t    u16;    /**< 16 bit representation */
-    uint8_t      u8[2]; /**< 8 bit representation */
+    uint16_t u16;       /**< 16 bit representation */
+    uint8_t u8[2];      /**< 8 bit representation */
 } be_uint16_t;
 
 /**
@@ -84,9 +84,9 @@ typedef union __attribute__((packed)) {
  *                 between different byte orders at compile time.
  */
 typedef union __attribute__((packed)) {
-    uint32_t    u32;    /**< 32 bit representation */
-    uint8_t      u8[4]; /**< 8 bit representation */
-    uint16_t    u16[2]; /**< 16 bit representation */
+    uint32_t u32;       /**< 32 bit representation */
+    uint8_t u8[4];      /**< 8 bit representation */
+    uint16_t u16[2];    /**< 16 bit representation */
     be_uint16_t b16[2]; /**< big endian 16 bit representation */
 } be_uint32_t;
 
@@ -96,10 +96,10 @@ typedef union __attribute__((packed)) {
  *                 between different byte orders at compile time.
  */
 typedef union __attribute__((packed)) {
-    uint64_t    u64;    /**< 64 bit representation */
-    uint8_t      u8[8]; /**< 8 bit representation */
-    uint16_t    u16[4]; /**< 16 bit representation */
-    uint32_t    u32[2]; /**< 32 bit representation */
+    uint64_t u64;       /**< 64 bit representation */
+    uint8_t u8[8];      /**< 8 bit representation */
+    uint16_t u16[4];    /**< 16 bit representation */
+    uint32_t u32[2];    /**< 32 bit representation */
     be_uint16_t b16[4]; /**< big endian 16 bit representation */
     be_uint32_t b32[2]; /**< big endian 32 bit representation */
 } be_uint64_t;
@@ -303,7 +303,7 @@ static inline uint64_t ntohll(uint64_t v);
 #ifdef HAVE_NO_BUILTIN_BSWAP16
 static inline unsigned short __builtin_bswap16(unsigned short a)
 {
-    return (a<<8)|(a>>8);
+    return (a << 8) | (a >> 8);
 }
 #endif
 
@@ -333,36 +333,42 @@ static inline uint64_t byteorder_swapll(uint64_t v)
 static inline be_uint16_t byteorder_ltobs(le_uint16_t v)
 {
     be_uint16_t result = { byteorder_swaps(v.u16) };
+
     return result;
 }
 
 static inline be_uint32_t byteorder_ltobl(le_uint32_t v)
 {
     be_uint32_t result = { byteorder_swapl(v.u32) };
+
     return result;
 }
 
 static inline be_uint64_t byteorder_ltobll(le_uint64_t v)
 {
     be_uint64_t result = { byteorder_swapll(v.u64) };
+
     return result;
 }
 
 static inline le_uint16_t byteorder_btols(be_uint16_t v)
 {
     le_uint16_t result = { byteorder_swaps(v.u16) };
+
     return result;
 }
 
 static inline le_uint32_t byteorder_btoll(be_uint32_t v)
 {
     le_uint32_t result = { byteorder_swapl(v.u32) };
+
     return result;
 }
 
 static inline le_uint64_t byteorder_btolll(be_uint64_t v)
 {
     le_uint64_t result = { byteorder_swapll(v.u64) };
+
     return result;
 }
 
@@ -370,7 +376,7 @@ static inline le_uint64_t byteorder_btolll(be_uint64_t v)
  * @brief Swaps the byteorder according to the endianness
  */
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-#   define _byteorder_swap(V, T) (byteorder_swap##T((V)))
+#   define _byteorder_swap(V, T) (byteorder_swap ## T((V)))
 #elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 #   define _byteorder_swap(V, T) (V)
 #else
@@ -380,18 +386,21 @@ static inline le_uint64_t byteorder_btolll(be_uint64_t v)
 static inline network_uint16_t byteorder_htons(uint16_t v)
 {
     network_uint16_t result = { _byteorder_swap(v, s) };
+
     return result;
 }
 
 static inline network_uint32_t byteorder_htonl(uint32_t v)
 {
     network_uint32_t result = { _byteorder_swap(v, l) };
+
     return result;
 }
 
 static inline network_uint64_t byteorder_htonll(uint64_t v)
 {
     network_uint64_t result = { _byteorder_swap(v, ll) };
+
     return result;
 }
 
@@ -428,18 +437,21 @@ static inline uint64_t htonll(uint64_t v)
 static inline uint16_t ntohs(uint16_t v)
 {
     network_uint16_t input = { v };
+
     return byteorder_ntohs(input);
 }
 
 static inline uint32_t ntohl(uint32_t v)
 {
     network_uint32_t input = { v };
+
     return byteorder_ntohl(input);
 }
 
 static inline uint64_t ntohll(uint64_t v)
 {
     network_uint64_t input = { v };
+
     return byteorder_ntohll(input);
 }
 

--- a/core/include/cib.h
+++ b/core/include/cib.h
@@ -7,7 +7,7 @@
  * directory for more details.
  */
 
- /**
+/**
  * @ingroup     core_util
  * @{
  *
@@ -40,7 +40,7 @@ typedef struct {
 /**
  * @brief   Initialize cib_t to a given size.
  */
-#define CIB_INIT(SIZE) { 0, 0, (SIZE) - 1 }
+#define CIB_INIT(SIZE) { 0, 0, (SIZE)-1 }
 
 /**
  * @brief Initialize @p cib to 0 and set buffer size to @p size.
@@ -80,7 +80,7 @@ static inline unsigned int cib_avail(const cib_t *cib)
  */
 static inline unsigned int cib_full(const cib_t *cib)
 {
-    return ((int) cib_avail(cib)) > ((int) cib->mask);
+    return ((int)cib_avail(cib)) > ((int)cib->mask);
 }
 
 /**
@@ -93,7 +93,7 @@ static inline unsigned int cib_full(const cib_t *cib)
 static inline int cib_get(cib_t *__restrict cib)
 {
     if (cib_avail(cib)) {
-        return (int) (cib->read_count++ & cib->mask);
+        return (int)(cib->read_count++ & cib->mask);
     }
 
     return -1;
@@ -109,7 +109,7 @@ static inline int cib_get(cib_t *__restrict cib)
 static inline int cib_peek(cib_t *__restrict cib)
 {
     if (cib_avail(cib)) {
-        return (int) (cib->read_count & cib->mask);
+        return (int)(cib->read_count & cib->mask);
     }
 
     return -1;
@@ -126,7 +126,7 @@ static inline int cib_peek(cib_t *__restrict cib)
  */
 static inline int cib_get_unsafe(cib_t *cib)
 {
-        return (int) (cib->read_count++ & cib->mask);
+    return (int)(cib->read_count++ & cib->mask);
 }
 
 /**
@@ -141,8 +141,8 @@ static inline int cib_put(cib_t *__restrict cib)
     unsigned int avail = cib_avail(cib);
 
     /* We use a signed compare, because the mask is -1u for an empty CIB. */
-    if ((int) avail <= (int) cib->mask) {
-        return (int) (cib->write_count++ & cib->mask);
+    if ((int)avail <= (int)cib->mask) {
+        return (int)(cib->write_count++ & cib->mask);
     }
 
     return -1;
@@ -159,7 +159,7 @@ static inline int cib_put(cib_t *__restrict cib)
  */
 static inline int cib_put_unsafe(cib_t *cib)
 {
-    return (int) (cib->write_count++ & cib->mask);
+    return (int)(cib->write_count++ & cib->mask);
 }
 
 #ifdef __cplusplus

--- a/core/include/clist.h
+++ b/core/include/clist.h
@@ -91,7 +91,7 @@
 #include "list.h"
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /**
@@ -252,9 +252,11 @@ static inline clist_node_t *clist_rpop(clist_node_t *list)
  * @returns         predecessor of node if found
  * @returns         NULL if node is not a list member
  */
-static inline clist_node_t *clist_find_before(const clist_node_t *list, const clist_node_t *node)
+static inline clist_node_t *clist_find_before(const clist_node_t *list,
+                                              const clist_node_t *node)
 {
     clist_node_t *pos = list->next;
+
     if (!pos) {
         return NULL;
     }
@@ -280,9 +282,11 @@ static inline clist_node_t *clist_find_before(const clist_node_t *list, const cl
  * @returns         node if found
  * @returns         NULL if node is not a list member
  */
-static inline clist_node_t *clist_find(const clist_node_t *list, const clist_node_t *node)
+static inline clist_node_t *clist_find(const clist_node_t *list,
+                                       const clist_node_t *node)
 {
     clist_node_t *tmp = clist_find_before(list, node);
+
     if (tmp) {
         return tmp->next;
     }
@@ -339,9 +343,12 @@ static inline clist_node_t *clist_remove(clist_node_t *list, clist_node_t *node)
  * @returns         NULL on empty list or full traversal
  * @returns         node that caused @p func(node, arg) to exit non-zero
  */
-static inline clist_node_t *clist_foreach(clist_node_t *list, int(*func)(clist_node_t *, void *), void *arg)
+static inline clist_node_t *clist_foreach(clist_node_t *list, int (*func)(
+                                              clist_node_t *,
+                                              void *), void *arg)
 {
     clist_node_t *node = list->next;
+
     if (node) {
         do {
             node = node->next;
@@ -432,6 +439,7 @@ static inline size_t clist_count(clist_node_t *list)
 {
     clist_node_t *node = list->next;
     size_t cnt = 0;
+
     if (node) {
         do {
             node = node->next;

--- a/core/include/debug.h
+++ b/core/include/debug.h
@@ -45,15 +45,16 @@ extern "C" {
 #ifdef DEVELHELP
 #include "cpu_conf.h"
 #define DEBUG_PRINT(...) \
-do { \
-    if ((sched_active_thread == NULL) || \
-        (sched_active_thread->stack_size >= THREAD_EXTRA_STACKSIZE_PRINTF)) { \
-        printf(__VA_ARGS__); \
-    } \
-    else { \
-        puts("Cannot debug, stack too small. Consider using DEBUG_PUTS()."); \
-    } \
-} while (0)
+    do { \
+        if ((sched_active_thread == NULL) || \
+            (sched_active_thread->stack_size >= \
+             THREAD_EXTRA_STACKSIZE_PRINTF)) { \
+            printf(__VA_ARGS__); \
+        } \
+        else { \
+            puts("Cannot debug, stack too small. Consider using DEBUG_PUTS()."); \
+        } \
+    } while (0)
 #else
 #define DEBUG_PRINT(...) printf(__VA_ARGS__)
 #endif

--- a/core/include/irq.h
+++ b/core/include/irq.h
@@ -24,7 +24,7 @@
 #include <stdbool.h>
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /**

--- a/core/include/kernel_defines.h
+++ b/core/include/kernel_defines.h
@@ -24,7 +24,7 @@
 #include <stddef.h>
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /* uncrustify gets mightily confused by these macros... */

--- a/core/include/kernel_defines.h
+++ b/core/include/kernel_defines.h
@@ -27,6 +27,9 @@
  extern "C" {
 #endif
 
+/* uncrustify gets mightily confused by these macros... */
+/* begin{code-style-ignore} */
+
 /**
  * @def         container_of(PTR, TYPE, MEMBER)
  * @brief       Returns the container of a pointer to a member.
@@ -215,6 +218,8 @@
 /**
  * @endcond
  */
+
+/* end{code-style-ignore} */
 
 #ifdef __cplusplus
 }

--- a/core/include/kernel_init.h
+++ b/core/include/kernel_init.h
@@ -22,7 +22,7 @@
 #define KERNEL_INIT_H
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /**

--- a/core/include/kernel_types.h
+++ b/core/include/kernel_types.h
@@ -36,17 +36,17 @@
 #       ifdef _POSIX_SSIZE_MAX
 #           define SSIZE_MAX _POSIX_SSIZE_MAX
 #       else
-#           define SSIZE_MAX ((ssize_t) (SIZE_MAX / 2))
+#           define SSIZE_MAX ((ssize_t)(SIZE_MAX / 2))
 #       endif
 #   endif
 
 #   ifdef MODULE_MSP430_COMMON
-        typedef signed ssize_t;
+typedef signed ssize_t;
 #   endif
 #endif
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /**

--- a/core/include/lifo.h
+++ b/core/include/lifo.h
@@ -24,7 +24,7 @@
 #define LIFO_H
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /**

--- a/core/include/log.h
+++ b/core/include/log.h
@@ -33,7 +33,7 @@
 #define LOG_H
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /**
@@ -75,13 +75,13 @@ enum {
  */
 #ifdef __clang__    /* following pragmas required for clang 3.8.0 */
 #define LOG(level, ...) do { \
-    _Pragma("clang diagnostic push") \
-    _Pragma("clang diagnostic ignored \"-Wtautological-compare\"") \
-    if ((level) <= LOG_LEVEL) log_write((level), __VA_ARGS__); } while (0U) \
-    _Pragma("clang diagnostic pop")
+        _Pragma("clang diagnostic push") \
+        _Pragma("clang diagnostic ignored \"-Wtautological-compare\"") \
+        if ((level) <= LOG_LEVEL) log_write((level), __VA_ARGS__); } while (0U) \
+        _Pragma("clang diagnostic pop")
 #else
 #define LOG(level, ...) do { \
-    if ((level) <= LOG_LEVEL) log_write((level), __VA_ARGS__); } while (0U)
+        if ((level) <= LOG_LEVEL) log_write((level), __VA_ARGS__); } while (0U)
 #endif /* __clang__ */
 
 /**

--- a/core/include/mbox.h
+++ b/core/include/mbox.h
@@ -32,8 +32,8 @@ extern "C" {
 
 /** Static initializer for mbox objects */
 #define MBOX_INIT(queue, queue_size) { \
-        {0}, {0}, CIB_INIT(queue_size), queue \
-    }
+        { 0 }, { 0 }, CIB_INIT(queue_size), queue \
+}
 
 /**
  * @brief Mailbox struct definition
@@ -59,9 +59,11 @@ enum {
  * @param[in]   queue       array of msg_t used as queue
  * @param[in]   queue_size  number of msg_t objects in queue
  */
-static inline void mbox_init(mbox_t *mbox, msg_t *queue, unsigned int queue_size)
+static inline void mbox_init(mbox_t *mbox, msg_t *queue,
+                             unsigned int queue_size)
 {
     mbox_t m = MBOX_INIT(queue, queue_size);
+
     *mbox = m;
 }
 

--- a/core/include/mbox.h
+++ b/core/include/mbox.h
@@ -31,7 +31,9 @@ extern "C" {
 #endif
 
 /** Static initializer for mbox objects */
-#define MBOX_INIT(queue, queue_size) {{0}, {0}, CIB_INIT(queue_size), queue}
+#define MBOX_INIT(queue, queue_size) { \
+        {0}, {0}, CIB_INIT(queue_size), queue \
+    }
 
 /**
  * @brief Mailbox struct definition

--- a/core/include/mutex.h
+++ b/core/include/mutex.h
@@ -28,7 +28,7 @@
 #include "list.h"
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /**
@@ -102,6 +102,7 @@ int _mutex_lock(mutex_t *mutex, volatile uint8_t *blocking);
 static inline int mutex_trylock(mutex_t *mutex)
 {
     volatile uint8_t blocking = 0;
+
     return _mutex_lock(mutex, &blocking);
 }
 
@@ -113,6 +114,7 @@ static inline int mutex_trylock(mutex_t *mutex)
 static inline void mutex_lock(mutex_t *mutex)
 {
     volatile uint8_t blocking = 1;
+
     _mutex_lock(mutex, &blocking);
 }
 

--- a/core/include/native_sched.h
+++ b/core/include/native_sched.h
@@ -34,7 +34,7 @@ extern "C" {
  * Required to use some C++11 headers with g++ on the native board.
  */
 #define __CPU_SETSIZE 1024
-#define __NCPUBITS (8* sizeof(__cpu_mask))
+#define __NCPUBITS (8 * sizeof(__cpu_mask))
 typedef unsigned long int __cpu_mask;
 typedef struct {
     __cpu_mask __bits[__CPU_SETSIZE / __NCPUBITS];

--- a/core/include/panic.h
+++ b/core/include/panic.h
@@ -25,7 +25,7 @@
 #include "kernel_defines.h"
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /**
@@ -38,18 +38,18 @@ typedef enum {
     PANIC_ASSERT_FAIL,
     PANIC_EXPECT_FAIL,
 #ifdef MODULE_CORTEXM_COMMON
-    PANIC_NMI_HANDLER,       /**< non maskable interrupt */
-    PANIC_HARD_FAULT,        /**< hard fault */
+    PANIC_NMI_HANDLER,          /**< non maskable interrupt */
+    PANIC_HARD_FAULT,           /**< hard fault */
 #if defined(CPU_ARCH_CORTEX_M3) || defined(CPU_ARCH_CORTEX_M4) || \
     defined(CPU_ARCH_CORTEX_M4F) || defined(CPU_ARCH_CORTEX_M7)
-    PANIC_MEM_MANAGE,        /**< memory controller interrupt */
-    PANIC_BUS_FAULT,         /**< bus fault */
-    PANIC_USAGE_FAULT,       /**< undefined instruction or unaligned access */
-    PANIC_DEBUG_MON,         /**< debug interrupt */
+    PANIC_MEM_MANAGE,           /**< memory controller interrupt */
+    PANIC_BUS_FAULT,            /**< bus fault */
+    PANIC_USAGE_FAULT,          /**< undefined instruction or unaligned access */
+    PANIC_DEBUG_MON,            /**< debug interrupt */
 #endif
-    PANIC_DUMMY_HANDLER,     /**< unhandled interrupt */
+    PANIC_DUMMY_HANDLER,        /**< unhandled interrupt */
 #endif
-    PANIC_SSP,               /**< stack smashing protector failure */
+    PANIC_SSP,                  /**< stack smashing protector failure */
     PANIC_UNDEFINED
 } core_panic_t;
 

--- a/core/include/priority_queue.h
+++ b/core/include/priority_queue.h
@@ -23,7 +23,7 @@
 #include <stdint.h>
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /**
@@ -56,9 +56,10 @@ typedef struct {
  *          pre-allocated priority_queue_node_t object, must not be NULL.
  */
 static inline void priority_queue_node_init(
-        priority_queue_node_t *priority_queue_node)
+    priority_queue_node_t *priority_queue_node)
 {
     priority_queue_node_t qn = PRIORITY_QUEUE_NODE_INIT;
+
     *priority_queue_node = qn;
 }
 
@@ -78,6 +79,7 @@ static inline void priority_queue_node_init(
 static inline void priority_queue_init(priority_queue_t *priority_queue)
 {
     priority_queue_t q = PRIORITY_QUEUE_INIT;
+
     *priority_queue = q;
 }
 

--- a/core/include/ringbuffer.h
+++ b/core/include/ringbuffer.h
@@ -47,7 +47,7 @@ typedef struct {
  * @param[in]    BUF   Buffer to use for the ringbuffer. The size is deduced through `sizeof (BUF)`.
  * @returns      The static initializer.
  */
-#define RINGBUFFER_INIT(BUF) { (BUF), sizeof (BUF), 0, 0 }
+#define RINGBUFFER_INIT(BUF) { (BUF), sizeof(BUF), 0, 0 }
 
 /**
  * @brief        Initialize a ringbuffer.
@@ -55,7 +55,8 @@ typedef struct {
  * @param[in]    buffer    Buffer to use by rb.
  * @param[in]    bufsize   `sizeof (buffer)`
  */
-static inline void ringbuffer_init(ringbuffer_t *__restrict rb, char *buffer, unsigned bufsize)
+static inline void ringbuffer_init(ringbuffer_t *__restrict rb, char *buffer,
+                                   unsigned bufsize)
 {
     rb->buf = buffer;
     rb->size = bufsize;
@@ -84,7 +85,8 @@ int ringbuffer_add_one(ringbuffer_t *__restrict rb, char c);
  * @param[in]       n     Maximum number of elements to add.
  * @returns         Number of elements actually added. 0 if rb is full.
  */
-unsigned ringbuffer_add(ringbuffer_t *__restrict rb, const char *buf, unsigned n);
+unsigned ringbuffer_add(ringbuffer_t *__restrict rb, const char *buf,
+                        unsigned n);
 
 /**
  * @brief           Peek and remove oldest element from the ringbuffer.
@@ -135,7 +137,8 @@ static inline int ringbuffer_full(const ringbuffer_t *__restrict rb)
  * @param[in,out]   rb Ringbuffer to query.
  * @returns         number of available bytes
  */
-static inline unsigned int ringbuffer_get_free(const ringbuffer_t *__restrict rb)
+static inline unsigned int ringbuffer_get_free(
+    const ringbuffer_t *__restrict rb)
 {
     return rb->size - rb->avail;
 }
@@ -154,7 +157,8 @@ int ringbuffer_peek_one(const ringbuffer_t *__restrict rb);
  * @param[in]       n     Read at most n elements.
  * @returns         Same as ringbuffer_get()
  */
-unsigned ringbuffer_peek(const ringbuffer_t *__restrict rb, char *buf, unsigned n);
+unsigned ringbuffer_peek(const ringbuffer_t *__restrict rb, char *buf,
+                         unsigned n);
 
 #ifdef __cplusplus
 }

--- a/core/include/rmutex.h
+++ b/core/include/rmutex.h
@@ -34,7 +34,7 @@
 #include "kernel_types.h"
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /**
@@ -80,6 +80,7 @@ typedef struct rmutex_t {
 static inline void rmutex_init(rmutex_t *rmutex)
 {
     rmutex_t empty_rmutex = RMUTEX_INIT;
+
     *rmutex = empty_rmutex;
 }
 

--- a/core/include/sched.h
+++ b/core/include/sched.h
@@ -87,7 +87,7 @@
 #include "clist.h"
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /**
@@ -122,7 +122,7 @@ typedef enum {
  * @{
  */
 #define STATUS_ON_RUNQUEUE      STATUS_RUNNING  /**< to check if on run queue:
-                                                 `st >= STATUS_ON_RUNQUEUE`   */
+                                                   `st >= STATUS_ON_RUNQUEUE`   */
 #define STATUS_NOT_FOUND ((thread_status_t)-1)  /**< Describes an illegal thread status */
 /** @} */
 /**

--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -130,7 +130,7 @@
 #endif
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /**
@@ -228,7 +228,8 @@ struct _thread {
  * @brief Size of the main task's stack in bytes
  */
 #ifndef THREAD_STACKSIZE_MAIN
-#define THREAD_STACKSIZE_MAIN      (THREAD_STACKSIZE_DEFAULT + THREAD_EXTRA_STACKSIZE_PRINTF)
+#define THREAD_STACKSIZE_MAIN      (THREAD_STACKSIZE_DEFAULT + \
+                                    THREAD_EXTRA_STACKSIZE_PRINTF)
 #endif
 
 /**
@@ -270,7 +271,7 @@ struct _thread {
  * @def THREAD_PRIORITY_MIN
  * @brief Least priority a thread can have
  */
-#define THREAD_PRIORITY_MIN            (SCHED_PRIO_LEVELS-1)
+#define THREAD_PRIORITY_MIN            (SCHED_PRIO_LEVELS - 1)
 
 /**
  * @def THREAD_PRIORITY_IDLE
@@ -283,7 +284,8 @@ struct _thread {
  * @brief Priority of the main thread
  */
 #ifndef THREAD_PRIORITY_MAIN
-#define THREAD_PRIORITY_MAIN           (THREAD_PRIORITY_MIN - (SCHED_PRIO_LEVELS/2))
+#define THREAD_PRIORITY_MAIN           (THREAD_PRIORITY_MIN - \
+                                        (SCHED_PRIO_LEVELS / 2))
 #endif
 
 /**
@@ -308,10 +310,10 @@ struct _thread {
  */
 #define THREAD_CREATE_WOUT_YIELD        (4)
 
- /**
-  * @brief Write markers into the thread's stack to measure stack usage (for
-  *        debugging and profiling purposes)
-  */
+/**
+ * @brief Write markers into the thread's stack to measure stack usage (for
+ *        debugging and profiling purposes)
+ */
 #define THREAD_CREATE_STACKTEST         (8)
 /** @} */
 
@@ -338,14 +340,14 @@ struct _thread {
  * @return              -EINVAL, if @p priority is greater than or equal to
  *                      @ref SCHED_PRIO_LEVELS
  * @return              -EOVERFLOW, if there are too many threads running already
-*/
+ */
 kernel_pid_t thread_create(char *stack,
-                  int stacksize,
-                  uint8_t priority,
-                  int flags,
-                  thread_task_func_t task_func,
-                  void *arg,
-                  const char *name);
+                           int stacksize,
+                           uint8_t priority,
+                           int flags,
+                           thread_task_func_t task_func,
+                           void *arg,
+                           const char *name);
 
 /**
  * @brief       Retrieve a thread control block by PID.
@@ -437,6 +439,7 @@ int thread_wakeup(kernel_pid_t pid);
 static inline kernel_pid_t thread_getpid(void)
 {
     extern volatile kernel_pid_t sched_active_pid;
+
     return sched_active_pid;
 }
 
@@ -450,7 +453,8 @@ static inline kernel_pid_t thread_getpid(void)
  *
  * @return stack pointer
  */
-char *thread_stack_init(thread_task_func_t task_func, void *arg, void *stack_start, int stack_size);
+char *thread_stack_init(thread_task_func_t task_func, void *arg,
+                        void *stack_start, int stack_size);
 
 /**
  * @brief Add thread to list, sorted by priority (internal)

--- a/core/lifo.c
+++ b/core/lifo.c
@@ -43,7 +43,9 @@ void lifo_insert(int *array, int i)
 
 #ifdef DEVELHELP
     if ((array[index] != -1) && (array[0] != -1)) {
-        LOG_WARNING("lifo_insert: overwriting array[%i] == %i with %i\n\n\n\t\tThe lifo is broken now.\n\n\n", index, array[index], array[0]);
+        LOG_WARNING(
+            "lifo_insert: overwriting array[%i] == %i with %i\n\n\n\t\tThe lifo is broken now.\n\n\n", index,
+            array[index], array[0]);
     }
 #endif
 
@@ -63,7 +65,7 @@ int lifo_get(int *array)
 #ifdef DEVELHELP
     /* make sure a double insert does not result in an infinite
      * resource of values */
-    array[head+1] = -1;
+    array[head + 1] = -1;
 #endif
 
     DEBUG("lifo_get: returning %i\n", head);

--- a/core/mbox.c
+++ b/core/mbox.c
@@ -32,8 +32,8 @@ static void _wake_waiter(thread_t *thread, unsigned irqstate)
 {
     sched_set_status(thread, STATUS_PENDING);
 
-    DEBUG("mbox: Thread %"PRIkernel_pid": _wake_waiter(): waking up "
-            "%"PRIkernel_pid".\n", sched_active_pid, thread->pid);
+    DEBUG("mbox: Thread %" PRIkernel_pid ": _wake_waiter(): waking up "
+          "%" PRIkernel_pid ".\n", sched_active_pid, thread->pid);
 
     uint16_t process_priority = thread->priority;
     irq_restore(irqstate);
@@ -42,17 +42,17 @@ static void _wake_waiter(thread_t *thread, unsigned irqstate)
 
 static void _wait(list_node_t *wait_list, unsigned irqstate)
 {
-    DEBUG("mbox: Thread %"PRIkernel_pid" _wait(): going blocked.\n",
-            sched_active_pid);
+    DEBUG("mbox: Thread %" PRIkernel_pid " _wait(): going blocked.\n",
+          sched_active_pid);
 
-    thread_t *me = (thread_t*) sched_active_thread;
+    thread_t *me = (thread_t *)sched_active_thread;
     sched_set_status(me, STATUS_MBOX_BLOCKED);
     thread_add_to_list(wait_list, me);
     irq_restore(irqstate);
     thread_yield();
 
-    DEBUG("mbox: Thread %"PRIkernel_pid" _wait(): woke up.\n",
-            sched_active_pid);
+    DEBUG("mbox: Thread %" PRIkernel_pid " _wait(): woke up.\n",
+          sched_active_pid);
 }
 
 int _mbox_put(mbox_t *mbox, msg_t *msg, int blocking)
@@ -60,10 +60,12 @@ int _mbox_put(mbox_t *mbox, msg_t *msg, int blocking)
     unsigned irqstate = irq_disable();
 
     list_node_t *next = list_remove_head(&mbox->readers);
+
     if (next) {
-        DEBUG("mbox: Thread %"PRIkernel_pid" mbox 0x%08x: _tryput(): "
-                "there's a waiter.\n", sched_active_pid, (unsigned)mbox);
-        thread_t *thread = container_of((clist_node_t*)next, thread_t, rq_entry);
+        DEBUG("mbox: Thread %" PRIkernel_pid " mbox 0x%08x: _tryput(): "
+              "there's a waiter.\n", sched_active_pid, (unsigned)mbox);
+        thread_t *thread =
+            container_of((clist_node_t *)next, thread_t, rq_entry);
         *(msg_t *)thread->wait_data = *msg;
         _wake_waiter(thread, irqstate);
         return 1;
@@ -80,8 +82,8 @@ int _mbox_put(mbox_t *mbox, msg_t *msg, int blocking)
             }
         }
 
-        DEBUG("mbox: Thread %"PRIkernel_pid" mbox 0x%08x: _tryput(): "
-                "queued message.\n", sched_active_pid, (unsigned)mbox);
+        DEBUG("mbox: Thread %" PRIkernel_pid " mbox 0x%08x: _tryput(): "
+              "queued message.\n", sched_active_pid, (unsigned)mbox);
         msg->sender_pid = sched_active_pid;
         /* copy msg into queue */
         mbox->msg_array[cib_put_unsafe(&mbox->cib)] = *msg;
@@ -95,13 +97,14 @@ int _mbox_get(mbox_t *mbox, msg_t *msg, int blocking)
     unsigned irqstate = irq_disable();
 
     if (cib_avail(&mbox->cib)) {
-        DEBUG("mbox: Thread %"PRIkernel_pid" mbox 0x%08x: _tryget(): "
-                "got queued message.\n", sched_active_pid, (unsigned)mbox);
+        DEBUG("mbox: Thread %" PRIkernel_pid " mbox 0x%08x: _tryget(): "
+              "got queued message.\n", sched_active_pid, (unsigned)mbox);
         /* copy msg from queue */
         *msg = mbox->msg_array[cib_get_unsafe(&mbox->cib)];
         list_node_t *next = list_remove_head(&mbox->writers);
         if (next) {
-            thread_t *thread = container_of((clist_node_t*)next, thread_t, rq_entry);
+            thread_t *thread = container_of((clist_node_t *)next, thread_t,
+                                            rq_entry);
             _wake_waiter(thread, irqstate);
         }
         else {
@@ -110,7 +113,7 @@ int _mbox_get(mbox_t *mbox, msg_t *msg, int blocking)
         return 1;
     }
     else if (blocking) {
-        sched_active_thread->wait_data = (void*)msg;
+        sched_active_thread->wait_data = (void *)msg;
         _wait(&mbox->readers, irqstate);
         /* sender has copied message */
         return 1;

--- a/core/mutex.c
+++ b/core/mutex.c
@@ -47,12 +47,12 @@ int _mutex_lock(mutex_t *mutex, volatile uint8_t *blocking)
         return 1;
     }
     else if (*blocking) {
-        thread_t *me = (thread_t*)sched_active_thread;
+        thread_t *me = (thread_t *)sched_active_thread;
         DEBUG("PID[%" PRIkernel_pid "]: Adding node to mutex queue: prio: %"
               PRIu32 "\n", sched_active_pid, (uint32_t)me->priority);
         sched_set_status(me, STATUS_MUTEX_BLOCKED);
         if (mutex->queue.next == MUTEX_LOCKED) {
-            mutex->queue.next = (list_node_t*)&me->rq_entry;
+            mutex->queue.next = (list_node_t *)&me->rq_entry;
             mutex->queue.next->next = NULL;
         }
         else {
@@ -92,7 +92,7 @@ void mutex_unlock(mutex_t *mutex)
 
     list_node_t *next = list_remove_head(&mutex->queue);
 
-    thread_t *process = container_of((clist_node_t*)next, thread_t, rq_entry);
+    thread_t *process = container_of((clist_node_t *)next, thread_t, rq_entry);
 
     DEBUG("mutex_unlock: waking up waiting thread %" PRIkernel_pid "\n",
           process->pid);
@@ -119,7 +119,7 @@ void mutex_unlock_and_sleep(mutex_t *mutex)
         }
         else {
             list_node_t *next = list_remove_head(&mutex->queue);
-            thread_t *process = container_of((clist_node_t*)next, thread_t,
+            thread_t *process = container_of((clist_node_t *)next, thread_t,
                                              rq_entry);
             DEBUG("PID[%" PRIkernel_pid "]: waking up waiter.\n", process->pid);
             sched_set_status(process, STATUS_PENDING);
@@ -130,7 +130,7 @@ void mutex_unlock_and_sleep(mutex_t *mutex)
     }
 
     DEBUG("PID[%" PRIkernel_pid "]: going to sleep.\n", sched_active_pid);
-    sched_set_status((thread_t*)sched_active_thread, STATUS_SLEEPING);
+    sched_set_status((thread_t *)sched_active_thread, STATUS_SLEEPING);
     irq_restore(irqstate);
     thread_yield_higher();
 }

--- a/core/panic.c
+++ b/core/panic.c
@@ -50,7 +50,7 @@ void __attribute__((weak)) panic_arch(void)
 NORETURN void core_panic(core_panic_t crash_code, const char *message)
 {
 #ifdef NDEBUG
-    (void) crash_code;
+    (void)crash_code;
 #endif
 
     if (crashed == 0) {

--- a/core/panic.c
+++ b/core/panic.c
@@ -41,7 +41,10 @@ const char assert_crash_message[] = "FAILED ASSERTION.";
 /* flag preventing "recursive crash printing loop" */
 static int crashed = 0;
 
-void __attribute__((weak)) panic_arch(void) {}
+void __attribute__((weak)) panic_arch(void)
+{
+    return;
+}
 
 /* WARNING: this function NEVER returns! */
 NORETURN void core_panic(core_panic_t crash_code, const char *message)

--- a/core/priority_queue.c
+++ b/core/priority_queue.c
@@ -28,7 +28,7 @@
 void priority_queue_remove(priority_queue_t *root_, priority_queue_node_t *node)
 {
     /* The strict aliasing rules allow this assignment. */
-    priority_queue_node_t *root = (priority_queue_node_t *) root_;
+    priority_queue_node_t *root = (priority_queue_node_t *)root_;
 
     while (root->next != NULL) {
         if (root->next == node) {
@@ -44,6 +44,7 @@ void priority_queue_remove(priority_queue_t *root_, priority_queue_node_t *node)
 priority_queue_node_t *priority_queue_remove_head(priority_queue_t *root)
 {
     priority_queue_node_t *head = root->first;
+
     if (head) {
         root->first = head->next;
     }
@@ -53,7 +54,7 @@ priority_queue_node_t *priority_queue_remove_head(priority_queue_t *root)
 void priority_queue_add(priority_queue_t *root, priority_queue_node_t *new_obj)
 {
     /* The strict aliasing rules allow this assignment. */
-    priority_queue_node_t *node = (priority_queue_node_t *) root;
+    priority_queue_node_t *node = (priority_queue_node_t *)root;
 
     while (node->next != NULL) {
         /* not trying to add the same node twice */
@@ -77,12 +78,14 @@ void priority_queue_print(priority_queue_t *root)
     printf("queue:\n");
 
     for (priority_queue_node_t *node = root->first; node; node = node->next) {
-        printf("Data: %u Priority: %lu\n", node->data, (unsigned long) node->priority);
+        printf("Data: %u Priority: %lu\n", node->data,
+               (unsigned long)node->priority);
     }
 }
 
 void priority_queue_print_node(priority_queue_node_t *node)
 {
-    printf("Data: %u Priority: %lu Next: %u\n", (unsigned int) node->data, (unsigned long) node->priority, (unsigned int)node->next);
+    printf("Data: %u Priority: %lu Next: %u\n", (unsigned int)node->data,
+           (unsigned long)node->priority, (unsigned int)node->next);
 }
 #endif

--- a/core/ringbuffer.c
+++ b/core/ringbuffer.c
@@ -30,6 +30,7 @@
 static void add_tail(ringbuffer_t *restrict rb, char c)
 {
     unsigned pos = rb->start + rb->avail++;
+
     if (pos >= rb->size) {
         pos -= rb->size;
     }
@@ -46,6 +47,7 @@ static void add_tail(ringbuffer_t *restrict rb, char c)
 static char get_head(ringbuffer_t *restrict rb)
 {
     char result = rb->buf[rb->start];
+
     if ((--rb->avail == 0) || (++rb->start == rb->size)) {
         rb->start = 0;
     }
@@ -55,6 +57,7 @@ static char get_head(ringbuffer_t *restrict rb)
 unsigned ringbuffer_add(ringbuffer_t *restrict rb, const char *buf, unsigned n)
 {
     unsigned i;
+
     for (i = 0; i < n; i++) {
         if (ringbuffer_full(rb)) {
             break;
@@ -67,8 +70,9 @@ unsigned ringbuffer_add(ringbuffer_t *restrict rb, const char *buf, unsigned n)
 int ringbuffer_add_one(ringbuffer_t *restrict rb, char c)
 {
     int result = -1;
+
     if (ringbuffer_full(rb)) {
-        result = (unsigned char) get_head(rb);
+        result = (unsigned char)get_head(rb);
     }
     add_tail(rb, c);
     return result;
@@ -77,7 +81,7 @@ int ringbuffer_add_one(ringbuffer_t *restrict rb, char c)
 int ringbuffer_get_one(ringbuffer_t *restrict rb)
 {
     if (!ringbuffer_empty(rb)) {
-        return (unsigned char) get_head(rb);
+        return (unsigned char)get_head(rb);
     }
     else {
         return -1;
@@ -132,11 +136,14 @@ unsigned ringbuffer_remove(ringbuffer_t *restrict rb, unsigned n)
 int ringbuffer_peek_one(const ringbuffer_t *restrict rb_)
 {
     ringbuffer_t rb = *rb_;
+
     return ringbuffer_get_one(&rb);
 }
 
-unsigned ringbuffer_peek(const ringbuffer_t *restrict rb_, char *buf, unsigned n)
+unsigned ringbuffer_peek(const ringbuffer_t *restrict rb_, char *buf,
+                         unsigned n)
 {
     ringbuffer_t rb = *rb_;
+
     return ringbuffer_get(&rb, buf, n);
 }

--- a/core/rmutex.c
+++ b/core/rmutex.c
@@ -36,9 +36,9 @@ static int _lock(rmutex_t *rmutex, int trylock)
     kernel_pid_t owner;
 
     /* try to lock the mutex */
-    DEBUG("rmutex %" PRIi16" : trylock\n", thread_getpid());
+    DEBUG("rmutex %" PRIi16 " : trylock\n", thread_getpid());
     if (mutex_trylock(&rmutex->mutex) == 0) {
-        DEBUG("rmutex %" PRIi16" : mutex already held\n", thread_getpid());
+        DEBUG("rmutex %" PRIi16 " : mutex already held\n", thread_getpid());
         /* Mutex is already held
          *
          * Case 1: Mutex is not held by me
@@ -79,12 +79,13 @@ static int _lock(rmutex_t *rmutex, int trylock)
 
         /* ensure that owner is read atomically, since I need a consistent value */
         owner = atomic_load_explicit(&rmutex->owner, memory_order_relaxed);
-        DEBUG("rmutex %" PRIi16" : mutex held by %" PRIi16" \n", thread_getpid(), owner);
+        DEBUG("rmutex %" PRIi16 " : mutex held by %" PRIi16 " \n",
+              thread_getpid(), owner);
 
         /* Case 1: Mutex is not held by me */
         if (owner != thread_getpid()) {
             /* wait for the mutex */
-            DEBUG("rmutex %" PRIi16" : locking mutex\n", thread_getpid());
+            DEBUG("rmutex %" PRIi16 " : locking mutex\n", thread_getpid());
 
             if (trylock) {
                 return 0;
@@ -97,15 +98,16 @@ static int _lock(rmutex_t *rmutex, int trylock)
         /* Note: There is nothing to do for Case 2; refcount is incremented below */
     }
 
-    DEBUG("rmutex %" PRIi16" : I am now holding the mutex\n", thread_getpid());
+    DEBUG("rmutex %" PRIi16 " : I am now holding the mutex\n", thread_getpid());
 
     /* I am holding the recursive mutex */
-    DEBUG("rmutex %" PRIi16" : setting the owner\n", thread_getpid());
+    DEBUG("rmutex %" PRIi16 " : setting the owner\n", thread_getpid());
 
     /* ensure that owner is written atomically, since others need a consistent value */
-    atomic_store_explicit(&rmutex->owner, thread_getpid(), memory_order_relaxed);
+    atomic_store_explicit(&rmutex->owner, thread_getpid(),
+                          memory_order_relaxed);
 
-    DEBUG("rmutex %" PRIi16" : increasing refs\n", thread_getpid());
+    DEBUG("rmutex %" PRIi16 " : increasing refs\n", thread_getpid());
 
     /* increase the refcount */
     rmutex->refcount++;
@@ -125,10 +127,11 @@ int rmutex_trylock(rmutex_t *rmutex)
 
 void rmutex_unlock(rmutex_t *rmutex)
 {
-    assert(atomic_load_explicit(&rmutex->owner,memory_order_relaxed) == thread_getpid());
+    assert(atomic_load_explicit(&rmutex->owner,
+                                memory_order_relaxed) == thread_getpid());
     assert(rmutex->refcount > 0);
 
-    DEBUG("rmutex %" PRIi16" : decrementing refs refs\n", thread_getpid());
+    DEBUG("rmutex %" PRIi16 " : decrementing refs refs\n", thread_getpid());
 
     /* decrement refcount */
     rmutex->refcount--;
@@ -137,12 +140,13 @@ void rmutex_unlock(rmutex_t *rmutex)
     if (rmutex->refcount == 0) {
         /* if not release the mutex */
 
-        DEBUG("rmutex %" PRIi16" : resetting owner\n", thread_getpid());
+        DEBUG("rmutex %" PRIi16 " : resetting owner\n", thread_getpid());
 
         /* ensure that owner is written only once */
-        atomic_store_explicit(&rmutex->owner, KERNEL_PID_UNDEF, memory_order_relaxed);
+        atomic_store_explicit(&rmutex->owner, KERNEL_PID_UNDEF,
+                              memory_order_relaxed);
 
-        DEBUG("rmutex %" PRIi16" : releasing mutex\n", thread_getpid());
+        DEBUG("rmutex %" PRIi16 " : releasing mutex\n", thread_getpid());
 
         mutex_unlock(&rmutex->mutex);
     }

--- a/core/sched.c
+++ b/core/sched.c
@@ -85,9 +85,12 @@ int __attribute__((used)) sched_run(void)
     int nextrq = bitarithm_lsb(runqueue_bitcache);
     thread_t *next_thread = container_of(sched_runqueues[nextrq].next->next, thread_t, rq_entry);
 
-    DEBUG("sched_run: active thread: %" PRIkernel_pid ", next thread: %" PRIkernel_pid "\n",
-          (kernel_pid_t)((active_thread == NULL) ? KERNEL_PID_UNDEF : active_thread->pid),
-          next_thread->pid);
+    DEBUG(
+        "sched_run: active thread: %" PRIkernel_pid ", next thread: %" PRIkernel_pid "\n",
+        (kernel_pid_t)((active_thread == NULL)
+                       ? KERNEL_PID_UNDEF
+                       : active_thread->pid),
+        next_thread->pid);
 
     if (active_thread == next_thread) {
         DEBUG("sched_run: done, sched_active_thread was not changed.\n");

--- a/core/sched.c
+++ b/core/sched.c
@@ -54,9 +54,11 @@ static uint32_t runqueue_bitcache = 0;
 
 /* Needed by OpenOCD to read sched_threads */
 #if defined(__APPLE__) && defined(__MACH__)
- #define FORCE_USED_SECTION __attribute__((used)) __attribute__((section ("__OPENOCD,__openocd")))
+ #define FORCE_USED_SECTION __attribute__((used)) __attribute__((section( \
+                                                                     "__OPENOCD,__openocd")))
 #else
- #define FORCE_USED_SECTION __attribute__((used)) __attribute__((section (".openocd")))
+ #define FORCE_USED_SECTION __attribute__((used)) __attribute__((section( \
+                                                                     ".openocd")))
 #endif
 
 FORCE_USED_SECTION
@@ -70,7 +72,8 @@ const uint8_t _tcb_name_offset = offsetof(thread_t, name);
 #endif
 
 #ifdef MODULE_SCHED_CB
-static void (*sched_cb) (kernel_pid_t active_thread, kernel_pid_t next_thread) = NULL;
+static void (*sched_cb) (kernel_pid_t active_thread,
+                         kernel_pid_t next_thread) = NULL;
 #endif
 
 int __attribute__((used)) sched_run(void)
@@ -83,7 +86,8 @@ int __attribute__((used)) sched_run(void)
      * since the threading should not be started before at least the idle thread was started.
      */
     int nextrq = bitarithm_lsb(runqueue_bitcache);
-    thread_t *next_thread = container_of(sched_runqueues[nextrq].next->next, thread_t, rq_entry);
+    thread_t *next_thread = container_of(sched_runqueues[nextrq].next->next,
+                                         thread_t, rq_entry);
 
     DEBUG(
         "sched_run: active thread: %" PRIkernel_pid ", next thread: %" PRIkernel_pid "\n",
@@ -103,8 +107,11 @@ int __attribute__((used)) sched_run(void)
         }
 
 #ifdef SCHED_TEST_STACK
-        if (*((uintptr_t *) active_thread->stack_start) != (uintptr_t) active_thread->stack_start) {
-            LOG_WARNING("scheduler(): stack overflow detected, pid=%" PRIkernel_pid "\n", active_thread->pid);
+        if (*((uintptr_t *)active_thread->stack_start) !=
+            (uintptr_t)active_thread->stack_start) {
+            LOG_WARNING(
+                "scheduler(): stack overflow detected, pid=%" PRIkernel_pid "\n",
+                active_thread->pid);
         }
 #endif
     }
@@ -120,14 +127,14 @@ int __attribute__((used)) sched_run(void)
 
     next_thread->status = STATUS_RUNNING;
     sched_active_pid = next_thread->pid;
-    sched_active_thread = (volatile thread_t *) next_thread;
+    sched_active_thread = (volatile thread_t *)next_thread;
 
 #ifdef MODULE_MPU_STACK_GUARD
     mpu_configure(
-        2,                                                /* MPU region 2 */
-        (uintptr_t)sched_active_thread->stack_start + 31, /* Base Address (rounded up) */
-        MPU_ATTR(1, AP_RO_RO, 0, 1, 0, 1, MPU_SIZE_32B)   /* Attributes and Size */
-    );
+        2,                                                  /* MPU region 2 */
+        (uintptr_t)sched_active_thread->stack_start + 31,   /* Base Address (rounded up) */
+        MPU_ATTR(1, AP_RO_RO, 0, 1, 0, 1, MPU_SIZE_32B)     /* Attributes and Size */
+        );
 
     mpu_enable();
 #endif
@@ -141,16 +148,19 @@ void sched_set_status(thread_t *process, thread_status_t status)
 {
     if (status >= STATUS_ON_RUNQUEUE) {
         if (!(process->status >= STATUS_ON_RUNQUEUE)) {
-            DEBUG("sched_set_status: adding thread %" PRIkernel_pid " to runqueue %" PRIu8 ".\n",
-                  process->pid, process->priority);
-            clist_rpush(&sched_runqueues[process->priority], &(process->rq_entry));
+            DEBUG(
+                "sched_set_status: adding thread %" PRIkernel_pid " to runqueue %" PRIu8 ".\n",
+                process->pid, process->priority);
+            clist_rpush(&sched_runqueues[process->priority],
+                        &(process->rq_entry));
             runqueue_bitcache |= 1 << process->priority;
         }
     }
     else {
         if (process->status >= STATUS_ON_RUNQUEUE) {
-            DEBUG("sched_set_status: removing thread %" PRIkernel_pid " from runqueue %" PRIu8 ".\n",
-                  process->pid, process->priority);
+            DEBUG(
+                "sched_set_status: removing thread %" PRIkernel_pid " from runqueue %" PRIu8 ".\n",
+                process->pid, process->priority);
             clist_lpop(&sched_runqueues[process->priority]);
 
             if (!sched_runqueues[process->priority].next) {
@@ -164,13 +174,14 @@ void sched_set_status(thread_t *process, thread_status_t status)
 
 void sched_switch(uint16_t other_prio)
 {
-    thread_t *active_thread = (thread_t *) sched_active_thread;
+    thread_t *active_thread = (thread_t *)sched_active_thread;
     uint16_t current_prio = active_thread->priority;
     int on_runqueue = (active_thread->status >= STATUS_ON_RUNQUEUE);
 
-    DEBUG("sched_switch: active pid=%" PRIkernel_pid" prio=%" PRIu16 " on_runqueue=%i "
+    DEBUG("sched_switch: active pid=%" PRIkernel_pid " prio=%" PRIu16 " on_runqueue=%i "
           ", other_prio=%" PRIu16 "\n",
-          active_thread->pid, current_prio, on_runqueue, other_prio);
+          active_thread->pid, current_prio, on_runqueue,
+          other_prio);
 
     if (!on_runqueue || (current_prio > other_prio)) {
         if (irq_is_in()) {
@@ -189,9 +200,10 @@ void sched_switch(uint16_t other_prio)
 
 NORETURN void sched_task_exit(void)
 {
-    DEBUG("sched_task_exit: ending thread %" PRIkernel_pid "...\n", sched_active_thread->pid);
+    DEBUG("sched_task_exit: ending thread %" PRIkernel_pid "...\n",
+          sched_active_thread->pid);
 
-    (void) irq_disable();
+    (void)irq_disable();
     sched_threads[sched_active_pid] = NULL;
     sched_num_threads--;
 

--- a/core/thread_flags.c
+++ b/core/thread_flags.c
@@ -26,19 +26,23 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-static thread_flags_t _thread_flags_clear_atomic(thread_t *thread, thread_flags_t mask)
+static thread_flags_t _thread_flags_clear_atomic(thread_t *thread,
+                                                 thread_flags_t mask)
 {
     unsigned state = irq_disable();
+
     mask &= thread->flags;
     thread->flags &= ~mask;
     irq_restore(state);
     return mask;
 }
 
-static void _thread_flags_wait(thread_flags_t mask, thread_t *thread, unsigned threadstate, unsigned irqstate)
+static void _thread_flags_wait(thread_flags_t mask, thread_t *thread,
+                               unsigned threadstate, unsigned irqstate)
 {
-    DEBUG("_thread_flags_wait: me->flags=0x%08x me->mask=0x%08x. going blocked.\n",
-            (unsigned)thread->flags, (unsigned)mask);
+    DEBUG(
+        "_thread_flags_wait: me->flags=0x%08x me->mask=0x%08x. going blocked.\n",
+        (unsigned)thread->flags, (unsigned)mask);
 
     thread->wait_data = (void *)(unsigned)mask;
     sched_set_status(thread, threadstate);
@@ -48,16 +52,19 @@ static void _thread_flags_wait(thread_flags_t mask, thread_t *thread, unsigned t
 
 thread_flags_t thread_flags_clear(thread_flags_t mask)
 {
-    thread_t *me = (thread_t*) sched_active_thread;
+    thread_t *me = (thread_t *)sched_active_thread;
+
     mask = _thread_flags_clear_atomic(me, mask);
-    DEBUG("thread_flags_clear(): pid %"PRIkernel_pid" clearing 0x%08x\n", thread_getpid(), mask);
+    DEBUG("thread_flags_clear(): pid %" PRIkernel_pid " clearing 0x%08x\n",
+          thread_getpid(), mask);
     return mask;
 }
 
 static void _thread_flags_wait_any(thread_flags_t mask)
 {
-    thread_t *me = (thread_t*) sched_active_thread;
+    thread_t *me = (thread_t *)sched_active_thread;
     unsigned state = irq_disable();
+
     if (!(me->flags & mask)) {
         _thread_flags_wait(mask, me, STATUS_FLAG_BLOCKED_ANY, state);
     }
@@ -68,7 +75,8 @@ static void _thread_flags_wait_any(thread_flags_t mask)
 
 thread_flags_t thread_flags_wait_any(thread_flags_t mask)
 {
-    thread_t *me = (thread_t*) sched_active_thread;
+    thread_t *me = (thread_t *)sched_active_thread;
+
     _thread_flags_wait_any(mask);
     return _thread_flags_clear_atomic(me, mask);
 }
@@ -76,7 +84,7 @@ thread_flags_t thread_flags_wait_any(thread_flags_t mask)
 thread_flags_t thread_flags_wait_one(thread_flags_t mask)
 {
     _thread_flags_wait_any(mask);
-    thread_t *me = (thread_t*) sched_active_thread;
+    thread_t *me = (thread_t *)sched_active_thread;
     thread_flags_t tmp = me->flags & mask;
     /* clear all but least significant bit */
     tmp &= (~tmp + 1);
@@ -86,9 +94,12 @@ thread_flags_t thread_flags_wait_one(thread_flags_t mask)
 thread_flags_t thread_flags_wait_all(thread_flags_t mask)
 {
     unsigned state = irq_disable();
-    thread_t *me = (thread_t*) sched_active_thread;
+    thread_t *me = (thread_t *)sched_active_thread;
+
     if (!((me->flags & mask) == mask)) {
-        DEBUG("thread_flags_wait_all(): pid %"PRIkernel_pid" waiting for %08x\n", thread_getpid(), (unsigned)mask);
+        DEBUG(
+            "thread_flags_wait_all(): pid %" PRIkernel_pid " waiting for %08x\n",
+            thread_getpid(), (unsigned)mask);
         _thread_flags_wait(mask, me, STATUS_FLAG_BLOCKED_ALL, state);
     }
     else {
@@ -102,7 +113,8 @@ inline int __attribute__((always_inline)) thread_flags_wake(thread_t *thread)
 {
     unsigned wakeup;
     thread_flags_t mask = (uint16_t)(unsigned)thread->wait_data;
-    switch(thread->status) {
+
+    switch (thread->status) {
         case STATUS_FLAG_BLOCKED_ANY:
             wakeup = (thread->flags & mask);
             break;
@@ -115,7 +127,8 @@ inline int __attribute__((always_inline)) thread_flags_wake(thread_t *thread)
     }
 
     if (wakeup) {
-        DEBUG("_thread_flags_wake(): waking up pid %"PRIkernel_pid"\n", thread->pid);
+        DEBUG("_thread_flags_wake(): waking up pid %" PRIkernel_pid "\n",
+              thread->pid);
         sched_set_status(thread, STATUS_PENDING);
         sched_context_switch_request = 1;
     }
@@ -125,7 +138,8 @@ inline int __attribute__((always_inline)) thread_flags_wake(thread_t *thread)
 
 void thread_flags_set(thread_t *thread, thread_flags_t mask)
 {
-    DEBUG("thread_flags_set(): setting 0x%08x for pid %"PRIkernel_pid"\n", mask, thread->pid);
+    DEBUG("thread_flags_set(): setting 0x%08x for pid %" PRIkernel_pid "\n",
+          mask, thread->pid);
     unsigned state = irq_disable();
     thread->flags |= mask;
     if (thread_flags_wake(thread)) {


### PR DESCRIPTION
### Contribution description

This PR applies the current uncrustify-riot.cfg to core.
```atomic_*.c``` are excluded due to too many misformattings in the macros.

Most of the changes are alright. My main pain point are string concatenations for inttype format macros, e.g.,

```DEBUG("foo %"PRIu32"\n");```

changes into

```DEBUG("foo %" PRIu32 "\n");```

(note the extra spaces between ```"``` and ```PRIu32```.

But I can live with that.

### Testing procedure

Check diff.

### Issues/PRs references

- #8519.

- ~~needs #10873~~