### PR TITLE
pkg/semtech-loramac: add timer calibration

### DIFF
--- a/pkg/semtech-loramac/contrib/semtech_loramac.c
+++ b/pkg/semtech-loramac/contrib/semtech_loramac.c
@@ -433,10 +433,14 @@ void _init_loramac(semtech_loramac_t *mac,
     semtech_loramac_set_class(mac, LORAMAC_DEFAULT_DEVICE_CLASS);
     semtech_loramac_set_tx_port(mac, LORAMAC_DEFAULT_TX_PORT);
     semtech_loramac_set_tx_mode(mac, LORAMAC_DEFAULT_TX_MODE);
+    semtech_loramac_set_system_max_rx_error(mac,
+            LORAMAC_DEFAULT_SYSTEM_MAX_RX_ERROR);
+    semtech_loramac_set_min_rx_symbols(mac, LORAMAC_DEFAULT_MIN_RX_SYMBOLS);
     mac->link_chk.available = false;
 #ifdef MODULE_PERIPH_EEPROM
     _read_loramac_config(mac);
 #endif
+
 }
 
 static void _join_otaa(semtech_loramac_t *mac)

--- a/pkg/semtech-loramac/contrib/semtech_loramac_getset.c
+++ b/pkg/semtech-loramac/contrib/semtech_loramac_getset.c
@@ -253,6 +253,26 @@ uint8_t semtech_loramac_get_tx_mode(semtech_loramac_t *mac)
     return mac->cnf;
 }
 
+void semtech_loramac_set_system_max_rx_error(semtech_loramac_t *mac, int error)
+{
+    MibRequestConfirm_t mibReq;
+    mutex_lock(&mac->lock);
+    mibReq.Type = MIB_SYSTEM_MAX_RX_ERROR;
+    mibReq.Param.SystemMaxRxError = error;
+    LoRaMacMibSetRequestConfirm(&mibReq);
+    mutex_unlock(&mac->lock);
+}
+
+void semtech_loramac_set_min_rx_symbols(semtech_loramac_t *mac, int min_rx)
+{
+    MibRequestConfirm_t mibReq;
+    mutex_lock(&mac->lock);
+    mibReq.Type = MIB_MIN_RX_SYMBOLS;
+    mibReq.Param.MinRxSymbols = min_rx;
+    LoRaMacMibSetRequestConfirm(&mibReq);
+    mutex_unlock(&mac->lock);
+}
+
 static void _semtech_loramac_set_rx2_params(semtech_loramac_channel_params_t params)
 {
     Rx2ChannelParams_t p;

--- a/pkg/semtech-loramac/contrib/semtech_loramac_radio.c
+++ b/pkg/semtech-loramac/contrib/semtech_loramac_radio.c
@@ -96,7 +96,7 @@ void SX127XSetRxConfig(RadioModems_t modem, uint32_t bandwidth,
     sx127x_set_freq_hop(&sx127x, freqHopOn);
     sx127x_set_hop_period(&sx127x, hopPeriod);
     sx127x_set_iq_invert(&sx127x, iqInverted);
-    sx127x_set_symbol_timeout(&sx127x, 2 * symbTimeout);
+    sx127x_set_symbol_timeout(&sx127x, symbTimeout);
     sx127x_set_rx_single(&sx127x, !rxContinuous);
 }
 

--- a/pkg/semtech-loramac/contrib/semtech_loramac_timer.c
+++ b/pkg/semtech-loramac/contrib/semtech_loramac_timer.c
@@ -60,12 +60,7 @@ void TimerSetValue(TimerEvent_t *obj, uint32_t value)
         xtimer_remove(&(obj->dev));
     }
 
-    /* According to the lorawan specifications, the data sent from the gateway
-       could arrive with a short shift in time of +/- 20ms. Here the timeout is
-       triggered 50ms in advance to make sure the radio switches to RX mode on
-       time and doesn't miss any downlink messages, taking in consideration
-       possible xtimer inaccuracies. */
-    obj->timeout = (value - 50) * US_PER_MS;
+    obj->timeout = value * US_PER_MS;
 }
 
 TimerTime_t TimerGetCurrentTime(void)

--- a/pkg/semtech-loramac/include/semtech_loramac.h
+++ b/pkg/semtech-loramac/include/semtech_loramac.h
@@ -389,6 +389,22 @@ uint8_t semtech_loramac_get_tx_power(semtech_loramac_t *mac);
 void semtech_loramac_set_tx_port(semtech_loramac_t *mac, uint8_t port);
 
 /**
+ * @brief   Sets the maximum system overall timing error for RX (in ms)
+ *
+ * @param[in] mac          Pointer to the mac
+ * @param[in] error        The maximum rx timing error
+ */
+void semtech_loramac_set_system_max_rx_error(semtech_loramac_t *mac, int error);
+
+/**
+ * @brief   Sets the minimum required number of symbols to detect a frame
+ *
+ * @param[in] mac          Pointer to the mac
+ * @param[in] min_rx       The minimum rx symbols
+ */
+void semtech_loramac_set_min_rx_symbols(semtech_loramac_t *mac, int min_rx);
+
+/**
  * @brief   Gets the TX application port
  *
  * @param[in] mac          Pointer to the mac

--- a/sys/include/net/loramac.h
+++ b/sys/include/net/loramac.h
@@ -106,69 +106,69 @@ extern "C" {
  * @brief   Default device class (A, B or C)
  */
 #ifndef LORAMAC_DEFAULT_DEVICE_CLASS
-#define LORAMAC_DEFAULT_DEVICE_CLASS    (LORAMAC_CLASS_A)
+#define LORAMAC_DEFAULT_DEVICE_CLASS           (LORAMAC_CLASS_A)
 #endif
 
 /**
  * @brief   Default NetID (only valid with ABP join procedure)
  */
 #ifndef LORAMAC_DEFAULT_NETID
-#define LORAMAC_DEFAULT_NETID           (1U)
+#define LORAMAC_DEFAULT_NETID                  (1U)
 #endif
 
 /**
  * @brief   Default network type (public or private)
  */
 #ifndef LORAMAC_DEFAULT_PUBLIC_NETWORK
-#define LORAMAC_DEFAULT_PUBLIC_NETWORK  (true)
+#define LORAMAC_DEFAULT_PUBLIC_NETWORK         (true)
 #endif
 /**
  * @brief   Default datarate (only valid for EU)
  */
 #ifndef LORAMAC_DEFAULT_DR
-#define LORAMAC_DEFAULT_DR             (LORAMAC_DR_0)
+#define LORAMAC_DEFAULT_DR                     (LORAMAC_DR_0)
 #endif
 
 /**
  * @brief   Default MAC TX power (14dBm in EU)
  */
 #ifndef LORAMAC_DEFAULT_TX_POWER
-#define LORAMAC_DEFAULT_TX_POWER       (LORAMAC_TX_PWR_1)
+#define LORAMAC_DEFAULT_TX_POWER               (LORAMAC_TX_PWR_1)
 #endif
 
 /**
  * @brief   Default MAC TX port (from 1 to 223)
  */
 #ifndef LORAMAC_DEFAULT_TX_PORT
-#define LORAMAC_DEFAULT_TX_PORT        (2U)
+#define LORAMAC_DEFAULT_TX_PORT                (2U)
 #endif
 
 /**
  * @brief   Default MAC TX mode (confirmable or unconfirmable)
  */
  #ifndef LORAMAC_DEFAULT_TX_MODE
- #define LORAMAC_DEFAULT_TX_MODE        (LORAMAC_TX_CNF)
+ #define LORAMAC_DEFAULT_TX_MODE               (LORAMAC_TX_CNF)
  #endif
 
 /**
  * @brief   Default MAC TX power (14dBm in EU)
  */
 #ifndef LORAMAC_DEFAULT_TX_POWER
-#define LORAMAC_DEFAULT_TX_POWER       (LORAMAC_TX_PWR_1)
+#define LORAMAC_DEFAULT_TX_POWER               (LORAMAC_TX_PWR_1)
 #endif
 
 /**
  * @brief   Default adaptive datarate state
  */
 #ifndef LORAMAC_DEFAULT_ADR
-#define LORAMAC_DEFAULT_ADR            (false)
+#define LORAMAC_DEFAULT_ADR                    (false)
 #endif
 
 /**
  * @brief   Default uplink retransmission
  */
 #ifndef LORAMAC_DEFAULT_RETX
-#define LORAMAC_DEFAULT_RETX           (5U)
+#define LORAMAC_DEFAULT_RETX                   (5U)
 #endif
 
 /**
@@ -177,89 +177,103 @@ extern "C" {
  *          0 means the link check process is disabled
  */
 #ifndef LORAMAC_DEFAULT_LINKCHK
-#define LORAMAC_DEFAULT_LINKCHK        (0U)
+#define LORAMAC_DEFAULT_LINKCHK                (0U)
 #endif
 
 /**
  * @brief   Default first RX window delay (in ms)
  */
 #ifndef LORAMAC_DEFAULT_RX1_DELAY
-#define LORAMAC_DEFAULT_RX1_DELAY      (1000U)
+#define LORAMAC_DEFAULT_RX1_DELAY              (1000U)
 #endif
 
 /**
  * @brief   Default second RX window delay (in ms)
  */
-#define LORAMAC_DEFAULT_RX2_DELAY      (1000U + LORAMAC_DEFAULT_RX1_DELAY)
+#define LORAMAC_DEFAULT_RX2_DELAY              (1000U + LORAMAC_DEFAULT_RX1_DELAY)
 
 /**
  * @brief   Default automatic reply status
  */
 #ifndef LORAMAC_DEFAULT_AR
-#define LORAMAC_DEFAULT_AR             (false)
+#define LORAMAC_DEFAULT_AR                     (false)
 #endif
 
 /**
  * @brief   Default second RX window datarate index
  */
 #ifndef LORAMAC_DEFAULT_RX2_DR
-#define LORAMAC_DEFAULT_RX2_DR         (LORAMAC_DR_0)
+#define LORAMAC_DEFAULT_RX2_DR                 (LORAMAC_DR_0)
 #endif
 
 /**
  * @brief   Default second RX window frequency (in Hz)
  */
 #ifndef LORAMAC_DEFAULT_RX2_FREQ
-#define LORAMAC_DEFAULT_RX2_FREQ       (869525000UL)
+#define LORAMAC_DEFAULT_RX2_FREQ               (869525000UL)
 #endif
 
 /**
  * @brief   Default LoRaMAC join procedure
  */
 #ifndef LORAMAC_DEFAULT_JOIN_PROCEDURE
-#define LORAMAC_DEFAULT_JOIN_PROCEDURE (LORAMAC_JOIN_OTAA)
+#define LORAMAC_DEFAULT_JOIN_PROCEDURE         (LORAMAC_JOIN_OTAA)
 #endif
 
 /**
  * @brief   Default LoRaMAC join accept delay 1 (in seconds)
  */
 #ifndef LORAMAC_DEFAULT_JOIN_DELAY1
-#define LORAMAC_DEFAULT_JOIN_DELAY1    (5U)
+#define LORAMAC_DEFAULT_JOIN_DELAY1            (5U)
 #endif
 
 /**
  * @brief   Default LoRaMAC join accept delay 2
  */
 #ifndef LORAMAC_DEFAULT_JOIN_DELAY2
-#define LORAMAC_DEFAULT_JOIN_DELAY2    (6U)
+#define LORAMAC_DEFAULT_JOIN_DELAY2            (6U)
 #endif
 
 /**
  * @brief   Default max FCNT gap
  */
 #ifndef LORAMAC_DEFAULT_MAX_FCNT_GAP
-#define LORAMAC_DEFAULT_MAX_FCNT_GAP   (16384U)
+#define LORAMAC_DEFAULT_MAX_FCNT_GAP           (16384U)
 #endif
 
 /**
  * @brief   Default adaptive datarate ACK limit (in s)
  */
 #ifndef LORAMAC_DEFAULT_ADR_ACK_LIMIT
-#define LORAMAC_DEFAULT_ADR_ACK_LIMIT  (64U)
+#define LORAMAC_DEFAULT_ADR_ACK_LIMIT          (64U)
 #endif
 
 /**
  * @brief   Default adaptive datarate ACK delay (in s)
  */
 #ifndef LORAMAC_DEFAULT_ADR_ACK_DELAY
-#define LORAMAC_DEFAULT_ADR_ACK_DELAY  (32U)
+#define LORAMAC_DEFAULT_ADR_ACK_DELAY          (32U)
 #endif
 
 /**
  * @brief   Default adaptive datarate timeout
  */
 #ifndef LORAMAC_DEFAULT_ADR_TIMEOUT
-#define LORAMAC_DEFAULT_ADR_TIMEOUT    (3U)
+#define LORAMAC_DEFAULT_ADR_TIMEOUT            (3U)
+#endif
+
+/**
+ * @brief   Default maximum system overall timing error
+ */
+#ifndef LORAMAC_DEFAULT_SYSTEM_MAX_RX_ERROR
+#define LORAMAC_DEFAULT_SYSTEM_MAX_RX_ERROR    (50)
+#endif
+
+/**
+ * @brief   Default minimum RX symbols to detect a frame
+ */
+#ifndef LORAMAC_DEFAULT_MIN_RX_SYMBOLS
+#define LORAMAC_DEFAULT_MIN_RX_SYMBOLS         (12)
 #endif
 /** @} */
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR adds 2 macros for calibrating LoRaMAC reception windows timers, as described in [RX Window Calibration](https://stackforce.github.io/LoRaMac-doc/_p_o_r_t_i_n_g__g_u_i_d_e.html) in the original Semtech documentation.

Macros are added to the `@config` group so can be found in Doxygen.
- `#define LORAMAC_DEFAULT_SYSTEM_MAX_RX_ERROR    (50)`
- `#define LORAMAC_DEFAULT_MIN_RX_SYMBOLS                  (12)`
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
- Try to perform OTA and send confirmed messages in LoRaMAC
- Check if the macros appear in Doxygen.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
#10352 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
