### PR TITLE
gnrc_icmpv6_echo: avoid crashing when pktbuf full

### DIFF
--- a/sys/net/gnrc/network_layer/icmpv6/echo/gnrc_icmpv6_echo.c
+++ b/sys/net/gnrc/network_layer/icmpv6/echo/gnrc_icmpv6_echo.c
@@ -93,6 +93,12 @@ void gnrc_icmpv6_echo_req_handle(gnrc_netif_t *netif, ipv6_hdr_t *ipv6_hdr,
     pkt = hdr;
     hdr = gnrc_netif_hdr_build(NULL, 0, NULL, 0);
 
+    if (hdr == NULL) {
+        DEBUG("icmpv6_echo: no space left in packet buffer\n");
+        gnrc_pktbuf_release(pkt);
+        return;
+    }
+
     if (netif != NULL) {
         ((gnrc_netif_hdr_t *)hdr->data)->if_pid = netif->pid;
     }


### PR DESCRIPTION
### Contribution description

This PR fixes the unchecked access to `(gnrc_netif_hdr_t *)hdr->data` where `hdr` is returned from `gnrc_netif_hdr_build`. If packet buffer is full, `gnrc_netif_hdr_build` may return `NULL`. The following unchecked access to the pointer can then lead to a crash.

### Testing procedure

Produce a lot of network traffic using ping command with maximum data size and an intervall of 0, if necessary from multiple terminals so that the packet buffer becomes full, e.g.
```
sudo ping6 fe80::5ecf:7fff:fe80:3f08 -Ieth0 -s1392 -i0
```
This test should not lead to a crash.

### Issues/PRs references

Problem was found during testing PR #10862 and described in issue #10861.