### PR TITLE
[WIP] Fixes to compile using DOCKER and flash boards without local toolchain

### DIFF
--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -169,7 +169,7 @@ ifneq (,$(filter esp_cxx,$(USEMODULE)))
     UNDEF += $(BINDIR)/esp_cxx/cxa_guard.o
 endif
 
-ESPTOOL ?= $(RIOTBASE)/dist/tools/esptool/esptool.py
+ESPTOOL ?= esptool.py
 
 # The ELFFILE is the base one used for flashing
 FLASHFILE ?= $(ELFFILE)


### PR DESCRIPTION
### Contribution description

I am working to run https://github.com/RIOT-OS/RIOT/blob/master/dist/tools/compile_and_test_for_board/compile_and_test_for_board.py on a machine with several boards connected and without local board specific toolchain installed. It only has some native compilation tools, relies on docker for building, has local flashers and python dependencies for running the tests.

This branch follows all the changes I found I needed to achieve this. The goal is not to merge this but to be split in several dedicated PRs.

Feel free to split some commits out of here if you want them before I do a dedicated PR.

Current boards being tested 

```arduino-mega2560 frdm-k64f frdm-kw41z msba2 mulle nrf52dk pba-d-01-kw2x sltb001a stm32f3discovery```

### Sub pull requests

* [x] makefiles/toolchain: fix command -v multiple commands https://github.com/RIOT-OS/RIOT/pull/10889
* [x] pyterm: use python3 by default #10992
* [x] msba2: compile 'lpc2k_pgm' when flashing #11185
* [x] cpu/kinetis: fix values stored in ROM_LEN/RAM_LEN variables #10888
* [x] jlink.sh: Exit with an error on failure for JLinkExe commands #11303
* [x] boards/sltb001a: reset before flashing #11548
* [x] cpu/kinetis: allow flashing without toolchain #11545
* [x] uniflash.inc.mk: add variables for configuration files #11906
* [x] boards/pba-d-01-kw2x: fix flashing from invalid state #11549
* [x] boards/frdm: fix flashing from invalid state #12261
* [x] boards/stm32f3discovery: fix openocd config to flash from invalid state #11550
* [x] boards/common/nrf52: add openocd support for 'nordic_softdevice_ble' #11470
  * [x] pkg/nordic_softdevice_ble: reset memory in the .hex file #11620
* [x] esp*: updates to the programmer configuration #11646
  * [x] cpu/esp32: use esptool.py from PATH #12028 (bonus)
* [ ] ...

Not a fix, but to be in a closer setup to the RIOT CI and ready to use in the future:

* [x] Makefile.include: add cleanterm target and use it for tests #12107
### Open issues

* [ ] bootloaders|tests/riotboot: broken with BUILD_IN_DOCKER and wrong flashfile #12003
  * [x] Makefile.include: add BUILD_FILES variable that holds all files to be built #12302


### Testing procedure

Compile, flash and test for some boards without any toolchain installed on your machine except the one needed to build flashers, objdump/objcopy, docker.


### Issues/PRs references

Preparing a test setup for the release tests and different weekly ci testing in general.
https://github.com/RIOT-OS/RIOT/issues/10857

* ~https://github.com/RIOT-OS/RIOT/pull/10889~
* ~#10992~