### PR TITLE
xtimer: check in xtimer_mutex_lock_timeout timeout callback if a thread blocked on mutex

### DIFF
--- a/sys/xtimer/xtimer.c
+++ b/sys/xtimer/xtimer.c
@@ -237,14 +237,16 @@ static void _mutex_timeout(void *arg)
 {
     mutex_thread_t *mt = (mutex_thread_t *)arg;
 
-    mt->timeout = 1;
-    list_node_t *node = list_remove(&mt->mutex->queue,
-                                    (list_node_t *)&mt->thread->rq_entry);
-    if ((node != NULL) && (mt->mutex->queue.next == NULL)) {
-        mt->mutex->queue.next = MUTEX_LOCKED;
+    if (mt->mutex->queue.next != MUTEX_LOCKED) {
+        mt->timeout = 1;
+        list_node_t *node = list_remove(&mt->mutex->queue,
+                                        (list_node_t *)&mt->thread->rq_entry);
+        if ((node != NULL) && (mt->mutex->queue.next == NULL)) {
+            mt->mutex->queue.next = MUTEX_LOCKED;
+        }
+        sched_set_status(mt->thread, STATUS_PENDING);
+        thread_yield_higher();
     }
-    sched_set_status(mt->thread, STATUS_PENDING);
-    thread_yield_higher();
 }
 
 int xtimer_mutex_lock_timeout(mutex_t *mutex, uint64_t timeout)


### PR DESCRIPTION
### Contribution description

Prevent a possible race condition for `xtimer_mutex_lock_timeout` when `_mutex_timeout` fires just after the mutex was locked but before the xtimer was removed

The flow
```
int xtimer_mutex_lock_timeout(mutex_t *mutex, uint64_t timeout) {
   ...
    mutex_lock(mutex);
    <- mutex locked ->
    <- _mutex_timeout fires and tries to remove thread from mutex queue ->
    xtimer_remove(&t);
    ...
}
```

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I didn't try to reproduce the bug because a backtrace was provided
```
gdb) bt#0  0x080558e2 in list_remove (list=0xffffffff, node=0x20008094 <_stack+1912>) at /RIOT/core/include/list.h:88
#1  0x08055a7a in _mutex_timeout (arg=0x20007f68 <_stack+1612>) at /RIOT/sys/xtimer/xtimer.c:241
#2  0x0800375c in _shoot (timer=0x20007f74 <_stack+1624>) at /RIOT/sys/xtimer/xtimer_core.c:166
#3  0x08003c36 in _timer_callback () at /RIOT/sys/xtimer/xtimer_core.c:517
#4  0x08003740 in _periph_timer_callback (arg=0x0, chan=0) at /RIOT/sys/xtimer/xtimer_core.c:161
#5  0x08004a74 in irq_handler (tim=0) at /RIOT/cpu/stm32_common/periph/timer.c:116
#6  0x08004a9a in isr_tim5 () at /RIOT/cpu/stm32_common/periph/timer.c:125
#7  <signal handler called>
#8  0x080010de in cpu_switch_context_exit () at /RIOT/cpu/cortexm_common/thread_arch.c:266
Backtrace stopped: previous frame identical to this frame (corrupt stack?)
```

```
gdb) bt#0  0x080010f8 in thread_yield_higher () at /RIOT/cpu/cortexm_common/thread_arch.c:280
#1  0x08000afc in _mutex_lock (mutex=0x2000a1f0 <_rsp_available>, blocking=1) at /RIOT/core/mutex.c:62
#2  0x08055908 in mutex_lock (mutex=0x2000a1f0 <_rsp_available>) at /RIOT/core/include/mutex.h:113
#3  0x08055b02 in xtimer_mutex_lock_timeout (mutex=0x2000a1f0 <_rsp_available>, timeout=500000) at /RIOT/sys/xtimer/xtimer.c:261
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Didn't create an issues
