### PR TITLE
uncrustify: split lines at 80 chars

### DIFF
--- a/uncrustify-riot.cfg
+++ b/uncrustify-riot.cfg
@@ -11,6 +11,12 @@ indent_switch_case      = 4                 # number
 indent_ternary_operator = 2                 # When the `:` is a continuation, indent it under `?`
 
 #
+# line splitting
+#
+
+code_width              = 80      # Try to limit code width to N columns.
+
+#
 # inter-symbol newlines
 #
 


### PR DESCRIPTION
### Contribution description

Currently, uncrustify doesn't care about too long lines. Unfortunately it also creates them itself, see [this](https://github.com/RIOT-OS/RIOT/pull/10867#discussion_r251011937).

This PR configures uncrustify to allow a maximum of 100 chars per line.

### Testing procedure

Check uncrustify output with and without this change.

### Issues/PRs references

#10867