### PR TITLE
native: use -g3 instead of -g

### DIFF
--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -118,15 +118,15 @@ debug-valgrind-server: export VALGRIND_FLAGS ?= --vgdb=yes --vgdb-error=0 -v \
 	--read-var-info=yes
 term-cachegrind: export CACHEGRIND_FLAGS += --tool=cachegrind
 term-gprof: TERMPROG = GMON_OUT_PREFIX=gmon.out $(ELFFILE)
-all-valgrind: export CFLAGS += -DHAVE_VALGRIND_H -g
+all-valgrind: export CFLAGS += -DHAVE_VALGRIND_H -g3
 all-valgrind: export NATIVEINCLUDES += $(shell pkg-config valgrind --cflags)
-all-debug: export CFLAGS += -g
-all-cachegrind: export CFLAGS += -g
+all-debug: export CFLAGS += -g3
+all-cachegrind: export CFLAGS += -g3
 all-gprof: export CFLAGS += -pg
 all-gprof: export LINKFLAGS += -pg
-all-asan: export CFLAGS += -fsanitize=address -fno-omit-frame-pointer -g
+all-asan: export CFLAGS += -fsanitize=address -fno-omit-frame-pointer -g3
 all-asan: export CFLAGS += -DNATIVE_IN_CALLOC
-all-asan: export LINKFLAGS += -fsanitize=address -fno-omit-frame-pointer -g
+all-asan: export LINKFLAGS += -fsanitize=address -fno-omit-frame-pointer -g3
 
 export INCLUDES += $(NATIVEINCLUDES)
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
I use `CFLAGS=-g3` for years and it is far more useful than the provided `-g` in most of our `native`-specific targets. I finally got fed up with it enough to try to change it ;-).
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
The affected targets should still be able to compile an application:

- `all-valgrind`
- `all-debug`
- `all-cachegrind`
- `all-asan`

The application should still be running without any problems.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
https://github.com/RIOT-OS/RIOT/pull/4413 I guess, but this only focuses on `native`
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
