### PR TITLE
sc_gnrc_ipv6_nib: check interface existence

### DIFF
--- a/sys/shell/commands/sc_gnrc_ipv6_nib.c
+++ b/sys/shell/commands/sc_gnrc_ipv6_nib.c
@@ -78,6 +78,15 @@ static void _usage_nib_route(char **argv)
     printf("       %s %s show [iface]\n", argv[0], argv[1]);
 }
 
+static inline gnrc_netif_t *_get_iface(unsigned iface)
+{
+     /* To prevent integer overflow we can't use pid_is_valid() since it
+      * itself would cause an overflow due to the cast to `kernel_pid_t` */
+    return (iface <= ((unsigned)KERNEL_PID_LAST))
+           ? gnrc_netif_get_by_pid(iface)
+           : NULL;
+}
+
 static int _nib_neigh(int argc, char **argv)
 {
     if ((argc == 2) || (strcmp(argv[2], "show") == 0)) {
@@ -101,6 +110,10 @@ static int _nib_neigh(int argc, char **argv)
         size_t l2addr_len = 0;
         unsigned iface = atoi(argv[3]);
 
+        if (_get_iface(iface) == NULL) {
+            printf("Interface %u does not exist\n", iface);
+            return 1;
+        }
         if (ipv6_addr_from_str(&ipv6_addr, argv[4]) == NULL) {
             _usage_nib_neigh(argv);
             return 1;
@@ -116,6 +129,10 @@ static int _nib_neigh(int argc, char **argv)
         ipv6_addr_t ipv6_addr;
         unsigned iface = atoi(argv[3]);
 
+        if (_get_iface(iface) == NULL) {
+            printf("Interface %u does not exist\n", iface);
+            return 1;
+        }
         if (ipv6_addr_from_str(&ipv6_addr, argv[4]) == NULL) {
             _usage_nib_neigh(argv);
             return 1;
@@ -138,6 +155,10 @@ static int _nib_prefix(int argc, char **argv)
 
         if (argc > 3) {
             iface = atoi(argv[3]);
+            if (_get_iface(iface) == NULL) {
+                printf("Interface %u does not exist\n", iface);
+                return 1;
+            }
         }
         while (gnrc_ipv6_nib_pl_iter(iface, &state, &entry)) {
             gnrc_ipv6_nib_pl_print(&entry);
@@ -152,6 +173,10 @@ static int _nib_prefix(int argc, char **argv)
         unsigned pfx_len = ipv6_addr_split_prefix(argv[4]);
         uint32_t valid_ltime = UINT32_MAX, pref_ltime = UINT32_MAX;
 
+        if (_get_iface(iface) == NULL) {
+            printf("Interface %u does not exist\n", iface);
+            return 1;
+        }
         if (ipv6_addr_from_str(&pfx, argv[4]) == NULL) {
             _usage_nib_prefix(argv);
             return 1;
@@ -175,6 +200,10 @@ static int _nib_prefix(int argc, char **argv)
         unsigned iface = atoi(argv[3]);
         unsigned pfx_len = ipv6_addr_split_prefix(argv[4]);
 
+        if (_get_iface(iface) == NULL) {
+            printf("Interface %u does not exist\n", iface);
+            return 1;
+        }
         if (ipv6_addr_from_str(&pfx, argv[4]) == NULL) {
             _usage_nib_prefix(argv);
             return 1;
@@ -197,6 +226,10 @@ static int _nib_route(int argc, char **argv)
 
         if (argc > 3) {
             iface = atoi(argv[3]);
+            if (_get_iface(iface) == NULL) {
+                printf("Interface %u does not exist\n", iface);
+                return 1;
+            }
         }
         while (gnrc_ipv6_nib_ft_iter(NULL, iface, &state, &entry)) {
             gnrc_ipv6_nib_ft_print(&entry);
@@ -211,6 +244,10 @@ static int _nib_route(int argc, char **argv)
         unsigned pfx_len = ipv6_addr_split_prefix(argv[4]);
         uint16_t ltime = 0;
 
+        if (_get_iface(iface) == NULL) {
+            printf("Interface %u does not exist\n", iface);
+            return 1;
+        }
         if (ipv6_addr_from_str(&pfx, argv[4]) == NULL) {
             /* check if string equals "default"
              * => keep pfx as unspecified address == default route */


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Currently an interface's existence is not checked when it is supplied
by the user with the `nib` command. This can lead to assertion errors
as soon as the generated entry tries to resolve an address or route
generated with that command and the network interface not being found.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Run `gnrc_networking` on any board and try to add a neighbor/prefix/route to an interface that does not exist. Without this PR you will succeed, worse even, if you send to that neighbor/prefix/route the node will run into a failed assertion within the `nib`. With this PR an error message will be printed, that the interface does not exist.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
