### PR TITLE
sam0 flashpage: wait for READY bit in INTFLAG after write command

### DIFF
--- a/cpu/sam0_common/periph/flashpage.c
+++ b/cpu/sam0_common/periph/flashpage.c
@@ -93,7 +93,11 @@ void flashpage_write_raw(void *target_addr, const void *data, size_t len)
         *dst++ = *data_addr++;
     }
     _NVMCTRL->CTRLA.reg = (NVMCTRL_CTRLA_CMDEX_KEY | NVMCTRL_CTRLA_CMD_WP);
-
+#ifdef CPU_SAML1X
+    while(!_NVMCTRL->STATUS.bit.READY) {}
+#else
+    while (!_NVMCTRL->INTFLAG.bit.READY) {}
+#endif
     _lock();
 }
 

--- a/cpu/sam0_common/periph/flashpage.c
+++ b/cpu/sam0_common/periph/flashpage.c
@@ -94,7 +94,7 @@ void flashpage_write_raw(void *target_addr, const void *data, size_t len)
     }
     _NVMCTRL->CTRLA.reg = (NVMCTRL_CTRLA_CMDEX_KEY | NVMCTRL_CTRLA_CMD_WP);
 #ifdef CPU_SAML1X
-    while(!_NVMCTRL->STATUS.bit.READY) {}
+    while (!_NVMCTRL->STATUS.bit.READY) {}
 #else
     while (!_NVMCTRL->INTFLAG.bit.READY) {}
 #endif
@@ -117,7 +117,7 @@ void flashpage_write(int page, const void *data)
 #endif
     _NVMCTRL->CTRLA.reg = (NVMCTRL_CTRLA_CMDEX_KEY | NVMCTRL_CTRLA_CMD_ER);
 #ifdef CPU_SAML1X
-    while(!_NVMCTRL->STATUS.bit.READY) {}
+    while (!_NVMCTRL->STATUS.bit.READY) {}
 #else
     while (!_NVMCTRL->INTFLAG.bit.READY) {}
 #endif

--- a/cpu/sam0_common/periph/flashpage.c
+++ b/cpu/sam0_common/periph/flashpage.c
@@ -41,6 +41,16 @@
 #define _NVMCTRL NVMCTRL
 #endif
 
+static inline void wait_nvm_is_ready(void) __attribute__((always_inline));
+static inline void wait_nvm_is_ready(void)
+{
+#ifdef CPU_SAML1X
+    while (!_NVMCTRL->STATUS.bit.READY) {}
+#else
+    while (!_NVMCTRL->INTFLAG.bit.READY) {}
+#endif
+}
+
 static void _unlock(void)
 {
     /* remove peripheral access lock for the NVMCTRL peripheral */
@@ -89,15 +99,12 @@ void flashpage_write_raw(void *target_addr, const void *data, size_t len)
     _unlock();
 
     _NVMCTRL->CTRLA.reg = (NVMCTRL_CTRLA_CMDEX_KEY | NVMCTRL_CTRLA_CMD_PBC);
+    wait_nvm_is_ready();
     for (unsigned i = 0; i < len; i++) {
         *dst++ = *data_addr++;
     }
     _NVMCTRL->CTRLA.reg = (NVMCTRL_CTRLA_CMDEX_KEY | NVMCTRL_CTRLA_CMD_WP);
-#ifdef CPU_SAML1X
-    while (!_NVMCTRL->STATUS.bit.READY) {}
-#else
-    while (!_NVMCTRL->INTFLAG.bit.READY) {}
-#endif
+    wait_nvm_is_ready();
     _lock();
 }
 
@@ -116,11 +123,7 @@ void flashpage_write(int page, const void *data)
     _NVMCTRL->ADDR.reg = (((uint32_t)page_addr) >> 1);
 #endif
     _NVMCTRL->CTRLA.reg = (NVMCTRL_CTRLA_CMDEX_KEY | NVMCTRL_CTRLA_CMD_ER);
-#ifdef CPU_SAML1X
-    while (!_NVMCTRL->STATUS.bit.READY) {}
-#else
-    while (!_NVMCTRL->INTFLAG.bit.READY) {}
-#endif
+    wait_nvm_is_ready();
     _lock();
 
     /* write data to page */


### PR DESCRIPTION
### Contribution description
While debugging on an issue with RWWEE (see devel mailing list) I saw in the SAML manual:

> Procedure for Manual Page Writes (CTRLB.MANW=1)
> The row to be written to must be erased before the write command is given.
> • Write to the page buffer by addressing the NVM main address space directly
> • Write the page buffer to memory: CTRL.CMD='Write Page' and CMDEX
> • The READY bit in the INTFLAG register will be low while programming is in progress, and access
> through the AHB will be stalled

And noticed that the last point, waiting for the READY bit in INTFLAG, was actually missing in current code (while it is done correctly for example for the erase cycle).
While I didn't notice myself any problem until now with the code without this READY bit waiting, I believe it may be more correct to add this code and prevent possible race conditions and strange errors.

### Testing procedure
On SAMx boards you can run the automated test in _tests/periph_flashpage_.
