### PR TITLE
drivers: new driver for TI BQ27441 Lithium Battery Fuel Gauge

### DIFF
--- a/drivers/Makefile.include
+++ b/drivers/Makefile.include
@@ -42,6 +42,10 @@ ifneq (,$(filter bmx280,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/bmx280/include
 endif
 
+ifneq (,$(filter bq27441,$(USEMODULE)))
+  USEMODULE_INCLUDES += $(RIOTBASE)/drivers/bq27441/include
+endif
+
 ifneq (,$(filter cc110x,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/cc110x/include
 endif

--- a/drivers/bq27441/Makefile
+++ b/drivers/bq27441/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/bq27441/bq27441.c
+++ b/drivers/bq27441/bq27441.c
@@ -1,0 +1,696 @@
+/*
+ * Copyright (C) 2018 Anatoliy Atanasov, Iliyan Stoyanov
+ *
+ * This file is port of https://github.com/sparkfun/Battery_Babysitter code
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_bq27441
+ * @{
+ *
+ * @file
+ * @brief       drivers_bq27441 fuel gauge device driver
+ *
+ * @author      Anatoliy Atanasov <anatoliy@6lowpan.io>
+ * @author      Iliyan Stoyanov <iliyan@6lowpan.io>
+ * @}
+ */
+
+#include "bq27441.h"
+#include "bq27441-internal.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <assert.h>
+#define ENABLE_DEBUG        (1)
+#include "debug.h"
+
+#ifndef I2C_ACK
+#define I2C_ACK         (0)
+#endif
+
+#include "periph/gpio.h"
+#include "xtimer.h"
+
+#define BQ72441_I2C_TIMEOUT 2000
+#define BQ72441_I2C_BUFSIZE (128U)
+
+uint8_t _constrain(uint8_t amt, uint8_t low, uint8_t high)
+{
+	return ((amt)<(low)?(low):((amt)>(high)?(high):(amt)));
+}
+
+static void debug_print_i2c_read(i2c_t dev, uint8_t reg, uint8_t *buf, int len)
+{
+    DEBUG_PRINT("Success: i2c_%i read %i byte(s) from reg 0x%02x ", dev, len, reg);
+    DEBUG_PRINT(": [");
+    for (int i = 0; i < len; i++) {
+        if (i != 0) {
+            DEBUG_PRINT(", ");
+        }
+        DEBUG_PRINT("0x%02x", buf[i]);
+    }
+    DEBUG_PRINT("]\n");
+}
+
+static int debug_print_i2c_error(int res)
+{
+    if (res == -EOPNOTSUPP) {
+        DEBUG_PRINT("Error: EOPNOTSUPP [%d]\n", -res);
+        return 1;
+    }
+    else if (res == -EINVAL) {
+        DEBUG_PRINT("Error: EINVAL [%d]\n", -res);
+        return 1;
+    }
+    else if (res == -EAGAIN) {
+        DEBUG_PRINT("Error: EAGAIN [%d]\n", -res);
+        return 1;
+    }
+    else if (res == -ENXIO) {
+        DEBUG_PRINT("Error: ENXIO [%d]\n", -res);
+        return 1;
+    }
+    else if (res == -EIO) {
+        DEBUG_PRINT("Error: EIO [%d]\n", -res);
+        return 1;
+    }
+    else if (res == -ETIMEDOUT) {
+        DEBUG_PRINT("Error: ETIMEDOUT [%d]\n", -res);
+        return 1;
+    }
+    else if (res == I2C_ACK) {
+        DEBUG_PRINT("Success: I2C_ACK [%d]\n", res);
+        return 0;
+    }
+    DEBUG_PRINT("Error: Unknown error [%d]\n", res);
+    return 1;
+}
+
+
+// Initializes I2C and verifies communication with the BQ27441.
+bool bq27441_init(bq27441_t *dev, const bq27441_param_t *param)
+{
+	assert(dev && param);
+    dev->param = *param;
+    dev->bus = param->bus;
+    dev->addr = param->addr;
+    dev->sealFlag =  false;
+    dev->userConfigControl = false;
+    i2c_init(dev->bus);
+    gpio_init_int(dev->param.alarm_pin, GPIO_IN, GPIO_FALLING, dev->cb, dev->arg);
+    return true;
+}
+
+// Configures the design capacity of the connected battery.
+bool bq27441_set_capacity(bq27441_t *dev, uint16_t capacity)
+{
+	// Write to STATE subclass (82) of BQ27441 extended memory.
+	// Offset 0x0A (10)
+	// Design capacity is a 2-byte piece of data - MSB first
+	uint8_t capMSB = capacity >> 8;
+	uint8_t capLSB = capacity & 0x00FF;
+	uint8_t capacityData[2] = {capMSB, capLSB};
+	return _bq27441_write_extended_data(dev, BQ27441_ID_STATE, 10, capacityData, 2);
+}
+
+// Reads and returns the battery voltage
+uint16_t bq27441_get_voltage(const bq27441_t *dev)
+{
+	return _bq27441_read_word(dev, BQ27441_COMMAND_VOLTAGE);
+}
+
+// Reads and returns the specified current measurement
+int16_t bq27441_get_current(const bq27441_t *dev, current_measure type)
+{
+	int16_t current = 0;
+	switch (type)
+	{
+	case AVG:
+		current = (int16_t) _bq27441_read_word(dev, BQ27441_COMMAND_AVG_CURRENT);
+		break;
+	case STBY:
+		current = (int16_t) _bq27441_read_word(dev, BQ27441_COMMAND_STDBY_CURRENT);
+		break;
+	case MAX:
+		current = (int16_t) _bq27441_read_word(dev, BQ27441_COMMAND_MAX_CURRENT);
+		break;
+	}
+
+	return current;
+}
+
+// Reads and returns the specified capacity measurement
+uint16_t bq27441_get_capacity(const bq27441_t *dev, capacity_measure type)
+{
+	uint16_t capacity = 0;
+	switch (type)
+	{
+	case REMAIN:
+		return _bq27441_read_word(dev, BQ27441_COMMAND_REM_CAPACITY);
+		break;
+	case FULL:
+		return _bq27441_read_word(dev, BQ27441_COMMAND_FULL_CAPACITY);
+		break;
+	case AVAIL:
+		capacity = _bq27441_read_word(dev, BQ27441_COMMAND_NOM_CAPACITY);
+		break;
+	case AVAIL_FULL:
+		capacity = _bq27441_read_word(dev, BQ27441_COMMAND_AVAIL_CAPACITY);
+		break;
+	case REMAIN_F:
+		capacity = _bq27441_read_word(dev, BQ27441_COMMAND_REM_CAP_FIL);
+		break;
+	case REMAIN_UF:
+		capacity = _bq27441_read_word(dev, BQ27441_COMMAND_REM_CAP_UNFL);
+		break;
+	case FULL_F:
+		capacity = _bq27441_read_word(dev, BQ27441_COMMAND_FULL_CAP_FIL);
+		break;
+	case FULL_UF:
+		capacity = _bq27441_read_word(dev, BQ27441_COMMAND_FULL_CAP_UNFL);
+		break;
+	case DESIGN:
+		capacity = _bq27441_read_word(dev, BQ27441_EXTENDED_CAPACITY);
+	}
+
+	return capacity;
+}
+
+// Reads and returns measured average power
+int16_t bq27441_get_power(const bq27441_t *dev)
+{
+	return (int16_t) _bq27441_read_word(dev, BQ27441_COMMAND_AVG_POWER);
+}
+
+// Reads and returns specified state of charge measurement
+uint16_t bq27441_get_soc(const bq27441_t *dev, soc_measure type)
+{
+	uint16_t socRet = 0;
+	switch (type)
+	{
+	case FILTERED:
+		socRet = _bq27441_read_word(dev, BQ27441_COMMAND_SOC);
+		break;
+	case UNFILTERED:
+		socRet = _bq27441_read_word(dev, BQ27441_COMMAND_SOC_UNFL);
+		break;
+	}
+
+	return socRet;
+}
+
+// Reads and returns specified state of health measurement
+uint8_t bq27441_get_soh(const bq27441_t *dev, soh_measure type)
+{
+	uint16_t sohRaw = _bq27441_read_word(dev, BQ27441_COMMAND_SOH);
+	uint8_t sohStatus = sohRaw >> 8;
+	uint8_t sohPercent = sohRaw & 0x00FF;
+
+	if (type == PERCENT)
+		return sohPercent;
+	else
+		return sohStatus;
+}
+
+// Reads and returns specified temperature measurement
+uint16_t bq27441_get_temperature(const bq27441_t *dev, temp_measure type)
+{
+	uint16_t temp = 0;
+	switch (type)
+	{
+	case BATTERY:
+		temp = _bq27441_read_word(dev, BQ27441_COMMAND_TEMP);
+		break;
+	case INTERNAL_TEMP:
+		temp = _bq27441_read_word(dev, BQ27441_COMMAND_INT_TEMP);
+		break;
+	}
+	return temp;
+}
+
+/*****************************************************************************
+ ************************** GPOUT Control Functions **************************
+ *****************************************************************************/
+// Get GPOUT polarity setting (active-high or active-low)
+bool bq27441_get_gpout_polarity(const bq27441_t *dev)
+{
+	uint16_t opConfigRegister = _bq27441_get_opConfig(dev);
+
+	return (opConfigRegister & BQ27441_OPCONFIG_GPIOPOL);
+}
+
+// Set GPOUT polarity to active-high or active-low
+bool bq27441_set_gpout_polarity(bq27441_t *dev, bool activeHigh)
+{
+	uint16_t oldOpConfig = _bq27441_get_opConfig(dev);
+
+	// Check to see if we need to update opConfig:
+	if ((activeHigh && (oldOpConfig & BQ27441_OPCONFIG_GPIOPOL)) ||
+        (!activeHigh && !(oldOpConfig & BQ27441_OPCONFIG_GPIOPOL)))
+		return true;
+
+	uint16_t newOpConfig = oldOpConfig;
+	if (activeHigh)
+		newOpConfig |= BQ27441_OPCONFIG_GPIOPOL;
+	else
+		newOpConfig &= ~(BQ27441_OPCONFIG_GPIOPOL);
+
+	return _bq27441_write_op_config(dev, newOpConfig);
+}
+
+// Get GPOUT function (BAT_LOW or SOC_INT)
+bool bq27441_get_gpout_function(const bq27441_t *dev)
+{
+	uint16_t opConfigRegister = _bq27441_get_opConfig(dev);
+
+	return (opConfigRegister & BQ27441_OPCONFIG_BATLOWEN);
+}
+
+// Set GPOUT function to BAT_LOW or SOC_INT
+bool bq27441_set_gpout_function(bq27441_t *dev, gpout_function function)
+{
+	uint16_t oldOpConfig = _bq27441_get_opConfig(dev);
+
+	// Check to see if we need to update opConfig:
+	if ((function && (oldOpConfig & BQ27441_OPCONFIG_BATLOWEN)) ||
+        (!function && !(oldOpConfig & BQ27441_OPCONFIG_BATLOWEN)))
+		return true;
+
+	// Modify BATLOWN_EN bit of opConfig:
+	uint16_t newOpConfig = oldOpConfig;
+	if (function)
+		newOpConfig |= BQ27441_OPCONFIG_BATLOWEN;
+	else
+		newOpConfig &= ~(BQ27441_OPCONFIG_BATLOWEN);
+
+	// Write new opConfig
+	return _bq27441_write_op_config(dev, newOpConfig);
+}
+
+// Get SOC1_Set Threshold - threshold to set the alert flag
+uint8_t bq27441_get_soc1_set_threshold(bq27441_t *dev)
+{
+	return _bq27441_read_extended_data(dev, BQ27441_ID_DISCHARGE, 0);
+}
+
+// Get SOC1_Clear Threshold - threshold to clear the alert flag
+uint8_t bq27441_get_soc1_clear_threshold(bq27441_t *dev)
+{
+	return _bq27441_read_extended_data(dev, BQ27441_ID_DISCHARGE, 1);
+}
+
+// Set the SOC1 set and clear thresholds to a percentage
+bool bq27441_set_soc1_thresholds(bq27441_t *dev, uint8_t set, uint8_t clear)
+{
+	uint8_t thresholds[2];
+	thresholds[0] = _constrain(set, 0, 100);
+	thresholds[1] = _constrain(clear, 0, 100);
+	return _bq27441_write_extended_data(dev, BQ27441_ID_DISCHARGE, 0, thresholds, 2);
+}
+
+// Get SOCF_Set Threshold - threshold to set the alert flag
+uint8_t bq27441_get_socf_set_threshold(bq27441_t *dev)
+{
+	return _bq27441_read_extended_data(dev, BQ27441_ID_DISCHARGE, 2);
+}
+
+// Get SOCF_Clear Threshold - threshold to clear the alert flag
+uint8_t bq27441_get_socf_clear_threshold(bq27441_t *dev)
+{
+	return _bq27441_read_extended_data(dev, BQ27441_ID_DISCHARGE, 3);
+}
+
+// Set the SOCF set and clear thresholds to a percentage
+bool bq27441_set_socf_thresholds(bq27441_t *dev, uint8_t set, uint8_t clear)
+{
+	uint8_t thresholds[2];
+	thresholds[0] = _constrain(set, 0, 100);
+	thresholds[1] = _constrain(clear, 0, 100);
+	return _bq27441_write_extended_data(dev, BQ27441_ID_DISCHARGE, 2, thresholds, 2);
+}
+
+// Check if the SOC1 flag is set
+bool bq27441_get_soc1_flag(const bq27441_t *dev)
+{
+	uint16_t flagState = bq27441_get_flags(dev);
+
+	return flagState & BQ27441_FLAG_SOC1;
+}
+
+// Check if the SOCF flag is set
+bool bq27441_get_socf_flag(const bq27441_t *dev)
+{
+	uint16_t flagState = bq27441_get_flags(dev);
+
+	return flagState & BQ27441_FLAG_SOCF;
+
+}
+
+// Get the SOC_INT interval delta
+uint8_t bq27441_get_soc_int_delta(bq27441_t *dev)
+{
+	return _bq27441_read_extended_data(dev, BQ27441_ID_STATE, 26);
+}
+
+// Set the SOC_INT interval delta to a value between 1 and 100
+bool bq27441_set_soc_int_delta(bq27441_t *dev, uint8_t delta)
+{
+	uint8_t soci = _constrain(delta, 0, 100);
+	return _bq27441_write_extended_data(dev, BQ27441_ID_STATE, 26, &soci, 1);
+}
+
+// Pulse the GPOUT pin - must be in SOC_INT mode
+bool bq27441_pulse_gpout(const bq27441_t *dev)
+{
+	return _bq27441_execute_control_word(dev, BQ27441_CONTROL_PULSE_SOC_INT);
+}
+
+// Read the device type - should be 0x0421
+uint16_t bq27441_get_device_type(const bq27441_t *dev)
+{
+	return _bq27441_read_control_word(dev, BQ27441_CONTROL_DEVICE_TYPE);
+}
+
+// Enter configuration mode - set userControl if calling from an Arduino sketch
+// and you want control over when to exitConfig
+bool bq27441_enter_config_mode(bq27441_t *dev, bool userControl)
+{
+	if (userControl) dev->userConfigControl = true;
+
+	if (_bq27441_sealed(dev))
+	{
+		dev->sealFlag = true;
+		_bq27441_unseal(dev); // Must be unsealed before making changes
+	}
+
+	if (_bq27441_execute_control_word(dev, BQ27441_CONTROL_SET_CFGUPDATE))
+	{
+		int16_t timeout = BQ72441_I2C_TIMEOUT;
+		while ((timeout--) && (!(bq27441_get_status(dev) & BQ27441_FLAG_CFGUPMODE)))
+			xtimer_nanosleep(1000);
+
+		if (timeout > 0)
+			return true;
+	}
+
+	return false;
+}
+
+// Exit configuration mode with the option to perform a resimulation
+bool bq27441_exit_config_mode(const bq27441_t *dev, bool resim)
+{
+	// There are two methods for exiting config mode:
+	//    1. Execute the EXIT_CFGUPDATE command
+	//    2. Execute the SOFT_RESET command
+	// EXIT_CFGUPDATE exits config mode _without_ an OCV (open-circuit voltage)
+	// measurement, and without resimulating to update unfiltered-SoC and SoC.
+	// If a new OCV measurement or resimulation is desired, SOFT_RESET or
+	// EXIT_RESIM should be used to exit config mode.
+	if (resim)
+	{
+		if (_bq27441_soft_reset(dev))
+		{
+			int16_t timeout = BQ72441_I2C_TIMEOUT;
+			while ((timeout--) && ((bq27441_get_flags(dev) & BQ27441_FLAG_CFGUPMODE)))
+				xtimer_nanosleep(1000);
+			if (timeout > 0)
+			{
+				if (dev->sealFlag) _bq27441_seal(dev); // Seal back up if we IC was sealed coming in
+				return true;
+			}
+		}
+		return false;
+	}
+	else
+	{
+		return _bq27441_execute_control_word(dev, BQ27441_CONTROL_EXIT_CFGUPDATE);
+	}
+}
+
+// Read the flags() command
+uint16_t bq27441_get_flags(const bq27441_t *dev)
+{
+	return _bq27441_read_word(dev, BQ27441_COMMAND_FLAGS);
+}
+
+// Read the CONTROL_STATUS subcommand of control()
+uint16_t bq27441_get_status(const bq27441_t *dev)
+{
+	return _bq27441_read_control_word(dev, BQ27441_CONTROL_STATUS);
+}
+
+bool _bq27441_sealed(const bq27441_t *dev)
+{
+	uint16_t stat = bq27441_get_status(dev);
+	return stat & BQ27441_STATUS_SS;
+}
+
+bool _bq27441_seal(const bq27441_t *dev)
+{
+	return _bq27441_read_control_word(dev, BQ27441_CONTROL_SEALED);
+}
+
+// UNseal the BQ27441-G1A
+bool _bq27441_unseal(const bq27441_t *dev)
+{
+	// To unseal the BQ27441, write the key to the control
+	// command. Then immediately write the same key to control again.
+	if (_bq27441_read_control_word(dev, BQ27441_UNSEAL_KEY))
+	{
+		return _bq27441_read_control_word(dev, BQ27441_UNSEAL_KEY);
+	}
+	return false;
+}
+
+// Read the 16-bit opConfig register from extended data
+uint16_t _bq27441_get_opConfig(const bq27441_t *dev)
+{
+	return _bq27441_read_word(dev, BQ27441_EXTENDED_OPCONFIG);
+}
+
+// Write the 16-bit opConfig register in extended data
+bool _bq27441_write_op_config(bq27441_t *dev, uint16_t value)
+{
+	uint8_t opConfigMSB = value >> 8;
+	uint8_t opConfigLSB = value & 0x00FF;
+	uint8_t opConfigData[2] = {opConfigMSB, opConfigLSB};
+
+	// OpConfig register location: BQ27441_ID_REGISTERS id, offset 0
+	return _bq27441_write_extended_data(dev, BQ27441_ID_REGISTERS, 0, opConfigData, 2);
+}
+
+// Issue a soft-reset to the BQ27441-G1A
+bool _bq27441_soft_reset(const bq27441_t *dev)
+{
+	return _bq27441_execute_control_word(dev, BQ27441_CONTROL_SOFT_RESET);
+}
+
+// Read a 16-bit command word from the BQ27441-G1A
+uint16_t _bq27441_read_word(const bq27441_t *dev, uint16_t subAddress)
+{
+	uint8_t data[2];
+	_bq27441_read_bytes_i2c(dev, subAddress, data, 2);
+	return ((uint16_t) data[1] << 8) | data[0];
+}
+
+// Read a 16-bit subcommand() from the BQ27441-G1A's control()
+uint16_t _bq27441_read_control_word(const bq27441_t *dev, uint16_t function)
+{
+	uint8_t subCommandMSB = (function >> 8);
+	uint8_t subCommandLSB = (function & 0x00FF);
+	uint8_t command[2] = {subCommandLSB, subCommandMSB};
+	uint8_t data[2] = {0, 0};
+
+	_bq27441_write_bytes_i2c(dev, (uint8_t) 0, command, 2);
+
+	if (_bq27441_read_bytes_i2c(dev, (uint8_t) 0, data, 2))
+	{
+		return ((uint16_t)data[1] << 8) | data[0];
+	}
+
+	return false;
+}
+
+// Execute a subcommand() from the BQ27441-G1A's control()
+bool _bq27441_execute_control_word(const bq27441_t *dev, uint16_t function)
+{
+	uint8_t subCommandMSB = (function >> 8);
+	uint8_t subCommandLSB = (function & 0x00FF);
+	uint8_t command[2] = {subCommandLSB, subCommandMSB};
+	//uint8_t data[2] = {0, 0};
+
+	if (_bq27441_write_bytes_i2c(dev, (uint8_t) 0, command, 2))
+		return true;
+
+	return false;
+}
+
+// Issue a BlockDataControl() command to enable BlockData access
+bool _bq27441_block_data_control(const bq27441_t *dev)
+{
+	uint8_t enableByte = 0x00;
+	return _bq27441_write_bytes_i2c(dev, BQ27441_EXTENDED_CONTROL, &enableByte, 1);
+}
+
+// Issue a DataClass() command to set the data class to be accessed
+bool _bq27441_block_data_class(const bq27441_t *dev, uint8_t id)
+{
+	return _bq27441_write_bytes_i2c(dev, BQ27441_EXTENDED_DATACLASS, &id, 1);
+}
+
+// Issue a DataBlock() command to set the data block to be accessed
+bool _bq27441_block_data_offset(const bq27441_t *dev, uint8_t offset)
+{
+	return _bq27441_write_bytes_i2c(dev, BQ27441_EXTENDED_DATABLOCK, &offset, 1);
+}
+
+// Read the current checksum using BlockDataCheckSum()
+uint8_t _bq27441_block_data_checksum(const bq27441_t *dev)
+{
+	uint8_t csum;
+	_bq27441_read_bytes_i2c(dev, BQ27441_EXTENDED_CHECKSUM, &csum, 1);
+	return csum;
+}
+
+// Use BlockData() to read a byte from the loaded extended data
+uint8_t _bq27441_read_block_data(const bq27441_t *dev, uint8_t offset)
+{
+	uint8_t ret;
+	uint8_t address = offset + BQ27441_EXTENDED_BLOCKDATA;
+	_bq27441_read_bytes_i2c(dev, address, &ret, 1);
+	return ret;
+}
+
+// Use BlockData() to write a byte to an offset of the loaded data
+bool _bq27441_write_block_data(const bq27441_t *dev, uint8_t offset, uint8_t data)
+{
+	uint8_t address = offset + BQ27441_EXTENDED_BLOCKDATA;
+	return _bq27441_write_bytes_i2c(dev, address, &data, 1);
+}
+
+// Read all 32 bytes of the loaded extended data and compute a
+// checksum based on the values.
+uint8_t _bq27441_compute_block_checksum(const bq27441_t *dev)
+{
+	uint8_t data[32];
+	_bq27441_read_bytes_i2c(dev, BQ27441_EXTENDED_BLOCKDATA, data, 32);
+
+	uint8_t csum = 0;
+	for (int i=0; i<32; i++)
+	{
+		csum += data[i];
+	}
+	csum = 255 - csum;
+
+	return csum;
+}
+
+// Use the BlockDataCheckSum() command to write a checksum value
+bool _bq27441_write_block_checksum(const bq27441_t *dev, uint8_t csum)
+{
+	return _bq27441_write_bytes_i2c(dev, BQ27441_EXTENDED_CHECKSUM, &csum, 1);
+}
+
+// Read a byte from extended data specifying a class ID and position offset
+uint8_t _bq27441_read_extended_data(bq27441_t *dev, uint8_t classID, uint8_t offset)
+{
+	uint8_t retData = 0;
+	if (!dev->userConfigControl) bq27441_enter_config_mode(dev, false);
+
+	if (!_bq27441_block_data_control(dev)) // // enable block data memory control
+		return false; // Return false if enable fails
+	if (!_bq27441_block_data_class(dev, classID)) // Write class ID using DataBlockClass()
+		return false;
+
+	_bq27441_block_data_offset(dev, offset / 32); // Write 32-bit block offset (usually 0)
+
+	_bq27441_compute_block_checksum(dev); // Compute checksum going in
+	//uint8_t oldCsum = blockDataChecksum();
+	/*for (int i=0; i<32; i++)
+		Serial.print(String(readBlockData(i)) + " ");*/
+	retData = _bq27441_read_block_data(dev, offset % 32); // Read from offset (limit to 0-31)
+
+	if (!dev->userConfigControl) bq27441_exit_config_mode(dev, true);
+
+	return retData;
+}
+
+// Write a specified number of bytes to extended data specifying a
+// class ID, position offset.
+bool _bq27441_write_extended_data(bq27441_t *dev, uint8_t classID, uint8_t offset, uint8_t * data, uint8_t len)
+{
+	if (len > 32)
+		return false;
+
+	if (!dev->userConfigControl) bq27441_enter_config_mode(dev, false);
+
+	if (!_bq27441_block_data_control(dev)) // // enable block data memory control
+		return false; // Return false if enable fails
+	if (!_bq27441_block_data_class(dev, classID)) // Write class ID using DataBlockClass()
+		return false;
+
+	_bq27441_block_data_offset(dev, offset / 32); // Write 32-bit block offset (usually 0)
+	_bq27441_compute_block_checksum(dev); // Compute checksum going in
+	//uint8_t oldCsum = blockDataChecksum();
+
+	// Write data bytes:
+	for (int i = 0; i < len; i++)
+	{
+		// Write to offset, mod 32 if offset is greater than 32
+		// The blockDataOffset above sets the 32-bit block
+		_bq27441_write_block_data(dev, (offset % 32) + i, data[i]);
+	}
+
+	// Write new checksum using BlockDataChecksum (0x60)
+	uint8_t newCsum = _bq27441_compute_block_checksum(dev); // Compute the new checksum
+	_bq27441_write_block_checksum(dev, newCsum);
+
+	if (!dev->userConfigControl) bq27441_exit_config_mode(dev, true);
+
+	return true;
+}
+
+// Read a specified number of bytes over I2C at a given subAddress
+int16_t _bq27441_read_bytes_i2c(const bq27441_t *dev, uint8_t subAddress, uint8_t * dest, uint8_t count)
+{
+    int res;
+    int16_t timeout = BQ72441_I2C_TIMEOUT;
+    uint8_t i2c_buf[BQ72441_I2C_BUFSIZE];
+
+    while (timeout--) {
+        xtimer_nanosleep(1000);
+        res = i2c_read_regs(dev->bus, BQ72441_I2C_ADDRESS, subAddress, i2c_buf, count, 0);
+        if (res == I2C_ACK) {
+            debug_print_i2c_read(dev->bus, subAddress, i2c_buf, count);
+            for (int i = 0; i < count; i++) {
+                dest[i] = i2c_buf[i];
+            }
+            break;
+        }
+        return debug_print_i2c_error(res);
+    }
+    return timeout;
+}
+
+// Write a specified number of bytes over I2C to a given subAddress
+uint16_t _bq27441_write_bytes_i2c(const bq27441_t *dev, uint8_t subAddress, uint8_t * src, uint8_t count)
+{
+    int res;
+    uint8_t i2c_buf[BQ72441_I2C_BUFSIZE];
+
+    for (int i = 0; i < count; i++) {
+        i2c_buf[i] = src[i];
+    }
+
+    res = i2c_write_regs(dev->bus, BQ72441_I2C_ADDRESS, subAddress, i2c_buf, count, 0);
+    if (res == I2C_ACK) {
+        DEBUG_PRINT("Success: i2c_%i wrote %i bytes to reg 0x%02x\n",
+            dev->bus, count, subAddress);
+        return 0;
+    }
+    return debug_print_i2c_error(res);
+}

--- a/drivers/bq27441/bq27441.c
+++ b/drivers/bq27441/bq27441.c
@@ -40,7 +40,7 @@
 
 uint8_t _constrain(uint8_t amt, uint8_t low, uint8_t high)
 {
-    return ((amt)<(low)?(low):((amt)>(high)?(high):(amt)));
+    return ((amt) < (low) ? (low) : ((amt) > (high) ? (high) : (amt)));
 }
 
 static void debug_print_i2c_read(i2c_t dev, uint8_t reg, uint8_t *buf, int len)
@@ -113,7 +113,8 @@ bool bq27441_set_capacity(bq27441_t *dev, uint16_t capacity)
     // Design capacity is a 2-byte piece of data - MSB first
     uint8_t capMSB = capacity >> 8;
     uint8_t capLSB = capacity & 0x00FF;
-    uint8_t capacityData[2] = {capMSB, capLSB};
+    uint8_t capacityData[2] = { capMSB, capLSB };
+
     return _bq27441_write_extended_data(dev, BQ27441_ID_STATE, 10, capacityData, 2);
 }
 
@@ -127,17 +128,17 @@ uint16_t bq27441_get_voltage(const bq27441_t *dev)
 int16_t bq27441_get_current(const bq27441_t *dev, current_measure type)
 {
     int16_t current = 0;
-    switch (type)
-    {
-    case AVG:
-        current = (int16_t) _bq27441_read_word(dev, BQ27441_COMMAND_AVG_CURRENT);
-        break;
-    case STBY:
-        current = (int16_t) _bq27441_read_word(dev, BQ27441_COMMAND_STDBY_CURRENT);
-        break;
-    case MAX:
-        current = (int16_t) _bq27441_read_word(dev, BQ27441_COMMAND_MAX_CURRENT);
-        break;
+
+    switch (type) {
+        case AVG:
+            current = (int16_t)_bq27441_read_word(dev, BQ27441_COMMAND_AVG_CURRENT);
+            break;
+        case STBY:
+            current = (int16_t)_bq27441_read_word(dev, BQ27441_COMMAND_STDBY_CURRENT);
+            break;
+        case MAX:
+            current = (int16_t)_bq27441_read_word(dev, BQ27441_COMMAND_MAX_CURRENT);
+            break;
     }
 
     return current;
@@ -147,34 +148,34 @@ int16_t bq27441_get_current(const bq27441_t *dev, current_measure type)
 uint16_t bq27441_get_capacity(const bq27441_t *dev, capacity_measure type)
 {
     uint16_t capacity = 0;
-    switch (type)
-    {
-    case REMAIN:
-        return _bq27441_read_word(dev, BQ27441_COMMAND_REM_CAPACITY);
-        break;
-    case FULL:
-        return _bq27441_read_word(dev, BQ27441_COMMAND_FULL_CAPACITY);
-        break;
-    case AVAIL:
-        capacity = _bq27441_read_word(dev, BQ27441_COMMAND_NOM_CAPACITY);
-        break;
-    case AVAIL_FULL:
-        capacity = _bq27441_read_word(dev, BQ27441_COMMAND_AVAIL_CAPACITY);
-        break;
-    case REMAIN_F:
-        capacity = _bq27441_read_word(dev, BQ27441_COMMAND_REM_CAP_FIL);
-        break;
-    case REMAIN_UF:
-        capacity = _bq27441_read_word(dev, BQ27441_COMMAND_REM_CAP_UNFL);
-        break;
-    case FULL_F:
-        capacity = _bq27441_read_word(dev, BQ27441_COMMAND_FULL_CAP_FIL);
-        break;
-    case FULL_UF:
-        capacity = _bq27441_read_word(dev, BQ27441_COMMAND_FULL_CAP_UNFL);
-        break;
-    case DESIGN:
-        capacity = _bq27441_read_word(dev, BQ27441_EXTENDED_CAPACITY);
+
+    switch (type) {
+        case REMAIN:
+            return _bq27441_read_word(dev, BQ27441_COMMAND_REM_CAPACITY);
+            break;
+        case FULL:
+            return _bq27441_read_word(dev, BQ27441_COMMAND_FULL_CAPACITY);
+            break;
+        case AVAIL:
+            capacity = _bq27441_read_word(dev, BQ27441_COMMAND_NOM_CAPACITY);
+            break;
+        case AVAIL_FULL:
+            capacity = _bq27441_read_word(dev, BQ27441_COMMAND_AVAIL_CAPACITY);
+            break;
+        case REMAIN_F:
+            capacity = _bq27441_read_word(dev, BQ27441_COMMAND_REM_CAP_FIL);
+            break;
+        case REMAIN_UF:
+            capacity = _bq27441_read_word(dev, BQ27441_COMMAND_REM_CAP_UNFL);
+            break;
+        case FULL_F:
+            capacity = _bq27441_read_word(dev, BQ27441_COMMAND_FULL_CAP_FIL);
+            break;
+        case FULL_UF:
+            capacity = _bq27441_read_word(dev, BQ27441_COMMAND_FULL_CAP_UNFL);
+            break;
+        case DESIGN:
+            capacity = _bq27441_read_word(dev, BQ27441_EXTENDED_CAPACITY);
     }
 
     return capacity;
@@ -183,21 +184,21 @@ uint16_t bq27441_get_capacity(const bq27441_t *dev, capacity_measure type)
 // Reads and returns measured average power
 int16_t bq27441_get_power(const bq27441_t *dev)
 {
-    return (int16_t) _bq27441_read_word(dev, BQ27441_COMMAND_AVG_POWER);
+    return (int16_t)_bq27441_read_word(dev, BQ27441_COMMAND_AVG_POWER);
 }
 
 // Reads and returns specified state of charge measurement
 uint16_t bq27441_get_soc(const bq27441_t *dev, soc_measure type)
 {
     uint16_t socRet = 0;
-    switch (type)
-    {
-    case FILTERED:
-        socRet = _bq27441_read_word(dev, BQ27441_COMMAND_SOC);
-        break;
-    case UNFILTERED:
-        socRet = _bq27441_read_word(dev, BQ27441_COMMAND_SOC_UNFL);
-        break;
+
+    switch (type) {
+        case FILTERED:
+            socRet = _bq27441_read_word(dev, BQ27441_COMMAND_SOC);
+            break;
+        case UNFILTERED:
+            socRet = _bq27441_read_word(dev, BQ27441_COMMAND_SOC_UNFL);
+            break;
     }
 
     return socRet;
@@ -210,31 +211,33 @@ uint8_t bq27441_get_soh(const bq27441_t *dev, soh_measure type)
     uint8_t sohStatus = sohRaw >> 8;
     uint8_t sohPercent = sohRaw & 0x00FF;
 
-    if (type == PERCENT)
+    if (type == PERCENT) {
         return sohPercent;
-    else
+    }
+    else {
         return sohStatus;
+    }
 }
 
 // Reads and returns specified temperature measurement
 uint16_t bq27441_get_temperature(const bq27441_t *dev, temp_measure type)
 {
     uint16_t temp = 0;
-    switch (type)
-    {
-    case BATTERY:
-        temp = _bq27441_read_word(dev, BQ27441_COMMAND_TEMP);
-        break;
-    case INTERNAL_TEMP:
-        temp = _bq27441_read_word(dev, BQ27441_COMMAND_INT_TEMP);
-        break;
+
+    switch (type) {
+        case BATTERY:
+            temp = _bq27441_read_word(dev, BQ27441_COMMAND_TEMP);
+            break;
+        case INTERNAL_TEMP:
+            temp = _bq27441_read_word(dev, BQ27441_COMMAND_INT_TEMP);
+            break;
     }
     return temp;
 }
 
 /*****************************************************************************
- ************************** GPOUT Control Functions **************************
- *****************************************************************************/
+************************** GPOUT Control Functions **************************
+*****************************************************************************/
 // Get GPOUT polarity setting (active-high or active-low)
 bool bq27441_get_gpout_polarity(const bq27441_t *dev)
 {
@@ -250,14 +253,17 @@ bool bq27441_set_gpout_polarity(bq27441_t *dev, bool activeHigh)
 
     // Check to see if we need to update opConfig:
     if ((activeHigh && (oldOpConfig & BQ27441_OPCONFIG_GPIOPOL)) ||
-        (!activeHigh && !(oldOpConfig & BQ27441_OPCONFIG_GPIOPOL)))
+        (!activeHigh && !(oldOpConfig & BQ27441_OPCONFIG_GPIOPOL))) {
         return true;
+    }
 
     uint16_t newOpConfig = oldOpConfig;
-    if (activeHigh)
+    if (activeHigh) {
         newOpConfig |= BQ27441_OPCONFIG_GPIOPOL;
-    else
+    }
+    else {
         newOpConfig &= ~(BQ27441_OPCONFIG_GPIOPOL);
+    }
 
     return _bq27441_write_op_config(dev, newOpConfig);
 }
@@ -277,15 +283,18 @@ bool bq27441_set_gpout_function(bq27441_t *dev, gpout_function function)
 
     // Check to see if we need to update opConfig:
     if ((function && (oldOpConfig & BQ27441_OPCONFIG_BATLOWEN)) ||
-        (!function && !(oldOpConfig & BQ27441_OPCONFIG_BATLOWEN)))
+        (!function && !(oldOpConfig & BQ27441_OPCONFIG_BATLOWEN))) {
         return true;
+    }
 
     // Modify BATLOWN_EN bit of opConfig:
     uint16_t newOpConfig = oldOpConfig;
-    if (function)
+    if (function) {
         newOpConfig |= BQ27441_OPCONFIG_BATLOWEN;
-    else
+    }
+    else {
         newOpConfig &= ~(BQ27441_OPCONFIG_BATLOWEN);
+    }
 
     // Write new opConfig
     return _bq27441_write_op_config(dev, newOpConfig);
@@ -307,6 +316,7 @@ uint8_t bq27441_get_soc1_clear_threshold(bq27441_t *dev)
 bool bq27441_set_soc1_thresholds(bq27441_t *dev, uint8_t set, uint8_t clear)
 {
     uint8_t thresholds[2];
+
     thresholds[0] = _constrain(set, 0, 100);
     thresholds[1] = _constrain(clear, 0, 100);
     return _bq27441_write_extended_data(dev, BQ27441_ID_DISCHARGE, 0, thresholds, 2);
@@ -328,6 +338,7 @@ uint8_t bq27441_get_socf_clear_threshold(bq27441_t *dev)
 bool bq27441_set_socf_thresholds(bq27441_t *dev, uint8_t set, uint8_t clear)
 {
     uint8_t thresholds[2];
+
     thresholds[0] = _constrain(set, 0, 100);
     thresholds[1] = _constrain(clear, 0, 100);
     return _bq27441_write_extended_data(dev, BQ27441_ID_DISCHARGE, 2, thresholds, 2);
@@ -360,6 +371,7 @@ uint8_t bq27441_get_soc_int_delta(bq27441_t *dev)
 bool bq27441_set_soc_int_delta(bq27441_t *dev, uint8_t delta)
 {
     uint8_t soci = _constrain(delta, 0, 100);
+
     return _bq27441_write_extended_data(dev, BQ27441_ID_STATE, 26, &soci, 1);
 }
 
@@ -379,22 +391,24 @@ uint16_t bq27441_get_device_type(const bq27441_t *dev)
 // and you want control over when to exitConfig
 bool bq27441_enter_config_mode(bq27441_t *dev, bool userControl)
 {
-    if (userControl) dev->userConfigControl = true;
+    if (userControl) {
+        dev->userConfigControl = true;
+    }
 
-    if (_bq27441_sealed(dev))
-    {
+    if (_bq27441_sealed(dev)) {
         dev->sealFlag = true;
         _bq27441_unseal(dev); // Must be unsealed before making changes
     }
 
-    if (_bq27441_execute_control_word(dev, BQ27441_CONTROL_SET_CFGUPDATE))
-    {
+    if (_bq27441_execute_control_word(dev, BQ27441_CONTROL_SET_CFGUPDATE)) {
         int16_t timeout = BQ72441_I2C_TIMEOUT;
-        while ((timeout--) && (!(bq27441_get_status(dev) & BQ27441_FLAG_CFGUPMODE)))
+        while ((timeout--) && (!(bq27441_get_status(dev) & BQ27441_FLAG_CFGUPMODE))) {
             xtimer_nanosleep(1000);
+        }
 
-        if (timeout > 0)
+        if (timeout > 0) {
             return true;
+        }
     }
 
     return false;
@@ -410,23 +424,22 @@ bool bq27441_exit_config_mode(const bq27441_t *dev, bool resim)
     // measurement, and without resimulating to update unfiltered-SoC and SoC.
     // If a new OCV measurement or resimulation is desired, SOFT_RESET or
     // EXIT_RESIM should be used to exit config mode.
-    if (resim)
-    {
-        if (_bq27441_soft_reset(dev))
-        {
+    if (resim) {
+        if (_bq27441_soft_reset(dev)) {
             int16_t timeout = BQ72441_I2C_TIMEOUT;
-            while ((timeout--) && ((bq27441_get_flags(dev) & BQ27441_FLAG_CFGUPMODE)))
+            while ((timeout--) && ((bq27441_get_flags(dev) & BQ27441_FLAG_CFGUPMODE))) {
                 xtimer_nanosleep(1000);
-            if (timeout > 0)
-            {
-                if (dev->sealFlag) _bq27441_seal(dev); // Seal back up if we IC was sealed coming in
+            }
+            if (timeout > 0) {
+                if (dev->sealFlag) {
+                    _bq27441_seal(dev);                // Seal back up if we IC was sealed coming in
+                }
                 return true;
             }
         }
         return false;
     }
-    else
-    {
+    else {
         return _bq27441_execute_control_word(dev, BQ27441_CONTROL_EXIT_CFGUPDATE);
     }
 }
@@ -446,6 +459,7 @@ uint16_t bq27441_get_status(const bq27441_t *dev)
 bool _bq27441_sealed(const bq27441_t *dev)
 {
     uint16_t stat = bq27441_get_status(dev);
+
     return stat & BQ27441_STATUS_SS;
 }
 
@@ -459,8 +473,7 @@ bool _bq27441_unseal(const bq27441_t *dev)
 {
     // To unseal the BQ27441, write the key to the control
     // command. Then immediately write the same key to control again.
-    if (_bq27441_read_control_word(dev, BQ27441_UNSEAL_KEY))
-    {
+    if (_bq27441_read_control_word(dev, BQ27441_UNSEAL_KEY)) {
         return _bq27441_read_control_word(dev, BQ27441_UNSEAL_KEY);
     }
     return false;
@@ -477,7 +490,7 @@ bool _bq27441_write_op_config(bq27441_t *dev, uint16_t value)
 {
     uint8_t opConfigMSB = value >> 8;
     uint8_t opConfigLSB = value & 0x00FF;
-    uint8_t opConfigData[2] = {opConfigMSB, opConfigLSB};
+    uint8_t opConfigData[2] = { opConfigMSB, opConfigLSB };
 
     // OpConfig register location: BQ27441_ID_REGISTERS id, offset 0
     return _bq27441_write_extended_data(dev, BQ27441_ID_REGISTERS, 0, opConfigData, 2);
@@ -493,8 +506,9 @@ bool _bq27441_soft_reset(const bq27441_t *dev)
 uint16_t _bq27441_read_word(const bq27441_t *dev, uint16_t subAddress)
 {
     uint8_t data[2];
+
     _bq27441_read_bytes_i2c(dev, subAddress, data, 2);
-    return ((uint16_t) data[1] << 8) | data[0];
+    return ((uint16_t)data[1] << 8) | data[0];
 }
 
 // Read a 16-bit subcommand() from the BQ27441-G1A's control()
@@ -502,13 +516,12 @@ uint16_t _bq27441_read_control_word(const bq27441_t *dev, uint16_t function)
 {
     uint8_t subCommandMSB = (function >> 8);
     uint8_t subCommandLSB = (function & 0x00FF);
-    uint8_t command[2] = {subCommandLSB, subCommandMSB};
-    uint8_t data[2] = {0, 0};
+    uint8_t command[2] = { subCommandLSB, subCommandMSB };
+    uint8_t data[2] = { 0, 0 };
 
-    _bq27441_write_bytes_i2c(dev, (uint8_t) 0, command, 2);
+    _bq27441_write_bytes_i2c(dev, (uint8_t)0, command, 2);
 
-    if (_bq27441_read_bytes_i2c(dev, (uint8_t) 0, data, 2))
-    {
+    if (_bq27441_read_bytes_i2c(dev, (uint8_t)0, data, 2)) {
         return ((uint16_t)data[1] << 8) | data[0];
     }
 
@@ -520,11 +533,13 @@ bool _bq27441_execute_control_word(const bq27441_t *dev, uint16_t function)
 {
     uint8_t subCommandMSB = (function >> 8);
     uint8_t subCommandLSB = (function & 0x00FF);
-    uint8_t command[2] = {subCommandLSB, subCommandMSB};
+    uint8_t command[2] = { subCommandLSB, subCommandMSB };
+
     //uint8_t data[2] = {0, 0};
 
-    if (_bq27441_write_bytes_i2c(dev, (uint8_t) 0, command, 2))
+    if (_bq27441_write_bytes_i2c(dev, (uint8_t)0, command, 2)) {
         return true;
+    }
 
     return false;
 }
@@ -533,6 +548,7 @@ bool _bq27441_execute_control_word(const bq27441_t *dev, uint16_t function)
 bool _bq27441_block_data_control(const bq27441_t *dev)
 {
     uint8_t enableByte = 0x00;
+
     return _bq27441_write_bytes_i2c(dev, BQ27441_EXTENDED_CONTROL, &enableByte, 1);
 }
 
@@ -552,6 +568,7 @@ bool _bq27441_block_data_offset(const bq27441_t *dev, uint8_t offset)
 uint8_t _bq27441_block_data_checksum(const bq27441_t *dev)
 {
     uint8_t csum;
+
     _bq27441_read_bytes_i2c(dev, BQ27441_EXTENDED_CHECKSUM, &csum, 1);
     return csum;
 }
@@ -561,6 +578,7 @@ uint8_t _bq27441_read_block_data(const bq27441_t *dev, uint8_t offset)
 {
     uint8_t ret;
     uint8_t address = offset + BQ27441_EXTENDED_BLOCKDATA;
+
     _bq27441_read_bytes_i2c(dev, address, &ret, 1);
     return ret;
 }
@@ -569,6 +587,7 @@ uint8_t _bq27441_read_block_data(const bq27441_t *dev, uint8_t offset)
 bool _bq27441_write_block_data(const bq27441_t *dev, uint8_t offset, uint8_t data)
 {
     uint8_t address = offset + BQ27441_EXTENDED_BLOCKDATA;
+
     return _bq27441_write_bytes_i2c(dev, address, &data, 1);
 }
 
@@ -577,11 +596,11 @@ bool _bq27441_write_block_data(const bq27441_t *dev, uint8_t offset, uint8_t dat
 uint8_t _bq27441_compute_block_checksum(const bq27441_t *dev)
 {
     uint8_t data[32];
+
     _bq27441_read_bytes_i2c(dev, BQ27441_EXTENDED_BLOCKDATA, data, 32);
 
     uint8_t csum = 0;
-    for (int i=0; i<32; i++)
-    {
+    for (int i = 0; i < 32; i++) {
         csum += data[i];
     }
     csum = 255 - csum;
@@ -599,47 +618,58 @@ bool _bq27441_write_block_checksum(const bq27441_t *dev, uint8_t csum)
 uint8_t _bq27441_read_extended_data(bq27441_t *dev, uint8_t classID, uint8_t offset)
 {
     uint8_t retData = 0;
-    if (!dev->userConfigControl) bq27441_enter_config_mode(dev, false);
 
-    if (!_bq27441_block_data_control(dev)) // // enable block data memory control
+    if (!dev->userConfigControl) {
+        bq27441_enter_config_mode(dev, false);
+    }
+
+    if (!_bq27441_block_data_control(dev)) { // // enable block data memory control
         return false; // Return false if enable fails
-    if (!_bq27441_block_data_class(dev, classID)) // Write class ID using DataBlockClass()
+    }
+    if (!_bq27441_block_data_class(dev, classID)) { // Write class ID using DataBlockClass()
         return false;
+    }
 
-    _bq27441_block_data_offset(dev, offset / 32); // Write 32-bit block offset (usually 0)
+    _bq27441_block_data_offset(dev, offset / 32);   // Write 32-bit block offset (usually 0)
 
-    _bq27441_compute_block_checksum(dev); // Compute checksum going in
+    _bq27441_compute_block_checksum(dev);           // Compute checksum going in
     //uint8_t oldCsum = blockDataChecksum();
     /*for (int i=0; i<32; i++)
         Serial.print(String(readBlockData(i)) + " ");*/
     retData = _bq27441_read_block_data(dev, offset % 32); // Read from offset (limit to 0-31)
 
-    if (!dev->userConfigControl) bq27441_exit_config_mode(dev, true);
+    if (!dev->userConfigControl) {
+        bq27441_exit_config_mode(dev, true);
+    }
 
     return retData;
 }
 
 // Write a specified number of bytes to extended data specifying a
 // class ID, position offset.
-bool _bq27441_write_extended_data(bq27441_t *dev, uint8_t classID, uint8_t offset, uint8_t * data, uint8_t len)
+bool _bq27441_write_extended_data(bq27441_t *dev, uint8_t classID, uint8_t offset, uint8_t *data, uint8_t len)
 {
-    if (len > 32)
+    if (len > 32) {
         return false;
+    }
 
-    if (!dev->userConfigControl) bq27441_enter_config_mode(dev, false);
+    if (!dev->userConfigControl) {
+        bq27441_enter_config_mode(dev, false);
+    }
 
-    if (!_bq27441_block_data_control(dev)) // // enable block data memory control
+    if (!_bq27441_block_data_control(dev)) { // // enable block data memory control
         return false; // Return false if enable fails
-    if (!_bq27441_block_data_class(dev, classID)) // Write class ID using DataBlockClass()
+    }
+    if (!_bq27441_block_data_class(dev, classID)) { // Write class ID using DataBlockClass()
         return false;
+    }
 
-    _bq27441_block_data_offset(dev, offset / 32); // Write 32-bit block offset (usually 0)
-    _bq27441_compute_block_checksum(dev); // Compute checksum going in
+    _bq27441_block_data_offset(dev, offset / 32);   // Write 32-bit block offset (usually 0)
+    _bq27441_compute_block_checksum(dev);           // Compute checksum going in
     //uint8_t oldCsum = blockDataChecksum();
 
     // Write data bytes:
-    for (int i = 0; i < len; i++)
-    {
+    for (int i = 0; i < len; i++) {
         // Write to offset, mod 32 if offset is greater than 32
         // The blockDataOffset above sets the 32-bit block
         _bq27441_write_block_data(dev, (offset % 32) + i, data[i]);
@@ -649,13 +679,15 @@ bool _bq27441_write_extended_data(bq27441_t *dev, uint8_t classID, uint8_t offse
     uint8_t newCsum = _bq27441_compute_block_checksum(dev); // Compute the new checksum
     _bq27441_write_block_checksum(dev, newCsum);
 
-    if (!dev->userConfigControl) bq27441_exit_config_mode(dev, true);
+    if (!dev->userConfigControl) {
+        bq27441_exit_config_mode(dev, true);
+    }
 
     return true;
 }
 
 // Read a specified number of bytes over I2C at a given subAddress
-int16_t _bq27441_read_bytes_i2c(const bq27441_t *dev, uint8_t subAddress, uint8_t * dest, uint8_t count)
+int16_t _bq27441_read_bytes_i2c(const bq27441_t *dev, uint8_t subAddress, uint8_t *dest, uint8_t count)
 {
     int16_t timeout = BQ72441_I2C_TIMEOUT;
     uint8_t i2c_buf[BQ72441_I2C_BUFSIZE];
@@ -676,7 +708,7 @@ int16_t _bq27441_read_bytes_i2c(const bq27441_t *dev, uint8_t subAddress, uint8_
 }
 
 // Write a specified number of bytes over I2C to a given subAddress
-uint16_t _bq27441_write_bytes_i2c(const bq27441_t *dev, uint8_t subAddress, uint8_t * src, uint8_t count)
+uint16_t _bq27441_write_bytes_i2c(const bq27441_t *dev, uint8_t subAddress, uint8_t *src, uint8_t count)
 {
     int res;
     uint8_t i2c_buf[BQ72441_I2C_BUFSIZE];
@@ -688,7 +720,7 @@ uint16_t _bq27441_write_bytes_i2c(const bq27441_t *dev, uint8_t subAddress, uint
     res = i2c_write_regs(dev->bus, BQ72441_I2C_ADDRESS, subAddress, i2c_buf, count, 0);
     if (res == I2C_ACK) {
         DEBUG_PRINT("Success: i2c_%i wrote %i bytes to reg 0x%02x\n",
-            dev->bus, count, subAddress);
+                    dev->bus, count, subAddress);
         return 0;
     }
     return debug_print_i2c_error(res);

--- a/drivers/bq27441/bq27441.c
+++ b/drivers/bq27441/bq27441.c
@@ -40,7 +40,7 @@
 
 uint8_t _constrain(uint8_t amt, uint8_t low, uint8_t high)
 {
-	return ((amt)<(low)?(low):((amt)>(high)?(high):(amt)));
+    return ((amt)<(low)?(low):((amt)>(high)?(high):(amt)));
 }
 
 static void debug_print_i2c_read(i2c_t dev, uint8_t reg, uint8_t *buf, int len)
@@ -94,7 +94,7 @@ static int debug_print_i2c_error(int res)
 // Initializes I2C and verifies communication with the BQ27441.
 bool bq27441_init(bq27441_t *dev, const bq27441_param_t *param)
 {
-	assert(dev && param);
+    assert(dev && param);
     dev->param = *param;
     dev->bus = param->bus;
     dev->addr = param->addr;
@@ -108,128 +108,128 @@ bool bq27441_init(bq27441_t *dev, const bq27441_param_t *param)
 // Configures the design capacity of the connected battery.
 bool bq27441_set_capacity(bq27441_t *dev, uint16_t capacity)
 {
-	// Write to STATE subclass (82) of BQ27441 extended memory.
-	// Offset 0x0A (10)
-	// Design capacity is a 2-byte piece of data - MSB first
-	uint8_t capMSB = capacity >> 8;
-	uint8_t capLSB = capacity & 0x00FF;
-	uint8_t capacityData[2] = {capMSB, capLSB};
-	return _bq27441_write_extended_data(dev, BQ27441_ID_STATE, 10, capacityData, 2);
+    // Write to STATE subclass (82) of BQ27441 extended memory.
+    // Offset 0x0A (10)
+    // Design capacity is a 2-byte piece of data - MSB first
+    uint8_t capMSB = capacity >> 8;
+    uint8_t capLSB = capacity & 0x00FF;
+    uint8_t capacityData[2] = {capMSB, capLSB};
+    return _bq27441_write_extended_data(dev, BQ27441_ID_STATE, 10, capacityData, 2);
 }
 
 // Reads and returns the battery voltage
 uint16_t bq27441_get_voltage(const bq27441_t *dev)
 {
-	return _bq27441_read_word(dev, BQ27441_COMMAND_VOLTAGE);
+    return _bq27441_read_word(dev, BQ27441_COMMAND_VOLTAGE);
 }
 
 // Reads and returns the specified current measurement
 int16_t bq27441_get_current(const bq27441_t *dev, current_measure type)
 {
-	int16_t current = 0;
-	switch (type)
-	{
-	case AVG:
-		current = (int16_t) _bq27441_read_word(dev, BQ27441_COMMAND_AVG_CURRENT);
-		break;
-	case STBY:
-		current = (int16_t) _bq27441_read_word(dev, BQ27441_COMMAND_STDBY_CURRENT);
-		break;
-	case MAX:
-		current = (int16_t) _bq27441_read_word(dev, BQ27441_COMMAND_MAX_CURRENT);
-		break;
-	}
+    int16_t current = 0;
+    switch (type)
+    {
+    case AVG:
+        current = (int16_t) _bq27441_read_word(dev, BQ27441_COMMAND_AVG_CURRENT);
+        break;
+    case STBY:
+        current = (int16_t) _bq27441_read_word(dev, BQ27441_COMMAND_STDBY_CURRENT);
+        break;
+    case MAX:
+        current = (int16_t) _bq27441_read_word(dev, BQ27441_COMMAND_MAX_CURRENT);
+        break;
+    }
 
-	return current;
+    return current;
 }
 
 // Reads and returns the specified capacity measurement
 uint16_t bq27441_get_capacity(const bq27441_t *dev, capacity_measure type)
 {
-	uint16_t capacity = 0;
-	switch (type)
-	{
-	case REMAIN:
-		return _bq27441_read_word(dev, BQ27441_COMMAND_REM_CAPACITY);
-		break;
-	case FULL:
-		return _bq27441_read_word(dev, BQ27441_COMMAND_FULL_CAPACITY);
-		break;
-	case AVAIL:
-		capacity = _bq27441_read_word(dev, BQ27441_COMMAND_NOM_CAPACITY);
-		break;
-	case AVAIL_FULL:
-		capacity = _bq27441_read_word(dev, BQ27441_COMMAND_AVAIL_CAPACITY);
-		break;
-	case REMAIN_F:
-		capacity = _bq27441_read_word(dev, BQ27441_COMMAND_REM_CAP_FIL);
-		break;
-	case REMAIN_UF:
-		capacity = _bq27441_read_word(dev, BQ27441_COMMAND_REM_CAP_UNFL);
-		break;
-	case FULL_F:
-		capacity = _bq27441_read_word(dev, BQ27441_COMMAND_FULL_CAP_FIL);
-		break;
-	case FULL_UF:
-		capacity = _bq27441_read_word(dev, BQ27441_COMMAND_FULL_CAP_UNFL);
-		break;
-	case DESIGN:
-		capacity = _bq27441_read_word(dev, BQ27441_EXTENDED_CAPACITY);
-	}
+    uint16_t capacity = 0;
+    switch (type)
+    {
+    case REMAIN:
+        return _bq27441_read_word(dev, BQ27441_COMMAND_REM_CAPACITY);
+        break;
+    case FULL:
+        return _bq27441_read_word(dev, BQ27441_COMMAND_FULL_CAPACITY);
+        break;
+    case AVAIL:
+        capacity = _bq27441_read_word(dev, BQ27441_COMMAND_NOM_CAPACITY);
+        break;
+    case AVAIL_FULL:
+        capacity = _bq27441_read_word(dev, BQ27441_COMMAND_AVAIL_CAPACITY);
+        break;
+    case REMAIN_F:
+        capacity = _bq27441_read_word(dev, BQ27441_COMMAND_REM_CAP_FIL);
+        break;
+    case REMAIN_UF:
+        capacity = _bq27441_read_word(dev, BQ27441_COMMAND_REM_CAP_UNFL);
+        break;
+    case FULL_F:
+        capacity = _bq27441_read_word(dev, BQ27441_COMMAND_FULL_CAP_FIL);
+        break;
+    case FULL_UF:
+        capacity = _bq27441_read_word(dev, BQ27441_COMMAND_FULL_CAP_UNFL);
+        break;
+    case DESIGN:
+        capacity = _bq27441_read_word(dev, BQ27441_EXTENDED_CAPACITY);
+    }
 
-	return capacity;
+    return capacity;
 }
 
 // Reads and returns measured average power
 int16_t bq27441_get_power(const bq27441_t *dev)
 {
-	return (int16_t) _bq27441_read_word(dev, BQ27441_COMMAND_AVG_POWER);
+    return (int16_t) _bq27441_read_word(dev, BQ27441_COMMAND_AVG_POWER);
 }
 
 // Reads and returns specified state of charge measurement
 uint16_t bq27441_get_soc(const bq27441_t *dev, soc_measure type)
 {
-	uint16_t socRet = 0;
-	switch (type)
-	{
-	case FILTERED:
-		socRet = _bq27441_read_word(dev, BQ27441_COMMAND_SOC);
-		break;
-	case UNFILTERED:
-		socRet = _bq27441_read_word(dev, BQ27441_COMMAND_SOC_UNFL);
-		break;
-	}
+    uint16_t socRet = 0;
+    switch (type)
+    {
+    case FILTERED:
+        socRet = _bq27441_read_word(dev, BQ27441_COMMAND_SOC);
+        break;
+    case UNFILTERED:
+        socRet = _bq27441_read_word(dev, BQ27441_COMMAND_SOC_UNFL);
+        break;
+    }
 
-	return socRet;
+    return socRet;
 }
 
 // Reads and returns specified state of health measurement
 uint8_t bq27441_get_soh(const bq27441_t *dev, soh_measure type)
 {
-	uint16_t sohRaw = _bq27441_read_word(dev, BQ27441_COMMAND_SOH);
-	uint8_t sohStatus = sohRaw >> 8;
-	uint8_t sohPercent = sohRaw & 0x00FF;
+    uint16_t sohRaw = _bq27441_read_word(dev, BQ27441_COMMAND_SOH);
+    uint8_t sohStatus = sohRaw >> 8;
+    uint8_t sohPercent = sohRaw & 0x00FF;
 
-	if (type == PERCENT)
-		return sohPercent;
-	else
-		return sohStatus;
+    if (type == PERCENT)
+        return sohPercent;
+    else
+        return sohStatus;
 }
 
 // Reads and returns specified temperature measurement
 uint16_t bq27441_get_temperature(const bq27441_t *dev, temp_measure type)
 {
-	uint16_t temp = 0;
-	switch (type)
-	{
-	case BATTERY:
-		temp = _bq27441_read_word(dev, BQ27441_COMMAND_TEMP);
-		break;
-	case INTERNAL_TEMP:
-		temp = _bq27441_read_word(dev, BQ27441_COMMAND_INT_TEMP);
-		break;
-	}
-	return temp;
+    uint16_t temp = 0;
+    switch (type)
+    {
+    case BATTERY:
+        temp = _bq27441_read_word(dev, BQ27441_COMMAND_TEMP);
+        break;
+    case INTERNAL_TEMP:
+        temp = _bq27441_read_word(dev, BQ27441_COMMAND_INT_TEMP);
+        break;
+    }
+    return temp;
 }
 
 /*****************************************************************************
@@ -238,432 +238,431 @@ uint16_t bq27441_get_temperature(const bq27441_t *dev, temp_measure type)
 // Get GPOUT polarity setting (active-high or active-low)
 bool bq27441_get_gpout_polarity(const bq27441_t *dev)
 {
-	uint16_t opConfigRegister = _bq27441_get_opConfig(dev);
+    uint16_t opConfigRegister = _bq27441_get_opConfig(dev);
 
-	return (opConfigRegister & BQ27441_OPCONFIG_GPIOPOL);
+    return (opConfigRegister & BQ27441_OPCONFIG_GPIOPOL);
 }
 
 // Set GPOUT polarity to active-high or active-low
 bool bq27441_set_gpout_polarity(bq27441_t *dev, bool activeHigh)
 {
-	uint16_t oldOpConfig = _bq27441_get_opConfig(dev);
+    uint16_t oldOpConfig = _bq27441_get_opConfig(dev);
 
-	// Check to see if we need to update opConfig:
-	if ((activeHigh && (oldOpConfig & BQ27441_OPCONFIG_GPIOPOL)) ||
+    // Check to see if we need to update opConfig:
+    if ((activeHigh && (oldOpConfig & BQ27441_OPCONFIG_GPIOPOL)) ||
         (!activeHigh && !(oldOpConfig & BQ27441_OPCONFIG_GPIOPOL)))
-		return true;
+        return true;
 
-	uint16_t newOpConfig = oldOpConfig;
-	if (activeHigh)
-		newOpConfig |= BQ27441_OPCONFIG_GPIOPOL;
-	else
-		newOpConfig &= ~(BQ27441_OPCONFIG_GPIOPOL);
+    uint16_t newOpConfig = oldOpConfig;
+    if (activeHigh)
+        newOpConfig |= BQ27441_OPCONFIG_GPIOPOL;
+    else
+        newOpConfig &= ~(BQ27441_OPCONFIG_GPIOPOL);
 
-	return _bq27441_write_op_config(dev, newOpConfig);
+    return _bq27441_write_op_config(dev, newOpConfig);
 }
 
 // Get GPOUT function (BAT_LOW or SOC_INT)
 bool bq27441_get_gpout_function(const bq27441_t *dev)
 {
-	uint16_t opConfigRegister = _bq27441_get_opConfig(dev);
+    uint16_t opConfigRegister = _bq27441_get_opConfig(dev);
 
-	return (opConfigRegister & BQ27441_OPCONFIG_BATLOWEN);
+    return (opConfigRegister & BQ27441_OPCONFIG_BATLOWEN);
 }
 
 // Set GPOUT function to BAT_LOW or SOC_INT
 bool bq27441_set_gpout_function(bq27441_t *dev, gpout_function function)
 {
-	uint16_t oldOpConfig = _bq27441_get_opConfig(dev);
+    uint16_t oldOpConfig = _bq27441_get_opConfig(dev);
 
-	// Check to see if we need to update opConfig:
-	if ((function && (oldOpConfig & BQ27441_OPCONFIG_BATLOWEN)) ||
+    // Check to see if we need to update opConfig:
+    if ((function && (oldOpConfig & BQ27441_OPCONFIG_BATLOWEN)) ||
         (!function && !(oldOpConfig & BQ27441_OPCONFIG_BATLOWEN)))
-		return true;
+        return true;
 
-	// Modify BATLOWN_EN bit of opConfig:
-	uint16_t newOpConfig = oldOpConfig;
-	if (function)
-		newOpConfig |= BQ27441_OPCONFIG_BATLOWEN;
-	else
-		newOpConfig &= ~(BQ27441_OPCONFIG_BATLOWEN);
+    // Modify BATLOWN_EN bit of opConfig:
+    uint16_t newOpConfig = oldOpConfig;
+    if (function)
+        newOpConfig |= BQ27441_OPCONFIG_BATLOWEN;
+    else
+        newOpConfig &= ~(BQ27441_OPCONFIG_BATLOWEN);
 
-	// Write new opConfig
-	return _bq27441_write_op_config(dev, newOpConfig);
+    // Write new opConfig
+    return _bq27441_write_op_config(dev, newOpConfig);
 }
 
 // Get SOC1_Set Threshold - threshold to set the alert flag
 uint8_t bq27441_get_soc1_set_threshold(bq27441_t *dev)
 {
-	return _bq27441_read_extended_data(dev, BQ27441_ID_DISCHARGE, 0);
+    return _bq27441_read_extended_data(dev, BQ27441_ID_DISCHARGE, 0);
 }
 
 // Get SOC1_Clear Threshold - threshold to clear the alert flag
 uint8_t bq27441_get_soc1_clear_threshold(bq27441_t *dev)
 {
-	return _bq27441_read_extended_data(dev, BQ27441_ID_DISCHARGE, 1);
+    return _bq27441_read_extended_data(dev, BQ27441_ID_DISCHARGE, 1);
 }
 
 // Set the SOC1 set and clear thresholds to a percentage
 bool bq27441_set_soc1_thresholds(bq27441_t *dev, uint8_t set, uint8_t clear)
 {
-	uint8_t thresholds[2];
-	thresholds[0] = _constrain(set, 0, 100);
-	thresholds[1] = _constrain(clear, 0, 100);
-	return _bq27441_write_extended_data(dev, BQ27441_ID_DISCHARGE, 0, thresholds, 2);
+    uint8_t thresholds[2];
+    thresholds[0] = _constrain(set, 0, 100);
+    thresholds[1] = _constrain(clear, 0, 100);
+    return _bq27441_write_extended_data(dev, BQ27441_ID_DISCHARGE, 0, thresholds, 2);
 }
 
 // Get SOCF_Set Threshold - threshold to set the alert flag
 uint8_t bq27441_get_socf_set_threshold(bq27441_t *dev)
 {
-	return _bq27441_read_extended_data(dev, BQ27441_ID_DISCHARGE, 2);
+    return _bq27441_read_extended_data(dev, BQ27441_ID_DISCHARGE, 2);
 }
 
 // Get SOCF_Clear Threshold - threshold to clear the alert flag
 uint8_t bq27441_get_socf_clear_threshold(bq27441_t *dev)
 {
-	return _bq27441_read_extended_data(dev, BQ27441_ID_DISCHARGE, 3);
+    return _bq27441_read_extended_data(dev, BQ27441_ID_DISCHARGE, 3);
 }
 
 // Set the SOCF set and clear thresholds to a percentage
 bool bq27441_set_socf_thresholds(bq27441_t *dev, uint8_t set, uint8_t clear)
 {
-	uint8_t thresholds[2];
-	thresholds[0] = _constrain(set, 0, 100);
-	thresholds[1] = _constrain(clear, 0, 100);
-	return _bq27441_write_extended_data(dev, BQ27441_ID_DISCHARGE, 2, thresholds, 2);
+    uint8_t thresholds[2];
+    thresholds[0] = _constrain(set, 0, 100);
+    thresholds[1] = _constrain(clear, 0, 100);
+    return _bq27441_write_extended_data(dev, BQ27441_ID_DISCHARGE, 2, thresholds, 2);
 }
 
 // Check if the SOC1 flag is set
 bool bq27441_get_soc1_flag(const bq27441_t *dev)
 {
-	uint16_t flagState = bq27441_get_flags(dev);
+    uint16_t flagState = bq27441_get_flags(dev);
 
-	return flagState & BQ27441_FLAG_SOC1;
+    return flagState & BQ27441_FLAG_SOC1;
 }
 
 // Check if the SOCF flag is set
 bool bq27441_get_socf_flag(const bq27441_t *dev)
 {
-	uint16_t flagState = bq27441_get_flags(dev);
+    uint16_t flagState = bq27441_get_flags(dev);
 
-	return flagState & BQ27441_FLAG_SOCF;
+    return flagState & BQ27441_FLAG_SOCF;
 
 }
 
 // Get the SOC_INT interval delta
 uint8_t bq27441_get_soc_int_delta(bq27441_t *dev)
 {
-	return _bq27441_read_extended_data(dev, BQ27441_ID_STATE, 26);
+    return _bq27441_read_extended_data(dev, BQ27441_ID_STATE, 26);
 }
 
 // Set the SOC_INT interval delta to a value between 1 and 100
 bool bq27441_set_soc_int_delta(bq27441_t *dev, uint8_t delta)
 {
-	uint8_t soci = _constrain(delta, 0, 100);
-	return _bq27441_write_extended_data(dev, BQ27441_ID_STATE, 26, &soci, 1);
+    uint8_t soci = _constrain(delta, 0, 100);
+    return _bq27441_write_extended_data(dev, BQ27441_ID_STATE, 26, &soci, 1);
 }
 
 // Pulse the GPOUT pin - must be in SOC_INT mode
 bool bq27441_pulse_gpout(const bq27441_t *dev)
 {
-	return _bq27441_execute_control_word(dev, BQ27441_CONTROL_PULSE_SOC_INT);
+    return _bq27441_execute_control_word(dev, BQ27441_CONTROL_PULSE_SOC_INT);
 }
 
 // Read the device type - should be 0x0421
 uint16_t bq27441_get_device_type(const bq27441_t *dev)
 {
-	return _bq27441_read_control_word(dev, BQ27441_CONTROL_DEVICE_TYPE);
+    return _bq27441_read_control_word(dev, BQ27441_CONTROL_DEVICE_TYPE);
 }
 
 // Enter configuration mode - set userControl if calling from an Arduino sketch
 // and you want control over when to exitConfig
 bool bq27441_enter_config_mode(bq27441_t *dev, bool userControl)
 {
-	if (userControl) dev->userConfigControl = true;
+    if (userControl) dev->userConfigControl = true;
 
-	if (_bq27441_sealed(dev))
-	{
-		dev->sealFlag = true;
-		_bq27441_unseal(dev); // Must be unsealed before making changes
-	}
+    if (_bq27441_sealed(dev))
+    {
+        dev->sealFlag = true;
+        _bq27441_unseal(dev); // Must be unsealed before making changes
+    }
 
-	if (_bq27441_execute_control_word(dev, BQ27441_CONTROL_SET_CFGUPDATE))
-	{
-		int16_t timeout = BQ72441_I2C_TIMEOUT;
-		while ((timeout--) && (!(bq27441_get_status(dev) & BQ27441_FLAG_CFGUPMODE)))
-			xtimer_nanosleep(1000);
+    if (_bq27441_execute_control_word(dev, BQ27441_CONTROL_SET_CFGUPDATE))
+    {
+        int16_t timeout = BQ72441_I2C_TIMEOUT;
+        while ((timeout--) && (!(bq27441_get_status(dev) & BQ27441_FLAG_CFGUPMODE)))
+            xtimer_nanosleep(1000);
 
-		if (timeout > 0)
-			return true;
-	}
+        if (timeout > 0)
+            return true;
+    }
 
-	return false;
+    return false;
 }
 
 // Exit configuration mode with the option to perform a resimulation
 bool bq27441_exit_config_mode(const bq27441_t *dev, bool resim)
 {
-	// There are two methods for exiting config mode:
-	//    1. Execute the EXIT_CFGUPDATE command
-	//    2. Execute the SOFT_RESET command
-	// EXIT_CFGUPDATE exits config mode _without_ an OCV (open-circuit voltage)
-	// measurement, and without resimulating to update unfiltered-SoC and SoC.
-	// If a new OCV measurement or resimulation is desired, SOFT_RESET or
-	// EXIT_RESIM should be used to exit config mode.
-	if (resim)
-	{
-		if (_bq27441_soft_reset(dev))
-		{
-			int16_t timeout = BQ72441_I2C_TIMEOUT;
-			while ((timeout--) && ((bq27441_get_flags(dev) & BQ27441_FLAG_CFGUPMODE)))
-				xtimer_nanosleep(1000);
-			if (timeout > 0)
-			{
-				if (dev->sealFlag) _bq27441_seal(dev); // Seal back up if we IC was sealed coming in
-				return true;
-			}
-		}
-		return false;
-	}
-	else
-	{
-		return _bq27441_execute_control_word(dev, BQ27441_CONTROL_EXIT_CFGUPDATE);
-	}
+    // There are two methods for exiting config mode:
+    //    1. Execute the EXIT_CFGUPDATE command
+    //    2. Execute the SOFT_RESET command
+    // EXIT_CFGUPDATE exits config mode _without_ an OCV (open-circuit voltage)
+    // measurement, and without resimulating to update unfiltered-SoC and SoC.
+    // If a new OCV measurement or resimulation is desired, SOFT_RESET or
+    // EXIT_RESIM should be used to exit config mode.
+    if (resim)
+    {
+        if (_bq27441_soft_reset(dev))
+        {
+            int16_t timeout = BQ72441_I2C_TIMEOUT;
+            while ((timeout--) && ((bq27441_get_flags(dev) & BQ27441_FLAG_CFGUPMODE)))
+                xtimer_nanosleep(1000);
+            if (timeout > 0)
+            {
+                if (dev->sealFlag) _bq27441_seal(dev); // Seal back up if we IC was sealed coming in
+                return true;
+            }
+        }
+        return false;
+    }
+    else
+    {
+        return _bq27441_execute_control_word(dev, BQ27441_CONTROL_EXIT_CFGUPDATE);
+    }
 }
 
 // Read the flags() command
 uint16_t bq27441_get_flags(const bq27441_t *dev)
 {
-	return _bq27441_read_word(dev, BQ27441_COMMAND_FLAGS);
+    return _bq27441_read_word(dev, BQ27441_COMMAND_FLAGS);
 }
 
 // Read the CONTROL_STATUS subcommand of control()
 uint16_t bq27441_get_status(const bq27441_t *dev)
 {
-	return _bq27441_read_control_word(dev, BQ27441_CONTROL_STATUS);
+    return _bq27441_read_control_word(dev, BQ27441_CONTROL_STATUS);
 }
 
 bool _bq27441_sealed(const bq27441_t *dev)
 {
-	uint16_t stat = bq27441_get_status(dev);
-	return stat & BQ27441_STATUS_SS;
+    uint16_t stat = bq27441_get_status(dev);
+    return stat & BQ27441_STATUS_SS;
 }
 
 bool _bq27441_seal(const bq27441_t *dev)
 {
-	return _bq27441_read_control_word(dev, BQ27441_CONTROL_SEALED);
+    return _bq27441_read_control_word(dev, BQ27441_CONTROL_SEALED);
 }
 
 // UNseal the BQ27441-G1A
 bool _bq27441_unseal(const bq27441_t *dev)
 {
-	// To unseal the BQ27441, write the key to the control
-	// command. Then immediately write the same key to control again.
-	if (_bq27441_read_control_word(dev, BQ27441_UNSEAL_KEY))
-	{
-		return _bq27441_read_control_word(dev, BQ27441_UNSEAL_KEY);
-	}
-	return false;
+    // To unseal the BQ27441, write the key to the control
+    // command. Then immediately write the same key to control again.
+    if (_bq27441_read_control_word(dev, BQ27441_UNSEAL_KEY))
+    {
+        return _bq27441_read_control_word(dev, BQ27441_UNSEAL_KEY);
+    }
+    return false;
 }
 
 // Read the 16-bit opConfig register from extended data
 uint16_t _bq27441_get_opConfig(const bq27441_t *dev)
 {
-	return _bq27441_read_word(dev, BQ27441_EXTENDED_OPCONFIG);
+    return _bq27441_read_word(dev, BQ27441_EXTENDED_OPCONFIG);
 }
 
 // Write the 16-bit opConfig register in extended data
 bool _bq27441_write_op_config(bq27441_t *dev, uint16_t value)
 {
-	uint8_t opConfigMSB = value >> 8;
-	uint8_t opConfigLSB = value & 0x00FF;
-	uint8_t opConfigData[2] = {opConfigMSB, opConfigLSB};
+    uint8_t opConfigMSB = value >> 8;
+    uint8_t opConfigLSB = value & 0x00FF;
+    uint8_t opConfigData[2] = {opConfigMSB, opConfigLSB};
 
-	// OpConfig register location: BQ27441_ID_REGISTERS id, offset 0
-	return _bq27441_write_extended_data(dev, BQ27441_ID_REGISTERS, 0, opConfigData, 2);
+    // OpConfig register location: BQ27441_ID_REGISTERS id, offset 0
+    return _bq27441_write_extended_data(dev, BQ27441_ID_REGISTERS, 0, opConfigData, 2);
 }
 
 // Issue a soft-reset to the BQ27441-G1A
 bool _bq27441_soft_reset(const bq27441_t *dev)
 {
-	return _bq27441_execute_control_word(dev, BQ27441_CONTROL_SOFT_RESET);
+    return _bq27441_execute_control_word(dev, BQ27441_CONTROL_SOFT_RESET);
 }
 
 // Read a 16-bit command word from the BQ27441-G1A
 uint16_t _bq27441_read_word(const bq27441_t *dev, uint16_t subAddress)
 {
-	uint8_t data[2];
-	_bq27441_read_bytes_i2c(dev, subAddress, data, 2);
-	return ((uint16_t) data[1] << 8) | data[0];
+    uint8_t data[2];
+    _bq27441_read_bytes_i2c(dev, subAddress, data, 2);
+    return ((uint16_t) data[1] << 8) | data[0];
 }
 
 // Read a 16-bit subcommand() from the BQ27441-G1A's control()
 uint16_t _bq27441_read_control_word(const bq27441_t *dev, uint16_t function)
 {
-	uint8_t subCommandMSB = (function >> 8);
-	uint8_t subCommandLSB = (function & 0x00FF);
-	uint8_t command[2] = {subCommandLSB, subCommandMSB};
-	uint8_t data[2] = {0, 0};
+    uint8_t subCommandMSB = (function >> 8);
+    uint8_t subCommandLSB = (function & 0x00FF);
+    uint8_t command[2] = {subCommandLSB, subCommandMSB};
+    uint8_t data[2] = {0, 0};
 
-	_bq27441_write_bytes_i2c(dev, (uint8_t) 0, command, 2);
+    _bq27441_write_bytes_i2c(dev, (uint8_t) 0, command, 2);
 
-	if (_bq27441_read_bytes_i2c(dev, (uint8_t) 0, data, 2))
-	{
-		return ((uint16_t)data[1] << 8) | data[0];
-	}
+    if (_bq27441_read_bytes_i2c(dev, (uint8_t) 0, data, 2))
+    {
+        return ((uint16_t)data[1] << 8) | data[0];
+    }
 
-	return false;
+    return false;
 }
 
 // Execute a subcommand() from the BQ27441-G1A's control()
 bool _bq27441_execute_control_word(const bq27441_t *dev, uint16_t function)
 {
-	uint8_t subCommandMSB = (function >> 8);
-	uint8_t subCommandLSB = (function & 0x00FF);
-	uint8_t command[2] = {subCommandLSB, subCommandMSB};
-	//uint8_t data[2] = {0, 0};
+    uint8_t subCommandMSB = (function >> 8);
+    uint8_t subCommandLSB = (function & 0x00FF);
+    uint8_t command[2] = {subCommandLSB, subCommandMSB};
+    //uint8_t data[2] = {0, 0};
 
-	if (_bq27441_write_bytes_i2c(dev, (uint8_t) 0, command, 2))
-		return true;
+    if (_bq27441_write_bytes_i2c(dev, (uint8_t) 0, command, 2))
+        return true;
 
-	return false;
+    return false;
 }
 
 // Issue a BlockDataControl() command to enable BlockData access
 bool _bq27441_block_data_control(const bq27441_t *dev)
 {
-	uint8_t enableByte = 0x00;
-	return _bq27441_write_bytes_i2c(dev, BQ27441_EXTENDED_CONTROL, &enableByte, 1);
+    uint8_t enableByte = 0x00;
+    return _bq27441_write_bytes_i2c(dev, BQ27441_EXTENDED_CONTROL, &enableByte, 1);
 }
 
 // Issue a DataClass() command to set the data class to be accessed
 bool _bq27441_block_data_class(const bq27441_t *dev, uint8_t id)
 {
-	return _bq27441_write_bytes_i2c(dev, BQ27441_EXTENDED_DATACLASS, &id, 1);
+    return _bq27441_write_bytes_i2c(dev, BQ27441_EXTENDED_DATACLASS, &id, 1);
 }
 
 // Issue a DataBlock() command to set the data block to be accessed
 bool _bq27441_block_data_offset(const bq27441_t *dev, uint8_t offset)
 {
-	return _bq27441_write_bytes_i2c(dev, BQ27441_EXTENDED_DATABLOCK, &offset, 1);
+    return _bq27441_write_bytes_i2c(dev, BQ27441_EXTENDED_DATABLOCK, &offset, 1);
 }
 
 // Read the current checksum using BlockDataCheckSum()
 uint8_t _bq27441_block_data_checksum(const bq27441_t *dev)
 {
-	uint8_t csum;
-	_bq27441_read_bytes_i2c(dev, BQ27441_EXTENDED_CHECKSUM, &csum, 1);
-	return csum;
+    uint8_t csum;
+    _bq27441_read_bytes_i2c(dev, BQ27441_EXTENDED_CHECKSUM, &csum, 1);
+    return csum;
 }
 
 // Use BlockData() to read a byte from the loaded extended data
 uint8_t _bq27441_read_block_data(const bq27441_t *dev, uint8_t offset)
 {
-	uint8_t ret;
-	uint8_t address = offset + BQ27441_EXTENDED_BLOCKDATA;
-	_bq27441_read_bytes_i2c(dev, address, &ret, 1);
-	return ret;
+    uint8_t ret;
+    uint8_t address = offset + BQ27441_EXTENDED_BLOCKDATA;
+    _bq27441_read_bytes_i2c(dev, address, &ret, 1);
+    return ret;
 }
 
 // Use BlockData() to write a byte to an offset of the loaded data
 bool _bq27441_write_block_data(const bq27441_t *dev, uint8_t offset, uint8_t data)
 {
-	uint8_t address = offset + BQ27441_EXTENDED_BLOCKDATA;
-	return _bq27441_write_bytes_i2c(dev, address, &data, 1);
+    uint8_t address = offset + BQ27441_EXTENDED_BLOCKDATA;
+    return _bq27441_write_bytes_i2c(dev, address, &data, 1);
 }
 
 // Read all 32 bytes of the loaded extended data and compute a
 // checksum based on the values.
 uint8_t _bq27441_compute_block_checksum(const bq27441_t *dev)
 {
-	uint8_t data[32];
-	_bq27441_read_bytes_i2c(dev, BQ27441_EXTENDED_BLOCKDATA, data, 32);
+    uint8_t data[32];
+    _bq27441_read_bytes_i2c(dev, BQ27441_EXTENDED_BLOCKDATA, data, 32);
 
-	uint8_t csum = 0;
-	for (int i=0; i<32; i++)
-	{
-		csum += data[i];
-	}
-	csum = 255 - csum;
+    uint8_t csum = 0;
+    for (int i=0; i<32; i++)
+    {
+        csum += data[i];
+    }
+    csum = 255 - csum;
 
-	return csum;
+    return csum;
 }
 
 // Use the BlockDataCheckSum() command to write a checksum value
 bool _bq27441_write_block_checksum(const bq27441_t *dev, uint8_t csum)
 {
-	return _bq27441_write_bytes_i2c(dev, BQ27441_EXTENDED_CHECKSUM, &csum, 1);
+    return _bq27441_write_bytes_i2c(dev, BQ27441_EXTENDED_CHECKSUM, &csum, 1);
 }
 
 // Read a byte from extended data specifying a class ID and position offset
 uint8_t _bq27441_read_extended_data(bq27441_t *dev, uint8_t classID, uint8_t offset)
 {
-	uint8_t retData = 0;
-	if (!dev->userConfigControl) bq27441_enter_config_mode(dev, false);
+    uint8_t retData = 0;
+    if (!dev->userConfigControl) bq27441_enter_config_mode(dev, false);
 
-	if (!_bq27441_block_data_control(dev)) // // enable block data memory control
-		return false; // Return false if enable fails
-	if (!_bq27441_block_data_class(dev, classID)) // Write class ID using DataBlockClass()
-		return false;
+    if (!_bq27441_block_data_control(dev)) // // enable block data memory control
+        return false; // Return false if enable fails
+    if (!_bq27441_block_data_class(dev, classID)) // Write class ID using DataBlockClass()
+        return false;
 
-	_bq27441_block_data_offset(dev, offset / 32); // Write 32-bit block offset (usually 0)
+    _bq27441_block_data_offset(dev, offset / 32); // Write 32-bit block offset (usually 0)
 
-	_bq27441_compute_block_checksum(dev); // Compute checksum going in
-	//uint8_t oldCsum = blockDataChecksum();
-	/*for (int i=0; i<32; i++)
-		Serial.print(String(readBlockData(i)) + " ");*/
-	retData = _bq27441_read_block_data(dev, offset % 32); // Read from offset (limit to 0-31)
+    _bq27441_compute_block_checksum(dev); // Compute checksum going in
+    //uint8_t oldCsum = blockDataChecksum();
+    /*for (int i=0; i<32; i++)
+        Serial.print(String(readBlockData(i)) + " ");*/
+    retData = _bq27441_read_block_data(dev, offset % 32); // Read from offset (limit to 0-31)
 
-	if (!dev->userConfigControl) bq27441_exit_config_mode(dev, true);
+    if (!dev->userConfigControl) bq27441_exit_config_mode(dev, true);
 
-	return retData;
+    return retData;
 }
 
 // Write a specified number of bytes to extended data specifying a
 // class ID, position offset.
 bool _bq27441_write_extended_data(bq27441_t *dev, uint8_t classID, uint8_t offset, uint8_t * data, uint8_t len)
 {
-	if (len > 32)
-		return false;
+    if (len > 32)
+        return false;
 
-	if (!dev->userConfigControl) bq27441_enter_config_mode(dev, false);
+    if (!dev->userConfigControl) bq27441_enter_config_mode(dev, false);
 
-	if (!_bq27441_block_data_control(dev)) // // enable block data memory control
-		return false; // Return false if enable fails
-	if (!_bq27441_block_data_class(dev, classID)) // Write class ID using DataBlockClass()
-		return false;
+    if (!_bq27441_block_data_control(dev)) // // enable block data memory control
+        return false; // Return false if enable fails
+    if (!_bq27441_block_data_class(dev, classID)) // Write class ID using DataBlockClass()
+        return false;
 
-	_bq27441_block_data_offset(dev, offset / 32); // Write 32-bit block offset (usually 0)
-	_bq27441_compute_block_checksum(dev); // Compute checksum going in
-	//uint8_t oldCsum = blockDataChecksum();
+    _bq27441_block_data_offset(dev, offset / 32); // Write 32-bit block offset (usually 0)
+    _bq27441_compute_block_checksum(dev); // Compute checksum going in
+    //uint8_t oldCsum = blockDataChecksum();
 
-	// Write data bytes:
-	for (int i = 0; i < len; i++)
-	{
-		// Write to offset, mod 32 if offset is greater than 32
-		// The blockDataOffset above sets the 32-bit block
-		_bq27441_write_block_data(dev, (offset % 32) + i, data[i]);
-	}
+    // Write data bytes:
+    for (int i = 0; i < len; i++)
+    {
+        // Write to offset, mod 32 if offset is greater than 32
+        // The blockDataOffset above sets the 32-bit block
+        _bq27441_write_block_data(dev, (offset % 32) + i, data[i]);
+    }
 
-	// Write new checksum using BlockDataChecksum (0x60)
-	uint8_t newCsum = _bq27441_compute_block_checksum(dev); // Compute the new checksum
-	_bq27441_write_block_checksum(dev, newCsum);
+    // Write new checksum using BlockDataChecksum (0x60)
+    uint8_t newCsum = _bq27441_compute_block_checksum(dev); // Compute the new checksum
+    _bq27441_write_block_checksum(dev, newCsum);
 
-	if (!dev->userConfigControl) bq27441_exit_config_mode(dev, true);
+    if (!dev->userConfigControl) bq27441_exit_config_mode(dev, true);
 
-	return true;
+    return true;
 }
 
 // Read a specified number of bytes over I2C at a given subAddress
 int16_t _bq27441_read_bytes_i2c(const bq27441_t *dev, uint8_t subAddress, uint8_t * dest, uint8_t count)
 {
-    int res;
     int16_t timeout = BQ72441_I2C_TIMEOUT;
     uint8_t i2c_buf[BQ72441_I2C_BUFSIZE];
 
     while (timeout--) {
         xtimer_nanosleep(1000);
-        res = i2c_read_regs(dev->bus, BQ72441_I2C_ADDRESS, subAddress, i2c_buf, count, 0);
+        int res = i2c_read_regs(dev->bus, BQ72441_I2C_ADDRESS, subAddress, i2c_buf, count, 0);
         if (res == I2C_ACK) {
             debug_print_i2c_read(dev->bus, subAddress, i2c_buf, count);
             for (int i = 0; i < count; i++) {

--- a/drivers/bq27441/include/bq27441-internal.h
+++ b/drivers/bq27441/include/bq27441-internal.h
@@ -27,12 +27,12 @@ extern "C" {
 /**
  * @brief Secret code to unseal the BQ27441-G1A
  */
-#define BQ27441_UNSEAL_KEY	0x8000
+#define BQ27441_UNSEAL_KEY  0x8000
 
 /**
  * @brief Default device ID
  */
-#define BQ27441_DEVICE_ID	0x0421
+#define BQ27441_DEVICE_ID   0x0421
 
 /**
  * @brief   Standard Commands
@@ -41,26 +41,26 @@ extern "C" {
  *          sequential command-code pair.
  * @{
  */
-#define BQ27441_COMMAND_CONTROL			0x00 /**< Control */
-#define BQ27441_COMMAND_TEMP			0x02 /**< Temperature */
-#define BQ27441_COMMAND_VOLTAGE			0x04 /**< Voltage */
-#define BQ27441_COMMAND_FLAGS			0x06 /**< Flags */
-#define BQ27441_COMMAND_NOM_CAPACITY	0x08 /**< NominalAvailableCapacity */
-#define BQ27441_COMMAND_AVAIL_CAPACITY	0x0A /**< FullAvailableCapacity */
-#define BQ27441_COMMAND_REM_CAPACITY	0x0C /**< RemainingCapacity */
-#define BQ27441_COMMAND_FULL_CAPACITY	0x0E /**< FullChargeCapacity */
-#define BQ27441_COMMAND_AVG_CURRENT		0x10 /**< AverageCurrent */
-#define BQ27441_COMMAND_STDBY_CURRENT	0x12 /**< StandbyCurrent */
-#define BQ27441_COMMAND_MAX_CURRENT		0x14 /**< MaxLoadCurrent */
-#define BQ27441_COMMAND_AVG_POWER		0x18 /**< AveragePower */
-#define BQ27441_COMMAND_SOC				0x1C /**< StateOfCharge */
-#define BQ27441_COMMAND_INT_TEMP		0x1E /**< InternalTemperature */
-#define BQ27441_COMMAND_SOH				0x20 /**< StateOfHealth */
-#define BQ27441_COMMAND_REM_CAP_UNFL	0x28 /**< RemainingCapacityUnfiltered */
-#define BQ27441_COMMAND_REM_CAP_FIL		0x2A /**< RemainingCapacityFiltered */
-#define BQ27441_COMMAND_FULL_CAP_UNFL	0x2C /**< FullChargeCapacityUnfiltered */
-#define BQ27441_COMMAND_FULL_CAP_FIL	0x2E /**< FullChargeCapacityFiltered */
-#define BQ27441_COMMAND_SOC_UNFL		0x30 /**< StateOfChargeUnfiltered */
+#define BQ27441_COMMAND_CONTROL         0x00    /**< Control */
+#define BQ27441_COMMAND_TEMP            0x02    /**< Temperature */
+#define BQ27441_COMMAND_VOLTAGE         0x04    /**< Voltage */
+#define BQ27441_COMMAND_FLAGS           0x06    /**< Flags */
+#define BQ27441_COMMAND_NOM_CAPACITY    0x08    /**< NominalAvailableCapacity */
+#define BQ27441_COMMAND_AVAIL_CAPACITY  0x0A    /**< FullAvailableCapacity */
+#define BQ27441_COMMAND_REM_CAPACITY    0x0C    /**< RemainingCapacity */
+#define BQ27441_COMMAND_FULL_CAPACITY   0x0E    /**< FullChargeCapacity */
+#define BQ27441_COMMAND_AVG_CURRENT     0x10    /**< AverageCurrent */
+#define BQ27441_COMMAND_STDBY_CURRENT   0x12    /**< StandbyCurrent */
+#define BQ27441_COMMAND_MAX_CURRENT     0x14    /**< MaxLoadCurrent */
+#define BQ27441_COMMAND_AVG_POWER       0x18    /**< AveragePower */
+#define BQ27441_COMMAND_SOC             0x1C    /**< StateOfCharge */
+#define BQ27441_COMMAND_INT_TEMP        0x1E    /**< InternalTemperature */
+#define BQ27441_COMMAND_SOH             0x20    /**< StateOfHealth */
+#define BQ27441_COMMAND_REM_CAP_UNFL    0x28    /**< RemainingCapacityUnfiltered */
+#define BQ27441_COMMAND_REM_CAP_FIL     0x2A    /**< RemainingCapacityFiltered */
+#define BQ27441_COMMAND_FULL_CAP_UNFL   0x2C    /**< FullChargeCapacityUnfiltered */
+#define BQ27441_COMMAND_FULL_CAP_FIL    0x2E    /**< FullChargeCapacityFiltered */
+#define BQ27441_COMMAND_SOC_UNFL        0x30    /**< StateOfChargeUnfiltered */
 /** @} */
 
 /**
@@ -72,25 +72,25 @@ extern "C" {
  *          different access modes.
  * @{
  */
-#define BQ27441_CONTROL_STATUS			0x00
-#define BQ27441_CONTROL_DEVICE_TYPE		0x01
-#define BQ27441_CONTROL_FW_VERSION		0x02
-#define BQ27441_CONTROL_DM_CODE			0x04
-#define BQ27441_CONTROL_PREV_MACWRITE	0x07
-#define BQ27441_CONTROL_CHEM_ID			0x08
-#define BQ27441_CONTROL_BAT_INSERT		0x0C
-#define BQ27441_CONTROL_BAT_REMOVE		0x0D
-#define BQ27441_CONTROL_SET_HIBERNATE	0x11
-#define BQ27441_CONTROL_CLEAR_HIBERNATE	0x12
-#define BQ27441_CONTROL_SET_CFGUPDATE	0x13
-#define BQ27441_CONTROL_SHUTDOWN_ENABLE	0x1B
-#define BQ27441_CONTROL_SHUTDOWN		0x1C
-#define BQ27441_CONTROL_SEALED			0x20
-#define BQ27441_CONTROL_PULSE_SOC_INT	0x23
-#define BQ27441_CONTROL_RESET			0x41
-#define BQ27441_CONTROL_SOFT_RESET		0x42
-#define BQ27441_CONTROL_EXIT_CFGUPDATE	0x43
-#define BQ27441_CONTROL_EXIT_RESIM		0x44
+#define BQ27441_CONTROL_STATUS          0x00
+#define BQ27441_CONTROL_DEVICE_TYPE     0x01
+#define BQ27441_CONTROL_FW_VERSION      0x02
+#define BQ27441_CONTROL_DM_CODE         0x04
+#define BQ27441_CONTROL_PREV_MACWRITE   0x07
+#define BQ27441_CONTROL_CHEM_ID         0x08
+#define BQ27441_CONTROL_BAT_INSERT      0x0C
+#define BQ27441_CONTROL_BAT_REMOVE      0x0D
+#define BQ27441_CONTROL_SET_HIBERNATE   0x11
+#define BQ27441_CONTROL_CLEAR_HIBERNATE 0x12
+#define BQ27441_CONTROL_SET_CFGUPDATE   0x13
+#define BQ27441_CONTROL_SHUTDOWN_ENABLE 0x1B
+#define BQ27441_CONTROL_SHUTDOWN        0x1C
+#define BQ27441_CONTROL_SEALED          0x20
+#define BQ27441_CONTROL_PULSE_SOC_INT   0x23
+#define BQ27441_CONTROL_RESET           0x41
+#define BQ27441_CONTROL_SOFT_RESET      0x42
+#define BQ27441_CONTROL_EXIT_CFGUPDATE  0x43
+#define BQ27441_CONTROL_EXIT_RESIM      0x44
 /** @} */
 
 /**
@@ -102,20 +102,20 @@ extern "C" {
  *          through using specified subcommands.
  * @{
  */
-#define BQ27441_STATUS_SHUTDOWNEN	(1<<15)
-#define BQ27441_STATUS_WDRESET		(1<<14)
-#define BQ27441_STATUS_SS			(1<<13)
-#define BQ27441_STATUS_CALMODE		(1<<12)
-#define BQ27441_STATUS_CCA			(1<<11)
-#define BQ27441_STATUS_BCA			(1<<10)
-#define BQ27441_STATUS_QMAX_UP		(1<<9)
-#define BQ27441_STATUS_RES_UP		(1<<8)
-#define BQ27441_STATUS_INITCOMP		(1<<7)
-#define BQ27441_STATUS_HIBERNATE	(1<<6)
-#define BQ27441_STATUS_SLEEP		(1<<4)
-#define BQ27441_STATUS_LDMD			(1<<3)
-#define BQ27441_STATUS_RUP_DIS		(1<<2)
-#define BQ27441_STATUS_VOK			(1<<1)
+#define BQ27441_STATUS_SHUTDOWNEN   (1 << 15)
+#define BQ27441_STATUS_WDRESET      (1 << 14)
+#define BQ27441_STATUS_SS           (1 << 13)
+#define BQ27441_STATUS_CALMODE      (1 << 12)
+#define BQ27441_STATUS_CCA          (1 << 11)
+#define BQ27441_STATUS_BCA          (1 << 10)
+#define BQ27441_STATUS_QMAX_UP      (1 << 9)
+#define BQ27441_STATUS_RES_UP       (1 << 8)
+#define BQ27441_STATUS_INITCOMP     (1 << 7)
+#define BQ27441_STATUS_HIBERNATE    (1 << 6)
+#define BQ27441_STATUS_SLEEP        (1 << 4)
+#define BQ27441_STATUS_LDMD         (1 << 3)
+#define BQ27441_STATUS_RUP_DIS      (1 << 2)
+#define BQ27441_STATUS_VOK          (1 << 1)
 /** @} */
 
 /**
@@ -125,17 +125,17 @@ extern "C" {
  *          register, depicting the current operating status.
  * @{
  */
-#define BQ27441_FLAG_OT			(1<<15)
-#define BQ27441_FLAG_UT			(1<<14)
-#define BQ27441_FLAG_FC			(1<<9)
-#define BQ27441_FLAG_CHG		(1<<8)
-#define BQ27441_FLAG_OCVTAKEN	(1<<7)
-#define BQ27441_FLAG_ITPOR		(1<<5)
-#define BQ27441_FLAG_CFGUPMODE	(1<<4)
-#define BQ27441_FLAG_BAT_DET	(1<<3)
-#define BQ27441_FLAG_SOC1		(1<<2)
-#define BQ27441_FLAG_SOCF		(1<<1)
-#define BQ27441_FLAG_DSG		(1<<0)
+#define BQ27441_FLAG_OT         (1 << 15)
+#define BQ27441_FLAG_UT         (1 << 14)
+#define BQ27441_FLAG_FC         (1 << 9)
+#define BQ27441_FLAG_CHG        (1 << 8)
+#define BQ27441_FLAG_OCVTAKEN   (1 << 7)
+#define BQ27441_FLAG_ITPOR      (1 << 5)
+#define BQ27441_FLAG_CFGUPMODE  (1 << 4)
+#define BQ27441_FLAG_BAT_DET    (1 << 3)
+#define BQ27441_FLAG_SOC1       (1 << 2)
+#define BQ27441_FLAG_SOCF       (1 << 1)
+#define BQ27441_FLAG_DSG        (1 << 0)
 /** @} */
 
 /**
@@ -145,13 +145,13 @@ extern "C" {
  *          commands, extended commands are not limited to 2-byte words.
  * @{
  */
-#define BQ27441_EXTENDED_OPCONFIG	0x3A /**< OpConfig */
-#define BQ27441_EXTENDED_CAPACITY	0x3C /**< DesignCapacity */
-#define BQ27441_EXTENDED_DATACLASS	0x3E /**< DataClass */
-#define BQ27441_EXTENDED_DATABLOCK	0x3F /**< DataBlock */
-#define BQ27441_EXTENDED_BLOCKDATA	0x40 /**< BlockData */
-#define BQ27441_EXTENDED_CHECKSUM	0x60 /**< BlockDataCheckSum */
-#define BQ27441_EXTENDED_CONTROL	0x61 /**< BlockDataControl */
+#define BQ27441_EXTENDED_OPCONFIG   0x3A    /**< OpConfig */
+#define BQ27441_EXTENDED_CAPACITY   0x3C    /**< DesignCapacity */
+#define BQ27441_EXTENDED_DATACLASS  0x3E    /**< DataClass */
+#define BQ27441_EXTENDED_DATABLOCK  0x3F    /**< DataBlock */
+#define BQ27441_EXTENDED_BLOCKDATA  0x40    /**< BlockData */
+#define BQ27441_EXTENDED_CHECKSUM   0x60    /**< BlockDataCheckSum */
+#define BQ27441_EXTENDED_CONTROL    0x61    /**< BlockDataControl */
 /** @} */
 
 /**
@@ -160,20 +160,20 @@ extern "C" {
  *          with one of these values.
  * @{
  */
-#define BQ27441_ID_SAFETY			2   /**< Configuration Class: Safety */
-#define BQ27441_ID_CHG_TERMINATION	36  /**< Configuration Class: Charge Termination */
-#define BQ27441_ID_CONFIG_DATA		48  /**< Configuration Class: Data */
-#define BQ27441_ID_DISCHARGE		49  /**< Configuration Class: Discharge */
-#define BQ27441_ID_REGISTERS		64  /**< Configuration Class: Registers */
-#define BQ27441_ID_POWER			68  /**< Configuration Class: Power */
-#define BQ27441_ID_IT_CFG			80  /**< Gas Gauging Class: IT Cfg */
-#define BQ27441_ID_CURRENT_THRESH	81  /**< Gas Gauging Class: Current Thresholds */
-#define BQ27441_ID_STATE			82  /**< Gas Gauging Class: State */
-#define BQ27441_ID_R_A_RAM			89  /**< Ra Tables Class: R_a RAM */
-#define BQ27441_ID_CALIB_DATA		104 /**< Calibration Class: Data */
-#define BQ27441_ID_CC_CAL			105 /**< Calibration Class: CC Cal */
-#define BQ27441_ID_CURRENT			107 /**< Calibration Class: Current */
-#define BQ27441_ID_CODES			112 /**< Security Class: Codes */
+#define BQ27441_ID_SAFETY           2   /**< Configuration Class: Safety */
+#define BQ27441_ID_CHG_TERMINATION  36  /**< Configuration Class: Charge Termination */
+#define BQ27441_ID_CONFIG_DATA      48  /**< Configuration Class: Data */
+#define BQ27441_ID_DISCHARGE        49  /**< Configuration Class: Discharge */
+#define BQ27441_ID_REGISTERS        64  /**< Configuration Class: Registers */
+#define BQ27441_ID_POWER            68  /**< Configuration Class: Power */
+#define BQ27441_ID_IT_CFG           80  /**< Gas Gauging Class: IT Cfg */
+#define BQ27441_ID_CURRENT_THRESH   81  /**< Gas Gauging Class: Current Thresholds */
+#define BQ27441_ID_STATE            82  /**< Gas Gauging Class: State */
+#define BQ27441_ID_R_A_RAM          89  /**< Ra Tables Class: R_a RAM */
+#define BQ27441_ID_CALIB_DATA       104 /**< Calibration Class: Data */
+#define BQ27441_ID_CC_CAL           105 /**< Calibration Class: CC Cal */
+#define BQ27441_ID_CURRENT          107 /**< Calibration Class: Current */
+#define BQ27441_ID_CODES            112 /**< Security Class: Codes */
 /** @} */
 
 /**
@@ -182,13 +182,13 @@ extern "C" {
  *
  * @{
  */
-#define BQ27441_OPCONFIG_BIE      (1<<13)
-#define BQ27441_OPCONFIG_BI_PU_EN (1<<12)
-#define BQ27441_OPCONFIG_GPIOPOL  (1<<11)
-#define BQ27441_OPCONFIG_SLEEP    (1<<5)
-#define BQ27441_OPCONFIG_RMFCC    (1<<4)
-#define BQ27441_OPCONFIG_BATLOWEN (1<<2)
-#define BQ27441_OPCONFIG_TEMPS    (1<<0)
+#define BQ27441_OPCONFIG_BIE      (1 << 13)
+#define BQ27441_OPCONFIG_BI_PU_EN (1 << 12)
+#define BQ27441_OPCONFIG_GPIOPOL  (1 << 11)
+#define BQ27441_OPCONFIG_SLEEP    (1 << 5)
+#define BQ27441_OPCONFIG_RMFCC    (1 << 4)
+#define BQ27441_OPCONFIG_BATLOWEN (1 << 2)
+#define BQ27441_OPCONFIG_TEMPS    (1 << 0)
 /** @} */
 
 #endif /* BQ27441_INTERNAL_H */

--- a/drivers/bq27441/include/bq27441-internal.h
+++ b/drivers/bq27441/include/bq27441-internal.h
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2018, Anatoliy Atanasov, Iliyan Stoyanov All rights reserved.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_bq27441
+ * @brief       Default parameters for the BQ27441 fuel gauge for single-cell Li-Ion batteries
+ * @{
+ *
+ * @file
+ * @brief       Default parameters for the BQ27441 fuel gauge
+ *
+ * @author      Anatoliy Atanasov <anatoliy@6lowpan.io>
+ * @author      Iliyan Stoyanov <iliyan@6lowpan.io>
+ */
+#ifndef BQ27441_INTERNAL_H
+#define BQ27441_INTERNAL_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Secret code to unseal the BQ27441-G1A
+ */
+#define BQ27441_UNSEAL_KEY	0x8000
+
+/**
+ * @brief Default device ID
+ */
+#define BQ27441_DEVICE_ID	0x0421
+
+/**
+ * @brief   Standard Commands
+ * @details The fuel gauge uses a series of 2-byte standard commands to enable system
+ *          reading and writing of battery information. Each command has an associated
+ *          sequential command-code pair.
+ * @{
+ */
+#define BQ27441_COMMAND_CONTROL			0x00 /**< Control */
+#define BQ27441_COMMAND_TEMP			0x02 /**< Temperature */
+#define BQ27441_COMMAND_VOLTAGE			0x04 /**< Voltage */
+#define BQ27441_COMMAND_FLAGS			0x06 /**< Flags */
+#define BQ27441_COMMAND_NOM_CAPACITY	0x08 /**< NominalAvailableCapacity */
+#define BQ27441_COMMAND_AVAIL_CAPACITY	0x0A /**< FullAvailableCapacity */
+#define BQ27441_COMMAND_REM_CAPACITY	0x0C /**< RemainingCapacity */
+#define BQ27441_COMMAND_FULL_CAPACITY	0x0E /**< FullChargeCapacity */
+#define BQ27441_COMMAND_AVG_CURRENT		0x10 /**< AverageCurrent */
+#define BQ27441_COMMAND_STDBY_CURRENT	0x12 /**< StandbyCurrent */
+#define BQ27441_COMMAND_MAX_CURRENT		0x14 /**< MaxLoadCurrent */
+#define BQ27441_COMMAND_AVG_POWER		0x18 /**< AveragePower */
+#define BQ27441_COMMAND_SOC				0x1C /**< StateOfCharge */
+#define BQ27441_COMMAND_INT_TEMP		0x1E /**< InternalTemperature */
+#define BQ27441_COMMAND_SOH				0x20 /**< StateOfHealth */
+#define BQ27441_COMMAND_REM_CAP_UNFL	0x28 /**< RemainingCapacityUnfiltered */
+#define BQ27441_COMMAND_REM_CAP_FIL		0x2A /**< RemainingCapacityFiltered */
+#define BQ27441_COMMAND_FULL_CAP_UNFL	0x2C /**< FullChargeCapacityUnfiltered */
+#define BQ27441_COMMAND_FULL_CAP_FIL	0x2E /**< FullChargeCapacityFiltered */
+#define BQ27441_COMMAND_SOC_UNFL		0x30 /**< StateOfChargeUnfiltered */
+/** @} */
+
+/**
+ * @brief   Control Sub-commands
+ * @details Issuing a Control command requires a subsequent 2-byte subcommand. These
+ *          additional bytes specify the particular control function desired. The
+ *          Control command allows the system to control specific features of the fuel
+ *          gauge during normal operation and additional features when the device is in
+ *          different access modes.
+ * @{
+ */
+#define BQ27441_CONTROL_STATUS			0x00
+#define BQ27441_CONTROL_DEVICE_TYPE		0x01
+#define BQ27441_CONTROL_FW_VERSION		0x02
+#define BQ27441_CONTROL_DM_CODE			0x04
+#define BQ27441_CONTROL_PREV_MACWRITE	0x07
+#define BQ27441_CONTROL_CHEM_ID			0x08
+#define BQ27441_CONTROL_BAT_INSERT		0x0C
+#define BQ27441_CONTROL_BAT_REMOVE		0x0D
+#define BQ27441_CONTROL_SET_HIBERNATE	0x11
+#define BQ27441_CONTROL_CLEAR_HIBERNATE	0x12
+#define BQ27441_CONTROL_SET_CFGUPDATE	0x13
+#define BQ27441_CONTROL_SHUTDOWN_ENABLE	0x1B
+#define BQ27441_CONTROL_SHUTDOWN		0x1C
+#define BQ27441_CONTROL_SEALED			0x20
+#define BQ27441_CONTROL_PULSE_SOC_INT	0x23
+#define BQ27441_CONTROL_RESET			0x41
+#define BQ27441_CONTROL_SOFT_RESET		0x42
+#define BQ27441_CONTROL_EXIT_CFGUPDATE	0x43
+#define BQ27441_CONTROL_EXIT_RESIM		0x44
+/** @} */
+
+/**
+ * @brief   Control Status Word - Bit Definitions
+ * @details Bit positions for the 16-bit data of CONTROL_STATUS.
+ *          CONTROL_STATUS instructs the fuel gauge to return status information to
+ *          Control addresses 0x00 and 0x01. The read-only status word contains status
+ *          bits that are set or cleared either automatically as conditions warrant or
+ *          through using specified subcommands.
+ * @{
+ */
+#define BQ27441_STATUS_SHUTDOWNEN	(1<<15)
+#define BQ27441_STATUS_WDRESET		(1<<14)
+#define BQ27441_STATUS_SS			(1<<13)
+#define BQ27441_STATUS_CALMODE		(1<<12)
+#define BQ27441_STATUS_CCA			(1<<11)
+#define BQ27441_STATUS_BCA			(1<<10)
+#define BQ27441_STATUS_QMAX_UP		(1<<9)
+#define BQ27441_STATUS_RES_UP		(1<<8)
+#define BQ27441_STATUS_INITCOMP		(1<<7)
+#define BQ27441_STATUS_HIBERNATE	(1<<6)
+#define BQ27441_STATUS_SLEEP		(1<<4)
+#define BQ27441_STATUS_LDMD			(1<<3)
+#define BQ27441_STATUS_RUP_DIS		(1<<2)
+#define BQ27441_STATUS_VOK			(1<<1)
+/** @} */
+
+/**
+ * @brief   Flag Command - Bit Definitions
+ * @details Bit positions for the 16-bit data of Flags
+ *          This read-word function returns the contents of the fuel gauging status
+ *          register, depicting the current operating status.
+ * @{
+ */
+#define BQ27441_FLAG_OT			(1<<15)
+#define BQ27441_FLAG_UT			(1<<14)
+#define BQ27441_FLAG_FC			(1<<9)
+#define BQ27441_FLAG_CHG		(1<<8)
+#define BQ27441_FLAG_OCVTAKEN	(1<<7)
+#define BQ27441_FLAG_ITPOR		(1<<5)
+#define BQ27441_FLAG_CFGUPMODE	(1<<4)
+#define BQ27441_FLAG_BAT_DET	(1<<3)
+#define BQ27441_FLAG_SOC1		(1<<2)
+#define BQ27441_FLAG_SOCF		(1<<1)
+#define BQ27441_FLAG_DSG		(1<<0)
+/** @} */
+
+/**
+ * @brief   Extended Data Commands
+ * @details Extended data commands offer additional functionality beyond the standard
+ *          set of commands. They are used in the same manner; however, unlike standard
+ *          commands, extended commands are not limited to 2-byte words.
+ * @{
+ */
+#define BQ27441_EXTENDED_OPCONFIG	0x3A /**< OpConfig */
+#define BQ27441_EXTENDED_CAPACITY	0x3C /**< DesignCapacity */
+#define BQ27441_EXTENDED_DATACLASS	0x3E /**< DataClass */
+#define BQ27441_EXTENDED_DATABLOCK	0x3F /**< DataBlock */
+#define BQ27441_EXTENDED_BLOCKDATA	0x40 /**< BlockData */
+#define BQ27441_EXTENDED_CHECKSUM	0x60 /**< BlockDataCheckSum */
+#define BQ27441_EXTENDED_CONTROL	0x61 /**< BlockDataControl */
+/** @} */
+
+/**
+ * @brief   Configuration Class, Subclass ID's
+ * @details To access a subclass of the extended data, set the DataClass() function
+ *          with one of these values.
+ * @{
+ */
+#define BQ27441_ID_SAFETY			2   /**< Configuration Class: Safety */
+#define BQ27441_ID_CHG_TERMINATION	36  /**< Configuration Class: Charge Termination */
+#define BQ27441_ID_CONFIG_DATA		48  /**< Configuration Class: Data */
+#define BQ27441_ID_DISCHARGE		49  /**< Configuration Class: Discharge */
+#define BQ27441_ID_REGISTERS		64  /**< Configuration Class: Registers */
+#define BQ27441_ID_POWER			68  /**< Configuration Class: Power */
+#define BQ27441_ID_IT_CFG			80  /**< Gas Gauging Class: IT Cfg */
+#define BQ27441_ID_CURRENT_THRESH	81  /**< Gas Gauging Class: Current Thresholds */
+#define BQ27441_ID_STATE			82  /**< Gas Gauging Class: State */
+#define BQ27441_ID_R_A_RAM			89  /**< Ra Tables Class: R_a RAM */
+#define BQ27441_ID_CALIB_DATA		104 /**< Calibration Class: Data */
+#define BQ27441_ID_CC_CAL			105 /**< Calibration Class: CC Cal */
+#define BQ27441_ID_CURRENT			107 /**< Calibration Class: Current */
+#define BQ27441_ID_CODES			112 /**< Security Class: Codes */
+/** @} */
+
+/**
+ * @brief   OpConfig Register - Bit Definitions
+ * @details Bit positions of the OpConfig Register
+ *
+ * @{
+ */
+#define BQ27441_OPCONFIG_BIE      (1<<13)
+#define BQ27441_OPCONFIG_BI_PU_EN (1<<12)
+#define BQ27441_OPCONFIG_GPIOPOL  (1<<11)
+#define BQ27441_OPCONFIG_SLEEP    (1<<5)
+#define BQ27441_OPCONFIG_RMFCC    (1<<4)
+#define BQ27441_OPCONFIG_BATLOWEN (1<<2)
+#define BQ27441_OPCONFIG_TEMPS    (1<<0)
+/** @} */
+
+#endif /* BQ27441_INTERNAL_H */
+/** @} */

--- a/drivers/bq27441/include/bq27441_params.h
+++ b/drivers/bq27441/include/bq27441_params.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018, Anatoliy Atanasov, Iliyan Stoyanov All rights reserved.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_bq27441
+ * @brief       Default parameters for the BQ27441 fuel gauge for single-cell Li-Ion batteries
+ * @{
+ *
+ * @file
+ * @brief       Default parameters for the BQ27441 fuel gauge
+ *
+ * @author      Anatoliy Atanasov <anatoliy@6lowpan.io>
+ * @author      Iliyan Stoyanov <iliyan@6lowpan.io>
+ */
+
+#ifndef BQ27441_PARAMS_H
+#define BQ27441_PARAMS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "board.h"  /* THIS INCLUDE IS MANDATORY */
+#include "bq27441.h"
+
+/**
+ * @brief   Default configuration parameters for BQ27441 sensors
+ * @{
+ */
+#ifndef BQ27441_PARAMS_I2C
+#define BQ27441_PARAMS_I2C            (I2C_DEV(0))
+#endif
+#ifndef BQ27441_PARAMS_ADDR
+#define BQ27441_PARAMS_ADDR           (BQ72441_I2C_ADDRESS)
+#endif
+#ifndef BQ27441_PARAMS_ALARM_PIN
+#define BQ27441_PARAMS_ALARM_PIN      GPIO_PIN(2, 3)
+#endif
+
+#ifndef BQ27441_PARAMS
+#define BQ27441_PARAMS            { .alarm_pin = BQ27441_PARAMS_ALARM_PIN, \
+                                      .bus  = BQ27441_PARAMS_I2C, \
+                                      .addr = BQ27441_PARAMS_ADDR }
+#endif
+/** @} */
+/**
+ * @brief   Allocation of BQ27441 configuration
+ */
+static const bq27441_param_t params_default[] = {
+    #ifdef BQ27441_PARAMS_BOARD
+        BQ27441_PARAMS_BOARD
+    #else
+        BQ27441_PARAMS
+    #endif
+};
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* BQ27441_PARAMS_H */

--- a/drivers/bq27441/include/bq27441_params.h
+++ b/drivers/bq27441/include/bq27441_params.h
@@ -44,8 +44,8 @@ extern "C" {
 
 #ifndef BQ27441_PARAMS
 #define BQ27441_PARAMS            { .alarm_pin = BQ27441_PARAMS_ALARM_PIN, \
-                                      .bus  = BQ27441_PARAMS_I2C, \
-                                      .addr = BQ27441_PARAMS_ADDR }
+                                    .bus = BQ27441_PARAMS_I2C, \
+                                    .addr = BQ27441_PARAMS_ADDR }
 #endif
 /** @} */
 /**
@@ -53,9 +53,9 @@ extern "C" {
  */
 static const bq27441_param_t params_default[] = {
     #ifdef BQ27441_PARAMS_BOARD
-        BQ27441_PARAMS_BOARD
+    BQ27441_PARAMS_BOARD
     #else
-        BQ27441_PARAMS
+    BQ27441_PARAMS
     #endif
 };
 

--- a/drivers/include/bq27441.h
+++ b/drivers/include/bq27441.h
@@ -1,0 +1,628 @@
+/*
+ * Copyright 2018, Anatoliy Atanasov, Iliyan Stoyanov All rights reserved.
+ *
+ * This file is port of https://github.com/sparkfun/Battery_Babysitter code
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_bq27441 BQ27441
+ * @ingroup     drivers_sensors
+ * @brief       Default parameters for the BQ27441 fuel gauge for single-cell Li-Ion batteries
+ * @{
+ *
+ * @file
+ * @brief       Default parameters for the BQ27441 fuel gauge
+ *
+ * @author      Anatoliy Atanasov <anatoliy@6lowpan.io>
+ * @author      Iliyan Stoyanov <iliyan@6lowpan.io>
+ */
+#ifndef BQ27441_H
+#define BQ27441_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "periph_conf.h"
+#include "periph/i2c.h"
+
+/**
+ * @brief Default I2C address of the BQ27441-G1A
+ */
+#define BQ72441_I2C_ADDRESS 0x55
+
+/**
+ * @brief Parameters for the bq27441_get_current() function, to specify which current to read
+ * @{
+ */
+typedef enum {
+	AVG,  /**< Average Current (DEFAULT) */
+	STBY, /**< Standby Current */
+	MAX   /**< Mx Current */
+} current_measure;
+/** @} */
+
+/**
+ * @brief Parameters for the bq27441_get_capacity() function, to specify which current to read
+ * @{
+ */
+typedef enum {
+	REMAIN,     /**< Remaining Capacity (DEFAULT) */
+	FULL,       /**< Full Capacity */
+	AVAIL,      /**< Available Capacity */
+	AVAIL_FULL, /**< Full Available Capacity */
+	REMAIN_F,   /**< Remaining Capacity Filtered */
+	REMAIN_UF,  /**< Remaining Capacity Unfiltered */
+	FULL_F,     /**< Full Capacity Filtered */
+	FULL_UF,    /**< Full Capacity Unfiltered */
+	DESIGN      /**< Design Capacity */
+} capacity_measure;
+/** @} */
+
+/**
+ * @brief Parameters for the bq27441_get_soc() function
+ * @{
+ */
+typedef enum {
+	FILTERED,  /**< State of Charge Filtered (DEFAULT) */
+	UNFILTERED /**< State of Charge Unfiltered */
+} soc_measure;
+/** @} */
+
+/**
+ * @brief Parameters for the bq27441_get_soh() function
+ * @{
+ */
+typedef enum {
+	PERCENT,  /**< State of Health Percentage (DEFAULT) */
+	SOH_STAT  /**< State of Health Status Bits */
+} soh_measure;
+/** @} */
+
+/**
+ * @brief Parameters for the bq27441_get_temperature() function
+ * @{
+ */
+typedef enum {
+	BATTERY,      /**< Battery Temperature (DEFAULT) */
+	INTERNAL_TEMP /**< Internal IC Temperature */
+} temp_measure;
+/** @} */
+
+/**
+ * @brief Parameters for the bq27441_set_gpout_function() function
+ * @{
+ */
+typedef enum {
+	SOC_INT, /**< Set GPOUT to SOC_INT functionality */
+	BAT_LOW  /**< Set GPOUT to BAT_LOW functionality */
+} gpout_function;
+/** @} */
+
+/**
+ * @brief Parameter struct for driver initialization
+ * @{
+ */
+typedef struct {
+    gpio_t alarm_pin;           /**< Pin which is connected to the interrupt pin of the sensor */
+    i2c_t bus;                  /**< I2C bus to use */
+    uint8_t addr;               /**< I2C Address of the fuel gauge */
+} bq27441_param_t;
+/** @} */
+
+/**
+ * @brief Typedef for the Callback function
+ * @details A function of this type will be called when an Interrupt is triggered on low RSOC or Voltage
+ * @param[in]  arg Additional Arguments that will be passed to the function
+ */
+typedef void (*bq27441_cb_t)(void *arg);
+
+/**
+ * @brief Device descriptor for the fuel gauge
+ * @details This struct will hold all information and configuration for the sensor
+ * @{
+ */
+typedef struct {
+    i2c_t bus;                  /**< I2C bus to use */
+    uint8_t addr;               /**< I2C Address of the fuel gauge */
+    bool sealFlag;              /**< Identify that IC was previously sealed */
+    bool userConfigControl;     /**< Identify that user has control over */
+    bq27441_param_t param;      /**< param struct with static settings etc*/
+    bq27441_cb_t cb;            /**< callback method*/
+    void *arg;                  /**< additional arguments for the callback method*/
+} bq27441_t;
+/** @} */
+
+/**
+ * @brief       Initializes I2C and verifies communication with the BQ27441. Must be called before using any other functions.
+ *
+ * @param[in]   *dev        pointer to bq27441_t struct containing the i2c device and the address
+ * @param[in]   *params     pointer to bq27441_params_t struct containing the interrupt pin and callback
+ *
+ * @return                  true if communication was successful.
+*/
+bool bq27441_init(bq27441_t *dev, const bq27441_param_t *params);
+
+/**
+ * @brief       Configures the design capacity of the connected battery.
+ *
+ * @param[in]   *dev        pointer to bq27441_t struct containing the i2c device and the address
+ * @param[in]   capacity    capacity of battery (unsigned 16-bit value)
+ *
+ * @return                  true if capacity successfully set.
+*/
+bool bq27441_set_capacity(bq27441_t *dev, uint16_t capacity);
+
+/**
+ * @brief       Reads and returns the battery voltage
+ *
+ * @param[in]   *dev        pointer to bq27441_t struct containing the i2c device and the address
+ *
+ * @return      battery voltage in mV
+*/
+uint16_t bq27441_get_voltage(const bq27441_t *dev);
+
+/**
+ * @brief       Reads and returns the specified current measurement
+ *
+ * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
+ * @param[in]   type    enum specifying current value to be read
+ *
+ * @return              specified current measurement in mA. >0 indicates charging.
+*/
+int16_t bq27441_get_current(const bq27441_t *dev, current_measure type);
+
+/**
+ * @brief       Reads and returns the specified capacity measurement
+ *
+ * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
+ * @param[in]   type    enum specifying capacity value to be read
+ *
+ * @return              specified capacity measurement in mAh.
+*/
+uint16_t bq27441_get_capacity(const bq27441_t *dev, capacity_measure type);
+
+/**
+ * @brief       Reads and returns measured average power
+ *
+ * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
+ *
+ * @return      average power in mAh. >0 indicates charging.
+*/
+int16_t bq27441_get_power(const bq27441_t *dev);
+
+/**
+ * @brief       Reads and returns specified state of charge measurement
+ *
+ * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
+ * @param[in]   type    enum specifying filtered or unfiltered measurement
+ *
+ * @return              specified state of charge measurement in %
+*/
+uint16_t bq27441_get_soc(const bq27441_t *dev, soc_measure type);
+
+/**
+ * @brief       Reads and returns specified state of health measurement
+ *
+ * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
+ * @param[in]   type    enum specifying filtered or unfiltered measurement
+ *
+ * @return              specified state of health measurement in %, or status bits
+*/
+uint8_t bq27441_get_soh(const bq27441_t *dev, soh_measure type);
+
+/**
+ * @brief       Reads and returns specified temperature measurement
+ *
+ * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
+ * @param[in]   type    enum specifying internal or battery measurement
+ *
+ * @return              specified temperature measurement in degrees C
+*/
+uint16_t bq27441_get_temperature(const bq27441_t *dev, temp_measure type);
+
+/**
+ * @brief       Get GPOUT polarity setting (active-high or active-low)
+ *
+ * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
+ *
+ * @return      true if active-high, false if active-low
+*/
+bool bq27441_get_gpout_polarity(const bq27441_t *dev);
+
+/**
+ * @brief       Set GPOUT polarity to active-high or active-low
+ *
+ * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
+ * @param[in]   activeHigh  is true if active-high, false if active-low
+ *
+ * @return                  true on success
+*/
+bool bq27441_set_gpout_polarity(bq27441_t *dev, bool activeHigh);
+
+/**
+ * @brief       Get GPOUT function (BAT_LOW or SOC_INT)
+ *
+ * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
+ *
+ * @return      true if BAT_LOW or false if SOC_INT
+*/
+bool bq27441_get_gpout_function(const bq27441_t *dev);
+
+/**
+ * @brief       Set GPOUT function to BAT_LOW or SOC_INT
+ *
+ * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
+ * @param[in]   function    should be either BAT_LOW or SOC_INT
+ *
+ * @return                  true on success
+*/
+bool bq27441_set_gpout_function(bq27441_t *dev, gpout_function function);
+
+/**
+ * @brief       Get SOC1_Set Threshold - threshold to set the alert flag
+ *
+ * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
+ *
+ * @return      state of charge value between 0 and 100%
+*/
+uint8_t bq27441_get_soc1_set_threshold(bq27441_t *dev);
+
+/**
+ * @brief       Get SOC1_Clear Threshold - threshold to clear the alert flag
+ *
+ * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
+ *
+ * @return      state of charge value between 0 and 100%
+*/
+uint8_t bq27441_get_soc1_clear_threshold(bq27441_t *dev);
+
+/**
+ * @brief       Set the SOC1 set and clear thresholds to a percentage
+ *
+ * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
+ * @param[in]   set     percentage between 0 and 100
+ * @param[in]   clear   percentage between 0 and 100. clear > set.
+ *
+ * @return              true on success
+*/
+bool bq27441_set_soc1_thresholds(bq27441_t *dev, uint8_t set, uint8_t clear);
+
+/**
+ * @brief       Get SOCF_Set Threshold - threshold to set the alert flag
+ *
+ * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
+ *
+ * @return      state of charge value between 0 and 100%
+*/
+uint8_t bq27441_get_socf_set_threshold(bq27441_t *dev);
+
+/**
+ * @brief       Get SOCF_Clear Threshold - threshold to clear the alert flag
+ *
+ * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
+ *
+ * @return      state of charge value between 0 and 100%
+*/
+uint8_t bq27441_get_socf_clear_threshold(bq27441_t *dev);
+
+/**
+ * @brief       Set the SOCF set and clear thresholds to a percentage
+ *
+ * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
+ * @param[in]   set     percentage between 0 and 100
+ * @param[in]   clear   percentage between 0 and 100. clear > set.
+ *
+ * @return              true on success
+*/
+bool bq27441_set_socf_thresholds(bq27441_t *dev, uint8_t set, uint8_t clear);
+
+/**
+ * @brief       Check if the SOC1 flag is set in flags()
+ *
+ * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
+ *
+ * @return      true if flag is set
+*/
+bool bq27441_get_soc1_flag(const bq27441_t *dev);
+
+/**
+ * @brief       Check if the SOCF flag is set in flags()
+ *
+ * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
+ *
+ * @return      true if flag is set
+*/
+bool bq27441_get_socf_flag(const bq27441_t *dev);
+
+/**
+ * @brief       Get the SOC_INT interval delta
+ *s
+ * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
+ *
+ * @return      interval percentage value between 1 and 100
+*/
+uint8_t bq27441_get_soc_int_delta(bq27441_t *dev);
+
+/**
+ * @brief       Set the SOC_INT interval delta to a value between 1 and 100
+ *
+ * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
+ * @param[in]   delta   interval percentage value between 1 and 100
+ *
+ * @return              true on success
+*/
+bool bq27441_set_soc_int_delta(bq27441_t *dev, uint8_t delta);
+
+/**
+ * @brief       Pulse the GPOUT pin - must be in SOC_INT mode
+ *
+ * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
+ *
+ * @return      true on success
+*/
+bool bq27441_pulse_gpout(const bq27441_t *dev);
+
+/**
+ * @brief       Read the device type - should be 0x0421
+ *
+ * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
+ *
+ * @return 16-bit value read from DEVICE_TYPE subcommand
+*/
+uint16_t bq27441_get_device_type(const bq27441_t *dev);
+
+/**
+ * @brief       Enter configuration mode - set userControl if calling from an Arduino sketch and you want control over when to exitConfig.
+ *
+ * @param[in]   *dev            pointer to bq27441_t struct containing the i2c device and the address
+ * @param[in]   userControl     true if the Arduino sketch is handling entering and exiting config mode (should be false in library calls).
+ *
+ * @return                      true on success
+*/
+bool bq27441_enter_config_mode(bq27441_t *dev, bool userControl);
+
+/**
+ * @brief       Exit configuration mode with the option to perform a resimulation
+ *
+ * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
+ * @param[in]   resim   true if resimulation should be performed after exiting
+ *
+ * @return              true on success
+*/
+bool bq27441_exit_config_mode(const bq27441_t *dev, bool resim);
+
+/**
+ * @brief       Read the flags() command
+ *
+ * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
+ *
+ * @return      16-bit representation of flags() command register
+*/
+uint16_t bq27441_get_flags(const bq27441_t *dev);
+
+/**
+ * @brief       Read the CONTROL_STATUS subcommand of control()
+ *
+ * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
+ *
+ * @return      16-bit representation of CONTROL_STATUS subcommand
+*/
+uint16_t bq27441_get_status(const bq27441_t *dev);
+
+/**
+ * @brief       Check if the BQ27441-G1A is sealed or not.
+ *
+ * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
+ *
+ * @return      true if the chip is sealed
+*/
+bool _bq27441_sealed(const bq27441_t *dev);
+
+/**
+ * @brief       Seal the BQ27441-G1A
+ *
+ * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
+ *
+ * @return true on success
+*/
+bool _bq27441_seal(const bq27441_t *dev);
+
+/**
+ * @brief       UNseal the BQ27441-G1A
+ *
+ * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
+ *
+ * @return      true on success
+*/
+bool _bq27441_unseal(const bq27441_t *dev);
+
+/**
+ * @brief       Read the 16-bit opConfig register from extended data
+ *
+ * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
+ *
+ * @return      opConfig register contents
+*/
+uint16_t _bq27441_get_opConfig(const bq27441_t *dev);
+
+/**
+ * @brief       Write the 16-bit opConfig register in extended data
+ *
+ * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
+ * @param[in]   value   16-bit value for opConfig
+ *
+ * @return              true on success
+*/
+bool _bq27441_write_op_config(bq27441_t *dev, uint16_t value);
+
+/**
+ * @brief       Issue a soft-reset to the BQ27441-G1A
+ *
+ * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
+ *
+ * @return      true on success
+*/
+bool _bq27441_soft_reset(const bq27441_t *dev);
+
+/**
+ * @brief       Read a 16-bit command word from the BQ27441-G1A
+ *
+ * @param[in]   *dev        pointer to bq27441_t struct containing the i2c device and the address
+ * @param[in]   subAddress  command to be read from
+ *
+ * @return                  16-bit value of the command's contents
+*/
+uint16_t _bq27441_read_word(const bq27441_t *dev, uint16_t subAddress);
+
+/**
+ * @brief       Read a 16-bit subcommand() from the BQ27441-G1A's control()
+ *
+ * @param[in]   *dev        pointer to bq27441_t struct containing the i2c device and the address
+ * @param[in]   function    subcommand of control() to be read
+ *
+ * @return                  16-bit value of the subcommand's contents
+*/
+uint16_t _bq27441_read_control_word(const bq27441_t *dev, uint16_t function);
+
+/**
+ * @brief       Execute a subcommand() from the BQ27441-G1A's control()
+ *
+ * @param[in]   *dev        pointer to bq27441_t struct containing the i2c device and the address
+ * @param[in]   function    subcommand of control() to be executed
+ *
+ * @return                  true on success
+*/
+bool _bq27441_execute_control_word(const bq27441_t *dev, uint16_t function);
+
+/**
+ * @brief       Issue a BlockDataControl() command to enable BlockData access
+ *
+ * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
+ *
+ * @return      true on success
+*/
+bool _bq27441_block_data_control(const bq27441_t *dev);
+
+/**
+ * @brief       Issue a DataClass() command to set the data class to be accessed
+ *
+ * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
+ * @param[in]   id  id number of the class
+ *
+ * @return          true on success
+*/
+bool _bq27441_block_data_class(const bq27441_t *dev, uint8_t id);
+
+/**
+ * @brief       Issue a DataBlock() command to set the data block to be accessed
+ *
+ * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
+ * @param[in]   offset  offset of the data block
+ *
+ * @return              true on success
+*/
+bool _bq27441_block_data_offset(const bq27441_t *dev, uint8_t offset);
+
+/**
+ * @brief       Read the current checksum using BlockDataCheckSum()
+ *
+ * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
+ *
+ * @return      true on success
+*/
+uint8_t _bq27441_block_data_checksum(const bq27441_t *dev);
+
+/**
+ * @brief       Use BlockData() to read a byte from the loaded extended data
+ *
+ * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
+ * @param[in]   offset  offset of data block byte to be read
+ *
+ * @return              true on success
+*/
+uint8_t _bq27441_read_block_data(const bq27441_t *dev, uint8_t offset);
+
+/**
+ * @brief       Use BlockData() to write a byte to an offset of the loaded data
+ *
+ * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
+ * @param[in]   offset  position of the byte to be written
+ * @param[in]   data    value to be written
+ *
+ * @return              true on success
+*/
+bool _bq27441_write_block_data(const bq27441_t *dev, uint8_t offset, uint8_t data);
+
+/**
+ * @brief       Read all 32 bytes of the loaded extended data and compute a checksum based on the values.
+ *
+ * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
+ *
+ * @return      8-bit checksum value calculated based on loaded data
+*/
+uint8_t _bq27441_compute_block_checksum(const bq27441_t *dev);
+
+/**
+ * @brief       Use the BlockDataCheckSum() command to write a checksum value
+ *
+ * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
+ * @param[in]   csum i  8-bit checksum to be written
+ *
+ * @return      true on success
+*/
+bool _bq27441_write_block_checksum(const bq27441_t *dev, uint8_t csum);
+
+/**
+ * @brief       Read a byte from extended data specifying a class ID and position offset
+ *
+ * @param[in]   *dev        pointer to bq27441_t struct containing the i2c device and the address
+ * @param[in]   classID     id of the class to be read from
+ * @param[in]   offset      byte position of the byte to be read
+ *
+ * @return                  8-bit value of specified data
+*/
+uint8_t _bq27441_read_extended_data(bq27441_t *dev, uint8_t classID, uint8_t offset);
+
+/**
+ * @brief       Write a specified number of bytes to extended data specifying a class ID, position offset.
+ *
+ * @param[in]   *dev        pointer to bq27441_t struct containing the i2c device and the address
+ * @param[in]   classID     id of the class to be read from
+ * @param[in]   offset      byte position of the byte to be read
+ * @param[in]   data        data buffer to be written
+ * @param[in]   len         number of bytes to be written
+ *
+ * @return                  true on success
+*/
+bool _bq27441_write_extended_data(bq27441_t *dev, uint8_t classID, uint8_t offset, uint8_t * data, uint8_t len);
+
+/**
+ * @brief       Read a specified number of bytes over I2C at a given subAddress
+ *
+ * @param[in]   *dev        pointer to bq27441_t struct containing the i2c device and the address
+ * @param[in]   subAddress  8-bit address of the data to be read
+ * @param[in]   dest        data buffer to be written to
+ * @param[in]   count       number of bytes to be read
+ *
+ * @return                  true on success
+*/
+int16_t _bq27441_read_bytes_i2c(const bq27441_t *dev, uint8_t subAddress, uint8_t * dest, uint8_t count);
+
+/**
+ * @brief       Write a specified number of bytes over I2C to a given subAddress
+ *
+ * @param[in]   *dev        pointer to bq27441_t struct containing the i2c device and the address
+ * @param[in]   subAddress  8-bit address of the data to be written to
+ * @param[in]   src         data buffer to be written
+ * @param[in]   count       number of bytes to be written
+ *
+ * @return true on success
+*/
+uint16_t _bq27441_write_bytes_i2c(const bq27441_t *dev, uint8_t subAddress, uint8_t * src, uint8_t count);
+
+#endif /* BQ27441_H */
+/** @} */

--- a/drivers/include/bq27441.h
+++ b/drivers/include/bq27441.h
@@ -39,9 +39,9 @@ extern "C" {
  * @{
  */
 typedef enum {
-    AVG,  /**< Average Current (DEFAULT) */
-    STBY, /**< Standby Current */
-    MAX   /**< Mx Current */
+    AVG,    /**< Average Current (DEFAULT) */
+    STBY,   /**< Standby Current */
+    MAX     /**< Mx Current */
 } current_measure;
 /** @} */
 
@@ -67,8 +67,8 @@ typedef enum {
  * @{
  */
 typedef enum {
-    FILTERED,  /**< State of Charge Filtered (DEFAULT) */
-    UNFILTERED /**< State of Charge Unfiltered */
+    FILTERED,   /**< State of Charge Filtered (DEFAULT) */
+    UNFILTERED  /**< State of Charge Unfiltered */
 } soc_measure;
 /** @} */
 
@@ -77,8 +77,8 @@ typedef enum {
  * @{
  */
 typedef enum {
-    PERCENT,  /**< State of Health Percentage (DEFAULT) */
-    SOH_STAT  /**< State of Health Status Bits */
+    PERCENT,    /**< State of Health Percentage (DEFAULT) */
+    SOH_STAT    /**< State of Health Status Bits */
 } soh_measure;
 /** @} */
 
@@ -87,8 +87,8 @@ typedef enum {
  * @{
  */
 typedef enum {
-    BATTERY,      /**< Battery Temperature (DEFAULT) */
-    INTERNAL_TEMP /**< Internal IC Temperature */
+    BATTERY,        /**< Battery Temperature (DEFAULT) */
+    INTERNAL_TEMP   /**< Internal IC Temperature */
 } temp_measure;
 /** @} */
 
@@ -97,8 +97,8 @@ typedef enum {
  * @{
  */
 typedef enum {
-    SOC_INT, /**< Set GPOUT to SOC_INT functionality */
-    BAT_LOW  /**< Set GPOUT to BAT_LOW functionality */
+    SOC_INT,    /**< Set GPOUT to SOC_INT functionality */
+    BAT_LOW     /**< Set GPOUT to BAT_LOW functionality */
 } gpout_function;
 /** @} */
 
@@ -143,7 +143,7 @@ typedef struct {
  * @param[in]   *params     pointer to bq27441_params_t struct containing the interrupt pin and callback
  *
  * @return                  true if communication was successful.
-*/
+ */
 bool bq27441_init(bq27441_t *dev, const bq27441_param_t *params);
 
 /**
@@ -153,7 +153,7 @@ bool bq27441_init(bq27441_t *dev, const bq27441_param_t *params);
  * @param[in]   capacity    capacity of battery (unsigned 16-bit value)
  *
  * @return                  true if capacity successfully set.
-*/
+ */
 bool bq27441_set_capacity(bq27441_t *dev, uint16_t capacity);
 
 /**
@@ -162,7 +162,7 @@ bool bq27441_set_capacity(bq27441_t *dev, uint16_t capacity);
  * @param[in]   *dev        pointer to bq27441_t struct containing the i2c device and the address
  *
  * @return      battery voltage in mV
-*/
+ */
 uint16_t bq27441_get_voltage(const bq27441_t *dev);
 
 /**
@@ -172,7 +172,7 @@ uint16_t bq27441_get_voltage(const bq27441_t *dev);
  * @param[in]   type    enum specifying current value to be read
  *
  * @return              specified current measurement in mA. >0 indicates charging.
-*/
+ */
 int16_t bq27441_get_current(const bq27441_t *dev, current_measure type);
 
 /**
@@ -182,7 +182,7 @@ int16_t bq27441_get_current(const bq27441_t *dev, current_measure type);
  * @param[in]   type    enum specifying capacity value to be read
  *
  * @return              specified capacity measurement in mAh.
-*/
+ */
 uint16_t bq27441_get_capacity(const bq27441_t *dev, capacity_measure type);
 
 /**
@@ -191,7 +191,7 @@ uint16_t bq27441_get_capacity(const bq27441_t *dev, capacity_measure type);
  * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
  *
  * @return      average power in mAh. >0 indicates charging.
-*/
+ */
 int16_t bq27441_get_power(const bq27441_t *dev);
 
 /**
@@ -201,7 +201,7 @@ int16_t bq27441_get_power(const bq27441_t *dev);
  * @param[in]   type    enum specifying filtered or unfiltered measurement
  *
  * @return              specified state of charge measurement in %
-*/
+ */
 uint16_t bq27441_get_soc(const bq27441_t *dev, soc_measure type);
 
 /**
@@ -211,7 +211,7 @@ uint16_t bq27441_get_soc(const bq27441_t *dev, soc_measure type);
  * @param[in]   type    enum specifying filtered or unfiltered measurement
  *
  * @return              specified state of health measurement in %, or status bits
-*/
+ */
 uint8_t bq27441_get_soh(const bq27441_t *dev, soh_measure type);
 
 /**
@@ -221,7 +221,7 @@ uint8_t bq27441_get_soh(const bq27441_t *dev, soh_measure type);
  * @param[in]   type    enum specifying internal or battery measurement
  *
  * @return              specified temperature measurement in degrees C
-*/
+ */
 uint16_t bq27441_get_temperature(const bq27441_t *dev, temp_measure type);
 
 /**
@@ -230,7 +230,7 @@ uint16_t bq27441_get_temperature(const bq27441_t *dev, temp_measure type);
  * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
  *
  * @return      true if active-high, false if active-low
-*/
+ */
 bool bq27441_get_gpout_polarity(const bq27441_t *dev);
 
 /**
@@ -240,7 +240,7 @@ bool bq27441_get_gpout_polarity(const bq27441_t *dev);
  * @param[in]   activeHigh  is true if active-high, false if active-low
  *
  * @return                  true on success
-*/
+ */
 bool bq27441_set_gpout_polarity(bq27441_t *dev, bool activeHigh);
 
 /**
@@ -249,7 +249,7 @@ bool bq27441_set_gpout_polarity(bq27441_t *dev, bool activeHigh);
  * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
  *
  * @return      true if BAT_LOW or false if SOC_INT
-*/
+ */
 bool bq27441_get_gpout_function(const bq27441_t *dev);
 
 /**
@@ -259,7 +259,7 @@ bool bq27441_get_gpout_function(const bq27441_t *dev);
  * @param[in]   function    should be either BAT_LOW or SOC_INT
  *
  * @return                  true on success
-*/
+ */
 bool bq27441_set_gpout_function(bq27441_t *dev, gpout_function function);
 
 /**
@@ -268,7 +268,7 @@ bool bq27441_set_gpout_function(bq27441_t *dev, gpout_function function);
  * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
  *
  * @return      state of charge value between 0 and 100%
-*/
+ */
 uint8_t bq27441_get_soc1_set_threshold(bq27441_t *dev);
 
 /**
@@ -277,7 +277,7 @@ uint8_t bq27441_get_soc1_set_threshold(bq27441_t *dev);
  * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
  *
  * @return      state of charge value between 0 and 100%
-*/
+ */
 uint8_t bq27441_get_soc1_clear_threshold(bq27441_t *dev);
 
 /**
@@ -288,7 +288,7 @@ uint8_t bq27441_get_soc1_clear_threshold(bq27441_t *dev);
  * @param[in]   clear   percentage between 0 and 100. clear > set.
  *
  * @return              true on success
-*/
+ */
 bool bq27441_set_soc1_thresholds(bq27441_t *dev, uint8_t set, uint8_t clear);
 
 /**
@@ -297,7 +297,7 @@ bool bq27441_set_soc1_thresholds(bq27441_t *dev, uint8_t set, uint8_t clear);
  * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
  *
  * @return      state of charge value between 0 and 100%
-*/
+ */
 uint8_t bq27441_get_socf_set_threshold(bq27441_t *dev);
 
 /**
@@ -306,7 +306,7 @@ uint8_t bq27441_get_socf_set_threshold(bq27441_t *dev);
  * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
  *
  * @return      state of charge value between 0 and 100%
-*/
+ */
 uint8_t bq27441_get_socf_clear_threshold(bq27441_t *dev);
 
 /**
@@ -317,7 +317,7 @@ uint8_t bq27441_get_socf_clear_threshold(bq27441_t *dev);
  * @param[in]   clear   percentage between 0 and 100. clear > set.
  *
  * @return              true on success
-*/
+ */
 bool bq27441_set_socf_thresholds(bq27441_t *dev, uint8_t set, uint8_t clear);
 
 /**
@@ -326,7 +326,7 @@ bool bq27441_set_socf_thresholds(bq27441_t *dev, uint8_t set, uint8_t clear);
  * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
  *
  * @return      true if flag is set
-*/
+ */
 bool bq27441_get_soc1_flag(const bq27441_t *dev);
 
 /**
@@ -335,16 +335,16 @@ bool bq27441_get_soc1_flag(const bq27441_t *dev);
  * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
  *
  * @return      true if flag is set
-*/
+ */
 bool bq27441_get_socf_flag(const bq27441_t *dev);
 
 /**
  * @brief       Get the SOC_INT interval delta
- *s
+ * s
  * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
  *
  * @return      interval percentage value between 1 and 100
-*/
+ */
 uint8_t bq27441_get_soc_int_delta(bq27441_t *dev);
 
 /**
@@ -354,7 +354,7 @@ uint8_t bq27441_get_soc_int_delta(bq27441_t *dev);
  * @param[in]   delta   interval percentage value between 1 and 100
  *
  * @return              true on success
-*/
+ */
 bool bq27441_set_soc_int_delta(bq27441_t *dev, uint8_t delta);
 
 /**
@@ -363,7 +363,7 @@ bool bq27441_set_soc_int_delta(bq27441_t *dev, uint8_t delta);
  * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
  *
  * @return      true on success
-*/
+ */
 bool bq27441_pulse_gpout(const bq27441_t *dev);
 
 /**
@@ -372,7 +372,7 @@ bool bq27441_pulse_gpout(const bq27441_t *dev);
  * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
  *
  * @return 16-bit value read from DEVICE_TYPE subcommand
-*/
+ */
 uint16_t bq27441_get_device_type(const bq27441_t *dev);
 
 /**
@@ -382,7 +382,7 @@ uint16_t bq27441_get_device_type(const bq27441_t *dev);
  * @param[in]   userControl     true if the Arduino sketch is handling entering and exiting config mode (should be false in library calls).
  *
  * @return                      true on success
-*/
+ */
 bool bq27441_enter_config_mode(bq27441_t *dev, bool userControl);
 
 /**
@@ -392,7 +392,7 @@ bool bq27441_enter_config_mode(bq27441_t *dev, bool userControl);
  * @param[in]   resim   true if resimulation should be performed after exiting
  *
  * @return              true on success
-*/
+ */
 bool bq27441_exit_config_mode(const bq27441_t *dev, bool resim);
 
 /**
@@ -401,7 +401,7 @@ bool bq27441_exit_config_mode(const bq27441_t *dev, bool resim);
  * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
  *
  * @return      16-bit representation of flags() command register
-*/
+ */
 uint16_t bq27441_get_flags(const bq27441_t *dev);
 
 /**
@@ -410,7 +410,7 @@ uint16_t bq27441_get_flags(const bq27441_t *dev);
  * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
  *
  * @return      16-bit representation of CONTROL_STATUS subcommand
-*/
+ */
 uint16_t bq27441_get_status(const bq27441_t *dev);
 
 /**
@@ -419,7 +419,7 @@ uint16_t bq27441_get_status(const bq27441_t *dev);
  * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
  *
  * @return      true if the chip is sealed
-*/
+ */
 bool _bq27441_sealed(const bq27441_t *dev);
 
 /**
@@ -428,7 +428,7 @@ bool _bq27441_sealed(const bq27441_t *dev);
  * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
  *
  * @return true on success
-*/
+ */
 bool _bq27441_seal(const bq27441_t *dev);
 
 /**
@@ -437,7 +437,7 @@ bool _bq27441_seal(const bq27441_t *dev);
  * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
  *
  * @return      true on success
-*/
+ */
 bool _bq27441_unseal(const bq27441_t *dev);
 
 /**
@@ -446,7 +446,7 @@ bool _bq27441_unseal(const bq27441_t *dev);
  * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
  *
  * @return      opConfig register contents
-*/
+ */
 uint16_t _bq27441_get_opConfig(const bq27441_t *dev);
 
 /**
@@ -456,7 +456,7 @@ uint16_t _bq27441_get_opConfig(const bq27441_t *dev);
  * @param[in]   value   16-bit value for opConfig
  *
  * @return              true on success
-*/
+ */
 bool _bq27441_write_op_config(bq27441_t *dev, uint16_t value);
 
 /**
@@ -465,7 +465,7 @@ bool _bq27441_write_op_config(bq27441_t *dev, uint16_t value);
  * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
  *
  * @return      true on success
-*/
+ */
 bool _bq27441_soft_reset(const bq27441_t *dev);
 
 /**
@@ -475,7 +475,7 @@ bool _bq27441_soft_reset(const bq27441_t *dev);
  * @param[in]   subAddress  command to be read from
  *
  * @return                  16-bit value of the command's contents
-*/
+ */
 uint16_t _bq27441_read_word(const bq27441_t *dev, uint16_t subAddress);
 
 /**
@@ -485,7 +485,7 @@ uint16_t _bq27441_read_word(const bq27441_t *dev, uint16_t subAddress);
  * @param[in]   function    subcommand of control() to be read
  *
  * @return                  16-bit value of the subcommand's contents
-*/
+ */
 uint16_t _bq27441_read_control_word(const bq27441_t *dev, uint16_t function);
 
 /**
@@ -495,7 +495,7 @@ uint16_t _bq27441_read_control_word(const bq27441_t *dev, uint16_t function);
  * @param[in]   function    subcommand of control() to be executed
  *
  * @return                  true on success
-*/
+ */
 bool _bq27441_execute_control_word(const bq27441_t *dev, uint16_t function);
 
 /**
@@ -504,7 +504,7 @@ bool _bq27441_execute_control_word(const bq27441_t *dev, uint16_t function);
  * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
  *
  * @return      true on success
-*/
+ */
 bool _bq27441_block_data_control(const bq27441_t *dev);
 
 /**
@@ -514,7 +514,7 @@ bool _bq27441_block_data_control(const bq27441_t *dev);
  * @param[in]   id  id number of the class
  *
  * @return          true on success
-*/
+ */
 bool _bq27441_block_data_class(const bq27441_t *dev, uint8_t id);
 
 /**
@@ -524,7 +524,7 @@ bool _bq27441_block_data_class(const bq27441_t *dev, uint8_t id);
  * @param[in]   offset  offset of the data block
  *
  * @return              true on success
-*/
+ */
 bool _bq27441_block_data_offset(const bq27441_t *dev, uint8_t offset);
 
 /**
@@ -533,7 +533,7 @@ bool _bq27441_block_data_offset(const bq27441_t *dev, uint8_t offset);
  * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
  *
  * @return      true on success
-*/
+ */
 uint8_t _bq27441_block_data_checksum(const bq27441_t *dev);
 
 /**
@@ -543,7 +543,7 @@ uint8_t _bq27441_block_data_checksum(const bq27441_t *dev);
  * @param[in]   offset  offset of data block byte to be read
  *
  * @return              true on success
-*/
+ */
 uint8_t _bq27441_read_block_data(const bq27441_t *dev, uint8_t offset);
 
 /**
@@ -554,7 +554,7 @@ uint8_t _bq27441_read_block_data(const bq27441_t *dev, uint8_t offset);
  * @param[in]   data    value to be written
  *
  * @return              true on success
-*/
+ */
 bool _bq27441_write_block_data(const bq27441_t *dev, uint8_t offset, uint8_t data);
 
 /**
@@ -563,7 +563,7 @@ bool _bq27441_write_block_data(const bq27441_t *dev, uint8_t offset, uint8_t dat
  * @param[in]   *dev    pointer to bq27441_t struct containing the i2c device and the address
  *
  * @return      8-bit checksum value calculated based on loaded data
-*/
+ */
 uint8_t _bq27441_compute_block_checksum(const bq27441_t *dev);
 
 /**
@@ -573,7 +573,7 @@ uint8_t _bq27441_compute_block_checksum(const bq27441_t *dev);
  * @param[in]   csum i  8-bit checksum to be written
  *
  * @return      true on success
-*/
+ */
 bool _bq27441_write_block_checksum(const bq27441_t *dev, uint8_t csum);
 
 /**
@@ -584,7 +584,7 @@ bool _bq27441_write_block_checksum(const bq27441_t *dev, uint8_t csum);
  * @param[in]   offset      byte position of the byte to be read
  *
  * @return                  8-bit value of specified data
-*/
+ */
 uint8_t _bq27441_read_extended_data(bq27441_t *dev, uint8_t classID, uint8_t offset);
 
 /**
@@ -597,8 +597,8 @@ uint8_t _bq27441_read_extended_data(bq27441_t *dev, uint8_t classID, uint8_t off
  * @param[in]   len         number of bytes to be written
  *
  * @return                  true on success
-*/
-bool _bq27441_write_extended_data(bq27441_t *dev, uint8_t classID, uint8_t offset, uint8_t * data, uint8_t len);
+ */
+bool _bq27441_write_extended_data(bq27441_t *dev, uint8_t classID, uint8_t offset, uint8_t *data, uint8_t len);
 
 /**
  * @brief       Read a specified number of bytes over I2C at a given subAddress
@@ -609,8 +609,8 @@ bool _bq27441_write_extended_data(bq27441_t *dev, uint8_t classID, uint8_t offse
  * @param[in]   count       number of bytes to be read
  *
  * @return                  true on success
-*/
-int16_t _bq27441_read_bytes_i2c(const bq27441_t *dev, uint8_t subAddress, uint8_t * dest, uint8_t count);
+ */
+int16_t _bq27441_read_bytes_i2c(const bq27441_t *dev, uint8_t subAddress, uint8_t *dest, uint8_t count);
 
 /**
  * @brief       Write a specified number of bytes over I2C to a given subAddress
@@ -621,8 +621,8 @@ int16_t _bq27441_read_bytes_i2c(const bq27441_t *dev, uint8_t subAddress, uint8_
  * @param[in]   count       number of bytes to be written
  *
  * @return true on success
-*/
-uint16_t _bq27441_write_bytes_i2c(const bq27441_t *dev, uint8_t subAddress, uint8_t * src, uint8_t count);
+ */
+uint16_t _bq27441_write_bytes_i2c(const bq27441_t *dev, uint8_t subAddress, uint8_t *src, uint8_t count);
 
 #endif /* BQ27441_H */
 /** @} */

--- a/drivers/include/bq27441.h
+++ b/drivers/include/bq27441.h
@@ -39,9 +39,9 @@ extern "C" {
  * @{
  */
 typedef enum {
-	AVG,  /**< Average Current (DEFAULT) */
-	STBY, /**< Standby Current */
-	MAX   /**< Mx Current */
+    AVG,  /**< Average Current (DEFAULT) */
+    STBY, /**< Standby Current */
+    MAX   /**< Mx Current */
 } current_measure;
 /** @} */
 
@@ -50,15 +50,15 @@ typedef enum {
  * @{
  */
 typedef enum {
-	REMAIN,     /**< Remaining Capacity (DEFAULT) */
-	FULL,       /**< Full Capacity */
-	AVAIL,      /**< Available Capacity */
-	AVAIL_FULL, /**< Full Available Capacity */
-	REMAIN_F,   /**< Remaining Capacity Filtered */
-	REMAIN_UF,  /**< Remaining Capacity Unfiltered */
-	FULL_F,     /**< Full Capacity Filtered */
-	FULL_UF,    /**< Full Capacity Unfiltered */
-	DESIGN      /**< Design Capacity */
+    REMAIN,     /**< Remaining Capacity (DEFAULT) */
+    FULL,       /**< Full Capacity */
+    AVAIL,      /**< Available Capacity */
+    AVAIL_FULL, /**< Full Available Capacity */
+    REMAIN_F,   /**< Remaining Capacity Filtered */
+    REMAIN_UF,  /**< Remaining Capacity Unfiltered */
+    FULL_F,     /**< Full Capacity Filtered */
+    FULL_UF,    /**< Full Capacity Unfiltered */
+    DESIGN      /**< Design Capacity */
 } capacity_measure;
 /** @} */
 
@@ -67,8 +67,8 @@ typedef enum {
  * @{
  */
 typedef enum {
-	FILTERED,  /**< State of Charge Filtered (DEFAULT) */
-	UNFILTERED /**< State of Charge Unfiltered */
+    FILTERED,  /**< State of Charge Filtered (DEFAULT) */
+    UNFILTERED /**< State of Charge Unfiltered */
 } soc_measure;
 /** @} */
 
@@ -77,8 +77,8 @@ typedef enum {
  * @{
  */
 typedef enum {
-	PERCENT,  /**< State of Health Percentage (DEFAULT) */
-	SOH_STAT  /**< State of Health Status Bits */
+    PERCENT,  /**< State of Health Percentage (DEFAULT) */
+    SOH_STAT  /**< State of Health Status Bits */
 } soh_measure;
 /** @} */
 
@@ -87,8 +87,8 @@ typedef enum {
  * @{
  */
 typedef enum {
-	BATTERY,      /**< Battery Temperature (DEFAULT) */
-	INTERNAL_TEMP /**< Internal IC Temperature */
+    BATTERY,      /**< Battery Temperature (DEFAULT) */
+    INTERNAL_TEMP /**< Internal IC Temperature */
 } temp_measure;
 /** @} */
 
@@ -97,8 +97,8 @@ typedef enum {
  * @{
  */
 typedef enum {
-	SOC_INT, /**< Set GPOUT to SOC_INT functionality */
-	BAT_LOW  /**< Set GPOUT to BAT_LOW functionality */
+    SOC_INT, /**< Set GPOUT to SOC_INT functionality */
+    BAT_LOW  /**< Set GPOUT to BAT_LOW functionality */
 } gpout_function;
 /** @} */
 

--- a/tests/driver_bq27441/Makefile
+++ b/tests/driver_bq27441/Makefile
@@ -1,0 +1,10 @@
+include ../Makefile.tests_common
+
+FEATURES_REQUIRED = periph_i2c
+
+USEMODULE += bq27441
+USEMODULE += xtimer
+USEMODULE += periph_gpio_irq
+CFLAGS += -DDEVELHELP
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/driver_bq27441/README.md
+++ b/tests/driver_bq27441/README.md
@@ -1,0 +1,7 @@
+# About
+This is a test application for the TI bq27441-G1 lithium battery gauge
+# Usage
+Just enter the `make BOARD=??? flash` command in the `tests/driver_bq27441/` folder.
+Make sure the `BQ27441_INT_PIN` is set in your boards periph_conf.h
+# Results
+The sensor will test the device id and the remaining capacity.

--- a/tests/driver_bq27441/main.c
+++ b/tests/driver_bq27441/main.c
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2018 Anatoliy Atanasov, Iliyan Stoyanov
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ * @file
+ * @brief       test aplication for the BQ27441 Lithium Battery fuel gauge by TI
+ *
+ * @author      Anatoliy Atanasov <anatoliy@6lowpan.io>
+ * @author      Iliyan Stoyanov <iliyan@6lowpan.io>
+ * @}
+ */
+
+#include <stdio.h>
+#include "xtimer.h"
+#include "bq27441.h"
+#include "bq27441_params.h"
+#include "periph/gpio.h"
+
+static void _gauge_cb(void *arg)
+{
+    (void)arg;
+    printf("\n BQ27441 CB \n");
+}
+
+int main(void)
+{
+    puts("BQ27441 Lithium Battery Fuel Gauge test application");
+    bq27441_t dev;
+    dev.cb = _gauge_cb;
+    dev.arg = NULL;
+    const unsigned int BATTERY_CAPACITY = 850;
+    gpio_t out_pin = GPIO_PIN(3, 3); // TODO: DEFINE CORRECTLY
+
+    i2c_acquire(params_default[0].bus);
+    if (bq27441_init(&dev, params_default)) {
+        xtimer_sleep(2);
+        if (bq27441_enter_config_mode(&dev, false)) {
+            bq27441_set_capacity(&dev, BATTERY_CAPACITY);
+            bq27441_set_gpout_polarity(&dev, false);
+            bq27441_set_gpout_function(&dev, SOC_INT);
+            bq27441_set_soc_int_delta(&dev, 1);
+            bq27441_exit_config_mode(&dev, false);
+        }
+        if (bq27441_get_gpout_polarity(&dev)) {
+            printf("GPOUT set to active-HIGH \n");
+        } else {
+            printf("GPOUT set to active-LOW \n");
+        }
+
+        if (bq27441_get_gpout_function(&dev)) {
+            printf("GPOUT function set to BAT_LOW \n");
+        } else {
+            printf("GPOUT function set to SOC_INT \n");
+        }
+        printf("SOCI Delta: 0x%02x \n", bq27441_get_soc_int_delta(&dev));
+
+        printf("Testing GPOUT Pulse\n");
+
+        bq27441_pulse_gpout(&dev);
+        int timeout = 10000; // The pulse can take a while to occur. Set max to 10s
+        while ((gpio_read(out_pin)) && timeout--)
+            xtimer_sleep(1); // Wait for GPOUT to go high, or timeout to occur
+        if (timeout > 0)
+        {
+            // If GPOUT pulsed, print success message.
+            printf("GPOUT test successful!");
+            printf("( %d )", (10000 - timeout));
+            printf("GPOUT will pulse whenever the SoC \n");
+            printf("value changes by SOCI delta.\n");
+            printf("Or when the battery changes from\n");
+            printf(" charging to discharging, or vice-versa.\n");
+        }
+        else
+        {
+            // If GPOUT didn't pulse, something went wrong. Print error message
+            // and loop forever.
+            printf("GPOUT didn't pulse.\n");
+            printf("Make sure it's connected to pin and reset. \n");
+        }
+        uint16_t device_id = bq27441_get_device_type(&dev); // Read deviceType from BQ27441
+        uint16_t capacity = bq27441_get_capacity(&dev, REMAIN);
+        uint16_t soc = bq27441_get_soc(&dev, FILTERED);
+        uint16_t voltage = bq27441_get_voltage(&dev);
+        uint16_t current = bq27441_get_current(&dev, AVG);
+        uint16_t full_capacity = bq27441_get_capacity(&dev, FULL);
+        int16_t power = bq27441_get_power(&dev);
+        uint8_t health = bq27441_get_soh(&dev, PERCENT);
+        printf("Device id: 0x%02x \n", device_id);
+        printf("Capacity : 0x%02x mAh \n", capacity);
+        printf("State of charge: 0x%02x %%\n", soc);
+        printf("Voltage: 0x%02x mV\n", voltage);
+        printf("Current id: 0x%02x mA\n", current);
+        printf("Full Capacity: 0x%02x mAh\n", full_capacity);
+        printf("Power: 0x%02x mW\n", power);
+        printf("Health: 0x%02x %% \n", health);
+    }
+    else {
+        printf("Could not connect to fuel gauge\n");
+    }
+    i2c_release(params_default[0].bus);
+
+    return 0;
+}

--- a/tests/driver_bq27441/main.c
+++ b/tests/driver_bq27441/main.c
@@ -50,13 +50,15 @@ int main(void)
         }
         if (bq27441_get_gpout_polarity(&dev)) {
             printf("GPOUT set to active-HIGH \n");
-        } else {
+        }
+        else {
             printf("GPOUT set to active-LOW \n");
         }
 
         if (bq27441_get_gpout_function(&dev)) {
             printf("GPOUT function set to BAT_LOW \n");
-        } else {
+        }
+        else {
             printf("GPOUT function set to SOC_INT \n");
         }
         printf("SOCI Delta: 0x%02x \n", bq27441_get_soc_int_delta(&dev));
@@ -64,11 +66,11 @@ int main(void)
         printf("Testing GPOUT Pulse\n");
 
         bq27441_pulse_gpout(&dev);
-        int timeout = 10000; // The pulse can take a while to occur. Set max to 10s
-        while ((gpio_read(out_pin)) && timeout--)
-            xtimer_sleep(1); // Wait for GPOUT to go high, or timeout to occur
-        if (timeout > 0)
-        {
+        int timeout = 10000;    // The pulse can take a while to occur. Set max to 10s
+        while ((gpio_read(out_pin)) && timeout--) {
+            xtimer_sleep(1);    // Wait for GPOUT to go high, or timeout to occur
+        }
+        if (timeout > 0) {
             // If GPOUT pulsed, print success message.
             printf("GPOUT test successful!");
             printf("( %d )", (10000 - timeout));
@@ -77,8 +79,7 @@ int main(void)
             printf("Or when the battery changes from\n");
             printf(" charging to discharging, or vice-versa.\n");
         }
-        else
-        {
+        else {
             // If GPOUT didn't pulse, something went wrong. Print error message
             // and loop forever.
             printf("GPOUT didn't pulse.\n");


### PR DESCRIPTION
### Contribution description

BQ27441 fuel gauge for single-cell Li-Ion batteries.
This work is port of https://github.com/sparkfun/Battery_Babysitter code


### Testing procedure

We are using custom hardware with bq27441-G1 that is connected to a STM32F446RE, but the setup can be replicated with any MCU and SparkFun's Battery Babysitter, or any other board that has bq27441-G1.


### Issues/PRs references

No issues, no references. New driver v1.