### PR TITLE
tests: remove leftover test targets in test application makefiles

### DIFF
--- a/tests/cond_order/Makefile
+++ b/tests/cond_order/Makefile
@@ -6,6 +6,3 @@ BOARD_INSUFFICIENT_MEMORY := nucleo32-f031 nucleo32-f042 nucleo32-l031 nucleo-f0
 							 nucleo-l031k6 nucleo-l053r8
 
 include $(RIOTBASE)/Makefile.include
-
-test:
-	tests/01-run.py

--- a/tests/pkg_cmsis-dsp/Makefile
+++ b/tests/pkg_cmsis-dsp/Makefile
@@ -36,6 +36,3 @@ BOARD_WHITELIST := \
   #
 
 include $(RIOTBASE)/Makefile.include
-
-test:
-	$(CURDIR)/tests/01-run.py

--- a/tests/pkg_lora-serialization/Makefile
+++ b/tests/pkg_lora-serialization/Makefile
@@ -4,6 +4,3 @@ USEPKG += lora-serialization
 
 TEST_ON_CI_WHITELIST += all
 include $(RIOTBASE)/Makefile.include
-
-test:
-	tests/01-run.py


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This is removing leftover `test` targets in test applications. Found while cleaning up generated applications after running the full test-suite.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- run `make distclean > /dev/null` from the riot directory
- with master, you get something like:
```
Makefile:11: warning: overriding recipe for target 'test'
...tests/cond_order/../../Makefile.include:568: warning: ignoring old recipe for target 'test'
/bin/sh: 1: Syntax error: Missing '))'
Makefile:41: warning: overriding recipe for target 'test'
...tests/pkg_cmsis-dsp/../../Makefile.include:568: warning: ignoring old recipe for target 'test'
Makefile:9: warning: overriding recipe for target 'test'
...tests/pkg_lora-serialization/../../Makefile.include:568: warning: ignoring old recipe for target 'test'

```
- with this PR, you now get something like:
```
/bin/sh: 1: Syntax error: Missing '))'
```

The syntax error comes from a bug with how the ROM_LEN is computed with kinetis based boards. I'll open a PR to fix this after this one.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
