### PR TITLE
cpu/kinetis: fix values stored in ROM_LEN/RAM_LEN variables

### DIFF
--- a/cpu/kinetis/Makefile.include
+++ b/cpu/kinetis/Makefile.include
@@ -13,7 +13,10 @@ LINKER_SCRIPT = kinetis.ld
 ROM_START_ADDR = 0x00000000
 RAM_BASE_ADDR  = 0x20000000
 RAM_START_ADDR = $$(($(RAM_BASE_ADDR)-($(KINETIS_SRAM_L_SIZE) * 1024)))
-ROM_LEN = $$(($(KINETIS_ROMSIZE) * 1024))
+# Define ROM_LEN with a non arithmetic value as it must be
+# evaluated in `cortexm_common` without a shell context
+# The `K` is correctly handled by both the linker and `cortexm_common`.
+ROM_LEN = $(KINETIS_ROMSIZE)K
 RAM_LEN = $$(($(KINETIS_RAMSIZE) * 1024))
 
 CFLAGS += \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is fixing a failure with kinetis cpus when building any application. This failure is not blocking the generation of firmwares though.

There is this error displayed in the terminal: `/bin/sh: 1: Syntax error: Missing '))'`. This error is generated when reaching [this line](https://github.com/RIOT-OS/RIOT/blob/master/cpu/cortexm_common/Makefile.include#L35).

This is because the way the ROM_LEN is determined breaks the computation of the SLOT0_LEN variable used for the bootloader. For SLOT0_LEN, the ROM_LEN is expected to be in KB by default.

For consistency, the RAM_LEN is computed the same way.

I put the RFC label, because I'm not 100% sure whether this is the best fix or not.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Run the following (because it's using a kinetis based board by default): `make -C tests/periph_adc`
- In master, you get something like:
```
make: Entering directory 'tests/periph_adc'
/bin/sh: 1: Syntax error: Missing '))'
Building application "tests_periph_adc" for "pba-d-01-kw2x" with MCU "kinetis".
[...]
```
You get this: `/bin/sh: 1: Syntax error: Missing '))'`
- With this PR:
```
make: Entering directory 'tests/periph_adc'
Building application "tests_periph_adc" for "pba-d-01-kw2x" with MCU "kinetis".
[...]
```
- Verify things related to the bootloader

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
