### PR TITLE
makefiles/toolchain: fix command -v multiple commands

### DIFF
--- a/makefiles/toolchain/gnu.inc.mk
+++ b/makefiles/toolchain/gnu.inc.mk
@@ -13,7 +13,7 @@ export NM         = $(PREFIX)nm
 export LINK       = $(PREFIX)gcc
 export LINKXX     = $(PREFIX)g++
 export SIZE       = $(PREFIX)size
-export OBJCOPY   ?= $(shell command -v $(PREFIX)objcopy gobjcopy objcopy | head -n 1)
+export OBJCOPY   ?= $(shell command -v $(PREFIX)objcopy || command -v gobjcopy || command -v objcopy)
 ifeq ($(OBJCOPY),)
 $(warning objcopy not found. Hex file will not be created.)
 export OBJCOPY    = true

--- a/makefiles/toolchain/llvm.inc.mk
+++ b/makefiles/toolchain/llvm.inc.mk
@@ -20,7 +20,7 @@ export LINK        = $(PREFIX)gcc
 export LINKXX      = $(PREFIX)g++
 # objcopy does not have a clear substitute in LLVM, use GNU binutils
 #export OBJCOPY     = $(LLVMPREFIX)objcopy
-export OBJCOPY    ?= $(shell command -v $(PREFIX)objcopy gobjcopy objcopy | head -n 1)
+export OBJCOPY    ?= $(shell command -v $(PREFIX)objcopy || command -v gobjcopy || command -v objcopy)
 ifeq ($(OBJCOPY),)
 $(warning objcopy not found. Hex file will not be created.)
 export OBJCOPY     = true


### PR DESCRIPTION
### Contribution description

`command -v first second third` only works in `bash` and not in `sh`.
So replace with multiple calls to `command`.

This fixes using `objcopy` when the toolchain `objcopy` is not available.


### Testing procedure 

I found this when building in docker with a machine without toolchain.

If you have your `arm` toolchain installed outside of the normal path you can try with the same procedure of changing the PATH.
Or use another board you do not have the toolchain for.

#### With this PR

It fallback to `objcopy`:

```
BOARD=samr21-xpro PATH=/usr/bin:/bin make --no-print-directory -C examples/hello-world/ info-debug-variable-OBJCOPY
/bin/sh: 1: arm-none-eabi-gcc: not found
/usr/bin/objcopy

TOOLCHAIN=llvm BOARD=samr21-xpro PATH=/usr/bin:/bin make --no-print-directory -C examples/hello-world/ info-debug-variable-OBJCOPY
/bin/sh: 1: arm-none-eabi-gcc: not found
/usr/bin/objcopy
```


Original behavior is kept:

```
BOARD=samr21-xpro  make --no-print-directory -C examples/hello-world/ info-debug-variable-OBJCOPY
/opt/gcc-arm-none-eabi-7-2018-q2-update/bin/arm-none-eabi-objcopy

TOOLCHAIN=llvm BOARD=samr21-xpro  make --no-print-directory -C examples/hello-world/ info-debug-variable-OBJCOPY
/opt/gcc-arm-none-eabi-7-2018-q2-update/bin/arm-none-eabi-objcopy
```

The `arm-none-eabi-gcc` error is unrelated to this PR and I think is related to https://github.com/RIOT-OS/RIOT/issues/10850 and is also present in `master`.

#### Behavior in master

Master does not fallback to `objcopy`.

```
BOARD=samr21-xpro PATH=/usr/bin:/bin make --no-print-directory -C examples/hello-world/ info-debug-variable-OBJCOPY
/bin/sh: 1: arm-none-eabi-gcc: not found
/home/harter/work/git/RIOT/makefiles/toolchain/gnu.inc.mk:18: objcopy not found. Hex file will not be created.
true
 TOOLCHAIN=llvm BOARD=samr21-xpro PATH=/usr/bin:/bin make --no-print-directory -C examples/hello-world/ info-debug-variable-OBJCOPY
/bin/sh: 1: arm-none-eabi-gcc: not found
/home/harter/work/git/RIOT/makefiles/toolchain/llvm.inc.mk:25: objcopy not found. Hex file will not be created.
true
```

Normal behavior was the same
```
BOARD=samr21-xpro  make --no-print-directory -C examples/hello-world/ info-debug-variable-OBJCOPY
/opt/gcc-arm-none-eabi-7-2018-q2-update/bin/arm-none-eabi-objcopy
TOOLCHAIN=llvm BOARD=samr21-xpro  make --no-print-directory -C examples/hello-world/ info-debug-variable-OBJCOPY
/opt/gcc-arm-none-eabi-7-2018-q2-update/bin/arm-none-eabi-objcopy
```

#### Low level justification

Difference between bash and sh and `make` uses `sh` by default.

```
sh -c 'command -v this does not exist false true'
# nothing is printed
```

```
bash -c 'command -v this does not exist false true'
false
true
```

### Issues/PRs references

I notified this in https://github.com/RIOT-OS/RIOT/pull/10870

#### Follow ups

Other boards/cpus are defining `objcopy` and other toolchains in their own `Makefile.include` when they should be using this one. It also goes for all the compiler variables.