### PR TITLE
boards/common/nrf52: Add OpenOCD support

### DIFF
--- a/boards/common/nrf52/Makefile.include
+++ b/boards/common/nrf52/Makefile.include
@@ -12,7 +12,11 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 # define jlink as default programmer, but overridable
 PROGRAMMER ?= jlink
 
-ifeq (jlink,$(PROGRAMMER))
+ifeq ($(PROGRAMMER),openocd)
+  # use common openocd configuration for nrf52
+  export OPENOCD_CONFIG = $(RIOTBOARD)/common/nrf52/dist/openocd.cfg
+  include $(RIOTMAKE)/tools/openocd.inc.mk
+else ifeq (jlink,$(PROGRAMMER))
   # setup JLink for flashing
   export JLINK_DEVICE := nrf52
 

--- a/boards/common/nrf52/dist/openocd.cfg
+++ b/boards/common/nrf52/dist/openocd.cfg
@@ -1,0 +1,3 @@
+source [find interface/jlink.cfg]
+transport select swd
+source [find target/nrf52.cfg]

--- a/boards/common/nrf52/include/board_common.h
+++ b/boards/common/nrf52/include/board_common.h
@@ -10,6 +10,30 @@
  * @defgroup    boards_common_nrf52 NRF52 common
  * @ingroup     boards_common
  * @brief       Shared files and configuration for all nRF52 boards.
+ *
+ * # Flashing
+ * ## Using JLink
+ * By default the nRF52 family of boards is flashed using the Segger's JLink
+ * tool. Due to its proprietary nature, only pre-build binary blobs are
+ * available for only the most common systems. You can use OpenOCD on those
+ * systems instead. If the JLink tool is installed on your system, you can
+ * compile and flash your application by running:
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * make BOARD=<nRF52_BOARD> flash
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *
+ * ## Using OpenOCD
+ * As of January 2018, the latest stable version of OpenOCD (version 0.10.0) is
+ * not able to flash nRF52 boards. Thus, you will currently need to build the
+ * current development version of OpenOCD in order to flash your boards using
+ * OpenOCD. If the development version of OpenOCD is installed, you can build
+ * and flash your application by running:
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * make BOARD=<nRF52_BOARD> PROGRAMMER=openocd flash
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *
  * @{
  *
  * @file

--- a/boards/nrf52840-mdk/Makefile.include
+++ b/boards/nrf52840-mdk/Makefile.include
@@ -12,7 +12,6 @@ ifeq (pyocd,$(PROGRAMMER))
   include $(RIOTMAKE)/tools/pyocd.inc.mk
 else ifeq (openocd,$(PROGRAMMER))
   export DEBUG_ADAPTER ?= dap
-  include $(RIOTMAKE)/tools/openocd.inc.mk
 endif
 
 include $(RIOTBOARD)/common/nrf52/Makefile.include

--- a/boards/nrf52840-mdk/dist/openocd.cfg
+++ b/boards/nrf52840-mdk/dist/openocd.cfg
@@ -1,2 +1,0 @@
-transport select swd
-source [find target/nrf52.cfg]


### PR DESCRIPTION
### Contribution description
This PR allows flashing & debugging nRF52 based boards using (the development version of) OpenOCD.

### Testing procedure
Check if flashing and debugging with OpenOCD works on your favorite nRF52 based board using:

```
make PROGRAMMER=openocd BOARD=<nRF52_BOARD> flash
make PROGRAMMER=openocd BOARD=<nRF52_BOARD> debug
```

**Beware:** The most recent stable version of OpenOCD will fail with "invalid subcommand" while flashing. So you'll need a development version of OpenOCD to use it.

State of testing:

 - [ ] acd52832
 - [ ] nrf52840-mdk
 - [ ] nrf52840dk
 - [ ] nrf52dk
 - [ ] ruuvitag
 - [ ] thingy52

### Issues/PRs references
Removes OpenOCD config of https://github.com/RIOT-OS/RIOT/pull/9833 in favor of a central config.