### PR TITLE
tests/periph_rtt: add Python script for automatic testing + use 5s delay between Hellos

### DIFF
--- a/tests/periph_rtt/README.md
+++ b/tests/periph_rtt/README.md
@@ -1,6 +1,6 @@
 Expected result
 ===============
-When everything works as expected, you should see a hello message popping up every 10 seconds.
+When everything works as expected, you should see a hello message popping up every 5 seconds.
 
 Background
 ==========

--- a/tests/periph_rtt/main.c
+++ b/tests/periph_rtt/main.c
@@ -14,7 +14,7 @@
  * @brief       Test for low-level Real Time Timer drivers
  *
  * This test will initialize the real-time timer and trigger an alarm printing
- * 'Hello' every 10 seconds
+ * 'Hello' every 5 seconds
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  *
@@ -29,7 +29,7 @@
 #include "periph_conf.h"
 #include "periph/rtt.h"
 
-#define TICKS_TO_WAIT       (10 * RTT_FREQUENCY)
+#define TICKS_TO_WAIT       (5 * RTT_FREQUENCY)
 
 static volatile uint32_t last;
 
@@ -47,7 +47,7 @@ void cb(void *arg)
 int main(void)
 {
     puts("\nRIOT RTT low-level driver test");
-    puts("This test will display 'Hello' every 10 seconds\n");
+    puts("This test will display 'Hello' every 5 seconds\n");
 
     puts("Initializing the RTT driver");
     rtt_init();
@@ -56,7 +56,7 @@ int main(void)
     printf("RTT now: %" PRIu32 "\n", now);
 
     last = (now + TICKS_TO_WAIT) & RTT_MAX_VALUE;
-    printf("Setting initial alarm to now + 10 s (%" PRIu32 ")\n", last);
+    printf("Setting initial alarm to now + 5 s (%" PRIu32 ")\n", last);
     rtt_set_alarm(last, cb, 0);
 
     puts("Done setting up the RTT, wait for many Hellos");

--- a/tests/periph_rtt/tests/01-run.py
+++ b/tests/periph_rtt/tests/01-run.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2019 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+import time
+from testrunner import run
+
+
+PRECISION = 0.05  # 5%
+MAX_HELLOS = 5
+
+
+def testfunc(child):
+    child.expect(r'This test will display \'Hello\' every (\d+) seconds')
+    period = int(child.match[1])
+    child.expect_exact('Initializing the RTT driver')
+    child.expect(r'RTT now: \d+')
+    child.expect(r'Setting initial alarm to now \+ {} s \(\d+\)'
+                 .format(period))
+    child.expect_exact('Done setting up the RTT, wait for many Hellos')
+    start = time.time()
+    for _ in range(MAX_HELLOS):
+        child.expect_exact('Hello\r\n', timeout=period + 1)
+
+    # Verify timings
+    elapsed = time.time() - start
+    assert elapsed > (MAX_HELLOS * period * (1 - PRECISION))
+    assert elapsed < (MAX_HELLOS * period * (1 + PRECISION))
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is updating the `periph_rtt` test application to display "Hello" every 5s instead of 10s and also adds a Python test to automatize the checks.

For each 'Hello' displayed a timeout of 'period + 1s' is used. To have a check on RTT precision, the test application have to be modified.

Tested with success on iotlab-m3 and samr21-xpro.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

This PR can be fully tested using IoT-LAB.

- Start an experiment on the testbed of Saclay:
```
$ iotlab-experiment -n rtt -d 20 -l 1,site=saclay+archi=m3:at86rf231 -l 1,site=saclay+archi=samr21:at86rf233
```
- Build/flash/test the application:
```
$ make BOARD=iotlab-m3 IOTLAB_NODE=auto-ssh -C tests/periph_rtt flash test
$ make BOARD=samr21-xpro IOTLAB_NODE=auto-ssh -C tests/periph_rtt flash test
```

All tests should succeed.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
