### PR TITLE
gnrc_rpl: do not assert netif on auto-init

### DIFF
--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_auto_init.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_auto_init.c
@@ -31,6 +31,8 @@ void auto_init_gnrc_rpl(void)
 #if (GNRC_NETIF_NUMOF == 1)
     gnrc_netif_t *netif = gnrc_netif_iter(NULL);
     if (netif == NULL) {
+        /* XXX this is just a work-around ideally this would happen with
+         * an `up` event of the interface */
         LOG_INFO("Unable to auto-initialize RPL. No interfaces found.\n");
         return;
     }
@@ -45,10 +47,14 @@ void auto_init_gnrc_rpl(void)
         gnrc_rpl_init(GNRC_RPL_DEFAULT_NETIF);
         return;
     }
+    /* XXX this is just a work-around ideally this would happen with
+     * an `up` event of the GNRC_RPL_DEFAULT_NETIF */
     DEBUG("auto_init_gnrc_rpl: could not initialize RPL on interface %" PRIkernel_pid" - "
           "interface does not exist\n", GNRC_RPL_DEFAULT_NETIF);
     return;
 #else
+    /* XXX this is just a work-around ideally this should be defined in some
+     * run-time interface configuration */
     DEBUG("auto_init_gnrc_rpl: please specify an interface by setting GNRC_RPL_DEFAULT_NETIF\n");
 #endif
 }

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_auto_init.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_auto_init.c
@@ -19,6 +19,7 @@
 
 #ifdef MODULE_AUTO_INIT_GNRC_RPL
 
+#include "log.h"
 #include "net/gnrc.h"
 #include "net/gnrc/rpl.h"
 
@@ -29,7 +30,10 @@ void auto_init_gnrc_rpl(void)
 {
 #if (GNRC_NETIF_NUMOF == 1)
     gnrc_netif_t *netif = gnrc_netif_iter(NULL);
-    assert(netif != NULL);
+    if (netif == NULL) {
+        LOG_INFO("Unable to auto-initialize RPL. No interfaces found.\n");
+        return;
+    }
     DEBUG("auto_init_gnrc_rpl: initializing RPL on interface %" PRIkernel_pid "\n",
           netif->pid);
     gnrc_rpl_init(netif->pid);


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
`gnrc_networking` is unusable when compiled for boards that do not have any network devices on-board due to an assertion in RPL's auto-init. I think this is pretty harsh. A friendly info message is enough, as it might not even be an error. Also, if one expects RPL to work without network interfaces they are a fool ;-). Also also, the `GNRC_NETIF_NUMOF != 1` case doesn't have this assertion either.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Compile `gnrc_networking` for a board without any on-board radios. Without this PR the board will run into a failed assertion on start-up. With it, it will just continue and print a message before the normal welcome message: "Unable to auto-initialize RPL. No interfaces found."
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None, but discovered in #10412.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
