### PR TITLE
sock_dns: correctly report too short messages [backport 2019.01]

### DIFF
--- a/sys/net/application_layer/dns/dns.c
+++ b/sys/net/application_layer/dns/dns.c
@@ -221,9 +221,15 @@ int sock_dns_query(const char *domain_name, void *addr_out, int family)
             continue;
         }
         res = sock_udp_recv(&sock_dns, reply_buf, sizeof(reply_buf), 1000000LU, NULL);
-        if ((res > 0) && (res > (int)DNS_MIN_REPLY_LEN)) {
-            if ((res = _parse_dns_reply(reply_buf, res, addr_out, family)) > 0) {
-                goto out;
+        if (res > 0) {
+            if (res > (int)DNS_MIN_REPLY_LEN) {
+                if ((res = _parse_dns_reply(reply_buf, res, addr_out,
+                                            family)) > 0) {
+                    goto out;
+                }
+            }
+            else {
+                res = -EBADMSG;
             }
         }
     }


### PR DESCRIPTION
# Backport of #10896

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
While writing the tests I promised in #10740 I noticed this bug. `sock_dns_query()` returns the length of a too short DNS response instead of just reporting that it is wrong. While this is not severe, it can lead to confusing behavior, as the function does not report an error but just a number `>0`. This basically means, `sock_dns_query()` will tell the user that the address is whatever currently is on the stack ;-).
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
After the interface configuration described in the README of `tests/gnrc_sock_dns` start the application (but not the `dnsmasq`) and the following command in a separate terminal

```
while sleep 1; do echo AACBAAAACpoAAAAA | base64 -d | sudo socat fd:0 udp6-sendto:'[<native-lladdr>%tap0]':49152,bind="[2001:db8::1]:53",sourceport=53; done
```

Without this PR the response the output will be

```
example.org resolves to ::
```

With it correctly reports

```
error resolving example.org
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None, but found while working on https://github.com/miri64/RIOT/tree/tests/enh/gnrc_sock_dns/tests/gnrc_sock_dns
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
