### PR TITLE
board/{blue,black}pill: Allow flashing 128 KiB with OpenOCD

### DIFF
--- a/boards/bluepill/doc.txt
+++ b/boards/bluepill/doc.txt
@@ -68,9 +68,13 @@ value is `stm32f103c8`. These two CPU models basically only have one
 major difference, the latter has 128 KB flash while the former has 64
 KB. You may also set `STM32F103C8_FLASH_HACK` as environment variable.
 
-If you want to flash a binary compiled this way you either need to
-figure out how to adjust the OpenOCD configuration to make it use 128 KB
-flash or use this [stlink fork][caboStlink] which has a
+The OpenOCD configuration overrides the flash size to 128 KB, but this is - as
+of January 2019 - only supported by the development version of OpenOCD. If
+you have this version installed, you can flash your board using:
+
+    $ make BOARD=bluepill flash
+
+Otherwise you can use this [stlink fork][caboStlink] which has a
 [patch][caboPatch] to make use of the entire 128 KB flash using:
 
     $ C8T6HACK=1 st-flash write /dev/sgX $pathToHexFile 0x8000000

--- a/boards/common/stm32f103c8/Makefile.include
+++ b/boards/common/stm32f103c8/Makefile.include
@@ -3,6 +3,7 @@ export CPU = stm32f1
 STM32F103C8_FLASH_HACK ?= 0
 ifneq ($(STM32F103C8_FLASH_HACK),0)
   export CPU_MODEL = stm32f103cb
+  export OPENOCD_CONFIG := $(RIOTBOARD)/common/stm32f103c8/dist/openocd-flash-hack.cfg
 else
   export CPU_MODEL = stm32f103c8
 endif

--- a/boards/common/stm32f103c8/dist/openocd-flash-hack.cfg
+++ b/boards/common/stm32f103c8/dist/openocd-flash-hack.cfg
@@ -1,5 +1,3 @@
-set WORKAREASIZE 0x5000
-
 set CHIPNAME STM32F103C8Tx
 
 # Enable debug when in low power modes
@@ -15,6 +13,7 @@ set CLOCK_FREQ 4000
 # connect_assert_srst needed if low power mode application running (WFI...)
 reset_config srst_only srst_nogate connect_assert_srst
 set CONNECT_UNDER_RESET 1
+set FLASH_SIZE 0x20000
 
 source [find target/stm32f1x.cfg]
 

--- a/boards/common/stm32f103c8/dist/openocd.cfg
+++ b/boards/common/stm32f103c8/dist/openocd.cfg
@@ -15,6 +15,7 @@ set CLOCK_FREQ 4000
 # connect_assert_srst needed if low power mode application running (WFI...)
 reset_config srst_only srst_nogate connect_assert_srst
 set CONNECT_UNDER_RESET 1
+set FLASH_SIZE 0x20000
 
 source [find target/stm32f1x.cfg]
 


### PR DESCRIPTION
### Contribution description

This change of the openocd.cfg overwrites the flash size to 128 KiB and, thus, allows flashing using `make flash`. Please note that `STM32F103C8_FLASH_HACK` has  to be set to `1` in order for the link time checks to also assume 128 KiB flash.

Be aware that - as of January 2019 - the latest stable release of OpenOCD does not allow overwriting the flash size, so you will currently need the development version for this to work.


### Testing procedure

Using the development version of OpenOCD:

Run `STM32F103C8_FLASH_HACK=1 make flash` e.g. in `examples/gnrc_networking`. (Because no network device is present an assertion will be triggered on boot, but flashing would not be possible with 64 KiB flash.)

Using the current stable version of OpenOCD:

Run `make flash` in e.g. `examples/default`. This should still work.

### Issues/PRs references
Follow up of https://github.com/RIOT-OS/RIOT/pull/10323