### PR TITLE
cpu/saml21: extend and fix exti configuration for saml21 variants [backport 2019.01]

### DIFF
--- a/cpu/saml21/include/periph_cpu.h
+++ b/cpu/saml21/include/periph_cpu.h
@@ -29,12 +29,45 @@ extern "C" {
 /**
  * @brief   Mapping of pins to EXTI lines, -1 means not EXTI possible
  */
+#if defined(CPU_MODEL_SAML21E18A) || defined(CPU_MODEL_SAML21E18B) || \
+    defined(CPU_MODEL_SAML21E17A) || defined(CPU_MODEL_SAML21E17B) || \
+    defined(CPU_MODEL_SAML21E16A) || defined(CPU_MODEL_SAML21E16B) || \
+    defined(CPU_MODEL_SAML21E15A) || defined(CPU_MODEL_SAML21E15B)
+static const int8_t exti_config[1][32] = {
+    { 0,  1,  2,  3,  4,  5,  6,  7, -1,  9, 10, 11, -1, -1, 14, 15,
+      0,  1,  2,  3, -1, -1,  6,  7, 12, 13, -1, 15, -1, -1, 10, 11},
+};
+#else /* CPU_MODEL_SAML21E */
 static const int8_t exti_config[2][32] = {
+#if defined(CPU_MODEL_SAML21G18A) || defined(CPU_MODEL_SAML21G18B) || \
+    defined(CPU_MODEL_SAML21G17A) || defined(CPU_MODEL_SAML21G17B) || \
+    defined(CPU_MODEL_SAML21G16A) || defined(CPU_MODEL_SAML21G16B)
+    { 0,  1,  2,  3,  4,  5,  6,  7, -1,  9, 10, 11, 12, 13, 14, 15,
+      0,  1,  2,  3,  4,  5,  6,  7, 12, 13, -1, 15, -1, -1, 10, 11},
+    {-1, -1,  2,  3, -1, -1, -1, -1,  8,  9, 10, 11, -1, -1, -1, -1,
+     -1, -1, -1, -1, -1, -1,  6,  7, -1, -1, -1, -1, -1, -1, -1, -1},
+#elif defined(CPU_MODEL_SAML21J18A) || defined(CPU_MODEL_SAML21J18B) || \
+      defined(CPU_MODEL_SAML21J17A) || defined(CPU_MODEL_SAML21J17B) || \
+      defined(CPU_MODEL_SAML21J16A) || defined(CPU_MODEL_SAML21J16B)
     { 0,  1,  2,  3,  4,  5,  6,  7, -1,  9, 10, 11, 12, 13, 14, 15,
       0,  1,  2,  3,  4,  5,  6,  7, 12, 13, -1, 15, -1, -1, 10, 11},
     { 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,
       0,  1, -1, -1, -1, -1,  6,  7, -1, -1, -1, -1, -1, -1, 14, 15},
+#elif defined(CPU_MODEL_SAMR30G18A)
+    { 0,  1, -1, -1,  4,  5,  6,  7, -1,  9, 10, 11, 12, 13, 14, 15,
+      0,  1,  2,  3,  4, -1,  6,  7, 12, 13, -1, 15,  8, -1, 10, 11},
+    { 0, -1,  2,  3, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 15,
+      0,  1, -1, -1, -1, -1,  6,  7, -1, -1, -1, -1, -1, -1, 14, 15},
+#elif defined(CPU_MODEL_SAMR30E18A)
+    {-1, -1, -1, -1, -1, -1,  6,  7, -1,  9, 10, 11, -1, -1, 14, 15,
+      0,  1,  2,  3,  4, -1, -1, -1, 12, 13, -1, 15,  8, -1, 10, 11},
+    { 0, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 15,
+      0,  1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 14, 15},
+#else
+    #error Please define a proper CPU_MODEL.
+#endif
 };
+#endif /* CPU_MODEL_SAML21E */
 
 #define HAVE_ADC_RES_T
 typedef enum {


### PR DESCRIPTION
# Backport of #10794

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

While reviewing #10653, I tested different things on samr30-xpro to verify there were no regressions introduced by the port. Indeed, the saml1x works relies a lot on saml21 cpus and samr30 are fully based on saml21 cpus (they are the same with a radio, like samr21 compared to samd21).

During my tests, I noticed the `tests/buttons` was broken: the on-board button gpio couldn't be initialized with IRQ.

After a look at the code, I found that the exti configuration was the same for all types of saml21 cpus which is wrong according the datasheet.

This PR is adding the missing configuration and, in the meantime, it fixes the broken `tests/buttons` application on samr30-xpro boards.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Flash and run `tests/buttons` application on samr30-xpro/saml21-xpro and verify that it works. on master, with samr30-xpro, you get an initialization failure, with this PR everything works smoothly.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Found while reviewing #10653 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
