### PR TITLE
drivers/sds011: Fix error return value on SAUL driver

### DIFF
--- a/drivers/sds011/sds011_saul.c
+++ b/drivers/sds011/sds011_saul.c
@@ -36,7 +36,7 @@ static int _read(const void *dev, phydat_t *res)
        res->scale = -7;
        return 2;
     }
-    return ECANCELED;
+    return -ECANCELED;
 }
 
 const saul_driver_t sds011_saul_driver = {


### PR DESCRIPTION
### Contribution description
The `read` function of a SAUL driver should return the number of values written into to result data structure [1-3], `-ENOTSUP` if the device does not support this operation or `-ECANCELED` on other errors.

This PR fixes the return value of the read function of the sds011 SAUL driver to `-ECANCELED` instead of `ECANCELED`.

### Testing procedure
Run the default SAUL application (`tests/saul`).

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
