### PR TITLE
 sx127x: 2 fixes and 1 enhancement

### DIFF
--- a/drivers/sx127x/sx127x_getset.c
+++ b/drivers/sx127x/sx127x_getset.c
@@ -269,37 +269,41 @@ void sx127x_set_rx(sx127x_t *dev)
                 sx127x_reg_write(dev, SX127X_REG_LR_IRQFLAGSMASK,
                                  /* SX127X_RF_LORA_IRQFLAGS_RXTIMEOUT |
                                     SX127X_RF_LORA_IRQFLAGS_RXDONE |
-                                    SX127X_RF_LORA_IRQFLAGS_PAYLOADCRCERROR | */
-                                 SX127X_RF_LORA_IRQFLAGS_VALIDHEADER |
+                                    SX127X_RF_LORA_IRQFLAGS_PAYLOADCRCERROR |
+                                    SX127X_RF_LORA_IRQFLAGS_VALIDHEADER | */
                                  SX127X_RF_LORA_IRQFLAGS_TXDONE |
                                  SX127X_RF_LORA_IRQFLAGS_CADDONE |
                                  /* SX127X_RF_LORA_IRQFLAGS_FHSSCHANGEDCHANNEL | */
                                  SX127X_RF_LORA_IRQFLAGS_CADDETECTED);
 
-                /* DIO0=RxDone, DIO2=FhssChangeChannel */
+                /* DIO0=RxDone, DIO2=FhssChangeChannel, DIO3=ValidHeader */
                 sx127x_reg_write(dev, SX127X_REG_DIOMAPPING1,
                                  (sx127x_reg_read(dev, SX127X_REG_DIOMAPPING1) &
                                   SX127X_RF_LORA_DIOMAPPING1_DIO0_MASK &
-                                  SX127X_RF_LORA_DIOMAPPING1_DIO2_MASK) |
+                                  SX127X_RF_LORA_DIOMAPPING1_DIO2_MASK &
+                                  SX127X_RF_LORA_DIOMAPPING1_DIO3_MASK) |
                                  SX127X_RF_LORA_DIOMAPPING1_DIO0_00 |
-                                 SX127X_RF_LORA_DIOMAPPING1_DIO2_00);
+                                 SX127X_RF_LORA_DIOMAPPING1_DIO2_00 |
+                                 SX127X_RF_LORA_DIOMAPPING1_DIO3_01);
             }
             else {
                 sx127x_reg_write(dev, SX127X_REG_LR_IRQFLAGSMASK,
                                  /* SX127X_RF_LORA_IRQFLAGS_RXTIMEOUT |
                                     SX127X_RF_LORA_IRQFLAGS_RXDONE |
-                                    SX127X_RF_LORA_IRQFLAGS_PAYLOADCRCERROR | */
-                                 SX127X_RF_LORA_IRQFLAGS_VALIDHEADER |
+                                    SX127X_RF_LORA_IRQFLAGS_PAYLOADCRCERROR |
+                                    SX127X_RF_LORA_IRQFLAGS_VALIDHEADER | */
                                  SX127X_RF_LORA_IRQFLAGS_TXDONE |
                                  SX127X_RF_LORA_IRQFLAGS_CADDONE |
                                  SX127X_RF_LORA_IRQFLAGS_FHSSCHANGEDCHANNEL |
                                  SX127X_RF_LORA_IRQFLAGS_CADDETECTED);
 
-                /* DIO0=RxDone */
+                /* DIO0=RxDone, DIO3=ValidHeader */
                 sx127x_reg_write(dev, SX127X_REG_DIOMAPPING1,
                                  (sx127x_reg_read(dev, SX127X_REG_DIOMAPPING1) &
-                                  SX127X_RF_LORA_DIOMAPPING1_DIO0_MASK) |
-                                 SX127X_RF_LORA_DIOMAPPING1_DIO0_00);
+                                  SX127X_RF_LORA_DIOMAPPING1_DIO0_MASK &
+                                  SX127X_RF_LORA_DIOMAPPING1_DIO3_MASK) |
+                                 SX127X_RF_LORA_DIOMAPPING1_DIO0_00 |
+                                 SX127X_RF_LORA_DIOMAPPING1_DIO3_01);
             }
 
             sx127x_reg_write(dev, SX127X_REG_LR_FIFORXBASEADDR, 0);

--- a/drivers/sx127x/sx127x_getset.c
+++ b/drivers/sx127x/sx127x_getset.c
@@ -351,17 +351,18 @@ void sx127x_set_tx(sx127x_t *dev)
             }
             else
             {
+                /* Enable TXDONE interrupt */
                 sx127x_reg_write(dev, SX127X_REG_LR_IRQFLAGSMASK,
                                  SX127X_RF_LORA_IRQFLAGS_RXTIMEOUT |
                                  SX127X_RF_LORA_IRQFLAGS_RXDONE |
                                  SX127X_RF_LORA_IRQFLAGS_PAYLOADCRCERROR |
                                  SX127X_RF_LORA_IRQFLAGS_VALIDHEADER |
-                                 /* RFLR_IRQFLAGS_TXDONE | */
+                                 /* SX127X_RF_LORA_IRQFLAGS_TXDONE | */
                                  SX127X_RF_LORA_IRQFLAGS_CADDONE |
                                  SX127X_RF_LORA_IRQFLAGS_FHSSCHANGEDCHANNEL |
                                  SX127X_RF_LORA_IRQFLAGS_CADDETECTED);
 
-                /* DIO0=TxDone */
+                /* Set TXDONE interrupt to the DIO0 line */
                 sx127x_reg_write(dev, SX127X_REG_DIOMAPPING1,
                                  (sx127x_reg_read(dev, SX127X_REG_DIOMAPPING1) &
                                   SX127X_RF_LORA_DIOMAPPING1_DIO0_MASK) |
@@ -371,10 +372,14 @@ void sx127x_set_tx(sx127x_t *dev)
         break;
     }
 
-    sx127x_set_state(dev, SX127X_RF_RX_RUNNING);
+    sx127x_set_state(dev, SX127X_RF_TX_RUNNING);
+
+    /* Start TX timeout timer */
     if (dev->settings.lora.tx_timeout != 0) {
         xtimer_set(&(dev->_internal.tx_timeout_timer), dev->settings.lora.tx_timeout);
     }
+
+    /* Put chip into transfer mode */
     sx127x_set_op_mode(dev, SX127X_RF_OPMODE_TRANSMITTER );
 }
 

--- a/drivers/sx127x/sx127x_netdev.c
+++ b/drivers/sx127x/sx127x_netdev.c
@@ -59,7 +59,8 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
             break;
         case SX127X_MODEM_LORA:
             /* Initializes the payload size */
-            sx127x_set_payload_length(dev, size);
+            if (!sx127x_get_fixed_header_len_mode(dev))
+                sx127x_set_payload_length(dev, size);
 
             /* Full buffer used for Tx */
             sx127x_reg_write(dev, SX127X_REG_LR_FIFOTXBASEADDR, 0x00);

--- a/drivers/sx127x/sx127x_netdev.c
+++ b/drivers/sx127x/sx127x_netdev.c
@@ -83,29 +83,7 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
             break;
     }
 
-    /* Enable TXDONE interrupt */
-    sx127x_reg_write(dev, SX127X_REG_LR_IRQFLAGSMASK,
-                     SX127X_RF_LORA_IRQFLAGS_RXTIMEOUT |
-                     SX127X_RF_LORA_IRQFLAGS_RXDONE |
-                     SX127X_RF_LORA_IRQFLAGS_PAYLOADCRCERROR |
-                     SX127X_RF_LORA_IRQFLAGS_VALIDHEADER |
-                     /* SX127X_RF_LORA_IRQFLAGS_TXDONE | */
-                     SX127X_RF_LORA_IRQFLAGS_CADDONE |
-                     SX127X_RF_LORA_IRQFLAGS_FHSSCHANGEDCHANNEL |
-                     SX127X_RF_LORA_IRQFLAGS_CADDETECTED);
-
-    /* Set TXDONE interrupt to the DIO0 line */
-    sx127x_reg_write(dev, SX127X_REG_DIOMAPPING1,
-                     (sx127x_reg_read(dev, SX127X_REG_DIOMAPPING1) &
-                      SX127X_RF_LORA_DIOMAPPING1_DIO0_MASK) |
-                     SX127X_RF_LORA_DIOMAPPING1_DIO0_01);
-
-    /* Start TX timeout timer */
-    xtimer_set(&dev->_internal.tx_timeout_timer, dev->settings.lora.tx_timeout);
-
-    /* Put chip into transfer mode */
-    sx127x_set_state(dev, SX127X_RF_TX_RUNNING);
-    sx127x_set_op_mode(dev, SX127X_RF_OPMODE_TRANSMITTER);
+    sx127x_set_tx(dev);
 
     return 0;
 }


### PR DESCRIPTION
### Contribution description

1 bugfix, 1 fix and 1 enhancement for sx127x driver (sx1272/sx1276 Lora chipset)

Bugfix for sending in implicit headers mode
Fix for netdev send call (remove duplicate code + bugfix for sx127x_set_tx())
Enhancement: set chipset's ValidHeader interrupt to NETDEV_EVENT_RX_STARTED netdev event

### Testing procedure

To test enhancement, add NETDEV_EVENT_RX_STARTED catching code in event callback function
