### PR TITLE
drivers/cc110x: Fixed MTU calculation

### DIFF
--- a/drivers/cc110x/cc110x-netdev.c
+++ b/drivers/cc110x/cc110x-netdev.c
@@ -111,7 +111,7 @@ static int _get(netdev_t *dev, netopt_t opt, void *value, size_t value_len)
             return sizeof(uint8_t);
         case NETOPT_MAX_PACKET_SIZE:
             assert(value_len > 0);
-            *((uint16_t *)value) = CC110X_PACKET_LENGTH;
+            *((uint16_t *)value) = CC110X_PACKET_LENGTH - CC110X_L2_HDR_SIZE;
             return sizeof(uint16_t);
         case NETOPT_IPV6_IID:
             return _get_iid(dev, value, value_len);

--- a/drivers/cc110x/cc110x-rxtx.c
+++ b/drivers/cc110x/cc110x-rxtx.c
@@ -147,7 +147,7 @@ static void _rx_read_data(cc110x_t *dev, void(*callback)(void*), void*arg)
             LOG_DEBUG("cc110x: received packet from=%u to=%u payload len=%u\n",
                       (unsigned)pkt_buf->packet.phy_src,
                       (unsigned)pkt_buf->packet.address,
-                      pkt_buf->packet.length - 3);
+                      pkt_buf->packet.length - CC110X_L2_HDR_SIZE);
             /* let someone know that we've got a packet */
             callback(arg);
 
@@ -157,7 +157,8 @@ static void _rx_read_data(cc110x_t *dev, void(*callback)(void*), void*arg)
             DEBUG("%s:%s:%u crc-error\n", RIOT_FILE_RELATIVE, __func__, __LINE__);
             dev->cc110x_statistic.packets_in_crc_fail++;
 #if defined(MODULE_OD) && ENABLE_DEBUG
-            od_hex_dump(pkt_buf->packet.data, pkt_buf->packet.length - 3,
+            od_hex_dump(pkt_buf->packet.data,
+                        pkt_buf->packet.length - CC110X_L2_HDR_SIZE,
                         OD_WIDTH_DEFAULT);
 #endif
             _rx_abort(dev);
@@ -273,7 +274,8 @@ void cc110x_isr_handler(cc110x_t *dev, void(*callback)(void*), void*arg)
 int cc110x_send(cc110x_t *dev, cc110x_pkt_t *packet)
 {
     DEBUG("cc110x: snd pkt to %u payload_length=%u\n",
-            (unsigned)packet->address, (unsigned)packet->length-3);
+            (unsigned)packet->address,
+            (unsigned)packet->length - CC110X_L2_HDR_SIZE);
     unsigned size;
 
     switch (dev->radio_state) {

--- a/drivers/cc110x/include/cc110x-internal.h
+++ b/drivers/cc110x/include/cc110x-internal.h
@@ -45,6 +45,7 @@ extern "C" {
 #define MAX_CHANNR                  (24)    /**< Maximum channel number */
 
 #define CC110X_PACKET_LENGTH        (0xFF)  /**< max packet length = 255b */
+#define CC110X_L2_HDR_SIZE          (3)     /**< Layer 2 header size */
 #define CC110X_SYNC_WORD_TX_TIME    (90000) /**< loop count (max. timeout ~15ms)
                                                  to wait for sync word to be
                                                  transmitted (GDO2 from low to

--- a/sys/net/gnrc/netif/gnrc_netif_device_type.c
+++ b/sys/net/gnrc/netif/gnrc_netif_device_type.c
@@ -140,9 +140,10 @@ void gnrc_netif_ipv6_init_mtu(gnrc_netif_t *netif)
     switch (netif->device_type) {
 #if defined(MODULE_NETDEV_IEEE802154) || defined(MODULE_NRFMIN) || \
     defined(MODULE_XBEE) || defined(MODULE_ESP_NOW) || \
-    defined(MODULE_GNRC_SIXLOENC)
+    defined(MODULE_GNRC_SIXLOENC) || defined(MODULE_CC110X)
         case NETDEV_TYPE_IEEE802154:
         case NETDEV_TYPE_NRFMIN:
+        case NETDEV_TYPE_CC110X:
 #ifdef MODULE_GNRC_SIXLOWPAN_IPHC
             netif->flags |= GNRC_NETIF_FLAGS_6LO_HC;
 #endif


### PR DESCRIPTION
### Contribution description

- The MTU of `cc110x` is reported incorrectly when used without 6LoWPAN:
    - `netdev_driver_t::get(NETOPT_MAX_PACKET_SIZE)` returns the maximum frame size including layer 2 header, not the maximum layer 2 PDU
- The MUT of`cc110x` is reported incorrectly when used with 6LoWPAN:
    - `gnrc_netif_ipv6_init_mtu()` does not yet handle the `CC110X`

This PR fixes both

### Testing procedure

Using the MSB-A2:

Flash `examples/gnrc_networking` and run `ifconfig`. The MTU should be 1280, as 6LoWPAN is used with this PR (but is 255 without this PR). The layer 2 PDU should be `252` instead of (without this PR) `255`. PR https://github.com/RIOT-OS/RIOT/pull/10923 extends `ifconfig` to also print the layer 2 PDU.

Also, `ping6` should still work. (Please keep in mind to change the address of one of the MSB-A2s, e.g. by `ifconfig 7 set addr 42`, `ifconfig 7 del fe80::ff:fe00:22`, and `ifconfig 7 add fe80::ff:fe00:42`.)

### Issues/PRs references

Partly a split off of PR https://github.com/RIOT-OS/RIOT/pull/10340. Depends on https://github.com/RIOT-OS/RIOT/pull/10923 for testing (and only for testing)

------

Update: Fixed testing procedure