### PR TITLE
cpu/native: fix race in thread_yield_higher() [backport 2019.01]

### DIFF
--- a/core/msg.c
+++ b/core/msg.c
@@ -330,6 +330,7 @@ static int _msg_receive(msg_t *m, int block)
             thread_yield_higher();
 
             /* sender copied message */
+            assert(sched_active_thread->status != STATUS_RECEIVE_BLOCKED);
         }
         else {
             irq_restore(state);

--- a/cpu/native/native_cpu.c
+++ b/cpu/native/native_cpu.c
@@ -208,6 +208,8 @@ void isr_thread_yield(void)
 
 void thread_yield_higher(void)
 {
+    sched_context_switch_request = 1;
+
     if (_native_in_isr == 0) {
         ucontext_t *ctx = (ucontext_t *)(sched_active_thread->sp);
         _native_in_isr = 1;
@@ -223,9 +225,6 @@ void thread_yield_higher(void)
             err(EXIT_FAILURE, "thread_yield_higher: swapcontext");
         }
         irq_enable();
-    }
-    else {
-        sched_context_switch_request = 1;
     }
 }
 


### PR DESCRIPTION
# Backport of #10891

### Contribution description

    Error case:
    1. thread_yield_higher() stores the thread's ucontext
    2. creates an "isr ucontext" for isr_thread_yield, switches to it
    
    Case 1: no signals are pending, continues in isr_thread_yield()
    3a. sched_run is called
    4a. return to sched_active_thread ucontext
    
    Case 2: signals pending (the crashing scenario), continues in native_irq_handler()
    3b. handles signals
    4b. if sched_context_switch_request is set, call sched_run
    5b. return to sched_active_thread ucontext
    
    4b misses the call to sched_run(), leading to a possible return into a
    non-ready thread.

Fixes #10881.

### Testing procedure

See #10881 and #10908

### Issues/PRs references

Fixes #10881.
Fixes #6123.