### PR TITLE
shell/ifconfig: Fixed stringification

### DIFF
--- a/sys/shell/commands/sc_gnrc_netif.c
+++ b/sys/shell/commands/sc_gnrc_netif.c
@@ -234,7 +234,7 @@ static void _print_netopt(netopt_t opt)
             break;
 
         case NETOPT_HOP_LIMIT:
-            printf("MTU");
+            printf("hop limit");
             break;
 
         case NETOPT_MAX_PACKET_SIZE:


### PR DESCRIPTION
### Contribution description

`NETOPT_HOP_LIMIT` was previously stringyfied to `"MTU"`, this PR changes this to `"hop limit"`.

### Testing procedure

None

### Issues/PRs references

None