### PR TITLE
shell/ifconfig: Add L2-PDU info

### DIFF
--- a/sys/shell/commands/sc_gnrc_netif.c
+++ b/sys/shell/commands/sc_gnrc_netif.c
@@ -505,6 +505,11 @@ static void _netif_list(kernel_pid_t iface)
                                    line_thresh);
     line_thresh = _netif_list_flag(iface, NETOPT_CHANNEL_HOP, "CHAN_HOP",
                                    line_thresh);
+    res = gnrc_netapi_get(iface, NETOPT_MAX_PACKET_SIZE, 0, &u16, sizeof(u16));
+    if (res > 0) {
+        printf("L2-PDU:%" PRIu16 " ", u16);
+        line_thresh++;
+    }
 #ifdef MODULE_GNRC_IPV6
     res = gnrc_netapi_get(iface, NETOPT_MAX_PACKET_SIZE, GNRC_NETTYPE_IPV6, &u16, sizeof(u16));
     if (res > 0) {


### PR DESCRIPTION
### Contribution description

When IPv6 is enabled, the MTU is given. So users(*) sending IPv6 packets can easily figure out what the supported maximum protocol unit is.

However, when IPv6 is disabled and a user wants to send layer 2 frames directly, no information about the maximum PDU is available using the shell.

When 6LoWPAN is used, a user may be interested in the layer 2 PDU as well in order to avoid layer 2 fragmentation.

This PR adds the L2-PDU info to the output of the ifconfig shell command, which is printed regardless of the use of IPv6.

(*): Here "users" refers to human beings interacting with the shell. Applications can get the maximum PDU of each layer more easily using `gnrc_netapi_get()` with `NETOPT_MAX_PACKET_SIZE` instead of using a shell command.

### Testing procedure

Flash `examples/gnrc_networking` and start shall command `ifconfig` without any parameter. The layer 2 PDU should be printed as `L2-PDU:<value>`.

### Issues/PRs references

This allows testing of https://github.com/RIOT-OS/RIOT/pull/10918