### PR TITLE
examples: use coap_opt_finish() in gcoap based examples

### DIFF
--- a/examples/cord_ep/main.c
+++ b/examples/cord_ep/main.c
@@ -56,8 +56,9 @@ static ssize_t _handler_dummy(coap_pkt_t *pdu,
     int16_t val = 23;
 
     gcoap_resp_init(pdu, buf, len, COAP_CODE_CONTENT);
-    size_t plen = fmt_s16_dec((char *)pdu->payload, val);
-    return gcoap_finish(pdu, plen, COAP_FORMAT_TEXT);
+    size_t resp_len = coap_opt_finish(pdu, COAP_OPT_FINISH_PAYLOAD);
+    resp_len += fmt_s16_dec((char *)pdu->payload, val);
+    return resp_len;
 }
 
 static ssize_t _handler_info(coap_pkt_t *pdu,
@@ -66,9 +67,10 @@ static ssize_t _handler_info(coap_pkt_t *pdu,
     (void)ctx;
 
     gcoap_resp_init(pdu, buf, len, COAP_CODE_CONTENT);
+    size_t resp_len = coap_opt_finish(pdu, COAP_OPT_FINISH_PAYLOAD);
     size_t slen = sizeof("SOME NODE INFOMRATION");
     memcpy(pdu->payload, "SOME NODE INFOMRATION", slen);
-    return gcoap_finish(pdu, slen, COAP_FORMAT_TEXT);
+    return resp_len + slen;
 }
 
 static const coap_resource_t _resources[] = {

--- a/examples/cord_epsim/main.c
+++ b/examples/cord_epsim/main.c
@@ -34,9 +34,11 @@ static ssize_t text_resp(coap_pkt_t *pdu, uint8_t *buf, size_t len,
                          const char *text, unsigned format)
 {
     gcoap_resp_init(pdu, buf, len, COAP_CODE_CONTENT);
+    coap_opt_add_format(pdu, format);
+    ssize_t resp_len = coap_opt_finish(pdu, COAP_OPT_FINISH_PAYLOAD);
     size_t slen = strlen(text);
     memcpy(pdu->payload, text, slen);
-    return gcoap_finish(pdu, slen, format);
+    return resp_len + slen;
 }
 
 static ssize_t handler_info(coap_pkt_t *pdu, uint8_t *buf, size_t len, void *ctx)

--- a/sys/net/application_layer/cord/ep/cord_ep.c
+++ b/sys/net/application_layer/cord/ep/cord_ep.c
@@ -146,7 +146,7 @@ static int _update_remove(unsigned code, gcoap_resp_handler_t handle)
         return CORD_EP_ERR;
     }
     coap_hdr_set_type(pkt.hdr, COAP_TYPE_CON);
-    ssize_t pkt_len = gcoap_finish(&pkt, 0, COAP_FORMAT_NONE);
+    ssize_t pkt_len = coap_opt_finish(&pkt, COAP_OPT_FINISH_NONE);
 
     /* send request */
     gcoap_req_send2(buf, pkt_len, &_rd_remote, handle);
@@ -220,7 +220,7 @@ static int _discover_internal(const sock_udp_ep_t *remote,
     }
     coap_hdr_set_type(pkt.hdr, COAP_TYPE_CON);
     gcoap_add_qstring(&pkt, "rt", "core.rd");
-    size_t pkt_len = gcoap_finish(&pkt, 0, COAP_FORMAT_NONE);
+    size_t pkt_len = coap_opt_finish(&pkt, COAP_OPT_FINISH_NONE);
     res = gcoap_req_send2(buf, pkt_len, remote, _on_discover);
     if (res < 0) {
         return CORD_EP_ERR;

--- a/sys/net/application_layer/cord/epsim/cord_epsim.c
+++ b/sys/net/application_layer/cord/epsim/cord_epsim.c
@@ -59,7 +59,7 @@ int cord_epsim_register(void)
         return CORD_EPSIM_ERROR;
     }
     /* finish, we don't have any payload */
-    ssize_t len = gcoap_finish(&pkt, 0, COAP_FORMAT_NONE);
+    ssize_t len = coap_opt_finish(&pkt, COAP_OPT_FINISH_NONE);
     if (gcoap_req_send2(buf, len, &remote, NULL) == 0) {
         return CORD_EPSIM_ERROR;
     }


### PR DESCRIPTION
### Contribution description
#10892 updates gcoap documentation and internal message generation to use coap_opt_finish() rather than gcoap_finish(). This PR updates RIOT examples that use gcoap to also use coap_opt_finish(). The examples include the gcoap CLI example, cord_epsim, and cord_ep.

### Testing procedure
- gcoap cli: Send requests to the CLI for /riot/stats and /riot/board. Use the CLI to send a request. Have an Observe client register for /cli/stats, and then create another request in the CLI, which will send a notification to the observer.
- cord_epsim: Register with a resource directory server. Also, send requests to the cord_epsim endpoint itself for /riot/foo and /riot/info.
- cord_ep: Use the CLI to register with a resource directory server. Also use the CLI to discover RD servers and remove the cord_ep client from the server. Also, send requests to the cord_ep endpoint itself for /sense/temp and /node/info.

FWIW, review my request_response, cord_ep, and cord_epsim [automated tests](https://github.com/kb2ma/riot-coap-pytest) for examples. 

### Issues/PRs references
Depends on #10892
