### PR TITLE
Introduce module vars

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -372,10 +372,20 @@ define uniq
   $(seen)
 endef
 
+# for each variable listed here, collect additions from used modules.  For
+# example, if CFLAGS.some_module is set and some_module is in USEMODULE, the
+# equivalent of CFLAGS += $(CFLAGS.some_module) will happen.
+MODULE_VARS += CFLAGS LINKFLAGS INCLUDES USEMODULE_INCLUDES
+
+define collect_var =
+  $(1) += $$(foreach module,$$(USEMODULE),$$($(1).$$(module)))
+endef
+
+$(foreach var,$(MODULE_VARS),$(eval $(call collect_var,$(var))))
+
+# add all paths in USEMODULE_INCLUDES to INCLUDES with "-I" prefix
 USEMODULE_INCLUDES_ = $(strip $(call uniq,$(USEMODULE_INCLUDES)))
-
 INCLUDES += $(USEMODULE_INCLUDES_:%=-I%)
-
 
 # include bindist target
 include $(RIOTMAKE)/bindist.inc.mk

--- a/sys/Makefile.include
+++ b/sys/Makefile.include
@@ -1,44 +1,23 @@
-ifneq (,$(filter nhdp,$(USEMODULE)))
-  USEMODULE_INCLUDES += $(RIOTBASE)/sys/net/routing/nhdp
+USEMODULE_INCLUDES.nhdp            += $(RIOTBASE)/sys/net/routing/nhdp
+USEMODULE_INCLUDES.fib             += $(RIOTBASE)/sys/posix/include
+USEMODULE_INCLUDES.gnrc_netif      += $(RIOTBASE)/sys/net/gnrc/netif/include
+
+USEMODULE_INCLUDES.gnrc_sock       += $(RIOTBASE)/sys/net/gnrc/sock/include
+ifneq (,$(filter gnrc_ipv6,$(USEMODULE)))
+    CFLAGS.gnrc_sock += -DSOCK_HAS_IPV6
 endif
 
-ifneq (,$(filter fib,$(USEMODULE)))
-  USEMODULE_INCLUDES += $(RIOTBASE)/sys/posix/include
-endif
-ifneq (,$(filter gnrc_netif,$(USEMODULE)))
-  USEMODULE_INCLUDES += $(RIOTBASE)/sys/net/gnrc/netif/include
-endif
-ifneq (,$(filter gnrc_sock,$(USEMODULE)))
-  USEMODULE_INCLUDES += $(RIOTBASE)/sys/net/gnrc/sock/include
-  ifneq (,$(filter gnrc_ipv6,$(USEMODULE)))
-    CFLAGS += -DSOCK_HAS_IPV6
-  endif
-endif
-ifneq (,$(filter posix,$(USEMODULE)))
-  USEMODULE_INCLUDES += $(RIOTBASE)/sys/posix/include
-endif
-ifneq (,$(filter posix_semaphore,$(USEMODULE)))
-  USEMODULE_INCLUDES += $(RIOTBASE)/sys/posix/include
-endif
-ifneq (,$(filter posix_sockets,$(USEMODULE)))
-  USEMODULE_INCLUDES += $(RIOTBASE)/sys/posix/include
-endif
-ifneq (,$(filter pthread,$(USEMODULE)))
-  USEMODULE_INCLUDES += $(RIOTBASE)/sys/posix/pthread/include
-endif
+USEMODULE_INCLUDES.posix           += $(RIOTBASE)/sys/posix/include
+USEMODULE_INCLUDES.posix_semaphore += $(RIOTBASE)/sys/posix/include
+USEMODULE_INCLUDES.posix_sockets   += $(RIOTBASE)/sys/posix/include
+USEMODULE_INCLUDES.pthread         += $(RIOTBASE)/sys/posix/pthread/include
+USEMODULE_INCLUDES.oneway_malloc   += $(RIOTBASE)/sys/oneway-malloc/include
+USEMODULE_INCLUDES.vfs             += $(RIOTBASE)/sys/posix/include
+USEMODULE_INCLUDES.cpp11-compat    += $(RIOTBASE)/sys/cpp11-compat/include
 
-ifneq (,$(filter oneway_malloc,$(USEMODULE)))
-  USEMODULE_INCLUDES += $(RIOTBASE)/sys/oneway-malloc/include
-endif
-
-ifneq (,$(filter vfs,$(USEMODULE)))
-  USEMODULE_INCLUDES += $(RIOTBASE)/sys/posix/include
-endif
-
+# make sure cppsupport.o is linked explicitly because __dso_handle is not
+# found if it is hidden away inside a static object.
 ifneq (,$(filter cpp11-compat,$(USEMODULE)))
-  USEMODULE_INCLUDES += $(RIOTBASE)/sys/cpp11-compat/include
-  # make sure cppsupport.o is linked explicitly because __dso_handle is not
-  # found if it is hidden away inside a static object.
   export UNDEF += $(BINDIR)/cpp11-compat/cppsupport.o
 endif
 


### PR DESCRIPTION
### Contribution description

Currently, if a module wants to add to the global CFLAGS et al, it needs this clumsy construct:

 ```
ifneq (,$(filter foo,$(USEMODULE)))
  CFLAGS += fooflag
endif
```

Apart from being ugly, it currently doesn't work reliably in cpu/foobar/Makefile.include, as the dependencies are not yet processed.

This PR allows used modules to append to some selected (through addition to MODULE_VARS) variables by setting e.g., 

```CFLAGS.modulename += flag```

Variables set like that will be collected *after* dependency resolution.
It is thus safe to e.g., set ```CFLAGS.newlib += -DNEWLIB``` even if newlib is unused. In that case, the statement will have no effect.

A second PR adapts sys/Makefile.include to this scheme.

### Testing procedure

Code should compile identically to before.

### Issues/PRs references

none