### PR TITLE
Fix hdc1000 renew interval documentation

### DIFF
--- a/drivers/include/hdc1000.h
+++ b/drivers/include/hdc1000.h
@@ -161,8 +161,9 @@ int hdc1000_read(const hdc1000_t *dev, int16_t *temp, int16_t *hum);
  * @brief   Extended read function including caching capability
  *
  * This function will return cached values if they are within the sampling
- * period (HDC1000_RENEW_INTERVAL), or will trigger a new conversion, wait for
- * the conversion to be finished and the get the results from the device.
+ * period (HDC1000_PARAM_RENEW_INTERVAL), or will trigger a new conversion,
+ * wait for the conversion to be finished and the get the results from the
+ * device.
  *
  * @param[in]  dev          device descriptor of sensor
  * @param[out] temp         temperature [in 100 * degree centigrade]


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The header documentation refers to the `HDC1000_PARAM_RENEW_INTERVAL` as
`HDC1000_RENEW_INTERVAL`. This PR fixes this in the documentation.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Read the generated documentation.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
