### PR TITLE
net/nanocoap: Packet API return error if buffer full

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -620,7 +620,8 @@ size_t coap_put_block1_ok(uint8_t *pkt_pos, coap_block1_t *block1, uint16_t last
  * @param[in]     separator   character used in @p string to separate parts
  *
  * @return        number of bytes written to buffer
- * @return        -ENOSPC if no available options
+ * @return        <0 on error
+ * @return        -ENOSPC if no available options or insufficient buffer space
  */
 ssize_t coap_opt_add_string(coap_pkt_t *pkt, uint16_t optnum, const char *string, char separator);
 
@@ -635,7 +636,8 @@ ssize_t coap_opt_add_string(coap_pkt_t *pkt, uint16_t optnum, const char *string
  * @param[in]     value       uint to encode
  *
  * @return        number of bytes written to buffer
- * @return        <0 reserved for error but not implemented yet
+ * @return        <0 on error
+ * @return        -ENOSPC if no available options or insufficient buffer space
  */
 ssize_t coap_opt_add_uint(coap_pkt_t *pkt, uint16_t optnum, uint32_t value);
 
@@ -649,7 +651,8 @@ ssize_t coap_opt_add_uint(coap_pkt_t *pkt, uint16_t optnum, uint32_t value);
  * @param[in]     format      COAP_FORMAT_xxx to use
  *
  * @return        number of bytes written to buffer
- * @return        <0 reserved for error but not implemented yet
+ * @return        <0 on error
+ * @return        -ENOSPC if no available options or insufficient buffer space
  */
 static inline ssize_t coap_opt_add_format(coap_pkt_t *pkt, uint16_t format)
 {

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -69,10 +69,13 @@
  *
  * - **minimal API** requires only a reference to the buffer for the message.
  * However, the caller must provide the last option number written as well as
- * the buffer position.
+ * the buffer position. The caller is primarily responsible for tracking and
+ * managing the space remaining in the buffer.
  *
  * - **struct-based API** uses a coap_pkt_t struct to conveniently track each
- * option as it is written and prepare for any payload.
+ * option as it is written and prepare for any payload. The caller must monitor
+ * space remaining in the buffer; however, the API *will not* write past the
+ * end of the buffer, and returns -ENOSPC when it is full.
  *
  * You must use one API exclusively for a given message. For either API, the
  * caller must write options in order by option number (see "CoAP option
@@ -89,6 +92,9 @@
  * option. These functions require the position in the buffer to start writing,
  * and return the number of bytes written.
  *
+ * @note You must ensure the buffer has enough space remaining to write each
+ * option. The API does not verify the safety of writing an option.
+ *
  * If there is a payload, append a payload marker (0xFF). Then write the
  * payload to within the maximum length remaining in the buffer.
  *
@@ -101,6 +107,10 @@
  * Next, use the coap_opt_add_xxx() functions to write each option, like
  * coap_opt_add_uint(). When all options have been added, call
  * coap_opt_finish().
+ *
+ * @note You must ensure the buffer has enough space remaining to write each
+ * option. You can monitor `coap_pkt_t.payload_len` for remaining space, or
+ * watch for a -ENOSPC return value from the API.
  *
  * Finally, write any message payload at the coap_pkt_t _payload_ pointer
  * attribute. The _payload_len_ attribute provides the available length in the

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -669,6 +669,7 @@ static inline ssize_t coap_opt_add_format(coap_pkt_t *pkt, uint16_t format)
  * @param[in]     flags       see COAP_OPT_FINISH... macros
  *
  * @return        total number of bytes written to buffer
+ * @return        -ENOSPC if no buffer space for payload marker
  */
 ssize_t coap_opt_finish(coap_pkt_t *pkt, uint16_t flags);
 

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -797,7 +797,9 @@ ssize_t coap_opt_add_uint(coap_pkt_t *pkt, uint16_t optnum, uint32_t value)
 ssize_t coap_opt_finish(coap_pkt_t *pkt, uint16_t flags)
 {
     if (flags & COAP_OPT_FINISH_PAYLOAD) {
-        assert(pkt->payload_len > 1);
+        if (!pkt->payload_len) {
+            return -ENOSPC;
+        }
 
         *pkt->payload++ = 0xFF;
         pkt->payload_len--;


### PR DESCRIPTION
### Contribution description
nanocoap's Packet API is meant to be safer to use than the Buffer API. Historically, an attempt to overfill the buffer with this API would generate an assert. However, given the pressure to optimize buffer sizes, it can be useful to provide the ability to recover from a write that would overfill the buffer.

This PR builds on #10823 to return -ENOSPC if a request to write to the message buffer is too long. This response applies to coap_opt_add_xxx() and coap_opt_finish() functions. An error return value allows an application response to recover, for example by returning a 5.00 error.

This PR also updates the module documentation to be clearer about application responsibility for managing the message buffer with each API.

### Testing procedure
Includes unit tests for nanocoap and gcoap.

### Issues/PRs references
Completes the work started in #10823 and #10926.