### PR TITLE
boards/sodaq-autonomo: switch to flashing with bossac

### DIFF
--- a/boards/sodaq-autonomo/Makefile.include
+++ b/boards/sodaq-autonomo/Makefile.include
@@ -2,4 +2,18 @@
 export CPU = samd21
 export CPU_MODEL = samd21j18a
 
-include $(RIOTMAKE)/boards/sam0.inc.mk
+#export needed for flash rule
+export PORT_LINUX ?= /dev/ttyACM0
+export PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
+
+# setup serial terminal
+include $(RIOTMAKE)/tools/serial.inc.mk
+
+# setup the flash tool used
+# we use BOSSA to flash this board since there's an Arduino bootloader
+# preflashed on it. ROM_OFFSET skips the space taken by such bootloader.
+ROM_OFFSET ?= 0x2000
+include $(RIOTMAKE)/tools/bossa.inc.mk
+
+# setup the boards dependencies
+include $(RIOTBOARD)/$(BOARD)/Makefile.dep


### PR DESCRIPTION
Flashing through bossac (instead of using Atmel ICE) is much easier. The SODAQ Autonomo board mostly is used by people who are familiar with Arduino. Thus it makes more sense to flash it in the same manner.

There may be not many Autonomo users in RIOT, so it won't hurt to just merge this.