### PR TITLE
sam0_common: check ADC_NUMOF on adc_init()

### DIFF
--- a/cpu/sam0_common/periph/adc.c
+++ b/cpu/sam0_common/periph/adc.c
@@ -156,6 +156,10 @@ static int _adc_configure(adc_res_t res)
 
 int adc_init(adc_t line)
 {
+    if (line >= ADC_NUMOF) {
+        DEBUG("adc: line arg not applicable\n");
+        return -1;
+    }
     _prep();
     gpio_init(adc_channels[line].pin, GPIO_IN);
     gpio_init_mux(adc_channels[line].pin, GPIO_MUX_B);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
While working on a [private project](https://github.com/miri64/RIOT_playground/tree/master/wand), I noticed that `adc_init` for `sam0_common` doesn't check the correctness of the `line` parameter. The doc states it [should return -1](http://doc.riot-os.org/group__drivers__periph__adc.html#ga259a7b0176a8a6f5a5e61aabce3574f0) on error, so I added the missing check and return.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Try initializing ADC on a `sam0` based board (e.g. `samr21-xpro`) for a line that is not defined (e.g. `ADC_LINE(9)`). Without this PR the board will crash. With it, the function will just return -1.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
