### PR TITLE
cpu/stm32_common: enable UART pin inversion

### DIFF
--- a/cpu/stm32_common/include/periph_cpu_common.h
+++ b/cpu/stm32_common/include/periph_cpu_common.h
@@ -432,6 +432,10 @@ typedef struct {
     gpio_af_t rx_af;        /**< alternate function for RX pin */
     gpio_af_t tx_af;        /**< alternate function for TX pin */
 #endif
+#ifdef MODULE_STM32_PERIPH_UART_PIN_INVERSION
+    uint8_t rx_pin_inv;          /**< RX pin inversion flag */
+    uint8_t tx_pin_inv;          /**< TX pin inversion flag */
+#endif
     uint8_t bus;            /**< APB bus */
     uint8_t irqn;           /**< IRQ channel */
 #ifdef MODULE_STM32_PERIPH_UART_HW_FC

--- a/cpu/stm32_common/periph/uart.c
+++ b/cpu/stm32_common/periph/uart.c
@@ -126,6 +126,13 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
     dev(uart)->CR2 = 0;
     dev(uart)->CR3 = 0;
 
+#if defined(MODULE_STM32_PERIPH_UART_PIN_INVERSION) && defined(USART_CR2_RXINV)
+    if (uart_config[uart].rx_pin_inv)
+        dev(uart)->CR2 |= USART_CR2_RXINV;
+    if (uart_config[uart].tx_pin_inv)
+        dev(uart)->CR2 |= USART_CR2_TXINV;
+#endif
+
 #if defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L4)
     switch (uart_config[uart].type) {
         case STM32_USART:


### PR DESCRIPTION
### Contribution description

Some STM32 UARTs provide pin inversion option. Add related
fields to the uart_conf_t struct, that allow separate inversion
configuration.

MODULE_STM32_PERIPH_UART_PIN_INVERSION macro enables this feature
and USART_CR2_RXINV macro ensures that particular platform supports
pin inversion.

### Testing procedure

Extend the `periph_conf.h` file of the board in question with pin inversion definition and also add `-DMODULE_STM32_PERIPH_UART_PIN_INVERSION` to the `CFLAGS`.

```
    {
          .dev        = USART6,
          .rcc_mask   = RCC_APB2ENR_USART6EN,
          .rx_pin     = GPIO_PIN(PORT_G, 9),
          .tx_pin     = GPIO_PIN(PORT_G, 14),
          .rx_af      = GPIO_AF8,
          .tx_af      = GPIO_AF8,
#ifdef MODULE_STM32_PERIPH_UART_PIN_INVERSION
          .rx_pin_inv = 1, /* invert RX pin */
          .tx_pin_inv = 0,
#endif
          .bus        = APB2,
          .irqn       = USART6_IRQn,
  #ifdef UART_USE_DMA
          .dma_stream = 5,
          .dma_chan   = 4
  #endif
      },


```
### Issues/PRs references

Fixes: #10935 