### PR TITLE
feather-m0: add BAT voltage ADC line (A7)

### DIFF
--- a/boards/feather-m0/doc.txt
+++ b/boards/feather-m0/doc.txt
@@ -24,7 +24,20 @@ SAMD21 mcu.
 ### Pinout
 
 <img src="https://cdn-learn.adafruit.com/assets/assets/000/030/921/original/adafruit_products_2772_pinout_v1_0.png"
-     alt="Adafruit Feather M0 proto pinout" style="width:800px;"/>
+     alt="Adafruit Feather M0 proto pinout" style="width:800px;"/><br/>
+
+`AIN7` can be used to [measure the voltage of a connected Lipoly battery][battery].
+It is mapped to ADC_LINE(6) in RIOT.
+
+~~~~~~~~~~~~~~~~ {.c}
+int vbat = adc_sample(ADC_LINE(6), ADC_RES_10BIT);
+vbat *= 2;      /* voltage was divided by 2, so multiply it back */
+vbat *= 33;     /* reference voltage 3.3V * 10 */
+vbat /= 10240;  /* resolution * 10 (because we multiplied 3.3V by 10) */
+printf("Bat: %dV\n", vbat);
+~~~~~~~~~~~~~~~~
+
+[battery]: https://learn.adafruit.com/adafruit-feather-m0-basic-proto/power-management#measuring-battery-4-9
 
 ### Flash the board
 

--- a/boards/feather-m0/include/periph_conf.h
+++ b/boards/feather-m0/include/periph_conf.h
@@ -177,9 +177,10 @@ static const adc_conf_chan_t adc_channels[] = {
     { GPIO_PIN(PA, 4), ADC_INPUTCTRL_MUXPOS_PIN4 },     /* A3 */
     { GPIO_PIN(PA, 5), ADC_INPUTCTRL_MUXPOS_PIN5 },     /* A4 */
     { GPIO_PIN(PB, 2), ADC_INPUTCTRL_MUXPOS_PIN10 },    /* A5 */
+    { GPIO_PIN(PA, 7), ADC_INPUTCTRL_MUXPOS_PIN7 },     /* A7 */
 };
 
-#define ADC_0_CHANNELS                     (6U)
+#define ADC_0_CHANNELS                     (7U)
 #define ADC_NUMOF                          ADC_0_CHANNELS
 /** @} */
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
While working on a [private project](https://github.com/miri64/RIOT_playground/tree/master/wand), I noticed that the ADC line A7 for [measuring the battery] isn't exposed via `periph/adc.h` for the `feather-m0`. For reference it can also be found in adafruit's [pinout diagram]. Since I'm not aware of an ADC line 6, I'm not sure the current approach to define A6 as `{ .pin = GPIO_UNDEF, .muxpos = 0 }` is the correct approach.

[measuring the battery]: https://learn.adafruit.com/adafruit-feather-m0-basic-proto/power-management#measuring-battery-4-8
[pinout diagram]: https://cdn-learn.adafruit.com/assets/assets/000/046/196/original/Feather_M0_Basic_Proto_v2.2.pdf?1504805559
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Connect a battery to the `feather-m0` and try to read its voltage from A7.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
