### PR TITLE
cpu/msp430_common: set top of heap for sbrk

### DIFF
--- a/cpu/msp430_common/msp430-main.c
+++ b/cpu/msp430_common/msp430-main.c
@@ -126,6 +126,8 @@ void msp430_cpu_init(void)
 
 #define STACK_EXTRA 32
 
+extern char __stack;     /* provided by linker script */
+char *__heap_end = NULL; /* top of heap */
 
 /*
  * Allocate memory from the heap. Check that we don't collide with the
@@ -135,12 +137,15 @@ void msp430_cpu_init(void)
  */
 void *sbrk(int incr)
 {
-    char *stack_pointer;
+    char *__heap_top = __heap_end;
 
-    asmv("mov r1, %0" : "=r"(stack_pointer));
-    stack_pointer -= STACK_EXTRA;
+    if (!__heap_top) {
+        /* set __heap_top to stack pointer if we are not in thread mode */
+        asmv("mov r1, %0" : "=r"(__heap_top));
+        __heap_top -= STACK_EXTRA;
+    }
 
-    if (incr > (stack_pointer - cur_break)) {
+    if (incr > (__heap_top - cur_break)) {
         return (void *) - 1;    /* ENOMEM */
     }
 

--- a/cpu/msp430_common/startup.c
+++ b/cpu/msp430_common/startup.c
@@ -26,6 +26,13 @@
 
 extern void board_init(void);
 
+/**
+ * Leave some extra space in the stack to allows us to finish the kernel
+ * initialization procedure. __heap_end is set the current stack, minus
+ * STACK_EXTRA since there is still code to execute.
+ */
+#define STACK_EXTRA 32
+
 __attribute__((constructor)) static void startup(void)
 {
     /* use putchar so the linker links it in: */
@@ -34,6 +41,11 @@ __attribute__((constructor)) static void startup(void)
     board_init();
 
     LOG_INFO("RIOT MSP430 hardware initialization complete.\n");
+
+    /* save current stack pointer as top of heap before enter the thread mode */
+    extern char *__heap_end;
+    __asm__ __volatile__("mov r1, %0" : "=r"(__heap_end));
+    __heap_end -= STACK_EXTRA;
 
     kernel_init();
 }


### PR DESCRIPTION
### Contribution description

MSP430 uses the module 'oneway_malloc' to provide the `malloc` function. The implemented `sbrk` function always checks whether the current break value ` cur_break` is less than the SP. However, since `cur_break` starts above the` .bss` section while SP in thread mode is always in thread stacks in `.bss` section, this check always fails and `malloc` does not work.

This PR fixes this problem by setting a variable `__heap_end` in the `startup` function to the current position of SP immediately before entering the thread mode. `sbrk` then checks `cur_break` value against this `__heap_end` variable.

The changes of this PR require 10 additional bytes of ROM and 2 additional bytes of RAM.

### Testing procedure

Use `tests/malloc` with the current master and the changes in this PR to verify the differences, for example:
```
make -C tests/malloc BOARD=wsn430-v1_3b flash test
```
With current master, `tests/malloc` doesn't work at all and gives no output. With the changes in this PR, `malloc` function works. `free` always fails since it is not implemented in `oneway_malloc`.

### Issues/PRs references

This PR is prerequisite for PR #10944.