### PR TITLE
gnrc_tcp: syn_rcvd pkt loss fix

### DIFF
--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp.c
@@ -203,14 +203,33 @@ static int _gnrc_tcp_open(gnrc_tcp_tcb_t *tcb, char *target_addr, uint16_t targe
            tcb->state != FSM_STATE_CLOSE_WAIT) {
         mbox_get(&(tcb->mbox), &msg);
         switch (msg.type) {
-            case MSG_TYPE_CONNECTION_TIMEOUT:
-                DEBUG("gnrc_tcp.c : _gnrc_tcp_open() : CONNECTION_TIMEOUT\n");
-                _fsm(tcb, FSM_EVENT_TIMEOUT_CONNECTION, NULL, NULL, 0);
-                ret = -ETIMEDOUT;
-                break;
-
             case MSG_TYPE_NOTIFY_USER:
                 DEBUG("gnrc_tcp.c : _gnrc_tcp_open() : MSG_TYPE_NOTIFY_USER\n");
+
+                /* Setup a timeout to be able to revert back to LISTEN state, in case the
+                 * send SYN+ACK we received upon entering SYN_RCVD is never acknowledged
+                 * by the peer. */
+                if ((tcb->state == FSM_STATE_SYN_RCVD) && (tcb->status & STATUS_PASSIVE)) {
+                    _setup_timeout(&connection_timeout, GNRC_TCP_CONNECTION_TIMEOUT_DURATION,
+                                   _cb_mbox_put_msg, &connection_timeout_arg);
+                }
+                break;
+
+            case MSG_TYPE_CONNECTION_TIMEOUT:
+                DEBUG("gnrc_tcp.c : _gnrc_tcp_open() : CONNECTION_TIMEOUT\n");
+
+                /* The connection establishment attempt timed out:
+                 * 1) Active connections return -ETIMEOUT.
+                 * 2) Passive connections stop the ongoing retransmissions and repeat the
+                 *    open call to wait for the next connection attempt. */
+                if (tcb->status & STATUS_PASSIVE) {
+                    _fsm(tcb, FSM_EVENT_CLEAR_RETRANSMIT, NULL, NULL, 0);
+                    _fsm(tcb, FSM_EVENT_CALL_OPEN, NULL, NULL, 0);
+                }
+                else {
+                    _fsm(tcb, FSM_EVENT_TIMEOUT_CONNECTION, NULL, NULL, 0);
+                    ret = -ETIMEDOUT;
+                }
                 break;
 
             default:

--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_fsm.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_fsm.c
@@ -191,6 +191,7 @@ static int _transition_to(gnrc_tcp_tcb_t *tcb, fsm_state_t state)
             mutex_unlock(&_list_tcb_lock);
             break;
 
+        case FSM_STATE_SYN_RCVD:
         case FSM_STATE_ESTABLISHED:
         case FSM_STATE_CLOSE_WAIT:
             tcb->status |= STATUS_NOTIFY_USER;


### PR DESCRIPTION
### Contribution description
This PR fixes #10945. Peter found a bug in gnrc_tcp() connection establishment procedure.

## Problem description
The Problem can be provoked by starting a RIOT Node with TCP in passive mode by calling gnrc_tcp_open_passive(). The function does not return until a connection was successfully established
or an error occurred. As soon as the RIOT Node received a SYN Packet, a SYN-ACK is added to the retransmission mechanism. By prohibiting the peer TCP to not send any response to the SYN-ACK,
gnrc_tcp() retransmits SYN+ACK infinitely and can never accept a new connection. 

From my point of view this is a very critical issue because either packet-loss or a manipulated  Handshake can deadlock a RIOT Node. As a side note: This Problem is not mentioned in the TCP RFC
so there is no definite strategy to address this.

## Fix description
TCP uses by default a two minute timeout to evaluate if a connection is alive. If the retransmission mechanism is longer that two minutes not successful in transmitting packets a connection is viewed as lost.

This fix starts a timer as soon as the SYN Packet is received from the peer. This Timer is stopped as soon as the connection is established. If the timer times out after two minutes the retransmission queue is cleared and the TCB reverts back to the LISTEN state waiting for the next incoming SYN.
