### PR TITLE
tests/gnrc_tcp_*: remove default PORT for native

### DIFF
--- a/tests/gnrc_tcp_client/Makefile
+++ b/tests/gnrc_tcp_client/Makefile
@@ -2,7 +2,10 @@ include ../Makefile.tests_common
 
 # If no BOARD is found in the environment, use this default:
 BOARD ?= native
-PORT ?= tap1
+
+ifeq (native,$(BOARD))
+  PORT ?= tap1
+endif
 
 TCP_TARGET_ADDR ?= fe80::affe%5
 TCP_TARGET_PORT ?= 80

--- a/tests/gnrc_tcp_server/Makefile
+++ b/tests/gnrc_tcp_server/Makefile
@@ -2,7 +2,10 @@ include ../Makefile.tests_common
 
 # If no BOARD is found in the environment, use this default:
 BOARD ?= native
-PORT ?= tap0
+
+ifeq (native,$(BOARD))
+  PORT ?= tap0
+endif
 
 TCP_LOCAL_ADDR ?= fe80::affe
 TCP_LOCAL_PORT ?= 80


### PR DESCRIPTION
### Contribution description

This PR removes the default `PORT?=` which was set to run the TCP client/server test applications on two native instances. A problem occurs when calling `BOARD=xyz make flash term` (with xyz not native) because in that case, `PORT` is set to `tap` by defualt. 


### Testing procedure

Build/flash/term a board with one of the applications *tests/gnrc_tcp_** with and without this PR.

### Issues/PRs references
 #10947
