### PR TITLE
 shell/sc_gnrc_ipv6_nib: extend for ABR

### DIFF
--- a/sys/include/net/gnrc/ipv6/nib/abr.h
+++ b/sys/include/net/gnrc/ipv6/nib/abr.h
@@ -28,7 +28,18 @@
 extern "C" {
 #endif
 
-#if (GNRC_IPV6_NIB_CONF_6LBR && GNRC_IPV6_NIB_CONF_MULTIHOP_P6C) || defined(DOXYGEN)
+/**
+ * @brief   Authoritative border router list entry view on NIB
+ */
+typedef struct {
+    ipv6_addr_t addr;       /**< The address of the border router */
+    uint32_t version;       /**< last received version */
+    uint32_t valid_until;   /**< timestamp (in minutes) until which the
+                             *   information is valid */
+} gnrc_ipv6_nib_abr_t;
+
+#if GNRC_IPV6_NIB_CONF_MULTIHOP_P6C || defined(DOXYGEN)
+#if GNRC_IPV6_NIB_CONF_6LBR || defined(DOXYGEN)
 /**
  * @brief   Adds the address of an authoritative border router to the NIB
  *
@@ -36,6 +47,8 @@ extern "C" {
  *
  * @return  0 on success.
  * @return  -ENOMEM, if no space is left in the neighbor cache.
+ * @return  -ENOTSUP, if @ref GNRC_IPV6_NIB_CONF_6LBR or
+ *          @ref GNRC_IPV6_NIB_CONF_MULTIHOP_P6C is not defined
  */
 int gnrc_ipv6_nib_abr_add(const ipv6_addr_t *addr);
 
@@ -45,7 +58,59 @@ int gnrc_ipv6_nib_abr_add(const ipv6_addr_t *addr);
  * @param[in] addr  The address of an authoritative border router.
  */
 void gnrc_ipv6_nib_abr_del(const ipv6_addr_t *addr);
-#endif  /* (GNRC_IPV6_NIB_CONF_6LBR && GNRC_IPV6_NIB_CONF_MULTIHOP_P6C) || defined(DOXYGEN) */
+#else   /* GNRC_IPV6_NIB_CONF_6LBR || defined(DOXYGEN) */
+#define gnrc_ipv6_nib_abr_add(addr)     (-ENOTSUP)
+#define gnrc_ipv6_nib_abr_del(addr)     (void)(addr)
+#endif  /* GNRC_IPV6_NIB_CONF_6LBR || defined(DOXYGEN) */
+
+/**
+ * @brief   Iterates over all authoritative border router in the NIB
+ *
+ * @pre `(state != NULL) && (abr != NULL)`
+ *
+ * @param[in,out] state Iteration state of the authoritative border router list.
+ *                      Must point to NULL pointer to start iteration
+ * @param[out] abr      The next authoritative border router list entry.
+ *
+ * Usage example:
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ {.c}
+ * #include "net/gnrc/ipv6/nib/abr.h"
+ *
+ * int main(void) {
+ *     void *state = NULL;
+ *     gnrc_ipv6_nib_abr_t abr;
+ *
+ *     puts("My border routers:");
+ *     while (gnrc_ipv6_nib_abr_iter(&state, &abr)) {
+ *         gnrc_ipv6_nib_abr_print(&abr);
+ *     }
+ *     return 0;
+ * }
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *
+ * @note    The list may change during iteration.
+ *
+ * @return  true, if iteration can be continued.
+ * @return  false, if @p abr is the last authoritative border router entry in
+ *          the NIB.
+ */
+bool gnrc_ipv6_nib_abr_iter(void **state, gnrc_ipv6_nib_abr_t *abr);
+
+/**
+ * @brief   Prints an authoritative border router list entry
+ *
+ * @pre `abr != NULL`
+ *
+ * @param[in] abr   An authoritative border router list entry
+ */
+void gnrc_ipv6_nib_abr_print(gnrc_ipv6_nib_abr_t *abr);
+#else   /* GNRC_IPV6_NIB_CONF_MULTIHOP_P6C || defined(DOXYGEN) */
+#define gnrc_ipv6_nib_abr_add(addr)         (-ENOTSUP)
+#define gnrc_ipv6_nib_abr_del(addr)         (void)(addr)
+#define gnrc_ipv6_nib_abr_iter(state, abr)  (false)
+#define gnrc_ipv6_nib_abr_print(abr)        (void)(abr)
+#endif  /* GNRC_IPV6_NIB_CONF_MULTIHOP_P6C || defined(DOXYGEN) */
 
 #ifdef __cplusplus
 }

--- a/sys/shell/commands/sc_gnrc_ipv6_nib.c
+++ b/sys/shell/commands/sc_gnrc_ipv6_nib.c
@@ -273,7 +273,7 @@ static int _nib_route(int argc, char **argv)
             return 1;
         }
         if (argc > 6) {
-            ltime = (uint16_t)atoi(argv[6]);
+            ltime = atoi(argv[6]);
         }
         gnrc_ipv6_nib_ft_add(&pfx, pfx_len, &next_hop, iface, ltime);
     }

--- a/sys/shell/commands/sc_gnrc_ipv6_nib.c
+++ b/sys/shell/commands/sc_gnrc_ipv6_nib.c
@@ -23,6 +23,9 @@ static void _usage(char **argv);
 static int _nib_neigh(int argc, char **argv);
 static int _nib_prefix(int argc, char **argv);
 static int _nib_route(int argc, char **argv);
+#if GNRC_IPV6_NIB_CONF_MULTIHOP_P6C
+static int _nib_abr(int argc, char **argv);
+#endif  /* GNRC_IPV6_NIB_CONF_MULTIHOP_P6C */
 
 int _gnrc_ipv6_nib(int argc, char **argv)
 {
@@ -41,6 +44,11 @@ int _gnrc_ipv6_nib(int argc, char **argv)
     else if (strcmp(argv[1], "route") == 0) {
         res = _nib_route(argc, argv);
     }
+#if GNRC_IPV6_NIB_CONF_MULTIHOP_P6C
+    else if (strcmp(argv[1], "abr") == 0) {
+        res = _nib_abr(argc, argv);
+    }
+#endif  /* GNRC_IPV6_NIB_CONF_MULTIHOP_P6C */
     else {
         _usage(argv);
     }
@@ -49,7 +57,11 @@ int _gnrc_ipv6_nib(int argc, char **argv)
 
 static void _usage(char **argv)
 {
+#if GNRC_IPV6_NIB_CONF_MULTIHOP_P6C
+    printf("usage: %s {neigh|prefix|route|abr|help} ...\n", argv[0]);
+#else   /* GNRC_IPV6_NIB_CONF_MULTIHOP_P6C */
     printf("usage: %s {neigh|prefix|route|help} ...\n", argv[0]);
+#endif  /* GNRC_IPV6_NIB_CONF_MULTIHOP_P6C */
 }
 
 static void _usage_nib_neigh(char **argv)
@@ -281,5 +293,75 @@ static int _nib_route(int argc, char **argv)
     }
     return 0;
 }
+
+#if GNRC_IPV6_NIB_CONF_MULTIHOP_P6C
+static void _usage_nib_abr(char **argv)
+{
+#if GNRC_IPV6_NIB_CONF_6LBR
+    printf("usage: %s %s [show|add|del|help]\n", argv[0], argv[1]);
+    printf("       %s %s add <ipv6 global addr>\n",
+           argv[0], argv[1]);
+    printf("       %s %s del <ipv6 global addr>\n", argv[0], argv[1]);
+#else   /* GNRC_IPV6_NIB_CONF_6LBR */
+    printf("usage: %s %s [show|help]\n", argv[0], argv[1]);
+#endif  /* GNRC_IPV6_NIB_CONF_6LBR */
+    printf("       %s %s show\n", argv[0], argv[1]);
+}
+
+static int _nib_abr(int argc, char **argv)
+{
+    if ((argc == 2) || (strcmp(argv[2], "show") == 0)) {
+        gnrc_ipv6_nib_abr_t entry;
+        void *state = NULL;
+
+        while (gnrc_ipv6_nib_abr_iter(&state, &entry)) {
+            gnrc_ipv6_nib_abr_print(&entry);
+        }
+    }
+    else if ((argc > 2) && (strcmp(argv[2], "help") == 0)) {
+        _usage_nib_abr(argv);
+    }
+#if GNRC_IPV6_NIB_CONF_6LBR
+    else if ((argc > 3) && (strcmp(argv[2], "del") == 0)) {
+        ipv6_addr_t addr = IPV6_ADDR_UNSPECIFIED;
+
+        if (ipv6_addr_from_str(&addr, argv[3]) == NULL) {
+            _usage_nib_abr(argv);
+            return 1;
+        }
+        gnrc_ipv6_nib_abr_del(&addr);
+    }
+    else if ((argc > 3) && (strcmp(argv[2], "add") == 0)) {
+        gnrc_netif_t *netif;
+        ipv6_addr_t addr = IPV6_ADDR_UNSPECIFIED;
+
+        if (ipv6_addr_from_str(&addr, argv[3]) == NULL) {
+            _usage_nib_abr(argv);
+            return 1;
+        }
+        /* check addr */
+        if (ipv6_addr_is_link_local(&addr)) {
+            printf("address %s must be global\n", argv[3]);
+            return 1;
+        }
+        if (!(((netif = gnrc_netif_get_by_ipv6_addr(&addr)) != NULL) &&
+              gnrc_netif_is_6lbr(netif))) {
+            printf("address %s is not assigned to a 6LBR interface\n",
+                   argv[3]);
+            return 1;
+        }
+        if (gnrc_ipv6_nib_abr_add(&addr) < 0) {
+            printf("unable to add border router %s\n", argv[3]);
+            return 1;
+        }
+    }
+#endif  /* GNRC_IPV6_NIB_CONF_6LBR */
+    else {
+        _usage_nib_abr(argv);
+        return 1;
+    }
+    return 0;
+}
+#endif  /* GNRC_IPV6_NIB_CONF_MULTIHOP_P6C */
 
 /** @} */

--- a/tests/unittests/tests-gnrc_ipv6_nib/tests-gnrc_ipv6_nib-abr.c
+++ b/tests/unittests/tests-gnrc_ipv6_nib/tests-gnrc_ipv6_nib-abr.c
@@ -46,14 +46,18 @@ static void set_up(void)
  */
 static void test_nib_abr_add__ENOMEM(void)
 {
+    void *iter_state = NULL;
     ipv6_addr_t addr = { .u64 = { { .u8 = GLOBAL_PREFIX },
                                 { .u64 = TEST_UINT64 } } };
+    gnrc_ipv6_nib_abr_t abr;
 
     for (unsigned i = 0; i < GNRC_IPV6_NIB_ABR_NUMOF; i++) {
         TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_abr_add(&addr));
         addr.u16[0].u16++;
+        TEST_ASSERT(gnrc_ipv6_nib_abr_iter(&iter_state, &abr));
     }
     TEST_ASSERT_EQUAL_INT(-ENOMEM, gnrc_ipv6_nib_abr_add(&addr));
+    TEST_ASSERT(!gnrc_ipv6_nib_abr_iter(&iter_state, &abr));
 }
 
 /*
@@ -63,14 +67,19 @@ static void test_nib_abr_add__ENOMEM(void)
  */
 static void test_nib_abr_add__success(void)
 {
+    void *iter_state = NULL;
     ipv6_addr_t addr = { .u64 = { { .u8 = GLOBAL_PREFIX },
                                 { .u64 = TEST_UINT64 } } };
+    gnrc_ipv6_nib_abr_t abr;
 
     for (unsigned i = 0; i < GNRC_IPV6_NIB_ABR_NUMOF; i++) {
         addr.u16[0].u16++;
         TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_abr_add(&addr));
+        TEST_ASSERT(gnrc_ipv6_nib_abr_iter(&iter_state, &abr));
+        TEST_ASSERT(memcmp(&abr.addr, &addr, sizeof(addr)) == 0);
     }
     TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_abr_add(&addr));
+    TEST_ASSERT(!gnrc_ipv6_nib_abr_iter(&iter_state, &abr));
 }
 
 /*
@@ -79,11 +88,16 @@ static void test_nib_abr_add__success(void)
  */
 static void test_nib_abr_del__success(void)
 {
+    void *iter_state = NULL;
     ipv6_addr_t addr = { .u64 = { { .u8 = GLOBAL_PREFIX },
                                   { .u64 = TEST_UINT64 } } };
+    gnrc_ipv6_nib_abr_t abr;
 
     TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_abr_add(&addr));
+    TEST_ASSERT(gnrc_ipv6_nib_abr_iter(&iter_state, &abr));
+    TEST_ASSERT(!gnrc_ipv6_nib_abr_iter(&iter_state, &abr));
     gnrc_ipv6_nib_abr_del(&addr);
+    TEST_ASSERT(!gnrc_ipv6_nib_abr_iter(&iter_state, &abr));
 }
 
 Test *tests_gnrc_ipv6_nib_abr_tests(void)
@@ -92,7 +106,7 @@ Test *tests_gnrc_ipv6_nib_abr_tests(void)
         new_TestFixture(test_nib_abr_add__ENOMEM),
         new_TestFixture(test_nib_abr_add__success),
         new_TestFixture(test_nib_abr_del__success),
-        /* gnrc_ipv6_nib_pl_iter() is tested during all the tests above */
+        /* gnrc_ipv6_nib_abr_iter() is tested during all the tests above */
     };
 
     EMB_UNIT_TESTCALLER(tests, set_up, NULL,


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Adds functionality to list and edit authoritative border router list. This might be useful for later extensions of 6Lo-ND.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Run two 6Lo-capable nodes with `gnrc_border_router` and `gnrc_networking`. Once the network bootstrapped the `nib abr` should show the current border router, its version and its lifetime in minutes.

Also try without `uhcpd` to manually bootstrap your network with `nib abr add` (hint you need to add a global address to the WPAN interface).

Also run the `unittests`.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
