### PR TITLE
[BUG] testrunner matching local echo

### DIFF
--- a/dist/pythonlibs/testrunner/spawn.py
+++ b/dist/pythonlibs/testrunner/spawn.py
@@ -37,7 +37,7 @@ def find_exc_origin(exc_info):
 
 def setup_child(timeout=10, spawnclass=pexpect.spawnu, env=None, logfile=None):
     child = spawnclass("make term", env=env, timeout=timeout,
-                       codec_errors='replace')
+                       codec_errors='replace', echo=False)
 
     # on many platforms, the termprog needs a short while to be ready...
     time.sleep(MAKE_TERM_STARTED_DELAY)


### PR DESCRIPTION
### Contribution description

When local echo is enabled, pexpect will also match on send lines to the
node. So could think a node is echoing when it is only seeing the sent
message.
The sent messages are still written to `logfile` but now only once.

This may show issues with our current tests implementation that expected
this behavior.


### Testing procedure

I included a test commit to show the fixed issue.
Sending a string to `hello-world` and matching on the same string works in master even if the nodes does not echo anything.


When running the test commit alone, it will fail with a `RuntimeError` to show the erroneous behavior.
With the `disable local echo` fix, the test passes.


```
# both with native and a board to show it is not a `pyterm` issue

BOARD=native make -C examples/hello-world flash test
BOARD=samr21-xpro make -C examples/hello-world flash test
```


EDIT: it can now be tested with https://github.com/RIOT-OS/RIOT/pull/11094 alone.

I will retry all our test suite on this:

* [x] `native` after running `dist/tools/tapsetup/tapsetup`
  + Only have the same error as in master
    - tests/gnrc_ipv6_ext No root permission
    - tests/gnrc_rpl_srh No root permission
* [x] `samr21-xpro`
  + Only have the same error as in master
    - tests/gnrc_ipv6_ext No root permission
    - tests/gnrc_rpl_srh No root permission
    - tests/pkg_fatfs_vfs It needs a special initial configuration


### Issues/PRs references

Found while implementing https://github.com/RIOT-OS/RIOT/pull/10949 based on `testrunner` handling.

Depends on ~https://github.com/RIOT-OS/RIOT/pull/11064~
Depends on https://github.com/RIOT-OS/RIOT/pull/11086 Silencing codacy for assert
Handling `make term` without local echo.