### PR TITLE
gnrc_sixlowpan_iphc: fix _compressible() [backport 2019.01]

### DIFF
--- a/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
@@ -647,8 +647,8 @@ static inline bool _compressible(gnrc_pktsnip_t *hdr)
         case GNRC_NETTYPE_IPV6:
 #if defined(MODULE_GNRC_SIXLOWPAN_IPHC_NHC) && defined(MODULE_GNRC_UDP)
         case GNRC_NETTYPE_UDP:
-            return true;
 #endif
+            return true;
         default:
             return false;
     }
@@ -705,6 +705,9 @@ void gnrc_sixlowpan_iphc_send(gnrc_pktsnip_t *pkt, void *ctx, unsigned page)
         dispatch = ptr; /* use dispatch as temporary point for prev */
         ptr = ptr->next;
     }
+    /* there should be at least one compressible header in `pkt`, otherwise this
+     * function should not be called */
+    assert(dispatch_size > 0);
     ipv6_hdr = pkt->next->data;
     dispatch = gnrc_pktbuf_add(NULL, NULL, dispatch_size,
                                GNRC_NETTYPE_SIXLOWPAN);


### PR DESCRIPTION
# Backport of #10950



<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
When either `gnrc_sixlowpan_iphc_nhc` or `gnrc_udp` is not compiled in `_compressible()` never returns `true`. This causes the `dispatch` snip in `gnrc_sixlowpan_iphc_send()` to be of length 0, meaning `dispatch->data` is `NULL`, causing possible crashes when trying to send IPv6 packets over 6LoWPAN without NHC or UDP.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`tests/gnrc_tcp_server` and `tests/gnrc_tcp_client` should work on a 6Lo-based board.
`examples/gnrc_networking` should still be able to exchange UDP packets. Those packets should be compressed with NHC (check with sniffer).
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Fixes #10947 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
