### PR TITLE
pkg: add pkg libbase58

### DIFF
--- a/pkg/libbase58/Makefile
+++ b/pkg/libbase58/Makefile
@@ -1,0 +1,11 @@
+PKG_NAME=libbase58
+PKG_URL=https://github.com/bitcoin/libbase58
+PKG_VERSION=d7591398443987e84d19833d86634c6ffe8b0796
+PKG_LICENSE=MIT
+
+include $(RIOTBASE)/pkg/pkg.mk
+
+.PHONY: all
+
+all:
+	"$(MAKE)" -C $(PKG_BUILDDIR) -f $(CURDIR)/Makefile.$(PKG_NAME)

--- a/pkg/libbase58/Makefile.dep
+++ b/pkg/libbase58/Makefile.dep
@@ -1,0 +1,1 @@
+USEMODULE += posix_headers

--- a/pkg/libbase58/Makefile.include
+++ b/pkg/libbase58/Makefile.include
@@ -1,0 +1,1 @@
+INCLUDES += -I$(PKGDIRBASE)/libbase58

--- a/pkg/libbase58/Makefile.libbase58
+++ b/pkg/libbase58/Makefile.libbase58
@@ -1,0 +1,5 @@
+SRC := base58.c
+
+CFLAGS += -Wno-unused-parameter
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/libbase58/doc.txt
+++ b/pkg/libbase58/doc.txt
@@ -1,0 +1,8 @@
+/**
+ * @defgroup pkg_libbase58  JSON parser library
+ * @ingroup  pkg
+ * @ingroup  sys_serialization
+ * @brief    C library for Bitcoin's base58 encoding
+ *
+ * @see      https://github.com/bitcoin/libbase58
+ */

--- a/tests/pkg_libbase58/Makefile
+++ b/tests/pkg_libbase58/Makefile
@@ -1,0 +1,6 @@
+include ../Makefile.tests_common
+
+USEMODULE += embunit
+USEPKG += libbase58
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/pkg_libbase58/main.c
+++ b/tests/pkg_libbase58/main.c
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2019 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup    tests
+ * @{
+ *
+ * @file
+ * @brief      Tests for pkg libbase58
+ *
+ * @author     Kaspar Schleiser <kaspar@schleiser.de>
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+#include "libbase58.h"
+#include "embUnit.h"
+
+static void test_libbase58_01(void)
+{
+    const char source[] = "base 58 test string";
+    const char encoded[] = "2NVj5VV1YMqTHot6N2xPBQnbqnUF";
+    char decoded[sizeof(source)] = {0};
+    char target[64] = {0};
+    size_t target_len = sizeof(target);
+    size_t decoded_len = sizeof(decoded);
+
+    /* testing encoding */
+    b58enc(target, &target_len, source, sizeof(source));
+
+    TEST_ASSERT_EQUAL_INT(target_len, sizeof(encoded));
+    TEST_ASSERT(strcmp(target, encoded) == 0);
+
+    /* testing decoding */
+    b58tobin(decoded, &decoded_len, target, target_len - 1);
+
+    TEST_ASSERT(memcmp(source, decoded, sizeof(source)) == 0);
+}
+
+Test *tests_libbase58(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_libbase58_01),
+    };
+
+    EMB_UNIT_TESTCALLER(libbase58_tests, NULL, NULL, fixtures);
+    return (Test *)&libbase58_tests;
+}
+
+int main(void)
+{
+    TESTS_START();
+    TESTS_RUN(tests_libbase58());
+    TESTS_END();
+    return 0;
+}

--- a/tests/pkg_libbase58/tests/01-run.py
+++ b/tests/pkg_libbase58/tests/01-run.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect(u"OK \\([0-9]+ tests\\)")
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc, timeout=120))


### PR DESCRIPTION
### Contribution description

This PR adds libbase58 + test.

From Wikipedia:

"Base58 is a group of binary-to-text encoding schemes used to represent large integers as alphanumeric text, introduced by Satoshi Nakamoto for use with Bitcoin."

I use it to generate human-readable sensor node IDs.

### Testing procedure

PR includes test application testing basic operation.

### Issues/PRs references

none