### PR TITLE
drivers: adcxx1c, ads101x: undef I2C before redefining it

### DIFF
--- a/drivers/adcxx1c/adcxx1c.c
+++ b/drivers/adcxx1c/adcxx1c.c
@@ -27,6 +27,7 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
+#undef I2C
 #define I2C (dev->params.i2c)
 #define ADDR (dev->params.addr)
 

--- a/drivers/ads101x/ads101x.c
+++ b/drivers/ads101x/ads101x.c
@@ -35,6 +35,7 @@
 #define ADS101X_READ_DELAY (8 * US_PER_MS)    /* Compatible with 128SPS */
 #endif
 
+#undef I2C
 #define I2C (dev->params.i2c)
 #define ADDR (dev->params.addr)
 


### PR DESCRIPTION
### Contribution description

I2C is used by cc26x0 periph_conf.h, leading to [name clash](https://gist.github.com/85695ed116855cc137ba7fedf8bea9c5).
This PR fixes the name clash by undefining the clashing macro before defining it.

I'm not sure what's the best solution here...

### Testing procedure

Successful compilation should be fine, maybe run test.

### Issues/PRs references

Clash found in #10955.