### PR TITLE
cpu/stm32_common: fix UART documentation

### DIFF
--- a/cpu/stm32_common/include/periph_cpu_common.h
+++ b/cpu/stm32_common/include/periph_cpu_common.h
@@ -370,6 +370,7 @@ typedef enum {
     STM32_LPUART,           /**< STM32 Low-power UART (LPUART) module type */
 } uart_type_t;
 
+#ifndef DOXYGEN
 /**
  * @brief   Invalid UART mode mask
  *
@@ -419,6 +420,7 @@ typedef enum {
    UART_STOP_BITS_2 = USART_CR2_STOP_1,   /**< 2 stop bits */
 } uart_stop_bits_t;
 /** @} */
+#endif /* ndef DOXYGEN */
 
 /**
  * @brief   Structure for UART configuration data


### PR DESCRIPTION
### Contribution description

Don't include overridden typedefs into doxygen as otherwise,
they'll appear twice.

### Testing procedure

`make doc`

### Issues/PRs references

Fixes #10743