### PR TITLE
sys/app_metadata: Add a way to print application metadata

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -312,6 +312,7 @@ endif
 BOARDDEF := $(shell echo $(BOARD) | tr 'a-z' 'A-Z' | tr '-' '_')
 CPUDEF := $(shell echo $(CPU) | tr 'a-z' 'A-Z' | tr '-' '_')
 MCUDEF := $(shell echo $(MCU) | tr 'a-z' 'A-Z' | tr '-' '_')
+CFLAGS += -DRIOT_APPLICATION=\"$(APPLICATION)\"
 CFLAGS += -DBOARD_$(BOARDDEF)=\"$(BOARD)\" -DRIOT_BOARD=BOARD_$(BOARDDEF)
 CFLAGS += -DCPU_$(CPUDEF)=\"$(CPU)\" -DRIOT_CPU=CPU_$(CPUDEF)
 CFLAGS += -DMCU_$(MCUDEF)=\"$(MCU)\" -DRIOT_MCU=MCU_$(MCUDEF)

--- a/sys/Makefile.include
+++ b/sys/Makefile.include
@@ -32,7 +32,10 @@ ifneq (,$(filter oneway_malloc,$(USEMODULE)))
 endif
 
 ifneq (,$(filter app_metadata,$(USEMODULE)))
-  # Overwrite the interface version
+  # Overwrite the application shell formats.
+  # This is an optional macro that can be used to coordinate
+  # standardized shell formats, as an example it can point to an RDM
+  # that specifies semantics.
   ifdef APP_SHELL_FMT
     CFLAGS += -DAPP_SHELL_FMT=\"$(APP_SHELL_FMT)\"
   endif

--- a/sys/Makefile.include
+++ b/sys/Makefile.include
@@ -31,6 +31,13 @@ ifneq (,$(filter oneway_malloc,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/sys/oneway-malloc/include
 endif
 
+ifneq (,$(filter app_metadata,$(USEMODULE)))
+  # Overwrite the interface version
+  ifdef APP_SHELL_FMT
+    CFLAGS += -DAPP_SHELL_FMT=\"$(APP_SHELL_FMT)\"
+  endif
+endif
+
 ifneq (,$(filter vfs,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/sys/posix/include
 endif

--- a/sys/app_metadata/Makefile
+++ b/sys/app_metadata/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/app_metadata/app_metadata.c
+++ b/sys/app_metadata/app_metadata.c
@@ -1,0 +1,31 @@
+/**
+Copyright (C) 2019, HAW Hamburg.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ * @ingroup sys_app_metadata
+ * @{
+ * @file
+ * @brief   Prints application metadata such as BOARD, CPU, OS_VERSION.
+ * @author  Kevin Weiss <kevin.weiss@haw-hamburg.de>
+ * @}
+ */
+
+#include <stdio.h>
+
+void app_metadata_print_json(void)
+{
+    puts("{\"cmd\": \"app_metadata_print_json()\"}");
+    printf("{\"data\": {\"APP_NAME\": \"%s\"}}\n", RIOT_APPLICATION);
+    printf("{\"data\": {\"BOARD\": \"%s\"}}\n", RIOT_BOARD);
+    printf("{\"data\": {\"CPU\": \"%s\"}}\n", RIOT_CPU);
+#ifdef APP_SHELL_FMT
+    printf("{\"data\": {\"APP_SHELL_FMT\": \"%s\"}}\n", APP_SHELL_FMT);
+#endif
+    printf("{\"data\": {\"MCU\": \"%s\"}}\n", RIOT_MCU);
+    printf("{\"data\": {\"OS_VERSION\": \"%s\"}}\n", RIOT_VERSION);
+
+    printf("{\"result\": \"SUCCESS\"}\n");
+}

--- a/sys/include/app_metadata.h
+++ b/sys/include/app_metadata.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2019 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+
+/**
+ * @defgroup    sys_app_metadata app_metadata
+ * @ingroup     sys
+ * @brief       Module for the application metadata
+ * @{
+ *
+ * @author      Kevin Weiss <kevin.weiss@haw-hamburg.de>
+ */
+
+#ifndef APP_METADATA_H
+#define APP_METADATA_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef DOXYGEN
+/**
+ * @brief   Application Shell Format is an optional application metadata
+ *          parameter intended to help coordinate any specific formats that
+ *          are being used.
+ *
+ * @details An example is if the application is following a specific format,
+ *          say semantics defined in a RDM or schema, that could be specified
+ *          by adding APP_SHELL_FMT="RDM001_v1", that would inform anything
+ *          using the shell that the formatting should follow what is dictated.
+ *          This define is only for documentation, to use the APP_SHELL_FMT
+ *          add it to the application makefile with APP_SHELL_FMT=<your value>
+ *          or when calling make such as `APP_SHELL_FMT=<your value> make flash`
+ */
+#define APP_SHELL_FMT
+#endif
+
+/**
+ * @brief   Prints the application metadata in json.
+ *
+ * @details Examples of application metadata are BOARD, OS_VERSION, APP_NAME...
+ */
+void app_metadata_print_json(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* APP_METADATA_H */
+/** @} */

--- a/sys/include/app_metadata.h
+++ b/sys/include/app_metadata.h
@@ -33,9 +33,9 @@ extern "C" {
  *          say semantics defined in a RDM or schema, that could be specified
  *          by adding APP_SHELL_FMT="RDM001_v1", that would inform anything
  *          using the shell that the formatting should follow what is dictated.
- *          This define is only for documentation, to use the APP_SHELL_FMT
- *          add it to the application makefile with APP_SHELL_FMT=<your value>
- *          or when calling make such as `APP_SHELL_FMT=<your value> make flash`
+ * @note    This define is only for documentation, to use the APP_SHELL_FMT
+ *          add it to the application makefile with APP_SHELL_FMT=your_value
+ *          or when calling make such as `APP_SHELL_FMT=your_value make flash`
  */
 #define APP_SHELL_FMT
 #endif

--- a/sys/shell/commands/Makefile
+++ b/sys/shell/commands/Makefile
@@ -2,6 +2,9 @@ MODULE = shell_commands
 
 SRC = shell_commands.c sc_sys.c
 
+ifneq (,$(filter app_metadata,$(USEMODULE)))
+  SRC += sc_app_metadata.c
+endif
 ifneq (,$(filter mci,$(USEMODULE)))
   SRC += sc_disk.c
 endif

--- a/sys/shell/commands/sc_app_metadata.c
+++ b/sys/shell/commands/sc_app_metadata.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2019 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys_shell_commands
+ * @{
+ *
+ * @file
+ * @brief       Shell command for getting application metadata.
+
+ *
+ * @author      Kevin Weiss <kevin.weiss@haw-hamburg.de>
+ * @}
+ */
+
+#include "app_metadata.h"
+
+int _app_metadata_handler(int argc, char **argv)
+{
+    (void) argc;
+    (void) argv;
+    app_metadata_print_json();
+    return 0;
+}

--- a/sys/shell/commands/shell_commands.c
+++ b/sys/shell/commands/shell_commands.c
@@ -141,6 +141,10 @@ extern int _can_handler(int argc, char **argv);
 extern int _cord_ep_handler(int argc, char **argv);
 #endif
 
+#ifdef MODULE_APP_METADATA
+extern int _app_metadata_handler(int argc, char **argv);
+#endif
+
 const shell_command_t _shell_command_list[] = {
     {"reboot", "Reboot the node", _reboot_handler},
 #ifdef MODULE_CONFIG
@@ -230,6 +234,9 @@ const shell_command_t _shell_command_list[] = {
 #endif
 #ifdef MODULE_CORD_EP
     {"cord_ep", "Resource directory endpoint commands", _cord_ep_handler },
+#endif
+#ifdef MODULE_APP_METADATA
+    {"app_metadata", "Returns application metadata", _app_metadata_handler },
 #endif
     {NULL, NULL, NULL}
 };

--- a/tests/shell/Makefile
+++ b/tests/shell/Makefile
@@ -1,6 +1,7 @@
 DEVELHELP=0
 include ../Makefile.tests_common
 
+USEMODULE += app_metadata
 USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += ps
@@ -10,6 +11,11 @@ DISABLE_MODULE += auto_init
 # chronos is missing a getchar implementation
 BOARD_BLACKLIST += chronos
 
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove \
+                             arduino-uno
+
 TEST_ON_CI_WHITELIST += all
+
+APP_SHELL_FMT ?= NONE
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/shell/tests/01-run.py
+++ b/tests/shell/tests/01-run.py
@@ -17,7 +17,8 @@ EXPECTED_HELP = (
     'end_test             ends a test',
     'echo                 prints the input command',
     'reboot               Reboot the node',
-    'ps                   Prints information about running threads.'
+    'ps                   Prints information about running threads.',
+    'app_metadata         Returns application metadata'
 )
 
 EXPECTED_PS = (


### PR DESCRIPTION
### Contribution description
This PR adds a command to print a number of useful application parameters such as BOARD, MCU, OS_VERSION, APP_NAME, etc.
The print function prints in json as it is human readable (enough) and machine readable/easy to format.
It also adds an optional parameter APP_SHELL_FMT (application shell format) intended to help coordinate any specific formatting that the application is following.  It can be specified in the makefile or in commandline but if not specified it doesn't print anything.

### Testing procedure
run `BOARD=<???> make flash term -C tests/shell/` or `APP_SHELL_FMT="test" BOARD=<???> make flash term -C tests/shell/` or add APP_SHELL_FMT="test" in the makefile.
Then in the shell check the response when calling `app_metadata`
Or just call `make flash test -C tests/shell/`

### Issues/PRs references
None
