### PR TITLE
gnrc_sixlowpan: move gnrc_ipv6 dependency to gnrc_sixlowpan_iphc

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -207,13 +207,13 @@ ifneq (,$(filter gnrc_sixlowpan_frag,$(USEMODULE)))
 endif
 
 ifneq (,$(filter gnrc_sixlowpan_iphc,$(USEMODULE)))
+  USEMODULE += gnrc_ipv6
   USEMODULE += gnrc_sixlowpan
   USEMODULE += gnrc_sixlowpan_ctx
   USEMODULE += gnrc_sixlowpan_iphc_nhc
 endif
 
 ifneq (,$(filter gnrc_sixlowpan,$(USEMODULE)))
-  USEMODULE += gnrc_ipv6
   USEMODULE += sixlowpan
 endif
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
@cgundogan  and I put some effort into making 6LoWPAN work without IPv6; except for when used with the IPv6 header compression of course. This is why `gnrc_ipv6` is only really *required* by `gnrc_sixlowpan_iphc` now.

With this change the `gnrc_ipv6` dependency is moved from the `gnrc_sixlowpan` module to the `gnrc_sixlowpan_iphc` module.


<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
- All applications including `gnrc_sixlowpan` should still work.
- `tests/gnrc_sixlowpan_frag` should still compile and pass (and not auto-include `gnrc_ipv6` anymore).
   - It should also still work with USEMODULE=gnrc_ipv6
- `examples/gnrc_networking` should still compile for 6Lo-based boards (e.g. `iotlab-m3` or `samr21-xpro`) and `ping6` to a link-local address should still work with the following patch:
   ```diff
   diff --git a/examples/gnrc_networking/Makefile b/examples/gnrc_networking/Makefile
   index 628b9c9..fa550d5 100644
   --- a/examples/gnrc_networking/Makefile
   +++ b/examples/gnrc_networking/Makefile
   @@ -24,7 +24,7 @@ USEMODULE += auto_init_gnrc_netif
    # Activate ICMPv6 error messages
    USEMODULE += gnrc_icmpv6_error
    # Specify the mandatory networking modules for IPv6 and UDP
   -USEMODULE += gnrc_ipv6_router_default
   +USEMODULE += gnrc_sixlowpan_frag
    USEMODULE += gnrc_udp
    # Add a routing protocol
    USEMODULE += gnrc_rpl
   ```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
