### PR TITLE
gnrc_tcp: change and verify addrs in use

### DIFF
--- a/tests/gnrc_tcp_client/Makefile
+++ b/tests/gnrc_tcp_client/Makefile
@@ -7,8 +7,9 @@ ifeq (native,$(BOARD))
   PORT ?= tap1
 endif
 
-TCP_TARGET_ADDR ?= fe80::affe%5
-TCP_TARGET_PORT ?= 80
+TCP_SERVER_ADDR ?= 2001:db8::affe:0001
+TCP_SERVER_PORT ?= 80
+TCP_CLIENT_ADDR ?= 2001:db8::affe:0002
 TCP_TEST_CYCLES ?= 3
 
 # Mark Boards with insufficient memory
@@ -21,15 +22,21 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon arduino-duemilanove arduino-mega2560 \
                              waspmote-pro wsn430-v1_3b wsn430-v1_4 yunjia-nrf51822 z1
 
 # Target Address, Target Port and number of Test Cycles
-CFLAGS += -DTARGET_ADDR=\"$(TCP_TARGET_ADDR)\"
-CFLAGS += -DTARGET_PORT=$(TCP_TARGET_PORT)
+CFLAGS += -DSERVER_ADDR=\"$(TCP_SERVER_ADDR)\"
+CFLAGS += -DSERVER_PORT=$(TCP_SERVER_PORT)
+CFLAGS += -DCLIENT_ADDR=\"$(TCP_CLIENT_ADDR)\"
 CFLAGS += -DCYCLES=$(TCP_TEST_CYCLES)
 CFLAGS += -DGNRC_NETIF_IPV6_GROUPS_NUMOF=3
+CFLAGS += -DGNRC_IPV6_NIB_CONF_ARSM=1
+CFLAGS += -DGNRC_IPV6_NIB_CONF_QUEUE_PKT=1
 
 # Modules to include
 USEMODULE += gnrc_netdev_default
 USEMODULE += auto_init_gnrc_netif
 USEMODULE += gnrc_ipv6_default
 USEMODULE += gnrc_tcp
+
+# include this for IP address manipulation
+USEMODULE += shell_commands
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/gnrc_tcp_server/Makefile
+++ b/tests/gnrc_tcp_server/Makefile
@@ -7,8 +7,8 @@ ifeq (native,$(BOARD))
   PORT ?= tap0
 endif
 
-TCP_LOCAL_ADDR ?= fe80::affe
-TCP_LOCAL_PORT ?= 80
+TCP_SERVER_ADDR ?= 2001:db8::affe:0001
+TCP_SERVER_PORT ?= 80
 TCP_TEST_CYCLES ?= 3
 
 # Mark Boards with insufficient memory
@@ -20,14 +20,13 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon arduino-duemilanove arduino-mega2560 \
                              saml10-xpro saml11-xpro sb-430 sb-430h stm32f0discovery telosb \
                              waspmote-pro wsn430-v1_3b wsn430-v1_4 yunjia-nrf51822 z1
 
-# This has to be the absolute path to the RIOT base directory:
-RIOTBASE ?= $(CURDIR)/../..
-
 # Local Address, Local Port and number of Test Cycles
-CFLAGS += -DLOCAL_ADDR=\"$(TCP_LOCAL_ADDR)\"
-CFLAGS += -DLOCAL_PORT=$(TCP_LOCAL_PORT)
+CFLAGS += -DSERVER_ADDR=\"$(TCP_SERVER_ADDR)\"
+CFLAGS += -DSERVER_PORT=$(TCP_SERVER_PORT)
 CFLAGS += -DCYCLES=$(TCP_TEST_CYCLES)
 CFLAGS += -DGNRC_NETIF_IPV6_GROUPS_NUMOF=3
+CFLAGS += -DGNRC_IPV6_NIB_CONF_ARSM=1
+CFLAGS += -DGNRC_IPV6_NIB_CONF_QUEUE_PKT=1
 
 # Modules to include
 USEMODULE += gnrc_netdev_default


### PR DESCRIPTION
### Contribution description
The existing gnrc_tcp test are currently flawed, because they use hard coded link-local ip addresses with
attached device identifiers. This causes problems with different platforms because the device identifier
depends on the netdev pid, the netdev pid however depends on the platform.

By using the Prefix 2001:db8::/32, no device identifier is required and the problem should go away.
