### PR TITLE
Documentation: don't include overridden typedefs

### DIFF
--- a/cpu/atmega_common/include/periph_cpu_common.h
+++ b/cpu/atmega_common/include/periph_cpu_common.h
@@ -56,6 +56,7 @@ typedef uint8_t gpio_t;
  */
 #define GPIO_PIN(x, y)          ((x << 4) | y)
 
+#ifndef DOXYGEN
 /**
  * @brief   Override the GPIO flanks
  *
@@ -73,6 +74,7 @@ typedef enum {
     GPIO_RISING,       /**< emit interrupt on rising flank */
 } gpio_flank_t;
 /** @} */
+#endif /* ndef DOXYGEN */
 
 /**
  * @brief   Use some common SPI functions

--- a/cpu/atmega_common/include/periph_cpu_common.h
+++ b/cpu/atmega_common/include/periph_cpu_common.h
@@ -84,6 +84,7 @@ typedef enum {
 #define PERIPH_SPI_NEEDS_TRANSFER_REGS
 /** @} */
 
+#ifndef DOXYGEN
 /**
  * @brief   SPI mode select macro
  *
@@ -131,6 +132,7 @@ typedef enum {
     SPI_CLK_10MHZ  = SPI_CLK_SEL(1, 0, 0)       /**< 16/2   -> 8MHz */
 } spi_clk_t;
 /** @} */
+#endif /* ndef DOXYGEN */
 
 /**
  * @brief  Bitmasks indicating which are the possible dividers for a timer

--- a/cpu/cc2538/include/periph_cpu.h
+++ b/cpu/cc2538/include/periph_cpu.h
@@ -106,6 +106,7 @@ void gpio_init_mux(gpio_t pin, uint8_t over, uint8_t sel, uint8_t func);
 #define PERIPH_I2C_NEED_WRITE_REGS
 /** @} */
 
+#ifndef DOXYGEN
 /**
  * @name   Override I2C clock speed values
  * @{
@@ -119,6 +120,8 @@ typedef enum {
     I2C_SPEED_HIGH      = 0x03,     /**< not supported */
 } i2c_speed_t;
 /** @} */
+#endif /* ndef DOXYGEN */
+
 /**
  * @brief   I2C configuration options
  */

--- a/cpu/cc2538/include/periph_cpu.h
+++ b/cpu/cc2538/include/periph_cpu.h
@@ -206,7 +206,6 @@ typedef enum {
    UART_STOP_BITS_2 = UART_LCRH_STP2,     /**< 2 stop bits */
 } uart_stop_bits_t;
 /** @} */
-#endif /* DOXYGEN */
 
 /**
  * @name   Override SPI mode settings
@@ -234,6 +233,7 @@ typedef enum {
     SPI_CLK_10MHZ  = 4      /**< drive the SPI bus with 10MHz */
 } spi_clk_t;
 /** @} */
+#endif /* ndef DOXYGEN */
 
 /**
  * @brief   Datafields for static SPI clock configuration values

--- a/cpu/cc2538/include/periph_cpu.h
+++ b/cpu/cc2538/include/periph_cpu.h
@@ -138,6 +138,7 @@ typedef struct {
 #define PERIPH_SPI_NEEDS_TRANSFER_REGS
 /** @} */
 
+#ifndef DOXYGEN
 /**
  * @name   Override the default GPIO mode settings
  * @{
@@ -153,7 +154,7 @@ typedef enum {
     GPIO_OD_PU      = (0xff)                            /**< not supported */
 } gpio_mode_t;
 /** @} */
-
+#endif /* ndef DOXYGEN */
 
 /**
  * @name   UART device configuration

--- a/cpu/cc2538/include/periph_cpu.h
+++ b/cpu/cc2538/include/periph_cpu.h
@@ -284,6 +284,7 @@ typedef struct {
     uint_fast8_t cfg;   /**< timer config word */
 } timer_conf_t;
 
+#ifndef DOXYGEN
 /**
  * @name   Override resolution options
  * @{
@@ -300,6 +301,7 @@ typedef enum {
     ADC_RES_16BIT =             (0xd00),    /**< not supported by hardware */
 } adc_res_t;
 /** @} */
+#endif /* ndef DOXYGEN */
 
 /**
  * @brief ADC configuration wrapper

--- a/cpu/esp32/include/periph_cpu.h
+++ b/cpu/esp32/include/periph_cpu.h
@@ -305,6 +305,7 @@ typedef enum {
  * @{
  */
 
+#ifndef DOXYGEN
 /**
  * @brief    Override I2C clock speed values
  *
@@ -320,6 +321,7 @@ typedef enum {
     I2C_SPEED_HIGH,         /**< not supported */
 } i2c_speed_t;
 /** @} */
+#endif /* ndef DOXYGEN */
 
 /**
  * @brief   I2C configuration structure type

--- a/cpu/esp32/include/periph_cpu.h
+++ b/cpu/esp32/include/periph_cpu.h
@@ -82,6 +82,7 @@ typedef unsigned int gpio_t;
 #define GPIO_PIN_NUMOF      (40)
 /** @} */
 
+#ifndef DOXYGEN
 /**
  * @brief   Override mode flank selection values
  *
@@ -117,6 +118,7 @@ typedef enum {
     GPIO_IN_OD_PU   /**< input and open-drain output */
 } gpio_mode_t;
 /** @} */
+#endif /* ndef DOXYGEN */
 /** @} */
 
 /**

--- a/cpu/esp32/include/periph_cpu.h
+++ b/cpu/esp32/include/periph_cpu.h
@@ -218,6 +218,8 @@ typedef enum {
  *
  * @{
  */
+
+#ifndef DOXYGEN
 /**
  * @brief   Possible ADC resolution settings
  */
@@ -233,6 +235,7 @@ typedef enum {
     ADC_RES_16BIT = 0xf3,   /**< ADC resolution: 16 bit is not supported */
 } adc_res_t;
 /** @} */
+#endif /* ndef DOXYGEN */
 
 /**
  * @brief  Number of ADC cahnnels that could be used at maximum

--- a/cpu/lm4f120/include/periph_cpu.h
+++ b/cpu/lm4f120/include/periph_cpu.h
@@ -142,6 +142,7 @@ typedef struct {
 #define PERIPH_SPI_NEEDS_INIT_CS 1
 /** @} */
 
+#ifndef DOXYGEN
 /**
  * @brief   Override SPI clock speed values
  * @{
@@ -169,6 +170,7 @@ typedef enum {
     SPI_MODE_3 = SSI_FRF_MOTO_MODE_0,       /**< CPOL=1, CPHA=1 */
 } spi_mode_t;
 /** @} */
+#endif /* ndef DOXYGEN */
 
 #ifdef __cplusplus
 }

--- a/cpu/lpc1768/include/periph_cpu.h
+++ b/cpu/lpc1768/include/periph_cpu.h
@@ -28,6 +28,7 @@
 extern "C" {
 #endif
 
+#ifndef DOXYGEN
 /**
  * @name   Override the default GPIO type
  * @{
@@ -62,6 +63,7 @@ typedef enum {
     GPIO_OD_PU = (PIN_DIR_OUT | PIN_MODE_OD | PIN_MODE_PU)  /**< open-drain output with pull-up */
 } gpio_mode_t;
 /** @} */
+#endif /* ndef DOXYGEN */
 
 /**
  * @brief   CPU provides own pm_off() function

--- a/cpu/lpc2387/include/periph_cpu.h
+++ b/cpu/lpc2387/include/periph_cpu.h
@@ -99,6 +99,7 @@ typedef struct {
 #define PERIPH_SPI_NEEDS_TRANSFER_REGS
 /* @} */
 
+#ifndef DOXYGEN
 /**
  * @brief   Override SPI clock speed values
  * @{
@@ -112,6 +113,7 @@ typedef enum {
     SPI_CLK_10MHZ  = 10000  /**< drive the SPI bus with 10MHz */
 } spi_clk_t;
 /** @} */
+#endif /* ndef DOXYGEN */
 
 /* @} */
 #ifdef __cplusplus

--- a/cpu/nrf51/include/periph_cpu.h
+++ b/cpu/nrf51/include/periph_cpu.h
@@ -40,6 +40,7 @@ extern "C" {
 #define SPI_MISOSEL         (dev(bus)->PSELMISO)
 /** @} */
 
+#ifndef DOXYGEN
 /**
  * @brief   Override I2C speed settings
  * @{
@@ -53,6 +54,7 @@ typedef enum {
     I2C_SPEED_HIGH      = 0x03,                         /**< not supported */
 } i2c_speed_t;
 /** @} */
+#endif /* ndef DOXYGEN */
 
 /**
  * @name    Use the shared I2C functions

--- a/cpu/nrf51/include/periph_cpu.h
+++ b/cpu/nrf51/include/periph_cpu.h
@@ -64,6 +64,7 @@ typedef enum {
 #define PERIPH_I2C_NEED_WRITE_REG
 /** @} */
 
+#ifndef DOXYGEN
 /**
  * @brief   Override ADC resolution values
  * @{
@@ -78,6 +79,7 @@ typedef enum {
     ADC_RES_16BIT = 0xf3    /**< ADC resolution: 16 bit (not supported) */
 } adc_res_t;
 /** @} */
+#endif /* ndef DOXYGEN */
 
 /**
  * @brief   I2C (TWI) configuration options

--- a/cpu/nrf52/include/periph_cpu.h
+++ b/cpu/nrf52/include/periph_cpu.h
@@ -84,6 +84,7 @@ typedef enum {
 /** @} */
 #endif /* ndef DOXYGEN */
 
+#ifndef DOXYGEN
 /**
  * @brief   Override I2C speed settings
  * @{
@@ -97,6 +98,7 @@ typedef enum {
     I2C_SPEED_HIGH      = 0xfd,                         /**< not supported */
 } i2c_speed_t;
 /** @} */
+#endif /* ndef DOXYGEN */
 
 /**
  * @brief   I2C (TWI) configuration options

--- a/cpu/nrf52/include/periph_cpu.h
+++ b/cpu/nrf52/include/periph_cpu.h
@@ -67,6 +67,7 @@ enum {
     NRF52_VDD  = 8,         /**< VDD, not useful if VDD is reference... */
 };
 
+#ifndef DOXYGEN
 /**
  * @brief   Override ADC resolution values
  * @{
@@ -81,6 +82,7 @@ typedef enum {
     ADC_RES_16BIT = 0xf2    /**< not supported by hardware */
 } adc_res_t;
 /** @} */
+#endif /* ndef DOXYGEN */
 
 /**
  * @brief   Override I2C speed settings

--- a/cpu/nrf5x_common/include/periph_cpu_common.h
+++ b/cpu/nrf5x_common/include/periph_cpu_common.h
@@ -128,6 +128,7 @@ typedef struct {
     uint8_t irqn;           /**< IRQ number of the timer device */
 } timer_conf_t;
 
+#ifndef DOXYGEN
 /**
  * @brief   Override SPI mode values
  * @{
@@ -154,6 +155,7 @@ typedef enum {
     SPI_CLK_10MHZ  = SPI_FREQUENCY_FREQUENCY_M8     /**< 10MHz */
 } spi_clk_t;
 /** @} */
+#endif /* ndef DOXYGEN */
 
 /**
  * @brief  SPI configuration values

--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -281,6 +281,7 @@ typedef enum {
     I2C_FLAG_RUN_STANDBY     = 0x1,    /**< run SERCOM in standby mode */
 } i2c_flag_t;
 
+#ifndef DOXYGEN
 /**
  * @name    Override I2C clock speed values
  * @{
@@ -294,6 +295,7 @@ typedef enum {
     I2C_SPEED_HIGH      = 3400000U,    /**< high speed mode:   ~3.4Mbit/s */
 } i2c_speed_t;
 /** @} */
+#endif /* ndef DOXYGEN */
 
 /**
  * @brief   I2C device configuration

--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -228,6 +228,7 @@ typedef enum {
     SPI_PAD_MOSI_0_SCK_3 = 0x3, /**< use pad 0 for MOSI, pad 3 for SCK */
 } spi_mosipad_t;
 
+#ifndef DOXYGEN
 /**
  * @brief   Override SPI modes
  * @{
@@ -254,6 +255,7 @@ typedef enum {
     SPI_CLK_10MHZ  = 10000000U  /**< drive the SPI bus with 10MHz */
 } spi_clk_t;
 /** @} */
+#endif /* ndef DOXYGEN */
 
 /**
  * @brief   SPI device configuration

--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -178,6 +178,7 @@ typedef enum {
     UART_FLAG_WAKEUP          = 0x2,    /**< wake from sleep on receive */
 } uart_flag_t;
 
+#ifndef DOXYGEN
 /**
  * @brief   Available SERCOM UART data size selections
  *
@@ -193,6 +194,7 @@ typedef enum {
     UART_DATA_BITS_8 = 0x0,   /**< 8 data bits */
 } uart_data_bits_t;
 /** @} */
+#endif /* ndef DOXYGEN */
 
 /**
  * @brief   UART device configuration

--- a/cpu/sam3/include/periph_cpu.h
+++ b/cpu/sam3/include/periph_cpu.h
@@ -149,6 +149,7 @@ typedef enum {
     GPIO_MUX_B = 1,         /**< alternate function B */
 } gpio_mux_t;
 
+#ifndef DOXYGEN
 /**
  * @brief   Override default SPI modes
  * @{
@@ -175,6 +176,7 @@ typedef enum {
     SPI_CLK_10MHZ  = (10000000)                     /**< 10MHz */
 } spi_clk_t;
 /** @} */
+#endif /* ndef DOXYGEN */
 
 #ifndef DOXYGEN
 /**

--- a/cpu/sam3/include/periph_cpu.h
+++ b/cpu/sam3/include/periph_cpu.h
@@ -176,6 +176,7 @@ typedef enum {
 } spi_clk_t;
 /** @} */
 
+#ifndef DOXYGEN
 /**
  * @brief   Override ADC resolution values
  * @{
@@ -190,6 +191,7 @@ typedef enum {
     ADC_RES_16BIT = 0x8                     /**< not applicable */
 } adc_res_t;
 /** @} */
+#endif /* ndef DOXYGEN */
 
 /**
  * @brief   Timer configuration data

--- a/cpu/samd21/include/periph_cpu.h
+++ b/cpu/samd21/include/periph_cpu.h
@@ -109,6 +109,7 @@ static inline int _sercom_id(SercomUsart *sercom)
     return ((((uint32_t)sercom) >> 10) & 0x7) - 2;
 }
 
+#ifndef DOXYGEN
 /**
  * @brief   Override the ADC resolution configuration
  * @{
@@ -123,6 +124,7 @@ typedef enum {
     ADC_RES_16BIT = 0xfd                        /**< not supported */
 } adc_res_t;
 /** @} */
+#endif /* ndef DOXYGEN */
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/saml1x/include/periph_cpu.h
+++ b/cpu/saml1x/include/periph_cpu.h
@@ -40,6 +40,7 @@ static const int8_t exti_config[1][32] = {
       5,  6,  7,  0, -1, -1,  1,  2,  3, 4, -1,  5, -1, -1, 6, 7},
 };
 
+#ifndef DOXYGEN
 #define HAVE_ADC_RES_T
 typedef enum {
     ADC_RES_6BIT  = 0xff,                       /**< not supported */
@@ -49,6 +50,7 @@ typedef enum {
     ADC_RES_14BIT = 0xfe,                       /**< not supported */
     ADC_RES_16BIT = 0xfd                        /**< not supported */
 } adc_res_t;
+#endif /* ndef DOXYGEN */
 /** @} */
 
 #ifdef __cplusplus

--- a/cpu/saml21/include/periph_cpu.h
+++ b/cpu/saml21/include/periph_cpu.h
@@ -74,6 +74,7 @@ static const int8_t exti_config[2][32] = {
 };
 #endif /* CPU_MODEL_SAML21E */
 
+#ifndef DOXYGEN
 #define HAVE_ADC_RES_T
 typedef enum {
     ADC_RES_6BIT  = 0xff,                       /**< not supported */
@@ -84,6 +85,8 @@ typedef enum {
     ADC_RES_16BIT = 0xfd                        /**< not supported */
 } adc_res_t;
 /** @} */
+#endif /* ndef DOXYGEN */
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/stm32_common/include/periph_cpu_common.h
+++ b/cpu/stm32_common/include/periph_cpu_common.h
@@ -504,6 +504,7 @@ typedef struct {
 #endif
 } spi_conf_t;
 
+#ifndef DOXYGEN
 /**
  * @brief   Default mapping of I2C bus speed values
  * @{
@@ -523,6 +524,7 @@ typedef enum {
 #endif
 } i2c_speed_t;
 /** @} */
+#endif /* ndef DOXYGEN */
 
 /**
  * @brief   Structure for I2C configuration data

--- a/cpu/stm32f2/include/periph_cpu.h
+++ b/cpu/stm32f2/include/periph_cpu.h
@@ -61,6 +61,7 @@ typedef struct {
     uint8_t chan;           /**< CPU ADC channel connected to the pin */
 } adc_conf_t;
 
+#ifndef DOXYGEN
 /**
  * @brief   Override the ADC resolution configuration
  * @{
@@ -75,6 +76,7 @@ typedef enum {
     ADC_RES_16BIT = 2            /**< ADC resolution: 16 bit (not supported)*/
 } adc_res_t;
 /** @} */
+#endif /* ndef DOXYGEN */
 
 #ifdef __cplusplus
 }

--- a/cpu/stm32l1/include/periph_cpu.h
+++ b/cpu/stm32l1/include/periph_cpu.h
@@ -59,6 +59,7 @@ typedef struct {
     uint8_t chan;           /**< CPU ADC channel connected to the pin */
 } adc_conf_t;
 
+#ifndef DOXYGEN
 /**
  * @brief   Override the ADC resolution configuration
  * @{
@@ -73,6 +74,7 @@ typedef enum {
     ADC_RES_16BIT = (0xff)                              /**< not applicable */
 } adc_res_t;
 /** @} */
+#endif /* ndef DOXYGEN */
 
 /**
  * @name    EEPROM configuration


### PR DESCRIPTION
### Contribution description

Exclude overridden typedefs as otherwise they appear multiple times in the generated documentation.

This series fixes documentation for ADC, GPIO, I2C and SPI drivers.

### Testing procedure

`make doc`