### PR TITLE
sys/ps: Fixed stringification

### DIFF
--- a/sys/ps/ps.c
+++ b/sys/ps/ps.c
@@ -40,6 +40,7 @@ static const char *state_names[] = {
     [STATUS_FLAG_BLOCKED_ANY] = "bl anyfl",
     [STATUS_FLAG_BLOCKED_ALL] = "bl allfl",
     [STATUS_MBOX_BLOCKED] = "bl mbox",
+    [STATUS_COND_BLOCKED] = "bl cond",
 };
 
 /**


### PR DESCRIPTION
### Contribution description

Added missing string for `STATUS_COND_BLOCKED`, so that the shell command "ps" no longer crashes when a thread has this state.

### Testing procedure

Apply the following patch to `examples/default`:

```patch
diff --git a/examples/default/main.c b/examples/default/main.c
index 9d6542d0f..03bf5c069 100644
--- a/examples/default/main.c
+++ b/examples/default/main.c
@@ -25,6 +25,8 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "cond.h"
+#include "mutex.h"
 #include "thread.h"
 #include "shell.h"
 #include "shell_commands.h"
@@ -34,6 +36,18 @@
 #include "net/gnrc.h"
 #endif
 
+static mutex_t m = MUTEX_INIT;
+static cond_t c = COND_INIT;
+static char crasher_stack[THREAD_STACKSIZE_DEFAULT];
+
+static void * crasher(void *unused)
+{
+    (void)unused;
+    mutex_lock(&m);
+    cond_wait(&c, &m);
+    return NULL;
+}
+
 int main(void)
 {
 #ifdef MODULE_NETIF
@@ -44,6 +58,10 @@ int main(void)
 
     (void) puts("Welcome to RIOT!");
 
+    thread_create(crasher_stack, sizeof(crasher_stack), 
+                  THREAD_PRIORITY_MAIN - 1, THREAD_CREATE_STACKTEST,
+                  crasher, NULL, "crasher");
+
     char line_buf[SHELL_DEFAULT_BUFSIZE];
     shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
 
```

Flash the program and start the shell command `ps`. This will crash RIOT with current master, but will not with this PR.

### Issues/PRs references

None