### PR TITLE
make: Allow for true pseudo-submodules

### DIFF
--- a/Makefile.base
+++ b/Makefile.base
@@ -31,7 +31,7 @@ ifeq (1, $(SUBMODULES))
   BASE_MODULE ?= $(MODULE)
 
   # for each $(BASE_MODULE)_<name> in USEMODULE, add <name>.c to SRC
-  SRC += $(patsubst $(BASE_MODULE)_%,%.c,$(filter $(BASE_MODULE)_%,$(USEMODULE)))
+  SRC += $(wildcard $(patsubst $(BASE_MODULE)_%,%.c,$(filter $(BASE_MODULE)_%,$(USEMODULE))))
 
   # don't fail if a selected *.c file does not exist
   ifeq (1, $(SUBMODULES_NOFORCE))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
When providing a pseudo-submodule for a module already using the `SUBMODULES` mechanism to provide submodules, it is not possible to create a true pseudo-module as submodule (i.e. one without any code on its own), since the build system currently always expects there to be a C file `module_submodule.c`.

This removes this requirement.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Build an application with e.g. `USEMODULE += core_foobar` (since [anything starting with `core_` is a pseudo-module](https://github.com/RIOT-OS/RIOT/blob/3c9130ec9ef421d4b095d21ac3703d15437e9c14/makefiles/pseudomodules.inc.mk#L10) this implicitly defines a pseudo-module at the moment). Without this PR, the build system will complain

```
make[2]: *** No rule to make target 'foobar.c', needed by '/home/mlenders/Repositories/RIOT-OS/RIOT/examples/hello-world/bin/native/core/foobar.o'.  Stop.
```

With this PR this error is does not exist anymore.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None (see https://github.com/RIOT-OS/RIOT/pull/10971 for a use-case)
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
