### PR TITLE
sys/random: use periph/hwrng as seed if available

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -661,6 +661,10 @@ ifneq (,$(filter random,$(USEMODULE)))
     USEMODULE += hashes
   endif
 
+  ifeq (,$(filter puf_sram,$(USEMODULE)))
+    FEATURES_OPTIONAL += periph_hwrng
+  endif
+
   USEMODULE += luid
 endif
 

--- a/sys/random/random.c
+++ b/sys/random/random.c
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2017 Kaspar Schleiser <kaspar@schleiser.de>
+ *               2019 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -14,6 +15,7 @@
  * @brief       PRNG seeding
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @}
  */
 
@@ -24,6 +26,9 @@
 #include "random.h"
 #ifdef MODULE_PUF_SRAM
 #include "puf_sram.h"
+#endif
+#ifdef MODULE_PERIPH_HWRNG
+#include "periph/hwrng.h"
 #endif
 #ifdef MODULE_PERIPH_CPUID
 #include "periph/cpuid.h"
@@ -41,6 +46,8 @@ void auto_init_random(void)
         LOG_WARNING("random: PUF SEED not fresh\n");
     }
     seed = puf_sram_seed;
+#elif defined (MODULE_PERIPH_HWRNG)
+    hwrng_read(&seed, 4);
 #elif defined (MODULE_PERIPH_CPUID)
     luid_get(&seed, 4);
 #else

--- a/sys/random/random.c
+++ b/sys/random/random.c
@@ -21,10 +21,12 @@
 
 #include "log.h"
 #include "luid.h"
-#include "periph/cpuid.h"
 #include "random.h"
 #ifdef MODULE_PUF_SRAM
 #include "puf_sram.h"
+#endif
+#ifdef MODULE_PERIPH_CPUID
+#include "periph/cpuid.h"
 #endif
 
 #define ENABLE_DEBUG (0)

--- a/sys/random/random.c
+++ b/sys/random/random.c
@@ -7,13 +7,13 @@
  */
 
  /**
- * @ingroup sys_random
+ * @ingroup     sys_random
  * @{
  * @file
  *
- * @brief PRNG seeding
+ * @brief       PRNG seeding
  *
- * @author Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @}
  */
 


### PR DESCRIPTION
### Contribution description
I just noticed, that we do not utilize any `periph/hwrng` implementation for seeding the `random` module. 
This PR uses the `hwrng` as seed source per default, if it is availble for the target platform, or if not overruled by using `puf_sram` (or any potentially any other more specific option in the future).

Was there any reason for not using the `hwrng` for seeding? If so, simply close this PR again. I don't really intend to trigger a lengthy discussion here...

### Testing procedure
- build `examples/default` with and without `USEMODULE += puf_sram` and on platforms with and without `hwrng` to verify module dependencies (`test/rng` does not work necessarily, as it always include `periph_hwrng` via `FEATURES_OPTIONAL`...)
- run `tests/rng` to verify the seeding...

### Issues/PRs references
n/a