### PR TITLE
gnrc_ipv6_nib/nc: remove from _next_removable on remove

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
@@ -272,6 +272,8 @@ void _nib_nc_remove(_nib_onl_entry_t *node)
         entry->pkt = NULL;
     }
 #endif  /* GNRC_IPV6_NIB_CONF_QUEUE_PKT */
+    /* remove from cache-out procedure */
+    clist_remove(&_next_removable, (clist_node_t *)node);
     _nib_onl_clear(node);
 }
 

--- a/tests/unittests/tests-gnrc_ipv6_nib/tests-gnrc_ipv6_nib-internal.c
+++ b/tests/unittests/tests-gnrc_ipv6_nib/tests-gnrc_ipv6_nib-internal.c
@@ -493,6 +493,40 @@ static void test_nib_nc_add__success_full_but_garbage_collectible(void)
 }
 
 /*
+ * Creates GNRC_IPV6_NIB_NUMOF neighbor cache entries with different IP
+ * addresses and a garbage-collectible AR state and then tries to add
+ * 3 more after removing two.
+ * Expected result: should not crash
+ *
+ * See https://github.com/RIOT-OS/RIOT/pull/10975
+ */
+static void test_nib_nc_add__cache_out_crash(void)
+{
+    _nib_onl_entry_t *node1, *node2;
+    ipv6_addr_t addr = { .u64 = { { .u8 = GLOBAL_PREFIX },
+                                  { .u64 = TEST_UINT64 } } };
+
+    for (int i = 0; i < GNRC_IPV6_NIB_NUMOF - 2; i++) {
+        TEST_ASSERT_NOT_NULL(_nib_nc_add(&addr, IFACE,
+                                         GNRC_IPV6_NIB_NC_INFO_NUD_STATE_STALE));
+        addr.u64[1].u64++;
+    }
+    TEST_ASSERT_NOT_NULL((node1 = _nib_nc_add(&addr, IFACE,
+                                             GNRC_IPV6_NIB_NC_INFO_NUD_STATE_STALE)));
+    addr.u64[1].u64++;
+    TEST_ASSERT_NOT_NULL((node2 = _nib_nc_add(&addr, IFACE,
+                                             GNRC_IPV6_NIB_NC_INFO_NUD_STATE_STALE)));
+    addr.u64[1].u64++;
+    _nib_nc_remove(node1);
+    _nib_nc_remove(node2);
+    for (int i = 0; i < 3; i++) {
+        TEST_ASSERT_NOT_NULL(_nib_nc_add(&addr, IFACE,
+                                         GNRC_IPV6_NIB_NC_INFO_NUD_STATE_STALE));
+        addr.u64[1].u64++;
+    }
+}
+
+/*
  * Creates a neighbor cache entry and sets it reachable
  * Expected result: node->info flags set to NUD_STATE_REACHABLE and NIB's event
  * timer contains a GNRC_IPV6_NIB_MSG_NUD_SET_STALE event
@@ -1935,6 +1969,7 @@ Test *tests_gnrc_ipv6_nib_internal_tests(void)
         new_TestFixture(test_nib_nc_add__success_duplicate),
         new_TestFixture(test_nib_nc_add__success),
         new_TestFixture(test_nib_nc_add__success_full_but_garbage_collectible),
+        new_TestFixture(test_nib_nc_add__cache_out_crash),
         new_TestFixture(test_nib_nc_remove__uncleared),
         new_TestFixture(test_nib_nc_remove__cleared),
         new_TestFixture(test_nib_nc_set_reachable__success),

--- a/tests/unittests/tests-gnrc_ipv6_nib/tests-gnrc_ipv6_nib-internal.c
+++ b/tests/unittests/tests-gnrc_ipv6_nib/tests-gnrc_ipv6_nib-internal.c
@@ -302,6 +302,10 @@ static void test_nib_iter__three_elem_middle_removed(void)
     addr.u64[1].u64++;
     TEST_ASSERT_NOT_NULL((node3 = _nib_onl_alloc(&addr, IFACE)));
     node3->mode = _DRL;
+    /* cppcheck-suppress redundantAssignment
+     * (reason: we assigned _FT before so _nib_onl_alloc would recognize node2
+     *          as used, now we want to clear it, so we need to set it to
+     *          _EMPTY... we are testing internals of data structures here) */
     node2->mode = _EMPTY;
     TEST_ASSERT(_nib_onl_clear(node2));
     TEST_ASSERT_NOT_NULL((res = _nib_onl_iter(NULL)));


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
The `_next_removable` list manages the cache-out of the neighbor cache. However, when a neighbor cache entry is removed, it is not removed from that list, which may lead to a segmentation fault when that list is accessed, since the whole entry (including its list pointer) is zeroed
after removal.

With this change the entry is removed from that list accordingly before the zeroing happens.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
~~This is hard to unittests, since the removal needs to happen *while* another entry is added (so this is a race condition though I'm not 100% clear how this happens, since both operations are supposed to run in the `gnrc_ipv6` thread). I used https://gist.github.com/miri64/fac4df86be36f0a65d9bdb4d2f09d5c7#file-03-4-test-sh and obseverd `tap0` (you can do that by typing `tmux select-window -t tap0; tmux a` in another terminal). Without this PR a segfault will happen here~~

~~https://github.com/RIOT-OS/RIOT/blob/master/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c#L153~~

~~With this PR this segfault does not happen.~~

There is a unittest for this edge case in this PR ;-).

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
