### PR TITLE
doxygen/Makefile: summarize warnings, log full output to file. 

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -23,13 +23,14 @@ RIOTTOOLS      ?= $(RIOTBASE)/dist/tools
 RIOTPROJECT    ?= $(shell git rev-parse --show-toplevel 2>/dev/null || pwd)
 GITCACHE       ?= $(RIOTTOOLS)/git/git-cache
 GIT_CACHE_DIR  ?= $(HOME)/.gitcache
-BUILD_DIR      ?= $(RIOTBASE)/build
 APPDIR         ?= $(CURDIR)
 BINDIRBASE     ?= $(APPDIR)/bin
 BINDIR         ?= $(BINDIRBASE)/$(BOARD)
 PKGDIRBASE     ?= $(BINDIRBASE)/pkg/$(BOARD)
 DLCACHE        ?= $(RIOTTOOLS)/dlcache/dlcache.sh
 DLCACHE_DIR    ?= $(RIOTBASE)/.dlcache
+
+include $(RIOTMAKE)/buildout.inc.mk
 
 __DIRECTORY_VARIABLES := \
   RIOTBASE \
@@ -41,6 +42,7 @@ __DIRECTORY_VARIABLES := \
   RIOTPROJECT \
   APPDIR \
   BUILD_DIR \
+  LOGS_DIR \
   BINDIRBASE \
   BINDIR \
   CCACHE_BASEDIR \
@@ -60,7 +62,6 @@ override RIOTTOOLS      := $(abspath $(RIOTTOOLS))
 override RIOTPROJECT    := $(abspath $(RIOTPROJECT))
 override GITCACHE       := $(abspath $(GITCACHE))
 override APPDIR         := $(abspath $(APPDIR))
-override BUILD_DIR      := $(abspath $(BUILD_DIR))
 override BINDIRBASE     := $(abspath $(BINDIRBASE))
 override BINDIR         := $(abspath $(BINDIR))
 override PKGDIRBASE     := $(abspath $(PKGDIRBASE))

--- a/dist/tools/doccheck/check.sh
+++ b/dist/tools/doccheck/check.sh
@@ -20,18 +20,16 @@ else
     CRESET=
 fi
 
-DOXY_OUTPUT=$(make -C "${RIOTBASE}" doc 2>&1)
+DOXY_STDERR=$(make -sC "${RIOTBASE}" doc 3>&2 2>&1 1>&3 3>&-)
 DOXY_ERRCODE=$?
 
 if [ "${DOXY_ERRCODE}" -ne 0 ] ; then
     echo "'make doc' exited with non-zero code (${DOXY_ERRCODE})"
-    echo "${DOXY_OUTPUT}"
     exit 2
 else
-    ERRORS=$(echo "${DOXY_OUTPUT}" | grep '.*warning' | sed "s#${PWD}/\([^:]*\)#\1#g")
-    if [ -n "${ERRORS}" ] ; then
+    if [ -n "${DOXY_STDERR}" ] ; then
         echo -e "${CERROR}ERROR: Doxygen generates the following warnings:${CRESET}"
-        echo "${ERRORS}"
+        echo "${DOXY_STDERR}"
         exit 2
     fi
 fi

--- a/doc/doxygen/Makefile
+++ b/doc/doxygen/Makefile
@@ -1,4 +1,7 @@
 RIOTBASE=$(shell git rev-parse --show-toplevel)
+
+include $(RIOTBASE)/makefiles/buildout.inc.mk
+
 # Generate list of quoted absolute include paths. Evaluated in riot.doxyfile.
 export STRIP_FROM_INC_PATH_LIST=$(shell \
     git ls-tree -dr --full-tree --name-only HEAD core drivers sys |\
@@ -9,17 +12,22 @@ export STRIP_FROM_INC_PATH_LIST=$(shell \
 # It can also be installed in ubuntu with the `node-less` package
 LESSC ?= $(shell command -v lessc 2>/dev/null)
 
+DOXYGEN ?= doxygen -
+
+DOXY_ERROR_PIPE = ($(DOXYGEN) 3>&2 2>&1 1>&3 3>&- | tee $(LOGS_DIR)/doxygen.log | \
+		   sed -nf warning_patterns.sed | sort | uniq -c) 3>&2 2>&1 1>&3 3>&-
+
 .PHONY: doc
 doc: html
 
 # by marking html as phony we force make to re-run Doxygen even if the directory exists.
 .PHONY: html
-html: src/css/riot.css src/changelog.md
-	( cat riot.doxyfile ; echo "GENERATE_HTML = yes" ) | doxygen -
+html: src/css/riot.css src/changelog.md | $(LOGS_DIR)
+	( cat riot.doxyfile ; echo "GENERATE_HTML = yes" ) | $(DOXY_ERROR_PIPE)
 
 .PHONY: man
-man: src/changelog.md
-	( cat riot.doxyfile ; echo "GENERATE_MAN = yes" ) | doxygen -
+man: src/changelog.md | $(LOGS_DIR)
+	( cat riot.doxyfile ; echo "GENERATE_MAN = yes" ) | $(DOXY_ERROR_PIPE)
 
 ifneq (,$(LESSC))
 src/css/riot.css: src/css/riot.less src/css/variables.less
@@ -34,8 +42,8 @@ src/changelog.md: src/changelog.md.tmp ../../release-notes.txt
 	@./generate-changelog.py $+ $@
 
 .PHONY:
-latex: src/changelog.md
-	( cat riot.doxyfile ; echo "GENERATE_LATEX= yes" ) | doxygen -
+latex: src/changelog.md | $(LOGS_DIR)
+	( cat riot.doxyfile ; echo "GENERATE_LATEX= yes" ) | $(DOXY_ERROR_PIPE)
 
 clean:
 	-@rm -rf latex man html doxygen_objdb_*.tmp doxygen_entrydb_*.tmp src/changelog.md

--- a/doc/doxygen/warning_patterns.sed
+++ b/doc/doxygen/warning_patterns.sed
@@ -1,0 +1,5 @@
+/Member .* is not documented/ { c Undocumented member
+	n}
+/multiple use of section label/ { c Repeated label
+	n}
+/warning/ c Other warnings

--- a/makefiles/buildout.inc.mk
+++ b/makefiles/buildout.inc.mk
@@ -1,0 +1,13 @@
+# Include this file to use the common buildout directory.
+
+BUILD_DIR      ?= $(RIOTBASE)/build
+LOGS_DIR       ?= $(BUILD_DIR)/logs
+
+override BUILD_DIR      := $(abspath $(BUILD_DIR))
+override LOGS_DIR       := $(abspath $(LOGS_DIR))
+
+# This rule is OK if the buildout dir only contains directorties (which should
+# be the case for tidyness)
+
+$(BUILD_DIR)/%:
+	$(Q)mkdir -p $@


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The latest versions of doxygen produce an unwieldy amount of warnings. Instead of ignoring them, this commit causes them to be saved to a log file in the common build directory and prints only a summary with a tally of the number of each type of warning found.

#### New logs directory

As a side effect of this change, I needed a place to place the logs. I defined BUILD_DIR/logs as that place.
Also, The definition of BUILD_DIR is moved to makefiles/buildout.inc.mk so that it can be reused by makefiles that do not include Makefile.include (such as the docs makefile).

### Testing procedure

Run `make doc` with a recent version of doxygen (I'm using 1.8.15) with and without this patch.

Without it, your screen will be flooded with warning messages. With the patch you get:

```
( cat riot.doxyfile ; echo "GENERATE_HTML = yes" ) | doxygen - 2>&1 1>&2 | tee /home/jcarrano/source/masterRIOT/build/logs/doxygen.log | sed -nf warning_patterns.sed | sort | uniq -c
     20 Repeated label
  12824 Undocumented member
```

and the file `logs/doxygen.log` will get created containing the full logs.

```
$ wc -l build/logs/doxygen.log
12844 build/logs/doxygen.log
```

### Issues/PRs references

Trying to alleviate #10815 .
