### PR TITLE
periph/uart: improve documentation

### DIFF
--- a/drivers/include/periph/uart.h
+++ b/drivers/include/periph/uart.h
@@ -14,24 +14,23 @@
  * This is a basic UART (Universal Asynchronous Receiver Transmitter) interface
  * to allow platform independent access to the MCU's serial communication
  * abilities. This interface is intentionally designed to be as simple as
- * possible, to allow for easy implementation and maximum portability. In RIOT
- * we only use the common 8-N-1 format of the serial port (8 data bits, no
- * parity bit, one stop bit).
+ * possible, to allow for easy implementation and maximum portability.
  *
- * The simple interface provides capabilities to initialize the serial
- * communication module, which automatically enables for receiving data, as well
- * as writing data to the UART port, which means transmitting data. The UART
- * device and the corresponding pins need to be mapped in
- * `RIOT/boards/ * /include/periph_conf.h`. Furthermore you need to select the
+ * The simple interface provides capabilities to initialize and configure
+ * the serial communication module, which automatically enables for receiving
+ * data, as well as writing data to the UART port, which means transmitting
+ * data. The UART device and the corresponding pins need to be mapped in
+ * `RIOT/boards/ * /include/periph_conf.h`. Furthermore, you need to select the
  * baudrate for initialization which is typically {9600, 19200, 38400, 57600,
- * 115200} baud. Additionally you should register a callback function that is
+ * 115200} baud. Additionally, you should register a callback function that is
  * executed in interrupt context when data is being received. The driver will
  * then read the received data byte, call the registered callback function and
  * pass the received data to it via its argument. The interface enforces the
  * receiving to be implemented in an interrupt driven mode. Thus, you never know
  * how many bytes are going to be received and might want to handle that in your
  * specific callback function. The transmit function can be implemented in any
- * way.
+ * way. You can also configure parity, the number of data and stop bits, i.e.
+ * such combinations as 8-E-1, 7-N-2 etc. 8-N-1 mode is set by default.
  *
  * By default the @p UART_DEV(0) device of each board is initialized and mapped
  * to STDIO in RIOT which is used for standard input/output functions like
@@ -175,7 +174,7 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg);
 /**
  * @brief   Setup parity, data and stop bits for a given UART device
  *
- * @param[in] uart          UART device to initialize
+ * @param[in] uart          UART device to configure
  * @param[in] data_bits     number of data bits in a UART frame
  * @param[in] parity        parity mode
  * @param[in] stop_bits     number of stop bits in a UART frame


### PR DESCRIPTION
### Contribution description

Change description to reflect the configurability of the serial
interface.

Also, fix the uart_mode parameter description as the UART will be
configured and not initialized.