### PR TITLE
tests/gnrc_ndp: enhance coverage

### DIFF
--- a/tests/gnrc_ndp/Makefile
+++ b/tests/gnrc_ndp/Makefile
@@ -2,10 +2,10 @@ include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo \
                              arduino-mega2560 arduino-nano arduino-uno chronos \
-                             i-nucleo-lrwan1 nucleo-f030r8 nucleo-f031k6 \
-                             nucleo-f042k6 nucleo-l031k6 nucleo-l053r8 \
-                             stm32f0discovery stm32l0538-disco telosb \
-                             waspmote-pro wsn430-v1_3b wsn430-v1_4
+                             i-nucleo-lrwan1 msb-430 msb-430h nucleo-f030r8 \
+                             nucleo-f031k6 nucleo-f042k6 nucleo-l031k6 \
+                             nucleo-l053r8 stm32f0discovery stm32l0538-disco \
+                             telosb waspmote-pro wsn430-v1_3b wsn430-v1_4
 
 USEMODULE += gnrc_ipv6_nib_router
 USEMODULE += gnrc_ndp

--- a/tests/gnrc_ndp/main.c
+++ b/tests/gnrc_ndp/main.c
@@ -491,6 +491,68 @@ static void test_nbr_sol_send__src_NOT_NULL(void)
     test_nbr_sol_send(&test_src);
 }
 
+static void test_nbr_sol_send__pktbuf_full1(void)
+{
+    /* don't be able to fit any more data into packet buffer
+     * - 24 == sizeof(gnrc_pktsnip_t) + pktbuf internal padding */
+    gnrc_pktsnip_t *tmp = gnrc_pktbuf_add(NULL, NULL,
+                                          GNRC_PKTBUF_SIZE - 24,
+                                          GNRC_NETTYPE_UNDEF);
+    TEST_ASSERT_NOT_NULL(tmp);
+    gnrc_ndp_nbr_sol_send(&test_tgt, test_netif, &test_src, &test_dst, NULL);
+    gnrc_pktbuf_release(tmp);
+    TEST_ASSERT(gnrc_pktbuf_is_sane());
+    TEST_ASSERT(gnrc_pktbuf_is_empty());
+}
+
+static void test_nbr_sol_send__pktbuf_full2(void)
+{
+    /* just be able to fit the SLLAO into packet buffer
+     * - 24 == sizeof(gnrc_pktsnip_t) + pktbuf internal padding
+     * - 16 == size of SLLAO for IEEE 802.15.4 */
+    gnrc_pktsnip_t *tmp = gnrc_pktbuf_add(NULL, NULL,
+                                          GNRC_PKTBUF_SIZE - (2 * 24) - 16,
+                                          GNRC_NETTYPE_UNDEF);
+    TEST_ASSERT_NOT_NULL(tmp);
+    gnrc_ndp_nbr_sol_send(&test_tgt, test_netif, &test_src, &test_dst, NULL);
+    gnrc_pktbuf_release(tmp);
+    TEST_ASSERT(gnrc_pktbuf_is_sane());
+    TEST_ASSERT(gnrc_pktbuf_is_empty());
+}
+
+static void test_nbr_sol_send__pktbuf_full3(void)
+{
+    /* just be able to fit the SLLAO and NS into packet buffer
+     * - 24 == sizeof(gnrc_pktsnip_t) + pktbuf internal padding
+     * - 16 == size of SLLAO for IEEE 802.15.4 */
+    gnrc_pktsnip_t *tmp = gnrc_pktbuf_add(NULL, NULL,
+                                          GNRC_PKTBUF_SIZE - (3 * 24) - 16 -
+                                          sizeof(ndp_nbr_sol_t),
+                                          GNRC_NETTYPE_UNDEF);
+    TEST_ASSERT_NOT_NULL(tmp);
+    gnrc_ndp_nbr_sol_send(&test_tgt, test_netif, &test_src, &test_dst, NULL);
+    gnrc_pktbuf_release(tmp);
+    TEST_ASSERT(gnrc_pktbuf_is_sane());
+    TEST_ASSERT(gnrc_pktbuf_is_empty());
+}
+
+static void test_nbr_sol_send__pktbuf_full4(void)
+{
+    /* just be able to fit the SLLAO, NS, and IPv6 header into packet buffer
+     * - 24 == sizeof(gnrc_pktsnip_t) + pktbuf internal padding
+     * - 16 == size of SLLAO for IEEE 802.15.4 */
+    gnrc_pktsnip_t *tmp = gnrc_pktbuf_add(NULL, NULL,
+                                          GNRC_PKTBUF_SIZE - (4 * 24) - 16 -
+                                          sizeof(ndp_nbr_sol_t) -
+                                          sizeof(ipv6_hdr_t),
+                                          GNRC_NETTYPE_UNDEF);
+    TEST_ASSERT_NOT_NULL(tmp);
+    gnrc_ndp_nbr_sol_send(&test_tgt, test_netif, &test_src, &test_dst, NULL);
+    gnrc_pktbuf_release(tmp);
+    TEST_ASSERT(gnrc_pktbuf_is_sane());
+    TEST_ASSERT(gnrc_pktbuf_is_empty());
+}
+
 static void test_nbr_adv_send(const ipv6_addr_t *tgt, const ipv6_addr_t *dst,
                               bool supply_tl2a, gnrc_pktsnip_t *exp_ext_opts)
 {
@@ -640,6 +702,68 @@ static void test_nbr_adv_send__src_tgt_specified_dst_supply_tl2a_ext_opts(void)
     test_nbr_adv_send(&test_src, &test_dst, true, ext_opts);
 }
 
+static void test_nbr_adv_send__pktbuf_full1(void)
+{
+    /* don't be able to fit any more data into packet buffer
+     * - 24 == sizeof(gnrc_pktsnip_t) + pktbuf internal padding */
+    gnrc_pktsnip_t *tmp = gnrc_pktbuf_add(NULL, NULL,
+                                          GNRC_PKTBUF_SIZE - 24,
+                                          GNRC_NETTYPE_UNDEF);
+    TEST_ASSERT_NOT_NULL(tmp);
+    gnrc_ndp_nbr_adv_send(&test_src, test_netif, &test_dst, true, NULL);
+    gnrc_pktbuf_release(tmp);
+    TEST_ASSERT(gnrc_pktbuf_is_sane());
+    TEST_ASSERT(gnrc_pktbuf_is_empty());
+}
+
+static void test_nbr_adv_send__pktbuf_full2(void)
+{
+    /* just be able to fit the TLLAO into packet buffer
+     * - 24 == sizeof(gnrc_pktsnip_t) + pktbuf internal padding
+     * - 16 == size of TLLAO for IEEE 802.15.4 */
+    gnrc_pktsnip_t *tmp = gnrc_pktbuf_add(NULL, NULL,
+                                          GNRC_PKTBUF_SIZE - (2 * 24) - 16,
+                                          GNRC_NETTYPE_UNDEF);
+    TEST_ASSERT_NOT_NULL(tmp);
+    gnrc_ndp_nbr_adv_send(&test_src, test_netif, &test_dst, true, NULL);
+    gnrc_pktbuf_release(tmp);
+    TEST_ASSERT(gnrc_pktbuf_is_sane());
+    TEST_ASSERT(gnrc_pktbuf_is_empty());
+}
+
+static void test_nbr_adv_send__pktbuf_full3(void)
+{
+    /* just be able to fit the TLLAO and NA into packet buffer
+     * - 24 == sizeof(gnrc_pktsnip_t) + pktbuf internal padding
+     * - 16 == size of TLLAO for IEEE 802.15.4 */
+    gnrc_pktsnip_t *tmp = gnrc_pktbuf_add(NULL, NULL,
+                                          GNRC_PKTBUF_SIZE - (3 * 24) - 16 -
+                                          sizeof(ndp_nbr_adv_t),
+                                          GNRC_NETTYPE_UNDEF);
+    TEST_ASSERT_NOT_NULL(tmp);
+    gnrc_ndp_nbr_adv_send(&test_src, test_netif, &test_dst, true, NULL);
+    gnrc_pktbuf_release(tmp);
+    TEST_ASSERT(gnrc_pktbuf_is_sane());
+    TEST_ASSERT(gnrc_pktbuf_is_empty());
+}
+
+static void test_nbr_adv_send__pktbuf_full4(void)
+{
+    /* just be able to fit the TLLAO, NA, and IPv6 header into packet buffer
+     * - 24 == sizeof(gnrc_pktsnip_t) + pktbuf internal padding
+     * - 16 == size of TLLAO for IEEE 802.15.4 */
+    gnrc_pktsnip_t *tmp = gnrc_pktbuf_add(NULL, NULL,
+                                          GNRC_PKTBUF_SIZE - (4 * 24) - 16 -
+                                          sizeof(ndp_nbr_adv_t) -
+                                          sizeof(ipv6_hdr_t),
+                                          GNRC_NETTYPE_UNDEF);
+    TEST_ASSERT_NOT_NULL(tmp);
+    gnrc_ndp_nbr_adv_send(&test_src, test_netif, &test_dst, true, NULL);
+    gnrc_pktbuf_release(tmp);
+    TEST_ASSERT(gnrc_pktbuf_is_sane());
+    TEST_ASSERT(gnrc_pktbuf_is_empty());
+}
+
 static void test_rtr_sol_send(const ipv6_addr_t *dst)
 {
     msg_t msg;
@@ -699,6 +823,68 @@ static void test_rtr_sol_send__dst_global(void)
     memcpy(&dst, &test_dst, sizeof(dst));
     ipv6_addr_init_prefix(&dst, &test_pfx, 64);
     test_rtr_sol_send(&test_dst);
+}
+
+static void test_rtr_sol_send__pktbuf_full1(void)
+{
+    /* don't be able to fit any more data into packet buffer
+     * - 24 == sizeof(gnrc_pktsnip_t) + pktbuf internal padding */
+    gnrc_pktsnip_t *tmp = gnrc_pktbuf_add(NULL, NULL,
+                                          GNRC_PKTBUF_SIZE - 24,
+                                          GNRC_NETTYPE_UNDEF);
+    TEST_ASSERT_NOT_NULL(tmp);
+    gnrc_ndp_rtr_sol_send(test_netif, &test_dst);
+    gnrc_pktbuf_release(tmp);
+    TEST_ASSERT(gnrc_pktbuf_is_sane());
+    TEST_ASSERT(gnrc_pktbuf_is_empty());
+}
+
+static void test_rtr_sol_send__pktbuf_full2(void)
+{
+    /* just be able to fit the SLLAO into packet buffer
+     * - 24 == sizeof(gnrc_pktsnip_t) + pktbuf internal padding
+     * - 16 == size of SLLAO for IEEE 802.15.4 */
+    gnrc_pktsnip_t *tmp = gnrc_pktbuf_add(NULL, NULL,
+                                          GNRC_PKTBUF_SIZE - (2 * 24) - 16,
+                                          GNRC_NETTYPE_UNDEF);
+    TEST_ASSERT_NOT_NULL(tmp);
+    gnrc_ndp_rtr_sol_send(test_netif, &test_dst);
+    gnrc_pktbuf_release(tmp);
+    TEST_ASSERT(gnrc_pktbuf_is_sane());
+    TEST_ASSERT(gnrc_pktbuf_is_empty());
+}
+
+static void test_rtr_sol_send__pktbuf_full3(void)
+{
+    /* just be able to fit the SLLAO and RS into packet buffer
+     * - 24 == sizeof(gnrc_pktsnip_t) + pktbuf internal padding
+     * - 16 == size of SLLAO for IEEE 802.15.4 */
+    gnrc_pktsnip_t *tmp = gnrc_pktbuf_add(NULL, NULL,
+                                          GNRC_PKTBUF_SIZE - (3 * 24) - 16 -
+                                          sizeof(ndp_rtr_sol_t),
+                                          GNRC_NETTYPE_UNDEF);
+    TEST_ASSERT_NOT_NULL(tmp);
+    gnrc_ndp_rtr_sol_send(test_netif, &test_dst);
+    gnrc_pktbuf_release(tmp);
+    TEST_ASSERT(gnrc_pktbuf_is_sane());
+    TEST_ASSERT(gnrc_pktbuf_is_empty());
+}
+
+static void test_rtr_sol_send__pktbuf_full4(void)
+{
+    /* just be able to fit the SLLAO, RS, and IPv6 header into packet buffer
+     * - 24 == sizeof(gnrc_pktsnip_t) + pktbuf internal padding
+     * - 16 == size of SLLAO for IEEE 802.15.4 */
+    gnrc_pktsnip_t *tmp = gnrc_pktbuf_add(NULL, NULL,
+                                          GNRC_PKTBUF_SIZE - (4 * 24) - 16 -
+                                          sizeof(ndp_rtr_sol_t) -
+                                          sizeof(ipv6_hdr_t),
+                                          GNRC_NETTYPE_UNDEF);
+    TEST_ASSERT_NOT_NULL(tmp);
+    gnrc_ndp_rtr_sol_send(test_netif, &test_dst);
+    gnrc_pktbuf_release(tmp);
+    TEST_ASSERT(gnrc_pktbuf_is_sane());
+    TEST_ASSERT(gnrc_pktbuf_is_empty());
 }
 
 #if GNRC_IPV6_NIB_CONF_ROUTER
@@ -837,6 +1023,68 @@ static void test_rtr_adv_send__src_dst_fin_ext_opts(void)
     gnrc_pktsnip_t *ext_opts = gnrc_pktbuf_add(NULL, NULL, 8U, GNRC_NETTYPE_UNDEF);
     test_rtr_adv_send(&test_src, &test_dst, true, ext_opts);
 }
+
+static void test_rtr_adv_send__pktbuf_full1(void)
+{
+    /* don't be able to fit any more data into packet buffer
+     * - 24 == sizeof(gnrc_pktsnip_t) + pktbuf internal padding */
+    gnrc_pktsnip_t *tmp = gnrc_pktbuf_add(NULL, NULL,
+                                          GNRC_PKTBUF_SIZE - 24,
+                                          GNRC_NETTYPE_UNDEF);
+    TEST_ASSERT_NOT_NULL(tmp);
+    gnrc_ndp_rtr_adv_send(test_netif, &test_src, &test_dst, false, NULL);
+    gnrc_pktbuf_release(tmp);
+    TEST_ASSERT(gnrc_pktbuf_is_sane());
+    TEST_ASSERT(gnrc_pktbuf_is_empty());
+}
+
+static void test_rtr_adv_send__pktbuf_full2(void)
+{
+    /* just be able to fit the SLLAO into packet buffer
+     * - 24 == sizeof(gnrc_pktsnip_t) + pktbuf internal padding
+     * - 16 == size of SLLAO for IEEE 802.15.4 */
+    gnrc_pktsnip_t *tmp = gnrc_pktbuf_add(NULL, NULL,
+                                          GNRC_PKTBUF_SIZE - (2 * 24) - 16,
+                                          GNRC_NETTYPE_UNDEF);
+    TEST_ASSERT_NOT_NULL(tmp);
+    gnrc_ndp_rtr_adv_send(test_netif, &test_src, &test_dst, false, NULL);
+    gnrc_pktbuf_release(tmp);
+    TEST_ASSERT(gnrc_pktbuf_is_sane());
+    TEST_ASSERT(gnrc_pktbuf_is_empty());
+}
+
+static void test_rtr_adv_send__pktbuf_full3(void)
+{
+    /* just be able to fit the SLLAO and RA into packet buffer
+     * - 24 == sizeof(gnrc_pktsnip_t) + pktbuf internal padding
+     * - 16 == size of SLLAO for IEEE 802.15.4 */
+    gnrc_pktsnip_t *tmp = gnrc_pktbuf_add(NULL, NULL,
+                                          GNRC_PKTBUF_SIZE - (3 * 24) - 16 -
+                                          sizeof(ndp_rtr_adv_t),
+                                          GNRC_NETTYPE_UNDEF);
+    TEST_ASSERT_NOT_NULL(tmp);
+    gnrc_ndp_rtr_adv_send(test_netif, &test_src, &test_dst, false, NULL);
+    gnrc_pktbuf_release(tmp);
+    TEST_ASSERT(gnrc_pktbuf_is_sane());
+    TEST_ASSERT(gnrc_pktbuf_is_empty());
+}
+
+static void test_rtr_adv_send__pktbuf_full4(void)
+{
+    /* just be able to fit the SLLAO, RA, and IPv6 header into packet buffer
+     * - 24 == sizeof(gnrc_pktsnip_t) + pktbuf internal padding
+     * - 16 == size of SLLAO for IEEE 802.15.4 */
+    gnrc_pktsnip_t *tmp = gnrc_pktbuf_add(NULL, NULL,
+                                          GNRC_PKTBUF_SIZE - (4 * 24) - 16 -
+                                          sizeof(ndp_rtr_adv_t) -
+                                          sizeof(ipv6_hdr_t),
+                                          GNRC_NETTYPE_UNDEF);
+    TEST_ASSERT_NOT_NULL(tmp);
+    gnrc_ndp_rtr_adv_send(test_netif, &test_src, &test_dst, false, NULL);
+    gnrc_pktbuf_release(tmp);
+    TEST_ASSERT(gnrc_pktbuf_is_sane());
+    TEST_ASSERT(gnrc_pktbuf_is_empty());
+}
 #endif
 
 static Test *tests_gnrc_ndp_build(void)
@@ -876,6 +1124,10 @@ static Test *tests_gnrc_ndp_send(void)
         new_TestFixture(test_nbr_sol_send__src_NULL),
         new_TestFixture(test_nbr_sol_send__src_unspecified),
         new_TestFixture(test_nbr_sol_send__src_NOT_NULL),
+        new_TestFixture(test_nbr_sol_send__pktbuf_full1),
+        new_TestFixture(test_nbr_sol_send__pktbuf_full2),
+        new_TestFixture(test_nbr_sol_send__pktbuf_full3),
+        new_TestFixture(test_nbr_sol_send__pktbuf_full4),
         new_TestFixture(test_nbr_adv_send__foreign_tgt_unspecified_dst_no_supply_tl2a_no_ext_opts),
         new_TestFixture(test_nbr_adv_send__foreign_tgt_unspecified_dst_no_supply_tl2a_ext_opts),
         new_TestFixture(test_nbr_adv_send__foreign_tgt_unspecified_dst_supply_tl2a_no_ext_opts),
@@ -892,9 +1144,17 @@ static Test *tests_gnrc_ndp_send(void)
         new_TestFixture(test_nbr_adv_send__src_tgt_specified_dst_no_supply_tl2a_ext_opts),
         new_TestFixture(test_nbr_adv_send__src_tgt_specified_dst_supply_tl2a_no_ext_opts),
         new_TestFixture(test_nbr_adv_send__src_tgt_specified_dst_supply_tl2a_ext_opts),
+        new_TestFixture(test_nbr_adv_send__pktbuf_full1),
+        new_TestFixture(test_nbr_adv_send__pktbuf_full2),
+        new_TestFixture(test_nbr_adv_send__pktbuf_full3),
+        new_TestFixture(test_nbr_adv_send__pktbuf_full4),
         new_TestFixture(test_rtr_sol_send__dst_NULL),
         new_TestFixture(test_rtr_sol_send__dst_local),
         new_TestFixture(test_rtr_sol_send__dst_global),
+        new_TestFixture(test_rtr_sol_send__pktbuf_full1),
+        new_TestFixture(test_rtr_sol_send__pktbuf_full2),
+        new_TestFixture(test_rtr_sol_send__pktbuf_full3),
+        new_TestFixture(test_rtr_sol_send__pktbuf_full4),
 #if GNRC_IPV6_NIB_CONF_ROUTER
         new_TestFixture(test_rtr_adv_send__src_NULL_dst_NULL_no_fin_no_ext_opts),
         new_TestFixture(test_rtr_adv_send__src_NULL_dst_NULL_no_fin_ext_opts),
@@ -912,6 +1172,10 @@ static Test *tests_gnrc_ndp_send(void)
         new_TestFixture(test_rtr_adv_send__src_dst_no_fin_ext_opts),
         new_TestFixture(test_rtr_adv_send__src_dst_fin_no_ext_opts),
         new_TestFixture(test_rtr_adv_send__src_dst_fin_ext_opts),
+        new_TestFixture(test_rtr_adv_send__pktbuf_full1),
+        new_TestFixture(test_rtr_adv_send__pktbuf_full2),
+        new_TestFixture(test_rtr_adv_send__pktbuf_full3),
+        new_TestFixture(test_rtr_adv_send__pktbuf_full4),
 #endif
     };
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
To ensure that the bug I was trying to fix in https://github.com/RIOT-OS/RIOT/pull/10985 wasn't actually caused by the `gnrc_ndp` sending functions I enhanced the module's test coverage.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
To make sure the coverage is actually enhanced I applied the following patch

```diff
diff --git a/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c b/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
index c42477cfee..cc82c4c35b 100644
--- a/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
+++ b/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
@@ -287,6 +287,7 @@ void gnrc_ndp_nbr_sol_send(const ipv6_addr_t *tgt, gnrc_netif_t *netif,
                 hdr = gnrc_ndp_opt_sl2a_build(l2src, l2src_len, pkt);
 
                 if (hdr == NULL) {
+                    puts("option failed");
                     DEBUG("ndp: error allocating SL2AO.\n");
                     break;
                 }
@@ -296,6 +297,7 @@ void gnrc_ndp_nbr_sol_send(const ipv6_addr_t *tgt, gnrc_netif_t *netif,
         /* add neighbor solicitation header */
         hdr = gnrc_ndp_nbr_sol_build(tgt, pkt);
         if (hdr == NULL) {
+            puts("message failed");
             DEBUG("ndp: error allocating neighbor solicitation.\n");
             break;
         }
@@ -369,6 +371,7 @@ void gnrc_ndp_nbr_adv_send(const ipv6_addr_t *tgt, gnrc_netif_t *netif,
                 hdr = gnrc_ndp_opt_tl2a_build(l2tgt, l2tgt_len, pkt);
 
                 if (hdr == NULL) {
+                    puts("option failed");
                     DEBUG("ndp: error allocating TL2AO.\n");
                     break;
                 }
@@ -385,6 +388,7 @@ void gnrc_ndp_nbr_adv_send(const ipv6_addr_t *tgt, gnrc_netif_t *netif,
         /* add neighbor advertisement header */
         hdr = gnrc_ndp_nbr_adv_build(tgt, adv_flags, pkt);
         if (hdr == NULL) {
+            puts("message failed");
             DEBUG("ndp: error allocating neighbor advertisement.\n");
             break;
         }
@@ -434,6 +438,7 @@ void gnrc_ndp_rtr_sol_send(gnrc_netif_t *netif, const ipv6_addr_t *dst)
                 /* add source address link-layer address option */
                 pkt = gnrc_ndp_opt_sl2a_build(l2src, l2src_len, NULL);
                 if (pkt == NULL) {
+                    puts("option failed");
                     DEBUG("ndp: error allocating SL2AO.\n");
                     break;
                 }
@@ -442,6 +447,7 @@ void gnrc_ndp_rtr_sol_send(gnrc_netif_t *netif, const ipv6_addr_t *dst)
         /* add router solicitation header */
         hdr = gnrc_ndp_rtr_sol_build(pkt);
         if (hdr == NULL) {
+            puts("message failed");
             DEBUG("ndp: error allocating router solicitation.\n");
             break;
         }
@@ -518,6 +524,7 @@ void gnrc_ndp_rtr_adv_send(gnrc_netif_t *netif, const ipv6_addr_t *src,
                 hdr = gnrc_ndp_opt_sl2a_build(l2src, l2src_len, pkt);
 
                 if (hdr == NULL) {
+                    puts("option failed");
                     DEBUG("ndp: error allocating Source Link-layer address "
                           "option.\n");
                     break;
@@ -556,6 +563,7 @@ void gnrc_ndp_rtr_adv_send(gnrc_netif_t *netif, const ipv6_addr_t *src,
         hdr = gnrc_ndp_rtr_adv_build(cur_hl, flags, adv_ltime, reach_time,
                                      retrans_timer, pkt);
         if (hdr == NULL) {
+            puts("message failed");
             DEBUG("ndp: error allocating router advertisement.\n");
             break;
         }
@@ -598,6 +606,7 @@ static gnrc_pktsnip_t *_build_headers(gnrc_netif_t *netif,
     gnrc_pktsnip_t *iphdr = gnrc_ipv6_hdr_build(payload, src, dst);
 
     if (iphdr == NULL) {
+        puts("IPv6 failed");
         DEBUG("ndp: error allocating IPv6 header.\n");
         return NULL;
     }
@@ -605,6 +614,7 @@ static gnrc_pktsnip_t *_build_headers(gnrc_netif_t *netif,
     /* add netif header for send interface specification */
     l2hdr = gnrc_netif_hdr_build(NULL, 0, NULL, 0);
     if (l2hdr == NULL) {
+        puts("netif failed");
         DEBUG("ndp: error allocating netif header.\n");
         gnrc_pktbuf_remove_snip(iphdr, iphdr);
         return NULL;
```

The test should then show something like

```
option failed
message failed
IPv6 failed
netif failed
```

4 times with varying numbers periods in-between with this PR, without it it probably won't show up at all (I did not test this case). I tested the first case on `native`, `samr21-xpro`, and `iotlab-m3`


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Ensurance that #10985 was the right hunch for the leak we've seen.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
