### PR TITLE
core: Use enum for thread states

### DIFF
--- a/core/include/sched.h
+++ b/core/include/sched.h
@@ -97,6 +97,35 @@
 typedef struct _thread thread_t;
 
 /**
+ * @name Thread states supported by RIOT
+ * @{
+ */
+typedef enum {
+    STATUS_STOPPED,                 /**< has terminated                       */
+    STATUS_SLEEPING,                /**< sleeping                             */
+    STATUS_MUTEX_BLOCKED,           /**< waiting for a locked mutex           */
+    STATUS_RECEIVE_BLOCKED,         /**< waiting for a message                */
+    STATUS_SEND_BLOCKED,            /**< waiting for message to be delivered  */
+    STATUS_REPLY_BLOCKED,           /**< waiting for a message response       */
+    STATUS_FLAG_BLOCKED_ANY,        /**< waiting for any flag from flag_mask  */
+    STATUS_FLAG_BLOCKED_ALL,        /**< waiting for all flags in flag_mask   */
+    STATUS_MBOX_BLOCKED,            /**< waiting for get/put on mbox          */
+    STATUS_COND_BLOCKED,            /**< waiting for a condition variable     */
+    STATUS_RUNNING,                 /**< currently running                    */
+    STATUS_PENDING,                 /**< waiting to be scheduled to run       */
+    STATUS_NUMOF                    /**< number of supported thread states    */
+} thread_state_t;
+/** @} */
+
+/**
+ * @name Helpers to work with thread states
+ * @{
+ */
+#define STATUS_ON_RUNQUEUE      STATUS_RUNNING  /**< to check if on run queue:
+                                                 `st >= STATUS_ON_RUNQUEUE`   */
+#define STATUS_NOT_FOUND ((thread_state_t)-1)   /**< Describes an illegal thread status */
+/** @} */
+/**
  * @def SCHED_PRIO_LEVELS
  * @brief The number of thread priority levels
  */
@@ -117,7 +146,7 @@ int sched_run(void);
  *                          targeted process
  * @param[in]   status      The new status of this thread
  */
-void sched_set_status(thread_t *process, unsigned int status);
+void sched_set_status(thread_t *process, thread_state_t status);
 
 /**
  * @brief       Yield if approriate.

--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -133,40 +133,6 @@
  extern "C" {
 #endif
 
-/* Thread states */
-/**
- * @name Special meaning thread states
- * @{
- */
-#define STATUS_NOT_FOUND        (-1)    /**< Describes an illegal thread status */
-/** @} */
-
-/**
- * @name Blocked thread states
- * @{
- */
-#define STATUS_STOPPED              0   /**< has terminated                     */
-#define STATUS_SLEEPING             1   /**< sleeping                           */
-#define STATUS_MUTEX_BLOCKED        2   /**< waiting for a locked mutex         */
-#define STATUS_RECEIVE_BLOCKED      3   /**< waiting for a message              */
-#define STATUS_SEND_BLOCKED         4   /**< waiting for message to be delivered*/
-#define STATUS_REPLY_BLOCKED        5   /**< waiting for a message response     */
-#define STATUS_FLAG_BLOCKED_ANY     6   /**< waiting for any flag from flag_mask*/
-#define STATUS_FLAG_BLOCKED_ALL     7   /**< waiting for all flags in flag_mask */
-#define STATUS_MBOX_BLOCKED         8   /**< waiting for get/put on mbox        */
-#define STATUS_COND_BLOCKED         9   /**< waiting for a condition variable   */
-/** @} */
-
-/**
- * @name Queued thread states
- * @{
- */
-#define STATUS_ON_RUNQUEUE      STATUS_RUNNING  /**< to check if on run queue:
-                                                 `st >= STATUS_ON_RUNQUEUE`             */
-#define STATUS_RUNNING         10               /**< currently running                  */
-#define STATUS_PENDING         11               /**< waiting to be scheduled to run     */
-/** @} */
-
 /**
  * @brief Prototype for a thread entry function
  */
@@ -177,7 +143,7 @@ typedef void *(*thread_task_func_t)(void *arg);
  */
 struct _thread {
     char *sp;                       /**< thread's stack pointer         */
-    uint8_t status;                 /**< thread's status                */
+    thread_state_t status;          /**< thread's status                */
     uint8_t priority;               /**< thread's priority              */
 
     kernel_pid_t pid;               /**< thread's process id            */

--- a/core/sched.c
+++ b/core/sched.c
@@ -158,7 +158,7 @@ void sched_register_cb(void (*callback)(uint32_t, uint32_t))
 }
 #endif
 
-void sched_set_status(thread_t *process, unsigned int status)
+void sched_set_status(thread_t *process, thread_state_t status)
 {
     if (status >= STATUS_ON_RUNQUEUE) {
         if (!(process->status >= STATUS_ON_RUNQUEUE)) {

--- a/core/thread.c
+++ b/core/thread.c
@@ -41,7 +41,7 @@ volatile thread_t *thread_get(kernel_pid_t pid)
 int thread_getstatus(kernel_pid_t pid)
 {
     volatile thread_t *t = thread_get(pid);
-    return t ? (int) t->status : STATUS_NOT_FOUND;
+    return t ? (int)t->status : (int)STATUS_NOT_FOUND;
 }
 
 const char *thread_getname(kernel_pid_t pid)
@@ -93,7 +93,7 @@ int thread_wakeup(kernel_pid_t pid)
     }
 
     irq_restore(old_state);
-    return STATUS_NOT_FOUND;
+    return (int)STATUS_NOT_FOUND;
 }
 
 void thread_yield(void)
@@ -224,7 +224,7 @@ kernel_pid_t thread_create(char *stack, int stacksize, char priority, int flags,
 #endif
 
     cb->priority = priority;
-    cb->status = 0;
+    cb->status = STATUS_STOPPED;
 
     cb->rq_entry.next = NULL;
 

--- a/core/thread_flags.c
+++ b/core/thread_flags.c
@@ -100,7 +100,7 @@ thread_flags_t thread_flags_wait_all(thread_flags_t mask)
 
 inline int __attribute__((always_inline)) thread_flags_wake(thread_t *thread)
 {
-    unsigned wakeup = 0;
+    unsigned wakeup;
     thread_flags_t mask = (uint16_t)(unsigned)thread->wait_data;
     switch(thread->status) {
         case STATUS_FLAG_BLOCKED_ANY:
@@ -108,6 +108,9 @@ inline int __attribute__((always_inline)) thread_flags_wake(thread_t *thread)
             break;
         case STATUS_FLAG_BLOCKED_ALL:
             wakeup = ((thread->flags & mask) == mask);
+            break;
+        default:
+            wakeup = 0;
             break;
     }
 

--- a/sys/cpp11-compat/thread.cpp
+++ b/sys/cpp11-compat/thread.cpp
@@ -42,7 +42,7 @@ void thread::join() {
   }
   if (joinable()) {
     auto status = thread_getstatus(m_handle);
-    if (status != STATUS_NOT_FOUND && status != STATUS_STOPPED) {
+    if (status != (int)STATUS_NOT_FOUND && status != STATUS_STOPPED) {
       m_data->joining_thread = sched_active_pid;
       thread_sleep();
     }

--- a/sys/ps/ps.c
+++ b/sys/ps/ps.c
@@ -96,7 +96,7 @@ void ps(void)
         thread_t *p = (thread_t *)sched_threads[i];
 
         if (p != NULL) {
-            int state = p->status;                                                 /* copy state */
+            thread_state_t state = p->status;                                      /* copy state */
             const char *sname = state_names[state];                                /* get state name */
             const char *queued = &queued_name[(int)(state >= STATUS_ON_RUNQUEUE)]; /* get queued flag */
 #ifdef DEVELHELP


### PR DESCRIPTION
### Contribution description

As pointed out by @kaspar030 in https://github.com/RIOT-OS/RIOT/pull/10977 an `enum` data type would better represent thread states. This PR introduced the new `enum` data type `thread_state_t` to indicate thread states. 

### Testing procedure

Compilation and scheduling should still work with this PR.

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/10977, https://github.com/RIOT-OS/RIOT/pull/10967