### PR TITLE
pyterm: use python3 by default

### DIFF
--- a/dist/tools/pyterm/pyterm
+++ b/dist/tools/pyterm/pyterm
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # Copyright (C) 2014  Oliver Hahm <oliver.hahm@inria.fr>


### PR DESCRIPTION
### Contribution description

Python3 has been the default in our scripts for some time now, but pyterm still
requested python which uses python2 on ubuntu stable.

This pushes toward only needing to install `python3` python
dependencies.

### Testing procedure

If you are using a distribution where `python == python3` by default, it should not change anything.
Running tests with `murdock` here should not help as tests are not run with `pyterm` I think.


Running `make term` and `make test` with boards using `pyterm` should still work by default:

```
BOARD=samr21-xpro make --no-print-directory -C examples/hello-world/ info-debug-variable-TERMPROG
/home/harter/work/git/RIOT/dist/tools/pyterm/pyterm
```

Then testing `make term` in `examples/default` for example and running the tests should work the same as without this pull request.
```
./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py . samr21-xpro
```

#### Vagrant

The vagrant image already installs `python3-serial` but would be nice to verify too.

* [ ] Vagrant test of `make term` on a board.

### Issues/PRs references

Found while testing on a machine where only `python3` dependencies were installed.

https://github.com/RIOT-OS/RIOT/pull/10870