### PR TITLE
net/sixlowpan: Fixed calculation of fragment size

### DIFF
--- a/sys/net/gnrc/network_layer/sixlowpan/frag/gnrc_sixlowpan_frag.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/gnrc_sixlowpan_frag.c
@@ -44,7 +44,7 @@ static uint16_t _tag;
 
 static inline uint16_t _floor8(uint16_t length)
 {
-    return length & 0xf8U;
+    return length & 0xfff8U;
 }
 
 static inline size_t _min(size_t a, size_t b)


### PR DESCRIPTION
### Contribution description

Fragment size calculation previously failed for devices that are able to transmit bigger layer 2 PDUs that 802.15.4 devices. This commit fixes the issue.

### Testing procedure

Try running `ping6 -s 512 <ADDR>` with https://github.com/RIOT-OS/RIOT/pull/10340. This will fail, as maximum fragment size calculation does not work. Rebase PR https://github.com/RIOT-OS/RIOT/pull/10340 against this PR and it will work.

### Issues/PRs references

Bug found when testing 6LoWPAN fragmentation with the `cc110x`, which has a maximum layer two DPU of 253 bytes, which is higher than the usual 127-x bytes of 802.15.4 transceivers.