### PR TITLE
gnrc_ipv6_nib: release packet when NC entry can't be added [backport 2019.01]

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -1130,6 +1130,7 @@ static bool _resolve_addr(const ipv6_addr_t *dst, gnrc_netif_t *netif,
             entry = _nib_nc_add(dst, (netif != NULL) ? netif->pid : 0,
                                 GNRC_IPV6_NIB_NC_INFO_NUD_STATE_INCOMPLETE);
             if (entry == NULL) {
+                gnrc_pktbuf_release(pkt);
                 return false;
             }
 #if GNRC_IPV6_NIB_CONF_ROUTER


### PR DESCRIPTION
# Backport of #10978

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
When the neighbor cache is full, the packet trying to resolve a neighbor is not released.

This change fixes that.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Run https://gist.github.com/miri64/fac4df86be36f0a65d9bdb4d2f09d5c7#file-03-4-test-sh in `examples/gnrc_networking` (compiled with `gnrc_pktbuf_cmd`) with `PING_COUNT` set to 10000 (*edit: for master you might need to adapt [this line](https://gist.github.com/miri64/fac4df86be36f0a65d9bdb4d2f09d5c7#file-03-4-test-sh-L62) to `sendline ${TAP} "ping6 -c ${PING_COUNT} ${TAP0_ADDR} -s 1452 -i 0"`*). You can either wait for the script to finish, but that might take a while or do the following:

- connect to the TMUX session (`tmux a`) after about 10 seconds, and go through all windows (`<Ctrl>+B n` in default config)
- When all the nodes sending pings are either done or all nodes that are not done are reporting `ping timeout` kill the nodes sending pings (using `<Ctrl>+C`).
- Go to the remaining node that was pinged and type `pktbuf`

With this PR the packet buffer should be empty (there is only one unused section with `next: (nil), size: 6144`), without this PR it is not (there is data dumped as hex to the output).

If you encounter a crash on the pinging node, merge #10975.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Testing procedures might only work for you when you merge #10975. For me that was the case, for @aabadie apparently not.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
