### PR TITLE
Documentation: fix dead links

### DIFF
--- a/boards/esp8266-esp-12x/doc.txt
+++ b/boards/esp8266-esp-12x/doc.txt
@@ -86,7 +86,7 @@ Following image shows the pinout of all WEMOS LOLIN D1 mini boards. It is compat
 
 ## <a name="nodemcu_devkit_esp8266"> NodeMCU DEVKIT </a>
 
-NodeMCU DEVKIT is an open-source hardware project hosted on [GitHub](ttps://github.com/nodemcu/nodemcu-devkit-v1.0). Therefore, there are a lot of clones available. The board was originally designed for NodeMCU firmware development.
+NodeMCU DEVKIT is an open-source hardware project hosted on [GitHub](https://github.com/nodemcu/nodemcu-devkit-v1.0). Therefore, there are a lot of clones available. The board was originally designed for NodeMCU firmware development.
 
 As the other boards described here, NodeMCU ESP12 is generic board that uses ESP-12E module and breaks out all available GPIO pins. It has a Micro-USB port including a flash/boot/reset logic which makes flashing much easier.
 

--- a/boards/jiminy-mega256rfr2/doc.txt
+++ b/boards/jiminy-mega256rfr2/doc.txt
@@ -9,7 +9,7 @@ The Jiminy board is a development of the
 (IAS) of the [RWTH Aachen University](https://www.rwth-aachen.de/). We started the project by porting
 RIOT OS to the [Pinoccio.io](https://github.com/Pinoccio/hardware-pinoccio) board. As there where severe
 limitations we designed the Jiminy board which has the the
-[ATmega256rfr2](www.atmel.com/Images/Atmel-8393-MCU_Wireless-ATmega256RFR2-ATmega128RFR2-ATmega64RFR2_Datasheet.pdf)
+[ATmega256rfr2](http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8393-MCU_Wireless-ATmega256RFR2-ATmega128RFR2-ATmega64RFR2_Datasheet.pdf)
 MCU as common feature.
 
 It is Arduino like and features USB programming. The [Bootloader](https://github.com/Josar/arduino_stk500v2)
@@ -48,12 +48,12 @@ The jiminy board has following ICs and features.
 | Features | Details |  Datasheet |
 |:------------- |:--------------------- |:------------- |
 | USB2Serial| ATmega16U2, High-performance, low-power AVR 8-Bit Advanced RISC Architecture | [Link](http://www.microchip.com/wwwproducts/en/ATmega16u2) |
-| MCU | ATmega256, AVR 8-Bit Advanced RISC Architecture |[Link](www.atmel.com/Images/Atmel-8393-MCU_Wireless-ATmega256RFR2-ATmega128RFR2-ATmega64RFR2_Datasheet.pdf) |
+| MCU | ATmega256, AVR 8-Bit Advanced RISC Architecture |[Link](http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8393-MCU_Wireless-ATmega256RFR2-ATmega128RFR2-ATmega64RFR2_Datasheet.pdf) |
 | Transceiver | High performance RF-CMOS 2.4 GHz radio transceiver targeted for IEEE802.15.4, ZigBee, IPv6 / 6LoWPAN, RF4CE, SP100, WirelessHART and ISM applications | above |
-| Li-ion Charger and Power Path | bq24298 , 3A Single Cell USB Charger With Power Path Management|[Link](www.ti.com/lit/ds/symlink/bq24298.pdf) |
-| Fuel Gauge| LC709203F, Fuel Gauge for a single lithium ion battery which provides accurate RSOC information even under unstable conditions (e.g. changes of battery temperature, loading, aging and self-discharge) |[Link](www.onsemi.com/pub/Collateral/LC709203F-D.PDF) |
-| AC Converter | TPS6274x, Output voltage selectable within a range from 1.8V to 3.3V in 100mV steps, output currents up to 300mA | [Link](www.ti.com/lit/ds/symlink/tps62740.pdf) |
-| RGB LED | Cree LED, hardware PWM controlled  |[Link](www.cree.com/led-components/media/documents/CLVBAFKA.pdf) |
+| Li-ion Charger and Power Path | bq24298 , 3A Single Cell USB Charger With Power Path Management|[Link](http://www.ti.com/lit/ds/symlink/bq24298.pdf) |
+| Fuel Gauge| LC709203F, Fuel Gauge for a single lithium ion battery which provides accurate RSOC information even under unstable conditions (e.g. changes of battery temperature, loading, aging and self-discharge) |[Link](https://www.onsemi.com/pub/Collateral/LC709203F-D.PDF) |
+| AC Converter | TPS6274x, Output voltage selectable within a range from 1.8V to 3.3V in 100mV steps, output currents up to 300mA | [Link](http://www.ti.com/lit/ds/symlink/tps62740.pdf) |
+| RGB LED | Cree LED, hardware PWM controlled  |[Link](https://www.cree.com/led-components/media/documents/ds-CLVBA-FKA.pdf) |
 
 
 ## MCU Details
@@ -74,7 +74,7 @@ The jiminy board has following ICs and features.
 | SPIs		| 3 (1 SPI & 2 USART SPI) |
 | I2Cs		| 1 (called TWI)	|
 | Vcc		| 1.8V - 3.6V		|
-| Datasheet / Reference Manual | [Datasheet and Reference Manual](www.atmel.com/Images/Atmel-8393-MCU_Wireless-ATmega256RFR2-ATmega128RFR2-ATmega64RFR2_Datasheet.pdf) |
+| Datasheet / Reference Manual | [Datasheet and Reference Manual](http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8393-MCU_Wireless-ATmega256RFR2-ATmega128RFR2-ATmega64RFR2_Datasheet.pdf) |
 | Board Manual	|  |
 | Pins          |  |
 

--- a/boards/nz32-sc151/doc.txt
+++ b/boards/nz32-sc151/doc.txt
@@ -3,7 +3,7 @@
 @ingroup     boards
 @brief       Support for the Modtronix nz32-sc151 board.
 
-This board provider is [modtronix](www.modtronix.com). They don't supply data
+This board provider is [modtronix](http://modtronix.com). They don't supply data
 sheet's but there wiki can be found
 [HERE](http://wiki.modtronix.com/doku.php?id=products:nz-stm32:nz32-sc151). The
 schematic for there board can be found
@@ -70,7 +70,7 @@ sudo apt-get install dfu-util
 ```
 
 but most repos install older versions, therefore you should clone from [dfu-
-util](git clone git://git.code.sf.net/p/dfu-util/dfu-util) and follow building
+util](https://sourceforge.net/p/dfu-util/dfu-util/ci/master/tree/) and follow building
 instructions [HERE](
 http://dfu-util.sourceforge.net/build.html).
 


### PR DESCRIPTION
### Contribution description

The link to nodemcu-devkit-v1.0 was missing 'h' in 'http'.

Other links were missing 'http://' or 'https://' and were pointing
to non-existing components on RIOT's web site.

### Testing procedure

These links were found using [linkchecker](https://github.com/linkchecker/linkchecker)