### PR TITLE
 gnrc_ipv6_nib: fix iteration conditions for cache-out

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
@@ -152,7 +152,11 @@ static inline _nib_onl_entry_t *_cache_out_onl_entry(const ipv6_addr_t *addr,
             /* no new entry created yet, get next entry in FIFO */
             tmp = (_nib_onl_entry_t *)clist_lpop(&_next_removable);
         }
-    } while ((tmp != first) && (res != NULL));
+    } while ((tmp != first) && (res == NULL));
+    if (res == NULL) {
+        /* we did not find any removable entry => requeue current one */
+        clist_rpush(&_next_removable, (clist_node_t *)tmp);
+    }
     return res;
 }
 

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
@@ -146,7 +146,8 @@ static inline _nib_onl_entry_t *_cache_out_onl_entry(const ipv6_addr_t *addr,
             res->mode = _NC;
         }
         /* requeue if not garbage collectible at the moment or queueing
-         * newly created NCE */
+         * newly created NCE or in case entry becomes garbage collectible
+         * again */
         clist_rpush(&_next_removable, (clist_node_t *)tmp);
         if (res == NULL) {
             /* no new entry created yet, get next entry in FIFO */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Following @cgundogan's comment in https://github.com/RIOT-OS/RIOT/pull/10978#pullrequestreview-202567367 I investigated what is broken and the loop has a broken stop condition. This fixes that, I also added a fix for the iteration, that the last element passed in case none can be garbage collected is re-added to the list (otherwise it won't never be garbage collected again).
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
For testing I ran https://gist.github.com/miri64/fac4df86be36f0a65d9bdb4d2f09d5c7#file-03-4-test-sh again, but I adapted [this line] firstly for master and secondly so that the packet buffer doesn't run over that easily: `sendline ${TAP} "ping6 -c ${PING_COUNT} ${TAP0_ADDR} -i 100`. When running it with this script I get a much fairer distribution of packet loss rates across the pinging nodes (one might get something around 0% which is the default router which is not garbage collectible).
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up to #10978.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
