### PR TITLE
tests/rng: replace printf_float with fmt/print_float

### DIFF
--- a/tests/rng/Makefile
+++ b/tests/rng/Makefile
@@ -8,7 +8,6 @@ BOARD_INSUFFICIENT_MEMORY += arduino-duemilanove arduino-uno
 # USEMODULE += prng_minstd
 
 USEMODULE += fmt
-USEMODULE += printf_float
 USEMODULE += random
 USEMODULE += shell
 USEMODULE += xtimer

--- a/tests/rng/test.c
+++ b/tests/rng/test.c
@@ -154,7 +154,7 @@ void test_distributions(uint32_t samples)
 
         /* count bits */
         for (int i = 0; i < 32; i++) {
-            if (value & (1 << i)) {
+            if (value & (UINT32_C(1) << i)) {
                 distributions[i]++;
             }
         }

--- a/tests/rng/test.c
+++ b/tests/rng/test.c
@@ -382,7 +382,15 @@ void test_entropy(uint32_t samples)
     }
 
     /* print results */
-    printf("Calculated %02f bits of entropy from %" PRIu32 " samples.\n", (double) entropy, samples);
+    /* Use 'fmt/print_float' to work on all platforms (atmega)
+     * Stdout should be flushed before to prevent garbled output. */
+    printf("Calculated ");
+#ifdef MODULE_NEWLIB
+    /* no fflush on msp430 */
+    fflush(stdout);
+#endif
+    print_float(entropy, 6);
+    printf(" bits of entropy from %" PRIu32 " samples.\n", samples);
 }
 
 void cb_speed_timeout(void *arg)


### PR DESCRIPTION
### Contribution description

When running the test on `arduino-mega2560` printing the float failed
and was printed as ` ?`.

    Calculated  ? bits of entropy from 10000 samples.

Replace using `printf` floating point printing by using `fmt/print_float`.
Now the test succeeds on `arduino-mega2560`.


I used `6` for the precision because that what was printed for `native` in the firmware output.

### Testing procedure

Run `tests/rng` on an `arduino-mega2560` the test should fail in master and work with this PR

Failure in master:

```
2019-02-12 14:00:58,909 - INFO # Calculated  ? bits of entropy from 10000 samples.
> Timeout in expect script at "child.expect(re.compile(r"Calculated 7\.994\d{3} bits of entropy from 10000 samples\."))" (tests/rng/tests/01-run.py:39)
```

Success with this PR.

```
BOARD=arduino-mega2560 make --no-print-directory -C tests/rng/ flash test
2019-02-12 14:03:30,060 - INFO # Running entropy test, with seed 1337 using constant value.
2019-02-12 14:03:30,061 - INFO #
2019-02-12 14:03:30,175 - INFO # Calculated 0.017260 bits of entropy from 10000 samples.
```

### Issues/PRs references

This was found during release tests: https://github.com/RIOT-OS/Release-Specs/issues/98
