### PR TITLE
net/nanocoap: Buffer API Block implementation

### DIFF
--- a/examples/nanocoap_server/coap_handler.c
+++ b/examples/nanocoap_server/coap_handler.c
@@ -148,7 +148,9 @@ ssize_t _sha256_handler(coap_pkt_t* pkt, uint8_t *buf, size_t len, void *context
 
     ssize_t reply_len = coap_build_reply(pkt, result, buf, len, 0);
     uint8_t *pkt_pos = (uint8_t*)pkt->hdr + reply_len;
-    pkt_pos += coap_put_block1_ok(pkt_pos, &block1, 0);
+    if (blockwise) {
+        pkt_pos += coap_opt_put_block1_control(pkt_pos, 0, &block1);
+    }
     if (result_len) {
         *pkt_pos++ = 0xFF;
         pkt_pos += fmt_bytes_hex((char *)pkt_pos, digest, sizeof(digest));

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -752,6 +752,45 @@ ssize_t coap_opt_finish(coap_pkt_t *pkt, uint16_t flags);
  */
 /**@{*/
 /**
+ * @brief   Insert block option into buffer
+ *
+ * When calling this function to initialize a packet with a block option, the
+ * more flag must be set to prevent the creation of an option with a length too
+ * small to contain the size bit.
+ *
+ * @param[out]  buf         buffer to write to
+ * @param[in]   lastonum    number of previous option, must be < @p option
+ * @param[in]   slicer      coap blockwise slicer helper struct
+ * @param[in]   more        more flag (1 or 0)
+ * @param[in]   option      option number (block1 or block2)
+ *
+ * @returns     amount of bytes written to @p buf
+ */
+size_t coap_opt_put_block(uint8_t *buf, uint16_t lastonum, coap_block_slicer_t *slicer,
+                          bool more, uint16_t option);
+
+/**
+ * @brief   Insert block1 option into buffer
+ *
+ * When calling this function to initialize a packet with a block1 option, the
+ * more flag must be set to prevent the creation of an option with a length too
+ * small to contain the size bit.
+ *
+ * @param[out]  buf         buffer to write to
+ * @param[in]   lastonum    number of previous option (for delta calculation),
+ *                          must be < 27
+ * @param[in]   slicer      coap blockwise slicer helper struct
+ * @param[in]   more        more flag (1 or 0)
+ *
+ * @returns     amount of bytes written to @p buf
+ */
+static inline size_t coap_opt_put_block1(uint8_t *buf, uint16_t lastonum,
+                                         coap_block_slicer_t *slicer, bool more)
+{
+    return coap_opt_put_block(buf, lastonum, slicer, more, COAP_OPT_BLOCK1);
+}
+
+/**
  * @brief   Insert block2 option into buffer
  *
  * When calling this function to initialize a packet with a block2 option, the
@@ -766,7 +805,11 @@ ssize_t coap_opt_finish(coap_pkt_t *pkt, uint16_t flags);
  *
  * @returns     amount of bytes written to @p buf
  */
-size_t coap_opt_put_block2(uint8_t *buf, uint16_t lastonum, coap_block_slicer_t *slicer, bool more);
+static inline size_t coap_opt_put_block2(uint8_t *buf, uint16_t lastonum,
+                                         coap_block_slicer_t *slicer, bool more)
+{
+    return coap_opt_put_block(buf, lastonum, slicer, more, COAP_OPT_BLOCK2);
+}
 
 /**
  * @brief   Encode the given string as multi-part option into buffer

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -812,6 +812,52 @@ static inline size_t coap_opt_put_block2(uint8_t *buf, uint16_t lastonum,
 }
 
 /**
+ * @brief   Insert block option into buffer from block struct
+ *
+ * @param[in]   buf         buffer to write to
+ * @param[in]   lastonum    last option number (must be < @p option)
+ * @param[in]   block       block option attribute struct
+ * @param[in]   option      option number (block1 or block2)
+ *
+ * @returns     amount of bytes written to @p buf
+ */
+size_t coap_opt_put_block_object(uint8_t *buf, uint16_t lastonum,
+                                 coap_block1_t *block, uint16_t option);
+
+/**
+ * @brief   Insert block1 option into buffer in control usage
+ *
+ * @param[in]   buf         buffer to write to
+ * @param[in]   lastonum    last option number (must be < 27)
+ * @param[in]   block       block option attribute struct
+ *
+ * @returns     amount of bytes written to @p buf
+ */
+static inline size_t coap_opt_put_block1_control(uint8_t *buf, uint16_t lastonum,
+                                                 coap_block1_t *block)
+{
+    return coap_opt_put_block_object(buf, lastonum, block, COAP_OPT_BLOCK1);
+}
+
+/**
+ * @brief   Insert block2 option into buffer in control usage
+ *
+ * Forces value of block 'more' attribute to zero, per spec.
+ *
+ * @param[in]   buf         buffer to write to
+ * @param[in]   lastonum    last option number (must be < 27)
+ * @param[in]   block       block option attribute struct
+ *
+ * @returns     amount of bytes written to @p buf
+ */
+static inline size_t coap_opt_put_block2_control(uint8_t *buf, uint16_t lastonum,
+                                                 coap_block1_t *block)
+{
+    block->more = 0;
+    return coap_opt_put_block_object(buf, lastonum, block, COAP_OPT_BLOCK2);
+}
+
+/**
  * @brief   Encode the given string as multi-part option into buffer
  *
  * @param[out]  buf         buffer to write to

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -707,13 +707,17 @@ size_t coap_put_block1_ok(uint8_t *pkt_pos, coap_block1_t *block1, uint16_t last
     }
 }
 
-size_t coap_opt_put_block2(uint8_t *buf, uint16_t lastonum, coap_block_slicer_t *slicer, bool more)
+size_t coap_opt_put_block(uint8_t *buf, uint16_t lastonum, coap_block_slicer_t *slicer,
+                          bool more, uint16_t option)
 {
     unsigned szx = _size2szx(slicer->end - slicer->start);
     unsigned blknum = _slicer_blknum(slicer);
 
+    uint32_t blkopt = (blknum << 4) | szx | (more ? 0x8 : 0);
+    size_t olen = _encode_uint(&blkopt);
+
     slicer->opt = buf;
-    return coap_put_option_block(buf, lastonum, blknum, szx, more, COAP_OPT_BLOCK2);
+    return coap_put_option(buf, lastonum, option, (uint8_t *)&blkopt, olen);
 }
 
 size_t coap_opt_put_string(uint8_t *buf, uint16_t lastonum, uint16_t optnum,

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -720,6 +720,15 @@ size_t coap_opt_put_block(uint8_t *buf, uint16_t lastonum, coap_block_slicer_t *
     return coap_put_option(buf, lastonum, option, (uint8_t *)&blkopt, olen);
 }
 
+size_t coap_opt_put_block_object(uint8_t *buf, uint16_t lastonum,
+                                 coap_block1_t *block, uint16_t option)
+{
+    uint32_t blkopt = (block->blknum << 4) | block->szx | (block->more ? 0x8 : 0);
+    size_t olen = _encode_uint(&blkopt);
+
+    return coap_put_option(buf, lastonum, option, (uint8_t *)&blkopt, olen);
+}
+
 size_t coap_opt_put_string(uint8_t *buf, uint16_t lastonum, uint16_t optnum,
                            const char *string, char separator)
 {


### PR DESCRIPTION
### Contribution description
Presently, the nanocoap Buffer API includes server side implementation of Block options. In other words, it includes block2 descriptive use (sends blockwise content) and block1 control use (receives/acks blockwise content). This PR extends the API to include block2 control use and block1 descriptive use for client side requests.

At the same time, this PR standardizes block function names to include "control" for control use, as shown in the table below.

| Old Function | New Function | Notes |
| ---------------- | ------------------ | ------- |
| coap_opt_put_block2() | coap_opt_put_block2() | no change |
| N/A | coap_opt_put_block2_control() | new |
| coap_put_option_block1()<br>coap_put_block1_ok() | coap_opt_put_block1_control() | coap_put_block1_ok() is a convenience function to only call coap_put_option_block1() if the _more_ attribute is 1. This approach is in error; see below. |
| N/A | coap_opt_put_block1() | accepts a slicer struct, like coap_opt_put_block2() |

### Testing procedure
For this PR our main focus is refactoring the current implementation, so testing is for regression. Ensure the nanocoap_server example /sha256 and /riot/ver resources still work. 

FWIW, I have functional tests in the [riot-coap-pytest](https://github.com/kb2ma/riot-coap-pytest) repository. If you run block1_client.py, which is a script for aiocoap to POST /sha256, you will see that the old implementation generates the warning below. This is due to coap_put_block1_ok() omitting the block option in the last ACK, as described in the table above. RFC 7959, sec. 3.2 also shows that the final response is expected to include the option in the final ACK.

```
$ ./block1_client.py -r[${TAP_LLADDR_SUT}] -b 32
WARNING:coap.blockwise-requester:Block1 option completely ignored by server, assuming it knows what it is doing.
Result: 2.04 Changed
b'C496DF5946783990BEC5EFDC2999530EEB9175B83094BAE66170FF2431FC896E'
```

However, the new implementation does not generate the warning.
```
$ ./block1_client.py -r[${TAP_LLADDR_SUT}] -b 32
Result: 2.04 Changed
b'C496DF5946783990BEC5EFDC2999530EEB9175B83094BAE66170FF2431FC896E'
```

The next PR in the sequence includes a couple of helper functions to make the new client side functions easy to use. We will add tests for those uses with that PR, but you can get a preview in the [nano-block-client](https://github.com/kb2ma/riot-apps/blob/kb2ma-master/nano-block-client/block_client.c) app.

### Issues/PRs references
Partially implements #10732. Depends on #10876.
