### PR TITLE
tools/serial.inc.mk: Support miniterm.py.

### DIFF
--- a/makefiles/tools/serial.inc.mk
+++ b/makefiles/tools/serial.inc.mk
@@ -19,4 +19,9 @@ ifeq ($(RIOT_TERMINAL),pyterm)
 else ifeq ($(RIOT_TERMINAL),picocom)
   export TERMPROG  ?= picocom
   export TERMFLAGS ?= --nolock --imap lfcrlf --echo --baud "$(BAUD)" "$(PORT)"
+else ifeq ($(RIOT_TERMINAL),miniterm.py)
+  export TERMPROG  ?= miniterm.py
+  # The RIOT shell will still transmit back a CRLF, but at least with --eol LF
+  # we avoid sending two lines on every "enter".
+  export TERMFLAGS ?= --eol LF "$(PORT)" "$(BAUD)"
 endif

--- a/tests/shell/Makefile
+++ b/tests/shell/Makefile
@@ -15,7 +15,7 @@ TEST_ON_CI_WHITELIST += all
 # In order to properly test and debug the shell it is better to use a terminal
 # program that does not modify the input and output streams and has no buffering.
 ifneq ($(BOARD), native)
-  RIOT_TERMINAL?=miniterm.py
+  RIOT_TERMINAL ?= miniterm.py
 endif
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/shell/Makefile
+++ b/tests/shell/Makefile
@@ -12,4 +12,10 @@ BOARD_BLACKLIST += chronos
 
 TEST_ON_CI_WHITELIST += all
 
+# In order to properly test and debug the shell it is better to use a terminal
+# program that does not modify the input and output streams and has no buffering.
+ifneq ($(BOARD), native)
+  RIOT_TERMINAL?=miniterm.py
+endif
+
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
### Contribution description

miniterm.py is a simple terminal program that is included with pyserial. This means that it is available wherever pyterm can work. It allows raw access, does line translation and passes through special characters.

For test scripts, a terminal that does not modify the input and output streams, configured without local echo, is preferred as it ensures the test setup is introducing as few noise as possible.

### Testing procedure

With this change, `tests/shell` uses miniterm.py. Just run the tests. Use a real board, native has no real TTY.

```
$ cd tests/shell
$ BOARD=samr21-xpro make all
$ BOARD=samr21-xpro make flash
$ BOARD=samr21-xpro make test
```

### Issues/PRs references

This PR is part of  #10994 and it's purpose is to ease shell automation.
Split from  #10788 .
