### PR TITLE
 sys/shell: cancel current line on CTRL-C.

### DIFF
--- a/sys/shell/shell.c
+++ b/sys/shell/shell.c
@@ -32,6 +32,7 @@
 #include "shell.h"
 #include "shell_commands.h"
 
+#define ETX '\x03'  /** ASCII "End-of-Text", or ctrl-C */
 #if !defined(SHELL_NO_ECHO) || !defined(SHELL_NO_PROMPT)
 #ifdef MODULE_NEWLIB
 /* use local copy of putchar, as it seems to be inlined,
@@ -243,7 +244,8 @@ static int readline(char *buf, size_t size)
         /* We allow Unix linebreaks (\n), DOS linebreaks (\r\n), and Mac linebreaks (\r). */
         /* QEMU transmits only a single '\r' == 13 on hitting enter ("-serial stdio"). */
         /* DOS newlines are handled like hitting enter twice, but empty lines are ignored. */
-        if (c == '\r' || c == '\n') {
+        /* Ctrl-C cancels the current line. */
+        if (c == '\r' || c == '\n' || c == ETX) {
             *line_buf_ptr = '\0';
 #ifndef SHELL_NO_ECHO
             _putchar('\r');
@@ -251,7 +253,7 @@ static int readline(char *buf, size_t size)
 #endif
 
             /* return 1 if line is empty, 0 otherwise */
-            return line_buf_ptr == buf;
+            return c == ETX || line_buf_ptr == buf;
         }
         /* QEMU uses 0x7f (DEL) as backspace, while 0x08 (BS) is for most terminals */
         else if (c == 0x08 || c == 0x7f) {

--- a/tests/shell/Makefile
+++ b/tests/shell/Makefile
@@ -6,6 +6,9 @@ USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += ps
 
+# Use a terminal that does not introduce extra characters into the stream.
+RIOT_TERMINAL ?= socat
+
 DISABLE_MODULE += auto_init
 
 # chronos is missing a getchar implementation

--- a/tests/shell/tests/01-run.py
+++ b/tests/shell/tests/01-run.py
@@ -27,19 +27,19 @@ EXPECTED_PS = (
     '\t  2 | running  Q |   7'
 )
 
-CMDS = {
-    'start_test': ('[TEST_START]'),
-    'end_test': ('[TEST_END]'),
-    '\n': ('>'),
-    '123456789012345678901234567890123456789012345678901234567890':
+CMDS = (
+    ('start_test', ('[TEST_START]')),
+    ('end_test', ('[TEST_END]')),
+    ('\n', ('>')),
+    ('123456789012345678901234567890123456789012345678901234567890',
         ('shell: command not found: '
-         '123456789012345678901234567890123456789012345678901234567890'),
-    'unknown_command': ('shell: command not found: unknown_command'),
-    'help': EXPECTED_HELP,
-    'echo a string': ('\"echo\"\"a\"\"string\"'),
-    'ps': EXPECTED_PS,
-    'reboot': ('test_shell.')
-}
+         '123456789012345678901234567890123456789012345678901234567890')),
+    ('unknown_command', ('shell: command not found: unknown_command')),
+    ('help', EXPECTED_HELP),
+    ('echo a string', ('\"echo\"\"a\"\"string\"')),
+    ('ps', EXPECTED_PS),
+    ('reboot', ('test_shell.'))
+)
 
 
 def check_cmd(child, cmd, expected):
@@ -53,7 +53,7 @@ def testfunc(child):
     child.expect('test_shell.')
 
     # loop other defined commands and expected output
-    for cmd, expected in CMDS.items():
+    for cmd, expected in CMDS:
         check_cmd(child, cmd, expected)
 
 

--- a/tests/shell/tests/01-run.py
+++ b/tests/shell/tests/01-run.py
@@ -27,6 +27,18 @@ EXPECTED_PS = (
     '\t  2 | running  Q |   7'
 )
 
+# In native we are directly executing the binary (no terminal program). We must
+# therefore use Ctrl-V (DLE or "data link escape") before Ctrl-C to send a
+# literal ETX instead of SIGINT.
+# When using a board it is also a problem because we are using a "user friendly"
+# terminal that interprets Ctrl-C. So until we have rawterm we must also use
+# ctrl-v in boards.
+
+DLE = '\x16'
+
+CONTROL_C = DLE+'\x03'
+CONTROL_D = DLE+'\x04'
+
 CMDS = (
     ('start_test', ('[TEST_START]')),
     ('end_test', ('[TEST_END]')),
@@ -38,6 +50,8 @@ CMDS = (
     ('help', EXPECTED_HELP),
     ('echo a string', ('\"echo\"\"a\"\"string\"')),
     ('ps', EXPECTED_PS),
+    ('garbage1234'+CONTROL_C, ('>')),  # test cancelling a line
+    ('help', EXPECTED_HELP),
     ('reboot', ('test_shell.'))
 )
 


### PR DESCRIPTION
### Contribution description

Just like in a regular UNIX terminal, control-C now cancels the current line.  This is a suggestion of @benemorius.

This is useful if one is using a dumb terminal to communicate with a node, as it saves having to repeatedly type backspace to discard the current line. It also helps when connecting to an already running node,
as one does not know what is on the line buffer, the safest thing to do is to begin by sending a ctrl-C.

#### Other changes

To be able to test this I had to do a couple of modifications to `tests/shell`.

- Fix the use of python dictionaries: Python dictionaries are not guaranteed to be ordered until version
3.7. In 3.6 they are ordered too, but that is an implementation detail. riotdocker seems to be using 3.5. The commands in this test were stored in a dict.

- Use miniterm instead of pyterm: pyterm messes up control characters, so the test was changed to use
miniterm.py instead.

### Testing procedure

I have included a test. It should work both on a board or in native:

```
$ cd tests/shell
$ BOARD=samr21-xpro make all
$ BOARD=samr21-xpro make flash
$ BOARD=samr21-xpro make test
```

If testing by hand:

- On a board, be sure to use a terminal that forwards ctrl-C, otherwise you will not be testing the thing. This means _no_ pyterm.
- On native, use Ctrl-V+ctrl-C to insert a literal ETX, otherwise you will be sending a SIGINT.

### Issues/PRs references

Depends on ~#11003~ for testing.
Part of #10994 .
Split from #10788 .