### PR TITLE
tests/periph_eeprom: use EEPROM_CLEAR_BYTE

### DIFF
--- a/tests/periph_eeprom/main.c
+++ b/tests/periph_eeprom/main.c
@@ -246,7 +246,10 @@ static int cmd_test(int argc, char **argv)
     assert(eeprom_read_byte(EEPROM_SIZE / 2) == 'A');
 
     /* clear some bytes */
-    const uint8_t cleared[4] = {0, 0, 0, 0,};
+    const uint8_t cleared[4] = {
+        EEPROM_CLEAR_BYTE, EEPROM_CLEAR_BYTE,
+        EEPROM_CLEAR_BYTE, EEPROM_CLEAR_BYTE,
+    };
     eeprom_clear(0, 4);
     memset(result, 0, 4);
     ret = eeprom_read(0, (uint8_t *)result, 4);

--- a/tests/periph_eeprom/main.c
+++ b/tests/periph_eeprom/main.c
@@ -226,7 +226,7 @@ static int cmd_test(int argc, char **argv)
 
     char result[4];
     ret = eeprom_read(0, (uint8_t *)result, 4);
-    assert(strncmp(result, expected, 4) == 0);
+    assert(memcmp(result, expected, 4) == 0);
     assert(ret == 4);
 
     /* read/write at end of EEPROM */
@@ -234,7 +234,7 @@ static int cmd_test(int argc, char **argv)
     assert(ret == 4);
     memset(result, 0, 4);
     ret = eeprom_read(EEPROM_SIZE - 4, (uint8_t *)result, 4);
-    assert(strncmp(result, expected, 4) == 0);
+    assert(memcmp(result, expected, 4) == 0);
     assert(ret == 4);
 
     /* read/write single byte */
@@ -260,13 +260,13 @@ static int cmd_test(int argc, char **argv)
     /* set some bytes */
     eeprom_set(0, 'A', 4);
     ret = eeprom_read(0, (uint8_t *)result, 4);
-    assert(strncmp(result, "AAAA", 4) == 0);
+    assert(memcmp(result, "AAAA", 4) == 0);
     assert(ret == 4);
 
     memset(result, 0, 4);
     eeprom_set(EEPROM_SIZE - 4, 'A', 4);
     ret = eeprom_read(EEPROM_SIZE - 4, (uint8_t *)result, 4);
-    assert(strncmp(result, "AAAA", 4) == 0);
+    assert(memcmp(result, "AAAA", 4) == 0);
     assert(ret == 4);
 
     puts("SUCCESS");

--- a/tests/periph_eeprom/main.c
+++ b/tests/periph_eeprom/main.c
@@ -246,15 +246,16 @@ static int cmd_test(int argc, char **argv)
     assert(eeprom_read_byte(EEPROM_SIZE / 2) == 'A');
 
     /* clear some bytes */
+    const uint8_t cleared[4] = {0, 0, 0, 0,};
     eeprom_clear(0, 4);
     memset(result, 0, 4);
     ret = eeprom_read(0, (uint8_t *)result, 4);
-    assert(strncmp(result, "", 4) == 0);
+    assert(memcmp(result, cleared, 4) == 0);
     assert(ret == 4);
 
     eeprom_clear(EEPROM_SIZE - 4, 4);
     ret = eeprom_read(EEPROM_SIZE - 4, (uint8_t *)result, 4);
-    assert(strncmp(result, "", 4) == 0);
+    assert(memcmp(result, cleared, 4) == 0);
     assert(ret == 4);
 
     /* set some bytes */

--- a/tests/periph_eeprom/main.c
+++ b/tests/periph_eeprom/main.c
@@ -226,7 +226,7 @@ static int cmd_test(int argc, char **argv)
 
     char result[4];
     ret = eeprom_read(0, (uint8_t *)result, 4);
-    assert(strncmp((const char *)result, (const char *)expected, 4) == 0);
+    assert(strncmp(result, expected, 4) == 0);
     assert(ret == 4);
 
     /* read/write at end of EEPROM */
@@ -234,7 +234,7 @@ static int cmd_test(int argc, char **argv)
     assert(ret == 4);
     memset(result, 0, 4);
     ret = eeprom_read(EEPROM_SIZE - 4, (uint8_t *)result, 4);
-    assert(strncmp((const char *)result, expected, 4) == 0);
+    assert(strncmp(result, expected, 4) == 0);
     assert(ret == 4);
 
     /* read/write single byte */
@@ -249,24 +249,24 @@ static int cmd_test(int argc, char **argv)
     eeprom_clear(0, 4);
     memset(result, 0, 4);
     ret = eeprom_read(0, (uint8_t *)result, 4);
-    assert(strncmp((const char *)result, "", 4) == 0);
+    assert(strncmp(result, "", 4) == 0);
     assert(ret == 4);
 
     eeprom_clear(EEPROM_SIZE - 4, 4);
     ret = eeprom_read(EEPROM_SIZE - 4, (uint8_t *)result, 4);
-    assert(strncmp((const char *)result, "", 4) == 0);
+    assert(strncmp(result, "", 4) == 0);
     assert(ret == 4);
 
     /* set some bytes */
     eeprom_set(0, 'A', 4);
     ret = eeprom_read(0, (uint8_t *)result, 4);
-    assert(strncmp((const char *)result, "AAAA", 4) == 0);
+    assert(strncmp(result, "AAAA", 4) == 0);
     assert(ret == 4);
 
     memset(result, 0, 4);
     eeprom_set(EEPROM_SIZE - 4, 'A', 4);
     ret = eeprom_read(EEPROM_SIZE - 4, (uint8_t *)result, 4);
-    assert(strncmp((const char *)result, "AAAA", 4) == 0);
+    assert(strncmp(result, "AAAA", 4) == 0);
     assert(ret == 4);
 
     puts("SUCCESS");

--- a/tests/periph_eeprom/main.c
+++ b/tests/periph_eeprom/main.c
@@ -224,7 +224,7 @@ static int cmd_test(int argc, char **argv)
     size_t ret = eeprom_write(0, (uint8_t *)expected, 4);
     assert(ret == 4);
 
-    char *result[4];
+    char result[4];
     ret = eeprom_read(0, (uint8_t *)result, 4);
     assert(strncmp((const char *)result, (const char *)expected, 4) == 0);
     assert(ret == 4);


### PR DESCRIPTION
### Contribution description

When eeprom/clear was introduced, the pull request was not tested on an `atmega` board even if it had `atmega` specific modifications.

The test `tests/periph_eeprom` failed with this board because `EEPROM_CLEAR_BYTE` was not taken into account.

This PR handles this fix and related issues found on the way.

* Use of an array of pointer instead of an array
* Clean of now un-necessary casts (and why even cast something to `const pointer` as an argument ?)
* Use of `strncmp` to verify that two memory regions are equal even when checking for a region with 4 times 0.
* The fix to use `EEPROM_CLEAR_BYTE`

It can be reviewed commits by commits and can be split on demand.

This is a new feature from the release so would be nice to have it integrated with a fixed test during this one.

### Testing procedure


Run the `tests/periph_eeprom` on `arduino-mega2560` the test should now work. It fails on master with a failed assertion on the `clear` test:

```
CFLAGS=-DDEBUG_ASSERT_VERBOSE DEVELHELP=1 DOCKER="sudo docker" BUILD_IN_DOCKER=1 BOARD=arduino-mega2560 make flash test
...
> test
2019-02-12 16:46:01,069 - INFO #  test
2019-02-12 16:46:01,204 - INFO # /data/riotbuild/riotproject/tests/periph_eeprom/main.c:252 => Stack Pointer: 0x0a68
2019-02-12 16:46:01,225 - INFO # *** RIOT kernel panic:
2019-02-12 16:46:01,245 - INFO # FAILED ASSERTION.
2019-02-12 16:46:01,245 - INFO # 
2019-02-12 16:46:01,257 - INFO # *** halted.
```

It would be nice to also run the test on other supported boards

* Tested boards:
  * atmega family: 
    * [x] arduino-mega2560

I did not trigger murdock tests as `samr21-xpro` does not have the eeprom support.


### Issues/PRs references

This issue was found during the tests for the release https://github.com/RIOT-OS/Release-Specs/issues/98

Introduced by https://github.com/RIOT-OS/RIOT/pull/10056