### PR TITLE
core: Added thread_signal & thread_await_signal

### DIFF
--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -119,6 +119,8 @@
 #ifndef THREAD_H
 #define THREAD_H
 
+#include <stdbool.h>
+
 #include "clist.h"
 #include "cib.h"
 #include "msg.h"
@@ -323,17 +325,7 @@ struct _thread {
  * @warning The active thread will be marked as received when this initializer
  *          is used
  */
-#define THREAD_SIGNAL_INIT              { .pid = sched_active_pid, .status = THREAD_AWAIT_SIGNAL }
-
-/**
- * @brief Status used to control whether @ref thread_await_signal will block or
- *        return right away
- */
-typedef enum {
-    THREAD_AWAIT_SIGNAL,            /**< @ref thread_await_signal will await the signal */
-    THREAD_SIGNAL_RECEIVED,         /**< signal received, no waiting required */
-    THREAD_SIGNAL_STATUS_NUMOF      /**< number of elements */
-} thread_signal_status_t;
+#define THREAD_SIGNAL_INIT              { .pid = sched_active_pid, .signal_received = false }
 
 /**
  * @brief Structure holding the data used by @ref thread_signal and
@@ -341,7 +333,7 @@ typedef enum {
  */
 typedef struct {
     kernel_pid_t pid;               /**< Thread to signal */
-    thread_signal_status_t status;  /**< Was signal received already? */
+    bool signal_received;           /**< Was signal received already? */
 } thread_signal_t;
 
 /** @} */
@@ -464,7 +456,7 @@ int thread_signal(thread_signal_t *signal);
  */
 static inline void thread_signal_init(thread_signal_t *signal, kernel_pid_t pid)
 {
-    signal->status = THREAD_AWAIT_SIGNAL;
+    signal->signal_received = false;
     signal->pid = pid;
 }
 
@@ -478,7 +470,7 @@ static inline void thread_signal_init(thread_signal_t *signal, kernel_pid_t pid)
  */
 static inline int thread_wakeup(kernel_pid_t pid)
 {
-    thread_signal_t sig = { .pid = pid, .status = THREAD_AWAIT_SIGNAL };
+    thread_signal_t sig = { .pid = pid, .signal_received = false };
     return (thread_signal(&sig) >= 0) ? 1 : STATUS_NOT_FOUND;
 }
 

--- a/core/thread.c
+++ b/core/thread.c
@@ -64,7 +64,8 @@ void thread_await_signal(thread_signal_t *signal)
     unsigned state = irq_disable();
     if (signal) {
         signal->pid = sched_active_pid;
-        if (signal->status == THREAD_SIGNAL_RECEIVED) {
+        if (signal->signal_received) {
+            signal->signal_received = false;
             irq_restore(state);
             return;
         }
@@ -72,6 +73,7 @@ void thread_await_signal(thread_signal_t *signal)
     sched_set_status((thread_t *)sched_active_thread, STATUS_SLEEPING);
     irq_restore(state);
     thread_yield_higher();
+    signal->signal_received = false;
 }
 
 int thread_signal(thread_signal_t *signal)
@@ -84,7 +86,7 @@ int thread_signal(thread_signal_t *signal)
 
     thread_t *other_thread = (thread_t *) thread_get(signal->pid);
 
-    signal->status = THREAD_SIGNAL_RECEIVED;
+    signal->signal_received = true;
 
     if (!other_thread) {
         DEBUG("thread_signal: Thread does not exist!\n");


### PR DESCRIPTION
### Contribution description

`thread_sleep()` and `thread_wakeup()` provide simple means to signal an event to a thread. However, the calls need to be synchronized: The waiting thread has to call `thread_sleep()` before `thread_wakeup()` is called.

This commit adds `thread_await_signal()` and `thread_signal()` which do not need to be synchronized: If `thread_signal()` is called between to calls to `thread_await_signal()`, the second call to `thread_await_signal()` will return immediately. If `thread_await_signal()` is called before the matching call to `thread_signal()`, they will behave like `thread_wakeup()` and `thread_sleep()`.

### Testing procedure

As `thread_sleep()` and `thread_wakeup()` are changed to internally use `thread_await_signal()` and `thread_signal()`, testing if they still work should be done. `thread_await_signal()` and `thread_signal()` could be tested with https://github.com/RIOT-OS/RIOT/pull/10340, which I will update to use this PR after my next appointment. I could also provide a minimum example application using both APIs, if needed be.

### Issues/PRs references

Used in PR https://github.com/RIOT-OS/RIOT/pull/10340 to make `netdev_driver_t::send()` blocking while still handling ISRs in a way that does not block the CPU for a couple of milliseconds. PR https://github.com/RIOT-OS/RIOT/pull/8304 be rewritten to use this more lightweight API instead of `thread_flags`. (To avoid confusion: This API is unable to replace `thread_flags` and does not want to do this. But in the use cases both could be used, this API is more lightweight.) Maybe also `at86rf2xx` implementation to make `netdev_driver_t::send()` blocking while waiting TX to complete could use this API and an interrupt instead of busy waiting for TX to complete.