### PR TITLE
gnrc_ipv6_nib/arsm: ensure proper int width in backoff calculation [backport 2019.01]

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.c
@@ -460,18 +460,10 @@ bool _is_reachable(_nib_onl_entry_t *entry)
 static inline uint32_t _exp_backoff_retrans_timer(uint8_t ns_sent,
                                                   uint32_t retrans_timer)
 {
-    uint32_t tmp = random_uint32_range(NDP_MIN_RANDOM_FACTOR,
-                                       NDP_MAX_RANDOM_FACTOR);
+    uint32_t factor = random_uint32_range(NDP_MIN_RANDOM_FACTOR,
+                                          NDP_MAX_RANDOM_FACTOR);
 
-    /* backoff according to  https://tools.ietf.org/html/rfc7048 with
-     * BACKOFF_MULTIPLE == 2 */
-    tmp = (uint32_t)(((uint64_t)(((uint32_t) 1) << ns_sent) * retrans_timer *
-                     tmp) / US_PER_MS);
-    /* random factors were statically multiplied with 1000 ^ */
-    if (tmp > NDP_MAX_RETRANS_TIMER_MS) {
-        tmp = NDP_MAX_RETRANS_TIMER_MS;
-    }
-    return tmp;
+    return _exp_backoff_retrans_timer_factor(ns_sent, retrans_timer, factor);
 }
 
 #if GNRC_IPV6_NIB_CONF_REDIRECT

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.c
@@ -465,7 +465,8 @@ static inline uint32_t _exp_backoff_retrans_timer(uint8_t ns_sent,
 
     /* backoff according to  https://tools.ietf.org/html/rfc7048 with
      * BACKOFF_MULTIPLE == 2 */
-    tmp = ((1 << ns_sent) * retrans_timer * tmp) / US_PER_MS;
+    tmp = (uint32_t)(((uint64_t)(((uint32_t) 1) << ns_sent) * retrans_timer *
+                     tmp) / US_PER_MS);
     /* random factors were statically multiplied with 1000 ^ */
     if (tmp > NDP_MAX_RETRANS_TIMER_MS) {
         tmp = NDP_MAX_RETRANS_TIMER_MS;

--- a/tests/unittests/tests-gnrc_ipv6_nib/tests-gnrc_ipv6_nib-internal.c
+++ b/tests/unittests/tests-gnrc_ipv6_nib/tests-gnrc_ipv6_nib-internal.c
@@ -21,6 +21,7 @@
 #include "net/gnrc/ipv6/nib.h"
 
 #include "_nib-internal.h"
+#include "_nib-arsm.h"
 
 #include "unittests-constants.h"
 
@@ -1947,6 +1948,58 @@ static void test_nib_abr_iter__three_elem_middle_removed(void)
 }
 #endif
 
+static void test_retrans_exp_backoff(void)
+{
+    TEST_ASSERT_EQUAL_INT(0,
+            _exp_backoff_retrans_timer_factor(0, 0, NDP_MIN_RANDOM_FACTOR));
+    /* factor 1000 means multiplied by 1 */
+    TEST_ASSERT_EQUAL_INT(NDP_RETRANS_TIMER_MS,
+            _exp_backoff_retrans_timer_factor(0, NDP_RETRANS_TIMER_MS, 1000));
+    TEST_ASSERT_EQUAL_INT(2 * NDP_RETRANS_TIMER_MS,     /* 2^1 = 2 */
+            _exp_backoff_retrans_timer_factor(1, NDP_RETRANS_TIMER_MS, 1000));
+    TEST_ASSERT_EQUAL_INT(4 * NDP_RETRANS_TIMER_MS,     /* 2^2 = 4 */
+            _exp_backoff_retrans_timer_factor(2, NDP_RETRANS_TIMER_MS, 1000));
+    TEST_ASSERT_EQUAL_INT(8 * NDP_RETRANS_TIMER_MS,     /* 2^3 = 8 */
+            _exp_backoff_retrans_timer_factor(3, NDP_RETRANS_TIMER_MS, 1000));
+    TEST_ASSERT_EQUAL_INT(16 * NDP_RETRANS_TIMER_MS,    /* 2^4 = 16 */
+            _exp_backoff_retrans_timer_factor(4, NDP_RETRANS_TIMER_MS, 1000));
+    TEST_ASSERT_EQUAL_INT(32 * NDP_RETRANS_TIMER_MS,    /* 2^5 = 32 */
+            _exp_backoff_retrans_timer_factor(5, NDP_RETRANS_TIMER_MS, 1000));
+    TEST_ASSERT_EQUAL_INT(NDP_MAX_RETRANS_TIMER_MS,
+            _exp_backoff_retrans_timer_factor(6, NDP_RETRANS_TIMER_MS, 1000));
+    TEST_ASSERT_EQUAL_INT(NDP_MAX_RETRANS_TIMER_MS,
+            _exp_backoff_retrans_timer_factor(0, UINT32_MAX,
+                                              NDP_MIN_RANDOM_FACTOR));
+    TEST_ASSERT_EQUAL_INT(NDP_MAX_RETRANS_TIMER_MS,
+            _exp_backoff_retrans_timer_factor(0, UINT32_MAX,
+                                              NDP_MAX_RANDOM_FACTOR - 1));
+    TEST_ASSERT_EQUAL_INT(NDP_MAX_RETRANS_TIMER_MS,
+            _exp_backoff_retrans_timer_factor(NDP_MAX_NS_NUMOF, UINT32_MAX,
+                                              NDP_MAX_RANDOM_FACTOR - 1));
+    TEST_ASSERT_EQUAL_INT(NDP_MAX_RETRANS_TIMER_MS,
+            _exp_backoff_retrans_timer_factor(NDP_MAX_NS_NUMOF,
+                                              NDP_RETRANS_TIMER_MS,
+                                              NDP_MAX_RANDOM_FACTOR - 1));
+    TEST_ASSERT_EQUAL_INT(NDP_MAX_RETRANS_TIMER_MS,
+            _exp_backoff_retrans_timer_factor(NDP_MAX_NS_NUMOF,
+                                              NDP_RETRANS_TIMER_MS,
+                                              NDP_MIN_RANDOM_FACTOR));
+    TEST_ASSERT_EQUAL_INT(NDP_MAX_RETRANS_TIMER_MS,
+            _exp_backoff_retrans_timer_factor(NDP_MAX_NS_NUMOF,
+                                              NDP_MAX_RETRANS_TIMER_MS,
+                                              NDP_MAX_RANDOM_FACTOR - 1));
+    TEST_ASSERT_EQUAL_INT(32768,
+            _exp_backoff_retrans_timer_factor(NDP_MAX_NS_NUMOF - 1, 1,
+                                              NDP_MIN_RANDOM_FACTOR));
+    TEST_ASSERT_EQUAL_INT(47653,
+            _exp_backoff_retrans_timer_factor(5U, 1118U, 1332));
+    TEST_ASSERT_EQUAL_INT(47653,
+            _exp_backoff_retrans_timer_factor(5U, 1118U, 1332));
+    /* test 64-bit overfrow */
+    TEST_ASSERT_EQUAL_INT(NDP_MAX_RETRANS_TIMER_MS,
+            _exp_backoff_retrans_timer_factor(NDP_MAX_NS_NUMOF, 32768, 1024));
+}
+
 Test *tests_gnrc_ipv6_nib_internal_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -2046,6 +2099,7 @@ Test *tests_gnrc_ipv6_nib_internal_tests(void)
         new_TestFixture(test_nib_abr_iter__three_elem),
         new_TestFixture(test_nib_abr_iter__three_elem_middle_removed),
 #endif
+        new_TestFixture(test_retrans_exp_backoff),
     };
 
     EMB_UNIT_TESTCALLER(tests, set_up, NULL,


### PR DESCRIPTION
# Backport of #10369

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Otherwise, the result might flow over on 8/16-bit platforms

### Testing procedure
I'm not sure the address resolution state machine fits on any of our 8/16-bit platforms... But otherwise: 

* flash an application with `gnrc_ipv6_default` an `GNRC_IPV6_NIB_CONF_ARSM == 1` to two 8- or 16-bit boards with networking capabilities
* let them find via neighbor discovery (e.g. by pinging one from the other)
* let the neighbor information go STALE (check with `nib neigh`)
* let one of the nodes become unreachable (e.g. by turning it off)
* try to update stale neighbor information (e.g. by pinging again)
* let the neighbor information go to UNREACHABLE (check with `nib neigh`)
* see (e.g. with wireshark) that the neighbor solicitations go out ad infinitum but with an truncated (at `NDP_MAX_RETRANS_TIMER_MS` == 1min) exponential (base 2) backoff between them.
* run `unittests` with `tests-gnrc_ipv6_nib` on various platforms.

### Issues/PRs references
Pointed out in https://github.com/RIOT-OS/RIOT/pull/10350#discussion_r231905390
