### PR TITLE
net/gnrc/pktbuf.h: add note in gnrc_pktbuf_mark

### DIFF
--- a/sys/include/net/gnrc/pktbuf.h
+++ b/sys/include/net/gnrc/pktbuf.h
@@ -113,6 +113,9 @@ gnrc_pktsnip_t *gnrc_pktbuf_add(gnrc_pktsnip_t *next, const void *data, size_t s
  * @param[in] size  The size of the new packet snip.
  * @param[in] type  The type of the new packet snip.
  *
+ * @note    It's not guaranteeed that `result->data` points to the same address
+ *          as the original `pkt->data`.
+ *
  * @return  The new packet snip in @p pkt on success.
  * @return  NULL, if pkt == NULL or size == 0 or size > pkt->size or pkt->data == NULL.
  * @return  NULL, if no space is left in the packet buffer.


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR adds a note to `gnrc_pktbuf_mark` documentation.
After calling this function, `result->data` might not point to the same address as the original `pkt->data`.

So, there would be a problem in code like:
```c
char *buf = pkt->data;
size_t size = pkt->size;
result = gnrc_pktbuf_mark(pkt, SIZE, GNRC_NETTYPE_UNDEF);
memset(buf, 0, size); /* This line could write to an invalid address in the pktbuf */
```
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`make doc`
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None so far
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
