### PR TITLE
gnrc_sixlowpan_frag: remove redundant PID member

### DIFF
--- a/sys/include/net/gnrc/sixlowpan/frag.h
+++ b/sys/include/net/gnrc/sixlowpan/frag.h
@@ -92,7 +92,6 @@ typedef struct {
     size_t datagram_size;   /**< Length of just the (uncompressed) IPv6 packet to be fragmented */
     uint16_t offset;        /**< Offset of the Nth fragment from the beginning of the
                              *   payload datagram */
-    kernel_pid_t pid;       /**< PID of the interface */
 } gnrc_sixlowpan_msg_frag_t;
 
 /**

--- a/sys/include/net/gnrc/sixlowpan/frag.h
+++ b/sys/include/net/gnrc/sixlowpan/frag.h
@@ -89,7 +89,7 @@ typedef struct {
  */
 typedef struct {
     gnrc_pktsnip_t *pkt;    /**< Pointer to the IPv6 packet to be fragmented */
-    size_t datagram_size;   /**< Length of just the (uncompressed) IPv6 packet to be fragmented */
+    uint16_t datagram_size; /**< Length of just the (uncompressed) IPv6 packet to be fragmented */
     uint16_t offset;        /**< Offset of the Nth fragment from the beginning of the
                              *   payload datagram */
 } gnrc_sixlowpan_msg_frag_t;

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/gnrc_sixlowpan_frag.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/gnrc_sixlowpan_frag.c
@@ -31,9 +31,7 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
-static gnrc_sixlowpan_msg_frag_t _fragment_msg = {
-        NULL, 0, 0, KERNEL_PID_UNDEF
-    };
+static gnrc_sixlowpan_msg_frag_t _fragment_msg;
 
 #if ENABLE_DEBUG
 /* For PRIu16 etc. */
@@ -238,7 +236,7 @@ void gnrc_sixlowpan_frag_send(gnrc_pktsnip_t *pkt, void *ctx, unsigned page)
 {
     assert(ctx != NULL);
     gnrc_sixlowpan_msg_frag_t *fragment_msg = ctx;
-    gnrc_netif_t *iface = gnrc_netif_get_by_pid(fragment_msg->pid);
+    gnrc_netif_t *iface;
     uint16_t res;
     /* payload_len: actual size of the packet vs
      * datagram_size: size of the uncompressed IPv6 packet */
@@ -248,6 +246,7 @@ void gnrc_sixlowpan_frag_send(gnrc_pktsnip_t *pkt, void *ctx, unsigned page)
     assert((fragment_msg->pkt == pkt) || (pkt == NULL));
     (void)page;
     (void)pkt;
+    iface = gnrc_netif_hdr_get_netif(fragment_msg->pkt->data);
 #if defined(DEVELHELP) && ENABLE_DEBUG
     if (iface == NULL) {
         DEBUG("6lo frag: iface == NULL, expect segmentation fault.\n");

--- a/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
@@ -129,7 +129,6 @@ void gnrc_sixlowpan_multiplex_by_size(gnrc_pktsnip_t *pkt,
             gnrc_pktbuf_release_error(pkt, ENOMEM);
             return;
         }
-        fragment_msg->pid = netif->pid;
         fragment_msg->pkt = pkt;
         fragment_msg->datagram_size = orig_datagram_size;
         /* Sending the first fragment has an offset==0 */


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
The interface ID is actually also provided in `pkt` so providing it in the `gnrc_sixlowpan_msg_frag_t` struct is redundant.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`examples/gnrc_networking` on a 6Lo-compatible board (e.g. `iotlab-m3`, `samr21-xpro`, etc.) should still be able to ping with large payloads (e.g. >100) to a node flashed with `examples/gnrc_border_router` (link-local addresses is enough).
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
