### PR TITLE
drivers/hts211: fix CTRL_REG2_OS_EN

### DIFF
--- a/drivers/hts221/include/hts221_regs.h
+++ b/drivers/hts221/include/hts221_regs.h
@@ -125,7 +125,7 @@ enum {
  */
 #define HTS221_REGS_CTRL_REG2_BOOT      (1 << 7)    /**< Reboot memory content */
 #define HTS221_REGS_CTRL_REG2_HEATER    (1 << 1)    /**< Heater ON */
-#define HTS221_REGS_CTRL_REG2_OS_EN     (1 << 2)    /**< One-shot enable, start new dataset */
+#define HTS221_REGS_CTRL_REG2_OS_EN     (1 << 0)    /**< One-shot enable, start new dataset */
 /** @} */
 
 /**


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

fixes #11013


### Testing procedure

compile and test the sensor, should still work.

### Issues/PRs references

#11013 