### PR TITLE
gnrc_sixlowpan_frag: allow send of multiple datagrams simultaneously

### DIFF
--- a/sys/include/net/gnrc/sixlowpan/config.h
+++ b/sys/include/net/gnrc/sixlowpan/config.h
@@ -49,6 +49,19 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Number of datagrams that can be fragmented simultaneously
+ *
+ * This determines the number of @ref gnrc_sixlowpan_msg_frag_t instances
+ * available.
+ *
+ * @note    Only applicable with
+ *          [gnrc_sixlowpan_frag](@ref net_gnrc_sixlowpan_frag) module
+ */
+#ifndef GNRC_SIXLOWPAN_MSG_FRAG_SIZE
+#define GNRC_SIXLOWPAN_MSG_FRAG_SIZE    (1U)
+#endif
+
+/**
  * @brief   Size of the reassembly buffer
  *
  * @note    Only applicable with

--- a/sys/include/net/gnrc/sixlowpan/frag.h
+++ b/sys/include/net/gnrc/sixlowpan/frag.h
@@ -91,6 +91,7 @@ typedef struct {
 typedef struct {
     gnrc_pktsnip_t *pkt;    /**< Pointer to the IPv6 packet to be fragmented */
     uint16_t datagram_size; /**< Length of just the (uncompressed) IPv6 packet to be fragmented */
+    uint16_t tag;           /**< Tag used for the fragment */
     uint16_t offset;        /**< Offset of the Nth fragment from the beginning of the
                              *   payload datagram */
 } gnrc_sixlowpan_msg_frag_t;

--- a/sys/include/net/gnrc/sixlowpan/frag.h
+++ b/sys/include/net/gnrc/sixlowpan/frag.h
@@ -130,6 +130,13 @@ void gnrc_sixlowpan_frag_send(gnrc_pktsnip_t *pkt, void *ctx, unsigned page);
 void gnrc_sixlowpan_frag_recv(gnrc_pktsnip_t *pkt, void *ctx, unsigned page);
 
 /**
+ * @brief   Generate a new datagram tag for sending
+ *
+ * @return  A new datagram tag.
+ */
+uint16_t gnrc_sixlowpan_frag_next_tag(void);
+
+/**
  * @brief   Garbage collect reassembly buffer.
  */
 void gnrc_sixlowpan_frag_rbuf_gc(void);

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/gnrc_sixlowpan_frag.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/gnrc_sixlowpan_frag.c
@@ -89,16 +89,16 @@ static uint16_t _send_1st_fragment(gnrc_netif_t *iface,
                                    size_t payload_len)
 {
     gnrc_pktsnip_t *frag, *pkt = fragment_msg->pkt;
-    uint16_t local_offset = 0;
+    sixlowpan_frag_t *hdr;
+    uint8_t *data;
     /* payload_len: actual size of the packet vs
      * datagram_size: size of the uncompressed IPv6 packet */
     int payload_diff = (fragment_msg->datagram_size - payload_len);
+    uint16_t local_offset = 0;
     /* virtually add payload_diff to flooring to account for offset (must be divisable by 8)
      * in uncompressed datagram */
     uint16_t max_frag_size = _floor8(iface->sixlo.max_frag_size + payload_diff -
                                      sizeof(sixlowpan_frag_t)) - payload_diff;
-    sixlowpan_frag_t *hdr;
-    uint8_t *data;
 
     DEBUG("6lo frag: determined max_frag_size = %" PRIu16 "\n", max_frag_size);
 
@@ -148,11 +148,11 @@ static uint16_t _send_nth_fragment(gnrc_netif_t *iface,
 {
     gnrc_pktsnip_t *frag, *pkt = fragment_msg->pkt;
     sixlowpan_frag_n_t *hdr;
+    uint8_t *data;
+    uint16_t local_offset = 0, offset_count = 0, offset = fragment_msg->offset;
     /* since dispatches aren't supposed to go into subsequent fragments, we need not account
      * for payload difference as for the first fragment */
     uint16_t max_frag_size = _floor8(iface->sixlo.max_frag_size - sizeof(sixlowpan_frag_n_t));
-    uint16_t local_offset = 0, offset_count = 0, offset = fragment_msg->offset;
-    uint8_t *data;
 
     DEBUG("6lo frag: determined max_frag_size = %" PRIu16 "\n", max_frag_size);
 

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/gnrc_sixlowpan_frag.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/gnrc_sixlowpan_frag.c
@@ -260,7 +260,7 @@ void gnrc_sixlowpan_frag_send(gnrc_pktsnip_t *pkt, void *ctx, unsigned page)
     /* Check whether to send the first or an Nth fragment */
     if (fragment_msg->offset == 0) {
         /* increment tag for successive, fragmented datagrams */
-        _tag++;
+        gnrc_sixlowpan_frag_next_tag();
         if ((res = _send_1st_fragment(iface, fragment_msg->pkt, payload_len,
                                       fragment_msg->datagram_size)) == 0) {
             /* error sending first fragment */
@@ -318,6 +318,11 @@ void gnrc_sixlowpan_frag_recv(gnrc_pktsnip_t *pkt, void *ctx, unsigned page)
     }
 
     rbuf_add(hdr, pkt, offset, page);
+}
+
+uint16_t gnrc_sixlowpan_frag_next_tag(void)
+{
+    return (++_tag);
 }
 
 void gnrc_sixlowpan_frag_rbuf_gc(void)

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/gnrc_sixlowpan_frag.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/gnrc_sixlowpan_frag.c
@@ -31,14 +31,14 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
-static gnrc_sixlowpan_msg_frag_t _fragment_msg;
+static gnrc_sixlowpan_msg_frag_t _fragment_msg[GNRC_SIXLOWPAN_MSG_FRAG_SIZE];
 
 #if ENABLE_DEBUG
 /* For PRIu16 etc. */
 #include <inttypes.h>
 #endif
 
-static uint16_t _tag;
+static uint16_t _current_tag;
 
 static inline uint16_t _floor8(uint16_t length)
 {
@@ -84,14 +84,15 @@ static gnrc_pktsnip_t *_build_frag_pkt(gnrc_pktsnip_t *pkt, size_t payload_len,
     return frag;
 }
 
-static uint16_t _send_1st_fragment(gnrc_netif_t *iface, gnrc_pktsnip_t *pkt,
-                                   size_t payload_len, size_t datagram_size)
+static uint16_t _send_1st_fragment(gnrc_netif_t *iface,
+                                   gnrc_sixlowpan_msg_frag_t *fragment_msg,
+                                   size_t payload_len)
 {
-    gnrc_pktsnip_t *frag;
+    gnrc_pktsnip_t *frag, *pkt = fragment_msg->pkt;
     uint16_t local_offset = 0;
     /* payload_len: actual size of the packet vs
      * datagram_size: size of the uncompressed IPv6 packet */
-    int payload_diff = (datagram_size - payload_len);
+    int payload_diff = (fragment_msg->datagram_size - payload_len);
     /* virtually add payload_diff to flooring to account for offset (must be divisable by 8)
      * in uncompressed datagram */
     uint16_t max_frag_size = _floor8(iface->sixlo.max_frag_size + payload_diff -
@@ -111,9 +112,9 @@ static uint16_t _send_1st_fragment(gnrc_netif_t *iface, gnrc_pktsnip_t *pkt,
     hdr = frag->next->data;
     data = (uint8_t *)(hdr + 1);
 
-    hdr->disp_size = byteorder_htons((uint16_t)datagram_size);
+    hdr->disp_size = byteorder_htons(fragment_msg->datagram_size);
     hdr->disp_size.u8[0] |= SIXLOWPAN_FRAG_1_DISP;
-    hdr->tag = byteorder_htons(_tag);
+    hdr->tag = byteorder_htons(fragment_msg->tag);
 
     /* Tell the link layer that we will send more fragments */
     gnrc_netif_hdr_t *netif_hdr = frag->data;
@@ -136,21 +137,21 @@ static uint16_t _send_1st_fragment(gnrc_netif_t *iface, gnrc_pktsnip_t *pkt,
 
     DEBUG("6lo frag: send first fragment (datagram size: %u, "
           "datagram tag: %" PRIu16 ", fragment size: %" PRIu16 ")\n",
-          (unsigned int)datagram_size, _tag, local_offset);
+          fragment_msg->datagram_size, fragment_msg->tag, local_offset);
     gnrc_sixlowpan_dispatch_send(frag, NULL, 0);
     return local_offset;
 }
 
-static uint16_t _send_nth_fragment(gnrc_netif_t *iface, gnrc_pktsnip_t *pkt,
-                                   size_t payload_len, size_t datagram_size,
-                                   uint16_t offset)
+static uint16_t _send_nth_fragment(gnrc_netif_t *iface,
+                                   gnrc_sixlowpan_msg_frag_t *fragment_msg,
+                                   size_t payload_len)
 {
-    gnrc_pktsnip_t *frag;
+    gnrc_pktsnip_t *frag, *pkt = fragment_msg->pkt;
+    sixlowpan_frag_n_t *hdr;
     /* since dispatches aren't supposed to go into subsequent fragments, we need not account
      * for payload difference as for the first fragment */
     uint16_t max_frag_size = _floor8(iface->sixlo.max_frag_size - sizeof(sixlowpan_frag_n_t));
-    uint16_t local_offset = 0, offset_count = 0;
-    sixlowpan_frag_n_t *hdr;
+    uint16_t local_offset = 0, offset_count = 0, offset = fragment_msg->offset;
     uint8_t *data;
 
     DEBUG("6lo frag: determined max_frag_size = %" PRIu16 "\n", max_frag_size);
@@ -167,11 +168,12 @@ static uint16_t _send_nth_fragment(gnrc_netif_t *iface, gnrc_pktsnip_t *pkt,
     data = (uint8_t *)(hdr + 1);
 
     /* XXX: truncation of datagram_size > 4095 may happen here */
-    hdr->disp_size = byteorder_htons((uint16_t)datagram_size);
+    hdr->disp_size = byteorder_htons(fragment_msg->datagram_size);
     hdr->disp_size.u8[0] |= SIXLOWPAN_FRAG_N_DISP;
-    hdr->tag = byteorder_htons(_tag);
+    hdr->tag = byteorder_htons(fragment_msg->tag);
     /* don't mention payload diff in offset */
-    hdr->offset = (uint8_t)((offset + (datagram_size - payload_len)) >> 3);
+    hdr->offset = (uint8_t)((offset +
+                             (fragment_msg->datagram_size - payload_len)) >> 3);
     pkt = pkt->next;    /* don't copy netif header */
 
     while ((pkt != NULL) && (offset_count != offset)) {   /* go to offset */
@@ -221,15 +223,20 @@ static uint16_t _send_nth_fragment(gnrc_netif_t *iface, gnrc_pktsnip_t *pkt,
     DEBUG("6lo frag: send subsequent fragment (datagram size: %u, "
           "datagram tag: %" PRIu16 ", offset: %" PRIu8 " (%u bytes), "
           "fragment size: %" PRIu16 ")\n",
-          (unsigned int)datagram_size, _tag, hdr->offset, hdr->offset << 3,
-          local_offset);
+          fragment_msg->datagram_size, fragment_msg->tag, hdr->offset,
+          hdr->offset << 3, local_offset);
     gnrc_sixlowpan_dispatch_send(frag, NULL, 0);
     return local_offset;
 }
 
 gnrc_sixlowpan_msg_frag_t *gnrc_sixlowpan_msg_frag_get(void)
 {
-    return (_fragment_msg.pkt == NULL) ? &_fragment_msg : NULL;
+    for (unsigned i = 0; i < GNRC_SIXLOWPAN_MSG_FRAG_SIZE; i++) {
+        if (_fragment_msg[i].pkt == NULL) {
+            return &_fragment_msg[i];
+        }
+    }
+    return NULL;
 }
 
 void gnrc_sixlowpan_frag_send(gnrc_pktsnip_t *pkt, void *ctx, unsigned page)
@@ -259,10 +266,7 @@ void gnrc_sixlowpan_frag_send(gnrc_pktsnip_t *pkt, void *ctx, unsigned page)
 
     /* Check whether to send the first or an Nth fragment */
     if (fragment_msg->offset == 0) {
-        /* increment tag for successive, fragmented datagrams */
-        gnrc_sixlowpan_frag_next_tag();
-        if ((res = _send_1st_fragment(iface, fragment_msg->pkt, payload_len,
-                                      fragment_msg->datagram_size)) == 0) {
+        if ((res = _send_1st_fragment(iface, fragment_msg, payload_len)) == 0) {
             /* error sending first fragment */
             DEBUG("6lo frag: error sending 1st fragment\n");
             goto error;
@@ -270,9 +274,7 @@ void gnrc_sixlowpan_frag_send(gnrc_pktsnip_t *pkt, void *ctx, unsigned page)
     }
     /* (offset + (datagram_size - payload_len) < datagram_size) simplified */
     else if (fragment_msg->offset < payload_len) {
-        if ((res = _send_nth_fragment(iface, fragment_msg->pkt, payload_len,
-                                      fragment_msg->datagram_size,
-                                      fragment_msg->offset)) == 0) {
+        if ((res = _send_nth_fragment(iface, fragment_msg, payload_len)) == 0) {
             /* error sending subsequent fragment */
             DEBUG("6lo frag: error sending subsequent fragment"
                   "(offset = %u)\n", fragment_msg->offset);
@@ -322,7 +324,7 @@ void gnrc_sixlowpan_frag_recv(gnrc_pktsnip_t *pkt, void *ctx, unsigned page)
 
 uint16_t gnrc_sixlowpan_frag_next_tag(void)
 {
-    return (++_tag);
+    return (++_current_tag);
 }
 
 void gnrc_sixlowpan_frag_rbuf_gc(void)

--- a/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
@@ -131,6 +131,7 @@ void gnrc_sixlowpan_multiplex_by_size(gnrc_pktsnip_t *pkt,
         }
         fragment_msg->pkt = pkt;
         fragment_msg->datagram_size = orig_datagram_size;
+        fragment_msg->tag = gnrc_sixlowpan_frag_next_tag();
         /* Sending the first fragment has an offset==0 */
         fragment_msg->offset = 0;
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
For fragment forwarding I need to be able to send (and in case the packet is compressed also [re-]construct) fragments of multiple datagrams. Currently this is not possible, since the source for the datagram tag is always taken from the global variable `_tag`. However, by adding the `tag` to the `gnrc_sixlowpan_msg_frag_t` type we are able to allocate a datagram tag from `_tag` at an earlier point and use the new member to set the fragments datagram tag field from that.

I also piggy-backed some optimizations to the `gnrc_sixlowpan_frag` module, which results in this enhancement only to require 20 more bytes of code.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`gnrc_networking` should still be able to ping between two 6Lo-capable nodes with large payloads.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
No dependencies, but provides basis for others:

![Route to 6Lo minimal fragment forwarding](http://page.mi.fu-berlin.de/mlenders/sixlo_minfwd.svg)
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
