### PR TITLE
gnrc_netif_ieee802154: propagate pend. frame flag to stack

### DIFF
--- a/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c
+++ b/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c
@@ -48,6 +48,7 @@ gnrc_netif_t *gnrc_netif_ieee802154_create(char *stack, int stacksize,
 
 static gnrc_pktsnip_t *_make_netif_hdr(uint8_t *mhr)
 {
+    gnrc_netif_hdr_t *hdr;
     gnrc_pktsnip_t *snip;
     uint8_t src[IEEE802154_LONG_ADDRESS_LEN], dst[IEEE802154_LONG_ADDRESS_LEN];
     int src_len, dst_len;
@@ -65,10 +66,14 @@ static gnrc_pktsnip_t *_make_netif_hdr(uint8_t *mhr)
         DEBUG("_make_netif_hdr: no space left in packet buffer\n");
         return NULL;
     }
+    hdr = snip->data;
     /* set broadcast flag for broadcast destination */
     if ((dst_len == 2) && (dst[0] == 0xff) && (dst[1] == 0xff)) {
-        gnrc_netif_hdr_t *hdr = snip->data;
         hdr->flags |= GNRC_NETIF_HDR_FLAGS_BROADCAST;
+    }
+    /* set flags for pending frames */
+    if (mhr[0] & IEEE802154_FCF_FRAME_PEND) {
+        hdr->flags |= GNRC_NETIF_HDR_FLAGS_MORE_DATA;
     }
     return snip;
 }


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This way we can re-use the flag e.g. for forwarding.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Sending broadcast 6LoWPAN packets should still work as before. Fragmented packets should have for the first n-1 fragments the `GNRC_NETIF_HDR_FLAGS_MORE_DATA` set. I checked the latter with the following patch:

```diff
diff --git a/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c b/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c
index 258237c58..01e758748 100644
--- a/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c
+++ b/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c
@@ -73,6 +73,7 @@ static gnrc_pktsnip_t *_make_netif_hdr(uint8_t *mhr)
     }
     /* set flags for pending frames */
     if (mhr[0] & IEEE802154_FCF_FRAME_PEND) {
+        puts("Set more data flag");
         hdr->flags |= GNRC_NETIF_HDR_FLAGS_MORE_DATA;
     }
     return snip;
```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
