### PR TITLE
net/nanocoap: Buffer API Block helper functions

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -611,6 +611,18 @@ static inline void coap_block2_finish(coap_block_slicer_t *slicer)
 void coap_block2_init(coap_pkt_t *pkt, coap_block_slicer_t *slicer);
 
 /**
+ * @brief Initialize a block slicer struct from content information
+ *
+ * @param[out]   slicer     slicer struct to initialize
+ * @param[in]    blknum     offset from the beginning of content, in terms of
+                            @p blksize byte blocks
+ * @param[in]    blksize    size of each block; must be a power of 2 between 16
+ *                          and 2 raised to #NANOCOAP_BLOCK_SIZE_EXP_MAX
+ */
+void coap_block_slicer_init(coap_block_slicer_t *slicer, size_t blknum,
+                            size_t blksize);
+
+/**
  * @brief Add a byte array to a block2 reply.
  *
  * This function is used to add an array of bytes to a CoAP block2 reply. it

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -554,17 +554,50 @@ void coap_block_object_init(coap_block1_t *block, size_t blknum, size_t blksize,
                             int more);
 
 /**
+ * @brief Finish a block request (block1 or block2)
+ *
+ * This function finalizes the block response header
+ *
+ * Checks whether the `more` bit should be set in the block option and
+ * sets/clears it if required.  Doesn't return the number of bytes, as this
+ * function overwrites bytes in the packet rather than adding new.
+ *
+ * @param[in]     slicer      Preallocated slicer struct to use
+ * @param[in]     option      option number (block1 or block2)
+ */
+void coap_block_finish(coap_block_slicer_t *slicer, uint16_t option);
+
+/**
+ * @brief Finish a block1 request
+ *
+ * This function finalizes the block1 response header
+ *
+ * Checks whether the `more` bit should be set in the block1 option and
+ * sets/clears it if required.  Doesn't return the number of bytes, as this
+ * function overwrites bytes in the packet rather than adding new.
+ *
+ * @param[in]     slicer      Preallocated slicer struct to use
+ */
+static inline void coap_block1_finish(coap_block_slicer_t *slicer)
+{
+    coap_block_finish(slicer, COAP_OPT_BLOCK1);
+}
+
+/**
  * @brief Finish a block2 response
  *
  * This function finalizes the block2 response header
  *
  * Checks whether the `more` bit should be set in the block2 option and
- * sets/clears it if required.  Doesn't return the number of bytes as this
- * overwrites bytes in the packet, it doesn't add new bytes to the packet.
+ * sets/clears it if required.  Doesn't return the number of bytes, as this
+ * function overwrites bytes in the packet rather than adding new.
  *
- * @param[inout]  slicer      Preallocated slicer struct to use
+ * @param[in]     slicer      Preallocated slicer struct to use
  */
-void coap_block2_finish(coap_block_slicer_t *slicer);
+static inline void coap_block2_finish(coap_block_slicer_t *slicer)
+{
+    coap_block_finish(slicer, COAP_OPT_BLOCK2);
+}
 
 /**
  * @brief Initialize a block2 slicer struct for writing the payload

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -541,6 +541,19 @@ static inline ssize_t coap_get_uri_query(const coap_pkt_t *pkt, uint8_t *target)
  */
 /**@{*/
 /**
+ * @brief Initialize a block struct from content information
+ *
+ * @param[out]   block      block struct to initialize
+ * @param[in]    blknum     offset from the beginning of content, in terms of
+                            @p blksize byte blocks
+ * @param[in]    blksize    size of each block; must be a power of 2 between 16
+ *                          and 2 raised to #NANOCOAP_BLOCK_SIZE_EXP_MAX
+ * @param[in]    more       more blocks? use 1 if yes; 0 if no or unknown
+ */
+void coap_block_object_init(coap_block1_t *block, size_t blknum, size_t blksize,
+                            int more);
+
+/**
  * @brief Finish a block2 response
  *
  * This function finalizes the block2 response header

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -710,14 +710,14 @@ size_t coap_put_block1_ok(uint8_t *pkt_pos, coap_block1_t *block1, uint16_t last
 size_t coap_opt_put_block(uint8_t *buf, uint16_t lastonum, coap_block_slicer_t *slicer,
                           bool more, uint16_t option)
 {
-    unsigned szx = _size2szx(slicer->end - slicer->start);
-    unsigned blknum = _slicer_blknum(slicer);
+    coap_block1_t block;
 
-    uint32_t blkopt = (blknum << 4) | szx | (more ? 0x8 : 0);
-    size_t olen = _encode_uint(&blkopt);
+    coap_block_object_init(&block, _slicer_blknum(slicer),
+                           slicer->end - slicer->start, more);
 
     slicer->opt = buf;
-    return coap_put_option(buf, lastonum, option, (uint8_t *)&blkopt, olen);
+
+    return coap_opt_put_block_object(buf, lastonum, &block, option);
 }
 
 size_t coap_opt_put_block_object(uint8_t *buf, uint16_t lastonum,

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -883,6 +883,14 @@ void coap_block_object_init(coap_block1_t *block, size_t blknum, size_t blksize,
     block->more = more;
 }
 
+void coap_block_slicer_init(coap_block_slicer_t *slicer, size_t blknum,
+                            size_t blksize)
+{
+    slicer->start = blknum * blksize;
+    slicer->end = slicer->start + blksize;
+    slicer->cur = 0;
+}
+
 void coap_block2_init(coap_pkt_t *pkt, coap_block_slicer_t *slicer)
 {
     uint32_t blknum;
@@ -896,9 +904,8 @@ void coap_block2_init(coap_pkt_t *pkt, coap_block_slicer_t *slicer)
             szx = NANOCOAP_BLOCK_SIZE_EXP_MAX - 4;
         }
     }
-    slicer->start = blknum * coap_szx2size(szx);
-    slicer->end = slicer->start + coap_szx2size(szx);
-    slicer->cur = 0;
+
+    coap_block_slicer_init(slicer, blknum, coap_szx2size(szx));
 }
 
 void coap_block_finish(coap_block_slicer_t *slicer, uint16_t option)

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -875,6 +875,14 @@ ssize_t coap_opt_finish(coap_pkt_t *pkt, uint16_t flags)
     return pkt->payload - (uint8_t *)pkt->hdr;
 }
 
+void coap_block_object_init(coap_block1_t *block, size_t blknum, size_t blksize,
+                            int more)
+{
+    block->szx = _size2szx(blksize);
+    block->blknum = blknum;
+    block->more = more;
+}
+
 void coap_block2_init(coap_pkt_t *pkt, coap_block_slicer_t *slicer)
 {
     uint32_t blknum;


### PR DESCRIPTION
### Contribution description
#11002 added client side implementations for Block for the Buffer API. This PR refines the implementation with helper functions.

| Function | Description |
| ---------- | ------------- |
| coap_block2_finish() | Refactored as inline, added coap_block1_finish() as inline for client side, and coap_block_finish() implementation. |
| coap_block_object_init() | Added for client to init a block2 control request, and refactored coap_opt_put_block() to use it.  |
| coap_block_slicer_init() | Added for client to init a block1 descriptive request, and refactored coap_block2_init() to use it. |

You can see the client side functions in action in [block_client.c](https://github.com/kb2ma/riot-apps/blob/kb2ma-master/nano-block-client/block_client.c) in my RIOT apps repostiory.

### Testing procedure
The [nano-block-client](https://github.com/kb2ma/riot-apps/tree/kb2ma-master/nano-block-client) RIOT app provides a command line with commands to generate CoAP requests for nanocoap_server example resources. So you can verify both client and server side.

- _get_ creates a block2 request for `/riot/ver`
- _post_ creates a block1 request for `/sha256`

### Issues/PRs references
Partially implements #10732. Depends on #11002.