### PR TITLE
drivers/sx127x: fix dead links

### DIFF
--- a/drivers/include/sx127x.h
+++ b/drivers/include/sx127x.h
@@ -46,8 +46,8 @@
  * - South Korea: KR920-923 (from 920.9MHz to 923.3MHz exactly)
  *
  * For more information on Semtech SX1272 and SX1276 modules see:
- * - [SX1272/73 datasheet](http://www.semtech.com/images/datasheet/sx1272.pdf)
- * - [SX1276/77/78/79 datasheet](http://www.semtech.com/images/datasheet/sx1276_77_78_79.pdf)
+ * - [SX1272/73 datasheet](https://www.semtech.com/uploads/documents/sx1272.pdf)
+ * - [SX1276/77/78/79 datasheet](https://www.semtech.com/uploads/documents/DS_SX1276-7-8-9_W_APP_V5.pdf)
  *
  * @{
  *


### PR DESCRIPTION
### Contribution description

URLs of the datasheets have been changed.
