### PR TITLE
boards/common/atmega: Refactoring periph_conf.h

### DIFF
--- a/boards/arduino-duemilanove/Makefile.dep
+++ b/boards/arduino-duemilanove/Makefile.dep
@@ -1,0 +1,3 @@
+USEMODULE += boards_common_arduino-atmega
+
+include $(RIOTBOARD)/common/arduino-atmega/Makefile.dep

--- a/boards/arduino-duemilanove/Makefile.include
+++ b/boards/arduino-duemilanove/Makefile.include
@@ -1,8 +1,6 @@
 # define the cpu used by the ardudino duemilanove board
 export CPU = atmega328p
 
-USEMODULE += boards_common_arduino-atmega
-
 # configure the terminal program
 PORT_LINUX  ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))

--- a/boards/arduino-mega2560/Makefile.dep
+++ b/boards/arduino-mega2560/Makefile.dep
@@ -1,0 +1,3 @@
+USEMODULE += boards_common_arduino-atmega
+
+include $(RIOTBOARD)/common/arduino-atmega/Makefile.dep

--- a/boards/arduino-uno/Makefile.dep
+++ b/boards/arduino-uno/Makefile.dep
@@ -1,0 +1,3 @@
+USEMODULE += boards_common_arduino-atmega
+
+include $(RIOTBOARD)/common/arduino-atmega/Makefile.dep

--- a/boards/arduino-uno/Makefile.include
+++ b/boards/arduino-uno/Makefile.include
@@ -1,8 +1,6 @@
 # define the cpu used by the arduino uno board
 export CPU = atmega328p
 
-USEMODULE += boards_common_arduino-atmega
-
 # configure the terminal program
 PORT_LINUX  ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))

--- a/boards/common/arduino-atmega/Makefile.include
+++ b/boards/common/arduino-atmega/Makefile.include
@@ -1,6 +1,3 @@
-# include optional dependencies
-include $(RIOTBOARD)/common/arduino-atmega/Makefile.dep
-
 INCLUDES += -I$(RIOTBOARD)/common/arduino-atmega/include
 
 include $(RIOTMAKE)/tools/serial.inc.mk
@@ -10,3 +7,4 @@ FFLAGS_EXTRA += -F -D
 
 # include avrdude flashing tool
 include $(RIOTMAKE)/tools/avrdude.inc.mk
+include $(RIOTBOARD)/common/atmega/Makefile.include

--- a/boards/common/arduino-atmega/include/periph_conf.h
+++ b/boards/common/arduino-atmega/include/periph_conf.h
@@ -1,7 +1,5 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin, Hinnerk van Bruinehsen
- *               2016 Laurent Navet <laurent.navet@gmail.com>
- *               2017 HAW Hamburg, Dimitri Nahm
+ * Copyright (C) 2019 Otto-von-Guericke-Universität Magdeburg
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -15,200 +13,27 @@
  * @file
  * @brief       Common configuration of MCU periphery for Arduino Atmega boards
  *
- * @author      Hinnerk van Bruinehsen <h.v.bruinehsen@fu-berlin.de>
- * @author      Laurent Navet <laurent.navet@gmail.com>
- * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
- * @author      Dimitri Nahm <dimitri.nahm@haw-hamburg.de>
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  */
 
 #ifndef PERIPH_CONF_H
 #define PERIPH_CONF_H
 
-#include "periph_cpu.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-/**
- * @name    Clock configuration
- * @{
+/*
+ * Any overwrites of the common ATmega periph config would come here, as needs
+ * to be placed before the include. (Currently none needed.)
  */
-#define CLOCK_CORECLOCK     (16000000UL)
-/** @} */
 
-/**
- * @name    Timer configuration
- *
- * arduino uno and arduino duemilanove:
- * The timer driver only supports the 16-bit timer (Timer1)
- * so this is the only one we can use here.
- *
- * arduino mega2560:
- * The timer driver only supports the four 16-bit timers (Timer1, Timer3,
- * Timer4, Timer5), so those are the only onces we can use here.
- *
- * @{
- */
-#ifdef CPU_ATMEGA328P
-#define TIMER_NUMOF         (1U)
-#define TIMER_CHANNELS      (2)
-
-#define TIMER_0             MEGA_TIMER1
-#define TIMER_0_MASK        &TIMSK1
-#define TIMER_0_FLAG        &TIFR1
-#define TIMER_0_ISRA        TIMER1_COMPA_vect
-#define TIMER_0_ISRB        TIMER1_COMPB_vect
-#endif
-
-#ifdef CPU_ATMEGA2560
-#define TIMER_NUMOF         (2U)
-#define TIMER_CHANNELS      (3)
-
-#define TIMER_0             MEGA_TIMER1
-#define TIMER_0_MASK        &TIMSK1
-#define TIMER_0_FLAG        &TIFR1
-#define TIMER_0_ISRA        TIMER1_COMPA_vect
-#define TIMER_0_ISRB        TIMER1_COMPB_vect
-#define TIMER_0_ISRC        TIMER1_COMPC_vect
-
-#define TIMER_1             MEGA_TIMER4
-#define TIMER_1_MASK        &TIMSK4
-#define TIMER_1_FLAG        &TIFR4
-#define TIMER_1_ISRA        TIMER4_COMPA_vect
-#define TIMER_1_ISRB        TIMER4_COMPB_vect
-#define TIMER_1_ISRC        TIMER4_COMPC_vect
-#endif
-/** @} */
-
-/**
- * @name    UART configuration
- *
- * The UART devices have fixed pin mappings, so all we need to do, is to specify
- * which devices we would like to use and their corresponding RX interrupts. See
- * the reference manual for the fixed pin mapping.
- *
- * @{
- */
-#ifdef CPU_ATMEGA328P
-#define UART_NUMOF          (1U)
-
-#define UART_0              MEGA_UART0
-#define UART_0_ISR          USART_RX_vect
-#endif
-
-#ifdef CPU_ATMEGA2560
-#define UART_NUMOF          (4U)
-
-#define UART_0              MEGA_UART0
-#define UART_0_ISR          USART0_RX_vect
-
-#define UART_1              MEGA_UART1
-#define UART_1_ISR          USART1_RX_vect
-
-#define UART_2              MEGA_UART2
-#define UART_2_ISR          USART2_RX_vect
-
-#define UART_3              MEGA_UART3
-#define UART_3_ISR          USART3_RX_vect
-#endif
-/** @} */
-
-/**
- * @name    SPI configuration
- *
- * The atmega2560/atmega1281/atmega328p has only one hardware SPI with fixed pin
- * configuration, so all we can do here, is to enable or disable it...
- *
- * The fixed pins for arduino uno and duemilanove (atmega328p) are:
- * MOSI - PB3 (Arduino pin 11)
- * MISO - PB4 (Arduino pin 12)
- * SCK  - PB5 (Arduino pin 13)
- * SS   - PB2 (Arduino pin 10) -> this pin is configured as output, but not used
- *
- * The fixed pins for arduino-mega2560 and atmega1281 are:
- * MOSI - PB2 (Arduino pin 51)
- * MISO - PB3 (Arduino pin 50)
- * SCK  - PB1 (Arduino pin 52)
- * SS   - PB0 (Arduino pin 53) -> this pin is configured as output, but not used
- *
- * The SS pin must be configured as output for the SPI device to work as
- * master correctly, though we do not use it for now (as we handle the chip
- * select externally for now)
- *
- * @{
- */
-#define SPI_NUMOF           1           /* set to 0 to disable SPI */
-/** @} */
-
-/**
- * @name    I2C configuration
- * @{
- */
-#define I2C_BUS_SPEED       I2C_SPEED_FAST
-#define I2C_NUMOF           1
-/** @} */
-
-/**
- * @name    ADC configuration
- *
- * The number of ADC channels of the atmega328p depends on the package:
- *  - 6-channel 10-bit ADC in PDIP package
- *  - 8-channel 10-bit ADC in TQFP and QFN/MLF package
- * Arduino UNO / Duemilanove has thereby 6 channels. But only 5 channels can be
- * used for ADC, because the pin of ADC5 emulate a software triggered interrupt.
- *  -> boards -> arduino-atmega-common -> include -> board_common.h
- * @{
- */
-#if defined (CPU_ATMEGA328P) || defined (CPU_ATMEGA1281)
-#define ADC_NUMOF       (8U)
-#elif defined (CPU_ATMEGA2560)
-#define ADC_NUMOF       (16U)
-#endif
-/** @} */
-
-/**
- * @name   PWM configuration
- *
- * The current implementation supports only 8-bit timers for PWM generation.
- * These timers are typically timer 0 and timer 2 in Atmega2560/1281/328p.
- *
- * Setting the first channel to GPIO_UNDEF allows multiple resolutions for the
- * PWM channel. Otherwise the resolution is fixed to 256, allowing duty cycle
- * values ranging from 0 to 255.
- *
- * @{
- */
-#if defined(CPU_ATMEGA328P)
-#define PWM_PINS_CH0 { GPIO_PIN(PORT_D, 6), GPIO_PIN(PORT_D, 5) }
-#define PWM_PINS_CH1 { GPIO_PIN(PORT_B, 3), GPIO_PIN(PORT_D, 3) }
-
-#elif defined(CPU_ATMEGA2560)
-#define PWM_PINS_CH0 { GPIO_PIN(PORT_B, 7), GPIO_PIN(PORT_G, 5) }
-#define PWM_PINS_CH1 { GPIO_PIN(PORT_B, 4), GPIO_PIN(PORT_H, 6) }
-
-#elif defined(CPU_ATMEGA1281)
-#define PWM_PINS_CH0 { GPIO_PIN(PORT_B, 7), GPIO_PIN(PORT_G, 5) }
-#define PWM_PINS_CH1 { GPIO_PIN(PORT_B, 4), GPIO_UNDEF }
-#endif
-
-static const pwm_conf_t pwm_conf[] = {
-    {
-        .dev = MINI_TIMER0,
-        .pin_ch = PWM_PINS_CH0,
-        .div = MINI_TIMER0_DIV,
-    },
-    {
-        .dev = MINI_TIMER2,
-        .pin_ch = PWM_PINS_CH1,
-        .div = MINI_TIMER2_DIV,
-    }
-};
-#define PWM_NUMOF (sizeof(pwm_conf) / sizeof(pwm_conf[0]))
 /** @} */
 
 #ifdef __cplusplus
 }
 #endif
+
+#include "periph_conf_atmega_common.h"
 
 #endif /* PERIPH_CONF_H */

--- a/boards/common/atmega/Makefile.include
+++ b/boards/common/atmega/Makefile.include
@@ -1,0 +1,1 @@
+INCLUDES += -I$(RIOTBOARD)/common/atmega/include

--- a/boards/common/atmega/include/periph_conf_atmega_common.h
+++ b/boards/common/atmega/include/periph_conf_atmega_common.h
@@ -1,0 +1,317 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin, Hinnerk van Bruinehsen
+ *               2016 Laurent Navet <laurent.navet@gmail.com>
+ *               2016 RWTH Aachen, Josua Arndt
+ *               2016 INRIA, Francisco Acosta
+ *               2017 HAW Hamburg, Dimitri Nahm
+ *               2018 Matthew Blue <matthew.blue.neuro@gmail.com>
+ *               2019 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_common_arduino-atmega
+ * @{
+ *
+ * @file
+ * @brief       Common configuration of MCU periphery for ATmega boards
+ *
+ * @author      Hinnerk van Bruinehsen <h.v.bruinehsen@fu-berlin.de>
+ * @author      Laurent Navet <laurent.navet@gmail.com>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Dimitri Nahm <dimitri.nahm@haw-hamburg.de>
+ * @author      Josua Arndt <jarndt@ias.rwth-aachen.de>
+ * @author      Steffen Robertz <steffen.robertz@rwth-aachen.de>
+ * @author      Matthew Blue <matthew.blue.neuro@gmail.com>
+ * @author      Francisco Acosta <francisco.acosta@inria.fr>
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ */
+
+#ifndef PERIPH_CONF_ATMEGA_COMMON_H
+#define PERIPH_CONF_ATMEGA_COMMON_H
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Clock configuration
+ * @{
+ */
+#ifndef CLOCK_CORECLOCK
+#define CLOCK_CORECLOCK     (16000000UL)
+#endif /* CLOCK_CORECLOCK */
+/** @} */
+
+/**
+ * @name    Timer configuration
+ *
+ * @details Only the 16 bit timers are used by xtimer
+ *
+ * ATmega256RFR2
+ * =============
+ * The timer driver only supports the four 16-bit timers
+ * (Timer1, TST, Timer3, Timer4, Timer5), so those are the Timer we can use here.
+ * Timer 1, TST, PORT B5/6/7 Out, Port D4/6 In,  Analog Comparator Input Capture, Output Compare Modulator, PWM
+ * Timer 3, TST, PORT E3/4/5 Out, Port E/6/7 In, Input or Output Compare and PWM Output
+ * Timer 4, TST, It can not be connected to any I/O Pin,
+ * Timer 5, TST, It can not be connected to any I/O Pin,
+ *
+ * Using Atmel Timer 4 and 5 seems to be the best choice
+ * Using Atmel Timer 4 as Xtimer
+ * and Atmel Timer 5 as timer available for the the application seems to be the best choice,
+ * as the special functions of the other timer are not lost.
+ * Atmel Timer1 to be used as PWM timer for RGB LED
+ *
+ * ATmega328p
+ * ==========
+ * The timer driver only supports the 16-bit timer (Timer1)
+ * so this is the only one we can use here.
+ *
+ * ATmega1281
+ * ==========
+ * The ATmega1281 has 6 timers. Timer0 and Timer2 are 8 Bit Timers,
+ * Timer0 has special uses too and therefore we'll avoid using it.
+ *
+ * The timer driver only supports the four 16-bit timers (Timer1, Timer3,
+ * Timer4, Timer5), so those are the only ones we can use here.
+ *
+ * ATmega1284P
+ * ===========
+ * The ATmega1284P has 4 timers. Timer0 and Timer2 are 8 Bit Timers.
+ *
+ * The timer driver only supports the two 16-bit timers (Timer1 and
+ * Timer3), so those are the only ones we can use here.
+ *
+ * ATmega2560
+ * ==========
+ * The timer driver only supports the four 16-bit timers (Timer1, Timer3,
+ * Timer4, Timer5), so those are the only onces we can use here.
+ *
+ * @{
+ */
+#ifndef TIMER_NUMOF
+#if defined(CPU_ATMEGA256RFR2)
+    #define TIMER_NUMOF         (3U)
+    #define TIMER_CHANNELS      (3)
+
+    #define TIMER_0             MEGA_TIMER4
+    #define TIMER_0_MASK        &TIMSK4
+    #define TIMER_0_FLAG        &TIFR4
+    #define TIMER_0_ISRA        TIMER4_COMPA_vect
+    #define TIMER_0_ISRB        TIMER4_COMPB_vect
+    #define TIMER_0_ISRC        TIMER4_COMPC_vect
+
+    #define TIMER_1             MEGA_TIMER5
+    #define TIMER_1_MASK        &TIMSK5
+    #define TIMER_1_FLAG        &TIFR5
+    #define TIMER_1_ISRA        TIMER5_COMPA_vect
+    #define TIMER_1_ISRB        TIMER5_COMPB_vect
+    #define TIMER_1_ISRC        TIMER5_COMPC_vect
+
+    #define TIMER_2             MEGA_TIMER1
+    #define TIMER_2_MASK        &TIMSK1
+    #define TIMER_2_FLAG        &TIFR1
+    #define TIMER_2_ISRA        TIMER1_COMPA_vect
+    #define TIMER_2_ISRB        TIMER1_COMPB_vect
+    #define TIMER_2_ISRC        TIMER1_COMPC_vect
+#elif defined(CPU_ATMEGA328P)
+    #define TIMER_NUMOF         (1U)
+    #define TIMER_CHANNELS      (2)
+
+    #define TIMER_0             MEGA_TIMER1
+    #define TIMER_0_MASK        &TIMSK1
+    #define TIMER_0_FLAG        &TIFR1
+    #define TIMER_0_ISRA        TIMER1_COMPA_vect
+    #define TIMER_0_ISRB        TIMER1_COMPB_vect
+#elif defined(CPU_ATMEGA1284P)
+    #define TIMER_NUMOF         (2U)
+    #define TIMER_CHANNELS      (2)
+
+    #define TIMER_0             MEGA_TIMER1
+    #define TIMER_0_MASK        &TIMSK1
+    #define TIMER_0_FLAG        &TIFR1
+    #define TIMER_0_ISRA        TIMER1_COMPA_vect
+    #define TIMER_0_ISRB        TIMER1_COMPB_vect
+
+    #define TIMER_1             MEGA_TIMER3
+    #define TIMER_1_MASK        &TIMSK3
+    #define TIMER_1_FLAG        &TIFR3
+    #define TIMER_1_ISRA        TIMER3_COMPA_vect
+    #define TIMER_1_ISRB        TIMER3_COMPB_vect
+#elif defined(CPU_ATMEGA2560) || defined(CPU_ATMEGA1281)
+    #define TIMER_NUMOF         (2U)
+    #define TIMER_CHANNELS      (3)
+
+    #define TIMER_0             MEGA_TIMER1
+    #define TIMER_0_MASK        &TIMSK1
+    #define TIMER_0_FLAG        &TIFR1
+    #define TIMER_0_ISRA        TIMER1_COMPA_vect
+    #define TIMER_0_ISRB        TIMER1_COMPB_vect
+    #define TIMER_0_ISRC        TIMER1_COMPC_vect
+
+    #define TIMER_1             MEGA_TIMER4
+    #define TIMER_1_MASK        &TIMSK4
+    #define TIMER_1_FLAG        &TIFR4
+    #define TIMER_1_ISRA        TIMER4_COMPA_vect
+    #define TIMER_1_ISRB        TIMER4_COMPB_vect
+    #define TIMER_1_ISRC        TIMER4_COMPC_vect
+#else
+    #define TIMER_NUMOF         (0U)
+#endif
+#endif /* TIMER_NUMOF */
+/** @} */
+
+/**
+ * @name    UART configuration
+ *
+ * The UART devices have fixed pin mappings, so all we need to do, is to specify
+ * which devices we would like to use and their corresponding RX interrupts. See
+ * the reference manual for the fixed pin mapping.
+ *
+ * @{
+ */
+
+#ifndef UART_NUMOF
+#if defined(CPU_ATMEGA256RFR2) || defined(CPU_ATMEGA1281) || defined(CPU_ATMEGA1284P) || defined(CPU_ATMEGA2560)
+    #define UART_NUMOF          (2U)
+
+    /* UART0 is used for stdio */
+    #define UART_0              MEGA_UART0
+    #define UART_0_ISR          USART0_RX_vect
+
+    #define UART_1              MEGA_UART1
+    #define UART_1_ISR          USART1_RX_vect
+#elif defined(CPU_ATMEGA328P)
+    #define UART_NUMOF          (1U)
+
+    #define UART_0              MEGA_UART0
+    #define UART_0_ISR          USART_RX_vect
+#else
+    #define UART_NUMOF          (0U)
+#endif
+#endif /* UART_NUMOF */
+/** @} */
+
+
+/**
+ * @name    SPI configuration
+ *
+ * All currently supported ATmega MCUs have only one hardware SPI with fixed pin
+ * configuration, so all we can do here, is to enable or disable it...
+ *
+ * The fixed pins ATmega328p are:
+ * MOSI - PB3
+ * MISO - PB4
+ * SCK  - PB5
+ * SS   - PB2 -> this pin is configured as output, but not used
+ *
+ * The fixed pins for the ATmega128rp are:
+ * MOSI - PB5
+ * MISO - PB6
+ * SCK  - PB7
+ * SS   - PB4 -> this pin is configured as output, but not used
+ *
+ * The fixed pins for the ATmega1281, ATmega256rfr2, and ATmega2560 are:
+ * MOSI - PB2
+ * MISO - PB3
+ * SCK  - PB1
+ * SS   - PB0 -> this pin is configured as output, but not used
+ *
+ * The SS pin must be configured as output for the SPI device to work as
+ * master correctly, though we do not use it for now (as we handle the chip
+ * select externally for now)
+ *
+ * @{
+ */
+#ifndef SPI_NUMOF
+#define SPI_NUMOF               (1U)
+#endif /* SPI_NUMOF */
+/** @} */
+
+/**
+ * @name    I2C configuration
+ * @{
+ */
+#ifndef I2C_NUMOF
+#define I2C_BUS_SPEED           I2C_SPEED_FAST
+#define I2C_NUMOF               (1U)
+#endif /* I2C_NUMOF */
+/** @} */
+
+/**
+ * @name ADC Configuration
+ *
+ * The number of ADC channels of the atmega328p depends on the package:
+ *  - 6-channel 10-bit ADC in PDIP package
+ *  - 8-channel 10-bit ADC in TQFP and QFN/MLF package
+ * Arduino UNO / Duemilanove has thereby 6 channels. But only 5 channels can be
+ * used for ADC, because the pin of ADC5 emulate a software triggered interrupt.
+ * @{
+ */
+#ifndef ADC_NUMOF
+#if defined(CPU_ATMEGA256RFR2) || defined(CPU_ATMEGA328P) || defined(CPU_ATMEGA1281) || defined(CPU_ATMEGA1284P)
+    #define ADC_NUMOF           (8U)
+#elif defined (CPU_ATMEGA2560)
+    #define ADC_NUMOF           (16U)
+#else
+    #define ADC_NUMOF           (0U)
+#endif
+#endif /* ADC_NUMOF */
+/** @} */
+
+/**
+ * @name   PWM configuration
+ *
+ * The current implementation supports only 8-bit timers for PWM generation.
+ * These timers are typically timer 0 and timer 2 in Atmega2560/1281/328p.
+ *
+ * Setting the first channel to GPIO_UNDEF allows multiple resolutions for the
+ * PWM channel. Otherwise the resolution is fixed to 256, allowing duty cycle
+ * values ranging from 0 to 255.
+ *
+ * @{
+ */
+#ifndef PWM_NUMOF
+#if defined(CPU_ATMEGA328P)
+    #define PWM_PINS_CH0 { GPIO_PIN(PORT_D, 6), GPIO_PIN(PORT_D, 5) }
+    #define PWM_PINS_CH1 { GPIO_PIN(PORT_B, 3), GPIO_PIN(PORT_D, 3) }
+#elif defined(CPU_ATMEGA1281)
+    #define PWM_PINS_CH0 { GPIO_PIN(PORT_B, 7), GPIO_PIN(PORT_G, 5) }
+    #define PWM_PINS_CH1 { GPIO_PIN(PORT_B, 4), GPIO_UNDEF }
+#elif defined(CPU_ATMEGA2560)
+    #define PWM_PINS_CH0 { GPIO_PIN(PORT_B, 7), GPIO_PIN(PORT_G, 5) }
+    #define PWM_PINS_CH1 { GPIO_PIN(PORT_B, 4), GPIO_PIN(PORT_H, 6) }
+#else
+    #define PWM_NUMOF           (0U)
+#endif
+
+#if defined(CPU_ATMEGA328P) || defined(CPU_ATMEGA1281) || defined(CPU_ATMEGA2560)
+    static const pwm_conf_t pwm_conf[] = {
+        {
+            .dev = MINI_TIMER0,
+            .pin_ch = PWM_PINS_CH0,
+            .div = MINI_TIMER0_DIV,
+        },
+        {
+            .dev = MINI_TIMER2,
+            .pin_ch = PWM_PINS_CH1,
+            .div = MINI_TIMER2_DIV,
+        }
+    };
+
+    #define PWM_NUMOF           (sizeof(pwm_conf) / sizeof(pwm_conf[0]))
+#endif
+#endif /* PWM_NUMOF */
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_ATMEGA_COMMON_H */

--- a/boards/jiminy-mega256rfr2/Makefile.include
+++ b/boards/jiminy-mega256rfr2/Makefile.include
@@ -28,3 +28,4 @@ BOOTLOADER_SIZE ?= 4K
 ROM_RESERVED ?= $(BOOTLOADER_SIZE)
 
 include $(RIOTMAKE)/tools/avrdude.inc.mk
+include $(RIOTBOARD)/common/atmega/Makefile.include

--- a/boards/jiminy-mega256rfr2/include/periph_conf.h
+++ b/boards/jiminy-mega256rfr2/include/periph_conf.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2016 RWTH Aachen, Josua Arndt
+ *               2019 Otto-von-Guericke-Universität Magdeburg
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -15,6 +16,7 @@
  *
  * @author      Josua Arndt <jarndt@ias.rwth-aachen.de>
  * @author      Steffen Robertz <steffen.robertz@rwth-aachen.de>
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  */
 
 #ifndef PERIPH_CONF_H
@@ -24,12 +26,6 @@
 extern "C" {
 #endif
 
-#include <stdint.h>
-#include <avr/io.h>
-#include "periph_cpu.h"
-#include "atmega_regs_common.h"
-#include "periph_cpu_common.h"
-
 /**
  * @name   Clock configuration
  * @{
@@ -37,100 +33,11 @@ extern "C" {
 #define CLOCK_CORECLOCK     (8000000UL)
 /** @} */
 
-/**
- * @name   Timer configuration
- *
- * ATTENTION RIOT Timer 0 is used for Xtimer which is system Timer
- *
- * The timer driver only supports the four 16-bit timers
- * (Timer1, TST, Timer3, Timer4, Timer5), so those are the Timer we can use here.
- * Timer 1, TST, PORT B5/6/7 Out, Port D4/6 In,  Analog Comparator Input Capture, Output Compare Modulator, PWM
- * Timer 3, TST, PORT E3/4/5 Out, Port E/6/7 In, Input or Output Compare and PWM Output
- * Timer 4, TST, It can not be connected to any I/O Pin,
- * Timer 5, TST, It can not be connected to any I/O Pin,
- *
- * Using Atmel Timer 4 and 5 seems to be the best choice
- * Using Atmel Timer 4 as Xtimer
- * and Atmel Timer 5 as timer available for the the application seems to be the best choice,
- * as the special functions of the other timer are not lost.
- * Atmel Timer1 to be used as PWM timer for RGB LED
- * @{
- */
-#define TIMER_NUMOF         (3U)
-#define TIMER_CHANNELS      (3)
-
-#define TIMER_0             MEGA_TIMER4
-#define TIMER_0_MASK        &TIMSK4
-#define TIMER_0_FLAG        &TIFR4
-#define TIMER_0_ISRA        TIMER4_COMPA_vect
-#define TIMER_0_ISRB        TIMER4_COMPB_vect
-#define TIMER_0_ISRC        TIMER4_COMPC_vect
-
-#define TIMER_1             MEGA_TIMER5
-#define TIMER_1_MASK        &TIMSK5
-#define TIMER_1_FLAG        &TIFR5
-#define TIMER_1_ISRA        TIMER5_COMPA_vect
-#define TIMER_1_ISRB        TIMER5_COMPB_vect
-#define TIMER_1_ISRC        TIMER5_COMPC_vect
-
-#define TIMER_2             MEGA_TIMER1
-#define TIMER_2_MASK        &TIMSK1
-#define TIMER_2_FLAG        &TIFR1
-#define TIMER_2_ISRA        TIMER1_COMPA_vect
-#define TIMER_2_ISRB        TIMER1_COMPB_vect
-#define TIMER_2_ISRC        TIMER1_COMPC_vect
-/** @} */
-
-/**
- * @name   UART configuration
- *
- * The UART devices have fixed pin mappings, so all we need to do, is to specify
- * which devices we would like to use and their corresponding RX interrupts. See
- * the reference manual for the fixed pin mapping.
- *
- * @{
- */
-#define UART_NUMOF          (2U)
-
-/* UART0 is used for stdio */
-#define UART_0              MEGA_UART0
-#define UART_0_ISR          USART0_RX_vect
-
-#define UART_1              MEGA_UART1
-#define UART_1_ISR          USART1_RX_vect
-/** @} */
-
-/**
- * @name SPI configuration
- *
- * The atmega256rfr has only one hardware SPI with fixed pin configuration, so all
- * we can do here, is to enable or disable it.
- *
- * PINS SS  SCK MOSI MISO
- *      PB0 PB1 PB2  PB3
- * @{
- */
-#define SPI_NUMOF           (1U)           /* set to 0 to disable SPI */
-/** @} */
-
-/**
- * @name    I2C configuration
- * @{
- */
-#define I2C_BUS_SPEED       I2C_SPEED_FAST
-#define I2C_NUMOF           (1U)
-/** @} */
-
-/**
- * @name ADC Configuration
- * @{
- */
-#define ADC_NUMOF           (8U)
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif
 
-/** @} */
+#include "periph_conf_atmega_common.h"
+
 #endif /* PERIPH_CONF_H */
+/** @} */

--- a/boards/mega-xplained/Makefile.include
+++ b/boards/mega-xplained/Makefile.include
@@ -26,3 +26,4 @@ endif
 FFLAGS_EXTRA += -F
 
 include $(RIOTMAKE)/tools/avrdude.inc.mk
+include $(RIOTBOARD)/common/atmega/Makefile.include

--- a/boards/mega-xplained/include/periph_conf.h
+++ b/boards/mega-xplained/include/periph_conf.h
@@ -3,6 +3,7 @@
  *               2016 Laurent Navet <laurent.navet@gmail.com>
  *               2017 HAW Hamburg, Dimitri Nahm
  *               2018 Matthew Blue <matthew.blue.neuro@gmail.com>
+ *               2019 Otto-von-Guericke-Universität Magdeburg
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -21,6 +22,7 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Dimitri Nahm <dimitri.nahm@haw-hamburg.de>
  * @author      Matthew Blue <matthew.blue.neuro@gmail.com>
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  */
 
 #ifndef PERIPH_CONF_H
@@ -40,88 +42,10 @@ extern "C" {
 #define CLOCK_CORECLOCK     (8000000UL)
 /** @} */
 
-/**
- * @name    Timer configuration
- *
- * The ATmega1284P has 4 timers. Timer0 and Timer2 are 8 Bit Timers.
- *
- * The timer driver only supports the two 16-bit timers (Timer1 and
- * Timer3), so those are the only ones we can use here.
- *
- * @{
- */
-#define TIMER_NUMOF         (2U)
-#define TIMER_CHANNELS      (2)
-
-#define TIMER_0             MEGA_TIMER1
-#define TIMER_0_MASK        &TIMSK1
-#define TIMER_0_FLAG        &TIFR1
-#define TIMER_0_ISRA        TIMER1_COMPA_vect
-#define TIMER_0_ISRB        TIMER1_COMPB_vect
-
-#define TIMER_1             MEGA_TIMER3
-#define TIMER_1_MASK        &TIMSK3
-#define TIMER_1_FLAG        &TIFR3
-#define TIMER_1_ISRA        TIMER3_COMPA_vect
-#define TIMER_1_ISRB        TIMER3_COMPB_vect
-/** @} */
-
-/**
- * @name    UART configuration
- *
- * The UART devices have fixed pin mappings, so all we need to do, is to specify
- * which devices we would like to use and their corresponding RX interrupts. See
- * the reference manual for the fixed pin mapping.
- *
- * @{
- */
-#define UART_NUMOF          (2U)
-
-#define UART_0              MEGA_UART0
-#define UART_0_ISR          USART0_RX_vect
-
-#define UART_1              MEGA_UART1
-#define UART_1_ISR          USART1_RX_vect
-/** @} */
-
-/**
- * @name    SPI configuration
- *
- * The ATmega1284P has only one hardware SPI with fixed pin configuration, so
- * all we can do here, is to enable or disable it...
- *
- * The fixed pins used are:
- * MOSI - PB5 (pin  1)
- * MISO - PB6 (pin  2)
- * SCK  - PB7 (pin  3)
- * SS   - PB4 (pin 44) -> this pin is configured as output, but not used
- *
- * The SS pin must be configured as output for the SPI device to work as
- * master correctly, though we do not use it for now (as we handle the chip
- * select externally for now)
- *
- * @{
- */
-#define SPI_NUMOF           1           /* set to 0 to disable SPI */
-/** @} */
-
-/**
- * @name    I2C configuration
- * @{
- */
-#define I2C_BUS_SPEED       I2C_SPEED_FAST
-#define I2C_NUMOF           1
-/** @} */
-
-/**
- * @name    ADC configuration
- * @{
- */
-#define ADC_NUMOF       (8U)
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif
+
+#include "periph_conf_atmega_common.h"
 
 #endif /* PERIPH_CONF_H */

--- a/boards/waspmote-pro/Makefile
+++ b/boards/waspmote-pro/Makefile
@@ -1,3 +1,5 @@
 MODULE = board
 
+DIRS = $(RIOTBOARD)/common/atmega
+
 include $(RIOTBASE)/Makefile.base

--- a/boards/waspmote-pro/Makefile.dep
+++ b/boards/waspmote-pro/Makefile.dep
@@ -1,3 +1,4 @@
+USEMODULE += boards_common_atmega
 #ifneq (,$(filter saul_default,$(USEMODULE)))
 #  USEMODULE += saul_gpio
 #endif

--- a/boards/waspmote-pro/Makefile.include
+++ b/boards/waspmote-pro/Makefile.include
@@ -25,3 +25,4 @@ FFLAGS_EXTRA += -b 115200
 FFLAGS_EXTRA += -F
 
 include $(RIOTMAKE)/tools/avrdude.inc.mk
+include $(RIOTBOARD)/common/atmega/Makefile.include

--- a/boards/waspmote-pro/include/periph_conf.h
+++ b/boards/waspmote-pro/include/periph_conf.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2014 Freie Universität Berlin, Hinnerk van Bruinehsen
  * Copyright (C) 2016 INRIA, Francisco Acosta
+ * Copyright (C) 2019 Otto-von-Guericke-Universität Magdeburg
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -16,6 +17,7 @@
  *
  * @author      Hinnerk van Bruinehsen <h.v.bruinehsen@fu-berlin.de>
  * @author      Francisco Acosta <francisco.acosta@inria.fr>
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  */
 
 #ifndef PERIPH_CONF_H
@@ -32,95 +34,10 @@ extern "C" {
 #define CLOCK_CORECLOCK     (14745600UL)
 /** @} */
 
-/**
- * @name    Timer peripheral configuration
- *
- * The ATmega1281 has 6 timers. Timer0 and Timer2 are 8 Bit Timers,
- * Timer0 has special uses too and therefore we'll avoid using it.
- *
- * The timer driver only supports the four 16-bit timers (Timer1, Timer3,
- * Timer4, Timer5), so those are the only ones we can use here.
- *
- * @{
- */
-#define TIMER_NUMOF         (2U)
-#define TIMER_CHANNELS      (3)
-
-#define TIMER_0             MEGA_TIMER1
-#define TIMER_0_MASK        &TIMSK1
-#define TIMER_0_FLAG        &TIFR1
-#define TIMER_0_ISRA        TIMER1_COMPA_vect
-#define TIMER_0_ISRB        TIMER1_COMPB_vect
-#define TIMER_0_ISRC        TIMER1_COMPC_vect
-
-#define TIMER_1             MEGA_TIMER4
-#define TIMER_1_MASK        &TIMSK4
-#define TIMER_1_FLAG        &TIFR4
-#define TIMER_1_ISRA        TIMER4_COMPA_vect
-#define TIMER_1_ISRB        TIMER4_COMPB_vect
-#define TIMER_1_ISRC        TIMER4_COMPC_vect
-/** @} */
-
-/**
- * @name    UART configuration
- *
- * The UART devices have fixed pin mappings, so all we need to do, is to specify
- * which devices we would like to use and their corresponding RX interrupts. See
- * the reference manual for the fixed pin mapping.
- *
- * @{
- */
-#define UART_NUMOF          (2U)
-
-#define UART_0              MEGA_UART0
-#define UART_0_ISR          USART0_RX_vect
-
-#define UART_1              MEGA_UART1
-#define UART_1_ISR          USART1_RX_vect
-
-/*
- * UART speed constants for CLK=14745600
- */
-#define UART_2400           (383)
-#define UART_4800           (191)
-#define UART_9600           (95)
-#define UART_115200         (7)
-/** @} */
-
-/**
- * @name    SPI configuration
- *
- * The atmega1281 has only one hardware SPI with fixed pin configuration, so all
- * we can do here, is to enable or disable it...
- *
- * The fixed pins used, are:
- * MOSI - PB2 (waspmote SPI-UART socket MOSI)
- * MISO - PB3 (waspmote SPI-UART socket MISO)
- * SCK  - PB1 (waspmote SPI-UART socket SCK)
- * SS   - PB0 (waspmote SD Card Chip Select) -> this pin is configured as output, but not used
- *
- * @{
- */
-#define SPI_NUMOF           1           /* set to 0 to disable SPI */
-/** @} */
-
-/**
- * @name    I2C configuration
- * @{
- */
-#define I2C_BUS_SPEED       I2C_SPEED_FAST
-#define I2C_NUMOF           1
-/** @} */
-
-/**
- * @name     ADC configuration
- * @{
- */
-#define ADC_NUMOF           (8U)
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif
+
+#include "periph_conf_atmega_common.h"
 
 #endif /* PERIPH_CONF_H */


### PR DESCRIPTION
### Contribution description

- Moved code for `periph_conf` of all ATmega based boards to `boards/common/atmega`
- Added possibility to override config from individual board:
  - Named file `periph_conf_atmega_common.h` and let this be included from  `board/$BOARD/include/periph_conf.h` to allow modifications
  - Guarded individual periph configs by `#ifndef $PERIPH_NUMOF` ... `#endif`

### Testing procedure

Do basic testing on ATmega based boards

- [x] Arduino Duemilanove (@maribu, (worked on an Arudino UNO which also uses the ATmega328p))
- [x] Arduino Mega2560 (@smlng)
- [x] Arduino Uno (@smlng)
- [ ] Jiminy Mega 256rfr2
- [ ] Mega1284P-Xplained
- [ ] Waspmote PRO v1.2

### Issues/PRs references

None

----

Update 1: Added testing state