### PR TITLE
pkt/emb6: fix typo in hwrng call

### DIFF
--- a/pkg/emb6/contrib/target.c
+++ b/pkg/emb6/contrib/target.c
@@ -50,7 +50,7 @@ uint8_t hal_getrand(void)
 {
 #if defined(MODULE_PERIPH_HWRNG)
     uint8_t res;
-    hwnrg_read((char *)&res, sizeof(res));
+    hwrng_read((char *)&res, sizeof(res));
     return res;
 #elif defined(MODULE_RANDOM)
     return (uint8_t)(random_uint32() % UINT8_MAX);


### PR DESCRIPTION
### Contribution description

This PR fixes a typo Murdock discovered in #10974. 


### Testing procedure

Run build test or look at [this log](https://ci.riot-os.org/RIOT-OS/RIOT/10974/b2c6364a0dcf2f41663e663a026dbe0663da5154/output.html)


### Issues/PRs references

#10974
