### PR TITLE
doc/doxygen: remove support for lesscpy

### DIFF
--- a/doc/doxygen/Makefile
+++ b/doc/doxygen/Makefile
@@ -5,15 +5,8 @@ export STRIP_FROM_INC_PATH_LIST=$(shell \
     grep '/include$$' |\
     sed 's/.*/\"$(subst /,\/,$(RIOTBASE))\/\0\"/')
 
-# use lessc (http://lesscss.org/#using-less) for compiling CSS, alternatively
-# fall back to lesscpy (https://github.com/lesscpy/lesscpy)
-ifeq (,$(LESSC))
-  ifneq (,$(shell command -v lessc 2>/dev/null))
-    LESSC=lessc
-  else ifneq (,$(shell command -v lesscpy 2>/dev/null))
-    LESSC=lesscpy
-  endif
-endif
+# use lessc (http://lesscss.org/#using-less) for compiling CSS
+LESSC ?= $(shell command -v lessc 2>/dev/null)
 
 .PHONY: doc
 doc: html

--- a/doc/doxygen/Makefile
+++ b/doc/doxygen/Makefile
@@ -6,6 +6,7 @@ export STRIP_FROM_INC_PATH_LIST=$(shell \
     sed 's/.*/\"$(subst /,\/,$(RIOTBASE))\/\0\"/')
 
 # use lessc (http://lesscss.org/#using-less) for compiling CSS
+# It can also be installed in ubuntu with the `node-less` package
 LESSC ?= $(shell command -v lessc 2>/dev/null)
 
 .PHONY: doc


### PR DESCRIPTION
### Contribution description

lessc (node-less) and lesscpy do not produce the same output.
There are some minor whitespace +-1 in color values which
are not important but the output file is not stable

However lesscpy removes comments and so the license of the output file
As it produces an invalid file it support is dropped.

https://lesscpy.readthedocs.io/en/latest/#differences-from-less-js


Apparently when it was added by https://github.com/RIOT-OS/RIOT/pull/7607 the output was not checked.

### Alternative solution

~Decide we do not care about the license header in `riot.css` and only use `lesscpy` instead of `node-less`.~
Not a valid alternative https://github.com/RIOT-OS/RIOT/pull/11037#issuecomment-465552480

### Testing procedure


I used this diff to show the command being executed:

```
diff --git a/doc/doxygen/Makefile b/doc/doxygen/Makefile
index 300739358..293daf17b 100644
--- a/doc/doxygen/Makefile
+++ b/doc/doxygen/Makefile
@@ -22,7 +22,7 @@ man: src/changelog.md

 ifneq (,$(LESSC))
 src/css/riot.css: src/css/riot.less src/css/variables.less
-       @$(LESSC) $< $@
+       $(LESSC) $< $@

 src/css/variables.less: src/config.json
        @grep "^\s*\"@" $< | sed -e 's/^\s*"//g' -e 's/":\s*"/: /g' \
```


With `node-less` installed and touching `riot.less` the file is rebuilt:
See the `/usr/bin/lessc src/css/riot.less src/css/riot.css` line:

```
touch doc/doxygen/src/css/riot.less

make doc
"make" -BC doc/doxygen
make[1]: Entering directory '/home/harter/work/git/RIOT/doc/doxygen'
/usr/bin/lessc src/css/riot.less src/css/riot.css
( cat riot.doxyfile ; echo "GENERATE_HTML = yes" ) | doxygen -
*make[1]: Leaving directory '/home/harter/work/git/RIOT/doc/doxygen'
```

If `LESSC` is empty it is not:

```
touch doc/doxygen/src/css/riot.less

LESSC= make doc
"make" -BC doc/doxygen
make[1]: Entering directory '/home/harter/work/git/RIOT/doc/doxygen'
( cat riot.doxyfile ; echo "GENERATE_HTML = yes" ) | doxygen -
*make[1]: Leaving directory '/home/harter/work/git/RIOT/doc/doxygen'
```

And if `node-less` is not installed it is not rebuild

```
command -v lessc

touch doc/doxygen/src/css/riot.less

make doc
"make" -BC doc/doxygen
make[1]: Entering directory '/home/harter/work/git/RIOT/doc/doxygen'
( cat riot.doxyfile ; echo "GENERATE_HTML = yes" ) | doxygen -
*make[1]: Leaving directory '/home/harter/work/git/RIOT/doc/doxygen'
```

### Issues/PRs references

The file was always being modified and said different from the version of the repository when doing `make doc` with only `lesscpy` installed.

I mentioned the issue with the comments being removed in https://github.com/RIOT-OS/RIOT/pull/10249#issuecomment-462417175