### PR TITLE
makefiles/tools: Improved avrdude integration

### DIFF
--- a/boards/arduino-duemilanove/Makefile.include
+++ b/boards/arduino-duemilanove/Makefile.include
@@ -12,8 +12,6 @@ BAUD        ?= 9600
 # using avrdude. Can be overridden for debugging (which requires changes
 # that require to use an ISP)
 PROGRAMMER ?= arduino
-# set mcu model for avrdude
-FFLAGS += -p m328p
 # configure programmer speed in baud
 FFLAGS_EXTRA += -b 57600
 

--- a/boards/arduino-mega2560/Makefile.include
+++ b/boards/arduino-mega2560/Makefile.include
@@ -12,8 +12,6 @@ BAUD        ?= 9600
 # using avrdude. Can be overridden for debugging (which requires changes
 # that require to use an ISP)
 PROGRAMMER ?= stk500v2
-# set mcu model for avrdude
-FFLAGS += -p m2560
 # configure programmer speed in baud
 FFLAGS_EXTRA += -b 115200
 

--- a/boards/arduino-uno/Makefile.include
+++ b/boards/arduino-uno/Makefile.include
@@ -12,8 +12,6 @@ BAUD        ?= 9600
 # using avrdude. Can be overridden for debugging (which requires changes
 # that require to use an ISP)
 PROGRAMMER ?= arduino
-# set mcu model for avrdude
-FFLAGS += -p m328p
 # configure programmer speed in baud
 FFLAGS_EXTRA += -b 115200
 

--- a/boards/jiminy-mega256rfr2/Makefile.include
+++ b/boards/jiminy-mega256rfr2/Makefile.include
@@ -15,8 +15,6 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 # using avrdude. Can be overridden for debugging (which requires changes
 # that require to use an ISP)
 PROGRAMMER ?= wiring
-# set mcu model for avrdude (mandatory)
-FFLAGS += -p atmega256rfr2
 # Serial Baud rate for flasher is configured to 500kBaud
 # see /usr/include/asm-generic/termbits.h for availabel baudrates on your linux system
 FFLAGS_EXTRA += -b 0010005

--- a/boards/mega-xplained/Makefile.include
+++ b/boards/mega-xplained/Makefile.include
@@ -14,8 +14,6 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 
 # PROGRAMMER defaults to the external flasher Bus Pirate ISP using avrdude.
 PROGRAMMER  ?= buspirate
-# set mcu model for avrdude
-FFLAGS += -p m1284p
 # set serial port for avrdude with buspirate
 ifeq ($(OS),Linux)
   AVRDUDE_PORT ?= /dev/ttyUSB0

--- a/boards/waspmote-pro/Makefile.include
+++ b/boards/waspmote-pro/Makefile.include
@@ -17,8 +17,6 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 # using avrdude. Can be overridden for debugging (which requires changes
 # that require to use an ISP)
 PROGRAMMER ?= stk500v1
-# set mcu model for avrdude
-FFLAGS += -p m1281
 # configure programmer speed in baud
 FFLAGS_EXTRA += -b 115200
 # avoid error if mcu signature doesn't match

--- a/makefiles/tools/avrdude.inc.mk
+++ b/makefiles/tools/avrdude.inc.mk
@@ -6,10 +6,14 @@ DEBUGSERVER_FLAGS = "-g -j usb :$(DEBUGSERVER_PORT)"
 DEBUGGER_FLAGS = "-x $(RIOTBOARD)/$(BOARD)/dist/gdb.conf $(ELFFILE)"
 DEBUGGER = $(DIST_PATH)/debug.sh $(DEBUGSERVER_FLAGS) $(DIST_PATH) $(DEBUGSERVER_PORT)
 
-# make the flasher port configurable (e.g. with atmelice the port is usb)
-# defaults to terminal's serial port if not configured
-AVRDUDE_PORT    ?= $(PORT)
-PROGRAMMER_FLAGS = -P $(AVRDUDE_PORT) $(FFLAGS_EXTRA)
+# Set flasher port only for programmers that require it
+ifneq (,$(filter $(PROGRAMMER),arduino buspirate stk500v1 stk500v2 wiring))
+  # make the flasher port configurable (e.g. with atmelice the port is usb)
+  # defaults to terminal's serial port if not configured
+  AVRDUDE_PORT     ?= $(PORT)
+  PROGRAMMER_FLAGS += -P $(AVRDUDE_PORT)
+endif
+PROGRAMMER_FLAGS += $(FFLAGS_EXTRA)
 
 # don't force to flash HEXFILE, but set it as default
 FLASHFILE ?= $(HEXFILE)

--- a/makefiles/tools/avrdude.inc.mk
+++ b/makefiles/tools/avrdude.inc.mk
@@ -6,6 +6,8 @@ DEBUGSERVER_FLAGS = "-g -j usb :$(DEBUGSERVER_PORT)"
 DEBUGGER_FLAGS = "-x $(RIOTBOARD)/$(BOARD)/dist/gdb.conf $(ELFFILE)"
 DEBUGGER = $(DIST_PATH)/debug.sh $(DEBUGSERVER_FLAGS) $(DIST_PATH) $(DEBUGSERVER_PORT)
 
+PROGRAMMER_FLAGS = -p $(subst atmega,m,$(CPU))
+
 # Set flasher port only for programmers that require it
 ifneq (,$(filter $(PROGRAMMER),arduino buspirate stk500v1 stk500v2 wiring))
   # make the flasher port configurable (e.g. with atmelice the port is usb)


### PR DESCRIPTION
### Contribution description

Currently it is impossible to use most ICSP programmers using RIOT's build system, e.g. using the `usbtiny` programmer to flash the `arduino-uno` will not work using

```
make BOARD=ardunio-uno PROGRAMMER=usbtiny
```

The reason is that the programmers serial port is set regardless of the programmer, but e.g. `usbtiny` does not use a serial port to interface with the PC. The first commit will only set the serial port for any of the default programmers of any AVR based board in RIOT (thus resulting in the same arguments for avrdude unless a custom value for `PROGRAMMER` is set). This allows using custom ICSP programmers.

The second commit sets the avrdude target based on the `$(CPU)` variable in the boards `Makefile.include`. Thus, the target no longer needs to be set for every AVR based board manually (and must no longer be set manually). The `Makefile.include` files for each board are updated accordingly.

### Testing procedure

Flashing for all AVR based boards should still work. (Instead of verifying all boards running `make BOARD=FOO flash-only` and verifying that the call to avrdude is still correct is just fine. Maybe it is good to still test for one or two boards on real hardware just to be sure.) Additionally, flashing with an ICSP (e.g. `usbtiny`) should now work.

***NOTE:*** The `jiminy-mega256rfr2` previously used `-p atmega256rfr2`, which does work. But according to the doc `-p m256rfr2` should be used. This PR changes the behavior to use `-p m256rfr2` instead.

### Issues/PRs references

None