### PR TITLE
boards/hifive1: fix hifive1 reset

### DIFF
--- a/boards/hifive1/Makefile.include
+++ b/boards/hifive1/Makefile.include
@@ -13,6 +13,7 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 include $(RIOTMAKE)/tools/serial.inc.mk
 
 # this board uses openocd
+export OPENOCD_CMD_RESET_RUN=_reset
 include $(RIOTMAKE)/tools/openocd.inc.mk
 
 # use our own openocd script to flash since HiFive1 has reset problems.

--- a/boards/hifive1/dist/openocd.cfg
+++ b/boards/hifive1/dist/openocd.cfg
@@ -31,13 +31,18 @@ $_TARGETNAME configure -work-area-phys 0x80000000 -work-area-size 10000 -work-ar
 flash bank onboard_spi_flash fespi 0x20000000 0 0 0 $_TARGETNAME
 #init
 #reset -- This type of reset is not implemented yet
-if {[ info exists pulse_srst]} {
+
+proc _reset {} {
   ftdi_set_signal nSRST 0
   ftdi_set_signal nSRST z
   #Wait for the reset stretcher
   #It will work without this, but
   #will incur lots of delays for later commands.
   sleep 1500
+}
+
+if {[ info exists pulse_srst]} {
+  _reset
 }
 #halt
 #flash protect 0 64 last off

--- a/cpu/fe310/periph/pm.c
+++ b/cpu/fe310/periph/pm.c
@@ -17,7 +17,9 @@
  * @}
  */
 
+#include <stdint.h>
 #include "periph/pm.h"
+#include "vendor/platform.h"
 
 void pm_set_lowest(void)
 {
@@ -30,4 +32,13 @@ void pm_off(void)
 
 void pm_reboot(void)
 {
+    AON_REG(AON_WDOGKEY) = AON_WDOGKEY_VALUE;
+    AON_REG(AON_WDOGCMP) = 0;
+    //wdogconfig: : wdogrsten | enablealways | reset to 0 | max scale
+    AON_REG(AON_WDOGKEY) = AON_WDOGKEY_VALUE;
+    AON_REG(AON_WDOGCFG) |= (AON_WDOGCFG_RSTEN | AON_WDOGCFG_ENALWAYS |\
+            AON_WDOGCFG_ZEROCMP | AON_WDOGCFG_SCALE) ;
+    AON_REG(AON_WDOGKEY) = AON_WDOGKEY_VALUE;
+    AON_REG(AON_WDOGFEED) = AON_WDOGFEED_VALUE;
+    while(1) {}
 }

--- a/dist/tools/openocd/openocd.sh
+++ b/dist/tools/openocd/openocd.sh
@@ -90,6 +90,8 @@
 # the target when starting a debug session. 'reset halt' can also be used
 # depending on the type of target.
 : ${OPENOCD_DBG_START_CMD:=-c 'halt'}
+# command used to reset the board
+: ${OPENOCD_CMD_RESET_RUN:="-c 'reset run'"}
 # This is an optional offset to the base address that can be used to flash an
 # image in a different location than it is linked at. This feature can be useful
 # when flashing images for firmware swapping/remapping boot loaders.
@@ -323,7 +325,7 @@ do_reset() {
             -c 'telnet_port 0' \
             -c 'gdb_port 0' \
             -c 'init' \
-            -c 'reset run' \
+            ${OPENOCD_CMD_RESET_RUN} \
             -c 'shutdown'"
 }
 


### PR DESCRIPTION
### Contribution description

```pm_reset()``` was not implemented, and ```make reset``` was non-functional on hifive1.
This PR fixes both.

Without this PR, "make test" is broken.

### Testing procedure

1. flash "tests/shell", try "reboot" with and without this PR
2. try "make term" in one terminal, then "make reset" in another
3. flash "tests/shell", run "make test"

### Issues/PRs references

none