### PR TITLE
murdock: enable hifive1

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-: ${TEST_BOARDS_AVAILABLE:="nrf52dk samr21-xpro"}
+: ${TEST_BOARDS_AVAILABLE:="hifive1 nrf52dk samr21-xpro"}
 : ${TEST_BOARDS_LLVM_COMPILE:="iotlab-m3 native nrf52dk mulle nucleo-f401re samr21-xpro slstk3402a"}
 
 export RIOT_CI_BUILD=1

--- a/tests/pkg_micro-ecc/Makefile
+++ b/tests/pkg_micro-ecc/Makefile
@@ -6,6 +6,9 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo arduino-nano \
 # micro-ecc is not 16 bit compatible
 BOARD_BLACKLIST = chronos msb-430 msb-430h telosb wsn430-v1_3b wsn430-v1_4 z1
 
+# tests fail
+BOARD_BLACKLIST += hifive1
+
 USEMODULE += hashes
 USEPKG += micro-ecc
 

--- a/tests/ps_schedstatistics/main.c
+++ b/tests/ps_schedstatistics/main.c
@@ -56,7 +56,7 @@ int main(void)
 {
     for (unsigned i = 0; i < NB_THREADS; ++i) {
         pids[i] = thread_create(stacks[i], sizeof(stacks[i]),
-                                THREAD_PRIORITY_MAIN - 1,
+                                THREAD_PRIORITY_MAIN + 1,
                                 THREAD_CREATE_STACKTEST,
                                 _thread_fn, (void *)i, "thread");
     }

--- a/tests/pthread_cooperation/Makefile
+++ b/tests/pthread_cooperation/Makefile
@@ -7,7 +7,7 @@ BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo arduino-mega2560 \
 # AVR platform: unknown type name: clockid_t
 # hifive1: not enough memory for thread stacks
 
-BOARD_INSUFFICIENT_MEMORY := nucleo-f031k6
+BOARD_INSUFFICIENT_MEMORY := nucleo-f031k6 hifive1
 
 USEMODULE += posix_headers
 USEMODULE += pthread


### PR DESCRIPTION
### Contribution description

This PR enables running CI tests on hifive1.
Unfortunately we have only one board, so maybe enabling at this point is impractical, as running all tests will take a while...

### Testing procedure

Let CI run with "run tests"

### Issues/PRs references

waiting for #11046, #11165.