### PR TITLE
pkg/semtech-loramac: fixing missing directive in doc

### DIFF
--- a/pkg/semtech-loramac/doc.txt
+++ b/pkg/semtech-loramac/doc.txt
@@ -32,6 +32,7 @@
  * set at compile time. Example for EU868:
  * ```
  *     CFLAGS += -DREGION_EU868
+ *     CFLAGS += -DLORAMAC_ACTIVE_REGION=LORAMAC_REGION_EU868
  * ```
  *
  * # Using the package API


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Setting the LORAMAC_ACTIVE_REGION define via cflags is required for building any lorawan application. The doxygen documentation is missing this define.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Read and follow the documentation to write your own lorawan application. You can compare to `examples/lorawan` and `tests/pkg_semtech-loramac` applications' Makefiles.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Loosely related to #8864 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
