### PR TITLE
tests/lwip_sock_ip: fix wrong memcpy assumption

### DIFF
--- a/tests/lwip_sock_ip/stack.c
+++ b/tests/lwip_sock_ip/stack.c
@@ -204,7 +204,7 @@ void _net_init(void)
     ip6_addr_t local6;
     s8_t idx;
 
-    memcpy(&local6.addr, local6_a, sizeof(local6));
+    memcpy(&local6.addr, local6_a, sizeof(local6_a));
     ip6_addr_clear_zone(&local6);
     netif_add_ip6_address(&netif, &local6, &idx);
     for (int i = 0; i <= idx; i++) {
@@ -241,7 +241,7 @@ void _prepare_send_checks(void)
         struct nd6_neighbor_cache_entry *nc = &neighbor_cache[i];
         if (nc->state == ND6_NO_ENTRY) {
             nc->state = ND6_REACHABLE;
-            memcpy(&nc->next_hop_address, remote6, sizeof(ip6_addr_t));
+            memcpy(&nc->next_hop_address, remote6, sizeof(remote6));
             ip6_addr_assign_zone(&nc->next_hop_address,
                                  IP6_UNICAST, &netif);
             memcpy(&nc->lladdr, mac, 6);


### PR DESCRIPTION
### Contribution description

Fixes wrong assumption in memcpy length.
ip6_addr_t is >16.

```
stack.c: In function '_net_init':                                                                    
stack.c:207:5: error: 'memcpy' reading 20 bytes from a region of size 16 [-Werror=stringop-overflow=]           
     memcpy(&local6.addr, local6_a, sizeof(local6));                                                                                         
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                      
stack.c: In function '_prepare_send_checks':
stack.c:244:13: error: 'memcpy' reading 20 bytes from a region of size 16 [-Werror=stringop-overflow=]
             memcpy(&nc->next_hop_address, remote6, sizeof(ip6_addr_t));
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```

### Testing procedure

Compile for hifive1 with gcc >8.

### Issues/PRs references

Found with #11041.