### PR TITLE
cpu/fe310: periph/timer: reset counter in timer_init()

### DIFF
--- a/cpu/fe310/periph/timer.c
+++ b/cpu/fe310/periph/timer.c
@@ -53,7 +53,11 @@ int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
     isr_cb = cb;
     isr_arg = arg;
 
-    /* No other configuration */
+
+    /* reset timer counter */
+    volatile uint64_t *mtime = (uint64_t *) (CLINT_CTRL_ADDR + CLINT_MTIME);
+    *mtime = 0;
+
     return 0;
 }
 


### PR DESCRIPTION
### Contribution description

fe310 (hifive1) did not reset the periph timer on timer_init().
This breaks e.g., isr_yield_higher.

### Testing procedure

Run tests/isr_yield_higher with and without this fix.

### Issues/PRs references

Found with #11041.