### PR TITLE
tests/periph_timer: add hifive1 exception

### DIFF
--- a/tests/periph_timer/Makefile
+++ b/tests/periph_timer/Makefile
@@ -8,6 +8,8 @@ TEST_ON_CI_WHITELIST += all
 
 ifneq (,$(filter arduino-duemilanove arduino-mega2560 arduino-uno waspmote-pro,$(BOARD)))
   TIMER_SPEED ?= 250000
+else ifneq (,$(filter hifive1,$(BOARD)))
+  TIMER_SPEED ?= 32768
 endif
 
 TIMER_SPEED ?= 1000000


### PR DESCRIPTION
### Contribution description

hifive1 (fe310) only supports 32768 as timer frequency.
This PR adds this exception.

### Testing procedure

Run on hifive1 with/without fix.


### Issues/PRs references

Found via #11041.