### PR TITLE
gnrc_netif_hdr: make in parameters const

### DIFF
--- a/sys/include/net/gnrc/netif/hdr.h
+++ b/sys/include/net/gnrc/netif/hdr.h
@@ -158,8 +158,9 @@ static inline uint8_t *gnrc_netif_hdr_get_src_addr(const gnrc_netif_hdr_t *hdr)
  * @param[in] addr          new source address
  * @param[in] addr_len      *addr* length
  */
-static inline void gnrc_netif_hdr_set_src_addr(gnrc_netif_hdr_t *hdr, uint8_t *addr,
-        uint8_t addr_len)
+static inline void gnrc_netif_hdr_set_src_addr(gnrc_netif_hdr_t *hdr,
+                                               const uint8_t *addr,
+                                               uint8_t addr_len)
 {
     if (addr_len != hdr->src_l2addr_len) {
         return;
@@ -189,8 +190,9 @@ static inline uint8_t *gnrc_netif_hdr_get_dst_addr(const gnrc_netif_hdr_t *hdr)
  * @param[in] addr          new destination address
  * @param[in] addr_len      *addr* length
  */
-static inline void gnrc_netif_hdr_set_dst_addr(gnrc_netif_hdr_t *hdr, uint8_t *addr,
-        uint8_t addr_len)
+static inline void gnrc_netif_hdr_set_dst_addr(gnrc_netif_hdr_t *hdr,
+                                               const uint8_t *addr,
+                                               uint8_t addr_len)
 {
     if (addr_len != hdr->dst_l2addr_len) {
         return;
@@ -272,7 +274,8 @@ static inline int gnrc_netif_hdr_ipv6_iid_from_dst(const gnrc_netif_t *netif,
  * @return  The generic network layer header on success.
  * @return  NULL on error.
  */
-gnrc_pktsnip_t *gnrc_netif_hdr_build(uint8_t *src, uint8_t src_len, uint8_t *dst, uint8_t dst_len);
+gnrc_pktsnip_t *gnrc_netif_hdr_build(const uint8_t *src, uint8_t src_len,
+                                     const uint8_t *dst, uint8_t dst_len);
 
 /**
  * @brief   Convenience function to get the corresponding interface struct for

--- a/sys/net/gnrc/netif/hdr/gnrc_netif_hdr.c
+++ b/sys/net/gnrc/netif/hdr/gnrc_netif_hdr.c
@@ -15,7 +15,8 @@
 
 #include "net/gnrc/netif/hdr.h"
 
-gnrc_pktsnip_t *gnrc_netif_hdr_build(uint8_t *src, uint8_t src_len, uint8_t *dst, uint8_t dst_len)
+gnrc_pktsnip_t *gnrc_netif_hdr_build(const uint8_t *src, uint8_t src_len,
+                                     const uint8_t *dst, uint8_t dst_len)
 {
     gnrc_pktsnip_t *pkt = gnrc_pktbuf_add(NULL, NULL,
                                           sizeof(gnrc_netif_hdr_t) + src_len + dst_len,


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
I encountered some tests were I couldn't initialize the `gnrc_netif_hdr` with `static const` addresses, so this fixes that.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Everything should still compile ;-).
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
