### PR TITLE
tests/pkg_relic: add hifive1 to blacklist

### DIFF
--- a/tests/pkg_relic/Makefile
+++ b/tests/pkg_relic/Makefile
@@ -6,6 +6,7 @@ BOARD_BLACKLIST :=  arduino-duemilanove \
                     arduino-uno \
                     chronos \
                     f4vi1 \
+                    hifive1 \
                     jiminy-mega256rfr2 \
                     mega-xplained \
                     msb-430 \


### PR DESCRIPTION
### Contribution description

test fails with this:

```
main(): This is RIOT! (Version: 2019.04-devel-237-gf2534-murdock_enable_hifive1)                             
.FATAL ERROR in /home/kaspar/src/riot/tests/pkg_relic/bin/pkg/hifive1/relic/src/bn/relic_bn_div.c:139                           
                                       
Timeout in expect script at "child.expect(r'OK \(\d+ tests\)', timeout=120)" (tests/pkg_relic/tests/01-run.py:14)
```

### Testing procedure

check hifive1 is not built anymore.

### Issues/PRs references

Found in #11040.