### PR TITLE
sys/shell: handle correctly long strings that overflow buffer

### DIFF
--- a/sys/shell/shell.c
+++ b/sys/shell/shell.c
@@ -44,6 +44,8 @@ static void _putchar(int c) {
 #endif
 #endif
 
+#define SHELL_LINE_TOO_LONG (-2)
+
 static void flush_if_needed(void)
 {
 #ifdef MODULE_NEWLIB
@@ -230,7 +232,7 @@ static int readline(char *buf, size_t size)
 
     while (1) {
         if ((line_buf_ptr - buf) >= ((int) size) - 1) {
-            return -1;
+            return SHELL_LINE_TOO_LONG;
         }
 
         int c = getchar();

--- a/tests/shell/tests/01-run.py
+++ b/tests/shell/tests/01-run.py
@@ -55,6 +55,14 @@ def testfunc(child):
     for cmd, expected in CMDS.items():
         check_cmd(child, cmd, expected)
 
+    # Test for a quite long line (400 bytes) that would overflow the shell buffer.
+    # Exact response depends on buffer length so check is done without an
+    # expect_exact here but we just check that shell is still alive
+    child.sendline('test' * 100)
+    child.expect('>')
+    child.sendline('')
+    child.expect('>')
+
 
 if __name__ == "__main__":
     sys.exit(run(testfunc))


### PR DESCRIPTION
### Contribution description
On very long input lines to the shell that are bigger than the shell buffer passed to the `shell_run` function (usually `SHELL_DEFAULT_BUFSIZE`) the shell process will exit.
My expected behaviour is that it will just discard or ignore the very long string and keep running. This was the original behaviour indeed but #10105 changed it as the return code of `getchar` for `EOF` is -1 which is the same value that was being used to signal a too long string. The solution is therefore trivially to use another error value for this case (I did a define for the sake of readability and possible future use).
The PR also adds an automated test for this case.

### Testing procedure
Execute a shell and send a very long string. In the old version shell will just exit, in the new chars will be discarded.
Or run the new version of automated tests under `tests/shell`
