### PR TITLE
pkg/nimble: improve structure of Makefiles

### DIFF
--- a/examples/nimble_gatt/Makefile
+++ b/examples/nimble_gatt/Makefile
@@ -12,6 +12,8 @@ RIOTBASE ?= $(CURDIR)/../..
 
 # Include NimBLE
 USEPKG += nimble
+USEMODULE += nimble_svc_gap
+USEMODULE += nimble_svc_gatt
 
 # We also use the AD part of the BLE helper module
 USEMODULE += bluetil_ad

--- a/pkg/nimble/Makefile
+++ b/pkg/nimble/Makefile
@@ -18,22 +18,50 @@ else
   CFLAGS += -Wno-unused-but-set-variable
 endif
 
+SUBMODS := $(filter nimble_%,$(USEMODULE))
+
 .PHONY: all
 
-all: git-download
-	"$(MAKE)" -C $(PDIR)/ext/tinycrypt/src/ -f $(TDIR)/ext.tinycrypt.mk
-	"$(MAKE)" -C $(PDIR)/nimble/host/src/ -f $(TDIR)/nimble.host.mk
-	"$(MAKE)" -C $(PDIR)/nimble/host/services/gap/src/ -f $(TDIR)/service.gap.mk
-	"$(MAKE)" -C $(PDIR)/nimble/host/services/gatt/src/ -f $(TDIR)/service.gatt.mk
-	"$(MAKE)" -C $(PDIR)/nimble/host/util/src/ -f $(TDIR)/nimble.host.util.mk
-	"$(MAKE)" -C $(PDIR)/nimble/host/store/ram/src/ -f $(TDIR)/nimble.host.store.ram.mk
+all: git-download $(SUBMODS)
+
+# blue code and RIOT port modules
+nimble_riot_contrib:
+	"$(MAKE)" -C $(TDIR)/contrib/
+
+nimble_porting_nimble:
 	"$(MAKE)" -C $(PDIR)/porting/nimble/src/ -f $(TDIR)/porting.nimble.mk
+
+nimble_npl_riot:
 	"$(MAKE)" -C $(PDIR)/porting/npl/riot/src/ -f $(TDIR)/porting.npl.riot.mk
 
-	"$(MAKE)" -C $(PDIR)/nimble/transport/ram/src/ -f $(TDIR)/transport.ram.mk
-	"$(MAKE)" -C $(PDIR)/nimble/controller/src/ -f $(TDIR)/controller.mk
-	"$(MAKE)" -C $(PDIR)/nimble/drivers/nrf52/src/ -f $(TDIR)/drivers.nrf52.mk
+# host modules
+nimble_host:
+	"$(MAKE)" -C $(PDIR)/nimble/host/src/ -f $(TDIR)/nimble.host.mk
 
-	"$(MAKE)" -C $(TDIR)/contrib/
+nimble_host_util:
+	"$(MAKE)" -C $(PDIR)/nimble/host/util/src/ -f $(TDIR)/nimble.host.util.mk
+
+nimble_host_store_ram:
+	"$(MAKE)" -C $(PDIR)/nimble/host/store/ram/src/ -f $(TDIR)/nimble.host.store.ram.mk
+
+nimble_tinycrypt:
+	"$(MAKE)" -C $(PDIR)/ext/tinycrypt/src/ -f $(TDIR)/ext.tinycrypt.mk
+
+# service implementations
+nimble_svc_gap:
+	"$(MAKE)" -C $(PDIR)/nimble/host/services/gap/src/ -f $(TDIR)/svc.gap.mk
+
+nimble_svc_gatt:
+	"$(MAKE)" -C $(PDIR)/nimble/host/services/gatt/src/ -f $(TDIR)/svc.gatt.mk
+
+# controller specific modules
+nimble_transport_ram:
+	"$(MAKE)" -C $(PDIR)/nimble/transport/ram/src/ -f $(TDIR)/transport.ram.mk
+
+nimble_controller:
+	"$(MAKE)" -C $(PDIR)/nimble/controller/src/ -f $(TDIR)/controller.mk
+
+nimble_drivers_nrf52:
+	"$(MAKE)" -C $(PDIR)/nimble/drivers/nrf52/src/ -f $(TDIR)/drivers.nrf52.mk
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/nimble/Makefile.dep
+++ b/pkg/nimble/Makefile.dep
@@ -6,19 +6,27 @@ USEMODULE += xtimer
 # glue code
 USEMODULE += nimble_riot_contrib
 
-# nimble sub-modules that we build
-USEMODULE += nimble_tinycrypt
-USEMODULE += nimble_host
-USEMODULE += nimble_host_services_gap
-USEMODULE += nimble_host_services_gatt
-USEMODULE += nimble_host_util
-USEMODULE += nimble_host_store_ram
+# RIOT port
 USEMODULE += nimble_porting_nimble
 USEMODULE += nimble_npl_riot
 
-# nimble controller specific sub-modules
-USEMODULE += nimble_controller
-USEMODULE += nimble_transport_ram
-ifeq (nrf52,$(CPU_FAM))
-  USEMODULE += nimble_drivers_nrf52
+# if nothing else is specified, we build the host and controller
+ifeq (,$(filter nimble_host nimble_controller,$(USEMODULE)))
+  USEMODULE += nimble_host
+  USEMODULE += nimble_controller
+endif
+
+# include host dependencies
+ifneq (,$(filter nimble_host,$(USEMODULE)))
+  USEMODULE += nimble_host_util
+  USEMODULE += nimble_tinycrypt
+  USEMODULE += nimble_host_store_ram
+endif
+
+# nimble controller dependencies
+ifneq (,$(filter nimble_controller,$(USEMODULE)))
+  USEMODULE += nimble_transport_ram
+  ifeq (nrf52,$(CPU_FAM))
+    USEMODULE += nimble_drivers_nrf52
+  endif
 endif

--- a/pkg/nimble/Makefile.include
+++ b/pkg/nimble/Makefile.include
@@ -3,32 +3,68 @@ NIMIBASE = -I$(PKGDIRBASE)/nimble
 # include RIOT glue code headers
 INCLUDES += -I$(RIOTPKG)/nimble/contrib/include
 
-# include tinycrypt headers
-INCLUDES += $(NIMIBASE)/ext/tinycrypt/include
+# include generic nimble headers
+INCLUDES += $(NIMIBASE)/nimble/include
 
 # include the RIOT NPL headers
 INCLUDES += $(NIMIBASE)/porting/npl/riot/include
-
-# include nimble controller headers
-INCLUDES += $(NIMIBASE)/nimble/transport/ram/include
-INCLUDES += $(NIMIBASE)/nimble/controller/include
-INCLUDES += $(NIMIBASE)/nimble/drivers/nrf52/include
-
-# include nimble host headers
-INCLUDES += $(NIMIBASE)/nimble/include
-INCLUDES += $(NIMIBASE)/nimble/host/include
-INCLUDES += $(NIMIBASE)/nimble/host/services/ans/include
-INCLUDES += $(NIMIBASE)/nimble/host/services/bas/include
-INCLUDES += $(NIMIBASE)/nimble/host/services/bleuart/include
-INCLUDES += $(NIMIBASE)/nimble/host/services/gap/include
-INCLUDES += $(NIMIBASE)/nimble/host/services/gatt/include
-INCLUDES += $(NIMIBASE)/nimble/host/services/ias/include
-INCLUDES += $(NIMIBASE)/nimble/host/services/lls/include
-INCLUDES += $(NIMIBASE)/nimble/host/services/tps/include
-INCLUDES += $(NIMIBASE)/nimble/host/store/ram/include
-INCLUDES += $(NIMIBASE)/nimble/host/util/include
 INCLUDES += $(NIMIBASE)/porting/nimble/include
 
-# set environment
-CFLAGS += -DNIMBLE_CFG_CONTROLLER=1
-CFLAGS += -DMYNEWT_VAL_OS_CPUTIME_FREQ=32768
+# include nimble controller headers
+ifneq (,$(filter nimble_controller,$(USEMODULE)))
+  INCLUDES += $(NIMIBASE)/nimble/controller/include
+  # set environment
+  CFLAGS += -DNIMBLE_CFG_CONTROLLER=1
+  CFLAGS += -DMYNEWT_VAL_OS_CPUTIME_FREQ=32768
+
+  ifneq (,$(filter nimble_drivers_nrf52,$(USEMODULE)))
+    INCLUDES += $(NIMIBASE)/nimble/drivers/nrf52/include
+  endif
+endif
+
+# include nimble host headers
+ifneq (,$(filter nimble_host,$(USEMODULE)))
+  INCLUDES += $(NIMIBASE)/nimble/host/include
+endif
+ifneq (,$(filter nimble_host_store_ram,$(USEMODULE)))
+  INCLUDES += $(NIMIBASE)/nimble/host/store/ram/include
+endif
+ifneq (,$(filter nimble_host_util,$(USEMODULE)))
+  INCLUDES += $(NIMIBASE)/nimble/host/util/include
+endif
+
+# include tinycrypt headers
+ifneq (,$(filter nimble_controller,$(USEMODULE)))
+  INCLUDES += $(NIMIBASE)/ext/tinycrypt/include
+endif
+
+# include transport headers
+ifneq (,$(filter nimble_transport_ram,$(USEMODULE)))
+  INCLUDES += $(NIMIBASE)/nimble/transport/ram/include
+endif
+
+# include services
+ifneq (,$(filter nimble_svc_ans,$(USEMODULE)))
+  INCLUDES += $(NIMIBASE)/nimble/host/services/ans/include
+endif
+ifneq (,$(filter nimble_svc_bas,$(USEMODULE)))
+  INCLUDES += $(NIMIBASE)/nimble/host/services/bas/include
+endif
+ifneq (,$(filter nimble_svc_bleuart,$(USEMODULE)))
+  INCLUDES += $(NIMIBASE)/nimble/host/services/bleuart/include
+endif
+ifneq (,$(filter nimble_svc_gap,$(USEMODULE)))
+  INCLUDES += $(NIMIBASE)/nimble/host/services/gap/include
+endif
+ifneq (,$(filter nimble_svc_gatt,$(USEMODULE)))
+  INCLUDES += $(NIMIBASE)/nimble/host/services/gatt/include
+endif
+ifneq (,$(filter nimble_svc_ias,$(USEMODULE)))
+  INCLUDES += $(NIMIBASE)/nimble/host/services/ias/include
+endif
+ifneq (,$(filter nimble_svc_lls,$(USEMODULE)))
+  INCLUDES += $(NIMIBASE)/nimble/host/services/lls/include
+endif
+ifneq (,$(filter nimble_svc_tps,$(USEMODULE)))
+  INCLUDES += $(NIMIBASE)/nimble/host/services/tps/include
+endif

--- a/pkg/nimble/contrib/nimble_riot.c
+++ b/pkg/nimble/contrib/nimble_riot.c
@@ -26,11 +26,15 @@
 #include "services/gap/ble_svc_gap.h"
 #include "services/gatt/ble_svc_gatt.h"
 
+#ifdef MODULE_NIMBLE_CONTROLLER
 #ifdef CPU_FAM_NRF52
 #include "nrf_clock.h"
 #endif
 
 static char _stack_controller[NIMBLE_CONTROLLER_STACKSIZE];
+#endif
+
+#ifdef MODULE_NIMBLE_HOST
 static char _stack_host[NIMBLE_HOST_STACKSIZE];
 
 static void *_host_thread(void *arg)
@@ -43,9 +47,11 @@ static void *_host_thread(void *arg)
     /* never reached */
     return NULL;
 }
+#endif
 
 void nimble_riot_init(void)
 {
+#ifdef MODULE_NIMBLE_CONTROLLER
     /* XXX: NimBLE needs the nRF5x's LF clock to run */
 #ifdef CPU_FAM_NRF52
     clock_start_lf();
@@ -61,11 +67,14 @@ void nimble_riot_init(void)
                   THREAD_CREATE_STACKTEST,
                   (thread_task_func_t)nimble_port_ll_task_func, NULL,
                   "nimble_ctrl");
+#endif
 
+#ifdef MODULE_NIMBLE_HOST
     /* and finally initialize and run the host */
     thread_create(_stack_host, sizeof(_stack_host),
                   NIMBLE_HOST_PRIO,
                   THREAD_CREATE_STACKTEST,
                   _host_thread, NULL,
                   "nimble_host");
+#endif
 }

--- a/pkg/nimble/controller.mk
+++ b/pkg/nimble/controller.mk
@@ -1,19 +1,3 @@
 MODULE = nimble_controller
 
-SRC += ble_ll_sched.c
-SRC += ble_ll_xcvr.c
-SRC += ble_ll_whitelist.c
-SRC += ble_ll_ctrl.c
-SRC += ble_ll_hci.c
-SRC += ble_ll_supp_cmd.c
-SRC += ble_ll_adv.c
-SRC += ble_ll_conn.c
-SRC += ble_ll_resolv.c
-SRC += ble_ll_conn_hci.c
-SRC += ble_ll_rand.c
-SRC += ble_ll.c
-SRC += ble_ll_scan.c
-SRC += ble_ll_dtm.c
-SRC += ble_ll_hci_ev.c
-
 include $(RIOTBASE)/Makefile.base

--- a/pkg/nimble/drivers.nrf52.mk
+++ b/pkg/nimble/drivers.nrf52.mk
@@ -1,6 +1,3 @@
 MODULE = nimble_drivers_nrf52
 
-SRC += ble_hw.c
-SRC += ble_phy.c
-
 include $(RIOTBASE)/Makefile.base

--- a/pkg/nimble/ext.tinycrypt.mk
+++ b/pkg/nimble/ext.tinycrypt.mk
@@ -1,10 +1,3 @@
 MODULE = nimble_tinycrypt
 
-SRC += aes_decrypt.c
-SRC += aes_encrypt.c
-SRC += cmac_mode.c
-SRC += ecc.c
-SRC += ecc_dh.c
-SRC += utils.c
-
 include $(RIOTBASE)/Makefile.base

--- a/pkg/nimble/nimble.host.mk
+++ b/pkg/nimble/nimble.host.mk
@@ -1,44 +1,8 @@
 MODULE = nimble_host
 
-SRC += ble_att.c
-SRC += ble_att_clt.c
-SRC += ble_att_cmd.c
-SRC += ble_att_svr.c
-SRC += ble_eddystone.c
-SRC += ble_gap.c
-SRC += ble_gattc.c
-SRC += ble_gatts.c
-SRC += ble_hs_adv.c
-SRC += ble_hs_atomic.c
-SRC += ble_hs.c
-SRC += ble_hs_cfg.c
-SRC += ble_hs_conn.c
-SRC += ble_hs_dbg.c
-SRC += ble_hs_flow.c
-SRC += ble_hs_hci.c
-SRC += ble_hs_hci_cmd.c
-SRC += ble_hs_hci_evt.c
-SRC += ble_hs_hci_util.c
-SRC += ble_hs_id.c
-SRC += ble_hs_log.c
-SRC += ble_hs_mbuf.c
-SRC += ble_hs_mqueue.c
-SRC += ble_hs_misc.c
-SRC += ble_hs_pvcy.c
-SRC += ble_hs_startup.c
-SRC += ble_ibeacon.c
-SRC += ble_l2cap.c
-SRC += ble_l2cap_coc.c
-SRC += ble_l2cap_sig.c
-SRC += ble_l2cap_sig_cmd.c
-SRC += ble_monitor.c
-SRC += ble_sm_alg.c
-SRC += ble_sm.c
-SRC += ble_sm_cmd.c
-SRC += ble_sm_lgcy.c
-SRC += ble_sm_sc.c
-SRC += ble_store.c
-SRC += ble_store_util.c
-SRC += ble_uuid.c
+# xxx: the following files do not compile for RIOT, so we skip them
+IGNORE := ble_gatts_lcl.c
+
+SRC := $(filter-out $(IGNORE),$(wildcard *.c))
 
 include $(RIOTBASE)/Makefile.base

--- a/pkg/nimble/nimble.host.store.ram.mk
+++ b/pkg/nimble/nimble.host.store.ram.mk
@@ -1,5 +1,3 @@
 MODULE = nimble_host_store_ram
 
-SRC += ble_store_ram.c
-
 include $(RIOTBASE)/Makefile.base

--- a/pkg/nimble/nimble.host.util.mk
+++ b/pkg/nimble/nimble.host.util.mk
@@ -1,5 +1,3 @@
 MODULE = nimble_host_util
 
-SRC += addr.c
-
 include $(RIOTBASE)/Makefile.base

--- a/pkg/nimble/porting.nimble.mk
+++ b/pkg/nimble/porting.nimble.mk
@@ -1,16 +1,3 @@
 MODULE = nimble_porting_nimble
 
-# host specific files
-SRC += nimble_port.c
-SRC += endian.c
-SRC += mem.c
-SRC += os_mbuf.c
-SRC += os_mempool.c
-SRC += os_msys_init.c
-
-# additional files needed for the controller
-SRC += os_cputime.c
-SRC += os_cputime_pwr2.c
-SRC += hal_timer.c
-
 include $(RIOTBASE)/Makefile.base

--- a/pkg/nimble/service.gap.mk
+++ b/pkg/nimble/service.gap.mk
@@ -1,5 +1,0 @@
-MODULE = nimble_host_services_gap
-
-SRC += ble_svc_gap.c
-
-include $(RIOTBASE)/Makefile.base

--- a/pkg/nimble/service.gatt.mk
+++ b/pkg/nimble/service.gatt.mk
@@ -1,5 +1,0 @@
-MODULE = nimble_host_services_gatt
-
-SRC += ble_svc_gatt.c
-
-include $(RIOTBASE)/Makefile.base

--- a/pkg/nimble/svc.gap.mk
+++ b/pkg/nimble/svc.gap.mk
@@ -1,3 +1,3 @@
-MODULE = nimble_npl_riot
+MODULE = nimble_svc_gap
 
 include $(RIOTBASE)/Makefile.base

--- a/pkg/nimble/svc.gatt.mk
+++ b/pkg/nimble/svc.gatt.mk
@@ -1,3 +1,3 @@
-MODULE = nimble_npl_riot
+MODULE = nimble_svc_gatt
 
 include $(RIOTBASE)/Makefile.base

--- a/pkg/nimble/transport.ram.mk
+++ b/pkg/nimble/transport.ram.mk
@@ -1,4 +1,3 @@
 MODULE += nimble_transport_ram
-SRC += ble_hci_ram.c
 
 include $(RIOTBASE)/Makefile.base


### PR DESCRIPTION
### Contribution description
This PR reworks the Makfiles for the `nimble` package a little bit, to make it more robust and improve modularity a bit. I think I still have to do some improvements to the `Makefile.include`, but aside from that the situation should be improved with this PR already...


### Testing procedure
Simply verify that `exampels/nimble_gatt` is still working as expected

### Issues/PRs references
fixes #11051