### PR TITLE
net/gcoap: add/use Packet API Block implementation

### DIFF
--- a/examples/gcoap/Makefile
+++ b/examples/gcoap/Makefile
@@ -26,6 +26,10 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo \
 #GCOAP_TOKENLEN = 2
 #CFLAGS += -DGCOAP_TOKENLEN=$(GCOAP_TOKENLEN)
 
+# Increase from default for confirmable block2 follow-on requests
+GCOAP_RESEND_BUFS_MAX ?= 2
+CFLAGS += -DGCOAP_RESEND_BUFS_MAX=$(GCOAP_RESEND_BUFS_MAX)
+
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
 USEMODULE += gnrc_netdev_default

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -718,6 +718,75 @@ static inline unsigned coap_szx2size(unsigned szx)
  * Use a coap_pkt_t struct to manage writing Options to the PDU.
  */
 /**
+ * @brief   Add block option in descriptive use from a slicer object
+ *
+ * When calling this function to initialize a packet with a block option, the
+ * more flag must be set to prevent the creation of an option with a length too
+ * small to contain the size bit.
+
+ * @post pkt.payload advanced to first byte after option
+ * @post pkt.payload_len reduced by option length
+ *
+ * @param[in,out] pkt         pkt referencing target buffer
+ * @param[in]     slicer      coap blockwise slicer helper struct
+ * @param[in]     more        more flag (1 or 0)
+ * @param[in]     option      option number (block1 or block2)
+ *
+ * @return        number of bytes written to buffer
+ * @return        <0 on error
+ * @return        -ENOSPC if no available options or insufficient buffer space
+ */
+ssize_t coap_opt_add_block(coap_pkt_t *pkt, coap_block_slicer_t *slicer,
+                           bool more, uint16_t option);
+
+/**
+ * @brief   Add block1 option in descriptive use from a slicer object
+ *
+ * When calling this function to initialize a packet with a block option, the
+ * more flag must be set to prevent the creation of an option with a length too
+ * small to contain the size bit.
+
+ * @post pkt.payload advanced to first byte after option
+ * @post pkt.payload_len reduced by option length
+ *
+ * @param[in,out] pkt         pkt referencing target buffer
+ * @param[in]     slicer      coap blockwise slicer helper struct
+ * @param[in]     more        more flag (1 or 0)
+ *
+ * @return        number of bytes written to buffer
+ * @return        <0 on error
+ * @return        -ENOSPC if no available options or insufficient buffer space
+ */
+static inline ssize_t coap_opt_add_block1(coap_pkt_t *pkt,
+                                          coap_block_slicer_t *slicer, bool more)
+{
+    return coap_opt_add_block(pkt, slicer, more, COAP_OPT_BLOCK1);
+}
+
+/**
+ * @brief   Add block2 option in descriptive use from a slicer object
+ *
+ * When calling this function to initialize a packet with a block option, the
+ * more flag must be set to prevent the creation of an option with a length too
+ * small to contain the size bit.
+
+ * @post pkt.payload advanced to first byte after option
+ * @post pkt.payload_len reduced by option length
+ *
+ * @param[in,out] pkt         pkt referencing target buffer
+ * @param[in]     slicer      coap blockwise slicer helper struct
+ * @param[in]     more        more flag (1 or 0)
+ *
+ * @return        number of bytes written to buffer
+ * @return        <0 on error
+ * @return        -ENOSPC if no available options or insufficient buffer space
+ */
+static inline ssize_t coap_opt_add_block2(coap_pkt_t *pkt,
+                                          coap_block_slicer_t *slicer, bool more)
+{
+    return coap_opt_add_block(pkt, slicer, more, COAP_OPT_BLOCK2);
+}
+/**
  * @brief   Encode the given uint option into pkt
  *
  * @post pkt.payload advanced to first byte after option
@@ -732,6 +801,43 @@ static inline unsigned coap_szx2size(unsigned szx)
  * @return        -ENOSPC if no available options or insufficient buffer space
  */
 ssize_t coap_opt_add_uint(coap_pkt_t *pkt, uint16_t optnum, uint32_t value);
+
+/**
+ * @brief   Encode the given block1 option in control use
+ *
+ * @post pkt.payload advanced to first byte after option
+ * @post pkt.payload_len reduced by option length
+ *
+ * @param[in,out] pkt         pkt referencing target buffer
+ * @param[in]     block       block to encode
+ *
+ * @return        number of bytes written to buffer
+ * @return        <0 on error
+ * @return        -ENOSPC if no available options or insufficient buffer space
+ */
+static inline ssize_t coap_opt_add_block1_control(coap_pkt_t *pkt, coap_block1_t *block) {
+    return coap_opt_add_uint(pkt, COAP_OPT_BLOCK1,
+                             (block->blknum << 4) | block->szx | (block->more ? 0x8 : 0));
+}
+
+/**
+ * @brief   Encode the given block2 option in control use
+ *
+ * @post pkt.payload advanced to first byte after option
+ * @post pkt.payload_len reduced by option length
+ *
+ * @param[in,out] pkt         pkt referencing target buffer
+ * @param[in]     block       block to encode
+ *
+ * @return        number of bytes written to buffer
+ * @return        <0 on error
+ * @return        -ENOSPC if no available options or insufficient buffer space
+ */
+static inline ssize_t coap_opt_add_block2_control(coap_pkt_t *pkt, coap_block1_t *block) {
+    /* block.more must be zero, so no need to 'or' it in */
+    return coap_opt_add_uint(pkt, COAP_OPT_BLOCK2,
+                             (block->blknum << 4) | block->szx);
+}
 
 /**
  * @brief   Append a Content-Format option to the pkt buffer

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -858,6 +858,18 @@ ssize_t coap_opt_add_uint(coap_pkt_t *pkt, uint16_t optnum, uint32_t value)
     return _add_opt_pkt(pkt, optnum, (uint8_t *)&tmp, tmp_len);
 }
 
+ssize_t coap_opt_add_block(coap_pkt_t *pkt, coap_block_slicer_t *slicer,
+                           bool more, uint16_t option)
+{
+    uint32_t blkopt = (_slicer_blknum(slicer) << 4);
+    blkopt |= _size2szx(slicer->end - slicer->start);
+    blkopt |= (more ? 0x8 : 0);
+
+    slicer->opt = pkt->payload;
+
+    return coap_opt_add_uint(pkt, option, blkopt);
+}
+
 ssize_t coap_opt_finish(coap_pkt_t *pkt, uint16_t flags)
 {
     if (flags & COAP_OPT_FINISH_PAYLOAD) {


### PR DESCRIPTION
### Contribution description
#11002 and #11024 completed the Blockwise implementation for the Buffer API, traditionally used with nanocoap sock's message send/receive functions. This PR completes the implementation for the Packet API, used by gcoap. It includes two pairs of functions:

- coap_opt_add_blockN() to send a blockwise payload (descriptive use)
- coap_opt_add_blockN_control() to request/ack a blockwise payload (control use)

_N_ is 1 when acting on a blockwise payload in a PUT/POST request, and 2 when acting on a blockwise payload in a GET response.

This PR also adds module documentation to describe typical use of these functions to send/receive blockwise content. Finally, this PR adds generic client side control use in the gcoap example to request blockwise content from a server. For example, this use allows gcoap to retrieve the full response from the nanocoap_server example for the /.well-known/core resource.

### Testing procedure
The gcoap module doc references an example for each use:

- [gcoap-block-server](https://github.com/kb2ma/riot-apps/blob/kb2ma-master/gcoap-block-server/gcoap_block.c) app for server side descriptive and control use, like the nanocoap_server example
- [gcoap-block-client](https://github.com/kb2ma/riot-apps/blob/kb2ma-master/gcoap-block-client/gcoap_block.c) app for client side descriptive use
- the gcoap example for client side control use, as mentioned above

The gcoap example caches the request path to retrieve remaining blocks. If the path is too long, the example displays `Path too long; can't complete blockwise`. To test this against nanocoap_server as described above, decrease `_LAST_REQ_PATH_MAX` in the example to 16.

FWIW, I use these examples in my automated [functional tests](https://github.com/kb2ma/riot-coap-pytest).

### Issues/PRs references
Partially implements #10732.
