### PR TITLE
net/coap: Block optimizations

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -1077,7 +1077,8 @@ size_t coap_opt_put_block_object(uint8_t *buf, uint16_t lastonum,
 static inline size_t coap_opt_put_block1_control(uint8_t *buf, uint16_t lastonum,
                                                  coap_block1_t *block)
 {
-    return coap_opt_put_block_object(buf, lastonum, block, COAP_OPT_BLOCK1);
+    return coap_opt_put_uint(buf, lastonum, COAP_OPT_BLOCK1,
+                             (block->blknum << 4) | block->szx | (block->more ? 0x8 : 0));
 }
 
 /**
@@ -1094,8 +1095,9 @@ static inline size_t coap_opt_put_block1_control(uint8_t *buf, uint16_t lastonum
 static inline size_t coap_opt_put_block2_control(uint8_t *buf, uint16_t lastonum,
                                                  coap_block1_t *block)
 {
-    block->more = 0;
-    return coap_opt_put_block_object(buf, lastonum, block, COAP_OPT_BLOCK2);
+    /* block.more must be zero, so no need to 'or' it in */
+    return coap_opt_put_uint(buf, lastonum, COAP_OPT_BLOCK2,
+                             (block->blknum << 4) | block->szx);
 }
 
 /**
@@ -1230,7 +1232,12 @@ size_t coap_put_option(uint8_t *buf, uint16_t lastonum, uint16_t onum, const uin
  *
  * @returns     amount of bytes written to @p buf
  */
-size_t coap_put_option_block1(uint8_t *buf, uint16_t lastonum, unsigned blknum, unsigned szx, int more);
+static inline size_t coap_put_option_block1(uint8_t *buf, uint16_t lastonum,
+                                            unsigned blknum, unsigned szx, int more)
+{
+    return coap_opt_put_uint(buf, lastonum, COAP_OPT_BLOCK1,
+                             (blknum << 4) | szx | (more ? 0x8 : 0));
+}
 
 /**
  * @brief   Insert content type option into buffer
@@ -1242,7 +1249,11 @@ size_t coap_put_option_block1(uint8_t *buf, uint16_t lastonum, unsigned blknum, 
  *
  * @returns     amount of bytes written to @p buf
  */
-size_t coap_put_option_ct(uint8_t *buf, uint16_t lastonum, uint16_t content_type);
+static inline size_t coap_put_option_ct(uint8_t *buf, uint16_t lastonum,
+                                        uint16_t content_type)
+{
+    return coap_opt_put_uint(buf, lastonum, COAP_OPT_CONTENT_FORMAT, content_type);
+}
 /**@}*/
 
 

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -1053,19 +1053,6 @@ size_t coap_opt_put_uint(uint8_t *buf, uint16_t lastonum, uint16_t onum,
                          uint32_t value);
 
 /**
- * @brief   Insert block option into buffer from block struct
- *
- * @param[in]   buf         buffer to write to
- * @param[in]   lastonum    last option number (must be < @p option)
- * @param[in]   block       block option attribute struct
- * @param[in]   option      option number (block1 or block2)
- *
- * @returns     amount of bytes written to @p buf
- */
-size_t coap_opt_put_block_object(uint8_t *buf, uint16_t lastonum,
-                                 coap_block1_t *block, uint16_t option);
-
-/**
  * @brief   Insert block1 option into buffer in control usage
  *
  * @param[in]   buf         buffer to write to

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -1039,6 +1039,20 @@ static inline size_t coap_opt_put_block2(uint8_t *buf, uint16_t lastonum,
 }
 
 /**
+ * @brief   Encode the given uint option into buffer
+ *
+ * @param[out]  buf         buffer to write to
+ * @param[in]   lastonum    number of previous option (for delta calculation),
+ *                          or 0 for first option
+ * @param[in]   onum        number of option
+ * @param[in]   value       value to encode
+ *
+ * @returns     amount of bytes written to @p buf
+ */
+size_t coap_opt_put_uint(uint8_t *buf, uint16_t lastonum, uint16_t onum,
+                         uint32_t value);
+
+/**
  * @brief   Insert block option into buffer from block struct
  *
  * @param[in]   buf         buffer to write to

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -718,6 +718,26 @@ size_t coap_blockwise_put_bytes(coap_block_slicer_t *slicer, uint8_t *bufpos,
 size_t coap_blockwise_put_char(coap_block_slicer_t *slicer, uint8_t *bufpos, char c);
 
 /**
+ * @brief    Block option getter
+ *
+ * This function gets a CoAP packet's block option and parses it into a helper
+ * structure.
+ *
+ * If no block option is present in @p pkt, the values in @p block will be
+ * initialized with zero. That implies both block->offset and block->more are
+ * also valid in that case, as packet with offset==0 and more==0 means it contains
+ * all the payload for the corresponding request.
+ *
+ * @param[in]   pkt     pkt to work on
+ * @param[out]  block   ptr to preallocated coap_block1_t structure
+ * @param[in]   option  block1 or block2
+ *
+ * @returns     0 if block option not present
+ * @returns     1 if structure has been filled
+ */
+int coap_get_block(coap_pkt_t *pkt, coap_block1_t *block, uint16_t option);
+
+/**
  * @brief    Block1 option getter
  *
  * This function gets a CoAP packet's block1 option and parses it into a helper
@@ -729,23 +749,29 @@ size_t coap_blockwise_put_char(coap_block_slicer_t *slicer, uint8_t *bufpos, cha
  * all the payload for the corresponding request.
  *
  * @param[in]   pkt     pkt to work on
- * @param[out]  block1  ptr to preallocated coap_block1_t structure
+ * @param[out]  block   ptr to preallocated coap_block1_t structure
  *
  * @returns     0 if block1 option not present
  * @returns     1 if structure has been filled
  */
-int coap_get_block1(coap_pkt_t *pkt, coap_block1_t *block1);
+static inline int coap_get_block1(coap_pkt_t *pkt, coap_block1_t *block)
+{
+    return coap_get_block(pkt, block, COAP_OPT_BLOCK1);
+}
 
 /**
  * @brief    Block2 option getter
  *
  * @param[in]   pkt     pkt to work on
- * @param[out]  block2  ptr to preallocated coap_block1_t structure
+ * @param[out]  block   ptr to preallocated coap_block1_t structure
  *
  * @returns     0 if block2 option not present
  * @returns     1 if structure has been filled
  */
-int coap_get_block2(coap_pkt_t *pkt, coap_block1_t *block2);
+static inline int coap_get_block2(coap_pkt_t *pkt, coap_block1_t *block)
+{
+    return coap_get_block(pkt, block, COAP_OPT_BLOCK2);
+}
 
 /**
  * @brief    Generic block option getter

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -681,30 +681,17 @@ static unsigned _slicer2blkopt(coap_block_slicer_t *slicer, bool more)
     return (blknum << 4) | _size2szx(blksize) | (more ? 0x8 : 0);
 }
 
-int coap_get_block1(coap_pkt_t *pkt, coap_block1_t *block1)
+int coap_get_block(coap_pkt_t *pkt, coap_block1_t *block, uint16_t option)
 {
-    uint32_t blknum;
-    unsigned szx;
-
-    block1->more = coap_get_blockopt(pkt, COAP_OPT_BLOCK1, &blknum, &szx);
-    if (block1->more >= 0) {
-        block1->offset = blknum << (szx + 4);
+    block->more = coap_get_blockopt(pkt, option, &block->blknum, &block->szx);
+    if (block->more >= 0) {
+        block->offset = block->blknum << (block->szx + 4);
     }
     else {
-        block1->offset = 0;
+        block->offset = 0;
     }
 
-    block1->blknum = blknum;
-    block1->szx = szx;
-
-    return (block1->more >= 0);
-}
-
-int coap_get_block2(coap_pkt_t *pkt, coap_block1_t *block2)
-{
-    block2->more = coap_get_blockopt(pkt, COAP_OPT_BLOCK2, &block2->blknum,
-                                     &block2->szx);
-    return (block2->more >= 0);
+    return (block->more >= 0);
 }
 
 size_t coap_put_block1_ok(uint8_t *pkt_pos, coap_block1_t *block1, uint16_t lastonum)

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -26,6 +26,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "bitarithm.h"
 #include "net/nanocoap.h"
 
 #define ENABLE_DEBUG (0)
@@ -655,16 +656,15 @@ size_t coap_put_option(uint8_t *buf, uint16_t lastonum, uint16_t onum, const uin
 
 static unsigned _size2szx(size_t size)
 {
-    unsigned szx = 0;
     assert(size <= 1024);
 
-    while (size) {
-        size = size >> 1;
-        szx++;
-    }
-    /* Size exponent + 1 */
-    assert(szx >= 5);
-    return szx - 5;
+    /* We must wait to subract the szx offset of 4 until after the assert below.
+     * Input should be a power of two, but if not it may have a stray low order
+     * '1' bit that would invalidate the subtraction. */
+    unsigned szx = bitarithm_lsb(size);
+
+    assert(szx >= 4);
+    return szx - 4;
 }
 
 static unsigned _slicer2blkopt(coap_block_slicer_t *slicer, bool more)

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -880,6 +880,7 @@ void coap_block_object_init(coap_block1_t *block, size_t blknum, size_t blksize,
     block->szx = _size2szx(blksize);
     block->blknum = blknum;
     block->more = more;
+    block->offset = block->blknum << (block->szx + 4);
 }
 
 void coap_block_slicer_init(coap_block_slicer_t *slicer, size_t blknum,

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -725,15 +725,6 @@ size_t coap_opt_put_block(uint8_t *buf, uint16_t lastonum, coap_block_slicer_t *
     return coap_opt_put_uint(buf, lastonum, option, _slicer2blkopt(slicer, more));
 }
 
-size_t coap_opt_put_block_object(uint8_t *buf, uint16_t lastonum,
-                                 coap_block1_t *block, uint16_t option)
-{
-    uint32_t blkopt = (block->blknum << 4) | block->szx | (block->more ? 0x8 : 0);
-    size_t olen = _encode_uint(&blkopt);
-
-    return coap_put_option(buf, lastonum, option, (uint8_t *)&blkopt, olen);
-}
-
 size_t coap_opt_put_string(uint8_t *buf, uint16_t lastonum, uint16_t optnum,
                            const char *string, char separator)
 {

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -810,6 +810,14 @@ size_t coap_opt_put_string(uint8_t *buf, uint16_t lastonum, uint16_t optnum,
     return bufpos - buf;
 }
 
+size_t coap_opt_put_uint(uint8_t *buf, uint16_t lastonum, uint16_t onum,
+                         uint32_t value)
+{
+    unsigned uint_len = _encode_uint(&value);
+
+    return coap_put_option(buf, lastonum, onum, (uint8_t *)&value, uint_len);
+}
+
 /* Common functionality for addition of an option */
 static ssize_t _add_opt_pkt(coap_pkt_t *pkt, uint16_t optnum, const uint8_t *val,
                             size_t val_len)


### PR DESCRIPTION
### Contribution description
While working on the Block implementation (#10732) we found several opportunities for optimization. However, we decided to wait until the implementation was complete before implementing them. This PR includes the improvements listed below. 

This PR also completes the Block implementation!

| Commit | Notes |
| ------ | ------ |
| c02872f | Adds coap_opt_put_uint() to write a generic uint-based option for the Buffer API. The Packet API already includes coap_opt_add_uint(). This function allows the implementation of simple options, like Content-Format, to inline this function. It also allows a user to easily add an option to a message for which there is not a specific implementation presently, like Max-Age or Size1.  |
| 1420c8e | Reimplements coap_opt_put_blockN(), coap_put_option_ct(), and coap_put_option_block1() to inline coap_opt_put_uint(). Removes implementations of those functions.  |
| d90f022 | Reworks the static _slicer_blknum() into the more useful _slicer2blkopt(). The former function only calculated the block number from a slicer struct. The latter adds a _more_ parameter to completely calculate the uint for the block option from a slicer struct. Also replaces three uses of _slicer_blknum() with _slicer2blkopt(), which also removes the duplicate calculation of the block option uint value. |
| d8ccda5 | The previous commit removed the only use of coap_opt_put_block_object(), which was added during recent development for completion of block. This commit removes coap_opt_put_block_object(). |
| 0ff2856 | The coap_get_blockN() functions were implemented separately. Only the defintiion of coap_get_block1() calculated the _offset_ attribute for the coap_block1_t struct. This commit reworks the implementation to a single definition that calculates the offset, with inlines for the specific "blockN" functions. |
| 789646e | Fixes coap_block_object_init() to also calculate the _offset_ attribute for coap_block1_t struct.  |

### Testing procedure
Verify no regression by rerunning the test procedure in #11024 and #11056.

### Issues/PRs references
Completes #10732.