### PR TITLE
tests : add periph_gpio_arduino for verifying arduino pin mappings

### DIFF
--- a/tests/periph_gpio_arduino/Makefile
+++ b/tests/periph_gpio_arduino/Makefile
@@ -1,0 +1,8 @@
+include ../Makefile.tests_common
+
+FEATURES_REQUIRED = periph_gpio
+
+USEMODULE += shell
+USEMODULE += arduino
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/periph_gpio_arduino/Makefile
+++ b/tests/periph_gpio_arduino/Makefile
@@ -1,5 +1,7 @@
 include ../Makefile.tests_common
 
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
+
 FEATURES_REQUIRED = periph_gpio
 
 USEMODULE += shell

--- a/tests/periph_gpio_arduino/README.md
+++ b/tests/periph_gpio_arduino/README.md
@@ -1,0 +1,67 @@
+# Arduino peripheral GPIO Test
+
+This test is designed for testing the Arduino to RIOT pin mapping
+on boards with Arduino support.  It is much like tests/periph_gpio
+but for Arduino pin numbers.
+
+In this test, pins are specified by integer pin numbers.
+It uses a single integer to indicate the arduino digital pin.
+
+At this point the Analog pins are not supported.
+
+## Commands
+
+`init_out <pin>`
+
+   init as output (push-pull mode)
+
+`init_in <pin>`
+
+   init as input w/o pull resistor
+
+`init_in_pu <pin>`
+
+   init as input with pull-up
+
+`read <pin>`
+
+   read pin status
+
+`set <pin>`
+
+   set pin to HIGH
+
+`clear <pin>`
+
+   set pin to LOW
+
+`toggle <pin>`
+
+   toggle pin
+
+## Example
+
+Blink the Arduino UNO led once.
+
+```
+2018-08-06 09:00:32,673 - INFO # main(): This is RIOT! (Version: 2018.10-devel-338-g2c8a2-z400-periph_gpio_arduino)
+2018-08-06 09:00:32,722 - INFO # Arduino GPIO peripheral driver test. ? for help
+> ?
+2018-08-06 09:00:38,347 - INFO #  help
+2018-08-06 09:00:38,383 - INFO # Command              Description
+2018-08-06 09:00:38,424 - INFO # ---------------------------------------
+2018-08-06 09:00:38,478 - INFO # init_out             init as output (push-pull mode)
+2018-08-06 09:00:38,535 - INFO # init_in              init as input w/o pull resistor
+2018-08-06 09:00:38,584 - INFO # init_in_pu           init as input with pull-up
+2018-08-06 09:00:38,621 - INFO # read                 read pin status
+2018-08-06 09:00:38,662 - INFO # set                  set pin to HIGH
+2018-08-06 09:00:38,699 - INFO # clear                set pin to LOW
+2018-08-06 09:00:38,732 - INFO # toggle               toggle pin
+> init_out 13
+2018-08-06 09:00:45,363 - INFO #  init_out 13
+> toggle 13
+2018-08-06 09:00:50,897 - INFO #  toggle 13
+> toggle 13
+2018-08-06 09:00:53,568 - INFO #  toggle 13
+> /exit
+```

--- a/tests/periph_gpio_arduino/main.sketch
+++ b/tests/periph_gpio_arduino/main.sketch
@@ -1,0 +1,201 @@
+/*
+ * Copyright (C) 2018 Tom Keddie
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Manual test application for GPIO peripheral drivers using
+ *              Arduino pin numbering
+ *
+ * @author      Tom Keddie <github@bronwenandtom.com>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "shell.h"
+#include "periph/gpio.h"
+
+#define ARDUINO_PIN_NUMOF ((int)(sizeof(arduino_pinmap)/sizeof(arduino_pinmap[0])))
+
+static int get_digital_pin(const char* pinstring)
+{
+    int arduino_pin = -1;
+    char *endptr  = NULL;
+
+    if (*pinstring == 'A') {
+        /* TODO : add analogInputToDigitalPin macro to arduino_board.h for all boards */
+        return -1;
+    }
+
+    arduino_pin = strtol(pinstring, &endptr, 0);
+    /* strtol returns 0 on error, manual check for pin 0, works for 0 but not
+       00 etc, this will have to be acceptable */
+    if (arduino_pin == 0 && (pinstring[0] != '0' || pinstring[1] != '\0'))
+        arduino_pin = -1;
+
+    if ((*endptr != '\0') || (arduino_pin == -1) || (arduino_pin > ARDUINO_PIN_NUMOF)) {
+        return -1;
+    }
+
+    return arduino_pin;
+}
+
+static int init_pin(int argc, char **argv, int mode)
+{
+    int pin;
+
+    if (argc < 2) {
+        printf("usage: %s <pin>\n", argv[0]);
+        return 1;
+    }
+
+    pin = get_digital_pin(argv[1]);
+    if (pin < 0) {
+        printf("Could not map Arduino pin %s to a gpio.\nExpected numeric pin number.\n", argv[1]);
+        return 1;
+    }
+
+    pinMode(pin, mode);
+
+    return 0;
+}
+
+static int init_out(int argc, char **argv)
+{
+    return init_pin(argc, argv, OUTPUT);
+}
+
+static int init_in(int argc, char **argv)
+{
+    return init_pin(argc, argv, INPUT);
+}
+
+static int init_in_pu(int argc, char **argv)
+{
+    return init_pin(argc, argv, INPUT_PULLUP);
+}
+
+static int read(int argc, char **argv)
+{
+    int pin;
+
+    if (argc < 2) {
+        printf("usage: %s <pin>\n", argv[0]);
+        return 1;
+    }
+
+    pin = get_digital_pin(argv[1]);
+    if (pin < 0) {
+        printf("Could not map Arduino pin %s to a gpio.\nExpected numeric pin number.\n", argv[1]);
+        return 1;
+    }
+
+    if (digitalRead(pin)) {
+        printf("ARDUINO_PIN(%i) is HIGH\n", pin);
+    }
+    else {
+        printf("ARDUINO_PIN(%i) is LOW\n", pin);
+    }
+
+    return 0;
+}
+
+static int set(int argc, char **argv)
+{
+    int pin;
+
+    if (argc < 2) {
+        printf("usage: %s <pin>\n", argv[0]);
+        return 1;
+    }
+
+    pin = get_digital_pin(argv[1]);
+    if (pin < 0) {
+        printf("Could not map Arduino pin %s to a gpio.\nExpected numeric pin number.\n", argv[1]);
+        return 1;
+    }
+
+    digitalWrite(pin, 1);
+
+    return 0;
+}
+
+static int clear(int argc, char **argv)
+{
+    int pin;
+
+    if (argc < 2) {
+        printf("usage: %s <pin>\n", argv[0]);
+        return 1;
+    }
+
+    pin = get_digital_pin(argv[1]);
+    if (pin < 0) {
+        printf("Could not map Arduino pin %s to a gpio.\nExpected numeric pin number.\n", argv[1]);
+        return 1;
+    }
+
+    digitalWrite(pin, 0);
+
+    return 0;
+}
+
+static int toggle(int argc, char **argv)
+{
+    int pin;
+
+    if (argc < 2) {
+        printf("usage: %s <pin>\n", argv[0]);
+        return 1;
+    }
+
+    pin = get_digital_pin(argv[1]);
+    if (pin < 0) {
+        printf("Could not map Arduino pin %s to a gpio.\nExpected numeric pin number.\n", argv[1]);
+        return 1;
+    }
+
+    /* not thread safe but Arduino doesn't promise such things */
+    if (digitalRead(pin)) {
+        digitalWrite(pin, 0);
+    }
+    else {
+        digitalWrite(pin, 1);
+    }
+
+    return 0;
+}
+
+static const shell_command_t shell_commands[] = {
+    { "init_out", "init as output (push-pull mode)", init_out },
+    { "init_in", "init as input w/o pull resistor", init_in },
+    { "init_in_pu", "init as input with pull-up", init_in_pu },
+    { "read", "read pin status", read },
+    { "set", "set pin to HIGH", set },
+    { "clear", "set pin to LOW", clear },
+    { "toggle", "toggle pin", toggle },
+    { NULL, NULL, NULL }
+};
+
+void setup(void)
+{
+    puts("Arduino GPIO peripheral driver test. ? for help");
+
+    /* start the shell */
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+}
+
+void loop(void)
+{
+}


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

copy with squashed version of #9707, retaining original authorship by @TomKeddie

### Testing procedure

compile and flash `tests/periph_gpio_arduino` onto your favourite Arduino board and e.g. toggle the LED with

```
init_out 13
toggle 13
toggle 13
```

### Issues/PRs references

see also #9707