### PR TITLE
boards/lobaro-lorabox: Remove auto init LED0

### DIFF
--- a/boards/lobaro-lorabox/include/board.h
+++ b/boards/lobaro-lorabox/include/board.h
@@ -28,7 +28,6 @@ extern "C" {
  * @name    LED pin definitions and handlers
  * @{
  */
-#define AUTO_INIT_LED0
 #define LED0_PORT           GPIOA
 #define LED0_PIN            GPIO_PIN(PORT_A, 1)
 #define LED0_MASK           (1 << 1)

--- a/boards/lobaro-lorabox/include/gpio_params.h
+++ b/boards/lobaro-lorabox/include/gpio_params.h
@@ -31,13 +31,11 @@ extern "C" {
  */
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
-#ifdef AUTO_INIT_LED0
     {
         .name = "LED(green)",
         .pin = LED0_PIN,
         .mode = GPIO_OUT
-    },
-#endif
+    }
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Contribution description
This PR removes the definition of `AUTO_INIT_LED0` from board.h as it was not being checked on the init but only on the saul gpio (and actually is not needed as no conflict exists on that pin).

The issue was found in #10322 as the definition of the macro causes a conflict. 

### Testing procedure
Run `tests/saul` application and LED0 should be initialized without having to define `AUTO_INIT_LED0`.

### Issues/PRs references
#10322