### PR TITLE
serial.inc.mk: disable local echo in picocom.

### DIFF
--- a/makefiles/tools/serial.inc.mk
+++ b/makefiles/tools/serial.inc.mk
@@ -22,5 +22,5 @@ else ifeq ($(RIOT_TERMINAL),socat)
   TERMFLAGS ?= $(SOCAT_OUTPUT) open:$(PORT),b$(BAUD),echo=0,raw
 else ifeq ($(RIOT_TERMINAL),picocom)
   TERMPROG  ?= picocom
-  TERMFLAGS ?= --nolock --imap lfcrlf --echo --baud "$(BAUD)" "$(PORT)"
+  TERMFLAGS ?= --nolock --imap lfcrlf --baud "$(BAUD)" "$(PORT)"
 endif


### PR DESCRIPTION
### Contribution description

Due to a recent fix in shell.c (#10630), remote echo is now working as originally intended. Local echo must be disabled or otherwise it will add up to the remote one, causing a character-by-character double echoing.

### Testing procedure

Note: exit picocom by typing Ctrl-a Ctrl-x.

Run `RIOT_TERMINAL=picocom BOARD=samr21-xpro make -C tests/shell term`

Without this fix:

```
Type [C-a] [C-h] to see available commands
Terminal ready


> hheellpp

Command              Description
---------------------------------------
start_test           starts a test
end_test             ends a test
echo                 prints the input command
reboot               Reboot the node
ps                   Prints information about running threads.
> <type enter here>
<empty line that shoul not exist>
>
```

With this fix:

```
> help
Command              Description
---------------------------------------
start_test           starts a test
end_test             ends a test
echo                 prints the input command
reboot               Reboot the node
ps                   Prints information about running threads.
>  <note no empty line after typing enter here>
>
```


### Issues/PRs references

See #10630, #10952 