### PR TITLE
gnrc_sixlowpan_frag: encapsulate msg_send_to_self()

### DIFF
--- a/sys/include/net/gnrc/sixlowpan/internal.h
+++ b/sys/include/net/gnrc/sixlowpan/internal.h
@@ -28,6 +28,14 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Returns the PID of the 6Lo thread
+ *
+ * @return  The PID of the 6Lo thread on success
+ * @return  KERNEL_PID_UNDEF, when 6Lo thread was not started.
+ */
+kernel_pid_t gnrc_sixlowpan_get_pid(void);
+
+/**
  * @brief   Delegates a packet to the network layer
  *
  * @param[in] pkt       A packet

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/gnrc_sixlowpan_frag.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/gnrc_sixlowpan_frag.c
@@ -241,7 +241,6 @@ void gnrc_sixlowpan_frag_send(gnrc_pktsnip_t *pkt, void *ctx, unsigned page)
     /* payload_len: actual size of the packet vs
      * datagram_size: size of the uncompressed IPv6 packet */
     size_t payload_len = gnrc_pkt_len(fragment_msg->pkt->next);
-    msg_t msg;
 
     assert((fragment_msg->pkt == pkt) || (pkt == NULL));
     (void)page;
@@ -284,9 +283,7 @@ void gnrc_sixlowpan_frag_send(gnrc_pktsnip_t *pkt, void *ctx, unsigned page)
         goto error;
     }
     fragment_msg->offset += res;
-    msg.type = GNRC_SIXLOWPAN_MSG_FRAG_SND,
-    msg.content.ptr = fragment_msg;
-    if (msg_send_to_self(&msg) == 0) {
+    if (!gnrc_sixlowpan_frag_send_msg(fragment_msg)) {
         DEBUG("6lo frag: message queue full, can't issue next fragment "
               "sending\n");
         goto error;

--- a/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
@@ -55,6 +55,11 @@ kernel_pid_t gnrc_sixlowpan_init(void)
     return _pid;
 }
 
+kernel_pid_t gnrc_sixlowpan_get_pid(void)
+{
+    return _pid;
+}
+
 void gnrc_sixlowpan_dispatch_recv(gnrc_pktsnip_t *pkt, void *context,
                                   unsigned page)
 {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This makes it easier to access this functionality for test cases e.g. from the `main` thread.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`gnrc_networking` with fragmented packets (e.g. `ping6 -s 120 <link-layer address>`) should still work. Neither code nor RAM size should change.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None but required for minimal fragment forwarding tests:

![Route to 6Lo minimal fragment forwarding](http://page.mi.fu-berlin.de/mlenders/sixlo_minfwd.svg)
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
