### PR TITLE
unexport TERM* variables

### DIFF
--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -40,7 +40,7 @@ else
   export DEBUGGER ?= gdb
 endif
 
-export TERMPROG ?= $(ELFFILE)
+TERMPROG ?= $(ELFFILE)
 export FLASHER = true
 export VALGRIND ?= valgrind
 export CGANNOTATE ?= cg_annotate
@@ -100,7 +100,7 @@ else
   export PORT =
 endif
 
-export TERMFLAGS := $(PORT) $(TERMFLAGS)
+TERMFLAGS := $(PORT) $(TERMFLAGS)
 
 export ASFLAGS =
 ifeq ($(shell basename $(DEBUGGER)),lldb)
@@ -117,7 +117,7 @@ debug-valgrind-server: export VALGRIND_FLAGS ?= --vgdb=yes --vgdb-error=0 -v \
 	--leak-check=full --track-origins=yes --fullpath-after=$(RIOTBASE) \
 	--read-var-info=yes
 term-cachegrind: export CACHEGRIND_FLAGS += --tool=cachegrind
-term-gprof: export TERMPROG = GMON_OUT_PREFIX=gmon.out $(ELFFILE)
+term-gprof: TERMPROG = GMON_OUT_PREFIX=gmon.out $(ELFFILE)
 all-valgrind: export CFLAGS += -DHAVE_VALGRIND_H -g
 all-valgrind: export NATIVEINCLUDES += $(shell pkg-config valgrind --cflags)
 all-debug: export CFLAGS += -g

--- a/makefiles/tools/serial.inc.mk
+++ b/makefiles/tools/serial.inc.mk
@@ -14,13 +14,13 @@ export BAUD ?= 115200
 
 RIOT_TERMINAL ?= pyterm
 ifeq ($(RIOT_TERMINAL),pyterm)
-  export TERMPROG  ?= $(RIOTTOOLS)/pyterm/pyterm
-  export TERMFLAGS ?= -p "$(PORT)" -b "$(BAUD)"
+  TERMPROG  ?= $(RIOTTOOLS)/pyterm/pyterm
+  TERMFLAGS ?= -p "$(PORT)" -b "$(BAUD)"
 else ifeq ($(RIOT_TERMINAL),socat)
   SOCAT_OUTPUT ?= -
-  export TERMPROG ?= $(RIOT_TERMINAL)
-  export TERMFLAGS ?= $(SOCAT_OUTPUT) open:$(PORT),b$(BAUD),echo=0,raw
+  TERMPROG ?= $(RIOT_TERMINAL)
+  TERMFLAGS ?= $(SOCAT_OUTPUT) open:$(PORT),b$(BAUD),echo=0,raw
 else ifeq ($(RIOT_TERMINAL),picocom)
-  export TERMPROG  ?= picocom
-  export TERMFLAGS ?= --nolock --imap lfcrlf --echo --baud "$(BAUD)" "$(PORT)"
+  TERMPROG  ?= picocom
+  TERMFLAGS ?= --nolock --imap lfcrlf --echo --baud "$(BAUD)" "$(PORT)"
 endif

--- a/makefiles/vars.inc.mk
+++ b/makefiles/vars.inc.mk
@@ -72,8 +72,8 @@ export GIT_CACHE_DIR         # path to git-cache cache directory
 export FLASHER               # The command to call on "make flash".
 export FFLAGS                # The parameters to supply to FLASHER.
 export FLASH_ADDR            # Define an offset to flash code into ROM memory.
-export TERMPROG              # The command to call on "make term".
-export TERMFLAGS             # Additional parameters to supply to TERMPROG.
+# TERMPROG                   # The command to call on "make term".
+# TERMFLAGS                  # Additional parameters to supply to TERMPROG.
 export PORT                  # The port to connect the TERMPROG to.
 export ELFFILE               # The unstripped result of the compilation.
 export HEXFILE               # The stripped result of the compilation.


### PR DESCRIPTION
### Contribution description

TERMPROG and TERMFLAGS variables do not need to be exported as they are
used directly by a make receipe.

Exporting them prevents overwriting 'RIOT_TERMINAL' in the test.


#### Other uses to unexport:

There is one remaining usage of `export TERMFLAGS` but it should be handled alone as it does not make sense as it does not handle `RIOT_TERMINAL`. I will add it to the tracking issue.

```
git grep -e 'export TERM'
boards/nz32-sc151/Makefile.include:export TERMFLAGS = -p $(PORT)
```

### Testing procedure

#### Review
We can see that there are not usages in other places than recipes that are declared in `Makefile.include`:


```
git grep -e '$(TERMPROG)' -e '$(TERMFLAGS)' -e '${TERMPROG}' -e '${TERMFLAGS}'
Makefile.include:       $(call check_cmd,$(TERMPROG),Terminal program)
Makefile.include:       $(TERMPROG) $(TERMFLAGS)
boards/native/Makefile.include:TERMFLAGS := $(PORT) $(TERMFLAGS)
boards/native/Makefile.include:  export DEBUGGER_FLAGS = -- $(ELFFILE) $(TERMFLAGS)
boards/native/Makefile.include:  export DEBUGGER_FLAGS = -q --args $(ELFFILE) $(TERMFLAGS)
makefiles/info.inc.mk:  @echo 'TERMPROG:  $(TERMPROG)'
makefiles/info.inc.mk:  @echo 'TERMFLAGS: $(TERMFLAGS)'
```


There are no more exports of `TERMFLAGS` or `TERMPROG` except the one already mentioned earlier:

```
git grep -e 'export TERM'
boards/nz32-sc151/Makefile.include:export TERMFLAGS = -p $(PORT)
```

### Testing `make term`

It is still working for both native and boards. You can try

```
make -C examples/hello-world/ all term
BOARD=samr21-xpro make -C examples/default all term
```

The `term-gprof` for native is not working both in master and with this PR.

### Overwriting `RIOT_TERMINAL` in testrunner:

The usage within `make test` can be checked with this diff.
With it, running a test on a board should use `socat`

``` diff
diff --git a/dist/pythonlibs/testrunner/__init__.py b/dist/pythonlibs/testrunner/__init__.py
index 67489f00c..06f086a02 100755
--- a/dist/pythonlibs/testrunner/__init__.py
+++ b/dist/pythonlibs/testrunner/__init__.py
@@ -38,6 +38,7 @@ def find_exc_origin(exc_info):
 
 def run(testfunc, timeout=10, echo=True, traceback=False):
     env = os.environ.copy()
+    env['RIOT_TERMINAL'] = 'socat'
     child = pexpect.spawnu("make term", env=env, timeout=timeout, codec_errors='replace')
```

```
BOARD=samr21-xpro  make -C tests/bloom_bytes/ flash test
make: Entering directory '/home/harter/work/git/RIOT/tests/bloom_bytes'
...
Programming..................................................... done.
Verification..................................................... done.
socat - open:/dev/ttyACM0,b115200,echo=0,raw
adding 512 elements took 262ms
checking 10000 elements took 2468ms

267 elements probably in the filter.
9733 elements not in the filter.
 false positive rate.

All done!
main(): Tmain(): This is RIOT! (Version: 2019.04-devel-269-g3b11-pr/bug/export/term_variables)
Testing Bloom filter.

m: 4096 k: 8

adding 512 elements took 262ms
checking 10000 elements took 2468ms

267 elements probably in the filter.
9733 elements not in the filter.
 false positive rate.

All done!

make: Leaving directory '/home/harter/work/git/RIOT/tests/bloom_bytes'
```


### Issues/PRs references

Tracking issue https://github.com/RIOT-OS/RIOT/issues/10850
Was an effective issue while working on https://github.com/RIOT-OS/RIOT/pull/10952
