### PR TITLE
boards/nz32-sc151: do not blindly set TERMFLAGS

### DIFF
--- a/boards/nz32-sc151/Makefile.include
+++ b/boards/nz32-sc151/Makefile.include
@@ -15,7 +15,6 @@ export RESET = # dfu-util has no support for resetting the device
 
 HEXFILE = $(BINFILE)
 export FFLAGS = -d $(ID) -a 0 -s 0x08000000:leave -D "$(HEXFILE)"
-export TERMFLAGS = -p $(PORT)
 
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk


### PR DESCRIPTION
### Contribution description

The board should not globally set `TERMFLAGS` without a RIOT_TERMINAL
condition.

Also the board does not export uart through usb and thus needs an uart
converter connected. Other boards in the same situation do not need
to set `TERMPROG` without a valid baudrate. So remove the definition
anyway.

This also removes the export of TERM* variables and should make it work
with the other RIOT_TERMINAL.

https://github.com/RIOT-OS/RIOT/blob/7e0891ebe5e3c090b0b058929eb8ab16ded57d7e/boards/nz32-sc151/doc.txt#L56-L61

### Testing procedure

I do not have the board here but testing the board with an external uart should still work.
@aabadie 

Also you can review the commit message if it makes sense for the board or not.

### Issues/PRs references

Tracking issue: https://github.com/RIOT-OS/RIOT/issues/10850
Found while working on https://github.com/RIOT-OS/RIOT/pull/10952
