### PR TITLE
boards/common/stm32: rework common clock configuration for stm32f4

### DIFF
--- a/boards/common/stm32/include/f4/cfg_clock_168_8_0.h
+++ b/boards/common/stm32/include/f4/cfg_clock_168_8_0.h
@@ -11,13 +11,13 @@
  * @{
  *
  * @file
- * @brief       Configure STM32F4 clock to 168MHz using PLL with LSE
+ * @brief       Configure STM32F4 clock to 168MHz using PLL and without LSE
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef F4_CFG_CLOCK_168_8_1_H
-#define F4_CFG_CLOCK_168_8_1_H
+#ifndef F4_CFG_CLOCK_168_8_0_H
+#define F4_CFG_CLOCK_168_8_0_H
 
 #include "f4/cfg_clock_168_8_common.h"
 
@@ -31,11 +31,11 @@ extern "C" {
  * 0: no external low speed crystal available,
  * 1: external crystal available (always 32.768kHz)
  */
-#define CLOCK_LSE           (1)
+#define CLOCK_LSE           (0)
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* F4_CFG_CLOCK_168_8_1_H */
+#endif /* F4_CFG_CLOCK_168_8_0_H */
 /** @} */

--- a/boards/common/stm32/include/f4/cfg_clock_168_8_common.h
+++ b/boards/common/stm32/include/f4/cfg_clock_168_8_common.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2018 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_common_stm32
+ * @{
+ *
+ * @file
+ * @brief       Configure STM32F4 clock to 168MHz using PLL
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ */
+
+#ifndef F4_CFG_CLOCK_168_8_COMMON_H
+#define F4_CFG_CLOCK_168_8_COMMON_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Clock settings
+ *
+ * @note    This is auto-generated from
+ *          `cpu/stm32_common/dist/clk_conf/clk_conf.c`
+ * @{
+ */
+/* give the target core clock (HCLK) frequency [in Hz],
+ * maximum: 168MHz */
+#define CLOCK_CORECLOCK     (168000000U)
+/* 0: no external high speed crystal available
+ * else: actual crystal frequency [in Hz] */
+#define CLOCK_HSE           (8000000U)
+/* peripheral clock setup */
+#define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1
+#define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
+#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV4     /* max 42MHz */
+#define CLOCK_APB1          (CLOCK_CORECLOCK / 4)
+#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV2     /* max 84MHz */
+#define CLOCK_APB2          (CLOCK_CORECLOCK / 2)
+
+/* Main PLL factors */
+#define CLOCK_PLL_M          (4)
+#define CLOCK_PLL_N          (168)
+#define CLOCK_PLL_P          (2)
+#define CLOCK_PLL_Q          (7)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* F4_CFG_CLOCK_168_8_COMMON_H */
+/** @} */

--- a/boards/stm32f4discovery/include/periph_conf.h
+++ b/boards/stm32f4discovery/include/periph_conf.h
@@ -21,7 +21,7 @@
 #define PERIPH_CONF_H
 
 #include "periph_cpu.h"
-#include "f4/cfg_clock_168_8_1.h"
+#include "f4/cfg_clock_168_8_0.h"
 #include "cfg_spi_divtable.h"
 
 #ifdef __cplusplus


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is slightly reworking the common clock configuration used with stm32f4 based boards running at 168MHz with HSE at 8MHz:
- add a common clock configuration header file without LSE define: `f4/cfg_clock_168_8_common.h`
- use this new header file with the exising clock configuration (`f4/cfg_clock_168_8_1.h`)
- add a new file for boards without LSE (`f4/cfg_clock_168_8_0.h`)

The stm32f4discovery board is now using the clock configuration without LSE. So this PR is also fixing #11029.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Applications are working with stm32f4discovery and nucleo-f429zi

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

fixes #11029 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
