### PR TITLE
gnrc_netif: expose message queue size configurable

### DIFF
--- a/sys/include/net/gnrc/netif/conf.h
+++ b/sys/include/net/gnrc/netif/conf.h
@@ -47,6 +47,17 @@ extern "C" {
 #endif
 
 /**
+ * @brief       Message queue size for network interface threads
+ *
+ * @attention   This has influence on the used stack memory of the thread, so
+ *              the thread's stack size might need to be adapted if this is
+ *              changed.
+ */
+#ifndef GNRC_NETIF_MSG_QUEUE_SIZE
+#define GNRC_NETIF_MSG_QUEUE_SIZE  (8U)
+#endif
+
+/**
  * @brief   Number of multicast addresses needed for @ref net_gnrc_rpl "RPL".
  *
  * @note    Used for calculation of @ref GNRC_NETIF_IPV6_GROUPS_NUMOF

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -38,8 +38,6 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
-#define _NETIF_NETAPI_MSG_QUEUE_SIZE    (8)
-
 static gnrc_netif_t _netifs[GNRC_NETIF_NUMOF];
 
 static void _update_l2addr_from_dev(gnrc_netif_t *netif);
@@ -1170,7 +1168,7 @@ static void *_gnrc_netif_thread(void *args)
     netdev_t *dev;
     int res;
     msg_t reply = { .type = GNRC_NETAPI_MSG_TYPE_ACK };
-    msg_t msg, msg_queue[_NETIF_NETAPI_MSG_QUEUE_SIZE];
+    msg_t msg, msg_queue[GNRC_NETIF_MSG_QUEUE_SIZE];
 
     DEBUG("gnrc_netif: starting thread %i\n", sched_active_pid);
     netif = args;
@@ -1178,7 +1176,7 @@ static void *_gnrc_netif_thread(void *args)
     dev = netif->dev;
     netif->pid = sched_active_pid;
     /* setup the link-layer's message queue */
-    msg_init_queue(msg_queue, _NETIF_NETAPI_MSG_QUEUE_SIZE);
+    msg_init_queue(msg_queue, GNRC_NETIF_MSG_QUEUE_SIZE);
     /* register the event callback with the device driver */
     dev->event_callback = _event_cb;
     dev->context = netif;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
In some offline discussions regarding https://github.com/RIOT-OS/RIOT/pull/10268 we noticed, that the message queue size is too small for some network devices to handle large fragmented packages. Not just the driver in #10268 is affected, but also e.g. the `kw2x` on `pba-d-01-kw2x`. This change

1. Increases the queue size from 8 to 16 for `gnrc_netif` threads and
2. ~~Exposes the macro for the message queue size and makes it configurable.~~ (see https://github.com/RIOT-OS/RIOT/pull/11067#issuecomment-467398847).
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Compile and flash `examples/gnrc_networking` to `pba-d-01-kw2x` with `CFLAGS=-DGNRC_NETIF_MSG_QUEUE_SIZE=16`, try to ping it from another IEEE-802.15.4-capable board with large payloads:

```
ping6 -s 1232 "<link-local address>"
```

~~Without this PR problems might arise, with it, it should work. Also try and see if for smaller boards (e.g. `z1` or `arduino-mega2560`) `examples/gnrc_minimal` still works without stack overflows (you can't send too huge packets though, as the packet buffer size is set to 512 in `gnrc_minimal`)~~ (`gnrc_minimal` does not work in master, see https://github.com/RIOT-OS/RIOT/pull/11067#issuecomment-467398112).
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Discovered in #10268.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
