### PR TITLE
core: Added thread_signal & thread_await_signal

### DIFF
--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -446,7 +446,6 @@ static inline void thread_signal(thread_signal_t *signal)
 /**
  * @brief Initialize the signal data structure
  * @param[out]  signal      Structure to initialize
- * @param[in]   pid         PID of the thread that will await the signal
  */
 static inline void thread_signal_init(thread_signal_t *signal)
 {


### PR DESCRIPTION
### Contribution description

`thread_sleep()` and `thread_wakeup()` provide simple means to signal an event to a thread. However, the calls need to be synchronized: The waiting thread has to call `thread_sleep()` before `thread_wakeup()` is called.

This commit adds `thread_await_signal()` and `thread_signal()` which do not need to be synchronized: If `thread_signal()` is called between to calls to `thread_await_signal()`, the second call to `thread_await_signal()` will return immediately. If `thread_await_signal()` is called before the matching call to `thread_signal()`, they will behave like `thread_wakeup()` and `thread_sleep()`.

### Testing procedure

As `thread_sleep()` and `thread_wakeup()` are changed to internally use `thread_await_signal()` and `thread_signal()`, testing if they still work should be done. `thread_await_signal()` and `thread_signal()` could be tested with https://github.com/RIOT-OS/RIOT/pull/10340, which I will update to use this PR after my next appointment. I could also provide a minimum example application using both APIs, if needed be.

### Issues/PRs references

Competes with https://github.com/RIOT-OS/RIOT/pull/11006