### PR TITLE
boards/stm32f3discovery: Fix no external low speed crystal

### DIFF
--- a/boards/stm32f3discovery/include/periph_conf.h
+++ b/boards/stm32f3discovery/include/periph_conf.h
@@ -40,7 +40,7 @@ extern "C" {
 #define CLOCK_HSE           (8000000U)
 /* 0: no external low speed crystal available,
  * 1: external crystal available (always 32.768kHz) */
-#define CLOCK_LSE           (1)
+#define CLOCK_LSE           (0)
 /* peripheral clock setup */
 #define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1
 #define CLOCK_AHB           (CLOCK_CORECLOCK / 1)


### PR DESCRIPTION
### Contribution description

The board does not have external low speed crystal.

Page 20 of User Manual: 6.10.2 "OSC 32 kHz clock supply"

 * X3 Crystal (not provided)

https://www.st.com/resource/en/user_manual/dm00063382.pdf

This fixes `example/default` and makes `tests/periph_rtc` work properly.


### Testing procedure

`examples/default` should correctly start and be able to interact with the shell:

```
BOARD=stm32f3discovery make -C examples/default/ flash term
...
help
2019-02-26 16:46:35,228 - INFO # help
2019-02-26 16:46:35,230 - INFO # Command              Description
2019-02-26 16:46:35,233 - INFO # ---------------------------------------
2019-02-26 16:46:35,236 - INFO # reboot               Reboot the node
2019-02-26 16:46:35,240 - INFO # ps                   Prints information about running threads.
2019-02-26 16:46:35,244 - INFO # rtc                  control RTC peripheral interface
2019-02-26 16:46:35,251 - INFO # saul                 interact with sensors and actuators using SAUL
```

`tests/periph_rtc` now works:

```
BOARD=stm32f3discovery make -C tests/periph_rtc flash test
...
Type '/exit' to exit.
2019-02-26 16:47:21,682 - INFO # Alarm!
2019-02-26 16:47:23,108 - INFO # main(): This is RIOT! (Version: 2019.04-devel-287-g5e58e-pr/bug/stm32f3discovery/clock_lse)
2019-02-26 16:47:23,108 - INFO # 
2019-02-26 16:47:23,108 - INFO # RIOT RTC low-level driver test
2019-02-26 16:47:23,112 - INFO # This test will display 'Alarm!' every 2 seconds for 4 times
2019-02-26 16:47:23,116 - INFO #   Setting clock to   2011-12-13 14:15:15
2019-02-26 16:47:23,119 - INFO # Clock value is now   2011-12-13 14:15:15
2019-02-26 16:47:23,123 - INFO #   Setting alarm to   2011-12-13 14:15:17
2019-02-26 16:47:23,127 - INFO #    Alarm is set to   2011-12-13 14:15:17
2019-02-26 16:47:23,127 - INFO # 
2019-02-26 16:47:25,115 - INFO # Alarm!
2019-02-26 16:47:27,108 - INFO # Alarm!
2019-02-26 16:47:29,101 - INFO # Alarm!
2019-02-26 16:47:31,093 - INFO # Alarm!
```

### Issues/PRs references

This is the same issue as in https://github.com/RIOT-OS/RIOT/issues/11029 and was found during the 2019.01 release tests.