### PR TITLE
net/nanocoap: don't abort server on recv error

### DIFF
--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -133,8 +133,7 @@ int nanocoap_server(sock_udp_ep_t *local, uint8_t *buf, size_t bufsize)
     while (1) {
         res = sock_udp_recv(&sock, buf, bufsize, -1, &remote);
         if (res < 0) {
-            DEBUG("error receiving UDP packet\n");
-            return -1;
+            DEBUG("error receiving UDP packet %d\n", (int)res);
         }
         else if (res > 0) {
             coap_pkt_t pkt;


### PR DESCRIPTION
### Contribution description
As reported in #10972, the nanocoap_server example becomes unresponsive after receiving a payload greater than 256 bytes long. This issue is caused by the nanocoap_server() function exiting on an any error to sock_udp_recv().

This PR fixes the issue by dropping the packet and resuming listening, rather than exiting the server. After review of the function documentation of sock_udp_recv(), I don't see a situation in which exiting the server is useful in this context. However, I did add debug logging of the error value.

### Testing procedure
See #10972. Thanks @jcarrano for the well written report!

### Issues/PRs references
Fixes #10972