### PR TITLE
samd21: enable idle modes

### DIFF
--- a/cpu/samd21/include/periph_cpu.h
+++ b/cpu/samd21/include/periph_cpu.h
@@ -29,6 +29,12 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Override the default initial PM blocker
+ * @todo   Idle modes are enabled by default, deep sleep mode blocked
+ */
+#define PM_BLOCKER_INITIAL  { .val_u32 = 0x00000001 }
+
+/**
  * @brief   Mapping of pins to EXTI lines, -1 means not EXTI possible
  */
 static const int8_t exti_config[2][32] = {


### PR DESCRIPTION
Currently idle modes are disabled by default on all CPUs.

This enables all idle modes on samd21 but leaves deep sleep disabled.

On samr21-xpro this makes the current draw drop from 12mA to 8mA, UART (shell) and 802.15.4 still work as before (sending and receiving).

I would suggest to enable Idle modes except mode 0 (deep sleep) for all CPUs and fix what's broken instead of disabling pm in general, but let's start with samd21 so pm code paths are actually exercised.