### PR TITLE
[PoC] core: remove "volatile" from active_thread, active_pid.

### DIFF
--- a/core/include/sched.h
+++ b/core/include/sched.h
@@ -181,7 +181,7 @@ extern volatile thread_t *sched_threads[KERNEL_PID_LAST + 1];
 /**
  *  Currently active thread
  */
-extern volatile thread_t *sched_active_thread;
+extern thread_t *sched_active_thread;
 
 /**
  *  Number of running (non-terminated) threads
@@ -191,7 +191,7 @@ extern volatile int sched_num_threads;
 /**
  *  Process ID of active thread
  */
-extern volatile kernel_pid_t sched_active_pid;
+extern kernel_pid_t sched_active_pid;
 
 /**
  * List of runqueues per priority level

--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -413,7 +413,7 @@ int thread_wakeup(kernel_pid_t pid);
  */
 static inline kernel_pid_t thread_getpid(void)
 {
-    extern volatile kernel_pid_t sched_active_pid;
+    extern kernel_pid_t sched_active_pid;
     return sched_active_pid;
 }
 

--- a/core/sched.c
+++ b/core/sched.c
@@ -50,9 +50,9 @@ volatile int sched_num_threads = 0;
 volatile unsigned int sched_context_switch_request;
 
 volatile thread_t *sched_threads[KERNEL_PID_LAST + 1];
-volatile thread_t *sched_active_thread;
+thread_t *sched_active_thread;
 
-volatile kernel_pid_t sched_active_pid = KERNEL_PID_UNDEF;
+kernel_pid_t sched_active_pid = KERNEL_PID_UNDEF;
 
 clist_node_t sched_runqueues[SCHED_PRIO_LEVELS];
 static uint32_t runqueue_bitcache = 0;
@@ -134,7 +134,7 @@ int __attribute__((used)) sched_run(void)
 
     next_thread->status = STATUS_RUNNING;
     sched_active_pid = next_thread->pid;
-    sched_active_thread = (volatile thread_t *) next_thread;
+    sched_active_thread = next_thread;
 
 #ifdef MODULE_MPU_STACK_GUARD
     mpu_configure(


### PR DESCRIPTION
### Contribution description

__NOTE:__ _The main purpose of this PR is to test the change in the CI._

There is no reason for these two variables to be volatile:

* In application (thread) context, the "active_thread" never changes- if   thread X is reading sched_active_pid, the value is always  X whenever thread X is active.

* In kernel context, it is the kernel that changes the value, so again, it needs not be volatile.

With regards to the contents of the thread structure itself, sometimes it is important that it is re-read (for example in msg_* functions). Here, however, there are calls to extern-defined functions to yield, etc. Since the compiler cannot know if these functions alter global memory, it is forced to emit code re-read these variables, so again volatile is unncesessary (maybe if using LTO it can "smart up" and do something stupid.) If later it turns out that an explicit barrier is necessary, it can be added.

For more information on this discussion, see this thread:
* https://lists.riot-os.org/pipermail/devel/2019-January/006077.html

And for more info on barriers vs volatile, see:
* https://www.kernel.org/doc/html/v4.17/process/volatile-considered-harmful.html
* https://gcc.gnu.org/onlinedocs/gcc/Volatiles.html
* https://yarchive.net/comp/linux/memory_barriers.html


### Testing procedure

Run __ALL__ the tests.

### Related Issues

#252, #10177, also see the thread in the devel mailing list.