### PR TITLE
usbus: Initial simple auto init structure

### DIFF
--- a/examples/usbus_minimal/Makefile
+++ b/examples/usbus_minimal/Makefile
@@ -13,6 +13,7 @@ RIOTBASE ?= $(CURDIR)/../..
 DEVELHELP ?= 1
 
 USEMODULE += usbus
+USEMODULE += auto_init_usbus
 
 # USB device vendor and product ID
 USB_VID ?= 1209

--- a/examples/usbus_minimal/main.c
+++ b/examples/usbus_minimal/main.c
@@ -19,26 +19,11 @@
  */
 
 #include <stdio.h>
-#include "usb/usbus.h"
-
-static char _stack[USBUS_STACKSIZE];
-
-static usbus_t usbus;
-/* TODO: remove as soon as we have decent auto_init */
-#include "periph_conf.h"
-#include "sam_usb.h"
 
 int main(void)
 {
     puts("RIOT USB stack example application");
 
-    /* TODO: remove as soon as we have decent auto_init */
-    usbdev_t *usbdev_ctx = usbdev_get_ctx(0);
-    /* start usb stack */
-    usbus_init(&usbus, usbdev_ctx);
-    usbus_create(_stack, sizeof(_stack), USBUS_PRIO, USBUS_TNAME, &usbus);
-
-    /* start shell */
     puts("Started USB stack!");
     return 0;
 }

--- a/sys/auto_init/Makefile
+++ b/sys/auto_init/Makefile
@@ -18,4 +18,8 @@ ifneq (,$(filter auto_init_loramac,$(USEMODULE)))
   DIRS += loramac
 endif
 
+ifneq (,$(filter auto_init_usbus,$(USEMODULE)))
+  DIRS += usb
+endif
+
 include $(RIOTBASE)/Makefile.base

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -182,6 +182,12 @@ void auto_init(void)
     auto_init_loramac();
 #endif
 
+/* initialize USB devices */
+#ifdef MODULE_AUTO_INIT_USBUS
+    extern void auto_init_usb(void);
+    auto_init_usb();
+#endif
+
 /* initialize network devices */
 #ifdef MODULE_AUTO_INIT_GNRC_NETIF
 

--- a/sys/auto_init/usb/Makefile
+++ b/sys/auto_init/usb/Makefile
@@ -1,0 +1,3 @@
+MODULE = auto_init_usbus
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/auto_init/usb/auto_init_usb.c
+++ b/sys/auto_init/usb/auto_init_usb.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2018 Koen Zandberg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+/**
+ * @ingroup     sys_auto_init
+ * @{
+ * @file
+ * @brief       initializes USBUS, usb devices and handlers
+ *
+ * This auto initialization for USBUS is designed to cover the common use case
+ * of a single usb peripheral. An USBUS instance is started with USB function
+ * handlers based on which module is compiled in.
+ *
+ * If this doesn't suit your use case, a different intialization function can
+ * to be created based on this initialization sequence.
+ *
+ * @author  Koen Zandberg <koen@bergzand.net>
+ * @}
+ */
+
+#include "usb/usbus.h"
+
+static char _stack[USBUS_STACKSIZE];
+static usbus_t usbus;
+
+void auto_init_usb(void)
+{
+    /* Get driver context */
+    usbdev_t *usbdev = usbdev_get_ctx(0);
+    assert(usbdev);
+
+    /* Initialize basic usbus struct, don't start the thread yet */
+    usbus_init(&usbus, usbdev);
+
+
+    /* Finally initialize USBUS thread */
+    usbus_create(_stack, USBUS_STACKSIZE, USBUS_PRIO, USBUS_TNAME, &usbus);
+}


### PR DESCRIPTION
### Contribution description

This code provides a simple auto_init structure for USB peripherals and USBUS provided functions. The auto_init as contributed is designed as a simple solution for the common case. It is intentionally not designed to solve all use cases.

### Testing procedure

The example should now provide a USB device without any usb specific handling in the `main.c` code.

### Issues/PRs references

Depends on #10916 

![image](https://bergzand.net/misc/usbus.dot.svg)