### PR TITLE
tools/compile_and_test_for_board: FIX outdated help docstring

### DIFF
--- a/dist/tools/compile_and_test_for_board/compile_and_test_for_board.py
+++ b/dist/tools/compile_and_test_for_board/compile_and_test_for_board.py
@@ -33,36 +33,46 @@ Usage
 
 ```
 usage: compile_and_test_for_board.py [-h] [--applications APPLICATIONS]
-                                     [--applications-exclude
-                                      APPLICATIONS_EXCLUDE]
+                                     [--applications-exclude APPLICATIONS_EXCLUDE]
                                      [--no-test]
-                                     [--loglevel {debug,info,warning,error,
-                                                  fatal,critical}]
+                                     [--loglevel {debug,info,warning,error,fatal,critical}]
                                      [--incremental] [--clean-after]
+                                     [--compile-targets COMPILE_TARGETS]
+                                     [--test-targets TEST_TARGETS]
                                      [--jobs JOBS]
                                      riot_directory board [result_directory]
 
 positional arguments:
   riot_directory        RIOT directory to test
   board                 Board to test
-  result_directory      Result directory, by default "results"
+  result_directory      Result directory, by default "results" (default:
+                        results)
 
 optional arguments:
   -h, --help            show this help message and exit
   --applications APPLICATIONS
                         List of applications to test, overwrites default
-                        configuration of testing all applications
+                        configuration of testing all applications (default:
+                        None)
   --applications-exclude APPLICATIONS_EXCLUDE
                         List of applications to exclude from tested
                         applications. Also applied after "--applications".
-  --no-test             Disable executing tests
+                        (default: None)
+  --no-test             Disable executing tests (default: False)
   --loglevel {debug,info,warning,error,fatal,critical}
-                        Python logger log level, defauts to "info"
+                        Python logger log level, defauts to "info" (default:
+                        info)
   --incremental         Do not rerun successful compilation and tests
-  --clean-after         Clean after running each test
+                        (default: False)
+  --clean-after         Clean after running each test (default: False)
+  --compile-targets COMPILE_TARGETS
+                        List of make targets to compile (default: clean all)
+  --test-targets TEST_TARGETS
+                        List of make targets to run test (default: test)
   --jobs JOBS, -j JOBS  Parallel building (0 means not limit, like '--jobs')
+                        (default: None)
 ```
-"""
+"""  # noqa
 
 import os
 import sys

--- a/dist/tools/compile_and_test_for_board/compile_and_test_for_board.py
+++ b/dist/tools/compile_and_test_for_board/compile_and_test_for_board.py
@@ -45,8 +45,7 @@ usage: compile_and_test_for_board.py [-h] [--applications APPLICATIONS]
 positional arguments:
   riot_directory        RIOT directory to test
   board                 Board to test
-  result_directory      Result directory, by default "results" (default:
-                        results)
+  result_directory      Result directory (default: results)
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -60,8 +59,7 @@ optional arguments:
                         (default: None)
   --no-test             Disable executing tests (default: False)
   --loglevel {debug,info,warning,error,fatal,critical}
-                        Python logger log level, defauts to "info" (default:
-                        info)
+                        Python logger log level (default: info)
   --incremental         Do not rerun successful compilation and tests
                         (default: False)
   --clean-after         Clean after running each test (default: False)
@@ -549,7 +547,7 @@ PARSER = argparse.ArgumentParser(
 PARSER.add_argument('riot_directory', help='RIOT directory to test')
 PARSER.add_argument('board', help='Board to test', type=_strip_board_equal)
 PARSER.add_argument('result_directory', nargs='?', default='results',
-                    help='Result directory, by default "results"')
+                    help='Result directory')
 PARSER.add_argument(
     '--applications', type=list_from_string,
     help=('List of applications to test, overwrites default configuration of'
@@ -563,7 +561,7 @@ PARSER.add_argument(
 PARSER.add_argument('--no-test', action='store_true', default=False,
                     help='Disable executing tests')
 PARSER.add_argument('--loglevel', choices=LOG_LEVELS, default='info',
-                    help='Python logger log level, defauts to "info"')
+                    help='Python logger log level')
 PARSER.add_argument('--incremental', action='store_true', default=False,
                     help='Do not rerun successful compilation and tests')
 PARSER.add_argument('--clean-after', action='store_true', default=False,

--- a/dist/tools/compile_and_test_for_board/tests/test_compile_and_test_for_board.py
+++ b/dist/tools/compile_and_test_for_board/tests/test_compile_and_test_for_board.py
@@ -1,0 +1,18 @@
+"""Test compile_and_test_for_board script."""
+
+import subprocess
+
+import compile_and_test_for_board
+
+
+def test_help_message():
+    """Verify that the help message is in the script documentation."""
+    script = 'compile_and_test_for_board.py'
+
+    # Read the help message from executing the script
+    help_bytes = subprocess.check_output(['./%s' % script, '--help'])
+    help_msg = help_bytes.decode('utf-8')
+
+    docstring = compile_and_test_for_board.__doc__
+
+    assert help_msg in docstring, "Help message not in the documentation"

--- a/dist/tools/compile_and_test_for_board/tox.ini
+++ b/dist/tools/compile_and_test_for_board/tox.ini
@@ -14,14 +14,14 @@ commands =
 [testenv:test]
 deps = pytest
 commands =
-    pytest -v --doctest-modules {env:script}
+    pytest -v --doctest-modules
 
 [testenv:lint]
 deps = pylint
 commands =
-    pylint {env:script}
+    pylint {env:script} tests
 
 [testenv:flake8]
 deps = flake8
 commands =
-    flake8 {env:script}
+    flake8 {env:script} tests


### PR DESCRIPTION
### Contribution description

Update the help message in the docstring.
It should reflect the content of `--help`.

I replaced the manual line wrapping by disabling the warning on the
docstring.

This pull requests also add a `tests` directory and a test to verify it is up to date.

### Testing procedure

```
cd dist/tools/compile_and_test_for_board
tox
```

The test suite should work, and the `Usage` string in the docstring should reflect the output of `./compile_and_test_for_board.py --help`.

Modifying the usage string should show an error.

### Issues/PRs references

I found the issue while reviewing and working on https://github.com/RIOT-OS/RIOT/pull/10838
