### PR TITLE
boards: add pyboard v1.1 support

### DIFF
--- a/boards/pyboard/Makefile
+++ b/boards/pyboard/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/pyboard/Makefile.dep
+++ b/boards/pyboard/Makefile.dep
@@ -1,0 +1,3 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif

--- a/boards/pyboard/Makefile.features
+++ b/boards/pyboard/Makefile.features
@@ -1,0 +1,11 @@
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# The board MPU family (used for grouping by the CI system)
+FEATURES_MCU_GROUP = cortex_m4_2
+
+include $(RIOTCPU)/stm32f4/Makefile.features

--- a/boards/pyboard/Makefile.include
+++ b/boards/pyboard/Makefile.include
@@ -1,0 +1,14 @@
+# the cpu to build for
+export CPU = stm32f4
+export CPU_MODEL = stm32f405rg
+
+# define the default port depending on the host OS
+PORT_LINUX ?= /dev/ttyUSB0
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+
+# setup serial terminal
+include $(RIOTMAKE)/tools/serial.inc.mk
+
+# this board is flashed using DFU
+DFU_ARGS += --alt 0 -s 0x8000000
+include $(RIOTMAKE)/tools/dfu.inc.mk

--- a/boards/pyboard/board.c
+++ b/boards/pyboard/board.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2019 Inria
+ *               2019 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_pyboard
+ * @{
+ *
+ * @file
+ * @brief       Board specific implementations for the pyboard
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * @}
+ */
+
+#include "board.h"
+#include "periph/gpio.h"
+
+void board_init(void)
+{
+    /* initialize the CPU */
+    cpu_init();
+
+    /* initialize LED */
+    gpio_init(LED0_PIN, GPIO_OUT);
+}

--- a/boards/pyboard/doc.txt
+++ b/boards/pyboard/doc.txt
@@ -1,0 +1,32 @@
+/**
+@defgroup    boards_pyboard pyboard
+@ingroup     boards
+@brief       Support for the pyboard
+
+# Overview
+
+This port adds basic support for the MicroPython pyboard.
+
+Currently the support is pretty minimal, and you might miss many features that
+the original firmware offers. E.g., the board won't show up via USB as either
+serial or mass storage device.
+
+In order to get serial output, connect an USB/serial adapter to USART1 RX/TX
+(Pins X9 / X10).
+
+# How to flash
+
+## put board into DFU mode:
+
+- connect board via USB
+- connect 3.3v to DFU pin (See [official docs](https://github.com/micropython/micropython/wiki/Pyboard-Firmware-Update))
+- press reset button
+
+## Flash as usual:
+
+    $ BOARD=pyboard make flash
+
+- unconnect 3.3v/DFU pin
+- reset again
+
+ */

--- a/boards/pyboard/include/board.h
+++ b/boards/pyboard/include/board.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2019 Inria
+ *               2019 Freie Universität Berlin
+ *               2019 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_pyboard
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the pyboard board
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include <stdint.h>
+
+#include "cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    LED pin definitions and handlers
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(PORT_B, 4)
+#define LED0_MASK           (1 << 4)
+
+#define LED0_ON             (GPIOB->BSRR = LED0_MASK)
+#define LED0_OFF            (GPIOB->BSRR = (LED0_MASK << 16))
+#define LED0_TOGGLE         (GPIOB->ODR  ^= LED0_MASK)
+/** @} */
+
+/**
+ * @brief   User button
+ */
+#define BTN_B1_PIN          GPIO_PIN(PORT_B, 3)
+
+/**
+ * @brief   Initialize board specific hardware, including clock, LEDs and stdio
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/pyboard/include/gpio_params.h
+++ b/boards/pyboard/include/gpio_params.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2019 Inria
+ *               2019 Freie Universität Berlin
+ *               2019 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   boards_pyboard
+ * @{
+ *
+ * @file
+ * @brief     Board specific configuration of direct mapped GPIOs
+ *
+ * @author    Kaspar Schleiser <kaspar@schleiser.de>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    GPIO pin configuration
+ */
+static const saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "LD1",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT
+    },
+    {
+        .name = "Button(B1 User)",
+        .pin = BTN_B1_PIN,
+        .mode = GPIO_IN_PU,
+        .flags = SAUL_GPIO_INVERTED
+    }
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/pyboard/include/periph_conf.h
+++ b/boards/pyboard/include/periph_conf.h
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) 2019 Inria
+ *               2019 Freie Universität Berln
+ *               2019 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_pyboard
+ * @{
+ *
+ * @file
+ * @brief       Peripheral MCU configuration for the pyboard board
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Clock settings
+ *
+ * @note    This is auto-generated from
+ *          `cpu/stm32_common/dist/clk_conf/clk_conf.c`
+ * @{
+ */
+/* give the target core clock (HCLK) frequency [in Hz],
+ * maximum: 168MHz */
+#define CLOCK_CORECLOCK     (168000000U)
+/* 0: no external high speed crystal available
+ * else: actual crystal frequency [in Hz] */
+#define CLOCK_HSE           (12000000U)
+/* 0: no external low speed crystal available,
+ * 1: external crystal available (always 32.768kHz) */
+#define CLOCK_LSE           (1U)
+/* peripheral clock setup */
+#define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1
+#define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
+#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV4     /* max 42MHz */
+#define CLOCK_APB1          (CLOCK_CORECLOCK / 4)
+#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV2     /* max 84MHz */
+#define CLOCK_APB2          (CLOCK_CORECLOCK / 2)
+
+/* Main PLL factors */
+#define CLOCK_PLL_M          (6)
+#define CLOCK_PLL_N          (168)
+#define CLOCK_PLL_P          (2)
+#define CLOCK_PLL_Q          (7)
+/** @} */
+
+/**
+ * @name    Timer configuration
+ * @{
+ */
+static const timer_conf_t timer_config[] = {
+    {
+        .dev      = TIM5,
+        .max      = 0xffffffff,
+        .rcc_mask = RCC_APB1ENR_TIM5EN,
+        .bus      = APB1,
+        .irqn     = TIM5_IRQn
+    }
+};
+
+#define TIMER_0_ISR         isr_tim5
+
+#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+/** @} */
+
+/**
+ * @name    UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev        = USART1,
+        .rcc_mask   = RCC_APB2ENR_USART1EN,
+        .rx_pin     = GPIO_PIN(PORT_B, 7),
+        .tx_pin     = GPIO_PIN(PORT_B, 6),
+        .rx_af      = GPIO_AF7,
+        .tx_af      = GPIO_AF7,
+        .bus        = APB2,
+        .irqn       = USART1_IRQn,
+#ifdef MODULE_PERIPH_DMA
+        .dma        = 2,
+        .dma_chan   = 2
+#endif
+    },
+};
+
+#define UART_0_ISR          (isr_usart1)
+
+#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+/** @} */
+
+/**
+ * @name    SPI configuration
+ *
+ * @note    The spi_divtable is auto-generated from
+ *          `cpu/stm32_common/dist/spi_divtable/spi_divtable.c`
+ * @{
+ */
+static const uint8_t spi_divtable[2][5] = {
+    {       /* for APB1 @ 42000000Hz */
+        7,  /* -> 164062Hz */
+        6,  /* -> 328125Hz */
+        4,  /* -> 1312500Hz */
+        2,  /* -> 5250000Hz */
+        1   /* -> 10500000Hz */
+    },
+    {       /* for APB2 @ 84000000Hz */
+        7,  /* -> 328125Hz */
+        7,  /* -> 328125Hz */
+        5,  /* -> 1312500Hz */
+        3,  /* -> 5250000Hz */
+        2   /* -> 10500000Hz */
+    }
+};
+
+static const spi_conf_t spi_config[] = {
+    {
+        .dev      = SPI1,
+        .mosi_pin = GPIO_PIN(PORT_A, 7),
+        .miso_pin = GPIO_PIN(PORT_A, 6),
+        .sclk_pin = GPIO_PIN(PORT_A, 5),
+        .cs_pin   = GPIO_UNDEF,
+        .af       = GPIO_AF5,
+        .rccmask  = RCC_APB2ENR_SPI1EN,
+        .apbbus   = APB2,
+#ifdef MODULE_PERIPH_DMA
+        .tx_dma   = 1,
+        .tx_dma_chan = 1,
+        .rx_dma   = 0,
+        .rx_dma_chan = 1,
+#endif
+    }
+};
+
+#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+/** @} */
+
+/**
+ * @name I2C configuration
+ * @{
+ */
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev            = I2C2,
+        .speed          = I2C_SPEED_NORMAL,
+        .scl_pin        = GPIO_PIN(PORT_B, 10),
+        .sda_pin        = GPIO_PIN(PORT_B, 11),
+        .scl_af         = GPIO_AF4,
+        .sda_af         = GPIO_AF4,
+        .bus            = APB1,
+        .rcc_mask       = RCC_APB1ENR_I2C2EN,
+        .clk            = CLOCK_APB1,
+        .irqn           = I2C2_ER_IRQn,
+    },
+};
+
+#define I2C_0_ISR           isr_i2c2_er
+
+#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+/** @} */
+
+/**
+ * @name   RTC configuration
+ * @{
+ */
+#define RTC_NUMOF           (1)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/makefiles/tools/dfu.inc.mk
+++ b/makefiles/tools/dfu.inc.mk
@@ -1,0 +1,8 @@
+DFU ?= dfu-util
+FLASHER ?= $(DFU)
+HEXFILE = $(BINFILE)
+
+FFLAGS ?= -D $(HEXFILE) --reset $(DFU_ARGS)
+
+RESET ?= $(DFU)
+RESET_FLAGS ?= $(DFU_ARGS) -t $(DFU_DEVICE_TYPE)


### PR DESCRIPTION
From the docs:

# Overview    
    
This port adds basic support for the MicroPython pyboard.    
    
Currently the support is pretty minimal, and you might miss many features that    
the original firmware offers. E.g., the board won't show up via USB as either    
serial or mass storage device.    
    
In order to get serial output, connect an USB/serial adapter to USART1 RX/TX    
(Pins X9 / X10).    
    
# How to flash    
    
## put board into DFU mode:    
    
- connect board via USB    
- connect 3.3v to DFU pin (See [official docs](https://github.com/micropython/micropython/wiki/Pyboard-Firmware-Update))    
- press reset button    
    
## Flash as usual:    
    $ BOARD=pyboard make flash"    
    
- unconnect 3.3v/DFU pin    
- reset again    


### Testing procedure

Run the usual tests on a pyboard.

### Issues/PRs references

None.