### PR TITLE
drivers/mtd_spi_nor: fix read spanning pages

### DIFF
--- a/drivers/mtd_spi_nor/mtd_spi_nor.c
+++ b/drivers/mtd_spi_nor/mtd_spi_nor.c
@@ -420,16 +420,8 @@ static int mtd_spi_nor_read(mtd_dev_t *mtd, void *dest, uint32_t addr, uint32_t 
     if (addr > chipsize) {
         return -EOVERFLOW;
     }
-    if (size > mtd->page_size) {
-        size = mtd->page_size;
-    }
     if ((addr + size) > chipsize) {
         size = chipsize - addr;
-    }
-    uint32_t page_addr_mask = dev->page_addr_mask;
-    if ((addr & page_addr_mask) != ((addr + size - 1) & page_addr_mask)) {
-        /* Reads across page boundaries must be split */
-        size = mtd->page_size - (addr & ~(page_addr_mask));
     }
     if (size == 0) {
         return 0;


### PR DESCRIPTION


### Contribution description

mtd_read() has no limitations regarding page boundaries.
mtd_spi_nor_read() was limiting size to the page_size which was wrong.
This removes the wrong check and adds a unittest.


### Testing procedure

Run tests-mtd unittest

