### PR TITLE
 tests/mcuboot: handle building in docker 

### DIFF
--- a/tests/mcuboot/Makefile
+++ b/tests/mcuboot/Makefile
@@ -7,6 +7,9 @@ BOARD_WHITELIST := nrf52dk
 export IMAGE_VERSION = 1.1.1+1
 
 # this test is supposed to always build the mcuboot image
+ifneq ($(BUILD_IN_DOCKER),1)
+# HACK: When building with docker, mcuboot target must be done only in docker
 all: mcuboot
+endif
 
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
### Contribution description

When using BUILD_IN_DOCKER only make 'all' execute `mcuboot`/`riotboot` target when
inside the container. Otherwise it will execute it using your hosttoolchain.

This is a hack as it cannot currently be handled at the `mcuboot`/`riotboot` target level.

### Hack and not a fix

I know it is a hack and not a library level fix.
Fixing it at `docker` level is currently harder with the way the integration is done, I tried but requires more changes that I hoped. I prefer put this HACK to make it usable until a proper fix can go in.

### Testing procedure

If your `arm-none-eabi-gcc` compiler is outside of `/usr/bin` and you can define a working PATH not including `arm-none-eabi-gcc` you can try the following. (or have a machine without `arm-gcc`):


Compiling either `tests/mcuboot` or `tests/riotboot` with docker would fail as it would be trying to use your local toolchain.

#### Fixed now

Even flashing is now handled with this pull request:

Flashing and test works with `samr-21` for `riotboot` and I can flash for `tests/mcuboot` with the `nrf52dk`. Note the `mcuboot` firmware is broken for me both on master and with this PR.

<details><summary> `DOCKER="sudo docker" BUILD_IN_DOCKER=1 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin make -C tests/riotboot flash test` </summary>
<p>

```
DOCKER="sudo docker" BUILD_IN_DOCKER=1 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin make -C tests/riotboot flash test
make: Entering directory '/home/harter/work/git/RIOT/tests/riotboot'
Launching build container using image "riot/riotbuild:latest".
sudo docker run --rm -t -u "$(id -u)" \
    -v '/home/harter/work/git/RIOT:/data/riotbuild/riotbase' \
    -v '/home/harter/work/git/RIOT/build:/data/riotbuild/build' \
    -v '/home/harter/work/git/RIOT/cpu:/data/riotbuild/riotcpu' \
    -v '/home/harter/work/git/RIOT/boards:/data/riotbuild/riotboard' \
    -v '/home/harter/work/git/RIOT/makefiles:/data/riotbuild/riotmake' \
    -v '/home/harter/work/git/RIOT:/data/riotbuild/riotproject' \
    -v '/usr/share/zoneinfo/Europe/Berlin:/etc/localtime:ro' \
    -e 'RIOTBASE=/data/riotbuild/riotbase' \
    -e 'BUILD_DIR=/data/riotbuild/build' \
    -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' \
    -e 'RIOTCPU=/data/riotbuild/riotcpu' \
    -e 'RIOTBOARD=/data/riotbuild/riotboard' \
    -e 'RIOTMAKE=/data/riotbuild/riotmake' \
    -e 'RIOTPROJECT=/data/riotbuild/riotproject' \
    -v /home/harter/.gitcache:/data/riotbuild/gitcache -e GIT_CACHE_DIR=/data/riotbuild/gitcache  \
     \
    -w '/data/riotbuild/riotproject/tests/riotboot/' \
    'riot/riotbuild:latest' make  
compiling /data/riotbuild/riotbase/dist/tools/riotboot_gen_hdr/bin/genhdr...
make: Nothing to be done for 'all'.
Building application "tests_riotboot" for "samr21-xpro" with MCU "samd21".

"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/checksum
"make" -C /data/riotbuild/riotbase/sys/isrpipe
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/pm_layered
"make" -C /data/riotbuild/riotbase/sys/riotboot
"make" -C /data/riotbuild/riotbase/sys/shell
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
"make" -C /data/riotbuild/riotbase/sys/tsrb
"make" -C /data/riotbuild/riotboard/samr21-xpro
"make" -C /data/riotbuild/riotcpu/samd21
"make" -C /data/riotbuild/riotcpu/cortexm_common
"make" -C /data/riotbuild/riotcpu/cortexm_common/periph
"make" -C /data/riotbuild/riotcpu/sam0_common
"make" -C /data/riotbuild/riotcpu/sam0_common/periph
"make" -C /data/riotbuild/riotcpu/samd21/periph
   text    data     bss     dec     hex filename
  11532     504    2612   14648    3938 /data/riotbuild/riotproject/tests/riotboot/bin/samr21-xpro/tests_riotboot.elf
creating /data/riotbuild/riotproject/tests/riotboot/bin/samr21-xpro/tests_riotboot-slot0.riot.bin...
creating /data/riotbuild/riotproject/tests/riotboot/bin/samr21-xpro/tests_riotboot-slot1.riot.bin...
"make" -C /data/riotbuild/riotbase/boards/samr21-xpro
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/samd21
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/sam0_common
"make" -C /data/riotbuild/riotbase/cpu/sam0_common/periph
"make" -C /data/riotbuild/riotbase/cpu/samd21/periph
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/checksum
"make" -C /data/riotbuild/riotbase/sys/isrpipe
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/pm_layered
"make" -C /data/riotbuild/riotbase/sys/riotboot
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
"make" -C /data/riotbuild/riotbase/sys/tsrb
/home/harter/work/git/RIOT/dist/tools/edbg/edbg  -t atmel_cm0p -b -v -p -f /home/harter/work/git/RIOT/tests/riotboot/bin/samr21-xpro/tests_riotboot-slot0-combined.bin
Debugger: ATMEL EDBG CMSIS-DAP ATML2127031800001911 01.1A.00FB (S)
Clock frequency: 16.0 MHz
Target: SAM R21G18 (Rev B)
Programming.................................................................... done.
Verification.................................................................... done.
curslotnr
/home/harter/work/git/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200"
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2019-02-28 17:42:07,068 - INFO # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
2019-02-28 17:42:10,136 - INFO # main(): This is RIOT! (Version: 2019.04-devel-310-gd22a2-pr/docker/hack/bootloader)
2019-02-28 17:42:10,156 - INFO # Hellomain(): This is RIOT! (Version: 2019.04-devel-310-gd22a2-pr/docker/hack/bootloader)
2019-02-28 17:42:10,158 - INFO # Hello riotboot!
2019-02-28 17:42:10,162 - INFO # You are running RIOT on a(n) samr21-xpro board.
2019-02-28 17:42:10,165 - INFO # This board features a(n) samd21 MCU.
2019-02-28 17:42:10,168 - INFO # riotboot_test: running from slot 0
2019-02-28 17:42:10,171 - INFO # Image magic_number: 0x544f4952
2019-02-28 17:42:10,173 - INFO # Image Version: 0x00000000
2019-02-28 17:42:10,176 - INFO # Image start address: 0x00001100
2019-02-28 17:42:10,178 - INFO # Header chksum: 0x7f7aaea1
2019-02-28 17:42:10,179 - INFO # 
> curslotnr
2019-02-28 17:42:10,199 - INFO #  curslotnr
2019-02-28 17:42:10,200 - INFO # Current slot=0
> curslothdr
curslothdr
2019-02-28 17:42:10,253 - INFO #  curslothdr
2019-02-28 17:42:10,256 - INFO # Image magic_number: 0x544f4952
2019-02-28 17:42:10,258 - INFO # Image Version: 0x00000000
2019-02-28 17:42:10,261 - INFO # Image start address: 0x00001100
2019-02-28 17:42:10,263 - INFO # Header chksum: 0x7f7aaea1
2019-02-28 17:42:10,264 - INFO # 
> getslotaddr 0
getslotaddr 0
2019-02-28 17:42:10,317 - INFO #  getslotaddr 0
2019-02-28 17:42:10,319 - INFO # Slot 0 address=0x00001100
> dumpaddrs
dumpaddrs
2019-02-28 17:42:10,372 - INFO #  dumpaddrs
2019-02-28 17:42:10,376 - INFO # slot 0: metadata: 0x1000 image: 0x00001100
2019-02-28 17:42:10,380 - INFO # slot 1: metadata: 0x20800 image: 0x22000030
> 
make: Leaving directory '/home/harter/work/git/RIOT/tests/riotboot'
```

</p>
</details>


<details><summary> `DOCKER="sudo docker" BUILD_IN_DOCKER=1 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin make -C tests/mcuboot/ flash`</summary>
<p>

```
DOCKER="sudo docker" BUILD_IN_DOCKER=1 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin make -C tests/mcuboot/ flash                                                                                                                                
make: Entering directory '/home/harter/work/git/RIOT/tests/mcuboot'                                                                                                                                                                                                                       
Launching build container using image "riot/riotbuild:latest".                                                                                                                                                                                                                            
sudo docker run --rm -t -u "$(id -u)" \                                                                                                                                                                                                                                                   
    -v '/home/harter/work/git/RIOT:/data/riotbuild/riotbase' \                                                                                                                                                                                                                            
    -v '/home/harter/work/git/RIOT/build:/data/riotbuild/build' \                                                                                                                                                                                                                         
    -v '/home/harter/work/git/RIOT/cpu:/data/riotbuild/riotcpu' \                                                                                                                                                                                                                         
    -v '/home/harter/work/git/RIOT/boards:/data/riotbuild/riotboard' \                                                                                                                                                                                                                    
    -v '/home/harter/work/git/RIOT/makefiles:/data/riotbuild/riotmake' \                                                                                                                                                                                                                  
    -v '/home/harter/work/git/RIOT:/data/riotbuild/riotproject' \                                                                                                                                                                                                                         
    -v '/usr/share/zoneinfo/Europe/Berlin:/etc/localtime:ro' \                                                                                                                                                                                                                            
    -e 'RIOTBASE=/data/riotbuild/riotbase' \                                                                                                                                                                                                                                              
    -e 'BUILD_DIR=/data/riotbuild/build' \                                                                                                                                                                                                                                                
    -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' \                                                                                                                                                                                                                                        
    -e 'RIOTCPU=/data/riotbuild/riotcpu' \                                                                                                                                                                                                                                                
    -e 'RIOTBOARD=/data/riotbuild/riotboard' \                                                                                                                                                                                                                                            
    -e 'RIOTMAKE=/data/riotbuild/riotmake' \                                                                                                                                                                                                                                              
    -e 'RIOTPROJECT=/data/riotbuild/riotproject' \                                                                                                                                                                                                                                        
    -v /home/harter/.gitcache:/data/riotbuild/gitcache -e GIT_CACHE_DIR=/data/riotbuild/gitcache  \                                                                                                                                                                                       
     \                                                                                                                                                                                                                                                                                    
    -w '/data/riotbuild/riotproject/tests/mcuboot/' \                                                                                                                                                                                                                                     
    'riot/riotbuild:latest' make                                                                                                                                                                                                                                                          
Building application "tests_mcuboot" for "nrf52dk" with MCU "nrf52".                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                          
"make" -C /data/riotbuild/riotbase/core                                                                                                                                                                                                                                                   
"make" -C /data/riotbuild/riotbase/drivers                                                                                                                                                                                                                                                
"make" -C /data/riotbuild/riotbase/drivers/periph_common                                                                                                                                                                                                                                  
"make" -C /data/riotbuild/riotbase/sys                                                                                                                                                                                                                                                    
"make" -C /data/riotbuild/riotbase/sys/auto_init                                                                                                                                                                                                                                          
"make" -C /data/riotbuild/riotbase/sys/isrpipe                                                                                                                                                                                                                                            
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default                                                                                                                                                                                                                            
"make" -C /data/riotbuild/riotbase/sys/stdio_uart                                                                                                                                                                                                                                         
"make" -C /data/riotbuild/riotbase/sys/tsrb                                                                                                                                                                                                                                               
"make" -C /data/riotbuild/riotboard/nrf52dk                                                                                                                                                                                                                                               
"make" -C /data/riotbuild/riotboard/common/nrf52xxxdk                                                                                                                                                                                                                                     
"make" -C /data/riotbuild/riotcpu/nrf52                                                                                                                                                                                                                                                   
"make" -C /data/riotbuild/riotcpu/cortexm_common                                                                                                                                                                                                                                          
"make" -C /data/riotbuild/riotcpu/cortexm_common/periph                                                                                                                                                                                                                                   
"make" -C /data/riotbuild/riotcpu/nrf52/periph                                                                                                                                                                                                                                            
"make" -C /data/riotbuild/riotcpu/nrf5x_common                                                                                                                                                                                                                                            
"make" -C /data/riotbuild/riotcpu/nrf5x_common/periph
   text    data     bss     dec     hex filename
   8148     136    2604   10888    2a88 /data/riotbuild/riotproject/tests/mcuboot/bin/nrf52dk/tests_mcuboot.elf

Re-linking for MCUBoot at 0x8000...


Signed with /data/riotbuild/riotproject/tests/mcuboot/bin/nrf52dk/key.pem for version 1.1.1+1\


/home/harter/work/git/RIOT/dist/tools/jlink/jlink.sh flash /home/harter/work/git/RIOT/tests/mcuboot/bin/nrf52dk/tests_mcuboot.bin
### Flashing Target ###
### Flashing at address 0x0 ###
SEGGER J-Link Commander V6.42d (Compiled Feb 15 2019 13:56:53)
DLL version V6.42d, compiled Feb 15 2019 13:56:43


J-Link Command File read successfully.
Processing script file...

J-Link connection not established yet but required for command.
Connecting to J-Link via USB...O.K.
Firmware: J-Link OB-SAM3U128-V2-NordicSemi compiled Jan  7 2019 14:07:15
Hardware version: V1.00
S/N: 682497679
VTref=3.300V
Target connection not established yet but required for command.
Device "NRF52" selected.


Connecting to target via SWD
Found SW-DP with ID 0x2BA01477
Found SW-DP with ID 0x2BA01477
Scanning AP map to find all available APs
AP[2]: Stopped AP scan as end of AP map has been reached
AP[0]: AHB-AP (IDR: 0x24770011)
AP[1]: JTAG-AP (IDR: 0x02880000)
Iterating through AP map to find AHB-AP to use
AP[0]: Core found
AP[0]: AHB-AP ROM base: 0xE00FF000
CPUID register: 0x410FC241. Implementer code: 0x41 (ARM)
Found Cortex-M4 r0p1, Little endian.
FPUnit: 6 code (BP) slots and 2 literal slots
CoreSight components:
ROMTbl[0] @ E00FF000
ROMTbl[0][0]: E000E000, CID: B105E00D, PID: 000BB00C SCS-M7
ROMTbl[0][1]: E0001000, CID: B105E00D, PID: 003BB002 DWT
ROMTbl[0][2]: E0002000, CID: B105E00D, PID: 002BB003 FPB
ROMTbl[0][3]: E0000000, CID: B105E00D, PID: 003BB001 ITM
ROMTbl[0][4]: E0040000, CID: B105900D, PID: 000BB9A1 TPIU
ROMTbl[0][5]: E0041000, CID: B105900D, PID: 000BB925 ETM
Cortex-M4 identified.

**************************
WARNING: T-bit of XPSR is 0 but should be 1. Changed to 1.
**************************

Downloading file [/home/harter/work/git/RIOT/tests/mcuboot/bin/nrf52dk/tests_mcuboot.bin]...
Comparing flash   [100%] Done.
Verifying flash   [100%] Done.
J-Link: Flash download: Bank 0 @ 0x00000000: Skipped. Contents already match
O.K.

Reset delay: 0 ms
Reset type NORMAL: Resets core & peripherals via SYSRESETREQ & VECTRESET bit.
Reset: Halt core after reset via DEMCR.VC_CORERESET.
Reset: Reset device via AIRCR.SYSRESETREQ.



Script processing completed.

make: Leaving directory '/home/harter/work/git/RIOT/tests/mcuboot'
```

</p>
</details>


#### Verify it is failing in master

<details><summary> `DOCKER="sudo docker" BUILD_IN_DOCKER=1 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin make -C tests/mcuboot/`</summary>
<p>

```
DOCKER="sudo docker" BUILD_IN_DOCKER=1 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin make -C tests/mcuboot/
make: Entering directory '/home/harter/work/git/RIOT/tests/mcuboot'
...
# Building in docker

Re-linking for MCUBoot at 0x8000...

/bin/sh: 1: arm-none-eabi-gcc: not found
/home/harter/work/git/RIOT/makefiles/mcuboot.mk:26: recipe for target 'mcuboot' failed
make: *** [mcuboot] Error 127
make: Leaving directory '/home/harter/work/git/RIOT/tests/mcuboot'
```
</p>
</details>



<details><summary> `DOCKER="sudo docker" BUILD_IN_DOCKER=1 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin make -C tests/riotboot/`</summary>
<p>

```
make: Entering directory '/home/harter/work/git/RIOT/tests/riotboot'
compiling /home/harter/work/git/RIOT/dist/tools/riotboot_gen_hdr/bin/genhdr...
make: Nothing to be done for 'all'.
make: *** No rule to make target '/home/harter/work/git/RIOT/tests/riotboot/bin/samr21-xpro/tests_riotboot-slot0.bin', needed by '/home/harter/work/git/RIOT/tests/riotboot/bin/samr21-xpro/tests_riotboot-slot0.hdr'.  Stop.
make: Leaving directory '/home/harter/work/git/RIOT/tests/riotboot'
```
</p>
</details>


### Issues/PRs references

Running compilation on a machine without toolchain installed.
Tracking issue https://github.com/RIOT-OS/RIOT/issues/9645