### PR TITLE
codacy: disable complaining about python assert

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,0 +1,3 @@
+# codacy:
+# Solve flagged valid Python "assert" statements
+skips: ['B101']


### PR DESCRIPTION
### Contribution description

This silents the reported issue in codacy about python asserts:

    Use of assert detected. The enclosed code will be removed when
    compiling to optimised byte code.

The concern is valid about python asserts, but they are used in tests
and python is not run with optimised byte code.

Solution taken from codacy website
https://support.codacy.com/hc/en-us/articles/207994335-Code-Patterns

### Testing procedure

This silents the issue from https://github.com/RIOT-OS/RIOT/pull/10952#issuecomment-468523775 where I now have this commit too.


### Issues/PRs references

Found about codacy complains in  https://github.com/RIOT-OS/RIOT/pull/10952#issuecomment-468523775