### PR TITLE
sys/xtimer: Fixed interrupt race-condition in _xtimer_set_absolute

### DIFF
--- a/sys/xtimer/xtimer_core.c
+++ b/sys/xtimer/xtimer_core.c
@@ -177,6 +177,7 @@ static inline void _lltimer_set(uint32_t target)
 
 int _xtimer_set_absolute(xtimer_t *timer, uint32_t target)
 {
+    unsigned state = irq_disable();
     uint32_t now = _xtimer_now();
     int res = 0;
 
@@ -199,16 +200,17 @@ int _xtimer_set_absolute(xtimer_t *timer, uint32_t target)
           now, target, offset);
 
     if (now >= target) {
+        irq_restore(state);
         _shoot(timer);
         return 0;
     } else if (offset <= XTIMER_BACKOFF) {
         /* backoff */
+        irq_restore(state);
         _xtimer_spin(offset);
         _shoot(timer);
         return 0;
     }
 
-    unsigned state = irq_disable();
     if (_is_set(timer)) {
         _remove(timer);
     }

--- a/sys/xtimer/xtimer_core.c
+++ b/sys/xtimer/xtimer_core.c
@@ -198,9 +198,12 @@ int _xtimer_set_absolute(xtimer_t *timer, uint32_t target)
     DEBUG("timer_set_absolute(): now=%" PRIu32 " target=%" PRIu32 " offset=%" PRIu32 "\n",
           now, target, offset);
 
-    if (offset <= XTIMER_BACKOFF) {
+    if (now >= target) {
+        _shoot(timer);
+        return 0;
+    } else if (offset <= XTIMER_BACKOFF) {
         /* backoff */
-        xtimer_spin_until(target);
+        _xtimer_spin(offset);
         _shoot(timer);
         return 0;
     }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
When setting a short timer using `xtimer_usleep`, there exists a race condition if an interrupt occurs between the `_xtimer_now()` call done in `_xtimer_set` and the one done in `_xtimer_set_absolute`. If this interrupt lasts longer than the duration of the timer, the offset variable in `_xtimer_set_absolute` will underflow, causing the timer to practically permanently sleep, until it fully wraps around.

I have fixed this problem by checking if the target has already been exceeded, and if so, immediately shoot the timer. In case we need to back off, I have also replaced `xtimer_spin_until` with `_xtimer_spin` because of an identical issue: Even if the calculated offset was correct, an interrupt between the offset calculation and the spin might cause the target to be exceeded before the spin, causing `xtimer_spin_until` to also permanently sleep until a wrap around.

### Testing procedure
I discovered this bug while working on a custom board, which runs on an stm32l496. I created the following test-case, which caused the main thread to freeze (and thus the led to stop blinking), usually after a few seconds up to a minute, given that a lot of data is being send on UART_0:

```C
static void SRV_PTC_UART_DSP_ReceiveCB(void *arg, uint8_t data) {
	for (volatile int i = 0 ; i < 100000 ; i++);
}

int main(void) {
	xtimer_init();
	uart_init(UART_DEV(0), 1200, SRV_PTC_UART_DSP_ReceiveCB, NULL);
	while (1) {
		LED1_TOGGLE;		
		for (size_t i = 0 ; i < 10000 ; i++)
			xtimer_usleep(30);
	}
}
```
With the changes in this commit, this code seems to be stable.

### Issues/PRs references
I haven't made an issue for this problem, so there is nothing to refer to. If needed I can make one, though.
