### PR TITLE
tests/riotboot: use FLASHFILE for the generated file

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -407,6 +407,11 @@ ELFFILE ?= $(BINDIR)/$(APPLICATION).elf
 HEXFILE ?= $(ELFFILE:.elf=.hex)
 BINFILE ?= $(ELFFILE:.elf=.bin)
 
+# include bootloaders support. It should be included early to allow using
+# variables defined in `riotboot.mk` for `FLASHFILE` before it is evaluated.
+# It should be included after defining 'BINFILE' for 'riotboot.bin' handling.
+include $(RIOTMAKE)/boot/riotboot.mk
+
 # Targets to get given file
 elffile: $(ELFFILE)
 hexfile: $(HEXFILE)
@@ -441,11 +446,6 @@ ifeq ($(BUILDOSXNATIVE),1)
 else
   _LINK = $(if $(CPPMIX),$(LINKXX),$(LINK)) $(UNDEF) $(LINKFLAGPREFIX)--start-group $(BASELIBS) -lm $(LINKFLAGPREFIX)--end-group $(LINKFLAGS) $(LINKFLAGPREFIX)-Map=$(BINDIR)/$(APPLICATION).map
 endif # BUILDOSXNATIVE
-
-# include bootloaders support. When trying to overwrite one variable
-# like HEXFILE, the value will already have been evaluated when declaring
-# the link target. Therefore, it must be placed before `link`.
-include $(RIOTMAKE)/boot/riotboot.mk
 
 ifeq ($(BUILD_IN_DOCKER),1)
 link: ..in-docker-container

--- a/makefiles/boot/riotboot.mk
+++ b/makefiles/boot/riotboot.mk
@@ -117,9 +117,12 @@ riotboot/flash-extended-slot0: HEXFILE=$(RIOTBOOT_EXTENDED_BIN)
 # Flashing rule for openocd to flash combined/extended binaries
 riotboot/flash-combined-slot0: ELFFILE=$(RIOTBOOT_COMBINED_BIN)
 riotboot/flash-extended-slot0: ELFFILE=$(RIOTBOOT_EXTENDED_BIN)
+
+riotboot/flash-combined-slot0: FLASHFILE=$(RIOTBOOT_COMBINED_BIN)
 riotboot/flash-combined-slot0: $(RIOTBOOT_COMBINED_BIN) $(FLASHDEPS)
 	$(FLASHER) $(FFLAGS)
 
+riotboot/flash-extended-slot0: FLASHFILE=$(RIOTBOOT_EXTENDED_BIN)
 riotboot/flash-extended-slot0: $(RIOTBOOT_EXTENDED_BIN) $(FLASHDEPS)
 	$(FLASHER) $(FFLAGS)
 
@@ -129,6 +132,7 @@ riotboot/flash-slot0: export IMAGE_OFFSET=$(SLOT0_OFFSET)
 riotboot/flash-slot0: HEXFILE=$(SLOT0_RIOT_BIN)
 # openocd
 riotboot/flash-slot0: ELFFILE=$(SLOT0_RIOT_BIN)
+riotboot/flash-slot0: FLASHFILE=$(SLOT0_RIOT_BIN)
 riotboot/flash-slot0: $(SLOT0_RIOT_BIN) $(FLASHDEPS)
 	$(FLASHER) $(FFLAGS)
 
@@ -138,6 +142,7 @@ riotboot/flash-slot1: export IMAGE_OFFSET=$(SLOT1_OFFSET)
 riotboot/flash-slot1: HEXFILE=$(SLOT1_RIOT_BIN)
 # openocd
 riotboot/flash-slot1: ELFFILE=$(SLOT1_RIOT_BIN)
+riotboot/flash-slot1: FLASHFILE=$(SLOT1_RIOT_BIN)
 riotboot/flash-slot1: $(SLOT1_RIOT_BIN) $(FLASHDEPS)
 	$(FLASHER) $(FFLAGS)
 

--- a/makefiles/boot/riotboot.mk
+++ b/makefiles/boot/riotboot.mk
@@ -35,8 +35,7 @@ SLOT0_RIOT_BIN = $(BINDIR_APP)-slot0.riot.bin
 SLOT1_RIOT_BIN = $(BINDIR_APP)-slot1.riot.bin
 SLOT_RIOT_BINS = $(SLOT0_RIOT_BIN) $(SLOT1_RIOT_BIN)
 
-# For slot generation only link is needed
-$(BINDIR_APP)-%.elf: link
+$(BINDIR_APP)-%.elf: $(BASELIBS)
 	$(Q)$(_LINK) -o $@
 
 # Slot 0 and 1 firmware offset, after header

--- a/tests/riotboot/Makefile
+++ b/tests/riotboot/Makefile
@@ -18,17 +18,15 @@ DEVELHELP ?= 1
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1
 
-all: riotboot
+# Target 'all' will generate the combined file directly.
+# It also makes 'flash' and 'flash-only' work without specific command.
+FLASHFILE = $(RIOTBOOT_COMBINED_BIN)
 
 include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include
 
-# Make 'flash' and 'flash-only' work without specific command.
-# This is currently hacky as there is no way of specifiying a FLASHFILE
-all: riotboot/combined-slot0
+# This is currently hacky as the flasher are not using 'FLASHFILE'
 # openocd
-ELFFILE = $(RIOTBOOT_COMBINED_BIN)
+ELFFILE = $(FLASHFILE)
 # edbg
-HEXFILE = $(RIOTBOOT_COMBINED_BIN)
-# murdock uses ':=' to get the flashfile variable so should also be overwritten
-FLASHFILE = $(RIOTBOOT_COMBINED_BIN)
+HEXFILE = $(FLASHFILE)

--- a/tests/riotboot/Makefile
+++ b/tests/riotboot/Makefile
@@ -27,8 +27,8 @@ include $(RIOTBASE)/Makefile.include
 # This is currently hacky as there is no way of specifiying a FLASHFILE
 all: riotboot/combined-slot0
 # openocd
-ELFFILE = $(BINDIR_APP)-slot0-combined.bin
+ELFFILE = $(RIOTBOOT_COMBINED_BIN)
 # edbg
-HEXFILE = $(BINDIR_APP)-slot0-combined.bin
+HEXFILE = $(RIOTBOOT_COMBINED_BIN)
 # murdock uses ':=' to get the flashfile variable so should also be overwritten
-FLASHFILE = $(BINDIR_APP)-slot0-combined.bin
+FLASHFILE = $(RIOTBOOT_COMBINED_BIN)


### PR DESCRIPTION
### Contribution description

FLASHFILE is now a generated file when doing `make all`.
This prepares also for when flashers will use `FLASHFILE` as a file to
be flashed.

It currently still needs the hack below for openocd and edbg.

This also fixes the issue when building 'riotboot' in docker that was
being built with the host toolchain.

### Description

This pull request is big and needs to modify many files to work. I could split if requested.

### Testing procedure

#### Murdock change:

Murdock keeps running tests on `samr21-xpro`, and also runs the `tests/riotboot` test on `samr21-xpro`.

#### Riotboot global change

Review the code difference, the main thing is that now we can do `FLASHFILE = $(RIOTBOOT_COMBINED_BIN)` before parsing `$(RIOTBASE)/Makefile.include`

When compiling it should compile without ever saying `Circular dependency`.

My testing procedure is the following to ensure the firmware is indeed flashed and not relying on the previous version:

```
git clean -xdf tests/riotboot; BOARD=samr21-xpro make -C examples/hello-world/ flash; make -C tests/riotboot flash test
```
The test should succeed both with `samr21-xpro` and `iotlab-m3`.

#### Building `riotboot` in docker

This change also now has the consequence that when doing `BUILD_IN_DOCKER=1 make all` riotboot is correctly build in docker. If you have `arm-gcc` outside of your normal path you can try compiling with:

```
git clean -xdf tests/riotboot; DOCKER="sudo docker" BUILD_IN_DOCKER=1 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin make -C tests/riotboot flash test
```

### Issues/PRs references

This is part of https://github.com/RIOT-OS/RIOT/pull/8838
This replaces part of https://github.com/RIOT-OS/RIOT/pull/11083

Depends on ~https://github.com/RIOT-OS/RIOT/pull/11097~