### PR TITLE
boards: Added standalone ATmega328p

### DIFF
--- a/boards/atmega328p/Makefile
+++ b/boards/atmega328p/Makefile
@@ -1,0 +1,5 @@
+MODULE = board
+
+DIRS = $(RIOTBOARD)/common/atmega
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/atmega328p/Makefile.dep
+++ b/boards/atmega328p/Makefile.dep
@@ -1,0 +1,1 @@
+USEMODULE += boards_common_atmega

--- a/boards/atmega328p/Makefile.features
+++ b/boards/atmega328p/Makefile.features
@@ -1,0 +1,9 @@
+CPU = atmega328p
+
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_gpio periph_gpio_irq
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart

--- a/boards/atmega328p/Makefile.include
+++ b/boards/atmega328p/Makefile.include
@@ -1,0 +1,18 @@
+# configure the terminal program
+PORT_LINUX          ?= /dev/ttyUSB0
+PORT_DARWIN         ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
+BAUD                ?= 9600
+ATMEGA328P_CLOCK    ?=
+include $(RIOTMAKE)/tools/serial.inc.mk
+
+# Allow overwriting programmer via env variables without affecting other boards
+PROGRAMMER_BOARD_ATMEGA328P ?= usbtiny
+# ICSP programmer to use for avrdude
+PROGRAMMER ?= $(PROGRAMMER_BOARD_ATMEGA328P)
+
+ifneq (,$(ATMEGA328P_CLOCK))
+  CFLAGS += -DCLOCK_CORECLOCK=$(ATMEGA328P_CLOCK)
+endif
+
+include $(RIOTMAKE)/tools/avrdude.inc.mk
+include $(RIOTBOARD)/common/atmega/Makefile.include

--- a/boards/atmega328p/doc.txt
+++ b/boards/atmega328p/doc.txt
@@ -1,0 +1,107 @@
+/**
+@defgroup    boards_atmega328p Standalone ATmega328p
+@ingroup     boards
+@brief       Support for using the ATmega328p as standalone board
+
+## Overview
+
+The ATmega328p is most popular in the Arduino UNO. However, the 28 PDIP package
+of the ATmega328p can easily be used without any "board": Just place it on a
+bread board, and connect a TTL adapter and an ISP and you're ready to go.
+
+The ATmega328p has two internal oscillators, one clocked at 8MHz and one at
+128kHz. By default the fuses of the ATmega328p are configured that the internal
+8MHz oscillator can be used. This allows the ATmega328p to be operated without
+any external components at a supply voltage anywhere between 2.7V and 5.5V.
+
+\htmlonly<style>div.image img[src="https://github.com/maribu/images/raw/master/ATmega328p.jpg"]{width:600px;}</style>\endhtmlonly
+@image html "https://github.com/maribu/images/raw/master/ATmega328p.jpg" "ATmega328p DIP package on a breadboard"<br>
+
+### MCU
+| MCU           | ATmega328p                             |
+|:------------- |:-------------------------------------- |
+| Family        | AVR/ATmega                             |
+| Vendor        | Microchip (previously Atmel)           |
+| RAM           | 2Kb                                    |
+| Flash         | 32Kb                                   |
+| Frequency     | 8MHz (up to 20MHz with external clock) |
+| Timers        | 3 (2x 8bit, 1x 16bit)                  |
+| ADCs          | 6 analog input pins                    |
+| UARTs         | 1                                      |
+| SPIs          | 1                                      |
+| I2Cs          | 1 (called TWI)                         |
+| Vcc           | 2.7V - 5.5V (when clocked at 8MHz)     |
+| Datasheet     | [Official datasheet](http://ww1.microchip.com/downloads/en/DeviceDoc/ATmega48A-PA-88A-PA-168A-PA-328-P-DS-DS40002061A.pdf) |
+
+### Pinout
+
+\htmlonly<style>div.image img[src="https://camo.githubusercontent.com/c55beef2f138da61fe671a1e4a307ff4ffbc318d/68747470733a2f2f692e696d6775722e636f6d2f715849456368542e6a7067"]{width:100%;}</style>\endhtmlonly
+@image html "https://camo.githubusercontent.com/c55beef2f138da61fe671a1e4a307ff4ffbc318d/68747470733a2f2f692e696d6775722e636f6d2f715849456368542e6a7067" "Pinout of the ATmega328p"<br>
+
+All credit for above pinout image goes to https://github.com/MCUdude/MiniCore#pinout
+
+### Clock Frequency
+
+The ATmega328p has two internal oscillators clocked at 8MHz and at 128kHz that
+allow it to be operated without any external clock source or crystal. By default
+the fuses are configured to use the internal 8MHz oscillator resulting in a
+clock speed of 8MHz. By setting the `CKDIV8` fuse the clock divider can be
+enabled to operate the ATmega328p at 1MHz.
+
+This "board" is configured to use 8MHz as core clock, so that the ATmega328p
+can be used without external circuitry and without any changes in the default
+fuse configuration.
+
+By setting the environment variable `ATMEGA328P_CLOCK` to a custom frequency in
+Hz (e.g. `1000000` for 1MHz), this core clock can be changed easily. Refer to
+the datasheet on how to configure the ATmega328p to use an external crystal,
+an external clock source or the clockd divider.
+
+### Relation Between Supply Voltage, Clock Frequency and Power Consumption
+
+A higher supply voltage results in a higher current drawn. Thus, lower power
+consumption can be achieved by using a lower supply voltage. However, higher
+clock frequencies require higher supply voltages for reliable operation.
+
+The lowest possible supply voltage at 8 MHz is 2.7V (with some safety margin),
+which results in an active supply current of less than 3 mA (about 8 mW power
+consumption) according to the datasheet. At 1 MHz core clock a supply voltage of
+1.8V is possible resulting in an active supply current of less than 0.3 mA
+(about 0.5 mW power consumption). For more details, refer to the official
+datasheet.
+
+## Flashing the Device
+
+In order to flash the ATmega328P without a bootloader, an ICSP programmer is
+needed. Connect the programmer as follows:
+
+| ISCP pin | ATmega328p pin |
+|:-------- |:-------------- |
+| MISO     | 18/PB4/MISO    |
+| VCC      | 7/VCC          |
+| SCK      | 19/PB5/SCK     |
+| MOSI     | 17/PB3/MOSI    |
+| RESET    | 1/RESET        |
+| Ground   | 22/GND         |
+
+The tool `avrdude` needs to be installed. When using the `usbtiny` (or one of
+the super cheap clones) running
+
+    make BOARD=atmega328p flash
+
+will take care of everything. To use the programmer `<FOOBAR>` instead, run
+
+    make BOARD=atmega328p PROGRAMMER=<FOOBAR> flash
+
+## Serial Terminal
+
+Connect a TTL adapter with pins 2/RXD and 3/TXD an run
+
+    make BOARD=atmega328p term
+
+Please note that the supply voltage should be compatible with the logic level of
+the TTL adapter. Usually everything between 3.3 V and 5 V should work.
+
+## Caution
+Don't expect having a working network stack due to very limited resources ;-)
+ */

--- a/boards/atmega328p/include/board.h
+++ b/boards/atmega328p/include/board.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin, Hinnerk van Bruinehsen
+ *               2016 Laurent Navet <laurent.navet@gmail.com>
+ *               2019 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_atmega328p
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the standalone ATmega328p "board"
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ * @author      Hinnerk van Bruinehsen <h.v.bruinehsen@fu-berlin.de>
+ * @author      Laurent Navet <laurent.navet@gmail.com>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    STDIO configuration
+ *
+ * As the CPU is too slow to handle 115200 baud, we set the default
+ * baudrate to 9600 for this board
+ * @{
+ */
+#define STDIO_UART_BAUDRATE (9600U)
+/** @} */
+
+/**
+ * @name    xtimer configuration values
+ * @{
+ */
+#define XTIMER_WIDTH                (16)
+#define XTIMER_HZ                   (250000UL)
+#define XTIMER_BACKOFF              (40)
+/** @} */
+
+/**
+ * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/atmega328p/include/periph_conf.h
+++ b/boards/atmega328p/include/periph_conf.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2019 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup boards_atmega328p
+ * @{
+ *
+ * @file
+ * @brief   Peripheral MCU configuration for the ATmega328p standalone "board"
+ *
+ * @author  Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Clock configuration
+ * @{
+ */
+#ifndef CLOCK_CORECLOCK
+/* Using 8MHz internal oscillator as default clock source */
+#define CLOCK_CORECLOCK     (8000000UL)
+#endif
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#include "periph_conf_atmega_common.h"
+
+#endif /* PERIPH_CONF_H */

--- a/boards/common/atmega/board.c
+++ b/boards/common/atmega/board.c
@@ -46,6 +46,8 @@ void board_init(void)
     atmega_set_prescaler(CPU_ATMEGA_CLK_SCALE_INIT);
 
     cpu_init();
+#ifdef LED0_ON
     led_init();
+#endif
     irq_enable();
 }

--- a/examples/asymcute_mqttsn/Makefile.ci
+++ b/examples/asymcute_mqttsn/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     chronos \
     hifive1 \
     hifive1b \

--- a/examples/cord_ep/Makefile.ci
+++ b/examples/cord_ep/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     chronos \
     hifive1 \
     hifive1b \

--- a/examples/cord_epsim/Makefile.ci
+++ b/examples/cord_epsim/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     chronos \
     hifive1 \
     hifive1b \

--- a/examples/default/Makefile.ci
+++ b/examples/default/Makefile.ci
@@ -3,4 +3,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     #

--- a/examples/dtls-echo/Makefile
+++ b/examples/dtls-echo/Makefile
@@ -9,8 +9,8 @@ RIOTBASE ?= $(CURDIR)/../..
 
 # TinyDTLS only has support for 32-bit architectures ATM
 BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
-                   arduino-mega2560 arduino-nano \
-                   arduino-uno chronos mega-xplained microduino-corerf \
+                   arduino-mega2560 arduino-nano arduino-uno atmega328p \
+                   chronos mega-xplained microduino-corerf \
                    msb-430 msb-430h telosb waspmote-pro wsn430-v1_3b \
                    wsn430-v1_4 z1
 

--- a/examples/emcute_mqttsn/Makefile.ci
+++ b/examples/emcute_mqttsn/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     chronos \
     hifive1 \
     hifive1b \

--- a/examples/filesystem/Makefile.ci
+++ b/examples/filesystem/Makefile.ci
@@ -3,5 +3,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     #

--- a/examples/gcoap/Makefile.ci
+++ b/examples/gcoap/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     chronos \
     i-nucleo-lrwan1 \
     mega-xplained \

--- a/examples/gnrc_border_router/Makefile.ci
+++ b/examples/gnrc_border_router/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     b-l072z-lrwan1 \
     blackpill \
     blackpill-128kib \

--- a/examples/gnrc_minimal/Makefile.ci
+++ b/examples/gnrc_minimal/Makefile.ci
@@ -3,5 +3,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     #

--- a/examples/gnrc_networking/Makefile.ci
+++ b/examples/gnrc_networking/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     blackpill \
     bluepill \
     calliope-mini \

--- a/examples/gnrc_tftp/Makefile.ci
+++ b/examples/gnrc_tftp/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     b-l072z-lrwan1 \
     blackpill \
     bluepill \

--- a/examples/ipc_pingpong/Makefile.ci
+++ b/examples/ipc_pingpong/Makefile.ci
@@ -3,5 +3,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     #

--- a/examples/javascript/Makefile
+++ b/examples/javascript/Makefile
@@ -8,7 +8,7 @@ BOARD ?= native
 RIOTBASE ?= $(CURDIR)/../..
 
 BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo arduino-mega2560 \
-                   arduino-nano arduino-uno chronos \
+                   arduino-nano arduino-uno atmega328p chronos \
                    msb-430 msb-430h telosb waspmote-pro wsn430-v1_3b \
                    wsn430-v1_4 z1 pic32-wifire pic32-clicker \
                    mega-xplained microduino-corerf

--- a/examples/lua_REPL/Makefile
+++ b/examples/lua_REPL/Makefile
@@ -7,7 +7,7 @@ BOARD ?= native
 RIOTBASE ?= $(CURDIR)/../..
 
 BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
-                   arduino-mega2560 arduino-nano arduino-uno \
+                   arduino-mega2560 arduino-nano arduino-uno atmega328p \
                    chronos hifive1 hifive1b mega-xplained microduino-corerf \
                    msb-430 msb-430h pic32-clicker pic32-wifire telosb \
                    waspmote-pro wsn430-v1_3b wsn430-v1_4 z1

--- a/examples/lua_basic/Makefile
+++ b/examples/lua_basic/Makefile
@@ -8,7 +8,7 @@ RIOTBASE ?= $(CURDIR)/../..
 
 BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
                    arduino-mega2560 arduino-nano \
-                   arduino-uno chronos hifive1 hifive1b \
+                   arduino-uno atmega328p chronos hifive1 hifive1b \
                    mega-xplained microduino-corerf msb-430 msb-430h pic32-clicker \
                    pic32-wifire telosb waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
 

--- a/examples/nanocoap_server/Makefile.ci
+++ b/examples/nanocoap_server/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     chronos \
     i-nucleo-lrwan1 \
     msb-430 \

--- a/examples/ndn-ping/Makefile.ci
+++ b/examples/ndn-ping/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     chronos \
     i-nucleo-lrwan1 \
     mega-xplained \

--- a/examples/posix_sockets/Makefile.ci
+++ b/examples/posix_sockets/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     chronos \
     i-nucleo-lrwan1 \
     mega-xplained \

--- a/examples/saul/Makefile.ci
+++ b/examples/saul/Makefile.ci
@@ -3,4 +3,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     #

--- a/examples/suit_update/Makefile.ci
+++ b/examples/suit_update/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     b-l072z-lrwan1 \
     chronos \
     lsn50 \

--- a/tests/bench_sizeof_coretypes/Makefile.ci
+++ b/tests/bench_sizeof_coretypes/Makefile.ci
@@ -3,4 +3,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     #

--- a/tests/bench_timers/Makefile.ci
+++ b/tests/bench_timers/Makefile.ci
@@ -3,4 +3,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     #

--- a/tests/bloom_bytes/Makefile.ci
+++ b/tests/bloom_bytes/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     chronos \
     msb-430 \
     msb-430h \

--- a/tests/can_trx/Makefile.ci
+++ b/tests/can_trx/Makefile.ci
@@ -3,4 +3,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     #

--- a/tests/cond_order/Makefile.ci
+++ b/tests/cond_order/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     i-nucleo-lrwan1 \
     nucleo-f030 \
     nucleo-f030r8 \

--- a/tests/conn_can/Makefile.ci
+++ b/tests/conn_can/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     chronos \
     hifive1 \
     hifive1b \

--- a/tests/driver_at/Makefile.ci
+++ b/tests/driver_at/Makefile.ci
@@ -3,5 +3,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     #

--- a/tests/driver_at30tse75x/Makefile.ci
+++ b/tests/driver_at30tse75x/Makefile.ci
@@ -3,4 +3,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     #

--- a/tests/driver_at86rf2xx/Makefile.ci
+++ b/tests/driver_at86rf2xx/Makefile.ci
@@ -3,5 +3,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     #

--- a/tests/driver_ata8520e/Makefile.ci
+++ b/tests/driver_ata8520e/Makefile.ci
@@ -3,4 +3,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     #

--- a/tests/driver_bmx055/Makefile.ci
+++ b/tests/driver_bmx055/Makefile.ci
@@ -3,4 +3,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     #

--- a/tests/driver_cc110x/Makefile.ci
+++ b/tests/driver_cc110x/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     blackpill \
     bluepill \
     i-nucleo-lrwan1 \

--- a/tests/driver_dynamixel/Makefile.ci
+++ b/tests/driver_dynamixel/Makefile.ci
@@ -3,4 +3,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     #

--- a/tests/driver_enc28j60/Makefile.ci
+++ b/tests/driver_enc28j60/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     i-nucleo-lrwan1 \
     mega-xplained \
     microduino-corerf \

--- a/tests/driver_encx24j600/Makefile.ci
+++ b/tests/driver_encx24j600/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     i-nucleo-lrwan1 \
     msb-430 \
     msb-430h \

--- a/tests/driver_feetech/Makefile.ci
+++ b/tests/driver_feetech/Makefile.ci
@@ -3,4 +3,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     #

--- a/tests/driver_kw2xrf/Makefile.ci
+++ b/tests/driver_kw2xrf/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     i-nucleo-lrwan1 \
     nucleo-f031k6 \
     nucleo-f042k6 \

--- a/tests/driver_ltc4150/Makefile.ci
+++ b/tests/driver_ltc4150/Makefile.ci
@@ -3,4 +3,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     #

--- a/tests/driver_mpu9150/Makefile.ci
+++ b/tests/driver_mpu9150/Makefile.ci
@@ -3,4 +3,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     #

--- a/tests/driver_mpu9x50/Makefile.ci
+++ b/tests/driver_mpu9x50/Makefile.ci
@@ -3,4 +3,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     #

--- a/tests/driver_nrf24l01p_lowlevel/Makefile.ci
+++ b/tests/driver_nrf24l01p_lowlevel/Makefile.ci
@@ -3,5 +3,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     #

--- a/tests/driver_nvram_spi/Makefile.ci
+++ b/tests/driver_nvram_spi/Makefile.ci
@@ -3,4 +3,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     #

--- a/tests/driver_pca9685/Makefile.ci
+++ b/tests/driver_pca9685/Makefile.ci
@@ -2,4 +2,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-duemilanove \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     #

--- a/tests/driver_pcd8544/Makefile.ci
+++ b/tests/driver_pcd8544/Makefile.ci
@@ -3,4 +3,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     #

--- a/tests/driver_pir/Makefile.ci
+++ b/tests/driver_pir/Makefile.ci
@@ -3,5 +3,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     #

--- a/tests/driver_rn2xx3/Makefile.ci
+++ b/tests/driver_rn2xx3/Makefile.ci
@@ -3,4 +3,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     #

--- a/tests/driver_sdcard_spi/Makefile.ci
+++ b/tests/driver_sdcard_spi/Makefile.ci
@@ -3,5 +3,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     #

--- a/tests/driver_sht1x/Makefile.ci
+++ b/tests/driver_sht1x/Makefile.ci
@@ -3,4 +3,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     #

--- a/tests/driver_srf02/Makefile.ci
+++ b/tests/driver_srf02/Makefile.ci
@@ -3,4 +3,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     #

--- a/tests/driver_sx127x/Makefile.ci
+++ b/tests/driver_sx127x/Makefile.ci
@@ -3,5 +3,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     #

--- a/tests/driver_tsl4531x/Makefile.ci
+++ b/tests/driver_tsl4531x/Makefile.ci
@@ -3,4 +3,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     #

--- a/tests/driver_xbee/Makefile.ci
+++ b/tests/driver_xbee/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \

--- a/tests/emb6/Makefile.ci
+++ b/tests/emb6/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     i-nucleo-lrwan1 \
     msb-430 \
     msb-430h \

--- a/tests/event_wait_timeout/Makefile.ci
+++ b/tests/event_wait_timeout/Makefile.ci
@@ -2,4 +2,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-duemilanove \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     #

--- a/tests/events/Makefile.ci
+++ b/tests/events/Makefile.ci
@@ -3,4 +3,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     #

--- a/tests/evtimer_msg/Makefile.ci
+++ b/tests/evtimer_msg/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     nucleo-f042k6 \
     #

--- a/tests/evtimer_underflow/Makefile.ci
+++ b/tests/evtimer_underflow/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     nucleo-f042k6 \
     #

--- a/tests/gnrc_ipv6_ext/Makefile.ci
+++ b/tests/gnrc_ipv6_ext/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \

--- a/tests/gnrc_ipv6_ext_frag/Makefile.ci
+++ b/tests/gnrc_ipv6_ext_frag/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \

--- a/tests/gnrc_ipv6_fwd_w_sub/Makefile.ci
+++ b/tests/gnrc_ipv6_fwd_w_sub/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     chronos \
     i-nucleo-lrwan1 \
     msb-430 \

--- a/tests/gnrc_ipv6_nib/Makefile.ci
+++ b/tests/gnrc_ipv6_nib/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     chronos \
     nucleo-f031k6 \
     nucleo-f042k6 \

--- a/tests/gnrc_ipv6_nib_6ln/Makefile.ci
+++ b/tests/gnrc_ipv6_nib_6ln/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     chronos \
     i-nucleo-lrwan1 \
     nucleo-f030r8 \

--- a/tests/gnrc_mac_timeout/Makefile.ci
+++ b/tests/gnrc_mac_timeout/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     chronos \
     i-nucleo-lrwan1 \
     nucleo-f030r8 \

--- a/tests/gnrc_ndp/Makefile.ci
+++ b/tests/gnrc_ndp/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     chronos \
     i-nucleo-lrwan1 \
     msb-430 \

--- a/tests/gnrc_netif/Makefile.ci
+++ b/tests/gnrc_netif/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     b-l072z-lrwan1 \
     blackpill \
     blackpill-128kib \

--- a/tests/gnrc_rpl_srh/Makefile.ci
+++ b/tests/gnrc_rpl_srh/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \

--- a/tests/gnrc_sixlowpan/Makefile.ci
+++ b/tests/gnrc_sixlowpan/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     chronos \
     hifive1 \
     hifive1b \

--- a/tests/gnrc_sixlowpan_frag/Makefile.ci
+++ b/tests/gnrc_sixlowpan_frag/Makefile.ci
@@ -3,5 +3,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     #

--- a/tests/gnrc_sock_dns/Makefile.ci
+++ b/tests/gnrc_sock_dns/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     chronos \
     hifive1 \
     hifive1b \

--- a/tests/gnrc_sock_ip/Makefile.ci
+++ b/tests/gnrc_sock_ip/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     chronos \
     nucleo-f031k6 \
     nucleo-f042k6 \

--- a/tests/gnrc_sock_udp/Makefile.ci
+++ b/tests/gnrc_sock_udp/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     chronos \
     nucleo-f031k6 \
     nucleo-f042k6 \

--- a/tests/gnrc_tcp/Makefile.ci
+++ b/tests/gnrc_tcp/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \

--- a/tests/gnrc_udp/Makefile.ci
+++ b/tests/gnrc_udp/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     calliope-mini \
     chronos \
     hifive1 \

--- a/tests/heap_cmd/Makefile.ci
+++ b/tests/heap_cmd/Makefile.ci
@@ -2,4 +2,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-duemilanove \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     #

--- a/tests/irq/Makefile.ci
+++ b/tests/irq/Makefile.ci
@@ -3,5 +3,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     #

--- a/tests/isr_yield_higher/Makefile.ci
+++ b/tests/isr_yield_higher/Makefile.ci
@@ -3,5 +3,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     #

--- a/tests/libfixmath_unittests/Makefile
+++ b/tests/libfixmath_unittests/Makefile
@@ -1,8 +1,8 @@
 include ../Makefile.tests_common
 
 BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
-                   arduino-mega2560 arduino-nano \
-                   arduino-uno mega-xplained microduino-corerf waspmote-pro
+                   arduino-mega2560 arduino-nano arduino-uno \
+                   atmega328p mega-xplained microduino-corerf waspmote-pro
 # arduino-mega2560: builds locally but breaks travis (possibly because of
 # differences in the toolchain)
 # The MSP boards don't feature round(), exp(), and log(), which are used in the unittests

--- a/tests/msg_send_receive/Makefile.ci
+++ b/tests/msg_send_receive/Makefile.ci
@@ -3,5 +3,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     #

--- a/tests/mutex_order/Makefile.ci
+++ b/tests/mutex_order/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     i-nucleo-lrwan1 \
     nucleo-f030r8 \
     nucleo-f031k6 \

--- a/tests/nanocoap_cli/Makefile.ci
+++ b/tests/nanocoap_cli/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     chronos \
     i-nucleo-lrwan1 \
     mega-xplained \

--- a/tests/netdev_test/Makefile.ci
+++ b/tests/netdev_test/Makefile.ci
@@ -3,5 +3,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     #

--- a/tests/nhdp/Makefile
+++ b/tests/nhdp/Makefile
@@ -1,8 +1,8 @@
 include ../Makefile.tests_common
 
 BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
-                   arduino-mega2560 arduino-nano \
-                   arduino-uno chronos mega-xplained microduino-corerf \
+                   arduino-mega2560 arduino-nano arduino-uno \
+                   atmega328p chronos mega-xplained microduino-corerf \
                    msb-430 msb-430h telosb waspmote-pro \
                    wsn430-v1_3b wsn430-v1_4 z1
 

--- a/tests/periph_eeprom/Makefile.ci
+++ b/tests/periph_eeprom/Makefile.ci
@@ -3,4 +3,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     #

--- a/tests/periph_gpio/Makefile.ci
+++ b/tests/periph_gpio/Makefile.ci
@@ -3,4 +3,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     #

--- a/tests/periph_gpio_arduino/Makefile.ci
+++ b/tests/periph_gpio_arduino/Makefile.ci
@@ -2,4 +2,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-duemilanove \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     #

--- a/tests/periph_i2c/Makefile.ci
+++ b/tests/periph_i2c/Makefile.ci
@@ -3,4 +3,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     #

--- a/tests/periph_pwm/Makefile.ci
+++ b/tests/periph_pwm/Makefile.ci
@@ -3,4 +3,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     #

--- a/tests/periph_spi/Makefile.ci
+++ b/tests/periph_spi/Makefile.ci
@@ -3,4 +3,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     #

--- a/tests/periph_timer/Makefile
+++ b/tests/periph_timer/Makefile
@@ -2,9 +2,24 @@ include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_timer
 
-ifneq (,$(filter arduino-duemilanove arduino-leonardo arduino-mega2560 arduino-uno waspmote-pro,$(BOARD)))
+BOARDS_TIMER_25kHz := \
+    arduino-duemilanove \
+    arduino-leonardo \
+    arduino-mega2560 \
+    arduino-uno \
+    atmega328p \
+    waspmote-pro \
+    #
+
+BOARDS_TIMER_32kHz := \
+    hifive1 \
+    hifive1b \
+    %-kw41z \
+    #
+
+ifneq (,$(filter $(BOARDS_TIMER_25kHz),$(BOARD)))
   TIMER_SPEED ?= 250000
-else ifneq (,$(filter hifive1 hifive1b %-kw41z,$(BOARD)))
+else ifneq (,$(filter $(BOARDS_TIMER_32kHz),$(BOARD)))
   TIMER_SPEED ?= 32768
 endif
 

--- a/tests/periph_uart/Makefile.ci
+++ b/tests/periph_uart/Makefile.ci
@@ -3,5 +3,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     #

--- a/tests/periph_uart_mode/Makefile.ci
+++ b/tests/periph_uart_mode/Makefile.ci
@@ -3,5 +3,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     #

--- a/tests/pipe/Makefile.ci
+++ b/tests/pipe/Makefile.ci
@@ -2,5 +2,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-duemilanove \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     #

--- a/tests/pkg_c25519/Makefile.ci
+++ b/tests/pkg_c25519/Makefile.ci
@@ -3,4 +3,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     #

--- a/tests/pkg_cifra/Makefile
+++ b/tests/pkg_cifra/Makefile
@@ -2,8 +2,8 @@ include ../Makefile.tests_common
 
 # No 8 bit and 16 bit support
 BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
-                   arduino-mega2560 arduino-nano \
-                   arduino-uno chronos mega-xplained microduino-corerf \
+                   arduino-mega2560 arduino-nano arduino-uno \
+                   atmega328p chronos mega-xplained microduino-corerf \
                    msb-430 msb-430h telosb waspmote-pro wsn430-v1_3b \
                    wsn430-v1_4 z1
 

--- a/tests/pkg_cn-cbor/Makefile
+++ b/tests/pkg_cn-cbor/Makefile
@@ -5,6 +5,7 @@ BOARD_BLACKLIST :=  arduino-duemilanove \
                     arduino-mega2560 \
                     arduino-nano \
                     arduino-uno \
+                    atmega328p \
                     chronos \
                     mega-xplained \
                     microduino-corerf \

--- a/tests/pkg_fatfs/Makefile.ci
+++ b/tests/pkg_fatfs/Makefile.ci
@@ -3,4 +3,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     #

--- a/tests/pkg_fatfs_vfs/Makefile.ci
+++ b/tests/pkg_fatfs_vfs/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     msb-430 \
     msb-430h \
     nucleo-f031k6 \

--- a/tests/pkg_hacl/Makefile
+++ b/tests/pkg_hacl/Makefile
@@ -1,8 +1,8 @@
 include ../Makefile.tests_common
 
 BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
-                   arduino-mega2560 arduino-nano \
-                   arduino-uno chronos mega-xplained microduino-corerf \
+                   arduino-mega2560 arduino-nano arduino-uno \
+                   atmega328p chronos mega-xplained microduino-corerf \
                    msb-430 msb-430h telosb waspmote-pro wsn430-v1_3b \
                    wsn430-v1_4 z1
 

--- a/tests/pkg_heatshrink/Makefile.ci
+++ b/tests/pkg_heatshrink/Makefile.ci
@@ -3,5 +3,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     #

--- a/tests/pkg_libb2/Makefile.ci
+++ b/tests/pkg_libb2/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     chronos \
     mega-xplained \
     microduino-corerf \

--- a/tests/pkg_libcoap/Makefile
+++ b/tests/pkg_libcoap/Makefile
@@ -2,8 +2,8 @@ include ../Makefile.tests_common
 
 # msp430 and avr have problems with int width and libcoaps usage of :x notation in structs
 BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
-                   arduino-mega2560 arduino-nano \
-                   arduino-uno chronos mega-xplained microduino-corerf msb-430 \
+                   arduino-mega2560 arduino-nano arduino-uno atmega328p \
+                   chronos mega-xplained microduino-corerf msb-430 \
                    msb-430h telosb waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
 
 USEMODULE += gnrc_ipv6

--- a/tests/pkg_libcose/Makefile
+++ b/tests/pkg_libcose/Makefile
@@ -2,8 +2,8 @@ include ../Makefile.tests_common
 
 # HACL* only compiles on 32bit platforms
 BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
-                   arduino-mega2560 arduino-nano \
-                   arduino-uno chronos mega-xplained microduino-corerf \
+                   arduino-mega2560 arduino-nano arduino-uno \
+                   atmega328p chronos mega-xplained microduino-corerf \
                    msb-430 msb-430h telosb waspmote-pro wsn430-v1_3b \
                    wsn430-v1_4 z1
 

--- a/tests/pkg_libhydrogen/Makefile
+++ b/tests/pkg_libhydrogen/Makefile
@@ -3,7 +3,7 @@ include ../Makefile.tests_common
 # AVR boards: require avr-gcc >= 7.0 (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=60040)
 # MSP430 boards: invalid alignment of 'hydro_random_context'
 BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
-                   arduino-mega2560 arduino-uno \
+                   arduino-mega2560 arduino-uno atmega328p \
                    mega-xplained microduino-corerf waspmote-pro \
                    chronos msb-430 msb-430h telosb wsn430-v1_3b wsn430-v1_4 z1
 

--- a/tests/pkg_littlefs/Makefile.ci
+++ b/tests/pkg_littlefs/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     i-nucleo-lrwan1 \
     nucleo-f030r8 \
     nucleo-f031k6 \

--- a/tests/pkg_micro-ecc/Makefile.ci
+++ b/tests/pkg_micro-ecc/Makefile.ci
@@ -3,4 +3,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     #

--- a/tests/pkg_microcoap/Makefile.ci
+++ b/tests/pkg_microcoap/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     chronos \
     i-nucleo-lrwan1 \
     msb-430 \

--- a/tests/pkg_monocypher/Makefile
+++ b/tests/pkg_monocypher/Makefile
@@ -2,8 +2,8 @@ include ../Makefile.tests_common
 
 # No 8 bit and 16 bit support
 BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
-                   arduino-mega2560 arduino-nano \
-                   arduino-uno chronos mega-xplained microduino-corerf \
+                   arduino-mega2560 arduino-nano arduino-uno \
+                   atmega328p chronos mega-xplained microduino-corerf \
                    msb-430 msb-430h telosb waspmote-pro wsn430-v1_3b \
                    wsn430-v1_4 z1
 

--- a/tests/pkg_qdsa/Makefile.ci
+++ b/tests/pkg_qdsa/Makefile.ci
@@ -3,5 +3,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     #

--- a/tests/pkg_relic/Makefile
+++ b/tests/pkg_relic/Makefile
@@ -6,6 +6,7 @@ BOARD_BLACKLIST :=  arduino-duemilanove \
                     arduino-mega2560 \
                     arduino-nano \
                     arduino-uno \
+                    atmega328p \
                     chronos \
                     f4vi1 \
                     hifive1 \

--- a/tests/pkg_semtech-loramac/Makefile.ci
+++ b/tests/pkg_semtech-loramac/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     nucleo-f042k6 \
     nucleo-l031k6 \

--- a/tests/pkg_spiffs/Makefile.ci
+++ b/tests/pkg_spiffs/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     i-nucleo-lrwan1 \
     nucleo-f030r8 \
     nucleo-f031k6 \

--- a/tests/pkg_tiny-asn1/Makefile.ci
+++ b/tests/pkg_tiny-asn1/Makefile.ci
@@ -3,4 +3,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     #

--- a/tests/pkg_tinycbor/Makefile
+++ b/tests/pkg_tinycbor/Makefile
@@ -3,7 +3,7 @@ include ../Makefile.tests_common
 # No 8 bit and 16 bit support yet
 BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
                    arduino-mega2560 arduino-nano \
-                   arduino-uno chronos esp32-mh-et-live-minikit \
+                   arduino-uno atmega328p chronos esp32-mh-et-live-minikit \
                    esp32-olimex-evb esp32-wemos-lolin-d32-pro \
                    esp32-wroom-32 esp32-wrover-kit microduino-corerf \
                    mega-xplained msb-430 msb-430h telosb waspmote-pro \

--- a/tests/pkg_tweetnacl/Makefile.ci
+++ b/tests/pkg_tweetnacl/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     mega-xplained \
     microduino-corerf \
     nucleo-f031k6 \

--- a/tests/pkg_u8g2/Makefile.ci
+++ b/tests/pkg_u8g2/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     chronos \
     msb-430 \
     msb-430h \

--- a/tests/pkg_ubasic/Makefile
+++ b/tests/pkg_ubasic/Makefile
@@ -9,6 +9,7 @@ BOARD_BLACKLIST := \
                    arduino-mega2560 \
                    arduino-nano \
                    arduino-uno \
+                   atmega328p \
                    chronos \
                    esp8266-esp-12x \
                    esp8266-olimex-mod \

--- a/tests/pkg_ucglib/Makefile.ci
+++ b/tests/pkg_ucglib/Makefile.ci
@@ -4,5 +4,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     waspmote-pro \
     #

--- a/tests/pkg_wolfcrypt-ed25519-verify/Makefile
+++ b/tests/pkg_wolfcrypt-ed25519-verify/Makefile
@@ -5,8 +5,8 @@ BOARD ?= native
 
 # Only 32-bit targets
 BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
-                   arduino-mega2560 arduino-nano \
-                   arduino-uno chronos esp8266-esp-12x esp8266-olimex-mod \
+                   arduino-mega2560 arduino-nano arduino-uno atmega328p \
+                   chronos esp8266-esp-12x esp8266-olimex-mod \
                    esp8266-sparkfun-thing mega-xplained microduino-corerf \
                    msb-430 msb-430h telosb waspmote-pro \
                    wsn430-v1_3b wsn430-v1_4 z1

--- a/tests/pkg_wolfssl/Makefile
+++ b/tests/pkg_wolfssl/Makefile
@@ -5,8 +5,8 @@ BOARD ?= native
 
 # Only 32-bit targets
 BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
-                   arduino-mega2560 arduino-nano \
-                   arduino-uno chronos esp8266-esp-12x esp8266-olimex-mod \
+                   arduino-mega2560 arduino-nano arduino-uno \
+                   atmega328p chronos esp8266-esp-12x esp8266-olimex-mod \
                    esp8266-sparkfun-thing mega-xplained microduino-corerf \
                    msb-430 msb-430h telosb waspmote-pro \
                    wsn430-v1_3b wsn430-v1_4 z1

--- a/tests/posix_semaphore/Makefile.ci
+++ b/tests/posix_semaphore/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     chronos \
     i-nucleo-lrwan1 \
     mbed_lpc1768 \

--- a/tests/ps_schedstatistics/Makefile.ci
+++ b/tests/ps_schedstatistics/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     chronos \
     i-nucleo-lrwan1 \
     msb-430 \

--- a/tests/pthread_cooperation/Makefile.ci
+++ b/tests/pthread_cooperation/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \

--- a/tests/pthread_flood/Makefile.ci
+++ b/tests/pthread_flood/Makefile.ci
@@ -2,5 +2,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-duemilanove \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     #

--- a/tests/pthread_rwlock/Makefile.ci
+++ b/tests/pthread_rwlock/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     chronos \
     i-nucleo-lrwan1 \
     msb-430 \

--- a/tests/pthread_tls/Makefile.ci
+++ b/tests/pthread_tls/Makefile.ci
@@ -2,4 +2,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-duemilanove \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     #

--- a/tests/riotboot_flashwrite/Makefile.ci
+++ b/tests/riotboot_flashwrite/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-mega2560 \
     arduino-uno \
+    atmega328p \
     chronos \
     i-nucleo-lrwan1 \
     msb-430 \

--- a/tests/rmutex/Makefile.ci
+++ b/tests/rmutex/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     i-nucleo-lrwan1 \
     nucleo-f030r8 \
     nucleo-f031k6 \

--- a/tests/rng/Makefile.ci
+++ b/tests/rng/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     nucleo-f042k6 \
     nucleo-l031k6 \

--- a/tests/saul/Makefile.ci
+++ b/tests/saul/Makefile.ci
@@ -3,4 +3,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     #

--- a/tests/sched_testing/Makefile.ci
+++ b/tests/sched_testing/Makefile.ci
@@ -3,5 +3,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     #

--- a/tests/shell/Makefile.ci
+++ b/tests/shell/Makefile.ci
@@ -3,4 +3,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     #

--- a/tests/slip/Makefile.ci
+++ b/tests/slip/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     i-nucleo-lrwan1 \
     msb-430 \
     msb-430h \

--- a/tests/sntp/Makefile.ci
+++ b/tests/sntp/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     chronos \
     i-nucleo-lrwan1 \
     msb-430 \

--- a/tests/struct_tm_utility/Makefile.ci
+++ b/tests/struct_tm_utility/Makefile.ci
@@ -3,4 +3,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     #

--- a/tests/sys_crypto/Makefile
+++ b/tests/sys_crypto/Makefile
@@ -6,6 +6,7 @@ BOARD_BLACKLIST += arduino-leonardo
 BOARD_BLACKLIST += arduino-mega2560
 BOARD_BLACKLIST += arduino-nano
 BOARD_BLACKLIST += arduino-uno
+BOARD_BLACKLIST += atmega328p
 BOARD_BLACKLIST += chronos
 BOARD_BLACKLIST += mega-xplained
 BOARD_BLACKLIST += microduino-corerf

--- a/tests/sys_irq_handler/Makefile.ci
+++ b/tests/sys_irq_handler/Makefile.ci
@@ -2,5 +2,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-duemilanove \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     #

--- a/tests/thread_cooperation/Makefile.ci
+++ b/tests/thread_cooperation/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     chronos \
     i-nucleo-lrwan1 \
     msb-430 \

--- a/tests/thread_exit/Makefile.ci
+++ b/tests/thread_exit/Makefile.ci
@@ -3,5 +3,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     #

--- a/tests/thread_flags/Makefile.ci
+++ b/tests/thread_flags/Makefile.ci
@@ -3,5 +3,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     #

--- a/tests/thread_float/Makefile.ci
+++ b/tests/thread_float/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     cc2650stk \
     chronos \
     maple-mini \

--- a/tests/thread_msg/Makefile.ci
+++ b/tests/thread_msg/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     nucleo-f042k6 \
     #

--- a/tests/thread_msg_block_race/Makefile.ci
+++ b/tests/thread_msg_block_race/Makefile.ci
@@ -2,5 +2,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-duemilanove \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     #

--- a/tests/thread_msg_seq/Makefile.ci
+++ b/tests/thread_msg_seq/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     nucleo-f042k6 \
     #

--- a/tests/thread_priority_inversion/Makefile.ci
+++ b/tests/thread_priority_inversion/Makefile.ci
@@ -3,5 +3,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     #

--- a/tests/thread_race/Makefile.ci
+++ b/tests/thread_race/Makefile.ci
@@ -3,4 +3,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     #

--- a/tests/unittests/Makefile.ci
+++ b/tests/unittests/Makefile.ci
@@ -9,6 +9,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mkrzero \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     arduino-zero \
     b-l072z-lrwan1 \
     blackpill \

--- a/tests/xtimer_drift/Makefile.ci
+++ b/tests/xtimer_drift/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     nucleo-f042k6 \
     #

--- a/tests/xtimer_hang/Makefile.ci
+++ b/tests/xtimer_hang/Makefile.ci
@@ -3,5 +3,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     #

--- a/tests/xtimer_longterm/Makefile.ci
+++ b/tests/xtimer_longterm/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     nucleo-f042k6 \
     #

--- a/tests/xtimer_msg/Makefile.ci
+++ b/tests/xtimer_msg/Makefile.ci
@@ -3,5 +3,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     #

--- a/tests/xtimer_mutex_lock_timeout/Makefile.ci
+++ b/tests/xtimer_mutex_lock_timeout/Makefile.ci
@@ -3,4 +3,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     #

--- a/tests/xtimer_periodic_wakeup/Makefile.ci
+++ b/tests/xtimer_periodic_wakeup/Makefile.ci
@@ -3,5 +3,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega328p \
     chronos \
     #


### PR DESCRIPTION
### Contribution description

The PR adds the `atmega328p` "board", which allows to use the ATmega328P without any external circuitry except a stable power supply. An ICSP programmer is required to flash the board and an TTL adapter to get the serial terminal. This "board" will be much less convenient to use than an Arduino UNO or an Arduino Nano (which contain this exact MCU), but it can be very convenient as a low-power companion MCU. E.g. the ATmega328p can be used to read out a bunch of slow sensors while the main (and more power demanding) MCU is in lowest power mode. The main MCU could periodically wake up to collect and process the accumulated data from the ATmegea328p.

![ATmega328p DIP package on a breadboard](https://github.com/maribu/images/raw/master/ATmega328p.jpg)

### Testing procedure

- Check the provided documentation
- Using an ICSP try if `make BOARD=atmega328p flash` for `examples/hello-world` works. Refer to the doc of this PR when not using `usbtiny` as programmer
- Using an TTL adapter check if you get the output. (Keep in mind that this is not an Arduino that conveniently reboots upon `make term`...)

As this shares most code with the Arduino UNO, no huge troubles are expected.

### Issues/PRs references

None
