### PR TITLE
make: verify before flash

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -519,9 +519,12 @@ distclean:
 	-@for i in $(USEPKG) ; do "$(MAKE)" -C $(RIOTPKG)/$$i distclean ; done
 	-@rm -rf $(BINDIRBASE)
 
+FLASHER_VERIFY ?= false
+
 define flash-recipe
+  $(call check_cmd,$(FLASHER_VERIFY),Flash verification program)
   $(call check_cmd,$(FLASHER),Flash program)
-  $(FLASHER) $(FFLAGS)
+  $(FLASHER_VERIFY) $(FFLAGS_VERIFY) || $(FLASHER) $(FFLAGS)
 endef
 
 # Do not add dependencies to "flash" directly, use FLASHDEPS, as this is shared

--- a/makefiles/tools/edbg.inc.mk
+++ b/makefiles/tools/edbg.inc.mk
@@ -14,10 +14,13 @@ endif
 # Set offset according to IMAGE_OFFSET if it's defined
 EDBG_ARGS += $(if $(IMAGE_OFFSET),--offset $(IMAGE_OFFSET))
 
-FFLAGS ?= $(EDBG_ARGS) -t $(EDBG_DEVICE_TYPE) -b -v -p -f $(HEXFILE)
+FFLAGS_BASE ?= $(EDBG_ARGS) -t $(EDBG_DEVICE_TYPE) -b -v -f $(HEXFILE)
+FFLAGS ?= $(FFLAGS_BASE) -p
 
 ifeq ($(RIOT_EDBG),$(FLASHER))
   FLASHDEPS += $(RIOT_EDBG)
 endif
 RESET ?= $(EDBG)
 RESET_FLAGS ?= $(EDBG_ARGS) -t $(EDBG_DEVICE_TYPE)
+FLASHER_VERIFY ?= $(EDBG)
+FFLAGS_VERIFY ?= $(FFLAGS_BASE)


### PR DESCRIPTION
### Contribution description

Some flashers (jlink) check if the flash contents already matches the to-be-written binary and if yes, skip re-programming. That saves time and flash cycles.

This PR adds make infrastructure to support that with other flashers, too.
Basically it works by, instead of doing ```$flash $flash_args```, it does ```$flash_verify || $flash $flash_args```.
If no ```FLASH_VERIFY``` is provided, `false` is used thus flashing is done as before.

Another commit implements this for edbg.

### Testing procedure

With an edbg supported board, try ```make all; make flash-only; make flash-only``` and observe that the first flashing actually programs the device, the second skips programming.

Also test non-edbg boards (which don't yet supply "FLASH_VERIFY").

### Issues/PRs references

none
