### PR TITLE
[WIP] tests/test_tools: add a test for the testing tools environment

### DIFF
--- a/dist/pythonlibs/testrunner/spawn.py
+++ b/dist/pythonlibs/testrunner/spawn.py
@@ -36,6 +36,13 @@ def find_exc_origin(exc_info):
 
 
 def setup_child(timeout=10, spawnclass=pexpect.spawnu, env=None, logfile=None):
+    env = env or os.environ
+    env = env.copy()
+    if env.get('RIOT_TERMINAL', 'pyterm') == 'pyterm':
+        termflags = '-p "$(PORT)" -b "$(BAUD)"'
+        termflags += ' --noprefix'
+        env['TERMFLAGS'] = termflags
+
     child = spawnclass("make term", env=env, timeout=timeout,
                        codec_errors='replace', echo=False)
 

--- a/tests/test_tools/Makefile
+++ b/tests/test_tools/Makefile
@@ -1,0 +1,11 @@
+DEVELHELP = 0
+include ../Makefile.tests_common
+
+USEMODULE += shell
+
+TEST_ON_CI_WHITELIST += all
+
+# Disable shell echo and prompt to not have them in the way for testing
+CFLAGS += -DSHELL_NO_ECHO=1 -DSHELL_NO_PROMPT=1
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/test_tools/README.md
+++ b/tests/test_tools/README.md
@@ -1,0 +1,8 @@
+`test_tools`
+============
+
+This test is here to verify the test tools integration with your board and test
+setup.
+
+It verify the assumptions required for testing on the board behaviour
+through make term.

--- a/tests/test_tools/main.c
+++ b/tests/test_tools/main.c
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2019 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @file
+ * @brief       Specific shell implementation for testing the testing tools.
+ *
+ * @author      Gaëtan Harter <gaetan.harter@fu-berlin.de>
+ *
+ */
+
+#include <stdio.h>
+
+#include "shell_commands.h"
+#include "shell.h"
+
+#if !defined(SHELL_NO_ECHO) || !defined(SHELL_NO_PROMPT)
+#error This test assumes no shell echo or shell prompt
+#endif
+
+
+/**
+ * @brief true - do nothing, successfully
+ *
+ * true [ignored command line arguments]
+ *
+ * Description taken from `man true` in coreutils.
+ *
+ * @param[in] argc  Number of arguments
+ * @param[in] argv  Array of arguments
+ *
+ * @return  0
+ *
+ */
+static int cmd_true(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+    return 0;
+}
+
+
+/**
+ * @brief shellping, replies shellpong
+ *
+ * Test if the shell is ready to take commands
+ *
+ * @param[in] argc  Number of arguments
+ * @param[in] argv  Array of arguments
+ *
+ * @return  0
+ *
+ */
+static int cmd_shellping(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+    puts("shellpong");
+    return 0;
+}
+
+
+static const shell_command_t shell_commands[] = {
+    { "shellping", "Just print 'shellpong'", cmd_shellping },
+    { "true", "do nothing, successfully", cmd_true },
+    { NULL, NULL, NULL }
+};
+
+int main(void)
+{
+    puts("Running 'tests_tools' application");
+
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    return 0;
+}

--- a/tests/test_tools/main.c
+++ b/tests/test_tools/main.c
@@ -65,7 +65,53 @@ static int cmd_shellping(int argc, char **argv)
 }
 
 
+static void cmd_increment_usage(char * name)
+{
+    printf("Usage: %s <uint8_t>\n", name);
+    puts("Increments given <uint8_t>");
+}
+
+static void cmd_increment_usage(char * name);
+/**
+ * @brief increment given argument by one
+ *
+ * First argument is read with scanf as an uint8_t and icremented
+ * It will overflow to 0 on UINT8_MAX.
+ *
+ * @param[in] argc  Number of arguments
+ * @param[in] argv  Array of arguments
+ *
+ * @return  0 on success
+ *
+ */
+static int cmd_increment(int argc, char **argv)
+{
+    if (argc != 2) {
+        puts("Invalid number of argument");
+        cmd_increment_usage(argv[0]);
+        return 1;
+    }
+
+    /* It cannot be an uint8_t otherwise it crashes on samr21-xpro...
+     * Do the uint8_t conversion explicitely */
+    unsigned int value;
+    if (1 != sscanf(argv[1], "%u", &value)) {
+        puts("Invalid argument");
+        cmd_increment_usage(argv[0]);
+        return 1;
+    }
+    value = UINT8_MAX & value;
+
+    /* Increment and manually handle overflow */
+    value = (value == UINT8_MAX ? 0 : value +1);
+    printf("%u\n", value);
+
+    return 0;
+}
+
+
 static const shell_command_t shell_commands[] = {
+    { "inc8", "increment first argument uint8_t", cmd_increment },
     { "shellping", "Just print 'shellpong'", cmd_shellping },
     { "true", "do nothing, successfully", cmd_true },
     { NULL, NULL, NULL }

--- a/tests/test_tools/tests/01-run.py
+++ b/tests/test_tools/tests/01-run.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Test behaviour of the test running and the term program interaction."""
+
+import sys
+import pexpect
+from testrunner import run
+
+
+def _shellping(child, timeout=1):
+    """Issue a 'shellping' command.
+
+    Raises a pexpect exception on failure.
+    :param timeout: timeout for the answer
+    """
+    child.sendline('shellping')
+    child.expect_exact('shellpong\r\n', timeout=timeout)
+
+
+def _wait_shell_ready(child, numtries=5):
+    """Wait until the shell is ready by using 'shellping'."""
+    for _ in range(numtries - 1):
+        try:
+            _shellping(child)
+        except pexpect.TIMEOUT:
+            pass
+        else:
+            break
+    else:
+        # This one should fail
+        _shellping(child)
+
+
+def _test_no_local_echo(child):
+    """Verify that there is not local echo while testing."""
+    msg = 'true this should not be echoed'
+    child.sendline(msg)
+    res = child.expect_exact([pexpect.TIMEOUT, msg], timeout=1)
+    assert res == 0, "There should have been a timeout and not match stdin"
+
+
+def testfunc(child):
+    """Run some tests to verify the board under test behaves correctly.
+
+    It currently tests:
+
+    * local echo
+    """
+    child.expect_exact("Running 'tests_tools' application")
+
+    _wait_shell_ready(child)
+
+    # Verify there is no local and remote echo as it is disabled
+    _test_no_local_echo(child)
+
+    # The node should still answer after the previous one
+    _shellping(child)
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))

--- a/tests/test_tools/tests/01-run.py
+++ b/tests/test_tools/tests/01-run.py
@@ -16,6 +16,13 @@ def _shellping(child, timeout=1):
     child.expect_exact('shellpong\r\n', timeout=timeout)
 
 
+def _inc8(child, num):
+    """Execute the 'inc8' command and return the value."""
+    child.sendline('inc8 %u' % num)
+    retline = child.readline()
+    return int(retline.strip())
+
+
 def _wait_shell_ready(child, numtries=5):
     """Wait until the shell is ready by using 'shellping'."""
     for _ in range(numtries - 1):
@@ -44,6 +51,7 @@ def testfunc(child):
     It currently tests:
 
     * local echo
+    * getting some test output without other messages
     """
     child.expect_exact("Running 'tests_tools' application")
 
@@ -54,6 +62,11 @@ def testfunc(child):
 
     # The node should still answer after the previous one
     _shellping(child)
+
+    # Check that 'inc' returns the next integer. Loops at 255
+    for num in (0, 1, 2, 4, 8, 255):
+        retnum = _inc8(child, num)
+        assert retnum == ((num + 1) % 256)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Contribution description

Check the interaction with a board through make term.
It is using a shell without echo or prompt for reference.
    
It currently checks: 
* that there is no local echo
* Get the output of a one line command without other garbage messages.


#### Warning

This is currently not ready for merging as it is waiting for a fix on `make term`.
But it should show the issue. I removed the test from #10952 so made this pull request for tracking the issue.


### Testing procedure

Testing on all the different environments.

There is currently a HACK for `picocom` and `pyterm` which should be correctly fixed.

```
BOARD=native make -C tests/test_tools/ flash test
BOARD=samr21-xpro make -C tests/test_tools/ flash test
BOARD=samr21-xpro RIOT_TERMINAL=picocom make -C tests/test_tools/ flash test
BOARD=samr21-xpro RIOT_TERMINAL=socat make -C tests/test_tools/ test
```

### Issues/PRs references

Test split out of https://github.com/RIOT-OS/RIOT/pull/10952 and depending on it.
Found while writing tests in https://github.com/RIOT-OS/RIOT/pull/10949

Depends on : "adding make rawterm"