### PR TITLE
pyterm: add /sleep function

### DIFF
--- a/dist/tools/pyterm/pyterm
+++ b/dist/tools/pyterm/pyterm
@@ -303,6 +303,14 @@ class SerCmd(cmd.Cmd):
         date = time.strftime("%Y-%m-%d %H:%M:%S")
         return ["%s" % (date)]
 
+    def do_PYTERM_sleep(self, line):
+        """Pyterm command: Sleep for n seconds.
+        """
+        if line:
+            time.sleep(float(line))
+        else:
+            self.logger.error("sleep: missing operand")
+
     def do_PYTERM_reset(self, line):
         """Pyterm command: Send a reset to the node.
         """


### PR DESCRIPTION
The init_cmd feature is quite handy for automated pyterm runs but there
is no delay between the commands, so they are all written to the target at once.

This adds a /sleep function that can be added between init_cmd commands
to prevent them from overflowing the RX buffer on the target.