### PR TITLE
boards: add support for Phytec 'reel board'

### DIFF
--- a/boards/reel/Makefile
+++ b/boards/reel/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/reel/Makefile.dep
+++ b/boards/reel/Makefile.dep
@@ -1,0 +1,6 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+  USEMODULE += mma8x5x
+endif
+
+include $(RIOTBOARD)/common/nrf52/Makefile.dep

--- a/boards/reel/Makefile.features
+++ b/boards/reel/Makefile.features
@@ -1,0 +1,6 @@
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_uart
+
+include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/reel/Makefile.include
+++ b/boards/reel/Makefile.include
@@ -1,0 +1,9 @@
+# specific CPU model used
+CPU_MODEL = nrf52840xxaa
+
+# set programming environment
+DEBUG_ADAPTER ?= dap
+PROGRAMMER ?= openocd
+
+# use the common nrf52 config for the rest
+include $(RIOTBOARD)/common/nrf52/Makefile.include

--- a/boards/reel/board.c
+++ b/boards/reel/board.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2019 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_reel
+ * @{
+ *
+ * @file
+ * @brief       Board initialization for the Phytec 'reel board'
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "board.h"
+
+void board_init(void)
+{
+    /* setup on-board LEDs */
+    NRF_P0->DIRSET = (LED_MASK_P0);
+    NRF_P0->OUTSET = (LED_MASK_P0);
+    NRF_P1->DIRSET = (LED_MASK_P1);
+    NRF_P1->OUTSET = (LED_MASK_P1);
+
+    /* initialize the CPU */
+    cpu_init();
+}

--- a/boards/reel/doc.txt
+++ b/boards/reel/doc.txt
@@ -1,0 +1,14 @@
+/**
+@defgroup    boards_reel Phytec reel board
+@ingroup     boards
+@brief       Support for the PHYTEC 'reel board'
+
+## Overview
+
+The 'reel board' is an IoT development platform based on Nordic's nRF52840 SoC.
+It was developed by PHYTEC in cooperation with the Zephyr project.
+
+@see https://www.phytec.eu/product-eu/internet-of-things/reelboard/
+@see https://docs.zephyrproject.org/latest/boards/arm/reel_board/doc/reel_board.html
+
+*/

--- a/boards/reel/include/board.h
+++ b/boards/reel/include/board.h
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2019 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_reel
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration for the Phytec 'reel board'
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    LED pin configuration
+ * @{
+ */
+#define LED0_PIN                GPIO_PIN(0, 11)
+#define LED1_PIN                GPIO_PIN(0, 12)
+#define LED2_PIN                GPIO_PIN(1, 9)
+#define LED3_PIN                GPIO_PIN(0, 13)
+
+#define LED0_MASK               (1 << 11)
+#define LED1_MASK               (1 << 12)
+#define LED2_MASK               (1 << 9)
+#define LED3_MASK               (1 << 13)
+#define LED_MASK_P0             (LED0_MASK | LED1_MASK | LED3_MASK)
+#define LED_MASK_P1             (LED2_MASK)
+
+#define LED0_ON                 (NRF_P0->OUTCLR = LED0_MASK)
+#define LED0_OFF                (NRF_P0->OUTSET = LED0_MASK)
+#define LED0_TOGGLE             (NRF_P0->OUT   ^= LED0_MASK)
+
+#define LED1_ON                 (NRF_P0->OUTCLR = LED1_MASK)
+#define LED1_OFF                (NRF_P0->OUTSET = LED1_MASK)
+#define LED1_TOGGLE             (NRF_P0->OUT   ^= LED1_MASK)
+
+#define LED2_ON                 (NRF_P1->OUTCLR = LED2_MASK)
+#define LED2_OFF                (NRF_P1->OUTSET = LED2_MASK)
+#define LED2_TOGGLE             (NRF_P1->OUT   ^= LED2_MASK)
+
+#define LED3_ON                 (NRF_P0->OUTCLR = LED3_MASK)
+#define LED3_OFF                (NRF_P0->OUTSET = LED3_MASK)
+#define LED3_TOGGLE             (NRF_P0->OUT   ^= LED3_MASK)
+/** @} */
+
+/**
+ * @name    Button pin configuration
+ * @{
+ */
+#define BTN0_PIN                GPIO_PIN(0, 7)
+#define BTN0_MODE               GPIO_IN_PU
+/** @} */
+
+/**
+ * @name    Electronic paper display configuration (SSD1673fb)
+ * @{
+ */
+#define SSD1673_SPI             SPI_DEV(0)
+#define SSD1673_CS              GPIO_PIN(0, 17)
+#define SSD1673_BUSY            GPIO_PIN(0, 14)
+#define SSD1673_RESET           GPIO_PIN(0, 15)
+#define SSD1673_DC_INPUT        GPIO_PIN(0, 16)
+/** @} */
+
+/**
+ * @name    Humidity and temperature sensor configuration (HDC1010)
+ * @{
+ */
+#define HDC1010_PARAM_I2C       I2C_DEV(0)
+#define HDC1010_PARAM_ADDR      (0x43)
+#define HDC1010_PIN_DRDY        GPIO_PIN(0, 22)
+/** @} */
+
+/**
+ * @name    Digital accelerometer configuration (MMA8652FC)
+ * @{
+ */
+#define MMA8X5X_PARAM_I2C       I2C_DEV(0)
+#define MMA8X5X_PARAM_ADDR      (0x1d)
+#define MMA8X5X_PARAM_PIN_INT1  GPIO_PIN(0, 24)
+#define MMA8X5X_PARAM_PIN_INT2  GPIO_PIN(0, 25)
+/** @} */
+
+/**
+ * @name    Digital proximity and ambient light sensor configuration (ADPS9960)
+ */
+#define ADPS9960_PARAM_I2C      I2C_DEV(0)
+#define ADPS9960_PARAM_ADDR     (0x29)
+#define ADPS9960_PARAM_PIN_INT  GPIO_PIN(0, 23)
+/** @} */
+
+/**
+ * @brief   Initialize board specific hardware
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/reel/include/gpio_params.h
+++ b/boards/reel/include/gpio_params.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2019 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_reel
+ * @{
+ *
+ * @file
+ * @brief       Configuration of SAUL mapped GPIO pins
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   LED and button mapping
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name  = "LED Red (RGB, front)",
+        .pin   = LED0_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name  = "LED Green (RGB, front)",
+        .pin   = LED1_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name  = "LED Blue (RGB, front)",
+        .pin   = LED2_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name  = "LED Green (back)",
+        .pin   = LED3_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name  = "Button",
+        .pin   = BTN0_PIN,
+        .mode  = BTN0_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+};
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/reel/include/periph_conf.h
+++ b/boards/reel/include/periph_conf.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2019 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_reel
+ * @{
+ *
+ * @file
+ * @brief       Peripheral configuration for the Phytec 'reel board'
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+#include "cfg_clock_32_1.h"
+#include "cfg_rtt_default.h"
+#include "cfg_timer_default.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev        = NRF_UARTE0,
+        .rx_pin     = GPIO_PIN(0,8),
+        .tx_pin     = GPIO_PIN(0,6),
+        .rts_pin    = (uint8_t)GPIO_UNDEF,
+        .cts_pin    = (uint8_t)GPIO_UNDEF,
+        .irqn       = UARTE0_UART0_IRQn,
+    },
+};
+
+#define UART_0_ISR          (isr_uart0)
+
+#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+/** @} */
+
+/**
+ * @name    SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .dev  = NRF_SPI0,
+        .sclk = GPIO_PIN(0, 19),
+        .mosi = GPIO_PIN(0, 20),
+        .miso = GPIO_PIN(0, 21),
+    }
+};
+
+#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+/** @} */
+
+/**
+ * @name    I2C configuration
+ * @{
+ */
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev = NRF_TWIM1,
+        .scl = GPIO_PIN(0, 27),
+        .sda = GPIO_PIN(0, 26),
+        .speed = I2C_SPEED_NORMAL
+    }
+};
+#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */


### PR DESCRIPTION
### Contribution description
Phyted and the Zephyr community designed and build this nice board, so it would be a shame not to support RIOT for it :-)

Infos about the board:
- https://www.phytec.eu/product-eu/internet-of-things/reelboard/
- https://docs.zephyrproject.org/latest/boards/arm/reel_board/doc/reel_board.html

If I have seen correctly, there are no RIOT drivers for the HDC1010 (humidity and temperature), ADPS9960 (light), and SSD1673 (e-ink display) devices in RIOT's master. Though I included there pin mappings, one can currently not use them. But hopefully drivers will be available soon.

Everything else should be pretty straight-forward...

### Testing procedure
Running the `default` example (use `BOARD=reel`) with SAUL gives access to all configured components of the board. Else simply run the complete test-suite and make sure everything passes.

### Issues/PRs references
none