### PR TITLE
makefiles/murdock.inc.mk: do not overwrite FLASHFILE if set

### DIFF
--- a/makefiles/murdock.inc.mk
+++ b/makefiles/murdock.inc.mk
@@ -2,8 +2,8 @@
 # This file contains helper targets used by the CI.
 #
 
-# (HACK) get actual flash binary from FFLAGS.
-FLASHFILE:=$(filter $(HEXFILE) $(ELFFILE:.elf=.bin) $(ELFFILE),$(FFLAGS))
+# (HACK) get actual flash binary from FFLAGS if not defined.
+FLASHFILE ?= $(filter $(HEXFILE) $(ELFFILE:.elf=.bin) $(ELFFILE),$(FFLAGS))
 
 #
 # This target will run "make test" on the CI cluster.


### PR DESCRIPTION
### Contribution description

If FLASHFILE is set keep the original value.

It changes the variable from an immediate to a deferred variable but if
murdocks keeps working there is no issue.

I forgot to also put this change when I did https://github.com/RIOT-OS/RIOT/pull/11084 otherwise `FLASHFILE` is not usable.

### Testing procedure

Murdock keeps running tests on samr21-xpro, and also runs the tests/riotboot test on samr21-xpro.

This allows setting FLASHFILE in the build system without having the value overwritten.
Testing can be done through https://github.com/RIOT-OS/RIOT/pull/11089 that uses this pull request.

Also, locally you can verify the value of FLASHFILE is the same for `samr21-xpro`:

```
BOARD=samr21-xpro make --no-print-directory -C examples/default/ info-debug-variable-FLASHFILE
/home/harter/work/git/RIOT/examples/default/bin/samr21-xpro/default.bin
BOARD=samr21-xpro make --no-print-directory -C tests/riotboot info-debug-variable-FLASHFILE
/home/harter/work/git/RIOT/tests/riotboot/bin/samr21-xpro/tests_riotboot-slot0-combined.bin
```

### Issues/PRs references

Part of https://github.com/RIOT-OS/RIOT/pull/8838
Needed by https://github.com/RIOT-OS/RIOT/pull/11089
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
