### PR TITLE
sys/net/application_layer/nanocoap: Add path prefix option

### DIFF
--- a/examples/nanocoap_server/README.md
+++ b/examples/nanocoap_server/README.md
@@ -63,15 +63,23 @@ The link-layer address in this case is "fe80::e42a:1aff:feca:10ec", the only
 Testing
 =======
 
-The CoAP server exposes 3 different resources:
+The CoAP server exposes 6 different resources:
 
 * `/.well-known/core`: returns the list of available resources on the server.
 This is part of the CoAP specifications. It works only with GET requests.
+* `/echo/`: will match any request that begins with '/echo/' and will echo
+  the remaining part of the URI path. Meant to show how the prefix works. It
+  works only with GET requests.
 * `/riot/board`: returns the name of the board running the server. It works
 only with GET requests.
 * `/riot/value`: returns the value of an internal variable of the server. It
 works with GET requests and also with PUT and POST requests, which means that
 this value can be updated from a client.
+* `/riot/ver`: returns the current RIOT version. Meant to show a block2 reply.
+  It works only with GET requests.
+* `/sha256`: creates a hash with the received payloads. It is meant to show
+  block1 support. It returns the hash when no more blocks are pending. Only
+  works with POST.
 
 There are multiple external CoAP clients you can use to easily test the server
 running on native.

--- a/examples/nanocoap_server/coap_handler.c
+++ b/examples/nanocoap_server/coap_handler.c
@@ -21,6 +21,21 @@ static const uint8_t block2_intro[] = "This is RIOT (Version: ";
 static const uint8_t block2_board[] = " running on a ";
 static const uint8_t block2_mcu[] = " board with a ";
 
+static ssize_t _echo_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len, void *context)
+{
+    (void)context;
+    char uri[NANOCOAP_URI_MAX];
+
+    if (coap_get_uri_path(pkt, (uint8_t *)uri) <= 0) {
+        return coap_reply_simple(pkt, COAP_CODE_INTERNAL_SERVER_ERROR, buf,
+                                 len, COAP_FORMAT_TEXT, NULL, 0);
+    }
+    char *sub_uri = uri + strlen("/echo/");
+    size_t sub_uri_len = strlen(sub_uri);
+    return coap_reply_simple(pkt, COAP_CODE_CONTENT, buf, len, COAP_FORMAT_TEXT,
+                             (uint8_t *)sub_uri, sub_uri_len);
+}
+
 static ssize_t _riot_board_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len, void *context)
 {
     (void)context;
@@ -145,6 +160,7 @@ ssize_t _sha256_handler(coap_pkt_t* pkt, uint8_t *buf, size_t len, void *context
 /* must be sorted by path (ASCII order) */
 const coap_resource_t coap_resources[] = {
     COAP_WELL_KNOWN_CORE_DEFAULT_HANDLER,
+    { "/echo/", COAP_GET | COAP_MATCH_SUBTREE, _echo_handler, NULL },
     { "/riot/board", COAP_GET, _riot_board_handler, NULL },
     { "/riot/value", COAP_GET | COAP_PUT | COAP_POST, _riot_value_handler, NULL },
     { "/riot/ver", COAP_GET, _riot_block2_handler, NULL },

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -26,6 +26,25 @@
  * capital precede lower case). nanocoap provides the
  * COAP_WELL_KNOWN_CORE_DEFAULT_HANDLER entry for `/.well-known/core`.
  *
+ * ### Path matching ###
+ * By default the URI-path of an incoming request should match exactly one of
+ * the registered resources. But also, a resource can be configured to
+ * match just a prefix of the URI-path of the request by adding the
+ * @ref COAP_MATCH_SUBTREE option to coap_resource_t::methods.
+ *
+ * For example, if a resource is configured with a
+ * @ref coap_resource_t::path "path" `/resource01` and the
+ * @ref COAP_MATCH_SUBTREE option is used it would match any of `/resource01/`,
+ * `/resource01/sub/path`, `/resource01alt`.
+ *
+ * If the behavior of matching `/resource01alt` is not wanted and only subtrees
+ * are wanted to match, the path should be `/resource01/`.
+ *
+ * If in addition just `/resource01` is wanted to match, together with any
+ * subtrees of `/resource01/`, then a first resource with the path `/resource01`
+ * and exact matching should be register, and then a second one with the path
+ * `/resource01/` and subtree matching.
+ *
  * ### Handler functions ###
  *
  * For each resource, you must implement a ::coap_handler_t handler function.
@@ -170,6 +189,8 @@ extern "C" {
 #define COAP_POST               (0x2)
 #define COAP_PUT                (0x4)
 #define COAP_DELETE             (0x8)
+#define COAP_MATCH_SUBTREE      (0x8000) /**< Path is considered as a prefix
+                                              when matching */
 /** @} */
 
 /**
@@ -1064,6 +1085,23 @@ static inline unsigned coap_method2flag(unsigned code)
 {
     return (1 << (code - 1));
 }
+
+/**
+ * @brief   Checks if a CoAP resource path matches a given URI
+ *
+ * Builds on strcmp() with rules specific to URI path matching
+ *
+ * @note This function is not intended for application use.
+ * @internal
+ *
+ * @param[in] resource CoAP resource to check
+ * @param[in] uri Null-terminated string URI to compare
+ *
+ * @return 0  if the resource path matches the URI
+ * @return <0 if the resource path sorts before the URI
+ * @return >0 if the resource path sorts after the URI
+ */
+int coap_match_path(const coap_resource_t *resource, uint8_t *uri);
 
 #if defined(MODULE_GCOAP) || defined(DOXYGEN)
 /**

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -399,7 +399,7 @@ static int _find_resource(coap_pkt_t *pdu, const coap_resource_t **resource_ptr,
                 resource++;
             }
 
-            int res = strcmp((char *)&uri[0], resource->path);
+            int res = coap_match_path(resource, uri);
             if (res > 0) {
                 continue;
             }

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -146,6 +146,21 @@ int coap_parse(coap_pkt_t *pkt, uint8_t *buf, size_t len)
     return 0;
 }
 
+int coap_match_path(const coap_resource_t *resource, uint8_t *uri)
+{
+    assert(resource && uri);
+    int res;
+
+    if (resource->methods & COAP_MATCH_SUBTREE) {
+        int len = strlen(resource->path);
+        res = strncmp((char *)uri, resource->path, len);
+    }
+    else {
+        res = strcmp((char *)uri, resource->path);
+    }
+    return res;
+}
+
 uint8_t *coap_find_option(const coap_pkt_t *pkt, unsigned opt_num)
 {
     const coap_optpos_t *optpos = pkt->options;
@@ -323,7 +338,7 @@ ssize_t coap_handle_req(coap_pkt_t *pkt, uint8_t *resp_buf, unsigned resp_buf_le
             continue;
         }
 
-        int res = strcmp((char *)uri, resource->path);
+        int res = coap_match_path(resource, uri);
         if (res > 0) {
             continue;
         }


### PR DESCRIPTION
### Contribution description
Right now the path matching in nanocoap and gcoap is performed by using `strcmp` on the request URI-path and the registered path of the resource. There are some cases where all the requests with a certain prefix want to be passed to one handler for further processing.

For example a [LWM2M](https://www.omaspecworks.org/what-is-oma-specworks/iot/lightweight-m2m-lwm2m/) client may need that all the requests that have the prefix `/lwm2m/` are redirected to a single handler, instead of having to register in runtime a path per resource for every instance of every object (e.g. `/lwm2m/3111/0/5850`)

This adds path options to the coap resource and modifies the way the path is matched on a request. This gives the option to use the resource path string as a prefix to redirect all the requests that match that prefix to that handler.

The nanocoap_server example is modified to include a resource that registers a prefix. ~This PR also adapts all coap_resource_t structure initializations to use the field names.~

### Testing procedure
Run the nanocoap server example, it includes now an `/echo/` resource that uses the prefix matching.

### Issues/PRs references
None.