### PR TITLE
[TRACKING] buildsystem: introduce "make rawterm"

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -543,8 +543,10 @@ flash-only: $(FLASHDEPS)
 preflash: $(BUILD_BEFORE_FLASH)
 	$(PREFLASHER) $(PREFFLAGS)
 
+rawterm: $(filter flash, $(MAKECMDGOALS)) $(TERMDEPS)
+	$(RAWTERMPROG) $(RAWTERMFLAGS)
+
 term: $(filter flash, $(MAKECMDGOALS)) $(TERMDEPS)
-	$(call check_cmd,$(TERMPROG),Terminal program)
 	$(TERMPROG) $(TERMFLAGS)
 
 list-ttys:

--- a/boards/common/msba2/Makefile.include
+++ b/boards/common/msba2/Makefile.include
@@ -19,6 +19,8 @@ PORT_LINUX ?= /dev/ttyUSB0
 # This does not make a lot of sense, but it has the same value as the previous code
 PORT_DARWIN ?= /dev/tty.usbserial-ARM
 
+# The -tg option is specific to pyterm so we are forced to use it.
+RIOT_TERMINAL = pyterm
 TERMFLAGS += -tg -p "$(PORT)"
 include $(RIOTMAKE)/tools/serial.inc.mk
 

--- a/boards/lobaro-lorabox/Makefile.include
+++ b/boards/lobaro-lorabox/Makefile.include
@@ -10,6 +10,8 @@ PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
 # setup serial terminal
+# The --set-rts option is specific to pyterm so we are forced to use it.
+RIOT_TERMINAL = pyterm
 include $(RIOTMAKE)/tools/serial.inc.mk
 
 FLASHER = $(RIOTTOOLS)/stm32loader/stm32loader.py

--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -60,7 +60,7 @@ NATIVE_FLAGS += $(PORT)  # Flags to the native executable
 
 # checkout the "sigint" flags. Without it ctrl-c just exits socat, which breaks
 # the pipe on the RIOT executable causing SIGPIPE and a dirty exit.
-SOCAT_REMOTE = exec:"$(NATIVE_EXEC) $(NATIVE_FLAGS)",sigint $(PORT)
+SOCAT_REMOTE = exec:"$(NATIVE_EXEC) $(NATIVE_FLAGS)",sigint,pty $(PORT)
 
 include $(RIOTMAKE)/tools/serial.inc.mk
 

--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -40,7 +40,30 @@ else
   export DEBUGGER ?= gdb
 endif
 
-TERMPROG ?= $(ELFFILE)
+# set the tap interface for term/valgrind
+# FIXME: this is not a port. It should be renames as "NET_INTERFACE" or
+# something else that is more honest.
+ifneq (,$(filter netdev_default gnrc_netdev_default,$(USEMODULE)))
+  export PORT ?= tap0
+else
+  export PORT =
+endif
+
+RIOT_TERMINAL ?= rlwrap
+# Silence the "Warning: no PORT set!" message
+# PORT ?= not-applicable
+# Wrapping native in socat disables line buffering so the behavior of native
+# is more similar to that of bare-metal RIOT.
+RIOT_RAWTERMINAL ?= socat
+NATIVE_EXEC ?= $(ELFFILE)
+NATIVE_FLAGS += $(PORT)  # Flags to the native executable
+
+# checkout the "sigint" flags. Without it ctrl-c just exits socat, which breaks
+# the pipe on the RIOT executable causing SIGPIPE and a dirty exit.
+SOCAT_REMOTE = exec:"$(NATIVE_EXEC) $(NATIVE_FLAGS)",sigint $(PORT)
+
+include $(RIOTMAKE)/tools/serial.inc.mk
+
 export FLASHER = true
 export VALGRIND ?= valgrind
 export CGANNOTATE ?= cg_annotate
@@ -93,14 +116,6 @@ else
 endif
 export LINKFLAGS += -ffunction-sections
 
-# set the tap interface for term/valgrind
-ifneq (,$(filter netdev_default gnrc_netdev_default,$(USEMODULE)))
-  export PORT ?= tap0
-else
-  export PORT =
-endif
-
-TERMFLAGS := $(PORT) $(TERMFLAGS)
 
 export ASFLAGS =
 ifeq ($(shell basename $(DEBUGGER)),lldb)
@@ -117,7 +132,7 @@ debug-valgrind-server: export VALGRIND_FLAGS ?= --vgdb=yes --vgdb-error=0 -v \
 	--leak-check=full --track-origins=yes --fullpath-after=$(RIOTBASE) \
 	--read-var-info=yes
 term-cachegrind: export CACHEGRIND_FLAGS += --tool=cachegrind
-term-gprof: TERMPROG = GMON_OUT_PREFIX=gmon.out $(ELFFILE)
+term-gprof: export GMON_OUT_PREFIX=gmon.out
 all-valgrind: export CFLAGS += -DHAVE_VALGRIND_H -g3
 all-valgrind: export NATIVEINCLUDES += $(shell pkg-config valgrind --cflags)
 all-debug: export CFLAGS += -g3

--- a/boards/ruuvitag/Makefile.include
+++ b/boards/ruuvitag/Makefile.include
@@ -3,8 +3,7 @@ CPU_MODEL = nrf52832xxaa
 
 # for this board, we are using Segger's RTT as default terminal interface
 USEMODULE += stdio_rtt
-TERMPROG = $(RIOTTOOLS)/jlink/jlink.sh
-TERMFLAGS = term_rtt
+RIOT_RAWTERMINAL = jlink
 
 # use shared Makefile.include
 include $(RIOTBOARD)/common/nrf52xxxdk/Makefile.include

--- a/boards/thingy52/Makefile.include
+++ b/boards/thingy52/Makefile.include
@@ -3,8 +3,7 @@ CPU_MODEL = nrf52832xxaa
 
 # for this board, we are using Segger's RTT as default terminal interface
 USEMODULE += stdio_rtt
-TERMPROG = $(RIOTTOOLS)/jlink/jlink.sh
-TERMFLAGS = term_rtt
+RIOT_RAWTERMINAL = jlink
 
 # use shared Makefile.include
 include $(RIOTBOARD)/common/nrf52/Makefile.include

--- a/dist/pythonlibs/testrunner/spawn.py
+++ b/dist/pythonlibs/testrunner/spawn.py
@@ -36,7 +36,7 @@ def find_exc_origin(exc_info):
 
 
 def setup_child(timeout=10, spawnclass=pexpect.spawnu, env=None, logfile=None):
-    child = spawnclass("make term", env=env, timeout=timeout,
+    child = spawnclass("make rawterm", env=env, timeout=timeout,
                        codec_errors='replace', echo=False)
 
     # on many platforms, the termprog needs a short while to be ready...

--- a/examples/gnrc_border_router/Makefile
+++ b/examples/gnrc_border_router/Makefile
@@ -35,7 +35,7 @@ ifeq (,$(filter native,$(BOARD)))
   CFLAGS += -DETHOS_BAUDRATE=$(ETHOS_BAUDRATE) -DUSE_ETHOS_FOR_STDIO
 else
   GNRC_NETIF_NUMOF := 2
-  TERMFLAGS += -z [::1]:17754
+  NATIVE_FLAGS += -z [::1]:17754
   USEMODULE += socket_zep
 endif
 

--- a/makefiles/info.inc.mk
+++ b/makefiles/info.inc.mk
@@ -80,6 +80,8 @@ info-build:
 	@echo ''
 	@echo 'TERMPROG:  $(TERMPROG)'
 	@echo 'TERMFLAGS: $(TERMFLAGS)'
+	@echo 'RAWTERMPROG:  $(RAWTERMPROG)'
+	@echo 'RAWTERMFLAGS: $(RAWTERMFLAGS)'
 	@echo 'PORT:      $(PORT)'
 	@echo ''
 	@echo 'DEBUGGER:       $(DEBUGGER)'

--- a/makefiles/tools/jlink.inc.mk
+++ b/makefiles/tools/jlink.inc.mk
@@ -9,3 +9,8 @@ export FFLAGS ?= flash $(FLASHFILE)
 export DEBUGGER_FLAGS ?= debug $(ELFFILE)
 export DEBUGSERVER_FLAGS ?= debug-server
 export RESET_FLAGS ?= reset
+
+ifeq ($(RIOT_RAWTERMINAL),jlink)
+  RAWTERMPROG  ?= $(RIOTTOOLS)/jlink/jlink.sh
+  RAWTERMFLAGS ?= term_rtt
+endif

--- a/makefiles/tools/serial.inc.mk
+++ b/makefiles/tools/serial.inc.mk
@@ -23,4 +23,7 @@ else ifeq ($(RIOT_TERMINAL),socat)
 else ifeq ($(RIOT_TERMINAL),picocom)
   TERMPROG  ?= picocom
   TERMFLAGS ?= --nolock --imap lfcrlf --baud "$(BAUD)" "$(PORT)"
+else ifeq ($(RIOT_TERMINAL),custom)
+  # Do nothing. This name is reserved so that TERMFLAGS does not get
+  # set if the user wants to override TERMPROG.
 endif

--- a/makefiles/tools/serial.inc.mk
+++ b/makefiles/tools/serial.inc.mk
@@ -16,6 +16,11 @@ RIOT_TERMINAL ?= pyterm
 ifeq ($(RIOT_TERMINAL),pyterm)
   TERMPROG  ?= $(RIOTTOOLS)/pyterm/pyterm
   TERMFLAGS ?= -p "$(PORT)" -b "$(BAUD)"
+else ifeq ($(RIOT_TERMINAL),rlwrap)
+  TERMPROG  ?= $(RIOT_TERMINAL)
+  RLWRAP_PROMPT ?= -pPurple -S 'RIOT $$ '
+  RLWRAP_FLAGS ?= -a -C RIOT-$(BOARD)
+  TERMFLAGS  ?= $(RLWRAP_PROMPT) $(RLWRAP_FLAGS) $(RAWTERMPROG) $(RAWTERMFLAGS)
 else ifeq ($(RIOT_TERMINAL),picocom)
   TERMPROG  ?= picocom
   TERMFLAGS ?= --nolock --imap lfcrlf --baud "$(BAUD)" "$(PORT)"

--- a/makefiles/tools/serial.inc.mk
+++ b/makefiles/tools/serial.inc.mk
@@ -16,14 +16,24 @@ RIOT_TERMINAL ?= pyterm
 ifeq ($(RIOT_TERMINAL),pyterm)
   TERMPROG  ?= $(RIOTTOOLS)/pyterm/pyterm
   TERMFLAGS ?= -p "$(PORT)" -b "$(BAUD)"
-else ifeq ($(RIOT_TERMINAL),socat)
-  SOCAT_OUTPUT ?= -
-  TERMPROG ?= $(RIOT_TERMINAL)
-  TERMFLAGS ?= $(SOCAT_OUTPUT) open:$(PORT),b$(BAUD),echo=0,raw
 else ifeq ($(RIOT_TERMINAL),picocom)
   TERMPROG  ?= picocom
   TERMFLAGS ?= --nolock --imap lfcrlf --baud "$(BAUD)" "$(PORT)"
 else ifeq ($(RIOT_TERMINAL),custom)
+  # Do nothing. This name is reserved so that TERMFLAGS does not get
+  # set if the user wants to override TERMPROG.
+endif
+
+RIOT_RAWTERMINAL ?= socat
+ifeq ($(RIOT_RAWTERMINAL),socat)
+  SOCAT_LOCAL ?= STDIO,icanon=0,echo=0,escape=0x04
+  SOCAT_REMOTE ?= open:$(PORT),b$(BAUD),echo=0,raw
+  RAWTERMPROG ?= $(RIOT_RAWTERMINAL)
+  RAWTERMFLAGS ?= $(SOCAT_LOCAL) $(SOCAT_REMOTE)
+else ifeq ($(RIOT_RAWTERMINAL),picocom)
+  RAWTERMPROG  ?= picocom
+  RAWTERMFLAGS ?= --nolock -q --imap lfcrlf --baud "$(BAUD)" "$(PORT)"
+else ifeq ($(RIOT_RAWTERMINAL),custom)
   # Do nothing. This name is reserved so that TERMFLAGS does not get
   # set if the user wants to override TERMPROG.
 endif

--- a/makefiles/vars.inc.mk
+++ b/makefiles/vars.inc.mk
@@ -72,8 +72,24 @@ export GIT_CACHE_DIR         # path to git-cache cache directory
 export FLASHER               # The command to call on "make flash".
 export FFLAGS                # The parameters to supply to FLASHER.
 export FLASH_ADDR            # Define an offset to flash code into ROM memory.
-# TERMPROG                   # The command to call on "make term".
+
+# --- Terminal Access --- #
+
+# RIOT_TERMINAL              # Preset to use for the "user friendly" terminal.
+                             # TERMPROG and TERMFLAGS will be set according to
+                             # RIOT_TERMINAL. The special name "custom" can be
+                             # used to leave these variables undefined.
+# TERMPROG                   # The command to call on "make term". This should be
+                             # "user friendly" terminal, with line editing-history, etc.
+                             # By default, rlwrap is used around the RAWTERM program.
 # TERMFLAGS                  # Additional parameters to supply to TERMPROG.
+
+# RIOT_RAWTERMINAL           # Like RIOT_TERMINAL but for the raw/testing terminal.
+# RAWTERMPROG                # The command to call on "make rawterm". This terminal
+                             # is used for testing. It should have no buffering,
+                             # and no translation or modification of input or output.
+# RAWTERMFLAGS               # Additional parameters to supply to RAWTERMPROG.
+
 export PORT                  # The port to connect the TERMPROG to.
 export ELFFILE               # The unstripped result of the compilation.
 export HEXFILE               # The stripped result of the compilation.

--- a/makefiles/vars.inc.mk
+++ b/makefiles/vars.inc.mk
@@ -90,6 +90,10 @@ export FLASH_ADDR            # Define an offset to flash code into ROM memory.
                              # and no translation or modification of input or output.
 # RAWTERMFLAGS               # Additional parameters to supply to RAWTERMPROG.
 
+# --- Native-specific --- #
+# NATIVE_EXEC                # Executable for native builds.
+# NATIVE_FLAGS               # Command line arguments for the native executable.
+
 export PORT                  # The port to connect the TERMPROG to.
 export ELFFILE               # The unstripped result of the compilation.
 export HEXFILE               # The stripped result of the compilation.

--- a/tests/gnrc_ipv6_ext/Makefile
+++ b/tests/gnrc_ipv6_ext/Makefile
@@ -19,7 +19,7 @@ export TAP ?= tap0
 ifeq (native,$(BOARD))
   USEMODULE += netdev_tap
 
-  TERMFLAGS ?= $(TAP)
+  NATIVE_FLAGS ?= $(TAP)
 else
   USEMODULE += ethos
 

--- a/tests/gnrc_rpl_srh/Makefile
+++ b/tests/gnrc_rpl_srh/Makefile
@@ -22,7 +22,7 @@ CFLAGS += -DOUTPUT=TEXT
 ifeq (native,$(BOARD))
   USEMODULE += netdev_tap
 
-  TERMFLAGS ?= $(TAP)
+  NATIVE_FLAGS ?= $(TAP)
 else
   USEMODULE += ethos
 

--- a/tests/socket_zep/Makefile
+++ b/tests/socket_zep/Makefile
@@ -10,6 +10,6 @@ USEMODULE += socket_zep
 
 CFLAGS += -DDEVELHELP
 
-TERMFLAGS ?= -z [::1]:17754
+NATIVE_FLAGS ?= -z [::1]:17754
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/socket_zep/tests/01-run.py
+++ b/tests/socket_zep/tests/01-run.py
@@ -54,7 +54,7 @@ def testfunc(child):
 
 
 if __name__ == "__main__":
-    os.environ['TERMFLAGS'] = "-z [%s]:%d,[%s]:%d" % (
+    os.environ['NATIVE_FLAGS'] = "-z [%s]:%d,[%s]:%d" % (
             zep_params['local_addr'], zep_params['local_port'],
             zep_params['remote_addr'], zep_params['remote_port'])
     s = socket.socket(family=socket.AF_INET6, type=socket.SOCK_DGRAM)


### PR DESCRIPTION
### Contribution description

_This is a tracking issue._ It will be split.

Currently, the tests invoke "make term" for interacting with the board. "make term" starts the "pyterm" program which may be nice for a human user but is horrible for a machine: it does line buffering, local echo, inserts lots of unnecessary data in the output stream, has "magical" behaviors (like hitting enter on an empty line repeats the last command, wtf?!?!). Normally, when testing, you want to test the actual thing and  try to take out of the equation any external factors. In any case, it's pointless to use any readline-based terminal program when the output is not a pty/tty but a pipe.

Add to this that the tests are done using "dumb matching" with pexpect and the result is that you try to match, say, an integer, and you could be matching your own input, or pyterm's "logging" info.

We are introducing "make rawterm" which gives a "raw" terminal, meaning one that is transparent- whatever you give to the terminal input goes to the serial device, whatever arrives to the serial device- and nothing- else goes to the terminal output.

On the native side, I tried to fix the conceptual error of having TERMPROG be the riot executable and TERMFLAGS be the flags to RIOT.

Other facts to take into account:

- The CI (murdock) is using picocom. It would be highly desirable that the same tool is used in the developer's machine and in the CI.
- @MrKevinWeiss's RIOT PAL currently has to REMOVE the superfluous information inserted by pyterm.

### Testing procedure

I will provide some tests stolen from #11094 to show the issues with the non-raw terminals and how they interfere with testing.

TODO:
- [ ] Make CI tests use "make rawterm"


### Issues/PRs references

Contains commits from: #11156, #11129 (needed for tests)
Would fix: #10952 
Part of: #10994 
Related to: #11094