### PR TITLE
cpu/nrf52/nrf802154: unify address generation

### DIFF
--- a/cpu/nrf52/radio/nrf802154/nrf802154.c
+++ b/cpu/nrf52/radio/nrf802154/nrf802154.c
@@ -230,8 +230,9 @@ static int _init(netdev_t *dev)
     NRF_RADIO->CRCINIT = 0;
 
     /* assign default addresses */
-    luid_get(nrf802154_dev.short_addr, IEEE802154_SHORT_ADDRESS_LEN);
     luid_get(nrf802154_dev.long_addr, IEEE802154_LONG_ADDRESS_LEN);
+    memcpy(nrf802154_dev.short_addr, &nrf802154_dev.long_addr[6],
+           IEEE802154_SHORT_ADDRESS_LEN);
 
     /* set default channel */
     _set_chan(nrf802154_dev.chan);


### PR DESCRIPTION
### Contribution description
In the discussion for #10268 it was noted, that other drivers re-use parts of their long address to set their short address. This PR adapts the `nrf802154` driver to do the same.

### Testing procedure
run e.g. the default example for the `nrf52840dk` and verify using `ifconfig´, that the short address now is made of the last two bytes of the long address.

### Issues/PRs references
follow up for #10268
