### PR TITLE
makefiles/tools/serial: disable picocom local echo

### DIFF
--- a/makefiles/tools/serial.inc.mk
+++ b/makefiles/tools/serial.inc.mk
@@ -22,5 +22,5 @@ else ifeq ($(RIOT_TERMINAL),socat)
   TERMFLAGS ?= $(SOCAT_OUTPUT) open:$(PORT),b$(BAUD),echo=0,raw
 else ifeq ($(RIOT_TERMINAL),picocom)
   TERMPROG  ?= picocom
-  TERMFLAGS ?= --nolock --imap lfcrlf --echo --baud "$(BAUD)" "$(PORT)"
+  TERMFLAGS ?= --nolock --imap lfcrlf --baud "$(BAUD)" "$(PORT)"
 endif


### PR DESCRIPTION
### Contribution description

#10630 fixed local echo in the shell. That being broken was the only reason to enable local echo in the first place. Thus I suggest disabling it, which this PR does for picocom.

### Testing procedure

Run tests/shell on a newlib board with RIOT_TERMINAL=picocom, see double echo in master, single echo with this PR.

### Issues/PRs references

#10630.