### PR TITLE
boards/nrf52832-mdk: add basic support

### DIFF
--- a/boards/nrf52832-mdk/Makefile
+++ b/boards/nrf52832-mdk/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/nrf52832-mdk/Makefile.dep
+++ b/boards/nrf52832-mdk/Makefile.dep
@@ -1,0 +1,5 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif
+
+include $(RIOTBOARD)/common/nrf52/Makefile.dep

--- a/boards/nrf52832-mdk/Makefile.features
+++ b/boards/nrf52832-mdk/Makefile.features
@@ -1,0 +1,4 @@
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_uart
+
+include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/nrf52832-mdk/Makefile.include
+++ b/boards/nrf52832-mdk/Makefile.include
@@ -1,0 +1,17 @@
+export CPU_MODEL = nrf52832xxaa
+
+# This board uses a DAP-Link programmer
+# Flashing support is provided through pyocd (default) and openocd.
+# For openocd, a version built against the development branch and containing
+# the support for nrf52 cpu is required.
+PROGRAMMER ?= pyocd
+ifeq (pyocd,$(PROGRAMMER))
+  # The board is not recognized automatically by pyocd, so the CPU target
+  # option is passed explicitly
+  export FLASH_TARGET_TYPE ?= -t $(CPU)
+  include $(RIOTMAKE)/tools/pyocd.inc.mk
+else ifeq (openocd,$(PROGRAMMER))
+  DEBUG_ADAPTER = dap
+endif
+
+include $(RIOTBOARD)/common/nrf52/Makefile.include

--- a/boards/nrf52832-mdk/board.c
+++ b/boards/nrf52832-mdk/board.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2019 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_nrf52832-mdk
+ * @{
+ *
+ * @file
+ * @brief       Board initialization for the nRF52832-MDK
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "board.h"
+
+#include "periph/gpio.h"
+
+void board_init(void)
+{
+    /* initialize the boards LEDs */
+    gpio_init(LED0_PIN, GPIO_OUT);
+    gpio_set(LED0_PIN);
+    gpio_init(LED1_PIN, GPIO_OUT);
+    gpio_set(LED1_PIN);
+    gpio_init(LED2_PIN, GPIO_OUT);
+    gpio_set(LED2_PIN);
+
+    /* initialize the CPU */
+    cpu_init();
+}

--- a/boards/nrf52832-mdk/doc.txt
+++ b/boards/nrf52832-mdk/doc.txt
@@ -1,0 +1,47 @@
+/**
+@defgroup    boards_nrf52832-mdk nRF52832-MDK
+@ingroup     boards
+@brief       Support for the nRF52832-MDK
+
+### General information
+
+The Makerdiary [nRF52832-MDK](https://github.com/makerdiary/nrf52832-mdk) board
+is an opensource, micro development kit using the nRF52832 SoC.
+This board provides BLE connectivity.
+
+The nRF52832-MDK v2 version provides a convenient USB dongle form factor.
+
+### Pinout
+
+For nRF52832-MDK v1:
+
+<img src="https://raw.githubusercontent.com/makerdiary/nrf52832-mdk/master/docs/images/nrf52832_mdk_v1_pinout.jpeg"
+     alt="pinout" style="height:800px;"/>
+
+For nRF52832-MDK v2:
+
+<img src="https://raw.githubusercontent.com/makerdiary/nrf52832-mdk/master/docs/images/nrf52832_mdk_v2_pinout.jpeg"
+     alt="pinout" style="height:800px;"/>
+
+### Flash the board
+
+By default, the board is flashed with PyOCD programmer via a DAPLink.
+
+PyOCD can be installed using Python package manager:
+```
+    pip install pyocd --user -U
+```
+
+See the `Flashing` section in @ref boards_common_nrf52.
+
+
+### Accessing STDIO via UART
+
+The STDIO is directly accessible via the USB port. On a Linux host, it's
+generally mapped to `/dev/ttyACM0`.
+
+Use the `term` target to connect to the board serial port<br/>
+```
+    make BOARD=nrf52832-mdk -C examples/hello-world term
+```
+ */

--- a/boards/nrf52832-mdk/include/board.h
+++ b/boards/nrf52832-mdk/include/board.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2019 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_nrf52832-mdk
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration for the nRF52832-MDK
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+#include "board_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    LED pin configuration
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(0, 23)
+#define LED1_PIN            GPIO_PIN(0, 22)
+#define LED2_PIN            GPIO_PIN(0, 24)
+
+#define LED_PORT            (NRF_P0)
+#define LED0_MASK           (1 << 23)
+#define LED1_MASK           (1 << 22)
+#define LED2_MASK           (1 << 24)
+#define LED_MASK            (LED0_MASK | LED1_MASK | LED2_MASK)
+
+#define LED0_ON             (LED_PORT->OUTCLR = LED0_MASK)
+#define LED0_OFF            (LED_PORT->OUTSET = LED0_MASK)
+#define LED0_TOGGLE         (LED_PORT->OUT   ^= LED0_MASK)
+
+#define LED1_ON             (LED_PORT->OUTCLR = LED1_MASK)
+#define LED1_OFF            (LED_PORT->OUTSET = LED1_MASK)
+#define LED1_TOGGLE         (LED_PORT->OUT   ^= LED1_MASK)
+
+#define LED2_ON             (LED_PORT->OUTCLR = LED2_MASK)
+#define LED2_OFF            (LED_PORT->OUTSET = LED2_MASK)
+#define LED2_TOGGLE         (LED_PORT->OUT   ^= LED2_MASK)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/nrf52832-mdk/include/gpio_params.h
+++ b/boards/nrf52832-mdk/include/gpio_params.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2019 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_nrf52832-mdk
+ * @{
+ *
+ * @file
+ * @brief       Configuration of SAUL mapped GPIO pins
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    LED configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name  = "Led Red",
+        .pin   = LED0_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name  = "Led Green",
+        .pin   = LED1_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name  = "Led Blue",
+        .pin   = LED2_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+};
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/nrf52832-mdk/include/periph_conf.h
+++ b/boards/nrf52832-mdk/include/periph_conf.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2019 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_nrf52832-mdk
+ * @{
+ *
+ * @file
+ * @brief       Peripheral configuration for the nRF52832-MDK
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+#include "cfg_clock_32_1.h"
+#include "cfg_rtt_default.h"
+#include "cfg_timer_default.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    UART configuration
+ * @{
+ */
+#define UART_NUMOF          (1U)
+#define UART_PIN_RX         GPIO_PIN(0,19)
+#define UART_PIN_TX         GPIO_PIN(0,20)
+/** @} */
+
+/**
+ * @name    SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .dev  = NRF_SPI0,
+        .sclk = 15,
+        .mosi = 13,
+        .miso = 14
+    }
+};
+
+#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */

--- a/examples/nimble_gatt/Makefile
+++ b/examples/nimble_gatt/Makefile
@@ -5,7 +5,7 @@ APPLICATION = nimble_gatt
 BOARD ?= nrf52dk
 
 # So far, NimBLE only works on nRF52 based platforms
-BOARD_WHITELIST := nrf52dk nrf52840dk
+BOARD_WHITELIST := nrf52dk nrf52840dk nrf52832-mdk
 
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds support for the [Makerdiary nrf52832-mdk](https://github.com/makerdiary/nrf52832-mdk) board.

The small USB dongle form factor is very convenient. The flasher is based on DAPLink and works with both PyOCD (default) and OpenOCD.

I tested a couple of applications (`examples/default`, `examples/nimble_gatt`), both worked.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Ideally, run `compile_and_test_board.py` for this board and verify all tests are passing.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None so far.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
