### PR TITLE
boards/nrf52840-mdk: fix openocd programmer configuration

### DIFF
--- a/boards/nrf52840-mdk/Makefile.include
+++ b/boards/nrf52840-mdk/Makefile.include
@@ -10,6 +10,8 @@ ifeq (pyocd,$(PROGRAMMER))
   # option is passed explicitly
   export FLASH_TARGET_TYPE ?= -t $(CPU)
   include $(RIOTMAKE)/tools/pyocd.inc.mk
+else ifeq (openocd,$(PROGRAMMER))
+  DEBUG_ADAPTER = dap
 endif
 
 include $(RIOTBOARD)/common/nrf52/Makefile.include


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is fixing the openocd configuration used with the nrf52840-mdk boards.
For nrf52 based boards, the default adapter is JLink and the nrf52840-mdk uses dap.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Just flash an application using openocd as programmer:
```
$ PROGRAMMER=openocd make BOARD=nrf52840-mdk -C examples/hello-world flash
```

On master it fails because no JLink adapter is found. With this PR it works.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Noticed while working on #11103.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
