### PR TITLE
makefiles/tools: Automatically detect gdb-multiarch

### DIFF
--- a/makefiles/tools/gdb.inc.mk
+++ b/makefiles/tools/gdb.inc.mk
@@ -1,2 +1,7 @@
+# new versions of gdb will support all architectures in one binary
+ifeq ($(shell gdb-multiarch -v 2>&1 > /dev/null; echo $$?),0)
+export GDB        ?= gdb-multiarch
+else
 export GDBPREFIX  ?= $(PREFIX)
 export GDB        ?= $(GDBPREFIX)gdb
+endif


### PR DESCRIPTION
Modern versions of GDB support multiple targets with the same gdb binary.
At least Ubuntu and Debian have dropped the gdb-arm-none-eabi package in favour
of gdb-multiarch.
Here, no `$(PREFIX)-gdb` binary is availiable, instead `gdb-multiarch` should be used.

This patch tries to automatically detect the presense of gdb-multiarch and uses it
instead of `arm-none-eabi-gdb`.
