### PR TITLE
cpu/stm32_common: prevent uart write stuck

### DIFF
--- a/cpu/stm32_common/periph/uart.c
+++ b/cpu/stm32_common/periph/uart.c
@@ -51,6 +51,10 @@
 
 #define RXENABLE            (USART_CR1_RE | USART_CR1_RXNEIE)
 
+#ifndef UART_MAX_WAIT
+#define UART_MAX_WAIT 10000
+#endif
+
 /**
  * @brief   Allocate memory to store the callback functions
  *
@@ -259,13 +263,19 @@ static inline void uart_init_lpuart(uart_t uart, uint32_t baudrate)
 
 static inline void send_byte(uart_t uart, uint8_t byte)
 {
-    while (!(dev(uart)->ISR_REG & ISR_TXE)) {}
+    int wait = UART_MAX_WAIT;
+    while (!(dev(uart)->ISR_REG & ISR_TXE) && wait != 0) {
+        wait--;
+    }
     dev(uart)->TDR_REG = byte;
 }
 
 static inline void wait_for_tx_complete(uart_t uart)
 {
-    while (!(dev(uart)->ISR_REG & ISR_TC)) {}
+    int wait = UART_MAX_WAIT;
+    while (!(dev(uart)->ISR_REG & ISR_TC) && wait != 0) {
+        wait--;
+    }
 }
 
 void uart_write(uart_t uart, const uint8_t *data, size_t len)

--- a/drivers/include/periph/uart.h
+++ b/drivers/include/periph/uart.h
@@ -196,8 +196,10 @@ int uart_mode(uart_t uart, uart_data_bits_t data_bits, uart_parity_t parity,
  * @param[in] data          data buffer to send
  * @param[in] len           number of bytes to send
  *
+ * @return                  0 on success
+ * @return                  -ETIMEDOUT on timeout
  */
-void uart_write(uart_t uart, const uint8_t *data, size_t len);
+int uart_write(uart_t uart, const uint8_t *data, size_t len);
 
 /**
  * @brief   Power on the given UART device


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
when trying to send something over uart while the CTS hardware flow control is low, we would get stuck endlessly waiting for the TXE flag to be cleared.

This PR adds a timeout to the uart write.

### Testing procedure
1. Set CTS line low
2. Try uart_write
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
