### PR TITLE
makefiles/modules.inc.mk: refactoring

### DIFF
--- a/makefiles/modules.inc.mk
+++ b/makefiles/modules.inc.mk
@@ -1,9 +1,11 @@
-ED = $(addprefix MODULE_,$(sort $(USEMODULE) $(USEPKG)))
+_ALLMODULES = $(sort $(USEMODULE) $(USEPKG))
+
+ED = $(addprefix MODULE_,$(_ALLMODULES))
 EXTDEFINES = $(addprefix -D,$(shell echo '$(ED)' | tr 'a-z-' 'A-Z_'))
 
 # filter "pseudomodules" from "real modules", but not "no_pseudomodules"
-NO_PSEUDOMODULES := $(filter $(NO_PSEUDOMODULES), $(sort $(USEMODULE) $(USEPKG)))
-REALMODULES = $(filter-out $(PSEUDOMODULES), $(sort $(USEMODULE) $(USEPKG))) $(NO_PSEUDOMODULES)
+NO_PSEUDOMODULES := $(filter $(NO_PSEUDOMODULES), $(_ALLMODULES))
+REALMODULES = $(filter-out $(PSEUDOMODULES), $(_ALLMODULES)) $(NO_PSEUDOMODULES)
 BASELIBS += $(REALMODULES:%=$(BINDIR)/%.a)
 
 CFLAGS += $(EXTDEFINES)

--- a/makefiles/modules.inc.mk
+++ b/makefiles/modules.inc.mk
@@ -7,5 +7,3 @@ REALMODULES = $(filter-out $(PSEUDOMODULES), $(sort $(USEMODULE) $(USEPKG))) $(N
 export BASELIBS += $(REALMODULES:%=$(BINDIR)/%.a)
 
 CFLAGS += $(EXTDEFINES)
-
-export USEMODULE

--- a/makefiles/modules.inc.mk
+++ b/makefiles/modules.inc.mk
@@ -6,6 +6,6 @@ EXTDEFINES = $(addprefix -D,$(shell echo '$(ED)' | tr 'a-z-' 'A-Z_'))
 CFLAGS += $(EXTDEFINES)
 
 # filter "pseudomodules" from "real modules", but not "no_pseudomodules"
-NO_PSEUDOMODULES := $(filter $(NO_PSEUDOMODULES), $(_ALLMODULES))
-REALMODULES = $(filter-out $(PSEUDOMODULES), $(_ALLMODULES)) $(NO_PSEUDOMODULES)
+REALMODULES += $(filter-out $(PSEUDOMODULES), $(_ALLMODULES))
+REALMODULES += $(filter $(NO_PSEUDOMODULES), $(_ALLMODULES))
 BASELIBS += $(REALMODULES:%=$(BINDIR)/%.a)

--- a/makefiles/modules.inc.mk
+++ b/makefiles/modules.inc.mk
@@ -1,11 +1,11 @@
 _ALLMODULES = $(sort $(USEMODULE) $(USEPKG))
 
+# Define MODULE_MODULE_NAME preprocessor macros for all modules.
 ED = $(addprefix MODULE_,$(_ALLMODULES))
 EXTDEFINES = $(addprefix -D,$(shell echo '$(ED)' | tr 'a-z-' 'A-Z_'))
+CFLAGS += $(EXTDEFINES)
 
 # filter "pseudomodules" from "real modules", but not "no_pseudomodules"
 NO_PSEUDOMODULES := $(filter $(NO_PSEUDOMODULES), $(_ALLMODULES))
 REALMODULES = $(filter-out $(PSEUDOMODULES), $(_ALLMODULES)) $(NO_PSEUDOMODULES)
 BASELIBS += $(REALMODULES:%=$(BINDIR)/%.a)
-
-CFLAGS += $(EXTDEFINES)

--- a/makefiles/modules.inc.mk
+++ b/makefiles/modules.inc.mk
@@ -4,6 +4,6 @@ EXTDEFINES = $(addprefix -D,$(shell echo '$(ED)' | tr 'a-z-' 'A-Z_'))
 # filter "pseudomodules" from "real modules", but not "no_pseudomodules"
 NO_PSEUDOMODULES := $(filter $(NO_PSEUDOMODULES), $(sort $(USEMODULE) $(USEPKG)))
 REALMODULES = $(filter-out $(PSEUDOMODULES), $(sort $(USEMODULE) $(USEPKG))) $(NO_PSEUDOMODULES)
-export BASELIBS += $(REALMODULES:%=$(BINDIR)/%.a)
+BASELIBS += $(REALMODULES:%=$(BINDIR)/%.a)
 
 CFLAGS += $(EXTDEFINES)


### PR DESCRIPTION
### Contribution description

This pull request does some refactoring in `makefiles/modules.inc.mk`.

* remove unnecessary exports
* factorize `$(sort $(USEMODULE) $(USEPKG))`
* re-organize by usage
* Change the way `REALMODULES` is defined

### Testing procedure


The value of `EXTDEFINES` and `REALMODULES` should be the same in `master` and this pull request for all applications and boards:

```
BOARD=samr21-xpro make --no-print-directory -C riot_master/examples/default info-debug-variable-EXTDEFINES
BOARD=samr21-xpro make --no-print-directory -C RIOT/examples/default info-debug-variable-EXTDEFINES
```

```
BOARD=samr21-xpro make --no-print-directory -C riot_master/examples/default info-debug-variable-REALMODULES
BOARD=samr21-xpro make --no-print-directory -C RIOT/examples/default info-debug-variable-REALMODULES
```

I provided an automated test script for this:

https://gist.github.com/cladmi/9818888da7412a9195ec0d4c3c2a8b8a

Both output should not report any difference

    ./compare_riot_repositories_variable_value.sh riot_master riot_pr EXTDEFINES
    ./compare_riot_repositories_variable_value.sh riot_master riot_pr REALMODULES

There are currently `/bin/sh: 1: Syntax error: Missing '))'` messages but they are unrelated.

### Issues/PRs references

I did this cleanup locally a long time ago to better understand this file, and now I want to use this as a pre-requisite to introducing `LIBS` for https://github.com/RIOT-OS/RIOT/pull/8711