### PR TITLE
riotboot,mcuboot: Use canned recipe for flashing.

### DIFF
--- a/makefiles/boot/riotboot.mk
+++ b/makefiles/boot/riotboot.mk
@@ -120,11 +120,11 @@ riotboot/flash-extended-slot0: ELFFILE=$(RIOTBOOT_EXTENDED_BIN)
 
 riotboot/flash-combined-slot0: FLASHFILE=$(RIOTBOOT_COMBINED_BIN)
 riotboot/flash-combined-slot0: $(RIOTBOOT_COMBINED_BIN) $(FLASHDEPS)
-	$(FLASHER) $(FFLAGS)
+	$(flash-recipe)
 
 riotboot/flash-extended-slot0: FLASHFILE=$(RIOTBOOT_EXTENDED_BIN)
 riotboot/flash-extended-slot0: $(RIOTBOOT_EXTENDED_BIN) $(FLASHDEPS)
-	$(FLASHER) $(FFLAGS)
+	$(flash-recipe)
 
 # Flashing rule for slot 0
 riotboot/flash-slot0: export IMAGE_OFFSET=$(SLOT0_OFFSET)
@@ -134,7 +134,7 @@ riotboot/flash-slot0: HEXFILE=$(SLOT0_RIOT_BIN)
 riotboot/flash-slot0: ELFFILE=$(SLOT0_RIOT_BIN)
 riotboot/flash-slot0: FLASHFILE=$(SLOT0_RIOT_BIN)
 riotboot/flash-slot0: $(SLOT0_RIOT_BIN) $(FLASHDEPS)
-	$(FLASHER) $(FFLAGS)
+	$(flash-recipe)
 
 # Flashing rule for slot 1
 riotboot/flash-slot1: export IMAGE_OFFSET=$(SLOT1_OFFSET)
@@ -144,7 +144,7 @@ riotboot/flash-slot1: HEXFILE=$(SLOT1_RIOT_BIN)
 riotboot/flash-slot1: ELFFILE=$(SLOT1_RIOT_BIN)
 riotboot/flash-slot1: FLASHFILE=$(SLOT1_RIOT_BIN)
 riotboot/flash-slot1: $(SLOT1_RIOT_BIN) $(FLASHDEPS)
-	$(FLASHER) $(FFLAGS)
+	$(flash-recipe)
 
 # Targets to generate only slots binary
 riotboot/slot0: $(SLOT0_RIOT_BIN)

--- a/makefiles/mcuboot.mk
+++ b/makefiles/mcuboot.mk
@@ -43,12 +43,14 @@ $(MCUBOOT_BIN):
 .PHONY: mcuboot-flash-bootloader mcuboot-flash
 
 mcuboot-flash-bootloader: HEXFILE = $(MCUBOOT_BIN)
+mcuboot-flash-bootloader: export FLASH_ADDR = 0x0
 mcuboot-flash-bootloader: $(MCUBOOT_BIN) $(FLASHDEPS)
-	FLASH_ADDR=0x0 $(FLASHER) $(FFLAGS)
+	$(flash-recipe)
 
 mcuboot-flash: HEXFILE = $(SIGN_BINFILE)
+mcuboot-flash: export FLASH_ADDR = $(MCUBOOT_SLOT0_SIZE)
 mcuboot-flash: mcuboot $(FLASHDEPS) mcuboot-flash-bootloader
-	FLASH_ADDR=$(MCUBOOT_SLOT0_SIZE) $(FLASHER) $(FFLAGS)
+	$(flash-recipe)
 
 else
 mcuboot:


### PR DESCRIPTION
### Contribution description

#10548 introduced a canned recipe for flashing. The aim was to reduce code duplication, and also to be able to perform more than one command. This is important for boards that need more complex procedure, for example to put them in a special mode or disabling the watchdog (currently done in "preflash")

By having the flashing recipe concentrated in a single place maintenance is simplified. Eventually the flash recipe will be defined with `?=` to allow overriding, and then the benefits of this change will become clearer.

### Testing procedure

Build and flash `tests/riotboot`. I could not test mcuboot because I do not have a supported board.

Flashing continue to work fine.

### Issues/PRs references

See: #10548.