### PR TITLE
makefiles: introduce 'LIBS' variable

### DIFF
--- a/makefiles/modules.inc.mk
+++ b/makefiles/modules.inc.mk
@@ -8,4 +8,16 @@ CFLAGS += $(EXTDEFINES)
 # filter "pseudomodules" from "real modules", but not "no_pseudomodules"
 REALMODULES += $(filter-out $(PSEUDOMODULES), $(_ALLMODULES))
 REALMODULES += $(filter $(NO_PSEUDOMODULES), $(_ALLMODULES))
-BASELIBS += $(REALMODULES:%=$(BINDIR)/%.a)
+
+# For 'shared libraries' every object must be included
+SHARED_LIBS = $(filter-out $(LIBS), $(REALMODULES))
+# For 'static libraries' only required object files are included
+STATIC_LIBS = $(filter $(LIBS), $(REALMODULES))
+
+# Warning: the shared/static libraries handling is not currently handled
+# for all architectures. But correctly defining them allows future proof
+# handling.
+
+SHARED_LIBS_FILES = $(SHARED_LIBS:%=$(BINDIR)/%.a)
+STATIC_LIBS_FILES = $(STATIC_LIBS:%=$(BINDIR)/%.a)
+BASELIBS += $(SHARED_LIBS_FILES) $(STATIC_LIBS_FILES)

--- a/makefiles/modules.inc.mk
+++ b/makefiles/modules.inc.mk
@@ -9,15 +9,16 @@ CFLAGS += $(EXTDEFINES)
 REALMODULES += $(filter-out $(PSEUDOMODULES), $(_ALLMODULES))
 REALMODULES += $(filter $(NO_PSEUDOMODULES), $(_ALLMODULES))
 
-# For 'shared libraries' every object must be included
-SHARED_LIBS = $(filter-out $(LIBS), $(REALMODULES))
-# For 'static libraries' only required object files are included
-STATIC_LIBS = $(filter $(LIBS), $(REALMODULES))
 
-# Warning: the shared/static libraries handling is not currently handled
-# for all architectures. But correctly defining them allows future proof
-# handling.
+# Modules that can be linked by including all objects
+OBJECTS_REALMODULES = $(filter-out $(LIBS), $(REALMODULES))
+# Modules that must be linked using the default 'archive' linking behaviour
+ARCHIVE_REALMODULES = $(filter $(LIBS), $(REALMODULES))
 
-SHARED_LIBS_FILES = $(SHARED_LIBS:%=$(BINDIR)/%.a)
-STATIC_LIBS_FILES = $(STATIC_LIBS:%=$(BINDIR)/%.a)
-BASELIBS += $(SHARED_LIBS_FILES) $(STATIC_LIBS_FILES)
+OBJECTS_LIBS += $(OBJECTS_REALMODULES:%=$(BINDIR)/%.a)
+ARCHIVE_LIBS += $(ARCHIVE_REALMODULES:%=$(BINDIR)/%.a)
+
+# Warning: the object/archive compilation handling is not currently handled
+# for all architectures.
+
+BASELIBS += $(OBJECTS_LIBS) $(ARCHIVE_LIBS)

--- a/makefiles/vars.inc.mk
+++ b/makefiles/vars.inc.mk
@@ -16,6 +16,7 @@ export CXXINCLUDES           # The extra include paths for c++, set by the vario
 
 export USEMODULE             # Sys Module dependencies of the application. Set in the application's Makefile.
 export USEPKG                # Pkg dependencies (third party modules) of the application. Set in the application's Makefile.
+# LIBS                       # Handle the module as a static library instead of a shared library. Set by the package's Makefile.include when necessary
 export DISABLE_MODULE        # Used in the application's Makefile to suppress DEFAULT_MODULEs.
 export APPDEPS               # Files / Makefile targets that need to be created before the application can be build. Set in the application's Makefile.
 # BUILDDEPS                  # Files / Makefile targets that need to be created before starting to build.

--- a/makefiles/vars.inc.mk
+++ b/makefiles/vars.inc.mk
@@ -16,7 +16,12 @@ export CXXINCLUDES           # The extra include paths for c++, set by the vario
 
 export USEMODULE             # Sys Module dependencies of the application. Set in the application's Makefile.
 export USEPKG                # Pkg dependencies (third party modules) of the application. Set in the application's Makefile.
-# LIBS                       # Handle the module as a static library instead of a shared library. Set by the package's Makefile.include when necessary
+# LIBS
+# List of modules that must be linked using the default 'archive' linking
+# behavior where only required/referenced objects/functions are included.
+#
+# Modules whose archive should not/cannot be linked with `--whole-archive`
+# must be added to LIBS in the module Makefile.include.
 export DISABLE_MODULE        # Used in the application's Makefile to suppress DEFAULT_MODULEs.
 export APPDEPS               # Files / Makefile targets that need to be created before the application can be build. Set in the application's Makefile.
 # BUILDDEPS                  # Files / Makefile targets that need to be created before starting to build.


### PR DESCRIPTION
### Contribution description

This introduced the LIBS variables to declare a module as a static
library.

It is a requirement to allow handling linking differently between
static libraries and shared libraries in upcoming pull requests.

Co-authored-by: Joakim Nohlgård <joakim.nohlgard@eistec.se>

This is split of https://github.com/RIOT-OS/RIOT/pull/8711 and modified as some specific handling done for `USEPKG` is not necessary anymore.

I took the name "static libraries" and "shared libraries" from `man ld` in the `--whole-archive` section.

### Testing procedure


Compiling should sill work in the same way and the output of `BASELIBS` should not have changed.

To simplify testing, I comment `APPDEPS` in the pic32 boards as it contains the full path and is not relevant for this test:

```diff
diff --git a/boards/pic32-clicker/Makefile.include b/boards/pic32-clicker/Makefile.include
index 264f0e502..3c9c68a90 100644
--- a/boards/pic32-clicker/Makefile.include
+++ b/boards/pic32-clicker/Makefile.include
@@ -1,4 +1,4 @@
 export CPU = mips_pic32mx
 export CPU_MODEL=p32mx470f512h
-export APPDEPS += $(RIOTCPU)/$(CPU)/$(CPU_MODEL)/$(CPU_MODEL).S
+#export APPDEPS += $(RIOTCPU)/$(CPU)/$(CPU_MODEL)/$(CPU_MODEL).S
 export USE_UHI_SYSCALLS = 1
diff --git a/boards/pic32-wifire/Makefile.include b/boards/pic32-wifire/Makefile.include
index 7e4a7c738..3c1a62eca 100644
--- a/boards/pic32-wifire/Makefile.include
+++ b/boards/pic32-wifire/Makefile.include
@@ -1,4 +1,4 @@
 export CPU = mips_pic32mz
 export CPU_MODEL=p32mz2048efg100
-export APPDEPS += $(RIOTCPU)/$(CPU)/$(CPU_MODEL)/$(CPU_MODEL).S
+#export APPDEPS += $(RIOTCPU)/$(CPU)/$(CPU_MODEL)/$(CPU_MODEL).S
 export USE_UHI_SYSCALLS = 1
```

and compare the value of `BASELIBS`.

I use https://gist.github.com/cladmi/9818888da7412a9195ec0d4c3c2a8b8a to compare the output and it should see no difference:

    BINDIR='/tmp/bin/$(BOARD)' ./scripts/compare_riot_repositories_variable_value.sh riot_master riot_pr BASELIBS

There are currently /bin/sh: 1: Syntax error: Missing '))' messages but they are unrelated.


### Issues/PRs references

This is a split and refactored out of https://github.com/RIOT-OS/RIOT/pull/8711
Depends on https://github.com/RIOT-OS/RIOT/pull/11109 refactoring