### PR TITLE
makefiles/mcuboot: prepare for when FLASHFILE is used

### DIFF
--- a/makefiles/mcuboot.mk
+++ b/makefiles/mcuboot.mk
@@ -43,11 +43,13 @@ $(MCUBOOT_BIN):
 .PHONY: mcuboot-flash-bootloader mcuboot-flash
 
 mcuboot-flash-bootloader: HEXFILE = $(MCUBOOT_BIN)
+mcuboot-flash-bootloader: FLASHFILE = $(MCUBOOT_BIN)
 mcuboot-flash-bootloader: export FLASH_ADDR = 0x0
 mcuboot-flash-bootloader: $(MCUBOOT_BIN) $(FLASHDEPS)
 	$(flash-recipe)
 
 mcuboot-flash: HEXFILE = $(SIGN_BINFILE)
+mcuboot-flash: FLASHFILE = $(SIGN_BINFILE)
 mcuboot-flash: export FLASH_ADDR = $(MCUBOOT_SLOT0_SIZE)
 mcuboot-flash: mcuboot $(FLASHDEPS) mcuboot-flash-bootloader
 	$(flash-recipe)


### PR DESCRIPTION
### Contribution description

Prepare to keep working when `FLASHFILE` is used for the FLASHER.


### Limitation

This does not declare the generated file to flash as `FLASHFILE` as it is currently not a file target.
This would come after https://github.com/RIOT-OS/RIOT/pull/10494

### Testing procedure

#### Nothing broke
The previous behavior did not change:

```
make -C tests/mcuboot/ mcuboot-flash 
```
```
make -C tests/mcuboot/ term
make: Entering directory '/home/harter/work/git/worktree/riot_release/tests/mcuboot'
/home/harter/work/git/worktree/riot_release/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200"
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2019-03-05 18:06:21,953 - INFO # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.

2019-03-05 18:09:20,682 - INFO # Hello MCUBoot!
2019-03-05 18:09:20,686 - INFO # You are running RIOT on a(n) nrf52dk board.
2019-03-05 18:09:20,689 - INFO # This board features a(n) nrf52 MCU.
2019-03-05 18:09:20,692 - INFO # The startup address is: 0x8200
```

#### Future should work

FLASHFILE is indeed given to the flash target.
It can be tested by replacing the flasher with echo $(FLASHFILE) and seeing the file being printed:

```
RIOT_CI_BUILD=1  make --no-print-directory -C tests/mcuboot mcuboot-flash FLASHER=echo FFLAGS='FLASHFILE: $(FLASHFILE)'
Building application "tests_mcuboot" for "nrf52dk" with MCU "nrf52".

   text    data     bss     dec     hex filename
   8108     136    2604   10848    2a60 /home/harter/work/git/worktree/riot_release/tests/mcuboot/bin/nrf52dk/tests_mcuboot.elf

Re-linking for MCUBoot at 0x8000...


Signed with /home/harter/work/git/worktree/riot_release/tests/mcuboot/bin/nrf52dk/key.pem for version 1.1.1+1\


/home/harter/work/git/worktree/riot_release/dist/tools/dlcache/dlcache.sh: getting "http://download.riot-os.org/mynewt.mcuboot.bin" from cache
echo FLASHFILE: /home/harter/work/git/worktree/riot_release/tests/mcuboot/bin/nrf52dk/mcuboot.bin
FLASHFILE: /home/harter/work/git/worktree/riot_release/tests/mcuboot/bin/nrf52dk/mcuboot.bin
echo FLASHFILE: /home/harter/work/git/worktree/riot_release/tests/mcuboot/bin/nrf52dk/signed-tests_mcuboot.bin
FLASHFILE: /home/harter/work/git/worktree/riot_release/tests/mcuboot/bin/nrf52dk/signed-tests_mcuboot.bin
```

### Issues/PRs references

This is part of #8838