### PR TITLE
[WIP] cpu/atmega_common: pin change interrupt implementation

### DIFF
--- a/cpu/atmega_common/periph/gpio.c
+++ b/cpu/atmega_common/periph/gpio.c
@@ -94,7 +94,7 @@ typedef struct {
     void *arg;              /**< optional argument */
 } gpio_isr_ctx_pcint_t;
 
-static gpio_t pcint_mapping[] = AVR_PCINT_GPIO_LIST; //wäre schöner wenn das nicht die ganze Zeit im Speicher liegt....
+static gpio_t pcint_mapping[] = AVR_PCINT_GPIO_LIST;
 static gpio_isr_ctx_pcint_t pcint_config[ sizeof(pcint_mapping) / sizeof(gpio_t) ]; 
 static int8_t pcint_lookup[ GPIO_PC_INT_NUMOF ] = { [0 ... (GPIO_PC_INT_NUMOF-1) ] = -1 };
 #endif /* GPIO_PC_INT_NUMOF */

--- a/cpu/atmega_common/periph/gpio.c
+++ b/cpu/atmega_common/periph/gpio.c
@@ -387,34 +387,26 @@ static inline void pcint_handler(uint8_t port_num, volatile uint8_t *mask_reg)
 /*
  * PCINT0 is always defined, if GPIO_PC_INT_NUMOF is defined
  */
-#if PCINT0_vect_num != AVR_CONTEXT_SWAP_INTERRUPT_VECT_NUM
 ISR(PCINT0_vect, ISR_BLOCK) {
     pcint_handler(0, &PCMSK0);
 }
-#endif /* AVR_CONTEXT_SWAP_INTERRUPT_VECT */
 
 #if defined(PCINT1_vect)
-#if PCINT1_vect_num != AVR_CONTEXT_SWAP_INTERRUPT_VECT_NUM
 ISR(PCINT1_vect, ISR_BLOCK) {
     pcint_handler(1, &PCMSK1);
 }
-#endif  /* AVR_CONTEXT_SWAP_INTERRUPT_VECT */
 #endif  /* PCINT1_vect */
 
 #if defined(PCINT2_vect)
-#if PCINT2_vect_num != AVR_CONTEXT_SWAP_INTERRUPT_VECT_NUM
 ISR(PCINT2_vect, ISR_BLOCK) {
     pcint_handler(2, &PCMSK2);
 }
-#endif  /* AVR_CONTEXT_SWAP_INTERRUPT_VECT */
 #endif  /* PCINT2_vect */
 
 #if defined(PCINT3_vect)
-#if PCINT3_vect_num != AVR_CONTEXT_SWAP_INTERRUPT_VECT_NUM
 ISR(PCINT3_vect, ISR_BLOCK) {
     pcint_handler(3, &PCMSK3);
 }
-#endif  /* AVR_CONTEXT_SWAP_INTERRUPT_VECT */
 #endif  /* PCINT3_vect */
 
 #endif /* GPIO_PC_INT_NUMOF */

--- a/cpu/atmega_common/periph/gpio.c
+++ b/cpu/atmega_common/periph/gpio.c
@@ -240,7 +240,7 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     if (int_num < 0) {
 	    /* If pin change interrupts are enabled, enable mask and interrupt */
         #ifdef GPIO_PC_INT_NUMOF
-        uint8_t broke = 0;
+        uint8_t found = 0;
         uint8_t pin_num = _pin_num(pin);
         uint8_t mapping_size = sizeof(pcint_mapping) / sizeof(gpio_t);
         for(uint8_t i=0 ; i<mapping_size ; i++) {
@@ -252,11 +252,11 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
                 pcint_config[i].flank   = flank;
                 pcint_config[i].arg     = arg;
                 pcint_config[i].cb      = cb;
-                broke = 1; 
+                found = 1; 
                 break;
             }
         }
-        if(broke != 1)
+        if(found != 1)
         {
             return -1;
         }


### PR DESCRIPTION
### Contribution description

This is a new proposal of a low-memory footprint implementation for pin change interrupts on atmega platforms. First, a lookup-table is used to indicate if a PCINT is configured for a port (`pcint_lookup`).

Each board then defines a list of GPIOs via `AVR_PCINT_GPIO_LIST` that should be used as pin change interrupts. These are put into a map `pcint_mapping` `(i -> gpio_t)`. When initializing a port pin, and it is not an external interrupt, it is checked if the GPIO was enabled before via AVR_PCINT_GPIO_LIST. Afterwards, the interrupt is enabled on that port and the state and config are saved.
Using a pre-defined list of available pin change interrupts for a board, the memory overhead is kept low.

### Issues/PRs references

See also #7610, #8993, #9159
