### PR TITLE
cpu/stm32l0: fix CPU_ARCH definition

### DIFF
--- a/cpu/stm32l0/Makefile.include
+++ b/cpu/stm32l0/Makefile.include
@@ -1,4 +1,4 @@
-export CPU_ARCH = cortex-m0
+export CPU_ARCH = cortex-m0plus
 export CPU_FAM  = stm32l0
 
 USEMODULE += pm_layered


### PR DESCRIPTION
### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR changes CPU_ARCH definition for stm32l0 from cortex-m0 to cortex-m0plus which is the actual cpu architecture this cpu family uses. This will allow some `#ifdef` conditions to be correctly executed when relating to the pertaining architecture. 

### Testing procedure

Tested on b-l072z-lrwan1 running all tests and applications, following tests failed (all of them beeing known issues or expected to fail):

Executed from /RIOT: 
`IOTLAB_NODE=auto-ssh python dist/tools/compile_and_test_for_board/compile_and_test_for_board.py  . b-l072z-lrwan1`

- tests/driver_grove_ledbar
- tests/driver_my9221
- tests/gnrc_ipv6_ext
- tests/gnrc_rpl_srh
- tests/pkg_fatfs_vfs

### Issues/PRs references

None
