### PR TITLE
core: add irq_is_enabled() function to irq interface

### DIFF
--- a/core/include/irq.h
+++ b/core/include/irq.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Freie Universität Berlin
+ * Copyright (C) 2013,2019 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -16,6 +16,7 @@
  * @brief       IRQ driver interface
  *
  * @author      Freie Universität Berlin, Computer Systems & Telematics
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
 #ifndef IRQ_H
@@ -59,6 +60,14 @@ unsigned irq_enable(void);
  * @see     irq_disable
  */
 void irq_restore(unsigned state);
+
+/**
+ * @brief   Test if IRQs are currently enabled
+ *
+ * @return  0 (false) if IRQs are currently disabled
+ * @return  != 0 (true) if IRQs are currently enabled
+ */
+int irq_is_enabled(void);
 
 /**
  * @brief   Check whether called from interrupt service routine

--- a/cpu/atmega_common/irq_arch.c
+++ b/cpu/atmega_common/irq_arch.c
@@ -83,6 +83,14 @@ void irq_restore(unsigned int state)
 }
 
 /**
+ * @brief Test if interrupts are currently enabled
+ */
+int irq_is_enabled(void)
+{
+    return __get_interrupt_state();
+}
+
+/**
  * @brief See if the current context is inside an ISR
  */
 int irq_is_in(void)

--- a/cpu/cortexm_common/irq_arch.c
+++ b/cpu/cortexm_common/irq_arch.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2015 Freie Universität Berlin
+ * Copyright (C) 2014-2019 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser General
  * Public License v2.1. See the file LICENSE in the top level directory for more
@@ -47,6 +47,14 @@ __attribute__((used)) unsigned int irq_enable(void)
 void irq_restore(unsigned int state)
 {
     __set_PRIMASK(state);
+}
+
+int irq_is_enabled(void)
+{
+    /* so far, all existing Cortex-M are only using the least significant bit
+     * in the PRIMARK register. If ever any other bit is used for different
+     * purposes, this function will not work properly anymore. */
+    return (__get_PRIMASK() == 0);
 }
 
 /**

--- a/cpu/msp430_common/irq.c
+++ b/cpu/msp430_common/irq.c
@@ -28,28 +28,24 @@ char __isr_stack[ISR_STACKSIZE];
 
 unsigned int irq_disable(void)
 {
-    unsigned int state;
-    __asm__("mov.w r2,%0" : "=r"(state));
-    state &= GIE;
+    int state = irq_is_enabled();
 
     if (state) {
         __disable_irq();
     }
 
-    return state;
+    return (unsigned)state;
 }
 
 unsigned int irq_enable(void)
 {
-    unsigned int state;
-    __asm__("mov.w r2,%0" : "=r"(state));
-    state &= GIE;
+    int state = irq_is_enabled();
 
     if (!state) {
         __enable_irq();
     }
 
-    return state;
+    return (unsigned)state;
 }
 
 void irq_restore(unsigned int state)
@@ -57,6 +53,13 @@ void irq_restore(unsigned int state)
     if (state) {
         __enable_irq();
     }
+}
+
+int irq_is_enabled(void)
+{
+    unsigned int state;
+    __asm__("mov.w r2,%0" : "=r"(state));
+    return (state & GIE);
 }
 
 int irq_is_in(void)

--- a/cpu/native/irq_cpu.c
+++ b/cpu/native/irq_cpu.c
@@ -220,6 +220,11 @@ void irq_restore(unsigned state)
     return;
 }
 
+int irq_is_enabled(void)
+{
+    return native_interrupts_enabled;
+}
+
 int irq_is_in(void)
 {
     DEBUG("irq_is_in: %i\n", _native_in_isr);

--- a/tests/irq/main.c
+++ b/tests/irq/main.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2013 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
+ *               2019 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -14,17 +15,20 @@
  * @brief IRQ test application
  *
  * @author      Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  *
  * @}
  */
 
 #include <stdio.h>
 
+#include "irq.h"
 #include "xtimer.h"
 #include "thread.h"
 
 static char busy_stack[THREAD_STACKSIZE_MAIN];
 static volatile int busy, i, k;
+
 
 void *busy_thread(void *arg)
 {
@@ -53,6 +57,41 @@ int main(void)
 {
     puts("START");
 
+    /* check if we can control interrupt enabling properly */
+
+    /* initially, interrupts should be enabled */
+    if (!irq_is_enabled()) {
+        goto err;
+    }
+
+    /* test a 'brute-force' disable/enable sequence */
+    irq_disable();
+    if (irq_is_enabled()) {
+        goto err;
+    }
+    irq_enable();
+    if (!irq_is_enabled()) {
+        goto err;
+    }
+
+    /* test a simple disable/restore sequence */
+    unsigned state = irq_disable();
+    if (irq_is_enabled()) {
+        goto err;
+    }
+    unsigned state_inner = irq_disable();
+    if (irq_is_enabled()) {
+        goto err;
+    }
+    irq_restore(state_inner);
+    if (irq_is_enabled()) {
+        goto err;
+    }
+    irq_restore(state);
+    if (!irq_is_enabled()) {
+        goto err;
+    }
+
     busy = 1;
     k = 23;
     thread_create(busy_stack, sizeof(busy_stack),
@@ -66,5 +105,9 @@ int main(void)
 
     puts("main: return");
 
+    return 0;
+
+err:
+    puts("FAILED");
     return 0;
 }


### PR DESCRIPTION
### Contribution description
I stumbled upon a bug in our `nimBLE` port, where I need to find out, if global interrupts are currently enabled (so far miss-use of `irq_is_in()`). So I noticed that this functionality was never included in our `core/irq.h` interface. This PR adds this function as `irq_is_enabled()` to RIOT.

Aside from my rather specific use case, this new function is also very useful for hardening code by including `assert(irq_is_enabled())` statements at certain critical points in the code...

Status of this PR:
- added the new function to the core interface
- added some simple test cases to the `tests/irq` test application
- implemented for
  - [x] cortexm_common (verified)
  - [x] native (verified)
  - [x] msp430 (untested)
  - [x] avr8 (untested)
  - [ ] esp32
  - [ ] esp8266
  - [ ] mips32
  - [ ] riscv
  - ...

If we want to go on with this PR, help for the remaining architectures would be highly appreciated! So please lets decide for the concept first, and only if we agree move to further implementations and testing...

### Testing procedure
run `tests/irq` on the target hardware

### Issues/PRs references
none