### PR TITLE
pkg/lwip: update pkg_url from git:// to https://

### DIFF
--- a/pkg/lwip/Makefile
+++ b/pkg/lwip/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME=lwip
-PKG_URL=git://git.savannah.nongnu.org/lwip.git
+PKG_URL=https://git.savannah.nongnu.org/git/lwip.git
 # lwIP v2.1.2
 PKG_VERSION=159e31b689577dbf69cf0683bbaffbd71fa5ee10
 PKG_LICENSE=BSD-3-Clause


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

When cloning pkg repo I get a connection error using the actual link[ git://git.savannah.nongnu.org/lwip.git ](url)but no issue if I change it to https://git.savannah.nongnu.org/git/lwip.git. In every other pkg https:// is used to pull the  repo.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Run on master `make -C tests/lwip`.

OS version: Ubuntu 18.04
Git version: 2.17.1

### Issues/PRs references

None