### PR TITLE
sys/random: cleanup includes

### DIFF
--- a/sys/random/random.c
+++ b/sys/random/random.c
@@ -22,7 +22,6 @@
 #include <stdint.h>
 
 #include "log.h"
-#include "luid.h"
 #include "random.h"
 #ifdef MODULE_PUF_SRAM
 #include "puf_sram.h"
@@ -31,7 +30,7 @@
 #include "periph/hwrng.h"
 #endif
 #ifdef MODULE_PERIPH_CPUID
-#include "periph/cpuid.h"
+#include "luid.h"
 #endif
 
 #define ENABLE_DEBUG (0)


### PR DESCRIPTION
### Contribution description
Simple little cleanup: the `periph/cpuid.h` is never used in the `random.c` file, so no need for including it. Also the `luid.h` is dependent on the `PERIPH_CPUID` module, so I made it dependent accordingly.

### Testing procedure
Compile test should do.

### Issues/PRs references
none