### PR TITLE
 gnrc_netif: increase message queue size

### DIFF
--- a/cpu/nrf52/Makefile.include
+++ b/cpu/nrf52/Makefile.include
@@ -22,9 +22,5 @@ RAM_START_ADDR ?= 0x20000000
 
 LINKER_SCRIPT ?= cortexm.ld
 
-ifneq (,$(filter nrf802154,$(USEMODULE)))
-  CFLAGS += -DGNRC_NETIF_MSG_QUEUE_SIZE=16
-endif
-
 include $(RIOTCPU)/nrf5x_common/Makefile.include
 include $(RIOTMAKE)/arch/cortexm.inc.mk

--- a/sys/include/net/gnrc/netif/conf.h
+++ b/sys/include/net/gnrc/netif/conf.h
@@ -54,7 +54,7 @@ extern "C" {
  *              changed.
  */
 #ifndef GNRC_NETIF_MSG_QUEUE_SIZE
-#define GNRC_NETIF_MSG_QUEUE_SIZE  (8U)
+#define GNRC_NETIF_MSG_QUEUE_SIZE  (16U)
 #endif
 
 /**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Since the netif threads are in general a more heavy lifters than the rest of the GNRC there queue size should be increased. This helps some network devices (e.g. `kw2x` and `nrf802154`) also to work without redefining the `GNRC_NETIF_MSG_QUEUE_SIZE` macro (so I reverted the change for `nrf802154` in a separate commit as well).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Compile and flash `examples/gnrc_minimal` to a board with smaller default stack size (e.g. `z1`), `make term` to it, and reset the board to get its target address (for `z1` it always should be `fe80::2023:2323:2323:2323` unless you redefine `LUID_BACKUP_SEED` ;-)). Compile and flash `examples/gnrc_networking` for another 6Lo-capable board (e.g. `samr21-xpro`). `make term` on that board, **deactivate IPHC** (`ifconfig <if> -iphc`), and try to ping the node `ping6 <address>`. The pinged node should not crash.

Pinging with any application should still work on `nrf52840dk` and also now work on `pba-d-01-kw2x` with large payloads.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
This was originally supposed to be introduced in https://github.com/RIOT-OS/RIOT/pull/11067 but an error in the testing procedures made me revert the change.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
