### PR TITLE
gnrc_sixlowpan: don't use PRIx8

### DIFF
--- a/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
@@ -27,11 +27,6 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
-#if ENABLE_DEBUG
-/* For PRIu16 etc. */
-#include <inttypes.h>
-#endif
-
 static kernel_pid_t _pid = KERNEL_PID_UNDEF;
 
 #if ENABLE_DEBUG
@@ -222,8 +217,7 @@ static void _receive(gnrc_pktsnip_t *pkt)
     }
 #endif
     else {
-        DEBUG("6lo: dispatch %02" PRIx8 " ... is not supported\n",
-              dispatch[0]);
+        DEBUG("6lo: dispatch %02x... is not supported\n", dispatch[0]);
         gnrc_pktbuf_release(pkt);
         return;
     }


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
With newlib nano-specs the debug output without this change will be

    6lo: dispatch 0hx ... is not supported

With this PR this will provide a correct output, e.g.

    6lo: dispatch 3f ... is not supported

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Flash two 6Lo-capable boards that utilize newlib-nano (e.g. `samr21-xpro` or `iotlab-m3`) with `ENABLE_DEBUG=1` in `sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c` with `gnrc_minimal` and `gnrc_networking` respectively. You need to reset `gnrc_minimal` once you connected a terminal to get the IPv6 address. Then try without any additional configuration to ping the `gnrc_minimal` node from the `gnrc_networking` node. Without this PR you should get the line

    6lo: dispatch 0hx ... is not supported

somewhere in the output, with it you will get

    6lo: dispatch 7a... is not supported
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Found when I was debugging https://github.com/RIOT-OS/RIOT/issues/11091#issuecomment-470487820.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
