### PR TITLE
tools/edbg: Use openocd to reset instead of edbg.

### DIFF
--- a/makefiles/tools/edbg.inc.mk
+++ b/makefiles/tools/edbg.inc.mk
@@ -19,5 +19,11 @@ FFLAGS ?= $(EDBG_ARGS) -t $(EDBG_DEVICE_TYPE) -b -v -p -f $(HEXFILE)
 ifeq ($(RIOT_EDBG),$(FLASHER))
   FLASHDEPS += $(RIOT_EDBG)
 endif
-RESET ?= $(EDBG)
-RESET_FLAGS ?= $(EDBG_ARGS) -t $(EDBG_DEVICE_TYPE)
+
+## A few commits ago edbg changed its behavior and now it resets the board
+## twice. This makes some tests fail, as the start on the first reset, but
+## shortly after the board is reset again.
+## See: https://github.com/ataradov/edbg/issues/77
+## Commenting this out causes RESET to be provided by OpenOCD instead.
+# RESET ?= $(EDBG)
+# RESET_FLAGS ?= $(EDBG_ARGS) -t $(EDBG_DEVICE_TYPE)


### PR DESCRIPTION
### Contribution description

A few commits ago edbg changed its behaviour and now it resets the board twice. This makes some tests fail, as the start on the first reset, but shortly after the board is reset again.

I already reported upstream (https://github.com/ataradov/edbg/issues/77) but in the meanwhile we need a workaround.

This comments out RESET and RESET_FLAGS in the edbg tool setting. Reset will now be done via OpenOCD, which is available and used anyways because it is needed for `make debug`.

### Testing procedure

Before trying this out, verify that edbg is on the latest version:
```
$ cd <RIOT REPO>
$ rm -rf dist/tools/edbg/edbg dist/tools/edbg/bin
$ make -C examples/hello-world $(pwd)/dist/tools/edbg/edbg
```

Compile and flash `hello-world` in any atmel board:
```
BOARD=saml21-xpro make -C examples/hello-world  all flash term
```

Open another terminal and reset the board:
```
BOARD=saml21-xpro make -C examples/hello-world  reset
```

Without this change: two resets
```
Welcome to pyterm!
Type '/exit' to exit.
2019-03-07 12:56:34,816 - INFO # main(): This is RIOT! (Version: 2019.04-devel-365-gda2f47-HEAD)
2019-03-07 12:56:34,817 - INFO # Hello World!
2019-03-07 12:56:34,822 - INFO # You are running RIOT on a(n) saml21-xpro board.
2019-03-07 12:56:34,838 - INFO # main(): This is RIOT! (Version: 2019.04-devel-365-gda2f47-HEAD)
2019-03-07 12:56:34,839 - INFO # Hello World!
2019-03-07 12:56:34,843 - INFO # You are running RIOT on a(n) saml21-xpro board.
2019-03-07 12:56:34,847 - INFO # This board features a(n) saml21 MCU.
```

With this change: only one reset (there's no point on pasting the output.)

### Issues/PRs references

Issue in edbg: https://github.com/ataradov/edbg/issues/77