### PR TITLE
nrf52: Add riotboot support

### DIFF
--- a/boards/common/nrf52/Makefile.features
+++ b/boards/common/nrf52/Makefile.features
@@ -1,6 +1,9 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_timer
+ifeq (,$(filter nordic_softdevice_ble,$(USEPKG)))
+  FEATURES_PROVIDED += riotboot
+endif
 
 # Various other features (if any)
 FEATURES_PROVIDED += radio_ble


### PR DESCRIPTION
### Contribution description

This PR attempts to add riotboot support to the nrf52 class mcu's. Unfortunately currently not compatible with the `nordic_softdevice_ble` package.

### Testing procedure

the default example (with and without bootloader) and the `tests/riotboot` test should both work with this PR

### Issues/PRs references

Depends on
* [x] nrf52: use cortexm.ld script when applicable https://github.com/RIOT-OS/RIOT/pull/11127
* [x] makefiles/tools/jlink.inc.mk: use FLASHFILE https://github.com/RIOT-OS/RIOT/pull/11130
- [x] jlink: handle flashing at IMAGE_OFFSET https://github.com/RIOT-OS/RIOT/pull/11200
- [x] Not needed ~riotboot.mk: get variable as hex rather than dec https://github.com/RIOT-OS/RIOT/pull/11201~