### PR TITLE
pkg/pkg.mk: make sure we are building the correct commit.

### DIFF
--- a/pkg/pkg.mk
+++ b/pkg/pkg.mk
@@ -9,25 +9,33 @@ ifneq (,$(PKG_SOURCE_LOCAL))
   include $(RIOTBASE)/pkg/local.mk
 else
 
-.PHONY: prepare git-download clean
+.PHONY: prepare git-download clean git-ensure-version
 
 prepare: git-download
 
 ifneq (,$(wildcard $(PKG_DIR)/patches))
 git-download: $(PKG_BUILDDIR)/.git-patched
 else
-git-download: $(PKG_BUILDDIR)/.git-downloaded
+git-download: git-ensure-version
 endif
 
 GITFLAGS ?= -c user.email=buildsystem@riot -c user.name="RIOT buildsystem"
 GITAMFLAGS ?= --no-gpg-sign --ignore-whitespace
 
 ifneq (,$(wildcard $(PKG_DIR)/patches))
-$(PKG_BUILDDIR)/.git-patched: $(PKG_BUILDDIR)/.git-downloaded $(PKG_DIR)/Makefile $(PKG_DIR)/patches/*.patch
+$(PKG_BUILDDIR)/.git-patched: git-ensure-version $(PKG_DIR)/Makefile $(PKG_DIR)/patches/*.patch
 	git -C $(PKG_BUILDDIR) checkout -f $(PKG_VERSION)
 	git $(GITFLAGS) -C $(PKG_BUILDDIR) am $(GITAMFLAGS) "$(PKG_DIR)"/patches/*.patch
 	touch $@
 endif
+
+git-ensure-version: $(PKG_BUILDDIR)/.git-downloaded
+	if [ $(shell git -C $(PKG_BUILDDIR) rev-parse HEAD) != $(PKG_VERSION) ] ; then \
+		git -C $(PKG_BUILDDIR) clean -xdff ; \
+		git -C $(PKG_BUILDDIR) fetch "$(PKG_URL)" "$(PKG_VERSION)" ; \
+		git -C $(PKG_BUILDDIR) checkout -f $(PKG_VERSION) ; \
+		touch $(PKG_BUILDDIR)/.git-downloaded ; \
+	fi
 
 $(PKG_BUILDDIR)/.git-downloaded:
 	rm -Rf $(PKG_BUILDDIR)


### PR DESCRIPTION
### Contribution description

This solves an issue I ran into while trying to figure out what was happening with edbg. I had two git worktrees and I had two different reset behaviours even though the PKG_VERSION of edbg was the same in both trees. Upon closer inspection I discovered that in one tree PKG_VERSION and the actual HEAD commit of edbg did not match.

Once the repo is downloaded, the version is not checked gain. This means that even if a package's Makefile is touched, that will only cause a rebuild of the previously downloaded version. For packages
that are normally not deleted, like edbg, this renders PKG_VERSION bumps ineffective, unless the user manually deletes the repo directory.

This patch fixes that by always checking that the repo is at the right commit.

### Testing procedure

I included a throwaway commit to make testing easier.

After checking out this, the first step is to go backwards to the commits before this PR, clean edbg, and download it and build it again:
```sh
# go before my first commit
$ git checkout 6ff1a57^
$ rm -rf dist/tools/edbg/edbg dist/tools/edbg/bin
$ make -C examples/hello-world $(pwd)/dist/tools/edbg/edbg
$ grep VERSION dist/tools/edbg/Makefile && git -C dist/tools/edbg/bin rev-parse HEAD
PKG_VERSION=807d948cc8a664ade3e9446b4937aa54268afcb2
807d948cc8a664ade3e9446b4937aa54268afcb2
```

Now let's try to bump the version:

```sh
$ git checkout 6ff1a57
$ make -C examples/hello-world $(pwd)/dist/tools/edbg/edbg
$ grep VERSION dist/tools/edbg/Makefile && git -C dist/tools/edbg/bin rev-parse HEAD
PKG_VERSION=ba864ebc46e985cb400ccdd63cdafaccbc3698c0
807d948cc8a664ade3e9446b4937aa54268afcb2
```

D'oh! that's not what we want. Now with the fix:
```sh
$ git checkout a0c709f
$ touch dist/tools/edbg/Makefile
$ make -C examples/hello-world $(pwd)/dist/tools/edbg/edbg
$ grep VERSION dist/tools/edbg/Makefile && git -C dist/tools/edbg/bin rev-parse HEAD
PKG_VERSION=ba864ebc46e985cb400ccdd63cdafaccbc3698c0
ba864ebc46e985cb400ccdd63cdafaccbc3698c0
```

### Issues/PRs references

Found when investigating #11125 .
