### PR TITLE
makefiles/tools/jlink.inc.mk: use FLASHFILE

### DIFF
--- a/makefiles/mcuboot.mk
+++ b/makefiles/mcuboot.mk
@@ -42,13 +42,11 @@ $(MCUBOOT_BIN):
 
 .PHONY: mcuboot-flash-bootloader mcuboot-flash
 
-mcuboot-flash-bootloader: HEXFILE = $(MCUBOOT_BIN)
 mcuboot-flash-bootloader: FLASHFILE = $(MCUBOOT_BIN)
 mcuboot-flash-bootloader: export FLASH_ADDR = 0x0
 mcuboot-flash-bootloader: $(MCUBOOT_BIN) $(FLASHDEPS)
 	$(flash-recipe)
 
-mcuboot-flash: HEXFILE = $(SIGN_BINFILE)
 mcuboot-flash: FLASHFILE = $(SIGN_BINFILE)
 mcuboot-flash: export FLASH_ADDR = $(MCUBOOT_SLOT0_SIZE)
 mcuboot-flash: mcuboot $(FLASHDEPS) mcuboot-flash-bootloader

--- a/makefiles/tools/jlink.inc.mk
+++ b/makefiles/tools/jlink.inc.mk
@@ -3,9 +3,9 @@ export DEBUGGER = $(RIOTTOOLS)/jlink/jlink.sh
 export DEBUGSERVER = $(RIOTTOOLS)/jlink/jlink.sh
 export RESET = $(RIOTTOOLS)/jlink/jlink.sh
 
-HEXFILE = $(BINFILE)
+FLASHFILE ?= $(BINFILE)
 
-export FFLAGS ?= flash $(HEXFILE)
+export FFLAGS ?= flash $(FLASHFILE)
 export DEBUGGER_FLAGS ?= debug $(ELFFILE)
 export DEBUGSERVER_FLAGS ?= debug-server
 export RESET_FLAGS ?= reset


### PR DESCRIPTION
### Contribution description

Update to use FLASHFILE as file to be flashed on the board.

### Testing procedure

We need to test that boards using `Jlink` would still work with this.
I will come up with a testing procedure without board.

#### Boards using JLink:

I listed all the boards using Jlink by using `git grep jlink.inc.mk` and checking also the boards using `common`.

```
echo ${JLINK_BOARDS}
arduino-mkr1000 arduino-mkrfox1200 arduino-mkrzero airfy-beacon calliope-mini microbit nrf51dk nrf51dongle nrf6310 yunjia-nrf51822 acd52832 nrf52840-mdk thingy52 nrf52840dk nrf52dk ruuvitag feather-m0 ikea-tradfri openmote-cc2538 sensebox_samd21 slstk3401a slstk3402a sltb001a slwstk6000b slwstk6220a stk3600 stk3700
```

Test flashing normal examples with the board:

* [x] nrf52dk @cladmi
* [x] sltb001a @cladmi 
* [ ] ... add other boards...

#### Test without board

I replaced FLASHER by 'true' to only show the FFLAGS and get the same output with master and this pull request:

```
for board in ${JLINK_BOARDS}; do echo ${board}; PROGRAMMER=jlink BOARD=${board} make --no-print-directory -C examples/hello-world/ flash-only FLASHER='true'; done
arduino-mkr1000
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/arduino-mkr1000/hello-world.bin
arduino-mkrfox1200
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/arduino-mkrfox1200/hello-world.bin
arduino-mkrzero
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/arduino-mkrzero/hello-world.bin
airfy-beacon
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/airfy-beacon/hello-world.elf
calliope-mini
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/calliope-mini/hello-world.bin
microbit
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/microbit/hello-world.bin
nrf51dk
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/nrf51dk/hello-world.bin
nrf51dongle
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/nrf51dongle/hello-world.bin
nrf6310
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/nrf6310/hello-world.bin
yunjia-nrf51822
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/yunjia-nrf51822/hello-world.elf
acd52832
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/acd52832/hello-world.bin
nrf52840-mdk
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/nrf52840-mdk/hello-world.bin
thingy52
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/thingy52/hello-world.bin
nrf52840dk
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/nrf52840dk/hello-world.bin
nrf52dk
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/nrf52dk/hello-world.bin
ruuvitag
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/ruuvitag/hello-world.bin
feather-m0
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/feather-m0/hello-world.bin
ikea-tradfri
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/ikea-tradfri/hello-world.bin
openmote-cc2538
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/openmote-cc2538/hello-world.bin
sensebox_samd21
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/sensebox_samd21/hello-world.bin
slstk3401a
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/slstk3401a/hello-world.bin
slstk3402a
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/slstk3402a/hello-world.bin
sltb001a
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/sltb001a/hello-world.bin
slwstk6000b
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/slwstk6000b/hello-world.bin
slwstk6220a
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/slwstk6220a/hello-world.bin
stk3600
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/stk3600/hello-world.bin
stk3700
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/stk3700/hello-world.bin
```

#### mcuboot test

Test flashing `tests/mcuboot` for `nrf52dk` (only one supported):

One `make term` and run `make -C tests/mcuboot/ clean mcuboot-flash`.
You should get:

```
2019-03-07 16:16:45,953 - INFO # You are running RIOT on a(n) nrf52dk board.
2019-03-07 16:16:45,957 - INFO # This board features a(n) nrf52 MCU.
2019-03-07 16:16:45,959 - INFO # The startup address is: 0x8200
```

### Issues/PRs references

Split out of https://github.com/RIOT-OS/RIOT/pull/8838
Depends on ~https://github.com/RIOT-OS/RIOT/pull/11112~
It would be useful to prevent extend the hack to Jlink for https://github.com/RIOT-OS/RIOT/pull/11126