### PR TITLE
pkg/nimble: optimize package initialization

### DIFF
--- a/examples/nimble_gatt/main.c
+++ b/examples/nimble_gatt/main.c
@@ -132,15 +132,6 @@ static const struct ble_gatt_svc_def gatt_svr_svcs[] = {
     },
 };
 
-static void update_ad(void)
-{
-    uint8_t buf[BLE_HS_ADV_MAX_SZ];
-    bluetil_ad_t ad;
-    bluetil_ad_init_with_flags(&ad, buf, sizeof(buf), BLUETIL_AD_FLAGS_DEFAULT);
-    bluetil_ad_add_name(&ad, device_name);
-    ble_gap_adv_set_data(ad.buf, ad.pos);
-}
-
 static int gap_event_cb(struct ble_gap_event *event, void *arg)
 {
     (void)arg;
@@ -346,8 +337,12 @@ int main(void)
     assert(rc == 0);
     (void)rc;
 
-    /* generate the advertising data */
-    update_ad();
+    /* configure and set the advertising data */
+    uint8_t buf[BLE_HS_ADV_MAX_SZ];
+    bluetil_ad_t ad;
+    bluetil_ad_init_with_flags(&ad, buf, sizeof(buf), BLUETIL_AD_FLAGS_DEFAULT);
+    bluetil_ad_add_name(&ad, device_name);
+    ble_gap_adv_set_data(ad.buf, ad.pos);
 
     /* start to advertise this node */
     start_advertise();

--- a/examples/nimble_gatt/main.c
+++ b/examples/nimble_gatt/main.c
@@ -35,6 +35,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "nimble_riot.h"
 #include "net/bluetil/ad.h"
 
 #include "host/ble_hs.h"
@@ -65,7 +66,6 @@ static const ble_uuid128_t gatt_svr_chr_rw_demo_readonly_uuid
                 0x4d, 0xd5, 0x40, 0x3f, 0x11, 0xdd, 0xcc);
 
 static const char *device_name = "NimBLE on RIOT";
-static uint8_t own_addr_type;
 
 static char rm_demo_write_data[64] = "This characteristic is read- and writeable!";
 
@@ -159,7 +159,7 @@ static void start_advertise(void)
     memset(&advp, 0, sizeof advp);
     advp.conn_mode = BLE_GAP_CONN_MODE_UND;
     advp.disc_mode = BLE_GAP_DISC_MODE_GEN;
-    rc = ble_gap_adv_start(own_addr_type, NULL, BLE_HS_FOREVER,
+    rc = ble_gap_adv_start(nimble_riot_own_addr_type, NULL, BLE_HS_FOREVER,
                            &advp, gap_event_cb, NULL);
     assert(rc == 0);
     (void)rc;
@@ -311,31 +311,16 @@ int main(void)
 
     int rc = 0;
 
+    /* verify and add our custom services */
     rc = ble_gatts_count_cfg(gatt_svr_svcs);
     assert(rc == 0);
-
     rc = ble_gatts_add_svcs(gatt_svr_svcs);
     assert(rc == 0);
 
     /* set the device name */
     ble_svc_gap_device_name_set(device_name);
-
-    /* initialize the GAP and GATT services */
-    ble_svc_gap_init();
-    ble_svc_gatt_init();
-    /* XXX: seems to be needed to apply the added services */
+    /* reload the GATT server to link our added services */
     ble_gatts_start();
-
-    /* make sure synchronization of host and controller is done, this should
-     * always be the case */
-    while (!ble_hs_synced()) {}
-
-    /* configure device address */
-    rc = ble_hs_util_ensure_addr(0);
-    assert(rc == 0);
-    rc = ble_hs_id_infer_auto(0, &own_addr_type);
-    assert(rc == 0);
-    (void)rc;
 
     /* configure and set the advertising data */
     uint8_t buf[BLE_HS_ADV_MAX_SZ];

--- a/pkg/nimble/contrib/include/nimble_riot.h
+++ b/pkg/nimble/contrib/include/nimble_riot.h
@@ -54,6 +54,11 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Export our own address type for later usage
+ */
+extern uint8_t nimble_riot_own_addr_type;
+
+/**
  * @brief   Setup and run NimBLE's controller and host threads
  */
 void nimble_riot_init(void);

--- a/pkg/nimble/contrib/nimble_riot.c
+++ b/pkg/nimble/contrib/nimble_riot.c
@@ -77,4 +77,8 @@ void nimble_riot_init(void)
                   _host_thread, NULL,
                   "nimble_host");
 #endif
+
+    /* make sure synchronization of host and controller is done, this should
+     * always be the case at this point */
+    while (!ble_hs_synced()) {}
 }

--- a/pkg/nimble/contrib/nimble_riot.c
+++ b/pkg/nimble/contrib/nimble_riot.c
@@ -22,6 +22,8 @@
 #include "nimble_riot.h"
 
 #include "nimble/nimble_port.h"
+#include "host/ble_hs.h"
+#include "host/util/util.h"
 
 #include "services/gap/ble_svc_gap.h"
 #include "services/gatt/ble_svc_gatt.h"
@@ -36,6 +38,8 @@ static char _stack_controller[NIMBLE_CONTROLLER_STACKSIZE];
 
 #ifdef MODULE_NIMBLE_HOST
 static char _stack_host[NIMBLE_HOST_STACKSIZE];
+
+uint8_t nimble_riot_own_addr_type;
 
 static void *_host_thread(void *arg)
 {
@@ -81,4 +85,12 @@ void nimble_riot_init(void)
     /* make sure synchronization of host and controller is done, this should
      * always be the case at this point */
     while (!ble_hs_synced()) {}
+
+    /* for reducing code duplication, we read our own address type once here
+     * so it can be re-used later on */
+    int res = ble_hs_util_ensure_addr(0);
+    assert(res == 0);
+    res = ble_hs_id_infer_auto(0, &nimble_riot_own_addr_type);
+    assert(res == 0);
+    (void)res;
 }

--- a/pkg/nimble/contrib/nimble_riot.c
+++ b/pkg/nimble/contrib/nimble_riot.c
@@ -93,4 +93,12 @@ void nimble_riot_init(void)
     res = ble_hs_id_infer_auto(0, &nimble_riot_own_addr_type);
     assert(res == 0);
     (void)res;
+
+    /* initialize the configured, build-in services */
+#ifdef MODULE_NIMBLE_SVC_GAP
+    ble_svc_gap_init();
+#endif
+#ifdef MODULE_NIMBLE_SVC_GATT
+    ble_svc_gatt_init();
+#endif
 }


### PR DESCRIPTION
### Contribution description
Some typical initialization steps for nimBLE need to be (re-)written for any application, so it makes sense to put them in the shared initialization code path to prevent (future) code duplication. I have a couple of additional example applications that I am preparing (mostly around ICN and IPv6 over BLE), and all of these will benefit from these proposed changes.

This PR collects some generic initialization artifacts and places them in the global init function. It then removes these lines from the `nimble_gatt` example.

### Testing procedure
Run the `examples/nimble_gatt` example an verify that all services are still working.

### Issues/PRs references
none