### PR TITLE
drivers/sx127x: add gpio pull config define for DIO pins

### DIFF
--- a/drivers/include/sx127x.h
+++ b/drivers/include/sx127x.h
@@ -95,6 +95,9 @@ extern "C" {
 #ifdef SX127X_USE_DIO_MULTI
 #define SX127X_IRQ_DIO_MULTI             (1<<6)  /**< DIO MULTI IRQ */
 #endif
+#ifndef SX127X_DIO_PULL_MODE
+#define SX127X_DIO_PULL_MODE             (GPIO_IN_PD) /**< pull down DIOx */
+#endif
 /** @} */
 
 /**

--- a/drivers/sx127x/sx127x.c
+++ b/drivers/sx127x/sx127x.c
@@ -234,8 +234,8 @@ static int _init_gpios(sx127x_t *dev)
 #ifndef SX127X_USE_DIO_MULTI
     /* Check if DIO0 pin is defined */
     if (dev->params.dio0_pin != GPIO_UNDEF) {
-        res = gpio_init_int(dev->params.dio0_pin, GPIO_IN, GPIO_RISING,
-                                sx127x_on_dio0_isr, dev);
+        res = gpio_init_int(dev->params.dio0_pin, SX127X_DIO_PULL_MODE,
+                            GPIO_RISING, sx127x_on_dio0_isr, dev);
         if (res < 0) {
             DEBUG("[sx127x] error: failed to initialize DIO0 pin\n");
             return res;
@@ -249,8 +249,8 @@ static int _init_gpios(sx127x_t *dev)
 
     /* Check if DIO1 pin is defined */
     if (dev->params.dio1_pin != GPIO_UNDEF) {
-        res = gpio_init_int(dev->params.dio1_pin, GPIO_IN, GPIO_RISING,
-                                sx127x_on_dio1_isr, dev);
+        res = gpio_init_int(dev->params.dio1_pin, SX127X_DIO_PULL_MODE,
+                            GPIO_RISING, sx127x_on_dio1_isr, dev);
         if (res < 0) {
             DEBUG("[sx127x] error: failed to initialize DIO1 pin\n");
             return res;
@@ -259,8 +259,8 @@ static int _init_gpios(sx127x_t *dev)
 
     /* check if DIO2 pin is defined */
     if (dev->params.dio2_pin != GPIO_UNDEF) {
-        res = gpio_init_int(dev->params.dio2_pin, GPIO_IN, GPIO_RISING,
-                            sx127x_on_dio2_isr, dev);
+        res = gpio_init_int(dev->params.dio2_pin, SX127X_DIO_PULL_MODE,
+                            GPIO_RISING, sx127x_on_dio2_isr, dev);
         if (res < 0) {
             DEBUG("[sx127x] error: failed to initialize DIO2 pin\n");
             return res;
@@ -269,8 +269,8 @@ static int _init_gpios(sx127x_t *dev)
 
     /* check if DIO3 pin is defined */
     if (dev->params.dio3_pin != GPIO_UNDEF) {
-        res = gpio_init_int(dev->params.dio3_pin, GPIO_IN, GPIO_RISING,
-                            sx127x_on_dio3_isr, dev);
+        res = gpio_init_int(dev->params.dio3_pin, SX127X_DIO_PULL_MODE,
+                            GPIO_RISING, sx127x_on_dio3_isr, dev);
         if (res < 0) {
             DEBUG("[sx127x] error: failed to initialize DIO3 pin\n");
             return res;
@@ -279,8 +279,8 @@ static int _init_gpios(sx127x_t *dev)
 #else
     if (dev->params.dio_multi_pin != GPIO_UNDEF) {
         DEBUG("[sx127x] info: Trying to initialize DIO MULTI pin\n");
-        res = gpio_init_int(dev->params.dio_multi_pin, GPIO_IN, GPIO_RISING,
-                                sx127x_on_dio_multi_isr, dev);
+        res = gpio_init_int(dev->params.dio_multi_pin, SX127X_DIO_PULL_MODE,
+                            GPIO_RISING, sx127x_on_dio_multi_isr, dev);
         if (res < 0) {
             DEBUG("[sx127x] error: failed to initialize DIO MULTI pin\n");
             return res;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
When testing #11022 I discovered that from time to time some spurious interrupts are triggered.
This adds a define to the sx127x driver that sets the gpios of the DIO pins to pull down by default because 
many lora modules actually come without pull resistors equipped (e.g. [I-NUCLEO-SX1272D](https://www.st.com/en/evaluation-tools/i-nucleo-sx1272d.html), [SX1276MB1xAS](https://os.mbed.com/components/SX1276MB1xAS/), [DRF1272F](https://www.tindie.com/products/DORJI_COM/868mhz-lora-sx1272-module-drf1272f/))

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
[edit] set `ENABLE_DEBUG (1)` in `pkg/semtech-loramac/contrib/semtech_loramac.c` then
flash tests/pkg_semtech-loramac on some nucleo board with one of the above modules connected and either leave it running for some hours or provoke an interrupt by touching the DIO3 Pin (aka PB4 or PWM//D5 on nucleo64 boards).
~Because of another bug in the driver this actually triggers a hardfault/reset.~ [edit] fixed by #11134


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
none
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
