### PR TITLE
nrf802154: Add rssi/lqi to received frames

### DIFF
--- a/cpu/nrf52/radio/nrf802154/nrf802154.c
+++ b/cpu/nrf52/radio/nrf802154/nrf802154.c
@@ -60,6 +60,9 @@ netdev_ieee802154_t nrf802154_dev = {
 static uint8_t rxbuf[IEEE802154_FRAME_LEN_MAX + 3]; /* len PHR + PSDU + LQI */
 static uint8_t txbuf[IEEE802154_FRAME_LEN_MAX + 3]; /* len PHR + PSDU + LQI */
 
+#define ED_RSSISCALE        (4U)
+#define ED_RSSIOFFS         (92U)
+
 #define RX_COMPLETE         (0x1)
 #define TX_COMPLETE         (0x2)
 #define LIFS                (40U)
@@ -317,6 +320,20 @@ static int _recv(netdev_t *dev, void *buf, size_t len, void *info)
     else {
         DEBUG("[nrf802154] recv: reading packet of length %i\n", pktlen);
         memcpy(buf, &rxbuf[1], pktlen);
+        if (info != NULL) {
+            netdev_ieee802154_rx_info_t *radio_info = info;
+            /* Hardware link quality indicator */
+            uint8_t hwlqi = rxbuf[pktlen + 1];
+            /* Convert to 802.15.4 LQI (page 319 of product spec v1.1) */
+            radio_info->lqi = (uint8_t)(hwlqi > UINT8_MAX/ED_RSSISCALE
+                                       ? UINT8_MAX
+                                       : hwlqi * ED_RSSISCALE);
+            /* Calculate RSSI by substracting the offset from the datasheet.
+             * Intentionally using a different calculation than the one from
+             * figure 122 of the v1.1 product specification. This appears to
+             * match real world performance better */
+            radio_info->rssi = (int16_t)hwlqi - ED_RSSIOFFS;
+        }
     }
 
     _reset_rx();


### PR DESCRIPTION
### Contribution description

This PR adds support for reporting RSSI and LQI values for received frames on the nrf802154 radio.

LQI calculation following the instructions from the datasheet. RSSI calculation appears to only require the offset and not the scaling factor, this was determined by measuring this by transmitting frames with a samr21-xpro and adjusting the power output on the samr21-xpro while keeping it stationary.

### Testing procedure

Should at least still compile. RSSI measurements can be displayed using #11092

### Issues/PRs references

None