### PR TITLE
pkg/semtech_loramac: add null pointer guards to semtech_loramac_radio…

### DIFF
--- a/pkg/semtech-loramac/contrib/semtech_loramac.c
+++ b/pkg/semtech-loramac/contrib/semtech_loramac.c
@@ -630,12 +630,18 @@ static void _semtech_loramac_event_cb(netdev_t *dev, netdev_event_t event)
 
         case NETDEV_EVENT_FHSS_CHANGE_CHANNEL:
             DEBUG("[semtech-loramac] FHSS channel change\n");
-            semtech_loramac_radio_events.FhssChangeChannel(((sx127x_t *)dev)->_internal.last_channel);
+            if(semtech_loramac_radio_events.FhssChangeChannel) {
+                semtech_loramac_radio_events.FhssChangeChannel((
+                            (sx127x_t *)dev)->_internal.last_channel);
+            }
             break;
 
         case NETDEV_EVENT_CAD_DONE:
             DEBUG("[semtech-loramac] test: CAD done\n");
-            semtech_loramac_radio_events.CadDone(((sx127x_t *)dev)->_internal.is_last_cad_success);
+            if(semtech_loramac_radio_events.CadDone) {
+                semtech_loramac_radio_events.CadDone((
+                            (sx127x_t *)dev)->_internal.is_last_cad_success);
+            }
             break;
 
         default:


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
See https://github.com/RIOT-OS/RIOT/pull/11132#issuecomment-470586008
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Testing procedure has to be done preferably without pull resistors (so no PR #11132).
Either touch the DIO3 in the board with a jumper wire or try to set it to high and low to trigger the interrupt. The application will crash without this PR.

Alternatively, call netdev->event_callback with NETDEV_EVENT_CAD_DONE. It will have the same effect.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Indirectly #11132 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
