### PR TITLE
gnrc_sixlowpan_frag: replace printf with DEBUG

### DIFF
--- a/sys/net/gnrc/network_layer/sixlowpan/frag/gnrc_sixlowpan_frag.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/gnrc_sixlowpan_frag.c
@@ -287,7 +287,7 @@ void gnrc_sixlowpan_frag_send(gnrc_pktsnip_t *pkt, void *ctx, unsigned page)
     msg.type = GNRC_SIXLOWPAN_MSG_FRAG_SND,
     msg.content.ptr = fragment_msg;
     if (msg_send_to_self(&msg) == 0) {
-        printf("6lo frag: message queue full, can't issue next fragment "
+        DEBUG("6lo frag: message queue full, can't issue next fragment "
               "sending\n");
         goto error;
     }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
In https://github.com/RIOT-OS/RIOT/pull/10679 there was a `printf()` introduced accidentally. This changes that to a `DEBUG()`. 
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`gnrc_networking` should still compile, it's size might shrink a bit but should not grow.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up to https://github.com/RIOT-OS/RIOT/pull/10679.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
