### PR TITLE
nrf802154: take FCS into account for lifs/sifs calculation

### DIFF
--- a/cpu/nrf52/radio/nrf802154/nrf802154.c
+++ b/cpu/nrf52/radio/nrf802154/nrf802154.c
@@ -280,7 +280,8 @@ static int _send(netdev_t *dev,  const iolist_t *iolist)
     DEBUG("[nrf802154] send: putting %i byte into the ether\n", len);
 
     /* set interframe spacing based on packet size */
-    unsigned int ifs = (len > SIFS_MAXPKTSIZE) ? LIFS : SIFS;
+    unsigned int ifs = (len + IEEE802154_FCS_LEN > SIFS_MAXPKTSIZE) ? LIFS
+                                                                    : SIFS;
     timer_set_absolute(NRF802154_TIMER, 0, ifs);
 
     return len;


### PR DESCRIPTION
### Contribution description

The FCS is part of the MAC frame and should be included in the size calculation for determining whether to use LIFS or SIFS between the frames

### Testing procedure

I have no clue unless somebody is able to actually measure or sniff this on the air.

### Issues/PRs references

None
