### PR TITLE
cpu/nrf5x: add driver for internal temperature sensor

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -602,6 +602,10 @@ ifneq (,$(filter saul,$(USEMODULE)))
   USEMODULE += phydat
 endif
 
+ifneq (,$(filter saul_nrf_temperature,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_temperature
+endif
+
 ifneq (,$(filter phydat,$(USEMODULE)))
   USEMODULE += fmt
 endif

--- a/boards/common/nrf51/Makefile.dep
+++ b/boards/common/nrf51/Makefile.dep
@@ -1,3 +1,7 @@
 ifneq (,$(filter gnrc_netdev_default netdev_default,$(USEMODULE)))
   USEMODULE += nrfmin
 endif
+
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_nrf_temperature
+endif

--- a/boards/common/nrf52/Makefile.dep
+++ b/boards/common/nrf52/Makefile.dep
@@ -3,3 +3,7 @@ include $(RIOTCPU)/nrf52/Makefile.dep
 ifneq (,$(filter skald,$(USEMODULE)))
   USEMODULE += nrfble
 endif
+
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_nrf_temperature
+endif

--- a/cpu/nrf5x_common/Makefile.features
+++ b/cpu/nrf5x_common/Makefile.features
@@ -3,6 +3,7 @@ FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_hwrng
+FEATURES_PROVIDED += periph_temperature
 
 # Various other features (if any)
 FEATURES_PROVIDED += radio_nrfmin

--- a/cpu/nrf5x_common/periph/temperature.c
+++ b/cpu/nrf5x_common/periph/temperature.c
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2019 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
+
+/**
+ * @ingroup     cpu_nrf5x_common
+ * @{
+ *
+ * @file
+ * @brief       Implementation of the temperature peripheral internal driver
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "saul.h"
+#include "saul_reg.h"
+#include "phydat.h"
+
+void temperature_read(int16_t *temp)
+{
+    /* Start temperature measurement task */
+    NRF_TEMP->TASKS_START = 1;
+
+    /* Wait for temperature measurement to be ready */
+    while (!NRF_TEMP->EVENTS_DATARDY); /* takes 36us according to manual */
+
+    /* temperature is in 0.25°C step, so just divide by 4 */
+    *temp = (int16_t)NRF_TEMP->TEMP >> 2;
+
+    /* Clear data ready bit and stop temperature measurement task */
+    NRF_TEMP->EVENTS_DATARDY = 0;
+    NRF_TEMP->TASKS_STOP = 1;
+}
+
+static int _read_temperature(const void *dev, phydat_t *res)
+{
+    (void) dev;
+    temperature_read(&res->val[0]);
+    res->val[1] = 0;
+    res->val[2] = 0;
+    res->unit = UNIT_TEMP_C;
+    res->scale = 0;
+    return 1;
+}
+
+const saul_reg_info_t nrf_temperature_saul_info = {
+    .name = "NRF_TEMP"
+};
+
+const saul_driver_t nrf_temperature_saul_driver = {
+    .read = _read_temperature,
+    .write = saul_notsup,
+    .type = SAUL_SENSE_TEMP,
+};

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -62,6 +62,7 @@ PSEUDOMODULES += riotboot_%
 PSEUDOMODULES += saul_adc
 PSEUDOMODULES += saul_default
 PSEUDOMODULES += saul_gpio
+PSEUDOMODULES += saul_nrf_temperature
 PSEUDOMODULES += schedstatistics
 PSEUDOMODULES += sock
 PSEUDOMODULES += sock_ip

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -326,6 +326,10 @@ void auto_init(void)
     extern void auto_init_gpio(void);
     auto_init_gpio();
 #endif
+#ifdef MODULE_SAUL_NRF_TEMPERATURE
+    extern void auto_init_nrf_temperature(void);
+    auto_init_nrf_temperature();
+#endif
 #ifdef MODULE_AD7746
     extern void auto_init_ad7746(void);
     auto_init_ad7746();

--- a/sys/auto_init/saul/auto_init_nrf_temperature.c
+++ b/sys/auto_init/saul/auto_init_nrf_temperature.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2019 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
+
+/**
+ * @ingroup     sys_auto_init_saul
+ * @{
+ *
+ * @file
+ * @brief       Auto initialization of internal temperature sensor directly mapped to SAUL reg
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#ifdef MODULE_SAUL_NRF_TEMPERATURE
+
+#include "cpu.h"
+#include "log.h"
+#include "saul_reg.h"
+#include "saul/periph.h"
+
+/**
+ * @brief   Memory for the registry entries
+ */
+static saul_reg_t saul_reg_entry;
+
+/**
+ * @brief   Reference the driver struct
+ */
+extern saul_driver_t nrf_temperature_saul_driver;
+
+/**
+ * @brief   Reference the information for saul registry
+ */
+extern saul_reg_info_t nrf_temperature_saul_info;
+
+void auto_init_nrf_temperature(void)
+{
+    saul_reg_entry.dev = NULL;
+    saul_reg_entry.name = nrf_temperature_saul_info.name;
+    saul_reg_entry.driver = &nrf_temperature_saul_driver;
+    /* add to registry */
+    saul_reg_add(&(saul_reg_entry));
+}
+
+#else
+typedef int dont_be_pedantic;
+#endif /* MODULE_SAUL_NRF_TEMPERATURE */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The Nordic MCUs provide an internal temperature sensor. This PR is providing a basic implementation for it and wraps it in the saul API.

The driver is enabled for all nrf (51 and 52) boards.

I'm not sure of the design approach of this PR, so review comments to improve are welcome.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Build and flash examples/saul on any nrf based board, and read the temperature.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
