### PR TITLE
stm32l0: add riotboot support

### DIFF
--- a/boards/b-l072z-lrwan1/Makefile.features
+++ b/boards/b-l072z-lrwan1/Makefile.features
@@ -6,6 +6,12 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
+# Put other features for this board (in alphabetical order)
+# For riotboot you need an openocd that supports dualbank flashing.
+# The 0.10.0 openocd version in Ubuntu Bionic doesn't work. The change was
+# introduced after Jun 8, 2017 - v0.10.0-1-20170607-2132-dev.
+FEATURES_PROVIDED += riotboot
+
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0_1
 

--- a/boards/nucleo-l073rz/Makefile.features
+++ b/boards/nucleo-l073rz/Makefile.features
@@ -9,8 +9,9 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
 # Put other features for this board (in alphabetical order)
-# For riotboot you need an openocd that supports dualbank flashing
-# (version >= v0.10.0)
+# For riotboot you need an openocd that supports dualbank flashing.
+# The 0.10.0 openocd version in Ubuntu Bionic doesn't work. The change was
+# introduced after Jun 8, 2017 - v0.10.0-1-20170607-2132-dev.
 FEATURES_PROVIDED += riotboot
 
 # load the common Makefile.features for Nucleo boards

--- a/boards/nucleo-l073rz/Makefile.features
+++ b/boards/nucleo-l073rz/Makefile.features
@@ -8,6 +8,11 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
+# Put other features for this board (in alphabetical order)
+# For riotboot you need an openocd that supports dualbank flashing
+# (version >= v0.10.0)
+FEATURES_PROVIDED += riotboot
+
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.features
 

--- a/cpu/stm32l0/include/cpu_conf.h
+++ b/cpu/stm32l0/include/cpu_conf.h
@@ -41,6 +41,7 @@ extern "C" {
 #else
 #define CPU_IRQ_NUMOF                   (32U)
 #endif
+#define CPU_FLASH_BASE                  FLASH_BASE
 /** @} */
 
 /**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

 This PR add's the bootlaoder feature to stm32l0 boards. In this case it has been tested on nucleo-l073rz and b-l072z-lrwan1. I didn't change the openocd script in stm32l0.cfg because not all stm32l0xx have dual flash so this depends on the actual cpu used and I thought it should be handled by each board.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

On mentioned boards run :

`BOARD=nucleo-l073rz FEATURES_REQUIRED+=riotboot APP_VER=$(date +%s) make -C examples/hello-world/ riotboot/flash-extended-slot0`

`BOARD=nucleo-l073rz FEATURES_REQUIRED+=riotboot APP_VER=$(date +%s) make -C examples/hello-world/ riotboot/flash-slot1
`
It works with other larger appilcations, tested with tests/pkg_semtech_loramac as well.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
 
Adding dual bank support fixes #10206, related to #10213. Depends on #11174.