### PR TITLE
added SPI support for Nucleo-F767ZI 

### DIFF
--- a/boards/nucleo-f767zi/include/periph_conf.h
+++ b/boards/nucleo-f767zi/include/periph_conf.h
@@ -142,6 +142,16 @@ static const spi_conf_t spi_config[] = {
         .rccmask  = RCC_APB2ENR_SPI1EN,
         .apbbus   = APB2
     },
+    {
+        .dev      = SPI4,
+        .mosi_pin = GPIO_PIN(PORT_E, 6),
+        .miso_pin = GPIO_PIN(PORT_E, 5),
+        .sclk_pin = GPIO_PIN(PORT_E, 2),
+        .cs_pin   = GPIO_UNDEF,
+        .af       = GPIO_AF5,
+        .rccmask  = RCC_APB2ENR_SPI4EN,
+        .apbbus   = APB2
+    }
 };
 
 #define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))


### PR DESCRIPTION
### Contribution description

SPI config  is missing for the nucleo-f767zi. 
I added the SPI divtable and configurations for SPI1 and SPI2  to `boards/nucleo-f767zi/include/periph_conf.h` and the corresponding `FEATURE_PROVIDED` to `boards/nucleo-f767zi/Makefile.features`

