### PR TITLE
netdev/lora: add netdev_lora_rx_info structure for RX info

### DIFF
--- a/drivers/include/net/netdev/lora.h
+++ b/drivers/include/net/netdev/lora.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2019 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for
+ * more details.
+ */
+
+/**
+ * @defgroup    drivers_netdev_lora LoRa drivers
+ * @ingroup     drivers_netdev_api
+ * @{
+ *
+ * @file
+ * @brief       Definitions for netdev common LoRa code
+ *
+ * @author      José Ignacio Alamos <jose.alamos@haw-hamburg.de>
+ */
+
+
+#ifndef NET_NETDEV_LORA_H
+#define NET_NETDEV_LORA_H
+
+#include <stdint.h>
+
+#include "net/netdev.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Received LoRa packet status information
+ */
+typedef struct {
+    uint8_t rssi;           /**< RSSI of a received packet */
+    int8_t snr;             /**< S/N ratio */
+} netdev_lora_rx_info_t;
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NET_NETDEV_LORA_H */
+/** @} */

--- a/drivers/sx127x/include/sx127x_netdev.h
+++ b/drivers/sx127x/include/sx127x_netdev.h
@@ -31,15 +31,6 @@ extern "C" {
  */
 extern const netdev_driver_t sx127x_driver;
 
-/**
- * @brief   Received LoRa packet status information
- */
-typedef struct netdev_radio_lora_packet_info {
-    uint8_t rssi;           /**< RSSI of a received packet */
-    uint8_t lqi;            /**< LQI of a received packet */
-    int8_t snr;             /**< S/N ratio */
-} netdev_sx127x_lora_packet_info_t;
-
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/sx127x/sx127x_netdev.c
+++ b/drivers/sx127x/sx127x_netdev.c
@@ -23,6 +23,7 @@
 
 #include "net/netopt.h"
 #include "net/netdev.h"
+#include "net/netdev/lora.h"
 #include "net/lora.h"
 
 #include "sx127x_registers.h"
@@ -138,10 +139,8 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
                 return -EBADMSG;
             }
 
-            netdev_sx127x_lora_packet_info_t *packet_info = info;
+            netdev_lora_rx_info_t *packet_info = info;
             if (packet_info) {
-                /* there is no LQI for LoRa */
-                packet_info->lqi = 0;
                 uint8_t snr_value = sx127x_reg_read(dev, SX127X_REG_LR_PKTSNRVALUE);
                 if (snr_value & 0x80) { /* The SNR is negative */
                     /* Invert and divide by 4 */

--- a/pkg/semtech-loramac/contrib/semtech_loramac.c
+++ b/pkg/semtech-loramac/contrib/semtech_loramac.c
@@ -31,6 +31,7 @@
 #include "mutex.h"
 
 #include "net/netdev.h"
+#include "net/netdev/lora.h"
 #include "net/loramac.h"
 
 #include "sx127x.h"
@@ -579,7 +580,7 @@ static void _semtech_loramac_call(semtech_loramac_func_t func, void *arg)
 
 static void _semtech_loramac_event_cb(netdev_t *dev, netdev_event_t event)
 {
-    netdev_sx127x_lora_packet_info_t packet_info;
+    netdev_lora_rx_info_t packet_info;
 
     msg_t msg;
     msg.content.ptr = dev;

--- a/tests/driver_sx127x/main.c
+++ b/tests/driver_sx127x/main.c
@@ -32,6 +32,7 @@
 #include "shell_commands.h"
 
 #include "net/netdev.h"
+#include "net/netdev/lora.h"
 #include "net/lora.h"
 
 #include "board.h"
@@ -324,7 +325,7 @@ static void _event_cb(netdev_t *dev, netdev_event_t event)
     }
     else {
         size_t len;
-        netdev_sx127x_lora_packet_info_t packet_info;
+        netdev_lora_rx_info_t packet_info;
         switch (event) {
             case NETDEV_EVENT_RX_COMPLETE:
                 len = dev->driver->recv(dev, NULL, 0, 0);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR adds a generic RX info structure for LoRa devices. This obsoletes the `netdev_sx127x_lora_packet_info_t` structure, so MAC layers are not dependent on driver specific headers.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Test documentation with `make doc`.
Test that `tests/pkg_semtech_loramac`, `examples/lorawan` and `tests/drivers_sx127x` compile with no errors.
You should be able to see these RX info with `tests/drivers_sx127x`
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Addresses https://github.com/RIOT-OS/RIOT/pull/6797#discussion_r260303912
#11022 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
