### PR TITLE
make: newlib: check if newlib nano folder was found

### DIFF
--- a/makefiles/libc/newlib.mk
+++ b/makefiles/libc/newlib.mk
@@ -93,6 +93,11 @@ ifeq (1,$(USE_NEWLIB_NANO))
   NEWLIB_NANO_INCLUDE_DIR ?= $(firstword $(wildcard $(NEWLIB_INCLUDE_DIR)/newlib-nano \
                                                     $(NEWLIB_INCLUDE_DIR)/newlib/nano \
                                                     $(NEWLIB_INCLUDE_DIR)/nano))
+
+  ifeq (,$(NEWLIB_NANO_INCLUDE_DIR))
+    $(error USE_NEWLIB_NANO==1 but nano include folder not found!)
+  endif
+
   # newlib-nano overrides newlib.h and its include dir should therefore go before
   # the regular system include dirs.
   INCLUDES := -isystem $(NEWLIB_NANO_INCLUDE_DIR) $(INCLUDES)


### PR DESCRIPTION
### Contribution description

The logic for finding the newlib nano include dir can, if no folder is found, end up with an empty "-I".
This leads to weird error messages, like:

```cc1: error: -I/home/kaspar/src/riot/core/include: No such file or directory [-Werror=missing-include-dirs]```

followed by many headers that cannot be found.

This is caused by "-I -Icpu/include". I lost a while debugging this, and just yesterday another user on IRC popped up with the same problem.

Underlying is a fedora newlib packaging problem, which seems to not build with nanospecs.

This PR adds a simple check whether NEWLIB_NANO_INCLUDE_DIR is empty despite nanospecs enabled, and outputs an error.

### Testing procedure

Move the newlib nano folder (/usr/arm-none-eabi/include/newlib-nano on my arch) out of the way. Compile on master and with this PR.

### Issues/PRs references

none