### PR TITLE
nrf802154: Fix IFS timings

### DIFF
--- a/cpu/nrf52/radio/nrf802154/nrf802154.c
+++ b/cpu/nrf52/radio/nrf802154/nrf802154.c
@@ -189,7 +189,6 @@ static void _timer_cb(void *arg, int chan)
     (void)chan;
     mutex_unlock(&_txlock);
     timer_stop(NRF802154_TIMER);
-    timer_clear(NRF802154_TIMER, 0);
 }
 
 static int _init(netdev_t *dev)
@@ -199,6 +198,7 @@ static int _init(netdev_t *dev)
     int result = timer_init(NRF802154_TIMER, TIMER_FREQ, _timer_cb, NULL);
     assert(result >= 0);
     (void)result;
+    timer_stop(NRF802154_TIMER);
 
     /* initialize local variables */
     mutex_init(&_txlock);
@@ -285,7 +285,7 @@ static int _send(netdev_t *dev,  const iolist_t *iolist)
     /* set interframe spacing based on packet size */
     unsigned int ifs = (len + IEEE802154_FCS_LEN > SIFS_MAXPKTSIZE) ? LIFS
                                                                     : SIFS;
-    timer_set_absolute(NRF802154_TIMER, 0, ifs);
+    timer_set(NRF802154_TIMER, 0, ifs);
 
     return len;
 }

--- a/cpu/nrf52/radio/nrf802154/nrf802154.c
+++ b/cpu/nrf52/radio/nrf802154/nrf802154.c
@@ -68,7 +68,7 @@ static uint8_t txbuf[IEEE802154_FRAME_LEN_MAX + 3]; /* len PHR + PSDU + LQI */
 #define LIFS                (40U)
 #define SIFS                (12U)
 #define SIFS_MAXPKTSIZE     (18U)
-#define TIMER_FREQ          (250000UL)
+#define TIMER_FREQ          (62500UL)
 static volatile uint8_t _state;
 static mutex_t _txlock;
 

--- a/cpu/nrf52/radio/nrf802154/nrf802154.c
+++ b/cpu/nrf52/radio/nrf802154/nrf802154.c
@@ -232,6 +232,9 @@ static int _init(netdev_t *dev)
     NRF_RADIO->CRCPOLY = 0x011021;
     NRF_RADIO->CRCINIT = 0;
 
+    /* Disable the hardware IFS handling  */
+    NRF_RADIO->MODECNF0 |= RADIO_MODECNF0_RU_Msk;
+
     /* assign default addresses */
     luid_get(nrf802154_dev.long_addr, IEEE802154_LONG_ADDRESS_LEN);
     memcpy(nrf802154_dev.short_addr, &nrf802154_dev.long_addr[6],


### PR DESCRIPTION
### Contribution description

This PR fixes two issues with the IFS timing in the nrf802154 radio driver.

 I've used the following patch to measure timings of the radio IFS timer:
```patch
diff --git a/cpu/nrf52/radio/nrf802154/nrf802154.c b/cpu/nrf52/radio/nrf802154/nrf802154.c
index 1a57a8799..9ce87eaa1 100644
--- a/cpu/nrf52/radio/nrf802154/nrf802154.c
+++ b/cpu/nrf52/radio/nrf802154/nrf802154.c
@@ -24,6 +24,7 @@
 #include <errno.h>

 #include "cpu.h"
+#include "periph/gpio.h"
 #include "luid.h"
 #include "mutex.h"

@@ -184,6 +185,7 @@ static void _timer_cb(void *arg, int chan)
 {
     (void)arg;
     (void)chan;
+    gpio_clear(GPIO_PIN(1,9));
     mutex_unlock(&_txlock);
     timer_stop(NRF802154_TIMER);
     timer_clear(NRF802154_TIMER, 0);
@@ -193,6 +195,7 @@ static int _init(netdev_t *dev)
 {
     (void)dev;

+    gpio_init(GPIO_PIN(1, 9), GPIO_OUT);
     int result = timer_init(NRF802154_TIMER, TIMER_FREQ, _timer_cb, NULL);
     assert(result >= 0);
     (void)result;
@@ -415,6 +418,7 @@ void isr_radio(void)
             case RADIO_STATE_STATE_Tx:
             case RADIO_STATE_STATE_TxIdle:
             case RADIO_STATE_STATE_TxDisable:
+                gpio_set(GPIO_PIN(1, 9));
                 timer_start(NRF802154_TIMER);
                 DEBUG("[nrf802154] TX state: %x\n", (uint8_t)NRF_RADIO->STATE);
                 _state |= TX_COMPLETE;
```
The GPIO is set before the timer is started and cleared in the interrupt.

Using this at the current master results in the following timing (LIFS value):
![nrf_orig](https://user-images.githubusercontent.com/5160052/54052130-ea8cfa00-41e3-11e9-88aa-e36bb15a05c8.png)

measured on the nrf52840 using `examples/gnrc_networking` with
```
ping6 fe80::7b67:1860:420c:f43a -c 100  -i 250 -s 200
```
The payload size of 200B is the most important as it causes the packet to be split into multiple frames.

The correct timing for the LIFS should be: 
 - LIFS: 40 symbols (IEEE 802.15.4-2011: *macLIFSPeriod* – 40 symbols)
 - Symbol rate: 62.5Ksymbol/s ((IEEE 802.15.4-2011 table 66, 2450 DSSS)
giving us 40 symbols / 62.5Ksymbol/s = 640μs.

This doesn't match the current measured timeout value.

### Fix

The fix here is twofold. The first commit is modifies the `TIMER_FREQ` to match the symbol rate as specified in the ieee 802.15.4 specification. With this a timer tick and an ieee 802.15.4 symbol are equal in duration. The `SIFS` and `LIFS` defines then also match their durations in symbols.

The second issue is caused by timer_clear function. It doesn't clear the hardware timer counter, but
is designed to clear the allocation of the channel. The consequence is that the IFS timer here is not set to zero in the callback, but only stopped at the current value. When the timer is started again, it has to
count the full timer range until it matches the timeout value again. With the timer never reset to zero, it doesn't count the `LIFS`/`SIFS` duration but the timer range * `TIMER_FREQ` duration (1024 μs in the intial measurement).

Measuring again with the same setup as above gives:
![nrf_fixed](https://user-images.githubusercontent.com/5160052/54052612-2a081600-41e5-11e9-96b4-e5bec3220acd.png)

Matching the calculated LIFS value from the spec.

### Testing procedure

I won't blame anyone for not reproducing my measurement with their own logic analyzer. Testing that ping with large payloads (multiple L2 frames) still work should IMHO be enough. Ping response timings should decrease slightly (121ms vs 117ms average for 1000B payload).

### Issues/PRs references

None