### PR TITLE
pkg/lwip: include log.h if module log is used

### DIFF
--- a/pkg/lwip/include/arch/cc.h
+++ b/pkg/lwip/include/arch/cc.h
@@ -29,6 +29,10 @@
 #include "byteorder.h"
 #include "mutex.h"
 
+#ifdef MODULE_LOG
+#include "log.h"
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
### Contribution description

If module `log` is used, `log.h` should be included. Otherwise, it might lead to compilation problems since `LOG_ERROR` macro isn't know in expansion of `LWIP_PLATFORM_ASSERT` macro.

### Testing procedure

Just compile any `lwip` test application.