### PR TITLE
l3g4200d: Fixes conversion bug

### DIFF
--- a/drivers/include/l3g4200d.h
+++ b/drivers/include/l3g4200d.h
@@ -95,8 +95,8 @@ typedef struct {
  * @brief   Device descriptor for L3G4200D sensors
  */
 typedef struct {
-    l3g4200d_params_t params; /**< device initialization parameters */
-    int scale;                /**< internal scaling factor to normalize results */
+    l3g4200d_params_t params;     /**< device initialization parameters */
+    int32_t scale;                /**< internal scaling factor to normalize results */
 } l3g4200d_t;
 
 /**


### PR DESCRIPTION
There is a bug in the l3g4200d driver, which converted all the values my MCU (atmega1284p) received from the sensor to 0. 

### Contribution description

This PR fixes a conversion bug in the l3g4200d driver.

### Issues/PRs references

Fixes #11151. 

