### PR TITLE
drivers/encx24j600: lock dev in netopt get()

### DIFF
--- a/drivers/encx24j600/encx24j600.c
+++ b/drivers/encx24j600/encx24j600.c
@@ -386,13 +386,18 @@ static int _get(netdev_t *dev, netopt_t opt, void *value, size_t max_len)
             }
             break;
         case NETOPT_LINK_CONNECTED:
-            if (reg_get((encx24j600_t *)dev, ENC_ESTAT) & ENC_PHYLNK) {
-                *((netopt_enable_t *)value) = NETOPT_ENABLE;
+            {
+                encx24j600_t * encdev = (encx24j600_t *) dev;
+                lock(encdev);
+                if (reg_get(encdev, ENC_ESTAT) & ENC_PHYLNK) {
+                    *((netopt_enable_t *)value) = NETOPT_ENABLE;
+                }
+                else {
+                    *((netopt_enable_t *)value) = NETOPT_DISABLE;
+                }
+                unlock(encdev);
+                return sizeof(netopt_enable_t);
             }
-            else {
-                *((netopt_enable_t *)value) = NETOPT_DISABLE;
-            }
-            return sizeof(netopt_enable_t);
         default:
             res = netdev_eth_get(dev, opt, value, max_len);
             break;


### PR DESCRIPTION
### Contribution description

#8601 introduced getting the link state via netopt. Unfortunately the reg_get() call wasn't wrapped in the driver's ```lock()/unlock()```, which also acquires and configures the SPI bus.
This made the driver hang in the netopt call, e.g., when typing "ifconfig" on any gnrc shell.

### Testing procedure

Try "ifconfig" with "tests/driver_encx24j600" with/without this PR.

### Issues/PRs references

#8601