### PR TITLE
bmp180: Fixes conversion bug

### DIFF
--- a/drivers/bmp180/bmp180.c
+++ b/drivers/bmp180/bmp180.c
@@ -147,8 +147,8 @@ uint32_t bmp180_read_pressure(const bmp180_t *dev)
     x1 = ((int32_t)dev->calibration.ac3 * b6) >> 13;
     x2 = ((int32_t)dev->calibration.b1 * (b6 * b6) >> 12) >> 16;
     x3 = ((x1 + x2) + 2) >> 2;
-    b4 = (int32_t)dev->calibration.ac4 * (uint32_t)(x3+32768) >> 15;
-    b7 = ((uint32_t)up - b3) * (uint32_t)(50000UL >> OVERSAMPLING);
+    b4 = ((uint32_t)dev->calibration.ac4 * (uint32_t)(x3 + 32768)) >> 15;
+    b7 = (uint32_t)(up - b3) * (uint32_t)(50000UL >> OVERSAMPLING);
     if (b7 < 0x80000000) {
         p = (b7 * 2) / b4;
     }
@@ -240,9 +240,9 @@ static int _read_up(const bmp180_t *dev, int32_t *output)
 
 static int _compute_b5(const bmp180_t *dev, int32_t ut, int32_t *output)
 {
-    int32_t x1, x2;
-    x1 = (ut - dev->calibration.ac6) * dev->calibration.ac5 >> 15;
-    x2 = (dev->calibration.mc << 11) / (x1 + dev->calibration.md);
+    int32_t x1 = 0, x2 = 0;
+    x1 = (((int32_t)ut - (int32_t)dev->calibration.ac6) * (int32_t)dev->calibration.ac5) >> 15;
+    x2 = ((int32_t)dev->calibration.mc << 11) / (x1 + dev->calibration.md);
 
     *output = x1 + x2;
 


### PR DESCRIPTION
Due to wrong typecasting, the bmp180 driver returned wrong temperature and pressure values. 

### Contribution description
This PR fixes the bug in the bmp180 driver.

### Testing procedure

If you want to test this: please note, that in the test driver_bmp180, your altitude is not calculated but set with a define in the makefile. This can be the cause for the test to return weird values for altitude and pressure.


