### PR TITLE
tools/edbg: Update to latest version.

### DIFF
--- a/dist/tools/edbg/Makefile
+++ b/dist/tools/edbg/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=edbg
 PKG_URL=https://github.com/ataradov/edbg
-PKG_VERSION=807d948cc8a664ade3e9446b4937aa54268afcb2
+PKG_VERSION=4f5d490bfffc7fd10855e513e6e88be5a9a3f789
 PKG_LICENSE=BSD-3-Clause
 PKG_BUILDDIR=$(CURDIR)/bin
 


### PR DESCRIPTION
### Contribution description

The lastest version of edbg solves a double-reset issue that was hindering testing (see #11125 and https://github.com/ataradov/edbg/issues/77)

It also adds support for SAMR34 and SAMR35, needed by @dylad for MCU port (that's why it has both the "bug" and "feature" labels.)

### Testing procedure

~Without #11129 the package won't be updated unless the edbg binary and the repo are deleted.~ (Edit: #11129 is in).

```sh
# EDIT: This is not needed anymore
$ rm -rf dist/tools/edbg/edbg dist/tools/edbg/bin
```

Proceed to flash and reset any atmel board.

```sh
$ BOARD=samr21-xpro make -C examples/hello-world all flash
$ BOARD=samr21-xpro make -C examples/hello-world reset
```

### Issues/PRs references

Fixes: #11125.
~Would be nice to have #11129 before so that users get the update automatically.~
I'm finding hard to test #11099 without this (double resets cause failures unrelated to the change).