### PR TITLE
cpu/stm32l1: add stop and standby modes, adds pm_layered

### DIFF
--- a/cpu/stm32_common/include/periph_cpu_common.h
+++ b/cpu/stm32_common/include/periph_cpu_common.h
@@ -78,7 +78,8 @@ extern "C" {
  * @brief   Number of usable low power modes
  */
 #if defined(CPU_FAM_STM32F1) || defined(CPU_FAM_STM32F2) || \
-    defined(CPU_FAM_STM32F4) || defined(CPU_FAM_STM32L0) || defined(DOXYGEN)
+    defined(CPU_FAM_STM32F4) || defined(CPU_FAM_STM32L0) || \
+    defined(CPU_FAM_STM32L1) || defined(DOXYGEN)
 #define PM_NUM_MODES    (2U)
 
 /**

--- a/cpu/stm32_common/periph/pm.c
+++ b/cpu/stm32_common/periph/pm.c
@@ -55,7 +55,20 @@ void pm_set(unsigned mode)
             /* Set PDDS to enter standby mode on deepsleep and clear flags */
             PWR->CR |= (PWR_CR_PDDS | PWR_CR_CWUF | PWR_CR_CSBF);
             /* Enable WKUP pin to use for wakeup from standby mode */
-#if defined(CPU_FAM_STM32L0)
+#if defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L1)
+            /* Regarding ULP, it's up to the user to configure it :
+             * 0: Internal Vref enabled during Deepsleep/Sleep/Low-power run mode
+             * 1: Disable internal voltage reference
+             *    Deepsleep/Sleep/Low-power run mode
+             */
+            /* Enable Ultra Low Power mode */
+            // PWR->CR |= PWR_CR_ULP;
+
+            /* This option is used to ensure that store operations are completed */
+            #if defined (__CC_ARM)
+            __force_stores();
+            #endif
+
             PWR->CSR |= (PWR_CSR_EWUP1 | PWR_CSR_EWUP2);
 #if !defined(CPU_LINE_STM32L053xx)
             /* STM32L053 only have 2 wake pins */
@@ -68,15 +81,27 @@ void pm_set(unsigned mode)
             deep = 1;
             break;
         case STM32_PM_STOP:
-#if defined(CPU_FAM_STM32L0)
+#if defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L1)
+            /* Clear Wakeup flag */
+            PWR->CR |= PWR_CR_CWUF;
             /* Clear PDDS to enter stop mode on */
             /*
              * Regarding LPSDSR, it's up to the user to configure it :
              * 0: Voltage regulator on during Deepsleep/Sleep/Low-power run mode
              * 1: Voltage regulator in low-power mode during
              *    Deepsleep/Sleep/Low-power run mode
+             * Regarding ULP, it's up to the user to configure it :
+             * 0: Internal Vref enabled during Deepsleep/Sleep/Low-power run mode
+             * 1: Disable internal voltage reference
+             *    Deepsleep/Sleep/Low-power run mode
              */
             PWR->CR &= ~(PWR_CR_PDDS);
+
+            /* Regulator in LP mode */
+            // PWR->CR |= PWR_CR_LPSDSR;
+
+            /* Enable Ultra Low Power mode*/
+            // PWR->CR |= PWR_CR_ULP;
 #else
             /* Clear PDDS and LPDS bits to enter stop mode on */
             /* deepsleep with voltage regulator on */

--- a/cpu/stm32_common/stmclk_l0l1.c
+++ b/cpu/stm32_common/stmclk_l0l1.c
@@ -69,7 +69,7 @@ void stmclk_init_sysclk(void)
     RCC->CFGR &= ~(RCC_CFGR_PLLSRC | RCC_CFGR_PLLDIV | RCC_CFGR_PLLMUL);
     /* Reset HSION, HSEON, CSSON and PLLON bits */
     RCC->CR &= ~(RCC_CR_HSION | RCC_CR_HSEON | RCC_CR_HSEBYP | RCC_CR_CSSON | RCC_CR_PLLON);
-    /* Disable all interrupts */
+    /* Clear all interrupts */
 
 #if defined(CPU_FAM_STM32L0)
     RCC->CICR = 0x0;
@@ -92,6 +92,8 @@ void stmclk_init_sysclk(void)
     FLASH->ACR |= FLASH_ACR_PRFTEN;
     /* Flash 1 wait state */
     FLASH->ACR |= CLOCK_FLASH_LATENCY;
+     /* Wait for flash to become ready */
+    while (!(FLASH->SR & FLASH_SR_READY)) {}
     /* Select the Voltage Range 1 (1.8 V) */
     PWR->CR = PWR_CR_VOS_0;
     /* Wait Until the Voltage Regulator is ready */

--- a/cpu/stm32l1/Makefile.include
+++ b/cpu/stm32l1/Makefile.include
@@ -1,5 +1,7 @@
 export CPU_ARCH = cortex-m3
 export CPU_FAM  = stm32l1
 
+USEMODULE += pm_layered
+
 include $(RIOTCPU)/stm32_common/Makefile.include
 include $(RIOTMAKE)/arch/cortexm.inc.mk


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
This PR adds low power modes STOP and STANDBY for stm32l0 boards. Achieves 100mA on STOP mode. For lower power consumption GPIO must be switched to AIN on startup, this is left for a different PR.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
Connect a multimeter or other current measuring device on IDD pin on nucleo-l152re boards, then run:

`make BOARD=nucleo-l152re -C tests/periph_pm/ PORT=/dev/ttyACM0 flash term`

Unblock using rtc mode 0 and 1 to see effect on current measurement/consumption.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
