### PR TITLE
cpu/stm32l1: add stop and standby modes, adds pm_layered 

### DIFF
--- a/cpu/stm32_common/include/periph_cpu_common.h
+++ b/cpu/stm32_common/include/periph_cpu_common.h
@@ -78,7 +78,8 @@ extern "C" {
  * @brief   Number of usable low power modes
  */
 #if defined(CPU_FAM_STM32F1) || defined(CPU_FAM_STM32F2) || \
-    defined(CPU_FAM_STM32F4) || defined(CPU_FAM_STM32L0) || defined(DOXYGEN)
+    defined(CPU_FAM_STM32F4) || defined(CPU_FAM_STM32L0) || \
+    defined(CPU_FAM_STM32L1) || defined(DOXYGEN)
 #define PM_NUM_MODES    (2U)
 
 /**

--- a/cpu/stm32_common/periph/pm.c
+++ b/cpu/stm32_common/periph/pm.c
@@ -58,13 +58,8 @@ void pm_set(unsigned mode)
             PWR->CR |= (PWR_CR_PDDS | PWR_CR_CWUF | PWR_CR_CSBF);
             /* Enable WKUP pin to use for wakeup from standby mode */
 #if defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L1)
-            /* Regarding ULP, it's up to the user to configure it :
-             * 0: Internal Vref enabled during Deepsleep/Sleep/Low-power run mode
-             * 1: Disable internal voltage reference
-             *    Deepsleep/Sleep/Low-power run mode
-             */
             /* Enable Ultra Low Power mode */
-            // PWR->CR |= PWR_CR_ULP;
+            PWR->CR |= PWR_CR_ULP;
 
             PWR->CSR |= PWR_CSR_EWUP1;
 #if !defined(CPU_LINE_STM32L053xx)
@@ -81,24 +76,13 @@ void pm_set(unsigned mode)
 #if defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L1)
             /* Clear Wakeup flag */
             PWR->CR |= PWR_CR_CWUF;
-            /* Clear PDDS to enter stop mode on */
-            /*
-             * Regarding LPSDSR, it's up to the user to configure it :
-             * 0: Voltage regulator on during Deepsleep/Sleep/Low-power run mode
-             * 1: Voltage regulator in low-power mode during
-             *    Deepsleep/Sleep/Low-power run mode
-             * Regarding ULP, it's up to the user to configure it :
-             * 0: Internal Vref enabled during Deepsleep/Sleep/Low-power run mode
-             * 1: Disable internal voltage reference
-             *    Deepsleep/Sleep/Low-power run mode
-             */
+            /* Clear PDDS to enter stop mode on  */
             PWR->CR &= ~(PWR_CR_PDDS);
-
             /* Regulator in LP mode */
-            // PWR->CR |= PWR_CR_LPSDSR;
+            PWR->CR |= PWR_CR_LPSDSR;
 
             /* Enable Ultra Low Power mode*/
-            // PWR->CR |= PWR_CR_ULP;
+            PWR->CR |= PWR_CR_ULP;
 #else
             /* Clear PDDS and LPDS bits to enter stop mode on */
             /* deepsleep with voltage regulator on */

--- a/cpu/stm32_common/periph/pm.c
+++ b/cpu/stm32_common/periph/pm.c
@@ -26,7 +26,8 @@
 #include "irq.h"
 #include "periph/pm.h"
 #if defined(CPU_FAM_STM32F1) || defined(CPU_FAM_STM32F2) || \
-    defined(CPU_FAM_STM32F4) || defined(CPU_FAM_STM32L0)
+    defined(CPU_FAM_STM32F4) || defined(CPU_FAM_STM32L0) || \
+    defined(CPU_FAM_STM32L1)
 #include "stmclk.h"
 #endif
 
@@ -49,13 +50,22 @@ void pm_set(unsigned mode)
 /* I just copied it from stm32f1/2/4, but I suppose it would work for the
  * others... /KS */
 #if defined(CPU_FAM_STM32F1) || defined(CPU_FAM_STM32F2) || \
-    defined(CPU_FAM_STM32F4) || defined(CPU_FAM_STM32L0)
+    defined(CPU_FAM_STM32F4) || defined(CPU_FAM_STM32L0) || \
+    defined(CPU_FAM_STM32L1)
     switch (mode) {
         case STM32_PM_STANDBY:
             /* Set PDDS to enter standby mode on deepsleep and clear flags */
             PWR->CR |= (PWR_CR_PDDS | PWR_CR_CWUF | PWR_CR_CSBF);
             /* Enable WKUP pin to use for wakeup from standby mode */
-#if defined(CPU_FAM_STM32L0)
+#if defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L1)
+            /* Regarding ULP, it's up to the user to configure it :
+             * 0: Internal Vref enabled during Deepsleep/Sleep/Low-power run mode
+             * 1: Disable internal voltage reference
+             *    Deepsleep/Sleep/Low-power run mode
+             */
+            /* Enable Ultra Low Power mode */
+            // PWR->CR |= PWR_CR_ULP;
+
             PWR->CSR |= PWR_CSR_EWUP1;
 #if !defined(CPU_LINE_STM32L053xx)
             /* STM32L053 only have 2 wake pins */
@@ -68,15 +78,27 @@ void pm_set(unsigned mode)
             deep = 1;
             break;
         case STM32_PM_STOP:
-#if defined(CPU_FAM_STM32L0)
+#if defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L1)
+            /* Clear Wakeup flag */
+            PWR->CR |= PWR_CR_CWUF;
             /* Clear PDDS to enter stop mode on */
             /*
              * Regarding LPSDSR, it's up to the user to configure it :
              * 0: Voltage regulator on during Deepsleep/Sleep/Low-power run mode
              * 1: Voltage regulator in low-power mode during
              *    Deepsleep/Sleep/Low-power run mode
+             * Regarding ULP, it's up to the user to configure it :
+             * 0: Internal Vref enabled during Deepsleep/Sleep/Low-power run mode
+             * 1: Disable internal voltage reference
+             *    Deepsleep/Sleep/Low-power run mode
              */
             PWR->CR &= ~(PWR_CR_PDDS);
+
+            /* Regulator in LP mode */
+            // PWR->CR |= PWR_CR_LPSDSR;
+
+            /* Enable Ultra Low Power mode*/
+            // PWR->CR |= PWR_CR_ULP;
 #else
             /* Clear PDDS and LPDS bits to enter stop mode on */
             /* deepsleep with voltage regulator on */
@@ -94,7 +116,8 @@ void pm_set(unsigned mode)
     cortexm_sleep(deep);
 
 #if defined(CPU_FAM_STM32F1) || defined(CPU_FAM_STM32F2) || \
-    defined(CPU_FAM_STM32F4) || defined(CPU_FAM_STM32L0)
+    defined(CPU_FAM_STM32F4) || defined(CPU_FAM_STM32L0) || \
+    defined(CPU_FAM_STM32L1)
     if (deep) {
         /* Re-init clock after STOP */
         stmclk_init_sysclk();
@@ -103,7 +126,8 @@ void pm_set(unsigned mode)
 }
 
 #if defined(CPU_FAM_STM32F1) || defined(CPU_FAM_STM32F2) || \
-    defined(CPU_FAM_STM32F4) || defined(CPU_FAM_STM32L0)
+    defined(CPU_FAM_STM32F4) || defined(CPU_FAM_STM32L0) || \
+    defined(CPU_FAM_STM32L1)
 void pm_off(void)
 {
     irq_disable();

--- a/cpu/stm32l1/Makefile.include
+++ b/cpu/stm32l1/Makefile.include
@@ -1,5 +1,7 @@
 export CPU_ARCH = cortex-m3
 export CPU_FAM  = stm32l1
 
+USEMODULE += pm_layered
+
 include $(RIOTCPU)/stm32_common/Makefile.include
 include $(RIOTMAKE)/arch/cortexm.inc.mk


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR adds low power modes STOP and STANDBY for stm32l1 boards. Achieves 100uA on STOP mode. For lower power consumption GPIO must be switched to AIN on startup, this is left for a different PR (2uA with this addition but this is not done automatically in L1 when entering LPM, which L0 does).

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Connect a multimeter or other current measuring device on IDD pin on nucleo-l152re boards, then run:

`make BOARD=nucleo-l152re -C tests/periph_pm/ PORT=/dev/ttyACM0 flash term`

Unblock using rtc mode 0 and 1 to see effect on current measurement/consumption.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

Based on #8403 and #7329