### PR TITLE
 gnrc_pktbuf: allow write-protect of size 0 snips

### DIFF
--- a/sys/net/gnrc/pktbuf_malloc/gnrc_pktbuf_malloc.c
+++ b/sys/net/gnrc/pktbuf_malloc/gnrc_pktbuf_malloc.c
@@ -232,7 +232,7 @@ void gnrc_pktbuf_release_error(gnrc_pktsnip_t *pkt, uint32_t err)
 gnrc_pktsnip_t *gnrc_pktbuf_start_write(gnrc_pktsnip_t *pkt)
 {
     mutex_lock(&_mutex);
-    if ((pkt == NULL) || (pkt->size == 0)) {
+    if (pkt == NULL) {
         mutex_unlock(&_mutex);
         return NULL;
     }

--- a/sys/net/gnrc/pktbuf_static/gnrc_pktbuf_static.c
+++ b/sys/net/gnrc/pktbuf_static/gnrc_pktbuf_static.c
@@ -249,7 +249,7 @@ void gnrc_pktbuf_release_error(gnrc_pktsnip_t *pkt, uint32_t err)
 gnrc_pktsnip_t *gnrc_pktbuf_start_write(gnrc_pktsnip_t *pkt)
 {
     mutex_lock(&_mutex);
-    if ((pkt == NULL) || (pkt->size == 0)) {
+    if (pkt == NULL) {
         mutex_unlock(&_mutex);
         return NULL;
     }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Size 0 snips are legal packet snips (empty payload e.g.) so it doesn't
make sense to issue an error in the write-protection in that case.

API documentation doesn't mention it either and the tests still pass
with the check removed.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Unittests should still pass, both with normal configuration

```sh
make -C tests/unittests tests-pktbuf test
```

and

```sh
USEMODULE=gnrc_pktbuf_malloc make -C tests/unittests tests-pktbuf test
```

(just noticed that this test fails in master as well due to an unrelated problem -.-)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Requires #11163 to be fixed to actually be able to send empty packets with `gnrc_networking`.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
