### PR TITLE
gnrc_sixlowpan_iphc: check ptr != NULL in compressible check

### DIFF
--- a/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
@@ -673,7 +673,7 @@ void gnrc_sixlowpan_iphc_send(gnrc_pktsnip_t *pkt, void *ctx, unsigned page)
     dispatch = NULL;    /* use dispatch as temporary pointer for prev */
     /* determine maximum dispatch size and write protect all headers until
      * then because they will be removed */
-    while (_compressible(ptr)) {
+    while ((ptr != NULL) && _compressible(ptr)) {
         gnrc_pktsnip_t *tmp = gnrc_pktbuf_start_write(ptr);
 
         if (tmp == NULL) {


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Not only does this leave open a risk to crash the node for the check
in `_compressible()` but also is the `tmp` check below getting confused
when `ptr` is `NULL`, since `gnrc_pktbuf_start_write()` returns `NULL`
in that case.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
If #11161 was merged and #11163 is fixed you can just send a packet with empty payload like this in `gnrc_networking` on a 6Lo-capable device (e.g. `samr21-xpro` or `iotlab-m3`)

```
udp send <destination address> <port> ""
```

With this PR the packet should be received at the destination (if a server with that port is open), without it the packet will be silently dropped.

If the referenced issues / PRs are not merged / fixed, apply the following patch before flashing:

```diff
diff --git a/examples/gnrc_networking/udp.c b/examples/gnrc_networking/udp.c
index ada54e5..f52a9de 100644
--- a/examples/gnrc_networking/udp.c
+++ b/examples/gnrc_networking/udp.c
@@ -61,16 +61,20 @@ static void send(char *addr_str, char *port_str, char *data, unsigned int num,
     }
 
     for (unsigned int i = 0; i < num; i++) {
-        gnrc_pktsnip_t *payload, *udp, *ip;
-        unsigned payload_size;
-        /* allocate payload */
-        payload = gnrc_pktbuf_add(NULL, data, strlen(data), GNRC_NETTYPE_UNDEF);
-        if (payload == NULL) {
-            puts("Error: unable to copy data to packet buffer");
-            return;
+        gnrc_pktsnip_t *payload = NULL, *udp, *ip;
+        unsigned payload_size = 0;
+        size_t data_len = strlen(data);
+
+        if (data_len) {
+            /* allocate payload */
+            payload = gnrc_pktbuf_add(NULL, data, data_len, GNRC_NETTYPE_UNDEF);
+            if (payload == NULL) {
+                puts("Error: unable to copy data to packet buffer");
+                return;
+            }
+            /* store size for output */
+            payload_size = (unsigned)payload->size;
         }
-        /* store size for output */
-        payload_size = (unsigned)payload->size;
         /* allocate UDP header, set source port := destination port */
         udp = gnrc_udp_hdr_build(payload, port, port);
         if (udp == NULL) {
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Requires #11163 to be fixed and #11161 to be merged to test without patch.


![Route to 6Lo minimal fragment forwarding](http://page.mi.fu-berlin.de/mlenders/sixlo_minfwd.svg)

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
