### PR TITLE
sys/xtimer: make xtimer_mutex_lock_timeout() actually use us arg

### DIFF
--- a/sys/xtimer/xtimer.c
+++ b/sys/xtimer/xtimer.c
@@ -255,7 +255,7 @@ int xtimer_mutex_lock_timeout(mutex_t *mutex, uint64_t timeout)
     if (timeout != 0) {
         t.callback = _mutex_timeout;
         t.arg = (void *)((mutex_thread_t *)&mt);
-        _xtimer_set64(&t, timeout, timeout >> 32);
+        xtimer_set64(&t, timeout);
     }
 
     mutex_lock(mutex);


### PR DESCRIPTION
### Contribution description

The docs state that ```xtimer_mutex_lock_timeout()``` gets an microsecond timeout, but then it uses the internal ```_xtimer_set64()``` to set the timer, which expects xtimer ticks. This breaks if ticks are not 1us.

### Testing procedure

Try the sema tests on hifive1, which uses 32768Hz ticks.

### Issues/PRs references

#5608