### PR TITLE
gnrc_ipv6: allow sending empty IPv6 packets

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -348,7 +348,7 @@ static int _fill_ipv6_hdr(gnrc_netif_t *netif, gnrc_pktsnip_t *ipv6)
     DEBUG("ipv6: write protect up to payload to calculate checksum\n");
     payload = ipv6;
     prev = ipv6;
-    do {
+    while (_is_ipv6_hdr(payload) && (payload->next != NULL)) {
         /* IPv6 header itself was already write-protected in caller function,
          * just write protect extension headers and payload header */
         if ((payload = gnrc_pktbuf_start_write(payload->next)) == NULL) {
@@ -359,7 +359,7 @@ static int _fill_ipv6_hdr(gnrc_netif_t *netif, gnrc_pktsnip_t *ipv6)
         }
         prev->next = payload;
         prev = payload;
-    } while (_is_ipv6_hdr(payload) && (payload->next != NULL));
+    }
     DEBUG("ipv6: calculate checksum for upper header.\n");
     if ((res = gnrc_netreg_calc_csum(payload, ipv6)) < 0) {
         if (res != -ENOENT) {   /* if there is no checksum we are okay */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
While trying to come up with a test for #11164 I noticed, that empty IPv6 packets, while valid, are not sent by GNRC. This fixes this issue (to speed up the process I came up with a different test case for #11164 though).
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Apply the following patch 

```diff
diff --git a/examples/gnrc_networking/udp.c b/examples/gnrc_networking/udp.c
index ada54e5..f17f190 100644
--- a/examples/gnrc_networking/udp.c
+++ b/examples/gnrc_networking/udp.c
@@ -79,7 +79,7 @@ static void send(char *addr_str, char *port_str, char *data, unsigned int num,
             return;
         }
         /* allocate IPv6 header */
-        ip = gnrc_ipv6_hdr_build(udp, NULL, &addr);
+        ip = gnrc_ipv6_hdr_build(NULL, NULL, &addr);
         if (ip == NULL) {
             puts("Error: unable to allocate IPv6 header");
             gnrc_pktbuf_release(udp);
@@ -93,7 +93,7 @@ static void send(char *addr_str, char *port_str, char *data, unsigned int num,
             LL_PREPEND(ip, netif);
         }
         /* send packet */
-        if (!gnrc_netapi_dispatch_send(GNRC_NETTYPE_UDP, GNRC_NETREG_DEMUX_CTX_ALL, ip)) {
+        if (!gnrc_netapi_dispatch_send(GNRC_NETTYPE_IPV6, GNRC_NETREG_DEMUX_CTX_ALL, ip)) {
             puts("Error: unable to locate UDP thread");
             gnrc_pktbuf_release(ip);
             return;
```

and compile and flash one instance of `gnrc_networking` for a board of your choice (e.g. native)

```sh
make -C examples/gnrc_networking
```

and `default` for a board that can communicate with the first one (e.g. also native; it should also be in that application's `BOARD_PROVIDES_NETIF` list) but include `gnrc_ipv6_default`:

```sh
USEMODULE=gnrc_ipv6_default make -C examples/default/
```

This allows us to see any network packet sent to that node in the output.

Try to send a "UDP" packet from the `gnrc_networking` node to the `default` node (due to the patch it just sends an empty UDP datagram so the port is irrelevant).

Without this PR, the empty IPv6 packet won't show up at the `default` node, with it, it will, e.g.:

```
PKTDUMP: data received:
~~ SNIP  0 - size:   0 byte, type: NETTYPE_UNDEF (0)
00000000~~ SNIP  1 - size:  40 byte, type: NETTYPE_IPV6 (1)
traffic class: 0x00 (ECN: 0x0, DSCP: 0x00)
flow label: 0x00000
length: 0  next header: 59  hop limit: 64
source address: fe80::cc76:afff:fe2c:7ff2
destination address: fe80::347c:84ff:fef7:7ddd
~~ SNIP  2 - size:  20 byte, type: NETTYPE_NETIF (-1)
if_pid: 5  rssi: 0  lqi: 0
flags: 0x0
src_l2addr: CE:76:AF:2C:7F:F2
dst_l2addr: 36:7C:84:F7:7D:DD
~~ PKT    -  3 snips, total size:  60 byte
```

Note, that #11161 and #11163 are not required, since we don't append an empty packet snip here to represent the empty payload but just omit it.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None, but found when trying to test #11164.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
