### PR TITLE
cpu/stm32_common: remove WKUP2 pin enable

### DIFF
--- a/cpu/stm32_common/periph/pm.c
+++ b/cpu/stm32_common/periph/pm.c
@@ -56,7 +56,7 @@ void pm_set(unsigned mode)
             PWR->CR |= (PWR_CR_PDDS | PWR_CR_CWUF | PWR_CR_CSBF);
             /* Enable WKUP pin to use for wakeup from standby mode */
 #if defined(CPU_FAM_STM32L0)
-            PWR->CSR |= (PWR_CSR_EWUP1 | PWR_CSR_EWUP2);
+            PWR->CSR |= PWR_CSR_EWUP1;
 #if !defined(CPU_LINE_STM32L053xx)
             /* STM32L053 only have 2 wake pins */
             PWR->CSR |= PWR_CSR_EWUP3;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Currently StandBy mode is unusable for nucleo l0 boards. When looking at the datasheet:

> WKUP pin 2 is used for wakeup from Standby mode and forced in input pull down
configuration (rising edge on WKUP pin 2 wakes-up the system from Standby mode).

But when looking at the boards schematic PC13 (wake-up pin 2), is also the user button which is connected to VDD, this means that unless user is holding the user button pressed all the time, a rising edge is triggered immediately. More so, it leaves the MCU in a weird state after reset.

Not enabling wake up pin 2 when entering StandBy fixes the issue.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

On nucleo boards that support LPM run:

`make BOARD=nucleo-l073rz -C tests/periph_pm/ PORT=/dev/ttyACM0 clean flash`
`unblock 0`
`unblock 1`
`unblock_rtc 1 3`

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
