### PR TITLE
Makefile.include: RIOTNOLINK ensure linking fails

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -454,11 +454,19 @@ else
 ifeq (,$(RIOTNOLINK))
 link: ..compiler-check ..build-message $(ELFFILE) $(FLASHFILE) $(HEXFILE) print-size
 else
-link: ..compiler-check ..build-message $(BASELIBS)
+link: ..compiler-check ..build-message $(ELFFILE).nolink
 endif # RIOTNOLINK
 
 $(ELFFILE): $(BASELIBS)
 	$(Q)$(_LINK) -o $@
+
+# Try to link and ensure it fails
+$(ELFFILE).nolink: FORCE
+$(ELFFILE).nolink: $(BASELIBS)
+	$(Q)\
+	  $(_LINK) -o $(ELFFILE) 2>&1 > $@; \
+	  ret=$$?; cat $@; \
+	  test $$ret -ne 0 || { echo 'Error, linking should have failed because of not enough memory but did not'; false; }
 
 $(BINDIR)/$(APPLICATION_MODULE).a: pkg-build $(BUILDDEPS)
 	$(Q)DIRS="$(DIRS)" "$(MAKE)" -C $(APPDIR) -f $(RIOTMAKE)/application.inc.mk


### PR DESCRIPTION
### Contribution description

This checks that linking correctly fails when it is supposed to.
This should help keeping the `BOARD_INSUFFICIENT_MEMORY` list up to date.


### Testing procedure

This verifies the board is indeed not linking:

```
RIOT_CI_BUILD=1 BOARD=arduino-uno make  -C examples/default
make: Entering directory '/home/harter/work/git/RIOT/examples/default'
CI-build: skipping link step
Building application "default" for "arduino-uno" with MCU "atmega328p".

/usr/lib/gcc/avr/5.4.0/../../../avr/bin/ld: address 0x800a56 of /home/harter/work/git/RIOT/examples/default/bin/arduino-uno/default.elf.nolink section `.data' is not within region `data'
/usr/lib/gcc/avr/5.4.0/../../../avr/bin/ld: address 0x800e1b of /home/harter/work/git/RIOT/examples/default/bin/arduino-uno/default.elf.nolink section `.bss' is not within region `data'
/usr/lib/gcc/avr/5.4.0/../../../avr/bin/ld: address 0x800e1d of /home/harter/work/git/RIOT/examples/default/bin/arduino-uno/default.elf.nolink section `.noinit' is not within region `data'
/usr/lib/gcc/avr/5.4.0/../../../avr/bin/ld: address 0x800a56 of /home/harter/work/git/RIOT/examples/default/bin/arduino-uno/default.elf.nolink section `.data' is not within region `data'
/usr/lib/gcc/avr/5.4.0/../../../avr/bin/ld: address 0x800e1b of /home/harter/work/git/RIOT/examples/default/bin/arduino-uno/default.elf.nolink section `.bss' is not within region `data'
/usr/lib/gcc/avr/5.4.0/../../../avr/bin/ld: address 0x800e1d of /home/harter/work/git/RIOT/examples/default/bin/arduino-uno/default.elf.nolink section `.noinit' is not within region `data'
collect2: error: ld returned 1 exit status
make: Leaving directory '/home/harter/work/git/RIOT/examples/default'
```

If the board should not link (here overwritten) but does, it shows an error:

```
RIOT_CI_BUILD=1 BOARD=samr21-xpro make -C examples/default/  BOARD_INSUFFICIENT_MEMORY='$(BOARD)'
make: Entering directory '/home/harter/work/git/RIOT/examples/default'
CI-build: skipping link step
Building application "default" for "samr21-xpro" with MCU "samd21".

Error, linking should have failed because of not enough memory but did not
/home/harter/work/git/RIOT/examples/default/../../Makefile.include:466: recipe for target '/home/harter/work/git/RIOT/examples/default/bin/samr21-xpro/default.elf.nolink' failed
make: *** [/home/harter/work/git/RIOT/examples/default/bin/samr21-xpro/default.elf.nolink] Error 1
make: Leaving directory '/home/harter/work/git/RIOT/examples/default'
```


### Issues/PRs references

https://github.com/RIOT-OS/RIOT/issues/11128