### PR TITLE
[WIP] Add ARM SUIT CBOR generator as tool

### DIFF
--- a/dist/tools/gen_suit_cbor/Makefile
+++ b/dist/tools/gen_suit_cbor/Makefile
@@ -1,0 +1,11 @@
+PKG_NAME=gen_suit_cbor
+PKG_URL=https://github.com/ARMmbed/suit-manifest-generator.git
+PKG_VERSION=5edd46d04f5833417d4388c68317da7e956be249
+PKG_LICENSE=Apache-2.0
+PKG_BUILDDIR=$(CURDIR)/bin
+
+.PHONY: all
+
+all: git-download
+
+include $(RIOTBASE)/pkg/pkg.mk


### PR DESCRIPTION
### Contribution description

This adds a makefile to download the SUIT manifest generator [here](https://github.com/ARMmbed/suit-manifest-generator), which as far as I'm aware is the main tool being developed for this by the SUIT working group.

At the moment this implements a simple download action. Later on, when we're deciding how to integrate all the OTA components into a single build action, we can implement other build system elements that handle manifest generation. That way, they will be driven by a real use case (our example application).

This currently downloads the head of the current master branch, which generates manifests based on [draft v1](https://datatracker.ietf.org/doc/draft-moran-suit-manifest/01/). Before merge we should change this to a commit which represents a version which matches the parser implementation in the firmware.

### Testing procedure

None yet - depends on build system integration decisions as described above