### PR TITLE
makefiles/edbg.inc.mk: use FLASHFILE

### DIFF
--- a/makefiles/boot/riotboot.mk
+++ b/makefiles/boot/riotboot.mk
@@ -97,9 +97,6 @@ $(RIOTBOOT_EXTENDED_BIN): $(RIOTBOOT_COMBINED_BIN)
 	$(Q)truncate -s $$(($(SLOT0_OFFSET) + $(SLOT0_LEN) + $(RIOTBOOT_HDR_LEN))) $@.tmp
 	$(Q)mv $@.tmp $@
 
-# Flashing rule for edbg to flash combined/extended binaries
-riotboot/flash-combined-slot0: HEXFILE=$(RIOTBOOT_COMBINED_BIN)
-riotboot/flash-extended-slot0: HEXFILE=$(RIOTBOOT_EXTENDED_BIN)
 # Flashing rule for openocd to flash combined/extended binaries
 riotboot/flash-combined-slot0: ELFFILE=$(RIOTBOOT_COMBINED_BIN)
 riotboot/flash-extended-slot0: ELFFILE=$(RIOTBOOT_EXTENDED_BIN)
@@ -114,18 +111,14 @@ riotboot/flash-extended-slot0: $(RIOTBOOT_EXTENDED_BIN) $(FLASHDEPS)
 
 # Flashing rule for slot 0
 riotboot/flash-slot0: export IMAGE_OFFSET=$(SLOT0_OFFSET)
-# Flashing rule for edbg to flash only slot 0
-riotboot/flash-slot0: HEXFILE=$(SLOT0_RIOT_BIN)
 # openocd
-riotboot/flash-slot0: ELFFILE=$(SLOT0_RIOT_BIN)
+riotboot/flash-slot1: ELFFILE=$(SLOT1_RIOT_BIN)
 riotboot/flash-slot0: FLASHFILE=$(SLOT0_RIOT_BIN)
 riotboot/flash-slot0: $(SLOT0_RIOT_BIN) $(FLASHDEPS)
 	$(flash-recipe)
 
 # Flashing rule for slot 1
 riotboot/flash-slot1: export IMAGE_OFFSET=$(SLOT1_OFFSET)
-# Flashing rule for edbg to flash only slot 1
-riotboot/flash-slot1: HEXFILE=$(SLOT1_RIOT_BIN)
 # openocd
 riotboot/flash-slot1: ELFFILE=$(SLOT1_RIOT_BIN)
 riotboot/flash-slot1: FLASHFILE=$(SLOT1_RIOT_BIN)

--- a/makefiles/tools/edbg.inc.mk
+++ b/makefiles/tools/edbg.inc.mk
@@ -1,7 +1,7 @@
 RIOT_EDBG = $(RIOTTOOLS)/edbg/edbg
 EDBG ?= $(RIOT_EDBG)
 FLASHER ?= $(EDBG)
-HEXFILE = $(BINFILE)
+FLASHFILE ?= $(BINFILE)
 # Use USB serial number to select device when more than one is connected
 # Use /dist/tools/usb-serial/list-ttys.sh to find out serial number.
 #   Usage:
@@ -14,7 +14,7 @@ endif
 # Set offset according to IMAGE_OFFSET if it's defined
 EDBG_ARGS += $(if $(IMAGE_OFFSET),--offset $(IMAGE_OFFSET))
 
-FFLAGS ?= $(EDBG_ARGS) -t $(EDBG_DEVICE_TYPE) -b -v -p -f $(HEXFILE)
+FFLAGS ?= $(EDBG_ARGS) -t $(EDBG_DEVICE_TYPE) -b -v -p -f $(FLASHFILE)
 
 ifeq ($(RIOT_EDBG),$(FLASHER))
   FLASHDEPS += $(RIOT_EDBG)

--- a/tests/riotboot/Makefile
+++ b/tests/riotboot/Makefile
@@ -28,5 +28,3 @@ include $(RIOTBASE)/Makefile.include
 # This is currently hacky as the flasher are not using 'FLASHFILE'
 # openocd
 ELFFILE = $(FLASHFILE)
-# edbg
-HEXFILE = $(FLASHFILE)


### PR DESCRIPTION
### Contribution description

Update to use FLASHFILE as file to be flashed on the board.

This also now removes the compatibility hack in `riotboot`.

### Testing procedure

We need to test that boards using edbg would still work with this.

#### Boards using edbg:

```
echo ${EDBG_BOARDS} 
arduino-zero samd21-xpro saml10-xpro saml11-xpro saml21-xpro samr21-xpro samr30-xpro
```

#### Test flashing normal examples with the board

* [x] samr21-xpro @cladmi 
* [x] saml21-xpro @dylad 
* [x] saml10-xpro @dylad 
* [x] saml11-xpro @dylad 
* [ ] ...

#### Test without board

I replaced FLASHER by 'true' to only show the FFLAGS and get the same output with master and this pull request:

```
for board in ${EDBG_BOARDS} ; do echo ${board}; BOARD=${board} make -C examples/hello-world/ --no-print-directory FLASHER=true flash-only; done
arduino-zero
true  -t atmel_cm0p -b -v -p -f /home/harter/work/git/RIOT/examples/hello-world/bin/arduino-zero/hello-world.bin
samd21-xpro
true  -t atmel_cm0p -b -v -p -f /home/harter/work/git/RIOT/examples/hello-world/bin/samd21-xpro/hello-world.bin
saml10-xpro
true  -t mchp_cm23 -b -v -p -f /home/harter/work/git/RIOT/examples/hello-world/bin/saml10-xpro/hello-world.bin
saml11-xpro
true  -t mchp_cm23 -b -v -p -f /home/harter/work/git/RIOT/examples/hello-world/bin/saml11-xpro/hello-world.bin
saml21-xpro
true  -t atmel_cm0p -b -v -p -f /home/harter/work/git/RIOT/examples/hello-world/bin/saml21-xpro/hello-world.bin
samr21-xpro
true  -t atmel_cm0p -b -v -p -f /home/harter/work/git/RIOT/examples/hello-world/bin/samr21-xpro/hello-world.bin
samr30-xpro
true  -t atmel_cm0p -b -v -p -f /home/harter/work/git/RIOT/examples/hello-world/bin/samr30-xpro/hello-world.bin
```

#### FLASHFILE can be updated


When setting FLASHFILE to another value from environment, like $(ELFFILE) it is correctly taken into account.

```
for board in ${EDBG_BOARDS} ; do echo ${board}; FLASHFILE='$(ELFFILE)' BOARD=${board} make -C examples/hello-world/ --no-print-directory FLASHER=true flash-only; done
```

<details><summary>wdiff output_master output_pr</summary>
<p>

```
arduino-zero
true  -t atmel_cm0p -b -v -p -f [-/home/harter/work/git/RIOT/examples/hello-world/bin/arduino-zero/hello-world.bin-] {+/home/harter/work/git/RIOT/examples/hello-world/bin/arduino-zero/hello-world.elf+}
samd21-xpro
true  -t atmel_cm0p -b -v -p -f [-/home/harter/work/git/RIOT/examples/hello-world/bin/samd21-xpro/hello-world.bin-] {+/home/harter/work/git/RIOT/examples/hello-world/bin/samd21-xpro/hello-world.elf+}
saml10-xpro
true  -t mchp_cm23 -b -v -p -f [-/home/harter/work/git/RIOT/examples/hello-world/bin/saml10-xpro/hello-world.bin-] {+/home/harter/work/git/RIOT/examples/hello-world/bin/saml10-xpro/hello-world.elf+}
saml11-xpro
true  -t mchp_cm23 -b -v -p -f [-/home/harter/work/git/RIOT/examples/hello-world/bin/saml11-xpro/hello-world.bin-] {+/home/harter/work/git/RIOT/examples/hello-world/bin/saml11-xpro/hello-world.elf+}
saml21-xpro
true  -t atmel_cm0p -b -v -p -f [-/home/harter/work/git/RIOT/examples/hello-world/bin/saml21-xpro/hello-world.bin-] {+/home/harter/work/git/RIOT/examples/hello-world/bin/saml21-xpro/hello-world.elf+}
samr21-xpro
true  -t atmel_cm0p -b -v -p -f [-/home/harter/work/git/RIOT/examples/hello-world/bin/samr21-xpro/hello-world.bin-] {+/home/harter/work/git/RIOT/examples/hello-world/bin/samr21-xpro/hello-world.elf+}
samr30-xpro
true  -t atmel_cm0p -b -v -p -f [-/home/harter/work/git/RIOT/examples/hello-world/bin/samr30-xpro/hello-world.bin-] {+/home/harter/work/git/RIOT/examples/hello-world/bin/samr30-xpro/hello-world.elf+}
```

</p>
</details>


#### `riotboot` test

Test running `tests/riotboot` test for `samr21-xpro` and `saml21-xpro`

```
BOARD=samr21-xpro make -C tests/riotboot flash test

2019-03-13 15:27:51,462 - INFO # main(): This is RIOT! (Version: 2019.04-devel-475-g4af35)
2019-03-13 15:27:51,463 - INFO # Hello riotboot!
2019-03-13 15:27:51,482 - INFO # You are running RIOTmain(): This is RIOT! (Version: 2019.04-devel-475-g4af35)
2019-03-13 15:27:51,483 - INFO # Hello riotboot!
2019-03-13 15:27:51,487 - INFO # You are running RIOT on a(n) samr21-xpro board.
2019-03-13 15:27:51,491 - INFO # This board features a(n) samd21 MCU.
2019-03-13 15:27:51,494 - INFO # riotboot_test: running from slot 0
2019-03-13 15:27:51,497 - INFO # Image magic_number: 0x544f4952
2019-03-13 15:27:51,499 - INFO # Image Version: 0x00000000
2019-03-13 15:27:51,502 - INFO # Image start address: 0x00001100
2019-03-13 15:27:51,504 - INFO # Header chksum: 0x7f7aaea1
2019-03-13 15:27:51,505 - INFO # 
> curslotnr
2019-03-13 15:27:51,527 - INFO #  curslotnr
2019-03-13 15:27:51,529 - INFO # Current slot=0
> curslothdr
curslothdr
2019-03-13 15:27:51,582 - INFO #  curslothdr
2019-03-13 15:27:51,585 - INFO # Image magic_number: 0x544f4952
2019-03-13 15:27:51,587 - INFO # Image Version: 0x00000000
2019-03-13 15:27:51,590 - INFO # Image start address: 0x00001100
2019-03-13 15:27:51,592 - INFO # Header chksum: 0x7f7aaea1
2019-03-13 15:27:51,592 - INFO # 
> getslotaddr 0
getslotaddr 0
2019-03-13 15:27:51,645 - INFO #  getslotaddr 0
2019-03-13 15:27:51,647 - INFO # Slot 0 address=0x00001100
> dumpaddrs
dumpaddrs
2019-03-13 15:27:51,699 - INFO #  dumpaddrs
2019-03-13 15:27:51,703 - INFO # slot 0: metadata: 0x1000 image: 0x00001100
2019-03-13 15:27:51,707 - INFO # slot 1: metadata: 0x20800 image: 0x00000000
> 
```

### Issues/PRs references

Split out of #8838 