### PR TITLE
cpu/stm32l4: add STOP and STANDBY low-power modes

### DIFF
--- a/cpu/stm32_common/include/periph_cpu_common.h
+++ b/cpu/stm32_common/include/periph_cpu_common.h
@@ -81,7 +81,7 @@ extern "C" {
 #if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F1) || \
     defined(CPU_FAM_STM32F2) || defined(CPU_FAM_STM32F4) || \
     defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L1) || \
-    defined(DOXYGEN)
+    defined(CPU_FAM_STM32L4) || defined(DOXYGEN)
 /**
  * @brief   Number of usable low power modes
  */

--- a/cpu/stm32l4/Makefile.include
+++ b/cpu/stm32l4/Makefile.include
@@ -1,5 +1,7 @@
 export CPU_ARCH = cortex-m4f
 export CPU_FAM  = stm32l4
 
+USEMODULE += pm_layered
+
 include $(RIOTCPU)/stm32_common/Makefile.include
 include $(RIOTMAKE)/arch/cortexm.inc.mk


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds STOP and STANDBY low-power modes to stm32l4 MCU family. There are 3 levels of STOP modes for L4, this PR uses STOP1 because I found less constraint (more peripherals can be used during this mode). Even if possible, the SRAM2 retention is disabled during standby mode.

On a nucleo-l433rc or nucleo-l476rg, I got the following consumption results:
- stop: ~8.5uA
- standby: ~0.5uA

For standby mode, the wake-up pins are disabled because when enabling them, there's an important consumption increase (around 300uA). On the l4 boards I have, except l496zg, one of the wake-up pin (PA2) in connected to the stdio UART: this crashes the cpus when entering standby mode and this wake-up pin is enabled.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Build an flash `tests/periph_pm` on a nucleo-l476rg
- Plug a multimeter on the IDD pins in Amper mode measurement
- Switch to STANDBY mode:
```
> unblock 0
> unblock 1
> unblock_rtc 1 5
```
You should see a drop of consumption from 3.8mA to 0.5uA. After 5 seconds, the board reboots.
- Switch to STOP mode:
```
> unblock 1
> unblock_rtc 1 5
```
You should see a drop of consumption from 3.8mA to 8.5uA

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
