### PR TITLE
boards/common/stm32l0: use dual bank with openocd if available

### DIFF
--- a/boards/common/stm32/dist/stm32l0.cfg
+++ b/boards/common/stm32/dist/stm32l0.cfg
@@ -1,3 +1,9 @@
-source [find target/stm32l0.cfg]
+# Try to use dual bank if available and supported
+try {
+    source [find target/stm32l0_dual_bank.cfg]
+} on error {} {
+    puts "WARNING: Your Openocd version does not support dual bank flash on your board. Falling back to single bank flashing."
+    source [find target/stm32l0.cfg]
+}
 reset_config srst_only connect_assert_srst
 $_TARGETNAME configure -rtos auto


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR adds the option to use the stm32l0_dual_bank.cfg configuration file for flashing with openocd. This allows to use the full flash space. The problem is this is not available on all openocd versions, needs to be compiled from source to be present. That is why I added a Makefile variable that a user can define if it flashes using stm32l0_dual_bank.cfg instead of stm32l0.cfg. In #11141 @aabadie sugested the default behavior should be using stm32l0.cfg. I welcome thoughts on a better way to do this, (some clever way to check opeoncd version?). 

#10206 won't be fixed on build tests unless OPENOCD_STM32L0_DUAL_BANK=1 is set.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

It can be tested by the same procedure as #11141 or veryfing the is fixes the issue in #10206 by running:

`make BOARD=b-l072z-lrwan1 -C examples/lua_basic/  flash
`
### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
 Fixes #10206, needed by #11141.