### PR TITLE
openocd: add debug_adapter gpio

### DIFF
--- a/makefiles/tools/openocd-adapters/sysfsgpio.inc.mk
+++ b/makefiles/tools/openocd-adapters/sysfsgpio.inc.mk
@@ -1,0 +1,24 @@
+# GPIO debug adapter
+export SWCLK ?= 21
+export SWDIO ?= 20
+export RST ?= 16
+
+export OPENOCD_ADAPTER_INIT ?= \
+  -c 'interface sysfsgpio' \
+  -c 'sysfsgpio_swd_nums $(SWCLK) $(SWDIO)' \
+  -c 'sysfsgpio_srst_num $(RST)' \
+  -c 'reset_config srst_only srst_push_pull' \
+  -c 'transport select swd' \
+  -c 'adapter_nsrst_delay 100' \
+  -c 'adapter_nsrst_assert_width 100'
+
+# if no openocd specific configuration file, check for default locations:
+# 1. Using the default dist/openocd.cfg (automatically set by openocd.sh)
+# 2. Using the common cpu specific config file
+ifeq (,$(OPENOCD_CONFIG))
+  # if no openocd default configuration is provided by the board,
+  # use the STM32 common one
+  ifeq (0,$(words $(wildcard $(RIOTBOARD)/$(BOARD)/dist/openocd.cfg)))
+    export OPENOCD_CONFIG := $(RIOTBASE)/boards/common/stm32/dist/$(CPU).cfg
+  endif
+endif


### PR DESCRIPTION
### Contribution description
Enables the possibility to flash a target using the gpio's of your system (eg. Raspberry Pi) 
This is especially useful inside a continuous integration system where images are flashed onto target to then be tested and interacted with through robot framework because no additional hardware needs to be bought for it to work.

The selection of gpio's happens with some environment variables, SWCLK, SWDIO and RST.
They are assigned default values respectively 21, 20 and 16, because that is the end of the connector on a RPI where there is also a convenient ground pin located to connect to.

Requires openocd to be configured with "--sysfsgpio" during installation. This option is only available in version 0.10.0 and upwards.

To build OpenOCD, use the following sequence of commands:
  ./bootstrap (when building from the git repository)
  ./configure --sysfsgpio
  make
  sudo make install

For more information, take a look at the openocd github page, https://github.com/ntfreak/openocd

### Testing procedure

The new debug_adapter was tested with various apps in the examples directory

To do it yourself:
1. Connect RPi pins to swd pins on <board_of_your_choice>
2. Add yourself to the gpio group on the system or run as root
3. Run BOARD=<board_of_your_choice> DEBUG_ADAPTER=sysfsgpio make flash -C <app_of_your_choice>
