### PR TITLE
nrf802154: don't call memcpy if iolist->iol_len==0

### DIFF
--- a/cpu/nrf52/radio/nrf802154/nrf802154.c
+++ b/cpu/nrf52/radio/nrf802154/nrf802154.c
@@ -268,8 +268,12 @@ static int _send(netdev_t *dev,  const iolist_t *iolist)
             mutex_unlock(&_txlock);
             return -EOVERFLOW;
         }
-        memcpy(&txbuf[len + 1], iolist->iol_base, iolist->iol_len);
-        len += iolist->iol_len;
+        /* Check if there is data to copy, prevents undefined behaviour with
+         * memcpy when iolist->iol_base == NULL */
+        if (iolist->iol_len) {
+            memcpy(&txbuf[len + 1], iolist->iol_base, iolist->iol_len);
+            len += iolist->iol_len;
+        }
     }
 
     /* specify the length of the package. */


### PR DESCRIPTION
### Contribution description

Should fix an ubsan complaint as memcpy with `iol->iol_base==NULL` is undefined.

### Testing procedure

Preferably with the procedure lined out in #11163

### Issues/PRs references

related: #10782 and #11163 