### PR TITLE
cpu/stm32f7: add STOP and STANDBY low-power modes

### DIFF
--- a/cpu/stm32_common/include/periph_cpu_common.h
+++ b/cpu/stm32_common/include/periph_cpu_common.h
@@ -81,7 +81,7 @@ extern "C" {
 #if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F1) || \
     defined(CPU_FAM_STM32F2) || defined(CPU_FAM_STM32F4) || \
     defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L1) || \
-    defined(DOXYGEN)
+    defined(CPU_FAM_STM32L4) || defined(DOXYGEN)
 /**
  * @brief   Number of usable low power modes
  */

--- a/cpu/stm32_common/include/periph_cpu_common.h
+++ b/cpu/stm32_common/include/periph_cpu_common.h
@@ -80,8 +80,9 @@ extern "C" {
  */
 #if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F1) || \
     defined(CPU_FAM_STM32F2) || defined(CPU_FAM_STM32F4) || \
-    defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L1) || \
-    defined(CPU_FAM_STM32L4) || defined(DOXYGEN)
+    defined(CPU_FAM_STM32F7) || defined(CPU_FAM_STM32L0) || \
+    defined(CPU_FAM_STM32L1) || defined(CPU_FAM_STM32L4) || \
+    defined(DOXYGEN)
 /**
  * @brief   Number of usable low power modes
  */

--- a/cpu/stm32_common/periph/pm.c
+++ b/cpu/stm32_common/periph/pm.c
@@ -22,6 +22,7 @@
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @author      Fabian Nack <nack@inf.fu-berlin.de>
  * @author      Vincent Dupont <vincent@otakeys.com>
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  *
  * @}
  */
@@ -45,6 +46,8 @@
 #define PM_STOP_CONFIG  (PWR_CR_LPSDSR | PWR_CR_ULP)
 #elif defined(CPU_FAM_STM32L4)
 #define PM_STOP_CONFIG  (PWR_CR1_LPMS_STOP1)
+#elif defined(CPU_FAM_STM32F7)
+#define PM_STOP_CONFIG  (PWR_CR1_LPDS | PWR_CR1_FPDS | PWR_CR1_LPUDS)
 #else
 #define PM_STOP_CONFIG  (PWR_CR_LPDS | PWR_CR_FPDS)
 #endif
@@ -60,6 +63,8 @@
 #define PM_STANDBY_CONFIG   (PWR_CR_PDDS | PWR_CR_CWUF | PWR_CR_CSBF | PWR_CR_ULP)
 #elif defined(CPU_FAM_STM32L4)
 #define PM_STANDBY_CONFIG   (PWR_CR1_LPMS_STANDBY)
+#elif defined(CPU_FAM_STM32F7)
+#define PM_STANDBY_CONFIG   (PWR_CR1_PDDS | PWR_CR1_CSBF)
 #else
 #define PM_STANDBY_CONFIG   (PWR_CR_PDDS | PWR_CR_CWUF | PWR_CR_CSBF)
 #endif
@@ -68,6 +73,9 @@
 #if defined(CPU_FAM_STM32L4)
 #define PWR_CR_REG     PWR->CR1
 #define PWR_WUP_REG    PWR->CR3
+#elif defined(CPU_FAM_STM32F7)
+#define PWR_CR_REG     PWR->CR1
+#define PWR_WUP_REG    PWR->CSR2
 #else
 #define PWR_CR_REG     PWR->CR
 #define PWR_WUP_REG    PWR->CSR

--- a/cpu/stm32f7/Makefile.include
+++ b/cpu/stm32f7/Makefile.include
@@ -1,5 +1,7 @@
 export CPU_ARCH = cortex-m7
 export CPU_FAM  = stm32f7
 
+USEMODULE += pm_layered
+
 include $(RIOTCPU)/stm32_common/Makefile.include
 include $(RIOTMAKE)/arch/cortexm.inc.mk

--- a/cpu/stm32l4/Makefile.include
+++ b/cpu/stm32l4/Makefile.include
@@ -1,5 +1,7 @@
 export CPU_ARCH = cortex-m4f
 export CPU_FAM  = stm32l4
 
+USEMODULE += pm_layered
+
 include $(RIOTCPU)/stm32_common/Makefile.include
 include $(RIOTMAKE)/arch/cortexm.inc.mk


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds STOP and STANDBY low-power modes for stm32f7 and is based on #9521 and #11173 for simplicity.

I tested it on nucleo-f746zg and got good results (looks valid compared with datasheet):
- standby: ~7uA
- stop: 2mA

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Build an flash `tests/periph_pm` on a nucleo-f746zg
- Plug a multimeter on the IDD pins in Amper mode measurement
- Switch to STANDBY mode:
```
> unblock 0
> unblock 1
> unblock_rtc 1 5
```
You should see a drop of consumption from 38mA to 7uA. After 5 seconds, the board reboots.
- Switch to STOP mode:
```
> unblock 1
> unblock_rtc 1 5
```
You should see a drop of consumption from 38mA to 2mA

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Based on #11173 and #9521 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
