### PR TITLE
riotboot: use epoch as APP_VER default

### DIFF
--- a/makefiles/boot/riotboot.mk
+++ b/makefiles/boot/riotboot.mk
@@ -27,8 +27,8 @@ export SLOT0_OFFSET ?= $(RIOTBOOT_LEN)
 # export does not work properly with variables using '$((  ))' so evaluate it in a shell
 export SLOT1_OFFSET ?= $(shell echo $$(($(SLOT0_OFFSET) + $(SLOT0_LEN))))
 
-# Mandatory APP_VER, set to 0 by default
-APP_VER ?= 0
+# Mandatory APP_VER, set to epoch by default
+APP_VER ?= $(shell date +%s)
 
 # Final target for slot 0 with riot_hdr
 SLOT0_RIOT_BIN = $(BINDIR_APP)-slot0.riot.bin


### PR DESCRIPTION
### Contribution description

Previously, a compiled image version would default to "0".
It would make an image that was simply compiled by "make riotboot" without specifying a version unbootable by default, as the existing version in slot 0 is always at least 0, too.

This PR makes the current time (in unix epoch format) the default version number. As time is increasing monotonically, that makes an image which was compiled after another bootable with high probability.

### Testing procedure

In order to test that the epoch is used, use ```BOARD=foo make -Ctests/riotboot riotboot/flash```.
On master, after flashing, the printed version number should be zero.
With this PR, it should increase everytime the flashing is repeated.

### Issues/PRs references

none