### PR TITLE
gnrc_ipv6_nib: check if pkt is NULL on error

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -203,7 +203,7 @@ int gnrc_ipv6_nib_get_next_hop_l2addr(const ipv6_addr_t *dst,
                 /* _resolve_addr releases pkt only if not queued (in which case
                  * we also shouldn't release), but if netif is not defined we
                  * should release in any case. */
-                if (netif == NULL) {
+                if ((netif == NULL) && (pkt != NULL)) {
                     gnrc_icmpv6_error_dst_unr_send(ICMPV6_ERROR_DST_UNR_ADDR,
                                                    pkt);
                     gnrc_pktbuf_release_error(pkt, EHOSTUNREACH);
@@ -228,10 +228,14 @@ int gnrc_ipv6_nib_get_next_hop_l2addr(const ipv6_addr_t *dst,
                     memcpy(&route.next_hop, dst, sizeof(route.next_hop));
                 }
                 else {
-                    gnrc_icmpv6_error_dst_unr_send(ICMPV6_ERROR_DST_UNR_NO_ROUTE,
-                                                   pkt);
                     res = -ENETUNREACH;
-                    gnrc_pktbuf_release_error(pkt, ENETUNREACH);
+                    if (pkt != NULL) {
+                        gnrc_icmpv6_error_dst_unr_send(
+                                ICMPV6_ERROR_DST_UNR_NO_ROUTE,
+                                pkt
+                            );
+                        gnrc_pktbuf_release_error(pkt, ENETUNREACH);
+                    }
                     break;
                 }
             }
@@ -1197,6 +1201,7 @@ static bool _resolve_addr(const ipv6_addr_t *dst, gnrc_netif_t *netif,
                     return false;
                 }
             }
+            /* pkt != NULL already checked above */
             else {
                 gnrc_icmpv6_error_dst_unr_send(ICMPV6_ERROR_DST_UNR_ADDR,
                                                pkt);


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
[According to the documentation of `gnrc_ipv6_nib_get_next_hop_l2addr()` `pkt` may be `NULL`](https://doc.riot-os.org/group__net__gnrc__ipv6__nib.html#ga021bb4bb0cf7ed73276608801bc0cee3). However, whenever that function sends an error message (the methods for that [require `orig_pkt` not to be NULL](https://doc.riot-os.org/group__net__gnrc__icmpv6__error.html)) `pkt` is not checked, which may lead to failed assertions.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Compile and flash `tests/gnrc_ipv6_nib` with `USEMODULE=gnrc_icmpv6_error`

```
USEMODULE=gnrc_icmpv6_error make flash
```

and run the test

```
make test
```

Without this fix the test will fail on an assertion at

https://github.com/RIOT-OS/RIOT/blob/94a10e9e103af972bd9edf9cdd1d2fa3c1300454/sys/net/gnrc/network_layer/icmpv6/error/gnrc_icmpv6_error.c#L244

With this fix the tests will pass.

### Issues/PRs references
Discovered while debugging #11068 where I use `gnrc_ipv6_nib_get_next_hop_l2addr()` with `pkt == NULL`

https://github.com/RIOT-OS/RIOT/blob/a235f613c107f3efcf92a5c8adbeddd957a9ad0f/sys/net/gnrc/network_layer/sixlowpan/frag/minfwd/gnrc_sixlowpan_frag_minfwd.c#L51-L54

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
