### PR TITLE
drivers/ds3234: Fix doxygen group

### DIFF
--- a/drivers/include/ds3234.h
+++ b/drivers/include/ds3234.h
@@ -8,6 +8,7 @@
 
 /**
  * @defgroup    drivers_ds3234  DS3234 Extremely Accurate SPI RTC
+ * @ingroup     drivers_sensors
 
  * @brief       Driver for Maxim DS3234 Extremely Accurate SPI Bus RTC with
  *              Integrated Crystal and SRAM


### PR DESCRIPTION
### Contribution description
The driver for the DS3234 RTC was not included in the `drivers_sensors`  group and as a consequence it is showing directly under `modules`. This fixes that.

### Testing procedure
Run `make doc` and check the driver is under the correct group.

### Issues/PRs references
none