### PR TITLE
cpu/esp32: esp_wifi doesn't call memcpy if iol_len is 0

### DIFF
--- a/cpu/esp32/esp-wifi/esp_wifi_netdev.c
+++ b/cpu/esp32/esp-wifi/esp_wifi_netdev.c
@@ -298,8 +298,10 @@ static int _esp_wifi_send(netdev_t *netdev, const iolist_t *iolist)
             mutex_unlock(&dev->dev_lock);
             return -EOVERFLOW;
         }
-        memcpy (dev->tx_buf + dev->tx_len, iol->iol_base, iol->iol_len);
-        dev->tx_len += iol->iol_len;
+        if (iol->iol_len) {
+            memcpy (dev->tx_buf + dev->tx_len, iol->iol_base, iol->iol_len);
+            dev->tx_len += iol->iol_len;
+        }
     }
 
     #if ENABLE_DEBUG


### PR DESCRIPTION
### Contribution description

Fixes the problem described in #11163.

### Testing procedure

Tested with the procedure described in #11163 

### Issues/PRs references

Related to issue #11163 