### PR TITLE
boards/lpc2k_pgm: use FLASHFILE for boards using lpc2k_pgm

### DIFF
--- a/boards/common/msba2/Makefile.include
+++ b/boards/common/msba2/Makefile.include
@@ -36,7 +36,8 @@ export LINKFLAGS += -Wl,--gc-sections
 # use the nano-specs of Newlib when available
 USEMODULE += newlib_nano
 
-FFLAGS = $(PORT) $(HEXFILE)
+FLASHFILE ?= $(HEXFILE)
+FFLAGS = $(PORT) $(FLASHFILE)
 
 INCLUDES += -I$(RIOTBOARD)/common/msba2/include
 


### PR DESCRIPTION
### Contribution description

Update to use FLASHFILE as file to be flashed on the board.

### Testing procedure

Flashing should work

```
make: Entering directory '/home/harter/work/git/RIOT/examples/hello-world'
Building application "hello-world" for "msba2" with MCU "lpc2387".

   text	   data	    bss	    dec	    hex	filename
  10824	    132	  98172	 109128	  1aa48	/home/harter/work/git/RIOT/examples/hello-world/bin/msba2/hello-world.elf
env -i PATH=/home/harter/.bin:/home/harter/.local/bin:/home/harter/bin:/opt/gnu-mcu-eclipse/openocd/0.10.0-11-20190118-1134/bin:/opt/gcc-arm-none-eabi-7-2018-q2-update/bin:/opt/gnu-mcu-eclipse/openocd/0.10.0-11-20190118-1134/bin:/opt/gcc-arm-none-eabi-7-2018-q2-update/bin:/home/harter/.bin:/home/harter/.local/bin:/home/harter/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin make -C /home/harter/work/git/RIOT/boards/common/msba2/tools
make: Entering directory '/home/harter/work/git/RIOT/boards/common/msba2/tools'
gcc -O0 -g3 -Wall -c -fmessage-length=0 -MMD -MP -MF"obj/lpc2k_pgm.d" -MT"obj/lpc2k_pgm.d" -c src/lpc2k_pgm.c -o obj/lpc2k_pgm.o
gcc -O0 -g3 -Wall -c -fmessage-length=0 -MMD -MP -MF"obj/download.d" -MT"obj/download.d" -c src/download.c -o obj/download.o
gcc -O0 -g3 -Wall -c -fmessage-length=0 -MMD -MP -MF"obj/uuencode.d" -MT"obj/uuencode.d" -c src/uuencode.c -o obj/uuencode.o
gcc -O0 -g3 -Wall -c -fmessage-length=0 -MMD -MP -MF"obj/ihex.d" -MT"obj/ihex.d" -c src/ihex.c -o obj/ihex.o
gcc -O0 -g3 -Wall -c -fmessage-length=0 -MMD -MP -MF"obj/serial.d" -MT"obj/serial.d" -c src/serial.c -o obj/serial.o
gcc -O0 -g3 -Wall -c -fmessage-length=0 -MMD -MP -MF"obj/chipinfo.d" -MT"obj/chipinfo.d" -c src/chipinfo.c -o obj/chipinfo.o
gcc -O0 -g3 -Wall -c -fmessage-length=0 -MMD -MP -MF"obj/boot_2xxx.d" -MT"obj/boot_2xxx.d" -c src/boot_2xxx.c -o obj/boot_2xxx.o
gcc -O0 -g3 -Wall -c -fmessage-length=0 -MMD -MP -MF"obj/boot_23xx.d" -MT"obj/boot_23xx.d" -c src/boot_23xx.c -o obj/boot_23xx.o
gcc -O0 -g3 -Wall -c -fmessage-length=0 -MMD -MP -MF"obj/control_2xxx.d" -MT"obj/control_2xxx.d" -c src/control_2xxx.c -o obj/control_2xxx.o
mkdir -p bin
gcc -o bin/lpc2k_pgm obj/lpc2k_pgm.o obj/download.o obj/uuencode.o obj/ihex.o obj/serial.o obj/chipinfo.o obj/boot_2xxx.o obj/boot_23xx.o obj/control_2xxx.o
gcc -O0 -g3 -Wall -c -fmessage-length=0 -MMD -MP -MF"obj/pseudoterm.d" -MT"obj/pseudoterm.d" -c src/pseudoterm.c -o obj/pseudoterm.o
mkdir -p bin
gcc -o bin/pseudoterm obj/pseudoterm.o obj/serial.o obj/control_2xxx.o -lpthread
make: Leaving directory '/home/harter/work/git/RIOT/boards/common/msba2/tools'
/home/harter/work/git/RIOT/boards/common/msba2/tools/bin/lpc2k_pgm /dev/ttyUSB0 /home/harter/work/git/RIOT/examples/hello-world/bin/msba2/hello-world.hex
Port "/dev/ttyUSB0" opened at 115200 baud

Entering Bootloader Mode
Reset CPU (into bootloader)
Read "/home/harter/work/git/RIOT/examples/hello-world/bin/msba2/hello-world.hex": 10956 bytes
Attempting baud sync.Baud sync sucessful
Found chip: "LPC2387 (500k)"
Device Unlocked
Erasing....
  Sector  0: prep, erase... Ok
  Sector  1: prep, erase... Ok
  Sector  2: prep, erase... Ok
  Sector  3: not used
  Sector  4: not used
  Sector  5: not used
  Sector  6: not used
  Sector  7: not used
  Sector  8: not used
  Sector  9: not used
  Sector 10: not used
  Sector 11: not used
  Sector 12: not used
  Sector 13: not used
  Sector 14: not used
  Sector 15: not used
  Sector 16: not used
  Sector 17: not used
  Sector 18: not used
  Sector 19: not used
  Sector 20: not used
  Sector 21: not used
  Sector 22: not used
  Sector 23: not used
  Sector 24: not used
  Sector 25: not used
  Sector 26: not used
Programming....
  Sector  0 (0x00000000-0x00000FFF): xmit....prep, write, Ok
  Sector  1 (0x00001000-0x00001FFF): xmit....prep, write, Ok
  Sector  2 (0x00002000-0x00002FFF): xmit....prep, write, Ok
  Sector  3 (0x00003000-0x00003FFF): not used
  Sector  4 (0x00004000-0x00004FFF): not used
  Sector  5 (0x00005000-0x00005FFF): not used
  Sector  6 (0x00006000-0x00006FFF): not used
  Sector  7 (0x00007000-0x00007FFF): not used
  Sector  8 (0x00008000-0x00008FFF): not used
  Sector  8 (0x00009000-0x00009FFF): not used
  Sector  8 (0x0000A000-0x0000AFFF): not used
  Sector  8 (0x0000B000-0x0000BFFF): not used
  Sector  8 (0x0000C000-0x0000CFFF): not used
  Sector  8 (0x0000D000-0x0000DFFF): not used
  Sector  8 (0x0000E000-0x0000EFFF): not used
  Sector  8 (0x0000F000-0x0000FFFF): not used
  Sector  9 (0x00010000-0x00010FFF): not used
  Sector  9 (0x00011000-0x00011FFF): not used
  Sector  9 (0x00012000-0x00012FFF): not used
  Sector  9 (0x00013000-0x00013FFF): not used
  Sector  9 (0x00014000-0x00014FFF): not used
  Sector  9 (0x00015000-0x00015FFF): not used
  Sector  9 (0x00016000-0x00016FFF): not used
  Sector  9 (0x00017000-0x00017FFF): not used
  Sector 10 (0x00018000-0x00018FFF): not used
  Sector 10 (0x00019000-0x00019FFF): not used
  Sector 10 (0x0001A000-0x0001AFFF): not used
  Sector 10 (0x0001B000-0x0001BFFF): not used
  Sector 10 (0x0001C000-0x0001CFFF): not used
  Sector 10 (0x0001D000-0x0001DFFF): not used
  Sector 10 (0x0001E000-0x0001EFFF): not used
  Sector 10 (0x0001F000-0x0001FFFF): not used
  Sector 11 (0x00020000-0x00020FFF): not used
  Sector 11 (0x00021000-0x00021FFF): not used
  Sector 11 (0x00022000-0x00022FFF): not used
  Sector 11 (0x00023000-0x00023FFF): not used
  Sector 11 (0x00024000-0x00024FFF): not used
  Sector 11 (0x00025000-0x00025FFF): not used
  Sector 11 (0x00026000-0x00026FFF): not used
  Sector 11 (0x00027000-0x00027FFF): not used
  Sector 12 (0x00028000-0x00028FFF): not used
  Sector 12 (0x00029000-0x00029FFF): not used
  Sector 12 (0x0002A000-0x0002AFFF): not used
  Sector 12 (0x0002B000-0x0002BFFF): not used
  Sector 12 (0x0002C000-0x0002CFFF): not used
  Sector 12 (0x0002D000-0x0002DFFF): not used
  Sector 12 (0x0002E000-0x0002EFFF): not used
  Sector 12 (0x0002F000-0x0002FFFF): not used
  Sector 13 (0x00030000-0x00030FFF): not used
  Sector 13 (0x00031000-0x00031FFF): not used
  Sector 13 (0x00032000-0x00032FFF): not used
  Sector 13 (0x00033000-0x00033FFF): not used
  Sector 13 (0x00034000-0x00034FFF): not used
  Sector 13 (0x00035000-0x00035FFF): not used
  Sector 13 (0x00036000-0x00036FFF): not used
  Sector 13 (0x00037000-0x00037FFF): not used
  Sector 14 (0x00038000-0x00038FFF): not used
  Sector 14 (0x00039000-0x00039FFF): not used
  Sector 14 (0x0003A000-0x0003AFFF): not used
  Sector 14 (0x0003B000-0x0003BFFF): not used
  Sector 14 (0x0003C000-0x0003CFFF): not used
  Sector 14 (0x0003D000-0x0003DFFF): not used
  Sector 14 (0x0003E000-0x0003EFFF): not used
  Sector 14 (0x0003F000-0x0003FFFF): not used
  Sector 15 (0x00040000-0x00040FFF): not used
  Sector 15 (0x00041000-0x00041FFF): not used
  Sector 15 (0x00042000-0x00042FFF): not used
  Sector 15 (0x00043000-0x00043FFF): not used
  Sector 15 (0x00044000-0x00044FFF): not used
  Sector 15 (0x00045000-0x00045FFF): not used
  Sector 15 (0x00046000-0x00046FFF): not used
  Sector 15 (0x00047000-0x00047FFF): not used
  Sector 16 (0x00048000-0x00048FFF): not used
  Sector 16 (0x00049000-0x00049FFF): not used
  Sector 16 (0x0004A000-0x0004AFFF): not used
  Sector 16 (0x0004B000-0x0004BFFF): not used
  Sector 16 (0x0004C000-0x0004CFFF): not used
  Sector 16 (0x0004D000-0x0004DFFF): not used
  Sector 16 (0x0004E000-0x0004EFFF): not used
  Sector 16 (0x0004F000-0x0004FFFF): not used
  Sector 17 (0x00050000-0x00050FFF): not used
  Sector 17 (0x00051000-0x00051FFF): not used
  Sector 17 (0x00052000-0x00052FFF): not used
  Sector 17 (0x00053000-0x00053FFF): not used
  Sector 17 (0x00054000-0x00054FFF): not used
  Sector 17 (0x00055000-0x00055FFF): not used
  Sector 17 (0x00056000-0x00056FFF): not used
  Sector 17 (0x00057000-0x00057FFF): not used
  Sector 18 (0x00058000-0x00058FFF): not used
  Sector 18 (0x00059000-0x00059FFF): not used
  Sector 18 (0x0005A000-0x0005AFFF): not used
  Sector 18 (0x0005B000-0x0005BFFF): not used
  Sector 18 (0x0005C000-0x0005CFFF): not used
  Sector 18 (0x0005D000-0x0005DFFF): not used
  Sector 18 (0x0005E000-0x0005EFFF): not used
  Sector 18 (0x0005F000-0x0005FFFF): not used
  Sector 19 (0x00060000-0x00060FFF): not used
  Sector 19 (0x00061000-0x00061FFF): not used
  Sector 19 (0x00062000-0x00062FFF): not used
  Sector 19 (0x00063000-0x00063FFF): not used
  Sector 19 (0x00064000-0x00064FFF): not used
  Sector 19 (0x00065000-0x00065FFF): not used
  Sector 19 (0x00066000-0x00066FFF): not used
  Sector 19 (0x00067000-0x00067FFF): not used
  Sector 20 (0x00068000-0x00068FFF): not used
  Sector 20 (0x00069000-0x00069FFF): not used
  Sector 20 (0x0006A000-0x0006AFFF): not used
  Sector 20 (0x0006B000-0x0006BFFF): not used
  Sector 20 (0x0006C000-0x0006CFFF): not used
  Sector 20 (0x0006D000-0x0006DFFF): not used
  Sector 20 (0x0006E000-0x0006EFFF): not used
  Sector 20 (0x0006F000-0x0006FFFF): not used
  Sector 21 (0x00070000-0x00070FFF): not used
  Sector 21 (0x00071000-0x00071FFF): not used
  Sector 21 (0x00072000-0x00072FFF): not used
  Sector 21 (0x00073000-0x00073FFF): not used
  Sector 21 (0x00074000-0x00074FFF): not used
  Sector 21 (0x00075000-0x00075FFF): not used
  Sector 21 (0x00076000-0x00076FFF): not used
  Sector 21 (0x00077000-0x00077FFF): not used
  Sector 22 (0x00078000-0x00078FFF): not used
  Sector 23 (0x00079000-0x00079FFF): not used
  Sector 24 (0x0007A000-0x0007AFFF): not used
  Sector 25 (0x0007B000-0x0007BFFF): not used
  Sector 26 (0x0007C000-0x0007CFFF): not used
Booting (hardware reset)...

Reset CPU (into user code)
Programming done.
make: Leaving directory '/home/harter/work/git/RIOT/examples/hello-world'
```

### Issues/PRs references

Depends on #11185 for the tool compiling
Split out of https://github.com/RIOT-OS/RIOT/pull/8838