### PR TITLE
tools/avrdude.inc.mk: use FLASHFILE variable

### DIFF
--- a/makefiles/tools/avrdude.inc.mk
+++ b/makefiles/tools/avrdude.inc.mk
@@ -19,4 +19,4 @@ PROGRAMMER_FLAGS += $(FFLAGS_EXTRA)
 
 # don't force to flash HEXFILE, but set it as default
 FLASHFILE ?= $(HEXFILE)
-FFLAGS += -c $(PROGRAMMER) $(PROGRAMMER_FLAGS) -U flash:w:$(HEXFILE)
+FFLAGS += -c $(PROGRAMMER) $(PROGRAMMER_FLAGS) -U flash:w:$(FLASHFILE)


### PR DESCRIPTION
### Contribution description

Update to use FLASHFILE as file to be flashed on the board.

### Testing procedure

Flashing on a board using `avrdude.inc.mk` works

```
RIOT_CI_BUILD=1 BOARD=arduino-mega2560 make -C examples/default/ flash term
make: Entering directory '/home/harter/work/git/RIOT/examples/default'
Building application "default" for "arduino-mega2560" with MCU "atmega2560".

   text    data     bss     dec     hex filename
  10144    2394     971   13509    34c5 /home/harter/work/git/RIOT/examples/default/bin/arduino-mega2560/default.elf
avrdude -c stk500v2 -p m2560 -P /dev/ttyACM0 -b 115200 -F -D -U flash:w:/home/harter/work/git/RIOT/examples/default/bin/arduino-mega2560/default.hex

avrdude: AVR device initialized and ready to accept instructions

Reading | ################################################## | 100% 0.01s

avrdude: Device signature = 0x1e9801 (probably m2560)
avrdude: reading input file "/home/harter/work/git/RIOT/examples/default/bin/arduino-mega2560/default.hex"
avrdude: input file /home/harter/work/git/RIOT/examples/default/bin/arduino-mega2560/default.hex auto detected as Intel Hex
avrdude: writing flash (12538 bytes):

Writing | ################################################## | 100% 2.01s

avrdude: 12538 bytes of flash written
avrdude: verifying flash memory against /home/harter/work/git/RIOT/examples/default/bin/arduino-mega2560/default.hex:
avrdude: load data flash data from input file /home/harter/work/git/RIOT/examples/default/bin/arduino-mega2560/default.hex:
avrdude: input file /home/harter/work/git/RIOT/examples/default/bin/arduino-mega2560/default.hex auto detected as Intel Hex
avrdude: input file /home/harter/work/git/RIOT/examples/default/bin/arduino-mega2560/default.hex contains 12538 bytes
avrdude: reading on-chip flash data:

Reading | ################################################## | 100% 1.59s

avrdude: verifying ...
avrdude: 12538 bytes of flash verified

avrdude: safemode: Fuses OK (E:FD, H:D0, L:FF)

avrdude done.  Thank you.

/home/harter/work/git/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "9600"
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2019-03-14 18:26:31,572 - INFO # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
2019-03-14 18:26:32,575 - INFO # ain(): This is RIOT! (Version: buildtest)
2019-03-14 18:26:32,575 - INFO # Welcome to RIOT!
> 2019-03-14 18:26:32,575 - INFO #  

2019-03-14 18:26:32,576 - INFO # main(): This is RIOT! (Version: buildtest)
2019-03-14 18:26:32,576 - INFO # Welcome to RIOT!
> 
```

#### Testing without a board

```
AVRDUDE_BOARDS=$(git grep -e avrdude.inc.mk -e common/arduino-atmega/Makefile.include | grep -v 'boards/common/' | cut -f 2 -d/)
echo ${AVRDUDE_BOARDS} 
arduino-duemilanove arduino-mega2560 arduino-uno jiminy-mega256rfr2 mega-xplained waspmote-pro
```

And there is the same output for `master` and this branch:

```
for board in ${AVRDUDE_BOARDS} ; do echo ${board}; BOARD=${board} make -C examples/hello-world/ --no-print-directory FLASHER=true flash-only; done
arduino-duemilanove
true -c arduino -p m328p -P /dev/ttyUSB0 -b 57600 -F -D -U flash:w:/home/harter/work/git/RIOT/examples/hello-world/bin/arduino-duemilanove/hello-world.hex
arduino-mega2560
true -c stk500v2 -p m2560 -P /dev/ttyACM0 -b 115200 -F -D -U flash:w:/home/harter/work/git/RIOT/examples/hello-world/bin/arduino-mega2560/hello-world.hex
arduino-uno
true -c arduino -p m328p -P /dev/ttyACM0 -b 115200 -F -D -U flash:w:/home/harter/work/git/RIOT/examples/hello-world/bin/arduino-uno/hello-world.hex
jiminy-mega256rfr2
true -c wiring -p m256rfr2 -P /dev/ttyACM0 -b 0010005 -F -U flash:w:/home/harter/work/git/RIOT/examples/hello-world/bin/jiminy-mega256rfr2/hello-world.hex
mega-xplained
true -c buspirate -p m1284p -P /dev/ttyUSB0 -F -U flash:w:/home/harter/work/git/RIOT/examples/hello-world/bin/mega-xplained/hello-world.hex
waspmote-pro
true -c stk500v1 -p m1281 -P /dev/ttyACM0 -b 115200 -F -U flash:w:/home/harter/work/git/RIOT/examples/hello-world/bin/waspmote-pro/hello-world.hex
```

### Issues/PRs references

Split out of #8838 