### PR TITLE
nrf802154: Validate frame length before dst filter

### DIFF
--- a/cpu/nrf52/radio/nrf802154/nrf802154.c
+++ b/cpu/nrf52/radio/nrf802154/nrf802154.c
@@ -139,6 +139,10 @@ static void _enable_tx(void)
  */
 static bool _data_frame_filter(void)
 {
+    size_t psdu_len = rxbuf[0];
+    if (psdu_len < IEEE802154_FCF_LEN) {
+        return false;
+    }
     size_t expected_len = ieee802154_get_frame_hdr_len(&rxbuf[1]);
     if (!expected_len) {
         return false;
@@ -146,7 +150,7 @@ static bool _data_frame_filter(void)
     /* Check CRC, data type, length and destination filter */
     return ((NRF_RADIO->CRCSTATUS == 1) &&
             ((rxbuf[1] & IEEE802154_FCF_TYPE_MASK) == IEEE802154_FCF_TYPE_DATA) &&
-            (rxbuf[0] > expected_len) &&
+            (psdu_len > expected_len) &&
             (netdev_ieee802154_dst_filter(&nrf802154_dev,  &rxbuf[1]) == 0));
 }
 

--- a/cpu/nrf52/radio/nrf802154/nrf802154.c
+++ b/cpu/nrf52/radio/nrf802154/nrf802154.c
@@ -139,19 +139,9 @@ static void _enable_tx(void)
  */
 static bool _data_frame_filter(void)
 {
-    size_t psdu_len = rxbuf[0];
-    if (psdu_len < IEEE802154_FCF_LEN) {
-        return false;
-    }
-    size_t expected_len = ieee802154_get_frame_hdr_len(&rxbuf[1]);
-    if (!expected_len) {
-        return false;
-    }
-    /* Check CRC, data type, length and destination filter */
+    /* Check CRC and data frame filter*/
     return ((NRF_RADIO->CRCSTATUS == 1) &&
-            ((rxbuf[1] & IEEE802154_FCF_TYPE_MASK) == IEEE802154_FCF_TYPE_DATA) &&
-            (psdu_len > expected_len) &&
-            (netdev_ieee802154_dst_filter(&nrf802154_dev,  &rxbuf[1]) == 0));
+            netdev_ieee802154_data_frame_filter(&nrf802154_dev, &rxbuf[1], rxbuf[0]));
 }
 
 static void _set_chan(uint16_t chan)

--- a/drivers/include/net/netdev/ieee802154.h
+++ b/drivers/include/net/netdev/ieee802154.h
@@ -192,6 +192,21 @@ int netdev_ieee802154_set(netdev_ieee802154_t *dev, netopt_t opt, const void *va
  */
 int netdev_ieee802154_dst_filter(netdev_ieee802154_t *dev, const uint8_t *mhr);
 
+/**
+ * @brief This function validates a data frame for minimal length and
+ * destination fields. It includes @ref netdev_ieee802154_dst_filter for
+ * validating the destination
+ *
+ * @param[in] dev       network device descriptor
+ * @param[in] mhr       mac header
+ * @param[in] frame_len Length of the frame as indicated by the phy
+ *
+ * @return 0            when the frame is not filtered
+ * @return 1            when the frame is filtered
+ */
+int netdev_ieee802154_data_frame_filter(netdev_ieee802154_t *dev,
+                                        const uint8_t *mhr, size_t frame_len);
+
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/netdev_ieee802154/netdev_ieee802154.c
+++ b/drivers/netdev_ieee802154/netdev_ieee802154.c
@@ -279,4 +279,21 @@ int netdev_ieee802154_dst_filter(netdev_ieee802154_t *dev, const uint8_t *mhr)
     return 1;
 }
 
+int netdev_ieee802154_data_frame_filter(netdev_ieee802154_t *dev,
+                                        const uint8_t *mhr, size_t frame_len)
+{
+    if (frame_len < IEEE802154_FCF_LEN) {
+        return 1;
+    }
+    size_t expected_len = ieee802154_get_frame_hdr_len(mhr);
+    /* Check lenght data type, length and destination filter */
+    if ((expected_len != 0) &&
+        (frame_len > expected_len) &&
+        ((*mhr & IEEE802154_FCF_TYPE_MASK) == IEEE802154_FCF_TYPE_DATA) &&
+        (netdev_ieee802154_dst_filter(dev, mhr) == 0)) {
+        return 0;
+    }
+    return 1;
+}
+
 /** @} */


### PR DESCRIPTION
### Contribution description

This PR adds a length check to the received frame. This prevents the destination filter check in the driver from reading beyond the received frame length. This increases the time spent in the receive part of the interrupt by 0.875µs (from 6.75µs to 7.625µs).

Also requesting a review from @miri64 and @haukepetersen as they probably also have an opinion on the additional check here.

### Testing procedure

Basic receive validation should be enough. 
Before this PR it should have been possible to trigger a netif receive operation on an incorrect frame after a valid frame was received.

### Issues/PRs references

None