### PR TITLE
net/gnrc_pktbuf: rm deprecated _pktbuf_get_iovec()

### DIFF
--- a/sys/include/net/gnrc/pktbuf.h
+++ b/sys/include/net/gnrc/pktbuf.h
@@ -191,23 +191,6 @@ static inline void gnrc_pktbuf_release(gnrc_pktsnip_t *pkt)
 gnrc_pktsnip_t *gnrc_pktbuf_start_write(gnrc_pktsnip_t *pkt);
 
 /**
- * @brief   Create a IOVEC representation of the packet pointed to by *pkt*
- *
- * @pre `(len != NULL)`
- *
- * @details This function will create a new packet snip in the packet buffer,
- *          which points to the given *pkt* and contains a IOVEC representation
- *          of the referenced packet in its data section.
- *
- * @param[in]  pkt  Packet to export as IOVEC
- * @param[out] len  Number of elements in the IOVEC
- *
- * @return  Pointer to the 'IOVEC packet snip'
- * @return  NULL, if packet is empty of the packet buffer is full
- */
-gnrc_pktsnip_t *gnrc_pktbuf_get_iovec(gnrc_pktsnip_t *pkt, size_t *len);
-
-/**
  * @brief   Deletes a snip from a packet and the packet buffer.
  *
  * @param[in] pkt   A packet.

--- a/sys/net/gnrc/pktbuf/gnrc_pktbuf.c
+++ b/sys/net/gnrc/pktbuf/gnrc_pktbuf.c
@@ -17,40 +17,6 @@
 
 #include "net/gnrc/pktbuf.h"
 
-gnrc_pktsnip_t *gnrc_pktbuf_get_iovec(gnrc_pktsnip_t *pkt, size_t *len)
-{
-    size_t length;
-    gnrc_pktsnip_t *head;
-    struct iovec *vec;
-
-    assert(len != NULL);
-    if (pkt == NULL) {
-        *len = 0;
-        return NULL;
-    }
-
-    /* count the number of snips in the packet and allocate the IOVEC */
-    length = gnrc_pkt_count(pkt);
-    head = gnrc_pktbuf_add(pkt, NULL, (length * sizeof(struct iovec)),
-                           GNRC_NETTYPE_IOVEC);
-    if (head == NULL) {
-        *len = 0;
-        return NULL;
-    }
-
-    assert(head->data != NULL);
-    vec = (struct iovec *)(head->data);
-    /* fill the IOVEC */
-    while (pkt != NULL) {
-        vec->iov_base = pkt->data;
-        vec->iov_len = pkt->size;
-        ++vec;
-        pkt = pkt->next;
-    }
-    *len = length;
-    return head;
-}
-
 gnrc_pktsnip_t *gnrc_pktbuf_remove_snip(gnrc_pktsnip_t *pkt,
                                         gnrc_pktsnip_t *snip)
 {

--- a/tests/unittests/tests-pktbuf/tests-pktbuf.c
+++ b/tests/unittests/tests-pktbuf/tests-pktbuf.c
@@ -811,59 +811,6 @@ static void test_pktbuf_start_write__pkt_users_2(void)
     TEST_ASSERT(gnrc_pktbuf_is_empty());
 }
 
-static void test_pktbuf_get_iovec__1_elem(void)
-{
-    struct iovec *vec;
-    size_t len;
-    gnrc_pktsnip_t *snip = gnrc_pktbuf_add(NULL, TEST_STRING16, sizeof(TEST_STRING16),
-                                           GNRC_NETTYPE_UNDEF);
-    snip = gnrc_pktbuf_get_iovec(snip, &len);
-    vec = (struct iovec *)snip->data;
-
-    TEST_ASSERT_EQUAL_INT(sizeof(struct iovec), snip->size);
-    TEST_ASSERT_EQUAL_INT(1, len);
-    TEST_ASSERT(snip->next->data == vec[0].iov_base);
-    TEST_ASSERT_EQUAL_INT(snip->next->size, vec[0].iov_len);
-
-    gnrc_pktbuf_release(snip);
-    TEST_ASSERT(gnrc_pktbuf_is_empty());
-}
-
-static void test_pktbuf_get_iovec__3_elem(void)
-{
-    struct iovec *vec;
-    size_t len;
-    gnrc_pktsnip_t *snip = gnrc_pktbuf_add(NULL, TEST_STRING16, sizeof(TEST_STRING16),
-                                           GNRC_NETTYPE_UNDEF);
-    snip = gnrc_pktbuf_add(snip, TEST_STRING8, sizeof(TEST_STRING8), GNRC_NETTYPE_UNDEF);
-    snip = gnrc_pktbuf_add(snip, TEST_STRING4, sizeof(TEST_STRING4), GNRC_NETTYPE_UNDEF);
-    snip = gnrc_pktbuf_get_iovec(snip, &len);
-    vec = (struct iovec *)snip->data;
-
-    TEST_ASSERT_EQUAL_INT((sizeof(struct iovec) * 3), snip->size);
-    TEST_ASSERT_EQUAL_INT(3, len);
-    TEST_ASSERT(snip->next->data == vec[0].iov_base);
-    TEST_ASSERT(snip->next->next->data == vec[1].iov_base);
-    TEST_ASSERT(snip->next->next->next->data == vec[2].iov_base);
-    TEST_ASSERT_EQUAL_INT(sizeof(TEST_STRING4), vec[0].iov_len);
-    TEST_ASSERT_EQUAL_INT(sizeof(TEST_STRING8), vec[1].iov_len);
-    TEST_ASSERT_EQUAL_INT(sizeof(TEST_STRING16), vec[2].iov_len);
-
-    gnrc_pktbuf_release(snip);
-    TEST_ASSERT(gnrc_pktbuf_is_empty());
-}
-
-static void test_pktbuf_get_iovec__null(void)
-{
-    gnrc_pktsnip_t *res;
-    size_t len;
-
-    res = gnrc_pktbuf_get_iovec(NULL, &len);
-
-    TEST_ASSERT(res == NULL);
-    TEST_ASSERT_EQUAL_INT(0, len);
-}
-
 static void test_pktbuf_reverse_snips__too_full(void)
 {
     gnrc_pktsnip_t *pkt, *pkt_next, *pkt_huge;
@@ -953,9 +900,6 @@ Test *tests_pktbuf_tests(void)
         new_TestFixture(test_pktbuf_start_write__NULL),
         new_TestFixture(test_pktbuf_start_write__pkt_users_1),
         new_TestFixture(test_pktbuf_start_write__pkt_users_2),
-        new_TestFixture(test_pktbuf_get_iovec__1_elem),
-        new_TestFixture(test_pktbuf_get_iovec__3_elem),
-        new_TestFixture(test_pktbuf_get_iovec__null),
         new_TestFixture(test_pktbuf_reverse_snips__too_full),
         new_TestFixture(test_pktbuf_reverse_snips__success),
     };


### PR DESCRIPTION
### Contribution description
`netdev` was changed from accepting `struct iovec` to using `iotlist_t` for quite a while now. So for this, the `gnrc_pktbuf_get_iovec()` function is not longer needed. This PR removes this function together with its unittests.

### Testing procedure
Build test should be sufficient? Also a `git grep _get_iovec` should prove that all occurrences of that functions are removed. 

### Issues/PRs references
none