### PR TITLE
tests/unittests: exclude ENOMEM tests for gnrc_pktbuf_malloc

### DIFF
--- a/tests/unittests/tests-pktbuf/tests-pktbuf.c
+++ b/tests/unittests/tests-pktbuf/tests-pktbuf.c
@@ -653,6 +653,7 @@ static void test_pktbuf_realloc_data__success3(void)
     TEST_ASSERT(gnrc_pktbuf_is_empty());
 }
 
+#ifndef MODULE_GNRC_PKTBUF_MALLOC
 static void test_pktbuf_merge_data__memfull(void)
 {
     gnrc_pktsnip_t *pkt = gnrc_pktbuf_add(NULL, NULL, (GNRC_PKTBUF_SIZE / 4),
@@ -664,6 +665,7 @@ static void test_pktbuf_merge_data__memfull(void)
     gnrc_pktbuf_release(pkt);
     TEST_ASSERT(gnrc_pktbuf_is_empty());
 }
+#endif /* MODULE_GNRC_PKTBUF_MALLOC */
 
 static void test_pktbuf_merge_data__success1(void)
 {
@@ -811,6 +813,7 @@ static void test_pktbuf_start_write__pkt_users_2(void)
     TEST_ASSERT(gnrc_pktbuf_is_empty());
 }
 
+#ifndef MODULE_GNRC_PKTBUF_MALLOC
 static void test_pktbuf_reverse_snips__too_full(void)
 {
     gnrc_pktsnip_t *pkt, *pkt_next, *pkt_huge;
@@ -832,6 +835,7 @@ static void test_pktbuf_reverse_snips__too_full(void)
     gnrc_pktbuf_release(pkt_next);
     TEST_ASSERT(gnrc_pktbuf_is_empty());
 }
+#endif /* MODULE_GNRC_PKTBUF_MALLOC */
 
 static void test_pktbuf_reverse_snips__success(void)
 {
@@ -888,7 +892,9 @@ Test *tests_pktbuf_tests(void)
         new_TestFixture(test_pktbuf_realloc_data__success),
         new_TestFixture(test_pktbuf_realloc_data__success2),
         new_TestFixture(test_pktbuf_realloc_data__success3),
+#ifndef MODULE_GNRC_PKTBUF_MALLOC
         new_TestFixture(test_pktbuf_merge_data__memfull),
+#endif /* MODULE_GNRC_PKTBUF_MALLOC */
         new_TestFixture(test_pktbuf_merge_data__success1),
         new_TestFixture(test_pktbuf_merge_data__success2),
         new_TestFixture(test_pktbuf_hold__pkt_null),
@@ -900,7 +906,9 @@ Test *tests_pktbuf_tests(void)
         new_TestFixture(test_pktbuf_start_write__NULL),
         new_TestFixture(test_pktbuf_start_write__pkt_users_1),
         new_TestFixture(test_pktbuf_start_write__pkt_users_2),
+#ifndef MODULE_GNRC_PKTBUF_MALLOC
         new_TestFixture(test_pktbuf_reverse_snips__too_full),
+#endif /* MODULE_GNRC_PKTBUF_MALLOC */
         new_TestFixture(test_pktbuf_reverse_snips__success),
     };
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Testing memory too full with `malloc()` is hard to test, so as with other such tests for the packet buffer, exclude them if `gnrc_pktbuf_malloc` is compiled in.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Run

```sh
USEMODULE=gnrc_pktbuf_malloc make -C tests/unittests tests-pktbuf flash-only test
```

for a board of your choice (considering it fits). With this PR it will succeed, without it, it will fail.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Discovered in #2860.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
