### PR TITLE
makefiles/tools/uniflash.inc.mk: add a common configuration for using UniFlash

### DIFF
--- a/boards/cc2650-launchpad/Makefile.include
+++ b/boards/cc2650-launchpad/Makefile.include
@@ -10,25 +10,4 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 include $(RIOTMAKE)/tools/serial.inc.mk
 
 # configure the flash tool
-export UNIFLASH_PATH ?= "UNIFLASH_PATH unconfigured"
-# check which uniflash version is available, either 4.x or 3.x
-ifneq ("$(wildcard $(UNIFLASH_PATH)/dslite.sh)","")
-  export FLASHER ?= $(UNIFLASH_PATH)/dslite.sh
-  export FFLAGS  = --config $(RIOTBOARD)/$(BOARD)/dist/$(CPU_MODEL)_$(XDEBUGGER).ccxml $(ELFFILE)
-  # configure uniflash for resetting target
-  export RESET = $(UNIFLASH_PATH)/simplelink/gen2/bin/xds110reset
-  export RESET_FLAGS
-else
-  export FLASHER = $(UNIFLASH_PATH)/uniflash.sh
-  export FFLAGS  = -ccxml $(RIOTBOARD)/$(BOARD)/dist/$(CPU_MODEL)_$(XDEBUGGER).ccxml -program $(ELFFILE)
-  # configure uniflash for resetting target
-  export RESET = $(UNIFLASH_PATH)/uniflash.sh
-  export RESET_FLAGS = -ccxml $(RIOTBOARD)/$(BOARD)/dist/$(CPU_MODEL)_$(XDEBUGGER).ccxml -reset
-endif
-# configure the debug server
-export DEBUGSERVER = $(UNIFLASH_PATH)/ccs_base/common/uscif/gdb_agent_console
-export DEBUGSERVER_FLAGS = -p 3333 $(RIOTBOARD)/$(BOARD)/dist/$(CPU_MODEL)_$(XDEBUGGER).dat
-
-# configure the debugging tool
-export DEBUGGER = $(PREFIX)gdb
-export DEBUGGER_FLAGS = -x $(RIOTBOARD)/$(BOARD)/dist/$(CPU_MODEL)_gdb.conf $(ELFFILE)
+include $(RIOTMAKE)/tools/uniflash.inc.mk

--- a/boards/cc2650stk/Makefile.include
+++ b/boards/cc2650stk/Makefile.include
@@ -10,25 +10,4 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 include $(RIOTMAKE)/tools/serial.inc.mk
 
 # configure the flash tool
-export UNIFLASH_PATH ?= "UNIFLASH_PATH unconfigured"
-# check which uniflash version is available, either 4.x or 3.x
-ifneq ("$(wildcard $(UNIFLASH_PATH)/dslite.sh)","")
-  export FLASHER ?= $(UNIFLASH_PATH)/dslite.sh
-  export FFLAGS  = --config $(RIOTBOARD)/$(BOARD)/dist/$(CPU_MODEL)_$(XDEBUGGER).ccxml $(ELFFILE)
-  # configure uniflash for resetting target
-  export RESET = $(UNIFLASH_PATH)/simplelink/gen2/bin/xds110reset
-  export RESET_FLAGS
-else
-  export FLASHER = $(UNIFLASH_PATH)/uniflash.sh
-  export FFLAGS  = -ccxml $(RIOTBOARD)/$(BOARD)/dist/$(CPU_MODEL)_$(XDEBUGGER).ccxml -program $(ELFFILE)
-  # configure uniflash for resetting target
-  export RESET = $(UNIFLASH_PATH)/uniflash.sh
-  export RESET_FLAGS = -ccxml $(RIOTBOARD)/$(BOARD)/dist/$(CPU_MODEL)_$(XDEBUGGER).ccxml -reset
-endif
-# configure the debug server
-export DEBUGSERVER = $(UNIFLASH_PATH)/ccs_base/common/uscif/gdb_agent_console
-export DEBUGSERVER_FLAGS = -p 3333 $(RIOTBOARD)/$(BOARD)/dist/$(CPU_MODEL)_$(XDEBUGGER).dat
-
-# configure the debugging tool
-export DEBUGGER = $(PREFIX)gdb
-export DEBUGGER_FLAGS = -x $(RIOTBOARD)/$(BOARD)/dist/$(CPU_MODEL)_gdb.conf $(ELFFILE)
+include $(RIOTMAKE)/tools/uniflash.inc.mk

--- a/boards/cc2650stk/Makefile.include
+++ b/boards/cc2650stk/Makefile.include
@@ -1,6 +1,6 @@
 export CPU       = cc26x0
 export CPU_MODEL = cc26x0f128
-export XDEBUGGER  = XDS110
+export XDEBUGGER = XDS110
 
 # set default port depending on operating system
 PORT_LINUX  ?= /dev/ttyACM0

--- a/makefiles/tools/uniflash.inc.mk
+++ b/makefiles/tools/uniflash.inc.mk
@@ -5,7 +5,12 @@ ifneq ("$(wildcard $(UNIFLASH_PATH)/dslite.sh)","")
   export FLASHER ?= $(UNIFLASH_PATH)/dslite.sh
   export FFLAGS  = --config $(RIOTBOARD)/$(BOARD)/dist/$(CPU_MODEL)_$(XDEBUGGER).ccxml $(ELFFILE)
   # configure uniflash for resetting target
-  export RESET = $(UNIFLASH_PATH)/simplelink/gen2/bin/xds110reset
+  # xds110reset path changed in version UniFlash v4.4.0
+  # Try to detect the newest one and fallback to only 'xds110reset'
+  _XDS110RESET_4_0_4_3 ?= $(UNIFLASH_PATH)/simplelink/gen2/bin/xds110reset
+  _XDS110RESET ?= $(UNIFLASH_PATH)/simplelink/imagecreator/bin/xds110reset
+  XDS110RESET ?= $(firstword $(wildcard $(_XDS110RESET) $(_XDS110RESET_4_0_4_3)) xds110reset)
+  export RESET = $(XDS110RESET)
   export RESET_FLAGS
 else
   export FLASHER = $(UNIFLASH_PATH)/uniflash.sh

--- a/makefiles/tools/uniflash.inc.mk
+++ b/makefiles/tools/uniflash.inc.mk
@@ -1,0 +1,23 @@
+# http://www.ti.com/tool/uniflash
+export UNIFLASH_PATH ?= "UNIFLASH_PATH unconfigured"
+# check which uniflash version is available, either 4.x or 3.x
+ifneq ("$(wildcard $(UNIFLASH_PATH)/dslite.sh)","")
+  export FLASHER ?= $(UNIFLASH_PATH)/dslite.sh
+  export FFLAGS  = --config $(RIOTBOARD)/$(BOARD)/dist/$(CPU_MODEL)_$(XDEBUGGER).ccxml $(ELFFILE)
+  # configure uniflash for resetting target
+  export RESET = $(UNIFLASH_PATH)/simplelink/gen2/bin/xds110reset
+  export RESET_FLAGS
+else
+  export FLASHER = $(UNIFLASH_PATH)/uniflash.sh
+  export FFLAGS  = -ccxml $(RIOTBOARD)/$(BOARD)/dist/$(CPU_MODEL)_$(XDEBUGGER).ccxml -program $(ELFFILE)
+  # configure uniflash for resetting target
+  export RESET = $(UNIFLASH_PATH)/uniflash.sh
+  export RESET_FLAGS = -ccxml $(RIOTBOARD)/$(BOARD)/dist/$(CPU_MODEL)_$(XDEBUGGER).ccxml -reset
+endif
+# configure the debug server
+export DEBUGSERVER = $(UNIFLASH_PATH)/ccs_base/common/uscif/gdb_agent_console
+export DEBUGSERVER_FLAGS = -p 3333 $(RIOTBOARD)/$(BOARD)/dist/$(CPU_MODEL)_$(XDEBUGGER).dat
+
+# configure the debugging tool
+export DEBUGGER = $(PREFIX)gdb
+export DEBUGGER_FLAGS = -x $(RIOTBOARD)/$(BOARD)/dist/$(CPU_MODEL)_gdb.conf $(ELFFILE)

--- a/makefiles/tools/uniflash.inc.mk
+++ b/makefiles/tools/uniflash.inc.mk
@@ -1,9 +1,11 @@
 # http://www.ti.com/tool/uniflash
+FLASHFILE ?= $(ELFFILE)
+
 export UNIFLASH_PATH ?= "UNIFLASH_PATH unconfigured"
 # check which uniflash version is available, either 4.x or 3.x
 ifneq ("$(wildcard $(UNIFLASH_PATH)/dslite.sh)","")
   export FLASHER ?= $(UNIFLASH_PATH)/dslite.sh
-  export FFLAGS  = --config $(RIOTBOARD)/$(BOARD)/dist/$(CPU_MODEL)_$(XDEBUGGER).ccxml $(ELFFILE)
+  export FFLAGS  = --config $(RIOTBOARD)/$(BOARD)/dist/$(CPU_MODEL)_$(XDEBUGGER).ccxml $(FLASHFILE)
   # configure uniflash for resetting target
   # xds110reset path changed in version UniFlash v4.4.0
   # Try to detect the newest one and fallback to only 'xds110reset'
@@ -14,7 +16,7 @@ ifneq ("$(wildcard $(UNIFLASH_PATH)/dslite.sh)","")
   export RESET_FLAGS
 else
   export FLASHER = $(UNIFLASH_PATH)/uniflash.sh
-  export FFLAGS  = -ccxml $(RIOTBOARD)/$(BOARD)/dist/$(CPU_MODEL)_$(XDEBUGGER).ccxml -program $(ELFFILE)
+  export FFLAGS  = -ccxml $(RIOTBOARD)/$(BOARD)/dist/$(CPU_MODEL)_$(XDEBUGGER).ccxml -program $(FLASHFILE)
   # configure uniflash for resetting target
   export RESET = $(UNIFLASH_PATH)/uniflash.sh
   export RESET_FLAGS = -ccxml $(RIOTBOARD)/$(BOARD)/dist/$(CPU_MODEL)_$(XDEBUGGER).ccxml -reset


### PR DESCRIPTION
### Contribution description

This pull request:
* adds a common uniflash flasher
* uses it in the cc2650xx boards.
* update the RESET configuration to handle `UniFlash` version >= 4.4.0 that had a different reset directory. In case it is not found, I used 'xds110reset' to be sure to have a value.
* use FLASHFILE as file to flash.

I tested with `cc2650-launchpad` with the versions:

* uniflash_sl.4.1.1329.run
* uniflash_sl.4.3.0.1802.run
* uniflash_sl.4.4.0.2009.run
* uniflash_sl.4.5.0.2056.run
* uniflash_sl.4.6.0.2176.run

The version `uniflash.4.0.986.run` did not work, even on master, as there is no `xds110reset`


### Testing procedure

#### Refactoring

An easier task without board could be to review commit by commit too.
The 3 first commits are only putting in common and can easily be checked by comparing the files.
The same for the `FLASHFILE` one.


#### Testing the reset handling

Either you review the code handling, or you test each versions (guess what I did…)

Detect the new path for reset

http://downloads.ti.com/ccs/esd/uniflash/uniflash_sl.4.4.0.2009.run?tracked=1
```
UNIFLASH_PATH=${HOME}/ti/uniflash_4.4.0 BOARD=cc2650-launchpad make --no-print-directory -C tests/shell/ reset
/home/harter/ti/uniflash_4.4.0/simplelink/imagecreator/bin/xds110reset
```

Detect the old path for reset (same as in master)

http://downloads.ti.com/ccs/esd/uniflash/uniflash_sl.4.3.0.1802.run?tracked=1
```
UNIFLASH_PATH=${HOME}/ti/uniflash_4.3.0 BOARD=cc2650-launchpad make --no-print-directory -C tests/shell/ reset
/home/harter/ti/uniflash_4.3.0/simplelink/gen2/bin/xds110reset
```

Detect the backup to `xds110reset` with this version
http://downloads.ti.com/ccs/esd/uniflash/uniflash.4.0.986.run?tracked=1

```
# This should fail as there is not `xds110reset` in uniflash and i the path
UNIFLASH_PATH=${HOME}/ti/uniflash_4.0 BOARD=cc2650-launchpad make --no-print-directory -C tests/shell/ reset
Reset program xds110reset is required but not found in PATH.  Aborting.
/home/harter/work/git/RIOT/tests/shell/../../Makefile.include:569: recipe for target 'reset' failed
```

####

Flashing still works:

```
UNIFLASH_PATH=${HOME}/ti/uniflash_4.6.0/ BOARD=cc2650-launchpad make --no-print-directory -C tests/shell/ flash test
# Test should succeed, do it with any test
```

#### Note

On my machine and the tested version, `DEBUGSERVER` file does not exist and was not working in master. I did not update this part yet.

### Issues/PRs references

Part of https://github.com/RIOT-OS/RIOT/pull/8838

Running the tests on `cc2560-launchpad` board given by @MrKevinWeiss for https://github.com/RIOT-OS/RIOT/pull/10870
