### PR TITLE
jlink: handle flashing at IMAGE_OFFSET

### DIFF
--- a/boards/openmote-cc2538/Makefile.include
+++ b/boards/openmote-cc2538/Makefile.include
@@ -12,7 +12,7 @@ export PROGRAMMER ?= cc2538-bsl
 ifeq ($(PROGRAMMER),jlink)
   # setup JLink for flashing
   export JLINK_DEVICE := cc2538sf53
-  export FLASH_ADDR := 200000
+  export FLASH_ADDR := 0x200000
   export JLINK_IF := JTAG
   export TUI := 1
   include $(RIOTMAKE)/tools/jlink.inc.mk


### PR DESCRIPTION
### Contribution description

Currently, the IMAGE_OFFSET variable isn't handled in jlink.sh. riotboot.mk is currently the only place where this variable is exported. So, this is needed for riotboot to flash properly using jlink. It attempts to be a non-destructive change for everything else.

The contribution attempts to ensure that the flashing address handling in jlink.sh remains the same for all other modules - i.e., it doesn't break anything. Further PRs will clean up the wider handling of the FLASH_ADDR and IMAGE_OFFSET variables. Handling of flashing address is now similar to that in openocd, except FLASH_ADDR is not automatically determined. So, this PR goes in the direction of making the handling of these variables homogenous.


### Testing procedure

Testing should cover all boards which use jlink and where riotboot is either currently supported or support is under development.

- [ ] tests/riotboot with nrf52dk, with slot0 only

Needed for:
https://github.com/RIOT-OS/RIOT/pull/11201
https://github.com/RIOT-OS/RIOT/pull/11126
