### PR TITLE
riotboot.mk: get variable as hex rather than dec

### DIFF
--- a/sys/riotboot/Makefile.include
+++ b/sys/riotboot/Makefile.include
@@ -7,7 +7,7 @@ RIOTBOOT_HDR_LEN ?= 0x100
 # slot 0. The values might be overridden to add more or less offset
 # if needed.
 SLOT0_OFFSET ?= $(RIOTBOOT_LEN)
-SLOT1_OFFSET ?= $(shell echo $$(($(SLOT0_OFFSET) + $(SLOT0_LEN))))
+SLOT1_OFFSET ?= $(shell printf "0x%X\n" $$(($(SLOT0_OFFSET) + $(SLOT0_LEN))))
 
 CFLAGS += -DSLOT0_LEN=$(SLOT0_LEN)
 CFLAGS += -DSLOT0_OFFSET=$(SLOT0_OFFSET)


### PR DESCRIPTION
### Contribution description

Previously, summing two hex values using the shell in this location was resulting in a decimal value, meaning the slot 1 image was flashing in the wrong place when using jlink. (Jlink seems to interpret all flashing values as hex values, even when not preceded by "0x".) This provides a fix.

Suggest making the same change in other locations where `shell echo` is used to sum hex variables?

### Testing procedure

- [ ] tests/riotboot with nrf52dk

- [ ] tests/riotboot with a board that uses openocd (e.g. samr21-xpro) 

### Issues/PRs references

Fixes https://github.com/RIOT-OS/RIOT/pull/11126

### Dependencies

https://github.com/RIOT-OS/RIOT/pull/11200