### PR TITLE
samd21: Expose PM states

### DIFF
--- a/cpu/samd21/include/periph_cpu.h
+++ b/cpu/samd21/include/periph_cpu.h
@@ -35,6 +35,16 @@ extern "C" {
 #define PM_BLOCKER_INITIAL  { .val_u32 = 0x00000001 }
 
 /**
+ * @name   SAMD21 sleep modes for PM
+ * @{
+ */
+#define SAMD21_PM_STANDBY       (0U)    /**< Standby mode (stops main clock) */
+#define SAMD21_PM_IDLE_2        (1U)    /**< Idle 2 (stops AHB, APB and CPU) */
+#define SAMD21_PM_IDLE_1        (2U)    /**< Idle 1 (stops AHB and CPU)      */
+#define SAMD21_PM_IDLE_0        (3U)    /**< Idle 0 (stops CPU)              */
+/** @} */
+
+/**
  * @brief   Mapping of pins to EXTI lines, -1 means not EXTI possible
  */
 static const int8_t exti_config[2][32] = {

--- a/cpu/samd21/periph/pm.c
+++ b/cpu/samd21/periph/pm.c
@@ -56,25 +56,25 @@ void pm_set(unsigned mode)
     int deep = 0;
 
     switch (mode) {
-        case 0:
+        case SAMD21_PM_STANDBY:
             /* Standby Mode
              * Potential Wake Up sources: asynchronous
              */
             deep = 1;
             break;
-        case 1:
+        case SAMD21_PM_IDLE_2:
             /* Sleep mode Idle 2
              * Potential Wake Up sources: asynchronous
              */
             PM->SLEEP.reg = SYSTEM_SLEEPMODE_IDLE_2;
             break;
-        case 2:
+        case SAMD21_PM_IDLE_1:
             /* Sleep mode Idle 1
              * Potential Wake Up sources: Synchronous (APB), asynchronous
              */
             PM->SLEEP.reg = SYSTEM_SLEEPMODE_IDLE_1;
             break;
-        case 3:
+        case SAMD21_PM_IDLE_0:
             /* Sleep mode Idle 0
              * Potential Wake Up sources: Synchronous (APB, AHB), asynchronous
             */


### PR DESCRIPTION
### Contribution description

This PR exposes the different PM states supported by the samd21 devices in the `periph_cpu.h` file. This is required to have peripherals block specific power modes with the pm_layered module.

### Testing procedure



### Issues/PRs references

Required for #10915 (requires blocking IDLE_1 and lower)