### PR TITLE
sys/riotboot: extend Makefile.include include to riotboot feature

### DIFF
--- a/sys/Makefile.include
+++ b/sys/Makefile.include
@@ -88,7 +88,7 @@ ifneq (,$(filter printf_float,$(USEMODULE)))
   endif
 endif
 
-ifneq (,$(filter riotboot_%,$(USEMODULE)))
+ifneq (,$(filter riotboot%,$(USEMODULE) $(FEATURES_USED)))
   include $(RIOTBASE)/sys/riotboot/Makefile.include
 endif
 


### PR DESCRIPTION
### Contribution description

#11181 broke riotboot compiles that don't use any of its modules (See [this](https://github.com/RIOT-OS/RIOT/pull/11181#issuecomment-474068519) comment).

The reason was a move of some riotboot variables (SLOTx_OFFSET) into the module's Makefile.include, as it was needed there. Defining it in makefiles/boot/riotboot.inc.mk was too late.
riotboot's Makefile.include was only included based on whether any riotboot module was compiled in.

This PR extends that to also include the file if the riotboot feature is used.

### Testing procedure

Try ```FEATURES_REQUIRED+=riotboot BOARD=samr21-xpro make -C examples/hello-world/ riotboot/flash``` on master. It fails.

Try with this PR, it should succeed.

### Issues/PRs references

#11181