### PR TITLE
cpu/stm32_common: use correct data bits macro

### DIFF
--- a/cpu/stm32_common/periph/uart.c
+++ b/cpu/stm32_common/periph/uart.c
@@ -181,7 +181,11 @@ int uart_mode(uart_t uart, uart_data_bits_t data_bits, uart_parity_t parity,
                 isr_ctx[uart].data_mask = 0x7F;
                 break;
             case UART_DATA_BITS_8:
+#ifdef USART_CR1_M0
+                data_bits = USART_CR1_M0;
+#else
                 data_bits = USART_CR1_M;
+#endif
                 break;
             default:
                 return UART_NOMODE;
@@ -196,7 +200,6 @@ int uart_mode(uart_t uart, uart_data_bits_t data_bits, uart_parity_t parity,
         return UART_INTERR;
     }
     dev(uart)->CR1 &= ~(USART_CR1_UE | USART_CR1_TE);
-    dev(uart)->CR1 &= ~USART_CR1_M1;
 #endif
 
     dev(uart)->CR2 &= ~USART_CR2_STOP;


### PR DESCRIPTION
### Contribution description

USART_CR1_M combines both USART_CR1_M0 and USART_CR1_M1 macros
affecting bits 12 and 28 on 7 data bits capable UARTs. Whereas
for other UARTs USART_CR1_M macro affects only bit 12.

This patch fixes wrong data bits usage on 7 data bits capable
UARTs with using USART_CR1_M0 macro for modes 8-E-x and 8-O-x.

It also simplifies bits unsetting as USART_CR1_M macro clears
all data bits related bits for both UART types.

### Testing procedure

Compile `periph_uart` test for nucleo-l476rg and setup 8-E-1. The UART will send data using 6-E-1 mode. 

### Issues/PRs references

Fixes #10743