### PR TITLE
boards/common/nrf52xxxdk: Fixed periph conf

### DIFF
--- a/boards/common/nrf52/include/cfg_spi_default.h
+++ b/boards/common/nrf52/include/cfg_spi_default.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2016-2018 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_common_nrf52
+ * @{
+ *
+ * @file
+ * @brief       Default SPI config for nRF52 based boards
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ */
+
+#ifndef CFG_SPI_DEFAULT_H
+#define CFG_SPI_DEFAULT_H
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .dev  = NRF_SPI0,
+        .sclk = GPIO_PIN(0, 15),
+        .mosi = GPIO_PIN(0, 13),
+        .miso = GPIO_PIN(0, 14),
+    }
+};
+
+#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CFG_SPI_DEFAULT_H */
+/** @} */

--- a/boards/common/nrf52xxxdk/include/periph_conf_common.h
+++ b/boards/common/nrf52xxxdk/include/periph_conf_common.h
@@ -31,22 +31,6 @@ extern "C" {
 #endif
 
 /**
- * @name    SPI configuration
- * @{
- */
-static const spi_conf_t spi_config[] = {
-    {
-        .dev  = NRF_SPI0,
-        .sclk = GPIO_PIN(0, 15),
-        .mosi = GPIO_PIN(0, 13),
-        .miso = GPIO_PIN(0, 14),
-    }
-};
-
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
-/** @} */
-
-/**
  * @name    I2C configuration
  * @{
  */

--- a/boards/common/nrf52xxxdk/include/periph_conf_common.h
+++ b/boards/common/nrf52xxxdk/include/periph_conf_common.h
@@ -37,9 +37,9 @@ extern "C" {
 static const spi_conf_t spi_config[] = {
     {
         .dev  = NRF_SPI0,
-        .sclk = 15,
-        .mosi = 13,
-        .miso = 14
+        .sclk = GPIO_PIN(0, 15),
+        .mosi = GPIO_PIN(0, 13),
+        .miso = GPIO_PIN(0, 14),
     }
 };
 

--- a/boards/nrf52832-mdk/include/periph_conf.h
+++ b/boards/nrf52832-mdk/include/periph_conf.h
@@ -23,6 +23,7 @@
 #include "periph_cpu.h"
 #include "cfg_clock_32_1.h"
 #include "cfg_rtt_default.h"
+#include "cfg_spi_default.h"
 #include "cfg_timer_default.h"
 
 #ifdef __cplusplus
@@ -36,22 +37,6 @@ extern "C" {
 #define UART_NUMOF          (1U)
 #define UART_PIN_RX         GPIO_PIN(0,19)
 #define UART_PIN_TX         GPIO_PIN(0,20)
-/** @} */
-
-/**
- * @name    SPI configuration
- * @{
- */
-static const spi_conf_t spi_config[] = {
-    {
-        .dev  = NRF_SPI0,
-        .sclk = 15,
-        .mosi = 13,
-        .miso = 14
-    }
-};
-
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nrf52840-mdk/include/periph_conf.h
+++ b/boards/nrf52840-mdk/include/periph_conf.h
@@ -23,6 +23,7 @@
 #include "periph_cpu.h"
 #include "cfg_clock_32_1.h"
 #include "cfg_rtt_default.h"
+#include "cfg_spi_default.h"
 #include "cfg_timer_default.h"
 
 #ifdef __cplusplus
@@ -47,22 +48,6 @@ static const uart_conf_t uart_config[] = {
 #define UART_0_ISR          (isr_uart0)
 
 #define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
-/** @} */
-
-/**
- * @name    SPI configuration
- * @{
- */
-static const spi_conf_t spi_config[] = {
-    {
-        .dev  = NRF_SPI0,
-        .sclk = 15,
-        .mosi = 13,
-        .miso = 14
-    }
-};
-
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
 /** @} */
 
 /**

--- a/boards/nrf52840dk/include/periph_conf.h
+++ b/boards/nrf52840dk/include/periph_conf.h
@@ -27,6 +27,21 @@ extern "C" {
 #endif
 
 /**
+ * @name    SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .dev  = NRF_SPI0,
+        .sclk = GPIO_PIN(1, 15),
+        .mosi = GPIO_PIN(1, 13),
+        .miso = GPIO_PIN(1, 14),
+    }
+};
+#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+/** @} */
+
+/**
  * @name    UART configuration
  * @{
  */

--- a/boards/nrf52dk/include/periph_conf.h
+++ b/boards/nrf52dk/include/periph_conf.h
@@ -29,6 +29,21 @@ extern "C" {
 #endif
 
 /**
+ * @name    SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .dev  = NRF_SPI0,
+        .sclk = GPIO_PIN(0, 25),
+        .mosi = GPIO_PIN(0, 23),
+        .miso = GPIO_PIN(0, 24),
+    }
+};
+#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+/** @} */
+
+/**
  * @name    UART configuration
  * @{
  */


### PR DESCRIPTION
### Contribution description
- Used proper `GPIO_PIN()` macro to declare pins, instead of hard coded values
- Allow providing a board specific SPI config by changing the common config to only provide an SPI config if none has been supplied yet
- Added board specific SPI config for the nRF52-DK, as it differs from the common config
- Added board specific SPI config for the nRF52840-DK, as it differs from the common config

### Testing procedure

E.g. run `examples/gnrc_networking` with the following patch applied and the W5100 ethernet shield.

```patch
diff --git a/examples/gnrc_networking/Makefile b/examples/gnrc_networking/Makefile
index 78a9eb7f56..29d3ae3da3 100644
--- a/examples/gnrc_networking/Makefile
+++ b/examples/gnrc_networking/Makefile
@@ -19,7 +19,6 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-nano \
 
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
-USEMODULE += gnrc_netdev_default
 USEMODULE += auto_init_gnrc_netif
 # Activate ICMPv6 error messages
 USEMODULE += gnrc_icmpv6_error
@@ -40,6 +39,7 @@ USEMODULE += ps
 USEMODULE += netstats_l2
 USEMODULE += netstats_ipv6
 USEMODULE += netstats_rpl
+USEMODULE += w5100
 
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the
@@ -74,3 +74,7 @@ else
     CFLAGS += -DIEEE802154_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
   endif
 endif
+
+CFLAGS += '-DW5100_PARAM_CS=GPIO_PIN(1,12)'
+CFLAGS += '-DW5100_PARAM_EVT=GPIO_PIN(1,3)'
+CFLAGS += '-DDEBUG_ASSERT_VERBOSE'
```

### Issues/PRs references

None

------

Update: Adapted description to reflect changes on this PR based on the received review