### PR TITLE
doc/mega-xplained: add JTAG/Atmel-ICE instructions

### DIFF
--- a/boards/mega-xplained/doc.txt
+++ b/boards/mega-xplained/doc.txt
@@ -10,21 +10,42 @@ is an evaluation kit by Atmel (now Microchip) for their ATmega1284P microcontrol
 
 ### Flash the board
 
-1. The board may be flashed through JTAG or using a SPI ISP programmer. If
-   the Buspirate is being used, then `make flash` can be used to flash the
-   board:
-```
-     make BOARD=mega-xplained -C examples/hello-world flash
-```
+You can change the fuses and flash the board using an SPI ISP programmer such
+as the Bus Pirate, or using a JTAG programmer such as the Atmel-ICE with a
+JTAG adapter.
 
-2. The default fuse settings must also be changed.<br/>
+If using the Atmel-ICE as a JTAG programmer, connect the adapter with the
+square pin on the adapter connecting with the square pin on the board.
+
+1. First, make sure the default fuse settings are correct.<br/>
+
+   WARNING: setting the fuses incorrectly can brick your board!
+
    If using the Buspirate:
 ```
      avrdude -p m1284p -c buspirate -P /dev/ttyUSB0 -U efuse:w:0xFF:m
      avrdude -p m1284p -c buspirate -P /dev/ttyUSB0 -U hfuse:w:0x99:m
      avrdude -p m1284p -c buspirate -P /dev/ttyUSB0 -U lfuse:w:0xE2:m
 ```
-WARNING: setting the fuses incorrectly can brick your board!
+
+   If using the Atmel-ICE:
+```
+     avrdude -p m1284p -c atmelice -U efuse:w:0xFF:m
+     avrdude -p m1284p -c atmelice -U hfuse:w:0x99:m
+     avrdude -p m1284p -c atmelice -U lfuse:w:0xE2:m
+```
+
+2. After the fuses are set, flash the application.
+
+   If using the Buspirate:
+```
+     BOARD=mega-xplained make -C examples/hello-world flash
+```
+
+   If using the Atmel-ICE:
+```
+     BOARD=mega-xplained PROGRAMMER=atmelice make -C examples/hello-world flash
+```
 
 ### Accessing STDIO via UART
 
@@ -32,6 +53,6 @@ STDIO can be accessed through the USB connector. The on-board UART-USB
 adapter is not affected by flashing. It shows up as /dev/ttyACM0 on Linux.
 It will be used automatically with `make term`:
 ```
-     make BOARD=mega-xplained -C examples/hello-world term
+     BOARD=mega-xplained make -C examples/hello-world term
 ```
  */


### PR DESCRIPTION
### Contribution description

Adds instructions for flashing with the Atmel-ICE with the JTAG header.

### Testing procedure

Get an Atmel-ICE and mega-xplained, follow these instructions, and see if it works 

### Issues/PRs references

Depends on https://github.com/RIOT-OS/RIOT/pull/9818 because there's an image of the setup that needs including