### PR TITLE
sys/fmt: Add print byte in decimal

### DIFF
--- a/sys/fmt/fmt.c
+++ b/sys/fmt/fmt.c
@@ -530,63 +530,12 @@ void print_byte_hex(uint8_t byte)
     print(buf, sizeof(buf));
 }
 
-#if LESS_CODE_SIZE_BUT_HARD_TO_UNDERSTAND
 void print_byte_dec(uint8_t byte)
 {
-    char str[3] = {0};
-    uint8_t dec = 2;
-
-    str[2] = 0x30;
-    if (byte >= 200) {
-        str[0] = 0x32;
-        byte -= 200;
-    }
-    else if (byte >= 100) {
-        str[0] = 0x31;
-        byte -= 100;
-    }
-    else if (byte >= 10) {
-        dec = 1;
-    }
-    else {
-        dec = 0;
-    }
-    while(byte >= 10) {
-        str[dec - 1]++;
-        byte -= 10;
-    }
-    if (dec) {
-        str[dec - 1] |= str[2];
-    }
-    str[dec] = byte | 0x30;
-    print(str, dec + 1);
+    char buf[3]; /* "255" */
+    size_t len = fmt_u32_dec(buf, byte);
+    print(buf, len);
 }
-#else
-void print_byte_dec(uint8_t byte)
-{
-    char val = 0;
-    if (byte >= 200) {
-        print("2", 1);
-        byte -= 200;
-        val |= 0x30;
-    }
-    else if (byte >= 100) {
-        print("1", 1);
-        byte -= 100;
-        val |= 0x30;
-    }
-    while(byte >= 10) {
-        val++;
-        byte -= 10;
-    }
-    if (val) {
-        val |= 0x30;
-        print((char*)&val, 1);
-    }
-    byte |= 0x30;
-    print((char*)&byte, 1);
-}
-#endif
 
 void print_u32_hex(uint32_t val)
 {

--- a/sys/fmt/fmt.c
+++ b/sys/fmt/fmt.c
@@ -530,6 +530,64 @@ void print_byte_hex(uint8_t byte)
     print(buf, sizeof(buf));
 }
 
+#if LESS_CODE_SIZE_BUT_HARD_TO_UNDERSTAND
+void print_byte_dec(uint8_t byte)
+{
+    char str[3] = {0};
+    uint8_t dec = 2;
+
+    str[2] = 0x30;
+    if (byte >= 200) {
+        str[0] = 0x32;
+        byte -= 200;
+    }
+    else if (byte >= 100) {
+        str[0] = 0x31;
+        byte -= 100;
+    }
+    else if (byte >= 10) {
+        dec = 1;
+    }
+    else {
+        dec = 0;
+    }
+    while(byte >= 10) {
+        str[dec - 1]++;
+        byte -= 10;
+    }
+    if (dec) {
+        str[dec - 1] |= str[2];
+    }
+    str[dec] = byte | 0x30;
+    print(str, dec + 1);
+}
+#else
+void print_byte_dec(uint8_t byte)
+{
+    char val = 0;
+    if (byte >= 200) {
+        print("2", 1);
+        byte -= 200;
+        val |= 0x30;
+    }
+    else if (byte >= 100) {
+        print("1", 1);
+        byte -= 100;
+        val |= 0x30;
+    }
+    while(byte >= 10) {
+        val++;
+        byte -= 10;
+    }
+    if (val) {
+        val |= 0x30;
+        print((char*)&val, 1);
+    }
+    byte |= 0x30;
+    print((char*)&byte, 1);
+}
+#endif
+
 void print_u32_hex(uint32_t val)
 {
     char buf[8];

--- a/sys/include/fmt.h
+++ b/sys/include/fmt.h
@@ -413,6 +413,13 @@ void print_u32_dec(uint32_t val);
 void print_s32_dec(int32_t val);
 
 /**
+ * @brief Print byte value as dec to stdout
+ *
+ * @param[in]  byte Byte value to print
+ */
+void print_byte_dec(const uint8_t byte);
+
+/**
  * @brief Print byte value as hex to stdout
  *
  * @param[in]  byte Byte value to print

--- a/tests/fmt_print/main.c
+++ b/tests/fmt_print/main.c
@@ -25,7 +25,10 @@
 int main(void)
 {
     print_str("If you can read this:\n");
+    for (int i = 0; i < 256; i++) {
+        print_byte_dec((uint8_t)i);
+        print_str("\n");
+    }
     print_str("Test successful.\n");
-
     return 0;
 }

--- a/tests/fmt_print/tests/01-run.py
+++ b/tests/fmt_print/tests/01-run.py
@@ -6,6 +6,8 @@ from testrunner import run
 
 def testfunc(child):
     child.expect_exact('If you can read this:')
+    for i in range(0, 255):
+        child.expect_exact(str(i))
     child.expect_exact('Test successful.')
 
 


### PR DESCRIPTION
### Contribution description

Since some formats don't like hex (json) printing a byte in decimal is nice
This takes some shortcuts to try to make it as effient as possible
It doesn't use any mod or div, just add and subtract

### Testing procedure

`make all test -C tests/fmt_print/`

### Issues/PRs references

None, prep for future stuff though.