### PR TITLE
usbdev: Add low level initialization to `periph_init()`

### DIFF
--- a/drivers/include/periph/usbdev.h
+++ b/drivers/include/periph/usbdev.h
@@ -356,6 +356,22 @@ typedef struct usbdev_driver {
 } usbdev_driver_t;
 
 /**
+ * @brief Low level USB peripheral driver initialization
+ *
+ * This function prepares all usbdev peripherals available for initialization
+ */
+void usbdev_init_lowlevel(void);
+
+/**
+ * @brief Retrieve usbdev context from the peripheral
+ *
+ * @param num   usbdev peripheral number to retrieve
+ *
+ * @returns     the usbdev context at index @p num
+ */
+usbdev_t *usbdev_get_ctx(unsigned num);
+
+/**
  * @brief Initialize the USB peripheral device
  *
  * @see @ref usbdev_driver_t::init

--- a/drivers/periph_common/init.c
+++ b/drivers/periph_common/init.c
@@ -35,6 +35,9 @@
 #ifdef MODULE_PERIPH_HWRNG
 #include "periph/hwrng.h"
 #endif
+#ifdef MODULE_PERIPH_USBDEV
+#include "periph/usbdev.h"
+#endif
 
 void periph_init(void)
 {
@@ -64,5 +67,9 @@ void periph_init(void)
 
 #ifdef MODULE_PERIPH_HWRNG
     hwrng_init();
+#endif
+
+#ifdef MODULE_PERIPH_USBDEV
+    usbdev_init_lowlevel();
 #endif
 }


### PR DESCRIPTION
### Contribution description

This PR adds low level initialization functions for `usbdev`. A low level init function is added to be called in `periph_init()`. This should prepare any configured usbdev device available on the mcu for the real initialization call. Most of this is going to be hooking up the right driver struct with the right context.

The other function is added to allow for retrieving a usbdev context. this is similar to the already existing `SPI_DEV()` and `I2C_DEV()` macros.

Both of these functions must be implemented by the cpu-specific usbdev periph code.

### Testing procedure

Must not impact anything normally as there is no board providing `periph_usbdev` yet. With `periph_usbdev` this should cause a linker error for a missing implementation of `usbdev_init_lowlevel()`

### Issues/PRs references

![image](https://bergzand.net/misc/usbus.dot.svg)
fixes a chicken/egg issue with the current usb PR set.