### PR TITLE
drivers/enc28j60: Allow sending with empty chunks

### DIFF
--- a/drivers/enc28j60/enc28j60.c
+++ b/drivers/enc28j60/enc28j60.c
@@ -217,12 +217,14 @@ static void cmd_rbm(enc28j60_t *dev, uint8_t *data, size_t len)
 
 static void cmd_wbm(enc28j60_t *dev, uint8_t *data, size_t len)
 {
-    /* start transaction */
-    spi_acquire(SPI_BUS, CS_PIN, SPI_MODE_0, SPI_CLK);
-    /* transfer data */
-    spi_transfer_regs(SPI_BUS, CS_PIN, CMD_WBM, data, NULL, len);
-    /* finish SPI transaction */
-    spi_release(SPI_BUS);
+    if (len) {
+        /* start transaction */
+        spi_acquire(SPI_BUS, CS_PIN, SPI_MODE_0, SPI_CLK);
+        /* transfer data */
+        spi_transfer_regs(SPI_BUS, CS_PIN, CMD_WBM, data, NULL, len);
+        /* finish SPI transaction */
+        spi_release(SPI_BUS);
+    }
 }
 
 static void mac_get(enc28j60_t *dev, uint8_t *mac)


### PR DESCRIPTION
### Contribution description
This commit allows `netdev_driver_t::send()` of `enc28j60` to be passed an `iolist_t` containing one or more empty elements.

### Testing procedure
Run `examples/gnrc_networking` and try if `udp send ff02::1 1337 ""` works now. It shouldn't with master. Also check if `ping6` to make sure no regression is introduces.

### Issues/PRs references
Fix of https://github.com/RIOT-OS/RIOT/issues/11163 for the `enc28j60`.