### PR TITLE
sx127x: ignore empty iolist element

### DIFF
--- a/drivers/sx127x/sx127x_netdev.c
+++ b/drivers/sx127x/sx127x_netdev.c
@@ -54,6 +54,11 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
 
     uint8_t size = iolist_size(iolist);
 
+    /* Ignore send if packet size is 0 */
+    if (size == 0) {
+        return 0;
+    }
+
     switch (dev->settings.modem) {
         case SX127X_MODEM_FSK:
             /* todo */
@@ -77,7 +82,9 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
 
             /* Write payload buffer */
             for (const iolist_t *iol = iolist; iol; iol = iol->iol_next) {
-                sx127x_write_fifo(dev, iol->iol_base, iol->iol_len);
+                if(iol->iol_len > 0) {
+                    sx127x_write_fifo(dev, iol->iol_base, iol->iol_len);
+                }
             }
             break;
         default:


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
fixes #11163 for the `sx127x` radio driver
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Apply the following patch:
```
diff --git a/tests/driver_sx127x/main.c b/tests/driver_sx127x/main.c
index a009e7a2f..92fa0d18f 100644
--- a/tests/driver_sx127x/main.c
+++ b/tests/driver_sx127x/main.c
@@ -236,8 +236,8 @@ int send_cmd(int argc, char **argv)
            argv[1], (unsigned)strlen(argv[1]) + 1);
 
     iolist_t iolist = {
-        .iol_base = argv[1],
-        .iol_len = (strlen(argv[1]) + 1)
+        .iol_base = NULL,
+        .iol_len = 0
     };
 
     netdev_t *netdev = (netdev_t*) &sx127x;
```
Compile and flash wit b-l072z-lrwan1 or any compatible LoRaWAN board. 
Without this PR, it will crash due to an SPI assertion
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
#11163 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
