### PR TITLE
thread: allow overriding THREAD_PRIORITY_MAIN

### DIFF
--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -282,7 +282,9 @@ struct _thread {
  * @def THREAD_PRIORITY_MAIN
  * @brief Priority of the main thread
  */
+#ifndef THREAD_PRIORITY_MAIN
 #define THREAD_PRIORITY_MAIN           (THREAD_PRIORITY_MIN - (SCHED_PRIO_LEVELS/2))
+#endif
 
 /**
  * @name Optional flags for controlling a threads initial state


### PR DESCRIPTION

### Contribution description

This PR aim is to allow the developer to override `THREAD_PRIORITY_MAIN`.

### Testing procedure

Adds `CFLAGS += -DTHREAD_PRIORITY_MAIN=xx` and check with `ps` that main thread priority changed.
