### PR TITLE
makefiles/utils/{strings, paths}: Add function library.

### DIFF
--- a/makefiles/utils/checks.mk
+++ b/makefiles/utils/checks.mk
@@ -1,6 +1,8 @@
 # Utilities to produce errors inside Make
 # Use this functions to produce friendlier error messages.
 
+include $(dir $(lastword $(MAKEFILE_LIST)))/strings.mk
+
 # Produce an error if the value is empty
 #
 # Parameters
@@ -9,3 +11,34 @@
 # Returns:
 #	the first argument, if it is not empty.
 ensure_value = $(if $(1),$(1),$(error $(2)))
+
+# Produce an error if the value is empty
+# This is similar to ensure_value, but always returns an empty string.
+#
+# Parameters
+#	value: a string which should not be empty
+#	message: The error message to display.
+# Returns:
+#	empty string
+assert = $(if $(1),,$(error $(2)))
+
+# Produce an error if the value is NOT empty
+# This is the opposite of assert
+#
+# Parameters
+#	value: a string which should be empty
+#	message: The error message to display.
+# Returns:
+#	empty string
+assert_not = $(if $(1),$(error $(2)),)
+
+# Produce an error if the values are not equal
+#
+# Parameters
+#	a: first string to match
+#	b: second string to match
+#	message (optional): The error message to display. If the message is empty a
+#					default message is shown.
+# Returns:
+#	empty string
+assert_eq = $(if $(call streq,$(1),$(2)),,$(error $(if $(3),$(3),Expected "$(2)" and got "$(1)")))

--- a/makefiles/utils/paths.mk
+++ b/makefiles/utils/paths.mk
@@ -1,0 +1,18 @@
+# Functions to manipulate filesystem paths
+
+include $(dir $(lastword $(MAKEFILE_LIST)))/strings.mk
+
+# Join components to make a path name
+joinpath = $(call intercal,/,$(1))
+
+# Split a path into its components
+splitpath = $(subst /, ,$(1))
+
+_putdots = $(patsubst %,..,$(1))
+_relpath ?= $(if $(call streq,$(firstword $(1)),$(firstword $(2))),\
+$(call _relpath,$(call rest,$(1)),$(call rest,$(2))),\
+$(call _putdots,$(1)) $(2))
+
+# Given a directory and a path (both absolute), calculate the path of the second
+# argument relative to the first one.
+relpath = $(call joinpath,$(call _relpath,$(call splitpath,$(1)),$(call splitpath,$(2))))

--- a/makefiles/utils/strings.mk
+++ b/makefiles/utils/strings.mk
@@ -1,0 +1,22 @@
+# String handling functions
+
+# Return an empty string if the arguments are different (works only for single
+# words
+streq = $(filter $(1),$(2))
+
+# Get the remaining words in a list (i.e. everything except the first)
+rest = $(wordlist 2,$(words $(1)),$(1))
+
+# Strings as truth values
+# In make, empty strings function as a "false" value and non-empty ones
+# as true.
+
+# Return a string ("x") if the argument is empty and vice versa
+strnot = $(if $(1),,x)
+
+# Concatenate a list of strings
+# Defined via "?=" because redefinition kill the recursive definition
+concat ?= $(if $(1),$(firstword $(1))$(call concat,$(call rest,$(1))),)
+
+# Intercalate: concatenate words in a list with a separator between each one.
+intercal = $(firstword $(2))$(call concat,$(addprefix $(1),$(call rest,$(2))))

--- a/makefiles/utils/strings.mk
+++ b/makefiles/utils/strings.mk
@@ -5,7 +5,10 @@
 streq = $(filter $(1),$(2))
 
 # Get the remaining words in a list (i.e. everything except the first)
-rest = $(wordlist 2,$(words $(1)),$(1))
+# The upper limit is set to an unrealistically high number. The "correct" thing
+# to do would be to count the words, but impacts performance, and nobody will
+# ever have 2**31 words.
+rest = $(wordlist 2,2147483647,$(1))
 
 # Strings as truth values
 # In make, empty strings function as a "false" value and non-empty ones

--- a/makefiles/utils/strings.mk
+++ b/makefiles/utils/strings.mk
@@ -20,3 +20,19 @@ concat ?= $(if $(1),$(firstword $(1))$(call concat,$(call rest,$(1))),)
 
 # Intercalate: concatenate words in a list with a separator between each one.
 intercal = $(firstword $(2))$(call concat,$(addprefix $(1),$(call rest,$(2))))
+
+# Translate all words/characters in the first set to characters in the second set
+# Parameters:
+#    $1: space separated list of words or characters
+#    $2: space separated list of words or characters, same length as $1
+#    $3: string to translate
+xlate ?= $(if $(1),$(call xlate,$(call rest,$(1)),$(call rest,$(2)),$(subst $(firstword $(1)),$(firstword $(2)),$(3))),$(3))
+
+_UPPER_LETTERS = A B C D E F G H I J K L M N O P Q R S T U V W X Y Z
+_LOWER_LETTERS = a b c d e f g h i j k l m n o p q r s t u v w x y z
+
+
+lowercase = $(call xlate,$(_UPPER_LETTERS),$(_LOWER_LETTERS),$(1))
+uppercase = $(call xlate,$(_LOWER_LETTERS),$(_UPPER_LETTERS),$(1))
+
+uppercase_and_underscore = $(call uppercase,$(subst -,_,$1))

--- a/makefiles/utils/test-checks.mk
+++ b/makefiles/utils/test-checks.mk
@@ -5,3 +5,21 @@ test-ensure_value:
 
 test-ensure_value-negative:
 	@echo $(call ensure_value,$^,"This should fail")
+
+test-assert:
+	@test -z "$(call assert,$@,"This should not fail")"
+
+test-assert-negative:
+	@test -z "$(call assert,$^,"This should fail")"
+
+test-assert_not:
+	@test -z "$(call assert_not,$^,"This should not fail")"
+
+test-assert_not-negative:
+	@test -z "$(call assert_not,$@,"This should fail")"
+
+test-assert_eq:
+	@test -z "$(call assert_eq,x,x,"This should not fail")"
+
+test-assert_eq-negative:
+	@test -z "$(call assert_eq,z,x,"This should fail")"

--- a/makefiles/utils/test-paths.mk
+++ b/makefiles/utils/test-paths.mk
@@ -1,0 +1,27 @@
+# Test filesystem path functions
+
+include paths.mk
+include checks.mk
+
+test-relpath:
+	$(call assert_eq,$(call relpath,/a/b/c/d/e,/a/b/X/c/d/e),../../../X/c/d/e)
+	$(call assert_eq,$(call relpath,/1/2/3/5/6/7,/),../../../../../..)
+	$(call assert_eq,$(call relpath,/,/1/2/3/5/6/),1/2/3/5/6)
+	$(call assert_eq,$(call relpath,/a/b/c,/a/b/X/k),../X/k)
+	@# these fail but it should not matter because $1 should always be a dir
+	@# and $2 a file.
+	@# Asserting that the result is empty at least protects us from a wrong
+	@# result and is even useful considering how relpath is used.
+	$(call assert_not,$(call relpath,/,/),"Expected empty relative path")
+	$(call assert_not,$(call relpath,/1/2/3,/1/2/3),"Expected empty relative path")
+	@true
+
+# Use coreutils to calculate a relative path
+# This will only work if coreutils is installed
+sys_relpath = $(shell realpath -m --relative-to=$(1) $(2))
+
+test-relpath-against-sys:
+	$(call assert_eq,$(call relpath,/1/2/3/5/6/7,/1/2/3/4/5/6/7),$(call sys_relpath,/1/2/3/5/6/7,/1/2/3/4/5/6/7),)
+	$(call assert_eq,$(call relpath,/1/2/3/5/6/7,/),$(call sys_relpath,/1/2/3/5/6/7,/),)
+	$(call assert_eq,$(call relpath,/,/1/2/3/5/6/),$(call sys_relpath,/,/1/2/3/5/6/),)
+	@true

--- a/makefiles/utils/test-strings.mk
+++ b/makefiles/utils/test-strings.mk
@@ -1,0 +1,38 @@
+# Test the string handling functions
+
+include strings.mk
+include checks.mk
+
+# String equality. This has to be tested BEFORE ensure_equal
+# (ensure_equal is defined in term of this).
+# The order is: test assert, assert_not, streq (this), assert_eq,
+# and then the rest of the tests in this file
+
+test-streq:
+	$(call assert,$(call streq,hello,hello),"Strings are equal, you should not be seeing this")
+	$(call assert_not,$(call streq,hello,goodbye),"Strings are different (OK)")
+	$(call assert_not,$(call streq,,goodbye),"First string empty (OK)")
+	$(call assert_not,$(call streq,hello,),"Second string empty (OK)")
+	$(call assert_not,$(call streq,,),"Both strings empty (OK)")
+	@true
+
+test-rest:
+	$(call assert_eq,$(call rest,ab xy),xy)
+	$(call assert_eq,$(call rest,$(call rest,one two three)),three)
+	$(call assert_not,$(call rest,first))
+	@true
+
+test-strnot:
+	$(call assert,$(call strnot,),"strnot(empty) should be true")
+	$(call assert_not,$(call strnot,something),"strnot(not empty) should be false")
+	@true
+
+test-concat:
+	$(call assert_eq,$(call concat,ab xy z),abxyz)
+	@true
+
+test-intercal:
+	@# The multiple spaces between xy and z are on purpose
+	$(call assert_eq,$(call intercal,-,ab xy   z),ab-xy-z)
+	$(call assert_eq,$(call intercal,-,ab),ab)
+	@true

--- a/makefiles/utils/test-strings.mk
+++ b/makefiles/utils/test-strings.mk
@@ -36,3 +36,19 @@ test-intercal:
 	$(call assert_eq,$(call intercal,-,ab xy   z),ab-xy-z)
 	$(call assert_eq,$(call intercal,-,ab),ab)
 	@true
+
+STRING_LOWER = abcdefghijklmnopqrstuvwxyz-123456789
+STRING_UPPER = ABCDEFGHIJKLMNOPQRSTUVWXYZ-123456789
+STRING_MACRO = ABCDEFGHIJKLMNOPQRSTUVWXYZ_123456789
+
+test-lowercase:
+	$(call assert_eq,$(call lowercase,$(STRING_UPPER)),$(STRING_LOWER))
+	@true
+
+test-uppercase:
+	$(call assert_eq,$(call uppercase,$(STRING_LOWER)),$(STRING_UPPER))
+	@true
+
+test-uppercase_and_underscore:
+	$(call assert_eq,$(call uppercase_and_underscore,$(STRING_LOWER)),$(STRING_MACRO))
+	@true

--- a/tests/build_system_utils/Makefile
+++ b/tests/build_system_utils/Makefile
@@ -19,15 +19,6 @@ endef
 
 MAKEFILES_UTILS = $(RIOTMAKE)/utils
 
-COMPILE_TESTS += test-exported-variables
-COMPILE_TESTS += test-memoized-variables
-
-test-exported-variables:
-	$(Q)$(call command_should_succeed,"$(MAKE)" -C $(MAKEFILES_UTILS) -f test-variables.mk test-exported-variables,exported-variables)
-
-test-memoized-variables:
-	$(Q)$(call command_should_succeed,"$(MAKE)" -C $(MAKEFILES_UTILS) -f test-variables.mk test-memoized-variables,memoized-variables)
-
 # Abstract away the most common test procedure:
 # In these rule, the firs prerequisite MUST be the .mk file where the test
 # is defined
@@ -49,6 +40,14 @@ TEST_CHECKS = 	test-ensure_value test-assert test-assert_not \
 COMPILE_TESTS += $(TEST_CHECKS)
 
 $(TEST_CHECKS): $(MAKEFILES_UTILS)/test-checks.mk
+
+# tests for variable helpers
+
+TEST_VARS = test-exported-variables test-memoized-variables
+
+$(TEST_VARS): $(MAKEFILES_UTILS)/test-variables.mk
+
+COMPILE_TESTS += $(TEST_VARS)
 
 # test for string equality. They depend on having a working assert and assert_not
 TEST_STREQ = test-streq

--- a/tests/build_system_utils/Makefile
+++ b/tests/build_system_utils/Makefile
@@ -65,7 +65,8 @@ TEST_CHECKS_ALL = $(TEST_CHECKS) $(TEST_ASSERT_EQ)
 
 # Now that we know string equality assertions work, we can run the rest of
 # the tests
-TEST_STRINGS = test-strnot test-rest test-concat test-intercal
+TEST_STRINGS = test-strnot test-rest test-concat test-intercal \
+	       test-lowercase test-uppercase test-uppercase_and_underscore
 COMPILE_TESTS += $(TEST_STRINGS)
 
 $(TEST_STRINGS): $(MAKEFILES_UTILS)/test-strings.mk $(TEST_CHECKS_ALL)

--- a/tests/build_system_utils/Makefile
+++ b/tests/build_system_utils/Makefile
@@ -5,37 +5,86 @@ include $(RIOTBASE)/Makefile.include
 
 
 # Test utils commands
+
+ok_message = $(COLOR_ECHO) "$(COLOR_GREEN) [OK] $1 $(COLOR_RESET)"
+fail_message = $(COLOR_ECHO) "$(COLOR_RED) [FAIL] $1 $(COLOR_RESET)"
+
 define command_should_fail
-$1 2>/dev/null && { echo "Command '$1' should have failed but did not" >&2; $1; exit 1; } || true
+$1 2>/dev/null && { $(call fail_message,Command '$1' should have failed but did not) >&2; $1; exit 1; } || $(call ok_message,$2)
 endef
 
 define command_should_succeed
-$1 || { echo "Command '$1' failed" >&2; $1; exit 1; }
+($1 && $(call ok_message,$2) )  || { $(call fail_message,Command '$1' failed) >&2; $1; exit 1; }
 endef
-
 
 MAKEFILES_UTILS = $(RIOTMAKE)/utils
 
-COMPILE_TESTS += test-ensure_value test-ensure_value-negative
 COMPILE_TESTS += test-exported-variables
 COMPILE_TESTS += test-memoized-variables
+
+test-exported-variables:
+	$(Q)$(call command_should_succeed,"$(MAKE)" -C $(MAKEFILES_UTILS) -f test-variables.mk test-exported-variables,exported-variables)
+
+test-memoized-variables:
+	$(Q)$(call command_should_succeed,"$(MAKE)" -C $(MAKEFILES_UTILS) -f test-variables.mk test-memoized-variables,memoized-variables)
+
+# Abstract away the most common test procedure:
+# In these rule, the firs prerequisite MUST be the .mk file where the test
+# is defined
+
+test-%-negative:
+	$(Q)$(call command_should_fail,"$(MAKE)" -C $(MAKEFILES_UTILS) -f $< $@-negative,$* (negative))
+
+test-%:
+	$(Q)$(call command_should_succeed,"$(MAKE)" -C $(MAKEFILES_UTILS) -f $< $@,$*)
 
 # Tests will be run both in the host machine and in `docker`
 all: build-system-utils-tests
 
+# tests for 'ensure_value', 'assert_etc'
+TEST_CHECKS = 	test-ensure_value test-assert test-assert_not \
+				test-ensure_value-negative test-assert-negative \
+				test-assert_not-negative
+
+COMPILE_TESTS += $(TEST_CHECKS)
+
+$(TEST_CHECKS): $(MAKEFILES_UTILS)/test-checks.mk
+
+# test for string equality. They depend on having a working assert and assert_not
+TEST_STREQ = test-streq
+COMPILE_TESTS += $(TEST_STREQ)
+
+$(TEST_STREQ): $(MAKEFILES_UTILS)/test-strings.mk $(TEST_CHECKS)
+
+# Continue testing assertions. These require a working streq.
+TEST_ASSERT_EQ = test-assert_eq test-assert_eq-negative
+COMPILE_TESTS += $(TEST_ASSERT_EQ)
+
+$(TEST_ASSERT_EQ): $(MAKEFILES_UTILS)/test-checks.mk $(TEST_STREQ)
+
+TEST_CHECKS_ALL = $(TEST_CHECKS) $(TEST_ASSERT_EQ)
+
+# Now that we know string equality assertions work, we can run the rest of
+# the tests
+TEST_STRINGS = test-strnot test-rest test-concat test-intercal
+COMPILE_TESTS += $(TEST_STRINGS)
+
+$(TEST_STRINGS): $(MAKEFILES_UTILS)/test-strings.mk $(TEST_CHECKS_ALL)
+
+# Path manipulation (this requires string functions to work)
+TEST_PATHS = test-relpath
+ifeq ($(OS),Linux)
+  # Only test against coreutils in linux
+  TEST_PATHS += test-relpath-against-sys
+endif
+
+COMPILE_TESTS += $(TEST_PATHS)
+
+$(TEST_PATHS): $(MAKEFILES_UTILS)/test-paths.mk $(TEST_STRINGS)
+
+.PHONY: build-system-utils-tests
+# $(COMPILE_TESTS) should be phony but that conflicts with the implicit rule
+$(COMPILE_TESTS): FORCE
+
 build-system-utils-tests: $(COMPILE_TESTS)
-.PHONY: build-system-utils-tests $(COMPILE_TESTS)
-
-
-# tests for 'ensure_value'
-test-ensure_value:
-	$(Q)$(call command_should_succeed,"$(MAKE)" -C $(MAKEFILES_UTILS) -f test-checks.mk test-ensure_value)
-
-test-ensure_value-negative:
-	$(Q)$(call command_should_fail,"$(MAKE)" -C $(MAKEFILES_UTILS) -f test-checks.mk test-ensure_value-negative)
-
-test-exported-variables:
-	$(Q)$(call command_should_succeed,"$(MAKE)" -C $(MAKEFILES_UTILS) -f test-variables.mk test-exported-variables)
-
-test-memoized-variables:
-	$(Q)$(call command_should_succeed,"$(MAKE)" -C $(MAKEFILES_UTILS) -f test-variables.mk test-memoized-variables)
+	@true


### PR DESCRIPTION
### Contribution description

Add a set of functions written in pure makefile. The only function that is really useful now is relpath, to calculate relative paths in systems without coreutils/realpath (e.g. Mac).

Tests were added to tests/build_system_utils. The Makefile for the test was also reworked to avoid code repetition.

### Testing procedure

Run `make -C tests/build_system_utils`. You should see several green lines showing tests that passed.


### Issues/PRs references

~Needed for #10195 .~