### PR TITLE
makefiles/docker: add term in docker

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -410,7 +410,7 @@ include $(RIOTMAKE)/bindist.inc.mk
 include $(RIOTMAKE)/modules.inc.mk
 
 
-.PHONY: all link clean flash flash-only termdeps term doc debug debug-server reset objdump help info-modules
+.PHONY: all link clean flash flash-only termdeps term term-indocker doc debug debug-server reset objdump help info-modules
 .PHONY: print-size elffile binfile hexfile flashfile
 .PHONY: ..in-docker-container
 
@@ -474,6 +474,10 @@ ifeq ($(BUILDOSXNATIVE),1)
 else
   _LINK = $(if $(CPPMIX),$(LINKXX),$(LINK)) $(UNDEF) $(LINKFLAGPREFIX)--start-group $(BASELIBS) -lm $(LINKFLAGPREFIX)--end-group $(LINKFLAGS) $(LINKFLAGPREFIX)-Map=$(BINDIR)/$(APPLICATION).map
 endif # BUILDOSXNATIVE
+
+ifeq ($(ALL_IN_DOCKER),1)
+  BUILD_IN_DOCKER = 1
+endif
 
 ifeq ($(BUILD_IN_DOCKER),1)
 link: ..in-docker-container
@@ -616,9 +620,21 @@ preflash: $(BUILD_BEFORE_FLASH)
 
 termdeps: $(TERMDEPS)
 
-term: $(filter flash, $(MAKECMDGOALS)) $(TERMDEPS)
+term: $(filter flash flash-only, $(MAKECMDGOALS)) $(TERMDEPS)
 	$(call check_cmd,$(TERMPROG),Terminal program)
 	$(TERMPROG) $(TERMFLAGS)
+
+# Define 'term-indocker' to run term in the container.
+ifeq ($(BUILD_IN_DOCKER),1)
+  term-indocker: ..in-docker-container
+else
+ifeq ($(INSIDE_DOCKER),1)
+  term-indocker: term
+else
+  term-indocker:
+	$(error $@ must be run with `BUILD_IN_DOCKER=1`)
+endif # INSIDE_DOCKER
+endif # BUILD_IN_DOCKER
 
 list-ttys:
 	$(Q)$(RIOTTOOLS)/usb-serial/list-ttys.sh


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR allows user to use make term and make flash from within the docker container.

The only problem is I haven't found a way to flash the device without giving --privileged flag when executing the docker container.

When only using term the --privileged flag won't be added and only the specific PORT will me mapped as a device to the docker container.

Pros:

- only use docker to build, flash and term
- option to use term can be added on its own

Cons:

- still need to take care of udev rules or run as sudo
- option to the use term not very interesting without flash
- "--privileged" flags passed when flashing
- need to update riot/riotbuild image
- not sure if it would work in mac or windows

How do you fill about the pros/cons balance? 

I think **properly documented** this can still be useful as an option for developing using RIOT, it barely changes the Image size and largely extends usability.

PS: if anyone has an idea of how to do this without --privileged, that would be great!
PS2: Can be though of as a **WIP** since I have only really tested it in Ubuntu.

### Testing procedure

Considerations:

- so far only tested in Ubuntu
- riot/riotbuild is not update with https://github.com/RIOT-OS/riotdocker where python dependencies have been added to the docker image. To test this properly you will need to build the image locally, to lets say riotbuild, and provided the DOCKER_IMAGE parameter.
- udev rules must be set in the host for popper access to the device, otherwise everything must be done using sudo.
   - for samr21-xpro:
`echo 'KERNEL=="hidraw*", SUBSYSTEM=="hidraw", MODE="0664", GROUP="plugdev"' \
    | sudo tee -a /etc/udev/rules.d/99-usb.rules`
- works with openocd using https://github.com/RIOT-OS/riotdocker/pull/69 as an image

To enable term and flash, ALL_IN_DOCKER=1 must be set

make term:
`
DOCKER_IMAGE=riotbuild ALL_IN_DOCKER=1 make -C examples/hello-world/ BOARD=samr21-xpro term`

make flash:
`
DOCKER_IMAGE=riotbuild ALL_IN_DOCKER=1 make -C examples/hello-world/ BOARD=samr21-xpro term`

### Issues/PRs references

If you want to use opeocd it needs riotdocker: https://github.com/RIOT-OS/riotdocker/pull/69