### PR TITLE
cpu/stm32_common: don't block STOP mode by default when initializing the UART

### DIFF
--- a/cpu/stm32_common/periph/uart.c
+++ b/cpu/stm32_common/periph/uart.c
@@ -330,11 +330,6 @@ void uart_write(uart_t uart, const uint8_t *data, size_t len)
 void uart_poweron(uart_t uart)
 {
     assert(uart < UART_NUMOF);
-#ifdef STM32_PM_STOP
-    if (isr_ctx[uart].rx_cb) {
-        pm_block(STM32_PM_STOP);
-    }
-#endif
     periph_clk_en(uart_config[uart].bus, uart_config[uart].rcc_mask);
 }
 
@@ -343,11 +338,6 @@ void uart_poweroff(uart_t uart)
     assert(uart < UART_NUMOF);
 
     periph_clk_dis(uart_config[uart].bus, uart_config[uart].rcc_mask);
-#ifdef STM32_PM_STOP
-    if (isr_ctx[uart].rx_cb) {
-        pm_unblock(STM32_PM_STOP);
-    }
-#endif
 }
 
 static inline void irq_handler(uart_t uart)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

While testing low-power modes with STM32 using the `tests/periph_pm`, I found that it was very counter intuitive to have to call `unblock` twice on the STOP level to enable it.

Looking at the code, it turns out that there the blocking counter of the STOP is incremented by the UART initialization (which call uart_poweron internally) but all pm modes are already blocked by default.

Comparing with other CPU implementations of the UART peripheral, there's nothing about such a thing. As a result, this PR is just removing this logic.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Flash `tests/periph_pm` on a board using an STM32L0/L1/F2/F4
- Switch to low-power modes using the unblock/unblock_rtc commands:
```
> unblock 0
> unblock_rtc 1 5
... wait 5 seconds and the board should reboot
> unblock_rtc 1 5
... wait 5 seconds
> help
```

On master, this doesn't work this way, one has to do the following to get the same result:
```
> unblock 0
> unblock 1
> unblock_rtc 1 5
... wait 5 seconds and the board should reboot
> unblock 1
> unblock_rtc 1 5
... wait 5 seconds
> help
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
