### PR TITLE
tests/posix_semaphore: sem_timedwait should not return before abstime

### DIFF
--- a/tests/posix_semaphore/main.c
+++ b/tests/posix_semaphore/main.c
@@ -279,7 +279,7 @@ void test4(void)
     }
 
     uint64_str[fmt_u64_dec(uint64_str, elapsed)] = '\0';
-    if (elapsed < (exp - 100)) {
+    if (elapsed < exp) {
         printf("first: waited only %s usec => FAILED\n", uint64_str);
     }
     else if (elapsed > (exp + TEST4_TIMEOUT_EXCEEDED_MARGIN)) {


### PR DESCRIPTION
### Contribution description

Update the test as sem_timedwait is not supposed to return before the
given abstime.

Source: http://pubs.opengroup.org/onlinepubs/9699919799.2016edition/functions/sem_timedwait.html

    The timeout shall expire when the absolute time specified by abstime
    passes, as measured by the clock on which timeouts are based (that is,
    when the value of that clock equals or exceeds abstime), or if the
    absolute time specified by abstime has already been passed at the time
    of the call.

### Testing procedure

I tested with `samr21-xpro`  and this diff applied to show that the error is correctly detected

``` diff
diff --git a/tests/posix_semaphore/main.c b/tests/posix_semaphore/main.c
index 764aeb684..368a94c6e 100644
--- a/tests/posix_semaphore/main.c
+++ b/tests/posix_semaphore/main.c
@@ -262,8 +262,8 @@ void test4(void)
     puts("first: wait 1 sec for s1");
 
     start = xtimer_now_usec64();
-    abs.tv_sec = (time_t)((start / US_PER_SEC) + 1);
-    abs.tv_nsec = (long)((start % US_PER_SEC) * 1000);
+    abs.tv_sec = (time_t)(((start -100)/ US_PER_SEC) + 1);
+    abs.tv_nsec = (long)(((start -100)% US_PER_SEC) * 1000);
 
     int ret = sem_timedwait(&s1, &abs);
     elapsed = xtimer_now_usec64() - start;

```
The test command and relevant output with the detected failure.
```
BOARD=samr21-xpro make -C tests/posix_semaphore/ flash test
...
2019-03-20 15:20:05,885 - INFO # ######################### TEST4:
2019-03-20 15:20:05,887 - INFO # first: sem_init s1
2019-03-20 15:20:05,889 - INFO # first: wait 1 sec for s1
2019-03-20 15:20:06,893 - INFO # first: timed out
2019-03-20 15:20:06,897 - INFO # first: waited only 999995 usec => FAILED
2019-03-20 15:20:06,900 - INFO # ######################### DONE

Timeout in expect script at "term.expect(r"first: waited 1\d{6} usec")" (tests/posix_semaphore/tests/01-run.py:89)
```

### Issues/PRs references

Found while reviewing https://github.com/RIOT-OS/RIOT/pull/11165