### PR TITLE
 sys/test_helper: Add test_helper module

### DIFF
--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -5,3 +5,10 @@ endif
 ifneq (,$(filter prng_fortuna,$(USEMODULE)))
   CFLAGS += -DCRYPTO_AES
 endif
+
+ifneq (,$(filter test_helper,$(USEMODULE)))
+  USEMODULE += app_metadata
+  USEMODULE += shell
+  USEMODULE += shell_commands
+  USEMODULE += fmt
+endif

--- a/sys/include/test_helper.h
+++ b/sys/include/test_helper.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2019 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    sys_test_helper TEST_HELPER
+ * @ingroup     sys
+ * @brief       Helpers that can be used to write tests
+ * @{
+ *
+ * @file        test_helper.h
+ * @brief       A collection of useful helpers when writing tests
+ *
+ * @author      Kevin Weiss <kevin.weiss@haw-hamburg.de>
+ */
+
+#ifndef TEST_HELPER_H
+#define TEST_HELPER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   A printf wrapper that creates a JSON formatted name and printf
+ *          value
+ *
+ * Prints a string name then the standard printf arguments.  For example the
+ * name may be "function" and the printf arguments may be ("function_call(%d)",
+ * 42), the result will print {"function":"function_call(42)"}\n.
+ * @note    Only use if needed, other functions don't use printf and could save
+            bytes.
+ */
+#define JSON_PRINTF_WRAPPER(name, ...) \
+do { \
+    printf("{\"%s\":\"", name); \
+    printf(__VA_ARGS__); \
+    printf("\"}\n"); \
+} while (0)
+
+/**
+ * @brief   Prints an echo from the shell command
+ *
+ * @param[in] argc  number of arguments
+ * @param[in] argv  array of arguments
+ */
+void print_echo(int argc, char **argv);
+
+/**
+ * @brief   Prints byte array value and name key in json formatting
+ *
+ * For example name="data" and a byte array of 1, 2, 3 were passed in then
+ * {"name":[1,2,3]} would print
+ *
+ * @param[in] name  string of the key of the json element
+ * @param[in] bytes byte array to be printed
+ * @param[in] size  size of the byte array
+ */
+void print_json_byte_array(const char* name, uint8_t* bytes, size_t size);
+
+/**
+ * @brief   Prints an int value and name key in json formatting
+ *
+ * For example name="data" and a integer of 42 were passed in then {"name":42}
+ * would print
+ *
+ * @param[in] name  string of the key of the json element
+ * @param[in] val   integer value to print
+ */
+void print_json_i32_dec(const char* name, int32_t val);
+
+/**
+ * @brief   Prints an string value and name key in json formatting
+ *
+ * For example of name="answer_of_life" and a string value of "forty_two"
+ * passed in then {"answer_of_life":"forty_two"} would print
+ *
+ * @param[in] name  string of the key of the json element
+ * @param[in] val   integer value to print
+ */
+void print_json_str(const char* name, const char* val);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TEST_HELPER_H */
+/** @} */

--- a/sys/shell/commands/Makefile
+++ b/sys/shell/commands/Makefile
@@ -76,5 +76,8 @@ endif
 ifneq (,$(filter periph_rtc,$(USEMODULE)))
   SRC += sc_rtc.c
 endif
+ifneq (,$(filter test_helper,$(USEMODULE)))
+  SRC += sc_print_echo.c
+endif
 
 include $(RIOTBASE)/Makefile.base

--- a/sys/shell/commands/sc_print_echo.c
+++ b/sys/shell/commands/sc_print_echo.c
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2019 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys_shell_commands
+ * @{
+ *
+ * @file
+ * @brief       Shell command to print echo.
+
+ *
+ * @author      Kevin Weiss <kevin.weiss@haw-hamburg.de>
+ * @}
+ */
+#include <stdint.h>
+#include <string.h>
+#include "test_helper.h"
+
+int _print_echo_handler(int argc, char **argv)
+{
+    print_echo(argc, argv);
+    return 0;
+}

--- a/sys/shell/commands/shell_commands.c
+++ b/sys/shell/commands/shell_commands.c
@@ -145,6 +145,10 @@ extern int _cord_ep_handler(int argc, char **argv);
 extern int _app_metadata_handler(int argc, char **argv);
 #endif
 
+#ifdef MODULE_TEST_HELPER
+extern int _print_echo_handler(int argc, char **argv);
+#endif
+
 const shell_command_t _shell_command_list[] = {
     {"reboot", "Reboot the node", _reboot_handler},
 #ifdef MODULE_CONFIG
@@ -237,6 +241,9 @@ const shell_command_t _shell_command_list[] = {
 #endif
 #ifdef MODULE_APP_METADATA
     {"app_metadata", "Returns application metadata", _app_metadata_handler },
+#endif
+#ifdef MODULE_TEST_HELPER
+    {"print_echo", "Echos input data", _print_echo_handler },
 #endif
     {NULL, NULL, NULL}
 };

--- a/sys/test_helper/Makefile
+++ b/sys/test_helper/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/test_helper/test_helper.c
+++ b/sys/test_helper/test_helper.c
@@ -1,0 +1,68 @@
+/**
+ * Print thread information.
+ *
+ * Copyright (C) 2019 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ * @ingroup sys_test_helper
+ * @{
+ * @file    test_helper.c
+ * @brief   Helpers that can be used to write tests
+ * @author  Kevin Weiss <kevin.weiss@haw-hamburg.de>
+ * @}
+ */
+
+#include <stdint.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "test_helper.h"
+#include "fmt.h"
+
+void print_echo(int argc, char **argv)
+{
+    for (int i = 1; i < argc; i++) {
+        print_str(argv[i]);
+        print_str(" ");
+    }
+    print_str("\n");
+}
+
+void print_json_str(const char* name, const char* val)
+{
+    print("{\"", sizeof("{\""));
+    print(name, fmt_strlen(name));
+    print("\":\"", sizeof("\":\""));
+    print(val, fmt_strlen(val));
+    print("\"}\n", sizeof("\"}\n"));
+}
+
+void print_json_i32_dec(const char* name, int32_t val)
+{
+    print("{\"", sizeof("{\""));
+    print(name, fmt_strlen(name));
+    print("\":", sizeof("\":"));
+    print_s32_dec(val);
+    print("}\n", sizeof("}\n"));
+}
+
+
+
+void print_json_byte_array(const char* name, uint8_t *bytes, size_t size)
+{
+    print("{\"", sizeof("{\""));
+    print(name, fmt_strlen(name));
+    print("\":[", sizeof("\"["));
+    while (size) {
+        print_u32_dec(*(bytes));
+        bytes++;
+        if (size != 1) {
+            print(",", sizeof(","));
+        }
+        size--;
+    }
+    print("]}\n", sizeof("]}\n"));
+}

--- a/tests/shell/Makefile
+++ b/tests/shell/Makefile
@@ -1,10 +1,8 @@
 DEVELHELP=0
 include ../Makefile.tests_common
 
-USEMODULE += app_metadata
-USEMODULE += shell
-USEMODULE += shell_commands
 USEMODULE += ps
+USEMODULE += test_helper
 
 DISABLE_MODULE += auto_init
 

--- a/tests/shell/main.c
+++ b/tests/shell/main.c
@@ -20,9 +20,11 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <stdint.h>
 
 #include "shell_commands.h"
 #include "shell.h"
+#include "test_helper.h"
 
 static int print_teststart(int argc, char **argv)
 {
@@ -42,28 +44,15 @@ static int print_testend(int argc, char **argv)
     return 0;
 }
 
-static int print_echo(int argc, char **argv)
-{
-    for (int i = 0; i < argc; ++i) {
-        printf("\"%s\"", argv[i]);
-    }
-    puts("");
-
-    return 0;
-}
-
 static const shell_command_t shell_commands[] = {
     { "start_test", "starts a test", print_teststart },
     { "end_test", "ends a test", print_testend },
-    { "echo", "prints the input command", print_echo },
     { NULL, NULL, NULL }
 };
 
 int main(void)
 {
-
     printf("test_shell.\n");
-
 
     /* define buffer to be used by the shell */
     char line_buf[SHELL_DEFAULT_BUFSIZE];

--- a/tests/shell/tests/01-run.py
+++ b/tests/shell/tests/01-run.py
@@ -15,10 +15,10 @@ EXPECTED_HELP = (
     '---------------------------------------',
     'start_test           starts a test',
     'end_test             ends a test',
-    'echo                 prints the input command',
     'reboot               Reboot the node',
     'ps                   Prints information about running threads.',
-    'app_metadata         Returns application metadata'
+    'app_metadata         Returns application metadata',
+    'print_echo           Echos input data'
 )
 
 EXPECTED_PS = (
@@ -36,7 +36,7 @@ CMDS = {
          '123456789012345678901234567890123456789012345678901234567890'),
     'unknown_command': ('shell: command not found: unknown_command'),
     'help': EXPECTED_HELP,
-    'echo a string': ('\"echo\"\"a\"\"string\"'),
+    'print_echo a string': ('a string'),
     'ps': EXPECTED_PS,
     'reboot': ('test_shell.')
 }


### PR DESCRIPTION
### Contribution description

This PR adds a test_helper module adds a collection of helpers used for shell based tests.  Specifically it adds basic, lightweight json formatting, print_echo and collects module dependencies.  This should make it easier to stick to a standard way of writing and reduce code duplication.

### Testing procedure

`make all -C tests/shell/ test`
