### PR TITLE
cpu/msp430fxyz: Add missing #include

### DIFF
--- a/cpu/msp430fxyz/include/periph_cpu.h
+++ b/cpu/msp430fxyz/include/periph_cpu.h
@@ -21,6 +21,7 @@
 #ifndef PERIPH_CPU_H
 #define PERIPH_CPU_H
 
+#include <stdbool.h>
 #include "cpu.h"
 #include "msp430_regs.h"
 


### PR DESCRIPTION
### Contribution description
`cpu/msp430fxyz/include/periph_cpu.h` is using `bool` in the function `void gpio_periph_mode(gpio_t pin, bool enable)`, but does not `#include` the corresponding header. This PR adds the missing `#include`

### Testing procedure
Murdock will do that for you :-)

### Issues/PRs references
Spun out of https://github.com/RIOT-OS/RIOT/pull/11226