### PR TITLE
cpu/msp430_common: Cleanup

### DIFF
--- a/cpu/msp430_common/cpu.c
+++ b/cpu/msp430_common/cpu.c
@@ -55,7 +55,6 @@ void *thread_isr_stack_start(void)
 
 NORETURN void cpu_switch_context_exit(void)
 {
-    sched_active_thread = sched_threads[0];
     sched_run();
 
     __restore_context();


### PR DESCRIPTION
### Contribution description
`void cpu_switch_context_exit(void)` assigns `sched_active_thread` just before calling `sched_run()`. This is unneeded, as `sched_run()` will updated that anyway. Also generally speaking, changing internal scheduler data from outside the scheduler is a risky thing to do.

### Testing procedure
Flash and run `tests/thread_basic` on a MSP430 based board.

### Issues/PRs references
Spun out of https://github.com/RIOT-OS/RIOT/pull/11226