### PR TITLE
sys/xtimer: Remove dependency to core_msg

### DIFF
--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -29,10 +29,14 @@
 #ifndef XTIMER_H
 #define XTIMER_H
 
+#include <stdbool.h>
 #include <stdint.h>
 #include "timex.h"
+#ifdef MODULE_CORE_MSG
 #include "msg.h"
+#endif /* MODULE_CORE_MSG */
 #include "mutex.h"
+#include "kernel_types.h"
 
 #include "board.h"
 #include "periph_conf.h"
@@ -208,42 +212,6 @@ static inline void xtimer_spin(xtimer_ticks32_t ticks);
 static inline void xtimer_periodic_wakeup(xtimer_ticks32_t *last_wakeup, uint32_t period);
 
 /**
- * @brief Set a timer that sends a message
- *
- * This function sets a timer that will send a message @p offset ticks
- * from now.
- *
- * The message struct specified by msg parameter will not be copied, e.g., it
- * needs to point to valid memory until the message has been delivered.
- *
- * @param[in] timer         timer struct to work with.
- *                          Its xtimer_t::target and xtimer_t::long_target
- *                          fields need to be initialized with 0 on first use.
- * @param[in] offset        microseconds from now
- * @param[in] msg           ptr to msg that will be sent
- * @param[in] target_pid    pid the message will be sent to
- */
-static inline void xtimer_set_msg(xtimer_t *timer, uint32_t offset, msg_t *msg, kernel_pid_t target_pid);
-
-/**
- * @brief Set a timer that sends a message, 64bit version
- *
- * This function sets a timer that will send a message @p offset microseconds
- * from now.
- *
- * The message struct specified by msg parameter will not be copied, e.g., it
- * needs to point to valid memory until the message has been delivered.
- *
- * @param[in] timer         timer struct to work with.
- *                          Its xtimer_t::target and xtimer_t::long_target
- *                          fields need to be initialized with 0 on first use.
- * @param[in] offset        microseconds from now
- * @param[in] msg           ptr to msg that will be sent
- * @param[in] target_pid    pid the message will be sent to
- */
-static inline void xtimer_set_msg64(xtimer_t *timer, uint64_t offset, msg_t *msg, kernel_pid_t target_pid);
-
-/**
  * @brief Set a timer that wakes up a thread
  *
  * This function sets a timer that will wake up a thread when the timer has
@@ -320,28 +288,6 @@ static inline void xtimer_set64(xtimer_t *timer, uint64_t offset_us);
  * @param[in] timer ptr to timer structure that will be removed
  */
 void xtimer_remove(xtimer_t *timer);
-
-/**
- * @brief receive a message blocking but with timeout
- *
- * @param[out] msg      pointer to a msg_t which will be filled in case of
- *                      no timeout
- * @param[in]  timeout  timeout in microseconds relative
- *
- * @return     < 0 on error, other value otherwise
- */
-static inline int xtimer_msg_receive_timeout(msg_t *msg, uint32_t timeout);
-
-/**
- * @brief receive a message blocking but with timeout, 64bit version
- *
- * @param[out] msg      pointer to a msg_t which will be filled in case of no
- *                      timeout
- * @param[in]  timeout  timeout in microseconds relative
- *
- * @return     < 0 on error, other value otherwise
- */
-static inline int xtimer_msg_receive_timeout64(msg_t *msg, uint64_t timeout);
 
 /**
  * @brief Convert microseconds to xtimer ticks
@@ -468,6 +414,66 @@ int xtimer_mutex_lock_timeout(mutex_t *mutex, uint64_t us);
  * @param[in]   timeout timeout in usec
  */
 void xtimer_set_timeout_flag(xtimer_t *t, uint32_t timeout);
+
+#ifdef MODULE_CORE_MSG
+/**
+ * @brief Set a timer that sends a message
+ *
+ * This function sets a timer that will send a message @p offset ticks
+ * from now.
+ *
+ * The message struct specified by msg parameter will not be copied, e.g., it
+ * needs to point to valid memory until the message has been delivered.
+ *
+ * @param[in] timer         timer struct to work with.
+ *                          Its xtimer_t::target and xtimer_t::long_target
+ *                          fields need to be initialized with 0 on first use.
+ * @param[in] offset        microseconds from now
+ * @param[in] msg           ptr to msg that will be sent
+ * @param[in] target_pid    pid the message will be sent to
+ */
+static inline void xtimer_set_msg(xtimer_t *timer, uint32_t offset, msg_t *msg, kernel_pid_t target_pid);
+
+/**
+ * @brief Set a timer that sends a message, 64bit version
+ *
+ * This function sets a timer that will send a message @p offset microseconds
+ * from now.
+ *
+ * The message struct specified by msg parameter will not be copied, e.g., it
+ * needs to point to valid memory until the message has been delivered.
+ *
+ * @param[in] timer         timer struct to work with.
+ *                          Its xtimer_t::target and xtimer_t::long_target
+ *                          fields need to be initialized with 0 on first use.
+ * @param[in] offset        microseconds from now
+ * @param[in] msg           ptr to msg that will be sent
+ * @param[in] target_pid    pid the message will be sent to
+ */
+static inline void xtimer_set_msg64(xtimer_t *timer, uint64_t offset, msg_t *msg, kernel_pid_t target_pid);
+
+/**
+ * @brief receive a message blocking but with timeout
+ *
+ * @param[out] msg      pointer to a msg_t which will be filled in case of
+ *                      no timeout
+ * @param[in]  timeout  timeout in microseconds relative
+ *
+ * @return     < 0 on error, other value otherwise
+ */
+static inline int xtimer_msg_receive_timeout(msg_t *msg, uint32_t timeout);
+
+/**
+ * @brief receive a message blocking but with timeout, 64bit version
+ *
+ * @param[out] msg      pointer to a msg_t which will be filled in case of no
+ *                      timeout
+ * @param[in]  timeout  timeout in microseconds relative
+ *
+ * @return     < 0 on error, other value otherwise
+ */
+static inline int xtimer_msg_receive_timeout64(msg_t *msg, uint64_t timeout);
+#endif
 
 /**
  * @brief xtimer backoff value

--- a/sys/include/xtimer/implementation.h
+++ b/sys/include/xtimer/implementation.h
@@ -84,12 +84,14 @@ int _xtimer_set_absolute(xtimer_t *timer, uint32_t target);
 void _xtimer_set(xtimer_t *timer, uint32_t offset);
 void _xtimer_set64(xtimer_t *timer, uint32_t offset, uint32_t long_offset);
 void _xtimer_periodic_wakeup(uint32_t *last_wakeup, uint32_t period);
-void _xtimer_set_msg(xtimer_t *timer, uint32_t offset, msg_t *msg, kernel_pid_t target_pid);
-void _xtimer_set_msg64(xtimer_t *timer, uint64_t offset, msg_t *msg, kernel_pid_t target_pid);
 void _xtimer_set_wakeup(xtimer_t *timer, uint32_t offset, kernel_pid_t pid);
 void _xtimer_set_wakeup64(xtimer_t *timer, uint64_t offset, kernel_pid_t pid);
+#ifdef MODULE_CORE_MSG
 int _xtimer_msg_receive_timeout(msg_t *msg, uint32_t ticks);
 int _xtimer_msg_receive_timeout64(msg_t *msg, uint64_t ticks);
+void _xtimer_set_msg(xtimer_t *timer, uint32_t offset, msg_t *msg, kernel_pid_t target_pid);
+void _xtimer_set_msg64(xtimer_t *timer, uint64_t offset, msg_t *msg, kernel_pid_t target_pid);
+#endif /* MODULE_CORE_MSG */
 
 /**
  * @brief  Sleep for the given number of ticks
@@ -210,16 +212,6 @@ static inline void xtimer_periodic_wakeup(xtimer_ticks32_t *last_wakeup, uint32_
     _xtimer_periodic_wakeup(&last_wakeup->ticks32, _xtimer_ticks_from_usec(period));
 }
 
-static inline void xtimer_set_msg(xtimer_t *timer, uint32_t offset, msg_t *msg, kernel_pid_t target_pid)
-{
-    _xtimer_set_msg(timer, _xtimer_ticks_from_usec(offset), msg, target_pid);
-}
-
-static inline void xtimer_set_msg64(xtimer_t *timer, uint64_t offset, msg_t *msg, kernel_pid_t target_pid)
-{
-    _xtimer_set_msg64(timer, _xtimer_ticks_from_usec64(offset), msg, target_pid);
-}
-
 static inline void xtimer_set_wakeup(xtimer_t *timer, uint32_t offset, kernel_pid_t pid)
 {
     _xtimer_set_wakeup(timer, _xtimer_ticks_from_usec(offset), pid);
@@ -241,6 +233,7 @@ static inline void xtimer_set64(xtimer_t *timer, uint64_t period_us)
     _xtimer_set64(timer, ticks, ticks >> 32);
 }
 
+#ifdef MODULE_CORE_MSG
 static inline int xtimer_msg_receive_timeout(msg_t *msg, uint32_t timeout)
 {
     return _xtimer_msg_receive_timeout(msg, _xtimer_ticks_from_usec(timeout));
@@ -250,6 +243,17 @@ static inline int xtimer_msg_receive_timeout64(msg_t *msg, uint64_t timeout)
 {
     return _xtimer_msg_receive_timeout64(msg, _xtimer_ticks_from_usec64(timeout));
 }
+
+static inline void xtimer_set_msg(xtimer_t *timer, uint32_t offset, msg_t *msg, kernel_pid_t target_pid)
+{
+    _xtimer_set_msg(timer, _xtimer_ticks_from_usec(offset), msg, target_pid);
+}
+
+static inline void xtimer_set_msg64(xtimer_t *timer, uint64_t offset, msg_t *msg, kernel_pid_t target_pid)
+{
+    _xtimer_set_msg64(timer, _xtimer_ticks_from_usec64(offset), msg, target_pid);
+}
+#endif /* MODULE_CORE_MSG */
 
 static inline xtimer_ticks32_t xtimer_ticks_from_usec(uint32_t usec)
 {

--- a/tests/xtimer_hang/Makefile
+++ b/tests/xtimer_hang/Makefile
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo arduino-nano \
                              arduino-uno nucleo-f031k6
 
 USEMODULE += xtimer
+DISABLE_MODULE := core_msg
 
 # Port and pin configuration for probing with oscilloscope
 # Define Test pin for hardware timer interrupt, hardware dependent


### PR DESCRIPTION
### Contribution description
When module `core_msg` is not used, `xtimer` now no longer provides the features related to messages. This allows using `xtimer` without `core_msg`.

### Testing procedure
The tests `test/xtimer*` should still work

### Issues/PRs references
Spun out of https://github.com/RIOT-OS/RIOT/pull/11226