### PR TITLE
cpu/esp32: add the new API function uart_mode to periph/uart

### DIFF
--- a/boards/common/esp32/Makefile.features
+++ b/boards/common/esp32/Makefile.features
@@ -5,6 +5,7 @@ include $(RIOTCPU)/esp32/Makefile.features
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_gpio_irq
 FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_uart_modecfg
 
 # other features provided by all boards
 FEATURES_PROVIDED += esp_spiffs

--- a/cpu/esp32/periph/uart.c
+++ b/cpu/esp32/periph/uart.c
@@ -69,20 +69,26 @@ static struct uart_hw_t _uarts[] = {
         .regs = &UART0,
         .pin_txd = GPIO1,
         .pin_rxd = GPIO3,
+        .used = false,
+        .baudrate = STDIO_UART_BAUDRATE,
+        .data = UART_DATA_BITS_8,
+        .stop = UART_STOP_BITS_1,
+        .parity = UART_PARITY_NONE,
         .signal_txd = U0TXD_OUT_IDX,
         .signal_rxd = U0RXD_IN_IDX,
-        .baudrate = STDIO_UART_BAUDRATE,
-        .used = false,
         .int_src = ETS_UART0_INTR_SOURCE
     },
     #if defined(UART1_TXD) && defined(UART1_RXD)
     {   .regs = &UART1,
         .pin_txd = UART1_TXD,
         .pin_rxd = UART1_RXD,
+        .used = false,
+        .baudrate = STDIO_UART_BAUDRATE,
+        .data = UART_DATA_BITS_8,
+        .stop = UART_STOP_BITS_1,
+        .parity = UART_PARITY_NONE,
         .signal_txd = U1TXD_OUT_IDX,
         .signal_rxd = U1RXD_IN_IDX,
-        .baudrate = STDIO_UART_BAUDRATE,
-        .used = false,
         .int_src = ETS_UART1_INTR_SOURCE
     },
     #endif
@@ -90,10 +96,13 @@ static struct uart_hw_t _uarts[] = {
     {   .regs = &UART2,
         .pin_txd = UART2_TXD,
         .pin_rxd = UART2_RXD,
+        .used = false,
+        .baudrate = STDIO_UART_BAUDRATE,
+        .data = UART_DATA_BITS_8,
+        .stop = UART_STOP_BITS_1,
+        .parity = UART_PARITY_NONE,
         .signal_txd = U2TXD_OUT_IDX,
         .signal_rxd = U2RXD_IN_IDX,
-        .baudrate = STDIO_UART_BAUDRATE,
-        .used = false,
         .int_src = ETS_UART2_INTR_SOURCE
     }
     #endif

--- a/cpu/esp32/periph/uart.c
+++ b/cpu/esp32/periph/uart.c
@@ -52,12 +52,15 @@ struct uart_hw_t {
     uart_dev_t* regs;       /* pointer to register data struct of the UART device */
     uint8_t  pin_txd;       /* TxD pin */
     uint8_t  pin_rxd;       /* RxD pin */
+    bool     used;          /* indicates whether UART is used */
+    uint32_t baudrate;      /* used baudrate */
+    uart_data_bits_t data;  /* used data bits */
+    uart_stop_bits_t stop;  /* used stop bits */
+    uart_parity_t  parity;  /* used parity bits */
+    uart_isr_ctx_t isr_ctx; /* callback functions */
     uint8_t  signal_txd;    /* TxD signal from the controller */
     uint8_t  signal_rxd;    /* RxD signal to the controller */
-    uint32_t baudrate;      /* used baudrate */
-    bool     used;          /* indicates whether UART is used */
     uint8_t  int_src;       /* peripheral interrupt source used by the UART device */
-    uart_isr_ctx_t isr_ctx; /* callback functions */
 };
 
 /* hardware ressources */

--- a/cpu/esp32/periph/uart.c
+++ b/cpu/esp32/periph/uart.c
@@ -168,6 +168,14 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
     return UART_OK;
 }
 
+#if MODULE_PERIPH_UART_MODECFG
+int uart_mode(uart_t uart, uart_data_bits_t data_bits, uart_parity_t parity,
+              uart_stop_bits_t stop_bits)
+{
+    return _uart_set_mode(uart, data_bits, parity, stop_bits);
+}
+#endif
+
 void uart_write(uart_t uart, const uint8_t *data, size_t len)
 {
     CHECK_PARAM (uart < UART_NUMOF);


### PR DESCRIPTION
### Contribution description

This PR adds API function `uart_mode` according to PR #10743 to `periph/uart` low level driver of ESP32 implementation. The PR depends on some in PR #11276.

### Testing procedure

1. Compile and flash `tests/periph_uart` with enabled module `periph_uart_modecfg`
```
USEMODULE=periph_uart_modecfg make BOARD=esp32-wroom-32 -C tests/periph_uart flash
```
2. Connect GPIO9 [UART_DEV(1):RX] and GPIO10 [UART_DEV(1):TX].

3. Use the following commands and observe the UART communication with a logic analyzer
```
init 1 9600
mode 1 7 o 2
send 1 hello
mode 1 6 e 2
send 1 hello
...
```
### Issues/PRs references

Depends on PR #11276 
Implementation according to #10743