### PR TITLE
pkg/nimble: fix include guards in nimble_riot.c

### DIFF
--- a/pkg/nimble/contrib/nimble_riot.c
+++ b/pkg/nimble/contrib/nimble_riot.c
@@ -25,8 +25,12 @@
 #include "host/ble_hs.h"
 #include "host/util/util.h"
 
+#ifdef MODULE_NIMBLE_SVC_GAP
 #include "services/gap/ble_svc_gap.h"
+#endif
+#ifdef MODULE_NIMBLE_SVC_GATT
 #include "services/gatt/ble_svc_gatt.h"
+#endif
 
 #ifdef MODULE_NIMBLE_CONTROLLER
 #ifdef CPU_FAM_NRF52


### PR DESCRIPTION
### Contribution description
When building `NimBLE` without GAT and/or GAPP GATT services, the current master will complain about missing headers in `pkg/nimble/contrib/nimble_riot.c`. This is due to missing include guards -> this PR fixes this.

I have some test applications in the pipeline that will trigger the faulty behavior once merged, but for streamlining the process this simple fix should be merged first.

### Testing procedure
Build test should do. 

### Issues/PRs references
none