### PR TITLE
net/bluetil/ad: add bluetil_ad_find_and_cmp()

### DIFF
--- a/sys/include/net/bluetil/ad.h
+++ b/sys/include/net/bluetil/ad.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Freie Universität Berlin
+ * Copyright (C) 2018,2019 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -96,6 +96,20 @@ void bluetil_ad_init(bluetil_ad_t *ad, void *buf, size_t pos, size_t size);
  */
 int bluetil_ad_find(const bluetil_ad_t *ad,
                     uint8_t type, bluetil_ad_data_t *data);
+
+/**
+ * @brief   Find a specific field and compare its value against the given data
+ *
+ * @param[in] ad        advertising data descriptor
+ * @param[in] type      field to search for
+ * @param[in] val       data to compare against
+ * @param[in] val_len   size of @p val in byte
+ *
+ * @return  true if the field was found and its data is equal to the given data
+ * @return  false if the field was not found or the data is not equal
+ */
+int bluetil_ad_find_and_cmp(const bluetil_ad_t *ad, uint8_t type,
+                            const void *val, size_t val_len);
 
 /**
  * @brief   Find the given field and copy its payload into a string

--- a/sys/net/ble/bluetil/bluetil_ad/bluetil_ad.c
+++ b/sys/net/ble/bluetil/bluetil_ad/bluetil_ad.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Freie Universität Berlin
+ * Copyright (C) 2018,2019 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -57,6 +57,17 @@ int bluetil_ad_find(const bluetil_ad_t *ad, uint8_t type,
     }
 
     return BLUETIL_AD_NOTFOUND;
+}
+
+int bluetil_ad_find_and_cmp(const bluetil_ad_t *ad, uint8_t type,
+                            const void *val, size_t val_len)
+{
+    bluetil_ad_data_t field;
+
+    if (bluetil_ad_find(ad, type, &field) == BLUETIL_AD_OK) {
+        return ((field.len == val_len) && memcmp(val, field.data, val_len) == 0);
+    }
+    return 0;
 }
 
 int bluetil_ad_find_str(const bluetil_ad_t *ad, uint8_t type,


### PR DESCRIPTION
### Contribution description
This PR adds a convenience function to the `bluetil/ad` submodule, that can be used to quickly find and compare the value of a selected AD field against some user given data. For example, one can use this function to easily find out, if a node advertises itself with a certain name.

### Testing procedure
I follow up PR will use this code and can therefore be used as validator for this PR. See below for the reference... So as this is more or less an experimental feature, a thourough code review should to the trick :-)

At some point unittests for the `bluetil` module could also be a good idea, but I simply don't have the time to write them currently.

### Issues/PRs references
none so far (but watch for referenced PRs below)