### PR TITLE
core/sched: Fixed typo

### DIFF
--- a/core/sched.c
+++ b/core/sched.c
@@ -170,7 +170,7 @@ void sched_set_status(thread_t *process, thread_state_t status)
     }
     else {
         if (process->status >= STATUS_ON_RUNQUEUE) {
-            DEBUG("sched_set_status: removing thread %" PRIkernel_pid " to runqueue %" PRIu8 ".\n",
+            DEBUG("sched_set_status: removing thread %" PRIkernel_pid " from runqueue %" PRIu8 ".\n",
                   process->pid, process->priority);
             clist_lpop(&sched_runqueues[process->priority]);
 


### PR DESCRIPTION
### Contribution description
Fixes a typo in the sched's debug message

### Testing procedure
Run `test/thread_basic` with `ENABLE_DEBUG` in `core/sched.c` set to `1`. There should be a typo in master, but no longer in this PR.


### Issues/PRs references
Noticed while testing https://github.com/RIOT-OS/RIOT/pull/11229