### PR TITLE
sys/net/gnrc/pktbuf: remove not needed "cpu_conf.h" include

### DIFF
--- a/sys/include/net/gnrc/pktbuf.h
+++ b/sys/include/net/gnrc/pktbuf.h
@@ -34,7 +34,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "cpu_conf.h"
 #include "net/gnrc/pkt.h"
 #include "net/gnrc/neterr.h"
 #include "net/gnrc/nettype.h"


### PR DESCRIPTION
### Contribution description

Stumbled upon this while cleaning dependencies.

### Testing procedure

I guess CI run should be fine.

### Issues/PRs references

none