### PR TITLE
shell: Add command i2c_scan

### DIFF
--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -35,6 +35,7 @@ PSEUDOMODULES += gnrc_sixlowpan_router
 PSEUDOMODULES += gnrc_sixlowpan_router_default
 PSEUDOMODULES += gnrc_sock_check_reuse
 PSEUDOMODULES += gnrc_txtsnd
+PSEUDOMODULES += i2c_scan
 PSEUDOMODULES += l2filter_blacklist
 PSEUDOMODULES += l2filter_whitelist
 PSEUDOMODULES += lis2dh12_spi

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -2,6 +2,10 @@ ifneq (,$(filter eepreg,$(USEMODULE)))
   FEATURES_REQUIRED += periph_eeprom
 endif
 
+ifneq (,$(filter i2c_scan,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_i2c
+endif
+
 ifneq (,$(filter prng_fortuna,$(USEMODULE)))
   CFLAGS += -DCRYPTO_AES
 endif

--- a/sys/shell/commands/Makefile
+++ b/sys/shell/commands/Makefile
@@ -77,4 +77,8 @@ ifneq (,$(filter periph_rtc,$(USEMODULE)))
   SRC += sc_rtc.c
 endif
 
+ifneq (,$(filter i2c_scan,$(USEMODULE)))
+  SRC += sc_i2c_scan.c
+endif
+
 include $(RIOTBASE)/Makefile.base

--- a/sys/shell/commands/sc_i2c_scan.c
+++ b/sys/shell/commands/sc_i2c_scan.c
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2019 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys_shell_commands
+ * @{
+ *
+ * @file
+ * @brief       An I2C bus scanner
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ *
+ * @}
+ */
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "board.h"
+#include "periph/i2c.h"
+
+static int get_dev(i2c_t *dev, int argc, char **argv)
+{
+    if (argc == 2) {
+        int idx = atoi(argv[1]);
+        if ((idx < 0) || (idx >= (int)I2C_NUMOF)) {
+            printf("I2C device with number \"%s\" not found\n", argv[1]);
+        }
+        else {
+            *dev = I2C_DEV(idx);
+            return 0;
+        }
+    }
+    printf("Usage: %s [DEVICE_NUMBER]\n", argv[0]);
+    return -1;
+}
+
+
+int _i2c_scan(int argc, char **argv)
+{
+    i2c_t dev;
+    if (get_dev(&dev, argc, argv)) {
+        return -1;
+    }
+
+    printf("Scanning I2C device %s...\n", argv[1]);
+    if (i2c_acquire(dev)){
+        puts("Failed to acquire I2C device");
+        return -1;
+    }
+
+    puts(
+        "Legend: no device = \"-\", device responded = \"X\", error = \"E\"\n"
+        "     0 1 2 3 4 5 6 7 8 9 a b c d e f"
+    );
+
+    for (char i = 0; i < 8; i++) {
+        char row[] = { '0', 'x', '0' + i, '0', '\0' };
+        fputs(row, stdout);
+        uint16_t addr = i;
+        addr <<= 4;
+        for (unsigned j = 0; j < 16; j++) {
+            char str[] = { ' ', '-', '\0' };
+            char dummy[1];
+            int retval;
+            while (-EAGAIN == (retval = i2c_read_byte(dev, addr, dummy, 0))) {
+                /* retry until bus arbitration succeeds */
+            }
+
+            switch (retval) {
+                case 0:
+                    /* success: Device did respond */
+                    str[1] = 'X';
+                    break;
+                case -ENXIO:
+                    /* No ACK --> no device */
+                    break;
+                default:
+                    /* Some unexpected error */
+                    str[1] = 'E';
+                    break;
+            }
+
+            fputs(str, stdout);
+            addr++;
+        }
+        puts("");
+    }
+
+    i2c_release(dev);
+    return 0;
+}

--- a/sys/shell/commands/shell_commands.c
+++ b/sys/shell/commands/shell_commands.c
@@ -145,6 +145,10 @@ extern int _cord_ep_handler(int argc, char **argv);
 extern int _app_metadata_handler(int argc, char **argv);
 #endif
 
+#ifdef MODULE_I2C_SCAN
+extern int _i2c_scan(int argc, char **argv);
+#endif
+
 const shell_command_t _shell_command_list[] = {
     {"reboot", "Reboot the node", _reboot_handler},
 #ifdef MODULE_CONFIG
@@ -237,6 +241,9 @@ const shell_command_t _shell_command_list[] = {
 #endif
 #ifdef MODULE_APP_METADATA
     {"app_metadata", "Returns application metadata", _app_metadata_handler },
+#endif
+#ifdef MODULE_I2C_SCAN
+    { "i2c_scan", "Performs an I2C bus scan", _i2c_scan },
 #endif
     {NULL, NULL, NULL}
 };


### PR DESCRIPTION
### Contribution description
Adds a trivial shell program that scans for all slaves on an I2C bus by iterating all of the possible 127 I2C addresses and checking for the ACK of the device.

Example output with 2 I2C slaves add addresses `0x44`, `0x50`, and `0x76`:

```
> i2c_scan 0
Scanning I2C device 0...
Legend: no device = "-", device responded = "X", error = "E"
     0 1 2 3 4 5 6 7 8 9 a b c d e f
0x00 - - - - - - - - - - - - - - - -
0x10 - - - - - - - - - - - - - - - -
0x20 - - - - - - - - - - - - - - - -
0x30 - - - - - - - - - - - - - - - -
0x40 - - - - X - - - - - - - - - - -
0x50 X - - - - - - - - - - - - - - -
0x60 - - - - - - - - - - - - - - - -
0x70 - - - - - - X - - - - - - - - -
```


### Testing procedure
Grab a board with I2C support, connect one or more I2C devices to it and run `USEMODULE=i2c_scan make flash` for the application `examples/default`. Run `i2c_scan 0` (or `i2c_scan 1` etc.)

### Issues/PRs references
None