### PR TITLE
pkg/semtech-loramac: provide a way to disable dutycycle

### DIFF
--- a/pkg/semtech-loramac/contrib/semtech_loramac.c
+++ b/pkg/semtech-loramac/contrib/semtech_loramac.c
@@ -40,6 +40,7 @@
 
 #include "semtech_loramac.h"
 #include "LoRaMac.h"
+#include "LoRaMacTest.h"
 #include "region/Region.h"
 
 #ifdef MODULE_PERIPH_EEPROM
@@ -427,6 +428,9 @@ void _init_loramac(semtech_loramac_t *mac,
     primitives->MacMlmeIndication = mlme_indication;
     LoRaMacInitialization(&semtech_loramac_radio_events, primitives, callbacks,
                           LORAMAC_ACTIVE_REGION);
+#ifdef DISABLE_LORAMAC_DUTYCYCLE
+    LoRaMacTestSetDutyCycleOn(false);
+#endif
     mutex_unlock(&mac->lock);
 
     semtech_loramac_set_dr(mac, LORAMAC_DEFAULT_DR);

--- a/tests/pkg_semtech-loramac/README.md
+++ b/tests/pkg_semtech-loramac/README.md
@@ -66,6 +66,11 @@ for US915 region.
 
 The default region is `EU868`.
 
+**For testing purpose**, it is possible to disable the duty-cycle restriction
+implemented in the MAC layer with the `DISABLE_LORAMAC_DUTYCYCLE` macro:
+
+      CFLAGS=-DDISABLE_LORAMAC_DUTYCYCLE LORA_REGION=US915 LORA_DRIVER=sx1272 make ...
+
 ## Using the shell
 
 This application provides the `loramac` command for configuring the MAC,


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR provides an hidden way to disable the loramac duty-cycle restriction.
See problems with OTAA and STOP mode explained in #11237 for details.

I want this change to remain hidden (not in the public API) because this is only for testing purpose normally, as explained in loramac-node code. But maybe it's worth to document it somewhere ? suggestions are welcome.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Build and flash `tests/pkg_semtech-loramac` with CFLAGS=-DDISABLE_LORAMAC_DUTYCYCLE
- Join a lorawan network using a low datarate (let's say 0)
- Verify that messages can be sent without having to wait for the duty-cycle to complete

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

This PR provides a fix for OTAA + STOP deep-sleep mode that was raised in #11237 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
