### PR TITLE
sys/riotboot: doxygen fix in slot.h

### DIFF
--- a/sys/include/riotboot/slot.h
+++ b/sys/include/riotboot/slot.h
@@ -8,8 +8,7 @@
  */
 
 /**
- * @defgroup    sys_riotboot_slot   Helpers to manipulate partitions (slots)
- *                              on internal flash
+ * @defgroup    sys_riotboot_slot   Helpers to manipulate partitions (slots) on internal flash
  * @ingroup     sys
  * @{
  *


### PR DESCRIPTION
### Contribution description

This PR fixes a documentation problem in `slot.h`. The `title` in `@defgroup` must not contain a line break.

In current documentation you will find an error in [Modules / System](https://riot-os.org/api/group__sys.html) page and further in [Modules / System / Helpers ...](https://riot-os.org/api/group__sys__riotboot__slot.html) for `Helpers to manipulate partitions (slots)`. This error is caused by the line break in the title of `@defgroup` statement.

### Testing procedure

`make doc` and check the result in the pages referred above.

### Issues/PRs references

Fixes issue 1 in #11243 