### PR TITLE
boards/nrf52840-mdk: add missing dependency to 802154 driver

### DIFF
--- a/boards/nrf52840-mdk/Makefile.dep
+++ b/boards/nrf52840-mdk/Makefile.dep
@@ -2,4 +2,10 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
 
+ifneq (,$(filter gnrc_netdev_default netdev_default,$(USEMODULE)))
+  ifeq (,$(filter nrfmin,$(USEMODULE)))
+    USEMODULE += nrf802154
+  endif
+endif
+
 include $(RIOTBOARD)/common/nrf52/Makefile.dep

--- a/boards/nrf52840-mdk/Makefile.features
+++ b/boards/nrf52840-mdk/Makefile.features
@@ -2,4 +2,7 @@
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_uart
 
+# Various other features (if any)
+FEATURES_PROVIDED += radio_nrf802154
+
 include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/examples/default/Makefile
+++ b/examples/default/Makefile
@@ -37,8 +37,8 @@ USEMODULE += ps
 USEMODULE += saul_default
 
 BOARD_PROVIDES_NETIF := acd52832 airfy-beacon b-l072z-lrwan1 cc2538dk fox iotlab-m3 iotlab-a8-m3 mulle \
-        microbit native nrf51dk nrf51dongle nrf52dk nrf52840dk nrf6310 openmote-cc2538 pba-d-01-kw2x \
-        remote-pa remote-reva samr21-xpro \
+        microbit native nrf51dk nrf51dongle nrf52dk nrf52840dk nrf52840-mdk nrf6310 \
+        openmote-cc2538 pba-d-01-kw2x remote-pa remote-reva samr21-xpro \
         spark-core telosb yunjia-nrf51822 z1
 
 ifneq (,$(filter $(BOARD),$(BOARD_PROVIDES_NETIF)))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is adding the missing provided features and dependency related to 802154 driver on nrf52840-mdk board.
In a second commit, it also add this board to the list of boards providing a netif.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Build and flash `examples/gnrc_networking` on the nrf52840-mdk board, then run `ifconfig`. With this PR, `ifconfig` lists an available interface with IPv6 address(es). Without this PR, the board crashes.
- Build and flash `examples/default`, then run `ifconfig`. With this PR, `ifconfig` lists an available interface. Without this PR, `ifconfig` returns nothing.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
