### PR TITLE
tests/malloc: fix of dereferencing a NULL pointer

### DIFF
--- a/tests/malloc/main.c
+++ b/tests/malloc/main.c
@@ -38,8 +38,10 @@ void fill_memory(struct node *head)
         printf("Allocated %d Bytes at 0x%p, total %d\n", CHUNK_SIZE, head->ptr, total += CHUNK_SIZE);
         memset(head->ptr, '@', CHUNK_SIZE);
         head = head->next = malloc(sizeof(struct node));
-        head->ptr =  0;
-        head->next = 0;
+        if (head) {
+            head->ptr =  0;
+            head->next = 0;
+        }
         total += sizeof(struct node);
     }
 }


### PR DESCRIPTION
### Contribution description

If the memory is exhausted during the allocation of the new `head` structure, subsequent accesses to `head` will result in dereferencing of a NULL pointer. This PR fixes the problem.

### Testing procedure

Compile and flash `tests/malloc` for any board and observe the results. The application should still work.