### PR TITLE
cpu/esp: treat undefined reference as errors

### DIFF
--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -135,6 +135,17 @@ LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ld/esp32.rom.ld
 LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ld/esp32.rom.nanofmt.ld
 LINKFLAGS += -nostdlib -Wl,-gc-sections -Wl,-static
 
+ifneq (, $(filter esp_idf_heap, $(USEMODULE)))
+    LINKFLAGS += -Wl,-wrap=malloc
+    LINKFLAGS += -Wl,-wrap=free
+    LINKFLAGS += -Wl,-wrap=calloc
+    LINKFLAGS += -Wl,-wrap=realloc
+    LINKFLAGS += -Wl,-wrap=_malloc_r
+    LINKFLAGS += -Wl,-wrap=_calloc_r
+    LINKFLAGS += -Wl,-wrap=_free_r
+    LINKFLAGS += -Wl,-wrap=_realloc_r
+endif
+
 # configure preflasher to convert .elf to .bin before flashing
 FLASH_MODE ?= dout  # FIX configuration, DO NOT CHANGE
 FLASH_FREQ  = 40m   # FIX configuration, DO NOT CHANGE

--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -29,10 +29,6 @@ endif
 # SPECIAL module dependencies
 # cannot be done in Makefile.dep since Makefile.dep is included too late
 
-ifneq (,$(findstring core_thread_flags,$(USEMODULE)))
-    USEMODULE += pthread
-endif
-
 ifneq (,$(filter esp_gdbstub,$(USEMODULE)))
     USEMODULE += esp_gdb
 endif

--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -120,19 +120,20 @@ endif
 LINKFLAGS += -L$(ESP32_SDK_DIR)/components/esp32
 LINKFLAGS += -L$(ESP32_SDK_DIR)/components/esp32/lib
 
+BASELIBS += -lhal -lg -lc -lgcc
+
 ifneq (,$(filter esp_wifi_any,$(USEMODULE)))
     BASELIBS += -lcore -lrtc -lnet80211 -lpp -lsmartconfig -lcoexist
     BASELIBS += -lwps -lwpa -lwpa2 -lespnow -lmesh -lphy -lstdc++
 endif
 
-LINKFLAGS += -lhal -lg -lc
 LINKFLAGS += -L$(RIOTCPU)/$(CPU)/ld/
 LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ld/esp32.ld
 LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ld/esp32.common.ld
 LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ld/esp32.peripherals.ld
 LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ld/esp32.rom.ld
 LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ld/esp32.rom.nanofmt.ld
-LINKFLAGS += -nostdlib -lgcc -u putchar -Wl,-gc-sections
+LINKFLAGS += -nostdlib -Wl,-gc-sections -Wl,-static
 
 # configure preflasher to convert .elf to .bin before flashing
 FLASH_MODE ?= dout  # FIX configuration, DO NOT CHANGE

--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -132,7 +132,6 @@ LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ld/esp32.peripherals.ld
 LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ld/esp32.rom.ld
 LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ld/esp32.rom.nanofmt.ld
 LINKFLAGS += -nostdlib -lgcc -u putchar -Wl,-gc-sections
-LINKFLAGS += -Wl,--warn-unresolved-symbols
 
 # configure preflasher to convert .elf to .bin before flashing
 FLASH_MODE ?= dout  # FIX configuration, DO NOT CHANGE

--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -93,6 +93,7 @@ CFLAGS  += -DLOG_TAG_IN_BRACKETS
 CFLAGS  += -Wno-unused-parameter -Wformat=0
 CFLAGS  += -mlongcalls -mtext-section-literals -fstrict-volatile-bitfields
 CFLAGS  += -fdata-sections -fzero-initialized-in-bss
+CFLAGS  += -ffunction-sections
 ASFLAGS += --longcalls --text-section-literals
 
 ifneq ($(CONFIGS),)

--- a/cpu/esp8266/Makefile.include
+++ b/cpu/esp8266/Makefile.include
@@ -131,7 +131,6 @@ endif
 
 LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ld/eagle.rom.addr.v6.ld
 LINKFLAGS += -nostdlib -lgcc -u ets_run -Wl,-gc-sections # -Wl,--print-gc-sections
-LINKFLAGS += -Wl,--warn-unresolved-symbols
 
 # configure preflasher to convert .elf to .bin before flashing
 FLASH_SIZE = -fs 8m

--- a/cpu/esp8266/Makefile.include
+++ b/cpu/esp8266/Makefile.include
@@ -78,6 +78,7 @@ CFLAGS  += -DESP_OPEN_SDK -DSCHED_PRIO_LEVELS=32
 CFLAGS  += -Wno-unused-parameter -Wformat=0
 CFLAGS  += -mlongcalls -mtext-section-literals
 CFLAGS  += -fdata-sections -fzero-initialized-in-bss
+CFLAGS  += -ffunction-sections
 ASFLAGS += --longcalls --text-section-literals
 
 ifeq (, $(filter esp_sdk_int_handling, $(USEMODULE)))


### PR DESCRIPTION
### Contribution description

For the esp cpus, treat undefined reference as errors.

It was silently ignoring compilation errors.

### Cleanup needed

This pull request should show compilation issues that are currently present and should be fixed to have this one merged.

I noticed that currently `stdio_uart` needs `isrpipe` that needs `xtimer` but without saying the dependency. This should show this issue when building everything and need to be handled in separate pull requests.


### Testing procedure

Just define an `extern void lala(void);` function in an application and call it.

The compilation works in master and ignores the issue.
With this pull request it will correctly complain about it.


### Issues/PRs references

Found while working on running tests with the `esp32` no open pull request yet.
