### PR TITLE
tests/doc: Add intial how to test doc

### DIFF
--- a/doc/doxygen/riot.doxyfile
+++ b/doc/doxygen/riot.doxyfile
@@ -765,6 +765,7 @@ INPUT                  = ../../doc.txt \
                          src/creating-modules.md \
                          src/creating-an-application.md \
                          src/getting-started.md \
+                         ../../tests/README.md \
                          src/advanced-build-system-tricks.md \
                          src/changelog.md \
                          ../../LOSTANDFOUND.md

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,22 @@
+Running and creating tests                        {#running-and-creating-tests}
+==========================
+
+There are a number of tests included in RIOT. They are located in the
+[tests folder](https://github.com/RIOT-OS/RIOT/tree/master/tests). These tests
+allow basic functionality to be verified as well as provide an example of
+usage.
+
+
+Running automated tests
+-----------------------
+
+Some tests can be performed automatically. The test automation scripts are
+defined in the `<test_application>/tests/` folder. They are written in python
+and interact through the uart with the test application code running on a
+board to do the validation. It is recommended to flash the board with the
+test just before running it because some platforms cannot be reset while
+testing.
+
+From the test application directory run:
+
+    BOARD=<board_of_your_choice> make flash test


### PR DESCRIPTION
### Contribution description

This PR adds an initial guide on how to run tests in RIOT.  Essentially explaining `make flash test` command.  Written as a README.md in the RIOT/tests/ directory.  It also adds a reference so that the README is included in the doxygen documentation.

### Testing procedure

Read in markdown preview, maybe check spelling

### Issues/PRs references
