### PR TITLE
saml1x: add riotboot support

### DIFF
--- a/boards/common/saml1x/Makefile.features
+++ b/boards/common/saml1x/Makefile.features
@@ -10,7 +10,6 @@ FEATURES_PROVIDED += periph_uart
 # Put other features on these boards (in alphabetical order)
 FEATURES_PROVIDED += riotboot
 
-
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m23
 

--- a/boards/common/saml1x/Makefile.features
+++ b/boards/common/saml1x/Makefile.features
@@ -7,6 +7,10 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
+# Put other features on these boards (in alphabetical order)
+FEATURES_PROVIDED += riotboot
+
+
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m23
 

--- a/cpu/cortexm_common/include/cpu.h
+++ b/cpu/cortexm_common/include/cpu.h
@@ -217,10 +217,11 @@ static inline void cpu_jump_to_image(uint32_t image_address)
     __asm("BX %0" :: "r" (destination_address));
 }
 
-/* The following register is only present for Cortex-M0+, -M3, -M4 and -M7 CPUs */
+/* The following register is only present for
+   Cortex-M0+, -M3, -M4, -M7 and -M23 CPUs */
 #if defined(CPU_ARCH_CORTEX_M0PLUS) || defined(CPU_ARCH_CORTEX_M3) || \
     defined(CPU_ARCH_CORTEX_M4) || defined(CPU_ARCH_CORTEX_M4F) || \
-    defined(CPU_ARCH_CORTEX_M7)
+    defined(CPU_ARCH_CORTEX_M7) || defined(CPU_ARCH_CORTEX_M23)
 static inline uint32_t cpu_get_image_baseaddr(void)
 {
     return SCB->VTOR;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds riotboot support for the SAML10-xpro and SAML11-xpro boards.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

if tests/riotboot works, we're fine ;)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

~~needs #11249 to work (additional clock initialization patch in cpu/saml1x/cpu.c )~~

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
