### PR TITLE
cpu/stm32_common: add watchdog for stm32

### DIFF
--- a/cpu/stm32_common/Makefile.features
+++ b/cpu/stm32_common/Makefile.features
@@ -2,6 +2,7 @@ FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += puf_sram
 FEATURES_PROVIDED += periph_uart_modecfg
+FEATURES_PROVIDED += periph_wdt
 
 ifneq (,$(filter $(BOARDS_WITHOUT_HWRNG),$(BOARD)))
   FEATURES_PROVIDED := $(filter-out periph_hwrng,$(FEATURES_PROVIDED))

--- a/cpu/stm32_common/include/periph_cpu_common.h
+++ b/cpu/stm32_common/include/periph_cpu_common.h
@@ -99,6 +99,23 @@ extern "C" {
 /** @} */
 
 /**
+ * @name    WDT upper and lower bound times in ms
+ * @{
+ */
+/* Actual Lower Limit is ~100us so round up */
+#define NWDT_TIME_LOWER_LIMIT          (1U)
+#define NWDT_TIME_UPPER_LIMIT          (4U * US_PER_MS * 4096U * (1 << 6U) \
+                                        / CLOCK_LSI)
+/* Once enabled wdt can't be stopped */
+#define WDT_HAS_STOP                   (0U)
+#if defined(CPU_FAM_STM32L4)
+#define WDT_HAS_INIT                   (1U)
+#else
+#define WDT_HAS_INIT                   (0U)
+#endif
+/** @} */
+
+/**
  * @brief   Available peripheral buses
  */
 typedef enum {

--- a/cpu/stm32_common/periph/Makefile
+++ b/cpu/stm32_common/periph/Makefile
@@ -15,4 +15,9 @@ ifneq (,$(filter periph_flashpage periph_eeprom,$(USEMODULE)))
   SRC += flash_common.c
 endif
 
+ifneq (,$(filter periph_wdt,$(USEMODULE)))
+  $(warning Attention! WDT is clocked by CLOCK_LSI, it needs manual measuring\
+    since values can deviate up to 50% from reference)
+endif
+
 include $(RIOTMAKE)/periph.mk

--- a/cpu/stm32_common/periph/wdt.c
+++ b/cpu/stm32_common/periph/wdt.c
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2019 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_stm32_common
+ * @ingroup     drivers_periph_wdt
+ *
+ * @brief
+ *
+ * @{
+ *
+ * @file        wdt.c
+ * @brief       Independent Watchdog timer for STM32L platforms
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ */
+
+#include <stdlib.h>
+#include <assert.h>
+
+#include "cpu.h"
+#include "timex.h"
+
+#include "periph_cpu.h"
+#include "periph/wdt.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define MAX_RELOAD                (4096U)
+#define MAX_PRESCALER             (6U)
+#define IWDG_STEP_MS              ((4U * US_PER_MS * MAX_RELOAD) / CLOCK_LSI)
+
+#define IWDG_KR_KEY_RELOAD        ((uint16_t)0xAAAA)
+#define IWDG_KR_KEY_ENABLE        ((uint16_t)0xCCCC)
+
+#define IWDG_UNLOCK               ((uint16_t)0x5555)
+#define IWDG_LOCK                 ((uint16_t)0x0000)
+
+#if ENABLE_DEBUG
+/* wdt_time (us) = LSI(us) x 4 x 2^PRE x RELOAD */
+static inline uint32_t _wdt_time(uint8_t pre, uint16_t rel)
+{
+    return (uint32_t)(((uint64_t) US_PER_SEC * 4 * (1 << pre) * rel ) / CLOCK_LSI);
+}
+#endif
+
+static inline void _iwdt_unlock(void)
+{
+    IWDG->KR = IWDG_UNLOCK;
+}
+
+static inline void _iwdt_lock(void)
+{
+    IWDG->KR = IWDG_LOCK;
+}
+
+static void _set_prescaler(uint8_t prescaler)
+{
+    assert(prescaler <= MAX_PRESCALER);
+
+    _iwdt_unlock();
+    IWDG->PR = prescaler;
+    _iwdt_lock();
+}
+
+static void _set_reload(uint16_t reload)
+{
+    assert(reload <= IWDG_RLR_RL);
+
+    _iwdt_unlock();
+    IWDG->RLR = reload;
+    _iwdt_lock();
+}
+
+static uint8_t _find_prescaler(uint32_t rst_time)
+{
+    /* Divide by the range to get power of 2 of the prescaler */
+    uint8_t pre = 32U - __builtin_clz(rst_time / IWDG_STEP_MS);
+    DEBUG("[wdt]: prescaler value %d\n", pre);
+    return pre;
+}
+
+static uint16_t _find_reload_value(uint8_t pre, uint32_t rst_time)
+{
+    /* Calculate best reload value = rst_time / LSI(ms) x 4 x 2^PRE */
+    uint16_t rel = (uint16_t)((rst_time * CLOCK_LSI) / \
+                             ((uint32_t) (US_PER_MS * 4 * (1 << pre))));
+    DEBUG("[wdt]: reload value %d\n", rel);
+    return rel;
+}
+
+void wdt_start(void)
+{
+    IWDG->KR = IWDG_KR_KEY_ENABLE;
+}
+
+#ifdef CPU_FAM_STM32L4
+void wdt_init(void)
+{
+    FLASH->OPTR |= ~(FLASH_OPTR_IWDG_STOP || FLASH_OPTR_IWDG_STDBY);
+}
+#endif
+
+void wdt_kick(void)
+{
+    IWDG->KR = IWDG_KR_KEY_RELOAD;
+}
+
+void wdt_setup_reboot(uint32_t min_time, uint32_t max_time)
+{
+    (void) min_time;
+    /* Windowed wdt not supported */
+    assert(min_time == 0);
+
+    /* Check reset time limit */
+    assert((max_time > NWDT_TIME_LOWER_LIMIT) || \
+           (max_time < NWDT_TIME_UPPER_LIMIT));
+
+    uint8_t pre = _find_prescaler(max_time);
+    uint16_t rel = _find_reload_value(pre, max_time);
+
+    /* Set watchdog prescaler and reload value */
+    _set_prescaler(pre);
+    _set_reload(rel);
+
+#if ENABLE_DEBUG
+    DEBUG("[wdt]: reset time %lu [us]\n", _wdt_time(pre, rel));
+#endif
+
+    /* Refresh wdt counter */
+    wdt_kick();
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/drivers/include/periph/wdt.h
+++ b/drivers/include/periph/wdt.h
@@ -173,6 +173,7 @@
 #define PERIPH_WDT_H
 
 #include <stdint.h>
+#include "periph_cpu.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/drivers/periph_common/init.c
+++ b/drivers/periph_common/init.c
@@ -38,6 +38,9 @@
 #ifdef MODULE_PERIPH_USBDEV
 #include "periph/usbdev.h"
 #endif
+#ifdef MODULE_PERIPH_WDT
+#include "periph/wdt.h"
+#endif
 
 void periph_init(void)
 {
@@ -71,5 +74,9 @@ void periph_init(void)
 
 #ifdef MODULE_PERIPH_USBDEV
     usbdev_init_lowlevel();
+#endif
+
+#if defined(MODULE_PERIPH_WDT) && WDT_HAS_INIT
+    wdt_init();
 #endif
 }

--- a/tests/periph_wdt/Makefile
+++ b/tests/periph_wdt/Makefile
@@ -1,0 +1,9 @@
+BOARD ?= nucleo-l152re
+include ../Makefile.tests_common
+
+FEATURES_REQUIRED += periph_wdt
+
+USEMODULE += xtimer
+USEMODULE += shell
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/periph_wdt/README.md
+++ b/tests/periph_wdt/README.md
@@ -1,0 +1,11 @@
+# Periph Wdg Test
+
+## About
+
+This application allows testing the wdg peripheral. User can define the reset
+time through the shell.
+
+## Expected Result
+
+If wdg was initialized with a valid reset period then once it is started user
+should see the application reset after the specified time period.

--- a/tests/periph_wdt/main.c
+++ b/tests/periph_wdt/main.c
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2019 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief       Test for wdt Drivers
+ *
+ *              This test initializes the wdt counter to a preset value
+ *              and spins until a wdt reset is triggered
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "periph/wdt.h"
+#include "shell.h"
+#include "xtimer.h"
+
+int get_range(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+    printf("lower_bound: %d upper_bound: %d \n", NWDT_TIME_LOWER_LIMIT,
+           NWDT_TIME_UPPER_LIMIT);
+    return 0;
+}
+
+int setup_wdt(int argc, char **argv)
+{
+    if (argc < 3) {
+        printf("usage: %s <min_time[ms]> <max_time[ms]>\n", argv[0]);
+        return -1;
+    }
+
+    uint32_t min_time = atoi(argv[1]);
+    uint32_t max_time = atoi(argv[2]);
+
+    if (max_time > NWDT_TIME_UPPER_LIMIT || max_time < NWDT_TIME_LOWER_LIMIT) {
+        puts("invalid times, see \"range\"");
+        return -1;
+    }
+
+    wdt_setup_reboot(min_time, max_time);
+    puts("valid configuration");
+
+    return 0;
+}
+
+int start_wdt(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+    puts("starting wdt timer");
+    wdt_start();
+    return 0;
+}
+
+int start_loop_wdt(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+    printf("start time: %" PRIu32 " us\n", xtimer_now_usec());
+    wdt_start();
+    while (1) {
+        printf("reset time: %" PRIu32 " us\n", xtimer_now_usec());
+    }
+    return 0;
+}
+
+#if WDT_HAS_STOP
+int stop_wdt(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+    puts("stopping wdt timer");
+    wdt_stop();
+    return 0;
+}
+#endif
+
+int kick_wdt(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+    puts("delaying wdt timer");
+    wdt_kick();
+    return 0;
+}
+
+static const shell_command_t shell_commands[] = {
+    { "range", "Return wdt Timer range", get_range },
+    { "setup", "Setup wdt Timer", setup_wdt },
+    { "kick", "Delay wdt timer", kick_wdt },
+    { "start", "Start wdt timer", start_wdt },
+    { "startloop", "Start wdt timer, loop print system time", start_loop_wdt },
+#if WDT_HAS_STOP
+    { "stop", "Stop wdt timer", stop_wdt },
+#endif
+    { NULL, NULL, NULL }
+};
+
+int main(void)
+{
+    puts("RIOT wdt test application");
+    /* run the shell */
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    return 0;
+}

--- a/tests/periph_wdt/tests/01-run.py
+++ b/tests/periph_wdt/tests/01-run.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2019 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+import pexpect
+import time
+from testrunner import run
+
+# We test only up to 10ms, with smaller times mcu doesn't have time to
+# print system time before resetting
+reset_times_ms = [1e2, 5e2, 1e3, 5e3]
+
+# We don't check for accuracy, only order of magnitude. Some MCU use an
+# an internal un-calibrated clock as reference which can deviate in
+# more than 50% from theoretical values (e.g STM32 board CLOCK_LSI)
+error_margin = 0.5
+
+
+def get_reset_time(child):
+    reset_time = 0
+    try:
+        start = time.time()
+        timeout = 10  # seconds
+        while time.time() < start + timeout:
+            child.expect(u"reset time: (\d+) us", timeout=1)
+            reset_time = int(child.match.group(1))
+        else:
+            # timeout
+            return reset_time
+    except pexpect.TIMEOUT:
+        return reset_time
+
+
+def testfunc(child):
+    child.sendline("range")
+    child.expect(u"lower_bound: (\d+) upper_bound: (\d+) ",
+                 timeout=1)
+    wdt_lower_bound = int(child.match.group(1))
+    wdt_upper_bound = int(child.match.group(2))
+
+    for rst_time in reset_times_ms:
+        child.sendline("setup 0 {}".format(rst_time))
+        if rst_time < wdt_lower_bound or rst_time > wdt_upper_bound:
+            child.expect_exact("invalid time, see \"range\"", timeout=1)
+        else:
+            child.sendline("startloop")
+            child.expect(u"start time: (\d+) us", timeout=1)
+            start_time_us = int(child.match.group(1))
+            reset_time_us = get_reset_time(child)
+            wdt_reset_time = (reset_time_us - start_time_us) / 1e3
+
+            if wdt_reset_time < rst_time*(1 - error_margin) or \
+               wdt_reset_time > rst_time*(1 + error_margin):
+                print("FAILED target time: {}[ms], actual_time: {}[ms]"
+                      .format(rst_time, wdt_reset_time))
+                sys.exit(-1)
+            else:
+                print("PASSED target time: {}[ms], actual_time: {}[ms]"
+                      .format(rst_time, wdt_reset_time))
+
+    print("TEST PASSED")
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc, echo=False))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR adds a simple watchdog implementation for stm32x boards. The api has been kept farely simple:

`* wdg_enable(void)`
`* wdg_disable(void)`
` * wdg_reset(void)`
 `* wdg_init(uint32_t time)`

For stm32 disable doesn't do anything since the watchdog can't be disabled in these platforms once enabled. It does freeze the wdg_timer on sleep modes for stm32l4. This function is added expecting that other platforms might have a disable function.

Pending support:

- [ ] window timer
- [ ] EWI (early wake up interrupt) (it's part of windowed timer support)

### Testing procedure

I have tested on stm32f0, stm32f4, stml321, stm32l1 & stm32l4. Haven't tested on stm32f2,3,7 but the workflow is exactly the same. There is a very simple application test that set-ups the timer with a modifiable reset_time.

`make BOARD=nucleo-l476rg -C tests/periph_wdg/ clean all flash -j term`

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
https://github.com/RIOT-OS/RIOT/pull/7374

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

Based on the wdt api discussed https://github.com/RIOT-OS/RIOT/pull/7374