### PR TITLE
tools/pyocd: add option for image offset

### DIFF
--- a/boards/nrf52840-mdk/Makefile.include
+++ b/boards/nrf52840-mdk/Makefile.include
@@ -8,7 +8,7 @@ PROGRAMMER ?= pyocd
 ifeq (pyocd,$(PROGRAMMER))
   # The board is not recognized automatically by pyocd, so the CPU target
   # option is passed explicitly
-  export FLASH_TARGET_TYPE ?= -t $(CPU)
+  export FLASH_TARGET_TYPE ?= -t nrf52840
   include $(RIOTMAKE)/tools/pyocd.inc.mk
 else ifeq (openocd,$(PROGRAMMER))
   DEBUG_ADAPTER = dap

--- a/dist/tools/pyocd/pyocd.sh
+++ b/dist/tools/pyocd/pyocd.sh
@@ -70,6 +70,12 @@
 # CPU Target type.
 # Use `-t` followed by value. Example: -t nrf51
 : ${FLASH_TARGET_TYPE:=}
+# This is an optional offset to the base address that can be used to flash an
+# image in a different location than it is linked at. This feature can be useful
+# when flashing images for firmware swapping/remapping boot loaders.
+# Default offset is 0, meaning the image will be flashed at the address that it
+# was linked at.
+: ${IMAGE_OFFSET:=0}
 
 #
 # Examples of alternative debugger configurations
@@ -112,8 +118,13 @@ test_hexfile() {
 do_flash() {
     HEX_FILE=$1
     test_hexfile
+
+    if [ "${IMAGE_OFFSET}" != "0" ]; then
+        echo "Flashing with IMAGE_OFFSET: ${IMAGE_OFFSET}"
+    fi
+
     # flash device
-    sh -c "${PYOCD_FLASH} ${FLASH_TARGET_TYPE} \"${HEX_FILE}\"" &&
+    sh -c "${PYOCD_FLASH} ${FLASH_TARGET_TYPE} -a ${IMAGE_OFFSET} \"${HEX_FILE}\"" &&
     echo 'Done flashing'
 }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds an option for setting a custom image offset when flashing with pyocd. This is useful when playing with riotboot on boards flashed by pyocd by default (nrf52xxx-mdk for example).

Note that flashing slot1 using `riotboot/flash-slot1` on nrf52840-mdk doesn't work probably because of an issue in pyocd:
```
### Flashing Target ###
Flashing with IMAGE_OFFSET: 526336
0000487:ERROR:__main__:uncaught exception: no memory region defined for address 0x00080800
Traceback (most recent call last):
  File "/home/aabadie/.local/lib/python3.6/site-packages/pyocd/__main__.py", line 304, in run
    self._commands[self._args.cmd]()
  File "/home/aabadie/.local/lib/python3.6/site-packages/pyocd/__main__.py", line 379, in do_flash
    file_format=self._args.format)
  File "/home/aabadie/.local/lib/python3.6/site-packages/pyocd/flash/loader.py", line 134, in program
    self._format_handlers[file_format](file_obj, **kwargs)
  File "/home/aabadie/.local/lib/python3.6/site-packages/pyocd/flash/loader.py", line 150, in _program_bin
    self._loader.add_data(address, data)
  File "/home/aabadie/.local/lib/python3.6/site-packages/pyocd/flash/loader.py", line 415, in add_data
    raise ValueError("no memory region defined for address 0x%08x" % address)
ValueError: no memory region defined for address 0x00080800
```

on nrf52832-mdk, this works:
```
### Flashing Target ###
Flashing with IMAGE_OFFSET: 264192
[====================] 100%
0001874:INFO:loader:Programmed 11868 bytes (4 pages) at 8.23 kB/s (0 pages unchanged)
Done flashing
```

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Use the different riotboot flash targets on `nrf52832-mdk`:
```
$ make BOARD=nrf52832-mdk -C tests/riotboot riotboot/flash term
$ make BOARD=nrf52832-mdk -C tests/riotboot riotboot/flash-slot0 term
$ make BOARD=nrf52832-mdk -C tests/riotboot riotboot/flash-slot1 term
$ make BOARD=nrf52832-mdk -C tests/riotboot riotboot/flash-combined-slot0 term
```
The riotboot shell is running and the application is running on the right slot.

- Other application can still be flashed as before and works:
```
$ make BOARD=nrf52832-mdk -C examples/default/ flash term
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
