### PR TITLE
makefiles/openocd.inc.mk: use FLASHFILE

### DIFF
--- a/boards/seeeduino_arch-pro/Makefile.include
+++ b/boards/seeeduino_arch-pro/Makefile.include
@@ -10,8 +10,8 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 
 DEBUG_ADAPTER ?= dap
 
-# this board uses openocd
-FFLAGS ?= flash $(HEXFILE)
+# this board uses openocd with an HEXFILE
+FLASHFILE ?= $(HEXFILE)
 include $(RIOTMAKE)/tools/openocd.inc.mk
 
 # generate image checksum from hex file

--- a/makefiles/boot/riotboot.mk
+++ b/makefiles/boot/riotboot.mk
@@ -97,30 +97,24 @@ $(RIOTBOOT_EXTENDED_BIN): $(RIOTBOOT_COMBINED_BIN)
 	$(Q)truncate -s $$(($(SLOT0_OFFSET) + $(SLOT0_LEN) + $(RIOTBOOT_HDR_LEN))) $@.tmp
 	$(Q)mv $@.tmp $@
 
-# Flashing rule for openocd to flash combined/extended binaries
-riotboot/flash-combined-slot0: ELFFILE=$(RIOTBOOT_COMBINED_BIN)
-riotboot/flash-extended-slot0: ELFFILE=$(RIOTBOOT_EXTENDED_BIN)
-
+# Flashing rule for combined binaries
 riotboot/flash-combined-slot0: FLASHFILE=$(RIOTBOOT_COMBINED_BIN)
 riotboot/flash-combined-slot0: $(RIOTBOOT_COMBINED_BIN) $(FLASHDEPS)
 	$(flash-recipe)
 
+# Flashing rule for extended binaries
 riotboot/flash-extended-slot0: FLASHFILE=$(RIOTBOOT_EXTENDED_BIN)
 riotboot/flash-extended-slot0: $(RIOTBOOT_EXTENDED_BIN) $(FLASHDEPS)
 	$(flash-recipe)
 
 # Flashing rule for slot 0
 riotboot/flash-slot0: export IMAGE_OFFSET=$(SLOT0_OFFSET)
-# openocd
-riotboot/flash-slot0: ELFFILE=$(SLOT0_RIOT_BIN)
 riotboot/flash-slot0: FLASHFILE=$(SLOT0_RIOT_BIN)
 riotboot/flash-slot0: $(SLOT0_RIOT_BIN) $(FLASHDEPS)
 	$(flash-recipe)
 
 # Flashing rule for slot 1
 riotboot/flash-slot1: export IMAGE_OFFSET=$(SLOT1_OFFSET)
-# openocd
-riotboot/flash-slot1: ELFFILE=$(SLOT1_RIOT_BIN)
 riotboot/flash-slot1: FLASHFILE=$(SLOT1_RIOT_BIN)
 riotboot/flash-slot1: $(SLOT1_RIOT_BIN) $(FLASHDEPS)
 	$(flash-recipe)

--- a/makefiles/tools/openocd.inc.mk
+++ b/makefiles/tools/openocd.inc.mk
@@ -3,7 +3,8 @@ export DEBUGGER = $(RIOTTOOLS)/openocd/openocd.sh
 export DEBUGSERVER = $(RIOTTOOLS)/openocd/openocd.sh
 export RESET ?= $(RIOTTOOLS)/openocd/openocd.sh
 
-export FFLAGS ?= flash $(ELFFILE)
+FLASHFILE ?= $(ELFFILE)
+export FFLAGS ?= flash $(FLASHFILE)
 export DEBUGGER_FLAGS ?= debug $(ELFFILE)
 export DEBUGSERVER_FLAGS ?= debug-server
 export RESET_FLAGS ?= reset

--- a/tests/riotboot/Makefile
+++ b/tests/riotboot/Makefile
@@ -24,7 +24,3 @@ FLASHFILE = $(RIOTBOOT_COMBINED_BIN)
 
 include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include
-
-# This is currently hacky as the flasher are not using 'FLASHFILE'
-# openocd
-ELFFILE = $(FLASHFILE)


### PR DESCRIPTION
### Contribution description

Update to use FLASHFILE as file to be flashed on the board.

This also now removes the compatibility hack in `riotboot`.

### Testing procedure

We need to test that boards using `openocd` still work with this.

Boards using `openocd`:

```
OPENOCD_BOARDS=$(git grep -l -e 'tools/openocd.inc.mk' -e 'boards/sam0.inc.mk' -e common/frdm/Makefile.include -e common/iotlab/Makefile.include -e common/nrf51/Makefile.include -e common/nrf52/Makefile.include -e common/nucleo/Makefile.include  -e common/saml1x/Makefile.include -e common/stm32f103c8/Makefile.include  ':!boards/common' ':!makefiles/boards' | cut -f 2 -d/)
```

```
echo ${OPENOCD_BOARDS}
acd52832 airfy-beacon arduino-zero b-l072z-lrwan1 b-l475e-iot01a blackpill bluepill calliope-mini ek-lm4f120xl fox frdm-k22f frdm-k64f frdm-kw41z hifive1 iotlab-a8-m3 iotlab-m3 limifrog-v1 maple-mini microbit msbiot mulle nrf51dk nrf51dongle nrf52832-mdk nrf52840-mdk nrf6310 pba-d-01-kw2x phynode-kw41z reel samd21-xpro saml10-xpro saml11-xpro saml21-xpro samr21-xpro samr30-xpro seeeduino_arch-pro spark-core stm32f0discovery stm32f3discovery stm32f429i-disc1 stm32f4discovery stm32f769i-disco stm32l476g-disco thingy52 ublox-c030-u201 usb-kw41z yunjia-nrf51822
```

### Test flashing normal examples with the board

* [x] samr21-xpro with `PROGRAMMER=openocd` @cladmi 
* [x] iotlab-m3 @cladmi 
* [ ] seeduino_arch-pro
* [x] samr21-xpro @MrKevinWeiss `PROGRAMMER=openocd`
* [x] nucleo-l073rz @MrKevinWeiss `PROGRAMMER=openocd`
* [x] nucleo-f411re @MrKevinWeiss `PROGRAMMER=openocd`
* [x] remote-revb @MrKevinWeiss `PROGRAMMER=openocd`
* [x] nucleo-f103rb @MrKevinWeiss `PROGRAMMER=openocd`
* [x] frdm-k22f @MrKevinWeiss `PROGRAMMER=openocd`
* [ ] ...

### Test without board

I get the same output for the `FFLAGS` for all these boards with both this PR and master 

`for board in ${OPENOCD_BOARDS}; do echo ${board}; BOARD=${board} PROGRAMMER=openocd make -C examples/hello-world/ --no-print-directory FLASHER=true flash-only; done`

<details><summary>FFLAGS output for all boards...</summary>
<p>

```
acd52832
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/acd52832/hello-world.elf
airfy-beacon
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/airfy-beacon/hello-world.elf
arduino-zero
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/arduino-zero/hello-world.elf
b-l072z-lrwan1
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/b-l072z-lrwan1/hello-world.elf
b-l475e-iot01a
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/b-l475e-iot01a/hello-world.elf
blackpill
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/blackpill/hello-world.elf
bluepill
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/bluepill/hello-world.elf
calliope-mini
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/calliope-mini/hello-world.elf
ek-lm4f120xl
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/ek-lm4f120xl/hello-world.elf
fox
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/fox/hello-world.elf
frdm-k22f
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/frdm-k22f/hello-world.elf
frdm-k64f
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/frdm-k64f/hello-world.elf
frdm-kw41z
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/frdm-kw41z/hello-world.elf
hifive1
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/hifive1/hello-world.elf
iotlab-a8-m3
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/iotlab-a8-m3/hello-world.elf
iotlab-m3
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/iotlab-m3/hello-world.elf
limifrog-v1
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/limifrog-v1/hello-world.elf
maple-mini
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/maple-mini/hello-world.elf
microbit
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/microbit/hello-world.elf
msbiot
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/msbiot/hello-world.elf
mulle
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/mulle/hello-world.elf
nrf51dk
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/nrf51dk/hello-world.elf
nrf51dongle
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/nrf51dongle/hello-world.elf
nrf52832-mdk
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/nrf52832-mdk/hello-world.elf
nrf52840-mdk
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/nrf52840-mdk/hello-world.elf
nrf6310
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/nrf6310/hello-world.elf
pba-d-01-kw2x
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/pba-d-01-kw2x/hello-world.elf
phynode-kw41z
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/phynode-kw41z/hello-world.elf
reel
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/reel/hello-world.elf
samd21-xpro
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/samd21-xpro/hello-world.elf
saml10-xpro
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/saml10-xpro/hello-world.elf
saml11-xpro
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/saml11-xpro/hello-world.elf
saml21-xpro
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/saml21-xpro/hello-world.elf
samr21-xpro
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/samr21-xpro/hello-world.elf
samr30-xpro
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/samr30-xpro/hello-world.elf
seeeduino_arch-pro
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/seeeduino_arch-pro/hello-world.hex
spark-core
true -d 1d50:607f -a 0 -s 0x08005000:leave -D "/home/harter/work/git/RIOT/examples/hello-world/bin/spark-core/hello-world.bin"
stm32f0discovery
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/stm32f0discovery/hello-world.elf
stm32f3discovery
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/stm32f3discovery/hello-world.elf
stm32f429i-disc1
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/stm32f429i-disc1/hello-world.elf
stm32f4discovery
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/stm32f4discovery/hello-world.elf
stm32f769i-disco
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/stm32f769i-disco/hello-world.elf
stm32l476g-disco
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/stm32l476g-disco/hello-world.elf
thingy52
/home/harter/work/git/RIOT/boards/common/nrf52/Makefile.include:32: *** Cannot use OpenOCD with thingy52 board.  Stop.
ublox-c030-u201
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/ublox-c030-u201/hello-world.elf
usb-kw41z
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/usb-kw41z/hello-world.elf
yunjia-nrf51822
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/yunjia-nrf51822/hello-world.elf
```

The output for `spark-core` shows it is not using `openocd` for flashing but was the same in master.

</p>
</details>


### `riotboot` test

Test running `tests/riotboot` for boards supporting it.
I tested `samr21-xpro` with `PROGRAMMER=openocd` and the `iotlab-m3`.
I also tested some of the other commands `riotboot/flash-slot1` `riotboot/flash-extended-slot0`.


```
PROGRAMMER=openocd BOARD=samr21-xpro make -C tests/riotboot flash test
2019-03-24 10:46:04,942 - INFO # main(): This is RIOT! (Version: 2019.04-devel-608-g411b1f-pr/make/openocd/flashfile)
2019-03-24 10:46:04,943 - INFO # Hello riotboot!
2019-03-24 10:46:04,947 - INFO # You are running RIOT on a(n) samr21-xpro board.
2019-03-24 10:46:04,951 - INFO # This board features a(n) samd21 MCU.
2019-03-24 10:46:04,954 - INFO # riotboot_test: running from slot 0
2019-03-24 10:46:04,957 - INFO # Image magic_number: 0x544f4952
2019-03-24 10:46:04,959 - INFO # Image Version: 0x00000001
2019-03-24 10:46:04,962 - INFO # Image start address: 0x00001100
2019-03-24 10:46:04,964 - INFO # Header chksum: 0x7f7eaea2
2019-03-24 10:46:04,964 - INFO #
> 2019-03-24 10:46:05,077 - INFO #  curslotnr
2019-03-24 10:46:05,078 - INFO # Current slot=0
> curslothdr
2019-03-24 10:46:05,132 - INFO #  curslothdr
2019-03-24 10:46:05,134 - INFO # Image magic_number: 0x544f4952
2019-03-24 10:46:05,137 - INFO # Image Version: 0x00000001
2019-03-24 10:46:05,140 - INFO # Image start address: 0x00001100
2019-03-24 10:46:05,142 - INFO # Header chksum: 0x7f7eaea2
2019-03-24 10:46:05,142 - INFO #
> getslotaddr 0
2019-03-24 10:46:05,195 - INFO #  getslotaddr 0
2019-03-24 10:46:05,198 - INFO # Slot 0 address=0x00001100
> dumpaddrs
2019-03-24 10:46:05,251 - INFO #  dumpaddrs
2019-03-24 10:46:05,255 - INFO # slot 0: metadata: 0x1000 image: 0x00001100
2019-03-24 10:46:05,259 - INFO # slot 1: metadata: 0x20800 image: 0xffffffff
>
```


### Issues/PRs references

Part of https://github.com/RIOT-OS/RIOT/pull/8838
