### PR TITLE
net/gnrc_netif/nrfmin: put NETOPT_PROTO assert at the right place

### DIFF
--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1212,12 +1212,12 @@ static void _test_options(gnrc_netif_t *netif)
             assert(netif->flags & GNRC_NETIF_FLAGS_HAS_L2ADDR);
             assert((IEEE802154_SHORT_ADDRESS_LEN == netif->l2addr_len) ||
                    (IEEE802154_LONG_ADDRESS_LEN == netif->l2addr_len));
-            assert(-ENOTSUP != netif->dev->driver->get(netif->dev, NETOPT_PROTO,
-                                                       &tmp, sizeof(tmp)));
 #ifdef MODULE_GNRC_IPV6
 #ifdef MODULE_GNRC_SIXLOWPAN
             assert(netif->ipv6.mtu == IPV6_MIN_MTU);
             assert(netif->sixlo.max_frag_size > 0);
+            assert(-ENOTSUP != netif->dev->driver->get(netif->dev, NETOPT_PROTO,
+                                                       &tmp, sizeof(tmp)));
 #else   /* MODULE_GNRC_SIXLOWPAN */
             assert(netif->ipv6.mtu < UINT16_MAX);
 #endif  /* MODULE_GNRC_SIXLOWPAN */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Fixes #11162 

In nrfmin netdev code, NETOPT_PROTO depends on GNRC_SIXLOWPAN and should be moved inside the corresponding preprocessor conditional code in the option verification code.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Build and flash `examples/default` and `examples/gnrc_networking` on any nrf boards with nrfmin enabled (it's enabled by default microbit and rnf51dk for example). There are some of these boards available on IoT-LAB
- The applications should behave as expected (ifconfig, txtsnd, udp, etc). On master, `examples/default` crashes as described in #11162.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Fixes #11162 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
