### PR TITLE
cpu/stm32_common: Fix i2c_2 NACK stopping twice

### DIFF
--- a/cpu/stm32_common/periph/i2c_2.c
+++ b/cpu/stm32_common/periph/i2c_2.c
@@ -329,7 +329,7 @@ static int _start(I2C_TypeDef *i2c, uint8_t address_byte, uint8_t flags,
         ret = _is_sr1_mask_set(i2c, I2C_SR1_ADDR, flags & ~I2C_NOSTOP);
         if (ret == -EIO){
             /* Since NACK happened during start it means no device connected */
-            ret = -ENXIO;
+            return -ENXIO;
         }
         /* Needed to clear address bit */
         i2c->SR2;


### PR DESCRIPTION
### Contribution description
Errors occur for any STM32 F1, F2, L1, and F4 using i2c_2.c.  When an address NACK occurs the stop bit gets set twice.  This stop bit cannot be cleared unless reinitialized.  As a result all following commands will not work because the an impossible stop must occur.  This PR removes the additional stop from happening so multiple nacks can occur.


### Testing procedure
Flash a STM32 F1, F2, L1, and F4 based board with 

    BOARD=<xxx> make flash term -C tests/periph_i2c/
and attempt to 

    i2c_read_byte 0 <any_address_that_will_nack> 0
multiple times.  You should not get a timeout, on master you will.

### Issues/PRs references
Reference #11240
