### PR TITLE
boards/nucleof7*: SPI and refactoring

### DIFF
--- a/boards/common/stm32/include/cfg_spi_divtable.h
+++ b/boards/common/stm32/include/cfg_spi_divtable.h
@@ -111,6 +111,15 @@ extern "C" {
         1   /* -> 12500000Hz */     \
     },
 
+#define CFG_SPIDIV_54               \
+    {       /* for 54000000Hz */    \
+        7,  /* -> 210937Hz */       \
+        6,  /* -> 421875Hz */       \
+        5,  /* -> 843750Hz */       \
+        3,  /* -> 3375000Hz */      \
+        2   /* -> 6750000Hz */      \
+    },
+
 #define CFG_SPIDIV_60               \
     {       /* for 60000000Hz */    \
         7,  /* -> 234375Hz */       \
@@ -173,6 +182,15 @@ extern "C" {
         3,  /* -> 6250000Hz */      \
         2   /* -> 12500000Hz */     \
     },
+
+#define CFG_SPIDIV_108              \
+    {       /* for 108000000Hz */   \
+        7,  /* -> 421875Hz */       \
+        7,  /* -> 421875Hz */       \
+        6,  /* -> 843750Hz */       \
+        4,  /* -> 3375000Hz */      \
+        3   /* -> 6750000Hz */      \
+    },
 /** @} */
 
 
@@ -203,6 +221,8 @@ static const uint8_t spi_divtable[2][5] = {
     CFG_SPIDIV_48
 #elif (CLOCK_APB1 == 50000000)
     CFG_SPIDIV_50
+#elif (CLOCK_APB1 == 54000000)
+    CFG_SPIDIV_54
 #elif (CLOCK_APB1 == 72000000)
     CFG_SPIDIV_72
 #elif (CLOCK_APB1 == 60000000)
@@ -253,6 +273,8 @@ static const uint8_t spi_divtable[2][5] = {
     CFG_SPIDIV_96
 #elif (CLOCK_APB2 == 100000000)
     CFG_SPIDIV_100
+#elif (CLOCK_APB2 == 108000000)
+    CFG_SPIDIV_108
 #else
 #error "CFG_SPI_DIVTABLE: no prescalers for selected APB2 bus clock defined"
 #endif

--- a/boards/common/stm32/include/f7/cfg_clock_216_8_1.h
+++ b/boards/common/stm32/include/f7/cfg_clock_216_8_1.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2019 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_common_stm32
+ * @{
+ *
+ * @file
+ * @brief       Configure STM32F7 clock to 216MHz and 8MHz HSE using PLL with
+ *              LSE
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ *
+ * @note        This is auto-generated from
+ *              `cpu/stm32_common/dist/clk_conf/clk_conf.c`
+ * @{
+ */
+
+#ifndef F7_CFG_CLOCK_216_8_1_H
+#define F7_CFG_CLOCK_216_8_1_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* give the target core clock (HCLK) frequency [in Hz],
+ * maximum: 216MHz */
+#define CLOCK_CORECLOCK     (216000000U)
+/* 0: no external high speed crystal available
+ * else: actual crystal frequency [in Hz] */
+#define CLOCK_HSE           (8000000U)
+/* 0: no external low speed crystal available,
+ * 1: external crystal available (always 32.768kHz) */
+#define CLOCK_LSE           (1U)
+/* peripheral clock setup */
+#define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1
+#define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
+#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV4     /* max 54MHz */
+#define CLOCK_APB1          (CLOCK_CORECLOCK / 4)
+#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV2     /* max 108MHz */
+#define CLOCK_APB2          (CLOCK_CORECLOCK / 2)
+
+/* Main PLL factors */
+#define CLOCK_PLL_M          (4)
+#define CLOCK_PLL_N          (216)
+#define CLOCK_PLL_P          (2)
+#define CLOCK_PLL_Q          (9)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* F7_CFG_CLOCK_216_8_1_H */
+/** @} */

--- a/boards/nucleo-f722ze/include/periph_conf.h
+++ b/boards/nucleo-f722ze/include/periph_conf.h
@@ -22,42 +22,12 @@
 #define PERIPH_CONF_H
 
 #include "periph_cpu.h"
+#include "f7/cfg_clock_216_8_1.h"
 #include "cfg_i2c1_pb8_pb9.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @name    Clock settings
- *
- * @note    This is auto-generated from
- *          `cpu/stm32_common/dist/clk_conf/clk_conf.c`
- * @{
- */
-/* give the target core clock (HCLK) frequency [in Hz],
- * maximum: 216MHz */
-#define CLOCK_CORECLOCK     (216000000U)
-/* 0: no external high speed crystal available
- * else: actual crystal frequency [in Hz] */
-#define CLOCK_HSE           (8000000U)
-/* 0: no external low speed crystal available,
- * 1: external crystal available (always 32.768kHz) */
-#define CLOCK_LSE           (1)
-/* peripheral clock setup */
-#define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1
-#define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV4     /* max 54MHz */
-#define CLOCK_APB1          (CLOCK_CORECLOCK / 4)
-#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV2     /* max 108MHz */
-#define CLOCK_APB2          (CLOCK_CORECLOCK / 2)
-
-/* Main PLL factors */
-#define CLOCK_PLL_M          (4)
-#define CLOCK_PLL_N          (216)
-#define CLOCK_PLL_P          (2)
-#define CLOCK_PLL_Q          (9)
-/** @} */
 
 /**
  * @name    Timer configuration

--- a/boards/nucleo-f746zg/include/periph_conf.h
+++ b/boards/nucleo-f746zg/include/periph_conf.h
@@ -22,42 +22,12 @@
 #define PERIPH_CONF_H
 
 #include "periph_cpu.h"
+#include "f7/cfg_clock_216_8_1.h"
 #include "cfg_i2c1_pb8_pb9.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @name    Clock settings
- *
- * @note    This is auto-generated from
- *          `cpu/stm32_common/dist/clk_conf/clk_conf.c`
- * @{
- */
-/* give the target core clock (HCLK) frequency [in Hz],
- * maximum: 216MHz */
-#define CLOCK_CORECLOCK     (216000000U)
-/* 0: no external high speed crystal available
- * else: actual crystal frequency [in Hz] */
-#define CLOCK_HSE           (8000000U)
-/* 0: no external low speed crystal available,
- * 1: external crystal available (always 32.768kHz) */
-#define CLOCK_LSE           (1)
-/* peripheral clock setup */
-#define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1
-#define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV4     /* max 54MHz */
-#define CLOCK_APB1          (CLOCK_CORECLOCK / 4)
-#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV2     /* max 108MHz */
-#define CLOCK_APB2          (CLOCK_CORECLOCK / 2)
-
-/* Main PLL factors */
-#define CLOCK_PLL_M          (4)
-#define CLOCK_PLL_N          (216)
-#define CLOCK_PLL_P          (2)
-#define CLOCK_PLL_Q          (9)
-/** @} */
 
 /**
  * @name    Timer configuration

--- a/boards/nucleo-f767zi/Makefile.features
+++ b/boards/nucleo-f767zi/Makefile.features
@@ -2,6 +2,7 @@
 FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 

--- a/boards/nucleo-f767zi/include/periph_conf.h
+++ b/boards/nucleo-f767zi/include/periph_conf.h
@@ -24,6 +24,7 @@
 #include "periph_cpu.h"
 #include "f7/cfg_clock_216_8_1.h"
 #include "cfg_i2c1_pb8_pb9.h"
+#include "cfg_spi_divtable.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -121,6 +122,29 @@ static const uart_conf_t uart_config[] = {
 #define UART_2_ISR          (isr_usart2)
 
 #define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+/** @} */
+
+/**
+ * @name   SPI configuration
+ *
+ * @note    The spi_divtable is auto-generated from
+ *          `cpu/stm32_common/dist/spi_divtable/spi_divtable.c`
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .dev      = SPI1,
+        .mosi_pin = GPIO_PIN(PORT_A, 7),
+        .miso_pin = GPIO_PIN(PORT_A, 6),
+        .sclk_pin = GPIO_PIN(PORT_A, 5),
+        .cs_pin   = GPIO_UNDEF,
+        .af       = GPIO_AF5,
+        .rccmask  = RCC_APB2ENR_SPI1EN,
+        .apbbus   = APB2
+    },
+};
+
+#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nucleo-f767zi/include/periph_conf.h
+++ b/boards/nucleo-f767zi/include/periph_conf.h
@@ -22,42 +22,12 @@
 #define PERIPH_CONF_H
 
 #include "periph_cpu.h"
+#include "f7/cfg_clock_216_8_1.h"
 #include "cfg_i2c1_pb8_pb9.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @name    Clock settings
- *
- * @note    This is auto-generated from
- *          `cpu/stm32_common/dist/clk_conf/clk_conf.c`
- * @{
- */
-/* give the target core clock (HCLK) frequency [in Hz],
- * maximum: 216MHz */
-#define CLOCK_CORECLOCK     (216000000U)
-/* 0: no external high speed crystal available
- * else: actual crystal frequency [in Hz] */
-#define CLOCK_HSE           (8000000U)
-/* 0: no external low speed crystal available,
- * 1: external crystal available (always 32.768kHz) */
-#define CLOCK_LSE           (1)
-/* peripheral clock setup */
-#define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1
-#define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV4     /* max 54MHz */
-#define CLOCK_APB1          (CLOCK_CORECLOCK / 4)
-#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV2     /* max 108MHz */
-#define CLOCK_APB2          (CLOCK_CORECLOCK / 2)
-
-/* Main PLL factors */
-#define CLOCK_PLL_M          (4)
-#define CLOCK_PLL_N          (216)
-#define CLOCK_PLL_P          (2)
-#define CLOCK_PLL_Q          (9)
-/** @} */
 
 /**
  * @name    DMA streams configuration


### PR DESCRIPTION
### Contribution description
- Refactored core clock settings for nucleo-f7* boards
- Added SPI for nucleo-f767zi

### Testing procedure
- Clock settings:
    - Proof read if `cfg_clock_216_8_1.h` contains the same numbers as each board contained previously
- SPI:
    - Hook up you're favorite SPI device (with RIOT support) and connect it to the board. (I tested with the CC1101 transceiver and it worked for me.)

### Issues/PRs references
None