### PR TITLE
boards/cpu/esp32: doc fix of built-in ROM size

### DIFF
--- a/boards/esp32-mh-et-live-minikit/doc.txt
+++ b/boards/esp32-mh-et-live-minikit/doc.txt
@@ -69,7 +69,7 @@ Vendor      | Espressif | |
 Cores       | 1 or 2 x Tensilica Xtensa LX6 | 1 core
 FPU         | yes (ULP - Ultra low power co-processor) | no
 RAM         | 520 kByte SRAM <br> 16 kByte  RTC SRAM | yes
-ROM         | 520 kByte | yes
+ROM         | 448 kByte | yes
 Flash       | 512 kByte ... 16 MByte |  yes
 Frequency   | 240 MHz, 160 MHz, 80 MHz | yes
 Power Consumption | 68 mA @ 240 MHz <br> 44 mA @ 160 MHz <br> 31 mA @ 80 MHz <br> 5 uA in deep sleep mode | yes <br> yes <br> yes <br> no

--- a/boards/esp32-olimex-evb/doc.txt
+++ b/boards/esp32-olimex-evb/doc.txt
@@ -62,7 +62,7 @@ Vendor      | Espressif | |
 Cores       | 1 or 2 x Tensilica Xtensa LX6 | 1 core
 FPU         | yes (ULP - Ultra low power co-processor) | no
 RAM         | 520 kByte SRAM <br> 16 kByte  RTC SRAM | yes
-ROM         | 520 kByte | yes
+ROM         | 448 kByte | yes
 Flash       | 512 kByte ... 16 MByte |  yes
 Frequency   | 240 MHz, 160 MHz, 80 MHz | yes
 Power Consumption | 68 mA @ 240 MHz <br> 44 mA @ 160 MHz <br> 31 mA @ 80 MHz <br> 5 uA in deep sleep mode | yes <br> yes <br> yes <br> no

--- a/boards/esp32-wemos-lolin-d32-pro/doc.txt
+++ b/boards/esp32-wemos-lolin-d32-pro/doc.txt
@@ -55,7 +55,7 @@ Vendor      | Espressif | |
 Cores       | 1 or 2 x Tensilica Xtensa LX6 | 1 core
 FPU         | yes (ULP - Ultra low power co-processor) | no
 RAM         | 520 kByte SRAM <br> 16 kByte  RTC SRAM | yes
-ROM         | 520 kByte | yes
+ROM         | 448 kByte | yes
 Flash       | 512 kByte ... 16 MByte |  yes
 Frequency   | 240 MHz, 160 MHz, 80 MHz | yes
 Power Consumption | 68 mA @ 240 MHz <br> 44 mA @ 160 MHz <br> 31 mA @ 80 MHz <br> 5 uA in deep sleep mode | yes <br> yes <br> yes <br> no

--- a/boards/esp32-wroom-32/doc.txt
+++ b/boards/esp32-wroom-32/doc.txt
@@ -49,7 +49,7 @@ Vendor      | Espressif | |
 Cores       | 1 or 2 x Tensilica Xtensa LX6 | 1 core
 FPU         | yes (ULP - Ultra low power co-processor) | no
 RAM         | 520 kByte SRAM <br> 16 kByte  RTC SRAM | yes
-ROM         | 520 kByte | yes
+ROM         | 448 kByte | yes
 Flash       | 512 kByte ... 16 MByte |  yes
 Frequency   | 240 MHz, 160 MHz, 80 MHz | yes
 Power Consumption | 68 mA @ 240 MHz <br> 44 mA @ 160 MHz <br> 31 mA @ 80 MHz <br> 5 uA in deep sleep mode | yes <br> yes <br> yes <br> no

--- a/boards/esp32-wrover-kit/doc.txt
+++ b/boards/esp32-wrover-kit/doc.txt
@@ -57,7 +57,7 @@ Vendor      | Espressif | |
 Cores       | 1 or 2 x Tensilica Xtensa LX6 | 1 core
 FPU         | yes (ULP - Ultra low power co-processor) | no
 RAM         | 520 kByte SRAM <br> 16 kByte  RTC SRAM | yes
-ROM         | 520 kByte | yes
+ROM         | 448 kByte | yes
 Flash       | 512 kByte ... 16 MByte |  yes
 Frequency   | 240 MHz, 160 MHz, 80 MHz | yes
 Power Consumption | 68 mA @ 240 MHz <br> 44 mA @ 160 MHz <br> 31 mA @ 80 MHz <br> 5 uA in deep sleep mode | yes <br> yes <br> yes <br> no

--- a/cpu/esp32/doc.txt
+++ b/cpu/esp32/doc.txt
@@ -139,7 +139,7 @@ Vendor      | Espressif | |
 Cores       | 1 or 2 x Tensilica Xtensa LX6 | 1 core
 FPU         | yes (ULP - Ultra low power co-processor) | no
 RAM         | 520 kByte SRAM <br> 16 kByte  RTC SRAM | yes
-ROM         | 520 kByte | yes
+ROM         | 448 kByte | yes
 Flash       | 512 kByte ... 16 MByte |  yes
 Frequency   | 240 MHz, 160 MHz, 80 MHz | yes
 Power Consumption | 68 mA @ 240 MHz <br> 44 mA @ 160 MHz <br> 31 mA @ 80 MHz <br> 5 uA in deep sleep mode | yes <br> yes <br> yes <br> no


### PR DESCRIPTION
### Contribution description

This PR contains only a very small documentation fix for all ESP32 boards and the ESP32 MCU. It simply changes the size of built-in ROM from 520 kBytes to 448 kBytes.

### Testing procedure

Generate the documentation with `make doc`. Check for example page [Modules / CPU / ESP32`](https://riot-os.org/api/group__cpu__esp32.html#esp32_features) in the documentation generated on your local system.