### PR TITLE
can: fix a race condition with tx_list

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -631,11 +631,12 @@ ifneq (,$(filter can,$(USEMODULE)))
   ifneq (,$(filter can_mbox,$(USEMODULE)))
     USEMODULE += core_mbox
   endif
-  USEMODULE += gnrc_pktbuf_static
+  USEMODULE += memarray
 endif
 
 ifneq (,$(filter can_isotp,$(USEMODULE)))
   USEMODULE += xtimer
+  USEMODULE += gnrc_pktbuf
 endif
 
 ifneq (,$(filter conn_can,$(USEMODULE)))

--- a/sys/can/conn/raw.c
+++ b/sys/can/conn/raw.c
@@ -115,7 +115,7 @@ static void _tx_conf_timeout(void *arg)
     msg.type = _TIMEOUT_TX_MSG_TYPE;
     msg.content.value = _TIMEOUT_MSG_VALUE;
 
-    mbox_put(&conn->mbox, &msg);
+    mbox_try_put(&conn->mbox, &msg);
 }
 
 int conn_can_raw_send(conn_can_raw_t *conn, const struct can_frame *frame, int flags)
@@ -195,7 +195,7 @@ static void _rx_timeout(void *arg)
     msg.type = _TIMEOUT_RX_MSG_TYPE;
     msg.content.value = _TIMEOUT_MSG_VALUE;
 
-    mbox_put(&conn->mbox, &msg);
+    mbox_try_put(&conn->mbox, &msg);
 }
 
 int conn_can_raw_recv(conn_can_raw_t *conn, struct can_frame *frame, uint32_t timeout)

--- a/sys/can/dll.c
+++ b/sys/can/dll.c
@@ -56,9 +56,7 @@ static int _get_ifnum(kernel_pid_t pid)
 
 int _send_pkt(can_pkt_t *pkt)
 {
-    if (!pkt) {
-        return -ENOMEM;
-    }
+    assert(pkt);
 
     msg_t msg;
     int handle = pkt->handle;
@@ -71,6 +69,9 @@ int _send_pkt(can_pkt_t *pkt)
     msg.content.ptr = (void*) pkt;
 
     if (msg_send(&msg, candev_list[pkt->entry.ifnum]->pid) <= 0) {
+        mutex_lock(&tx_lock);
+        LL_DELETE(tx_list[pkt->entry.ifnum], &pkt->entry);
+        mutex_unlock(&tx_lock);
         return -EOVERFLOW;
     }
 
@@ -85,11 +86,18 @@ int raw_can_send(int ifnum, const struct can_frame *frame, kernel_pid_t pid)
     assert(ifnum < candev_nb);
 
     pkt = can_pkt_alloc_tx(ifnum, frame, pid);
+    if (!pkt) {
+        return -ENOMEM;
+    }
 
     DEBUG("raw_can_send: ifnum=%d, id=0x%" PRIx32 " from pid=%" PRIkernel_pid ", handle=%d\n",
           ifnum, frame->can_id, pid, pkt->handle);
 
-    return _send_pkt(pkt);
+    int ret = _send_pkt(pkt);
+    if (ret < 0) {
+        can_pkt_free(pkt);
+    }
+    return ret;
 }
 
 #ifdef MODULE_CAN_MBOX
@@ -101,10 +109,17 @@ int raw_can_send_mbox(int ifnum, const struct can_frame *frame, mbox_t *mbox)
     assert(ifnum < candev_nb);
 
     pkt = can_pkt_alloc_mbox_tx(ifnum, frame, mbox);
+    if (!pkt) {
+        return -ENOMEM;
+    }
 
     DEBUG("raw_can_send: ifnum=%d, id=0x%" PRIx32 ", handle=%d\n", ifnum, frame->can_id, pkt->handle);
 
-    return _send_pkt(pkt);
+    int ret = _send_pkt(pkt);
+    if (ret < 0) {
+        can_pkt_free(pkt);
+    }
+    return ret;
 }
 #endif
 
@@ -113,6 +128,7 @@ int raw_can_abort(int ifnum, int handle)
     msg_t msg, reply;
     can_pkt_t *pkt = NULL;
     can_reg_entry_t *entry;
+    can_reg_entry_t *prev = tx_list[ifnum];
 
     assert(ifnum < candev_nb);
 
@@ -122,11 +138,16 @@ int raw_can_abort(int ifnum, int handle)
     LL_FOREACH(tx_list[ifnum], entry) {
         pkt = container_of(entry, can_pkt_t, entry);
         if (pkt->handle == handle) {
+            if (prev == tx_list[ifnum]) {
+                tx_list[ifnum] = entry->next;
+            }
+            else {
+                prev->next = entry->next;
+            }
             break;
         }
+        prev = entry;
     }
-
-    LL_DELETE(tx_list[ifnum], entry);
     mutex_unlock(&tx_lock);
 
     if (pkt == NULL) {
@@ -336,32 +357,56 @@ int can_dll_dispatch_rx_frame(struct can_frame *frame, kernel_pid_t pid)
     return can_router_dispatch_rx_indic(pkt);
 }
 
+static int _remove_entry_from_list(can_reg_entry_t **list, can_reg_entry_t *entry)
+{
+    assert(list);
+    int res = -1;
+    can_reg_entry_t *_tmp;
+    if (*list == entry) {
+        res = 0;
+        *list = (*list)->next;
+    }
+    else if (*list != NULL) {
+        _tmp = *list;
+        while (_tmp->next && (_tmp->next != entry)) {
+            _tmp = _tmp->next;
+        }
+        if (_tmp->next) {
+            _tmp->next = entry->next;
+            res = 0;
+        }
+    }
+    return res;
+}
+
 int can_dll_dispatch_tx_conf(can_pkt_t *pkt)
 {
-    DEBUG("can_dll_dispatch_tx_conf: pkt=0x%p\n", (void*)pkt);
-
-    can_router_dispatch_tx_conf(pkt);
+    DEBUG("can_dll_dispatch_tx_conf: pkt=%p\n", (void*)pkt);
 
     mutex_lock(&tx_lock);
-    LL_DELETE(tx_list[pkt->entry.ifnum], &pkt->entry);
+    int res = _remove_entry_from_list(&tx_list[pkt->entry.ifnum], &pkt->entry);
     mutex_unlock(&tx_lock);
 
-    can_pkt_free(pkt);
+    if (res == 0) {
+        can_router_dispatch_tx_conf(pkt);
+        can_pkt_free(pkt);
+    }
 
     return 0;
 }
 
 int can_dll_dispatch_tx_error(can_pkt_t *pkt)
 {
-    DEBUG("can_dll_dispatch_tx_error: pkt=0x%p\n", (void*)pkt);
-
-    can_router_dispatch_tx_error(pkt);
+    DEBUG("can_dll_dispatch_tx_error: pkt=%p\n", (void*)pkt);
 
     mutex_lock(&tx_lock);
-    LL_DELETE(tx_list[pkt->entry.ifnum], &pkt->entry);
+    int res = _remove_entry_from_list(&tx_list[pkt->entry.ifnum], &pkt->entry);
     mutex_unlock(&tx_lock);
 
-    can_pkt_free(pkt);
+    if (res == 0) {
+        can_router_dispatch_tx_error(pkt);
+        can_pkt_free(pkt);
+    }
 
     return 0;
 

--- a/sys/can/dll.c
+++ b/sys/can/dll.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 OTA keys S.A.
+ * Copyright (C) 2016-2018 OTA keys S.A.
  *
  * This file is subject to the terms and conditions of the GNU Lesser General
  * Public License v2.1. See the file LICENSE in the top level directory for more
@@ -263,6 +263,9 @@ int raw_can_unsubscribe_rx_mbox(int ifnum, struct can_filter *filter, mbox_t *mb
 
 int raw_can_free_frame(can_rx_data_t *frame)
 {
+    if (!frame) {
+        return 0;
+    }
     int ret = can_router_free_frame((struct can_frame *)frame->data.iov_base);
 
     can_pkt_free_rx_data(frame);
@@ -386,6 +389,7 @@ int can_dll_dispatch_bus_off(kernel_pid_t pid)
 int can_dll_init(void)
 {
     can_pkt_init();
+    can_router_init();
 
     return 0;
 }

--- a/sys/include/can/common.h
+++ b/sys/include/can/common.h
@@ -38,7 +38,6 @@ extern "C" {
 #ifdef MODULE_CAN_MBOX
 #include "mbox.h"
 #endif
-#include "net/gnrc/pktbuf.h"
 
 /**
  * @brief CAN options
@@ -123,9 +122,7 @@ enum can_msg {
 typedef struct can_rx_data {
     struct iovec data;    /**< iovec containing received data */
     void *arg;            /**< upper layer private param */
-    gnrc_pktsnip_t *snip; /**< pointer to the allocated snip */
 } can_rx_data_t;
-
 
 /**
  * @brief registry entry types

--- a/sys/include/can/pkt.h
+++ b/sys/include/can/pkt.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 OTA keys S.A.
+ * Copyright (C) 2016-2018 OTA keys S.A.
  *
  * This file is subject to the terms and conditions of the GNU Lesser General
  * Public License v2.1. See the file LICENSE in the top level directory for more
@@ -26,8 +26,6 @@ extern "C" {
 
 #include <stdatomic.h>
 
-#include "net/gnrc/pktbuf.h"
-
 #include "can/common.h"
 #include "can/can.h"
 #include "msg.h"
@@ -45,7 +43,6 @@ typedef struct {
     atomic_uint ref_count;   /**< Reference counter (for rx frames) */
     int handle;              /**< handle (for tx frames */
     struct can_frame frame;  /**< CAN Frame */
-    gnrc_pktsnip_t *snip;    /**< Pointer to the allocated snip */
 } can_pkt_t;
 
 /**

--- a/sys/include/can/router.h
+++ b/sys/include/can/router.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 OTA keys S.A.
+ * Copyright (C) 2016-2018 OTA keys S.A.
  *
  * This file is subject to the terms and conditions of the GNU Lesser General
  * Public License v2.1. See the file LICENSE in the top level directory for more
@@ -28,6 +28,11 @@ extern "C" {
 
 #include "can/can.h"
 #include "can/pkt.h"
+
+/**
+ * @brief Initialize CAN router
+ */
+void can_router_init(void);
 
 /**
  * @brief Register a user @p entry to receive a frame @p can_id

--- a/tests/conn_can/Makefile
+++ b/tests/conn_can/Makefile
@@ -9,8 +9,6 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-nano \
                              saml11-xpro stm32f0discovery telosb waspmote-pro \
                              wsn430-v1_3b wsn430-v1_4 z1
 
-CFLAGS += -DLOG_LEVEL=LOG_ALL
-
 USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += ps
@@ -20,5 +18,9 @@ USEMODULE += can_isotp
 USEMODULE += conn_can_isotp_multi
 USEMODULE += can_pm
 USEMODULE += can_trx
+
+CFLAGS += -DGNRC_PKTBUF_SIZE=4096
+CFLAGS += -DCAN_PKT_BUF_SIZE=64
+CFLAGS += -DCAN_ROUTER_MAX_FILTER=32
 
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION

### Contribution description

This PR fixes a race condition with tx_list (linked list of packet that are being sent) between abort and tx confirmation. It could lead to the list being corrupted, thus a crash.

The last commit improves the conn layer to not used message blocking functions from an interrupt.

### Testing procedure

Tested in debug

### Issues/PRs references

based on #9404
