### PR TITLE
at86rf2xx: do not try to send when device is busy

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -22,6 +22,9 @@ endif
 
 ifneq (,$(filter at86rf%, $(filter-out at86rf215%, $(USEMODULE))))
   USEMODULE += at86rf2xx
+  ifneq (,$(filter gnrc_netif,$(USEMODULE)))
+    USEMODULE += gnrc_netif_pktq
+  endif
 endif
 
 ifneq (,$(filter bme680_%,$(USEMODULE)))

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -69,6 +69,15 @@ static void _irq_handler(void *arg)
 }
 #endif
 
+static inline bool _is_busy(at86rf2xx_t *dev)
+{
+    uint8_t state = at86rf2xx_get_status(dev);
+
+    return (state == AT86RF2XX_STATE_BUSY_RX_AACK) ||
+           (state == AT86RF2XX_STATE_BUSY_TX_ARET) ||
+           (state == AT86RF2XX_STATE_IN_PROGRESS);
+}
+
 static int _init(netdev_t *netdev)
 {
     at86rf2xx_t *dev = (at86rf2xx_t *)netdev;
@@ -114,6 +123,9 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
     at86rf2xx_t *dev = (at86rf2xx_t *)netdev;
     size_t len = 0;
 
+    if (_is_busy(dev)) {
+        return -EBUSY;
+    }
     at86rf2xx_tx_prepare(dev);
 
     /* load packet data into FIFO */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Otherwise, a race condition might be triggered where data that was just
received (which is the reason the device might be busy) is overridden
by the sent data (see #11256).
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Run the tests in #11256 ~~together with #11263~~ [the test doesn't include `gnrc_netif` so merging #11263 would be pointless] (I did not do this myself yet, this is why I marked it as WIP).
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
This prevents the race condition show-cased in #11256.
Together with #11263 the sent packets are tried to be sent later instead of just being dropped.

Depends on https://github.com/RIOT-OS/RIOT/pull/11263

Basis for #11068 

![Route to 6Lo minimal fragment forwarding](http://page.mi.fu-berlin.de/mlenders/sixlo_minfwd.svg)
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
