### PR TITLE
boards/b-l072z-lrwan1: provide periph_rtt feature

### DIFF
--- a/boards/b-l072z-lrwan1/Makefile.features
+++ b/boards/b-l072z-lrwan1/Makefile.features
@@ -2,6 +2,7 @@
 FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart

--- a/boards/b-l072z-lrwan1/include/periph_conf.h
+++ b/boards/b-l072z-lrwan1/include/periph_conf.h
@@ -221,6 +221,17 @@ static const i2c_conf_t i2c_config[] = {
 /** @} */
 
 /**
+ * @name    RTT configuration
+ *
+ * On the STM32Lx platforms, we always utilize the LPTIM1.
+ * @{
+ */
+#define RTT_NUMOF           (1)
+#define RTT_FREQUENCY       (1024U)             /* 32768 / 2^n */
+#define RTT_MAX_VALUE       (0x0000ffff)        /* 16-bit timer */
+/** @} */
+
+/**
  * @name    RTC configuration
  * @{
  */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR improves the situation on stm32l0 when using an LSE with RTT:
- it provides and configure the periph_rtt features on b-l072z-lrwan1
- ~it enables LSE on b-l072z-lrwan1 because without it the RTT is very inaccurate (LSI clock speed is at 37kHz and prescalers used by the RTT driver are expecting 32.768kHz as a base)~
- ~it fixes the tests/periph_rtt when using LSE as clock source for the RTT: the alarm interrupt is raised right after setting the alarm because the timer counter is still 0. The idea of the fix is just to wait a bit before exiting the init function. I'm not sure it's the best fix but I found nothing to configure in the reference manual that could avoid this.~

The 3 changes are provided in separate commits to simplify the review.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

The testing procedure can be done on the boards provided by IoT-LAB (assuming your account is in the LoRa group, if not you can ask me, I'll add it):
- Start an experiment on IoT-LAB:
```
$ iotlab-experiment -n test -d 60 -l 1,site=saclay+archi=st-lrwan1:sx1276
$ iotlab-experiment wait
```
- Build/flash/test the `tests/periph_rtt` application:
```
$ make BOARD=b-l072z-lrwan1 IOTLAB_NODE=auto-ssh -C tests/periph_rtt flash test
```
~The test should succeed.~ The test fails because the low-speed clock is very inaccurate. We would need CLOCK_LSE to improve this. The LSE change is done in #11304.


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
