### PR TITLE
 isrpipe: split isrpipe_read_timeout to isolate xtimer dependency 

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -405,6 +405,11 @@ ifneq (,$(filter isrpipe,$(USEMODULE)))
   USEMODULE += tsrb
 endif
 
+ifneq (,$(filter isrpipe_read_timeout,$(USEMODULE)))
+  USEMODULE += isrpipe
+  USEMODULE += xtimer
+endif
+
 ifneq (,$(filter shell_commands,$(USEMODULE)))
   ifneq (,$(filter fib,$(USEMODULE)))
     USEMODULE += posix_inet

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -32,7 +32,6 @@ endif
 ifneq (,$(filter at,$(USEMODULE)))
   FEATURES_REQUIRED += periph_uart
   USEMODULE += fmt
-  USEMODULE += xtimer
   USEMODULE += isrpipe
   USEMODULE += isrpipe_read_timeout
 endif

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -34,6 +34,7 @@ ifneq (,$(filter at,$(USEMODULE)))
   USEMODULE += fmt
   USEMODULE += xtimer
   USEMODULE += isrpipe
+  USEMODULE += isrpipe_read_timeout
 endif
 
 ifneq (,$(filter at30tse75x,$(USEMODULE)))

--- a/drivers/at/at.c
+++ b/drivers/at/at.c
@@ -12,6 +12,7 @@
 #include "at.h"
 #include "fmt.h"
 #include "isrpipe.h"
+#include "isrpipe/read_timeout.h"
 #include "periph/uart.h"
 #include "xtimer.h"
 

--- a/drivers/at/at.c
+++ b/drivers/at/at.c
@@ -14,7 +14,6 @@
 #include "isrpipe.h"
 #include "isrpipe/read_timeout.h"
 #include "periph/uart.h"
-#include "xtimer.h"
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -4,6 +4,9 @@ endif
 ifneq (,$(filter eepreg,$(USEMODULE)))
   DIRS += eepreg
 endif
+ifneq (,$(filter isrpipe_read_timeout,$(USEMODULE)))
+  DIRS += isrpipe/read_timeout
+endif
 ifneq (,$(filter posix_inet,$(USEMODULE)))
   DIRS += posix/inet
 endif

--- a/sys/include/isrpipe.h
+++ b/sys/include/isrpipe.h
@@ -75,40 +75,6 @@ int isrpipe_write_one(isrpipe_t *isrpipe, char c);
  */
 int isrpipe_read(isrpipe_t *isrpipe, char *buf, size_t count);
 
-/**
- * @brief   Read data from isrpipe (with timeout, blocking)
- *
- * Currently, the timeout parameter is applied on every underlying read, which
- * might be *per single byte*.
- *
- * @note This function might return less than @p count bytes
- *
- * @param[in]   isrpipe    isrpipe object to operate on
- * @param[in]   buf        buffer to write to
- * @param[in]   count      number of bytes to read
- * @param[in]   timeout    timeout in microseconds
- *
- * @returns     number of bytes read
- * @returns     -ETIMEDOUT on timeout
- */
-int isrpipe_read_timeout(isrpipe_t *isrpipe, char *buf, size_t count, uint32_t timeout);
-
-/**
- * @brief   Read data from isrpipe (with timeout, blocking, wait until all read)
- *
- * This function is like @ref isrpipe_read_timeout, but will only return on
- * timeout or when @p count bytes have been received.
- *
- * @param[in]   isrpipe    isrpipe object to operate on
- * @param[in]   buf        buffer to write to
- * @param[in]   count      number of bytes to read
- * @param[in]   timeout    timeout in microseconds
- *
- * @returns     number of bytes read
- * @returns     -ETIMEDOUT on timeout
- */
-int isrpipe_read_all_timeout(isrpipe_t *isrpipe, char *buf, size_t count, uint32_t timeout);
-
 #ifdef __cplusplus
 }
 #endif

--- a/sys/include/isrpipe/read_timeout.h
+++ b/sys/include/isrpipe/read_timeout.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    isr_pipe_read_timeout  Read timeouts with ISR pipe
+ * @ingroup     isr_pipe
+ * @brief       ISR -> userspace pipe with timeout
+ *
+ * @{
+ * @file
+ * @brief       isrpipe read timeout Interface
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ */
+
+#ifndef ISRPIPE_READ_TIMEOUT_H
+#define ISRPIPE_READ_TIMEOUT_H
+
+#include "isrpipe.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Read data from isrpipe (with timeout, blocking)
+ *
+ * Currently, the timeout parameter is applied on every underlying read, which
+ * might be *per single byte*.
+ *
+ * @note This function might return less than @p count bytes
+ *
+ * @param[in]   isrpipe    isrpipe object to operate on
+ * @param[in]   buf        buffer to write to
+ * @param[in]   count      number of bytes to read
+ * @param[in]   timeout    timeout in microseconds
+ *
+ * @returns     number of bytes read
+ * @returns     -ETIMEDOUT on timeout
+ */
+int isrpipe_read_timeout(isrpipe_t *isrpipe, char *buf, size_t count, uint32_t timeout);
+
+/**
+ * @brief   Read data from isrpipe (with timeout, blocking, wait until all read)
+ *
+ * This function is like @ref isrpipe_read_timeout, but will only return on
+ * timeout or when @p count bytes have been received.
+ *
+ * @param[in]   isrpipe    isrpipe object to operate on
+ * @param[in]   buf        buffer to write to
+ * @param[in]   count      number of bytes to read
+ * @param[in]   timeout    timeout in microseconds
+ *
+ * @returns     number of bytes read
+ * @returns     -ETIMEDOUT on timeout
+ */
+int isrpipe_read_all_timeout(isrpipe_t *isrpipe, char *buf, size_t count, uint32_t timeout);
+
+#ifdef __cplusplus
+}
+#endif
+/** @} */
+#endif /* ISRPIPE_READ_TIMEOUT_H */

--- a/sys/isrpipe/isrpipe.c
+++ b/sys/isrpipe/isrpipe.c
@@ -17,10 +17,7 @@
  * @}
  */
 
-#include <errno.h>
-
 #include "isrpipe.h"
-#include "xtimer.h"
 
 void isrpipe_init(isrpipe_t *isrpipe, char *buf, size_t bufsize)
 {
@@ -48,57 +45,4 @@ int isrpipe_read(isrpipe_t *isrpipe, char *buffer, size_t count)
         mutex_lock(&isrpipe->mutex);
     }
     return res;
-}
-
-typedef struct {
-    mutex_t *mutex;
-    int flag;
-} _isrpipe_timeout_t;
-
-static void _cb(void *arg)
-{
-    _isrpipe_timeout_t *_timeout = (_isrpipe_timeout_t *) arg;
-
-    _timeout->flag = 1;
-    mutex_unlock(_timeout->mutex);
-}
-
-int isrpipe_read_timeout(isrpipe_t *isrpipe, char *buffer, size_t count, uint32_t timeout)
-{
-    int res;
-
-    _isrpipe_timeout_t _timeout = { .mutex = &isrpipe->mutex, .flag = 0 };
-
-    xtimer_t timer = { .callback = _cb, .arg = &_timeout };
-
-    xtimer_set(&timer, timeout);
-    while (!(res = tsrb_get(&isrpipe->tsrb, buffer, count))) {
-        mutex_lock(&isrpipe->mutex);
-        if (_timeout.flag) {
-            res = -ETIMEDOUT;
-            break;
-        }
-    }
-
-    xtimer_remove(&timer);
-    return res;
-}
-
-
-int isrpipe_read_all_timeout(isrpipe_t *isrpipe, char *buffer, size_t count, uint32_t timeout)
-{
-    char *pos = buffer;
-
-    while (count) {
-        int res = isrpipe_read_timeout(isrpipe, pos, count, timeout);
-        if (res >= 0) {
-            count -= res;
-            pos += res;
-        }
-        else {
-            return res;
-        }
-    }
-
-    return pos - buffer;
 }

--- a/sys/isrpipe/read_timeout/Makefile
+++ b/sys/isrpipe/read_timeout/Makefile
@@ -1,0 +1,3 @@
+MODULE = isrpipe_read_timeout
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/isrpipe/read_timeout/read_timeout.c
+++ b/sys/isrpipe/read_timeout/read_timeout.c
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     isr_pipe_read_timeout
+ * @{
+ * @file
+ * @brief       ISR -> userspace pipe with timeout implementation
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * @}
+ */
+
+#include <errno.h>
+
+#include "isrpipe/read_timeout.h"
+#include "xtimer.h"
+
+typedef struct {
+    mutex_t *mutex;
+    int flag;
+} _isrpipe_timeout_t;
+
+static void _cb(void *arg)
+{
+    _isrpipe_timeout_t *_timeout = (_isrpipe_timeout_t *) arg;
+
+    _timeout->flag = 1;
+    mutex_unlock(_timeout->mutex);
+}
+
+int isrpipe_read_timeout(isrpipe_t *isrpipe, char *buffer, size_t count, uint32_t timeout)
+{
+    int res;
+
+    _isrpipe_timeout_t _timeout = { .mutex = &isrpipe->mutex, .flag = 0 };
+
+    xtimer_t timer = { .callback = _cb, .arg = &_timeout };
+
+    xtimer_set(&timer, timeout);
+    while (!(res = tsrb_get(&isrpipe->tsrb, buffer, count))) {
+        mutex_lock(&isrpipe->mutex);
+        if (_timeout.flag) {
+            res = -ETIMEDOUT;
+            break;
+        }
+    }
+
+    xtimer_remove(&timer);
+    return res;
+}
+
+
+int isrpipe_read_all_timeout(isrpipe_t *isrpipe, char *buffer, size_t count, uint32_t timeout)
+{
+    char *pos = buffer;
+
+    while (count) {
+        int res = isrpipe_read_timeout(isrpipe, pos, count, timeout);
+        if (res >= 0) {
+            count -= res;
+            pos += res;
+        }
+        else {
+            return res;
+        }
+    }
+
+    return pos - buffer;
+}


### PR DESCRIPTION
### Contribution description

This defines a new 'isrpipe_read_timeout' module that should be used when using
the timeout based function of isrpipe.

This fix the implicit dependency to 'xtimer' that is only needed for the
'_timeout' functions.

It prevents 'stdio_uart' that uses 'isrpipe' to need to depend on xtimer.
This was silently solved at link time for most platforms but not for the
'esp32' for example.

'drivers/at' needed to be updated at the same time to follow the api change.


### Testing procedure

In master, the esp32 actually provides warning when compiling some of the applications regarding the missing `xtimer` symbols. But there are only handled as warnings (https://github.com/RIOT-OS/RIOT/pull/11246)

```
RIOT_CI_BUILD=1 DOCKER="sudo docker" BOARD=esp32-wroom-32 BUILD_IN_DOCKER=1 make -C tests/pkg_cn-cbor/
...
make" -C /data/riotbuild/riotbase/tests/pkg_cn-cbor/bin/pkg/esp32-wroom-32/cn-cbor/src -f /data/riotbuild/riotbase/pkg/cn-cbor/Makefile.cn-cbor
/data/riotbuild/riotbase/tests/pkg_cn-cbor/bin/esp32-wroom-32/isrpipe.a(isrpipe.o): In function `isrpipe_read':
isrpipe.c:(.text+0x84): warning: undefined reference to `_xtimer_set'
isrpipe.c:(.text+0x88): warning: undefined reference to `xtimer_remove'
isrpipe.c:(.text+0xb2): warning: undefined reference to `_xtimer_set'
/data/riotbuild/riotbase/tests/pkg_cn-cbor/bin/esp32-wroom-32/isrpipe.a(isrpipe.o): In function `isrpipe_read_timeout':
```

With this pull request there is no reported error anymore. It also removes all the issues with `isrpipe.c` in https://github.com/RIOT-OS/RIOT/pull/11246


### Issues/PRs references

Part of enabling error at link time for esp https://github.com/RIOT-OS/RIOT/pull/11246
It was found while trying to run the test suite on esp32.