### PR TITLE
net/ble: cleanup doxygen grouping

### DIFF
--- a/pkg/nimble/contrib/include/nimble_riot.h
+++ b/pkg/nimble/contrib/include/nimble_riot.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     pkg_nimble
+ * @ingroup     ble_nimble
  * @{
  *
  * @file

--- a/pkg/nimble/contrib/nimble_riot.c
+++ b/pkg/nimble/contrib/nimble_riot.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     pkg_nimble
+ * @ingroup     ble_nimble
  * @{
  *
  * @file

--- a/pkg/nimble/doc.txt
+++ b/pkg/nimble/doc.txt
@@ -1,10 +1,10 @@
 /**
- * @defgroup pkg_nimble     NimBLE BLE stack
+ * @defgroup ble_nimble NimBLE
  * @ingroup  pkg
- * @ingroup  net
+ * @ingroup  ble
  * @brief    RIOT port of the NimBLE BLE stack
  *
- * This package includes the NimBLE BLE stack to RIOT.
+ * This package includes the RIOT port of the NimBLE BLE stack.
  *
  * @see https://github.com/apache/mynewt-nimble
  */

--- a/sys/include/net/ble.h
+++ b/sys/include/net/ble.h
@@ -7,8 +7,8 @@
  */
 
 /**
- * @defgroup    net_ble BLE defines
- * @ingroup     net
+ * @defgroup    ble_defs Generic BLE defines
+ * @ingroup     ble
  * @brief       General values defined by the BT standard
  * @{
  *

--- a/sys/include/net/bluetil/ad.h
+++ b/sys/include/net/bluetil/ad.h
@@ -7,8 +7,8 @@
  */
 
 /**
- * @defgroup    net_bluetil_ad BLE Advertising Data (AD) Processing
- * @ingroup     net
+ * @defgroup    ble_bluetil_ad BLE Advertising Data (AD) Processing
+ * @ingroup     ble_bluetil
  * @brief       Generic BLE advertising and scan request data processing
  *
  * This module provides functionality for user friendly reading and writing of

--- a/sys/net/ble/bluetil/bluetil_ad/bluetil_ad.c
+++ b/sys/net/ble/bluetil/bluetil_ad/bluetil_ad.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     net_bluetil_ad
+ * @ingroup     ble_bluetil_ad
  * @{
  *
  * @file

--- a/sys/net/ble/bluetil/doc.txt
+++ b/sys/net/ble/bluetil/doc.txt
@@ -1,0 +1,7 @@
+/**
+@defgroup    ble_bluetil Bluetil
+@ingroup     ble
+@brief       Collection of generic BLE utility modules
+
+
+*/

--- a/sys/net/ble/doc.txt
+++ b/sys/net/ble/doc.txt
@@ -1,0 +1,5 @@
+/**
+@defgroup    ble Bluetooth Low Energy (BLE)
+@ingroup     net
+@brief       Bluetooth Low Energy (BLE) support for RIOT
+*/


### PR DESCRIPTION
### Contribution description
This PR adds some more structure to the doxygen grouping of the 'BLE subsystem'. Now all BLE groups are subgroups of a global `ble` (EDIT) doxygen group.

### Testing procedure
Compile a verify doxygen html output

### Issues/PRs references
none