### PR TITLE
 Makefile.include: add a 'test/available' target

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -569,13 +569,17 @@ reset:
 	$(call check_cmd,$(RESET),Reset program)
 	$(RESET) $(RESET_FLAGS)
 
-.PHONY: test
+.PHONY: test test/available
 TESTS ?= $(foreach file,$(wildcard $(APPDIR)/tests/*),\
                         $(shell test -f $(file) -a -x $(file) && echo $(file)))
 test: $(TEST_DEPS)
 	$(Q) for t in $(TESTS); do \
 		$$t || exit 1; \
 	done
+
+test/available:
+	$(Q)test -n "$(strip $(TESTS))"
+
 
 # Default OBJDUMPFLAGS for platforms which do not specify it:
 OBJDUMPFLAGS ?= -S -D -h

--- a/Makefile.include
+++ b/Makefile.include
@@ -569,6 +569,7 @@ reset:
 	$(call check_cmd,$(RESET),Reset program)
 	$(RESET) $(RESET_FLAGS)
 
+.PHONY: test
 TESTS ?= $(foreach file,$(wildcard $(APPDIR)/tests/*),\
                         $(shell test -f $(file) -a -x $(file) && echo $(file)))
 test: $(TEST_DEPS)

--- a/tests/README.md
+++ b/tests/README.md
@@ -20,3 +20,10 @@ testing.
 From the test application directory run:
 
     BOARD=<board_of_your_choice> make flash test
+
+
+An automated way of knowing if a test is available is to execute the
+'test/available' target from the test application directory.
+It executes without error if tests run by 'make test' are present.
+
+    make test/available


### PR DESCRIPTION
### Contribution description

This allows querying the build system if there are test available.

Before, one should rely on 'info-debug-variable-TESTS' to print the list
of test files. But was not reliable as sometime the build system printed
messages anyway.

    BOARD=esp32-wroom-32 make --silent --no-print-directory \
        -C examples/hello-world/ info-debug-variable-TESTS
    ESP32_SDK_DIR should be defined as /path/to/esp-idf directory
    ESP32_SDK_DIR is set by default to /opt/esp/esp-idf
    # empty line here

I used the `test/available` pattern as I am thinking about defining new `test-manual` or `test-root` targets and wanted a pattern that would also work for these ones.

This pull request also updates `compile_and_test_for_board.py` to use this target and allow overwriting them as it would make sense when changing `--test-targets`


### Testing procedure

No test in `hello-world`
```
make --no-print-directory -C examples/hello-world/ test/available
/home/harter/work/git/worktree/riot_test/examples/hello-world/../../Makefile.include:581: recipe for target 'test/available' failed
make: *** [test/available] Error 1
```
Test in `bloom_bytes`
```
make --no-print-directory -C tests/bloom_bytes/ test/available
# Nothing and returncode 0
```

#### Testing `compile_and_test_for_board.py`

No test found when using the `esp32-wroom-32` anymore when there is not test

```
 BUILD_IN_DOCKER=1 DOCKER="sudo docker" ./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py . esp32-wroom-32 --applications=examples/hello-world 
INFO:esp32-wroom-32:Saving toolchain
INFO:esp32-wroom-32.examples/hello-world:Board supported: True
INFO:esp32-wroom-32.examples/hello-world:Board has enough memory: True
INFO:esp32-wroom-32.examples/hello-world:Run compilation
INFO:esp32-wroom-32.examples/hello-world:Success
INFO:esp32-wroom-32:Tests successful
```

In master it was finding a test when there was none.

```
INFO:esp32-wroom-32:Saving toolchain
INFO:esp32-wroom-32.examples/hello-world:Board supported: True
INFO:esp32-wroom-32.examples/hello-world:Board has enough memory: True
INFO:esp32-wroom-32.examples/hello-world:Run compilation
INFO:esp32-wroom-32.examples/hello-world:Run test
INFO:esp32-wroom-32.examples/hello-world:Run test.flash
...
```


Command can be overwritten with the option, this makes it think there is indeed a test.

```
./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py . native --applications=examples/hello-world --test-available-targets=info-build
INFO:native:Saving toolchain
INFO:native.examples/hello-world:Board supported: True
INFO:native.examples/hello-world:Board has enough memory: True
INFO:native.examples/hello-world:Run compilation
INFO:native.examples/hello-world:Run test
INFO:native.examples/hello-world:Run test.flash
INFO:native.examples/hello-world:Success
INFO:native:Tests successful
```

#### tox test suite

    cd dist/tools/compile_and_test_for_board/
    tox
    # executes without errors
### Issues/PRs references

It was found while trying to run the test suite on esp32.