### PR TITLE
cpu/esp32: additional _ removed from __uart_* in static symbols

### DIFF
--- a/cpu/esp32/periph/uart.c
+++ b/cpu/esp32/periph/uart.c
@@ -217,7 +217,7 @@ void uart_print_config(void)
     }
 }
 
-void IRAM _uart_intr_handler (void *arg)
+static void IRAM _uart_intr_handler (void *arg)
 {
     /* to satisfy the compiler */
     (void)arg;

--- a/cpu/esp32/periph/uart.c
+++ b/cpu/esp32/periph/uart.c
@@ -61,7 +61,7 @@ struct uart_hw_t {
 };
 
 /* hardware ressources */
-static struct uart_hw_t __uarts[] = {
+static struct uart_hw_t _uarts[] = {
     {
         .regs = &UART0,
         .pin_txd = GPIO1,
@@ -100,50 +100,50 @@ static struct uart_hw_t __uarts[] = {
 extern void uart_div_modify(uint8_t uart_no, uint32_t div);
 
 /* forward declaration of internal functions */
-static uint8_t IRAM __uart_rx_one_char (uart_t uart);
-static void __uart_tx_one_char(uart_t uart, uint8_t data);
-static void __uart_intr_enable (uart_t uart);
-static void IRAM __uart_intr_handler (void *para);
+static uint8_t IRAM _uart_rx_one_char (uart_t uart);
+static void _uart_tx_one_char(uart_t uart, uint8_t data);
+static void _uart_intr_enable (uart_t uart);
+static void IRAM _uart_intr_handler (void *para);
 
-void __uart_config (uart_t uart)
+void _uart_config (uart_t uart)
 {
     CHECK_PARAM (uart < UART_NUMOF);
 
     /* setup the baudrate */
     if (uart == UART_DEV(0) || uart == UART_DEV(1)) {
         /* for UART0 and UART1, we can us the ROM function */
-        uart_div_modify(uart, (UART_CLK_FREQ << 4) / __uarts[uart].baudrate);
+        uart_div_modify(uart, (UART_CLK_FREQ << 4) / _uarts[uart].baudrate);
     }
     else {
         /* for UART2, we have to control it by registers */
-        __uarts[uart].regs->conf0.tick_ref_always_on = 1; /* use APB_CLK */
+        _uarts[uart].regs->conf0.tick_ref_always_on = 1; /* use APB_CLK */
         /* compute and set the integral and the decimal part */
-        uint32_t clk = (UART_CLK_FREQ << 4) / __uarts[uart].baudrate;
-        __uarts[uart].regs->clk_div.div_int  = clk >> 4;
-        __uarts[uart].regs->clk_div.div_frag = clk & 0xf;
+        uint32_t clk = (UART_CLK_FREQ << 4) / _uarts[uart].baudrate;
+        _uarts[uart].regs->clk_div.div_int  = clk >> 4;
+        _uarts[uart].regs->clk_div.div_frag = clk & 0xf;
     }
 
     /* set 8 data bits */
-    __uarts[uart].regs->conf0.bit_num = 3;
+    _uarts[uart].regs->conf0.bit_num = 3;
     /* reset the FIFOs */
-    __uarts[uart].regs->conf0.rxfifo_rst = 1;
-    __uarts[uart].regs->conf0.rxfifo_rst = 0;
-    __uarts[uart].regs->conf0.txfifo_rst = 1;
-    __uarts[uart].regs->conf0.txfifo_rst = 0;
+    _uarts[uart].regs->conf0.rxfifo_rst = 1;
+    _uarts[uart].regs->conf0.rxfifo_rst = 0;
+    _uarts[uart].regs->conf0.txfifo_rst = 1;
+    _uarts[uart].regs->conf0.txfifo_rst = 0;
 
-    if (__uarts[uart].isr_ctx.rx_cb) {
+    if (_uarts[uart].isr_ctx.rx_cb) {
         /* since reading can only be done byte by byte, we set
            UART_RXFIFO_FULL_THRHD interrupt level to 1 byte */
-        __uarts[uart].regs->conf1.rxfifo_full_thrhd = 1;
+        _uarts[uart].regs->conf1.rxfifo_full_thrhd = 1;
 
         /* enable the RX FIFO FULL interrupt */
-        __uart_intr_enable (uart);
+        _uart_intr_enable (uart);
 
         /* route all UART interrupt sources to same the CPU interrupt */
-        intr_matrix_set(PRO_CPU_NUM, __uarts[uart].int_src, CPU_INUM_UART);
+        intr_matrix_set(PRO_CPU_NUM, _uarts[uart].int_src, CPU_INUM_UART);
 
         /* we have to enable therefore the CPU interrupt here */
-        xt_set_interrupt_handler(CPU_INUM_UART, __uart_intr_handler, NULL);
+        xt_set_interrupt_handler(CPU_INUM_UART, _uart_intr_handler, NULL);
         xt_ints_on(BIT(CPU_INUM_UART));
     }
 }
@@ -158,36 +158,36 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
     if (uart == UART_DEV(1) || uart == UART_DEV(2)) {
 
         /* reset the pins when they were already used as UART pins */
-        if (gpio_get_pin_usage(__uarts[uart].pin_txd) == _UART) {
-            gpio_set_pin_usage(__uarts[uart].pin_txd, _GPIO);
+        if (gpio_get_pin_usage(_uarts[uart].pin_txd) == _UART) {
+            gpio_set_pin_usage(_uarts[uart].pin_txd, _GPIO);
         }
-        if (gpio_get_pin_usage(__uarts[uart].pin_rxd) == _UART) {
-            gpio_set_pin_usage(__uarts[uart].pin_rxd, _GPIO);
+        if (gpio_get_pin_usage(_uarts[uart].pin_rxd) == _UART) {
+            gpio_set_pin_usage(_uarts[uart].pin_rxd, _GPIO);
         }
 
         /* try to initialize the pins as GPIOs first */
-        if (gpio_init (__uarts[uart].pin_txd, GPIO_OUT) ||
-            gpio_init (__uarts[uart].pin_rxd, GPIO_IN)) {
+        if (gpio_init (_uarts[uart].pin_txd, GPIO_OUT) ||
+            gpio_init (_uarts[uart].pin_rxd, GPIO_IN)) {
             return -1;
         }
 
         /* store the usage type in GPIO table */
-        gpio_set_pin_usage(__uarts[uart].pin_txd, _UART);
-        gpio_set_pin_usage(__uarts[uart].pin_rxd, _UART);
+        gpio_set_pin_usage(_uarts[uart].pin_txd, _UART);
+        gpio_set_pin_usage(_uarts[uart].pin_rxd, _UART);
 
         /* connect TxD pin to the TxD output signal through the GPIO matrix */
-        GPIO.func_out_sel_cfg[__uarts[uart].pin_txd].func_sel = __uarts[uart].signal_txd;
+        GPIO.func_out_sel_cfg[_uarts[uart].pin_txd].func_sel = _uarts[uart].signal_txd;
 
         /* connect RxD input signal to the RxD pin through the GPIO matrix */
-        GPIO.func_in_sel_cfg[__uarts[uart].signal_rxd].sig_in_sel = 1;
-        GPIO.func_in_sel_cfg[__uarts[uart].signal_rxd].sig_in_inv = 0;
-        GPIO.func_in_sel_cfg[__uarts[uart].signal_rxd].func_sel = __uarts[uart].pin_rxd;
+        GPIO.func_in_sel_cfg[_uarts[uart].signal_rxd].sig_in_sel = 1;
+        GPIO.func_in_sel_cfg[_uarts[uart].signal_rxd].sig_in_inv = 0;
+        GPIO.func_in_sel_cfg[_uarts[uart].signal_rxd].func_sel = _uarts[uart].pin_rxd;
     }
-    __uarts[uart].baudrate = baudrate;
+    _uarts[uart].baudrate = baudrate;
 
     /* register interrupt context */
-    __uarts[uart].isr_ctx.rx_cb = rx_cb;
-    __uarts[uart].isr_ctx.arg   = arg;
+    _uarts[uart].isr_ctx.rx_cb = rx_cb;
+    _uarts[uart].isr_ctx.arg   = arg;
 
     /* enable and configure the according UART module */
     uart_poweron(uart);
@@ -200,7 +200,7 @@ void uart_write(uart_t uart, const uint8_t *data, size_t len)
     CHECK_PARAM (uart < UART_NUMOF);
 
     for (size_t i = 0; i < len; i++) {
-        __uart_tx_one_char(uart, data[i]);
+        _uart_tx_one_char(uart, data[i]);
     }
 }
 
@@ -209,17 +209,17 @@ void uart_poweron (uart_t uart)
     switch (uart) {
         #if UART_NUMOF
         case 0:  periph_module_enable(PERIPH_UART0_MODULE);
-                 __uart_config(uart);
+                 _uart_config(uart);
                  break;
         #endif
         #if UART_NUMOF > 1
         case 1:  periph_module_enable(PERIPH_UART1_MODULE);
-                 __uart_config(uart);
+                 _uart_config(uart);
                  break;
         #endif
         #if UART_NUMOF > 2
         case 2:  periph_module_enable(PERIPH_UART2_MODULE);
-                 __uart_config(uart);
+                 _uart_config(uart);
                  break;
         #endif
         default: break;
@@ -242,7 +242,7 @@ void uart_poweroff (uart_t uart)
     }
 }
 
-void IRAM __uart_intr_handler (void *arg)
+void IRAM _uart_intr_handler (void *arg)
 {
     /* to satisfy the compiler */
     (void)arg;
@@ -252,23 +252,23 @@ void IRAM __uart_intr_handler (void *arg)
     /* UART0, UART1, UART2 peripheral interrupt sources are routed to the same
        interrupt, so we have to use the status to distinguish interruptees */
     for (unsigned uart = 0; uart < UART_NUMOF; uart++) {
-        if (__uarts[uart].used) {
+        if (_uarts[uart].used) {
             DEBUG("%s uart=%d int_st=%08x\n", __func__,
-                  uart, __uarts[uart].regs->int_st.val);
+                  uart, _uarts[uart].regs->int_st.val);
 
-            if (__uarts[uart].used && __uarts[uart].regs->int_st.rxfifo_full) {
+            if (_uarts[uart].used && _uarts[uart].regs->int_st.rxfifo_full) {
                 /* read one byte of data */
-                uint8_t data = __uart_rx_one_char (uart);
+                uint8_t data = _uart_rx_one_char (uart);
                 /* if registered, call the RX callback function */
-                if (__uarts[uart].isr_ctx.rx_cb) {
-                    __uarts[uart].isr_ctx.rx_cb(__uarts[uart].isr_ctx.arg, data);
+                if (_uarts[uart].isr_ctx.rx_cb) {
+                    _uarts[uart].isr_ctx.rx_cb(_uarts[uart].isr_ctx.arg, data);
                 }
                 /* clear interrupt flag */
-                __uarts[uart].regs->int_clr.rxfifo_full = 1;
+                _uarts[uart].regs->int_clr.rxfifo_full = 1;
             }
 
             /* TODO handle other types of interrupts, for the moment just clear them */
-            __uarts[uart].regs->int_clr.val = ~0x0;
+            _uarts[uart].regs->int_clr.val = ~0x0;
         }
     }
 
@@ -279,32 +279,32 @@ void IRAM __uart_intr_handler (void *arg)
 #define UART_FIFO_MAX 127
 
 /* receive one data byte with wait */
-static uint8_t IRAM __uart_rx_one_char (uart_t uart)
+static uint8_t IRAM _uart_rx_one_char (uart_t uart)
 {
     /* wait until at least von byte is in RX FIFO */
-    while (!__uarts[uart].regs->status.rxfifo_cnt) {}
+    while (!_uarts[uart].regs->status.rxfifo_cnt) {}
 
     /* read the lowest byte from RX FIFO register */
-    return __uarts[uart].regs->fifo.rw_byte;
+    return _uarts[uart].regs->fifo.rw_byte;
 }
 
 /* send one data byte with wait */
-static void __uart_tx_one_char(uart_t uart, uint8_t data)
+static void _uart_tx_one_char(uart_t uart, uint8_t data)
 {
     /* wait until at least one byte is avaiable in the TX FIFO */
-    while (__uarts[uart].regs->status.txfifo_cnt >= UART_FIFO_MAX) {}
+    while (_uarts[uart].regs->status.txfifo_cnt >= UART_FIFO_MAX) {}
 
     /* send the byte by placing it in the TX FIFO using MPU */
     WRITE_PERI_REG(UART_FIFO_AHB_REG(uart), data);
 }
 
-static void __uart_intr_enable(uart_t uart)
+static void _uart_intr_enable(uart_t uart)
 {
-    __uarts[uart].regs->int_ena.rxfifo_full = 1;
-    __uarts[uart].regs->int_clr.rxfifo_full = 1;
-    __uarts[uart].used = true;
+    _uarts[uart].regs->int_ena.rxfifo_full = 1;
+    _uarts[uart].regs->int_clr.rxfifo_full = 1;
+    _uarts[uart].used = true;
 
-    DEBUG("%s %08x\n", __func__, __uarts[uart].regs->int_ena.val);
+    DEBUG("%s %08x\n", __func__, _uarts[uart].regs->int_ena.val);
 }
 
 /* systemwide UART initializations */
@@ -312,7 +312,7 @@ void uart_system_init (void)
 {
     for (unsigned uart = 0; uart < UART_NUMOF; uart++) {
         /* reset all UART interrupt status registers */
-        __uarts[uart].regs->int_clr.val = ~0;
+        _uarts[uart].regs->int_clr.val = ~0;
     }
 }
 
@@ -320,7 +320,7 @@ void uart_print_config(void)
 {
     for (unsigned uart = 0; uart < UART_NUMOF; uart++) {
         ets_printf("\tUART_DEV(%d)\ttxd=%d rxd=%d\n", uart,
-                   __uarts[uart].pin_txd, __uarts[uart].pin_rxd);
+                   _uarts[uart].pin_txd, _uarts[uart].pin_rxd);
     }
 }
 
@@ -331,11 +331,11 @@ int uart_set_baudrate(uart_t uart, uint32_t baudrate)
     CHECK_PARAM_RET (uart < UART_NUMOF, -1);
 
     /* use APB_CLK */
-    __uarts[uart].regs->conf0.tick_ref_always_on = 1;
+    _uarts[uart].regs->conf0.tick_ref_always_on = 1;
     /* compute and set the integral and the decimal part */
     uint32_t clk = (UART_CLK_FREQ << 4) / baudrate;
-    __uarts[uart].regs->clk_div.div_int  = clk >> 4;
-    __uarts[uart].regs->clk_div.div_frag = clk & 0xf;
+    _uarts[uart].regs->clk_div.div_int  = clk >> 4;
+    _uarts[uart].regs->clk_div.div_frag = clk & 0xf;
 
     return UART_OK;
 }

--- a/cpu/esp32/periph/uart.c
+++ b/cpu/esp32/periph/uart.c
@@ -200,6 +200,23 @@ void uart_poweroff (uart_t uart)
     }
 }
 
+/* systemwide UART initializations */
+void uart_system_init (void)
+{
+    for (unsigned uart = 0; uart < UART_NUMOF; uart++) {
+        /* reset all UART interrupt status registers */
+        _uarts[uart].regs->int_clr.val = ~0;
+    }
+}
+
+void uart_print_config(void)
+{
+    for (unsigned uart = 0; uart < UART_NUMOF; uart++) {
+        ets_printf("\tUART_DEV(%d)\ttxd=%d rxd=%d\n", uart,
+                   _uarts[uart].pin_txd, _uarts[uart].pin_rxd);
+    }
+}
+
 void IRAM _uart_intr_handler (void *arg)
 {
     /* to satisfy the compiler */
@@ -304,23 +321,6 @@ static void _uart_config (uart_t uart)
         /* we have to enable therefore the CPU interrupt here */
         xt_set_interrupt_handler(CPU_INUM_UART, _uart_intr_handler, NULL);
         xt_ints_on(BIT(CPU_INUM_UART));
-    }
-}
-
-/* systemwide UART initializations */
-void uart_system_init (void)
-{
-    for (unsigned uart = 0; uart < UART_NUMOF; uart++) {
-        /* reset all UART interrupt status registers */
-        _uarts[uart].regs->int_clr.val = ~0;
-    }
-}
-
-void uart_print_config(void)
-{
-    for (unsigned uart = 0; uart < UART_NUMOF; uart++) {
-        ets_printf("\tUART_DEV(%d)\ttxd=%d rxd=%d\n", uart,
-                   _uarts[uart].pin_txd, _uarts[uart].pin_rxd);
     }
 }
 


### PR DESCRIPTION
### Contribution description

This PR removes the additional _ for static symbols that has been added by mistake. This will make future merging with the reimplementation of ESP8266 easier.

### Testing procedure

Successful compilation of application `tests/uart` should be enough.

If it more testing is required, compile and flash the `tests/uart` application for a board that defines `UART_DEV(1)`, e.g., `esp32-wroom-32`:
```
make BOARD=esp32-wroom-32 -C tests/periph_uart flash
```
Connect GPIO9 and GPIO10 and execute the following test in terminal program
```
init 1 9600
send 1 test
```
You should be able to observe the following output:
```
> init 1 9600
Success: Initialized UART_DEV(1) at BAUD 9600
UARD_DEV(1): test uart_poweron() and uart_poweroff()  ->  [OK]
> 
> send 1 test
UART_DEV(1) TX: test
> 
> Success: UART_DEV(1) RX: [test]\n
```

### Issues/PRs references