### PR TITLE
ble/nimble: add address helper submodule

### DIFF
--- a/pkg/nimble/Makefile
+++ b/pkg/nimble/Makefile
@@ -64,4 +64,7 @@ nimble_controller:
 nimble_drivers_nrf52:
 	"$(MAKE)" -C $(PDIR)/nimble/drivers/nrf52/src/ -f $(TDIR)/drivers.nrf52.mk
 
+# additional, RIOT specific nimble modules
+nimble_addr:
+	"$(MAKE)" -C $(TDIR)/addr/
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/nimble/Makefile.dep
+++ b/pkg/nimble/Makefile.dep
@@ -30,3 +30,7 @@ ifneq (,$(filter nimble_controller,$(USEMODULE)))
     USEMODULE += nimble_drivers_nrf52
   endif
 endif
+
+ifneq (,$(filter nimble_addr,$(USEMODULE)))
+  USEMODULE += bluetil_addr
+endif

--- a/pkg/nimble/Makefile.include
+++ b/pkg/nimble/Makefile.include
@@ -68,3 +68,8 @@ endif
 ifneq (,$(filter nimble_svc_tps,$(USEMODULE)))
   INCLUDES += $(NIMIBASE)/nimble/host/services/tps/include
 endif
+
+# include additional headers for RIOT specific NimBLE submodules
+ifneq (,$(filter nimble_addr,$(USEMODULE)))
+  INCLUDES += -I$(RIOTPKG)/nimble/addr/include
+endif

--- a/pkg/nimble/addr/Makefile
+++ b/pkg/nimble/addr/Makefile
@@ -1,0 +1,3 @@
+MODULE = nimble_addr
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/nimble/addr/include/nimble_addr.h
+++ b/pkg/nimble/addr/include/nimble_addr.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2019 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    ble_nimble_addr Address helper for NimBLE
+ * @ingroup     ble_nimble
+ * @brief       NimBLE specific helper functions for handling addresses
+ * @{
+ *
+ * @file
+ * @brief       Interface for NimBLE specific address helper functions
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ */
+
+#ifndef NIMBLE_ADDR_H
+#define NIMBLE_ADDR_H
+
+#include "nimble/ble.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Length of an address string in byte, including `\0` termination
+ */
+#define NIMBLE_ADDR_STRLEN          (28U)
+
+/**
+ * @brief   Print the given address on STDIO
+ *
+ * @param[in] addr      address to print
+ */
+void nimble_addr_print(const ble_addr_t *addr);
+
+/**
+ * @brief   Write the string representation of the given address into a buffer
+ *
+ * The resulting string written to @p buf is `\0` terminated and is always
+ * 28 bytes (NIMBLE_ADDR_STRLEN) long.
+ *
+ * @param[out] buf      buffer
+ * @param[in] addr      addre to convert
+ */
+void nimble_addr_sprint(char *buf, const ble_addr_t *addr);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NIMBLE_ADDR_H */
+/** @} */

--- a/pkg/nimble/addr/nimble_addr.c
+++ b/pkg/nimble/addr/nimble_addr.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2019 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     ble_nimble_addr
+ * @{
+ *
+ * @file
+ * @brief       NimBLE specific BLE address helper functions
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "nimble_addr.h"
+#include "net/bluetil/addr.h"
+
+void nimble_addr_print(const ble_addr_t *addr)
+{
+    char tmp[NIMBLE_ADDR_STRLEN];
+    nimble_addr_sprint(tmp, addr);
+    printf("%s", tmp);
+}
+
+void nimble_addr_sprint(char *buf, const ble_addr_t *addr)
+{
+    bluetil_addr_sprint(buf, addr->val);
+    const char *type;
+    switch (addr->type) {
+        case BLE_ADDR_PUBLIC:       type = " (public) "; break;
+        case BLE_ADDR_RANDOM:       type = " (random) "; break;
+        case BLE_ADDR_PUBLIC_ID:    type = " (id_pub) "; break;
+        case BLE_ADDR_RANDOM_ID:    type = " (id_rand)"; break;
+        default:                    type = " (unknown)"; break;
+    }
+    memcpy(&buf[BLUETIL_ADDR_STRLEN - 1], type, 10);
+    buf[BLUETIL_ADDR_STRLEN - 1] = '\0';
+}


### PR DESCRIPTION
### Contribution description
NimBLE has its own internal address type (including a 7th byte marking type of the BT address). This PR adds a shared submodule for printing this address into a buffer or to STDIO. This is mainly useful for debugging and shell purposes.

### Testing procedure
The best you can do is probably a build test by adding `USEMODULE += nimble_addr` to the `examples/nimble_gatt` example's Makefile.

EDIT: this PR is now testable through #11281

### Issues/PRs references
depends and is rebased on #11271