### PR TITLE
pkg/tinydtls: Update repository URL to new location, fix posix_sockets 

### DIFF
--- a/pkg/tinydtls/Makefile
+++ b/pkg/tinydtls/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=tinydtls
-PKG_URL=https://git.eclipse.org/r/tinydtls/org.eclipse.tinydtls
-PKG_VERSION=84f1f4e3ca13101a5a9aedeaf08039636c4f34dd
+PKG_URL=https://github.com/eclipse/tinydtls.git
+PKG_VERSION=dcac93f1b38e74f0a57b5df47647943f3df005c2
 PKG_LICENSE=EPL-1.0,EDL-1.0
 
 CFLAGS += -Wno-implicit-fallthrough

--- a/pkg/tinydtls/Makefile.include
+++ b/pkg/tinydtls/Makefile.include
@@ -14,7 +14,7 @@ ifneq (,$(filter tinydtls,$(USEMODULE)))
   # Dependencies partially under control of the App's requirements
 
   # The configuration for socket overrides Sock
-  ifeq (,$(filter WITH_RIOT_SOCKETS,$(CFLAGS)))
+  ifeq (,$(filter posix_sockets,$(USEMODULE)))
     CFLAGS += -DWITH_RIOT_GNRC
   endif
 


### PR DESCRIPTION
[tinydtls](https://projects.eclipse.org/projects/iot.tinydtls) has moved [its source repository](https://github.com/eclipse/tinydtls) to GitHub. This change therefore updates the `PKG_URL` for package tinydtls and the `PKG_VERSION` to the HEAD of the development branch. (Note that there is no official stable release for tinydtls yet and the development branch contains the entire RIOT support.)

The second change in this PR fixes the configuration for `posix_sockets` as the existing CFLAGS-based method did not work.