### PR TITLE
stm32_common/i2c_2: fix unused *i2c when no DEVELHELP

### DIFF
--- a/cpu/stm32_common/periph/i2c_2.c
+++ b/cpu/stm32_common/periph/i2c_2.c
@@ -79,9 +79,7 @@ void i2c_init(i2c_t dev)
 
     mutex_init(&locks[dev]);
 
-    I2C_TypeDef *i2c = i2c_config[dev].dev;
-
-    assert(i2c != NULL);
+    assert(i2c_config[dev].dev != NULL);
 
     periph_clk_en(i2c_config[dev].bus, i2c_config[dev].rcc_mask);
     NVIC_SetPriority(i2c_config[dev].irqn, I2C_IRQ_PRIO);
@@ -91,9 +89,9 @@ void i2c_init(i2c_t dev)
 
 #if defined(CPU_FAM_STM32F4)
     /* make sure the analog filters don't hang -> see errata sheet 2.14.7 */
-    if (i2c->SR2 & I2C_SR2_BUSY) {
+    if (i2c_config[dev].dev->SR2 & I2C_SR2_BUSY) {
         /* disable peripheral */
-        i2c->CR1 &= ~I2C_CR1_PE;
+        i2c_config[dev].dev->CR1 &= ~I2C_CR1_PE;
         /* toggle both pins to reset analog filter */
         gpio_init(i2c_config[dev].scl_pin, GPIO_OD);
         gpio_init(i2c_config[dev].sda_pin, GPIO_OD);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR fixes an error when compiling for boards that use stm32_common/periph/i2c_2.c without using DEVELHELP, since assert is optimized out there is a unused I2C_TypeDef * i2c pointer.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Without this PR:

` make -C tests/periph_i2c/ BOARD=nucleo-l152re DEVELHELP=0`

throws this error:

`/home/francisco/workspace/RIOT/cpu/stm32_common/periph/i2c_2.c:82:18: error: unused variable 'i2c' [-Werror=unused-variable]
     I2C_TypeDef *i2c = i2c_config[dev].dev;`

With this PR:

` make -C tests/periph_i2c/ BOARD=nucleo-l152re DEVELHELP=0`

Compiles Fine

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
