### PR TITLE
ble/nimble: fix missing stdint incl in riot_nimble

### DIFF
--- a/pkg/nimble/contrib/include/nimble_riot.h
+++ b/pkg/nimble/contrib/include/nimble_riot.h
@@ -19,6 +19,8 @@
 #ifndef NIMBLE_RIOT_H
 #define NIMBLE_RIOT_H
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
### Contribution description
Through some changes in include chains i stumbled upon compile issues because of missing `<stdint>` include in `nimble_riot.h` (unknown type `uint8_t`). This fixes that.

### Testing procedure
Murdock will tell. Also this change can by definition not break anything...

### Issues/PRs references
none