### PR TITLE
sam0_common: Fix syntax mistake in usbdev driver

### DIFF
--- a/cpu/sam0_common/periph/usbdev.c
+++ b/cpu/sam0_common/periph/usbdev.c
@@ -457,7 +457,7 @@ static void _ep_enable(usbdev_ep_t *ep)
         case USB_EP_TYPE_INTERRUPT:
             type = 0x04;
             break;
-        case default:
+        default:
             /* Must never happen */
             assert(false);
     }


### PR DESCRIPTION
### Contribution description

At the very last moment I put a small syntax error in the sam0_common usbdev driver

### Issues/PRs references

fixes a syntax error introduced in #10915 
