### PR TITLE
makefiles/boot/riotboot.mk: fix unrelated introduced change

### DIFF
--- a/makefiles/boot/riotboot.mk
+++ b/makefiles/boot/riotboot.mk
@@ -112,7 +112,7 @@ riotboot/flash-extended-slot0: $(RIOTBOOT_EXTENDED_BIN) $(FLASHDEPS)
 # Flashing rule for slot 0
 riotboot/flash-slot0: export IMAGE_OFFSET=$(SLOT0_OFFSET)
 # openocd
-riotboot/flash-slot1: ELFFILE=$(SLOT1_RIOT_BIN)
+riotboot/flash-slot0: ELFFILE=$(SLOT0_RIOT_BIN)
 riotboot/flash-slot0: FLASHFILE=$(SLOT0_RIOT_BIN)
 riotboot/flash-slot0: $(SLOT0_RIOT_BIN) $(FLASHDEPS)
 	$(flash-recipe)


### PR DESCRIPTION
### Contribution description

This change was introduced by mistake by the `edbg` refactoring. This
restores the original value for openocd.

### Testing procedure


This fixes `tests/riotboot_flashwrite`  when called with `riotboot/flash-slot0`:

```
BOARD=iotlab-m3 make -C tests/riotboot_flashwrite/ riotboot/flash-slot0 FLASHER=true
true flash /home/harter/work/git/RIOT/tests/riotboot_flashwrite/bin/iotlab-m3/tests_riotboot_flashwrite-slot0.riot.bin

```
in master
```
true flash /home/harter/work/git/RIOT/tests/riotboot_flashwrite/bin/iotlab-m3/tests_riotboot_flashwrite.elf
```

The flashed file for `riotboot/flash-slot0` in `tests/riotboot`was however still correct in `master` due to the `ELFFILE = $(FLASHFILE)` hack to have `make flash` working in `tests/riotboot`.

```
BOARD=iotlab-m3 make -C tests/riotboot riotboot/flash-slot0 FLASHER=true
true flash /home/harter/work/git/RIOT/tests/riotboot/bin/iotlab-m3/tests_riotboot-slot0.riot.bin
```

### Review only:


`git diff 72bc21c0d -- makefiles/boot` should show that now only changes to `HEXFILE` are left

``` diff
diff --git a/makefiles/boot/riotboot.mk b/makefiles/boot/riotboot.mk
index bca34b714..90ad575cb 100644
--- a/makefiles/boot/riotboot.mk
+++ b/makefiles/boot/riotboot.mk
@@ -97,9 +97,6 @@ $(RIOTBOOT_EXTENDED_BIN): $(RIOTBOOT_COMBINED_BIN)
        $(Q)truncate -s $$(($(SLOT0_OFFSET) + $(SLOT0_LEN) + $(RIOTBOOT_HDR_LEN))) $@.tmp
        $(Q)mv $@.tmp $@

-# Flashing rule for edbg to flash combined/extended binaries
-riotboot/flash-combined-slot0: HEXFILE=$(RIOTBOOT_COMBINED_BIN)
-riotboot/flash-extended-slot0: HEXFILE=$(RIOTBOOT_EXTENDED_BIN)
 # Flashing rule for openocd to flash combined/extended binaries
 riotboot/flash-combined-slot0: ELFFILE=$(RIOTBOOT_COMBINED_BIN)
 riotboot/flash-extended-slot0: ELFFILE=$(RIOTBOOT_EXTENDED_BIN)
@@ -114,8 +111,6 @@ riotboot/flash-extended-slot0: $(RIOTBOOT_EXTENDED_BIN) $(FLASHDEPS)

 # Flashing rule for slot 0
 riotboot/flash-slot0: export IMAGE_OFFSET=$(SLOT0_OFFSET)
-# Flashing rule for edbg to flash only slot 0
-riotboot/flash-slot0: HEXFILE=$(SLOT0_RIOT_BIN)
 # openocd
 riotboot/flash-slot0: ELFFILE=$(SLOT0_RIOT_BIN)
 riotboot/flash-slot0: FLASHFILE=$(SLOT0_RIOT_BIN)
@@ -124,8 +119,6 @@ riotboot/flash-slot0: $(SLOT0_RIOT_BIN) $(FLASHDEPS)

 # Flashing rule for slot 1
 riotboot/flash-slot1: export IMAGE_OFFSET=$(SLOT1_OFFSET)
-# Flashing rule for edbg to flash only slot 1
-riotboot/flash-slot1: HEXFILE=$(SLOT1_RIOT_BIN)
 # openocd
 riotboot/flash-slot1: ELFFILE=$(SLOT1_RIOT_BIN)
 riotboot/flash-slot1: FLASHFILE=$(SLOT1_RIOT_BIN)
```

### Issues/PRs references

#11172 when updating edbg
This is to get a proper fix for this issue only without the whole change from https://github.com/RIOT-OS/RIOT/pull/11254 that now also includes this commit.