### PR TITLE
cpu/stm32f103: make gpio B4 usable as output pin

### DIFF
--- a/cpu/stm32f1/periph/gpio.c
+++ b/cpu/stm32f1/periph/gpio.c
@@ -88,6 +88,16 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     /* enable the clock for the selected port */
     periph_clk_en(APB2, (RCC_APB2ENR_IOPAEN << _port_num(pin)));
 
+#ifdef BOARD_NUCLEO_F103RB
+    /* disable the default SWJ RST mode to allow using the pin as IO
+       this may also work on other f103 based boards but it was only tested on
+       nucleo-f103rb */
+    if ((pin_num == 4) && _port_num(pin)) {
+        RCC->APB2ENR |= RCC_APB2ENR_AFIOEN;
+        AFIO->MAPR |= AFIO_MAPR_SWJ_CFG_NOJNTRST;
+    }
+#endif
+
     /* set pin mode */
     port->CR[pin_num >> 3] &= ~(0xf << ((pin_num & 0x7) * 4));
     port->CR[pin_num >> 3] |=  ((mode & MODE_MASK) << ((pin_num & 0x7) * 4));


### PR DESCRIPTION
By default the pin B4 is used as SWJRST making it unusable as IO.
On the stm32-f103rb this pin is actually one of the arduino headers which is problematic for some shields.
THe provided code remaps the pin only when it is initialized with gpio_init.
Currently its only enabled for stm32f104rb

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
run tests/periph_gpio with and without this PR and execute the following commands:
`init_out 1 4`

With this PR the pin goes to 0, without it stays high.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
