### PR TITLE
boards/esp32: changes the approach for configurations of ADC channels in board definitions

### DIFF
--- a/boards/common/esp32/include/periph_conf_common.h
+++ b/boards/common/esp32/include/periph_conf_common.h
@@ -47,6 +47,11 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Static array with declared ADC channels
+ */
+static const gpio_t adc_channels[] = ADC_GPIOS;
+
+/**
  * @brief Number of GPIOs declared as ADC channels
  *
  * The number of GPIOs that are declared as ADC channels is determined from
@@ -54,7 +59,7 @@ extern "C" {
  *
  * @note ADC_NUMOF definition must not be changed.
  */
-#define ADC_NUMOF   (adc_chn_num)
+#define ADC_NUMOF   (sizeof(adc_channels) / sizeof(adc_channels[0]))
 /** @} */
 
 /**

--- a/boards/esp32-olimex-evb/Makefile.features
+++ b/boards/esp32-olimex-evb/Makefile.features
@@ -2,7 +2,9 @@
 include $(RIOTBOARD)/common/esp32/Makefile.features
 
 # additional features provided by the board (no ADC and no DAC)
-FEATURES_PROVIDED += periph_adc
+ifneq (,$(filter olimex_esp32_gateway,$(USEMODULE)))
+    FEATURES_PROVIDED += periph_adc
+endif
 FEATURES_PROVIDED += periph_dac
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm

--- a/cpu/esp32/include/periph_cpu.h
+++ b/cpu/esp32/include/periph_cpu.h
@@ -40,20 +40,83 @@ extern "C" {
 #define CPUID_LEN           (7U)
 
 /**
- * @brief   Available ports on the ESP32
+ * @name   GPIO configuration
  * @{
  */
-#define PORT_GPIO 0       /**< port GPIO */
+
+/**
+ * @brief   Override the default gpio_t type definition
+ *
+ * This is required here to have gpio_t defined in this file.
+ * @{
+ */
+#define HAVE_GPIO_T
+typedef unsigned int gpio_t;
+/** @} */
+
+/**
+ * @brief   Definition of a fitting UNDEF value
+ * @{
+ */
+#define GPIO_UNDEF          (0xffffffff)
+/** @} */
+
+/**
+ * @brief   Define a CPU specific GPIO pin generator macro
+ * @{
+ */
+#define GPIO_PIN(x, y)      ((x & 0) | y)
+/** @} */
+
+/**
+ * @brief   Available GPIO ports on ESP32
+ * @{
+ */
+#define PORT_GPIO           (0)
 /** @} */
 
 /**
  * @brief   Define CPU specific number of GPIO pins
  * @{
  */
-#define GPIO_PIN_NUMOF  40
-#ifndef GPIO_PIN_COUNT
-#define GPIO_PIN_COUNT  GPIO_PIN_NUMOF
-#endif
+#define GPIO_PIN_NUMOF      (40)
+/** @} */
+
+/**
+ * @brief   Override mode flank selection values
+ *
+ * @{
+ */
+#define HAVE_GPIO_FLANK_T
+typedef enum {
+    GPIO_NONE    = 0,
+    GPIO_RISING  = 1,        /**< emit interrupt on rising flank  */
+    GPIO_FALLING = 2,        /**< emit interrupt on falling flank */
+    GPIO_BOTH    = 3,        /**< emit interrupt on both flanks   */
+    GPIO_LOW     = 4,        /**< emit interrupt on low level     */
+    GPIO_HIGH    = 5         /**< emit interrupt on low level     */
+} gpio_flank_t;
+
+/** @} */
+
+/**
+ * @brief   Override GPIO modes
+ *
+ * @{
+ */
+#define HAVE_GPIO_MODE_T
+typedef enum {
+    GPIO_IN,        /**< input */
+    GPIO_IN_PD,     /**< input with pull-down */
+    GPIO_IN_PU,     /**< input with pull-up */
+    GPIO_OUT,       /**< output */
+    GPIO_OD,        /**< open-drain output */
+    GPIO_OD_PU,     /**< open-drain output with pull-up */
+    GPIO_IN_OUT,    /**< input and output */
+    GPIO_IN_OD,     /**< input and open-drain output */
+    GPIO_IN_OD_PU   /**< input and open-drain output */
+} gpio_mode_t;
+/** @} */
 /** @} */
 
 /**
@@ -98,42 +161,6 @@ extern "C" {
 #define GPIO37      (GPIO_PIN(PORT_GPIO,37))
 #define GPIO38      (GPIO_PIN(PORT_GPIO,38))
 #define GPIO39      (GPIO_PIN(PORT_GPIO,39))
-/** @} */
-
-/**
- * @brief   Override mode flank selection values
- *
- * @{
- */
-#define HAVE_GPIO_FLANK_T
-typedef enum {
-    GPIO_NONE    = 0,
-    GPIO_RISING  = 1,        /**< emit interrupt on rising flank  */
-    GPIO_FALLING = 2,        /**< emit interrupt on falling flank */
-    GPIO_BOTH    = 3,        /**< emit interrupt on both flanks   */
-    GPIO_LOW     = 4,        /**< emit interrupt on low level     */
-    GPIO_HIGH    = 5         /**< emit interrupt on low level     */
-} gpio_flank_t;
-
-/** @} */
-
-/**
- * @brief   Override GPIO modes
- *
- * @{
- */
-#define HAVE_GPIO_MODE_T
-typedef enum {
-    GPIO_IN,        /**< input */
-    GPIO_IN_PD,     /**< input with pull-down */
-    GPIO_IN_PU,     /**< input with pull-up */
-    GPIO_OUT,       /**< output */
-    GPIO_OD,        /**< open-drain output */
-    GPIO_OD_PU,     /**< open-drain output with pull-up */
-    GPIO_IN_OUT,    /**< input and output */
-    GPIO_IN_OD,     /**< input and open-drain output */
-    GPIO_IN_OD_PU   /**< input and open-drain output */
-} gpio_mode_t;
 /** @} */
 
 /**

--- a/cpu/esp32/include/periph_cpu.h
+++ b/cpu/esp32/include/periph_cpu.h
@@ -243,9 +243,6 @@ typedef enum {
  */
 #define ADC_NUMOF_MAX   16
 
-/** Number of ADC channels determined from ADC_GPIOS */
-extern const unsigned adc_chn_num;
-
 /** @} */
 
 /**


### PR DESCRIPTION
### Contribution description

This PR changes the approach of peripheral configurations for ADC in board definitions to the usual RIOT approach. With these changes, peripheral configurations use static const arrays in the `boards/esp32*/periph_conf.h` files and define the `*_NUMOF` macros using the size of these static array.

The static configuration arrays contain only definitions that can be changed by the board definition or the application. They do not contain any MCU implementation detail. The board definitions use preprocessor defines as before to fill these static configuration arrays. This makes it possible to override all configurations either with the make command or application specific configuration files.

### Testing procedure

Compilation and test with the most common ESP32 board should be executed
```
make BOARD=esp32-wroom-32 -C tests/periph_adc flash test
```

### Issues/PRs references

PRs #11289 #11290 #11291 #11292 #11293 #11294 are releated and should be merged together.