### PR TITLE
boards/esp32: changes the approach for configurations of DAC channels in board definitions

### DIFF
--- a/boards/common/esp32/include/periph_conf_common.h
+++ b/boards/common/esp32/include/periph_conf_common.h
@@ -79,6 +79,11 @@ static const gpio_t adc_channels[] = ADC_GPIOS;
 #endif
 
 /**
+ * @brief   Static array with declared DAC channels
+ */
+static const gpio_t dac_channels[] = DAC_GPIOS;
+
+/**
  * @brief Number of GPIOs declared as DAC channels
  *
  * The number of GPIOs that are declared as DAC channels is determined from
@@ -86,7 +91,7 @@ static const gpio_t adc_channels[] = ADC_GPIOS;
  *
  * @note DAC_NUMOF definition must not be changed.
  */
-#define DAC_NUMOF   (dac_chn_num)
+#define DAC_NUMOF   (sizeof(dac_channels) / sizeof(dac_channels[0]))
 /** @} */
 
 

--- a/boards/esp32-olimex-evb/Makefile.features
+++ b/boards/esp32-olimex-evb/Makefile.features
@@ -5,7 +5,6 @@ include $(RIOTBOARD)/common/esp32/Makefile.features
 ifneq (,$(filter olimex_esp32_gateway,$(USEMODULE)))
     FEATURES_PROVIDED += periph_adc
 endif
-FEATURES_PROVIDED += periph_dac
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_spi

--- a/boards/esp32-wrover-kit/Makefile.features
+++ b/boards/esp32-wrover-kit/Makefile.features
@@ -3,7 +3,6 @@ include $(RIOTBOARD)/common/esp32/Makefile.features
 
 # additional features provided by the board
 FEATURES_PROVIDED += periph_adc
-FEATURES_PROVIDED += periph_dac
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_spi

--- a/cpu/esp32/include/periph_cpu.h
+++ b/cpu/esp32/include/periph_cpu.h
@@ -274,9 +274,6 @@ typedef enum {
  */
 #define DAC_NUMOF_MAX   2
 
-/** Number of DAC channels determined from DAC_GPIOS */
-extern const unsigned dac_chn_num;
-
 /** @} */
 
 /**

--- a/cpu/esp32/periph/dac.c
+++ b/cpu/esp32/periph/dac.c
@@ -35,12 +35,6 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
-/** Map of RIOT DAC lines to GPIOs */
-static const uint32_t dac_pins[] = DAC_GPIOS;
-
-/** number of DAC channels */
-const unsigned dac_chn_num = (sizeof(dac_pins) / sizeof(dac_pins[0]));
-
 /* declaration of external functions */
 extern void _adc2_ctrl_init(void);
 
@@ -53,7 +47,7 @@ extern const gpio_t _gpio_rtcio_map[];
 
 int8_t dac_init (dac_t line)
 {
-    CHECK_PARAM_RET (line < dac_chn_num, DAC_NOLINE)
+    CHECK_PARAM_RET (line < DAC_NUMOF, DAC_NOLINE)
 
     if (!_dac_module_initialized) {
         /* do some configuration checks */
@@ -65,7 +59,7 @@ int8_t dac_init (dac_t line)
 
     _adc2_ctrl_init();
 
-    uint8_t rtcio = _gpio_rtcio_map[dac_pins[line]];
+    uint8_t rtcio = _gpio_rtcio_map[dac_channels[line]];
     uint8_t idx;
 
     /* try to initialize the pin as DAC ouput */
@@ -112,27 +106,27 @@ int8_t dac_init (dac_t line)
 
 void dac_set (dac_t line, uint16_t value)
 {
-    CHECK_PARAM (line < dac_chn_num);
-    RTCIO.pad_dac[_gpio_rtcio_map[dac_pins[line]] - RTCIO_DAC1].dac = value >> 8;
+    CHECK_PARAM (line < DAC_NUMOF);
+    RTCIO.pad_dac[_gpio_rtcio_map[dac_channels[line]] - RTCIO_DAC1].dac = value >> 8;
 }
 
 void dac_poweroff (dac_t line)
 {
-    CHECK_PARAM (line < dac_chn_num);
+    CHECK_PARAM (line < DAC_NUMOF);
 }
 
 void dac_poweron (dac_t line)
 {
-    CHECK_PARAM (line < dac_chn_num);
+    CHECK_PARAM (line < DAC_NUMOF);
 }
 
 static bool _dac_conf_check(void)
 {
-    for (unsigned i = 0; i < dac_chn_num; i++) {
-        if (_gpio_rtcio_map[dac_pins[i]] != RTCIO_DAC1 &&
-            _gpio_rtcio_map[dac_pins[i]] != RTCIO_DAC2) {
+    for (unsigned i = 0; i < DAC_NUMOF; i++) {
+        if (_gpio_rtcio_map[dac_channels[i]] != RTCIO_DAC1 &&
+            _gpio_rtcio_map[dac_channels[i]] != RTCIO_DAC2) {
             LOG_TAG_ERROR("dac", "GPIO%d cannot be used as DAC line\n",
-                          dac_pins[i]);
+                          dac_channels[i]);
             return false;
         }
     }
@@ -144,8 +138,8 @@ void dac_print_config(void)
 {
     ets_printf("\tDAC\t\tpins=[ ");
 #if defined(DAC_GPIOS)
-    for (unsigned i = 0; i < dac_chn_num; i++) {
-        ets_printf("%d ", dac_pins[i]);
+    for (unsigned i = 0; i < DAC_NUMOF; i++) {
+        ets_printf("%d ", dac_channels[i]);
     }
 #endif /* defined(DAC_GPIOS) */
     ets_printf("]\n");


### PR DESCRIPTION
### Contribution description

This PR changes the approach of peripheral configurations for DAC channels in board definitions to the usual RIOT approach. With these changes, peripheral configurations use static const arrays in the `boards/esp32*/periph_conf.h` files and define the `*_NUMOF` macros using the size of these static array.

The static configuration arrays contain only definitions that can be changed by the board definition or the application. They do not contain any MCU implementation detail. The board definitions use preprocessor defines as before to fill these static configuration arrays. This makes it possible to override all configurations either with the make command or application specific configuration files.

Please note that commit https://github.com/RIOT-OS/RIOT/commit/8b48dfd62b9ef74dcf3bf023d2fe30fefe76dee3 is in also in related PRs to get each PR compilable separately.

### Testing procedure

Compilation and test with the most common ESP32 board should be executed
```
make BOARD=esp32-wroom-32 -C tests/periph_dac flash test
```

### Issues/PRs references

PRs #11289 #11290 #11291 #11292 #11293 #11294 are releated and should be merged together.
Depends on PR #11289.