### PR TITLE
boards/esp32: changes the approach for configurations of I2C in board definitions

### DIFF
--- a/boards/common/esp32/include/periph_conf_common.h
+++ b/boards/common/esp32/include/periph_conf_common.h
@@ -89,11 +89,30 @@ static const gpio_t adc_channels[] = ADC_GPIOS;
 #define DAC_NUMOF   (dac_chn_num)
 /** @} */
 
-
 /**
  * @name   I2C configuration
  * @{
  */
+
+/**
+ * @brief   Static array with configuration for declared I2C devices
+ */
+static const i2c_conf_t i2c_config[] = {
+    #if defined(I2C0_SCL) && defined(I2C0_SDA) && defined(I2C0_SPEED)
+    {
+        .speed = I2C0_SPEED,
+        .scl = I2C0_SCL,
+        .sda = I2C0_SDA,
+    },
+    #endif
+    #if defined(I2C1_SCL) && defined(I2C1_SDA) && defined(I2C1_SPEED)
+    {
+        .speed = I2C1_SPEED,
+        .scl = I2C1_SCL,
+        .sda = I2C1_SDA,
+    },
+    #endif
+};
 
 /**
  * @brief Number of I2C interfaces
@@ -103,7 +122,7 @@ static const gpio_t adc_channels[] = ADC_GPIOS;
  *
  * @note I2C_NUMOF definition must not be changed.
  */
-#define I2C_NUMOF   (i2c_bus_num)
+#define I2C_NUMOF   (sizeof(i2c_config) / sizeof(i2c_config[0]))
 
 /** @} */
 

--- a/cpu/esp32/include/periph_cpu.h
+++ b/cpu/esp32/include/periph_cpu.h
@@ -303,8 +303,30 @@ extern const unsigned dac_chn_num;
  * @{
  */
 
-/** Number of I2C interfaces determined from I2Cn_* definitions */
-extern const unsigned i2c_bus_num;
+/**
+ * @brief    Override I2C clock speed values
+ *
+ * This is required here to have i2c_speed_t defined in this file.
+ * @{
+ */
+#define HAVE_I2C_SPEED_T
+typedef enum {
+    I2C_SPEED_LOW = 0,      /**< 10 kbit/s */
+    I2C_SPEED_NORMAL,       /**< 100 kbit/s */
+    I2C_SPEED_FAST,         /**< 400 kbit/s */
+    I2C_SPEED_FAST_PLUS,    /**< 1 Mbit/s */
+    I2C_SPEED_HIGH,         /**< not supported */
+} i2c_speed_t;
+/** @} */
+
+/**
+ * @brief   I2C configuration structure type
+ */
+typedef struct {
+    i2c_speed_t speed;      /**< I2C bus speed */
+    gpio_t scl;             /**< GPIO used as SCL pin */
+    gpio_t sda;             /**< GPIO used as SDA pin */
+} i2c_conf_t;
 
 #define PERIPH_I2C_NEED_READ_REG    /**< i2c_read_reg required */
 #define PERIPH_I2C_NEED_READ_REGS   /**< i2c_read_regs required */

--- a/cpu/esp32/periph/i2c_hw.c
+++ b/cpu/esp32/periph/i2c_hw.c
@@ -87,8 +87,6 @@ struct i2c_hw_t {
     i2c_dev_t* regs;        /* pointer to register data struct of the I2C device */
     uint8_t mod;            /* peripheral hardware module of the I2C interface */
     uint8_t int_src;        /* peripheral interrupt source used by the I2C device */
-    uint8_t pin_scl;        /* SCL pin */
-    uint8_t pin_sda;        /* SDA pin */
     uint8_t signal_scl_in;  /* SCL signal to the controller */
     uint8_t signal_scl_out; /* SCL signal from the controller */
     uint8_t signal_sda_in;  /* SDA signal to the controller */
@@ -96,32 +94,24 @@ struct i2c_hw_t {
 };
 
 static const struct i2c_hw_t _i2c_hw[] = {
-    #if defined(I2C0_SCL) && defined(I2C0_SDA) && defined(I2C0_SPEED)
     {
         .regs = &I2C0,
         .mod = PERIPH_I2C0_MODULE,
         .int_src = ETS_I2C_EXT0_INTR_SOURCE,
-        .pin_scl = I2C0_SCL,
-        .pin_sda = I2C0_SDA,
         .signal_scl_in = I2CEXT0_SCL_IN_IDX,
         .signal_scl_out = I2CEXT0_SCL_OUT_IDX,
         .signal_sda_in = I2CEXT0_SDA_IN_IDX,
         .signal_sda_out = I2CEXT0_SDA_OUT_IDX,
     },
-    #endif
-    #if defined(I2C1_SCL) && defined(I2C1_SDA) && defined(I2C1_SPEED)
     {
         .regs = &I2C1,
         .mod = PERIPH_I2C1_MODULE,
         .int_src = ETS_I2C_EXT1_INTR_SOURCE,
-        .pin_scl = I2C1_SCL,
-        .pin_sda = I2C1_SDA,
         .signal_scl_in = I2CEXT1_SCL_IN_IDX,
         .signal_scl_out = I2CEXT1_SCL_OUT_IDX,
         .signal_sda_in = I2CEXT1_SDA_IN_IDX,
         .signal_sda_out = I2CEXT1_SDA_OUT_IDX,
     }
-    #endif
 };
 
 struct _i2c_bus_t
@@ -134,28 +124,7 @@ struct _i2c_bus_t
     uint32_t results;  /* results of a transfer */
 };
 
-static struct _i2c_bus_t _i2c_bus[] =
-{
-    #if defined(I2C0_SCL) && defined(I2C0_SDA) && defined(I2C0_SPEED)
-    {
-        .speed = I2C0_SPEED,
-        .cmd = 0,
-        .data = 0,
-        .lock = MUTEX_INIT
-    },
-    #endif
-    #if defined(I2C1_SCL) && defined(I2C1_SDA) && defined(I2C1_SPEED)
-    {
-        .speed = I2C1_SPEED,
-        .cmd = 0,
-        .data = 0,
-        .lock = MUTEX_INIT
-    },
-    #endif
-};
-
-/* the number of I2C bus devices used */
-const unsigned i2c_bus_num = sizeof(_i2c_bus) / sizeof(_i2c_bus[0]);
+static struct _i2c_bus_t _i2c_bus[I2C_NUMOF] = {};
 
 /* forward declaration of internal functions */
 
@@ -175,22 +144,25 @@ static inline void _i2c_delay (uint32_t delay);
 
 void i2c_init(i2c_t dev)
 {
-    CHECK_PARAM (dev < i2c_bus_num)
+    CHECK_PARAM (dev < I2C_NUMOF)
 
-    if (_i2c_bus[dev].speed == I2C_SPEED_FAST_PLUS ||
-        _i2c_bus[dev].speed == I2C_SPEED_HIGH) {
+    if (i2c_config[dev].speed == I2C_SPEED_FAST_PLUS ||
+        i2c_config[dev].speed == I2C_SPEED_HIGH) {
         LOG_TAG_INFO("i2c", "I2C_SPEED_FAST_PLUS and I2C_SPEED_HIGH "
                      "are not supported\n");
         return;
     }
 
+    mutex_init(&_i2c_bus[dev].lock);
+
     i2c_acquire (dev);
 
     _i2c_bus[dev].cmd = 0;
     _i2c_bus[dev].data = 0;
+    _i2c_bus[dev].speed = i2c_config[dev].speed;
 
     DEBUG ("%s scl=%d sda=%d speed=%d\n", __func__,
-           _i2c_hw[dev].pin_scl, _i2c_hw[dev].pin_sda, _i2c_bus[dev].speed);
+           i2c_config[dev].scl, i2c_config[dev].sda, _i2c_bus[dev].speed);
 
     /* enable (power on) the according I2C module */
     periph_module_enable(_i2c_hw[dev].mod);
@@ -298,7 +270,7 @@ int i2c_acquire(i2c_t dev)
 {
     DEBUG ("%s\n", __func__);
 
-    CHECK_PARAM_RET (dev < i2c_bus_num, -1)
+    CHECK_PARAM_RET (dev < I2C_NUMOF, -1)
 
     mutex_lock(&_i2c_bus[dev].lock);
     _i2c_reset_hw(dev);
@@ -309,7 +281,7 @@ int i2c_release(i2c_t dev)
 {
     DEBUG ("%s\n", __func__);
 
-    CHECK_PARAM_RET (dev < i2c_bus_num, -1)
+    CHECK_PARAM_RET (dev < I2C_NUMOF, -1)
 
     _i2c_reset_hw (dev);
     mutex_unlock(&_i2c_bus[dev].lock);
@@ -341,7 +313,7 @@ int i2c_read_bytes(i2c_t dev, uint16_t addr, void *data, size_t len, uint8_t fla
     DEBUG ("%s dev=%u addr=%02x data=%p len=%d flags=%01x\n",
            __func__, dev, addr, data, len, flags);
 
-    CHECK_PARAM_RET (dev < i2c_bus_num, -EINVAL);
+    CHECK_PARAM_RET (dev < I2C_NUMOF, -EINVAL);
     CHECK_PARAM_RET (len > 0, -EINVAL);
     CHECK_PARAM_RET (data != NULL, -EINVAL);
 
@@ -428,7 +400,7 @@ int i2c_write_bytes(i2c_t dev, uint16_t addr, const void *data, size_t len, uint
     DEBUG ("%s dev=%u addr=%02x data=%p len=%d flags=%01x\n",
            __func__, dev, addr, data, len, flags);
 
-    CHECK_PARAM_RET (dev < i2c_bus_num, -EINVAL);
+    CHECK_PARAM_RET (dev < I2C_NUMOF, -EINVAL);
     CHECK_PARAM_RET (len > 0, -EINVAL);
     CHECK_PARAM_RET (data != NULL, -EINVAL);
 
@@ -500,38 +472,38 @@ static int _i2c_init_pins(i2c_t dev)
      * reset GPIO usage type if the pins were used already for I2C before to
      * make it possible to reinitialize I2C
      */
-    if (gpio_get_pin_usage(_i2c_hw[dev].pin_scl) == _I2C) {
-        gpio_set_pin_usage(_i2c_hw[dev].pin_scl, _GPIO);
+    if (gpio_get_pin_usage(i2c_config[dev].scl) == _I2C) {
+        gpio_set_pin_usage(i2c_config[dev].scl, _GPIO);
     }
-    if (gpio_get_pin_usage(_i2c_hw[dev].pin_sda) == _I2C) {
-        gpio_set_pin_usage(_i2c_hw[dev].pin_sda, _GPIO);
+    if (gpio_get_pin_usage(i2c_config[dev].sda) == _I2C) {
+        gpio_set_pin_usage(i2c_config[dev].sda, _GPIO);
     }
 
     /* try to configure SDA and SCL pin as GPIO in open-drain mode with enabled pull-ups */
-    if (gpio_init (_i2c_hw[dev].pin_scl, GPIO_IN_OD_PU) ||
-        gpio_init (_i2c_hw[dev].pin_sda, GPIO_IN_OD_PU)) {
+    if (gpio_init (i2c_config[dev].scl, GPIO_IN_OD_PU) ||
+        gpio_init (i2c_config[dev].sda, GPIO_IN_OD_PU)) {
         return -ENODEV;
     }
 
     /* bring signals to high */
-    gpio_set(_i2c_hw[dev].pin_scl);
-    gpio_set(_i2c_hw[dev].pin_sda);
+    gpio_set(i2c_config[dev].scl);
+    gpio_set(i2c_config[dev].sda);
 
     /* store the usage type in GPIO table */
-    gpio_set_pin_usage(_i2c_hw[dev].pin_scl, _I2C);
-    gpio_set_pin_usage(_i2c_hw[dev].pin_sda, _I2C);
+    gpio_set_pin_usage(i2c_config[dev].scl, _I2C);
+    gpio_set_pin_usage(i2c_config[dev].sda, _I2C);
 
     /* connect SCL and SDA pins to output signals through the GPIO matrix */
-    GPIO.func_out_sel_cfg[_i2c_hw[dev].pin_scl].func_sel = _i2c_hw[dev].signal_scl_out;
-    GPIO.func_out_sel_cfg[_i2c_hw[dev].pin_sda].func_sel = _i2c_hw[dev].signal_sda_out;
+    GPIO.func_out_sel_cfg[i2c_config[dev].scl].func_sel = _i2c_hw[dev].signal_scl_out;
+    GPIO.func_out_sel_cfg[i2c_config[dev].sda].func_sel = _i2c_hw[dev].signal_sda_out;
 
     /* connect SCL and SDA input signals to pins through the GPIO matrix */
     GPIO.func_in_sel_cfg[_i2c_hw[dev].signal_scl_in].sig_in_sel = 1;
     GPIO.func_in_sel_cfg[_i2c_hw[dev].signal_scl_in].sig_in_inv = 0;
-    GPIO.func_in_sel_cfg[_i2c_hw[dev].signal_scl_in].func_sel = _i2c_hw[dev].pin_scl;
+    GPIO.func_in_sel_cfg[_i2c_hw[dev].signal_scl_in].func_sel = i2c_config[dev].scl;
     GPIO.func_in_sel_cfg[_i2c_hw[dev].signal_sda_in].sig_in_sel = 1;
     GPIO.func_in_sel_cfg[_i2c_hw[dev].signal_sda_in].sig_in_inv = 0;
-    GPIO.func_in_sel_cfg[_i2c_hw[dev].signal_sda_in].func_sel = _i2c_hw[dev].pin_sda;
+    GPIO.func_in_sel_cfg[_i2c_hw[dev].signal_sda_in].func_sel = i2c_config[dev].sda;
 
     return 0;
 }
@@ -733,7 +705,7 @@ static void IRAM_ATTR _i2c_intr_handler (void *arg)
 
     /* all I2C peripheral interrupt sources are routed to the same interrupt,
        so we have to use the status register to distinguish interruptees */
-    for (unsigned dev = 0; dev < i2c_bus_num; dev++) {
+    for (unsigned dev = 0; dev < I2C_NUMOF; dev++) {
         /* test for transfer related interrupts */
         if (_i2c_hw[dev].regs->int_status.val & transfer_int_mask) {
             /* set transfer result */
@@ -761,37 +733,37 @@ static void IRAM_ATTR _i2c_intr_handler (void *arg)
 static void _i2c_clear_bus(i2c_t dev)
 {
     /* reset the usage type in GPIO table */
-    gpio_set_pin_usage(_i2c_hw[dev].pin_scl, _GPIO);
-    gpio_set_pin_usage(_i2c_hw[dev].pin_sda, _GPIO);
+    gpio_set_pin_usage(i2c_config[dev].scl, _GPIO);
+    gpio_set_pin_usage(i2c_config[dev].sda, _GPIO);
 
     /* configure SDA and SCL pin as GPIO in open-drain mode temporarily */
-    gpio_init (_i2c_hw[dev].pin_scl, GPIO_IN_OD_PU);
-    gpio_init (_i2c_hw[dev].pin_sda, GPIO_IN_OD_PU);
+    gpio_init (i2c_config[dev].scl, GPIO_IN_OD_PU);
+    gpio_init (i2c_config[dev].sda, GPIO_IN_OD_PU);
 
     /* master send some clock pulses to make the slave release the bus */
-    gpio_set (_i2c_hw[dev].pin_scl);
-    gpio_set (_i2c_hw[dev].pin_sda);
-    gpio_clear (_i2c_hw[dev].pin_sda);
+    gpio_set (i2c_config[dev].scl);
+    gpio_set (i2c_config[dev].sda);
+    gpio_clear (i2c_config[dev].sda);
     for (int i = 0; i < 20; i++) {
-        gpio_toggle(_i2c_hw[dev].pin_scl);
+        gpio_toggle(i2c_config[dev].scl);
     }
-    gpio_set(_i2c_hw[dev].pin_sda);
+    gpio_set(i2c_config[dev].sda);
 
     /* store the usage type in GPIO table */
-    gpio_set_pin_usage(_i2c_hw[dev].pin_scl, _I2C);
-    gpio_set_pin_usage(_i2c_hw[dev].pin_sda, _I2C);
+    gpio_set_pin_usage(i2c_config[dev].scl, _I2C);
+    gpio_set_pin_usage(i2c_config[dev].sda, _I2C);
 
     /* connect SCL and SDA pins to output signals through the GPIO matrix */
-    GPIO.func_out_sel_cfg[_i2c_hw[dev].pin_scl].func_sel = _i2c_hw[dev].signal_scl_out;
-    GPIO.func_out_sel_cfg[_i2c_hw[dev].pin_sda].func_sel = _i2c_hw[dev].signal_sda_out;
+    GPIO.func_out_sel_cfg[i2c_config[dev].scl].func_sel = _i2c_hw[dev].signal_scl_out;
+    GPIO.func_out_sel_cfg[i2c_config[dev].sda].func_sel = _i2c_hw[dev].signal_sda_out;
 
     /* connect SCL and SDA input signals to pins through the GPIO matrix */
     GPIO.func_in_sel_cfg[_i2c_hw[dev].signal_scl_in].sig_in_sel = 1;
     GPIO.func_in_sel_cfg[_i2c_hw[dev].signal_scl_in].sig_in_inv = 0;
-    GPIO.func_in_sel_cfg[_i2c_hw[dev].signal_scl_in].func_sel = _i2c_hw[dev].pin_scl;
+    GPIO.func_in_sel_cfg[_i2c_hw[dev].signal_scl_in].func_sel = i2c_config[dev].scl;
     GPIO.func_in_sel_cfg[_i2c_hw[dev].signal_sda_in].sig_in_sel = 1;
     GPIO.func_in_sel_cfg[_i2c_hw[dev].signal_sda_in].sig_in_inv = 0;
-    GPIO.func_in_sel_cfg[_i2c_hw[dev].signal_sda_in].func_sel = _i2c_hw[dev].pin_sda;
+    GPIO.func_in_sel_cfg[_i2c_hw[dev].signal_sda_in].func_sel = i2c_config[dev].sda;
 
     return;
 }
@@ -851,9 +823,9 @@ static void _i2c_reset_hw (i2c_t dev)
 
 void i2c_print_config(void)
 {
-    for (unsigned bus = 0; bus < i2c_bus_num; bus++) {
+    for (unsigned dev = 0; dev < I2C_NUMOF; dev++) {
         ets_printf("\tI2C_DEV(%d)\tscl=%d sda=%d\n",
-                   bus, _i2c_hw[bus].pin_scl, _i2c_hw[bus].pin_sda);
+                   dev, i2c_config[dev].scl, i2c_config[dev].sda);
     }
 }
 


### PR DESCRIPTION
### Contribution description

This PR changes the approach of peripheral configurations for I2C in board definitions to the usual RIOT approach. With these changes, peripheral configurations use static const arrays in the `boards/esp32*/periph_conf.h` files and define the `*_NUMOF` macros using the size of these static array.

The static configuration arrays contain only definitions that can be changed by the board definition or the application. They do not contain any MCU implementation detail. The board definitions use preprocessor defines as before to fill these static configuration arrays. This makes it possible to override all configurations either with the make command or application specific configuration files.

Please note that commit https://github.com/RIOT-OS/RIOT/commit/8b48dfd62b9ef74dcf3bf023d2fe30fefe76dee3 is in also in related PRs to get each PR compilable separately.

### Testing procedure

Compilation and test with the most common ESP32 board should be executed
```
make BOARD=esp32-wroom-32 -C tests/periph_i2c flash test
```

### Issues/PRs references

PRs #11289 #11290 #11291 #11292 #11293 #11294 are releated and should be merged together.