### PR TITLE
boards/esp32: changes the approach for configurations of PWM channels in board definitions

### DIFF
--- a/boards/common/esp32/include/periph_conf_common.h
+++ b/boards/common/esp32/include/periph_conf_common.h
@@ -113,6 +113,19 @@ static const gpio_t adc_channels[] = ADC_GPIOS;
  */
 
 /**
+ * @brief   Static array of GPIOs that can be used as channels of PWM0
+ */
+#ifdef PWM0_GPIOS
+static const gpio_t pwm0_channels[] = PWM0_GPIOS;
+#endif
+/**
+ * @brief   Static array of GPIOs that can be used as channels of PWM0
+ */
+#ifdef PWM1_GPIOS
+static const gpio_t pwm1_channels[] = PWM1_GPIOS;
+#endif
+
+/**
  * @brief   Number of PWM devices
  *
  * The number of PWM devices is determined from the PWM0_GPIOS and PWM1_GPIOS
@@ -120,7 +133,13 @@ static const gpio_t adc_channels[] = ADC_GPIOS;
  *
  * @note PWM_NUMOF definition must not be changed.
  */
-#define PWM_NUMOF   (pwm_dev_num)
+#if defined(PWM0_GPIOS) && defined(PWM1_GPIOS)
+#define PWM_NUMOF  (2)
+#elif defined(PWM0_GPIOS) || defined(PWM1_GPIOS)
+#define PWM_NUMOF  (1)
+#else
+#define PWM_NUMOF  (0)
+#endif
 
 /** @} */
 

--- a/boards/esp32-wrover-kit/Makefile.features
+++ b/boards/esp32-wrover-kit/Makefile.features
@@ -3,7 +3,6 @@ include $(RIOTBOARD)/common/esp32/Makefile.features
 
 # additional features provided by the board
 FEATURES_PROVIDED += periph_adc
-FEATURES_PROVIDED += periph_dac
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_spi

--- a/boards/esp32-wrover-kit/include/periph_conf.h
+++ b/boards/esp32-wrover-kit/include/periph_conf.h
@@ -122,7 +122,7 @@
  */
 #ifndef PWM0_GPIOS
 #if !MODULE_ESP32_WROVER_KIT_CAMERA || DOXYGEN
-#define PWM0_GPIOS  { LED0_PIN, LED2_PIN } /**< only available when camera is not connected */
+#define PWM0_GPIOS  { GPIO0, GPIO4 } /**< only available when camera is not connected */
 #else
 #define PWM0_GPIOS  { }
 #endif

--- a/cpu/esp32/include/periph_cpu.h
+++ b/cpu/esp32/include/periph_cpu.h
@@ -339,12 +339,14 @@ extern const unsigned i2c_bus_num;
  */
 
 /**
+ * @brief   Maximum number of PWM devices
+ */
+#define PWM_NUMOF_MAX           (2)
+
+/**
  * @brief   Maximum number of channels per PWM device.
  */
 #define PWM_CHANNEL_NUM_DEV_MAX (6)
-
-/** Number of PWM devices determined from PWM0_GPIOS and PWM1_GPIOS. */
-extern const unsigned pwm_dev_num;
 
 /** @} */
 

--- a/cpu/esp32/periph/pwm.c
+++ b/cpu/esp32/periph/pwm.c
@@ -40,7 +40,6 @@
 
 #if defined(PWM0_GPIOS) || defined(PWM1_GPIOS)
 
-#define PWM_NUMOF_MAX (2)           /* maximum number of PWM devices */
 #define PWM_CLK       (160000000UL) /* base clock of PWM devices */
 #define PWM_CPS_MAX   (10000000UL)  /* maximum cycles per second supported */
 #define PWM_CPS_MIN   (2500UL)      /* minumum cycles per second supported */
@@ -101,8 +100,8 @@ static const struct _pwm_hw_t _pwm_hw[] =
         .mod = PERIPH_PWM0_MODULE,
         .int_src = ETS_PWM0_INTR_SOURCE,
         .signal_group = PWM0_OUT0A_IDX,
-        .gpio_num = sizeof(_pwm_channel_gpios_0) >> 2,
-        .gpios = _pwm_channel_gpios_0,
+        .gpio_num = sizeof(pwm0_channels) / sizeof(pwm0_channels[0]),
+        .gpios = pwm0_channels,
     },
     #endif
     #ifdef PWM1_GPIOS
@@ -111,14 +110,11 @@ static const struct _pwm_hw_t _pwm_hw[] =
         .mod = PERIPH_PWM1_MODULE,
         .int_src = ETS_PWM1_INTR_SOURCE,
         .signal_group = PWM1_OUT0A_IDX,
-        .gpio_num = sizeof(_pwm_channel_gpios_1) >> 2,
-        .gpios = _pwm_channel_gpios_1,
+        .gpio_num = sizeof(pwm1_channels) / sizeof(pwm1_channels[0]),
+        .gpios = pwm1_channels,
     },
     #endif
 };
-
-/* the number of PWM devices used */
-const unsigned pwm_dev_num = sizeof(_pwm_hw) / sizeof(_pwm_hw[0]);
 
 /* data structure dynamic channel configuration */
 typedef struct {
@@ -146,7 +142,7 @@ uint32_t pwm_init(pwm_t pwm, pwm_mode_t mode, uint32_t freq, uint16_t res)
 {
     DEBUG ("%s pwm=%u mode=%u freq=%u, res=%u\n", __func__, pwm, mode, freq, res);
 
-    CHECK_PARAM_RET (pwm < pwm_dev_num, 0);
+    CHECK_PARAM_RET (pwm < PWM_NUMOF, 0);
     CHECK_PARAM_RET (freq > 0, 0);
 
     if (_pwm_init_first_time) {
@@ -203,7 +199,7 @@ uint32_t pwm_init(pwm_t pwm, pwm_mode_t mode, uint32_t freq, uint16_t res)
 
 uint8_t pwm_channels(pwm_t pwm)
 {
-    CHECK_PARAM_RET (pwm < pwm_dev_num, 0);
+    CHECK_PARAM_RET (pwm < PWM_NUMOF, 0);
 
     return _pwm_hw[pwm].gpio_num;
 }
@@ -212,7 +208,7 @@ void pwm_set(pwm_t pwm, uint8_t channel, uint16_t value)
 {
     DEBUG("%s pwm=%u channel=%u value=%u\n", __func__, pwm, channel, value);
 
-    CHECK_PARAM (pwm < pwm_dev_num);
+    CHECK_PARAM (pwm < PWM_NUMOF);
     CHECK_PARAM (channel < _pwm_dev[pwm].chn_num);
     CHECK_PARAM (value <= _pwm_dev[pwm].res);
 
@@ -287,14 +283,14 @@ void pwm_set(pwm_t pwm, uint8_t channel, uint16_t value)
 
 void pwm_poweron(pwm_t pwm)
 {
-    CHECK_PARAM (pwm < pwm_dev_num);
+    CHECK_PARAM (pwm < PWM_NUMOF);
     periph_module_enable(_pwm_hw[pwm].mod);
     _pwm_start(pwm);
 }
 
 void pwm_poweroff(pwm_t pwm)
 {
-    CHECK_PARAM (pwm < pwm_dev_num);
+    CHECK_PARAM (pwm < PWM_NUMOF);
     _pwm_stop (pwm);
     periph_module_disable(_pwm_hw[pwm].mod);
 }
@@ -385,7 +381,7 @@ static void _pwm_start(pwm_t pwm)
     }
 
     /* sync all timers */
-    for (unsigned i = 0; i < pwm_dev_num; i++) {
+    for (unsigned i = 0; i < PWM_NUMOF; i++) {
         _pwm_hw[i].regs->timer[0].sync.sync_sw = ~_pwm_hw[i].regs->timer[0].sync.sync_sw;
     }
 }
@@ -399,13 +395,13 @@ static void _pwm_stop(pwm_t pwm)
 /* do some static initialization and configuration checks */
 static bool _pwm_configuration(void)
 {
-    if (pwm_dev_num > PWM_NUMOF_MAX) {
+    if (PWM_NUMOF > PWM_NUMOF_MAX) {
         LOG_TAG_ERROR("pwm", "%d PWM devices were defined, only %d PWM are "
-                      "supported\n", pwm_dev_num, PWM_NUMOF_MAX);
+                      "supported\n", PWM_NUMOF, PWM_NUMOF_MAX);
         return false;
     }
 
-    for (unsigned i = 0; i < pwm_dev_num; i++) {
+    for (unsigned i = 0; i < PWM_NUMOF; i++) {
         if (_pwm_hw[i].gpio_num > PWM_CHANNEL_NUM_DEV_MAX) {
             LOG_TAG_ERROR("pwm", "Number of PWM channels of device %d is %d, "
                           "at maximum only %d channels per PWM device are "
@@ -415,8 +411,8 @@ static bool _pwm_configuration(void)
         }
     }
     bool multiple_used = false;
-    for (unsigned i = 0; i < pwm_dev_num; i++) {
-        for (unsigned j = 0; j < pwm_dev_num; j++) {
+    for (unsigned i = 0; i < PWM_NUMOF; i++) {
+        for (unsigned j = 0; j < PWM_NUMOF; j++) {
             if (i != j) {
                 for (unsigned k = 0; k < _pwm_hw[i].gpio_num >> 2; k++) {
                     for (unsigned l = 0; l < _pwm_hw[j].gpio_num >> 2; l++) {
@@ -440,7 +436,7 @@ static bool _pwm_configuration(void)
 
 void pwm_print_config(void)
 {
-    for (unsigned pwm = 0; pwm < pwm_dev_num; pwm++) {
+    for (unsigned pwm = 0; pwm < PWM_NUMOF; pwm++) {
         ets_printf("\tPWM_DEV(%d)\tchannels=[ ", pwm);
         for (int i = 0; i < _pwm_hw[pwm].gpio_num; i++) {
             ets_printf("%d ", _pwm_hw[pwm].gpios[i]);


### PR DESCRIPTION
### Contribution description

This PR changes the approach of peripheral configurations for PWM channels in board definitions to the usual RIOT approach. With these changes, peripheral configurations use static const arrays in the `boards/esp32*/periph_conf.h` files and define the `*_NUMOF` macros using the size of these static array.

The static configuration arrays contain only definitions that can be changed by the board definition or the application. They do not contain any MCU implementation detail. The board definitions use preprocessor defines as before to fill these static configuration arrays. This makes it possible to override all configurations either with the make command or application specific configuration files.

Please note that commit https://github.com/RIOT-OS/RIOT/commit/8b48dfd62b9ef74dcf3bf023d2fe30fefe76dee3 is in also in related PRs to get each PR compilable separately.

### Testing procedure

Compilation and test with the most common ESP32 board should be executed
```
make BOARD=esp32-wroom-32 -C tests/periph_pwm flash test
```

### Issues/PRs references

PRs #11289 #11290 #11291 #11292 #11293 #11294 are releated and should be merged together.
Depends on PR #11289 