### PR TITLE
boards/esp32: changes the approach for configurations of SPI interfaces in board definitions

### DIFF
--- a/boards/common/esp32/include/periph_conf_common.h
+++ b/boards/common/esp32/include/periph_conf_common.h
@@ -129,6 +129,30 @@ static const gpio_t adc_channels[] = ADC_GPIOS;
  */
 
 /**
+ * @brief   Static array with configuration for declared I2C devices
+ */
+static const spi_conf_t spi_config[] = {
+#ifdef SPI0_CTRL
+    {
+        .ctrl = SPI0_CTRL,
+        .sck = SPI0_SCK,
+        .mosi = SPI0_MOSI,
+        .miso = SPI0_MISO,
+        .cs = SPI0_CS0,
+    },
+#endif
+#ifdef SPI1_CTRL
+    {
+        .ctrl = SPI1_CTRL,
+        .sck = SPI1_SCK,
+        .mosi = SPI1_MOSI,
+        .miso = SPI1_MISO,
+        .cs = SPI1_CS0,
+    },
+#endif
+};
+
+/**
  * @brief Number of SPI interfaces
  *
  * The number of SPI interfaces is determined from board-specific peripheral
@@ -136,7 +160,7 @@ static const gpio_t adc_channels[] = ADC_GPIOS;
  *
  * @note SPI_NUMOF definition must not be changed.
  */
-#define SPI_NUMOF   (spi_bus_num)
+#define SPI_NUMOF   (sizeof(spi_config) / sizeof(spi_config[0]))
 
 /** @} */
 

--- a/cpu/esp32/include/periph_cpu.h
+++ b/cpu/esp32/include/periph_cpu.h
@@ -353,8 +353,8 @@ extern const unsigned pwm_dev_num;
  *
  * ESP32 has four SPI controllers:
  *
- * - controller SPI0 is reserved for caching the flash memory
- * - controller SPI1 is reserved for external memories like flash and PSRAM
+ * - controller SPI0 is reserved for caching the flash memory (CPSI)
+ * - controller SPI1 is reserved for external memories like flash and PSRAM (FSPI)
  * - controller SPI2 realizes interface HSPI that can be used for peripherals
  * - controller SPI3 realizes interface VSPI that can be used for peripherals
  *
@@ -376,17 +376,31 @@ extern const unsigned pwm_dev_num;
  * - SPIn_CS0, the GPIO used as CS signal when the cs parameter in spi_aquire
  *   is GPIO_UNDEF,
  *
- * where n can be 0 or 1.
- *
- * @note The configuration of the SPI interfaces SPI_DEV(n) should be in
- * continuous ascending order of n.
+ * where n can be 0 or 1. If they are not defined, the according SPI interface
+ * SPI_DEV(n) is not used.
  *
  * SPI_NUMOF is determined automatically from the board-specific peripheral
  * definitions of SPIn_*.
  */
 
-/** Number of SPI interfaces determined from SPI_* definitions */
-extern const unsigned spi_bus_num;
+/**
+ * @brief   SPI controllers that can be used for peripheral interfaces
+ */
+typedef enum {
+    HSPI = 2,         /**< HSPI interface controller */
+    VSPI = 3,         /**< VSPI interface controller */
+} spi_ctrl_t;
+
+/**
+ * @brief   SPI configuration structure type
+ */
+typedef struct {
+    spi_ctrl_t ctrl;        /**< SPI controller used for the interface */
+    gpio_t sck;             /**< GPIO used as SCK pin */
+    gpio_t mosi;            /**< GPIO used as MOSI pin */
+    gpio_t miso;            /**< GPIO used as MISO pin */
+    gpio_t cs;              /**< GPIO used as CS0 pin */
+} spi_conf_t;
 
 #define PERIPH_SPI_NEEDS_TRANSFER_BYTE  /**< requires function spi_transfer_byte */
 #define PERIPH_SPI_NEEDS_TRANSFER_REG   /**< requires function spi_transfer_reg */


### PR DESCRIPTION
### Contribution description

This PR changes the approach of peripheral configurations for SPI interfaces in board definitions to the usual RIOT approach. With these changes, peripheral configurations use static const arrays in the `boards/esp32*/periph_conf.h` files and define the `*_NUMOF` macros using the size of these static array.

The static configuration arrays contain only definitions that can be changed by the board definition or the application. They do not contain any MCU implementation detail. The board definitions use preprocessor defines as before to fill these static configuration arrays. This makes it possible to override all configurations either with the make command or application specific configuration files.

Please note that commit https://github.com/RIOT-OS/RIOT/commit/8b48dfd62b9ef74dcf3bf023d2fe30fefe76dee3 is in also in related PRs to get each PR compilable separately.

### Testing procedure

Compilation and test with the most common ESP32 board should be executed
```
make BOARD=esp32-wroom-32 -C tests/periph_spi flash test
```

### Issues/PRs references

PRs #11289 #11290 #11291 #11292 #11293 #11294 are releated and should be merged together.