### PR TITLE
boards/esp32: changes the approach for configurations of UART interfaces in board definitions

### DIFF
--- a/boards/common/esp32/include/periph_conf_common.h
+++ b/boards/common/esp32/include/periph_conf_common.h
@@ -144,6 +144,35 @@ static const gpio_t adc_channels[] = ADC_GPIOS;
  * @name   UART configuration
  */
 
+#ifndef UART0_TXD
+#define UART0_TXD   (GPIO1)  /**< TxD of UART_DEV(0) used on all ESP32 boards */
+#endif
+#ifndef UART0_RXD
+#define UART0_RXD   (GPIO3)  /**< RxD of UART_DEV(0) used on all ESP32 boards */
+#endif
+
+/**
+ * @brief   Static array with configuration for declared I2C devices
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .txd = UART0_TXD,
+        .rxd = UART0_RXD,
+    },
+    #if defined(UART1_TXD) && defined(UART1_RXD)
+    {
+        .txd = UART1_TXD,
+        .rxd = UART1_RXD,
+    },
+    #endif
+    #if defined(UART2_TXD) && defined(UART2_RXD)
+    {
+        .txd = UART2_TXD,
+        .rxd = UART2_RXD,
+    },
+    #endif
+};
+
 /**
  * @brief Number of UART interfaces
  *

--- a/cpu/esp32/include/periph_cpu.h
+++ b/cpu/esp32/include/periph_cpu.h
@@ -423,25 +423,33 @@ extern const unsigned spi_bus_num;
  * configuration and is always available. All ESP32 boards use it as standard
  * configuration for the console.
  *
- * UART_DEV(0).TXD      GPIO1
- * UART_DEV(0).RXD      GPIO3
+ *      UART_DEV(0).TXD      GPIO1
+ *      UART_DEV(0).RXD      GPIO3
  *
  * The pin configuration of UART_DEV(1) and UART_DEV(2) are defined in
  * board specific peripheral configuration by
  *
- * UARTn_TXD, the GPIO used as TxD signal, and
- * UARTn_RXD, the GPIO used as RxD signal,
+ * - UARTn_TXD, the GPIO used as TxD signal, and
+ * - UARTn_RXD, the GPIO used as RxD signal,
  *
- * where n can be 2 or 3. If they are not defined, the UART interface
+ * where n can be 1 or 2. If they are not defined, the according UART interface
  * UART_DEV(n) is not used.
  *
  * UART_NUMOF is determined automatically from the board-specific peripheral
- * definitions of UARTn_TXD and UARTn_RXD.
+ * definitions of UARTn_*.
  *
  * @{
  */
-/** @} */
 
+/**
+ * @brief   UART configuration structure type
+ */
+typedef struct {
+    gpio_t txd;             /**< GPIO used as TxD pin */
+    gpio_t rxd;             /**< GPIO used as RxD pin */
+} uart_conf_t;
+
+/** @} */
 
 #ifdef __cplusplus
 }

--- a/cpu/esp32/periph/uart.c
+++ b/cpu/esp32/periph/uart.c
@@ -50,8 +50,7 @@
 
 struct uart_hw_t {
     uart_dev_t* regs;       /* pointer to register data struct of the UART device */
-    uint8_t  pin_txd;       /* TxD pin */
-    uint8_t  pin_rxd;       /* RxD pin */
+    uint8_t  mod;           /* peripheral hardware module of the UART interface */
     bool     used;          /* indicates whether UART is used */
     uint32_t baudrate;      /* used baudrate */
     uart_data_bits_t data;  /* used data bits */
@@ -67,55 +66,38 @@ struct uart_hw_t {
 static struct uart_hw_t _uarts[] = {
     {
         .regs = &UART0,
-        .pin_txd = GPIO1,
-        .pin_rxd = GPIO3,
+        .mod = PERIPH_UART0_MODULE,
         .used = false,
         .baudrate = STDIO_UART_BAUDRATE,
         .data = UART_DATA_BITS_8,
         .stop = UART_STOP_BITS_1,
         .parity = UART_PARITY_NONE,
-        .mod = PERIPH_UART0_MODULE,
         .signal_txd = U0TXD_OUT_IDX,
         .signal_rxd = U0RXD_IN_IDX,
-        .baudrate = STDIO_UART_BAUDRATE,
-        .used = false,
         .int_src = ETS_UART0_INTR_SOURCE
     },
-    #if defined(UART1_TXD) && defined(UART1_RXD)
-    {   .regs = &UART1,
-        .pin_txd = UART1_TXD,
-        .pin_rxd = UART1_RXD,
-        .used = false,
-        .baudrate = STDIO_UART_BAUDRATE,
-        .data = UART_DATA_BITS_8,
-        .stop = UART_STOP_BITS_1,
-        .parity = UART_PARITY_NONE,
     {
         .regs = &UART1,
         .mod = PERIPH_UART1_MODULE,
-        .signal_txd = U1TXD_OUT_IDX,
-        .signal_rxd = U1RXD_IN_IDX,
-        .baudrate = STDIO_UART_BAUDRATE,
-        .used = false,
-        .int_src = ETS_UART1_INTR_SOURCE
-    },
-    #endif
-    #if defined(UART2_TXD) && defined(UART2_RXD)
-    {   .regs = &UART2,
-        .pin_txd = UART2_TXD,
-        .pin_rxd = UART2_RXD,
         .used = false,
         .baudrate = STDIO_UART_BAUDRATE,
         .data = UART_DATA_BITS_8,
         .stop = UART_STOP_BITS_1,
         .parity = UART_PARITY_NONE,
+        .signal_txd = U1TXD_OUT_IDX,
+        .signal_rxd = U1RXD_IN_IDX,
+        .int_src = ETS_UART1_INTR_SOURCE
+    },
     {
         .regs = &UART2,
         .mod = PERIPH_UART2_MODULE,
+        .used = false,
+        .baudrate = STDIO_UART_BAUDRATE,
+        .data = UART_DATA_BITS_8,
+        .stop = UART_STOP_BITS_1,
+        .parity = UART_PARITY_NONE,
         .signal_txd = U2TXD_OUT_IDX,
         .signal_rxd = U2RXD_IN_IDX,
-        .baudrate = STDIO_UART_BAUDRATE,
-        .used = false,
         .int_src = ETS_UART2_INTR_SOURCE
     }
 };


### PR DESCRIPTION
### Contribution description

This PR changes the approach of peripheral configurations for UART interfaces in board definitions to the usual RIOT approach. With these changes, peripheral configurations use static const arrays in the `boards/esp32*/periph_conf.h` files and define the `*_NUMOF` macros using the size of these static array.

The static configuration arrays contain only definitions that can be changed by the board definition or the application. They do not contain any MCU implementation detail. The board definitions use preprocessor defines as before to fill these static configuration arrays. This makes it possible to override all configurations either with the make command or application specific configuration files.

Please note that commit https://github.com/RIOT-OS/RIOT/commit/8b48dfd62b9ef74dcf3bf023d2fe30fefe76dee3 is in also in related PRs to get each PR compilable separately.

### Testing procedure

Compilation and test with the most common ESP32 board should be executed
```
make BOARD=esp32-wroom-32 -C tests/periph_uart flash test
```

### Issues/PRs references

PRs #11289 #11290 #11291 #11292 #11293 #11294 are releated and should be merged together.