### PR TITLE
ble/nimble: add support for build-in IPSS service

### DIFF
--- a/pkg/nimble/Makefile
+++ b/pkg/nimble/Makefile
@@ -54,6 +54,9 @@ nimble_svc_gap:
 nimble_svc_gatt:
 	"$(MAKE)" -C $(PDIR)/nimble/host/services/gatt/src/ -f $(TDIR)/svc.gatt.mk
 
+nimble_svc_ipss:
+	"$(MAKE)" -C $(PDIR)/nimble/host/services/ipss/src/ -f $(TDIR)/svc.ipss.mk
+
 # controller specific modules
 nimble_transport_ram:
 	"$(MAKE)" -C $(PDIR)/nimble/transport/ram/src/ -f $(TDIR)/transport.ram.mk

--- a/pkg/nimble/Makefile.include
+++ b/pkg/nimble/Makefile.include
@@ -62,6 +62,9 @@ endif
 ifneq (,$(filter nimble_svc_ias,$(USEMODULE)))
   INCLUDES += $(NIMIBASE)/nimble/host/services/ias/include
 endif
+ifneq (,$(filter nimble_svc_ipss,$(USEMODULE)))
+  INCLUDES += $(NIMIBASE)/nimble/host/services/ipss/include
+endif
 ifneq (,$(filter nimble_svc_lls,$(USEMODULE)))
   INCLUDES += $(NIMIBASE)/nimble/host/services/lls/include
 endif

--- a/pkg/nimble/contrib/nimble_riot.c
+++ b/pkg/nimble/contrib/nimble_riot.c
@@ -31,6 +31,9 @@
 #ifdef MODULE_NIMBLE_SVC_GATT
 #include "services/gatt/ble_svc_gatt.h"
 #endif
+#ifdef MODULE_NIMBLE_SVC_IPSS
+#include "services/ipss/ble_svc_ipss.h"
+#endif
 
 #ifdef MODULE_NIMBLE_CONTROLLER
 #ifdef CPU_FAM_NRF52
@@ -102,5 +105,8 @@ void nimble_riot_init(void)
 #endif
 #ifdef MODULE_NIMBLE_SVC_GATT
     ble_svc_gatt_init();
+#endif
+#ifdef MODULE_NIMBLE_SVC_IPSS
+    ble_svc_ipss_init();
 #endif
 }

--- a/pkg/nimble/svc.ipss.mk
+++ b/pkg/nimble/svc.ipss.mk
@@ -1,0 +1,3 @@
+MODULE = nimble_svc_ipss
+
+include $(RIOTBASE)/Makefile.base


### PR DESCRIPTION
### Contribution description
Step 1 for enabling IPv6-over-BLE for NimBLE on RIOT. More to follow.

This PR adds support for building the `IPSS` (internet protocol support service) for NimBLE. The actual service is implemented in NimBLE upstream, so this PR only adds the corresponding makefiles and auto-init capabilities.

### Testing procedure
Simply build and flash `examples/nimble_gatt` with `USEMODULE=nimble_svc_ipss` and scan the device with a scanner of your choice. When doing a GATT service discovery, the `Internet Protocol Support Server` should show up.

Problem: we have a little hen-and-egg problem, as the service is not yet merged to NimBLE master (see https://github.com/apache/mynewt-nimble/pull/392), and also the NimBLE package in RIOT is not based on that branch. So for testing one hast to manually point the NimBLE package to the mentioned NimBLE branch (for now).

### Issues/PRs references
~~depends on NimBLE upstream PR: https://github.com/apache/mynewt-nimble/pull/392~~
~~#11273 will bump the NimBLE version in RIOT to pull in the above changes~~