### PR TITLE
gnrc_netif: fix fall-through comment

### DIFF
--- a/sys/net/gnrc/netif/gnrc_netif_device_type.c
+++ b/sys/net/gnrc/netif/gnrc_netif_device_type.c
@@ -75,8 +75,8 @@ int gnrc_netif_eui64_from_addr(const gnrc_netif_t *netif,
                     default:
                         break;
                 }
-                /* Intentionally falls through */
 #endif  /* defined(MODULE_NETDEV_IEEE802154) || defined(MODULE_XBEE) */
+                /* Intentionally falls through */
             default:
                 return l2util_eui64_from_addr(netif->device_type, addr,
                                               addr_len, eui64);


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
GCC 8.2.1 has problems with the comment being within the `#ifdef`
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Try compile on a somewhat recent Archlinux for native (should have v8.2.1. Without this PR it won't work.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up to #10589.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
