### PR TITLE
net/ndp: make addr array ptr c++ compliant

### DIFF
--- a/sys/include/net/ndp.h
+++ b/sys/include/net/ndp.h
@@ -338,6 +338,7 @@ typedef struct __attribute__((packed)) {
  * @extends ndp_opt_t
  *
  * @see     [RFC 8106, section 5.1](https://tools.ietf.org/html/rfc8106#section-5.1)
+ * @see     ndp_opt_rdnss_impl_t
  */
 typedef struct __attribute__((packed)) {
     uint8_t type;           /**< option type */
@@ -346,6 +347,24 @@ typedef struct __attribute__((packed)) {
     network_uint32_t ltime; /**< lifetime in seconds */
     ipv6_addr_t addrs[];    /**< addresses of IPv6 recursive DNS servers */
 } ndp_opt_rdnss_t;
+
+#ifndef __cplusplus
+/**
+ * @brief   Recursive DNS server option format with payload
+ * @extends ndp_opt_rdnss_t
+ * @details Auxiliary struct that contains a zero-length array as convenience
+ *          pointer to the addresses. Only for use in C, invalid in ISO-C++.
+ *
+ * @see     [RFC 8106, section 5.1](https://tools.ietf.org/html/rfc8106#section-5.1)
+ */
+typedef struct __attribute__((packed)) {
+    uint8_t type;           /**< option type */
+    uint8_t len;            /**< length in units of 8 octets */
+    network_uint16_t resv;  /**< reserved field */
+    network_uint32_t ltime; /**< lifetime in seconds */
+    ipv6_addr_t addrs[];    /**< addresses of IPv6 recursive DNS servers */
+} ndp_opt_rdnss_impl_t;
+#endif
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/ndp.h
+++ b/sys/include/net/ndp.h
@@ -334,7 +334,7 @@ typedef struct __attribute__((packed)) {
 } ndp_opt_mtu_t;
 
 /**
- * @brief   Recursive DNS server option format
+ * @brief   Recursive DNS server option format without payload
  * @extends ndp_opt_t
  *
  * @see     [RFC 8106, section 5.1](https://tools.ietf.org/html/rfc8106#section-5.1)
@@ -345,7 +345,6 @@ typedef struct __attribute__((packed)) {
     uint8_t len;            /**< length in units of 8 octets */
     network_uint16_t resv;  /**< reserved field */
     network_uint32_t ltime; /**< lifetime in seconds */
-    ipv6_addr_t addrs[];    /**< addresses of IPv6 recursive DNS servers */
 } ndp_opt_rdnss_t;
 
 #ifndef __cplusplus

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -413,7 +413,7 @@ static void _handle_mtuo(gnrc_netif_t *netif, const icmpv6_hdr_t *icmpv6,
                          const ndp_opt_mtu_t *mtuo);
 #if GNRC_IPV6_NIB_CONF_DNS
 static uint32_t _handle_rdnsso(gnrc_netif_t *netif, const icmpv6_hdr_t *icmpv6,
-                               const ndp_opt_rdnss_t *rdnsso);
+                               const ndp_opt_rdnss_impl_t *rdnsso);
 #endif
 #if GNRC_IPV6_NIB_CONF_MULTIHOP_P6C
 static uint32_t _handle_pio(gnrc_netif_t *netif, const icmpv6_hdr_t *icmpv6,
@@ -729,7 +729,7 @@ static void _handle_rtr_adv(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
             case NDP_OPT_RDNSS:
                 next_timeout = _min(_handle_rdnsso(netif,
                                                    (icmpv6_hdr_t *)rtr_adv,
-                                                   (ndp_opt_rdnss_t *)opt),
+                                                   (ndp_opt_rdnss_impl_t *)opt),
                                     next_timeout);
                 break;
 #endif
@@ -1349,7 +1349,7 @@ static void _handle_mtuo(gnrc_netif_t *netif, const icmpv6_hdr_t *icmpv6,
 
 #if GNRC_IPV6_NIB_CONF_DNS
 static uint32_t _handle_rdnsso(gnrc_netif_t *netif, const icmpv6_hdr_t *icmpv6,
-                               const ndp_opt_rdnss_t *rdnsso)
+                               const ndp_opt_rdnss_impl_t *rdnsso)
 {
     uint32_t ltime = UINT32_MAX;
     const ipv6_addr_t *addr;

--- a/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
+++ b/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
@@ -234,7 +234,7 @@ gnrc_pktsnip_t *gnrc_ndp_opt_rdnss_build(uint32_t ltime, ipv6_addr_t *addrs,
     gnrc_pktsnip_t *pkt = gnrc_ndp_opt_build(NDP_OPT_RDNSS, opt_size, next);
 
     if (pkt != NULL) {
-        ndp_opt_rdnss_t *rdnss_opt = pkt->data;
+        ndp_opt_rdnss_impl_t *rdnss_opt = pkt->data;
         rdnss_opt->resv.u16 = 0;
         rdnss_opt->ltime = byteorder_htonl(ltime);
         for (unsigned i = 0; i < addrs_num; i++) {


### PR DESCRIPTION
### Contribution description

This PR can be seen as a follow-up to #10248.
It is convenient to add a dynamic-sized array as the last member of a (header) structure to point at the first byte of payload, because it points there and doesn't use any space itself.
The downside is that dynamic-sized arrays are not compliant with ISO-C++.
The solution that we agreed upon in #10248 was to replace the convenience pointer with an inline method that handles the pointer arithmetic.

I was wondering about the best place for this function. The header ndp.h defines no function, so the definition there is a bit out of the ordinary, but in my view it makes sense to keep it close to the definition of the structure.

Maybe a note for the user in the struct def might be helpful. One could, for example, just make a remark where the member was defined, or mention the function in the struct doxygen description. Do you have thoughts on that?

### Testing procedure
To produce the compiler error, set up something that uses ndp (my [working example](https://github.com/llueder/RIOT/commit/97f12efe2c4f1a78e640f574702b0e05255db465) uses the coap example) and compile with C++

### Issues/PRs references
Addresses the same issue as #10248
The problem appears several times in different modules, so I will open PRs for those and list them here.
* tcp: #11300 
* uhcp: #11301 
* sock dns: #11302 
This PR shall contain the discussions that apply to all of these cases.