### PR TITLE
WIP net/sock dns: make header payload pointer c++ compliant

### DIFF
--- a/sys/include/net/sock/dns.h
+++ b/sys/include/net/sock/dns.h
@@ -34,7 +34,9 @@ extern "C" {
 #endif
 
 /**
- * @brief DNS internal structure
+ * @brief DNS internal structure without payload
+ *
+ * @see   sock_dns_hdr_impl_t
  */
 typedef struct {
     uint16_t id;        /**< read           */
@@ -42,8 +44,7 @@ typedef struct {
     uint16_t qdcount;   /**< RFC            */
     uint16_t ancount;   /**< for            */
     uint16_t nscount;   /**< detailed       */
-    uint16_t arcount;   /**< explanations   */
-    uint8_t payload[];  /**< !!             */
+    uint16_t arcount;   /**< explanations!! */
 } sock_dns_hdr_t;
 
 #ifndef __cplusplus

--- a/sys/include/net/sock/dns.h
+++ b/sys/include/net/sock/dns.h
@@ -46,6 +46,24 @@ typedef struct {
     uint8_t payload[];  /**< !!             */
 } sock_dns_hdr_t;
 
+#ifndef __cplusplus
+/**
+ * @brief   DNS internal structure with payload
+ * @extends sock_dns_hdr_t
+ * @details Auxiliary struct that contains a zero-length array as convenience
+ *          pointer to the payload. Only for use in C, invalid in ISO-C++.
+ */
+typedef struct {
+    uint16_t id;        /**< read           */
+    uint16_t flags;     /**< DNS            */
+    uint16_t qdcount;   /**< RFC            */
+    uint16_t ancount;   /**< for            */
+    uint16_t nscount;   /**< detailed       */
+    uint16_t arcount;   /**< explanations   */
+    uint8_t  payload[]; /**< !!             */
+} sock_dns_hdr_impl_t;
+#endif
+
 /**
  * @name DNS defines
  * @{


### PR DESCRIPTION
### Contribution description

Same as #11299 
I would like to keep discussions which are not specific for this dns case over at #11299 

In this special case, the struct is not packed, so I wrapped the solution that @jcarrano suggested for this case in the discussion in #10248 into the same form as in #11299