### PR TITLE
jlink.sh: Exit with an error on failure for JLinkExe commands

### DIFF
--- a/dist/tools/jlink/jlink.sh
+++ b/dist/tools/jlink/jlink.sh
@@ -170,6 +170,7 @@ do_flash() {
     cat ${RIOTTOOLS}/jlink/reset.seg >> ${BINDIR}/burn.seg
     # flash device
     sh -c "${JLINK} ${JLINK_SERIAL} \
+                    -ExitOnError 1 \
                     -device '${JLINK_DEVICE}' \
                     -speed '${JLINK_SPEED}' \
                     -if '${JLINK_IF}' \
@@ -218,6 +219,7 @@ do_reset() {
     test_serial
     # reset the board
     sh -c "${JLINK} ${JLINK_SERIAL} \
+                    -ExitOnError 1 \
                     -device '${JLINK_DEVICE}' \
                     -speed '${JLINK_SPEED}' \
                     -if '${JLINK_IF}' \
@@ -245,6 +247,7 @@ do_term() {
     trap '' INT
     # start Jlink as RTT server
     sh -c "${JLINK} ${JLINK_SERIAL} \
+            -ExitOnError 1 \
             -device '${JLINK_DEVICE}' \
             -speed '${JLINK_SPEED}' \
             -if '${JLINK_IF}' \


### PR DESCRIPTION
### Contribution description

On error Jlink exits with a no error code by default.

From the JLink User Guide:

'-ExitOnError' has the same meaning as the 'exitonerror' command

    'exitonerror' command
    This command toggles whether J-Link Commander exits on error or not.

    1: J-Link Commander will now exit on Error.
    0: J-Link Commander will no longer exit on Error.

Executing 'flash/reset' without a board connected now correctly returns an
error. For 'term' it does not show an error due to the way it is handled
internally.

It also returns an error when the board fails to do an operation when it
is in a state where it cannot be flashed for example.

### Testing procedure without board

Without a board connected run `flash` and `reset` for a board using jlink, it now fails correctly:

```
BOARD=nrf52dk make --no-print-directory -C examples/hello-world/ reset  && echo NO ERROR || echo ERROR
/home/harter/work/git/RIOT/dist/tools/jlink/jlink.sh reset
### Resetting Target ###
SEGGER J-Link Commander V6.42d (Compiled Feb 15 2019 13:56:53)
DLL version V6.42d, compiled Feb 15 2019 13:56:43

J-Link Commander will now exit on Error

J-Link Command File read successfully.
Processing script file...

J-Link connection not established yet but required for command.
Connecting to J-Link via USB...FAILED: Cannot connect to J-Link via USB.

Script processing completed.

/home/harter/work/git/RIOT/examples/hello-world/../../Makefile.include:569: recipe for target 'reset' failed
make: *** [reset] Error 1
ERROR
```

```
RIOT_CI_BUILD=1 BOARD=nrf52dk make --no-print-directory -C examples/hello-world/ flash && echo NO ERROR || echo ERROR
Building application "hello-world" for "nrf52dk" with MCU "nrf52".

   text    data     bss     dec     hex filename
   8048     136    2604   10788    2a24 /home/harter/work/git/RIOT/examples/hello-world/bin/nrf52dk/hello-world.elf
/home/harter/work/git/RIOT/dist/tools/jlink/jlink.sh flash /home/harter/work/git/RIOT/examples/hello-world/bin/nrf52dk/hello-world.bin
### Flashing Target ###
### Flashing at base address 0x0 with offset 0 ###
SEGGER J-Link Commander V6.42d (Compiled Feb 15 2019 13:56:53)
DLL version V6.42d, compiled Feb 15 2019 13:56:43

J-Link Commander will now exit on Error

J-Link Command File read successfully.
Processing script file...

J-Link connection not established yet but required for command.
Connecting to J-Link via USB...FAILED: Cannot connect to J-Link via USB.

Script processing completed.

/home/harter/work/git/RIOT/examples/hello-world/../../Makefile.include:538: recipe for target 'flash' failed
make: *** [flash] Error 1
ERROR
```

In master it was not reporting any error:


```
BOARD=nrf52dk make --no-print-directory -C examples/hello-world/ reset  && echo NO ERROR || echo ERROR
/home/harter/work/git/RIOT/dist/tools/jlink/jlink.sh reset
### Resetting Target ###
SEGGER J-Link Commander V6.42d (Compiled Feb 15 2019 13:56:53)
DLL version V6.42d, compiled Feb 15 2019 13:56:43


J-Link Command File read successfully.
Processing script file...

J-Link connection not established yet but required for command.
Connecting to J-Link via USB...FAILED: Cannot connect to J-Link via USB.

J-Link connection not established yet but required for command.
Connecting to J-Link via USB...FAILED: Cannot connect to J-Link via USB.


Script processing completed.

NO ERROR
```

```
RIOT_CI_BUILD=1 BOARD=nrf52dk make --no-print-directory -C examples/hello-world/ flash && echo NO ERROR || echo ERROR
Building application "hello-world" for "nrf52dk" with MCU "nrf52".

   text    data     bss     dec     hex filename
   8048     136    2604   10788    2a24 /home/harter/work/git/RIOT/examples/hello-world/bin/nrf52dk/hello-world.elf
/home/harter/work/git/RIOT/dist/tools/jlink/jlink.sh flash /home/harter/work/git/RIOT/examples/hello-world/bin/nrf52dk/hello-world.bin
### Flashing Target ###
### Flashing at base address 0x0 with offset 0 ###
SEGGER J-Link Commander V6.42d (Compiled Feb 15 2019 13:56:53)
DLL version V6.42d, compiled Feb 15 2019 13:56:43


J-Link Command File read successfully.
Processing script file...

J-Link connection not established yet but required for command.
Connecting to J-Link via USB...FAILED: Cannot connect to J-Link via USB.

J-Link connection not established yet but required for command.
Connecting to J-Link via USB...FAILED: Cannot connect to J-Link via USB.

J-Link connection not established yet but required for command.
Connecting to J-Link via USB...FAILED: Cannot connect to J-Link via USB.


Script processing completed.

NO ERROR
```

### Checking `term-rtt`:

Term still does not return any error on failure but at least it is put in the right mode:

With this diff:

``` diff
diff --git a/dist/tools/jlink/jlink.sh b/dist/tools/jlink/jlink.sh
index 4c463b46d..cea7c90d1 100755
--- a/dist/tools/jlink/jlink.sh
+++ b/dist/tools/jlink/jlink.sh
@@ -252,7 +252,7 @@ do_term() {
             -speed '${JLINK_SPEED}' \
             -if '${JLINK_IF}' \
             -jtagconf -1,-1 \
-            -commandfile '${RIOTTOOLS}/jlink/term.seg' >/dev/null & \
+            -commandfile '${RIOTTOOLS}/jlink/term.seg' & \
             echo  \$! > $JLINK_PIDFILE" &
 
     sh -c "${JLINK_TERMPROG} ${JLINK_TERMFLAGS}"
```

We now get a "J-Link Commander will now exit on Error" message that is not there in master.
I must be run with a BOARD using `stdio_rtt`.

```
BOARD=thingy52 make -C examples/hello-world/ term
make: Entering directory '/home/harter/work/git/RIOT/examples/hello-world'
/home/harter/work/git/RIOT/dist/tools/jlink/jlink.sh term_rtt
### Starting RTT terminal ###
SEGGER J-Link Commander V6.42d (Compiled Feb 15 2019 13:56:53)
DLL version V6.42d, compiled Feb 15 2019 13:56:43

J-Link Commander will now exit on Error

J-Link Command File read successfully.
Processing script file...

J-Link connection not established yet but required for command.
Connecting to J-Link via USB...Twisted not available, please install it if you want to use pyterm's JSON capabilities
2019-03-28 11:37:39,592 - WARNING # Host name for TCP connection is missing, defaulting to "localhost"
2019-03-28 11:37:39,592 - INFO # Connect to localhost:19021
2019-03-28 11:37:39,594 - ERROR # Something went wrong connecting to localhost:19021
make: Leaving directory '/home/harter/work/git/RIOT/examples/hello-world'
```

### Issues/PRs references

Split out of https://github.com/RIOT-OS/RIOT/pull/10870
Confronted again while testing #9013 