### PR TITLE
stm32 common/rtc: reset the rtc when clock source has changed

### DIFF
--- a/boards/b-l072z-lrwan1/include/periph_conf.h
+++ b/boards/b-l072z-lrwan1/include/periph_conf.h
@@ -31,6 +31,7 @@ extern "C" {
  */
 #define CLOCK_HSI           (16000000U)         /* internal oscillator */
 #define CLOCK_CORECLOCK     (32000000U)         /* desired core clock frequency */
+#define CLOCK_LSE           (1)                 /* enable low speed external oscillator */
 
 /* configuration of PLL prescaler and multiply values */
 /* CORECLOCK := HSI / CLOCK_PLL_DIV * CLOCK_PLL_MUL */

--- a/boards/nucleo-l073rz/include/periph_conf.h
+++ b/boards/nucleo-l073rz/include/periph_conf.h
@@ -35,6 +35,7 @@ extern "C" {
  */
 #define CLOCK_HSI           (16000000U)         /* internal oscillator */
 #define CLOCK_CORECLOCK     (32000000U)         /* desired core clock frequency */
+#define CLOCK_LSE           (1)                 /* enable low speed external oscillator */
 
 /* configuration of PLL prescaler and multiply values */
 /* CORECLOCK := HSI / CLOCK_PLL_DIV * CLOCK_PLL_MUL */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR tries to improve the situation when changing the low speed clock source from LSI to LSE on L0/L1 boards.

On master, doing this no nucleo-l073rz/b-l072z-lrwan1 results in `rtc_init` being stuck when switching from LSI to LSE. With this PR, this is fixed.

I mark this as RFC because I'm not 100% sure the approach is ok.

I think the problem comes from how the RTC init is performed on a board reset (software or POR).

See reference manual RM0376, section 7.2.12, page 182:
`Once the RTC clock source have been selected, the only possible way of modifying the selection is to set the RTCRST bit in the RCC_CSR register, or by a POR.`

So the fix is to set the RTCRST bit when the clock source has changed. The source detection is done by using a magic number stored in a backup register of the RTC.

I haven't check if the approach would also work for other STM32 families.

This PR is also enabling LSE for nucleo-l073rz and b-l072z-lrwan1. I tested it on them with good results.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

1. Build and flash `tests/periph_rtc` on related boards => the `Alarm` are displayed ok
2. Change to CLOCK_LSE = 0 in `periph_conf.h` and run 1. again
3. Change to CLOCK_LSE = 1 in `periph_conf.h` and run 1. again

In master, step 3 would hang. With this PR is still works.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Fix for https://github.com/RIOT-OS/RIOT/pull/11266#issuecomment-477550574

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
