### PR TITLE
tests/periph_flashpage: add RWWEE automatic test if hw supports it

### DIFF
--- a/tests/periph_flashpage/tests/01-run.py
+++ b/tests/periph_flashpage/tests/01-run.py
@@ -11,6 +11,10 @@ from testrunner import run
 
 
 def testfunc(child):
+    # Make sure we are at a clean prompt before starting
+    child.sendline("")
+    child.expect('>')
+
     # writes and verifies the last page of the flash
     child.sendline("test_last")
     child.expect_exact('wrote local page buffer to last flash page')
@@ -23,6 +27,15 @@ def testfunc(child):
     if index == 0:
         child.sendline("test_last_raw")
         child.expect_exact('wrote raw short buffer to last flash page')
+        child.expect('>')
+
+    # check if board has RWWEE capability and if so test that as well
+    # capability is deduced from help contents
+    child.sendline("help")
+    index = child.expect(['test_last_rwwee', '>'])
+    if index == 0:
+        child.sendline("test_last_rwwee")
+        child.expect_exact('wrote local page buffer to last RWWEE flash page')
         child.expect('>')
 
 


### PR DESCRIPTION
### Contribution description
This small PR adds automatic tests for RWWEE flash for which support was added in  #10884 . The test checks if the board implements this feature and if so runs and automatic test.
While adding this a small improvement was done that improves its stability: before sending commands we make sure the command prompt is reached.

I tested this succesfully on a board with RWWEE (saml21-xpro) and one without (stk3700).

### Testing procedure
Automatic tests in tests/periph_flashpage can be built and executed
```
cd tests/periph_flashpage
BOARD=xyz make all flash test
```

### Issues/PRs references
Adds automatic testing for #10884 improving #10106
