### PR TITLE
netopt: specify drop of device driver support for IPV6_IID

### DIFF
--- a/sys/include/net/netopt.h
+++ b/sys/include/net/netopt.h
@@ -110,6 +110,8 @@ typedef enum {
      *
      * @deprecated  Do not implement this in a network device. Other APIs
      *              utilizing [netopt](@ref net_netopt) may still implement it.
+     *              Existing support of drivers will be dropped after the
+     *              2019.07 release.
      *
      * The generation of the interface identifier is dependent on the link-layer.
      * Please refer to the appropriate IPv6 over `<link>` specification for


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
With #10599 and #10596 being merged, `NETOPT_IPV6_IID` is not used anymore within the RIOT code-base (except for some tests that just test the `netdev`/`gnrc_netif` behaviour for this option, which I will remove in the next couple of days) so it is time to plan the removal of the driver support. The deprecation was already put up for the 2019.01 release, so I think removing it for the 2019.07 release seems reasonable.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Compile `make doc`.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up to #10589, #10596, and #10599. 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
