### PR TITLE
tests: remove NETOPT_IPV6_IID dependency from lwip_sock tests

### DIFF
--- a/tests/lwip_sock_ip/Makefile
+++ b/tests/lwip_sock_ip/Makefile
@@ -29,6 +29,7 @@ ifneq (0, $(LWIP_IPV6))
 endif
 
 USEMODULE += inet_csum
+USEMODULE += l2util
 USEMODULE += lwip_netdev
 USEMODULE += lwip_sock_ip
 USEMODULE += netdev_eth

--- a/tests/lwip_sock_ip/stack.c
+++ b/tests/lwip_sock_ip/stack.c
@@ -50,14 +50,6 @@ static kernel_pid_t _check_pid = KERNEL_PID_UNDEF;
 static mutex_t _netdev_buffer_mutex = MUTEX_INIT;
 static uint8_t _netdev_buffer_size;
 
-static inline void _get_iid(uint8_t *iid)
-{
-    uint8_t _local_ip[] = _TEST_ADDR6_LOCAL;
-
-    memcpy(iid, &_local_ip[8], sizeof(uint64_t));
-    iid[0] ^= 0x2;
-}
-
 static int _get_max_pkt_size(netdev_t *dev, void *value, size_t max_len)
 {
     return netdev_eth_get(dev, NETOPT_MAX_PDU_SIZE, value, max_len);
@@ -79,24 +71,13 @@ static int _get_src_len(netdev_t *dev, void *value, size_t max_len)
 
 static int _get_addr(netdev_t *dev, void *value, size_t max_len)
 {
-    uint8_t iid[ETHERNET_ADDR_LEN + 2];
-    uint8_t *addr = value;
+    static const uint8_t _local_ip[] = _TEST_ADDR6_LOCAL;
 
     (void)dev;
-    if (max_len < ETHERNET_ADDR_LEN) {
-        return -EOVERFLOW;
-    }
-
-    _get_iid(iid);
-
-    addr[0] = iid[0];
-    addr[1] = iid[1];
-    addr[2] = iid[2];
-    addr[3] = iid[5];
-    addr[4] = iid[6];
-    addr[5] = iid[7];
-
-    return ETHERNET_ADDR_LEN;
+    assert(max_len >= ETHERNET_ADDR_LEN);
+    return l2util_ipv6_iid_to_addr(NETDEV_TYPE_ETHERNET,
+                                   (eui64_t *)&_local_ip[8],
+                                   value);
 }
 
 static int _get_addr_len(netdev_t *dev, void *value, size_t max_len)
@@ -107,16 +88,6 @@ static int _get_addr_len(netdev_t *dev, void *value, size_t max_len)
 static int _get_device_type(netdev_t *dev, void *value, size_t max_len)
 {
     return netdev_eth_get(dev, NETOPT_DEVICE_TYPE, value, max_len);
-}
-
-static int _get_ipv6_iid(netdev_t *dev, void *value, size_t max_len)
-{
-    (void)dev;
-    if (max_len != sizeof(uint64_t)) {
-        return -EOVERFLOW;
-    }
-    _get_iid(value);
-    return sizeof(uint64_t);
 }
 
 static void _netdev_isr(netdev_t *dev)
@@ -181,8 +152,6 @@ void _net_init(void)
                             _get_addr_len);
     netdev_test_set_get_cb(&netdev, NETOPT_DEVICE_TYPE,
                             _get_device_type);
-    netdev_test_set_get_cb(&netdev, NETOPT_IPV6_IID,
-                            _get_ipv6_iid);
     netdev_test_set_recv_cb(&netdev, _netdev_recv);
     netdev_test_set_isr_cb(&netdev, _netdev_isr);
     /* netdev needs to be set-up */

--- a/tests/lwip_sock_udp/Makefile
+++ b/tests/lwip_sock_udp/Makefile
@@ -29,6 +29,7 @@ ifneq (0, $(LWIP_IPV6))
 endif
 
 USEMODULE += inet_csum
+USEMODULE += l2util
 USEMODULE += lwip_netdev
 USEMODULE += lwip_sock_udp
 USEMODULE += netdev_eth

--- a/tests/lwip_sock_udp/stack.c
+++ b/tests/lwip_sock_udp/stack.c
@@ -18,6 +18,7 @@
 #include "msg.h"
 #include "net/ethernet.h"
 #include "net/ipv6.h"
+#include "net/l2util.h"
 #include "net/netdev/eth.h"
 #include "net/netdev_test.h"
 #include "net/sock.h"
@@ -51,14 +52,6 @@ static kernel_pid_t _check_pid = KERNEL_PID_UNDEF;
 static mutex_t _netdev_buffer_mutex = MUTEX_INIT;
 static uint8_t _netdev_buffer_size;
 
-static inline void _get_iid(uint8_t *iid)
-{
-    static const uint8_t _local_ip[] = _TEST_ADDR6_LOCAL;
-
-    memcpy(iid, &_local_ip[8], sizeof(uint64_t));
-    iid[0] ^= 0x2;
-}
-
 static int _get_max_pkt_size(netdev_t *dev, void *value, size_t max_len)
 {
     return netdev_eth_get(dev, NETOPT_MAX_PDU_SIZE, value, max_len);
@@ -80,24 +73,13 @@ static int _get_src_len(netdev_t *dev, void *value, size_t max_len)
 
 static int _get_addr(netdev_t *dev, void *value, size_t max_len)
 {
-    uint8_t iid[ETHERNET_ADDR_LEN + 2];
-    uint8_t *addr = value;
+    static const uint8_t _local_ip[] = _TEST_ADDR6_LOCAL;
 
     (void)dev;
-    if (max_len < ETHERNET_ADDR_LEN) {
-        return -EOVERFLOW;
-    }
-
-    _get_iid(iid);
-
-    addr[0] = iid[0];
-    addr[1] = iid[1];
-    addr[2] = iid[2];
-    addr[3] = iid[5];
-    addr[4] = iid[6];
-    addr[5] = iid[7];
-
-    return ETHERNET_ADDR_LEN;
+    assert(max_len >= ETHERNET_ADDR_LEN);
+    return l2util_ipv6_iid_to_addr(NETDEV_TYPE_ETHERNET,
+                                   (eui64_t *)&_local_ip[8],
+                                   value);
 }
 
 static int _get_addr_len(netdev_t *dev, void *value, size_t max_len)
@@ -108,16 +90,6 @@ static int _get_addr_len(netdev_t *dev, void *value, size_t max_len)
 static int _get_device_type(netdev_t *dev, void *value, size_t max_len)
 {
     return netdev_eth_get(dev, NETOPT_DEVICE_TYPE, value, max_len);
-}
-
-static int _get_ipv6_iid(netdev_t *dev, void *value, size_t max_len)
-{
-    (void)dev;
-    if (max_len != sizeof(uint64_t)) {
-        return -EOVERFLOW;
-    }
-    _get_iid(value);
-    return sizeof(uint64_t);
 }
 
 static void _netdev_isr(netdev_t *dev)
@@ -183,8 +155,6 @@ void _net_init(void)
                             _get_addr_len);
     netdev_test_set_get_cb(&netdev, NETOPT_DEVICE_TYPE,
                             _get_device_type);
-    netdev_test_set_get_cb(&netdev, NETOPT_IPV6_IID,
-                            _get_ipv6_iid);
     netdev_test_set_recv_cb(&netdev, _netdev_recv);
     netdev_test_set_isr_cb(&netdev, _netdev_isr);
     /* netdev needs to be set-up */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This removes some code duplication and the provision of `NETOPT_IPV6_IID` through the mock device from the `lwip_sock` tests.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Run

- `make -C tests/lwip_sock_ip all test`
- `make -C tests/lwip_sock_udp all test`

`native` and `LWIP_IPV6` suffice.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
