### PR TITLE
sys: make uart_stdio RX optional (attempt #2)

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -396,8 +396,18 @@ ifneq (,$(filter stdio_rtt,$(USEMODULE)))
   USEMODULE += xtimer
 endif
 
-ifneq (,$(filter stdio_uart,$(USEMODULE)))
+ifneq (,$(filter shell,$(USEMODULE)))
+  ifneq (,$(filter stdio_uart,$(USEMODULE)))
+    USEMODULE += stdio_uart_rx
+  endif
+endif
+
+ifneq (,$(filter stdio_uart_rx,$(USEMODULE)))
   USEMODULE += isrpipe
+  USEMODULE += stdio_uart
+endif
+
+ifneq (,$(filter stdio_uart,$(USEMODULE)))
   FEATURES_REQUIRED += periph_uart
 endif
 

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -67,6 +67,7 @@ PSEUDOMODULES += sock
 PSEUDOMODULES += sock_ip
 PSEUDOMODULES += sock_tcp
 PSEUDOMODULES += sock_udp
+PSEUDOMODULES += stdio_uart_rx
 
 # print ascii representation in function od_hex_dump()
 PSEUDOMODULES += od_string


### PR DESCRIPTION

### Contribution description

This is a rebase of #7974 that fixes conflicts. This allows to not block the low power mode if the shell is not used.

### Issues/PRs references

#7974
