### PR TITLE
cpu/stm32l1: fix issue when  writing NULL bytes to eeprom

### DIFF
--- a/cpu/stm32_common/periph/eeprom.c
+++ b/cpu/stm32_common/periph/eeprom.c
@@ -94,7 +94,7 @@ size_t eeprom_read(uint32_t pos, uint8_t *data, size_t len)
     DEBUG("Reading data from EEPROM at pos %" PRIu32 ": ", pos);
     for (size_t i = 0; i < len; i++) {
         _wait_for_pending_operations();
-        *p++ = *(uint8_t *)(EEPROM_START_ADDR + pos++);
+        *p++ = *(__IO uint8_t *)(EEPROM_START_ADDR + pos++);
         DEBUG("0x%02X ", *p);
     }
     DEBUG("\n");

--- a/cpu/stm32_common/periph/eeprom.c
+++ b/cpu/stm32_common/periph/eeprom.c
@@ -16,6 +16,7 @@
  *
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  * @author      Oleg Artamonov <oleg@unwds.com>
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  *
  * @}
  */
@@ -35,6 +36,54 @@ extern void _wait_for_pending_operations(void);
 #ifndef EEPROM_START_ADDR
 #error "periph/eeprom: EEPROM_START_ADDR is not defined"
 #endif
+
+#if defined(CPU_MODEL_STM32L151CB)
+#define ALIGN_MASK          (0x00000003)
+#define BYTE_MASK           (0xFF)
+#define BYTE_BITS           (0x08)
+
+static void _erase_word(uint32_t addr)
+{
+    /* Wait for last operation to be completed */
+    _wait_for_pending_operations();
+
+    /* Write "00000000h" to valid address in the data memory" */
+    *(__IO uint32_t *)addr = 0x00000000;
+}
+
+static void _write_word(uint32_t addr, uint32_t data)
+{
+    /* Wait for last operation to be completed */
+    _wait_for_pending_operations();
+
+    *(__IO uint32_t *)addr = data;
+}
+#endif
+
+static void _write_byte(uint32_t addr, uint8_t data)
+{
+    /* Wait for last operation to be completed */
+    _wait_for_pending_operations();
+
+#if defined(CPU_MODEL_STM32L151CB)
+    /* stm32l1xxx cat 1 can't write NULL bytes RefManual p79*/
+    uint32_t tmp = 0;
+    uint32_t data_mask = 0;
+
+    if (data != (uint8_t)0x00) {
+        *(__IO uint8_t *)addr = data;
+    }
+    else {
+        tmp = *(__IO uint32_t *)(addr & (~ALIGN_MASK));
+        data_mask = BYTE_MASK << ((uint32_t)(BYTE_BITS * (addr & ALIGN_MASK)));
+        tmp &= ~data_mask;
+        _erase_word(addr & (~ALIGN_MASK));
+        _write_word((addr & (~ALIGN_MASK)), tmp);
+    }
+#else
+    *(__IO uint8_t *)addr = data;
+#endif
+}
 
 size_t eeprom_read(uint32_t pos, uint8_t *data, size_t len)
 {
@@ -62,8 +111,7 @@ size_t eeprom_write(uint32_t pos, const uint8_t *data, size_t len)
     _unlock();
 
     for (size_t i = 0; i < len; i++) {
-        _wait_for_pending_operations();
-        *(uint8_t *)(EEPROM_START_ADDR + pos++) = *p++;
+        _write_byte((EEPROM_START_ADDR + pos++), *p++);
     }
 
     _lock();


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR fixes an issue where category 1,2,3 stm32l1xxx devices can't write NULL bytes to eeprom (reference manual pag 78). If this is attempted the app freezes.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

You need a category 1,2 or 3 board. eg: im880b or lobaro-lorabox. Run:

`make -C tests/periph_eeprom BOARD=im880b test
`

without this PR failes.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

Can use #11315 to test. ~~Depends on #11355~~.