### PR TITLE
boards: add support for im880b lora board

### DIFF
--- a/boards/im880b/Makefile
+++ b/boards/im880b/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/im880b/Makefile.dep
+++ b/boards/im880b/Makefile.dep
@@ -1,0 +1,3 @@
+ifneq (,$(filter netdev_default,$(USEMODULE)))
+  USEMODULE += sx1272
+endif

--- a/boards/im880b/Makefile.features
+++ b/boards/im880b/Makefile.features
@@ -1,0 +1,11 @@
+## the cpu to build for
+CPU = stm32l1
+CPU_MODEL = stm32l151cb
+
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart

--- a/boards/im880b/Makefile.include
+++ b/boards/im880b/Makefile.include
@@ -1,0 +1,14 @@
+# define the default port depending on the host OS
+PORT_LINUX ?= /dev/ttyUSB0
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+
+# setup serial terminal
+include $(RIOTMAKE)/tools/serial.inc.mk
+
+DEBUG_ADAPTER ?= stlink
+
+CFLAGS+=-DSX127X_TX_SWITCH
+CFLAGS+=-DSX127X_RX_SWITCH
+
+# this board uses openocd
+include $(RIOTMAKE)/tools/openocd.inc.mk

--- a/boards/im880b/board.c
+++ b/boards/im880b/board.c
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2019 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_im880b
+ * @{
+ *
+ * @file
+ * @brief       Board specific implementations for the im880b board
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ *
+ * @}
+ */
+
+#include "board.h"
+#include "periph/gpio.h"
+
+void board_init(void)
+{
+    /* initialize the CPU */
+    cpu_init();
+}

--- a/boards/im880b/doc.txt
+++ b/boards/im880b/doc.txt
@@ -1,0 +1,73 @@
+/**
+@defgroup    boards_im880b im880b
+@ingroup     boards
+@brief       Support for the im880b with stm32l151cb-a
+
+## Hardware
+
+![LoraBox](https://www.wireless-solutions.de/images/stories/products/im880a.png)
+
+
+### MCU
+| MCU        | stm32l151cb-a |
+|:------------- |:--------------------- |
+| Family | ARM Cortex-M3     |
+| Vendor | ST Microelectronics   |
+| RAM        | 16Kb  |
+| Flash      | 128Kb             |
+| Frequency  | 32MHz (no external oscilator connected) |
+| FPU        | no                |
+| Timers | 10 (8x 16-bit, 2x watchdog timers)   |
+| ADCs       | 1x 24-channel 12-bit          |
+| UARTs      | 3                 |
+| SPIs       | 2                 |
+| I2Cs       | 2                 |
+| Vcc        | 1.65V - 3.6V          |
+| Datasheet  | [Datasheet](https://www.st.com/resource/en/datasheet/stm32l151cb-a.pdf) |
+| Reference Manual | [Reference Manual](https://www.st.com/content/ccc/resource/technical/document/reference_manual/cc/f9/93/b2/f0/82/42/57/CD00240193.pdf/files/CD00240193.pdf/jcr:content/translations/en.CD00240193.pdf) |
+| Programming Manual | [Programming Manual](https://www.st.com/content/ccc/resource/technical/document/programming_manual/5b/ca/8d/83/56/7f/40/08/CD00228163.pdf/files/CD00228163.pdf/jcr:content/translations/en.CD00228163.pdf) |
+| Board Manual   | [Board Manual](https://cdn.sos.sk/productdata/29/eb/a68245ed/im880b-l-lorawan.pdf)|
+
+### User Interface
+
+## Flashing
+As no usb connector is present on the device an external programmer must
+be connected to the board for flashing. You can use JTAG or STLINK programmer.
+
+ *  JTAG:
+ *    - JTDO: PB_3 / P39
+ *    - JTDI: PA_15 / P38
+ *    - JTCK: PA_14 / P37
+ *    - JTMS: PA_13 / P34
+
+ *  STLINK:
+ *    - NRST: NRST / P7
+ *    - SWCLK: PA_14 / P37
+ *    - SWDAT: PA_13 / P34
+
+### STM32 Loader
+To flash RIOT on the board, after connecting the UART-USB bridge, just run:
+```
+BOARD=im880b make flash
+```
+This uses the stm32loader script to erase the memory and flash it interfacing
+with the STM32 ROM bootloader.
+
+## Connecting via Serial
+The default UART port is the USART1, there is no usb connection a USB/TTL
+converter must be used to connect to the board TX & RX pins. The default
+port is /dev/ttyUSB0. The pin connections are:
+
+ *  USART1:
+ *    - TX: PA_9 / P30
+ *    - RX: PA_10 / P31
+
+```
+BOARD=im880b make term
+```
+ */
+
+## SX1272 radio
+Please note that the board has a Semtech SX1272 radio. This means that when the
+semtech-loramac package or the sx127x driver are used the correct driver version
+(sx1272) must be selected.

--- a/boards/im880b/include/board.h
+++ b/boards/im880b/include/board.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2019 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_im880b
+ * @brief       Support for im880b
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the im880b board.
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include <stdint.h>
+
+#include "cpu.h"
+#include "periph_conf.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    xtimer configuration
+ * @{
+ */
+#define XTIMER_BACKOFF              (11)
+#define XTIMER_WIDTH                (16)
+/** @} */
+
+/**
+ * @name    sx1272 configuration
+ * @{
+ */
+#define SX127X_PARAM_SPI_NSS                GPIO_PIN(PORT_B, 0)
+
+#define SX127X_PARAM_RESET                  GPIO_PIN(PORT_A, 2)
+#define SX127X_PARAM_DIO0                   GPIO_PIN(PORT_B, 1)
+#define SX127X_PARAM_DIO1                   GPIO_PIN(PORT_B, 10)
+#define SX127X_PARAM_DIO2                   GPIO_PIN(PORT_B, 11)
+/* stm32l1xxx Errata: Pull-up on PB7 when configured in analog mode */
+#define SX127X_PARAM_DIO3                   GPIO_PIN(PORT_B, 7)
+
+#define SX127X_PARAM_RX_SWITCH              GPIO_PIN(PORT_C, 13)
+#define SX127X_PARAM_TX_SWITCH              GPIO_PIN(PORT_A, 4)
+/** @} */
+
+
+/**
+ * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/im880b/include/board.h
+++ b/boards/im880b/include/board.h
@@ -50,6 +50,8 @@ extern "C" {
 /* stm32l1xxx Errata: Pull-up on PB7 when configured in analog mode */
 #define SX127X_PARAM_DIO3                   GPIO_PIN(PORT_B, 7)
 
+#define SX127X_PARAM_PASELECT               (SX127X_PA_BOOST)
+
 #define SX127X_PARAM_RX_SWITCH              GPIO_PIN(PORT_C, 13)
 #define SX127X_PARAM_TX_SWITCH              GPIO_PIN(PORT_A, 4)
 /** @} */

--- a/boards/im880b/include/periph_conf.h
+++ b/boards/im880b/include/periph_conf.h
@@ -1,0 +1,209 @@
+/*
+ * Copyright (C) 2019 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_im880b
+ * @{
+ *
+ * @file
+ * @brief       Peripheral MCU configuration for the im808b board
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Clock system configuration
+ * @{
+ **/
+#define CLOCK_HSE           (16000000U)         /* external oscillator */
+#define CLOCK_CORECLOCK     (32000000U)         /* desired core clock frequency */
+
+/*
+ * 0: no external low speed crystal available,
+ * 1: external crystal available (always 32.768kHz)
+ */
+#ifndef CLOCK_LSE
+#define CLOCK_LSE           (1)
+#endif
+/* configuration of PLL prescaler and multiply values */
+/* CORECLOCK := HSE / CLOCK_PLL_DIV * CLOCK_PLL_MUL */
+#define CLOCK_PLL_DIV       RCC_CFGR_PLLDIV2
+#define CLOCK_PLL_MUL       RCC_CFGR_PLLMUL4
+/* configuration of peripheral bus clock prescalers */
+#define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1      /* AHB clock -> 32MHz */
+#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV1     /* APB2 clock -> 32MHz */
+#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV1     /* APB1 clock -> 32MHz */
+/* configuration of flash access cycles */
+#define CLOCK_FLASH_LATENCY FLASH_ACR_LATENCY
+
+/* bus clocks for simplified peripheral initialization, UPDATE MANUALLY! */
+#define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
+#define CLOCK_APB1          (CLOCK_CORECLOCK / 1)
+#define CLOCK_APB2          (CLOCK_CORECLOCK / 1)
+/** @} */
+
+/**
+ * @name    Timer configuration
+ * @{
+ */
+static const timer_conf_t timer_config[] = {
+    {
+        .dev      = TIM3,
+        .max      = 0x0000ffff,
+        .rcc_mask = RCC_APB1ENR_TIM3EN,
+        .bus      = APB1,
+        .irqn     = TIM3_IRQn
+    }
+};
+
+#define TIMER_0_ISR         (isr_tim3)
+
+#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+/** @} */
+
+/**
+ * @name    UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev      = USART1,
+        .rcc_mask = RCC_APB2ENR_USART1EN,
+        .rx_pin   = GPIO_PIN(PORT_A, 10),
+        .tx_pin   = GPIO_PIN(PORT_A, 9),
+        .rx_af    = GPIO_AF7,
+        .tx_af    = GPIO_AF7,
+        .bus      = APB2,
+        .irqn     = USART1_IRQn
+    },
+};
+
+#define UART_0_ISR          (isr_usart1)
+
+#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+/** @} */
+
+/**
+ * @name    SPI configuration
+ *
+ * @note    The spi_divtable is auto-generated from
+ *          `cpu/stm32_common/dist/spi_divtable/spi_divtable.c`
+ * @{
+ */
+static const uint8_t spi_divtable[2][5] = {
+    {       /* for APB1 @ 32000000Hz */
+        7,  /* -> 125000Hz */
+        5,  /* -> 500000Hz */
+        4,  /* -> 1000000Hz */
+        2,  /* -> 4000000Hz */
+        1   /* -> 8000000Hz */
+    },
+    {       /* for APB2 @ 32000000Hz */
+        7,  /* -> 125000Hz */
+        5,  /* -> 500000Hz */
+        4,  /* -> 1000000Hz */
+        2,  /* -> 4000000Hz */
+        1   /* -> 8000000Hz */
+    }
+};
+
+static const spi_conf_t spi_config[] = {
+    {
+        .dev      = SPI1,
+        .mosi_pin = GPIO_PIN(PORT_A, 7),
+        .miso_pin = GPIO_PIN(PORT_A, 6),
+        .sclk_pin = GPIO_PIN(PORT_A, 5),
+        .cs_pin   = GPIO_UNDEF,
+        .mosi_af  = GPIO_AF5,
+        .miso_af  = GPIO_AF5,
+        .sclk_af  = GPIO_AF5,
+        .cs_af    = GPIO_AF5,
+        .rccmask  = RCC_APB2ENR_SPI1EN,
+        .apbbus   = APB2
+    },
+    {
+        .dev      = SPI2,
+        .mosi_pin = GPIO_PIN(PORT_B, 14),
+        .miso_pin = GPIO_PIN(PORT_B, 15),
+        .sclk_pin = GPIO_PIN(PORT_B, 13),
+        .cs_pin   = GPIO_PIN(PORT_B, 12),
+        .mosi_af  = GPIO_AF5,
+        .miso_af  = GPIO_AF5,
+        .sclk_af  = GPIO_AF5,
+        .cs_af    = GPIO_AF5,
+        .rccmask  = RCC_APB1ENR_SPI2EN,
+        .apbbus   = APB1
+    }
+};
+
+#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+/** @} */
+
+/**
+ * @name    I2C configuration
+ * @{
+ */
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev            = I2C1,
+        .speed          = I2C_SPEED_NORMAL,
+        .scl_pin        = GPIO_PIN(PORT_B, 8),
+        .sda_pin        = GPIO_PIN(PORT_B, 9),
+        .scl_af         = GPIO_AF4,
+        .sda_af         = GPIO_AF4,
+        .bus            = APB1,
+        .rcc_mask       = RCC_APB1ENR_I2C1EN,
+        .clk            = CLOCK_APB1,
+        .irqn           = I2C1_EV_IRQn
+    }
+};
+
+#define I2C_0_ISR           isr_i2c1_ev
+
+#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+/** @} */
+
+/**
+ * @name    RTC configuration
+ * @{
+ */
+#define RTC_NUMOF           (1U)
+/** @} */
+
+/**
+ * @name    ADC configuration
+ * @{
+ */
+#define ADC_CONFIG {              \
+    { GPIO_PIN(PORT_A, 0), 0 }, /* P14 */ \
+    { GPIO_PIN(PORT_A, 1), 1 }, /* P15 */ \
+    { GPIO_PIN(PORT_A, 3), 3 }, /* P17 */ \
+    /* ADC Temperature channel */ \
+    { GPIO_UNDEF,          16 },  \
+    /* ADC VREF channel */        \
+    { GPIO_UNDEF,          17 },  \
+}
+
+#define ADC_NUMOF           (5)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/examples/asymcute_mqttsn/Makefile.ci
+++ b/examples/asymcute_mqttsn/Makefile.ci
@@ -12,6 +12,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \
+    im880b \
     mega-xplained \
     microbit \
     microduino-corerf \

--- a/examples/cord_ep/Makefile.ci
+++ b/examples/cord_ep/Makefile.ci
@@ -11,6 +11,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \
+    im880b \
     mega-xplained \
     microduino-corerf \
     msb-430 \

--- a/examples/dtls-echo/Makefile.ci
+++ b/examples/dtls-echo/Makefile.ci
@@ -9,6 +9,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \
+    im880b \
     lsn50 \
     maple-mini \
     microbit \

--- a/examples/dtls-sock/Makefile.ci
+++ b/examples/dtls-sock/Makefile.ci
@@ -11,6 +11,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \
+    im880b \
     lsn50 \
     maple-mini \
     microbit \

--- a/examples/dtls-wolfssl/Makefile.ci
+++ b/examples/dtls-wolfssl/Makefile.ci
@@ -8,6 +8,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     cc2650stk \
     hifive1 \
     i-nucleo-lrwan1 \
+    im880b \
     maple-mini \
     microbit \
     nrf51dongle \

--- a/examples/emcute_mqttsn/Makefile.ci
+++ b/examples/emcute_mqttsn/Makefile.ci
@@ -11,6 +11,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \
+    im880b \
     mega-xplained \
     microduino-corerf \
     msb-430 \

--- a/examples/gnrc_border_router/Makefile.ci
+++ b/examples/gnrc_border_router/Makefile.ci
@@ -19,6 +19,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \
+    im880b \
     lsn50 \
     maple-mini \
     mega-xplained \

--- a/examples/gnrc_networking/Makefile.ci
+++ b/examples/gnrc_networking/Makefile.ci
@@ -14,6 +14,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \
+    im880b \
     mega-xplained \
     microbit \
     microduino-corerf \

--- a/examples/javascript/Makefile.ci
+++ b/examples/javascript/Makefile.ci
@@ -11,6 +11,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \
+    im880b \
     lobaro-lorabox \
     lsn50 \
     maple-mini \

--- a/examples/lua_REPL/Makefile.ci
+++ b/examples/lua_REPL/Makefile.ci
@@ -23,6 +23,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     hamilton \
     i-nucleo-lrwan1 \
     ikea-tradfri \
+    im880b \
     limifrog-v1 \
     lobaro-lorabox \
     lsn50 \

--- a/examples/lua_basic/Makefile.ci
+++ b/examples/lua_basic/Makefile.ci
@@ -7,6 +7,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     cc2650-launchpad \
     cc2650stk \
     i-nucleo-lrwan1 \
+    im880b \
     lobaro-lorabox \
     maple-mini \
     microbit \

--- a/examples/posix_sockets/Makefile.ci
+++ b/examples/posix_sockets/Makefile.ci
@@ -10,6 +10,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     chronos \
     derfmega128 \
     i-nucleo-lrwan1 \
+    im880b \
     mega-xplained \
     microduino-corerf \
     msb-430 \

--- a/examples/wakaama/Makefile.ci
+++ b/examples/wakaama/Makefile.ci
@@ -9,6 +9,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \
+    im880b \
     lsn50 \
     maple-mini \
     microbit \
@@ -16,12 +17,11 @@ BOARD_INSUFFICIENT_MEMORY := \
     nrf6310 \
     nucleo-f030r8 \
     nucleo-f031k6 \
-    nucleo-f302r8 \
-    nucleo-f303k8 \
     nucleo-f042k6 \
     nucleo-f070rb \
     nucleo-f072rb \
     nucleo-f302r8 \
+    nucleo-f303k8 \
     nucleo-f334r8 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/bench_xtimer/Makefile.ci
+++ b/tests/bench_xtimer/Makefile.ci
@@ -1,3 +1,4 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    im880b \
     olimexino-stm32 \
     #

--- a/tests/conn_can/Makefile.ci
+++ b/tests/conn_can/Makefile.ci
@@ -11,6 +11,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \
+    im880b \
     microbit \
     msb-430 \
     msb-430h \

--- a/tests/driver_cc110x/Makefile.ci
+++ b/tests/driver_cc110x/Makefile.ci
@@ -12,6 +12,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \
+    im880b \
     mega-xplained \
     microduino-corerf \
     nucleo-f031k6 \

--- a/tests/emcute/Makefile.ci
+++ b/tests/emcute/Makefile.ci
@@ -20,6 +20,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \
+    im880b \
     lsn50 \
     maple-mini \
     mega-xplained \

--- a/tests/gnrc_dhcpv6_client/Makefile.ci
+++ b/tests/gnrc_dhcpv6_client/Makefile.ci
@@ -10,6 +10,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \
+    im880b \
     mega-xplained \
     microduino-corerf \
     msb-430 \

--- a/tests/gnrc_dhcpv6_client_6lbr/Makefile.ci
+++ b/tests/gnrc_dhcpv6_client_6lbr/Makefile.ci
@@ -19,6 +19,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \
+    im880b \
     lsn50 \
     maple-mini \
     mega-xplained \

--- a/tests/gnrc_ipv6_ext/Makefile.ci
+++ b/tests/gnrc_ipv6_ext/Makefile.ci
@@ -9,6 +9,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     derfmega128 \
     hifive1 \
     hifive1b \
+    im880b \
     i-nucleo-lrwan1 \
     mega-xplained \
     microduino-corerf \

--- a/tests/gnrc_ipv6_ext_frag/Makefile.ci
+++ b/tests/gnrc_ipv6_ext_frag/Makefile.ci
@@ -12,6 +12,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \
+    im880b \
     mega-xplained \
     microduino-corerf \
     msb-430 \

--- a/tests/gnrc_netif/Makefile.ci
+++ b/tests/gnrc_netif/Makefile.ci
@@ -20,6 +20,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \
+    im880b \
     lsn50 \
     maple-mini \
     mega-xplained \

--- a/tests/gnrc_rpl_srh/Makefile.ci
+++ b/tests/gnrc_rpl_srh/Makefile.ci
@@ -10,6 +10,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \
+    im880b \
     mega-xplained \
     microduino-corerf \
     msb-430 \

--- a/tests/gnrc_sixlowpan/Makefile.ci
+++ b/tests/gnrc_sixlowpan/Makefile.ci
@@ -9,6 +9,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \
+    im880b \
     msb-430 \
     msb-430h \
     nucleo-f030r8 \

--- a/tests/gnrc_tcp/Makefile.ci
+++ b/tests/gnrc_tcp/Makefile.ci
@@ -10,6 +10,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \
+    im880b \
     mega-xplained \
     microduino-corerf \
     msb-430 \

--- a/tests/gnrc_udp/Makefile.ci
+++ b/tests/gnrc_udp/Makefile.ci
@@ -13,6 +13,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \
+    im880b \
     mega-xplained \
     microbit \
     microduino-corerf \

--- a/tests/pkg_utensor/Makefile.ci
+++ b/tests/pkg_utensor/Makefile.ci
@@ -4,9 +4,10 @@ BOARD_INSUFFICIENT_MEMORY := \
     bluepill \
     bluepill-128kib \
     calliope-mini \
-    cc2650stk \
     cc2650-launchpad \
+    cc2650stk \
     i-nucleo-lrwan1 \
+    im880b \
     lobaro-lorabox \
     maple-mini \
     microbit \

--- a/tests/pthread_cooperation/Makefile.ci
+++ b/tests/pthread_cooperation/Makefile.ci
@@ -10,6 +10,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     derfmega256 \
     hifive1 \
     hifive1b \
+    im880b \
     i-nucleo-lrwan1 \
     mega-xplained \
     microduino-corerf \

--- a/tests/unittests/Makefile.ci
+++ b/tests/unittests/Makefile.ci
@@ -33,6 +33,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     hifive1b \
     i-nucleo-lrwan1 \
     ikea-tradfri \
+    im880b \
     limifrog-v1 \
     lobaro-lorabox \
     lsn50 \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR adds [im880b](https://www.wireless-solutions.de/products/radiomodules/im880b-l.html) board, this board has a stm32l152cb microcontroler and a sx1272 radio. 

### Testing procedure

Run all tests:
`python dist/tools/compile_and_test_for_board/compile_and_test_for_board.py --jobs 0 ..RIOT im880b`

Manually test:
Compile and test the loramac test application.
`make BOARD=im880b LORA_DRIVER=sx1272-C tests/pkg_semtech-loramac clean all -j flash`

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

Depends on: ~~#11314 & #11316~~
