### PR TITLE
drivers/sx127x: add support for rx and tx switch pin

### DIFF
--- a/drivers/include/sx127x.h
+++ b/drivers/include/sx127x.h
@@ -217,6 +217,10 @@ typedef struct {
 #ifdef SX127X_USE_DIO_MULTI
     gpio_t dio_multi_pin;              /**< Interrupt line for multiple IRQs */
 #endif
+#if defined(SX127X_USE_TX_SWITCH) || defined(SX127X_USE_RX_SWITCH)
+    gpio_t rx_switch_pin;              /**< Rx antenna switch */
+    gpio_t tx_switch_pin;              /**< Tx antenna switch */
+#endif
     uint8_t paselect;                  /**< Power amplifier mode (RFO or PABOOST) */
 } sx127x_params_t;
 

--- a/drivers/sx127x/include/sx127x_params.h
+++ b/drivers/sx127x/include/sx127x_params.h
@@ -68,6 +68,14 @@ extern "C" {
 #define SX127X_PARAM_PASELECT               (SX127X_PA_RFO)
 #endif
 
+#ifndef SX127X_PARAM_TX_SWITCH
+#define SX127X_PARAM_TX_SWITCH              GPIO_UNDEF
+#endif
+
+#ifndef SX127X_PARAM_RX_SWITCH
+#define SX127X_PARAM_RX_SWITCH              GPIO_UNDEF
+#endif
+
 #ifndef SX127X_PARAMS
 #ifdef SX127X_USE_DIO_MULTI
 #define SX127X_PARAMS             { .spi       = SX127X_PARAM_SPI,          \
@@ -79,6 +87,17 @@ extern "C" {
                                     .dio3_pin  = SX127X_PARAM_DIO3,         \
                                     .dio_multi_pin = SX127X_PARAM_DIO_MULTI,\
                                     .paselect  = SX127X_PARAM_PASELECT }
+#elif defined(SX127X_USE_TX_SWITCH) || defined(SX127X_USE_RX_SWITCH)
+#define SX127X_PARAMS             { .spi            = SX127X_PARAM_SPI,          \
+                                    .nss_pin        = SX127X_PARAM_SPI_NSS,      \
+                                    .reset_pin      = SX127X_PARAM_RESET,        \
+                                    .dio0_pin       = SX127X_PARAM_DIO0,         \
+                                    .dio1_pin       = SX127X_PARAM_DIO1,         \
+                                    .dio2_pin       = SX127X_PARAM_DIO2,         \
+                                    .dio3_pin       = SX127X_PARAM_DIO3,         \
+                                    .rx_switch_pin  = SX127X_PARAM_RX_SWITCH,    \
+                                    .tx_switch_pin  = SX127X_PARAM_TX_SWITCH,    \
+                                    .paselect       = SX127X_PARAM_PASELECT }
 #else
 #define SX127X_PARAMS             { .spi       = SX127X_PARAM_SPI,          \
                                     .nss_pin   = SX127X_PARAM_SPI_NSS,      \

--- a/drivers/sx127x/sx127x.c
+++ b/drivers/sx127x/sx127x.c
@@ -84,6 +84,17 @@ int sx127x_reset(const sx127x_t *dev)
 
     gpio_init(dev->params.reset_pin, GPIO_OUT);
 
+#ifdef SX127X_USE_TX_SWITCH
+    /* tx switch as output, start in rx */
+    gpio_init(dev->params.tx_switch_pin, GPIO_OUT);
+    gpio_clear(dev->params.tx_switch_pin);
+#endif
+#ifdef SX127X_USE_RX_SWITCH
+    /* rx switch as output, start in rx */
+    gpio_init(dev->params.rx_switch_pin, GPIO_OUT);
+    gpio_set(dev->params.rx_switch_pin);
+#endif
+
     /* Set reset pin to 0 */
     gpio_clear(dev->params.reset_pin);
 

--- a/drivers/sx127x/sx127x_getset.c
+++ b/drivers/sx127x/sx127x_getset.c
@@ -35,7 +35,6 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-
 uint8_t sx127x_get_state(const sx127x_t *dev)
 {
     return dev->settings.state;
@@ -225,6 +224,13 @@ void sx127x_set_rx(sx127x_t *dev)
 {
     DEBUG("[sx127x] Set RX\n");
 
+#ifdef SX127X_USE_TX_SWITCH
+    gpio_clear(dev->params.tx_switch_pin);
+#endif
+#ifdef SX127X_USE_RX_SWITCH
+    gpio_set(dev->params.rx_switch_pin);
+#endif
+
     switch (dev->settings.modem) {
         case SX127X_MODEM_FSK:
             /* todo */
@@ -328,6 +334,13 @@ void sx127x_set_rx(sx127x_t *dev)
 
 void sx127x_set_tx(sx127x_t *dev)
 {
+#ifdef SX127X_USE_RX_SWITCH
+    gpio_clear(dev->params.rx_switch_pin);
+#endif
+#ifdef SX127X_USE_TX_SWITCH
+    gpio_set(dev->params.tx_switch_pin);
+#endif
+
      switch (dev->settings.modem) {
         case SX127X_MODEM_FSK:
             /* todo */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR adds support for RX/TX antena switch for sx1727x. Most of the boards used so far have this fucntion covered by hardware. Some of them don't, eg [im880b](https://www.wireless-solutions.de/downloads/Radio-Modules/iM880B/General_Information/iM880B_Datasheet_V1_6.pdf). In some cases this switch is devided in to two, as the case of IM880b, 1 for tx and another for rx. In other [boards](https://os.mbed.com/media/uploads/GregCr/sx1272mb2xas_e364v01a_sch.pdf) there is a single pin that can be toogled (High when TX). 

Define SX127X_TX_SWITCH, and if needed SX127X_RX_SWITCH in the boards makefiles.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Compile on two lora capable boards, where one is im880b:

`make BOARD=im880b DRIVER=sx172x -C tests/driver_sx127x clean -j flash`

Listen on one and send on the other with SX127X_TX_SWITCH and SX127X_RX_SWITCH flags enabled for sx127x, re-flash without and notice SNR/RSSI difference.

> - INFO # {Payload: "hello" (6 bytes), RSSI: 221, SNR: 9, TOA: 1188}
> - INFO # {Payload: "hello" (6 bytes), RSSI: 212, SNR: 7, TOA: 1188}

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

Can use #11315 to test
