### PR TITLE
drivers/encx24j600: Allow empty iolist elements

### DIFF
--- a/drivers/encx24j600/encx24j600.c
+++ b/drivers/encx24j600/encx24j600.c
@@ -205,6 +205,10 @@ static void sram_op(encx24j600_t *dev, uint16_t cmd, uint16_t addr, char *ptr, i
     char* in = NULL;
     char* out = NULL;
 
+    if (!len) {
+        return;
+    }
+
     /* determine pointer addr
      *
      * all SRAM access commands have an


### PR DESCRIPTION
### Contribution description
This commits allows using netdev_driver_t::send() to be called with one or more empty iolist elements. This f1x3s issue https://github.com/RIOT-OS/RIOT/issues/11163

### Testing procedure
See https://github.com/RIOT-OS/RIOT/issues/11163

### Issues/PRs references
F1x3s https://github.com/RIOT-OS/RIOT/issues/11163

(leet-speak used to prevent auto-close)