### PR TITLE
sys/random: add missing includes

### DIFF
--- a/sys/random/random.c
+++ b/sys/random/random.c
@@ -20,9 +20,12 @@
  */
 
 #include <stdint.h>
+#include <assert.h>
 
 #include "log.h"
 #include "random.h"
+#include "bitarithm.h"
+
 #ifdef MODULE_PUF_SRAM
 #include "puf_sram.h"
 #endif


### PR DESCRIPTION
### Contribution description

```sys/random.c``` was using both assert() and bitarithm_msb() without including the corresponding headers.

### Testing procedure

Plain' old looking at code should suffice. Code worked before probably because both headers were included from somewhere else.

### Issues/PRs references

none