### PR TITLE
net/coap: Add Link Format attributes to resources

### DIFF
--- a/examples/cord_ep/main.c
+++ b/examples/cord_ep/main.c
@@ -74,9 +74,9 @@ static ssize_t _handler_info(coap_pkt_t *pdu,
 }
 
 static const coap_resource_t _resources[] = {
-    { "/node/info",  COAP_GET, _handler_info, NULL },
-    { "/sense/hum",  COAP_GET, _handler_dummy, NULL },
-    { "/sense/temp", COAP_GET, _handler_dummy, NULL }
+    { .path = "/node/info",  .methods = COAP_GET, .handler = _handler_info,  .context = NULL },
+    { .path = "/sense/hum",  .methods = COAP_GET, .handler = _handler_dummy, .context = NULL },
+    { .path = "/sense/temp", .methods = COAP_GET, .handler = _handler_dummy, .context = NULL }
 };
 
 static gcoap_listener_t _listener = {

--- a/examples/cord_epsim/main.c
+++ b/examples/cord_epsim/main.c
@@ -54,9 +54,9 @@ static ssize_t handler_text(coap_pkt_t *pdu, uint8_t *buf, size_t len, void *ctx
 }
 
 static const coap_resource_t resources[] = {
-    { "/riot/bar",  COAP_GET, handler_text, "foo" },
-    { "/riot/foo",  COAP_GET, handler_text, "bar" },
-    { "/riot/info", COAP_GET, handler_info, NULL }
+    { .path = "/riot/bar",  .methods = COAP_GET, .handler = handler_text, .context = "foo" },
+    { .path = "/riot/foo",  .methods = COAP_GET, .handler = handler_text, .context = "bar" },
+    { .path = "/riot/info", .methods = COAP_GET, .handler = handler_info, .context = NULL  }
 };
 
 static gcoap_listener_t listener = {

--- a/examples/gcoap/Makefile
+++ b/examples/gcoap/Makefile
@@ -42,6 +42,9 @@ USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += ps
 
+# Use resources Link Format parameters
+CFLAGS += -DNANOCOAP_CLIF_STATIC
+
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the
 # development process:

--- a/examples/gcoap/gcoap_cli.c
+++ b/examples/gcoap/gcoap_cli.c
@@ -36,8 +36,12 @@ static ssize_t _riot_board_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, vo
 
 /* CoAP resources. Must be sorted by path (ASCII order). */
 static const coap_resource_t _resources[] = {
-    { "/cli/stats", COAP_GET | COAP_PUT, _stats_handler, NULL },
-    { "/riot/board", COAP_GET, _riot_board_handler, NULL },
+    { .path = "/cli/stats", .methods = COAP_GET | COAP_PUT, .handler = _stats_handler, .context = NULL },
+    { .path = "/riot/board", .methods = COAP_GET, .handler = _riot_board_handler, .context = NULL,
+#ifdef NANOCOAP_CLIF_STATIC
+      .clif_params = "rt=\"info\";ct=0"
+#endif
+    },
 };
 
 static gcoap_listener_t _listener = {

--- a/examples/nanocoap_server/coap_handler.c
+++ b/examples/nanocoap_server/coap_handler.c
@@ -160,11 +160,16 @@ ssize_t _sha256_handler(coap_pkt_t* pkt, uint8_t *buf, size_t len, void *context
 /* must be sorted by path (ASCII order) */
 const coap_resource_t coap_resources[] = {
     COAP_WELL_KNOWN_CORE_DEFAULT_HANDLER,
-    { "/echo/", COAP_GET | COAP_MATCH_SUBTREE, _echo_handler, NULL },
-    { "/riot/board", COAP_GET, _riot_board_handler, NULL },
-    { "/riot/value", COAP_GET | COAP_PUT | COAP_POST, _riot_value_handler, NULL },
-    { "/riot/ver", COAP_GET, _riot_block2_handler, NULL },
-    { "/sha256", COAP_POST, _sha256_handler, NULL },
+    { .path = "/echo/", .methods = COAP_GET | COAP_MATCH_SUBTREE,
+      .handler = _echo_handler, .context = NULL },
+    { .path = "/riot/board", .methods = COAP_GET,
+      .handler = _riot_board_handler, .context = NULL },
+    { .path = "/riot/value", .methods = COAP_GET | COAP_PUT | COAP_POST,
+      .handler = _riot_value_handler, .context =  NULL },
+    { .path = "/riot/ver", .methods = COAP_GET,
+      .handler = _riot_block2_handler, .context = NULL },
+    { .path = "/sha256", .methods = COAP_POST,
+      .handler = _sha256_handler, .context = NULL },
 };
 
 const unsigned coap_resources_numof = sizeof(coap_resources) / sizeof(coap_resources[0]);

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -51,6 +51,21 @@
  * gcoap itself defines a resource for `/.well-known/core` discovery, which
  * lists all of the registered paths.
  *
+ *
+ * ### Resource description ###
+ *
+ * By default resources have no description, but by defining
+ * `NANOCOAP_CLIF_STATIC` a CoRE Link Format
+ * [(RFC 6690)](https://tools.ietf.org/html/rfc6690) string of parameters can
+ * be added to them (coap_resource_t::clif_params). This Link Format parameters
+ * are used for resource discovery and registration in resource directories.
+ * 
+ * So, if a CoAP resource represents a temperature sensor, it could have the
+ * following atributes:
+ * ```
+ * rt="temperature-c";if="sensor"
+ * ```
+ *
  * ### Creating a response ###
  *
  * An application resource includes a callback function, a coap_handler_t. After

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -289,6 +289,10 @@ typedef struct {
     unsigned methods;               /**< OR'ed methods this resource allows */
     coap_handler_t handler;         /**< ptr to resource handler            */
     void *context;                  /**< ptr to user defined context data   */
+#if defined(NANOCOAP_CLIF_STATIC) || defined(DOXYGEN)
+    const char *clif_params;        /**< link format attributes @see Resource
+                                         description section of net_gcoap */
+#endif
 } coap_resource_t;
 
 /**

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -57,7 +57,7 @@ static void _find_obs_memo_resource(gcoap_observe_memo_t **memo,
 
 /* Internal variables */
 const coap_resource_t _default_resources[] = {
-    { "/.well-known/core", COAP_GET, _well_known_core_handler, NULL },
+    { .path = "/.well-known/core", .methods = COAP_GET, .handler = _well_known_core_handler, .context = NULL, },
 };
 
 static gcoap_listener_t _default_listener = {

--- a/tests/nanocoap_cli/request_handlers.c
+++ b/tests/nanocoap_cli/request_handlers.c
@@ -74,7 +74,8 @@ static ssize_t _value_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len, void *c
 /* must be sorted by path (ASCII order) */
 const coap_resource_t coap_resources[] = {
     COAP_WELL_KNOWN_CORE_DEFAULT_HANDLER,
-    { "/value", COAP_GET | COAP_PUT | COAP_POST, _value_handler, NULL },
+    { .path = "/value", .methods = COAP_GET | COAP_PUT | COAP_POST,
+      .handler = _value_handler, .context = NULL },
 };
 
 const unsigned coap_resources_numof = sizeof(coap_resources) / sizeof(coap_resources[0]);


### PR DESCRIPTION
### Contribution description
This PR implements the 'Static Case' part of https://github.com/RIOT-OS/RIOT/issues/11171#issuecomment-478348346 proposed by @kb2ma. It is marked as RFC as the discussion is ongoing, but I created this to have an idea of how it could look like.

It provides a way to (optionally by `NANOCOAP_CLIF_STATIC`) add Link Format encoded attributes to CoAP resources. This attributes are used for `/.well-known/core` resource discovery and resource directory registration. Later on this can also be used for resource filtering.

The resource encoding is done manually now but if #11189 gets merged it could be used instead.

### Testing procedure
Run `examples/gcoap` application, replies to GET requests to `/.well-known/core` now should also include the resources Link Format attributes, if defined.

### Issues/PRs references
Discussion in #11171 
Could eventually use #11189 