### PR TITLE
drivers/xbee: prevent 0 length packet sent to UART

### DIFF
--- a/drivers/xbee/xbee.c
+++ b/drivers/xbee/xbee.c
@@ -664,7 +664,9 @@ static int xbee_send(netdev_t *dev, const iolist_t *iolist)
     DEBUG("[xbee] send: now sending out %i byte\n", (int)size);
     mutex_lock(&(xbee->tx_lock));
     for (const iolist_t *iol = iolist; iol; iol = iol->iol_next) {
-        uart_write(xbee->p.uart, iol->iol_base, iol->iol_len);
+        if (iol->iol_len > 0) {
+            uart_write(xbee->p.uart, iol->iol_base, iol->iol_len);
+        }
     }
     uart_write(xbee->p.uart, &csum, 1);
     mutex_unlock(&(xbee->tx_lock));


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
This PR prevents the xbee driver to write 0 len frames into UART, for which is not specified if it's valid or not. It also spares a `uart_write()` operation if it's not needed.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
See #11163.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
#11163 