### PR TITLE
cpu/esp32: fix of periph_* submodule compilation

### DIFF
--- a/boards/common/esp32/board_common.c
+++ b/boards/common/esp32/board_common.c
@@ -49,6 +49,7 @@ void board_init(void)
 }
 
 extern void adc_print_config(void);
+extern void dac_print_config(void);
 extern void pwm_print_config(void);
 extern void i2c_print_config(void);
 extern void spi_print_config(void);
@@ -59,11 +60,24 @@ void print_board_config (void)
 {
     ets_printf("\nBoard configuration:\n");
 
+    #if MODULE_PERIPH_ADC
     adc_print_config();
+    #endif
+    #if MODULE_PERIPH_DAC
+    dac_print_config();
+    #endif
+    #if MODULE_PERIPH_PWM
     pwm_print_config();
+    #endif
+    #if MODULE_PERIPH_I2C
     i2c_print_config();
+    #endif
+    #if MODULE_PERIPH_SPI
     spi_print_config();
+    #endif
+    #if MODULE_PERIPH_UART
     uart_print_config();
+    #endif
 
     #ifdef MODULE_ESP_CAN
     can_print_config();

--- a/cpu/esp32/Makefile.dep
+++ b/cpu/esp32/Makefile.dep
@@ -50,13 +50,18 @@ ifneq (,$(filter riot_freertos,$(USEMODULE)))
     USEMODULE += xtimer
 endif
 
-ifneq (,$(filter esp_i2c_hw,$(USEMODULE)))
-    USEMODULE += xtimer
-else
-    # PLEASE NOTE: because of the very poor and faulty hardware implementation
-    # we use software implementation by default for the moment (if module
-    # esp_i2c_hw is not explicitly used)
-    USEMODULE += esp_i2c_sw
+ifneq (,$(filter periph_i2c,$(USEMODULE)))
+    ifneq (,$(filter esp_i2c_hw,$(USEMODULE)))
+        USEMODULE += core_thread_flags
+        USEMODULE += xtimer
+        USEMODULE += periph_i2c_hw
+    else
+        # PLEASE NOTE: because of the very poor and faulty hardware implementation
+        # we use software implementation by default for the moment (if module
+        # esp_i2c_hw is not explicitly used)
+        USEMODULE += esp_i2c_sw
+        USEMODULE += periph_i2c_sw
+    endif
 endif
 
 ifneq (, $(filter esp_spi_ram, $(DISABLE_MODULE)))

--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -67,7 +67,12 @@ USEMODULE += esp_idf_esp32
 USEMODULE += esp_idf_soc
 USEMODULE += log
 USEMODULE += periph
+USEMODULE += periph_adc_ctrl
 USEMODULE += periph_common
+USEMODULE += periph_hwrng
+USEMODULE += periph_flash
+USEMODULE += periph_rtc
+USEMODULE += periph_uart
 USEMODULE += random
 USEMODULE += xtensa
 

--- a/cpu/esp32/include/adc_arch.h
+++ b/cpu/esp32/include/adc_arch.h
@@ -78,16 +78,6 @@ int adc_set_attenuation(adc_t line, adc_attenuation_t atten);
  */
 int adc_vref_to_gpio25 (void);
 
-/**
-  * @brief  Configure sleep mode for an GPIO pin if the pin is an RTCIO pin
-  * @param  pin     GPIO pin
-  * @param  mode    active in sleep mode if true
-  * @param  input   as input if true, as output otherwise
-  * @return 0 success
-  * @return -1 on invalid pin
-  */
-int rtcio_config_sleep_mode (gpio_t pin, bool mode, bool input);
-
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/esp32/include/adc_ctrl.h
+++ b/cpu/esp32/include/adc_ctrl.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2019 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_esp32
+ * @{
+ *
+ * @file
+ * @brief       ADC controller functions used by ADC and DAC peripherals
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @}
+ */
+
+#ifndef ADC_CTRL_H
+#define ADC_CTRL_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "periph/gpio.h"
+
+/**
+ * @brief   ADC controllers
+ */
+enum {
+    ADC1_CTRL,              /**< ADC1 controller */
+    ADC2_CTRL               /**< ADC2 controller */
+};
+
+/**
+ * @brief   RTC IO pin type (does not correspond to RTC gpio num order)
+ */
+enum {
+
+    RTCIO_TOUCH0 = 0,        /**< touch sensor 0 */
+    RTCIO_TOUCH1,            /**< touch sensor 1 */
+    RTCIO_TOUCH2,            /**< touch sensor 2 */
+    RTCIO_TOUCH3,            /**< touch sensor 3 */
+    RTCIO_TOUCH4,            /**< touch sensor 4 */
+    RTCIO_TOUCH5,            /**< touch sensor 5 */
+    RTCIO_TOUCH6,            /**< touch sensor 6 */
+    RTCIO_TOUCH7,            /**< touch sensor 7 */
+    RTCIO_TOUCH8,            /**< touch sensor 8, 32K_XP */
+    RTCIO_TOUCH9,            /**< touch sensor 9, 32K_XN */
+
+    RTCIO_ADC_ADC1,          /**< VDET_1 */
+    RTCIO_ADC_ADC2,          /**< VDET_2 */
+
+    RTCIO_SENSOR_SENSE1,     /**< SENSOR_VP */
+    RTCIO_SENSOR_SENSE2,     /**< SENSOR_CAPP */
+    RTCIO_SENSOR_SENSE3,     /**< SENSOR_CAPN */
+    RTCIO_SENSOR_SENSE4,     /**< SENSOR_VN */
+
+    RTCIO_DAC1,              /**< DAC output */
+    RTCIO_DAC2,              /**< DAC output */
+
+    RTCIO_NA,                /**< RTC pad not available */
+};
+
+/**
+ * @brief   ADC pin hardware information type (for internal use only)
+ */
+struct _adc_hw_t {
+    gpio_t   gpio;          /**< GPIO */
+    uint8_t  rtc_gpio;      /**< corresponding RTC GPIO */
+    uint8_t  adc_ctrl;      /**< ADC controller */
+    uint8_t  adc_channel;   /**< channel of ADC controller */
+    char*    pad_name;      /**< symbolic name of pad */
+};
+
+/**
+ * @brief   RTC hardware map
+ *
+ * The index corresponds to RTC pin type _rtcio_pin_t (Table 19 in Technical
+ * Reference)
+ */
+extern const struct _adc_hw_t _adc_hw[];
+
+/**
+  * @brief  Configure sleep mode for an GPIO pin if the pin is a RTCIO pin
+  * @param  pin     GPIO pin
+  * @param  mode    active in sleep mode if true
+  * @param  input   as input if true, as output otherwise
+  * @return 0 success
+  * @return -1 on invalid pin
+  */
+int rtcio_config_sleep_mode (gpio_t pin, bool mode, bool input);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ADC_CTRL_H */

--- a/cpu/esp32/periph/Makefile
+++ b/cpu/esp32/periph/Makefile
@@ -1,3 +1,3 @@
 MODULE = periph
 
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/periph.mk

--- a/cpu/esp32/periph/adc.c
+++ b/cpu/esp32/periph/adc.c
@@ -19,19 +19,12 @@
  * @}
  */
 
-#define ENABLE_DEBUG    0
-#include "debug.h"
-#include "esp_common.h"
-
 #include "board.h"
-#include "cpu.h"
-#include "log.h"
-#include "mutex.h"
 #include "periph/adc.h"
-#include "periph/dac.h"
-#include "periph/gpio.h"
 
 #include "adc_arch.h"
+#include "adc_ctrl.h"
+#include "esp_common.h"
 #include "gpio_arch.h"
 #include "rom/ets_sys.h"
 #include "soc/rtc_io_struct.h"
@@ -39,137 +32,26 @@
 #include "soc/sens_reg.h"
 #include "soc/sens_struct.h"
 
-#define ADC1_CTRL    0
-#define ADC2_CTRL    1
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
 
-/* RTC pin type (does not correspond to RTC gpio num order) */
-typedef enum {
-
-    RTCIO_TOUCH0 = 0,        /* touch sensor 0 */
-    RTCIO_TOUCH1,            /* touch sensor 1 */
-    RTCIO_TOUCH2,            /* touch sensor 2 */
-    RTCIO_TOUCH3,            /* touch sensor 3 */
-    RTCIO_TOUCH4,            /* touch sensor 4 */
-    RTCIO_TOUCH5,            /* touch sensor 5 */
-    RTCIO_TOUCH6,            /* touch sensor 6 */
-    RTCIO_TOUCH7,            /* touch sensor 7 */
-    RTCIO_TOUCH8,            /* touch sensor 8, 32K_XP */
-    RTCIO_TOUCH9,            /* touch sensor 9, 32K_XN */
-
-    RTCIO_ADC_ADC1,          /* VDET_1 */
-    RTCIO_ADC_ADC2,          /* VDET_2 */
-
-    RTCIO_SENSOR_SENSE1,     /* SENSOR_VP */
-    RTCIO_SENSOR_SENSE2,     /* SENSOR_CAPP */
-    RTCIO_SENSOR_SENSE3,     /* SENSOR_CAPN */
-    RTCIO_SENSOR_SENSE4,     /* SENSOR_VN */
-
-    RTCIO_DAC1,              /* DAC output */
-    RTCIO_DAC2,              /* DAC output */
-
-    RTCIO_NA,                /* RTC pad not available */
-} _rtcio_pin_t;
-
-/* ADC pin hardware information type (for internal use only) */
-struct _adc_hw_t {
-    gpio_t   gpio;
-    uint8_t  rtc_gpio;
-    uint8_t  adc_ctrl;
-    uint8_t  adc_channel;
-    char*    pad_name;
-};
-
-/* RTC hardware map, the index corresponds to RTC pin type _rtcio_pin_t
-   (Table 19 in Technical Reference) */
-const struct _adc_hw_t _adc_hw[] =
-{
-    /* gpio  rtc_gpio  adc_ctrl  adc_channel, pad_name */
-    {  GPIO4,  10,    ADC2_CTRL, 0, "GPIO4" },       /* RTCIO_TOUCH0 */
-    {  GPIO0,  11,    ADC2_CTRL, 1, "GPIO0" },       /* RTCIO_TOUCH1 */
-    {  GPIO2,  12,    ADC2_CTRL, 2, "GPIO2" },       /* RTCIO_TOUCH2 */
-    {  GPIO15, 13,    ADC2_CTRL, 3, "MTDO" },        /* RTCIO_TOUCH3 */
-    {  GPIO13, 14,    ADC2_CTRL, 4, "MTCK" },        /* RTCIO_TOUCH4 */
-    {  GPIO12, 15,    ADC2_CTRL, 5, "MTDI" },        /* RTCIO_TOUCH5 */
-    {  GPIO14, 16,    ADC2_CTRL, 6, "MTMS" },        /* RTCIO_TOUCH6 */
-    {  GPIO27, 17,    ADC2_CTRL, 7, "GPIO27" },      /* RTCIO_TOUCH7 */
-    {  GPIO33,  8,    ADC1_CTRL, 5, "32K_XN" },      /* RTCIO_TOUCH8 */
-    {  GPIO32,  9,    ADC1_CTRL, 4, "32K_XP" },      /* RTCIO_TOUCH9 */
-    {  GPIO34,  4,    ADC1_CTRL, 6, "VDET_1" },      /* RTCIO_ADC_ADC1 */
-    {  GPIO35,  5,    ADC1_CTRL, 7, "VDET_2" },      /* RTCIO_ADC_ADC2 */
-    {  GPIO36,  0,    ADC1_CTRL, 0, "SENSOR_VP" },   /* RTCIO_SENSOR_SENSE1 */
-    {  GPIO37,  1,    ADC1_CTRL, 1, "SENSOR_CAPP" }, /* RTCIO_SENSOR_SENSE2 */
-    {  GPIO38,  2,    ADC1_CTRL, 2, "SENSOR_CAPN" }, /* RTCIO_SENSOR_SENSE3 */
-    {  GPIO39,  3,    ADC1_CTRL, 3, "SENSOR_VN" },   /* RTCIO_SENSOR_SENSE4 */
-    {  GPIO25,  6,    ADC2_CTRL, 8, "GPIO25" },      /* RTCIO_DAC1 */
-    {  GPIO26,  7,    ADC2_CTRL, 9, "GPIO26" }       /* RTCIO_DAC2 */
-};
-
-/* maps GPIO pin to RTC pin, this index is used to access ADC hardware table
-   (Table 19 in Technical Reference) */
-const gpio_t _gpio_rtcio_map[] = {
-    RTCIO_TOUCH1,        /* GPIO0 */
-    RTCIO_NA     ,       /* GPIO1 */
-    RTCIO_TOUCH2,        /* GPIO2 */
-    RTCIO_NA,            /* GPIO3 */
-    RTCIO_TOUCH0,        /* GPIO4 */
-    RTCIO_NA,            /* GPIO5 */
-    RTCIO_NA,            /* GPIO6 */
-    RTCIO_NA,            /* GPIO7 */
-    RTCIO_NA,            /* GPIO8 */
-    RTCIO_NA,            /* GPIO9 */
-    RTCIO_NA,            /* GPIO10 */
-    RTCIO_NA,            /* GPIO11 */
-    RTCIO_TOUCH5,        /* GPIO12 MTDI */
-    RTCIO_TOUCH4,        /* GPIO13 MTCK */
-    RTCIO_TOUCH6,        /* GPIO14 MTMS */
-    RTCIO_TOUCH3,        /* GPIO15 MTDO */
-    RTCIO_NA,            /* GPIO16 */
-    RTCIO_NA,            /* GPIO17 */
-    RTCIO_NA,            /* GPIO18 */
-    RTCIO_NA,            /* GPIO19 */
-    RTCIO_NA,            /* GPIO20 */
-    RTCIO_NA,            /* GPIO21 */
-    RTCIO_NA,            /* GPIO22 */
-    RTCIO_NA,            /* GPIO23 */
-    RTCIO_NA,            /* GPIO24 */
-    RTCIO_DAC1,          /* GPIO25 */
-    RTCIO_DAC2,          /* GPIO26 */
-    RTCIO_TOUCH7,        /* GPIO27 */
-    RTCIO_NA,            /* GPIO28 */
-    RTCIO_NA,            /* GPIO29 */
-    RTCIO_NA,            /* GPIO30 */
-    RTCIO_NA,            /* GPIO31 */
-    RTCIO_TOUCH9,        /* GPIO32 32K_XP */
-    RTCIO_TOUCH8,        /* GPIO33 32K_XN */
-    RTCIO_ADC_ADC1,      /* GPIO34 VDET_1 */
-    RTCIO_ADC_ADC2,      /* GPIO35 VDET_2 */
-    RTCIO_SENSOR_SENSE1, /* GPIO36 SENSOR_VP */
-    RTCIO_SENSOR_SENSE2, /* GPIO37 SENSOR_CAPP */
-    RTCIO_SENSOR_SENSE3, /* GPIO38 SENSOR_CAPN */
-    RTCIO_SENSOR_SENSE4, /* GPIO39 SENSOR_VN */
-};
-
-/** Map of RIOT ADC and DAC lines to GPIOs */
+/** Map of RIOT ADC to GPIOs */
 static const uint32_t adc_pins[] = ADC_GPIOS;
-static const uint32_t dac_pins[] = DAC_GPIOS;
 
-/** number of ADC and DAC channels */
+/** number of ADC channels */
 const unsigned adc_chn_num = (sizeof(adc_pins) / sizeof(adc_pins[0]));
-const unsigned dac_chn_num = (sizeof(dac_pins) / sizeof(dac_pins[0]));
 
-#if defined(ADC_GPIOS) || defined(DAC_GPIOS)
-/* forward declaration of internal functions */
-static void _adc1_ctrl_init(void);
-static void _adc2_ctrl_init(void);
+/* declaration of external functions */
+extern void _adc1_ctrl_init(void);
+extern void _adc2_ctrl_init(void);
 
-static bool _adc1_ctrl_initialized = false;
-static bool _adc2_ctrl_initialized = false;
-#endif /* defined(ADC_GPIOS) || defined(DAC_GPIOS) */
-
-#if defined(ADC_GPIOS)
+/* forward declarations of internal functions */
 static bool _adc_conf_check(void);
 static void _adc_module_init(void);
 static bool _adc_module_initialized  = false;
+
+/* external variable declarations */
+extern const gpio_t _gpio_rtcio_map[];
 
 int adc_init(adc_t line)
 {
@@ -186,10 +68,10 @@ int adc_init(adc_t line)
 
     uint8_t rtcio = _gpio_rtcio_map[adc_pins[line]];
 
-    if (_adc_hw[rtcio].adc_ctrl == ADC1_CTRL && !_adc1_ctrl_initialized) {
+    if (_adc_hw[rtcio].adc_ctrl == ADC1_CTRL) {
         _adc1_ctrl_init();
     }
-    if (_adc_hw[rtcio].adc_ctrl == ADC2_CTRL && !_adc2_ctrl_initialized) {
+    if (_adc_hw[rtcio].adc_ctrl == ADC2_CTRL) {
         _adc2_ctrl_init();
     }
 
@@ -393,258 +275,13 @@ static void _adc_module_init(void)
     SENS.sar_tctrl.tsens_power_up = 0;       /* power down */
 }
 
-#endif /* defined(ADC_GPIOS) */
-
-#if defined(DAC_GPIOS)
-
-static bool _dac_conf_check(void);
-static bool _dac_module_initialized  = false;
-
-int8_t dac_init (dac_t line)
+void adc_print_config(void)
 {
-    CHECK_PARAM_RET (line < dac_chn_num, DAC_NOLINE)
-
-    if (!_dac_module_initialized) {
-        /* do some configuration checks */
-        if (!_dac_conf_check()) {
-            return -1;
-        }
-        _dac_module_initialized = true;
-    }
-
-    if (!_adc2_ctrl_initialized) {
-        _adc2_ctrl_init();
-    }
-
-    uint8_t rtcio = _gpio_rtcio_map[dac_pins[line]];
-    uint8_t idx;
-
-    /* try to initialize the pin as DAC ouput */
-    if (gpio_get_pin_usage(_adc_hw[rtcio].gpio) != _GPIO) {
-        LOG_TAG_ERROR("dac", "GPIO%d is used for %s and cannot be used as "
-                      "DAC output\n", _adc_hw[rtcio].gpio,
-                      gpio_get_pin_usage_str(_adc_hw[rtcio].gpio));
-        return DAC_NOLINE;
-    }
-
-    /* disable the output of the pad */
-    RTCIO.enable_w1tc.val = BIT(_adc_hw[rtcio].rtc_gpio);
-
-    switch (rtcio) {
-        case RTCIO_DAC1: /* GPIO25, RTC6 */
-        case RTCIO_DAC2: /* GPIO26, RTC7 */
-                idx = rtcio - RTCIO_DAC1;
-                RTCIO.pad_dac[idx].mux_sel = 1; /* route to RTC */
-                RTCIO.pad_dac[idx].fun_sel = 0; /* function ADC2_CH8, ADC2_CH9 */
-                RTCIO.pad_dac[idx].fun_ie = 0;  /* input disabled */
-                RTCIO.pad_dac[idx].rue = 0;     /* pull-up disabled */
-                RTCIO.pad_dac[idx].rde = 0;     /* pull-down disabled */
-
-                RTCIO.pad_dac[idx].dac_xpd_force = 1; /* use RTC pad not the FSM*/
-                RTCIO.pad_dac[idx].xpd_dac = 1;       /* DAC powered on */
-                break;
-
-        default: return DAC_NOLINE;
-    }
-
-    /* set pin usage type  */
-    gpio_set_pin_usage(_adc_hw[rtcio].gpio, _DAC);
-
-    /* don't use DMA */
-    SENS.sar_dac_ctrl1.dac_dig_force = 0;
-
-    /* disable CW generators and invert DAC signal */
-    SENS.sar_dac_ctrl1.sw_tone_en = 0;
-    SENS.sar_dac_ctrl2.dac_cw_en1 = 0;
-    SENS.sar_dac_ctrl2.dac_cw_en2 = 0;
-
-    return DAC_OK;
-}
-
-void dac_set (dac_t line, uint16_t value)
-{
-    CHECK_PARAM (line < dac_chn_num);
-    RTCIO.pad_dac[_gpio_rtcio_map[dac_pins[line]] - RTCIO_DAC1].dac = value >> 8;
-}
-
-void dac_poweroff (dac_t line)
-{
-    CHECK_PARAM (line < dac_chn_num);
-}
-
-void dac_poweron (dac_t line)
-{
-    CHECK_PARAM (line < dac_chn_num);
-}
-
-static bool _dac_conf_check(void)
-{
-    for (unsigned i = 0; i < dac_chn_num; i++) {
-        if (_gpio_rtcio_map[dac_pins[i]] != RTCIO_DAC1 &&
-            _gpio_rtcio_map[dac_pins[i]] != RTCIO_DAC2) {
-            LOG_TAG_ERROR("dac", "GPIO%d cannot be used as DAC line\n",
-                          dac_pins[i]);
-            return false;
-        }
-    }
-
-    return true;
-}
-
-#endif /* defined(DAC_GPIOS) */
-
-#if defined(ADC_GPIOS) || defined(DAC_GPIOS)
-
-static void _adc1_ctrl_init(void)
-{
-    /* always power on */
-    SENS.sar_meas_wait2.force_xpd_sar = SENS_FORCE_XPD_SAR_PU;
-
-    /* power off LN amp */
-    SENS.sar_meas_wait2.sar2_rstb_wait = 2;
-    SENS.sar_meas_ctrl.amp_rst_fb_fsm = 0;
-    SENS.sar_meas_ctrl.amp_short_ref_fsm = 0;
-    SENS.sar_meas_ctrl.amp_short_ref_gnd_fsm = 0;
-    SENS.sar_meas_wait1.sar_amp_wait1 = 1;
-    SENS.sar_meas_wait1.sar_amp_wait2 = 1;
-    SENS.sar_meas_wait2.sar_amp_wait3 = 1;
-    SENS.sar_meas_wait2.force_xpd_amp = SENS_FORCE_XPD_AMP_PD;
-
-    /* SAR ADC1 controller configuration */
-    SENS.sar_read_ctrl.sar1_dig_force = 0;      /* SAR ADC1 controlled by RTC */
-    SENS.sar_meas_start1.meas1_start_force = 1; /* SAR ADC1 started by SW */
-    SENS.sar_meas_start1.sar1_en_pad_force = 1; /* pad enable bitmap controlled by SW */
-    SENS.sar_touch_ctrl1.xpd_hall_force = 1;    /* XPD HALL is controlled by SW */
-    SENS.sar_touch_ctrl1.hall_phase_force = 1;  /* HALL PHASE is controlled by SW */
-    SENS.sar_read_ctrl.sar1_data_inv = 1;       /* invert data */
-    SENS.sar_atten1 = 0xffffffff;               /* set attenuation to 11 dB for all pads
-                                                   (input range 0 ... 3,3 V) */
-    /* power off built-in hall sensor */
-    RTCIO.hall_sens.xpd_hall = 0;
-
-    /* set default resolution */
-    SENS.sar_start_force.sar1_bit_width = ADC_RES_12BIT;
-    SENS.sar_read_ctrl.sar1_sample_bit = ADC_RES_12BIT;
-
-    _adc1_ctrl_initialized = true;
-}
-
-static void _adc2_ctrl_init(void)
-{
-    /* SAR ADC2 controller configuration */
-    SENS.sar_read_ctrl2.sar2_dig_force = 0;     /* SAR ADC2 controlled by RTC not DIG*/
-    SENS.sar_meas_start2.meas2_start_force = 1; /* SAR ADC2 started by SW */
-    SENS.sar_meas_start2.sar2_en_pad_force = 1; /* pad enable bitmap controlled by SW */
-    SENS.sar_read_ctrl2.sar2_data_inv = 1;      /* invert data */
-    SENS.sar_atten2 = 0xffffffff;               /* set attenuation to 11 dB for all pads
-                                                   (input range 0 ... 3,3 V) */
-    /* set default resolution */
-    SENS.sar_start_force.sar2_bit_width = ADC_RES_12BIT;
-    SENS.sar_read_ctrl2.sar2_sample_bit = ADC_RES_12BIT;
-
-    _adc2_ctrl_initialized = true;
-}
-
-#endif /* defined(ADC_GPIOS) || defined(DAC_GPIOS) */
-
-extern const gpio_t _gpio_rtcio_map[];
-
-int rtcio_config_sleep_mode (gpio_t pin, bool mode, bool input)
-{
-    CHECK_PARAM_RET(pin < GPIO_PIN_NUMOF, -1);
-
-    uint8_t rtcio = _gpio_rtcio_map[pin];
-    uint8_t idx;
-
-    /* route pads to RTC and if possible, disable input, pull-up/pull-down */
-    switch (rtcio) {
-        case RTCIO_SENSOR_SENSE1: /* GPIO36, RTC0 */
-                RTCIO.sensor_pads.sense1_mux_sel = 1;     /* route to RTC */
-                RTCIO.sensor_pads.sense1_fun_sel = 0;     /* RTC mux function 0 */
-                RTCIO.sensor_pads.sense1_slp_sel = mode;  /* sleep mode */
-                RTCIO.sensor_pads.sense1_slp_ie  = input; /* input enabled */
-                break;
-        case RTCIO_SENSOR_SENSE2: /* GPIO37, RTC1 */
-                RTCIO.sensor_pads.sense2_mux_sel = 1;     /* route to RTC */
-                RTCIO.sensor_pads.sense2_fun_sel = 0;     /* RTC mux function 0 */
-                RTCIO.sensor_pads.sense2_slp_sel = mode;  /* sleep mode */
-                RTCIO.sensor_pads.sense2_slp_ie  = input; /* input enabled */
-                break;
-        case RTCIO_SENSOR_SENSE3: /* GPIO38, RTC2 */
-                RTCIO.sensor_pads.sense3_mux_sel = 1;     /* route to RTC */
-                RTCIO.sensor_pads.sense3_fun_sel = 0;     /* RTC mux function 0 */
-                RTCIO.sensor_pads.sense3_slp_sel = mode;  /* sleep mode */
-                RTCIO.sensor_pads.sense3_slp_ie  = input; /* input enabled */
-                break;
-        case RTCIO_SENSOR_SENSE4: /* GPIO39, RTC3 */
-                RTCIO.sensor_pads.sense4_mux_sel = 1;     /* route to RTC */
-                RTCIO.sensor_pads.sense4_fun_sel = 0;     /* RTC mux function 0 */
-                RTCIO.sensor_pads.sense4_slp_sel = mode;  /* sleep mode */
-                RTCIO.sensor_pads.sense4_slp_ie  = input; /* input enabled */
-                break;
-
-        case RTCIO_TOUCH0: /* GPIO4, RTC10 */
-        case RTCIO_TOUCH1: /* GPIO0, RTC11 */
-        case RTCIO_TOUCH2: /* GPIO2, RTC12 */
-        case RTCIO_TOUCH3: /* GPIO15, RTC13 */
-        case RTCIO_TOUCH4: /* GPIO13, RTC14 */
-        case RTCIO_TOUCH5: /* GPIO12, RTC15 */
-        case RTCIO_TOUCH6: /* GPIO14, RTC16 */
-        case RTCIO_TOUCH7: /* GPIO27, RTC17 */
-        case RTCIO_TOUCH8: /* GPIO33, RTC8 */
-        case RTCIO_TOUCH9: /* GPIO32, RTC9 */
-                idx = rtcio - RTCIO_TOUCH0;
-                RTCIO.touch_pad[idx].mux_sel = 1;      /* route to RTC */
-                RTCIO.touch_pad[idx].fun_sel = 0;      /* RTC mux function 0 */
-                RTCIO.touch_pad[idx].slp_sel = mode;   /* sleep mode */
-                RTCIO.touch_pad[idx].slp_ie  = input;  /* input enabled */
-                RTCIO.touch_pad[idx].slp_oe  = ~input; /* output enabled*/
-                break;
-
-        case RTCIO_ADC_ADC1: /* GPIO34, RTC4 */
-                RTCIO.adc_pad.adc1_mux_sel = 1;     /* route to RTC */
-                RTCIO.adc_pad.adc1_fun_sel = 0;     /* RTC mux function 0 */
-                RTCIO.adc_pad.adc1_slp_sel = mode;  /* sleep mode */
-                RTCIO.adc_pad.adc1_slp_ie  = input; /* input enabled */
-                break;
-        case RTCIO_ADC_ADC2: /* GPIO35, RTC5 */
-                RTCIO.adc_pad.adc2_mux_sel = 1;     /* route to RTC */
-                RTCIO.adc_pad.adc2_fun_sel = 0;     /* RTC mux function 0 */
-                RTCIO.adc_pad.adc2_slp_sel = mode;  /* sleep mode */
-                RTCIO.adc_pad.adc2_slp_ie  = input; /* input enabled */
-                break;
-
-        case RTCIO_DAC1: /* GPIO25, RTC6 */
-        case RTCIO_DAC2: /* GPIO26, RTC7 */
-                idx = rtcio - RTCIO_DAC1;
-                RTCIO.pad_dac[idx].mux_sel = 1;      /* route to RTC */
-                RTCIO.pad_dac[idx].fun_sel = 0;      /* RTC mux function 0 */
-                RTCIO.pad_dac[idx].slp_sel = mode;   /* sleep mode */
-                RTCIO.pad_dac[idx].slp_ie  = input;  /* input enabled */
-                RTCIO.pad_dac[idx].slp_oe  = ~input; /* output enabled*/
-                break;
-        default:
-                LOG_TAG_ERROR("gpio", "GPIO %d is not an RTCIO pin and "
-                              "cannot be used in sleep mode\n", pin);
-                return -1;
-    }
-    return 0;
-}
-
-void adc_print_config(void) {
     ets_printf("\tADC\t\tpins=[ ");
-    #if defined(ADC_GPIOS)
+#if defined(ADC_GPIOS)
     for (unsigned i = 0; i < adc_chn_num; i++) {
         ets_printf("%d ", adc_pins[i]);
     }
-    #endif /* defined(ADC_GPIOS) */
-    ets_printf("]\n");
-
-    ets_printf("\tDAC\t\tpins=[ ");
-    #if defined(DAC_GPIOS)
-    for (unsigned i = 0; i < dac_chn_num; i++) {
-        ets_printf("%d ", dac_pins[i]);
-    }
-    #endif /* defined(DAC_GPIOS) */
+#endif /* defined(ADC_GPIOS) */
     ets_printf("]\n");
 }

--- a/cpu/esp32/periph/adc_ctrl.c
+++ b/cpu/esp32/periph/adc_ctrl.c
@@ -1,0 +1,251 @@
+/*
+ * Copyright (C) 2019 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     cpu_esp32
+ * @{
+ *
+ * @file
+ * @brief       ADC controller functions used by ADC and DAC peripherals
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ *
+ * @}
+ */
+
+#include "board.h"
+
+#include "adc_ctrl.h"
+#include "esp_common.h"
+#include "soc/rtc_io_struct.h"
+#include "soc/rtc_cntl_struct.h"
+#include "soc/sens_reg.h"
+#include "soc/sens_struct.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+/**
+ * @brief   RTC hardware map
+ *
+ * The index corresponds to RTC pin type _rtcio_pin_t (Table 19 in Technical
+ * Reference)
+ */
+const struct _adc_hw_t _adc_hw[] =
+{
+    /* gpio  rtc_gpio  adc_ctrl  adc_channel, pad_name */
+    {  GPIO4,  10,    ADC2_CTRL, 0, "GPIO4" },       /* RTCIO_TOUCH0 */
+    {  GPIO0,  11,    ADC2_CTRL, 1, "GPIO0" },       /* RTCIO_TOUCH1 */
+    {  GPIO2,  12,    ADC2_CTRL, 2, "GPIO2" },       /* RTCIO_TOUCH2 */
+    {  GPIO15, 13,    ADC2_CTRL, 3, "MTDO" },        /* RTCIO_TOUCH3 */
+    {  GPIO13, 14,    ADC2_CTRL, 4, "MTCK" },        /* RTCIO_TOUCH4 */
+    {  GPIO12, 15,    ADC2_CTRL, 5, "MTDI" },        /* RTCIO_TOUCH5 */
+    {  GPIO14, 16,    ADC2_CTRL, 6, "MTMS" },        /* RTCIO_TOUCH6 */
+    {  GPIO27, 17,    ADC2_CTRL, 7, "GPIO27" },      /* RTCIO_TOUCH7 */
+    {  GPIO33,  8,    ADC1_CTRL, 5, "32K_XN" },      /* RTCIO_TOUCH8 */
+    {  GPIO32,  9,    ADC1_CTRL, 4, "32K_XP" },      /* RTCIO_TOUCH9 */
+    {  GPIO34,  4,    ADC1_CTRL, 6, "VDET_1" },      /* RTCIO_ADC_ADC1 */
+    {  GPIO35,  5,    ADC1_CTRL, 7, "VDET_2" },      /* RTCIO_ADC_ADC2 */
+    {  GPIO36,  0,    ADC1_CTRL, 0, "SENSOR_VP" },   /* RTCIO_SENSOR_SENSE1 */
+    {  GPIO37,  1,    ADC1_CTRL, 1, "SENSOR_CAPP" }, /* RTCIO_SENSOR_SENSE2 */
+    {  GPIO38,  2,    ADC1_CTRL, 2, "SENSOR_CAPN" }, /* RTCIO_SENSOR_SENSE3 */
+    {  GPIO39,  3,    ADC1_CTRL, 3, "SENSOR_VN" },   /* RTCIO_SENSOR_SENSE4 */
+    {  GPIO25,  6,    ADC2_CTRL, 8, "GPIO25" },      /* RTCIO_DAC1 */
+    {  GPIO26,  7,    ADC2_CTRL, 9, "GPIO26" }       /* RTCIO_DAC2 */
+};
+
+/* maps GPIO pin to RTC pin, this index is used to access ADC hardware table
+   (Table 19 in Technical Reference) */
+const gpio_t _gpio_rtcio_map[] = {
+    RTCIO_TOUCH1,        /* GPIO0 */
+    RTCIO_NA     ,       /* GPIO1 */
+    RTCIO_TOUCH2,        /* GPIO2 */
+    RTCIO_NA,            /* GPIO3 */
+    RTCIO_TOUCH0,        /* GPIO4 */
+    RTCIO_NA,            /* GPIO5 */
+    RTCIO_NA,            /* GPIO6 */
+    RTCIO_NA,            /* GPIO7 */
+    RTCIO_NA,            /* GPIO8 */
+    RTCIO_NA,            /* GPIO9 */
+    RTCIO_NA,            /* GPIO10 */
+    RTCIO_NA,            /* GPIO11 */
+    RTCIO_TOUCH5,        /* GPIO12 MTDI */
+    RTCIO_TOUCH4,        /* GPIO13 MTCK */
+    RTCIO_TOUCH6,        /* GPIO14 MTMS */
+    RTCIO_TOUCH3,        /* GPIO15 MTDO */
+    RTCIO_NA,            /* GPIO16 */
+    RTCIO_NA,            /* GPIO17 */
+    RTCIO_NA,            /* GPIO18 */
+    RTCIO_NA,            /* GPIO19 */
+    RTCIO_NA,            /* GPIO20 */
+    RTCIO_NA,            /* GPIO21 */
+    RTCIO_NA,            /* GPIO22 */
+    RTCIO_NA,            /* GPIO23 */
+    RTCIO_NA,            /* GPIO24 */
+    RTCIO_DAC1,          /* GPIO25 */
+    RTCIO_DAC2,          /* GPIO26 */
+    RTCIO_TOUCH7,        /* GPIO27 */
+    RTCIO_NA,            /* GPIO28 */
+    RTCIO_NA,            /* GPIO29 */
+    RTCIO_NA,            /* GPIO30 */
+    RTCIO_NA,            /* GPIO31 */
+    RTCIO_TOUCH9,        /* GPIO32 32K_XP */
+    RTCIO_TOUCH8,        /* GPIO33 32K_XN */
+    RTCIO_ADC_ADC1,      /* GPIO34 VDET_1 */
+    RTCIO_ADC_ADC2,      /* GPIO35 VDET_2 */
+    RTCIO_SENSOR_SENSE1, /* GPIO36 SENSOR_VP */
+    RTCIO_SENSOR_SENSE2, /* GPIO37 SENSOR_CAPP */
+    RTCIO_SENSOR_SENSE3, /* GPIO38 SENSOR_CAPN */
+    RTCIO_SENSOR_SENSE4, /* GPIO39 SENSOR_VN */
+};
+
+/* flags to indicate whether the according controller is already initialized */
+static bool _adc1_ctrl_initialized = false;
+static bool _adc2_ctrl_initialized = false;
+
+void _adc1_ctrl_init(void)
+{
+    /* return if already intialized */
+    if (_adc1_ctrl_initialized) {
+        return;
+    }
+
+    /* always power on */
+    SENS.sar_meas_wait2.force_xpd_sar = SENS_FORCE_XPD_SAR_PU;
+
+    /* power off LN amp */
+    SENS.sar_meas_wait2.sar2_rstb_wait = 2;
+    SENS.sar_meas_ctrl.amp_rst_fb_fsm = 0;
+    SENS.sar_meas_ctrl.amp_short_ref_fsm = 0;
+    SENS.sar_meas_ctrl.amp_short_ref_gnd_fsm = 0;
+    SENS.sar_meas_wait1.sar_amp_wait1 = 1;
+    SENS.sar_meas_wait1.sar_amp_wait2 = 1;
+    SENS.sar_meas_wait2.sar_amp_wait3 = 1;
+    SENS.sar_meas_wait2.force_xpd_amp = SENS_FORCE_XPD_AMP_PD;
+
+    /* SAR ADC1 controller configuration */
+    SENS.sar_read_ctrl.sar1_dig_force = 0;      /* SAR ADC1 controlled by RTC */
+    SENS.sar_meas_start1.meas1_start_force = 1; /* SAR ADC1 started by SW */
+    SENS.sar_meas_start1.sar1_en_pad_force = 1; /* pad enable bitmap controlled by SW */
+    SENS.sar_touch_ctrl1.xpd_hall_force = 1;    /* XPD HALL is controlled by SW */
+    SENS.sar_touch_ctrl1.hall_phase_force = 1;  /* HALL PHASE is controlled by SW */
+    SENS.sar_read_ctrl.sar1_data_inv = 1;       /* invert data */
+    SENS.sar_atten1 = 0xffffffff;               /* set attenuation to 11 dB for all pads
+                                                   (input range 0 ... 3,3 V) */
+    /* power off built-in hall sensor */
+    RTCIO.hall_sens.xpd_hall = 0;
+
+    /* set default resolution */
+    SENS.sar_start_force.sar1_bit_width = ADC_RES_12BIT;
+    SENS.sar_read_ctrl.sar1_sample_bit = ADC_RES_12BIT;
+
+    _adc1_ctrl_initialized = true;
+}
+
+void _adc2_ctrl_init(void)
+{
+    /* return if already intialized */
+    if (_adc2_ctrl_initialized) {
+        return;
+    }
+
+    /* SAR ADC2 controller configuration */
+    SENS.sar_read_ctrl2.sar2_dig_force = 0;     /* SAR ADC2 controlled by RTC not DIG*/
+    SENS.sar_meas_start2.meas2_start_force = 1; /* SAR ADC2 started by SW */
+    SENS.sar_meas_start2.sar2_en_pad_force = 1; /* pad enable bitmap controlled by SW */
+    SENS.sar_read_ctrl2.sar2_data_inv = 1;      /* invert data */
+    SENS.sar_atten2 = 0xffffffff;               /* set attenuation to 11 dB for all pads
+                                                   (input range 0 ... 3,3 V) */
+    /* set default resolution */
+    SENS.sar_start_force.sar2_bit_width = ADC_RES_12BIT;
+    SENS.sar_read_ctrl2.sar2_sample_bit = ADC_RES_12BIT;
+
+    _adc2_ctrl_initialized = true;
+}
+
+int rtcio_config_sleep_mode (gpio_t pin, bool mode, bool input)
+{
+    CHECK_PARAM_RET(pin < GPIO_PIN_NUMOF, -1);
+
+    uint8_t rtcio = _gpio_rtcio_map[pin];
+    uint8_t idx;
+
+    /* route pads to RTC and if possible, disable input, pull-up/pull-down */
+    switch (rtcio) {
+        case RTCIO_SENSOR_SENSE1: /* GPIO36, RTC0 */
+                RTCIO.sensor_pads.sense1_mux_sel = 1;     /* route to RTC */
+                RTCIO.sensor_pads.sense1_fun_sel = 0;     /* RTC mux function 0 */
+                RTCIO.sensor_pads.sense1_slp_sel = mode;  /* sleep mode */
+                RTCIO.sensor_pads.sense1_slp_ie  = input; /* input enabled */
+                break;
+        case RTCIO_SENSOR_SENSE2: /* GPIO37, RTC1 */
+                RTCIO.sensor_pads.sense2_mux_sel = 1;     /* route to RTC */
+                RTCIO.sensor_pads.sense2_fun_sel = 0;     /* RTC mux function 0 */
+                RTCIO.sensor_pads.sense2_slp_sel = mode;  /* sleep mode */
+                RTCIO.sensor_pads.sense2_slp_ie  = input; /* input enabled */
+                break;
+        case RTCIO_SENSOR_SENSE3: /* GPIO38, RTC2 */
+                RTCIO.sensor_pads.sense3_mux_sel = 1;     /* route to RTC */
+                RTCIO.sensor_pads.sense3_fun_sel = 0;     /* RTC mux function 0 */
+                RTCIO.sensor_pads.sense3_slp_sel = mode;  /* sleep mode */
+                RTCIO.sensor_pads.sense3_slp_ie  = input; /* input enabled */
+                break;
+        case RTCIO_SENSOR_SENSE4: /* GPIO39, RTC3 */
+                RTCIO.sensor_pads.sense4_mux_sel = 1;     /* route to RTC */
+                RTCIO.sensor_pads.sense4_fun_sel = 0;     /* RTC mux function 0 */
+                RTCIO.sensor_pads.sense4_slp_sel = mode;  /* sleep mode */
+                RTCIO.sensor_pads.sense4_slp_ie  = input; /* input enabled */
+                break;
+
+        case RTCIO_TOUCH0: /* GPIO4, RTC10 */
+        case RTCIO_TOUCH1: /* GPIO0, RTC11 */
+        case RTCIO_TOUCH2: /* GPIO2, RTC12 */
+        case RTCIO_TOUCH3: /* GPIO15, RTC13 */
+        case RTCIO_TOUCH4: /* GPIO13, RTC14 */
+        case RTCIO_TOUCH5: /* GPIO12, RTC15 */
+        case RTCIO_TOUCH6: /* GPIO14, RTC16 */
+        case RTCIO_TOUCH7: /* GPIO27, RTC17 */
+        case RTCIO_TOUCH8: /* GPIO33, RTC8 */
+        case RTCIO_TOUCH9: /* GPIO32, RTC9 */
+                idx = rtcio - RTCIO_TOUCH0;
+                RTCIO.touch_pad[idx].mux_sel = 1;      /* route to RTC */
+                RTCIO.touch_pad[idx].fun_sel = 0;      /* RTC mux function 0 */
+                RTCIO.touch_pad[idx].slp_sel = mode;   /* sleep mode */
+                RTCIO.touch_pad[idx].slp_ie  = input;  /* input enabled */
+                RTCIO.touch_pad[idx].slp_oe  = ~input; /* output enabled*/
+                break;
+
+        case RTCIO_ADC_ADC1: /* GPIO34, RTC4 */
+                RTCIO.adc_pad.adc1_mux_sel = 1;     /* route to RTC */
+                RTCIO.adc_pad.adc1_fun_sel = 0;     /* RTC mux function 0 */
+                RTCIO.adc_pad.adc1_slp_sel = mode;  /* sleep mode */
+                RTCIO.adc_pad.adc1_slp_ie  = input; /* input enabled */
+                break;
+        case RTCIO_ADC_ADC2: /* GPIO35, RTC5 */
+                RTCIO.adc_pad.adc2_mux_sel = 1;     /* route to RTC */
+                RTCIO.adc_pad.adc2_fun_sel = 0;     /* RTC mux function 0 */
+                RTCIO.adc_pad.adc2_slp_sel = mode;  /* sleep mode */
+                RTCIO.adc_pad.adc2_slp_ie  = input; /* input enabled */
+                break;
+
+        case RTCIO_DAC1: /* GPIO25, RTC6 */
+        case RTCIO_DAC2: /* GPIO26, RTC7 */
+                idx = rtcio - RTCIO_DAC1;
+                RTCIO.pad_dac[idx].mux_sel = 1;      /* route to RTC */
+                RTCIO.pad_dac[idx].fun_sel = 0;      /* RTC mux function 0 */
+                RTCIO.pad_dac[idx].slp_sel = mode;   /* sleep mode */
+                RTCIO.pad_dac[idx].slp_ie  = input;  /* input enabled */
+                RTCIO.pad_dac[idx].slp_oe  = ~input; /* output enabled*/
+                break;
+        default:
+                LOG_TAG_ERROR("gpio", "GPIO %d is not an RTCIO pin and "
+                              "cannot be used in sleep mode\n", pin);
+                return -1;
+    }
+    return 0;
+}

--- a/cpu/esp32/periph/dac.c
+++ b/cpu/esp32/periph/dac.c
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2019 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     cpu_esp32
+ * @ingroup     drivers_periph_adc
+ * @{
+ *
+ * @file
+ * @brief       Low-level DAC driver implementation
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ *
+ * @}
+ */
+
+#include "board.h"
+#include "periph/dac.h"
+
+#include "adc_arch.h"
+#include "adc_ctrl.h"
+#include "esp_common.h"
+#include "gpio_arch.h"
+#include "rom/ets_sys.h"
+#include "soc/rtc_io_struct.h"
+#include "soc/rtc_cntl_struct.h"
+#include "soc/sens_reg.h"
+#include "soc/sens_struct.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+/** Map of RIOT DAC lines to GPIOs */
+static const uint32_t dac_pins[] = DAC_GPIOS;
+
+/** number of DAC channels */
+const unsigned dac_chn_num = (sizeof(dac_pins) / sizeof(dac_pins[0]));
+
+/* declaration of external functions */
+extern void _adc2_ctrl_init(void);
+
+/* forward declarations of internal functions */
+static bool _dac_conf_check(void);
+static bool _dac_module_initialized  = false;
+
+/* external variable declarations */
+extern const gpio_t _gpio_rtcio_map[];
+
+int8_t dac_init (dac_t line)
+{
+    CHECK_PARAM_RET (line < dac_chn_num, DAC_NOLINE)
+
+    if (!_dac_module_initialized) {
+        /* do some configuration checks */
+        if (!_dac_conf_check()) {
+            return DAC_NOLINE;
+        }
+        _dac_module_initialized = true;
+    }
+
+    _adc2_ctrl_init();
+
+    uint8_t rtcio = _gpio_rtcio_map[dac_pins[line]];
+    uint8_t idx;
+
+    /* try to initialize the pin as DAC ouput */
+    if (gpio_get_pin_usage(_adc_hw[rtcio].gpio) != _GPIO) {
+        LOG_TAG_ERROR("dac", "GPIO%d is used for %s and cannot be used as "
+                      "DAC output\n", _adc_hw[rtcio].gpio,
+                      gpio_get_pin_usage_str(_adc_hw[rtcio].gpio));
+        return DAC_NOLINE;
+    }
+
+    /* disable the output of the pad */
+    RTCIO.enable_w1tc.val = BIT(_adc_hw[rtcio].rtc_gpio);
+
+    switch (rtcio) {
+        case RTCIO_DAC1: /* GPIO25, RTC6 */
+        case RTCIO_DAC2: /* GPIO26, RTC7 */
+                idx = rtcio - RTCIO_DAC1;
+                RTCIO.pad_dac[idx].mux_sel = 1; /* route to RTC */
+                RTCIO.pad_dac[idx].fun_sel = 0; /* function ADC2_CH8, ADC2_CH9 */
+                RTCIO.pad_dac[idx].fun_ie = 0;  /* input disabled */
+                RTCIO.pad_dac[idx].rue = 0;     /* pull-up disabled */
+                RTCIO.pad_dac[idx].rde = 0;     /* pull-down disabled */
+
+                RTCIO.pad_dac[idx].dac_xpd_force = 1; /* use RTC pad not the FSM*/
+                RTCIO.pad_dac[idx].xpd_dac = 1;       /* DAC powered on */
+                break;
+
+        default: return DAC_NOLINE;
+    }
+
+    /* set pin usage type  */
+    gpio_set_pin_usage(_adc_hw[rtcio].gpio, _DAC);
+
+    /* don't use DMA */
+    SENS.sar_dac_ctrl1.dac_dig_force = 0;
+
+    /* disable CW generators and invert DAC signal */
+    SENS.sar_dac_ctrl1.sw_tone_en = 0;
+    SENS.sar_dac_ctrl2.dac_cw_en1 = 0;
+    SENS.sar_dac_ctrl2.dac_cw_en2 = 0;
+
+    return DAC_OK;
+}
+
+void dac_set (dac_t line, uint16_t value)
+{
+    CHECK_PARAM (line < dac_chn_num);
+    RTCIO.pad_dac[_gpio_rtcio_map[dac_pins[line]] - RTCIO_DAC1].dac = value >> 8;
+}
+
+void dac_poweroff (dac_t line)
+{
+    CHECK_PARAM (line < dac_chn_num);
+}
+
+void dac_poweron (dac_t line)
+{
+    CHECK_PARAM (line < dac_chn_num);
+}
+
+static bool _dac_conf_check(void)
+{
+    for (unsigned i = 0; i < dac_chn_num; i++) {
+        if (_gpio_rtcio_map[dac_pins[i]] != RTCIO_DAC1 &&
+            _gpio_rtcio_map[dac_pins[i]] != RTCIO_DAC2) {
+            LOG_TAG_ERROR("dac", "GPIO%d cannot be used as DAC line\n",
+                          dac_pins[i]);
+            return false;
+        }
+    }
+
+    return true;
+}
+
+void dac_print_config(void)
+{
+    ets_printf("\tDAC\t\tpins=[ ");
+#if defined(DAC_GPIOS)
+    for (unsigned i = 0; i < dac_chn_num; i++) {
+        ets_printf("%d ", dac_pins[i]);
+    }
+#endif /* defined(DAC_GPIOS) */
+    ets_printf("]\n");
+}

--- a/cpu/esp32/periph/gpio.c
+++ b/cpu/esp32/periph/gpio.c
@@ -38,6 +38,7 @@
 
 #include "esp_common.h"
 #include "adc_arch.h"
+#include "adc_ctrl.h"
 #include "gpio_arch.h"
 #include "irq_arch.h"
 #include "syscalls.h"


### PR DESCRIPTION
### Contribution description

This PR changes the handling of `periph_*` submoduls during compilation for ESP32. Until now, all `periph_*` submodules were always compiled. `#if MODULE_PERIPH_*` wrappers were used instead for the following reason:

ADC and DAC channels are implemented by the same hardware controller. Therefore, both peripherals were implemented in the same file `periph/adc.c`, which in turn prevented the use of `$(RIOTMAKE)/periph.mk` and periph_ * submodules.

With this PR

- separate submodules and source files are introduced for ADC and DAC,
- functionality which is required by ADC and DAC is moved to a new submodule `periph_adc_ctrl`,
- required dependencies are added to the makefiles, and
- print board configuration is adapted accordingly.

### Testing procedure

Since the implementation of peripherals did not change with exception of ADC and DAC, successful compilation of tests that use peripherals should be enough.

Due to the changes of ADC and DAC implementation structure, `tests/periph_adc` and `tests/periph_dac` should be executed on any ESP32 board with ADC and DAC channels, e.g., `esp32-wroom-32`.

### Issues/PRs references

This PR was initiated by the discussion in PR #11289.