### PR TITLE
tests/drivers_ds18: add tested boards to the board whitelist

### DIFF
--- a/drivers/include/ds18.h
+++ b/drivers/include/ds18.h
@@ -38,6 +38,7 @@
 #ifndef DS18_H
 #define DS18_H
 
+#include <stdint.h>
 #include "periph/gpio.h"
 
 #ifdef __cplusplus

--- a/drivers/include/ds18.h
+++ b/drivers/include/ds18.h
@@ -38,7 +38,6 @@
 #ifndef DS18_H
 #define DS18_H
 
-#include <stdint.h>
 #include "periph/gpio.h"
 
 #ifdef __cplusplus

--- a/tests/driver_ds18/Makefile
+++ b/tests/driver_ds18/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.tests_common
 
-BOARD_WHITELIST := sensebox_samd21 samr21-xpro nucleo-l152re
+BOARD_WHITELIST := sensebox_samd21 samr21-xpro nucleo-l152re nucleo-l432kc nucleo-l073rz b-l072z-lrwan
 
 USEMODULE += ds18
 USEMODULE += xtimer

--- a/tests/driver_ds18/Makefile
+++ b/tests/driver_ds18/Makefile
@@ -1,7 +1,5 @@
 include ../Makefile.tests_common
 
-BOARD_WHITELIST := sensebox_samd21 samr21-xpro nucleo-l152re nucleo-l432kc nucleo-l073rz b-l072z-lrwan
-
 USEMODULE += ds18
 USEMODULE += xtimer
 USEMODULE += printf_float

--- a/tests/driver_ds18/Makefile
+++ b/tests/driver_ds18/Makefile
@@ -1,5 +1,7 @@
 include ../Makefile.tests_common
 
+BOARD_WHITELIST := sensebox_samd21 samr21-xpro nucleo-l152re nucleo-l432kc nucleo-l073rz b-l072z-lrwan
+
 USEMODULE += ds18
 USEMODULE += xtimer
 USEMODULE += printf_float


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Add new boards to the BOARD_WHITELIST for which the DS18 driver has been tested. The BOARD_WHITELIST is now updated with the nucleo-l432kc, nucleo-l073rz and the b-l072z-lrwan boards.



### Testing procedure

To test this contribution make a board image specifying the BOARD to one of the newly added boards. The result should of executing the make command is that messages:
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- The selected BOARD=<board_name> is not whitelisted: <whitelisted_boards>
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- EXPECT ERRORS!

