### PR TITLE
cpu/stm32_common: fix month encoding in RTC driver for alarm

### DIFF
--- a/cpu/stm32_common/periph/rtc.c
+++ b/cpu/stm32_common/periph/rtc.c
@@ -299,7 +299,7 @@ int rtc_get_alarm(struct tm *time)
     uint32_t alrm = RTC->ALRMAR;
 
     time->tm_year = bcd2val(dr, RTC_DR_YU_Pos, DR_Y_MASK) + YEAR_OFFSET;
-    time->tm_mon  = bcd2val(dr, RTC_DR_MU_Pos, DR_M_MASK);
+    time->tm_mon  = bcd2val(dr, RTC_DR_MU_Pos, DR_M_MASK) - 1;
     time->tm_mday = bcd2val(alrm, RTC_ALRMAR_DU_Pos, ALRM_D_MASK);
     time->tm_hour = bcd2val(alrm, RTC_ALRMAR_HU_Pos, ALRM_H_MASK);
     time->tm_min  = bcd2val(alrm, RTC_ALRMAR_MNU_Pos, ALRM_M_MASK);


### PR DESCRIPTION

### Contribution description

Forgot to update the alarm reading in #11326 

### Testing procedure

set and get an alarm

### Issues/PRs references

#11326 
