### PR TITLE
drivers/at86rf2xx: fix build when MODULE_AT86RF212B is set

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -98,7 +98,7 @@ void at86rf2xx_reset(at86rf2xx_t *dev)
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__TRX_CTRL_1, tmp);
 
     /* configure smart idle listening feature */
-#if AT86RF2XX_SMART_IDLE_LISTENING
+#if AT86RF2XX_SMART_IDLE_LISTENING && !defined(MODULE_AT86RF212B)
     tmp = at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_RPC);
     tmp |= (AT86RF2XX_TRX_RPC_MASK__RX_RPC_EN |
             AT86RF2XX_TRX_RPC_MASK__PDT_RPC_EN |


### PR DESCRIPTION
### Contribution description

AT86RF212B doesn't seem to support this feature and there is no TRX_RPC
register, resulting in a build failue when MODULE_AT86RF212B is set.

To fix this, don't try to enable this non-exiting feature for this module.

### Testing procedure

Build a board with the at86rf2xx driver and `#define MODULE_AT86RF212B 1` set. Obsever that the build failure no longer occurs.

### Issues/PRs references

None - seems like nobody tested this in a while.