### PR TITLE
WIP doc: Add instructions for shell access via J-Link Segger RTT

### DIFF
--- a/boards/hamilton/doc.txt
+++ b/boards/hamilton/doc.txt
@@ -1,0 +1,29 @@
+/**
+@defgroup    boards_hamilton HamiltonIoT Hamilton
+@ingroup     boards
+@brief       Support for the Hamilton board
+
+## Flash the board
+
+Use the J-Link Segger to flash the board. See the `Flashing` section in @ref
+boards_common_nrf52.
+
+## Term into the board
+
+A shell into RIOT can be accessed via the J-Link Segger and its RTT (real time
+transfer) technology. This allows serial data to be passed to/from the Segger
+via (non-UART supporting) memory locations.
+
+To use this, you need to run a debug client (e.g. gdb), a debug server (e.g.
+JLinkExe), and a terminal client (e.g., PyTerm). The terminal client connects
+to the debug server on port 19021. If you want to use the standard RIOT
+toolchain, flash the board, open two terminal windows, and input the
+following, all in your application directory:
+
+Window 1: `BOARD=ruuvitag make debug`
+Window 2: `BOARD=ruuvitag make term`
+Window 1: (gdb) `c`
+
+You will then be able to communicate with the RIOT shell in window 2.
+
+ */

--- a/boards/hamilton/include/board.h
+++ b/boards/hamilton/include/board.h
@@ -7,8 +7,7 @@
  */
 
 /**
- * @defgroup    boards_hamilton HamiltonIoT Hamilton
- * @ingroup     boards
+ * @ingroup     boards_hamilton
  * @brief       Support for the HamiltonIoT Hamilton board.
  * @{
  *

--- a/boards/ruuvitag/doc.txt
+++ b/boards/ruuvitag/doc.txt
@@ -5,6 +5,25 @@
 
 ## Flash the board
 
-See the `Flashing` section in @ref boards_common_nrf52.
+Use the J-Link Segger to flash the board. See the `Flashing` section in @ref
+boards_common_nrf52.
+
+## Term into the board
+
+A shell into RIOT can be accessed via the J-Link Segger and its RTT (real time
+transfer) technology. This allows serial data to be passed to/from the Segger
+via (non-UART supporting) memory locations.
+
+To use this, you need to run a debug client (e.g. gdb), a debug server (e.g.
+JLinkExe), and a terminal client (e.g., PyTerm). The terminal client connects
+to the debug server on port 19021. If you want to use the standard RIOT
+toolchain, flash the board, open two terminal windows, and input the
+following, all in your application directory:
+
+Window 1: `BOARD=ruuvitag make debug`
+Window 2: `BOARD=ruuvitag make term`
+Window 1: (gdb) `c`
+
+You will then be able to communicate with the RIOT shell in window 2.
 
  */

--- a/boards/thingy52/doc.txt
+++ b/boards/thingy52/doc.txt
@@ -5,6 +5,25 @@
 
 ## Flash the board
 
-See the `Flashing` section in @ref boards_common_nrf52.
+Use the J-Link Segger to flash the board. See the `Flashing` section in @ref
+boards_common_nrf52.
+
+## Term into the board
+
+A shell into RIOT can be accessed via the J-Link Segger and its RTT (real time
+transfer) technology. This allows serial data to be passed to/from the Segger
+via (non-UART supporting) memory locations.
+
+To use this, you need to run a debug client (e.g. gdb), a debug server (e.g.
+JLinkExe), and a terminal client (e.g., PyTerm). The terminal client connects
+to the debug server on port 19021. If you want to use the standard RIOT
+toolchain, flash the board, open two terminal windows, and input the
+following, all in your application directory:
+
+Window 1: `BOARD=ruuvitag make debug`
+Window 2: `BOARD=ruuvitag make term`
+Window 1: (gdb) `c`
+
+You will then be able to communicate with the RIOT shell in window 2.
 
  */


### PR DESCRIPTION
### Contribution description

This gives information on how to term into boards which use J-Link Segger and RTT. These boards are, as far as I'm aware, only the Ruuvitag, Thingy:52, and Hamilton.

WIP because these instructions are currently untested on the Ruuvitag and Thingy:52. I'll test on them as soon as I can get some hardware.

### Testing procedure

Follow the instructions and see if you can successfully access RIOT without any assistance other than this documentation.
