### PR TITLE
boards/stm32*: remove useless RTC_NUMOF defines

### DIFF
--- a/boards/b-l072z-lrwan1/include/periph_conf.h
+++ b/boards/b-l072z-lrwan1/include/periph_conf.h
@@ -176,13 +176,6 @@ static const spi_conf_t spi_config[] = {
 #define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
 /** @} */
 
-/**
- * @name    RTC configuration
- * @{
- */
-#define RTC_NUMOF           (1U)
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/b-l475e-iot01a/include/periph_conf.h
+++ b/boards/b-l475e-iot01a/include/periph_conf.h
@@ -256,13 +256,6 @@ static const i2c_conf_t i2c_config[] = {
 #define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
 /** @} */
 
-/**
- * @name   RTC configuration
- * @{
- */
-#define RTC_NUMOF           (1)
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/i-nucleo-lrwan1/include/periph_conf.h
+++ b/boards/i-nucleo-lrwan1/include/periph_conf.h
@@ -133,13 +133,6 @@ static const i2c_conf_t i2c_config[] = {
 #define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
 /** @} */
 
-/**
- * @name    RTC configuration
- * @{
- */
-#define RTC_NUMOF           (1U)
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/lobaro-lorabox/include/periph_conf.h
+++ b/boards/lobaro-lorabox/include/periph_conf.h
@@ -90,13 +90,6 @@ static const timer_conf_t timer_config[] = {
 /** @} */
 
 /**
- * @name Real time counter configuration
- * @{
- */
-#define RTC_NUMOF           (1U)
-/** @} */
-
-/**
  * @name   UART configuration
  * @{
  */

--- a/boards/lsn50/include/periph_conf.h
+++ b/boards/lsn50/include/periph_conf.h
@@ -182,13 +182,6 @@ static const i2c_conf_t i2c_config[] = {
 #define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
 /** @} */
 
-/**
- * @name    RTC configuration
- * @{
- */
-#define RTC_NUMOF           (1U)
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/nucleo-f030r8/Makefile.features
+++ b/boards/nucleo-f030r8/Makefile.features
@@ -1,6 +1,9 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_pwm
+# For RTC, Nucleos with MB1136 C-02 or MB1136 C-03 -sticker on it have the
+# required LSE oscillator provided on the X2 slot.
+# See Nucleo User Manual UM1724 section 5.6.2.
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart

--- a/boards/nucleo-f030r8/include/periph_conf.h
+++ b/boards/nucleo-f030r8/include/periph_conf.h
@@ -205,18 +205,6 @@ static const spi_conf_t spi_config[] = {
 #define ADC_NUMOF           (6)
 /** @} */
 
-/**
- * @name RTC configuration
- * @{
- */
-/**
- * Nucleos with MB1136 C-02 or MB1136 C-03 -sticker on it have the required LSE
- * oscillator provided on the X2 slot.
- * See Nucleo User Manual UM1724 section 5.6.2.
- */
-#define RTC_NUMOF           (1U)
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/nucleo-f070rb/Makefile.features
+++ b/boards/nucleo-f070rb/Makefile.features
@@ -2,6 +2,9 @@
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
+# For RTC, Nucleos with MB1136 C-02 or MB1136 C-03 -sticker on it have the
+# required LSE oscillator provided on the X2 slot.
+# See Nucleo User Manual UM1724 section 5.6.2.
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart

--- a/boards/nucleo-f070rb/include/periph_conf.h
+++ b/boards/nucleo-f070rb/include/periph_conf.h
@@ -168,18 +168,6 @@ static const pwm_conf_t pwm_config[] = {
 #define ADC_NUMOF           (6)
 /** @} */
 
-/**
- * @name RTC configuration
- * @{
- */
-/**
- * Nucleos with MB1136 C-02 or MB1136 C-03 -sticker on it have the required LSE
- * oscillator provided on the X2 slot.
- * See Nucleo User Manual UM1724 section 5.6.2.
- */
-#define RTC_NUMOF           (1U)
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/nucleo-f072rb/Makefile.features
+++ b/boards/nucleo-f072rb/Makefile.features
@@ -2,6 +2,9 @@
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
+# For RTC, Nucleos with MB1136 C-02 or MB1136 C-03 -sticker on it have the
+# required LSE oscillator provided on the X2 slot.
+# See Nucleo User Manual UM1724 section 5.6.2.
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart

--- a/boards/nucleo-f072rb/include/periph_conf.h
+++ b/boards/nucleo-f072rb/include/periph_conf.h
@@ -226,18 +226,6 @@ static const spi_conf_t spi_config[] = {
 #define ADC_NUMOF           (6)
 /** @} */
 
-/**
- * @name RTC configuration
- * @{
- */
-/**
- * Nucleos with MB1136 C-02 or MB1136 C-03 -sticker on it have the required LSE
- * oscillator provided on the X2 slot.
- * See Nucleo User Manual UM1724 section 5.6.2.
- */
-#define RTC_NUMOF           (1U)
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/nucleo-f091rc/Makefile.features
+++ b/boards/nucleo-f091rc/Makefile.features
@@ -3,6 +3,9 @@ FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
+# For RTC, Nucleos with MB1136 C-02 or MB1136 C-03 -sticker on it have the
+# required LSE oscillator provided on the X2 slot.
+# See Nucleo User Manual UM1724 section 5.6.2.
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart

--- a/boards/nucleo-f091rc/include/periph_conf.h
+++ b/boards/nucleo-f091rc/include/periph_conf.h
@@ -225,18 +225,6 @@ static const pwm_conf_t pwm_config[] = {
 /** @} */
 
 /**
- * @name RTC configuration
- * @{
- */
-/**
- * Nucleos with MB1136 C-02 or MB1136 C-03 -sticker on it have the required LSE
- * oscillator provided on the X2 slot.
- * See Nucleo User Manual UM1724 section 5.6.2.
- */
-#define RTC_NUMOF           (1U)
-/** @} */
-
-/**
  * @name   ADC configuration
  * @{
  */

--- a/boards/nucleo-f207zg/include/periph_conf.h
+++ b/boards/nucleo-f207zg/include/periph_conf.h
@@ -243,13 +243,6 @@ static const spi_conf_t spi_config[] = {
 #define ADC_NUMOF          (2)
 /** @} */
 
-/**
- * @name    RTC configuration
- * @{
- */
-#define RTC_NUMOF           (1)
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/nucleo-f401re/include/periph_conf.h
+++ b/boards/nucleo-f401re/include/periph_conf.h
@@ -241,13 +241,6 @@ static const spi_conf_t spi_config[] = {
 }
 /** @} */
 
-/**
- * @name   RTC configuration
- * @{
- */
-#define RTC_NUMOF           (1)
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/nucleo-f412zg/include/periph_conf.h
+++ b/boards/nucleo-f412zg/include/periph_conf.h
@@ -200,13 +200,6 @@ static const spi_conf_t spi_config[] = {
 }
 /** @} */
 
-/**
- * @name    RTC configuration
- * @{
- */
-#define RTC_NUMOF           (1)
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/nucleo-f413zh/include/periph_conf.h
+++ b/boards/nucleo-f413zh/include/periph_conf.h
@@ -230,13 +230,6 @@ static const spi_conf_t spi_config[] = {
 /** @} */
 
 /**
- * @name    RTC configuration
- * @{
- */
-#define RTC_NUMOF           (1)
-/** @} */
-
-/**
  * @name    RTT configuration
  * @{
  */

--- a/boards/nucleo-l031k6/include/periph_conf.h
+++ b/boards/nucleo-l031k6/include/periph_conf.h
@@ -147,13 +147,6 @@ static const spi_conf_t spi_config[] = {
 #define ADC_NUMOF           (7U)
 /** @} */
 
-/**
- * @name    RTC configuration
- * @{
- */
-#define RTC_NUMOF           (1U)
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/nucleo-l053r8/include/periph_conf.h
+++ b/boards/nucleo-l053r8/include/periph_conf.h
@@ -147,13 +147,6 @@ static const spi_conf_t spi_config[] = {
 #define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
 /** @} */
 
-/**
- * @name    RTC configuration
- * @{
- */
-#define RTC_NUMOF           (1U)
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/nucleo-l073rz/include/periph_conf.h
+++ b/boards/nucleo-l073rz/include/periph_conf.h
@@ -216,13 +216,6 @@ static const i2c_conf_t i2c_config[] = {
 #define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
 /** @} */
 
-/**
- * @name    RTC configuration
- * @{
- */
-#define RTC_NUMOF           (1U)
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/nucleo-l152re/include/periph_conf.h
+++ b/boards/nucleo-l152re/include/periph_conf.h
@@ -103,13 +103,6 @@ static const timer_conf_t timer_config[] = {
 /** @} */
 
 /**
- * @name Real time counter configuration
- * @{
- */
-#define RTC_NUMOF           (1U)
-/** @} */
-
-/**
  * @name   UART configuration
  * @{
  */

--- a/boards/nucleo-l433rc/include/periph_conf.h
+++ b/boards/nucleo-l433rc/include/periph_conf.h
@@ -226,13 +226,6 @@ static const i2c_conf_t i2c_config[] = {
 #define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
 /** @} */
 
-/**
- * @name   RTC configuration
- * @{
- */
-#define RTC_NUMOF           (1)
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/nucleo-l452re/include/periph_conf.h
+++ b/boards/nucleo-l452re/include/periph_conf.h
@@ -202,13 +202,6 @@ static const spi_conf_t spi_config[] = {
 #define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
 /** @} */
 
-/**
- * @name   RTC configuration
- * @{
- */
-#define RTC_NUMOF           (1)
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/nucleo-l476rg/include/periph_conf.h
+++ b/boards/nucleo-l476rg/include/periph_conf.h
@@ -297,13 +297,6 @@ static const spi_conf_t spi_config[] = {
 }
 /** @} */
 
-/**
- * @name   RTC configuration
- * @{
- */
-#define RTC_NUMOF           (1)
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/nucleo-l496zg/include/periph_conf.h
+++ b/boards/nucleo-l496zg/include/periph_conf.h
@@ -221,13 +221,6 @@ static const spi_conf_t spi_config[] = {
 #define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
 /** @} */
 
-/**
- * @name   RTC configuration
- * @{
- */
-#define RTC_NUMOF           (1)
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/nz32-sc151/include/periph_conf.h
+++ b/boards/nz32-sc151/include/periph_conf.h
@@ -217,13 +217,6 @@ static const i2c_conf_t i2c_config[] = {
 /** @} */
 
 /**
- * @name    RTC configuration
- * @{
- */
-#define RTC_NUMOF           (1U)
-/** @} */
-
-/**
  * @name    ADC configuration
  * @{
  */

--- a/boards/pyboard/include/periph_conf.h
+++ b/boards/pyboard/include/periph_conf.h
@@ -173,13 +173,6 @@ static const i2c_conf_t i2c_config[] = {
 #define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
 /** @} */
 
-/**
- * @name   RTC configuration
- * @{
- */
-#define RTC_NUMOF           (1)
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/stm32f769i-disco/include/periph_conf.h
+++ b/boards/stm32f769i-disco/include/periph_conf.h
@@ -103,13 +103,6 @@ static const uart_conf_t uart_config[] = {
 #define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
 /** @} */
 
-/**
- * @name    RTC configuration
- * @{
- */
-#define RTC_NUMOF           (1)
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/stm32l476g-disco/include/periph_conf.h
+++ b/boards/stm32l476g-disco/include/periph_conf.h
@@ -117,13 +117,6 @@ static const uart_conf_t uart_config[] = {
 #define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
 /** @} */
 
-/**
- * @name   RTC configuration
- * @{
- */
-#define RTC_NUMOF           (1)
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/ublox-c030-u201/include/periph_conf.h
+++ b/boards/ublox-c030-u201/include/periph_conf.h
@@ -252,13 +252,6 @@ static const i2c_conf_t i2c_config[] = {
 }
 /** @} */
 
-/**
- * @name    RTC configuration
- * @{
- */
-#define RTC_NUMOF           (1U)
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR removes RTC_NUMOF defines from peripheral configuration headers of STM32 based boards.
`git grep` reports that these defines are not used anywhere in peripheral drivers, so I think they are useless and should be removed. STM32 CPUs only provide one RTC and the driver implementation cannot handle multiple peripherals.

Maybe other boards using different CPUs (SAM, EFM32, etc) could be cleaned up as well, in follow-up PRs.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

A green Murdock should be enough.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
