### PR TITLE
tests/bench_timers: improve test to work on some SAM based boards

### DIFF
--- a/tests/bench_timers/Makefile
+++ b/tests/bench_timers/Makefile
@@ -8,7 +8,6 @@ SINGLE_TIMER_BOARDS = \
   native \
   nucleo-f031k6 \
   nucleo-f042k6 \
-  samd21-xpro \
   saml10-xpro \
   saml11-xpro \
   saml21-xpro \

--- a/tests/bench_timers/Makefile
+++ b/tests/bench_timers/Makefile
@@ -8,6 +8,11 @@ SINGLE_TIMER_BOARDS = \
   native \
   nucleo-f031k6 \
   nucleo-f042k6 \
+  samd21-xpro \
+  saml10-xpro \
+  saml11-xpro \
+  saml21-xpro \
+  samr30-xpro \
   #
 
 # These boards have too little RAM to support collecting detailed statistics

--- a/tests/bench_timers/bench_timers_config.h
+++ b/tests/bench_timers/bench_timers_config.h
@@ -116,11 +116,7 @@ extern "C" {
 #endif
 /* Minimum delay for relative timers, should usually work with any value */
 #ifndef TEST_MIN_REL
-#if TEST_XTIMER
 #define TEST_MIN_REL (TEST_MIN)
-#else
-#define TEST_MIN_REL (0)
-#endif
 #endif
 /* Number of test values */
 #define TEST_NUM ((TEST_MAX) - (TEST_MIN) + 1)


### PR DESCRIPTION
### Contribution description
This PR does some small improvements to the bench_timers test to make it work on some SAM based boards and probably also improve test portability to other boards.
Specifically:
-) specific SAM boards definition with only one timer are added to Makefile so correct timer is used
-) before calling `timer_init` on a timer this is first stopped with `timer_stop` otherwise for most of SAM based CPUs the init will not have any effect since if the timer has already been inited (and it is at boot) then initialization would be skipped and test would block undefinitely waiting for the callback to be called. 
Ie see code:
```
/**
 * @brief Setup the given timer
 */
int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
{
   ...
        if (TIMER_0_DEV.CTRLA.bit.ENABLE) {
            return 0;
        }
```
-) Default minimum time for relative timer test (`TEST_MIN_REL`) is set to `TEST_MIN` (which is the minimum for absolute alarms) as the previous 0 results in timer shooting off before the callback is even set and test blocking. It sounds reasonable that the minimum for the relative test should be the same as the one for absolute by the user. It can anyhow, as before, be overridden explicitly if needed.

### Testing procedure
In tests/bench_timers:
`BOARD=XYZ make all flash`
And then see the test output (after a while) on the serial

### Issues/PRs references
Addresses problems of test execution explained in #10523 (even if doesn't address the timer driver problem).