### PR TITLE
tests/pkg_c25519: increase timeout on non-native [backport 2019.04]

### DIFF
--- a/tests/pkg_c25519/tests/01-run.py
+++ b/tests/pkg_c25519/tests/01-run.py
@@ -12,7 +12,10 @@ import sys
 
 
 def testfunc(child):
-    child.expect(r"OK \(2 tests\)")
+    board = os.environ['BOARD']
+    # Increase timeout on "real" hardware
+    timeout = 20 if board is not 'native' else -1
+    child.expect(r"OK \(2 tests\)", timeout=timeout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Backport of #11347

### Contribution description

Nightly CI was failing on this test as it takes around 13-14 seconds on a samr21-xpro. Increased to 20 seconds to give it some margin.

### Testing procedure

Checking the code and checking the CI status should be enough

### Issues/PRs references

The [nightly output](https://ci.riot-os.org/RIOT-OS/RIOT/master/f6f988cfbfde8cb97d7110cbd6f23cc559a213ad/output.html)