### PR TITLE
stm32_common/flash: move wait_for_pending_operation to flash_common

### DIFF
--- a/cpu/stm32_common/periph/eeprom.c
+++ b/cpu/stm32_common/periph/eeprom.c
@@ -15,6 +15,7 @@
  * @brief       Low-level eeprom driver implementation
  *
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ * @author      Oleg Artamonov <oleg@unwds.com>
  *
  * @}
  */
@@ -29,6 +30,7 @@
 
 extern void _lock(void);
 extern void _unlock(void);
+extern void _wait_for_pending_operations(void);
 
 #ifndef EEPROM_START_ADDR
 #error "periph/eeprom: EEPROM_START_ADDR is not defined"
@@ -42,6 +44,7 @@ size_t eeprom_read(uint32_t pos, uint8_t *data, size_t len)
 
     DEBUG("Reading data from EEPROM at pos %" PRIu32 ": ", pos);
     for (size_t i = 0; i < len; i++) {
+        _wait_for_pending_operations();
         *p++ = *(uint8_t *)(EEPROM_START_ADDR + pos++);
         DEBUG("0x%02X ", *p);
     }
@@ -59,6 +62,7 @@ size_t eeprom_write(uint32_t pos, const uint8_t *data, size_t len)
     _unlock();
 
     for (size_t i = 0; i < len; i++) {
+        _wait_for_pending_operations();
         *(uint8_t *)(EEPROM_START_ADDR + pos++) = *p++;
     }
 

--- a/cpu/stm32_common/periph/flash_common.c
+++ b/cpu/stm32_common/periph/flash_common.c
@@ -14,6 +14,7 @@
  * @brief       Low-level flash lock/unlock implementation
  *
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ * @author      Oleg Artamonov <oleg@unwds.com>
  *
  * @}
  */
@@ -54,5 +55,18 @@ void _lock(void)
     if (!(CNTRL_REG & CNTRL_REG_LOCK)) {
         DEBUG("[flash-common] locking the flash module\n");
         CNTRL_REG |= CNTRL_REG_LOCK;
+    }
+}
+
+void _wait_for_pending_operations(void)
+{
+    if (FLASH->SR & FLASH_SR_BSY) {
+        DEBUG("[flash-common] waiting for any pending operation to finish\n");
+        while (FLASH->SR & FLASH_SR_BSY) {}
+    }
+
+    /* Clear 'end of operation' bit in status register */
+    if (FLASH->SR & FLASH_SR_EOP) {
+        FLASH->SR &= ~(FLASH_SR_EOP);
     }
 }

--- a/cpu/stm32_common/periph/flashpage.c
+++ b/cpu/stm32_common/periph/flashpage.c
@@ -52,6 +52,7 @@
 
 extern void _lock(void);
 extern void _unlock(void);
+extern void _wait_for_pending_operations(void);
 
 static void _unlock_flash(void)
 {
@@ -67,17 +68,6 @@ static void _unlock_flash(void)
         }
     }
 #endif
-}
-
-static void _wait_for_pending_operations(void)
-{
-    DEBUG("[flashpage] waiting for any pending operation to finish\n");
-    while (FLASH->SR & FLASH_SR_BSY) {}
-
-    /* Clear 'end of operation' bit in status register */
-    if (FLASH->SR & FLASH_SR_EOP) {
-        FLASH->SR &= ~(FLASH_SR_EOP);
-    }
 }
 
 static void _erase_page(void *page_addr)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR contains work done by @olegart in https://github.com/RIOT-OS/RIOT/pull/10026/files. It moves _wait_for_pending_operations to flash_common so it can also be used in eeprom.c. 

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Test on stm32 boards.

` make BOARD=nucleo-l152re -C tests/periph_flashpage/ flash  test`
` make BOARD=nucleo-l152re -C tests/periph_eeprom/ flash  test`

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

Taken from #10026.
