### PR TITLE
tests/gnrc_udp: Replace atoi() by strtol().

### DIFF
--- a/tests/gnrc_udp/udp.c
+++ b/tests/gnrc_udp/udp.c
@@ -17,6 +17,7 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <inttypes.h>
 
 #include "msg.h"
@@ -82,6 +83,7 @@ static void send(char *addr_str, char *port_str, char *data_len_str, unsigned in
                  unsigned int delay)
 {
     int iface;
+    char *conversion_end;
     uint16_t port;
     ipv6_addr_t addr;
     size_t data_len;
@@ -103,8 +105,8 @@ static void send(char *addr_str, char *port_str, char *data_len_str, unsigned in
         return;
     }
 
-    data_len = atoi(data_len_str);
-    if (data_len == 0) {
+    data_len = strtoul(data_len_str, &conversion_end, 0);
+    if (*conversion_end != '\0') {
         puts("Error: unable to parse data_len");
         return;
     }

--- a/tests/gnrc_udp/udp.c
+++ b/tests/gnrc_udp/udp.c
@@ -60,7 +60,7 @@ static void *_eventloop(void *arg)
 
         switch (msg.type) {
             case GNRC_NETAPI_MSG_TYPE_RCV:
-                printf("Packets received: %d\n", ++rcv_count);
+                printf("Packets received: %u\n", ++rcv_count);
                 gnrc_pktbuf_release(msg.content.ptr);
                 break;
             case GNRC_NETAPI_MSG_TYPE_GET:


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

atoi() cannot detect errors. Many implementation return zero on error and that is what was being checked here, making the "udp send" command unable to parse integer values of zero. On top of this, the behavior on errors does not seem to be specified in the standard (so it is not even correct to check for zero even when zero is not an accepted value, like for a port number).

The result of all this is that sending UDP packets of zero length (as required by the Release Specs) was not possible.

This patch replaces atoi by strlen, which allows for robust error detection. Sending zero length packets is possible.

### Testing procedure

Run `make -C tests/gnrc_udp all term`

In the RIOT terminal, try to send a 0 length packet:

```
> udp send fe80::bd:b7e 1337 0
udp send fe80::bd:b7e 1337 0
Error: unable to parse data_len
```

With this patch:

```
> udp send fe80::bd:b7e 1337 0
udp send fe80::bd:b7e 1337 0
Success: send 0 byte to [fe80::bd:b7e]:1337
```

### Issues/PRs references

None.
