### PR TITLE
boards/hifive1: fixup custom reset command

### DIFF
--- a/boards/hifive1/Makefile.include
+++ b/boards/hifive1/Makefile.include
@@ -12,8 +12,8 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
 
-# this board uses openocd
-export OPENOCD_CMD_RESET_RUN=_reset
+# this board uses openocd with a custom reset command
+export OPENOCD_CMD_RESET_RUN=-c _reset
 include $(RIOTMAKE)/tools/openocd.inc.mk
 
 # use our own openocd script to flash since HiFive1 has reset problems.


### PR DESCRIPTION
### Contribution description

#11040 introduced a custom reset command, but during its fixups, it forgot a "-c", effectively breaking it.
This PR fixes that.

### Testing procedure

Grab a hifive1, compile & flash any app, try "BOARD=hifive1 make reset" from another terminal.
Should fail on master, work with this PR.

### Issues/PRs references

#11040