### PR TITLE
boards: add I2C config for cc2650stk

### DIFF
--- a/boards/cc2650stk/Makefile.features
+++ b/boards/cc2650stk/Makefile.features
@@ -1,5 +1,6 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
+FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 

--- a/boards/cc2650stk/include/periph_conf.h
+++ b/boards/cc2650stk/include/periph_conf.h
@@ -78,6 +78,15 @@ static const timer_conf_t timer_config[] = {
 #define UART_TX_PIN         (29)
 /** @} */
 
+/**
+ * @name    I2C configuration
+ * @{
+ */
+#define I2C_NUMOF           (1)
+#define I2C_SDA_PIN         (5)
+#define I2C_SCL_PIN         (6)
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

see title, it's that simple


### Testing procedure

run `tests/driver_hdc1000` with this board, you should see some nice output of temperatures and humidity.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
