### PR TITLE
cpu/atmega_common: Moved atmega_stdio_init() to cpu_init()

### DIFF
--- a/boards/common/atmega/board.c
+++ b/boards/common/atmega/board.c
@@ -34,10 +34,6 @@ void board_init(void)
 
     atmega_set_prescaler(CPU_ATMEGA_CLK_SCALE_INIT);
 
-#ifdef MODULE_AVR_LIBC_EXTRA
-    atmega_stdio_init();
-#endif
-
     cpu_init();
     led_init();
     irq_enable();

--- a/boards/waspmote-pro/board.c
+++ b/boards/waspmote-pro/board.c
@@ -58,10 +58,6 @@ void board_init(void)
 #endif
 #endif
 
-#ifdef MODULE_AVR_LIBC_EXTRA
-    atmega_stdio_init();
-#endif
-
     cpu_init();
     led_init();
     irq_enable();

--- a/cpu/atmega_common/cpu.c
+++ b/cpu/atmega_common/cpu.c
@@ -105,6 +105,10 @@ void cpu_init(void)
     wdt_reset();   /* should not be nececessary as done in bootloader */
     wdt_disable(); /* but when used without bootloader this is needed */
 
+    /* Initialize stdio before periph_init() to allow use of DEBUG() there */
+#ifdef MODULE_AVR_LIBC_EXTRA
+    atmega_stdio_init();
+#endif
     /* Initialize peripherals for which modules are included in the makefile.*/
     /* spi_init */
     /* rtc_init */


### PR DESCRIPTION
### Contribution description
Moving atmega_stdio_init() to cpu_init() just before periph_init() guarantees that stdio is available to allow DEBUG() in periph_init(). This also helps to unify the boot up process of ATmega boards and de-duplicates the stdio init from board_init().

### Testing procedure
Flash and run `examples/hello-world`

- [x] `arduino-uno` (@maribu)
- [x] `arduino-mega2560 (@maribu)
- [ ] ATmega1284p based board (maybe @roberthartung ?)
- [ ] `jiminiy-mega256rfr2` (maybe @Josar ?)
- [ ] `waspmote-pro` (Nobody seems to have such a board anymore ...)

### Issues/PRs references
Spun out of / partly replaces https://github.com/RIOT-OS/RIOT/pull/10806