### PR TITLE
cpu: Moved stdio_init() prior to periph_init() for ARM targets

### DIFF
--- a/boards/msba2/board_init.c
+++ b/boards/msba2/board_init.c
@@ -27,6 +27,7 @@
 #include "board.h"
 #include "cpu.h"
 #include "periph/init.h"
+#include "stdio_base.h"
 
 void bl_init_ports(void)
 {
@@ -42,6 +43,11 @@ void bl_init_ports(void)
 
     LED0_OFF;
     LED0_OFF;
+
+    /* initialize stdio prior to periph_init() to allow use of DEBUG() there */
+    stdio_init();
+
+    /* trigger static peripheral initialization */
     periph_init();
 }
 

--- a/cpu/cc2538/cpu.c
+++ b/cpu/cc2538/cpu.c
@@ -21,6 +21,7 @@
 
 #include "cpu.h"
 #include "periph/init.h"
+#include "stdio_base.h"
 
 #define BIT(n)          ( 1UL << (n) )
 
@@ -48,6 +49,8 @@ void cpu_init(void)
     SYS_CTRL->I_MAP = 1;
     /* initialize the clock system */
     cpu_clock_init();
+    /* initialize stdio prior to periph_init() to allow use of DEBUG() there */
+    stdio_init();
     /* trigger static peripheral initialization */
     periph_init();
 }

--- a/cpu/cc26x0/cpu.c
+++ b/cpu/cc26x0/cpu.c
@@ -20,6 +20,7 @@
 #include "cpu.h"
 #include "periph_conf.h"
 #include "periph/init.h"
+#include "stdio_base.h"
 
 #ifndef HF_CLOCK_SOURCE
 #define HF_CLOCK_SOURCE DDI_0_OSC_CTL0_SCLK_HF_SRC_SEL_RCOSC /* set 48MHz RCOSC */
@@ -43,6 +44,9 @@ void cpu_init(void)
 
     /* initialize the system clock */
     cpu_clock_init();
+
+    /* initialize stdio prior to periph_init() to allow use of DEBUG() there */
+    stdio_init();
 
     /* trigger static peripheral initialization */
     periph_init();

--- a/cpu/efm32/cpu.c
+++ b/cpu/efm32/cpu.c
@@ -22,6 +22,7 @@
 #include "cpu.h"
 #include "periph_conf.h"
 #include "periph/init.h"
+#include "stdio_base.h"
 
 #include "em_chip.h"
 #include "em_cmu.h"
@@ -171,6 +172,9 @@ void cpu_init(void)
 
     /* initialize power management interface */
     pm_init();
+
+    /* initialize stdio prior to periph_init() to allow use of DEBUG() there */
+    stdio_init();
 
     /* trigger static peripheral initialization */
     periph_init();

--- a/cpu/ezr32wg/cpu.c
+++ b/cpu/ezr32wg/cpu.c
@@ -20,6 +20,7 @@
 #include "cpu.h"
 #include "periph_conf.h"
 #include "periph/init.h"
+#include "stdio_base.h"
 
 /**
  * @brief   Configure clock sources and the CPU frequency
@@ -60,6 +61,8 @@ void cpu_init(void)
     cortexm_init();
     /* Initialise clock sources and generic clocks */
     clk_init();
+    /* initialize stdio prior to periph_init() to allow use of DEBUG() there */
+    stdio_init();
     /* trigger static peripheral initialization */
     periph_init();
 }

--- a/cpu/kinetis/cpu.c
+++ b/cpu/kinetis/cpu.c
@@ -19,6 +19,7 @@
 
 #include "cpu.h"
 #include "periph/init.h"
+#include "stdio_base.h"
 #ifdef MODULE_PERIPH_MCG
 #include "mcg.h"
 #endif
@@ -41,6 +42,10 @@ void cpu_init(void)
     /* initialize the CPU clocking provided by the MCG module */
     kinetis_mcg_init();
 #endif
+
+    /* initialize stdio prior to periph_init() to allow use of DEBUG() there */
+    stdio_init();
+
     /* trigger static peripheral initialization */
     periph_init();
 }

--- a/cpu/lm4f120/cpu.c
+++ b/cpu/lm4f120/cpu.c
@@ -24,6 +24,7 @@
 #include "irq.h"
 #include "periph/init.h"
 #include "periph_conf.h"
+#include "stdio_base.h"
 
 /**
  * @brief Initialize the CPU, set IRQ priorities
@@ -35,6 +36,9 @@ void cpu_init(void)
 
     /* initialize the clock system */
     cpu_clock_init(CLOCK_SOURCE);
+
+    /* initialize stdio prior to periph_init() to allow use of DEBUG() there */
+    stdio_init();
 
     /* trigger static peripheral initialization */
     periph_init();

--- a/cpu/lpc1768/cpu.c
+++ b/cpu/lpc1768/cpu.c
@@ -19,6 +19,7 @@
 
 #include "cpu.h"
 #include "periph/init.h"
+#include "stdio_base.h"
 
 /**
  * @brief Initialize the CPU, set IRQ priorities
@@ -27,6 +28,8 @@ void cpu_init(void)
 {
     /* initialize the Cortex-M core */
     cortexm_init();
+    /* initialize stdio prior to periph_init() to allow use of DEBUG() there */
+    stdio_init();
     /* trigger static peripheral initialization */
     periph_init();
 }

--- a/cpu/nrf51/cpu.c
+++ b/cpu/nrf51/cpu.c
@@ -21,6 +21,7 @@
 #include "nrf_clock.h"
 #include "periph_conf.h"
 #include "periph/init.h"
+#include "stdio_base.h"
 
 /**
  * @brief Initialize the CPU, set IRQ priorities
@@ -31,6 +32,8 @@ void cpu_init(void)
     cortexm_init();
     /* setup the HF clock */
     clock_init_hf();
+    /* initialize stdio prior to periph_init() to allow use of DEBUG() there */
+    stdio_init();
     /* trigger static peripheral initialization */
     periph_init();
 }

--- a/cpu/nrf52/cpu.c
+++ b/cpu/nrf52/cpu.c
@@ -26,6 +26,7 @@
 #include "nrf_clock.h"
 #include "periph_conf.h"
 #include "periph/init.h"
+#include "stdio_base.h"
 
 /* FTPAN helper functions */
 static bool ftpan_32(void);
@@ -82,6 +83,9 @@ void cpu_init(void)
 
     /* enable wake up on events for __WFE CPU sleep */
     SCB->SCR |= SCB_SCR_SEVONPEND_Msk;
+
+    /* initialize stdio prior to periph_init() to allow use of DEBUG() there */
+    stdio_init();
 
     /* trigger static peripheral initialization */
     periph_init();

--- a/cpu/sam3/cpu.c
+++ b/cpu/sam3/cpu.c
@@ -20,6 +20,7 @@
 #include "cpu.h"
 #include "periph_conf.h"
 #include "periph/init.h"
+#include "stdio_base.h"
 
 /**
  * @brief   Keys needed for editing certain PMC registers
@@ -89,6 +90,9 @@ void cpu_init(void)
     PMC->PMC_MCKR = PMC_MCKR_CSS_PLLA_CLK;
     /* wait for master clock to be ready */
     while (!(PMC->PMC_SR & PMC_SR_MCKRDY));
+
+    /* initialize stdio prior to periph_init() to allow use of DEBUG() there */
+    stdio_init();
 
     /* trigger static peripheral initialization */
     periph_init();

--- a/cpu/samd21/cpu.c
+++ b/cpu/samd21/cpu.c
@@ -21,6 +21,7 @@
 #include "cpu.h"
 #include "periph_conf.h"
 #include "periph/init.h"
+#include "stdio_base.h"
 
 #ifndef CLOCK_8MHZ
 #define CLOCK_8MHZ          1
@@ -218,6 +219,8 @@ void cpu_init(void)
     cortexm_init();
     /* Initialise clock sources and generic clocks */
     clk_init();
+    /* initialize stdio prior to periph_init() to allow use of DEBUG() there */
+    stdio_init();
     /* trigger static peripheral initialization */
     periph_init();
 }

--- a/cpu/samd5x/cpu.c
+++ b/cpu/samd5x/cpu.c
@@ -20,6 +20,7 @@
 #include "cpu.h"
 #include "periph_conf.h"
 #include "periph/init.h"
+#include "stdio_base.h"
 
 static void xosc32k_init(void)
 {
@@ -136,6 +137,9 @@ void cpu_init(void)
 #ifdef MODULE_PERIPH_USBDEV
     gclk_connect(6, GCLK_SOURCE_DFLL, 0);
 #endif
+
+    /* initialize stdio prior to periph_init() to allow use of DEBUG() there */
+    stdio_init();
 
     /* trigger static peripheral initialization */
     periph_init();

--- a/cpu/saml1x/cpu.c
+++ b/cpu/saml1x/cpu.c
@@ -22,6 +22,7 @@
 #include "periph/init.h"
 #include "periph_conf.h"
 #include "board.h"
+#include "stdio_base.h"
 
 #ifdef CPU_FAM_SAML11
 #define _NVMCTRL NVMCTRL_SEC
@@ -114,6 +115,9 @@ void cpu_init(void)
 
     /* Setup GCLK generators */
     _gclk_setup(0, GCLK_GENCTRL_GENEN | GCLK_GENCTRL_SRC_OSC16M);
+
+    /* initialize stdio prior to periph_init() to allow use of DEBUG() there */
+    stdio_init();
 
     /* trigger static peripheral initialization */
     periph_init();

--- a/cpu/saml21/cpu.c
+++ b/cpu/saml21/cpu.c
@@ -21,6 +21,7 @@
 #include "cpu.h"
 #include "periph/init.h"
 #include "periph_conf.h"
+#include "stdio_base.h"
 
 static void _gclk_setup(int gclk, uint32_t reg)
 {
@@ -117,6 +118,9 @@ void cpu_init(void)
      */
     SUPC->BOD33.bit.ENABLE=0;
 #endif
+
+    /* initialize stdio prior to periph_init() to allow use of DEBUG() there */
+    stdio_init();
 
     /* trigger static peripheral initialization */
     periph_init();

--- a/cpu/stm32_common/cpu_init.c
+++ b/cpu/stm32_common/cpu_init.c
@@ -33,6 +33,7 @@
  */
 
 #include "cpu.h"
+#include "stdio_base.h"
 #include "stmclk.h"
 #include "periph_cpu.h"
 #include "periph/init.h"
@@ -160,6 +161,8 @@ void cpu_init(void)
     /*  initialize DMA streams */
     dma_init();
 #endif
+    /* initialize stdio prior to periph_init() to allow use of DEBUG() there */
+    stdio_init();
     /* trigger static peripheral initialization */
     periph_init();
 }

--- a/sys/newlib_syscalls_default/syscalls.c
+++ b/sys/newlib_syscalls_default/syscalls.c
@@ -69,7 +69,7 @@ char *heap_top = &_sheap + 4;
  */
 void _init(void)
 {
-    stdio_init();
+    /* nothing to do here */
 }
 
 /**


### PR DESCRIPTION
### Contribution description
In current RIOT master `stdio_init()` is called via newlib's `_init()`, which is way too late during boot up to allow `DEBUG()`ing during `periph_init()`. This PR moves `stdio_init()` into `cpu_init()` just before `periph_init()` is called.

### Testing procedure
Flash and run `examples/default` and interact with the shell. Input and output should still work as expected.

Boards using these CPUs:
- [x] `cc2538` (@dylad tested on firefly remotely on iotlab)
- [x] `cc26x0` (@MrKevinWeiss tested on cc2650-launchpad)
- [x] `efm32` (@MrKevinWeiss tested on slstk3402a)
- [ ] `ezr32wg`
- [ ] `lm4f120`
- [x] `lpc1768` (@MrKevinWeiss tested on mbed-lpc1768)
- [x] `nrf51` (@dylad tested on nrf51dk remotely on iotlab)
- [x] `nrf52` (@maribu tested with `nrf42840dk`)
- [x] `sam3`
- [x] `samd21` (@dylad tested on arduino-zero remotely on iotlab)
- [x] samd51 (@dylad tested with SAME54-XPRO)
- [x] `saml1x`(@dylad tested with SAML10-XPRO and SAML11-XPRO)
- [x] `saml21`(@dylad tested with SAML21-XPRO)
- [x] STM32-F1* (@MrKevinWeiss tested on nucleo-f103rb)
- [x] STM32-F2* (@MrKevinWeiss tested on nucleo-f207zg)
- [x] STM32-F3* (@maribu tested with `nucleo-f303re`)
- [x] STM32-F4* (@MrKevinWeiss tested on nucleo-f413zh)
- [x] STM32-F7* (@maribu tested with `nucleo-f767zi`)
- [x] STM32-L0* (@fjmolinas  tested with `b-l072z-lrwan1`)
- [x] STM32-L1* (@MrKevinWeiss tested on nucleo-l152re)
- [x] STM32-L4* (@MrKevinWeiss tested on nucleo-l433rc)
- [x]  KINETIS-KW (@fjmolinas  tested with `frdm-kw41z`, `pba-d-01-kw2x`)
- [x]  KINETIS-KW (@fjmolinas  tested with `frdm-k64f`)
- [ ]  KINETIS-EA

Boards with custom/weird boot up sequence:
- [x] Board `msba2` (@maribu)

### Issues/PRs references
Spun out of / partly replaces https://github.com/RIOT-OS/RIOT/pull/10806