### PR TITLE
posix_sockets.c: fix send() for connected UDP sockets [backport 2019.04]

### DIFF
--- a/sys/posix/sockets/posix_sockets.c
+++ b/sys/posix/sockets/posix_sockets.c
@@ -928,7 +928,7 @@ static ssize_t socket_sendto(socket_t *s, const void *buffer, size_t length,
             return res;
         }
     }
-#if defined(MODULE_SOCK_IP) || defined(MODULE_SOCK_UDP)
+#if defined(MODULE_SOCK_IP)
     if ((res = _sockaddr_to_ep(address, address_len, &ep)) < 0)
         return res;
 #endif
@@ -959,7 +959,13 @@ static ssize_t socket_sendto(socket_t *s, const void *buffer, size_t length,
 #endif
 #ifdef MODULE_SOCK_UDP
         case SOCK_DGRAM:
-            if ((res = sock_udp_send(&s->sock->udp, buffer, length, &ep)) < 0) {
+            if (address == NULL) {
+                res = sock_udp_get_remote(&s->sock->udp, &ep);
+            } else {
+                res = _sockaddr_to_ep(address, address_len, &ep);
+            }
+            if ((res < 0) ||
+                (res = sock_udp_send(&s->sock->udp, buffer, length, &ep)) < 0) {
                 errno = -res;
                 res = -1;
             }


### PR DESCRIPTION
# Backport of #11364

### Contribution description

Calling send() on a connected UDP socket raises a kernel panic
in posix_sockets.c, line 215, because sendto() is called from
send() with address set to NULL.

This change modifies sendto() to

* Check if the UDP socket is connected when the address argument
  is NULL.
* If connected, pass the stored remote address to socket_sendto().

The reason this is not done directly in the implementation of `send()` is that `send()` is an inline function in a header file. The proposed solution here seems a bit less intrusive.

### Testing procedure

Example code for testing (obviously, the Makefile must include `USEMODULE += posix_sockets`):

```c
#include <assert.h>
#include <errno.h>
#include <netinet/in.h>
#include <stdio.h>
#include <sys/socket.h>

int main(void)
{
    int srv = socket(AF_INET6, SOCK_DGRAM, 0);
    int sock = socket(AF_INET6, SOCK_DGRAM, 0);
    assert(srv >= 0 && sock >= 0);

    struct sockaddr_in6 addr;
    addr.sin6_family = AF_INET6;
    addr.sin6_addr = in6addr_loopback;
    addr.sin6_port = htons(7000);
    if (bind(srv, (struct sockaddr *)&addr, sizeof(struct sockaddr_in6)) != 0) {
        printf("bind failed: %d\n", errno);
        return 1;
    }
    if (connect(sock, (struct sockaddr *)&addr, sizeof(struct sockaddr_in6)) != 0) {
        printf("connect failed: %d\n", errno);
        return 1;
    }

    send(sock, "", 1, 0);
    return 0;
}
```

`make term` without this patch results in a RIOT kernel panic:

```
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2019.04-devel-861-ga1a8d-posix_sockets_udp_connect)
sys/posix/sockets/posix_sockets.c:215 => 0x5660a44e
*** RIOT kernel panic:
FAILED ASSERTION.

*** halted.


native: exiting
```

Expected behavior with this patch applied:

```
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2019.04-devel-861-ga1a8d-posix_sockets_udp_connect)
^C
native: exiting
```