### PR TITLE
WIP: introduce periph_sleepmem

### DIFF
--- a/cpu/stm32_common/periph/sleepmem.c
+++ b/cpu/stm32_common/periph/sleepmem.c
@@ -1,0 +1,59 @@
+#include <string.h>
+
+#include "periph/sleepmem.h"
+
+#include "cpu.h"
+
+#ifndef RTC_BKP_NUMBER
+#define RTC_BKP_NUMBER (20u)
+#endif
+
+extern void rtc_lock(void);
+extern void rtc_enable(void);
+extern void rtc_unlock(void);
+
+size_t sleepmem_size = (RTC_BKP_NUMBER * 4);
+
+void sleepmem_init(void)
+{
+    rtc_enable();
+}
+
+size_t sleepmem_put(void *src, size_t n)
+{
+    n = (n <= sleepmem_size) ? n : sleepmem_size;
+
+    volatile uint32_t *rtcregs = &RTC->BKP0R;
+
+    rtc_unlock();
+
+    while (n) {
+        unsigned to_copy = (n >= 4) ? 4 : n;
+        uint32_t tmp;
+        memcpy(&tmp, src, to_copy);
+        *rtcregs++ = tmp;
+        n -= to_copy;
+        src += to_copy;
+    }
+
+    rtc_lock();
+
+    return n;
+}
+
+size_t sleepmem_get(void *target, size_t n)
+{
+    n = (n <= sleepmem_size) ? n : sleepmem_size;
+
+    volatile uint32_t *rtcregs = &RTC->BKP0R;
+
+    while (n) {
+        unsigned to_copy = (n >= 4) ? 4 : n;
+        uint32_t tmp = *rtcregs++;
+        memcpy(target, &tmp, to_copy);
+        n -= to_copy;
+        target += to_copy;
+    }
+
+    return n;
+}

--- a/drivers/include/periph/sleepmem.h
+++ b/drivers/include/periph/sleepmem.h
@@ -1,0 +1,12 @@
+#ifndef SLEEPMEM_H
+#define SLEEPMEM_H
+
+#include <unistd.h>
+
+extern size_t sleepmem_size;
+
+void sleepmem_init(void);
+size_t sleepmem_put(void *src, size_t n);
+size_t sleepmem_get(void *target, size_t n);
+
+#endif /* SLEEPMEM_H */


### PR DESCRIPTION
### Contribution description

Some MCU's offer a couple of registers or memory that retain(s) state even in the deepest sleep mode (when e.g., RAM is not retained). This PR tries to come up with a generic API to make those usable, and an implementation for stm32's RTC backup registers.

While working fine on stm32f4, this is otherwise completely WIP and missing licenses, docs, test application, ...

### Testing procedure

I'd say this is in planning phase, so please check if the API makes sense.

### Issues/PRs references

Briefly discussed backup registers in https://github.com/RIOT-OS/RIOT/pull/11258#discussion_r273891656.