### PR TITLE
tests/gnrc_sock_dns: Give time to allow node to set its ll address

### DIFF
--- a/tests/gnrc_sock_dns/tests/01-run.py
+++ b/tests/gnrc_sock_dns/tests/01-run.py
@@ -13,6 +13,7 @@ import socket
 import sys
 import subprocess
 import threading
+import time
 
 from scapy.all import DNS, DNSQR, DNSRR, Raw, raw
 from testrunner import run
@@ -274,6 +275,7 @@ def testfunc(child):
     tap = get_bridge(os.environ["TAP"])
     lladdr = get_host_lladdr(tap)
 
+    time.sleep(3)
     try:
         server = Server(family=socket.AF_INET6, type=socket.SOCK_DGRAM,
                         bind_addr=lladdr + "%" + tap, bind_port=SERVER_PORT)


### PR DESCRIPTION
### Contribution description

This puts a delay of three seconds at the beginning of the test. Without it, the node will send a neighbour solicitation with a blank link local address, it won't receive a reply, and the test will fail for non-native nodes.

### Testing procedure

Run `sudo BOARD=[boardname] make test`, after flashing.