### PR TITLE
examples/nimble*: add more nrf52 based boards in whitelist

### DIFF
--- a/examples/nimble_gatt/Makefile
+++ b/examples/nimble_gatt/Makefile
@@ -5,7 +5,8 @@ APPLICATION = nimble_gatt
 BOARD ?= nrf52dk
 
 # So far, NimBLE only works on nRF52 based platforms
-BOARD_WHITELIST := nrf52dk nrf52840dk nrf52832-mdk
+BOARD_WHITELIST := acd52832 nrf52dk nrf52840dk nrf52832-mdk nrf52840-mdk \
+                   reel ruuvitag thingy52
 
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..

--- a/examples/nimble_scanner/Makefile
+++ b/examples/nimble_scanner/Makefile
@@ -5,7 +5,8 @@ APPLICATION = nimble_scanner
 BOARD ?= nrf52dk
 
 # So far, NimBLE only works on nRF52 based platforms
-BOARD_WHITELIST := nrf52dk nrf52840dk
+BOARD_WHITELIST := acd52832 nrf52dk nrf52840dk nrf52832-mdk nrf52840-mdk \
+                   reel ruuvitag thingy52
 
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds all nrf52 based boards supported in RIOT to the board whitelist of nimble applications.

I know this solution is not the most maintainable but since there are not so many nrf52 based boards in RIOT, it should be fine for now.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

`examples/nimble_*` should work on the boards (they do on nrf52xxx-mdk boards)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
