### PR TITLE
Esp32 documentation fixes

### DIFF
--- a/boards/esp32-mh-et-live-minikit/doc.txt
+++ b/boards/esp32-mh-et-live-minikit/doc.txt
@@ -83,7 +83,7 @@ UARTs       | 3 | yes
 WiFi        | IEEE 802.11 b/g/n built in | yes
 Bluetooth   | v4.2 BR/EDR and BLE | no
 Ethernet    | MAC interface with dedicated DMA and IEEE 1588 support | yes
-CAN         | version 2.0 | no
+CAN         | version 2.0 | yes
 IR          | up to 8 channels TX/RX | no
 Motor PWM   | 2 devices x 6 channels | yes
 LED PWM     | 16 channels | no

--- a/boards/esp32-olimex-evb/doc.txt
+++ b/boards/esp32-olimex-evb/doc.txt
@@ -76,7 +76,7 @@ UARTs       | 3 | yes
 WiFi        | IEEE 802.11 b/g/n built in | yes
 Bluetooth   | v4.2 BR/EDR and BLE | no
 Ethernet    | MAC interface with dedicated DMA and IEEE 1588 support | yes
-CAN         | version 2.0 | no
+CAN         | version 2.0 | yes
 IR          | up to 8 channels TX/RX | no
 Motor PWM   | 2 devices x 6 channels | yes
 LED PWM     | 16 channels | no

--- a/boards/esp32-wemos-lolin-d32-pro/doc.txt
+++ b/boards/esp32-wemos-lolin-d32-pro/doc.txt
@@ -144,7 +144,7 @@ MRF24J40-based IEEE 802.15.4 radio modules and ENC28J60-based Ethernet network i
 #define ENC28J80_PARAM_CS       GPIO15      /* ENC28J80 CS signal    */
 #define ENC28J80_PARAM_RESET    GPIO2       /* ENC28J80 RESET signal */
 #define ENC28J80_PARAM_INT      GPIO13      /* ENC28J80 INT signal   */
-endif
+#endif
 
 #endif
 ```

--- a/boards/esp32-wemos-lolin-d32-pro/doc.txt
+++ b/boards/esp32-wemos-lolin-d32-pro/doc.txt
@@ -69,7 +69,7 @@ UARTs       | 3 | yes
 WiFi        | IEEE 802.11 b/g/n built in | yes
 Bluetooth   | v4.2 BR/EDR and BLE | no
 Ethernet    | MAC interface with dedicated DMA and IEEE 1588 support | yes
-CAN         | version 2.0 | no
+CAN         | version 2.0 | yes
 IR          | up to 8 channels TX/RX | no
 Motor PWM   | 2 devices x 6 channels | yes
 LED PWM     | 16 channels | no

--- a/boards/esp32-wroom-32/doc.txt
+++ b/boards/esp32-wroom-32/doc.txt
@@ -145,7 +145,7 @@ MRF24J40-based IEEE 802.15.4 radio modules and ENC28J60-based Ethernet network i
 #define ENC28J80_PARAM_CS       GPIO32      /* ENC28J80 CS signal    */
 #define ENC28J80_PARAM_RESET    GPIO33      /* ENC28J80 RESET signal */
 #define ENC28J80_PARAM_INT      GPIO35      /* ENC28J80 INT signal   */
-endif
+#endif
 
 #endif
 ```

--- a/boards/esp32-wroom-32/doc.txt
+++ b/boards/esp32-wroom-32/doc.txt
@@ -63,7 +63,7 @@ UARTs       | 3 | yes
 WiFi        | IEEE 802.11 b/g/n built in | yes
 Bluetooth   | v4.2 BR/EDR and BLE | no
 Ethernet    | MAC interface with dedicated DMA and IEEE 1588 support | yes
-CAN         | version 2.0 | no
+CAN         | version 2.0 | yes
 IR          | up to 8 channels TX/RX | no
 Motor PWM   | 2 devices x 6 channels | yes
 LED PWM     | 16 channels | no

--- a/boards/esp32-wrover-kit/doc.txt
+++ b/boards/esp32-wrover-kit/doc.txt
@@ -71,7 +71,7 @@ UARTs       | 3 | yes
 WiFi        | IEEE 802.11 b/g/n built in | yes
 Bluetooth   | v4.2 BR/EDR and BLE | no
 Ethernet    | MAC interface with dedicated DMA and IEEE 1588 support | yes
-CAN         | version 2.0 | no
+CAN         | version 2.0 | yes
 IR          | up to 8 channels TX/RX | no
 Motor PWM   | 2 devices x 6 channels | yes
 LED PWM     | 16 channels | no

--- a/boards/esp32-wrover-kit/doc.txt
+++ b/boards/esp32-wrover-kit/doc.txt
@@ -215,7 +215,7 @@ MRF24J40-based IEEE 802.15.4 radio modules and ENC28J60-based Ethernet network i
 #define ENC28J80_PARAM_CS       GPIO9       /* ENC28J80 CS signal    */
 #define ENC28J80_PARAM_INT      GPIO10      /* ENC28J80 INT signal   */
 #define ENC28J80_PARAM_RESET    GPIO12      /* ENC28J80 RESET signal */
-endif
+#endif
 
 #endif
 ```


### PR DESCRIPTION
### Contribution description

Fix ENC28J60 configuration example and mark CAN as supported for ESP32 platform.

### Testing procedure

`make doc` and look at the esp32-wroom-32 board documentation.