### PR TITLE
tests/posix_semaphore: add (lack of) fe310 timer accuracy workaround

### DIFF
--- a/tests/posix_semaphore/main.c
+++ b/tests/posix_semaphore/main.c
@@ -243,6 +243,13 @@ void test3(void)
 /* nrf51 based boards needs a slightly higher margin value. Using 105us makes
  test4 result more reliable. */
 #define TEST4_TIMEOUT_EXCEEDED_MARGIN (105)
+#elif defined(CPU_FE310)
+/*
+ * the fe310 used on Hifive1 only offers a 32kHZ RTC, which xtimer uses by
+ * default.  There seem to be inaccuracies getting introduced somewhere, in the order of 2 to 8 ticks.
+ * Thus allow for 8 * (1000000/32768) us.
+ */
+#define TEST4_TIMEOUT_EXCEEDED_MARGIN (245)
 #else
 #define TEST4_TIMEOUT_EXCEEDED_MARGIN (100)
 #endif /* BOARD_NATIVE */


### PR DESCRIPTION
### Contribution description

On hifive1, the test runs slightly longer than the default allows. This is probably caused by the board using a 32kHz timer as base for xtimer. This PR adds a workaround (allow up to 250usec/sec too long) only for the FE310 cpu.

### Testing procedure

- assert validity of fix
- see #11041 passing the test on all boards including hifive1

### Issues/PRs references

#11041