### PR TITLE
tests/pthread_tls: allow negative key values

### DIFF
--- a/tests/pthread_tls/tests/01-run.py
+++ b/tests/pthread_tls/tests/01-run.py
@@ -8,7 +8,7 @@ def _check_test_output(child):
     child.expect('show tls values:')
     for i in range(20):
         if i != 5:
-            child.expect('key\[%d\]: \d+, val: %d'
+            child.expect('key\[%d\]: -?\d+, val: %d'
                          % (i, i + 1 if i != 3 else 42))
 
 
@@ -17,7 +17,7 @@ def testfunc(child):
     child.expect('-= TEST 1 - create 20 tls with sequencial values 0...19 =-')
     _check_test_output(child)
     child.expect('-= TEST 2 - '
-                 'delete deliberate key \(key\[5\]:\d+\) =-')
+                 'delete deliberate key \(key\[5\]:-?\d+\) =-')
     _check_test_output(child)
     child.expect('-= TEST 3 - create new tls =-')
     _check_test_output(child)
@@ -26,10 +26,10 @@ def testfunc(child):
     child.expect('-= TEST 5 - try delete non-existing key =-')
     child.expect('try to delete returns: 0')
     child.expect('-= TEST 6 - add key and delete without a tls =-')
-    child.expect('created key: \d+')
+    child.expect('created key: -?\d+')
     child.expect('try to delete returns: 0')
     child.expect('-= TEST 7 - add key without tls =-')
-    child.expect('created key: \d+')
+    child.expect('created key: -?\d+')
     child.expect('test_7_val: (0|\(nil\))')
     child.expect('tls tests finished.')
     child.expect('SUCCESS')


### PR DESCRIPTION
### Contribution description

On Hifive1, the created keys have a negative value. IIUC the key is basically a pointer converted to int, which on hifive1 is in a memory area which causes the sign to be negative.
This commit adjusts the pexpect script to allow for that.

### Testing procedure

See #11041 succeeding on hifive1 with this fix.

### Issues/PRs references

#11041