### PR TITLE
tests/pthread_cooperation: add hifive1 to BLACKLIST

### DIFF
--- a/tests/pthread_cooperation/Makefile
+++ b/tests/pthread_cooperation/Makefile
@@ -1,10 +1,12 @@
 include ../Makefile.tests_common
 
 BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-nano \
-                   arduino-uno jiminy-mega256rfr2 mega-xplained waspmote-pro
+                   arduino-uno jiminy-mega256rfr2 mega-xplained waspmote-pro \
+                   hifive1
 # arduino mega2560 uno duemilanove : unknown type name: clockid_t
 # jiminy-mega256rfr2: unknown type name: clockid_t
 # mega-xplained: unknown type name: clockid_t
+# hifive1: not enough memory for thread stacks
 
 BOARD_INSUFFICIENT_MEMORY := nucleo-f031k6
 


### PR DESCRIPTION
### Contribution description

The hifive1 has only 16kB of memory. The tests tries to allocate 12
thread stacks with 1kB (default) stacksize each. The corresponding
malloc() fails for the last two threads, making the test fail silently.

(an underlying issue is that pthread_create() doesn't fail if malloc() fails...)

### Testing procedure

Run test on hifive1, watch it get stuck.

### Issues/PRs references

#11041 