### PR TITLE
cpu/esp32: use modules newlib_syscalls_default and stdio_uart by default

### DIFF
--- a/cpu/esp32/Makefile.dep
+++ b/cpu/esp32/Makefile.dep
@@ -77,22 +77,9 @@ ifneq (,$(filter ndn-riot,$(USEPKG)))
     USEMODULE += cipher_modes
 endif
 
-ifneq (,$(findstring posix_headers,$(USEMODULE)))
-    USEMODULE += newlib_syscalls_default
-endif
-
 ifneq (,$(filter shell,$(USEMODULE)))
-    USEMODULE += newlib_syscalls_default
     USEMODULE += ps
     USEMODULE += xtimer
-endif
-
-ifneq (,$(filter xtimer,$(USEMODULE)))
-    USEMODULE += newlib_syscalls_default
-endif
-
-ifneq (,$(filter newlib_syscalls_default,$(USEMODULE)))
-    USEMODULE += stdio_uart
 endif
 
 # if SPI RAM is enabled, ESP-IDF heap and quot flash mode have to be used

--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -66,9 +66,11 @@ USEMODULE += esp_idf_driver
 USEMODULE += esp_idf_esp32
 USEMODULE += esp_idf_soc
 USEMODULE += log
+USEMODULE += newlib_syscalls_default
 USEMODULE += periph
 USEMODULE += periph_common
 USEMODULE += random
+USEMODULE += stdio_uart
 USEMODULE += xtensa
 
 INCLUDES += -I$(RIOTCPU)/$(CPU)/vendor/


### PR DESCRIPTION
### Contribution description

This PR fixes the problem that ESP32's newlibc function `_write_r` does not write the output for `stdio` to the UART interface.

To fix this problem, modules `newlib_syscalls_default`  and `stdio_uart` are now used by default. It fixes the problem since function `_write_r` of module `newlib_syscalls_default` uses `stdio_write` which in turn uses `uart_write` if module `stdio_uart` is used.

### Testing procedure

Change `examples/hello-world` as following:
```diff
--- a/examples/hello-world/main.c
+++ b/examples/hello-world/main.c
@@ -21,9 +21,12 @@
 
 #include <stdio.h>
 
+#include "fmt.h"
+
 int main(void)
 {
-    puts("Hello World!");
+    puts("Hello World via puts!");
+    print_str("Hello world via print_str!");
 
     printf("You are running RIOT on a(n) %s board.\n", RIOT_BOARD);
     printf("This board features a(n) %s MCU.\n", RIOT_MCU);
```

Compile and flash it with command
```
USEMODULE=fmt make BOARD=esp32-wroom-32 -C examples/hello-world flash term
```
and observe the output.
```
Starting RIOT kernel on PRO cpu
I (...) [main_trampoline]: main(): This is RIOT! (Version: ....)
Hello World via puts!
Hello World via print_str!
You are running RIOT on a(n) esp32-mh-et-live-minikit board.
```

### Issues/PRs references

Fixes issue #11354 