### PR TITLE
tests/xtimer_periodic_wakeup: allow for negative difference

### DIFF
--- a/tests/xtimer_periodic_wakeup/tests/01-run.py
+++ b/tests/xtimer_periodic_wakeup/tests/01-run.py
@@ -16,9 +16,9 @@ def testfunc(child):
     for i in range(256):
         child.expect(u"Testing interval \d+... \(now=\d+\)")
     for i in range(256):
-        child.expect(u" +\d+ diff=\d+")
+        child.expect(u" +\d+ diff=-?\d+")
 
-    child.expect(u"Min/max error: \d+/\d+")
+    child.expect(u"Min/max error: -?\d+/-?\d+")
     child.expect_exact("Test complete.")
 
 


### PR DESCRIPTION
### Contribution description

Some boards (e.g., Hifive1 with 32kHz xtimer), this test shows negative
offsets. As the test doesn't do any judgement on the values anyways,
change the pexpect script to allow for that.

### Testing procedure

Ensure that tests still run as expected.

### Issues/PRs references

#11041 