### PR TITLE
cpu/stm32: centralize PM_BLOCKER_INITIAL define

### DIFF
--- a/cpu/stm32f1/include/periph_cpu.h
+++ b/cpu/stm32f1/include/periph_cpu.h
@@ -62,12 +62,6 @@ extern "C" {
 #define PM_NUM_MODES        (2U)
 
 /**
- * @brief   Override the default initial PM blocker
- * @todo   we block all modes per default, until PM is cleanly implemented
- */
-#define PM_BLOCKER_INITIAL  { .val_u32 = 0x01010101 }
-
-/**
  * @brief  Define the config flag for stop mode
  */
 #define PM_STOP_CONFIG      (PWR_CR_LPDS)

--- a/cpu/stm32l0/include/periph_cpu.h
+++ b/cpu/stm32l0/include/periph_cpu.h
@@ -71,12 +71,6 @@ typedef struct {
 } adc_conf_t;
 
 /**
- * @brief   Override the default initial PM blocker
- * @todo   we block all modes per default, until PM is cleanly implemented
- */
-#define PM_BLOCKER_INITIAL  { .val_u32 = 0x01010101 }
-
-/**
  * @name    EEPROM configuration
  * @{
  */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR move the PM_BLOCKER_INITIAL macro definition of stm32f1/stm32l0 to a common stm32 place. This is because all STM32 families now support pm_layered.

The define is also overridable now: this is required when one wants to unlock by default a certain pm mode from its application Makefile (useful with LoRaWAN).

Another option is to completely remove the define from stm32l0 and stm32f1, since the default value in pm_layered is already the same. Maybe this would be the preferred solution ?

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

A green Murdock should be enough. One can also add `CFLAGS += '-DPM_BLOCKER_INITIAL={ .val_u32=0x01010100 }'` in any application and verify that it builds without error.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Required by #11237 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
