### PR TITLE
drivers/sx127x: optimize power consumption on nss pin

### DIFF
--- a/drivers/sx127x/sx127x.c
+++ b/drivers/sx127x/sx127x.c
@@ -345,6 +345,9 @@ static int _init_spi(sx127x_t *dev)
         return -1;
     }
 
+    /* Minimize power consumption of NSS pin */
+    gpio_init(dev->params.nss_pin, SX127X_DIO_PULL_MODE);
+
     DEBUG("[sx127x] SPI_%i initialized with success\n", dev->params.spi);
     return 0;
 }

--- a/drivers/sx127x/sx127x_internal.c
+++ b/drivers/sx127x/sx127x_internal.c
@@ -81,6 +81,9 @@ uint8_t sx127x_reg_read(const sx127x_t *dev, uint8_t addr)
 void sx127x_reg_write_burst(const sx127x_t *dev, uint8_t addr, uint8_t *buffer,
                             uint8_t size)
 {
+    /* Restore NSS pin working state */
+    gpio_init(dev->params.nss_pin, GPIO_OUT);
+
     spi_acquire(dev->params.spi, SPI_CS_UNDEF, SX127X_SPI_MODE, SX127X_SPI_SPEED);
 
     gpio_clear(dev->params.nss_pin);
@@ -88,11 +91,17 @@ void sx127x_reg_write_burst(const sx127x_t *dev, uint8_t addr, uint8_t *buffer,
     gpio_set(dev->params.nss_pin);
 
     spi_release(dev->params.spi);
+
+    /* Minimize power consumption of NSS pin */
+    gpio_init(dev->params.nss_pin, SX127X_DIO_PULL_MODE);
 }
 
 void sx127x_reg_read_burst(const sx127x_t *dev, uint8_t addr, uint8_t *buffer,
                            uint8_t size)
 {
+    /* Restore NSS pin working state */
+    gpio_init(dev->params.nss_pin, GPIO_OUT);
+
     spi_acquire(dev->params.spi, SPI_CS_UNDEF, SX127X_SPI_MODE, SX127X_SPI_SPEED);
 
     gpio_clear(dev->params.nss_pin);
@@ -100,6 +109,9 @@ void sx127x_reg_read_burst(const sx127x_t *dev, uint8_t addr, uint8_t *buffer,
     gpio_set(dev->params.nss_pin);
 
     spi_release(dev->params.spi);
+
+    /* Minimize power consumption of NSS pin */
+    gpio_init(dev->params.nss_pin, SX127X_DIO_PULL_MODE);
 }
 
 void sx127x_write_fifo(const sx127x_t *dev, uint8_t *buffer, uint8_t size)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

With this PR the power consumption drops from 6mA to 40uA when a stm32l0 CPU is sleeping.
I'm not sure it's the best fix and perhaps there's still for improving power consumption.

cc @fjmolinas who might be interested.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- LoRaWAN application should still work
- Measure power consumption when running the `examples/lorawan` application (you might need to test this with #11237). I used a Nucleo-l073rz + an mbed lora shield + an [x-nucleo-lpm01a](https://www.st.com/en/evaluation-tools/x-nucleo-lpm01a.html) shield.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Required by #11237

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
