### PR TITLE
nanocoap: Support adding opaque (blob / buffer) data

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -463,7 +463,7 @@ void coap_pkt_init(coap_pkt_t *pkt, uint8_t *buf, size_t len, size_t header_len)
  *
  * @returns     amount of bytes written to @p buf
  */
-size_t coap_put_option(uint8_t *buf, uint16_t lastonum, uint16_t onum, uint8_t *odata, size_t olen);
+size_t coap_put_option(uint8_t *buf, uint16_t lastonum, uint16_t onum, const uint8_t *odata, size_t olen);
 
 /**
  * @brief   Insert content type option into buffer

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -657,6 +657,23 @@ size_t coap_put_block1_ok(uint8_t *pkt_pos, coap_block1_t *block1, uint16_t last
 ssize_t coap_opt_add_string(coap_pkt_t *pkt, uint16_t optnum, const char *string, char separator);
 
 /**
+ * @brief   Encode the given buffer as an opaque data option into pkt
+ *
+ * @post pkt.payload advanced to first byte after option(s)
+ * @post pkt.payload_len reduced by option(s) length
+ *
+ * @param[in,out] pkt         pkt referencing target buffer
+ * @param[in]     optnum      option number to use
+ * @param[in]     val         pointer to the value to be set
+ * @param[in]     val_len     length of val
+ *
+ * @return        number of bytes written to buffer
+ * @return        <0 on error
+ * @return        -ENOSPC if no available options
+ */
+ssize_t coap_opt_add_opaque(coap_pkt_t *pkt, uint16_t optnum, const uint8_t *val, size_t val_len);
+
+/**
  * @brief   Encode the given uint option into pkt
  *
  * @post pkt.payload advanced to first byte after option

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -566,7 +566,7 @@ static unsigned _put_delta_optlen(uint8_t *buf, unsigned offset, unsigned shift,
     return offset;
 }
 
-size_t coap_put_option(uint8_t *buf, uint16_t lastonum, uint16_t onum, uint8_t *odata, size_t olen)
+size_t coap_put_option(uint8_t *buf, uint16_t lastonum, uint16_t onum, const uint8_t *odata, size_t olen)
 {
     assert(lastonum <= onum);
 
@@ -728,7 +728,7 @@ size_t coap_opt_put_string(uint8_t *buf, uint16_t lastonum, uint16_t optnum,
 }
 
 /* Common functionality for addition of an option */
-static ssize_t _add_opt_pkt(coap_pkt_t *pkt, uint16_t optnum, uint8_t *val,
+static ssize_t _add_opt_pkt(coap_pkt_t *pkt, uint16_t optnum, const uint8_t *val,
                             size_t val_len)
 {
     if (pkt->options_len >= NANOCOAP_NOPTS_MAX) {
@@ -802,7 +802,7 @@ ssize_t coap_opt_add_string(coap_pkt_t *pkt, uint16_t optnum, const char *string
     return write_len;
 }
 
-ssize_t coap_opt_add_opaque(coap_pkt_t *pkt, uint16_t optnum, uint8_t *val, size_t val_len)
+ssize_t coap_opt_add_opaque(coap_pkt_t *pkt, uint16_t optnum, const uint8_t *val, size_t val_len)
 {
     return _add_opt_pkt(pkt, optnum, val, val_len);
 }

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -802,6 +802,11 @@ ssize_t coap_opt_add_string(coap_pkt_t *pkt, uint16_t optnum, const char *string
     return write_len;
 }
 
+ssize_t coap_opt_add_opaque(coap_pkt_t *pkt, uint16_t optnum, uint8_t *val, size_t val_len)
+{
+    return _add_opt_pkt(pkt, optnum, val, val_len);
+}
+
 ssize_t coap_opt_add_uint(coap_pkt_t *pkt, uint16_t optnum, uint32_t value)
 {
     uint32_t tmp = value;


### PR DESCRIPTION
### Contribution description

This adds a `coap_opt_add_opaque(...)` function that adds binary data from a buffer as an option. The name stems from the RFC7252 name for such options.

The ETag options (ETag, If-Match) are options of that form, and having a generic way of adding options also helps porting more high-level CoAP libraries to nanocoap / Gcoap. (My current use case involves using Rust CoAP abstractions on a gcoap handled server).

A follow-up commit adds const qualifiers to input data of the function itself, its internal helper (which does not modify the data in its original location) and the public `coap_put_option` low-level function used by it (which does neither). The behavior of the functions, both in implementation and semantically, is already const, the declarations were just missing; adding them makes using it easier with const-heavy code.

### Testing procedure

None of the examples use the method, but the gcoap example can easily be made to, by adding in _riot_board_handler before (!) coap_opt_add_format:

```patch
     gcoap_resp_init(pdu, buf, len, COAP_CODE_CONTENT);
+    coap_opt_add_opaque(pdu, 4, (uint8_t*)"etag", 4);
     coap_opt_add_format(pdu, COAP_FORMAT_TEXT);
```

Then, a query to the riot/board resource can be verified using Wireshark to contain a 4-byte ETag option. (Tested using the native board).

### Issues/PRs references

This was not reported as a dedicated issue as it's probably small enough to handle in a PR right away.