### PR TITLE
tests/periph_rtt: Correct the test script syntax

### DIFF
--- a/tests/periph_rtt/tests/01-run.py
+++ b/tests/periph_rtt/tests/01-run.py
@@ -17,7 +17,7 @@ MAX_HELLOS = 5
 
 def testfunc(child):
     child.expect(r'This test will display \'Hello\' every (\d+) seconds')
-    period = int(child.match[1])
+    period = int(child.match.group(1))
     child.expect_exact('Initializing the RTT driver')
     child.expect(r'RTT now: \d+')
     child.expect(r'Setting initial alarm to now \+ {} s \(\d+\)'


### PR DESCRIPTION
Previously the test was failing due to apparently incorrect Python syntax in
the testrunner script. This fix corrects this and the test now passes.

### Testing procedure

`BOARD=[boardname] make flash test`
