### PR TITLE
Tests/pkg_fatfs_vfs: make test fail correctly for samr21-xpro

### DIFF
--- a/drivers/sdcard_spi/include/sdcard_spi_internal.h
+++ b/drivers/sdcard_spi/include/sdcard_spi_internal.h
@@ -132,9 +132,9 @@ extern "C" {
 #define SD_DATA_TOKEN_RETRY_CNT    1000000
 #define INIT_CMD_RETRY_CNT         1000000
 #define INIT_CMD0_RETRY_CNT        3
-#define SD_WAIT_FOR_NOT_BUSY_CNT   1000000 /* use -1 for full blocking till the card isn't busy */
-#define SD_BLOCK_READ_CMD_RETRIES  10     /* only affects sending of cmd not whole transaction! */
-#define SD_BLOCK_WRITE_CMD_RETRIES 10    /* only affects sending of cmd not whole transaction! */
+#define SD_WAIT_FOR_NOT_BUSY_CNT   2000    /* use -1 for full blocking till the card isn't busy */
+#define SD_BLOCK_READ_CMD_RETRIES  10      /* only affects sending of cmd not whole transaction! */
+#define SD_BLOCK_WRITE_CMD_RETRIES 10      /* only affects sending of cmd not whole transaction! */
 
 /* memory capacity in bytes = (C_SIZE+1) * SD_CSD_V2_C_SIZE_BLOCK_MULT * BLOCK_LEN */
 #define SD_CSD_V2_C_SIZE_BLOCK_MULT 1024

--- a/tests/pkg_fatfs_vfs/tests/01-run.py
+++ b/tests/pkg_fatfs_vfs/tests/01-run.py
@@ -9,26 +9,15 @@
 import sys
 from testrunner import run
 
-
-class TestFailed(Exception):
-    pass
-
-
 def testfunc(child):
 
     child.expect(u"Tests for FatFs over VFS - test results will be printed in "
                  "the format test_name:result\r\n")
 
-    while True:
-        res = child.expect([u"[^\n]*:\[OK\]\r\n",
-                            u"Test end.\r\n",
-                            u".[^\n]*:\[FAILED\]\r\n",
-                            u".*\r\n"])
-        if res > 1:
-            raise TestFailed(child.after.split(':', 1)[0] + " test failed!")
-        elif res == 1:
-            break
-
+    child.expect([u"[^\n]*:\[OK\]\r\n",
+                  u"Test end.\r\n",
+                  u".[^\n]*:\[FAILED\]\r\n",
+                  u".*\r\n"])
 
 if __name__ == "__main__":
     sys.exit(run(testfunc))


### PR DESCRIPTION
### Contribution description

The tests/pkg_fatfs_vfs previously hung, rather than failing, which it should do if there's no SD card present.

The reason for the hanging was that the timeouts in the sdcard_spi module were very long. Once this was reduced, the test script would fail, but by throwing an exception rather than running fully and giving an error code. This is different from the behaviour of other tests and IMO not the best way to do it: an exception should really indicate a failure/error of the test script, not the program under test.

### Testing procedure

`make test` with a SAMR21-xpro.