### PR TITLE
drivers: add licence to motor_driver source files

### DIFF
--- a/drivers/motor_driver/motor_driver.c
+++ b/drivers/motor_driver/motor_driver.c
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) 2018 Gilles DOFFE <g.doffe@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_motor
+ * @{
+ *
+ * @file
+ * @brief       High-level driver for DC motors
+ *
+ * @author      Gilles DOFFE <g.doffe@gmail.com>
+ * @}
+ */
+
 #include <errno.h>
 
 /* RIOT includes */

--- a/tests/driver_motor_driver/main.c
+++ b/tests/driver_motor_driver/main.c
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) 2018 Gilles DOFFE <g.doffe@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       High-level driver for DC motors test application
+ *
+ * @author      Gilles DOFFE <g.doffe@gmail.com>
+ * @}
+ */
+
 #include <stdio.h>
 #include <string.h>
 


### PR DESCRIPTION
Related to PR #10290, add missing licence to some source files.

@kaspar030 