### PR TITLE
cpu/nrf5x/nrfmin: fix isr termination

### DIFF
--- a/cpu/nrf5x_common/radio/nrfmin/nrfmin.c
+++ b/cpu/nrf5x_common/radio/nrfmin/nrfmin.c
@@ -302,10 +302,11 @@ void isr_radio(void)
             if ((NRF_RADIO->CRCSTATUS != 1) || !(nrfmin_dev.event_callback)) {
                 rx_buf.pkt.hdr.len = 0;
                 NRF_RADIO->TASKS_START = 1;
-                return;
             }
-            rx_lock = 0;
-            nrfmin_dev.event_callback(&nrfmin_dev, NETDEV_EVENT_ISR);
+            else {
+                rx_lock = 0;
+                nrfmin_dev.event_callback(&nrfmin_dev, NETDEV_EVENT_ISR);
+            }
         }
         else if (state == STATE_TX) {
             goto_target_state();


### PR DESCRIPTION
### Contribution description

The nrfmin driver had a serious bug terminating the interrupt handler in case of an invalid CRC value.
Instead of closing with `cortexm_isr_end();` it just returned, which resulted in unwanted behaviour.

This PR fixes one error mentioned in #10878 and is based on the solution of @pystub

### Testing procedure

Testing should at least involve receiving and then sending packets with a valid CRC. However, it is appreciated if a reviewer makes sure that the behaviour is also correct with invalid CRC.

Make sure to test it using nrfmin with `USEMODULE=nrfmin` on nrf5x boards.