### PR TITLE
SAUL: Extract name from saul_gpio_params

### DIFF
--- a/boards/acd52832/include/gpio_params.h
+++ b/boards/acd52832/include/gpio_params.h
@@ -22,6 +22,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -33,19 +34,25 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LED 1",
         .pin = LED0_PIN,
         .mode = GPIO_OUT,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
     },
-        {
-        .name = "Button 1",
+    {
         .pin  = BTN0_PIN,
         .mode = BTN0_MODE,
         .flags = SAUL_GPIO_INVERTED,
     }
 };
 
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LED 1" },
+    { .name = "Button 1" }
+};
 
 #ifdef __cplusplus
 }

--- a/boards/arduino-zero/include/gpio_params.h
+++ b/boards/arduino-zero/include/gpio_params.h
@@ -23,6 +23,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -34,10 +35,17 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LED(orange)",
         .pin = LED0_PIN,
         .mode = GPIO_OUT
     },
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LED(orange)" }
 };
 
 #ifdef __cplusplus

--- a/boards/b-l072z-lrwan1/include/gpio_params.h
+++ b/boards/b-l072z-lrwan1/include/gpio_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -33,31 +34,40 @@ static const  saul_gpio_params_t saul_gpio_params[] =
 {
 #ifdef AUTO_INIT_LED0
     {
-        .name = "LD2(red)",
         .pin = LED0_PIN,
         .mode = GPIO_OUT
     },
 #endif
     {
-        .name = "LD1(green)",
         .pin = LED1_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "LD3(blue)",
         .pin = LED2_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "LD4(red)",
         .pin = LED3_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "Button(B1 User)",
         .pin = BTN_B1_PIN,
         .mode = GPIO_IN_PU
     },
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+#ifdef AUTO_INIT_LED0
+    { .name = "LD2(red)" },
+#endif
+    { .name = "LD1(green)" },
+    { .name = "LD3(blue)" },
+    { .name = "LD4(red)" },
+    { .name = "Button(B1 User)" }
 };
 
 #ifdef __cplusplus

--- a/boards/b-l475e-iot01a/include/gpio_params.h
+++ b/boards/b-l475e-iot01a/include/gpio_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -35,22 +36,31 @@ static const  saul_gpio_params_t saul_gpio_params[] =
     /* The LED pin is also used for SPI, so we enable it
        only if explicitly wanted by the user */
     {
-        .name = "LD1",
         .pin = LED0_PIN,
         .mode = GPIO_OUT
     },
 #endif
     {
-        .name = "LD2",
         .pin = LED1_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "Button(B1 User)",
         .pin = BTN_B1_PIN,
         .mode = GPIO_IN_PU,
         .flags = SAUL_GPIO_INVERTED
     }
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+#ifdef AUTO_INIT_LED0
+    { .name = "LD1" },
+#endif
+    { .name = "LD2" },
+    { .name = "Button(B1 User)" }
 };
 
 #ifdef __cplusplus

--- a/boards/blackpill/include/gpio_params.h
+++ b/boards/blackpill/include/gpio_params.h
@@ -23,6 +23,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -34,11 +35,18 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LED",
         .pin = LED0_PIN,
         .mode = GPIO_OUT,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR)
     },
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LED" }
 };
 
 #ifdef __cplusplus

--- a/boards/bluepill/include/gpio_params.h
+++ b/boards/bluepill/include/gpio_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,11 +33,18 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LED",
         .pin = LED0_PIN,
         .mode = GPIO_OUT,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR)
     },
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LED" }
 };
 
 #ifdef __cplusplus

--- a/boards/calliope-mini/include/gpio_params.h
+++ b/boards/calliope-mini/include/gpio_params.h
@@ -22,6 +22,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -33,17 +34,24 @@ extern "C" {
 static const saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name  = "Button A",
         .pin   = BTN0_PIN,
         .mode  = BTN0_MODE,
         .flags = SAUL_GPIO_INVERTED,
     },
     {
-        .name  = "Button B",
         .pin   = BTN1_PIN,
         .mode  = BTN1_MODE,
         .flags = SAUL_GPIO_INVERTED,
     },
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "Button A" },
+    { .name = "Button B" }
 };
 
 #ifdef __cplusplus

--- a/boards/cc2650stk/include/gpio_params.h
+++ b/boards/cc2650stk/include/gpio_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,25 +33,32 @@ extern "C" {
 static const saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LED(red)",
         .pin  = LED0_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "LED(green)",
         .pin  = LED1_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "Button A",
         .pin  = BTN0_PIN,
         .mode = BTN0_MODE
     },
     {
-        .name = "Button B",
         .pin  = BTN1_PIN,
         .mode = BTN1_MODE
     },
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LED(red)" },
+    { .name = "LED(green)" },
+    { .name = "Button A" },
+    { .name = "Button B" }
 };
 
 #ifdef __cplusplus

--- a/boards/common/arduino-atmega/include/gpio_params.h
+++ b/boards/common/arduino-atmega/include/gpio_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,10 +33,17 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LED",
         .pin = LED0_PIN,
         .mode = GPIO_OUT
     }
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LED" }
 };
 
 #ifdef __cplusplus

--- a/boards/common/arduino-due/include/gpio_params.h
+++ b/boards/common/arduino-due/include/gpio_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,10 +33,17 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LED",
         .pin = LED0_PIN,
         .mode = GPIO_OUT
     }
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LED" }
 };
 
 #ifdef __cplusplus

--- a/boards/common/arduino-mkr/include/gpio_params.h
+++ b/boards/common/arduino-mkr/include/gpio_params.h
@@ -23,6 +23,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -34,10 +35,17 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LED(Green)",
         .pin = LED0_PIN,
         .mode = GPIO_OUT
     },
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LED(Green)" }
 };
 
 #ifdef __cplusplus

--- a/boards/common/iotlab/include/gpio_params.h
+++ b/boards/common/iotlab/include/gpio_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,23 +33,30 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LED(red)",
         .pin = LED0_PIN,
         .mode = GPIO_OUT,
         .flags = SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR,
     },
     {
-        .name = "LED(green)",
         .pin = LED1_PIN,
         .mode = GPIO_OUT,
         .flags = SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR,
     },
     {
-        .name = "LED(orange)",
         .pin = LED2_PIN,
         .mode = GPIO_OUT,
         .flags = SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR,
     },
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LED(red)" },
+    { .name = "LED(green)" },
+    { .name = "LED(orange)" }
 };
 
 #ifdef __cplusplus

--- a/boards/common/nrf52xxxdk/include/gpio_params.h
+++ b/boards/common/nrf52xxxdk/include/gpio_params.h
@@ -22,6 +22,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -33,14 +34,12 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name  = "LED 1",
         .pin   = LED0_PIN,
         .mode  = GPIO_OUT,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
     },
 #ifdef LED1_PIN
     {
-        .name  = "LED 2",
         .pin   = LED1_PIN,
         .mode  = GPIO_OUT,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
@@ -48,7 +47,6 @@ static const  saul_gpio_params_t saul_gpio_params[] =
 #endif
 #ifdef LED2_PIN
     {
-        .name  = "LED 3",
         .pin   = LED2_PIN,
         .mode  = GPIO_OUT,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
@@ -56,7 +54,6 @@ static const  saul_gpio_params_t saul_gpio_params[] =
 #endif
 #ifdef LED3_PIN
     {
-        .name  = "LED 4",
         .pin   = LED3_PIN,
         .mode  = GPIO_OUT,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
@@ -64,7 +61,6 @@ static const  saul_gpio_params_t saul_gpio_params[] =
 #endif
 #ifdef BTN0_PIN
     {
-        .name  = "Button 1",
         .pin   = BTN0_PIN,
         .mode  = BTN0_MODE,
         .flags = SAUL_GPIO_INVERTED,
@@ -72,7 +68,6 @@ static const  saul_gpio_params_t saul_gpio_params[] =
 #endif
 #ifdef BTN1_PIN
     {
-        .name  = "Button 2",
         .pin   = BTN1_PIN,
         .mode  = BTN1_MODE,
         .flags = SAUL_GPIO_INVERTED,
@@ -80,7 +75,6 @@ static const  saul_gpio_params_t saul_gpio_params[] =
 #endif
 #ifdef BTN2_PIN
     {
-        .name  = "Button 3",
         .pin   = BTN2_PIN,
         .mode  = BTN2_MODE,
         .flags = SAUL_GPIO_INVERTED,
@@ -88,7 +82,6 @@ static const  saul_gpio_params_t saul_gpio_params[] =
 #endif
 #ifdef BTN3_PIN
     {
-        .name  = "Button 4",
         .pin   = BTN3_PIN,
         .mode  = BTN3_MODE,
         .flags = SAUL_GPIO_INVERTED,
@@ -96,6 +89,34 @@ static const  saul_gpio_params_t saul_gpio_params[] =
 #endif
 };
 
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LED 1" },
+#ifdef LED1_PIN
+    { .name = "LED 2" },
+#endif
+#ifdef LED2_PIN
+    { .name = "LED 3" },
+#endif
+#ifdef LED3_PIN
+    { .name = "LED 4" },
+#endif
+#ifdef BTN0_PIN
+    { .name = "Button 1" },
+#endif
+#ifdef BTN1_PIN
+    { .name = "Button 2" },
+#endif
+#ifdef BTN2_PIN
+    { .name = "Button 3" },
+#endif
+#ifdef BTN3_PIN
+    { .name = "Button 4" },
+#endif
+};
 
 #ifdef __cplusplus
 }

--- a/boards/common/nucleo144/include/gpio_params.h
+++ b/boards/common/nucleo144/include/gpio_params.h
@@ -22,6 +22,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -33,25 +34,32 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LD1(green)",
         .pin = LED0_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "LD2(blue)",
         .pin = LED1_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "LD3(red)",
         .pin = LED2_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "B1(User button)",
         .pin  = BTN0_PIN,
         .mode = BTN0_MODE
     }
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LD1(green)" },
+    { .name = "LD2(blue)" },
+    { .name = "LD3(red)" },
+    { .name = "B1(User button)" }
 };
 
 #ifdef __cplusplus

--- a/boards/common/nucleo32/include/gpio_params.h
+++ b/boards/common/nucleo32/include/gpio_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -28,6 +29,7 @@ extern "C" {
 
 #ifndef AUTO_INIT_LED0
 #define SAUL_GPIO_NUMOF (0U)
+#define SAUL_GPIO_INFO_NUMOF (0U)
 #else
 /**
  * @brief    GPIO pin configuration
@@ -35,10 +37,17 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LD3(green)",
         .pin = LED0_PIN,
         .mode = GPIO_OUT
     }
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LD3(green)" }
 };
 #endif /* AUTO_INIT_LED0 */
 

--- a/boards/common/nucleo64/include/gpio_params.h
+++ b/boards/common/nucleo64/include/gpio_params.h
@@ -22,6 +22,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -34,19 +35,28 @@ static const  saul_gpio_params_t saul_gpio_params[] =
 {
 #ifdef AUTO_INIT_LED0
     {
-        .name = "LED(green)",
         .pin = LED0_PIN,
         .mode = GPIO_OUT
     },
 #endif
     {
-        .name = "Button(B1 User)",
         .pin  = BTN0_PIN,
         .mode = BTN0_MODE,
 #ifndef CPU_MODEL_STM32L433RC
         .flags = SAUL_GPIO_INVERTED
 #endif
     },
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+#ifdef AUTO_INIT_LED0
+    { .name = "LED(green)" },
+#endif
+    { .name = "Button(B1 User)" }
 };
 
 #ifdef __cplusplus

--- a/boards/common/saml1x/include/gpio_params.h
+++ b/boards/common/saml1x/include/gpio_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,17 +33,24 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LED(orange)",
         .pin = LED0_PIN,
         .mode = GPIO_OUT,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR)
     },
     {
-        .name = "Button(SW0)",
         .pin  = BTN0_PIN,
         .mode = BTN0_MODE,
         .flags = SAUL_GPIO_INVERTED
     },
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LED(orange)" },
+    { .name = "Button(SW0)" }
 };
 
 #ifdef __cplusplus

--- a/boards/esp32-mh-et-live-minikit/include/gpio_params.h
+++ b/boards/esp32-mh-et-live-minikit/include/gpio_params.h
@@ -19,6 +19,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -30,11 +31,18 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LED",
         .pin = LED0_PIN,
         .mode = GPIO_OUT,
         .flags = SAUL_GPIO_INIT_CLEAR
     }
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LED" }
 };
 
 #ifdef __cplusplus

--- a/boards/esp32-olimex-evb/include/gpio_params.h
+++ b/boards/esp32-olimex-evb/include/gpio_params.h
@@ -19,6 +19,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -31,18 +32,27 @@ static const  saul_gpio_params_t saul_gpio_params[] =
 {
     #if MODULE_OLIMEX_ESP32_GATEWAY
     {
-        .name = "LED",
         .pin = LED0_PIN,
         .mode = GPIO_OUT,
         .flags = SAUL_GPIO_INIT_CLEAR
     },
     #endif
     {
-        .name = "BUT1",
         .pin = BUTTON0_PIN,
         .mode = GPIO_IN,
         .flags = SAUL_GPIO_INVERTED
     },
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+#if MODULE_OLIMEX_ESP32_GATEWAY
+    { .name = "LED" },
+#endif
+    { .name = "BUT1" }
 };
 
 #ifdef __cplusplus

--- a/boards/esp32-wemos-lolin-d32-pro/include/gpio_params.h
+++ b/boards/esp32-wemos-lolin-d32-pro/include/gpio_params.h
@@ -19,6 +19,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -30,11 +31,18 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LED",
         .pin = LED0_PIN,
         .mode = GPIO_OUT,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR)
     }
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LED" }
 };
 
 #ifdef __cplusplus

--- a/boards/esp32-wroom-32/include/gpio_params.h
+++ b/boards/esp32-wroom-32/include/gpio_params.h
@@ -19,6 +19,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -30,11 +31,18 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "BOOT",
         .pin = BUTTON0_PIN,
         .mode = GPIO_IN,
         .flags = SAUL_GPIO_INVERTED
     },
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "BOOT" }
 };
 
 #ifdef __cplusplus

--- a/boards/esp32-wrover-kit/include/gpio_params.h
+++ b/boards/esp32-wrover-kit/include/gpio_params.h
@@ -19,6 +19,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -31,7 +32,6 @@ static const  saul_gpio_params_t saul_gpio_params[] =
 {
 #ifdef LED0_PIN
     {
-        .name = "LED red",
         .pin = LED0_PIN,
         .mode = GPIO_OUT,
         .flags = SAUL_GPIO_INIT_CLEAR
@@ -39,7 +39,6 @@ static const  saul_gpio_params_t saul_gpio_params[] =
 #endif
 #ifdef LED1_PIN
     {
-        .name = "LED blue",
         .pin = LED1_PIN,
         .mode = GPIO_OUT,
         .flags = SAUL_GPIO_INIT_CLEAR
@@ -47,11 +46,26 @@ static const  saul_gpio_params_t saul_gpio_params[] =
 #endif
 #ifdef LED2_PIN
     {
-        .name = "LED green",
         .pin = LED2_PIN,
         .mode = GPIO_OUT,
         .flags = SAUL_GPIO_INIT_CLEAR
     }
+#endif
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+#ifdef LED0_PIN
+    { .name = "LED red" },
+#endif
+#ifdef LED1_PIN
+    { .name = "LED blue" },
+#endif
+#ifdef LED2_PIN
+    { .name = "LED green" },
 #endif
 };
 

--- a/boards/esp8266-esp-12x/include/gpio_params.h
+++ b/boards/esp8266-esp-12x/include/gpio_params.h
@@ -19,6 +19,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -30,11 +31,18 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LED",
         .pin = LED0_PIN,
         .mode = GPIO_OUT,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR)
     }
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LED" }
 };
 
 #ifdef __cplusplus

--- a/boards/esp8266-olimex-mod/include/gpio_params.h
+++ b/boards/esp8266-olimex-mod/include/gpio_params.h
@@ -19,6 +19,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -30,11 +31,18 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LED",
         .pin = LED0_PIN,
         .mode = GPIO_OUT,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR)
     }
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LED" }
 };
 
 #ifdef __cplusplus

--- a/boards/esp8266-sparkfun-thing/include/gpio_params.h
+++ b/boards/esp8266-sparkfun-thing/include/gpio_params.h
@@ -19,6 +19,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -30,11 +31,18 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LED",
         .pin = LED0_PIN,
         .mode = GPIO_OUT,
         .flags = SAUL_GPIO_INIT_CLEAR
     }
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LED" }
 };
 
 #ifdef __cplusplus

--- a/boards/feather-m0/include/gpio_params.h
+++ b/boards/feather-m0/include/gpio_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,10 +33,17 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LED(Red)",
         .pin = LED0_PIN,
         .mode = GPIO_OUT
     },
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LED(Red)" },
 };
 
 #ifdef __cplusplus

--- a/boards/firefly/include/gpio_params.h
+++ b/boards/firefly/include/gpio_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,25 +33,32 @@ extern "C" {
 static const saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LED(red)",
         .pin = LED0_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "LED(green)",
         .pin = LED1_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "LED(blue)",
         .pin = LED2_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "Button(User)",
         .pin = BTN0_PIN,
         .mode = BTN0_MODE
     },
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LED(red)" },
+    { .name = "LED(green)" },
+    { .name = "LED(blue)" },
+    { .name = "Button(User)" }
 };
 
 #ifdef __cplusplus

--- a/boards/frdm-k22f/include/gpio_params.h
+++ b/boards/frdm-k22f/include/gpio_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,20 +33,27 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LED(red)",
         .pin = LED0_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "LED(green)",
         .pin = LED1_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "LED(blue)",
         .pin = LED2_PIN,
         .mode = GPIO_OUT
     },
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LED(red)" },
+    { .name = "LED(green)" },
+    { .name = "LED(blue)" }
 };
 
 #ifdef __cplusplus

--- a/boards/frdm-kw41z/include/gpio_params.h
+++ b/boards/frdm-kw41z/include/gpio_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -37,41 +38,48 @@ static const  saul_gpio_params_t saul_gpio_params[] =
     /* LED1 and LED2 on the board are wired to the target CPU reset pin, and the
      * power supply line and are not software controllable */
     {
-        .name = "LED3",
         .pin = LED0_PIN,
         .mode = GPIO_OUT,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
     },
     {
-        .name = "LED4_R",
         .pin = LED1_PIN,
         .mode = GPIO_OUT,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
     },
     {
-        .name = "LED4_G",
         .pin = LED2_PIN,
         .mode = GPIO_OUT,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
     },
     {
-        .name = "LED4_B",
         .pin = LED3_PIN,
         .mode = GPIO_OUT,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
     },
     {
-        .name = "SW3",
         .pin = BTN0_PIN,
         .mode = BTN0_MODE,
         .flags = (SAUL_GPIO_INVERTED),
     },
     {
-        .name = "SW4",
         .pin = BTN1_PIN,
         .mode = BTN1_MODE,
         .flags = (SAUL_GPIO_INVERTED),
     },
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LED3" },
+    { .name = "LED4_R" },
+    { .name = "LED4_G" },
+    { .name = "LED4_B" },
+    { .name = "SW3" },
+    { .name = "SW4" }
 };
 
 #ifdef __cplusplus

--- a/boards/hamilton/include/gpio_params.h
+++ b/boards/hamilton/include/gpio_params.h
@@ -26,6 +26,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -37,17 +38,24 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LED(red)",
         .pin = LED0_PIN,
         .mode = GPIO_OUT,
         .flags = SAUL_GPIO_INVERTED,
     },
     {
-        .name = "Button",
         .pin  = BTN0_PIN,
         .mode = BTN0_MODE,
         .flags = SAUL_GPIO_INVERTED,
     },
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LED(red)" },
+    { .name = "Button" }
 };
 
 #ifdef __cplusplus

--- a/boards/ikea-tradfri/include/gpio_params.h
+++ b/boards/ikea-tradfri/include/gpio_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,15 +33,22 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LED 0",
         .pin = LED0_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "LED 1",
         .pin = LED1_PIN,
         .mode = GPIO_OUT
     }
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LED 0" },
+    { .name = "LED 1" }
 };
 
 #ifdef __cplusplus

--- a/boards/lobaro-lorabox/include/gpio_params.h
+++ b/boards/lobaro-lorabox/include/gpio_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,10 +33,17 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LED(green)",
         .pin = LED0_PIN,
         .mode = GPIO_OUT
     }
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LED(green)" }
 };
 
 #ifdef __cplusplus

--- a/boards/maple-mini/include/gpio_params.h
+++ b/boards/maple-mini/include/gpio_params.h
@@ -22,6 +22,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -33,15 +34,22 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LED",
         .pin = LED0_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "BUTTON",
         .pin  = BTN0_PIN,
         .mode = BTN0_MODE
     }
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LED" },
+    { .name = "BUTTON" }
 };
 
 #ifdef __cplusplus

--- a/boards/mbed_lpc1768/include/gpio_params.h
+++ b/boards/mbed_lpc1768/include/gpio_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,25 +33,32 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LED 0",
         .pin = LED0_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "LED 1",
         .pin = LED1_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "LED 2",
         .pin = LED2_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "LED 3",
         .pin = LED3_PIN,
         .mode = GPIO_OUT
     }
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LED 0" },
+    { .name = "LED 1" },
+    { .name = "LED 2" },
+    { .name = "LED 3" }
 };
 
 #ifdef __cplusplus

--- a/boards/mega-xplained/include/gpio_params.h
+++ b/boards/mega-xplained/include/gpio_params.h
@@ -23,6 +23,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -34,30 +35,37 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "Button 0",
         .pin  = BTN0_PIN,
         .mode = BTN0_MODE,
         .flags = SAUL_GPIO_INVERTED,
     },
     {
-        .name = "Button 1",
         .pin  = BTN1_PIN,
         .mode = BTN1_MODE,
         .flags = SAUL_GPIO_INVERTED,
     },
     /* BTN2, LED0,2 currently unsupported due to lack of GPIO_OD support */
     {
-        .name = "LED 1",
         .pin = LED1_PIN,
         .mode = LED1_MODE,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
     },
     {
-        .name = "LED 3",
         .pin = LED3_PIN,
         .mode = LED3_MODE,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
     }
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "Button 0" },
+    { .name = "Button 1" },
+    { .name = "LED 1" },
+    { .name = "LED 3" }
 };
 
 #ifdef __cplusplus

--- a/boards/microbit/include/gpio_params.h
+++ b/boards/microbit/include/gpio_params.h
@@ -22,6 +22,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -33,17 +34,24 @@ extern "C" {
 static const saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "Button A",
         .pin  = BTN0_PIN,
         .mode = BTN0_MODE,
         .flags = SAUL_GPIO_INVERTED,
     },
     {
-        .name = "Button B",
         .pin  = BTN1_PIN,
         .mode = BTN1_MODE,
         .flags = SAUL_GPIO_INVERTED,
     },
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "Button A" },
+    { .name = "Button B" }
 };
 
 #ifdef __cplusplus

--- a/boards/msbiot/include/gpio_params.h
+++ b/boards/msbiot/include/gpio_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,35 +33,42 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "red LED",
         .pin = LED0_PIN,
         .mode = GPIO_OUT,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR)
     },
     {
-        .name = "yellow LED",
         .pin = LED1_PIN,
         .mode = GPIO_OUT,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR)
     },
     {
-        .name = "green LED",
         .pin = LED2_PIN,
         .mode = GPIO_OUT,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR)
     },
     {
-        .name = "left button",
         .pin = BUTTON0_PIN,
         .mode = GPIO_IN,
         .flags = 0
     },
     {
-        .name = "right button",
         .pin = BUTTON1_PIN,
         .mode = GPIO_IN,
         .flags = 0
     },
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "red LED" },
+    { .name = "yellow LED" },
+    { .name = "green LED" },
+    { .name = "left button" },
+    { .name = "right button" }
 };
 
 #ifdef __cplusplus

--- a/boards/mulle/include/gpio_params.h
+++ b/boards/mulle/include/gpio_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,20 +33,27 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LED(red)",
         .pin = LED0_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "LED(yellow)",
         .pin = LED1_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "LED(green)",
         .pin = LED2_PIN,
         .mode = GPIO_OUT
     },
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LED(red)" },
+    { .name = "LED(yellow)" },
+    { .name = "LED(green)" }
 };
 
 #ifdef __cplusplus

--- a/boards/nrf51dk/include/gpio_params.h
+++ b/boards/nrf51dk/include/gpio_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,53 +33,60 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name  = "LED 1",
         .pin   = LED0_PIN,
         .mode  = GPIO_OUT,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
     },
     {
-        .name  = "LED 2",
         .pin   = LED1_PIN,
         .mode  = GPIO_OUT,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
     },
     {
-        .name  = "LED 3",
         .pin   = LED2_PIN,
         .mode  = GPIO_OUT,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
     },
     {
-        .name  = "LED 4",
         .pin   = LED3_PIN,
         .mode  = GPIO_OUT,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
     },
     {
-        .name  = "Button 1",
         .pin   = BTN0_PIN,
         .mode  = BTN0_MODE,
         .flags = SAUL_GPIO_INVERTED,
     },
     {
-        .name  = "Button 2",
         .pin   = BTN1_PIN,
         .mode  = BTN1_MODE,
         .flags = SAUL_GPIO_INVERTED,
     },
     {
-        .name  = "Button 3",
         .pin   = BTN2_PIN,
         .mode  = BTN2_MODE,
         .flags = SAUL_GPIO_INVERTED,
     },
     {
-        .name  = "Button 4",
         .pin   = BTN3_PIN,
         .mode  = BTN3_MODE,
         .flags = SAUL_GPIO_INVERTED,
     },
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LED 1" },
+    { .name = "LED 2" },
+    { .name = "LED 3" },
+    { .name = "LED 4" },
+    { .name = "Button 1" },
+    { .name = "Button 2" },
+    { .name = "Button 3" },
+    { .name = "Button 4" }
 };
 
 #ifdef __cplusplus

--- a/boards/nrf52832-mdk/include/gpio_params.h
+++ b/boards/nrf52832-mdk/include/gpio_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,25 +33,31 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name  = "Led Red",
         .pin   = LED0_PIN,
         .mode  = GPIO_OUT,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
     },
     {
-        .name  = "Led Green",
         .pin   = LED1_PIN,
         .mode  = GPIO_OUT,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
     },
     {
-        .name  = "Led Blue",
         .pin   = LED2_PIN,
         .mode  = GPIO_OUT,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
     },
 };
 
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "Led Red" },
+    { .name = "Led Green" },
+    { .name = "Led Blue" }
+};
 
 #ifdef __cplusplus
 }

--- a/boards/nrf52840-mdk/include/gpio_params.h
+++ b/boards/nrf52840-mdk/include/gpio_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,31 +33,37 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name  = "Led Red",
         .pin   = LED0_PIN,
         .mode  = GPIO_OUT,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
     },
     {
-        .name  = "Led Green",
         .pin   = LED1_PIN,
         .mode  = GPIO_OUT,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
     },
     {
-        .name  = "Led Blue",
         .pin   = LED2_PIN,
         .mode  = GPIO_OUT,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
     },
     {
-        .name  = "Button 1",
         .pin   = BTN0_PIN,
         .mode  = BTN0_MODE,
         .flags = SAUL_GPIO_INVERTED,
     },
 };
 
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "Led Red" },
+    { .name = "Led Green" },
+    { .name = "Led Blue" },
+    { .name = "Button 1" }
+};
 
 #ifdef __cplusplus
 }

--- a/boards/nz32-sc151/include/gpio_params.h
+++ b/boards/nz32-sc151/include/gpio_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,10 +33,17 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LED (PB2)",
         .pin = LED0_PIN,
         .mode = GPIO_OUT
     }
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LED (PB2)" }
 };
 
 #ifdef __cplusplus

--- a/boards/pba-d-01-kw2x/include/gpio_params.h
+++ b/boards/pba-d-01-kw2x/include/gpio_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,35 +33,42 @@ extern "C" {
 static const saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name   = "LED(red)",
         .pin    = LED0_PIN,
         .mode   = GPIO_OUT,
         .flags  = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR)
     },
     {
-        .name   = "LED(green)",
         .pin    = LED1_PIN,
         .mode   = GPIO_OUT,
         .flags  = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR)
     },
     {
-        .name   = "LED(blue)",
         .pin    = LED2_PIN,
         .mode   = GPIO_OUT,
         .flags  = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR)
     },
     {
-        .name   = "Button(SW0)",
         .pin    = BTN0_PIN,
         .mode   = BTN0_MODE,
         .flags  = SAUL_GPIO_INVERTED
     },
     {
-        .name   = "Button(CS0)",
         .pin    = BTN1_PIN,
         .mode   = BTN1_MODE,
         .flags  = 0x0
     },
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LED(red)" },
+    { .name = "LED(green)" },
+    { .name = "LED(blue)" },
+    { .name = "Button(SW0)" },
+    { .name = "Button(CS0)" }
 };
 
 #ifdef __cplusplus

--- a/boards/phynode-kw41z/include/gpio_params.h
+++ b/boards/phynode-kw41z/include/gpio_params.h
@@ -23,6 +23,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -37,7 +38,6 @@ static const  saul_gpio_params_t saul_gpio_params[] =
      * RGB LED (D10). The RGB LED is configured with 3 LEDx macros. */
 #ifdef LED0_PIN
     {
-        .name = "D2 (Orange)",
         .pin = LED0_PIN,
         .mode = GPIO_OUT,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
@@ -45,7 +45,6 @@ static const  saul_gpio_params_t saul_gpio_params[] =
 #endif /* LED0_PIN */
 #ifdef LED1_PIN
     {
-        .name = "D10 RGB (Red)",
         .pin = LED1_PIN,
         .mode = GPIO_OUT,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
@@ -53,26 +52,43 @@ static const  saul_gpio_params_t saul_gpio_params[] =
 #endif /* LED1_PIN */
 #ifdef LED2_PIN
     {
-        .name = "D10 RGB (Green)",
         .pin = LED2_PIN,
         .mode = GPIO_OUT,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
     },
-#endif /* LED1_PIN */
+#endif /* LED2_PIN */
 #ifdef LED3_PIN
     {
-        .name = "D10 RGB (Blue)",
         .pin = LED3_PIN,
         .mode = GPIO_OUT,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
     },
-#endif /* LED1_PIN */
+#endif /* LED3_PIN */
     {
-        .name = "S2 (Button)",
         .pin = BTN0_PIN,
         .mode = BTN0_MODE,
         .flags = (SAUL_GPIO_INVERTED),
     },
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+#ifdef LED0_PIN
+    { .name = "D2 (Orange)" },
+#endif /* LED0_PIN */
+#ifdef LED1_PIN
+    { .name = "D10 RGB (Red)" },
+#endif /* LED1_PIN */
+#ifdef LED2_PIN
+    { .name = "D10 RGB (Green)" },
+#endif /* LED2_PIN */
+#ifdef LED3_PIN
+    { .name = "D10 RGB (Blue)" },
+#endif /* LED3_PIN */
+    { .name = "S2 (Button)" }
 };
 
 #ifdef __cplusplus

--- a/boards/pyboard/include/gpio_params.h
+++ b/boards/pyboard/include/gpio_params.h
@@ -23,6 +23,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -34,16 +35,23 @@ extern "C" {
 static const saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LD1",
         .pin = LED0_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "Button(B1 User)",
         .pin = BTN_B1_PIN,
         .mode = GPIO_IN_PU,
         .flags = SAUL_GPIO_INVERTED
     }
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LD1" },
+    { .name = "Button(B1 User)" }
 };
 
 #ifdef __cplusplus

--- a/boards/reel/include/gpio_params.h
+++ b/boards/reel/include/gpio_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,37 +33,43 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name  = "LED Red (RGB, front)",
         .pin   = LED0_PIN,
         .mode  = GPIO_OUT,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
     },
     {
-        .name  = "LED Green (RGB, front)",
         .pin   = LED1_PIN,
         .mode  = GPIO_OUT,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
     },
     {
-        .name  = "LED Blue (RGB, front)",
         .pin   = LED2_PIN,
         .mode  = GPIO_OUT,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
     },
     {
-        .name  = "LED Green (back)",
         .pin   = LED3_PIN,
         .mode  = GPIO_OUT,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
     },
     {
-        .name  = "Button",
         .pin   = BTN0_PIN,
         .mode  = BTN0_MODE,
         .flags = SAUL_GPIO_INVERTED,
     },
 };
 
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LED Red (RGB, front)" },
+    { .name = "LED Green (RGB, front)" },
+    { .name = "LED Blue (RGB, front)" },
+    { .name = "LED Green (back)" },
+    { .name = "Button" }
+};
 
 #ifdef __cplusplus
 }

--- a/boards/remote-pa/include/gpio_params.h
+++ b/boards/remote-pa/include/gpio_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,29 +33,36 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name  = "LED(red)",
         .pin   = LED0_PIN,
         .mode  = GPIO_OUT,
         .flags = 0x0,
     },
     {
-        .name  = "LED(green)",
         .pin   = LED1_PIN,
         .mode  = GPIO_OUT,
         .flags = 0x0,
     },
     {
-        .name  = "LED(blue)",
         .pin   = LED2_PIN,
         .mode  = GPIO_OUT,
         .flags = 0x0,
     },
     {
-        .name  = "Button(User)",
         .pin   = BTN0_PIN,
         .mode  = BTN0_MODE,
         .flags = SAUL_GPIO_INVERTED,
     },
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LED(red)" },
+    { .name = "LED(green)" },
+    { .name = "LED(blue)" },
+    { .name = "Button(User)" }
 };
 
 #ifdef __cplusplus

--- a/boards/remote-reva/include/gpio_params.h
+++ b/boards/remote-reva/include/gpio_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,29 +33,36 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name  = "LED(red)",
         .pin   = LED0_PIN,
         .mode  = GPIO_OUT,
         .flags = 0x0,
     },
     {
-        .name  = "LED(green)",
         .pin   = LED1_PIN,
         .mode  = GPIO_OUT,
         .flags = 0x0,
     },
     {
-        .name  = "LED(blue)",
         .pin   = LED2_PIN,
         .mode  = GPIO_OUT,
         .flags = 0x0,
     },
     {
-        .name  = "Button(User)",
         .pin   = BTN0_PIN,
         .mode  = BTN0_MODE,
         .flags = SAUL_GPIO_INVERTED,
     },
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LED(red)" },
+    { .name = "LED(green)" },
+    { .name = "LED(blue)" },
+    { .name = "Button(User)" }
 };
 
 #ifdef __cplusplus

--- a/boards/remote-revb/include/gpio_params.h
+++ b/boards/remote-revb/include/gpio_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,29 +33,36 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name  = "LED(red)",
         .pin   = LED0_PIN,
         .mode  = GPIO_OUT,
         .flags = 0x0,
     },
     {
-        .name  = "LED(green)",
         .pin   = LED1_PIN,
         .mode  = GPIO_OUT,
         .flags = 0x0,
     },
     {
-        .name  = "LED(blue)",
         .pin   = LED2_PIN,
         .mode  = GPIO_OUT,
         .flags = 0x0,
     },
     {
-        .name  = "Button(User)",
         .pin   = BTN0_PIN,
         .mode  = BTN0_MODE,
         .flags = SAUL_GPIO_INVERTED,
     },
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LED(red)" },
+    { .name = "LED(green)" },
+    { .name = "LED(blue)" },
+    { .name = "Button(User)" }
 };
 
 #ifdef __cplusplus

--- a/boards/samd21-xpro/include/gpio_params.h
+++ b/boards/samd21-xpro/include/gpio_params.h
@@ -24,6 +24,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -35,15 +36,22 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LED(orange)",
         .pin = LED0_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "Button(SW0)",
         .pin  = BTN0_PIN,
         .mode = BTN0_MODE
     },
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LED(orange)" },
+    { .name = "Button(SW0)" }
 };
 
 #ifdef __cplusplus

--- a/boards/samr21-xpro/include/gpio_params.h
+++ b/boards/samr21-xpro/include/gpio_params.h
@@ -24,6 +24,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -35,17 +36,24 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LED(orange)",
         .pin = LED0_PIN,
         .mode = GPIO_OUT,
         .flags = SAUL_GPIO_INVERTED,
     },
     {
-        .name = "Button(SW0)",
         .pin  = BTN0_PIN,
         .mode = BTN0_MODE,
         .flags = SAUL_GPIO_INVERTED,
     },
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LED(orange)" },
+    { .name = "Button(SW0)" }
 };
 
 #ifdef __cplusplus

--- a/boards/samr30-xpro/include/gpio_params.h
+++ b/boards/samr30-xpro/include/gpio_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,23 +33,30 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LED(green)",
         .pin = LED0_PIN,
         .mode = GPIO_OUT,
         .flags = SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR,
     },
     {
-        .name = "LED(orange)",
         .pin = LED1_PIN,
         .mode = GPIO_OUT,
         .flags = SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR,
     },
     {
-        .name = "Button(SW0)",
         .pin  = BTN0_PIN,
         .mode = BTN0_MODE,
         .flags = SAUL_GPIO_INVERTED,
     },
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LED(green)" },
+    { .name = "LED(orange)" },
+    { .name = "Button(SW0)" }
 };
 
 #ifdef __cplusplus

--- a/boards/seeeduino_arch-pro/include/gpio_params.h
+++ b/boards/seeeduino_arch-pro/include/gpio_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,29 +33,36 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LED 0",
         .pin = LED0_PIN,
         .mode = GPIO_OUT,
         .flags = SAUL_GPIO_INVERTED
     },
     {
-        .name = "LED 1",
         .pin = LED1_PIN,
         .mode = GPIO_OUT,
         .flags = SAUL_GPIO_INVERTED
     },
     {
-        .name = "LED 2",
         .pin = LED2_PIN,
         .mode = GPIO_OUT,
         .flags = SAUL_GPIO_INVERTED
     },
     {
-        .name = "LED 3",
         .pin = LED3_PIN,
         .mode = GPIO_OUT,
         .flags = SAUL_GPIO_INVERTED
     }
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LED 0" },
+    { .name = "LED 1" },
+    { .name = "LED 2" },
+    { .name = "LED 3" }
 };
 
 #ifdef __cplusplus

--- a/boards/sensebox_samd21/include/gpio_params.h
+++ b/boards/sensebox_samd21/include/gpio_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,20 +33,27 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LED(Red)",
         .pin = LED0_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "LED(Green)",
         .pin = LED1_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "BTN",
         .pin = BTN0_PIN,
         .mode = BTN0_MODE
     }
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LED(Red)" },
+    { .name = "LED(Green)" },
+    { .name = "BTN" }
 };
 
 #ifdef __cplusplus

--- a/boards/slstk3401a/include/gpio_params.h
+++ b/boards/slstk3401a/include/gpio_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,27 +33,34 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LED 0",
         .pin = LED0_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "LED 1",
         .pin = LED1_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "Button 1",
         .pin = PB0_PIN,
         .mode = GPIO_IN_PU,
         .flags = SAUL_GPIO_INVERTED
     },
     {
-        .name = "Button 2",
         .pin = PB1_PIN,
         .mode = GPIO_IN_PU,
         .flags = SAUL_GPIO_INVERTED
     }
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LED 0" },
+    { .name = "LED 1" },
+    { .name = "Button 1" },
+    { .name = "Button 2" }
 };
 
 #ifdef __cplusplus

--- a/boards/slstk3402a/include/gpio_params.h
+++ b/boards/slstk3402a/include/gpio_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,27 +33,34 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LED 0",
         .pin = LED0_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "LED 1",
         .pin = LED1_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "Button 1",
         .pin = PB0_PIN,
         .mode = GPIO_IN_PU,
         .flags = SAUL_GPIO_INVERTED
     },
     {
-        .name = "Button 2",
         .pin = PB1_PIN,
         .mode = GPIO_IN_PU,
         .flags = SAUL_GPIO_INVERTED
     }
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LED 0" },
+    { .name = "LED 1" },
+    { .name = "Button 1" },
+    { .name = "Button 2" }
 };
 
 #ifdef __cplusplus

--- a/boards/sltb001a/include/gpio_params.h
+++ b/boards/sltb001a/include/gpio_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,27 +33,34 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LED 0",
         .pin = LED0_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "LED 1",
         .pin = LED1_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "Button 1",
         .pin = PB0_PIN,
         .mode = GPIO_IN_PU,
         .flags = SAUL_GPIO_INVERTED
     },
     {
-        .name = "Button 2",
         .pin = PB1_PIN,
         .mode = GPIO_IN_PU,
         .flags = SAUL_GPIO_INVERTED
     }
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LED 0" },
+    { .name = "LED 1" },
+    { .name = "Button 1" },
+    { .name = "Button 2" }
 };
 
 #ifdef __cplusplus

--- a/boards/slwstk6000b/include/gpio_params.h
+++ b/boards/slwstk6000b/include/gpio_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,27 +33,34 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LED 0",
         .pin = LED0_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "LED 1",
         .pin = LED1_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "Button 1",
         .pin = PB0_PIN,
         .mode = GPIO_IN_PU,
         .flags = SAUL_GPIO_INVERTED
     },
     {
-        .name = "Button 2",
         .pin = PB1_PIN,
         .mode = GPIO_IN_PU,
         .flags = SAUL_GPIO_INVERTED
     }
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LED 0" },
+    { .name = "LED 1" },
+    { .name = "Button 1" },
+    { .name = "Button 2" }
 };
 
 #ifdef __cplusplus

--- a/boards/sodaq-autonomo/include/gpio_params.h
+++ b/boards/sodaq-autonomo/include/gpio_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,10 +33,17 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LED(green)",
         .pin = LED0_PIN,
         .mode = GPIO_OUT
     },
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LED(green)" }
 };
 
 #ifdef __cplusplus

--- a/boards/sodaq-explorer/include/gpio_params.h
+++ b/boards/sodaq-explorer/include/gpio_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,16 +33,23 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LED",
         .pin = LED0_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "Button",
         .pin  = BTN0_PIN,
         .mode = BTN0_MODE,
         .flags = SAUL_GPIO_INVERTED
     }
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LED" },
+    { .name = "Button" }
 };
 
 #ifdef __cplusplus

--- a/boards/sodaq-one/include/gpio_params.h
+++ b/boards/sodaq-one/include/gpio_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,26 +33,33 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LED Red",
         .pin = LED0_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "LED Green",
         .pin = LED1_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "LED Blue",
         .pin = LED2_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "Button",
         .pin  = BTN0_PIN,
         .mode = BTN0_MODE,
         .flags = SAUL_GPIO_INVERTED
     },
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LED Red" },
+    { .name = "LED Green" },
+    { .name = "LED Blue" },
+    { .name = "Button" }
 };
 
 #ifdef __cplusplus

--- a/boards/sodaq-sara-aff/include/gpio_params.h
+++ b/boards/sodaq-sara-aff/include/gpio_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,28 +33,35 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LED Builtin",
         .pin  = LED0_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "LED Red",
         .pin = LED1_PIN,
         .mode = GPIO_OUT,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR)
     },
     {
-        .name = "LED Green",
         .pin = LED2_PIN,
         .mode = GPIO_OUT,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR)
     },
     {
-        .name = "LED Blue",
         .pin = LED3_PIN,
         .mode = GPIO_OUT,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR)
     }
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LED Builtin" },
+    { .name = "LED Red" },
+    { .name = "LED Green" },
+    { .name = "LED Blue" }
 };
 
 #ifdef __cplusplus

--- a/boards/stk3600/include/gpio_params.h
+++ b/boards/stk3600/include/gpio_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,27 +33,34 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LED 0",
         .pin = LED0_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "LED 1",
         .pin = LED1_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "Button 1",
         .pin = PB0_PIN,
         .mode = GPIO_IN_PU,
         .flags = SAUL_GPIO_INVERTED
     },
     {
-        .name = "Button 2",
         .pin = PB1_PIN,
         .mode = GPIO_IN_PU,
         .flags = SAUL_GPIO_INVERTED
     }
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LED 0" },
+    { .name = "LED 1" },
+    { .name = "Button 1" },
+    { .name = "Button 2" }
 };
 
 #ifdef __cplusplus

--- a/boards/stk3700/include/gpio_params.h
+++ b/boards/stk3700/include/gpio_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,27 +33,34 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LED 0",
         .pin = LED0_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "LED 1",
         .pin = LED1_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "Button 1",
         .pin = PB0_PIN,
         .mode = GPIO_IN_PU,
         .flags = SAUL_GPIO_INVERTED
     },
     {
-        .name = "Button 2",
         .pin = PB1_PIN,
         .mode = GPIO_IN_PU,
         .flags = SAUL_GPIO_INVERTED
     }
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LED 0" },
+    { .name = "LED 1" },
+    { .name = "Button 1" },
+    { .name = "Button 2" }
 };
 
 #ifdef __cplusplus

--- a/boards/stm32f0discovery/include/gpio_params.h
+++ b/boards/stm32f0discovery/include/gpio_params.h
@@ -24,6 +24,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -35,20 +36,27 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LD3",
         .pin = LED0_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "LD4",
         .pin = LED1_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "BTN USER",
         .pin  = BTN0_PIN,
         .mode = BTN0_MODE
     },
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LD3" },
+    { .name = "LD4" },
+    { .name = "BTN USER" }
 };
 
 #ifdef __cplusplus

--- a/boards/stm32f3discovery/include/gpio_params.h
+++ b/boards/stm32f3discovery/include/gpio_params.h
@@ -22,6 +22,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -33,50 +34,57 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LD3",
         .pin = LED0_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "LD4",
         .pin = LED1_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "LD5",
         .pin = LED2_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "LD6",
         .pin = LED3_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "LD7",
         .pin = LED4_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "LD8",
         .pin = LED5_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "LD9",
         .pin = LED6_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "LD10",
         .pin = LED7_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "BTN USER",
         .pin  = BTN0_PIN,
         .mode = BTN0_MODE
     },
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LD3" },
+    { .name = "LD4" },
+    { .name = "LD5" },
+    { .name = "LD6" },
+    { .name = "LD7" },
+    { .name = "LD8" },
+    { .name = "LD9" },
+    { .name = "LD10" },
+    { .name = "BTN USER" }
 };
 
 #ifdef __cplusplus

--- a/boards/stm32f429i-disc1/include/gpio_params.h
+++ b/boards/stm32f429i-disc1/include/gpio_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,20 +33,27 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LD3 (green)",
         .pin = LED0_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "LD4 (red)",
         .pin = LED1_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "BTN USER",
         .pin  = BTN0_PIN,
         .mode = BTN0_MODE
     },
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LD3 (green)" },
+    { .name = "LD4 (red)" },
+    { .name = "BTN USER" }
 };
 
 #ifdef __cplusplus

--- a/boards/stm32f4discovery/include/gpio_params.h
+++ b/boards/stm32f4discovery/include/gpio_params.h
@@ -24,6 +24,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -35,30 +36,37 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LD3",
         .pin = LED0_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "LD4",
         .pin = LED1_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "LD5",
         .pin = LED2_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "LD6",
         .pin = LED3_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "BTN USER",
         .pin  = BTN0_PIN,
         .mode = BTN0_MODE
     },
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LD3" },
+    { .name = "LD4" },
+    { .name = "LD5" },
+    { .name = "LD6" },
+    { .name = "BTN USER" }
 };
 
 #ifdef __cplusplus

--- a/boards/stm32f769i-disco/include/gpio_params.h
+++ b/boards/stm32f769i-disco/include/gpio_params.h
@@ -22,6 +22,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -33,30 +34,37 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LD1",
         .pin = LED0_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "LD2",
         .pin = LED1_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "LD3",
         .pin = LED2_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "LD4",
         .pin = LED3_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "BTN USER",
         .pin  = BTN0_PIN,
         .mode = BTN0_MODE
     },
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LD1" },
+    { .name = "LD2" },
+    { .name = "LD3" },
+    { .name = "LD4" },
+    { .name = "BTN USER" }
 };
 
 #ifdef __cplusplus

--- a/boards/stm32l476g-disco/include/gpio_params.h
+++ b/boards/stm32l476g-disco/include/gpio_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,40 +33,47 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LD4",
         .pin = LED0_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "LD5",
         .pin = LED1_PIN,
         .mode = GPIO_OUT
     },
     {
-        .name = "Joystick (Center)",
         .pin = BTN0_PIN,
         .mode = BTN0_MODE
     },
     {
-        .name = "Joystick (Left)",
         .pin = BTN1_PIN,
         .mode = BTN1_MODE
     },
     {
-        .name = "Joystick (Down)",
         .pin = BTN2_PIN,
         .mode = BTN2_MODE
     },
     {
-        .name = "Joystick (Right)",
         .pin = BTN3_PIN,
         .mode = BTN3_MODE
     },
     {
-        .name = "Joystick (Up)",
         .pin = BTN4_PIN,
         .mode = BTN4_MODE
     },
+};
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LD4" },
+    { .name = "LD5" },
+    { .name = "Joystick (Center)" },
+    { .name = "Joystick (Left)" },
+    { .name = "Joystick (Down)" },
+    { .name = "Joystick (Right)" },
+    { .name = "Joystick (Up)" },
 };
 
 #ifdef __cplusplus

--- a/boards/ublox-c030-u201/include/gpio_params.h
+++ b/boards/ublox-c030-u201/include/gpio_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,29 +33,37 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LD1(red)",
         .pin = LED0_PIN,
         .mode = GPIO_OUT,
         .flags = SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR,
     },
     {
-        .name = "LD2(green)",
         .pin = LED1_PIN,
         .mode = GPIO_OUT,
         .flags = SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR,
     },
     {
-        .name = "LD3(blue)",
         .pin = LED2_PIN,
         .mode = GPIO_OUT,
         .flags = SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR,
     },
     {
-        .name = "Button(B1 User)",
         .pin = BTN_B1_PIN,
         .mode = GPIO_IN,
     },
 };
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+    { .name = "LD1(red)" },
+    { .name = "LD2(green)" },
+    { .name = "LD3(blue)" },
+    { .name = "Button(B1 User)" }
+};
+
 
 #ifdef __cplusplus
 }

--- a/boards/usb-kw41z/include/gpio_params.h
+++ b/boards/usb-kw41z/include/gpio_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -36,7 +37,6 @@ static const  saul_gpio_params_t saul_gpio_params[] =
      * been applied. See boards/usb-kw41z/include/board.h */
 #ifdef LED0_PIN
     {
-        .name = "D2",
         .pin = LED0_PIN,
         .mode = GPIO_OUT,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
@@ -44,19 +44,32 @@ static const  saul_gpio_params_t saul_gpio_params[] =
 #endif /* LED0_PIN */
 #ifdef LED1_PIN
     {
-        .name = "D3",
         .pin = LED1_PIN,
         .mode = GPIO_OUT,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
     },
 #endif /* LED1_PIN */
     {
-        .name = "SW1",
         .pin = BTN0_PIN,
         .mode = BTN0_MODE,
         .flags = (SAUL_GPIO_INVERTED),
     },
 };
+
+/**
+ * @brief GPIO information for SAUL registry
+ */
+static const saul_reg_info_t saul_gpio_info[] =
+{
+#ifdef LED0_PIN
+    { .name = "D2" },
+#endif /* LED0_PIN */
+#ifdef LED1_PIN
+    { .name = "D3" },
+#endif /* LED1_PIN */
+    { .name = "SW1" }
+};
+
 
 #ifdef __cplusplus
 }

--- a/drivers/include/saul/periph.h
+++ b/drivers/include/saul/periph.h
@@ -45,7 +45,6 @@ typedef enum {
  * @brief   Direct mapped GPIO configuration values
  */
 typedef struct {
-    const char *name;           /**< name of the device connected to this pin */
     gpio_t pin;                 /**< GPIO pin to initialize and expose */
     gpio_mode_t mode;           /**< pin mode to use */
     saul_gpio_flags_t flags;    /**< Configuration flags */

--- a/sys/auto_init/saul/auto_init_gpio.c
+++ b/sys/auto_init/saul/auto_init_gpio.c
@@ -21,6 +21,7 @@
 
 #ifdef MODULE_SAUL_GPIO
 
+#include "assert.h"
 #include "log.h"
 #include "saul_reg.h"
 #include "saul/periph.h"
@@ -39,6 +40,10 @@ void auto_init_gpio(void)
 #else
 #define SAUL_GPIO_NUMOF (sizeof(saul_gpio_params)/sizeof(saul_gpio_params[0]))
 
+/**
+ * @brief   Define the number of saul info
+ */
+#define SAUL_GPIO_INFO_NUMOF (sizeof(saul_gpio_info) / sizeof(saul_gpio_info[0]))
 
 /**
  * @brief   Memory for the registry entries
@@ -58,13 +63,15 @@ extern saul_driver_t gpio_out_saul_driver;
 
 void auto_init_gpio(void)
 {
+    assert(SAUL_GPIO_NUMOF == SAUL_GPIO_INFO_NUMOF);
+
     for (unsigned int i = 0; i < SAUL_GPIO_NUMOF; i++) {
         const saul_gpio_params_t *p = &saul_gpio_params[i];
 
         LOG_DEBUG("[auto_init_saul] initializing GPIO #%u\n", i);
 
         saul_reg_entries[i].dev = (void *)p;
-        saul_reg_entries[i].name = p->name;
+        saul_reg_entries[i].name = saul_gpio_info[i].name;
         if ((p->mode == GPIO_IN) || (p->mode == GPIO_IN_PD) ||
             (p->mode == GPIO_IN_PU)) {
             saul_reg_entries[i].driver = &gpio_in_saul_driver;


### PR DESCRIPTION
### Contribution description
For almost all devices in SAUL we currently have a `saul_reg_info_t` structure that holds the information for the SAUL registry and some other structure that holds the parameters needed for its initialization. There are two exceptions to that: GPIOs and ADCs. This difference breaks the pattern and makes it more difficult to treat all devices in a generic way.

This PR extracts the information that actually belongs to a `saul_reg_info_t` structure from the `saul_gpio_params_t` (currently just the name), and creates an array of structures that holds that information, like all other drivers do, making everything more consistent.

Right now moving the names out of the structure might seem a little strange, but there are plans to expand the metadata for the SAUL registry entries, and the place for it is the `saul_reg_info_t` structure.

### Testing procedure
Run `examples/saul` and check that the names of the GPIOs are correctly displayed.

### Issues/PRs references
