### PR TITLE
SAUL: Extract name from saul_adc_params_t

### DIFF
--- a/boards/firefly/include/adc_params.h
+++ b/boards/firefly/include/adc_params.h
@@ -22,6 +22,7 @@
 #include "board.h"
 #include "saul/periph.h"
 #include "periph/adc.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -33,20 +34,27 @@ extern "C" {
 static const  saul_adc_params_t saul_adc_params[] =
 {
     {
-        .name = "ADC1",
         .line = ADC_LINE(0),
         .res  = ADC_RES_12BIT,
     },
     {
-        .name = "ADC2",
         .line = ADC_LINE(1),
         .res  = ADC_RES_12BIT,
     },
     {
-        .name = "ADC3",
         .line = ADC_LINE(2),
         .res  = ADC_RES_12BIT,
     }
+};
+
+/**
+ * @brief   ADC information for SAUL registry
+ */
+static const saul_reg_info_t saul_adc_info[] =
+{
+    { .name = "ADC1" },
+    { .name = "ADC2" },
+    { .name = "ADC3" }
 };
 
 #ifdef __cplusplus

--- a/boards/frdm-k22f/include/adc_params.h
+++ b/boards/frdm-k22f/include/adc_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,46 +33,54 @@ extern "C" {
 static const  saul_adc_params_t saul_adc_params[] =
 {
     {
-        .name = "ADC0_DP",
         .line = ADC_LINE(0),
         .res  = ADC_RES_16BIT,
     },
     {
-        .name = "ADC0_DM",
         .line = ADC_LINE(1),
         .res  = ADC_RES_16BIT,
     },
     {
-        .name = "ADC1_DP",
         .line = ADC_LINE(2),
         .res  = ADC_RES_16BIT,
     },
     {
-        .name = "ADC1_DM",
         .line = ADC_LINE(3),
         .res  = ADC_RES_16BIT,
     },
     {
-        .name = "A0",
         .line = ADC_LINE(4),
         .res  = ADC_RES_16BIT,
     },
     {
-        .name = "A1",
         .line = ADC_LINE(5),
         .res  = ADC_RES_16BIT,
     },
     {
-        .name = "A2",
         .line = ADC_LINE(6),
         .res  = ADC_RES_16BIT,
     },
     {
-        .name = "A3",
         .line = ADC_LINE(7),
         .res  = ADC_RES_16BIT,
     },
 };
+
+/**
+ * @brief   ADC information for SAUL registry
+ */
+static const saul_reg_info_t saul_adc_info[] =
+{
+    { .name = "ADC0_DP" },
+    { .name = "ADC0_DM" },
+    { .name = "ADC1_DP" },
+    { .name = "ADC1_DM" },
+    { .name = "A0" },
+    { .name = "A1" },
+    { .name = "A2" },
+    { .name = "A3" }
+};
+
 
 #ifdef __cplusplus
 }

--- a/boards/frdm-k64f/include/adc_params.h
+++ b/boards/frdm-k64f/include/adc_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -31,26 +32,53 @@ extern "C" {
  */
 static const  saul_adc_params_t saul_adc_params[] =
 {
-    { .name = "PTB2",     .line = ADC_LINE(0), .res  = ADC_RES_16BIT, },
-    { .name = "PTB3",     .line = ADC_LINE(1), .res  = ADC_RES_16BIT, },
-    { .name = "PTB10",    .line = ADC_LINE(2), .res  = ADC_RES_16BIT, },
-    { .name = "PTB11",    .line = ADC_LINE(3), .res  = ADC_RES_16BIT, },
-    { .name = "PTC11",    .line = ADC_LINE(4), .res  = ADC_RES_16BIT, },
-    { .name = "PTC10",    .line = ADC_LINE(5), .res  = ADC_RES_16BIT, },
-    { .name = "ADC0_DP0", .line = ADC_LINE(6), .res  = ADC_RES_16BIT, },
-    { .name = "ADC0_DM0", .line = ADC_LINE(7), .res  = ADC_RES_16BIT, },
-    { .name = "ADC0_DP0-ADC0_DM0", .line = ADC_LINE(8), .res  = ADC_RES_16BIT, },
-    { .name = "ADC1_DP0", .line = ADC_LINE(9), .res  = ADC_RES_16BIT, },
-    { .name = "ADC1_DM0", .line = ADC_LINE(10), .res  = ADC_RES_16BIT, },
-    { .name = "ADC1_DP0-ADC1_DM0", .line = ADC_LINE(11), .res  = ADC_RES_16BIT, },
-    { .name = "ADC0_DP1", .line = ADC_LINE(12), .res  = ADC_RES_16BIT, },
-    { .name = "ADC0_DM1", .line = ADC_LINE(13), .res  = ADC_RES_16BIT, },
-    { .name = "ADC0_DP1-ADC0_DM1", .line = ADC_LINE(14), .res  = ADC_RES_16BIT, },
-    { .name = "ADC1_DP1", .line = ADC_LINE(15), .res  = ADC_RES_16BIT, },
-    { .name = "ADC1_DM1", .line = ADC_LINE(16), .res  = ADC_RES_16BIT, },
-    { .name = "ADC1_DP1-ADC1_DM1", .line = ADC_LINE(17), .res  = ADC_RES_16BIT, },
-    { .name = "coretemp", .line = ADC_LINE(18), .res  = ADC_RES_16BIT, },
-    { .name = "corebandgap", .line = ADC_LINE(19), .res  = ADC_RES_16BIT, },
+    { .line = ADC_LINE(0),  .res  = ADC_RES_16BIT, },
+    { .line = ADC_LINE(1),  .res  = ADC_RES_16BIT, },
+    { .line = ADC_LINE(2),  .res  = ADC_RES_16BIT, },
+    { .line = ADC_LINE(3),  .res  = ADC_RES_16BIT, },
+    { .line = ADC_LINE(4),  .res  = ADC_RES_16BIT, },
+    { .line = ADC_LINE(5),  .res  = ADC_RES_16BIT, },
+    { .line = ADC_LINE(6),  .res  = ADC_RES_16BIT, },
+    { .line = ADC_LINE(7),  .res  = ADC_RES_16BIT, },
+    { .line = ADC_LINE(8),  .res  = ADC_RES_16BIT, },
+    { .line = ADC_LINE(9),  .res  = ADC_RES_16BIT, },
+    { .line = ADC_LINE(10), .res  = ADC_RES_16BIT, },
+    { .line = ADC_LINE(11), .res  = ADC_RES_16BIT, },
+    { .line = ADC_LINE(12), .res  = ADC_RES_16BIT, },
+    { .line = ADC_LINE(13), .res  = ADC_RES_16BIT, },
+    { .line = ADC_LINE(14), .res  = ADC_RES_16BIT, },
+    { .line = ADC_LINE(15), .res  = ADC_RES_16BIT, },
+    { .line = ADC_LINE(16), .res  = ADC_RES_16BIT, },
+    { .line = ADC_LINE(17), .res  = ADC_RES_16BIT, },
+    { .line = ADC_LINE(18), .res  = ADC_RES_16BIT, },
+    { .line = ADC_LINE(19), .res  = ADC_RES_16BIT, },
+};
+
+/**
+ * @brief   ADC information for SAUL registry
+ */
+static const saul_reg_info_t saul_adc_info[] =
+{
+    { .name = "PTB2" },
+    { .name = "PTB3" },
+    { .name = "PTB10" },
+    { .name = "PTB11" },
+    { .name = "PTC11" },
+    { .name = "PTC10" },
+    { .name = "ADC0_DP0" },
+    { .name = "ADC0_DM0" },
+    { .name = "ADC0_DP0-ADC0_DM0" },
+    { .name = "ADC1_DP0" },
+    { .name = "ADC1_DM0" },
+    { .name = "ADC1_DP0-ADC1_DM0" },
+    { .name = "ADC0_DP1" },
+    { .name = "ADC0_DM1" },
+    { .name = "ADC0_DP1-ADC0_DM1" },
+    { .name = "ADC1_DP1" },
+    { .name = "ADC1_DM1" },
+    { .name = "ADC1_DP1-ADC1_DM1" },
+    { .name = "coretemp" },
+    { .name = "corebandgap" }
 };
 
 #ifdef __cplusplus

--- a/boards/frdm-kw41z/include/adc_params.h
+++ b/boards/frdm-kw41z/include/adc_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,40 +33,47 @@ extern "C" {
 static const  saul_adc_params_t saul_adc_params[] =
 {
     {
-        .name = "ADC0_DP-DM",
         .line = ADC_LINE(0),
         .res  = ADC_RES_16BIT,
     },
     {
-        .name = "ADC0_DP",
         .line = ADC_LINE(1),
         .res  = ADC_RES_16BIT,
     },
     {
-        .name = "PTB2",
         .line = ADC_LINE(2),
         .res  = ADC_RES_16BIT,
     },
     {
-        .name = "PTB3",
         .line = ADC_LINE(3),
         .res  = ADC_RES_16BIT,
     },
     {
-        .name = "coretemp",
         .line = ADC_LINE(4),
         .res  = ADC_RES_16BIT,
     },
     {
-        .name = "corebandgap",
         .line = ADC_LINE(5),
         .res  = ADC_RES_16BIT,
     },
     {
-        .name = "dcdcvbat",
         .line = ADC_LINE(6),
         .res  = ADC_RES_16BIT,
     },
+};
+
+/**
+ * @brief   ADC information for SAUL registry
+ */
+static const saul_reg_info_t saul_adc_info[] =
+{
+    { .name = "ADC0_DP-DM" },
+    { .name = "ADC0_DP" },
+    { .name = "PTB2" },
+    { .name = "PTB3" },
+    { .name = "coretemp" },
+    { .name = "corebandgap" },
+    { .name = "dcdcvbat" }
 };
 
 #ifdef __cplusplus

--- a/boards/mega-xplained/include/adc_params.h
+++ b/boards/mega-xplained/include/adc_params.h
@@ -23,6 +23,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -34,20 +35,27 @@ extern "C" {
 static const  saul_adc_params_t saul_adc_params[] =
 {
     {
-        .name = "NTC thermistor",
         .line = NTC_OUTPUT,
         .res  = ADC_RES_10BIT,
     },
     {
-        .name = "Light sensor",
         .line = LIGHT_SENSOR_OUTPUT,
         .res  = ADC_RES_10BIT,
     },
     {
-        .name = "RC filter",
         .line = FILTER_OUTPUT,
         .res  = ADC_RES_10BIT,
     }
+};
+
+/**
+ * @brief   ADC information for SAUL registry
+ */
+static const saul_reg_info_t saul_adc_info[] =
+{
+    { .name = "NTC thermistor" },
+    { .name = "Light sensor" },
+    { .name = "RC filter" }
 };
 
 #ifdef __cplusplus

--- a/boards/mulle/include/adc_params.h
+++ b/boards/mulle/include/adc_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,90 +33,97 @@ extern "C" {
 static const  saul_adc_params_t saul_adc_params[] =
 {
     {
-        .name = "k60temp",
         .line = ADC_LINE(0),
         .res  = ADC_RES_16BIT,
     },
     {
-        .name = "k60vrefsh",
         .line = ADC_LINE(2),
         .res  = ADC_RES_16BIT,
     },
     {
-        .name = "k60vrefsl",
         .line = ADC_LINE(3),
         .res  = ADC_RES_16BIT,
     },
     {
-        .name = "k60bandgap",
         .line = ADC_LINE(1),
         .res  = ADC_RES_16BIT,
     },
     {
-        .name = "DAC0feedback",
         .line = ADC_LINE(4),
         .res  = ADC_RES_16BIT,
     },
     {
-        .name = "VREFfeedback",
         .line = ADC_LINE(5),
         .res  = ADC_RES_16BIT,
     },
     {
-        .name = "Vbat",
         .line = MULLE_VBAT_ADC_LINE,
         .res  = ADC_RES_16BIT,
     },
     {
-        .name = "Vchr",
         .line = MULLE_VCHR_ADC_LINE,
         .res  = ADC_RES_16BIT,
     },
     {
-        .name = "PGA0_DP",
         .line = ADC_LINE(8),
         .res  = ADC_RES_16BIT,
     },
     {
-        .name = "PGA0_DM",
         .line = ADC_LINE(9),
         .res  = ADC_RES_16BIT,
     },
     {
-        .name = "PTA17",
         .line = ADC_LINE(10),
         .res  = ADC_RES_16BIT,
     },
     {
-        .name = "PTB0",
         .line = ADC_LINE(11),
         .res  = ADC_RES_16BIT,
     },
     {
-        .name = "PTC0",
         .line = ADC_LINE(12),
         .res  = ADC_RES_16BIT,
     },
     {
-        .name = "PTC8",
         .line = ADC_LINE(13),
         .res  = ADC_RES_16BIT,
     },
     {
-        .name = "PTC9",
         .line = ADC_LINE(14),
         .res  = ADC_RES_16BIT,
     },
     {
-        .name = "PTC10",
         .line = ADC_LINE(15),
         .res  = ADC_RES_16BIT,
     },
     {
-        .name = "PTC11",
         .line = ADC_LINE(16),
         .res  = ADC_RES_16BIT,
     },
+};
+
+/**
+ * @brief   ADC information for SAUL registry
+ */
+static const saul_reg_info_t saul_adc_info[] =
+{
+    { .name = "k60temp" },
+    { .name = "k60vrefsh" },
+    { .name = "k60vrefsl" },
+    { .name = "k60bandgap" },
+    { .name = "DAC0feedback" },
+    { .name = "VREFfeedback" },
+    { .name = "Vbat" },
+    { .name = "Vchr" },
+    { .name = "PGA0_DP" },
+    { .name = "PGA0_DM" },
+    { .name = "PTA17" },
+    { .name = "PTB0" },
+    { .name = "PTC0" },
+    { .name = "PTC8" },
+    { .name = "PTC9" },
+    { .name = "PTC10" },
+    { .name = "PTC11" }
 };
 
 #ifdef __cplusplus

--- a/boards/phynode-kw41z/include/adc_params.h
+++ b/boards/phynode-kw41z/include/adc_params.h
@@ -23,6 +23,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -34,20 +35,27 @@ extern "C" {
 static const  saul_adc_params_t saul_adc_params[] =
 {
     {
-        .name = "coretemp",
         .line = ADC_LINE(0),
         .res  = ADC_RES_16BIT,
     },
     {
-        .name = "corebandgap",
         .line = ADC_LINE(1),
         .res  = ADC_RES_16BIT,
     },
     {
-        .name = "dcdcvbat",
         .line = ADC_LINE(2),
         .res  = ADC_RES_16BIT,
     },
+};
+
+/**
+ * @brief   ADC information for SAUL registry
+ */
+static const saul_reg_info_t saul_adc_info[] =
+{
+    { .name = "coretemp" },
+    { .name = "corebandgap" },
+    { .name = "dcdcvbat" }
 };
 
 #ifdef __cplusplus

--- a/boards/remote-pa/include/adc_params.h
+++ b/boards/remote-pa/include/adc_params.h
@@ -23,6 +23,7 @@
 #include "board.h"
 #include "saul/periph.h"
 #include "periph/adc.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -34,15 +35,22 @@ extern "C" {
 static const  saul_adc_params_t saul_adc_params[] =
 {
     {
-        .name = "ADC2",
         .line = ADC_LINE(0),
         .res  = ADC_RES_12BIT,
     },
     {
-        .name = "ADC3",
         .line = ADC_LINE(1),
         .res  = ADC_RES_12BIT,
     }
+};
+
+/**
+ * @brief   ADC information for SAUL registry
+ */
+static const saul_reg_info_t saul_adc_info[] =
+{
+    { .name = "ADC2" },
+    { .name = "ADC3" }
 };
 
 #ifdef __cplusplus

--- a/boards/remote-reva/include/adc_params.h
+++ b/boards/remote-reva/include/adc_params.h
@@ -23,6 +23,7 @@
 #include "board.h"
 #include "saul/periph.h"
 #include "periph/adc.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -34,20 +35,27 @@ extern "C" {
 static const  saul_adc_params_t saul_adc_params[] =
 {
     {
-        .name = "ADC1",
         .line = ADC_LINE(0),
         .res  = ADC_RES_12BIT,
     },
     {
-        .name = "ADC2",
         .line = ADC_LINE(1),
         .res  = ADC_RES_12BIT,
     },
     {
-        .name = "ADC3",
         .line = ADC_LINE(2),
         .res  = ADC_RES_12BIT,
     }
+};
+
+/**
+ * @brief   ADC information for SAUL registry
+ */
+static const saul_reg_info_t saul_adc_info[] =
+{
+    { .name = "ADC1" },
+    { .name = "ADC2" },
+    { .name = "ADC3" }
 };
 
 #ifdef __cplusplus

--- a/boards/remote-revb/include/adc_params.h
+++ b/boards/remote-revb/include/adc_params.h
@@ -23,6 +23,7 @@
 #include "board.h"
 #include "saul/periph.h"
 #include "periph/adc.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -34,20 +35,27 @@ extern "C" {
 static const  saul_adc_params_t saul_adc_params[] =
 {
     {
-        .name = "ADC1",
         .line = ADC_LINE(0),
         .res  = ADC_RES_12BIT,
     },
     {
-        .name = "ADC2",
         .line = ADC_LINE(1),
         .res  = ADC_RES_12BIT,
     },
     {
-        .name = "ADC3",
         .line = ADC_LINE(2),
         .res  = ADC_RES_12BIT,
     }
+};
+
+/**
+ * @brief   ADC information for SAUL registry
+ */
+static const saul_reg_info_t saul_adc_info[] =
+{
+    { .name = "ADC1" },
+    { .name = "ADC2" },
+    { .name = "ADC3" }
 };
 
 #ifdef __cplusplus

--- a/boards/usb-kw41z/include/adc_params.h
+++ b/boards/usb-kw41z/include/adc_params.h
@@ -21,6 +21,7 @@
 
 #include "board.h"
 #include "saul/periph.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,20 +33,27 @@ extern "C" {
 static const  saul_adc_params_t saul_adc_params[] =
 {
     {
-        .name = "coretemp",
         .line = ADC_LINE(0),
         .res  = ADC_RES_16BIT,
     },
     {
-        .name = "bandgap_1V",
         .line = ADC_LINE(1),
         .res  = ADC_RES_16BIT,
     },
     {
-        .name = "dcdcvbat",
         .line = ADC_LINE(2),
         .res  = ADC_RES_16BIT,
     },
+};
+
+/**
+ * @brief   ADC information for SAUL registry
+ */
+static const saul_reg_info_t saul_adc_info[] =
+{
+    { .name = "coretemp" },
+    { .name = "bandgap_1V" },
+    { .name = "dcdcvbat" }
 };
 
 #ifdef __cplusplus

--- a/drivers/include/saul/periph.h
+++ b/drivers/include/saul/periph.h
@@ -57,7 +57,6 @@ typedef struct {
  * @brief   Direct mapped ADC configuration values
  */
 typedef struct {
-    const char *name;       /**< name of the device connected to this pin */
     adc_t line;             /**< ADC line to initialize and expose */
     adc_res_t res;          /**< ADC resolution */
 } saul_adc_params_t;

--- a/sys/auto_init/saul/auto_init_adc.c
+++ b/sys/auto_init/saul/auto_init_adc.c
@@ -21,6 +21,7 @@
 
 #ifdef MODULE_SAUL_ADC
 
+#include "assert.h"
 #include "log.h"
 #include "saul_reg.h"
 #include "saul/periph.h"
@@ -31,6 +32,11 @@
  * @brief   Define the number of configured sensors
  */
 #define SAUL_ADC_NUMOF    (sizeof(saul_adc_params)/sizeof(saul_adc_params[0]))
+
+/**
+ * @brief   Define the number of saul info
+ */
+#define SAUL_ADC_INFO_NUMOF (sizeof(saul_adc_info) / sizeof(saul_adc_info[0]))
 
 /**
  * @brief   Allocate memory for pointers to the ADC parameter structs
@@ -52,6 +58,8 @@ extern saul_driver_t adc_saul_driver;
 
 void auto_init_adc(void)
 {
+    assert(SAUL_ADC_NUMOF == SAUL_ADC_INFO_NUMOF);
+
     for (unsigned i = 0; i < SAUL_ADC_NUMOF; i++) {
         const saul_adc_params_t *p = &saul_adc_params[i];
         saul_adcs[i] = p;
@@ -59,7 +67,7 @@ void auto_init_adc(void)
         LOG_DEBUG("[auto_init_saul] initializing direct ADC #%u\n", i);
 
         saul_reg_entries[i].dev = &saul_adcs[i];
-        saul_reg_entries[i].name = p->name;
+        saul_reg_entries[i].name = saul_adc_info[i].name;
         saul_reg_entries[i].driver = &adc_saul_driver;
         /* initialize the ADC line */
         adc_init(p->line);


### PR DESCRIPTION
### Contribution description
**See #11396 for some background**

This PR extracts the information that actually belongs to a `saul_reg_info_t` structure from the `saul_adc_params_t` (currently just the name), and creates an array of structures that holds that information, like all other drivers do, making everything more consistent.

### Testing procedure
Run `examples/saul` and check that the names of the ADCs are correctly displayed.

### Issues/PRs references
#11396 