### PR TITLE
 tests/gnrc_udp: reimplement using sys/optparse.

### DIFF
--- a/sys/Makefile
+++ b/sys/Makefile
@@ -145,6 +145,9 @@ endif
 ifneq (,$(filter bluetil_%,$(USEMODULE)))
   DIRS += net/ble/bluetil
 endif
+ifneq (,$(filter optparse,$(USEMODULE)))
+  DIRS += optparse
+endif
 
 DIRS += $(dir $(wildcard $(addsuffix /Makefile, $(USEMODULE))))
 

--- a/sys/include/optparse.h
+++ b/sys/include/optparse.h
@@ -1,0 +1,260 @@
+/*
+ *      optparse.h
+ *
+ *      Copyright 2010 Juan I Carrano <juan@carrano.com.ar>
+ *      Copyright 2018 Freie Universität Berlin
+ *
+ *      This program is free software; you can redistribute it and/or modify
+ *      it under the terms of the GNU General Public License as published by
+ *      the Free Software Foundation; either version 2 of the License, or
+ *      (at your option) any later version.
+ */
+
+/**
+ * @{
+ * @defgroup sys_optparse   Command line option parser.
+ * @ingroup sys
+ * @file
+ * @brief  Command-line parser
+ * @author Juan I Carrano <j.carrano@fu-berlin.de>
+ *
+ * Terminology:
+ *
+ * option: Optional value. Consists of a key an possibly a value. Each type of
+ *         options has a predefined number of arguments it takes, and that may
+ *         be either 0 or 1. Example:
+ *              -v --number 5 -k hello
+ *         Options (key, value): (v, none), (number, 5), (k, hello)
+ * switch: An option taking 0 values.
+ * argument: A value without a key. For example, in "-c 3 abcd", abcd is an
+ *          argument.
+ * short-option: Starts with a single dash and consists of a single character.
+ * long-option: Starts with two dashes and consists of one or more characters
+ *          (i.e. a string).
+ *
+ *
+ * Tips for defining rules:
+ *
+ * 1. Make an enum with the name of the parameters:
+ *    enum {HEIGHT, WIDTH, VERBOSE, ETC, .... , N_PARAMETERS }
+ * 2. Declare `struct opt_rule rules[N_PARAMETERS];`
+ * 3. Initialize. This can't be done in the initalization because it would be
+ *    necessary to know the values of pointers beforehand.
+ *    The standard way would be:
+ *      ```
+ *      rules[HEIGHT].short_id = 'h';
+ *      rules[HEIGHT].long_id = "height";
+ *      ... etc ...
+ *      ```
+ *    Alternatively, if the compiler supports compound literals and tags the
+ *    following syntax can be used:
+ *      ```
+ *      rules[HEIGHT] = (struct optparse){ .short_id = 'a', .long_id= ....etc ....};
+ *      ```
+ * 4. If none of those options is adequate, initializer functions are provided.
+ */
+
+#ifndef OPTPARSE_H
+#define OPTPARSE_H
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+/**
+ * Used to indicate that an option has no short (i.e. single character) variant.
+ */
+#define OPTPARSE_NO_SHORT '\0'
+
+/* Este es el idioma de generic_parser y amigos, y los callback deben usarlos
+ * para indicar su exito o fracaso */
+enum OPTPARSE_RESULT {
+    OPTPARSE_OK,            /**< Parsing suceeded */
+    OPTPARSE_NOMEM,         /**< Not enough memory. Only OPTPARSE_STR or a
+                                 custom parser may cause this error. */
+    OPTPARSE_BADSYNTAX,     /**< Command line is wrongly formed */
+    OPTPARSE_BADCONFIG,     /**< The parser configuration is invalid. */
+    OPTPARSE_REQHELP        /**< The help option was requested. */
+};
+
+/**
+ * Built-in actions for options.
+ */
+enum OPTPARSE_ACTIONS {
+    OPTPARSE_IGNORE_SWITCH, /**< Ignore a switch. Takes 0 arguments */
+    OPTPARSE_IGNORE,        /**< Ignore a key and its value. Takes 1 argument. */
+
+    OPTPARSE_SET_BOOL,      /**< Set opt_rule::data::d_bool to true. Takes 0 arguments.*/
+    OPTPARSE_UNSET_BOOL,    /**< Set opt_rule::data::d_bool to false. Takes 0 arguments.*/
+    OPTPARSE_COUNT,         /**< Count the number of occurences. Increments data::d_int
+                             *  each time the option is found. */
+
+    OPTPARSE_CUSTOM_ACTION, /**< Delegate the action to a callback
+                             * int callback(char *key, char *value, void *data)
+                             * The callback and the data are placed in
+                             * opt_rule::data::d_custom
+                             */
+    OPTPARSE_INT,           /**< Parse the value as an int and store it in *opt_rule.data.d_int */
+    OPTPARSE_DOUBLE,        /**< Parse the value as double and store it in *opt_rule.data.d_double */
+    OPTPARSE_FLOAT,         /**< Parse the value as float and store it in *opt_rule.data.d_float */
+
+    OPTPARSE_STR,           /**< Make a copy of the value string with strdup() and place it
+                             *  in *opt_rule.data.d_str. The string must be deallocated with free()
+                             */
+
+    OPTPARSE_STR_NOCOPY,    /*! Place a pointer to the value string in data::d_str.
+                             * In contrast with OPTPARSE_STR, this does NOT make a
+                             * copy of the string. It should not be used if the
+                             * strings will be modified.
+                             */
+
+    OPTPARSE_DO_HELP        /**< Print the following string, except if they are NULL:
+                             * - opt_conf::helpstr
+                             * - For each element of opt_conf::opt_rule:
+                             * short_id (tab) long_id (tab) desc
+                             *
+                             * In addition it causes the parser to exit with code
+                             * OPTPARSE_REQHELP.
+                             */
+};
+
+/**
+ * Configuration rules for a single command line option.
+ */
+struct opt_rule {
+    char short_id;          /**< Short style option name ("-w"). Can be OPTPARSE_NO_SHORT.*/
+    const char *long_id;    /**< Long style option name ("--width") . Can be NULL */
+    const char *desc;       /**< Help description. Can be NULL */
+    int action;             /**< Parsing type/action. See OPTPARSE_ACTIONS. */
+    /** The parse results will be placed in this union depending on action */
+    union {
+        int *d_int;
+        bool *d_bool;
+        double *d_double;
+        float *d_float;
+        char **d_str;       /**< Pointer to a user-defined pointer */
+        /**
+         * Callback for user defined actions.
+         *
+         * Prototype:
+         *  int callback(char *key, char *value, void *data, const char **msg)
+         *
+         * The callback must return a non-negative value to indicate success.
+         * The callback can place a message into msg and it will get printed to
+         * the error stream (without causing an error).
+         */
+        struct {
+            void *data;
+            int (*callback)(char *, char *, void *, const char **);
+        } d_custom;
+    } data;
+};
+
+/**
+ * Options that control the behavior of the option parser.
+ *
+ * The bitmasks (without the _b suffix are probably more useful.
+ */
+enum OPTPARSE_TUNABLES {
+    OPTPARSE_IGNORE_ARGV0_b,
+    OPTPARSE_NULL_ARGPARSER_b
+};
+
+/** Should argv[0] be skipped? */
+#define OPTPARSE_IGNORE_ARGV0 (1 << OPTPARSE_IGNORE_ARGV0_b)
+/** Should arguments be ignored if arg_parser is NULL? */
+#define OPTPARSE_NULL_ARGPARSER (1 << OPTPARSE_NULL_ARGPARSER_b)
+
+typedef uint16_t optparse_tune; /*! Option bitfield */
+
+/**
+ * Configuration for the command line parser.
+ */
+struct opt_conf {
+    char *helpstr;          /**< Program's description and general help string. */
+    struct opt_rule *rules; /**< Array of options. */
+    int n_rules;            /**< Number of elements in rules. */
+    optparse_tune tune;     /**< Option bitfield. */
+
+    /**
+     * int arg_parser(int current_index, char *valor, void *userdata)
+     *
+     * This function will be called each time an value without a key (i.e.
+     * an argument) is found. The first parameter (current_index) indicates the
+     * position if the argument and is useful for identifying argv[0].
+     * arg_parser can be NULL. In that case, finding an argument will generate
+     * an error, unless OPTPARSE_NULL_ARGPARSER is set.
+     */
+    int (*arg_parser)(int, char *, void *);
+    void *arg_parser_data; /**< Callback data for arg_parser. */
+};
+
+/**
+ * Main interface to the option parser.
+ *
+ * Short options:
+ *
+ * A short option that takes a value can be immediately followed by the value
+ * in the same argv string. For example "-upeter" would assign "peter" to the
+ * "u" option.
+ *
+ * Short switches can be merged together like "-xj".
+ *
+ * Dash handling:
+ *
+ * A double dash (--) indicates the parser that there are no more  options/
+ * switches and all the remaining command line arguments are sent to
+ * arg_parser.
+ *
+ * A single dash is interpreted as an argument and sent to arg_parser.
+ *
+ * @return  non-negative on sucess
+ * @return  A negative error code from OPTPARSE_RESULT on error.
+ */
+extern int optparse_cmd(struct opt_conf *config, int argc, char *argv[]);
+
+/**
+ * @defgroup sys_optparse_initializers  Optparse initializers
+ * @{
+ *
+ * @brief   Initialize optparse structures.
+ *
+ * These initializers can be used to safely construct configurations, without
+ * the risk of missing a parameter.
+ *
+ */
+
+extern void opt_conf_init(struct opt_conf *conf,
+                          struct opt_rule *rules, size_t n_rules,
+                          char *helpstr, optparse_tune tune,
+                          int (*arg_parser)(int, char *, void *),
+                          void *arg_parser_data);
+
+
+
+extern void set_parse_meta(struct opt_rule *rule, char short_id,
+                           const char *long_id, const char *desc);
+
+extern void set_parse_ignore(struct opt_rule *rule);
+extern void set_parse_ignore_sw(struct opt_rule *rule);
+extern void set_parse_help(struct opt_rule *rule);
+
+extern void set_parse_custom(struct opt_rule *rule,
+                             int (*callback)(char *, char *, void *, const char **),
+                             void *data);
+
+/* set_parse_*( struct opt_rule *rule, <type> *data) */
+
+extern void set_parse_int(struct opt_rule *rule, int *data);
+extern void set_parse_bool(struct opt_rule *rule, bool *data);
+extern void set_parse_bool_unset(struct opt_rule *rule, bool *data);
+extern void set_parse_double(struct opt_rule *rule, double *data);
+extern void set_parse_float(struct opt_rule *rule, float *data);
+extern void set_parse_str(struct opt_rule *rule, char * *data);
+extern void set_parse_str_nocopy(struct opt_rule *rule, char * *data);
+
+/** @} */
+
+#endif /* OPTPARSE_H */
+
+/** @} */

--- a/sys/include/optparse.h
+++ b/sys/include/optparse.h
@@ -130,13 +130,7 @@ enum OPTPARSE_RESULT {
  * Built-in actions for options.
  */
 enum OPTPARSE_ACTIONS {
-    OPTPARSE_IGNORE_SWITCH, /**< Ignore a switch. Takes 0 arguments */
     OPTPARSE_IGNORE,        /**< Ignore a key and its value. Takes 1 argument. */
-
-    OPTPARSE_SET_BOOL,      /**< Set opt_data::d_bool to true. Takes 0 arguments.*/
-    OPTPARSE_UNSET_BOOL,    /**< Set opt_data::d_bool to false. Takes 0 arguments.*/
-    OPTPARSE_COUNT,         /**< Count the number of occurences. Increments data::d_int
-                             *  each time the option is found. */
 
     OPTPARSE_CUSTOM_ACTION, /**< Delegate the action to a callback
                              * int _thin_callback(union opt_key key,
@@ -160,6 +154,13 @@ enum OPTPARSE_ACTIONS {
                              * copy of the string. It should not be used if the
                              * strings will be modified.
                              */
+    _OPTPARSE_MAX_NEEDS_VALUE_END, /**< Marker for the end of options that need a value.*/
+    OPTPARSE_IGNORE_SWITCH=_OPTPARSE_MAX_NEEDS_VALUE_END,
+                            /**< Ignore a switch. Takes 0 arguments */
+    OPTPARSE_SET_BOOL,      /**< Set opt_data::d_bool to true. Takes 0 arguments.*/
+    OPTPARSE_UNSET_BOOL,    /**< Set opt_data::d_bool to false. Takes 0 arguments.*/
+    OPTPARSE_COUNT,         /**< Count the number of occurences. Increments data::d_int
+                             *  each time the option is found. */
 
     OPTPARSE_DO_HELP,       /**< Print the following string, except if they are NULL:
                              * - opt_conf::helpstr
@@ -169,7 +170,9 @@ enum OPTPARSE_ACTIONS {
                              * In addition it causes the parser to exit with code
                              * OPTPARSE_REQHELP.
                              */
-    OPTPARSE_POSITIONAL,    /**< Indicates that the rule is a mandatory
+    _OPTPARSE_POSITIONAL_START,
+    OPTPARSE_POSITIONAL=_OPTPARSE_POSITIONAL_START,
+                                /**< Indicates that the rule is a mandatory
                                  positional argument and not an option. */
     OPTPARSE_POSITIONAL_OPT /**< Indicates that the rule is an optional
                                  positional argument and not an option. */

--- a/sys/include/optparse.h
+++ b/sys/include/optparse.h
@@ -132,7 +132,10 @@ enum OPTPARSE_ACTIONS {
     OPTPARSE_FLOAT,         /**< Parse the value as float and store it in *opt_rule.data.d_float */
 
     OPTPARSE_STR,           /**< Make a copy of the value string with strdup() and place it
-                             *  in *opt_rule.data.d_str. The string must be deallocated with free()
+                             *  in *opt_rule.data.d_str. The string must be deallocated with free().
+                             * It is suggested that the default value for this option is
+                             * NULL, so that it is easier to know afterwards if the pointer
+                             * should be freed.
                              */
 
     OPTPARSE_STR_NOCOPY,    /*! Place a pointer to the value string in data::d_cstr.

--- a/sys/include/optparse.h
+++ b/sys/include/optparse.h
@@ -157,10 +157,10 @@ enum OPTPARSE_ACTIONS {
  * Configuration rules for a single command line option.
  */
 typedef struct opt_rule {
+    enum OPTPARSE_ACTIONS action;  /**< Parsing type/action. See OPTPARSE_ACTIONS. */
     char short_id;          /**< Short style option name ("-w"). Can be OPTPARSE_NO_SHORT.*/
     const char *long_id;    /**< Long style option name ("--width") . Can be NULL */
     const char *desc;       /**< Help description. Can be NULL */
-    int action;             /**< Parsing type/action. See OPTPARSE_ACTIONS. */
     union {
         int *d_int;
         bool *d_bool;
@@ -207,7 +207,7 @@ typedef uint16_t optparse_tune; /**< Option bitfield */
  */
 typedef struct opt_conf {
     char *helpstr;          /**< Program's description and general help string. */
-    opt_rule_t *rules; /**< Array of options. */
+    opt_rule_t *rules;      /**< Array of options. */
     int n_rules;            /**< Number of elements in rules. */
     optparse_tune tune;     /**< Option bitfield. */
 

--- a/sys/include/optparse.h
+++ b/sys/include/optparse.h
@@ -206,7 +206,7 @@ typedef uint16_t optparse_tune; /**< Option bitfield */
  * Configuration for the command line parser.
  */
 typedef struct opt_conf {
-    char *helpstr;          /**< Program's description and general help string. */
+    const char *helpstr;          /**< Program's description and general help string. */
     opt_rule_t *rules;      /**< Array of options. */
     int n_rules;            /**< Number of elements in rules. */
     optparse_tune tune;     /**< Option bitfield. */

--- a/sys/include/optparse.h
+++ b/sys/include/optparse.h
@@ -16,29 +16,43 @@
  */
 
 /**
- * @{
  * @defgroup sys_optparse   Command line option parser.
  * @ingroup sys
- * @file
- * @brief  Command-line parser
- * @author Juan I Carrano <j.carrano@fu-berlin.de>
+ * @{
  *
- * Terminology:
+ * This module provides a generic way of describing and parsing command line
+ * arguments. Features:
+ *
+ * - Supports both short form ("-k") and long form ("--key") options.
+ * - Built-in parsers for most common options.
+ * - Automatically formats and prints a help string.
+ * - Supports custom parsers via callbacks.
+ *
+ * # Usage
+ *
+ * Initialize the required ::opt_conf_t and ::opt_rule_t structures and call
+ * optparse_cmd().
+ *
+ * # Terminology
  *
  * option: Optional value. Consists of a key an possibly a value. Each type of
  *         options has a predefined number of arguments it takes, and that may
  *         be either 0 or 1. Example:
  *              -v --number 5 -k hello
  *         Options (key, value): (v, none), (number, 5), (k, hello)
+ *
  * switch: An option taking 0 values.
+ *
  * argument: A value without a key. For example, in "-c 3 abcd", abcd is an
  *          argument.
+ *
  * short-option: Starts with a single dash and consists of a single character.
+ *
  * long-option: Starts with two dashes and consists of one or more characters
  *          (i.e. a string).
  *
  *
- * Tips for defining rules:
+ * # Tips for defining rules:
  *
  * 1. Make an enum with the name of the parameters:
  *    enum {HEIGHT, WIDTH, VERBOSE, ETC, .... , N_PARAMETERS }
@@ -57,6 +71,12 @@
  *      rules[HEIGHT] = (struct optparse){ .short_id = 'a', .long_id= ....etc ....};
  *      ```
  * 4. If none of those options is adequate, initializer functions are provided.
+ *
+ * @{
+ * @file
+ * @brief  Command-line parser
+ * @author Juan I Carrano <j.carrano@fu-berlin.de>
+ * @}
  */
 
 #ifndef OPTPARSE_H
@@ -75,8 +95,12 @@ extern "C" {
  */
 #define OPTPARSE_NO_SHORT '\0'
 
-/* Este es el idioma de generic_parser y amigos, y los callback deben usarlos
- * para indicar su exito o fracaso */
+/**
+ * Error codes used by optparse_cmd.
+ *
+ * User callbacks should use the same error codes. On error, a negative code
+ * is returned.
+ */
 enum OPTPARSE_RESULT {
     OPTPARSE_OK,            /**< Parsing suceeded */
     OPTPARSE_NOMEM,         /**< Not enough memory. Only OPTPARSE_STR or a
@@ -93,8 +117,8 @@ enum OPTPARSE_ACTIONS {
     OPTPARSE_IGNORE_SWITCH, /**< Ignore a switch. Takes 0 arguments */
     OPTPARSE_IGNORE,        /**< Ignore a key and its value. Takes 1 argument. */
 
-    OPTPARSE_SET_BOOL,      /**< Set opt_rule::data::d_bool to true. Takes 0 arguments.*/
-    OPTPARSE_UNSET_BOOL,    /**< Set opt_rule::data::d_bool to false. Takes 0 arguments.*/
+    OPTPARSE_SET_BOOL,      /**< Set *opt_rule.data.d_bool to true. Takes 0 arguments.*/
+    OPTPARSE_UNSET_BOOL,    /**< Set *opt_rule.data.d_bool to false. Takes 0 arguments.*/
     OPTPARSE_COUNT,         /**< Count the number of occurences. Increments data::d_int
                              *  each time the option is found. */
 
@@ -135,7 +159,6 @@ typedef struct opt_rule {
     const char *long_id;    /**< Long style option name ("--width") . Can be NULL */
     const char *desc;       /**< Help description. Can be NULL */
     int action;             /**< Parsing type/action. See OPTPARSE_ACTIONS. */
-    /** The parse results will be placed in this union depending on action */
     union {
         int *d_int;
         bool *d_bool;
@@ -158,7 +181,7 @@ typedef struct opt_rule {
             void *data;
             int (*callback)(const char *, const char *, void *, const char **);
         } d_custom;
-    } data;
+    } data; /**< The parse results will be placed in this union depending on action */
 } opt_rule_t;
 
 /**
@@ -176,7 +199,7 @@ enum OPTPARSE_TUNABLES {
 /** Should arguments be ignored if arg_parser is NULL? */
 #define OPTPARSE_NULL_ARGPARSER (1 << OPTPARSE_NULL_ARGPARSER_b)
 
-typedef uint16_t optparse_tune; /*! Option bitfield */
+typedef uint16_t optparse_tune; /**< Option bitfield */
 
 /**
  * Configuration for the command line parser.
@@ -235,17 +258,19 @@ int optparse_cmd(struct opt_conf *config, int argc, const char * const argv[]);
  *
  */
 
+/** Set general parser options */
 void opt_conf_init(struct opt_conf *conf,
                    struct opt_rule *rules, size_t n_rules,
                    char *helpstr, optparse_tune tune,
                    int (*arg_parser)(int, const char *, void *),
                    void *arg_parser_data);
 
-
-
+/** Set common options for a rule */
 void set_parse_meta(struct opt_rule *rule, char short_id,
                     const char *long_id, const char *desc);
 
+
+/** @{ */
 void set_parse_ignore(struct opt_rule *rule);
 void set_parse_ignore_sw(struct opt_rule *rule);
 void set_parse_help(struct opt_rule *rule);
@@ -262,7 +287,7 @@ void set_parse_double(struct opt_rule *rule, double *data);
 void set_parse_float(struct opt_rule *rule, float *data);
 void set_parse_str(struct opt_rule *rule, char **data);
 void set_parse_str_nocopy(struct opt_rule *rule, const char **data);
-
+/** @} */
 
 /** @} */
 

--- a/sys/include/optparse.h
+++ b/sys/include/optparse.h
@@ -2,7 +2,7 @@
  * optparse.h
  *
  * Copyright 2010 Juan I Carrano <juan@carrano.com.ar>
- * Copyright 2018 Freie Universität Berlin
+ * Copyright 2018-2019 Freie Universität Berlin
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -24,9 +24,21 @@
  * arguments. Features:
  *
  * - Supports both short form ("-k") and long form ("--key") options.
- * - Built-in parsers for most common options.
+ * - Supports both mandatory and optional positional arguments.
+ * - Built-in parsers for most common options/argument types.
  * - Automatically formats and prints a help string.
  * - Supports custom parsers via callbacks.
+ * - The parser specification is designed to be read-only so it can be
+ *   placed in the .text section of a binary (and in an MCU, into the FLASH).
+ *
+ * Limitations:
+ *
+ * - There is no way to tell that an option was not specified: options have
+ *   default value and it is generally not possible to tell this value apart
+ *   from a user supplied value.
+ * - When using custom actions, a character used as a short option key should
+ *   NOT be used as a long option key in another rule or else the user callback
+ *   will not be able to tell them apart (may or may not be an issue.)
  *
  * # Usage
  *
@@ -36,41 +48,44 @@
  * # Terminology
  *
  * option: Optional value. Consists of a key an possibly a value. Each type of
- *         options has a predefined number of arguments it takes, and that may
+ *         options has a predefined number of arguments it takes that may
  *         be either 0 or 1. Example:
  *              -v --number 5 -k hello
  *         Options (key, value): (v, none), (number, 5), (k, hello)
+ *         Options are identified by a string (or character) key.
  *
  * switch: An option taking 0 values.
  *
- * argument: A value without a key. For example, in "-c 3 abcd", abcd is an
- *          argument.
+ * (positional) argument: A value without a key. For example, in "-c 3 abcd",
+ *         abcd is an argument. Arguments can be either mandatory or optional
+ *         and are identified by an integer index. Because of this, optional
+ *         arguments must always come AFTER mandatory ones.
  *
  * short-option: Starts with a single dash and consists of a single character.
+ *         For example "-k 78", "-c", "-f filename".
  *
  * long-option: Starts with two dashes and consists of one or more characters
- *          (i.e. a string).
+ *          (i.e. a string). For example "--echo", "--factor 1.5".
  *
  *
  * # Tips for defining rules:
  *
- * 1. Make an enum with the name of the parameters:
+ * 1. Make an enum with the name of the parameters (options and arguments) and
+ *    with a last element marking its lebgth:
  *    enum {HEIGHT, WIDTH, VERBOSE, ETC, .... , N_PARAMETERS }
- * 2. Declare `struct opt_rule rules[N_PARAMETERS];`
- * 3. Initialize. This can't be done in the initalization because it would be
- *    necessary to know the values of pointers beforehand.
- *    The standard way would be:
+ * 2. Declare `const opt_rule_t rules[N_PARAMETERS];`
+ * 3. Initialize it. If your compiler supports specifying subobject in array and
+ *    struct/union initializers, they initializer macros can be used. These
+ *    provide a fail-safe way to construct an array (i.e. they ensure that the
+ *    correct tags and union elements are set:
  *      ```
- *      rules[HEIGHT].short_id = 'h';
- *      rules[HEIGHT].long_id = "height";
+ *      const struct opt_rule rules[N_PARAMETERS] = {
+ *      [WIDTH] = OPTPARSE_O_INT('w', "width", 640, "Display height in px"),
+ *      [HEIGHT] = OPTPARSE_O_INT('h', "height", 480, "Display height in px"),
  *      ... etc ...
+ *      }
  *      ```
- *    Alternatively, if the compiler supports compound literals and tags the
- *    following syntax can be used:
- *      ```
- *      rules[HEIGHT] = (struct optparse){ .short_id = 'a', .long_id= ....etc ....};
- *      ```
- * 4. If none of those options is adequate, initializer functions are provided.
+ * 4. Declare and initialize ::opt_conf_t.
  *
  * @{
  * @file
@@ -84,6 +99,7 @@
 
 #include <stdlib.h>
 #include <stdint.h>
+#include <limits.h>
 #include <stdbool.h>
 
 #ifdef __cplusplus
@@ -117,24 +133,26 @@ enum OPTPARSE_ACTIONS {
     OPTPARSE_IGNORE_SWITCH, /**< Ignore a switch. Takes 0 arguments */
     OPTPARSE_IGNORE,        /**< Ignore a key and its value. Takes 1 argument. */
 
-    OPTPARSE_SET_BOOL,      /**< Set *opt_rule.data.d_bool to true. Takes 0 arguments.*/
-    OPTPARSE_UNSET_BOOL,    /**< Set *opt_rule.data.d_bool to false. Takes 0 arguments.*/
+    OPTPARSE_SET_BOOL,      /**< Set opt_data::d_bool to true. Takes 0 arguments.*/
+    OPTPARSE_UNSET_BOOL,    /**< Set opt_data::d_bool to false. Takes 0 arguments.*/
     OPTPARSE_COUNT,         /**< Count the number of occurences. Increments data::d_int
                              *  each time the option is found. */
 
     OPTPARSE_CUSTOM_ACTION, /**< Delegate the action to a callback
-                             * int callback(char *key, char *value, void *data)
-                             * The callback and the data are placed in
-                             * opt_rule::data::d_custom
+                             * int _thin_callback(union opt_key key,
+                                                  const char *value,
+                                                  union opt_data *data,
+                                                  const char **msg)
                              */
-    OPTPARSE_INT,           /**< Parse the value as an int and store it in *opt_rule.data.d_int */
-    OPTPARSE_FLOAT,         /**< Parse the value as float and store it in *opt_rule.data.d_float */
+
+    // TODO: figure out if this is needed
+    //OPTPARSE_CUSTOM_ACTION_FAT, /**< */
+    OPTPARSE_UINT,          /**< Parse the value as an unsigned int and store it in opt_data::d_uint */
+    OPTPARSE_INT,           /**< Parse the value as an int and store it in opt_data::d_int */
+    OPTPARSE_FLOAT,         /**< Parse the value as float and store it in opt_data::d_float */
 
     OPTPARSE_STR,           /**< Make a copy of the value string with strdup() and place it
-                             *  in *opt_rule.data.d_str. The string must be deallocated with free().
-                             * It is suggested that the default value for this option is
-                             * NULL, so that it is easier to know afterwards if the pointer
-                             * should be freed.
+                             *  in data::d_str. The string must be deallocated with free().
                              */
 
     OPTPARSE_STR_NOCOPY,    /*! Place a pointer to the value string in data::d_cstr.
@@ -143,7 +161,7 @@ enum OPTPARSE_ACTIONS {
                              * strings will be modified.
                              */
 
-    OPTPARSE_DO_HELP        /**< Print the following string, except if they are NULL:
+    OPTPARSE_DO_HELP,       /**< Print the following string, except if they are NULL:
                              * - opt_conf::helpstr
                              * - For each element of opt_conf::opt_rule:
                              * short_id (tab) long_id (tab) desc
@@ -151,39 +169,123 @@ enum OPTPARSE_ACTIONS {
                              * In addition it causes the parser to exit with code
                              * OPTPARSE_REQHELP.
                              */
+    OPTPARSE_POSITIONAL,    /**< Indicates that the rule is a mandatory
+                                 positional argument and not an option. */
+    OPTPARSE_POSITIONAL_OPT /**< Indicates that the rule is an optional
+                                 positional argument and not an option. */
 };
+
+/**
+ * Built-in actions for positional arguments.
+ *
+ * These are a subset of the actions for options.
+ */
+enum OPTPARSE_POSITIONAL_ACTIONS {
+    OPTPARSE_POS_IGNORE = OPTPARSE_IGNORE,
+    OPTPARSE_POS_COUNT = OPTPARSE_COUNT,
+    OPTPARSE_POS_CUSTOM_ACTION = OPTPARSE_CUSTOM_ACTION,
+//    OPTPARSE_POS_CUSTOM_ACTION_FAT = OPTPARSE_CUSTOM_ACTION_FAT,
+    OPTPARSE_POS_UINT = OPTPARSE_UINT,
+    OPTPARSE_POS_INT = OPTPARSE_INT,
+    OPTPARSE_POS_FLOAT = OPTPARSE_FLOAT,
+    OPTPARSE_POS_STR = OPTPARSE_STR,
+    OPTPARSE_POS_STR_NOCOPY = OPTPARSE_STR_NOCOPY,
+};
+
+/** Maximum number of positional arguments supported. */
+#define OPTPARSE_MAX_POSITIONAL UCHAR_MAX
+
+/**
+ * Identify a positional argument.
+ */
+struct opt_positionalkey {
+    unsigned char position; /**< Position (counting from zero) of this argument.
+                                 Note that options do not contribute to this count
+                                 Whether argv[0] is counted depends on the status
+                                 of OPTPARSE_IGNORE_ARGV0.*/
+    const char *name;       /**< User-supplied name of this arguments (from
+                                 opt_rule_t::name .*/
+};
+
+struct opt_optionkey;
+
+/**
+ * Structure to inform user callbacks of the argument or option being
+ * parsed.
+ */
+union opt_key {
+    const struct opt_positionalkey *argument;
+    const struct opt_optionkey *option;
+};
+
+/**
+ * Value type for options and arguments.
+ */
+typedef union opt_data {
+    int d_int;
+    unsigned int d_uint;
+    bool d_bool;
+    float d_float;
+    char *d_str;           /**< Pointer to a string */
+    const char *d_cstr;    /**< Pointer to a string, constant variant */
+    void *data;            /**< Generic data for custom parsers. */
+
+    /**
+     * Callback for user defined actions.
+     *
+     * Prototype:
+     *  int _thin_callback(union opt_key key,
+     *                     const char *value,
+     *                     union opt_data *data, const char **msg)
+     *
+     * When parsing an option, key.option will point to a struct holding the
+     * short and long option keys. When parsing a positional argument
+     * key.option will point to a opt_positionalkey structure holding the index
+     * and the name.
+     *
+     * The callback must return a non-negative value to indicate success.
+     * It should place the result of the conversion in *data.
+     *
+     * During the initialization procedure, it will be called with a NULL
+     * valued data to set the default value. After this, data will never be
+     * NULL.
+     *
+     * The callback can place a message into msg and it will get printed to
+     * the error stream (without causing an error if the result value is not
+     * negative).
+     */
+    int (*_thin_callback)(union opt_key, const char *, union opt_data *,
+                          const char **);
+} opt_data_t;
+
 
 /**
  * Configuration rules for a single command line option.
  */
 typedef struct opt_rule {
     enum OPTPARSE_ACTIONS action;  /**< Parsing type/action. See OPTPARSE_ACTIONS. */
-    char short_id;          /**< Short style option name ("-w"). Can be OPTPARSE_NO_SHORT.*/
-    const char *long_id;    /**< Long style option name ("--width") . Can be NULL */
-    const char *desc;       /**< Help description. Can be NULL */
+
     union {
-        int *d_int;
-        bool *d_bool;
-        float *d_float;
-        char **d_str;              /**< Pointer to a user-defined pointer */
-        const char **d_cstr;       /**< Pointer to a user-defined pointer, constant variant */
-        /**
-         * Callback for user defined actions.
-         *
-         * Prototype:
-         *  int callback(const char *key, const char *value,
-         *               void *data, const char **msg)
-         *
-         * The callback must return a non-negative value to indicate success.
-         * The callback can place a message into msg and it will get printed to
-         * the error stream (without causing an error).
-         */
+        /** If the action is OPTPARSE_POSITIONAL or OPTPARSE_POSITIONAL_OPT,
+            this should hold the required action. */
         struct {
-            void *data;
-            int (*callback)(const char *, const char *, void *, const char **);
-        } d_custom;
-    } data; /**< The parse results will be placed in this union depending on action */
+            enum OPTPARSE_POSITIONAL_ACTIONS pos_action;
+            const char *name;
+        } argument;
+
+        /** If this rule is for an option (not a positional argument) this
+            should hold the option keys.*/
+        struct opt_optionkey {
+            char short_id;          /**< Short style option name ("-w"). Can be OPTPARSE_NO_SHORT.*/
+            const char *long_id;    /**< Long style option name ("--width") . Can be NULL */
+        } option;
+    } action_data;      /**< Keys for options, action type for positional args*/
+    const char *desc;   /**< Help description. Can be NULL */
+
+    opt_data_t default_value; /**< Value for when the option is not given. */
 } opt_rule_t;
+
+// /**< The parse results will be placed in this union depending on action */
 
 /**
  * Options that control the behavior of the option parser.
@@ -192,13 +294,14 @@ typedef struct opt_rule {
  */
 enum OPTPARSE_TUNABLES {
     OPTPARSE_IGNORE_ARGV0_b,
-    OPTPARSE_NULL_ARGPARSER_b
+    OPTPARSE_COLLECT_LAST_POS_b,
 };
 
 /** Should argv[0] be skipped? */
 #define OPTPARSE_IGNORE_ARGV0 (1 << OPTPARSE_IGNORE_ARGV0_b)
-/** Should arguments be ignored if arg_parser is NULL? */
-#define OPTPARSE_NULL_ARGPARSER (1 << OPTPARSE_NULL_ARGPARSER_b)
+/** If this flag is set, the last positional argument rule is applied to all
+    extra positional arguments (i.e. it "collects" them all) */
+#define OPTPARSE_COLLECT_LAST_POS (1 << OPTPARSE_COLLECT_LAST_POS_b)
 
 typedef uint16_t optparse_tune; /**< Option bitfield */
 
@@ -206,22 +309,10 @@ typedef uint16_t optparse_tune; /**< Option bitfield */
  * Configuration for the command line parser.
  */
 typedef struct opt_conf {
-    const char *helpstr;          /**< Program's description and general help string. */
-    opt_rule_t *rules;      /**< Array of options. */
+    const char *helpstr;    /**< Program's description and general help string. */
+    const opt_rule_t *rules;      /**< Array of options. */
     int n_rules;            /**< Number of elements in rules. */
     optparse_tune tune;     /**< Option bitfield. */
-
-    /**
-     * int arg_parser(int current_index, const char *value, void *userdata)
-     *
-     * This function will be called each time an value without a key (i.e.
-     * an argument) is found. The first parameter (current_index) indicates the
-     * position if the argument and is useful for identifying argv[0].
-     * arg_parser can be NULL. In that case, finding an argument will generate
-     * an error, unless OPTPARSE_NULL_ARGPARSER is set.
-     */
-    int (*arg_parser)(int, const char *, void *);
-    void *arg_parser_data; /**< Callback data for arg_parser. */
 } opt_conf_t;
 
 /**
@@ -238,15 +329,33 @@ typedef struct opt_conf {
  * Dash handling:
  *
  * A double dash (--) indicates the parser that there are no more  options/
- * switches and all the remaining command line arguments are sent to
- * arg_parser.
+ * switches and all the remaining command line arguments are to be interpreted
+ * as positional arguments
  *
- * A single dash is interpreted as an argument and sent to arg_parser.
+ * A single dash is interpreted as a positional argument argument.
  *
- * @return  non-negative on sucess
+ * Optional positional arguments:
+ *
+ * Optional positional arguments MUST follow mandatory arguments. The n-th
+ * optional argument cannot be set if the (n-1)th optional argument is not
+ * set.
+ *
+ * @return  Number of positional arguments converted.
  * @return  A negative error code from OPTPARSE_RESULT on error.
  */
-int optparse_cmd(struct opt_conf *config, int argc, const char * const argv[]);
+int optparse_cmd(const struct opt_conf *config,
+                 union opt_data *result,
+                 int argc, const char * const argv[]);
+
+/**
+ * Free all strings allocated by OPTPARSE_STR and OPTPARSE_POS_STR.
+ *
+ * Note that on a parsing error all strings are automatically deallocated.
+ *
+ * This procedure will set all d_str fields to NULL, so it is safe to call
+ * it more than once.
+ */
+void optparse_free_strings(const opt_conf_t *config, opt_data_t *result);
 
 /**
  * @defgroup sys_optparse_initializers  Optparse initializers
@@ -256,41 +365,68 @@ int optparse_cmd(struct opt_conf *config, int argc, const char * const argv[]);
  *
  * These initializers can be used to safely construct configurations, without
  * the risk of missing a parameter.
- *
  */
 
-/** Set general parser options */
-void opt_conf_init(struct opt_conf *conf,
-                   struct opt_rule *rules, size_t n_rules,
-                   char *helpstr, optparse_tune tune,
-                   int (*arg_parser)(int, const char *, void *),
-                   void *arg_parser_data);
+#define _OPTPARSE_IGNORE_SWITCH_INIT    d_int
+#define _OPTPARSE_IGNORE_INIT           d_int
+#define _OPTPARSE_SET_BOOL_INIT         d_bool
+#define _OPTPARSE_UNSET_BOOL_INIT       d_bool
+#define _OPTPARSE_COUNT_INIT            d_int
+#define _OPTPARSE_CUSTOM_ACTION_INIT    _thin_callback
+#define _OPTPARSE_UINT_INIT             d_uint
+#define _OPTPARSE_INT_INIT              d_int
+#define _OPTPARSE_FLOAT_INIT            d_float
+#define _OPTPARSE_STR_INIT              d_str
+#define _OPTPARSE_STR_NOCOPY_INIT       d_cstr
+#define _OPTPARSE_DO_HELP_INIT          d_int
 
-/** Set common options for a rule */
-void set_parse_meta(struct opt_rule *rule, char short_id,
-                    const char *long_id, const char *desc);
+/**
+ * Declare an option.
+ *
+ * type must be a member of OPTPARSE_ACTIONS, with the "OPTPARSE_" prefix
+ * removed. For example:
+ *
+ * OPTPARSE_O(SET_BOOL, 's', "set", "Set a flag 's'", false)
+ */
+#define OPTPARSE_O(type, short_, long_, description, default_value_) \
+    {.action=OPTPARSE_##type, .action_data.option.short_id=(short_), \
+     .action_data.option.long_id=(long_), .desc=(description), \
+     .default_value._OPTPARSE_##type##_INIT = (default_value_)}
 
+#define _OPTPARSE_P(type0, type, name_, description, default_value_) \
+    {.action=(type0), .action_data.argument.pos_action = OPTPARSE_POS_##type, \
+     .action_data.argument.name=(name_), .desc=(description), \
+     .default_value._OPTPARSE_##type##_INIT = (default_value_)}
 
-/** @{ */
-void set_parse_ignore(struct opt_rule *rule);
-void set_parse_ignore_sw(struct opt_rule *rule);
-void set_parse_help(struct opt_rule *rule);
+/**
+ * Declare a mandatory positional argument.
+ *
+ * type must be a member of OPTPARSE_POS_ACTIONS, with the "OPTPARSE_POS" prefix
+ * removed. For example:
+ *
+ * OPTPARSE_P(STR_NOCOPY, "filename", "Output file", "whatever.out")
+ */
+#define OPTPARSE_P(type, name, description, default_value) \
+    _OPTPARSE_P(OPTPARSE_POSITIONAL, type, name, description, default_value)
 
-void set_parse_custom(struct opt_rule *rule,
-                      int (*callback)(const char *, const char *, void *, const char **),
-                      void *data);
+/**
+ * Declare an optional positional argument.
+ *
+ * Like OPTPARSE_P, but it is not an error if the argument is missing.
+ * Remember that optional arguments MUST come after mandatory ones on the
+ * opt_conf::rules array.
+ */
+#define OPTPARSE_P_OPT(type, name, description, default_value) \
+    _OPTPARSE_P(OPTPARSE_POSITIONAL_OPT, type, name, description, default_value)
 
-void set_parse_int(struct opt_rule *rule, int *data);
-void set_parse_bool(struct opt_rule *rule, bool *data);
-void set_parse_bool_unset(struct opt_rule *rule, bool *data);
-void set_parse_count(struct opt_rule *rule, int *data);
-void set_parse_float(struct opt_rule *rule, float *data);
-void set_parse_str(struct opt_rule *rule, char **data);
-void set_parse_str_nocopy(struct opt_rule *rule, const char **data);
 /** @} */
 
-/** @} */
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* OPTPARSE_H */
 
 /** @} */
+
+

--- a/sys/include/optparse.h
+++ b/sys/include/optparse.h
@@ -128,7 +128,6 @@ enum OPTPARSE_ACTIONS {
                              * opt_rule::data::d_custom
                              */
     OPTPARSE_INT,           /**< Parse the value as an int and store it in *opt_rule.data.d_int */
-    OPTPARSE_DOUBLE,        /**< Parse the value as double and store it in *opt_rule.data.d_double */
     OPTPARSE_FLOAT,         /**< Parse the value as float and store it in *opt_rule.data.d_float */
 
     OPTPARSE_STR,           /**< Make a copy of the value string with strdup() and place it
@@ -165,7 +164,6 @@ typedef struct opt_rule {
     union {
         int *d_int;
         bool *d_bool;
-        double *d_double;
         float *d_float;
         char **d_str;              /**< Pointer to a user-defined pointer */
         const char **d_cstr;       /**< Pointer to a user-defined pointer, constant variant */
@@ -286,7 +284,6 @@ void set_parse_int(struct opt_rule *rule, int *data);
 void set_parse_bool(struct opt_rule *rule, bool *data);
 void set_parse_bool_unset(struct opt_rule *rule, bool *data);
 void set_parse_count(struct opt_rule *rule, int *data);
-void set_parse_double(struct opt_rule *rule, double *data);
 void set_parse_float(struct opt_rule *rule, float *data);
 void set_parse_str(struct opt_rule *rule, char **data);
 void set_parse_str_nocopy(struct opt_rule *rule, const char **data);

--- a/sys/include/optparse.h
+++ b/sys/include/optparse.h
@@ -1,13 +1,18 @@
 /*
- *      optparse.h
+ * optparse.h
  *
- *      Copyright 2010 Juan I Carrano <juan@carrano.com.ar>
- *      Copyright 2018 Freie Universität Berlin
+ * Copyright 2010 Juan I Carrano <juan@carrano.com.ar>
+ * Copyright 2018 Freie Universität Berlin
  *
- *      This program is free software; you can redistribute it and/or modify
- *      it under the terms of the GNU General Public License as published by
- *      the Free Software Foundation; either version 2 of the License, or
- *      (at your option) any later version.
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  */
 
 /**
@@ -60,6 +65,10 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * Used to indicate that an option has no short (i.e. single character) variant.
@@ -121,7 +130,7 @@ enum OPTPARSE_ACTIONS {
 /**
  * Configuration rules for a single command line option.
  */
-struct opt_rule {
+typedef struct opt_rule {
     char short_id;          /**< Short style option name ("-w"). Can be OPTPARSE_NO_SHORT.*/
     const char *long_id;    /**< Long style option name ("--width") . Can be NULL */
     const char *desc;       /**< Help description. Can be NULL */
@@ -148,7 +157,7 @@ struct opt_rule {
             int (*callback)(char *, char *, void *, const char **);
         } d_custom;
     } data;
-};
+} opt_rule_t;
 
 /**
  * Options that control the behavior of the option parser.
@@ -170,9 +179,9 @@ typedef uint16_t optparse_tune; /*! Option bitfield */
 /**
  * Configuration for the command line parser.
  */
-struct opt_conf {
+typedef struct opt_conf {
     char *helpstr;          /**< Program's description and general help string. */
-    struct opt_rule *rules; /**< Array of options. */
+    opt_rule_t *rules; /**< Array of options. */
     int n_rules;            /**< Number of elements in rules. */
     optparse_tune tune;     /**< Option bitfield. */
 
@@ -187,7 +196,7 @@ struct opt_conf {
      */
     int (*arg_parser)(int, char *, void *);
     void *arg_parser_data; /**< Callback data for arg_parser. */
-};
+} opt_conf_t;
 
 /**
  * Main interface to the option parser.
@@ -211,7 +220,7 @@ struct opt_conf {
  * @return  non-negative on sucess
  * @return  A negative error code from OPTPARSE_RESULT on error.
  */
-extern int optparse_cmd(struct opt_conf *config, int argc, char *argv[]);
+int optparse_cmd(struct opt_conf *config, int argc, char *argv[]);
 
 /**
  * @defgroup sys_optparse_initializers  Optparse initializers
@@ -224,7 +233,7 @@ extern int optparse_cmd(struct opt_conf *config, int argc, char *argv[]);
  *
  */
 
-extern void opt_conf_init(struct opt_conf *conf,
+void opt_conf_init(struct opt_conf *conf,
                           struct opt_rule *rules, size_t n_rules,
                           char *helpstr, optparse_tune tune,
                           int (*arg_parser)(int, char *, void *),
@@ -232,26 +241,24 @@ extern void opt_conf_init(struct opt_conf *conf,
 
 
 
-extern void set_parse_meta(struct opt_rule *rule, char short_id,
-                           const char *long_id, const char *desc);
+void set_parse_meta(struct opt_rule *rule, char short_id,
+                    const char *long_id, const char *desc);
 
-extern void set_parse_ignore(struct opt_rule *rule);
-extern void set_parse_ignore_sw(struct opt_rule *rule);
-extern void set_parse_help(struct opt_rule *rule);
+void set_parse_ignore(struct opt_rule *rule);
+void set_parse_ignore_sw(struct opt_rule *rule);
+void set_parse_help(struct opt_rule *rule);
 
-extern void set_parse_custom(struct opt_rule *rule,
+void set_parse_custom(struct opt_rule *rule,
                              int (*callback)(char *, char *, void *, const char **),
                              void *data);
 
-/* set_parse_*( struct opt_rule *rule, <type> *data) */
-
-extern void set_parse_int(struct opt_rule *rule, int *data);
-extern void set_parse_bool(struct opt_rule *rule, bool *data);
-extern void set_parse_bool_unset(struct opt_rule *rule, bool *data);
-extern void set_parse_double(struct opt_rule *rule, double *data);
-extern void set_parse_float(struct opt_rule *rule, float *data);
-extern void set_parse_str(struct opt_rule *rule, char * *data);
-extern void set_parse_str_nocopy(struct opt_rule *rule, char * *data);
+void set_parse_int(struct opt_rule *rule, int *data);
+void set_parse_bool(struct opt_rule *rule, bool *data);
+void set_parse_bool_unset(struct opt_rule *rule, bool *data);
+void set_parse_double(struct opt_rule *rule, double *data);
+void set_parse_float(struct opt_rule *rule, float *data);
+void set_parse_str(struct opt_rule *rule, char * *data);
+void set_parse_str_nocopy(struct opt_rule *rule, char * *data);
 
 /** @} */
 

--- a/sys/optparse/Makefile
+++ b/sys/optparse/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/optparse/optparse.c
+++ b/sys/optparse/optparse.c
@@ -100,9 +100,9 @@ const uint16_t need_value_mask = _MSK(OPTPARSE_IGNORE)
  *
  * If it does not start with a dash, returns null.
  */
-static char *strip_dash(char stri[])
+static const char *strip_dash(const char stri[])
 {
-    char *ret = NULL;
+    const char *ret = NULL;
 
     if (stri[0] == OPT) {
         ret = &stri[1];
@@ -113,7 +113,7 @@ static char *strip_dash(char stri[])
 /**
  * Return true if the string is not null and not empty.
  */
-static bool str_notempty(char *str)
+static bool str_notempty(const char *str)
 {
     return str != NULL && str[0] != TERM;
 }
@@ -146,7 +146,7 @@ static void do_help(const opt_conf_t *config)
  *
  * @return  An exit code from OPTPARSE_RESULT.
  */
-static int do_action(opt_rule_t *rule, char *key, char *value)
+static int do_action(opt_rule_t *rule, const char *key, const char *value)
 {
     int ret = OPTPARSE_OK;
     char *copied_str = NULL;
@@ -165,7 +165,7 @@ static int do_action(opt_rule_t *rule, char *key, char *value)
             LOAD_VAR(rule->data.d_float, strtof(value, NULL));
             break;
         case OPTPARSE_STR_NOCOPY:
-            LOAD_VAR(rule->data.d_str, value);
+            LOAD_VAR(rule->data.d_cstr, value);
             break;
         case OPTPARSE_SET_BOOL:
             LOAD_VAR(rule->data.d_bool, true);
@@ -215,7 +215,7 @@ static int do_action(opt_rule_t *rule, char *key, char *value)
  *
  * A short id of 0 never matches. A NULL long id never matches.
  */
-static opt_rule_t *find_rule(opt_conf_t *config, char *long_id,
+static opt_rule_t *find_rule(opt_conf_t *config, const char *long_id,
                              char short_id)
 {
     int rule_i;
@@ -232,17 +232,17 @@ static opt_rule_t *find_rule(opt_conf_t *config, char *long_id,
     return NULL;
 }
 
-int optparse_cmd(opt_conf_t *config, int argc, char *argv[])
+int optparse_cmd(opt_conf_t *config, int argc, const char * const argv[])
 {
     int error = 0, i, no_more_options = 0;
     /* Used for handling combined switches like -axf (equivalent to -a -x -f)
      * Instead of advancing argv, we keep reading from the string*/
-    char *pending_opt = NULL;
+    const char *pending_opt = NULL;
 
     i = (config->tune & OPTPARSE_IGNORE_ARGV0) ? 1 : 0;
 
     while (error >= OPTPARSE_OK && i < argc) {
-        char *key, *value;
+        const char *key, *value;
 
         if (!no_more_options
             && ((pending_opt != NULL)
@@ -252,7 +252,7 @@ int optparse_cmd(opt_conf_t *config, int argc, char *argv[])
             opt_rule_t *curr_rule;
 
             if (pending_opt == NULL) {
-                char *tmp_key;
+                const char *tmp_key;
                 is_long = (tmp_key = strip_dash(key)) != NULL;
 
                 if (is_long) {
@@ -332,7 +332,7 @@ parse_loop_end:
 
 void opt_conf_init(opt_conf_t *conf,
                    opt_rule_t *rules, size_t n_rules, char *helpstr,
-                   optparse_tune tune, int (*arg_parser)(int, char *, void *),
+                   optparse_tune tune, int (*arg_parser)(int, const char *, void *),
                    void *arg_parser_data)
 {
     conf->helpstr = helpstr;
@@ -364,7 +364,7 @@ void set_parse_meta(opt_rule_t *rule, char short_id, const char *long_id,
     }
 
 void set_parse_custom(opt_rule_t *rule,
-                      int (*callback)(char *, char *, void *, const char **), void *data)
+                      int (*callback)(const char *, const char *, void *, const char **), void *data)
 {
     SET_ACTION(rule, OPTPARSE_CUSTOM_ACTION);
     rule->data.d_custom.callback = callback;
@@ -382,6 +382,6 @@ MK_SETTER1(set_parse_bool, OPTPARSE_SET_BOOL, bool, d_bool)
 MK_SETTER1(set_parse_bool_unset, OPTPARSE_UNSET_BOOL, bool, d_bool)
 MK_SETTER1(set_parse_count, OPTPARSE_COUNT, int, d_int)
 MK_SETTER1(set_parse_str, OPTPARSE_STR, char *, d_str)
-MK_SETTER1(set_parse_str_nocopy, OPTPARSE_STR_NOCOPY, char *, d_str)
+MK_SETTER1(set_parse_str_nocopy, OPTPARSE_STR_NOCOPY, const char *, d_cstr)
 
 /** @} */

--- a/sys/optparse/optparse.c
+++ b/sys/optparse/optparse.c
@@ -317,7 +317,7 @@ int optparse_cmd(opt_conf_t *config, int argc, const char * const argv[])
         }
         else {
             P_ERR("Argument %s missing key\n", argv[i] );
-            if (config->tune & OPTPARSE_NULL_ARGPARSER) {
+            if (!(config->tune & OPTPARSE_NULL_ARGPARSER)) {
                 error = -OPTPARSE_BADSYNTAX; /* BYE! <===========> */
             }
         }

--- a/sys/optparse/optparse.c
+++ b/sys/optparse/optparse.c
@@ -32,8 +32,6 @@
 
 #include "optparse.h"
 
-#define DEVELHELP
-
 #define TERM '\0'   /**< String terminator character */
 #define OPT '-'     /**< The character that marks an option */
 
@@ -186,20 +184,22 @@ static void do_help(const opt_conf_t *config)
  */
 static bool sanity_check(const opt_conf_t *config)
 {
-   int rule_i;
-   bool found_optional = false;
+    int rule_i;
+    bool found_optional = false;
 
     for (rule_i = 0; rule_i < config->n_rules; rule_i++) {
         bool is_positional = _is_argument(config->rules[rule_i].action);
         bool is_optional = _is_optional(config->rules[rule_i].action);
 
-        if (!is_positional)
+        if (!is_positional) {
             continue;
+        }
 
-        if (found_optional && !is_optional)
+        if (found_optional && !is_optional) {
             return false;
+        }
 
-        found_optional = found_optional || !is_optional;
+        found_optional = found_optional || is_optional;
     }
 
     return true;

--- a/sys/optparse/optparse.c
+++ b/sys/optparse/optparse.c
@@ -355,7 +355,7 @@ static const opt_rule_t *find_arg_rule(const opt_conf_t *config, int arg_n)
     int rule_i;
     int last_handler;
     int handlers_found = 0;
-    bool repeat_last = !!(config->tune | OPTPARSE_COLLECT_LAST_POS);
+    bool repeat_last = !!(config->tune & OPTPARSE_COLLECT_LAST_POS);
 
     for (rule_i = 0; rule_i < config->n_rules; rule_i++) {
         const opt_rule_t this_rule = config->rules[rule_i];

--- a/sys/optparse/optparse.c
+++ b/sys/optparse/optparse.c
@@ -1,0 +1,360 @@
+/*
+ *      optparse.c
+ *
+ *      Copyright 2010 Juan I Carrano <juan@carrano.com.ar>
+ *		Copyright 2018 Freie Universität Berlin
+ *
+ *      This program is free software; you can redistribute it and/or modify
+ *      it under the terms of the GNU General Public License as published by
+ *      the Free Software Foundation; either version 2 of the License, or
+ *      (at your option) any later version.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "../optparse.h"
+
+#define TERM '\0'
+#define ERROR 0
+#define OPT '-'
+
+#define P_ERR(...) fprintf(stderr, __VA_ARGS__)
+#define STR_ERR(s) fputs(s, stderr)
+
+#ifndef DEBUG
+
+#define P_DEBUG(...)
+#define LOAD_VAR(var, value) do { if ((var) != NULL) { *(var) = value; } } while (0)
+
+#else /* DEBUG */
+
+#define P_DEBUG P_ERR
+#define LOAD_VAR(var, value) do { if ((var) != NULL) { *(var) = value; } \
+                                  else { P_DEBUG("Warning! NULL pointer:" #var "%c\n", ' '); } } while (0)
+
+#endif /*DEBUG */
+
+#define HELP_STREAM stdout /* TODO: remove this */
+
+#define SAFE_FPUTS(str, stream) (((str) != NULL) ? fputs(str, stream) : 0)
+#define SAFE_FPUTC(c, stream) ((c != TERM) ? fputc(c, stream) : 0)
+
+#if (_XOPEN_SOURCE >= 500) || (_POSIX_C_SOURCE > 200809L)
+#define my_strdup strdup
+#else
+
+char *my_strdup(const char *s)
+{
+    char *dup;
+    int len = strlen(s) + 1;
+
+    if ((dup = malloc(len)) != NULL) {
+        memcpy(dup, s, len);
+    }
+
+    return dup;
+}
+
+#endif /* no posix source */
+
+#define _MSK(x) (1 << (x))
+const uint16_t need_value_mask = _MSK(OPTPARSE_IGNORE)
+                                 | _MSK(OPTPARSE_CUSTOM_ACTION) | _MSK(OPTPARSE_INT)
+                                 | _MSK(OPTPARSE_DOUBLE) | _MSK(OPTPARSE_FLOAT)
+                                 | _MSK(OPTPARSE_STR) | _MSK(OPTPARSE_STR_NOCOPY);
+
+#define NEEDS_VALUE(rule) (!!(_MSK((rule)->action) & need_value_mask))
+
+/**
+ * If the string stri starts with a dash, remove it and return a string to
+ * the part after the dash.
+ *
+ * If it does not start with a dash, returns null.
+ */
+static char *strip_dash(char stri[])
+{
+    char *ret = NULL;
+
+    if (stri[0] == OPT) {
+        ret = &stri[1];
+    }
+    return ret;
+}
+
+/**
+ * Return true if the string is not null and not empty.
+ */
+static bool str_notempty(char *str)
+{
+    return str != NULL && str[0] != TERM;
+}
+
+/* TODO: make help stream into an argument */
+static void do_help(const struct opt_conf *config)
+{
+    int rule_i;
+
+    SAFE_FPUTS(config->helpstr, HELP_STREAM);
+    SAFE_FPUTC('\n', HELP_STREAM);
+    for (rule_i = 0; rule_i < config->n_rules; rule_i++) {
+        SAFE_FPUTC('-', HELP_STREAM);
+        SAFE_FPUTC(config->rules[rule_i].short_id, HELP_STREAM);
+        SAFE_FPUTS("\t--", HELP_STREAM);
+        SAFE_FPUTS(config->rules[rule_i].long_id, HELP_STREAM);
+        SAFE_FPUTC('\t', HELP_STREAM);
+        SAFE_FPUTS(config->rules[rule_i].desc, HELP_STREAM);
+        SAFE_FPUTC('\n', HELP_STREAM);
+    }
+}
+
+/**
+ * Execute the action associated with an argument.
+ *
+ * key is only used for custom commands.
+ * value is only used for commands that need it.
+ * This assumes key and value are not null if they should not be.
+ *
+ * @return	An exit code from OPTPARSE_RESULT.
+ */
+static int do_action(struct opt_rule *rule, char *key, char *value)
+{
+    int ret = OPTPARSE_OK;
+    char *copied_str = NULL;
+    const char *custom_message = NULL;
+
+    switch (rule->action) {
+        case OPTPARSE_IGNORE: case OPTPARSE_IGNORE_SWITCH:
+            break;
+        case OPTPARSE_INT:
+            LOAD_VAR(rule->data.d_int, strtol(value, NULL, 0));
+            break;
+        case OPTPARSE_DOUBLE:
+            LOAD_VAR(rule->data.d_double, strtod(value, NULL));
+            break;
+        case OPTPARSE_FLOAT:
+            LOAD_VAR(rule->data.d_float, strtof(value, NULL));
+            break;
+        case OPTPARSE_STR_NOCOPY:
+            LOAD_VAR(rule->data.d_str, value);
+            break;
+        case OPTPARSE_SET_BOOL:
+            LOAD_VAR(rule->data.d_bool, true);
+            break;
+        case OPTPARSE_UNSET_BOOL:
+            LOAD_VAR(rule->data.d_bool, false);
+            break;
+        case OPTPARSE_COUNT:
+            LOAD_VAR(rule->data.d_int, *rule->data.d_int + 1);
+            break;
+        case OPTPARSE_STR:
+            if (rule->data.d_str != NULL && (copied_str = my_strdup(value)) != NULL) {
+                *rule->data.d_str = copied_str;
+            }
+            else {
+                P_DEBUG("OPTPARSE_STR failed: d_str: %p,", (void *)rule->data.d_str);
+                P_DEBUG(" copied_str %p\n", copied_str);
+                if (rule->data.d_str == NULL) {
+                    ret = -OPTPARSE_BADCONFIG;
+                }
+                else {
+                    ret = -OPTPARSE_NOMEM;
+                }
+            }
+            break;
+        case OPTPARSE_DO_HELP:
+            P_DEBUG("do_action found OPTPARSE_DO_HELP\n");
+            break; /*this is a meta-action and has to be implemented in generic_parser*/
+        case OPTPARSE_CUSTOM_ACTION:
+            ret = rule->data.d_custom.callback(key, value,
+                                               rule->data.d_custom.data, &custom_message);
+            if (custom_message != NULL) {
+                STR_ERR(custom_message);
+            }
+            break;
+        default:
+            P_DEBUG("Unknown action: %d\n", rule->action);
+            ret = -OPTPARSE_BADCONFIG;
+            break;
+    }
+
+    return ret;
+}
+
+/**
+ * Find a rule with the given short id or long id.
+ *
+ * A short id of 0 never matches. A NULL long id never matches.
+ */
+static struct opt_rule *find_rule(struct opt_conf *config, char *long_id,
+                                  char short_id)
+{
+    int rule_i;
+
+    for (rule_i = 0; rule_i < config->n_rules; rule_i++) {
+        if ((short_id
+             && config->rules[rule_i].short_id == short_id)
+            || ((long_id != NULL) && (config->rules[rule_i].long_id != NULL)
+                && strcmp(long_id, config->rules[rule_i].long_id) == 0)) {
+            return config->rules + rule_i;
+        }
+    }
+
+    return NULL;
+}
+
+int optparse_cmd(struct opt_conf *config, int argc, char *argv[])
+{
+    int error = 0, i, no_more_options = 0;
+    /* Used for handling combined switches like -axf (equivalent to -a -x -f)
+     * Instead of advancing argv, we keep reading from the string*/
+    char *pending_opt = NULL;
+
+    i = (config->tune & OPTPARSE_IGNORE_ARGV0) ? 1 : 0;
+
+    while (error >= OPTPARSE_OK && i < argc) {
+        char *key, *value;
+
+        if (!no_more_options
+            && ((pending_opt != NULL)
+                || str_notempty(key = strip_dash(argv[i])))) {
+
+            bool is_long;
+            struct opt_rule *curr_rule;
+
+            if (pending_opt == NULL) {
+                char *tmp_key;
+                is_long = (tmp_key = strip_dash(key)) != NULL;
+
+                if (is_long) {
+                    key = tmp_key;
+                }
+
+                if (is_long && tmp_key[0] == TERM) { /* we read a "--" */
+                    no_more_options = 1;
+                    goto parse_loop_end;
+                }
+            }
+            else { /* pending_opt != NULL, we are reading combined switches */
+                is_long = false;
+                key = pending_opt;
+                pending_opt = NULL; /* We reset this because we need to check again
+                                       if the current option is a switch*/
+            }
+
+            curr_rule = find_rule(config, is_long ? key : NULL,
+                                  (!is_long) ? key[0] : 0);
+
+            if (curr_rule != NULL) {
+                if (curr_rule->action == OPTPARSE_DO_HELP) {
+                    do_help(config);
+                    error = -OPTPARSE_REQHELP; /* BYE! <===========> */
+                }
+                else if (NEEDS_VALUE(curr_rule)) {
+                    if (!is_long && key[1] != TERM) {
+                        /* This allows one to write the option value like -d12.6 */
+                        value = &key[1];
+                    }
+                    else if (i < (argc - 1)) {
+                        /* "i" is only incremented here and at the end of the loop */
+                        value = argv[++i];
+                    }
+                    else {
+                        (is_long) ?
+                        P_ERR("Option is missing value: %s\n", key)
+                        : P_ERR("Option is missing value: %c\n", key[0]);
+                        error = -OPTPARSE_BADSYNTAX; /* BYE! <===========> */
+                    }
+                }
+                else {     /* Handle switches (no arguments) */
+                    value = NULL;
+                    if (!is_long && key[1] != TERM) {
+                        pending_opt = &key[1];
+                    }
+                }
+
+                if (error >= OPTPARSE_OK) {
+                    error = do_action(curr_rule, key, value); /* BYE???? <==> */
+                }
+            }
+            else {
+                P_ERR("Unknown option: %s\n", key);
+                error = -OPTPARSE_BADSYNTAX;
+            }
+        }
+        else if (config->arg_parser != NULL) {
+            /* BYE???? <===========> */
+            error = config->arg_parser(i, argv[i], config->arg_parser_data);
+        }
+        else {
+            P_ERR("Argument %s missing key\n", argv[i] );
+            if (config->tune & OPTPARSE_NULL_ARGPARSER) {
+                error = -OPTPARSE_BADSYNTAX; /* BYE! <===========> */
+            }
+        }
+parse_loop_end:
+        if (pending_opt == NULL) {
+            i++; /* "i" is only incremented here and above */
+        }
+    }
+
+    return error;
+}
+
+/* SETTERS : Should not be fed null arguments*/
+
+void opt_conf_init(struct opt_conf *conf,
+                   struct opt_rule *rules, size_t n_rules, char *helpstr,
+                   optparse_tune tune, int (*arg_parser)(int, char *, void *),
+                   void *arg_parser_data)
+{
+    conf->helpstr = helpstr;
+    conf->n_rules = n_rules;
+    conf->rules = rules;
+    conf->tune = tune;
+    conf->arg_parser = arg_parser;
+    conf->arg_parser_data = arg_parser_data;
+}
+
+void set_parse_meta(struct opt_rule *rule, char short_id, const char *long_id,
+                    const char *desc)
+{
+    rule->short_id = short_id;
+    rule->long_id = long_id;
+    rule->desc = desc;
+}
+
+#define SET_ACTION(rule, action_) (rule)->action = (action_)
+#define MK_SETTER1(name, action, type, var) \
+    void name(struct opt_rule *rule, type *data) { \
+        SET_ACTION(rule, action); \
+        rule->data.var = data; \
+    }
+
+#define MK_SETTER0(name, action) \
+    void name(struct opt_rule *rule) { \
+        SET_ACTION(rule, action); \
+    }
+
+void set_parse_custom(struct opt_rule *rule,
+                      int (*callback)(char *, char *, void *, const char **), void *data)
+{
+    SET_ACTION(rule, OPTPARSE_CUSTOM_ACTION);
+    rule->data.d_custom.callback = callback;
+    rule->data.d_custom.data = data;
+}
+
+MK_SETTER0(set_parse_ignore, OPTPARSE_IGNORE)
+MK_SETTER0(set_parse_ignore_sw, OPTPARSE_IGNORE_SWITCH)
+MK_SETTER0(set_parse_help, OPTPARSE_DO_HELP)
+
+MK_SETTER1(set_parse_int, OPTPARSE_INT, int, d_int)
+MK_SETTER1(set_parse_double, OPTPARSE_DOUBLE, double, d_double)
+MK_SETTER1(set_parse_float, OPTPARSE_FLOAT, float, d_float)
+MK_SETTER1(set_parse_bool, OPTPARSE_SET_BOOL, bool, d_bool)
+MK_SETTER1(set_parse_bool_unset, OPTPARSE_UNSET_BOOL, bool, d_bool)
+MK_SETTER1(set_parse_count, OPTPARSE_COUNT, int, d_int)
+MK_SETTER1(set_parse_str, OPTPARSE_STR, char *, d_str)
+MK_SETTER1(set_parse_str_nocopy, OPTPARSE_STR_NOCOPY, char *, d_str)

--- a/sys/optparse/optparse.c
+++ b/sys/optparse/optparse.c
@@ -89,7 +89,7 @@ char *my_strdup(const char *s)
 #define _MSK(x) (1 << (x))
 const uint16_t need_value_mask = _MSK(OPTPARSE_IGNORE)
                                  | _MSK(OPTPARSE_CUSTOM_ACTION) | _MSK(OPTPARSE_INT)
-                                 | _MSK(OPTPARSE_DOUBLE) | _MSK(OPTPARSE_FLOAT)
+                                 | _MSK(OPTPARSE_FLOAT)
                                  | _MSK(OPTPARSE_STR) | _MSK(OPTPARSE_STR_NOCOPY);
 
 #define NEEDS_VALUE(rule) (!!(_MSK((rule)->action) & need_value_mask))
@@ -155,9 +155,6 @@ static int do_action(opt_rule_t *rule, const char *key, const char *value)
             break;
         case OPTPARSE_INT:
             LAZY_LOAD(rule->data.d_int, strtol(value, NULL, 0));
-            break;
-        case OPTPARSE_DOUBLE:
-            LAZY_LOAD(rule->data.d_double, strtod(value, NULL));
             break;
         case OPTPARSE_FLOAT:
             LAZY_LOAD(rule->data.d_float, strtof(value, NULL));
@@ -378,7 +375,6 @@ MK_SETTER0(set_parse_ignore_sw, OPTPARSE_IGNORE_SWITCH)
 MK_SETTER0(set_parse_help, OPTPARSE_DO_HELP)
 
 MK_SETTER1(set_parse_int, OPTPARSE_INT, int, d_int)
-MK_SETTER1(set_parse_double, OPTPARSE_DOUBLE, double, d_double)
 MK_SETTER1(set_parse_float, OPTPARSE_FLOAT, float, d_float)
 MK_SETTER1(set_parse_bool, OPTPARSE_SET_BOOL, bool, d_bool)
 MK_SETTER1(set_parse_bool_unset, OPTPARSE_UNSET_BOOL, bool, d_bool)

--- a/tests/gnrc_udp/Makefile
+++ b/tests/gnrc_udp/Makefile
@@ -23,6 +23,9 @@ USEMODULE += shell_commands
 USEMODULE += ps
 USEMODULE += netstats_l2
 USEMODULE += netstats_ipv6
+USEMODULE += optparse
+
+CFLAGS+=-DDEBUG_ASSERT_VERBOSE
 
 include $(RIOTBASE)/Makefile.include
 

--- a/tests/gnrc_udp/main.c
+++ b/tests/gnrc_udp/main.c
@@ -26,10 +26,16 @@
 #define MAIN_QUEUE_SIZE     (8)
 static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
 
-extern int udp_cmd(int argc, char **argv);
+extern int udp_client_send(int argc, char **argv);
+extern int udp_server_start(int argc, char **argv);
+extern int udp_server_stop(int argc, char **argv);
+extern int udp_server_reset(int argc, char **argv);
 
 static const shell_command_t shell_commands[] = {
-    { "udp", "send data over UDP and listen on UDP ports", udp_cmd },
+    { "udp-send", "Send data over UDP", udp_client_send },
+    { "udp-start", "Listen on UDP ports", udp_server_start },
+    { "udp-stop", "Stop udp-server", udp_server_stop },
+    { "udp-reset", "Stop udp-server", udp_server_stop },
     { NULL, NULL, NULL }
 };
 

--- a/tests/unittests/tests-optparse/Makefile
+++ b/tests/unittests/tests-optparse/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/tests/unittests/tests-optparse/Makefile.include
+++ b/tests/unittests/tests-optparse/Makefile.include
@@ -1,0 +1,1 @@
+USEMODULE += optparse

--- a/tests/unittests/tests-optparse/tests-optparse.c
+++ b/tests/unittests/tests-optparse/tests-optparse.c
@@ -53,7 +53,6 @@ enum _rules {
     KEY,
     HELP_OPT,
     FLOATTHING,
-    DOUBLETHING,
     INTTHING,
     IGNORED1,
     IGNORED2,
@@ -92,7 +91,7 @@ static void test_optparse_actions(void)
     int parse_result;
     static const char *argv1[] = { "test", "-c", "3", "--key", "hello", "-vf5.5",
                                    "-qpasted", "-vv9", "--verbose", "-i", "-v", /* this -v is an argument to -i */
-                                   "-s", "-u", "-", "--d", "8.5", "quack", "--124",
+                                   "-s", "-u", "-", "quack", "--124",
                                    "--", "-qwerty" };
     static const char *argv_help[] = { "test", "-c", "3", "-h", "--invalid-option" };
     argparser_data_t adata = { 0 };
@@ -104,7 +103,6 @@ static void test_optparse_actions(void)
     const char *q = "nothing";
     int vlevel = 0;
     bool flag_s = false, flag_u = true;
-    double d = -1.0;
 
     set_parse_meta(rules + VERBOSITY, 'v', "verbose", "Verbosity level (can be specified multiple times");
     set_parse_count(rules + VERBOSITY, &vlevel);
@@ -124,8 +122,6 @@ static void test_optparse_actions(void)
     /* (-f, --q) and (-k, --d), just to add some confusion! */
     set_parse_meta(rules + FLOATTHING, 'f', "q", "Set a float");
     set_parse_float(rules + FLOATTHING, &f);
-    set_parse_meta(rules + DOUBLETHING, 'k', "d", "Set a double");
-    set_parse_double(rules + DOUBLETHING, &d);
 
     set_parse_meta(rules + INTTHING, 'c', NULL, "Set an integer");
     set_parse_int(rules + INTTHING, &c);
@@ -153,7 +149,6 @@ static void test_optparse_actions(void)
     TEST_ASSERT_EQUAL_STRING("hello", key);
     TEST_ASSERT_EQUAL_STRING("pasted", q);
     TEST_ASSERT(f == 5.5f);
-    TEST_ASSERT(d == 8.5);
     TEST_ASSERT(flag_s);
     TEST_ASSERT(!flag_u);
 

--- a/tests/unittests/tests-optparse/tests-optparse.c
+++ b/tests/unittests/tests-optparse/tests-optparse.c
@@ -8,6 +8,7 @@
 
 #include <string.h>
 #include <malloc.h>
+#include <assert.h>
 
 #include "embUnit.h"
 
@@ -31,17 +32,27 @@ static void test_optparse_trivial(void)
 
     memset(&cfg, 0, sizeof(cfg));
 
-    parse_result = optparse_cmd(&cfg, 0, NULL);
+    /* Do nothing: should never fail. */
+    parse_result = optparse_cmd(&cfg, NULL, 0, NULL);
     TEST_ASSERT_EQUAL_INT(OPTPARSE_OK, parse_result);
 
-    parse_result = optparse_cmd(&cfg, 1, argv1);
-    TEST_ASSERT_EQUAL_INT(-2, parse_result);
+    /* Ignore the first argument. */
+    cfg.tune |= OPTPARSE_IGNORE_ARGV0;
 
-    parse_result = optparse_cmd(&cfg, 2, argv2);
+    parse_result = optparse_cmd(&cfg, NULL, 1, argv1);
+    TEST_ASSERT_EQUAL_INT(0, parse_result);
+
+    /* Do not ignore the first argument. */
+    cfg.tune = 0;
+
+    parse_result = optparse_cmd(&cfg, NULL, 1, argv1);
+    TEST_ASSERT_EQUAL_INT(-OPTPARSE_BADSYNTAX, parse_result);
+
+    parse_result = optparse_cmd(&cfg, NULL, 2, argv2);
     TEST_ASSERT_EQUAL_INT(-OPTPARSE_BADSYNTAX, parse_result);
 
     /* This is OK because "--" is eaten up by the parser */
-    parse_result = optparse_cmd(&cfg, 1, argv_dash);
+    parse_result = optparse_cmd(&cfg, NULL, 1, argv_dash);
     TEST_ASSERT_EQUAL_INT(OPTPARSE_OK, parse_result);
 }
 
@@ -49,14 +60,21 @@ enum _rules {
     VERBOSITY,
     SETTABLE,
     UNSETTABLE,
+    ARG1,
+    WILLNOTUSE,
     QTHING,
     KEY,
     HELP_OPT,
     FLOATTHING,
     INTTHING,
+    ARG2,
+    UINTTHING,
     IGNORED1,
     IGNORED2,
-    N_RULES
+    ARG3,
+    ARG4,
+    ARG5,
+    N_RULES,
 };
 
 #define MAX_ARGS 3
@@ -66,110 +84,178 @@ typedef struct argparser_data {
     const char *arguments[MAX_ARGS];
 } argparser_data_t;
 
-int arg_parser(int argn, const char *v, void *_data)
+int count_letters(union opt_key key, const char *value,
+                  union opt_data *dest,
+                  const char **message)
 {
-    argparser_data_t *data = _data;
+    bool valid;
 
-    (void)argn;
-
-    if (data->n >= MAX_ARGS) {
-        return -OPTPARSE_BADSYNTAX;
+    /* If the value is null, we are being requested the default value. */
+    if (value == NULL) {
+        dest->d_uint = 402;
+    } else {
+        dest->d_uint = strlen(value);
+        *message = "counted letters!\n";
     }
 
-    data->arguments[data->n++] = v;
+    /* Test error handling. */
+    valid = dest->d_uint != 1;
 
-    return -OPTPARSE_OK;
+    return (strcmp("count-my-letters", key.argument->name) == 0 && valid)?
+            -OPTPARSE_OK : -OPTPARSE_BADSYNTAX;
 }
+
+static const opt_rule_t rules[N_RULES] = {
+    [VERBOSITY] = OPTPARSE_O(COUNT, 'v', "verbose",
+                    "Verbosity level (can be specified multiple times)", 0),
+
+    [WILLNOTUSE] = OPTPARSE_O(COUNT, 'W', NULL,
+                    "Do not use (check initialization)", 101),
+
+    [SETTABLE] = OPTPARSE_O(SET_BOOL, 's', NULL, "Set a flag 's'", false),
+
+    [UNSETTABLE] = OPTPARSE_O(UNSET_BOOL, 'u', NULL, "Unset the flag 'u'", true),
+
+    [QTHING] = OPTPARSE_O(STR_NOCOPY, 'q', "qthing", "Set the string q.", "nothing"),
+
+    [KEY] = OPTPARSE_O(STR, OPTPARSE_NO_SHORT, "key", "Choose a key", NULL),
+
+    /* (-f, --q)  just to add some confusion! */
+    [FLOATTHING] = OPTPARSE_O(FLOAT, 'f', "q", "Set a float", 1.0f),
+
+    [INTTHING] = OPTPARSE_O(INT, 'c', NULL,
+                            "Set an integer (try a negative value)", -10),
+
+    [UINTTHING] = OPTPARSE_O(UINT, OPTPARSE_NO_SHORT, "cc", "Set uint", 19),
+
+    [IGNORED1] = OPTPARSE_O(IGNORE, 'i', NULL, "No op (takes 1 arg)", 0),
+    [IGNORED2] = OPTPARSE_O(IGNORE_SWITCH, '9', "124", "No op switch", 0),
+    [HELP_OPT] = OPTPARSE_O(DO_HELP, 'h', "help", "Show this help", 0),
+    [ARG1] = OPTPARSE_P(STR_NOCOPY, "first-argument", "Just store this string", "hello!"),
+    [ARG2] = OPTPARSE_P(CUSTOM_ACTION, "count-my-letters",
+                        "Store the n. of letter in this str.", count_letters),
+
+    [ARG3] = OPTPARSE_P_OPT(STR_NOCOPY, "optional-stuff",
+                            "This is optional.", NULL),
+    [ARG4] = OPTPARSE_P_OPT(INT, "an optional integer",
+                            "check that it gets correctly parsed", 89),
+    [ARG5] = OPTPARSE_P_OPT(CUSTOM_ACTION, "count-my-letters",
+                        "Store the n. of letter in this str.", count_letters),
+
+};
+
+static const opt_conf_t cfg = {
+    .helpstr = "Test program",
+    .tune = OPTPARSE_IGNORE_ARGV0,
+    .rules = rules,
+    .n_rules = N_RULES
+};
 
 /**
  * Test all actions.
  */
-static void test_optparse_actions(void)
+static void test_optparse_basic(void)
 {
-    opt_conf_t cfg;
-    opt_rule_t rules[N_RULES];
+    opt_data_t results[N_RULES];
     int parse_result;
-    static const char *argv1[] = { "test", "-c", "3", "--key", "hello", "-vf5.5",
+    static const char *argv[] = { "test", "-c", "-3", "--key", "hello", "-vf5.5",
                                    "-qpasted", "-vv9", "--verbose", "-i", "-v", /* this -v is an argument to -i */
-                                   "-s", "-u", "-", "quack", "--124",
-                                   "--", "-qwerty" };
+                                   "-s", "-u", "-", "quack", "--124", "--cc",
+                                   "423", "--", "-qwerty" };
+
+    parse_result = optparse_cmd(&cfg, results,
+                                sizeof(argv) / sizeof(*argv), argv);
+
+    //TEST_ASSERT_EQUAL_INT(101, results[WILLNOTUSE].d_int);
+
+    /* 3, because we supplied 3 positional arguments. */
+    TEST_ASSERT_EQUAL_INT(3, parse_result);
+    TEST_ASSERT_EQUAL_INT(89, results[ARG4].d_int);
+    TEST_ASSERT_EQUAL_STRING("-", results[ARG1].d_cstr);
+    TEST_ASSERT_EQUAL_INT(strlen("quack"), results[ARG2].d_uint);
+    TEST_ASSERT_EQUAL_STRING("-qwerty", results[ARG3].d_cstr);
+
+    TEST_ASSERT_EQUAL_INT(101, results[WILLNOTUSE].d_int);
+
+    TEST_ASSERT_EQUAL_INT(-3, results[INTTHING].d_int);
+    TEST_ASSERT_EQUAL_INT(423, results[UINTTHING].d_uint);
+    TEST_ASSERT_EQUAL_INT(4, results[VERBOSITY].d_int);
+    TEST_ASSERT_EQUAL_STRING("hello", results[KEY].d_str);
+    TEST_ASSERT_EQUAL_STRING("pasted", results[QTHING].d_cstr);
+    TEST_ASSERT((results[FLOATTHING].d_float == 5.5f));
+    TEST_ASSERT(results[SETTABLE].d_bool);
+    TEST_ASSERT(!results[UNSETTABLE].d_bool);
+
+
+    free(results[KEY].d_str);
+}
+
+/**
+ * Test help.
+ */
+static void test_optparse_help(void)
+{
+    opt_data_t results[N_RULES];
+    int parse_result;
     static const char *argv_help[] = { "test", "-c", "3", "-h", "--invalid-option" };
-    argparser_data_t adata = { 0 };
 
-
-    int c = 10;
-    char *key = NULL;
-    float f = 1.0f;
-    const char *q = "nothing";
-    int vlevel = 0;
-    bool flag_s = false, flag_u = true;
-
-    set_parse_meta(rules + VERBOSITY, 'v', "verbose", "Verbosity level (can be specified multiple times");
-    set_parse_count(rules + VERBOSITY, &vlevel);
-
-    set_parse_meta(rules + SETTABLE, 's', NULL, "Set a flag 's'");
-    set_parse_bool(rules + SETTABLE, &flag_s);
-
-    set_parse_meta(rules + UNSETTABLE, 'u', NULL, "Unset the flag 'u'");
-    set_parse_bool_unset(rules + UNSETTABLE, &flag_u);
-
-    set_parse_meta(rules + QTHING, 'q', "qthing", "Set the string q.");
-    set_parse_str_nocopy(rules + QTHING, &q);
-
-    set_parse_meta(rules + KEY, OPTPARSE_NO_SHORT, "key", "Choose a key");
-    set_parse_str(rules + KEY, &key);
-
-    /* (-f, --q) and (-k, --d), just to add some confusion! */
-    set_parse_meta(rules + FLOATTHING, 'f', "q", "Set a float");
-    set_parse_float(rules + FLOATTHING, &f);
-
-    set_parse_meta(rules + INTTHING, 'c', NULL, "Set an integer");
-    set_parse_int(rules + INTTHING, &c);
-
-    set_parse_meta(rules + IGNORED1, 'i', NULL, "No op (takes 1 arg)");
-    set_parse_ignore(rules + IGNORED1);
-
-    set_parse_meta(rules + IGNORED2, '9', "124", "No op switch");
-    set_parse_ignore_sw(rules + IGNORED2);
-
-    set_parse_meta(rules + HELP_OPT, 'h', "help", "Show this help");
-    set_parse_help(rules + HELP_OPT);
-
-    opt_conf_init(&cfg, rules, N_RULES,
-                  "Test program", OPTPARSE_IGNORE_ARGV0,
-                  arg_parser, (void *)&adata);
-
-
-    parse_result = optparse_cmd(&cfg, sizeof(argv1) / sizeof(*argv1), argv1);
-
-    TEST_ASSERT_EQUAL_INT(-OPTPARSE_OK, parse_result);
-
-    TEST_ASSERT_EQUAL_INT(3, c);
-    TEST_ASSERT_EQUAL_INT(4, vlevel);
-    TEST_ASSERT_EQUAL_STRING("hello", key);
-    TEST_ASSERT_EQUAL_STRING("pasted", q);
-    TEST_ASSERT(f == 5.5f);
-    TEST_ASSERT(flag_s);
-    TEST_ASSERT(!flag_u);
-
-    TEST_ASSERT_EQUAL_INT(3, adata.n);
-    TEST_ASSERT_EQUAL_STRING("-", adata.arguments[0]);
-    TEST_ASSERT_EQUAL_STRING("quack", adata.arguments[1]);
-    TEST_ASSERT_EQUAL_STRING("-qwerty", adata.arguments[2]);
-
-    free(key);
-    key = NULL;
-
-    parse_result = optparse_cmd(&cfg, sizeof(argv_help) / sizeof(*argv_help), argv_help);
+    parse_result = optparse_cmd(&cfg, results,
+                                sizeof(argv_help) / sizeof(*argv_help), argv_help);
 
     TEST_ASSERT_EQUAL_INT(-OPTPARSE_REQHELP, parse_result);
 }
+
+/**
+ * Test default value assignment.
+ */
+static void test_optparse_default(void)
+{
+    opt_data_t results[N_RULES];
+    int parse_result;
+    static const char *argv[] = { NULL, "b", "cc" };
+
+    parse_result = optparse_cmd(&cfg, results,
+                                sizeof(argv) / sizeof(*argv), argv);
+
+    TEST_ASSERT_EQUAL_INT(2, parse_result);
+
+#define my_TEST_ASSERT_EQUAL_INT(idx, field) TEST_ASSERT_EQUAL_INT(rules[idx].default_value.field, results[idx].field)
+#define my_TEST_ASSERT_EQUAL_STRING(idx, field) TEST_ASSERT_EQUAL_STRING(rules[idx].default_value.field, results[idx].field)
+#define my_TEST_ASSERT_EQUAL_WHATEVER(idx, field) TEST_ASSERT_EQUAL_WHATEVER(rules[idx].default_value.field, results[idx].field)
+#define TEST_ASSERT_EQUAL_WHATEVER(x, y) TEST_ASSERT((x) == (y))
+
+    TEST_ASSERT_EQUAL_STRING("b", results[ARG1].d_cstr);
+    TEST_ASSERT_EQUAL_INT(2, results[ARG2].d_uint);
+    my_TEST_ASSERT_EQUAL_STRING(ARG3, d_cstr);
+    my_TEST_ASSERT_EQUAL_INT(ARG4, d_int);
+
+    /* this one has a special behavior. */
+    TEST_ASSERT_EQUAL_INT(402, results[ARG5].d_uint);
+
+    my_TEST_ASSERT_EQUAL_INT(WILLNOTUSE, d_int);
+    my_TEST_ASSERT_EQUAL_INT(INTTHING, d_int);
+    my_TEST_ASSERT_EQUAL_INT(UINTTHING, d_uint);
+    my_TEST_ASSERT_EQUAL_INT(VERBOSITY, d_int);
+    my_TEST_ASSERT_EQUAL_STRING(KEY, d_str);
+    my_TEST_ASSERT_EQUAL_STRING(QTHING, d_cstr);
+    my_TEST_ASSERT_EQUAL_WHATEVER(FLOATTHING, d_float);
+    my_TEST_ASSERT_EQUAL_WHATEVER(SETTABLE, d_bool);
+    my_TEST_ASSERT_EQUAL_WHATEVER(UNSETTABLE, d_bool);
+
+    free(results[KEY].d_str);
+}
+
+/**
+ * Test invalid numbers
+ */
 
 Test *tests_optparse_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
         new_TestFixture(test_optparse_trivial),
-        new_TestFixture(test_optparse_actions),
+        new_TestFixture(test_optparse_basic),
+        new_TestFixture(test_optparse_help),
+        new_TestFixture(test_optparse_default),
     };
 
     EMB_UNIT_TESTCALLER(optparse_tests, NULL, NULL, fixtures);

--- a/tests/unittests/tests-optparse/tests-optparse.c
+++ b/tests/unittests/tests-optparse/tests-optparse.c
@@ -89,13 +89,13 @@ int count_letters(union opt_key key, const char *value,
                   const char **message)
 {
     bool valid;
+    (void)message;
 
     /* If the value is null, we are being requested the default value. */
     if (value == NULL) {
         dest->d_uint = 402;
     } else {
         dest->d_uint = strlen(value);
-        *message = "counted letters!\n";
     }
 
     /* Test error handling. */
@@ -246,6 +246,52 @@ static void test_optparse_default(void)
 }
 
 /**
+ * Test number syntax errors (int)
+ */
+static void test_optparse_int_err(void)
+{
+    opt_data_t results[N_RULES];
+    int parse_result;
+    static const char *argv[] = { NULL, "x1", "x2", "-c", "45."};
+
+    /* first check that without the -c option it works */
+    parse_result = optparse_cmd(&cfg, results,
+                                sizeof(argv) / sizeof(*argv) - 2, argv);
+
+    TEST_ASSERT_EQUAL_INT(2, parse_result);
+
+    /* Now check that the -c option with invalid argument fails */
+    parse_result = optparse_cmd(&cfg, results,
+                                 sizeof(argv) / sizeof(*argv), argv);
+
+
+    TEST_ASSERT_EQUAL_INT(-OPTPARSE_BADSYNTAX, parse_result);
+}
+
+/**
+ * Test number syntax errors (float)
+ */
+static void test_optparse_float_err(void)
+{
+    opt_data_t results[N_RULES];
+    int parse_result;
+    static const char *argv[] = { NULL, "x1", "x2", "-f", "46.7.9"};
+
+    /* first check that without the -f option it works */
+    parse_result = optparse_cmd(&cfg, results,
+                                sizeof(argv) / sizeof(*argv) - 2, argv);
+
+    TEST_ASSERT_EQUAL_INT(2, parse_result);
+
+    /* Now check that the -f option with invalid argument fails */
+    parse_result = optparse_cmd(&cfg, results,
+                                 sizeof(argv) / sizeof(*argv), argv);
+
+
+    TEST_ASSERT_EQUAL_INT(-OPTPARSE_BADSYNTAX, parse_result);
+}
+
+/**
  * Test invalid numbers
  */
 
@@ -256,6 +302,8 @@ Test *tests_optparse_tests(void)
         new_TestFixture(test_optparse_basic),
         new_TestFixture(test_optparse_help),
         new_TestFixture(test_optparse_default),
+        new_TestFixture(test_optparse_int_err),
+        new_TestFixture(test_optparse_float_err),
     };
 
     EMB_UNIT_TESTCALLER(optparse_tests, NULL, NULL, fixtures);

--- a/tests/unittests/tests-optparse/tests-optparse.c
+++ b/tests/unittests/tests-optparse/tests-optparse.c
@@ -1,0 +1,189 @@
+/*
+ * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#include <string.h>
+#include <malloc.h>
+
+#include "embUnit.h"
+
+#include "optparse.h"
+
+/**
+ * Test an empty parser.
+ *
+ * According to the docs, all fields of opt_conf_t can be zero. In that case
+ * the parser will fail except if argc = 0.
+ *
+ * Also, if argc=0, argv=NULL should be OK.
+ */
+static void test_optparse_trivial(void)
+{
+    opt_conf_t cfg;
+    int parse_result;
+    static const char *argv1[] = { "batman" };
+    static const char *argv2[] = { "-y", "3" };
+    static const char *argv_dash[] = { "--" };
+
+    memset(&cfg, 0, sizeof(cfg));
+
+    parse_result = optparse_cmd(&cfg, 0, NULL);
+    TEST_ASSERT_EQUAL_INT(OPTPARSE_OK, parse_result);
+
+    parse_result = optparse_cmd(&cfg, 1, argv1);
+    TEST_ASSERT_EQUAL_INT(-2, parse_result);
+
+    parse_result = optparse_cmd(&cfg, 2, argv2);
+    TEST_ASSERT_EQUAL_INT(-OPTPARSE_BADSYNTAX, parse_result);
+
+    /* This is OK because "--" is eaten up by the parser */
+    parse_result = optparse_cmd(&cfg, 1, argv_dash);
+    TEST_ASSERT_EQUAL_INT(OPTPARSE_OK, parse_result);
+}
+
+enum _rules {
+    VERBOSITY,
+    SETTABLE,
+    UNSETTABLE,
+    QTHING,
+    KEY,
+    HELP_OPT,
+    FLOATTHING,
+    DOUBLETHING,
+    INTTHING,
+    IGNORED1,
+    IGNORED2,
+    N_RULES
+};
+
+#define MAX_ARGS 3
+
+typedef struct argparser_data {
+    int n;
+    const char *arguments[MAX_ARGS];
+} argparser_data_t;
+
+int arg_parser(int argn, const char *v, void *_data)
+{
+    argparser_data_t *data = _data;
+
+    (void)argn;
+
+    if (data->n >= MAX_ARGS) {
+        return -OPTPARSE_BADSYNTAX;
+    }
+
+    data->arguments[data->n++] = v;
+
+    return -OPTPARSE_OK;
+}
+
+/**
+ * Test all actions.
+ */
+static void test_optparse_actions(void)
+{
+    opt_conf_t cfg;
+    opt_rule_t rules[N_RULES];
+    int parse_result;
+    static const char *argv1[] = { "test", "-c", "3", "--key", "hello", "-vf5.5",
+                                   "-qpasted", "-vv9", "--verbose", "-i", "-v", /* this -v is an argument to -i */
+                                   "-s", "-u", "-", "--d", "8.5", "quack", "--124",
+                                   "--", "-qwerty" };
+    static const char *argv_help[] = { "test", "-c", "3", "-h", "--invalid-option" };
+    argparser_data_t adata = { 0 };
+
+
+    int c = 10;
+    char *key = NULL;
+    float f = 1.0f;
+    const char *q = "nothing";
+    int vlevel = 0;
+    bool flag_s = false, flag_u = true;
+    double d = -1.0;
+
+    set_parse_meta(rules + VERBOSITY, 'v', "verbose", "Verbosity level (can be specified multiple times");
+    set_parse_count(rules + VERBOSITY, &vlevel);
+
+    set_parse_meta(rules + SETTABLE, 's', NULL, "Set a flag 's'");
+    set_parse_bool(rules + SETTABLE, &flag_s);
+
+    set_parse_meta(rules + UNSETTABLE, 'u', NULL, "Unset the flag 'u'");
+    set_parse_bool_unset(rules + UNSETTABLE, &flag_u);
+
+    set_parse_meta(rules + QTHING, 'q', "qthing", "Set the string q.");
+    set_parse_str_nocopy(rules + QTHING, &q);
+
+    set_parse_meta(rules + KEY, OPTPARSE_NO_SHORT, "key", "Choose a key");
+    set_parse_str(rules + KEY, &key);
+
+    /* (-f, --q) and (-k, --d), just to add some confusion! */
+    set_parse_meta(rules + FLOATTHING, 'f', "q", "Set a float");
+    set_parse_float(rules + FLOATTHING, &f);
+    set_parse_meta(rules + DOUBLETHING, 'k', "d", "Set a double");
+    set_parse_double(rules + DOUBLETHING, &d);
+
+    set_parse_meta(rules + INTTHING, 'c', NULL, "Set an integer");
+    set_parse_int(rules + INTTHING, &c);
+
+    set_parse_meta(rules + IGNORED1, 'i', NULL, "No op (takes 1 arg)");
+    set_parse_ignore(rules + IGNORED1);
+
+    set_parse_meta(rules + IGNORED2, '9', "124", "No op switch");
+    set_parse_ignore_sw(rules + IGNORED2);
+
+    set_parse_meta(rules + HELP_OPT, 'h', "help", "Show this help");
+    set_parse_help(rules + HELP_OPT);
+
+    opt_conf_init(&cfg, rules, N_RULES,
+                  "Test program", OPTPARSE_IGNORE_ARGV0,
+                  arg_parser, (void *)&adata);
+
+
+    parse_result = optparse_cmd(&cfg, sizeof(argv1) / sizeof(*argv1), argv1);
+
+    TEST_ASSERT_EQUAL_INT(-OPTPARSE_OK, parse_result);
+
+    TEST_ASSERT_EQUAL_INT(3, c);
+    TEST_ASSERT_EQUAL_INT(4, vlevel);
+    TEST_ASSERT_EQUAL_STRING("hello", key);
+    TEST_ASSERT_EQUAL_STRING("pasted", q);
+    TEST_ASSERT(f == 5.5f);
+    TEST_ASSERT(d == 8.5);
+    TEST_ASSERT(flag_s);
+    TEST_ASSERT(!flag_u);
+
+    TEST_ASSERT_EQUAL_INT(3, adata.n);
+    TEST_ASSERT_EQUAL_STRING("-", adata.arguments[0]);
+    TEST_ASSERT_EQUAL_STRING("quack", adata.arguments[1]);
+    TEST_ASSERT_EQUAL_STRING("-qwerty", adata.arguments[2]);
+
+    free(key);
+    key = NULL;
+
+    parse_result = optparse_cmd(&cfg, sizeof(argv_help) / sizeof(*argv_help), argv_help);
+
+    TEST_ASSERT_EQUAL_INT(-OPTPARSE_REQHELP, parse_result);
+}
+
+Test *tests_optparse_tests(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_optparse_trivial),
+        new_TestFixture(test_optparse_actions),
+    };
+
+    EMB_UNIT_TESTCALLER(optparse_tests, NULL, NULL, fixtures);
+
+    return (Test *)&optparse_tests;
+}
+
+
+void tests_optparse(void)
+{
+    TESTS_RUN(tests_optparse_tests());
+}


### PR DESCRIPTION
### Contribution description

Some time ago I wrote #9538 but it was lacking an example of how it can be used. Now, inspired by #11357 , I present the "optparse version" of  tests/gnrc_udp.

For more information, see #9538

### Testing procedure1

The module is tested in the original PR. The goal of this is just to show how code looks like when it uses sys/optparse.

### Issues/PRs references

Depends on #9538.
