### PR TITLE
gnrc_netif_ieee802154: check if mhr_len is lesser than nread [backport 2019.04]

### DIFF
--- a/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c
+++ b/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c
@@ -143,7 +143,9 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
 #endif
             size_t mhr_len = ieee802154_get_frame_hdr_len(pkt->data);
 
-            if (mhr_len == 0) {
+            /* nread was checked for <= 0 before so we can safely cast it to
+             * unsigned */
+            if ((mhr_len == 0) || ((size_t)nread < mhr_len)) {
                 DEBUG("_recv_ieee802154: illegally formatted frame received\n");
                 gnrc_pktbuf_release(pkt);
                 return NULL;


### PR DESCRIPTION
# Backport of #11399

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Fixes https://github.com/RIOT-OS/RIOT/issues/11398
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
~~With the descriptions given in https://github.com/RIOT-OS/RIOT/issues/11398, read the code ;-).~~

~~(I'll provide a test case soon-ish)~~

Cherry-pick #11401 to the `2019.04-branch` release branch and run it with or without this PR.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Fixes https://github.com/RIOT-OS/RIOT/issues/11398
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
