### PR TITLE
examples/cord_ep: fix typo in node information + move it in a define

### DIFF
--- a/examples/cord_ep/main.c
+++ b/examples/cord_ep/main.c
@@ -30,6 +30,8 @@
 #define MAIN_QUEUE_SIZE     (8)
 static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
 
+#define NODE_INFO  "SOME NODE INFORMATION"
+
 /* we will use a custom event handler for dumping cord_ep events */
 static void _on_ep_event(cord_ep_standalone_event_t event)
 {
@@ -68,8 +70,8 @@ static ssize_t _handler_info(coap_pkt_t *pdu,
 
     gcoap_resp_init(pdu, buf, len, COAP_CODE_CONTENT);
     size_t resp_len = coap_opt_finish(pdu, COAP_OPT_FINISH_PAYLOAD);
-    size_t slen = sizeof("SOME NODE INFORMATION");
-    memcpy(pdu->payload, "SOME NODE INFORMATION", slen);
+    size_t slen = sizeof(NODE_INFO);
+    memcpy(pdu->payload, NODE_INFO, slen);
     return resp_len + slen;
 }
 

--- a/examples/cord_ep/main.c
+++ b/examples/cord_ep/main.c
@@ -68,8 +68,8 @@ static ssize_t _handler_info(coap_pkt_t *pdu,
 
     gcoap_resp_init(pdu, buf, len, COAP_CODE_CONTENT);
     size_t resp_len = coap_opt_finish(pdu, COAP_OPT_FINISH_PAYLOAD);
-    size_t slen = sizeof("SOME NODE INFOMRATION");
-    memcpy(pdu->payload, "SOME NODE INFOMRATION", slen);
+    size_t slen = sizeof("SOME NODE INFORMATION");
+    memcpy(pdu->payload, "SOME NODE INFORMATION", slen);
     return resp_len + slen;
 }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Fixes an obvious typo in the node information string of the `examples/cord_ep` application and move this string in a define.

The PR is split in 2 commits:
- bbbb62b5718ce66bffdf384b3a0a3854341daab1 fixes the typo
- 75d9e7892cd825ba1c50e20a68f96eda67b01b6b move the node information in a define to avoid code duplication.

I can squash in a single commit if needed.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Should build fine and work as before

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
