### PR TITLE
boards/calliope-mini: rework programmer config (openocd and pyocd)

### DIFF
--- a/boards/calliope-mini/Makefile.include
+++ b/boards/calliope-mini/Makefile.include
@@ -17,7 +17,7 @@ ifeq (fscopy,$(PROGRAMMER))
   export DEBUGGER =
   export DEBUGSERVER =
 else ifeq (openocd,$(PROGRAMMER))
-  DEBUG_ADAPTER = jlink
+  DEBUG_ADAPTER = dap
 endif
 
 # include nrf51 boards common configuration

--- a/boards/calliope-mini/Makefile.include
+++ b/boards/calliope-mini/Makefile.include
@@ -18,6 +18,11 @@ ifeq (fscopy,$(PROGRAMMER))
   export DEBUGSERVER =
 else ifeq (openocd,$(PROGRAMMER))
   DEBUG_ADAPTER = dap
+else ifeq (pyocd,$(PROGRAMMER))
+  # PyOCD doesn't recognize automatically the board ID, so target type has to
+  # be passed explicitly
+  export FLASH_TARGET_TYPE ?= -t nrf51
+  include $(RIOTMAKE)/tools/pyocd.inc.mk
 endif
 
 # include nrf51 boards common configuration


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is changing the programmer options for the calliope-mini board. After #11404 was opened, I checked and apparently this board provides a CMSIS-DAP programmer interface by default, which is compatible with openocd and pyocd.

For example, they use [this openocd configuration](https://github.com/calliope-mini/calliope-demo/blob/master/contrib/openocd.cfg) in there sample projects.

I'm wondering why jlink adapter was selected as the default. There's no documentation about that.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Try to flash a calliope-mini with `PROGRAMMER=openocd` or `PROGRAMMER=pyocd`, it should work.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Noticed while looking at #11404 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
