### PR TITLE
dist/tools/backport_pr: several improvements

### DIFF
--- a/dist/tools/backport_pr/backport_pr.py
+++ b/dist/tools/backport_pr/backport_pr.py
@@ -74,11 +74,17 @@ def _get_latest_release(branches):
     return (release_short, release_fullname)
 
 
-def _get_upstream(repo):
+def _find_remote(repo, user, repo_name):
     for remote in repo.remotes:
-        if (remote.url.endswith("{}/{}.git".format(ORG, REPO)) or
-                remote.url.endswith("{}/{}".format(ORG, REPO))):
+        if (remote.url.endswith("{}/{}.git".format(user, repo_name)) or
+                remote.url.endswith("{}/{}".format(user, repo_name))):
             return remote
+    raise ValueError("Could not find remote with URL ending in {}/{}.git"
+                     .format(user, repo_name))
+
+
+def _get_upstream(repo):
+    return _find_remote(repo, ORG, REPO)
 
 
 def _delete_worktree(repo, workdir):

--- a/dist/tools/backport_pr/backport_pr.py
+++ b/dist/tools/backport_pr/backport_pr.py
@@ -185,9 +185,10 @@ def main():
         for commit in commits:
             bp_repo.git.cherry_pick('-x', commit['sha'])
         # Push to github
-        print("Pushing branch {} to origin".format(new_branch))
+        origin = _find_remote(repo, username, REPO)
+        print("Pushing branch {} to {}".format(new_branch, origin))
         if not args.noop:
-            repo.git.push('origin', '{0}:{0}'.format(new_branch))
+            repo.git.push(origin, '{0}:{0}'.format(new_branch))
     except Exception as exc:
         # Delete worktree
         print("Pruning temporary workdir at {}".format(worktree_dir))

--- a/dist/tools/backport_pr/backport_pr.py
+++ b/dist/tools/backport_pr/backport_pr.py
@@ -174,6 +174,9 @@ def main():
     # Build topic branch in temp dir
     new_branch = args.backport_branch_fmt.format(release=release_shortname,
                                                  origbranch=orig_branch)
+    if new_branch in repo.branches:
+        print("ERROR: Branch {} already exists".format(new_branch))
+        sys.exit(1)
     worktree_dir = os.path.join(args.gitdir, WORKTREE_SUBDIR)
     repo.git.worktree("add", "-b",
                       new_branch,


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This adds several improvements to the PR backporting script that came from the fact that in @SemjonKerner's work usual environment it does not work:

1. Clean-up worktree + temporary branch in case of error (we both did not know about `git worktree` so we were quite frustrated that `git branch -D backport/...` did not work as we expected)
2. Don't assume `origin` to be the developer's fork remote
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
For (1) I just added an exception raising into the try block:
```diff
diff --git a/dist/tools/backport_pr/backport_pr.py b/dist/tools/backport_pr/backport_pr.py
index ce47476..8c04701 100755
--- a/dist/tools/backport_pr/backport_pr.py
+++ b/dist/tools/backport_pr/backport_pr.py
@@ -184,6 +184,7 @@ def main():
                       "{}/{}".format(upstream_remote, release_fullname))
     try:
         bp_repo = git.Repo(worktree_dir)
+        raise KeyError()
         # Apply commits
         for commit in commits:
             bp_repo.git.cherry_pick('-x', commit['sha'])
```

And made a dry run for a closed PR, e.g.:

```sh
$ dist/tools/backport_pr/backport_pr.py -n 11395
[…]
$ git worktree list
/home/mlenders/Repositories/RIOT-OS/RIOT  1930368 [dist/enh/backport_pr_fixes]
$ git branch | grep "backport/nrfmin_fix_isr"
```

For 2. I renamed my development fork's remote

```sh
git remote rename origin oranges
```

and made sure that at least the push happens on a "dry" run:

```patch
diff --git a/dist/tools/backport_pr/backport_pr.py b/dist/tools/backport_pr/backport_pr.py
index ce47476..914760e 100755
--- a/dist/tools/backport_pr/backport_pr.py
+++ b/dist/tools/backport_pr/backport_pr.py
@@ -190,7 +190,7 @@ def main():
         # Push to github
         origin = _find_remote(repo, username, REPO)
         print("Pushing branch {} to {}".format(new_branch, origin))
-        if not args.noop:
+        if not args.noop or True:
             repo.git.push(origin, '{0}:{0}'.format(new_branch))
     except Exception as exc:
         # Delete worktree
```

I then executed the script on a closed PR with a "dry" run:

```sh
dist/tools/backport_pr/backport_pr.py -n 11309
```

and observed

- `Pushing branch backport/2019.04/tests/enh/lwip_sock-l2util to`**`oranges`**

#### Clean-up
```sh
git checkout -f
git remote rename oranges origin
git push origin :backport/2019.04/tests/enh/lwip_sock-l2util
git branch -D backport/2019.04/tests/enh/lwip_sock-l2util
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
