### PR TITLE
esp32: documentation fixes

### DIFF
--- a/boards/esp32-olimex-evb/include/board.h
+++ b/boards/esp32-olimex-evb/include/board.h
@@ -50,7 +50,7 @@ extern "C" {
 /**
  * @name    LED (on-board) configuration
  *
- * Olimex ESP32-GATEWAY has an ob-board LED.
+ * Olimex ESP32-GATEWAY has an on-board LED.
  * @{
  */
 #if MODULE_OLIMEX_ESP32_GATEWAY

--- a/cpu/esp32/doc.txt
+++ b/cpu/esp32/doc.txt
@@ -153,7 +153,7 @@ UARTs       | 3 | yes
 WiFi        | IEEE 802.11 b/g/n built in | yes
 Bluetooth   | v4.2 BR/EDR and BLE | no
 Ethernet    | MAC interface with dedicated DMA and IEEE 1588 support | yes
-CAN         | version 2.0 | no
+CAN         | version 2.0 | yes
 IR          | up to 8 channels TX/RX | no
 Motor PWM   | 2 devices x 6 channels | yes
 LED PWM     | 16 channels | no
@@ -176,6 +176,7 @@ The RIOT-OS for ESP32 SoCs supports the following features at the moment:
 - I2C interfaces
 - SPI interfaces
 - UART interfaces
+- CAN interface
 - CPU ID access
 - RTC module
 - ADC and DAC channels


### PR DESCRIPTION
### Contribution description

Revise CAN support for the ESP32 CPU and fix a typo in a comment. 

### Testing procedure

`make doc` and look at the ESP32 CPU page.