### PR TITLE
make: don't execute tilde files on test target

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -570,7 +570,7 @@ reset:
 	$(RESET) $(RESET_FLAGS)
 
 .PHONY: test test/available
-TESTS ?= $(foreach file,$(wildcard $(APPDIR)/tests/*),\
+TESTS ?= $(foreach file,$(wildcard $(APPDIR)/tests/*[^~]),\
                         $(shell test -f $(file) -a -x $(file) && echo $(file)))
 test: $(TEST_DEPS)
 	$(Q) for t in $(TESTS); do \


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
My system (Ubuntu 16.04) creates a backup when opening a file with `vim`. This backup is called `filename~`. Due to it being a copy of the file before opening, it also is executable, which is why it is selected for execution with the `make test` target.

This change makes the `TESTS` macro exclude files ending in `~`. This way files ending in `~` are not executed with `make test`.

Since e.g. projects like NextCloud are excluding such files also from their sync [[1]], I think this is fine.

[1]: https://github.com/nextcloud/desktop/blob/d7b881feb6c2dbee84d9c49bef0f494afe25b6b8/sync-exclude.lst#L3
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
```
cp tests/shell/tests/01-run.py tests/shell/tests/01-run.py~
make -C tests/shell/ all test
```

On current master this results in the tests being executed twice. With this PR it is only executed once.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
