### PR TITLE
drivers/hx711: driver and SAUL adaption for the HX711 sensor

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -199,6 +199,11 @@ ifneq (,$(filter hts221,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
 endif
 
+ifneq (,$(filter hx711,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_gpio
+  USEMODULE += xtimer
+endif
+
 ifneq (,$(filter ina220,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
 endif

--- a/drivers/Makefile.include
+++ b/drivers/Makefile.include
@@ -110,6 +110,10 @@ ifneq (,$(filter hts221,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/hts221/include
 endif
 
+ifneq (,$(filter hx711,$(USEMODULE)))
+  USEMODULE_INCLUDES += $(RIOTBASE)/drivers/hx711/include
+endif
+
 ifneq (,$(filter ina220,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/ina220/include
 endif

--- a/drivers/hx711/Makefile
+++ b/drivers/hx711/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/hx711/hx711.c
+++ b/drivers/hx711/hx711.c
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2019 Philipp-Alexander Blum <philipp-blum@jakiku.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_hx711 HX711 digital scale sensor
+ * @ingroup     drivers_sensors
+ * @brief       Driver for the HX711 digital scale sensor
+ *
+ * @{
+ * @file
+ * @brief       HX711 driver
+ *
+ * @author      Philipp-Alexander Blum <philipp-blum@jakiku.de>
+ */
+
+#include "periph/gpio.h"
+#include "periph/gpio_util.h"
+#include "xtimer.h"
+
+#include "hx711.h"
+#include "hx711_params.h"
+
+/**
+ * @brief Needs to wait for device to be ready while initialization
+ */
+void wait_for_ready(void)
+{
+    while(gpio_read(HX711_PARAM_DOUT) > 0){
+        xtimer_usleep(HX711_PARAM_SLEEP_TIME);
+    }
+}
+
+/**
+ * @brief Gets a single 24-Bit value from the HX711.
+ * @return The 24-Bit shift in value
+ */
+int32_t hx711_read(void)
+{
+    wait_for_ready();
+
+    float value = 0;
+    uint8_t data[3];
+    uint8_t fill_byte = 0x00;
+
+    data[2] = gpio_util_shiftin(HX711_PARAM_DOUT, HX711_PARAM_SCK);
+    data[1] = gpio_util_shiftin(HX711_PARAM_DOUT, HX711_PARAM_SCK);
+    data[0] = gpio_util_shiftin(HX711_PARAM_DOUT, HX711_PARAM_SCK);
+
+
+    for (int i = 0; i < HX711_PARAM_GAIN_PULSES; i++) {
+        gpio_set(HX711_PARAM_SCK);
+        gpio_clear(HX711_PARAM_SCK);
+    }
+
+
+    if (data[2] & 0x80) {
+        fill_byte = 0xFF;
+    } else {
+        fill_byte = 0x00;
+    }
+
+    value = ( (unsigned long)(fill_byte) << 24
+              | (unsigned long)(data[2]) << 16
+              | (unsigned long)(data[1]) << 8
+              | (unsigned long)(data[0]) );
+
+    return (int32_t) value;
+}
+
+void hx711_init(void)
+{
+    gpio_init(HX711_PARAM_SCK, GPIO_OUT);
+    gpio_init(HX711_PARAM_DOUT, GPIO_IN);
+
+    gpio_clear(HX711_PARAM_SCK);
+    hx711_read();
+}
+
+/**
+ * @brief Read a raw value a configurable times and return the average raw value for it
+ * @param times
+ * @return the average value. Always rounded up.
+ */
+int32_t hx711_read_average(uint8_t times)
+{
+    int32_t sum = 0;
+    for (uint8_t i = 0; i < times; i++) {
+        sum += hx711_read();
+    }
+    return (int32_t) ((sum / times) + 0.5);
+}
+
+/**
+ * @brief Read a value a configurable times and return the average value. Always rounded up.
+ * @param times
+ * @return returns AVG(RAW_VALUE) - HX711_PARAM_OFFSET
+ */
+int32_t hx711_get_value(uint8_t times)
+{
+    return (int32_t) ((hx711_read_average(times) - HX711_PARAM_OFFSET) + 0.5);
+}
+
+/**
+ * @brief Read the average of a configurable times of a cleared and scaled value. Always rounded up.
+ * @param times
+ * @return returns (AVG(RAW_VALUE) - HX711_PARAM_OFFSET) / HX711_PARAM_SCALE
+ */
+int32_t hx711_get_units(uint8_t times)
+{
+    return (int32_t) ((hx711_get_value(times) / HX711_PARAM_SCALE) + 0.5);
+}
+
+void hx711_power_down(void)
+{
+    gpio_clear(HX711_PARAM_SCK);
+    gpio_set(HX711_PARAM_SCK);
+}
+
+void hx711_power_up(void)
+{
+    gpio_clear(HX711_PARAM_SCK);
+}

--- a/drivers/hx711/hx711_saul.c
+++ b/drivers/hx711/hx711_saul.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2019 Philipp-Alexander Blum
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_hx711
+ * @{
+ *
+ * @file
+ * @brief       SAUL adaption for HX711 devices
+ *
+ * @author      Philipp-Alexander Blum <philipp-blum@jakiku.de>
+ *
+ * @}
+ */
+
+#include <string.h>
+#include <stdio.h>
+
+#include "saul.h"
+#include "hx711.h"
+#include "hx711_params.h"
+
+static int read_weight(const void *dev, phydat_t *res)
+{
+    (void)dev;
+    uint32_t result = hx711_get_units(HX711_PARAM_AVG_TIMES);
+    res->val[0] = (int16_t) result;
+    res->unit = UNIT_G;
+    res->scale = 0;
+    return 1;
+}
+
+const saul_driver_t hx711_saul_driver = {
+        .read = read_weight,
+        .write = saul_notsup,
+        .type = SAUL_SENSE_WEIGHT
+};

--- a/drivers/hx711/include/hx711_params.h
+++ b/drivers/hx711/include/hx711_params.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2019 Philipp-Alexander Blum
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_hx711
+ *
+ * @{
+ * @file
+ * @brief       Default configuration for HX711 devices
+ *
+ * @author      Philipp-Alexander Blum <philipp-blum@jakiku.de>
+ *
+ *
+ */
+
+#ifndef HX711_PARAMS_H
+#define HX711_PARAMS_H
+
+#include "board.h"
+#include "hx711.h"
+#include "saul_reg.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* @name   Set default configuration parameters for the HX711 driver
+* @{
+*/
+#ifndef HX711_PARAM_SCK
+#define HX711_PARAM_SCK     GPIO_PIN(0, 0)
+#endif
+#ifndef HX711_PARAM_DOUT
+#define HX711_PARAM_DOUT    GPIO_PIN(0, 0)
+#endif
+/**
+ * @note Read the HX711 datasheet for more information
+ * CHANNEL_A_128 => 1
+ * CHANNEL_B_32 => 2
+ * CHANNEL_A_64 => 3
+ */
+#ifndef HX711_PARAM_GAIN_PULSES
+#define HX711_PARAM_GAIN_PULSES    1
+#endif
+/**
+ * @brief Offset, where to start 0 at. Formular: (RAW_VALUE - HX711_PARAM_OFFSET) / HX711_PARAM_SCALE
+*/
+#ifndef HX711_PARAM_OFFSET
+#define HX711_PARAM_OFFSET  0
+#endif
+#ifndef HX711_PARAM_SCALE
+#define HX711_PARAM_SCALE   1
+#endif
+/**
+ * @brief Default for hx711_read_average. Also used in hx711_get_units.
+ * Reads the value HX711_PARAM_AVG_TIMES times and returns SUM / HX711_PARAM_AVG_TIMES.
+ */
+#ifndef HX711_PARAM_AVG_TIMES
+#define HX711_PARAM_AVG_TIMES   20
+#endif
+#ifndef HX711_PARAM_SLEEP_TIME
+#define HX711_PARAM_SLEEP_TIME  1000
+#endif
+#ifndef HX711_SAUL_INFO
+#define HX711_SAUL_INFO          { .name = "hx711" }
+#endif
+
+
+/**
+ * @brief Meta information to keep in the SAUL registry
+ */
+static const saul_reg_info_t hx711_saul_info = HX711_SAUL_INFO;
+/**@}*/
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HX711_PARAMS_H */

--- a/drivers/include/hx711.h
+++ b/drivers/include/hx711.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2019 Philipp-Alexander Blum <philipp-blum@jakiku.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_hx711 HX711 digital scale sensor
+ * @ingroup     drivers_sensors
+ * @brief       Driver for the HX711 digital scale sensor
+ *
+ * @{
+ * @file
+ * @brief       HX711 driver
+ *
+ * @author      Philipp-Alexander Blum <philipp-blum@jakiku.de>
+ */
+
+#ifndef HX711_H
+#define HX711_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Initialization of the connected HX711 IC
+ */
+void hx711_init(void);
+
+
+/**
+ * @brief Read the average of a configurable times of a cleared and scaled value. Always rounded up.
+ * @param times
+ * @return returns (AVG(RAW_VALUE) - HX711_PARAM_OFFSET) / HX711_PARAM_SCALE
+ */
+int32_t hx711_get_units(uint8_t times);
+
+/**
+ * @brief Power down the HX711 IC
+ */
+void hx711_power_down(void);
+
+/**
+ * @brief Power up the HX711 IC
+ */
+void hx711_power_up(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HX711_H */
+/** @} */

--- a/drivers/include/saul.h
+++ b/drivers/include/saul.h
@@ -104,6 +104,7 @@ enum {
     SAUL_SENSE_PM          = 0x96,     /**< sensor: particulate matter */
     SAUL_SENSE_CAPACITANCE = 0x97,     /**< sensor: capacitance */
     SAUL_SENSE_VOLTAGE     = 0x98,     /**< sensor: voltage */
+    SAUL_SENSE_WEIGHT      = 0x99,     /**< sensor: weight scale */
     SAUL_CLASS_ANY         = 0xff      /**< any device - wildcard */
     /* extend this list as needed... */
 };

--- a/drivers/saul/saul_str.c
+++ b/drivers/saul/saul_str.c
@@ -61,6 +61,7 @@ const char *saul_class_to_str(const uint8_t class_id)
         case SAUL_SENSE_PM:          return "SENSE_PM";
         case SAUL_SENSE_CAPACITANCE: return "SENSE_CAPACITANCE";
         case SAUL_SENSE_VOLTAGE:     return "SENSE_VOLTAGE";
+        case SAUL_SENSE_WEIGHT:      return "SENSE_WEIGHT";
         case SAUL_CLASS_ANY:         return "CLASS_ANY";
         default:                     return "CLASS_UNKNOWN";
     }

--- a/examples/hx711_driver_calibration/Makefile
+++ b/examples/hx711_driver_calibration/Makefile
@@ -1,0 +1,29 @@
+# name of your application
+APPLICATION = hx711_driver_calibration
+
+# Use the ST B-L072Z-LRWAN1 board by default:
+BOARD ?= native
+
+# This has to be the absolute path to the RIOT base directory:
+RIOTBASE ?= $(CURDIR)/../..
+
+FEATURES_REQUIRED += periph_gpio
+USEMODULE += xtimer
+USEMODULE += hx711
+
+# Change these values, if your device is connected on different pins
+CFLAGS += "-DHX711_PARAM_SCK=GPIO_PIN(1, 13)"
+CFLAGS += "-DHX711_PARAM_DOUT=GPIO_PIN(1, 14)"
+
+CFLAGS += "-DHX711_PARAM_OFFSET=95600"
+CFLAGS += "-DHX711_PARAM_SCALE=333"
+
+# Comment this out to disable code in RIOT that does safety checking
+# which is not needed in a production environment but helps in the
+# development process:
+DEVELHELP ?= 1
+
+# Change this to 0 show compiler invocation lines by default:
+QUIET ?= 1
+
+include $(RIOTBASE)/Makefile.include

--- a/examples/hx711_driver_calibration/README.md
+++ b/examples/hx711_driver_calibration/README.md
@@ -1,0 +1,12 @@
+# Do the following to calibrate your HX711
+
+1. Start with "HX711_PARAM_OFFSET 0" and "HX711_PARAM_SCALE 1" in your Makefile
+2. Flash your microcontroller with these values
+3. Remove all weights on your scale.
+Only keep the things on your load cells which should be included for finding the zero point.
+4. Check the returned values in your terminal and use it for the offset.
+5. Flash again with the new offset
+6. Place a reference weight on your connected load cell.
+7. Get the average value and use HX711_PARAM_SCALE = AVG_VALUE / REFERENCE_WEIGHT
+8. You should use different reference weights. For example 1g, 2g, 5g, 10g, 20g.
+Depending on the accuracy you need.

--- a/examples/hx711_driver_calibration/main.c
+++ b/examples/hx711_driver_calibration/main.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2019 Philipp-Alexander Blum
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     examples
+ * @{
+ *
+ * @file
+ * @brief       HX711 Calibration example
+ *
+ * @author      Philipp-Alexander Blum <philipp-blum@jakiku.de>
+ *
+ * @}
+ */
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "hx711.h"
+#include "xtimer.h"
+
+int main(void)
+{
+    puts("RIOT HX711 Scale calibration");
+    puts("=====================================");
+
+    puts("Init HX711...");
+    hx711_init();
+    puts("Initialized HX711.");
+
+    while(true){
+        printf("Read units: %li\n", hx711_get_units(40));
+        xtimer_sleep(2);
+    }
+
+    return 0;
+}

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -381,6 +381,10 @@ void auto_init(void)
     extern void auto_init_hts221(void);
     auto_init_hts221();
 #endif
+#ifdef MODULE_HX711
+    extern void auto_init_hx711(void);
+    auto_init_hx711();
+#endif
 #ifdef MODULE_IO1_XPLAINED
     extern void auto_init_io1_xplained(void);
     auto_init_io1_xplained();

--- a/sys/auto_init/saul/auto_init_hx711.c
+++ b/sys/auto_init/saul/auto_init_hx711.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2019 Philipp-Alexander Blum
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
+
+/*
+ * @ingroup     sys_auto_init_saul
+ * @{
+ *
+ * @file
+ * @brief       Auto initialization for HX711 devices
+ *
+ * @author      Philipp-Alexander Blum <philipp-blum@jakiku.de>
+ *
+ * @}
+ */
+
+#ifdef MODULE_HX711
+
+#include "log.h"
+#include "saul_reg.h"
+#include "hx711.h"
+#include "hx711_params.h"
+
+/**
+ * @brief   Allocate memory for the device descriptors
+ */
+static int hx711_devs;
+
+/**
+ * @brief   Memory for the SAUL registry entries
+ */
+static saul_reg_t saul_entries[1];
+
+/**
+ * @brief   Reference the driver struct
+ */
+extern saul_driver_t hx711_saul_driver;
+
+void auto_init_hx711(void)
+{
+    hx711_init();
+    saul_entries[0].dev = &hx711_devs;
+    saul_entries[0].name = hx711_saul_info.name;
+    saul_entries[0].driver = &hx711_saul_driver;
+    saul_reg_add(&(saul_entries[0]));
+}
+
+#else
+typedef int dont_be_pedantic;
+#endif /* MODULE_HTS221 */

--- a/tests/driver_hx711/Makefile
+++ b/tests/driver_hx711/Makefile
@@ -1,0 +1,10 @@
+include ../Makefile.tests_common
+
+USEMODULE += hx711
+USEMODULE += xtimer
+
+# Change these values, if your device is connected on different pins
+CFLAGS += "-DHX711_PARAM_SCK=GPIO_PIN(1, 13)"
+CFLAGS += "-DHX711_PARAM_DOUT=GPIO_PIN(1, 14)"
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/driver_hx711/README.md
+++ b/tests/driver_hx711/README.md
@@ -1,0 +1,1 @@
+Check the hx711_driver_calibration for further details about how to calibrate the sensor.

--- a/tests/driver_hx711/main.c
+++ b/tests/driver_hx711/main.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2019 Philipp-Alexander Blum
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for HX711 scale weight sensor
+ *
+ * @author      Philipp-Alexander Blum <philipp-blum@jakiku.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <inttypes.h>
+
+#include "hx711.h"
+#include "hx711_params.h"
+#include "xtimer.h"
+#include "board.h"
+
+int main(void)
+{
+    puts("HX711 test application\n");
+
+    printf("+------------Initializing------------+\n");
+    hx711_init();
+
+    puts("Initialization successful");
+
+    printf("\n+--------Starting Measurements--------+\n");
+    while (1) {
+        printf("Unit values: %lu"
+               "\n+-------------------------------------+\n",
+               hx711_get_units(40));
+
+        /* 2s delay before next measure*/
+        xtimer_sleep(2);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
### Contribution description
Add drivers for the HX711 weight scale sensor. SAUL adoption included. 
Added SAUL_SENSE_WEIGHT as new SAUL type.

### Testing procedure
Flash tests/driver_hx711 or example/hx711_driver_calibration with your board configuration.
Read the README.md before. You might need to change the SCK and DOUT pin configuration.

### Issues/PRs references
~~periph/gpio_util is needed for this driver. See #9771.~~ merged
