### PR TITLE
cpu/esp32: resolve esptool.py warning

### DIFF
--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -139,7 +139,7 @@ LINKFLAGS += -Wl,--warn-unresolved-symbols
 # configure preflasher to convert .elf to .bin before flashing
 FLASH_MODE ?= dout  # FIX configuration, DO NOT CHANGE
 FLASH_FREQ  = 40m   # FIX configuration, DO NOT CHANGE
-FLASH_SIZE ?= 16m
+FLASH_SIZE ?= 2MB
 export PREFLASHER = $(ESPTOOL)
 export PREFFLAGS  = --chip esp32 elf2image
 export PREFFLAGS += -fm $(FLASH_MODE) -fs $(FLASH_SIZE) -ff $(FLASH_FREQ)


### PR DESCRIPTION
### Contribution description

During the flash step `esptool.py` gives the following warning:

WARNING: Flash size arguments in megabits like '16m' are deprecated.
Please use the equivalent size '2MB'.
Megabit arguments may be removed in a future release.
esptool.py v2.7-dev

This patch replaces '16m' with '2MB' to enable future compatibility.

### Testing procedure

Flash an image to any ESP32 board