### PR TITLE
boards/esp32: add TTGO T-Beam board definition

### DIFF
--- a/boards/esp32-ttgo-t-beam/Makefile
+++ b/boards/esp32-ttgo-t-beam/Makefile
@@ -1,0 +1,5 @@
+MODULE = board
+
+DIRS = $(RIOTBOARD)/common/esp32
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/esp32-ttgo-t-beam/Makefile.dep
+++ b/boards/esp32-ttgo-t-beam/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/common/esp32/Makefile.dep

--- a/boards/esp32-ttgo-t-beam/Makefile.features
+++ b/boards/esp32-ttgo-t-beam/Makefile.features
@@ -1,0 +1,15 @@
+# common board and CPU features
+include $(RIOTBOARD)/common/esp32/Makefile.features
+
+# additional features provided by the board
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_dac
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_uart
+
+FEATURES_PROVIDED += arduino
+
+# unique features provided by the board
+FEATURES_PROVIDED += esp_spi_ram

--- a/boards/esp32-ttgo-t-beam/Makefile.include
+++ b/boards/esp32-ttgo-t-beam/Makefile.include
@@ -1,0 +1,5 @@
+PSEUDOMODULES += esp32_ttgo_t_beam_v1_0
+
+USEMODULE += boards_common_esp32
+
+include $(RIOTBOARD)/common/esp32/Makefile.include

--- a/boards/esp32-ttgo-t-beam/doc.txt
+++ b/boards/esp32-ttgo-t-beam/doc.txt
@@ -1,0 +1,197 @@
+/*
+ * Copyright (C) 2019 Yegor Yefremov
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    boards_esp32_ttgo-t-beam TTGO T-Beam
+ * @ingroup     boards_esp32
+ * @brief       Support for TTGO T-Beam boards
+ * @author      Yegor Yefremov <yegorslists@googlemail.com>
+
+## <a name="toc"> Table of Contents </a>
+
+1. [Overview](#overview)
+2. [Hardware](#hardware)
+    1. [MCU](#mcu)
+    2. [Board Configuration](#board_configuration)
+    3. [Board Pinout](#pinout)
+    4. [Optional Hardware Configurations](#optional_hardware)
+3. [Flashing the Device](#flashing)
+
+## <a name="overview"> Overview </a> &nbsp;&nbsp; [[TOC](#toc)]
+
+TTGO T-Beam is an ESP32 development board with 4 MB Flash that uses
+the EPS32 chip directly. It integrates:
+
+- a SemTech SX1276 or SX1278 for LoRaWAN communication
+- a U-Blox Neo-6M GPS receiver
+
+There are at least three board types: rev0, rev1, and V1.0. Versions
+rev0 and rev1 are very similar, the only difference is that rev1 has
+an additional LED connected to GPIO14. The pinout of V1.0 has more
+changes thus it is necessary to add the following line to the makefile
+of the application to use the according configuration for TTGO T-Beam V1.0:
+```
+USEMODULE += esp32_ttgo_t_beam_v1_0
+```
+
+## <a name="hardware"> Hardware </a> &nbsp;&nbsp; [[TOC](#toc)]
+
+This section describes
+
+- the [MCU](#mcu),
+- the default [board configuration](#board_configuration),
+- [optional hardware configurations](#optional_hardware),
+- the [board pinout](#pinout).
+
+### <a name="mcu"> MCU </a> &nbsp;&nbsp; [[TOC](#toc)]
+
+Most features of the board are provided by the ESP32 SoC. The following
+table summarizes these features and gives an overview of which of these
+features are supported by RIOT. For detailed information about the ESP32,
+see section \ref esp32_mcu "MCU ESP32".
+
+<center>
+MCU         | ESP32     | Supported by RIOT
+------------|-----------|------------------
+Vendor      | Espressif | |
+Cores       | 1 or 2 x Tensilica Xtensa LX6 | 1 core
+FPU         | yes (ULP - Ultra low power co-processor) | no
+RAM         | 520 kByte SRAM <br> 16 kByte  RTC SRAM | yes
+ROM         | 448 kByte | yes
+Flash       | 512 kByte ... 16 MByte |  yes
+Frequency   | 240 MHz, 160 MHz, 80 MHz | yes
+Power Consumption | 68 mA @ 240 MHz <br> 44 mA @ 160 MHz <br> 31 mA @ 80 MHz <br> 5 uA in deep sleep mode | yes <br> yes <br> yes <br> no
+Timers      | 4 x 64 bit | yes
+ADCs        | 2 x SAR-ADC with up to 18 x 12 bit channels total | yes
+DACs        | 2 x DAC with 8 bit | yes
+GPIOs       | 34 (6 of them are only inputs) | yes
+I2Cs        | 2 | yes
+SPIs        | 4 | yes
+UARTs       | 3 | yes
+WiFi        | IEEE 802.11 b/g/n built in | yes
+Bluetooth   | v4.2 BR/EDR and BLE | no
+Ethernet    | MAC interface with dedicated DMA and IEEE 1588 support | yes
+CAN         | version 2.0 | yes
+IR          | up to 8 channels TX/RX | no
+Motor PWM   | 2 devices x 6 channels | yes
+LED PWM     | 16 channels | no
+Crypto      | Hardware acceleration of AES, SHA-2, RSA, ECC, RNG | no
+Vcc         | 2.5 - 3.6 V | |
+Documents   | [Datasheet](https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf) <br> [Technical Reference](https://www.espressif.com/sites/default/files/documentation/esp32_technical_reference_manual_en.pdf) | |
+</center>
+
+### <a name="board_configuration"> Board Configuration </a> &nbsp;&nbsp; [[TOC](#toc)]
+
+TTGO T-Beam has the following on-board components:
+
+- SemTech SX1276 or SX1278 for LoRaWAN communication
+- U-Blox Neo-6M GPS receiver
+
+There are two hardware versions of the board:
+
+- SemTech SX1276 for LoRaWAN communication in the 433 MHz band
+- SemTech SX1278 for LoRaWAN communication in the 868/915 MHz band
+
+Since many GPIOs are broken out, they can be used for different purposes
+in different applications. For flexibility, some GPIOs might be listed in
+various peripheral configurations. For example, GPIO0 is used in the ADC
+channel definition \ref ADC_GPIOS and the PWM channel definition \ref PWM0_GPIOS.
+
+This is possible because GPIOs are only used for a specific peripheral
+interface when
+
+- the corresponding peripheral module is used, e.g., module `periph_i2c`, or
+- a corresponding init function is called e.g., \ref adc_init, \ref dac_init
+  and \ref pwm_init, or
+- the corresponding peripheral interface is used for the first time, e.g.,
+  \ref spi_acquire.
+
+That is, the purpose for which a GPIO is actually used depends on which module
+or function is used first.
+
+@note GPIOs 5, 12, 15, 16, 17, 18, 19, 26, and 27 are
+used for board control functions and should not be used for other purposes
+unless you exactly know what you are doing.
+
+The following table shows the default board configuration, which is sorted
+according to the defined functionality of GPIOs. This configuration can be
+overridden by \ref esp32_app_spec_conf "application-specific configurations".
+
+TTGO- T-Beam rev1
+
+<center>
+\anchor esp32_ttgo_t_beam_rev1_table_board_configuration
+Function        | GPIOs  | Remarks |Configuration
+:---------------|:-------|:--------|:----------------------------------
+BUTTON0         | GPIO39 | low active  | |
+LED0            | GPIO14 | high active | |
+ADC             | GPIO0, GPIO2, GPIO4, GPIO13,<br>GPIO25, GPIO32, GPIO33, GPIO34,<br>GPIO35 | | \ref esp32_adc_channels "ADC Channels"
+DAC             | GPIO25 | | \ref esp32_dac_channels "DAC Channels"
+PWM_DEV(0)      | GPIO0, GPIO2, GPIO25 | | \ref esp32_pwm_channels "PWM Channels"
+I2C_DEV(0):SDA  | GPIO21 | | \ref esp32_i2c_interfaces "I2C Interfaces"
+I2C_DEV(0):SCL  | GPIO22 | I2C_SPEED_FAST is used | \ref esp32_i2c_interfaces "I2C Interfaces"
+SPI_DEV(0):CLK  | GPIO5 | VSPI is used | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(0):MISO | GPIO19 | VSPI is used | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(0):MOSI | GPIO27 | VSPI is used | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(0):CS0  | GPIO18 | VSPI is used | \ref esp32_spi_interfaces "SPI Interfaces"
+UART_DEV(0):TxD | GPIO1  | Console (configuration is fixed) | \ref esp32_uart_interfaces "UART interfaces"
+UART_DEV(0):RxD | GPIO3  | Console (configuration is fixed) | \ref esp32_uart_interfaces "UART interfaces"
+UART_DEV(1):TxD | GPIO15 | GPS (configuration is fixed) | \ref esp32_uart_interfaces "UART interfaces"
+UART_DEV(1):RxD | GPIO12 | GPS (configuration is fixed) | \ref esp32_uart_interfaces "UART interfaces"
+</center>
+
+TTGO- T-Beam V1.0
+
+<center>
+\anchor esp32_ttgo_t_beam_v1_0_table_board_configuration
+Function        | GPIOs  | Remarks |Configuration
+:---------------|:-------|:--------|:----------------------------------
+BUTTON0         | GPIO38 | low active  | |
+ADC             | GPIO0, GPIO2, GPIO4, GPIO13,<br>GPIO25, GPIO32, GPIO33, GPIO35 | | \ref esp32_adc_channels "ADC Channels"
+DAC             | GPIO25 | | \ref esp32_dac_channels "DAC Channels"
+PWM_DEV(0)      | GPIO0, GPIO2, GPIO25 | | \ref esp32_pwm_channels "PWM Channels"
+I2C_DEV(0):SDA  | GPIO21 | | \ref esp32_i2c_interfaces "I2C Interfaces"
+I2C_DEV(0):SCL  | GPIO22 | I2C_SPEED_FAST is used | \ref esp32_i2c_interfaces "I2C Interfaces"
+SPI_DEV(0):CLK  | GPIO5 | VSPI is used | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(0):MISO | GPIO19 | VSPI is used | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(0):MOSI | GPIO27 | VSPI is used | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(0):CS0  | GPIO18 | VSPI is used | \ref esp32_spi_interfaces "SPI Interfaces"
+UART_DEV(0):TxD | GPIO1  | Console (configuration is fixed) | \ref esp32_uart_interfaces "UART interfaces"
+UART_DEV(0):RxD | GPIO3  | Console (configuration is fixed) | \ref esp32_uart_interfaces "UART interfaces"
+UART_DEV(1):TxD | GPIO34 | GPS (configuration is fixed) | \ref esp32_uart_interfaces "UART interfaces"
+UART_DEV(1):RxD | GPIO12 | GPS (configuration is fixed) | \ref esp32_uart_interfaces "UART interfaces"
+</center>
+
+<br>
+@note
+- The configuration of ADC channels contains all ESP32 GPIOs that can be used
+  as ADC channels.
+
+For detailed information about the configuration of ESP32 boards, see
+section \ref esp32_comm_periph "Common Peripherals".
+
+### <a name="pinout"> Board Pinout </a> &nbsp;&nbsp; [[TOC](#toc)]
+
+The following figures show the pinout of the defined default configurations for TTGO T-Beam boards.
+
+\anchor esp32_ttgo_t_beam_rev1_pinout
+@image html "https://ae01.alicdn.com/kf/HTB1OhPmXtzvK1RkSnfoq6zMwVXah.jpg" "TTGO T-Beam rev1 Pintout Diagram"
+
+\anchor esp32_ttgo_t_beam_v1_0_pinout
+@image html "https://ae01.alicdn.com/kf/Hee7e9a85bb294351952a073325e6b2f96.jpg" "TTGO T-Beam V1.0 Pintout Diagram"
+
+The corresponding board schematics can be found on TinyMicros.com for [TTGO T-Beam rev0](http://tinymicros.com/mediawiki/images/b/b9/TTGO_T-Beam_Schematic.pdf) and GitHub for [TTGO T-Beam V1.0](https://github.com/Xinyuan-LilyGO/TTGO-T-Beam/raw/master/schematic/T_BeamV1.0.pdf)
+
+## <a name="flashing"> Flashing the Device </a> &nbsp;&nbsp; [[TOC](#toc)]
+
+Flashing RIOT is quite easy. The board has a Micro-USB connector with reset/boot/flash logic. Just connect the board to your host computer and type using the programming port:
+```
+make flash BOARD=esp32-ttgo-t-beam ...
+```
+For detailed information about ESP32 as well as configuring and compiling RIOT for ESP32 boards, see \ref esp32_riot.
+ */

--- a/boards/esp32-ttgo-t-beam/include/arduino_board.h
+++ b/boards/esp32-ttgo-t-beam/include/arduino_board.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2019 Yegor Yefremov
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_esp32_ttgo-t-beam
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration for the Arduino API
+ *
+ * @author      Yegor Yefremov <yegorslists@googlemail.com>
+ */
+
+#ifndef ARDUINO_BOARD_H
+#define ARDUINO_BOARD_H
+
+#include "arduino_board_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   The on-board LED is connected to Arduino pin 3 on this board
+ */
+#ifndef MODULE_ESP32_TTGO_T_BEAM_V1_0
+#define ARDUINO_LED         (3)
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_BOARD_H */
+/** @} */

--- a/boards/esp32-ttgo-t-beam/include/arduino_pinmap.h
+++ b/boards/esp32-ttgo-t-beam/include/arduino_pinmap.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2019 Yegor Yefremov
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_esp32_ttgo-t-beam
+ * @{
+ *
+ * @file
+ * @brief       Mapping from MCU pins to Arduino pins
+ *
+ * @author      Yegor Yefremov <yegorslists@googlemail.com>
+ */
+
+#ifndef ARDUINO_PINMAP_H
+#define ARDUINO_PINMAP_H
+
+#include "periph/gpio.h"
+#include "periph/adc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name   Mapping of MCU pins to Arduino pins
+ * @{
+ */
+#define ARDUINO_PIN_0   GPIO3       /**< Arduino Uno pin 0 (RxD) */
+#define ARDUINO_PIN_1   GPIO1       /**< Arduino Uno pin 1 (TxD) */
+#define ARDUINO_PIN_2   GPIO0       /**< Arduino Uno pin 2 */
+#define ARDUINO_PIN_3   GPIO2       /**< Arduino Uno pin 3 (PWM) */
+#define ARDUINO_PIN_4   GPIO4       /**< Arduino Uno pin 4 */
+#define ARDUINO_PIN_5   GPIO13      /**< Arduino Uno pin 5 (PWM) */
+#define ARDUINO_PIN_6   GPIO15      /**< Arduino Uno pin 6 (PWM) */
+#define ARDUINO_PIN_7   GPIO21      /**< Arduino Uno pin 7 */
+#define ARDUINO_PIN_8   GPIO22      /**< Arduino Uno pin 8 */
+#define ARDUINO_PIN_9   GPIO23      /**< Arduino Uno pin 9 (PWM) */
+#define ARDUINO_PIN_10  GPIO_UNDEF  /**< Arduino Uno pin 10 (CS0 / PWM)  */
+#define ARDUINO_PIN_11  GPIO_UNDEF  /**< Arduino Uno pin 11 (MOSI / PWM) */
+#define ARDUINO_PIN_12  GPIO_UNDEF  /**< Arduino Uno pin 12 (MISO) */
+#define ARDUINO_PIN_13  GPIO14      /**< Arduino Uno pin 13 (LED) */
+#define ARDUINO_PIN_A0  GPIO25      /**< Arduino Uno pin A0 */
+#define ARDUINO_PIN_A1  GPIO32      /**< Arduino Uno pin A1 */
+#define ARDUINO_PIN_A2  GPIO33      /**< Arduino Uno pin A2 */
+#define ARDUINO_PIN_A3  GPIO35      /**< Arduino Uno pin A3 */
+#define ARDUINO_PIN_A4  GPIO36      /**< Arduino Uno pin A4 (SDA) */
+#define ARDUINO_PIN_A5  GPIO39      /**< Arduino Uno pin A5 (SCL) */
+/** @ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_PINMAP_H */
+/** @} */

--- a/boards/esp32-ttgo-t-beam/include/board.h
+++ b/boards/esp32-ttgo-t-beam/include/board.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2019 Yegor Yefremov
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_esp32_ttgo-t-beam
+ * @brief       Board specific definitions for TTGO T-Beam board
+ * @{
+ *
+ * TTGO T-Beam is an ESP32 development board with 8 MB Flash that
+ * uses the EPS32 chip directly. It integrates a SemTech SX1276 or SX1278 for
+ * LoRaWAN communication in the 433 MHz or the 868/915 MHz band, respectively.
+ * Additionally, it has an OLED display connected via I2C on board.
+ *
+ * For detailed information about the configuration of ESP32 boards, see
+ * section \ref esp32_comm_periph "Common Peripherals".
+ *
+ * @note
+ * Most definitions can be overridden by an \ref esp32_app_spec_conf
+ * "application-specific board configuration".
+ *
+ * @file
+ * @author      Yegor Yefremov <yegorslists@googlemail.com>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/**
+ * @name    Button pin definitions
+ * @{
+ */
+#if MODULE_ESP32_TTGO_T_BEAM_V1_0
+#define BUTTON0_PIN     GPIO38
+#else
+#define BUTTON0_PIN     GPIO39
+#endif
+/** @} */
+
+/**
+ * @name    LED (on-board) configuration
+ *
+ * @{
+ */
+#ifndef MODULE_ESP32_TTGO_T_BEAM_V1_0
+#define LED0_PIN        GPIO14
+#define LED0_ACTIVE     (1)     /**< LED is high active */
+#endif
+/** @} */
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+/**
+ * @name        SX127X
+ *
+ * SX127X configuration.
+ * @{
+ */
+#define SX127X_PARAM_SPI_NSS            GPIO18
+#define SX127X_PARAM_RESET              GPIO23
+#define SX127X_PARAM_DIO0               GPIO26
+#define SX127X_PARAM_DIO1               GPIO_UNDEF /* Pin is not connected to the LoRa chip directly */
+#define SX127X_PARAM_DIO2               GPIO_UNDEF /* Pin is not connected to the LoRa chip directly */
+#define SX127X_PARAM_DIO3               GPIO_UNDEF
+/** @} */
+
+/* include common board definitions as last step */
+#include "board_common.h"
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/esp32-ttgo-t-beam/include/gpio_params.h
+++ b/boards/esp32-ttgo-t-beam/include/gpio_params.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2019 Yegor Yefremov
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+/**
+ * @ingroup     boards_esp32_ttgo-t-beam
+ * @brief       Board specific configuration of direct mapped GPIOs
+ * @file
+ * @author      Yegor Yefremov <yegorslists@googlemail.com>
+ * @{
+ */
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   LED configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+#ifndef MODULE_ESP32_TTGO_T_BEAM_V1_0
+    {
+        .name = "LED",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT,
+        .flags = SAUL_GPIO_INIT_CLEAR
+    },
+#endif
+    {
+        .name = "PRG",
+        .pin = BUTTON0_PIN,
+        .mode = GPIO_IN,
+        .flags = SAUL_GPIO_INVERTED
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/esp32-ttgo-t-beam/include/periph_conf.h
+++ b/boards/esp32-ttgo-t-beam/include/periph_conf.h
@@ -1,0 +1,182 @@
+/*
+ * Copyright (C) 2019 Yegor Yefremov
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_esp32_ttgo-t-beam
+ * @brief       Peripheral MCU configuration for TTGO T-Beam board
+ * @{
+ *
+ * TTGO T-Beam is an ESP32 development board with 4 MB Flash that
+ * uses the EPS32 chip directly. It integrates a SemTech SX1276 or SX1278 for
+ * LoRaWAN communication in the 433 MHz or the 868/915 MHz band, respectively.
+ * Additionally, it has an GPS receiver connected via UART on board.
+ *
+ * For detailed information about the configuration of ESP32 boards, see
+ * section \ref esp32_comm_periph "Common Peripherals".
+ *
+ * @note
+ * Most definitions can be overridden by an \ref esp32_app_spec_conf
+ * "application-specific board configuration".
+ *
+ * @file
+ * @author      Yegor Yefremov <yegorslists@googlemail.com>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/**
+ * @name    ADC and DAC channel configuration
+ * @{
+ */
+
+/**
+ * @brief   Declaration of GPIOs that can be used as ADC channels
+ *
+ * @note As long as the GPIOs listed in ADC_GPIOS are not initialized as ADC
+ * channels with the \ref adc_init function, they can be used for other
+ * purposes.
+ */
+#ifndef ADC_GPIOS
+#if MODULE_ESP32_TTGO_T_BEAM_V1_0
+#define ADC_GPIOS   { GPIO0, GPIO2, GPIO4, GPIO13, GPIO25, \
+                      GPIO32, GPIO33, GPIO35 }
+#else
+#define ADC_GPIOS   { GPIO0, GPIO2, GPIO4, GPIO13, GPIO25, \
+                      GPIO32, GPIO33, GPIO34, GPIO35 }
+#endif
+#endif
+
+/**
+ * @brief   Declaration of GPIOs that can be used as DAC channels
+ *
+ * @note As long as the GPIOs listed in DAC_GPIOS are not initialized as DAC
+ * channels with the \ref dac_init function, they can be used for other
+ * purposes.
+ *
+ * Since all DAC GPIOs are used for board control functions, there are no
+ * GPIOs left that can be used as DAC channels.
+ */
+#ifndef DAC_GPIOS
+#define DAC_GPIOS   { GPIO25 }
+#endif
+/** @} */
+
+
+/**
+ * @name   I2C configuration
+ *
+ * Only I2C interface I2C_DEV(0) is used.
+ *
+ * @note The GPIOs listed in the configuration are only initialized as I2C
+ * signals when module `perpih_i2c` is used. Otherwise they are not
+ * allocated and can be used for other purposes.
+ *
+ * @{
+ */
+#ifndef I2C0_SPEED
+#define I2C0_SPEED  I2C_SPEED_FAST  /**< I2C bus speed of I2C_DEV(0) */
+#endif
+#ifndef I2C0_SCL
+#define I2C0_SCL    GPIO22          /**< SCL signal of I2C_DEV(0) */
+#endif
+#ifndef I2C0_SDA
+#define I2C0_SDA    GPIO21          /**< SDA signal of I2C_DEV(0) */
+#endif
+/** @} */
+
+
+/**
+ * @name   PWM channel configuration
+ *
+ * @note As long as the according PWM device is not initialized with
+ * the ```pwm_init```, the GPIOs declared for this device can be used
+ * for other purposes.
+ *
+ * @{
+ */
+/** PWM channels for device PWM_DEV(0) */
+#ifndef PWM0_GPIOS
+#define PWM0_GPIOS  { GPIO14, GPIO0, GPIO2, GPIO25 }
+#endif
+/** @} */
+
+/**
+ * @name    SPI configuration
+ *
+ * @note The GPIOs listed in the configuration are first initialized as SPI
+ * signals when the corresponding SPI interface is used for the first time
+ * by either calling the ```spi_init_cs``` function or the ```spi_acquire```
+ * function. That is, they are not allocated as SPI signals before and can
+ * be used for other purposes as long as the SPI interface is not used.
+ *
+ * @{
+ */
+#ifndef SPI0_CTRL
+#define SPI0_CTRL   VSPI    /**< VSPI is used as SPI_DEV(0) */
+#endif
+#ifndef SPI0_SCK
+#define SPI0_SCK    GPIO5   /**< VSPI SCK */
+#endif
+#ifndef SPI0_MISO
+#define SPI0_MISO   GPIO19  /**< VSPI MISO */
+#endif
+#ifndef SPI0_MOSI
+#define SPI0_MOSI   GPIO27  /**< VSPI MOSI */
+#endif
+#ifndef SPI0_CS0
+#define SPI0_CS0    GPIO18  /**< VSPI CS0 */
+#endif
+/** @} */
+
+/**
+ * @name   UART configuration
+ *
+ * ESP32 provides 3 UART interfaces at maximum:
+ *
+ * UART_DEV(0) uses fixed standard configuration.<br>
+ * UART_DEV(1) is defined here.<br>
+ * UART_DEV(2) is not used.<br>
+ *
+ * @{
+ */
+#define UART0_TXD   GPIO1  /**< direct I/O pin for UART_DEV(0) TxD, can't be changed */
+#define UART0_RXD   GPIO3  /**< direct I/O pin for UART_DEV(0) RxD, can't be changed */
+
+#ifndef UART1_TXD
+#if MODULE_ESP32_TTGO_T_BEAM_V1_0
+#define UART1_TXD   GPIO12  /**< direct I/O pin for UART_DEV(1) TxD */
+#else
+#define UART1_TXD   GPIO15  /**< direct I/O pin for UART_DEV(1) TxD */
+#endif /* MODULE_ESP32_TTGO_T_BEAM_V1_0 */
+#endif
+#ifndef UART1_RXD
+#if MODULE_ESP32_TTGO_T_BEAM_V1_0
+#define UART1_RXD   GPIO34  /**< direct I/O pin for UART_DEV(1) RxD */
+#else
+#define UART1_RXD   GPIO12  /**< direct I/O pin for UART_DEV(1) RxD */
+#endif /* MODULE_ESP32_TTGO_T_BEAM_V1_0 */
+#endif
+/** @} */
+
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+/* include common board definitions as last step */
+#include "periph_conf_common.h"
+
+#endif /* PERIPH_CONF_H */
+/** @} */


### PR DESCRIPTION
### Contribution description

This PR adds the board definition for TTGO T-Beam board. TTGO T-Beam is an ESP32 development board with 4 MB Flash that uses the EPS32 chip directly. It integrates

    a SemTech SX1276 or SX1278 for LoRaWAN communication and
    a GPS receiver connected via UART.

Many GPIOs are broken out. 