### PR TITLE
dist/tools/nrf52_resetpin: delete obsolete register [backport 2019.04]

### DIFF
--- a/dist/tools/nrf52_resetpin_cfg/main.c
+++ b/dist/tools/nrf52_resetpin_cfg/main.c
@@ -73,7 +73,6 @@ static void _restore_uicr(void)
     NRF_UICR->APPROTECT = _buf.APPROTECT;
     NRF_UICR->NFCPINS = _buf.NFCPINS;
 #ifdef CPU_MODEL_NRF52840XXAA
-    NRF_UICR->EXTSUPPLY = _buf.EXTSUPPLY;
     NRF_UICR->REGOUT0 = _buf.REGOUT0;
 #endif
 


### PR DESCRIPTION
# Backport of #11411

### Contribution description

After updating the vendor headers of the nrf52840 the tool to setup the resetpin of nrf52 boards did not work anymore for nrf52840dk. The reason was a faulty description of the `EXTSUPPLY` register.
This PR simply deletes setting of this register.

### Testing procedure

Testing it by flashing the tool on nrf52840dk and follow instructions of the tool.

EDIT: you might want to dig around the files history, to see how it vanished:
https://github.com/RIOT-OS/RIOT/commit/d8a30eeedf0afa494cc7773656226efa31190780#diff-34ea33c0ff70a29b6da073842653ccddL626
https://github.com/NordicSemiconductor/nrfx/commit/b7cfe970b45ad7cc9c36b62ee620508e9e2c7fb5#diff-578dfd966c1aacf8241aa7e27c7d36bbL619
https://github.com/NordicSemiconductor/nrfx/commit/cf78ebfea1719d85cf4018fe6c08cc73fe5ec719#diff-578dfd966c1aacf8241aa7e27c7d36bbL619