### PR TITLE
Makefile.include: include Makefile.features after $(CPU)/Makefile.include

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -244,9 +244,6 @@ export PREFIX ?= $(if $(TARGET_ARCH),$(TARGET_ARCH)-)
 # Add standard include directories
 INCLUDES += -I$(RIOTBASE)/core/include -I$(RIOTBASE)/drivers/include -I$(RIOTBASE)/sys/include
 
-# process provided features
-include $(RIOTBOARD)/$(BOARD)/Makefile.features
-
 # mandatory includes!
 include $(RIOTMAKE)/pseudomodules.inc.mk
 include $(RIOTMAKE)/defaultmodules.inc.mk
@@ -256,6 +253,9 @@ INCLUDES += $(addprefix -I,$(wildcard $(RIOTBOARD)/$(BOARD)/include))
 include $(RIOTBOARD)/$(BOARD)/Makefile.include
 INCLUDES += -I$(RIOTCPU)/$(CPU)/include
 include $(RIOTCPU)/$(CPU)/Makefile.include
+
+# process provided features
+include $(RIOTBOARD)/$(BOARD)/Makefile.features
 
 # Sanity check
 # The check is only done after 'include $(RIOTBOARD)/$(BOARD)/Makefile.include'


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Currently in base Makefile.include, Makefile.fatures for a BOARD is included after `$(RIOTCPU)/$(CPU)/Makefile.include`. 

https://github.com/RIOT-OS/RIOT/blob/9a6473104d27e050a5e9318d58dc92bb55c4f268/Makefile.include#L247-L258

This causes the below statement to have no effect since KINETIS_SERIES isn't defined at this point. But more generaly means none of the variables defined are in `$(RIOTCPU)/$(CPU)/Makefile.include` are yet available.

https://github.com/RIOT-OS/RIOT/blob/9a6473104d27e050a5e9318d58dc92bb55c4f268/cpu/kinetis/Makefile.features#L5-L9

Moving Makfile.features below `include $(RIOTCPU)/$(CPU)/Makefile.include`. would allow using the SERIES, FAMILY, etc. to include some features for the specific group.

I'm not sure of the impact of this change, I would like @cladmi insight on the matter. Based on my inspection of the build system there would be no negative impact since FEATURES_PROVIDED are first used by Makefile.dep. Also Makefile.features files only reference themselves so this doesn't affect the include `$(RIOTBOARD)/$(BOARD)/Makefile.include` and `$(RIOTCPU)/$(CPU)/Makefile.include`.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

All applications for all boards should still compile as expected.

To see this fixes #11423 add `$(info Kinetis series: $(KINETIS_SERIES))` just before the above the code below and call `make -C examples/hello-world/ BOARD=pba-d-01-kw2x`.

https://github.com/RIOT-OS/RIOT/blob/9a6473104d27e050a5e9318d58dc92bb55c4f268/cpu/kinetis/Makefile.features#L5-L9

Without this PR:
```
make: Entering directory '/home/francisco/workspace/RIOT/examples/hello-world'
Kinetis series: W
Building application "hello-world" for "pba-d-01-kw2x" with MCU "kinetis".
```

Without this PR:
```
make: Entering directory '/home/francisco/workspace/RIOT/examples/hello-world'
Kinetis series:
Building application "hello-world" for "pba-d-01-kw2x" with MCU "kinetis".
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

Could fix #11423.
Related to #8713

