### PR TITLE
makefiles: add bootloaders to the list of applications

### DIFF
--- a/makefiles/app_dirs.inc.mk
+++ b/makefiles/app_dirs.inc.mk
@@ -6,8 +6,9 @@ RIOTBASE ?= .
 # 3. use patsubst to drop possible leading "./"
 # 4. sort
 APPLICATION_DIRS := $(sort $(patsubst ./%,%,$(patsubst %/,%,$(dir $(wildcard \
-	$(RIOTBASE)/examples/*/Makefile \
-	$(RIOTBASE)/tests/*/Makefile    \
+	$(RIOTBASE)/bootloaders/*/Makefile \
+	$(RIOTBASE)/examples/*/Makefile    \
+	$(RIOTBASE)/tests/*/Makefile       \
 	)))))
 
 info-applications:


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This is adding bootloaders applications (for the moment only applicable to riotboot) to the list of applications to run `distclean` target on.

I needed to save some space on my hard drive and found that this was not cleanup by the distclean target.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- build riotboot: `make -C tests/riotboot` and verify there's a bin directory in `bootloaders/riotboot`
- run `make distclean`: when it completes there shouldn't be any `bin` directory remaining in `bootloaders/riotboot`. On master, this has no effect on this `bin` directory.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
