### PR TITLE
drivers/at86rf2xx: enable NETOPT_RX_END_IRQ and fix RSSI values

### DIFF
--- a/tests/driver_at86rf2xx/main.c
+++ b/tests/driver_at86rf2xx/main.c
@@ -91,6 +91,7 @@ int main(void)
     xtimer_init();
 
     for (unsigned i = 0; i < AT86RF2XX_NUM; i++) {
+        netopt_enable_t en = NETOPT_ENABLE;
         const at86rf2xx_params_t *p = &at86rf2xx_params[i];
         netdev_t *dev = (netdev_t *)(&devs[i]);
 
@@ -98,6 +99,7 @@ int main(void)
         at86rf2xx_setup(&devs[i], p);
         dev->event_callback = _event_cb;
         dev->driver->init(dev);
+        dev->driver->set(dev, NETOPT_RX_END_IRQ, &en, sizeof(en));
     }
 
     _recv_pid = thread_create(stack, sizeof(stack), THREAD_PRIORITY_MAIN - 1,

--- a/tests/driver_at86rf2xx/recv.c
+++ b/tests/driver_at86rf2xx/recv.c
@@ -111,7 +111,7 @@ void recv(netdev_t *dev)
         }
     }
     printf("\n");
-    printf("RSSI: %u, LQI: %u\n\n", rx_info.rssi, rx_info.lqi);
+    printf("RSSI: %i, LQI: %u\n\n", rx_info.rssi, rx_info.lqi);
 }
 
 /** @} */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR fixes the `at86rf2xx` test:
- Enables NETOPT_RX_END_IRQ in order to receive packets.
- Prints RSSI as signed instead of unsigned


<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`make -C tests/drivers_at86rf2xx all flash term`. Try using the `txtsnd` command with and without this PR, and check received packets and RSSI values.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None so far
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
