### PR TITLE
gnrc_ipv6_nib: don't autoconfig IPv6 address without L2 addr [backport 2019.04]

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
@@ -34,6 +34,10 @@ void _auto_configure_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
     int idx;
     uint8_t flags = GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_TENTATIVE;
 
+    if (!(netif->flags & GNRC_NETIF_FLAGS_HAS_L2ADDR)) {
+        DEBUG("nib: interface %i has no link-layer addresses\n", netif->pid);
+        return;
+    }
     DEBUG("nib: add address based on %s/%u automatically to interface %u\n",
           ipv6_addr_to_str(addr_str, pfx, sizeof(addr_str)),
           pfx_len, netif->pid);


### PR DESCRIPTION
# Backport of #10483

### Contribution description
If the interface's link-layer doesn't use link-layer addresses it obviously doesn't make sense to auto-configure an IPv6 address from it. Moreover, I think the address `fe80::` is actual illegal, but I couldn't find any references for it.

### Testing procedure
Try running an application with `slipdev`. The interfaces should not have an auto-configured IPv6 address with this PR. Without this PR an address `fe80::` (and the respective solicited nodes multicast address) show up.

### Issues/PRs references
Unrelated but found when debugging #10480.