### PR TITLE
Makefile.include: allow overwriting flash-recipe

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -526,10 +526,12 @@ distclean:
 	-@for i in $(USEPKG) ; do "$(MAKE)" -C $(RIOTPKG)/$$i distclean ; done
 	-@rm -rf $(BINDIRBASE)
 
-define flash-recipe
+# Define flash-recipe with a default value
+define default-flash-recipe
   $(call check_cmd,$(FLASHER),Flash program)
   $(FLASHER) $(FFLAGS)
 endef
+flash-recipe ?= $(default-flash-recipe)
 
 # Do not add dependencies to "flash" directly, use FLASHDEPS, as this is shared
 # with flash-only too


### PR DESCRIPTION
### Contribution description

This allows changing the flashing commands from the outside or in a BSP.

### Implementation

It cannot be set as `define flash-recipe ?=` as the feature is only introduced only in `gnumake 4`.
Also this allows re-using `default-flash-recipe` if wanted.

### Testing procedure

Flashing still works for a board that flashes. (CI will test this)

It can be overwritten:

```
make --no-print-directory -C examples/hello-world/ flash-only flash-recipe="echo changed recipe"
echo changed recipe
changed recipe
```

### Issues/PRs references

Could be used for #11093 without introducing a one flasher feature for the moment.

I need to overwrite `flash-recipe` to handle flashing on another machine in my setup and currently need to rely on `override` for setting the variable.

This would allow refactoring the `esp` flashing command to use commands on different lines
https://github.com/RIOT-OS/RIOT/blob/master/cpu/esp32/Makefile.include