### PR TITLE
 backport_pr: exclude 'Reviewed' labels from backport

### DIFF
--- a/dist/tools/backport_pr/backport_pr.py
+++ b/dist/tools/backport_pr/backport_pr.py
@@ -26,7 +26,7 @@ WORKTREE_SUBDIR = "backport_temp"
 RELEASE_PREFIX = ""
 RELEASE_SUFFIX = "-branch"
 
-LABELS_REMOVE = ['Process: needs backport']
+LABELS_REMOVE = ['Process: needs backport', 'Reviewed: ']
 LABELS_ADD = ['Process: release backport']
 
 BACKPORT_BRANCH = 'backport/{release}/{origbranch}'
@@ -36,14 +36,16 @@ def _get_labels(pr):
     """
     >>> _get_labels({'labels': [{'name': 'test'}, {'name': 'abcd'}]})
     ['Process: release backport', 'abcd', 'test']
+    >>> _get_labels({'labels': [{'name': 'Reviewed: what'}, {'name': 'Reviewed: 3-testing'}]})
+    ['Process: release backport']
     >>> _get_labels({'labels': [{'name': 'Process: release backport'}]})
     ['Process: release backport']
     >>> _get_labels({'labels': [{'name': 'Process: needs backport'}]})
     ['Process: release backport']
     """
-    labels = {label['name'] for label in pr['labels']}
-    for remove in LABELS_REMOVE:
-        labels.discard(remove)
+    labels = set(label['name'] for label in pr['labels']
+                 if all(not label['name'].startswith(remove)
+                        for remove in LABELS_REMOVE))
     labels.update(LABELS_ADD)
     return sorted(list(labels))
 

--- a/dist/tools/backport_pr/backport_pr.py
+++ b/dist/tools/backport_pr/backport_pr.py
@@ -33,6 +33,14 @@ BACKPORT_BRANCH = 'backport/{release}/{origbranch}'
 
 
 def _get_labels(pr):
+    """
+    >>> _get_labels({'labels': [{'name': 'test'}, {'name': 'abcd'}]})
+    ['Process: release backport', 'abcd', 'test']
+    >>> _get_labels({'labels': [{'name': 'Process: release backport'}]})
+    ['Process: release backport']
+    >>> _get_labels({'labels': [{'name': 'Process: needs backport'}]})
+    ['Process: release backport']
+    """
     labels = {label['name'] for label in pr['labels']}
     for remove in LABELS_REMOVE:
         labels.discard(remove)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
I noticed in https://github.com/RIOT-OS/RIOT/pull/11430 that the backporting scripts also sets the `Reviewed: ` labels, which given that the new PR needs to be re-reviewed might be confusing to unhelpful. This PR removes those labels (and also provides some doc-tests for the `_get_labels()` function).
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
```sh
python3 -m doctest dist/tools/backport_pr/backport_pr.py
```

should pass with and without the last commit (~~6b25328~~ e3a99c4).
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
