### PR TITLE
backport_pr: set tracking branch to remotely created branch

### DIFF
--- a/dist/tools/backport_pr/backport_pr.py
+++ b/dist/tools/backport_pr/backport_pr.py
@@ -193,7 +193,8 @@ def main():
         origin = _find_remote(repo, username, REPO)
         print("Pushing branch {} to {}".format(new_branch, origin))
         if not args.noop:
-            repo.git.push(origin, '{0}:{0}'.format(new_branch))
+            push_info = origin.push('{0}:{0}'.format(new_branch))
+            new_branch.set_tracking_branch(push_info[0].remote_ref)
     except Exception as exc:
         # Delete worktree
         print("Pruning temporary workdir at {}".format(worktree_dir))

--- a/dist/tools/backport_pr/backport_pr.py
+++ b/dist/tools/backport_pr/backport_pr.py
@@ -182,6 +182,8 @@ def main():
                       new_branch,
                       WORKTREE_SUBDIR,
                       "{}/{}".format(upstream_remote, release_fullname))
+    # transform branch name into Head object for later configuring
+    new_branch = repo.branches[new_branch]
     try:
         bp_repo = git.Repo(worktree_dir)
         # Apply commits


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
I think it is confusing, that the tracking branch of the backport branch is set to the release branch.

However, you can actually get the info about which remote branch the branch was pushed to by using `remote.push(branch)` instead of `repo.git.push(remote, branch)` (see [`PushInfo` doc](https://gitpython.readthedocs.io/en/2.1.9/reference.html?highlight=PushInfo#git.remote.PushInfo). We can use the `remote_ref` attribute of that to [configure the tracking branch](https://gitpython.readthedocs.io/en/2.1.9/reference.html#git.refs.head.Head.set_tracking_branch) of the backport branch.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
For testing I removed the PR creation part of the script

```diff
diff --git a/dist/tools/backport_pr/backport_pr.py b/dist/tools/backport_pr/backport_pr.py
index 9ccad01..72edd26 100755
--- a/dist/tools/backport_pr/backport_pr.py
+++ b/dist/tools/backport_pr/backport_pr.py
@@ -206,41 +206,6 @@ def main():
         _delete_worktree(repo, worktree_dir)
     repo.branches[new_branch].set_tracking_branch(push_info[0].remote_ref)
 
-    labels = _get_labels(pulldata)
-    merger = pulldata['merged_by']['login']
-    if not args.noop:
-        # Open new PR on github
-        pr = {
-            'title': "{} [backport {}]".format(pulldata['title'],
-                                               release_shortname),
-            'head': '{}:{}'.format(username, new_branch),
-            'base': release_fullname,
-            'body': "# Backport of #{}\n\n{}".format(args.PR,
-                                                     pulldata['body']),
-            'maintainer_can_modify': True,
-        }
-        status, new_pr = g.repos[ORG][REPO].pulls.post(body=pr)
-        if status != 201:
-            print("Error creating the new pr: \"{}\". Is \"Public Repo\""
-                  " access enabled for the token"
-                  .format(new_pr['message']))
-        pr_number = new_pr['number']
-        print("Create PR number #{} for backport".format(pr_number))
-        g.repos[ORG][REPO].issues[pr_number].labels.post(body=labels)
-        review_request = {"reviewers": [merger]}
-        g.repos[ORG][REPO].pulls[pr_number].\
-            requested_reviewers.post(body=review_request)
-
-    # Put commit under old PR
-    if args.comment and not args.noop:
-        comment = {"body": "Backport provided in #{}".format(pr_number)}
-        status, res = g.repos[ORG][REPO].\
-            issues[args.PR].comments.post(body=comment)
-        if status != 201:
-            print("Something went wrong adding the comment: {}"
-                  .format(res['message']))
-        print("Added comment to #{}".format(args.PR))
-
 
 if __name__ == "__main__":
     main()
```

And picked a random closed PR to test the script with (considering `2019.04-branch` is still the most current release branch):

```
$ ./dist/tools/backport_pr/backport_pr.py 11427
Fetching for commit: #11427: pkg/c25519: cleanup in Makefiles
found 33bc8b67cc24dead665033cd2cccf0737dc905a7 : tests/pkg_c25519: remove useless test target
found 4ae1ef3f22f51f0f02d44d010e60849f7350f4ed : pkg/c25519: remove inexistent SHAFILE cleanup
Backport based on branch 2019.04-branch
Fetching upstream remote
Pushing branch backport/2019.04/pr/pkg/c25519_make_cleanup to origin
Pruning temporary workdir at /home/mlenders/Repositories/RIOT-OS/RIOT/backport_temp
$ git branch --list -vv backport/2019.04/pr/pkg/c25519_make_cleanup to origin
  backport/2019.04/pr/pkg/c25519_make_cleanup c749985 [origin/backport/2019.04/pr/pkg/c25519_make_cleanup] pkg/c25519: remove inexistent SHAFILE cleanup
```

Before this change it was

```
$ git branch --list -vv backport/2019.04/pr/pkg/c25519_make_cleanup to origin
  backport/2019.04/pr/pkg/c25519_make_cleanup c749985 [upstream/2019.04-branch] pkg/c25519: remove inexistent SHAFILE cleanup
```

#### Clean-up
```
git branch -D backport/2019.04/pr/pkg/c25519_make_cleanup
git push origin :backport/2019.04/pr/pkg/c25519_make_cleanup
```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
