### PR TITLE
net/nanocoap: add subtree handler

### DIFF
--- a/examples/nanocoap_server/coap_handler.c
+++ b/examples/nanocoap_server/coap_handler.c
@@ -157,6 +157,17 @@ ssize_t _sha256_handler(coap_pkt_t* pkt, uint8_t *buf, size_t len, void *context
     return pkt_pos - (uint8_t*)pkt->hdr;
 }
 
+/* example for having a subtree of coap resources handled by
+ * coap_subtree_handler */
+const coap_resource_t _subtree_example[] = {
+    { "/subtree/riot/ver", COAP_GET, _riot_block2_handler, NULL },
+};
+
+const coap_resource_subtree_t _subtree = {
+    _subtree_example,
+    1   /* number of entries in _subtree_example */
+};
+
 /* must be sorted by path (ASCII order) */
 const coap_resource_t coap_resources[] = {
     COAP_WELL_KNOWN_CORE_DEFAULT_HANDLER,
@@ -165,6 +176,7 @@ const coap_resource_t coap_resources[] = {
     { "/riot/value", COAP_GET | COAP_PUT | COAP_POST, _riot_value_handler, NULL },
     { "/riot/ver", COAP_GET, _riot_block2_handler, NULL },
     { "/sha256", COAP_POST, _sha256_handler, NULL },
+    { "/subtree", COAP_GET | COAP_MATCH_SUBTREE, coap_subtree_handler, (void *)&_subtree },
 };
 
 const unsigned coap_resources_numof = sizeof(coap_resources) / sizeof(coap_resources[0]);

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -302,6 +302,14 @@ typedef struct {
 } coap_resource_t;
 
 /**
+ * @brief   Type for CoAP resource subtrees
+ */
+typedef const struct {
+    const coap_resource_t *resources;   /**< ptr to resource array  */
+    const size_t resources_numof;       /**< nr of entries in array */
+} coap_resource_subtree_t;
+
+/**
  * @brief   Block1 helper struct
  */
 typedef struct {
@@ -1178,6 +1186,12 @@ static inline uint32_t coap_get_observe(coap_pkt_t *pkt)
 extern ssize_t coap_well_known_core_default_handler(coap_pkt_t *pkt, \
                                                     uint8_t *buf, size_t len,
                                                     void *context);
+
+/**
+ * @brief   Handler for delegating to subtree
+ */
+ssize_t coap_subtree_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len,
+                             void *context);
 
 /**
  * @brief   Resource definition for the default .well-known/core handler


### PR DESCRIPTION
### Contribution description

This PR adds a method to have subtrees consisting of coap_resource_t arrays.
#11098 added path prefix matching, this PR allows path prefixes to be defined in their own coap_resoucrce_t[].
Use-case is a module defining several endpoints grouped in a subtree.

I consider this a first iteration. Subtrees have no way of being listed in ".well-known/core", yet.

### Testing procedure

run examples/nanocoap_server, get "subtree/riot/ver".

### Issues/PRs references

#11098