### PR TITLE
sys: Added simple memory barrier API

### DIFF
--- a/core/include/mem_order.h
+++ b/core/include/mem_order.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2019 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    core_mem_order Low-Level Memory Ordering Primitives
+ * @ingroup     sys
+ * @brief       Low-Level Memory Ordering Primitives
+ *
+ * Low-level primitives to enforce order of memory accesses. These are not
+ * intended to be used by application code, please use the easier to use high
+ * level synchronization mechanisms in @ref core_sync instead.
+ *
+ * @file
+ * @{
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ */
+
+#ifndef MEM_ORDER_H
+#define MEM_ORDER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Prevent the compiler from moving global memory accesses across this
+ *          barrier, but **NOT** prevent the CPU from doing so
+ * @see     memory_barrier
+ * @see     compiler_barrier_data
+ * @warning Application code should use high level synchronization primitives
+ *          instead, see @ref core_sync
+ *
+ * Any read or store to global memory that is written in the code before this
+ * function will not be moved after this barrier by the compiler. Likewise,
+ * every read or store to global after this barrier will not be moved before
+ * this barrier.
+ */
+#define compiler_barrier() __asm__ volatile("": : :"memory")
+
+/**
+ * @brief   Prevent the compiler from moving global memory accesses across this
+ *          barrier and accesses to the local memory @p ptr points to, but
+ *          do **NOT** prevent the CPU from doing so
+ * @see     memory_barrier
+ * @see     compiler_barrier
+ * @warning Application code should use high level synchronization primitives
+ *          instead, see @ref core_sync
+ * @param   ptr     Pointer to local memory to also protect by the barrier
+ *
+ * This is identical to @ref compiler_barrier, but also accesses to the local
+ * memory @p ptr points to are protected. In order to include multiple local
+ * variables, repeat this macro for each local variable to protect. (You should
+ * put **no** code between the repeated calls to @ref compiler_barrier_data in
+ * order to pay the performance penalty of the global memory barrier only once.)
+ */
+#define compiler_barrier_data(ptr) __asm__ volatile("": : "r"(ptr) :"memory")
+
+/**
+ * @brief   Prevent both the compiler and the CPU from moving memory accesses
+ *          across this barrier
+ * @warning Application code should use high level synchronization primitives
+ *          instead, see @ref core_sync
+ */
+static inline void memory_barrier(void)
+{
+    __sync_synchronize();
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+#endif /* MEM_ORDER_H */


### PR DESCRIPTION
### Contribution description
- Added two and a half primitives to enforce memory ordering
    - `compiler_barrier()` (and `compiler_barrier_data()`) prevent the compiler from reordering memory accesses across them
    - `memory_barrier()` prevents the compiler from reordering memory accesses and - on out-of-order platforms only - prevents the CPU from doing so as well

### Testing procedure
 - Review the two lines of code
    - For `compiler_barrier()` check https://en.wikipedia.org/wiki/Memory_ordering#Compiler_memory_barrier
    - For `memory_barrier()` check https://gcc.gnu.org/onlinedocs/gcc/_005f_005fsync-Builtins.html and https://llvm.org/docs/Atomics.html
-  Test compilation of the following C code (e.g. by pasting into `examples/hello-world/main.c`)
    - Without the memory barrier the writes to `a` and `b` will be reordered and combined to two 32 bit writes on 32-bit platforms.
    - With the memory barrier only writes prior the barrier will be completed before the writes after the barrier take place. (Note that e.g. writes to `a` can still be merged and reordered in regard to the write to `b.u8[0]`, but not in regard to any other write to `b` - which take place after the barrier.)
    - With the memory barriers on sophisticated platforms (e.g. `nucleo-f767zi`) actual memory barrier instructions are emitted by the compiler (e.g. `dmb` (data memory barrier)); On in-order CPUs those instructions are neither supported nor needed

```C
#include <stdint.h>
#include "barriers.h"

typedef union {
    uint32_t u32;
    uint8_t u8[4];
} foo_t;

foo_t a, b;

void bar(void) {
    a.u8[0] = 0xa0;
    a.u8[1] = 0xa1;
    b.u8[0] = 0xb0;
    a.u8[2] = 0xa2;
    a.u8[3] = 0xa3;
    /* Add memory_barrier() here */
    b.u8[1] = 0xb1;
    b.u8[2] = 0xb2;
    b.u8[3] = 0xb3;
}
```

### Issues/PRs references
Potential users of this API: https://github.com/RIOT-OS/RIOT/pull/11073, https://github.com/RIOT-OS/RIOT/pull/8842