### PR TITLE
cpu/arm7_common: Make irq_*() compiler barriers

### DIFF
--- a/cpu/arm7_common/VIC.c
+++ b/cpu/arm7_common/VIC.c
@@ -14,20 +14,20 @@
 static inline unsigned __get_cpsr(void)
 {
     unsigned long retval;
-    __asm__ volatile(" mrs  %0, cpsr" : "=r"(retval) : /* no inputs */);
+    __asm__ volatile(" mrs  %0, cpsr" : "=r"(retval) : /* no inputs */ : "memory");
     return retval;
 }
 
 int irq_is_in(void)
 {
     int retval;
-    __asm__ volatile(" mrs  %0, cpsr" : "=r"(retval) : /* no inputs */);
+    __asm__ volatile(" mrs  %0, cpsr" : "=r"(retval) : /* no inputs */ : "memory");
     return (retval & INTMode) == 18;
 }
 
 static inline void __set_cpsr(unsigned val)
 {
-    __asm__ volatile(" msr  cpsr, %0" : /* no outputs */ : "r"(val));
+    __asm__ volatile(" msr  cpsr, %0" : /* no outputs */ : "r"(val) : "memory");
 }
 
 unsigned irq_disable(void)


### PR DESCRIPTION
### Contribution description
Previously the compiler was allowed to reorder access to the interrupt control registers in regard to memory access not marked as `volatile` (at least some people - most notably some compiler developers - read the C standard this way). In practise this did not happen as irq_disable(), irq_restore(), irq_enable() are part of a separate compilation unit: Calls to external functions unknown to the compiler are treated as if they were memory barriers. But if link time optimization (LTO) is enabled, this no longer would work: The compiler could inline the code accessing the interrupt control registers and reorder the memory accesses wrapped in irq_disable() and irq_restore() outside of their protection.

This commit adds the "memory" clobber to the inline assembly accessing the interrupt control registers. This makes those accesses explicit compiler memory barriers. The machine code generated without LTO enabled should not differ in any way by this commit. But the use of irq_*() should now be safe with LTO.

### Testing procedure
Compile some application for an ARMv7 (no CortexM) board, e.g. the MSB-A2. Without LTO no differences before and after this PR should be present, with this PR they could be present.

E.g. here is the output of [elf_diff](https://github.com/CapeLeidokos/elf_diff/) generated for the binaries in `examples/default` generated by:

- `make BOARD=msba2` https://mari-bu.de/arm7_no_lto.html
- `make BOARD=msba2 LTO=1` https://mari-bu.de/arm7_lto.html

### Issues/PRs references
Related to https://github.com/RIOT-OS/RIOT/pull/11438, as this implements the barrier claimed to be present in the doc there

----

Update 1: Updated binary diffs