### PR TITLE
gnrc_sixlowpan_frag: make aggresive override configurable

### DIFF
--- a/sys/include/net/gnrc/sixlowpan/config.h
+++ b/sys/include/net/gnrc/sixlowpan/config.h
@@ -69,6 +69,22 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Aggressively override reassembly buffer when full
+ *
+ * @note    Only applicable with
+ *          [gnrc_sixlowpan_frag](@ref net_gnrc_sixlowpan_frag) module
+ *
+ * When set to a non-zero value this will cause the reassembly buffer to
+ * override the oldest entry no matter what. When set to zero only the oldest
+ * entry that is older than @ref GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_MS will be
+ * overwritten (they will still timeout normally if reassembly buffer is not
+ * full).
+ */
+#ifndef GNRC_SIXLOWPAN_FRAG_RBUF_AGGRESSIVE_OVERRIDE
+#define GNRC_SIXLOWPAN_FRAG_RBUF_AGGRESSIVE_OVERRIDE    (1)
+#endif
+
+/**
  * @brief   Registration lifetime in minutes for the address registration option
  *
  * This value should be adapted to the devices power-lifecycle so that it is

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.c
@@ -322,10 +322,17 @@ static rbuf_t *_rbuf_get(const void *src, size_t src_len,
         /* if oldest is not empty, res must not be NULL (because otherwise
          * oldest could have been picked as res) */
         assert(!rbuf_entry_empty(oldest));
-        DEBUG("6lo rfrag: reassembly buffer full, remove oldest entry\n");
-        gnrc_pktbuf_release(oldest->super.pkt);
-        rbuf_rm(oldest);
-        res = oldest;
+        if (GNRC_SIXLOWPAN_FRAG_RBUF_AGGRESSIVE_OVERRIDE ||
+            ((now_usec - oldest->arrival) >
+            GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_MS)) {
+            DEBUG("6lo rfrag: reassembly buffer full, remove oldest entry\n");
+            gnrc_pktbuf_release(oldest->super.pkt);
+            rbuf_rm(oldest);
+            res = oldest;
+        }
+        else {
+            return NULL;
+        }
     }
 
     /* now we have an empty spot */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Currently, our 6Lo implementation always overrides the oldest reassembly buffer entry even if that one did not time out yet. While with larger reassembly buffers this can make sense to give newer datagrams precedence, smaller once suffer especially in multi-hop scenarios, where a router might reassemble multiple datagrams at once. As far as I am aware [RFC 4944](https://tools.ietf.org/html/rfc4944) does not mention this behavior, and I think I just adapted it from the legacy implementation back then. So it makes sense to make this aggressive behavior configurable.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Try compile with `CFLAGS += -DGNRC_SIXLOWPAN_FRAG_RBUF_AGGRESSIVE_OVERRIDE=0` and `CFLAGS += -DGNRC_SIXLOWPAN_FRAG_RBUF_AGGRESSIVE_OVERRIDE=1` both configurations should still work and when compiled with `-DGNRC_SIXLOWPAN_FRAG_RBUF_SIZE=1` larger datagrams should still be received with aggressive override deactivated when a node is pinged by two nodes while they are always not when aggressive override is activated.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None, but incorporated at the moment into #11068.

![Route to 6Lo minimal fragment forwarding](http://page.mi.fu-berlin.de/mlenders/sixlo_minfwd.svg)
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
