### PR TITLE
gcoap: remove deprecated function gcoap_req_send()

### DIFF
--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -597,23 +597,6 @@ size_t gcoap_req_send2(const uint8_t *buf, size_t len,
                        gcoap_resp_handler_t resp_handler);
 
 /**
- * @brief  Sends a buffer containing a CoAP request to the provided host/port
- *
- * @deprecated  Please use @ref gcoap_req_send2() instead
- *
- * @param[in] buf           Buffer containing the PDU
- * @param[in] len           Length of the buffer
- * @param[in] addr          Destination for the packet
- * @param[in] port          Port at the destination
- * @param[in] resp_handler  Callback when response received, may be NULL
- *
- * @return  length of the packet
- * @return  0 if cannot send
- */
-size_t gcoap_req_send(const uint8_t *buf, size_t len, const ipv6_addr_t *addr,
-                      uint16_t port, gcoap_resp_handler_t resp_handler);
-
-/**
  * @brief   Initializes a CoAP response packet on a buffer
  *
  * Initializes payload location within the buffer based on packet setup.

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -597,6 +597,27 @@ size_t gcoap_req_send(const uint8_t *buf, size_t len,
                       gcoap_resp_handler_t resp_handler);
 
 /**
+ * @brief   Sends a buffer containing a CoAP request to the provided endpoint
+ *
+ * @deprecated  Migration alias for @ref gcoap_req_send(). Will be removed after
+ *              the 2020.01 release.
+ *
+ * @param[in] buf           Buffer containing the PDU
+ * @param[in] len           Length of the buffer
+ * @param[in] remote        Destination for the packet
+ * @param[in] resp_handler  Callback when response received, may be NULL
+ *
+ * @return  length of the packet
+ * @return  0 if cannot send
+ */
+static inline size_t gcoap_req_send2(const uint8_t *buf, size_t len,
+                                     const sock_udp_ep_t *remote,
+                                     gcoap_resp_handler_t resp_handler)
+{
+    return gcoap_req_send(buf, len, remote, resp_handler);
+}
+
+/**
  * @brief   Initializes a CoAP response packet on a buffer
  *
  * Initializes payload location within the buffer based on packet setup.

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -592,9 +592,9 @@ static inline ssize_t gcoap_request(coap_pkt_t *pdu, uint8_t *buf, size_t len,
  * @return  length of the packet
  * @return  0 if cannot send
  */
-size_t gcoap_req_send2(const uint8_t *buf, size_t len,
-                       const sock_udp_ep_t *remote,
-                       gcoap_resp_handler_t resp_handler);
+size_t gcoap_req_send(const uint8_t *buf, size_t len,
+                      const sock_udp_ep_t *remote,
+                      gcoap_resp_handler_t resp_handler);
 
 /**
  * @brief   Initializes a CoAP response packet on a buffer

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -707,9 +707,9 @@ ssize_t gcoap_finish(coap_pkt_t *pdu, size_t payload_len, unsigned format)
     return pdu->payload_len + (pdu->payload - (uint8_t *)pdu->hdr);
 }
 
-size_t gcoap_req_send2(const uint8_t *buf, size_t len,
-                       const sock_udp_ep_t *remote,
-                       gcoap_resp_handler_t resp_handler)
+size_t gcoap_req_send(const uint8_t *buf, size_t len,
+                      const sock_udp_ep_t *remote,
+                      gcoap_resp_handler_t resp_handler)
 {
     gcoap_request_memo_t *memo = NULL;
     unsigned msg_type  = (*buf & 0x30) >> 4;

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -707,20 +707,6 @@ ssize_t gcoap_finish(coap_pkt_t *pdu, size_t payload_len, unsigned format)
     return pdu->payload_len + (pdu->payload - (uint8_t *)pdu->hdr);
 }
 
-size_t gcoap_req_send(const uint8_t *buf, size_t len, const ipv6_addr_t *addr,
-                      uint16_t port, gcoap_resp_handler_t resp_handler)
-{
-    sock_udp_ep_t remote;
-
-    remote.family = AF_INET6;
-    remote.netif  = SOCK_ADDR_ANY_NETIF;
-    remote.port   = port;
-
-    memcpy(&remote.addr.ipv6[0], &addr->u8[0], sizeof(addr->u8));
-
-    return gcoap_req_send2(buf, len, &remote, resp_handler);
-}
-
 size_t gcoap_req_send2(const uint8_t *buf, size_t len,
                        const sock_udp_ep_t *remote,
                        gcoap_resp_handler_t resp_handler)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This function was deprecated [1,5 years ago](https://github.com/RIOT-OS/RIOT/commit/af1eca90#diff-d696c4c71e4cef0f608c90caebbabf0bR357), so I think we can remove it now. Additionally I renamed `gcoap_req_send2()` to `gcoap_req_send()` and provided a migration wrapper around it named `gcoap_req_send2()` that is already deprecated with removal slated for the 2019.10 release.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Compiling `examples/gcoap` should still work when all commits are used.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
