### PR TITLE
SAUL: Introduce undefined value

### DIFF
--- a/drivers/include/saul.h
+++ b/drivers/include/saul.h
@@ -138,6 +138,12 @@ typedef int(*saul_read_t)(const void *dev, phydat_t *res);
  * For actuators this function is used to influence the actuators state, e.g.
  * switching a switch or setting the speed of a motor.
  *
+ * If a dimension of @p data should be ignored by the device, its value should
+ * be @ref saul_driver_t::undef_value "'undefined'". The 'undefined' value
+ * depends on the device.
+ *
+ * @see saul_reg_get_undef_value
+ *
  * @param[in] dev       device descriptor of the target device
  * @param[in] data      data to write to the device
  *
@@ -154,7 +160,14 @@ typedef struct {
     saul_read_t read;       /**< read function pointer */
     saul_write_t write;     /**< write function pointer */
     uint8_t type;           /**< device class the device belongs to */
+    int16_t undef_value;    /**< value used to ignore a dimension during writing */
 } saul_driver_t;
+
+/**
+ * @brief   Default value to be used in the write operation when a dimension
+ *          should be ignored
+ */
+#define SAUL_DEFAULT_UNDEF_VAL  (0)
 
 /**
  * @brief   Default not supported function

--- a/sys/include/saul_reg.h
+++ b/sys/include/saul_reg.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015 Freie Universität Berlin
+ *               2019 HAW Hamburg
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -19,6 +20,7 @@
  * @brief       SAUL registry interface definition
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
  */
 
 #ifndef SAUL_REG_H
@@ -134,6 +136,19 @@ int saul_reg_read(saul_reg_t *dev, phydat_t *res);
  * @return      -ECANCELED on device errors
  */
 int saul_reg_write(saul_reg_t *dev, phydat_t *data);
+
+/**
+ * @brief   Get the value that represents 'undefined' for a given device.
+ *          When that value is used in one dimension during a write operation,
+ *          it will be ignored by the device.
+ *
+ * @param[in] dev       device from which to get the value
+ *
+ * @return      the 'undefined' value for the device
+ */
+static inline int saul_reg_get_undef_value(saul_reg_t *dev) {
+    return dev->driver->undef_value;
+}
 
 #ifdef __cplusplus
 }

--- a/sys/shell/commands/sc_saul_reg.c
+++ b/sys/shell/commands/sc_saul_reg.c
@@ -113,15 +113,23 @@ static void write(int argc, char **argv)
         puts("error: undefined device given");
         return;
     }
+    /* get the 'undefined value for the device */
+    int undef = saul_reg_get_undef_value(dev);
+
     /* parse value(s) */
     memset(&data, 0, sizeof(data));
     dim = ((argc - 3) > (int)PHYDAT_DIM) ? (int)PHYDAT_DIM : (argc - 3);
-    for (int i = 0; i < dim; i++) {
-        data.val[i] = atoi(argv[i + 3]);
+    for (int i = 0; i < (int)PHYDAT_DIM; i++) {
+        if (i < dim) {
+            data.val[i] = atoi(argv[i + 3]);
+        }
+        else {
+            data.val[i] = undef;
+        }
     }
     /* print values before writing */
     printf("Writing to device #%i - %s\n", num, dev->name);
-    phydat_dump(&data, dim);
+    phydat_dump(&data, PHYDAT_DIM);
     /* write values to device */
     dim = saul_reg_write(dev, &data);
     if (dim <= 0) {

--- a/tests/unittests/tests-saul_reg/tests-saul_reg.c
+++ b/tests/unittests/tests-saul_reg/tests-saul_reg.c
@@ -25,10 +25,10 @@
 #include "saul_reg.h"
 #include "tests-saul_reg.h"
 
-static const saul_driver_t s0_dri = { NULL, NULL, SAUL_ACT_SERVO };
-static const saul_driver_t s1_dri = { NULL, NULL, SAUL_SENSE_TEMP };
-static const saul_driver_t s2_dri = { NULL, NULL, SAUL_SENSE_LIGHT };
-static const saul_driver_t s3_dri = { NULL, NULL, SAUL_ACT_LED_RGB };
+static const saul_driver_t s0_dri = { NULL, NULL, SAUL_ACT_SERVO,   0 };
+static const saul_driver_t s1_dri = { NULL, NULL, SAUL_SENSE_TEMP,  0 };
+static const saul_driver_t s2_dri = { NULL, NULL, SAUL_SENSE_LIGHT, 0 };
+static const saul_driver_t s3_dri = { NULL, NULL, SAUL_ACT_LED_RGB, 0 };
 
 static saul_reg_t s0 = { NULL, NULL, "S0", &s0_dri };
 static saul_reg_t s1 = { NULL, NULL, "S1", &s1_dri };


### PR DESCRIPTION
### Contribution description

This PR add a way for SAUL drivers to define a particular value as 'undefined'. When this value is used on a write operation in any dimension of the phydat_t structure, that dimension will be ignored.

The use-case is updating a subset of the dimensions during a writing operation, on a driver that accepts multiple (e.g. a RGB LED driver).

The PR also changes the saul_reg shell command, to use the proper undefined value of the device (previously it was using 0).

### Testing procedure
- Right now there are no drivers that implement the undefined value. To see it in action you can define this value for an actuator (e.g. saul_gpio) and run the saul example application. You should see that, when a dimension is not defined, it value will be the one defined on the driver structure.
- `tests/unittests/tests-saul_reg` should still work

### Issues/PRs references
None