### PR TITLE
murdock: enable esp32-wroom-32 for CI testing

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-: ${TEST_BOARDS_AVAILABLE:="nrf52dk samr21-xpro"}
+: ${TEST_BOARDS_AVAILABLE:="esp32-wroom-32 nrf52dk samr21-xpro"}
 : ${TEST_BOARDS_LLVM_COMPILE:="iotlab-m3 native nrf52dk mulle nucleo-f401re samr21-xpro slstk3402a"}
 
 export RIOT_CI_BUILD=1

--- a/tests/driver_hd44780/Makefile
+++ b/tests/driver_hd44780/Makefile
@@ -2,4 +2,8 @@ include ../Makefile.tests_common
 
 USEMODULE += hd44780
 
+# Fails on esp32 because the driver defines default GPIOs that are used for the
+# SPI flash interface.
+TEST_ON_CI_BLACKLIST += esp32-wroom-32
+
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
### Contribution description

I've added three esp32-wroom-32 boards to the CI. This PR enables them for testing.

### Testing procedure

Let CI run with "run tests" set.

### Issues/PRs references

none