### PR TITLE
drivers/adt7310: Replace binary literal with hex literal

### DIFF
--- a/drivers/adt7310/adt7310.c
+++ b/drivers/adt7310/adt7310.c
@@ -66,7 +66,7 @@
 #define ADT7310_REG_ID_MASK_SILICON_VERSION  (0x07)
 
 /** @brief Expected manufacturer ID */
-#define ADT7310_EXPECTED_MANUF_ID (0b11000000)
+#define ADT7310_EXPECTED_MANUF_ID (0xC0)
 
 /** @brief 13 bit temperature mask */
 #define ADT7310_REG_VALUE_MASK_13BIT  (0xF8)


### PR DESCRIPTION
### Contribution description

This PR is related to PR #11352, where I suggest to add support for Linux' `/dev/spidev` devices to the native cpu. [As discussed](https://github.com/RIOT-OS/RIOT/pull/11352#issuecomment-486231452), enabling SPI causes the `tests/driver_adt7310` test to be run with the gnu and llvm toolchain. With the current configuration, these toolchains don't like binary literals in the code and raise a warning/error.

So I suggest to change the binary literal for `ADT7310_EXPECTED_MANUF_ID` to a hexadecimal one, so that I can then rebase the other PR and the Murdock build will no longer fail for this test.

### Testing procedure

I don't own an ADT7310 temperature sensor to test the change by myself, but I assume changing `0b1100000` to the equivalent `0bC0` in the code will have no impact besides removing compiler warnings. (The value is mentioned in table 10 of the [datasheet](https://www.analog.com/media/en/technical-documentation/data-sheets/ADT7310.pdf))

### Issues/PRs references

Required for PR #11352 
