### PR TITLE
drivers/pcd8544: Use uint8_t instead of char for byte represenatation

### DIFF
--- a/drivers/include/pcd8544.h
+++ b/drivers/include/pcd8544.h
@@ -118,9 +118,9 @@ void pcd8544_set_bias(const pcd8544_t *dev, uint8_t bias);
  * datasheet.
  *
  * @param[in] dev           device descriptor of display to use
- * @param[in] img           char array with image data (must be of size := 504)
+ * @param[in] img           uint8_t array with image data (must be of size := 504)
  */
-void pcd8544_write_img(const pcd8544_t *dev, const char img[]);
+void pcd8544_write_img(const pcd8544_t *dev, const uint8_t img[]);
 
 /**
  * @brief   Write a single ASCII character to the display

--- a/drivers/pcd8544/pcd8544.c
+++ b/drivers/pcd8544/pcd8544.c
@@ -133,7 +133,7 @@ static const uint8_t _ascii[][5] = {
     {0x10, 0x08, 0x08, 0x10, 0x08},/* 7e ~ */
 };
 
-static const char _riot[] = {
+static const uint8_t _riot[] = {
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -209,12 +209,12 @@ static inline void done(const pcd8544_t *dev)
     spi_release(dev->spi);
 }
 
-static void _write(const pcd8544_t *dev, uint8_t is_data, char data)
+static void _write(const pcd8544_t *dev, uint8_t is_data, uint8_t data)
 {
     /* set command or data mode */
     gpio_write(dev->mode, is_data);
     /* write byte to LCD */
-    spi_transfer_bytes(dev->spi, dev->cs, false, (uint8_t *)&data, NULL, 1);
+    spi_transfer_bytes(dev->spi, dev->cs, false, &data, NULL, 1);
 }
 
 static inline void _set_x(const pcd8544_t *dev, uint8_t x)
@@ -307,7 +307,7 @@ void pcd8544_riot(const pcd8544_t *dev)
     pcd8544_write_img(dev, _riot);
 }
 
-void pcd8544_write_img(const pcd8544_t *dev, const char img[])
+void pcd8544_write_img(const pcd8544_t *dev, const uint8_t img[])
 {
     /* set initial position */
     lock(dev);


### PR DESCRIPTION
### Contribution description

This PR is related to PR #11352, where I suggest to add support for Linux' `/dev/spidev` devices to the native cpu. [As mentioned in that PR](https://github.com/RIOT-OS/RIOT/pull/11352#issuecomment-486231452), enabling SPI causes the `tests/driver_pcd8544` test to be run with the gnu toolchain for the first time. This build fails in Murdock ([Logfile](https://ci.riot-os.org/RIOT-OS/RIOT/11352/fb4c52747487659a540d72eb760e0ae66d420beb/output/compile/tests/driver_pcd8544/native:gnu.txt)), because `char` is signed by default on this platform. The PCD8544 driver uses `char` arrays to pass raw bytes around instead of the platform-independent `uint8_t` version.

I suggest to change the occurrences of `char` where applicable to `uint8_t`. For all platforms with SPI support this should not change the behavior (they don't create warnings now, so I assume they all use unsigned `char`s by default). However, building for Linux should then work, as the literals in the definition of the `_riot` array then is in a valid range.

As far as I could see, the driver isn't used anywhere else in the repository but in the corresponding test. So this shouldn't break anything else, but applications using the driver might notice the API change of `pcd8544_write_img(...)`.

### Testing procedure

I haven't got the hardware at hand to run a real test against the display controller, but I tried to build the `tests/driver_pcd8544` for some architectures (e.g. `arduino-atmega2560` for AVR, `feather-m0` for ARM, `esp32-wroom-32` for xtensa) before and after the change to verify that they still compile and no warnings of incompatible types are shown.

To verify that this will solve the CI build issue in #11532, I tried merging my [spi_native](https://github.com/fhessel/RIOT/tree/native_spi) branch and the content of this PR on the current master branch and build the test with `BOARD=native`, which then also succeeded.

### Issues/PRs references

Required for PR #11352 
