### PR TITLE
cpu/atmega_common: Bugfixes in irq_arch.c

### DIFF
--- a/cpu/atmega_common/irq_arch.c
+++ b/cpu/atmega_common/irq_arch.c
@@ -52,7 +52,7 @@ __attribute__((always_inline)) inline void __set_interrupt_state(uint8_t state)
                       "out __SREG__, r15 \n\t"
                       :
                       : "g"(state)
-                      : "r15", "r16");
+                      : "r15", "r16", "memory");
 }
 
 /**
@@ -61,7 +61,7 @@ __attribute__((always_inline)) inline void __set_interrupt_state(uint8_t state)
 unsigned int irq_disable(void)
 {
     uint8_t mask = __get_interrupt_state();
-    cli();
+    cli(); /* <-- acts as memory barrier, see doc of avr-libc */
     return (unsigned int) mask;
 }
 
@@ -71,7 +71,7 @@ unsigned int irq_disable(void)
 unsigned int irq_enable(void)
 {
     uint8_t mask = __get_interrupt_state();
-    sei();
+    sei(); /* <-- acts as memory barrier, see doc of avr-libc */
     return mask;
 }
 
@@ -88,5 +88,7 @@ void irq_restore(unsigned int state)
  */
 int irq_is_in(void)
 {
-    return __in_isr;
+    int result = __in_isr;
+    __asm__ volatile("" ::: "memory");
+    return result;
 }

--- a/cpu/atmega_common/irq_arch.c
+++ b/cpu/atmega_common/irq_arch.c
@@ -70,8 +70,9 @@ unsigned int irq_disable(void)
  */
 unsigned int irq_enable(void)
 {
+    uint8_t mask = __get_interrupt_state();
     sei();
-    return __get_interrupt_state();
+    return mask;
 }
 
 /**


### PR DESCRIPTION
### Contribution description

1. Fixed the return code of `irq_enable()`:
    - Previously the status register after enabling the interrupts was returned, not prior to enabling it
        - The doc states the return value is the "Previous value of the status register", not the new value
    - The first commit changes this to return the new value
2. Added required memory barriers to `irq_*()` family of functions
    - Added barriers to prevent the compiler from reordering code across calls to `irq_disable()`, `irq_restore()` and `irq_enable()`
    - Added barrier to `irq_is_in()`


### Testing procedure
- Regarding the fixed return value:
    - I personally think a code review is sufficient here. If the reviewer insists, I will come up with a test
- Regarding the barriers:
    - The optimization potential on the AVR platform by reordering or combining memory accesses is practically zero. Most instructions are executed in one cycle and access to memory can only be performed in 8 bit chunks
        - Thus: Reordering and combining memory accesses is unlikely to yield any benefit.
        - Thus: The compiler will not reorder or combine memory accesses most of the time even without memory barriers
    - I compiled `examples/default` for the Arduino Mega2560 using GCC 8.3.0 before (master + fix of return value of `irq_enable()`) and after (this PR):
        - With LTO: https://www.mari-bu.de/avr_irq_lto.html
        - Without LTO: https://www.mari-bu.de/avr_irq_no_lto.html
    - As seen this does not change the binaries, so there cannot be a regression introduced.

### Issues/PRs references
Same as https://github.com/RIOT-OS/RIOT/pull/11440, but for AVR. Related to https://github.com/RIOT-OS/RIOT/pull/11438