### PR TITLE
cpu/atmega_common: Fix function attributes

### DIFF
--- a/cpu/atmega_common/thread_arch.c
+++ b/cpu/atmega_common/thread_arch.c
@@ -196,7 +196,6 @@ void thread_stack_print(void)
     printf("stack size: %u bytes\n", size);
 }
 
-void cpu_switch_context_exit(void) __attribute__((naked));
 void cpu_switch_context_exit(void)
 {
     sched_run();
@@ -212,7 +211,6 @@ extern char *__brkval;
 /**
  * @brief Set the MCU into Thread-Mode and load the initial task from the stack and run it
  */
-void NORETURN __enter_thread_mode(void) __attribute__((naked));
 void NORETURN __enter_thread_mode(void)
 {
     irq_enable();


### PR DESCRIPTION
### Contribution description
Functions marked with `__atribute__((naked))` may only use basic inline assembly and must not use any c code. The functions `__enter_thread_mode()` and `cpu_switch_context_exit()` are using C code, so they must not be marked as naked.

[This saves 4 Bytes of .text when using GCC 8.3.0.](http://mari-bu.de/atmega_naked.html)

### Testing procedure
Code review and basic testing, e.g. does `examples/default` still run properly e.g. on an Arduino Mega2560.

### Issues/PRs references
None