### PR TITLE
boards/frdm-k64f: hack disable periph_hwrng as it crashes

### DIFF
--- a/boards/frdm-k64f/Makefile.features
+++ b/boards/frdm-k64f/Makefile.features
@@ -12,3 +12,6 @@ FEATURES_PROVIDED += periph_uart
 FEATURES_MCU_GROUP = cortex_m4_1
 
 include $(RIOTCPU)/kinetis/Makefile.features
+# HACK the board currently uses the wrong hwrng register
+# Remove this line when fixed
+FEATURES_PROVIDED := $(filter-out periph_hwrng,$(FEATURES_PROVIDED))


### PR DESCRIPTION
### Contribution description

Disable the `frdm-k64f` as is it misconfigured since https://github.com/RIOT-OS/RIOT/commit/925a908d957f11e40d2935130232322109cedd83

Use the same disable as in `frdm-kw41z`.

It fixes breakage with all firmwares using `rng`.

This is not the fix to make `hwrng` work but only disable it until fixed.

### Testing procedure

#### `tests/periph_hwrng`

Run `tests/periph_hwrng` crashes with the `frdm-k64f` now it is said to be unsupported (still crashes).

```
BOARD=frdm-k64f make -C tests/periph_hwrng/
make: Entering directory '/home/harter/work/git/RIOT/tests/periph_hwrng'
There are unsatisfied feature requirements: periph_hwrng


EXPECT ERRORS!
```

#### Firmwares using `rng`:

`examples/gnrc_networking` for example, does not crash anymore as it does not use `hwrng` anymore.

`examples/gnrc_networking` for `frdm-k64f` with `master`:
```
Type '/exit' to exit.
2019-04-26 12:17:19,136 - INFO # 00
2019-04-26 12:17:19,138 - INFO #  HFSR: 0x40000000
2019-04-26 12:17:19,138 - INFO #  DFSR: 0x00000000
2019-04-26 12:17:19,139 - INFO #  AFSR: 0x00000000
2019-04-26 12:17:19,140 - INFO #  BFAR: 0x40029004
2019-04-26 12:17:19,141 - INFO # Misc
2019-04-26 12:17:19,141 - INFO # EXC_RET: 0xfffffffd
2019-04-26 12:17:19,143 - INFO # Attempting to reconstruct state for debugging...
2019-04-26 12:17:19,144 - INFO # In GDB:
2019-04-26 12:17:19,144 - INFO #   set $pc=0x7fc2
2019-04-26 12:17:19,145 - INFO #   frame 0
2019-04-26 12:17:19,145 - INFO #   bt
2019-04-26 12:17:19,146 - INFO #
2019-04-26 12:17:19,147 - INFO # ISR stack overflowed by at least 16 bytes.
2019-04-26 12:17:19,148 - INFO #
2019-04-26 12:17:19,149 - INFO # Context before hardfault:
2019-04-26 12:17:19,149 - INFO #    r0: 0x1fff0c04
2019-04-26 12:17:19,150 - INFO #    r1: 0x00000004
2019-04-26 12:17:19,151 - INFO #    r2: 0x00000002
2019-04-26 12:17:19,151 - INFO #    r3: 0x40029000
2019-04-26 12:17:19,152 - INFO #   r12: 0x00000000
2019-04-26 12:17:19,153 - INFO #    lr: 0x00008019
2019-04-26 12:17:19,154 - INFO #    pc: 0x00007fc2
2019-04-26 12:17:19,154 - INFO #   psr: 0x01000200
2019-04-26 12:17:19,155 - INFO #
2019-04-26 12:17:19,155 - INFO # FSR/FAR:
2019-04-26 12:17:19,156 - INFO #  CFSR: 0x00008600
2019-04-26 12:17:19,156 - INFO #  HFSR: 0x40000000
```


### Issues/PRs references

Issue: https://github.com/RIOT-OS/RIOT/issues/11447
It does not closes the issue as it is not a fix to make the 'hwrng' but disable it until fixed.

The test automation for testing `tests/periph_hwrng` https://github.com/RIOT-OS/RIOT/pull/11448