### PR TITLE
[backport-2019.04] release-notes.txt: Add info on frdm-k64f failures

### DIFF
--- a/release-notes.txt
+++ b/release-notes.txt
@@ -226,6 +226,7 @@ Native related issues
 
 Other platform related issues
 -----------------------------
+#11447: frdm-k64f: hwrng support broken, applications using RNG crash
 #11354: ESP32: `write(STDIO_FILENO, ...)` not working
 #11104: STM32: SPI clock not returning to idle state and generating additional
         clock cycles


### PR DESCRIPTION
Although not a formal part of the release specs tests, these recently
discovered failures are significant enough to warrant documenting in the
release notes.