### PR TITLE
cpu/esp: fix computation of coprocessor save area pointer in initial thread context

### DIFF
--- a/cpu/esp32/thread_arch.c
+++ b/cpu/esp32/thread_arch.c
@@ -183,7 +183,7 @@ char* thread_stack_init(thread_task_func_t task_func, void *arg, void *stack_sta
 
     uint32_t *p;
 
-    p = (uint32_t *)(((uint32_t)(top_of_stack + 1) - XT_CP_SIZE) & ~0xf);
+    p = (uint32_t *)(((uint32_t)(top_of_stack + 1) - XT_CP_SIZE));
     p[0] = 0;
     p[1] = 0;
     p[2] = (((uint32_t) p) + 12 + XCHAL_TOTAL_SA_ALIGN - 1) & -XCHAL_TOTAL_SA_ALIGN;

--- a/cpu/esp8266/thread_arch.c
+++ b/cpu/esp8266/thread_arch.c
@@ -174,7 +174,7 @@ char* thread_stack_init(thread_task_func_t task_func, void *arg, void *stack_sta
      */
     uint32_t *p;
 
-    p = (uint32_t *)(((uint32_t) pxTopOfStack - XT_CP_SIZE) & ~0xf);
+    p = (uint32_t *)(((uint32_t) pxTopOfStack - XT_CP_SIZE));
     p[0] = 0;
     p[1] = 0;
     p[2] = (((uint32_t) p) + 12 + XCHAL_TOTAL_SA_ALIGN - 1) & -XCHAL_TOTAL_SA_ALIGN;


### PR DESCRIPTION
### Contribution description

This PR fixes a problem that was figured out in issue #11443.

With commit 28d9599d52cf07d7282da1931cb240c027fea1f6, the following change was introduced:

```diff
--- a/cpu/esp32/thread_arch.c
+++ b/cpu/esp32/thread_arch.c
@@ -186,1 +186,1 @@ char* thread_stack_init(thread_task_func_t task_func, void *arg, void *stack_sta
-    p = (uint32_t *)(((uint32_t)(top_of_stack + 1) - XT_CP_SIZE));
+    p = (uint32_t *)(((uint32_t)(top_of_stack + 1) - XT_CP_SIZE) & ~0xf);
```

`top_of_stack` isn't aligned down to the previous 16 byte aligned address. Furthermore, `top_of_stack` as well as `XT_CP_SIZE` are used unaligned in `cpu/esp_common/vendor/xtensa/portasm.S` in address computation for the coprocessor save area, .

Aligning pointer `p` down to the previous 16 byte aligned address results in a wrong address of the coprocessor save area during the initialization of the thread context. This leads to wrong values and wrong positions of these values in the coprocessor save area in inital thread context.

Since ESP8266 doesn't have a coprocessor, this bug affects only ESP32.

### Testing procedure

The only known application suffering from this problem is `examples/lorawan` on one of the new LoRa32 board definitions in PR #11265 and #11418. Therefore, it is suggested to test this PR with one of these boards.

```
make BOARD=esp32-heltec-lora32-v2 -C examples/lorawan flash
```
Before the fix, the application hangs in function `semtech_loramac_init` and ends within a boot loop. 
```
...
Starting RIOT kernel on PRO cpu
I (247) [main_trampoline]: main(): This is RIOT! (Version: 2019.07-devel-141-g203c-boards/esp32-heltec-lora32)
LoRaWAN Class A low-power application
=====================================
ets Jun  8 2016 00:22:57

rst:0x7 (TG0WDT_SYS_RESET),boot:0x13 (SPI_FAST_FLASH_BOOT)
...
```
With the fix, function `semtech_loramac_init` works and the application prints the message "Starting join procedure".
```
...
Starting RIOT kernel on PRO cpu
I (247) [main_trampoline]: main(): This is RIOT! (Version: 2019.07-devel-141-g203c-boards/esp32-heltec-lora32)
LoRaWAN Class A low-power application
=====================================
Starting join procedure
...
```

### Issues/PRs references

Fixes #11443 