### PR TITLE
pkg/nimble: adapt to nrf51 family

### DIFF
--- a/boards/common/nrf51/Makefile.features
+++ b/boards/common/nrf51/Makefile.features
@@ -2,4 +2,7 @@
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_timer
 
+# Various other features (if any)
+FEATURES_PROVIDED += ble_nimble
+
 -include $(RIOTCPU)/nrf51/Makefile.features

--- a/boards/common/nrf51/Makefile.include
+++ b/boards/common/nrf51/Makefile.include
@@ -7,6 +7,11 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 # include common nrf51 headers
 INCLUDES += -I$(RIOTBOARD)/common/nrf51/include
 
+# use alternative xtimer mapping if applicable
+ifneq (,$(filter nimble,$(USEPKG)))
+  CFLAGS += -DBOARD_NRF51_XTIMER_ALT
+endif
+
 ifeq ($(PROGRAMMER),openocd)
   # use common openocd configuration for nrf51
   export OPENOCD_CONFIG = $(RIOTBOARD)/common/nrf51/dist/openocd.cfg

--- a/boards/common/nrf51/include/board_common.h
+++ b/boards/common/nrf51/include/board_common.h
@@ -31,9 +31,22 @@ extern "C" {
 
 /**
  * @name    Xtimer configuration
+ *
+ * Some external packages (e.g. NimBLE) require dedicated access to timer 0.
+ * Setting the BOARD_NRF51_XTIMER_ALT variable allows to change the default
+ * xtimer configuration to use
+ *
  * @{
  */
+#ifndef BOARD_NRF51_XTIMER_ALT
+/* default xtimer mapping */
 #define XTIMER_WIDTH                (24)
+#else
+/* alternative mapping to TIMER_DEV(1) */
+#define XTIMER_DEV                  TIMER_DEV(1)
+#define XTIMER_WIDTH                (16)
+#define XTIMER_CHAN                 (0)
+#endif
 #define XTIMER_BACKOFF              (40)
 /** @} */
 

--- a/pkg/nimble/Makefile
+++ b/pkg/nimble/Makefile
@@ -64,8 +64,8 @@ nimble_transport_ram:
 nimble_controller:
 	"$(MAKE)" -C $(PDIR)/nimble/controller/src/ -f $(TDIR)/controller.mk
 
-nimble_drivers_nrf52:
-	"$(MAKE)" -C $(PDIR)/nimble/drivers/nrf52/src/ -f $(TDIR)/drivers.nrf52.mk
+nimble_drivers_nrf5x:
+	"$(MAKE)" -C $(PDIR)/nimble/drivers/$(CPU_FAM)/src/ -f $(TDIR)/drivers.nrf5x.mk
 
 # additional, RIOT specific nimble modules
 nimble_addr:

--- a/pkg/nimble/Makefile.dep
+++ b/pkg/nimble/Makefile.dep
@@ -29,8 +29,8 @@ endif
 # nimble controller dependencies
 ifneq (,$(filter nimble_controller,$(USEMODULE)))
   USEMODULE += nimble_transport_ram
-  ifeq (nrf52,$(CPU_FAM))
-    USEMODULE += nimble_drivers_nrf52
+  ifneq (,$(filter nrf5%,$(CPU_FAM)))
+    USEMODULE += nimble_drivers_nrf5x
   endif
 endif
 

--- a/pkg/nimble/Makefile.include
+++ b/pkg/nimble/Makefile.include
@@ -17,8 +17,8 @@ ifneq (,$(filter nimble_controller,$(USEMODULE)))
   CFLAGS += -DNIMBLE_CFG_CONTROLLER=1
   CFLAGS += -DMYNEWT_VAL_OS_CPUTIME_FREQ=32768
 
-  ifneq (,$(filter nimble_drivers_nrf52,$(USEMODULE)))
-    INCLUDES += $(NIMIBASE)/nimble/drivers/nrf52/include
+  ifneq (,$(filter nimble_drivers_nrf5x,$(USEMODULE)))
+    INCLUDES += $(NIMIBASE)/nimble/drivers/$(CPU_FAM)/include
   endif
 endif
 

--- a/pkg/nimble/contrib/nimble_riot.c
+++ b/pkg/nimble/contrib/nimble_riot.c
@@ -36,7 +36,7 @@
 #endif
 
 #ifdef MODULE_NIMBLE_CONTROLLER
-#ifdef CPU_FAM_NRF52
+#if defined(CPU_FAM_NRF52) || defined(CPU_FAM_NRF51)
 #include "nrf_clock.h"
 #endif
 
@@ -56,9 +56,10 @@ static void *_host_thread(void *arg)
 
 #ifdef MODULE_NIMBLE_CONTROLLER
     /* XXX: NimBLE needs the nRF5x's LF clock to run */
-#ifdef CPU_FAM_NRF52
+#if defined(CPU_FAM_NRF52) || defined(CPU_FAM_NRF51)
     clock_start_lf();
 #endif
+
     /* Run the controller
      *
      * Create task where NimBLE LL will run. This one is required as LL has its

--- a/pkg/nimble/drivers.nrf5x.mk
+++ b/pkg/nimble/drivers.nrf5x.mk
@@ -1,3 +1,3 @@
-MODULE = nimble_drivers_nrf52
+MODULE = nimble_drivers_nrf5x
 
 include $(RIOTBASE)/Makefile.base

--- a/tests/nimble_l2cap_server/nimble.inc.mk
+++ b/tests/nimble_l2cap_server/nimble.inc.mk
@@ -1,3 +1,14 @@
+# For nRF51-based targets, we need to reduce buffer sizes to make this test fit
+# into RAM
+# Note: as the CPU variable is not set at this point, we manually 'whitelist'
+#       all supported nrf51-boards here
+BOARDS_NRF51 := airfy-beacon calliope-mini microbit nrf51dk nrf51dongle \
+                nrf6310 yunjia-nrf51822
+ifneq (,$(filter $(BOARDS_NRF51),$(BOARD)))
+  APP_MTU ?= 250
+  MSYS_CNT ?= 6
+endif
+
 # Set the tests default configuration
 APP_MTU ?= 5000
 APP_BUF_CHUNKSIZE ?= 250    # must be full divider of APP_MTU
@@ -14,10 +25,11 @@ CFLAGS += -DAPP_CID=$(APP_CID)
 
 # configure NimBLE
 USEPKG += nimble
+MSYS_CNT ?= 23
 CFLAGS += -DMYNEWT_VAL_BLE_L2CAP_COC_MAX_NUM=1
 CFLAGS += -DMYNEWT_VAL_BLE_L2CAP_COC_MPS=250
 CFLAGS += -DMYNEWT_VAL_BLE_MAX_CONNECTIONS=1
-CFLAGS += -DMYNEWT_VAL_MSYS_1_BLOCK_COUNT=23
+CFLAGS += -DMYNEWT_VAL_MSYS_1_BLOCK_COUNT=$(MSYS_CNT)
 CFLAGS += -DMYNEWT_VAL_MSYS_1_BLOCK_SIZE=298
 CFLAGS += -DMYNEWT_VAL_BLE_LL_CFG_FEAT_DATA_LEN_EXT=1
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is adapting the Nimble package to make it compliant with nrf51 based boards. ~For the moment it needs a specific branch on my Apache-nimble fork (see https://github.com/apache/mynewt-nimble/pull/429).~ Some changes were applied on the upstream project, so the package version had to be updated.

I tested `examples/nimble_gatt` and it worked with `nrf51dk`. The `examples/nimble_scanner` doesn't work, maybe because of insufficient memory.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Build and flash `examples/nimble_gatt` on an nrf51 based board. It should appear in NRF connect application running on a Phone or using bluetoothctl on a Linux with bluetooth radio enabled.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
