### PR TITLE
examples/nimble_scanner: fix typo in scan command description

### DIFF
--- a/examples/nimble_scanner/main.c
+++ b/examples/nimble_scanner/main.c
@@ -57,7 +57,7 @@ int _cmd_scan(int argc, char **argv)
 }
 
 static const shell_command_t _commands[] = {
-    { "scan", "trigger a BLE scann", _cmd_scan },
+    { "scan", "trigger a BLE scan", _cmd_scan },
     { NULL, NULL, NULL }
 };
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is fixing an obvious typo in the `examples/nimble_scanner` shell command description.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Build and flash `examples/nimble_scanner` on one of the supported board
- Call `help`, the typo in `scan` command description should be gone with this PR.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Found in #11463 while testing `examples/nimble_scanner` on nrf51

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
