### PR TITLE
drivers/sdcard_spi: Use uint8_t instead of char for byte representation

### DIFF
--- a/drivers/include/sdcard_spi.h
+++ b/drivers/include/sdcard_spi.h
@@ -230,7 +230,7 @@ int sdcard_spi_init(sdcard_spi_t *card, const sdcard_spi_params_t *params);
  *
  * @return                number of successfully read blocks (0 if no block was read).
  */
-int sdcard_spi_read_blocks(sdcard_spi_t *card, int blockaddr, char *data, int blocksize,
+int sdcard_spi_read_blocks(sdcard_spi_t *card, int blockaddr, uint8_t *data, int blocksize,
                            int nblocks, sd_rw_response_t *state);
 
 /**
@@ -252,7 +252,7 @@ int sdcard_spi_read_blocks(sdcard_spi_t *card, int blockaddr, char *data, int bl
  *
  * @return                number of successfully written blocks (0 if no block was written).
  */
-int sdcard_spi_write_blocks(sdcard_spi_t *card, int blockaddr, const char *data, int blocksize,
+int sdcard_spi_write_blocks(sdcard_spi_t *card, int blockaddr, const uint8_t *data, int blocksize,
                             int nblocks, sd_rw_response_t *state);
 
 /**

--- a/drivers/sdcard_spi/include/sdcard_spi_internal.h
+++ b/drivers/sdcard_spi/include/sdcard_spi_internal.h
@@ -186,7 +186,7 @@ typedef enum {
  * @return                SD_INVALID_R1_RESPONSE if either waiting for the card to enter
  *                        not-busy-state timed out or spi communication failed
  */
-char sdcard_spi_send_cmd(sdcard_spi_t *card, char sd_cmd_idx, uint32_t argument, int32_t max_retry);
+uint8_t sdcard_spi_send_cmd(sdcard_spi_t *card, uint8_t sd_cmd_idx, uint32_t argument, int32_t max_retry);
 
 /**
  * @brief                 Sends an acmd to the sd card. ACMD<n> consists of sending CMD55 + CMD<n>
@@ -204,7 +204,7 @@ char sdcard_spi_send_cmd(sdcard_spi_t *card, char sd_cmd_idx, uint32_t argument,
  * @return                SD_INVALID_R1_RESPONSE if either waiting for the card to enter
  *                        not-busy-state timed out or spi communication failed
  */
-char sdcard_spi_send_acmd(sdcard_spi_t *card, char sd_cmd_idx, uint32_t argument, int32_t max_retry);
+uint8_t sdcard_spi_send_acmd(sdcard_spi_t *card, uint8_t sd_cmd_idx, uint32_t argument, int32_t max_retry);
 
 /**
  * @brief                 Gets the sector count of the card.

--- a/drivers/sdcard_spi/sdcard_spi.c
+++ b/drivers/sdcard_spi/sdcard_spi.c
@@ -33,31 +33,31 @@
 
 static inline void _select_card_spi(sdcard_spi_t *card);
 static inline void _unselect_card_spi(sdcard_spi_t *card);
-static inline char _wait_for_r1(sdcard_spi_t *card, int32_t max_retries);
+static inline uint8_t _wait_for_r1(sdcard_spi_t *card, int32_t max_retries);
 static inline void _send_dummy_byte(sdcard_spi_t *card);
 static inline bool _wait_for_not_busy(sdcard_spi_t *card, int32_t max_retries);
-static inline bool _wait_for_token(sdcard_spi_t *card, char token, int32_t max_retries);
+static inline bool _wait_for_token(sdcard_spi_t *card, uint8_t token, int32_t max_retries);
 static sd_init_fsm_state_t _init_sd_fsm_step(sdcard_spi_t *card, sd_init_fsm_state_t state);
 static sd_rw_response_t _read_cid(sdcard_spi_t *card);
 static sd_rw_response_t _read_csd(sdcard_spi_t *card);
-static sd_rw_response_t _read_data_packet(sdcard_spi_t *card, char token, char *data, int size);
-static sd_rw_response_t _write_data_packet(sdcard_spi_t *card, char token, const char *data, int size);
+static sd_rw_response_t _read_data_packet(sdcard_spi_t *card, uint8_t token, uint8_t *data, int size);
+static sd_rw_response_t _write_data_packet(sdcard_spi_t *card, uint8_t token, const uint8_t *data, int size);
 
 /* CRC-7 (polynomial: x^7 + x^3 + 1) LSB of CRC-7 in a 8-bit variable is always 1*/
-static char _crc_7(const char *data, int n);
+static uint8_t _crc_7(const uint8_t *data, int n);
 
 /* use this transfer method instead of _transfer_bytes to force the use of 0xFF as dummy bytes */
-static inline int _transfer_bytes(sdcard_spi_t *card, const char *out, char *in, unsigned int length);
+static inline int _transfer_bytes(sdcard_spi_t *card, const uint8_t *out, uint8_t *in, unsigned int length);
 
 /* uses bitbanging for spi communication which allows to enable pull-up on the miso pin for
 greater card compatibility on platforms that don't have a hw pull up installed */
-static inline int _sw_spi_rxtx_byte(sdcard_spi_t *card, char out, char *in);
+static inline int _sw_spi_rxtx_byte(sdcard_spi_t *card, uint8_t out, uint8_t *in);
 
 /* wrapper for default spi_transfer_byte function */
-static inline int _hw_spi_rxtx_byte(sdcard_spi_t *card, char out, char *in);
+static inline int _hw_spi_rxtx_byte(sdcard_spi_t *card, uint8_t out, uint8_t *in);
 
 /* function pointer to switch to hw spi mode after init sequence */
-static int (*_dyn_spi_rxtx_byte)(sdcard_spi_t *card, char out, char *in);
+static int (*_dyn_spi_rxtx_byte)(sdcard_spi_t *card, uint8_t out, uint8_t *in);
 
 int sdcard_spi_init(sdcard_spi_t *card, const sdcard_spi_params_t *params)
 {
@@ -129,7 +129,7 @@ static sd_init_fsm_state_t _init_sd_fsm_step(sdcard_spi_t *card, sd_init_fsm_sta
 
             /* select sdcard for cmd0 */
             gpio_clear(card->params.cs);
-            char cmd0_r1 = sdcard_spi_send_cmd(card, SD_CMD_0, SD_CMD_NO_ARG, INIT_CMD0_RETRY_CNT);
+            uint8_t cmd0_r1 = sdcard_spi_send_cmd(card, SD_CMD_0, SD_CMD_NO_ARG, INIT_CMD0_RETRY_CNT);
             gpio_set(card->params.cs);
 
             if (R1_VALID(cmd0_r1) && !R1_ERROR(cmd0_r1) && R1_IDLE_BIT_SET(cmd0_r1)) {
@@ -147,7 +147,7 @@ static sd_init_fsm_state_t _init_sd_fsm_step(sdcard_spi_t *card, sd_init_fsm_sta
         case SD_INIT_ENABLE_CRC:
             DEBUG("SD_INIT_ENABLE_CRC\n");
             _select_card_spi(card);
-            char r1 = sdcard_spi_send_cmd(card, SD_CMD_59, SD_CMD_59_ARG_EN, INIT_CMD_RETRY_CNT);
+            uint8_t r1 = sdcard_spi_send_cmd(card, SD_CMD_59, SD_CMD_59_ARG_EN, INIT_CMD_RETRY_CNT);
             _unselect_card_spi(card);
 
             if (R1_VALID(r1) && !R1_ERROR(r1)) {
@@ -160,12 +160,12 @@ static sd_init_fsm_state_t _init_sd_fsm_step(sdcard_spi_t *card, sd_init_fsm_sta
             DEBUG("SD_INIT_SEND_CMD8\n");
             _select_card_spi(card);
             int cmd8_arg = (SD_CMD_8_VHS_2_7_V_TO_3_6_V << 8) | SD_CMD_8_CHECK_PATTERN;
-            char cmd8_r1 = sdcard_spi_send_cmd(card, SD_CMD_8, cmd8_arg, INIT_CMD_RETRY_CNT);
+            uint8_t cmd8_r1 = sdcard_spi_send_cmd(card, SD_CMD_8, cmd8_arg, INIT_CMD_RETRY_CNT);
 
             if (R1_VALID(cmd8_r1) && !R1_ERROR(cmd8_r1)) {
                 DEBUG("CMD8: [OK] --> reading remaining bytes for R7\n");
 
-                char r7[4];
+                uint8_t r7[4];
 
                 if (_transfer_bytes(card, 0, &r7[0], sizeof(r7)) == sizeof(r7)) {
                     DEBUG("R7 response: 0x%02x 0x%02x 0x%02x 0x%02x\n", r7[0], r7[1], r7[2], r7[3]);
@@ -198,7 +198,7 @@ static sd_init_fsm_state_t _init_sd_fsm_step(sdcard_spi_t *card, sd_init_fsm_sta
             DEBUG("SD_INIT_SEND_ACMD41_HCS\n");
             int acmd41_hcs_retries = 0;
             do {
-                char acmd41hcs_r1 = sdcard_spi_send_acmd(card, SD_CMD_41, SD_ACMD_41_ARG_HC, 0);
+                uint8_t acmd41hcs_r1 = sdcard_spi_send_acmd(card, SD_CMD_41, SD_ACMD_41_ARG_HC, 0);
                 if (R1_VALID(acmd41hcs_r1) && !R1_ERROR(acmd41hcs_r1) &&
                     !R1_IDLE_BIT_SET(acmd41hcs_r1)) {
                     DEBUG("ACMD41: [OK]\n");
@@ -213,7 +213,7 @@ static sd_init_fsm_state_t _init_sd_fsm_step(sdcard_spi_t *card, sd_init_fsm_sta
             DEBUG("SD_INIT_SEND_ACMD41\n");
             int acmd41_retries = 0;
             do {
-                char acmd41_r1 = sdcard_spi_send_acmd(card, SD_CMD_41, SD_CMD_NO_ARG, 0);
+                uint8_t acmd41_r1 = sdcard_spi_send_acmd(card, SD_CMD_41, SD_CMD_NO_ARG, 0);
                 if (R1_VALID(acmd41_r1) && !R1_ERROR(acmd41_r1) && !R1_IDLE_BIT_SET(acmd41_r1)) {
                     DEBUG("ACMD41: [OK]\n");
                     card->use_block_addr = false;
@@ -234,12 +234,12 @@ static sd_init_fsm_state_t _init_sd_fsm_step(sdcard_spi_t *card, sd_init_fsm_sta
 
         case SD_INIT_SEND_CMD58:
             DEBUG("SD_INIT_SEND_CMD58\n");
-            char cmd58_r1 = sdcard_spi_send_cmd(card, SD_CMD_58, SD_CMD_NO_ARG, INIT_CMD_RETRY_CNT);
+            uint8_t cmd58_r1 = sdcard_spi_send_cmd(card, SD_CMD_58, SD_CMD_NO_ARG, INIT_CMD_RETRY_CNT);
             if (R1_VALID(cmd58_r1) && !R1_ERROR(cmd58_r1)) {
                 DEBUG("CMD58: [OK]\n");
                 card->card_type = SD_V2;
 
-                char r3[4];
+                uint8_t r3[4];
                 if (_transfer_bytes(card, 0, r3, sizeof(r3)) == sizeof(r3)) {
                     uint32_t ocr = ((uint32_t)r3[0] << (3 * 8)) |
                                    ((uint32_t)r3[1] << (2 * 8)) | (r3[2] << 8) | r3[3];
@@ -282,7 +282,7 @@ static sd_init_fsm_state_t _init_sd_fsm_step(sdcard_spi_t *card, sd_init_fsm_sta
 
         case SD_INIT_SEND_CMD16:
             DEBUG("SD_INIT_SEND_CMD16\n");
-            char r1_16 = sdcard_spi_send_cmd(card, SD_CMD_16, SD_HC_BLOCK_SIZE, INIT_CMD_RETRY_CNT);
+            uint8_t r1_16 = sdcard_spi_send_cmd(card, SD_CMD_16, SD_HC_BLOCK_SIZE, INIT_CMD_RETRY_CNT);
             if (R1_VALID(r1_16) && !R1_ERROR(r1_16)) {
                 DEBUG("CARD TYPE IS SDSC (SD_V1 with byte adressing)\n");
                 _unselect_card_spi(card);
@@ -332,12 +332,12 @@ static sd_init_fsm_state_t _init_sd_fsm_step(sdcard_spi_t *card, sd_init_fsm_sta
     }
 }
 
-static inline bool _wait_for_token(sdcard_spi_t *card, char token, int32_t max_retries)
+static inline bool _wait_for_token(sdcard_spi_t *card, uint8_t token, int32_t max_retries)
 {
     int tried = 0;
 
     do {
-        char read_byte = 0;
+        uint8_t read_byte = 0;
         read_byte = spi_transfer_byte(card->params.spi_dev, GPIO_UNDEF, true,
                                       SD_CARD_DUMMY_BYTE);
         if (read_byte == token) {
@@ -356,7 +356,7 @@ static inline bool _wait_for_token(sdcard_spi_t *card, char token, int32_t max_r
 
 static inline void _send_dummy_byte(sdcard_spi_t *card)
 {
-    char read_byte;
+    uint8_t read_byte;
 
     if (_dyn_spi_rxtx_byte(card, SD_CARD_DUMMY_BYTE, &read_byte) == 1) {
         DEBUG("_send_dummy_byte:echo: 0x%02x\n", read_byte);
@@ -368,12 +368,12 @@ static inline void _send_dummy_byte(sdcard_spi_t *card)
 
 static inline bool _wait_for_not_busy(sdcard_spi_t *card, int32_t max_retries)
 {
-    char read_byte;
+    uint8_t read_byte;
     int tried = 0;
 
     do {
         if (_dyn_spi_rxtx_byte(card, SD_CARD_DUMMY_BYTE, &read_byte) == 1) {
-            if ((uint8_t)read_byte == 0xFF) {
+            if (read_byte == 0xFF) {
                 DEBUG("_wait_for_not_busy: [OK]\n");
                 return true;
             }
@@ -393,12 +393,12 @@ static inline bool _wait_for_not_busy(sdcard_spi_t *card, int32_t max_retries)
     return false;
 }
 
-static char _crc_7(const char *data, int n)
+static uint8_t _crc_7(const uint8_t *data, int n)
 {
-    char crc = 0;
+    uint8_t crc = 0;
 
     for (int i = 0; i < n; i++) {
-        char d = data[i];
+        uint8_t d = data[i];
         for (int j = 0; j < 8; j++) {
             crc <<= 1;
             if ((d & 0x80) ^ (crc & 0x80)) {
@@ -410,11 +410,11 @@ static char _crc_7(const char *data, int n)
     return (crc << 1) | 1;
 }
 
-char sdcard_spi_send_cmd(sdcard_spi_t *card, char sd_cmd_idx, uint32_t argument, int32_t max_retry)
+uint8_t sdcard_spi_send_cmd(sdcard_spi_t *card, uint8_t sd_cmd_idx, uint32_t argument, int32_t max_retry)
 {
     int try_cnt = 0;
-    char r1_resu;
-    char cmd_data[6];
+    uint8_t r1_resu;
+    uint8_t cmd_data[6];
 
     cmd_data[0] = SD_CMD_PREFIX_MASK | sd_cmd_idx;
     cmd_data[1] = argument >> (3 * 8);
@@ -423,7 +423,7 @@ char sdcard_spi_send_cmd(sdcard_spi_t *card, char sd_cmd_idx, uint32_t argument,
     cmd_data[4] = argument & 0xFF;
     cmd_data[5] = _crc_7(cmd_data, sizeof(cmd_data) - 1);
 
-    char echo[sizeof(cmd_data)];
+    uint8_t echo[sizeof(cmd_data)];
 
     do {
         DEBUG("sdcard_spi_send_cmd: CMD%02d (0x%08" PRIx32 ") (retry %d)\n", sd_cmd_idx, argument, try_cnt);
@@ -469,10 +469,10 @@ char sdcard_spi_send_cmd(sdcard_spi_t *card, char sd_cmd_idx, uint32_t argument,
     return r1_resu;
 }
 
-char sdcard_spi_send_acmd(sdcard_spi_t *card, char sd_cmd_idx, uint32_t argument, int32_t max_retry)
+uint8_t sdcard_spi_send_acmd(sdcard_spi_t *card, uint8_t sd_cmd_idx, uint32_t argument, int32_t max_retry)
 {
     int err_cnt = 0;
-    char r1_resu;
+    uint8_t r1_resu;
 
     do {
         DEBUG("sdcard_spi_send_acmd: CMD%02d (0x%08" PRIx32 ")(retry %d)\n", sd_cmd_idx, argument, err_cnt);
@@ -499,10 +499,10 @@ char sdcard_spi_send_acmd(sdcard_spi_t *card, char sd_cmd_idx, uint32_t argument
     return r1_resu;
 }
 
-static inline char _wait_for_r1(sdcard_spi_t *card, int32_t max_retries)
+static inline uint8_t _wait_for_r1(sdcard_spi_t *card, int32_t max_retries)
 {
     int tried = 0;
-    char r1;
+    uint8_t r1;
 
     do {
         if (_dyn_spi_rxtx_byte(card, SD_CARD_DUMMY_BYTE, &r1) != 1) {
@@ -538,8 +538,8 @@ void _unselect_card_spi(sdcard_spi_t *card)
     spi_release(card->params.spi_dev);
 }
 
-static inline int _sw_spi_rxtx_byte(sdcard_spi_t *card, char out, char *in){
-    char rx = 0;
+static inline int _sw_spi_rxtx_byte(sdcard_spi_t *card, uint8_t out, uint8_t *in){
+    uint8_t rx = 0;
     int i = 7;
     for(; i >= 0; i--){
         if( ((out >> (i)) & 0x01) == 1){
@@ -557,15 +557,15 @@ static inline int _sw_spi_rxtx_byte(sdcard_spi_t *card, char out, char *in){
     return 1;
 }
 
-static inline int _hw_spi_rxtx_byte(sdcard_spi_t *card, char out, char *in){
+static inline int _hw_spi_rxtx_byte(sdcard_spi_t *card, uint8_t out, uint8_t *in){
     *in = spi_transfer_byte(card->params.spi_dev, GPIO_UNDEF, true, out);
     return 1;
 }
 
-static inline int _transfer_bytes(sdcard_spi_t *card, const char *out, char *in, unsigned int length){
+static inline int _transfer_bytes(sdcard_spi_t *card, const uint8_t *out, uint8_t *in, unsigned int length){
     int trans_ret;
     unsigned trans_bytes = 0;
-    char in_temp;
+    uint8_t in_temp;
 
     for (trans_bytes = 0; trans_bytes < length; trans_bytes++) {
         if (out != NULL) {
@@ -585,7 +585,7 @@ static inline int _transfer_bytes(sdcard_spi_t *card, const char *out, char *in,
     return trans_bytes;
 }
 
-static sd_rw_response_t _read_data_packet(sdcard_spi_t *card, char token, char *data, int size)
+static sd_rw_response_t _read_data_packet(sdcard_spi_t *card, uint8_t token, uint8_t *data, int size)
 {
     DEBUG("_read_data_packet: size: %d\n", size);
     if (_wait_for_token(card, token, SD_DATA_TOKEN_RETRY_CNT) == true) {
@@ -604,7 +604,7 @@ static sd_rw_response_t _read_data_packet(sdcard_spi_t *card, char token, char *
         }
         DEBUG("\n");
 
-        char crc_bytes[2];
+        uint8_t crc_bytes[2];
         if (_transfer_bytes(card, 0, crc_bytes, sizeof(crc_bytes)) == sizeof(crc_bytes)) {
             uint16_t data_crc16 = (crc_bytes[0] << 8) | crc_bytes[1];
 
@@ -626,14 +626,14 @@ static sd_rw_response_t _read_data_packet(sdcard_spi_t *card, char token, char *
     return SD_RW_RX_TX_ERROR;
 }
 
-static inline int _read_blocks(sdcard_spi_t *card, int cmd_idx, int bladdr, char *data, int blsz,
+static inline int _read_blocks(sdcard_spi_t *card, int cmd_idx, int bladdr, uint8_t *data, int blsz,
                                int nbl, sd_rw_response_t *state)
 {
     _select_card_spi(card);
     int reads = 0;
 
     uint32_t addr = card->use_block_addr ? bladdr : (bladdr * SD_HC_BLOCK_SIZE);
-    char cmd_r1_resu = sdcard_spi_send_cmd(card, cmd_idx, addr, SD_BLOCK_READ_CMD_RETRIES);
+    uint8_t cmd_r1_resu = sdcard_spi_send_cmd(card, cmd_idx, addr, SD_BLOCK_READ_CMD_RETRIES);
 
     if (R1_VALID(cmd_r1_resu) && !R1_ERROR(cmd_r1_resu)) {
         DEBUG("_read_blocks: send CMD%d: [OK]\n", cmd_idx);
@@ -678,7 +678,7 @@ static inline int _read_blocks(sdcard_spi_t *card, int cmd_idx, int bladdr, char
     return reads;
 }
 
-int sdcard_spi_read_blocks(sdcard_spi_t *card, int blockaddr, char *data, int blocksize,
+int sdcard_spi_read_blocks(sdcard_spi_t *card, int blockaddr, uint8_t *data, int blocksize,
                            int nblocks, sd_rw_response_t *state)
 {
     if (nblocks > 1) {
@@ -689,7 +689,7 @@ int sdcard_spi_read_blocks(sdcard_spi_t *card, int blockaddr, char *data, int bl
     }
 }
 
-static sd_rw_response_t _write_data_packet(sdcard_spi_t *card, char token, const char *data, int size)
+static sd_rw_response_t _write_data_packet(sdcard_spi_t *card, uint8_t token, const uint8_t *data, int size)
 {
 
     spi_transfer_byte(card->params.spi_dev, GPIO_UNDEF, true, token);
@@ -697,13 +697,11 @@ static sd_rw_response_t _write_data_packet(sdcard_spi_t *card, char token, const
     if (_transfer_bytes(card, data, 0, size) == size) {
 
         uint16_t data_crc16 = ucrc16_calc_be((uint8_t *)data, size, UCRC16_CCITT_POLY_BE, 0);
-        char crc[sizeof(uint16_t)] = { data_crc16 >> 8, data_crc16 & 0xFF };
+        uint8_t crc[sizeof(uint16_t)] = { data_crc16 >> 8, data_crc16 & 0xFF };
 
         if (_transfer_bytes(card, crc, 0, sizeof(crc)) == sizeof(crc)) {
 
-            char data_response;
-
-            data_response = (char)spi_transfer_byte(card->params.spi_dev, GPIO_UNDEF,
+            uint8_t data_response = spi_transfer_byte(card->params.spi_dev, GPIO_UNDEF,
                                                     true, SD_CARD_DUMMY_BYTE);
 
             DEBUG("_write_data_packet: DATA_RESPONSE: 0x%02x\n", data_response);
@@ -744,14 +742,14 @@ static sd_rw_response_t _write_data_packet(sdcard_spi_t *card, char token, const
     }
 }
 
-static inline int _write_blocks(sdcard_spi_t *card, char cmd_idx, int bladdr, const char *data, int blsz,
+static inline int _write_blocks(sdcard_spi_t *card, uint8_t cmd_idx, int bladdr, const uint8_t *data, int blsz,
                                 int nbl, sd_rw_response_t *state)
 {
     _select_card_spi(card);
     int written = 0;
 
     uint32_t addr = card->use_block_addr ? bladdr : (bladdr * SD_HC_BLOCK_SIZE);
-    char cmd_r1_resu = sdcard_spi_send_cmd(card, cmd_idx, addr, SD_BLOCK_WRITE_CMD_RETRIES);
+    uint8_t cmd_r1_resu = sdcard_spi_send_cmd(card, cmd_idx, addr, SD_BLOCK_WRITE_CMD_RETRIES);
 
     if (R1_VALID(cmd_r1_resu) && !R1_ERROR(cmd_r1_resu)) {
         DEBUG("_write_blocks: send CMD%d: [OK]\n", cmd_idx);
@@ -812,7 +810,7 @@ static inline int _write_blocks(sdcard_spi_t *card, char cmd_idx, int bladdr, co
     }
 }
 
-int sdcard_spi_write_blocks(sdcard_spi_t *card, int blockaddr, const char *data, int blocksize,
+int sdcard_spi_write_blocks(sdcard_spi_t *card, int blockaddr, const uint8_t *data, int blocksize,
                             int nblocks, sd_rw_response_t *state)
 {
     if (nblocks > 1) {
@@ -825,7 +823,7 @@ int sdcard_spi_write_blocks(sdcard_spi_t *card, int blockaddr, const char *data,
 
 sd_rw_response_t _read_cid(sdcard_spi_t *card)
 {
-    char cid_raw_data[SD_SIZE_OF_CID_AND_CSD_REG];
+    uint8_t cid_raw_data[SD_SIZE_OF_CID_AND_CSD_REG];
     sd_rw_response_t state;
     int nbl = _read_blocks(card, SD_CMD_10, 0, cid_raw_data, SD_SIZE_OF_CID_AND_CSD_REG,
                            SD_BLOCKS_FOR_REG_READ, &state);
@@ -837,14 +835,14 @@ sd_rw_response_t _read_cid(sdcard_spi_t *card)
     }
     DEBUG("\n");
 
-    char crc7 = _crc_7(&(cid_raw_data[0]), SD_SIZE_OF_CID_AND_CSD_REG - 1);
+    uint8_t crc7 = _crc_7(&(cid_raw_data[0]), SD_SIZE_OF_CID_AND_CSD_REG - 1);
     if (nbl == SD_BLOCKS_FOR_REG_READ) {
         if (crc7 == cid_raw_data[SD_SIZE_OF_CID_AND_CSD_REG - 1]) {
             card->cid.MID = cid_raw_data[0];
             memcpy(&card->cid.OID[0], &cid_raw_data[1], SD_SIZE_OF_OID);
             memcpy(&card->cid.PNM[0], &cid_raw_data[2], SD_SIZE_OF_PNM);
             card->cid.PRV = cid_raw_data[8];
-            memcpy((char *)&card->cid.PSN, &cid_raw_data[9], 4);
+            memcpy((uint8_t *)&card->cid.PSN, &cid_raw_data[9], 4);
             card->cid.MDT = (cid_raw_data[13]<<4) | cid_raw_data[14];
             card->cid.CID_CRC = cid_raw_data[15];
             DEBUG("_read_cid: [OK]\n");
@@ -861,7 +859,7 @@ sd_rw_response_t _read_cid(sdcard_spi_t *card)
 
 sd_rw_response_t _read_csd(sdcard_spi_t *card)
 {
-    char c[SD_SIZE_OF_CID_AND_CSD_REG];
+    uint8_t c[SD_SIZE_OF_CID_AND_CSD_REG];
     sd_rw_response_t state;
     int read_resu = _read_blocks(card, SD_CMD_9, 0, c, SD_SIZE_OF_CID_AND_CSD_REG,
                                  SD_BLOCKS_FOR_REG_READ, &state);
@@ -951,8 +949,8 @@ sd_rw_response_t _read_csd(sdcard_spi_t *card)
 
 sd_rw_response_t sdcard_spi_read_sds(sdcard_spi_t *card, sd_status_t *sd_status){
     _select_card_spi(card);
-    char sds_raw_data[SD_SIZE_OF_SD_STATUS];
-    char r1_resu = sdcard_spi_send_cmd(card, SD_CMD_55, SD_CMD_NO_ARG, 0);
+    uint8_t sds_raw_data[SD_SIZE_OF_SD_STATUS];
+    uint8_t r1_resu = sdcard_spi_send_cmd(card, SD_CMD_55, SD_CMD_NO_ARG, 0);
     _unselect_card_spi(card);
     if (R1_VALID(r1_resu)) {
         if(!R1_ERROR(r1_resu)){

--- a/tests/driver_sdcard_spi/main.c
+++ b/tests/driver_sdcard_spi/main.c
@@ -39,7 +39,7 @@
 extern sdcard_spi_t sdcard_spi_devs[sizeof(sdcard_spi_params) / sizeof(sdcard_spi_params[0])];
 sdcard_spi_t *card = &sdcard_spi_devs[0];
 
-char buffer[SD_HC_BLOCK_SIZE * MAX_BLOCKS_IN_BUFFER];
+uint8_t buffer[SD_HC_BLOCK_SIZE * MAX_BLOCKS_IN_BUFFER];
 
 static int _init(int argc, char **argv)
 {
@@ -293,18 +293,18 @@ static int _write(int argc, char **argv)
     }
 
     /* copy data to a full-block-sized buffer an fill remaining block space according to -r param*/
-    char buffer[SD_HC_BLOCK_SIZE];
-    for (unsigned i = 0; i < sizeof(buffer); i++) {
+    uint8_t write_buffer[SD_HC_BLOCK_SIZE];
+    for (unsigned i = 0; i < sizeof(write_buffer); i++) {
         if (repeat_data || ((int)i < size)) {
-            buffer[i] = data[i % size];
+            write_buffer[i] = data[i % size];
         }
         else {
-            buffer[i] = 0;
+            write_buffer[i] = 0;
         }
     }
 
     sd_rw_response_t state;
-    int chunks_written = sdcard_spi_write_blocks(card, bladdr, buffer, SD_HC_BLOCK_SIZE, 1, &state);
+    int chunks_written = sdcard_spi_write_blocks(card, bladdr, write_buffer, SD_HC_BLOCK_SIZE, 1, &state);
 
     if (state != SD_RW_OK) {
         printf("write error %d (wrote %d/%d blocks)\n", state, chunks_written, 1);
@@ -319,7 +319,7 @@ static int _copy(int argc, char **argv)
 {
     int src_block;
     int dst_block;
-    char tmp_copy[SD_HC_BLOCK_SIZE];
+    uint8_t tmp_copy[SD_HC_BLOCK_SIZE];
 
     if (argc != 3) {
         printf("usage: %s src_block dst_block\n", argv[0]);


### PR DESCRIPTION
### Contribution description

This PR is related to PR #11352, where I suggest to add support for Linux' `/dev/spidev` devices to the native cpu. [As mentioned in that PR](https://github.com/RIOT-OS/RIOT/pull/11352#issuecomment-486231452), enabling SPI causes the `tests/driver_sdcard_spi` to be run for the first time on the gnu / llvm toolchain. As the driver and the test use `char` for byte representation and rely on the platform's definition for `char` being unsigned, the test fails as this does not hold for Linux and these toolchains.

So in this PR, I suggest to use `uint8_t` instead of `char` for all bytes and byte arrays in the `sdcard_spi` driver and the corresponding test to be platform-independent. I checked the variables for command identifiers that I modified against the [SD Card Specs](https://www.sdcard.org/downloads/pls/), and all of them are meant to be unsigned bytes.

### Testing procedure

**Testing on hardware:**

This should assure that the changes do not break anything in platforms where the SD card can already be used. It should not be a problem, because if the code did compile without warnings before, `char` should've already been an unsigned 8 bit integer.

The `driver_sdcard_spi` or `pkg_fatfs` tests are suitable to test the modified driver. I'd suggest to wire up a board with SPI support to an SD Card slot and run the test first against the current master branch to verify the setup, and then to the modified version from this PR.

I had an ESP32 at hand and used the `esp32-wroom-32` board for testing. To do so, I added the following parameters to the test's Makefile ...

```
CFLAGS += -DSDCARD_SPI_PARAM_CS="GPIO_PIN(0,5)"
CFLAGS += -DSDCARD_SPI_PARAM_CLK="GPIO_PIN(0,18)"
CFLAGS += -DSDCARD_SPI_PARAM_MOSI="GPIO_PIN(0,23)"
CFLAGS += -DSDCARD_SPI_PARAM_MISO="GPIO_PIN(0,19)"
```

... and wired the SD card module to the corresponding pins.

Additionally, I had to change `SD_CARD_SPI_SPEED_POSTINIT` to `SPI_CLK_400KHZ` in `drivers/sdcard_spi/include/sdcard_spi_internal.h:148`, as my jumper-wire-setup failed for higher speeds. In that case you'll be able to retrieve information about the card in the slot, but not to read/write any actual data without the modification.

<details>
<summary>Example for the driver_sdcard_spi test</summary>

```
INFO # SD-card spi driver test application
INFO # insert SD-card and use 'init' command to set card to spi mode
INFO # WARNING: using 'write' or 'copy' commands WILL overwrite data on your sd-card and
INFO # almost for sure corrupt existing filesystems, partitions and contained data!
> cid
INFO #  cid
INFO # ----------------------------------------
INFO # MID: 3
INFO # OID: SD
       ...
> size
INFO #  size
INFO # Card size: 
INFO # 15931539456 bytes (14,836 GiB | 15,931 GB)
> read 0 4
INFO #  read 0 4
INFO # BLOCK 0:
INFO # fa b8 00 10 8e d0 bc 00 b0 b8 00 00 8e d8 8e c0 
INFO # fb be 00 7c bf 00 06 b9 00 02 f3 a4 ea 21 06 00
       ...
```

</details>

<details>
<summary>Example for the pkg_fatfs test</summary>

```
INFO # init sdcard_mtd 0 [OK]
> mount 0
INFO #  mount 0
INFO # mounting file system image...
INFO # [OK]
INFO # Volume name: 
INFO # 14,821 GiB of 14,821 GiB available
> ls
INFO #  ls
INFO # //LOREM.TXT
INFO # //HELLO.TXT
> read //LOREM.TXT
INFO #  read //LOREM.TXT
INFO # Lorem ipsum dolor sit amet, ...
```

</details>

**Test the changes:**

To make sure that this PR solves the problem in #11352, both branches have to be merged on top of each other (should for now work without any conflicts). Then, build `tests/driver_sdcard_spi` with gnu and/or llvm for `BOARD=native` and check that it does no longer throw any warnings, in contrast to the previous [Murdock build](https://ci.riot-os.org/RIOT-OS/RIOT/11352/fb4c52747487659a540d72eb760e0ae66d420beb/output.html). Note that `tests/pkg_fatfs` isn't suitable here as it uses the native MTD implementation.

### Issues/PRs references

Required for PR #11352
