### PR TITLE
stm32/gpio: fix variable usage in gpio_init_int

### DIFF
--- a/cpu/stm32_common/periph/gpio.c
+++ b/cpu/stm32_common/periph/gpio.c
@@ -237,9 +237,9 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     SYSCFG->EXTICR[pin_num >> 2] |= (port_num << ((pin_num & 0x03) * 4));
 
     /* clear any pending requests */
-    EXTI->PR = (1 << pin);
+    EXTI->PR = (1 << pin_num);
     /* unmask the pins interrupt channel */
-    EXTI->IMR |= (1 << pin);
+    EXTI->IMR |= (1 << pin_num);
 
     return 0;
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes a wrongly used variable in `gpio_init_int` of `stm32_common`, ~~and adds functionality to clear pending interrupt requests before (re)enabling interrupts for the common and f1 specific peripheral gpio implementation.~~

[edit]: removed the other commits, needs deeper investigation


### Testing procedure

Try some interrupts with `tests/periph_gpio` on you favourite Nucleo boards, should still work.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->