### PR TITLE
tests/posix_semaphore: unify and increase allowed test4 margin

### DIFF
--- a/tests/posix_semaphore/main.c
+++ b/tests/posix_semaphore/main.c
@@ -236,16 +236,16 @@ void test3(void)
     sem_post(&s1);
 }
 
-#ifdef BOARD_NATIVE
-/* native can sometime take more time to respond as it is not real time */
-#define TEST4_TIMEOUT_EXCEEDED_MARGIN (300)
-#elif CPU_FAM_NRF51
-/* nrf51 based boards needs a slightly higher margin value. Using 105us makes
- test4 result more reliable. */
-#define TEST4_TIMEOUT_EXCEEDED_MARGIN (105)
-#else
-#define TEST4_TIMEOUT_EXCEEDED_MARGIN (100)
-#endif /* BOARD_NATIVE */
+/*
+ * Allowed margin for waiting too long.
+ *
+ * Waiting too short is forbidden by POSIX, but is checked elsewhere.
+ *
+ * This allows waiting a little (0.1%) longer than exactly 1000000us.
+ * The value should be large enough to not trip over timer inaccuracies, but
+ * small enough to catch any fundamental problems.
+ */
+#define TEST4_TIMEOUT_EXCEEDED_MARGIN (1000)
 
 void test4(void)
 {


### PR DESCRIPTION
### Contribution description

The test configured tight margins for how much too long a semaphore wait can take. This is becoming a maintenance burden.

Instead of adding more special cases, this PR changes the allowed margin to 1ms (which is 0.1percent of the 1sec delay). This should be high enough to not trip over slightly inaccurate timers or slow platforms, but high enough to show fundamental problems with the interaction between timers and posix semaphores.

Remember, this should test semaphores, not timer subsystem accuracy.

### Testing procedure

Validate soundness, execute tests on some boards (or let CI do it),

### Issues/PRs references

#11449