### PR TITLE
tests/periph_timer: include kw41z boards in low-power timer boards

### DIFF
--- a/tests/periph_timer/Makefile
+++ b/tests/periph_timer/Makefile
@@ -8,7 +8,7 @@ TEST_ON_CI_WHITELIST += all
 
 ifneq (,$(filter arduino-duemilanove arduino-mega2560 arduino-uno waspmote-pro,$(BOARD)))
   TIMER_SPEED ?= 250000
-else ifneq (,$(filter hifive1,$(BOARD)))
+else ifneq (,$(filter hifive1 %-kw41z,$(BOARD)))
   TIMER_SPEED ?= 32768
 endif
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

`tests/periph_timer` is broken on kw41z based boards and this PR is fixing this the same way it's done with hifive board.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Build, flash and test `tests/periph_timer` on frdm-kw41z board: it should work. The same result is expected with usb-kw41z and phynode-kw41z boards, since they share the same timer configuration.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
