### PR TITLE
boards/common/nrf52: add openocd support for 'nordic_softdevice_ble' 

### DIFF
--- a/boards/common/nrf52/Makefile.include
+++ b/boards/common/nrf52/Makefile.include
@@ -41,8 +41,24 @@ else ifeq (openocd,$(PROGRAMMER))
   # for nrf52dk and nrf52840dk boards. To use OpenOCD with these a version
   # build from source (master > 2018, August the 13rd) is required.
   ifneq (,$(filter nordic_softdevice_ble,$(USEPKG)))
-    # openocd doesn't work (yet) with softdevice
-    $(error Cannot use OpenOCD with nordic_softdevice module)
+    LINKER_SCRIPT ?= $(RIOTCPU)/$(CPU)/ldscripts/$(CPU_MODEL)_sd.ld
+
+    export OPENOCD_PRE_FLASH_CMDS += -c 'flash write_image erase "$(BINDIR)/softdevice.hex"'
+    export OPENOCD_PRE_VERIFY_CMDS += -c 'verify_image "$(BINDIR)/softdevice.hex"'
+
+    # Cannot use the 'ELFFILE' here
+    # The segments are 0x10000 aligned so padding bytes are copied and verified
+    #
+    # Using 'LINKFLAGS += -Wl,--nmagic' prevents it but would require
+    # dedicated testing/review
+    FLASHFILE ?= $(HEXFILE)
+
+    # murdock: softdevice.hex file is used for flashing
+    # It must be taken into account for the test input hash and
+    # be sent to the separated testing boards
+    TEST_EXTRA_FILES += $(BINDIR)/softdevice.hex
+    # Files in TEST_EXTRA_FILES need to have an explicit target
+    $(BINDIR)/softdevice.hex: | $(ELFFILE)
   endif
   DEBUG_ADAPTER ?= jlink
   export OPENOCD_CONFIG := $(RIOTBOARD)/common/nrf52/dist/openocd.cfg


### PR DESCRIPTION
### Contribution description

Enable the handling of flashing `softdevice.hex` when flashing the firmware
for openocd.

However, for flashing, only the `hexfile` and `binfile` can currently be used.

The `elffile` is generated with local pages aligned to `0x10000` which makes
the program starting at `0x1f000` be flashed from `0x10000` with padding bytes
even if the `.text` section is indeed at `0x1f000`:

    readelf --sections bin/nrf52dk/gnrc_networking.elf

      ...
      [ 1] .text         PROGBITS    0001f000 00f000 00f698 00  AX  0   0 16
      ...

    readelf --segments  bin/nrf52dk/gnrc_networking.elf

      ...
      LOAD           0x000000 0x00010000 0x00010000 0x1e6a0 0x1e6a0 R E 0x10000
      ...

The padding bytes would go through `verify_image` in `openocd` so be expected
to not be overwritten but are by `softdevice.hex`

Using --nmagic at link time removes the local page alignement but would
need dedicated testing.


### Testing procedure


It can be tested with `gnrc_networking` and `tests/nordic_softdevice_ble`.

`Murdock` test execution output is not showing it is working as it does not use `openocd`. It would only show this did not break anything (even if the real changes are only in the `openocd` branch).

<details><summary>hwrng issue fixed</summary>

> I currently do not know which examples works with `nordic_softdevice_ble` as `gnrc_networking` does not give any output when using it even when flashed with `Jlink`.
>
> **EDIT**: By disabling `periph_hwrng` inclusion it can be tested with `gnrc_networking`.
>
> ``` diff
> diff --git a/Makefile.dep b/Makefile.dep
> index 3de6f2bf7..b45f78142 100644
> --- a/Makefile.dep
> +++ b/Makefile.dep
> @@ -680,7 +680,7 @@ ifneq (,$(filter random,$(USEMODULE)))
>   endif
> 
>    ifeq (,$(filter puf_sram,$(USEMODULE)))
> -    FEATURES_OPTIONAL += periph_hwrng
> +    #FEATURES_OPTIONAL += periph_hwrng
>    endif
>  
>    USEMODULE += luid
> ```
</details>

<details><summary>Previous memory comparison that shown issues and that is now handled in #11620</summary>

Another testing procedure will be showing memory comparison with what Jlink flashes.

I added a test file to generate all the memory files to compare.


#### Prequisite info

`softdevice.hex` is not full, bytes in `[0x8bc, 0x3000[` are empty and the file is `0x1eb58` bytes long.

So any change in unused bytes in the output is not important.

Comparison of the output of the objcopy with `--gap-fill`

```diff
diff -u softdevice.0x00.bin.hex  softdevice.0xff.bin.hex 
--- softdevice.0x00.bin.hex     2019-04-30 14:35:14.221786128 +0200
+++ softdevice.0xff.bin.hex     2019-04-30 14:35:14.237786282 +0200
@@ -137,8 +137,8 @@
 0000880 4a07 4710 4a07 6812 322c 6812 4710 0000
 0000890 b500 4b05 681b 4a05 589b 4798 bd00 0000
 00008a0 02ff 0000 0000 2000 08b0 0000 0004 0000
-00008b0 3000 0000 2000 0000 2400 00f4 0000 0000
-00008c0 0000 0000 0000 0000 0000 0000 0000 0000
+00008b0 3000 0000 2000 0000 2400 00f4 ffff ffff
+00008c0 ffff ffff ffff ffff ffff ffff ffff ffff
 *
 0003000 23c0 2000 e901 0001 3d91 0000 e85f 0001
 0003010 3d91 0000 3d91 0000 3d91 0000 0000 0000
```

```
tail -n 5 softdevice.0x00.bin.hex 
001eb20 319c 0000 f04f 20e0 f8d0 1200 f011 0f02
001eb30 d0fa 4770 3701 2e02 3601 0001 0001 3784
001eb40 fb20 9b34 805f 2b04 0080 3310 017f bc02
001eb50 e429 e845 0001 0000                    
001eb58
```


#### Output comparison

In the openocd case, I did not erase the memory as done for Jlink as I think it is not necessary.

#### Comparison with the `erased` version

    diff -u jlink_flashed.hex openocd_erased.hex
    # No difference

#### Comparison with setting the memory to `0x00`

All the changes are between `0x1000` and `0x2000` so can be ignored.

```diff
diff -u jlink_flashed.hex openocd_set_to_0.hex
--- jlink_flashed.hex   2019-04-30 15:03:28.211596293 +0200
+++ openocd_set_to_0.hex        2019-04-30 15:04:16.503979616 +0200
@@ -140,6 +140,10 @@
 00008b0 3000 0000 2000 0000 2400 00f4 ffff ffff
 00008c0 ffff ffff ffff ffff ffff ffff ffff ffff
 *
+0001000 0000 0000 0000 0000 0000 0000 0000 0000
+*
+0002000 ffff ffff ffff ffff ffff ffff ffff ffff
+*
 0003000 23c0 2000 e901 0001 3d91 0000 e85f 0001
 0003010 3d91 0000 3d91 0000 3d91 0000 0000 0000
 0003020 0000 0000 0000 0000 0000 0000 e965 0001
```

### Comparison with flashing the memory from a previous firmware without setting memory

Here too, the difference is only between `0x1000` and `0x2000` so within unused range.

I provide the full output anyway if anybody is interested for reviewing without executing it themself.

<details><summary><tt>diff -u jlink_flashed.hex  openocd_dirty.hex</tt></summary>
<p>


```diff
diff -u jlink_flashed.hex  openocd_dirty.hex
--- jlink_flashed.hex	2019-04-30 15:03:28.211596293 +0200
+++ openocd_dirty.hex	2019-04-30 15:03:42.711706773 +0200
@@ -140,6 +140,259 @@
 00008b0 3000 0000 2000 0000 2400 00f4 ffff ffff
 00008c0 ffff ffff ffff ffff ffff ffff ffff ffff
 *
+0001000 6d60 89a3 075a d505 6863 1ac0 6b63 b10b
+0001010 6c23 1ac0 2300 4602 6ae6 6a21 4628 47b0
+0001020 1c43 89a3 d106 6829 291d d848 4a29 40ca
+0001030 07d6 d544 2200 6062 04d9 6922 6022 d504
+0001040 1c42 d101 682b b903 6560 6b61 602f 2900
+0001050 d0c9 f104 0344 4299 d002 4628 f000 f99c
+0001060 2000 6360 e7c0 2301 4628 47b0 1c41 d1c8
+0001070 682b 2b00 d0c5 2b1d d001 2b16 d101 602f
+0001080 e7b1 89a3 f043 0340 81a3 e7ad 690f 2f00
+0001090 d0a9 0793 680e bf08 694b 600f bf18 2300
+00010a0 eba6 0807 608b f1b8 0f00 dd9c 4643 463a
+00010b0 6a21 6aa6 4628 47b0 2800 dc06 89a3 f043
+00010c0 0340 81a3 f04f 30ff e78e 4407 eba8 0800
+00010d0 e7e9 bf00 0001 2040 b538 690b 4605 460c
+00010e0 b1db b118 6983 b90b f000 f860 4b0c 429c
+00010f0 d109 686c f9b4 300c b17b 4621 4628 e8bd
+0001100 4038 f7ff bf63 4b07 429c d101 68ac e7f1
+0001110 4b05 429c bf08 68ec e7ec 2000 bd38 bf00
+0001120 1efc 0000 1f1c 0000 1edc 0000 2300 b510
+0001130 4604 e9c0 3300 6083 8181 6643 81c2 e9c0
+0001140 3304 6183 4619 2208 305c f000 f91d 4b05
+0001150 6263 4b05 62a3 4b05 62e3 4b05 6224 6323
+0001160 bd10 bf00 1a79 0000 1a9b 0000 1ad3 0000
+0001170 1af7 0000 4901 f000 b885 bf00 10d9 0000
+0001180 b570 1e4a 2568 4355 460e f105 0174 f000
+0001190 f951 4604 b140 2100 e9c0 1600 300c 60a0
+00011a0 f105 0268 f000 f8f0 4620 bd70 6983 b510
+00011b0 4604 bb33 e9c0 3312 6503 4b12 4a12 681b
+00011c0 6282 4298 bf04 2301 6183 f000 f81f 6060
+00011d0 4620 f000 f81b 60a0 4620 f000 f817 2200
+00011e0 60e0 2104 6860 f7ff ffa1 2201 2109 68a0
+00011f0 f7ff ff9c 2202 2112 68e0 f7ff ff97 2301
+0001200 61a3 bd10 1ed8 0000 1175 0000 b5f8 4b1b
+0001210 681e 69b3 4607 b913 4630 f7ff ffc7 3648
+0001220 e9d6 3401 3b01 d503 6833 b133 6836 e7f7
+0001230 f9b4 500c b16d 3468 e7f4 2104 4638 f7ff
+0001240 ff9f 6030 2800 d1f1 230c 603b 4604 4620
+0001250 bdf8 4b0b 6665 e9c4 5500 60a5 e9c4 3503
+0001260 e9c4 5505 2208 4629 f104 005c f000 f88c
+0001270 e9c4 550d e9c4 5512 e7e9 bf00 1ed8 0000
+0001280 0001 ffff e92d 43f8 4680 4689 f100 0448
+0001290 2600 b914 4630 e8bd 83f8 e9d4 7501 3f01
+00012a0 d501 6824 e7f5 89ab 2b01 d907 f9b5 300e
+00012b0 3301 d003 4629 4640 47c8 4306 3568 e7ee
+00012c0 b570 460e f9b1 100e 2900 b096 4614 461d
+00012d0 da07 2300 602b 89b3 061a d410 f44f 6380
+00012e0 e00e 466a f7fe ff2e 2800 dbf2 9a01 f402
+00012f0 4270 f5a2 5300 425a 415a 602a e7ee 2340
+0001300 2000 6023 b016 bd70 898b b573 079d 4606
+0001310 460c d507 f104 0347 6023 6123 2301 6163
+0001320 b002 bd70 ab01 466a f7ff ffca 9900 4605
+0001330 4630 f000 f87f b948 f9b4 300c 059a d4ef
+0001340 f023 0303 f043 0302 81a3 e7e3 4b0d 62b3
+0001350 89a3 6020 f043 0380 81a3 9b00 6163 9b01
+0001360 6120 b15b f9b4 100e 4630 f7fe fef0 b128
+0001370 89a3 f023 0303 f043 0301 81a3 89a3 431d
+0001380 81a5 e7cd 1175 0000 4402 4603 4293 d100
+0001390 4770 f803 1b01 e7f9 b538 4605 2900 d045
+00013a0 f851 3c04 1f0c 2b00 bfb8 18e4 f000 fbf8
+00013b0 4a1f 6813 4610 b933 6063 6014 4628 e8bd
+00013c0 4038 f000 bbee 42a3 d90c 6821 1862 4293
+00013d0 bf04 681a 685b 6063 bf04 1852 6022 6004
+00013e0 e7ec 4613 685a b10a 42a2 d9fa 6819 1858
+00013f0 42a0 d10b 6820 4401 1858 4282 6019 d1dd
+0001400 6810 6852 605a 4401 6019 e7d7 d902 230c
+0001410 602b e7d3 6820 1821 428a bf04 6811 6852
+0001420 6062 bf04 1809 6021 605c e7c7 bd38 bf00
+0001430 0aac 2000 b570 1ccd f025 0503 3508 2d0c
+0001440 bf38 250c 2d00 4606 db01 42a9 d903 230c
+0001450 6033 2000 bd70 f000 fba3 4a21 6814 4621
+0001460 b991 4c20 6823 b91b 4630 f7fe fe3b 6020
+0001470 4629 4630 f7fe fe36 1c43 d124 230c 6033
+0001480 4630 f000 fb8e e7e4 680b 1b5b d418 2b0b
+0001490 d90f 600b 50cd 18cc 4630 f000 fb82 f104
+00014a0 000b 1d23 f020 0007 1ac3 d0d3 425a 50e2
+00014b0 e7d0 428c 684b bf16 6063 6013 460c e7eb
+00014c0 460c 6849 e7cc 1cc4 f024 0403 42a0 d005
+00014d0 1a21 4630 f7fe fe06 3001 d0cf 6025 e7db
+00014e0 0aac 2000 0ab0 2000 6893 3b01 2b00 b410
+00014f0 6093 da08 6994 42a3 db01 290a d103 f85d
+0001500 4b04 f7ff bca3 6813 1c58 6010 7019 4608
+0001510 f85d 4b04 4770 b5f8 4606 460f 4614 18d5
+0001520 42ac d101 2000 e007 463a f814 1b01 4630
+0001530 f7ff ffda 1c43 d1f3 bdf8 0000 e92d 4ff0
+0001540 460c b09d 4617 461d 4606 b118 6983 b90b
+0001550 f7ff fe2c 4b7c 429c d158 6874 89a3 0718
+0001560 d55e 6923 2b00 d05b 2300 9309 2320 f88d
+0001570 3029 2330 f88d 302a 9503 f04f 0b01 46b8
+0001580 4645 f815 3b01 b10b 2b25 d154 ebb8 0a07
+0001590 d00b 4653 463a 4621 4630 f7ff ffbc 3001
+00015a0 f000 80c2 9b09 4453 9309 f898 3000 2b00
+00015b0 f000 80ba 2300 f04f 32ff e9cd 2305 9304
+00015c0 9307 f88d 3053 931a 46a8 2205 f818 1b01
+00015d0 485e f000 fa95 9b04 bb78 06d9 bf44 2220
+00015e0 f88d 2053 071a bf44 222b f88d 2053 782a
+00015f0 2a2a d02a 9a07 46a8 2000 250a 4641 f811
+0001600 3b01 3b30 2b09 d969 b360 e024 4b50 429c
+0001610 d101 68b4 e7a2 4b4f 429c bf08 68f4 e79d
+0001620 4621 4630 f7ff fc64 2800 d09d f04f 30ff
+0001630 b01d e8bd 8ff0 46a8 e7a2 4a44 1a80 fa0b
+0001640 f000 4318 9004 4645 e7be 9a03 1d11 6812
+0001650 9103 2a00 db01 9207 e004 4252 f043 0302
+0001660 9207 9304 f898 3000 2b2e d10e f898 3001
+0001670 2b2a d138 9b03 1d1a 681b 9203 2b00 bfb8
+0001680 f04f 33ff f108 0802 9305 4d33 f898 1000
+0001690 2203 4628 f000 fa34 b140 2340 1b40 fa03
+00016a0 f000 9b04 4303 f108 0801 9304 f898 1000
+00016b0 482a f88d 1028 2206 f108 0701 f000 fa20
+00016c0 2800 d037 4b26 bb1b 9b03 3307 f023 0307
+00016d0 3308 9303 9b09 444b 9309 e750 fb05 3202
+00016e0 2001 4688 e78a 2300 f108 0801 9305 4619
+00016f0 250a 4640 f810 2b01 3a30 2a09 d903 2b00
+0001700 d0c3 9105 e7c1 fb05 2101 2301 4680 e7f0
+0001710 ab03 9300 4622 4b13 a904 4630 f3af 8000
+0001720 f1b0 3fff 4681 d1d5 89a3 065b f53f af7e
+0001730 9809 e77d ab03 9300 4622 4b0a a904 4630
+0001740 f000 f888 e7ec bf00 1efc 0000 1f3c 0000
+0001750 1f1c 0000 1edc 0000 1f42 0000 1f46 0000
+0001760 0000 0000 1517 0000 e92d 47f0 4691 461f
+0001770 688a 690b f8dd 8020 4293 bfb8 4613 f8c9
+0001780 3000 f891 2043 4606 460c b112 3301 f8c9
+0001790 3000 6823 0699 bf42 f8d9 3000 3302 f8c9
+00017a0 3000 6825 f015 0506 d107 f104 0a19 68e3
+00017b0 f8d9 2000 1a9b 42ab dc28 f894 3043 6822
+00017c0 3300 bf18 2301 0692 d42d f104 0243 4639
+00017d0 4630 47c0 3001 d020 6823 68e5 f8d9 2000
+00017e0 f003 0306 2b04 bf08 1aad 68a3 6922 bf0c
+00017f0 ea25 75e5 2500 4293 bfc4 1a9b 18ed f04f
+0001800 0900 341a 454d d11a 2000 e008 2301 4652
+0001810 4639 4630 47c0 3001 d103 f04f 30ff e8bd
+0001820 87f0 3501 e7c3 18e1 1c5a 2030 f881 0043
+0001830 4422 f894 1045 f882 1043 3302 e7c5 2301
+0001840 4622 4639 4630 47c0 3001 d0e6 f109 0901
+0001850 e7d8 0000 e92d 43f0 f101 0c43 460c 7e09
+0001860 b085 296e 4617 4606 4698 9a0c f000 80b3
+0001870 d822 2963 d036 d80a 2900 f000 80b9 2958
+0001880 f000 8083 f104 0542 f884 1042 e032 2964
+0001890 d001 2969 d1f6 6820 6813 0605 f103 0104
+00018a0 d52a 681b 6011 2b00 da03 222d 425b f884
+00018b0 2043 486f 220a e039 2973 f000 809d d808
+00018c0 296f d020 2970 d1dd 6823 f043 0320 6023
+00018d0 e003 2975 d017 2978 d1d4 2378 f884 3045
+00018e0 4864 e055 6813 1d19 681b 6011 f104 0542
+00018f0 f884 3042 2301 e08c 681b 6011 f010 0f40
+0001900 bf18 b21b e7cf 6813 6825 1d18 6010 0628
+0001910 d501 681b e002 0668 d5fb 881b 4854 296f
+0001920 bf14 220a 2208 2100 f884 1043 6865 60a5
+0001930 2d00 f2c0 8095 6821 f021 0104 6021 2b00
+0001940 d13d 2d00 f040 808e 4665 2a08 d10b 6823
+0001950 07db d508 6923 6862 429a bfde 2330 f805
+0001960 3c01 f105 35ff ebac 0305 6123 f8cd 8000
+0001970 463b aa03 4621 4630 f7ff fef6 3001 d14d
+0001980 f04f 30ff b005 e8bd 83f0 4839 f884 1045
+0001990 6813 6821 1d1d 681b 6015 060a d50b 07ca
+00019a0 bf44 f041 0120 6021 b91b 6822 f022 0220
+00019b0 6022 2210 e7b7 064d bf48 b29b e7ef 4665
+00019c0 fbb3 f1f2 fb02 3311 5cc3 f805 3d01 460b
+00019d0 2900 d1f5 e7b9 6813 6825 6961 1d18 6010
+00019e0 0628 681b d501 6019 e002 066a d5fb 8019
+00019f0 2300 6123 4665 e7b9 6813 1d19 6011 681d
+0001a00 6862 2100 4628 f000 f87b b108 1b40 6060
+0001a10 6863 6123 2300 f884 3043 e7a7 6923 462a
+0001a20 4639 4630 47c0 3001 d0aa 6823 079b d413
+0001a30 68e0 9b03 4298 bfb8 4618 e7a3 2301 464a
+0001a40 4639 4630 47c0 3001 d09a 3501 68e3 9a03
+0001a50 1a9b 42ab dcf2 e7eb 2500 f104 0919 e7f5
+0001a60 2b00 d1ac 7803 f884 3042 f104 0542 e76c
+0001a70 1f4d 0000 1f5e 0000 b510 460c f9b1 100e
+0001a80 f7fe fb4e 2800 bfab 6d63 89a3 181b f423
+0001a90 5380 bfac 6563 81a3 bd10 e92d 41f0 461f
+0001aa0 898b 05db 4605 460c 4616 d505 2302 2200
+0001ab0 f9b1 100e f7fe fb41 89a3 f9b4 100e f423
+0001ac0 5380 81a3 4632 463b 4628 e8bd 41f0 f7fe
+0001ad0 bb2b b510 460c f9b1 100e f7fe fb2e 1c43
+0001ae0 89a3 bf15 6560 f423 5380 f443 5380 81a3
+0001af0 bf18 81a3 bd10 f9b1 100e f7fe bb19 0000
+0001b00 f001 01ff 2a10 db2b f010 0f07 d008 f810
+0001b10 3b01 3a01 428b d02d f010 0f07 b342 d1f6
+0001b20 b4f0 ea41 2101 ea41 4101 f022 0407 f07f
+0001b30 0700 2300 e8f0 5602 3c08 ea85 0501 ea86
+0001b40 0601 fa85 f547 faa3 f587 fa86 f647 faa5
+0001b50 f687 b98e d1ee bcf0 f001 01ff f002 0207
+0001b60 b132 f810 3b01 3a01 ea83 0301 b113 d1f8
+0001b70 2000 4770 3801 4770 2d00 bf06 4635 3803
+0001b80 3807 f015 0f01 d107 3001 f415 7f80 bf02
+0001b90 3001 f415 3fc0 3001 bcf0 3801 4770 bf00
+0001ba0 4770 4770 5542 2053 4146 4c55 2054 4148
+0001bb0 444e 454c 0052 4544 5542 2047 4f4d 204e
+0001bc0 4148 444e 454c 0052 5544 4d4d 2059 4148
+0001bd0 444e 454c 0052 490a 5253 7320 6174 6b63
+0001be0 6f20 6576 6672 6f6c 6577 0064 7453 6361
+0001bf0 206b 6f70 6e69 6574 2072 6f63 7272 7075
+0001c00 6574 2c64 7220 7365 7465 7420 206f 6f74
+0001c10 2070 666f 7320 6174 6b63 0a00 6f43 746e
+0001c20 7865 2074 6562 6f66 6572 6820 7261 6664
+0001c30 7561 746c 003a 2020 7220 3a30 3020 2578
+0001c40 3830 786c 200a 2020 3172 203a 7830 3025
+0001c50 6c38 0a78 2020 7220 3a32 3020 2578 3830
+0001c60 786c 200a 2020 3372 203a 7830 3025 6c38
+0001c70 0a78 2000 7220 3231 203a 7830 3025 6c38
+0001c80 0a78 2020 6c20 3a72 3020 2578 3830 786c
+0001c90 200a 2020 6370 203a 7830 3025 6c38 0a78
+0001ca0 2020 7370 3a72 3020 2578 3830 786c 0a0a
+0001cb0 4600 5253 462f 5241 003a 4320 5346 3a52
+0001cc0 3020 2578 3830 786c 000a 4820 5346 3a52
+0001cd0 3020 2578 3830 786c 000a 4420 5346 3a52
+0001ce0 3020 2578 3830 786c 000a 4120 5346 3a52
+0001cf0 3020 2578 3830 786c 000a 4220 4146 3a52
+0001d00 3020 2578 3830 786c 000a 4d4d 4146 3a52
+0001d10 3020 2578 3830 786c 000a 694d 6373 4500
+0001d20 4358 525f 5445 203a 7830 3025 6c38 0a78
+0001d30 4100 7474 6d65 7470 6e69 2067 6f74 7220
+0001d40 6365 6e6f 7473 7572 7463 7320 6174 6574
+0001d50 6620 726f 6420 6265 6775 6967 676e 2e2e
+0001d60 002e 6e49 4720 4244 0a3a 2020 6573 2074
+0001d70 7024 3d63 7830 6c25 0a78 2020 7266 6d61
+0001d80 2065 0a30 2020 7462 000a 490a 5253 7320
+0001d90 6174 6b63 6f20 6576 6672 6f6c 6577 2064
+0001da0 7962 6120 2074 656c 7361 2074 6425 6220
+0001db0 7479 7365 0a2e 4800 5241 2044 4146 4c55
+0001dc0 2054 4148 444e 454c 0052 454d 204d 414d
+0001dd0 414e 4547 4820 4e41 4c44 5245 4e00 494d
+0001de0 4820 4e41 4c44 5245 5500 4153 4547 4620
+0001df0 5541 544c 4820 4e41 4c44 5245 4600 4941
+0001e00 454c 2044 5341 4553 5452 4f49 2e4e 2500
+0001e10 0a70 2a00 2a2a 5220 4f49 2054 656b 6e72
+0001e20 6c65 7020 6e61 6369 0a3a 7325 0a0a 2a00
+0001e30 2a2a 6820 6c61 6574 2e64 0a0a 6d00 6961
+0001e40 286e 3a29 5420 6968 2073 7369 5220 4f49
+0001e50 2154 2820 6556 7372 6f69 3a6e 6220 6975
+0001e60 646c 6574 7473 0a29 6900 6c64 0065 616d
+0001e70 6e69 4800 6c65 6f6c 5720 726f 646c 0021
+0001e80 726e 3566 6432 006b 6f59 2075 7261 2065
+0001e90 7572 6e6e 6e69 2067 4952 544f 6f20 206e
+0001ea0 2861 296e 2520 2073 6f62 7261 2e64 000a
+0001eb0 726e 3566 0032 6854 7369 6220 616f 6472
+0001ec0 6620 6165 7574 6572 2073 2861 296e 2520
+0001ed0 2073 434d 2e55 000a 0224 2000 0000 0000
+0001ee0 0000 0000 0000 0000 0000 0000 0000 0000
+*
+0001f30 0000 0000 0000 0000 0000 0000 2d23 2b30
+0001f40 0020 6c68 004c 6665 4567 4746 3000 3231
+0001f50 3433 3635 3837 4139 4342 4544 0046 3130
+0001f60 3332 3534 3736 3938 6261 6463 6665 0000
+0001f70 0ab8 2000 0360 2000 0040 0000 0000 0000
+0001f80 0000 0000 0000 0000 1e69 0000 1e6e 0000
+0001f90 0224 2000 0000 0000 1efc 0000 1f1c 0000
+0001fa0 1edc 0000 0000 0000 0000 0000 0000 0000
+0001fb0 0000 0000 0000 0000 0000 0000 0000 0000
+*
+0001ff0 0000 0000 2128 0000 ffff ffff ffff ffff
+0002000 ffff ffff ffff ffff ffff ffff ffff ffff
+*
 0003000 23c0 2000 e901 0001 3d91 0000 e85f 0001
 0003010 3d91 0000 3d91 0000 3d91 0000 0000 0000
 0003020 0000 0000 0000 0000 0000 0000 e965 0001
```

</p>
</details>

</details>

### Issues/PRs references

I worked on this in the context of https://github.com/RIOT-OS/RIOT/pull/10870 as my `nrf52dk` does not `reset` anymore with `Jlink` but does with `openocd`.