### PR TITLE
release-stats: simplify script usage

### DIFF
--- a/dist/tools/release-stats/release-stats.sh
+++ b/dist/tools/release-stats/release-stats.sh
@@ -11,29 +11,34 @@
 # a release for https://github.com/RIOT-OS/RIOT/wiki/release-statistics
 
 RIOTBASE="$(realpath "$( cd "$(dirname "${0}")" && pwd )/../../..")"
-OLD="${1}"
-NEW="${2}"
+RELEASE="${1}"
 
-if [ $# -lt 2 ]; then
-    echo "usage: ${0} <old> <new> [<riotbase>]" >&2
+if [ $# -lt 1 ]; then
+    echo "usage: ${0} <release> [<old> [<riotbase>]]" >&2
     exit 1
+fi
+
+if [ $# -gt 1 ]; then
+    OLD="${2}"
+else
+    OLD="${RELEASE}-devel"
 fi
 
 if [ $# -gt 2 ]; then
     RIOTBASE="$(realpath "${3}")"
 fi
 
-FILES=$(git ls-tree --full-tree -r "${NEW}")
+FILES=$(git ls-tree --full-tree -r "${RELEASE}")
 START=$(git -C "${RIOTBASE}" log -n 1 --pretty="format:%at" "${OLD}")
-END=$(git -C "${RIOTBASE}" log -n 1 --pretty="format:%at" "${NEW}")
+END=$(git -C "${RIOTBASE}" log -n 1 --pretty="format:%at" "${RELEASE}")
 
 echo "    <tr>"
-echo "        <td>${NEW}</td>"
+echo "        <td>${RELEASE}</td>"
 echo "        <td>$(echo "${FILES}" | wc -l)</td>"
 echo -n "        <td>$(echo "${FILES}"  | awk '{ print $3 }' | xargs -I'{}' git cat-file blob '{}'| wc -l) "
 echo "($(echo "$FILES" | grep -i "[chs]$" | awk '{ print $3 }' | xargs -I'{}' git cat-file blob '{}' | wc -l))</td>"
 echo "        <td>$(( (END - START) / (60 * 60 * 24) )) days</td>"
-echo "        <td>$(git log --no-merges --pretty=oneline "${OLD}".."${NEW}" | wc -l)</td>"
-echo "        <td>$(git diff --shortstat --no-renames "${OLD}".."${NEW}" | sed 's#^\s\+##')</td>"
-echo "        <td>$(git shortlog --no-merges -n -s "${OLD}".."${NEW}" | head -n 5 | sed 's#\s\+# #g;s#^ ##;s#$#<br />#;2,$s#^#            #')</td>"
+echo "        <td>$(git log --no-merges --pretty=oneline "${OLD}".."${RELEASE}" | wc -l)</td>"
+echo "        <td>$(git diff --shortstat --no-renames "${OLD}".."${RELEASE}" | sed 's#^\s\+##')</td>"
+echo "        <td>$(git shortlog --no-merges -n -s "${OLD}".."${RELEASE}" | head -n 5 | sed 's#\s\+# #g;s#^ ##;s#$#<br />#;2,$s#^#            #')</td>"
 echo "    </tr>"


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
With this change one can just type `./release-stats.sh <release>` (given the tag was created) and the release statistics will be generated. It used to be `./release-stats.sh <old> <new>`, which still can be achieved by using the slightly changed syntax `./release-stats <new> <old>`
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Try

```sh
./release-stats.sh 2019.04
```

and compare with https://github.com/RIOT-OS/RIOT/wiki/release-statistics.

Now try

```sh
./release-stats.sh 2019.04 2019.04-RC1
```

Columns 3-6 should have way smaller numbers.


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
