### PR TITLE
netdev_ieee802154: add radio capabilities

### DIFF
--- a/cpu/nrf52/radio/nrf802154/nrf802154.c
+++ b/cpu/nrf52/radio/nrf802154/nrf802154.c
@@ -194,6 +194,9 @@ static void _timer_cb(void *arg, int chan)
 static int _init(netdev_t *dev)
 {
     (void)dev;
+    /* fill transceiver capabilities */
+    netdev_ieee802154_t *ieee802154_dev = (netdev_ieee802154_t*) dev;
+    ieee802154_dev->caps = NETDEV_IEEE802154_CAPS_TX_CHECKSUM;
 
     int result = timer_init(NRF802154_TIMER, TIMER_FREQ, _timer_cb, NULL);
     assert(result >= 0);

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -71,6 +71,15 @@ static int _init(netdev_t *netdev)
 {
     at86rf2xx_t *dev = (at86rf2xx_t *)netdev;
 
+    /* fill transceiver capabilities */
+    netdev_ieee802154_t *ieee802154_dev = (netdev_ieee802154_t*) netdev;
+    ieee802154_dev->caps = NETDEV_IEEE802154_CAPS_TX_CHECKSUM    |
+                           NETDEV_IEEE802154_CAPS_CSMA           |
+                           NETDEV_IEEE802154_CAPS_FRAME_RETRIES  |
+                           NETDEV_IEEE802154_CAPS_ADDRESS_FILTER |
+                           NETDEV_IEEE802154_CAPS_AUTO_ACK       |
+                           NETDEV_IEEE802154_CAPS_PROMISCUOUS;
+
     /* initialize GPIOs */
     spi_init_cs(dev->params.spi, dev->params.cs_pin);
     gpio_init(dev->params.sleep_pin, GPIO_OUT);

--- a/drivers/cc2420/cc2420_netdev.c
+++ b/drivers/cc2420/cc2420_netdev.c
@@ -100,6 +100,13 @@ static int _init(netdev_t *netdev)
 {
     cc2420_t *dev = (cc2420_t *)netdev;
 
+    /* fill transceiver capabilities */
+    netdev_ieee802154_t *ieee802154_dev = (netdev_ieee802154_t*) netdev;
+    ieee802154_dev->caps = NETDEV_IEEE802154_CAPS_TX_CHECKSUM    |
+                           NETDEV_IEEE802154_CAPS_CSMA           |
+                           NETDEV_IEEE802154_CAPS_ADDRESS_FILTER |
+                           NETDEV_IEEE802154_CAPS_AUTO_ACK       |
+                           NETDEV_IEEE802154_CAPS_PROMISCUOUS;
     uint16_t reg;
 
     /* initialize power and reset pins -> put the device into reset state */

--- a/drivers/include/net/netdev/ieee802154.h
+++ b/drivers/include/net/netdev/ieee802154.h
@@ -20,6 +20,7 @@
 #ifndef NET_NETDEV_IEEE802154_H
 #define NET_NETDEV_IEEE802154_H
 
+#include <stdbool.h>
 #include "net/ieee802154.h"
 #include "net/gnrc/nettype.h"
 #include "net/netopt.h"
@@ -79,6 +80,66 @@ typedef enum {
 } netdev_ieee802154_cca_mode_t;
 
 /**
+ * @name IEEE 802.15.4 radio caps
+ * @brief Flags that indicate IEEE 802.15.4 capabilities on transceivers
+ *
+ * @{
+ */
+
+/**
+ * @brief Transceiver calculates FCS on transmission
+ */
+#define NETDEV_IEEE802154_CAPS_TX_CHECKSUM              (1<<0)
+
+/**
+ * @brief Transceiver supports CSMA
+ */
+#define NETDEV_IEEE802154_CAPS_CSMA                     (1<<1)
+
+/**
+ * @brief Transceiver supports energy scan
+ */
+#define NETDEV_IEEE802154_CAPS_ENERGY_SCAN              (1<<2)
+
+/**
+ * @brief Transceiver supports automatic retransmission of frames (with CSMA)
+ */
+#define NETDEV_IEEE802154_CAPS_FRAME_RETRIES            (1<<3)
+
+/**
+ * @brief Transceiver handles ACK automatically
+ */
+#define NETDEV_IEEE802154_CAPS_AUTO_ACK                 (1<<4)
+
+/**
+ * @brief Transceiver removes FCS on received packet
+ */
+#define NETDEV_IEEE802154_CAPS_RX_OMIT_CHECKSUM         (1<<5)
+
+/**
+ * @brief Transceiver drops packet on bad checksum
+ */
+#define NETDEV_IEEE802154_CAPS_RX_DROP_BAD_CHECKSUM     (1<<6)
+
+/**
+ * @brief Transceiver supports address filtering
+ */
+#define NETDEV_IEEE802154_CAPS_ADDRESS_FILTER           (1<<7)
+
+/**
+ * @brief Transceiver supports promiscuous mode
+ */
+#define NETDEV_IEEE802154_CAPS_PROMISCUOUS              (1<<8)
+/**
+ * @}
+ */
+
+/**
+ * @brief IEEE 802.15.4 transceiver capabilites type definition
+ */
+typedef uint16_t netdev_ieee802154_trx_caps_t;
+
+/**
  * @brief Extended structure to hold IEEE 802.15.4 driver state
  *
  * @extends netdev_t
@@ -115,6 +176,7 @@ typedef struct {
     uint8_t page;                           /**< channel page */
     uint16_t flags;                         /**< flags as defined above */
     int16_t txpower;                        /**< tx power in dBm */
+    netdev_ieee802154_trx_caps_t caps;      /**< radio capabilities flags */
     /** @} */
 } netdev_ieee802154_t;
 
@@ -133,6 +195,20 @@ typedef struct netdev_radio_rx_info netdev_ieee802154_rx_info_t;
  */
 void netdev_ieee802154_reset(netdev_ieee802154_t *dev);
 
+/**
+ * @brief   Check if the IEEE802.15.4 radio supports a given capability
+ *
+ * @param[in] netdev    IEEE802.15.4 device descriptor
+ * @param[in] cap       Capability to be checked
+ *
+ * @return              true if the radio supports the given cap.
+ * @return              false otherwise
+ */
+static inline bool netdev_ieee802154_has_cap(netdev_ieee802154_t *netdev,
+        netdev_ieee802154_trx_caps_t cap)
+{
+    return netdev->caps & cap;
+}
 
 /**
  * @brief   Fallback function for netdev IEEE 802.15.4 devices' _get function

--- a/drivers/kw2xrf/kw2xrf_netdev.c
+++ b/drivers/kw2xrf/kw2xrf_netdev.c
@@ -73,6 +73,14 @@ static int _init(netdev_t *netdev)
 {
     kw2xrf_t *dev = (kw2xrf_t *)netdev;
 
+    /* fill transceiver capabilities */
+    netdev_ieee802154_t *ieee802154_dev = (netdev_ieee802154_t*) netdev;
+    ieee802154_dev->caps = NETDEV_IEEE802154_CAPS_TX_CHECKSUM    |
+                           NETDEV_IEEE802154_CAPS_CSMA           |
+                           NETDEV_IEEE802154_CAPS_ADDRESS_FILTER |
+                           NETDEV_IEEE802154_CAPS_AUTO_ACK       |
+                           NETDEV_IEEE802154_CAPS_PROMISCUOUS;
+
     dev->thread = (thread_t *)thread_get(thread_getpid());
 
     /* initialize SPI and GPIOs */

--- a/drivers/mrf24j40/mrf24j40_netdev.c
+++ b/drivers/mrf24j40/mrf24j40_netdev.c
@@ -51,6 +51,15 @@ static int _init(netdev_t *netdev)
 {
     mrf24j40_t *dev = (mrf24j40_t *)netdev;
 
+    /* fill transceiver capabilities */
+    netdev_ieee802154_t *ieee802154_dev = (netdev_ieee802154_t*) netdev;
+    ieee802154_dev->caps = NETDEV_IEEE802154_CAPS_TX_CHECKSUM    |
+                           NETDEV_IEEE802154_CAPS_CSMA           |
+                           NETDEV_IEEE802154_CAPS_FRAME_RETRIES  |
+                           NETDEV_IEEE802154_CAPS_ADDRESS_FILTER |
+                           NETDEV_IEEE802154_CAPS_AUTO_ACK       |
+                           NETDEV_IEEE802154_CAPS_PROMISCUOUS;
+
     /* initialize GPIOs */
     spi_init_cs(dev->params.spi, dev->params.cs_pin);
     gpio_init(dev->params.reset_pin, GPIO_OUT);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Several radios include hardware acceleration for common MAC tasks (automatic ACK handling, automatic retransmissions, CSMA, automatic FCS, etc).
Since these are MAC tasks, the MAC layer needs a mechanism for discovering which tasks are already handled by the radio.

Here comes the concept of radio capabilities.

E.g:
```c
/* ieee802154_mac */

void _send(...) {
    netdev->driver->send(...);
    if(!(netdev->caps & NETDEV_IEEE802154_CAPS_FRAME_RETRIES)) {
        /* The radio does not handle the frame retransmission procedure. Use software logic */
        retrans_procedure();
    }
}
```
I took the caps that I think make more sense for RIOT. I added a typedef for caps so we don't have to change the API if the flags grow (e.g uint16_t to uint32_t).

This tends to be a common pattern (check [Linux IEEE802154 MAC](https://github.com/torvalds/linux/blob/6f0d349d922ba44e4348a17a78ea51b7135965b1/include/net/mac802154.h#L95) and [OpenThread caps](https://github.com/openthread/openthread/blob/ae04d5928030b809c72dd710f0c2a00d847aaa3f/include/openthread/platform/radio.h#L119))
I didn't handle these caps as NETOPT because it's assumed a radio can enable or disable a feature if it exists but not otherwise. E.g it's indeed possible to disable the automatic ACK procedure while in extended mode of the driver (at82rf2xx), but the radio is still capable of handling ACKs. 

This is required in order to implement components of the IEEE802.15.4 MAC and add basic mode support for radios.

### Testing procedure
- Check the capabilities for each radio match the datasheet/implementation
- `make doc`
- Check if the defined capabilities make sense
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
I will be updating this list on the run

#11150 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
