### PR TITLE
tests/pkg_c25519: increase timeout for arduino-mega2560

### DIFF
--- a/tests/pkg_c25519/tests/01-run.py
+++ b/tests/pkg_c25519/tests/01-run.py
@@ -14,7 +14,8 @@ import sys
 def testfunc(child):
     board = os.environ['BOARD']
     # Increase timeout on "real" hardware
-    timeout = 20 if board is not 'native' else -1
+    # 170 seconds on `arduino-mega2560`
+    timeout = 200 if board is not 'native' else -1
     child.expect(r"OK \(2 tests\)", timeout=timeout)
 
 


### PR DESCRIPTION
### Contribution description

`arduino-mega2560` finishes the test in 170 seconds so set a bigger timeout.

### Testing procedure

Run the test on `arduino-mega2560` and it should succeed.

My output was:

```
RIOT_CI_BUILD=1 BOARD=arduino-mega2560 make -C tests/pkg_c25519 flash test
...
2019-04-30 22:03:10,597 - INFO # random: NO SEED AVAILABLE!
2019-04-30 22:03:10,599 - INFO # main(): This is RIOT! (Version: buildtest)
2019-04-30 22:06:01,439 - INFO # ..
2019-04-30 22:06:01,452 - INFO # OK (2 tests)
```

### Issues/PRs references

New failed test for `arduino-mega2560` was found as part of the release testing.
