### PR TITLE
Makefile.features: prerequisites for moving CPU/CPU_MODEL to boards/Makefile.features

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -5,6 +5,13 @@ OLD_USEPKG := $(sort $(USEPKG))
 # include board dependencies
 -include $(RIOTBOARD)/$(BOARD)/Makefile.dep
 
+# Transitional conditional include until all boards define 'CPU' in
+# Makefile.features
+ifneq (,$(CPU))
+  # include cpu dependencies
+  -include $(RIOTCPU)/$(CPU)/Makefile.dep
+endif
+
 # include external modules dependencies
 # processed before RIOT ones to be evaluated before the 'default' rules.
 -include $(EXTERNAL_MODULE_DIRS:%=%/Makefile.dep)

--- a/Makefile.features
+++ b/Makefile.features
@@ -1,4 +1,13 @@
 # Process FEATURES variables
+#
+# The board/board common are responsible for defining the CPU and CPU_MODEL
+# variables in their Makefile.features.
+# This makes them available when setting features based on CPU_MODEL in the cpu
+# Makefile.features and also during dependency resolution.
+
+# Transition:
+#   Moving 'CPU/CPU_MODEL' to Makefile.features is an ongoing work and may not
+#   reflect the state of all boards for the moment.
 
 include $(RIOTBOARD)/$(BOARD)/Makefile.features
 

--- a/Makefile.features
+++ b/Makefile.features
@@ -11,6 +11,11 @@
 
 include $(RIOTBOARD)/$(BOARD)/Makefile.features
 
+# Transitional conditional include until all boards define 'CPU'
+ifneq (,$(CPU))
+  include $(RIOTCPU)/$(CPU)/Makefile.features
+endif
+
 
 # Resolve FEATURES_ variables
 # Their value will only be complete after resolving dependencies

--- a/Makefile.include
+++ b/Makefile.include
@@ -275,7 +275,7 @@ include $(RIOTCPU)/$(CPU)/Makefile.include
 # The check is only done after 'include $(RIOTBOARD)/$(BOARD)/Makefile.include'
 # because we need to have the 'CPU' variable defined
 ifeq (,$(filter $(RIOTCPU)/$(CPU)/Makefile.features,$(MAKEFILE_LIST)))
-  $(error $$(RIOTCPU)/$$(CPU)/Makefile.features must have been included by the board / board common Makefile.features)
+  $(error $$(RIOTCPU)/$$(CPU)/Makefile.features must have been included by the board / board common Makefile.features or Makefile.features)
 endif
 
 # Assume GCC/GNU as supported toolchain if CPU's Makefile.include doesn't

--- a/makefiles/info-global.inc.mk
+++ b/makefiles/info-global.inc.mk
@@ -14,7 +14,14 @@ define board_missing_features
   DISABLE_MODULE    := $(DISABLE_MODULE_GLOBAL)
   FEATURES_REQUIRED := $(FEATURES_REQUIRED_GLOBAL)
   FEATURES_OPTIONAL := $(FEATURES_OPTIONAL_GLOBAL)
+
+  # Remove board specific variables set by Makefile.features/Makefile.dep
   FEATURES_PROVIDED :=
+
+  # Undefine variables that must not be defined when starting.
+  # Some are sometime set as `?=`
+  undefine CPU
+  undefine CPU_MODEL
 
   include $(RIOTBASE)/Makefile.features
 

--- a/makefiles/vars.inc.mk
+++ b/makefiles/vars.inc.mk
@@ -8,8 +8,8 @@ export QUIET                 # The parameter to use whether to show verbose make
 export APPLICATION           # The application, set in the Makefile which is run by the user.
 export APPLICATION_MODULE    # The application module name.
 export BOARD                 # The board to compile the application for.
-export CPU                   # The CPU, set by the board's Makefile.include.
-export CPU_MODEL             # The specific identifier of the used CPU, used for some CPU implementations to differentiate between different memory layouts
+export CPU                   # The CPU, set by the board's Makefile.features.
+export CPU_MODEL             # The specific identifier of the used CPU, used for some CPU implementations to differentiate between different memory layouts. Set by the board's Makefile.features.
 export MCU                   # The MCU, set by the board's Makefile.include, or defaulted to the same value as CPU.
 export INCLUDES              # The extra include paths, set by the various Makefile.include files.
 export CXXINCLUDES           # The extra include paths for c++, set by the various Makefile.include files.


### PR DESCRIPTION
### Contribution description

This pull request introduce a new `Makefile.features` file and prepares for handling `CPU/CPU_MODEL` being defined in `boards/Makefile.features` instead of `Makefile.include`.

It is somehow the official start of the migration.

This is an API change and may need to be advertised on the mailing list.

### Testing procedure

Currently this should have no difference as nothing is defining `CPU/CPU_MODEL` in the board.

Testing may come more from testing #11477 directly (TODO too)

### Reviewing procedure

Please look at the review commit by commit too and ask any question on each steps.

* The `undefine` in `makefiles/info-global.inc.mk` ensure that no definition will leak between steps
* The inclusion of `CPU/Makefile.features` currently break some boards (boards removing `hwrng` after `kinetis/Makefile.features`, so defining CPU for these ones require a fix.
    * -> https://github.com/RIOT-OS/RIOT/pull/11479

### Issues/PRs references


Tracking: move CPU/CPU_MODEL to Makefile.features #11477
Tracking issue: Build dependencies - processing order issues #9913

Depends on ~https://github.com/RIOT-OS/RIOT/pull/11480~
