### PR TITLE
kinetis: move filtering-out periph_hwrng in cpu/kinetis

### DIFF
--- a/boards/frdm-k64f/Makefile.features
+++ b/boards/frdm-k64f/Makefile.features
@@ -12,6 +12,3 @@ FEATURES_PROVIDED += periph_uart
 FEATURES_MCU_GROUP = cortex_m4_1
 
 include $(RIOTCPU)/kinetis/Makefile.features
-# HACK the board currently uses the wrong hwrng register
-# Remove this line when fixed
-FEATURES_PROVIDED := $(filter-out periph_hwrng,$(FEATURES_PROVIDED))

--- a/boards/frdm-kw41z/Makefile.features
+++ b/boards/frdm-kw41z/Makefile.features
@@ -11,5 +11,3 @@ FEATURES_PROVIDED += periph_uart
 FEATURES_MCU_GROUP = cortex_m0_2
 
 include $(RIOTCPU)/kinetis/Makefile.features
-# Remove this line after TRNG driver is implemented
-FEATURES_PROVIDED := $(filter-out periph_hwrng,$(FEATURES_PROVIDED))

--- a/boards/phynode-kw41z/Makefile.features
+++ b/boards/phynode-kw41z/Makefile.features
@@ -11,6 +11,3 @@ FEATURES_PROVIDED += periph_uart
 FEATURES_MCU_GROUP = cortex_m0_2
 
 include $(RIOTCPU)/kinetis/Makefile.features
-#
-# Remove this line after TRNG driver is implemented
-FEATURES_PROVIDED := $(filter-out periph_hwrng,$(FEATURES_PROVIDED))

--- a/boards/teensy31/Makefile.features
+++ b/boards/teensy31/Makefile.features
@@ -9,5 +9,3 @@ FEATURES_PROVIDED += periph_uart
 FEATURES_MCU_GROUP = cortex_m4_2
 
 include $(RIOTCPU)/kinetis/Makefile.features
-# No HWRNG in MK20D7 devices
-FEATURES_PROVIDED := $(filter-out periph_hwrng,$(FEATURES_PROVIDED))

--- a/boards/usb-kw41z/Makefile.features
+++ b/boards/usb-kw41z/Makefile.features
@@ -11,5 +11,3 @@ FEATURES_PROVIDED += periph_uart
 FEATURES_MCU_GROUP = cortex_m0_2
 
 include $(RIOTCPU)/kinetis/Makefile.features
-# Remove this line after TRNG driver is implemented
-FEATURES_PROVIDED := $(filter-out periph_hwrng,$(FEATURES_PROVIDED))

--- a/cpu/kinetis/Makefile.features
+++ b/cpu/kinetis/Makefile.features
@@ -1,5 +1,18 @@
 FEATURES_PROVIDED += periph_cpuid
-FEATURES_PROVIDED += periph_hwrng
+
+# HACK Do not define 'hwrng' if the board does not supports it
+# A whitelist on CPU_MODEL would be better but this information/variable is not
+# available yet.
+# HWRNG uses the wrong hwrng register for the frdm-k64f board/cpu_model
+_KINETIS_BOARDS_WITHOUT_HWRNG += frdm-k64f
+# TRNG driver is not implemented for 'CPU_MODEL == mkw41z512vht4'
+_KINETIS_BOARDS_WITHOUT_HWRNG += frdm-kw41z phynode-kw41z usb-kw41z
+# No HWRNG in MK20D7 devices
+_KINETIS_BOARDS_WITHOUT_HWRNG += teensy31
+ifneq (,$(filter-out $(_KINETIS_BOARDS_WITHOUT_HWRNG),$(BOARD)))
+  FEATURES_PROVIDED += periph_hwrng
+endif
+
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_gpio_irq
 ifeq (EA,$(KINETIS_SERIES))


### PR DESCRIPTION
### Contribution description

This removes doing `filter-out periph_hwrng, $(FEATURES_PROVIDED)`
after processing `cpu/$(CPU)/Makefile.features`.
The current solution is a HACK as `CPU_MODEL` is currently not available
at that moment but will be in the near future.

It will allow always including `cpu/$(CPU)/Makefile.features` after
`boards/$(BOARD)/Makefile.features`.

It is a part of moving `CPU/CPU_MODEL` definitions to `Makefile.features`.

### Testing procedure

For all the modified boards, the provided features are the same as in `master`.
I only checked `examples/hello-world` as it should not change anything for these ones.

```
for board in frdm-k64f frdm-kw41z phynode-kw41z teensy31 usb-kw41z; do echo ${board}; BOARD=${board} make --no-print-directory -C examples/hello-world info-debug-variable-FEATURES_PROVIDED; done
frdm-k64f
periph_adc periph_i2c periph_pwm periph_rtc periph_rtt periph_spi periph_timer periph_uart periph_cpuid periph_gpio periph_gpio_irq periph_mcg periph_pm cpp
frdm-kw41z
periph_adc periph_i2c periph_rtc periph_rtt periph_spi periph_timer periph_uart periph_cpuid periph_gpio periph_gpio_irq periph_mcg periph_pm cpp
phynode-kw41z
periph_adc periph_i2c periph_rtc periph_rtt periph_spi periph_timer periph_uart periph_cpuid periph_gpio periph_gpio_irq periph_mcg periph_pm cpp
teensy31
periph_pwm periph_rtc periph_rtt periph_timer periph_uart periph_cpuid periph_gpio periph_gpio_irq periph_mcg periph_pm cpp
usb-kw41z
periph_adc periph_i2c periph_rtc periph_rtt periph_spi periph_timer periph_uart periph_cpuid periph_gpio periph_gpio_irq periph_mcg periph_pm cpp
```

I also looked at all boards to verify they did not change but did not post the output.


### Issues/PRs references

Required to apply https://github.com/RIOT-OS/RIOT/pull/11478
Split out of https://github.com/RIOT-OS/RIOT/pull/11477
