### PR TITLE
Makefile.features: add a common file for the features parsing

### DIFF
--- a/Makefile.features
+++ b/Makefile.features
@@ -1,0 +1,3 @@
+# Process FEATURES variables
+
+include $(RIOTBOARD)/$(BOARD)/Makefile.features

--- a/Makefile.include
+++ b/Makefile.include
@@ -245,7 +245,7 @@ export PREFIX ?= $(if $(TARGET_ARCH),$(TARGET_ARCH)-)
 INCLUDES += -I$(RIOTBASE)/core/include -I$(RIOTBASE)/drivers/include -I$(RIOTBASE)/sys/include
 
 # process provided features
-include $(RIOTBOARD)/$(BOARD)/Makefile.features
+include $(RIOTBASE)/Makefile.features
 
 # mandatory includes!
 include $(RIOTMAKE)/pseudomodules.inc.mk

--- a/makefiles/info-global.inc.mk
+++ b/makefiles/info-global.inc.mk
@@ -16,7 +16,9 @@ define board_missing_features
   FEATURES_OPTIONAL := $(FEATURES_OPTIONAL_GLOBAL)
   FEATURES_MISSING  :=
   FEATURES_PROVIDED :=
-  include $$(RIOTBOARD)/$(1)/Makefile.features
+
+  include $(RIOTBASE)/Makefile.features
+
   ifdef BUILDTEST_MCU_GROUP
     ifneq ($(BUILDTEST_MCU_GROUP), $$(FEATURES_MCU_GROUP))
       BOARDS_FEATURES_MISSING += "$(1) $(BUILDTEST_MCU_GROUP)"


### PR DESCRIPTION
### Contribution description

This will allow sharing it between Makefile.include and
makefiles/info-global.inc.mk.

Also some common variables definition can also be moved to here.

Part of moving CPU/CPU_MODEL definition to Makefile.features to have it
available before Makefile.include.

### Next steps

* Base the pull requests for migrating `CPU/CPU_MODEL` onto this one
* Move the definition of `FEATURES_MISSING/FEATURES_USED/FEATURES_OPTIONAL_USED/FEATURES_CONFLICTING` to this file instead of duplicating it


### Testing procedure

Features are still parsed, so any example with required features still list the same output like for example

```
make --no-print-directory -C tests/periph_hwrng/ info-boards-supported
acd52832 airfy-beacon arduino-due b-l072z-lrwan1 b-l475e-iot01a calliope-mini cc2538dk esp32-mh-et-live-minikit esp32-olimex-evb esp32-wemos-lolin-d32-pro esp32-wroom-32 esp32-wrover-kit esp8266-esp-12x esp8266-olimex-mod esp8266-sparkfun-thing f4vi1 firefly frdm-k22f microbit msbiot mulle native nrf51dk nrf51dongle nrf52832-mdk nrf52840-mdk nrf52840dk nrf52dk nrf6310 nucleo-f207zg nucleo-f410rb nucleo-f412zg nucleo-f413zh nucleo-f429zi nucleo-f722ze nucleo-f746zg nucleo-f767zi nucleo-l053r8 nucleo-l073rz nucleo-l432kc nucleo-l433rc nucleo-l452re nucleo-l476rg nucleo-l496zg openmote-b openmote-cc2538 pba-d-01-kw2x pic32-wifire pyboard reel remote-pa remote-reva remote-revb ruuvitag stm32f429i-disc1 stm32f4discovery stm32f769i-disco stm32l476g-disco thingy52 ublox-c030-u201 udoo yunjia-nrf51822
```


### Issues/PRs references


It is part of
* Makefile.features: prerequisites for moving CPU/CPU_MODEL to boards/Makefile.features #11478
*  Tracking: move CPU/CPU_MODEL to Makefile.features #11477 