### PR TITLE
Added board support for ESP32 TTGO Lora V1 board

### DIFF
--- a/boards/esp32-ttgo-lora32-v1/Makefile
+++ b/boards/esp32-ttgo-lora32-v1/Makefile
@@ -1,0 +1,5 @@
+MODULE = board
+
+DIRS = $(RIOTBOARD)/common/esp32
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/esp32-ttgo-lora32-v1/Makefile.dep
+++ b/boards/esp32-ttgo-lora32-v1/Makefile.dep
@@ -1,0 +1,49 @@
+include $(RIOTBOARD)/common/esp32/Makefile.dep
+
+# default parameter definitions when module enc28j60 is used
+ifneq (, $(filter enc28j60, $(USEMODULE)))
+
+    # avoid multiple definitions when package depenedencies are resolved recursively
+    ifndef ENC28J60_PARAM_DEFINED
+        export ENC28J60_PARAM_DEFINED = 1
+
+        # default definitions
+        ENC28J60_PARAM_SPI   ?= SPI_DEV\(0\)
+        ENC28J60_PARAM_CS    ?= GPIO32
+        ENC28J60_PARAM_INT   ?= GPIO35
+        ENC28J60_PARAM_RESET ?= GPIO33
+        CFLAGS += -DENC28J60_PARAM_SPI=$(ENC28J60_PARAM_SPI)
+        CFLAGS += -DENC28J60_PARAM_CS=$(ENC28J60_PARAM_CS)
+        CFLAGS += -DENC28J60_PARAM_INT=$(ENC28J60_PARAM_INT)
+        CFLAGS += -DENC28J60_PARAM_RESET=$(ENC28J60_PARAM_RESET)
+
+        # to satisfy variable defintions in tests/driver_enc28j60/Makefile
+        ENC_SPI = $(ENC28J60_PARAM_SPI)
+        ENC_CS  = $(ENC28J60_PARAM_CS)
+        ENC_INT = $(ENC28J60_PARAM_INT)
+        ENC_RST = $(ENC28J60_PARAM_RESET)
+
+    endif
+endif
+
+# default parameter definitions when module mfr24j40 is used
+ifneq (, $(filter mrf24j40, $(USEMODULE)))
+
+    # avoid multiple definitions when package depenedencies are resolved recursively
+    ifndef MRF24J40_PARAM_DEFINED
+        export MRF24J40_PARAM_DEFINED = 1
+
+        # default definitions
+        MRF24J40_PARAM_SPI     = SPI_DEV\(0\)
+        MRF24J40_PARAM_SPI_CLK = SPI_CLK_1MHZ
+        MRF24J40_PARAM_CS     ?= GPIO16
+        MRF24J40_PARAM_INT    ?= GPIO34
+        MRF24J40_PARAM_RESET  ?= GPIO17
+        CFLAGS += -DMRF24J40_PARAM_SPI=$(MRF24J40_PARAM_SPI)
+        CFLAGS += -DMRF24J40_PARAM_SPI_CLK=$(MRF24J40_PARAM_SPI_CLK)
+        CFLAGS += -DMRF24J40_PARAM_CS=$(MRF24J40_PARAM_CS)
+        CFLAGS += -DMRF24J40_PARAM_INT=$(MRF24J40_PARAM_INT)
+        CFLAGS += -DMRF24J40_PARAM_RESET=$(MRF24J40_PARAM_RESET)
+
+    endif
+endif

--- a/boards/esp32-ttgo-lora32-v1/Makefile.features
+++ b/boards/esp32-ttgo-lora32-v1/Makefile.features
@@ -1,0 +1,11 @@
+# common board and CPU features
+include $(RIOTBOARD)/common/esp32/Makefile.features
+
+# additional features provided by the board
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_dac
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_spi
+
+FEATURES_PROVIDED += arduino

--- a/boards/esp32-ttgo-lora32-v1/Makefile.include
+++ b/boards/esp32-ttgo-lora32-v1/Makefile.include
@@ -1,0 +1,3 @@
+USEMODULE += boards_common_esp32
+
+include $(RIOTBOARD)/common/esp32/Makefile.include

--- a/boards/esp32-ttgo-lora32-v1/doc.txt
+++ b/boards/esp32-ttgo-lora32-v1/doc.txt
@@ -1,0 +1,173 @@
+/*
+ * Copyright (C) 2018 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    boards_esp32_wroom-32 Generic ESP32-WROOM-32 boards
+ * @ingroup     boards_esp32
+ * @brief       Support for generic ESP32-WROOM-32 boards
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+
+## <a name="toc"> Table of Contents </a>
+
+1. [Overview](#overview)
+2. [Hardware](#hardware)
+    1. [MCU](#mcu)
+    2. [Board Configuration](#board_configuration)
+    3. [Board Pinout](#pinout)
+    4. [Optional Hardware Configurations](#optional_hardware)
+3. [Flashing the Device](#flashing)
+
+## <a name="overview"> Overview </a> &nbsp;&nbsp; [[TOC](#toc)]
+
+This board definition covers not just a single board, but rather a large set of generic boards that use an ESP32-WROOM-32 module and simply break out all GPIOs to external pads without having any special hardware or interfaces on-board. Examples are Espressif's ESP32-DevKitC or NodeMCU-ESP32S and a large number of clones.
+
+\htmlonly<style>div.image img[src="https://docs.espressif.com/projects/esp-idf/en/latest/_images/esp32-devkitc-functional-overview1.jpg"]{width:600px;}</style>\endhtmlonly
+\image html "https://docs.espressif.com/projects/esp-idf/en/latest/_images/esp32-devkitc-functional-overview1.jpg" "Espressif ESP32-DevKitC V4"
+
+## <a name="hardware"> Hardware </a> &nbsp;&nbsp; [[TOC](#toc)]
+
+This section describes
+
+- the [MCU](#mcu),
+- the default [board configuration](#board_configuration),
+- [optional hardware configurations](#optional_hardware),
+- the [board pinout](#pinout).
+
+### <a name="mcu"> MCU </a> &nbsp;&nbsp; [[TOC](#toc)]
+
+Most features of ESP32 boards are provided by the ESP32 SoC. The following table summarizes these features and gives an overview of which of these features are supported by RIOT. For detailed information about the ESP32, see section \ref esp32_mcu "MCU ESP32".
+
+<center>
+MCU         | ESP32     | Supported by RIOT
+------------|-----------|------------------
+Vendor      | Espressif | |
+Cores       | 1 or 2 x Tensilica Xtensa LX6 | 1 core
+FPU         | yes (ULP - Ultra low power co-processor) | no
+RAM         | 520 kByte SRAM <br> 16 kByte  RTC SRAM | yes
+ROM         | 520 kByte | yes
+Flash       | 512 kByte ... 16 MByte |  yes
+Frequency   | 240 MHz, 160 MHz, 80 MHz | yes
+Power Consumption | 68 mA @ 240 MHz <br> 44 mA @ 160 MHz <br> 31 mA @ 80 MHz <br> 5 uA in deep sleep mode | yes <br> yes <br> yes <br> no
+Timers      | 4 x 64 bit | yes
+ADCs        | 2 x SAR-ADC with up to 18 x 12 bit channels total | yes
+DACs        | 2 x DAC with 8 bit | yes
+GPIOs       | 34 (6 of them are only inputs) | yes
+I2Cs        | 2 | yes
+SPIs        | 4 | yes
+UARTs       | 3 | yes
+WiFi        | IEEE 802.11 b/g/n built in | yes
+Bluetooth   | v4.2 BR/EDR and BLE | no
+Ethernet    | MAC interface with dedicated DMA and IEEE 1588 support | yes
+CAN         | version 2.0 | no
+IR          | up to 8 channels TX/RX | no
+Motor PWM   | 2 devices x 6 channels | yes
+LED PWM     | 16 channels | no
+Crypto      | Hardware acceleration of AES, SHA-2, RSA, ECC, RNG | no
+Vcc         | 2.5 - 3.6 V | |
+Documents   | [Datasheet](https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf) <br> [Technical Reference](https://www.espressif.com/sites/default/files/documentation/esp32_technical_reference_manual_en.pdf) | |
+</center>
+
+### <a name="board_configuration"> Board Configuration </a> &nbsp;&nbsp; [[TOC](#toc)]
+
+Generic ESP32-WROOM-32 boards do not have special hardware on board and all GPIOs are simply broken out for flexibility. Therefore, the board configuration is the most flexible one with provides:
+
+18 x ADC channels at maximum
+2 x DAC channels at maximum
+2 x SPI at maximum
+1 x I2C at maximum
+2 x UART
+
+Since all GPIOs have broken out, GPIOs can be used for different purposes in different applications. For flexibility, GPIOs can be listed in various peripheral configurations. For example, GPIO13 is used in the ADC channel definition and the definition of the MOSI signal of SPI_DEV(0).
+
+This is possible because GPIOs are only used for a specific peripheral interface when
+
+- the corresponding peripheral module is used, eg. periph_i2c, or
+- a corresponding init function is called z. adc_init, dac_init and pwm_init or
+- The corresponding peripheral interface is used for the first time, eg. spi_aqcuire.
+
+That is, the purpose for which a GPIO is used depends on which module or function is used first.
+
+For example, if module periph_i2c is not used, the GPIOs listed in I2C configuration can be used for the other purposes.
+
+The following table shows the default board configuration, which is sorted according to the defined functionality of GPIOs. This configuration can be overridden by \ref esp32_app_spec_conf "application-specific configurations".
+
+<center>
+\anchor esp32_wroom_32_table_board_configuration
+Function        | GPIOs  | Remarks |Configuration
+:---------------|:-------|:--------|:----------------------------------
+BUTTON0         | GPIO0  | | |
+ADC             | GPIO0, GPIO2, GPIO4, GPIO12, GPIO13, <br> GPIO14, GPIO15, GPIO25, GPIO26, GPIO27, <br> GPIO32, GPIO33, GPIO34, GPIO35, GPIO36, <br> GPIO39 | | see \ref esp32_adc_channels "ADC Channels"
+DAC             | GPIO25, GPIO26 | | \ref esp32_dac_channels "refer"
+PWM_DEV(0)      | GPIO0, GPIO2, GPIO4, GPIO16, GPIO17 | - | \ref esp32_pwm_channels "DAC Channels"
+PWM_DEV(1)      | GPIO27, GPIO32, GPIO33 | - | \ref esp32_pwm_channels "PWM Channels"
+I2C_DEV(0):SDA  | GPIO21 | | \ref esp32_i2c_interfaces "I2C Interfaces"
+I2C_DEV(0):SCL  | GPIO22 | | \ref esp32_i2c_interfaces "I2C Interfaces"
+SPI_DEV(0):CLK  | GPIO18 | VSPI is used | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(0):MISO | GPIO19 | VSPI is used | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(0):MOSI | GPIO23 | VSPI is used | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(0):CS0  | GPIO5  | VSPI is used | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(1):CLK  | GPIO14 | HSPI is used | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(1):MISO | GPIO12 | HSPI is used | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(1):MOSI | GPIO13 | HSPI is used | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(1):CS0  | GPIO15 | HSPI is used | \ref esp32_spi_interfaces "SPI Interfaces"
+UART_DEV(0):TxD | GPIO1  | Console (configuration is fixed) | \ref esp32_uart_interfaces "UART interfaces"
+UART_DEV(0):RxD | GPIO3  | Console (configuration is fixed) | \ref esp32_uart_interfaces "UART interfaces"
+UART_DEV(1):TxD | GPIO10 | not available in **qout** and **qio** flash mode | \ref esp32_uart_interfaces "UART interfaces"
+UART_DEV(1):RxD | GPIO9  | not available in **qout** and **qio** flash mode | \ref esp32_uart_interfaces "UART interfaces"
+</center>
+
+@note
+- The configuration of ADC channels contains all ESP32 GPIOs that can be used as ADC channels.
+- The configuration of DAC channels contains all ESP32 GPIOs that can be used as DAC channels.
+- GPIO9 and GIOP10 can only be used in **dout** and **dio** \ref esp32_flash_modes "flash modes".
+
+For detailed information about the configuration of ESP32 boards, see section \ref esp32_comm_periph "Common Peripherals".
+
+### <a name="optional_hardware"> Optional Hardware Configurations </a> &nbsp;&nbsp; [[TOC](#toc)]
+
+MRF24J40-based IEEE 802.15.4 radio modules and ENC28J60-based Ethernet network interface modules have been tested with the board. You could use the following code in your \ref esp32_app_spec_conf "application-specific configuration" to use such modules:
+
+```
+#ifdef BOARD_ESP32_WROOM-32
+
+#if MODULE_MRF24J40
+#define MRF24J40_PARAM_CS       GPIO16      /* MRF24J40 CS signal    */
+#define MRF24J40_PARAM_RESET    GPIO17      /* MRF24J40 RESET signal */
+#define MRF24J40_PARAM_INT      GPIO34      /* MRF24J40 INT signal   */
+#endif
+
+#if MODULE_ENC28J80
+#define ENC28J80_PARAM_CS       GPIO32      /* ENC28J80 CS signal    */
+#define ENC28J80_PARAM_RESET    GPIO33      /* ENC28J80 RESET signal */
+#define ENC28J80_PARAM_INT      GPIO35      /* ENC28J80 INT signal   */
+endif
+
+#endif
+```
+For other parameters, the default values defined by the drivers can be used.
+
+@note The **RESET** signal of MRF24J40 and ENC28J60 based modules can also be connected to the **RST** pin of the board (see \ref esp32_wroom_32_pinout "pinout") to keep the configured GPIO free for other purposes.
+
+### <a name="pinout"> Board Pinout </a> &nbsp;&nbsp; [[TOC](#toc)]
+
+The following figure shows the pinout of the defined default configuration for the EPS32-DevKitC board as an example of generic ESP32-WROOM-32 boards. The light green GPIOs are not used by configured on-board hardware components and can be used for any purpose. However, if optional off-board hardware modules are used, these GPIOs may also be occupied, see \ref esp32_wroom_32_table_board_configuration "optional functions" in table board configuration.
+
+The corresponding board schematics can be found her [here](https://dl.espressif.com/dl/schematics/esp32_devkitc_v4-sch-20180607a.pdf)
+
+\anchor esp32_wroom_32_pinout
+@image html "https://gitlab.com/gschorcht/RIOT.wiki-Images/raw/master/esp32/ESP32-WROOM-32_pinouts.png?inline=false" "EPS32-DevKitC V4 Pinout"
+
+## <a name="flashing"> Flashing the Device </a> &nbsp;&nbsp; [[TOC](#toc)]
+
+Flashing RIOT is quite easy. The board has a Micro-USB connector with reset/boot/flash logic. Just connect the board to your host computer and type using the programming port:
+```
+make flash BOARD=esp32-wroom-32 ...
+```
+For detailed information about ESP32 as well as configuring and compiling RIOT for ESP32 boards, see \ref esp32_riot.
+
+ */

--- a/boards/esp32-ttgo-lora32-v1/include/arduino_board.h
+++ b/boards/esp32-ttgo-lora32-v1/include/arduino_board.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C)  2018 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_esp32_wroom-32
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration for the Arduino API
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef ARDUINO_BOARD_H
+#define ARDUINO_BOARD_H
+
+#include "arduino_board_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   The on-board LED is on pin 2
+ */
+#define ARDUINO_LED         (2)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_BOARD_H */
+/** @} */

--- a/boards/esp32-ttgo-lora32-v1/include/arduino_pinmap.h
+++ b/boards/esp32-ttgo-lora32-v1/include/arduino_pinmap.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C)  2018 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_esp32_wroom-32
+ * @{
+ *
+ * @file
+ * @brief       Mapping from MCU pins to Arduino pins
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef ARDUINO_PINMAP_H
+#define ARDUINO_PINMAP_H
+
+#include "periph/gpio.h"
+#include "periph/adc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name   Mapping of MCU pins to Arduino pins
+ * @{
+ */
+#define ARDUINO_PIN_0   GPIO3       /**< Arduino Uno pin 0 (RxD) */
+#define ARDUINO_PIN_1   GPIO1       /**< Arduino Uno pin 1 (TxD) */
+
+#define ARDUINO_PIN_2   GPIO12      /**< Arduino Uno pin 2 */
+#define ARDUINO_PIN_3   GPIO27      /**< Arduino Uno pin 3 (PWM) */
+#define ARDUINO_PIN_4   GPIO2       /**< Arduino Uno pin 4 */
+#define ARDUINO_PIN_5   GPIO32      /**< Arduino Uno pin 5 (PWM) */
+#define ARDUINO_PIN_6   GPIO33      /**< Arduino Uno pin 6 (PWM) */
+#define ARDUINO_PIN_7   GPIO13      /**< Arduino Uno pin 7 */
+#define ARDUINO_PIN_8   GPIO14      /**< Arduino Uno pin 8 */
+#define ARDUINO_PIN_9   GPIO0       /**< Arduino Uno pin 9 (PWM) */
+
+#define ARDUINO_PIN_10  GPIO5       /**< Arduino Uno pin 10 (CS0 / PWM)  */
+#define ARDUINO_PIN_11  GPIO23      /**< Arduino Uno pin 11 (MOSI / PWM) */
+#define ARDUINO_PIN_12  GPIO19      /**< Arduino Uno pin 12 (MISO) */
+#define ARDUINO_PIN_13  GPIO18      /**< Arduino Uno pin 13 (SCK)  */
+
+#define ARDUINO_PIN_A0  GPIO25      /**< Arduino Uno pin A0 */
+#define ARDUINO_PIN_A1  GPIO26      /**< Arduino Uno pin A1 */
+#define ARDUINO_PIN_A2  GPIO4       /**< Arduino Uno pin A2 */
+#define ARDUINO_PIN_A3  GPIO15      /**< Arduino Uno pin A3 */
+
+#define ARDUINO_PIN_A4  GPIO21      /**< Arduino Uno pin A4 (SDA) */
+#define ARDUINO_PIN_A5  GPIO22      /**< Arduino Uno pin A5 (SCL) */
+/** @ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_PINMAP_H */
+/** @} */

--- a/boards/esp32-ttgo-lora32-v1/include/board.h
+++ b/boards/esp32-ttgo-lora32-v1/include/board.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2018 Gunar Schorcht
+ *
+ * Changed by FcGDAM (2018) for supporting the TTGO V1 ESP32 LORA OLED board
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_esp32_TTGO_LORA_V1
+ * @brief       Board specific definition for TTGO ESP32 LORA OLED V1 board
+ * @{
+ *
+ * For detailed information about the configuration of ESP32 boards, see
+ * section \ref esp32_comm_periph "Common Peripherals".
+ *
+ * @note
+ * Most definitions can be overridden by an \ref esp32_app_spec_conf
+ * "application-specific board configuration".
+ *
+ * @file
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+/* The TTGO ESP32 LORA board uses 26MHz crystal instead of 40Mhz */
+#define ESP32_XTAL_FREQ (26)
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+/**
+ * @name    Button pin definitions
+ * @{
+ */
+/**
+  * Generic ESP32 boards have a BOOT button, which can be used as normal button
+  * during normal operation. Since the GPIO0 pin is pulled up, the button
+  * signal is inverted, i.e., pressing the button will give a low signal.
+  */
+#define BUTTON0_PIN         GPIO0
+/** @} */
+
+/**
+ * @name    LED (on-board) configuration
+ *
+ * TTGO ESP32 board on-board LED.
+ * @{
+ */
+#define LED0_PIN GPIO2
+#define LED0_ACTIVE 1
+/** @} */
+
+/**
+ * @name   OLED (on-board) reset pin configuration
+ *
+ * TTGO SSD1306 OLED Reset pin
+ * @{
+ */
+#define OLED_RESET_PIN GPIO16
+/** @} */
+
+/**
+ * @name   OLED (on-board) I2C address
+ *
+ * TTGO SSD1306 OLED I2C address
+ * @{
+ */
+#define OLED_I2C_ADDR    0x3C
+/** @} */
+
+/**
+ * @name    sx1276 (on-board) pins
+ *
+ * TTGO V1 sx1276 Lora transceiver pins
+ * @{
+ */
+#define SX127X_PARAM_SPI_NSS    GPIO18
+#define SX127X_PARAM_SPI_RESET  GPIO14
+#define SX127X_PARAM_DIO0       GPIO26
+#define SX127X_PARAM_DIO1       GPIO33
+#define SX127X_PARAM_DIO2       GPIO32
+#define SX127X_PARAM_DIO3       GPIO_UNDEF
+/** @} */
+
+/* include common board definitions as last step */
+#include "board_common.h"
+
+#endif /* BOARD_H */
+/** @} */
+

--- a/boards/esp32-ttgo-lora32-v1/include/gpio_params.h
+++ b/boards/esp32-ttgo-lora32-v1/include/gpio_params.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2018 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+/**
+ * @ingroup     boards_esp32_wroom-32
+ * @brief       Board specific configuration of direct mapped GPIOs
+ * @file
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @{
+ */
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   LED and Button configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "BOOT",
+        .pin = BUTTON0_PIN,
+        .mode = GPIO_IN,
+        .flags = 0
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/esp32-ttgo-lora32-v1/include/periph_conf.h
+++ b/boards/esp32-ttgo-lora32-v1/include/periph_conf.h
@@ -1,0 +1,203 @@
+/*
+ * Copyright (C) 2018 Gunar Schorcht
+ *
+ * Modified by FCGDAM(2018) for supporting the TTGO V1 ESP32 LORA OLED board
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_esp32_TTGO_LORA_V1
+ * @brief       Peripheral MCU configuration for TTGO V1 LORA OLED board
+ * @{
+ *
+ * For detailed information about the configuration of ESP32 boards, see
+ * section \ref esp32_comm_periph "Common Peripherals".
+ *
+ * @note
+ * Most definitions can be overridden by an \ref esp32_app_spec_conf
+ * "application-specific board configuration".
+ *
+ * @file
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    ADC and DAC channel configuration
+ * @{
+ */
+/**
+ * @brief   Declaration of GPIOs that can be used as ADC channels
+ *
+ * For generic boards, all ADC pins that have broken out are declared as ADC
+ * channels.
+ *
+ * @note As long as the GPIOs listed in ADC_GPIOS are not initialized as ADC
+ * channels with the ```adc_init``` function, they can be used for other
+ * purposes.
+ */
+#ifndef ADC_GPIOS
+#define ADC_GPIOS   { GPIO36, GPIO37, GPIO38, GPIO39, GPIO32, GPIO33, GPIO34, GPIO35, \
+                      GPIO4,  GPIO0,  GPIO2,  GPIO15, GPIO13, GPIO12, GPIO14, GPIO25, GPIO26 }  
+#endif
+
+/**
+ * @brief   Declaration of GPIOs that can be used as DAC channels
+ *
+ * For generic boards the 2 DAC lines GPIO25 and GPIO26 are declared as
+ * DAC channels.
+ *
+ * @note As long as the GPIOs listed in DAC_GPIOS are not initialized as DAC
+ * channels with the ```dac_init``` function, they can be used for other
+ * purposes.
+ */
+#ifndef DAC_GPIOS
+#define DAC_GPIOS   { GPIO25 }
+#endif
+/** @} */
+
+/**
+ * @name   I2C configuration
+ *
+ * Only one I2C interface I2C_DEV(0) is defined for the TTGO board.
+ * The I2C Speed must be set to NORMAL, otherwise the display won't work
+ *
+ * The GPIOs listed in the configuration are only initialized as I2C signals
+ * when module ```perpih_i2c``` is used. Otherwise they are not allocated and
+ * can be used for other purposes.
+ *
+ * @{
+ */
+#ifndef I2C0_SPEED
+#define I2C0_SPEED  I2C_SPEED_NORMAL  /**< I2C bus speed of I2C_DEV(0) */
+#endif
+#ifndef I2C0_SCL
+#define I2C0_SCL    GPIO15            /**< SCL signal of I2C_DEV(0) [UEXT1] */
+#endif
+#ifndef I2C0_SDA
+#define I2C0_SDA    GPIO4             /**< SDA signal of I2C_DEV(0) [UEXT1] */
+#endif
+/** @} */
+
+/**
+ * @name   PWM channel configuration
+ *
+ * For generic boards, two PWM devices are configured. These devices
+ * contain all GPIOs that are not defined as I2C, SPI or UART for this board.
+ * Generally, all outputs pins could be used as PWM channels.
+ *
+ * @note As long as the according PWM device is not initialized with
+ * the ```pwm_init```, the GPIOs declared for this device can be used
+ * for other purposes.
+ *
+ * @{
+ */
+
+/**
+ * @brief Declaration of the channels for device PWM_DEV(0),
+ *        at maximum six channels.
+ */
+#ifndef PWM0_GPIOS
+#define PWM0_GPIOS  { GPIO0, GPIO17 }
+#endif
+
+/**
+ * @brief Declaration of the channels for device PWM_DEV(1),
+ *        at maximum six channels.
+ */
+#ifndef PWM1_GPIOS
+#define PWM1_GPIOS  { GPIO27  }
+#endif
+/** @} */
+
+/**
+ * @name    SPI configuration
+ *
+ * @note The GPIOs listed in the configuration are first initialized as SPI
+ * signals when the corresponding SPI interface is used for the first time
+ * by either calling the ```spi_init_cs``` function or the ```spi_acquire```
+ * function. That is, they are not allocated as SPI signals before and can
+ * be used for other purposes as long as the SPI interface is not used.
+ * @{
+ */
+#ifndef SPI0_CTRL
+#define SPI0_CTRL   VSPI    /**< VSPI is used as SPI_DEV(0) */
+#endif
+#ifndef SPI0_SCK
+#define SPI0_SCK    GPIO5   /**< VSPI SCK */
+#endif
+#ifndef SPI0_MISO
+#define SPI0_MISO   GPIO19  /**< VSPI MISO */
+#endif
+#ifndef SPI0_MOSI
+#define SPI0_MOSI   GPIO27  /**< VSPI MOSI */
+#endif
+#ifndef SPI0_CS0
+#define SPI0_CS0    GPIO18   /**< VSPI CS0 */
+#endif
+
+//#ifndef SPI1_DEV
+//#define SPI1_DEV    HSPI    /**< HSPI is used as SPI_DEV(1) */
+//#endif
+//#ifndef SPI1_SCK
+//#define SPI1_SCK    GPIO14  /**< HSPI SCK */
+//#endif
+//#ifndef SPI1_MISO
+//#define SPI1_MISO   GPIO12  /**< HSPI MISO */
+//#endif
+//#ifndef SPI1_MOSI
+//#define SPI1_MOSI   GPIO13  /**< HSPI MOSI */
+//#endif
+//#ifndef SPI1_CS0
+//#define SPI1_CS0    GPIO15  /**< HSPI CS0 */
+//#endif
+/** @} */
+
+/**
+ * @name   UART configuration
+ *
+ * ESP32 provides 3 UART interaces at maximum:
+ *
+ * UART_DEV(0) uses fixed standard configuration.<br>
+ * UART_DEV(1) is defined here.<br>
+ * UART_DEV(2) is not used.<br>
+ *
+ * @{
+ */
+#define UART0_TXD   GPIO10 /**< direct I/O pin for UART_DEV(0) TxD, can't be changed */
+#define UART0_RXD   GPIO9  /**< direct I/O pin for UART_DEV(0) RxD, can't be changed */
+
+#if FLASH_MODE_DOUT || FLASH_MODE_DIO || DOXYGEN
+#ifndef UART1_TXD
+#define UART1_TXD   GPIO10  /**< direct I/O pin for UART_DEV(1) TxD */
+#endif
+#ifndef UART1_RXD
+#define UART1_RXD   GPIO9   /**< direct I/O pin for UART_DEV(1) RxD */
+#endif
+#else
+#warning Configuration problem: Flash mode is qio or qout, \
+         GPIO9 and GPIO10 are not available for UART1 as configured
+#endif
+/** @} */
+
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+/* include common peripheral definitions as last step */
+#include "periph_conf_common.h"
+
+#endif /* PERIPH_CONF_H */
+/** @} */


### PR DESCRIPTION
### Contribution description

The TTGO ESP32 Lora board is a ESP32 based board with onboard Lora transceiver and OLED.
This contribution adds support for this board, version 1 (there are two or more versions) by defining the required pins for communication with the SX127x Lora transceiver, the OLed I2C address and some other required configurations such the buttons and led GPIO.

### Testing procedure

With the board definition, the standard Lorawan example should work OOTB.
