### PR TITLE
nanocoap: Move application functionality to nanocoap sock

### DIFF
--- a/examples/nanocoap_server/coap_handler.c
+++ b/examples/nanocoap_server/coap_handler.c
@@ -11,7 +11,7 @@
 #include <string.h>
 
 #include "fmt.h"
-#include "net/nanocoap.h"
+#include "net/nanocoap_sock.h"
 #include "hashes/sha256.h"
 
 /* internal value that can be read/written via CoAP */

--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -26,9 +26,176 @@
 
 #include "net/nanocoap_sock.h"
 #include "net/sock/udp.h"
+#include "timex.h"
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"
+
+/**
+ * @name    Internally used CoAP packet types
+ * @{
+ */
+#define COAP_REQ                (0)
+#define COAP_RESP               (2)
+#define COAP_RST                (3)
+/** @} */
+
+ssize_t coap_handle_req(coap_pkt_t *pkt, uint8_t *resp_buf, unsigned resp_buf_len)
+{
+    if (coap_get_code_class(pkt) != COAP_REQ) {
+        DEBUG("coap_handle_req(): not a request.\n");
+        return -EBADMSG;
+    }
+
+    if (pkt->hdr->code == 0) {
+        return coap_build_reply(pkt, COAP_CODE_EMPTY, resp_buf, resp_buf_len, 0);
+    }
+    return coap_tree_handler(pkt, resp_buf, resp_buf_len, coap_resources,
+                             coap_resources_numof);
+}
+
+ssize_t coap_tree_handler(coap_pkt_t *pkt, uint8_t *resp_buf,
+                          unsigned resp_buf_len,
+                          const coap_resource_t *resources,
+                          size_t resources_numof)
+{
+    coap_method_flags_t method_flag = coap_method2flag(coap_get_code_detail(pkt));
+
+    uint8_t uri[NANOCOAP_URI_MAX];
+    if (coap_get_uri_path(pkt, uri) <= 0) {
+        return -EBADMSG;
+    }
+    DEBUG("nanocoap: URI path: \"%s\"\n", uri);
+
+    for (unsigned i = 0; i < resources_numof; i++) {
+        const coap_resource_t *resource = &resources[i];
+        if (!(resource->methods & method_flag)) {
+            continue;
+        }
+
+        int res = coap_match_path(resource, uri);
+        if (res > 0) {
+            continue;
+        }
+        else if (res < 0) {
+            break;
+        }
+        else {
+            return resource->handler(pkt, resp_buf, resp_buf_len, resource->context);
+        }
+    }
+
+    return coap_build_reply(pkt, COAP_CODE_404, resp_buf, resp_buf_len, 0);
+}
+
+ssize_t coap_reply_simple(coap_pkt_t *pkt,
+                          unsigned code,
+                          uint8_t *buf, size_t len,
+                          unsigned ct,
+                          const uint8_t *payload, uint8_t payload_len)
+{
+    uint8_t *payload_start = buf + coap_get_total_hdr_len(pkt);
+    uint8_t *bufpos = payload_start;
+
+    if (payload_len) {
+        bufpos += coap_put_option_ct(bufpos, 0, ct);
+        *bufpos++ = 0xff;
+    }
+
+    ssize_t res = coap_build_reply(pkt, code, buf, len,
+                                   bufpos - payload_start + payload_len);
+
+    if (payload_len && (res > 0)) {
+        assert(payload);
+        memcpy(bufpos, payload, payload_len);
+    }
+
+    return res;
+}
+
+ssize_t coap_build_reply(coap_pkt_t *pkt, unsigned code,
+                         uint8_t *rbuf, unsigned rlen, unsigned payload_len)
+{
+    unsigned tkl = coap_get_token_len(pkt);
+    unsigned len = sizeof(coap_hdr_t) + tkl;
+
+    if ((len + payload_len) > rlen) {
+        return -ENOSPC;
+    }
+
+    /* if code is COAP_CODE_EMPTY (zero), assume Reset (RST) type */
+    unsigned type = COAP_TYPE_RST;
+    if (code) {
+        if (coap_get_type(pkt) == COAP_TYPE_CON) {
+            type = COAP_TYPE_ACK;
+        }
+        else {
+            type = COAP_TYPE_NON;
+        }
+    }
+
+    coap_build_hdr((coap_hdr_t *)rbuf, type, pkt->token, tkl, code,
+                   ntohs(pkt->hdr->id));
+    coap_hdr_set_type((coap_hdr_t *)rbuf, type);
+    coap_hdr_set_code((coap_hdr_t *)rbuf, code);
+
+    len += payload_len;
+
+    return len;
+}
+
+ssize_t coap_block2_build_reply(coap_pkt_t *pkt, unsigned code,
+                                uint8_t *rbuf, unsigned rlen, unsigned payload_len,
+                                coap_block_slicer_t *slicer)
+{
+    /* Check if the generated data filled the requested block */
+    if (slicer->cur < slicer->start) {
+        return coap_build_reply(pkt, COAP_CODE_BAD_OPTION, rbuf, rlen, 0);
+    }
+    coap_block2_finish(slicer);
+    return coap_build_reply(pkt, code, rbuf, rlen, payload_len);
+}
+
+size_t coap_blockwise_put_char(coap_block_slicer_t *slicer, uint8_t *bufpos, char c)
+{
+    /* Only copy the char if it is within the window */
+    if ((slicer->start <= slicer->cur) && (slicer->cur < slicer->end)) {
+        *bufpos = c;
+        slicer->cur++;
+        return 1;
+    }
+    slicer->cur++;
+    return 0;
+}
+
+ssize_t coap_well_known_core_default_handler(coap_pkt_t *pkt, uint8_t *buf, \
+                                             size_t len, void *context)
+{
+    (void)context;
+    coap_block_slicer_t slicer;
+    coap_block2_init(pkt, &slicer);
+    uint8_t *payload = buf + coap_get_total_hdr_len(pkt);
+    uint8_t *bufpos = payload;
+    bufpos += coap_put_option_ct(bufpos, 0, COAP_FORMAT_LINK);
+    bufpos += coap_opt_put_block2(bufpos, COAP_OPT_CONTENT_FORMAT, &slicer, 1);
+
+    *bufpos++ = 0xff;
+
+    for (unsigned i = 0; i < coap_resources_numof; i++) {
+        if (i) {
+            bufpos += coap_blockwise_put_char(&slicer, bufpos, ',');
+        }
+        bufpos += coap_blockwise_put_char(&slicer, bufpos, '<');
+        unsigned url_len = strlen(coap_resources[i].path);
+        bufpos += coap_blockwise_put_bytes(&slicer, bufpos,
+                (uint8_t*)coap_resources[i].path, url_len);
+        bufpos += coap_blockwise_put_char(&slicer, bufpos, '>');
+    }
+
+    unsigned payload_len = bufpos - payload;
+    return coap_block2_build_reply(pkt, COAP_CODE_205, buf, len, payload_len,
+                                   &slicer);
+}
 
 ssize_t nanocoap_request(coap_pkt_t *pkt, sock_udp_ep_t *local, sock_udp_ep_t *remote, size_t len)
 {

--- a/tests/nanocoap_cli/request_handlers.c
+++ b/tests/nanocoap_cli/request_handlers.c
@@ -24,7 +24,7 @@
 #include <string.h>
 
 #include "fmt.h"
-#include "net/nanocoap.h"
+#include "net/nanocoap_sock.h"
 
 #define _MAX_PAYLOAD_LEN  (16)
 

--- a/tests/unittests/tests-nanocoap/Makefile.include
+++ b/tests/unittests/tests-nanocoap/Makefile.include
@@ -1,1 +1,4 @@
 USEMODULE += nanocoap
+USEMODULE += nanocoap_sock
+USEMODULE += gnrc_sock_udp
+USEMODULE += gnrc_ipv6_default

--- a/tests/unittests/tests-nanocoap/tests-nanocoap.c
+++ b/tests/unittests/tests-nanocoap/tests-nanocoap.c
@@ -19,7 +19,7 @@
 
 #include "embUnit.h"
 
-#include "net/nanocoap.h"
+#include "net/nanocoap_sock.h"
 
 #include "unittests-constants.h"
 #include "tests-nanocoap.h"


### PR DESCRIPTION
### Contribution description
#11098 added the ability for a single (nano|g)coap resource to respond to a subtree of request URIs. Open PR #11436 additionally will provide a mechanism to lookup into a nested set of resources to handle requests within that subtree. This mechanism includes a new function and a subtree handler struct in the base nanocoap library. However, gcoap already has the ability to specify multiple sets of handlers via its listener mechanism.

The location of the additional capability for 11436 in the base nanocoap library means gcoap must evaluate whether or how to incorporate the new nanocoap subtree handlers. In this case, the new mechanism is not required. This conflict illustrates how "nanocoap" really is a combination of two tools:

* a base CoAP library, useful for any application level tool like gcoap
* an application level tool itself

nanocoap as an application already includes the [nanocoap sock](http://doc.riot-os.org/group__net__nanosock.html) module for high level functions to send and receive a message. So, this PR extends the split of these two roles by moving more application level functionality to the nanocoap sock module. Specifically, this includes these methods and structs:

* coap_build_reply()
* coap_block2_build_reply()
* coap_handle_req()
* coap_tree_handler()
* coap_reply_simple()
* coap_well_known_core_default_handler()
* coap_resources[]
* coap_resources_numof

With this change, nanocoap sock independently can add the subtree handler functionality in 11436. This relocation allows nanocoap to innovate without causing a conflict with gcoap. At the same time, if this new mechanism develops into a generally worthwhile feature, it can be migrated to the base nanocoap library in the future.

### Testing procedure
No new functionality, so ensure nothing is broken:

* nanocoap unit tests
* nanocoap_cli test 
* nanocoap_server example

### Issues/PRs references
See description.
