### PR TITLE
make.dep: fix dependencies for the arduino module

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -582,6 +582,8 @@ endif
 
 ifneq (,$(filter arduino,$(USEMODULE)))
   FEATURES_REQUIRED += arduino
+  FEATURES_REQUIRED += periph_adc
+  FEATURES_REQUIRED += periph_gpio
   USEMODULE += xtimer
 endif
 


### PR DESCRIPTION
### Contribution description
The Arduino mapping (`sys/arduino`) dependes on the `periph/gpio` and the `periph/adc` drivers. But this dependency is so far not declared in `Makefile.dep`. This PR should take care of this.

### Testing procedure
Add a `analogRead(1)` call anywhere into the setup or loop function in  `examples/arduino_hello-world/hello-world.sketch`. Without this PR, the example does not link anymore (due to the missing `periph_adc` module). With this PR, it should compile just fine.

### Issues/PRs references
see `[riot-users] Arduino-due undefined reference` by Afif on users mailing list
