### PR TITLE
pkg/pkg.mk: Avoid doing a git fetch if we already have the commit.

### DIFF
--- a/pkg/pkg.mk
+++ b/pkg/pkg.mk
@@ -32,7 +32,7 @@ endif
 git-ensure-version: $(PKG_BUILDDIR)/.git-downloaded
 	if [ $(shell git -C $(PKG_BUILDDIR) rev-parse HEAD) != $(PKG_VERSION) ] ; then \
 		git -C $(PKG_BUILDDIR) clean -xdff ; \
-		if git cat-file -e -t '$(PKG_VERSION)^{commit}' ; then \
+		if ! git -C $(PKG_BUILDDIR) cat-file -e '$(PKG_VERSION)^{commit}' ; then \
 			git -C $(PKG_BUILDDIR) fetch "$(PKG_URL)" "$(PKG_VERSION)" ; \
 		fi; \
 		git -C $(PKG_BUILDDIR) checkout -f $(PKG_VERSION) ; \

--- a/pkg/pkg.mk
+++ b/pkg/pkg.mk
@@ -32,7 +32,9 @@ endif
 git-ensure-version: $(PKG_BUILDDIR)/.git-downloaded
 	if [ $(shell git -C $(PKG_BUILDDIR) rev-parse HEAD) != $(PKG_VERSION) ] ; then \
 		git -C $(PKG_BUILDDIR) clean -xdff ; \
-		git -C $(PKG_BUILDDIR) fetch "$(PKG_URL)" "$(PKG_VERSION)" ; \
+		if git cat-file -e -t '$(PKG_VERSION)^{commit}' ; then \
+			git -C $(PKG_BUILDDIR) fetch "$(PKG_URL)" "$(PKG_VERSION)" ; \
+		fi; \
 		git -C $(PKG_BUILDDIR) checkout -f $(PKG_VERSION) ; \
 		touch $(PKG_BUILDDIR)/.git-downloaded ; \
 	fi


### PR DESCRIPTION
### Contribution description

D'oh! I screwed up a little in #11129 and a git fetch was being done for each package every time the user ran make.

If the commit is already in the local repo, we should not need to do any network operation.

### Testing procedure

Type `make` twice in any example that uses packages. See how it is fetched twice. With this patch it is not.

### Issues/PRs references

Bug introduced in #11129.
