### PR TITLE
tests/xtimer_usleep: fail with negative offsets

### DIFF
--- a/tests/xtimer_usleep/README.md
+++ b/tests/xtimer_usleep/README.md
@@ -84,3 +84,20 @@ Invalid timeout 1464 ,expected 1172 < 1234 < 1295
 Host max error  61
 error           291
 ```
+
+Test also fails with negative offset as xtimer_usleep must sleep for at least
+the expected time.
+
+```
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Connect to serial port /dev/ttyACM0
+Welcome to pyterm!
+Type '/exit' to exit.
+XXXX-XX-XX XX:XX:XX,XXX - INFO # main(): This is RIOT! (XXX)
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Running test 5 times with 7 distinct sleep times
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Please hit any key and then ENTER to continue
+a
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 9979 us (expected: 10000 us) Offset: -21 us
+Invalid timeout 9979 ,expected 10000 < 10500
+Host max error  500
+error           -21
+```

--- a/tests/xtimer_usleep/tests/01-run.py
+++ b/tests/xtimer_usleep/tests/01-run.py
@@ -33,17 +33,17 @@ def testfunc(child):
         start_test = time.time()
         for m in range(RUNS):
             for n in range(SLEEP_TIMES_NUMOF):
-                child.expect(u"Slept for (\\d+) us \\(expected: (\\d+) us\\) Offset: (\\d+) us")
+                child.expect(u"Slept for (\\d+) us \\(expected: (\\d+) us\\) Offset: (-?\\d+) us")
                 sleep_time = int(child.match.group(1))
                 exp = int(child.match.group(2))
-                lower_bound = exp - (exp * INTERNAL_JITTER)
                 upper_bound = exp + (exp * INTERNAL_JITTER)
-                if not (lower_bound < sleep_time < upper_bound):
-                    delta = (upper_bound-lower_bound)/2
-                    raise InvalidTimeout("Invalid timeout %d ,expected %d < %d < %d"
+                if not (exp < sleep_time < upper_bound):
+                    delta = (upper_bound-exp)
+                    error = min(upper_bound-sleep_time, sleep_time-exp)
+                    raise InvalidTimeout("Invalid timeout %d, expected %d < timeout < %d"
                                          "\nHost max error\t%d\nerror\t\t%d" %
-                                         (sleep_time, lower_bound, exp, upper_bound,
-                                          delta, sleep_time-lower_bound))
+                                         (sleep_time, exp, upper_bound,
+                                          delta, error))
         testtime = (time.time() - start_test) * US_PER_SEC
         child.expect(u"Test ran for (\\d+) us")
         exp = int(child.match.group(1))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR modifies xtimer_usleep automated test to recognize negative offset with respect to target sleep time.

When reviewing #11044 I realized tests/xtimer_usleep ~wasn't passing because the python script was not recognizing negative integers as acceptable values for the timer offset, this is done now.~ was failing because of a pexpect timeout and not because of negative offsets (sleeping less than the specified time).

### Testing procedure

With frdm-kw41z or usb-kw41z (or any board witch would produce negative offset with respect to the target usleep time)

`→ make -C tests/xtimer_usleep BOARD=usb-kw41z flash test
`

~Failed without this PR, succeeds with it.~ Failes correctly with this PR


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
