### PR TITLE
examples/openthread: document libtool dependency

### DIFF
--- a/examples/openthread/README.md
+++ b/examples/openthread/README.md
@@ -13,6 +13,9 @@ You can either build a FTD or MTD firmware:
        An MTD may or may not be sleepy.
 - FTD: A Full Thread Device has router functionality compiled in.
 
+## Dependencies
+- You need to have `libtool` installed to be able to build this example.
+
 ## Quick usage
 
 With RIOT port, a node is auto-setup and ready to communicate with


### PR DESCRIPTION
### Contribution description
I didn't have `libtool` installed and got the following error while trying to compile `examples/openthread`:

```
cd /Users/lonk/code/riot/examples/openthread/bin/pkg/samr21-xpro/openthread && PREFIX="/" ./bootstrap
/Users/lonk/code/riot/examples/openthread/bin/pkg/samr21-xpro/openthread/third_party/nlbuild-autotools/repo/scripts/bootstrap: line 280: --automake: command not found
cd /Users/lonk/code/riot/examples/openthread/bin/pkg/samr21-xpro/openthread && CPP="arm-none-eabi-gcc -E" CC="arm-none-eabi-gcc" CXX="arm-none-eabi-g++"\
		OBJC="" OBJCXX="" AR="arm-none-eabi-ar" RANLIB="arm-none-eabi-ranlib" NM="arm-none-eabi-nm" \
		STRIP="" \
		CPPFLAGS="-fdata-sections -ffunction-sections -Os -Wno-implicit-fallthrough -Wno-unused-parameter -mcpu=cortex-m0plus -mlittle-endian -mthumb -mfloat-abi=soft -march=armv6s-m -DOPENTHREAD_PROJECT_CORE_CONFIG_FILE='\"platform_config.h\"'" \
		CFLAGS="-fdata-sections -ffunction-sections -Os -Wno-implicit-fallthrough -Wno-unused-parameter -mcpu=cortex-m0plus -mlittle-endian -mthumb -mfloat-abi=soft -march=armv6s-m " \
		CXXFLAGS="-fdata-sections -ffunction-sections -Os -Wno-implicit-fallthrough -Wno-unused-parameter -mcpu=cortex-m0plus -mlittle-endian -mthumb -mfloat-abi=soft -march=armv6s-m -fno-exceptions -fno-rtti " \
		LDFLAGS="-fdata-sections -ffunction-sections -Os -Wno-implicit-fallthrough -Wno-unused-parameter -mcpu=cortex-m0plus -mlittle-endian -mthumb -mfloat-abi=soft -march=armv6s-m -nostartfiles -specs=nano.specs \
		-specs=nosys.specs -Wl,--gc-sections -Wl,-Map=map.map " \
		./configure --disable-docs --host=arm-none-eabi --target=arm-none-eabi \
		--prefix=/ --enable-default-logging --enable-cli-app=ftd --enable-application-coap
/bin/sh: ./configure: No such file or directory
make[1]: *** [all] Error 127
make: *** [pkg-build-openthread] Error 2
```

this PR adds a note for future users.

### Testing procedure
uninstall libtools, try compiling examples/openthread, see if the error mentioned above pops up?

### Issues/PRs references
--