### PR TITLE
makefiles/blobs: Add rules for binary blob embedding. 

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -377,6 +377,8 @@ USEMODULE_INCLUDES_ = $(strip $(call uniq,$(USEMODULE_INCLUDES)))
 
 INCLUDES += $(USEMODULE_INCLUDES_:%=-I%)
 
+# include blob support
+include $(RIOTMAKE)/blobs.inc.mk
 
 # include bindist target
 include $(RIOTMAKE)/bindist.inc.mk

--- a/examples/lua_REPL/Makefile
+++ b/examples/lua_REPL/Makefile
@@ -51,28 +51,10 @@ CFLAGS += -DTHREAD_STACKSIZE_MAIN='(THREAD_STACKSIZE_DEFAULT+7000)'
 
 USEPKG += lua
 
-LUA_PATH = $(BINDIR)/lua
-
-# add directory of generated *.lua.h files to include path
-CFLAGS += -I$(LUA_PATH)
-
-# generate .lua.h header files of .lua files
-LUA = $(wildcard *.lua)
-
-LUA_H = $(LUA:%.lua=$(LUA_PATH)/%.lua.h)
-
-BUILDDEPS += $(LUA_H) $(LUA_PATH)/
+# generate .lua.o files of .lua files
+BLOBS = $(wildcard *.lua)
 
 include $(RIOTBASE)/Makefile.include
 
-# The code below generates a header file from any .lua scripts in the
-# example directory. The header file contains a byte array of the
-# ASCII characters in the .lua script.
-
-$(LUA_PATH)/:
-	$(Q)mkdir -p $@
-
-# FIXME: This way of embedding lua code is not robust. A proper script will
-#        be included later.
-$(LUA_H): $(LUA_PATH)/%.lua.h: %.lua | $(LUA_PATH)/
-	$(Q)xxd -i $< | sed 's/^unsigned/const unsigned/g' > $@
+$(call blob_get_header,repl.lua): BLOB_DATATYPE = const uint8_t
+$(call blob_get_header,repl.lua): BLOB_HDR_INCLUDES = <stdint.h>

--- a/examples/lua_REPL/main.c
+++ b/examples/lua_REPL/main.c
@@ -35,7 +35,7 @@ static char lua_memory[MAIN_LUA_MEM_SIZE] __attribute__ ((aligned(__BIGGEST_ALIG
 #define BARE_MINIMUM_MODS (LUAR_LOAD_BASE | LUAR_LOAD_IO | LUAR_LOAD_CORO | LUAR_LOAD_PACKAGE)
 
 const struct lua_riot_builtin_lua _lua_riot_builtin_lua_table[] = {
-    { "repl", repl_lua, sizeof(repl_lua) }
+    { "repl", _binary_repl_lua_start, _binary_repl_lua_SIZE}
 };
 
 

--- a/examples/lua_basic/Makefile
+++ b/examples/lua_basic/Makefile
@@ -37,28 +37,10 @@ endif
 
 USEPKG += lua
 
-LUA_PATH = $(BINDIR)/lua
-
-# add directory of generated *.lua.h files to include path
-CFLAGS += -I$(LUA_PATH)
-
-# generate .lua.h header files of .lua files
-LUA = $(wildcard *.lua)
-
-LUA_H = $(LUA:%.lua=$(LUA_PATH)/%.lua.h)
-
-BUILDDEPS += $(LUA_H) $(LUA_PATH)/
+# generate .lua.o files of .lua files
+BLOBS = $(wildcard *.lua)
 
 include $(RIOTBASE)/Makefile.include
 
-# The code below generates a header file from any .lua scripts in the
-# example directory. The header file contains a byte array of the
-# ASCII characters in the .lua script.
-
-$(LUA_PATH)/:
-	$(Q)mkdir -p $@
-
-# FIXME: This way of embedding lua code is not robust. A proper script will
-#        be included later.
-$(LUA_H): $(LUA_PATH)/%.lua.h: %.lua | $(LUA_PATH)/
-	$(Q)xxd -i $< | sed 's/^unsigned/const unsigned/g' > $@
+$(call blob_get_header,main.lua): BLOB_DATATYPE = const uint8_t
+$(call blob_get_header,main.lua): BLOB_HDR_INCLUDES = <stdint.h>

--- a/examples/lua_basic/main.c
+++ b/examples/lua_basic/main.c
@@ -54,7 +54,7 @@ int lua_run_script(const uint8_t *buffer, size_t buffer_len)
 int main(void)
 {
     puts("Lua RIOT build");
-    lua_run_script(main_lua, main_lua_len);
+    lua_run_script(_binary_main_lua_start, _binary_main_lua_SIZE);
     puts("Lua interpreter exited");
 
     return 0;

--- a/makefiles/blobs.inc.mk
+++ b/makefiles/blobs.inc.mk
@@ -1,0 +1,154 @@
+#
+# ----------------------- Binary blob support ----------------------------
+#
+# Description
+#
+# This file allows applications to embed raw binary data into binaries. A
+# common use case is application resources, such as images, certificates, text
+# files, etc.
+#
+# Files are interpreted as binary and compiled into object files using `ld`.
+# For each blob, a header is created with declarations.
+#
+# Given a file "a.b", these rules will generate "$(BINDIR)/blobs/a.b.o" and a
+# header which you can include via `#include "a.b.h"`.
+# The header declares three (extern) variables:
+#
+# - start of blob data  (points to the first memory location containing the data)
+#   extern char _binary_a_b_start[];
+# - end of blob data (points to a memory location just after the end of the data)
+#   extern char _binary_a_b_end[];
+# - size of data (in terms of number of char, like what sizeof would return).
+#   size_t _binary_a_b_end; (this is actually a macro.)
+#
+# Usage
+#
+# Set the variable `BLOBS` to the files you wish to include as blobs. Access
+# blob data using the include as defined above.
+#
+# Inner workings
+#
+# Blob creation proceeds in two steps. First $(LD) is used to make an object
+# file from a binary. $(LD) is used because it is smarter about setting section
+# properties and does not require giving being explicit about the output format.
+#
+# By default `ld` places the output in section ".data". Normally one wants
+# blobs read-only so $(OBJCOPY) is used to rename ".data" to ".rodata". This
+# renaming is configurable (see next section.)
+#
+# Customization
+#
+# The functionality here can be customized either by globally changing variables
+# or on a per-file basis, by setting target specific variables. To this end,
+# two helper functions are available:
+#
+# - blob_get_header: given the name of a blob file, generate the name of the
+#                    corresponding h file.
+# - blob_get_obj: given the name of a blob file, generate the name of the
+#                 corresponding object file.
+#
+#
+# - BLOB_DATATYPE: in the headers, type for the arrays in the extern declaration.
+#                  Default is "const char".
+# - BLOB_HDR_INCLUDES: Extra headers to include in the blob header. E.g.
+#                  "<stddef.h> \"myheader.h\""
+# - LD_BLOBFLAGS: flags to pass to $(LD) to create a blob from a binary.
+# - BLOB_SECTION: Section where the blob should be placed (defaults to .rodata)
+# - OBJCOPY_RENAMEFLAGS: flags to pass to $(OBJCOPY) when renaming sections.
+#
+# Advanced usage
+#
+# For more advanced usage, it is recommended to override rules.
+#
+
+# ############## Make app depend on blobs ################################### #
+
+BLOB_PATH = $(BINDIR)/blobs
+BLOB_IPATH = $(BLOB_PATH)/include
+
+BLOBS_H = $(BLOBS:%=$(BLOB_IPATH)/%.h)
+BLOBS_O = $(BLOBS:%=$(BLOB_PATH)/%.o)
+
+blob_get_header = $(BLOB_IPATH)/$(1).h
+blob_get_obj = $(BLOB_PATH)/$(1).h
+
+CFLAGS += -I$(BLOB_IPATH)
+
+BUILDDEPS += $(BLOBS_H) $(BLOB_IPATH)/
+BASELIBS += $(BLOBS_O)
+
+# ################### Create include files ################################### #
+
+$(BLOB_PATH)/ $(BLOB_IPATH)/:
+	$(Q)mkdir -p $@
+
+blob_name_to_id = $(shell echo -n '$1' | tr -c "[:alnum:]" _)
+
+# Important: keep the empty space below the include, it generates a newline
+# after the include.
+define _blob_include
+	#include $1
+
+endef
+
+# Generate a header with extern declarations to access the blob contents.
+# Parameters:
+#	$1: blob_file_id
+#	$2: data_type
+#	$3: extra includes
+#	$4: blob size
+# Note: _binary_$1_size is an "absolute" symbol. Because of relocation in
+# virtual memory systems (i.e. native) this will not work in such systems.
+# instead, we will have to hardcode the blob size.
+define blob_header_template
+	/* *** Automatically generated, do not edit! *** */
+	#ifndef BLOB_$1
+	#define BLOB_$1
+
+$(foreach hdr,$(3),$(call _blob_include,$(hdr)))
+
+	extern $2 _binary_$1_start[];
+	extern $2 _binary_$1_end[];
+	/* Do NOT use this variable. Use _binary_$1_SIZE instead. */
+	extern char _binary_$1_size;
+
+	#if (BOARD == native)
+	static const size_t _binary_$1_SIZE = $4;
+	#else
+	#define _binary_$1_SIZE ((size_t)&_binary_$1_size)
+	#endif
+
+	#endif $(call blob_hdr_guard_name)
+	/* *** End auto-generated. ***/
+endef
+
+blob_size = $(shell wc -c <$1)
+
+blob_header = $(call blob_header_template,$(call blob_name_to_id,$1),$2,$3,$(call blob_size,$1))
+BLOB_DATATYPE ?= const char
+
+$(BLOBS_H): $(BLOB_IPATH)/%.h: % | $(BLOB_IPATH)/
+	$(file >$@,$(call blob_header,$*,$(BLOB_DATATYPE),<stddef.h> $(BLOB_HDR_INCLUDES)))
+
+# ################### Create blobs ########################################## #
+
+# -z noexecstack adds a .note.GNU_STACK to mark the stack as not executable.
+# AFAIK this only matters in native and its absence only causes the stack to
+# be marked executable in the final application binary (slight security issue).
+
+LD_BLOBFLAGS ?= -r -b binary -z noexecstack
+
+ifeq (native,$(BOARD))
+  LD_BLOBFLAGS += -m elf_i386
+endif
+
+BLOB_SECTION ?= .rodata,alloc,load,readonly,data,contents
+OBJCOPY_RENAMEFLAGS ?= --rename-section .data=$(BLOB_SECTION)
+
+.INTERMEDIATE: $(BLOBS:%=$(BLOB_PATH)/%.o.tmp)
+
+$(BLOBS:%=$(BLOB_PATH)/%.o.tmp): $(BLOB_PATH)/%.o.tmp: % | $(BLOB_PATH)/
+	$(Q)$(LD) $(LD_BLOBFLAGS) $< -o $@
+
+$(BLOBS_O): %: %.tmp
+	$(Q)$(OBJCOPY) $(OBJCOPY_RENAMEFLAGS) $< $@

--- a/makefiles/toolchain/gnu.inc.mk
+++ b/makefiles/toolchain/gnu.inc.mk
@@ -8,6 +8,7 @@ else
 export AR         = $(PREFIX)ar
 export RANLIB     = $(PREFIX)ranlib
 endif
+export LD         = $(PREFIX)ld
 export AS         = $(PREFIX)as
 export NM         = $(PREFIX)nm
 export LINK       = $(PREFIX)gcc

--- a/makefiles/toolchain/llvm.inc.mk
+++ b/makefiles/toolchain/llvm.inc.mk
@@ -12,7 +12,7 @@ export CCAS       ?= $(CC)
 export AS          = $(LLVMPREFIX)as
 export AR          = $(LLVMPREFIX)ar
 export NM          = $(LLVMPREFIX)nm
-export LD          = $(LLVMPREFIX)ld
+export LD          = $(PREFIX)ld
 # LLVM does have a linker, however, it is not entirely
 # compatible with GCC. For instance spec files as used in
 # `makefiles/libc/newlib.mk` are not supported. Therefore

--- a/makefiles/toolchain/llvm.inc.mk
+++ b/makefiles/toolchain/llvm.inc.mk
@@ -12,6 +12,7 @@ export CCAS       ?= $(CC)
 export AS          = $(LLVMPREFIX)as
 export AR          = $(LLVMPREFIX)ar
 export NM          = $(LLVMPREFIX)nm
+export LD          = $(LLVMPREFIX)ld
 # LLVM does have a linker, however, it is not entirely
 # compatible with GCC. For instance spec files as used in
 # `makefiles/libc/newlib.mk` are not supported. Therefore

--- a/makefiles/vars.inc.mk
+++ b/makefiles/vars.inc.mk
@@ -51,6 +51,7 @@ export CXXUWFLAGS            # (Patterns of) flags in CFLAGS that should not be 
 export CXXEXFLAGS            # Additional flags that should be passed to CXX.
 export CCASUWFLAGS           # (Patterns of) flags in CFLAGS that should not be passed to CCAS.
 export CCASEXFLAGS           # Additional flags that should be passed to CCAS.
+export LD                    # Linker (not used for linking the executable, see LINKER)
 export AR                    # The command to create the object file archives.
 export ARFLAGS               # Command-line options to pass to AR, default `rcs`.
 export AS                    # The assembler.


### PR DESCRIPTION
### Contribution description

This PR adds a new makefile module for embedding raw binary data intoexecutables. These is useful for including resources such as graphics (for UIs), certificates, crypto keys, scripts, etc.

Previously such a global rule did not exist and people had to resort to either provide a pre-generated C-file with an array or hand-craft a (header) file with xxd. The advantage of the new rules are:

- No additional tools required (uses only the toolchain's tools)
- Declared data types are easy to configure (no sed magic.)
- No arrays in headers.
- Output section is configurable (this makes it possible to include code, not only data.)

### Testing procedure

I migrated the two Lua examples to the new system. They should compile and run without problems.

### Issues/PRs references

Partial alternative to #9565.
See, for example, this file: https://github.com/RIOT-OS/RIOT/pull/10308/files#diff-09ce13303248a398e36e3febb371129a