### PR TITLE
openthread: fix compile error when CLI is not present

### DIFF
--- a/examples/openthread/Makefile
+++ b/examples/openthread/Makefile
@@ -13,18 +13,20 @@ RIOTBASE ?= $(CURDIR)/../..
 QUIET ?= 1
 
 USEPKG += openthread
+
+# FTD: A Full Thread Device has router functionality compiled in
+#
+# MTD: A Minimal Thread Device does not have router functionality
+# compiled in. As a result, it is not necessary to configure the
+# routerrole on an MTD. At the same time, an MTD may or may not be sleepy.
+#
+# Use FTD by default
 OPENTHREAD_TYPE ?= ftd
-ifeq ($(OPENTHREAD_TYPE),mtd)
-  # MTD: A Minimal Thread Device does not have router functionality
-  # compiled in. As a result, it is not necessary to configure the
-  # routerrole on an MTD. At the same time, an MTD may or may not be sleepy.
-  USEMODULE += openthread-mtd
-  USEMODULE += openthread-cli-mtd
-else
-  # ftd: A Full Thread Device has router functionality compiled in
-  USEMODULE += openthread-ftd
-  USEMODULE += openthread-cli-ftd
-endif
+
+USEMODULE += openthread-$(OPENTHREAD_TYPE)
+
+# Comment the following line in order to disable the OpenThread CLI
+USEMODULE += openthread-cli
 
 #Define PANID, CHANNEL and UART_BAUDRATE used by default
 OPENTHREAD_PANID ?= 0xbeef

--- a/pkg/openthread/Makefile
+++ b/pkg/openthread/Makefile
@@ -3,15 +3,22 @@ PKG_URL=https://github.com/openthread/openthread.git
 PKG_VERSION=thread-reference-20170716
 PKG_BUILDDIR ?= $(PKGDIRBASE)/$(PKG_NAME)
 
-ifneq (,$(filter openthread-cli-ftd,$(USEMODULE)))
+ifneq (,$(filter openthread-ftd,$(USEMODULE)))
+  TD = ftd
   $(info Compile OpenThread for FTD device)
-  OPENTHREAD_ARGS += --enable-cli-app=ftd
-endif
-ifneq (,$(filter openthread-cli-mtd,$(USEMODULE)))
+else ifneq (,$(filter openthread-mtd,$(USEMODULE)))
   $(info Compile OpenThread for MTD device)
-  OPENTHREAD_ARGS += --enable-cli-app=mtd --enable-joiner
+  TD = mtd
+  JOINER_ARG = --enable-joiner
+else
+  $(error "Please use either USEMODULE=openthread-ftd or USEMODULE=openthread-mtd")
 endif
-OPENTHREAD_ARGS += --enable-application-coap
+
+ifneq (,$(filter openthread-cli,$(USEMODULE)))
+  CLI_ARG = --enable-cli-app=$(TD)
+endif
+
+OPENTHREAD_ARGS += $(CLI_ARG) $(JOINER_ARG) --enable-application-coap
 CONFIG_FILE      = OPENTHREAD_PROJECT_CORE_CONFIG_FILE='\"platform_config.h\"'
 $(info $$OPENTHREAD_ARGS is [${OPENTHREAD_ARGS}])
 
@@ -35,13 +42,10 @@ all: git-download
 	cd $(PKG_BUILDDIR) &&  DESTDIR=$(PKG_BUILDDIR)/output PREFIX=/ make -j4 --no-print-directory install
 
 	cp $(PKG_BUILDDIR)/output/lib/libmbedcrypto.a ${BINDIR}/mbedcrypto.a
-ifneq (,$(filter openthread-cli-ftd,$(USEMODULE)))
-	cp $(PKG_BUILDDIR)/output/lib/libopenthread-ftd.a ${BINDIR}/openthread-ftd.a
-	cp $(PKG_BUILDDIR)/output/lib/libopenthread-cli-ftd.a ${BINDIR}/openthread-cli-ftd.a
-endif
-ifneq (,$(filter openthread-cli-mtd,$(USEMODULE)))
-	cp $(PKG_BUILDDIR)/output/lib/libopenthread-mtd.a ${BINDIR}/openthread-mtd.a
-	cp $(PKG_BUILDDIR)/output/lib/libopenthread-cli-mtd.a ${BINDIR}/openthread-cli-mtd.a
+
+	cp $(PKG_BUILDDIR)/output/lib/libopenthread-$(TD).a ${BINDIR}/openthread-$(TD).a
+ifneq (,$(filter openthread-cli,$(USEMODULE)))
+	cp $(PKG_BUILDDIR)/output/lib/libopenthread-cli-$(TD).a ${BINDIR}/openthread-cli.a
 endif
 
 include $(RIOTBASE)/pkg/pkg.mk


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR fixes compilation error when OpenThread CLI is not included (see #11498).

I separated the CLI and FTD/MTD variables so the whole logic is much simpler.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Compile and run OpenThread in FTD and MTD:
```
OPENTHREAD_TYPE=ftd make -C examples/openthread all flash term
```
and 
```
OPENTHREAD_TYPE=mtd make -C examples/openthread all flash term
```
Run `help` command in both instances. The MTD node should show less commands than the FTD

Then, comment the `USEMODULE=openthread-cli` line in `examples/openthread/Makefile`. Compile and run both FTD and MTD again. Now, the shell shouldn't be available (and after reset, you should see `Current panid: ...`)
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Fixes #11498 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
