### PR TITLE
cpu/saml21: set PL2 by default

### DIFF
--- a/cpu/saml21/cpu.c
+++ b/cpu/saml21/cpu.c
@@ -64,13 +64,14 @@ void cpu_init(void)
     OSCCTRL->OSC16MCTRL.bit.ONDEMAND = 0;
     OSCCTRL->OSC16MCTRL.bit.RUNSTDBY = 0;
 
+    PM->PLCFG.reg = PM_PLCFG_PLSEL_PL2;
+    while (!PM->INTFLAG.bit.PLRDY) {}
+
     /* Setup GCLK generators */
     _gclk_setup(0, GCLK_GENCTRL_GENEN | GCLK_GENCTRL_SRC_OSC16M);
     _gclk_setup(1, GCLK_GENCTRL_GENEN | GCLK_GENCTRL_SRC_OSCULP32K);
 
 #ifdef MODULE_PERIPH_PM
-    /* enable power managemet module */
-    MCLK->APBAMASK.reg |= MCLK_APBAMASK_PM;
     PM->CTRLA.reg = PM_CTRLA_MASK & (~PM_CTRLA_IORET);
 
     /* disable brownout detection


### PR DESCRIPTION
### Contribution description

This PR set SAML21 to use Performance level 2 since by default, all SAML21-based board are running at 16MHz. According to its [datasheet](http://ww1.microchip.com/downloads/en/DeviceDoc/60001477A.pdf), SAML21 must use PL2 when CPU clock is above 12MHz.
More details in Table 46-6. Maximum Peripheral Clock Frequencies

NVM Wait states can stay to its default value (0) as VDDIN is > 2.7 V

### Testing procedure

Run any test you want, SAML21/SAMR30 should be alive.


### Issues/PRs references
None.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
