### PR TITLE
cpu/cc2538: Add periph_uart_mode implementation

### DIFF
--- a/cpu/cc2538/Makefile.features
+++ b/cpu/cc2538/Makefile.features
@@ -1,5 +1,6 @@
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_hwrng
+FEATURES_PROVIDED += periph_uart_modecfg
 FEATURES_PROVIDED += puf_sram
 
 -include $(RIOTCPU)/cortexm_common/Makefile.features

--- a/cpu/cc2538/include/periph_cpu.h
+++ b/cpu/cc2538/include/periph_cpu.h
@@ -28,6 +28,7 @@
 
 #include "cpu.h"
 #include "vendor/hw_ssi.h"
+#include "vendor/hw_uart.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -166,6 +167,46 @@ typedef struct {
     gpio_t rts_pin;           /**< RTS pin - set to GPIO_UNDEF when not using */
 } uart_conf_t;
 /** @} */
+
+#ifndef DOXYGEN
+/**
+ * @brief   Override parity values
+ * @{
+ */
+#define HAVE_UART_PARITY_T
+typedef enum {
+   UART_PARITY_NONE = 0,                                                /**< no parity */
+   UART_PARITY_EVEN = (UART_LCRH_PEN | UART_LCRH_EPS),                  /**< even parity */
+   UART_PARITY_ODD = UART_LCRH_PEN,                                     /**< odd parity */
+   UART_PARITY_MARK = (UART_LCRH_PEN | UART_LCRH_SPS),                  /**< mark */
+   UART_PARITY_SPACE = (UART_LCRH_PEN | UART_LCRH_EPS | UART_LCRH_SPS)  /**< space */
+} uart_parity_t;
+/** @} */
+
+ /**
+ * @brief   Override data bits length values
+ * @{
+ */
+#define HAVE_UART_DATA_BITS_T
+typedef enum {
+    UART_DATA_BITS_5 = (0 << UART_LCRH_WLEN_S),     /**< 5 data bits */
+    UART_DATA_BITS_6 = (1 << UART_LCRH_WLEN_S),     /**< 6 data bits */
+    UART_DATA_BITS_7 = (2 << UART_LCRH_WLEN_S),     /**< 7 data bits */
+    UART_DATA_BITS_8 = (3 << UART_LCRH_WLEN_S),     /**< 8 data bits */
+} uart_data_bits_t;
+/** @} */
+
+/**
+ * @brief   Override stop bits length values
+ * @{
+ */
+#define HAVE_UART_STOP_BITS_T
+typedef enum {
+   UART_STOP_BITS_1 = 0,                  /**< 1 stop bit */
+   UART_STOP_BITS_2 = UART_LCRH_STP2,     /**< 2 stop bits */
+} uart_stop_bits_t;
+/** @} */
+#endif /* DOXYGEN */
 
 /**
  * @name   Override SPI mode settings

--- a/cpu/cc2538/periph/uart.c
+++ b/cpu/cc2538/periph/uart.c
@@ -157,6 +157,35 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
     return UART_OK;
 }
 
+#ifdef MODULE_PERIPH_UART_MODECFG
+int uart_mode(uart_t uart, uart_data_bits_t data_bits, uart_parity_t parity,
+              uart_stop_bits_t stop_bits)
+{
+    assert(uart < UART_NUMOF);
+
+    assert(data_bits == UART_DATA_BITS_5 ||
+           data_bits == UART_DATA_BITS_6 ||
+           data_bits == UART_DATA_BITS_7 ||
+           data_bits == UART_DATA_BITS_8);
+
+    assert(parity == UART_PARITY_NONE ||
+           parity == UART_PARITY_EVEN ||
+           parity == UART_PARITY_ODD ||
+           parity == UART_PARITY_MARK ||
+           parity == UART_PARITY_SPACE);
+
+    assert(stop_bits == UART_STOP_BITS_1 ||
+           stop_bits == UART_STOP_BITS_2);
+
+    cc2538_reg_t *lcrh = &(uart_config[uart].dev->cc2538_uart_lcrh.LCRH);
+    uint32_t tmp = *lcrh;
+    tmp &= ~(UART_LCRH_WLEN_M | UART_LCRH_FEN_M | UART_LCRH_STP2_M |
+             UART_LCRH_PEN | UART_LCRH_EPS | UART_LCRH_SPS);
+    *lcrh = tmp | data_bits | parity | stop_bits;
+    return 0;
+}
+#endif
+
 void uart_write(uart_t uart, const uint8_t *data, size_t len)
 {
     assert(uart < UART_NUMOF);


### PR DESCRIPTION
### Contribution description

This pr adds the periph_uart_mode USEMODULE
It implements all functionality defined in the common uart driver
This means all parity modes, data bits, and stop bits


### Testing procedure

Run `USEMODULE=periph_uart_mode BOARD=remote-revb make flash term -C tests/periph_uart/`
In the terminal run
`init 1 115200`
and change all different modes (databits 5-8, parity n/e/o/m/s, and stop bits 1/2)
eg. `mode 1 5 o 2`
_note: the API says that init must be called before mode however this implementation allows the user to also call mode at any time_
Verify with a scope or analyser that the changes work/
Verify loopback works as well.

### Issues/PRs references
Implementation based off RFC #10743
Taken over from #5899
