### PR TITLE
drivers/ds75lx: add basic driver for temperature sensor

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -128,6 +128,11 @@ ifneq (,$(filter ds3234,$(USEMODULE)))
   FEATURES_REQUIRED += periph_spi
 endif
 
+ifneq (,$(filter ds75lx,$(USEMODULE)))
+  USEMODULE += xtimer
+  FEATURES_REQUIRED += periph_i2c
+endif
+
 ifneq (,$(filter dsp0401,$(USEMODULE)))
   USEMODULE += xtimer
   FEATURES_REQUIRED += periph_gpio

--- a/drivers/Makefile.include
+++ b/drivers/Makefile.include
@@ -70,6 +70,10 @@ ifneq (,$(filter ds3234,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/ds3234/include
 endif
 
+ifneq (,$(filter ds75lx,$(USEMODULE)))
+  USEMODULE_INCLUDES += $(RIOTBASE)/drivers/ds75lx/include
+endif
+
 ifneq (,$(filter dsp0401,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/dsp0401/include
 endif

--- a/drivers/ds75lx/Makefile
+++ b/drivers/ds75lx/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/ds75lx/ds75lx.c
+++ b/drivers/ds75lx/ds75lx.c
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2019 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_ds75lx
+ * @{
+ *
+ * @file
+ * @brief       Device driver implementation for the DS75LX temperature sensor.
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "xtimer.h"
+
+#include "ds75lx.h"
+#include "ds75lx_internals.h"
+#include "ds75lx_params.h"
+#include "periph/i2c.h"
+
+#define ENABLE_DEBUG        (0)
+#include "debug.h"
+
+#define DEV_I2C      (dev->params.i2c)
+#define DEV_ADDR     (dev->params.addr)
+
+static int _update_configuration_bits(const ds75lx_t *dev, uint8_t bit,
+                                      uint8_t mask, bool set)
+{
+    /* Acquire exclusive access */
+    i2c_acquire(DEV_I2C);
+
+    uint8_t config;
+    if (i2c_read_reg(DEV_I2C, DEV_ADDR, DS75LX_REG_CONFIGURATION, &config, 0) < 0) {
+        DEBUG("[ds75lx] error reading configuration register\n");
+        /* Release I2C device */
+        i2c_release(DEV_I2C);
+
+        return -DS75LX_ERR_I2C;
+    }
+
+    DEBUG("[ds75lx] initial configuration register value: 0x%02X\n", config);
+
+    /* clear bits */
+    config &= ~mask;
+
+    /* set bits if required */
+    if (set) {
+        config |= bit;
+    }
+
+    DEBUG("[ds75lx] configuration register value: 0x%02X\n", config);
+
+    if (i2c_write_reg(DEV_I2C, DEV_ADDR, DS75LX_REG_CONFIGURATION, config, 0) < 0) {
+        DEBUG("[ds75lx] error writing configuration register\n");
+        /* Release I2C device */
+        i2c_release(DEV_I2C);
+
+        return -DS75LX_ERR_I2C;
+    }
+
+    /* Release I2C device */
+    i2c_release(DEV_I2C);
+
+    return DS75LX_OK;
+}
+
+int ds75lx_init(ds75lx_t *dev, const ds75lx_params_t *params)
+{
+    dev->params = *params;
+
+    /* Set resolution bits + force shutdown of sensor */
+    return _update_configuration_bits(dev,
+        (dev->params.resolution << DS75LX_CONF_R0_POS) | (1 << DS75LX_CONF_SD_POS),
+        (DS75LX_CONF_R0_MASK | (1 << DS75LX_CONF_SD_POS)), true);
+}
+
+int ds75lx_read_temperature(const ds75lx_t *dev, int16_t *temperature)
+{
+    /* Acquire exclusive access */
+    i2c_acquire(DEV_I2C);
+
+    uint8_t tmp[2];
+    uint16_t temp;
+
+    if (i2c_read_regs(DEV_I2C, DEV_ADDR, DS75LX_REG_TEMPERATURE, tmp, 2, 0) < 0) {
+        DEBUG("[ds75lx] error reading temperature register\n");
+        /* Release I2C device */
+        i2c_release(DEV_I2C);
+
+        return -DS75LX_ERR_I2C;
+    }
+
+    /* Release I2C device */
+    i2c_release(DEV_I2C);
+
+    temp = (tmp[0] << 8) | tmp[1];
+    DEBUG("[ds75lx] temperature register content 0x%04X\n", temp);
+
+    /* isolate integer part of the temperature */
+    int8_t temp_int = (temp & 0xff00) >> 8;
+    /* compute fractional part of the temperature, the LSB bits 3 to 0 are
+    always zero and not used in the conversion */
+    uint8_t temp_frac = (temp & 0x00f0) >> 4;
+
+    /* fractional part is a multiple of 0.0625. Temperature is returned in c°C */
+    *temperature  = (temp_int * 100 + ((uint16_t)temp_frac * 100 >> 4));
+
+    return DS75LX_OK;
+}
+
+int ds75lx_wakeup(const ds75lx_t *dev)
+{
+    /* disable shutdown bit in configuration register */
+    int ret = _update_configuration_bits(dev, (1 << DS75LX_CONF_SD_POS),
+                                         (1 << DS75LX_CONF_SD_POS), false);
+
+    if (ret == DS75LX_OK) {
+        /* Wait max conversion time (depends on resolution) */
+        xtimer_usleep((DS75LX_MAX_CONVERSION_TIME << dev->params.resolution) * US_PER_MS);
+    }
+
+    return ret;
+}
+
+int ds75lx_shutdown(const ds75lx_t *dev)
+{
+    /* enable shutdown bit in configuration register */
+    return _update_configuration_bits(dev, (1 << DS75LX_CONF_SD_POS),
+                                      (1 << DS75LX_CONF_SD_POS), true);
+}

--- a/drivers/ds75lx/ds75lx_saul.c
+++ b/drivers/ds75lx/ds75lx_saul.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2019 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_ds75lx
+ * @{
+ *
+ * @file
+ * @brief       SAUL adaption for DS75LX device
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include <string.h>
+
+#include "saul.h"
+#include "ds75lx.h"
+
+static int read_temperature(const void *dev, phydat_t *res)
+{
+    ds75lx_wakeup((const ds75lx_t *)dev);
+    if (ds75lx_read_temperature((const ds75lx_t *)dev, &res->val[0]) != DS75LX_OK) {
+        ds75lx_shutdown((const ds75lx_t *)dev);
+        return -ECANCELED;
+    }
+    ds75lx_shutdown((const ds75lx_t *)dev);
+
+    res->unit = UNIT_TEMP_C;
+    res->scale = -2;
+    return 1;
+}
+
+const saul_driver_t ds75lx_temperature_saul_driver = {
+    .read = read_temperature,
+    .write = saul_notsup,
+    .type = SAUL_SENSE_TEMP
+};

--- a/drivers/ds75lx/include/ds75lx_internals.h
+++ b/drivers/ds75lx/include/ds75lx_internals.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2019 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_ds75lx
+ * @{
+ *
+ * @file
+ * @brief       Internal addresses, registers, constants for the DS75LX sensor.
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef DS75LX_INTERNALS_H
+#define DS75LX_INTERNALS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   DS75LX I2C address (7 bit address)
+ */
+#define DS75LX_ADDR                     (0x48)
+
+/**
+ * @name    DS75LX registers
+ * @{
+ */
+#define DS75LX_REG_TEMPERATURE          (0x00)
+#define DS75LX_REG_CONFIGURATION        (0x01)
+#define DS75LX_REG_T_HYST               (0x02)
+#define DS75LX_REG_T_OS                 (0x03)
+/** @} */
+
+/**
+ * @name    Configuration register bits
+ * @{
+ */
+#define DS75LX_CONF_SD_POS              (0)
+#define DS75LX_CONF_TM_POS              (1)
+#define DS75LX_CONF_POL_POS             (2)
+#define DS75LX_CONF_F0_POS              (3)
+#define DS75LX_CONF_F0_MASK             (0x18)
+#define DS75LX_CONF_R0_POS              (5)
+#define DS75LX_CONF_R0_MASK             (0x60)
+/** @} */
+
+/**
+ * @brief   Max conversion time unit (ms)
+ */
+#define DS75LX_MAX_CONVERSION_TIME      (25U)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DS75LX_INTERNALS_H */
+/** @} */

--- a/drivers/ds75lx/include/ds75lx_params.h
+++ b/drivers/ds75lx/include/ds75lx_params.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2019 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_ds75lx
+ *
+ * @{
+ * @file
+ * @brief       Default configuration for DS75LX
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef DS75LX_PARAMS_H
+#define DS75LX_PARAMS_H
+
+#include "board.h"
+#include "ds75lx.h"
+#include "ds75lx_internals.h"
+#include "saul_reg.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Set default configuration parameters for the DS75LX
+ * @{
+ */
+#ifndef DS75LX_PARAM_I2C_DEV
+#define DS75LX_PARAM_I2C_DEV         I2C_DEV(0)
+#endif
+#ifndef DS75LX_PARAM_I2C_ADDR
+#define DS75LX_PARAM_I2C_ADDR        DS75LX_ADDR
+#endif
+#ifndef DS75LX_PARAM_RESOLUTION
+#define DS75LX_PARAM_RESOLUTION      DS75LX_RESOLUTION_10
+#endif
+
+#ifndef DS75LX_PARAMS
+#define DS75LX_PARAMS                { .i2c        = DS75LX_PARAM_I2C_DEV,  \
+                                       .addr       = DS75LX_PARAM_I2C_ADDR, \
+                                       .resolution = DS75LX_PARAM_RESOLUTION }
+#endif
+/**@}*/
+
+/**
+ * @brief   Configure DS75LX
+ */
+static const ds75lx_params_t ds75lx_params[] =
+{
+    DS75LX_PARAMS
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DS75LX_PARAMS_H */
+/** @} */

--- a/drivers/ds75lx/include/ds75lx_params.h
+++ b/drivers/ds75lx/include/ds75lx_params.h
@@ -47,6 +47,9 @@ extern "C" {
                                        .addr       = DS75LX_PARAM_I2C_ADDR, \
                                        .resolution = DS75LX_PARAM_RESOLUTION }
 #endif
+#ifndef DS75LX_SAUL_INFO
+#define DS75LX_SAUL_INFO             { .name = "ds75lx" }
+#endif
 /**@}*/
 
 /**
@@ -55,6 +58,14 @@ extern "C" {
 static const ds75lx_params_t ds75lx_params[] =
 {
     DS75LX_PARAMS
+};
+
+/**
+ * @brief   Configure SAUL registry entries
+ */
+static const saul_reg_info_t ds75lx_saul_info[] =
+{
+    DS75LX_SAUL_INFO
 };
 
 #ifdef __cplusplus

--- a/drivers/include/ds75lx.h
+++ b/drivers/include/ds75lx.h
@@ -9,8 +9,10 @@
 /**
  * @defgroup    drivers_ds75lx Maxim DS75LX temperature sensor
  * @ingroup     drivers_sensors
+ * @ingroup     drivers_saul
  * @brief       Device driver interface for the Maxim DS75LX temperature sensor
  *
+ * This driver provides @ref drivers_saul capabilities.
  * @{
  *
  * @file

--- a/drivers/include/ds75lx.h
+++ b/drivers/include/ds75lx.h
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2019 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_ds75lx Maxim DS75LX temperature sensor
+ * @ingroup     drivers_sensors
+ * @brief       Device driver interface for the Maxim DS75LX temperature sensor
+ *
+ * @{
+ *
+ * @file
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef DS75LX_H
+#define DS75LX_H
+
+#include "saul.h"
+#include "periph/i2c.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Thermometer resolution
+ */
+typedef enum {
+    DS75LX_RESOLUTION_9 = 0,        /**< 9 bits resolution, 25ms max conversion time */
+    DS75LX_RESOLUTION_10,           /**< 10 bits resolution, 50ms max conversion time */
+    DS75LX_RESOLUTION_11,           /**< 11 bits resolution, 100ms max conversion time */
+    DS75LX_RESOLUTION_12,           /**< 12 bits resolution, 200ms max conversion time */
+} ds75lx_resolution_t;
+
+/**
+ * @brief   Device initialization parameters
+ */
+typedef struct {
+    i2c_t i2c;                      /**< I2C device which is used */
+    uint8_t addr;                   /**< I2C address */
+    ds75lx_resolution_t resolution; /**< Thermometer resolution */
+} ds75lx_params_t;
+
+/**
+ * @brief   Device descriptor for the DS75LX sensor
+ */
+typedef struct {
+    ds75lx_params_t params;         /**< Device initialization parameters */
+} ds75lx_t;
+
+/**
+ * @brief   Status and error return codes
+ */
+enum {
+    DS75LX_OK = 0,                  /**< everything was fine */
+    DS75LX_ERR_I2C,                 /**< error when reading/writing I2C bus */
+};
+
+/**
+ * @brief   Initialize the given DS75LX device
+ *
+ * @param[out] dev          Initialized device descriptor of DS75LX device
+ * @param[in]  params       Initialization parameters
+ *
+ * @return                  DS75LX_OK on success
+ * @return                  -DS75LX_ERR_I2C if an error occured when reading/writing
+ */
+int ds75lx_init(ds75lx_t *dev, const ds75lx_params_t *params);
+
+/**
+ * @brief   Read temperature value from the given DS75LX device, returned in c°C
+ *
+ * @param[in] dev           Device descriptor of DS75LX device
+ * @param[out] temperature  Temperature in c°C
+ *
+ * @return                  DS75LX_OK on success
+ * @return                  -DS75LX_ERR_I2C if an error occured when reading/writing
+ */
+int ds75lx_read_temperature(const ds75lx_t *dev, int16_t *temperature);
+
+/**
+ * @brief   Wakeup the sensor
+ *
+ * @param[in] dev           Device descriptor of DS75LX device
+ *
+ * @return                  DS75LX_OK on success
+ * @return                  -DS75LX_ERR_I2C if an error occured when reading/writing
+ */
+int ds75lx_wakeup(const ds75lx_t *dev);
+
+/**
+ * @brief   Shutdown the sensor
+ *
+ * @param[in] dev           Device descriptor of DS75LX device
+ *
+ * @return                  DS75LX_OK on success
+ * @return                  -DS75LX_ERR_I2C if an error occured when reading/writing
+ */
+int ds75lx_shutdown(const ds75lx_t *dev);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DS75LX_H */
+/** @} */

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -365,6 +365,10 @@ void auto_init(void)
     extern void auto_init_ds18(void);
     auto_init_ds18();
 #endif
+#ifdef MODULE_DS75LX
+    extern void auto_init_ds75lx(void);
+    auto_init_ds75lx();
+#endif
 #ifdef MODULE_FXOS8700
     extern void auto_init_fxos8700(void);
     auto_init_fxos8700();

--- a/sys/auto_init/saul/auto_init_ds75lx.c
+++ b/sys/auto_init/saul/auto_init_ds75lx.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2019 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys_auto_init_saul
+ * @{
+ *
+ * @file
+ * @brief       Auto initialization of DS75LX driver.
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#ifdef MODULE_DS75LX
+
+#include "assert.h"
+#include "log.h"
+#include "saul_reg.h"
+#include "ds75lx.h"
+#include "ds75lx_params.h"
+
+/**
+ * @brief   Define the number of configured sensors
+ */
+#define DS75LX_NUM      (sizeof(ds75lx_params) / sizeof(ds75lx_params[0]))
+
+/**
+ * @brief   Allocation of memory for device descriptors
+ */
+static ds75lx_t ds75lx_devs[DS75LX_NUM];
+
+/**
+ * @brief   Memory for the SAUL registry entries
+ */
+static saul_reg_t saul_entries[DS75LX_NUM];
+
+/**
+ * @brief   Define the number of saul info
+ */
+#define DS75LX_INFO_NUM (sizeof(ds75lx_saul_info) / sizeof(ds75lx_saul_info[0]))
+
+/**
+ * @name    Reference the driver structs.
+ * @{
+ */
+extern const saul_driver_t ds75lx_temperature_saul_driver;
+/** @} */
+
+void auto_init_ds75lx(void)
+{
+    assert(DS75LX_INFO_NUM == DS75LX_NUM);
+
+    for (unsigned i = 0; i < DS75LX_NUM; i++) {
+        LOG_DEBUG("[auto_init_saul] initializing ds75lx #%u\n", i);
+
+        if (ds75lx_init(&ds75lx_devs[i],
+                        &ds75lx_params[i]) != DS75LX_OK) {
+            LOG_ERROR("[auto_init_saul] error initializing ds75lx #%u\n", i);
+            continue;
+        }
+
+        saul_entries[i].dev = &(ds75lx_devs[i]);
+        saul_entries[i].name = ds75lx_saul_info[i].name;
+        saul_entries[i].driver = &ds75lx_temperature_saul_driver;
+
+        /* register to saul */
+        saul_reg_add(&(saul_entries[i]));
+    }
+}
+#else
+typedef int dont_be_pedantic;
+#endif /* MODULE_DS75LX */

--- a/tests/driver_ds75lx/Makefile
+++ b/tests/driver_ds75lx/Makefile
@@ -1,0 +1,6 @@
+include ../Makefile.tests_common
+
+USEMODULE += ds75lx
+USEMODULE += xtimer
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/driver_ds75lx/README.md
+++ b/tests/driver_ds75lx/README.md
@@ -1,0 +1,6 @@
+## About
+This is a test application for the Maxim DS75LX Temperature sensor.
+
+## Usage
+The application will initialize the DS75LX sensor and, every 2 seconds, reads
+and display the temperature measured by the sensor.

--- a/tests/driver_ds75lx/main.c
+++ b/tests/driver_ds75lx/main.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2019 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for the DS75LX temperature sensor
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <inttypes.h>
+
+#include "ds75lx.h"
+#include "ds75lx_params.h"
+#include "xtimer.h"
+
+int main(void)
+{
+    ds75lx_t dev;
+    int result;
+
+    puts("DS75LX test application\n");
+
+    printf("+------------Initializing------------+\n");
+    result = ds75lx_init(&dev, &ds75lx_params[0]);
+    if (result != DS75LX_OK) {
+        puts("[Error] Failed to initialize DS75LX sensor");
+        return 1;
+    }
+
+    puts("Initialization successful\n");
+
+    printf("\n+--------Starting Measurements--------+\n");
+    int16_t temperature;
+    while (1) {
+        ds75lx_wakeup(&dev);
+        /* Get temperature in degrees celsius */
+        ds75lx_read_temperature(&dev, &temperature);
+        ds75lx_shutdown(&dev);
+
+        bool negative = (temperature < 0);
+        if (negative) {
+            temperature = -temperature;
+        }
+
+        printf("Temperature [°C]: %c%d.%02d\n",
+               negative ? '-': ' ',
+               (int)(temperature / 100),
+               (int)(temperature % 100));
+
+        xtimer_sleep(2);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds a basic driver for the [Maxim DS75LX](https://datasheets.maximintegrated.com/en/ds/DS75LX.pdf) temperature sensor.

For the moment, this is very basic: interrupt and comparator modes are not implemented. There is no SAUL either but this can be added later if needed.

This sensor is available on the IM880b LoRa board provided in #11315.

CC'ing @parksprojets who might be interested as well.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Build and flash `tests/driver_ds75lx` application and verify that the temperature measures are correct.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Can be used with #11315 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
