### PR TITLE
cpu/nrf5x/radio/nrfmin: Enhance nrfmin reliability

### DIFF
--- a/cpu/nrf5x_common/radio/nrfmin/nrfmin.c
+++ b/cpu/nrf5x_common/radio/nrfmin/nrfmin.c
@@ -320,7 +320,10 @@ static int nrfmin_send(netdev_t *dev, const iolist_t *iolist)
 {
     (void)dev;
 
-    assert((iolist) && (state != STATE_OFF));
+    assert(iolist);
+    if (state == STATE_OFF) {
+        return -ENETDOWN;
+    }
 
     /* wait for any ongoing transmission to finish and go into idle state */
     while (state == STATE_TX) {}
@@ -355,7 +358,9 @@ static int nrfmin_recv(netdev_t *dev, void *buf, size_t len, void *info)
     (void)dev;
     (void)info;
 
-    assert(state != STATE_OFF);
+    if (state == STATE_OFF) {
+        return -ENETDOWN;
+    }
 
     unsigned pktlen = rx_buf.pkt.hdr.len;
 

--- a/cpu/nrf5x_common/radio/nrfmin/nrfmin.c
+++ b/cpu/nrf5x_common/radio/nrfmin/nrfmin.c
@@ -163,7 +163,9 @@ static void goto_target_state(void)
         NRF_RADIO->PACKETPTR = (uint32_t)(&rx_buf);
         NRF_RADIO->BASE0 = (CONF_ADDR_BASE | my_addr);
         /* goto RX mode */
+        NRF_RADIO->EVENTS_READY = 0;
         NRF_RADIO->TASKS_RXEN = 1;
+        while (NRF_RADIO->EVENTS_READY == 0) {}
         state = STATE_RX;
     }
 
@@ -347,8 +349,10 @@ static int nrfmin_send(netdev_t *dev, const iolist_t *iolist)
 
     /* trigger the actual transmission */
     DEBUG("[nrfmin] send: putting %i byte into the ether\n", (int)hdr->len);
-    state = STATE_TX;
+    NRF_RADIO->EVENTS_READY = 0;
     NRF_RADIO->TASKS_TXEN = 1;
+    while (NRF_RADIO->EVENTS_READY == 0) {}
+    state = STATE_TX;
 
     return (int)pos;
 }

--- a/cpu/nrf5x_common/radio/nrfmin/nrfmin.c
+++ b/cpu/nrf5x_common/radio/nrfmin/nrfmin.c
@@ -423,7 +423,8 @@ static int nrfmin_init(netdev_t *dev)
     /* always send from logical address 0 */
     NRF_RADIO->TXADDRESS = 0x00UL;
     /* and listen to logical addresses 0 and 1 */
-    NRF_RADIO->RXADDRESSES = 0x03UL;
+    /* workaround errata nrf52832 3.41 [143] */
+    NRF_RADIO->RXADDRESSES = 0x10003UL;
     /* configure data fields and packet length whitening and endianess */
     NRF_RADIO->PCNF0 = ((CONF_S1 << RADIO_PCNF0_S1LEN_Pos) |
                         (CONF_S0 << RADIO_PCNF0_S0LEN_Pos) |


### PR DESCRIPTION
### Contribution description

This PR provides fix for 3 independent flaws of the nrfmin radio driver:

The most profound commit fixes a bug discovered by @PeterKietzmann that allows to receive packets with a false receiver address. This Bug happend for receiver boards nrf52840dk and nrf52dk and was fixed with a workaround given by the errata sheet of the nrf52832.

Further this PR provides testing of power state when sending or receiving. Instead of throwing an assert, it now returns `ENETDOWN /*Network is down (POSIX.1-2001).*/`, when the device is powered off. This is, to avoid assertion fails on development, but rather avoid unspecified behavior when not in debug mode.

Also it adds a minor fix, lend from nrf52840 radio driver, to wait for the Ready-Event, which is triggered when the device is Ready to send/receive. This helped to increase reliability when flooding, as presented by @pystub in #10878.

I can split this PR, if prefered.

### Testing procedure

Test with examples/default on boards with nrf52840 or nrf52832 cpus. Make sure to use nrfmin with `USEMODULE=nrfmin`. Send packets with `txtsnd`.

On master, try to find an invalid address, that is accepted by the receiver by substituting single figures of the receiver address, preferably the last figure.
With this PR invalid addresses, generated with this approach will not work anymore.

Further testing could cover flooding with a small intervall of 0.1 seconds, as given in #10878.

### Issues/PRs references

Fixes #10878
