### PR TITLE
core/thread: unify thread_t variable naming

### DIFF
--- a/core/thread.c
+++ b/core/thread.c
@@ -40,15 +40,15 @@ volatile thread_t *thread_get(kernel_pid_t pid)
 
 int thread_getstatus(kernel_pid_t pid)
 {
-    volatile thread_t *t = thread_get(pid);
-    return t ? (int)t->status : (int)STATUS_NOT_FOUND;
+    volatile thread_t *thread = thread_get(pid);
+    return thread ? (int)thread->status : (int)STATUS_NOT_FOUND;
 }
 
 const char *thread_getname(kernel_pid_t pid)
 {
 #ifdef DEVELHELP
-    volatile thread_t *t = thread_get(pid);
-    return t ? t->name : NULL;
+    volatile thread_t *thread = thread_get(pid);
+    return thread ? thread->name : NULL;
 #else
     (void)pid;
     return NULL;
@@ -73,18 +73,18 @@ int thread_wakeup(kernel_pid_t pid)
 
     unsigned old_state = irq_disable();
 
-    thread_t *other_thread = (thread_t *) thread_get(pid);
+    thread_t *thread = (thread_t *) thread_get(pid);
 
-    if (!other_thread) {
+    if (!thread) {
         DEBUG("thread_wakeup: Thread does not exist!\n");
     }
-    else if (other_thread->status == STATUS_SLEEPING) {
+    else if (thread->status == STATUS_SLEEPING) {
         DEBUG("thread_wakeup: Thread is sleeping.\n");
 
-        sched_set_status(other_thread, STATUS_RUNNING);
+        sched_set_status(thread, STATUS_RUNNING);
 
         irq_restore(old_state);
-        sched_switch(other_thread->priority);
+        sched_switch(thread->priority);
 
         return 1;
     }
@@ -173,7 +173,7 @@ kernel_pid_t thread_create(char *stack, int stacksize, char priority, int flags,
         DEBUG("thread_create: stacksize is too small!\n");
     }
     /* allocate our thread control block at the top of our stackspace */
-    thread_t *cb = (thread_t *) (stack + stacksize);
+    thread_t *thread = (thread_t *) (stack + stacksize);
 
 #if defined(DEVELHELP) || defined(SCHED_TEST_STACK)
     if (flags & THREAD_CREATE_STACKTEST) {
@@ -209,41 +209,41 @@ kernel_pid_t thread_create(char *stack, int stacksize, char priority, int flags,
         return -EOVERFLOW;
     }
 
-    sched_threads[pid] = cb;
+    sched_threads[pid] = thread;
 
-    cb->pid = pid;
-    cb->sp = thread_stack_init(function, arg, stack, stacksize);
+    thread->pid = pid;
+    thread->sp = thread_stack_init(function, arg, stack, stacksize);
 
 #if defined(DEVELHELP) || defined(SCHED_TEST_STACK) || defined(MODULE_MPU_STACK_GUARD)
-    cb->stack_start = stack;
+    thread->stack_start = stack;
 #endif
 
 #ifdef DEVELHELP
-    cb->stack_size = total_stacksize;
-    cb->name = name;
+    thread->stack_size = total_stacksize;
+    thread->name = name;
 #endif
 
-    cb->priority = priority;
-    cb->status = STATUS_STOPPED;
+    thread->priority = priority;
+    thread->status = STATUS_STOPPED;
 
-    cb->rq_entry.next = NULL;
+    thread->rq_entry.next = NULL;
 
 #ifdef MODULE_CORE_MSG
-    cb->wait_data = NULL;
-    cb->msg_waiters.next = NULL;
-    cib_init(&(cb->msg_queue), 0);
-    cb->msg_array = NULL;
+    thread->wait_data = NULL;
+    thread->msg_waiters.next = NULL;
+    cib_init(&(thread->msg_queue), 0);
+    thread->msg_array = NULL;
 #endif
 
     sched_num_threads++;
 
-    DEBUG("Created thread %s. PID: %" PRIkernel_pid ". Priority: %u.\n", name, cb->pid, priority);
+    DEBUG("Created thread %s. PID: %" PRIkernel_pid ". Priority: %u.\n", name, thread->pid, priority);
 
     if (flags & THREAD_CREATE_SLEEPING) {
-        sched_set_status(cb, STATUS_SLEEPING);
+        sched_set_status(thread, STATUS_SLEEPING);
     }
     else {
-        sched_set_status(cb, STATUS_PENDING);
+        sched_set_status(thread, STATUS_PENDING);
 
         if (!(flags & THREAD_CREATE_WOUT_YIELD)) {
             irq_restore(state);


### PR DESCRIPTION
### Contribution description

thread_t variables in ```core/thread.c``` were named t, other_thread, cb.
For consistency, change all occurrences to just "thread".

### Testing procedure

This is cosmetic only, so CI compilation should be fine

### Issues/PRs references
