### PR TITLE
core: rename thread_state_t to thread_status_t

### DIFF
--- a/core/include/sched.h
+++ b/core/include/sched.h
@@ -114,7 +114,7 @@ typedef enum {
     STATUS_RUNNING,                 /**< currently running                    */
     STATUS_PENDING,                 /**< waiting to be scheduled to run       */
     STATUS_NUMOF                    /**< number of supported thread states    */
-} thread_state_t;
+} thread_status_t;
 /** @} */
 
 /**
@@ -123,7 +123,7 @@ typedef enum {
  */
 #define STATUS_ON_RUNQUEUE      STATUS_RUNNING  /**< to check if on run queue:
                                                  `st >= STATUS_ON_RUNQUEUE`   */
-#define STATUS_NOT_FOUND ((thread_state_t)-1)   /**< Describes an illegal thread status */
+#define STATUS_NOT_FOUND ((thread_status_t)-1)  /**< Describes an illegal thread status */
 /** @} */
 /**
  * @def SCHED_PRIO_LEVELS
@@ -146,7 +146,7 @@ int sched_run(void);
  *                          targeted process
  * @param[in]   status      The new status of this thread
  */
-void sched_set_status(thread_t *process, thread_state_t status);
+void sched_set_status(thread_t *process, thread_status_t status);
 
 /**
  * @brief       Yield if approriate.

--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -143,7 +143,7 @@ typedef void *(*thread_task_func_t)(void *arg);
  */
 struct _thread {
     char *sp;                       /**< thread's stack pointer         */
-    thread_state_t status;          /**< thread's status                */
+    thread_status_t status;         /**< thread's status                */
     uint8_t priority;               /**< thread's priority              */
 
     kernel_pid_t pid;               /**< thread's process id            */

--- a/core/sched.c
+++ b/core/sched.c
@@ -158,7 +158,7 @@ void sched_register_cb(void (*callback)(uint32_t, uint32_t))
 }
 #endif
 
-void sched_set_status(thread_t *process, thread_state_t status)
+void sched_set_status(thread_t *process, thread_status_t status)
 {
     if (status >= STATUS_ON_RUNQUEUE) {
         if (!(process->status >= STATUS_ON_RUNQUEUE)) {

--- a/sys/ps/ps.c
+++ b/sys/ps/ps.c
@@ -96,7 +96,7 @@ void ps(void)
         thread_t *p = (thread_t *)sched_threads[i];
 
         if (p != NULL) {
-            thread_state_t state = p->status;                                      /* copy state */
+            thread_status_t state = p->status;                                     /* copy state */
             const char *sname = state_names[state];                                /* get state name */
             const char *queued = &queued_name[(int)(state >= STATUS_ON_RUNQUEUE)]; /* get queued flag */
 #ifdef DEVELHELP


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This way it can't come to name collisions on `native` with [Mac OSX' threading library][1].

[1]: https://opensource.apple.com/source/xnu/xnu-792/osfmk/mach/thread_status.h.auto.html
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Just a naming change. Check code base with `git grep thread_state_t`, otherwise everything should still compile (that is Murdock's job). If you have access to a Mac, `gnrc_networking` should now be compiling for `native` again.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Fixes #11508.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
