### PR TITLE
cpu/nrf52: i2c bugfix

### DIFF
--- a/cpu/nrf52/periph/i2c.c
+++ b/cpu/nrf52/periph/i2c.c
@@ -89,8 +89,8 @@ void i2c_init(i2c_t dev)
      * called */
     bus(dev)->ENABLE = TWIM_ENABLE_ENABLE_Disabled;
     /* configure pins */
-    gpio_init(i2c_config[dev].scl, GPIO_IN_PU);
-    gpio_init(i2c_config[dev].sda, GPIO_IN_PU);
+    gpio_init(i2c_config[dev].scl, GPIO_IN_OD_PU);
+    gpio_init(i2c_config[dev].sda, GPIO_IN_OD_PU);
     bus(dev)->PSEL.SCL = i2c_config[dev].scl;
     bus(dev)->PSEL.SDA = i2c_config[dev].sda;
     /* configure dev clock speed */

--- a/cpu/nrf5x_common/include/periph_cpu_common.h
+++ b/cpu/nrf5x_common/include/periph_cpu_common.h
@@ -61,11 +61,12 @@ extern "C" {
  * @brief   Generate GPIO mode bitfields
  *
  * We use 4 bit to encode the pin mode:
- * - bit   0: output enable
- * - bit   1: input connect
- * - bit 2+3: pull resistor configuration
+ * - bit      0: output enable
+ * - bit      1: input connect
+ * - bit    2+3: pull resistor configuration
+ * - bit 8+9+10: drive configuration
  */
-#define GPIO_MODE(oe, ic, pr)   (oe | (ic << 1) | (pr << 2))
+#define GPIO_MODE(oe, ic, pr, dr)   (oe | (ic << 1) | (pr << 2) | (dr << 8))
 
 /**
  * @brief   No support for HW chip select...
@@ -94,12 +95,13 @@ extern "C" {
  */
 #define HAVE_GPIO_MODE_T
 typedef enum {
-    GPIO_IN    = GPIO_MODE(0, 0, 0),    /**< IN */
-    GPIO_IN_PD = GPIO_MODE(0, 0, 1),    /**< IN with pull-down */
-    GPIO_IN_PU = GPIO_MODE(0, 0, 3),    /**< IN with pull-up */
-    GPIO_OUT   = GPIO_MODE(1, 1, 0),    /**< OUT (push-pull) */
-    GPIO_OD    = (0xff),                /**< not supported by HW */
-    GPIO_OD_PU = (0xfe)                 /**< not supported by HW */
+    GPIO_IN       = GPIO_MODE(0, 0, 0, 0), /**< IN */
+    GPIO_IN_PD    = GPIO_MODE(0, 0, 1, 0), /**< IN with pull-down */
+    GPIO_IN_PU    = GPIO_MODE(0, 0, 3, 0), /**< IN with pull-up */
+    GPIO_IN_OD_PU = GPIO_MODE(0, 0, 3, 6), /**< IN with pull-up and open drain output */
+    GPIO_OUT      = GPIO_MODE(1, 1, 0, 0), /**< OUT (push-pull) */
+    GPIO_OD       = (0xff),                /**< not supported by HW */
+    GPIO_OD_PU    = (0xfe)                 /**< not supported by HW */
 } gpio_mode_t;
 /** @} */
 

--- a/cpu/nrf5x_common/periph/gpio.c
+++ b/cpu/nrf5x_common/periph/gpio.c
@@ -97,8 +97,10 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
         case GPIO_IN:
         case GPIO_IN_PD:
         case GPIO_IN_PU:
+        case GPIO_IN_OD_PU:
         case GPIO_OUT:
-            /* configure pin direction, input buffer and pull resistor state */
+            /* configure pin direction, input buffer, pull resistor state
+             * and drive configuration */
             port(pin)->PIN_CNF[pin_num(pin)] = mode;
             break;
         default:


### PR DESCRIPTION
### Contribution description
During the testing of a device driver for the u-blox SAM-M8Q GPS receiver (uses clock stretching) on the NRF52840-MDK board, I noticed that I couldn't get the slave to ACK over I2C no matter what I tried. It seemed like a short on SDA between master and slave [See](https://devzone.nordicsemi.com/f/nordic-q-a/16116/twi-clock-pull-up). The driver works just fine on the Zolertia Firefly. 

The nRF52840 datasheet states on page 431 to set the GPIO drive configuration (bit 8-10) of the PIN_CNF register to S0D1(0x06) for both, SCL and SDA. I fixed this in the cpu/nrf5x_common as well as cpu/nrf52. The nrf51 already sets the drive configuration to S0D1.

### Testing procedure
Test on any board with a NRF52 with I2C configured. For me it works fine now with the NRF52840-MDK board and the u-blox SAM-M8Q as well as the Bosch BMX280 devices.

### Issues/PRs references
None
