### PR TITLE
boards/nrf52840-mdk: added I2C config

### DIFF
--- a/boards/nrf52840-mdk/Makefile.features
+++ b/boards/nrf52840-mdk/Makefile.features
@@ -1,6 +1,7 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_i2c
 
 # Various other features (if any)
 FEATURES_PROVIDED += radio_nrf802154

--- a/boards/nrf52840-mdk/include/periph_conf.h
+++ b/boards/nrf52840-mdk/include/periph_conf.h
@@ -65,6 +65,21 @@ static const spi_conf_t spi_config[] = {
 #define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
 /** @} */
 
+/**
+ * @name    I2C configuration
+ * @{
+ */
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev = NRF_TWIM0,
+        .scl = 27,
+        .sda = 26,
+        .speed = I2C_SPEED_NORMAL
+    }
+};
+#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
### Contribution description
Added a I2C config for the nrf52840-mdk. The pins correspond to the first Grove port of the Base Dock ([See](https://store.makerdiary.com/collections/frontpage/products/base-dock))

### Testing procedure
run `tests/driver_bmx280` or any other i2c device with this board

### Issues/PRs references
None