### PR TITLE
core: fix c11 atomic definitions (fix gcc9 compilation)

### DIFF
--- a/core/atomic_sync.c
+++ b/core/atomic_sync.c
@@ -29,7 +29,17 @@
 #include <string.h>
 #include "irq.h"
 
-#if !defined(__llvm__) && !defined(__clang__)
+/* use gcc/clang implementation if available */
+#if defined(__GNUC__) \
+    && (__GNUC__ > 4 || \
+       (__GNUC__ == 4 && (__GNUC_MINOR__ > 7 || \
+       (__GNUC_MINOR__ == 7 && __GNUC_PATCHLEVEL__ > 0)))) \
+    || defined(__llvm__) || defined(__clang__)
+#define HAVE_C11_SYNC
+#endif
+
+#if !defined(HAVE_C11_SYNC)
+
 /* GCC documentation refers to the types as I1, I2, I4, I8, I16 */
 typedef uint8_t  I1;
 typedef uint16_t I2;

--- a/cpu/cortexm_common/vectors_cortexm.c
+++ b/cpu/cortexm_common/vectors_cortexm.c
@@ -221,7 +221,7 @@ __attribute__((naked)) void hard_fault_default(void)
         "mov r3, sp                         \n" /* r4_to_r11_stack parameter  */
         "bl hard_fault_handler              \n" /* hard_fault_handler(r0)     */
           :
-          : [sram]   "r" (&_sram + HARDFAULT_HANDLER_REQUIRED_STACK_SPACE),
+          : [sram]   "r" ((uintptr_t)&_sram + HARDFAULT_HANDLER_REQUIRED_STACK_SPACE),
             [eram]   "r" (&_eram),
             [estack] "r" (&_estack)
           : "r0","r4","r5","r6","r8","r9","r10","r11","lr"


### PR DESCRIPTION
### Contribution description

gcc 9 broke the compilation of our c11 atomics on ARM.

Basically, where the operations previously took ```uint[8, 16, 32]_t *``` pointers as arguments, they are now expected to get ```void *````pointers.

Furthermore, the return type for "int" sized atomic builtins is expected to be ```unsigned int``` instead of the stdint type.

For core/atomic_sync.c, a commit adds a guard to only compile if gcc < 4.7, which solves the problem altogether.

For core/atomic_c11.c, the arguments are fixed accordingly. The return type is fixed by making the respective typedefs depend on ```__SIZEOF_INT__```.

I've piggybacked another commit fixing the type of an ```uint8_t[1] + large value``` on Cortex-M.

### Testing procedure

Compile with gcc 9 (e.g., on current Arch linux). Compile with older compilers. Run tests to see if anything breaks.

### Issues/PRs references

