### PR TITLE
tools/compile_and_test_for_board: assert resultdir is valid

### DIFF
--- a/dist/tools/compile_and_test_for_board/compile_and_test_for_board.py
+++ b/dist/tools/compile_and_test_for_board/compile_and_test_for_board.py
@@ -190,6 +190,24 @@ def create_directory(directory, clean=False, mode=0o755):
     os.makedirs(directory, mode=mode, exist_ok=True)
 
 
+def is_in_directory(path, directory):
+    """Return if `path` is inside `directory`.
+
+    >>> is_in_directory('RIOT/a/b/c', 'RIOT')
+    True
+    >>> is_in_directory('RIOT/../a', 'RIOT')
+    False
+
+    # Also work if path is absolute but not the directory
+    >>> curdir = os.path.abspath(os.curdir)
+    >>> is_in_directory(os.path.join(curdir, 'RIOT', 'a'), 'RIOT')
+    True
+    """
+    directory = os.path.abspath(directory)
+    path = os.path.abspath(path)
+    return path.startswith(directory)
+
+
 class RIOTApplication():
     """RIOT Application representation.
 

--- a/dist/tools/compile_and_test_for_board/compile_and_test_for_board.py
+++ b/dist/tools/compile_and_test_for_board/compile_and_test_for_board.py
@@ -232,6 +232,10 @@ class RIOTApplication():
         self.resultdir = os.path.join(resultdir, appdir)
         self.logger = logging.getLogger('%s.%s' % (board, appdir))
 
+        # Currently not handling absolute directories or outside of RIOT
+        assert is_in_directory(self.resultdir, resultdir), \
+            "Application result directory is outside main result directory"
+
     # Extract values from make
     def name(self):
         """Get application name."""


### PR DESCRIPTION
### Contribution description

Currently giving an absolute result or outside of RIOT application breaks the
result directory evaluation which can lead to deleting the application.

Add an assertion to detect it.

### Testing procedure

`tox` inside the `compile_and_test_for_board` directory runs without error. 

<details><summary><code>RIOT/dist/tools/compile_and_test_for_board $ tox</code></summary><p>

```
test installed: atomicwrites==1.3.0,attrs==19.1.0,more-itertools==7.0.0,pluggy==0.11.0,py==1.8.0,pytest==4.5.0,six==1.12.0,wcwidth==0.1.7
test run-test-pre: PYTHONHASHSEED='3511953664'
test runtests: commands[0] | pytest -v --doctest-modules
================================================================================================================================== test session starts ===================================================================================================================================
platform linux -- Python 3.6.7, pytest-4.5.0, py-1.8.0, pluggy-0.11.0 -- /home/harter/work/git/RIOT/dist/tools/compile_and_test_for_board/.tox/test/bin/python
cachedir: .tox/test/.pytest_cache
rootdir: /home/harter/work/git/RIOT/dist/tools/compile_and_test_for_board
collected 3 items                                                                                                                                                                                                                                                                        

compile_and_test_for_board.py::compile_and_test_for_board.is_in_directory PASSED                                                                                                                                                                                                   [ 33%]
compile_and_test_for_board.py::compile_and_test_for_board.list_from_string PASSED                                                                                                                                                                                                  [ 66%]
tests/test_compile_and_test_for_board.py::test_help_message PASSED                                                                                                                                                                                                                 [100%]

================================================================================================================================ 3 passed in 0.08 seconds ================================================================================================================================
lint installed: astroid==2.2.5,isort==4.3.19,lazy-object-proxy==1.4.1,mccabe==0.6.1,pylint==2.3.1,six==1.12.0,typed-ast==1.3.5,wrapt==1.11.1
lint run-test-pre: PYTHONHASHSEED='3511953664'
lint runtests: commands[0] | pylint compile_and_test_for_board.py tests

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

flake8 installed: entrypoints==0.3,flake8==3.7.7,mccabe==0.6.1,pycodestyle==2.5.0,pyflakes==2.1.1
flake8 run-test-pre: PYTHONHASHSEED='3511953664'
flake8 runtests: commands[0] | flake8 compile_and_test_for_board.py tests
________________________________________________________________________________________________________________________________________ summary _________________________________________________________________________________________________________________________________________
  test: commands succeeded
  lint: commands succeeded
  flake8: commands succeeded
  congratulations :)
```
</p></details>


The error is detected even if the directories do not exist:

<details><summary><code>./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py . --applications=../relative native</code></summary><p>

```
./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py . --applications=../relative native
INFO:native:Saving toolchain
Traceback (most recent call last):
  File "./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py", line 669, in <module>
    main()
  File "./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py", line 646, in main
    for app_dir in app_dirs]
  File "./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py", line 646, in <listcomp>
    for app_dir in app_dirs]
  File "./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py", line 237, in __init__
    "Application result directory is outside main result directory"
AssertionError: Application result directory is outside main result directory
```
</p></details>

<details><summary><code>./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py . --applications=/tmp/absolute native</code></summary><p>

```
./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py . --applications=/tmp/absolute native
INFO:native:Saving toolchain
Traceback (most recent call last):
  File "./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py", line 669, in <module>
    main()
  File "./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py", line 646, in main
    for app_dir in app_dirs]
  File "./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py", line 646, in <listcomp>
    for app_dir in app_dirs]
  File "./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py", line 237, in __init__
    "Application result directory is outside main result directory"
AssertionError: Application result directory is outside main result directory
```

</p></details>


Running it with an application outside of RIOT would delete the application as it was deleting the directory content with master.

### Issues/PRs references

This was found while working on https://github.com/RIOT-OS/RIOT/pull/10838
