### PR TITLE
tools/compile_and_test_for_board: ignore git tracked or not

### DIFF
--- a/dist/tools/compile_and_test_for_board/compile_and_test_for_board.py
+++ b/dist/tools/compile_and_test_for_board/compile_and_test_for_board.py
@@ -113,45 +113,13 @@ def apps_directories(riotdir, apps_dirs=None, apps_dirs_skip=None):
     :param apps_dirs_skip: list of application directories to remove, applied
                            on the RIOT list or `apps_dirs`
     """
-    apps_dirs = apps_dirs or _riot_tracked_applications_dirs(riotdir)
+    apps_dirs = apps_dirs or _riot_applications_dirs(riotdir)
     apps_dirs_skip = apps_dirs_skip or []
 
     # Remove applications to skip
     apps_dirs = set(apps_dirs) - set(apps_dirs_skip)
 
     return sorted(list(apps_dirs))
-
-
-def _is_git_repo(riotdir):
-    """Check if directory is a git repository."""
-    cmd = ['git', 'rev-parse', '--git-dir']
-    ret = subprocess.call(cmd, cwd=riotdir,
-                          stdout=subprocess.DEVNULL,
-                          stderr=subprocess.DEVNULL)
-    return ret == 0
-
-
-def _is_git_tracked(appdir):
-    """Check if directory is a git repository."""
-    cmd = ['git', 'ls-files', '--error-unmatch', 'Makefile']
-    ret = subprocess.call(cmd, cwd=appdir,
-                          stdout=subprocess.DEVNULL,
-                          stderr=subprocess.DEVNULL)
-    return ret == 0
-
-
-def _riot_tracked_applications_dirs(riotdir):
-    """Applications directories in the RIOT repository with relative path.
-
-    Only return 'tracked' applications if riotdir is a git repository.
-    """
-    apps_dirs = _riot_applications_dirs(riotdir)
-
-    # Only keep tracked directories
-    if _is_git_repo(riotdir):
-        apps_dirs = [dir for dir in apps_dirs
-                     if _is_git_tracked(os.path.join(riotdir, dir))]
-    return apps_dirs
 
 
 def _riot_applications_dirs(riotdir):


### PR DESCRIPTION
### Contribution description

Remove the check that directory are git tracked or not.
This should not be done by the script and was a mistake.

If need be to be checked it should be moved to RIOT 'info-applications'
and running tests should be done in a clean environment anyway.

### Testing procedure


Directories not tracked are used by `dist/tools/compile_and_test_for_board/compile_and_test_for_board.py` as they are listed by `make info-applications`.

```
cp -r examples/hello-world examples/aaa
```

```
make info-applications  | head -n 3
bootloaders/riotboot
examples/aaa
examples/arduino_hello-world
```

```
./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py . native
INFO:native:Saving toolchain
INFO:native.bootloaders/riotboot:Board supported: False
INFO:native.examples/aaa:Board supported: True
INFO:native.examples/aaa:Board has enough memory: True
INFO:native.examples/aaa:Run compilation
INFO:native.examples/aaa:Success
INFO:native.examples/arduino_hello-world:Board supported: False
...
```

It would have been ignored in `master`.

`tox` output does not show any issue

<details><summary><code>dist/tools/compile_and_test_for_board $ tox</code></summary><p>

```
test installed: atomicwrites==1.3.0,attrs==19.1.0,more-itertools==7.0.0,pluggy==0.11.0,py==1.8.0,pytest==4.5.0,six==1.12.0,wcwidth==0.1.7
test run-test-pre: PYTHONHASHSEED='2779660058'
test runtests: commands[0] | pytest -v --doctest-modules
================================================================================================================================== test session starts ===================================================================================================================================
platform linux -- Python 3.6.7, pytest-4.5.0, py-1.8.0, pluggy-0.11.0 -- /home/harter/work/git/RIOT/dist/tools/compile_and_test_for_board/.tox/test/bin/python
cachedir: .tox/test/.pytest_cache
rootdir: /home/harter/work/git/RIOT/dist/tools/compile_and_test_for_board
collected 2 items                                                                                                                                                                                                                                                                        

compile_and_test_for_board.py::compile_and_test_for_board.list_from_string PASSED                                                                                                                                                                                                  [ 50%]
tests/test_compile_and_test_for_board.py::test_help_message PASSED                                                                                                                                                                                                                 [100%]

================================================================================================================================ 2 passed in 0.07 seconds ================================================================================================================================
lint installed: astroid==2.2.5,isort==4.3.19,lazy-object-proxy==1.4.1,mccabe==0.6.1,pylint==2.3.1,six==1.12.0,typed-ast==1.3.5,wrapt==1.11.1
lint run-test-pre: PYTHONHASHSEED='2779660058'
lint runtests: commands[0] | pylint compile_and_test_for_board.py tests

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

flake8 installed: entrypoints==0.3,flake8==3.7.7,mccabe==0.6.1,pycodestyle==2.5.0,pyflakes==2.1.1
flake8 run-test-pre: PYTHONHASHSEED='2779660058'
flake8 runtests: commands[0] | flake8 compile_and_test_for_board.py tests
________________________________________________________________________________________________________________________________________ summary _________________________________________________________________________________________________________________________________________  test: commands succeeded
  lint: commands succeeded
  flake8: commands succeeded
  congratulations :)
```

</p></details>


### Issues/PRs references

None