### PR TITLE
cpu/nrf52: set RIOTBOOT_LEN to 8k

### DIFF
--- a/cpu/nrf52/Makefile.include
+++ b/cpu/nrf52/Makefile.include
@@ -1,6 +1,11 @@
 export CPU_ARCH = cortex-m4f
 export CPU_FAM  = nrf52
 
+# Slot size is determined by "((total_flash_size - RIOTBOOT_LEN) / 2)".
+# If RIOTBOOT_LEN uses an uneven number of flashpages, the remainder of the
+# flash cannot be divided by two slots while staying FLASHPAGE_SIZE aligned.
+RIOTBOOT_LEN ?= 0x2000
+
 # Export internal ROM alignment and slot sizes for bootloader support
 export MCUBOOT_IMAGE_ALIGN = 8
 export MCUBOOT_SLOT0_SIZE = 0x8000


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

For nrf52 flash page is 4k. By default the bootloader is 4k but it needs to be at max(4k, 2xFASHPAGE_SIZE) so slots start at the beginning of a page since for now there is only support for writing full pages with flashpage module.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

In https://github.com/RIOT-OS/RIOT/blob/master/tests/riotboot_flashwrite/Makefile uncomment ethos lines. Then flash firmware on an nrf52 board:

    $ BOARD=nrf52840dk make riotboot/flash

Setup ethos 

    sudo ./dist/tools/ethos/start_network.sh /dev/ttyACM0 riot0 2001:db8::/64

Confirm it booted from slot 0 (it should print "Current slot=0"), then
recompile in order to get an image for the second slot with a newer version
number:

    $ BOARD=nrf52840dk make riotboot

Then send via CoAP, for example, with libcoap's coap_client:

    $ coap-client -m post coap://[fe80::2%riot0]/flashwrite \
       -f bin/nrf52840dk/tests_riotboot_flashwrite-slot1.riot.bin -b 64

Then reboot the node manually. **With this PR it will reboot from slot 1**, without this pr it will reboot from slot 0.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

#9342
