### PR TITLE
cortexm_common: add .noinit section

### DIFF
--- a/cpu/cortexm_common/ldscripts/cortexm_base.ld
+++ b/cpu/cortexm_common/ldscripts/cortexm_base.ld
@@ -127,6 +127,17 @@ SECTIONS
         _erelocate = .;
     } > ram AT> rom
 
+    /*
+     * collect all uninitialized sections that go into RAM
+     */
+    .noinit (NOLOAD) :
+    {
+        __noinit_start = .;
+        *(.noinit)
+        . = ALIGN(4);
+        __noinit_end = .;
+    }  > ram
+
     /* .bss section which is used for uninitialized data */
     .bss (NOLOAD) :
     {


### PR DESCRIPTION
Make it possible to specify a section of RAM that is not touched by the init routing so data can be kept across resets.

This should behave the same as on atmega & lpc2387.
Actually it was taken straight out of [`lpc2387.ld`](https://github.com/RIOT-OS/RIOT/blob/master/cpu/lpc2387/ldscripts/lpc2387.ld#L158).