### PR TITLE
pkg/semtech_loramac: fix DEBUG message when payload is NULL

### DIFF
--- a/pkg/semtech-loramac/contrib/semtech_loramac.c
+++ b/pkg/semtech-loramac/contrib/semtech_loramac.c
@@ -82,7 +82,7 @@ typedef struct {
 static uint8_t _semtech_loramac_send(semtech_loramac_t *mac,
                                      uint8_t *payload, uint8_t len)
 {
-    DEBUG("[semtech-loramac] send frame %s\n", (char *)payload);
+    DEBUG("[semtech-loramac] send frame %s\n", payload ? (char *)payload : "(empty)");
     McpsReq_t mcpsReq;
     LoRaMacTxInfo_t txInfo;
     uint8_t dr = semtech_loramac_get_dr(mac);


### PR DESCRIPTION
### Contribution description

In function `_semtech_loramac_send` parameter `payload` can be `NULL` (that's the case when scheduling an immediate TX, [line 726][line-726]). As `DEBUG` macro uses `printf`, a `%s` parameter can't be `NULL` so we have to handle that case.


### Testing procedure

First enable debug messages in `semtech_loramac.c`.  
Then make uplinks until you get the debug message `[semtech-loramac] schedule immediate TX` which indicates that the end device must provide an uplink as soon as possible. As `payload` parameter is `NULL` and `DEBUG` macro uses `%s` an undefined behavior will happen (see image below).


### Issues/PRs references

None

![Undefined behavior](https://i.imgur.com/vwJAqtG.png)

[line-726]: https://github.com/RIOT-OS/RIOT/blob/master/pkg/semtech-loramac/contrib/semtech_loramac.c#L726