### PR TITLE
tools/pr_check: add check preventing PKG_SOURCE_LOCAL merges

### DIFF
--- a/dist/tools/pr_check/pr_check.sh
+++ b/dist/tools/pr_check/pr_check.sh
@@ -50,4 +50,10 @@ if [ -n "$TRAVIS_PULL_REQUEST" -o -n "$CI_PULL_NR" ]; then
     fi
 fi
 
+if git grep -q PKG_SOURCE_LOCAL -- pkg/*/Makefile; then
+    echo -e "${CERROR}The following files contain a PKG_SOURCE_LOCAL definition:${CRESET}"
+    git grep -l PKG_SOURCE_LOCAL -- pkg/*/Makefile
+    EXIT_CODE=1
+fi
+
 exit ${EXIT_CODE}


### PR DESCRIPTION
### Contribution description

PKG_SOURCE_LOCAL only makes sense while developing. This PR makes sure no such definition can land in master (through accidental commits).

PR contains a test commit.

### Testing procedure

Watch it fail because of test commit. ACK, have it squashed, watch it succeed.

### Issues/PRs references

