### PR TITLE
drivers/at: Add 'at_recv_bytes_until_string' function

### DIFF
--- a/drivers/include/at.h
+++ b/drivers/include/at.h
@@ -212,6 +212,25 @@ ssize_t at_send_cmd_get_lines(at_dev_t *dev, const char *command, char *resp_buf
 int at_expect_bytes(at_dev_t *dev, const char *bytes, uint32_t timeout);
 
 /**
+ * @brief   Receives bytes into @p bytes buffer until the string pattern
+ * @p string is received or the buffer is full.
+ * 
+ * @param[in] dev               device to operate on
+ * @param[in] string            string pattern to expect
+ * @param[out] bytes            buffer to store received bytes
+ * @param[in, out] bytes_len    pointer to the maximum number of bytes to
+ *                              receive. On return stores the amount of received
+ *                              bytes.
+ * @param[in] timeout           timeout (in usec) of inactivity to finish read
+ *
+ * @returns                     0 on success
+ * @returns                     <0 on error
+ */
+int at_recv_bytes_until_string(at_dev_t *dev, const char *string,
+                               char *bytes, size_t *bytes_len,
+                               uint32_t timeout);
+
+/**
  * @brief   Send raw bytes to a device
  *
  * @param[in]   dev     device to operate on

--- a/drivers/include/at.h
+++ b/drivers/include/at.h
@@ -214,7 +214,7 @@ int at_expect_bytes(at_dev_t *dev, const char *bytes, uint32_t timeout);
 /**
  * @brief   Receives bytes into @p bytes buffer until the string pattern
  * @p string is received or the buffer is full.
- * 
+ *
  * @param[in] dev               device to operate on
  * @param[in] string            string pattern to expect
  * @param[out] bytes            buffer to store received bytes

--- a/tests/driver_at/README.md
+++ b/tests/driver_at/README.md
@@ -1,6 +1,6 @@
 Expected result
 ===============
-You should be presented with a RIOT shell that privides commands to
+You should be presented with a RIOT shell that provides commands to
 initialize an UART and send AT commands to an AT module.
 
 Background

--- a/tests/driver_at/main.c
+++ b/tests/driver_at/main.c
@@ -134,6 +134,34 @@ static int send_recv_bytes(int argc, char **argv)
     return 0;
 }
 
+static int send_recv_bytes_until_string(int argc, char **argv)
+{
+    char buffer[128];
+    size_t len = sizeof(buffer);
+
+    memset(buffer, 0, sizeof(buffer));
+
+    if (argc < 3) {
+        printf("Usage: %s <command> <string to expect>\n", argv[0]);
+        return 1;
+    }
+
+    sprintf(buffer, "%s%s", argv[1], AT_SEND_EOL);
+    at_send_bytes(&at_dev, buffer, strlen(buffer));
+    memset(buffer, 0, sizeof(buffer));
+
+    int res = at_recv_bytes_until_string(&at_dev, argv[2], buffer, &len,
+                                         10 * US_PER_SEC);
+
+    if (res) {
+        puts("Error");
+        return 1;
+    }
+
+    printf("Response (len=%d): %s\n", (int)len, buffer);
+    return 0;
+}
+
 static int drain(int argc, char **argv)
 {
     (void)argc;
@@ -258,6 +286,8 @@ static const shell_command_t shell_commands[] = {
     { "send_ok", "Send a command and wait OK", send_ok },
     { "send_lines", "Send a command and wait lines", send_lines },
     { "send_recv_bytes", "Send a command and wait response as raw bytes", send_recv_bytes },
+    { "send_recv_until_string", "Send a command and receive response until "
+      "the expected pattern arrives", send_recv_bytes_until_string },
     { "drain", "Drain AT device", drain },
     { "power_on", "Power on AT device", power_on },
     { "power_off", "Power off AT device", power_off },


### PR DESCRIPTION
### Contribution description
This PR adds a the `at_recv_bytes_until_string` function to the AT driver. It receives bytes until the provided pattern is received, the maximum length of the buffer is reached or the reception times out.
It is particularly useful to receive known templates where the exact number of bytes is not known beforehand.

A new command is also added to the test application for the driver.

### Testing procedure
Run the `tests/driver_at` application and use the `send_recv_until_string` command.

### Issues/PRs references
None