### PR TITLE
make/pkg: allow to set SOURCE_LOCAL per pkg

### DIFF
--- a/pkg/pkg.mk
+++ b/pkg/pkg.mk
@@ -3,6 +3,7 @@
 #
 PKG_DIR?=$(CURDIR)
 PKG_BUILDDIR?=$(PKGDIRBASE)/$(PKG_NAME)
+PKG_SOURCE_LOCAL ?= $(PKG_SOURCE_LOCAL_$(shell echo $(PKG_NAME) | tr a-z- A-Z_))
 
 # allow overriding package source with local folder (useful during development)
 ifneq (,$(PKG_SOURCE_LOCAL))


### PR DESCRIPTION
### Contribution description
When working with packages in RIOT, the `PKG_SOURCE_LOCAL` variable is extremely helpful. But it currently needs to be set in the package Makefile, hence introducing 'debug' code into the RIOT source tree.

This PR allows to set this variable globally on a per-pkg basis, by simply mapping the package name in a variable name, e.g. building with `PKG_MYPKG_SOURCE_LOCAL=/some/dir make ...` will build an application with `PKG_SOURCE_LOCAL=/some/dir` set for the package  `RIOT/pkg/mypkg`.

Only caveat so far: if set in the applications Makefile, it needs to be exported.

### Testing procedure
Take a package and a fitting RIOT application of your choice and set the according `PKG_xxx_SOURCE_LOCAL` variable to the local source folder of that package. You should see in the build output, that the package is actually copied from the specified location to the bin folder, instead of being checked out from the configured repository.

### Issues/PRs references
none