### PR TITLE
 drivers/ds18: fix `ds18_read` for negative temperatures

### DIFF
--- a/drivers/ds18/ds18.c
+++ b/drivers/ds18/ds18.c
@@ -184,7 +184,7 @@ int ds18_read(const ds18_t *dev, int16_t *temperature)
 
     DEBUG("[DS18] Received byte: 0x%02x\n", b2);
 
-    int32_t measurement = ((int32_t)(b2 << 8 | b1) * 625);
+    int32_t measurement = ((int16_t)(b2 << 8 | b1) * 625);
     *temperature = (int16_t)(measurement / 100);
 
     return DS18_OK;

--- a/tests/driver_ds18/main.c
+++ b/tests/driver_ds18/main.c
@@ -48,9 +48,16 @@ int main(void)
 
         /* Get temperature in centidegrees celsius */
         if (ds18_get_temperature(&dev, &temperature) == DS18_OK) {
-            printf("Temperature [ºC]: %d.%d"
+            bool negative = (temperature < 0);
+            if (negative) {
+                temperature = -temperature;
+            }
+
+            printf("Temperature [ºC]: %c%d.%02d"
                    "\n+-------------------------------------+\n",
-                   (temperature / 100), (int)(temperature % 100));
+                   negative ? '-': ' ',
+                   temperature / 100,
+                   temperature % 100);
         }
         else {
             puts("[Error] Could not read temperature");


### PR DESCRIPTION
### Contribution description

This pull request fixes `ds18` module when the temperature is negative. The function `ds18_read` was always returning a positive value. Also it makes DS18 test displaying negative temperatures well.

Currently, when the real temperature is `-25.0625 °C` the test displays
> `Temperature [ºC]: 138.77`

After fixing `ds18_read` function, the test was displaying
> `Temperature [ºC]: -25.-6`

And now the temperature is well displayed
> `Temperature [ºC]: -25.06`


### Testing procedure

Find a board with a DS18 module and take a trip to Antarctica (or wait for winter, [because it's coming][winter-coming]). 
Alternatively put your module in a fridge to have a negative temperature.

Also, you can test values from *Table 1*, page 6 from the [specification][spec], with both the old code and new one.  
Here with a temperature of `-25.0625 °C`, the old code returns a positive value.

```c
uint8_t b1 = 0x6F, b2 = 0xFE;  // -25.0625 °C
int32_t measurement = ((int32_t)(b2 << 8 | b1) * 625);
int16_t temperature = (int16_t)(measurement / 100);
// Here temperature is 13877
```
Whereas the new code is working as expected.

```c
uint8_t b1 = 0x6F, b2 = 0xFE;  // -25.0625 °C
int32_t measurement = ((int16_t)(b2 << 8 | b1) * 625);
int16_t temperature = (int16_t)(measurement / 100);
// Here temperature is -2506
```


### Issues/PRs references

None

[spec]: https://datasheets.maximintegrated.com/en/ds/DS18B20.pdf
[winter-coming]: https://en.wikipedia.org/wiki/Winter_Is_Coming