### PR TITLE
sys/xtimer.h: fix XTIMER_BACKOFF doc

### DIFF
--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -138,7 +138,7 @@ static inline void xtimer_sleep(uint32_t seconds);
  *
  * When called from an ISR, this function will spin and thus block the MCU for
  * the specified amount in microseconds, so only use it there for *very* short
- * periods, e.g., less than XTIMER_BACKOFF.
+ * periods, e.g., less than xtimer_usec_from_ticks(XTIMER_BACKOFF).
  *
  * @param[in] microseconds  the amount of microseconds the thread should sleep
  */
@@ -280,8 +280,8 @@ static inline void xtimer_set_wakeup64(xtimer_t *timer, uint64_t offset, kernel_
  * ticks in the future.
  *
  * @warning BEWARE! Callbacks from xtimer_set() are being executed in interrupt
- * context (unless offset < XTIMER_BACKOFF). DON'T USE THIS FUNCTION unless you
- * know *exactly* what that means.
+ * context (unless offset < xtimer_usec_from_ticks(XTIMER_BACKOFF)). DON'T USE
+ * THIS FUNCTION unless you know *exactly* what that means.
  *
  * @param[in] timer     the timer structure to use.
  *                      Its xtimer_t::target and xtimer_t::long_target
@@ -301,8 +301,8 @@ static inline void xtimer_set(xtimer_t *timer, uint32_t offset);
  * microseconds in the future.
  *
  * @warning BEWARE! Callbacks from xtimer_set() are being executed in interrupt
- * context (unless offset < XTIMER_BACKOFF). DON'T USE THIS FUNCTION unless you
- * know *exactly* what that means.
+ * context (unless offset < xtimer_usec_from_ticks(XTIMER_BACKOFF)). DON'T USE
+ * THIS FUNCTION unless you know *exactly* what that means.
  *
  * @param[in] timer       the timer structure to use.
  *                        Its xtimer_t::target and xtimer_t::long_target
@@ -474,7 +474,7 @@ void xtimer_set_timeout_flag(xtimer_t *t, uint32_t timeout);
 /**
  * @brief xtimer backoff value
  *
- * All timers that are less than XTIMER_BACKOFF microseconds in the future will
+ * All timers that are less than XTIMER_BACKOFF ticks in the future will
  * just spin.
  *
  * This is supposed to be defined per-device in e.g., periph_conf.h.


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR fixes the XTIMER_BACKOFF documentation inconsistency detailed in #11522. XTIMER_BACKOFF is used:

https://github.com/RIOT-OS/RIOT/blob/568a3514557fe301aaf8b2413b76c701dac98492/sys/xtimer/xtimer_core.c#L147-L154

https://github.com/RIOT-OS/RIOT/blob/568a3514557fe301aaf8b2413b76c701dac98492/sys/xtimer/xtimer_core.c#L201-L206

in both cases it is used as 'ticks' while in some places documentation insinuates it has 'us' units

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

None.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

Part of #11522 
