### PR TITLE
sys/xtimer.h: fix typo in xtimer_set_msg

### DIFF
--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -213,7 +213,7 @@ static inline void xtimer_periodic_wakeup(xtimer_ticks32_t *last_wakeup, uint32_
  * This function sets a timer that will send a message @p offset ticks
  * from now.
  *
- * The mesage struct specified by msg parameter will not be copied, e.g., it
+ * The message struct specified by msg parameter will not be copied, e.g., it
  * needs to point to valid memory until the message has been delivered.
  *
  * @param[in] timer         timer struct to work with.
@@ -231,7 +231,7 @@ static inline void xtimer_set_msg(xtimer_t *timer, uint32_t offset, msg_t *msg, 
  * This function sets a timer that will send a message @p offset microseconds
  * from now.
  *
- * The mesage struct specified by msg parameter will not be copied, e.g., it
+ * The message struct specified by msg parameter will not be copied, e.g., it
  * needs to point to valid memory until the message has been delivered.
  *
  * @param[in] timer         timer struct to work with.


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Fix function description typo.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
