### PR TITLE
stm32-common/spi: allow custom pin modes on spi to minimize power consumption

### DIFF
--- a/boards/b-l072z-lrwan1/Makefile.features
+++ b/boards/b-l072z-lrwan1/Makefile.features
@@ -3,7 +3,7 @@ FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt
-FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_spi periph_spi_gpio_mode
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 

--- a/boards/i-nucleo-lrwan1/Makefile.features
+++ b/boards/i-nucleo-lrwan1/Makefile.features
@@ -3,7 +3,7 @@ FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_lpuart
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt
-FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_spi periph_spi_gpio_mode
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 

--- a/boards/lobaro-lorabox/Makefile.features
+++ b/boards/lobaro-lorabox/Makefile.features
@@ -1,7 +1,7 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtc
-FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_spi periph_spi_gpio_mode
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 

--- a/boards/lsn50/Makefile.features
+++ b/boards/lsn50/Makefile.features
@@ -3,7 +3,7 @@ FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt
-FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_spi periph_spi_gpio_mode
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 

--- a/boards/nucleo-l073rz/Makefile.features
+++ b/boards/nucleo-l073rz/Makefile.features
@@ -5,7 +5,7 @@ FEATURES_PROVIDED += periph_lpuart
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt
-FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_spi periph_spi_gpio_mode
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 

--- a/boards/nucleo-l152re/Makefile.features
+++ b/boards/nucleo-l152re/Makefile.features
@@ -5,7 +5,7 @@ FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
-FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_spi periph_spi_gpio_mode
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 

--- a/boards/nz32-sc151/Makefile.features
+++ b/boards/nz32-sc151/Makefile.features
@@ -4,7 +4,7 @@ FEATURES_PROVIDED += periph_dac
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
-FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_spi periph_spi_gpio_mode
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 

--- a/cpu/stm32_common/periph/spi.c
+++ b/cpu/stm32_common/periph/spi.c
@@ -116,6 +116,28 @@ int spi_init_cs(spi_t bus, spi_cs_t cs)
     return SPI_OK;
 }
 
+#ifdef MODULE_PERIPH_SPI_GPIO_MODE
+int spi_init_with_gpio_mode(spi_t bus, spi_gpio_mode_t mode)
+{
+    assert(bus < SPI_NUMOF);
+
+    int ret = 0;
+
+#ifdef CPU_FAM_STM32F1
+    /* This has no effect on STM32F1 */
+    return ret;
+#else
+    ret += gpio_init(spi_config[bus].mosi_pin, mode.mosi);
+    ret += gpio_init(spi_config[bus].miso_pin, mode.miso);
+    ret += gpio_init(spi_config[bus].sclk_pin, mode.sclk);
+    gpio_init_af(spi_config[bus].mosi_pin, spi_config[bus].af);
+    gpio_init_af(spi_config[bus].miso_pin, spi_config[bus].af);
+    gpio_init_af(spi_config[bus].sclk_pin, spi_config[bus].af);
+    return ret;
+#endif
+}
+#endif
+
 int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
 {
     /* lock bus */

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -489,6 +489,7 @@ ifneq (,$(filter sx127%,$(USEMODULE)))
   FEATURES_REQUIRED += periph_gpio
   FEATURES_REQUIRED += periph_gpio_irq
   FEATURES_REQUIRED += periph_spi
+  FEATURES_OPTIONAL += periph_spi_gpio_mode
   USEMODULE += iolist
   USEMODULE += xtimer
   USEMODULE += sx127x

--- a/drivers/include/periph/spi.h
+++ b/drivers/include/periph/spi.h
@@ -225,6 +225,29 @@ void spi_init_pins(spi_t bus);
  */
 int spi_init_cs(spi_t bus, spi_cs_t cs);
 
+#if defined(MODULE_PERIPH_SPI_GPIO_MODE) || DOXYGEN
+
+/**
+ * @brief   SPI gpio mode
+ */
+typedef struct {
+    gpio_mode_t mosi;       /**< GPIO mode used for MOSI pin */
+    gpio_mode_t miso;       /**< GPIO mode used for MISO pin */
+    gpio_mode_t sclk;       /**< GPIO mode used for SCLK pin */
+} spi_gpio_mode_t;
+
+/**
+ * @brief   Initialize MOSI/MISO/SCLK pins with adapted GPIO modes
+ *
+ * @param[in] bus       SPI device that is used with the given CS line
+ * @param[in] mode      a struct containing the 3 modes to use on each pin
+ *
+ * @return              0 on success
+ * @return              <0 on error
+ */
+int spi_init_with_gpio_mode(spi_t bus, spi_gpio_mode_t mode);
+#endif
+
 /**
  * @brief   Start a new SPI transaction
  *

--- a/drivers/sx127x/sx127x.c
+++ b/drivers/sx127x/sx127x.c
@@ -344,6 +344,15 @@ static int _init_spi(sx127x_t *dev)
     /* Setup SPI for SX127X */
     res = spi_init_cs(dev->params.spi, dev->params.nss_pin);
 
+#ifdef MODULE_PERIPH_SPI_GPIO_MODE
+    spi_gpio_mode_t gpio_modes = {
+        .mosi = (GPIO_OUT | SX127X_DIO_PULL_MODE),
+        .miso = (SX127X_DIO_PULL_MODE),
+        .sclk = (GPIO_OUT | SX127X_DIO_PULL_MODE),
+    };
+    res += spi_init_with_gpio_mode(dev->params.spi, gpio_modes);
+#endif
+
     if (res != SPI_OK) {
         DEBUG("[sx127x] error: failed to initialize SPI_%i device (code %i)\n",
               dev->params.spi, res);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is an attempt to provide a way to better optimize power consumption on STM32 by giving a finer control on the GPIO modes configured on each SPI pins (MOSI/MISO/SCLK).

All STM32 but STM32F1 support push-pull (GPIO_OUT) with a pull-up/pull-down configuration. In general, the default is to not use both at the same time but it appears that on STM32, not using pull-up/pull-down with push-pull results in higher power consumption.

Since the choice of pull-up/pull-down is highly correlated to the board configuration, this PR provides a way to configure this in the peripheral configuration struct for each configured SPI periph, for better flexibility. The feature is provided as an extension of `periph_spi` called `periph_spi_gpio_mode` (similiar `periph_gpio_int` with `periph_gpio`).

As an example, it's applied to nucleo-l152re but maybe this could be applied to all nucleo boards. At least the current approach allows to add this progressively.


<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Build and flash an application using SPI and verify that it still work. Another interesting test could be to measure power consumption of this application when the board goes to deep sleep. With this PR, the minimal power consumption is reached, with master, it's always noticeably greater.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Replaces #11384 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
