### PR TITLE
sys/xtimer: improve spin define handling/documentation

### DIFF
--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -520,7 +520,7 @@ void xtimer_set_timeout_flag(xtimer_t *t, uint32_t timeout);
 
 #ifndef XTIMER_PERIODIC_SPIN
 /**
- * @brief   xtimer_periodic_wakeup spin cutoff
+ * @brief   xtimer_periodic_wakeup spin cutoff, in microseconds
  *
  * If the difference between target time and now is less than this value, then
  * xtimer_periodic_wakeup will use xtimer_spin instead of setting a timer.

--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -530,7 +530,7 @@ void xtimer_set_timeout_flag(xtimer_t *t, uint32_t timeout);
 
 #ifndef XTIMER_PERIODIC_RELATIVE
 /**
- * @brief   xtimer_periodic_wakeup relative target cutoff
+ * @brief   xtimer_periodic_wakeup relative target cutoff, in hardware ticks
  *
  * If the difference between target time and now is less than this value, then
  * xtimer_periodic_wakeup will set a relative target time in the future instead

--- a/sys/include/xtimer/implementation.h
+++ b/sys/include/xtimer/implementation.h
@@ -97,13 +97,6 @@ int _xtimer_msg_receive_timeout64(msg_t *msg, uint64_t ticks);
 void _xtimer_tsleep(uint32_t offset, uint32_t long_offset);
 /** @} */
 
-#ifndef XTIMER_MIN_SPIN
-/**
- * @brief Minimal value xtimer_spin() can spin
- */
-#define XTIMER_MIN_SPIN _xtimer_usec_from_ticks(1)
-#endif
-
 #ifndef DOXYGEN
 /* Doxygen warns that these are undocumented, but the documentation can be found in xtimer.h */
 

--- a/sys/xtimer/xtimer.c
+++ b/sys/xtimer/xtimer.c
@@ -114,7 +114,7 @@ void _xtimer_periodic_wakeup(uint32_t *last_wakeup, uint32_t period) {
      */
     uint32_t offset = target - now;
     DEBUG("xps, now: %9" PRIu32 ", tgt: %9" PRIu32 ", off: %9" PRIu32 "\n", now, target, offset);
-    if (offset < XTIMER_PERIODIC_SPIN) {
+    if (offset < xtimer_ticks_from_usec(XTIMER_PERIODIC_SPIN).ticks32) {
         _xtimer_spin(offset);
     }
     else {

--- a/sys/xtimer/xtimer_core.c
+++ b/sys/xtimer/xtimer_core.c
@@ -144,7 +144,7 @@ void _xtimer_set(xtimer_t *timer, uint32_t offset)
 
     xtimer_remove(timer);
 
-    if (offset < XTIMER_BACKOFF) {
+    if (offset < xtimer_ticks_from_usec(XTIMER_BACKOFF).ticks32) {
         _xtimer_spin(offset);
         _shoot(timer);
     }
@@ -198,7 +198,7 @@ int _xtimer_set_absolute(xtimer_t *timer, uint32_t target)
     DEBUG("timer_set_absolute(): now=%" PRIu32 " target=%" PRIu32 " offset=%" PRIu32 "\n",
           now, target, offset);
 
-    if (offset <= XTIMER_BACKOFF) {
+    if (offset <= xtimer_ticks_from_usec(XTIMER_BACKOFF).ticks32) {
         /* backoff */
         xtimer_spin_until(target);
         _shoot(timer);


### PR DESCRIPTION
### Contribution description

This PR adds missing type conversion/documentation of multiple `XTIMER` defines, tackling confusion between hardware ticks and microseconds.

This PR also deletes `XTIMER_MIN_SPIN`, which by my digging was never used from first definition on, yet touched a lot... rabbit hole:
https://github.com/RIOT-OS/RIOT/commit/a719e7d61ff90ce3c40a6508a5ed5af6b873cfe9#diff-2fb2297f4238db71ba10656337cfe96eR451
https://github.com/RIOT-OS/RIOT/commit/f86c118594dd15447f67e1fd0162e492e3a733d6#diff-2fb2297f4238db71ba10656337cfe96eR458
https://github.com/RIOT-OS/RIOT/commit/856c5e1539a356cb9a7f1620caa365be59e88d51#diff-2fb2297f4238db71ba10656337cfe96eR463
https://github.com/RIOT-OS/RIOT/commit/63e91151cd0b3dfde28bd7cc9b3ef23b140f3730#diff-4cf746d1ae899bdb66748fb93ac17eb0R81

If you know of more broken definitions in XTIMER, please let me so I can add them.

### Testing procedure

Do some tests/xtimer_* and make sure the values are still sane with this PR.

### Issues/PRs references

Fixes #11522 
