### PR TITLE
makefiles/toolchain: fallback to 'objdump'

### DIFF
--- a/makefiles/toolchain/gnu.inc.mk
+++ b/makefiles/toolchain/gnu.inc.mk
@@ -18,6 +18,7 @@ ifeq ($(OBJCOPY),)
 $(warning objcopy not found. Hex file will not be created.)
 export OBJCOPY    = true
 endif
-export OBJDUMP    = $(PREFIX)objdump
+# Default to the native (g)objdump, helps when using toolchain from docker
+export OBJDUMP   ?= $(or $(shell command -v $(PREFIX)objdump || command -v gobjdump),objdump)
 # We use GDB for debugging
 include $(RIOTMAKE)/tools/gdb.inc.mk

--- a/makefiles/toolchain/llvm.inc.mk
+++ b/makefiles/toolchain/llvm.inc.mk
@@ -25,7 +25,8 @@ ifeq ($(OBJCOPY),)
 $(warning objcopy not found. Hex file will not be created.)
 export OBJCOPY     = true
 endif
-export OBJDUMP     = $(LLVMPREFIX)objdump
+# Default to the native (g)objdump, helps when using toolchain from docker
+export OBJDUMP    ?= $(or $(shell command -v $(LLVMPREFIX)objdump || command -v gobjdump),objdump)
 export SIZE        = $(LLVMPREFIX)size
 # LLVM lacks a binutils strip tool as well...
 #export STRIP      = $(LLVMPREFIX)strip


### PR DESCRIPTION
### Contribution description

When '$(PREFIX)objdump' is not present fallback to 'objdump'.
'objdump' is used when flashing for some boards but the toolchain may
not be installed when building in docker.

If none is found, I fallback to saying 'false' but not sure if it is a
decent solution or not. Maybe just always default to 'objdump' ?

This will allow using 'objdump' in 'cpu/kinetis/dist/check-fcfield-elf.sh'.


### Question

Should the default be `false` or `objdump` which may not be present ?

### Testing procedure

```
BOARD=samr21-xpro make --no-print-directory -C examples/hello-world/ info-debug-variable-OBJDUMP
/opt/gcc-arm-none-eabi-7-2018-q2-update/bin/arm-none-eabi-objdump
```

```
PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" BOARD=samr21-xpro make --no-print-directory -C examples/hello-world/ info-debug-variable-OBJDUMP
/bin/sh: 1: arm-none-eabi-gcc: not found
/usr/bin/objdump
```

Removed in the last version
> And another one, that I do not ask to test but review the result more
> 
> ```
> sudo mv /usr/bin/objdump /usr/bin/objdump.save
> 
> PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" BOARD=samr21-xpro make --no-print-directory -C examples/hello-world/ info-debug-variable-OBJDUMP
> /bin/sh: 1: arm-none-eabi-gcc: not found
> false
> 
> sudo mv /usr/bin/objdump.save /usr/bin/objdump
> ```

It also solves the main issue to use `objdump` when flashing `kinetis` boards when `arm-none-eabi-ojbdump` is not present. See main PR https://github.com/RIOT-OS/RIOT/pull/11545

### Issues/PRs references

Part of https://github.com/RIOT-OS/RIOT/pull/11545 to flash kinetis without arm toolchain.
Which is part of https://github.com/RIOT-OS/RIOT/pull/10870 to only use toolchain from docker.