### PR TITLE
boards/sltb001a: reset before flashing

### DIFF
--- a/boards/sltb001a/Makefile.include
+++ b/boards/sltb001a/Makefile.include
@@ -11,6 +11,7 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 
 # setup JLink for flashing
 export JLINK_DEVICE := EFR32MG1PxxxF256
+export JLINK_PRE_FLASH = r
 include $(RIOTMAKE)/tools/jlink.inc.mk
 
 # add board common drivers


### PR DESCRIPTION
### Contribution description

When it was running 'hello-world', the board could not be flashed through
JLinkExe anymore and only through the drag and drop support.

By resetting the board before doing 'loadbin' it can now be flashed
properly.

There may be other firmwares too, but `hello-world` shows enough the issues.

### Testing procedure

Try flashing two or more times `hello-world`

With this pull request it works without issues.

<details><summary><code>RIOT_CI_BUILD=1 BOARD=sltb001a make --no-print-directory -C examples/hello-world/ flash-only</code></summary><p>

```
RIOT_CI_BUILD=1 BOARD=sltb001a make --no-print-directory -C examples/hello-world/ flash-only
/home/harter/work/git/worktree/riot_master/dist/tools/jlink/jlink.sh flash /home/harter/work/git/worktree/riot_master/examples/hello-world/bin/sltb001a/hello-world.bin
### Flashing Target ###
### Flashing at base address 0x0 with offset 0 ###
SEGGER J-Link Commander V6.42d (Compiled Feb 15 2019 13:56:53)
DLL version V6.42d, compiled Feb 15 2019 13:56:43

J-Link Commander will now exit on Error

J-Link Command File read successfully.
Processing script file...

J-Link connection not established yet but required for command.
Connecting to J-Link via USB...O.K.
Firmware: Silicon Labs J-Link OB compiled Nov 28 2017 15:39:56
Hardware version: V1.00
S/N: 440068262
License(s): RDI
VTref=3.308V
Target connection not established yet but required for command.
Device "EFR32MG1PXXXF256" selected.


Connecting to target via SWD
Found SW-DP with ID 0x2BA01477
Scanning AP map to find all available APs
AP[1]: Stopped AP scan as end of AP map has been reached
AP[0]: AHB-AP (IDR: 0x24770011)
Iterating through AP map to find AHB-AP to use
AP[0]: Core found
AP[0]: AHB-AP ROM base: 0xE00FF000
CPUID register: 0x410FC241. Implementer code: 0x41 (ARM)
Found Cortex-M4 r0p1, Little endian.
FPUnit: 6 code (BP) slots and 2 literal slots
CoreSight components:
ROMTbl[0] @ E00FF000
ROMTbl[0][0]: E000E000, CID: B105E00D, PID: 000BB00C SCS-M7
ROMTbl[0][1]: E0001000, CID: B105E00D, PID: 003BB002 DWT
ROMTbl[0][2]: E0002000, CID: B105E00D, PID: 002BB003 FPB
ROMTbl[0][3]: E0000000, CID: B105E00D, PID: 003BB001 ITM
ROMTbl[0][4]: E0040000, CID: B105900D, PID: 003BB923 TPIU-Lite
Cortex-M4 identified.
Reset delay: 0 ms
Reset type NORMAL: Resets core & peripherals via SYSRESETREQ & VECTRESET bit.
Reset: Halt core after reset via DEMCR.VC_CORERESET.
Reset: Reset device via AIRCR.SYSRESETREQ.

Downloading file [/home/harter/work/git/worktree/riot_master/examples/hello-world/bin/sltb001a/hello-world.bin]...
Comparing flash   [100%] Done.
Verifying flash   [100%] Done.
J-Link: Flash download: Bank 0 @ 0x00000000: Skipped. Contents already match
O.K.

Reset delay: 0 ms
Reset type NORMAL: Resets core & peripherals via SYSRESETREQ & VECTRESET bit.
Reset: Halt core after reset via DEMCR.VC_CORERESET.
Reset: Reset device via AIRCR.SYSRESETREQ.



Script processing completed.
```

</p></details>

With master after the second time it fails:

<details><summary><code>****** Error: Timeout while checking target RAM, RAMCode did not respond in time. (PC = 0x00000009, CPSR = 0x00000008, LR = 0x81000000)!</code></summary><p>

```
RIOT_CI_BUILD=1 BOARD=sltb001a make --no-print-directory -C examples/hello-world/ flash-only
/home/harter/work/git/worktree/riot_master/dist/tools/jlink/jlink.sh flash /home/harter/work/git/worktree/riot_master/examples/hello-world/bin/sltb001a/hello-world.bin
### Flashing Target ###
### Flashing at base address 0x0 with offset 0 ###
SEGGER J-Link Commander V6.42d (Compiled Feb 15 2019 13:56:53)
DLL version V6.42d, compiled Feb 15 2019 13:56:43

J-Link Commander will now exit on Error

J-Link Command File read successfully.
Processing script file...

J-Link connection not established yet but required for command.
Connecting to J-Link via USB...O.K.
Firmware: Silicon Labs J-Link OB compiled Nov 28 2017 15:39:56
Hardware version: V1.00
S/N: 440068262
License(s): RDI
VTref=3.307V
Target connection not established yet but required for command.
Device "EFR32MG1PXXXF256" selected.


Connecting to target via SWD
Found SW-DP with ID 0x2BA01477
Scanning AP map to find all available APs
AP[1]: Stopped AP scan as end of AP map has been reached
AP[0]: AHB-AP (IDR: 0x24770011)
Iterating through AP map to find AHB-AP to use
AP[0]: Core found
AP[0]: AHB-AP ROM base: 0xE00FF000
CPUID register: 0x410FC241. Implementer code: 0x41 (ARM)
Found Cortex-M4 r0p1, Little endian.
FPUnit: 6 code (BP) slots and 2 literal slots
CoreSight components:
ROMTbl[0] @ E00FF000
ROMTbl[0][0]: E000E000, CID: B105E00D, PID: 000BB00C SCS-M7
ROMTbl[0][1]: E0001000, CID: B105E00D, PID: 003BB002 DWT
ROMTbl[0][2]: E0002000, CID: B105E00D, PID: 002BB003 FPB
ROMTbl[0][3]: E0000000, CID: B105E00D, PID: 003BB001 ITM
ROMTbl[0][4]: E0040000, CID: B105900D, PID: 003BB923 TPIU-Lite
Cortex-M4 identified.
Halting CPU for downloading file.
Downloading file [/home/harter/work/git/worktree/riot_master/examples/hello-world/bin/sltb001a/hello-world.bin]...

****** Error: Timeout while checking target RAM, RAMCode did not respond in time. (PC = 0x00000009, CPSR = 0x00000008, LR = 0x81000000)!
Failed to prepare for programming.
Failed to execute RAMCode for RAM check!
Unspecified error -1

Script processing completed.

/home/harter/work/git/worktree/riot_master/examples/hello-world/../../Makefile.include:541: recipe for target 'flash-only' failed
make: *** [flash-only] Error 1
```

</p></details>


### Issues/PRs references

Found while running the test suite on the board in https://github.com/RIOT-OS/RIOT/pull/10870