### PR TITLE
boards/pba-d-01-kw2x: fix flashing from invalid state

### DIFF
--- a/boards/pba-d-01-kw2x/Makefile.include
+++ b/boards/pba-d-01-kw2x/Makefile.include
@@ -29,5 +29,9 @@ endif
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
 
+# The board can become un-flashable after some firmware, use connect_assert_srst
+# to always be able to flash or reset the board.
+export OPENOCD_RESET_USE_CONNECT_ASSERT_SRST ?= 1
+
 # this board uses openocd
 include $(RIOTMAKE)/tools/openocd.inc.mk

--- a/boards/pba-d-01-kw2x/dist/openocd.cfg
+++ b/boards/pba-d-01-kw2x/dist/openocd.cfg
@@ -1,2 +1,3 @@
 source [find target/kx.cfg]
+reset_config srst_only
 $_TARGETNAME configure -rtos auto


### PR DESCRIPTION
### Contribution description

When in an invalid state, the board could not flash anymore.
Like for example after flashing `tests/driver_adt7310` this makes it
flash again.

I used `reset_config srst_only` as the other kinetis boards are also
configured that way.

https://github.com/RIOT-OS/RIOT/blob/c439346f6d84fad19115efda5b9e33536ccf5a51/boards/common/frdm/dist/old-openocd-kx.cfg#L38-L39

### Testing procedure

Thy flashing two or more times `tests/driver_adt7310` compile first and run `flash-only`.

With this pull request it works without issues.

<details><summary><code>RIOT_CI_BUILD=1 BOARD=pba-d-01-kw2x make -C tests/driver_adt7310/ flash-only</code></summary><p>

```
RIOT_CI_BUILD=1 BOARD=pba-d-01-kw2x make -C tests/driver_adt7310/ flash-only
make: Entering directory '/home/harter/work/git/worktree/riot_master/tests/driver_adt7310'
/home/harter/work/git/worktree/riot_master/dist/tools/openocd/openocd.sh flash /home/harter/work/git/worktree/riot_master/tests/driver_adt7310/bin/pba-d-01-kw2x/tests_driver_adt7310.elf
### Flashing Target ###
/home/harter/work/git/worktree/riot_master/tests/driver_adt7310/bin/pba-d-01-kw2x/tests_driver_adt7310.elf is fine.
GNU MCU Eclipse 64-bit Open On-Chip Debugger 0.10.0+dev-00462-gdd1d90111 (2019-01-18-11:37)
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
Info : auto-selecting first available session transport "swd". To override use 'transport select <transport>'.
Info : add flash_bank kinetis kx.pflash
adapter speed: 1000 kHz
none separate
cortex_m reset_config sysresetreq
srst_only separate srst_nogate srst_open_drain connect_assert_srst
Info : CMSIS-DAP: SWD  Supported
Info : CMSIS-DAP: FW Version = 1.0
Info : CMSIS-DAP: Interface Initialised (SWD)
Info : SWCLK/TCK = 0 SWDIO/TMS = 1 TDI = 0 TDO = 0 nTRST = 0 nRESET = 1
Info : Connecting under reset
Info : CMSIS-DAP: Interface ready
Info : clock speed 1000 kHz
Info : SWD DPIDR 0x2ba01477
Info : MDM: Chip is unsecured. Continuing.
Info : kx.cpu: hardware has 6 breakpoints, 4 watchpoints
Info : Listening on port 38973 for gdb connections
    TargetName         Type       Endian TapName            State
--  ------------------ ---------- ------ ------------------ ------------
 0* kx.cpu             cortex_m   little kx.cpu             reset
Info : MDM: Chip is unsecured. Continuing.
target halted due to debug-request, current mode: Thread
xPSR: 0x01000000 pc: 0x00000740 msp: 0x1fffc200
auto erase enabled
Info : Kinetis MK21DN512xxx5 detected: 2 flash blocks
Info : 2 PFlash banks: 512k total
wrote 16384 bytes from file /home/harter/work/git/worktree/riot_master/tests/driver_adt7310/bin/pba-d-01-kw2x/tests_driver_adt7310.elf in 0.605979s (26.404 KiB/s)
34 bytes written at address 0x20000000
downloaded 34 bytes in 0.004076s (8.146 KiB/s)
target halted due to breakpoint, current mode: Thread
xPSR: 0x01000000 pc: 0x20000020 msp: 0x1fffc200
verified 14388 bytes in 0.437898s (32.087 KiB/s)
Info : MDM: Chip is unsecured. Continuing.
Error: Failed to write memory and, additionally, failed to find out where
Error: Failed to enable the FPB
Polling target kx.cpu failed, trying to reexamine
Error: MDM: failed to read ID register
Error: Could not find MEM-AP to control the core
Examination failed, GDB will be halted. Polling again in 100ms
shutdown command invoked
Done flashing
make: Leaving directory '/home/harter/work/git/worktree/riot_master/tests/driver_adt7310'
```

</p></details>


With master after the second time it fails:

<details><summary><code>Flash fails without error message</code></summary><p>

```
RIOT_CI_BUILD=1 BOARD=pba-d-01-kw2x make -C tests/driver_adt7310/ flash-only
make: Entering directory '/home/harter/work/git/worktree/riot_master/tests/driver_adt7310'
/home/harter/work/git/worktree/riot_master/dist/tools/openocd/openocd.sh flash /home/harter/work/git/worktree/riot_master/tests/driver_adt7310/bin/pba-d-01-kw2x/tests_driver_adt7310.elf
### Flashing Target ###
/home/harter/work/git/worktree/riot_master/tests/driver_adt7310/bin/pba-d-01-kw2x/tests_driver_adt7310.elf is fine.
GNU MCU Eclipse 64-bit Open On-Chip Debugger 0.10.0+dev-00462-gdd1d90111 (2019-01-18-11:37)
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
Info : auto-selecting first available session transport "swd". To override use 'transport select <transport>'.
Info : add flash_bank kinetis kx.pflash
adapter speed: 1000 kHz
none separate
cortex_m reset_config sysresetreq
Info : CMSIS-DAP: SWD  Supported
Info : CMSIS-DAP: FW Version = 1.0
Info : CMSIS-DAP: Interface Initialised (SWD)
Info : SWCLK/TCK = 0 SWDIO/TMS = 1 TDI = 0 TDO = 0 nTRST = 0 nRESET = 1
Info : CMSIS-DAP: Interface ready
Info : clock speed 1000 kHz


/home/harter/work/git/worktree/riot_master/tests/driver_adt7310/../../Makefile.include:541: recipe for target 'flash-only' failed
make: *** [flash-only] Error 1
make: Leaving directory '/home/harter/work/git/worktree/riot_master/tests/driver_adt7310'

```

</p></details>

### Issues/PRs references

Found while running the test suite on the board in #10870