### PR TITLE
boards/stm32f3discovery: fix openocd config to flash from invalid state

### DIFF
--- a/boards/stm32f3discovery/Makefile.include
+++ b/boards/stm32f3discovery/Makefile.include
@@ -8,5 +8,9 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 DEBUG_ADAPTER ?= stlink
 STLINK_VERSION ?= 2
 
+# The board can become un-flashable after some execution,
+# use connect_assert_srst to always be able to flash or reset the board.
+export OPENOCD_RESET_USE_CONNECT_ASSERT_SRST ?= 1
+
 # this board uses openocd
 include $(RIOTMAKE)/tools/openocd.inc.mk


### PR DESCRIPTION
### Contribution description

When flashing some applications the flasher sometimes gets stuck which
prevents flashing after.
It may be from a specific firmware or operation but do not have one yet.
Connect with reset asserted fix flashing from this state.

It was found after the `stm32f3discovery` get stuck in a non-flashable mode
after some firmwares.

### Testing procedure

TODO: find a firmware that prevents re-flashing it

Flashing still works.

It should also fix flashing from invalid state but I do not know any way of re-creating it.

### Issues/PRs references

Found while running the test suite on the board in #10870

Depends on https://github.com/RIOT-OS/RIOT/pull/11976