### PR TITLE
pkg/semtech-loramac: provide basic persistence for MAC state

### DIFF
--- a/pkg/semtech-loramac/contrib/semtech_loramac_getset.c
+++ b/pkg/semtech-loramac/contrib/semtech_loramac_getset.c
@@ -61,32 +61,69 @@ void semtech_loramac_get_appkey(const semtech_loramac_t *mac, uint8_t *key)
 
 void semtech_loramac_set_appskey(semtech_loramac_t *mac, const uint8_t *skey)
 {
-    memcpy(mac->appskey, skey, LORAMAC_APPSKEY_LEN);
+    mutex_lock(&mac->lock);
+    MibRequestConfirm_t mibReq;
+    mibReq.Type = MIB_APP_SKEY;
+    memcpy(mibReq.Param.AppSKey, skey, LORAMAC_APPSKEY_LEN);
+    LoRaMacMibSetRequestConfirm(&mibReq);
+    mutex_unlock(&mac->lock);
 }
 
-void semtech_loramac_get_appskey(const semtech_loramac_t *mac, uint8_t *skey)
+void semtech_loramac_get_appskey(semtech_loramac_t *mac, uint8_t *skey)
 {
-    memcpy(skey, mac->appskey, LORAMAC_APPSKEY_LEN);
+    mutex_lock(&mac->lock);
+    MibRequestConfirm_t mibReq;
+    mibReq.Type = MIB_APP_SKEY;
+    LoRaMacMibGetRequestConfirm(&mibReq);
+    memcpy(skey, mibReq.Param.AppSKey, LORAMAC_APPSKEY_LEN);
+    mutex_unlock(&mac->lock);
 }
 
 void semtech_loramac_set_nwkskey(semtech_loramac_t *mac, const uint8_t *skey)
 {
-    memcpy(mac->nwkskey, skey, LORAMAC_NWKSKEY_LEN);
+    mutex_lock(&mac->lock);
+    MibRequestConfirm_t mibReq;
+    mibReq.Type = MIB_NWK_SKEY;
+    memcpy(mibReq.Param.NwkSKey, skey, LORAMAC_NWKSKEY_LEN);
+    LoRaMacMibSetRequestConfirm(&mibReq);
+    mutex_unlock(&mac->lock);
 }
 
-void semtech_loramac_get_nwkskey(const semtech_loramac_t *mac, uint8_t *skey)
+void semtech_loramac_get_nwkskey(semtech_loramac_t *mac, uint8_t *skey)
 {
-    memcpy(skey, mac->nwkskey, LORAMAC_NWKSKEY_LEN);
+    mutex_lock(&mac->lock);
+    MibRequestConfirm_t mibReq;
+    mibReq.Type = MIB_NWK_SKEY;
+    LoRaMacMibGetRequestConfirm(&mibReq);
+    memcpy(skey, mibReq.Param.NwkSKey, LORAMAC_NWKSKEY_LEN);
+    mutex_unlock(&mac->lock);
 }
 
 void semtech_loramac_set_devaddr(semtech_loramac_t *mac, const uint8_t *addr)
 {
-    memcpy(mac->devaddr, addr, LORAMAC_DEVADDR_LEN);
+    mutex_lock(&mac->lock);
+    MibRequestConfirm_t mibReq;
+    mibReq.Type = MIB_DEV_ADDR;
+    mibReq.Param.DevAddr = ((uint32_t)addr[0] << 24 |
+                            (uint32_t)addr[1] << 16 |
+                            (uint32_t)addr[2] << 8 |
+                            (uint32_t)addr[3]);
+    LoRaMacMibSetRequestConfirm(&mibReq);
+    mutex_unlock(&mac->lock);
 }
 
-void semtech_loramac_get_devaddr(const semtech_loramac_t *mac, uint8_t *addr)
+void semtech_loramac_get_devaddr(semtech_loramac_t *mac, uint8_t *addr)
 {
-    memcpy(addr, mac->devaddr, LORAMAC_DEVADDR_LEN);
+    mutex_lock(&mac->lock);
+    DEBUG("[semtech-loramac] get device address\n");
+    MibRequestConfirm_t mibReq;
+    mibReq.Type = MIB_DEV_ADDR;
+    LoRaMacMibGetRequestConfirm(&mibReq);
+    addr[0] = (uint8_t)(mibReq.Param.DevAddr >> 24);
+    addr[1] = (uint8_t)(mibReq.Param.DevAddr >> 16);
+    addr[2] = (uint8_t)(mibReq.Param.DevAddr >> 8);
+    addr[3] = (uint8_t)(mibReq.Param.DevAddr);
+    mutex_unlock(&mac->lock);
 }
 
 void semtech_loramac_set_class(semtech_loramac_t *mac, loramac_class_t cls)

--- a/pkg/semtech-loramac/doc.txt
+++ b/pkg/semtech-loramac/doc.txt
@@ -139,6 +139,21 @@
  *               THREAD_PRIORITY_MAIN - 1, 0, _recv, NULL, "recv thread");
  * ```
  *
+ * # Persistence
+ *
+ * If the board CPU provides an internal EEPROM, this package provides a
+ * mecanism for storing EUIs, keys and some MAC parameters (frame counter,
+ * join status).
+ * After a successful join procedure, use `semtech_loramac_save` function to
+ * persist this information and it will be loaded automatically at the next
+ * reboot.
+ * If the device is already joined to a network, to avoid another OTAA join
+ * procedure use `semtech_loramac_is_mac_joined` function to check the join
+ * status of the device.
+ *
+ * This mecanism is especially useful when using deep sleep power modes that
+ * don't preserve RAM.
+ *
  * @warning It is not possible to directly call the original LoRaMAC-node API
  *          using this package. This package should only be considered as a
  *          wrapper around the original LoRaMAC-node API and only the API

--- a/pkg/semtech-loramac/include/semtech_loramac.h
+++ b/pkg/semtech-loramac/include/semtech_loramac.h
@@ -123,9 +123,6 @@ typedef struct {
     uint8_t deveui[LORAMAC_DEVEUI_LEN];          /**< device EUI */
     uint8_t appeui[LORAMAC_APPEUI_LEN];          /**< application EUI */
     uint8_t appkey[LORAMAC_APPKEY_LEN];          /**< application key */
-    uint8_t appskey[LORAMAC_APPSKEY_LEN];        /**< application session key */
-    uint8_t nwkskey[LORAMAC_NWKSKEY_LEN];        /**< network session key */
-    uint8_t devaddr[LORAMAC_DEVADDR_LEN];        /**< device address */
 #if defined(MODULE_SEMTECH_LORAMAC_RX) || DOXYGEN
     semtech_loramac_rx_data_t rx_data;           /**< struct handling the RX data */
     semtech_loramac_link_check_info_t link_chk;  /**< link check information */
@@ -205,6 +202,15 @@ uint8_t semtech_loramac_send(semtech_loramac_t *mac, uint8_t *data, uint8_t len)
 uint8_t semtech_loramac_recv(semtech_loramac_t *mac);
 #endif
 
+/**
+ * @brief   Check if network is already joined
+ *
+ * @param[in] mac          Pointer to the mac
+ *
+ * @return true when network is joined, false otherwise
+ */
+bool semtech_loramac_is_mac_joined(semtech_loramac_t *mac);
+
 #if defined(MODULE_SEMTECH_LORAMAC_RX) || DOXYGEN
 /**
  * @brief   Requests a LoRaWAN link check
@@ -279,7 +285,7 @@ void semtech_loramac_set_appskey(semtech_loramac_t *mac, const uint8_t *skey);
  * @param[in] mac          Pointer to the mac
  * @param[in] skey         The application session key
  */
-void semtech_loramac_get_appskey(const semtech_loramac_t *mac, uint8_t *skey);
+void semtech_loramac_get_appskey(semtech_loramac_t *mac, uint8_t *skey);
 
 /**
  * @brief   Sets the network session key
@@ -295,7 +301,7 @@ void semtech_loramac_set_nwkskey(semtech_loramac_t *mac, const uint8_t *skey);
  * @param[in] mac          Pointer to the mac
  * @param[in] skey         The network session key
  */
-void semtech_loramac_get_nwkskey(const semtech_loramac_t *mac, uint8_t *skey);
+void semtech_loramac_get_nwkskey(semtech_loramac_t *mac, uint8_t *skey);
 
 /**
  * @brief   Sets the device address
@@ -311,7 +317,7 @@ void semtech_loramac_set_devaddr(semtech_loramac_t *mac, const uint8_t *addr);
  * @param[in] mac          Pointer to the mac
  * @param[in] addr         The device address
  */
-void semtech_loramac_get_devaddr(const semtech_loramac_t *mac, uint8_t *addr);
+void semtech_loramac_get_devaddr(semtech_loramac_t *mac, uint8_t *addr);
 
 /**
  * @brief   Sets the device class


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR provides an automatic persistence mecanism of the LoRaMAC session keys and devaddr. This allows to put a device a standby (no ram retention) when using OTAA activation and to continue sending data after wakep without having to join the network again.

Only devaddr, nwkskey, appskey and joined status are saved. But maybe we can extend to more information (DR, ADR, etc) ?

To avoid conflicts, note that this PR is based on #11541 which also provides a useful rework

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Build and flash `tests/pkg_semtech-loramac` application, join a network using OTAA procedure, send a message:
```
> loramac set deveui <deveui>
> loramac set appeui <appeui>
> loramac set appkey <appkey>
> loramac set dr 5
> loramac join otaa
Join procedure succeeded!
> loramac tx test
Message sent with success
```
- Save the current status of the MAC and reboot:
```
> loramac save
> reboot
```
- Try to send another message without joining again:
```
> loramac tx anothertest
Message sent with success
```

All steps should work. Other things that can also be tested: `uncnf`, receive a downlink. Also test that ABP activation still works.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Based on #11541 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
